### PR TITLE
Meta-shift-click and drag for column/box selection

### DIFF
--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -506,6 +506,17 @@ describe "EditSession", ->
         [selection1] = selections
         expect(selection1.getScreenRange()).toEqual [[3, 10], [7, 4]]
         expect(selection1.isReversed()).toBeTruthy()
+    fdescribe ".selectColumnToScreenPosition(screenPosition)", ->
+      it "creates a selection for each row", ->
+        editSession.setCursorScreenPosition([4, 10])
+        editSession.columnStartRange = null
+        editSession.selectColumnToScreenPosition([5, 27])
+        selections = editSession.getSelections()
+        expect(selections.length).toBe 2
+        [selection1, selection2] = selections
+        expect(selection1.getScreenRange()).toEqual [[4, 10], [4, 27]]
+        expect(selection1.isReversed()).toBeFalsy()
+        expect(selection2.getScreenRange()).toEqual [[5, 10], [5, 27]]
 
     describe ".selectToTop()", ->
       it "selects text from cusor position to the top of the buffer", ->

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -637,6 +637,34 @@ describe "Editor", ->
         expect(selection1.getScreenRange()).toEqual [[4, 10], [5, 27]]
         expect(selection2.getScreenRange()).toEqual [[6, 10], [8, 27]]
 
+    fdescribe "meta-shift-click and drag", ->
+      it "adds an additional cursor on each line", ->
+        editor.renderedLines.trigger mousedownEvent(editor: editor, point: [4, 10], metaKey:true, shiftKey:true)
+        editor.renderedLines.trigger mousemoveEvent(editor: editor, point: [6, 27], metaKey:true, shiftKey:true)
+        editor.renderedLines.trigger 'mouseup'
+
+        selections = editor.getSelections()
+        expect(selections.length).toBe 3
+        [selection1, selection2] = selections
+        expect(selection1.getScreenRange()).toEqual [[4, 10], [4, 27]]
+        expect(selection2.getScreenRange()).toEqual [[5, 10], [5, 27]]
+      it "modifies the range on each line", ->
+        editor.renderedLines.trigger mousedownEvent(editor: editor, point: [4, 10], metaKey:true, shiftKey:true)
+        editor.renderedLines.trigger mousemoveEvent(editor: editor, point: [5, 27], metaKey:true, shiftKey:true)
+        editor.renderedLines.trigger mousemoveEvent(editor: editor, point: [6, 13], metaKey:true, shiftKey:true)
+
+        selections = editor.getSelections()
+        expect(selections.length).toBe 3
+        [selection1, selection2, selection3] = selections
+        expect(selection1.getScreenRange()).toEqual [[4, 10], [4, 13]]
+        expect(selection2.getScreenRange()).toEqual [[5, 10], [5, 13]]
+        expect(selection3.getScreenRange()).toEqual [[6, 10], [6, 13]]
+
+        editor.renderedLines.trigger mousemoveEvent(editor: editor, point: [5, 13], metaKey:true, shiftKey:true)
+        editor.renderedLines.trigger 'mouseup'
+        selections = editor.getSelections()
+        expect(selections.length).toBe 2
+
   describe "when text input events are triggered on the hidden input element", ->
     it "inserts the typed character at the cursor position, both in the buffer and the pre element", ->
       editor.attachToDom()

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -723,10 +723,29 @@ class EditSession
     fn(cursor) for cursor in @getCursors()
     @mergeCursors()
 
-  selectToScreenPosition: (position) ->
+  selectToScreenPosition: (position, mergeAfter=true) ->
     lastSelection = @getLastSelection()
     lastSelection.selectToScreenPosition(position)
-    @mergeIntersectingSelections(reverse: lastSelection.isReversed())
+    if mergeAfter
+      @mergeIntersectingSelections(reverse: lastSelection.isReversed())
+
+  selectColumnToScreenPosition: (position) ->
+    @columnStartRange ?= @getLastSelection().getScreenRange().start
+    size = (if position.column? then position.column else position[1]) - @columnStartRange.column
+    startRow = @columnStartRange.row
+    endRow = if position.row? then position.row else position[0]
+    @clearSelections()
+    @moveCursors (cursor) => cursor.setScreenPosition(@columnStartRange)
+    for row in [startRow..endRow]
+      startPosition = _.clone(@columnStartRange)
+      startPosition.row = row
+      endPosition = _.clone(@columnStartRange)
+      endPosition.column = startPosition.column + size
+      endPosition.row = row
+      marker = @markScreenPosition(startPosition, invalidationStrategy: 'never')
+      @addSelection(marker)
+      @selectToScreenPosition(endPosition, false)
+
 
   selectRight: ->
     @expandSelectionsForward (selection) => selection.selectRight()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -212,6 +212,7 @@ class Editor extends View
   selectToEndOfWord: -> @activeEditSession.selectToEndOfWord()
   selectWord: -> @activeEditSession.selectWord()
   selectToScreenPosition: (position) -> @activeEditSession.selectToScreenPosition(position)
+  selectColumnToScreenPosition: (position) -> @activeEditSession.selectColumnToScreenPosition(position)
   transpose: -> @activeEditSession.transpose()
   upperCase: -> @activeEditSession.upperCase()
   lowerCase: -> @activeEditSession.lowerCase()
@@ -362,10 +363,15 @@ class Editor extends View
 
       screenPosition = @screenPositionFromMouseEvent(e)
       if clickCount == 1
-        if e.metaKey
+        if e.shiftKey
+          if e.metaKey
+            @setCursorScreenPosition(screenPosition)
+            @activeEditSession.columnStartRange = null
+            @column = true
+          else
+            @selectToScreenPosition(screenPosition)
+        else if e.metaKey
           @addCursorAtScreenPosition(screenPosition)
-        else if e.shiftKey
-          @selectToScreenPosition(screenPosition)
         else
           @setCursorScreenPosition(screenPosition)
       else if clickCount == 2
@@ -407,7 +413,10 @@ class Editor extends View
     lastMoveEvent = null
     moveHandler = (event = lastMoveEvent) =>
       if event
-        @selectToScreenPosition(@screenPositionFromMouseEvent(event))
+        if @column
+          @selectColumnToScreenPosition(@screenPositionFromMouseEvent(event))
+        else
+          @selectToScreenPosition(@screenPositionFromMouseEvent(event))
         lastMoveEvent = event
 
     $(document).on "mousemove.editor-#{@id}", moveHandler
@@ -417,9 +426,11 @@ class Editor extends View
       clearInterval(interval)
       $(document).off 'mousemove', moveHandler
       reverse = @activeEditSession.getLastSelection().isReversed()
-      @activeEditSession.mergeIntersectingSelections({reverse})
+      if !@column
+        @activeEditSession.mergeIntersectingSelections({reverse})
       @activeEditSession.finalizeSelections()
       @syncCursorAnimations()
+      @column = false
 
   afterAttach: (onDom) ->
     return unless onDom


### PR DESCRIPTION
Column/box selection. Basically this creates a selection per line to allow editing on multiple lines at the same time.

In the specs it works, however when actually using it, once it goes over two or three lines of selections the editor gets really slow, so probably I'm doing something wrong or not quite right.
