### PR TITLE
Upgrade telepath to v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "semver": "1.1.4",
     "space-pen": "1.2.0",
     "tantamount": "0.3.0",
-    "telepath": "0.4.0",
+    "telepath": "0.5.1",
     "temp": "0.5.0",
     "underscore": "1.4.4",
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "autoflow": "0.2.0",
     "bookmarks": "0.3.0",
     "bracket-matcher": "0.4.0",
-    "collaboration": "0.14.0",
+    "collaboration": "0.15.1",
     "command-logger": "0.3.0",
     "command-palette": "0.3.0",
     "editor-stats": "0.2.0",

--- a/src/event-emitter.coffee
+++ b/src/event-emitter.coffee
@@ -105,8 +105,11 @@ module.exports =
   # Identifies how many events are registered.
   #
   # Returns a {Number}.
-  subscriptionCount: ->
+  getSubscriptionCount: ->
     count = 0
     for name, handlers of @eventHandlersByEventName
       count += handlers.length
     count
+
+  # Deprecated
+  subscriptionCount: -> @getSubscriptionCount()


### PR DESCRIPTION
This version of telepath provides telepath.Model, document-based property resolution, and relational operators. Nothing much has changed yet except for the serialization of the window state, but this upgrade begins a process that will eventually eliminate all manual (de)serialization and manual management of telepath state documents.
