### PR TITLE
Use multiple editors rather than one per pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "editor-stats": "0.3.0",
     "exception-reporting": "0.4.0",
     "find-and-replace": "0.24.0",
-    "fuzzy-finder": "0.8.0",
+    "fuzzy-finder": "0.9.0",
     "gfm": "0.5.0",
     "git-diff": "0.5.0",
     "gists": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "command-palette": "0.4.0",
     "editor-stats": "0.3.0",
     "exception-reporting": "0.4.0",
-    "find-and-replace": "0.24.0",
+    "find-and-replace": "0.24.1",
     "fuzzy-finder": "0.9.0",
     "gfm": "0.5.0",
     "git-diff": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "command-palette": "0.4.0",
     "editor-stats": "0.3.0",
     "exception-reporting": "0.4.0",
-    "find-and-replace": "0.24.1",
+    "find-and-replace": "0.24.2",
     "fuzzy-finder": "0.9.0",
     "gfm": "0.5.0",
     "git-diff": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "settings-view": "0.27.0",
     "snippets": "0.6.0",
     "spell-check": "0.6.0",
-    "status-bar": "0.9.0",
+    "status-bar": "0.10.1",
     "symbols-view": "0.8.0",
     "tabs": "0.5.0",
     "terminal": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "find-and-replace": "0.24.2",
     "fuzzy-finder": "0.9.0",
     "gfm": "0.5.0",
-    "git-diff": "0.5.0",
+    "git-diff": "0.6.1",
     "gists": "0.3.0",
     "github-sign-in": "0.7.0",
     "go-to-line": "0.4.0",

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -236,6 +236,7 @@ describe "Pane", ->
 
     describe "when the item is a model", ->
       it "removes the associated view only when all items that require it have been removed", ->
+        pane.showItem(editSession1)
         pane.showItem(editSession2)
         pane.removeItem(editSession2)
         expect(pane.itemViews.find('.editor')).toExist()

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -94,43 +94,42 @@ describe "Pane", ->
           expect(editor.activeEditSession).toBe editSession1
 
       describe "when a valid view has already been appended for another item", ->
-        describe "when the view has a setModel method", ->
-          it "recycles the existing view by assigning the selected item to it", ->
-            pane.showItem(editSession1)
-            pane.showItem(editSession2)
-            expect(pane.itemViews.find('.editor').length).toBe 1
-            editor = pane.activeView
-            expect(editor.css('display')).toBe ''
-            expect(editor.activeEditSession).toBe editSession2
+        it "multiple views are created for multiple items", ->
+          pane.showItem(editSession1)
+          pane.showItem(editSession2)
+          expect(pane.itemViews.find('.editor').length).toBe 2
+          editor = pane.activeView
+          expect(editor.css('display')).toBe ''
+          expect(editor.activeEditSession).toBe editSession2
 
-        describe "when the view does not have a setModel method", ->
-          it "creates a new view with the item", ->
-            initialViewCount = pane.itemViews.find('.test-view').length
+        it "creates a new view with the item", ->
+          initialViewCount = pane.itemViews.find('.test-view').length
+          console.log 'initial', initialViewCount
 
-            model1 =
-              id: 'test-model-1'
-              text: 'Test Model 1'
-              serialize: -> {@id, @text}
-              getViewClass: -> TestView
+          model1 =
+            id: 'test-model-1'
+            text: 'Test Model 1'
+            serialize: -> {@id, @text}
+            getViewClass: -> TestView
 
-            model2 =
-              id: 'test-model-2'
-              text: 'Test Model 2'
-              serialize: -> {@id, @text}
-              getViewClass: -> TestView
+          model2 =
+            id: 'test-model-2'
+            text: 'Test Model 2'
+            serialize: -> {@id, @text}
+            getViewClass: -> TestView
 
-            pane.showItem(model1)
-            pane.showItem(model2)
-            expect(pane.itemViews.find('.test-view').length).toBe initialViewCount + 2
+          pane.showItem(model1)
+          pane.showItem(model2)
+          expect(pane.itemViews.find('.test-view').length).toBe initialViewCount + 2
 
-            pane.showPreviousItem()
-            expect(pane.itemViews.find('.test-view').length).toBe initialViewCount + 2
+          pane.showPreviousItem()
+          expect(pane.itemViews.find('.test-view').length).toBe initialViewCount + 2
 
-            pane.removeItem(model2)
-            expect(pane.itemViews.find('.test-view').length).toBe initialViewCount + 1
+          pane.removeItem(model2)
+          expect(pane.itemViews.find('.test-view').length).toBe initialViewCount + 1
 
-            pane.removeItem(model1)
-            expect(pane.itemViews.find('.test-view').length).toBe initialViewCount
+          pane.removeItem(model1)
+          expect(pane.itemViews.find('.test-view').length).toBe initialViewCount
 
     describe "when showing a view item", ->
       it "appends it to the itemViews div if it hasn't already been appended and shows it", ->

--- a/spec/root-view-spec.coffee
+++ b/spec/root-view-spec.coffee
@@ -33,7 +33,7 @@ describe "RootView", ->
         editor1 = rootView.getActiveView()
         buffer = editor1.getBuffer()
         editor1.splitRight()
-        expect(rootView.getActiveView()).toBe rootView.getEditors()[1]
+        expect(rootView.getActiveView()).toBe rootView.getEditors()[2]
 
         refreshRootViewAndProject()
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -830,9 +830,6 @@ class Editor extends View
   getModel: ->
     @activeEditSession
 
-  setModel: (editSession) ->
-    @edit(editSession)
-
   showBufferConflictAlert: (editSession) ->
     atom.confirm(
       editSession.getPath(),

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -830,6 +830,9 @@ class Editor extends View
   getModel: ->
     @activeEditSession
 
+  setModel: (editSession) ->
+    @edit(editSession)
+
   showBufferConflictAlert: (editSession) ->
     atom.confirm(
       editSession.getPath(),

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -320,16 +320,23 @@ class Pane extends View
   cleanupItemView: (item) ->
     if item instanceof $
       viewToRemove = item
-    else if @viewsByItem.get(item)
+    else if viewToRemove = @viewsByItem.get(item)
       @viewsByItem.delete(item)
 
     if @items.length > 0
       if @isMovingItem and item is viewToRemove
         viewToRemove?.detach()
+      else if @isMovingItem and viewToRemove?.setModel
+        viewToRemove.setModel(null) # dont want to destroy the model, so set to null
+        viewToRemove.remove()
       else
         viewToRemove?.remove()
     else
-      viewToRemove?.detach() if @isMovingItem and item is viewToRemove
+      if @isMovingItem and item is viewToRemove
+        viewToRemove?.detach()
+      else if @isMovingItem and viewToRemove?.setModel
+        viewToRemove.setModel(null) # dont want to destroy the model, so set to null
+
       @parent().view().removeChild(this, updateState: false)
 
   # Private:

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -28,7 +28,6 @@ class Pane extends View
 
   activeItem: null
   items: null
-  viewsByClassName: null # Views with a setModel() method are stored here
   viewsByItem: null      # Views without a setModel() method are stored here
 
   # Private:
@@ -53,7 +52,6 @@ class Pane extends View
       return if site is @state.site.id
       @showItemForUri(newValue) if key is 'activeItemUri'
 
-    @viewsByClassName = {}
     @viewsByItem = new WeakMap()
     activeItemUri = @state.get('activeItemUri')
     unless activeItemUri? and @showItemForUri(activeItemUri)
@@ -322,16 +320,8 @@ class Pane extends View
   cleanupItemView: (item) ->
     if item instanceof $
       viewToRemove = item
-    else
-      if viewToRemove = @viewsByItem.get(item)
-        @viewsByItem.delete(item)
-      else
-        viewClass = item.getViewClass()
-        otherItemsForView = @items.filter (i) -> i.getViewClass?() is viewClass
-        unless otherItemsForView.length
-          viewToRemove = @viewsByClassName[viewClass.name]
-          viewToRemove?.setModel(null)
-          delete @viewsByClassName[viewClass.name]
+    else if @viewsByItem.get(item)
+      @viewsByItem.delete(item)
 
     if @items.length > 0
       if @isMovingItem and item is viewToRemove
@@ -350,14 +340,8 @@ class Pane extends View
       view
     else
       viewClass = item.getViewClass()
-      if view = @viewsByClassName[viewClass.name]
-        view.setModel(item)
-      else
-        view = new viewClass(item)
-        if _.isFunction(view.setModel)
-          @viewsByClassName[viewClass.name] = view
-        else
-          @viewsByItem.set(item, view)
+      view = new viewClass(item)
+      @viewsByItem.set(item, view)
       view
 
   # Private:


### PR DESCRIPTION
Depends on #946 

Gets rid of the `viewsByClassName` approach from the pane. Just uses `viewsByItem`.
