### PR TITLE
Sort buffers by most recently opened

### DIFF
--- a/src/packages/fuzzy-finder/lib/fuzzy-finder-view.coffee
+++ b/src/packages/fuzzy-finder/lib/fuzzy-finder-view.coffee
@@ -160,7 +160,7 @@ class FuzzyFinderView extends SelectList
 
     @setArray(@paths)
 
-  getPaths: ->
+  getOpenedPaths: ->
     paths = {}
     for editSession in rootView.project.getEditSessions()
       paths[editSession.getPath()] = editSession.lastOpened

--- a/src/packages/fuzzy-finder/lib/fuzzy-finder-view.coffee
+++ b/src/packages/fuzzy-finder/lib/fuzzy-finder-view.coffee
@@ -147,9 +147,7 @@ class FuzzyFinderView extends SelectList
       @loadPathsTask.start()
 
   populateOpenBufferPaths: ->
-    editSessions = []
-    rootView.eachEditSession (editSession) ->
-      editSessions.push editSession
+    editSessions = rootView.project.getEditSessions()
 
     editSessions = _.sortBy editSessions, (editSession) =>
       if editSession is rootView.getActiveEditSession()

--- a/src/packages/fuzzy-finder/lib/fuzzy-finder-view.coffee
+++ b/src/packages/fuzzy-finder/lib/fuzzy-finder-view.coffee
@@ -158,7 +158,7 @@ class FuzzyFinderView extends SelectList
         -(editSession.lastOpened or 1)
 
     @paths = _.map editSessions, (editSession) =>
-      rootView.project.relativize editSession.buffer.getPath()
+      rootView.project.relativize editSession.getPath()
 
     @setArray(@paths)
 

--- a/src/packages/fuzzy-finder/lib/fuzzy-finder-view.coffee
+++ b/src/packages/fuzzy-finder/lib/fuzzy-finder-view.coffee
@@ -160,6 +160,12 @@ class FuzzyFinderView extends SelectList
 
     @setArray(@paths)
 
+  getPaths: ->
+    paths = {}
+    for editSession in rootView.project.getEditSessions()
+      paths[editSession.getPath()] = editSession.lastOpened
+    paths
+
   detach: ->
     super
 

--- a/src/packages/fuzzy-finder/lib/fuzzy-finder.coffee
+++ b/src/packages/fuzzy-finder/lib/fuzzy-finder.coffee
@@ -30,7 +30,7 @@ module.exports =
     @fuzzyFinderView = null
 
   serialize: ->
-    @fuzzyFinderView?.getPaths()
+    @fuzzyFinderView?.getOpenedPaths()
 
   createView:  ->
     unless @fuzzyFinderView

--- a/src/packages/fuzzy-finder/lib/fuzzy-finder.coffee
+++ b/src/packages/fuzzy-finder/lib/fuzzy-finder.coffee
@@ -1,8 +1,10 @@
+_ = require 'underscore'
+
 module.exports =
   projectPaths: null
   fuzzyFinderView: null
 
-  activate: ->
+  activate: (state) ->
     rootView.command 'fuzzy-finder:toggle-file-finder', =>
       @createView().toggleFileFinder()
     rootView.command 'fuzzy-finder:toggle-buffer-finder', =>
@@ -15,12 +17,20 @@ module.exports =
       @loadPathsTask = new LoadPathsTask((paths) => @projectPaths = paths)
       @loadPathsTask.start()
 
+    for path, lastOpened of state
+      session = _.detect rootView.project.getEditSessions(), (editSession) ->
+        editSession.getPath() is path
+      session?.lastOpened = lastOpened
+
   deactivate: ->
     @loadPathsTask?.terminate()
     @fuzzyFinderView?.cancel()
     @fuzzyFinderView = null
     @projectPaths = null
     @fuzzyFinderView = null
+
+  serialize: ->
+    @fuzzyFinderView?.getPaths()
 
   createView:  ->
     unless @fuzzyFinderView

--- a/src/packages/fuzzy-finder/spec/fuzzy-finder-spec.coffee
+++ b/src/packages/fuzzy-finder/spec/fuzzy-finder-spec.coffee
@@ -1,6 +1,7 @@
 RootView = require 'root-view'
 FuzzyFinder = require 'fuzzy-finder/lib/fuzzy-finder-view'
 LoadPathsTask = require 'fuzzy-finder/lib/load-paths-task'
+_ = require 'underscore'
 $ = require 'jquery'
 {$$} = require 'space-pen'
 fs = require 'fs'
@@ -144,6 +145,21 @@ describe 'FuzzyFinder', ->
           expect(finderView.list.find("li:contains(sample.txt)")).toExist()
           expect(finderView.list.find("li:contains(sample-with-tabs.coffee)")).toExist()
           expect(finderView.list.children().first()).toHaveClass 'selected'
+
+        it "serializes the list of paths and their last opened time", ->
+          rootView.open 'sample-with-tabs.coffee'
+          rootView.trigger 'fuzzy-finder:toggle-buffer-finder'
+          rootView.open 'sample.js'
+          rootView.trigger 'fuzzy-finder:toggle-buffer-finder'
+
+          states = rootView.serialize().packageStates
+          states = _.map states['fuzzy-finder'], (path, time) -> [ path, time ]
+          states = _.sortBy states, (path, time) -> -time
+
+          paths = [ 'sample-with-tabs.coffee', 'sample.txt', 'sample.js' ]
+          for [time, path] in states
+            expect(_.last path.split '/').toBe paths.shift()
+            expect(time).toBeGreaterThan 50000
 
       describe "when the active editor only contains edit sessions for anonymous buffers", ->
         it "does not open", ->

--- a/src/packages/fuzzy-finder/spec/fuzzy-finder-spec.coffee
+++ b/src/packages/fuzzy-finder/spec/fuzzy-finder-spec.coffee
@@ -123,11 +123,26 @@ describe 'FuzzyFinder', ->
           rootView.trigger 'fuzzy-finder:toggle-buffer-finder'
           expect(finderView.miniEditor.getText()).toBe ''
 
-        it "lists the paths of the current open buffers", ->
+        it "lists the paths of the current open buffers by most recently modified", ->
+          rootView.attachToDom()
+          rootView.open 'sample-with-tabs.coffee'
           rootView.trigger 'fuzzy-finder:toggle-buffer-finder'
-          expect(finderView.list.children('li').length).toBe 2
+          children = finderView.list.children('li')
+          expect(children.get(0).outerText).toBe "sample.txt"
+          expect(children.get(1).outerText).toBe "sample.js"
+          expect(children.get(2).outerText).toBe "sample-with-tabs.coffee"
+
+          rootView.open 'sample.txt'
+          rootView.trigger 'fuzzy-finder:toggle-buffer-finder'
+          children = finderView.list.children('li')
+          expect(children.get(0).outerText).toBe "sample-with-tabs.coffee"
+          expect(children.get(1).outerText).toBe "sample.js"
+          expect(children.get(2).outerText).toBe "sample.txt"
+
+          expect(finderView.list.children('li').length).toBe 3
           expect(finderView.list.find("li:contains(sample.js)")).toExist()
           expect(finderView.list.find("li:contains(sample.txt)")).toExist()
+          expect(finderView.list.find("li:contains(sample-with-tabs.coffee)")).toExist()
           expect(finderView.list.children().first()).toHaveClass 'selected'
 
       describe "when the active editor only contains edit sessions for anonymous buffers", ->


### PR DESCRIPTION
This orders the buffers in `meta-b` by the time they were opened. The most recently opened buffer is at the top. The currently opened buffer is at the bottom. This means you can keep hitting `meta-b` to toggle between two files you're working on.
