### PR TITLE
Create a user's package directory if missing

### DIFF
--- a/spec/app/config-spec.coffee
+++ b/spec/app/config-spec.coffee
@@ -183,6 +183,20 @@ describe "Config", ->
           expect(fsUtils.exists(path.join(config.configDirPath, 'themes'))).toBeTruthy()
           expect(fsUtils.isFileSync(path.join(config.configDirPath, 'config.cson'))).toBeTruthy()
 
+  describe ".initializePackageDirectory()", ->
+    beforeEach ->
+      config.configDirPath = '/tmp/dot-atom-dir'
+      config.userPackagesDirPath = '/tmp/dot-atom-dir/packages'
+      expect(fsUtils.exists(config.configDirPath)).toBeFalsy()
+
+    afterEach ->
+      fsUtils.remove('/tmp/dot-atom-dir') if fsUtils.exists('/tmp/dot-atom-dir')
+
+    describe "when the userPackagesDirPath doesn't exist", ->
+      it "creates it", ->
+        config.initializePackageDirectory()
+        expect(fsUtils.exists(config.userPackagesDirPath)).toBeTruthy()
+
   describe ".loadUserConfig()", ->
     beforeEach ->
       config.configDirPath = '/tmp/dot-atom-dir'

--- a/src/app/config.coffee
+++ b/src/app/config.coffee
@@ -60,8 +60,13 @@ class Config
       queue.push({sourcePath, destinationPath})
     fsUtils.traverseTree(templateConfigDirPath, onConfigDirFile, (path) -> true)
 
+  initializePackageDirectory: ->
+    return if fsUtils.exists(@userPackagesDirPath)
+    fsUtils.makeTree(@userPackagesDirPath)
+
   load: ->
     @initializeConfigDirectory()
+    @initializePackageDirectory()
     @loadUserConfig()
     @observeUserConfig()
 


### PR DESCRIPTION
This now makes sure that new users can install packages (as if the directory is missing, packages won't install).

@probablycorey @nathansobo feedback appreciated.
