### PR TITLE
Adds deploy-docs grunt task

### DIFF
--- a/tasks/docs-task.coffee
+++ b/tasks/docs-task.coffee
@@ -20,3 +20,33 @@ module.exports = (grunt) ->
     done = @async()
     args = [commonArgs..., '--noOutput', '--missing', 'src/app/']
     grunt.util.spawn({cmd, args, opts}, done)
+
+  grunt.registerTask 'deploy-docs', 'Publishes latest API docs to atom-docs.githubapp.com', ->
+    done = @async()
+
+    pushHeroku = (error, result, code) ->
+      sha = String(result).trim()
+      cmd = 'git'
+      args = ['--work-tree=../atom-docs/', '--git-dir=../atom-docs/.git/', 'push', 'heroku', 'master']
+      grunt.util.spawn({cmd, args, opts}, done)
+
+    pushOrigin = (error, result, code) ->
+      sha = String(result).trim()
+      cmd = 'git'
+      args = ['--work-tree=../atom-docs/', '--git-dir=../atom-docs/.git/', 'push', 'origin', 'master']
+      grunt.util.spawn({cmd, args, opts}, pushHeroku)
+
+    commitChanges = (error, result, code) ->
+      sha = String(result).trim()
+      cmd = 'git'
+      args = ['--work-tree=../atom-docs/', '--git-dir=../atom-docs/.git/', 'commit', '-a', "-m Update API docs to #{sha}"]
+      grunt.util.spawn({cmd, args, opts}, pushOrigin)
+
+    fetchSha = (error, result, code) ->
+      cmd = 'git'
+      args = ['rev-parse', 'HEAD']
+      grunt.util.spawn({cmd, args}, commitChanges)
+
+    cmd = 'cp'
+    args = ['-r', 'docs/api', '../atom-docs/public/']
+    grunt.util.spawn {cmd, args, opts}, fetchSha


### PR DESCRIPTION
So in order to make the Atom API docs more available I put together https://github.com/atom/atom-docs which powers https://atom-docs.githubapp.com (which is oauth protected to the atom and github owner teams).

However since the app is so basic it's necessary to pre-generate the docs and republish them. Ideally this would be done automatically at release time but for now it's just a simple grunt task that needs to be run by hand after releasing. In the future this can be more fully automated. Note: You'll need the atom-docs repo checked out as a sibling to your atom repository otherwise the relative paths in these scripts will fail.

This setup should be considered the precursor to the documentation that will be available on atom.io. If there's interest, I'd also consider generating static versions of the available guides and also placing them on atom-docs.githubapp.com.
