### PR TITLE
Add proper indents to comments on toggle-line-comments Closes #615

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed: Using toggle comment shortcut respects indentation level
+
 * Fixed: Search never completing in the command panel
 
 * Fixed: cmd-n now works when no windows are open

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -1717,10 +1717,10 @@ describe "EditSession", ->
         editSession.setSelectedBufferRange([[4, 5], [7, 5]])
         editSession.toggleLineCommentsInSelection()
 
-        expect(buffer.lineForRow(4)).toBe "//     while(items.length > 0) {"
-        expect(buffer.lineForRow(5)).toBe "//       current = items.shift();"
-        expect(buffer.lineForRow(6)).toBe "//       current < pivot ? left.push(current) : right.push(current);"
-        expect(buffer.lineForRow(7)).toBe "//     }"
+        expect(buffer.lineForRow(4)).toBe "    // while(items.length > 0) {"
+        expect(buffer.lineForRow(5)).toBe "    //   current = items.shift();"
+        expect(buffer.lineForRow(6)).toBe "    //   current < pivot ? left.push(current) : right.push(current);"
+        expect(buffer.lineForRow(7)).toBe "    // }"
         expect(editSession.getSelectedBufferRange()).toEqual [[4, 8], [7, 8]]
 
         editSession.toggleLineCommentsInSelection()
@@ -1732,9 +1732,9 @@ describe "EditSession", ->
       it "does not comment the last line of a non-empty selection if it ends at column 0", ->
         editSession.setSelectedBufferRange([[4, 5], [7, 0]])
         editSession.toggleLineCommentsInSelection()
-        expect(buffer.lineForRow(4)).toBe "//     while(items.length > 0) {"
-        expect(buffer.lineForRow(5)).toBe "//       current = items.shift();"
-        expect(buffer.lineForRow(6)).toBe "//       current < pivot ? left.push(current) : right.push(current);"
+        expect(buffer.lineForRow(4)).toBe "    // while(items.length > 0) {"
+        expect(buffer.lineForRow(5)).toBe "    //   current = items.shift();"
+        expect(buffer.lineForRow(6)).toBe "    //   current < pivot ? left.push(current) : right.push(current);"
         expect(buffer.lineForRow(7)).toBe "    }"
 
       it "uncomments lines if all lines match the comment regex", ->

--- a/spec/app/language-mode-spec.coffee
+++ b/spec/app/language-mode-spec.coffee
@@ -15,10 +15,11 @@ fdescribe "LanguageMode", ->
       {buffer, languageMode} = editSession
 
     describe ".minIndentLevelForRowRange(startRow, endRow)", ->
-      it "returns indent levels for ranges", ->
+      it "returns the minimum indent level for the given row range", ->
         expect(languageMode.minIndentLevelForRowRange(4, 7)).toBe 2
         expect(languageMode.minIndentLevelForRowRange(5, 7)).toBe 2
         expect(languageMode.minIndentLevelForRowRange(5, 6)).toBe 3
+        expect(languageMode.minIndentLevelForRowRange(9, 11)).toBe 1
 
     describe ".toggleLineCommentsForBufferRows(start, end)", ->
       it "comments/uncomments lines in the given range", ->
@@ -61,11 +62,6 @@ fdescribe "LanguageMode", ->
       atom.activatePackage('coffee-script-tmbundle', sync: true)
       editSession = project.open('coffee.coffee', autoIndent: false)
       {buffer, languageMode} = editSession
-
-    describe ".minIndentLevelForRowRange(startRow, endRow)", ->
-      it "returns indent levels for ranges", ->
-        expect(languageMode.minIndentLevelForRowRange(4, 6)).toBe 2
-        expect(languageMode.minIndentLevelForRowRange(4, 7)).toBe 2
 
     describe ".toggleLineCommentsForBufferRows(start, end)", ->
       it "comments/uncomments lines in the given range", ->

--- a/spec/app/language-mode-spec.coffee
+++ b/spec/app/language-mode-spec.coffee
@@ -20,6 +20,7 @@ describe "LanguageMode", ->
         expect(languageMode.minIndentLevelForRowRange(5, 7)).toBe 2
         expect(languageMode.minIndentLevelForRowRange(5, 6)).toBe 3
         expect(languageMode.minIndentLevelForRowRange(9, 11)).toBe 1
+        expect(languageMode.minIndentLevelForRowRange(10, 10)).toBe 0
 
     describe ".toggleLineCommentsForBufferRows(start, end)", ->
       it "comments/uncomments lines in the given range", ->

--- a/spec/app/language-mode-spec.coffee
+++ b/spec/app/language-mode-spec.coffee
@@ -2,7 +2,7 @@ Project = require 'project'
 Buffer = require 'text-buffer'
 EditSession = require 'edit-session'
 
-fdescribe "LanguageMode", ->
+describe "LanguageMode", ->
   [editSession, buffer, languageMode] = []
 
   afterEach ->

--- a/spec/app/language-mode-spec.coffee
+++ b/spec/app/language-mode-spec.coffee
@@ -2,7 +2,7 @@ Project = require 'project'
 Buffer = require 'text-buffer'
 EditSession = require 'edit-session'
 
-describe "LanguageMode", ->
+fdescribe "LanguageMode", ->
   [editSession, buffer, languageMode] = []
 
   afterEach ->
@@ -14,11 +14,11 @@ describe "LanguageMode", ->
       editSession = project.open('sample.js', autoIndent: false)
       {buffer, languageMode} = editSession
 
-    describe ".calcMinIndent(startRow, endRow)", ->
+    describe ".minIndentLevelForRowRange(startRow, endRow)", ->
       it "returns indent levels for ranges", ->
-        expect(languageMode.calcMinIndent(4, 7)).toBe 2
-        expect(languageMode.calcMinIndent(5, 7)).toBe 2
-        expect(languageMode.calcMinIndent(5, 6)).toBe 3
+        expect(languageMode.minIndentLevelForRowRange(4, 7)).toBe 2
+        expect(languageMode.minIndentLevelForRowRange(5, 7)).toBe 2
+        expect(languageMode.minIndentLevelForRowRange(5, 6)).toBe 3
 
     describe ".toggleLineCommentsForBufferRows(start, end)", ->
       it "comments/uncomments lines in the given range", ->
@@ -62,10 +62,10 @@ describe "LanguageMode", ->
       editSession = project.open('coffee.coffee', autoIndent: false)
       {buffer, languageMode} = editSession
 
-    describe ".calcMinIndent(startRow, endRow)", ->
+    describe ".minIndentLevelForRowRange(startRow, endRow)", ->
       it "returns indent levels for ranges", ->
-        expect(languageMode.calcMinIndent(4, 6)).toBe 2
-        expect(languageMode.calcMinIndent(4, 7)).toBe 2
+        expect(languageMode.minIndentLevelForRowRange(4, 6)).toBe 2
+        expect(languageMode.minIndentLevelForRowRange(4, 7)).toBe 2
 
     describe ".toggleLineCommentsForBufferRows(start, end)", ->
       it "comments/uncomments lines in the given range", ->

--- a/spec/app/language-mode-spec.coffee
+++ b/spec/app/language-mode-spec.coffee
@@ -14,19 +14,25 @@ describe "LanguageMode", ->
       editSession = project.open('sample.js', autoIndent: false)
       {buffer, languageMode} = editSession
 
+    describe ".calcMinIndent(startRow, endRow)", ->
+      it "returns indent levels for ranges", ->
+        expect(languageMode.calcMinIndent(4, 7)).toBe 2
+        expect(languageMode.calcMinIndent(5, 7)).toBe 2
+        expect(languageMode.calcMinIndent(5, 6)).toBe 3
+
     describe ".toggleLineCommentsForBufferRows(start, end)", ->
       it "comments/uncomments lines in the given range", ->
         languageMode.toggleLineCommentsForBufferRows(4, 7)
-        expect(buffer.lineForRow(4)).toBe "//     while(items.length > 0) {"
-        expect(buffer.lineForRow(5)).toBe "//       current = items.shift();"
-        expect(buffer.lineForRow(6)).toBe "//       current < pivot ? left.push(current) : right.push(current);"
-        expect(buffer.lineForRow(7)).toBe "//     }"
+        expect(buffer.lineForRow(4)).toBe "    // while(items.length > 0) {"
+        expect(buffer.lineForRow(5)).toBe "    //   current = items.shift();"
+        expect(buffer.lineForRow(6)).toBe "    //   current < pivot ? left.push(current) : right.push(current);"
+        expect(buffer.lineForRow(7)).toBe "    // }"
 
         languageMode.toggleLineCommentsForBufferRows(4, 5)
         expect(buffer.lineForRow(4)).toBe "    while(items.length > 0) {"
         expect(buffer.lineForRow(5)).toBe "      current = items.shift();"
-        expect(buffer.lineForRow(6)).toBe "//       current < pivot ? left.push(current) : right.push(current);"
-        expect(buffer.lineForRow(7)).toBe "//     }"
+        expect(buffer.lineForRow(6)).toBe "    //   current < pivot ? left.push(current) : right.push(current);"
+        expect(buffer.lineForRow(7)).toBe "    // }"
 
     describe "fold suggestion", ->
       describe ".doesBufferRowStartFold(bufferRow)", ->
@@ -56,19 +62,35 @@ describe "LanguageMode", ->
       editSession = project.open('coffee.coffee', autoIndent: false)
       {buffer, languageMode} = editSession
 
+    describe ".calcMinIndent(startRow, endRow)", ->
+      it "returns indent levels for ranges", ->
+        expect(languageMode.calcMinIndent(4, 6)).toBe 2
+        expect(languageMode.calcMinIndent(4, 7)).toBe 2
+
     describe ".toggleLineCommentsForBufferRows(start, end)", ->
       it "comments/uncomments lines in the given range", ->
-        languageMode.toggleLineCommentsForBufferRows(4, 7)
-        expect(buffer.lineForRow(4)).toBe "#     pivot = items.shift()"
-        expect(buffer.lineForRow(5)).toBe "#     left = []"
-        expect(buffer.lineForRow(6)).toBe "#     right = []"
-        expect(buffer.lineForRow(7)).toBe "# "
+        languageMode.toggleLineCommentsForBufferRows(4, 6)
+        expect(buffer.lineForRow(4)).toBe "    # pivot = items.shift()"
+        expect(buffer.lineForRow(5)).toBe "    # left = []"
+        expect(buffer.lineForRow(6)).toBe "    # right = []"
 
         languageMode.toggleLineCommentsForBufferRows(4, 5)
         expect(buffer.lineForRow(4)).toBe "    pivot = items.shift()"
         expect(buffer.lineForRow(5)).toBe "    left = []"
-        expect(buffer.lineForRow(6)).toBe "#     right = []"
-        expect(buffer.lineForRow(7)).toBe "# "
+        expect(buffer.lineForRow(6)).toBe "    # right = []"
+
+      it "comments/uncomments lines when empty line", ->
+        languageMode.toggleLineCommentsForBufferRows(4, 7)
+        expect(buffer.lineForRow(4)).toBe "    # pivot = items.shift()"
+        expect(buffer.lineForRow(5)).toBe "    # left = []"
+        expect(buffer.lineForRow(6)).toBe "    # right = []"
+        expect(buffer.lineForRow(7)).toBe "    # "
+
+        languageMode.toggleLineCommentsForBufferRows(4, 5)
+        expect(buffer.lineForRow(4)).toBe "    pivot = items.shift()"
+        expect(buffer.lineForRow(5)).toBe "    left = []"
+        expect(buffer.lineForRow(6)).toBe "    # right = []"
+        expect(buffer.lineForRow(7)).toBe "    # "
 
     describe "fold suggestion", ->
       describe ".doesBufferRowStartFold(bufferRow)", ->

--- a/src/app/language-mode.coffee
+++ b/src/app/language-mode.coffee
@@ -189,8 +189,7 @@ class LanguageMode
   #
   # Returns a {Number} of the indent level of the block of lines.
   minIndentLevelForRowRange: (startRow, endRow) ->
-    buffer = @editSession.buffer
-    indents = (@editSession.indentationForBufferRow(row) for row in [startRow..endRow] when buffer.lineForRow(row).trim())
+    indents = (@editSession.indentationForBufferRow(row) for row in [startRow..endRow] when @editSession.lineForBufferRow(row).trim())
     Math.min(indents...)
 
   # Indents all the rows between two buffer row numbers.

--- a/src/app/language-mode.coffee
+++ b/src/app/language-mode.coffee
@@ -81,8 +81,10 @@ class LanguageMode
             columnEnd = columnStart + match[2].length
             buffer.change([[row, columnStart], [row, columnEnd]], "")
       else
+        indent = @calcMinIndent(start, end)
+        indentString = @editSession.buildIndentString(indent)
         for row in [start..end]
-          buffer.insert([row, 0], commentStartString)
+          buffer.change(new Range([row, 0], [row, indentString.length]), indentString+commentStartString)
 
   # Folds all the foldable lines in the buffer.
   foldAll: ->
@@ -179,6 +181,17 @@ class LanguageMode
     desiredIndentLevel -= 1 if decreaseIndentRegex.test(currentLine)
 
     desiredIndentLevel
+
+  # Calculate a minimum indent level for a range of lines.
+  #
+  # startRow - The row {Number} to start at
+  # endRow - The row {Number} to end at
+  #
+  # Returns a {Number} of the indent level of the block of lines.
+  calcMinIndent: (startRow, endRow) ->
+    buffer = @editSession.buffer
+    indents = (@editSession.indentationForBufferRow(row) for row in [startRow..endRow] when buffer.lineForRow(row).trim())
+    Math.min(indents...)
 
   # Indents all the rows between two buffer row numbers.
   #

--- a/src/app/language-mode.coffee
+++ b/src/app/language-mode.coffee
@@ -81,7 +81,7 @@ class LanguageMode
             columnEnd = columnStart + match[2].length
             buffer.change([[row, columnStart], [row, columnEnd]], "")
       else
-        indent = @calcMinIndent(start, end)
+        indent = @minIndentLevelForRowRange(start, end)
         indentString = @editSession.buildIndentString(indent)
         for row in [start..end]
           buffer.change(new Range([row, 0], [row, indentString.length]), indentString+commentStartString)
@@ -188,7 +188,7 @@ class LanguageMode
   # endRow - The row {Number} to end at
   #
   # Returns a {Number} of the indent level of the block of lines.
-  calcMinIndent: (startRow, endRow) ->
+  minIndentLevelForRowRange: (startRow, endRow) ->
     buffer = @editSession.buffer
     indents = (@editSession.indentationForBufferRow(row) for row in [startRow..endRow] when buffer.lineForRow(row).trim())
     Math.min(indents...)

--- a/src/app/language-mode.coffee
+++ b/src/app/language-mode.coffee
@@ -182,7 +182,7 @@ class LanguageMode
 
     desiredIndentLevel
 
-  # Calculate a minimum indent level for a range of lines.
+  # Calculate a minimum indent level for a range of lines excluding empty lines.
   #
   # startRow - The row {Number} to start at
   # endRow - The row {Number} to end at

--- a/src/app/language-mode.coffee
+++ b/src/app/language-mode.coffee
@@ -190,7 +190,8 @@ class LanguageMode
   # Returns a {Number} of the indent level of the block of lines.
   minIndentLevelForRowRange: (startRow, endRow) ->
     indents = (@editSession.indentationForBufferRow(row) for row in [startRow..endRow] when @editSession.lineForBufferRow(row).trim())
-    Math.min(indents...)
+    min = Math.min(indents...)
+    if min == Infinity then 0 else min
 
   # Indents all the rows between two buffer row numbers.
   #

--- a/src/app/language-mode.coffee
+++ b/src/app/language-mode.coffee
@@ -84,7 +84,7 @@ class LanguageMode
         indent = @minIndentLevelForRowRange(start, end)
         indentString = @editSession.buildIndentString(indent)
         for row in [start..end]
-          buffer.change([[row, 0], [row, indentString.length]], indentString+commentStartString)
+          buffer.change([[row, 0], [row, indentString.length]], indentString + commentStartString)
 
   # Folds all the foldable lines in the buffer.
   foldAll: ->

--- a/src/app/language-mode.coffee
+++ b/src/app/language-mode.coffee
@@ -189,9 +189,9 @@ class LanguageMode
   #
   # Returns a {Number} of the indent level of the block of lines.
   minIndentLevelForRowRange: (startRow, endRow) ->
-    indents = (@editSession.indentationForBufferRow(row) for row in [startRow..endRow] when @editSession.lineForBufferRow(row).trim())
-    min = Math.min(indents...)
-    if min == Infinity then 0 else min
+    indents = (@editSession.indentationForBufferRow(row) for row in [startRow..endRow] when not @editSession.isBufferRowBlank(row))
+    indents = [0] unless indents.length
+    Math.min(indents...)
 
   # Indents all the rows between two buffer row numbers.
   #

--- a/src/app/language-mode.coffee
+++ b/src/app/language-mode.coffee
@@ -84,7 +84,7 @@ class LanguageMode
         indent = @minIndentLevelForRowRange(start, end)
         indentString = @editSession.buildIndentString(indent)
         for row in [start..end]
-          buffer.change(new Range([row, 0], [row, indentString.length]), indentString+commentStartString)
+          buffer.change([[row, 0], [row, indentString.length]], indentString+commentStartString)
 
   # Folds all the foldable lines in the buffer.
   foldAll: ->


### PR DESCRIPTION
``` coffeescript
class Something
  whatev: (items) ->
    while items.length > 0
      # current = items.shift()
      # if current < pivot
      #   left.push(current)
      # else
      #   right.push(current);
```

Rather than

``` coffeescript
class Something
  whatev: (items) ->
    while items.length > 0
#       current = items.shift()
#       if current < pivot
#         left.push(current)
#       else
#         right.push(current);
```
