### PR TITLE
Add "save as" keybinding

### DIFF
--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -151,6 +151,7 @@ class Editor extends View
         'core:select-to-bottom': @selectToBottom
         'core:close': @destroyActiveEditSession
         'editor:save': @save
+        'editor:save-as': @saveAs
         'editor:newline-below': @insertNewlineBelow
         'editor:toggle-soft-tabs': @toggleSoftTabs
         'editor:toggle-soft-wrap': @toggleSoftWrap
@@ -653,6 +654,9 @@ class Editor extends View
       session.save()
       onSuccess?()
     else
+      @saveAs(session, onSuccess)
+
+  saveAs: (session=@activeEditSession, onSuccess) ->
       atom.showSaveDialog (path) =>
         if path
           session.saveAs(path)

--- a/src/app/keymaps/atom.cson
+++ b/src/app/keymaps/atom.cson
@@ -22,7 +22,7 @@
   'pageup': 'core:page-up'
   'pagedown': 'core:page-down'
 
-  'meta-S': 'window:save-all'
+  'meta-alt-S': 'window:save-all'
   'meta-W': 'window:close'
   'meta-+': 'window:increase-font-size'
   'meta--': 'window:decrease-font-size'

--- a/src/app/keymaps/editor.cson
+++ b/src/app/keymaps/editor.cson
@@ -1,5 +1,6 @@
 '.editor':
   'meta-s': 'editor:save'
+  'meta-S': 'editor:save-as'
   'enter': 'editor:newline'
   'meta-enter': 'editor:newline-below'
   'tab': 'editor:indent'


### PR DESCRIPTION
On OS X I generally expect in a document editor that command-shift-S gives me a "Save As" dialog; I couldn't find an existing binding that would let you save the contents of a buffer with an existing path under a new path.

The cmd-shift-S keybinding was already set to `window:save-all`, so please reject this pull if you want to keep it that way. It was just a little surprising to me as a mostly-Mac user.
