### PR TITLE
Leave Markdown files alone when trimming whitespace

### DIFF
--- a/src/app/text-buffer.coffee
+++ b/src/app/text-buffer.coffee
@@ -587,7 +587,7 @@ class Buffer
   # startIndex - The starting row {Number}
   # endIndex - The ending row {Number}
   #
-  # Returns an {Array} of {RegExp}s, representing the matches
+  # Returns an {Array} of {RegExp}s, representing the matches.
   matchesInCharacterRange: (regex, startIndex, endIndex) ->
     text = @getText()
     matches = []

--- a/src/packages/whitespace/lib/whitespace.coffee
+++ b/src/packages/whitespace/lib/whitespace.coffee
@@ -4,14 +4,18 @@ module.exports =
 
   configDefaults:
     ensureSingleTrailingNewline: true
-    ignoredGrammars: ["GitHub Markdown"]
 
   whitespaceBeforeSave: (editSession) ->
     buffer = editSession.buffer
     buffer.on 'will-be-saved', ->
-      return if editSession.getGrammar().name in config.get("whitespace.ignoredGrammars")
       buffer.transact ->
-        buffer.scan /[ \t]+$/g, ({replace}) -> replace('')
+        regex = null
+
+        buffer.scan /[ \t]+$/g, ({match, replace}) -> 
+          # GFM permits two whitespaces at the end of a line--trim anything else
+          unless editSession.getGrammar().scopeName = "scope.gfm" and match[0].length == 2
+            replace('')
+
         if config.get('whitespace.ensureSingleTrailingNewline')
           if buffer.getLastLine() is ''
             row = buffer.getLastRow() - 1

--- a/src/packages/whitespace/lib/whitespace.coffee
+++ b/src/packages/whitespace/lib/whitespace.coffee
@@ -4,13 +4,14 @@ module.exports =
 
   configDefaults:
     ensureSingleTrailingNewline: true
+    ignoredGrammars: ["GitHub Markdown"]
 
   whitespaceBeforeSave: (editSession) ->
     buffer = editSession.buffer
     buffer.on 'will-be-saved', ->
+      return if editSession.getGrammar().name in config.get("whitespace.ignoredGrammars")
       buffer.transact ->
         buffer.scan /[ \t]+$/g, ({replace}) -> replace('')
-
         if config.get('whitespace.ensureSingleTrailingNewline')
           if buffer.getLastLine() is ''
             row = buffer.getLastRow() - 1

--- a/src/packages/whitespace/lib/whitespace.coffee
+++ b/src/packages/whitespace/lib/whitespace.coffee
@@ -9,11 +9,9 @@ module.exports =
     buffer = editSession.buffer
     buffer.on 'will-be-saved', ->
       buffer.transact ->
-        regex = null
-
-        buffer.scan /[ \t]+$/g, ({match, replace}) -> 
+        buffer.scan /[ \t]+$/g, ({match, replace}) ->
           # GFM permits two whitespaces at the end of a line--trim anything else
-          unless editSession.getGrammar().scopeName = "scope.gfm" and match[0].length == 2
+          unless editSession.getGrammar().scopeName is "source.gfm" and match[0] == "  "
             replace('')
 
         if config.get('whitespace.ensureSingleTrailingNewline')

--- a/src/packages/whitespace/lib/whitespace.coffee
+++ b/src/packages/whitespace/lib/whitespace.coffee
@@ -11,7 +11,7 @@ module.exports =
       buffer.transact ->
         buffer.scan /[ \t]+$/g, ({match, replace}) ->
           # GFM permits two whitespaces at the end of a line--trim anything else
-          unless editSession.getGrammar().scopeName is "source.gfm" and match[0] == "  "
+          unless editSession.getGrammar().scopeName is "source.gfm" and match[0] is "  "
             replace('')
 
         if config.get('whitespace.ensureSingleTrailingNewline')

--- a/src/packages/whitespace/spec/whitespace-spec.coffee
+++ b/src/packages/whitespace/spec/whitespace-spec.coffee
@@ -108,7 +108,6 @@ describe "Whitespace", ->
       editor.getBuffer().save()
       expect(editor.getText()).toBe "foo  \nline break!\n"
 
-
     it "trims GFM text with a more than two spaces", ->
       editor.activeEditSession.setGrammar(grammar)
       editor.insertText "foo   \nline break!"

--- a/src/packages/whitespace/spec/whitespace-spec.coffee
+++ b/src/packages/whitespace/spec/whitespace-spec.coffee
@@ -87,29 +87,30 @@ describe "Whitespace", ->
       expect(editor.getText()).toBe "foo\n"
       expect(editor.getCursorBufferPosition()).toEqual([0,3])
 
-  describe "whitespace.ignoredGrammars config", ->
-    [originalConfigValue] = []
+  describe "GFM whitespace trimming", ->
     grammar = null
 
     beforeEach ->
-      originalConfigValue = config.get("whitespace.ignoredGrammars")
-      expect(originalConfigValue).toEqual ["GitHub Markdown"]
       spyOn(syntax, "addGrammar").andCallThrough()
       atom.activatePackage("gfm")
       expect(syntax.addGrammar).toHaveBeenCalled()
       grammar = syntax.addGrammar.argsForCall[0][0]
 
-    afterEach ->
-      config.set("whitespace.ignoredGrammars", originalConfigValue)
-      config.update()
-
-    it "parses the grammar as GFM", ->
-      expect(grammar).toBeDefined()
-      expect(grammar.scopeName).toBe "source.gfm"
-
-    it "leaves GFM files alone", ->
+    it "trims GFM text with a single space", ->
       editor.activeEditSession.setGrammar(grammar)
-      expect(editor.getGrammar().name).toBe "GitHub Markdown"
+      editor.insertText "foo \nline break!"
+      editor.getBuffer().save()
+      expect(editor.getText()).toBe "foo\nline break!\n"
+
+    it "leaves GFM text with double spaces alone", ->
+      editor.activeEditSession.setGrammar(grammar)
       editor.insertText "foo  \nline break!"
       editor.getBuffer().save()
-      expect(editor.getText()).toBe "foo  \nline break!"
+      expect(editor.getText()).toBe "foo  \nline break!\n"
+
+
+    it "trims GFM text with a more than two spaces", ->
+      editor.activeEditSession.setGrammar(grammar)
+      editor.insertText "foo   \nline break!"
+      editor.getBuffer().save()
+      expect(editor.getText()).toBe "foo\nline break!\n"

--- a/src/packages/whitespace/spec/whitespace-spec.coffee
+++ b/src/packages/whitespace/spec/whitespace-spec.coffee
@@ -86,3 +86,28 @@ describe "Whitespace", ->
       editor.getBuffer().save()
       expect(editor.getText()).toBe "foo\n"
       expect(editor.getCursorBufferPosition()).toEqual([0,3])
+
+  describe "whitespace.ensureSingleTrailingNewline config", ->
+    [originalConfigValue] = []
+    grammar = null
+
+    beforeEach ->
+      originalConfigValue = config.get("whitespace.ignoredGrammars")
+      expect(originalConfigValue).toEqual ["GitHub Markdown"]
+      spyOn(syntax, "addGrammar").andCallThrough()
+      atom.activatePackage("gfm")
+      expect(syntax.addGrammar).toHaveBeenCalled()
+      grammar = syntax.addGrammar.argsForCall[0][0]
+
+    afterEach ->
+      config.set("whitespace.ignoredGrammars", originalConfigValue)
+      config.update()
+
+    it "parses the grammar", ->
+      expect(grammar).toBeDefined()
+      expect(grammar.scopeName).toBe "source.gfm"
+
+    it "leaves Markdown files alone", ->
+      editor.insertText "foo  \nline break!"
+      editor.getBuffer().save()
+      expect(editor.getText()).toBe "foo  \nline break!"

--- a/src/packages/whitespace/spec/whitespace-spec.coffee
+++ b/src/packages/whitespace/spec/whitespace-spec.coffee
@@ -87,7 +87,7 @@ describe "Whitespace", ->
       expect(editor.getText()).toBe "foo\n"
       expect(editor.getCursorBufferPosition()).toEqual([0,3])
 
-  describe "whitespace.ensureSingleTrailingNewline config", ->
+  describe "whitespace.ignoredGrammars config", ->
     [originalConfigValue] = []
     grammar = null
 
@@ -103,11 +103,13 @@ describe "Whitespace", ->
       config.set("whitespace.ignoredGrammars", originalConfigValue)
       config.update()
 
-    it "parses the grammar", ->
+    it "parses the grammar as GFM", ->
       expect(grammar).toBeDefined()
       expect(grammar.scopeName).toBe "source.gfm"
 
-    it "leaves Markdown files alone", ->
+    it "leaves GFM files alone", ->
+      editor.activeEditSession.setGrammar(grammar)
+      expect(editor.getGrammar().name).toBe "GitHub Markdown"
       editor.insertText "foo  \nline break!"
       editor.getBuffer().save()
       expect(editor.getText()).toBe "foo  \nline break!"


### PR DESCRIPTION
In GFM it's perfectly valid (and sometimes necessary) to end a line with two whitespaces, then line break. This spits out a <`br/>` instead of a closing `<p>`.

I noticed most grammar manipulation works around `editSession.getGrammar().scopeName`. I'm not totally convinced that using `scopeName` is better than `name` in this (or other) cases. For consistency, I can change it, I just happen to think `GitHub Markdown` is easier to remember than `scope.gfm`. Though I'd like to hear thoughts one way or the other.
