### PR TITLE
Improve IME support

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -884,6 +884,10 @@ describe "Editor", ->
         expect(editor.getSelection().isEmpty()).toBeTruthy()
         expect(cursorView).toBeVisible()
 
+      it "moves the hiddenInput to the same position with cursor's view", ->
+        editor.setCursorScreenPosition(row: 2, column: 2)
+        expect(editor.getCursorView().offset()).toEqual(editor.hiddenInput.offset())
+
       describe "when the editor is using a variable-width font", ->
         beforeEach ->
           editor.setFontFamily('sans-serif')

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -702,17 +702,13 @@ class Editor extends View
       cursorView = @getCursorView()
       @hiddenInput.offset(cursorView.offset()) if cursorView.is(':visible')
 
-    startScreenPosition = null
     @hiddenInput.on 'compositionstart', =>
-      startScreenPosition = @getCursorScreenPosition()
       @hiddenInput.css('width', '100%')
     @hiddenInput.on 'compositionupdate', (e) =>
-      @insertText(e.originalEvent.data)
-      @selectToScreenPosition(startScreenPosition)
+      @insertText(e.originalEvent.data, select: true)
     @hiddenInput.on 'compositionend', =>
       @delete()
       @hiddenInput.css('width', '1px')
-      startScreenPosition = null
 
   selectOnMousemoveUntilMouseup: ->
     lastMoveEvent = null

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -705,11 +705,13 @@ class Editor extends View
     startScreenPosition = null
     @hiddenInput.on 'compositionstart', =>
       startScreenPosition = @getCursorScreenPosition()
+      @hiddenInput.css('width', '100%')
     @hiddenInput.on 'compositionupdate', (e) =>
       @insertText(e.originalEvent.data)
       @selectToScreenPosition(startScreenPosition)
     @hiddenInput.on 'compositionend', =>
       @delete()
+      @hiddenInput.css('width', '1px')
       startScreenPosition = null
 
   selectOnMousemoveUntilMouseup: ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -705,9 +705,9 @@ class Editor extends View
     @hiddenInput.on 'compositionstart', =>
       @hiddenInput.css('width', '100%')
     @hiddenInput.on 'compositionupdate', (e) =>
-      @insertText(e.originalEvent.data, select: true)
+      @insertText(e.originalEvent.data, {select: true, skipUndo: true})
     @hiddenInput.on 'compositionend', =>
-      @delete()
+      @insertText('', skipUndo: true)
       @hiddenInput.css('width', '1px')
 
   selectOnMousemoveUntilMouseup: ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -88,6 +88,7 @@ class Editor extends View
     @configure()
     @bindKeys()
     @handleEvents()
+    @handleImeEvents()
     @cursorViews = []
     @selectionViews = []
     @pendingChanges = []
@@ -695,6 +696,10 @@ class Editor extends View
         @gutter.removeClass('drop-shadow')
       else
         @gutter.addClass('drop-shadow')
+
+  handleImeEvents: ->
+    @on 'cursor:moved', =>
+      @hiddenInput.offset(@getCursorView().offset())
 
   selectOnMousemoveUntilMouseup: ->
     lastMoveEvent = null

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -702,12 +702,14 @@ class Editor extends View
       cursorView = @getCursorView()
       @hiddenInput.offset(cursorView.offset()) if cursorView.is(':visible')
 
+    selectedText = null
     @hiddenInput.on 'compositionstart', =>
+      selectedText = @getSelectedText()
       @hiddenInput.css('width', '100%')
     @hiddenInput.on 'compositionupdate', (e) =>
       @insertText(e.originalEvent.data, {select: true, skipUndo: true})
     @hiddenInput.on 'compositionend', =>
-      @insertText('', skipUndo: true)
+      @insertText(selectedText, {select: true, skipUndo: true})
       @hiddenInput.css('width', '1px')
 
   selectOnMousemoveUntilMouseup: ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -699,7 +699,18 @@ class Editor extends View
 
   handleImeEvents: ->
     @on 'cursor:moved', =>
-      @hiddenInput.offset(@getCursorView().offset())
+      cursorView = @getCursorView()
+      @hiddenInput.offset(cursorView.offset()) if cursorView.is(':visible')
+
+    startScreenPosition = null
+    @hiddenInput.on 'compositionstart', =>
+      startScreenPosition = @getCursorScreenPosition()
+    @hiddenInput.on 'compositionupdate', (e) =>
+      @insertText(e.originalEvent.data)
+      @selectToScreenPosition(startScreenPosition)
+    @hiddenInput.on 'compositionend', =>
+      @delete()
+      startScreenPosition = null
 
   selectOnMousemoveUntilMouseup: ->
     lastMoveEvent = null

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -713,9 +713,7 @@ class Editor extends View
       # Work around of the accented character suggestion feature in OS X.
       selectedLength = @hiddenInput[0].selectionEnd - @hiddenInput[0].selectionStart
       if selectedLength is 1 and lastInput is @hiddenInput.val()
-        position = @getCursorScreenPosition()
-        position.column -= 1
-        @selectToScreenPosition(position)
+        @selectLeft()
 
       lastInput = e.originalEvent.data
       @insertText(lastInput)

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -296,6 +296,8 @@ class Selection
   #    + autoDecreaseIndent:
   #      if `true`, decreases indent level appropriately (for example, when a
   #      closing bracket is inserted)
+  #    + skipUndo:
+  #      if `true`, skips the undo stack for this operation.
   insertText: (text, options={}) ->
     oldBufferRange = @getBufferRange()
     @editSession.destroyFoldsContainingBufferRow(oldBufferRange.end.row)
@@ -306,7 +308,7 @@ class Selection
     if options.indentBasis? and not options.autoIndent
       text = @normalizeIndents(text, options.indentBasis)
 
-    newBufferRange = @editSession.buffer.change(oldBufferRange, text)
+    newBufferRange = @editSession.buffer.change(oldBufferRange, text, skipUndo: options.skipUndo)
     if options.select
       @setBufferRange(newBufferRange, isReversed: wasReversed)
     else


### PR DESCRIPTION
- Make IME's input bubble follow the cursor.
- Fix OS X's accented character suggestion. (https://github.com/atom/atom-shell/issues/50)
- Show IME's composition text in the editor (https://github.com/atom/atom/issues/795)
