### PR TITLE
Grammar parsing tweaks

### DIFF
--- a/native/v8_extensions/onig_scanner.mm
+++ b/native/v8_extensions/onig_scanner.mm
@@ -57,10 +57,7 @@ class OnigScannerUserData : public CefBase {
       bool useCachedResult = false;
       OnigResult *result = NULL;
 
-      // In Oniguruma, \G is based on the start position of the match, so the result
-      // changes based on the start position. So it can't be cached.
-      BOOL containsBackslashG = [regExp.expression rangeOfString:@"\\G"].location != NSNotFound;
-      if (useCachedResults && index <= maxCachedIndex && ! containsBackslashG) {
+      if (useCachedResults && index <= maxCachedIndex) {
         result = cachedResults[index];
         useCachedResult = (result == NULL || [result locationAt:0] >= startLocation);
       }

--- a/spec/app/tokenized-buffer-spec.coffee
+++ b/spec/app/tokenized-buffer-spec.coffee
@@ -337,6 +337,14 @@ describe "TokenizedBuffer", ->
     afterEach ->
       editSession.destroy()
 
+    it "correctly parses a long line", ->
+      longLine = tokenizedBuffer.lineForScreenRow(0)
+      expect(longLine.text).toBe "longggggggggggggggggggggggggggggggggggggggggggggggg"
+      { tokens } = longLine
+
+      expect(tokens[0].value).toBe "longggggggggggggggggggggggggggggggggggggggggggggggg"
+      expect(tokens[0].scopes).toEqual ["text.git-commit", "meta.scope.message.git-commit", "invalid.deprecated.line-too-long.git-commit"]
+
     it "correctly parses the number sign of the first comment line", ->
       commentLine = tokenizedBuffer.lineForScreenRow(1)
       expect(commentLine.text).toBe "# Please enter the commit message for your changes. Lines starting"

--- a/spec/app/tokenized-buffer-spec.coffee
+++ b/spec/app/tokenized-buffer-spec.coffee
@@ -14,7 +14,7 @@ describe "TokenizedBuffer", ->
 
   fullyTokenize = (tokenizedBuffer) ->
     advanceClock() while tokenizedBuffer.firstInvalidRow()?
-    changeHandler.reset()
+    changeHandler?.reset()
 
   describe "when the buffer contains soft-tabs", ->
     beforeEach ->
@@ -326,3 +326,21 @@ describe "TokenizedBuffer", ->
 
         expect(tokenizedBuffer.lineForScreenRow(2).text).toBe "#{tabAsSpaces} buy()#{tabAsSpaces}while supply > demand"
 
+  describe "when a Git commit message file is tokenized", ->
+    beforeEach ->
+      editSession =  fixturesProject.buildEditSessionForPath('COMMIT_EDITMSG', autoIndent: false)
+      buffer = editSession.buffer
+      tokenizedBuffer = editSession.displayBuffer.tokenizedBuffer
+      editSession.setVisible(true)
+      fullyTokenize(tokenizedBuffer)
+
+    afterEach ->
+      editSession.destroy()
+
+    it "correctly parses the number sign of the first comment line", ->
+      commentLine = tokenizedBuffer.lineForScreenRow(1)
+      expect(commentLine.text).toBe "# Please enter the commit message for your changes. Lines starting"
+      { tokens } = commentLine
+
+      expect(tokens[0].value).toBe "#"
+      expect(tokens[0].scopes).toEqual ["text.git-commit", "meta.scope.metadata.git-commit", "comment.line.number-sign.git-commit", "punctuation.definition.comment.git-commit"]

--- a/spec/app/tokenized-buffer-spec.coffee
+++ b/spec/app/tokenized-buffer-spec.coffee
@@ -352,3 +352,34 @@ describe "TokenizedBuffer", ->
 
       expect(tokens[0].value).toBe "#"
       expect(tokens[0].scopes).toEqual ["text.git-commit", "meta.scope.metadata.git-commit", "comment.line.number-sign.git-commit", "punctuation.definition.comment.git-commit"]
+
+  describe "when a C++ source file is tokenized", ->
+    beforeEach ->
+      editSession =  fixturesProject.buildEditSessionForPath('includes.cc', autoIndent: false)
+      buffer = editSession.buffer
+      tokenizedBuffer = editSession.displayBuffer.tokenizedBuffer
+      editSession.setVisible(true)
+      fullyTokenize(tokenizedBuffer)
+
+    afterEach ->
+      editSession.destroy()
+
+    it "correctly parses the first include line", ->
+      longLine = tokenizedBuffer.lineForScreenRow(0)
+      expect(longLine.text).toBe '#include "a.h"'
+      { tokens } = longLine
+
+      expect(tokens[0].value).toBe "#"
+      expect(tokens[0].scopes).toEqual ["source.c++", "meta.preprocessor.c.include"]
+      expect(tokens[1].value).toBe 'include'
+      expect(tokens[1].scopes).toEqual ["source.c++", "meta.preprocessor.c.include", "keyword.control.import.include.c"]
+
+    it "correctly parses the second include line", ->
+      commentLine = tokenizedBuffer.lineForScreenRow(1)
+      expect(commentLine.text).toBe '#include "b.h"'
+      { tokens } = commentLine
+
+      expect(tokens[0].value).toBe "#"
+      expect(tokens[0].scopes).toEqual ["source.c++", "meta.preprocessor.c.include"]
+      expect(tokens[1].value).toBe 'include'
+      expect(tokens[1].scopes).toEqual ["source.c++", "meta.preprocessor.c.include", "keyword.control.import.include.c"]

--- a/spec/fixtures/COMMIT_EDITMSG
+++ b/spec/fixtures/COMMIT_EDITMSG
@@ -1,0 +1,2 @@
+longggggggggggggggggggggggggggggggggggggggggggggggg
+# Please enter the commit message for your changes. Lines starting

--- a/spec/fixtures/includes.cc
+++ b/spec/fixtures/includes.cc
@@ -1,0 +1,2 @@
+#include "a.h"
+#include "b.h"

--- a/src/app/language-mode.coffee
+++ b/src/app/language-mode.coffee
@@ -186,5 +186,5 @@ class LanguageMode
     if desiredIndentLevel < currentIndentLevel
       @editSession.setIndentationForBufferRow(bufferRow, desiredIndentLevel)
 
-  tokenizeLine: (line, stack) ->
-    {tokens, stack} = @grammar.tokenizeLine(line, stack)
+  tokenizeLine: (line, stack, firstLine) ->
+    {tokens, stack} = @grammar.tokenizeLine(line, stack, firstLine)

--- a/src/app/text-mate-grammar.coffee
+++ b/src/app/text-mate-grammar.coffee
@@ -61,6 +61,7 @@ class TextMateGrammar
         ))
         break
 
+    ruleStack.forEach (rule) -> rule.clearAnchorPosition()
     { tokens, ruleStack }
 
   ruleForInclude: (name) ->
@@ -78,7 +79,7 @@ class Rule
   patterns: null
   allPatterns: null
   createEndPattern: null
-  anchor: -1
+  anchorPosition: -1
 
   constructor: (@grammar, {@scopeName, patterns, @endPattern}) ->
     patterns ?= []
@@ -95,6 +96,8 @@ class Rule
       @allPatterns.push(pattern.getIncludedPatterns(included)...)
     @allPatterns
 
+  clearAnchorPosition: -> @anchorPosition = -1
+
   getScanner: (position, firstLine) ->
     return @scanner if @scanner
 
@@ -103,7 +106,7 @@ class Rule
     @getIncludedPatterns().forEach (pattern) =>
       if pattern.anchored
         anchored = true
-        regex = pattern.replaceAnchor(firstLine, position, @anchor)
+        regex = pattern.replaceAnchor(firstLine, position, @anchorPosition)
       else
         regex = pattern.regexSource
       regexes.push regex if regex
@@ -232,7 +235,7 @@ class Pattern
         tokens = [new Token(value: line[start...end], scopes: scopes)]
     if @pushRule
       ruleToPush = @pushRule.getRuleToPush(line, captureIndices)
-      ruleToPush.anchor = captureIndices[2]
+      ruleToPush.anchorPosition = captureIndices[2]
       stack.push(ruleToPush)
     else if @popRule
       stack.pop()

--- a/src/app/text-mate-grammar.coffee
+++ b/src/app/text-mate-grammar.coffee
@@ -41,7 +41,7 @@ class TextMateGrammar
         tokens = [new Token(value: "", scopes: scopes)]
         return { tokens, ruleStack }
 
-      break if position == line.length
+      break if position == line.length + 1 # include trailing newline position
 
       if match = _.last(ruleStack).getNextTokens(ruleStack, line, position, firstLine)
         { nextTokens, tokensStartPosition, tokensEndPosition } = match
@@ -55,10 +55,11 @@ class TextMateGrammar
         position = tokensEndPosition
 
       else # push filler token for unmatched text at end of line
-        tokens.push(new Token(
-          value: line[position...line.length]
-          scopes: scopes
-        ))
+        if position < line.length
+          tokens.push(new Token(
+            value: line[position...line.length]
+            scopes: scopes
+          ))
         break
 
     ruleStack.forEach (rule) -> rule.clearAnchorPosition()

--- a/src/app/text-mate-grammar.coffee
+++ b/src/app/text-mate-grammar.coffee
@@ -176,8 +176,16 @@ class Pattern
     for character in @regexSource.split('')
       if escape
         switch character
-          when 'A' then escaped.push(placeholder) unless firstLine
-          when 'G' then escaped.push(placeholder) unless offset is anchor
+          when 'A'
+            if firstLine
+              escaped.push("\\#{character}")
+            else
+              escaped.push(placeholder)
+          when 'G'
+            if offset is anchor
+              escaped.push("\\#{character}")
+            else
+              escaped.push(placeholder)
           when 'z' then escaped.push('$(?!\n)(?<!\n)')
           else escaped.push("\\#{character}")
         escape = false

--- a/src/app/text-mate-grammar.coffee
+++ b/src/app/text-mate-grammar.coffee
@@ -165,7 +165,7 @@ class Pattern
     return false unless @regexSource
     escape = false
     for character in @regexSource.split('')
-      return true if escape and (character is 'A' or character is 'G' or character is 'z')
+      return true if escape and 'AGz'.indexOf(character) isnt -1
       escape = not escape and character is '\\'
     false
 
@@ -224,7 +224,7 @@ class Pattern
         tokens = [new Token(value: line[start...end], scopes: scopes)]
     if @pushRule
       ruleToPush = @pushRule.getRuleToPush(line, captureIndices)
-      ruleToPush.anchor = captureIndices[1]
+      ruleToPush.anchor = captureIndices[2]
       stack.push(ruleToPush)
     else if @popRule
       stack.pop()

--- a/src/app/tokenized-buffer.coffee
+++ b/src/app/tokenized-buffer.coffee
@@ -134,7 +134,7 @@ class TokenizedBuffer
 
   buildTokenizedScreenLineForRow: (row, ruleStack) ->
     line = @buffer.lineForRow(row)
-    { tokens, ruleStack } = @languageMode.tokenizeLine(line, ruleStack)
+    { tokens, ruleStack } = @languageMode.tokenizeLine(line, ruleStack, row is 0)
     new ScreenLine({tokens, ruleStack, @tabLength})
 
   lineForScreenRow: (row) ->


### PR DESCRIPTION
Updates grammar support for replacing anchors and matching the trailing newline character included with a line.
# Git commit messages
## Before

![Screen Shot 2012-12-21 at 1 24 21 PM](https://f.cloud.github.com/assets/671378/27934/f6001286-4bb4-11e2-9067-cd13c98b7ec6.png)
## After

![Screen Shot 2012-12-21 at 1 25 13 PM](https://f.cloud.github.com/assets/671378/27937/fe907c24-4bb4-11e2-8bc5-245c9826327c.png)
# Objective-C files
## Before

![Screen Shot 2012-12-21 at 1 27 01 PM](https://f.cloud.github.com/assets/671378/27946/cf3228a0-4bb5-11e2-93bb-6d50c6d00ece.png)
## After

![Screen Shot 2012-12-21 at 1 31 16 PM](https://f.cloud.github.com/assets/671378/27948/e7835096-4bb5-11e2-8db5-03be5a39261a.png)
