### PR TITLE
Fix blank bug

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -63,6 +63,15 @@ describe "Editor", ->
       expect(editor).not.toMatchSelector ':focus'
       expect(editor.hiddenInput).toMatchSelector ':focus'
 
+    it "does not scroll the editor (regression)", ->
+      editor.attachToDom(heightInLines: 2)
+      editor.selectAll()
+      editor.hiddenInput.blur()
+      editor.focus()
+
+      expect(editor.hiddenInput).toMatchSelector ':focus'
+      expect($(editor[0]).scrollTop()).toBe 0
+
   describe "when the hidden input is focused / unfocused", ->
     it "assigns the isFocused flag on the editor and also adds/removes the .focused css class", ->
       editor.attachToDom()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -630,13 +630,15 @@ class Editor extends View
 
   handleEvents: ->
     @on 'focus', =>
-      @updateHiddenInputOffset()
       @hiddenInput.focus()
       false
 
     @hiddenInput.on 'focus', =>
       @isFocused = true
       @addClass 'is-focused'
+
+    @hiddenInput.on 'blur', =>
+      @hiddenInput.offset(top: 0, left: 0)
 
     @hiddenInput.on 'focusout', =>
       @isFocused = false
@@ -696,10 +698,7 @@ class Editor extends View
 
   updateHiddenInputOffset: ->
     cursorView = @getCursorView()
-    if cursorView?.is(':visible')
-      offset = cursorView.offset()
-      offset.top = Math.min(@height(), offset.top)
-      @hiddenInput.offset(offset)
+    @hiddenInput.offset(cursorView.offset()) if cursorView?.is(':visible')
 
   handleInputEvents: ->
     @on 'cursor:moved', => @updateHiddenInputOffset()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -630,6 +630,7 @@ class Editor extends View
 
   handleEvents: ->
     @on 'focus', =>
+      @updateHiddenInputOffset()
       @hiddenInput.focus()
       false
 
@@ -693,10 +694,15 @@ class Editor extends View
       else
         @gutter.addClass('drop-shadow')
 
+  updateHiddenInputOffset: ->
+    cursorView = @getCursorView()
+    if cursorView?.is(':visible')
+      offset = cursorView.offset()
+      offset.top = Math.min(@height(), offset.top)
+      @hiddenInput.offset(offset)
+
   handleInputEvents: ->
-    @on 'cursor:moved', =>
-      cursorView = @getCursorView()
-      @hiddenInput.offset(cursorView.offset()) if cursorView.is(':visible')
+    @on 'cursor:moved', => @updateHiddenInputOffset()
 
     selectedText = null
     @hiddenInput.on 'compositionstart', =>

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -637,12 +637,10 @@ class Editor extends View
       @isFocused = true
       @addClass 'is-focused'
 
-    @hiddenInput.on 'blur', =>
-      @hiddenInput.offset(top: 0, left: 0)
-
     @hiddenInput.on 'focusout', =>
       @isFocused = false
       @removeClass 'is-focused'
+      @hiddenInput.offset(top: 0, left: 0)
 
     @underlayer.on 'mousedown', (e) =>
       @renderedLines.trigger(e)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -696,12 +696,10 @@ class Editor extends View
       else
         @gutter.addClass('drop-shadow')
 
-  updateHiddenInputOffset: ->
-    cursorView = @getCursorView()
-    @hiddenInput.offset(cursorView.offset()) if cursorView?.is(':visible')
-
   handleInputEvents: ->
-    @on 'cursor:moved', => @updateHiddenInputOffset()
+    @on 'cursor:moved', =>
+      cursorView = @getCursorView()
+      @hiddenInput.offset(cursorView.offset()) if cursorView.is(':visible')
 
     selectedText = null
     @hiddenInput.on 'compositionstart', =>


### PR DESCRIPTION
:black_large_square::black_medium_small_square::black_large_square:
:black_medium_small_square::black_large_square::black_medium_small_square:
:black_large_square::black_medium_small_square::black_large_square:

Fix the regression where the editor sometimes goes blank introduced in #852 

Basic idea is that now that the hidden input has an offset it needs to be reset to `0,0` on blur so the next focus event doesn't cause the editor to scroll.

Steps to reproduce:
1. Open atom with no editors open
2. Open a large file (something the size of jquery.js or editor.coffee works consistently)
3. Click the tab icon
4. Editor goes blank
