### PR TITLE
Remove paths from config

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "metrics": "0.8.0",
     "package-generator": "0.17.0",
     "release-notes": "0.11.0",
-    "settings-view": "0.37.0",
+    "settings-view": "0.38.0",
     "snippets": "0.13.0",
     "spell-check": "0.11.0",
     "status-bar": "0.15.1",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "link": "0.7.0",
     "markdown-preview": "0.15.0",
     "metrics": "0.8.0",
-    "package-generator": "0.17.0",
+    "package-generator": "0.19.0",
     "release-notes": "0.11.0",
     "settings-view": "0.38.0",
     "snippets": "0.13.0",

--- a/spec/keymap-spec.coffee
+++ b/spec/keymap-spec.coffee
@@ -6,11 +6,10 @@ Keymap = require '../src/keymap'
 describe "Keymap", ->
   fragment = null
   keymap = null
+  resourcePath = atom.getLoadSettings().resourcePath
 
   beforeEach ->
-    keymap = new Keymap
-      resourcePath: window.resourcePath
-      configDirPath: atom.getConfigDirPath()
+    keymap = new Keymap({configDirPath: atom.getConfigDirPath(), resourcePath})
     fragment = $ """
       <div class="command-mode">
         <div class="child-node">

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -77,6 +77,8 @@ beforeEach ->
   config = new Config
     resourcePath: window.resourcePath
     configDirPath: atom.getConfigDirPath()
+  config.setDefaults('core', RootView.configDefaults)
+  config.setDefaults('editor', Editor.configDefaults)
   spyOn(config, 'load')
   spyOn(config, 'save')
   config.set "editor.fontFamily", "Courier"

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -77,7 +77,6 @@ beforeEach ->
   config = new Config
     resourcePath: window.resourcePath
     configDirPath: atom.getConfigDirPath()
-  config.packageDirPaths.unshift(fixturePackagesPath)
   spyOn(config, 'load')
   spyOn(config, 'save')
   config.set "editor.fontFamily", "Courier"

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -77,10 +77,10 @@ beforeEach ->
   config = new Config
     resourcePath: window.resourcePath
     configDirPath: atom.getConfigDirPath()
-  config.setDefaults('core', RootView.configDefaults)
-  config.setDefaults('editor', Editor.configDefaults)
   spyOn(config, 'load')
   spyOn(config, 'save')
+  config.setDefaults('core', RootView.configDefaults)
+  config.setDefaults('editor', Editor.configDefaults)
   config.set "editor.fontFamily", "Courier"
   config.set "editor.fontSize", 16
   config.set "editor.autoIndent", false

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -6,11 +6,10 @@ AtomPackage = require '../src/atom-package'
 
 describe "ThemeManager", ->
   themeManager = null
+  resourcePath = atom.getLoadSettings().resourcePath
 
   beforeEach ->
-    themeManager = new ThemeManager
-      packageManager: atom.packages
-      resourcePath: window.resourcePath
+    themeManager = new ThemeManager({packageManager: atom.packages, resourcePath})
 
   afterEach ->
     themeManager.deactivateThemes()

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -7,9 +7,10 @@ AtomPackage = require '../src/atom-package'
 describe "ThemeManager", ->
   themeManager = null
   resourcePath = atom.getLoadSettings().resourcePath
+  configDirPath = atom.getConfigDirPath()
 
   beforeEach ->
-    themeManager = new ThemeManager({packageManager: atom.packages, resourcePath})
+    themeManager = new ThemeManager({packageManager: atom.packages, resourcePath, configDirPath})
 
   afterEach ->
     themeManager.deactivateThemes()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -251,6 +251,10 @@ class Atom
   getConfigDirPath: ->
     @configDirPath ?= fs.absolute('~/.atom')
 
+  # Public: Get the directory path to Atom's storage area.
+  getStorageDirPath: ->
+    @storageDirPath ?= path.join(@getConfigDirPath(), 'storage')
+
   getWindowStatePath: ->
     switch @windowMode
       when 'spec'
@@ -262,7 +266,7 @@ class Atom
           filename = "editor-#{sha1}"
 
     if filename
-      path.join(@config.userStoragePath, filename)
+      path.join(@getStorageDirPath(), filename)
     else
       null
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -64,7 +64,7 @@ class Atom
     @subscribe @packages, 'activated', => @watchThemes()
     @themes = new ThemeManager({packageManager: @packages, resourcePath})
     @contextMenu = new ContextMenuManager(devMode)
-    @menu = new MenuManager()
+    @menu = new MenuManager({resourcePath})
     @pasteboard = new Pasteboard()
     @syntax = deserialize(@getWindowState('syntax')) ? new Syntax()
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -62,7 +62,7 @@ class Atom
     @packages = new PackageManager({devMode, configDirPath, resourcePath})
 
     @subscribe @packages, 'activated', => @watchThemes()
-    @themes = new ThemeManager({packageManager: @packages, resourcePath})
+    @themes = new ThemeManager({packageManager: @packages, configDirPath, resourcePath})
     @contextMenu = new ContextMenuManager(devMode)
     @menu = new MenuManager({resourcePath})
     @pasteboard = new Pasteboard()

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -33,13 +33,6 @@ class Config
 
   # Private: Created during initialization, available as `global.config`
   constructor: ({@configDirPath, @resourcePath}={}) ->
-    @nodeModulesDirPath = path.join(@resourcePath, "node_modules")
-    @bundledPackageDirPaths = [@nodeModulesDirPath]
-    @packageDirPaths = [path.join(@configDirPath, "packages")]
-    if atom.getLoadSettings().devMode
-      @packageDirPaths.unshift(path.join(@configDirPath, "dev", "packages"))
-    @userPackageDirPaths = _.clone(@packageDirPaths)
-
     @defaultSettings = {}
     @settings = {}
     @configFilePath = fs.resolve(@configDirPath, 'config', ['json', 'cson'])

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -41,7 +41,6 @@ class Config
     if atom.getLoadSettings().devMode
       @packageDirPaths.unshift(path.join(@configDirPath, "dev", "packages"))
     @userPackageDirPaths = _.clone(@packageDirPaths)
-    @userStoragePath = path.join(@configDirPath, "storage")
 
     @defaultSettings =
       core: _.clone(require('./root-view').configDefaults)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -33,7 +33,6 @@ class Config
 
   # Private: Created during initialization, available as `global.config`
   constructor: ({@configDirPath, @resourcePath}={}) ->
-    @bundledKeymapsDirPath = path.join(@resourcePath, "keymaps")
     @bundledMenusDirPath = path.join(resourcePath, "menus")
     @nodeModulesDirPath = path.join(@resourcePath, "node_modules")
     @bundledPackageDirPaths = [@nodeModulesDirPath]

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -42,9 +42,7 @@ class Config
       @packageDirPaths.unshift(path.join(@configDirPath, "dev", "packages"))
     @userPackageDirPaths = _.clone(@packageDirPaths)
 
-    @defaultSettings =
-      core: _.clone(require('./root-view').configDefaults)
-      editor: _.clone(require('./editor').configDefaults)
+    @defaultSettings = {}
     @settings = {}
     @configFilePath = fs.resolve(@configDirPath, 'config', ['json', 'cson'])
     @configFilePath ?= path.join(@configDirPath, 'config.cson')

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -33,7 +33,6 @@ class Config
 
   # Private: Created during initialization, available as `global.config`
   constructor: ({@configDirPath, @resourcePath}={}) ->
-    @bundledMenusDirPath = path.join(resourcePath, "menus")
     @nodeModulesDirPath = path.join(@resourcePath, "node_modules")
     @bundledPackageDirPaths = [@nodeModulesDirPath]
     @packageDirPaths = [path.join(@configDirPath, "packages")]

--- a/src/keymap.coffee
+++ b/src/keymap.coffee
@@ -30,7 +30,7 @@ class Keymap
   bindingSetsByFirstKeystroke: null
   queuedKeystrokes: null
 
-  constructor: ({resourcePath, @configDirPath})->
+  constructor: ({@resourcePath, @configDirPath})->
     @bindingSets = []
     @bindingSetsByFirstKeystroke = {}
 

--- a/src/keymap.coffee
+++ b/src/keymap.coffee
@@ -35,7 +35,7 @@ class Keymap
     @bindingSetsByFirstKeystroke = {}
 
   loadBundledKeymaps: ->
-    @loadDirectory(path.join(@resourcePath, 'keymaps')
+    @loadDirectory(path.join(@resourcePath, 'keymaps'))
     @emit('bundled-keymaps-loaded')
 
   loadUserKeymap: ->

--- a/src/keymap.coffee
+++ b/src/keymap.coffee
@@ -31,12 +31,11 @@ class Keymap
   queuedKeystrokes: null
 
   constructor: ({resourcePath, @configDirPath})->
-    @bundledKeymapsDirPath = path.join(resourcePath, "keymaps")
     @bindingSets = []
     @bindingSetsByFirstKeystroke = {}
 
   loadBundledKeymaps: ->
-    @loadDirectory(@bundledKeymapsDirPath)
+    @loadDirectory(path.join(@resourcePath, 'keymaps')
     @emit('bundled-keymaps-loaded')
 
   loadUserKeymap: ->

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -12,7 +12,7 @@ fs = require 'fs-plus'
 module.exports =
 class MenuManager
   # Private:
-  constructor: ->
+  constructor: ({@resourcePath}) ->
     @template = []
     atom.keymap.on 'bundled-keymaps-loaded', => @loadCoreItems()
 
@@ -36,7 +36,8 @@ class MenuManager
 
   # Private
   loadCoreItems: ->
-    menuPaths = fs.listSync(atom.config.bundledMenusDirPath, ['cson', 'json'])
+    menusDirPath = path.join(@resourcePath, 'menus')
+    menuPaths = fs.listSync(menusDirPath, ['cson', 'json'])
     for menuPath in menuPaths
       data = CSON.readFileSync(menuPath)
       @add(data.menu)

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -194,6 +194,18 @@ class PackageManager
     {engines} = Package.loadMetadata(packagePath, true)
     engines?.atom?
 
+  isBundledPackage: (packageName) ->
+    @getPackageDependencies().hasOwnProperty(packageName)
+
+  getPackageDependencies: ->
+    unless @packageDependencies?
+      try
+        metadataPath = path.join(@resourcePath, 'package.json')
+        {@packageDependencies} = JSON.parse(fs.readFileSync(metadataPath)) ? {}
+        @packageDependencies ?= {}
+
+    @packageDependencies
+
   getAvailablePackagePaths: ->
     packagePaths = []
 
@@ -201,9 +213,6 @@ class PackageManager
       for packagePath in fs.listSync(packageDirPath)
         packagePaths.push(packagePath) if fs.isDirectorySync(packagePath)
 
-    try
-      metadataPath = path.join(@resourcePath, 'package.json')
-      {packageDependencies} = JSON.parse(fs.readFileSync(metadataPath)) ? {}
     packagesPath = path.join(@resourcePath, 'node_modules')
     for packageName, packageVersion of packageDependencies ? {}
       packagePath = path.join(packagesPath, packageName)

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -40,6 +40,12 @@ class PackageManager
   getApmPath: ->
     @apmPath ?= require.resolve('atom-package-manager/bin/apm')
 
+  # Public: Get the paths being used to look for packages.
+  #
+  # Returns an Array of String directory paths.
+  getPackageDirPaths: ->
+    _.clone(@packageDirPaths)
+
   getPackageState: (name) ->
     @packageStates[name]
 

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -17,7 +17,7 @@ module.exports =
 class ThemeManager
   Emitter.includeInto(this)
 
-  constructor: ({@packageManager, @resourcePath}) ->
+  constructor: ({@packageManager, @resourcePath, @configDirPath}) ->
     @lessCache = null
     @packageManager.registerPackageActivator(this, ['theme'])
 
@@ -87,7 +87,7 @@ class ThemeManager
 
   # Public:
   getUserStylesheetPath: ->
-    stylesheetPath = fs.resolve(path.join(atom.config.configDirPath, 'user'), ['css', 'less'])
+    stylesheetPath = fs.resolve(path.join(@configDirPath, 'user'), ['css', 'less'])
     if fs.isFileSync(stylesheetPath)
       stylesheetPath
     else

--- a/src/window.coffee
+++ b/src/window.coffee
@@ -49,6 +49,8 @@ window.startEditorWindow = ->
   windowEventHandler = new WindowEventHandler
   atom.restoreDimensions()
   atom.config.load()
+  atom.config.setDefaults('core', require('./root-view').configDefaults)
+  atom.config.setDefaults('editor', require('./editor').configDefaults)
   atom.keymap.loadBundledKeymaps()
   atom.themes.loadBaseStylesheets()
   atom.packages.loadPackages()


### PR DESCRIPTION
Removes paths from `config.coffee` and place them in appropriate locations, i.e `ThemeManager`, `PackageManager`, etc.

This PR was originally going to extract config but instead now just cleans it up and it can be extracted later.

Refs #950 
