### PR TITLE
Load package stylesheets right before activation

### DIFF
--- a/src/atom-package.coffee
+++ b/src/atom-package.coffee
@@ -65,6 +65,7 @@ class AtomPackage extends Package
   activateNow: ->
     try
       @activateConfig()
+      @activateStylesheets()
       if @requireMainModule()
         @mainModule.activate(atom.getPackageState(@name) ? {})
         @mainActivated = true
@@ -80,11 +81,13 @@ class AtomPackage extends Package
       @mainModule.activateConfig?()
     @configActivated = true
 
+  activateStylesheets: ->
+    type = if @metadata.theme then 'theme' else 'bundled'
+    applyStylesheet(stylesheetPath, content, type) for [stylesheetPath, content] in @stylesheets
+
   activateResources: ->
     keymap.add(keymapPath, map) for [keymapPath, map] in @keymaps
     atom.contextMenu.add(menuPath, map['context-menu']) for [menuPath, map] in @menus
-    type = if @metadata.theme then 'theme' else 'bundled'
-    applyStylesheet(stylesheetPath, content, type) for [stylesheetPath, content] in @stylesheets
     syntax.addGrammar(grammar) for grammar in @grammars
     for [scopedPropertiesPath, selector, properties] in @scopedProperties
       syntax.addProperties(scopedPropertiesPath, selector, properties)


### PR DESCRIPTION
Atom currently loads a package's stylesheets when activated even for packages using activation events.

This can cause atom to have a delayed startup since it is too eagerly loading things it might not even use.  Now that we have less caching going on it is even more important to only load stylesheets when needed.

If packages are using activation events it should signal that they don't need their stylesheets actually loaded until right before `activate` is called on their package main.

A good example of where this can speed things up is the markdown preview.  It has a pretty hefty stylesheet that is loaded immediately at startup even though it isn't used until a markdown file is previewed.
