### PR TITLE
Support variable width fonts

### DIFF
--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -541,6 +541,9 @@ describe "Editor", ->
       expect($("head style.font-family")).not.toExist()
 
     describe "when the font family changes", ->
+      afterEach ->
+        editor.clearFontFamily()
+
       it "updates the font family on new and existing editors", ->
         rootView.attachToDom()
         rootView.height(200)
@@ -549,7 +552,7 @@ describe "Editor", ->
         config.set("editor.fontFamily", "Courier")
         newEditor = editor.splitRight()
 
-        expect($("head style.font-family").text()).toMatch "{font-family: Courier}"
+        expect($("head style.editor-font-family").text()).toMatch "{font-family: Courier}"
         expect(editor.css('font-family')).toBe 'Courier'
         expect(newEditor.css('font-family')).toBe 'Courier'
 
@@ -560,7 +563,7 @@ describe "Editor", ->
 
         lineHeightBefore = editor.lineHeight
         charWidthBefore = editor.charWidth
-        config.set("editor.fontFamily", "Inconsolata")
+        config.set("editor.fontFamily", "Courier")
         editor.setCursorScreenPosition [5, 6]
         expect(editor.charWidth).not.toBe charWidthBefore
         expect(editor.getCursorView().position()).toEqual { top: 5 * editor.lineHeight, left: 6 * editor.charWidth }

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -1098,6 +1098,19 @@ describe "Editor", ->
         expect(editor.getSelection().isEmpty()).toBeTruthy()
         expect(cursorView).toBeVisible()
 
+      describe "when the editor is using a variable-width font", ->
+        beforeEach ->
+          editor.setFontFamily('sans-serif')
+
+        afterEach ->
+          editor.clearFontFamily()
+
+        it "correctly positions the cursor", ->
+          editor.setCursorBufferPosition([3, 30])
+          expect(editor.getCursorView().position()).toEqual {top: 3 * editor.lineHeight, left: 178}
+          editor.setCursorBufferPosition([3, Infinity])
+          expect(editor.getCursorView().position()).toEqual {top: 3 * editor.lineHeight, left: 353}
+
       describe "autoscrolling", ->
         it "only autoscrolls when the last cursor is moved", ->
           editor.setCursorBufferPosition([11,0])

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -633,7 +633,7 @@ describe "Editor", ->
         expect(editor.renderedLines.find(".line").length).toBeGreaterThan originalLineCount
 
       describe "when the editor is detached", ->
-        it "updates the font-size correctly and recalculates the dimensions by placing the rendered lines on the DOM", ->
+        it "redraws the editor according to the new font size when it is reattached", ->
           rootView.attachToDom()
           rootView.height(200)
           rootView.width(200)

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -482,13 +482,13 @@ describe "Editor", ->
       openHandler = jasmine.createSpy('openHandler')
       editor.on 'editor:attached', openHandler
 
-      editor.simulateDomAttachment()
+      editor.attachToDom()
       expect(openHandler).toHaveBeenCalled()
       [event, eventEditor] = openHandler.argsForCall[0]
       expect(eventEditor).toBe editor
 
       openHandler.reset()
-      editor.simulateDomAttachment()
+      editor.attachToDom()
       expect(openHandler).not.toHaveBeenCalled()
 
   describe "editor-path-changed event", ->

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -1351,7 +1351,6 @@ describe "Editor", ->
         it "changes the max line length and repositions the cursor when the window size changes", ->
           editor.setCursorBufferPosition([3, 60])
           setEditorWidthInChars(editor, 40)
-          $(window).trigger 'resize'
           expect(editor.renderedLines.find('.line').length).toBe 19
           expect(editor.renderedLines.find('.line:eq(4)').text()).toBe "left = [], right = [];"
           expect(editor.renderedLines.find('.line:eq(5)').text()).toBe "    while(items.length > 0) {"

--- a/src/app/display-buffer.coffee
+++ b/src/app/display-buffer.coffee
@@ -28,7 +28,8 @@ class DisplayBuffer
     @foldsById = {}
     @markers = {}
     @buildLineMap()
-    @tokenizedBuffer.on 'changed', (e) => @handleTokenizedBufferChange(e)
+    @tokenizedBuffer.on 'changed', @handleTokenizedBufferChange
+    @buffer.on 'markers-updated', @handleMarkersUpdated
 
   setVisible: (visible) -> @tokenizedBuffer.setVisible(visible)
 
@@ -37,8 +38,11 @@ class DisplayBuffer
     @lineMap.insertAtScreenRow 0, @buildLinesForBufferRows(0, @buffer.getLastRow())
 
   triggerChanged: (eventProperties, refreshMarkers=true) ->
-    @refreshMarkerScreenPositions() if refreshMarkers
+    if refreshMarkers
+      @pauseMarkerObservers()
+      @refreshMarkerScreenPositions()
     @trigger 'changed', eventProperties
+    @resumeMarkerObservers()
 
   setSoftWrapColumn: (@softWrapColumn) ->
     start = 0
@@ -131,7 +135,6 @@ class DisplayBuffer
       screenDelta = newScreenRange.end.row - oldScreenRange.end.row
       bufferDelta = 0
 
-      @refreshMarkerScreenPositions()
       @triggerChanged({ start, end, screenDelta, bufferDelta })
 
   destroyFoldsContainingBufferRow: (bufferRow) ->
@@ -216,7 +219,7 @@ class DisplayBuffer
     allFolds.push(folds...) for row, folds of @activeFolds
     fold.handleBufferChange(e) for fold in allFolds
 
-  handleTokenizedBufferChange: (tokenizedBufferChange) ->
+  handleTokenizedBufferChange: (tokenizedBufferChange) =>
     if bufferChange = tokenizedBufferChange.bufferChange
       @handleBufferChange(bufferChange)
       bufferDelta = bufferChange.newRange.end.row - bufferChange.oldRange.end.row
@@ -231,7 +234,17 @@ class DisplayBuffer
     @lineMap.replaceScreenRows(start, end, newScreenLines)
     screenDelta = @lastScreenRowForBufferRow(tokenizedBufferEnd + tokenizedBufferDelta) - end
 
-    @triggerChanged({ start, end, screenDelta, bufferDelta }, false)
+    changeEvent = { start, end, screenDelta, bufferDelta }
+    if bufferChange
+      @pauseMarkerObservers()
+      @pendingChangeEvent = changeEvent
+    else
+      @triggerChanged(changeEvent, false)
+
+  handleMarkersUpdated: =>
+    event = @pendingChangeEvent
+    @pendingChangeEvent = null
+    @triggerChanged(event, false)
 
   buildLineForBufferRow: (bufferRow) ->
     @buildLinesForBufferRows(bufferRow, bufferRow)
@@ -372,12 +385,19 @@ class DisplayBuffer
   observeMarker: (id, callback) ->
     @getMarker(id).observe(callback)
 
+  pauseMarkerObservers: ->
+    marker.pauseEvents() for marker in @getMarkers()
+
+  resumeMarkerObservers: ->
+    marker.resumeEvents() for marker in @getMarkers()
+
   refreshMarkerScreenPositions: ->
     for marker in @getMarkers()
       marker.notifyObservers(bufferChanged: false)
 
   destroy: ->
     @tokenizedBuffer.destroy()
+    @buffer.off 'markers-updated', @handleMarkersUpdated
 
   logLines: (start, end) ->
     @lineMap.logLines(start, end)

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -742,15 +742,18 @@ class Editor extends View
   setFontFamily: (fontFamily) ->
     return if fontFamily == undefined
     headTag = $("head")
-    styleTag = headTag.find("style.font-family")
+    styleTag = headTag.find("style.editor-font-family")
     if styleTag.length == 0
-      styleTag = $$ -> @style class: 'font-family'
+      styleTag = $$ -> @style class: 'editor-font-family'
       headTag.append styleTag
 
     styleTag.text(".editor {font-family: #{fontFamily}}")
     @redraw()
 
   getFontFamily: -> @css("font-family")
+
+  clearFontFamily: ->
+    $('head style.editor-font-family').remove()
 
   redraw: ->
     return unless @hasParent()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -1191,6 +1191,7 @@ class Editor extends View
     @pixelPositionForScreenPosition(@screenPositionForBufferPosition(position))
 
   pixelPositionForScreenPosition: (position) ->
+    return { top: 0, left: 0 } unless @isOnDom()
     {row, column} = Point.fromObject(position)
     [lineElement] = @buildLineElementsForScreenRows(row, row)
     @renderedLines.append(lineElement)

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -1208,7 +1208,6 @@ class Editor extends View
 
   positionLeftForLineAndColumn: (lineElement, column) ->
     return 0 if column is 0
-
     delta = 0
     iterator = document.createNodeIterator(lineElement, NodeFilter.SHOW_TEXT, acceptNode: -> NodeFilter.FILTER_ACCEPT)
     while textNode = iterator.nextNode()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -733,8 +733,7 @@ class Editor extends View
     if @isOnDom()
       @redraw()
     else
-      @redrawOnReattach = true
-
+      @redrawOnReattach = @attached
 
   getFontSize: ->
     parseInt(@css("font-size"))

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -1101,6 +1101,9 @@ class Editor extends View
     @pendingChanges.push(change)
     @requestDisplayUpdate()
 
+  buildLineElementForScreenRow: (screenRow) ->
+    @buildLineElementsForScreenRows(screenRow, screenRow)[0]
+
   buildLineElementsForScreenRows: (startRow, endRow) ->
     div = document.createElement('div')
     div.innerHTML = @buildLinesHtml(@activeEditSession.linesForScreenRows(startRow, endRow))
@@ -1192,11 +1195,16 @@ class Editor extends View
   pixelPositionForScreenPosition: (position) ->
     return { top: 0, left: 0 } unless @isOnDom()
     {row, column} = Point.fromObject(position)
-    [lineElement] = @buildLineElementsForScreenRows(row, row)
-    @renderedLines.append(lineElement)
+    actualRow = Math.floor(row)
+
+    lineElement = existingLineElement = @lineElementForScreenRow(actualRow)[0]
+    unless existingLineElement
+      lineElement = @buildLineElementForScreenRow(actualRow)
+      @renderedLines.append(lineElement)
     left = @positionLeftForLineAndColumn(lineElement, column)
-    @renderedLines[0].removeChild(lineElement)
-    { top: row * @lineHeight, left: left }
+    unless existingLineElement
+      @renderedLines[0].removeChild(lineElement)
+    { top: row * @lineHeight, left }
 
   positionLeftForLineAndColumn: (lineElement, column) ->
     return 0 if column is 0


### PR DESCRIPTION
The new atom-light-syntax theme makes use of bold, and since not all fixed-width fonts have the same width for bold and non-bold characters, this really forces our hand to support this.
- [x] make sure the whole build passes
- [x] investigate performance implications
- [x] optimize if necessary

![variable-width](https://f.cloud.github.com/assets/1789/142742/d2dd5088-7315-11e2-9211-564434c048af.gif)
