### PR TITLE
Add dev mode status to windows

### DIFF
--- a/src/application-menu.coffee
+++ b/src/application-menu.coffee
@@ -9,10 +9,9 @@ _ = require 'underscore'
 module.exports =
 class ApplicationMenu
   version: null
-  devMode: null
   menu: null
 
-  constructor: (@version, @devMode) ->
+  constructor: (@version) ->
     @menu = Menu.buildFromTemplate @getDefaultTemplate()
     Menu.setApplicationMenu @menu
 
@@ -149,7 +148,6 @@ class ApplicationMenu
       submenu: [ { label: 'In Development Mode', enabled: false } ]
 
     template = [atomMenu, fileMenu, editMenu, viewMenu, windowMenu]
-    template.push devMenu if @devMode
 
     @translateTemplate template, keystrokesByCommand
 

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -57,7 +57,7 @@ class AtomApplication
     @pathsToOpen ?= []
     @windows = []
 
-    @applicationMenu = new ApplicationMenu(@version, devMode)
+    @applicationMenu = new ApplicationMenu(@version)
     @atomProtocolHandler = new AtomProtocolHandler(@resourcePath)
 
     @listenForArgumentsFromNewProcess()

--- a/src/root-view.coffee
+++ b/src/root-view.coffee
@@ -65,6 +65,8 @@ class RootView extends View
 
   # Private:
   initialize: (state={}) ->
+    @prepend("<div class='dev-mode'></div>") if atom.getLoadSettings().devMode
+
     if state instanceof telepath.Document
       @state = state
       panes = deserialize(state.get('panes'))

--- a/src/root-view.coffee
+++ b/src/root-view.coffee
@@ -65,7 +65,7 @@ class RootView extends View
 
   # Private:
   initialize: (state={}) ->
-    @prepend("<div class='dev-mode'></div>") if atom.getLoadSettings().devMode
+    @prepend($$ -> @div class: 'dev-mode') if atom.getLoadSettings().devMode
 
     if state instanceof telepath.Document
       @state = state

--- a/static/root-view.less
+++ b/static/root-view.less
@@ -37,6 +37,19 @@ h6 {
     -webkit-flex: 1;
     -webkit-flex-flow: column;
   }
+
+  .dev-mode {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 10px;
+    height: 10px;
+    z-index: 1000;
+    opacity: 0.75;
+    border: 5px #CF4647 solid;
+    border-bottom-color: transparent;
+    border-left-color: transparent;
+  }
 }
 
 #panes {

--- a/static/root-view.less
+++ b/static/root-view.less
@@ -46,7 +46,7 @@ h6 {
     height: 10px;
     z-index: 1000;
     opacity: 0.75;
-    border: 5px #CF4647 solid;
+    border: 5px @background-color-warning solid;
     border-bottom-color: transparent;
     border-left-color: transparent;
   }

--- a/static/root-view.less
+++ b/static/root-view.less
@@ -39,16 +39,19 @@ h6 {
   }
 
   .dev-mode {
+
+    &:before {
+      content: ""; // This is not a space, it is a skull and crossbones
+    }
+
     position: absolute;
     top: 0;
     right: 0;
-    width: 10px;
-    height: 10px;
+    font-family: Wingdings;
+    font-size: 25px;
     z-index: 1000;
     opacity: 0.75;
-    border: 5px @background-color-warning solid;
-    border-bottom-color: transparent;
-    border-left-color: transparent;
+    color: @text-color-highlight;
   }
 }
 


### PR DESCRIPTION
It would be nice to add this to the window chrome. But I don't think we can do that yet with atom-shell. For now I've added a little warning triangle to the upper right when the window is in dev mode. Is this too annoying?

![atom - _users_corey_github_atom](https://f.cloud.github.com/assets/596/1214567/3c5f51f2-2642-11e3-9880-12511fd7768a.jpg)
