### PR TITLE
Add new commands for moving between words

### DIFF
--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -313,30 +313,30 @@ describe "EditSession", ->
         editSession.moveCursorToBeginningOfWord()
         expect(editSession.getCursorBufferPosition()).toEqual [9, 2]
 
-    describe ".moveCursorToPreviousWordBoundry()", ->
-      it "moves the cursor to the previous word boundry", ->
+    describe ".moveCursorToPreviousWordBoundary()", ->
+      it "moves the cursor to the previous word boundary", ->
         editSession.setCursorBufferPosition [0, 8]
         editSession.addCursorAtBufferPosition [2, 0]
         editSession.addCursorAtBufferPosition [2, 4]
         editSession.addCursorAtBufferPosition [3, 14]
         [cursor1, cursor2, cursor3, cursor4] = editSession.getCursors()
 
-        editSession.moveCursorToPreviousWordBoundry()
+        editSession.moveCursorToPreviousWordBoundary()
 
         expect(cursor1.getBufferPosition()).toEqual [0, 4]
         expect(cursor2.getBufferPosition()).toEqual [1, 30]
         expect(cursor3.getBufferPosition()).toEqual [2, 0]
         expect(cursor4.getBufferPosition()).toEqual [3, 13]
 
-    describe ".moveCursorToNextWordBoundry()", ->
-      it "moves the cursor to the previous word boundry", ->
+    describe ".moveCursorToNextWordBoundary()", ->
+      it "moves the cursor to the previous word boundary", ->
         editSession.setCursorBufferPosition [0, 8]
         editSession.addCursorAtBufferPosition [2, 40]
         editSession.addCursorAtBufferPosition [3, 0]
         editSession.addCursorAtBufferPosition [3, 30]
         [cursor1, cursor2, cursor3, cursor4] = editSession.getCursors()
 
-        editSession.moveCursorToNextWordBoundry()
+        editSession.moveCursorToNextWordBoundary()
 
         expect(cursor1.getBufferPosition()).toEqual [0, 13]
         expect(cursor2.getBufferPosition()).toEqual [3, 0]
@@ -698,14 +698,14 @@ describe "EditSession", ->
         expect(selection2.getBufferRange()).toEqual [[3,48], [3,51]]
         expect(selection2.isReversed()).toBeFalsy()
 
-    describe ".selectToPreviousWordBoundry()", ->
-      it "select to the previous word boundry", ->
+    describe ".selectToPreviousWordBoundary()", ->
+      it "select to the previous word boundary", ->
         editSession.setCursorBufferPosition [0, 8]
         editSession.addCursorAtBufferPosition [2, 0]
         editSession.addCursorAtBufferPosition [3, 4]
         editSession.addCursorAtBufferPosition [3, 14]
 
-        editSession.selectToPreviousWordBoundry()
+        editSession.selectToPreviousWordBoundary()
 
         expect(editSession.getSelections().length).toBe 4
         [selection1, selection2, selection3, selection4] = editSession.getSelections()
@@ -718,14 +718,14 @@ describe "EditSession", ->
         expect(selection4.getBufferRange()).toEqual [[3,14], [3,13]]
         expect(selection4.isReversed()).toBeTruthy()
 
-    describe ".selectToNextWordBoundry()", ->
-      it "select to the next word boundry", ->
+    describe ".selectToNextWordBoundary()", ->
+      it "select to the next word boundary", ->
         editSession.setCursorBufferPosition [0, 8]
         editSession.addCursorAtBufferPosition [2, 40]
         editSession.addCursorAtBufferPosition [4, 0]
         editSession.addCursorAtBufferPosition [3, 30]
 
-        editSession.selectToNextWordBoundry()
+        editSession.selectToNextWordBoundary()
 
         expect(editSession.getSelections().length).toBe 4
         [selection1, selection2, selection3, selection4] = editSession.getSelections()

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -313,7 +313,7 @@ describe "EditSession", ->
         editSession.moveCursorToBeginningOfWord()
         expect(editSession.getCursorBufferPosition()).toEqual [9, 2]
 
-    fdescribe ".moveCursorToPreviousWordBoundry()", ->
+    describe ".moveCursorToPreviousWordBoundry()", ->
       it "moves the cursor to the previous word boundry", ->
         editSession.setCursorBufferPosition [0, 8]
         editSession.addCursorAtBufferPosition [2, 0]
@@ -327,6 +327,21 @@ describe "EditSession", ->
         expect(cursor2.getBufferPosition()).toEqual [1, 30]
         expect(cursor3.getBufferPosition()).toEqual [2, 0]
         expect(cursor4.getBufferPosition()).toEqual [3, 13]
+
+    describe ".moveCursorToNextWordBoundry()", ->
+      it "moves the cursor to the previous word boundry", ->
+        editSession.setCursorBufferPosition [0, 8]
+        editSession.addCursorAtBufferPosition [2, 40]
+        editSession.addCursorAtBufferPosition [3, 0]
+        editSession.addCursorAtBufferPosition [3, 30]
+        [cursor1, cursor2, cursor3, cursor4] = editSession.getCursors()
+
+        editSession.moveCursorToNextWordBoundry()
+
+        expect(cursor1.getBufferPosition()).toEqual [0, 13]
+        expect(cursor2.getBufferPosition()).toEqual [3, 0]
+        expect(cursor3.getBufferPosition()).toEqual [3, 4]
+        expect(cursor4.getBufferPosition()).toEqual [3, 31]
 
     describe ".moveCursorToEndOfWord()", ->
       it "moves the cursor to the end of the word", ->

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -698,6 +698,46 @@ describe "EditSession", ->
         expect(selection2.getBufferRange()).toEqual [[3,48], [3,51]]
         expect(selection2.isReversed()).toBeFalsy()
 
+    describe ".selectToPreviousWordBoundry()", ->
+      it "select to the previous word boundry", ->
+        editSession.setCursorBufferPosition [0, 8]
+        editSession.addCursorAtBufferPosition [2, 0]
+        editSession.addCursorAtBufferPosition [3, 4]
+        editSession.addCursorAtBufferPosition [3, 14]
+
+        editSession.selectToPreviousWordBoundry()
+
+        expect(editSession.getSelections().length).toBe 4
+        [selection1, selection2, selection3, selection4] = editSession.getSelections()
+        expect(selection1.getBufferRange()).toEqual [[0,8], [0,4]]
+        expect(selection1.isReversed()).toBeTruthy()
+        expect(selection2.getBufferRange()).toEqual [[2,0], [1,30]]
+        expect(selection2.isReversed()).toBeTruthy()
+        expect(selection3.getBufferRange()).toEqual [[3,4], [3,0]]
+        expect(selection3.isReversed()).toBeTruthy()
+        expect(selection4.getBufferRange()).toEqual [[3,14], [3,13]]
+        expect(selection4.isReversed()).toBeTruthy()
+
+    describe ".selectToNextWordBoundry()", ->
+      it "select to the next word boundry", ->
+        editSession.setCursorBufferPosition [0, 8]
+        editSession.addCursorAtBufferPosition [2, 40]
+        editSession.addCursorAtBufferPosition [4, 0]
+        editSession.addCursorAtBufferPosition [3, 30]
+
+        editSession.selectToNextWordBoundry()
+
+        expect(editSession.getSelections().length).toBe 4
+        [selection1, selection2, selection3, selection4] = editSession.getSelections()
+        expect(selection1.getBufferRange()).toEqual [[0,8], [0,13]]
+        expect(selection1.isReversed()).toBeFalsy()
+        expect(selection2.getBufferRange()).toEqual [[2,40], [3,0]]
+        expect(selection2.isReversed()).toBeFalsy()
+        expect(selection3.getBufferRange()).toEqual [[4,0], [4,4]]
+        expect(selection3.isReversed()).toBeFalsy()
+        expect(selection4.getBufferRange()).toEqual [[3,30], [3,31]]
+        expect(selection4.isReversed()).toBeFalsy()
+
     describe ".selectWord()", ->
       describe "when the cursor is inside a word", ->
         it "selects the entire word", ->

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -313,6 +313,21 @@ describe "EditSession", ->
         editSession.moveCursorToBeginningOfWord()
         expect(editSession.getCursorBufferPosition()).toEqual [9, 2]
 
+    fdescribe ".moveCursorToPreviousWordBoundry()", ->
+      it "moves the cursor to the previous word boundry", ->
+        editSession.setCursorBufferPosition [0, 8]
+        editSession.addCursorAtBufferPosition [2, 0]
+        editSession.addCursorAtBufferPosition [2, 4]
+        editSession.addCursorAtBufferPosition [3, 14]
+        [cursor1, cursor2, cursor3, cursor4] = editSession.getCursors()
+
+        editSession.moveCursorToPreviousWordBoundry()
+
+        expect(cursor1.getBufferPosition()).toEqual [0, 4]
+        expect(cursor2.getBufferPosition()).toEqual [1, 30]
+        expect(cursor3.getBufferPosition()).toEqual [2, 0]
+        expect(cursor4.getBufferPosition()).toEqual [3, 13]
+
     describe ".moveCursorToEndOfWord()", ->
       it "moves the cursor to the end of the word", ->
         editSession.setCursorBufferPosition [0, 6]

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -244,14 +244,14 @@ class Cursor
     if position = @getBeginningOfNextWordBufferPosition()
       @setBufferPosition(position)
 
-  # Moves the cursor to the previous word boundry.
-  moveToPreviousWordBoundry: ->
-    if position = @getMovePreviousWordBoundryBufferPosition()
+  # Moves the cursor to the previous word boundary.
+  moveToPreviousWordBoundary: ->
+    if position = @getMovePreviousWordBoundaryBufferPosition()
       @setBufferPosition(position)
 
-  # Moves the cursor to the next word boundry.
-  moveToNextWordBoundry: ->
-    if position = @getMoveNextWordBoundryBufferPosition()
+  # Moves the cursor to the next word boundary.
+  moveToNextWordBoundary: ->
+    if position = @getMoveNextWordBoundaryBufferPosition()
       @setBufferPosition(position)
 
   # Retrieves the buffer position of where the current word starts.
@@ -277,7 +277,7 @@ class Cursor
 
   # Retrieves buffer position of previous word boiundry. It might be on the
   # current word, or the previous word.
-  getMovePreviousWordBoundryBufferPosition: (options = {}) ->
+  getMovePreviousWordBoundaryBufferPosition: (options = {}) ->
     currentBufferPosition = @getBufferPosition()
     previousNonBlankRow = @editSession.buffer.previousNonBlankRow(currentBufferPosition.row)
     scanRange = [[previousNonBlankRow, 0], currentBufferPosition]
@@ -299,7 +299,7 @@ class Cursor
 
   # Retrieves buffer position of previous word boiundry. It might be on the
   # current word, or the previous word.
-  getMoveNextWordBoundryBufferPosition: (options = {}) ->
+  getMoveNextWordBoundaryBufferPosition: (options = {}) ->
     currentBufferPosition = @getBufferPosition()
     scanRange = [currentBufferPosition, @editSession.getEofBufferPosition()]
 

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -244,6 +244,11 @@ class Cursor
     if position = @getBeginningOfNextWordBufferPosition()
       @setBufferPosition(position)
 
+  # Moves the cursor to the previous word boundry.
+  moveToPreviousWordBoundry: ->
+    if position = @getMovePreviousWordBoundryBufferPosition()
+      @setBufferPosition(position)
+
   # Retrieves the buffer position of where the current word starts.
   #
   # options - A hash with one option:
@@ -260,6 +265,28 @@ class Cursor
     @editSession.backwardsScanInBufferRange (options.wordRegex ? @wordRegExp()), scanRange, ({range, stop}) =>
       if range.end.isGreaterThanOrEqual(currentBufferPosition) or allowPrevious
         beginningOfWordPosition = range.start
+      if not beginningOfWordPosition?.isEqual(currentBufferPosition)
+        stop()
+
+    beginningOfWordPosition or currentBufferPosition
+
+  # Retrieves buffer position of previous word boiundry. It might be on the
+  # current word, or the previous word.
+  getMovePreviousWordBoundryBufferPosition: (options = {}) ->
+    currentBufferPosition = @getBufferPosition()
+    previousNonBlankRow = @editSession.buffer.previousNonBlankRow(currentBufferPosition.row)
+    scanRange = [[previousNonBlankRow, 0], currentBufferPosition]
+
+    beginningOfWordPosition = null
+    @editSession.backwardsScanInBufferRange (options.wordRegex ? @wordRegExp()), scanRange, ({range, stop}) =>
+      if range.start.row < currentBufferPosition.row and currentBufferPosition.column > 0
+        # force it to stop at the beginning of each line
+        beginningOfWordPosition = new Point(currentBufferPosition.row, 0)
+      else if range.end.isLessThan(currentBufferPosition)
+        beginningOfWordPosition = range.end
+      else
+        beginningOfWordPosition = range.start
+
       if not beginningOfWordPosition?.isEqual(currentBufferPosition)
         stop()
 

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -249,6 +249,11 @@ class Cursor
     if position = @getMovePreviousWordBoundryBufferPosition()
       @setBufferPosition(position)
 
+  # Moves the cursor to the next word boundry.
+  moveToNextWordBoundry: ->
+    if position = @getMoveNextWordBoundryBufferPosition()
+      @setBufferPosition(position)
+
   # Retrieves the buffer position of where the current word starts.
   #
   # options - A hash with one option:
@@ -291,6 +296,27 @@ class Cursor
         stop()
 
     beginningOfWordPosition or currentBufferPosition
+
+  # Retrieves buffer position of previous word boiundry. It might be on the
+  # current word, or the previous word.
+  getMoveNextWordBoundryBufferPosition: (options = {}) ->
+    currentBufferPosition = @getBufferPosition()
+    scanRange = [currentBufferPosition, @editSession.getEofBufferPosition()]
+
+    endOfWordPosition = null
+    @editSession.scanInBufferRange (options.wordRegex ? @wordRegExp()), scanRange, ({range, stop}) =>
+      if range.start.row > currentBufferPosition.row # and currentBufferPosition.column > 0
+        # force it to stop at the beginning of each line
+        endOfWordPosition = new Point(range.start.row, 0)
+      else if range.start.isGreaterThan(currentBufferPosition)
+        endOfWordPosition = range.start
+      else
+        endOfWordPosition = range.end
+
+      if not endOfWordPosition?.isEqual(currentBufferPosition)
+        stop()
+
+    endOfWordPosition or currentBufferPosition
 
   # Retrieves the buffer position of where the current word ends.
   #

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -305,7 +305,7 @@ class Cursor
 
     endOfWordPosition = null
     @editSession.scanInBufferRange (options.wordRegex ? @wordRegExp()), scanRange, ({range, stop}) =>
-      if range.start.row > currentBufferPosition.row # and currentBufferPosition.column > 0
+      if range.start.row > currentBufferPosition.row
         # force it to stop at the beginning of each line
         endOfWordPosition = new Point(range.start.row, 0)
       else if range.start.isGreaterThan(currentBufferPosition)

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -1104,6 +1104,9 @@ class EditSession
   moveCursorToPreviousWordBoundry: ->
     @moveCursors (cursor) -> cursor.moveToPreviousWordBoundry()
 
+  moveCursorToNextWordBoundry: ->
+    @moveCursors (cursor) -> cursor.moveToNextWordBoundry()
+
   # Internal:
   moveCursors: (fn) ->
     fn(cursor) for cursor in @getCursors()

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -1101,6 +1101,9 @@ class EditSession
   moveCursorToBeginningOfNextWord: ->
     @moveCursors (cursor) -> cursor.moveToBeginningOfNextWord()
 
+  moveCursorToPreviousWordBoundry: ->
+    @moveCursors (cursor) -> cursor.moveToPreviousWordBoundry()
+
   # Internal:
   moveCursors: (fn) ->
     fn(cursor) for cursor in @getCursors()

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -1101,11 +1101,11 @@ class EditSession
   moveCursorToBeginningOfNextWord: ->
     @moveCursors (cursor) -> cursor.moveToBeginningOfNextWord()
 
-  moveCursorToPreviousWordBoundry: ->
-    @moveCursors (cursor) -> cursor.moveToPreviousWordBoundry()
+  moveCursorToPreviousWordBoundary: ->
+    @moveCursors (cursor) -> cursor.moveToPreviousWordBoundary()
 
-  moveCursorToNextWordBoundry: ->
-    @moveCursors (cursor) -> cursor.moveToNextWordBoundry()
+  moveCursorToNextWordBoundary: ->
+    @moveCursors (cursor) -> cursor.moveToNextWordBoundary()
 
   # Internal:
   moveCursors: (fn) ->
@@ -1156,11 +1156,11 @@ class EditSession
   selectToEndOfLine: ->
     @expandSelectionsForward (selection) => selection.selectToEndOfLine()
 
-  selectToPreviousWordBoundry: ->
-    @expandSelectionsBackward (selection) => selection.selectToPreviousWordBoundry()
+  selectToPreviousWordBoundary: ->
+    @expandSelectionsBackward (selection) => selection.selectToPreviousWordBoundary()
 
-  selectToNextWordBoundry: ->
-    @expandSelectionsForward (selection) => selection.selectToNextWordBoundry()
+  selectToNextWordBoundary: ->
+    @expandSelectionsForward (selection) => selection.selectToNextWordBoundary()
 
   # Selects the current line.
   selectLine: ->

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -1156,6 +1156,12 @@ class EditSession
   selectToEndOfLine: ->
     @expandSelectionsForward (selection) => selection.selectToEndOfLine()
 
+  selectToPreviousWordBoundry: ->
+    @expandSelectionsBackward (selection) => selection.selectToPreviousWordBoundry()
+
+  selectToNextWordBoundry: ->
+    @expandSelectionsForward (selection) => selection.selectToNextWordBoundry()
+
   # Selects the current line.
   selectLine: ->
     @expandSelectionsForward (selection) => selection.selectLine()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -148,6 +148,8 @@ class Editor extends View
       'editor:select-to-end-of-word': @selectToEndOfWord
       'editor:select-to-beginning-of-word': @selectToBeginningOfWord
       'editor:select-to-beginning-of-next-word': @selectToBeginningOfNextWord
+      'editor:select-to-next-word-boundary': @selectToNextWordBoundary
+      'editor:select-to-previous-word-boundary': @selectToPreviousWordBoundary
       'editor:add-selection-below': @addSelectionBelow
       'editor:add-selection-above': @addSelectionAbove
       'editor:select-line': @selectLine
@@ -337,6 +339,12 @@ class Editor extends View
 
   # {Delegates to: EditSession.selectToEndOfLine}
   selectToEndOfLine: -> @activeEditSession.selectToEndOfLine()
+
+  # {Delegates to: EditSession.selectToPreviousWordBoundary}
+  selectToPreviousWordBoundary: -> @activeEditSession.selectToPreviousWordBoundary()
+
+  # {Delegates to: EditSession.selectToNextWordBoundary}
+  selectToNextWordBoundary: -> @activeEditSession.selectToNextWordBoundary()
 
   # {Delegates to: EditSession.addSelectionBelow}
   addSelectionBelow: -> @activeEditSession.addSelectionBelow()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -142,6 +142,7 @@ class Editor extends View
       'editor:move-to-end-of-word': @moveCursorToEndOfWord
       'editor:move-to-beginning-of-next-word': @moveCursorToBeginningOfNextWord
       'editor:move-to-previous-word-boundry': @moveCursorToPreviousWordBoundry
+      'editor:move-to-next-word-boundry': @moveCursorToNextWordBoundry
       'editor:select-to-end-of-line': @selectToEndOfLine
       'editor:select-to-beginning-of-line': @selectToBeginningOfLine
       'editor:select-to-end-of-word': @selectToEndOfWord
@@ -240,6 +241,9 @@ class Editor extends View
 
   # {Delegates to: EditSession.moveCursorToPreviousWordBoundry}
   moveCursorToPreviousWordBoundry: -> @activeEditSession.moveCursorToPreviousWordBoundry()
+
+  # {Delegates to: EditSession.moveCursorToNextWordBoundry}
+  moveCursorToNextWordBoundry: -> @activeEditSession.moveCursorToNextWordBoundry()
 
   # {Delegates to: EditSession.moveCursorToEndOfLine}
   moveCursorToEndOfLine: -> @activeEditSession.moveCursorToEndOfLine()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -141,6 +141,7 @@ class Editor extends View
       'editor:move-to-beginning-of-word': @moveCursorToBeginningOfWord
       'editor:move-to-end-of-word': @moveCursorToEndOfWord
       'editor:move-to-beginning-of-next-word': @moveCursorToBeginningOfNextWord
+      'editor:move-to-previous-word-boundry': @moveCursorToPreviousWordBoundry
       'editor:select-to-end-of-line': @selectToEndOfLine
       'editor:select-to-beginning-of-line': @selectToBeginningOfLine
       'editor:select-to-end-of-word': @selectToEndOfWord
@@ -236,6 +237,9 @@ class Editor extends View
 
   # {Delegates to: EditSession.moveCursorToFirstCharacterOfLine}
   moveCursorToFirstCharacterOfLine: -> @activeEditSession.moveCursorToFirstCharacterOfLine()
+
+  # {Delegates to: EditSession.moveCursorToPreviousWordBoundry}
+  moveCursorToPreviousWordBoundry: -> @activeEditSession.moveCursorToPreviousWordBoundry()
 
   # {Delegates to: EditSession.moveCursorToEndOfLine}
   moveCursorToEndOfLine: -> @activeEditSession.moveCursorToEndOfLine()

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -141,8 +141,8 @@ class Editor extends View
       'editor:move-to-beginning-of-word': @moveCursorToBeginningOfWord
       'editor:move-to-end-of-word': @moveCursorToEndOfWord
       'editor:move-to-beginning-of-next-word': @moveCursorToBeginningOfNextWord
-      'editor:move-to-previous-word-boundry': @moveCursorToPreviousWordBoundry
-      'editor:move-to-next-word-boundry': @moveCursorToNextWordBoundry
+      'editor:move-to-previous-word-boundary': @moveCursorToPreviousWordBoundary
+      'editor:move-to-next-word-boundary': @moveCursorToNextWordBoundary
       'editor:select-to-end-of-line': @selectToEndOfLine
       'editor:select-to-beginning-of-line': @selectToBeginningOfLine
       'editor:select-to-end-of-word': @selectToEndOfWord
@@ -239,11 +239,11 @@ class Editor extends View
   # {Delegates to: EditSession.moveCursorToFirstCharacterOfLine}
   moveCursorToFirstCharacterOfLine: -> @activeEditSession.moveCursorToFirstCharacterOfLine()
 
-  # {Delegates to: EditSession.moveCursorToPreviousWordBoundry}
-  moveCursorToPreviousWordBoundry: -> @activeEditSession.moveCursorToPreviousWordBoundry()
+  # {Delegates to: EditSession.moveCursorToPreviousWordBoundary}
+  moveCursorToPreviousWordBoundary: -> @activeEditSession.moveCursorToPreviousWordBoundary()
 
-  # {Delegates to: EditSession.moveCursorToNextWordBoundry}
-  moveCursorToNextWordBoundry: -> @activeEditSession.moveCursorToNextWordBoundry()
+  # {Delegates to: EditSession.moveCursorToNextWordBoundary}
+  moveCursorToNextWordBoundary: -> @activeEditSession.moveCursorToNextWordBoundary()
 
   # {Delegates to: EditSession.moveCursorToEndOfLine}
   moveCursorToEndOfLine: -> @activeEditSession.moveCursorToEndOfLine()

--- a/src/app/selection.coffee
+++ b/src/app/selection.coffee
@@ -214,6 +214,14 @@ class Selection
   selectToBeginningOfNextWord: ->
     @modifySelection => @cursor.moveToBeginningOfNextWord()
 
+  # Selects text to the previous word boundry.
+  selectToPreviousWordBoundry: ->
+    @modifySelection => @cursor.moveToPreviousWordBoundry()
+
+  # Selects text to the next word boundry.
+  selectToNextWordBoundry: ->
+    @modifySelection => @cursor.moveToNextWordBoundry()
+
   # Moves the selection down one row.
   addSelectionBelow: ->
     range = (@goalBufferRange ? @getBufferRange()).copy()

--- a/src/app/selection.coffee
+++ b/src/app/selection.coffee
@@ -214,13 +214,13 @@ class Selection
   selectToBeginningOfNextWord: ->
     @modifySelection => @cursor.moveToBeginningOfNextWord()
 
-  # Selects text to the previous word boundry.
-  selectToPreviousWordBoundry: ->
-    @modifySelection => @cursor.moveToPreviousWordBoundry()
+  # Selects text to the previous word boundary.
+  selectToPreviousWordBoundary: ->
+    @modifySelection => @cursor.moveToPreviousWordBoundary()
 
-  # Selects text to the next word boundry.
-  selectToNextWordBoundry: ->
-    @modifySelection => @cursor.moveToNextWordBoundry()
+  # Selects text to the next word boundary.
+  selectToNextWordBoundary: ->
+    @modifySelection => @cursor.moveToNextWordBoundary()
 
   # Moves the selection down one row.
   addSelectionBelow: ->


### PR DESCRIPTION
Moving between words with `editor:move-to-end-of-word` and `editor:move-to-beginning-of-word` confuse me. So I'm adding new commands that work more like sublime. They will be:
- [x] `editor:move-to-previous-word-boundary`
- [x] `editor:move-to-next-word-boundary`
- [x] `editor:select-to-previous-word-boundary`
- [x] `editor:select-to-next-word-boundary`

Basically, my issues are:
- Moving around wordwise messes with my expectations
  - expect it to stop at end of line
  - expect it to stop at begin of line
  - `(@somevar|, omg)` cursor at pipe, move word left x2, expect it to be `(|@somevar, omg)` but is `|(@somevar, omg)`
- Moving around wordwise should be consistent backward to forward
  Cursor is at pipe
  
  ```
    @scrollView.on 'scroll', =>|
      if @scrollLeft() == 0
  ```
  
  Then move right one word, it does this:
  
  ```
    @scrollView.on 'scroll', =>
      if| @scrollLeft() == 0
  ```
  
  I expect cursor to land at pipes when moving right from initial
  
  ```
    @scrollView.on 'scroll', =>|
  |  |if| @scrollLeft() == 0
  ```
