### PR TITLE
Only using the fixed width font inside the editor

### DIFF
--- a/static/atom.css
+++ b/static/atom.css
@@ -1,5 +1,5 @@
 html, body {
-  font: 16px Inconsolata, Monaco, Courier !important;
+  font: caption !important;
   width: 100%;
   height: 100%;
   overflow: hidden;

--- a/static/editor.css
+++ b/static/editor.css
@@ -6,7 +6,7 @@
   -webkit-box-flex: 1;
   position: relative;
   z-index: 0;
-  font: 16px Inconsolata, Monaco, Courier !important;
+  font-family: Inconsolata, Monaco, Courier !important;
 }
 
 .editor.mini {

--- a/static/editor.css
+++ b/static/editor.css
@@ -6,6 +6,7 @@
   -webkit-box-flex: 1;
   position: relative;
   z-index: 0;
+  font: 16px Inconsolata, Monaco, Courier !important;
 }
 
 .editor.mini {


### PR DESCRIPTION
This pull request sets the global font to the system font. "Lucida Grande" on mac. And sets only the `.editor` to have the fixed width font.

I believe this helps the user distinguish the code from the rest of the UI.

![atom css _Users_jonrohan_github_atom](https://f.cloud.github.com/assets/54012/30090/6a419e5a-4e10-11e2-9729-70c783fa753c.png)

@nathansobo @probablycorey @kevinsawicki 
