### PR TITLE
Reverse the loading order of themes

### DIFF
--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -39,8 +39,8 @@ describe "ThemeManager", ->
 
       config.set('core.themes', ['atom-light-syntax', 'atom-dark-syntax'])
       expect($('style.theme').length).toBe 2
-      expect($('style.theme:eq(0)').attr('id')).toMatch /atom-light-syntax/
-      expect($('style.theme:eq(1)').attr('id')).toMatch /atom-dark-syntax/
+      expect($('style.theme:eq(0)').attr('id')).toMatch /atom-dark-syntax/
+      expect($('style.theme:eq(1)').attr('id')).toMatch /atom-light-syntax/
 
       config.set('core.themes', [])
       expect($('style.theme').length).toBe 0

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -42,7 +42,7 @@ class ThemeManager
 
       # Reverse so the first (top) theme is loaded after the others. We want
       # the first/top theme to override later themes in the stack.
-      (themeNames = _.clone(themeNames)).reverse()
+      themeNames = _.clone(themeNames).reverse()
 
       @activateTheme(themeName) for themeName in themeNames
       @loadUserStylesheet()

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -39,6 +39,11 @@ class ThemeManager
     config.observe 'core.themes', (themeNames) =>
       @unload()
       themeNames = [themeNames] unless _.isArray(themeNames)
+
+      # Reverse so the first (top) theme is loaded after the others. We want
+      # the first/top theme to override later themes in the stack.
+      (themeNames = _.clone(themeNames)).reverse()
+
       @activateTheme(themeName) for themeName in themeNames
       @loadUserStylesheet()
 


### PR DESCRIPTION
Right now theme loading order is a bit non-intuitive. Visually in the settings, themes are stacked vertically. My expectation is that the top most theme should override any styles defined in themes below.

This is currently true for the `ui-variables` loading -- the top-most theme's `ui-variables` are picked to override any other `ui-variables` files.

But theme loading is currently the opposite -- themes are loaded top to bottom, so the bottom theme can override things on the top theme.

This pull reverses the order of theme loading so the top-most theme is loaded last. That way, the top-most theme's styles can override any styles defined by themes below/after it. 
