### PR TITLE
Add editor:select-to-first-character-of-line command

### DIFF
--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -703,6 +703,31 @@ describe "EditSession", ->
           editSession.selectWord()
           expect(editSession.getSelectedBufferRange()).toEqual [[12, 2], [12, 6]]
 
+    describe ".selectToFirstCharacterOfLine()", ->
+      it "moves to the first character of the current line or the beginning of the line if it's already on the first character", ->
+        editSession.setCursorScreenPosition [0,5]
+        editSession.addCursorAtScreenPosition [1,7]
+
+        editSession.selectToFirstCharacterOfLine()
+
+        [cursor1, cursor2] = editSession.getCursors()
+        expect(cursor1.getBufferPosition()).toEqual [0,0]
+        expect(cursor2.getBufferPosition()).toEqual [1,2]
+
+        expect(editSession.getSelections().length).toBe 2
+        [selection1, selection2] = editSession.getSelections()
+        expect(selection1.getBufferRange()).toEqual [[0,0], [0,5]]
+        expect(selection1.isReversed()).toBeTruthy()
+        expect(selection2.getBufferRange()).toEqual [[1,2], [1,7]]
+        expect(selection2.isReversed()).toBeTruthy()
+
+        editSession.selectToFirstCharacterOfLine()
+        [selection1, selection2] = editSession.getSelections()
+        expect(selection1.getBufferRange()).toEqual [[0,0], [0,5]]
+        expect(selection1.isReversed()).toBeTruthy()
+        expect(selection2.getBufferRange()).toEqual [[1,0], [1,7]]
+        expect(selection2.isReversed()).toBeTruthy()
+
     describe ".setSelectedBufferRanges(ranges)", ->
       it "clears existing selections and creates selections for each of the given ranges", ->
         editSession.setSelectedBufferRanges([[[2, 2], [3, 3]], [[4, 4], [5, 5]]])

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -1146,7 +1146,7 @@ class EditSession
   selectToBeginningOfLine: ->
     @expandSelectionsBackward (selection) => selection.selectToBeginningOfLine()
 
-  # Moves every cursor to the first non-whitespace character of the line.
+  # Selects to the first non-whitespace character of the line.
   selectToFirstCharacterOfLine: ->
     @expandSelectionsBackward (selection) => selection.selectToFirstCharacterOfLine()
 

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -1146,6 +1146,10 @@ class EditSession
   selectToBeginningOfLine: ->
     @expandSelectionsBackward (selection) => selection.selectToBeginningOfLine()
 
+  # Moves every cursor to the first non-whitespace character of the line.
+  selectToFirstCharacterOfLine: ->
+    @expandSelectionsBackward (selection) => selection.selectToFirstCharacterOfLine()
+
   # Selects all the text from the current cursor position to the end of the line.
   selectToEndOfLine: ->
     @expandSelectionsForward (selection) => selection.selectToEndOfLine()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -146,6 +146,7 @@ class Editor extends View
       'editor:select-to-end-of-word': @selectToEndOfWord
       'editor:select-to-beginning-of-word': @selectToBeginningOfWord
       'editor:select-to-beginning-of-next-word': @selectToBeginningOfNextWord
+      'editor:select-to-first-character-of-line': @selectToFirstCharacterOfLine
       'editor:add-selection-below': @addSelectionBelow
       'editor:add-selection-above': @addSelectionAbove
       'editor:select-line': @selectLine
@@ -326,6 +327,9 @@ class Editor extends View
 
   # {Delegates to: EditSession.selectToBeginningOfLine}
   selectToBeginningOfLine: -> @activeEditSession.selectToBeginningOfLine()
+
+  # {Delegates to: EditSession.selectToFirstCharacterOfLine}
+  selectToFirstCharacterOfLine: -> @activeEditSession.selectToFirstCharacterOfLine()
 
   # {Delegates to: EditSession.selectToEndOfLine}
   selectToEndOfLine: -> @activeEditSession.selectToEndOfLine()

--- a/src/app/selection.coffee
+++ b/src/app/selection.coffee
@@ -198,7 +198,7 @@ class Selection
   selectToBeginningOfLine: ->
     @modifySelection => @cursor.moveToBeginningOfLine()
 
-  # Selects all the text from the current cursor position to the beginning of the line.
+  # Selects all the text from the current cursor position to the first character of the line.
   selectToFirstCharacterOfLine: ->
     @modifySelection => @cursor.moveToFirstCharacterOfLine()
 

--- a/src/app/selection.coffee
+++ b/src/app/selection.coffee
@@ -198,6 +198,10 @@ class Selection
   selectToBeginningOfLine: ->
     @modifySelection => @cursor.moveToBeginningOfLine()
 
+  # Selects all the text from the current cursor position to the beginning of the line.
+  selectToFirstCharacterOfLine: ->
+    @modifySelection => @cursor.moveToFirstCharacterOfLine()
+
   # Selects all the text from the current cursor position to the end of the line.
   selectToEndOfLine: ->
     @modifySelection => @cursor.moveToEndOfLine()


### PR DESCRIPTION
There was a `editor:move-to-first-character-of-line` but no corresponding `editor:select-to-first-character-of-line` command. This adds the select command.
