### PR TITLE
Command panel fixes

### DIFF
--- a/spec/app/display-buffer-spec.coffee
+++ b/spec/app/display-buffer-spec.coffee
@@ -530,14 +530,22 @@ describe "DisplayBuffer", ->
         expect(displayBuffer.bufferPositionForScreenPosition([9, 2])).toEqual [12, 2]
 
     describe ".destroyFoldsContainingBufferRow(row)", ->
-      describe "when two folds start on the given buffer row", ->
-        it "destroys both folds", ->
+      it "destroys all folds containing the given row", ->
           displayBuffer.createFold(2, 4)
           displayBuffer.createFold(2, 6)
+          displayBuffer.createFold(7, 8)
+          displayBuffer.createFold(1, 9)
+          displayBuffer.createFold(11, 12)
 
-          expect(displayBuffer.lineForRow(3).text).toBe '7'
+          expect(displayBuffer.lineForRow(1).text).toBe '1'
+          expect(displayBuffer.lineForRow(2).text).toBe '10'
+
           displayBuffer.destroyFoldsContainingBufferRow(2)
-          expect(displayBuffer.lineForRow(3).text).toBe '3'
+          expect(displayBuffer.lineForRow(1).text).toBe '1'
+          expect(displayBuffer.lineForRow(2).text).toBe '2'
+          expect(displayBuffer.lineForRow(7).fold).toBeDefined()
+          expect(displayBuffer.lineForRow(8).text).toMatch /^9-+/
+          expect(displayBuffer.lineForRow(10).fold).toBeDefined()
 
   describe ".clipScreenPosition(screenPosition, wrapBeyondNewlines: false, wrapAtSoftNewlines: false, skipAtomicTokens: false)", ->
     beforeEach ->

--- a/spec/extensions/command-interpreter-spec.coffee
+++ b/spec/extensions/command-interpreter-spec.coffee
@@ -233,3 +233,15 @@ describe "CommandInterpreter", ->
           interpreter.eval(editor, 's/current/foo/g')
           expect(buffer.lineForRow(5)).toBe '      foo = items.shift();'
           expect(buffer.lineForRow(6)).toBe '      foo < pivot ? left.push(foo) : right.push(current);'
+
+  describe "when command selects folded text", ->
+    it "unfolds lines that command selects", ->
+      editor.createFold(1, 9)
+      editor.createFold(5, 8)
+      editor.setSelectedBufferRange([[0,0], [0,0]])
+
+      interpreter.eval(editor, '/push/')
+      expect(editor.getSelection().getBufferRange()).toEqual [[6,29], [6,33]]
+      expect(editor.lineForScreenRow(1).fold).toBeUndefined()
+      expect(editor.lineForScreenRow(5).fold).toBeUndefined()
+      expect(editor.lineForScreenRow(6).text).toBe buffer.lineForRow(6)

--- a/src/app/display-buffer.coffee
+++ b/src/app/display-buffer.coffee
@@ -108,8 +108,9 @@ class DisplayBuffer
       @trigger 'change', oldRange: oldScreenRange, newRange: newScreenRange, lineNumbersChanged: true
 
   destroyFoldsContainingBufferRow: (bufferRow) ->
-    folds = @activeFolds[bufferRow] ? []
-    fold.destroy() for fold in new Array(folds...)
+    for row, folds of @activeFolds
+      for fold in new Array(folds...)
+        fold.destroy() if fold.getBufferRange().containsRow(bufferRow)
 
   registerFold: (fold) ->
     @activeFolds[fold.startRow] ?= []

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -193,7 +193,7 @@ class EditSession
   destroyFoldsContainingBufferRow: (bufferRow) ->
     @displayBuffer.destroyFoldsContainingBufferRow(bufferRow)
 
-  unfoldCurrentRow: (row) ->
+  unfoldCurrentRow: ->
     @displayBuffer.largestFoldForBufferRow(@getLastCursor().getCurrentBufferRow())?.destroy()
 
   destroyFold: (foldId) ->

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -217,6 +217,7 @@ class Editor extends View
     softWrapColumn ?= @calcSoftWrapColumn()
     @activeEditSession.setSoftWrapColumn(softWrapColumn) if softWrapColumn
 
+  lineForScreenRow: (screenRow) -> @activeEditSession.lineForScreenRow(screenRow)
   linesForScreenRows: (start, end) -> @activeEditSession.linesForScreenRows(start, end)
   screenLineCount: -> @activeEditSession.screenLineCount()
   maxScreenLineLength: -> @activeEditSession.maxScreenLineLength()

--- a/src/app/range.coffee
+++ b/src/app/range.coffee
@@ -50,6 +50,9 @@ class Range
     point = Point.fromObject(point)
     point.isGreaterThanOrEqual(@start) and point.isLessThanOrEqual(@end)
 
+  containsRow: (row) ->
+    @start.row <= row <= @end.row
+
   union: (otherRange) ->
     start = if @start.isLessThan(otherRange.start) then @start else otherRange.start
     end = if @end.isGreaterThan(otherRange.end) then @end else otherRange.end

--- a/src/extensions/command-interpreter/composite-command.coffee
+++ b/src/extensions/command-interpreter/composite-command.coffee
@@ -10,6 +10,11 @@ class CompositeCommand
       currentRanges = editor.getSelectionsOrderedByBufferPosition().map (selection) -> selection.getBufferRange()
       for currentRange in currentRanges
         newRanges.push(command.execute(editor, currentRange)...)
+
+      for range in newRanges
+        for row in [range.start.row..range.end.row]
+          editor.destroyFoldsContainingBufferRow(row)
+
       editor.setSelectedBufferRanges(newRanges)
 
   reverse: ->


### PR DESCRIPTION
Searching text using the command panel expands folds. Previously, when the found text was inside of a fold you couldn't really do much with it, because it was hidden. Now the fold auto-expands so you can see what you found.
