### PR TITLE
Make benchmarks runnable via command

### DIFF
--- a/benchmark/benchmark-bootstrap.coffee
+++ b/benchmark/benchmark-bootstrap.coffee
@@ -2,4 +2,5 @@ require 'atom'
 {runSpecSuite} = require 'jasmine-helper'
 
 document.title = "Benchmark Suite"
-runSpecSuite("benchmark-suite", true)
+benchmarkSuite = require.resolve('./benchmark-suite')
+runSpecSuite(benchmarkSuite, true)

--- a/benchmark/benchmark-bootstrap.coffee
+++ b/benchmark/benchmark-bootstrap.coffee
@@ -1,6 +1,8 @@
 require 'atom'
 {runSpecSuite} = require 'jasmine-helper'
 
+atom.openDevTools()
+
 document.title = "Benchmark Suite"
 benchmarkSuite = require.resolve('./benchmark-suite')
 runSpecSuite(benchmarkSuite, true)

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -116,6 +116,7 @@ class AtomApplication
   handleEvents: ->
     @on 'application:about', -> Menu.sendActionToFirstResponder('orderFrontStandardAboutPanel:')
     @on 'application:run-all-specs', -> @runSpecs(exitWhenDone: false, resourcePath: global.devResourcePath)
+    @on 'application:run-benchmarks', -> @runBenchmarks()
     @on 'application:show-settings', -> (@focusedWindow() ? this).openPath("atom://config")
     @on 'application:quit', -> app.quit()
     @on 'application:hide', -> Menu.sendActionToFirstResponder('hide:')
@@ -271,6 +272,11 @@ class AtomApplication
     isSpec = true
     devMode = true
     new AtomWindow({bootstrapScript, resourcePath, exitWhenDone, isSpec, devMode, specPath})
+
+  runBenchmarks: ->
+    bootstrapScript = 'benchmark/benchmark-bootstrap'
+    isSpec = true # So the spec folder is added to NODE_PATH
+    new AtomWindow({bootstrapScript, @resourcePath, isSpec})
 
   # Private: Opens a native dialog to prompt the user for a path.
   #

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -275,7 +275,7 @@ class AtomApplication
 
   runBenchmarks: ->
     bootstrapScript = 'benchmark/benchmark-bootstrap'
-    isSpec = true # So the spec folder is added to NODE_PATH
+    isSpec = true # Needed because this flag adds the spec directory to the NODE_PATH
     new AtomWindow({bootstrapScript, @resourcePath, isSpec})
 
   # Private: Opens a native dialog to prompt the user for a path.

--- a/src/root-view.coffee
+++ b/src/root-view.coffee
@@ -93,6 +93,7 @@ class RootView extends View
 
     @command 'application:about', -> ipc.sendChannel('command', 'application:about')
     @command 'application:run-all-specs', -> ipc.sendChannel('command', 'application:run-all-specs')
+    @command 'application:run-benchmarks', -> ipc.sendChannel('command', 'application:run-benchmarks')
     @command 'application:show-settings', -> ipc.sendChannel('command', 'application:show-settings')
     @command 'application:quit', -> ipc.sendChannel('command', 'application:quit')
     @command 'application:hide', -> ipc.sendChannel('command', 'application:hide')


### PR DESCRIPTION
We lost benchmark running in the atom-shell purge, this brings them back.
