### PR TITLE
Speed up fuzzy finder

### DIFF
--- a/native/v8_extensions/native.js
+++ b/native/v8_extensions/native.js
@@ -16,7 +16,7 @@ var $native = {};
   native function list(path, recursive);
   $native.list = list;
 
-  native function traverseTree(path, callback);
+  native function traverseTree(path, onFile, onDirectory);
   $native.traverseTree = traverseTree;
 
   native function isFile(path);

--- a/native/v8_extensions/native.js
+++ b/native/v8_extensions/native.js
@@ -13,9 +13,6 @@ var $native = {};
   native function absolute(path);
   $native.absolute = absolute;
 
-  native function list(path, recursive);
-  $native.list = list;
-
   native function traverseTree(path, onFile, onDirectory);
   $native.traverseTree = traverseTree;
 

--- a/native/v8_extensions/native.js
+++ b/native/v8_extensions/native.js
@@ -16,6 +16,9 @@ var $native = {};
   native function list(path, recursive);
   $native.list = list;
 
+  native function traverseTree(path, callback);
+  $native.traverseTree = traverseTree;
+
   native function isFile(path);
   $native.isFile = isFile;
 

--- a/native/v8_extensions/native.mm
+++ b/native/v8_extensions/native.mm
@@ -137,36 +137,6 @@ bool Native::Execute(const CefString& name,
 
       return true;
   }
-  else if (name == "list") {
-    NSString *path = stringFromCefV8Value(arguments[0]);
-    bool recursive = arguments[1]->GetBoolValue();
-
-    if (!path or [path length] == 0) {
-      exception = "$native.list requires a path argument";
-      return true;
-    }
-
-    std::string argument = arguments[0]->GetStringValue().ToString();
-    char rootPath[argument.size() + 1];
-    strcpy(rootPath, argument.c_str());
-    char * const paths[] = {rootPath, NULL};
-    FTS *tree = fts_open(paths, FTS_PHYSICAL | FTS_NOCHDIR | FTS_NOSTAT, NULL);
-    retval = CefV8Value::CreateArray(0);
-    int index = 0;
-    if (tree != NULL) {
-      FTSENT *entry;
-      while ((entry = fts_read(tree)) != NULL) {
-        if (entry->fts_level == 0)
-          continue;
-        if (!recursive)
-          fts_set(tree, entry, FTS_SKIP);
-        if (entry->fts_info == FTS_D || entry->fts_info == FTS_NSOK)
-          retval->SetValue(index++, CefV8Value::CreateString(entry->fts_path));
-      }
-    }
-
-    return true;
-  }
   else if (name == "isDirectory") {
     NSString *path = stringFromCefV8Value(arguments[0]);
 

--- a/native/v8_extensions/native.mm
+++ b/native/v8_extensions/native.mm
@@ -121,6 +121,7 @@ bool Native::Execute(const CefString& name,
           strncpy(relative, entry->fts_path + rootPathLength, pathLength);
           args.clear();
           args.push_back(CefV8Value::CreateString(relative));
+          args.push_back(CefV8Value::CreateString(entry->fts_name));
           args.push_back(CefV8Value::CreateBool((entry->fts_info & FTS_F) != 0));
           if (!function->ExecuteFunction(function, args)->GetBoolValue())
             fts_set(tree, entry, FTS_SKIP);

--- a/native/v8_extensions/native.mm
+++ b/native/v8_extensions/native.mm
@@ -128,8 +128,11 @@ bool Native::Execute(const CefString& name,
         args.push_back(CefV8Value::CreateString(relative));
         if (isFile)
           onFile->ExecuteFunction(onFile, args);
-        else if (!onDir->ExecuteFunction(onDir, args)->GetBoolValue())
+        else {
+          CefRefPtr<CefV8Value> enterDir = onDir->ExecuteFunction(onDir, args);
+          if(enterDir != NULL && !enterDir->GetBoolValue())
             fts_set(tree, entry, FTS_SKIP);
+        }
       }
 
       return true;

--- a/native/v8_extensions/native.mm
+++ b/native/v8_extensions/native.mm
@@ -104,7 +104,7 @@ bool Native::Execute(const CefString& name,
       strcpy(rootPath, argument.c_str());
       char * const paths[] = {rootPath, NULL};
 
-      FTS *tree = fts_open(paths, FTS_NOCHDIR | FTS_NOSTAT, NULL);
+      FTS *tree = fts_open(paths, FTS_PHYSICAL| FTS_NOCHDIR | FTS_NOSTAT, NULL);
       if (tree == NULL)
         return true;
 
@@ -150,7 +150,7 @@ bool Native::Execute(const CefString& name,
     char rootPath[argument.size() + 1];
     strcpy(rootPath, argument.c_str());
     char * const paths[] = {rootPath, NULL};
-    FTS *tree = fts_open(paths, FTS_NOCHDIR | FTS_NOSTAT, NULL);
+    FTS *tree = fts_open(paths, FTS_PHYSICAL | FTS_NOCHDIR | FTS_NOSTAT, NULL);
     retval = CefV8Value::CreateArray(0);
     int index = 0;
     if (tree != NULL) {

--- a/native/v8_extensions/native.mm
+++ b/native/v8_extensions/native.mm
@@ -123,7 +123,7 @@ bool Native::Execute(const CefString& name,
           args.push_back(CefV8Value::CreateString(relative));
           args.push_back(CefV8Value::CreateBool((entry->fts_info & FTS_F) != 0));
           if (!function->ExecuteFunction(function, args)->GetBoolValue())
-                    fts_set(tree, entry, FTS_SKIP);
+            fts_set(tree, entry, FTS_SKIP);
         }
       }
 

--- a/native/v8_extensions/native.mm
+++ b/native/v8_extensions/native.mm
@@ -108,22 +108,30 @@ bool Native::Execute(const CefString& name,
       if (tree == NULL)
         return true;
 
-      CefRefPtr<CefV8Value> function = arguments[1];
+      CefRefPtr<CefV8Value> onFile = arguments[1];
+      CefRefPtr<CefV8Value> onDirectory = arguments[2];
       CefV8ValueList args;
       FTSENT *entry;
       while ((entry = fts_read(tree)) != NULL) {
         if (entry->fts_level == 0)
           continue;
-        if ((entry->fts_info & FTS_D) != 0 || (entry->fts_info & FTS_F) != 0) {
+        if((entry->fts_info & FTS_F) != 0) {
           int pathLength = entry->fts_pathlen - rootPathLength;
           char relative[pathLength + 1];
           relative[pathLength] = '\0';
           strncpy(relative, entry->fts_path + rootPathLength, pathLength);
           args.clear();
           args.push_back(CefV8Value::CreateString(relative));
-          args.push_back(CefV8Value::CreateString(entry->fts_name));
-          args.push_back(CefV8Value::CreateBool((entry->fts_info & FTS_F) != 0));
-          if (!function->ExecuteFunction(function, args)->GetBoolValue())
+          onFile->ExecuteFunction(onFile, args);
+        }
+        else if ((entry->fts_info & FTS_D) != 0) {
+          int pathLength = entry->fts_pathlen - rootPathLength;
+          char relative[pathLength + 1];
+          relative[pathLength] = '\0';
+          strncpy(relative, entry->fts_path + rootPathLength, pathLength);
+          args.clear();
+          args.push_back(CefV8Value::CreateString(relative));
+          if (!onDirectory->ExecuteFunction(onDirectory, args)->GetBoolValue())
             fts_set(tree, entry, FTS_SKIP);
         }
       }

--- a/native/v8_extensions/native.mm
+++ b/native/v8_extensions/native.mm
@@ -104,26 +104,27 @@ bool Native::Execute(const CefString& name,
       strcpy(rootPath, argument.c_str());
       char * const paths[] = {rootPath, NULL};
 
+      FTS *tree = fts_open(paths, FTS_NOCHDIR | FTS_NOSTAT, NULL);
+      if (tree == NULL)
+        return true;
+
       CefRefPtr<CefV8Value> function = arguments[1];
       CefV8ValueList args;
-      FTS *tree = fts_open(paths, FTS_NOCHDIR | FTS_NOSTAT, NULL);
-      if (tree != NULL) {
-          FTSENT *entry;
-          while ((entry = fts_read(tree)) != NULL) {
-              if (entry->fts_level == 0)
-                  continue;
-              if ((entry->fts_info & FTS_D) != 0 || (entry->fts_info & FTS_F) != 0) {
-                  int pathLength = entry->fts_pathlen - rootPathLength;
-                  char relative[pathLength + 1];
-                  relative[pathLength] = '\0';
-                  strncpy(relative, entry->fts_path + rootPathLength, pathLength);
-                  args.clear();
-                  args.push_back(CefV8Value::CreateString(relative));
-                  args.push_back(CefV8Value::CreateBool((entry->fts_info & FTS_F) != 0));
-                  if (!function->ExecuteFunction(function, args)->GetBoolValue())
+      FTSENT *entry;
+      while ((entry = fts_read(tree)) != NULL) {
+        if (entry->fts_level == 0)
+          continue;
+        if ((entry->fts_info & FTS_D) != 0 || (entry->fts_info & FTS_F) != 0) {
+          int pathLength = entry->fts_pathlen - rootPathLength;
+          char relative[pathLength + 1];
+          relative[pathLength] = '\0';
+          strncpy(relative, entry->fts_path + rootPathLength, pathLength);
+          args.clear();
+          args.push_back(CefV8Value::CreateString(relative));
+          args.push_back(CefV8Value::CreateBool((entry->fts_info & FTS_F) != 0));
+          if (!function->ExecuteFunction(function, args)->GetBoolValue())
                     fts_set(tree, entry, FTS_SKIP);
-              }
-          }
+        }
       }
 
       return true;

--- a/native/v8_extensions/native.mm
+++ b/native/v8_extensions/native.mm
@@ -157,7 +157,7 @@ bool Native::Execute(const CefString& name,
           continue;
         if (!recursive)
           fts_set(tree, entry, FTS_SKIP);
-        if ((entry->fts_info & FTS_D) != 0 || (entry->fts_info & FTS_F) != 0)
+        if (entry->fts_info == FTS_D || entry->fts_info == FTS_NSOK)
           retval->SetValue(index++, CefV8Value::CreateString(entry->fts_path));
       }
     }

--- a/native/v8_extensions/native.mm
+++ b/native/v8_extensions/native.mm
@@ -105,7 +105,7 @@ bool Native::Execute(const CefString& name,
       char * const paths[] = {rootPath, NULL};
 
       CefRefPtr<CefV8Value> function = arguments[1];
-
+      CefV8ValueList args;
       FTS *tree = fts_open(paths, FTS_NOCHDIR | FTS_NOSTAT, NULL);
       if (tree != NULL) {
           FTSENT *entry;
@@ -113,11 +113,11 @@ bool Native::Execute(const CefString& name,
               if (entry->fts_level == 0)
                   continue;
               if ((entry->fts_info & FTS_D) != 0 || (entry->fts_info & FTS_F) != 0) {
-                  CefV8ValueList args;
                   int pathLength = entry->fts_pathlen - rootPathLength;
                   char relative[pathLength + 1];
                   relative[pathLength] = '\0';
                   strncpy(relative, entry->fts_path + rootPathLength, pathLength);
+                  args.clear();
                   args.push_back(CefV8Value::CreateString(relative));
                   args.push_back(CefV8Value::CreateBool((entry->fts_info & FTS_F) != 0));
                   if (!function->ExecuteFunction(function, args)->GetBoolValue())

--- a/spec/app/project-spec.coffee
+++ b/spec/app/project-spec.coffee
@@ -111,7 +111,8 @@ describe "Project", ->
 
   describe ".getFilePaths()", ->
     it "ignores files that return true from atom.ignorePath(path)", ->
-      spyOn(project, 'ignorePath').andCallFake (path) -> fs.base(path).match /a$/
+      spyOn(project, 'ignoreDirectory').andCallFake (path) -> fs.base(path).match /a$/
+      spyOn(project, 'ignoreFile').andCallFake (path) -> fs.base(path).match /a$/
 
       project.getFilePaths().done (paths) ->
         expect(paths).not.toContain('a')

--- a/spec/stdlib/fs-spec.coffee
+++ b/spec/stdlib/fs-spec.coffee
@@ -62,7 +62,7 @@ describe "fs", ->
       fs.makeTree("/tmp/a/b/c")
       expect(fs.exists("/tmp/a/b/c")).toBeTruthy()
 
-  describe ".traverseTree(path, fn)", ->
+  describe ".traverseTree(path, onFile, onDirectory)", ->
     fixturesDir = null
 
     beforeEach ->
@@ -70,19 +70,21 @@ describe "fs", ->
 
     it "calls fn for every path in the tree at the given path", ->
       paths = []
-      fs.traverseTree fixturesDir, (path) ->
+      onPath = (path) ->
         paths.push(fs.join(fixturesDir, path))
         true
+      fs.traverseTree fixturesDir, onPath, onPath
       expect(paths).toEqual fs.listTree(fixturesDir)
 
     it "does not recurse into a directory if it is pruned", ->
       paths = []
-      fs.traverseTree fixturesDir, (path, prune) ->
+      onPath = (path) ->
         if path.match(/\/dir$/)
           false
         else
           paths.push(path)
           true
+      fs.traverseTree fixturesDir, onPath, onPath
 
       expect(paths.length).toBeGreaterThan 0
       for path in paths

--- a/spec/stdlib/fs-spec.coffee
+++ b/spec/stdlib/fs-spec.coffee
@@ -70,16 +70,19 @@ describe "fs", ->
 
     it "calls fn for every path in the tree at the given path", ->
       paths = []
-      fs.traverseTree fixturesDir, (path) -> paths.push(path)
+      fs.traverseTree fixturesDir, (path) ->
+        paths.push(fs.join(fixturesDir, path))
+        true
       expect(paths).toEqual fs.listTree(fixturesDir)
 
     it "does not recurse into a directory if it is pruned", ->
       paths = []
       fs.traverseTree fixturesDir, (path, prune) ->
         if path.match(/\/dir$/)
-          prune()
+          false
         else
           paths.push(path)
+          true
 
       expect(paths.length).toBeGreaterThan 0
       for path in paths

--- a/src/app/project.coffee
+++ b/src/app/project.coffee
@@ -55,13 +55,18 @@ class Project
 
     filePaths = []
 
+    count = 0
+    start = new Date().getTime()
     onFile = (path) =>
+      count++
       filePaths.push(path) unless @ignoreFile(path)
 
     onDirectory = (path) =>
+      count++
       return not @ignoreDirectory(path)
 
     fs.traverseTree @getPath(), onFile, onDirectory
+    console.log "#{count} paths in #{new Date().getTime()-start}ms"
     deferred.resolve filePaths
     deferred
 

--- a/src/app/project.coffee
+++ b/src/app/project.coffee
@@ -51,13 +51,15 @@ class Project
     deferred = $.Deferred()
 
     filePaths = []
-    fs.traverseTree @getPath(), (path, prune) =>
-      if @ignorePath(path)
-        prune()
-      else if fs.isFile(path)
-        prune()
-        filePaths.push @relativize(path)
 
+    fs.traverseTree @getPath(), (path, isFile) =>
+      if @ignorePath(path)
+        false
+      else if isFile
+        filePaths.push path
+        false
+      else
+        true
     deferred.resolve filePaths
     deferred
 

--- a/src/app/project.coffee
+++ b/src/app/project.coffee
@@ -55,18 +55,13 @@ class Project
 
     filePaths = []
 
-    count = 0
-    start = new Date().getTime()
     onFile = (path) =>
-      count++
       filePaths.push(path) unless @ignoreFile(path)
 
     onDirectory = (path) =>
-      count++
       return not @ignoreDirectory(path)
 
     fs.traverseTree @getPath(), onFile, onDirectory
-    console.log "#{count} paths in #{new Date().getTime()-start}ms"
     deferred.resolve filePaths
     deferred
 

--- a/src/stdlib/fs.coffee
+++ b/src/stdlib/fs.coffee
@@ -60,11 +60,21 @@ module.exports =
 
   # Returns an array with all the names of files contained
   # in the directory path.
-  list: (path) ->
-    $native.list(path, false)
+  list: (rootPath) ->
+    paths = []
+    onPath = (path) =>
+      paths.push(@join(rootPath, path))
+      false
+    @traverseTree(rootPath, onPath, onPath)
+    paths
 
-  listTree: (path) ->
-    $native.list(path, true)
+  listTree: (rootPath) ->
+    paths = []
+    onPath = (path) =>
+      paths.push(@join(rootPath, path))
+      true
+    @traverseTree(rootPath, onPath, onPath)
+    paths
 
   move: (source, target) ->
     $native.move(source, target)

--- a/src/stdlib/fs.coffee
+++ b/src/stdlib/fs.coffee
@@ -102,8 +102,8 @@ module.exports =
       @makeTree(@directory(path))
       @makeDirectory(path)
 
-  traverseTree: (rootPath, fn) ->
-    $native.traverseTree(rootPath, fn)
+  traverseTree: (rootPath, onFile, onDirectory) ->
+    $native.traverseTree(rootPath, onFile, onDirectory)
 
   lastModified: (path) ->
     $native.lastModified(path)

--- a/src/stdlib/fs.coffee
+++ b/src/stdlib/fs.coffee
@@ -103,13 +103,7 @@ module.exports =
       @makeDirectory(path)
 
   traverseTree: (rootPath, fn) ->
-    recurse = null
-    prune = -> recurse = false
-
-    for path in @list(rootPath)
-      recurse = true
-      fn(path, prune)
-      @traverseTree(path, fn) if recurse and @isDirectory(path)
+    $native.traverseTree(rootPath, fn)
 
   lastModified: (path) ->
     $native.lastModified(path)


### PR DESCRIPTION
### What changed
- Add `native.traverseTree` that can optionally not recurse into sub-directories.
- Execute `onFile` and `onDirectory` callback functions for current path in C++ instead of JavaScript.
- Use [fst_open](http://www.kernel.org/doc/man-pages/online/pages/man3/fts.3.html) to walk tree
- Relativize returned paths in C++ instead of JavaScript
- Remove need to call`native.isFile()` and `native.isDirectory()` on each entry by using the information provided by the current `FTSENT`.
### Results
#### Current times

github/atom: `12359 paths took 529ms`
github/github: `45117 paths took 2120ms`
#### New times

github/atom: `12359 paths took 146ms`
github/github: `45117 paths took 541ms`
