### PR TITLE
Add guides to atom-docs.githubapp.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ node_modules
 npm-debug.log
 /tags
 /atom-shell/
-docs/api
-docs/guides
+docs/output

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 /tags
 /atom-shell/
 docs/api
+docs/guides

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -125,7 +125,7 @@ module.exports = (grunt) ->
           expand: true,
           cwd: 'docs'
           src: '**/*.md',
-          dest: 'docs/guides/',
+          dest: 'docs/output/',
           ext: '.html'
         ]
         markdownOptions:

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,8 +1,14 @@
 fs = require 'fs'
 path = require 'path'
 
+fm = require 'json-front-matter'
+_ = require 'underscore'
+
+packageJson = require './package.json'
+
 module.exports = (grunt) ->
   appName = 'Atom.app'
+  [major, minor, patch] = packageJson.version.split('.')
   buildDir = grunt.option('build-dir') ? '/tmp/atom-build'
   shellAppDir = path.join(buildDir, appName)
   contentsDir = path.join(shellAppDir, 'Contents')
@@ -122,14 +128,23 @@ module.exports = (grunt) ->
     markdown:
       guides:
         files: [
-          expand: true,
+          expand: true
           cwd: 'docs'
-          src: '**/*.md',
-          dest: 'docs/output/',
+          src: '**/*.md'
+          dest: 'docs/output/'
           ext: '.html'
         ]
-        markdownOptions:
-          gfm: true
+        options:
+          template: 'docs/template.jst'
+          templateContext:
+            tag: "v#{major}.#{minor}"
+          markdownOptions:
+            gfm: true
+          preCompile: (src, context) ->
+            parsed = fm.parse(src)
+            _.extend(context, parsed.attributes)
+            parsed.body
+
 
   grunt.loadNpmTasks('grunt-coffeelint')
   grunt.loadNpmTasks('grunt-lesslint')

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -119,16 +119,30 @@ module.exports = (grunt) ->
         'themes/**/*.less'
       ]
 
+    markdown:
+      guides:
+        files: [
+          expand: true,
+          cwd: 'docs'
+          src: '**/*.md',
+          dest: 'docs/guides/',
+          ext: '.html'
+        ]
+        markdownOptions:
+          gfm: true
+
   grunt.loadNpmTasks('grunt-coffeelint')
   grunt.loadNpmTasks('grunt-lesslint')
   grunt.loadNpmTasks('grunt-cson')
   grunt.loadNpmTasks('grunt-contrib-csslint')
   grunt.loadNpmTasks('grunt-contrib-coffee')
   grunt.loadNpmTasks('grunt-contrib-less')
+  grunt.loadNpmTasks('grunt-markdown')
   grunt.loadTasks('tasks')
 
   grunt.registerTask('compile', ['coffee', 'less', 'cson'])
   grunt.registerTask('lint', ['coffeelint', 'csslint', 'lesslint'])
   grunt.registerTask('ci', ['lint', 'partial-clean', 'update-atom-shell', 'build', 'set-development-version', 'test'])
   grunt.registerTask('deploy', ['partial-clean', 'update-atom-shell', 'build', 'codesign'])
+  grunt.registerTask('docs', ['markdown:guides', 'build-docs'])
   grunt.registerTask('default', ['update-atom-shell', 'build', 'set-development-version', 'install'])

--- a/docs/configuring-atom.md
+++ b/docs/configuring-atom.md
@@ -1,3 +1,7 @@
+{{{
+"title": "Configuring Atom"
+}}}
+
 # Configuration Settings
 
 ## Your .atom Directory

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,7 @@
+{{{
+"title": "Getting Started"
+}}}
+
 # Getting Started
 
 Welcome to Atom. This documentation provides a basic introduction to being

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+## Atom Reference
+
+* [API](api/index.html)
+
+## Atom Guides
+
+* [Getting Started](getting-started.html)
+* [Configuring Atom](configuring-atom.html)
+* Builtin Packages
+  * [Introduction](built-in-packages/intro.html)
+  * [Command Panel](built-in-packages/command-panel.html)
+  * [Markdown Preview](built-in-packages/markdown-preview.html)
+  * [Wrap Guide](built-in-packages/wrap-guide.html)
+* Packages
+  * [Authoring Packages](packages/authoring-packages.html)
+  * [Creating a Package](packages/creating_a_package.html)
+  * [Included Libraries](packages/included_libraries.html)
+  * [package.json](packages/package_json.html)
+* Themes
+  * [Authoring Themes](themes/authoring-themes.html)
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,3 @@
-## Atom Reference
-
-* [API](api/index.html)
-
 ## Atom Guides
 
 * [Getting Started](getting-started.html)
@@ -18,5 +14,3 @@
   * [package.json](packages/package_json.html)
 * Themes
   * [Authoring Themes](themes/authoring-themes.html)
-
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+{{{
+"title": "Guides"
+}}}
+
 ## Atom Guides
 
 * [Getting Started](getting-started.html)
@@ -9,7 +13,7 @@
   * [Wrap Guide](built-in-packages/wrap-guide.html)
 * Packages
   * [Authoring Packages](packages/authoring-packages.html)
-  * [Creating a Package](packages/creating_a_package.html)
+  * [Creating Packages](packages/creating_a_package.html)
   * [Included Libraries](packages/included_libraries.html)
   * [package.json](packages/package_json.html)
 * Themes

--- a/docs/packages/authoring-packages.md
+++ b/docs/packages/authoring-packages.md
@@ -1,3 +1,7 @@
+{{{
+"title": "Authoring Packages"
+}}}
+
 # Authoring Packages
 
 Packages are at the core of Atom. Nearly everything outside of the main editor manipulation

--- a/docs/packages/creating_a_package.md
+++ b/docs/packages/creating_a_package.md
@@ -1,3 +1,7 @@
+{{{
+"title": "Creating Packages"
+}}}
+
 # Creating Packages
 
 Let's take a look at creating our first package.

--- a/docs/packages/included_libraries.md
+++ b/docs/packages/included_libraries.md
@@ -1,3 +1,7 @@
+{{{
+"title": "Creating Packages"
+}}}
+
 # Included Libraries
 
 In addition to core node.js modules, all packages can `require` the following popular

--- a/docs/packages/package_json.md
+++ b/docs/packages/package_json.md
@@ -1,3 +1,7 @@
+{{{
+"title": "Creating Packages"
+}}}
+
 # package.json format
 
 The following keys are available to your package's _package.json_ manifest file:

--- a/docs/template.jst
+++ b/docs/template.jst
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-theme.min.css">
+    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+      <script src="../../assets/js/html5shiv.js"></script>
+      <script src="../../assets/js/respond.min.js"></script>
+    <![endif]-->
+
+    <title>Atom Documentation</title>
+    <style>
+      /*github.com style (c) Vasily Polovnyov <vast@whiteants.net>*/
+      pre code {
+        display: block; padding: 0.5em;
+        color: #333;
+        background: #f8f8ff
+      }
+      pre .comment,
+      pre .template_comment,
+      pre .diff .header,
+      pre .javadoc {
+        color: #998;
+        font-style: italic
+      }
+      pre .keyword,
+      pre .css .rule .keyword,
+      pre .winutils,
+      pre .javascript .title,
+      pre .nginx .title,
+      pre .subst,
+      pre .request,
+      pre .status {
+        color: #333;
+        font-weight: bold
+      }
+      pre .number,
+      pre .hexcolor,
+      pre .ruby .constant {
+        color: #099;
+      }
+      pre .string,
+      pre .tag .value,
+      pre .phpdoc,
+      pre .tex .formula {
+        color: #d14
+      }
+      pre .title,
+      pre .id {
+        color: #900;
+        font-weight: bold
+      }
+      pre .javascript .title,
+      pre .lisp .title,
+      pre .clojure .title,
+      pre .subst {
+        font-weight: normal
+      }
+      pre .class .title,
+      pre .haskell .type,
+      pre .vhdl .literal,
+      pre .tex .command {
+        color: #458;
+        font-weight: bold
+      }
+      pre .tag,
+      pre .tag .title,
+      pre .rules .property,
+      pre .django .tag .keyword {
+        color: #000080;
+        font-weight: normal
+      }
+      pre .attribute,
+      pre .variable,
+      pre .lisp .body {
+        color: #008080
+      }
+      pre .regexp {
+        color: #009926
+      }
+      pre .class {
+        color: #458;
+        font-weight: bold
+      }
+      pre .symbol,
+      pre .ruby .symbol .string,
+      pre .lisp .keyword,
+      pre .tex .special,
+      pre .prompt {
+        color: #990073
+      }
+      pre .built_in,
+      pre .lisp .title,
+      pre .clojure .built_in {
+        color: #0086b3
+      }
+      pre .preprocessor,
+      pre .pi,
+      pre .doctype,
+      pre .shebang,
+      pre .cdata {
+        color: #999;
+        font-weight: bold
+      }
+      pre .deletion {
+        background: #fdd
+      }
+      pre .addition {
+        background: #dfd
+      }
+      pre .diff .change {
+        background: #0086b3
+      }
+      pre .chunk {
+        color: #aaa
+      }
+
+      body {
+        padding-top: 50px;
+      }
+    </style>
+  </head>
+  <body>
+   <div class="navbar navbar-inverse navbar-fixed-top">
+      <div class="container">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="/<%= tag %>/index.html">Atom Documentation</a>
+        </div>
+        <div class="collapse navbar-collapse">
+          <ul class="nav navbar-nav">
+            <li><a href="/<%= tag %>/index.html">Guides</a></li>
+            <li><a href="/<%= tag %>/api/index.html">API</a></li>
+          </ul>
+        </div><!--/.nav-collapse -->
+      </div>
+    </div>
+
+    <div class="container">
+      <%= content %>
+    </div>
+  </body>
+</html>

--- a/docs/template.jst
+++ b/docs/template.jst
@@ -12,7 +12,7 @@
       <script src="../../assets/js/respond.min.js"></script>
     <![endif]-->
 
-    <title>Atom Documentation</title>
+    <title>Atom - <%= title %></title>
     <style>
       /*github.com style (c) Vasily Polovnyov <vast@whiteants.net>*/
       pre code {

--- a/docs/themes/authoring-themes.md
+++ b/docs/themes/authoring-themes.md
@@ -1,3 +1,7 @@
+{{{
+"title": "Authoring Themes"
+}}}
+
 # Authoring Themes
 
 If you understand CSS, you can write an Atom theme easily. Your theme can style

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atom",
-  "version": "0.0.0",
+  "version": "20.0.0",
   "main": "./src/main.js",
   "repository": {
     "type": "git",
@@ -111,7 +111,8 @@
     "walkdir": "0.0.7",
     "ws": "0.4.27",
     "js-yaml": "~2.1.0",
-    "grunt-markdown": "~0.4.0"
+    "grunt-markdown": "~0.4.0",
+    "json-front-matter": "~0.1.3"
   },
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "jasmine-focused": "~0.7.0",
     "walkdir": "0.0.7",
     "ws": "0.4.27",
-    "js-yaml": "~2.1.0"
+    "js-yaml": "~2.1.0",
+    "grunt-markdown": "~0.4.0"
   },
   "private": true,
   "scripts": {

--- a/tasks/docs-task.coffee
+++ b/tasks/docs-task.coffee
@@ -8,7 +8,7 @@ module.exports = (grunt) ->
 
   grunt.registerTask 'build-docs', 'Builds the API docs in src/app', ->
     done = @async()
-    args = [commonArgs..., '-o', 'docs/api', 'src/']
+    args = [commonArgs..., '-o', 'docs/output/api', 'src/']
     grunt.util.spawn({cmd, args, opts}, done)
 
   grunt.registerTask 'lint-docs', 'Generate stats about the doc coverage', ->
@@ -33,18 +33,9 @@ module.exports = (grunt) ->
         else
           callback(null, String(result).trim())
 
-    copyGuides = (tag, callback) ->
-      cmd = 'cp'
-      args = ['-r', 'docs/guides', "../atom-docs/public/#{tag}"]
-      grunt.util.spawn {cmd, args}, (error, result) ->
-        if error?
-          callback(error)
-        else
-          callback(null, tag)
-
     copyApiDocs = (tag, callback) ->
       cmd = 'cp'
-      args = ['-r', 'docs/api', "../atom-docs/public/#{tag}/api"]
+      args = ['-r', 'docs/output/', "../atom-docs/public/#{tag}/"]
       grunt.util.spawn {cmd, args}, (error, result) ->
         if error?
           callback(error)
@@ -82,4 +73,4 @@ module.exports = (grunt) ->
       args = [docsRepoArgs..., 'push', 'heroku', 'master']
       grunt.util.spawn({cmd, args, opts}, callback)
 
-    grunt.util.async.waterfall [fetchTag, copyGuides, copyApiDocs, stageDocs, fetchSha, commitChanges, pushOrigin, pushHeroku], done
+    grunt.util.async.waterfall [fetchTag, copyApiDocs, stageDocs, fetchSha, commitChanges, pushOrigin, pushHeroku], done


### PR DESCRIPTION
So this does several things:
- Adds an index.md file which references all of currently available guides.
- Adds a grunt task `markdown:guides` which builds the current guides.
- Update the grunt `deploy-docs` task so that it includes guides and it uses the latest tag for versioning purposes in the atom-docs repo. Now urls look like `/v20.0/api/index.html`, so people can reference `/v19.0/api/index.html` if they desire.

Future Work
- `docs/built-in-packages` should probably be split out into each project's separate repo. I also think there is a bigger question about where this documentation should, I imagine it will be exposed through the web package list so that users could browse it before be installed.
- I realize the generated markdown isn't pretty for now I'm focused on the content.
