### PR TITLE
Dynamically replace Atom version in application menu

### DIFF
--- a/menus/base.cson
+++ b/menus/base.cson
@@ -3,7 +3,7 @@
     label: 'Atom'
     submenu: [
       { label: 'About Atom', command: 'application:about' }
-      { label: "Version #{@version}", enabled: false }
+      { label: "VERSION", enabled: false }
       { label: "Install update", command: 'application:install-update', visible: false }
       { type: 'separator' }
       { label: 'Preferences...', command: 'application:show-settings' }


### PR DESCRIPTION
This correctly replaces the Atom version string in the application menu.
