### PR TITLE
ATomDoc: A scalable docs format proposal

### DIFF
--- a/docs/proposals/api-docs.md
+++ b/docs/proposals/api-docs.md
@@ -1,0 +1,105 @@
+# API Docs Proposal
+
+## Goals
+- Distinguish between **public** and **private** methods
+- Generate a HTML documentation of the public API that can be browsed online.
+- Provide *relevant*, *non-obvious* explanation beyond what can be inferred from
+  method signatures.
+- Provide type-information for what is otherwise a dynamically-typed language.
+- Effort should scale proportionately to the amount of information being
+  provided. The conventions should enforce minimal conventions for simple
+  methods, while simultaneously providing robust conventions when deeper
+  explanation is needed.
+- Clutter source files as little as possible
+
+## Proposal
+
+Basic API documentation is a combination of a **visibility declaration**, one or
+more **type signatures**, and a short string of informal, non-obvious
+**explanatory text**. Expanded documentation can be also added, separated by a
+newline. All explanatory text is in markdown format, with special links to
+other code entities wrapped in `{}`, like `{Array::splice}`.
+
+### Examples
+
+Minimal requirement for public methods: A visibility declaration and a type
+signature. Use this when the method's behavior can be reasonably inferred from its
+name and signature.
+
+```coffee-script
+# Public :: (Point) -> Cursor
+addCursorAtBufferPosition(bufferPosition) -> # ...
+```
+
+Common case: Includes the visibility and type declarations, plus a short,
+non-obvious explanation. Note the empty type signature representing a method that
+takes no arguments and has no return value.
+
+```coffee-script
+# Public :: ->
+# Reduces multiple selections to a single, empty selection. Only the *last*
+# selection is retained.
+clearSelections: -> # ...
+```
+
+Expanded approach: Includes an expanded description of individual attributes or
+other details in markdown format. Also note the optional parameter name in
+the type signature, since for implementation reasons we were unable to include
+it in the method signature in the source.
+
+```coffee-script
+# Public :: ([options :: Object], [Function]) ->
+# If passed a function, it executes the function with merging suppressed,
+# then merges intersecting selections afterward.
+#
+# - options
+#   See {EditSession::setSelectedBufferRange} for a description of options.
+#
+mergeIntersectingSelections: (args...) -> # ...
+```
+
+Multiple type signatures: Each type signature can also include its own
+description or expanded commentary.
+
+```coffee-script
+# Public: Creates a replicated document instance based on the given object.
+#
+# :: (Document) -> Document
+# If the argument is already a Document, it will be returned unchanged.
+#
+# :: (Array, [Object]) -> SharedArray
+# :: (Object, [Object]) -> SharedMap
+@create: (value, options={}) -> # ...
+```
+
+### Type Signatures
+
+The goal of a type signature is to express type information and to provide
+parameter names in cases where they can't be provided in the code.
+
+A fully-qualified type signature for the `Array::splice` method would look like
+this. Note that the type qualifier symbol should always be surrounded with
+whitespace to distinguish it from CoffeeScripts prototype syntax. There
+will rarely be a need to spell a signature out so completely, but this is here
+for reference.
+
+```coffee-script
+# Array::splice :: (index :: Number, count :: Number, elements :: Array) -> removed :: Array
+```
+
+If the above type signature were above a method definition, then the method name
+and parameter names could be dropped. The return value name could be kept for
+clarity.
+
+```coffee-script
+# :: (Number, Number, Array) -> removed :: Array
+splice: (index, count, elements) -> # ...
+```
+
+Optional parameters are wrapped in `[]`. Variable numbers of parameters can be
+indicated by adding `...`.
+
+```coffee-script
+# Array::slice :: (start :: Number, [end :: Number]) -> Array
+# console.log :: (Object...) ->
+```


### PR DESCRIPTION
We've had some deep discussion on #747 :airplane: about the conventions we want to adopt for documenting our source code. On the one hand, we want to provide rich, browsable documentation for the consumers of our APIs. This is clearly critical to the success of our community. On the other hand, we we want the experience of _working_ with documented source code to be as smooth and lightweight as possible and keep our source files looking sexy.

So far, the discussion has been about the full fidelity of TomDoc vs. the compactness and lower maintenance burden of less a less formal approach. After pondering this for a while, I think that by innovating on our documentation format we can satisfy all of these concerns. With this PR, I'd like to start a conversation about what that format might look like.

While it's true that TomDoc is a standard of sorts, I don't think it's meeting our needs well. My main criticism is that it feels very bulky, and it's causing our source files to feel extremely cluttered. We need a format that's simple for simple methods–on the order of a single line–but that also scales smoothly to five, ten, or even more lines as the need for documentation increases. I think this proposal can provide that.
