### PR TITLE
Tokenize asynchronously

### DIFF
--- a/spec/app/display-buffer-spec.coffee
+++ b/spec/app/display-buffer-spec.coffee
@@ -565,4 +565,3 @@ describe "DisplayBuffer", ->
   describe ".maxLineLength()", ->
     it "returns the length of the longest screen line", ->
       expect(displayBuffer.maxLineLength()).toBe 65
-

--- a/spec/app/tokenized-buffer-spec.coffee
+++ b/spec/app/tokenized-buffer-spec.coffee
@@ -76,7 +76,6 @@ fdescribe "TokenizedBuffer", ->
 
     describe "when the buffer is fully tokenized", ->
       beforeEach ->
-        console.log "FULLY TOKENIZE"
         fullyTokenize(tokenizedBuffer)
 
       describe "when there is a buffer change that is smaller than the chunk size", ->

--- a/spec/app/tokenized-buffer-spec.coffee
+++ b/spec/app/tokenized-buffer-spec.coffee
@@ -26,7 +26,7 @@ describe "TokenizedBuffer", ->
       expect(tokenizedBuffer.findClosingBracket([1, 29])).toEqual [9, 2]
 
   describe "tokenization", ->
-    it "only creates untokenized screen lines on construction", ->
+    xit "only creates untokenized screen lines on construction", ->
       line0 = tokenizedBuffer.lineForScreenRow(0)
       expect(line0.tokens.length).toBe 1
       expect(line0.tokens[0]).toEqual(value: line0.text, scopes: ['source.js'])
@@ -36,7 +36,7 @@ describe "TokenizedBuffer", ->
       expect(line11.tokens[0]).toEqual(value: "  ", scopes: ['source.js'], isAtomic: true)
       expect(line11.tokens[1]).toEqual(value: "return sort(Array.apply(this, arguments));", scopes: ['source.js'])
 
-    describe "when #tokenizeInBackground() is called", ->
+    xdescribe "when #tokenizeInBackground() is called", ->
       it "tokenizes screen lines one chunk at a time asynchronously after calling #activate()", ->
         tokenizedBuffer.chunkSize = 5
         tokenizedBuffer.tokenizeInBackground()

--- a/spec/app/tokenized-buffer-spec.coffee
+++ b/spec/app/tokenized-buffer-spec.coffee
@@ -4,7 +4,7 @@ Buffer = require 'buffer'
 Range = require 'range'
 _ = require 'underscore'
 
-fdescribe "TokenizedBuffer", ->
+describe "TokenizedBuffer", ->
   [editSession, tokenizedBuffer, buffer, changeHandler] = []
 
   beforeEach ->

--- a/spec/app/tokenized-buffer-spec.coffee
+++ b/spec/app/tokenized-buffer-spec.coffee
@@ -102,8 +102,23 @@ fdescribe "TokenizedBuffer", ->
             expect(tokenizedBuffer.firstInvalidRow()).toBe 8
 
       describe "when there is a buffer change surrounding an invalid row", ->
+        it "pushes the invalid row to the end of the change", ->
+          buffer.change([[4, 0], [6, 0]], "\n\n\n")
+          changeHandler.reset()
+
+          expect(tokenizedBuffer.firstInvalidRow()).toBe 8
+          advanceClock()
 
       describe "when there is a buffer change inside an invalid region", ->
+        it "does not attempt to tokenize the lines in the change, and preserves the existing invalid row", ->
+          expect(tokenizedBuffer.firstInvalidRow()).toBe 5
+          buffer.change([[6, 0], [7, 0]], "\n\n\n")
+
+          expect(tokenizedBuffer.lineForScreenRow(6).ruleStack?).toBeFalsy()
+          expect(tokenizedBuffer.lineForScreenRow(7).ruleStack?).toBeFalsy()
+
+          changeHandler.reset()
+          expect(tokenizedBuffer.firstInvalidRow()).toBe 5
 
     describe "when the buffer is fully tokenized", ->
       beforeEach ->

--- a/spec/app/tokenized-buffer-spec.coffee
+++ b/spec/app/tokenized-buffer-spec.coffee
@@ -67,121 +67,134 @@ describe "TokenizedBuffer", ->
       expect(tokenizedBuffer.lineForScreenRow(0).tokens[0]).toEqual(value: 'var', scopes: ['source.js', 'storage.modifier.js'])
       expect(tokenizedBuffer.lineForScreenRow(11).tokens[1]).toEqual(value: 'return', scopes: ['source.js', 'keyword.control.js'])
 
-    describe "when the buffer changes", ->
-      describe "when lines are updated, but none are added or removed", ->
-        it "updates tokens for each of the changed lines", ->
-          range = new Range([0, 0], [2, 0])
-          buffer.change(range, "foo()\n7\n")
+    describe "when there is a buffer change starting in the tokenized region", ->
+      describe "when the change causes fewer than @chunkSize lines to be retokenized", ->
+        describe "when lines are updated, but none are added or removed", ->
+          it "updates tokens for each of the changed lines", ->
+            range = new Range([0, 0], [2, 0])
+            buffer.change(range, "foo()\n7\n")
 
-          expect(tokenizedBuffer.lineForScreenRow(0).tokens[1]).toEqual(value: '(', scopes: ['source.js', 'meta.brace.round.js'])
-          expect(tokenizedBuffer.lineForScreenRow(1).tokens[0]).toEqual(value: '7', scopes: ['source.js', 'constant.numeric.js'])
-          # line 2 is unchanged
-          expect(tokenizedBuffer.lineForScreenRow(2).tokens[2]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
+            expect(tokenizedBuffer.lineForScreenRow(0).tokens[1]).toEqual(value: '(', scopes: ['source.js', 'meta.brace.round.js'])
+            expect(tokenizedBuffer.lineForScreenRow(1).tokens[0]).toEqual(value: '7', scopes: ['source.js', 'constant.numeric.js'])
+            # line 2 is unchanged
+            expect(tokenizedBuffer.lineForScreenRow(2).tokens[2]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
 
-          expect(changeHandler).toHaveBeenCalled()
-          [event] = changeHandler.argsForCall[0]
-          delete event.bufferChange
-          expect(event).toEqual(start: 0, end: 2, delta: 0)
+            expect(changeHandler).toHaveBeenCalled()
+            [event] = changeHandler.argsForCall[0]
+            delete event.bufferChange
+            expect(event).toEqual(start: 0, end: 2, delta: 0)
 
-        it "updates tokens for lines beyond the changed lines if needed", ->
-          buffer.insert([5, 30], '/* */')
-          changeHandler.reset()
+          it "updates tokens for lines beyond the changed lines if needed", ->
+            buffer.insert([5, 30], '/* */')
+            changeHandler.reset()
 
-          buffer.insert([2, 0], '/*')
-          expect(tokenizedBuffer.lineForScreenRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-          expect(tokenizedBuffer.lineForScreenRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-          expect(tokenizedBuffer.lineForScreenRow(5).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            buffer.insert([2, 0], '/*')
+            expect(tokenizedBuffer.lineForScreenRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.lineForScreenRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.lineForScreenRow(5).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
 
-          expect(changeHandler).toHaveBeenCalled()
-          [event] = changeHandler.argsForCall[0]
-          delete event.bufferChange
-          expect(event).toEqual(start: 2, end: 5, delta: 0)
+            expect(changeHandler).toHaveBeenCalled()
+            [event] = changeHandler.argsForCall[0]
+            delete event.bufferChange
+            expect(event).toEqual(start: 2, end: 5, delta: 0)
 
-        it "resumes highlighting with the state of the previous line", ->
-          buffer.insert([0, 0], '/*')
-          buffer.insert([5, 0], '*/')
+          it "resumes highlighting with the state of the previous line", ->
+            buffer.insert([0, 0], '/*')
+            buffer.insert([5, 0], '*/')
 
-          buffer.insert([1, 0], 'var ')
-          expect(tokenizedBuffer.lineForScreenRow(1).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            buffer.insert([1, 0], 'var ')
+            expect(tokenizedBuffer.lineForScreenRow(1).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
 
-      describe "when lines are both updated and removed", ->
-        it "updates tokens to reflect the removed lines", ->
-          range = new Range([1, 0], [3, 0])
-          buffer.change(range, "foo()")
+        describe "when lines are both updated and removed", ->
+          it "updates tokens to reflect the removed lines", ->
+            range = new Range([1, 0], [3, 0])
+            buffer.change(range, "foo()")
 
-          # previous line 0 remains
-          expect(tokenizedBuffer.lineForScreenRow(0).tokens[0]).toEqual(value: 'var', scopes: ['source.js', 'storage.modifier.js'])
+            # previous line 0 remains
+            expect(tokenizedBuffer.lineForScreenRow(0).tokens[0]).toEqual(value: 'var', scopes: ['source.js', 'storage.modifier.js'])
 
-          # previous line 3 should be combined with input to form line 1
-          expect(tokenizedBuffer.lineForScreenRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js'])
-          expect(tokenizedBuffer.lineForScreenRow(1).tokens[6]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
+            # previous line 3 should be combined with input to form line 1
+            expect(tokenizedBuffer.lineForScreenRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js'])
+            expect(tokenizedBuffer.lineForScreenRow(1).tokens[6]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
 
-          # lines below deleted regions should be shifted upward
-          expect(tokenizedBuffer.lineForScreenRow(2).tokens[2]).toEqual(value: 'while', scopes: ['source.js', 'keyword.control.js'])
-          expect(tokenizedBuffer.lineForScreenRow(3).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
-          expect(tokenizedBuffer.lineForScreenRow(4).tokens[4]).toEqual(value: '<', scopes: ['source.js', 'keyword.operator.js'])
+            # lines below deleted regions should be shifted upward
+            expect(tokenizedBuffer.lineForScreenRow(2).tokens[2]).toEqual(value: 'while', scopes: ['source.js', 'keyword.control.js'])
+            expect(tokenizedBuffer.lineForScreenRow(3).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
+            expect(tokenizedBuffer.lineForScreenRow(4).tokens[4]).toEqual(value: '<', scopes: ['source.js', 'keyword.operator.js'])
 
-          expect(changeHandler).toHaveBeenCalled()
-          [event] = changeHandler.argsForCall[0]
-          delete event.bufferChange
-          expect(event).toEqual(start: 1, end: 3, delta: -2)
+            expect(changeHandler).toHaveBeenCalled()
+            [event] = changeHandler.argsForCall[0]
+            delete event.bufferChange
+            expect(event).toEqual(start: 1, end: 3, delta: -2)
 
-        it "updates tokens for lines beyond the changed lines if needed", ->
-          buffer.insert([5, 30], '/* */')
-          changeHandler.reset()
+          it "updates tokens for lines beyond the changed lines if needed", ->
+            buffer.insert([5, 30], '/* */')
+            changeHandler.reset()
 
-          buffer.change(new Range([2, 0], [3, 0]), '/*')
-          expect(tokenizedBuffer.lineForScreenRow(2).tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
-          expect(tokenizedBuffer.lineForScreenRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-          expect(tokenizedBuffer.lineForScreenRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            buffer.change(new Range([2, 0], [3, 0]), '/*')
+            expect(tokenizedBuffer.lineForScreenRow(2).tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
+            expect(tokenizedBuffer.lineForScreenRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.lineForScreenRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
 
-          expect(changeHandler).toHaveBeenCalled()
-          [event] = changeHandler.argsForCall[0]
-          delete event.bufferChange
-          expect(event).toEqual(start: 2, end: 5, delta: -1)
+            expect(changeHandler).toHaveBeenCalled()
+            [event] = changeHandler.argsForCall[0]
+            delete event.bufferChange
+            expect(event).toEqual(start: 2, end: 5, delta: -1)
 
-      describe "when lines are both updated and inserted", ->
-        it "updates tokens to reflect the inserted lines", ->
-          range = new Range([1, 0], [2, 0])
-          buffer.change(range, "foo()\nbar()\nbaz()\nquux()")
+        describe "when lines are both updated and inserted", ->
+          it "updates tokens to reflect the inserted lines", ->
+            range = new Range([1, 0], [2, 0])
+            buffer.change(range, "foo()\nbar()\nbaz()\nquux()")
 
-          # previous line 0 remains
-          expect(tokenizedBuffer.lineForScreenRow(0).tokens[0]).toEqual( value: 'var', scopes: ['source.js', 'storage.modifier.js'])
+            # previous line 0 remains
+            expect(tokenizedBuffer.lineForScreenRow(0).tokens[0]).toEqual( value: 'var', scopes: ['source.js', 'storage.modifier.js'])
 
-          # 3 new lines inserted
-          expect(tokenizedBuffer.lineForScreenRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js'])
-          expect(tokenizedBuffer.lineForScreenRow(2).tokens[0]).toEqual(value: 'bar', scopes: ['source.js'])
-          expect(tokenizedBuffer.lineForScreenRow(3).tokens[0]).toEqual(value: 'baz', scopes: ['source.js'])
+            # 3 new lines inserted
+            expect(tokenizedBuffer.lineForScreenRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js'])
+            expect(tokenizedBuffer.lineForScreenRow(2).tokens[0]).toEqual(value: 'bar', scopes: ['source.js'])
+            expect(tokenizedBuffer.lineForScreenRow(3).tokens[0]).toEqual(value: 'baz', scopes: ['source.js'])
 
-          # previous line 2 is joined with quux() on line 4
-          expect(tokenizedBuffer.lineForScreenRow(4).tokens[0]).toEqual(value: 'quux', scopes: ['source.js'])
-          expect(tokenizedBuffer.lineForScreenRow(4).tokens[4]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
+            # previous line 2 is joined with quux() on line 4
+            expect(tokenizedBuffer.lineForScreenRow(4).tokens[0]).toEqual(value: 'quux', scopes: ['source.js'])
+            expect(tokenizedBuffer.lineForScreenRow(4).tokens[4]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
 
-          # previous line 3 is pushed down to become line 5
-          expect(tokenizedBuffer.lineForScreenRow(5).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
+            # previous line 3 is pushed down to become line 5
+            expect(tokenizedBuffer.lineForScreenRow(5).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
 
-          expect(changeHandler).toHaveBeenCalled()
-          [event] = changeHandler.argsForCall[0]
-          delete event.bufferChange
-          expect(event).toEqual(start: 1, end: 2, delta: 2)
+            expect(changeHandler).toHaveBeenCalled()
+            [event] = changeHandler.argsForCall[0]
+            delete event.bufferChange
+            expect(event).toEqual(start: 1, end: 2, delta: 2)
 
-        it "updates tokens for lines beyond the changed lines if needed", ->
-          buffer.insert([5, 30], '/* */')
-          changeHandler.reset()
+          it "updates tokens for lines beyond the changed lines if needed", ->
+            buffer.insert([5, 30], '/* */')
+            changeHandler.reset()
 
-          buffer.insert([2, 0], '/*\nabcde\nabcder')
-          expect(tokenizedBuffer.lineForScreenRow(2).tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
-          expect(tokenizedBuffer.lineForScreenRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-          expect(tokenizedBuffer.lineForScreenRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-          expect(tokenizedBuffer.lineForScreenRow(5).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-          expect(tokenizedBuffer.lineForScreenRow(6).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-          expect(tokenizedBuffer.lineForScreenRow(7).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-          expect(tokenizedBuffer.lineForScreenRow(8).tokens[0].scopes).not.toBe ['source.js', 'comment.block.js']
+            buffer.insert([2, 0], '/*\nabcde\nabcder')
+            expect(tokenizedBuffer.lineForScreenRow(2).tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
+            expect(tokenizedBuffer.lineForScreenRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.lineForScreenRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.lineForScreenRow(5).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.lineForScreenRow(6).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.lineForScreenRow(7).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.lineForScreenRow(8).tokens[0].scopes).not.toBe ['source.js', 'comment.block.js']
 
-          expect(changeHandler).toHaveBeenCalled()
-          [event] = changeHandler.argsForCall[0]
-          delete event.bufferChange
-          expect(event).toEqual(start: 2, end: 5, delta: 2)
+            expect(changeHandler).toHaveBeenCalled()
+            [event] = changeHandler.argsForCall[0]
+            delete event.bufferChange
+            expect(event).toEqual(start: 2, end: 5, delta: 2)
+
+      describe "when the change causes more than @chunkSize lines to be retokenized", ->
+        describe "when the buffer change itself is larger than the chunk size", ->
+
+        describe "when the buffer change is smaller than the chunk size, but the scope of rehighlighting is larger", ->
+
+        describe "when the end of rehighlighted region is outside the tokenized region", ->
+          it "extends the boundary of the tokenized region and resumes tokenizing after it", ->
+
+
+    describe "when there is a buffer change in the untokenized region", ->
+      it "updates the untokenized screen lines to match the buffer but does not tokenize the lines", ->
 
 
     describe "when the buffer contains tab characters", ->

--- a/spec/app/tokenized-buffer-spec.coffee
+++ b/spec/app/tokenized-buffer-spec.coffee
@@ -21,6 +21,7 @@ describe "TokenizedBuffer", ->
       editSession = fixturesProject.buildEditSessionForPath('sample.js', autoIndent: false)
       buffer = editSession.buffer
       tokenizedBuffer = editSession.displayBuffer.tokenizedBuffer
+      editSession.setVisible(true)
       changeHandler = jasmine.createSpy('changeHandler')
       tokenizedBuffer.on "change", changeHandler
 
@@ -289,6 +290,7 @@ describe "TokenizedBuffer", ->
       editSession = fixturesProject.buildEditSessionForPath('sample-with-tabs.coffee', { tabLength })
       buffer = editSession.buffer
       tokenizedBuffer = editSession.displayBuffer.tokenizedBuffer
+      editSession.setVisible(true)
 
     afterEach ->
       editSession.destroy()

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -10,6 +10,7 @@ RootView = require 'root-view'
 Editor = require 'editor'
 TextMateBundle = require 'text-mate-bundle'
 TextMateTheme = require 'text-mate-theme'
+TokenizedBuffer = require 'tokenized-buffer'
 fs = require 'fs'
 require 'window'
 
@@ -28,6 +29,10 @@ beforeEach ->
   spyOn(window, "setTimeout").andCallFake window.fakeSetTimeout
   spyOn(window, "clearTimeout").andCallFake window.fakeClearTimeout
   spyOn(File.prototype, "detectResurrectionAfterDelay").andCallFake -> @detectResurrection()
+
+  # make tokenization synchronous
+  TokenizedBuffer.prototype.chunkSize = Infinity
+  spyOn(TokenizedBuffer.prototype, "tokenizeInBackground").andCallFake -> @tokenizeNextChunk()
 
 afterEach ->
   delete window.rootView if window.rootView

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -107,7 +107,6 @@ class Cursor
   moveToFirstCharacterOfLine: ->
     position = @getBufferPosition()
     range = @getCurrentLineBufferRange()
-    console.log range.inspect()
     newPosition = null
     @editSession.scanInRange /^\s*/, range, (match, matchRange) =>
       newPosition = matchRange.end

--- a/src/app/display-buffer.coffee
+++ b/src/app/display-buffer.coffee
@@ -39,9 +39,6 @@ class DisplayBuffer
     bufferDelta = 0
     @trigger 'change', { start, end, screenDelta, bufferDelta }
 
-  tokenizeInBackground: ->
-    @tokenizedBuffer.tokenizeInBackground()
-
   lineForRow: (row) ->
     @lineMap.lineForScreenRow(row)
 

--- a/src/app/display-buffer.coffee
+++ b/src/app/display-buffer.coffee
@@ -39,6 +39,9 @@ class DisplayBuffer
     bufferDelta = 0
     @trigger 'change', { start, end, screenDelta, bufferDelta }
 
+  tokenizeInBackground: ->
+    @tokenizedBuffer.tokenizeInBackground()
+
   lineForRow: (row) ->
     @lineMap.lineForScreenRow(row)
 

--- a/src/app/display-buffer.coffee
+++ b/src/app/display-buffer.coffee
@@ -27,6 +27,8 @@ class DisplayBuffer
     @buildLineMap()
     @tokenizedBuffer.on 'change', (e) => @handleTokenizedBufferChange(e)
 
+  setVisible: (visible) -> @tokenizedBuffer.setVisible(visible)
+
   buildLineMap: ->
     @lineMap = new LineMap
     @lineMap.insertAtScreenRow 0, @buildLinesForBufferRows(0, @buffer.getLastRow())

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -84,9 +84,6 @@ class EditSession
   copy: ->
     EditSession.deserialize(@serialize(), @project)
 
-  activate: ->
-    @displayBuffer.tokenizeInBackground()
-
   isEqual: (other) ->
     return false unless other instanceof EditSession
     @buffer == other.buffer and

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -84,6 +84,9 @@ class EditSession
   copy: ->
     EditSession.deserialize(@serialize(), @project)
 
+  activate: ->
+    @displayBuffer.tokenizeInBackground()
+
   isEqual: (other) ->
     return false unless other instanceof EditSession
     @buffer == other.buffer and

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -91,6 +91,8 @@ class EditSession
       @scrollLeft == other.getScrollLeft() and
       @getCursorScreenPosition().isEqual(other.getCursorScreenPosition())
 
+  setVisible: (visible) -> @displayBuffer.setVisible(visible)
+
   setScrollTop: (@scrollTop) ->
   getScrollTop: -> @scrollTop
 

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -422,7 +422,6 @@ class Editor extends View
       @activeEditSession.off()
 
     @activeEditSession = @editSessions[index]
-    @activeEditSession.activate()
 
     @activeEditSession.on "buffer-contents-change-on-disk", =>
       @showBufferConflictAlert(@activeEditSession)

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -422,6 +422,7 @@ class Editor extends View
       @activeEditSession.off()
 
     @activeEditSession = @editSessions[index]
+    @activeEditSession.setVisible(true)
 
     @activeEditSession.on "buffer-contents-change-on-disk", =>
       @showBufferConflictAlert(@activeEditSession)

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -422,6 +422,7 @@ class Editor extends View
       @activeEditSession.off()
 
     @activeEditSession = @editSessions[index]
+    @activeEditSession.activate()
 
     @activeEditSession.on "buffer-contents-change-on-disk", =>
       @showBufferConflictAlert(@activeEditSession)

--- a/src/app/tokenized-buffer.coffee
+++ b/src/app/tokenized-buffer.coffee
@@ -65,7 +65,7 @@ class TokenizedBuffer
   tokenizeNextChunk: ->
     rowsRemaining = @chunkSize
 
-    while @invalidRows.length and rowsRemaining > 0
+    while @firstInvalidRow()? and rowsRemaining > 0
       invalidRow = @invalidRows.shift()
       lastRow = @getLastRow()
       continue if invalidRow > lastRow
@@ -86,7 +86,7 @@ class TokenizedBuffer
       @invalidateRow(row + 1) unless filledRegion
       @trigger "change", { start: invalidRow, end: row, delta: 0 }
 
-    @tokenizeInBackground()
+    @tokenizeInBackground() if @firstInvalidRow()?
 
   firstInvalidRow: ->
     @invalidRows[0]

--- a/src/app/tokenized-buffer.coffee
+++ b/src/app/tokenized-buffer.coffee
@@ -25,27 +25,6 @@ class TokenizedBuffer
     @invalidateRow(0)
     @buffer.on "change.tokenized-buffer#{@id}", (e) => @handleBufferChange(e)
 
-  handleBufferChange: (e) ->
-    {oldRange, newRange} = e
-    start = oldRange.start.row
-    end = oldRange.end.row
-    delta = newRange.end.row - oldRange.end.row
-
-    @updateInvalidRows(start, end, delta)
-
-    previousStack = @stackForRow(end) # used in spill detection below
-
-    stack = @stackForRow(start - 1)
-    if stack? or start == 0
-      @screenLines[start..end] = @buildTokenizedScreenLinesForRows(start, end + delta, stack)
-    else
-      @screenLines[start..end] = @buildPlaceholderScreenLinesForRows(start, end + delta, stack)
-
-    unless _.isEqual(@stackForRow(end + delta), previousStack)
-      @invalidateRow(end + delta + 1)
-
-    @trigger "change", { start, end, delta, bufferChange: e }
-
   getTabLength: ->
     @tabLength
 
@@ -107,6 +86,27 @@ class TokenizedBuffer
         end + delta + 1
       else if row > end
         row + delta
+
+  handleBufferChange: (e) ->
+    {oldRange, newRange} = e
+    start = oldRange.start.row
+    end = oldRange.end.row
+    delta = newRange.end.row - oldRange.end.row
+
+    @updateInvalidRows(start, end, delta)
+
+    previousStack = @stackForRow(end) # used in spill detection below
+
+    stack = @stackForRow(start - 1)
+    if stack? or start == 0
+      @screenLines[start..end] = @buildTokenizedScreenLinesForRows(start, end + delta, stack)
+    else
+      @screenLines[start..end] = @buildPlaceholderScreenLinesForRows(start, end + delta, stack)
+
+    unless _.isEqual(@stackForRow(end + delta), previousStack)
+      @invalidateRow(end + delta + 1)
+
+    @trigger "change", { start, end, delta, bufferChange: e }
 
   buildPlaceholderScreenLinesForRows: (startRow, endRow) ->
     @buildPlaceholderScreenLineForRow(row) for row in [startRow..endRow]

--- a/src/app/tokenized-buffer.coffee
+++ b/src/app/tokenized-buffer.coffee
@@ -16,6 +16,7 @@ class TokenizedBuffer
   screenLines: null
   chunkSize: 50
   invalidRows: null
+  visible: false
 
   constructor: (@buffer, { @languageMode, @tabLength }) ->
     @tabLength ?= 2
@@ -24,6 +25,9 @@ class TokenizedBuffer
     @invalidRows = []
     @invalidateRow(0)
     @buffer.on "change.tokenized-buffer#{@id}", (e) => @handleBufferChange(e)
+
+  setVisible: (@visible) ->
+    @tokenizeInBackground() if @visible
 
   getTabLength: ->
     @tabLength
@@ -35,7 +39,7 @@ class TokenizedBuffer
     @trigger "change", { start: 0, end: lastRow, delta: 0 }
 
   tokenizeInBackground: ->
-    return if @pendingChunk
+    return if not @visible or @pendingChunk
     @pendingChunk = true
     _.defer =>
       @pendingChunk = false

--- a/src/app/tokenized-buffer.coffee
+++ b/src/app/tokenized-buffer.coffee
@@ -33,6 +33,7 @@ class TokenizedBuffer
     previousStack = @stackForRow(end) # used in spill detection below
 
     stack = @stackForRow(start - 1)
+
     @screenLines[start..end] = @buildTokenizedScreenLinesForRows(start, end + delta, stack)
 
     # spill detection
@@ -49,7 +50,6 @@ class TokenizedBuffer
     # if highlighting spilled beyond the bounds of the textual change, update the
     # end of the affected range to reflect the larger area of highlighting
     end = Math.max(end, nextRow - delta) if nextRow
-
     @trigger "change", { start, end, delta, bufferChange: e }
 
   getTabLength: ->
@@ -177,6 +177,9 @@ class TokenizedBuffer
             position = startPosition
             stop()
     position
+
+  getLastRow: ->
+    @buffer.getLastRow()
 
   logLines: (start=0, end=@buffer.getLastRow()) ->
     for row in [start..end]


### PR DESCRIPTION
The rendering cascade looks like this: `Buffer => TokenizedBuffer => DisplayBuffer => Editor View`

Previously, we were tokenizing the entire file when we constructed the `TokenizedBuffer`, but for big files this was really slow. It locked up the UI thread for like 5-6 seconds loading jQuery. This PR makes that process asynchronous. We render lines in an untokenized form initially, then tokenize them one chunk at a time in the background while yielding back to the UI thread between chunks.

**This still isn't good enough, but it's a start.** This approach still consumes a lot of time on the UI thread, so even though we haven't locked it completely, performance is still pretty crappy during tokenization. To _truly_ tokenize in the background, we need to use a worker thread or another process. That will allow the UI to be super responsive even while we are tokenizing. I'll give it a try if we can manage to switch to [node-webkit](https://github.com/rogerwang/node-webkit).
