### PR TITLE
Use images served over https in guides

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ key commands interactively. If you'd like to learn about adding or changing a
 binding for a command, refer to the [key bindings](#customizing-key-bindings)
 section below.
 
-![Command Palette](http://f.cl.ly/items/32041o3w471F3C0F0V2O/Screen%20Shot%202013-02-13%20at%207.27.41%20PM.png)
+![Command Palette](https://f.cloud.github.com/assets/1424/1091618/ee7c3554-166a-11e3-9955-aaa61bb5509c.png)
 
 ## The Basics
 

--- a/docs/internals/view-system.md
+++ b/docs/internals/view-system.md
@@ -38,7 +38,7 @@ singleton instance of the `RootView` view class. The root view fills the entire
 window, and contains every other view. If you open Atom's inspector with
 `alt-cmd-i`, you can see the internal structure of `RootView`:
 
-![RootView in the inspector](http://f.cl.ly/items/2n0s3m0I2d223p3s3W01/root-view-inspector.png)
+![RootView in the inspector](https://f.cloud.github.com/assets/1424/1091631/1932c2d6-166b-11e3-8adf-9690fe82d3b8.png)
 
 #### Panes
 


### PR DESCRIPTION
So we should use being ssl hosted assets in our guides to prevent content warnings.
