### PR TITLE
Use pacakge's fixture as the default project when running package specs

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -3,6 +3,7 @@ window.setUpEnvironment('spec')
 window.restoreDimensions()
 
 nakedLoad 'jasmine-jquery'
+path = require 'path'
 $ = jQuery = require 'jquery'
 _ = require 'underscore'
 Keymap = require 'keymap'
@@ -37,7 +38,9 @@ jasmine.getEnv().defaultTimeoutInterval = 5000
 
 beforeEach ->
   jQuery.fx.off = true
-  window.project = new Project(fsUtils.resolveOnLoadPath('fixtures'))
+
+  specDirectory = atom.getLoadSettings().specDirectory ? path.resolve("./specs")
+  window.project = new Project(path.join(specDirectory, 'fixtures'))
 
   window.resetTimeouts()
   atom.packageStates = {}

--- a/spec/spec-suite.coffee
+++ b/spec/spec-suite.coffee
@@ -8,9 +8,9 @@ measure 'spec suite require time', ->
   Git = require 'git'
   require 'spec-helper'
 
-  requireSpecs = (directoryPath, specType) ->
-    for specPath in fsUtils.listTreeSync(path.join(directoryPath, 'spec')) when /-spec\.coffee$/.test specPath
-      require specPath
+  requireSpecs = (specDirectory, specType) ->
+    for specFilePath in fsUtils.listTreeSync(specDirectory) when /-spec\.coffee$/.test specFilePath
+      require specFilePath
 
   setSpecType = (specType) ->
     for spec in jasmine.getEnv().currentRunner().specs() when not spec.specType?
@@ -19,7 +19,7 @@ measure 'spec suite require time', ->
   runAllSpecs = ->
     # Only run core specs when resource path is the Atom repository
     if Git.exists(window.resourcePath)
-      requireSpecs(window.resourcePath)
+      requireSpecs(path.join(window.resourcePath, 'spec'))
       setSpecType('core')
 
     fixturesPackagesPath = fsUtils.resolveOnLoadPath('fixtures/packages')
@@ -33,18 +33,15 @@ measure 'spec suite require time', ->
         'user'
 
     # Run bundled package specs
-    requireSpecs(packagePath) for packagePath in packagePaths.bundled ? []
+    requireSpecs(path.join(packagePath, 'spec')) for packagePath in packagePaths.bundled ? []
     setSpecType('bundled')
 
     # Run user package specs
-    requireSpecs(packagePath) for packagePath in packagePaths.user ? []
+    requireSpecs(path.join(packagePath, 'spec')) for packagePath in packagePaths.user ? []
     setSpecType('user')
 
-  runSpecs = (specPath) ->
-    requireSpecs(specPath)
-    setSpecType("user")
-
-    runSpecs(specPath)
   if specDirectory = atom.getLoadSettings().specDirectory
+    requireSpecs(specDirectory)
+    setSpecType('user')
   else
     runAllSpecs()

--- a/spec/spec-suite.coffee
+++ b/spec/spec-suite.coffee
@@ -44,7 +44,7 @@ measure 'spec suite require time', ->
     requireSpecs(specPath)
     setSpecType("user")
 
-  if specPath = atom.getLoadSettings().specPath
     runSpecs(specPath)
+  if specDirectory = atom.getLoadSettings().specDirectory
   else
     runAllSpecs()

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -157,8 +157,8 @@ class AtomApplication
     ipc.once 'update-application-menu', (processId, routingId, keystrokesByCommand) =>
       @applicationMenu.update(keystrokesByCommand)
 
-    ipc.on 'run-package-specs', (processId, routingId, packagePath) =>
-      @runSpecs({resourcePath: global.devResourcePath, specPath: packagePath, exitWhenDone: false})
+    ipc.on 'run-package-specs', (processId, routingId, specDirectory) =>
+      @runSpecs({resourcePath: global.devResourcePath, specDirectory: specDirectory, exitWhenDone: false})
 
     ipc.on 'command', (processId, routingId, command) =>
       @emit(command)
@@ -264,14 +264,14 @@ class AtomApplication
   #      The path to include specs from.
   #    + specPath:
   #      The directory to load specs from.
-  runSpecs: ({exitWhenDone, resourcePath, specPath}) ->
+  runSpecs: ({exitWhenDone, resourcePath, specDirectory}) ->
     if resourcePath isnt @resourcePath and not fs.existsSync(resourcePath)
       resourcePath = @resourcePath
 
     bootstrapScript = 'spec-bootstrap'
     isSpec = true
     devMode = true
-    new AtomWindow({bootstrapScript, resourcePath, exitWhenDone, isSpec, devMode, specPath})
+    new AtomWindow({bootstrapScript, resourcePath, exitWhenDone, isSpec, devMode, specDirectory})
 
   runBenchmarks: ->
     bootstrapScript = 'benchmark/benchmark-bootstrap'

--- a/src/root-view.coffee
+++ b/src/root-view.coffee
@@ -107,7 +107,7 @@ class RootView extends View
     @command 'application:zoom', -> ipc.sendChannel('command', 'application:zoom')
     @command 'application:bring-all-windows-to-front', -> ipc.sendChannel('command', 'application:bring-all-windows-to-front')
 
-    @command 'window:run-package-specs', => ipc.sendChannel('run-package-specs', project.getPath())
+    @command 'window:run-package-specs', => ipc.sendChannel('run-package-specs', path.join(project.getPath(), 'spec'))
     @command 'window:increase-font-size', =>
       config.set("editor.fontSize", config.get("editor.fontSize") + 1)
 


### PR DESCRIPTION
This is useful when developing a package outside of Atom core. I still need to handle the case where there is no `spec/fixtures` directory.
