### PR TITLE
Soft wrap tweaks

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -69,15 +69,12 @@ describe "DisplayBuffer", ->
         it "uses the preferred line length as the soft wrap column when it is less than the configured soft wrap column", ->
           config.set('editor.preferredLineLength', 100)
           config.set('editor.softWrapAtPreferredLineLength', true)
-          displayBuffer.updateWrappedScreenLines()
           expect(displayBuffer.lineForRow(10).text).toBe '    return '
 
           config.set('editor.preferredLineLength', 5)
-          displayBuffer.updateWrappedScreenLines()
           expect(displayBuffer.lineForRow(10).text).toBe 'funct'
 
           config.set('editor.softWrapAtPreferredLineLength', false)
-          displayBuffer.updateWrappedScreenLines()
           expect(displayBuffer.lineForRow(10).text).toBe '    return '
 
       describe "when the line is shorter than the max line length", ->

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -17,9 +17,9 @@ describe "DisplayBuffer", ->
     buffer.release()
 
   describe "@deserialize(state)", ->
-    it "constructs a display buffer with the same buffer, folds, softWrapColumn, and tabLength", ->
+    it "constructs a display buffer with the same buffer, folds, editorWidthInChars, and tabLength", ->
       displayBuffer.setTabLength(4)
-      displayBuffer.setSoftWrapColumn(64)
+      displayBuffer.setEditorWidthInChars(64)
       displayBuffer.createFold(2, 4)
       displayBuffer2 = deserialize(displayBuffer.serialize())
       expect(displayBuffer2.id).toBe displayBuffer.id
@@ -61,7 +61,7 @@ describe "DisplayBuffer", ->
   describe "soft wrapping", ->
     beforeEach ->
       displayBuffer.setSoftWrap(true)
-      displayBuffer.setSoftWrapColumn(50)
+      displayBuffer.setEditorWidthInChars(50)
       changeHandler.reset()
 
     describe "rendering of soft-wrapped lines", ->
@@ -94,7 +94,7 @@ describe "DisplayBuffer", ->
         describe "when there is no whitespace before the boundary", ->
           it "wraps the line exactly at the boundary since there's no more graceful place to wrap it", ->
             buffer.change([[0, 0], [1, 0]], 'abcdefghijklmnopqrstuvwxyz\n')
-            displayBuffer.setSoftWrapColumn(10)
+            displayBuffer.setEditorWidthInChars(10)
             expect(displayBuffer.lineForRow(0).text).toBe 'abcdefghij'
             expect(displayBuffer.lineForRow(1).text).toBe 'klmnopqrst'
             expect(displayBuffer.lineForRow(2).text).toBe 'uvwxyz'
@@ -156,7 +156,7 @@ describe "DisplayBuffer", ->
       describe "when a newline is inserted, deleted, and re-inserted at the end of a wrapped line (regression)", ->
         it "correctly renders the original wrapped line", ->
           buffer = project.buildBuffer(null, '')
-          displayBuffer = new DisplayBuffer({buffer, tabLength, softWrapColumn: 30, softWrap: true})
+          displayBuffer = new DisplayBuffer({buffer, tabLength, editorWidthInChars: 30, softWrap: true})
 
           buffer.insert([0, 0], "the quick brown fox jumps over the lazy dog.")
           buffer.insert([0, Infinity], '\n')
@@ -195,9 +195,9 @@ describe "DisplayBuffer", ->
         expect(displayBuffer.bufferPositionForScreenPosition([3, -5])).toEqual([3, 0])
         expect(displayBuffer.bufferPositionForScreenPosition([3, Infinity])).toEqual([3, 50])
 
-    describe ".setSoftWrapColumn(length)", ->
+    describe ".setEditorWidthInChars(length)", ->
       it "changes the length at which lines are wrapped and emits a change event for all screen lines", ->
-        displayBuffer.setSoftWrapColumn(40)
+        displayBuffer.setEditorWidthInChars(40)
         expect(tokensText displayBuffer.lineForRow(4).tokens).toBe 'left = [], right = [];'
         expect(tokensText displayBuffer.lineForRow(5).tokens).toBe '    while(items.length > 0) {'
         expect(tokensText displayBuffer.lineForRow(12).tokens).toBe 'sort(left).concat(pivot).concat(sort(rig'
@@ -519,7 +519,7 @@ describe "DisplayBuffer", ->
   describe ".clipScreenPosition(screenPosition, wrapBeyondNewlines: false, wrapAtSoftNewlines: false, skipAtomicTokens: false)", ->
     beforeEach ->
       displayBuffer.setSoftWrap(true)
-      displayBuffer.setSoftWrapColumn(50)
+      displayBuffer.setEditorWidthInChars(50)
 
     it "allows valid positions", ->
       expect(displayBuffer.clipScreenPosition([4, 5])).toEqual [4, 5]

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -60,6 +60,7 @@ describe "DisplayBuffer", ->
 
   describe "soft wrapping", ->
     beforeEach ->
+      displayBuffer.setSoftWrap(true)
       displayBuffer.setSoftWrapColumn(50)
       changeHandler.reset()
 
@@ -143,7 +144,7 @@ describe "DisplayBuffer", ->
       describe "when a newline is inserted, deleted, and re-inserted at the end of a wrapped line (regression)", ->
         it "correctly renders the original wrapped line", ->
           buffer = project.buildBuffer(null, '')
-          displayBuffer = new DisplayBuffer({buffer, tabLength, softWrapColumn: 30})
+          displayBuffer = new DisplayBuffer({buffer, tabLength, softWrapColumn: 30, softWrap: true})
 
           buffer.insert([0, 0], "the quick brown fox jumps over the lazy dog.")
           buffer.insert([0, Infinity], '\n')
@@ -505,6 +506,7 @@ describe "DisplayBuffer", ->
 
   describe ".clipScreenPosition(screenPosition, wrapBeyondNewlines: false, wrapAtSoftNewlines: false, skipAtomicTokens: false)", ->
     beforeEach ->
+      displayBuffer.setSoftWrap(true)
       displayBuffer.setSoftWrapColumn(50)
 
     it "allows valid positions", ->

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -65,6 +65,21 @@ describe "DisplayBuffer", ->
       changeHandler.reset()
 
     describe "rendering of soft-wrapped lines", ->
+      describe "when editor.softWrapAtPreferredLineLength is set", ->
+        it "uses the preferred line length as the soft wrap column when it is less than the configured soft wrap column", ->
+          config.set('editor.preferredLineLength', 100)
+          config.set('editor.softWrapAtPreferredLineLength', true)
+          displayBuffer.updateWrappedScreenLines()
+          expect(displayBuffer.lineForRow(10).text).toBe '    return '
+
+          config.set('editor.preferredLineLength', 5)
+          displayBuffer.updateWrappedScreenLines()
+          expect(displayBuffer.lineForRow(10).text).toBe 'funct'
+
+          config.set('editor.softWrapAtPreferredLineLength', false)
+          displayBuffer.updateWrappedScreenLines()
+          expect(displayBuffer.lineForRow(10).text).toBe '    return '
+
       describe "when the line is shorter than the max line length", ->
         it "renders the line unchanged", ->
           expect(displayBuffer.lineForRow(0).text).toBe buffer.lineForRow(0)

--- a/spec/edit-session-spec.coffee
+++ b/spec/edit-session-spec.coffee
@@ -102,6 +102,7 @@ describe "EditSession", ->
 
       describe "when soft-wrap is enabled and code is folded", ->
         beforeEach ->
+          editSession.setSoftWrap(true)
           editSession.setSoftWrapColumn(50)
           editSession.createFold(2, 3)
 
@@ -325,6 +326,7 @@ describe "EditSession", ->
     describe ".moveCursorToBeginningOfLine()", ->
       describe "when soft wrap is on", ->
         it "moves cursor to the beginning of the screen line", ->
+          editSession.setSoftWrap(true)
           editSession.setSoftWrapColumn(10)
           editSession.setCursorScreenPosition([1, 2])
           editSession.moveCursorToBeginningOfLine()
@@ -344,6 +346,7 @@ describe "EditSession", ->
     describe ".moveCursorToEndOfLine()", ->
       describe "when soft wrap is on", ->
         it "moves cursor to the beginning of the screen line", ->
+          editSession.setSoftWrap(true)
           editSession.setSoftWrapColumn(10)
           editSession.setCursorScreenPosition([1, 2])
           editSession.moveCursorToEndOfLine()
@@ -363,6 +366,7 @@ describe "EditSession", ->
     describe ".moveCursorToFirstCharacterOfLine()", ->
       describe "when soft wrap is on", ->
         it "moves to the first character of the current screen line or the beginning of the screen line if it's already on the first character", ->
+          editSession.setSoftWrap(true)
           editSession.setSoftWrapColumn(10)
           editSession.setCursorScreenPosition [2,5]
           editSession.addCursorAtScreenPosition [8,7]
@@ -1778,6 +1782,7 @@ describe "EditSession", ->
       describe ".cutToEndOfLine()", ->
         describe "when soft wrap is on", ->
           it "cuts up to the end of the line", ->
+            editSession.setSoftWrap(true)
             editSession.setSoftWrapColumn(10)
             editSession.setCursorScreenPosition([2, 2])
             editSession.cutToEndOfLine()
@@ -2234,6 +2239,7 @@ describe "EditSession", ->
 
     describe "when soft wrap is enabled", ->
       it "deletes the entire line that the cursor is on", ->
+        editSession.setSoftWrap(true)
         editSession.setSoftWrapColumn(10)
         editSession.setCursorBufferPosition([6])
 

--- a/spec/edit-session-spec.coffee
+++ b/spec/edit-session-spec.coffee
@@ -121,7 +121,7 @@ describe "EditSession", ->
       describe "when soft-wrap is enabled and code is folded", ->
         beforeEach ->
           editSession.setSoftWrap(true)
-          editSession.setSoftWrapColumn(50)
+          editSession.setEditorWidthInChars(50)
           editSession.createFold(2, 3)
 
         it "positions the cursor at the buffer position that corresponds to the given screen position", ->
@@ -345,7 +345,7 @@ describe "EditSession", ->
       describe "when soft wrap is on", ->
         it "moves cursor to the beginning of the screen line", ->
           editSession.setSoftWrap(true)
-          editSession.setSoftWrapColumn(10)
+          editSession.setEditorWidthInChars(10)
           editSession.setCursorScreenPosition([1, 2])
           editSession.moveCursorToBeginningOfLine()
           cursor = editSession.getCursor()
@@ -365,7 +365,7 @@ describe "EditSession", ->
       describe "when soft wrap is on", ->
         it "moves cursor to the beginning of the screen line", ->
           editSession.setSoftWrap(true)
-          editSession.setSoftWrapColumn(10)
+          editSession.setEditorWidthInChars(10)
           editSession.setCursorScreenPosition([1, 2])
           editSession.moveCursorToEndOfLine()
           cursor = editSession.getCursor()
@@ -385,7 +385,7 @@ describe "EditSession", ->
       describe "when soft wrap is on", ->
         it "moves to the first character of the current screen line or the beginning of the screen line if it's already on the first character", ->
           editSession.setSoftWrap(true)
-          editSession.setSoftWrapColumn(10)
+          editSession.setEditorWidthInChars(10)
           editSession.setCursorScreenPosition [2,5]
           editSession.addCursorAtScreenPosition [8,7]
 
@@ -1801,7 +1801,7 @@ describe "EditSession", ->
         describe "when soft wrap is on", ->
           it "cuts up to the end of the line", ->
             editSession.setSoftWrap(true)
-            editSession.setSoftWrapColumn(10)
+            editSession.setEditorWidthInChars(10)
             editSession.setCursorScreenPosition([2, 2])
             editSession.cutToEndOfLine()
             expect(editSession.lineForScreenRow(2).text).toBe '=  () {'
@@ -2258,7 +2258,7 @@ describe "EditSession", ->
     describe "when soft wrap is enabled", ->
       it "deletes the entire line that the cursor is on", ->
         editSession.setSoftWrap(true)
-        editSession.setSoftWrapColumn(10)
+        editSession.setEditorWidthInChars(10)
         editSession.setCursorBufferPosition([6])
 
         line7 = buffer.lineForRow(7)

--- a/spec/edit-session-spec.coffee
+++ b/spec/edit-session-spec.coffee
@@ -49,6 +49,24 @@ describe "EditSession", ->
       editSession2.unfoldBufferRow(4)
       expect(editSession2.isFoldedAtBufferRow(4)).not.toBe editSession.isFoldedAtBufferRow(4)
 
+  describe "config defaults", ->
+    it "uses the `editor.tabLength`, `editor.softWrap`, and `editor.softTabs` config values", ->
+      config.set('editor.tabLength', 4)
+      config.set('editor.softWrap', true)
+      config.set('editor.softTabs', false)
+      editSession1 = project.open('a')
+      expect(editSession1.getTabLength()).toBe 4
+      expect(editSession1.getSoftWrap()).toBe true
+      expect(editSession1.getSoftTabs()).toBe false
+
+      config.set('editor.tabLength', 100)
+      config.set('editor.softWrap', false)
+      config.set('editor.softTabs', true)
+      editSession2 = project.open('b')
+      expect(editSession2.getTabLength()).toBe 100
+      expect(editSession2.getSoftWrap()).toBe false
+      expect(editSession2.getSoftTabs()).toBe true
+
   describe "title", ->
     describe ".getTitle()", ->
       it "uses the basename of the buffer's path as its title, or 'untitled' if the path is undefined", ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2670,3 +2670,11 @@ describe "Editor", ->
 
       for rowNumber in [1..5]
         expect(editor.lineElementForScreenRow(rowNumber).text()).toBe buffer.lineForRow(rowNumber)
+
+  describe "when the window is resized", ->
+    it "updates the active edit session with the current soft wrap column", ->
+      editor.attachToDom()
+      expect(editor.activeEditSession.getSoftWrapColumn()).toBe 78
+      editor.width(editor.width() * 2)
+      $(window).trigger 'resize'
+      expect(editor.activeEditSession.getSoftWrapColumn()).toBe 155

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1632,7 +1632,7 @@ describe "Editor", ->
       setEditorHeightInLines(editor, 20)
       setEditorWidthInChars(editor, 50)
       editor.setSoftWrap(true)
-      expect(editor.activeEditSession.softWrapColumn).toBe 50
+      expect(editor.activeEditSession.getSoftWrapColumn()).toBe 50
 
     it "wraps lines that are too long to fit within the editor's width, adjusting cursor positioning accordingly", ->
       expect(editor.renderedLines.find('.line').length).toBe 16

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1485,7 +1485,7 @@ describe "Editor", ->
         it "doesn't show the end of line invisible at the end of lines broken due to wrapping", ->
           editor.setText "a line that wraps"
           editor.attachToDom()
-          editor.setSoftWrapColumn(6)
+          editor.setWidthInChars(6)
           config.set "editor.showInvisibles", true
           space = editor.invisibles?.space
           expect(space).toBeTruthy()
@@ -1497,7 +1497,7 @@ describe "Editor", ->
         it "displays trailing carriage return using a visible non-empty value", ->
           editor.setText "a line that\r\n"
           editor.attachToDom()
-          editor.setSoftWrapColumn(6)
+          editor.setWidthInChars(6)
           config.set "editor.showInvisibles", true
           space = editor.invisibles?.space
           expect(space).toBeTruthy()
@@ -1699,15 +1699,15 @@ describe "Editor", ->
       editor.moveCursorRight()
       expect(editor.getCursorScreenPosition()).toEqual [11, 0]
 
-    it "calls .setSoftWrapColumn() when the editor is attached because now its dimensions are available to calculate it", ->
+    it "calls .setWidthInChars() when the editor is attached because now its dimensions are available to calculate it", ->
       otherEditor = new Editor(editSession: project.open('sample.js'))
-      spyOn(otherEditor, 'setSoftWrapColumn')
+      spyOn(otherEditor, 'setWidthInChars')
 
       otherEditor.activeEditSession.setSoftWrap(true)
-      expect(otherEditor.setSoftWrapColumn).not.toHaveBeenCalled()
+      expect(otherEditor.setWidthInChars).not.toHaveBeenCalled()
 
       otherEditor.simulateDomAttachment()
-      expect(otherEditor.setSoftWrapColumn).toHaveBeenCalled()
+      expect(otherEditor.setWidthInChars).toHaveBeenCalled()
       otherEditor.remove()
 
   describe "gutter rendering", ->
@@ -1744,7 +1744,7 @@ describe "Editor", ->
     describe "when wrapping is on", ->
       it "renders a • instead of line number for wrapped portions of lines", ->
         editSession.setSoftWrap(true)
-        editor.setSoftWrapColumn(50)
+        editor.setWidthInChars(50)
         expect(editor.gutter.find('.line-number').length).toEqual(8)
         expect(editor.gutter.find('.line-number:eq(3)').intValue()).toBe 4
         expect(editor.gutter.find('.line-number:eq(4)').html()).toBe '&nbsp;•'

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1013,7 +1013,7 @@ describe "Editor", ->
 
           describe "when soft-wrap is enabled", ->
             beforeEach ->
-              editor.setSoftWrap(true)
+              editSession.setSoftWrap(true)
 
             it "does not scroll the buffer horizontally", ->
               editor.width(charWidth * 30)
@@ -1480,7 +1480,7 @@ describe "Editor", ->
 
       describe "when wrapping is on", ->
         beforeEach ->
-          editor.setSoftWrap(true)
+          editSession.setSoftWrap(true)
 
         it "doesn't show the end of line invisible at the end of lines broken due to wrapping", ->
           editor.setText "a line that wraps"
@@ -1631,10 +1631,10 @@ describe "Editor", ->
 
   describe "when soft-wrap is enabled", ->
     beforeEach ->
+      editSession.setSoftWrap(true)
       editor.attachToDom()
       setEditorHeightInLines(editor, 20)
       setEditorWidthInChars(editor, 50)
-      editor.setSoftWrap(true)
       expect(editor.activeEditSession.getSoftWrapColumn()).toBe 50
 
     it "wraps lines that are too long to fit within the editor's width, adjusting cursor positioning accordingly", ->
@@ -1703,7 +1703,7 @@ describe "Editor", ->
       otherEditor = new Editor(editSession: project.open('sample.js'))
       spyOn(otherEditor, 'setSoftWrapColumn')
 
-      otherEditor.setSoftWrap(true)
+      otherEditor.activeEditSession.setSoftWrap(true)
       expect(otherEditor.setSoftWrapColumn).not.toHaveBeenCalled()
 
       otherEditor.simulateDomAttachment()
@@ -1743,7 +1743,7 @@ describe "Editor", ->
 
     describe "when wrapping is on", ->
       it "renders a • instead of line number for wrapped portions of lines", ->
-        editor.setSoftWrap(true)
+        editSession.setSoftWrap(true)
         editor.setSoftWrapColumn(50)
         expect(editor.gutter.find('.line-number').length).toEqual(8)
         expect(editor.gutter.find('.line-number:eq(3)').intValue()).toBe 4
@@ -1883,7 +1883,7 @@ describe "Editor", ->
     describe "when there is wrapping", ->
       beforeEach ->
         editor.attachToDom(30)
-        editor.setSoftWrap(true)
+        editSession.setSoftWrap(true)
         setEditorWidthInChars(editor, 20)
 
       it "highlights the line where the initial cursor position is", ->
@@ -1946,7 +1946,7 @@ describe "Editor", ->
 
     describe "when there is wrapping", ->
       beforeEach ->
-        editor.setSoftWrap(true)
+        editSession.setSoftWrap(true)
         setEditorWidthInChars(editor, 20)
 
       it "highlights the line where the initial cursor position is", ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1479,10 +1479,13 @@ describe "Editor", ->
         expect(editor.renderedLines.find('.line:first').text()).toBe "a line that ends with a carriage return#{cr}#{eol}"
 
       describe "when wrapping is on", ->
+        beforeEach ->
+          editor.setSoftWrap(true)
+
         it "doesn't show the end of line invisible at the end of lines broken due to wrapping", ->
-          editor.setSoftWrapColumn(6)
           editor.setText "a line that wraps"
           editor.attachToDom()
+          editor.setSoftWrapColumn(6)
           config.set "editor.showInvisibles", true
           space = editor.invisibles?.space
           expect(space).toBeTruthy()
@@ -1492,9 +1495,9 @@ describe "Editor", ->
           expect(editor.renderedLines.find('.line:last').text()).toBe "wraps#{eol}"
 
         it "displays trailing carriage return using a visible non-empty value", ->
-          editor.setSoftWrapColumn(6)
           editor.setText "a line that\r\n"
           editor.attachToDom()
+          editor.setSoftWrapColumn(6)
           config.set "editor.showInvisibles", true
           space = editor.invisibles?.space
           expect(space).toBeTruthy()
@@ -1740,6 +1743,7 @@ describe "Editor", ->
 
     describe "when wrapping is on", ->
       it "renders a • instead of line number for wrapped portions of lines", ->
+        editor.setSoftWrap(true)
         editor.setSoftWrapColumn(50)
         expect(editor.gutter.find('.line-number').length).toEqual(8)
         expect(editor.gutter.find('.line-number:eq(3)').intValue()).toBe 4

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1670,13 +1670,9 @@ describe "Editor", ->
       editor.edit(otherEditSession)
       expect(editor.renderedLines.find('.line').length).toBe(1)
 
-    it "unwraps lines and cancels window resize listener when softwrap is disabled", ->
+    it "unwraps lines when softwrap is disabled", ->
       editor.toggleSoftWrap()
       expect(editor.renderedLines.find('.line:eq(3)').text()).toBe '    var pivot = items.shift(), current, left = [], right = [];'
-
-      spyOn(editor, 'setSoftWrapColumn')
-      $(window).trigger 'resize'
-      expect(editor.setSoftWrapColumn).not.toHaveBeenCalled()
 
     it "allows the cursor to move down to the last line", ->
       _.times editor.getLastScreenRow(), -> editor.moveCursorDown()

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2674,7 +2674,8 @@ describe "Editor", ->
   describe "when the window is resized", ->
     it "updates the active edit session with the current soft wrap column", ->
       editor.attachToDom()
-      expect(editor.activeEditSession.getSoftWrapColumn()).toBe 78
-      editor.width(editor.width() * 2)
+      setEditorWidthInChars(editor, 50)
+      expect(editor.activeEditSession.getSoftWrapColumn()).toBe 50
+      setEditorWidthInChars(editor, 100)
       $(window).trigger 'resize'
-      expect(editor.activeEditSession.getSoftWrapColumn()).toBe 155
+      expect(editor.activeEditSession.getSoftWrapColumn()).toBe 100

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -66,23 +66,6 @@ describe "Project", ->
       Project.unregisterOpener(barOpener)
 
     describe "when passed a path that doesn't match a custom opener", ->
-      it "creates the edit session with the configured `editor.tabLength` and `editor.softWrap` settings", ->
-        config.set('editor.tabLength', 4)
-        config.set('editor.softWrap', true)
-        config.set('editor.softTabs', false)
-        editSession1 = project.open('a')
-        expect(editSession1.getTabLength()).toBe 4
-        expect(editSession1.getSoftWrap()).toBe true
-        expect(editSession1.getSoftTabs()).toBe false
-
-        config.set('editor.tabLength', 100)
-        config.set('editor.softWrap', false)
-        config.set('editor.softTabs', true)
-        editSession2 = project.open('b')
-        expect(editSession2.getTabLength()).toBe 100
-        expect(editSession2.getSoftWrap()).toBe false
-        expect(editSession2.getSoftTabs()).toBe true
-
       describe "when given an absolute path that hasn't been opened previously", ->
         it "returns a new edit session for the given path and emits 'buffer-created' and 'edit-session-created' events", ->
           editSession = project.open(absolutePath)

--- a/src/config-observer.coffee
+++ b/src/config-observer.coffee
@@ -1,7 +1,7 @@
 module.exports =
-  observeConfig: (keyPath, callback) ->
+  observeConfig: (keyPath, args...) ->
     @configSubscriptions ?= {}
-    @configSubscriptions[keyPath] = config.observe(keyPath, callback)
+    @configSubscriptions[keyPath] = config.observe(keyPath, args...)
 
   unobserveConfig: ->
     for keyPath, subscription of @configSubscriptions ? {}

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -177,10 +177,10 @@ class Config
   # Establishes an event listener for a given key.
   #
   # `callback` is fired whenever the value of the key is changed and will
-  #  be fired immediately unless the `callbackImmediately` option is `false`.
+  #  be fired immediately unless the `callNow` option is `false`.
   #
   # keyPath - The {String} name of the key to watch
-  # options - An optional {Object} containing the `callbackImmediately` key.
+  # options - An optional {Object} containing the `callNow` key.
   # callback - The {Function} that fires when the. It is given a single argument, `value`,
   #            which is the new value of `keyPath`.
   observe: (keyPath, options={}, callback) ->
@@ -198,7 +198,7 @@ class Config
 
     subscription = { cancel: => @off 'updated', updateCallback  }
     @on 'updated', updateCallback
-    callback(value) if options.callbackImmediately ? true
+    callback(value) if options.callNow ? true
     subscription
 
   ### Internal ###

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -176,12 +176,18 @@ class Config
 
   # Establishes an event listener for a given key.
   #
-  # `callback` is fired immediately and whenever the value of the key is changed
+  # `callback` is fired whenever the value of the key is changed and will
+  #  be fired immediately unless the `callbackImmediately` option is `false`.
   #
   # keyPath - The {String} name of the key to watch
+  # options - An optional {Object} containing the `callbackImmediately` key.
   # callback - The {Function} that fires when the. It is given a single argument, `value`,
   #            which is the new value of `keyPath`.
-  observe: (keyPath, callback) ->
+  observe: (keyPath, options={}, callback) ->
+    if _.isFunction(options)
+      callback = options
+      options = {}
+
     value = @get(keyPath)
     previousValue = _.clone(value)
     updateCallback = =>
@@ -192,7 +198,7 @@ class Config
 
     subscription = { cancel: => @off 'updated', updateCallback  }
     @on 'updated', updateCallback
-    callback(value)
+    callback(value) if options.callbackImmediately ? true
     subscription
 
   ### Internal ###

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -14,14 +14,9 @@ DefaultSoftWrapColumn = 1000000
 
 module.exports =
 class DisplayBuffer
-  screenLines: null
-  rowMap: null
-  tokenizedBuffer: null
-  markers: null
-  foldsByMarkerId: null
-
   @acceptsDocuments: true
   registerDeserializer(this)
+  @version: 1
 
   @deserialize: (state) -> new this(state)
 
@@ -32,13 +27,15 @@ class DisplayBuffer
       @tokenizedBuffer = deserialize(@state.get('tokenizedBuffer'))
       @buffer = @tokenizedBuffer.buffer
     else
-      {@buffer, softWrapColumn} = optionsOrState
+      {@buffer, softWrap, softWrapColumn} = optionsOrState
       @id = guid.create().toString()
       @tokenizedBuffer = new TokenizedBuffer(optionsOrState)
       @state = site.createDocument
         deserializer: @constructor.name
+        version: @constructor.version
         id: @id
         tokenizedBuffer: @tokenizedBuffer.getState()
+        softWrap: softWrap ? false
         softWrapColumn: softWrapColumn ? DefaultSoftWrapColumn
 
     @markers = {}
@@ -78,6 +75,10 @@ class DisplayBuffer
   #
   # visible - A {Boolean} indicating of the tokenized buffer is shown
   setVisible: (visible) -> @tokenizedBuffer.setVisible(visible)
+
+  setSoftWrap: (softWrap) -> @state.set('softWrap', softWrap)
+
+  getSoftWrap: -> @state.get('softWrap')
 
   # Defines the limit at which the buffer begins to soft wrap text.
   #

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -10,8 +10,6 @@ Token = require 'token'
 DisplayBufferMarker = require 'display-buffer-marker'
 Subscriber = require 'subscriber'
 
-DefaultSoftWrapColumn = 1000000
-
 module.exports =
 class DisplayBuffer
   @acceptsDocuments: true
@@ -36,7 +34,7 @@ class DisplayBuffer
         id: @id
         tokenizedBuffer: @tokenizedBuffer.getState()
         softWrap: softWrap ? false
-        softWrapColumn: softWrapColumn ? DefaultSoftWrapColumn
+        softWrapColumn: softWrapColumn
 
     @markers = {}
     @foldsByMarkerId = {}
@@ -408,6 +406,7 @@ class DisplayBuffer
   # Returns a {Number} representing the `line` position where the wrap would take place.
   # Returns `null` if a wrap wouldn't occur.
   findWrapColumn: (line, softWrapColumn=@getSoftWrapColumn()) ->
+    return unless @getSoftWrap()
     return unless line.length > softWrapColumn
 
     if /\s/.test(line[softWrapColumn])

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -23,8 +23,7 @@ class DisplayBuffer
   @acceptsDocuments: true
   registerDeserializer(this)
 
-  @deserialize: (state) ->
-    new DisplayBuffer(state)
+  @deserialize: (state) -> new this(state)
 
   constructor: (optionsOrState) ->
     if optionsOrState instanceof telepath.Document

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -45,6 +45,12 @@ class DisplayBuffer
     @subscribe @buffer, 'markers-updated', @handleBufferMarkersUpdated
     @subscribe @buffer, 'marker-created', @handleBufferMarkerCreated
 
+    @state.on 'changed', ({key, newValue}) =>
+      switch key
+        when 'softWrap'
+          @trigger 'soft-wrap-changed', newValue
+          @updateWrappedScreenLines()
+
   serialize: -> @state.clone()
   getState: -> @state
 
@@ -67,6 +73,14 @@ class DisplayBuffer
     @trigger 'changed', eventProperties
     @resumeMarkerObservers()
 
+  updateWrappedScreenLines: ->
+    start = 0
+    end = @getLastRow()
+    @updateAllScreenLines()
+    screenDelta = @getLastRow() - end
+    bufferDelta = 0
+    @triggerChanged({ start, end, screenDelta, bufferDelta })
+
   ### Public ###
 
   # Sets the visibility of the tokenized buffer.
@@ -83,12 +97,7 @@ class DisplayBuffer
   # softWrapColumn - A {Number} defining the soft wrap limit.
   setSoftWrapColumn: (softWrapColumn) ->
     @state.set('softWrapColumn', softWrapColumn)
-    start = 0
-    end = @getLastRow()
-    @updateAllScreenLines()
-    screenDelta = @getLastRow() - end
-    bufferDelta = 0
-    @triggerChanged({ start, end, screenDelta, bufferDelta })
+    @updateWrappedScreenLines() if @getSoftWrap()
 
   getSoftWrapColumn: ->
     @state.get('softWrapColumn')

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -415,6 +415,8 @@ class DisplayBuffer
   # Returns a {Number} representing the `line` position where the wrap would take place.
   # Returns `null` if a wrap wouldn't occur.
   findWrapColumn: (line, softWrapColumn=@getSoftWrapColumn()) ->
+    if config.get('editor.softWrapAtPreferredLineLength')
+      softWrapColumn = Math.min(softWrapColumn, config.getPositiveInt('editor.preferredLineLength', softWrapColumn))
     return unless @getSoftWrap()
     return unless line.length > softWrapColumn
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -33,7 +33,7 @@ class DisplayBuffer
         version: @constructor.version
         id: @id
         tokenizedBuffer: @tokenizedBuffer.getState()
-        softWrap: softWrap ? false
+        softWrap: softWrap ? config.get('editor.softWrap') ? false
         softWrapColumn: softWrapColumn
 
     @markers = {}

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -56,10 +56,10 @@ class DisplayBuffer
           @trigger 'soft-wrap-changed', newValue
           @updateWrappedScreenLines()
 
-    @observeConfig 'editor.preferredLineLength', callbackImmediately: false, =>
+    @observeConfig 'editor.preferredLineLength', callNow: false, =>
       @updateWrappedScreenLines() if @getSoftWrap() and config.get('editor.softWrapAtPreferredLineLength')
 
-    @observeConfig 'editor.softWrapAtPreferredLineLength', callbackImmediately: false, =>
+    @observeConfig 'editor.softWrapAtPreferredLineLength', callNow: false, =>
       @updateWrappedScreenLines() if @getSoftWrap()
 
   serialize: -> @state.clone()

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -51,6 +51,12 @@ class DisplayBuffer
           @trigger 'soft-wrap-changed', newValue
           @updateWrappedScreenLines()
 
+    config.observe 'editor.preferredLineLength', callbackImmediately: false, =>
+      @updateWrappedScreenLines() if @getSoftWrap() and config.get('editor.softWrapAtPreferredLineLength')
+
+    config.observe 'editor.softWrapAtPreferredLineLength', callbackImmediately: false, =>
+      @updateWrappedScreenLines() if @getSoftWrap()
+
   serialize: -> @state.clone()
   getState: -> @state
 

--- a/src/edit-session.coffee
+++ b/src/edit-session.coffee
@@ -22,7 +22,7 @@ class EditSession
 
   ### Internal ###
 
-  @version: 4
+  @version: 5
 
   @deserialize: (state) ->
     new EditSession(state)
@@ -56,13 +56,12 @@ class EditSession
     else
       {buffer, displayBuffer, tabLength, softTabs, softWrap, suppressCursorCreation} = optionsOrState
       @id = guid.create().toString()
-      displayBuffer ?= new DisplayBuffer({buffer, tabLength})
+      displayBuffer ?= new DisplayBuffer({buffer, tabLength, softWrap})
       @state = site.createDocument
         deserializer: @constructor.name
         version: @constructor.version
         id: @id
         displayBuffer: displayBuffer.getState()
-        softWrap: softWrap ? false
         softTabs: buffer.usesSoftTabs() ? softTabs ? true
         scrollTop: 0
         scrollLeft: 0
@@ -122,8 +121,7 @@ class EditSession
     tabLength = @getTabLength()
     displayBuffer = @displayBuffer.copy()
     softTabs = @getSoftTabs()
-    softWrap = @getSoftWrap()
-    newEditSession = new EditSession({@buffer, displayBuffer, tabLength, softTabs, softWrap, suppressCursorCreation: true})
+    newEditSession = new EditSession({@buffer, displayBuffer, tabLength, softTabs, suppressCursorCreation: true})
     newEditSession.setScrollTop(@getScrollTop())
     newEditSession.setScrollLeft(@getScrollLeft())
     for marker in @findMarkers(editSessionId: @id)
@@ -212,14 +210,12 @@ class EditSession
   # Retrieves whether soft tabs are enabled.
   #
   # Returns a {Boolean}.
-  getSoftWrap: ->
-    @state.get('softWrap')
+  getSoftWrap: -> @displayBuffer.getSoftWrap()
 
   # Defines whether to use soft wrapping of text.
   #
   # softTabs - A {Boolean} which, if `true`, indicates that you want soft wraps.
-  setSoftWrap: (softWrap) ->
-    @state.set('softWrap', softWrap)
+  setSoftWrap: (softWrap) -> @displayBuffer.setSoftWrap(softWrap)
 
   # Retrieves that character used to indicate a tab.
   #

--- a/src/edit-session.coffee
+++ b/src/edit-session.coffee
@@ -194,10 +194,12 @@ class EditSession
   # Returns a {Number} defining the `scrollLeft`, in pixels.
   getScrollLeft: -> @state.get('scrollLeft')
 
-  # Defines the limit at which the buffer begins to soft wrap text.
+  # Set the number of characters that can be displayed horizontally in the
+  # editor that contains this edit session.
   #
-  # softWrapColumn - A {Number} defining the soft wrap limit
-  setSoftWrapColumn: (softWrapColumn) -> @displayBuffer.setSoftWrapColumn(softWrapColumn)
+  # editorWidthInChars - A {Number} of characters
+  setEditorWidthInChars: (editorWidthInChars) ->
+    @displayBuffer.setEditorWidthInChars(editorWidthInChars)
 
   getSoftWrapColumn: -> @displayBuffer.getSoftWrapColumn()
 

--- a/src/edit-session.coffee
+++ b/src/edit-session.coffee
@@ -97,6 +97,7 @@ class EditSession
     @subscribe @displayBuffer, "changed", (e) => @trigger 'screen-lines-changed', e
     @subscribe @displayBuffer, "markers-updated", => @mergeIntersectingSelections()
     @subscribe @displayBuffer, 'grammar-changed', => @handleGrammarChange()
+    @subscribe @displayBuffer, 'soft-wrap-changed', (args...) => @trigger 'soft-wrap-changed', args...
 
   getViewClass: ->
     require 'editor'

--- a/src/edit-session.coffee
+++ b/src/edit-session.coffee
@@ -196,7 +196,7 @@ class EditSession
   # Defines the limit at which the buffer begins to soft wrap text.
   #
   # softWrapColumn - A {Number} defining the soft wrap limit
-  setSoftWrapColumn: (@softWrapColumn) -> @displayBuffer.setSoftWrapColumn(@softWrapColumn)
+  setSoftWrapColumn: (softWrapColumn) -> @displayBuffer.setSoftWrapColumn(softWrapColumn)
 
   getSoftWrapColumn: -> @displayBuffer.getSoftWrapColumn()
 

--- a/src/edit-session.coffee
+++ b/src/edit-session.coffee
@@ -62,7 +62,7 @@ class EditSession
         version: @constructor.version
         id: @id
         displayBuffer: displayBuffer.getState()
-        softTabs: buffer.usesSoftTabs() ? softTabs ? true
+        softTabs: buffer.usesSoftTabs() ? softTabs ? config.get('editor.softTabs') ? true
         scrollTop: 0
         scrollLeft: 0
       @setBuffer(buffer)

--- a/src/edit-session.coffee
+++ b/src/edit-session.coffee
@@ -198,6 +198,8 @@ class EditSession
   # softWrapColumn - A {Number} defining the soft wrap limit
   setSoftWrapColumn: (@softWrapColumn) -> @displayBuffer.setSoftWrapColumn(@softWrapColumn)
 
+  getSoftWrapColumn: -> @displayBuffer.getSoftWrapColumn()
+
   getSoftTabs: ->
     @state.get('softTabs')
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -26,6 +26,7 @@ class Editor extends View
     tabLength: 2
     softWrap: false
     softTabs: true
+    softWrapAtPreferredLineLength: false
 
   @nextEditorId: 1
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -773,6 +773,9 @@ class Editor extends View
     @activeEditSession.on 'scroll-left-changed.editor', (scrollLeft) =>
       @scrollLeft(scrollLeft)
 
+    @activeEditSession.on 'soft-wrap-changed.editor', (softWrap) =>
+      @setSoftWrap(softWrap)
+
     @trigger 'editor:path-changed'
     @resetDisplay()
 
@@ -902,7 +905,7 @@ class Editor extends View
 
   # Activates soft wraps in the editor.
   toggleSoftWrap: ->
-    @setSoftWrap(not @activeEditSession.getSoftWrap())
+    @activeEditSession.setSoftWrap(not @activeEditSession.getSoftWrap())
 
   calcSoftWrapColumn: ->
     Math.floor(@scrollView.width() / @charWidth)
@@ -912,10 +915,8 @@ class Editor extends View
   # softWrap - A {Boolean} which, if `true`, sets soft wraps
   # softWrapColumn - A {Number} indicating the length of a line in the editor when soft
   # wrapping turns on
-  setSoftWrap: (softWrap, softWrapColumn=undefined) ->
-    @activeEditSession.setSoftWrap(softWrap)
-    @setSoftWrapColumn(softWrapColumn) if @attached
-    if @activeEditSession.getSoftWrap()
+  setSoftWrap: (softWrap) ->
+    if softWrap
       @addClass 'soft-wrap'
       @scrollLeft(0)
     else
@@ -1133,6 +1134,7 @@ class Editor extends View
     @updateLayerDimensions()
     @scrollTop(editSessionScrollTop)
     @scrollLeft(editSessionScrollLeft)
+    @setSoftWrap(@activeEditSession.getSoftWrap())
     @newCursors = @activeEditSession.getAllCursors()
     @newSelections = @activeEditSession.getAllSelections()
     @updateDisplay(suppressAutoScroll: true)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -900,11 +900,11 @@ class Editor extends View
       @activeEditSession.setScrollTop(@scrollTop())
       @activeEditSession.setScrollLeft(@scrollLeft())
 
-  # {Delegates to: EditSession.setSoftTabs}
+  # Toggle soft tabs on the edit session.
   toggleSoftTabs: ->
     @activeEditSession.setSoftTabs(not @activeEditSession.softTabs)
 
-  # Activates soft wraps in the editor.
+  # Toggle soft wrap on the edit session.
   toggleSoftWrap: ->
     @activeEditSession.setSoftWrap(not @activeEditSession.getSoftWrap())
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -499,10 +499,10 @@ class Editor extends View
   # {Delegates to: EditSession.getScreenLineCount}
   getScreenLineCount: -> @activeEditSession.getScreenLineCount()
 
-  # {Delegates to: EditSession.setSoftWrapColumn}
-  setSoftWrapColumn: (softWrapColumn) ->
-    softWrapColumn ?= @calcSoftWrapColumn()
-    @activeEditSession.setSoftWrapColumn(softWrapColumn) if softWrapColumn
+  # {Delegates to: EditSession.setEditorWidthInChars}
+  setWidthInChars: (widthInChars) ->
+    widthInChars ?= @calculateWidthInChars()
+    @activeEditSession.setEditorWidthInChars(widthInChars) if widthInChars
 
   # {Delegates to: EditSession.getMaxScreenLineLength}
   getMaxScreenLineLength: -> @activeEditSession.getMaxScreenLineLength()
@@ -720,9 +720,9 @@ class Editor extends View
     return if @attached
     @attached = true
     @calculateDimensions()
-    @setSoftWrapColumn()
+    @setWidthInChars()
     @subscribe $(window), "resize.editor-#{@id}", =>
-      @setSoftWrapColumn()
+      @setWidthInChars()
       @requestDisplayUpdate()
     @focus() if @isFocused
 
@@ -908,7 +908,7 @@ class Editor extends View
   toggleSoftWrap: ->
     @activeEditSession.setSoftWrap(not @activeEditSession.getSoftWrap())
 
-  calcSoftWrapColumn: ->
+  calculateWidthInChars: ->
     Math.floor(@scrollView.width() / @charWidth)
 
   # Enables/disables soft wrap on the editor.

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -719,8 +719,10 @@ class Editor extends View
     return if @attached
     @attached = true
     @calculateDimensions()
-    @setSoftWrapColumn() if @activeEditSession.getSoftWrap()
-    @subscribe $(window), "resize.editor-#{@id}", => @requestDisplayUpdate()
+    @setSoftWrapColumn()
+    @subscribe $(window), "resize.editor-#{@id}", =>
+      @setSoftWrapColumn()
+      @requestDisplayUpdate()
     @focus() if @isFocused
 
     if pane = @getPane()
@@ -919,11 +921,8 @@ class Editor extends View
     if @activeEditSession.getSoftWrap()
       @addClass 'soft-wrap'
       @scrollLeft(0)
-      @_setSoftWrapColumn = => @setSoftWrapColumn()
-      $(window).on "resize.editor-#{@id}", @_setSoftWrapColumn
     else
       @removeClass 'soft-wrap'
-      $(window).off 'resize', @_setSoftWrapColumn
 
   # Sets the font size for the editor.
   #

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -905,10 +905,7 @@ class Editor extends View
     @setSoftWrap(not @activeEditSession.getSoftWrap())
 
   calcSoftWrapColumn: ->
-    if @activeEditSession.getSoftWrap()
-      Math.floor(@scrollView.width() / @charWidth)
-    else
-      Infinity
+    Math.floor(@scrollView.width() / @charWidth)
 
   # Sets the soft wrap column for the editor.
   #

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -911,11 +911,9 @@ class Editor extends View
   calcSoftWrapColumn: ->
     Math.floor(@scrollView.width() / @charWidth)
 
-  # Sets the soft wrap column for the editor.
+  # Enables/disables soft wrap on the editor.
   #
-  # softWrap - A {Boolean} which, if `true`, sets soft wraps
-  # softWrapColumn - A {Number} indicating the length of a line in the editor when soft
-  # wrapping turns on
+  # softWrap - A {Boolean} which, if `true`, enables soft wrap
   setSoftWrap: (softWrap) ->
     if softWrap
       @addClass 'soft-wrap'

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -342,16 +342,9 @@ class Project
   ### Internal ###
 
   buildEditSessionForBuffer: (buffer, editSessionOptions) ->
-    options = _.extend(@defaultEditSessionOptions(), editSessionOptions)
-    options.buffer = buffer
-    editSession = new EditSession(options)
+    editSession = new EditSession(_.extend({buffer}, editSessionOptions))
     @addEditSession(editSession)
     editSession
-
-  defaultEditSessionOptions: ->
-    tabLength: config.get('editor.tabLength')
-    softTabs: config.get('editor.softTabs')
-    softWrap: config.get('editor.softWrap')
 
   eachEditSession: (callback) ->
     callback(editSession) for editSession in @getEditSessions()

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -33,7 +33,7 @@ class TokenizedBuffer
       @state = site.createDocument
         deserializer: @constructor.name
         bufferPath: @buffer.getRelativePath()
-        tabLength: tabLength ? 2
+        tabLength: tabLength ? config.get('editor.tabLength') ? 2
 
     @subscribe syntax, 'grammar-added grammar-updated', (grammar) =>
       if grammar.injectionSelector?


### PR DESCRIPTION
- [x] Store soft wrap state on `DisplayBuffer` instead of `EditSession`
- [x] Listener for soft wrap state changes in `Editor`
- [x] Always calculate the soft wrap column and set it on the display buffer
- [x] Remove edit session defaults from `Project`, just put them in their appropriate locations
- [x] Rename `softWrapColumn` to `editorWidthInChars`
- [x] Add preference to always soft wrap at preferred line length (`editor.softWrapAtPreferredLineLength`)

Fixes #703, #721
