### PR TITLE
Fix hidden input placement

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -904,8 +904,7 @@ describe "Editor", ->
 
       it "moves the hiddenInput to the same position with cursor's view", ->
         editor.setCursorScreenPosition(row: 2, column: 2)
-        expect(editor.getCursorView()[0].style.left).toEqual(editor.hiddenInput[0].style.left)
-        expect(editor.getCursorView()[0].style.top).toEqual(editor.hiddenInput[0].style.top)
+        expect(editor.getCursorView().offset()).toEqual(editor.hiddenInput.offset())
 
       describe "when the editor is using a variable-width font", ->
         beforeEach ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -42,9 +42,9 @@ class Editor extends View
     _.extend(attributes, params.attributes) if params.attributes
     @div attributes, =>
       @subview 'gutter', new Gutter
-      @input class: 'hidden-input', outlet: 'hiddenInput'
       @div class: 'scroll-view', outlet: 'scrollView', =>
-        @div class: 'overlayer', outlet: 'overlayer'
+        @div class: 'overlayer', outlet: 'overlayer', =>
+          @input class: 'hidden-input', outlet: 'hiddenInput'
         @div class: 'lines', outlet: 'renderedLines'
         @div class: 'underlayer', outlet: 'underlayer'
       @div class: 'vertical-scrollbar', outlet: 'verticalScrollbar', =>

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -739,7 +739,7 @@ class Editor extends View
       false
 
   bringHiddenInputIntoView: ->
-    @hiddenInput.css(top: @scrollTop() + 'px', left: @scrollLeft())
+    @hiddenInput.css(top: @scrollTop(), left: @scrollLeft())
 
   selectOnMousemoveUntilMouseup: ->
     lastMoveEvent = null

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -649,6 +649,7 @@ class Editor extends View
       @addClass 'is-focused'
 
     @hiddenInput.on 'focusout', =>
+      @bringHiddenInputIntoView()
       @isFocused = false
       @removeClass 'is-focused'
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -43,10 +43,10 @@ class Editor extends View
     @div attributes, =>
       @subview 'gutter', new Gutter
       @div class: 'scroll-view', outlet: 'scrollView', =>
-        @div class: 'overlayer', outlet: 'overlayer', =>
-          @input class: 'hidden-input', outlet: 'hiddenInput'
+        @div class: 'overlayer', outlet: 'overlayer'
         @div class: 'lines', outlet: 'renderedLines'
-        @div class: 'underlayer', outlet: 'underlayer'
+        @div class: 'underlayer', outlet: 'underlayer', =>
+          @input class: 'hidden-input', outlet: 'hiddenInput'
       @div class: 'vertical-scrollbar', outlet: 'verticalScrollbar', =>
         @div outlet: 'verticalScrollbarContent'
 
@@ -640,6 +640,7 @@ class Editor extends View
 
   handleEvents: ->
     @on 'focus', =>
+      @bringHiddenInputIntoView()
       @hiddenInput.focus()
       false
 
@@ -650,7 +651,6 @@ class Editor extends View
     @hiddenInput.on 'focusout', =>
       @isFocused = false
       @removeClass 'is-focused'
-      @hiddenInput.offset(top: 0, left: 0)
 
     @underlayer.on 'mousedown', (e) =>
       @renderedLines.trigger(e)
@@ -736,6 +736,9 @@ class Editor extends View
       @insertText(lastInput)
       @hiddenInput.val(lastInput)
       false
+
+  bringHiddenInputIntoView: ->
+    @hiddenInput.css(top: @scrollTop() + 'px', left: 0)
 
   selectOnMousemoveUntilMouseup: ->
     lastMoveEvent = null
@@ -851,6 +854,7 @@ class Editor extends View
     @underlayer.css('top', -scrollTop)
     @overlayer.css('top', -scrollTop)
     @gutter.lineNumbers.css('top', -scrollTop)
+
     if options?.adjustVerticalScrollbar ? true
       @verticalScrollbar.scrollTop(scrollTop)
     @activeEditSession.setScrollTop(@scrollTop())

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -739,7 +739,7 @@ class Editor extends View
       false
 
   bringHiddenInputIntoView: ->
-    @hiddenInput.css(top: @scrollTop() + 'px', left: 0)
+    @hiddenInput.css(top: @scrollTop() + 'px', left: @scrollLeft())
 
   selectOnMousemoveUntilMouseup: ->
     lastMoveEvent = null

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -640,7 +640,6 @@ class Editor extends View
 
   handleEvents: ->
     @on 'focus', =>
-      @bringHiddenInputIntoView()
       @hiddenInput.focus()
       false
 


### PR DESCRIPTION
In the speedup work i've been doing, I changed the `editor.hiddenInput` to use the cursorView's style attribute rather than `$.offset()` because it is much faster. However the hiddenInput and the cursorView had different parents, so was placing the hidden input in the wrong spot. Occasionally the hiddenInput would get focus and scroll the `scrollView` which blanks the editor window.

Soooo, this moves the hiddenInput to the underlayer, and places it in the visible area when it's focused, keeping the speedup and mitigating the editor blank screen.
