### PR TITLE
Not adding a font family when the user doesn't have it set

### DIFF
--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -520,9 +520,8 @@ describe "Editor", ->
     beforeEach ->
       expect(editor.css('font-family')).not.toBe 'Courier'
 
-    it "sets the initial font family based on the value from config", ->
-      expect($("head style.font-family")).toExist()
-      expect($("head style.font-family").text()).toMatch "{font-family: #{config.get('editor.fontFamily')}}"
+    it "when there is no config in fontFamily don't set it", ->
+      expect($("head style.font-family")).not.toExist()
 
     describe "when the font family changes", ->
       it "updates the font family on new and existing editors", ->
@@ -544,7 +543,7 @@ describe "Editor", ->
 
         lineHeightBefore = editor.lineHeight
         charWidthBefore = editor.charWidth
-        config.set("editor.fontFamily", "Courier")
+        config.set("editor.fontFamily", "Inconsolata")
         editor.setCursorScreenPosition [5, 6]
         expect(editor.charWidth).not.toBe charWidthBefore
         expect(editor.getCursorView().position()).toEqual { top: 5 * editor.lineHeight, left: 6 * editor.charWidth }

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -14,7 +14,6 @@ _ = require 'underscore'
 module.exports =
 class Editor extends View
   @configDefaults:
-    fontFamily: "Inconsolata, Monaco, Courier"
     fontSize: 20
     showInvisibles: false
     autosave: false
@@ -697,6 +696,7 @@ class Editor extends View
     parseInt(@css("font-size"))
 
   setFontFamily: (fontFamily) ->
+    return if fontFamily == undefined
     headTag = $("head")
     styleTag = headTag.find("style.font-family")
     if styleTag.length == 0


### PR DESCRIPTION
I don't think we should add a `font-family` to the head when the user **doesn't** have it set in their `config.json`.

Without it there, the theme can bundle it's own monospaced font with it. If we put a default value at the bottom, then it over writes the theme font-family and makes it difficult to override.

@probablycorey @Caged 
