### PR TITLE
Remove tree-view specific fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "timecop": "0.5.0",
     "to-the-hubs": "0.6.0",
     "toml": "0.3.0",
-    "tree-view": "0.10.0",
+    "tree-view": "0.12.0",
     "ui-demo": "0.8.0",
     "whitespace": "0.5.0",
     "wrap-guide": "0.3.0",


### PR DESCRIPTION
This is just a clean up piece which allows tree-view tests to be run independently from the rest of the Atom's test suite.

See atom/tree-view@2af39e9ed26af6874c451bcc80defafd7750f357
