### PR TITLE
Better line movement when soft wrap is enabled.

### DIFF
--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -1732,24 +1732,32 @@ describe "EditSession", ->
           expect(clipboard.readText()).toBe 'quicksort\nsort'
 
       describe ".cutToEndOfLine()", ->
-        describe "when nothing is selected", ->
+        describe "when soft wrap is on", ->
           it "cuts up to the end of the line", ->
-            editSession.setCursorBufferPosition([2, 20])
-            editSession.addCursorAtBufferPosition([3, 20])
+            editSession.setSoftWrapColumn(10)
+            editSession.setCursorScreenPosition([2, 2])
             editSession.cutToEndOfLine()
-            expect(buffer.lineForRow(2)).toBe '    if (items.length'
-            expect(buffer.lineForRow(3)).toBe '    var pivot = item'
-            expect(pasteboard.read()[0]).toBe ' <= 1) return items;\ns.shift(), current, left = [], right = [];'
+            expect(editSession.lineForScreenRow(2).text).toBe '=  () {'
 
-        describe "when text is selected", ->
-          it "only cuts the selected text, not to the end of the line", ->
-            editSession.setSelectedBufferRanges([[[2,20], [2, 30]], [[3, 20], [3, 20]]])
+        describe "when soft wrap is off", ->
+          describe "when nothing is selected", ->
+            it "cuts up to the end of the line", ->
+              editSession.setCursorBufferPosition([2, 20])
+              editSession.addCursorAtBufferPosition([3, 20])
+              editSession.cutToEndOfLine()
+              expect(buffer.lineForRow(2)).toBe '    if (items.length'
+              expect(buffer.lineForRow(3)).toBe '    var pivot = item'
+              expect(pasteboard.read()[0]).toBe ' <= 1) return items;\ns.shift(), current, left = [], right = [];'
 
-            editSession.cutToEndOfLine()
+          describe "when text is selected", ->
+            it "only cuts the selected text, not to the end of the line", ->
+              editSession.setSelectedBufferRanges([[[2,20], [2, 30]], [[3, 20], [3, 20]]])
 
-            expect(buffer.lineForRow(2)).toBe '    if (items.lengthurn items;'
-            expect(buffer.lineForRow(3)).toBe '    var pivot = item'
-            expect(pasteboard.read()[0]).toBe ' <= 1) ret\ns.shift(), current, left = [], right = [];'
+              editSession.cutToEndOfLine()
+
+              expect(buffer.lineForRow(2)).toBe '    if (items.lengthurn items;'
+              expect(buffer.lineForRow(3)).toBe '    var pivot = item'
+              expect(pasteboard.read()[0]).toBe ' <= 1) ret\ns.shift(), current, left = [], right = [];'
 
       describe ".copySelectedText()", ->
         it "copies selected text onto the clipboard", ->

--- a/spec/app/edit-session-spec.coffee
+++ b/spec/app/edit-session-spec.coffee
@@ -289,44 +289,72 @@ describe "EditSession", ->
         expect(editSession.getCursorBufferPosition()).toEqual [12,2]
 
     describe ".moveCursorToBeginningOfLine()", ->
-      it "moves cursor to the beginning of line", ->
-        editSession.setCursorScreenPosition [0,5]
-        editSession.addCursorAtScreenPosition [1,7]
-        editSession.moveCursorToBeginningOfLine()
-        expect(editSession.getCursors().length).toBe 2
-        [cursor1, cursor2] = editSession.getCursors()
-        expect(cursor1.getBufferPosition()).toEqual [0,0]
-        expect(cursor2.getBufferPosition()).toEqual [1,0]
+      describe "when soft wrap is on", ->
+        it "moves cursor to the beginning of the screen line", ->
+          editSession.setSoftWrapColumn(10)
+          editSession.setCursorScreenPosition([1, 2])
+          editSession.moveCursorToBeginningOfLine()
+          cursor = editSession.getCursor()
+          expect(cursor.getScreenPosition()).toEqual [1, 0]
+
+      describe "when soft wrap is off", ->
+        it "moves cursor to the beginning of then line", ->
+          editSession.setCursorScreenPosition [0,5]
+          editSession.addCursorAtScreenPosition [1,7]
+          editSession.moveCursorToBeginningOfLine()
+          expect(editSession.getCursors().length).toBe 2
+          [cursor1, cursor2] = editSession.getCursors()
+          expect(cursor1.getBufferPosition()).toEqual [0,0]
+          expect(cursor2.getBufferPosition()).toEqual [1,0]
 
     describe ".moveCursorToEndOfLine()", ->
-      it "moves cursor to the end of line", ->
-        editSession.setCursorScreenPosition [0,0]
-        editSession.addCursorAtScreenPosition [1,0]
-        editSession.moveCursorToEndOfLine()
-        expect(editSession.getCursors().length).toBe 2
-        [cursor1, cursor2] = editSession.getCursors()
-        expect(cursor1.getBufferPosition()).toEqual [0,29]
-        expect(cursor2.getBufferPosition()).toEqual [1,30]
+      describe "when soft wrap is on", ->
+        it "moves cursor to the beginning of the screen line", ->
+          editSession.setSoftWrapColumn(10)
+          editSession.setCursorScreenPosition([1, 2])
+          editSession.moveCursorToEndOfLine()
+          cursor = editSession.getCursor()
+          expect(cursor.getScreenPosition()).toEqual [1, 9]
+
+      describe "when soft wrap is off", ->
+        it "moves cursor to the end of line", ->
+          editSession.setCursorScreenPosition [0,0]
+          editSession.addCursorAtScreenPosition [1,0]
+          editSession.moveCursorToEndOfLine()
+          expect(editSession.getCursors().length).toBe 2
+          [cursor1, cursor2] = editSession.getCursors()
+          expect(cursor1.getBufferPosition()).toEqual [0,29]
+          expect(cursor2.getBufferPosition()).toEqual [1,30]
 
     describe ".moveCursorToFirstCharacterOfLine()", ->
-      it "moves to the first character of the current line or the beginning of the line if it's already on the first character", ->
-        editSession.setCursorScreenPosition [0,5]
-        editSession.addCursorAtScreenPosition [1,7]
+      describe "when soft wrap is on", ->
+        it "moves to the first character of the current screen line or the beginning of the screen line if it's already on the first character", ->
+          editSession.setSoftWrapColumn(10)
+          editSession.setCursorScreenPosition [2,5]
+          editSession.addCursorAtScreenPosition [8,7]
 
-        editSession.moveCursorToFirstCharacterOfLine()
-        [cursor1, cursor2] = editSession.getCursors()
-        expect(cursor1.getBufferPosition()).toEqual [0,0]
-        expect(cursor2.getBufferPosition()).toEqual [1,2]
-
-        editSession.moveCursorToFirstCharacterOfLine()
-        expect(cursor1.getBufferPosition()).toEqual [0,0]
-        expect(cursor2.getBufferPosition()).toEqual [1,0]
-
-      describe "when triggered ", ->
-        it "does not move the cursor", ->
-          editSession.setCursorBufferPosition([10, 0])
           editSession.moveCursorToFirstCharacterOfLine()
-          expect(editSession.getCursorBufferPosition()).toEqual [10, 0]
+          [cursor1, cursor2] = editSession.getCursors()
+          expect(cursor1.getScreenPosition()).toEqual [2,0]
+          expect(cursor2.getScreenPosition()).toEqual [8,4]
+
+          editSession.moveCursorToFirstCharacterOfLine()
+          expect(cursor1.getScreenPosition()).toEqual [2,0]
+          expect(cursor2.getScreenPosition()).toEqual [8,0]
+
+      describe "when soft wrap is of", ->
+        it "moves to the first character of the current line or the beginning of the line if it's already on the first character", ->
+          editSession.setCursorScreenPosition [0,5]
+          editSession.addCursorAtScreenPosition [1,7]
+
+          editSession.moveCursorToFirstCharacterOfLine()
+          [cursor1, cursor2] = editSession.getCursors()
+          expect(cursor1.getBufferPosition()).toEqual [0,0]
+          expect(cursor2.getBufferPosition()).toEqual [1,2]
+
+          editSession.moveCursorToFirstCharacterOfLine()
+          expect(cursor1.getBufferPosition()).toEqual [0,0]
+          expect(cursor2.getBufferPosition()).toEqual [1,0]
 
     describe ".moveCursorToBeginningOfWord()", ->
       it "moves the cursor to the beginning of the word", ->

--- a/src/app/cursor.coffee
+++ b/src/app/cursor.coffee
@@ -230,20 +230,20 @@ class Cursor
   moveToBottom: ->
     @setBufferPosition(@editSession.getEofBufferPosition())
 
-  # Moves the cursor to the beginning of the buffer line.
+  # Moves the cursor to the beginning of the screen line.
   moveToBeginningOfLine: ->
-    @setBufferPosition([@getBufferRow(), 0])
+    @setScreenPosition([@getScreenRow(), 0])
 
   # Moves the cursor to the beginning of the first character in the line.
   moveToFirstCharacterOfLine: ->
-    position = @getBufferPosition()
-    scanRange = @getCurrentLineBufferRange()
-    newPosition = null
-    @editSession.scanInBufferRange /^\s*/, scanRange, ({range}) =>
-      newPosition = range.end
-    return unless newPosition
-    newPosition = [position.row, 0] if newPosition.isEqual(position)
-    @setBufferPosition(newPosition)
+    {row, column} = @getScreenPosition()
+    screenline = @editSession.lineForScreenRow(row)
+
+    goalColumn = screenline.text.search(/\S/)
+    return if goalColumn == -1
+
+    goalColumn = 0 if goalColumn == column
+    @setScreenPosition([row, goalColumn])
 
   # Moves the cursor to the beginning of the buffer line, skipping all whitespace.
   skipLeadingWhitespace: ->
@@ -257,7 +257,7 @@ class Cursor
 
   # Moves the cursor to the end of the buffer line.
   moveToEndOfLine: ->
-    @setBufferPosition([@getBufferRow(), Infinity])
+    @setScreenPosition([@getScreenRow(), Infinity])
 
   # Moves the cursor to the beginning of the word.
   moveToBeginningOfWord: ->


### PR DESCRIPTION
I'm not sure if all of these are needed, but here is a list of line commands that I'd like to make work better when a buffer is soft wrapped.
- [x] `editor:move-to-end-of-line`
- [x] `editor:move-to-beginning-of-line`
- [x] `editor:move-to-first-character-of-line` 
- [x] `editor:cut-to-end-of-line`
- [x] `editor:newline-below`
- [x] `editor:newline-above`
- [ ] `editor:delete-line` (ignoring because sublime and textmate do)
- [ ] `editor:move-line-up`  (ignoring because sublime and textmate do)
- [ ] `editor:move-line-down`  (ignoring because sublime and textmate do)
- [ ] `editor:duplicate-line`  (ignoring because sublime and textmate do)

Fixing #673 so @briandoll can make this money.
