### PR TITLE
Namespace theme styles by adding a class to the body

### DIFF
--- a/spec/app/theme-spec.coffee
+++ b/spec/app/theme-spec.coffee
@@ -24,6 +24,7 @@ describe "Theme", ->
       themePath = project.resolve('themes/theme-stylesheet.less')
       theme = new Theme(themePath)
       expect($(".editor").css("padding-top")).toBe "4321px"
+      expect($('body')).toHaveClass('theme-stylesheet')
 
   describe "when the theme contains a package.json file", ->
     it "loads and applies stylesheets from package.json in the correct order", ->
@@ -36,6 +37,13 @@ describe "Theme", ->
       expect($(".editor").css("padding-top")).toBe("101px")
       expect($(".editor").css("padding-right")).toBe("102px")
       expect($(".editor").css("padding-bottom")).toBe("103px")
+
+    it "adds a class to the body, and removes it when deactivated", ->
+      themePath = project.resolve('themes/theme-with-package-file')
+      theme = new Theme(themePath)
+      expect($('body')).toHaveClass('theme-with-package-file')
+      theme.deactivate()
+      expect($('body')).not.toHaveClass('theme-with-package-file')
 
   describe "when the theme does not contain a package.json file and is a directory", ->
     it "loads all stylesheet files in the directory", ->

--- a/src/app/theme.coffee
+++ b/src/app/theme.coffee
@@ -1,5 +1,6 @@
 fsUtils = require 'fs-utils'
 path = require 'path'
+$ = require 'jquery'
 
 ### Internal ###
 
@@ -14,6 +15,8 @@ class Theme
       @stylesheetPath = name
     else
       @stylesheetPath = fsUtils.resolve(config.themeDirPaths..., name, ['', '.css', 'less'])
+
+    @name = path.basename(@stylesheetPath, path.extname(@stylesheetPath))
 
     throw new Error("No theme exists named '#{name}'") unless @stylesheetPath
 
@@ -41,6 +44,8 @@ class Theme
     @stylesheets.push stylesheetPath
     content = window.loadStylesheet(stylesheetPath)
     window.applyStylesheet(stylesheetPath, content, 'userTheme')
+    $('body').addClass(@name)
 
   deactivate: ->
     window.removeStylesheet(stylesheetPath) for stylesheetPath in @stylesheets
+    $('body').removeClass(@name)


### PR DESCRIPTION
Packages should specify the styles for each theme they care to support. I'm sure you guys have talked about how you might want to do this. This is a simple way.

It just adds a class of the theme name to the body element. 

So in my package, I can specify a 

```
.atom-dark-ui {
   .my-plugin-junk {...}
}
```

We could also encourage that they are broken up into stylesheets named by the theme. But of course, a package author could just put this theme specific stuff into their global stylesheet. 

An alternative is selectively loading stylesheets with the same name as the theme from the package's `stylesheet` directory (I remember a section in the docs talking about this with a 'not implemented' tag). I haven't looked too deeply into the pkg manager yet to know how difficult it might be.

Thoughts?
