### PR TITLE
Literate CoffeeScript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "wrap-guide": "0.1.0",
 
     "c-tmbundle": "1.0.0",
-    "coffee-script-tmbundle": "4.0.0",
+    "coffee-script-tmbundle": "5.0.0",
     "css-tmbundle": "1.0.0",
     "git-tmbundle": "1.0.0",
     "go-tmbundle": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "wrap-guide": "0.1.0",
 
     "c-tmbundle": "1.0.0",
-    "coffee-script-tmbundle": "5.0.0",
+    "coffee-script-tmbundle": "6.0.0",
     "css-tmbundle": "1.0.0",
     "git-tmbundle": "1.0.0",
     "go-tmbundle": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "less": "git://github.com/nathansobo/less.js.git",
     "nak": "0.2.16",
     "nslog": "0.1.0",
-    "oniguruma": "0.16.0",
+    "oniguruma": "0.20.0",
     "optimist": "0.4.0",
     "pathwatcher": "0.5.0",
     "patrick": "0.4.0",

--- a/src/text-mate-grammar.coffee
+++ b/src/text-mate-grammar.coffee
@@ -145,7 +145,7 @@ class TextMateGrammar
         break if position is line.length and nextTokens.length is 0 and ruleStack.length is previousRuleStackLength
 
       else # push filler token for unmatched text at end of line
-        if position < line.length
+        if position < line.length or line.length == 0
           tokens.push(new Token(
             value: line[position...line.length]
             scopes: scopes

--- a/src/text-mate-grammar.coffee
+++ b/src/text-mate-grammar.coffee
@@ -130,10 +130,6 @@ class TextMateGrammar
         ruleStack = originalRuleStack
         break
 
-      if line.length == 0
-        tokens = [new Token(value: "", scopes: scopes)]
-        return { tokens, ruleStack }
-
       break if position == line.length + 1 # include trailing newline position
 
       if match = _.last(ruleStack).getNextTokens(ruleStack, line, position, firstLine)

--- a/themes/atom-dark-syntax.less
+++ b/themes/atom-dark-syntax.less
@@ -59,6 +59,32 @@
       color: #aaa;
     }
   }
+
+  .markdown {
+    .paragraph {
+      color: #999;
+    }
+
+    .heading {
+      color: #eee;
+    }
+
+    .raw {
+      color: #aaa;
+    }
+
+    .link {
+      color: #555;
+
+      .string {
+        color: #555;
+
+        &.title {
+          color: #ddd;
+        }
+      }
+    }
+  }
 }
 
 .bracket-matcher {

--- a/themes/atom-light-syntax.less
+++ b/themes/atom-light-syntax.less
@@ -221,6 +221,24 @@
       color: #888;
     }
   }
+
+  .markdown {
+    .paragraph {
+      color: #444;
+    }
+
+    .heading {
+      color: #111;
+    }
+
+    .link {
+      color: #888;
+
+      .string {
+        color: #888;
+      }
+    }
+  }
 }
 
 .bracket-matcher {


### PR DESCRIPTION
This is a :earth_americas: that @jbarnette wants to live in.
- [x] Upgrade to latest `coffee-script-tmbundle` for latest Literate grammar
- [x] Upgrade `oniguruma` to support named capture groups (the exception shown in #776)
- [x] Tokenize empty lines
- [x] Add markdown styles to light and dark themes

We need to tokenize empty lines since the grammar matches empty lines to denote the end of a paragraph section.

Fixes #776 

![screen shot 2013-08-30 at 4 20 43 pm](https://f.cloud.github.com/assets/671378/1061265/cc81f744-11ca-11e3-84af-83da38c0c776.png)
