### PR TITLE
Change title of Don't Save button

### DIFF
--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -701,7 +701,7 @@ class Editor extends View
       "Your changes will be lost if you don't save them"
       "Save", => @save(session, callback),
       "Cancel", null
-      "Don't save", callback
+      "Don't Save", callback
     )
 
   remove: (selector, keepData) ->


### PR DESCRIPTION
On OS X, I expect to be able to cmd-d in a Save confirmation and have it choose "Don't Save". You can either set the key binding when adding the `NSButton`, or if your button is "Don't Save" (with a capital S), OS X automagically turns it on for you.
