### PR TITLE
Remove node_modules from NODE_PATH

### DIFF
--- a/src/atom-window.coffee
+++ b/src/atom-window.coffee
@@ -41,9 +41,7 @@ class AtomWindow
     @openPath(pathToOpen, initialLine)
 
   setupNodePath: (resourcePath) ->
-    paths = ['exports', 'node_modules']
-    paths = paths.map (relativePath) -> path.resolve(resourcePath, relativePath)
-    process.env['NODE_PATH'] = paths.join path.delimiter
+    process.env['NODE_PATH'] = path.resolve(resourcePath, 'exports')
 
   getInitialPath: ->
     @browserWindow.loadSettings.initialPath


### PR DESCRIPTION
Packages now specify their dependencies in package.json so they should no longer rely on the availability of modules in the main node_modules folder.

Any package passively using atom's `node_modules` folder for requires will now fail to run when linked.
