### PR TITLE
Faster CI

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -175,7 +175,7 @@ module.exports = (grunt) ->
   grunt.registerTask('compile', ['coffee', 'less', 'cson'])
   grunt.registerTask('lint', ['coffeelint', 'csslint', 'lesslint'])
   grunt.registerTask('test', ['shell:kill-atom', 'shell:test'])
-  grunt.registerTask('ci', ['lint', 'partial-clean', 'update-atom-shell', 'build', 'set-development-version', 'test'])
+  grunt.registerTask('ci', ['lint', 'update-atom-shell', 'build', 'set-development-version', 'test'])
   grunt.registerTask('deploy', ['partial-clean', 'update-atom-shell', 'build', 'codesign'])
   grunt.registerTask('docs', ['markdown:guides', 'build-docs'])
   grunt.registerTask('default', ['update-atom-shell', 'build', 'set-development-version', 'install'])

--- a/script/cibuild
+++ b/script/cibuild
@@ -7,5 +7,6 @@ cd "$(dirname "$0")/.."
 rm -rf ~/.atom
 git clean -dff
 
-rm -fr node_modules
-./script/test
+./script/bootstrap
+./node_modules/.bin/apm clean
+./node_modules/.bin/grunt ci --stack --no-color

--- a/tasks/clean-task.coffee
+++ b/tasks/clean-task.coffee
@@ -7,7 +7,6 @@ module.exports = (grunt) ->
     rm grunt.config.get('atom.buildDir')
     rm '/tmp/atom-coffee-cache'
     rm '/tmp/atom-cached-atom-shells'
-    rm 'node'
     rm 'atom-shell'
 
   grunt.registerTask 'clean', 'Delete all the build files', ->


### PR DESCRIPTION
# Background

Long ago CI was a bit flaky as we integrated the building of node modules and atom-shell into atom's build process.

To get it consistently building we decided to have `script/cibuild` be as aggressive as possible in deleting cached files between builds. Everything went, the coffee cache, the local `atom-shell` folder, cached atom-shell zips, the local `node_modules` folder, and the cache of previously downloaded modules.

Things are now significantly less flaky; atom-shell tags releases, we are tagging and publishing our own atom packages, apm rebuilds native modules when atom-shell gets upgraded, and therefore I am proposing we now favor faster build times over a pristine atom build environment.

This will not impact the deploy script, we will still do the super clean and make sure everything builds with fresh copies of all the modules and atom-shell.
# Results

The non-spec portion of atom's build goes from ~4 minutes to ~1 minute.

The last master build when this branch started was [380 seconds](https://janky.rs.github.com/atom/master), the latest build of this branch was [218 seconds](https://janky.rs.github.com/atom/less-clean).
