### PR TITLE
Upgrade to to-the-hubs v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "symbols-view": "0.4.0",
     "tabs": "0.3.0",
     "terminal": "0.7.0",
-    "to-the-hubs": "0.1.0",
+    "to-the-hubs": "0.2.0",
     "toml": "0.1.0",
     "tree-view": "0.3.0",
     "ui-demo": "0.3.1",


### PR DESCRIPTION
Upgrade to [to-the-hubs v0.2.0](https://github.com/atom/to-the-hubs/releases/tag/v0.2.0), which includes the [history command](https://github.com/atom/to-the-hubs/pull/3) that @kevinsawicki added, as well as a few minor tweaks.
