### PR TITLE
Publish docs don't need patch versions

### DIFF
--- a/tasks/docs-task.coffee
+++ b/tasks/docs-task.coffee
@@ -33,7 +33,7 @@ module.exports = (grunt) ->
         if error?
           callback(error)
         else
-          callback(null, String(result).trim())
+          callback(null, String(result).trim().split('.')[0..1].join('.'))
 
     copyDocs = (tag, callback) ->
       cmd = 'cp'
@@ -58,7 +58,7 @@ module.exports = (grunt) ->
         if error?
           callback(error)
         else
-          callback(null, String(result).trim())
+          callback(null, String(result).trim().split('.')[0..1].join('.'))
 
     stageDocs = (tag, callback) ->
       cmd = 'git'


### PR DESCRIPTION
I don't think documentation urls should have patch versions in them (ie I think it should be `/v26.0/` and _not_ `/v26.0.0/`).

I'll leave this open for a day and see if anyone disagrees, if not I'll merge it.
