### PR TITLE
support escape key to exit command panel

### DIFF
--- a/src/packages/command-panel/src/command-panel-view.coffee
+++ b/src/packages/command-panel/src/command-panel-view.coffee
@@ -44,6 +44,7 @@ class CommandPanelView extends View
 
     @command 'tool-panel:unfocus', => @rootView.focus()
     @command 'core:close', => @detach(); false
+    @command 'core:cancel', => @detach(); false
     @command 'core:confirm', => @execute()
     @command 'core:move-up', => @navigateBackwardInHistory()
     @command 'core:move-down', => @navigateForwardInHistory()

--- a/src/packages/command-panel/src/command-panel-view.coffee
+++ b/src/packages/command-panel/src/command-panel-view.coffee
@@ -44,7 +44,6 @@ class CommandPanelView extends View
 
     @command 'tool-panel:unfocus', => @rootView.focus()
     @command 'core:close', => @detach(); false
-    @command 'core:cancel', => @detach(); false
     @command 'core:confirm', => @execute()
     @command 'core:move-up', => @navigateBackwardInHistory()
     @command 'core:move-down', => @navigateForwardInHistory()

--- a/src/packages/command-panel/src/preview-list.coffee
+++ b/src/packages/command-panel/src/preview-list.coffee
@@ -83,7 +83,7 @@ class PreviewList extends ScrollView
     editSession = @rootView.open(operation.getPath())
     bufferRange = operation.execute(editSession)
     editSession.setSelectedBufferRange(bufferRange, autoscroll: true) if bufferRange
-    @rootView.focus()
+    @.focus()
     false
 
   getPathCount: ->


### PR DESCRIPTION
escape closes most dialogs except the command panel.  This allows you to use `esc` to get out of the command panel when it's focused.
