### PR TITLE
Improve undo manager

### DIFF
--- a/.atom/atom.coffee
+++ b/.atom/atom.coffee
@@ -1,0 +1,10 @@
+requireExtension 'autocomplete'
+requireExtension 'strip-trailing-whitespace'
+requireExtension 'fuzzy-finder'
+requireExtension 'tree-view'
+requireExtension 'command-panel'
+requireExtension 'keybindings-view'
+requireExtension 'snippets'
+
+# status-bar is a bit broken until webkit gets a decent flexbox implementation
+# requireExtension 'status-bar'

--- a/.atom/snippets/coffee.snippets
+++ b/.atom/snippets/coffee.snippets
@@ -1,0 +1,34 @@
+snippet de "Describe block"
+describe "${1:description}", ->
+  ${2:body}
+endsnippet
+
+snippet i "It block"
+it "$1", ->
+  $2
+endsnippet
+
+snippet be "Before each"
+beforeEach ->
+  $1
+endsnippet
+
+snippet ex "Expectation"
+expect($1).to$2
+endsnippet
+
+snippet log "Console log"
+console.log $1
+endsnippet
+
+snippet ra "Range array"
+[[$1, $2], [$3, $4]]
+endsnippet
+
+snippet pt "Point array"
+[$1, $2]
+endsnippet
+
+snippet spy "Jasmine spy"
+jasmine.createSpy("${1:description}")$2
+endsnippet

--- a/Atom/src/AtomController.mm
+++ b/Atom/src/AtomController.mm
@@ -118,11 +118,13 @@
     CefRefPtr<CefV8Value> retval;
     CefRefPtr<CefV8Exception> exception;
     CefV8ValueList arguments;
+
     global->GetValue("reload")->ExecuteFunction(global, arguments, retval, exception, true);
-    if (exception) _clientHandler->GetBrowser()->ReloadIgnoreCache();
+    if (exception.get()) {
+      _clientHandler->GetBrowser()->ReloadIgnoreCache();
+    }
     context->Exit();
     
-
     return YES;
   }
   

--- a/spec/app/buffer-spec.coffee
+++ b/spec/app/buffer-spec.coffee
@@ -220,6 +220,11 @@ describe 'Buffer', ->
         expect(event.oldText).toBe oldText
         expect(event.newText).toBe "foo\nbar"
 
+    it "allows a 'change' event handler to safely undo the change", ->
+      buffer.on 'change', -> buffer.undo()
+      buffer.change([0, 0], "hello")
+      expect(buffer.lineForRow(0)).toBe "var quicksort = function () {"
+
   describe ".setText(text)", ->
     it "changes the entire contents of the buffer and emits a change event", ->
       lastRow = buffer.getLastRow()

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -6,18 +6,16 @@ describe "EditSession", ->
   [buffer, editSession, lineLengths] = []
 
   beforeEach ->
-    buffer = new Buffer(require.resolve('fixtures/sample.js'))
-    editSession = new EditSession
-      buffer: buffer
-      tabText: '  '
-      autoIndent: false
-      softWrap: false
-      project: new Project()
+    buffer = new Buffer()
+    editSession = fixturesProject.open('sample.js', autoIndent: false)
 
+    console.log editSession.tabText
+
+    buffer = editSession.buffer
     lineLengths = buffer.getLines().map (line) -> line.length
 
   afterEach ->
-    buffer.destroy()
+    fixturesProject.destroy()
 
   describe "cursor movement", ->
     describe ".setCursorScreenPosition(screenPosition)", ->
@@ -1262,6 +1260,16 @@ describe "EditSession", ->
         editSession.redo()
         expect(selections[0].getBufferRange()).toEqual [[1, 6], [1, 6]]
         expect(selections[1].getBufferRange()).toEqual [[1, 18], [1, 18]]
+
+      it "restores selected ranges even when the change occurred in another edit session", ->
+        otherEditSession = fixturesProject.open(editSession.getPath())
+        otherEditSession.setSelectedBufferRange([[2, 2], [3, 3]])
+        otherEditSession.delete()
+
+        editSession.undo()
+
+        expect(editSession.getSelectedBufferRange()).toEqual [[2, 2], [3, 3]]
+        expect(otherEditSession.getSelectedBufferRange()).toEqual [[3, 3], [3, 3]]
 
     describe "when the buffer is changed (via its direct api, rather than via than edit session)", ->
       it "moves the cursor so it is in the same relative position of the buffer", ->

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -8,9 +8,6 @@ describe "EditSession", ->
   beforeEach ->
     buffer = new Buffer()
     editSession = fixturesProject.open('sample.js', autoIndent: false)
-
-    console.log editSession.tabText
-
     buffer = editSession.buffer
     lineLengths = buffer.getLines().map (line) -> line.length
 

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -120,8 +120,8 @@ describe "Editor", ->
       expect(otherEditSession.buffer.subscriptionCount()).toBeGreaterThan 1
 
       editor.remove()
-      expect(previousEditSession.buffer.subscriptionCount()).toBe 1
-      expect(otherEditSession.buffer.subscriptionCount()).toBe 1
+      expect(previousEditSession.buffer.subscriptionCount()).toBe 0
+      expect(otherEditSession.buffer.subscriptionCount()).toBe 0
 
   describe "when 'close' is triggered", ->
     it "closes active edit session and loads next edit session", ->

--- a/spec/app/undo-manager-spec.coffee
+++ b/spec/app/undo-manager-spec.coffee
@@ -7,7 +7,7 @@ describe "UndoManager", ->
 
   beforeEach ->
     buffer = new Buffer(require.resolve('fixtures/sample.js'))
-    undoManager = new UndoManager(buffer)
+    undoManager = buffer.undoManager
 
   afterEach ->
     buffer.destroy()

--- a/spec/app/undo-manager-spec.coffee
+++ b/spec/app/undo-manager-spec.coffee
@@ -63,49 +63,37 @@ describe "UndoManager", ->
       undoManager.redo()
       expect(buffer.getText()).toContain 'qsport'
 
-  describe "startUndoBatch() / endUndoBatch()", ->
-    it "causes changes in batch to be undone simultaneously and returns an array of ranges to select from undo and redo", ->
+  describe "transact(fn)", ->
+    it "causes changes in the transaction to be undone simultaneously", ->
       buffer.insert([0, 0], "foo")
 
-      ignoredRanges = [[[666, 666], [666, 666]], [[666, 666], [666, 666]]]
-      beforeRanges = [[[1, 2], [1, 2]], [[1, 9], [1, 9]]]
-      afterRanges =[[[1, 5], [1, 5]], [[1, 12], [1, 12]]]
-
-      undoManager.startUndoBatch(beforeRanges)
-      undoManager.startUndoBatch(ignoredRanges) # calls can be nested
-      buffer.insert([1, 2], "111")
-      buffer.insert([1, 9], "222")
-      undoManager.endUndoBatch(ignoredRanges) # calls can be nested
-      undoManager.endUndoBatch(afterRanges)
+      undoManager.transact ->
+        undoManager.transact ->
+          buffer.insert([1, 2], "111")
+          buffer.insert([1, 9], "222")
 
       expect(buffer.lineForRow(1)).toBe '  111var 222sort = function(items) {'
 
-      ranges = undoManager.undo()
-      expect(ranges).toBe beforeRanges
+      undoManager.undo()
       expect(buffer.lineForRow(1)).toBe '  var sort = function(items) {'
       expect(buffer.lineForRow(0)).toContain 'foo'
 
-      ranges = undoManager.undo()
-      expect(ranges).toBeUndefined()
+      undoManager.undo()
 
       expect(buffer.lineForRow(0)).not.toContain 'foo'
 
-      ranges = undoManager.redo()
-      expect(ranges).toBeUndefined()
+      undoManager.redo()
       expect(buffer.lineForRow(0)).toContain 'foo'
 
-      ranges = undoManager.redo()
-      expect(ranges).toBe afterRanges
+      undoManager.redo()
       expect(buffer.lineForRow(1)).toBe '  111var 222sort = function(items) {'
 
-      ranges = undoManager.undo()
-      expect(ranges).toBe beforeRanges
+      undoManager.undo()
       expect(buffer.lineForRow(1)).toBe '  var sort = function(items) {'
 
-    it "does not store empty batches", ->
+    it "does not record empty transactions", ->
       buffer.insert([0,0], "foo")
-      undoManager.startUndoBatch()
-      undoManager.endUndoBatch()
+      undoManager.transact ->
 
       undoManager.undo()
       expect(buffer.lineForRow(0)).not.toContain("foo")

--- a/spec/app/window-spec.coffee
+++ b/spec/app/window-spec.coffee
@@ -61,4 +61,4 @@ describe "Window", ->
 
       $(window).trigger 'beforeunload'
 
-      expect(editor1.getBuffer().subscriptionCount()).toBe 1 # buffer has a self-subscription for the undo manager
+      expect(editor1.getBuffer().subscriptionCount()).toBe 0

--- a/spec/extensions/snippets-spec.coffee
+++ b/spec/extensions/snippets-spec.coffee
@@ -150,7 +150,7 @@ describe "Snippets extension", ->
         expect(editor.getCursorScreenPosition()).toEqual [0, 5]
 
     describe "when a previous snippet expansion has just been undone", ->
-      fit "expands the snippet based on the current prefix rather than jumping to the old snippet's tab stop", ->
+      xit "expands the snippet based on the current prefix rather than jumping to the old snippet's tab stop", ->
         editor.insertText 't5\n'
         editor.setCursorBufferPosition [0, 2]
         editor.trigger keydownEvent('tab', target: editor[0])

--- a/spec/extensions/snippets-spec.coffee
+++ b/spec/extensions/snippets-spec.coffee
@@ -160,6 +160,19 @@ describe "Snippets extension", ->
         editor.trigger keydownEvent('tab', target: editor[0])
         expect(buffer.lineForRow(0)).toBe "first line"
 
+    describe "when a snippet expansion is undone and redone", ->
+      it "recreates the snippet's tab stops", ->
+        editor.insertText '    t5\n'
+        editor.setCursorBufferPosition [0, 6]
+        editor.trigger keydownEvent('tab', target: editor[0])
+        expect(buffer.lineForRow(0)).toBe "    first line"
+        editor.undo()
+        editor.redo()
+
+        expect(editor.getCursorBufferPosition()).toEqual [0, 14]
+        editor.trigger keydownEvent('tab', target: editor[0])
+        expect(editor.getSelectedBufferRange()).toEqual [[1, 6], [1, 36]]
+
   describe ".loadSnippetsFile(path)", ->
     it "loads the snippets in the given file", ->
       spyOn(fs, 'read').andReturn """

--- a/spec/extensions/snippets-spec.coffee
+++ b/spec/extensions/snippets-spec.coffee
@@ -41,6 +41,11 @@ describe "Snippets extension", ->
         go here ${1:first} and then here ${2:second}
 
         endsnippet
+
+        snippet t5 "Caused problems with undo"
+        first line $1
+          ${2:placeholder ending second line}
+        endsnippet
       """
 
     describe "when the letters preceding the cursor trigger a snippet", ->
@@ -143,6 +148,18 @@ describe "Snippets extension", ->
         editor.trigger 'tab'
         expect(buffer.lineForRow(0)).toBe "xte  var quicksort = function () {"
         expect(editor.getCursorScreenPosition()).toEqual [0, 5]
+
+    describe "when a previous snippet expansion has just been undone", ->
+      fit "expands the snippet based on the current prefix rather than jumping to the old snippet's tab stop", ->
+        editor.insertText 't5\n'
+        editor.setCursorBufferPosition [0, 2]
+        editor.trigger keydownEvent('tab', target: editor[0])
+        expect(buffer.lineForRow(0)).toBe "first line"
+        editor.undo()
+        editor.undo()
+        expect(buffer.lineForRow(0)).toBe "t5"
+        editor.trigger keydownEvent('tab', target: editor[0])
+        expect(buffer.lineForRow(0)).toBe "first line"
 
   describe ".loadSnippetsFile(path)", ->
     it "loads the snippets in the given file", ->

--- a/spec/extensions/snippets-spec.coffee
+++ b/spec/extensions/snippets-spec.coffee
@@ -173,6 +173,20 @@ describe "Snippets extension", ->
         editor.trigger keydownEvent('tab', target: editor[0])
         expect(editor.getSelectedBufferRange()).toEqual [[1, 6], [1, 36]]
 
+      it "restores tabs stops in active edit session even when the initial expansion was in a different edit session", ->
+        anotherEditor = editor.splitRight()
+
+        editor.insertText '    t5\n'
+        editor.setCursorBufferPosition [0, 6]
+        editor.trigger keydownEvent('tab', target: editor[0])
+        expect(buffer.lineForRow(0)).toBe "    first line"
+        editor.undo()
+
+        anotherEditor.redo()
+        expect(anotherEditor.getCursorBufferPosition()).toEqual [0, 14]
+        anotherEditor.trigger keydownEvent('tab', target: anotherEditor[0])
+        expect(anotherEditor.getSelectedBufferRange()).toEqual [[1, 6], [1, 36]]
+
   describe ".loadSnippetsFile(path)", ->
     it "loads the snippets in the given file", ->
       spyOn(fs, 'read').andReturn """

--- a/spec/extensions/snippets-spec.coffee
+++ b/spec/extensions/snippets-spec.coffee
@@ -43,7 +43,7 @@ describe "Snippets extension", ->
         endsnippet
 
         snippet t5 "Caused problems with undo"
-        first line $1
+        first line$1
           ${2:placeholder ending second line}
         endsnippet
       """
@@ -150,12 +150,11 @@ describe "Snippets extension", ->
         expect(editor.getCursorScreenPosition()).toEqual [0, 5]
 
     describe "when a previous snippet expansion has just been undone", ->
-      xit "expands the snippet based on the current prefix rather than jumping to the old snippet's tab stop", ->
+      it "expands the snippet based on the current prefix rather than jumping to the old snippet's tab stop", ->
         editor.insertText 't5\n'
         editor.setCursorBufferPosition [0, 2]
         editor.trigger keydownEvent('tab', target: editor[0])
         expect(buffer.lineForRow(0)).toBe "first line"
-        editor.undo()
         editor.undo()
         expect(buffer.lineForRow(0)).toBe "t5"
         editor.trigger keydownEvent('tab', target: editor[0])

--- a/src/app/buffer-change-operation.coffee
+++ b/src/app/buffer-change-operation.coffee
@@ -1,0 +1,53 @@
+Range = require 'range'
+
+module.exports =
+class BufferChangeOperation
+  buffer: null
+  oldRange: null
+  oldText: null
+  newRange: null
+  newText: null
+
+  constructor: ({@buffer, @oldRange, @newText}) ->
+
+  do: ->
+    @oldText = @buffer.getTextInRange(@oldRange)
+    @newRange = @calculateNewRange(@oldRange, @newText)
+    @changeBuffer
+      oldRange: @oldRange
+      newRange: @newRange
+      oldText: @oldText
+      newText: @newText
+
+  undo: ->
+    @changeBuffer
+      oldRange: @newRange
+      newRange: @oldRange
+      oldText: @newText
+      newText: @oldText
+
+  changeBuffer: ({ oldRange, newRange, newText, oldText }) ->
+    { prefix, suffix } = @buffer.prefixAndSuffixForRange(oldRange)
+
+    newTextLines = newText.split('\n')
+    if newTextLines.length == 1
+      newTextLines = [prefix + newText + suffix]
+    else
+      lastLineIndex = newTextLines.length - 1
+      newTextLines[0] = prefix + newTextLines[0]
+      newTextLines[lastLineIndex] += suffix
+
+    @buffer.replaceLines(oldRange.start.row, oldRange.end.row, newTextLines)
+    @buffer.trigger 'change', { oldRange, newRange, oldText, newText }
+    newRange
+
+  calculateNewRange: (oldRange, newText) ->
+    newRange = new Range(oldRange.start.copy(), oldRange.start.copy())
+    newTextLines = newText.split('\n')
+    if newTextLines.length == 1
+      newRange.end.column += newText.length
+    else
+      lastLineIndex = newTextLines.length - 1
+      newRange.end.row += lastLineIndex
+      newRange.end.column = newTextLines[lastLineIndex].length
+    newRange

--- a/src/app/buffer.coffee
+++ b/src/app/buffer.coffee
@@ -142,9 +142,9 @@ class Buffer
     @lines[startRow..endRow] = newLines
     @modified = true
 
-  pushOperation: (operation) ->
+  pushOperation: (operation, editSession) ->
     if @undoManager
-      @undoManager.pushOperation(operation)
+      @undoManager.pushOperation(operation, editSession)
     else
       operation.do()
 

--- a/src/app/buffer.coffee
+++ b/src/app/buffer.coffee
@@ -9,6 +9,7 @@ UndoManager = require 'undo-manager'
 module.exports =
 class Buffer
   @idCounter = 1
+  undoManager: null
   modified: null
   lines: null
   file: null

--- a/src/app/buffer.coffee
+++ b/src/app/buffer.coffee
@@ -132,10 +132,7 @@ class Buffer
   change: (oldRange, newText) ->
     oldRange = Range.fromObject(oldRange)
     operation = new BufferChangeOperation({buffer: this, oldRange, newText})
-    if @undoManager
-      @undoManager.pushOperation(operation)
-    else
-      operation.do()
+    @pushOperation(operation)
 
   prefixAndSuffixForRange: (range) ->
     prefix: @lines[range.start.row][0...range.start.column]
@@ -145,11 +142,14 @@ class Buffer
     @lines[startRow..endRow] = newLines
     @modified = true
 
-  startUndoBatch: (selectedBufferRanges) ->
-    @undoManager.startUndoBatch(selectedBufferRanges)
+  pushOperation: (operation) ->
+    if @undoManager
+      @undoManager.pushOperation(operation)
+    else
+      operation.do()
 
-  endUndoBatch: (selectedBufferRanges) ->
-    @undoManager.endUndoBatch(selectedBufferRanges)
+  transact: (fn) ->
+    @undoManager.transact(fn)
 
   undo: ->
     @undoManager.undo()

--- a/src/app/buffer.coffee
+++ b/src/app/buffer.coffee
@@ -151,11 +151,11 @@ class Buffer
   transact: (fn) ->
     @undoManager.transact(fn)
 
-  undo: ->
-    @undoManager.undo()
+  undo: (editSession) ->
+    @undoManager.undo(editSession)
 
-  redo: ->
-    @undoManager.redo()
+  redo: (editSession) ->
+    @undoManager.redo(editSession)
 
   save: ->
     @saveAs(@getPath())

--- a/src/app/buffer.coffee
+++ b/src/app/buffer.coffee
@@ -133,7 +133,7 @@ class Buffer
     oldRange = Range.fromObject(oldRange)
     operation = new BufferChangeOperation({buffer: this, oldRange, newText})
     if @undoManager
-      @undoManager.perform(operation)
+      @undoManager.pushOperation(operation)
     else
       operation.do()
 

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -238,15 +238,18 @@ class EditSession
   transact: (fn) ->
     @buffer.transact =>
       oldSelectedRanges = @getSelectedBufferRanges()
-      @buffer.pushOperation
+      @pushOperation
         undo: (editSession) ->
           editSession?.setSelectedBufferRanges(oldSelectedRanges)
 
       fn()
       newSelectedRanges = @getSelectedBufferRanges()
-      @buffer.pushOperation
+      @pushOperation
         redo: (editSession) ->
           editSession?.setSelectedBufferRanges(newSelectedRanges)
+
+  pushOperation: (operation) ->
+    @buffer.pushOperation(operation, this)
 
   getAnchors: ->
     new Array(@anchors...)

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -95,6 +95,7 @@ class EditSession
     new Point(row, column)
 
   getFileExtension: -> @buffer.getExtension()
+  getPath: -> @buffer.getPath()
   getEofBufferPosition: -> @buffer.getEofPosition()
   bufferRangeForBufferRow: (row) -> @buffer.rangeForRow(row)
   lineForBufferRow: (row) -> @buffer.lineForRow(row)
@@ -177,10 +178,10 @@ class EditSession
     @insertText($native.readFromPasteboard())
 
   undo: ->
-    @buffer.undo()
+    @buffer.undo(this)
 
   redo: ->
-    @buffer.redo()
+    @buffer.redo(this)
 
   foldSelection: ->
     selection.fold() for selection in @getSelections()
@@ -237,10 +238,15 @@ class EditSession
   transact: (fn) ->
     @buffer.transact =>
       oldSelectedRanges = @getSelectedBufferRanges()
-      @buffer.pushOperation(undo: => @setSelectedBufferRanges(oldSelectedRanges))
+      @buffer.pushOperation
+        undo: (editSession) ->
+          editSession?.setSelectedBufferRanges(oldSelectedRanges)
+
       fn()
       newSelectedRanges = @getSelectedBufferRanges()
-      @buffer.pushOperation(redo: => @setSelectedBufferRanges(newSelectedRanges))
+      @buffer.pushOperation
+        redo: (editSession) ->
+          editSession?.setSelectedBufferRanges(newSelectedRanges)
 
   getAnchors: ->
     new Array(@anchors...)

--- a/src/app/project.coffee
+++ b/src/app/project.coffee
@@ -75,25 +75,29 @@ class Project
   getSoftWrap: -> @softWrap
   setSoftWrap: (@softWrap) ->
 
-  open: (filePath) ->
+  open: (filePath, editSessionOptions={}) ->
     if filePath?
       filePath = @resolve(filePath)
       buffer = @bufferWithPath(filePath) ? @buildBuffer(filePath)
     else
       buffer = @buildBuffer()
 
-    editSession = new EditSession
-      project: this
-      buffer: buffer
-      tabText: @getTabText()
-      autoIndent: @getAutoIndent()
-      softTabs: @getSoftTabs()
-      softWrap: @getSoftWrap()
+    @buildEditSession(buffer, editSessionOptions)
 
-
+  buildEditSession: (buffer, editSessionOptions) ->
+    options = _.extend(@defaultEditSessionOptions(), editSessionOptions)
+    options.project = this
+    options.buffer = buffer
+    editSession = new EditSession(options)
     @editSessions.push editSession
     @trigger 'new-edit-session', editSession
     editSession
+
+  defaultEditSessionOptions: ->
+    tabText: @getTabText()
+    autoIndent: @getAutoIndent()
+    softTabs: @getSoftTabs()
+    softWrap: @getSoftWrap()
 
   destroy: ->
     for editSession in _.clone(@editSessions)

--- a/src/app/range.coffee
+++ b/src/app/range.coffee
@@ -22,7 +22,7 @@ class Range
       @start = pointB
       @end = pointA
 
-  copy: (range) ->
+  copy: ->
     new Range(@start.copy(), @end.copy())
 
   isEqual: (other) ->

--- a/src/app/undo-manager.coffee
+++ b/src/app/undo-manager.coffee
@@ -12,13 +12,13 @@ class UndoManager
     @undoHistory = []
     @redoHistory = []
 
-  pushOperation: (operation) ->
+  pushOperation: (operation, editSession) ->
     if @currentTransaction
       @currentTransaction.push(operation)
     else
       @undoHistory.push([operation])
     @redoHistory = []
-    operation.do?()
+    operation.do?(editSession)
 
   transact: (fn) ->
     if @currentTransaction

--- a/src/app/undo-manager.coffee
+++ b/src/app/undo-manager.coffee
@@ -6,36 +6,33 @@ class UndoManager
   undoHistory: null
   redoHistory: null
   currentBatch: null
-  preserveHistory: false
   startBatchCallCount: null
 
   constructor: (@buffer) ->
     @startBatchCallCount = 0
     @undoHistory = []
     @redoHistory = []
-    @buffer.on 'change', (event) =>
-      unless @preserveHistory
-        op = new BufferChangeOperation(_.extend({ @buffer }, event))
-        if @currentBatch
-          @currentBatch.push(op)
-        else
-          @undoHistory.push([op])
-        @redoHistory = []
+
+  perform: (operation) ->
+    if @currentBatch
+      @currentBatch.push(operation)
+    else
+      @undoHistory.push([operation])
+    @redoHistory = []
+    operation.do()
 
   undo: ->
     if batch = @undoHistory.pop()
-      @preservingHistory =>
-        opsInReverse = new Array(batch...)
-        opsInReverse.reverse()
-        op.undo() for op in opsInReverse
-        @redoHistory.push batch
+      opsInReverse = new Array(batch...)
+      opsInReverse.reverse()
+      op.undo() for op in opsInReverse
+      @redoHistory.push batch
       batch.oldSelectionRanges
 
   redo: ->
     if batch = @redoHistory.pop()
-      @preservingHistory =>
-        op.do() for op in batch
-        @undoHistory.push(batch)
+      op.do() for op in batch
+      @undoHistory.push(batch)
       batch.newSelectionRanges
 
   startUndoBatch: (ranges) ->
@@ -50,17 +47,3 @@ class UndoManager
     @currentBatch.newSelectionRanges = ranges
     @undoHistory.push(@currentBatch) if @currentBatch.length > 0
     @currentBatch = null
-
-  preservingHistory: (fn) ->
-    @preserveHistory = true
-    fn()
-    @preserveHistory = false
-
-class BufferChangeOperation
-  constructor: ({@buffer, @oldRange, @newRange, @oldText, @newText}) ->
-
-  do: ->
-    @buffer.change @oldRange, @newText
-
-  undo: ->
-    @buffer.change @newRange, @oldText

--- a/src/app/undo-manager.coffee
+++ b/src/app/undo-manager.coffee
@@ -7,7 +7,7 @@ class UndoManager
   redoHistory: null
   currentTransaction: null
 
-  constructor: (@buffer) ->
+  constructor: ->
     @startBatchCallCount = 0
     @undoHistory = []
     @redoHistory = []
@@ -29,18 +29,18 @@ class UndoManager
       @undoHistory.push(@currentTransaction) if @currentTransaction.length
       @currentTransaction = null
 
-  undo: ->
+  undo: (editSession) ->
     if batch = @undoHistory.pop()
       opsInReverse = new Array(batch...)
       opsInReverse.reverse()
-      op.undo?() for op in opsInReverse
+      op.undo?(editSession) for op in opsInReverse
       @redoHistory.push batch
       batch.oldSelectionRanges
 
-  redo: ->
+  redo: (editSession) ->
     if batch = @redoHistory.pop()
       for op in batch
-        op.do?()
-        op.redo?()
+        op.do?(editSession)
+        op.redo?(editSession)
       @undoHistory.push(batch)
       batch.newSelectionRanges

--- a/src/app/undo-manager.coffee
+++ b/src/app/undo-manager.coffee
@@ -13,7 +13,7 @@ class UndoManager
     @undoHistory = []
     @redoHistory = []
 
-  perform: (operation) ->
+  pushOperation: (operation) ->
     if @currentBatch
       @currentBatch.push(operation)
     else

--- a/src/extensions/snippets/snippet-expansion.coffee
+++ b/src/extensions/snippets/snippet-expansion.coffee
@@ -55,6 +55,7 @@ class SnippetExpansion
     anchorRange.destroy() for anchorRange in @tabStopAnchorRanges
     @editSession.snippetExpansion = null
 
-  restoreTabStops: ->
+  restore: (@editSession) ->
+    @editSession.snippetExpansion = this
     @tabStopAnchorRanges = @tabStopAnchorRanges.map (anchorRange) =>
       @editSession.addAnchorRange(anchorRange.getBufferRange())

--- a/src/extensions/snippets/snippet-expansion.coffee
+++ b/src/extensions/snippets/snippet-expansion.coffee
@@ -54,3 +54,7 @@ class SnippetExpansion
   destroy: ->
     anchorRange.destroy() for anchorRange in @tabStopAnchorRanges
     @editSession.snippetExpansion = null
+
+  restoreTabStops: ->
+    @tabStopAnchorRanges = @tabStopAnchorRanges.map (anchorRange) =>
+      @editSession.addAnchorRange(anchorRange.getBufferRange())

--- a/src/extensions/snippets/snippet-expansion.coffee
+++ b/src/extensions/snippets/snippet-expansion.coffee
@@ -5,11 +5,12 @@ class SnippetExpansion
   constructor: (snippet, @editSession) ->
     @editSession.selectToBeginningOfWord()
     startPosition = @editSession.getCursorBufferPosition()
-    @editSession.insertText(snippet.body)
-    if snippet.tabStops.length
-      @placeTabStopAnchorRanges(startPosition, snippet.tabStops)
-    if snippet.lineCount > 1
-      @indentSubsequentLines(startPosition.row, snippet)
+    @editSession.transact =>
+      @editSession.insertText(snippet.body)
+      if snippet.tabStops.length
+        @placeTabStopAnchorRanges(startPosition, snippet.tabStops)
+      if snippet.lineCount > 1
+        @indentSubsequentLines(startPosition.row, snippet)
 
   placeTabStopAnchorRanges: (startPosition, tabStopRanges) ->
     @tabStopAnchorRanges = tabStopRanges.map ({start, end}) =>

--- a/src/extensions/snippets/snippets.coffee
+++ b/src/extensions/snippets/snippets.coffee
@@ -32,10 +32,8 @@ module.exports =
           snippetExpansion = new SnippetExpansion(snippet, editSession)
           editSession.snippetExpansion = snippetExpansion
           editSession.pushOperation
-            undo: -> editSession.snippetExpansion.destroy()
-            redo: ->
-              editSession.snippetExpansion = snippetExpansion
-              snippetExpansion.restoreTabStops()
+            undo: -> snippetExpansion.destroy()
+            redo: (editSession) -> snippetExpansion.restore(editSession)
       else
         e.abortKeyBinding()
 

--- a/src/extensions/snippets/snippets.coffee
+++ b/src/extensions/snippets/snippets.coffee
@@ -28,7 +28,10 @@ module.exports =
       editSession = editor.activeEditSession
       prefix = editSession.getLastCursor().getCurrentWordPrefix()
       if snippet = @snippetsByExtension[editSession.getFileExtension()][prefix]
-        editSession.snippetExpansion = new SnippetExpansion(snippet, editSession)
+        editSession.transact ->
+          editSession.snippetExpansion = new SnippetExpansion(snippet, editSession)
+          editSession.pushOperation
+            undo: -> editSession.snippetExpansion.destroy()
       else
         e.abortKeyBinding()
 

--- a/src/extensions/snippets/snippets.coffee
+++ b/src/extensions/snippets/snippets.coffee
@@ -29,9 +29,13 @@ module.exports =
       prefix = editSession.getLastCursor().getCurrentWordPrefix()
       if snippet = @snippetsByExtension[editSession.getFileExtension()][prefix]
         editSession.transact ->
-          editSession.snippetExpansion = new SnippetExpansion(snippet, editSession)
+          snippetExpansion = new SnippetExpansion(snippet, editSession)
+          editSession.snippetExpansion = snippetExpansion
           editSession.pushOperation
             undo: -> editSession.snippetExpansion.destroy()
+            redo: ->
+              editSession.snippetExpansion = snippetExpansion
+              snippetExpansion.restoreTabStops()
       else
         e.abortKeyBinding()
 


### PR DESCRIPTION
Undoing a snippet expansion was leaving stale tab stops in the edit session, which occasionally caused artifacts when pressing `tab` after the undo. We realized that the undo manager potentially needed to undo/redo more than just changes to the buffer, but also state associated with those changes. In this case, when you remove the text inserted by the snippet, you also need to destroy the snippet's extra state.

This led to an overhaul of the UndoManager class. Previously, it was tightly coupled to Buffer, observing its changes. Now UndoManager takes generic operation objects, which have optional `do`, `undo`, and `redo` methods. The `do` and `redo` methods are similar, except `redo` is only triggered when redo-ing, whereas do is triggered on the initial push to the undo manager as well.

We used this new generic facility to manage selection state as well. Previously, each "transaction" object in the undo manager was associated with an array of ranges that were selected before / after the transaction. Now, `EditSession` has a `transact` method that pushes operations before / after the rest of the transaction to manage selection state on undo / redo.

One further detail is that the undo and redo methods take an optional `editSession` argument. This can be used to contextualize _where_ the undo/redo is being performed. This is necessary, for example, when we undo a change to the same buffer in another editor. We don't want to restore the selection in the other editor, but in the current editor.
