### PR TITLE
Set font size and family directly on editor

### DIFF
--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -113,7 +113,7 @@ class AtomReporter extends View
       specCount = "#{@completeSpecCount - @skippedCount}/#{@totalSpecCount - @skippedCount} (#{@skippedCount} skipped)"
     else
       specCount = "#{@completeSpecCount}/#{@totalSpecCount}"
-    @specCount.text specCount
+    @specCount[0].textContent = specCount
 
   updateStatusView: (spec) ->
     if @failedCount > 0
@@ -127,7 +127,7 @@ class AtomReporter extends View
 
     time = "#{Math.round((spec.endedAt - @startedAt.getTime()) / 10)}"
     time = "0#{time}" if time.length < 3
-    @time.text "#{time[0...-2]}.#{time[-2..]}s"
+    @time[0].textContent = "#{time[0...-2]}.#{time[-2..]}s"
 
   addSpecs: (specs) ->
     coreSpecs = 0

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -288,15 +288,13 @@ describe "Editor", ->
 
   describe "font family", ->
     beforeEach ->
-      expect(editor.css('font-family')).not.toBe 'Courier'
+      expect(editor.css('font-family')).toBe 'Courier'
 
     it "when there is no config in fontFamily don't set it", ->
-      expect($("head style.font-family")).not.toExist()
+      atom.config.set('editor.fontFamily', null)
+      expect(editor.css('font-family')).toBe ''
 
     describe "when the font family changes", ->
-      afterEach ->
-        editor.clearFontFamily()
-
       it "updates the font family of editors and recalculates dimensions critical to cursor positioning", ->
         editor.attachToDom(12)
         lineHeightBefore = editor.lineHeight
@@ -305,7 +303,6 @@ describe "Editor", ->
 
         config.set("editor.fontFamily", "PCMyungjo")
         expect(editor.css('font-family')).toBe 'PCMyungjo'
-        expect($("head style.editor-font-family").text()).toMatch "{font-family: PCMyungjo}"
         expect(editor.charWidth).not.toBe charWidthBefore
         expect(editor.getCursorView().position()).toEqual { top: 5 * editor.lineHeight, left: 6 * editor.charWidth }
 
@@ -319,8 +316,7 @@ describe "Editor", ->
       expect(editor.css('font-size')).not.toBe "10px"
 
     it "sets the initial font size based on the value from config", ->
-      expect($("head style.font-size")).toExist()
-      expect($("head style.font-size").text()).toMatch "{font-size: #{config.get('editor.fontSize')}px}"
+      expect(editor.css('font-size')).toBe "#{config.get('editor.fontSize')}px"
 
     describe "when the font size changes", ->
       it "updates the font sizes of editors and recalculates dimensions critical to cursor positioning", ->
@@ -405,9 +401,6 @@ describe "Editor", ->
       describe "when the editor is using a variable-width font", ->
         beforeEach ->
           editor.setFontFamily('sans-serif')
-
-        afterEach ->
-          editor.clearFontFamily()
 
         it "positions the cursor to the clicked row and column", ->
           {top, left} = editor.pixelOffsetForScreenPosition([3, 30])
@@ -916,9 +909,6 @@ describe "Editor", ->
       describe "when the editor is using a variable-width font", ->
         beforeEach ->
           editor.setFontFamily('sans-serif')
-
-        afterEach ->
-          editor.clearFontFamily()
 
         it "correctly positions the cursor", ->
           editor.setCursorBufferPosition([3, 30])

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -960,14 +960,7 @@ class Editor extends View
   #
   # fontSize - A {Number} indicating the font size in pixels.
   setFontSize: (fontSize) ->
-    headTag = $("head")
-    styleTag = headTag.find("style.font-size")
-    if styleTag.length == 0
-      styleTag = $$ -> @style class: 'font-size'
-      headTag.append styleTag
-
-    styleTag.text(".editor {font-size: #{fontSize}px}")
-
+    @css('font-size', "#{fontSize}px}")
     if @isOnDom()
       @redraw()
     else
@@ -982,18 +975,8 @@ class Editor extends View
   # Sets the font family for the editor.
   #
   # fontFamily - A {String} identifying the CSS `font-family`,
-  setFontFamily: (fontFamily) ->
-    headTag = $("head")
-    styleTag = headTag.find("style.editor-font-family")
-
-    if fontFamily?
-      if styleTag.length == 0
-        styleTag = $$ -> @style class: 'editor-font-family'
-        headTag.append styleTag
-      styleTag.text(".editor {font-family: #{fontFamily}}")
-    else
-      styleTag.remove()
-
+  setFontFamily: (fontFamily='') ->
+    @css('font-family', fontFamily)
     @redraw()
 
   # Gets the font family for the editor.
@@ -1001,11 +984,7 @@ class Editor extends View
   # Returns a {String} identifying the CSS `font-family`,
   getFontFamily: -> @css("font-family")
 
-  # Clears the CSS `font-family` property from the editor.
-  clearFontFamily: ->
-    $('head style.editor-font-family').remove()
-
-  # Clears the CSS `font-family` property from the editor.
+  # Redraw the editor
   redraw: ->
     return unless @hasParent()
     return unless @attached


### PR DESCRIPTION
Previously this involved finding/creating/removing and style tag which took up some time in specs and this seemed functionally equivalent.
