### PR TITLE
Swap ag for nak

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ctags": "0.1.0",
     "oniguruma": "0.4.0",
     "mkdirp": "0.3.5",
-    "nak" : "0.1.10"
+    "nak" : "0.2.0"
   },
 
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ctags": "0.1.0",
     "oniguruma": "0.4.0",
     "mkdirp": "0.3.5",
-    "nak" : "0.2.0"
+    "nak" : "0.2.1"
   },
 
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "coffee-script": "1.5",
     "ctags": "0.1.0",
     "oniguruma": "0.4.0",
-    "mkdirp": "0.3.5"
+    "mkdirp": "0.3.5",
+    "nak" : "0.1.10"
   },
 
   "scripts": {

--- a/src/app/project.coffee
+++ b/src/app/project.coffee
@@ -206,8 +206,8 @@ class Project
         readPath(line) if state is 'readingPath'
         readLine(line) if state is 'readingLines'
 
-    command = require.resolve('ag')
-    args = ['--ackmate', regex.source, @getPath()]
+    command = nodeRequire.resolve("nak")
+    args = ['--ackmate', "#{regex.source}", @getPath()]
     new BufferedProcess({command, args, stdout, exit})
     deferred
 


### PR DESCRIPTION
Picking up on an idea from _way back_ [in Janauary](https://github.com/github/atom/issues/129).

Personally, I believe mucking around with node-gyp and compiling native entities should be kept to a minimum. Especially when coming up with a cross-platform application, cross-platform features need to be respected. 

Among other things, `ag` doesn't really work too well on Windows. I would like to suggest switching to [`nak`](https://github.com/gjtorikian/nak) if possible.
### Advantages
- Cross platform (you got Node, you got `nak`)
- Streams results. This is key, I think. Think of how search results populate in through Sublime Text. `ag` (and currently, Atom) just dump a blob of search results. That's a wonky UX.
- Search results are _in order_. Whereas `ag` returns results like this:  
      `./vendor/themes/Zenburnesque.tmTheme`  
      `./vendor/underscore.js`  
  `nak` knows that you should search and list your current dir, before advancing alphabetically through the subdirs.
### Disadvantages

Over the last few weeks, `ag` got faster. I shaved 500ms off of `nak` in comparison searches, but it's still about four times slower. Here are some numbers:
- Searching for the word "silver" in all of atom (13300 files) 
  - `ag`: 0.240 seconds
  - `nak`: 1.516 seconds
- Searching for the word "function" in all of atom (13300 files) 
  - `ag`: 0.602 seconds
  - `nak`: 1.989s seconds
- Searching for the letter "v" in my dev dir (69329 files) 
  - `ag`: 10.42 seconds
  - `nak`: 13.37 seconds

Can `nak` be faster? Actually, yes. Since `console.log` is blocking, every time I stream back  a chunk of results I'm holding up the processing. If I drop the streaming results I can improve the speed a little more, but I kind of prefer the stream.
### Other search-y stuff

`ag` and `nak` both allow for whole word matching, case-sensitivity, non-regexps, _e.t.c._. Atom needs to figure out a way to do these things.

Also, `nak` supports find _and replace_ in files. You can also filter on the file level, _e.g._, `--ignore *.js` excludes JS files, `--include *.less` only checks LESS files. 
#### More ?!

`nak` can also be used to populate the fuzzy-file list. It takes around 300ms to get all the files in the Atom dir. Unfortunately, that's not in this PR, because I couldn't get it to work properly.
