### PR TITLE
Compile extension

### DIFF
--- a/native/v8_extensions/native.mm
+++ b/native/v8_extensions/native.mm
@@ -478,6 +478,11 @@ bool Native::Execute(const CefString& name,
       };
     }
 
+    NSString *cwd = stringFromCefV8Value(options->GetValue("cwd"));
+    if (cwd) {
+      [task setCurrentDirectoryPath: cwd];
+    }
+
     [task launch];
 
     return true;

--- a/src/app/root-view.coffee
+++ b/src/app/root-view.coffee
@@ -198,6 +198,9 @@ class RootView extends View
   activeKeybindings: ->
     keymap.bindingsForElement(document.activeElement)
 
+  getProject: ->
+    @project or null
+
   getTitle: ->
     @title or "untitled"
 

--- a/src/packages/compile/Makefile
+++ b/src/packages/compile/Makefile
@@ -1,0 +1,2 @@
+default:
+	echo "true"

--- a/src/packages/compile/README.md
+++ b/src/packages/compile/README.md
@@ -1,0 +1,16 @@
+# Atom Compile Extension
+
+This extension should act as a base to "extend" other compilation extensions.
+The idea is inspired by the Emacs compile-mode and similar utilities.
+Running tests or CI is distinctly similar to the build process in software.
+
+Example usage:
+
+```
+Compile = require('compile')
+
+module.exports =
+class RubyTest extends Compile
+  compileCommand: ->
+    'bin/rspec'
+```

--- a/src/packages/compile/index.coffee
+++ b/src/packages/compile/index.coffee
@@ -1,0 +1,1 @@
+module.exports = require './lib/compile'

--- a/src/packages/compile/keymaps/compile.cson
+++ b/src/packages/compile/keymaps/compile.cson
@@ -1,0 +1,2 @@
+window.keymap.bindKeys '.editor'
+  'meta-shift-c': 'compile:run'

--- a/src/packages/compile/lib/compile.coffee
+++ b/src/packages/compile/lib/compile.coffee
@@ -1,0 +1,24 @@
+fs = require 'fs'
+ChildProcess = require 'child-process'
+
+module.exports =
+class Compile
+  @activate: (rootView, state) ->
+    instance = new Compile()
+    rootView.command 'compile:run', => instance.run(rootView)
+
+  initialize: ->
+    super
+
+  run: ->
+    ChildProcess.exec 'ls',
+      cwd: rootView.getProject().getRootDirectory(),
+      bufferLines: true,
+      stdout: @stdoutHandler,
+      stderr: @stderrHandler
+
+  stdoutHandler: (data) ->
+    console.log data
+
+  stderrHandler: (data) ->
+    console.log data

--- a/src/packages/compile/spec/compile-spec.coffee
+++ b/src/packages/compile/spec/compile-spec.coffee
@@ -1,0 +1,14 @@
+Compile = require 'compile'
+RootView = require 'root-view'
+
+describe "Compile", ->
+  [rootView, editor, path] = []
+
+  beforeEach ->
+    path = "/tmp/atom-whitespace.txt"
+    fs.write(path, "")
+    rootView = new RootView(path)
+
+    StripTrailingWhitespace.activate(rootView)
+    rootView.focus()
+    editor = rootView.getActiveEditor()


### PR DESCRIPTION
WIP
- [ ] specs
- [ ] proof of concept ruby test package using this base

This extension should act as a base to "extend" for other compilation extensions.
The idea is inspired by the Emacs compile-mode and similar utilities.

Example theoretical usage:

```
Compile = require('compile')

module.exports =
class RubyTest extends Compile
  compileCommand: ->
    'bin/rspec'

# maybe some automated binding to the same key regular Compile would use?
```

Maybe this should just be a library in the stdlib?

Kinda want to hear thoughts on this approach.
