### PR TITLE
Favor the word when double clicking between word/non-word

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -456,6 +456,13 @@ describe "Editor", ->
           editor.renderedLines.trigger 'mouseup'
           expect(editor.getSelectedText()).toBe "items"
 
+          editor.setCursorBufferPosition([0, 0])
+          editor.renderedLines.trigger mousedownEvent(editor: editor, point: [0, 28], originalEvent: {detail: 1})
+          editor.renderedLines.trigger 'mouseup'
+          editor.renderedLines.trigger mousedownEvent(editor: editor, point: [0, 28], originalEvent: {detail: 2})
+          editor.renderedLines.trigger 'mouseup'
+          expect(editor.getSelectedText()).toBe "{"
+
     describe "triple/quardruple/etc-click", ->
       it "selects the line under the cursor", ->
         expect(editor.getCursorScreenPosition()).toEqual(row: 0, column: 0)

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -440,6 +440,22 @@ describe "Editor", ->
         editor.renderedLines.trigger mousedownEvent(editor: editor, point: [3, 12], originalEvent: {detail: 1}, shiftKey: true)
         expect(editor.getSelectedBufferRange()).toEqual [[3, 10], [3, 12]]
 
+      describe "when clicking between a word and a non-word", ->
+        it "selects the word", ->
+          expect(editor.getCursorScreenPosition()).toEqual(row: 0, column: 0)
+          editor.renderedLines.trigger mousedownEvent(editor: editor, point: [1, 21], originalEvent: {detail: 1})
+          editor.renderedLines.trigger 'mouseup'
+          editor.renderedLines.trigger mousedownEvent(editor: editor, point: [1, 21], originalEvent: {detail: 2})
+          editor.renderedLines.trigger 'mouseup'
+          expect(editor.getSelectedText()).toBe "function"
+
+          editor.setCursorBufferPosition([0, 0])
+          editor.renderedLines.trigger mousedownEvent(editor: editor, point: [1, 22], originalEvent: {detail: 1})
+          editor.renderedLines.trigger 'mouseup'
+          editor.renderedLines.trigger mousedownEvent(editor: editor, point: [1, 22], originalEvent: {detail: 2})
+          editor.renderedLines.trigger 'mouseup'
+          expect(editor.getSelectedText()).toBe "items"
+
     describe "triple/quardruple/etc-click", ->
       it "selects the line under the cursor", ->
         expect(editor.getCursorScreenPosition()).toEqual(row: 0, column: 0)

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -141,6 +141,9 @@ class Cursor
   # character. The non-word characters are defined by the
   # `editor.nonWordCharacters` config value.
   #
+  # This method returns false if the character before or after the cursor is
+  # whitespace.
+  #
   # Returns a Boolean.
   isBetweenWordAndNonWord: ->
     return false if @isAtBeginningOfLine() or @isAtEndOfLine()
@@ -148,11 +151,10 @@ class Cursor
     {row, column} = @getBufferPosition()
     range = [[row, column - 1], [row, column + 1]]
     [before, after] = @editSession.getTextInBufferRange(range)
-    if before and after
-      nonWordCharacters = config.get('editor.nonWordCharacters').split('')
-      _.contains(nonWordCharacters, before) isnt _.contains(nonWordCharacters, after)
-    else
-      false
+    return false if /\s/.test(before) or /\s/.test(after)
+
+    nonWordCharacters = config.get('editor.nonWordCharacters').split('')
+    _.contains(nonWordCharacters, before) isnt _.contains(nonWordCharacters, after)
 
   # Public: Returns whether this cursor is between a word's start and end.
   isInsideWord: ->

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -102,7 +102,7 @@ class Cursor
   # Public: Returns the visibility of the cursor.
   isVisible: -> @visible
 
-  # Public: Get the RegExp used by the cursor to determin what a "word" is.
+  # Public: Get the RegExp used by the cursor to determine what a "word" is.
   #
   # * options:
   #    + includeNonWordCharacters:
@@ -328,7 +328,7 @@ class Cursor
 
     beginningOfWordPosition or currentBufferPosition
 
-  # Public: Retrieves buffer position of previous word boundry. It might be on
+  # Public: Retrieves buffer position of previous word boundary. It might be on
   # the current word, or the previous word.
   getPreviousWordBoundaryBufferPosition: (options = {}) ->
     currentBufferPosition = @getBufferPosition()
@@ -350,7 +350,7 @@ class Cursor
 
     beginningOfWordPosition or currentBufferPosition
 
-  # Public: Retrieves buffer position of the next word boundry. It might be on
+  # Public: Retrieves buffer position of the next word boundary. It might be on
   # the current word, or the previous word.
   getMoveNextWordBoundaryBufferPosition: (options = {}) ->
     currentBufferPosition = @getBufferPosition()

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -137,6 +137,11 @@ class Cursor
     range = [[row, Math.min(0, column - 1)], [row, Math.max(0, column + 1)]]
     /^\s+$/.test @editSession.getTextInBufferRange(range)
 
+  # Public: Returns whether the cursor is currently between a word and non-word
+  # character. The non-word characters are defined by the
+  # `editor.nonWordCharacters` config value.
+  #
+  # Returns a Boolean.
   isBetweenWordAndNonWord: ->
     return false if @isAtBeginningOfLine() or @isAtEndOfLine()
 
@@ -148,7 +153,6 @@ class Cursor
       _.contains(nonWordCharacters, before) isnt _.contains(nonWordCharacters, after)
     else
       false
-
 
   # Public: Returns whether this cursor is between a word's start and end.
   isInsideWord: ->
@@ -418,7 +422,6 @@ class Cursor
   getCurrentWordBufferRange: (options={}) ->
     startOptions = _.extend(_.clone(options), allowPrevious: false)
     endOptions = _.extend(_.clone(options), allowNext: false)
-
     new Range(@getBeginningOfCurrentWordBufferPosition(startOptions), @getEndOfCurrentWordBufferPosition(endOptions))
 
   # Public: Returns the buffer Range for the current line.

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -115,6 +115,8 @@ class Selection
   selectWord: ->
     options = {}
     options.wordRegex = /[\t ]*/ if @cursor.isSurroundedByWhitespace()
+    if @cursor.isBetweenWordAndNonWord()
+      options.includeNonWordCharacters = false
 
     @setBufferRange(@cursor.getCurrentWordBufferRange(options))
     @wordwise = true


### PR DESCRIPTION
Changes `Selection.selectWord()` to not match on non-word characters if the cursor is currently between and word and non-word character.
