### PR TITLE
Add metrics package to default bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "image-view": "0.3.0",
     "link": "0.1.0",
     "markdown-preview": "0.2.0",
+    "metrics": "0.1.0",
     "package-generator": "0.4.0",
     "settings-view": "0.11.0",
     "snippets": "0.2.0",


### PR DESCRIPTION
This allows us to collect some basic metrics about our users. See atom/metrics for more details.

I think we should install this be default so that's why I've included in the bundled packages. If we're cool with this I'll merge.
