### PR TITLE
window.project -> atom.getActiveProject()

### DIFF
--- a/spec/app/display-buffer-spec.coffee
+++ b/spec/app/display-buffer-spec.coffee
@@ -3,8 +3,9 @@ Buffer = require 'buffer'
 _ = require 'underscore'
 
 describe "DisplayBuffer", ->
-  [editSession, displayBuffer, buffer, changeHandler, tabLength] = []
+  [project, editSession, displayBuffer, buffer, changeHandler, tabLength] = []
   beforeEach ->
+    project = atom.getActiveProject()
     tabLength = 2
     editSession = project.buildEditSession('sample.js', { tabLength })
     { buffer, displayBuffer } = editSession

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -3,12 +3,13 @@ Buffer = require 'buffer'
 EditSession = require 'edit-session'
 
 describe "EditSession", ->
-  [buffer, editSession, lineLengths] = []
+  [project, buffer, editSession, lineLengths] = []
 
   convertToHardTabs = (buffer) ->
     buffer.setText(buffer.getText().replace(/[ ]{2}/g, "\t"))
 
   beforeEach ->
+    project = atom.getActiveProject()
     editSession = project.buildEditSession('sample.js', autoIndent: false)
     buffer = editSession.buffer
     lineLengths = buffer.getLines().map (line) -> line.length

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -9,9 +9,10 @@ _ = require 'underscore'
 fs = require 'fs'
 
 describe "Editor", ->
-  [buffer, editor, editSession, cachedLineHeight, cachedCharWidth] = []
+  [project, buffer, editor, editSession, cachedLineHeight, cachedCharWidth] = []
 
   beforeEach ->
+    project = atom.getActiveProject()
     editSession = project.buildEditSession('sample.js')
     buffer = editSession.buffer
     editor = new Editor(editSession)

--- a/spec/app/git-spec.coffee
+++ b/spec/app/git-spec.coffee
@@ -3,9 +3,11 @@ fs = require 'fs'
 Task = require 'task'
 
 describe "Git", ->
+  project = null
   repo = null
 
   beforeEach ->
+    project = atom.getActiveProject()
     fs.remove('/tmp/.git') if fs.isDirectory('/tmp/.git')
 
   afterEach ->

--- a/spec/app/language-mode-spec.coffee
+++ b/spec/app/language-mode-spec.coffee
@@ -3,7 +3,10 @@ Buffer = require 'buffer'
 EditSession = require 'edit-session'
 
 describe "LanguageMode", ->
-  [editSession, buffer, languageMode] = []
+  [project, editSession, buffer, languageMode] = []
+
+  beforeEach ->
+    project = atom.getActiveProject()
 
   afterEach ->
     editSession.destroy()

--- a/spec/app/pane-spec.coffee
+++ b/spec/app/pane-spec.coffee
@@ -4,9 +4,10 @@ Pane = require 'pane'
 $ = require 'jquery'
 
 describe "Pane", ->
-  [container, view1, view2, editSession1, editSession2, pane] = []
+  [project, container, view1, view2, editSession1, editSession2, pane] = []
 
   beforeEach ->
+    project = atom.getActiveProject()
     container = new PaneContainer
     view1 = $$ -> @div id: 'view-1', tabindex: -1, 'View 1'
     view2 = $$ -> @div id: 'view-2', tabindex: -1, 'View 2'

--- a/spec/app/project-spec.coffee
+++ b/spec/app/project-spec.coffee
@@ -3,7 +3,10 @@ fs = require 'fs'
 _ = require 'underscore'
 
 describe "Project", ->
+  project = null
+
   beforeEach ->
+    project = atom.getActiveProject()
     project.setPath(project.resolve('dir'))
 
   describe "when an edit session is destroyed", ->

--- a/spec/app/root-view-spec.coffee
+++ b/spec/app/root-view-spec.coffee
@@ -8,9 +8,11 @@ Pane = require 'pane'
 {View, $$} = require 'space-pen'
 
 describe "RootView", ->
+  project = null
   pathToOpen = null
 
   beforeEach ->
+    project = atom.getActiveProject()
     project.setPath(project.resolve('dir'))
     pathToOpen = project.resolve('a')
     window.rootView = new RootView

--- a/spec/app/text-mate-grammar-spec.coffee
+++ b/spec/app/text-mate-grammar-spec.coffee
@@ -5,9 +5,11 @@ fs = require 'fs'
 _ = require 'underscore'
 
 describe "TextMateGrammar", ->
+  project = null
   grammar = null
 
   beforeEach ->
+    project = atom.getActiveProject()
     grammar = syntax.grammarForFilePath("hello.coffee")
 
   describe ".tokenizeLine(line, ruleStack)", ->

--- a/spec/app/theme-spec.coffee
+++ b/spec/app/theme-spec.coffee
@@ -3,9 +3,11 @@ fs = require 'fs'
 Theme = require 'theme'
 
 describe "@load(name)", ->
+  project = null
   theme = null
 
   beforeEach ->
+    project = atom.getActiveProject()
     $("#jasmine-content").append $("<div class='editor'></div>")
 
   afterEach ->

--- a/spec/app/tokenized-buffer-spec.coffee
+++ b/spec/app/tokenized-buffer-spec.coffee
@@ -5,9 +5,10 @@ Range = require 'range'
 _ = require 'underscore'
 
 describe "TokenizedBuffer", ->
-  [editSession, tokenizedBuffer, buffer, changeHandler] = []
+  [project, editSession, tokenizedBuffer, buffer, changeHandler] = []
 
   beforeEach ->
+    project = atom.getActiveProject()
     # enable async tokenization
     TokenizedBuffer.prototype.chunkSize = 5
     jasmine.unspy(TokenizedBuffer.prototype, 'tokenizeInBackground')

--- a/spec/app/window-spec.coffee
+++ b/spec/app/window-spec.coffee
@@ -3,12 +3,14 @@ fs = require 'fs'
 {less} = require 'less'
 
 describe "Window", ->
+  project = null
   projectPath = null
 
   beforeEach ->
     spyOn(atom, 'getPathToOpen').andReturn(project.getPath())
     window.handleWindowEvents()
     window.buildProjectAndRootView()
+    project = atom.getActiveProject()
     projectPath = project.getPath()
 
   afterEach ->

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -29,12 +29,14 @@ jasmine.getEnv().addEqualityTester(_.isEqual) # Use underscore's definition of e
 jasmine.getEnv().defaultTimeoutInterval = 5000
 
 beforeEach ->
+  project = new Project(require.resolve('fixtures'))
+  atom.setActiveProject(project)
+
   jQuery.fx.off = true
-  window.project = new Project(require.resolve('fixtures'))
   window.git = Git.open(project.getPath())
-  window.project.on 'path-changed', ->
+  project.on 'path-changed', ->
     window.git?.destroy()
-    window.git = Git.open(window.project.getPath())
+    window.git = Git.open(project.getPath())
 
   window.resetTimeouts()
   atom.atomPackageStates = {}
@@ -71,6 +73,8 @@ beforeEach ->
   addCustomMatchers(this)
 
 afterEach ->
+  project = atom.getActiveProject()
+
   keymap.bindingSets = bindingSetsToRestore
   keymap.bindingSetsByFirstKeystrokeToRestore = bindingSetsByFirstKeystrokeToRestore
   if rootView?
@@ -78,7 +82,7 @@ afterEach ->
     window.rootView = null
   if project?
     project.destroy()
-    window.project = null
+    atom.setActiveProject(null)
   if git?
     git.destroy()
     window.git = null

--- a/src/app/atom.coffee
+++ b/src/app/atom.coffee
@@ -5,6 +5,7 @@ TextMatePackage = require 'text-mate-package'
 Theme = require 'theme'
 LoadTextMatePackagesTask = require 'load-text-mate-packages-task'
 
+activeProject = null
 messageIdCounter = 1
 originalSendMessageToBrowserProcess = atom.sendMessageToBrowserProcess
 
@@ -18,6 +19,12 @@ _.extend atom,
   atomPackageStates: {}
   presentingModal: false
   pendingModals: [[]]
+
+  getActiveProject: ->
+    activeProject
+
+  setActiveProject: (project) ->
+    activeProject = project
 
   getPathToOpen: ->
     @getWindowState('pathToOpen') ? window.location.params.pathToOpen

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -15,6 +15,8 @@ class EditSession
   registerDeserializer(this)
 
   @deserialize: (state) ->
+    project = atom.getActiveProject()
+
     if fs.exists(state.buffer)
       session = project.buildEditSession(state.buffer)
     else

--- a/src/app/git.coffee
+++ b/src/app/git.coffee
@@ -41,7 +41,7 @@ class Git
         @refreshIndex()
         @refreshStatus()
 
-    project?.eachBuffer this, (buffer) =>
+    atom.getActiveProject()?.eachBuffer this, (buffer) =>
       bufferStatusHandler = =>
         path = buffer.getPath()
         @getPathStatus(path) if path

--- a/src/app/grammar-view.coffee
+++ b/src/app/grammar-view.coffee
@@ -46,6 +46,8 @@ class GrammarView extends SelectList
     @setArray(grammars)
 
   confirmed: (grammar) ->
+    project = atom.getActiveProject()
+
     @cancel()
     if grammar is @autoDetect
       project.removeGrammarOverrideForPath(@path)

--- a/src/app/root-view.coffee
+++ b/src/app/root-view.coffee
@@ -35,6 +35,8 @@ class RootView extends View
     new RootView({panes})
 
   initialize: ->
+    project = atom.getActiveProject()
+
     @command 'toggle-dev-tools', => atom.toggleDevTools()
     @on 'focus', (e) => @handleFocus(e)
     @subscribe $(window), 'focus', (e) =>
@@ -99,6 +101,8 @@ class RootView extends View
     @remove()
 
   open: (path, options = {}) ->
+    project = atom.getActiveProject()
+
     changeFocus = options.changeFocus ? true
     path = project.resolve(path) if path?
     if activePane = @getActivePane()
@@ -116,6 +120,8 @@ class RootView extends View
     editSession
 
   updateTitle: ->
+    project = atom.getActiveProject()
+
     if projectPath = project.getPath()
       if item = @getActivePaneItem()
         @setTitle("#{item.getTitle?() ? 'untitled'} - #{projectPath}")
@@ -154,7 +160,7 @@ class RootView extends View
 
   remove: ->
     editor.remove() for editor in @getEditors()
-    project.destroy()
+    atom.getActiveProject().destroy()
     super
 
   saveAll: ->
@@ -174,8 +180,8 @@ class RootView extends View
     @on 'editor:attached', (e, editor) -> callback(editor)
 
   eachEditSession: (callback) ->
-    project.eachEditSession(callback)
+    atom.getActiveProject().eachEditSession(callback)
 
   eachBuffer: (callback) ->
-    project.eachBuffer(callback)
+    atom.getActiveProject().eachBuffer(callback)
 

--- a/src/app/window.coffee
+++ b/src/app/window.coffee
@@ -9,6 +9,12 @@ require 'space-pen-extensions'
 deserializers = {}
 deferredDeserializers = {}
 
+window.__defineGetter__ 'project', ->
+  atom.getActiveProject()
+
+window.__defineSetter__ 'project', (project) ->
+  atom.setActiveProject(project)
+
 # This method is called in any window needing a general environment, including specs
 window.setUpEnvironment = ->
   Config = require 'config'

--- a/src/app/window.coffee
+++ b/src/app/window.coffee
@@ -10,9 +10,13 @@ deserializers = {}
 deferredDeserializers = {}
 
 window.__defineGetter__ 'project', ->
+  console.warn "Use atom.getActiveProject(), not the 'project' global."
+  console.trace()
   atom.getActiveProject()
 
 window.__defineSetter__ 'project', (project) ->
+  console.warn "Use atom.setActiveProject(), not the 'project' global."
+  console.trace()
   atom.setActiveProject(project)
 
 # This method is called in any window needing a general environment, including specs
@@ -71,6 +75,8 @@ window.startup = ->
   $(window).focus()
 
 window.shutdown = ->
+  project = atom.getActiveProject()
+
   return if not project and not rootView
   atom.setWindowState('pathToOpen', project.getPath())
   atom.setRootViewStateForPath project.getPath(),
@@ -81,7 +87,8 @@ window.shutdown = ->
   git?.destroy()
   $(window).off('focus blur before')
   window.rootView = null
-  window.project = null
+
+  atom.setActiveProject(null)
   window.git = null
 
 window.installAtomCommand = (commandPath) ->
@@ -105,7 +112,8 @@ window.buildProjectAndRootView = ->
 
   pathToOpen = atom.getPathToOpen()
   windowState = atom.getRootViewStateForPath(pathToOpen) ? {}
-  window.project = deserialize(windowState.project) ? new Project(pathToOpen)
+  project = deserialize(windowState.project) ? new Project(pathToOpen)
+  atom.setActiveProject(project)
   window.rootView = deserialize(windowState.rootView) ? new RootView
 
   if !windowState.rootView and (!pathToOpen or fs.isFile(pathToOpen))

--- a/src/packages/autocomplete/spec/autocomplete-spec.coffee
+++ b/src/packages/autocomplete/spec/autocomplete-spec.coffee
@@ -6,7 +6,10 @@ Editor = require 'editor'
 RootView = require 'root-view'
 
 describe "Autocomplete", ->
+  project = null
+
   beforeEach ->
+    project = atom.getActiveProject()
     window.rootView = new RootView
     rootView.open('sample.js')
     rootView.simulateDomAttachment()
@@ -34,11 +37,13 @@ describe "Autocomplete", ->
       expect(rightEditor.find('.autocomplete')).toExist()
 
 describe "AutocompleteView", ->
+  project = null
   autocomplete = null
   editor = null
   miniEditor = null
 
   beforeEach ->
+    project = atom.getActiveProject()
     window.rootView = new RootView
     editor = new Editor(editSession: project.buildEditSession('sample.js'))
     window.loadPackage('autocomplete')

--- a/src/packages/command-panel/lib/command-panel-view.coffee
+++ b/src/packages/command-panel/lib/command-panel-view.coffee
@@ -30,6 +30,7 @@ class CommandPanelView extends View
   maxSerializedHistorySize: 100
 
   initialize: (state) ->
+    project = atom.getActiveProject()
     @commandInterpreter = new CommandInterpreter(project)
 
     @command 'tool-panel:unfocus', => rootView.focus()

--- a/src/packages/command-panel/spec/command-interpreter-spec.coffee
+++ b/src/packages/command-panel/spec/command-interpreter-spec.coffee
@@ -6,9 +6,10 @@ EditSession = require 'edit-session'
 _ = require 'underscore'
 
 describe "CommandInterpreter", ->
-  [interpreter, editSession, buffer] = []
+  [project, interpreter, editSession, buffer] = []
 
   beforeEach ->
+    project = atom.getActiveProject()
     interpreter = new CommandInterpreter(project)
     editSession = project.buildEditSession('sample.js')
     buffer = editSession.buffer

--- a/src/packages/command-panel/spec/command-panel-spec.coffee
+++ b/src/packages/command-panel/spec/command-panel-spec.coffee
@@ -3,9 +3,10 @@ CommandPanelView = require 'command-panel/lib/command-panel-view'
 _ = require 'underscore'
 
 describe "CommandPanel", ->
-  [editSession, buffer, commandPanel] = []
+  [project, editSession, buffer, commandPanel] = []
 
   beforeEach ->
+    project = atom.getActiveProject()
     window.rootView = new RootView
     rootView.open('sample.js')
     rootView.enableKeymap()

--- a/src/packages/fuzzy-finder/lib/fuzzy-finder.coffee
+++ b/src/packages/fuzzy-finder/lib/fuzzy-finder.coffee
@@ -6,6 +6,8 @@ module.exports =
   loadPathsTask: null
 
   activate: (state) ->
+    project = atom.getActiveProject()
+
     rootView.command 'fuzzy-finder:toggle-file-finder', =>
       @createView().toggleFileFinder()
     rootView.command 'fuzzy-finder:toggle-buffer-finder', =>

--- a/src/packages/fuzzy-finder/lib/load-paths-task.coffee
+++ b/src/packages/fuzzy-finder/lib/load-paths-task.coffee
@@ -6,6 +6,8 @@ class LoadPathsTask extends Task
     super('fuzzy-finder/lib/load-paths-handler')
 
   started: ->
+    project = atom.getActiveProject()
+
     ignoredNames = config.get('fuzzyFinder.ignoredNames') ? []
     ignoredNames = ignoredNames.concat(config.get('core.ignoredNames') ? [])
     excludeGitIgnoredPaths = config.get('core.hideGitIgnoredFiles')

--- a/src/packages/markdown-preview/spec/markdown-preview-view-spec.coffee
+++ b/src/packages/markdown-preview/spec/markdown-preview-view-spec.coffee
@@ -3,9 +3,10 @@ $ = require 'jquery'
 {$$$} = require 'space-pen'
 
 describe "MarkdownPreviewView", ->
-  [buffer, preview] = []
+  [project, buffer, preview] = []
 
   beforeEach ->
+    project = atom.getActiveProject()
     spyOn($, 'ajax')
     project.setPath(project.resolve('markdown'))
     buffer = project.bufferForPath('file.markdown')

--- a/src/packages/snippets/spec/snippets-spec.coffee
+++ b/src/packages/snippets/spec/snippets-spec.coffee
@@ -8,8 +8,9 @@ fs = require 'fs'
 Package = require 'package'
 
 describe "Snippets extension", ->
-  [buffer, editor, editSession] = []
+  [project, buffer, editor, editSession] = []
   beforeEach ->
+    project = atom.getActiveProject()
     window.rootView = new RootView
     rootView.open('sample.js')
     spyOn(LoadSnippetsTask.prototype, 'start')

--- a/src/packages/status-bar/lib/status-bar-view.coffee
+++ b/src/packages/status-bar/lib/status-bar-view.coffee
@@ -112,6 +112,8 @@ class StatusBarView extends View
       @gitStatusIcon.text("+#{@buffer.getLineCount()}")
 
   updatePathText: ->
+    project = atom.getActiveProject()
+
     if path = @editor.getPath()
       @currentPath.text(project.relativize(path))
     else

--- a/src/packages/status-bar/spec/status-bar-spec.coffee
+++ b/src/packages/status-bar/spec/status-bar-spec.coffee
@@ -5,9 +5,10 @@ StatusBar = require 'status-bar/lib/status-bar-view'
 fs = require 'fs'
 
 describe "StatusBar", ->
-  [editor, statusBar, buffer] = []
+  [project, editor, statusBar, buffer] = []
 
   beforeEach ->
+    project = atom.getActiveProject()
     window.rootView = new RootView
     rootView.open('sample.js')
     rootView.simulateDomAttachment()

--- a/src/packages/tabs/spec/tabs-spec.coffee
+++ b/src/packages/tabs/spec/tabs-spec.coffee
@@ -22,7 +22,7 @@ describe "Tabs package main", ->
       expect(rootView.panes.find('.pane > .tabs').length).toBe 2
 
 describe "TabBarView", ->
-  [item1, item2, editSession1, pane, tabBar] = []
+  [project, item1, item2, editSession1, pane, tabBar] = []
 
   class TestView extends View
     @deserialize: ({title, longTitle}) -> new TestView(title, longTitle)
@@ -33,6 +33,7 @@ describe "TabBarView", ->
     serialize: -> { deserializer: 'TestView', @title, @longTitle }
 
   beforeEach ->
+    project = atom.getActiveProject()
     registerDeserializer(TestView)
     item1 = new TestView('Item 1')
     item2 = new TestView('Item 2')

--- a/src/packages/tree-view/lib/tree-view.coffee
+++ b/src/packages/tree-view/lib/tree-view.coffee
@@ -21,6 +21,8 @@ class TreeView extends ScrollView
   selectedPath: null
 
   initialize: (state) ->
+    project = atom.getActiveProject()
+
     super
     @on 'click', '.entry', (e) => @entryClicked(e)
     @on 'mousedown', '.tree-view-resizer', (e) => @resizeStarted(e)
@@ -76,6 +78,7 @@ class TreeView extends ScrollView
       @focus()
 
   attach: ->
+    project = atom.getActiveProject()
     return unless project.getPath()
     rootView.horizontal.prepend(this)
 
@@ -118,6 +121,8 @@ class TreeView extends ScrollView
     @css(width: e.pageX)
 
   updateRoot: ->
+    project = atom.getActiveProject()
+
     @root?.remove()
 
     if rootDirectory = project.getRootDirectory()
@@ -133,6 +138,8 @@ class TreeView extends ScrollView
       @deselect()
 
   revealActiveFile: ->
+    project = atom.getActiveProject()
+
     @attach()
     @focus()
 
@@ -207,6 +214,8 @@ class TreeView extends ScrollView
       rootView.open(selectedEntry.getPath(), { changeFocus })
 
   moveSelectedEntry: ->
+    project = atom.getActiveProject()
+
     entry = @selectedEntry()
     return unless entry and entry isnt @root
     oldPath = entry.getPath()
@@ -246,6 +255,8 @@ class TreeView extends ScrollView
     )
 
   add: ->
+    project = atom.getActiveProject()
+
     selectedEntry = @selectedEntry() or @root
     selectedPath = selectedEntry.getPath()
     directoryPath = if fs.isFile(selectedPath) then fs.directory(selectedPath) else selectedPath

--- a/src/packages/tree-view/spec/tree-view-spec.coffee
+++ b/src/packages/tree-view/spec/tree-view-spec.coffee
@@ -7,9 +7,10 @@ Directory = require 'directory'
 fs = require 'fs'
 
 describe "TreeView", ->
-  [treeView, sampleJs, sampleTxt] = []
+  [project, treeView, sampleJs, sampleTxt] = []
 
   beforeEach ->
+    project = atom.getActiveProject()
     project.setPath(project.resolve('tree-view'))
     window.rootView = new RootView
 


### PR DESCRIPTION
This isn't necessarily the interface we'll want in the end, but all I care about right now is taking a stab at removing the `project` global.

This prints deprecation warnings every time `window.project` is get or set directly. There are some spec failures I don't totally understand. Extra hands here would be very, very welcome.
