### PR TITLE
Resize tree view when resizing the window

### DIFF
--- a/src/packages/tree-view/lib/tree-view.coffee
+++ b/src/packages/tree-view/lib/tree-view.coffee
@@ -24,6 +24,7 @@ class TreeView extends ScrollView
     super
     @on 'click', '.entry', (e) => @entryClicked(e)
     @on 'mousedown', '.tree-view-resizer', (e) => @resizeStarted(e)
+    @subscribe $(window), 'resize', => @resize()
     @command 'core:move-up', => @moveUp()
     @command 'core:move-down', => @moveDown()
     @command 'core:close', => @detach(); false
@@ -119,6 +120,9 @@ class TreeView extends ScrollView
 
   resizeTreeView: (e) =>
     @css(width: e.pageX)
+
+  resize: =>
+    @treeViewList.append(@root?.remove())
 
   updateRoot: ->
     @root?.remove()

--- a/src/packages/tree-view/spec/tree-view-spec.coffee
+++ b/src/packages/tree-view/spec/tree-view-spec.coffee
@@ -960,3 +960,9 @@ describe "TreeView", ->
     describe "when a file is ignored", ->
       it "adds a custom style", ->
         expect(treeView.find('.file:contains(tree-view.js)')).toHaveClass 'ignored'
+
+  describe "when the window containing the view is resized", ->
+    it "resizes the tree view as well", ->
+      spyOn(treeView, "resize")
+      $(window).trigger 'resize'
+      expect(treeView.resize).toHaveBeenCalled()


### PR DESCRIPTION
When resizing the tree view it does not update the background, leaving a grey shape in the newly created window area:

![Screen Shot 2013-02-20 at 3 25 58 PM](https://f.cloud.github.com/assets/829/176103/82cc075e-7b69-11e2-95c8-066d7fa6ac8d.png)
