### PR TITLE
newlines follow last line's indent

### DIFF
--- a/src/app/language-mode.coffee
+++ b/src/app/language-mode.coffee
@@ -222,7 +222,7 @@ class LanguageMode
     return currentIndentLevel unless increaseIndentRegex = @increaseIndentRegexForScopes(scopes)
 
     currentLine = @buffer.lineForRow(bufferRow)
-    precedingRow = @buffer.previousNonBlankRow(bufferRow)
+    precedingRow = if bufferRow > 0 then bufferRow - 1 else null
     return currentIndentLevel unless precedingRow?
 
     precedingLine = @buffer.lineForRow(precedingRow)


### PR DESCRIPTION
When you hit enter/newline, the default indent choice, when no lang specific indent was the last non blank row's indent. For me, this would often indent more than I wanted (say, I'm creating a new function after some other function).

So this pull changes the default indent to be the last line's indent instead. That way I can tab back a few, and hit enter as many times as I want without it messing up my tabbing.
