### PR TITLE
Fix color highlight issue in Ruby, #716

### DIFF
--- a/themes/atom-dark-syntax.less
+++ b/themes/atom-dark-syntax.less
@@ -126,14 +126,6 @@
   background-color: rgba(86, 45, 86, 0.75);
 }
 
-.source .string .source {
-  color: #EDEDED;
-
-  .punctuation.section.embedded {
-    color: #00A0A0;
-  }
-}
-
 .string {
   color: #A8FF60;
 

--- a/themes/atom-dark-syntax.less
+++ b/themes/atom-dark-syntax.less
@@ -126,6 +126,22 @@
   background-color: rgba(86, 45, 86, 0.75);
 }
 
+// String interpolation in Ruby, CoffeeScript, and others
+.source .string {
+  .source,
+  .meta.embedded.line {
+    color: #EDEDED;
+  }
+
+  .punctuation.section.embedded {
+    color: #00A0A0;
+
+    .source {
+      color: #00A0A0;  // Required for the end of embedded strings in Ruby #716
+    }
+  }
+}
+
 .string {
   color: #A8FF60;
 

--- a/themes/atom-light-syntax.less
+++ b/themes/atom-light-syntax.less
@@ -48,6 +48,23 @@
     color: #D14;
   }
 
+  // String interpolation in Ruby, CoffeeScript, and others
+  .source .string {
+    .source,
+    .meta.embedded.line {
+      color: #5A5A5A;
+    }
+
+    .punctuation.section.embedded {
+      color: #920B2D;
+
+      .source {
+        color: #920B2D;  // Required for the end of embedded strings in Ruby #716
+      }
+    }
+  }
+
+
   .constant {
     &.numeric {
       color: #D14;

--- a/themes/atom-light-syntax.less
+++ b/themes/atom-light-syntax.less
@@ -48,14 +48,6 @@
     color: #D14;
   }
 
-  .source .string .source {
-    color: #5A5A5A;
-
-    .punctuation.section.embedded {
-      color: #920B2D;
-    }
-  }
-
   .constant {
     &.numeric {
       color: #D14;


### PR DESCRIPTION
So currently our ruby highlighting of string interpolation looks something like this:

![screen shot 2013-08-16 at 1 53 30 pm](https://f.cloud.github.com/assets/64050/978173/fb718198-06b5-11e3-85d3-bfcc95ee895c.png)

This fixes that but I'm unsure what else I might be breaking as I don't know an example of what `.punctuation.section.embedded` is. Can someone else confirm that this won't break something else?
