### PR TITLE
Scroll performance tweaks

### DIFF
--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -12,6 +12,7 @@ class Cursor extends View
   anchor: null
   editor: null
   wordRegex: /(\w+)|([^\w\s]+)/g
+  hidden: false
 
   initialize: ({editor, screenPosition} = {}) ->
     @editor = editor
@@ -178,8 +179,10 @@ class Cursor extends View
       @editor.scrollTo(pixelPosition)
 
     if @editor.isFoldedAtScreenRow(screenPosition.row)
-      @hide()
+      @hide() unless @hidden
+      @hidden = true
     else
-      @show()
+      @show() if @hidden
+      @hidden = false
 
     @selection.updateAppearance()

--- a/static/atom.css
+++ b/static/atom.css
@@ -47,7 +47,6 @@ body {
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  -webkit-box-shadow: inset 0px 0px 2px 2px rgba(0, 0, 0, .1);
 }
 
 #root-view #panes .row > * + * {


### PR DESCRIPTION
This makes a couple simple adjustments to improve scroll performance. Disabling inset box shadows on frames cuts repaints time by 30-40%, and caching cursor visibility state avoids an extra DOM hit. More avoidance of DOM hits could be possible by caching the height / width and scroll position of the scrollView, but I'm concerned that we'll have trouble keeping the cached value in sync.
