### PR TITLE
Allow tree view sidebar to be resized.

### DIFF
--- a/src/packages/tabs/stylesheets/tabs.css
+++ b/src/packages/tabs/stylesheets/tabs.css
@@ -2,6 +2,12 @@
   background: #333333;
   border-bottom: 4px solid #424242;
   font: caption;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .tab {

--- a/src/packages/tabs/stylesheets/tabs.css
+++ b/src/packages/tabs/stylesheets/tabs.css
@@ -2,11 +2,7 @@
   background: #333333;
   border-bottom: 4px solid #424242;
   font: caption;
-  -webkit-touch-callout: none;
   -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 

--- a/src/packages/tree-view/src/tree-view.coffee
+++ b/src/packages/tree-view/src/tree-view.coffee
@@ -131,7 +131,7 @@ class TreeView extends ScrollView
 
   resizeTreeView: (e) =>
     $('.tree-view').css(width: e.pageX)
-    $('.tree-view .tree-view-resizer').css(left: e.pageX + 12) # Tree view has padding-left: 12
+    $('.tree-view .tree-view-resizer').css(left: e.pageX)
 
   updateRoot: ->
     @root?.remove()

--- a/src/packages/tree-view/src/tree-view.coffee
+++ b/src/packages/tree-view/src/tree-view.coffee
@@ -27,7 +27,8 @@ class TreeView extends ScrollView
     @instance.serialize()
 
   @content: (rootView) ->
-    @ol class: 'tree-view tool-panel', tabindex: -1
+    @ol class: 'tree-view tool-panel', tabindex: -1, =>
+      @div class: 'tree-view-resizer'
 
   @deserialize: (state, rootView) ->
     treeView = new TreeView(rootView)
@@ -46,6 +47,7 @@ class TreeView extends ScrollView
   initialize: (@rootView) ->
     super
     @on 'click', '.entry', (e) => @entryClicked(e)
+    @on 'mousedown', '.tree-view-resizer', (e) => @resizeStarted(e)
     @command 'core:move-up', => @moveUp()
     @command 'core:move-down', => @moveDown()
     @command 'core:close', => @detach(); false
@@ -118,6 +120,18 @@ class TreeView extends ScrollView
           entry.toggleExpansion()
 
     false
+
+  resizeStarted: (e) =>
+    $(document.body).bind('mousemove', @resizeTreeView)
+    $(document.body).bind('mouseup', @resizeStopped)
+
+  resizeStopped: (e) =>
+    $(document.body).unbind('mousemove', @resizeTreeView)
+    $(document.body).unbind('mouseup', @resizeStopped)
+
+  resizeTreeView: (e) =>
+    $('.tree-view').css(width: e.pageX)
+    $('.tree-view .tree-view-resizer').css(left: e.pageX + 12) # Tree view has padding-left: 12
 
   updateRoot: ->
     @root?.remove()

--- a/src/packages/tree-view/src/tree-view.coffee
+++ b/src/packages/tree-view/src/tree-view.coffee
@@ -36,6 +36,7 @@ class TreeView extends ScrollView
     treeView.selectEntryForPath(state.selectedPath)
     treeView.focusAfterAttach = state.hasFocus
     treeView.scrollTopAfterAttach = state.scrollTop
+    treeView.width(state.width)
     treeView.attach() if state.attached
     treeView
 
@@ -81,6 +82,7 @@ class TreeView extends ScrollView
     hasFocus: @hasFocus()
     attached: @hasParent()
     scrollTop: @scrollTop()
+    width: @width()
 
   deactivate: ->
     @root?.unwatchEntries()

--- a/src/packages/tree-view/src/tree-view.coffee
+++ b/src/packages/tree-view/src/tree-view.coffee
@@ -28,7 +28,7 @@ class TreeView extends ScrollView
 
   @content: (rootView) ->
     @ol class: 'tree-view tool-panel', tabindex: -1, =>
-      @div class: 'tree-view-resizer'
+      @div class: 'tree-view-resizer', outlet: 'resizer'
 
   @deserialize: (state, rootView) ->
     treeView = new TreeView(rootView)
@@ -122,16 +122,18 @@ class TreeView extends ScrollView
     false
 
   resizeStarted: (e) =>
-    $(document.body).bind('mousemove', @resizeTreeView)
-    $(document.body).bind('mouseup', @resizeStopped)
+    $(document.body).on('mousemove', @resizeTreeView)
+    $(document.body).on('mouseup', @resizeStopped)
+    @css(overflow: 'hidden')
 
   resizeStopped: (e) =>
-    $(document.body).unbind('mousemove', @resizeTreeView)
-    $(document.body).unbind('mouseup', @resizeStopped)
+    $(document.body).off('mousemove', @resizeTreeView)
+    $(document.body).off('mouseup', @resizeStopped)
+    @css(overflow: 'auto')
 
   resizeTreeView: (e) =>
-    $('.tree-view').css(width: e.pageX)
-    $('.tree-view .tree-view-resizer').css(left: e.pageX)
+    @css(width: e.pageX)
+    @resizer.css(left: e.pageX)
 
   updateRoot: ->
     @root?.remove()

--- a/src/packages/tree-view/stylesheets/tree-view.css
+++ b/src/packages/tree-view/stylesheets/tree-view.css
@@ -9,13 +9,12 @@
   min-width: 100px;
   width: 200px;
   z-index: 2;
-  padding-left: 12px;
 }
 
 .tree-view .tree-view-resizer {
   position: fixed;
   float: right;
-  left: 212px;
+  left: 200px;
   height: 100%;
   width: 10px;
   background: transparent;

--- a/src/packages/tree-view/stylesheets/tree-view.css
+++ b/src/packages/tree-view/stylesheets/tree-view.css
@@ -7,12 +7,25 @@
   -webkit-user-select: none;
   border-right: 2px solid #191919;
   min-width: 100px;
+  width: 200px;
   z-index: 2;
   padding-left: 12px;
 }
 
+.tree-view .tree-view-resizer {
+  position: fixed;
+  float: right;
+  left: 212px;
+  height: 100%;
+  width: 2px;
+  background: transparent;
+  cursor: col-resize;
+}
+
 .tree-view .entry {
   text-shadow: 0 -1px 0 #000;
+  text-wrap: none;
+  white-space: nowrap;
 }
 
 .tree-view .entries {

--- a/src/packages/tree-view/stylesheets/tree-view.css
+++ b/src/packages/tree-view/stylesheets/tree-view.css
@@ -11,9 +11,7 @@
 }
 
 .tree-view .tree-view-resizer {
-  position: fixed;
   float: right;
-  left: 200px;
   height: 100%;
   width: 10px;
   background: transparent;

--- a/src/packages/tree-view/stylesheets/tree-view.css
+++ b/src/packages/tree-view/stylesheets/tree-view.css
@@ -17,7 +17,7 @@
   float: right;
   left: 212px;
   height: 100%;
-  width: 2px;
+  width: 10px;
   background: transparent;
   cursor: col-resize;
 }

--- a/src/packages/tree-view/stylesheets/tree-view.css
+++ b/src/packages/tree-view/stylesheets/tree-view.css
@@ -6,7 +6,6 @@
   cursor: default;
   -webkit-user-select: none;
   border-right: 2px solid #191919;
-  min-width: 100px;
   width: 200px;
   z-index: 2;
 }

--- a/src/packages/tree-view/stylesheets/tree-view.css
+++ b/src/packages/tree-view/stylesheets/tree-view.css
@@ -6,7 +6,7 @@
   cursor: default;
   -webkit-user-select: none;
   border-right: 2px solid #191919;
-  width: 200px;
+  min-width: 100px;
   z-index: 2;
 }
 

--- a/static/select-list.css
+++ b/static/select-list.css
@@ -10,6 +10,7 @@
   -webkit-box-shadow: 0 0 5px 5px #222;
   padding: 5px;
   z-index: 99;
+  cursor: pointer;
 }
 
 .select-list .editor {


### PR DESCRIPTION
Currently, the sidebar width is determined by the width of its content. So if you close a very wide directory, the sidebar shrinks, and whatever code you're looking at jumps on the page. This PR allows drag and drop resizing.

![resize-demo](https://f.cloud.github.com/assets/483/76256/a68ff89a-60e7-11e2-9664-c795afd0f6ea.gif)
## Issues
- [x] If you drag too fast, the names of your tabs get highlighted
- [x] The size of the window is off by 12px because of padding in the tree view
- [x] The resize area is very small so it's easy to miss.
- [x] The behavior/styles are being applied to the package browser
