### PR TITLE
Remove unused key bindings from mini editors

### DIFF
--- a/keymaps/editor.cson
+++ b/keymaps/editor.cson
@@ -1,10 +1,16 @@
 '.editor':
+  'meta-d': 'editor:delete-line'
+  'ctrl-W': 'editor:select-word'
+  'meta-alt-p': 'editor:log-cursor-scope'
+  'meta-u': 'editor:upper-case'
+  'meta-U': 'editor:lower-case'
+
+'.editor:not(.mini)':
   'enter': 'editor:newline'
   'meta-enter': 'editor:newline-below'
   'meta-shift-enter': 'editor:newline-above'
   'tab': 'editor:indent'
   'meta-=': 'editor:auto-indent'
-  'meta-d': 'editor:delete-line'
 
   'ctrl-[': 'editor:fold-current-row'
   'ctrl-]': 'editor:unfold-current-row'
@@ -26,11 +32,8 @@
   'shift-tab': 'editor:outdent-selected-rows'
   'meta-[': 'editor:outdent-selected-rows'
   'meta-]': 'editor:indent-selected-rows'
+
   'meta-/': 'editor:toggle-line-comments'
-  'ctrl-W': 'editor:select-word'
-  'meta-alt-p': 'editor:log-cursor-scope'
-  'meta-u': 'editor:upper-case'
-  'meta-U': 'editor:lower-case'
   'ctrl-C': 'editor:copy-path'
   'ctrl-meta-up': 'editor:move-line-up'
   'ctrl-meta-down': 'editor:move-line-down'

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "metrics": "0.1.1",
     "package-generator": "0.5.0",
     "settings-view": "0.18.0",
-    "snippets": "0.2.0",
+    "snippets": "0.3.0",
     "spell-check": "0.3.0",
     "status-bar": "0.5.0",
     "symbols-view": "0.4.0",

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -126,12 +126,7 @@ class Editor extends View
       'core:paste': @paste
       'editor:move-to-previous-word': @moveCursorToPreviousWord
       'editor:select-word': @selectWord
-      'editor:newline': @insertNewline
       'editor:consolidate-selections': @consolidateSelections
-      'editor:indent': @indent
-      'editor:auto-indent': @autoIndent
-      'editor:indent-selected-rows': @indentSelectedRows
-      'editor:outdent-selected-rows': @outdentSelectedRows
       'editor:backspace-to-beginning-of-word': @backspaceToBeginningOfWord
       'editor:backspace-to-beginning-of-line': @backspaceToBeginningOfLine
       'editor:delete-to-end-of-word': @deleteToEndOfWord
@@ -153,8 +148,6 @@ class Editor extends View
       'editor:select-to-next-word-boundary': @selectToNextWordBoundary
       'editor:select-to-previous-word-boundary': @selectToPreviousWordBoundary
       'editor:select-to-first-character-of-line': @selectToFirstCharacterOfLine
-      'editor:add-selection-below': @addSelectionBelow
-      'editor:add-selection-above': @addSelectionAbove
       'editor:select-line': @selectLine
       'editor:transpose': @transpose
       'editor:upper-case': @upperCase
@@ -172,8 +165,15 @@ class Editor extends View
         'core:select-down': @selectDown
         'core:select-to-top': @selectToTop
         'core:select-to-bottom': @selectToBottom
+        'editor:indent': @indent
+        'editor:auto-indent': @autoIndent
+        'editor:indent-selected-rows': @indentSelectedRows
+        'editor:outdent-selected-rows': @outdentSelectedRows
+        'editor:newline': @insertNewline
         'editor:newline-below': @insertNewlineBelow
         'editor:newline-above': @insertNewlineAbove
+        'editor:add-selection-below': @addSelectionBelow
+        'editor:add-selection-above': @addSelectionAbove
         'editor:toggle-soft-tabs': @toggleSoftTabs
         'editor:toggle-soft-wrap': @toggleSoftWrap
         'editor:fold-all': @foldAll


### PR DESCRIPTION
Commands like `editor:newline` and `editor:outdent-selected-rows` aren't applicable for mini-editors. But those keybindings where still being captured by mini-editors.

This pull ensures only the key bindings that mini-editors use are captured. It  also removes irrelevant commands that mini editors shouldn't respond to.
