### PR TITLE
script/bootstrap on win32

### DIFF
--- a/script/bootstrap.ps1
+++ b/script/bootstrap.ps1
@@ -1,6 +1,11 @@
 git submodule --quiet sync
 git submodule --quiet update --recursive --init
 
+if (!(Get-Command "npm")) {
+    Write-Error "You need to install Node and have npm on the PATH"
+    Break
+}
+
 cd vendor/apm
 npm install --silent .
 

--- a/script/bootstrap.ps1
+++ b/script/bootstrap.ps1
@@ -1,0 +1,10 @@
+git submodule --quiet sync
+git submodule --quiet update --recursive --init
+
+cd vendor/apm
+npm install --silent .
+
+cd ../..
+npm install --silent vendor/apm
+
+./node_modules/.bin/apm.cmd install --silent


### PR DESCRIPTION
This PR gets script/bootstrap running on Windows. Here's how far we've got so far:

``` sh
C:\atom\atom [bootstrap-on-win32]> .\script\bootstrap.ps1

> atom-package-manager@0.7.0 prepublish C:\atom\atom\vendor\apm
> grunt clean lint coffee

Running "clean" task

Running "coffeelint:src" (coffeelint) task
>> 21 files lint free.

Running "coffeelint:test" (coffeelint) task
>> 2 files lint free.

Running "coffee:glob_to_multiple" (coffee) task
File lib/apm-cli.js created.
File lib/apm.js created.
File lib/cleaner.js created.
File lib/command.js created.
File lib/config.js created.
File lib/couch/app.js created.
File lib/developer.js created.
File lib/fetcher.js created.
File lib/fs.js created.
File lib/init.js created.
File lib/installer.js created.
File lib/link-lister.js created.
File lib/linker.js created.
File lib/lister.js created.
File lib/publisher.js created.
File lib/rebuilder.js created.
File lib/test.js created.
File lib/tree.js created.
File lib/uninstaller.js created.
File lib/unlinker.js created.
File lib/updater.js created.

Done, without errors.
atom-package-manager@0.7.0 node_modules\atom-package-manager
├── colors@0.6.2
├── temp@0.5.1
├── semver@1.1.4
├── wordwrap@0.0.2
├── async@0.2.9
├── mkdirp@0.3.5
├── wrench@1.5.1
├── underscore@1.4.4
├── optimist@0.4.0
├── rimraf@2.1.4 (graceful-fs@1.2.3)
├── season@0.9.0 (coffee-script@1.6.3)
├── npmconf@0.0.24 (inherits@1.0.0, once@1.1.1, osenv@0.0.3, ini@1.1.0, nopt@2.1.2, config-chain@1.1.8)
├── request@2.21.0 (aws-sign@0.3.0, json-stringify-safe@4.0.0, qs@0.6.5, forever-agent@0.5.0, tunnel-agent@0.3.0, oauth-
sign@0.3.0, cookie-jar@0.3.0, mime@1.2.11, node-uuid@1.4.1, http-signature@0.9.11, hawk@0.13.1, form-data@0.0.8)
├── node-gyp@0.10.10 (osenv@0.0.3, which@1.0.5, graceful-fs@2.0.1, nopt@2.1.2, semver@2.1.0, glob@3.2.6, fstream@0.1.24,
 npmlog@0.0.4, minimatch@0.2.12, tar@0.1.18)
└── npm@1.3.9
Installing node@0.10.18 ✓
Installing modules ✗

> atom@31.0.0 preinstall C:\atom\atom
> true
```
## TODO
- [ ] Start hacking into apm to figure out what's failing
- [ ] Create shim Windows versions of modules we're pulling in if needed
