### PR TITLE
Add API to open urls

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -51,7 +51,9 @@ beforeEach ->
   bindingSetsByFirstKeystrokeToRestore = _.clone(keymap.bindingSetsByFirstKeystroke)
 
   # reset config before each spec; don't load or save from/to `config.json`
-  config = new Config()
+  config = new Config
+    resourcePath: window.resourcePath
+    configDirPath: atom.getConfigDirPath()
   config.packageDirPaths.unshift(fixturePackagesPath)
   spyOn(config, 'load')
   spyOn(config, 'save')

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -18,6 +18,7 @@ atom.themes.loadBaseStylesheets()
 atom.themes.requireStylesheet '../static/jasmine'
 
 fixturePackagesPath = path.resolve(__dirname, './fixtures/packages')
+atom.packages.packageDirPaths.unshift(fixturePackagesPath)
 atom.keymap.loadBundledKeymaps()
 [bindingSetsToRestore, bindingSetsByFirstKeystrokeToRestore] = []
 

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -272,7 +272,6 @@ class AtomApplication
 
     pack = _.find @packages.getAvailablePackageMetadata(), ({name}) -> name is packageName
     if pack?
-      console.log(pack)
       if pack.urlMain
         packagePath = @packages.resolvePackagePath(packageName)
         bootstrapScript = path.resolve(packagePath, pack.urlMain)

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -268,6 +268,7 @@ class AtomApplication
         devMode: devMode
         configDirPath: fsUtils.absolute('~/.atom')
         resourcePath: @resourcePath
+        urlToOpen: urlToOpen
       })
 
     pack = _.find @packages.getAvailablePackageMetadata(), ({name}) -> name is packageName

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -263,8 +263,6 @@ class AtomApplication
   #    + devMode:
   #      Boolean to control the opened window's dev mode.
   openUrl: ({urlToOpen, devMode}) ->
-    parsedUrl = url.parse(urlToOpen)
-    packageName = parsedUrl.host
     unless @packages?
       PackageManager = require './package-manager'
       fsUtils = require './fs-utils'
@@ -274,6 +272,7 @@ class AtomApplication
         resourcePath: @resourcePath
         urlToOpen: urlToOpen
 
+    packageName = url.parse(urlToOpen).host
     pack = _.find @packages.getAvailablePackageMetadata(), ({name}) -> name is packageName
     if pack?
       if pack.urlMain

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -251,7 +251,11 @@ class AtomApplication
             console.log("Killing process #{pid} failed: #{error.code}")
         delete @pidsToOpenWindows[pid]
 
-  # Private: Handles an atom:// url.
+  # Private: Open an atom:// url.
+  #
+  # The host of the URL being opened is assumed to be the package name
+  # responsible for opening the URL.  A new window will be created with
+  # that package's `urlMain` as the bootstrap script.
   #
   # * options
   #    + urlToOpen:

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -270,7 +270,6 @@ class AtomApplication
         configDirPath: fsUtils.absolute('~/.atom')
         devMode: devMode
         resourcePath: @resourcePath
-        urlToOpen: urlToOpen
 
     packageName = url.parse(urlToOpen).host
     pack = _.find @packages.getAvailablePackageMetadata(), ({name}) -> name is packageName
@@ -278,7 +277,7 @@ class AtomApplication
       if pack.urlMain
         packagePath = @packages.resolvePackagePath(packageName)
         bootstrapScript = path.resolve(packagePath, pack.urlMain)
-        new AtomWindow({bootstrapScript, @resourcePath, devMode})
+        new AtomWindow({bootstrapScript, @resourcePath, devMode, urlToOpen})
       else
         console.log "Package '#{pack.name}' does not have a url main: #{urlToOpen}"
     else

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -269,8 +269,8 @@ class AtomApplication
       PackageManager = require './package-manager'
       fsUtils = require './fs-utils'
       @packages = new PackageManager
-        devMode: devMode
         configDirPath: fsUtils.absolute('~/.atom')
+        devMode: devMode
         resourcePath: @resourcePath
         urlToOpen: urlToOpen
 

--- a/src/atom-application.coffee
+++ b/src/atom-application.coffee
@@ -264,12 +264,11 @@ class AtomApplication
     unless @packages?
       PackageManager = require './package-manager'
       fsUtils = require './fs-utils'
-      @packages = new PackageManager({
+      @packages = new PackageManager
         devMode: devMode
         configDirPath: fsUtils.absolute('~/.atom')
         resourcePath: @resourcePath
         urlToOpen: urlToOpen
-      })
 
     pack = _.find @packages.getAvailablePackageMetadata(), ({name}) -> name is packageName
     if pack?

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -52,7 +52,6 @@ class Atom
     @keymap = new Keymap()
     @syntax = deserialize(@getWindowState('syntax')) ? new Syntax()
 
-
   getCurrentWindow: ->
     remote.getCurrentWindow()
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -27,6 +27,8 @@ class Atom
   initialize: ->
     @unsubscribe()
 
+    {devMode, resourcePath} = atom.getLoadSettings()
+
     Config = require './config'
     Keymap = require './keymap'
     PackageManager = require './package-manager'
@@ -35,19 +37,19 @@ class Atom
     ThemeManager = require './theme-manager'
     ContextMenuManager = require './context-menu-manager'
 
-    @packages = new PackageManager()
-
-    #TODO Remove once packages have been updated to not touch atom.packageStates directly
-    @__defineGetter__ 'packageStates', => @packages.packageStates
-    @__defineSetter__ 'packageStates', (packageStates) => @packages.packageStates = packageStates
-
-    @subscribe @packages, 'loaded', => @watchThemes()
     @themes = new ThemeManager()
-    @contextMenu = new ContextMenuManager(@getLoadSettings().devMode)
+    @contextMenu = new ContextMenuManager(devMode)
     @config = new Config()
     @pasteboard = new Pasteboard()
     @keymap = new Keymap()
     @syntax = deserialize(@getWindowState('syntax')) ? new Syntax()
+
+    @packages = new PackageManager({devMode, resourcePath, configDirPath: @config.getDirectoryPath()})
+    @subscribe @packages, 'loaded', => @watchThemes()
+
+    #TODO Remove once packages have been updated to not touch atom.packageStates directly
+    @__defineGetter__ 'packageStates', => @packages.packageStates
+    @__defineSetter__ 'packageStates', (packageStates) => @packages.packageStates = packageStates
 
   getCurrentWindow: ->
     remote.getCurrentWindow()

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -117,6 +117,9 @@ class Config
     _.extend hash, defaults
     @update()
 
+  # Public: Get the path to this config's directory.
+  getDirectoryPath: -> @configDirPath
+
   # Public: Returns a new {Object} containing all of settings and defaults.
   getSettings: ->
     _.deepExtend(@settings, @defaultSettings)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -41,18 +41,18 @@ class Config
       path.join(@resourcePath, 'static', 'variables')
       path.join(@resourcePath, 'static')
     ]
-    @packageDirPaths = [path.join(configDirPath, "packages")]
+    @packageDirPaths = [path.join(@configDirPath, "packages")]
     if atom.getLoadSettings().devMode
-      @packageDirPaths.unshift(path.join(configDirPath, "dev", "packages"))
+      @packageDirPaths.unshift(path.join(@configDirPath, "dev", "packages"))
     @userPackageDirPaths = _.clone(@packageDirPaths)
-    @userStoragePath = path.join(configDirPath, "storage")
+    @userStoragePath = path.join(@configDirPath, "storage")
 
     @defaultSettings =
       core: _.clone(require('./root-view').configDefaults)
       editor: _.clone(require('./editor').configDefaults)
     @settings = {}
-    @configFilePath = fsUtils.resolve(configDirPath, 'config', ['json', 'cson'])
-    @configFilePath ?= path.join(configDirPath, 'config.cson')
+    @configFilePath = fsUtils.resolve(@configDirPath, 'config', ['json', 'cson'])
+    @configFilePath ?= path.join(@configDirPath, 'config.cson')
 
   # Private:
   initializeConfigDirectory: (done) ->

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -7,8 +7,6 @@ path = require 'path'
 async = require 'async'
 pathWatcher = require 'pathwatcher'
 
-configDirPath = fsUtils.absolute("~/.atom")
-
 # Public: Used to access all of Atom's configuration details.
 #
 # A global instance of this class is available to all plugins which can be
@@ -35,14 +33,13 @@ class Config
   configFileHasErrors: null
 
   # Private: Created during initialization, available as `global.config`
-  constructor: ->
-    @configDirPath = configDirPath
-    @bundledKeymapsDirPath = path.join(resourcePath, "keymaps")
-    @nodeModulesDirPath = path.join(resourcePath, "node_modules")
+  constructor: ({@configDirPath, @resourcePath}={}) ->
+    @bundledKeymapsDirPath = path.join(@resourcePath, "keymaps")
+    @nodeModulesDirPath = path.join(@resourcePath, "node_modules")
     @bundledPackageDirPaths = [@nodeModulesDirPath]
     @lessSearchPaths = [
-      path.join(resourcePath, 'static', 'variables')
-      path.join(resourcePath, 'static')
+      path.join(@resourcePath, 'static', 'variables')
+      path.join(@resourcePath, 'static')
     ]
     @packageDirPaths = [path.join(configDirPath, "packages")]
     if atom.getLoadSettings().devMode
@@ -67,7 +64,7 @@ class Config
       fsUtils.copy(sourcePath, destinationPath, callback)
     queue.drain = done
 
-    templateConfigDirPath = fsUtils.resolve(window.resourcePath, 'dot-atom')
+    templateConfigDirPath = fsUtils.resolve(@resourcePath, 'dot-atom')
     onConfigDirFile = (sourcePath) =>
       relativePath = sourcePath.substring(templateConfigDirPath.length + 1)
       destinationPath = path.join(@configDirPath, relativePath)
@@ -116,9 +113,6 @@ class Config
 
     _.extend hash, defaults
     @update()
-
-  # Public: Get the path to this config's directory.
-  getDirectoryPath: -> @configDirPath
 
   # Public: Returns a new {Object} containing all of settings and defaults.
   getSettings: ->

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -8,7 +8,11 @@ module.exports =
 class PackageManager
   _.extend @prototype, EventEmitter
 
-  constructor: ->
+  constructor: ({configDirPath, devMode, @resourcePath}) ->
+    @packageDirPaths = [path.join(configDirPath, "packages")]
+    if devMode
+      @packageDirPaths.unshift(path.join(configDirPath, "dev", "packages"))
+
     @loadedPackages = {}
     @activePackages = {}
     @packageStates = {}
@@ -83,10 +87,10 @@ class PackageManager
   resolvePackagePath: (name) ->
     return name if fsUtils.isDirectorySync(name)
 
-    packagePath = fsUtils.resolve(config.packageDirPaths..., name)
+    packagePath = fsUtils.resolve(@packageDirPaths..., name)
     return packagePath if fsUtils.isDirectorySync(packagePath)
 
-    packagePath = path.join(window.resourcePath, 'node_modules', name)
+    packagePath = path.join(@resourcePath, 'node_modules', name)
     return packagePath if @isInternalPackage(packagePath)
 
   isInternalPackage: (packagePath) ->
@@ -108,11 +112,11 @@ class PackageManager
   getAvailablePackagePaths: ->
     packagePaths = []
 
-    for packageDirPath in config.packageDirPaths
+    for packageDirPath in @packageDirPaths
       for packagePath in fsUtils.listSync(packageDirPath)
         packagePaths.push(packagePath) if fsUtils.isDirectorySync(packagePath)
 
-    for packagePath in fsUtils.listSync(path.join(window.resourcePath, 'node_modules'))
+    for packagePath in fsUtils.listSync(path.join(@resourcePath, 'node_modules'))
       packagePaths.push(packagePath) if @isInternalPackage(packagePath)
 
     _.uniq(packagePaths)

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -122,8 +122,8 @@ class PackageManager
 
   getAvailablePackageMetadata: ->
     packages = []
-    for packagePath in atom.getAvailablePackagePaths()
+    for packagePath in @getAvailablePackagePaths()
       name = path.basename(packagePath)
-      metadata = atom.getLoadedPackage(name)?.metadata ? Package.loadMetadata(packagePath, true)
+      metadata = @getLoadedPackage(name)?.metadata ? Package.loadMetadata(packagePath, true)
       packages.push(metadata)
     packages


### PR DESCRIPTION
Packages can now register a `urlMain` that will be loaded as the bootstrap script for new windows spawned from opening urls.

The basic idea is that the host of the url being opened is mapped to the package name.  If that package has a `urlMain` registered then a new window is created with that `urlMain` as the bootstrap script.

So `atom://collaboration/12345` would load the collaboration package's `./lib/bootstrap.coffee` when opened.

The goal of this PR is to get collaboration URLs working again without Atom core knowing about the collaboration package.

See https://github.com/atom/collaboration/pull/14 for a reference implementation.
