### PR TITLE
Fix compiler error in Xcode 4.3

### DIFF
--- a/Atom/src/Atom.mm
+++ b/Atom/src/Atom.mm
@@ -24,7 +24,7 @@
 
 - (void)dealloc {
   [_hiddenWindow release];
-  [self dealloc];
+  [super dealloc];
 }
 
 - (BOOL)isHandlingSendEvent {


### PR DESCRIPTION
Presumably this also indicated infinite recursion, but I don't believe Atom is
ever actually deallocated.
