### PR TITLE
Improve search behavior

### DIFF
--- a/src/packages/command-panel/lib/commands/regex-address.coffee
+++ b/src/packages/command-panel/lib/commands/regex-address.coffee
@@ -1,18 +1,28 @@
 Address = require './address'
 Range = require 'range'
+_ = require 'underscore'
 
 module.exports =
 class RegexAddress extends Address
   regex: null
   reverse: null
 
-  constructor: (@pattern, isReversed, options) ->
+  searchOptions = 
+    regex: true
+    caseSensitive: false
+
+  constructor: (@pattern, isReversed) ->
     flags = ""
     pattern = pattern.source if pattern.source
-
-    patternContainsCapitalLetter = /(^|[^\\])[A-Z]/.test(pattern)
-    flags += "i" unless patternContainsCapitalLetter
+    
     @isReversed = isReversed
+
+    if !searchOptions.regex
+      pattern = @escape(pattern)
+    if !searchOptions.caseSensitive
+      flags += "i"
+    if searchOptions.wholeWord
+      pattern = "\\b#{pattern}\\b"
 
     @regex = new RegExp(pattern, flags)
 
@@ -45,3 +55,9 @@ class RegexAddress extends Address
 
   reverse: ->
     new RegexAddress(@regex, !@isReversed)
+
+  @setOptions: (options) ->
+    searchOptions = _.extend(searchOptions, options)
+
+  escape: (pattern) ->
+    pattern.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')

--- a/static/command-panel.css
+++ b/static/command-panel.css
@@ -120,6 +120,39 @@
   padding: 1px;
 }
 
+.search-options li {
+  display: inline;
+  float: left;
+}
+
+.search-options .octicons:before {
+  font-family: 'Octicons Regular';
+  font-size: 14px;
+  width: 14px;
+  height: 14px;
+  line-height: 14px;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 5px;
+}
+
+.search-options .regexp-icon:before {
+  content: "\f20d";
+}
+
+.search-options .case-sensitive-icon:before {
+  content: "\f23d";
+}
+
+.search-options .whole-word-icon:before {
+  content: "\f263";
+}
+
+.search-option.active .octicons {
+  color: red;
+}
+
 .command-panel .prompt-and-editor .editor {
   position: relative;
 }


### PR DESCRIPTION
I'm really interested in improving the search experience. Much of my behavior, whether I'm in an unfamiliar codebase or just trying to mass-update some content, revolve around search. I'd love Atom to duplicate, at a minimum, the capabilities found in other editors.

In this PR, I've got an extraordinarily basic set of functionality working: non-RegExp searches, case sensitive searches, and whole word searches. What I'm most concerned about is validating whether I'm comprehending how search works. Here's what I'm observing:
1. Search latches onto the command panel, which uses Sam syntaxes
2. When you fire off a search, you call the command interpreter, which  takes a look at _commands.pegjs_ to determine what it is you want to do
3. After realizing you want to search, a new `RegexAddress` is constructed, and executed

My confusion comes from how to correctly pass along options to `RegexAddress` in a sane manner. The way I'm doing it right now is kind of ugly: after clicking a button in the command-panel, [global options are set in `RegexAddress`](https://github.com/github/atom/blob/8fbef8e598ea37ea277089cc1fad2fb0f7bfea48/src/packages/command-panel/lib/command-panel-view.coffee#L149-L150). Every time a search is executed, [those options are read](https://github.com/github/atom/blob/8fbef8e598ea37ea277089cc1fad2fb0f7bfea48/src/packages/command-panel/lib/commands/regex-address.coffee#L20-L25). 

I feel like there's a better way to do this.

Pending items:
- [ ] Implement a sane way to inject options into search
- [ ] Get proper Octicons for search options (file an issue to get these added?)
- [ ] Add CSS for `active` and `hover` states
- [ ] Add tooltips (is it possible to use non-native tooltips?)
- [ ] Write tests

P.S. I have so many other concerns about the Sam syntax--like, should a user that hits `Ctrl-F` be able to delete the starting `/` or `Xx/`? Should there be a "reset" button? Should there be more UI options for choices like `,x/` or replacing content? I really have a soft spot for Plan 9 (though I'm more familiar with Acme :smirk_cat:); I just think every function accessible to the keyboard-typing crowd should be there for the mouse-clicking crowd.
