### PR TITLE
Add spec-directory command line option

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -9,7 +9,7 @@ if [ ! -d $ATOM_PATH ]; then
   exit 1
 fi
 
-while getopts ":whvft-:" opt; do
+while getopts ":whvftr-:" opt; do
   case "$opt" in
     -)
       case "${OPTARG}" in
@@ -24,7 +24,7 @@ while getopts ":whvft-:" opt; do
     w)
       WAIT=1
       ;;
-    h|v|f|t)
+    h|v|f|t|r)
       EXPECT_OUTPUT=1
       ;;
   esac

--- a/atom.sh
+++ b/atom.sh
@@ -9,7 +9,7 @@ if [ ! -d $ATOM_PATH ]; then
   exit 1
 fi
 
-while getopts ":whvftr-:" opt; do
+while getopts ":whvfts-:" opt; do
   case "$opt" in
     -)
       case "${OPTARG}" in
@@ -24,7 +24,7 @@ while getopts ":whvftr-:" opt; do
     w)
       WAIT=1
       ;;
-    h|v|f|t|r)
+    h|v|f|t)
       EXPECT_OUTPUT=1
       ;;
   esac

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -51,7 +51,7 @@ class AtomApplication
   resourcePath: null
   version: null
 
-  constructor: ({@resourcePath, pathsToOpen, urlsToOpen, @version, test, pidToKillWhenClosed, devMode, newWindow}) ->
+  constructor: ({@resourcePath, pathsToOpen, urlsToOpen, @version, test, pidToKillWhenClosed, devMode, newWindow, specDirectory}) ->
     global.atomApplication = this
 
     @pidsToOpenWindows = {}
@@ -67,7 +67,7 @@ class AtomApplication
     @checkForUpdates()
 
     if test
-      @runSpecs({exitWhenDone: true, @resourcePath})
+      @runSpecs({exitWhenDone: true, @resourcePath, specDirectory})
     else if pathsToOpen.length > 0
       @openPaths({pathsToOpen, pidToKillWhenClosed, newWindow, devMode})
     else if urlsToOpen.length > 0

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -82,6 +82,7 @@ parseCommandLine = ->
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')
   options.alias('f', 'foreground').boolean('f').describe('f', 'Keep the browser process in the foreground.')
   options.alias('w', 'wait').boolean('w').describe('w', 'Wait for window to be closed before returning.')
+  options.alias('s', 'spec-directory').string('s').describe('s', 'Sets the directory to load specs from, useful for packages.')
   args = options.argv
 
   if args.h
@@ -97,6 +98,7 @@ parseCommandLine = ->
   pathsToOpen = args._
   pathsToOpen = [executedFrom] if executedFrom and pathsToOpen.length is 0
   test = args['test']
+  specDirectory = args['spec-directory']
   newWindow = args['new-window']
   pidToKillWhenClosed = args['pid'] if args['wait']
 
@@ -112,4 +114,4 @@ parseCommandLine = ->
     devMode = false
     resourcePath = path.dirname(__dirname)
 
-  {resourcePath, pathsToOpen, executedFrom, test, version, pidToKillWhenClosed, devMode, newWindow}
+  {resourcePath, pathsToOpen, executedFrom, test, version, pidToKillWhenClosed, devMode, newWindow, specDirectory}

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -76,13 +76,13 @@ parseCommandLine = ->
     Usage: atom [options] [file ...]
   """
   options.alias('d', 'dev').boolean('d').describe('d', 'Run in development mode.')
+  options.alias('f', 'foreground').boolean('f').describe('f', 'Keep the browser process in the foreground.')
   options.alias('h', 'help').boolean('h').describe('h', 'Print this usage message.')
   options.alias('n', 'new-window').boolean('n').describe('n', 'Open a new window.')
-  options.alias('t', 'test').boolean('t').describe('t', 'Run the Atom specs and exit with error code on failures.')
+  options.alias('s', 'spec-directory').string('s').describe('s', 'Set the directory from which specs are loaded (default: Atom\'s spec directory).')
+  options.alias('t', 'test').boolean('t').describe('t', 'Run the specified specs and exit with error code on failures.')
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')
-  options.alias('f', 'foreground').boolean('f').describe('f', 'Keep the browser process in the foreground.')
   options.alias('w', 'wait').boolean('w').describe('w', 'Wait for window to be closed before returning.')
-  options.alias('s', 'spec-directory').string('s').describe('s', 'Sets the directory to load specs from, useful for packages.')
   args = options.argv
 
   if args.h


### PR DESCRIPTION
This is useful for implementing `apm test` from atom/apm#5.

To run tests from the command-line you can now do `atom -t --spec-directory="<dir-to-specs>"` the output will be in the console and a return code of 0 indicates success.

@kevinsawicki thoughts?
