### PR TITLE
Only reload active package stylesheets

### DIFF
--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -145,7 +145,7 @@ class Atom
 
   watchThemes: ->
     @themes.on 'reloaded', =>
-      pack.reloadStylesheets?() for name, pack of @getLoadedPackages()
+      pack.reloadStylesheets?() for name, pack of @packages.getActivePackages()
       null
 
   open: (options) ->


### PR DESCRIPTION
During a little startup profiling I noticed that all package stylesheets were being loaded twice.

This change fixes that but I just wanted to check with @benogle  and @mcolyer to double check that this is okay to do. Stylesheets aren't loaded until packages are activated as of pull #880 so this seemed safe to me.
