### PR TITLE
NODE_PATH tweaks

### DIFF
--- a/src/atom-window.coffee
+++ b/src/atom-window.coffee
@@ -52,8 +52,7 @@ class AtomWindow
     ]
     paths.push('spec') if @isSpec
 
-    paths = paths.map (relativeOrAbsolutePath) ->
-      path.resolve resourcePath, relativeOrAbsolutePath
+    paths = paths.map (relativePath) -> path.resolve(resourcePath, relativePath)
     paths.push(resourcePath)
 
     process.env['NODE_PATH'] = paths.join path.delimiter

--- a/src/atom-window.coffee
+++ b/src/atom-window.coffee
@@ -53,8 +53,6 @@ class AtomWindow
       ''
     ]
 
-    paths.push path.join(app.getHomeDir(), '.atom', 'packages')
-
     paths = paths.map (relativeOrAbsolutePath) ->
       path.resolve resourcePath, relativeOrAbsolutePath
 

--- a/src/atom-window.coffee
+++ b/src/atom-window.coffee
@@ -49,12 +49,12 @@ class AtomWindow
       'vendor'
       'static'
       'node_modules'
-      'spec'
-      ''
     ]
+    paths.push('spec') if @isSpec
 
     paths = paths.map (relativeOrAbsolutePath) ->
       path.resolve resourcePath, relativeOrAbsolutePath
+    paths.push(resourcePath)
 
     process.env['NODE_PATH'] = paths.join path.delimiter
 


### PR DESCRIPTION
This removes `~/.atom/packages` from the `NODE_PATH`, I couldn't think of any good reason it should be on there as packages can resolve each other via the `atom` global.

This also only puts `spec` on the `NODE_PATH` when running a spec window.
