### PR TITLE
Add platform stylesheet

### DIFF
--- a/.pairs
+++ b/.pairs
@@ -2,6 +2,7 @@ pairs:
   ns: Nathan Sobo; nathan
   cj: Corey Johnson; cj
   dg: David Graham; dgraham
+  ks: Kevin Sawicki; kevin
 email:
   domain: github.com
 #global: true

--- a/Atom-Linux/native_handler.cpp
+++ b/Atom-Linux/native_handler.cpp
@@ -56,7 +56,8 @@ NativeHandler::NativeHandler() :
       "absolute", "list", "isFile", "isDirectory", "remove", "asyncList",
       "open", "openDialog", "quit", "writeToPasteboard", "readFromPasteboard",
       "showDevTools", "newWindow", "saveDialog", "exit", "watchPath",
-      "unwatchPath", "makeDirectory", "move", "moveToTrash", "md5ForPath" };
+      "unwatchPath", "makeDirectory", "move", "moveToTrash", "md5ForPath",
+      "getPlatform" };
   int arrayLength = sizeof(functionNames) / sizeof(const char *);
   for (int i = 0; i < arrayLength; i++) {
     const char *functionName = functionNames[i];
@@ -520,6 +521,8 @@ bool NativeHandler::Execute(const CefString& name, CefRefPtr<CefV8Value> object,
     UnwatchPath(name, object, arguments, retval, exception);
   else if (name == "md5ForPath")
     Digest(name, object, arguments, retval, exception);
+  else if (name == "getPlatform")
+    retval = CefV8Value::CreateString("linux");
   else
     cout << "Unhandled -> " + name.ToString() << " : "
         << arguments[0]->GetStringValue().ToString() << endl;

--- a/Atom/src/native_handler.mm
+++ b/Atom/src/native_handler.mm
@@ -526,9 +526,7 @@ bool NativeHandler::Execute(const CefString& name,
     return true;
   }
   else if (name == "getPlatform") {
-    NSString *platform = @"mac";
-    retval = CefV8Value::CreateString([platform UTF8String]);
-
+    retval = CefV8Value::CreateString("mac");
     return true;
   }
   return false;

--- a/Atom/src/native_handler.mm
+++ b/Atom/src/native_handler.mm
@@ -33,7 +33,7 @@ void throwException(const CefRefPtr<CefV8Value>& global, CefRefPtr<CefV8Exceptio
 NativeHandler::NativeHandler() : CefV8Handler() {  
   std::string extensionCode =  "var $native = {}; (function() {";
   
-  const char *functionNames[] = {"exists", "alert", "read", "write", "absolute", "list", "isFile", "isDirectory", "remove", "asyncList", "open", "openDialog", "quit", "writeToPasteboard", "readFromPasteboard", "showDevTools", "toggleDevTools", "newWindow", "saveDialog", "exit", "watchPath", "unwatchPath", "makeDirectory", "move", "moveToTrash", "reload", "lastModified", "md5ForPath", "exec"};
+  const char *functionNames[] = {"exists", "alert", "read", "write", "absolute", "list", "isFile", "isDirectory", "remove", "asyncList", "open", "openDialog", "quit", "writeToPasteboard", "readFromPasteboard", "showDevTools", "toggleDevTools", "newWindow", "saveDialog", "exit", "watchPath", "unwatchPath", "makeDirectory", "move", "moveToTrash", "reload", "lastModified", "md5ForPath", "exec", "getPlatform"};
   NSUInteger arrayLength = sizeof(functionNames) / sizeof(const char *);
   for (NSUInteger i = 0; i < arrayLength; i++) {
     std::string functionName = std::string(functionNames[i]);
@@ -523,6 +523,12 @@ bool NativeHandler::Execute(const CefString& name,
     
     [task launch];
     
+    return true;
+  }
+  else if (name == "getPlatform") {
+    NSString *platform = @"mac";
+    retval = CefV8Value::CreateString([platform UTF8String]);
+
     return true;
   }
   return false;

--- a/spec/app/native-spec.coffee
+++ b/spec/app/native-spec.coffee
@@ -1,0 +1,7 @@
+describe 'Native', ->
+
+  describe '$native.getPlatform()', ->
+    it 'returns a non-empty value', ->
+      platform = $native.getPlatform()
+      expect(platform).not.toBe ''
+      expect(platform.length).toBeGreaterThan(0)

--- a/spec/app/native-spec.coffee
+++ b/spec/app/native-spec.coffee
@@ -1,5 +1,4 @@
 describe 'Native', ->
-
   describe '$native.getPlatform()', ->
     it 'returns a non-empty value', ->
       platform = $native.getPlatform()

--- a/src/app/window.coffee
+++ b/src/app/window.coffee
@@ -11,6 +11,7 @@ windowAdditions =
   rootViewParentSelector: 'body'
   rootView: null
   keymap: null
+  platform: $native.getPlatform()
 
   setUpKeymap: ->
     Keymap = require 'keymap'

--- a/src/app/window.coffee
+++ b/src/app/window.coffee
@@ -50,8 +50,8 @@ windowAdditions =
     $(@rootViewParentSelector).append @rootView
 
   requireStylesheet: (path) ->
-    fullPath = require.resolve(path)
-    return unless fs.isFile(fullPath)
+    unless fullPath = require.resolve(path)
+      throw new Error("requireStylesheet could not find a file at path '#{path}'")
     content = fs.read(fullPath)
     return if $("head style[path='#{fullPath}']").length
     $('head').append "<style path='#{fullPath}'>#{content}</style>"
@@ -100,4 +100,6 @@ require 'underscore-extensions'
 
 requireStylesheet 'reset.css'
 requireStylesheet 'atom.css'
-requireStylesheet "#{$native.getPlatform()}.css"
+
+if nativeStylesheetPath = require.resolve("#{platform}.css")
+  requireStylesheet(nativeStylesheetPath)

--- a/src/app/window.coffee
+++ b/src/app/window.coffee
@@ -51,6 +51,7 @@ windowAdditions =
 
   requireStylesheet: (path) ->
     fullPath = require.resolve(path)
+    return unless fs.isFile(fullPath)
     content = fs.read(fullPath)
     return if $("head style[path='#{fullPath}']").length
     $('head').append "<style path='#{fullPath}'>#{content}</style>"
@@ -99,3 +100,4 @@ require 'underscore-extensions'
 
 requireStylesheet 'reset.css'
 requireStylesheet 'atom.css'
+requireStylesheet "#{$native.getPlatform()}.css"

--- a/src/stdlib/require.coffee
+++ b/src/stdlib/require.coffee
@@ -17,10 +17,12 @@ nakedLoad = (file) ->
   code = __read file
   window.eval(code + "\n//@ sourceURL=" + file)
 
-require = (file, cb) ->
-  return cb require file if cb?
+require = (path, cb) ->
+  return cb require path if cb?
 
-  file  = resolve file
+  unless file = resolve(path)
+    throw new Error("Require can't find file at path '#{path}'")
+
   parts = file.split '.'
   ext   = parts[parts.length-1]
 
@@ -86,10 +88,10 @@ resolve = (file) ->
   else
     file = __expand(file) or file
 
-  if file[0] isnt '/'
-    throw "require: Can't find '#{file}'"
-
-  return file
+  if file[0] == '/'
+    file
+  else
+    null
 
 __expand = (path) ->
   return path if __isFile path

--- a/static/linux.css
+++ b/static/linux.css
@@ -3,8 +3,8 @@
 }
 
 ::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-thumb {

--- a/static/linux.css
+++ b/static/linux.css
@@ -1,0 +1,13 @@
+::-webkit-scrollbar-corner {
+  background-color: transparent;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+  -webkit-border-radius: 2px;
+  background: rgba(150, 150, 150, .33);
+}


### PR DESCRIPTION
### The Problem

Native scrollbars on most Linux distros look terrible.
### The Solution

Override the scrollbars using a Linux-specific stylesheet.

This required adding a native `getPlatform()` method that is stored as the `platform` property on the window object that is used to require a stylesheet with the current platform name.
#### Before

![](http://img.skitch.com/20120803-qncdnp8bfnw1a4wg7844i67da1.png)
#### After

![](http://img.skitch.com/20120803-k8hxwy6d88cj2yei52qc3e1r5b.png)
