### PR TITLE
How is Edit Session formed? How Editor get created?

### DIFF
--- a/benchmark/benchmark-suite.coffee
+++ b/benchmark/benchmark-suite.coffee
@@ -10,6 +10,7 @@ describe "editor.", ->
     window.rootViewParentSelector = '#jasmine-content'
     spyOn(window, 'loadUserConfiguration')
     window.startup()
+    rootView.project.setPath(require.resolve('fixtures'))
     editor = rootView.activeEditor()
 
   afterEach ->
@@ -24,7 +25,7 @@ describe "editor.", ->
 
   describe "300-line-file.", ->
     beforeEach ->
-      editor.setBuffer new Buffer(require.resolve('fixtures/medium.coffee'))
+      editor.edit rootView.project.open('fixtures/medium.coffee')
 
     describe "at-begining.", ->
       benchmark "insert-delete", ->
@@ -45,11 +46,11 @@ describe "editor.", ->
 
   describe "9000-line-file.", ->
     benchmark "opening.", 5, ->
-      editor.setBuffer new Buffer(require.resolve('fixtures/huge.js'))
+      editor.edit rootView.project.open('fixtures/huge.js')
 
     describe "after-opening.", ->
       beforeEach ->
-        editor.setBuffer new Buffer(require.resolve('fixtures/huge.js'))
+        editor.edit rootView.project.open('fixtures/huge.js')
 
       benchmark "moving-to-eof.", 1, ->
         editor.moveCursorToBottom()

--- a/spec/app/buffer-spec.coffee
+++ b/spec/app/buffer-spec.coffee
@@ -39,19 +39,6 @@ describe 'Buffer', ->
       expect(eventHandler).toHaveBeenCalledWith(buffer)
 
   describe ".isModified()", ->
-    describe "when deserialized", ->
-      it "returns false", ->
-        buffer = Buffer.deserialize(buffer.serialize(), new Project)
-        expect(buffer.isModified()).toBe false
-
-        buffer = Buffer.deserialize((new Buffer).serialize(), new Project)
-        expect(buffer.isModified()).toBe false
-
-      it "returns is true if buffer no path and had changes", ->
-        buffer = new Buffer
-        buffer.insert([0,0], "oh hi")
-        expect(buffer.isModified()).toBe true
-
     it "returns true when user changes buffer", ->
       expect(buffer.isModified()).toBeFalsy()
       buffer.insert([0,0], "hi")
@@ -67,25 +54,6 @@ describe 'Buffer', ->
 
       buffer.save()
       expect(buffer.isModified()).toBe false
-
-  describe '.deserialize(state, project)', ->
-    project = null
-
-    beforeEach ->
-      project = new Project(fs.directory(filePath))
-
-    describe 'when the state has a path', ->
-      it 'use the project to open the path', ->
-        savedBuffer = project.open(filePath)
-        buffer = Buffer.deserialize(savedBuffer.serialize(), project)
-        expect(buffer).toBe savedBuffer
-
-    describe 'when the state has text (and no path)', ->
-      it 'creates a new empty buffer (does not serialze unsaved text)', ->
-        unsavedBuffer = project.open()
-        unsavedBuffer.setText("OMGWTFBBQ")
-        buffer = Buffer.deserialize(unsavedBuffer.serialize(), project)
-        expect(buffer.getText()).toBe ""
 
   describe ".getLines()", ->
     it "returns an array of lines in the text contents", ->

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -6,12 +6,12 @@ describe "EditSession", ->
 
   beforeEach ->
     buffer = new Buffer(require.resolve('fixtures/sample.js'))
-    editSession = new EditSession(
+    editSession = new EditSession
       buffer: buffer
       tabText: '  '
       autoIndent: false
       softWrapColumn: Infinity
-    )
+
     lineLengths = buffer.getLines().map (line) -> line.length
 
   describe "cursor movement", ->

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -10,7 +10,7 @@ describe "EditSession", ->
       buffer: buffer
       tabText: '  '
       autoIndent: false
-      softWrapColumn: Infinity
+      softWrap: false
 
     lineLengths = buffer.getLines().map (line) -> line.length
 

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -66,6 +66,7 @@ describe "Editor", ->
       expect(editor.serialize).toHaveBeenCalled()
       expect(Editor.deserialize).toHaveBeenCalled()
 
+
       expect(newEditor.buffer).toBe editor.buffer
       expect(newEditor.getCursorScreenPosition()).toEqual editor.getCursorScreenPosition()
       expect(newEditor.editSessions[0]).toEqual(editor.editSessions[0])

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -14,7 +14,7 @@ describe "Editor", ->
 
   getLineHeight = ->
     return cachedLineHeight if cachedLineHeight?
-    editorForMeasurement = new Editor(editSession: project.open('sample.js'))
+    editorForMeasurement = new Editor(editSession: rootView.project.open('sample.js'))
     editorForMeasurement.attachToDom()
     cachedLineHeight = editorForMeasurement.lineHeight
     editorForMeasurement.remove()
@@ -22,7 +22,6 @@ describe "Editor", ->
 
   beforeEach ->
     rootView = new RootView(require.resolve('fixtures/sample.js'))
-    project = rootView.project
     editor = rootView.activeEditor()
     buffer = editor.buffer
 
@@ -32,7 +31,7 @@ describe "Editor", ->
       $('#jasmine-content').append(this)
 
     editor.lineOverdraw = 2
-    editor.setAutoIndent(false)
+    rootView.project.setAutoIndent(false)
     editor.enableKeymap()
     editor.isFocused = true
 
@@ -93,7 +92,7 @@ describe "Editor", ->
       expect(editor).toMatchSelector ":has(:focus)"
 
     it "unsubscribes from the buffer when it is removed from the dom", ->
-      editSession = project.open('sample.txt')
+      editSession = rootView.project.open('sample.txt')
       previousSubscriptionCount = editSession.buffer.subscriptionCount()
       editor.attachToDom()
       editor.edit(editSession)
@@ -126,7 +125,7 @@ describe "Editor", ->
   describe ".remove()", ->
     it "removes subscriptions from all edit session buffers", ->
       previousEditSession = editor.activeEditSession
-      otherEditSession = project.open('sample.txt')
+      otherEditSession = rootView.project.open('sample.txt')
       expect(previousEditSession.buffer.subscriptionCount()).toBeGreaterThan 1
 
       editor.edit(otherEditSession)
@@ -138,7 +137,7 @@ describe "Editor", ->
 
   describe "when 'close' is triggered", ->
     it "closes active edit session and loads next edit session", ->
-      editor.edit(project.open())
+      editor.edit(rootView.project.open())
       spyOn(editor, "remove")
       editor.trigger "close"
       expect(editor.remove).not.toHaveBeenCalled()
@@ -171,7 +170,7 @@ describe "Editor", ->
     otherEditSession = null
 
     beforeEach ->
-      otherEditSession = project.open()
+      otherEditSession = rootView.project.open()
 
     describe "when the edit session wasn't previously assigned to this editor", ->
       it "adds edit session to editor", ->
@@ -219,10 +218,10 @@ describe "Editor", ->
     beforeEach ->
       session0 = editor.activeEditSession
 
-      editor.edit(project.open('sample.txt'))
+      editor.edit(rootView.project.open('sample.txt'))
       session1 = editor.activeEditSession
 
-      editor.edit(project.open('two-hundred.txt'))
+      editor.edit(rootView.project.open('two-hundred.txt'))
       session2 = editor.activeEditSession
 
     describe ".setActiveEditSessionIndex(index)", ->
@@ -278,7 +277,7 @@ describe "Editor", ->
         rootView = new RootView(tempFilePath)
         project = rootView.project
 
-        editor.edit(project.open(tempFilePath))
+        editor.edit(rootView.project.open(tempFilePath))
         expect(editor.buffer.getPath()).toBe tempFilePath
 
       afterEach ->
@@ -296,7 +295,7 @@ describe "Editor", ->
     describe "when the current buffer has no path", ->
       selectedFilePath = null
       beforeEach ->
-        editor.edit(project.open())
+        editor.edit(rootView.project.open())
 
         expect(editor.buffer.getPath()).toBeUndefined()
         editor.buffer.setText 'Save me to a new path'
@@ -413,7 +412,7 @@ describe "Editor", ->
     it "emits event when editor receives a new buffer", ->
       eventHandler = jasmine.createSpy('eventHandler')
       editor.on 'editor-path-change', eventHandler
-      editor.edit(project.open("something.txt"))
+      editor.edit(rootView.project.open("something.txt"))
       expect(eventHandler).toHaveBeenCalled()
 
     it "stops listening to events on previously set buffers", ->
@@ -421,7 +420,7 @@ describe "Editor", ->
       oldBuffer = editor.buffer
       editor.on 'editor-path-change', eventHandler
 
-      editor.edit(project.open("something.txt"))
+      editor.edit(rootView.project.open("something.txt"))
       expect(eventHandler).toHaveBeenCalled()
 
       eventHandler.reset()
@@ -1024,11 +1023,11 @@ describe "Editor", ->
           expect(editor.renderedLines.find('.line:eq(5)').text()).toBe "    while(items.length > 0) {"
           expect(editor.bufferPositionForScreenPosition(editor.getCursorScreenPosition())).toEqual [3, 60]
 
-        it "wraps the lines of any newly assigned buffers", ->
-          otherEditSession = project.open()
+        it "does not wrap the lines of any newly assigned buffers", ->
+          otherEditSession = rootView.project.open()
           otherEditSession.buffer.setText([1..100].join(''))
           editor.edit(otherEditSession)
-          expect(editor.renderedLines.find('.line').length).toBeGreaterThan(1)
+          expect(editor.renderedLines.find('.line').length).toBe(1)
 
         it "unwraps lines and cancels window resize listener when softwrap is disabled", ->
           editor.toggleSoftWrap()
@@ -1061,7 +1060,7 @@ describe "Editor", ->
           expect(editor.getCursorScreenPosition()).toEqual [11, 0]
 
         it "calls .setSoftWrapColumn() when the editor is attached because now its dimensions are available to calculate it", ->
-          otherEditor = new Editor(editSession: project.open('sample.js'))
+          otherEditor = new Editor(editSession: rootView.project.open('sample.js'))
           spyOn(otherEditor, 'setSoftWrapColumn')
 
           otherEditor.setSoftWrap(true)
@@ -1321,8 +1320,9 @@ describe "Editor", ->
 
     describe "when autoscrolling at the end of the document", ->
       it "renders lines properly", ->
-        editor.edit(project.open('fixtures/two-hundred.txt'))
+        editor.edit(rootView.project.open('two-hundred.txt'))
         editor.attachToDom(heightInLines: 5.5)
+
         expect(editor.renderedLines.find('.line').length).toBe 8
 
         editor.moveCursorToBottom()
@@ -1486,7 +1486,7 @@ describe "Editor", ->
 
   describe "folding", ->
     beforeEach ->
-      editSession = project.open('two-hundred.txt')
+      editSession = rootView.project.open('two-hundred.txt')
       buffer = editSession.buffer
       editor.edit(editSession)
       editor.attachToDom()

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -9,11 +9,11 @@ _ = require 'underscore'
 fs = require 'fs'
 
 describe "Editor", ->
-  [rootView, buffer, editor, cachedLineHeight] = []
+  [rootView, project, buffer, editor, cachedLineHeight] = []
 
   getLineHeight = ->
     return cachedLineHeight if cachedLineHeight?
-    editorForMeasurement = new Editor()
+    editorForMeasurement = new Editor(editSession: project.open('sample.js'))
     editorForMeasurement.attachToDom()
     cachedLineHeight = editorForMeasurement.lineHeight
     editorForMeasurement.remove()
@@ -39,13 +39,8 @@ describe "Editor", ->
     editor.remove()
 
   describe "construction", ->
-    it "assigns an empty buffer and correctly handles text input (regression coverage)", ->
-      editor = new Editor
-      editor.attachToDom()
-      expect(editor.buffer.getPath()).toBeUndefined()
-      expect(editor.renderedLines.find('.line').length).toBe 1
-      editor.insertText('x')
-      expect(editor.renderedLines.find('.line').length).toBe 1
+    it "throws an error if no editor session is given", ->
+      expect(-> new Editor).toThrow()
 
   describe ".copy()", ->
     it "builds a new editor with the same edit sessions, cursor position, and scroll position as the receiver", ->
@@ -1061,7 +1056,7 @@ describe "Editor", ->
           expect(editor.getCursorScreenPosition()).toEqual [11, 0]
 
         it "calls .setSoftWrapColumn() when the editor is attached because now its dimensions are available to calculate it", ->
-          otherEditor = new Editor()
+          otherEditor = new Editor(editSession: project.open('sample.js'))
           spyOn(otherEditor, 'setSoftWrapColumn')
 
           otherEditor.setSoftWrap(true)

--- a/spec/app/project-spec.coffee
+++ b/spec/app/project-spec.coffee
@@ -14,30 +14,30 @@ describe "Project", ->
       project.on 'new-buffer', newBufferHandler
 
     describe "when given an absolute path that hasn't been opened previously", ->
-      it "returns a new buffer for the given path and emits a 'new-buffer' event", ->
-        buffer = project.open(absolutePath)
-        expect(buffer.path).toBe absolutePath
-        expect(newBufferHandler).toHaveBeenCalledWith buffer
+      it "returns a new edit session for the given path and emits a 'new-buffer' event", ->
+        editSession = project.open(absolutePath)
+        expect(editSession.buffer.path).toBe absolutePath
+        expect(newBufferHandler).toHaveBeenCalledWith editSession.buffer
 
     describe "when given a relative path that hasn't been opened previously", ->
-      it "returns a buffer for the given path (relative to the project root) and emits a 'new-buffer' event", ->
-        buffer = project.open('a')
-        expect(buffer.path).toBe absolutePath
-        expect(newBufferHandler).toHaveBeenCalledWith buffer
+      it "returns a new edit session for the given path (relative to the project root) and emits a 'new-buffer' event", ->
+        editSession = project.open('a')
+        expect(editSession.buffer.path).toBe absolutePath
+        expect(newBufferHandler).toHaveBeenCalledWith editSession.buffer
 
     describe "when passed the path to a buffer that has already been opened", ->
-      it "returns the previously opened buffer", ->
-        buffer = project.open(absolutePath)
+      it "returns a new edit session containing previously opened buffer", ->
+        editSession = project.open(absolutePath)
         newBufferHandler.reset()
-        expect(project.open(absolutePath)).toBe buffer
-        expect(project.open('a')).toBe buffer
+        expect(project.open(absolutePath).buffer).toBe editSession.buffer
+        expect(project.open('a').buffer).toBe editSession.buffer
         expect(newBufferHandler).not.toHaveBeenCalled()
 
     describe "when not passed a path", ->
-      it "returns a new buffer and emits a new-buffer event", ->
-        buffer = project.open()
-        expect(buffer.path).toBeUndefined()
-        expect(newBufferHandler).toHaveBeenCalledWith(buffer)
+      it "returns a new edit session and emits a new-buffer event", ->
+        editSession = project.open()
+        expect(editSession.buffer.getPath()).toBeUndefined()
+        expect(newBufferHandler).toHaveBeenCalledWith(editSession.buffer)
 
   describe ".resolve(path)", ->
     it "returns an absolute path based on the project's root", ->

--- a/spec/app/root-view-spec.coffee
+++ b/spec/app/root-view-spec.coffee
@@ -7,7 +7,6 @@ Editor = require 'editor'
 
 describe "RootView", ->
   rootView = null
-  project = null
   path = null
 
   beforeEach ->
@@ -15,7 +14,6 @@ describe "RootView", ->
     rootView = new RootView(path)
     rootView.enableKeymap()
     rootView.focus()
-    project = rootView.project
 
   describe "initialize(pathToOpen)", ->
     describe "when called with a pathToOpen", ->
@@ -61,14 +59,18 @@ describe "RootView", ->
 
       describe "when the serialized RootView has a project", ->
         beforeEach ->
+          path = require.resolve 'fixtures'
+          rootView = new RootView(path)
+          rootView.open('dir/a')
+
           editor1 = rootView.activeEditor()
           editor2 = editor1.splitRight()
           editor3 = editor2.splitRight()
           editor4 = editor2.splitDown()
-          editor2.setBuffer(new Buffer(require.resolve 'fixtures/dir/b'))
-          editor3.setBuffer(new Buffer(require.resolve 'fixtures/sample.js'))
+          editor2.edit(rootView.project.open('dir/b'))
+          editor3.edit(rootView.project.open('sample.js'))
           editor3.setCursorScreenPosition([2, 3])
-          editor4.setBuffer(new Buffer(require.resolve 'fixtures/sample.txt'))
+          editor4.edit(rootView.project.open('sample.txt'))
           editor4.setCursorScreenPosition([0, 2])
           rootView.attachToDom()
           editor2.focus()
@@ -440,14 +442,14 @@ describe "RootView", ->
       expect(document.title).toBe path
 
       editor2 = rootView.activeEditor().splitLeft()
-      editor2.setBuffer(new Buffer("second.txt"))
+      editor2.edit(rootView.project.open("second.txt"))
       expect(pathChangeHandler).toHaveBeenCalled()
-      expect(document.title).toBe "second.txt"
+      expect(document.title).toBe rootView.project.resolve("second.txt")
 
       pathChangeHandler.reset()
       editor1.buffer.setPath("should-not-be-title.txt")
       expect(pathChangeHandler).not.toHaveBeenCalled()
-      expect(document.title).toBe "second.txt"
+      expect(document.title).toBe rootView.project.resolve("second.txt")
 
     it "creates a project if there isn't one yet and the buffer was previously unsaved", ->
       rootView = new RootView
@@ -475,7 +477,7 @@ describe "RootView", ->
       rootView.focus()
       expect(pathChangeHandler).not.toHaveBeenCalled()
 
-      editor2.setBuffer editor1.buffer
+      editor2.edit(editor1.activeEditSession)
       editor2.focus()
       expect(pathChangeHandler).not.toHaveBeenCalled()
 

--- a/spec/extensions/autocomplete-spec.coffee
+++ b/spec/extensions/autocomplete-spec.coffee
@@ -345,13 +345,13 @@ describe "Autocomplete", ->
         autocomplete.attach()
         expect(autocomplete.buildWordList).not.toHaveBeenCalled()
 
-  describe "when a new buffer is assigned on editor", ->
+  describe "when a new edit session is assigned on editor", ->
     it 'creates and uses a new word list based on new buffer', ->
       wordList = autocomplete.wordList
       expect(wordList).toContain "quicksort"
       expect(wordList).not.toContain "Some"
 
-      editor.setBuffer new Buffer(require.resolve('fixtures/sample.txt'))
+      editor.edit(fixturesProject.open('sample.txt'))
 
       wordList = autocomplete.wordList
       expect(wordList).not.toContain "quicksort"
@@ -359,7 +359,7 @@ describe "Autocomplete", ->
 
     it 'stops listening to previous buffers change events', ->
       previousBuffer = editor.buffer
-      editor.setBuffer new Buffer(require.resolve('fixtures/sample.txt'))
+      editor.edit(fixturesProject.open('sample.txt'))
       spyOn(autocomplete, "buildWordList")
 
       previousBuffer.change([[0,0],[0,1]], "sauron")

--- a/spec/extensions/autocomplete-spec.coffee
+++ b/spec/extensions/autocomplete-spec.coffee
@@ -10,8 +10,7 @@ describe "Autocomplete", ->
   miniEditor = null
 
   beforeEach ->
-    editor = new Editor()
-    editor.setBuffer new Buffer(require.resolve('fixtures/sample.js'))
+    editor = new Editor(editSession: fixturesProject.open('sample.js'))
     autocomplete = new Autocomplete(editor)
     miniEditor = autocomplete.miniEditor
 

--- a/spec/extensions/command-interpreter-spec.coffee
+++ b/spec/extensions/command-interpreter-spec.coffee
@@ -1,5 +1,6 @@
 CommandInterpreter = require 'command-interpreter'
 Buffer = require 'buffer'
+EditSession = require 'edit-session'
 Editor = require 'editor'
 
 describe "CommandInterpreter", ->
@@ -7,7 +8,8 @@ describe "CommandInterpreter", ->
 
   beforeEach ->
     buffer = new Buffer(require.resolve 'fixtures/sample.js')
-    editor = new Editor({buffer})
+    editSession = new EditSession({buffer})
+    editor = new Editor({editSessions:[editSession]})
     interpreter = new CommandInterpreter()
 
   describe "addresses", ->

--- a/spec/extensions/command-interpreter-spec.coffee
+++ b/spec/extensions/command-interpreter-spec.coffee
@@ -7,9 +7,9 @@ describe "CommandInterpreter", ->
   [interpreter, editor, buffer] = []
 
   beforeEach ->
-    buffer = new Buffer(require.resolve 'fixtures/sample.js')
-    editSession = new EditSession({buffer})
-    editor = new Editor({editSessions:[editSession]})
+    editSession = fixturesProject.open('sample.js')
+    buffer = editSession.buffer
+    editor = new Editor(editSession: editSession)
     interpreter = new CommandInterpreter()
 
   describe "addresses", ->

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -3,6 +3,7 @@ $ = require 'jquery'
 _ = require 'underscore'
 Keymap = require 'keymap'
 Point = require 'point'
+Project = require 'project'
 Directory = require 'directory'
 require 'window'
 window.showConsole()
@@ -13,6 +14,7 @@ defaultTitle = document.title
 directoriesWithSubscriptions = null
 
 beforeEach ->
+  window.fixturesProject = new Project(require.resolve('fixtures'))
   window.resetTimeouts()
   directoriesWithSubscriptions = []
 

--- a/src/app/buffer.coffee
+++ b/src/app/buffer.coffee
@@ -12,9 +12,6 @@ class Buffer
   lines: null
   path: null
 
-  @deserialize: (state, project) ->
-    project.open(state.path)
-
   constructor: (path) ->
     @id = @constructor.idCounter++
     @setPath(path)
@@ -25,9 +22,6 @@ class Buffer
       @setText('')
     @undoManager = new UndoManager(this)
     @modified = false
-
-  serialize: ->
-    path: @getPath()
 
   getPath: ->
     @path

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -24,11 +24,12 @@ class EditSession
   selections: null
   autoIndent: true
   softTabs: true
+  softWrap: false
 
-  constructor: ({@buffer, @tabText, @autoIndent, @softTabs, @softWrapColumn}) ->
+  constructor: ({@buffer, @tabText, @autoIndent, @softTabs, @softWrap}) ->
     @id = @constructor.idCounter++
     @softTabs ?= true
-    @displayBuffer = new DisplayBuffer(@buffer, { @softWrapColumn, @tabText })
+    @displayBuffer = new DisplayBuffer(@buffer, { @tabText })
     @tokenizedBuffer = @displayBuffer.tokenizedBuffer
     @cursors = []
     @selections = []
@@ -69,6 +70,9 @@ class EditSession
   setSoftWrapColumn: (@softWrapColumn) -> @displayBuffer.setSoftWrapColumn(@softWrapColumn)
   setAutoIndent: (@autoIndent) ->
   setSoftTabs: (@softTabs) ->
+
+  getSoftWrap: -> @softWrap
+  setSoftWrap: (@softWrap) ->
 
   clipBufferPosition: (bufferPosition, options) ->
     { row, column } = Point.fromObject(bufferPosition)

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -446,4 +446,7 @@ class EditSession
           @mergeIntersectingSelections(options)
           return
 
+  inspect: ->
+    JSON.stringify @serialize()
+
 _.extend(EditSession.prototype, EventEmitter)

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -11,13 +11,7 @@ class EditSession
   @idCounter: 1
 
   @deserialize: (state, editor, rootView) ->
-    buffer = Buffer.deserialize(state.buffer, rootView.project)
-    session = new EditSession(
-      buffer: buffer
-      tabText: editor.tabText
-      autoIndent: editor.autoIndent
-      softTabs: editor.softTabs
-    )
+    session = rootView.project.open(state.buffer)
     session.setScrollTop(state.scrollTop)
     session.setScrollLeft(state.scrollLeft)
     session.setCursorScreenPosition(state.cursorScreenPosition)
@@ -54,7 +48,7 @@ class EditSession
     @displayBuffer.destroy()
 
   serialize: ->
-    buffer: @buffer.serialize()
+    buffer: @buffer.getPath()
     scrollTop: @getScrollTop()
     scrollLeft: @getScrollLeft()
     cursorScreenPosition: @getCursorScreenPosition().serialize()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -45,6 +45,7 @@ class Editor extends View
   isFocused: false
   softTabs: true
   tabText: '  '
+  activeEditSession: null
   editSessions: null
   attached: false
   lineOverdraw: 100
@@ -84,8 +85,11 @@ class Editor extends View
 
   serialize: ->
     @saveActiveEditSession()
-    editSessions = @editSessions.map (session) -> session.serialize()
-    { viewClass: "Editor", editSessions, @activeEditSessionIndex, @isFocused }
+
+    viewClass: "Editor"
+    editSessions: @editSessions.map (session) -> session.serialize()
+    activeEditSessionIndex: @getActiveEditSessionIndex()
+    isFocused: @isFocused
 
   copy: ->
     Editor.deserialize(@serialize(), @rootView())
@@ -382,13 +386,16 @@ class Editor extends View
       _.remove(@editSessions, editSession)
 
   loadNextEditSession: ->
-    nextIndex = (@activeEditSessionIndex + 1) % @editSessions.length
+    nextIndex = (@getActiveEditSessionIndex() + 1) % @editSessions.length
     @setActiveEditSessionIndex(nextIndex)
 
   loadPreviousEditSession: ->
-    previousIndex = @activeEditSessionIndex - 1
+    previousIndex = @getActiveEditSessionIndex() - 1
     previousIndex = @editSessions.length - 1 if previousIndex < 0
     @setActiveEditSessionIndex(previousIndex)
+
+  getActiveEditSessionIndex: ->
+    return index for session, index in @editSessions when session == @activeEditSession
 
   setActiveEditSessionIndex: (index) ->
     throw new Error("Edit session not found") unless @editSessions[index]
@@ -398,7 +405,6 @@ class Editor extends View
       @activeEditSession.off()
 
     @activeEditSession = @editSessions[index]
-    @activeEditSessionIndex = index
 
     @unsubscribeFromBuffer() if @buffer
     @buffer = @activeEditSession.buffer

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -72,7 +72,8 @@ class Editor extends View
     @editSessions = []
 
     if editSession?
-      @setActiveEditSession(editSession)
+      @editSessions.push editSession
+      @setActiveEditSessionIndex(0)
     else if @mini
       editSession = new EditSession
         softWrapColumn: @calcSoftWrapColumn()
@@ -81,7 +82,8 @@ class Editor extends View
         autoIndent: @autoIndent
         softTabs: @softTabs
 
-      @setActiveEditSession(editSession)
+      @editSessions.push editSession
+      @setActiveEditSessionIndex(0)
     else
       throw new Error("Editor initialization requires an editSession")
 
@@ -348,36 +350,14 @@ class Editor extends View
 
     @trigger 'editor-open', [this]
 
-  setBuffer: (buffer) ->
-    @activateEditSessionForBuffer(buffer)
+  edit: (editSession) ->
+    index = @editSessions.indexOf(editSession)
 
-  setActiveEditSession: (editSession) ->
-    index = @editSessionIndexForBuffer(editSession.buffer)
-
-    unless index?
+    if index == -1
       index = @editSessions.length
       @editSessions.push(editSession)
 
     @setActiveEditSessionIndex(index)
-
-  activateEditSessionForBuffer: (buffer) ->
-    index = @editSessionIndexForBuffer(buffer)
-    unless index?
-      index = @editSessions.length
-      @editSessions.push(new EditSession(
-        softWrapColumn: @calcSoftWrapColumn()
-        buffer: buffer
-        tabText: @tabText
-        autoIndent: @autoIndent
-        softTabs: @softTabs
-      ))
-
-    @setActiveEditSessionIndex(index)
-
-  editSessionIndexForBuffer: (buffer) ->
-    for editSession, index in @editSessions
-      return index if editSession.buffer == buffer
-    null
 
   removeActiveEditSession: ->
     if @editSessions.length == 1
@@ -411,6 +391,7 @@ class Editor extends View
     @unsubscribeFromBuffer() if @buffer
     @buffer = @activeEditSession.buffer
     @buffer.on "path-change.editor#{@id}", => @trigger 'editor-path-change'
+
     @trigger 'editor-path-change'
 
     @renderWhenAttached()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -40,11 +40,8 @@ class Editor extends View
   cursorViews: null
   selectionViews: null
   buffer: null
-  autoIndent: true
   lineCache: null
   isFocused: false
-  softTabs: true
-  tabText: '  '
   activeEditSession: null
   editSessions: null
   attached: false
@@ -76,11 +73,11 @@ class Editor extends View
       @setActiveEditSessionIndex(0)
     else if @mini
       editSession = new EditSession
-        softWrapColumn: @calcSoftWrapColumn()
         buffer: new Buffer()
-        tabText: @tabText
-        autoIndent: @autoIndent
-        softTabs: @softTabs
+        softWrapColumn: null
+        tabText: "  "
+        autoIndent: false
+        softTabs: true
 
       @editSessions.push editSession
       @setActiveEditSessionIndex(0)
@@ -233,15 +230,13 @@ class Editor extends View
   isFoldedAtScreenRow: (screenRow) -> @activeEditSession.isFoldedAtScreenRow(screenRow)
   unfoldCurrentRow: -> @activeEditSession.unfoldCurrentRow()
 
-  setAutoIndent: (@autoIndent) -> @activeEditSession.setAutoIndent(@autoIndent)
-  setSoftTabs: (@softTabs) -> @activeEditSession.setSoftTabs(@softTabs)
+  lineForScreenRow: (screenRow) -> @activeEditSession.lineForScreenRow(screenRow)
+  linesForScreenRows: (start, end) -> @activeEditSession.linesForScreenRows(start, end)
+  screenLineCount: -> @activeEditSession.screenLineCount()
   setSoftWrapColumn: (softWrapColumn) ->
     softWrapColumn ?= @calcSoftWrapColumn()
     @activeEditSession.setSoftWrapColumn(softWrapColumn) if softWrapColumn
 
-  lineForScreenRow: (screenRow) -> @activeEditSession.lineForScreenRow(screenRow)
-  linesForScreenRows: (start, end) -> @activeEditSession.linesForScreenRows(start, end)
-  screenLineCount: -> @activeEditSession.screenLineCount()
   maxScreenLineLength: -> @activeEditSession.maxScreenLineLength()
   getLastScreenRow: -> @activeEditSession.getLastScreenRow()
   clipScreenPosition: (screenPosition, options={}) -> @activeEditSession.clipScreenPosition(screenPosition, options)

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -52,11 +52,11 @@ class Editor extends View
   @deserialize: (state, rootView) ->
     editSessions = state.editSessions.map (state) -> EditSession.deserialize(state, editor, rootView)
 
-    editor = new Editor(activeEditSessionIndex: state.activeEditSessionIndex, editSessions: editSessions, suppressBufferCreation: true, mini: state.mini)
+    editor = new Editor(activeEditSessionIndex: state.activeEditSessionIndex, editSessions: editSessions, mini: state.mini)
     editor.isFocused = state.isFocused
     editor
 
-  initialize: ({activeEditSessionIndex, editSessions, suppressBufferCreation, @mini} = {}) ->
+  initialize: ({activeEditSessionIndex, editSessions,  @mini} = {}) ->
     requireStylesheet 'editor.css'
     requireStylesheet 'theme/twilight.css'
 
@@ -72,7 +72,7 @@ class Editor extends View
       @setActiveEditSessionIndex(activeEditSessionIndex)
     else if @editSessions.length > 0
       @setActiveEditSessionIndex(0)
-    else if !suppressBufferCreation
+    else
       editSession = new EditSession
         softWrapColumn: @calcSoftWrapColumn()
         buffer: new Buffer()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -53,11 +53,13 @@ class Editor extends View
   @deserialize: (state, rootView) ->
     editSessions = state.editSessions.map (state) -> EditSession.deserialize(state, editor, rootView)
 
-    editor = new Editor(activeEditSessionIndex: state.activeEditSessionIndex, editSessions: editSessions, mini: state.mini)
+    editSession = editSessions[state.activeEditSessionIndex]
+    editor = new Editor(editSession: editSession, mini: state.mini)
+    editor.editSession = editSessions
     editor.isFocused = state.isFocused
     editor
 
-  initialize: ({activeEditSessionIndex, editSessions,  @mini} = {}) ->
+  initialize: ({editSession, @mini} = {}) ->
     requireStylesheet 'editor.css'
     requireStylesheet 'theme/twilight.css'
 
@@ -67,13 +69,11 @@ class Editor extends View
     @handleEvents()
     @cursorViews = []
     @selectionViews = []
-    @editSessions = editSessions ? []
+    @editSessions = []
 
-    if activeEditSessionIndex?
-      @setActiveEditSessionIndex(activeEditSessionIndex)
-    else if @editSessions.length > 0
-      @setActiveEditSessionIndex(0)
-    else
+    if editSession?
+      @setActiveEditSession(editSession)
+    else if @mini
       editSession = new EditSession
         softWrapColumn: @calcSoftWrapColumn()
         buffer: new Buffer()
@@ -82,6 +82,8 @@ class Editor extends View
         softTabs: @softTabs
 
       @setActiveEditSession(editSession)
+    else
+      throw new Error("Editor initialization requires an editSession")
 
   serialize: ->
     @saveActiveEditSession()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -33,7 +33,6 @@ class Editor extends View
 
   vScrollMargin: 2
   hScrollMargin: 10
-  softWrap: false
   lineHeight: null
   charWidth: null
   charHeight: null
@@ -74,7 +73,7 @@ class Editor extends View
     else if @mini
       editSession = new EditSession
         buffer: new Buffer()
-        softWrapColumn: null
+        softWrap: false
         tabText: "  "
         autoIndent: false
         softTabs: true
@@ -337,7 +336,7 @@ class Editor extends View
     @subscribeToFontSize()
     @calculateDimensions()
     @hiddenInput.width(@charWidth)
-    @setSoftWrapColumn() if @softWrap
+    @setSoftWrapColumn() if @activeEditSession.getSoftWrap()
     $(window).on "resize.editor#{@id}", => @updateRenderedLines()
     @focus() if @isFocused
 
@@ -436,7 +435,7 @@ class Editor extends View
       @scrollTop(desiredTop)
 
   scrollHorizontally: (pixelPosition) ->
-    return if @softWrap
+    return if @activeEditSession.getSoftWrap()
 
     charsInView = @scrollView.width() / @charWidth
     maxScrollMargin = Math.floor((charsInView - 1) / 2)
@@ -471,17 +470,18 @@ class Editor extends View
     @activeEditSession.setScrollLeft(@scrollView.scrollLeft())
 
   toggleSoftWrap: ->
-    @setSoftWrap(not @softWrap)
+    @setSoftWrap(not @activeEditSession.getSoftWrap())
 
   calcSoftWrapColumn: ->
-    if @softWrap
+    if @activeEditSession.getSoftWrap()
       Math.floor(@scrollView.width() / @charWidth)
     else
       Infinity
 
-  setSoftWrap: (@softWrap, softWrapColumn=undefined) ->
+  setSoftWrap: (softWrap, softWrapColumn=undefined) ->
+    @activeEditSession.setSoftWrap(softWrap)
     @setSoftWrapColumn(softWrapColumn) if @attached
-    if @softWrap
+    if @activeEditSession.getSoftWrap()
       @addClass 'soft-wrap'
       @_setSoftWrapColumn = => @setSoftWrapColumn()
       $(window).on 'resize', @_setSoftWrapColumn

--- a/src/app/project.coffee
+++ b/src/app/project.coffee
@@ -11,10 +11,18 @@ module.exports =
 class Project
   rootDirectory: null
   editSessions: null
+  tabText: null
+  autoIndent: null
+  softTabs: null
+  softWrapColumn: null
 
   constructor: (path) ->
     @setPath(path)
     @editSessions = []
+
+    @setTabText('  ')
+    @setAutoIndent(true)
+    @setSoftTabs(true)
 
   getPath: ->
     @rootDirectory?.path
@@ -56,6 +64,18 @@ class Project
   relativize: (fullPath) ->
     fullPath.replace(@getPath(), "").replace(/^\//, '')
 
+  getTabText: -> @tabText
+  setTabText: (@tabText) ->
+
+  getAutoIndent: -> @autoIndent
+  setAutoIndent: (@autoIndent) ->
+
+  getSoftTabs: -> @softTabs
+  setSoftTabs: (@softTabs) ->
+
+  getSoftWrapColumn: -> @softWrapColumn
+  setSoftWrapColumn: (@softWrapColumn) ->
+
   open: (filePath) ->
     if filePath?
       filePath = @resolve(filePath)
@@ -63,7 +83,13 @@ class Project
     else
       buffer = @buildBuffer()
 
-    editSession = new EditSession({buffer, tabText: "  ", autoIndent: true, softTabs: true, softWrapColumn: null})
+    editSession = new EditSession
+      buffer: buffer
+      tabText: @getTabText()
+      autoIndent: @getAutoIndent()
+      softTabs: @getSoftTabs()
+      softWrapColumn: @getSoftWrapColumn()
+
     @editSessions.push editSession
     editSession
 

--- a/src/app/project.coffee
+++ b/src/app/project.coffee
@@ -14,12 +14,11 @@ class Project
   tabText: null
   autoIndent: null
   softTabs: null
-  softWrapColumn: null
+  softWrap: null
 
   constructor: (path) ->
     @setPath(path)
     @editSessions = []
-
     @setTabText('  ')
     @setAutoIndent(true)
     @setSoftTabs(true)
@@ -73,8 +72,8 @@ class Project
   getSoftTabs: -> @softTabs
   setSoftTabs: (@softTabs) ->
 
-  getSoftWrapColumn: -> @softWrapColumn
-  setSoftWrapColumn: (@softWrapColumn) ->
+  getSoftWrap: -> @softWrap
+  setSoftWrap: (@softWrap) ->
 
   open: (filePath) ->
     if filePath?
@@ -88,7 +87,7 @@ class Project
       tabText: @getTabText()
       autoIndent: @getAutoIndent()
       softTabs: @getSoftTabs()
-      softWrapColumn: @getSoftWrapColumn()
+      softWrap: @getSoftWrap()
 
     @editSessions.push editSession
     editSession

--- a/src/app/root-view.coffee
+++ b/src/app/root-view.coffee
@@ -91,12 +91,12 @@ class RootView extends View
     @remove()
 
   open: (path, changeFocus=true) ->
-    buffer = @project.open(path)
+    editSession = @project.open(path)
 
     if @activeEditor()
-      @activeEditor().setBuffer(buffer)
+      @activeEditor().setActiveEditSession(editSession)
     else
-      editor = new Editor({ buffer })
+      editor = new Editor(editSessions: [editSession])
       pane = new Pane(editor)
       @panes.append(pane)
       if changeFocus

--- a/src/app/root-view.coffee
+++ b/src/app/root-view.coffee
@@ -96,7 +96,7 @@ class RootView extends View
     if @activeEditor()
       @activeEditor().setActiveEditSession(editSession)
     else
-      editor = new Editor(editSessions: [editSession])
+      editor = new Editor(editSession: editSession)
       pane = new Pane(editor)
       @panes.append(pane)
       if changeFocus

--- a/src/app/root-view.coffee
+++ b/src/app/root-view.coffee
@@ -94,7 +94,7 @@ class RootView extends View
     editSession = @project.open(path)
 
     if @activeEditor()
-      @activeEditor().setActiveEditSession(editSession)
+      @activeEditor().edit(editSession)
     else
       editor = new Editor(editSession: editSession)
       pane = new Pane(editor)

--- a/src/extensions/strip-trailing-whitespace.coffee
+++ b/src/extensions/strip-trailing-whitespace.coffee
@@ -1,6 +1,6 @@
 module.exports =
   activate: (rootView) ->
-    for buffer in rootView.project.buffers
+    for buffer in rootView.project.getBuffers()
       @stripTrailingWhitespaceBeforeSave(buffer)
 
     rootView.project.on 'new-buffer', (buffer) =>


### PR DESCRIPTION
I moved all settings (tabText, softWrap, autoIndent...) to the Project class. I think most settings will be set on a per-project basis, but you can still override project settings by directly changing properties on an edit session.

I also changed Project.open to return an EditSession instead of a Buffer. Because Project.open is the only way a EditSession should be created in Atom, a project now has access to all edit sessions and buffers open in the window.

I still need to do a run through of the specs again and make sure have good coverage.
