### PR TITLE
Speed up pane swapping -- isVisible() is slow

### DIFF
--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1175,7 +1175,7 @@ class Editor extends View
   updateDisplay: (options={}) ->
     return unless @attached and @activeEditSession
     return if @activeEditSession.destroyed
-    unless @isVisible()
+    unless @isOnDom() and @isVisible()
       @redrawOnReattach = true
       return
 

--- a/src/jquery-extensions.coffee
+++ b/src/jquery-extensions.coffee
@@ -35,7 +35,7 @@ $.fn.isOnDom = ->
   @closest(document.body).length is 1
 
 $.fn.isVisible = ->
-  @is(':visible')
+  @length > 0 and @css('display') != 'none'
 
 $.fn.isDisabled = ->
   !!@attr('disabled')

--- a/src/jquery-extensions.coffee
+++ b/src/jquery-extensions.coffee
@@ -35,7 +35,21 @@ $.fn.isOnDom = ->
   @closest(document.body).length is 1
 
 $.fn.isVisible = ->
-  @length > 0 and @css('display') != 'none'
+  !@isHidden()
+
+$.fn.isHidden = ->
+  # Implementation taken from jQuery's `:hidden` expression code:
+  # https://github.com/jquery/jquery/blob/master/src/css/hiddenVisibleSelectors.js
+  #
+  # We were using a pseudo selector: @is(':hidden'). But jQuery's pseudo
+  # selector code checks the element's webkitMatchesSelector, which is always
+  # false, and is really really really slow.
+
+  elem = this[0]
+
+  return null unless elem
+
+  elem.offsetWidth <= 0 and elem.offsetHeight <= 0
 
 $.fn.isDisabled = ->
   !!@attr('disabled')


### PR DESCRIPTION
Moving between tabs is slow for me, and it's frustrating.

I did some profiling and it turns out `isVisible()` is slow. `Editor.updateDisplay` and `Editor.pixelPositionForScreenPosition` both call it every time they are called. And when you switch panes, bookmarks and git-diff use it to check for gutter visibility. 

So, I changed it to not use the `:visible` filter, and just check the display property instead. 
- Are there cases where an editor is not visible, but display is not none? Maybe there are cases I'm not thinking about.

This even makes scrolling feel snappier for me. Win, provided there arent any cases where this fails.
