### PR TITLE
Bring back old coffee cache strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "status-bar": "0.3.0",
     "symbols-view": "0.4.0",
     "tabs": "0.2.0",
-    "terminal": "0.6.0",
+    "terminal": "coffee-cache",
     "to-the-hubs": "0.1.0",
     "toml": "0.1.0",
     "tree-view": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "atomShellVersion": "0.4.5",
   "dependencies": {
     "async": "0.2.6",
-    "coffee-cache": "0.1.0",
     "coffee-script": "1.6.2",
     "coffeestack": "0.4.0",
     "first-mate": "0.1.0",

--- a/script/cibuild
+++ b/script/cibuild
@@ -5,7 +5,6 @@ set -e
 cd "$(dirname "$0")/.."
 
 rm -rf ~/.atom
-rm -rf /tmp/atom-coffee-cache
 git clean -dff
 
 ./script/bootstrap

--- a/src/coffee-cache.coffee
+++ b/src/coffee-cache.coffee
@@ -5,9 +5,11 @@ path = require 'path'
 CoffeeScript = require 'coffee-script'
 mkdir = require('mkdirp').sync
 
+cacheDir = '/tmp/atom-compile-cache/coffee'
+
 getCachePath = (coffee) ->
   digest = crypto.createHash('sha1').update(coffee, 'utf8').digest('hex')
-  path.join('/tmp/atom-compile-cache/coffee', "#{digest}.coffee")
+  path.join(cacheDir, "#{digest}.coffee")
 
 getCachedJavaScript = (cachePath) ->
   try
@@ -25,3 +27,5 @@ require.extensions['.coffee'] = (module, filePath) ->
   cachePath = getCachePath(coffee)
   js = getCachedJavaScript(cachePath) ? compileCoffeeScript(coffee, filePath, cachePath)
   module._compile(js, filePath)
+
+module.exports = {cacheDir}

--- a/src/coffee-cache.coffee
+++ b/src/coffee-cache.coffee
@@ -1,0 +1,24 @@
+crypto = require 'crypto'
+fs = require 'fs'
+path = require 'path'
+
+CoffeeScript = require 'coffee-script'
+mkdir = require('mkdirp').sync
+
+getCachePath = (coffeeContents)->
+  digest = crypto.createHash('sha1').update(coffeeContents, 'utf8').digest('hex')
+  path.join('/tmp/atom-compile-cache/coffee', "#{digest}.coffee")
+
+require.extensions['.coffee'] = (module, filePath) ->
+  coffeeContents = fs.readFileSync(filePath, 'utf8')
+  cachePath = getCachePath(coffeeContents)
+  try
+    jsContents = fs.readFileSync(cachePath, 'utf8') if fs.statSync(cachePath).isFile()
+
+  unless jsContents?
+    jsContents = CoffeeScript.compile(coffeeContents, filename: filePath)
+    try
+      mkdir(path.dirname(cachePath))
+      fs.writeFileSync(cachePath, jsContents)
+
+  module._compile(jsContents, filePath)

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -44,8 +44,8 @@ delegate.browserMainParts.preMainMessageLoopRun = ->
 
     if args.devMode
       require('coffee-script')
-      require('coffee-cache').setCacheDir('/tmp/atom-coffee-cache')
-      require('module').globalPaths.push(args.resourcePath + "/src")
+      require(path.join(args.resourcePath, 'src', 'coffee-cache'))
+      require('module').globalPaths.push(path.join(args.resourcePath, 'src'))
     else
       appSrcPath = path.resolve(process.argv[0], "../../Resources/app/src")
       require('module').globalPaths.push(appSrcPath)

--- a/src/task.coffee
+++ b/src/task.coffee
@@ -45,7 +45,7 @@ class Task
   constructor: (taskPath) ->
     bootstrap = """
       require('coffee-script');
-      require('coffee-cache').setCacheDir('/tmp/atom-coffee-cache');
+      require('coffee-cache');
       Object.defineProperty(require.extensions, '.coffee', {
         writable: false,
         value: require.extensions['.coffee']

--- a/static/index.html
+++ b/static/index.html
@@ -8,7 +8,7 @@
       var currentWindow = require('remote').getCurrentWindow();
       try {
         require('coffee-script');
-        require('coffee-cache').setCacheDir('/tmp/atom-coffee-cache');
+        require('coffee-cache');
         Object.defineProperty(require.extensions, '.coffee', {
           writable: false,
           value: require.extensions['.coffee']

--- a/tasks/clean-task.coffee
+++ b/tasks/clean-task.coffee
@@ -5,7 +5,7 @@ module.exports = (grunt) ->
 
   grunt.registerTask 'partial-clean', 'Delete some of the build files', ->
     rm grunt.config.get('atom.buildDir')
-    rm '/tmp/atom-coffee-cache'
+    rm '/tmp/atom-compile-cache'
     rm '/tmp/atom-cached-atom-shells'
     rm 'atom-shell'
 

--- a/tasks/clean-task.coffee
+++ b/tasks/clean-task.coffee
@@ -3,9 +3,10 @@ path = require 'path'
 module.exports = (grunt) ->
   {rm} = require('./task-helpers')(grunt)
 
+
   grunt.registerTask 'partial-clean', 'Delete some of the build files', ->
     rm grunt.config.get('atom.buildDir')
-    rm '/tmp/atom-compile-cache'
+    rm require('../src/coffee-cache').cacheDir
     rm '/tmp/atom-cached-atom-shells'
     rm 'atom-shell'
 


### PR DESCRIPTION
The coffee-cache module is no longer working for us since when you sync back to an older version of a module the cache thinks the file is older than the cached version and therefore doesn't recompile it.

This PR brings back our old pre-node strategy of using the digest of a file's content to determine its cache path.
