### PR TITLE
Small dark theme change

### DIFF
--- a/themes/atom-dark-syntax.less
+++ b/themes/atom-dark-syntax.less
@@ -27,8 +27,7 @@
     background-color: #444444;
   }
 
-  .line-number.cursor-line-no-selection,
-  .line.cursor-line {
+  .line-number.cursor-line-no-selection {
     background-color: rgba(255, 255, 255, 0.14);
   }
 

--- a/themes/atom-dark-syntax.less
+++ b/themes/atom-dark-syntax.less
@@ -24,7 +24,7 @@
   }
 
   .selection .region {
-    background-color: #333333;
+    background-color: #444444;
   }
 
   .line-number.cursor-line-no-selection,


### PR DESCRIPTION
The text selection was less visible than the current line highlight. And when selecting, then unselecting text, the current line highlight would pop in and out making me think the current line was selected.
