### PR TITLE
Only attach the mousewheel handler on regular editors. Fix #838

### DIFF
--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -681,10 +681,11 @@ class Editor extends View
       @insertText(e.originalEvent.data)
       false
 
-    @scrollView.on 'mousewheel', (e) =>
-      if delta = e.originalEvent.wheelDeltaY
-        @scrollTop(@scrollTop() - delta)
-        false
+    unless @mini
+      @scrollView.on 'mousewheel', (e) =>
+        if delta = e.originalEvent.wheelDeltaY
+          @scrollTop(@scrollTop() - delta)
+          false
 
     @verticalScrollbar.on 'scroll', =>
       @scrollTop(@verticalScrollbar.scrollTop(), adjustVerticalScrollbar: false)


### PR DESCRIPTION
Mini editor capture the mousewheel events. This fixes it. See #838 
