### PR TITLE
Async grammars continued

### DIFF
--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -2060,18 +2060,18 @@ describe "EditSession", ->
       editSession.buffer.reload()
       expect(editSession.getCursorScreenPosition()).toEqual [0,1]
 
-  describe "when the 'grammars-loaded' event is triggered on the syntax global", ->
-    it "reloads the edit session's grammar and re-tokenizes the buffer if it changes", ->
+  describe "when a better-matched grammar is added to syntax", ->
+    it "switches to the better-matched grammar and re-tokenizes the buffer", ->
       editSession.destroy()
       jsGrammar = syntax.selectGrammar('a.js')
-      grammarToReturn = syntax.nullGrammar
-      spyOn(syntax, 'selectGrammar').andCallFake -> grammarToReturn
+      syntax.removeGrammar(jsGrammar)
 
       editSession = project.buildEditSession('sample.js', autoIndent: false)
+      expect(editSession.getGrammar()).toBe syntax.nullGrammar
       expect(editSession.lineForScreenRow(0).tokens.length).toBe 1
 
-      grammarToReturn = jsGrammar
-      syntax.trigger 'grammars-loaded'
+      syntax.addGrammar(jsGrammar)
+      expect(editSession.getGrammar()).toBe jsGrammar
       expect(editSession.lineForScreenRow(0).tokens.length).toBeGreaterThan 1
 
   describe "auto-indent", ->

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -2113,7 +2113,7 @@ describe "Editor", ->
       editor.edit(project.buildEditSession(path))
       expect(editor.getGrammar().name).toBe 'Plain Text'
       syntax.setGrammarOverrideForPath(path, 'source.js')
-      expect(editor.reloadGrammar()).toBeTruthy()
+      editor.reloadGrammar()
       expect(editor.getGrammar().name).toBe 'JavaScript'
 
       tokenizedBuffer = editor.activeEditSession.displayBuffer.tokenizedBuffer

--- a/spec/app/syntax-spec.coffee
+++ b/spec/app/syntax-spec.coffee
@@ -13,7 +13,7 @@ describe "the `syntax` global", ->
       expect(syntax.selectGrammar(path).name).not.toBe 'Ruby'
       syntax.setGrammarOverrideForPath(path, 'source.ruby')
       syntax2 = deserialize(syntax.serialize())
-      syntax2.addGrammar(grammar) for grammar in syntax.grammars
+      syntax2.addGrammar(grammar) for grammar in syntax.grammars when grammar isnt syntax.nullGrammar
       expect(syntax2.selectGrammar(path).name).toBe 'Ruby'
 
   describe ".selectGrammar(filePath)", ->

--- a/spec/app/syntax-spec.coffee
+++ b/spec/app/syntax-spec.coffee
@@ -23,8 +23,8 @@ describe "the `syntax` global", ->
       expect(syntax.selectGrammar("file.js").name).toBe "JavaScript" # based on extension (.js)
       expect(syntax.selectGrammar("/tmp/.git/config").name).toBe "Git Config" # based on end of the path (.git/config)
       expect(syntax.selectGrammar("Rakefile").name).toBe "Ruby" # based on the file's basename (Rakefile)
-      expect(syntax.selectGrammar("curb").name).toBe "Plain Text"
-      expect(syntax.selectGrammar("/hu.git/config").name).toBe "Plain Text"
+      expect(syntax.selectGrammar("curb").name).toBe "Null Grammar"
+      expect(syntax.selectGrammar("/hu.git/config").name).toBe "Null Grammar"
 
     it "uses the filePath's shebang line if the grammar cannot be determined by the extension or basename", ->
       filePath = require.resolve("fixtures/shebang")
@@ -37,7 +37,7 @@ describe "the `syntax` global", ->
       expect(syntax.selectGrammar("dummy.coffee", fileContent).name).toBe "CoffeeScript"
 
       fileContent = '<?xml version="1.0" encoding="UTF-8"?>'
-      expect(syntax.selectGrammar("grammar.tmLanguage", fileContent).name).toBe "Plain Text"
+      expect(syntax.selectGrammar("grammar.tmLanguage", fileContent).name).toBe "Null Grammar"
 
       fileContent += '\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
       expect(syntax.selectGrammar("grammar.tmLanguage", fileContent).name).toBe "Property List (XML)"

--- a/spec/app/text-mate-grammar-spec.coffee
+++ b/spec/app/text-mate-grammar-spec.coffee
@@ -138,7 +138,7 @@ describe "TextMateGrammar", ->
 
     describe "when the line matches a pattern with no `name` or `contentName`", ->
       it "creates tokens without adding a new scope", ->
-        grammar = syntax.grammarsByFileType["rb"]
+        grammar = syntax.selectGrammar('foo.rb')
         {tokens} = grammar.tokenizeLine('%w|oh \\look|')
         expect(tokens.length).toBe 5
         expect(tokens[0]).toEqual value: '%w|',  scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby", "punctuation.definition.string.begin.ruby"]
@@ -183,7 +183,7 @@ describe "TextMateGrammar", ->
 
       describe "when the end pattern contains a back reference", ->
         it "constructs the end rule based on its back-references to captures in the begin rule", ->
-          grammar = syntax.grammarsByFileType["rb"]
+          grammar = syntax.selectGrammar('foo.rb')
           {tokens} = grammar.tokenizeLine('%w|oh|,')
           expect(tokens.length).toBe 4
           expect(tokens[0]).toEqual value: '%w|',  scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby", "punctuation.definition.string.begin.ruby"]
@@ -192,7 +192,7 @@ describe "TextMateGrammar", ->
           expect(tokens[3]).toEqual value: ',',  scopes: ["source.ruby", "punctuation.separator.object.ruby"]
 
         it "allows the rule containing that end pattern to be pushed to the stack multiple times", ->
-          grammar = syntax.grammarsByFileType["rb"]
+          grammar = syntax.selectGrammar('foo.rb')
           {tokens} = grammar.tokenizeLine('%Q+matz had some #{%Q-crazy ideas-} for ruby syntax+ # damn.')
           expect(tokens[0]).toEqual value: '%Q+', scopes: ["source.ruby","string.quoted.other.literal.upper.ruby","punctuation.definition.string.begin.ruby"]
           expect(tokens[1]).toEqual value: 'matz had some ', scopes: ["source.ruby","string.quoted.other.literal.upper.ruby"]
@@ -212,7 +212,7 @@ describe "TextMateGrammar", ->
           atom.activatePackage('html.tmbundle', sync: true)
           atom.activatePackage('ruby-on-rails-tmbundle', sync: true)
 
-          grammar = syntax.grammarsByFileType["html.erb"]
+          grammar = syntax.selectGrammar('foo.html.erb')
           {tokens} = grammar.tokenizeLine("<div class='name'><%= User.find(2).full_name %></div>")
 
           expect(tokens[0]).toEqual value: '<', scopes: ["text.html.ruby","meta.tag.block.any.html","punctuation.definition.tag.begin.html"]

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -57,7 +57,7 @@ class EditSession
     @subscribe @displayBuffer, "changed", (e) =>
       @trigger 'screen-lines-changed', e
 
-    @subscribe syntax, 'grammars-loaded', => @reloadGrammar()
+    @languageMode.on 'grammar-changed', => @handleGrammarChange()
 
   getViewClass: ->
     require 'editor'
@@ -846,17 +846,14 @@ class EditSession
   getGrammar: -> @languageMode.grammar
 
   setGrammar: (grammar) ->
-    @languageMode.grammar = grammar
-    @handleGrammarChange()
+    @languageMode.setGrammar(grammar)
 
   reloadGrammar: ->
-    @handleGrammarChange() if @languageMode.reloadGrammar()
+    @languageMode.reloadGrammar()
 
   handleGrammarChange: ->
     @unfoldAll()
-    @displayBuffer.tokenizedBuffer.resetScreenLines()
     @trigger 'grammar-changed'
-    true
 
   getDebugSnapshot: ->
     [

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -83,6 +83,7 @@ class EditSession
     @buffer.release()
     selection.destroy() for selection in @getSelections()
     @displayBuffer.destroy()
+    @languageMode.destroy()
     @project?.removeEditSession(this)
     @trigger 'destroyed'
     @off()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -1147,16 +1147,9 @@ class Editor extends View
   setGrammar: (grammar) ->
     throw new Error("Only mini-editors can explicity set their grammar") unless @mini
     @activeEditSession.setGrammar(grammar)
-    @handleGrammarChange()
 
   reloadGrammar: ->
-    grammarChanged = @activeEditSession.reloadGrammar()
-    @handleGrammarChange() if grammarChanged
-    grammarChanged
-
-  handleGrammarChange: ->
-    @clearRenderedLines()
-    @updateDisplay()
+    @activeEditSession.reloadGrammar()
 
   bindToKeyedEvent: (key, event, callback) ->
     binding = {}

--- a/src/app/language-mode.coffee
+++ b/src/app/language-mode.coffee
@@ -3,6 +3,7 @@ _ = require 'underscore'
 require 'underscore-extensions'
 {OnigRegExp} = require 'oniguruma'
 EventEmitter = require 'event-emitter'
+Subscriber = require 'subscriber'
 
 module.exports =
 class LanguageMode
@@ -14,9 +15,12 @@ class LanguageMode
   constructor: (@editSession) ->
     @buffer = @editSession.buffer
     @reloadGrammar()
-    syntax.on 'grammar-added', (grammar) =>
+    @subscribe syntax, 'grammar-added', (grammar) =>
       newScore = grammar.getScore(@buffer.getPath(), @buffer.getText())
       @setGrammar(grammar, newScore) if newScore > @currentGrammarScore
+
+  destroy: ->
+    @unsubscribe()
 
   setGrammar: (grammar, score) ->
     return if grammar is @grammar
@@ -169,3 +173,4 @@ class LanguageMode
       new OnigRegExp(foldEndPattern)
 
 _.extend LanguageMode.prototype, EventEmitter
+_.extend LanguageMode.prototype, Subscriber

--- a/src/app/language-mode.coffee
+++ b/src/app/language-mode.coffee
@@ -9,15 +9,19 @@ class LanguageMode
   buffer = null
   grammar = null
   editSession = null
+  currentGrammarScore: null
 
   constructor: (@editSession) ->
     @buffer = @editSession.buffer
     @reloadGrammar()
-    syntax.on 'grammars-loaded', => @reloadGrammar()
+    syntax.on 'grammar-added', (grammar) =>
+      newScore = grammar.getScore(@buffer.getPath(), @buffer.getText())
+      @setGrammar(grammar, newScore) if newScore > @currentGrammarScore
 
-  setGrammar: (grammar) ->
+  setGrammar: (grammar, score) ->
     return if grammar is @grammar
     @grammar = grammar
+    @currentGrammarScore = score ? grammar.getScore(@buffer.getPath(), @buffer.getText())
     @trigger 'grammar-changed', grammar
 
   reloadGrammar: ->

--- a/src/app/null-grammar.coffee
+++ b/src/app/null-grammar.coffee
@@ -5,5 +5,7 @@ class NullGrammar
   name: 'Null Grammar'
   scopeName: 'text.plain.null-grammar'
 
+  getScore: -> 0
+
   tokenizeLine: (line) ->
     { tokens: [new Token(value: line, scopes: ['null-grammar.text.plain'])] }

--- a/src/app/syntax.coffee
+++ b/src/app/syntax.coffee
@@ -18,7 +18,6 @@ class Syntax
   constructor: ->
     @nullGrammar = new NullGrammar
     @grammars = [@nullGrammar]
-    @grammarsByFileType = {}
     @grammarsByScopeName = {}
     @grammarOverridesByPath = {}
     @scopedPropertiesIndex = 0
@@ -29,14 +28,11 @@ class Syntax
 
   addGrammar: (grammar) ->
     @grammars.push(grammar)
-    @grammarsByFileType[fileType] = grammar for fileType in grammar.fileTypes
     @grammarsByScopeName[grammar.scopeName] = grammar
 
   removeGrammar: (grammar) ->
-    if _.include(@grammars, grammar)
-      _.remove(@grammars, grammar)
-      delete @grammarsByFileType[fileType] for fileType in grammar.fileTypes
-      delete @grammarsByScopeName[grammar.scopeName]
+    _.remove(@grammars, grammar)
+    delete @grammarsByScopeName[grammar.scopeName]
 
   setGrammarOverrideForPath: (path, scopeName) ->
     @grammarOverridesByPath[path] = scopeName

--- a/src/app/syntax.coffee
+++ b/src/app/syntax.coffee
@@ -29,6 +29,7 @@ class Syntax
   addGrammar: (grammar) ->
     @grammars.push(grammar)
     @grammarsByScopeName[grammar.scopeName] = grammar
+    @trigger 'grammar-added', grammar
 
   removeGrammar: (grammar) ->
     _.remove(@grammars, grammar)

--- a/src/app/text-mate-grammar.coffee
+++ b/src/app/text-mate-grammar.coffee
@@ -43,12 +43,10 @@ class TextMateGrammar
     contents = fsUtils.read(path) if not contents? and fsUtils.isFile(path)
 
     if syntax.grammarOverrideForPath(path) is @scopeName
-      Infinity
-    else if @matchesContents(contents)
       3
-    else if @matchesPath(path)
+    else if @matchesContents(contents)
       2
-    else if @isTextGrammar()
+    else if @matchesPath(path)
       1
     else
       -1
@@ -77,9 +75,6 @@ class TextMateGrammar
       fileTypeComponents = fileType.split(pathSplitRegex)
       pathSuffix = pathComponents[-fileTypeComponents.length..-1]
       _.isEqual(pathSuffix, fileTypeComponents)
-
-  isTextGrammar: ->
-    @scopeName is 'text.plain'
 
   tokenizeLine: (line, ruleStack=[@initialRule], firstLine=false) ->
     originalRuleStack = ruleStack

--- a/src/app/text-mate-package.coffee
+++ b/src/app/text-mate-package.coffee
@@ -13,7 +13,6 @@ class TextMatePackage extends Package
   @getLoadQueue: ->
     return @loadQueue if @loadQueue
     @loadQueue = async.queue (pack, done) -> pack.loadGrammars(done)
-    @loadQueue.drain = -> syntax.trigger 'grammars-loaded'
     @loadQueue
 
   constructor: ->

--- a/src/app/tokenized-buffer.coffee
+++ b/src/app/tokenized-buffer.coffee
@@ -23,6 +23,7 @@ class TokenizedBuffer
     @id = @constructor.idCounter++
     @resetScreenLines()
     @buffer.on "changed.tokenized-buffer#{@id}", (e) => @handleBufferChange(e)
+    @languageMode.on 'grammar-changed', => @resetScreenLines()
 
   resetScreenLines: ->
     @screenLines = @buildPlaceholderScreenLinesForRows(0, @buffer.getLastRow())

--- a/src/packages/spell-check/lib/spell-check.coffee
+++ b/src/packages/spell-check/lib/spell-check.coffee
@@ -9,12 +9,9 @@ module.exports =
     ]
 
   activate: ->
-    syntax.on 'grammars-loaded.spell-check', => @subscribeToEditors()
-
-  deactivate: ->
-    syntax.off '.spell-check'
-
-  subscribeToEditors: ->
     rootView.eachEditor (editor) ->
       if editor.attached and not editor.mini
         editor.underlayer.append(new SpellCheckView(editor))
+
+  deactivate: ->
+    syntax.off '.spell-check'

--- a/src/packages/spell-check/spec/spell-check-spec.coffee
+++ b/src/packages/spell-check/spec/spell-check-spec.coffee
@@ -10,7 +10,6 @@ describe "Spell check", ->
     rootView.open('sample.js')
     config.set('spell-check.grammars', [])
     atom.activatePackage('spell-check', immediate: true)
-    syntax.trigger 'grammars-loaded'
     rootView.attachToDom()
     editor = rootView.getActiveView()
 

--- a/src/packages/status-bar/spec/status-bar-spec.coffee
+++ b/src/packages/status-bar/spec/status-bar-spec.coffee
@@ -183,7 +183,6 @@ describe "StatusBar", ->
     beforeEach ->
       atom.activatePackage('text.tmbundle', sync: true)
       atom.activatePackage('javascript.tmbundle', sync: true)
-      syntax.trigger 'grammars-loaded'
 
     it "displays the name of the current grammar", ->
       expect(statusBar.find('.grammar-name').text()).toBe 'JavaScript'


### PR DESCRIPTION
Previously, we emitted a `grammars-loaded` event once all the TextMate packages were loaded, and then selected a grammar for each open edit session. Now, we emit a `grammar-added` event whenever a grammar is added, and every grammar can return a "score" for a given file, saying how good a match it is for that file. Whenever a grammar is added (at any time, not just startup), we will switch to it if it is has a higher score than the file's current grammar.
