### PR TITLE
Fix .block css definition. Fixes #836

### DIFF
--- a/static/utilities.less
+++ b/static/utilities.less
@@ -15,11 +15,11 @@
 
 // Blocks
 
-.block {
-  display: block;
+// Must be div.block so as not to affect syntax highlighting.
+div.block {
   margin-bottom: @component-padding;
 }
-div > .block:last-child {
+div > div.block:last-child {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
It was selecting .blocks in the highlighted syntax. See #836
