### PR TITLE
Prevent missing rendered lines

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -13,6 +13,8 @@ describe "Editor", ->
     editor.lineOverdraw = 2
     editor.isFocused = true
     editor.enableKeymap()
+    editor.calculateHeightInLines = ->
+      Math.ceil(@height() / @lineHeight)
     editor.attachToDom = ({ heightInLines, widthInChars } = {}) ->
       heightInLines ?= @getBuffer().getLineCount()
       @height(getLineHeight() * heightInLines)


### PR DESCRIPTION
This has been a long standing Atom issue where the editor only renders a certain number of lines based on its current height, but if that height changes because another view is hidden or removed then the editor will display missing lines.

The proposed fix is to render enough lines to fill the window since the editor does get a window resize event for when it shrinks/grows.
### Steps to reproduce
1. Open Atom with no editors open
2. Do a project find for something with a lot of results so that the view takes up most of the vertical space
3. Open an editor
4. Close the find and replace view
5. The editor is now missing rendered lines

The following screenshot shows this bug, the editor has 37 lines but after the find and replace view is closed only 29 lines are rendered.  Clicking in the editor causes the remaining lines to render.

![screen shot 2013-09-30 at 4 13 12 pm](https://f.cloud.github.com/assets/671378/1241758/e9a47d10-2a25-11e3-8513-ff94b4ebb905.png)
