### PR TITLE
Move some hard-coded shortcuts to application menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 .DS_Store
 .project
 .svn

--- a/native/atom_application.h
+++ b/native/atom_application.h
@@ -21,10 +21,12 @@ class AtomCefClient;
 - (void)openDev:(NSString *)path;
 - (void)open:(NSString *)path pidToKillWhenWindowCloses:(NSNumber *)pid;
 - (IBAction)runSpecs:(id)sender;
-- (IBAction)runBenchmarks:(id)sender;
 - (void)runSpecsThenExit:(BOOL)exitWhenDone;
-- (NSDictionary *)arguments;
+- (IBAction)runBenchmarks:(id)sender;
 - (void)runBenchmarksThenExit:(BOOL)exitWhenDone;
+- (IBAction)focusOnNextWindow:(id)sender;
+- (IBAction)focusOnPreviousWindow:(id)sender;
+- (NSDictionary *)arguments;
 
 @property (nonatomic, retain) NSDictionary *arguments;
 

--- a/native/atom_application.mm
+++ b/native/atom_application.mm
@@ -181,6 +181,41 @@
   [[AtomWindowController alloc] initBenchmarksThenExit:exitWhenDone];
 }
 
+- (IBAction)focusOnNextWindow:(id)sender {
+  NSArray *windows = [NSApp windows];
+  int count = [windows count];
+  int start = [windows indexOfObject:[NSApp keyWindow]];
+
+  int i = start;
+  while (true) {
+    i = (i + 1) % count;
+    if (i == start) break;
+    NSWindow *window = [windows objectAtIndex:i];
+    if ([window isVisible] && ![window isExcludedFromWindowsMenu]) {
+      [window makeKeyAndOrderFront:nil];
+      break;
+    }
+  }
+}
+
+- (IBAction)focusOnPreviousWindow:(id)sender {
+  NSArray *windows = [NSApp windows];
+  int count = [windows count];
+  int start = [windows indexOfObject:[NSApp keyWindow]];
+
+  int i = start;
+  while (true) {
+    i = i - 1;
+    if (i == 0) i = count -1;
+    if (i == start) break;
+    NSWindow *window = [windows objectAtIndex:i];
+    if ([window isVisible] && ![window isExcludedFromWindowsMenu]) {
+      [window makeKeyAndOrderFront:nil];
+      break;
+    }
+  }
+}
+
 # pragma mark NSApplicationDelegate
 
 - (BOOL)shouldOpenFiles {

--- a/native/atom_cef_client.cpp
+++ b/native/atom_cef_client.cpp
@@ -146,10 +146,6 @@ bool AtomCefClient::OnKeyEvent(CefRefPtr<CefBrowser> browser,
   }
   else if (event.modifiers == (EVENTFLAG_COMMAND_DOWN | EVENTFLAG_ALT_DOWN) && event.unmodified_character == 'i') {
     ToggleDevTools(browser);
-  } else if (event.modifiers == EVENTFLAG_COMMAND_DOWN && event.unmodified_character == '`') {
-    FocusNextWindow();
-  } else if (event.modifiers == (EVENTFLAG_COMMAND_DOWN | EVENTFLAG_SHIFT_DOWN) && event.unmodified_character == '~') {
-    FocusPreviousWindow();
   }
   else {
     return false;

--- a/native/atom_cef_client.cpp
+++ b/native/atom_cef_client.cpp
@@ -134,12 +134,12 @@ bool AtomCefClient::OnKeyEvent(CefRefPtr<CefBrowser> browser,
                                CefEventHandle os_event) {
   if (m_HandlePasteboardCommands && event.modifiers == EVENTFLAG_COMMAND_DOWN && event.unmodified_character == 'x') {
     browser->GetFocusedFrame()->Cut();
-  }
-  if (m_HandlePasteboardCommands && event.modifiers == EVENTFLAG_COMMAND_DOWN && event.unmodified_character == 'c') {
+  } else if (m_HandlePasteboardCommands && event.modifiers == EVENTFLAG_COMMAND_DOWN && event.unmodified_character == 'c') {
     browser->GetFocusedFrame()->Copy();
-  }
-  if (m_HandlePasteboardCommands && event.modifiers == EVENTFLAG_COMMAND_DOWN && event.unmodified_character == 'v') {
+  } else if (m_HandlePasteboardCommands && event.modifiers == EVENTFLAG_COMMAND_DOWN && event.unmodified_character == 'v') {
     browser->GetFocusedFrame()->Paste();
+  } else {
+    return false;
   }
 
   return true;

--- a/native/atom_cef_client.cpp
+++ b/native/atom_cef_client.cpp
@@ -132,9 +132,6 @@ bool AtomCefClient::OnConsoleMessage(CefRefPtr<CefBrowser> browser,
 bool AtomCefClient::OnKeyEvent(CefRefPtr<CefBrowser> browser,
                                const CefKeyEvent& event,
                                CefEventHandle os_event) {
-  if (event.modifiers == EVENTFLAG_COMMAND_DOWN && event.unmodified_character == 'r') {
-    browser->SendProcessMessage(PID_RENDERER, CefProcessMessage::Create("reload"));
-  }
   if (m_HandlePasteboardCommands && event.modifiers == EVENTFLAG_COMMAND_DOWN && event.unmodified_character == 'x') {
     browser->GetFocusedFrame()->Cut();
   }

--- a/native/atom_cef_client.cpp
+++ b/native/atom_cef_client.cpp
@@ -144,12 +144,6 @@ bool AtomCefClient::OnKeyEvent(CefRefPtr<CefBrowser> browser,
   if (m_HandlePasteboardCommands && event.modifiers == EVENTFLAG_COMMAND_DOWN && event.unmodified_character == 'v') {
     browser->GetFocusedFrame()->Paste();
   }
-  else if (event.modifiers == (EVENTFLAG_COMMAND_DOWN | EVENTFLAG_ALT_DOWN) && event.unmodified_character == 'i') {
-    ToggleDevTools(browser);
-  }
-  else {
-    return false;
-  }
 
   return true;
 }

--- a/native/atom_cef_client.h
+++ b/native/atom_cef_client.h
@@ -105,8 +105,6 @@ class AtomCefClient : public CefClient,
   bool m_HandlePasteboardCommands = false;
   bool m_IgnoreTitleChanges = false;
 
-  void FocusNextWindow();
-  void FocusPreviousWindow();
   void Open(std::string path);
   void Open();
   void OpenDev(std::string path);

--- a/native/atom_cef_client_mac.mm
+++ b/native/atom_cef_client_mac.mm
@@ -73,7 +73,7 @@ void AtomCefClient::OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString
 
 void AtomCefClient::ToggleDevTools(CefRefPtr<CefBrowser> browser) {
   AtomWindowController *windowController = [[browser->GetHost()->GetWindowHandle() window] windowController];
-  [windowController toggleDevTools];
+  [windowController toggleDevtools:nil];
 }
 
 void AtomCefClient::ShowDevTools(CefRefPtr<CefBrowser> browser) {

--- a/native/atom_cef_client_mac.mm
+++ b/native/atom_cef_client_mac.mm
@@ -73,7 +73,7 @@ void AtomCefClient::OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString
 
 void AtomCefClient::ToggleDevTools(CefRefPtr<CefBrowser> browser) {
   AtomWindowController *windowController = [[browser->GetHost()->GetWindowHandle() window] windowController];
-  [windowController toggleDevtools:nil];
+  [windowController toggleDevTools:nil];
 }
 
 void AtomCefClient::ShowDevTools(CefRefPtr<CefBrowser> browser) {

--- a/native/atom_cef_client_mac.mm
+++ b/native/atom_cef_client_mac.mm
@@ -7,41 +7,6 @@
 #import "atom_window_controller.h"
 #import "atom_application.h"
 
-void AtomCefClient::FocusNextWindow() {
-  NSArray *windows = [NSApp windows];
-  int count = [windows count];
-  int start = [windows indexOfObject:[NSApp keyWindow]];
-
-  int i = start;
-  while (true) {
-    i = (i + 1) % count;
-    if (i == start) break;
-    NSWindow *window = [windows objectAtIndex:i];
-    if ([window isVisible] && ![window isExcludedFromWindowsMenu]) {
-      [window makeKeyAndOrderFront:nil];
-      break;
-    }
-  }
-}
-
-void AtomCefClient::FocusPreviousWindow() {
-  NSArray *windows = [NSApp windows];
-  int count = [windows count];
-  int start = [windows indexOfObject:[NSApp keyWindow]];
-
-  int i = start;
-  while (true) {
-    i = i - 1;
-    if (i == 0) i = count -1;
-    if (i == start) break;
-    NSWindow *window = [windows objectAtIndex:i];
-    if ([window isVisible] && ![window isExcludedFromWindowsMenu]) {
-      [window makeKeyAndOrderFront:nil];
-      break;
-    }
-  }
-}
-
 void AtomCefClient::Open(std::string path) {
   NSString *pathString = [NSString stringWithCString:path.c_str() encoding:NSUTF8StringEncoding];
   [(AtomApplication *)[AtomApplication sharedApplication] open:pathString];

--- a/native/atom_window_controller.h
+++ b/native/atom_window_controller.h
@@ -31,6 +31,7 @@ class AtomCefClient;
 - (id)initBenchmarksThenExit:(BOOL)exitWhenDone;
 - (void)setPidToKillOnClose:(NSNumber *)pid;
 
+- (IBAction)reloadWindow:(id)sender;
 - (IBAction)toggleDevtools:(id)sender;
 - (void)showDevTools;
 

--- a/native/atom_window_controller.h
+++ b/native/atom_window_controller.h
@@ -32,7 +32,7 @@ class AtomCefClient;
 - (void)setPidToKillOnClose:(NSNumber *)pid;
 
 - (IBAction)reloadWindow:(id)sender;
-- (IBAction)toggleDevtools:(id)sender;
+- (IBAction)toggleDevTools:(id)sender;
 - (void)showDevTools;
 
 @end

--- a/native/atom_window_controller.h
+++ b/native/atom_window_controller.h
@@ -31,7 +31,7 @@ class AtomCefClient;
 - (id)initBenchmarksThenExit:(BOOL)exitWhenDone;
 - (void)setPidToKillOnClose:(NSNumber *)pid;
 
-- (void)toggleDevTools;
+- (IBAction)toggleDevtools:(id)sender;
 - (void)showDevTools;
 
 @end

--- a/native/atom_window_controller.mm
+++ b/native/atom_window_controller.mm
@@ -177,7 +177,7 @@
   [self addBrowserToView:self.webView url:[urlString UTF8String] cefHandler:_cefClient];
 }
 
-- (void)toggleDevTools {
+- (IBAction)toggleDevtools:(id)sender {
   if (_devToolsView) {
     [self hideDevTools];
   }

--- a/native/atom_window_controller.mm
+++ b/native/atom_window_controller.mm
@@ -181,7 +181,7 @@
   _cefClient->GetBrowser()->SendProcessMessage(PID_RENDERER, CefProcessMessage::Create("reload"));
 }
 
-- (IBAction)toggleDevtools:(id)sender {
+- (IBAction)toggleDevTools:(id)sender {
   if (_devToolsView) {
     [self hideDevTools];
   }

--- a/native/atom_window_controller.mm
+++ b/native/atom_window_controller.mm
@@ -177,6 +177,10 @@
   [self addBrowserToView:self.webView url:[urlString UTF8String] cefHandler:_cefClient];
 }
 
+- (IBAction)reloadWindow:(id)sender {
+  _cefClient->GetBrowser()->SendProcessMessage(PID_RENDERER, CefProcessMessage::Create("reload"));
+}
+
 - (IBAction)toggleDevtools:(id)sender {
   if (_devToolsView) {
     [self hideDevTools];

--- a/native/mac/English.lproj/MainMenu.xib
+++ b/native/mac/English.lproj/MainMenu.xib
@@ -141,6 +141,15 @@
 								<bool key="EncodedWithXMLCoder">YES</bool>
 								<object class="NSMenuItem" id="195519793">
 									<reference key="NSMenu" ref="679500086"/>
+									<string key="NSTitle">Reload</string>
+									<string key="NSKeyEquiv">r</string>
+									<int key="NSKeyEquivModMask">1048576</int>
+									<int key="NSMnemonicLoc">2147483647</int>
+									<reference key="NSOnImage" ref="293900348"/>
+									<reference key="NSMixedImage" ref="169361956"/>
+								</object>
+								<object class="NSMenuItem" id="1039208338">
+									<reference key="NSMenu" ref="679500086"/>
 									<string key="NSTitle">Toogle Devtools</string>
 									<string key="NSKeyEquiv">i</string>
 									<int key="NSKeyEquivModMask">1572864</int>
@@ -376,9 +385,17 @@
 					<object class="IBActionConnection" key="connection">
 						<string key="label">toggleDevtools:</string>
 						<reference key="source" ref="1014"/>
+						<reference key="destination" ref="1039208338"/>
+					</object>
+					<int key="connectionID">532</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">reloadWindow:</string>
+						<reference key="source" ref="1014"/>
 						<reference key="destination" ref="195519793"/>
 					</object>
-					<int key="connectionID">529</int>
+					<int key="connectionID">533</int>
 				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -564,6 +581,7 @@
 							<reference ref="374313607"/>
 							<reference ref="1054511002"/>
 							<reference ref="905547100"/>
+							<reference ref="1039208338"/>
 						</object>
 						<reference key="parent" ref="550651221"/>
 					</object>
@@ -585,6 +603,11 @@
 					<object class="IBObjectRecord">
 						<int key="objectID">527</int>
 						<reference key="object" ref="905547100"/>
+						<reference key="parent" ref="679500086"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">531</int>
+						<reference key="object" ref="1039208338"/>
 						<reference key="parent" ref="679500086"/>
 					</object>
 				</object>
@@ -620,11 +643,13 @@
 					<string>525.IBPluginDependency</string>
 					<string>526.IBPluginDependency</string>
 					<string>527.IBPluginDependency</string>
+					<string>531.IBPluginDependency</string>
 					<string>56.IBPluginDependency</string>
 					<string>57.IBPluginDependency</string>
 				</object>
 				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -668,7 +693,7 @@
 				<reference key="dict.values" ref="755588897"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">530</int>
+			<int key="maxID">533</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -742,14 +767,35 @@
 					<string key="className">AtomWindowController</string>
 					<string key="superclassName">NSWindowController</string>
 					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">toggleDevtools:</string>
-						<string key="NS.object.0">id</string>
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>reloadWindow:</string>
+							<string>toggleDevtools:</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>id</string>
+							<string>id</string>
+						</object>
 					</object>
 					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">toggleDevtools:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">toggleDevtools:</string>
-							<string key="candidateClassName">id</string>
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>reloadWindow:</string>
+							<string>toggleDevtools:</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBActionInfo">
+								<string key="name">reloadWindow:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">toggleDevtools:</string>
+								<string key="candidateClassName">id</string>
+							</object>
 						</object>
 					</object>
 					<object class="NSMutableDictionary" key="outlets">
@@ -799,14 +845,35 @@
 				<object class="IBPartialClassDescription">
 					<string key="className">FirstResponder</string>
 					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">toggleDevtools:</string>
-						<string key="NS.object.0">id</string>
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>reloadWindow:</string>
+							<string>toggleDevtools:</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>id</string>
+							<string>id</string>
+						</object>
 					</object>
 					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">toggleDevtools:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">toggleDevtools:</string>
-							<string key="candidateClassName">id</string>
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>reloadWindow:</string>
+							<string>toggleDevtools:</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBActionInfo">
+								<string key="name">reloadWindow:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">toggleDevtools:</string>
+								<string key="candidateClassName">id</string>
+							</object>
 						</object>
 					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">

--- a/native/mac/English.lproj/MainMenu.xib
+++ b/native/mac/English.lproj/MainMenu.xib
@@ -383,19 +383,19 @@
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBActionConnection" key="connection">
-						<string key="label">toggleDevtools:</string>
-						<reference key="source" ref="1014"/>
-						<reference key="destination" ref="1039208338"/>
-					</object>
-					<int key="connectionID">532</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
 						<string key="label">reloadWindow:</string>
 						<reference key="source" ref="1014"/>
 						<reference key="destination" ref="195519793"/>
 					</object>
 					<int key="connectionID">533</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">toggleDevTools:</string>
+						<reference key="source" ref="1014"/>
+						<reference key="destination" ref="1039208338"/>
+					</object>
+					<int key="connectionID">534</int>
 				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -693,7 +693,7 @@
 				<reference key="dict.values" ref="755588897"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">533</int>
+			<int key="maxID">534</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -771,7 +771,7 @@
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>reloadWindow:</string>
-							<string>toggleDevtools:</string>
+							<string>toggleDevTools:</string>
 						</object>
 						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
@@ -784,7 +784,7 @@
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>reloadWindow:</string>
-							<string>toggleDevtools:</string>
+							<string>toggleDevTools:</string>
 						</object>
 						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
@@ -793,7 +793,7 @@
 								<string key="candidateClassName">id</string>
 							</object>
 							<object class="IBActionInfo">
-								<string key="name">toggleDevtools:</string>
+								<string key="name">toggleDevTools:</string>
 								<string key="candidateClassName">id</string>
 							</object>
 						</object>
@@ -849,7 +849,7 @@
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>reloadWindow:</string>
-							<string>toggleDevtools:</string>
+							<string>toggleDevTools:</string>
 						</object>
 						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
@@ -862,7 +862,7 @@
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>reloadWindow:</string>
-							<string>toggleDevtools:</string>
+							<string>toggleDevTools:</string>
 						</object>
 						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
@@ -871,7 +871,7 @@
 								<string key="candidateClassName">id</string>
 							</object>
 							<object class="IBActionInfo">
-								<string key="name">toggleDevtools:</string>
+								<string key="name">toggleDevTools:</string>
 								<string key="candidateClassName">id</string>
 							</object>
 						</object>

--- a/native/mac/English.lproj/MainMenu.xib
+++ b/native/mac/English.lproj/MainMenu.xib
@@ -2,10 +2,10 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
 	<data>
 		<int key="IBDocument.SystemTarget">1050</int>
-		<string key="IBDocument.SystemVersion">12C3103</string>
+		<string key="IBDocument.SystemVersion">12D78</string>
 		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
+		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
 			<string key="NS.object.0">3084</string>
@@ -176,6 +176,34 @@
 									<reference key="NSOnImage" ref="293900348"/>
 									<reference key="NSMixedImage" ref="169361956"/>
 								</object>
+								<object class="NSMenuItem" id="819434856">
+									<reference key="NSMenu" ref="378777354"/>
+									<string key="NSTitle">Focus on Next Window</string>
+									<string key="NSKeyEquiv">`</string>
+									<int key="NSKeyEquivModMask">1048576</int>
+									<int key="NSMnemonicLoc">2147483647</int>
+									<reference key="NSOnImage" ref="293900348"/>
+									<reference key="NSMixedImage" ref="169361956"/>
+								</object>
+								<object class="NSMenuItem" id="978130937">
+									<reference key="NSMenu" ref="378777354"/>
+									<string key="NSTitle">Focus on Previous Window</string>
+									<string key="NSKeyEquiv">`</string>
+									<int key="NSKeyEquivModMask">1179648</int>
+									<int key="NSMnemonicLoc">2147483647</int>
+									<reference key="NSOnImage" ref="293900348"/>
+									<reference key="NSMixedImage" ref="169361956"/>
+								</object>
+								<object class="NSMenuItem" id="82826686">
+									<reference key="NSMenu" ref="378777354"/>
+									<bool key="NSIsDisabled">YES</bool>
+									<bool key="NSIsSeparator">YES</bool>
+									<string key="NSTitle"/>
+									<string key="NSKeyEquiv"/>
+									<int key="NSMnemonicLoc">2147483647</int>
+									<reference key="NSOnImage" ref="293900348"/>
+									<reference key="NSMixedImage" ref="169361956"/>
+								</object>
 								<object class="NSMenuItem" id="337587793">
 									<reference key="NSMenu" ref="378777354"/>
 									<string key="NSTitle">Bring All to Front</string>
@@ -229,6 +257,22 @@
 						<reference key="destination" ref="781500792"/>
 					</object>
 					<int key="connectionID">465</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">focusOnNextWindow:</string>
+						<reference key="source" ref="1050"/>
+						<reference key="destination" ref="819434856"/>
+					</object>
+					<int key="connectionID">471</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">focusOnPreviousWindow:</string>
+						<reference key="source" ref="1050"/>
+						<reference key="destination" ref="978130937"/>
+					</object>
+					<int key="connectionID">472</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBActionConnection" key="connection">
@@ -386,6 +430,9 @@
 							<reference ref="501070065"/>
 							<reference ref="895514792"/>
 							<reference ref="337587793"/>
+							<reference ref="82826686"/>
+							<reference ref="819434856"/>
+							<reference ref="978130937"/>
 						</object>
 						<reference key="parent" ref="409487558"/>
 					</object>
@@ -434,6 +481,21 @@
 						<reference key="object" ref="781500792"/>
 						<reference key="parent" ref="110575045"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">466</int>
+						<reference key="object" ref="82826686"/>
+						<reference key="parent" ref="378777354"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">467</int>
+						<reference key="object" ref="819434856"/>
+						<reference key="parent" ref="378777354"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">469</int>
+						<reference key="object" ref="978130937"/>
+						<reference key="parent" ref="378777354"/>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -459,11 +521,17 @@
 					<string>459.IBPluginDependency</string>
 					<string>460.IBPluginDependency</string>
 					<string>464.IBPluginDependency</string>
+					<string>466.IBPluginDependency</string>
+					<string>467.IBPluginDependency</string>
+					<string>469.IBPluginDependency</string>
 					<string>56.IBPluginDependency</string>
 					<string>57.IBPluginDependency</string>
 				</object>
 				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -499,7 +567,7 @@
 				<reference key="dict.values" ref="755588897"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">465</int>
+			<int key="maxID">472</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -511,11 +579,15 @@
 						<bool key="EncodedWithXMLCoder">YES</bool>
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>focusOnNextWindow:</string>
+							<string>focusOnPreviousWindow:</string>
 							<string>runBenchmarks:</string>
 							<string>runSpecs:</string>
 						</object>
 						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>id</string>
+							<string>id</string>
 							<string>id</string>
 							<string>id</string>
 						</object>
@@ -524,11 +596,21 @@
 						<bool key="EncodedWithXMLCoder">YES</bool>
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>focusOnNextWindow:</string>
+							<string>focusOnPreviousWindow:</string>
 							<string>runBenchmarks:</string>
 							<string>runSpecs:</string>
 						</object>
 						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBActionInfo">
+								<string key="name">focusOnNextWindow:</string>
+								<string key="candidateClassName">id</string>
+							</object>
+							<object class="IBActionInfo">
+								<string key="name">focusOnPreviousWindow:</string>
+								<string key="candidateClassName">id</string>
+							</object>
 							<object class="IBActionInfo">
 								<string key="name">runBenchmarks:</string>
 								<string key="candidateClassName">id</string>

--- a/native/mac/English.lproj/MainMenu.xib
+++ b/native/mac/English.lproj/MainMenu.xib
@@ -59,20 +59,10 @@
 							<string key="NSTitle">Atom</string>
 							<object class="NSMutableArray" key="NSMenuItems">
 								<bool key="EncodedWithXMLCoder">YES</bool>
-								<object class="NSMenuItem" id="933434717">
+								<object class="NSMenuItem" id="191085065">
 									<reference key="NSMenu" ref="110575045"/>
-									<string key="NSTitle">Run Specs</string>
-									<string key="NSKeyEquiv">s</string>
-									<int key="NSKeyEquivModMask">1835008</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<reference key="NSOnImage" ref="293900348"/>
-									<reference key="NSMixedImage" ref="169361956"/>
-								</object>
-								<object class="NSMenuItem" id="122997695">
-									<reference key="NSMenu" ref="110575045"/>
-									<string key="NSTitle">Run Benchmarks</string>
-									<string key="NSKeyEquiv">b</string>
-									<int key="NSKeyEquivModMask">1835008</int>
+									<string key="NSTitle">About Atom</string>
+									<string key="NSKeyEquiv"/>
 									<int key="NSMnemonicLoc">2147483647</int>
 									<reference key="NSOnImage" ref="293900348"/>
 									<reference key="NSMixedImage" ref="169361956"/>
@@ -126,7 +116,7 @@
 								</object>
 								<object class="NSMenuItem" id="632727374">
 									<reference key="NSMenu" ref="110575045"/>
-									<string key="NSTitle">Quit</string>
+									<string key="NSTitle">Quit Atom</string>
 									<string key="NSKeyEquiv">q</string>
 									<int key="NSKeyEquivModMask">1048576</int>
 									<int key="NSMnemonicLoc">2147483647</int>
@@ -135,6 +125,58 @@
 								</object>
 							</object>
 							<string key="NSName">_NSAppleMenu</string>
+						</object>
+					</object>
+					<object class="NSMenuItem" id="550651221">
+						<reference key="NSMenu" ref="649796088"/>
+						<string key="NSTitle">Develop</string>
+						<string key="NSKeyEquiv"/>
+						<int key="NSMnemonicLoc">2147483647</int>
+						<reference key="NSOnImage" ref="293900348"/>
+						<reference key="NSMixedImage" ref="169361956"/>
+						<string key="NSAction">submenuAction:</string>
+						<object class="NSMenu" key="NSSubmenu" id="679500086">
+							<string key="NSTitle">Develop</string>
+							<object class="NSMutableArray" key="NSMenuItems">
+								<bool key="EncodedWithXMLCoder">YES</bool>
+								<object class="NSMenuItem" id="195519793">
+									<reference key="NSMenu" ref="679500086"/>
+									<string key="NSTitle">Toogle Devtools</string>
+									<string key="NSKeyEquiv">i</string>
+									<int key="NSKeyEquivModMask">1572864</int>
+									<int key="NSMnemonicLoc">2147483647</int>
+									<reference key="NSOnImage" ref="293900348"/>
+									<reference key="NSMixedImage" ref="169361956"/>
+								</object>
+								<object class="NSMenuItem" id="374313607">
+									<reference key="NSMenu" ref="679500086"/>
+									<bool key="NSIsDisabled">YES</bool>
+									<bool key="NSIsSeparator">YES</bool>
+									<string key="NSTitle"/>
+									<string key="NSKeyEquiv"/>
+									<int key="NSMnemonicLoc">2147483647</int>
+									<reference key="NSOnImage" ref="293900348"/>
+									<reference key="NSMixedImage" ref="169361956"/>
+								</object>
+								<object class="NSMenuItem" id="1054511002">
+									<reference key="NSMenu" ref="679500086"/>
+									<string key="NSTitle">Run Specs</string>
+									<string key="NSKeyEquiv">s</string>
+									<int key="NSKeyEquivModMask">1835008</int>
+									<int key="NSMnemonicLoc">2147483647</int>
+									<reference key="NSOnImage" ref="293900348"/>
+									<reference key="NSMixedImage" ref="169361956"/>
+								</object>
+								<object class="NSMenuItem" id="905547100">
+									<reference key="NSMenu" ref="679500086"/>
+									<string key="NSTitle">Run Benchmarks</string>
+									<string key="NSKeyEquiv">b</string>
+									<int key="NSKeyEquivModMask">1835008</int>
+									<int key="NSMnemonicLoc">2147483647</int>
+									<reference key="NSOnImage" ref="293900348"/>
+									<reference key="NSMixedImage" ref="169361956"/>
+								</object>
+							</object>
 						</object>
 					</object>
 					<object class="NSMenuItem" id="409487558">
@@ -235,22 +277,6 @@
 					<int key="connectionID">440</int>
 				</object>
 				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">runSpecs:</string>
-						<reference key="source" ref="1050"/>
-						<reference key="destination" ref="933434717"/>
-					</object>
-					<int key="connectionID">446</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">runBenchmarks:</string>
-						<reference key="source" ref="1050"/>
-						<reference key="destination" ref="122997695"/>
-					</object>
-					<int key="connectionID">447</int>
-				</object>
-				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
 						<string key="label">_versionMenuItem</string>
 						<reference key="source" ref="1050"/>
@@ -273,6 +299,22 @@
 						<reference key="destination" ref="978130937"/>
 					</object>
 					<int key="connectionID">472</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">runSpecs:</string>
+						<reference key="source" ref="1050"/>
+						<reference key="destination" ref="1054511002"/>
+					</object>
+					<int key="connectionID">528</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">runBenchmarks:</string>
+						<reference key="source" ref="1050"/>
+						<reference key="destination" ref="905547100"/>
+					</object>
+					<int key="connectionID">530</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBActionConnection" key="connection">
@@ -322,6 +364,22 @@
 					</object>
 					<int key="connectionID">463</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">orderFrontStandardAboutPanel:</string>
+						<reference key="source" ref="1014"/>
+						<reference key="destination" ref="191085065"/>
+					</object>
+					<int key="connectionID">511</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBActionConnection" key="connection">
+						<string key="label">toggleDevtools:</string>
+						<reference key="source" ref="1014"/>
+						<reference key="destination" ref="195519793"/>
+					</object>
+					<int key="connectionID">529</int>
+				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<object class="NSArray" key="orderedObjects">
@@ -359,6 +417,7 @@
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<reference ref="694149608"/>
 							<reference ref="409487558"/>
+							<reference ref="550651221"/>
 						</object>
 						<reference key="parent" ref="755588897"/>
 						<string key="objectName">MainMenu</string>
@@ -378,13 +437,12 @@
 						<object class="NSMutableArray" key="children">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<reference ref="632727374"/>
-							<reference ref="933434717"/>
-							<reference ref="122997695"/>
 							<reference ref="139213332"/>
 							<reference ref="574677965"/>
 							<reference ref="90109190"/>
 							<reference ref="884100265"/>
 							<reference ref="781500792"/>
+							<reference ref="191085065"/>
 						</object>
 						<reference key="parent" ref="694149608"/>
 					</object>
@@ -400,19 +458,6 @@
 						<reference key="parent" ref="755588897"/>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">442</int>
-						<reference key="object" ref="933434717"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-						</object>
-						<reference key="parent" ref="110575045"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">445</int>
-						<reference key="object" ref="122997695"/>
-						<reference key="parent" ref="110575045"/>
-					</object>
-					<object class="IBObjectRecord">
 						<int key="objectID">448</int>
 						<reference key="object" ref="409487558"/>
 						<object class="NSMutableArray" key="children">
@@ -420,41 +465,6 @@
 							<reference ref="378777354"/>
 						</object>
 						<reference key="parent" ref="649796088"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">449</int>
-						<reference key="object" ref="378777354"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="960804065"/>
-							<reference ref="501070065"/>
-							<reference ref="895514792"/>
-							<reference ref="337587793"/>
-							<reference ref="82826686"/>
-							<reference ref="819434856"/>
-							<reference ref="978130937"/>
-						</object>
-						<reference key="parent" ref="409487558"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">450</int>
-						<reference key="object" ref="960804065"/>
-						<reference key="parent" ref="378777354"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">451</int>
-						<reference key="object" ref="501070065"/>
-						<reference key="parent" ref="378777354"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">452</int>
-						<reference key="object" ref="895514792"/>
-						<reference key="parent" ref="378777354"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">453</int>
-						<reference key="object" ref="337587793"/>
-						<reference key="parent" ref="378777354"/>
 					</object>
 					<object class="IBObjectRecord">
 						<int key="objectID">457</int>
@@ -482,8 +492,28 @@
 						<reference key="parent" ref="110575045"/>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">466</int>
-						<reference key="object" ref="82826686"/>
+						<int key="objectID">509</int>
+						<reference key="object" ref="191085065"/>
+						<reference key="parent" ref="110575045"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">449</int>
+						<reference key="object" ref="378777354"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="960804065"/>
+							<reference ref="501070065"/>
+							<reference ref="895514792"/>
+							<reference ref="337587793"/>
+							<reference ref="82826686"/>
+							<reference ref="819434856"/>
+							<reference ref="978130937"/>
+						</object>
+						<reference key="parent" ref="409487558"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">469</int>
+						<reference key="object" ref="978130937"/>
 						<reference key="parent" ref="378777354"/>
 					</object>
 					<object class="IBObjectRecord">
@@ -492,9 +522,70 @@
 						<reference key="parent" ref="378777354"/>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">469</int>
-						<reference key="object" ref="978130937"/>
+						<int key="objectID">466</int>
+						<reference key="object" ref="82826686"/>
 						<reference key="parent" ref="378777354"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">453</int>
+						<reference key="object" ref="337587793"/>
+						<reference key="parent" ref="378777354"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">452</int>
+						<reference key="object" ref="895514792"/>
+						<reference key="parent" ref="378777354"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">451</int>
+						<reference key="object" ref="501070065"/>
+						<reference key="parent" ref="378777354"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">450</int>
+						<reference key="object" ref="960804065"/>
+						<reference key="parent" ref="378777354"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">519</int>
+						<reference key="object" ref="550651221"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="679500086"/>
+						</object>
+						<reference key="parent" ref="649796088"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">520</int>
+						<reference key="object" ref="679500086"/>
+						<object class="NSMutableArray" key="children">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<reference ref="195519793"/>
+							<reference ref="374313607"/>
+							<reference ref="1054511002"/>
+							<reference ref="905547100"/>
+						</object>
+						<reference key="parent" ref="550651221"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">524</int>
+						<reference key="object" ref="195519793"/>
+						<reference key="parent" ref="679500086"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">525</int>
+						<reference key="object" ref="374313607"/>
+						<reference key="parent" ref="679500086"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">526</int>
+						<reference key="object" ref="1054511002"/>
+						<reference key="parent" ref="679500086"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">527</int>
+						<reference key="object" ref="905547100"/>
+						<reference key="parent" ref="679500086"/>
 					</object>
 				</object>
 			</object>
@@ -508,8 +599,6 @@
 					<string>136.IBPluginDependency</string>
 					<string>29.IBPluginDependency</string>
 					<string>389.IBPluginDependency</string>
-					<string>442.IBPluginDependency</string>
-					<string>445.IBPluginDependency</string>
 					<string>448.IBPluginDependency</string>
 					<string>449.IBPluginDependency</string>
 					<string>450.IBPluginDependency</string>
@@ -524,11 +613,23 @@
 					<string>466.IBPluginDependency</string>
 					<string>467.IBPluginDependency</string>
 					<string>469.IBPluginDependency</string>
+					<string>509.IBPluginDependency</string>
+					<string>519.IBPluginDependency</string>
+					<string>520.IBPluginDependency</string>
+					<string>524.IBPluginDependency</string>
+					<string>525.IBPluginDependency</string>
+					<string>526.IBPluginDependency</string>
+					<string>527.IBPluginDependency</string>
 					<string>56.IBPluginDependency</string>
 					<string>57.IBPluginDependency</string>
 				</object>
 				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
+					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -567,7 +668,7 @@
 				<reference key="dict.values" ref="755588897"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">472</int>
+			<int key="maxID">530</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -635,6 +736,82 @@
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
 						<string key="minorKey">./Classes/AtomApplication.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">AtomWindowController</string>
+					<string key="superclassName">NSWindowController</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">toggleDevtools:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">toggleDevtools:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">toggleDevtools:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="outlets">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>devToolsView</string>
+							<string>splitView</string>
+							<string>webView</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>NSView</string>
+							<string>NSSplitView</string>
+							<string>NSView</string>
+						</object>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<object class="NSArray" key="dict.sortedKeys">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<string>devToolsView</string>
+							<string>splitView</string>
+							<string>webView</string>
+						</object>
+						<object class="NSArray" key="dict.values">
+							<bool key="EncodedWithXMLCoder">YES</bool>
+							<object class="IBToOneOutletInfo">
+								<string key="name">devToolsView</string>
+								<string key="candidateClassName">NSView</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">splitView</string>
+								<string key="candidateClassName">NSSplitView</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">webView</string>
+								<string key="candidateClassName">NSView</string>
+							</object>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/AtomWindowController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">FirstResponder</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">toggleDevtools:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">toggleDevtools:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">toggleDevtools:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBUserSource</string>
+						<string key="minorKey"/>
 					</object>
 				</object>
 			</object>


### PR DESCRIPTION
Some features such as reload current window, are hard-coded in `OnKeyEvent`, I moved them into menubar so when you press corresponding shortcuts you can see visual feedbacks on menubar.

![Screen Shot 2013-03-21 at 10 54 31 PM](https://f.cloud.github.com/assets/639601/286231/4cc4d5ac-9237-11e2-8d05-7aba16239804.png)
![Screen Shot 2013-03-21 at 10 54 42 PM](https://f.cloud.github.com/assets/639601/286232/51128460-9237-11e2-9f66-47cb67f911d3.png)
![3](https://f.cloud.github.com/assets/639601/286212/f2e7a2f8-9236-11e2-9c32-b59cfa6471c9.png)
