### PR TITLE
The CSON library requires the underscore-extensions library

### DIFF
--- a/src/stdlib/cson.coffee
+++ b/src/stdlib/cson.coffee
@@ -1,3 +1,4 @@
+require 'underscore-extensions'
 _ = require 'underscore'
 
 module.exports =


### PR DESCRIPTION
I was trying to hook into atom's grammer loading stuff and dump the plist to CSON, but it was failing because the underscore library didn't have a `multiplyString` function. It looks like that function is defined in the `underscore-extensions` library. Adding the `require 'underscore-extensions'` at the top of the CSON library fixed it.
