### PR TITLE
Add indexForBufferPosition method to EditSession

### DIFF
--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -411,6 +411,16 @@ describe "EditSession", ->
       it "returns the buffer index for the middle of a line", ->
         expect(editSession.indexForBufferPosition({row: 6, column: 10 })).toBe 236
 
+    describe ".bufferPositionForIndex()", ->
+      it "returns the buffer position for the start of a line", ->
+        expect(editSession.bufferPositionForIndex(102)).toEqual {row: 3, column: 0 }
+
+      it "returns the buffer position for the start of a line, relative to a non-zero starting row", ->
+        expect(editSession.bufferPositionForIndex(41, 2)).toEqual {row: 3, column: 0 }
+
+      it "returns the buffer position for the middle of a line", ->
+        expect(editSession.bufferPositionForIndex(236)).toEqual {row: 6, column: 10 }
+
     describe "cursor-moved events", ->
       cursorMovedHandler = null
 

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -401,6 +401,16 @@ describe "EditSession", ->
         editSession.setCursorBufferPosition([3, 1])
         expect(editSession.getCurrentParagraphBufferRange()).toBeUndefined()
 
+    describe ".indexForBufferPosition()", ->
+      it "returns the buffer index for the start of a line", ->
+        expect(editSession.indexForBufferPosition({row: 3, column: 0 })).toBe 102
+
+      it "returns the buffer index for the start of a line, relative to a non-zero starting row", ->
+        expect(editSession.indexForBufferPosition({row: 3, column: 0 }, 2)).toBe 41
+
+      it "returns the buffer index for the middle of a line", ->
+        expect(editSession.indexForBufferPosition({row: 6, column: 10 })).toBe 236
+
     describe "cursor-moved events", ->
       cursorMovedHandler = null
 

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -389,6 +389,34 @@ class EditSession
   # {Delegates to: DisplayBuffer.tokenForBufferPosition}
   tokenForBufferPosition: (bufferPosition) -> @displayBuffer.tokenForBufferPosition(bufferPosition)
 
+  # Converts the `{row, column}` buffer position to its character index.
+  #
+  # Index refers to the "absolute position" of a character in the buffer. For example:
+  #
+  # ```javascript
+  # var x = 0; // 10 characters, plus one for newline
+  # var y = -1;
+  # ```
+  #
+  # Here, `y` is at index 15: 11 characters for the first row, and 5 characters until `y` in the second.
+  #
+  # indexForBufferPosition - The buffer position
+  # startRow - The buffer row to start calculating from (default: 0)
+  #
+  # Returns the index {Number}.
+  indexForBufferPosition: (bufferPosition, startRow=0) ->
+    newlineLength = 1
+    bufferSize = @getText().length
+    row = Math.min(bufferPosition.row, bufferSize)
+    startRow = bufferSize if startRow > bufferSize
+
+    i = startRow - 1
+    index = 0
+    while ++i < row
+      index += @lineLengthForBufferRow(i) + newlineLength
+
+    return index + bufferPosition.column
+
   # Retrieves the grammar's token scopes for the line with the most recently added cursor.
   #
   # Returns an {Array} of {String}s.

--- a/src/app/edit-session.coffee
+++ b/src/app/edit-session.coffee
@@ -400,7 +400,7 @@ class EditSession
   #
   # Here, `y` is at index 15: 11 characters for the first row, and 5 characters until `y` in the second.
   #
-  # indexForBufferPosition - The buffer position
+  # bufferPosition - The buffer position
   # startRow - The buffer row to start calculating from (default: 0)
   #
   # Returns the index {Number}.
@@ -416,6 +416,35 @@ class EditSession
       index += @lineLengthForBufferRow(i) + newlineLength
 
     return index + bufferPosition.column
+
+  # Converts a character index position to its `{row, column}` buffer position.
+  #
+  # Index refers to the "absolute position" of a character in the buffer. For example:
+  #
+  # ```javascript
+  # var x = 0; // 10 characters, plus one for newline
+  # var y = -1;
+  # ```
+  #
+  # Here, `y` is at index 15: 11 characters for the first row, and 5 characters until `y` in the second.
+  #
+  # indexPosition - The index position
+  # startRow - The buffer row to start calculating from (default: 0)
+  #
+  # Returns the buffer position {Object} as a `{row, column}`.
+  bufferPositionForIndex: (indexPosition, startRow=0) ->
+    lines = @getText()
+    newlineLength = 1
+
+    i = startRow - 1
+    bufferSize = @getText().length
+    while ++i < bufferSize
+      indexPosition -= @lineLengthForBufferRow(i) + newlineLength
+
+      if indexPosition < 0
+        return {row: i, column: indexPosition + @lineLengthForBufferRow(i) + newlineLength}
+
+    return {row: l - 1, column: lines[l - 1].length}
 
   # Retrieves the grammar's token scopes for the line with the most recently added cursor.
   #

--- a/src/app/editor.coffee
+++ b/src/app/editor.coffee
@@ -564,6 +564,9 @@ class Editor extends View
   #  {Delegates to: Buffer.getTextInRange}
   getTextInRange: (range) -> @getBuffer().getTextInRange(range)
 
+  #  {Delegates to: Buffer.getTextInRange}
+  setTextInRange: (range, text) -> @getBuffer().setTextInRange(range, text)
+
   #  {Delegates to: Buffer.getEofPosition}
   getEofPosition: -> @getBuffer().getEofPosition()
 

--- a/src/app/text-buffer.coffee
+++ b/src/app/text-buffer.coffee
@@ -193,6 +193,10 @@ class TextBuffer
 
     return multipleLines.join ''
 
+  # {Delegates to: Buffer.change}
+  setTextInRange: (range, text) ->
+    @change(range, text)
+
   # Gets all the lines in a file.
   #
   # Returns an {Array} of {String}s.
@@ -659,6 +663,14 @@ class TextBuffer
 
   abort: -> @undoManager.abort()
 
+  # Given a range, replaces it with some new text.
+  #
+  # oldRange - A {Range} object specifying your points of interest
+  # newText - A {String} representing the new text
+  # options - An optional {Object} with the following keys:
+  #           normalizeLineEndings: A {Boolean} which, if `true`, normalizes the text's line endings
+  #
+  # Returns a {Range} representing the new text range.
   change: (oldRange, newText, options) ->
     oldRange = Range.fromObject(oldRange)
     operation = new BufferChangeOperation({buffer: this, oldRange, newText, options})


### PR DESCRIPTION
I'm working on creating an Emmet plugin for Atom.

Most of what needs to be done is overriding Emmet functionality to work with Atom's API. Most of the interactions with Emmet expect character index positions in a document. Basically, this necessitates translating `[row, column]` positions into the index position.

I'd like to add the `indexForBufferPosition and`bufferPositionForIndex` to translate between the two positions. You can see it [used here](https://github.com/atom/emmet/blob/1e274e258956ed67a14f059e1186405ef78194ab/lib/editor-proxy.coffee#L107-L116).

Ideally I would prefer this to go right into `Point`, but the whole point is that it depends on `@buffer` to know how to calculate previous line lengths. 
