### PR TITLE
Timecop

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "symbols-view": "0.5.0",
     "tabs": "0.4.0",
     "terminal": "0.9.0",
-    "timecop": "0.1.0",
+    "timecop": "0.2.0",
     "to-the-hubs": "0.3.0",
     "toml": "0.2.0",
     "tree-view": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "symbols-view": "0.5.0",
     "tabs": "0.4.0",
     "terminal": "0.9.0",
+    "timecop": "0.1.0",
     "to-the-hubs": "0.3.0",
     "toml": "0.2.0",
     "tree-view": "0.5.0",

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -61,7 +61,7 @@ window.atom =
 
   loadPackages: ->
     # Ensure atom exports is already in the require cache so the load time
-    # of the first package isn't impacted by being the first to require atom
+    # of the first package isn't skewed by being the first to require atom
     require '../exports/atom'
 
     @loadPackage(name) for name in @getAvailablePackageNames() when not @isPackageDisabled(name)

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -60,6 +60,10 @@ window.atom =
     _.values(@activePackages)
 
   loadPackages: ->
+    # Ensure atom exports is already in the require cache so the load time
+    # of the first package isn't impacted by being the first to require atom
+    require '../exports/atom'
+
     @loadPackage(name) for name in @getAvailablePackageNames() when not @isPackageDisabled(name)
     @watchThemes()
 


### PR DESCRIPTION
Adds a new package that displays information about where time is spent in Atom.

Currently includes 2 things, package loading, and package activation.

Just wanted to get a plugin going where we surface this information so if people are finding atom startup sluggish they have a place to look for the possible cause.

![screen shot 2013-09-22 at 3 32 32 pm](https://f.cloud.github.com/assets/671378/1188525/f6e41940-23d6-11e3-8c99-c70e62587c6c.png)
