### PR TITLE
Fix scrollbar css issues

### DIFF
--- a/src/packages/tree-view/stylesheets/tree-view.less
+++ b/src/packages/tree-view/stylesheets/tree-view.less
@@ -13,7 +13,7 @@
   .tree-view-resize-handle {
     position: absolute;
     top: 0;
-    right: 0;
+    right: -5px;
     bottom: 0;
     width: 10px;
     cursor: col-resize;

--- a/static/editor.less
+++ b/static/editor.less
@@ -98,7 +98,7 @@
   bottom: 0;
   width: 15px;
   overflow-y: auto;
-  z-index: 1;
+  z-index: 3;
 }
 
 .editor .scroll-view {


### PR DESCRIPTION
I whined about them in #640. 
- [x] the treeview resize handle covers the scrollbar
- [x] the scrollbar in the editor is covered up
