### PR TITLE
Add support for vendoring atom packages and npms as submodules

### DIFF
--- a/src/atom-window.coffee
+++ b/src/atom-window.coffee
@@ -49,6 +49,7 @@ class AtomWindow
       'vendor'
       'static'
       'node_modules'
+      'node_submodules'
       'spec'
       ''
     ]
@@ -57,6 +58,7 @@ class AtomWindow
 
     paths = paths.map (relativeOrAbsolutePath) ->
       path.resolve resourcePath, relativeOrAbsolutePath
+    paths = _.compact(paths)
 
     process.env['NODE_PATH'] = paths.join path.delimiter
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -88,9 +88,6 @@ window.atom =
     packagePath = fsUtils.resolve(config.packageDirPaths..., name)
     return packagePath if fsUtils.isDirectorySync(packagePath)
 
-    packagePath = path.join(window.resourcePath, 'node_modules', name)
-    return packagePath if @isInternalPackage(packagePath)
-
   isInternalPackage: (packagePath) ->
     {engines} = Package.loadMetadata(packagePath, true)
     engines?.atom?

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -8,7 +8,10 @@ async = require 'async'
 pathWatcher = require 'pathwatcher'
 
 configDirPath = fsUtils.absolute("~/.atom")
-nodeModulesDirPath = path.join(resourcePath, "node_modules")
+nodeModulesDirPath = path.join(global.resourcePath, "node_modules")
+nodeSubmodulesDirPath = path.join(global.resourcePath, "node_submodules")
+bundledPackageDirPaths = [nodeModulesDirPath]
+bundledPackageDirPaths.unshift(nodeSubmodulesDirPath) if fsUtils.exists(nodeSubmodulesDirPath)
 bundledThemesDirPath = path.join(resourcePath, "themes")
 bundledKeymapsDirPath = path.join(resourcePath, "keymaps")
 userThemesDirPath = path.join(configDirPath, "themes")
@@ -40,10 +43,10 @@ class Config
 
   configDirPath: configDirPath
   themeDirPaths: [userThemesDirPath, bundledThemesDirPath]
-  bundledPackageDirPaths: [nodeModulesDirPath]
+  bundledPackageDirPaths: bundledPackageDirPaths
   bundledKeymapsDirPath: bundledKeymapsDirPath
   nodeModulesDirPath: nodeModulesDirPath
-  packageDirPaths: _.clone(userPackageDirPaths)
+  packageDirPaths: [userPackageDirPaths..., bundledPackageDirPaths...]
   userPackageDirPaths: userPackageDirPaths
   userStoragePath: userStoragePath
   lessSearchPaths: [path.join(resourcePath, 'static'), path.join(resourcePath, 'vendor')]


### PR DESCRIPTION
**This may never get merged**, but I'm putting it out there as something to think about should we decide to transition back to thinking about some of our packages as "tightly coupled" to Atom core for a while.

@kevinsawicki and I had a good talk last night that makes me doubt whether we need to do this. Here's the situation:

Our ability to version packages independently of atom core basically hinges on the stability of our core API. If we're able to make backward-compatible changes to core, then there's no imperative to commit repairs to broken packages in lock-step with our core changes, because nothing will break. This will have to be our approach when we launch private alpha, because otherwise we'll break other people's packages in addition to our own. Core API stability will be a high priority.

However, for the next two months we're going to make one last push to fix any outstanding issues with the design of our API. We may or may not be able to preserve backward compatibility for all packages during this transition. If it's easy to preserve, then I'm inclined to do so. But my top priority is getting the design in good shape as quickly as possible, so if backward compatibility is getting in the way, submoduling some or all of our core packages again _temporarily_ may be a good option. In this final push to improve the API before giving this to people, its stability is a low priority.

I'm going to attempt the MVVM refactoring in a way that maximizes backward compatibility and make a small number of non-backward compatible changes directly on master. Depending on our experience in the coming weeks, we may discover we don't need to submodule. On the other hand, I think it could be expedient as a temporary measure while things are in massive flux. I promise to stop breaking the world when we release, but the world isn't how I want it yet.
