### PR TITLE
Fold simplification

### DIFF
--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -2446,7 +2446,7 @@ describe "Editor", ->
 
         expect(editor.getCursorBufferPosition()).toEqual [3, 0]
 
-    describe "when a cursor is on a fold placeholder line", ->
+    describe "when the unfold event is triggered when the cursor is on a fold placeholder line", ->
       it "removes the associated fold and places the cursor at its beginning", ->
         editor.getSelection().setBufferRange(new Range([3, 0], [9, 0]))
         editor.trigger 'fold-selection'
@@ -2461,7 +2461,7 @@ describe "Editor", ->
         expect(editor.getCursorBufferPosition()).toEqual [3, 0]
 
     describe "when a selection starts/stops intersecting a fold", ->
-      it "adds/removes the 'selected' class to the fold's line element", ->
+      it "adds/removes the 'selected' class to the fold's line element and hides the cursor if it is on the fold line", ->
         editor.createFold(2, 4)
 
         editor.setSelectionBufferRange([[1, 0], [2, 0]], reverse: true)
@@ -2478,6 +2478,10 @@ describe "Editor", ->
 
         editor.setCursorScreenPosition([2,0])
         expect(editor.lineElementForScreenRow(2)).toMatchSelector('.fold.selected')
+        expect(editor.find('.cursor').css('display')).toBe 'none'
+
+        editor.setCursorScreenPosition([3,0])
+        expect(editor.find('.cursor').css('display')).toBe 'block'
 
     describe "when a selected fold is scrolled into view (and the fold line was not previously rendered)", ->
       it "renders the fold's line element with the 'selected' class", ->

--- a/spec/app/renderer-spec.coffee
+++ b/spec/app/renderer-spec.coffee
@@ -293,36 +293,45 @@ describe "Renderer", ->
           expect(event.newRange).toEqual [[1, 0], [1, 9]]
           expect(event.lineNumbersChanged).toBeTruthy()
 
+      describe "when multiple changes happen above the fold", ->
+        it "repositions folds correctly", ->
+          buffer.delete([[1, 1], [2, 0]])
+          buffer.insert([0, 1], "\nnew")
+
+          expect(fold1.startRow).toBe 2
+          expect(fold1.endRow).toBe 4
+
       describe "when the old range precedes lines with a fold", ->
-        it "updates the buffer and re-positions subsequent folds", ->
-          buffer.change([[0, 0], [1, 1]], 'abc')
+        describe "when the new range precedes lines with a fold", ->
+          it "updates the buffer and re-positions subsequent folds", ->
+            buffer.change([[0, 0], [1, 1]], 'abc')
 
-          expect(renderer.lineForRow(0).text).toBe "abc"
-          expect(renderer.lineForRow(1).fold).toBe fold1
-          expect(renderer.lineForRow(2).text).toBe "5"
-          expect(renderer.lineForRow(3).fold).toBe fold2
-          expect(renderer.lineForRow(4).text).toMatch /^9-+/
+            expect(renderer.lineForRow(0).text).toBe "abc"
+            expect(renderer.lineForRow(1).fold).toBe fold1
+            expect(renderer.lineForRow(2).text).toBe "5"
+            expect(renderer.lineForRow(3).fold).toBe fold2
+            expect(renderer.lineForRow(4).text).toMatch /^9-+/
 
-          expect(changeHandler).toHaveBeenCalled()
-          [[event]] = changeHandler.argsForCall
-          expect(event.oldRange).toEqual [[0, 0], [1, 1]]
-          expect(event.newRange).toEqual [[0, 0], [0, 3]]
-          expect(event.lineNumbersChanged).toBeTruthy()
-          changeHandler.reset()
+            expect(changeHandler).toHaveBeenCalled()
+            [[event]] = changeHandler.argsForCall
+            expect(event.oldRange).toEqual [[0, 0], [1, 1]]
+            expect(event.newRange).toEqual [[0, 0], [0, 3]]
+            expect(event.lineNumbersChanged).toBeTruthy()
+            changeHandler.reset()
 
-          fold1.destroy()
-          expect(renderer.lineForRow(0).text).toBe "abc"
-          expect(renderer.lineForRow(1).text).toBe "2"
-          expect(renderer.lineForRow(3).text).toMatch /^4-+/
-          expect(renderer.lineForRow(4).text).toBe "5"
-          expect(renderer.lineForRow(5).fold).toBe fold2
-          expect(renderer.lineForRow(6).text).toMatch /^9-+/
+            fold1.destroy()
+            expect(renderer.lineForRow(0).text).toBe "abc"
+            expect(renderer.lineForRow(1).text).toBe "2"
+            expect(renderer.lineForRow(3).text).toMatch /^4-+/
+            expect(renderer.lineForRow(4).text).toBe "5"
+            expect(renderer.lineForRow(5).fold).toBe fold2
+            expect(renderer.lineForRow(6).text).toMatch /^9-+/
 
-          expect(changeHandler).toHaveBeenCalled()
-          [[event]] = changeHandler.argsForCall
-          expect(event.oldRange).toEqual [[1, 0], [1, 1]]
-          expect(event.newRange).toEqual [[1, 0], [3, 101]]
-          expect(event.lineNumbersChanged).toBeTruthy()
+            expect(changeHandler).toHaveBeenCalled()
+            [[event]] = changeHandler.argsForCall
+            expect(event.oldRange).toEqual [[1, 0], [1, 1]]
+            expect(event.newRange).toEqual [[1, 0], [3, 101]]
+            expect(event.lineNumbersChanged).toBeTruthy()
 
       describe "when the old range straddles the beginning of a fold", ->
         it "replaces lines in the portion of the range that precedes the fold and adjusts the end of the fold to encompass additional lines", ->

--- a/spec/app/selection-spec.coffee
+++ b/spec/app/selection-spec.coffee
@@ -285,6 +285,12 @@ describe "Selection", ->
         selection.insertText('holy cow')
         expect(editor.screenLineForRow(3).text).toBe buffer.lineForRow(3)
 
+    describe "backspace", ->
+      it "destroys the fold", ->
+        selection.setBufferRange([[1,0], [2,0]])
+        selection.backspace()
+        expect(editor.screenLineForRow(3).text).toBe buffer.lineForRow(3)
+
     describe "when the selection is empty", ->
       describe "delete, when the selection is empty", ->
         it "removes the lines contained by the fold", ->

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -177,4 +177,9 @@ class Cursor extends View
     if this == _.last(@editor.getCursors())
       @editor.scrollTo(pixelPosition)
 
+    if @editor.isFoldedAtScreenRow(screenPosition.row)
+      @hide()
+    else
+      @show()
+
     @selection.updateAppearance()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -343,7 +343,6 @@ class Editor extends View
         screenRow = @firstRenderedScreenRow + i
         element = @lineElementForScreenRow(screenRow)
         if @compositeSelection.intersectsBufferRange(fold.getBufferRange())
-          
           element.addClass('selected')
         else
           element.removeClass('selected')
@@ -362,6 +361,9 @@ class Editor extends View
 
   getLastScreenRow: ->
     @screenLineCount() - 1
+
+  isFoldedAtScreenRow: (screenRow) ->
+    @screenLineForRow(screenRow).fold?
 
   destroyFoldsContainingBufferRow: (bufferRow) ->
     @renderer.destroyFoldsContainingBufferRow(bufferRow)

--- a/src/app/fold.coffee
+++ b/src/app/fold.coffee
@@ -36,7 +36,7 @@ class Fold
 
     if @startRow != oldStartRow
       @renderer.unregisterFold(oldStartRow, this)
-      @renderer.registerFold(@startRow, this)
+      @renderer.registerFold(this)
 
   isContainedByRange: (range) ->
     range.start.row <= @startRow and @endRow <= range.end.row

--- a/src/app/renderer.coffee
+++ b/src/app/renderer.coffee
@@ -127,9 +127,9 @@ class Renderer
     @lineMap.clipScreenPosition(position, options)
 
   handleBufferChange: (e) ->
-    for row, folds of @activeFolds
-      for fold in new Array(folds...)
-        fold.handleBufferChange(e)
+    allFolds = [] # Folds can modify @activeFolds, so first make sure we have a stable array of folds
+    allFolds.push(folds...) for row, folds of @activeFolds
+    fold.handleBufferChange(e) for fold in allFolds
 
     @handleHighlighterChange(@lastHighlighterChangeEvent)
 

--- a/src/app/renderer.coffee
+++ b/src/app/renderer.coffee
@@ -53,7 +53,7 @@ class Renderer
 
   createFold: (startRow, endRow) ->
     fold = new Fold(this, startRow, endRow)
-    @registerFold(startRow, fold)
+    @registerFold(fold)
 
     bufferRange = new Range([startRow, 0], [endRow, @buffer.lineLengthForRow(endRow)])
     oldScreenRange = @screenLineRangeForBufferRange(bufferRange)
@@ -83,9 +83,9 @@ class Renderer
     folds = @activeFolds[bufferRow] ? []
     fold.destroy() for fold in new Array(folds...)
 
-  registerFold: (bufferRow, fold) ->
-    @activeFolds[bufferRow] ?= []
-    @activeFolds[bufferRow].push(fold)
+  registerFold: (fold) ->
+    @activeFolds[fold.startRow] ?= []
+    @activeFolds[fold.startRow].push(fold)
     @foldsById[fold.id] = fold
 
   unregisterFold: (bufferRow, fold) ->

--- a/src/app/selection.coffee
+++ b/src/app/selection.coffee
@@ -145,6 +145,7 @@ class Selection extends View
     @editor.getCurrentMode().autoOutdent(state, new AceOutdentAdaptor(@editor.buffer, @editor), bufferRow)
 
   backspace: ->
+    @editor.destroyFoldsContainingBufferRow(@getBufferRange().end.row)
     @selectLeft() if @isEmpty()
     @deleteSelectedText()
 

--- a/static/theme/twilight.css
+++ b/static/theme/twilight.css
@@ -70,12 +70,12 @@ color:#D2A8A1;
 }
 
 .fold {
-  background-color: #52412C;
+  background-color: #524228;
   color: #969696;
 }
 
 .fold.selected {
-  background-color: #82715C;
+  background-color: #2A3B2A;
   color: #969696;
 }
 


### PR DESCRIPTION
This converts our previous free-form folds to line-wise folds. Before, arbitrary regions could be folded into a single token that could be anywhere in the buffer. But this made it possible for multiple folds to be on one screen line and had evil interactions with line wrapping. Instead of battling corner cases to death, we've decided to simplify it. You can only fold entire buffer lines now. It's actually easier to see where your folds are, because we have a more obvious UI treatment.
### TODO
- When Input events occur on a folded line they cause the fold to be destroyed.
- When the cursor is on a fold line, the fold line should be highlighted
### Pictures!

_Unfolded_
![](https://img.skitch.com/20120524-mjj58g999dwhg1j7bgfn2a9fby.jpg)

_Folded_
<img src="https://img.skitch.com/20120524-kxtrwt1tkahnjkyip8ikiw7b92.jpg" alt="/Volumes/github/code/Atom/src/app/editor.coffee" />
