### PR TITLE
Support optional doc strings for commands

### DIFF
--- a/spec/stdlib/jquery-extensions-spec.coffee
+++ b/spec/stdlib/jquery-extensions-spec.coffee
@@ -77,6 +77,47 @@ describe 'jQuery extensions', ->
         'a1': "A1: Waste perfectly-good steak"
         'a2': null
 
+  describe "$.fn.command(eventName, [selector, options,] handler)", ->
+    [view, handler] = []
+
+    beforeEach ->
+      view = $$ ->
+        @div class: 'a', =>
+          @div class: 'b'
+          @div class: 'c'
+      handler = jasmine.createSpy("commandHandler")
+
+    it "binds the handler to the given event / selector for all argument combinations", ->
+      view.command 'test:foo', handler
+      view.trigger 'test:foo'
+      expect(handler).toHaveBeenCalled()
+      handler.reset()
+
+      view.command 'test:bar', '.b', handler
+      view.find('.b').trigger 'test:bar'
+      view.find('.c').trigger 'test:bar'
+      expect(handler.callCount).toBe 1
+      handler.reset()
+
+      view.command 'test:baz', doc: 'Spaz', handler
+      view.trigger 'test:baz'
+      expect(handler).toHaveBeenCalled()
+      handler.reset()
+
+      view.command 'test:quux', '.c', doc: 'Lorem', handler
+      view.find('.b').trigger 'test:quux'
+      view.find('.c').trigger 'test:quux'
+      expect(handler.callCount).toBe 1
+
+    it "passes the 'data' option through when binding the event handler", ->
+      view.command 'test:foo', data: "bar", handler
+      view.trigger 'test:foo'
+      expect(handler.argsForCall[0][0].data).toBe 'bar'
+
+    it "sets a custom docstring if the 'doc' option is specified", ->
+      view.command 'test:foo', doc: "Foo!", handler
+      expect(view.events()).toEqual 'test:foo': 'Test: Foo!'
+
   describe "$.fn.scrollUp/Down/ToTop/ToBottom", ->
     it "scrolls the element in the specified way if possible", ->
       view = $$ -> @div => _.times 20, => @div('A')

--- a/spec/stdlib/jquery-extensions-spec.coffee
+++ b/spec/stdlib/jquery-extensions-spec.coffee
@@ -116,6 +116,10 @@ describe 'jQuery extensions', ->
       view.command 'test:foo', doc: "Foo!", handler
       expect(view.events()).toEqual 'test:foo': 'Test: Foo!'
 
+    it "capitalizes the 'github' prefix how we like it", ->
+      view.command 'github:spelling', handler
+      expect(view.events()).toEqual 'github:spelling': 'GitHub: Spelling'
+
   describe "$.fn.scrollUp/Down/ToTop/ToBottom", ->
     it "scrolls the element in the specified way if possible", ->
       view = $$ -> @div => _.times 20, => @div('A')

--- a/spec/stdlib/jquery-extensions-spec.coffee
+++ b/spec/stdlib/jquery-extensions-spec.coffee
@@ -42,7 +42,7 @@ describe 'jQuery extensions', ->
         element.trigger 'foo'
         expect(events).toEqual [2,1,3]
 
-  describe "$.fn.events() and $.fn.document", ->
+  describe "$.fn.events() and $.fn.document(...)", ->
     it "returns a list of all events being listened for on the target node or its ancestors, along with their documentation string", ->
       view = $$ ->
         @div id: 'a', =>
@@ -50,20 +50,18 @@ describe 'jQuery extensions', ->
             @div id: 'c'
           @div id: 'd'
 
-      view.document
-        'a1': "This is event A2"
-        'b2': "This is event b2"
+      view.document 'a1', "This is event A2"
+      view.document 'b2', "This is event b2"
 
-      view.document 'a1': "A1: Waste perfectly-good steak"
+      view.document 'a1', "A1: Waste perfectly-good steak"
       view.on 'a1', ->
       view.on 'a2', ->
       view.on 'b1', -> # should not appear as a duplicate
 
       divB = view.find('#b')
 
-      divB.document
-        'b1': "B1: Super-sonic bomber"
-        'b2': "B2: Looks evil. Kinda is."
+      divB.document 'b1', "B1: Super-sonic bomber"
+      divB.document 'b2', "B2: Looks evil. Kinda is."
       divB.on 'b1', ->
       divB.on 'b2', ->
 

--- a/src/stdlib/jquery-extensions.coffee
+++ b/src/stdlib/jquery-extensions.coffee
@@ -80,13 +80,8 @@ $.fn.events = ->
   else
     events
 
-# Valid calling styles:
-# command(eventName, handler)
-# command(eventName, selector, handler)
-# command(eventName, options, handler)
-# command(eventName, selector, options, handler)
 $.fn.command = (eventName, selector, options, handler) ->
-  if not options? and not handler?
+  if not options?
     handler  = selector
     selector = null
   else if not handler?
@@ -94,11 +89,10 @@ $.fn.command = (eventName, selector, options, handler) ->
     options = null
 
   if selector? and typeof(selector) is 'object'
-    handler  = options
     options  = selector
     selector = null
 
-  @document(eventName, _.humanizeEventName(eventName, options?["xxx"]))
+  @document(eventName, _.humanizeEventName(eventName, options?["doc"]))
   @on(eventName, selector, options?['data'], handler)
 
 $.fn.iconSize = (size) ->

--- a/src/stdlib/jquery-extensions.coffee
+++ b/src/stdlib/jquery-extensions.coffee
@@ -59,7 +59,12 @@ $.fn.trueHeight = ->
 $.fn.trueWidth = ->
   this[0].getBoundingClientRect().width
 
-$.fn.document = (eventDescriptions) ->
+$.fn.document = (eventDescriptions, optionalDoc) ->
+  if optionalDoc
+    eventName = eventDescriptions
+    eventDescriptions = {}
+    eventDescriptions[eventName] = optionalDoc
+
   @data('documentation', {}) unless @data('documentation')
   _.extend(@data('documentation'), eventDescriptions)
 
@@ -75,12 +80,26 @@ $.fn.events = ->
   else
     events
 
-$.fn.command = (args...) ->
-  eventName = args[0]
-  documentation = {}
-  documentation[eventName] = _.humanizeEventName(eventName)
-  @document(documentation)
-  @on(args...)
+# Valid calling styles:
+# command(eventName, handler)
+# command(eventName, selector, handler)
+# command(eventName, options, handler)
+# command(eventName, selector, options, handler)
+$.fn.command = (eventName, selector, options, handler) ->
+  if not options? and not handler?
+    handler  = selector
+    selector = null
+  else if not handler?
+    handler = options
+    options = null
+
+  if selector? and typeof(selector) is 'object'
+    handler  = options
+    options  = selector
+    selector = null
+
+  @document(eventName, _.humanizeEventName(eventName, options?["xxx"]))
+  @on(eventName, selector, options?['data'], handler)
 
 $.fn.iconSize = (size) ->
   @width(size).height(size).css('font-size', size)

--- a/src/stdlib/jquery-extensions.coffee
+++ b/src/stdlib/jquery-extensions.coffee
@@ -59,12 +59,9 @@ $.fn.trueHeight = ->
 $.fn.trueWidth = ->
   this[0].getBoundingClientRect().width
 
-$.fn.document = (eventDescriptions, optionalDoc) ->
-  if optionalDoc
-    eventName = eventDescriptions
-    eventDescriptions = {}
-    eventDescriptions[eventName] = optionalDoc
-
+$.fn.document = (eventName, docString) ->
+  eventDescriptions = {}
+  eventDescriptions[eventName] = docString
   @data('documentation', {}) unless @data('documentation')
   _.extend(@data('documentation'), eventDescriptions)
 

--- a/src/stdlib/underscore-extensions.coffee
+++ b/src/stdlib/underscore-extensions.coffee
@@ -52,17 +52,16 @@ _.mixin
     regex = RegExp('[' + specials.join('\\') + ']', 'g')
     string.replace(regex, "\\$&");
 
-  humanizeEventName: (eventName, optionalDocString) ->
+  humanizeEventName: (eventName, eventDoc) ->
     return "GitHub" if eventName.toLowerCase() is "github"
 
-    if /:/.test(eventName)
-      [namespace, name] = eventName.split(':')
-      return "#{@humanizeEventName(namespace)}: #{@humanizeEventName(name, optionalDocString)}"
+    [namespace, event]  = eventName.split(':')
+    return _.capitalize(namespace) unless event?
 
-    return optionalDocString if not _.isEmpty(optionalDocString)
+    namespaceDoc   = _.undasherize(namespace)
+    eventDoc     ||= _.undasherize(event)
 
-    words = eventName.split('-')
-    words.map(_.capitalize).join(' ')
+    "#{namespaceDoc}: #{eventDoc}"
 
   capitalize: (word) ->
     word[0].toUpperCase() + word[1..]
@@ -83,6 +82,9 @@ _.mixin
         "-" + letter.toLowerCase()
       else
         "-"
+
+  undasherize: (string) ->
+    string.split('-').map(_.capitalize).join(' ')
 
   underscore: (string) ->
     string = string[0].toLowerCase() + string[1..]

--- a/src/stdlib/underscore-extensions.coffee
+++ b/src/stdlib/underscore-extensions.coffee
@@ -52,10 +52,14 @@ _.mixin
     regex = RegExp('[' + specials.join('\\') + ']', 'g')
     string.replace(regex, "\\$&");
 
-  humanizeEventName: (eventName) ->
+  humanizeEventName: (eventName, optionalDocString) ->
+    return "GitHub" if eventName.toLowerCase() is "github"
+
     if /:/.test(eventName)
       [namespace, name] = eventName.split(':')
-      return "#{@humanizeEventName(namespace)}: #{@humanizeEventName(name)}"
+      return "#{@humanizeEventName(namespace)}: #{@humanizeEventName(name, optionalDocString)}"
+
+    return optionalDocString if not _.isEmpty(optionalDocString)
 
     words = eventName.split('-')
     words.map(_.capitalize).join(' ')

--- a/src/stdlib/underscore-extensions.coffee
+++ b/src/stdlib/underscore-extensions.coffee
@@ -53,18 +53,19 @@ _.mixin
     string.replace(regex, "\\$&");
 
   humanizeEventName: (eventName, eventDoc) ->
-    return "GitHub" if eventName.toLowerCase() is "github"
-
     [namespace, event]  = eventName.split(':')
     return _.capitalize(namespace) unless event?
 
-    namespaceDoc   = _.undasherize(namespace)
-    eventDoc     ||= _.undasherize(event)
+    namespaceDoc = _.undasherize(namespace)
+    eventDoc ?= _.undasherize(event)
 
     "#{namespaceDoc}: #{eventDoc}"
 
   capitalize: (word) ->
-    word[0].toUpperCase() + word[1..]
+    if word.toLowerCase() is 'github'
+      'GitHub'
+    else
+      word[0].toUpperCase() + word[1..]
 
   pluralize: (count=0, singular, plural=singular+'s') ->
     if count is 1


### PR DESCRIPTION
This PR changes `jQuery.fn.command` from a straight `on` passthrough to something a little more specific.

The new signature is `command(eventName, selector, options, handler)`. This signature clarifies usage a bit: Unlike `on`, `command` takes a single event name. `selector` and `options` are optional.

The `options` object can have two keys:
- `data`, an Object passed through to `on`. This isn't used very often, but it's there.
- `doc`, a String to replace the auto-generated docstring for an event.

The `doc` key is only used to replace the portion of an event name after the `:`.

Before:

``` coffeescript
@command "testing:show-alert", ->
  # => "Testing: Show Alert
```

After:

``` coffeescript
@command "testing:show-alert", doc: "Hi!", ->
  # => "Testing: Hi!"
```

I also dropped a little tweak in to always change `github` to `GitHub` if it's an event namespace. :octocat: 
