### PR TITLE
Package generator

### DIFF
--- a/spec/app/atom-spec.coffee
+++ b/spec/app/atom-spec.coffee
@@ -101,7 +101,7 @@ describe "the `atom` global", ->
     describe ".activateAtomPackage(package)", ->
       it "calls activate on the package", ->
         atom.activateAtomPackage(pack)
-        expect(packageModule.activate).toHaveBeenCalledWith(undefined)
+        expect(packageModule.activate).toHaveBeenCalledWith({})
 
       it "calls activate on the package module with its previous state", ->
         atom.activateAtomPackage(pack)

--- a/spec/spec-suite.coffee
+++ b/spec/spec-suite.coffee
@@ -8,6 +8,6 @@ for path in fs.listTree(require.resolve("spec")) when /-spec\.coffee$/.test path
 
 # Run extension specs
 for packageDirPath in config.packageDirPaths
-  for packagePath in fs.listTree(packageDirPath)
+  for packagePath in fs.list(packageDirPath)
     for path in fs.listTree(fs.join(packagePath, "spec")) when /-spec\.coffee$/.test path
       require path

--- a/spec/stdlib/underscore-extensions-spec.coffee
+++ b/spec/stdlib/underscore-extensions-spec.coffee
@@ -30,3 +30,27 @@ describe "underscore extensions", ->
       expect(_.endsWith("test.txt", ".txt2")).toBeFalsy()
       expect(_.endsWith("test.txt", ".tx")).toBeFalsy()
       expect(_.endsWith("test.txt", "test")).toBeFalsy()
+
+  describe "camelize(string)", ->
+    it "converts `string` to camel case", ->
+      expect(_.camelize("corey_dale_johnson")).toBe "coreyDaleJohnson"
+      expect(_.camelize("corey-dale-johnson")).toBe "coreyDaleJohnson"
+      expect(_.camelize("corey_dale-johnson")).toBe "coreyDaleJohnson"
+      expect(_.camelize("coreyDaleJohnson")).toBe "coreyDaleJohnson"
+      expect(_.camelize("CoreyDaleJohnson")).toBe "CoreyDaleJohnson"
+
+  describe "dasherize(string)", ->
+    it "converts `string` to use dashes", ->
+      expect(_.dasherize("corey_dale_johnson")).toBe "corey-dale-johnson"
+      expect(_.dasherize("coreyDaleJohnson")).toBe "corey-dale-johnson"
+      expect(_.dasherize("CoreyDaleJohnson")).toBe "corey-dale-johnson"
+      expect(_.dasherize("corey-dale-johnson")).toBe "corey-dale-johnson"
+
+  describe "underscore(string)", ->
+    it "converts `string` to use underscores", ->
+      expect(_.underscore("corey-dale-johnson")).toBe "corey_dale_johnson"
+      expect(_.underscore("coreyDaleJohnson")).toBe "corey_dale_johnson"
+      expect(_.underscore("CoreyDaleJohnson")).toBe "corey_dale_johnson"
+      expect(_.underscore("corey_dale_johnson")).toBe "corey_dale_johnson"
+
+

--- a/src/app/atom.coffee
+++ b/src/app/atom.coffee
@@ -18,7 +18,7 @@ _.extend atom,
 
   activateAtomPackage: (pack) ->
     @activatedAtomPackages.push(pack)
-    pack.packageMain.activate(@atomPackageStates[pack.name])
+    pack.packageMain.activate(@atomPackageStates[pack.name] ? {})
 
   deactivateAtomPackages: ->
     pack.packageMain.deactivate?() for pack in @activatedAtomPackages

--- a/src/app/config.coffee
+++ b/src/app/config.coffee
@@ -18,6 +18,7 @@ class Config
   configDirPath: configDirPath
   themeDirPaths: [userThemesDirPath, bundledThemesDirPath, vendoredThemesDirPath]
   packageDirPaths: [userPackagesDirPath, vendoredPackagesDirPath, bundledPackagesDirPath]
+  userPackagesDirPath: userPackagesDirPath
   defaultSettings: null
   settings: null
 

--- a/src/app/keymaps/editor.cson
+++ b/src/app/keymaps/editor.cson
@@ -44,3 +44,8 @@
   'ctrl-meta-up': 'editor:move-line-up'
   'ctrl-meta-down': 'editor:move-line-down'
   'meta-D': 'editor:duplicate-line'
+
+'.editor.mini':
+  'enter': 'core:confirm',
+  'escape': 'core:cancel'
+  'meta-w': 'core:cancel'

--- a/src/packages/command-logger/lib/command-logger.coffee
+++ b/src/packages/command-logger/lib/command-logger.coffee
@@ -5,7 +5,7 @@ module.exports =
   commandLoggerView: null
   originalTrigger: null
 
-  activate: (state={})->
+  activate: (state) ->
     @eventLog = state.eventLog ? {}
     rootView.command 'command-logger:clear-data', => @eventLog = {}
     rootView.command 'command-logger:toggle', => @createView().toggle(@eventLog)

--- a/src/packages/command-panel/lib/command-panel-view.coffee
+++ b/src/packages/command-panel/lib/command-panel-view.coffee
@@ -23,7 +23,7 @@ class CommandPanelView extends View
   historyIndex: 0
   maxSerializedHistorySize: 100
 
-  initialize: (state={}) ->
+  initialize: (state) ->
     @commandInterpreter = new CommandInterpreter(rootView.project)
 
     @command 'tool-panel:unfocus', => rootView.focus()

--- a/src/packages/package-generator/lib/package-generator-view.coffee
+++ b/src/packages/package-generator/lib/package-generator-view.coffee
@@ -1,0 +1,68 @@
+{View} = require 'space-pen'
+Editor = require 'editor'
+$ = require 'jquery'
+fs = require 'fs'
+
+module.exports =
+class PackageGeneratorView extends View
+  previouslyFocusedElement: null
+
+  @content: ->
+    @div class: 'package-generator overlay from-top', =>
+      @subview 'miniEditor', new Editor(mini: true)
+      @div class: 'error', outlet: 'error'
+      @div class: 'message', outlet: 'message'
+
+  initialize: ->
+    rootView.command "package-generator:generate", => @attach()
+    @miniEditor.on 'focusout', => @detach()
+    @on 'core:confirm', => @confirm()
+    @on 'core:cancel', => @detach()
+
+  attach: ->
+    @previouslyFocusedElement = $(':focus')
+    @message.text("Enter package path")
+    placeholderName = "package-name"
+    @miniEditor.setText(fs.join(config.userPackagesDirPath, placeholderName));
+    pathLength = @miniEditor.getText().length
+    @miniEditor.setSelectedBufferRange([[0, pathLength - placeholderName.length], [0, pathLength]])
+    @miniEditor.focus()
+    rootView.append(this)
+
+  detach: ->
+    return unless @hasParent()
+    @previouslyFocusedElement?.focus()
+    super
+
+  confirm: ->
+    if @validPackagePath()
+      @createPackageFiles()
+      atom.open(@getPackagePath())
+      @detach()
+
+  getPackagePath: ->
+    @miniEditor.getText()
+
+  validPackagePath: ->
+    if fs.exists(@getPackagePath())
+      @error.text("Path already exists at '#{@getPackagePath()}'")
+      @error.show()
+      false
+    else
+      true
+
+  createPackageFiles: ->
+    templatePath = require.resolve(fs.join("package-generator", "template"))
+    packageName = fs.base(@getPackagePath())
+
+    for path in fs.listTree(templatePath)
+      relativePath = path.replace(templatePath, "")
+      relativePath = relativePath.replace(/^\//, '')
+      relativePath = relativePath.replace("__packageName__", packageName)
+
+      sourcePath = fs.join(@getPackagePath(), relativePath)
+      if fs.isDirectory(path)
+        fs.makeTree(sourcePath)
+      if fs.isFile(path)
+        fs.makeTree(fs.directory(sourcePath))
+        fs.write(sourcePath, fs.read(path))

--- a/src/packages/package-generator/lib/package-generator.coffee
+++ b/src/packages/package-generator/lib/package-generator.coffee
@@ -1,0 +1,7 @@
+PackageGeneratorView = require 'package-generator/lib/package-generator-view'
+
+module.exports =
+  view: null
+
+  activate: (state) ->
+    @view = new PackageGeneratorView()

--- a/src/packages/package-generator/package.cson
+++ b/src/packages/package-generator/package.cson
@@ -1,0 +1,1 @@
+'main': 'lib/package-generator'

--- a/src/packages/package-generator/spec/package-generator-spec.coffee
+++ b/src/packages/package-generator/spec/package-generator-spec.coffee
@@ -1,0 +1,90 @@
+RootView = require 'root-view'
+fs = require 'fs'
+
+describe 'Package Generator', ->
+  [packageGenerator] = []
+
+  beforeEach ->
+    new RootView(require.resolve('fixtures/sample.js'))
+    atom.loadPackage("package-generator")
+
+  afterEach ->
+    rootView.deactivate()
+
+  describe "when package-generator:generate is triggered", ->
+    it "displays a miniEditor", ->
+      rootView.trigger("package-generator:generate")
+      packageGeneratorView = rootView.find(".package-generator")
+      expect(packageGeneratorView).toExist()
+
+  describe "when core:cancel is triggered", ->
+    it "detaches from the DOM and focuses the the previously focused element", ->
+      rootView.attachToDom()
+      rootView.trigger("package-generator:generate")
+      packageGeneratorView = rootView.find(".package-generator").view()
+      expect(packageGeneratorView.miniEditor.isFocused).toBeTruthy()
+      expect(rootView.getActiveEditor().isFocused).toBeFalsy()
+
+      packageGeneratorView.trigger("core:cancel")
+      expect(packageGeneratorView.hasParent()).toBeFalsy()
+      expect(rootView.getActiveEditor().isFocused).toBeTruthy()
+
+  describe "when a package is generated", ->
+    [packageName, packagePath] = []
+
+    beforeEach ->
+      spyOn(atom, "open")
+
+      packageName = "sweet-package-dude"
+      packagePath = "/tmp/atom-packages/#{packageName}"
+      fs.remove(packagePath) if fs.exists(packagePath)
+
+      @addMatchers
+        toExistOnDisk: (expected) ->
+          notText = this.isNot and " not" or ""
+          @message = -> return "Expected path '" + @actual + notText + "' to exist."
+          fs.exists(@actual)
+
+    afterEach ->
+      fs.remove(packagePath) if fs.exists(packagePath)
+
+    it "correctly lays out the package files and closes the package generator view", ->
+      rootView.trigger("package-generator:generate")
+      packageGeneratorView = rootView.find(".package-generator").view()
+      expect(packageGeneratorView.hasParent()).toBeTruthy()
+      packageGeneratorView.miniEditor.setText(packagePath)
+      packageGeneratorView.miniEditor.trigger "core:confirm"
+
+      expect("#{packagePath}/package.cson").toExistOnDisk()
+      expect("#{packagePath}/lib/#{packageName}.coffee").toExistOnDisk()
+      expect("#{packagePath}/lib/#{packageName}-view.coffee").toExistOnDisk()
+      expect("#{packagePath}/spec/#{packageName}-spec.coffee").toExistOnDisk()
+      expect("#{packagePath}/spec/#{packageName}-view-spec.coffee").toExistOnDisk()
+      expect("#{packagePath}/keymaps/#{packageName}.cson").toExistOnDisk()
+      expect("#{packagePath}/stylesheets/#{packageName}.css").toExistOnDisk()
+
+      expect(packageGeneratorView.hasParent()).toBeFalsy()
+      expect(rootView.getActiveEditor().isFocused).toBeTruthy()
+
+    it "displays an error when the package path already exists", ->
+      rootView.attachToDom()
+      fs.makeTree(packagePath)
+      rootView.trigger("package-generator:generate")
+      packageGeneratorView = rootView.find(".package-generator").view()
+
+      expect(packageGeneratorView.hasParent()).toBeTruthy()
+      expect(packageGeneratorView.error).not.toBeVisible()
+      packageGeneratorView.miniEditor.setText(packagePath)
+      packageGeneratorView.miniEditor.trigger "core:confirm"
+      expect(packageGeneratorView.hasParent()).toBeTruthy()
+      expect(packageGeneratorView.error).toBeVisible()
+
+    it "opens the package", ->
+      rootView.trigger("package-generator:generate")
+      packageGeneratorView = rootView.find(".package-generator").view()
+      packageGeneratorView.miniEditor.setText(packagePath)
+      packageGeneratorView.trigger "core:confirm"
+
+      expect(atom.open).toHaveBeenCalledWith(packagePath)
+
+

--- a/src/packages/package-generator/stylesheets/package-generator.css
+++ b/src/packages/package-generator/stylesheets/package-generator.css
@@ -1,0 +1,3 @@
+.package-generator .error {
+  display: none;
+}

--- a/src/packages/package-generator/template/keymaps/##package-name##.cson
+++ b/src/packages/package-generator/template/keymaps/##package-name##.cson
@@ -1,0 +1,3 @@
+# DOCUMENT: link to keymap documentation
+'body':
+  'meta-alt-ctrl-o': '##package-name##:toggle'

--- a/src/packages/package-generator/template/lib/##package-name##-view.coffee
+++ b/src/packages/package-generator/template/lib/##package-name##-view.coffee
@@ -1,0 +1,25 @@
+{$$, View} = require 'space-pen'
+
+module.exports =
+class ##PackageName##View extends View
+  @content: ->
+    @div class: '##package-name## overlay from-top', =>
+      @div "The ##PackageName## package is Alive! It's ALIVE!", class: "message"
+
+  initialize: (serializeState) ->
+    rootView.command "##package-name##:toggle", => @toggle()
+
+  # Returns an object that can be retrieved when package is activated
+  serialize: ->
+
+  # Tear down any state and detach
+  destroy: ->
+    @detach()
+
+  toggle: ->
+    console.log "##PackageName##View was toggled!"
+    if @hasParent()
+      @detach()
+    else
+      rootView.append(this)
+

--- a/src/packages/package-generator/template/lib/##package-name##.coffee
+++ b/src/packages/package-generator/template/lib/##package-name##.coffee
@@ -1,0 +1,13 @@
+##PackageName##View = require '##package-name##/lib/##package-name##-view'
+
+module.exports =
+  ##packageName##View: null
+
+  activate: (state) ->
+    @##packageName##View = new ##PackageName##View(state.##packageName##ViewState)
+
+  deactivate: ->
+    @##packageName##View.destroy()
+
+  serialize: ->
+    ##packageName##ViewState: @##packageName##View.serialize()

--- a/src/packages/package-generator/template/package.cson
+++ b/src/packages/package-generator/template/package.cson
@@ -1,0 +1,2 @@
+'main': 'lib/##package-name##'
+'activationEvents': ['##package-name##:toggle']

--- a/src/packages/package-generator/template/spec/##package-name##-spec.coffee
+++ b/src/packages/package-generator/template/spec/##package-name##-spec.coffee
@@ -1,0 +1,5 @@
+##PackageName## = require '##package-name##/lib/##package-name##'
+
+describe "##PackageName##", ->
+  it "has one valid test", ->
+    expect("life").toBe "easy"

--- a/src/packages/package-generator/template/spec/##package-name##-view-spec.coffee
+++ b/src/packages/package-generator/template/spec/##package-name##-view-spec.coffee
@@ -1,0 +1,24 @@
+##PackageName##View = require '##package-name##/lib/##package-name##-view'
+RootView = require 'root-view'
+
+# This spec is focused because it starts with an `f`. Remove the `f`
+# to unfocus the spec.
+#
+# Press meta-alt-ctrl-s to run the specs
+fdescribe "##PackageName##View", ->
+  ##packageName## = null
+
+  beforeEach ->
+    new RootView()
+    ##packageName## = atom.loadPackage('##packageName##', activateImmediately: true)
+
+  afterEach ->
+    rootView.deactivate()
+
+  describe "when the ##package-name##:toggle event is triggered", ->
+    it "attaches and then detaches the view", ->
+      expect(rootView.find('.##package-name##')).not.toExist()
+      rootView.trigger '##package-name##:toggle'
+      expect(rootView.find('.##package-name##')).toExist()
+      rootView.trigger '##package-name##:toggle'
+      expect(rootView.find('.##package-name##')).not.toExist()

--- a/src/packages/package-generator/template/stylesheets/##package-name##.css
+++ b/src/packages/package-generator/template/stylesheets/##package-name##.css
@@ -1,0 +1,2 @@
+.##package-name## {
+}

--- a/src/packages/tree-view/lib/tree-view.coffee
+++ b/src/packages/tree-view/lib/tree-view.coffee
@@ -10,33 +10,17 @@ _ = require 'underscore'
 
 module.exports =
 class TreeView extends ScrollView
-  @activate: (state) ->
-    if state
-      TreeView.deserialize(state)
-    else
-      new TreeView
-
   @content: (rootView) ->
     @div class: 'tree-view-wrapper', =>
       @ol class: 'tree-view tool-panel', tabindex: -1, outlet: 'treeViewList'
       @div class: 'tree-view-resizer', outlet: 'resizer'
-
-  @deserialize: (state) ->
-    treeView = new TreeView
-    treeView.root.deserializeEntryExpansionStates(state.directoryExpansionStates)
-    treeView.selectEntryForPath(state.selectedPath)
-    treeView.focusAfterAttach = state.hasFocus
-    treeView.scrollTopAfterAttach = state.scrollTop
-    treeView.width(state.width)
-    treeView.attach() if state.attached
-    treeView
 
   root: null
   focusAfterAttach: false
   scrollTopAfterAttach: -1
   selectedPath: null
 
-  initialize: ->
+  initialize: (state) ->
     super
     @on 'click', '.entry', (e) => @entryClicked(e)
     @on 'mousedown', '.tree-view-resizer', (e) => @resizeStarted(e)
@@ -60,7 +44,14 @@ class TreeView extends ScrollView
     rootView.project.on 'path-changed', => @updateRoot()
     @observeConfig 'core.hideGitIgnoredFiles', => @updateRoot()
 
-    @selectEntry(@root) if @root
+    if @root
+      @selectEntry(@root)
+      @root.deserializeEntryExpansionStates(state.directoryExpansionStates)
+    @selectEntryForPath(state.selectedPath) if state.selectedPath
+    @focusAfterAttach = state.hasFocus
+    @scrollTopAfterAttach = state.scrollTop if state.scrollTop
+    @width(state.width) if state.width
+    @attach() if state.attached
 
   afterAttach: (onDom) ->
     @focus() if @focusAfterAttach

--- a/src/packages/tree-view/lib/tree.coffee
+++ b/src/packages/tree-view/lib/tree.coffee
@@ -1,7 +1,7 @@
 module.exports =
   treeView: null
 
-  activate: (@state={}) ->
+  activate: (@state) ->
     @createView() if @state.attached
     rootView.command 'tree-view:toggle', => @createView().toggle()
     rootView.command 'tree-view:reveal-active-file', => @createView().revealActiveFile()

--- a/src/packages/tree-view/lib/tree.coffee
+++ b/src/packages/tree-view/lib/tree.coffee
@@ -1,12 +1,8 @@
 module.exports =
   treeView: null
 
-  activate: (@state) ->
-    if state
-      @createView().attach() if state.attached
-    else if rootView.project.getPath() and not rootView.pathToOpenIsFile
-      @createView().attach()
-
+  activate: (@state={}) ->
+    @createView() if @state.attached
     rootView.command 'tree-view:toggle', => @createView().toggle()
     rootView.command 'tree-view:reveal-active-file', => @createView().revealActiveFile()
 
@@ -23,5 +19,5 @@ module.exports =
   createView: ->
     unless @treeView?
       TreeView = require 'tree-view/lib/tree-view'
-      @treeView = TreeView.activate(@state)
+      @treeView = new TreeView(@state)
     @treeView

--- a/src/stdlib/underscore-extensions.coffee
+++ b/src/stdlib/underscore-extensions.coffee
@@ -69,6 +69,25 @@ _.mixin
     else
       "#{count} #{plural}"
 
+  camelize: (string) ->
+    string.replace /[_-]+(\w)/g, (m) -> m[1].toUpperCase()
+
+  dasherize: (string) ->
+    string = string[0].toLowerCase() + string[1..]
+    string.replace /([A-Z])|(_)/g, (m, letter, underscore) ->
+      if letter
+        "-" + letter.toLowerCase()
+      else
+        "-"
+
+  underscore: (string) ->
+    string = string[0].toLowerCase() + string[1..]
+    string.replace /([A-Z])|(-)/g, (m, letter, dash) ->
+      if letter
+        "_" + letter.toLowerCase()
+      else
+        "_"
+
   losslessInvert: (hash) ->
     inverted = {}
     for key, value of hash


### PR DESCRIPTION
Based on Issued #130.

Calling the `package-generator:generate` command will create a basic package in ~/.atom/packages. I tried to keep the package as simple as possible but enforce conventions that we use. For example, the generated `package.cson` file includes `activationEvents` so the package won't be loaded synchronously on launch. Hopefully this will feel more natural than a CLI based generator.

I'd like to talk to @jonrohan and @Caged about adding theme generator support.
