### PR TITLE
Fast pass

### DIFF
--- a/script/copy-files-to-bundle
+++ b/script/copy-files-to-bundle
@@ -8,7 +8,10 @@ RESOUCES_PATH="$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
 
 # Copy non-coffee files into bundle
 rsync --archive --recursive \
-      --exclude="src/**.coffee" --exclude="src/**.cson" \
-      --exclude="src/**.less" --exclude="static/**.less" \
+      --exclude="src/**.coffee" \
+      --exclude="src/**.cson" \
+      --exclude="src/**.less" \
+      --exclude="static/**.less" \
+      --exclude="themes/**.less" \
       node_modules src static vendor spec benchmark themes dot-atom atom.sh \
       "${COMPILED_SOURCES_DIR}/" "$RESOUCES_PATH"

--- a/script/copy-files-to-bundle
+++ b/script/copy-files-to-bundle
@@ -10,6 +10,7 @@ RESOUCES_PATH="$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
 rsync --archive --recursive \
       --exclude="src/**.coffee" \
       --exclude="src/**.cson" \
+      --exclude="themes/**.cson" \
       --exclude="src/**.less" \
       --exclude="static/**.less" \
       --exclude="themes/**.less" \

--- a/script/copy-files-to-bundle
+++ b/script/copy-files-to-bundle
@@ -6,7 +6,7 @@ set -e
 COMPILED_SOURCES_DIR="${1}"
 RESOUCES_PATH="$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
 
-# Copy non-coffee files into bundle
+# Copy non-coffee/cson/less files into bundle
 rsync --archive --recursive \
       --exclude="src/**.coffee" \
       --exclude="src/**.cson" \

--- a/script/generate-sources-gypi
+++ b/script/generate-sources-gypi
@@ -28,7 +28,7 @@ $(find_files '*.coffee' | file_list)
 $(find_files '*.cson' | file_list)
     ],
     'less_sources': [
-$(find src static -type file -name '*.less' | file_list)
+$(find src static themes -type file -name '*.less' | file_list)
     ],
   },
 }

--- a/script/generate-sources-gypi
+++ b/script/generate-sources-gypi
@@ -4,12 +4,6 @@ set -e
 
 cd "$(dirname $0)/.."
 
-DIRS="src static vendor"
-
-find_files() {
-  find ${DIRS} -type file -name ${1}
-}
-
 file_list() {
   while read file; do
     echo "      '${file}',"
@@ -22,10 +16,10 @@ cat > sources.gypi <<EOF
     'compiled_sources_dir': '<(INTERMEDIATE_DIR)/atom-resources',
     'compiled_sources_dir_xcode': '\${INTERMEDIATE_DIR}/atom-resources',
     'coffee_sources': [
-$(find_files '*.coffee' | file_list)
+$(find src static vendor -type file -name '*.coffee' | file_list)
     ],
     'cson_sources': [
-$(find_files '*.cson' | file_list)
+$(find src static themes vendor -type file -name '*.cson' | file_list)
     ],
     'less_sources': [
 $(find src static themes -type file -name '*.less' | file_list)

--- a/spec/app/config-spec.coffee
+++ b/spec/app/config-spec.coffee
@@ -120,19 +120,33 @@ describe "Config", ->
 
     describe "when the configDirPath doesn't exist", ->
       it "copies the contents of dot-atom to ~/.atom", ->
-        config.initializeConfigDirectory()
-        expect(fsUtils.exists(config.configDirPath)).toBeTruthy()
-        expect(fsUtils.exists(fsUtils.join(config.configDirPath, 'packages'))).toBeTruthy()
-        expect(fsUtils.exists(fsUtils.join(config.configDirPath, 'snippets'))).toBeTruthy()
-        expect(fsUtils.exists(fsUtils.join(config.configDirPath, 'themes'))).toBeTruthy()
-        expect(fsUtils.isFile(fsUtils.join(config.configDirPath, 'config.cson'))).toBeTruthy()
+        initializationDone = false
+        jasmine.unspy(window, "setTimeout")
+        config.initializeConfigDirectory ->
+          initializationDone = true
+
+        waitsFor -> initializationDone
+
+        runs ->
+          expect(fsUtils.exists(config.configDirPath)).toBeTruthy()
+          expect(fsUtils.exists(fsUtils.join(config.configDirPath, 'packages'))).toBeTruthy()
+          expect(fsUtils.exists(fsUtils.join(config.configDirPath, 'snippets'))).toBeTruthy()
+          expect(fsUtils.exists(fsUtils.join(config.configDirPath, 'themes'))).toBeTruthy()
+          expect(fsUtils.isFile(fsUtils.join(config.configDirPath, 'config.cson'))).toBeTruthy()
 
       it "copies the bundles themes to ~/.atom", ->
-        config.initializeConfigDirectory()
-        expect(fsUtils.isFile(fsUtils.join(config.configDirPath, 'themes/atom-dark-ui/package.cson'))).toBeTruthy()
-        expect(fsUtils.isFile(fsUtils.join(config.configDirPath, 'themes/atom-light-ui/package.cson'))).toBeTruthy()
-        expect(fsUtils.isFile(fsUtils.join(config.configDirPath, 'themes/atom-dark-syntax.css'))).toBeTruthy()
-        expect(fsUtils.isFile(fsUtils.join(config.configDirPath, 'themes/atom-light-syntax.css'))).toBeTruthy()
+        initializationDone = false
+        jasmine.unspy(window, "setTimeout")
+        config.initializeConfigDirectory ->
+          initializationDone = true
+
+        waitsFor -> initializationDone
+
+        runs ->
+          expect(fsUtils.isFile(fsUtils.join(config.configDirPath, 'themes/atom-dark-ui/package.cson'))).toBeTruthy()
+          expect(fsUtils.isFile(fsUtils.join(config.configDirPath, 'themes/atom-light-ui/package.cson'))).toBeTruthy()
+          expect(fsUtils.isFile(fsUtils.join(config.configDirPath, 'themes/atom-dark-syntax.css'))).toBeTruthy()
+          expect(fsUtils.isFile(fsUtils.join(config.configDirPath, 'themes/atom-light-syntax.css'))).toBeTruthy()
 
   describe "when the config file is not parseable", ->
     beforeEach ->

--- a/spec/app/window-spec.coffee
+++ b/spec/app/window-spec.coffee
@@ -165,8 +165,12 @@ describe "Window", ->
       it "copies atom.sh to the specified path", ->
         expect(fsUtils.exists(commandPath)).toBeFalsy()
         window.installAtomCommand(commandPath)
-        expect(fsUtils.exists(commandPath)).toBeTruthy()
-        expect(fsUtils.read(commandPath).length).toBeGreaterThan 1
+
+        waitsFor ->
+          fsUtils.exists(commandPath)
+
+        runs ->
+          expect(fsUtils.read(commandPath).length).toBeGreaterThan 1
 
   describe ".deserialize(state)", ->
     class Foo

--- a/src/app/atom-package.coffee
+++ b/src/app/atom-package.coffee
@@ -83,13 +83,13 @@ class AtomPackage extends Package
   loadGrammars: ->
     @grammars = []
     grammarsDirPath = fsUtils.join(@path, 'grammars')
-    for grammarPath in fsUtils.list(grammarsDirPath, ['.cson', '.json'])
+    for grammarPath in fsUtils.list(grammarsDirPath, ['.json', '.cson'])
       @grammars.push(TextMateGrammar.loadSync(grammarPath))
 
   loadScopedProperties: ->
     @scopedProperties = []
     scopedPropertiessDirPath = fsUtils.join(@path, 'scoped-properties')
-    for scopedPropertiesPath in fsUtils.list(scopedPropertiessDirPath, ['.cson', '.json'])
+    for scopedPropertiesPath in fsUtils.list(scopedPropertiessDirPath, ['.json', '.cson'])
       for selector, properties of fsUtils.readObject(scopedPropertiesPath)
         @scopedProperties.push([scopedPropertiesPath, selector, properties])
 

--- a/src/app/atom-package.coffee
+++ b/src/app/atom-package.coffee
@@ -56,7 +56,7 @@ class AtomPackage extends Package
       console.warn "Failed to activate package named '#{@name}'", e.stack
 
   loadMetadata: ->
-    if metadataPath = fsUtils.resolveExtension(fsUtils.join(@path, 'package'), ['cson', 'json'])
+    if metadataPath = fsUtils.resolveExtension(fsUtils.join(@path, 'package'), ['json', 'cson'])
       @metadata = CSON.readObject(metadataPath)
     @metadata ?= {}
 
@@ -66,7 +66,7 @@ class AtomPackage extends Package
   getKeymapPaths: ->
     keymapsDirPath = fsUtils.join(@path, 'keymaps')
     if @metadata.keymaps
-      @metadata.keymaps.map (name) -> fsUtils.resolve(keymapsDirPath, name, ['cson', 'json', ''])
+      @metadata.keymaps.map (name) -> fsUtils.resolve(keymapsDirPath, name, ['json', 'cson', ''])
     else
       fsUtils.list(keymapsDirPath, ['cson', 'json']) ? []
 

--- a/src/app/atom-package.coffee
+++ b/src/app/atom-package.coffee
@@ -68,7 +68,7 @@ class AtomPackage extends Package
     if @metadata.keymaps
       @metadata.keymaps.map (name) -> fsUtils.resolve(keymapsDirPath, name, ['json', 'cson', ''])
     else
-      fsUtils.list(keymapsDirPath, ['cson', 'json']) ? []
+      fsUtils.list(keymapsDirPath, ['cson', 'json'])
 
   loadStylesheets: ->
     @stylesheets = @getStylesheetPaths().map (path) -> [path, loadStylesheet(path)]
@@ -78,18 +78,18 @@ class AtomPackage extends Package
     if @metadata.stylesheets
       @metadata.stylesheets.map (name) -> fsUtils.resolve(stylesheetDirPath, name, ['css', 'less', ''])
     else
-      fsUtils.list(stylesheetDirPath, ['css', 'less']) ? []
+      fsUtils.list(stylesheetDirPath, ['css', 'less'])
 
   loadGrammars: ->
     @grammars = []
     grammarsDirPath = fsUtils.join(@path, 'grammars')
-    for grammarPath in fsUtils.list(grammarsDirPath, ['.cson', '.json']) ? []
+    for grammarPath in fsUtils.list(grammarsDirPath, ['.cson', '.json'])
       @grammars.push(TextMateGrammar.loadSync(grammarPath))
 
   loadScopedProperties: ->
     @scopedProperties = []
     scopedPropertiessDirPath = fsUtils.join(@path, 'scoped-properties')
-    for scopedPropertiesPath in fsUtils.list(scopedPropertiessDirPath, ['.cson', '.json']) ? []
+    for scopedPropertiesPath in fsUtils.list(scopedPropertiessDirPath, ['.cson', '.json'])
       for selector, properties of fsUtils.readObject(scopedPropertiesPath)
         @scopedProperties.push([scopedPropertiesPath, selector, properties])
 

--- a/src/app/atom-theme.coffee
+++ b/src/app/atom-theme.coffee
@@ -1,6 +1,5 @@
 fsUtils = require 'fs-utils'
 Theme = require 'theme'
-CSON = require 'cson'
 
 # Internal: Represents a theme that Atom can use.
 module.exports =
@@ -19,7 +18,7 @@ class AtomTheme extends Theme
     else
       metadataPath = fsUtils.resolveExtension(fsUtils.join(@path, 'package'), ['cson', 'json'])
       if fsUtils.isFile(metadataPath)
-        stylesheetNames = CSON.readObject(metadataPath)?.stylesheets
+        stylesheetNames = fsUtils.readObject(metadataPath)?.stylesheets
         if stylesheetNames
           for name in stylesheetNames
             filename = fsUtils.resolveExtension(fsUtils.join(@path, name), ['.css', '.less', ''])

--- a/src/app/atom.coffee
+++ b/src/app/atom.coffee
@@ -58,7 +58,10 @@ _.extend atom,
     _.clone(@activePackages)
 
   loadPackages: ->
-    @loadPackage(path) for path in @getPackagePaths() when not @isPackageDisabled(path)
+    measure "load packages", =>
+      for path in @getPackagePaths() when not @isPackageDisabled(path)
+        measure "loading #{fsUtils.base(path)}", =>
+          @loadPackage(path)
 
   loadPackage: (id, options) ->
     if @isPackageDisabled(id)

--- a/src/app/atom.coffee
+++ b/src/app/atom.coffee
@@ -58,10 +58,7 @@ _.extend atom,
     _.clone(@activePackages)
 
   loadPackages: ->
-    measure "load packages", =>
-      for path in @getPackagePaths() when not @isPackageDisabled(path)
-        measure "loading #{fsUtils.base(path)}", =>
-          @loadPackage(path)
+    @loadPackage(path) for path in @getPackagePaths() when not @isPackageDisabled(path)
 
   loadPackage: (id, options) ->
     if @isPackageDisabled(id)

--- a/src/app/text-mate-package.coffee
+++ b/src/app/text-mate-package.coffee
@@ -74,8 +74,6 @@ class TextMatePackage extends Package
   getGrammars: -> @grammars
 
   loadScopedProperties: ->
-    @scopedProperties = []
-
     for grammar in @getGrammars()
       if properties = @propertiesFromTextMateSettings(grammar)
         selector = syntax.cssSelectorFromScopeSelector(grammar.scopeName)

--- a/src/app/text-mate-package.coffee
+++ b/src/app/text-mate-package.coffee
@@ -110,7 +110,7 @@ class TextMatePackage extends Package
 
       @scopedProperties = scopedProperties
       if atom.isPackageActive(@path)
-        for { selector, properties } in @scopedProperties
+        for {selector, properties} in @scopedProperties
           syntax.addProperties(@path, selector, properties)
     @loadTextMatePreferenceObjects(preferenceObjects, done)
 

--- a/src/app/text-mate-package.coffee
+++ b/src/app/text-mate-package.coffee
@@ -29,6 +29,7 @@ class TextMatePackage extends Package
   load: ({sync}={}) ->
     if sync
       @loadGrammarsSync()
+      @loadScopedPropertiesSync()
     else
       TextMatePackage.getLoadQueue().push(this)
 
@@ -45,10 +46,14 @@ class TextMatePackage extends Package
 
   loadGrammars: (done) ->
     fsUtils.isDirectoryAsync @syntaxesPath, (isDirectory) =>
-      return unless isDirectory
+      return done() unless isDirectory
 
-      fsUtils.listAsync @syntaxesPath, @legalGrammarExtensions, (err, paths) =>
-        return console.log("Error loading grammars of TextMate package '#{@path}':", err.stack, err) if err
+      fsUtils.listAsync @syntaxesPath, @legalGrammarExtensions, (error, paths) =>
+        if error?
+          console.log("Error loading grammars of TextMate package '#{@path}':", error.stack, error)
+          done()
+          return
+
         async.waterfall [
             (next) =>
               async.eachSeries paths, @loadGrammarAtPath, next
@@ -64,7 +69,7 @@ class TextMatePackage extends Package
       done()
 
   loadGrammarsSync: ->
-    for path in fsUtils.list(@syntaxesPath, @legalGrammarExtensions) ? []
+    for path in fsUtils.list(@syntaxesPath, @legalGrammarExtensions)
       @addGrammar(TextMateGrammar.loadSync(path))
 
   addGrammar: (grammar) ->
@@ -73,30 +78,60 @@ class TextMatePackage extends Package
 
   getGrammars: -> @grammars
 
-  loadScopedProperties: ->
+  loadScopedPropertiesSync: ->
     for grammar in @getGrammars()
       if properties = @propertiesFromTextMateSettings(grammar)
         selector = syntax.cssSelectorFromScopeSelector(grammar.scopeName)
         @scopedProperties.push({selector, properties})
 
-    for {scope, settings} in @getTextMatePreferenceObjects()
+    for path in fsUtils.list(@preferencesPath)
+      {scope, settings} = fsUtils.readObject(path)
       if properties = @propertiesFromTextMateSettings(settings)
         selector = syntax.cssSelectorFromScopeSelector(scope) if scope?
         @scopedProperties.push({selector, properties})
 
-    if atom.isPackageActive(@path)
-      for { selector, properties } in @scopedProperties
-        syntax.addProperties(@path, selector, properties)
+    for {selector, properties} in @scopedProperties
+      syntax.addProperties(@path, selector, properties)
 
-  getTextMatePreferenceObjects: ->
+  loadScopedProperties: ->
+    scopedProperties = []
+
+    for grammar in @getGrammars()
+      if properties = @propertiesFromTextMateSettings(grammar)
+        selector = syntax.cssSelectorFromScopeSelector(grammar.scopeName)
+        scopedProperties.push({selector, properties})
+
     preferenceObjects = []
-    if fsUtils.exists(@preferencesPath)
-      for preferencePath in fsUtils.list(@preferencesPath)
-        try
-          preferenceObjects.push(fsUtils.readObject(preferencePath))
-        catch e
-          console.warn "Failed to parse preference at path '#{preferencePath}'", e.stack
-    preferenceObjects
+    done = =>
+      for {scope, settings} in preferenceObjects
+        if properties = @propertiesFromTextMateSettings(settings)
+          selector = syntax.cssSelectorFromScopeSelector(scope) if scope?
+          scopedProperties.push({selector, properties})
+
+      @scopedProperties = scopedProperties
+      if atom.isPackageActive(@path)
+        for { selector, properties } in @scopedProperties
+          syntax.addProperties(@path, selector, properties)
+    @loadTextMatePreferenceObjects(preferenceObjects, done)
+
+  loadTextMatePreferenceObjects: (preferenceObjects, done) ->
+    fsUtils.isDirectoryAsync @preferencesPath, (isDirectory) =>
+      return done() unless isDirectory
+
+      fsUtils.listAsync @preferencesPath, (error, paths) =>
+        if error?
+          console.log("Error loading preferences of TextMate package '#{@path}':", error.stack, error)
+          done()
+          return
+
+        loadPreferencesAtPath = (path, done) ->
+          fsUtils.readObjectAsync path, (error, preferences) =>
+            if error?
+              console.warn("Failed to parse preference at path '#{path}'", error.stack, error)
+            else
+              preferenceObjects.push(preferences)
+            done()
+        async.eachSeries paths, loadPreferencesAtPath, done
 
   propertiesFromTextMateSettings: (textMateSettings) ->
     if textMateSettings.shellVariables

--- a/src/app/text-mate-package.coffee
+++ b/src/app/text-mate-package.coffee
@@ -45,16 +45,18 @@ class TextMatePackage extends Package
 
   loadGrammars: (done) ->
     fsUtils.isDirectoryAsync @syntaxesPath, (isDirectory) =>
-      if isDirectory
-        fsUtils.listAsync @syntaxesPath, @legalGrammarExtensions, (err, paths) =>
-          return console.log("Error loading grammars of TextMate package '#{@path}':", err.stack, err) if err
-          async.waterfall [
-              (next) =>
-                async.eachSeries paths, @loadGrammarAtPath, next
-              (next) =>
-                @loadScopedProperties()
-                next()
-          ], done
+      return unless isDirectory
+
+      fsUtils.listAsync @syntaxesPath, @legalGrammarExtensions, (err, paths) =>
+        return console.log("Error loading grammars of TextMate package '#{@path}':", err.stack, err) if err
+        async.waterfall [
+            (next) =>
+              async.eachSeries paths, @loadGrammarAtPath, next
+            (next) =>
+              @loadScopedProperties()
+              next()
+        ], done
+
   loadGrammarAtPath: (path, done) =>
     TextMateGrammar.load path, (err, grammar) =>
       return console.log("Error loading grammar at path '#{path}':", err.stack ? err) if err

--- a/src/app/window.coffee
+++ b/src/app/window.coffee
@@ -72,13 +72,21 @@ window.shutdown = ->
   window.project = null
   window.git = null
 
-window.installAtomCommand = (commandPath) ->
-  return if fsUtils.exists(commandPath)
+window.installAtomCommand = (commandPath, done) ->
+  fs.exists commandPath, (exists) ->
+    return if exists
 
-  bundledCommandPath = fsUtils.resolve(window.resourcePath, 'atom.sh')
-  if bundledCommandPath?
-    fsUtils.write(commandPath, fsUtils.read(bundledCommandPath))
-    fs.chmod(commandPath, 0o755, commandPath)
+    bundledCommandPath = fsUtils.resolve(window.resourcePath, 'atom.sh')
+    if bundledCommandPath?
+      fs.readFile bundledCommandPath, (error, data) ->
+        if error?
+          console.warn "Failed to install `atom` binary", error
+        else
+          fsUtils.writeAsync commandPath, data, (error) ->
+            if error?
+              console.warn "Failed to install `atom` binary", error
+            else
+              fs.chmod(commandPath, 0o755, commandPath)
 
 window.handleWindowEvents = ->
   $(window).command 'window:toggle-full-screen', => atom.toggleFullScreen()

--- a/src/packages/fuzzy-finder/lib/fuzzy-finder.coffee
+++ b/src/packages/fuzzy-finder/lib/fuzzy-finder.coffee
@@ -41,7 +41,7 @@ module.exports =
   createView:  ->
     unless @fuzzyFinderView
       @loadPathsTask?.abort()
-      FuzzyFinderView  = require 'fuzzy-finder/lib/fuzzy-finder-view'
+      FuzzyFinderView  = require './fuzzy-finder-view'
       @fuzzyFinderView = new FuzzyFinderView()
       if @projectPaths?.length > 0 and not @fuzzyFinderView.projectPaths?
         @fuzzyFinderView.projectPaths = @projectPaths

--- a/src/packages/snippets/lib/snippets.coffee
+++ b/src/packages/snippets/lib/snippets.coffee
@@ -111,7 +111,7 @@ module.exports =
       syntax.addProperties(selector, snippets: snippetsByPrefix)
 
   getBodyParser: ->
-    require 'snippets/lib/snippet-body-parser'
+    require './snippet-body-parser'
 
   enableSnippetsInEditor: (editor) ->
     editor.command 'snippets:expand', (e) =>

--- a/src/packages/spell-check/lib/spell-check.coffee
+++ b/src/packages/spell-check/lib/spell-check.coffee
@@ -12,4 +12,5 @@ module.exports =
 
   activate: ->
     rootView.eachEditor (editor) =>
-      editor.underlayer.append(@createView(editor)) if editor.getPane()?
+      if editor.attached and editor.getPane()?
+        editor.underlayer.append(@createView(editor))

--- a/src/packages/spell-check/lib/spell-check.coffee
+++ b/src/packages/spell-check/lib/spell-check.coffee
@@ -1,5 +1,3 @@
-SpellCheckView = require './spell-check-view'
-
 module.exports =
   configDefaults:
     grammars: [
@@ -8,7 +6,10 @@ module.exports =
       'text.git-commit'
     ]
 
+  createView: (editor) ->
+    @spellCheckViewClass ?= require './spell-check-view'
+    new @spellCheckViewClass(editor)
+
   activate: ->
-    rootView.eachEditor (editor) ->
-      if editor.attached and not editor.mini
-        editor.underlayer.append(new SpellCheckView(editor))
+    rootView.eachEditor (editor) =>
+      editor.underlayer.append(@createView(editor)) if editor.getPane()?

--- a/src/stdlib/fs-utils.coffee
+++ b/src/stdlib/fs-utils.coffee
@@ -155,6 +155,13 @@ module.exports =
     mkdirp.sync(@directory(path))
     fs.writeFileSync(path, content)
 
+  writeAsync: (path, content, callback) ->
+    mkdirp @directory(path), (error) ->
+      if error?
+        callback?(error)
+      else
+        fs.writeFile(path, content, callback)
+
   makeDirectory: (path) ->
     fs.mkdirSync(path)
 


### PR DESCRIPTION
These changes reduced the load time with no open editors on my machine from `~650ms` to `~515ms`.
- [x] Precompile theme `.less` files to `.css`
- [x] Precompile theme `.cson` files to `.json`
- [x] Load TextMate bundle preferences asynchronously like grammars
- [x] Install `atom` executable asynchronously
- [x] Defer a few requires here and there
- [x] Install folders into `~/.atom` directory asynchronously
