### PR TITLE
Fix Editor leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "scandal": "0.2.0",
     "season": "0.13.0",
     "semver": "1.1.4",
-    "space-pen": "1.2.0",
+    "space-pen": "1.2.1",
     "tantamount": "0.3.0",
     "telepath": "0.8.0",
     "temp": "0.5.0",

--- a/spec/selection-spec.coffee
+++ b/spec/selection-spec.coffee
@@ -68,5 +68,6 @@ describe "Selection", ->
   describe "when the selection is destroyed", ->
     it "destroys its marker", ->
       selection.setBufferRange([[2, 0], [2, 10]])
+      marker = selection.marker
       selection.destroy()
-      expect(selection.marker.isDestroyed()).toBeTruthy()
+      expect(marker.isDestroyed()).toBeTruthy()

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -78,6 +78,7 @@ beforeEach ->
 afterEach ->
   keymap.bindingSets = bindingSetsToRestore
   keymap.bindingSetsByFirstKeystroke = bindingSetsByFirstKeystrokeToRestore
+  window.resetTimeouts()
   atom.deactivatePackages()
   if rootView?
     rootView.remove?()

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -1,5 +1,6 @@
 {Point, Range} = require 'telepath'
 EventEmitter = require './event-emitter'
+Subscriber = require './subscriber'
 _ = require './underscore-extensions'
 
 # Public: The `Cursor` class represents the little blinking line identifying
@@ -10,6 +11,7 @@ _ = require './underscore-extensions'
 module.exports =
 class Cursor
   _.extend @prototype, EventEmitter
+  _.extend @prototype, Subscriber
 
   screenPosition: null
   bufferPosition: null
@@ -20,7 +22,7 @@ class Cursor
   # Private: Instantiated by an {EditSession}
   constructor: ({@editSession, @marker}) ->
     @updateVisibility()
-    @marker.on 'changed', (e) =>
+    @subscribe @marker, 'changed', (e) =>
       @updateVisibility()
       {oldHeadScreenPosition, newHeadScreenPosition} = e
       {oldHeadBufferPosition, newHeadBufferPosition} = e
@@ -38,8 +40,9 @@ class Cursor
 
       @trigger 'moved', movedEvent
       @editSession.trigger 'cursor-moved', movedEvent
-    @marker.on 'destroyed', =>
+    @subscribe @marker, 'destroyed', =>
       @destroyed = true
+      @unsubscribe()
       @editSession.removeCursor(this)
       @trigger 'destroyed'
     @needsAutoscroll = true

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -47,9 +47,9 @@ class DisplayBuffer
     @updateAllScreenLines()
     @createFoldForMarker(marker) for marker in @buffer.findMarkers(@getFoldMarkerAttributes())
     @subscribe @tokenizedBuffer, 'grammar-changed', (grammar) => @trigger 'grammar-changed', grammar
-    @subscribe @tokenizedBuffer, 'changed', @handleTokenizedBufferChange
-    @subscribe @buffer, 'markers-updated', @handleBufferMarkersUpdated
-    @subscribe @buffer, 'marker-created', @handleBufferMarkerCreated
+    @subscribe @tokenizedBuffer, 'changed', (change) => @handleTokenizedBufferChange(change)
+    @subscribe @buffer, 'markers-updated', => @handleBufferMarkersUpdated()
+    @subscribe @buffer, 'marker-created', (marker) => @handleBufferMarkerCreated(marker)
 
     @subscribe @state, 'changed', ({key, newValue}) =>
       switch key
@@ -590,7 +590,7 @@ class DisplayBuffer
 
   ### Internal ###
 
-  handleTokenizedBufferChange: (tokenizedBufferChange) =>
+  handleTokenizedBufferChange: (tokenizedBufferChange) ->
     {start, end, delta, bufferChange} = tokenizedBufferChange
     @updateScreenLines(start, end + 1, delta, delayChangeEvent: bufferChange?)
 
@@ -683,12 +683,12 @@ class DisplayBuffer
         @longestScreenRow = maxLengthCandidatesStartRow + screenRow
         @maxLineLength = length
 
-  handleBufferMarkersUpdated: =>
+  handleBufferMarkersUpdated: ->
     if event = @pendingChangeEvent
       @pendingChangeEvent = null
       @triggerChanged(event, false)
 
-  handleBufferMarkerCreated: (marker) =>
+  handleBufferMarkerCreated: (marker) ->
     @createFoldForMarker(marker) if marker.matchesAttributes(@getFoldMarkerAttributes())
     @trigger 'marker-created', @getMarker(marker.id)
 

--- a/src/edit-session.coffee
+++ b/src/edit-session.coffee
@@ -124,7 +124,7 @@ class EditSession
 
   # Private:
   setDisplayBuffer: (@displayBuffer) ->
-    @subscribe @displayBuffer, 'marker-created', @handleMarkerCreated
+    @subscribe @displayBuffer, 'marker-created', (marker) => @handleMarkerCreated(marker)
     @subscribe @displayBuffer, "changed", (e) => @trigger 'screen-lines-changed', e
     @subscribe @displayBuffer, "markers-updated", => @mergeIntersectingSelections()
     @subscribe @displayBuffer, 'grammar-changed', => @handleGrammarChange()
@@ -1428,7 +1428,7 @@ class EditSession
     @trigger 'grammar-changed'
 
   # Private:
-  handleMarkerCreated: (marker) =>
+  handleMarkerCreated: (marker) ->
     if marker.matchesAttributes(@getSelectionMarkerAttributes())
       @addSelection(marker)
 

--- a/src/edit-session.coffee
+++ b/src/edit-session.coffee
@@ -141,6 +141,7 @@ class EditSession
     @unsubscribe()
     @buffer.release()
     selection.destroy() for selection in @getSelections()
+    cursor.destroy() for cursor in @getCursors()
     @displayBuffer.destroy()
     @languageMode.destroy()
     project?.removeEditSession(this)

--- a/src/event-emitter.coffee
+++ b/src/event-emitter.coffee
@@ -52,7 +52,7 @@ module.exports =
           new Array(handlers...).forEach (handler) -> handler(args...)
       else
         if handlers = @eventHandlersByEventName?[eventName]
-          handlers.forEach (handler) -> handler(args...)
+          new Array(handlers...).forEach (handler) -> handler(args...)
 
   # Stops executing handlers for a registered event.
   #

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -59,12 +59,12 @@ class Pane extends View
     unless activeItemUri? and @showItemForUri(activeItemUri)
       @showItem(@items[0]) if @items.length > 0
 
-    @command 'core:close', @destroyActiveItem
-    @command 'core:save', @saveActiveItem
-    @command 'core:save-as', @saveActiveItemAs
-    @command 'pane:save-items', @saveItems
-    @command 'pane:show-next-item', @showNextItem
-    @command 'pane:show-previous-item', @showPreviousItem
+    @command 'core:close', => @destroyActiveItem()
+    @command 'core:save',  => @saveActiveItem()
+    @command 'core:save-as', => @saveActiveItemAs()
+    @command 'pane:save-items', => @saveItems()
+    @command 'pane:show-next-item', => @showNextItem()
+    @command 'pane:show-previous-item', => @showPreviousItem()
 
     @command 'pane:show-item-1', => @showItemAtIndex(0)
     @command 'pane:show-item-2', => @showItemAtIndex(1)
@@ -127,7 +127,7 @@ class Pane extends View
     new Array(@items...)
 
   # Public: Switches to the next contained item.
-  showNextItem: =>
+  showNextItem: ->
     index = @getActiveItemIndex()
     if index < @items.length - 1
       @showItemAtIndex(index + 1)
@@ -135,7 +135,7 @@ class Pane extends View
       @showItemAtIndex(0)
 
   # Public: Switches to the previous contained item.
-  showPreviousItem: =>
+  showPreviousItem: ->
     index = @getActiveItemIndex()
     if index > 0
       @showItemAtIndex(index - 1)
@@ -161,13 +161,14 @@ class Pane extends View
   showItem: (item) ->
     return if !item? or item is @activeItem
 
-    if @activeItem
-      @activeItem.off? 'title-changed', @activeItemTitleChanged
+    if @activeItem?
+      @unsubscribe(@activeItem)
       @autosaveActiveItem()
 
     isFocused = @is(':has(:focus)')
     @addItem(item)
-    item.on? 'title-changed', @activeItemTitleChanged
+    if _.isFunction(item.on)
+      @subscribe item, 'title-changed', => @activeItemTitleChanged()
     view = @viewForItem(item)
     @itemViews.children().not(view).hide()
     @itemViews.append(view) unless view.parent().is(@itemViews)
@@ -180,7 +181,7 @@ class Pane extends View
     @state.set('activeItemUri', item.getUri?())
 
   # Private:
-  activeItemTitleChanged: =>
+  activeItemTitleChanged: ->
     @trigger 'pane:active-item-title-changed'
 
   # Public: Add an additional item at the specified index.
@@ -194,7 +195,7 @@ class Pane extends View
     item
 
   # Public: Remove the currently active item.
-  destroyActiveItem: =>
+  destroyActiveItem: ->
     @destroyItem(@activeItem)
     false
 
@@ -237,11 +238,11 @@ class Pane extends View
       when 2 then true
 
   # Public: Saves the currently focused item.
-  saveActiveItem: =>
+  saveActiveItem: ->
     @saveItem(@activeItem)
 
   # Public: Save and prompt for path for the currently focused item.
-  saveActiveItemAs: =>
+  saveActiveItemAs: ->
     @saveItemAs(@activeItem)
 
   # Public: Saves the specified item and call the next action when complete.
@@ -265,7 +266,7 @@ class Pane extends View
       nextAction?()
 
   # Public: Saves all items in this pane.
-  saveItems: =>
+  saveItems: ->
     @saveItem(item) for item in @getItems()
 
   # Public: Autosaves the currently focused item.
@@ -284,7 +285,7 @@ class Pane extends View
   # Public: Just remove the item at the given index.
   removeItemAtIndex: (index, options={}) ->
     item = @items[index]
-    @activeItem.off? 'title-changed', @activeItemTitleChanged if item is @activeItem
+    @unsubscribe(@activeItem) if item is @activeItem
     @showNextItem() if item is @activeItem and @items.length > 1
     _.remove(@items, item)
     @state.get('items').remove(index) if options.updateState ? true

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -454,3 +454,5 @@ class Pane extends View
       @getContainer().makeNextPaneActive()
 
     item.destroy?() for item in @getItems()
+    @activeItem = null
+    @activeView = null

--- a/src/selection-view.coffee
+++ b/src/selection-view.coffee
@@ -13,8 +13,9 @@ class SelectionView extends View
 
   initialize: ({@editor, @selection} = {}) ->
     @regions = []
-    @selection.on 'screen-range-changed', => @editor.requestDisplayUpdate()
-    @selection.on 'destroyed', =>
+    @subscribe @selection, 'screen-range-changed', =>
+      @editor.requestDisplayUpdate()
+    @subscribe @selection, 'destroyed', =>
       @needsRemoval = true
       @editor.requestDisplayUpdate()
 

--- a/src/selection-view.coffee
+++ b/src/selection-view.coffee
@@ -84,6 +84,9 @@ class SelectionView extends View
   unhighlight: ->
     @removeClass('highlighted')
 
+  beforeRemove: ->
+    @editor = null
+
   remove: ->
     @editor.removeSelectionView(this)
     super

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -1,11 +1,13 @@
 {Range} = require 'telepath'
 EventEmitter = require './event-emitter'
+Subscriber = require './subscriber'
 _ = require './underscore-extensions'
 
 # Public: Represents a selection in the {EditSession}.
 module.exports =
 class Selection
   _.extend @prototype, EventEmitter
+  _.extend @prototype, Subscriber
 
   cursor: null
   marker: null
@@ -14,13 +16,13 @@ class Selection
   wordwise: false
   needsAutoscroll: null
 
-
   # Private:
   constructor: ({@cursor, @marker, @editSession}) ->
     @cursor.selection = this
-    @marker.on 'changed', => @screenRangeChanged()
-    @marker.on 'destroyed', =>
+    @subscribe @marker, 'changed', => @screenRangeChanged()
+    @subscribe @marker, 'destroyed', =>
       @destroyed = true
+      @unsubscribe()
       @editSession.removeSelection(this)
       @trigger 'destroyed' unless @editSession.destroyed
 

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -25,6 +25,9 @@ class Selection
       @unsubscribe()
       @editSession.removeSelection(this)
       @trigger 'destroyed' unless @editSession.destroyed
+      @editSession = null
+      @cursor = null
+      @marker = null
 
   # Private:
   destroy: ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -55,7 +55,7 @@ class TextBuffer
         version: @constructor.version
         text: @text
 
-    @subscribe @text, 'changed', @handleTextChange
+    @subscribe @text, 'changed', (event) => @handleTextChange(event)
     @subscribe @text, 'marker-created', (marker) => @trigger 'marker-created', marker
     @subscribe @text, 'markers-updated', => @trigger 'markers-updated'
 
@@ -68,7 +68,7 @@ class TextBuffer
 
   ### Internal ###
 
-  handleTextChange: (event) =>
+  handleTextChange: (event) ->
     @cachedMemoryContents = null
     @conflict = false if @conflict and !@isModified()
     bufferChangeEvent = _.pick(event, 'oldRange', 'newRange', 'oldText', 'newText')


### PR DESCRIPTION
It appears that each opened editor is never gc'ed.
### Steps to reproduce
1. Open Atom with no editors open
2. Open `vendor/jquery.js`
3. Close the editor
4. Run `gc()`
5. Look at heap usage
6. Repeat
### Before

![screen shot 2013-09-27 at 8 37 21 am](https://f.cloud.github.com/assets/671378/1227038/debcf7da-278a-11e3-8bc6-77a8d036368e.png)
