### PR TITLE
Auto-indent config

### DIFF
--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -1918,7 +1918,7 @@ describe "EditSession", ->
 
   describe "auto-indent", ->
     describe "editor.autoIndent", ->
-      it "auto-indents newlines if editor.autoIndent is undefined (the default)", ->
+      it "auto-indents newlines if editor.autoIndent is true", ->
         config.set("editor.autoIndent", undefined)
         editSession.setCursorBufferPosition([1, 30])
         editSession.insertText("\n")
@@ -1930,8 +1930,8 @@ describe "EditSession", ->
         editSession.insertText("\n")
         expect(editSession.lineForBufferRow(2)).toBe ""
 
-      it "auto-indents calls to `indent` if editor.autoIndent is undefined (the default)", ->
-        config.set("editor.autoIndent", undefined)
+      it "auto-indents calls to `indent` if editor.autoIndent is true", ->
+        config.set("editor.autoIndent", true)
         editSession.setCursorBufferPosition([1, 30])
         editSession.insertText("\n ")
         expect(editSession.lineForBufferRow(2)).toBe " "

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -1918,7 +1918,8 @@ describe "EditSession", ->
 
   describe "auto-indent", ->
     describe "editor.autoIndent", ->
-      it "auto-indents newlines by default", ->
+      it "auto-indents newlines if editor.autoIndent is undefined (the default)", ->
+        config.set("editor.autoIndent", undefined)
         editSession.setCursorBufferPosition([1, 30])
         editSession.insertText("\n")
         expect(editSession.lineForBufferRow(2)).toBe "    "
@@ -1929,7 +1930,8 @@ describe "EditSession", ->
         editSession.insertText("\n")
         expect(editSession.lineForBufferRow(2)).toBe ""
 
-      it "auto-indents calls to `indent` by default", ->
+      it "auto-indents calls to `indent` if editor.autoIndent is undefined (the default)", ->
+        config.set("editor.autoIndent", undefined)
         editSession.setCursorBufferPosition([1, 30])
         editSession.insertText("\n ")
         expect(editSession.lineForBufferRow(2)).toBe " "

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -675,10 +675,7 @@ describe "EditSession", ->
           editSession.insertText('holy cow')
           expect(editSession.lineForScreenRow(2).fold).toBeUndefined()
 
-      describe "when auto-indent is enabled and the `autoIndent` option is true", ->
-        beforeEach ->
-          editSession.setAutoIndent(true)
-
+      describe "when auto-indent is enabled", ->
         describe "when a single newline is inserted", ->
           describe "when the newline is inserted on a line that starts a new level of indentation", ->
             it "auto-indents the new line to one additional level of indentation beyond the preceding line", ->
@@ -739,16 +736,13 @@ describe "EditSession", ->
           removeLeadingWhitespace = (text) -> text.replace(/^\s*/, '')
 
           describe "when the cursor is preceded only by whitespace", ->
-           describe "when auto-indent is enabled", ->
-              beforeEach ->
-                editSession.setAutoIndent(true)
-
+            describe "when auto-indent is enabled", ->
               describe "when the cursor's current column is less than the suggested indent level", ->
                 describe "when the indentBasis is inferred from the first line", ->
                   it "indents all lines relative to the suggested indent", ->
-                    editSession.insertText('\n xx')
+                    editSession.insertText('\n xx', autoIndent: true)
                     editSession.setCursorBufferPosition([3, 1])
-                    editSession.insertText(text, normalizeIndent: true)
+                    editSession.insertText(text, normalizeIndent: true, autoIndent: true)
 
                     expect(editSession.lineForBufferRow(3)).toBe "    while (true) {"
                     expect(editSession.lineForBufferRow(4)).toBe "      foo();"
@@ -759,7 +753,7 @@ describe "EditSession", ->
                   it "indents all lines relative to the suggested indent", ->
                     editSession.insertText('\n xx')
                     editSession.setCursorBufferPosition([3, 1])
-                    editSession.insertText(removeLeadingWhitespace(text), normalizeIndent: true, indentBasis: 2)
+                    editSession.insertText(removeLeadingWhitespace(text), normalizeIndent: true, indentBasis: 2, autoIndent: true)
 
                     expect(editSession.lineForBufferRow(3)).toBe "    while (true) {"
                     expect(editSession.lineForBufferRow(4)).toBe "      foo();"
@@ -775,7 +769,7 @@ describe "EditSession", ->
                     """
 
                     editSession.setCursorBufferPosition([1, 0])
-                    editSession.insertText(text, normalizeIndent: true)
+                    editSession.insertText(text, normalizeIndent: true, autoIndent: true)
 
                     expect(editSession.lineForBufferRow(1)).toBe "\t\t\twhile (true) {"
                     expect(editSession.lineForBufferRow(2)).toBe "\t\t\t\tfoo();"
@@ -791,7 +785,7 @@ describe "EditSession", ->
                     """
 
                     editSession.setCursorBufferPosition([1, 0])
-                    editSession.insertText(text, normalizeIndent: true)
+                    editSession.insertText(text, normalizeIndent: true, autoIndent: true)
 
                     expect(editSession.lineForBufferRow(1)).toBe "\t\twhile (true) {"
                     expect(editSession.lineForBufferRow(2)).toBe "\t\t\tfoo();"
@@ -820,9 +814,6 @@ describe "EditSession", ->
                     expect(editSession.lineForBufferRow(6)).toBe "    bar();"
 
             describe "if auto-indent is disabled", ->
-              beforeEach ->
-                expect(editSession.autoIndent).toBeFalsy()
-
               describe "when the indentBasis is inferred from the first line", ->
                 it "always normalizes indented lines to the cursor's current indentation level", ->
                   editSession.insertText('\n ')
@@ -845,7 +836,6 @@ describe "EditSession", ->
           describe "when the cursor is preceded by non-whitespace characters", ->
             describe "when the indentBasis is inferred from the first line", ->
               it "normalizes the indentation level of all lines based on the level of the existing first line", ->
-                editSession.setAutoIndent(true)
                 editSession.buffer.delete([[2, 0], [2, 2]])
                 editSession.insertText(text, normalizeIndent:true)
 
@@ -856,7 +846,6 @@ describe "EditSession", ->
 
             describe "when an indentBasis is provided", ->
               it "normalizes the indentation level of all lines based on the level of the existing first line", ->
-                editSession.setAutoIndent(true)
                 editSession.buffer.delete([[2, 0], [2, 2]])
                 editSession.insertText(removeLeadingWhitespace(text), normalizeIndent:true, indentBasis: 2)
 
@@ -1311,8 +1300,7 @@ describe "EditSession", ->
               it "moves the cursor to the end of the leading whitespace and inserts enough whitespace to bring the line to the suggested level of indentaion", ->
                 buffer.insert([5, 0], "  \n")
                 editSession.setCursorBufferPosition [5, 0]
-                editSession.setAutoIndent(true)
-                editSession.indent()
+                editSession.indent(autoIndent: true)
                 expect(buffer.lineForRow(5)).toMatch /^\s+$/
                 expect(buffer.lineForRow(5).length).toBe 6
                 expect(editSession.getCursorBufferPosition()).toEqual [5, 6]
@@ -1323,8 +1311,7 @@ describe "EditSession", ->
                 editSession.softTabs = false
                 buffer.insert([5, 0], "\t\n")
                 editSession.setCursorBufferPosition [5, 0]
-                editSession.setAutoIndent(true)
-                editSession.indent()
+                editSession.indent(autoIndent: true)
                 expect(buffer.lineForRow(5)).toMatch /^\t\t\t$/
                 expect(editSession.getCursorBufferPosition()).toEqual [5, 3]
 
@@ -1333,8 +1320,7 @@ describe "EditSession", ->
               it "moves the cursor to the end of the leading whitespace and inserts 'tabLength' spaces into the buffer", ->
                 buffer.insert([7, 0], "      \n")
                 editSession.setCursorBufferPosition [7, 2]
-                editSession.setAutoIndent(true)
-                editSession.indent()
+                editSession.indent(autoIndent: true)
                 expect(buffer.lineForRow(7)).toMatch /^\s+$/
                 expect(buffer.lineForRow(7).length).toBe 8
                 expect(editSession.getCursorBufferPosition()).toEqual [7, 8]
@@ -1345,8 +1331,7 @@ describe "EditSession", ->
                 editSession.softTabs = false
                 buffer.insert([7, 0], "\t\t\t\n")
                 editSession.setCursorBufferPosition [7, 1]
-                editSession.setAutoIndent(true)
-                editSession.indent()
+                editSession.indent(autoIndent: true)
                 expect(buffer.lineForRow(7)).toMatch /^\t\t\t\t$/
                 expect(editSession.getCursorBufferPosition()).toEqual [7, 4]
 
@@ -1421,17 +1406,16 @@ describe "EditSession", ->
           expect(editSession.buffer.lineForRow(0)).toBe "var first = function () {"
           expect(buffer.lineForRow(1)).toBe "  var first = function(items) {"
 
-      it "preserves the indent level when copying and pasting multiple lines", ->
-        editSession.setAutoIndent(true)
-        editSession.setSelectedBufferRange([[4, 4], [7, 5]])
-        editSession.copySelectedText()
-        editSession.setCursorBufferPosition([10, 0])
-        editSession.pasteText()
+        it "preserves the indent level when copying and pasting multiple lines", ->
+          editSession.setSelectedBufferRange([[4, 4], [7, 5]])
+          editSession.copySelectedText()
+          editSession.setCursorBufferPosition([10, 0])
+          editSession.pasteText(autoIndent: true)
 
-        expect(editSession.lineForBufferRow(10)).toBe "  while(items.length > 0) {"
-        expect(editSession.lineForBufferRow(11)).toBe "    current = items.shift();"
-        expect(editSession.lineForBufferRow(12)).toBe "    current < pivot ? left.push(current) : right.push(current);"
-        expect(editSession.lineForBufferRow(13)).toBe "  }"
+          expect(editSession.lineForBufferRow(10)).toBe "  while(items.length > 0) {"
+          expect(editSession.lineForBufferRow(11)).toBe "    current = items.shift();"
+          expect(editSession.lineForBufferRow(12)).toBe "    current < pivot ? left.push(current) : right.push(current);"
+          expect(editSession.lineForBufferRow(13)).toBe "  }"
 
     describe ".indentSelectedRows()", ->
       describe "when nothing is selected", ->

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -1916,17 +1916,30 @@ describe "EditSession", ->
       editSession.buffer.reload()
       expect(editSession.getCursorScreenPosition()).toEqual [0,1]
 
-  describe "autoIndent", ->
-    describe "when editor.autoIndent returns true based on the EditSession's grammar scope", ->
-      it "auto indents lines", ->
-        syntax.addProperties("." + editSession.languageMode.grammar.scopeName, editor: autoIndent: true )
+  describe "auto-indent", ->
+    describe "editor.autoIndent", ->
+      it "auto-indents newlines by default", ->
         editSession.setCursorBufferPosition([1, 30])
         editSession.insertText("\n")
         expect(editSession.lineForBufferRow(2)).toBe "    "
 
-    describe "when editor.autoIndent returns false based on the EditSession's grammar scope", ->
-      it "auto indents lines", ->
-        syntax.addProperties("." + editSession.languageMode.grammar.scopeName, editor: autoIndent: false )
+      it "does not auto-indent newlines if editor.autoIndent is false", ->
+        config.set("editor.autoIndent", false)
         editSession.setCursorBufferPosition([1, 30])
         editSession.insertText("\n")
         expect(editSession.lineForBufferRow(2)).toBe ""
+
+      it "auto-indents calls to `indent` by default", ->
+        editSession.setCursorBufferPosition([1, 30])
+        editSession.insertText("\n ")
+        expect(editSession.lineForBufferRow(2)).toBe " "
+        editSession.indent()
+        expect(editSession.lineForBufferRow(2)).toBe "    "
+
+      it "does not auto-indents calls to `indent` if editor.autoIndent is false", ->
+        config.set("editor.autoIndent", false)
+        editSession.setCursorBufferPosition([1, 30])
+        editSession.insertText("\n ")
+        expect(editSession.lineForBufferRow(2)).toBe " "
+        editSession.indent()
+        expect(editSession.lineForBufferRow(2)).toBe "   "

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -1943,3 +1943,27 @@ describe "EditSession", ->
         expect(editSession.lineForBufferRow(2)).toBe " "
         editSession.indent()
         expect(editSession.lineForBufferRow(2)).toBe "   "
+
+    describe "editor.autoIndentPastedText", ->
+      it "does not auto-indent pasted text by default", ->
+        editSession.setCursorBufferPosition([2, 0])
+        editSession.insertText("0\n  2\n    4\n")
+        editSession.getSelection().setBufferRange([[2,0], [5,0]])
+        editSession.cutSelectedText()
+
+        editSession.pasteText()
+        expect(editSession.lineForBufferRow(2)).toBe "0"
+        expect(editSession.lineForBufferRow(3)).toBe "  2"
+        expect(editSession.lineForBufferRow(4)).toBe "    4"
+
+      it "auto-indents pasted text when editor.autoIndentPastedText is true", ->
+        config.set("editor.autoIndentPastedText", true)
+        editSession.setCursorBufferPosition([2, 0])
+        editSession.insertText("0\n  2\n    4\n")
+        editSession.getSelection().setBufferRange([[2,0], [5,0]])
+        editSession.cutSelectedText()
+
+        editSession.pasteText()
+        expect(editSession.lineForBufferRow(2)).toBe "    0"
+        expect(editSession.lineForBufferRow(3)).toBe "      2"
+        expect(editSession.lineForBufferRow(4)).toBe "        4"

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -1915,3 +1915,18 @@ describe "EditSession", ->
       editSession.setCursorScreenPosition([0, 1])
       editSession.buffer.reload()
       expect(editSession.getCursorScreenPosition()).toEqual [0,1]
+
+  describe "autoIndent", ->
+    describe "when editor.autoIndent returns true based on the EditSession's grammar scope", ->
+      it "auto indents lines", ->
+        syntax.addProperties("." + editSession.languageMode.grammar.scopeName, editor: autoIndent: true )
+        editSession.setCursorBufferPosition([1, 30])
+        editSession.insertText("\n")
+        expect(editSession.lineForBufferRow(2)).toBe "    "
+
+    describe "when editor.autoIndent returns false based on the EditSession's grammar scope", ->
+      it "auto indents lines", ->
+        syntax.addProperties("." + editSession.languageMode.grammar.scopeName, editor: autoIndent: false )
+        editSession.setCursorBufferPosition([1, 30])
+        editSession.insertText("\n")
+        expect(editSession.lineForBufferRow(2)).toBe ""

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -1946,7 +1946,7 @@ describe "EditSession", ->
         editSession.indent()
         expect(editSession.lineForBufferRow(2)).toBe "   "
 
-    describe "editor.autoIndentPastedText", ->
+    describe "editor.autoIndentOnPaste", ->
       it "does not auto-indent pasted text by default", ->
         editSession.setCursorBufferPosition([2, 0])
         editSession.insertText("0\n  2\n    4\n")
@@ -1958,8 +1958,8 @@ describe "EditSession", ->
         expect(editSession.lineForBufferRow(3)).toBe "  2"
         expect(editSession.lineForBufferRow(4)).toBe "    4"
 
-      it "auto-indents pasted text when editor.autoIndentPastedText is true", ->
-        config.set("editor.autoIndentPastedText", true)
+      it "auto-indents pasted text when editor.autoIndentOnPaste is true", ->
+        config.set("editor.autoIndentOnPaste", true)
         editSession.setCursorBufferPosition([2, 0])
         editSession.insertText("0\n  2\n    4\n")
         editSession.getSelection().setBufferRange([[2,0], [5,0]])

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -34,6 +34,7 @@ beforeEach ->
   spyOn(config, 'load')
   spyOn(config, 'save')
   config.set "editor.fontSize", 16
+  config.set "editor.autoIndent", false
 
   # make editor display updates synchronous
   spyOn(Editor.prototype, 'requestDisplayUpdate').andCallFake -> @updateDisplay()

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -158,7 +158,7 @@ class EditSession
   logScreenLines: (start, end) -> @displayBuffer.logLines(start, end)
 
   shouldAutoIndent: ->
-    false
+    syntax.getProperty(["." + @languageMode.grammar.scopeName], "editor.autoIndent") ? false
 
   insertText: (text, options={}) ->
     options.autoIndent ?= @shouldAutoIndent()

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -160,6 +160,9 @@ class EditSession
   shouldAutoIndent: ->
     config.get("editor.autoIndent") ? true
 
+  shouldAutoIndentPastedText: ->
+    config.get("editor.autoIndentPastedText") ? false
+
   insertText: (text, options={}) ->
     options.autoIndent ?= @shouldAutoIndent()
     @mutateSelectedText (selection) -> selection.insertText(text, options)
@@ -220,12 +223,14 @@ class EditSession
       selection.copy(maintainPasteboard)
       maintainPasteboard = true
 
-  pasteText: (options={})->
+  pasteText: (options={}) ->
     options.normalizeIndent ?= true
+    options.autoIndent ?= @shouldAutoIndentPastedText()
 
     [text, metadata] = pasteboard.read()
     _.extend(options, metadata) if metadata
 
+    console.log options
     @insertText(text, options)
 
   undo: ->

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -158,7 +158,7 @@ class EditSession
   logScreenLines: (start, end) -> @displayBuffer.logLines(start, end)
 
   shouldAutoIndent: ->
-    syntax.getProperty(["." + @languageMode.grammar.scopeName], "editor.autoIndent") ? false
+    config.get("editor.autoIndent") ? true
 
   insertText: (text, options={}) ->
     options.autoIndent ?= @shouldAutoIndent()

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -33,11 +33,10 @@ class EditSession
   anchorRanges: null
   cursors: null
   selections: null
-  autoIndent: false # TODO: re-enabled auto-indent after fixing the rest of tokenization
   softTabs: true
   softWrap: false
 
-  constructor: ({@project, @buffer, tabLength, @autoIndent, softTabs, @softWrap }) ->
+  constructor: ({@project, @buffer, tabLength, softTabs, @softWrap }) ->
     @softTabs = @buffer.usesSoftTabs() ? softTabs ? true
     @languageMode = new LanguageMode(this, @buffer.getExtension())
     @displayBuffer = new DisplayBuffer(@buffer, { @languageMode, tabLength })

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -161,7 +161,7 @@ class EditSession
     config.get("editor.autoIndent") ? true
 
   shouldAutoIndentPastedText: ->
-    config.get("editor.autoIndentPastedText") ? false
+    config.get("editor.autoIndentOnPaste") ? false
 
   insertText: (text, options={}) ->
     options.autoIndent ?= @shouldAutoIndent()
@@ -230,7 +230,6 @@ class EditSession
     [text, metadata] = pasteboard.read()
     _.extend(options, metadata) if metadata
 
-    console.log options
     @insertText(text, options)
 
   undo: ->

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -158,10 +158,10 @@ class EditSession
   logScreenLines: (start, end) -> @displayBuffer.logLines(start, end)
 
   shouldAutoIndent: ->
-    config.get("editor.autoIndent") ? true
+    config.get("editor.autoIndent")
 
   shouldAutoIndentPastedText: ->
-    config.get("editor.autoIndentOnPaste") ? false
+    config.get("editor.autoIndentOnPaste")
 
   insertText: (text, options={}) ->
     options.autoIndent ?= @shouldAutoIndent()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -17,6 +17,8 @@ class Editor extends View
     fontSize: 20
     showInvisibles: false
     autosave: false
+    autoIndent: true
+    autoIndentOnPaste: false
 
   @content: (params) ->
     @div class: @classes(params), tabindex: -1, =>

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -243,7 +243,7 @@ class Editor extends View
   insertText: (text, options) -> @activeEditSession.insertText(text, options)
   insertNewline: -> @activeEditSession.insertNewline()
   insertNewlineBelow: -> @activeEditSession.insertNewlineBelow()
-  indent: -> @activeEditSession.indent()
+  indent: (options) -> @activeEditSession.indent(options)
   indentSelectedRows: -> @activeEditSession.indentSelectedRows()
   outdentSelectedRows: -> @activeEditSession.outdentSelectedRows()
   cutSelection: -> @activeEditSession.cutSelectedText()
@@ -380,7 +380,7 @@ class Editor extends View
       @selectOnMousemoveUntilMouseup()
 
     @on "textInput", (e) =>
-      @insertText(e.originalEvent.data, autoIndent: true)
+      @insertText(e.originalEvent.data)
       false
 
     @scrollView.on 'mousewheel', (e) =>

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -80,7 +80,6 @@ class Editor extends View
         buffer: new Buffer()
         softWrap: false
         tabLength: 2
-        autoIndent: false
         softTabs: true
 
       @editSessions.push editSession

--- a/src/app/project.coffee
+++ b/src/app/project.coffee
@@ -16,7 +16,6 @@ class Project
     new Project(state.path, state.grammarOverridesByPath)
 
   tabLength: 2
-  autoIndent: true
   softTabs: true
   softWrap: false
   rootDirectory: null
@@ -91,9 +90,6 @@ class Project
   relativize: (fullPath) ->
     fullPath.replace(@getPath(), "").replace(/^\//, '')
 
-  getAutoIndent: -> @autoIndent
-  setAutoIndent: (@autoIndent) ->
-
   getSoftTabs: -> @softTabs
   setSoftTabs: (@softTabs) ->
 
@@ -114,7 +110,6 @@ class Project
 
   defaultEditSessionOptions: ->
     tabLength: @tabLength
-    autoIndent: @getAutoIndent()
     softTabs: @getSoftTabs()
     softWrap: @getSoftWrap()
 

--- a/src/app/root-view.coffee
+++ b/src/app/root-view.coffee
@@ -102,6 +102,10 @@ class RootView extends View
       config.set("editor.showInvisibles", !config.get("editor.showInvisibles"))
     @command 'window:toggle-ignored-files', =>
       config.set("core.hideGitIgnoredFiles", not config.core.hideGitIgnoredFiles)
+    @command 'window:toggle-auto-indent', =>
+      config.set("editor.autoIndent", !config.get("editor.autoIndent"))
+    @command 'window:toggle-auto-indent-on-paste', =>
+      config.set("editor.autoIndentOnPaste", !config.get("editor.autoIndentOnPaste"))
 
   afterAttach: (onDom) ->
     @focus() if onDom

--- a/src/app/selection.coffee
+++ b/src/app/selection.coffee
@@ -179,13 +179,13 @@ class Selection
     else
       @cursor.setBufferPosition(newBufferRange.end, skipAtomicTokens: true) if wasReversed
 
-    if @editSession.autoIndent and options.autoIndent
+    if options.autoIndent
       if text == '\n'
         @editSession.autoIndentBufferRow(newBufferRange.end.row)
       else
         @editSession.autoDecreaseIndentForRow(newBufferRange.start.row)
 
-  indent: ->
+  indent: ({ autoIndent }={})->
     { row, column } = @cursor.getBufferPosition()
 
     if @isEmpty()
@@ -193,7 +193,7 @@ class Selection
       desiredIndent = @editSession.suggestedIndentForBufferRow(row)
       delta = desiredIndent - @cursor.getIndentLevel()
 
-      if @editSession.autoIndent and delta > 0
+      if autoIndent and delta > 0
         @insertText(@editSession.buildIndentString(delta))
       else
         @insertText(@editSession.getTabText())
@@ -221,7 +221,7 @@ class Selection
 
     if insideExistingLine
       desiredBasis = @editSession.indentationForBufferRow(currentBufferRow)
-    else if @editSession.autoIndent
+    else if options.autoIndent
       desiredBasis = @editSession.suggestedIndentForBufferRow(currentBufferRow)
     else
       desiredBasis = @cursor.getIndentLevel()


### PR DESCRIPTION
This adds two config options (default settings shown below)

``` coffeescript
editor:
  autoIndent: true
  autoIndentOnPaste: false
```

We use TextMate grammars to predict the appropriate indentation level. 

`editor.autoIndent` will use use this indentation level when you insert a newline or when you press tab on at the beginning of a line.

`editor.autoIndentOnPaste` will using the predicted indentation level to indent pasted text (duh.)

These config options can be toggle by the commands `window.auto-indent` and `window:auto-indent-on-paste`
