### PR TITLE
Move all code and resources into Atom.framework

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ task :install => [:clean, :build] do
   # Install Atom.app
   dest_path =  "/Applications/#{File.basename(path)}"
   `rm -rf #{dest_path}`
-  `cp -r #{path} #{File.expand_path(dest_path)}`
+  `cp -a #{path} #{File.expand_path(dest_path)}`
 
   # Install atom cli
   if File.directory?("/opt/boxen")

--- a/atom.gyp
+++ b/atom.gyp
@@ -16,6 +16,22 @@
         'toolkit_uses_gtk%': 0,
       }],
     ],
+    'fix_framework_link_command': [
+      'install_name_tool',
+      '-change',
+      '@executable_path/libcef.dylib',
+      '@rpath/Chromium Embedded Framework.framework/Libraries/libcef.dylib',
+      '-change',
+      '@executable_path/../Frameworks/CocoaOniguruma.framework/Versions/A/CocoaOniguruma',
+      '@rpath/CocoaOniguruma.framework/Versions/A/CocoaOniguruma',
+      '-change',
+      '@loader_path/../Frameworks/Sparkle.framework/Versions/A/Sparkle',
+      '@rpath/Sparkle.framework/Versions/A/Sparkle',
+      '-change',
+      '@executable_path/libgit2.0.17.0.dylib',
+      '@rpath/libgit2.framework/Libraries/libgit2.0.17.0.dylib',
+      '${BUILT_PRODUCTS_DIR}/${EXECUTABLE_PATH}'
+    ],
   },
   'includes': [
     'cef/cef_paths2.gypi',
@@ -45,39 +61,20 @@
       'mac_bundle': 1,
       'msvs_guid': 'D22C6F51-AA2D-457C-B579-6C97A96C724D',
       'dependencies': [
-        'libcef_dll_wrapper',
+        'atom_framework',
       ],
-      'defines': [
-        'USING_CEF_SHARED',
-      ],
-      'include_dirs': [ '.', 'cef', 'git2' ],
       'mac_framework_dirs': [ 'native/frameworks' ],
-      'libraries': [ 'native/frameworks/CocoaOniguruma.framework', 'native/frameworks/Sparkle.framework'],
       'sources': [
-        '<@(includes_common)',
-        '<@(includes_wrapper)',
-        'native/main_mac.mm',
-        'native/atom_application.h',
-        'native/atom_application.mm',
-        'native/atom_cef_app.h',
-        'native/atom_window_controller.h',
-        'native/atom_window_controller.mm',
-        'native/atom_cef_client_mac.mm',
-        'native/atom_cef_client.cpp',
-        'native/atom_cef_client.h',
-        'native/message_translation.cpp',
-        'native/message_translation.h',
+        'native/main.cpp',
       ],
       'mac_bundle_resources': [
         'native/mac/atom.icns',
         'native/mac/file.icns',
         'native/mac/speakeasy.pem',
-        'native/mac/English.lproj/MainMenu.xib',
-        'native/mac/English.lproj/AtomWindow.xib',
       ],
       'xcode_settings': {
         'INFOPLIST_FILE': 'native/mac/info.plist',
-        'OTHER_LDFLAGS': ['-Wl,-headerpad_max_install_names'], # Necessary to avoid an "install_name_tool: changing install names or rpaths can't be redone" error.
+        'LD_RUNPATH_SEARCH_PATHS': '@executable_path/../Frameworks',
       },
       'conditions': [
         ['CODE_SIGN' , {
@@ -142,6 +139,7 @@
             {
               'destination': '<(PRODUCT_DIR)/Atom.app/Contents/Frameworks',
               'files': [
+                '<(PRODUCT_DIR)/Atom.framework',
                 'native/frameworks/CocoaOniguruma.framework',
                 'native/frameworks/Sparkle.framework',
               ],
@@ -155,12 +153,6 @@
           ],
           'postbuilds': [
             {
-              'postbuild_name': 'Copy and Compile Static Files',
-              'action': [
-                'script/copy-files-to-bundle'
-              ],
-            },
-            {
               'postbuild_name': 'Copy Helper App',
               'action': [
                 'cp',
@@ -172,11 +164,7 @@
             {
               'postbuild_name': 'Fix Framework Link',
               'action': [
-                'install_name_tool',
-                '-change',
-                '@executable_path/libcef.dylib',
-                '@executable_path/../Frameworks/Chromium Embedded Framework.framework/Libraries/libcef.dylib',
-                '${BUILT_PRODUCTS_DIR}/${EXECUTABLE_PATH}'
+                '<@(fix_framework_link_command)',
               ],
             },
             {
@@ -232,6 +220,87 @@
       ],
     },
     {
+      'target_name': 'atom_framework',
+      'product_name': 'Atom',
+      'type': 'shared_library',
+      'mac_bundle': 1,
+      'dependencies': [
+        'libcef_dll_wrapper',
+      ],
+      'defines': [
+        'USING_CEF_SHARED',
+      ],
+      'xcode_settings': {
+        'INFOPLIST_FILE': 'native/mac/framework-info.plist',
+        'LD_DYLIB_INSTALL_NAME': '@rpath/Atom.framework/Atom',
+      },
+      'include_dirs': [ '.', 'cef', 'git2' ],
+      'mac_framework_dirs': [ 'native/frameworks' ],
+      'sources': [
+        '<@(includes_common)',
+        '<@(includes_wrapper)',
+        'native/atom_application.h',
+        'native/atom_application.mm',
+        'native/atom_cef_app.h',
+        'native/atom_cef_app.h',
+        'native/atom_cef_client.cpp',
+        'native/atom_cef_client.h',
+        'native/atom_cef_client_mac.mm',
+        'native/atom_cef_render_process_handler.h',
+        'native/atom_cef_render_process_handler.mm',
+        'native/atom_window_controller.h',
+        'native/atom_window_controller.mm',
+        'native/atom_main.h',
+        'native/atom_main_mac.mm',
+        'native/message_translation.cpp',
+        'native/message_translation.cpp',
+        'native/message_translation.h',
+        'native/message_translation.h',
+        'native/path_watcher.h',
+        'native/path_watcher.mm',
+        'native/v8_extensions/atom.h',
+        'native/v8_extensions/atom.mm',
+        'native/v8_extensions/git.h',
+        'native/v8_extensions/git.mm',
+        'native/v8_extensions/native.h',
+        'native/v8_extensions/native.mm',
+        'native/v8_extensions/onig_reg_exp.h',
+        'native/v8_extensions/onig_reg_exp.mm',
+        'native/v8_extensions/onig_scanner.h',
+        'native/v8_extensions/onig_scanner.mm',
+        'native/v8_extensions/readtags.c',
+        'native/v8_extensions/readtags.h',
+        'native/v8_extensions/tags.h',
+        'native/v8_extensions/tags.mm',
+      ],
+      'link_settings': {
+        'libraries': [
+          '$(SDKROOT)/System/Library/Frameworks/AppKit.framework',
+          'git2/frameworks/libgit2.0.17.0.dylib',
+          'native/frameworks/CocoaOniguruma.framework',
+          'native/frameworks/Sparkle.framework',
+        ],
+      },
+      'mac_bundle_resources': [
+        'native/mac/English.lproj/AtomWindow.xib',
+        'native/mac/English.lproj/MainMenu.xib',
+      ],
+      'postbuilds': [
+        {
+          'postbuild_name': 'Copy and Compile Static Files',
+          'action': [
+            'script/copy-files-to-bundle'
+          ],
+        },
+        {
+          'postbuild_name': 'Fix Framework Link',
+          'action': [
+            '<@(fix_framework_link_command)',
+          ],
+        },
+      ],
+    },
+    {
       'target_name': 'libcef_dll_wrapper',
       'type': 'static_library',
       'msvs_guid': 'A9D6DC71-C0DC-4549-AEA0-3B15B44E86A9',
@@ -271,46 +340,15 @@
           'product_name': 'Atom Helper',
           'mac_bundle': 1,
           'dependencies': [
-            'libcef_dll_wrapper',
+            'atom_framework',
           ],
           'defines': [
             'USING_CEF_SHARED',
             'PROCESS_HELPER_APP',
           ],
-          'include_dirs': [ '.', 'cef', 'git2' ],
           'mac_framework_dirs': [ 'native/frameworks' ],
-          'link_settings': {
-            'libraries': [
-              '$(SDKROOT)/System/Library/Frameworks/AppKit.framework',
-            ],
-          },
-          'libraries': [
-            'native/frameworks/CocoaOniguruma.framework',
-            'git2/frameworks/libgit2.0.17.0.dylib',
-          ],
           'sources': [
-            'native/atom_cef_app.h',
-            'native/atom_cef_render_process_handler.h',
-            'native/atom_cef_render_process_handler.mm',
-            'native/message_translation.cpp',
-            'native/message_translation.h',
-            'native/path_watcher.mm',
-            'native/path_watcher.h',
-            'native/main_helper_mac.mm',
-            'native/v8_extensions/native.mm',
-            'native/v8_extensions/native.h',
-            'native/v8_extensions/onig_reg_exp.mm',
-            'native/v8_extensions/onig_reg_exp.h',
-            'native/v8_extensions/onig_scanner.mm',
-            'native/v8_extensions/onig_scanner.h',
-            'native/v8_extensions/atom.mm',
-            'native/v8_extensions/atom.h',
-            'native/v8_extensions/git.mm',
-            'native/v8_extensions/git.h',
-            'native/v8_extensions/readtags.h',
-            'native/v8_extensions/readtags.c',
-            'native/v8_extensions/tags.h',
-            'native/v8_extensions/tags.mm',
+            'native/main.cpp',
           ],
           # TODO(mark): For now, don't put any resources into this app.  Its
           # resources directory will be a symbolic link to the browser app's
@@ -320,45 +358,13 @@
           ],
           'xcode_settings': {
             'INFOPLIST_FILE': 'native/mac/helper-info.plist',
-            'OTHER_LDFLAGS': ['-Wl,-headerpad_max_install_names'], # Necessary to avoid an "install_name_tool: changing install names or rpaths can't be redone" error.
+            'LD_RUNPATH_SEARCH_PATHS': '@executable_path/../../..',
           },
-          'copies': [
-            {
-              'destination': '<(PRODUCT_DIR)/Atom Helper.app/Contents/Frameworks',
-              'files': [
-                'native/frameworks/CocoaOniguruma.framework',
-              ],
-            },
-          ],
           'postbuilds': [
             {
-              # The framework defines its load-time path
-              # (DYLIB_INSTALL_NAME_BASE) relative to the main executable
-              # (chrome).  A different relative path needs to be used in
-              # atom_helper_app.
-              'postbuild_name': 'Fix CEF Framework Link',
+              'postbuild_name': 'Fix Framework Link',
               'action': [
-                'install_name_tool',
-                '-change',
-                '@executable_path/libcef.dylib',
-                '@executable_path/../../../../Frameworks/Chromium Embedded Framework.framework/Libraries/libcef.dylib',
-                '${BUILT_PRODUCTS_DIR}/${EXECUTABLE_PATH}'
-              ],
-            },
-            {
-              'postbuild_name': 'Fix libgit2 Framework Link',
-              'action': [
-                'install_name_tool',
-                '-change',
-                '@executable_path/libgit2.0.17.0.dylib',
-                '@executable_path/../../../../Frameworks/libgit2.framework/Libraries/libgit2.0.17.0.dylib',
-                '${BUILT_PRODUCTS_DIR}/${EXECUTABLE_PATH}'
-              ],
-            },
-            {
-              'postbuild_name': 'Copy and Compile Static Files',
-              'action': [
-                'script/copy-files-to-bundle'
+                '<@(fix_framework_link_command)',
               ],
             },
           ],

--- a/atom.gyp
+++ b/atom.gyp
@@ -139,6 +139,7 @@
             {
               'destination': '<(PRODUCT_DIR)/Atom.app/Contents/Frameworks',
               'files': [
+                '<(PRODUCT_DIR)/Atom Helper.app',
                 '<(PRODUCT_DIR)/Atom.framework',
                 'native/frameworks/CocoaOniguruma.framework',
                 'native/frameworks/Sparkle.framework',
@@ -150,30 +151,18 @@
                 'git2/frameworks/libgit2.0.17.0.dylib',
               ],
             },
-          ],
-          'postbuilds': [
             {
-              'postbuild_name': 'Copy Helper App',
-              'action': [
-                'cp',
-                '-r',
-                '${BUILT_PRODUCTS_DIR}/Atom Helper.app',
-                '${BUILT_PRODUCTS_DIR}/Atom.app/Contents/Frameworks',
+              'destination': '<(PRODUCT_DIR)/Atom.app/Contents/Frameworks/Chromium Embedded Framework.framework',
+              'files': [
+                'cef/Resources',
               ],
             },
+          ],
+          'postbuilds': [
             {
               'postbuild_name': 'Fix Framework Link',
               'action': [
                 '<@(fix_framework_link_command)',
-              ],
-            },
-            {
-              'postbuild_name': 'Copy Framework Resources Directory',
-              'action': [
-                'cp',
-                '-r',
-                'cef/Resources',
-                '${BUILT_PRODUCTS_DIR}/Atom.app/Contents/Frameworks/Chromium Embedded Framework.framework/'
               ],
             },
             {

--- a/native/atom_cef_app.h
+++ b/native/atom_cef_app.h
@@ -4,17 +4,13 @@
 
 #include "include/cef_app.h"
 
-#ifdef PROCESS_HELPER_APP
 #include "atom_cef_render_process_handler.h"
-#endif
 
 class AtomCefApp : public CefApp {
 
-#ifdef PROCESS_HELPER_APP
   virtual CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() OVERRIDE {
     return CefRefPtr<CefRenderProcessHandler>(new AtomCefRenderProcessHandler);
   }
-#endif
 
   IMPLEMENT_REFCOUNTING(AtomCefApp);
 };

--- a/native/atom_main.h
+++ b/native/atom_main.h
@@ -1,0 +1,1 @@
+__attribute__((visibility("default"))) int AtomMain(int argc, char* argv[]);

--- a/native/atom_main_mac.mm
+++ b/native/atom_main_mac.mm
@@ -1,3 +1,5 @@
+#import "atom_main.h"
+#import "atom_cef_app.h"
 #import "include/cef_application_mac.h"
 #import "native/atom_application.h"
 #include <sys/types.h>
@@ -10,7 +12,19 @@ void listenForPathToOpen(int fd, NSString *socketPath);
 void activateOpenApp();
 BOOL isAppAlreadyOpen();
 
-int main(int argc, char* argv[]) {
+int AtomMain(int argc, char* argv[]) {
+  {
+    // See if we're being run as a secondary process.
+
+    CefMainArgs main_args(argc, argv);
+    CefRefPtr<CefApp> app(new AtomCefApp);
+    int exitCode = CefExecuteProcess(main_args, app);
+    if (exitCode >= 0)
+      return exitCode;
+  }
+
+  // We're the main process.
+
   @autoreleasepool {
     handleBeingOpenedAgain(argc, argv);
 
@@ -18,7 +32,7 @@ int main(int argc, char* argv[]) {
     AtomApplication *application = [AtomApplication applicationWithArguments:argv count:argc];
 
     NSString *mainNibName = [infoDictionary objectForKey:@"NSMainNibFile"];
-    NSNib *mainNib = [[NSNib alloc] initWithNibNamed:mainNibName bundle:[NSBundle mainBundle]];
+    NSNib *mainNib = [[NSNib alloc] initWithNibNamed:mainNibName bundle:[NSBundle bundleWithIdentifier:@"com.github.atom.framework"]];
     [mainNib instantiateNibWithOwner:application topLevelObjects:nil];
 
     CefRunMessageLoop();

--- a/native/atom_window_controller.mm
+++ b/native/atom_window_controller.mm
@@ -45,7 +45,7 @@
   }
 
   if (alwaysUseBundleResourcePath || !_resourcePath) {
-    _resourcePath = [[NSBundle mainBundle] resourcePath];
+    _resourcePath = [[NSBundle bundleForClass:self.class] resourcePath];
   }
   [_resourcePath retain];
 
@@ -119,7 +119,7 @@
 // have the correct initial size based on the frame's last stored size.
 // HACK: I hate this and want to place this code directly in windowDidLoad
 - (void)attachWebView {
-  NSURL *url = [[NSBundle mainBundle] resourceURL];
+  NSURL *url = [[NSBundle bundleForClass:self.class] resourceURL];
   NSMutableString *urlString = [NSMutableString string];
   [urlString appendString:[[url URLByAppendingPathComponent:@"static/index.html"] absoluteString]];
   [urlString appendFormat:@"?bootstrapScript=%@", [self encodeUrlParam:_bootstrapScript]];

--- a/native/mac/framework-info.plist
+++ b/native/mac/framework-info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>com.github.atom.framework</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/native/main.cpp
+++ b/native/main.cpp
@@ -1,0 +1,5 @@
+#include "atom_main.h"
+
+int main(int argc, char* argv[]) {
+  return AtomMain(argc, argv);
+}

--- a/native/main_helper_mac.mm
+++ b/native/main_helper_mac.mm
@@ -1,8 +1,0 @@
-#include "include/cef_app.h"
-#include "atom_cef_app.h"
-
-int main(int argc, char* argv[]) {
-  CefMainArgs main_args(argc, argv);
-  CefRefPtr<CefApp> app(new AtomCefApp);
-  return CefExecuteProcess(main_args, app); // Execute the secondary process.
-}


### PR DESCRIPTION
All our native code now gets built into `Atom.framework`. `Atom.app` and `Atom Helper.app` both link against this framework. All resources other than a couple of main-bundle-only ones (e.g., `atom.icns`) go into `Atom.framework`.

Note that this means that there's no compile- or link-time separation between main process code and helper process code. We could introduce a compile-time separation by building main process and helper process code into separate static libraries with mutually exclusive include paths, if we want.

Atom.framework exports a single symbol: `AtomMain()`. `Atom.app` and `Atom Helper.app` contain a single source file: `main.cpp`. `main()` just calls `AtomMain()`.

All frameworks are placed in `Atom.app/Contents/Frameworks`. We now link against all frameworks using `@rpath`-based install names, which allows `Atom.app` and `Atom Helper.app` to find them automatically based on their own `LD_RUNPATH_SEARCH_PATH` settings. We use `install_name_tool` at build time on each of our three binaries (`Atom.app`, `Atom Helper.app`, `Atom.framework`) to set the install names.

By reducing duplication of code and resources between `Atom.app` and `Atom Helper.app` (and the `EH`/`NP` copies of `Atom Helper.app`), this reduces the size of the total `Atom.app` bundle from 145MB to 82MB. By compiling `.coffee` and `.cson` files only once, clean build time drops from 114 seconds to 79 seconds on my MacBook Pro.
