### PR TITLE
Cache LESS files

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -32,14 +32,12 @@ module.exports = (grunt) ->
       paths: [
         'static/variables'
         'static'
-        'vendor/bootstrap/less'
       ]
     glob_to_multiple:
       expand: true
       src: [
         'src/**/*.less'
         'static/**/*.less'
-        'vendor/bootstrap/less/bootstrap.less'
       ]
       dest: appDir
       ext: '.css'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -172,7 +172,7 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks('grunt-shell')
   grunt.loadTasks('tasks')
 
-  grunt.registerTask('compile', ['coffee', 'less', 'cson'])
+  grunt.registerTask('compile', ['coffee', 'cson'])
   grunt.registerTask('lint', ['coffeelint', 'csslint', 'lesslint'])
   grunt.registerTask('test', ['shell:kill-atom', 'shell:test'])
   grunt.registerTask('ci', ['lint', 'update-atom-shell', 'build', 'set-development-version', 'test'])

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -36,7 +36,6 @@ module.exports = (grunt) ->
     glob_to_multiple:
       expand: true
       src: [
-        'src/**/*.less'
         'static/**/*.less'
       ]
       dest: appDir

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -39,7 +39,6 @@ module.exports = (grunt) ->
       src: [
         'src/**/*.less'
         'static/**/*.less'
-        'themes/**/*.less'
         'vendor/bootstrap/less/bootstrap.less'
       ]
       dest: appDir

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -45,6 +45,12 @@ module.exports = (grunt) ->
       dest: appDir
       ext: '.css'
 
+  prebuildLessConfig =
+    src: [
+      'static/**/*.less'
+      'vendor/bootstrap/less/bootstrap.less'
+    ]
+
   csonConfig =
     options:
       rootObject: true
@@ -60,10 +66,11 @@ module.exports = (grunt) ->
 
   for child in fs.readdirSync('node_modules') when child isnt '.bin'
     directory = path.join('node_modules', child)
-    {engines} = grunt.file.readJSON(path.join(directory, 'package.json'))
+    {engines, theme} = grunt.file.readJSON(path.join(directory, 'package.json'))
     if engines?.atom?
       coffeeConfig.glob_to_multiple.src.push("#{directory}/**/*.coffee")
       lessConfig.glob_to_multiple.src.push("#{directory}/**/*.less")
+      prebuildLessConfig.src.push("#{directory}/**/*.less") unless theme
       csonConfig.glob_to_multiple.src.push("#{directory}/**/*.cson")
 
   grunt.initConfig
@@ -74,6 +81,8 @@ module.exports = (grunt) ->
     coffee: coffeeConfig
 
     less: lessConfig
+
+    'prebuild-less': prebuildLessConfig
 
     cson: csonConfig
 
@@ -172,7 +181,7 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks('grunt-shell')
   grunt.loadTasks('tasks')
 
-  grunt.registerTask('compile', ['coffee', 'cson'])
+  grunt.registerTask('compile', ['coffee', 'prebuild-less', 'cson'])
   grunt.registerTask('lint', ['coffeelint', 'csslint', 'lesslint'])
   grunt.registerTask('test', ['shell:kill-atom', 'shell:test'])
   grunt.registerTask('ci', ['lint', 'update-atom-shell', 'build', 'set-development-version', 'test'])

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -32,7 +32,7 @@ module.exports = (grunt) ->
       paths: [
         'static/variables'
         'static'
-        'vendor'
+        'vendor/bootstrap/less'
       ]
     glob_to_multiple:
       expand: true

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -58,7 +58,6 @@ module.exports = (grunt) ->
       src: [
         'keymaps/*.cson'
         'static/**/*.cson'
-        'themes/**/*.cson'
       ]
       dest: appDir
       ext: '.json'
@@ -124,13 +123,11 @@ module.exports = (grunt) ->
         'vendor-prefix': false
       src: [
         'static/**/*.css'
-        'themes/**/*.css'
       ]
 
     lesslint:
       src: [
         'static/**/*.less'
-        'themes/**/*.less'
       ]
 
     markdown:

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "jasmine-focused": "~0.12.0",
     "mkdirp": "0.3.5",
     "less": "git://github.com/nathansobo/less.js.git",
+    "less-cache": "0.5.0",
     "nak": "0.2.18",
     "nslog": "0.1.0",
     "oniguruma": "0.20.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "jasmine-focused": "~0.12.0",
     "mkdirp": "0.3.5",
     "less": "git://github.com/nathansobo/less.js.git",
-    "less-cache": "0.5.0",
+    "less-cache": "0.7.0",
     "nak": "0.2.18",
     "nslog": "0.1.0",
     "oniguruma": "0.20.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "markdown-preview": "0.2.0",
     "metrics": "0.1.0",
     "package-generator": "0.4.0",
-    "settings-view": "0.17.0",
+    "settings-view": "0.18.0",
     "snippets": "0.2.0",
     "spell-check": "0.3.0",
     "status-bar": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "jasmine-focused": "~0.12.0",
     "mkdirp": "0.3.5",
     "less": "git://github.com/nathansobo/less.js.git",
-    "less-cache": "0.7.0",
+    "less-cache": "0.8.0",
     "nak": "0.2.18",
     "nslog": "0.1.0",
     "oniguruma": "0.20.0",

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -141,7 +141,7 @@ window.atom =
       null
 
   loadBaseStylesheets: ->
-    requireStylesheet("bootstrap/less/bootstrap")
+    requireStylesheet('bootstrap')
     @reloadBaseStylesheets()
 
   reloadBaseStylesheets: ->

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -141,7 +141,7 @@ window.atom =
       null
 
   loadBaseStylesheets: ->
-    requireStylesheet('bootstrap')
+    requireStylesheet('bootstrap/less/bootstrap')
     @reloadBaseStylesheets()
 
   reloadBaseStylesheets: ->

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -46,7 +46,6 @@ class Config
   lessSearchPaths: [
     path.join(resourcePath, 'static', 'variables')
     path.join(resourcePath, 'static')
-    path.join(resourcePath, 'vendor', 'less')
   ]
   defaultSettings: null
   settings: null

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -43,7 +43,11 @@ class Config
   packageDirPaths: _.clone(userPackageDirPaths)
   userPackageDirPaths: userPackageDirPaths
   userStoragePath: userStoragePath
-  lessSearchPaths: [path.join(resourcePath, 'static', 'variables'), path.join(resourcePath, 'static'), path.join(resourcePath, 'vendor')]
+  lessSearchPaths: [
+    path.join(resourcePath, 'static', 'variables')
+    path.join(resourcePath, 'static')
+    path.join(resourcePath, 'vendor', 'less')
+  ]
   defaultSettings: null
   settings: null
   configFileHasErrors: null

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -3,7 +3,6 @@ path = require 'path'
 _ = require 'underscore'
 LessCache = require 'less-cache'
 
-
 module.exports =
 class LessCompileCache
   _.extend @prototype, require('./subscriber')

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -1,0 +1,21 @@
+_ = require 'underscore'
+LessCache = require 'less-cache'
+
+module.exports =
+class LessCompileCache
+  _.extend @prototype, require('subscriber')
+
+  @cacheDir: '/tmp/atom-compile-cache/less'
+
+  constructor: ->
+    importPaths =
+    @cache = new LessCache
+      cacheDir: @constructor.cacheDir
+      importPaths: @getImportPaths()
+    @subscribe atom.themes, 'reloaded', => @cache.setImportPaths(@getImportPaths())
+
+  getImportPaths: -> atom.themes.getImportPaths().concat(config.lessSearchPaths)
+
+  read: (stylesheetPath) -> @cache.readFileSync(stylesheetPath)
+
+  destroy: -> @unsubscribe()

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -1,5 +1,8 @@
+path = require 'path'
+
 _ = require 'underscore'
 LessCache = require 'less-cache'
+
 
 module.exports =
 class LessCompileCache
@@ -8,10 +11,12 @@ class LessCompileCache
   @cacheDir: '/tmp/atom-compile-cache/less'
 
   constructor: ->
-    importPaths =
     @cache = new LessCache
       cacheDir: @constructor.cacheDir
       importPaths: @getImportPaths()
+      resourcePath: window.resourcePath
+      fallbackDir: path.join(window.resourcePath, 'less-compile-cache')
+
     @subscribe atom.themes, 'reloaded', => @cache.setImportPaths(@getImportPaths())
 
   getImportPaths: -> atom.themes.getImportPaths().concat(config.lessSearchPaths)

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -3,7 +3,7 @@ LessCache = require 'less-cache'
 
 module.exports =
 class LessCompileCache
-  _.extend @prototype, require('subscriber')
+  _.extend @prototype, require('./subscriber')
 
   @cacheDir: '/tmp/atom-compile-cache/less'
 

--- a/tasks/build-task.coffee
+++ b/tasks/build-task.coffee
@@ -30,7 +30,6 @@ module.exports = (grunt) ->
       directory = path.join('node_modules', child)
       try
         {name, engines} = grunt.file.readJSON(path.join(directory, 'package.json'))
-        continue if devDependencies[name]?
         if engines?.atom?
           packageDirectories.push(directory)
         else

--- a/tasks/build-task.coffee
+++ b/tasks/build-task.coffee
@@ -49,11 +49,11 @@ module.exports = (grunt) ->
     for directory in nonPackageDirectories
       cp directory, path.join(appDir, directory), filter: nodeModulesFilter
     for directory in packageDirectories
-      cp directory, path.join(appDir, directory), filter: /.+\.(cson|coffee|less)$/
+      cp directory, path.join(appDir, directory), filter: /.+\.(cson|coffee)$/
 
     cp 'spec', path.join(appDir, 'spec')
-    cp 'src', path.join(appDir, 'src'), filter: /.+\.(cson|coffee|less)$/
-    cp 'static', path.join(appDir, 'static'), filter: /.+\.less$/
+    cp 'src', path.join(appDir, 'src'), filter: /.+\.(cson|coffee)$/
+    cp 'static', path.join(appDir, 'static')
 
     grunt.file.recurse path.join('resources', 'mac'), (sourcePath, rootDirectory, subDirectory='', filename) ->
       unless /.+\.plist/.test(sourcePath)

--- a/tasks/clean-task.coffee
+++ b/tasks/clean-task.coffee
@@ -3,7 +3,6 @@ path = require 'path'
 module.exports = (grunt) ->
   {rm} = require('./task-helpers')(grunt)
 
-
   grunt.registerTask 'partial-clean', 'Delete some of the build files', ->
     rm grunt.config.get('atom.buildDir')
     rm require('../src/coffee-cache').cacheDir

--- a/tasks/clean-task.coffee
+++ b/tasks/clean-task.coffee
@@ -7,6 +7,7 @@ module.exports = (grunt) ->
   grunt.registerTask 'partial-clean', 'Delete some of the build files', ->
     rm grunt.config.get('atom.buildDir')
     rm require('../src/coffee-cache').cacheDir
+    rm require('../src/less-compile-cache').cacheDir
     rm '/tmp/atom-cached-atom-shells'
     rm 'atom-shell'
 

--- a/tasks/prebuild-less-task.coffee
+++ b/tasks/prebuild-less-task.coffee
@@ -19,10 +19,16 @@ module.exports = (grunt) ->
         path.resolve('static')
         path.resolve('vendor')
       ]
+      themeMains = []
       for theme in configuration
         # TODO Use AtomPackage class once it runs outside of an Atom context
-        themePath = path.resolve('node_modules', theme, 'stylesheets')
-        importPaths.unshift(themePath) if grunt.file.isDir(themePath)
+        themePath = path.resolve('node_modules', theme)
+        stylesheetsDir = path.join(themePath, 'stylesheets')
+        {main} = grunt.file.readJSON(path.join(themePath, 'package.json'))
+        main ?= 'index.less'
+        mainPath = path.join(themePath, main)
+        themeMains.push(mainPath) if grunt.file.isFile(mainPath)
+        importPaths.unshift(stylesheetsDir) if grunt.file.isDir(stylesheetsDir)
 
       grunt.log.writeln("Building LESS cache for #{configuration.join(', ').yellow}")
       lessCache = new LessCache
@@ -31,5 +37,9 @@ module.exports = (grunt) ->
         importPaths: importPaths
 
       for file in @filesSrc
+        grunt.log.writeln("File #{file.cyan} created in cache.")
+        lessCache.readFileSync(file)
+
+      for file in themeMains
         grunt.log.writeln("File #{file.cyan} created in cache.")
         lessCache.readFileSync(file)

--- a/tasks/prebuild-less-task.coffee
+++ b/tasks/prebuild-less-task.coffee
@@ -20,7 +20,7 @@ module.exports = (grunt) ->
         path.resolve('vendor')
       ]
       for theme in configuration
-        # TODO Using AtomPackage class once it runs outside of an Atom context
+        # TODO Use AtomPackage class once it runs outside of an Atom context
         themePath = path.resolve('node_modules', theme, 'stylesheets')
         importPaths.unshift(themePath) if grunt.file.isDir(themePath)
 

--- a/tasks/prebuild-less-task.coffee
+++ b/tasks/prebuild-less-task.coffee
@@ -14,11 +14,7 @@ module.exports = (grunt) ->
     directory = path.join(grunt.config.get('atom.appDir'), 'less-compile-cache')
 
     for configuration in prebuiltConfigurations
-      importPaths = [
-        path.resolve('static/variables')
-        path.resolve('static')
-        path.resolve('vendor')
-      ]
+      importPaths = grunt.config.get('less.options.paths')
       themeMains = []
       for theme in configuration
         # TODO Use AtomPackage class once it runs outside of an Atom context

--- a/tasks/prebuild-less-task.coffee
+++ b/tasks/prebuild-less-task.coffee
@@ -1,0 +1,35 @@
+path = require 'path'
+
+LessCache = require 'less-cache'
+
+module.exports = (grunt) ->
+  grunt.registerMultiTask 'prebuild-less', 'Prebuild cached of compiled LESS files', ->
+    prebuiltConfigurations = [
+      ['atom-dark-ui', 'atom-dark-syntax']
+      ['atom-dark-ui', 'atom-light-syntax']
+      ['atom-light-ui', 'atom-light-syntax']
+      ['atom-light-ui', 'atom-dark-syntax']
+    ]
+
+    directory = path.join(grunt.config.get('atom.appDir'), 'less-compile-cache')
+
+    for configuration in prebuiltConfigurations
+      importPaths = [
+        path.resolve('static/variables')
+        path.resolve('static')
+        path.resolve('vendor')
+      ]
+      for theme in configuration
+        # TODO Using AtomPackage class once it runs outside of an Atom context
+        themePath = path.resolve('node_modules', theme, 'stylesheets')
+        importPaths.unshift(themePath) if grunt.file.isDir(themePath)
+
+      grunt.log.writeln("Building LESS cache for #{configuration.join(', ').yellow}")
+      lessCache = new LessCache
+        cacheDir: directory
+        resourcePath: path.resolve('.')
+        importPaths: importPaths
+
+      for file in @filesSrc
+        grunt.log.writeln("File #{file.cyan} created in cache.")
+        lessCache.readFileSync(file)


### PR DESCRIPTION
- [x] Use [less-cache](https://github.com/atom/less-cache) to cache compiled LESS files to `/tmp/atom-compile-cache/less`.
- [x] Bundle pre-built caches for light/dark ui/syntax combinations

This makes opening a dev window go from 3 seconds to 1 second on my machine.
