### PR TITLE
Focus editor when selecting an item from tree view

### DIFF
--- a/src/packages/tree-view/lib/tree-view.coffee
+++ b/src/packages/tree-view/lib/tree-view.coffee
@@ -95,7 +95,7 @@ class TreeView extends ScrollView
     switch e.originalEvent?.detail ? 1
       when 1
         @selectEntry(entry)
-        @openSelectedEntry(false) if entry instanceof FileView
+        @openSelectedEntry(true) if entry instanceof FileView
       when 2
         if entry.is('.selected.file')
           rootView.getActiveEditor().focus()


### PR DESCRIPTION
Currently clicking an item in the tree view doesn't focus the editor, which can be confusing.
