### PR TITLE
Improve scrolling performance

### DIFF
--- a/benchmark/benchmark-bootstrap.coffee
+++ b/benchmark/benchmark-bootstrap.coffee
@@ -1,6 +1,6 @@
 require '../src/window'
-require '../src/atom'
-require 'atom'
+Atom = require '../src/atom'
+window.atom = new Atom()
 
 {runSpecSuite} = require '../spec/jasmine-helper'
 

--- a/benchmark/benchmark-bootstrap.coffee
+++ b/benchmark/benchmark-bootstrap.coffee
@@ -1,5 +1,7 @@
-Atom = require '../src/atom'
-window.atom = new Atom()
+require '../src/window'
+require '../src/atom'
+require 'atom'
+
 {runSpecSuite} = require '../spec/jasmine-helper'
 
 atom.openDevTools()

--- a/benchmark/benchmark-helper.coffee
+++ b/benchmark/benchmark-helper.coffee
@@ -1,11 +1,9 @@
 require '../spec/spec-helper'
 
-$ = require 'jquery'
-_ = require 'underscore'
-{Point} = require 'telepath'
-Project = require 'project'
-fsUtils = require 'fs-utils'
-TokenizedBuffer = require 'tokenized-buffer'
+{$, _, Point, fs} = require 'atom'
+Project = require '../src/project'
+fsUtils = require '../src/fs-utils'
+TokenizedBuffer = require '../src/tokenized-buffer'
 
 defaultCount = 100
 window.pbenchmark = (args...) -> window.benchmark(args..., profile: true)
@@ -13,7 +11,7 @@ window.fbenchmark = (args...) -> window.benchmark(args..., focused: true)
 window.fpbenchmark = (args...) -> window.benchmark(args..., profile: true, focused: true)
 window.pfbenchmark = window.fpbenchmark
 
-window.benchmarkFixturesProject = new Project(fsUtils.resolveOnLoadPath('benchmark/fixtures'))
+window.benchmarkFixturesProject = new Project(fsUtils.resolveOnLoadPath('../benchmark/fixtures'))
 
 beforeEach ->
   window.project = window.benchmarkFixturesProject

--- a/benchmark/benchmark-suite.coffee
+++ b/benchmark/benchmark-suite.coffee
@@ -95,7 +95,7 @@ describe "editor.", ->
       benchmark "resetDisplay", 50, ->
         editor.resetDisplay()
 
-      benchmark "htmlForScreenRows", 1000, ->
+      fbenchmark "htmlForScreenRows", 1000, ->
         lastRow = editor.getLastScreenRow()
         editor.htmlForScreenRows(0, lastRow)
 

--- a/benchmark/benchmark-suite.coffee
+++ b/benchmark/benchmark-suite.coffee
@@ -59,22 +59,47 @@ describe "editor.", ->
         editor.insertText('"')
         editor.backspace()
 
+    describe "calculating-pixel-position.", ->
+      line = null
+      beforeEach ->
+        editor.scrollTop(2000)
+        editor.resetDisplay()
+        line = editor.lineElementForScreenRow(106)[0]
+
+      benchmark "positionLeftForLineAndColumn", 20000, ->
+        editor.positionLeftForLineAndColumn(line, 82)
+        editor.pixelLeftCache.delete(line)
+
+      benchmark "positionLeftForLineAndColumn.cached", 20000, ->
+        editor.positionLeftForLineAndColumn(line, 82)
+
     describe "text-rendering.", ->
       beforeEach ->
-        editor.scrollTop(200)
+        editor.scrollTop(2000)
 
-      benchmark "resetDisplay", 20, ->
+      benchmark "resetDisplay", 50, ->
         editor.resetDisplay()
 
       benchmark "htmlForScreenRows", 50, ->
         lastRow = editor.getLastScreenRow()
         editor.htmlForScreenRows(0, lastRow)
 
-      benchmark "htmlForScreenRows.htmlParsing", 20, ->
+      benchmark "htmlForScreenRows.htmlParsing", 50, ->
         lastRow = editor.getLastScreenRow()
         html = editor.htmlForScreenRows(0, lastRow)
 
         div = document.createElement('div')
+        div.innerHTML = html
+
+    describe "line-htmlification.", ->
+      div = null
+      html = null
+      beforeEach ->
+        lastRow = editor.getLastScreenRow()
+        html = editor.htmlForScreenRows(0, lastRow)
+        div = document.createElement('div')
+
+      benchmark "setInnerHTML", 1, ->
         div.innerHTML = html
 
   describe "9000-line-file.", ->

--- a/benchmark/benchmark-suite.coffee
+++ b/benchmark/benchmark-suite.coffee
@@ -95,7 +95,7 @@ describe "editor.", ->
       benchmark "resetDisplay", 50, ->
         editor.resetDisplay()
 
-      benchmark "htmlForScreenRows", 50, ->
+      benchmark "htmlForScreenRows", 1000, ->
         lastRow = editor.getLastScreenRow()
         editor.htmlForScreenRows(0, lastRow)
 

--- a/benchmark/benchmark-suite.coffee
+++ b/benchmark/benchmark-suite.coffee
@@ -59,7 +59,7 @@ describe "editor.", ->
         editor.insertText('"')
         editor.backspace()
 
-    describe "calculating-pixel-position.", ->
+    fdescribe "calculating-pixel-position.", ->
       line = null
       beforeEach ->
         editor.scrollTop(2000)

--- a/benchmark/benchmark-suite.coffee
+++ b/benchmark/benchmark-suite.coffee
@@ -59,19 +59,34 @@ describe "editor.", ->
         editor.insertText('"')
         editor.backspace()
 
-    fdescribe "calculating-pixel-position.", ->
+    describe "positionLeftForLineAndColumn.", ->
       line = null
       beforeEach ->
         editor.scrollTop(2000)
         editor.resetDisplay()
         line = editor.lineElementForScreenRow(106)[0]
 
-      benchmark "positionLeftForLineAndColumn", 20000, ->
-        editor.positionLeftForLineAndColumn(line, 82)
-        editor.pixelLeftCache.delete(line)
+      describe "one-line.", ->
+        beforeEach ->
+          editor.clearCharacterWidthCache()
 
-      benchmark "positionLeftForLineAndColumn.cached", 20000, ->
-        editor.positionLeftForLineAndColumn(line, 82)
+        benchmark "uncached", 5000, ->
+          editor.positionLeftForLineAndColumn(line, 106, 82)
+          editor.clearCharacterWidthCache()
+
+        benchmark "cached", 5000, ->
+          editor.positionLeftForLineAndColumn(line, 106, 82)
+
+      describe "multiple-lines.", ->
+        [firstRow, lastRow] = []
+        beforeEach ->
+          firstRow = editor.getFirstVisibleScreenRow()
+          lastRow = editor.getLastVisibleScreenRow()
+
+        benchmark "cache-entire-visible-area", 100, ->
+          for i in [firstRow..lastRow]
+            line = editor.lineElementForScreenRow(i)[0]
+            editor.positionLeftForLineAndColumn(line, i, Math.max(0, editor.lineLengthForBufferRow(i)))
 
     describe "text-rendering.", ->
       beforeEach ->

--- a/benchmark/benchmark-suite.coffee
+++ b/benchmark/benchmark-suite.coffee
@@ -59,6 +59,23 @@ describe "editor.", ->
         editor.insertText('"')
         editor.backspace()
 
+    describe "empty-vs-set-innerHTML.", ->
+      [firstRow, lastRow] = []
+      beforeEach ->
+        firstRow = editor.getFirstVisibleScreenRow()
+        lastRow = editor.getLastVisibleScreenRow()
+
+      benchmark "build-gutter-html.", 1000, ->
+        editor.gutter.renderLineNumbers(null, firstRow, lastRow)
+
+      benchmark "set-innerHTML.", 1000, ->
+        editor.gutter.renderLineNumbers(null, firstRow, lastRow)
+        editor.gutter.lineNumbers[0].innerHtml = ''
+
+      benchmark "empty.", 1000, ->
+        editor.gutter.renderLineNumbers(null, firstRow, lastRow)
+        editor.gutter.lineNumbers.empty()
+
     describe "positionLeftForLineAndColumn.", ->
       line = null
       beforeEach ->
@@ -95,7 +112,7 @@ describe "editor.", ->
       benchmark "resetDisplay", 50, ->
         editor.resetDisplay()
 
-      fbenchmark "htmlForScreenRows", 1000, ->
+      benchmark "htmlForScreenRows", 1000, ->
         lastRow = editor.getLastScreenRow()
         editor.htmlForScreenRows(0, lastRow)
 

--- a/benchmark/benchmark-suite.coffee
+++ b/benchmark/benchmark-suite.coffee
@@ -10,7 +10,6 @@ describe "editor.", ->
     window.rootView = new RootView
     window.rootView.attachToDom()
 
-
     rootView.width(1024)
     rootView.height(768)
     rootView.open() # open blank editor
@@ -59,6 +58,24 @@ describe "editor.", ->
       benchmark "insert-delete", ->
         editor.insertText('"')
         editor.backspace()
+
+    describe "text-rendering.", ->
+      beforeEach ->
+        editor.scrollTop(200)
+
+      benchmark "resetDisplay", 20, ->
+        editor.resetDisplay()
+
+      benchmark "htmlForScreenRows", 50, ->
+        lastRow = editor.getLastScreenRow()
+        editor.htmlForScreenRows(0, lastRow)
+
+      benchmark "htmlForScreenRows.htmlParsing", 20, ->
+        lastRow = editor.getLastScreenRow()
+        html = editor.htmlForScreenRows(0, lastRow)
+
+        div = document.createElement('div')
+        div.innerHTML = html
 
   describe "9000-line-file.", ->
     benchmark "opening.", 5, ->

--- a/benchmark/benchmark-suite.coffee
+++ b/benchmark/benchmark-suite.coffee
@@ -1,8 +1,6 @@
 require './benchmark-helper'
-$ = require 'jquery'
-_ = require 'underscore'
-TokenizedBuffer = require 'tokenized-buffer'
-RootView = require 'root-view'
+{$, _, RootView} = require 'atom'
+TokenizedBuffer = require '../src/tokenized-buffer'
 
 describe "editor.", ->
   editor = null

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "autocomplete": "0.6.0",
     "autoflow": "0.3.0",
     "bookmarks": "0.4.0",
-    "bracket-matcher": "0.5.0",
+    "bracket-matcher": "0.6.0",
     "collaboration": "0.20.0",
     "command-logger": "0.4.0",
     "command-palette": "0.4.0",

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -917,7 +917,6 @@ describe "Editor", ->
           editor.setCursorBufferPosition([3, Infinity])
           expect(editor.getCursorView().position()).toEqual {top: 3 * editor.lineHeight, left: 353}
 
-
       describe "autoscrolling", ->
         it "only autoscrolls when the last cursor is moved", ->
           editor.setCursorBufferPosition([11,0])
@@ -1880,7 +1879,6 @@ describe "Editor", ->
 
         # doesn't allow regular editors to set grammars
         expect(-> editor.setGrammar()).toThrow()
-
 
     describe "when config.editor.showLineNumbers is false", ->
       it "doesn't render any line numbers", ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2199,9 +2199,33 @@ describe "Editor", ->
         expect(editor.pixelPositionForBufferPosition([2,7])).toEqual top: 0, left: 0
 
     describe "when the editor is attached and visible", ->
-      it "returns the top and left pixel positions", ->
+      beforeEach ->
         editor.attachToDom()
+
+      it "returns the top and left pixel positions", ->
         expect(editor.pixelPositionForBufferPosition([2,7])).toEqual top: 40, left: 70
+
+      it "caches the left position", ->
+        editor.renderedLines.css('font-size', '16px')
+        expect(editor.pixelPositionForBufferPosition([2,8])).toEqual top: 40, left: 80
+
+        # make characters smaller
+        editor.renderedLines.css('font-size', '15px')
+
+        expect(editor.pixelPositionForBufferPosition([2,8])).toEqual top: 40, left: 80
+
+      it "breaks left position cache when line is changed", ->
+        editor.renderedLines.css('font-size', '16px')
+        expect(editor.pixelPositionForBufferPosition([2,8])).toEqual top: 40, left: 80
+
+        editor.setCursorBufferPosition([2, 8])
+        editor.insertText("a")
+
+        # make characters smaller
+        editor.renderedLines.css('font-size', '15px')
+
+        expect(editor.pixelPositionForBufferPosition([2,8])).toEqual top: 40, left: 72
+
 
   describe "when clicking in the gutter", ->
     beforeEach ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -140,7 +140,6 @@ describe "Editor", ->
       expect(editor.lineElementForScreenRow(40).text()).toBe "hello3"
 
       editor.edit(editSession)
-      console.log editor.scrollTop(), editSession.getCursorScreenPosition()
       { firstRenderedScreenRow, lastRenderedScreenRow } = editor
       expect(editor.lineElementForScreenRow(firstRenderedScreenRow).text()).toBe buffer.lineForRow(firstRenderedScreenRow)
       expect(editor.lineElementForScreenRow(lastRenderedScreenRow).text()).toBe buffer.lineForRow(editor.lastRenderedScreenRow)
@@ -917,7 +916,6 @@ describe "Editor", ->
           expect(editor.getCursorView().position()).toEqual {top: 3 * editor.lineHeight, left: 178}
           editor.setCursorBufferPosition([3, Infinity])
           expect(editor.getCursorView().position()).toEqual {top: 3 * editor.lineHeight, left: 353}
-          console.log Editor.CHARACTER_WIDTH_CACHE
 
 
       describe "autoscrolling", ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1090,25 +1090,39 @@ describe "Editor", ->
         expect(span0.children('span:eq(0)')).toMatchSelector '.storage.modifier.js'
         expect(span0.children('span:eq(0)').text()).toBe 'var'
 
-        span0_1 = span0.children('span:eq(1)')
-        expect(span0_1).toMatchSelector '.meta.function.js'
-        expect(span0_1.text()).toBe 'quicksort = function ()'
-        expect(span0_1.children('span:eq(0)')).toMatchSelector '.entity.name.function.js'
-        expect(span0_1.children('span:eq(0)').text()).toBe "quicksort"
-        expect(span0_1.children('span:eq(1)')).toMatchSelector '.keyword.operator.js'
-        expect(span0_1.children('span:eq(1)').text()).toBe "="
-        expect(span0_1.children('span:eq(2)')).toMatchSelector '.storage.type.function.js'
-        expect(span0_1.children('span:eq(2)').text()).toBe "function"
-        expect(span0_1.children('span:eq(3)')).toMatchSelector '.punctuation.definition.parameters.begin.js'
-        expect(span0_1.children('span:eq(3)').text()).toBe "("
-        expect(span0_1.children('span:eq(4)')).toMatchSelector '.punctuation.definition.parameters.end.js'
-        expect(span0_1.children('span:eq(4)').text()).toBe ")"
+        expect(span0.children('span:eq(1)')).toMatchSelector '.character'
+        expect(span0.children('span:eq(1)').text()).toBe " "
 
-        expect(span0.children('span:eq(2)')).toMatchSelector '.meta.brace.curly.js'
-        expect(span0.children('span:eq(2)').text()).toBe "{"
+        span0_2 = span0.children('span:eq(2)')
+        console.log span0
+        console.log span0_2[0]
+        expect(span0_2).toMatchSelector '.meta.function.js'
+        expect(span0_2.text()).toBe 'quicksort = function ()'
+        expect(span0_2.children('span:eq(0)')).toMatchSelector '.entity.name.function.js'
+        expect(span0_2.children('span:eq(0)').text()).toBe "quicksort"
+        expect(span0_2.children('span:eq(1)')).toMatchSelector '.character'
+        expect(span0_2.children('span:eq(1)').text()).toBe " "
+        expect(span0_2.children('span:eq(2)')).toMatchSelector '.keyword.operator.js'
+        expect(span0_2.children('span:eq(2)').text()).toBe "="
+        expect(span0_2.children('span:eq(3)')).toMatchSelector '.character'
+        expect(span0_2.children('span:eq(3)').text()).toBe " "
+        expect(span0_2.children('span:eq(4)')).toMatchSelector '.storage.type.function.js'
+        expect(span0_2.children('span:eq(4)').text()).toBe "function"
+        expect(span0_2.children('span:eq(5)')).toMatchSelector '.character'
+        expect(span0_2.children('span:eq(5)').text()).toBe " "
+        expect(span0_2.children('span:eq(6)')).toMatchSelector '.punctuation.definition.parameters.begin.js'
+        expect(span0_2.children('span:eq(6)').text()).toBe "("
+        expect(span0_2.children('span:eq(7)')).toMatchSelector '.punctuation.definition.parameters.end.js'
+        expect(span0_2.children('span:eq(7)').text()).toBe ")"
 
-        line12 = editor.renderedLines.find('.line:eq(11)')
-        expect(line12.find('span:eq(2)')).toMatchSelector '.keyword'
+        expect(span0.children('span:eq(3)')).toMatchSelector '.character'
+        expect(span0.children('span:eq(3)').text()).toBe " "
+
+        expect(span0.children('span:eq(4)')).toMatchSelector '.meta.brace.curly.js'
+        expect(span0.children('span:eq(4)').text()).toBe "{"
+
+        line12 = editor.renderedLines.find('.line:eq(11)').children('span:eq(0)')
+        expect(line12.children('span:eq(1)')).toMatchSelector '.keyword'
 
       it "wraps hard tabs in a span", ->
         editor.setText('\t<- hard tab')
@@ -1123,12 +1137,37 @@ describe "Editor", ->
         expect(span0_0).toMatchSelector '.leading-whitespace'
         expect(span0_0.text()).toBe '  '
 
-      it "wraps trailing whitespace in a span", ->
-        editor.setText('trailing whitespace ->   ')
+      it "wraps every character in a span", ->
+        text = '  leading and no trailing whitespace'
+        editor.setText(text)
         line0 = editor.renderedLines.find('.line:first')
-        span0_last = line0.children('span:eq(0)').children('span:last')
-        expect(span0_last).toMatchSelector '.trailing-whitespace'
-        expect(span0_last.text()).toBe '   '
+        characters = line0.find('.character')
+
+        renderedText = ''
+        renderedText += $(ch).text() for ch in characters
+
+        expect(characters).toHaveLength text.length
+        expect(renderedText).toEqual text
+
+      describe "when the line has trailing whitespace", ->
+        it "wraps trailing whitespace in a span", ->
+          editor.setText('trailing whitespace ->   ')
+          line0 = editor.renderedLines.find('.line:first')
+          span0_last = line0.children('span:eq(0)').children('span:last')
+          expect(span0_last).toMatchSelector '.trailing-whitespace'
+          expect(span0_last.text()).toBe '   '
+
+        it "wraps every character in a span", ->
+          text = '  leading and trailing whitespace   '
+          editor.setText(text)
+          line0 = editor.renderedLines.find('.line:first')
+          characters = line0.find('.character')
+
+          renderedText = ''
+          renderedText += $(ch).text() for ch in characters
+
+          expect(characters).toHaveLength text.length
+          expect(renderedText).toEqual text
 
       describe "when lines are updated in the buffer", ->
         it "syntax highlights the updated lines", ->
@@ -1476,7 +1515,7 @@ describe "Editor", ->
         editor.setShowInvisibles(true)
         editor.attachToDom()
         editor.setText "var"
-        expect(editor.find('.line').html()).toBe '<span class="source js"><span class="storage modifier js">var</span></span><span class="invisible-character">¬</span>'
+        expect(editor.find('.line').html()).toBe '<span class="source js"><span class="storage modifier js"><span class="character">v</span><span class="character">a</span><span class="character">r</span></span></span><span class="invisible-character">¬</span>'
 
       it "allows invisible glyphs to be customized via config.editor.invisibles", ->
         editor.setText(" \t ")

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1,7 +1,7 @@
 {_, $, $$, fs, Editor, Range, RootView} = require 'atom'
 path = require 'path'
 
-fdescribe "Editor", ->
+describe "Editor", ->
   [buffer, editor, editSession, cachedLineHeight, cachedCharWidth] = []
 
   beforeEach ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1,7 +1,7 @@
 {_, $, $$, fs, Editor, Range, RootView} = require 'atom'
 path = require 'path'
 
-describe "Editor", ->
+fdescribe "Editor", ->
   [buffer, editor, editSession, cachedLineHeight, cachedCharWidth] = []
 
   beforeEach ->
@@ -119,36 +119,37 @@ describe "Editor", ->
 
     it "updates the rendered lines, cursors, selections, scroll position, and event subscriptions to match the given edit session", ->
       editor.attachToDom(heightInLines: 5, widthInChars: 30)
-      editor.setCursorBufferPosition([3, 5])
+      editor.setCursorBufferPosition([6, 13])
       editor.scrollToBottom()
       editor.scrollLeft(150)
       previousScrollHeight = editor.verticalScrollbar.prop('scrollHeight')
       previousScrollTop = editor.scrollTop()
       previousScrollLeft = editor.scrollLeft()
 
-      newEditSession.setScrollTop(120)
+      newEditSession.setScrollTop(900)
       newEditSession.setSelectedBufferRange([[40, 0], [43, 1]])
 
       editor.edit(newEditSession)
       { firstRenderedScreenRow, lastRenderedScreenRow } = editor
       expect(editor.lineElementForScreenRow(firstRenderedScreenRow).text()).toBe newBuffer.lineForRow(firstRenderedScreenRow)
       expect(editor.lineElementForScreenRow(lastRenderedScreenRow).text()).toBe newBuffer.lineForRow(editor.lastRenderedScreenRow)
-      expect(editor.scrollTop()).toBe 120
+      expect(editor.scrollTop()).toBe 900
       expect(editor.scrollLeft()).toBe 0
       expect(editor.getSelectionView().regions[0].position().top).toBe 40 * editor.lineHeight
       editor.insertText("hello")
       expect(editor.lineElementForScreenRow(40).text()).toBe "hello3"
 
       editor.edit(editSession)
+      console.log editor.scrollTop(), editSession.getCursorScreenPosition()
       { firstRenderedScreenRow, lastRenderedScreenRow } = editor
       expect(editor.lineElementForScreenRow(firstRenderedScreenRow).text()).toBe buffer.lineForRow(firstRenderedScreenRow)
       expect(editor.lineElementForScreenRow(lastRenderedScreenRow).text()).toBe buffer.lineForRow(editor.lastRenderedScreenRow)
       expect(editor.verticalScrollbar.prop('scrollHeight')).toBe previousScrollHeight
       expect(editor.scrollTop()).toBe previousScrollTop
       expect(editor.scrollLeft()).toBe previousScrollLeft
-      expect(editor.getCursorView().position()).toEqual { top: 3 * editor.lineHeight, left: 5 * editor.charWidth }
+      expect(editor.getCursorView().position()).toEqual { top: 6 * editor.lineHeight, left: 13 * editor.charWidth }
       editor.insertText("goodbye")
-      expect(editor.lineElementForScreenRow(3).text()).toMatch /^    vgoodbyear/
+      expect(editor.lineElementForScreenRow(6).text()).toMatch /^      currentgoodbye/
 
     it "triggers alert if edit session's buffer goes into conflict with changes on disk", ->
       filePath = "/tmp/atom-changed-file.txt"
@@ -904,7 +905,8 @@ describe "Editor", ->
 
       it "moves the hiddenInput to the same position with cursor's view", ->
         editor.setCursorScreenPosition(row: 2, column: 2)
-        expect(editor.getCursorView().offset()).toEqual(editor.hiddenInput.offset())
+        expect(editor.getCursorView()[0].style.left).toEqual(editor.hiddenInput[0].style.left)
+        expect(editor.getCursorView()[0].style.top).toEqual(editor.hiddenInput[0].style.top)
 
       describe "when the editor is using a variable-width font", ->
         beforeEach ->
@@ -915,6 +917,8 @@ describe "Editor", ->
           expect(editor.getCursorView().position()).toEqual {top: 3 * editor.lineHeight, left: 178}
           editor.setCursorBufferPosition([3, Infinity])
           expect(editor.getCursorView().position()).toEqual {top: 3 * editor.lineHeight, left: 353}
+          console.log Editor.CHARACTER_WIDTH_CACHE
+
 
       describe "autoscrolling", ->
         it "only autoscrolls when the last cursor is moved", ->
@@ -1090,36 +1094,22 @@ describe "Editor", ->
         expect(span0.children('span:eq(0)')).toMatchSelector '.storage.modifier.js'
         expect(span0.children('span:eq(0)').text()).toBe 'var'
 
-        expect(span0.children('span:eq(1)')).toMatchSelector '.character'
-        expect(span0.children('span:eq(1)').text()).toBe " "
+        span0_1 = span0.children('span:eq(1)')
+        expect(span0_1).toMatchSelector '.meta.function.js'
+        expect(span0_1.text()).toBe 'quicksort = function ()'
+        expect(span0_1.children('span:eq(0)')).toMatchSelector '.entity.name.function.js'
+        expect(span0_1.children('span:eq(0)').text()).toBe "quicksort"
+        expect(span0_1.children('span:eq(1)')).toMatchSelector '.keyword.operator.js'
+        expect(span0_1.children('span:eq(1)').text()).toBe "="
+        expect(span0_1.children('span:eq(2)')).toMatchSelector '.storage.type.function.js'
+        expect(span0_1.children('span:eq(2)').text()).toBe "function"
+        expect(span0_1.children('span:eq(3)')).toMatchSelector '.punctuation.definition.parameters.begin.js'
+        expect(span0_1.children('span:eq(3)').text()).toBe "("
+        expect(span0_1.children('span:eq(4)')).toMatchSelector '.punctuation.definition.parameters.end.js'
+        expect(span0_1.children('span:eq(4)').text()).toBe ")"
 
-        span0_2 = span0.children('span:eq(2)')
-        console.log span0
-        console.log span0_2[0]
-        expect(span0_2).toMatchSelector '.meta.function.js'
-        expect(span0_2.text()).toBe 'quicksort = function ()'
-        expect(span0_2.children('span:eq(0)')).toMatchSelector '.entity.name.function.js'
-        expect(span0_2.children('span:eq(0)').text()).toBe "quicksort"
-        expect(span0_2.children('span:eq(1)')).toMatchSelector '.character'
-        expect(span0_2.children('span:eq(1)').text()).toBe " "
-        expect(span0_2.children('span:eq(2)')).toMatchSelector '.keyword.operator.js'
-        expect(span0_2.children('span:eq(2)').text()).toBe "="
-        expect(span0_2.children('span:eq(3)')).toMatchSelector '.character'
-        expect(span0_2.children('span:eq(3)').text()).toBe " "
-        expect(span0_2.children('span:eq(4)')).toMatchSelector '.storage.type.function.js'
-        expect(span0_2.children('span:eq(4)').text()).toBe "function"
-        expect(span0_2.children('span:eq(5)')).toMatchSelector '.character'
-        expect(span0_2.children('span:eq(5)').text()).toBe " "
-        expect(span0_2.children('span:eq(6)')).toMatchSelector '.punctuation.definition.parameters.begin.js'
-        expect(span0_2.children('span:eq(6)').text()).toBe "("
-        expect(span0_2.children('span:eq(7)')).toMatchSelector '.punctuation.definition.parameters.end.js'
-        expect(span0_2.children('span:eq(7)').text()).toBe ")"
-
-        expect(span0.children('span:eq(3)')).toMatchSelector '.character'
-        expect(span0.children('span:eq(3)').text()).toBe " "
-
-        expect(span0.children('span:eq(4)')).toMatchSelector '.meta.brace.curly.js'
-        expect(span0.children('span:eq(4)').text()).toBe "{"
+        expect(span0.children('span:eq(2)')).toMatchSelector '.meta.brace.curly.js'
+        expect(span0.children('span:eq(2)').text()).toBe "{"
 
         line12 = editor.renderedLines.find('.line:eq(11)').children('span:eq(0)')
         expect(line12.children('span:eq(1)')).toMatchSelector '.keyword'
@@ -1137,18 +1127,6 @@ describe "Editor", ->
         expect(span0_0).toMatchSelector '.leading-whitespace'
         expect(span0_0.text()).toBe '  '
 
-      it "wraps every character in a span", ->
-        text = '  leading and no trailing whitespace'
-        editor.setText(text)
-        line0 = editor.renderedLines.find('.line:first')
-        characters = line0.find('.character')
-
-        renderedText = ''
-        renderedText += $(ch).text() for ch in characters
-
-        expect(characters).toHaveLength text.length
-        expect(renderedText).toEqual text
-
       describe "when the line has trailing whitespace", ->
         it "wraps trailing whitespace in a span", ->
           editor.setText('trailing whitespace ->   ')
@@ -1156,18 +1134,6 @@ describe "Editor", ->
           span0_last = line0.children('span:eq(0)').children('span:last')
           expect(span0_last).toMatchSelector '.trailing-whitespace'
           expect(span0_last.text()).toBe '   '
-
-        it "wraps every character in a span", ->
-          text = '  leading and trailing whitespace   '
-          editor.setText(text)
-          line0 = editor.renderedLines.find('.line:first')
-          characters = line0.find('.character')
-
-          renderedText = ''
-          renderedText += $(ch).text() for ch in characters
-
-          expect(characters).toHaveLength text.length
-          expect(renderedText).toEqual text
 
       describe "when lines are updated in the buffer", ->
         it "syntax highlights the updated lines", ->
@@ -1515,7 +1481,7 @@ describe "Editor", ->
         editor.setShowInvisibles(true)
         editor.attachToDom()
         editor.setText "var"
-        expect(editor.find('.line').html()).toBe '<span class="source js"><span class="storage modifier js"><span class="character">v</span><span class="character">a</span><span class="character">r</span></span></span><span class="invisible-character">¬</span>'
+        expect(editor.find('.line').html()).toBe '<span class="source js"><span class="storage modifier js">var</span></span><span class="invisible-character">¬</span>'
 
       it "allows invisible glyphs to be customized via config.editor.invisibles", ->
         editor.setText(" \t ")
@@ -2213,19 +2179,6 @@ describe "Editor", ->
         editor.renderedLines.css('font-size', '15px')
 
         expect(editor.pixelPositionForBufferPosition([2,8])).toEqual top: 40, left: 80
-
-      it "breaks left position cache when line is changed", ->
-        editor.renderedLines.css('font-size', '16px')
-        expect(editor.pixelPositionForBufferPosition([2,8])).toEqual top: 40, left: 80
-
-        editor.setCursorBufferPosition([2, 8])
-        editor.insertText("a")
-
-        # make characters smaller
-        editor.renderedLines.css('font-size', '15px')
-
-        expect(editor.pixelPositionForBufferPosition([2,8])).toEqual top: 40, left: 72
-
 
   describe "when clicking in the gutter", ->
     beforeEach ->

--- a/src/cursor-view.coffee
+++ b/src/cursor-view.coffee
@@ -54,6 +54,14 @@ class CursorView extends View
 
     @setVisible(@cursor.isVisible() and not @editor.isFoldedAtScreenRow(screenPosition.row))
 
+  # Override for speed. The base function checks the computedStyle
+  isHidden: ->
+    style = this[0].style
+    if style.display == 'none' or not @isOnDom()
+      true
+    else
+      false
+
   needsAutoscroll: ->
     @cursor.needsAutoscroll
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1764,21 +1764,21 @@ class Editor extends View
     if not mini and showIndentGuide
       if indentation > 0
         tabLength = activeEditSession.getTabLength()
-        indentGuideHtml = []
+        indentGuideHtml = ''
         for level in [0...indentation]
-          indentLevelHtml = ["<span class='indent-guide'>"]
+          indentLevelHtml = "<span class='indent-guide'>"
           for characterPosition in [0...tabLength]
             if invisible = eolInvisibles.shift()
-              indentLevelHtml.push("<span class='invisible-character'>#{invisible}</span>")
+              indentLevelHtml += "<span class='invisible-character'>#{invisible}</span>"
             else
-              indentLevelHtml.push(' ')
-          indentLevelHtml.push("</span>")
-          indentGuideHtml.push(indentLevelHtml.join(''))
+              indentLevelHtml += ' '
+          indentLevelHtml += "</span>"
+          indentGuideHtml += indentLevelHtml
 
         for invisible in eolInvisibles
-          indentGuideHtml.push("<span class='invisible-character'>#{invisible}</span>")
+          indentGuideHtml += "<span class='invisible-character'>#{invisible}</span>"
 
-        return indentGuideHtml.join('')
+        return indentGuideHtml
 
     if htmlEolInvisibles.length > 0
       htmlEolInvisibles

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -703,7 +703,7 @@ class Editor extends View
     @on 'cursor:moved', =>
       return unless @isFocused
       cursorView = @getCursorView()
-      @hiddenInput.offset(cursorView.offset()) if cursorView.is(':visible')
+      @hiddenInput.offset(cursorView.offset()) if cursorView.isVisible()
 
     selectedText = null
     @hiddenInput.on 'compositionstart', =>

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1400,14 +1400,18 @@ class Editor extends View
   #
   # Returns a {Number}.
   getFirstVisibleScreenRow: ->
-    Math.floor(@scrollTop() / @lineHeight)
+    screenRow = Math.floor(@scrollTop() / @lineHeight)
+    screenRow = 0 if isNaN(screenRow)
+    screenRow
 
   # Retrieves the number of the row that is visible and currently at the bottom of the editor.
   #
   # Returns a {Number}.
   getLastVisibleScreenRow: ->
     calculatedRow = Math.ceil((@scrollTop() + @scrollView.height()) / @lineHeight) - 1
-    Math.max(0, Math.min(@getScreenLineCount() - 1, calculatedRow))
+    screenRow = Math.max(0, Math.min(@getScreenLineCount() - 1, calculatedRow))
+    screenRow = 0 if isNaN(screenRow)
+    screenRow
 
   # Given a row number, identifies if it is currently visible.
   #

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1557,7 +1557,7 @@ class Editor extends View
       for char in token.value
         return left if index >= column
 
-        val = @checkCharacterWidthCache(token.scopes, char)
+        val = @getCharacterWidthCache(token.scopes, char)
         if val?
           left += val
         else
@@ -1590,7 +1590,7 @@ class Editor extends View
         oldLeft = left
 
         scopes = @scopesForColumn(tokenizedLine, index)
-        cachedVal = @checkCharacterWidthCache(scopes, char)
+        cachedVal = @getCharacterWidthCache(scopes, char)
 
         if cachedVal?
           left = oldLeft + cachedVal
@@ -1608,7 +1608,7 @@ class Editor extends View
 
     returnLeft ? left
 
-  checkCharacterWidthCache: (scopes, char) ->
+  getCharacterWidthCache: (scopes, char) ->
     scopes ?= NoScope
     obj = Editor.characterWidthCache
     for scope in scopes
@@ -1746,7 +1746,7 @@ class Editor extends View
     scopeStack.push(scope)
     line.push("<span class=\"#{scope.replace(/\./g, ' ')}\">")
 
-  @popScope: (line, scopeStack)->
+  @popScope: (line, scopeStack) ->
     scopeStack.pop()
     line.push("</span>")
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1213,7 +1213,6 @@ class Editor extends View
     should = (startRow >= @firstRenderedScreenRow and startRow <= @lastRenderedScreenRow) or (endRow >= @firstRenderedScreenRow and endRow <= @lastRenderedScreenRow)
     should
 
-
   syncCursorAnimations: ->
     for cursorView in @getCursorViews()
       do (cursorView) -> cursorView.resetBlinking()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1215,8 +1215,7 @@ class Editor extends View
     return false unless cursorView.needsUpdate
 
     pos = cursorView.getScreenPosition()
-    should = pos.row >= @firstRenderedScreenRow and pos.row <= @lastRenderedScreenRow
-    should
+    pos.row >= @firstRenderedScreenRow and pos.row <= @lastRenderedScreenRow
 
   updateSelectionViews: ->
     if @newSelections.length > 0
@@ -1233,8 +1232,7 @@ class Editor extends View
     screenRange = selectionView.getScreenRange()
     startRow = screenRange.start.row
     endRow = screenRange.end.row
-    should = (startRow >= @firstRenderedScreenRow and startRow <= @lastRenderedScreenRow) or (endRow >= @firstRenderedScreenRow and endRow <= @lastRenderedScreenRow)
-    should
+    (startRow >= @firstRenderedScreenRow and startRow <= @lastRenderedScreenRow) or (endRow >= @firstRenderedScreenRow and endRow <= @lastRenderedScreenRow)
 
   syncCursorAnimations: ->
     for cursorView in @getCursorViews()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1184,8 +1184,15 @@ class Editor extends View
     for cursorView in @getCursorViews()
       if cursorView.needsRemoval
         cursorView.remove()
-      else if cursorView.needsUpdate
+      else if @shouldUpdateCursor(cursorView)
         cursorView.updateDisplay()
+
+  shouldUpdateCursor: (cursorView) ->
+    return false unless cursorView.needsUpdate
+
+    pos = cursorView.getScreenPosition()
+    should = pos.row >= @firstRenderedScreenRow and pos.row <= @lastRenderedScreenRow
+    should
 
   updateSelectionViews: ->
     if @newSelections.length > 0
@@ -1195,8 +1202,16 @@ class Editor extends View
     for selectionView in @getSelectionViews()
       if selectionView.needsRemoval
         selectionView.remove()
-      else
+      else if @shouldUpdateSelection(selectionView)
         selectionView.updateDisplay()
+
+  shouldUpdateSelection: (selectionView) ->
+    screenRange = selectionView.getScreenRange()
+    startRow = screenRange.start.row
+    endRow = screenRange.end.row
+    should = (startRow >= @firstRenderedScreenRow and startRow <= @lastRenderedScreenRow) or (endRow >= @firstRenderedScreenRow and endRow <= @lastRenderedScreenRow)
+    should
+
 
   syncCursorAnimations: ->
     for cursorView in @getCursorViews()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1560,7 +1560,7 @@ class Editor extends View
   positionLeftForLineAndColumn: (lineElement, screenRow, column) ->
     return 0 if column == 0
 
-    bufferRow = @bufferRowsForScreenRows(screenRow)[0] ? screenRow
+    bufferRow = @bufferRowsForScreenRows(screenRow, screenRow)[0] ? screenRow
     tokenizedLine = @activeEditSession.displayBuffer.tokenizedBuffer.tokenizedLines[bufferRow]
 
     left = 0

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1514,6 +1514,7 @@ class Editor extends View
     lineElement = existingLineElement = line[0]
     unless existingLineElement
       lineElement = @buildLineElementForScreenRow(actualRow)
+      line = $(lineElement)
       @renderedLines.append(lineElement)
     left = @positionLeftForLineAndColumn(line, column)
     unless existingLineElement

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -9,9 +9,9 @@ fsUtils = require './fs-utils'
 $ = require './jquery-extensions'
 _ = require './underscore-extensions'
 
-MEASURE_RANGE = document.createRange()
-TEXT_NODE_FILTER = { acceptNode: -> NodeFilter.FILTER_ACCEPT }
-NO_SCOPE = ['no-scope']
+MeasureRange = document.createRange()
+TextNodeFileter = { acceptNode: -> NodeFilter.FILTER_ACCEPT }
+NoScope = ['no-scope']
 
 # Private: Represents the entire visual pane in Atom.
 #
@@ -1588,7 +1588,7 @@ class Editor extends View
 
   measureToColumn: (lineElement, tokenizedLine, column) ->
     left = oldLeft = index = 0
-    iterator = document.createNodeIterator(lineElement, NodeFilter.SHOW_TEXT, TEXT_NODE_FILTER)
+    iterator = document.createNodeIterator(lineElement, NodeFilter.SHOW_TEXT, TextNodeFileter)
 
     returnLeft = null
 
@@ -1608,9 +1608,9 @@ class Editor extends View
           left = oldLeft + cachedVal
         else
           # i + 1 to measure to the end of the current character
-          MEASURE_RANGE.setEnd(textNode, i + 1)
-          MEASURE_RANGE.collapse()
-          left = MEASURE_RANGE.getClientRects()[0].left - Math.floor(@scrollView.offset().left) + Math.floor(@scrollLeft())
+          MeasureRange.setEnd(textNode, i + 1)
+          MeasureRange.collapse()
+          left = MeasureRange.getClientRects()[0].left - Math.floor(@scrollView.offset().left) + Math.floor(@scrollLeft())
 
           @setCharacterWidthCache(scopes, char, left - oldLeft) if scopes?
 
@@ -1619,7 +1619,7 @@ class Editor extends View
     returnLeft ? left
 
   checkCharacterWidthCache: (scopes, char) ->
-    scopes ?= NO_SCOPE
+    scopes ?= NoScope
     obj = Editor.characterWidthCache
     for scope in scopes
       obj = obj[scope]
@@ -1627,7 +1627,7 @@ class Editor extends View
     obj[char]
 
   setCharacterWidthCache: (scopes, char, val) ->
-    scopes ?= NO_SCOPE
+    scopes ?= NoScope
     obj = Editor.characterWidthCache
     for scope in scopes
       obj[scope] ?= {}

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1554,13 +1554,22 @@ class Editor extends View
 
     return lineCache[column] if lineCache[column]?
 
-    chars = lineElement.getElementsByClassName('character')
-    left = 0
-    for i in [0...column]
-      left += chars[i].offsetWidth if chars[i]
+    delta = 0
+    iterator = document.createNodeIterator(lineElement, NodeFilter.SHOW_TEXT, acceptNode: -> NodeFilter.FILTER_ACCEPT)
+    while textNode = iterator.nextNode()
+      nextDelta = delta + textNode.textContent.length
+      if nextDelta >= column
+        offset = column - delta
+        break
+      delta = nextDelta
+
+    range = document.createRange()
+    range.setEnd(textNode, offset)
+    range.collapse()
+    left = range.getClientRects()[0].left - Math.floor(@scrollView.offset().left) + Math.floor(@scrollLeft())
+    range.detach()
 
     lineCache[column] = left
-
     left
 
   pixelOffsetForScreenPosition: (position) ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -9,6 +9,8 @@ fsUtils = require './fs-utils'
 $ = require './jquery-extensions'
 _ = require './underscore-extensions'
 
+MEASURE_RANGE = document.createRange()
+
 # Private: Represents the entire visual pane in Atom.
 #
 # The Editor manages the {EditSession}, which manages the file buffers.
@@ -1563,11 +1565,9 @@ class Editor extends View
         break
       delta = nextDelta
 
-    range = document.createRange()
-    range.setEnd(textNode, offset)
-    range.collapse()
-    left = range.getClientRects()[0].left - Math.floor(@scrollView.offset().left) + Math.floor(@scrollLeft())
-    range.detach()
+    MEASURE_RANGE.setEnd(textNode, offset)
+    MEASURE_RANGE.collapse()
+    left = MEASURE_RANGE.getClientRects()[0].left - Math.floor(@scrollView.offset().left) + Math.floor(@scrollLeft())
 
     lineCache[column] = left
     left

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1598,7 +1598,9 @@ class Editor extends View
           # i + 1 to measure to the end of the current character
           MeasureRange.setEnd(textNode, i + 1)
           MeasureRange.collapse()
-          left = MeasureRange.getClientRects()[0].left - Math.floor(@scrollView.offset().left) + Math.floor(@scrollLeft())
+          rects = MeasureRange.getClientRects()
+          return 0 if rects.length == 0
+          left = rects[0].left - Math.floor(@scrollView.offset().left) + Math.floor(@scrollLeft())
 
           @setCharacterWidthCache(scopes, char, left - oldLeft) if scopes?
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1509,43 +1509,22 @@ class Editor extends View
     {row, column} = Point.fromObject(position)
     actualRow = Math.floor(row)
 
-    lineElement = existingLineElement = @lineElementForScreenRow(actualRow)[0]
+    line = @lineElementForScreenRow(actualRow)
+    lineElement = existingLineElement = line[0]
     unless existingLineElement
       lineElement = @buildLineElementForScreenRow(actualRow)
       @renderedLines.append(lineElement)
-    left = @positionLeftForLineAndColumn(lineElement, column)
+    left = @positionLeftForLineAndColumn(line, column)
     unless existingLineElement
       @renderedLines[0].removeChild(lineElement)
     { top: row * @lineHeight, left }
 
   positionLeftForLineAndColumn: (lineElement, column) ->
-    return 0 if column is 0
-
-    @pixelLeftCache ?= {}
-    cacheKey = lineElement.getAttribute('line-id')+':'+column
-
-    if @pixelLeftCache[cacheKey]?
-      #console.log 'hit', cacheKey
-      return @pixelLeftCache[cacheKey]
-
-    delta = 0
-    iterator = document.createNodeIterator(lineElement, NodeFilter.SHOW_TEXT, acceptNode: -> NodeFilter.FILTER_ACCEPT)
-    while textNode = iterator.nextNode()
-      nextDelta = delta + textNode.textContent.length
-      if nextDelta >= column
-        offset = column - delta
-        break
-      delta = nextDelta
-
-    range = document.createRange()
-    range.setEnd(textNode, offset)
-    range.collapse()
-    leftPixels = range.getClientRects()[0].left - Math.floor(@scrollView.offset().left) + Math.floor(@scrollLeft())
-    range.detach()
-
-    @pixelLeftCache[cacheKey] = leftPixels
-
-    leftPixels
+    chars = lineElement.find('.character')
+    left = 0
+    for i in [0...column]
+      left += chars[i].offsetWidth if chars[i]
+    left
 
   pixelOffsetForScreenPosition: (position) ->
     {top, left} = @pixelPositionForScreenPosition(position)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1270,7 +1270,7 @@ class Editor extends View
     changes = @pendingChanges
     intactRanges = @computeIntactRanges(renderFrom, renderTo)
 
-    @gutter.updateLineNumbers(changes, intactRanges, renderFrom, renderTo)
+    @gutter.updateLineNumbers(changes, renderFrom, renderTo)
 
     @clearDirtyRanges(intactRanges)
     @fillDirtyRanges(intactRanges, renderFrom, renderTo)
@@ -1353,40 +1353,30 @@ class Editor extends View
       i++
     intactRanges.sort (a, b) -> a.domStart - b.domStart
 
-  # renderedLines - optional
-  # clearLine - optional
-  clearDirtyRanges: (intactRanges, renderedLines, clearLine) ->
-    renderedLines ?= @renderedLines[0]
-    clearLine ?= @clearLine
-
+  clearDirtyRanges: (intactRanges) ->
     if intactRanges.length == 0
-      renderedLines.innerHTML = ''
-    else if currentLine = renderedLines.firstChild
+      @renderedLines[0].innerHTML = ''
+    else if currentLine = @renderedLines[0].firstChild
       domPosition = 0
       for intactRange in intactRanges
         while intactRange.domStart > domPosition
-          currentLine = clearLine(currentLine)
+          currentLine = @clearLine(currentLine)
           domPosition++
         for i in [intactRange.start..intactRange.end]
           currentLine = currentLine.nextSibling
           domPosition++
       while currentLine
-        currentLine = clearLine(currentLine)
+        currentLine = @clearLine(currentLine)
 
   clearLine: (lineElement) =>
     next = lineElement.nextSibling
     @renderedLines[0].removeChild(lineElement)
     next
 
-  # renderedLines - optional
-  # buildLineElements - optional
-  fillDirtyRanges: (intactRanges, renderFrom, renderTo, renderedLines, buildLineElements) ->
-    renderedLines ?= @renderedLines[0]
-    buildLineElements ?= @buildLineElementsForScreenRows
-
+  fillDirtyRanges: (intactRanges, renderFrom, renderTo) ->
     i = 0
     nextIntact = intactRanges[i]
-    currentLine = renderedLines.firstChild
+    currentLine = @renderedLines[0].firstChild
 
     row = renderFrom
     while row <= renderTo
@@ -1399,8 +1389,8 @@ class Editor extends View
         else
           dirtyRangeEnd = renderTo
 
-        for lineElement in buildLineElements(row, dirtyRangeEnd)
-          renderedLines.insertBefore(lineElement, currentLine)
+        for lineElement in @buildLineElementsForScreenRows(row, dirtyRangeEnd)
+          @renderedLines[0].insertBefore(lineElement, currentLine)
           row++
       else
         currentLine = currentLine.nextSibling

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -10,7 +10,7 @@ $ = require './jquery-extensions'
 _ = require './underscore-extensions'
 
 MeasureRange = document.createRange()
-TextNodeFileter = { acceptNode: -> NodeFilter.FILTER_ACCEPT }
+TextNodeFilter = { acceptNode: -> NodeFilter.FILTER_ACCEPT }
 NoScope = ['no-scope']
 
 # Private: Represents the entire visual pane in Atom.
@@ -1576,7 +1576,7 @@ class Editor extends View
 
   measureToColumn: (lineElement, tokenizedLine, column) ->
     left = oldLeft = index = 0
-    iterator = document.createNodeIterator(lineElement, NodeFilter.SHOW_TEXT, TextNodeFileter)
+    iterator = document.createNodeIterator(lineElement, NodeFilter.SHOW_TEXT, TextNodeFilter)
 
     returnLeft = null
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1366,7 +1366,7 @@ class Editor extends View
       while currentLine
         currentLine = @clearLine(currentLine)
 
-  clearLine: (lineElement) =>
+  clearLine: (lineElement) ->
     next = lineElement.nextSibling
     @renderedLines[0].removeChild(lineElement)
     next
@@ -1439,7 +1439,7 @@ class Editor extends View
   buildLineElementForScreenRow: (screenRow) ->
     @buildLineElementsForScreenRows(screenRow, screenRow)[0]
 
-  buildLineElementsForScreenRows: (startRow, endRow) =>
+  buildLineElementsForScreenRows: (startRow, endRow) ->
     div = document.createElement('div')
     div.innerHTML = @htmlForScreenRows(startRow, endRow)
     new Array(div.children...)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1539,24 +1539,22 @@ class Editor extends View
     {row, column} = Point.fromObject(position)
     actualRow = Math.floor(row)
 
-    line = @lineElementForScreenRow(actualRow)
-    lineElement = existingLineElement = line[0]
+    lineElement = existingLineElement = @lineElementForScreenRow(actualRow)[0]
     unless existingLineElement
       lineElement = @buildLineElementForScreenRow(actualRow)
-      line = $(lineElement)
       @renderedLines.append(lineElement)
-    left = @positionLeftForLineAndColumn(line, column)
+    left = @positionLeftForLineAndColumn(lineElement, column)
     unless existingLineElement
       @renderedLines[0].removeChild(lineElement)
     { top: row * @lineHeight, left }
 
-  positionLeftForLineAndColumn: (line, column) ->
-    lineCache = @pixelLeftCache.get(line[0])
-    @pixelLeftCache.set(line[0], lineCache = {}) unless lineCache?
+  positionLeftForLineAndColumn: (lineElement, column) ->
+    lineCache = @pixelLeftCache.get(lineElement)
+    @pixelLeftCache.set(lineElement, lineCache = {}) unless lineCache?
 
     return lineCache[column] if lineCache[column]?
 
-    chars = line.find('.character')
+    chars = lineElement.getElementsByClassName('character')
     left = 0
     for i in [0...column]
       left += chars[i].offsetWidth if chars[i]

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1761,6 +1761,7 @@ class Editor extends View
     line.push("</span>")
 
   @buildEmptyLineHtml: (showIndentGuide, eolInvisibles, htmlEolInvisibles, indentation, activeEditSession, mini) ->
+    indentCharIndex = 0
     if not mini and showIndentGuide
       if indentation > 0
         tabLength = activeEditSession.getTabLength()
@@ -1768,7 +1769,7 @@ class Editor extends View
         for level in [0...indentation]
           indentLevelHtml = "<span class='indent-guide'>"
           for characterPosition in [0...tabLength]
-            if invisible = eolInvisibles.shift()
+            if invisible = eolInvisibles[indentCharIndex++]
               indentLevelHtml += "<span class='invisible-character'>#{invisible}</span>"
             else
               indentLevelHtml += ' '

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -704,7 +704,12 @@ class Editor extends View
     @on 'cursor:moved', =>
       return unless @isFocused
       cursorView = @getCursorView()
-      @hiddenInput.offset(cursorView.offset()) if cursorView.isVisible()
+
+      if cursorView.isVisible()
+        # This is an order of magnitude faster than checking .offset().
+        style = cursorView[0].style
+        @hiddenInput[0].style.top = style.top
+        @hiddenInput[0].style.left = style.left
 
     selectedText = null
     @hiddenInput.on 'compositionstart', =>

--- a/src/gutter.coffee
+++ b/src/gutter.coffee
@@ -64,7 +64,7 @@ class Gutter extends View
 
   ### Internal ###
 
-  updateLineNumbers: (changes, intactRanges, renderFrom, renderTo) ->
+  updateLineNumbers: (changes, renderFrom, renderTo) ->
     if renderFrom < @firstScreenRow or renderTo > @lastScreenRow
       performUpdate = true
     else if @getEditor().getLastScreenRow() < @lastScreenRow
@@ -75,9 +75,9 @@ class Gutter extends View
           performUpdate = true
           break
 
-    @renderLineNumbers(intactRanges, renderFrom, renderTo) if performUpdate
+    @renderLineNumbers(renderFrom, renderTo) if performUpdate
 
-  renderLineNumbers: (intactRanges, startScreenRow, endScreenRow) ->
+  renderLineNumbers: (startScreenRow, endScreenRow) ->
     @lineNumbers[0].innerHTML = @buildLineElementsHtml(startScreenRow, endScreenRow)
     @firstScreenRow = startScreenRow
     @lastScreenRow = endScreenRow

--- a/src/gutter.coffee
+++ b/src/gutter.coffee
@@ -78,22 +78,13 @@ class Gutter extends View
     @renderLineNumbers(intactRanges, renderFrom, renderTo) if performUpdate
 
   renderLineNumbers: (intactRanges, startScreenRow, endScreenRow) ->
-    editor = @getEditor()
-
-    editor.clearDirtyRanges(intactRanges, @lineNumbers[0], @clearLine)
-    editor.fillDirtyRanges(intactRanges, startScreenRow, endScreenRow, @lineNumbers[0], @buildLineElements)
-
+    @lineNumbers[0].innerHTML = @buildLineElementsHtml(startScreenRow, endScreenRow)
     @firstScreenRow = startScreenRow
     @lastScreenRow = endScreenRow
     @highlightedRows = null
     @highlightLines()
 
-  clearLine: (lineElement) =>
-    next = lineElement.nextSibling
-    @lineNumbers[0].removeChild(lineElement)
-    next
-
-  buildLineElements: (startScreenRow, endScreenRow) =>
+  buildLineElementsHtml: (startScreenRow, endScreenRow) =>
     editor = @getEditor()
     maxDigits = editor.getLineCount().toString().length
     rows = editor.bufferRowsForScreenRows(startScreenRow, endScreenRow)
@@ -114,9 +105,7 @@ class Gutter extends View
 
       lastScreenRow = row
 
-    div = document.createElement('div')
-    div.innerHTML = html
-    new Array(div.children...)
+    html
 
   removeLineHighlights: ->
     return unless @highlightedLineNumbers

--- a/src/jquery-extensions.coffee
+++ b/src/jquery-extensions.coffee
@@ -40,7 +40,14 @@ $.fn.isVisible = ->
 $.fn.isHidden = ->
   # We used to check @is(':hidden'). But this is much faster than the
   # offsetWidth/offsetHeight check + all the pseudo selector mess in jquery.
-  @css('display') == 'none'
+  style = this[0].style
+
+  if style.display == 'none' or not @isOnDom()
+    true
+  else if style.display
+    false
+  else
+    getComputedStyle(this[0]).display == 'none'
 
 $.fn.isDisabled = ->
   !!@attr('disabled')

--- a/src/jquery-extensions.coffee
+++ b/src/jquery-extensions.coffee
@@ -38,18 +38,9 @@ $.fn.isVisible = ->
   !@isHidden()
 
 $.fn.isHidden = ->
-  # Implementation taken from jQuery's `:hidden` expression code:
-  # https://github.com/jquery/jquery/blob/master/src/css/hiddenVisibleSelectors.js
-  #
-  # We were using a pseudo selector: @is(':hidden'). But jQuery's pseudo
-  # selector code checks the element's webkitMatchesSelector, which is always
-  # false, and is really really really slow.
-
-  elem = this[0]
-
-  return null unless elem
-
-  elem.offsetWidth <= 0 and elem.offsetHeight <= 0
+  # We used to check @is(':hidden'). But this is much faster than the
+  # offsetWidth/offsetHeight check + all the pseudo selector mess in jquery.
+  @css('display') == 'none'
 
 $.fn.isDisabled = ->
   !!@attr('disabled')

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -179,6 +179,6 @@ class Token
         when '>' then '&gt;'
         else str[i]
 
-      ret += "<span class='character'>#{character}</span>"
+      ret += character
 
     ret

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -5,6 +5,10 @@ WhitespaceRegexesByTabLength = {}
 LeadingWhitespaceRegex = /^[ ]+/
 TrailingWhitespaceRegex = /[ ]+$/
 EscapeRegex = /[&"'<>]/g
+CharacterRegex = /./g
+StartCharacterRegex = /^./
+StartDotRegex = /^\.?/
+WhitespaceRegex = /\S/
 
 # Private: Represents a single unit of text as selected by a grammar.
 module.exports =
@@ -115,10 +119,10 @@ class Token
     )
 
   isOnlyWhitespace: ->
-    not /\S/.test(@value)
+    not WhitespaceRegex.test(@value)
 
   matchesScopeSelector: (selector) ->
-    targetClasses = selector.replace(/^\.?/, '').split('.')
+    targetClasses = selector.replace(StartDotRegex, '').split('.')
     _.any @scopes, (scope) ->
       scopeClasses = scope.split('.')
       _.isSubset(targetClasses, scopeClasses)
@@ -131,7 +135,7 @@ class Token
       classes = 'hard-tab'
       classes += ' indent-guide' if hasIndentGuide
       classes += ' invisible-character' if invisibles.tab
-      html = html.replace /^./, (match) =>
+      html = html.replace StartCharacterRegex, (match) =>
         match = invisibles.tab ? match
         "<span class='#{classes}'>#{@escapeString(match)}</span>"
     else
@@ -146,8 +150,8 @@ class Token
         classes += ' indent-guide' if hasIndentGuide
         classes += ' invisible-character' if invisibles.space
 
-        match[0] = match[0].replace(/./g, invisibles.space) if invisibles.space
-        leadingHtml = "<span class='#{classes}'>#{@escapeString(match[0])}</span>"
+        match[0] = match[0].replace(CharacterRegex, invisibles.space) if invisibles.space
+        leadingHtml = "<span class='#{classes}'>#{match[0]}</span>"
 
         startIndex = match[0].length
 
@@ -156,8 +160,8 @@ class Token
         classes += ' indent-guide' if hasIndentGuide and not hasLeadingWhitespace
         classes += ' invisible-character' if invisibles.space
 
-        match[0] = match[0].replace(/./g, invisibles.space) if invisibles.space
-        trailingHtml = "<span class='#{classes}'>#{@escapeString(match[0])}</span>"
+        match[0] = match[0].replace(CharacterRegex, invisibles.space) if invisibles.space
+        trailingHtml = "<span class='#{classes}'>#{match[0]}</span>"
 
         endIndex = match.index
 

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -1,9 +1,9 @@
 _ = require './underscore-extensions'
 textUtils = require './text-utils'
 
-whitespaceRegexesByTabLength = {}
-LEADING_WHITESPACE_REGEX = /^[ ]+/
-TRAILING_WHITESPACE_REGEX = /[ ]+$/
+WhitespaceRegexesByTabLength = {}
+LeadingWhitespaceRegex = /^[ ]+/
+TrailingWhitespaceRegex = /[ ]+$/
 EscapeRegex = /[&"'<>]/g
 
 # Private: Represents a single unit of text as selected by a grammar.
@@ -36,7 +36,7 @@ class Token
     [new Token(value: value1, scopes: @scopes), new Token(value: value2, scopes: @scopes)]
 
   whitespaceRegexForTabLength: (tabLength) ->
-    whitespaceRegexesByTabLength[tabLength] ?= new RegExp("([ ]{#{tabLength}})|(\t)|([^\t]+)", "g")
+    WhitespaceRegexesByTabLength[tabLength] ?= new RegExp("([ ]{#{tabLength}})|(\t)|([^\t]+)", "g")
 
   breakOutAtomicTokens: (tabLength, breakOutLeadingWhitespace) ->
     if @hasSurrogatePair
@@ -141,7 +141,7 @@ class Token
       leadingHtml = ''
       trailingHtml = ''
 
-      if hasLeadingWhitespace and match = LEADING_WHITESPACE_REGEX.exec(html)
+      if hasLeadingWhitespace and match = LeadingWhitespaceRegex.exec(html)
         classes = 'leading-whitespace'
         classes += ' indent-guide' if hasIndentGuide
         classes += ' invisible-character' if invisibles.space
@@ -151,7 +151,7 @@ class Token
 
         startIndex = match[0].length
 
-      if hasTrailingWhitespace and match = TRAILING_WHITESPACE_REGEX.exec(html)
+      if hasTrailingWhitespace and match = TrailingWhitespaceRegex.exec(html)
         classes = 'trailing-whitespace'
         classes += ' indent-guide' if hasIndentGuide and not hasLeadingWhitespace
         classes += ' invisible-character' if invisibles.space


### PR DESCRIPTION
Scrolling is really laggy/choppy on my machine. So I did a bunch of profiling:
- [x] When scrolling, the Editor updates the position of the cursors and selection, calling `Editor.positionLeftForLineAndColumn`. When the cursor or selection is on an unrendered line, `Editor` creates the line! 
  - I added a check to only update the cursors and selections when they are within the rendered range (7f83b38)
- [x] `positionLeftForLineAndColumn` is _crazy slow_
  - When scrolling, the cursor doesn't move and the lines dont change, but the Editor still uniquely calculates the left pixel value.
  - I added a cache of line-and-column:pixel-value (the beginnings in 5448da9, finished in 4852f0c)
  - I wrapped each character in a span and changed `positionLeftForLineAndColumn` to get all the character spans, then sum the widths of them. This turned out take ~40% the time of the previous implementation. Yay! See  de9bfb4
- [x] Gutter rendering is slow. It rerenders all gutter numbers when scrolling. The editor only renders the dirty lines. We should rework it so the Editor tells the Gutter to only render the dirty lines. Note: I tried reusing the current nodes rather than regenerating everything all the time and it is marginally faster.
  - Implemented in fdd9e30
- [x] `isVisible` is still slow. Turns out calculating the width and height is slow. In my previous tests the browser must have been caching the size. I want to find another way to calc it or eliminate it from the updateDisplay calcs.
  - Using `css('display') != 'none'` again in de1346d
- [ ] GitDiff rendering is slow when there are changes. There is a lot of querying the gutter nodes
- [ ] Bookmarks rendering is slow. There is a lot of querying the gutter nodes

I would like feedback in approach and other places to look for speedups.
