### PR TITLE
Multi keystroke bindings

### DIFF
--- a/spec/app/keymap-spec.coffee
+++ b/spec/app/keymap-spec.coffee
@@ -126,20 +126,21 @@ describe "Keymap", ->
             expect(bazHandler).toHaveBeenCalled()
 
     describe "when at least one binding partially matches the event's keystroke", ->
+      [quitHandler, closeOtherWindowsHandler] = []
+
       beforeEach ->
         keymap.bindKeys "*",
           'ctrl-x ctrl-c': 'quit'
           'ctrl-x 1': 'close-other-windows'
 
+        quitHandler = jasmine.createSpy('quitHandler')
+        closeOtherWindowsHandler = jasmine.createSpy('closeOtherWindowsHandler')
+        fragment.on 'quit', quitHandler
+        fragment.on 'close-other-windows', closeOtherWindowsHandler
+
       describe "when the event's target node matches a selector with a partially matching multi-stroke binding", ->
         describe "when a second keystroke added to the first to match a multi-stroke binding completely", ->
           fit "triggers the event associated with the matched multi-stroke binding", ->
-
-            quitHandler = jasmine.createSpy('quitHandler')
-            fragment.on 'quit', quitHandler
-            closeOtherWindowsHandler = jasmine.createSpy('closeOtherWindowsHandler')
-            fragment.on 'close-other-windows', closeOtherWindowsHandler
-
             expect(keymap.handleKeyEvent(keydownEvent('x', target: fragment[0], ctrlKey: true))).toBeFalsy()
             expect(keymap.handleKeyEvent(keydownEvent('c', target: fragment[0], ctrlKey: true))).toBeFalsy()
 
@@ -154,7 +155,13 @@ describe "Keymap", ->
             expect(closeOtherWindowsHandler).toHaveBeenCalled()
 
         describe "when a second keystroke added to the first doesn't match any bindings", ->
-          it "clears the queued keystrokes without triggering any events", ->
+          fit "clears the queued keystrokes without triggering any events", ->
+            expect(keymap.handleKeyEvent(keydownEvent('x', target: fragment[0], ctrlKey: true))).toBeFalsy()
+            expect(keymap.handleKeyEvent(keydownEvent('c', target: fragment[0]))).toBeFalsy()
+            expect(quitHandler).not.toHaveBeenCalled()
+            expect(closeOtherWindowsHandler).not.toHaveBeenCalled()
+
+            expect(keymap.handleKeyEvent(keydownEvent('c', target: fragment[0]))).toBeTruthy()
 
       describe "when the event's target node descends from multiple nodes that match selectors with a partial binding match", ->
         it "allows any of the bindings to be triggered upon a second keystroke"

--- a/spec/app/keymap-spec.coffee
+++ b/spec/app/keymap-spec.coffee
@@ -28,10 +28,10 @@ describe "Keymap", ->
       fragment.on 'deleteChar', deleteCharHandler
       fragment.on 'insertChar', insertCharHandler
 
-    it "adds a 'keystroke' string to the event object", ->
+    it "adds a 'keystrokes' string to the event object", ->
       event = keydownEvent('x', altKey: true, metaKey: true)
       keymap.handleKeyEvent(event)
-      expect(event.keystroke).toBe 'alt-meta-x'
+      expect(event.keystrokes).toBe 'alt-meta-x'
 
     describe "when no binding matches the event's keystroke", ->
       it "returns true, so the event continues to propagate", ->
@@ -54,7 +54,7 @@ describe "Keymap", ->
           expect(insertCharHandler).toHaveBeenCalled()
           commandEvent = insertCharHandler.argsForCall[0][0]
           expect(commandEvent.keyEvent).toBe event
-          expect(event.keystroke).toBe 'x'
+          expect(event.keystrokes).toBe 'x'
 
       describe "when the event's target node *descends* from a selector with a matching binding", ->
         it "triggers the command event associated with that binding on the target node and returns false", ->
@@ -158,7 +158,7 @@ describe "Keymap", ->
             expect(closeOtherWindowsHandler).toHaveBeenCalled()
 
         describe "when a second keystroke added to the first doesn't match any bindings", ->
-          fit "clears the queued keystrokes without triggering any events", ->
+          it "clears the queued keystrokes without triggering any events", ->
             expect(keymap.handleKeyEvent(keydownEvent('x', target: fragment[0], ctrlKey: true))).toBeFalsy()
             expect(keymap.handleKeyEvent(keydownEvent('c', target: fragment[0]))).toBeFalsy()
             expect(quitHandler).not.toHaveBeenCalled()
@@ -167,7 +167,7 @@ describe "Keymap", ->
             expect(keymap.handleKeyEvent(keydownEvent('c', target: fragment[0]))).toBeTruthy()
 
       describe "when the event's target node descends from multiple nodes that match selectors with a partial binding match", ->
-        fit "allows any of the bindings to be triggered upon a second keystroke, favoring the most specific selector", ->
+        it "allows any of the bindings to be triggered upon a second keystroke, favoring the most specific selector", ->
            keymap.bindKeys ".grandchild-node", 'ctrl-x ctrl-c': 'more-specific-quit'
            grandchildNode = fragment.find('.grandchild-node')[0]
            moreSpecificQuitHandler = jasmine.createSpy('moreSpecificQuitHandler')
@@ -280,7 +280,6 @@ describe "Keymap", ->
         expect(keymap.keystrokeStringForEvent(keydownEvent('{', shiftKey: true))).toBe '{'
         expect(keymap.keystrokeStringForEvent(keydownEvent('left', shiftKey: true))).toBe 'shift-left'
         expect(keymap.keystrokeStringForEvent(keydownEvent('Left', shiftKey: true))).toBe 'shift-left'
-
 
   describe ".bindingsForElement(element)", ->
     it "returns the matching bindings for the element", ->

--- a/spec/app/keymap-spec.coffee
+++ b/spec/app/keymap-spec.coffee
@@ -138,9 +138,12 @@ describe "Keymap", ->
         fragment.on 'quit', quitHandler
         fragment.on 'close-other-windows', closeOtherWindowsHandler
 
+      it "only matches entire keystroke patters", ->
+        expect(keymap.handleKeyEvent(keydownEvent('c', target: fragment[0]))).toBeTruthy()
+
       describe "when the event's target node matches a selector with a partially matching multi-stroke binding", ->
         describe "when a second keystroke added to the first to match a multi-stroke binding completely", ->
-          fit "triggers the event associated with the matched multi-stroke binding", ->
+          it "triggers the event associated with the matched multi-stroke binding", ->
             expect(keymap.handleKeyEvent(keydownEvent('x', target: fragment[0], ctrlKey: true))).toBeFalsy()
             expect(keymap.handleKeyEvent(keydownEvent('c', target: fragment[0], ctrlKey: true))).toBeFalsy()
 

--- a/spec/app/keymap-spec.coffee
+++ b/spec/app/keymap-spec.coffee
@@ -164,7 +164,24 @@ describe "Keymap", ->
             expect(keymap.handleKeyEvent(keydownEvent('c', target: fragment[0]))).toBeTruthy()
 
       describe "when the event's target node descends from multiple nodes that match selectors with a partial binding match", ->
-        it "allows any of the bindings to be triggered upon a second keystroke"
+        fit "allows any of the bindings to be triggered upon a second keystroke, favoring the most specific selector", ->
+           keymap.bindKeys ".grandchild-node", 'ctrl-x ctrl-c': 'more-specific-quit'
+           grandchildNode = fragment.find('.grandchild-node')[0]
+           moreSpecificQuitHandler = jasmine.createSpy('moreSpecificQuitHandler')
+           fragment.on 'more-specific-quit', moreSpecificQuitHandler
+
+           expect(keymap.handleKeyEvent(keydownEvent('x', target: grandchildNode, ctrlKey: true))).toBeFalsy()
+           expect(keymap.handleKeyEvent(keydownEvent('1', target: grandchildNode))).toBeFalsy()
+           expect(quitHandler).not.toHaveBeenCalled()
+           expect(moreSpecificQuitHandler).not.toHaveBeenCalled()
+           expect(closeOtherWindowsHandler).toHaveBeenCalled()
+           closeOtherWindowsHandler.reset()
+
+           expect(keymap.handleKeyEvent(keydownEvent('x', target: grandchildNode, ctrlKey: true))).toBeFalsy()
+           expect(keymap.handleKeyEvent(keydownEvent('c', target: grandchildNode, ctrlKey: true))).toBeFalsy()
+           expect(quitHandler).not.toHaveBeenCalled()
+           expect(closeOtherWindowsHandler).not.toHaveBeenCalled()
+           expect(moreSpecificQuitHandler).toHaveBeenCalled()
 
       describe "when there is a complete binding with a less specific selector", ->
         it "favors the more specific partial match", ->

--- a/spec/app/keymap-spec.coffee
+++ b/spec/app/keymap-spec.coffee
@@ -33,96 +33,137 @@ describe "Keymap", ->
       keymap.handleKeyEvent(event)
       expect(event.keystroke).toBe 'alt-meta-x'
 
-    describe "when no binding matches the event", ->
+    describe "when no binding matches the event's keystroke", ->
       it "returns true, so the event continues to propagate", ->
         expect(keymap.handleKeyEvent(keydownEvent('0', target: fragment[0]))).toBeTruthy()
 
-    describe "when the event's target node matches a selector with a matching binding", ->
-      it "triggers the command event associated with that binding on the target node and returns false", ->
-        result = keymap.handleKeyEvent(keydownEvent('x', target: fragment[0]))
-        expect(result).toBe(false)
-        expect(deleteCharHandler).toHaveBeenCalled()
-        expect(insertCharHandler).not.toHaveBeenCalled()
+    describe "when at least one binding fully matches the event's keystroke", ->
+      describe "when the event's target node matches a selector with a matching binding", ->
+        it "triggers the command event associated with that binding on the target node and returns false", ->
+          result = keymap.handleKeyEvent(keydownEvent('x', target: fragment[0]))
+          expect(result).toBe(false)
+          expect(deleteCharHandler).toHaveBeenCalled()
+          expect(insertCharHandler).not.toHaveBeenCalled()
 
-        deleteCharHandler.reset()
-        fragment.removeClass('command-mode').addClass('insert-mode')
+          deleteCharHandler.reset()
+          fragment.removeClass('command-mode').addClass('insert-mode')
 
-        event = keydownEvent('x', target: fragment[0])
-        keymap.handleKeyEvent(event)
-        expect(deleteCharHandler).not.toHaveBeenCalled()
-        expect(insertCharHandler).toHaveBeenCalled()
-        commandEvent = insertCharHandler.argsForCall[0][0]
-        expect(commandEvent.keyEvent).toBe event
-        expect(event.keystroke).toBe 'x'
+          event = keydownEvent('x', target: fragment[0])
+          keymap.handleKeyEvent(event)
+          expect(deleteCharHandler).not.toHaveBeenCalled()
+          expect(insertCharHandler).toHaveBeenCalled()
+          commandEvent = insertCharHandler.argsForCall[0][0]
+          expect(commandEvent.keyEvent).toBe event
+          expect(event.keystroke).toBe 'x'
 
-    describe "when the event's target node *descends* from a selector with a matching binding", ->
-      it "triggers the command event associated with that binding on the target node and returns false", ->
-        target = fragment.find('.child-node')[0]
-        result = keymap.handleKeyEvent(keydownEvent('x', target: target))
-        expect(result).toBe(false)
-        expect(deleteCharHandler).toHaveBeenCalled()
-        expect(insertCharHandler).not.toHaveBeenCalled()
+      describe "when the event's target node *descends* from a selector with a matching binding", ->
+        it "triggers the command event associated with that binding on the target node and returns false", ->
+          target = fragment.find('.child-node')[0]
+          result = keymap.handleKeyEvent(keydownEvent('x', target: target))
+          expect(result).toBe(false)
+          expect(deleteCharHandler).toHaveBeenCalled()
+          expect(insertCharHandler).not.toHaveBeenCalled()
 
-        deleteCharHandler.reset()
-        fragment.removeClass('command-mode').addClass('insert-mode')
+          deleteCharHandler.reset()
+          fragment.removeClass('command-mode').addClass('insert-mode')
 
-        keymap.handleKeyEvent(keydownEvent('x', target: target))
-        expect(deleteCharHandler).not.toHaveBeenCalled()
-        expect(insertCharHandler).toHaveBeenCalled()
+          keymap.handleKeyEvent(keydownEvent('x', target: target))
+          expect(deleteCharHandler).not.toHaveBeenCalled()
+          expect(insertCharHandler).toHaveBeenCalled()
 
-    describe "when the event's target node descends from multiple nodes that match selectors with a binding", ->
-      it "only triggers bindings on selectors associated with the closest ancestor node", ->
-        keymap.bindKeys '.child-node', 'x': 'foo'
-        fooHandler = jasmine.createSpy 'fooHandler'
-        fragment.on 'foo', fooHandler
-
-        target = fragment.find('.grandchild-node')[0]
-        keymap.handleKeyEvent(keydownEvent('x', target: target))
-        expect(fooHandler).toHaveBeenCalled()
-        expect(deleteCharHandler).not.toHaveBeenCalled()
-        expect(insertCharHandler).not.toHaveBeenCalled()
-
-    describe "when the event bubbles to a node that matches multiple selectors", ->
-      describe "when the matching selectors differ in specificity", ->
-        it "triggers the binding for the most specific selector", ->
-          keymap.bindKeys 'div .child-node', 'x': 'foo'
-          keymap.bindKeys '.command-mode .child-node', 'x': 'baz'
-          keymap.bindKeys '.child-node', 'x': 'bar'
-
+      describe "when the event's target node descends from multiple nodes that match selectors with a binding", ->
+        it "only triggers bindings on selectors associated with the closest ancestor node", ->
+          keymap.bindKeys '.child-node', 'x': 'foo'
           fooHandler = jasmine.createSpy 'fooHandler'
-          barHandler = jasmine.createSpy 'barHandler'
-          bazHandler = jasmine.createSpy 'bazHandler'
           fragment.on 'foo', fooHandler
-          fragment.on 'bar', barHandler
-          fragment.on 'baz', bazHandler
 
           target = fragment.find('.grandchild-node')[0]
           keymap.handleKeyEvent(keydownEvent('x', target: target))
+          expect(fooHandler).toHaveBeenCalled()
+          expect(deleteCharHandler).not.toHaveBeenCalled()
+          expect(insertCharHandler).not.toHaveBeenCalled()
 
-          expect(fooHandler).not.toHaveBeenCalled()
-          expect(barHandler).not.toHaveBeenCalled()
-          expect(bazHandler).toHaveBeenCalled()
+      describe "when the event bubbles to a node that matches multiple selectors", ->
+        describe "when the matching selectors differ in specificity", ->
+          it "triggers the binding for the most specific selector", ->
+            keymap.bindKeys 'div .child-node', 'x': 'foo'
+            keymap.bindKeys '.command-mode .child-node', 'x': 'baz'
+            keymap.bindKeys '.child-node', 'x': 'bar'
 
-      describe "when the matching selectors have the same specificity", ->
-        it "triggers the bindings for the most recently declared selector", ->
-          keymap.bindKeys '.child-node', 'x': 'foo', 'y': 'baz'
-          keymap.bindKeys '.child-node', 'x': 'bar'
+            fooHandler = jasmine.createSpy 'fooHandler'
+            barHandler = jasmine.createSpy 'barHandler'
+            bazHandler = jasmine.createSpy 'bazHandler'
+            fragment.on 'foo', fooHandler
+            fragment.on 'bar', barHandler
+            fragment.on 'baz', bazHandler
 
-          fooHandler = jasmine.createSpy 'fooHandler'
-          barHandler = jasmine.createSpy 'barHandler'
-          bazHandler = jasmine.createSpy 'bazHandler'
-          fragment.on 'foo', fooHandler
-          fragment.on 'bar', barHandler
-          fragment.on 'baz', bazHandler
+            target = fragment.find('.grandchild-node')[0]
+            keymap.handleKeyEvent(keydownEvent('x', target: target))
 
-          target = fragment.find('.grandchild-node')[0]
-          keymap.handleKeyEvent(keydownEvent('x', target: target))
+            expect(fooHandler).not.toHaveBeenCalled()
+            expect(barHandler).not.toHaveBeenCalled()
+            expect(bazHandler).toHaveBeenCalled()
 
-          expect(barHandler).toHaveBeenCalled()
-          expect(fooHandler).not.toHaveBeenCalled()
+        describe "when the matching selectors have the same specificity", ->
+          it "triggers the bindings for the most recently declared selector", ->
+            keymap.bindKeys '.child-node', 'x': 'foo', 'y': 'baz'
+            keymap.bindKeys '.child-node', 'x': 'bar'
 
-          keymap.handleKeyEvent(keydownEvent('y', target: target))
-          expect(bazHandler).toHaveBeenCalled()
+            fooHandler = jasmine.createSpy 'fooHandler'
+            barHandler = jasmine.createSpy 'barHandler'
+            bazHandler = jasmine.createSpy 'bazHandler'
+            fragment.on 'foo', fooHandler
+            fragment.on 'bar', barHandler
+            fragment.on 'baz', bazHandler
+
+            target = fragment.find('.grandchild-node')[0]
+            keymap.handleKeyEvent(keydownEvent('x', target: target))
+
+            expect(barHandler).toHaveBeenCalled()
+            expect(fooHandler).not.toHaveBeenCalled()
+
+            keymap.handleKeyEvent(keydownEvent('y', target: target))
+            expect(bazHandler).toHaveBeenCalled()
+
+    describe "when at least one binding partially matches the event's keystroke", ->
+      beforeEach ->
+        keymap.bindKeys "*",
+          'ctrl-x ctrl-c': 'quit'
+          'ctrl-x 1': 'close-other-windows'
+
+      describe "when the event's target node matches a selector with a partially matching multi-stroke binding", ->
+        describe "when a second keystroke added to the first to match a multi-stroke binding completely", ->
+          fit "triggers the event associated with the matched multi-stroke binding", ->
+
+            quitHandler = jasmine.createSpy('quitHandler')
+            fragment.on 'quit', quitHandler
+            closeOtherWindowsHandler = jasmine.createSpy('closeOtherWindowsHandler')
+            fragment.on 'close-other-windows', closeOtherWindowsHandler
+
+            expect(keymap.handleKeyEvent(keydownEvent('x', target: fragment[0], ctrlKey: true))).toBeFalsy()
+            expect(keymap.handleKeyEvent(keydownEvent('c', target: fragment[0], ctrlKey: true))).toBeFalsy()
+
+            expect(quitHandler).toHaveBeenCalled()
+            expect(closeOtherWindowsHandler).not.toHaveBeenCalled()
+            quitHandler.reset()
+
+            expect(keymap.handleKeyEvent(keydownEvent('x', target: fragment[0], ctrlKey: true))).toBeFalsy()
+            expect(keymap.handleKeyEvent(keydownEvent('1', target: fragment[0]))).toBeFalsy()
+
+            expect(quitHandler).not.toHaveBeenCalled()
+            expect(closeOtherWindowsHandler).toHaveBeenCalled()
+
+        describe "when a second keystroke added to the first doesn't match any bindings", ->
+          it "clears the queued keystrokes without triggering any events", ->
+
+      describe "when the event's target node descends from multiple nodes that match selectors with a partial binding match", ->
+        it "allows any of the bindings to be triggered upon a second keystroke"
+
+      describe "when there is a complete binding with a less specific selector", ->
+        it "favors the more specific partial match", ->
+
+      describe "when there is a complete binding with a more specific selector", ->
+        it "favors the more specific complete match", ->
 
   describe ".bindKeys(selector, fnOrMap)", ->
     describe "when called with a selector and a hash", ->

--- a/spec/app/root-view-spec.coffee
+++ b/spec/app/root-view-spec.coffee
@@ -3,6 +3,7 @@ fs = require 'fs'
 RootView = require 'root-view'
 Buffer = require 'buffer'
 Editor = require 'editor'
+{View} = require 'space-pen'
 
 describe "RootView", ->
   rootView = null
@@ -331,6 +332,30 @@ describe "RootView", ->
         expect(rootView.panes.children().length).toBe 1
         expect(rootView.panes.children('.pane').length).toBe 1
         expect(pane1.outerWidth()).toBe rootView.panes.width()
+
+    describe ".focusNextPane()", ->
+      it "focuses the wrapped view of the pane after the currently focused pane", ->
+        class DummyView extends View
+          @content: (number) -> @div(number, tabindex: -1)
+
+        view1 = pane1.wrappedView
+        view2 = new DummyView(2)
+        view3 = new DummyView(3)
+        pane2 = pane1.splitDown(view2)
+        pane3 = pane2.splitRight(view3)
+        rootView.attachToDom()
+        view1.focus()
+
+        spyOn(view1, 'focus').andCallThrough()
+        spyOn(view2, 'focus').andCallThrough()
+        spyOn(view3, 'focus').andCallThrough()
+
+        rootView.focusNextPane()
+        expect(view2.focus).toHaveBeenCalled()
+        rootView.focusNextPane()
+        expect(view3.focus).toHaveBeenCalled()
+        rootView.focusNextPane()
+        expect(view1.focus).toHaveBeenCalled()
 
   describe "extensions", ->
     extension = null

--- a/src/app/binding-set.coffee
+++ b/src/app/binding-set.coffee
@@ -27,8 +27,11 @@ class BindingSet
         null
 
   matchesKeystrokePrefix: (event) ->
+    eventKeystrokes = event.keystrokes.split(' ')
     for keystrokes, command of @commandsByKeystrokes
-      return true if keystrokes.indexOf(event.keystrokes) == 0
+      bindingKeystrokes = keystrokes.split(' ')
+      continue unless eventKeystrokes.length < bindingKeystrokes.length
+      return true if _.isEqual(eventKeystrokes, bindingKeystrokes[0...eventKeystrokes.length])
     false
 
   normalizeCommandsByKeystrokes: (commandsByKeystrokes) ->

--- a/src/app/keymap.coffee
+++ b/src/app/keymap.coffee
@@ -8,6 +8,7 @@ Specificity = require 'specificity'
 module.exports =
 class Keymap
   bindingSets: null
+  queuedKeystrokes: null
 
   constructor: ->
     @bindingSets = []
@@ -40,7 +41,8 @@ class Keymap
     keystrokeMap
 
   handleKeyEvent: (event) ->
-    event.keystroke = @keystrokeStringForEvent(event)
+    event.keystrokes = @multiKeystrokeStringForEvent(event)
+    @queuedKeystrokes = null
     currentNode = $(event.target)
     while currentNode.length
       candidateBindingSets = @bindingSets.filter (set) -> currentNode.is(set.selector)
@@ -52,6 +54,10 @@ class Keymap
           return false
         else if command == false
           return false
+
+        if bindingSet.matchesKeystrokePrefix(event)
+          @queuedKeystrokes = event.keystrokes
+          return false
       currentNode = currentNode.parent()
     true
 
@@ -59,6 +65,13 @@ class Keymap
     commandEvent = $.Event(commandName)
     commandEvent.keyEvent = keyEvent
     $(keyEvent.target).trigger(commandEvent)
+
+  multiKeystrokeStringForEvent: (event) ->
+    currentKeystroke = @keystrokeStringForEvent(event)
+    if @queuedKeystrokes
+      @queuedKeystrokes + ' ' + currentKeystroke
+    else
+      currentKeystroke
 
   keystrokeStringForEvent: (event) ->
     if /^U\+/i.test event.originalEvent.keyIdentifier

--- a/src/app/keymap.coffee
+++ b/src/app/keymap.coffee
@@ -35,13 +35,14 @@ class Keymap
     while currentNode.length
       bindingSets = @bindingSets.filter (set) -> currentNode.is(set.selector)
       bindingSets.sort (a, b) -> b.specificity - a.specificity
-      _.defaults(keystrokeMap, set.keystrokeMap) for set in bindingSets
+      _.defaults(keystrokeMap, set.commandsByKeystrokes) for set in bindingSets
       currentNode = currentNode.parent()
 
     keystrokeMap
 
   handleKeyEvent: (event) ->
     event.keystrokes = @multiKeystrokeStringForEvent(event)
+    isMultiKeystroke = @queuedKeystrokes?
     @queuedKeystrokes = null
     currentNode = $(event.target)
     while currentNode.length
@@ -59,7 +60,8 @@ class Keymap
           @queuedKeystrokes = event.keystrokes
           return false
       currentNode = currentNode.parent()
-    true
+
+    !isMultiKeystroke
 
   triggerCommandEvent: (keyEvent, commandName) ->
     commandEvent = $.Event(commandName)

--- a/src/app/keymaps/editor.coffee
+++ b/src/app/keymaps/editor.coffee
@@ -5,7 +5,6 @@ window.keymap.bindKeys '.editor',
   'shift-up': 'select-up'
   'shift-down': 'select-down'
   'meta-a': 'select-all'
-  'ctrl-w': 'select-word'
   'enter': 'newline'
   'meta-enter': 'newline-below'
   'tab': 'tab'
@@ -33,3 +32,5 @@ window.keymap.bindKeys '.editor',
   'meta-+': 'increase-font-size'
   'meta--': 'decrease-font-size'
   'meta-/': 'toggle-line-comments'
+  'ctrl-w w': 'focus-next-pane'
+  'ctrl-W': 'select-word'

--- a/src/app/root-view.coffee
+++ b/src/app/root-view.coffee
@@ -59,6 +59,7 @@ class RootView extends View
 
     @on 'increase-font-size', => @setFontSize(@getFontSize() + 1)
     @on 'decrease-font-size', => @setFontSize(@getFontSize() - 1)
+    @on 'focus-next-pane', => @focusNextPane()
 
   afterAttach: (onDom) ->
     @focus() if onDom

--- a/src/app/root-view.coffee
+++ b/src/app/root-view.coffee
@@ -140,6 +140,15 @@ class RootView extends View
     else
       @panes.find('.editor:first').view()
 
+  focusNextPane: ->
+    panes = @panes.find('.pane')
+    currentIndex = panes.toArray().indexOf(@getFocusedPane()[0])
+    nextIndex = (currentIndex + 1) % panes.length
+    panes.eq(nextIndex).view().wrappedView.focus()
+
+  getFocusedPane: ->
+    @panes.find('.pane:has(:focus)')
+
   setRootPane: (pane) ->
     @panes.empty()
     @panes.append(pane)


### PR DESCRIPTION
Here we add the `ctrl-w w` binding to switch between split panes. Basically if no binding explicitly matches a keystroke, the keymap looks for partial prefix matches. If there are prefix matches, it enqueues the keystroke, then appends the next keystroke on the next key event.

Pane switching is supported by RootView. It queries all panes, then finds which pane currently has focus and length-modulo-increments its index to determine the next pane to focus. This will work with split panes containing editors, or any other view that can accept focus.
