### PR TITLE
Spell check

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Welcome to Atom. This documentation is intented to offer a basic introduction
+Welcome to Atom. This documentation is intended to offer a basic introduction
 of how to get productive with this editor. Then we'll delve into more details
 about configuring, theming, and extending Atom.
 

--- a/native/v8_extensions/native.mm
+++ b/native/v8_extensions/native.mm
@@ -27,7 +27,8 @@ namespace v8_extensions {
       "exists", "read", "write", "absolute", "getAllFilePathsAsync", "traverseTree", "isDirectory",
       "isFile", "remove", "writeToPasteboard", "readFromPasteboard", "quit", "watchPath", "unwatchPath",
       "getWatchedPaths", "unwatchAllPaths", "makeDirectory", "move", "moveToTrash", "reload", "lastModified",
-      "md5ForPath", "exec", "getPlatform", "setWindowState", "getWindowState", "isMisspelled"
+      "md5ForPath", "exec", "getPlatform", "setWindowState", "getWindowState", "isMisspelled",
+      "getCorrectionsForMisspelling"
     };
 
     CefRefPtr<CefV8Value> nativeObject = CefV8Value::CreateObject(NULL);
@@ -525,6 +526,22 @@ namespace v8_extensions {
       NSString *word = stringFromCefV8Value(arguments[0]);
       NSRange range = [[NSSpellChecker sharedSpellChecker] checkSpellingOfString:word startingAt:0];
       retval = CefV8Value::CreateBool(range.length > 0);
+      return true;
+    }
+
+    else if (name == "getCorrectionsForMisspelling") {
+      NSString *misspelling = stringFromCefV8Value(arguments[0]);
+      NSSpellChecker *spellchecker = [NSSpellChecker sharedSpellChecker];
+      NSString *language = [spellchecker language];
+      NSRange range;
+      range.location = 0;
+      range.length = [misspelling length];
+      NSArray *guesses = [spellchecker guessesForWordRange:range inString:misspelling language:language inSpellDocumentWithTag:0];
+      CefRefPtr<CefV8Value> v8Guesses = CefV8Value::CreateArray([guesses count]);
+      for (int i = 0; i < [guesses count]; i++) {
+        v8Guesses->SetValue(i, CefV8Value::CreateString([[guesses objectAtIndex:i] UTF8String]));
+      }
+      retval = v8Guesses;
       return true;
     }
 

--- a/native/v8_extensions/native.mm
+++ b/native/v8_extensions/native.mm
@@ -27,7 +27,7 @@ namespace v8_extensions {
       "exists", "read", "write", "absolute", "getAllFilePathsAsync", "traverseTree", "isDirectory",
       "isFile", "remove", "writeToPasteboard", "readFromPasteboard", "quit", "watchPath", "unwatchPath",
       "getWatchedPaths", "unwatchAllPaths", "makeDirectory", "move", "moveToTrash", "reload", "lastModified",
-      "md5ForPath", "exec", "getPlatform", "setWindowState", "getWindowState"
+      "md5ForPath", "exec", "getPlatform", "setWindowState", "getWindowState", "isMisspelled"
     };
 
     CefRefPtr<CefV8Value> nativeObject = CefV8Value::CreateObject(NULL);
@@ -518,6 +518,13 @@ namespace v8_extensions {
       [windowStateLock lock];
       retval = CefV8Value::CreateString(windowState);
       [windowStateLock unlock];
+      return true;
+    }
+
+    else if (name == "isMisspelled") {
+      NSString *word = stringFromCefV8Value(arguments[0]);
+      NSRange range = [[NSSpellChecker sharedSpellChecker] checkSpellingOfString:word startingAt:0];
+      retval = CefV8Value::CreateBool(range.length > 0);
       return true;
     }
 

--- a/spec/app/buffer-spec.coffee
+++ b/spec/app/buffer-spec.coffee
@@ -861,8 +861,8 @@ describe 'Buffer', ->
         buffer.undo()
         expect(buffer.getMarkerRange(marker)).toBeUndefined()
 
-        # even "stayValid" markers get destroyed properly
-        marker2 = buffer.markRange([[4, 20], [4, 23]], stayValid: true)
+        # even "invalidationStrategy: never" markers get destroyed properly
+        marker2 = buffer.markRange([[4, 20], [4, 23]], invalidationStrategy: 'never')
         buffer.delete([[4, 15], [4, 25]])
         buffer.destroyMarker(marker2)
         buffer.undo()
@@ -873,7 +873,7 @@ describe 'Buffer', ->
 
       beforeEach ->
         marker1 = buffer.markRange([[4, 20], [4, 23]])
-        marker2 = buffer.markRange([[4, 20], [4, 23]], stayValid: true)
+        marker2 = buffer.markRange([[4, 20], [4, 23]], invalidationStrategy: 'never')
 
       describe "when the buffer changes due to a new operation", ->
         describe "when the change precedes the marker range", ->
@@ -911,14 +911,14 @@ describe 'Buffer', ->
             expect(buffer.getMarkerRange(marker1)).toEqual [[4, 20], [4, 26]]
 
         describe "when the change surrounds the marker range", ->
-          describe "when the marker was created with stayValid: false (the default)", ->
+          describe "when the marker's invalidation strategy is 'contains' (the default)", ->
             it "invalidates the marker", ->
               buffer.delete([[4, 15], [4, 25]])
               expect(buffer.getMarkerRange(marker1)).toBeUndefined()
               buffer.undo()
               expect(buffer.getMarkerRange(marker1)).toEqual [[4, 20], [4, 23]]
 
-          describe "when the marker was created with stayValid: true", ->
+          describe "when the marker's invalidation strategy is 'never'", ->
             it "does not invalidate the marker, but sets it to an empty range at the end of the change", ->
               buffer.change([[4, 15], [4, 25]], "...")
               expect(buffer.getMarkerRange(marker2)).toEqual [[4, 18], [4, 18]]
@@ -926,14 +926,14 @@ describe 'Buffer', ->
               expect(buffer.getMarkerRange(marker2)).toEqual [[4, 20], [4, 23]]
 
         describe "when the change straddles the start of the marker range", ->
-          describe "when the marker was created with stayValid: false (the default)", ->
+          describe "when the marker's invalidation strategy is 'contains' (the default)", ->
             it "invalidates the marker", ->
               buffer.delete([[4, 15], [4, 22]])
               expect(buffer.getMarkerRange(marker1)).toBeUndefined()
               buffer.undo()
               expect(buffer.getMarkerRange(marker1)).toEqual [[4, 20], [4, 23]]
 
-          describe "when the marker was created with stayValid: true", ->
+          describe "when the marker's invalidation strategy is 'never'", ->
             it "moves the start of the marker range to the end of the change", ->
               buffer.delete([[4, 15], [4, 22]])
               expect(buffer.getMarkerRange(marker2)).toEqual [[4, 15], [4, 16]]
@@ -941,14 +941,14 @@ describe 'Buffer', ->
               expect(buffer.getMarkerRange(marker1)).toEqual [[4, 20], [4, 23]]
 
         describe "when the change straddles the end of the marker range", ->
-          describe "when the marker was created with stayValid: false (the default)", ->
+          describe "when the marker's invalidation strategy is 'contains' (the default)", ->
             it "invalidates the marker", ->
               buffer.delete([[4, 22], [4, 25]])
               expect(buffer.getMarkerRange(marker1)).toBeUndefined()
               buffer.undo()
               expect(buffer.getMarkerRange(marker1)).toEqual [[4, 20], [4, 23]]
 
-          describe "when the marker was created with stayValid: true", ->
+          describe "when the marker's invalidation strategy is 'never'", ->
             it "moves the end of the marker range to the start of the change", ->
               buffer.delete([[4, 22], [4, 25]])
               expect(buffer.getMarkerRange(marker2)).toEqual [[4, 20], [4, 22]]

--- a/spec/app/buffer-spec.coffee
+++ b/spec/app/buffer-spec.coffee
@@ -741,6 +741,7 @@ describe 'Buffer', ->
           oldTailPosition: [4, 20]
           newTailPosition: [4, 20]
           bufferChanged: false
+          valid: true
         }
         observeHandler.reset()
 
@@ -751,6 +752,7 @@ describe 'Buffer', ->
           oldHeadPosition: [6, 2]
           newHeadPosition: [6, 5]
           bufferChanged: true
+          valid: true
         }
 
       it "calls the given callback when the marker's tail position changes", ->
@@ -762,6 +764,7 @@ describe 'Buffer', ->
           oldTailPosition: [4, 20]
           newTailPosition: [6, 2]
           bufferChanged: false
+          valid: true
         }
         observeHandler.reset()
 
@@ -773,6 +776,7 @@ describe 'Buffer', ->
           oldTailPosition: [6, 2]
           newTailPosition: [6, 5]
           bufferChanged: true
+          valid: true
         }
 
       it "calls the callback when the selection's tail is cleared", ->
@@ -784,6 +788,7 @@ describe 'Buffer', ->
           oldTailPosition: [4, 20]
           newTailPosition: [4, 23]
           bufferChanged: false
+          valid: true
         }
 
       it "only calls the callback once when both the marker's head and tail positions change due to the same operation", ->
@@ -795,6 +800,7 @@ describe 'Buffer', ->
           oldHeadPosition: [4, 23]
           newHeadPosition: [4, 26]
           bufferChanged: true
+          valid: true
         }
         observeHandler.reset()
 
@@ -806,6 +812,31 @@ describe 'Buffer', ->
           oldHeadPosition: [4, 26]
           newHeadPosition: [1, 1]
           bufferChanged: false
+          valid: true
+        }
+
+      it "calls the callback with the valid flag set to false when the marker is invalidated", ->
+        buffer.deleteRow(4)
+        expect(observeHandler.callCount).toBe 1
+        expect(observeHandler.argsForCall[0][0]).toEqual {
+          oldTailPosition: [4, 20]
+          newTailPosition: [4, 20]
+          oldHeadPosition: [4, 23]
+          newHeadPosition: [4, 23]
+          bufferChanged: true
+          valid: false
+        }
+
+        observeHandler.reset()
+        buffer.undo()
+        expect(observeHandler.callCount).toBe 1
+        expect(observeHandler.argsForCall[0][0]).toEqual {
+          oldTailPosition: [4, 20]
+          newTailPosition: [4, 20]
+          oldHeadPosition: [4, 23]
+          newHeadPosition: [4, 23]
+          bufferChanged: true
+          valid: true
         }
 
       it "allows the observation subscription to be cancelled", ->

--- a/spec/app/display-buffer-spec.coffee
+++ b/spec/app/display-buffer-spec.coffee
@@ -661,6 +661,7 @@ describe "DisplayBuffer", ->
           newTailScreenPosition: [5, 4]
           newTailBufferPosition: [8, 4]
           bufferChanged: false
+          valid: true
         }
         observeHandler.reset()
 
@@ -676,6 +677,7 @@ describe "DisplayBuffer", ->
           newTailScreenPosition: [5, 4]
           newTailBufferPosition: [8, 4]
           bufferChanged: true
+          valid: true
         }
         observeHandler.reset()
 
@@ -691,6 +693,7 @@ describe "DisplayBuffer", ->
           newTailScreenPosition: [8, 4]
           newTailBufferPosition: [8, 4]
           bufferChanged: false
+          valid: true
         }
         observeHandler.reset()
 
@@ -706,6 +709,7 @@ describe "DisplayBuffer", ->
           newTailScreenPosition: [5, 4]
           newTailBufferPosition: [8, 4]
           bufferChanged: false
+          valid: true
         }
 
       it "calls the callback whenever the marker tail's position changes in the buffer or on screen", ->
@@ -721,6 +725,7 @@ describe "DisplayBuffer", ->
           newTailScreenPosition: [8, 20]
           newTailBufferPosition: [11, 20]
           bufferChanged: false
+          valid: true
         }
         observeHandler.reset()
 
@@ -736,6 +741,40 @@ describe "DisplayBuffer", ->
           newTailScreenPosition: [8, 23]
           newTailBufferPosition: [11, 23]
           bufferChanged: true
+          valid: true
+        }
+
+      it "calls the callback whenever the marker is invalidated or revalidated", ->
+        buffer.deleteRow(8)
+        expect(observeHandler).toHaveBeenCalled()
+        expect(observeHandler.argsForCall[0][0]).toEqual {
+          oldHeadScreenPosition: [5, 10]
+          oldHeadBufferPosition: [8, 10]
+          newHeadScreenPosition: [5, 10]
+          newHeadBufferPosition: [8, 10]
+          oldTailScreenPosition: [5, 4]
+          oldTailBufferPosition: [8, 4]
+          newTailScreenPosition: [5, 4]
+          newTailBufferPosition: [8, 4]
+          bufferChanged: true
+          valid: false
+        }
+
+        observeHandler.reset()
+        buffer.undo()
+
+        expect(observeHandler).toHaveBeenCalled()
+        expect(observeHandler.argsForCall[0][0]).toEqual {
+          oldHeadScreenPosition: [5, 10]
+          oldHeadBufferPosition: [8, 10]
+          newHeadScreenPosition: [5, 10]
+          newHeadBufferPosition: [8, 10]
+          oldTailScreenPosition: [5, 4]
+          oldTailBufferPosition: [8, 4]
+          newTailScreenPosition: [5, 4]
+          newTailBufferPosition: [8, 4]
+          bufferChanged: true
+          valid: true
         }
 
       it "does not call the callback for screen changes that don't change the position of the marker", ->

--- a/src/app/buffer-change-operation.coffee
+++ b/src/app/buffer-change-operation.coffee
@@ -107,5 +107,4 @@ class BufferChangeOperation
       if validMarker = @buffer.validMarkers[id]
         validMarker.setRange(previousRange)
       else if invalidMarker = @buffer.invalidMarkers[id]
-        @buffer.validMarkers[id] = invalidMarker
-
+        invalidMarker.revalidate()

--- a/src/app/buffer-marker.coffee
+++ b/src/app/buffer-marker.coffee
@@ -141,7 +141,7 @@ class BufferMarker
     @suppressObserverNotification = false
     @notifyObservers({oldHeadPosition, newHeadPosition, oldTailPosition, newTailPosition, bufferChanged})
 
-  invalidate: (preserve) ->
+  invalidate: ->
     delete @buffer.validMarkers[@id]
     @buffer.invalidMarkers[@id] = this
 

--- a/src/app/buffer-marker.coffee
+++ b/src/app/buffer-marker.coffee
@@ -8,9 +8,9 @@ class BufferMarker
   headPosition: null
   tailPosition: null
   suppressObserverNotification: false
-  stayValid: false
+  invalidationStrategy: 'contains'
 
-  constructor: ({@id, @buffer, range, @stayValid, noTail, reverse}) ->
+  constructor: ({@id, @buffer, range, @invalidationStrategy, noTail, reverse}) ->
     @setRange(range, {noTail, reverse})
 
   setRange: (range, options={}) ->
@@ -76,7 +76,7 @@ class BufferMarker
     containsEnd = oldRange.containsPoint(@getEndPosition(), exclusive: true)
     return unless containsEnd or containsStart
 
-    if @stayValid
+    if @invalidationStrategy is 'never'
       previousRange = @getRange()
       if containsStart and containsEnd
         @setRange([oldRange.end, oldRange.end])

--- a/src/app/display-buffer-marker.coffee
+++ b/src/app/display-buffer-marker.coffee
@@ -87,7 +87,9 @@ class DisplayBufferMarker
 
   notifyObservers: ({oldHeadBufferPosition, oldTailBufferPosition, bufferChanged, valid} = {}) ->
     oldHeadScreenPosition = @getHeadScreenPosition()
+    newHeadScreenPosition = oldHeadScreenPosition
     oldTailScreenPosition = @getTailScreenPosition()
+    newTailScreenPosition = oldTailScreenPosition
     valid ?= true
 
     if valid
@@ -95,11 +97,11 @@ class DisplayBufferMarker
       newHeadScreenPosition = @getHeadScreenPosition()
       @tailScreenPosition = null
       newTailScreenPosition = @getTailScreenPosition()
-    else
-      newHeadScreenPosition = oldHeadScreenPosition
-      newTailScreenPosition = oldTailScreenPosition
 
-    return if valid is @valid and _.isEqual(newHeadScreenPosition, oldHeadScreenPosition) and _.isEqual(newTailScreenPosition, oldTailScreenPosition)
+    validChanged = valid isnt @valid
+    headScreenPositionChanged = not _.isEqual(newHeadScreenPosition, oldHeadScreenPosition)
+    tailScreenPositionChanged = not _.isEqual(newTailScreenPosition, oldTailScreenPosition)
+    return unless validChanged or headScreenPositionChanged or tailScreenPositionChanged
 
     oldHeadBufferPosition ?= @getHeadBufferPosition()
     newHeadBufferPosition = @getHeadBufferPosition() ? oldHeadBufferPosition

--- a/src/app/display-buffer.coffee
+++ b/src/app/display-buffer.coffee
@@ -332,8 +332,9 @@ class DisplayBuffer
   getMarkers: ->
     _.values(@markers)
 
-  markScreenRange: (screenRange) ->
-    @markBufferRange(@bufferRangeForScreenRange(screenRange))
+  markScreenRange: (args...) ->
+    bufferRange = @bufferRangeForScreenRange(args.shift())
+    @markBufferRange(bufferRange, args...)
 
   markBufferRange: (args...) ->
     @buffer.markRange(args...)

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -538,11 +538,11 @@ class EditSession
     _.last(@cursors)
 
   addCursorAtScreenPosition: (screenPosition) ->
-    marker = @markScreenPosition(screenPosition, stayValid: true)
+    marker = @markScreenPosition(screenPosition, invalidationStrategy: 'never')
     @addSelection(marker).cursor
 
   addCursorAtBufferPosition: (bufferPosition) ->
-    marker = @markBufferPosition(bufferPosition, stayValid: true)
+    marker = @markBufferPosition(bufferPosition, invalidationStrategy: 'never')
     @addSelection(marker).cursor
 
   addCursor: (marker) ->
@@ -565,7 +565,7 @@ class EditSession
     selection
 
   addSelectionForBufferRange: (bufferRange, options={}) ->
-    options = _.defaults({stayValid: true}, options)
+    options = _.defaults({invalidationStrategy: 'never'}, options)
     marker = @markBufferRange(bufferRange, options)
     @addSelection(marker)
 

--- a/src/app/range.coffee
+++ b/src/app/range.coffee
@@ -57,7 +57,11 @@ class Range
     else
       otherRange.intersectsWith(this)
 
-  containsPoint: (point, { exclusive } = {}) ->
+  containsRange: (otherRange, {exclusive} = {}) ->
+    { start, end } = Range.fromObject(otherRange)
+    @containsPoint(start, {exclusive}) and @containsPoint(end, {exclusive})
+
+  containsPoint: (point, {exclusive} = {}) ->
     point = Point.fromObject(point)
     if exclusive
       point.isGreaterThan(@start) and point.isLessThan(@end)

--- a/src/packages/autocomplete/lib/autocomplete.coffee
+++ b/src/packages/autocomplete/lib/autocomplete.coffee
@@ -7,4 +7,3 @@ module.exports =
     rootView.eachEditor (editor) =>
       if editor.attached and not editor.mini
         @autoCompleteViews.push new AutocompleteView(editor)
-

--- a/src/packages/spell-check/keymaps/spell-check.cson
+++ b/src/packages/spell-check/keymaps/spell-check.cson
@@ -1,0 +1,2 @@
+'.editor':
+  'meta-0': 'editor:correct-misspelling'

--- a/src/packages/spell-check/lib/corrections-view.coffee
+++ b/src/packages/spell-check/lib/corrections-view.coffee
@@ -1,0 +1,71 @@
+{$$} = require 'space-pen'
+Range = require 'range'
+SelectList = require 'select-list'
+
+module.exports =
+class CorrectionsView extends SelectList
+  @viewClass: -> "corrections #{super} popover-list"
+
+  editor: null
+  corrections: null
+  misspellingRange: null
+  aboveCursor: false
+
+  initialize: (@editor, @corrections, @misspellingRange) ->
+    super
+
+    @attach()
+
+  itemForElement: (word) ->
+    $$ ->
+      @li word
+
+  selectNextItem: ->
+    super
+
+    false
+
+  selectPreviousItem: ->
+    super
+
+    false
+
+  confirmed: (correction) ->
+    @cancel()
+    return unless correction
+    @editor.transact =>
+      @editor.setSelectedBufferRange(@editor.bufferRangeForScreenRange(@misspellingRange))
+      @editor.insertText(correction)
+
+  attach: ->
+    @aboveCursor = false
+    if @corrections.length > 0
+      @setArray(@corrections)
+    else
+      @setError("No corrections found")
+
+    @editor.appendToLinesView(this)
+    @setPosition()
+    @miniEditor.focus()
+
+  detach: ->
+    super
+
+    @editor.focus()
+
+  setPosition: ->
+    { left, top } = @editor.pixelPositionForScreenPosition(@misspellingRange.start)
+    height = @outerHeight()
+    potentialTop = top + @editor.lineHeight
+    potentialBottom = potentialTop - @editor.scrollTop() + height
+
+    if @aboveCursor or potentialBottom > @editor.outerHeight()
+      @aboveCursor = true
+      @css(left: left, top: top - height, bottom: 'inherit')
+    else
+      @css(left: left, top: potentialTop, bottom: 'inherit')
+
+  populateList: ->
+    super
+
+    @setPosition()

--- a/src/packages/spell-check/lib/misspelling-view.coffee
+++ b/src/packages/spell-check/lib/misspelling-view.coffee
@@ -1,0 +1,40 @@
+{View} = require 'space-pen'
+Range = require 'range'
+
+module.exports =
+class MisspellingView extends View
+  @content: ->
+    @div class: 'misspelling'
+
+  initialize: (range, @editor) ->
+    @editSession = @editor.activeEditSession
+    range = @editSession.screenRangeForBufferRange(Range.fromObject(range))
+    @startPosition = range.start
+    @endPosition = range.end
+
+    @marker = @editSession.markScreenRange(range, invalidationStrategy: 'between')
+    @editSession.observeMarker @marker, ({newHeadScreenPosition, newTailScreenPosition, valid}) =>
+      @startPosition = newTailScreenPosition
+      @endPosition = newHeadScreenPosition
+      @updateDisplayPosition = valid
+      @hide() unless valid
+
+    @editor.on 'editor:display-updated', =>
+      @updatePosition() if @updateDisplayPosition
+
+    @updatePosition()
+
+  updatePosition: ->
+    @updateDisplayPosition = false
+    startPixelPosition = @editor.pixelPositionForScreenPosition(@startPosition)
+    endPixelPosition = @editor.pixelPositionForScreenPosition(@endPosition)
+    @css
+      top: startPixelPosition.top
+      left: startPixelPosition.left
+      width: endPixelPosition.left - startPixelPosition.left
+      height: @editor.lineHeight
+    @show()
+
+  destroy: ->
+    @editSession.destroyMarker(@marker)
+    @remove()

--- a/src/packages/spell-check/lib/spell-check-handler.coffee
+++ b/src/packages/spell-check/lib/spell-check-handler.coffee
@@ -1,6 +1,6 @@
 module.exports =
   findMisspellings: (text) ->
-    wordRegex = /(?:^|\s)([a-zA-Z]+)(?=\s|\.|$)/g
+    wordRegex = /(?:^|\s)([a-zA-Z']+)(?=\s|\.|$)/g
     row = 0
     misspellings = []
     for line in text.split('\n')

--- a/src/packages/spell-check/lib/spell-check-handler.coffee
+++ b/src/packages/spell-check/lib/spell-check-handler.coffee
@@ -1,0 +1,14 @@
+module.exports =
+  findMisspellings: (text) ->
+    wordRegex = /(?:^|\s)([a-zA-Z]+)(?=\s|\.|$)/g
+    row = 0
+    misspellings = []
+    for line in text.split('\n')
+      while matches = wordRegex.exec(line)
+        word = matches[1]
+        continue unless $native.isMisspelled(word)
+        startColumn = matches.index + matches[0].length - word.length
+        endColumn = startColumn + word.length
+        misspellings.push([[row, startColumn], [row, endColumn]])
+      row++
+    callTaskMethod('misspellingsFound', misspellings)

--- a/src/packages/spell-check/lib/spell-check-task.coffee
+++ b/src/packages/spell-check/lib/spell-check-task.coffee
@@ -1,0 +1,14 @@
+Task = require 'task'
+
+module.exports =
+class SpellCheckTask extends Task
+
+  constructor: (@text, @callback) ->
+    super('spell-check/lib/spell-check-handler')
+
+  started: ->
+    @callWorkerMethod('findMisspellings', @text)
+
+  misspellingsFound: (misspellings) ->
+    @done()
+    @callback(misspellings)

--- a/src/packages/spell-check/lib/spell-check-task.coffee
+++ b/src/packages/spell-check/lib/spell-check-task.coffee
@@ -2,7 +2,6 @@ Task = require 'task'
 
 module.exports =
 class SpellCheckTask extends Task
-
   constructor: (@text, @callback) ->
     super('spell-check/lib/spell-check-handler')
 

--- a/src/packages/spell-check/lib/spell-check-view.coffee
+++ b/src/packages/spell-check/lib/spell-check-view.coffee
@@ -1,5 +1,4 @@
 {View} = require 'space-pen'
-$ = require 'jquery'
 _ = require 'underscore'
 SpellCheckTask = require './spell-check-task'
 MisspellingView = require './misspelling-view'
@@ -38,16 +37,17 @@ class SpellCheckView extends View
       view.destroy() for view in @views
       @views = []
 
-  addView: (misspelling)->
-    view = new MisspellingView(misspelling, @editor)
-    @views.push(view)
-    @append(view)
+  addViews: (misspellings) ->
+    for misspelling in misspellings
+      view = new MisspellingView(misspelling, @editor)
+      @views.push(view)
+      @append(view)
 
   updateMisspellings: ->
     @task?.abort()
 
     callback = (misspellings) =>
       @destroyViews()
-      @addView(misspelling) for misspelling in misspellings
+      @addViews(misspellings)
     @task = new SpellCheckTask(@buffer.getText(), callback)
     @task.start()

--- a/src/packages/spell-check/lib/spell-check-view.coffee
+++ b/src/packages/spell-check/lib/spell-check-view.coffee
@@ -1,0 +1,53 @@
+{View} = require 'space-pen'
+$ = require 'jquery'
+_ = require 'underscore'
+SpellCheckTask = require './spell-check-task'
+MisspellingView = require './misspelling-view'
+
+module.exports =
+class SpellCheckView extends View
+  @content: ->
+    @div class: 'spell-check'
+
+  views: []
+
+  initialize: (@editor) ->
+    @subscribe @editor, 'editor:path-changed', => @subscribeToBuffer()
+    @subscribe @editor, 'editor:grammar-changed', => @subscribeToBuffer()
+    @observeConfig 'editor.fontSize', => @subscribeToBuffer()
+    @observeConfig 'spell-check.grammars', => @subscribeToBuffer()
+
+    @subscribeToBuffer()
+
+  subscribeToBuffer: ->
+    @destroyViews()
+    @task?.abort()
+    return unless @spellCheckCurrentGrammar()
+
+    @buffer?.off '.spell-check'
+    @buffer = @editor.getBuffer()
+    @buffer.on 'contents-modified.spell-check', => @updateMisspellings()
+    @updateMisspellings()
+
+  spellCheckCurrentGrammar: ->
+    grammar = @editor.getGrammar().scopeName
+    _.contains config.get('spell-check.grammars'), grammar
+
+  destroyViews: ->
+    if @views
+      view.destroy() for view in @views
+      @views = []
+
+  addView: (misspelling)->
+    view = new MisspellingView(misspelling, @editor)
+    @views.push(view)
+    @append(view)
+
+  updateMisspellings: ->
+    @task?.abort()
+
+    callback = (misspellings) =>
+      @destroyViews()
+      @addView(misspelling) for misspelling in misspellings
+    @task = new SpellCheckTask(@buffer.getText(), callback)
+    @task.start()

--- a/src/packages/spell-check/lib/spell-check.coffee
+++ b/src/packages/spell-check/lib/spell-check.coffee
@@ -1,0 +1,20 @@
+SpellCheckView = require './spell-check-view'
+
+module.exports =
+  configDefaults:
+    grammars: [
+      'text.plain'
+      'source.gfm'
+      'text.git-commit'
+    ]
+
+  activate: ->
+    if syntax.grammars.length > 1
+      @subscribeToEditors()
+    else
+      syntax.on 'grammars-loaded', => @subscribeToEditors()
+
+  subscribeToEditors: ->
+    rootView.eachEditor (editor) ->
+      if editor.attached and not editor.mini
+        editor.underlayer.append(new SpellCheckView(editor))

--- a/src/packages/spell-check/package.cson
+++ b/src/packages/spell-check/package.cson
@@ -1,0 +1,1 @@
+'main': 'lib/spell-check.coffee'

--- a/src/packages/spell-check/spec/spell-check-spec.coffee
+++ b/src/packages/spell-check/spec/spell-check-spec.coffee
@@ -1,0 +1,47 @@
+RootView = require 'root-view'
+
+describe "Spell check", ->
+  [editor] = []
+
+  beforeEach ->
+    window.rootView = new RootView
+    rootView.open('sample.js')
+    config.set('spell-check.grammars', [])
+    window.loadPackage('spell-check')
+    rootView.attachToDom()
+    editor = rootView.getActiveEditor()
+
+  it "decorates all misspelled words", ->
+    editor.setText("This middle of thiss sentencts has issues.")
+    config.set('spell-check.grammars', ['source.js'])
+
+    waitsFor ->
+      editor.find('.misspelling').length > 0
+
+    runs ->
+      expect(editor.find('.misspelling').length).toBe 2
+
+      typo1StartPosition = editor.pixelPositionForBufferPosition([0, 15])
+      typo1EndPosition = editor.pixelPositionForBufferPosition([0, 20])
+      expect(editor.find('.misspelling:eq(0)').position()).toEqual typo1StartPosition
+      expect(editor.find('.misspelling:eq(0)').width()).toBe typo1EndPosition.left - typo1StartPosition.left
+
+      typo2StartPosition = editor.pixelPositionForBufferPosition([0, 21])
+      typo2EndPosition = editor.pixelPositionForBufferPosition([0, 30])
+      expect(editor.find('.misspelling:eq(1)').position()).toEqual typo2StartPosition
+      expect(editor.find('.misspelling:eq(1)').width()).toBe typo2EndPosition.left - typo2StartPosition.left
+
+  it "hides decorations when a misspelled word is edited", ->
+    editor.setText('notaword')
+    advanceClock(editor.getBuffer().stoppedChangingDelay)
+    config.set('spell-check.grammars', ['source.js'])
+
+    waitsFor ->
+      editor.find('.misspelling').length > 0
+
+    runs ->
+      expect(editor.find('.misspelling').length).toBe 1
+      editor.moveCursorToEndOfLine()
+      editor.insertText('a')
+      advanceClock(editor.getBuffer().stoppedChangingDelay)
+      expect(editor.find('.misspelling')).toBeHidden()

--- a/src/packages/spell-check/spec/spell-check-spec.coffee
+++ b/src/packages/spell-check/spec/spell-check-spec.coffee
@@ -45,3 +45,17 @@ describe "Spell check", ->
       editor.insertText('a')
       advanceClock(editor.getBuffer().stoppedChangingDelay)
       expect(editor.find('.misspelling')).toBeHidden()
+
+  describe "when spell checking for a grammar is removed", ->
+    it "removes all current decorations", ->
+      editor.setText('notaword')
+      advanceClock(editor.getBuffer().stoppedChangingDelay)
+      config.set('spell-check.grammars', ['source.js'])
+
+      waitsFor ->
+        editor.find('.misspelling').length > 0
+
+      runs ->
+        expect(editor.find('.misspelling').length).toBe 1
+        config.set('spell-check.grammars', [])
+        expect(editor.find('.misspelling').length).toBe 0

--- a/src/packages/spell-check/spec/spell-check-spec.coffee
+++ b/src/packages/spell-check/spec/spell-check-spec.coffee
@@ -59,3 +59,40 @@ describe "Spell check", ->
         expect(editor.find('.misspelling').length).toBe 1
         config.set('spell-check.grammars', [])
         expect(editor.find('.misspelling').length).toBe 0
+
+  describe "when 'editor:correct-misspelling' is triggered on the editor", ->
+    describe "when the cursor touches a misspelling that has corrections", ->
+      it "displays the corrections for the misspelling and replaces the misspelling when a correction is selected", ->
+        editor.setText('fryday')
+        advanceClock(editor.getBuffer().stoppedChangingDelay)
+        config.set('spell-check.grammars', ['source.js'])
+
+        waitsFor ->
+          editor.find('.misspelling').length > 0
+
+        runs ->
+          editor.trigger 'editor:correct-misspelling'
+          expect(editor.find('.corrections').length).toBe 1
+          expect(editor.find('.corrections li').length).toBeGreaterThan 0
+          expect(editor.find('.corrections li:first').text()).toBe "Friday"
+          editor.find('.corrections').view().confirmSelection()
+          expect(editor.getText()).toBe 'Friday'
+          expect(editor.getCursorBufferPosition()).toEqual [0, 6]
+          advanceClock(editor.getBuffer().stoppedChangingDelay)
+          expect(editor.find('.misspelling')).toBeHidden()
+          expect(editor.find('.corrections').length).toBe 0
+
+    describe "when the cursor touches a misspelling that has no corrections", ->
+      it "displays a message saying no corrections found", ->
+        editor.setText('asdfasdf')
+        advanceClock(editor.getBuffer().stoppedChangingDelay)
+        config.set('spell-check.grammars', ['source.js'])
+
+        waitsFor ->
+          editor.find('.misspelling').length > 0
+
+        runs ->
+          editor.trigger 'editor:correct-misspelling'
+          expect(editor.find('.corrections').length).toBe 1
+          expect(editor.find('.corrections li').length).toBe 0
+          expect(editor.find('.corrections .error').text()).toBe "No corrections found"

--- a/src/packages/spell-check/stylesheets/spell-check.css
+++ b/src/packages/spell-check/stylesheets/spell-check.css
@@ -1,0 +1,4 @@
+.misspelling {
+  border-bottom: 1px dashed rgba(250, 128, 114, .5);
+  position: absolute;
+}


### PR DESCRIPTION
- Displays corrections on `meta-0`
- Initially enabled for:
  - Plain text files
  - Markdown files
  - Git commit messages
- Can be styled with the `.misspelling` class.

![Screen Shot 2013-02-26 at 6 52 39 PM](https://f.cloud.github.com/assets/671378/199516/d521333e-8088-11e2-8291-33697b2667dc.png)
