### PR TITLE
Change how Atom defines a 'word'

### DIFF
--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -570,10 +570,15 @@ describe "EditSession", ->
           expect(editSession.getSelectedText()).toBe 'quicksort'
 
       describe "when the cursor is between two words", ->
-        it "selects the nearest word", ->
+        it "selects the word the cursor is on", ->
           editSession.setCursorScreenPosition([0, 4])
           editSession.selectWord()
           expect(editSession.getSelectedText()).toBe 'quicksort'
+
+          editSession.setCursorScreenPosition([0, 3])
+          editSession.selectWord()
+          expect(editSession.getSelectedText()).toBe 'var'
+
 
       describe "when the cursor is inside a region of whitespace", ->
         it "selects the whitespace region", ->

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -16,7 +16,7 @@ describe "EditSession", ->
   afterEach ->
     fixturesProject.destroy()
 
-  describe "cursor", ->
+  fdescribe "cursor", ->
     describe ".getCursor()", ->
       it "returns the most recently created cursor", ->
         editSession.addCursorAtScreenPosition([1, 0])
@@ -276,17 +276,17 @@ describe "EditSession", ->
         editSession.moveCursorToBeginningOfWord()
 
         expect(cursor1.getBufferPosition()).toEqual [0, 4]
-        expect(cursor2.getBufferPosition()).toEqual [1, 10]
+        expect(cursor2.getBufferPosition()).toEqual [1, 11]
         expect(cursor3.getBufferPosition()).toEqual [2, 39]
 
       it "does not fail at position [0, 0]", ->
         editSession.setCursorBufferPosition([0, 0])
         editSession.moveCursorToBeginningOfWord()
 
-      it "works when the preceding line is blank", ->
-        editSession.setCursorBufferPosition([10, 0])
+      it "works when the previous line is blank", ->
+        editSession.setCursorBufferPosition([11, 0])
         editSession.moveCursorToBeginningOfWord()
-        expect(editSession.getCursorBufferPosition()).toEqual [9, 0]
+        expect(editSession.getCursorBufferPosition()).toEqual [10, 0]
 
     describe ".moveCursorToEndOfWord()", ->
       it "moves the cursor to the end of the word", ->

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -266,7 +266,7 @@ describe "EditSession", ->
           editSession.moveCursorToFirstCharacterOfLine()
           expect(editSession.getCursorBufferPosition()).toEqual [10, 0]
 
-    fdescribe ".moveCursorToBeginningOfWord()", ->
+    describe ".moveCursorToBeginningOfWord()", ->
       it "moves the cursor to the beginning of the word", ->
         editSession.setCursorBufferPosition [0, 8]
         editSession.addCursorAtBufferPosition [1, 12]
@@ -293,7 +293,7 @@ describe "EditSession", ->
         editSession.moveCursorToBeginningOfWord()
         expect(editSession.getCursorBufferPosition()).toEqual [9, 2]
 
-    fdescribe ".moveCursorToEndOfWord()", ->
+    describe ".moveCursorToEndOfWord()", ->
       it "moves the cursor to the end of the word", ->
         editSession.setCursorBufferPosition [0, 6]
         editSession.addCursorAtBufferPosition [1, 10]
@@ -534,13 +534,13 @@ describe "EditSession", ->
         expect(editSession.getCursors().length).toBe 2
         [cursor1, cursor2] = editSession.getCursors()
         expect(cursor1.getBufferPosition()).toEqual [0,4]
-        expect(cursor2.getBufferPosition()).toEqual [3,44]
+        expect(cursor2.getBufferPosition()).toEqual [3,47]
 
         expect(editSession.getSelections().length).toBe 2
         [selection1, selection2] = editSession.getSelections()
         expect(selection1.getBufferRange()).toEqual [[0,4], [0,13]]
         expect(selection1.isReversed()).toBeTruthy()
-        expect(selection2.getBufferRange()).toEqual [[3,44], [3,49]]
+        expect(selection2.getBufferRange()).toEqual [[3,47], [3,49]]
         expect(selection2.isReversed()).toBeTruthy()
 
     describe ".selectToEndOfWord()", ->
@@ -553,40 +553,44 @@ describe "EditSession", ->
         expect(editSession.getCursors().length).toBe 2
         [cursor1, cursor2] = editSession.getCursors()
         expect(cursor1.getBufferPosition()).toEqual [0,13]
-        expect(cursor2.getBufferPosition()).toEqual [3,51]
+        expect(cursor2.getBufferPosition()).toEqual [3,50]
 
         expect(editSession.getSelections().length).toBe 2
         [selection1, selection2] = editSession.getSelections()
         expect(selection1.getBufferRange()).toEqual [[0,4], [0,13]]
         expect(selection1.isReversed()).toBeFalsy()
-        expect(selection2.getBufferRange()).toEqual [[3,48], [3,51]]
+        expect(selection2.getBufferRange()).toEqual [[3,48], [3,50]]
         expect(selection2.isReversed()).toBeFalsy()
 
     describe ".selectWord()", ->
-       describe "when the cursor is inside a word", ->
-         it "selects the entire word", ->
-           editSession.setCursorScreenPosition([0, 8])
-           editSession.selectWord()
-           expect(editSession.getSelectedText()).toBe 'quicksort'
+      describe "when the cursor is inside a word", ->
+        it "selects the entire word", ->
+          editSession.setCursorScreenPosition([0, 8])
+          editSession.selectWord()
+          expect(editSession.getSelectedText()).toBe 'quicksort'
 
-       describe "when the cursor is between two words", ->
-         it "selects both words", ->
-           editSession.setCursorScreenPosition([0, 4])
-           editSession.selectWord()
-           expect(editSession.getSelectedText()).toBe ' quicksort'
+      describe "when the cursor is between two words", ->
+        it "selects the nearest word", ->
+          editSession.setCursorScreenPosition([0, 4])
+          editSession.selectWord()
+          expect(editSession.getSelectedText()).toBe 'quicksort'
 
-       describe "when the cursor is inside a region of whitespace", ->
-         it "selects the whitespace region", ->
-           editSession.setCursorScreenPosition([5, 2])
-           editSession.selectWord()
-           expect(editSession.getSelectedBufferRange()).toEqual [[5, 0], [5, 6]]
+      describe "when the cursor is inside a region of whitespace", ->
+        it "selects the whitespace region", ->
+          editSession.setCursorScreenPosition([5, 2])
+          editSession.selectWord()
+          expect(editSession.getSelectedBufferRange()).toEqual [[5, 0], [5, 6]]
 
-       describe "when the cursor is at the end of the text", ->
-         it "select the previous word", ->
-           editSession.buffer.append 'word'
-           editSession.moveCursorToBottom()
-           editSession.selectWord()
-           expect(editSession.getSelectedBufferRange()).toEqual [[12, 2], [12, 6]]
+          editSession.setCursorScreenPosition([5, 0])
+          editSession.selectWord()
+          expect(editSession.getSelectedBufferRange()).toEqual [[5, 0], [5, 6]]
+
+      describe "when the cursor is at the end of the text", ->
+        it "select the previous word", ->
+          editSession.buffer.append 'word'
+          editSession.moveCursorToBottom()
+          editSession.selectWord()
+          expect(editSession.getSelectedBufferRange()).toEqual [[12, 2], [12, 6]]
 
     describe ".setSelectedBufferRanges(ranges)", ->
       it "clears existing selections and creates selections for each of the given ranges", ->
@@ -1126,25 +1130,26 @@ describe "EditSession", ->
       describe "when no text is selected", ->
         it "deletes all text between the cursor and the beginning of the word", ->
           editSession.setCursorBufferPosition([1, 24])
-          editSession.addCursorAtBufferPosition([2, 5])
+          editSession.addCursorAtBufferPosition([3, 5])
           [cursor1, cursor2] = editSession.getCursors()
 
           editSession.backspaceToBeginningOfWord()
           expect(buffer.lineForRow(1)).toBe '  var sort = function(ems) {'
-          expect(buffer.lineForRow(2)).toBe '    f (items.length <= 1) return items;'
+          expect(buffer.lineForRow(3)).toBe '    ar pivot = items.shift(), current, left = [], right = [];'
           expect(cursor1.getBufferPosition()).toEqual [1, 22]
-          expect(cursor2.getBufferPosition()).toEqual [2, 4]
+          expect(cursor2.getBufferPosition()).toEqual [3, 4]
 
           editSession.backspaceToBeginningOfWord()
           expect(buffer.lineForRow(1)).toBe '  var sort = functionems) {'
-          expect(buffer.lineForRow(2)).toBe 'f (items.length <= 1) return items;'
+          expect(buffer.lineForRow(2)).toBe '    if (items.length <= 1) return itemsar pivot = items.shift(), current, left = [], right = [];'
           expect(cursor1.getBufferPosition()).toEqual [1, 21]
-          expect(cursor2.getBufferPosition()).toEqual [2, 0]
+          expect(cursor2.getBufferPosition()).toEqual [2, 39]
 
           editSession.backspaceToBeginningOfWord()
-          expect(buffer.lineForRow(1)).toBe '  var sort = emsf (items.length <= 1) return items;'
+          expect(buffer.lineForRow(1)).toBe '  var sort = ems) {'
+          expect(buffer.lineForRow(2)).toBe '    if (items.length <= 1) return ar pivot = items.shift(), current, left = [], right = [];'
           expect(cursor1.getBufferPosition()).toEqual [1, 13]
-          expect(cursor2.getBufferPosition()).toEqual [1, 16]
+          expect(cursor2.getBufferPosition()).toEqual [2, 34]
 
       describe "when text is selected", ->
         it "deletes only selected text", ->
@@ -1312,7 +1317,7 @@ describe "EditSession", ->
           expect(cursor2.getBufferPosition()).toEqual [2, 5]
 
           editSession.deleteToEndOfWord()
-          expect(buffer.lineForRow(1)).toBe '  var sort = function(it'
+          expect(buffer.lineForRow(1)).toBe '  var sort = function(it {'
           expect(buffer.lineForRow(2)).toBe '    iitems.length <= 1) return items;'
           expect(cursor1.getBufferPosition()).toEqual [1, 24]
           expect(cursor2.getBufferPosition()).toEqual [2, 5]

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -16,7 +16,7 @@ describe "EditSession", ->
   afterEach ->
     fixturesProject.destroy()
 
-  fdescribe "cursor", ->
+  describe "cursor", ->
     describe ".getCursor()", ->
       it "returns the most recently created cursor", ->
         editSession.addCursorAtScreenPosition([1, 0])
@@ -266,7 +266,7 @@ describe "EditSession", ->
           editSession.moveCursorToFirstCharacterOfLine()
           expect(editSession.getCursorBufferPosition()).toEqual [10, 0]
 
-    describe ".moveCursorToBeginningOfWord()", ->
+    fdescribe ".moveCursorToBeginningOfWord()", ->
       it "moves the cursor to the beginning of the word", ->
         editSession.setCursorBufferPosition [0, 8]
         editSession.addCursorAtBufferPosition [1, 12]
@@ -283,12 +283,17 @@ describe "EditSession", ->
         editSession.setCursorBufferPosition([0, 0])
         editSession.moveCursorToBeginningOfWord()
 
-      it "works when the previous line is blank", ->
+      it "treats lines with only whitespace as a word", ->
         editSession.setCursorBufferPosition([11, 0])
         editSession.moveCursorToBeginningOfWord()
         expect(editSession.getCursorBufferPosition()).toEqual [10, 0]
 
-    describe ".moveCursorToEndOfWord()", ->
+      it "works when the current line is blank", ->
+        editSession.setCursorBufferPosition([10, 0])
+        editSession.moveCursorToBeginningOfWord()
+        expect(editSession.getCursorBufferPosition()).toEqual [9, 2]
+
+    fdescribe ".moveCursorToEndOfWord()", ->
       it "moves the cursor to the end of the word", ->
         editSession.setCursorBufferPosition [0, 6]
         editSession.addCursorAtBufferPosition [1, 10]
@@ -298,14 +303,25 @@ describe "EditSession", ->
         editSession.moveCursorToEndOfWord()
 
         expect(cursor1.getBufferPosition()).toEqual [0, 13]
-        expect(cursor2.getBufferPosition()).toEqual [1, 13]
-        expect(cursor3.getBufferPosition()).toEqual [3, 4]
+        expect(cursor2.getBufferPosition()).toEqual [1, 12]
+        expect(cursor3.getBufferPosition()).toEqual [3, 7]
 
       it "does not blow up when there is no next word", ->
         editSession.setCursorBufferPosition [Infinity, Infinity]
         endPosition = editSession.getCursorBufferPosition()
         editSession.moveCursorToEndOfWord()
         expect(editSession.getCursorBufferPosition()).toEqual endPosition
+
+      it "treats lines with only whitespace as a word", ->
+        editSession.setCursorBufferPosition([9, 4])
+        editSession.moveCursorToEndOfWord()
+        expect(editSession.getCursorBufferPosition()).toEqual [10, 0]
+
+      it "works when the current line is blank", ->
+        editSession.setCursorBufferPosition([10, 0])
+        editSession.moveCursorToEndOfWord()
+        expect(editSession.getCursorBufferPosition()).toEqual [11, 8]
+
 
     describe ".getCurrentParagraphBufferRange()", ->
       it "returns the buffer range of the current paragraph, delimited by blank lines or the beginning / end of the file", ->

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -9,7 +9,6 @@ class Cursor
   screenPosition: null
   bufferPosition: null
   goalColumn: null
-  wordRegex: /(\w+)|([^\w\n]+)/g
   visible: true
   needsAutoscroll: false
 
@@ -150,7 +149,7 @@ class Cursor
     previousLinesRange = [[previousNonBlankRow, 0], currentBufferPosition]
 
     beginningOfWordPosition = currentBufferPosition
-    @editSession.backwardsScanInRange (options.wordRegex || @wordRegex), previousLinesRange, (match, matchRange, { stop }) =>
+    @editSession.backwardsScanInRange (options.wordRegex ? config.get("editor.wordRegex")), previousLinesRange, (match, matchRange, { stop }) =>
       if matchRange.end.isGreaterThanOrEqual(currentBufferPosition) or allowPrevious
         beginningOfWordPosition = matchRange.start
       stop()
@@ -162,7 +161,7 @@ class Cursor
     range = [currentBufferPosition, @editSession.getEofBufferPosition()]
 
     endOfWordPosition = null
-    @editSession.scanInRange (options.wordRegex || @wordRegex), range, (match, matchRange, { stop }) =>
+    @editSession.scanInRange (options.wordRegex ? config.get("editor.wordRegex")), range, (match, matchRange, { stop }) =>
       endOfWordPosition = matchRange.end
       if not allowNext and matchRange.start.isGreaterThan(currentBufferPosition)
         endOfWordPosition = currentBufferPosition

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -147,9 +147,9 @@ class Cursor
     if position = @getEndOfCurrentWordBufferPosition()
       @setBufferPosition(position)
 
-  wordSeparatorsRegExp: ->
-    wordSeparators = config.get("editor.wordSeparators")
-    new RegExp("^[\t ]*$|[^\\s#{_.escapeRegExp(wordSeparators)}]+|[#{_.escapeRegExp(wordSeparators)}]+", "mg")
+  wordRegExp: ->
+    nonWordCharacters = config.get("editor.nonWordCharacters")
+    new RegExp("^[\t ]*$|[^\\s#{_.escapeRegExp(nonWordCharacters)}]+|[#{_.escapeRegExp(nonWordCharacters)}]+", "mg")
 
   getBeginningOfCurrentWordBufferPosition: (options = {}) ->
     allowPrevious = options.allowPrevious ? true
@@ -159,7 +159,7 @@ class Cursor
 
     beginningOfWordPosition = currentBufferPosition
 
-    @editSession.backwardsScanInRange (options.wordRegex ? @wordSeparatorsRegExp()), previousLinesRange, (match, matchRange, { stop }) =>
+    @editSession.backwardsScanInRange (options.wordRegex ? @wordRegExp()), previousLinesRange, (match, matchRange, { stop }) =>
       if matchRange.end.isGreaterThanOrEqual(currentBufferPosition) or allowPrevious
         beginningOfWordPosition = matchRange.start
       stop() unless beginningOfWordPosition.isEqual(currentBufferPosition)
@@ -172,7 +172,7 @@ class Cursor
     range = [currentBufferPosition, @editSession.getEofBufferPosition()]
 
     endOfWordPosition = null
-    @editSession.scanInRange (options.wordRegex ? @wordSeparatorsRegExp()),
+    @editSession.scanInRange (options.wordRegex ? @wordRegExp()),
     range, (match, matchRange, { stop }) =>
       endOfWordPosition = matchRange.end
       return if endOfWordPosition.isEqual(currentBufferPosition)

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -57,7 +57,7 @@ class Cursor
 
   wordRegExp: ->
     nonWordCharacters = config.get("editor.nonWordCharacters")
-    new RegExp("^[\t ]*$|[^\\s#{_.escapeRegExp(nonWordCharacters)}]+|[#{_.escapeRegExp(nonWordCharacters)}]+", "mg")
+    new RegExp("^[\t ]*$|[^\\s#{_.escapeRegExp(nonWordCharacters)}]+|[#{_.escapeRegExp(nonWordCharacters)}]+", "g")
 
   isLastCursor: ->
     this == @editSession.getCursor()

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -55,6 +55,10 @@ class Cursor
 
   isVisible: -> @visible
 
+  wordRegExp: ->
+    nonWordCharacters = config.get("editor.nonWordCharacters")
+    new RegExp("^[\t ]*$|[^\\s#{_.escapeRegExp(nonWordCharacters)}]+|[#{_.escapeRegExp(nonWordCharacters)}]+", "mg")
+
   isLastCursor: ->
     this == @editSession.getCursor()
 
@@ -146,10 +150,6 @@ class Cursor
   moveToEndOfWord: ->
     if position = @getEndOfCurrentWordBufferPosition()
       @setBufferPosition(position)
-
-  wordRegExp: ->
-    nonWordCharacters = config.get("editor.nonWordCharacters")
-    new RegExp("^[\t ]*$|[^\\s#{_.escapeRegExp(nonWordCharacters)}]+|[#{_.escapeRegExp(nonWordCharacters)}]+", "mg")
 
   getBeginningOfCurrentWordBufferPosition: (options = {}) ->
     allowPrevious = options.allowPrevious ? true

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -58,6 +58,11 @@ class Cursor
   isLastCursor: ->
     this == @editSession.getCursor()
 
+  isSurroundedByWhitespace: ->
+    {row, column} = @getBufferPosition()
+    range = [[row, column + 1], [row, Math.max(0, column - 1)]]
+    /^\s+$/.test @editSession.getTextInBufferRange(range)
+
   autoscrolled: ->
     @needsAutoscroll = false
 

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -64,7 +64,7 @@ class Cursor
 
   isSurroundedByWhitespace: ->
     {row, column} = @getBufferPosition()
-    range = [[row, column + 1], [row, Math.max(0, column - 1)]]
+    range = [[row, Math.min(0, column - 1)], [row, Math.max(0, column + 1)]]
     /^\s+$/.test @editSession.getTextInBufferRange(range)
 
   autoscrolled: ->

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -149,10 +149,14 @@ class Cursor
     previousLinesRange = [[previousNonBlankRow, 0], currentBufferPosition]
 
     beginningOfWordPosition = currentBufferPosition
-    @editSession.backwardsScanInRange (options.wordRegex ? config.get("editor.wordRegex")), previousLinesRange, (match, matchRange, { stop }) =>
+
+    wordSeparators = config.get("editor.wordSeparators")
+    wordSeparatorsRegex = new RegExp("^[\t ]*\n|[^\\s#{_.escapeRegExp(wordSeparators)}]+|[#{_.escapeRegExp(wordSeparators)}]+", "m")
+    @editSession.backwardsScanInRange (options.wordRegex ? wordSeparatorsRegex), previousLinesRange, (match, matchRange, { stop }) =>
       if matchRange.end.isGreaterThanOrEqual(currentBufferPosition) or allowPrevious
         beginningOfWordPosition = matchRange.start
       stop()
+
     beginningOfWordPosition
 
   getEndOfCurrentWordBufferPosition: (options = {}) ->

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -173,10 +173,9 @@ class Cursor
 
     endOfWordPosition = null
     @editSession.scanInRange (options.wordRegex ? @wordRegExp()), range, (match, matchRange, { stop }) =>
-      endOfWordPosition = matchRange.end
-      if matchRange.start.isGreaterThan(currentBufferPosition) and not allowNext
-        endOfWordPosition = currentBufferPosition
-      if not endOfWordPosition.isEqual(currentBufferPosition)
+      if matchRange.start.isLessThanOrEqual(currentBufferPosition) or allowNext
+        endOfWordPosition = matchRange.end
+      if not endOfWordPosition?.isEqual(currentBufferPosition)
         stop()
 
     endOfWordPosition or currentBufferPosition

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -19,7 +19,7 @@ class Editor extends View
     autosave: false
     autoIndent: true
     autoIndentOnPaste: false
-    nonWordCharacters: "./\()\"’-_:,.;<>~!@#$%^&*|+=[]{}`~?"
+    nonWordCharacters: "./\\()\"’-_:,.;<>~!@#$%^&*|+=[]{}`~?"
 
   @content: (params) ->
     @div class: @classes(params), tabindex: -1, =>

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -19,8 +19,7 @@ class Editor extends View
     autosave: false
     autoIndent: true
     autoIndentOnPaste: false
-    wordRegex: /(\w+)|([^\w\n]+)/g
-    wordSeparators: "./\()\"’-:,.;<>~!@#$%^&*|+=[]{}`~?"
+    nonWordCharacters: "./\()\"’-:,.;<>~!@#$%^&*|+=[]{}`~?"
 
   @content: (params) ->
     @div class: @classes(params), tabindex: -1, =>

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -20,6 +20,7 @@ class Editor extends View
     autoIndent: true
     autoIndentOnPaste: false
     wordRegex: /(\w+)|([^\w\n]+)/g
+    wordSeparators: "./\()\"’-:,.;<>~!@#$%^&*|+=[]{}`~?"
 
   @content: (params) ->
     @div class: @classes(params), tabindex: -1, =>

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -19,7 +19,7 @@ class Editor extends View
     autosave: false
     autoIndent: true
     autoIndentOnPaste: false
-    nonWordCharacters: "./\()\"’-:,.;<>~!@#$%^&*|+=[]{}`~?"
+    nonWordCharacters: "./\()\"’-_:,.;<>~!@#$%^&*|+=[]{}`~?"
 
   @content: (params) ->
     @div class: @classes(params), tabindex: -1, =>

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -19,6 +19,7 @@ class Editor extends View
     autosave: false
     autoIndent: true
     autoIndentOnPaste: false
+    wordRegex: /(\w+)|([^\w\n]+)/g
 
   @content: (params) ->
     @div class: @classes(params), tabindex: -1, =>

--- a/src/app/selection.coffee
+++ b/src/app/selection.coffee
@@ -96,7 +96,10 @@ class Selection
     @screenRangeChanged()
 
   selectWord: ->
-    @setBufferRange(@cursor.getCurrentWordBufferRange())
+    options = {}
+    options.wordRegex = /[\t ]*/ if @cursor.isSurroundedByWhitespace()
+
+    @setBufferRange(@cursor.getCurrentWordBufferRange(options))
     @wordwise = true
     @initialScreenRange = @getScreenRange()
 


### PR DESCRIPTION
Issued #82 caused me to rethink how Atom defines words. The config option `editor.nonWordCharacters` now determines words. I found it easier to understand and describe what is **not** a word rather than what **is** a word. This also changes Atom's word movement behavior to match Vim's instead of TextMates, because I think Vim has a better mechanic.
