### PR TITLE
Make Project.open extensible

### DIFF
--- a/benchmark/benchmark-suite.coffee
+++ b/benchmark/benchmark-suite.coffee
@@ -106,7 +106,7 @@ describe "TokenizedBuffer.", ->
     [languageMode, buffer] = []
 
     beforeEach ->
-      editSession = benchmarkFixturesProject.buildEditSession('medium.coffee')
+      editSession = benchmarkFixturesProject.open('medium.coffee')
       { languageMode, buffer } = editSession
 
     benchmark "construction", 20, ->

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -10,7 +10,7 @@ describe "EditSession", ->
 
   beforeEach ->
     atom.activatePackage('javascript.tmbundle', sync: true)
-    editSession = project.buildEditSession('sample.js', autoIndent: false)
+    editSession = project.open('sample.js', autoIndent: false)
     buffer = editSession.buffer
     lineLengths = buffer.getLines().map (line) -> line.length
 
@@ -1762,7 +1762,7 @@ describe "EditSession", ->
 
       it "does not explode if the current language mode has no comment regex", ->
         editSession.destroy()
-        editSession = project.buildEditSession(null, autoIndent: false)
+        editSession = project.open(null, autoIndent: false)
         editSession.setSelectedBufferRange([[4, 5], [4, 5]])
         editSession.toggleLineCommentsInSelection()
         expect(buffer.lineForRow(4)).toBe "    while(items.length > 0) {"
@@ -2149,13 +2149,13 @@ describe "EditSession", ->
 
   describe "soft-tabs detection", ->
     it "assign soft / hard tabs based on the contents of the buffer, or uses the default if unknown", ->
-      editSession = project.buildEditSession('sample.js', softTabs: false)
+      editSession = project.open('sample.js', softTabs: false)
       expect(editSession.softTabs).toBeTruthy()
 
-      editSession = project.buildEditSession('sample-with-tabs.coffee', softTabs: true)
+      editSession = project.open('sample-with-tabs.coffee', softTabs: true)
       expect(editSession.softTabs).toBeFalsy()
 
-      editSession = project.buildEditSession(null, softTabs: false)
+      editSession = project.open(null, softTabs: false)
       expect(editSession.softTabs).toBeFalsy()
 
   describe ".indentLevelForLine(line)", ->
@@ -2184,7 +2184,7 @@ describe "EditSession", ->
       jsGrammar = syntax.selectGrammar('a.js')
       syntax.removeGrammar(jsGrammar)
 
-      editSession = project.buildEditSession('sample.js', autoIndent: false)
+      editSession = project.open('sample.js', autoIndent: false)
       expect(editSession.getGrammar()).toBe syntax.nullGrammar
       expect(editSession.lineForScreenRow(0).tokens.length).toBe 1
 
@@ -2455,7 +2455,7 @@ describe "EditSession", ->
       expect(editSession.shouldPromptToSave()).toBeFalsy()
       buffer.setText('changed')
       expect(editSession.shouldPromptToSave()).toBeTruthy()
-      editSession2 = project.buildEditSession('sample.js', autoIndent: false)
+      editSession2 = project.open('sample.js', autoIndent: false)
       expect(editSession.shouldPromptToSave()).toBeFalsy()
       editSession2.destroy()
       expect(editSession.shouldPromptToSave()).toBeTruthy()

--- a/spec/app/editor-spec.coffee
+++ b/spec/app/editor-spec.coffee
@@ -15,7 +15,7 @@ describe "Editor", ->
   beforeEach ->
     atom.activatePackage('text.tmbundle', sync: true)
     atom.activatePackage('javascript.tmbundle', sync: true)
-    editSession = project.buildEditSession('sample.js')
+    editSession = project.open('sample.js')
     buffer = editSession.buffer
     editor = new Editor(editSession)
     editor.lineOverdraw = 2
@@ -38,7 +38,7 @@ describe "Editor", ->
     cachedCharWidth
 
   calcDimensions = ->
-    editorForMeasurement = new Editor(editSession: project.buildEditSession('sample.js'))
+    editorForMeasurement = new Editor(editSession: project.open('sample.js'))
     editorForMeasurement.attachToDom()
     cachedLineHeight = editorForMeasurement.lineHeight
     cachedCharWidth = editorForMeasurement.charWidth
@@ -85,7 +85,7 @@ describe "Editor", ->
     it "triggers an alert", ->
       path = "/tmp/atom-changed-file.txt"
       fsUtils.write(path, "")
-      editSession = project.buildEditSession(path)
+      editSession = project.open(path)
       editor.edit(editSession)
       editor.insertText("now the buffer is modified")
 
@@ -111,7 +111,7 @@ describe "Editor", ->
     [newEditSession, newBuffer] = []
 
     beforeEach ->
-      newEditSession = project.buildEditSession('two-hundred.txt')
+      newEditSession = project.open('two-hundred.txt')
       newBuffer = newEditSession.buffer
 
     it "updates the rendered lines, cursors, selections, scroll position, and event subscriptions to match the given edit session", ->
@@ -149,7 +149,7 @@ describe "Editor", ->
     it "triggers alert if edit session's buffer goes into conflict with changes on disk", ->
       path = "/tmp/atom-changed-file.txt"
       fsUtils.write(path, "")
-      tempEditSession = project.buildEditSession(path)
+      tempEditSession = project.open(path)
       editor.edit(tempEditSession)
       tempEditSession.insertText("a buffer change")
 
@@ -243,7 +243,7 @@ describe "Editor", ->
     it "emits event when editor receives a new buffer", ->
       eventHandler = jasmine.createSpy('eventHandler')
       editor.on 'editor:path-changed', eventHandler
-      editor.edit(project.buildEditSession(path))
+      editor.edit(project.open(path))
       expect(eventHandler).toHaveBeenCalled()
 
     it "stops listening to events on previously set buffers", ->
@@ -251,7 +251,7 @@ describe "Editor", ->
       oldBuffer = editor.getBuffer()
       editor.on 'editor:path-changed', eventHandler
 
-      editor.edit(project.buildEditSession(path))
+      editor.edit(project.open(path))
       expect(eventHandler).toHaveBeenCalled()
 
       eventHandler.reset()
@@ -1399,7 +1399,7 @@ describe "Editor", ->
 
     describe "when autoscrolling at the end of the document", ->
       it "renders lines properly", ->
-        editor.edit(project.buildEditSession('two-hundred.txt'))
+        editor.edit(project.open('two-hundred.txt'))
         editor.attachToDom(heightInLines: 5.5)
 
         expect(editor.renderedLines.find('.line').length).toBe 8
@@ -1624,7 +1624,7 @@ describe "Editor", ->
       expect(editor.bufferPositionForScreenPosition(editor.getCursorScreenPosition())).toEqual [3, 60]
 
     it "does not wrap the lines of any newly assigned buffers", ->
-      otherEditSession = project.buildEditSession()
+      otherEditSession = project.open()
       otherEditSession.buffer.setText([1..100].join(''))
       editor.edit(otherEditSession)
       expect(editor.renderedLines.find('.line').length).toBe(1)
@@ -1660,7 +1660,7 @@ describe "Editor", ->
       expect(editor.getCursorScreenPosition()).toEqual [11, 0]
 
     it "calls .setSoftWrapColumn() when the editor is attached because now its dimensions are available to calculate it", ->
-      otherEditor = new Editor(editSession: project.buildEditSession('sample.js'))
+      otherEditor = new Editor(editSession: project.open('sample.js'))
       spyOn(otherEditor, 'setSoftWrapColumn')
 
       otherEditor.setSoftWrap(true)
@@ -1764,7 +1764,7 @@ describe "Editor", ->
 
     describe "when the switching from an edit session for a long buffer to an edit session for a short buffer", ->
       it "updates the line numbers to reflect the shorter buffer", ->
-        emptyEditSession = project.buildEditSession(null)
+        emptyEditSession = project.open(null)
         editor.edit(emptyEditSession)
         expect(editor.gutter.lineNumbers.find('.line-number').length).toBe 1
 
@@ -1926,7 +1926,7 @@ describe "Editor", ->
 
   describe "folding", ->
     beforeEach ->
-      editSession = project.buildEditSession('two-hundred.txt')
+      editSession = project.open('two-hundred.txt')
       buffer = editSession.buffer
       editor.edit(editSession)
       editor.attachToDom()
@@ -2064,7 +2064,7 @@ describe "Editor", ->
     beforeEach ->
       path = project.resolve('git/working-dir/file.txt')
       originalPathText = fsUtils.read(path)
-      editor.edit(project.buildEditSession(path))
+      editor.edit(project.open(path))
 
     afterEach ->
       fsUtils.write(path, originalPathText)
@@ -2185,7 +2185,7 @@ describe "Editor", ->
       fsUtils.remove(path) if fsUtils.exists(path)
 
     it "updates all the rendered lines when the grammar changes", ->
-      editor.edit(project.buildEditSession(path))
+      editor.edit(project.open(path))
       expect(editor.getGrammar().name).toBe 'Plain Text'
       syntax.setGrammarOverrideForPath(path, 'source.js')
       editor.reloadGrammar()
@@ -2205,7 +2205,7 @@ describe "Editor", ->
       expect(editor.getGrammar().name).toBe 'JavaScript'
 
     it "emits an editor:grammar-changed event when updated", ->
-      editor.edit(project.buildEditSession(path))
+      editor.edit(project.open(path))
 
       eventHandler = jasmine.createSpy('eventHandler')
       editor.on('editor:grammar-changed', eventHandler)

--- a/spec/app/language-mode-spec.coffee
+++ b/spec/app/language-mode-spec.coffee
@@ -11,7 +11,7 @@ describe "LanguageMode", ->
   describe "javascript", ->
     beforeEach ->
       atom.activatePackage('javascript.tmbundle', sync: true)
-      editSession = project.buildEditSession('sample.js', autoIndent: false)
+      editSession = project.open('sample.js', autoIndent: false)
       { buffer, languageMode } = editSession
 
     describe ".toggleLineCommentsForBufferRows(start, end)", ->
@@ -53,7 +53,7 @@ describe "LanguageMode", ->
   describe "coffeescript", ->
     beforeEach ->
       atom.activatePackage('coffee-script-tmbundle', sync: true)
-      editSession = project.buildEditSession('coffee.coffee', autoIndent: false)
+      editSession = project.open('coffee.coffee', autoIndent: false)
       { buffer, languageMode } = editSession
 
     describe ".toggleLineCommentsForBufferRows(start, end)", ->
@@ -89,7 +89,7 @@ describe "LanguageMode", ->
   describe "css", ->
     beforeEach ->
       atom.activatePackage('css.tmbundle', sync: true)
-      editSession = project.buildEditSession('css.css', autoIndent: false)
+      editSession = project.open('css.css', autoIndent: false)
       { buffer, languageMode } = editSession
 
     describe ".toggleLineCommentsForBufferRows(start, end)", ->

--- a/spec/app/pane-spec.coffee
+++ b/spec/app/pane-spec.coffee
@@ -10,8 +10,8 @@ describe "Pane", ->
     container = new PaneContainer
     view1 = $$ -> @div id: 'view-1', tabindex: -1, 'View 1'
     view2 = $$ -> @div id: 'view-2', tabindex: -1, 'View 2'
-    editSession1 = project.buildEditSession('sample.js')
-    editSession2 = project.buildEditSession('sample.txt')
+    editSession1 = project.open('sample.js')
+    editSession2 = project.open('sample.txt')
     pane = new Pane(view1, editSession1, view2, editSession2)
     container.append(pane)
 

--- a/spec/app/project-spec.coffee
+++ b/spec/app/project-spec.coffee
@@ -99,12 +99,17 @@ describe "Project", ->
         buffer = project.bufferForPath("a").retain().release()
         expect(project.bufferForPath("a").retain().release()).not.toBe buffer
 
-  describe ".resolve(path)", ->
-    it "returns an absolute path based on the project's root", ->
-      absolutePath = fsUtils.resolveOnLoadPath('fixtures/dir/a')
-      expect(project.resolve('a')).toBe absolutePath
-      expect(project.resolve(absolutePath + '/../a')).toBe absolutePath
-      expect(project.resolve('a/../a')).toBe absolutePath
+  describe ".resolve(uri)", ->
+    describe "when passed an absolute or relative path", ->
+      it "returns an absolute path based on the project's root", ->
+        absolutePath = fsUtils.resolveOnLoadPath('fixtures/dir/a')
+        expect(project.resolve('a')).toBe absolutePath
+        expect(project.resolve(absolutePath + '/../a')).toBe absolutePath
+        expect(project.resolve('a/../a')).toBe absolutePath
+
+    describe "when passed a uri with a scheme", ->
+      it "does not modify uris that begin with a scheme", ->
+        expect(project.resolve('http://zombo.com')).toBe 'http://zombo.com'
 
   describe ".relativize(path)", ->
     it "returns an relative path based on the project's root", ->

--- a/spec/app/project-spec.coffee
+++ b/spec/app/project-spec.coffee
@@ -9,8 +9,8 @@ describe "Project", ->
 
   describe "when an edit session is destroyed", ->
     it "removes edit session and calls destroy on buffer (if buffer is not referenced by other edit sessions)", ->
-      editSession = project.buildEditSession("a")
-      anotherEditSession = project.buildEditSession("a")
+      editSession = project.open("a")
+      anotherEditSession = project.open("a")
 
       expect(project.editSessions.length).toBe 2
       expect(editSession.buffer).toBe anotherEditSession.buffer
@@ -26,12 +26,12 @@ describe "Project", ->
       path = project.resolve('a')
       project.setPath(undefined)
       expect(project.getPath()).toBeUndefined()
-      editSession = project.buildEditSession()
+      editSession = project.open()
       editSession.saveAs('/tmp/atom-test-save-sets-project-path')
       expect(project.getPath()).toBe '/tmp'
       fsUtils.remove('/tmp/atom-test-save-sets-project-path')
 
-  describe ".buildEditSession(path)", ->
+  describe ".open(path)", ->
     [absolutePath, newBufferHandler, newEditSessionHandler] = []
     beforeEach ->
       absolutePath = fsUtils.resolveOnLoadPath('fixtures/dir/a')
@@ -42,30 +42,30 @@ describe "Project", ->
 
     describe "when given an absolute path that hasn't been opened previously", ->
       it "returns a new edit session for the given path and emits 'buffer-created' and 'edit-session-created' events", ->
-        editSession = project.buildEditSession(absolutePath)
+        editSession = project.open(absolutePath)
         expect(editSession.buffer.getPath()).toBe absolutePath
         expect(newBufferHandler).toHaveBeenCalledWith editSession.buffer
         expect(newEditSessionHandler).toHaveBeenCalledWith editSession
 
     describe "when given a relative path that hasn't been opened previously", ->
       it "returns a new edit session for the given path (relative to the project root) and emits 'buffer-created' and 'edit-session-created' events", ->
-        editSession = project.buildEditSession('a')
+        editSession = project.open('a')
         expect(editSession.buffer.getPath()).toBe absolutePath
         expect(newBufferHandler).toHaveBeenCalledWith editSession.buffer
         expect(newEditSessionHandler).toHaveBeenCalledWith editSession
 
     describe "when passed the path to a buffer that has already been opened", ->
       it "returns a new edit session containing previously opened buffer and emits a 'edit-session-created' event", ->
-        editSession = project.buildEditSession(absolutePath)
+        editSession = project.open(absolutePath)
         newBufferHandler.reset()
-        expect(project.buildEditSession(absolutePath).buffer).toBe editSession.buffer
-        expect(project.buildEditSession('a').buffer).toBe editSession.buffer
+        expect(project.open(absolutePath).buffer).toBe editSession.buffer
+        expect(project.open('a').buffer).toBe editSession.buffer
         expect(newBufferHandler).not.toHaveBeenCalled()
         expect(newEditSessionHandler).toHaveBeenCalledWith editSession
 
     describe "when not passed a path", ->
       it "returns a new edit session and emits 'buffer-created' and 'edit-session-created' events", ->
-        editSession = project.buildEditSession()
+        editSession = project.open()
         expect(editSession.buffer.getPath()).toBeUndefined()
         expect(newBufferHandler).toHaveBeenCalledWith(editSession.buffer)
         expect(newEditSessionHandler).toHaveBeenCalledWith editSession

--- a/spec/app/root-view-spec.coffee
+++ b/spec/app/root-view-spec.coffee
@@ -46,10 +46,10 @@ describe "RootView", ->
           pane2 = pane1.splitRight()
           pane3 = pane2.splitRight()
           pane4 = pane2.splitDown()
-          pane2.showItem(project.buildEditSession('b'))
-          pane3.showItem(project.buildEditSession('../sample.js'))
+          pane2.showItem(project.open('b'))
+          pane3.showItem(project.open('../sample.js'))
           pane3.activeItem.setCursorScreenPosition([2, 4])
-          pane4.showItem(project.buildEditSession('../sample.txt'))
+          pane4.showItem(project.open('../sample.txt'))
           pane4.activeItem.setCursorScreenPosition([0, 2])
           pane2.focus()
 

--- a/spec/app/text-mate-grammar-spec.coffee
+++ b/spec/app/text-mate-grammar-spec.coffee
@@ -448,7 +448,7 @@ describe "TextMateGrammar", ->
 
       describe "when the grammar is added", ->
         it "retokenizes existing buffers that contain tokens that match the injection selector", ->
-          editSession = project.buildEditSession('sample.js')
+          editSession = project.open('sample.js')
           editSession.setText("// http://github.com")
 
           {tokens} = editSession.lineForScreenRow(0)
@@ -463,7 +463,7 @@ describe "TextMateGrammar", ->
 
       describe "when the grammar is updated", ->
         it "retokenizes existing buffers that contain tokens that match the injection selector", ->
-          editSession = project.buildEditSession('sample.js')
+          editSession = project.open('sample.js')
           editSession.setText("// SELECT * FROM OCTOCATS")
 
           {tokens} = editSession.lineForScreenRow(0)

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -24,7 +24,7 @@ class EditSession
     session = project.buildEditSessionForBuffer(Buffer.deserialize(state.buffer))
     if !session?
       console.warn "Could not build edit session for path '#{state.buffer}' because that file no longer exists" if state.buffer
-      session = project.buildEditSession(null)
+      session = project.open(null)
     session.setScrollTop(state.scrollTop)
     session.setScrollLeft(state.scrollLeft)
     session.setCursorScreenPosition(state.cursorScreenPosition)

--- a/src/app/image-edit-session.coffee
+++ b/src/app/image-edit-session.coffee
@@ -12,7 +12,7 @@ class ImageEditSession
 
   @deserialize: (state) ->
     if fsUtils.exists(state.path)
-      project.buildEditSession(state.path)
+      project.open(state.path)
     else
       console.warn "Could not build edit session for path '#{state.path}' because that file no longer exists"
 

--- a/src/app/image-edit-session.coffee
+++ b/src/app/image-edit-session.coffee
@@ -8,7 +8,15 @@ module.exports=
 class ImageEditSession
   registerDeserializer(this)
 
+  # Files with these extensions will be opened as images
+  @imageExtensions: ['.gif', '.jpeg', '.jpg', '.png']
+
   ### Internal ###
+
+  Project = require 'project'
+  Project.registerOpener (path) =>
+    new ImageEditSession(path) if _.include(@imageExtensions, fsUtils.extension(path))
+
 
   @deserialize: (state) ->
     if fsUtils.exists(state.path)
@@ -26,19 +34,6 @@ class ImageEditSession
     require 'image-view'
 
   ### Public ###
-
-  # Identifies if a path can be opened by the image viewer.
-  #
-  # path - The {String} name of the path to check
-  #
-  # Returns a {Boolean}.
-  @canOpen: (path) ->
-    _.indexOf([
-      '.gif'
-      '.jpeg'
-      '.jpg'
-      '.png'
-    ], fsUtils.extension(path), true) >= 0
 
   # Retrieves the filename of the open file.
   #

--- a/src/app/project.coffee
+++ b/src/app/project.coffee
@@ -148,7 +148,7 @@ class Project
   # editSessionOptions - Options that you can pass to the `EditSession` constructor
   #
   # Returns either an {EditSession} (for text) or {ImageEditSession} (for images).
-  buildEditSession: (filePath, editSessionOptions={}) ->
+  open: (filePath, editSessionOptions={}) ->
     if ImageEditSession.canOpen(filePath)
       new ImageEditSession(filePath)
     else

--- a/src/app/project.coffee
+++ b/src/app/project.coffee
@@ -17,6 +17,14 @@ module.exports =
 class Project
   registerDeserializer(this)
 
+  @openers: []
+
+  @registerOpener: (opener) ->
+    @openers.push(opener)
+
+  @unregisterOpener: (opener) ->
+    _.remove(@openers, opener)
+
   tabLength: 2
   softTabs: true
   softWrap: false
@@ -148,11 +156,14 @@ class Project
   # editSessionOptions - Options that you can pass to the `EditSession` constructor
   #
   # Returns either an {EditSession} (for text) or {ImageEditSession} (for images).
-  open: (filePath, editSessionOptions={}) ->
+  open: (filePath, options={}) ->
+    for opener in @constructor.openers
+      return resource if resource = opener(filePath, options)
+
     if ImageEditSession.canOpen(filePath)
       new ImageEditSession(filePath)
     else
-      @buildEditSessionForBuffer(@bufferForPath(filePath), editSessionOptions)
+      @buildEditSessionForBuffer(@bufferForPath(filePath), options)
 
   # Retrieves all the {EditSession}s in the project; that is, the `EditSession`s for all open files.
   #

--- a/src/app/project.coffee
+++ b/src/app/project.coffee
@@ -111,14 +111,18 @@ class Project
   ignoreRepositoryPath: (path) ->
     config.get("core.hideGitIgnoredFiles") and git?.isPathIgnored(fsUtils.join(@getPath(), path))
 
-  # Given a path, this resolves it relative to the project directory.
+  # Given a uri, this resolves it relative to the project directory. If the path
+  # is already absolute or if it is prefixed with a scheme, it is returned unchanged.
   #
-  # filePath - The {String} name of the path to convert
+  # uri - The {String} name of the path to convert
   #
   # Returns a {String}.
-  resolve: (filePath) ->
-    filePath = fsUtils.join(@getPath(), filePath) unless filePath[0] == '/'
-    fsUtils.absolute filePath
+  resolve: (uri) ->
+    if uri?.match(/[A-Za-z0-9+-.]+:\/\//) # leave path alone if it has a scheme
+      uri
+    else
+      uri = fsUtils.join(@getPath(), uri) unless uri[0] == '/'
+      fsUtils.absolute uri
 
   # Given a path, this makes it relative to the project directory.
   #

--- a/src/app/project.coffee
+++ b/src/app/project.coffee
@@ -4,7 +4,6 @@ $ = require 'jquery'
 Range = require 'range'
 Buffer = require 'text-buffer'
 EditSession = require 'edit-session'
-ImageEditSession = require 'image-edit-session'
 EventEmitter = require 'event-emitter'
 Directory = require 'directory'
 BufferedProcess = require 'buffered-process'
@@ -160,10 +159,7 @@ class Project
     for opener in @constructor.openers
       return resource if resource = opener(filePath, options)
 
-    if ImageEditSession.canOpen(filePath)
-      new ImageEditSession(filePath)
-    else
-      @buildEditSessionForBuffer(@bufferForPath(filePath), options)
+    @buildEditSessionForBuffer(@bufferForPath(filePath), options)
 
   # Retrieves all the {EditSession}s in the project; that is, the `EditSession`s for all open files.
   #
@@ -311,3 +307,5 @@ class Project
       @on 'buffer-created', (buffer) -> callback(buffer)
 
 _.extend Project.prototype, EventEmitter
+
+require 'image-edit-session'

--- a/src/app/root-view.coffee
+++ b/src/app/root-view.coffee
@@ -109,10 +109,10 @@ class RootView extends View
     changeFocus = options.changeFocus ? true
     path = project.resolve(path) if path?
     if activePane = @getActivePane()
-      editSession = activePane.itemForUri(path) ? project.buildEditSession(path)
+      editSession = activePane.itemForUri(path) ? project.open(path)
       activePane.showItem(editSession)
     else
-      editSession = project.buildEditSession(path)
+      editSession = project.open(path)
       activePane = new Pane(editSession)
       @panes.append(activePane)
 

--- a/src/packages/autocomplete/spec/autocomplete-spec.coffee
+++ b/src/packages/autocomplete/spec/autocomplete-spec.coffee
@@ -40,7 +40,7 @@ describe "AutocompleteView", ->
 
   beforeEach ->
     window.rootView = new RootView
-    editor = new Editor(editSession: project.buildEditSession('sample.js'))
+    editor = new Editor(editSession: project.open('sample.js'))
     atom.activatePackage('autocomplete')
     autocomplete = new AutocompleteView(editor)
     miniEditor = autocomplete.miniEditor

--- a/src/packages/command-panel/spec/command-interpreter-spec.coffee
+++ b/src/packages/command-panel/spec/command-interpreter-spec.coffee
@@ -10,7 +10,7 @@ describe "CommandInterpreter", ->
 
   beforeEach ->
     interpreter = new CommandInterpreter(project)
-    editSession = project.buildEditSession('sample.js')
+    editSession = project.open('sample.js')
     buffer = editSession.buffer
 
   afterEach ->
@@ -445,7 +445,7 @@ describe "CommandInterpreter", ->
       runs ->
         expect(operationsToPreview.length).toBeGreaterThan 3
         for operation in operationsToPreview
-          editSession = project.buildEditSession(operation.getPath())
+          editSession = project.open(operation.getPath())
           editSession.setSelectedBufferRange(operation.execute(editSession))
           expect(editSession.getSelectedText()).toMatch /a+/
           editSession.destroy()

--- a/src/packages/fuzzy-finder/lib/fuzzy-finder-view.coffee
+++ b/src/packages/fuzzy-finder/lib/fuzzy-finder-view.coffee
@@ -69,7 +69,7 @@ class FuzzyFinderView extends SelectList
     path = @getSelectedElement()
     return unless path
     if pane = rootView.getActivePane()
-      fn(pane, project.buildEditSession(path))
+      fn(pane, project.open(path))
     else
       @openPath(path)
 

--- a/src/packages/tabs/spec/tabs-spec.coffee
+++ b/src/packages/tabs/spec/tabs-spec.coffee
@@ -36,7 +36,7 @@ describe "TabBarView", ->
     registerDeserializer(TestView)
     item1 = new TestView('Item 1')
     item2 = new TestView('Item 2')
-    editSession1 = project.buildEditSession('sample.js')
+    editSession1 = project.open('sample.js')
     paneContainer = new PaneContainer
     pane = new Pane(item1, editSession1, item2)
     pane.showItem(item2)
@@ -77,7 +77,7 @@ describe "TabBarView", ->
       expect(tabBar.tabAtIndex(1).find('.title')).toHaveText 'Item 3'
 
     it "adds the 'modified' class to the new tab if the item is initially modified", ->
-      editSession2 = project.buildEditSession('sample.txt')
+      editSession2 = project.open('sample.txt')
       editSession2.insertText('x')
       pane.showItem(editSession2)
       expect(tabBar.tabForItem(editSession2)).toHaveClass 'modified'


### PR DESCRIPTION
Originally, `Project.open` only ever returned `EditSession`s. Now, we also return `ImageEditSession`s if you're opening a path that ends with an image file extension. In my rework of @mutle's terminal package, I want to be able to call `rootView.open("terminal://~")` to open a terminal with `~` as its working directory using the same mechanism that I use to open anything else. This makes it possible:

To register a custom opener, call `Project.registerOpener(fn)` with a function that takes a `uri`a and an optional `options` hash as parameters. Whenever anything is opened, the project will attempt all openers in the order they are registered. If your function returns a resource, it will short-circuit the opening process and `Project.open` will return it.

You can also call `Project.unregisterOpener(fn)` with the same function to unregister it, which you should do upon deactivation of your package.
