### PR TITLE
Add #getUpstreamBranch to Git

### DIFF
--- a/src/git.coffee
+++ b/src/git.coffee
@@ -217,6 +217,17 @@ class Git
   # Public: Returns the origin url of the repository.
   getOriginUrl: -> @getConfigValue('remote.origin.url')
 
+  # Public: Returns the upstream branch for the current HEAD, or null if there
+  # is no upstream branch for the current HEAD.
+  #
+  # Examples
+  #
+  #   getUpstreamBranch()
+  #   # => "refs/remotes/origin/master"
+  #
+  # Returns a String.
+  getUpstreamBranch: -> @getRepo().getUpstreamBranch()
+
   # Public: ?
   getReferenceTarget: (reference) -> @getRepo().getReferenceTarget(reference)
 


### PR DESCRIPTION
As discussed in [atom/to-the-hubs#1](https://github.com/atom/to-the-hubs/pull/1#discussion_r5995319), it's useful to have `Git` provide a delegator for `#getUpstreamBranch`, in addition to the other delegators that it provides.

Note: Based on the [numerous other delegators](https://github.com/atom/atom/blob/34f16c58e80678d65b9ba19bb35f556bdcfaffa6/src/git.coffee#L214-L224) in this class, it looks like we've chosen not to add [specs](https://github.com/atom/atom/blob/34f16c58e80678d65b9ba19bb35f556bdcfaffa6/spec/git-spec.coffee) for simple delegators. So, I've followed that convention. However, if it would be helpful to have a spec for this method, I'd be happy to add one. (We'd likely need to add a [fixture repo](https://github.com/atom/atom/tree/34f16c58e80678d65b9ba19bb35f556bdcfaffa6/spec/fixtures/git) that includes an upstream branch.)
