### PR TITLE
Remove blank options in renderMarkdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "plist": "git://github.com/nathansobo/node-plist.git",
     "space-pen": "1.0.0",
     "less": "git://github.com/nathansobo/less.js.git",
-    "roaster": "0.0.4",
+    "roaster": "0.0.5",
     "jqueryui-browser": "1.10.2-1",
     "season": "0.7.0",
     "humanize-plus": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "plist": "git://github.com/nathansobo/node-plist.git",
     "space-pen": "1.0.0",
     "less": "git://github.com/nathansobo/less.js.git",
-    "roaster": "0.0.3",
+    "roaster": "0.0.4",
     "jqueryui-browser": "1.10.2-1",
     "season": "0.7.0",
     "humanize-plus": "1.1.0"

--- a/src/packages/markdown-preview/lib/markdown-preview-view.coffee
+++ b/src/packages/markdown-preview/lib/markdown-preview-view.coffee
@@ -95,7 +95,7 @@ class MarkdownPreviewView extends ScrollView
 
   renderMarkdown: ->
     @setLoading()
-    roaster @buffer.getText(), {}, (err, html) =>
+    roaster @buffer.getText(), (err, html) =>
       if err
         @setErrorHtml(err)
       else


### PR DESCRIPTION
From https://github.com/gjtorikian/roaster/issues/1

Roaster was updated to properly handle a null `options` argument.
