### PR TITLE
The currently highlighted tab shows more tab

### DIFF
--- a/src/packages/tabs/stylesheets/tabs.css
+++ b/src/packages/tabs/stylesheets/tabs.css
@@ -1,14 +1,20 @@
 .tabs {
   -webkit-user-select: none;
+  display: -webkit-box;
+  -webkit-box-align: center;
 }
 
 .tab {
-  display: table-cell;
+  -webkit-box-flex: 2;
   position: relative;
-  width:175px;
+  width: 175px;
+  max-width: 175px;
   min-width: 40px;
   box-sizing: border-box;
-  height: 24px;
+}
+
+.tab.active {
+  -webkit-box-flex: 1;
 }
 
 .tab.file-modified .close-icon {
@@ -23,9 +29,5 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  position: absolute;
-  left: 9px;
-  top:4px;
-  bottom:4px;
-  right: 21px;
+  padding: 3px 5px;
 }

--- a/themes/Atom - Dark/tabs.css
+++ b/themes/Atom - Dark/tabs.css
@@ -61,7 +61,7 @@
 .tab.active:hover {
   border-top: 1px solid #4a4a4a;
   box-shadow: inset -1px 0 0 #595959, inset 1px 0 0 #595959;
-  border-bottom: 0 none;
+  border-bottom-color: #424242;
   background-image: -webkit-linear-gradient(#555555, #424242);
 }
 

--- a/themes/Atom - Light/tabs.css
+++ b/themes/Atom - Light/tabs.css
@@ -54,7 +54,7 @@
 
 .tab.active,
 .tab.active:hover {
-  border-bottom: 0 none;
+  border-bottom-color: #e5e5e5;
   box-shadow: inset -1px 0 0 #e0e0e0, inset 1px 0 0 #e0e0e0;
   background-image: -webkit-linear-gradient(#fefefe, #e7e6e7);
 }
@@ -62,7 +62,7 @@
 .tab.active:before,
 .tab.active:after {
   position: absolute;
-  bottom: 0;
+  bottom: -1px;
   width: 4px;
   height: 4px;
   content: " ";


### PR DESCRIPTION
Through the power of `-webkit-box-flex` I've re-written the tabs so that the current tab will flex larger to show of it's sexy tab name.

![animated-2013-01-25_16h-28m-58s](https://f.cloud.github.com/assets/54012/99233/6a81f4a2-674f-11e2-81bd-e198d1594c9f.gif)
