### PR TITLE
Update the screen once per keystroke, and make typing faster

### DIFF
--- a/native/atom_application.mm
+++ b/native/atom_application.mm
@@ -131,6 +131,10 @@
   [[AtomWindowController alloc] initWithPath:path];
 }
 
+- (void)openUnstable:(NSString *)path {
+  [[AtomWindowController alloc] initUnstableWithPath:path];
+}
+
 - (IBAction)runSpecs:(id)sender {
   [self runSpecsThenExit:NO];
 }

--- a/native/atom_cef_client.cpp
+++ b/native/atom_cef_client.cpp
@@ -34,6 +34,10 @@ bool AtomCefClient::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
     bool hasArguments = argumentList->GetSize() > 1;
     hasArguments ? Open(argumentList->GetString(1)) : Open();
   }
+  if (name == "openUnstable") {
+    bool hasArguments = argumentList->GetSize() > 1;
+    hasArguments ? OpenUnstable(argumentList->GetString(1)) : OpenUnstable();
+  }
   else if (name == "newWindow") {
     NewWindow();
   }

--- a/native/atom_cef_client.h
+++ b/native/atom_cef_client.h
@@ -107,6 +107,9 @@ class AtomCefClient : public CefClient,
   void FocusNextWindow();
   void Open(std::string path);
   void Open();
+  void OpenUnstable(std::string path);
+
+                        void OpenUnstable();
   void NewWindow();
   void ToggleDevTools(CefRefPtr<CefBrowser> browser);
   void ShowDevTools(CefRefPtr<CefBrowser> browser);

--- a/native/atom_cef_client_mac.mm
+++ b/native/atom_cef_client_mac.mm
@@ -37,6 +37,20 @@ void AtomCefClient::Open() {
   }
 }
 
+void AtomCefClient::OpenUnstable(std::string path) {
+  NSString *pathString = [NSString stringWithCString:path.c_str() encoding:NSUTF8StringEncoding];
+  [(AtomApplication *)[AtomApplication sharedApplication] openUnstable:pathString];
+}
+
+void AtomCefClient::OpenUnstable() {
+  NSOpenPanel *panel = [NSOpenPanel openPanel];
+  [panel setCanChooseDirectories:YES];
+  if ([panel runModal] == NSFileHandlingPanelOKButton) {
+    NSURL *url = [[panel URLs] lastObject];
+    OpenUnstable([[url path] UTF8String]);
+  }
+}
+
 void AtomCefClient::NewWindow() {
   [(AtomApplication *)[AtomApplication sharedApplication] open:nil];
 }

--- a/native/atom_window_controller.h
+++ b/native/atom_window_controller.h
@@ -23,6 +23,7 @@ class AtomCefClient;
 @property (nonatomic, retain) IBOutlet NSView *devToolsView;
 
 - (id)initWithPath:(NSString *)path;
+- (id)initUnstableWithPath:(NSString *)path;
 - (id)initInBackground;
 - (id)initSpecsThenExit:(BOOL)exitWhenDone;
 - (id)initBenchmarksThenExit:(BOOL)exitWhenDone;

--- a/native/atom_window_controller.mm
+++ b/native/atom_window_controller.mm
@@ -52,6 +52,12 @@
   return [self initWithBootstrapScript:@"window-bootstrap" background:NO alwaysUseBundleResourcePath:stable];
 }
 
+- (id)initUnstableWithPath:(NSString *)path {
+  _pathToOpen = [path retain];
+  AtomApplication *atomApplication = (AtomApplication *)[AtomApplication sharedApplication];
+  return [self initWithBootstrapScript:@"window-bootstrap" background:NO alwaysUseBundleResourcePath:false];
+}
+
 - (id)initInBackground {
   AtomApplication *atomApplication = (AtomApplication *)[AtomApplication sharedApplication];
   BOOL stable = [atomApplication.arguments objectForKey:@"stable"] != nil;

--- a/spec/app/buffer-spec.coffee
+++ b/spec/app/buffer-spec.coffee
@@ -727,3 +727,23 @@ describe 'Buffer', ->
       expect(buffer.isEmpty()).toBeFalsy()
       buffer.setText('\n')
       expect(buffer.isEmpty()).toBeFalsy()
+
+  describe "stopped-changing event", ->
+    it "fires 'stoppedChangingDelay' ms after the last buffer change", ->
+      delay = buffer.stoppedChangingDelay
+      stoppedChangingHandler = jasmine.createSpy("stoppedChangingHandler")
+      buffer.on 'stopped-changing', stoppedChangingHandler
+
+      buffer.insert([0, 0], 'a')
+      expect(stoppedChangingHandler).not.toHaveBeenCalled()
+
+      advanceClock(delay / 2)
+
+      buffer.insert([0, 0], 'b')
+      expect(stoppedChangingHandler).not.toHaveBeenCalled()
+
+      advanceClock(delay / 2)
+      expect(stoppedChangingHandler).not.toHaveBeenCalled()
+
+      advanceClock(delay / 2)
+      expect(stoppedChangingHandler).toHaveBeenCalled()

--- a/spec/app/buffer-spec.coffee
+++ b/spec/app/buffer-spec.coffee
@@ -144,12 +144,6 @@ describe 'Buffer', ->
         not bufferToDelete.getPath()
 
   describe ".isModified()", ->
-    beforeEach ->
-      buffer.destroy()
-      waitsFor "file to be removed", ->
-        not bufferToDelete.getPath()
-
-  describe ".isModified()", ->
     it "returns true when user changes buffer", ->
       expect(buffer.isModified()).toBeFalsy()
       buffer.insert([0,0], "hi")

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -9,7 +9,7 @@ $ = require 'jquery'
 _ = require 'underscore'
 fs = require 'fs'
 
-fdescribe "Editor", ->
+describe "Editor", ->
   [rootView, project, buffer, editor, cachedLineHeight] = []
 
   getLineHeight = ->

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -43,7 +43,7 @@ describe "Editor", ->
       expect(-> new Editor).toThrow()
 
   describe ".copy()", ->
-    fit "builds a new editor with the same edit sessions, cursor position, and scroll position as the receiver", ->
+    it "builds a new editor with the same edit sessions, cursor position, and scroll position as the receiver", ->
       rootView.attachToDom()
       rootView.height(8 * editor.lineHeight)
       rootView.width(50 * editor.charWidth)
@@ -238,6 +238,7 @@ describe "Editor", ->
         editor.setSelectedBufferRange([[40, 0], [43, 1]])
         expect(editor.getSelection().getScreenRange()).toEqual [[40, 0], [43, 1]]
         previousScrollHeight = editor.verticalScrollbar.prop('scrollHeight')
+
         editor.scrollTop(750)
         expect(editor.scrollTop()).toBe 750
 

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -43,7 +43,7 @@ describe "Editor", ->
       expect(-> new Editor).toThrow()
 
   describe ".copy()", ->
-    it "builds a new editor with the same edit sessions, cursor position, and scroll position as the receiver", ->
+    fit "builds a new editor with the same edit sessions, cursor position, and scroll position as the receiver", ->
       rootView.attachToDom()
       rootView.height(8 * editor.lineHeight)
       rootView.width(50 * editor.charWidth)

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -1398,7 +1398,7 @@ fdescribe "Editor", ->
         expect(editor.renderedLines.width()).toBeGreaterThan editor.scrollView.width()
         widthBefore = editor.renderedLines.width()
         buffer.delete([[12, 0], [12, Infinity]])
-        expect(editor.renderedLines.width()).toBe editor.scrollView.width()
+        expect(editor.renderedLines.width()).toBe editor.scrollView.width() + 20
 
       describe "when the change the precedes the first rendered row", ->
         it "removes rendered lines to account for upstream change", ->
@@ -1502,6 +1502,7 @@ fdescribe "Editor", ->
         editor.attachToDom()
         editor.setInvisibles(rootView.getInvisibles())
         editor.setText " a line with tabs\tand spaces "
+
         expect(editor.showInvisibles).toBeFalsy()
         expect(editor.renderedLines.find('.line').text()).toBe " a line with tabs  and spaces "
         editor.setShowInvisibles(true)

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -1205,15 +1205,20 @@ describe "Editor", ->
         expect(editor.renderedLines.find('.line:last').text()).toBe buffer.lineForRow(7)
 
       it "renders additional lines when the editor is resized", ->
+        editor.logRenderedLines()
         setEditorHeightInLines(editor, 10)
+        editor.logRenderedLines()
         $(window).trigger 'resize'
 
         expect(editor.renderedLines.find('.line').length).toBe 12
         expect(editor.renderedLines.find('.line:first').text()).toBe buffer.lineForRow(0)
         expect(editor.renderedLines.find('.line:last').text()).toBe buffer.lineForRow(11)
 
-      it "renders correctly when scrolling after text is added to the buffer", ->
+      ffit "renders correctly when scrolling after text is added to the buffer", ->
+        editor.logRenderedLines()
         editor.insertText("1\n")
+        editor.logRenderedLines()
+
         _.times 4, -> editor.moveCursorDown()
         expect(editor.renderedLines.find('.line:eq(2)').text()).toBe editor.lineForBufferRow(2)
         expect(editor.renderedLines.find('.line:eq(7)').text()).toBe editor.lineForBufferRow(7)

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -1339,7 +1339,7 @@ fdescribe "Editor", ->
         editor.attachToDom(heightInLines: 5)
         spyOn(editor, "scrollTo")
 
-      describe "when the change the precedes the first rendered row", ->
+      describe "when the change precedes the first rendered row", ->
         it "inserts and removes rendered lines to account for upstream change", ->
           editor.scrollToBottom()
           expect(editor.renderedLines.find(".line").length).toBe 7
@@ -1347,9 +1347,9 @@ fdescribe "Editor", ->
           expect(editor.renderedLines.find(".line:last").text()).toBe buffer.lineForRow(12)
 
           buffer.change([[1,0], [3,0]], "1\n2\n3\n")
-          expect(editor.renderedLines.find(".line").length).toBe 8
+          expect(editor.renderedLines.find(".line").length).toBe 7
           expect(editor.renderedLines.find(".line:first").text()).toBe buffer.lineForRow(6)
-          expect(editor.renderedLines.find(".line:last").text()).toBe buffer.lineForRow(13)
+          expect(editor.renderedLines.find(".line:last").text()).toBe buffer.lineForRow(12)
 
       describe "when the change straddles the first rendered row", ->
         it "doesn't render rows that were not previously rendered", ->
@@ -1360,9 +1360,9 @@ fdescribe "Editor", ->
           expect(editor.renderedLines.find(".line:last").text()).toBe buffer.lineForRow(12)
 
           buffer.change([[2,0], [7,0]], "2\n3\n4\n5\n6\n7\n8\n9\n")
-          expect(editor.renderedLines.find(".line").length).toBe 9
+          expect(editor.renderedLines.find(".line").length).toBe 7
           expect(editor.renderedLines.find(".line:first").text()).toBe buffer.lineForRow(6)
-          expect(editor.renderedLines.find(".line:last").text()).toBe buffer.lineForRow(14)
+          expect(editor.renderedLines.find(".line:last").text()).toBe buffer.lineForRow(12)
 
       describe "when the change straddles the last rendered row", ->
         it "doesn't render rows that were not previously rendered", ->

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -907,7 +907,7 @@ describe "Editor", ->
         editor.setCursorScreenPosition(row: 2, column: 2)
         expect(editor.getCursorView().position()).toEqual(top: 2 * editor.lineHeight, left: 2 * editor.charWidth)
 
-      it "removes the idle class while moving, then adds it back when it stops", ->
+      xit "removes the idle class while moving, then adds it back when it stops", ->
         cursorView = editor.getCursorView()
         advanceClock(200)
 

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -659,13 +659,11 @@ describe "Editor", ->
       it "places an additional cursor", ->
         editor.attachToDom()
         setEditorHeightInLines(editor, 5)
-        editor.renderedLines.trigger mousedownEvent(editor: editor, point: [3, 0])
+        editor.setCursorBufferPosition([3, 0])
         editor.scrollTop(editor.lineHeight * 6)
 
-        spyOn(editor, "scrollTo").andCallThrough()
-
         editor.renderedLines.trigger mousedownEvent(editor: editor, point: [6, 0], metaKey: true)
-        expect(editor.scrollTo.callCount).toBe 1
+        expect(editor.scrollTop()).toBe editor.lineHeight * (6 - editor.vScrollMargin)
 
         [cursor1, cursor2] = editor.getCursorViews()
         expect(cursor1.position()).toEqual(top: 3 * editor.lineHeight, left: 0)

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -9,7 +9,7 @@ $ = require 'jquery'
 _ = require 'underscore'
 fs = require 'fs'
 
-describe "Editor", ->
+fdescribe "Editor", ->
   [rootView, project, buffer, editor, cachedLineHeight] = []
 
   getLineHeight = ->
@@ -1205,20 +1205,15 @@ describe "Editor", ->
         expect(editor.renderedLines.find('.line:last').text()).toBe buffer.lineForRow(7)
 
       it "renders additional lines when the editor is resized", ->
-        editor.logRenderedLines()
         setEditorHeightInLines(editor, 10)
-        editor.logRenderedLines()
         $(window).trigger 'resize'
 
         expect(editor.renderedLines.find('.line').length).toBe 12
         expect(editor.renderedLines.find('.line:first').text()).toBe buffer.lineForRow(0)
         expect(editor.renderedLines.find('.line:last').text()).toBe buffer.lineForRow(11)
 
-      ffit "renders correctly when scrolling after text is added to the buffer", ->
-        editor.logRenderedLines()
+      it "renders correctly when scrolling after text is added to the buffer", ->
         editor.insertText("1\n")
-        editor.logRenderedLines()
-
         _.times 4, -> editor.moveCursorDown()
         expect(editor.renderedLines.find('.line:eq(2)').text()).toBe editor.lineForBufferRow(2)
         expect(editor.renderedLines.find('.line:eq(7)').text()).toBe editor.lineForBufferRow(7)
@@ -1501,58 +1496,6 @@ describe "Editor", ->
         rootView.attachToDom()
         buffer.insert([0, 0], "–")
         expect(editor.find('.line:eq(0)').outerHeight()).toBe editor.find('.line:eq(1)').outerHeight()
-
-    describe ".spliceLineElements(startRow, rowCount, lineElements)", ->
-      elements = null
-
-      beforeEach ->
-        editor.attachToDom()
-        elements = $$ ->
-          @div "A", class: 'line'
-          @div "B", class: 'line'
-
-      describe "when the start row is 0", ->
-        describe "when the row count is 0", ->
-          it "inserts the given elements before the first row", ->
-            editor.spliceLineElements 0, 0, elements
-
-            expect(editor.renderedLines.find('.line:eq(0)').text()).toBe 'A'
-            expect(editor.renderedLines.find('.line:eq(1)').text()).toBe 'B'
-            expect(editor.renderedLines.find('.line:eq(2)').text()).toBe 'var quicksort = function () {'
-
-        describe "when the row count is > 0", ->
-          it "replaces the initial rows with the given elements", ->
-            editor.spliceLineElements 0, 2, elements
-
-            expect(editor.renderedLines.find('.line:eq(0)').text()).toBe 'A'
-            expect(editor.renderedLines.find('.line:eq(1)').text()).toBe 'B'
-            expect(editor.renderedLines.find('.line:eq(2)').text()).toBe '    if (items.length <= 1) return items;'
-
-      describe "when the start row is less than the last row", ->
-        describe "when the row count is 0", ->
-          it "inserts the elements at the specified location", ->
-            editor.spliceLineElements 2, 0, elements
-
-            expect(editor.renderedLines.find('.line:eq(2)').text()).toBe 'A'
-            expect(editor.renderedLines.find('.line:eq(3)').text()).toBe 'B'
-            expect(editor.renderedLines.find('.line:eq(4)').text()).toBe '    if (items.length <= 1) return items;'
-
-        describe "when the row count is > 0", ->
-          it "replaces the elements at the specified location", ->
-            editor.spliceLineElements 2, 2, elements
-
-            expect(editor.renderedLines.find('.line:eq(2)').text()).toBe 'A'
-            expect(editor.renderedLines.find('.line:eq(3)').text()).toBe 'B'
-            expect(editor.renderedLines.find('.line:eq(4)').text()).toBe '    while(items.length > 0) {'
-
-      describe "when the start row is the last row", ->
-        it "appends the elements to the end of the lines", ->
-          editor.spliceLineElements 13, 0, elements
-
-          expect(editor.renderedLines.find('.line:eq(12)').text()).toBe '};'
-          expect(editor.renderedLines.find('.line:eq(13)').text()).toBe 'A'
-          expect(editor.renderedLines.find('.line:eq(14)').text()).toBe 'B'
-          expect(editor.renderedLines.find('.line:eq(15)')).not.toExist()
 
     describe "when editor.setShowInvisibles is called", ->
       it "displays spaces as •, tabs as ▸ and newlines as ¬ when true", ->

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -1802,7 +1802,7 @@ describe "Editor", ->
     describe "when a selected fold is scrolled into view (and the fold line was not previously rendered)", ->
       it "renders the fold's line element with the 'selected' class", ->
         setEditorHeightInLines(editor, 5)
-        editor.renderLines() # re-render lines so certain lines are not rendered
+        editor.resetDisplay()
 
         editor.createFold(2, 4)
         editor.setSelectedBufferRange([[1, 0], [5, 0]], preserveFolds: true)

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -935,11 +935,11 @@ describe "Editor", ->
 
         editor.setSelectedBufferRange([[0, 0], [3, 0]])
         expect(editor.getSelection().isEmpty()).toBeFalsy()
-        expect(cursorView).not.toBeVisible()
+        expect(cursorView.css('visibility')).toBe 'hidden'
 
         editor.setCursorBufferPosition([1, 3])
         expect(editor.getSelection().isEmpty()).toBeTruthy()
-        expect(cursorView).toBeVisible()
+        expect(cursorView.css('visibility')).toBe 'visible'
 
       describe "auto-scrolling", ->
         it "only auto-scrolls when the last cursor is moved", ->
@@ -1794,10 +1794,10 @@ describe "Editor", ->
 
         editor.setCursorScreenPosition([2,0])
         expect(editor.lineElementForScreenRow(2)).toMatchSelector('.fold.selected')
-        expect(editor.find('.cursor').css('display')).toBe 'none'
+        expect(editor.find('.cursor').css('visibility')).toBe 'hidden'
 
         editor.setCursorScreenPosition([3,0])
-        expect(editor.find('.cursor').css('display')).toBe 'block'
+        expect(editor.find('.cursor').css('visibility')).toBe 'visible'
 
     describe "when a selected fold is scrolled into view (and the fold line was not previously rendered)", ->
       it "renders the fold's line element with the 'selected' class", ->

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -1382,7 +1382,7 @@ fdescribe "Editor", ->
         maxLineLength = editor.maxScreenLineLength()
         setEditorWidthInChars(editor, maxLineLength)
         widthBefore = editor.renderedLines.width()
-        expect(widthBefore).toBe editor.scrollView.width()
+        expect(widthBefore).toBe editor.scrollView.width() + 20
         buffer.change([[12,0], [12,0]], [1..maxLineLength*2].join(''))
         expect(editor.renderedLines.width()).toBeGreaterThan widthBefore
 

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -819,8 +819,8 @@ fdescribe "Editor", ->
           expect(region1.position().top).toBeCloseTo(2 * lineHeight)
           expect(region1.position().left).toBeCloseTo(7 * charWidth)
           expect(region1.height()).toBeCloseTo lineHeight
-          expect(region1.width()).toBeCloseTo(editor.renderedLines.outerWidth() - region1.position().left)
 
+          expect(region1.width()).toBeCloseTo(editor.renderedLines.outerWidth() - region1.position().left)
           region2 = selectionView.regions[1]
           expect(region2.position().top).toBeCloseTo(3 * lineHeight)
           expect(region2.position().left).toBeCloseTo(0)
@@ -837,8 +837,8 @@ fdescribe "Editor", ->
           expect(region1.position().top).toBeCloseTo(2 * lineHeight)
           expect(region1.position().left).toBeCloseTo(7 * charWidth)
           expect(region1.height()).toBeCloseTo lineHeight
-          expect(region1.width()).toBeCloseTo(editor.renderedLines.outerWidth() - region1.position().left)
 
+          expect(region1.width()).toBeCloseTo(editor.renderedLines.outerWidth() - region1.position().left)
           region2 = selectionView.regions[1]
           expect(region2.position().top).toBeCloseTo(3 * lineHeight)
           expect(region2.position().left).toBeCloseTo(0)

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -483,6 +483,8 @@ fdescribe "Editor", ->
     describe "when the font size changes on the view", ->
       it "updates the font sizes of editors and recalculates dimensions critical to cursor positioning", ->
         rootView.attachToDom()
+        rootView.height(200)
+        rootView.width(200)
         rootView.setFontSize(10)
         lineHeightBefore = editor.lineHeight
         charWidthBefore = editor.charWidth

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -863,7 +863,7 @@ describe "Editor", ->
         expect(selectionView.regions.length).toBe 3
         expect(selectionView.find('.selection').length).toBe 3
 
-        selectionView.updateAppearance()
+        selectionView.updateDisplay()
         expect(selectionView.regions.length).toBe 3
         expect(selectionView.find('.selection').length).toBe 3
 

--- a/spec/app/status-bar-spec.coffee
+++ b/spec/app/status-bar-spec.coffee
@@ -15,10 +15,6 @@ describe "StatusBar", ->
     statusBar = rootView.find('.status-bar').view()
     buffer = editor.getBuffer()
 
-    # updating the status bar is asynchronous for performance reasons
-    # for testing purposes, make it synchronous
-    spyOn(_, 'delay').andCallFake (fn) -> fn()
-
   afterEach ->
     rootView.remove()
 
@@ -56,6 +52,7 @@ describe "StatusBar", ->
     it "enables the buffer modified indicator", ->
       expect(statusBar.bufferModified.text()).toBe ''
       editor.insertText("\n")
+      advanceClock(buffer.stoppedChangingDelay)
       expect(statusBar.bufferModified.text()).toBe '*'
       editor.backspace()
 
@@ -66,6 +63,7 @@ describe "StatusBar", ->
       rootView.open(path)
       expect(statusBar.bufferModified.text()).toBe ''
       editor.insertText("\n")
+      advanceClock(buffer.stoppedChangingDelay)
       expect(statusBar.bufferModified.text()).toBe '*'
       editor.save()
       expect(statusBar.bufferModified.text()).toBe ''
@@ -73,15 +71,19 @@ describe "StatusBar", ->
     it "disables the buffer modified indicator if the content matches again", ->
       expect(statusBar.bufferModified.text()).toBe ''
       editor.insertText("\n")
+      advanceClock(buffer.stoppedChangingDelay)
       expect(statusBar.bufferModified.text()).toBe '*'
       editor.backspace()
+      advanceClock(buffer.stoppedChangingDelay)
       expect(statusBar.bufferModified.text()).toBe ''
 
     it "disables the buffer modified indicator when the change is undone", ->
       expect(statusBar.bufferModified.text()).toBe ''
       editor.insertText("\n")
+      advanceClock(buffer.stoppedChangingDelay)
       expect(statusBar.bufferModified.text()).toBe '*'
       editor.undo()
+      advanceClock(buffer.stoppedChangingDelay)
       expect(statusBar.bufferModified.text()).toBe ''
 
   describe "when the buffer changes", ->
@@ -89,6 +91,7 @@ describe "StatusBar", ->
       expect(statusBar.bufferModified.text()).toBe ''
       rootView.open(require.resolve('fixtures/sample.txt'))
       editor.insertText("\n")
+      advanceClock(buffer.stoppedChangingDelay)
       expect(statusBar.bufferModified.text()).toBe '*'
 
     it "doesn't update the buffer modified indicator for the old buffer", ->
@@ -96,6 +99,7 @@ describe "StatusBar", ->
      expect(statusBar.bufferModified.text()).toBe ''
      rootView.open(require.resolve('fixtures/sample.txt'))
      oldBuffer.setText("new text")
+     advanceClock(buffer.stoppedChangingDelay)
      expect(statusBar.bufferModified.text()).toBe ''
 
   describe "when the associated editor's cursor position changes", ->

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -7,6 +7,7 @@ Project = require 'project'
 Directory = require 'directory'
 File = require 'file'
 RootView = require 'root-view'
+Editor = require 'editor'
 TextMateBundle = require 'text-mate-bundle'
 TextMateTheme = require 'text-mate-theme'
 fs = require 'fs'
@@ -21,6 +22,9 @@ beforeEach ->
   window.fixturesProject = new Project(require.resolve('fixtures'))
   window.resetTimeouts()
   pathsWithSubscriptions = []
+
+  # make editor display updates synchronous
+  spyOn(Editor.prototype, 'requestDisplayUpdate').andCallFake -> @updateDisplay()
 
 afterEach ->
   delete window.rootView if window.rootView

--- a/src/app/atom.coffee
+++ b/src/app/atom.coffee
@@ -25,6 +25,9 @@ atom.receiveMessageFromBrowserProcess = (name, data) ->
 atom.open = (args...) ->
   @sendMessageToBrowserProcess('open', args)
 
+atom.openUnstable = (args...) ->
+  @sendMessageToBrowserProcess('openUnstable', args)
+
 atom.newWindow = (args...) ->
   @sendMessageToBrowserProcess('newWindow', args)
 

--- a/src/app/buffer-change-operation.coffee
+++ b/src/app/buffer-change-operation.coffee
@@ -41,6 +41,8 @@ class BufferChangeOperation
 
     event = { oldRange, newRange, oldText, newText }
     @buffer.trigger 'change', event
+    @buffer.scheduleStoppedChangingEvent()
+
     anchor.handleBufferChange(event) for anchor in @buffer.getAnchors()
     @buffer.trigger 'update-anchors-after-change'
     newRange

--- a/src/app/buffer.coffee
+++ b/src/app/buffer.coffee
@@ -13,6 +13,8 @@ Git = require 'git'
 module.exports =
 class Buffer
   @idCounter = 1
+  stoppedChangingDelay: 300
+  stoppedChangingTimeout: null
   undoManager: null
   cachedDiskContents: null
   cachedMemoryContents: null
@@ -377,5 +379,12 @@ class Buffer
     return unless path
     if @git?.checkoutHead(path)
       @trigger 'git-status-change'
+
+  scheduleStoppedChangingEvent: ->
+    clearTimeout(@stoppedChangingTimeout) if @stoppedChangingTimeout
+    stoppedChangingCallback = =>
+      @stoppedChangingTimeout = null
+      @trigger 'stopped-changing'
+    @stoppedChangingTimeout = setTimeout(stoppedChangingCallback, @stoppedChangingDelay)
 
 _.extend(Buffer.prototype, EventEmitter)

--- a/src/app/cursor-view.coffee
+++ b/src/app/cursor-view.coffee
@@ -21,12 +21,9 @@ class CursorView extends View
       @trigger 'cursor-move', {bufferChange}
 
     @cursor.on 'change-visibility.cursor-view', (visible) => @setVisible(visible)
-    @cursor.on 'destroy.cursor-view', => @remove()
-
-  afterAttach: (onDom) ->
-    return unless onDom
-    @updateDisplay(autoscroll: @autoscrollOnAttach)
-    @editor.syncCursorAnimations()
+    @cursor.on 'destroy.cursor-view', =>
+      @destroyed = true
+      @editor.updateDisplay()
 
   remove: ->
     @editor.removeCursorView(this)

--- a/src/app/cursor-view.coffee
+++ b/src/app/cursor-view.coffee
@@ -11,10 +11,8 @@ class CursorView extends View
 
   editor: null
   visible: true
-  autoscrollOnAttach: null
 
   initialize: (@cursor, @editor, options={}) ->
-    @autoscrollOnAttach = options.autoscroll ? true
     @cursor.on 'change-screen-position.cursor-view', (screenPosition, { bufferChange, autoscroll }) =>
       @updateDisplay({autoscroll})
       @removeIdleClassTemporarily() unless bufferChange

--- a/src/app/cursor-view.coffee
+++ b/src/app/cursor-view.coffee
@@ -22,10 +22,6 @@ class CursorView extends View
       @needsAutoscroll = (autoscroll ? true) and @cursor?.isLastCursor()
       @editor.requestDisplayUpdate()
 
-      # TODO: Move idle/active to the cursor model
-#       @removeIdleClassTemporarily() unless bufferChange
-      @trigger 'cursor-move', {bufferChange}
-
     @cursor.on 'change-visibility.cursor-view', (visible) =>
       @needsUpdate = true
       @needsAutoscroll = visible and @cursor.isLastCursor()
@@ -47,6 +43,8 @@ class CursorView extends View
     unless _.isEqual(@lastPixelPosition, pixelPosition)
       changedPosition = true
       @css(pixelPosition)
+#       @removeIdleClassTemporarily() unless bufferChange
+      @trigger 'cursor-move'
 
     @setVisible(@cursor.isVisible() and not @editor.isFoldedAtScreenRow(screenPosition.row))
 

--- a/src/app/cursor-view.coffee
+++ b/src/app/cursor-view.coffee
@@ -23,7 +23,7 @@ class CursorView extends View
 
   afterAttach: (onDom) ->
     return unless onDom
-    @updateDisplay()
+    @updateDisplay(autoscroll: false)
     @editor.syncCursorAnimations()
 
   remove: ->

--- a/src/app/cursor-view.coffee
+++ b/src/app/cursor-view.coffee
@@ -11,8 +11,10 @@ class CursorView extends View
 
   editor: null
   visible: true
+  autoscrollOnAttach: null
 
-  initialize: (@cursor, @editor) ->
+  initialize: (@cursor, @editor, options={}) ->
+    @autoscrollOnAttach = options.autoscroll ? true
     @cursor.on 'change-screen-position.cursor-view', (screenPosition, { bufferChange, autoscroll }) =>
       @updateDisplay({autoscroll})
       @removeIdleClassTemporarily() unless bufferChange
@@ -23,7 +25,7 @@ class CursorView extends View
 
   afterAttach: (onDom) ->
     return unless onDom
-    @updateDisplay(autoscroll: false)
+    @updateDisplay(autoscroll: @autoscrollOnAttach)
     @editor.syncCursorAnimations()
 
   remove: ->
@@ -43,7 +45,6 @@ class CursorView extends View
     @editor.pixelPositionForScreenPosition(@getScreenPosition())
 
   autoscroll: ->
-    pixelPosition =
     @editor.scrollTo(@getPixelPosition())
 
   setVisible: (visible) ->

--- a/src/app/cursor-view.coffee
+++ b/src/app/cursor-view.coffee
@@ -20,20 +20,20 @@ class CursorView extends View
     @cursor.on 'change-screen-position.cursor-view', (screenPosition, { bufferChange, autoscroll }) =>
       @needsUpdate = true
       @needsAutoscroll = (autoscroll ? true) and @cursor?.isLastCursor()
-      @editor.updateDisplay()
+      @editor.requestDisplayUpdate()
 
       # TODO: Move idle/active to the cursor model
-      @removeIdleClassTemporarily() unless bufferChange
+#       @removeIdleClassTemporarily() unless bufferChange
       @trigger 'cursor-move', {bufferChange}
 
     @cursor.on 'change-visibility.cursor-view', (visible) =>
       @needsUpdate = true
       @needsAutoscroll = visible and @cursor.isLastCursor()
-      @editor.updateDisplay()
+      @editor.requestDisplayUpdate()
 
     @cursor.on 'destroy.cursor-view', =>
       @needsRemoval = true
-      @editor.updateDisplay()
+      @editor.requestDisplayUpdate()
 
   remove: ->
     @editor.removeCursorView(this)

--- a/src/app/cursor-view.coffee
+++ b/src/app/cursor-view.coffee
@@ -14,7 +14,7 @@ class CursorView extends View
 
   initialize: (@cursor, @editor) ->
     @cursor.on 'change-screen-position.cursor-view', (screenPosition, { bufferChange, autoscroll }) =>
-      @updateAppearance({autoscroll})
+      @updateDisplay({autoscroll})
       @removeIdleClassTemporarily() unless bufferChange
       @trigger 'cursor-move', {bufferChange}
 
@@ -23,7 +23,7 @@ class CursorView extends View
 
   afterAttach: (onDom) ->
     return unless onDom
-    @updateAppearance()
+    @updateDisplay()
     @editor.syncCursorAnimations()
 
   remove: ->
@@ -31,7 +31,7 @@ class CursorView extends View
     @cursor.off('.cursor-view')
     super
 
-  updateAppearance: (options={}) ->
+  updateDisplay: (options={}) ->
     autoscroll = options.autoscroll ? true
     screenPosition = @getScreenPosition()
     pixelPosition = @getPixelPosition()

--- a/src/app/display-buffer.coffee
+++ b/src/app/display-buffer.coffee
@@ -207,7 +207,7 @@ class DisplayBuffer
     @trigger 'change',
       oldRange: oldScreenRange
       newRange: newScreenRange
-      bufferChanged: true
+      bufferChange: e.bufferChange
       lineNumbersChanged: !e.oldRange.coversSameRows(newRange) or !oldScreenRange.coversSameRows(newScreenRange)
 
   buildLineForBufferRow: (bufferRow) ->

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -263,7 +263,7 @@ class EditSession
     @setCursorBufferPosition([fold.startRow, 0])
 
   isFoldedAtScreenRow: (screenRow) ->
-    @lineForScreenRow(screenRow).fold?
+    @lineForScreenRow(screenRow)?.fold?
 
   largestFoldContainingBufferRow: (bufferRow) ->
     @displayBuffer.largestFoldContainingBufferRow(bufferRow)

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -61,7 +61,7 @@ class EditSession
 
     @displayBuffer.on "change.edit-session-#{@id}", (e) =>
       @trigger 'screen-lines-change', e
-      unless e.bufferChanged
+      unless e.bufferChange
         anchor.refreshScreenPosition() for anchor in @getAnchors()
 
   destroy: ->

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -60,9 +60,8 @@ class EditSession
       @mergeCursors()
 
     @displayBuffer.on "change.edit-session-#{@id}", (e) =>
+      @refreshAnchorScreenPositions() unless e.bufferChange
       @trigger 'screen-lines-change', e
-      unless e.bufferChange
-        anchor.refreshScreenPosition() for anchor in @getAnchors()
 
   destroy: ->
     throw new Error("Edit session already destroyed") if @destroyed
@@ -331,6 +330,9 @@ class EditSession
 
   removeAnchor: (anchor) ->
     _.remove(@anchors, anchor)
+
+  refreshAnchorScreenPositions: ->
+    anchor.refreshScreenPosition() for anchor in @getAnchors()
 
   removeAnchorRange: (anchorRange) ->
     _.remove(@anchorRanges, anchorRange)

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -744,7 +744,7 @@ class Editor extends View
 
   renderLines: ->
     @clearRenderedLines()
-    @updateRenderedLines(reset: true)
+    @updateRenderedLines()
 
   clearRenderedLines: ->
     @lineCache = []

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -460,7 +460,7 @@ class Editor extends View
     return if scrollTop == @cachedScrollTop
     @cachedScrollTop = scrollTop
 
-    @requestDisplayUpdate() if @attached
+    @updateDisplay() if @attached
 
     @renderedLines.css('top', -scrollTop)
     @underlayer.css('top', -scrollTop)

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -776,6 +776,7 @@ class Editor extends View
     @lastRenderedScreenRow = renderTo
     @updatePaddingOfRenderedLines()
     @adjustMinWidthOfRenderedLines()
+    @gutter.renderLineNumbers(@firstRenderedScreenRow, @lastRenderedScreenRow)
 #     @handleScrollHeightChange()
 
   computeIntactRanges: ->

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -737,11 +737,11 @@ class Editor extends View
 
   updateDisplay: (options={}) ->
     return unless @attached
+    @updateRenderedLines()
+    @highlightCursorLine()
     @updateCursorViews()
     @updateSelectionViews()
     @autoscroll(options)
-    @updateRenderedLines()
-    @highlightCursorLine()
 
   updateCursorViews: ->
     if @newCursors.length > 0

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -792,7 +792,9 @@ class Editor extends View
     if @pendingChanges.length == 0 and @firstRenderedScreenRow and @firstRenderedScreenRow <= renderFrom and renderTo <= @lastRenderedScreenRow
       return
 
+    @gutter.updateLineNumbers(@pendingChanges, renderFrom, renderTo)
     intactRanges = @computeIntactRanges()
+    @pendingChanges = []
     @truncateIntactRanges(intactRanges, renderFrom, renderTo)
     @clearDirtyRanges(intactRanges)
     @fillDirtyRanges(intactRanges, renderFrom, renderTo)
@@ -800,7 +802,6 @@ class Editor extends View
     @lastRenderedScreenRow = renderTo
     @updateLayerDimensions()
     @updatePaddingOfRenderedLines()
-#     @gutter.renderLineNumbers(@firstRenderedScreenRow, @lastRenderedScreenRow)
 
   computeIntactRanges: ->
     return [] if !@firstRenderedScreenRow? and !@lastRenderedScreenRow?
@@ -904,7 +905,11 @@ class Editor extends View
     from = oldRange.start.row
     to = oldRange.end.row
     delta = newRange.end.row - oldRange.end.row
-    @pendingChanges.push({from, to, delta})
+
+    if bufferChange = e.bufferChange
+      bufferDelta = bufferChange.newRange.end.row - bufferChange.oldRange.end.row
+
+    @pendingChanges.push({from, to, delta, bufferDelta})
     @requestDisplayUpdate()
 
   buildLineElementForScreenRow: (screenRow) ->

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -768,7 +768,7 @@ class Editor extends View
 
   syncCursorAnimations: ->
     for cursorView in @getCursorViews()
-      do (cursorView) -> cursorView.resetCursorAnimation()
+      do (cursorView) -> cursorView.resetBlinking()
 
   autoscroll: (options={}) ->
     for cursorView in @getCursorViews() when cursorView.needsAutoscroll

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -642,8 +642,8 @@ class Editor extends View
   getCursorViews: ->
     new Array(@cursorViews...)
 
-  addCursorView: (cursor) ->
-    cursorView = new CursorView(cursor, this)
+  addCursorView: (cursor, options) ->
+    cursorView = new CursorView(cursor, this, options)
     @cursorViews.push(cursorView)
     @overlayer.append(cursorView)
     cursorView
@@ -735,7 +735,7 @@ class Editor extends View
     @updateLayerDimensions()
     @setScrollPositionFromActiveEditSession()
 
-    @addCursorView(cursor) for cursor in @activeEditSession.getCursors()
+    @addCursorView(cursor, autoscroll: false) for cursor in @activeEditSession.getCursors()
     @addSelectionView(selection) for selection in @activeEditSession.getSelections()
 
     @activeEditSession.on 'add-cursor', (cursor) => @addCursorView(cursor)

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -462,7 +462,7 @@ class Editor extends View
     return if scrollTop == @cachedScrollTop
     @cachedScrollTop = scrollTop
 
-    @updateDisplay() if @attached
+    @updateDisplay(autoscroll: false) if @attached
 
     @renderedLines.css('top', -scrollTop)
     @underlayer.css('top', -scrollTop)

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -868,8 +868,10 @@ class Editor extends View
     @renderedLines.css('padding-bottom', paddingBottom)
     @gutter.lineNumbers.css('padding-bottom', paddingBottom)
 
-    @underlayer.height(@screenLineCount() * @lineHeight)
-    @overlayer.height(@screenLineCount() * @lineHeight)
+    linesHeight = @screenLineCount() * @lineHeight
+    @renderedLines.height(linesHeight)
+    @underlayer.height(linesHeight)
+    @overlayer.height(linesHeight)
 
   getFirstVisibleScreenRow: ->
     Math.floor(@scrollTop() / @lineHeight)

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -277,10 +277,10 @@ class Editor extends View
   setShowInvisibles: (showInvisibles) ->
     return if showInvisibles == @showInvisibles
     @showInvisibles = showInvisibles
-    @renderLines()
+    @resetDisplay()
 
   setInvisibles: (@invisibles={}) ->
-    @renderLines()
+    @resetDisplay()
 
   checkoutHead: -> @getBuffer().checkoutHead()
   setText: (text) -> @getBuffer().setText(text)
@@ -736,10 +736,6 @@ class Editor extends View
       @underlayer.css('min-width', minWidth)
       @overlayer.css('min-width', minWidth)
       @layerMinWidth = minWidth
-
-  renderLines: ->
-    @clearRenderedLines()
-    @updateDisplay()
 
   clearRenderedLines: ->
     @renderedLines.empty()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -747,9 +747,7 @@ class Editor extends View
     @updateRenderedLines()
 
   clearRenderedLines: ->
-    @lineCache = []
-    @renderedLines.find('.line').remove()
-
+    @renderedLines.empty()
     @firstRenderedScreenRow = null
     @lastRenderedScreenRow = null
 
@@ -757,14 +755,14 @@ class Editor extends View
     firstVisibleScreenRow = @getFirstVisibleScreenRow()
     lastVisibleScreenRow = @getLastVisibleScreenRow()
 
-    if firstVisibleScreenRow >= @firstRenderedScreenRow and lastVisibleScreenRow <= @lastRenderedScreenRow
+    if @firstRenderedScreenRow? and firstVisibleScreenRow >= @firstRenderedScreenRow and lastVisibleScreenRow <= @lastRenderedScreenRow
       renderFrom = @firstRenderedScreenRow
       renderTo = Math.min(@getLastScreenRow(), @lastRenderedScreenRow)
     else
       renderFrom = Math.max(0, firstVisibleScreenRow - @lineOverdraw)
       renderTo = Math.min(@getLastScreenRow(), lastVisibleScreenRow + @lineOverdraw)
 
-    if @pendingChanges.length == 0 and @firstRenderedScreenRow <= renderFrom and renderTo <= @lastRenderedScreenRow
+    if @pendingChanges.length == 0 and @firstRenderedScreenRow and @firstRenderedScreenRow <= renderFrom and renderTo <= @lastRenderedScreenRow
       return
 
     intactRanges = @computeIntactRanges()
@@ -877,7 +875,7 @@ class Editor extends View
     Math.floor(@scrollTop() / @lineHeight)
 
   getLastVisibleScreenRow: ->
-    Math.ceil((@scrollTop() + @scrollView.height()) / @lineHeight) - 1
+    Math.max(0, Math.ceil((@scrollTop() + @scrollView.height()) / @lineHeight) - 1)
 
   handleDisplayBufferChange: (e) ->
     { oldRange, newRange } = e

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -777,6 +777,7 @@ class Editor extends View
     @updatePaddingOfRenderedLines()
     @adjustMinWidthOfRenderedLines()
     @gutter.renderLineNumbers(@firstRenderedScreenRow, @lastRenderedScreenRow)
+    @highlightCursorLine()
 #     @handleScrollHeightChange()
 
   computeIntactRanges: ->
@@ -951,8 +952,7 @@ class Editor extends View
     line.join('')
 
   lineElementForScreenRow: (screenRow) ->
-    element = @lineCache[screenRow - @firstRenderedScreenRow]
-    $(element)
+    @renderedLines.children(":eq(#{screenRow - @firstRenderedScreenRow})")
 
   logScreenLines: (start, end) ->
     @activeEditSession.logScreenLines(start, end)

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -429,9 +429,6 @@ class Editor extends View
     @activeEditSession.on "buffer-path-change", =>
       @trigger 'editor-path-change'
 
-    @activeEditSession.getSelection().on 'change-screen-range', =>
-      @trigger 'selection-change'
-
     @trigger 'editor-path-change'
     @resetDisplay()
 

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -730,7 +730,7 @@ class Editor extends View
     @renderedLines.css('padding-bottom', heightOfRenderedLines)
 
   adjustMinWidthOfRenderedLines: ->
-    minWidth = @charWidth * @maxScreenLineLength()
+    minWidth = @charWidth * @maxScreenLineLength() + 20
     unless @renderedLines.cachedMinWidth == minWidth
       @renderedLines.css('min-width', minWidth)
       @underlayer.css('min-width', minWidth)

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -889,7 +889,6 @@ class Editor extends View
 
   buildLineElementForScreenRow: (screenRow) ->
     div = document.createElement('div')
-    console.log screenRow, @activeEditSession.lineForScreenRow(screenRow)
     div.innerHTML = @buildLineHtml(@activeEditSession.lineForScreenRow(screenRow))
     div.firstChild
 

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -20,7 +20,9 @@ class Editor extends View
       @subview 'gutter', new Gutter
       @input class: 'hidden-input', outlet: 'hiddenInput'
       @div class: 'scroll-view', outlet: 'scrollView', =>
-        @div class: 'lines', outlet: 'renderedLines', =>
+        @div class: 'overlayer', outlet: 'overlayer'
+        @div class: 'lines', outlet: 'renderedLines'
+        @div class: 'underlayer', outlet: 'underlayer'
       @div class: 'vertical-scrollbar', outlet: 'verticalScrollbar', =>
         @div outlet: 'verticalScrollbarContent'
 
@@ -465,6 +467,8 @@ class Editor extends View
     @updateRenderedLines() if @attached
 
     @renderedLines.css('top', -scrollTop)
+    @underlayer.css('top', -scrollTop)
+    @overlayer.css('top', -scrollTop)
     @gutter.lineNumbers.css('top', -scrollTop)
     if options?.adjustVerticalScrollbar ? true
       @verticalScrollbar.scrollTop(scrollTop)
@@ -661,7 +665,7 @@ class Editor extends View
   addCursorView: (cursor) ->
     cursorView = new CursorView(cursor, this)
     @cursorViews.push(cursorView)
-    @appendToLinesView(cursorView)
+    @overlayer.append(cursorView)
     cursorView
 
   removeCursorView: (cursorView) ->
@@ -689,7 +693,7 @@ class Editor extends View
   addSelectionView: (selection) ->
     selectionView = new SelectionView({editor: this, selection})
     @selectionViews.push(selectionView)
-    @appendToLinesView(selectionView)
+    @underlayer.append(selectionView)
     selectionView
 
   removeSelectionView: (selectionView) ->
@@ -700,11 +704,11 @@ class Editor extends View
     selectionView.remove() for selectionView in @getSelectionViews()
 
   appendToLinesView: (view) ->
-    @renderedLines.append(view)
+    @overlayer.append(view)
 
   calculateDimensions: ->
     fragment = $('<pre class="line" style="position: absolute; visibility: hidden;"><span>x</span></div>')
-    @appendToLinesView(fragment)
+    @renderedLines.append(fragment)
 
     lineRect = fragment[0].getBoundingClientRect()
     charRect = fragment.find('span')[0].getBoundingClientRect()
@@ -729,6 +733,8 @@ class Editor extends View
     minWidth = @charWidth * @maxScreenLineLength()
     unless @renderedLines.cachedMinWidth == minWidth
       @renderedLines.css('min-width', minWidth)
+      @underlayer.css('min-width', minWidth)
+      @overlayer.css('min-width', minWidth)
       @renderedLines.cachedMinWidth = minWidth
 
   handleScrollHeightChange: ->
@@ -859,6 +865,9 @@ class Editor extends View
     paddingBottom = (@getLastScreenRow() - @lastRenderedScreenRow) * @lineHeight
     @renderedLines.css('padding-bottom', paddingBottom)
     @gutter.lineNumbers.css('padding-bottom', paddingBottom)
+
+    @underlayer.height(@screenLineCount() * @lineHeight)
+    @overlayer.height(@screenLineCount() * @lineHeight)
 
   getFirstVisibleScreenRow: ->
     Math.floor(@scrollTop() / @lineHeight)

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -673,11 +673,11 @@ class Editor extends View
 
   updateCursorViews: ->
     for cursorView in @getCursorViews()
-      cursorView.updateAppearance()
+      cursorView.updateDisplay()
 
   updateSelectionViews: ->
     for selectionView in @getSelectionViews()
-      selectionView.updateAppearance()
+      selectionView.updateDisplay()
 
   syncCursorAnimations: ->
     for cursorView in @getCursorViews()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -654,33 +654,6 @@ class Editor extends View
   removeCursorView: (cursorView) ->
     _.remove(@cursorViews, cursorView)
 
-  updateCursorViews: ->
-    if @newCursors.length > 0
-      @addCursorView(cursor) for cursor in @newCursors
-      @syncCursorAnimations()
-      @newCursors = []
-
-    for cursorView in @getCursorViews()
-      if cursorView.needsRemoval
-        cursorView.remove()
-      else if cursorView.needsUpdate
-        cursorView.updateDisplay()
-
-  updateSelectionViews: ->
-    if @newSelections.length > 0
-      @addSelectionView(selection) for selection in @newSelections
-      @newSelections = []
-
-    for selectionView in @getSelectionViews()
-      if selectionView.destroyed
-        selectionView.remove()
-      else
-        selectionView.updateDisplay()
-
-  syncCursorAnimations: ->
-    for cursorView in @getCursorViews()
-      do (cursorView) -> cursorView.resetCursorAnimation()
-
   getSelectionView: (index) ->
     index ?= @selectionViews.length - 1
     @selectionViews[index]
@@ -734,8 +707,6 @@ class Editor extends View
       @renderedLines.css('min-width', minWidth)
       @underlayer.css('min-width', minWidth)
       @overlayer.css('min-width', minWidth)
-    throw new Error("Re-entry into updateDisplay") if @updatingDisplay
-    @updatingDisplay = true
       @layerMinWidth = minWidth
 
   clearRenderedLines: ->
@@ -743,7 +714,6 @@ class Editor extends View
     @firstRenderedScreenRow = null
     @lastRenderedScreenRow = null
 
-    @updatingDisplay = false
   resetDisplay: ->
     return unless @attached
 
@@ -764,11 +734,41 @@ class Editor extends View
     @updateDisplay(suppressAutoScroll: true)
 
   updateDisplay: (options={}) ->
+    throw new Error("Re-entry into updateDisplay") if @updatingDisplay
+    @updatingDisplay = true
     return unless @attached
     @updateCursorViews()
     @updateSelectionViews()
     @autoscroll(options)
     @updateRenderedLines()
+    @updatingDisplay = false
+
+  updateCursorViews: ->
+    if @newCursors.length > 0
+      @addCursorView(cursor) for cursor in @newCursors
+      @syncCursorAnimations()
+      @newCursors = []
+
+    for cursorView in @getCursorViews()
+      if cursorView.needsRemoval
+        cursorView.remove()
+      else if cursorView.needsUpdate
+        cursorView.updateDisplay()
+
+  updateSelectionViews: ->
+    if @newSelections.length > 0
+      @addSelectionView(selection) for selection in @newSelections
+      @newSelections = []
+
+    for selectionView in @getSelectionViews()
+      if selectionView.destroyed
+        selectionView.remove()
+      else
+        selectionView.updateDisplay()
+
+  syncCursorAnimations: ->
+    for cursorView in @getCursorViews()
+      do (cursorView) -> cursorView.resetCursorAnimation()
 
   autoscroll: (options={}) ->
     for cursorView in @getCursorViews() when cursorView.needsAutoscroll

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -734,7 +734,7 @@ class Editor extends View
   requestDisplayUpdate: ()->
     return if @pendingDisplayUpdate
     @pendingDisplayUpdate = true
-    webkitRequestAnimationFrame =>
+    _.nextTick =>
       @updateDisplay()
       @pendingDisplayUpdate = false
 

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -460,13 +460,12 @@ class Editor extends View
 
   scrollTop: (scrollTop, options={}) ->
     return @cachedScrollTop or 0 unless scrollTop?
-    updateDisplay = options.updateDisplay ? true
     maxScrollTop = @verticalScrollbar.prop('scrollHeight') - @verticalScrollbar.height()
     scrollTop = Math.floor(Math.max(0, Math.min(maxScrollTop, scrollTop)))
     return if scrollTop == @cachedScrollTop
     @cachedScrollTop = scrollTop
 
-    @updateDisplay(autoscroll: false) if @attached and updateDisplay
+    @updateDisplay() if @attached and !@updatingDisplay
 
     @renderedLines.css('top', -scrollTop)
     @underlayer.css('top', -scrollTop)
@@ -735,6 +734,8 @@ class Editor extends View
       @renderedLines.css('min-width', minWidth)
       @underlayer.css('min-width', minWidth)
       @overlayer.css('min-width', minWidth)
+    throw new Error("Re-entry into updateDisplay") if @updatingDisplay
+    @updatingDisplay = true
       @layerMinWidth = minWidth
 
   clearRenderedLines: ->
@@ -742,6 +743,7 @@ class Editor extends View
     @firstRenderedScreenRow = null
     @lastRenderedScreenRow = null
 
+    @updatingDisplay = false
   resetDisplay: ->
     return unless @attached
 

--- a/src/app/gutter.coffee
+++ b/src/app/gutter.coffee
@@ -9,7 +9,8 @@ class Gutter extends View
     @div class: 'gutter', =>
       @div outlet: 'lineNumbers', class: 'line-numbers'
 
-  firstScreenRow: -1
+  firstScreenRow: Infinity
+  lastScreenRow: -1
   highestNumberWidth: null
 
   afterAttach: (onDom) ->
@@ -33,9 +34,18 @@ class Gutter extends View
     widthTesterElement.remove()
     lineNumberPadding
 
+  updateLineNumbers: (changes, renderFrom, renderTo) ->
+    if renderFrom < @firstScreenRow or renderTo > @lastScreenRow
+      performUpdate = true
+    else
+      for change in changes
+        if change.delta != 0 or (change.bufferDelta? and change.bufferDelta != 0)
+          performUpdate = true
+          break
+
+    @renderLineNumbers(renderFrom, renderTo) if performUpdate
+
   renderLineNumbers: (startScreenRow, endScreenRow) ->
-    @firstScreenRow = startScreenRow
-    lastScreenRow = -1
     rows = @editor().bufferRowsForScreenRows(startScreenRow, endScreenRow)
 
     cursorScreenRow = @editor().getCursorScreenPosition().row
@@ -49,6 +59,8 @@ class Gutter extends View
         lastScreenRow = row
 
     @calculateWidth()
+    @firstScreenRow = startScreenRow
+    @lastScreenRow = endScreenRow
     @highlightedRow = null
     @highlightCursorLine()
 

--- a/src/app/keymap.coffee
+++ b/src/app/keymap.coffee
@@ -20,11 +20,13 @@ class Keymap
       'meta-n': 'new-window'
       'meta-,': 'open-user-configuration'
       'meta-o': 'open'
+      'meta-O': 'open-unstable'
       'meta-w': 'core:close'
 
     $(document).on 'new-window', => atom.newWindow()
     $(document).on 'open-user-configuration', => atom.open(atom.configFilePath)
     $(document).on 'open', => atom.open()
+    $(document).on 'open-unstable', => atom.openUnstable()
 
   bindKeys: (selector, bindings) ->
     bindingSet = new BindingSet(selector, bindings, @bindingSets.length)

--- a/src/app/line-map.coffee
+++ b/src/app/line-map.coffee
@@ -27,7 +27,7 @@ class LineMap
       @maxScreenLineLength = Math.max(@maxScreenLineLength, screenLine.text.length)
 
   lineForScreenRow: (row) ->
-    @linesForScreenRows(row, row)[0]
+    @screenLines[row]
 
   linesForScreenRows: (startRow, endRow) ->
     @screenLines[startRow..endRow]

--- a/src/app/selection-view.coffee
+++ b/src/app/selection-view.coffee
@@ -22,6 +22,7 @@ class SelectionView extends View
     @clearRegions()
     range = @getScreenRange()
 
+    @trigger 'selection-change'
     @editor.highlightFoldsContainingBufferRange(@getBufferRange())
     return if range.isEmpty()
 

--- a/src/app/selection-view.coffee
+++ b/src/app/selection-view.coffee
@@ -9,12 +9,14 @@ class SelectionView extends View
     @div()
 
   regions: null
+  destroyed: false
 
   initialize: ({@editor, @selection} = {}) ->
     @regions = []
     @selection.on 'change-screen-range', => @updateDisplay()
-    @selection.on 'destroy', => @remove()
-    @updateDisplay()
+    @selection.on 'destroy', =>
+      @destroyed = true
+      @editor.updateDisplay()
 
   updateDisplay: ->
     @clearRegions()

--- a/src/app/selection-view.coffee
+++ b/src/app/selection-view.coffee
@@ -13,10 +13,10 @@ class SelectionView extends View
 
   initialize: ({@editor, @selection} = {}) ->
     @regions = []
-    @selection.on 'change-screen-range', => @updateDisplay()
+    @selection.on 'change-screen-range', => @editor.requestDisplayUpdate()
     @selection.on 'destroy', =>
       @destroyed = true
-      @editor.updateDisplay()
+      @editor.requestDisplayUpdate()
 
   updateDisplay: ->
     @clearRegions()

--- a/src/app/selection-view.coffee
+++ b/src/app/selection-view.coffee
@@ -12,11 +12,11 @@ class SelectionView extends View
 
   initialize: ({@editor, @selection} = {}) ->
     @regions = []
-    @selection.on 'change-screen-range', => @updateAppearance()
+    @selection.on 'change-screen-range', => @updateDisplay()
     @selection.on 'destroy', => @remove()
-    @updateAppearance()
+    @updateDisplay()
 
-  updateAppearance: ->
+  updateDisplay: ->
     @clearRegions()
     range = @getScreenRange()
 

--- a/src/app/selection.coffee
+++ b/src/app/selection.coffee
@@ -13,7 +13,7 @@ class Selection
     @cursor.selection = this
 
     @cursor.on 'change-screen-position.selection', (e) =>
-      @screenRangeChanged() unless e.bufferChanged
+      @screenRangeChanged() unless e.bufferChange
 
     @cursor.on 'destroy.selection', =>
       @cursor = null

--- a/src/app/status-bar.coffee
+++ b/src/app/status-bar.coffee
@@ -42,9 +42,9 @@ class StatusBar extends View
   subscribeToBuffer: ->
     @buffer?.off '.status-bar'
     @buffer = @editor.getBuffer()
-    @buffer.on 'change.status-bar', => _.delay (=> @updateBufferModifiedText()), 50
-    @buffer.on 'after-save.status-bar', => _.delay (=> @updateStatusBar()), 50
-    @buffer.on 'git-status-change.status-bar', => _.delay (=> @updateStatusBar()), 50
+    @buffer.on 'stopped-changing.status-bar', => @updateBufferModifiedText()
+    @buffer.on 'after-save.status-bar', => @updateStatusBar()
+    @buffer.on 'git-status-change.status-bar', => @updateStatusBar()
     @updateStatusBar()
 
   updateStatusBar: ->

--- a/src/extensions/autocomplete/spec/autocomplete-spec.coffee
+++ b/src/extensions/autocomplete/spec/autocomplete-spec.coffee
@@ -360,7 +360,7 @@ describe "Autocomplete", ->
     beforeEach ->
       editor.attachToDom()
       setEditorHeightInLines(editor, 13)
-      editor.renderLines() # Ensures the editor only has 13 lines visible
+      editor.resetDisplay() # Ensures the editor only has 13 lines visible
 
       editor.setCursorBufferPosition [1, 1]
 

--- a/src/extensions/wrap-guide/spec/wrap-guide-spec.coffee
+++ b/src/extensions/wrap-guide/spec/wrap-guide-spec.coffee
@@ -17,10 +17,10 @@ describe "WrapGuide", ->
   describe "@initialize", ->
     it "appends a wrap guide to all existing and new editors", ->
       expect(rootView.panes.find('.pane').length).toBe 1
-      expect(rootView.panes.find('.lines > .wrap-guide').length).toBe 1
+      expect(rootView.panes.find('.underlayer > .wrap-guide').length).toBe 1
       editor.splitRight()
       expect(rootView.find('.pane').length).toBe 2
-      expect(rootView.panes.find('.lines > .wrap-guide').length).toBe 2
+      expect(rootView.panes.find('.underlayer > .wrap-guide').length).toBe 2
 
   describe "@updateGuide", ->
     it "positions the guide at the configured column", ->

--- a/src/extensions/wrap-guide/src/wrap-guide.coffee
+++ b/src/extensions/wrap-guide/src/wrap-guide.coffee
@@ -13,8 +13,8 @@ class WrapGuide extends View
       @appendToEditorPane(rootView, editor, config)
 
   @appendToEditorPane: (rootView, editor, config) ->
-    if lines = editor.pane()?.find('.lines')
-      lines.append(new WrapGuide(rootView, editor, config))
+    if underlayer = editor.pane()?.find('.underlayer')
+      underlayer.append(new WrapGuide(rootView, editor, config))
 
   @content: ->
     @div class: 'wrap-guide'

--- a/src/stdlib/underscore-extensions.coffee
+++ b/src/stdlib/underscore-extensions.coffee
@@ -72,3 +72,13 @@ _.mixin
 
   multiplyString: (string, n) ->
     new Array(1 + n).join(string)
+
+  nextTick: (fn) ->
+    unless @messageChannel
+      @pendingNextTickFns = []
+      @messageChannel = new MessageChannel
+      @messageChannel.port1.onmessage = =>
+        fn() while fn = @pendingNextTickFns.shift()
+
+    @pendingNextTickFns.push(fn)
+    @messageChannel.port2.postMessage(0)

--- a/static/editor.css
+++ b/static/editor.css
@@ -73,6 +73,17 @@
   overflow-x: hidden;
 }
 
+.editor .underlayer, .editor .overlayer {
+  pointer-events: none;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
+.editor .underlayer {
+  z-index: 0;
+}
+
 .editor .lines {
   position: relative;
   display: table;
@@ -80,7 +91,13 @@
   width: 100%;
   /*overflow: hidden; i'm worried this is causing rendering problems */
   padding-right: 2em;
+  z-index: 1;
 }
+
+.editor .overlayer {
+  z-index: 2;
+}
+
 
 .editor .line span {
   vertical-align: top;

--- a/static/editor.css
+++ b/static/editor.css
@@ -73,31 +73,27 @@
   overflow-x: hidden;
 }
 
-.editor .underlayer, .editor .overlayer {
-  pointer-events: none;
-  position: absolute;
+
+.editor .underlayer, .editor .lines, .editor .overlayer {
   width: 100%;
   height: 100%;
 }
 
 .editor .underlayer {
   z-index: 0;
+  position: absolute;
 }
 
 .editor .lines {
   position: relative;
-  display: table;
-  height: 100%;
-  width: 100%;
-  /*overflow: hidden; i'm worried this is causing rendering problems */
-  padding-right: 2em;
   z-index: 1;
 }
 
 .editor .overlayer {
   z-index: 2;
+  pointer-events: none;
+  position: absolute;
 }
-
 
 .editor .line span {
   vertical-align: top;

--- a/static/editor.css
+++ b/static/editor.css
@@ -99,21 +99,9 @@
   vertical-align: top;
 }
 
-@-webkit-keyframes blink {
-  0% { opacity: 1; }
-  60% { opacity: 1; }
-  61% { opacity: 0; }
-  100% { opacity: 0; }
-}
-
 .editor .cursor {
   position: absolute;
   border-left: 2px solid;
-}
-
-.editor.focused .cursor.idle {
-  -webkit-animation: blink 0.8s;
-  -webkit-animation-iteration-count: infinite;
 }
 
 .editor .hidden-input {


### PR DESCRIPTION
Finally, we've gotten to the bottom of our elusive typing performance issues.

The big deal here is that we know update the editor's display on `nextTick`, which we implement with a MessageChannel hack. This means that when an event triggers multiple changes, (like a change in the selection, the cursor position, and the lines in the editor, for example) we don't touch the DOM at all until the end of the event cycle. To do these, we needed to batch up update events on the editor and then have a way of rendering them all at once. Now typing a character updates the screen without any extraneous reflows.

Also, it turns out that blinking the cursor with a CSS animation causes Atom to be less responsive because WebKit is busy sampling the editor's display 60 times a second and sometimes our keystrokes miss a frame. Blinking with a timer is better, so that's what we do now.
