### PR TITLE
Drag-drop with external applications

### DIFF
--- a/spec/app/window-spec.coffee
+++ b/spec/app/window-spec.coffee
@@ -198,3 +198,31 @@ describe "Window", ->
           expect(deserialize({ deserializer: 'Foo', version: 3, name: 'Bar' })).toBeUndefined()
           expect(deserialize({ deserializer: 'Foo', version: 1, name: 'Bar' })).toBeUndefined()
           expect(deserialize({ deserializer: 'Foo', name: 'Bar' })).toBeUndefined()
+
+  describe "drag and drop", ->
+    buildDragEvent = (type, files) ->
+      dataTransfer =
+        files: files
+        data: {}
+        setData: (key, value) -> @data[key] = value
+        getData: (key) -> @data[key]
+
+      event = $.Event(type)
+      event.originalEvent = { dataTransfer }
+      event.preventDefault = ->
+      event.stopPropagation = ->
+      event
+
+    describe "when a file is dragged to window", ->
+      it "opens it", ->
+        spyOn(atom, "open")
+        event = buildDragEvent("drop", [ {path: "/fake1"}, {path: "/fake2"} ])
+        window.onDrop(event)
+        expect(atom.open.callCount).toBe 2
+
+    describe "when a non-file is dragged to window", ->
+      it "does nothing", ->
+        spyOn(atom, "open")
+        event = buildDragEvent("drop", [])
+        window.onDrop(event)
+        expect(atom.open).not.toHaveBeenCalled()

--- a/src/app/window.coffee
+++ b/src/app/window.coffee
@@ -25,12 +25,6 @@ window.setUpEnvironment = ->
   $(document).on 'keydown', keymap.handleKeyEvent
   keymap.bindDefaultKeys()
 
-  ignoreEvents = (e) ->
-    e.preventDefault()
-    e.stopPropagation()
-  $(document).on 'dragover', ignoreEvents
-  $(document).on 'drop', ignoreEvents
-
   requireStylesheet 'reset'
   requireStylesheet 'atom'
   requireStylesheet 'overlay'
@@ -50,6 +44,7 @@ window.startup = ->
     console.warn "Failed to install `atom` binary"
 
   handleWindowEvents()
+  handleDragDrop()
   config.load()
   keymap.loadBundledKeymaps()
   atom.loadThemes()
@@ -92,6 +87,18 @@ window.handleWindowEvents = ->
   $(window).on 'blur',  -> $("body").addClass('is-blurred')
   $(window).command 'window:close', => confirmClose()
   $(window).command 'window:reload', => reload()
+
+window.handleDragDrop = ->
+  $(document).on 'dragover', (e) ->
+    e.preventDefault()
+    e.stopPropagation()
+  $(document).on 'drop', onDrop
+
+window.onDrop = (e) ->
+  e.preventDefault()
+  e.stopPropagation()
+  for file in e.originalEvent.dataTransfer.files
+    atom.open(file.path)
 
 window.deserializeWindowState = ->
   RootView = require 'root-view'

--- a/src/packages/tabs/lib/tab-bar-view.coffee
+++ b/src/packages/tabs/lib/tab-bar-view.coffee
@@ -77,11 +77,8 @@ class TabBarView extends View
     (@paneContainer.getPanes().length > 1) or (@pane.getItems().length > 1)
 
   onDragStart: (event) =>
-    unless @shouldAllowDrag(event)
-      event.preventDefault()
-      return
-
-    event.originalEvent.dataTransfer.setData 'atom-event', 'true'
+    if @shouldAllowDrag()
+      event.originalEvent.dataTransfer.setData 'atom-event', 'true'
 
     el = $(event.target).closest('.sortable')
     el.addClass 'is-dragging'

--- a/src/packages/tabs/lib/tab-bar-view.coffee
+++ b/src/packages/tabs/lib/tab-bar-view.coffee
@@ -91,6 +91,11 @@ class TabBarView extends View
     paneIndex = @paneContainer.indexOfPane(pane)
     event.originalEvent.dataTransfer.setData 'from-pane-index', paneIndex
 
+    item = @pane.getItems()[el.index()]
+    if item.getPath?
+      event.originalEvent.dataTransfer.setData 'text/uri-list', 'file://' + item.getPath()
+      event.originalEvent.dataTransfer.setData 'text/plain', item.getPath()
+
   onDragEnd: (event) =>
     @find(".is-dragging").removeClass 'is-dragging'
 

--- a/src/packages/tabs/lib/tab-bar-view.coffee
+++ b/src/packages/tabs/lib/tab-bar-view.coffee
@@ -98,6 +98,8 @@ class TabBarView extends View
 
   onDragEnd: (event) =>
     @find(".is-dragging").removeClass 'is-dragging'
+    @children('.is-drop-target').removeClass 'is-drop-target'
+    @children('.drop-target-is-after').removeClass 'drop-target-is-after'
 
   onDragOver: (event) =>
     unless event.originalEvent.dataTransfer.getData('atom-event') is 'true'
@@ -125,8 +127,6 @@ class TabBarView extends View
       return
 
     event.stopPropagation()
-    @children('.is-drop-target').removeClass 'is-drop-target'
-    @children('.drop-target-is-after').removeClass 'drop-target-is-after'
 
     dataTransfer  = event.originalEvent.dataTransfer
     fromIndex     = parseInt(dataTransfer.getData('sortable-index'))

--- a/src/packages/tabs/spec/tabs-spec.coffee
+++ b/src/packages/tabs/spec/tabs-spec.coffee
@@ -279,8 +279,8 @@ describe "TabBarView", ->
         expect(pane2.activeItem).toBe item1
         expect(pane2.focus).toHaveBeenCalled()
 
-    describe 'when a non-tab is dragged to pane', ->
-      it 'has no effect', ->
+    describe "when a non-tab is dragged to pane", ->
+      it "has no effect", ->
         expect(tabBar.getTabs().map (tab) -> tab.text()).toEqual ["Item 1", "sample.js", "Item 2"]
         expect(pane.getItems()).toEqual [item1, editSession1, item2]
         expect(pane.activeItem).toBe item2
@@ -293,4 +293,12 @@ describe "TabBarView", ->
         expect(pane.getItems()).toEqual [item1, editSession1, item2]
         expect(pane.activeItem).toBe item2
         expect(pane.focus).not.toHaveBeenCalled()
+
+    describe "when a tab is dragged out of application", ->
+      it "should carry file's information", ->
+        [dragStartEvent, dropEvent] = buildDragEvents(tabBar.tabAtIndex(1), tabBar.tabAtIndex(1))
+        tabBar.onDragStart(dragStartEvent)
+
+        expect(dragStartEvent.originalEvent.dataTransfer.getData("text/plain")).toEqual editSession1.getPath()
+        expect(dragStartEvent.originalEvent.dataTransfer.getData("text/uri-list")).toEqual 'file://' + editSession1.getPath()
 


### PR DESCRIPTION
- [x] Drag a tab to other applications should have the same effect of dragging the actual file.
- [x] Drag a file from Finder to Atom should make Atom open it (in current window or in new window).
- [x] When tab is dropped out of Atom, the blue marker should disappear.
- [x] When there is only one tab, it should be able to be dragged out of Atom.
- [ ] <del> Tabs should be able to be dragged between different windows of Atom if the file belongs to both projects.</del>
- [ ] <del> Drag a tab out of Atom and not drop it in other applications should open the tab in a new window.</del>
