### PR TITLE
Make cursor change to pointer when hovering over close tab icon

### DIFF
--- a/src/extensions/tabs/src/tabs.css
+++ b/src/extensions/tabs/src/tabs.css
@@ -37,6 +37,7 @@
   width: 14px;
   height: 14px;
   color: #777;
+  cursor: pointer;
 }
 
 .tab .close-icon:before {


### PR DESCRIPTION
This makes the cursor change to the hand/pointer thingy when you hover over the close tab icon. Currently, the only indication on hover is the change in icon color with the cursor staying as an arrow.
