### PR TITLE
Only run specs found in the current project's spec folder

### DIFF
--- a/keymaps/atom.cson
+++ b/keymaps/atom.cson
@@ -45,6 +45,7 @@
   'ctrl-meta-f': 'window:toggle-full-screen'
   'meta-r': 'window:reload'
   'alt-meta-i': 'window:toggle-dev-tools'
+  'meta-alt-ctrl-p': 'window:run-package-specs'
 
   'ctrl-|': 'pane:split-right'
   'ctrl-w v': 'pane:split-right'

--- a/keymaps/atom.cson
+++ b/keymaps/atom.cson
@@ -9,7 +9,7 @@
   'meta-m': 'application:minimize'
   'meta-,': 'application:show-settings'
   'alt-meta-ctrl-m': 'application:zoom'
-  'meta-alt-ctrl-s': 'application:run-specs'
+  'meta-alt-ctrl-s': 'application:run-all-specs'
 
   'meta-s': 'core:save'
   'meta-S': 'core:save-as'

--- a/spec/spec-suite.coffee
+++ b/spec/spec-suite.coffee
@@ -15,24 +15,33 @@ measure 'spec suite require time', ->
     for spec in jasmine.getEnv().currentRunner().specs() when not spec.specType?
       spec.specType = specType
 
-  # Run core specs
-  requireSpecs(window.resourcePath)
-  setSpecType('core')
+  runAllSpecs = ->
+    requireSpecs(window.resourcePath)
+    setSpecType('core')
 
-  fixturesPackagesPath = fsUtils.resolveOnLoadPath('fixtures/packages')
-  packagePaths = atom.getAvailablePackageNames().map (packageName) -> atom.resolvePackagePath(packageName)
-  packagePaths = _.groupBy packagePaths, (packagePath) ->
-    if packagePath.indexOf("#{fixturesPackagesPath}#{path.sep}") is 0
-      'fixtures'
-    else if packagePath.indexOf("#{window.resourcePath}#{path.sep}") is 0
-      'bundled'
-    else
-      'user'
+    fixturesPackagesPath = fsUtils.resolveOnLoadPath('fixtures/packages')
+    packagePaths = atom.getAvailablePackageNames().map (packageName) -> atom.resolvePackagePath(packageName)
+    packagePaths = _.groupBy packagePaths, (packagePath) ->
+      if packagePath.indexOf("#{fixturesPackagesPath}#{path.sep}") is 0
+        'fixtures'
+      else if packagePath.indexOf("#{window.resourcePath}#{path.sep}") is 0
+        'bundled'
+      else
+        'user'
 
-  # Run bundled package specs
-  requireSpecs(packagePath) for packagePath in packagePaths.bundled ? []
-  setSpecType('bundled')
+    # Run bundled package specs
+    requireSpecs(packagePath) for packagePath in packagePaths.bundled ? []
+    setSpecType('bundled')
 
-  # Run user package specs
-  requireSpecs(packagePath) for packagePath in packagePaths.user ? []
-  setSpecType('user')
+    # Run user package specs
+    requireSpecs(packagePath) for packagePath in packagePaths.user ? []
+    setSpecType('user')
+
+  runSpecs = (specPath) ->
+    requireSpecs(specPath)
+    setSpecType("user")
+
+  if specPath = atom.getLoadSettings().specPath
+    runSpecs(specPath)
+  else
+    runAllSpecs()

--- a/src/application-menu.coffee
+++ b/src/application-menu.coffee
@@ -58,7 +58,7 @@ class ApplicationMenu
         { label: 'Hide Others', command: 'application:hide-other-applications' }
         { label: 'Show All', command: 'application:unhide-all-applications' }
         { type: 'separator' }
-        { label: 'Run Specs', command: 'application:run-specs' }
+        { label: 'Run Atom Specs', command: 'application:run-all-specs' }
         { type: 'separator' }
         { label: 'Quit', command: 'application:quit' }
       ]

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -140,6 +140,9 @@ class AtomApplication
     ipc.once 'update-application-menu', (processId, routingId, keystrokesByCommand) =>
       @applicationMenu.update(keystrokesByCommand)
 
+    ipc.on 'run-package-specs', (processId, routingId, packagePath) =>
+      @runSpecs({@resourcePath, specPath: packagePath, exitWhenDone: false})
+
     ipc.on 'command', (processId, routingId, command) =>
       @emit(command)
 
@@ -194,14 +197,14 @@ class AtomApplication
     else
       console.log "Opening unknown url #{urlToOpen}"
 
-  runSpecs: ({exitWhenDone, resourcePath}) ->
+  runSpecs: ({exitWhenDone, resourcePath, specPath}) ->
     if resourcePath isnt @resourcePath and not fs.existsSync(resourcePath)
       resourcePath = @resourcePath
 
     bootstrapScript = 'spec-bootstrap'
     isSpec = true
     devMode = true
-    new AtomWindow({bootstrapScript, resourcePath, exitWhenDone, isSpec, devMode})
+    new AtomWindow({bootstrapScript, resourcePath, exitWhenDone, isSpec, devMode, specPath})
 
   promptForPath: ({devMode}={}) ->
     pathsToOpen = dialog.showOpenDialog title: 'Open', properties: ['openFile', 'openDirectory', 'multiSelections', 'createDirectory']

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -99,7 +99,7 @@ class AtomApplication
 
   handleEvents: ->
     @on 'application:about', -> Menu.sendActionToFirstResponder('orderFrontStandardAboutPanel:')
-    @on 'application:run-specs', -> @runSpecs(exitWhenDone: false, resourcePath: global.devResourcePath)
+    @on 'application:run-all-specs', -> @runSpecs(exitWhenDone: false, resourcePath: global.devResourcePath)
     @on 'application:show-settings', -> (@focusedWindow() ? this).openPath("atom://config")
     @on 'application:quit', -> app.quit()
     @on 'application:hide', -> Menu.sendActionToFirstResponder('hide:')

--- a/src/root-view.coffee
+++ b/src/root-view.coffee
@@ -67,7 +67,7 @@ class RootView extends View
     @on 'pane:active-item-title-changed', '.active.pane', => @updateTitle()
 
     @command 'application:about', -> ipc.sendChannel('command', 'application:about')
-    @command 'application:run-specs', -> ipc.sendChannel('command', 'application:run-specs')
+    @command 'application:run-all-specs', -> ipc.sendChannel('command', 'application:run-all-specs')
     @command 'application:show-settings', -> ipc.sendChannel('command', 'application:show-settings')
     @command 'application:quit', -> ipc.sendChannel('command', 'application:quit')
     @command 'application:hide', -> ipc.sendChannel('command', 'application:hide')

--- a/src/root-view.coffee
+++ b/src/root-view.coffee
@@ -81,6 +81,7 @@ class RootView extends View
     @command 'application:zoom', -> ipc.sendChannel('command', 'application:zoom')
     @command 'application:bring-all-windows-to-front', -> ipc.sendChannel('command', 'application:bring-all-windows-to-front')
 
+    @command 'window:run-package-specs', => ipc.sendChannel('run-package-specs', project.getPath())
     @command 'window:increase-font-size', =>
       config.set("editor.fontSize", config.get("editor.fontSize") + 1)
 


### PR DESCRIPTION
Running specs while writing a package is painful. This lets you only run the specs from the package you are working on.
