### PR TITLE
changing the space invisible to 00b7 'middot'

### DIFF
--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -312,7 +312,7 @@ class Editor extends View
   setInvisibles: (@invisibles={}) ->
     _.defaults @invisibles,
       eol: '\u00ac'
-      space: '\u2022'
+      space: '\u00b7'
       tab: '\u00bb'
       cr: '\u00a4'
     @resetDisplay()


### PR DESCRIPTION
The bullets for the space invisible were soooo chunky. I thought this might be nicer.

Before:

![Screen Shot 2013-01-29 at 2 37 10 PM](https://f.cloud.github.com/assets/54012/108358/89cae3d8-6a4b-11e2-8cd2-9833a4e2fc6f.png)

After:

![Screen Shot 2013-01-29 at 2 36 48 PM](https://f.cloud.github.com/assets/54012/108361/8fe4be1a-6a4b-11e2-9d49-dfacbd4b0240.png)
