### PR TITLE
Don't use shims in core

### DIFF
--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -137,28 +137,28 @@ describe "the `atom` global", ->
               element2 = $$ -> @div class: 'test-2'
               element3 = $$ -> @div class: 'test-3'
 
-              expect(keymap.bindingsForElement(element1)['ctrl-z']).toBeUndefined()
-              expect(keymap.bindingsForElement(element2)['ctrl-z']).toBeUndefined()
-              expect(keymap.bindingsForElement(element3)['ctrl-z']).toBeUndefined()
+              expect(atom.keymap.bindingsForElement(element1)['ctrl-z']).toBeUndefined()
+              expect(atom.keymap.bindingsForElement(element2)['ctrl-z']).toBeUndefined()
+              expect(atom.keymap.bindingsForElement(element3)['ctrl-z']).toBeUndefined()
 
               atom.activatePackage("package-with-keymaps")
 
-              expect(keymap.bindingsForElement(element1)['ctrl-z']).toBe "test-1"
-              expect(keymap.bindingsForElement(element2)['ctrl-z']).toBe "test-2"
-              expect(keymap.bindingsForElement(element3)['ctrl-z']).toBeUndefined()
+              expect(atom.keymap.bindingsForElement(element1)['ctrl-z']).toBe "test-1"
+              expect(atom.keymap.bindingsForElement(element2)['ctrl-z']).toBe "test-2"
+              expect(atom.keymap.bindingsForElement(element3)['ctrl-z']).toBeUndefined()
 
           describe "when the metadata contains a 'keymaps' manifest", ->
             it "loads only the keymaps specified by the manifest, in the specified order", ->
               element1 = $$ -> @div class: 'test-1'
               element3 = $$ -> @div class: 'test-3'
 
-              expect(keymap.bindingsForElement(element1)['ctrl-z']).toBeUndefined()
+              expect(atom.keymap.bindingsForElement(element1)['ctrl-z']).toBeUndefined()
 
               atom.activatePackage("package-with-keymaps-manifest")
 
-              expect(keymap.bindingsForElement(element1)['ctrl-z']).toBe 'keymap-1'
-              expect(keymap.bindingsForElement(element1)['ctrl-n']).toBe 'keymap-2'
-              expect(keymap.bindingsForElement(element3)['ctrl-y']).toBeUndefined()
+              expect(atom.keymap.bindingsForElement(element1)['ctrl-z']).toBe 'keymap-1'
+              expect(atom.keymap.bindingsForElement(element1)['ctrl-n']).toBe 'keymap-2'
+              expect(atom.keymap.bindingsForElement(element3)['ctrl-y']).toBeUndefined()
 
         describe "menu loading", ->
           beforeEach ->
@@ -317,8 +317,8 @@ describe "the `atom` global", ->
         it "removes the package's keymaps", ->
           atom.activatePackage('package-with-keymaps')
           atom.deactivatePackage('package-with-keymaps')
-          expect(keymap.bindingsForElement($$ -> @div class: 'test-1')['ctrl-z']).toBeUndefined()
-          expect(keymap.bindingsForElement($$ -> @div class: 'test-2')['ctrl-z']).toBeUndefined()
+          expect(atom.keymap.bindingsForElement($$ -> @div class: 'test-1')['ctrl-z']).toBeUndefined()
+          expect(atom.keymap.bindingsForElement($$ -> @div class: 'test-2')['ctrl-z']).toBeUndefined()
 
         it "removes the package's stylesheets", ->
           atom.activatePackage('package-with-stylesheets')

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -22,11 +22,11 @@ describe "the `atom` global", ->
 
         it "continues if the package has an invalid package.json", ->
           spyOn(console, 'warn')
-          config.set("core.disabledPackages", [])
+          atom.config.set("core.disabledPackages", [])
           expect(-> atom.loadPackage("package-with-broken-package-json")).not.toThrow()
 
         it "continues if the package has an invalid keymap", ->
-          config.set("core.disabledPackages", [])
+          atom.config.set("core.disabledPackages", [])
           expect(-> atom.loadPackage("package-with-broken-keymap")).not.toThrow()
 
     describe ".unloadPackage(name)", ->
@@ -72,10 +72,10 @@ describe "the `atom` global", ->
               expect(pack.mainModule).toBe indexModule
 
           it "assigns config defaults from the module", ->
-            expect(config.get('package-with-config-defaults.numbers.one')).toBeUndefined()
+            expect(atom.config.get('package-with-config-defaults.numbers.one')).toBeUndefined()
             atom.activatePackage('package-with-config-defaults')
-            expect(config.get('package-with-config-defaults.numbers.one')).toBe 1
-            expect(config.get('package-with-config-defaults.numbers.two')).toBe 2
+            expect(atom.config.get('package-with-config-defaults.numbers.one')).toBe 1
+            expect(atom.config.get('package-with-config-defaults.numbers.two')).toBe 2
 
           describe "when the package metadata includes activation events", ->
             [mainModule, pack] = []
@@ -125,7 +125,7 @@ describe "the `atom` global", ->
           expect(pack.mainModule.activate).toHaveBeenCalledWith({someNumber: 77})
 
         it "logs warning instead of throwing an exception if the package fails to load", ->
-          config.set("core.disabledPackages", [])
+          atom.config.set("core.disabledPackages", [])
           spyOn(console, "warn")
           expect(-> atom.activatePackage("package-that-throws-an-exception")).not.toThrow()
           expect(console.warn).toHaveBeenCalled()
@@ -387,7 +387,7 @@ describe "the `atom` global", ->
           packageName = 'package-with-main'
           atom.config.pushAtKeyPath('core.disabledPackages', packageName)
           atom.packages.observeDisabledPackages()
-          expect(config.get('core.disabledPackages')).toContain packageName
+          expect(atom.config.get('core.disabledPackages')).toContain packageName
 
           pack = atom.packages.enablePackage(packageName)
 
@@ -395,19 +395,19 @@ describe "the `atom` global", ->
           activatedPackages = atom.packages.getActivePackages()
           expect(loadedPackages).toContain(pack)
           expect(activatedPackages).toContain(pack)
-          expect(config.get('core.disabledPackages')).not.toContain packageName
+          expect(atom.config.get('core.disabledPackages')).not.toContain packageName
 
         it ".disablePackage() disables an enabled package", ->
           packageName = 'package-with-main'
           atom.packages.activatePackage(packageName)
           atom.packages.observeDisabledPackages()
-          expect(config.get('core.disabledPackages')).not.toContain packageName
+          expect(atom.config.get('core.disabledPackages')).not.toContain packageName
 
           pack = atom.packages.disablePackage(packageName)
 
           activatedPackages = atom.packages.getActivePackages()
           expect(activatedPackages).not.toContain(pack)
-          expect(config.get('core.disabledPackages')).toContain packageName
+          expect(atom.config.get('core.disabledPackages')).toContain packageName
 
       describe "with themes", ->
         beforeEach ->
@@ -420,20 +420,20 @@ describe "the `atom` global", ->
         it ".enablePackage() and .disablePackage() enables and disables a theme", ->
           packageName = 'theme-with-package-file'
 
-          expect(config.get('core.themes')).not.toContain packageName
-          expect(config.get('core.disabledPackages')).not.toContain packageName
+          expect(atom.config.get('core.themes')).not.toContain packageName
+          expect(atom.config.get('core.disabledPackages')).not.toContain packageName
 
           # enabling of theme
           pack = atom.packages.enablePackage(packageName)
           activatedPackages = atom.packages.getActivePackages()
           expect(activatedPackages).toContain(pack)
-          expect(config.get('core.themes')).toContain packageName
-          expect(config.get('core.disabledPackages')).not.toContain packageName
+          expect(atom.config.get('core.themes')).toContain packageName
+          expect(atom.config.get('core.disabledPackages')).not.toContain packageName
 
           # disabling of theme
           pack = atom.packages.disablePackage(packageName)
           activatedPackages = atom.packages.getActivePackages()
           expect(activatedPackages).not.toContain(pack)
-          expect(config.get('core.themes')).not.toContain packageName
-          expect(config.get('core.themes')).not.toContain packageName
-          expect(config.get('core.disabledPackages')).not.toContain packageName
+          expect(atom.config.get('core.themes')).not.toContain packageName
+          expect(atom.config.get('core.themes')).not.toContain packageName
+          expect(atom.config.get('core.disabledPackages')).not.toContain packageName

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -240,24 +240,24 @@ describe "the `atom` global", ->
         describe "grammar loading", ->
           it "loads the package's grammars", ->
             atom.activatePackage('package-with-grammars')
-            expect(syntax.selectGrammar('a.alot').name).toBe 'Alot'
-            expect(syntax.selectGrammar('a.alittle').name).toBe 'Alittle'
+            expect(atom.syntax.selectGrammar('a.alot').name).toBe 'Alot'
+            expect(atom.syntax.selectGrammar('a.alittle').name).toBe 'Alittle'
 
         describe "scoped-property loading", ->
           it "loads the scoped properties", ->
             atom.activatePackage("package-with-scoped-properties")
-            expect(syntax.getProperty ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
+            expect(atom.syntax.getProperty ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
 
       describe "textmate packages", ->
         it "loads the package's grammars", ->
-          expect(syntax.selectGrammar("file.rb").name).toBe "Null Grammar"
+          expect(atom.syntax.selectGrammar("file.rb").name).toBe "Null Grammar"
           atom.activatePackage('language-ruby', sync: true)
-          expect(syntax.selectGrammar("file.rb").name).toBe "Ruby"
+          expect(atom.syntax.selectGrammar("file.rb").name).toBe "Ruby"
 
         it "translates the package's scoped properties to Atom terms", ->
-          expect(syntax.getProperty(['.source.ruby'], 'editor.commentStart')).toBeUndefined()
+          expect(atom.syntax.getProperty(['.source.ruby'], 'editor.commentStart')).toBeUndefined()
           atom.activatePackage('language-ruby', sync: true)
-          expect(syntax.getProperty(['.source.ruby'], 'editor.commentStart')).toBe '# '
+          expect(atom.syntax.getProperty(['.source.ruby'], 'editor.commentStart')).toBe '# '
 
         describe "when the package has no grammars but does have preferences", ->
           it "loads the package's preferences as scoped properties", ->
@@ -267,9 +267,9 @@ describe "the `atom` global", ->
             atom.activatePackage('package-with-preferences-tmbundle')
 
             waitsFor ->
-              syntax.addProperties.callCount > 0
+              atom.syntax.addProperties.callCount > 0
             runs ->
-              expect(syntax.getProperty(['.source.pref'], 'editor.increaseIndentPattern')).toBe '^abc$'
+              expect(atom.syntax.getProperty(['.source.pref'], 'editor.increaseIndentPattern')).toBe '^abc$'
 
     describe ".deactivatePackage(id)", ->
       describe "atom packages", ->
@@ -311,8 +311,8 @@ describe "the `atom` global", ->
         it "removes the package's grammars", ->
           atom.activatePackage('package-with-grammars')
           atom.deactivatePackage('package-with-grammars')
-          expect(syntax.selectGrammar('a.alot').name).toBe 'Null Grammar'
-          expect(syntax.selectGrammar('a.alittle').name).toBe 'Null Grammar'
+          expect(atom.syntax.selectGrammar('a.alot').name).toBe 'Null Grammar'
+          expect(atom.syntax.selectGrammar('a.alittle').name).toBe 'Null Grammar'
 
         it "removes the package's keymaps", ->
           atom.activatePackage('package-with-keymaps')
@@ -332,22 +332,22 @@ describe "the `atom` global", ->
 
         it "removes the package's scoped-properties", ->
           atom.activatePackage("package-with-scoped-properties")
-          expect(syntax.getProperty ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
+          expect(atom.syntax.getProperty ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
           atom.deactivatePackage("package-with-scoped-properties")
-          expect(syntax.getProperty ['.source.omg'], 'editor.increaseIndentPattern').toBeUndefined()
+          expect(atom.syntax.getProperty ['.source.omg'], 'editor.increaseIndentPattern').toBeUndefined()
 
       describe "textmate packages", ->
         it "removes the package's grammars", ->
-          expect(syntax.selectGrammar("file.rb").name).toBe "Null Grammar"
+          expect(atom.syntax.selectGrammar("file.rb").name).toBe "Null Grammar"
           atom.activatePackage('language-ruby', sync: true)
-          expect(syntax.selectGrammar("file.rb").name).toBe "Ruby"
+          expect(atom.syntax.selectGrammar("file.rb").name).toBe "Ruby"
           atom.deactivatePackage('language-ruby')
-          expect(syntax.selectGrammar("file.rb").name).toBe "Null Grammar"
+          expect(atom.syntax.selectGrammar("file.rb").name).toBe "Null Grammar"
 
         it "removes the package's scoped properties", ->
           atom.activatePackage('language-ruby', sync: true)
           atom.deactivatePackage('language-ruby')
-          expect(syntax.getProperty(['.source.ruby'], 'editor.commentStart')).toBeUndefined()
+          expect(atom.syntax.getProperty(['.source.ruby'], 'editor.commentStart')).toBeUndefined()
 
     describe ".activate()", ->
       packageActivator = null

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -8,104 +8,104 @@ describe "Config", ->
 
   describe ".get(keyPath)", ->
     it "allows a key path's value to be read", ->
-      expect(config.set("foo.bar.baz", 42)).toBe 42
-      expect(config.get("foo.bar.baz")).toBe 42
-      expect(config.get("bogus.key.path")).toBeUndefined()
+      expect(atom.config.set("foo.bar.baz", 42)).toBe 42
+      expect(atom.config.get("foo.bar.baz")).toBe 42
+      expect(atom.config.get("bogus.key.path")).toBeUndefined()
 
     it "returns a deep clone of the key path's value", ->
-      config.set('value', array: [1, b: 2, 3])
-      retrievedValue = config.get('value')
+      atom.config.set('value', array: [1, b: 2, 3])
+      retrievedValue = atom.config.get('value')
       retrievedValue.array[0] = 4
       retrievedValue.array[1].b = 2.1
-      expect(config.get('value')).toEqual(array: [1, b: 2, 3])
+      expect(atom.config.get('value')).toEqual(array: [1, b: 2, 3])
 
   describe ".set(keyPath, value)", ->
     it "allows a key path's value to be written", ->
-      expect(config.set("foo.bar.baz", 42)).toBe 42
-      expect(config.get("foo.bar.baz")).toBe 42
+      expect(atom.config.set("foo.bar.baz", 42)).toBe 42
+      expect(atom.config.get("foo.bar.baz")).toBe 42
 
     it "updates observers and saves when a key path is set", ->
       observeHandler = jasmine.createSpy "observeHandler"
-      config.observe "foo.bar.baz", observeHandler
+      atom.config.observe "foo.bar.baz", observeHandler
       observeHandler.reset()
 
-      config.set("foo.bar.baz", 42)
+      atom.config.set("foo.bar.baz", 42)
 
-      expect(config.save).toHaveBeenCalled()
+      expect(atom.config.save).toHaveBeenCalled()
       expect(observeHandler).toHaveBeenCalledWith 42, {previous: undefined}
 
     describe "when the value equals the default value", ->
       it "does not store the value", ->
-        config.setDefaults("foo", same: 1, changes: 1)
-        expect(config.settings.foo).toBeUndefined()
-        config.set('foo.same', 1)
-        config.set('foo.changes', 2)
-        expect(config.settings.foo).toEqual {changes: 2}
+        atom.config.setDefaults("foo", same: 1, changes: 1)
+        expect(atom.config.settings.foo).toBeUndefined()
+        atom.config.set('foo.same', 1)
+        atom.config.set('foo.changes', 2)
+        expect(atom.config.settings.foo).toEqual {changes: 2}
 
-        config.set('foo.changes', 1)
-        expect(config.settings.foo).toEqual {}
+        atom.config.set('foo.changes', 1)
+        expect(atom.config.settings.foo).toEqual {}
 
   describe ".toggle(keyPath)", ->
     it "negates the boolean value of the current key path value", ->
-      config.set('foo.a', 1)
-      config.toggle('foo.a')
-      expect(config.get('foo.a')).toBe false
+      atom.config.set('foo.a', 1)
+      atom.config.toggle('foo.a')
+      expect(atom.config.get('foo.a')).toBe false
 
-      config.set('foo.a', '')
-      config.toggle('foo.a')
-      expect(config.get('foo.a')).toBe true
+      atom.config.set('foo.a', '')
+      atom.config.toggle('foo.a')
+      expect(atom.config.get('foo.a')).toBe true
 
-      config.set('foo.a', null)
-      config.toggle('foo.a')
-      expect(config.get('foo.a')).toBe true
+      atom.config.set('foo.a', null)
+      atom.config.toggle('foo.a')
+      expect(atom.config.get('foo.a')).toBe true
 
-      config.set('foo.a', true)
-      config.toggle('foo.a')
-      expect(config.get('foo.a')).toBe false
+      atom.config.set('foo.a', true)
+      atom.config.toggle('foo.a')
+      expect(atom.config.get('foo.a')).toBe false
 
   describe ".pushAtKeyPath(keyPath, value)", ->
     it "pushes the given value to the array at the key path and updates observers", ->
-      config.set("foo.bar.baz", ["a"])
+      atom.config.set("foo.bar.baz", ["a"])
       observeHandler = jasmine.createSpy "observeHandler"
-      config.observe "foo.bar.baz", observeHandler
+      atom.config.observe "foo.bar.baz", observeHandler
       observeHandler.reset()
 
-      expect(config.pushAtKeyPath("foo.bar.baz", "b")).toBe 2
-      expect(config.get("foo.bar.baz")).toEqual ["a", "b"]
-      expect(observeHandler).toHaveBeenCalledWith config.get("foo.bar.baz"), {previous: ['a']}
+      expect(atom.config.pushAtKeyPath("foo.bar.baz", "b")).toBe 2
+      expect(atom.config.get("foo.bar.baz")).toEqual ["a", "b"]
+      expect(observeHandler).toHaveBeenCalledWith atom.config.get("foo.bar.baz"), {previous: ['a']}
 
   describe ".unshiftAtKeyPath(keyPath, value)", ->
     it "unshifts the given value to the array at the key path and updates observers", ->
-      config.set("foo.bar.baz", ["b"])
+      atom.config.set("foo.bar.baz", ["b"])
       observeHandler = jasmine.createSpy "observeHandler"
-      config.observe "foo.bar.baz", observeHandler
+      atom.config.observe "foo.bar.baz", observeHandler
       observeHandler.reset()
 
-      expect(config.unshiftAtKeyPath("foo.bar.baz", "a")).toBe 2
-      expect(config.get("foo.bar.baz")).toEqual ["a", "b"]
-      expect(observeHandler).toHaveBeenCalledWith config.get("foo.bar.baz"), {previous: ['b']}
+      expect(atom.config.unshiftAtKeyPath("foo.bar.baz", "a")).toBe 2
+      expect(atom.config.get("foo.bar.baz")).toEqual ["a", "b"]
+      expect(observeHandler).toHaveBeenCalledWith atom.config.get("foo.bar.baz"), {previous: ['b']}
 
   describe ".removeAtKeyPath(keyPath, value)", ->
     it "removes the given value from the array at the key path and updates observers", ->
-      config.set("foo.bar.baz", ["a", "b", "c"])
+      atom.config.set("foo.bar.baz", ["a", "b", "c"])
       observeHandler = jasmine.createSpy "observeHandler"
-      config.observe "foo.bar.baz", observeHandler
+      atom.config.observe "foo.bar.baz", observeHandler
       observeHandler.reset()
 
-      expect(config.removeAtKeyPath("foo.bar.baz", "b")).toEqual ["a", "c"]
-      expect(config.get("foo.bar.baz")).toEqual ["a", "c"]
-      expect(observeHandler).toHaveBeenCalledWith config.get("foo.bar.baz"), {previous: ['a', 'b', 'c']}
+      expect(atom.config.removeAtKeyPath("foo.bar.baz", "b")).toEqual ["a", "c"]
+      expect(atom.config.get("foo.bar.baz")).toEqual ["a", "c"]
+      expect(observeHandler).toHaveBeenCalledWith atom.config.get("foo.bar.baz"), {previous: ['a', 'b', 'c']}
 
   describe ".getPositiveInt(keyPath, defaultValue)", ->
     it "returns the proper current or default value", ->
-      config.set('editor.preferredLineLength', 0)
-      expect(config.getPositiveInt('editor.preferredLineLength', 80)).toBe 80
-      config.set('editor.preferredLineLength', -1234)
-      expect(config.getPositiveInt('editor.preferredLineLength', 80)).toBe 80
-      config.set('editor.preferredLineLength', 'abcd')
-      expect(config.getPositiveInt('editor.preferredLineLength', 80)).toBe 80
-      config.set('editor.preferredLineLength', null)
-      expect(config.getPositiveInt('editor.preferredLineLength', 80)).toBe 80
+      atom.config.set('editor.preferredLineLength', 0)
+      expect(atom.config.getPositiveInt('editor.preferredLineLength', 80)).toBe 80
+      atom.config.set('editor.preferredLineLength', -1234)
+      expect(atom.config.getPositiveInt('editor.preferredLineLength', 80)).toBe 80
+      atom.config.set('editor.preferredLineLength', 'abcd')
+      expect(atom.config.getPositiveInt('editor.preferredLineLength', 80)).toBe 80
+      atom.config.set('editor.preferredLineLength', null)
+      expect(atom.config.getPositiveInt('editor.preferredLineLength', 80)).toBe 80
 
   describe ".save()", ->
     nodeFs = require 'fs'
@@ -116,86 +116,86 @@ describe "Config", ->
 
     describe "when ~/.atom/config.json exists", ->
       it "writes any non-default properties to ~/.atom/config.json", ->
-        config.configFilePath = path.join(config.configDirPath, "config.json")
-        config.set("a.b.c", 1)
-        config.set("a.b.d", 2)
-        config.set("x.y.z", 3)
-        config.setDefaults("a.b", e: 4, f: 5)
+        atom.config.configFilePath = path.join(atom.config.configDirPath, "atom.config.json")
+        atom.config.set("a.b.c", 1)
+        atom.config.set("a.b.d", 2)
+        atom.config.set("x.y.z", 3)
+        atom.config.setDefaults("a.b", e: 4, f: 5)
 
         nodeFs.writeFileSync.reset()
-        config.save()
+        atom.config.save()
 
-        expect(nodeFs.writeFileSync.argsForCall[0][0]).toBe(path.join(config.configDirPath, "config.json"))
+        expect(nodeFs.writeFileSync.argsForCall[0][0]).toBe(path.join(atom.config.configDirPath, "atom.config.json"))
         writtenConfig = JSON.parse(nodeFs.writeFileSync.argsForCall[0][1])
-        expect(writtenConfig).toEqual config.settings
+        expect(writtenConfig).toEqual atom.config.settings
 
     describe "when ~/.atom/config.json doesn't exist", ->
       it "writes any non-default properties to ~/.atom/config.cson", ->
-        config.configFilePath = path.join(config.configDirPath, "config.cson")
-        config.set("a.b.c", 1)
-        config.set("a.b.d", 2)
-        config.set("x.y.z", 3)
-        config.setDefaults("a.b", e: 4, f: 5)
+        atom.config.configFilePath = path.join(atom.config.configDirPath, "atom.config.cson")
+        atom.config.set("a.b.c", 1)
+        atom.config.set("a.b.d", 2)
+        atom.config.set("x.y.z", 3)
+        atom.config.setDefaults("a.b", e: 4, f: 5)
 
         nodeFs.writeFileSync.reset()
-        config.save()
+        atom.config.save()
 
-        expect(nodeFs.writeFileSync.argsForCall[0][0]).toBe(path.join(config.configDirPath, "config.cson"))
+        expect(nodeFs.writeFileSync.argsForCall[0][0]).toBe(path.join(atom.config.configDirPath, "atom.config.cson"))
         CoffeeScript = require 'coffee-script'
         writtenConfig = CoffeeScript.eval(nodeFs.writeFileSync.argsForCall[0][1], bare: true)
-        expect(writtenConfig).toEqual config.settings
+        expect(writtenConfig).toEqual atom.config.settings
 
   describe ".setDefaults(keyPath, defaults)", ->
     it "assigns any previously-unassigned keys to the object at the key path", ->
-      config.set("foo.bar.baz", a: 1)
-      config.setDefaults("foo.bar.baz", a: 2, b: 3, c: 4)
-      expect(config.get("foo.bar.baz.a")).toBe 1
-      expect(config.get("foo.bar.baz.b")).toBe 3
-      expect(config.get("foo.bar.baz.c")).toBe 4
+      atom.config.set("foo.bar.baz", a: 1)
+      atom.config.setDefaults("foo.bar.baz", a: 2, b: 3, c: 4)
+      expect(atom.config.get("foo.bar.baz.a")).toBe 1
+      expect(atom.config.get("foo.bar.baz.b")).toBe 3
+      expect(atom.config.get("foo.bar.baz.c")).toBe 4
 
-      config.setDefaults("foo.quux", x: 0, y: 1)
-      expect(config.get("foo.quux.x")).toBe 0
-      expect(config.get("foo.quux.y")).toBe 1
+      atom.config.setDefaults("foo.quux", x: 0, y: 1)
+      expect(atom.config.get("foo.quux.x")).toBe 0
+      expect(atom.config.get("foo.quux.y")).toBe 1
 
   describe ".observe(keyPath)", ->
     observeHandler = null
 
     beforeEach ->
       observeHandler = jasmine.createSpy("observeHandler")
-      config.set("foo.bar.baz", "value 1")
-      config.observe "foo.bar.baz", observeHandler
+      atom.config.set("foo.bar.baz", "value 1")
+      atom.config.observe "foo.bar.baz", observeHandler
 
     it "fires the given callback with the current value at the keypath", ->
       expect(observeHandler).toHaveBeenCalledWith("value 1")
 
     it "fires the callback every time the observed value changes", ->
       observeHandler.reset() # clear the initial call
-      config.set('foo.bar.baz', "value 2")
+      atom.config.set('foo.bar.baz', "value 2")
       expect(observeHandler).toHaveBeenCalledWith("value 2", {previous: 'value 1'})
       observeHandler.reset()
 
-      config.set('foo.bar.baz', "value 1")
+      atom.config.set('foo.bar.baz', "value 1")
       expect(observeHandler).toHaveBeenCalledWith("value 1", {previous: 'value 2'})
 
     it "fires the callback when the observed value is deleted", ->
       observeHandler.reset() # clear the initial call
-      config.set('foo.bar.baz', undefined)
+      atom.config.set('foo.bar.baz', undefined)
       expect(observeHandler).toHaveBeenCalledWith(undefined, {previous: 'value 1'})
 
     it "fires the callback when the full key path goes into and out of existence", ->
       observeHandler.reset() # clear the initial call
-      config.set("foo.bar", undefined)
+      atom.config.set("foo.bar", undefined)
 
       expect(observeHandler).toHaveBeenCalledWith(undefined, {previous: 'value 1'})
       observeHandler.reset()
 
-      config.set("foo.bar.baz", "i'm back")
+      atom.config.set("foo.bar.baz", "i'm back")
       expect(observeHandler).toHaveBeenCalledWith("i'm back", {previous: undefined})
 
   describe ".initializeConfigDirectory()", ->
     beforeEach ->
-      config.configDirPath = dotAtomPath
-      expect(fs.existsSync(config.configDirPath)).toBeFalsy()
+      atom.config.configDirPath = dotAtomPath
+      expect(fs.existsSync(atom.config.configDirPath)).toBeFalsy()
 
     afterEach ->
       fs.removeSync(dotAtomPath) if fs.existsSync(dotAtomPath)
@@ -204,94 +204,94 @@ describe "Config", ->
       it "copies the contents of dot-atom to ~/.atom", ->
         initializationDone = false
         jasmine.unspy(window, "setTimeout")
-        config.initializeConfigDirectory ->
+        atom.config.initializeConfigDirectory ->
           initializationDone = true
 
         waitsFor -> initializationDone
 
         runs ->
-          expect(fs.existsSync(config.configDirPath)).toBeTruthy()
-          expect(fs.existsSync(path.join(config.configDirPath, 'packages'))).toBeTruthy()
-          expect(fs.existsSync(path.join(config.configDirPath, 'snippets'))).toBeTruthy()
-          expect(fs.isFileSync(path.join(config.configDirPath, 'config.cson'))).toBeTruthy()
+          expect(fs.existsSync(atom.config.configDirPath)).toBeTruthy()
+          expect(fs.existsSync(path.join(atom.config.configDirPath, 'packages'))).toBeTruthy()
+          expect(fs.existsSync(path.join(atom.config.configDirPath, 'snippets'))).toBeTruthy()
+          expect(fs.isFileSync(path.join(atom.config.configDirPath, 'atom.config.cson'))).toBeTruthy()
 
   describe ".loadUserConfig()", ->
     beforeEach ->
-      config.configDirPath = dotAtomPath
-      config.configFilePath = path.join(config.configDirPath, "config.cson")
-      expect(fs.existsSync(config.configDirPath)).toBeFalsy()
+      atom.config.configDirPath = dotAtomPath
+      atom.config.configFilePath = path.join(atom.config.configDirPath, "atom.config.cson")
+      expect(fs.existsSync(atom.config.configDirPath)).toBeFalsy()
 
     afterEach ->
       fs.removeSync(dotAtomPath) if fs.existsSync(dotAtomPath)
 
     describe "when the config file contains valid cson", ->
       beforeEach ->
-        fs.writeFileSync(config.configFilePath, "foo: bar: 'baz'")
-        config.loadUserConfig()
+        fs.writeFileSync(atom.config.configFilePath, "foo: bar: 'baz'")
+        atom.config.loadUserConfig()
 
       it "updates the config data based on the file contents", ->
-        expect(config.get("foo.bar")).toBe 'baz'
+        expect(atom.config.get("foo.bar")).toBe 'baz'
 
     describe "when the config file contains invalid cson", ->
       beforeEach ->
         spyOn(console, 'error')
-        fs.writeFileSync(config.configFilePath, "{{{{{")
+        fs.writeFileSync(atom.config.configFilePath, "{{{{{")
 
       it "logs an error to the console and does not overwrite the config file on a subsequent save", ->
-        config.loadUserConfig()
+        atom.config.loadUserConfig()
         expect(console.error).toHaveBeenCalled()
-        config.set("hair", "blonde") # trigger a save
-        expect(config.save).not.toHaveBeenCalled()
+        atom.config.set("hair", "blonde") # trigger a save
+        expect(atom.config.save).not.toHaveBeenCalled()
 
     describe "when the config file does not exist", ->
       it "creates it with an empty object", ->
-        fs.makeTreeSync(config.configDirPath)
-        config.loadUserConfig()
-        expect(fs.existsSync(config.configFilePath)).toBe true
-        expect(CSON.readFileSync(config.configFilePath)).toEqual {}
+        fs.makeTreeSync(atom.config.configDirPath)
+        atom.config.loadUserConfig()
+        expect(fs.existsSync(atom.config.configFilePath)).toBe true
+        expect(CSON.readFileSync(atom.config.configFilePath)).toEqual {}
 
   describe ".observeUserConfig()", ->
     updatedHandler = null
 
     beforeEach ->
-      config.configDirPath = dotAtomPath
-      config.configFilePath = path.join(config.configDirPath, "config.cson")
-      expect(fs.existsSync(config.configDirPath)).toBeFalsy()
-      fs.writeFileSync(config.configFilePath, "foo: bar: 'baz'")
-      config.loadUserConfig()
-      config.observeUserConfig()
+      atom.config.configDirPath = dotAtomPath
+      atom.config.configFilePath = path.join(atom.config.configDirPath, "atom.config.cson")
+      expect(fs.existsSync(atom.config.configDirPath)).toBeFalsy()
+      fs.writeFileSync(atom.config.configFilePath, "foo: bar: 'baz'")
+      atom.config.loadUserConfig()
+      atom.config.observeUserConfig()
       updatedHandler = jasmine.createSpy("updatedHandler")
-      config.on 'updated', updatedHandler
+      atom.config.on 'updated', updatedHandler
 
     afterEach ->
-      config.unobserveUserConfig()
+      atom.config.unobserveUserConfig()
       fs.removeSync(dotAtomPath) if fs.existsSync(dotAtomPath)
 
     describe "when the config file changes to contain valid cson", ->
       it "updates the config data", ->
-        fs.writeFileSync(config.configFilePath, "foo: { bar: 'quux', baz: 'bar'}")
+        fs.writeFileSync(atom.config.configFilePath, "foo: { bar: 'quux', baz: 'bar'}")
         waitsFor 'update event', -> updatedHandler.callCount > 0
         runs ->
-          expect(config.get('foo.bar')).toBe 'quux'
-          expect(config.get('foo.baz')).toBe 'bar'
+          expect(atom.config.get('foo.bar')).toBe 'quux'
+          expect(atom.config.get('foo.baz')).toBe 'bar'
 
     describe "when the config file changes to contain invalid cson", ->
       beforeEach ->
         spyOn(console, 'error')
-        fs.writeFileSync(config.configFilePath, "}}}")
+        fs.writeFileSync(atom.config.configFilePath, "}}}")
         waitsFor "error to be logged", -> console.error.callCount > 0
 
       it "logs a warning and does not update config data", ->
         expect(updatedHandler.callCount).toBe 0
-        expect(config.get('foo.bar')).toBe 'baz'
-        config.set("hair", "blonde") # trigger a save
-        expect(config.save).not.toHaveBeenCalled()
+        expect(atom.config.get('foo.bar')).toBe 'baz'
+        atom.config.set("hair", "blonde") # trigger a save
+        expect(atom.config.save).not.toHaveBeenCalled()
 
       describe "when the config file subsequently changes again to contain valid cson", ->
         beforeEach ->
-          fs.writeFileSync(config.configFilePath, "foo: bar: 'baz'")
+          fs.writeFileSync(atom.config.configFilePath, "foo: bar: 'baz'")
           waitsFor 'update event', -> updatedHandler.callCount > 0
 
         it "updates the config data and resumes saving", ->
-          config.set("hair", "blonde")
-          expect(config.save).toHaveBeenCalled()
+          atom.config.set("hair", "blonde")
+          expect(atom.config.save).toHaveBeenCalled()

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -213,7 +213,7 @@ describe "Config", ->
           expect(fs.existsSync(atom.config.configDirPath)).toBeTruthy()
           expect(fs.existsSync(path.join(atom.config.configDirPath, 'packages'))).toBeTruthy()
           expect(fs.existsSync(path.join(atom.config.configDirPath, 'snippets'))).toBeTruthy()
-          expect(fs.isFileSync(path.join(atom.config.configDirPath, 'atom.config.cson'))).toBeTruthy()
+          expect(fs.isFileSync(path.join(atom.config.configDirPath, 'config.cson'))).toBeTruthy()
 
   describe ".loadUserConfig()", ->
     beforeEach ->

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -45,6 +45,24 @@ describe "Config", ->
         config.set('foo.changes', 1)
         expect(config.settings.foo).toEqual {}
 
+  describe ".toggle(keyPath)", ->
+    it "negates the boolean value of the current key path value", ->
+      config.set('foo.a', 1)
+      config.toggle('foo.a')
+      expect(config.get('foo.a')).toBe false
+
+      config.set('foo.a', '')
+      config.toggle('foo.a')
+      expect(config.get('foo.a')).toBe true
+
+      config.set('foo.a', null)
+      config.toggle('foo.a')
+      expect(config.get('foo.a')).toBe true
+
+      config.set('foo.a', true)
+      config.toggle('foo.a')
+      expect(config.get('foo.a')).toBe false
+
   describe ".pushAtKeyPath(keyPath, value)", ->
     it "pushes the given value to the array at the key path and updates observers", ->
       config.set("foo.bar.baz", ["a"])

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -66,14 +66,14 @@ describe "DisplayBuffer", ->
     describe "rendering of soft-wrapped lines", ->
       describe "when editor.softWrapAtPreferredLineLength is set", ->
         it "uses the preferred line length as the soft wrap column when it is less than the configured soft wrap column", ->
-          config.set('editor.preferredLineLength', 100)
-          config.set('editor.softWrapAtPreferredLineLength', true)
+          atom.config.set('editor.preferredLineLength', 100)
+          atom.config.set('editor.softWrapAtPreferredLineLength', true)
           expect(displayBuffer.lineForRow(10).text).toBe '    return '
 
-          config.set('editor.preferredLineLength', 5)
+          atom.config.set('editor.preferredLineLength', 5)
           expect(displayBuffer.lineForRow(10).text).toBe 'funct'
 
-          config.set('editor.softWrapAtPreferredLineLength', false)
+          atom.config.set('editor.softWrapAtPreferredLineLength', false)
           expect(displayBuffer.lineForRow(10).text).toBe '    return '
 
       describe "when the line is shorter than the max line length", ->

--- a/spec/edit-session-spec.coffee
+++ b/spec/edit-session-spec.coffee
@@ -57,17 +57,17 @@ describe "EditSession", ->
 
     describe "config defaults", ->
       it "uses the `editor.tabLength`, `editor.softWrap`, and `editor.softTabs` config values", ->
-        config.set('editor.tabLength', 4)
-        config.set('editor.softWrap', true)
-        config.set('editor.softTabs', false)
+        atom.config.set('editor.tabLength', 4)
+        atom.config.set('editor.softWrap', true)
+        atom.config.set('editor.softTabs', false)
         editSession1 = project.openSync('a')
         expect(editSession1.getTabLength()).toBe 4
         expect(editSession1.getSoftWrap()).toBe true
         expect(editSession1.getSoftTabs()).toBe false
 
-        config.set('editor.tabLength', 100)
-        config.set('editor.softWrap', false)
-        config.set('editor.softTabs', true)
+        atom.config.set('editor.tabLength', 100)
+        atom.config.set('editor.softWrap', false)
+        atom.config.set('editor.softTabs', true)
         editSession2 = project.openSync('b')
         expect(editSession2.getTabLength()).toBe 100
         expect(editSession2.getSoftWrap()).toBe false
@@ -1335,7 +1335,7 @@ describe "EditSession", ->
             expect(editSession.getCursorBufferPosition()).toEqual [0,2]
 
         it "inserts a newline below the cursor's current line, autoindents it, and moves the cursor to the end of the line", ->
-          config.set("editor.autoIndent", true)
+          atom.config.set("editor.autoIndent", true)
           editSession.insertNewlineBelow()
           expect(buffer.lineForRow(0)).toBe "var quicksort = function () {"
           expect(buffer.lineForRow(1)).toBe "  "
@@ -2419,13 +2419,13 @@ describe "EditSession", ->
               editSession.insertText("\n ")
               expect(editSession.lineForBufferRow(2)).toBe " "
 
-              config.set("editor.autoIndent", false)
+              atom.config.set("editor.autoIndent", false)
               editSession.indent()
               expect(editSession.lineForBufferRow(2)).toBe "   "
 
         describe "when editor.autoIndent is true", ->
           beforeEach ->
-            config.set("editor.autoIndent", true)
+            atom.config.set("editor.autoIndent", true)
 
           describe "when `indent` is triggered", ->
             it "auto-indents the line", ->
@@ -2433,7 +2433,7 @@ describe "EditSession", ->
               editSession.insertText("\n ")
               expect(editSession.lineForBufferRow(2)).toBe " "
 
-              config.set("editor.autoIndent", true)
+              atom.config.set("editor.autoIndent", true)
               editSession.indent()
               expect(editSession.lineForBufferRow(2)).toBe "    "
 
@@ -2463,7 +2463,7 @@ describe "EditSession", ->
               editSession.insertText('  var this-line-should-be-indented-more\n')
               expect(editSession.indentationForBufferRow(1)).toBe 1
 
-              config.set("editor.autoIndent", true)
+              atom.config.set("editor.autoIndent", true)
               editSession.setCursorBufferPosition([2, Infinity])
               editSession.insertText('\n')
               expect(editSession.indentationForBufferRow(1)).toBe 1
@@ -2508,11 +2508,11 @@ describe "EditSession", ->
 
       describe "editor.normalizeIndentOnPaste", ->
         beforeEach ->
-          config.set('editor.normalizeIndentOnPaste', true)
+          atom.config.set('editor.normalizeIndentOnPaste', true)
 
         it "does not normalize the indentation level of the text when editor.normalizeIndentOnPaste is false", ->
           copyText("   function() {\nvar cool = 1;\n  }\n")
-          config.set('editor.normalizeIndentOnPaste', false)
+          atom.config.set('editor.normalizeIndentOnPaste', false)
           editSession.setCursorBufferPosition([5, 2])
           editSession.pasteText()
           expect(editSession.lineForBufferRow(5)).toBe "     function() {"

--- a/spec/edit-session-spec.coffee
+++ b/spec/edit-session-spec.coffee
@@ -1823,7 +1823,7 @@ describe "EditSession", ->
                 editSession.cutToEndOfLine()
                 expect(buffer.lineForRow(2)).toBe '    if (items.length'
                 expect(buffer.lineForRow(3)).toBe '    var pivot = item'
-                expect(pasteboard.read()[0]).toBe ' <= 1) return items;\ns.shift(), current, left = [], right = [];'
+                expect(atom.pasteboard.read()[0]).toBe ' <= 1) return items;\ns.shift(), current, left = [], right = [];'
 
             describe "when text is selected", ->
               it "only cuts the selected text, not to the end of the line", ->
@@ -1833,7 +1833,7 @@ describe "EditSession", ->
 
                 expect(buffer.lineForRow(2)).toBe '    if (items.lengthurn items;'
                 expect(buffer.lineForRow(3)).toBe '    var pivot = item'
-                expect(pasteboard.read()[0]).toBe ' <= 1) ret\ns.shift(), current, left = [], right = [];'
+                expect(atom.pasteboard.read()[0]).toBe ' <= 1) ret\ns.shift(), current, left = [], right = [];'
 
         describe ".copySelectedText()", ->
           it "copies selected text onto the clipboard", ->
@@ -1844,7 +1844,7 @@ describe "EditSession", ->
 
         describe ".pasteText()", ->
           it "pastes text into the buffer", ->
-            pasteboard.write('first')
+            atom.pasteboard.write('first')
             editSession.pasteText()
             expect(editSession.buffer.lineForRow(0)).toBe "var first = function () {"
             expect(buffer.lineForRow(1)).toBe "  var first = function(items) {"

--- a/spec/edit-session-spec.coffee
+++ b/spec/edit-session-spec.coffee
@@ -2390,14 +2390,14 @@ describe "EditSession", ->
     describe "when a better-matched grammar is added to syntax", ->
       it "switches to the better-matched grammar and re-tokenizes the buffer", ->
         editSession.destroy()
-        jsGrammar = syntax.selectGrammar('a.js')
-        syntax.removeGrammar(jsGrammar)
+        jsGrammar = atom.syntax.selectGrammar('a.js')
+        atom.syntax.removeGrammar(jsGrammar)
 
         editSession = project.openSync('sample.js', autoIndent: false)
-        expect(editSession.getGrammar()).toBe syntax.nullGrammar
+        expect(editSession.getGrammar()).toBe atom.syntax.nullGrammar
         expect(editSession.lineForScreenRow(0).tokens.length).toBe 1
 
-        syntax.addGrammar(jsGrammar)
+        atom.syntax.addGrammar(jsGrammar)
         expect(editSession.getGrammar()).toBe jsGrammar
         expect(editSession.lineForScreenRow(0).tokens.length).toBeGreaterThan 1
 

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2442,7 +2442,7 @@ describe "Editor", ->
   describe "when editor:copy-path is triggered", ->
     it "copies the absolute path to the editor's file to the pasteboard", ->
       editor.trigger 'editor:copy-path'
-      expect(pasteboard.read()[0]).toBe editor.getPath()
+      expect(atom.pasteboard.read()[0]).toBe editor.getPath()
 
   describe "when editor:move-line-up is triggered", ->
     describe "when there is no selection", ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1925,7 +1925,7 @@ describe "Editor", ->
         miniEditor = new Editor(mini: true)
         miniEditor.setText("var something")
         previousTokens = miniEditor.lineForScreenRow(0).tokens
-        miniEditor.setGrammar(syntax.selectGrammar('something.js'))
+        miniEditor.setGrammar(atom.syntax.selectGrammar('something.js'))
         expect(miniEditor.getGrammar().name).toBe "JavaScript"
         expect(previousTokens).not.toEqual miniEditor.lineForScreenRow(0).tokens
 
@@ -2357,7 +2357,7 @@ describe "Editor", ->
     it "updates all the rendered lines when the grammar changes", ->
       editor.edit(project.openSync(filePath))
       expect(editor.getGrammar().name).toBe 'Plain Text'
-      syntax.setGrammarOverrideForPath(filePath, 'source.js')
+      atom.syntax.setGrammarOverrideForPath(filePath, 'source.js')
       editor.reloadGrammar()
       expect(editor.getGrammar().name).toBe 'JavaScript'
 
@@ -2383,7 +2383,7 @@ describe "Editor", ->
 
       expect(eventHandler).not.toHaveBeenCalled()
 
-      syntax.setGrammarOverrideForPath(filePath, 'source.js')
+      atom.syntax.setGrammarOverrideForPath(filePath, 'source.js')
       editor.reloadGrammar()
       expect(eventHandler).toHaveBeenCalled()
 

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -310,7 +310,7 @@ describe "Editor", ->
         charWidthBefore = editor.charWidth
         editor.setCursorScreenPosition [5, 6]
 
-        config.set("editor.fontFamily", fontFamily)
+        atom.config.set("editor.fontFamily", fontFamily)
         expect(editor.css('font-family')).toBe fontFamily
         expect(editor.charWidth).not.toBe charWidthBefore
         expect(editor.getCursorView().position()).toEqual { top: 5 * editor.lineHeight, left: 6 * editor.charWidth }
@@ -325,17 +325,17 @@ describe "Editor", ->
       expect(editor.css('font-size')).not.toBe "10px"
 
     it "sets the initial font size based on the value from config", ->
-      expect(editor.css('font-size')).toBe "#{config.get('editor.fontSize')}px"
+      expect(editor.css('font-size')).toBe "#{atom.config.get('editor.fontSize')}px"
 
     describe "when the font size changes", ->
       it "updates the font sizes of editors and recalculates dimensions critical to cursor positioning", ->
-        config.set("editor.fontSize", 10)
+        atom.config.set("editor.fontSize", 10)
         editor.attachToDom()
         lineHeightBefore = editor.lineHeight
         charWidthBefore = editor.charWidth
         editor.setCursorScreenPosition [5, 6]
 
-        config.set("editor.fontSize", 30)
+        atom.config.set("editor.fontSize", 30)
         expect(editor.css('font-size')).toBe '30px'
         expect(editor.lineHeight).toBeGreaterThan lineHeightBefore
         expect(editor.charWidth).toBeGreaterThan charWidthBefore
@@ -349,11 +349,11 @@ describe "Editor", ->
         expect(newEditor.css('font-size')).toBe '30px'
 
       it "updates the position and size of selection regions", ->
-        config.set("editor.fontSize", 10)
+        atom.config.set("editor.fontSize", 10)
         editor.setSelectedBufferRange([[5, 2], [5, 7]])
         editor.attachToDom()
 
-        config.set("editor.fontSize", 30)
+        atom.config.set("editor.fontSize", 30)
         selectionRegion = editor.find('.region')
         expect(selectionRegion.position().top).toBe 5 * editor.lineHeight
         expect(selectionRegion.position().left).toBe 2 * editor.charWidth
@@ -365,7 +365,7 @@ describe "Editor", ->
         originalLineCount = editor.renderedLines.find(".line").length
         expect(originalLineCount).toBeGreaterThan 0
 
-        config.set("editor.fontSize", 10)
+        atom.config.set("editor.fontSize", 10)
         expect(editor.renderedLines.find(".line").length).toBeGreaterThan originalLineCount
 
       describe "when the font size changes while editor is detached", ->
@@ -378,7 +378,7 @@ describe "Editor", ->
           initialScrollbarHeight = editor.verticalScrollbarContent.height()
           editor.detach()
 
-          config.set("editor.fontSize", 10)
+          atom.config.set("editor.fontSize", 10)
           expect(editor.lineHeight).toBe initialLineHeight
           expect(editor.charWidth).toBe initialCharWidth
 
@@ -1482,15 +1482,15 @@ describe "Editor", ->
         buffer.insert([0, 0], "–")
         expect(editor.find('.line:eq(0)').outerHeight()).toBe editor.find('.line:eq(1)').outerHeight()
 
-    describe "when config.editor.showInvisibles is set to true", ->
+    describe "when editor.showInvisibles config is set to true", ->
       it "displays spaces, tabs, and newlines using visible non-empty values", ->
         editor.setText " a line with tabs\tand spaces "
         editor.attachToDom()
 
-        expect(config.get("editor.showInvisibles")).toBeFalsy()
+        expect(atom.config.get("editor.showInvisibles")).toBeFalsy()
         expect(editor.renderedLines.find('.line').text()).toBe " a line with tabs  and spaces "
 
-        config.set("editor.showInvisibles", true)
+        atom.config.set("editor.showInvisibles", true)
         space = editor.invisibles?.space
         expect(space).toBeTruthy()
         tab = editor.invisibles?.tab
@@ -1499,7 +1499,7 @@ describe "Editor", ->
         expect(eol).toBeTruthy()
         expect(editor.renderedLines.find('.line').text()).toBe "#{space}a line with tabs#{tab} and spaces#{space}#{eol}"
 
-        config.set("editor.showInvisibles", false)
+        atom.config.set("editor.showInvisibles", false)
         expect(editor.renderedLines.find('.line').text()).toBe " a line with tabs  and spaces "
 
       it "displays newlines as their own token outside of the other tokens scope", ->
@@ -1508,21 +1508,21 @@ describe "Editor", ->
         editor.setText "var"
         expect(editor.find('.line').html()).toBe '<span class="source js"><span class="storage modifier js">var</span></span><span class="invisible-character">¬</span>'
 
-      it "allows invisible glyphs to be customized via config.editor.invisibles", ->
+      it "allows invisible glyphs to be customized via the editor.invisibles config", ->
         editor.setText(" \t ")
         editor.attachToDom()
-        config.set("editor.showInvisibles", true)
-        config.set("editor.invisibles", eol: ";", space: "_", tab: "tab")
+        atom.config.set("editor.showInvisibles", true)
+        atom.config.set("editor.invisibles", eol: ";", space: "_", tab: "tab")
         expect(editor.find(".line:first").text()).toBe "_tab _;"
 
       it "displays trailing carriage return using a visible non-empty value", ->
         editor.setText "a line that ends with a carriage return\r\n"
         editor.attachToDom()
 
-        expect(config.get("editor.showInvisibles")).toBeFalsy()
+        expect(atom.config.get("editor.showInvisibles")).toBeFalsy()
         expect(editor.renderedLines.find('.line:first').text()).toBe "a line that ends with a carriage return"
 
-        config.set("editor.showInvisibles", true)
+        atom.config.set("editor.showInvisibles", true)
         cr = editor.invisibles?.cr
         expect(cr).toBeTruthy()
         eol = editor.invisibles?.eol
@@ -1537,7 +1537,7 @@ describe "Editor", ->
           editor.setText "a line that wraps"
           editor.attachToDom()
           editor.setWidthInChars(6)
-          config.set "editor.showInvisibles", true
+          atom.config.set "editor.showInvisibles", true
           space = editor.invisibles?.space
           expect(space).toBeTruthy()
           eol = editor.invisibles?.eol
@@ -1549,7 +1549,7 @@ describe "Editor", ->
           editor.setText "a line that\r\n"
           editor.attachToDom()
           editor.setWidthInChars(6)
-          config.set "editor.showInvisibles", true
+          atom.config.set "editor.showInvisibles", true
           space = editor.invisibles?.space
           expect(space).toBeTruthy()
           cr = editor.invisibles?.cr
@@ -1560,12 +1560,12 @@ describe "Editor", ->
           expect(editor.renderedLines.find('.line:eq(1)').text()).toBe "that#{cr}#{eol}"
           expect(editor.renderedLines.find('.line:last').text()).toBe "#{eol}"
 
-    describe "when config.editor.showIndentGuide is set to true", ->
+    describe "when editor.showIndentGuide is set to true", ->
       it "adds an indent-guide class to each leading whitespace span", ->
         editor.attachToDom()
 
-        expect(config.get("editor.showIndentGuide")).toBeFalsy()
-        config.set("editor.showIndentGuide", true)
+        expect(atom.config.get("editor.showIndentGuide")).toBeFalsy()
+        atom.config.set("editor.showIndentGuide", true)
         expect(editor.showIndentGuide).toBeTruthy()
 
         expect(editor.renderedLines.find('.line:eq(0) .indent-guide').length).toBe 0
@@ -1608,7 +1608,7 @@ describe "Editor", ->
       describe "when the indentation level on a line before an empty line is changed", ->
         it "updates the indent guide on the empty line", ->
           editor.attachToDom()
-          config.set("editor.showIndentGuide", true)
+          atom.config.set("editor.showIndentGuide", true)
 
           expect(editor.renderedLines.find('.line:eq(10) .indent-guide').length).toBe 1
           expect(editor.renderedLines.find('.line:eq(10) .indent-guide').text()).toBe '  '
@@ -1622,7 +1622,7 @@ describe "Editor", ->
       describe "when the indentation level on a line after an empty line is changed", ->
         it "updates the indent guide on the empty line", ->
           editor.attachToDom()
-          config.set("editor.showIndentGuide", true)
+          atom.config.set("editor.showIndentGuide", true)
 
           expect(editor.renderedLines.find('.line:eq(10) .indent-guide').length).toBe 1
           expect(editor.renderedLines.find('.line:eq(10) .indent-guide').text()).toBe '  '
@@ -1636,7 +1636,7 @@ describe "Editor", ->
       describe "when a line contains only whitespace", ->
         it "displays an indent guide on the line", ->
           editor.attachToDom()
-          config.set("editor.showIndentGuide", true)
+          atom.config.set("editor.showIndentGuide", true)
 
           editor.setCursorBufferPosition([10])
           editor.indent()
@@ -1647,7 +1647,7 @@ describe "Editor", ->
 
         it "uses the highest indent guide level from the next or previous non-empty line", ->
           editor.attachToDom()
-          config.set("editor.showIndentGuide", true)
+          atom.config.set("editor.showIndentGuide", true)
 
           editor.setCursorBufferPosition([1, Infinity])
           editor.insertNewline()
@@ -1658,7 +1658,7 @@ describe "Editor", ->
       describe "when the line has leading and trailing whitespace", ->
         it "does not display the indent guide in the trailing whitespace", ->
           editor.attachToDom()
-          config.set("editor.showIndentGuide", true)
+          atom.config.set("editor.showIndentGuide", true)
 
           editor.insertText("/*\n * \n*/")
           expect(editor.renderedLines.find('.line:eq(1) .indent-guide').length).toBe 1
@@ -1667,8 +1667,8 @@ describe "Editor", ->
       describe "when the line is empty and end of show invisibles are enabled", ->
         it "renders the indent guides interleaved with the end of line invisibles", ->
           editor.attachToDom()
-          config.set("editor.showIndentGuide", true)
-          config.set("editor.showInvisibles", true)
+          atom.config.set("editor.showIndentGuide", true)
+          atom.config.set("editor.showInvisibles", true)
           eol = editor.invisibles?.eol
 
           expect(editor.renderedLines.find('.line:eq(10) .indent-guide').length).toBe 1
@@ -1903,7 +1903,7 @@ describe "Editor", ->
         expect(miniEditor.find('.line.cursor-line').length).toBe 0
 
       it "doesn't show the end of line invisible", ->
-        config.set "editor.showInvisibles", true
+        atom.config.set "editor.showInvisibles", true
         miniEditor = new Editor(mini: true)
         miniEditor.attachToDom()
         space = miniEditor.invisibles?.space
@@ -1914,7 +1914,7 @@ describe "Editor", ->
         expect(miniEditor.renderedLines.find('.line').text()).toBe "#{space}a line with tabs#{tab} and spaces#{space}"
 
       it "doesn't show the indent guide", ->
-        config.set "editor.showIndentGuide", true
+        atom.config.set "editor.showIndentGuide", true
         miniEditor = new Editor(mini: true)
         miniEditor.attachToDom()
         miniEditor.setText("      and indented line")
@@ -1932,10 +1932,10 @@ describe "Editor", ->
         # doesn't allow regular editors to set grammars
         expect(-> editor.setGrammar()).toThrow()
 
-    describe "when config.editor.showLineNumbers is false", ->
+    describe "when the editor.showLineNumbers config is false", ->
       it "doesn't render any line numbers", ->
         expect(editor.gutter.lineNumbers).toBeVisible()
-        config.set("editor.showLineNumbers", false)
+        atom.config.set("editor.showLineNumbers", false)
         expect(editor.gutter.lineNumbers).not.toBeVisible()
 
     describe "using gutter's api", ->

--- a/spec/keymap-spec.coffee
+++ b/spec/keymap-spec.coffee
@@ -9,6 +9,8 @@ describe "Keymap", ->
 
   beforeEach ->
     keymap = new Keymap
+      resourcePath: window.resourcePath
+      configDirPath: atom.getConfigDirPath()
     fragment = $ """
       <div class="command-mode">
         <div class="child-node">

--- a/spec/pasteboard-spec.coffee
+++ b/spec/pasteboard-spec.coffee
@@ -1,10 +1,10 @@
 describe "Pasteboard", ->
   describe "write(text, metadata) and read()", ->
     it "writes and reads text to/from the native pasteboard", ->
-      expect(pasteboard.read()).toEqual ['initial pasteboard content']
-      pasteboard.write('next')
-      expect(pasteboard.read()[0]).toBe 'next'
+      expect(atom.pasteboard.read()).toEqual ['initial pasteboard content']
+      atom.pasteboard.write('next')
+      expect(atom.pasteboard.read()[0]).toBe 'next'
 
     it "returns metadata if the item on the native pasteboard matches the last written item", ->
-      pasteboard.write('next', {meta: 'data'})
-      expect(pasteboard.read()).toEqual ['next', {meta: 'data'}]
+      atom.pasteboard.write('next', {meta: 'data'})
+      expect(atom.pasteboard.read()).toEqual ['next', {meta: 'data'}]

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -449,7 +449,7 @@ describe "Project", ->
 
         it "excludes ignored files", ->
           project.setPath(projectPath)
-          config.set('core.excludeVcsIgnoredPaths', true)
+          atom.config.set('core.excludeVcsIgnoredPaths', true)
           resultHandler = jasmine.createSpy("result found")
           waitsForPromise ->
             project.scan /match/, (results) ->
@@ -495,9 +495,9 @@ describe "Project", ->
 
       it "excludes values in core.ignoredNames", ->
         projectPath = path.join(__dirname, 'fixtures', 'git', 'working-dir')
-        ignoredNames = config.get("core.ignoredNames")
+        ignoredNames = atom.config.get("core.ignoredNames")
         ignoredNames.push("a")
-        config.set("core.ignoredNames", ignoredNames)
+        atom.config.set("core.ignoredNames", ignoredNames)
 
         resultHandler = jasmine.createSpy("result found")
         waitsForPromise ->

--- a/spec/root-view-spec.coffee
+++ b/spec/root-view-spec.coffee
@@ -195,20 +195,20 @@ describe "RootView", ->
 
   describe "font size adjustment", ->
     it "increases/decreases font size when increase/decrease-font-size events are triggered", ->
-      fontSizeBefore = config.get('editor.fontSize')
+      fontSizeBefore = atom.config.get('editor.fontSize')
       rootView.trigger 'window:increase-font-size'
-      expect(config.get('editor.fontSize')).toBe fontSizeBefore + 1
+      expect(atom.config.get('editor.fontSize')).toBe fontSizeBefore + 1
       rootView.trigger 'window:increase-font-size'
-      expect(config.get('editor.fontSize')).toBe fontSizeBefore + 2
+      expect(atom.config.get('editor.fontSize')).toBe fontSizeBefore + 2
       rootView.trigger 'window:decrease-font-size'
-      expect(config.get('editor.fontSize')).toBe fontSizeBefore + 1
+      expect(atom.config.get('editor.fontSize')).toBe fontSizeBefore + 1
       rootView.trigger 'window:decrease-font-size'
-      expect(config.get('editor.fontSize')).toBe fontSizeBefore
+      expect(atom.config.get('editor.fontSize')).toBe fontSizeBefore
 
     it "does not allow the font size to be less than 1", ->
-      config.set("editor.fontSize", 1)
+      atom.config.set("editor.fontSize", 1)
       rootView.trigger 'window:decrease-font-size'
-      expect(config.get('editor.fontSize')).toBe 1
+      expect(atom.config.get('editor.fontSize')).toBe 1
 
   describe ".openSync(filePath, options)", ->
     describe "when there is no active pane", ->

--- a/spec/root-view-spec.coffee
+++ b/spec/root-view-spec.coffee
@@ -136,7 +136,7 @@ describe "RootView", ->
       commandHandler = jasmine.createSpy('commandHandler')
       rootView.on('foo-command', commandHandler)
 
-      window.keymap.bindKeys('*', 'x': 'foo-command')
+      atom.keymap.bindKeys('*', 'x': 'foo-command')
 
     describe "when a keydown event is triggered in the RootView", ->
       it "triggers matching keybindings for that event", ->

--- a/spec/space-pen-extensions-spec.coffee
+++ b/spec/space-pen-extensions-spec.coffee
@@ -23,21 +23,21 @@ describe "SpacePen extensions", ->
       expect(observeHandler).toHaveBeenCalledWith(undefined)
       observeHandler.reset()
 
-      config.set("foo.bar", "hello")
+      atom.config.set("foo.bar", "hello")
 
       expect(observeHandler).toHaveBeenCalledWith("hello", previous: undefined)
       observeHandler.reset()
 
       view.unobserveConfig()
 
-      config.set("foo.bar", "goodbye")
+      atom.config.set("foo.bar", "goodbye")
 
       expect(observeHandler).not.toHaveBeenCalled()
 
     it "unobserves when the view is removed", ->
       observeHandler.reset()
       parent.remove()
-      config.set("foo.bar", "hello")
+      atom.config.set("foo.bar", "hello")
       expect(observeHandler).not.toHaveBeenCalled()
 
   describe "View.subscribe(eventEmitter, eventName, callback)", ->

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -77,15 +77,15 @@ beforeEach ->
   config = new Config
     resourcePath: window.resourcePath
     configDirPath: atom.getConfigDirPath()
-  config.packageDirPaths.unshift(fixturePackagesPath)
+  atom.config.packageDirPaths.unshift(fixturePackagesPath)
   spyOn(config, 'load')
   spyOn(config, 'save')
-  config.set "editor.fontFamily", "Courier"
-  config.set "editor.fontSize", 16
-  config.set "editor.autoIndent", false
-  config.set "core.disabledPackages", ["package-that-throws-an-exception",
+  atom.config.set "editor.fontFamily", "Courier"
+  atom.config.set "editor.fontSize", 16
+  atom.config.set "editor.autoIndent", false
+  atom.config.set "core.disabledPackages", ["package-that-throws-an-exception",
     "package-with-broken-package-json", "package-with-broken-keymap"]
-  config.save.reset()
+  atom.config.save.reset()
   atom.config = config
   window.config = config
 

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -67,8 +67,8 @@ beforeEach ->
   resolvePackagePath = _.bind(spy.originalValue, atom.packages)
 
   # used to reset keymap after each spec
-  bindingSetsToRestore = _.clone(keymap.bindingSets)
-  bindingSetsByFirstKeystrokeToRestore = _.clone(keymap.bindingSetsByFirstKeystroke)
+  bindingSetsToRestore = _.clone(atom.keymap.bindingSets)
+  bindingSetsByFirstKeystrokeToRestore = _.clone(atom.keymap.bindingSetsByFirstKeystroke)
 
   # prevent specs from modifying Atom's menus
   spyOn(atom.menu, 'sendToBrowserProcess')
@@ -107,8 +107,8 @@ beforeEach ->
   addCustomMatchers(this)
 
 afterEach ->
-  keymap.bindingSets = bindingSetsToRestore
-  keymap.bindingSetsByFirstKeystroke = bindingSetsByFirstKeystrokeToRestore
+  atom.keymap.bindingSets = bindingSetsToRestore
+  atom.keymap.bindingSetsByFirstKeystroke = bindingSetsByFirstKeystrokeToRestore
   atom.deactivatePackages()
   atom.menu.template = []
 
@@ -265,7 +265,7 @@ $.fn.resultOfTrigger = (type) ->
   event.result
 
 $.fn.enableKeymap = ->
-  @on 'keydown', (e) => window.keymap.handleKeyEvent(e)
+  @on 'keydown', (e) => atom.keymap.handleKeyEvent(e)
 
 $.fn.attachToDom = ->
   @appendTo($('#jasmine-content'))

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -77,15 +77,15 @@ beforeEach ->
   config = new Config
     resourcePath: window.resourcePath
     configDirPath: atom.getConfigDirPath()
-  atom.config.packageDirPaths.unshift(fixturePackagesPath)
+  config.packageDirPaths.unshift(fixturePackagesPath)
   spyOn(config, 'load')
   spyOn(config, 'save')
-  atom.config.set "editor.fontFamily", "Courier"
-  atom.config.set "editor.fontSize", 16
-  atom.config.set "editor.autoIndent", false
-  atom.config.set "core.disabledPackages", ["package-that-throws-an-exception",
+  config.set "editor.fontFamily", "Courier"
+  config.set "editor.fontSize", 16
+  config.set "editor.autoIndent", false
+  config.set "core.disabledPackages", ["package-that-throws-an-exception",
     "package-with-broken-package-json", "package-with-broken-keymap"]
-  atom.config.save.reset()
+  config.save.reset()
   atom.config = config
   window.config = config
 

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -1,6 +1,6 @@
 require '../src/window'
 window.setUpEnvironment('spec')
-window.restoreDimensions()
+atom.restoreDimensions()
 
 require '../vendor/jasmine-jquery'
 path = require 'path'

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -126,7 +126,7 @@ afterEach ->
   delete atom.windowState
   jasmine.unspy(atom, 'saveWindowState')
   ensureNoPathSubscriptions()
-  syntax.off()
+  atom.syntax.off()
   waits(0) # yield to ui thread to make screen update more frequently
 
 ensureNoPathSubscriptions = ->

--- a/spec/syntax-spec.coffee
+++ b/spec/syntax-spec.coffee
@@ -13,52 +13,52 @@ describe "the `syntax` global", ->
   describe "serialization", ->
     it "remembers grammar overrides by path", ->
       filePath = '/foo/bar/file.js'
-      expect(syntax.selectGrammar(filePath).name).not.toBe 'Ruby'
-      syntax.setGrammarOverrideForPath(filePath, 'source.ruby')
-      syntax2 = deserialize(syntax.serialize())
-      syntax2.addGrammar(grammar) for grammar in syntax.grammars when grammar isnt syntax.nullGrammar
+      expect(atom.syntax.selectGrammar(filePath).name).not.toBe 'Ruby'
+      atom.syntax.setGrammarOverrideForPath(filePath, 'source.ruby')
+      syntax2 = deserialize(atom.syntax.serialize())
+      syntax2.addGrammar(grammar) for grammar in atom.syntax.grammars when grammar isnt atom.syntax.nullGrammar
       expect(syntax2.selectGrammar(filePath).name).toBe 'Ruby'
 
   describe ".selectGrammar(filePath)", ->
     it "can use the filePath to load the correct grammar based on the grammar's filetype", ->
       atom.activatePackage('language-git', sync: true)
 
-      expect(syntax.selectGrammar("file.js").name).toBe "JavaScript" # based on extension (.js)
-      expect(syntax.selectGrammar(path.join(temp.dir, '.git', 'config')).name).toBe "Git Config" # based on end of the path (.git/config)
-      expect(syntax.selectGrammar("Rakefile").name).toBe "Ruby" # based on the file's basename (Rakefile)
-      expect(syntax.selectGrammar("curb").name).toBe "Null Grammar"
-      expect(syntax.selectGrammar("/hu.git/config").name).toBe "Null Grammar"
+      expect(atom.syntax.selectGrammar("file.js").name).toBe "JavaScript" # based on extension (.js)
+      expect(atom.syntax.selectGrammar(path.join(temp.dir, '.git', 'config')).name).toBe "Git Config" # based on end of the path (.git/config)
+      expect(atom.syntax.selectGrammar("Rakefile").name).toBe "Ruby" # based on the file's basename (Rakefile)
+      expect(atom.syntax.selectGrammar("curb").name).toBe "Null Grammar"
+      expect(atom.syntax.selectGrammar("/hu.git/config").name).toBe "Null Grammar"
 
     it "uses the filePath's shebang line if the grammar cannot be determined by the extension or basename", ->
       filePath = require.resolve("./fixtures/shebang")
-      expect(syntax.selectGrammar(filePath).name).toBe "Ruby"
+      expect(atom.syntax.selectGrammar(filePath).name).toBe "Ruby"
 
     it "uses the number of newlines in the first line regex to determine the number of lines to test against", ->
       atom.activatePackage('language-property-list', sync: true)
 
       fileContent = "first-line\n<html>"
-      expect(syntax.selectGrammar("dummy.coffee", fileContent).name).toBe "CoffeeScript"
+      expect(atom.syntax.selectGrammar("dummy.coffee", fileContent).name).toBe "CoffeeScript"
 
       fileContent = '<?xml version="1.0" encoding="UTF-8"?>'
-      expect(syntax.selectGrammar("grammar.tmLanguage", fileContent).name).toBe "Null Grammar"
+      expect(atom.syntax.selectGrammar("grammar.tmLanguage", fileContent).name).toBe "Null Grammar"
 
       fileContent += '\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
-      expect(syntax.selectGrammar("grammar.tmLanguage", fileContent).name).toBe "Property List (XML)"
+      expect(atom.syntax.selectGrammar("grammar.tmLanguage", fileContent).name).toBe "Property List (XML)"
 
     it "doesn't read the file when the file contents are specified", ->
       filePath = require.resolve("./fixtures/shebang")
       filePathContents = fs.readFileSync(filePath, 'utf8')
       spyOn(fs, 'read').andCallThrough()
-      expect(syntax.selectGrammar(filePath, filePathContents).name).toBe "Ruby"
+      expect(atom.syntax.selectGrammar(filePath, filePathContents).name).toBe "Ruby"
       expect(fs.read).not.toHaveBeenCalled()
 
     it "allows the default grammar to be overridden for a path", ->
       filePath = '/foo/bar/file.js'
-      expect(syntax.selectGrammar(filePath).name).not.toBe 'Ruby'
-      syntax.setGrammarOverrideForPath(filePath, 'source.ruby')
-      expect(syntax.selectGrammar(filePath).name).toBe 'Ruby'
-      syntax.clearGrammarOverrideForPath(filePath)
-      expect(syntax.selectGrammar(filePath).name).not.toBe 'Ruby'
+      expect(atom.syntax.selectGrammar(filePath).name).not.toBe 'Ruby'
+      atom.syntax.setGrammarOverrideForPath(filePath, 'source.ruby')
+      expect(atom.syntax.selectGrammar(filePath).name).toBe 'Ruby'
+      atom.syntax.clearGrammarOverrideForPath(filePath)
+      expect(atom.syntax.selectGrammar(filePath).name).not.toBe 'Ruby'
 
     describe "when multiple grammars have matching fileTypes", ->
       it "selects the grammar with the longest fileType match", ->
@@ -72,46 +72,46 @@ describe "the `syntax` global", ->
           scopeName: 'source2'
           fileTypes: ['test']
 
-        syntax.addGrammar(grammar1)
-        syntax.addGrammar(grammar2)
+        atom.syntax.addGrammar(grammar1)
+        atom.syntax.addGrammar(grammar2)
 
-        expect(syntax.selectGrammar('more.test', '')).toBe grammar1
+        expect(atom.syntax.selectGrammar('more.test', '')).toBe grammar1
 
     describe "when there is no file path", ->
       it "does not throw an exception (regression)", ->
-        expect(-> syntax.selectGrammar(null, '#!/usr/bin/ruby')).not.toThrow()
-        expect(-> syntax.selectGrammar(null, '')).not.toThrow()
-        expect(-> syntax.selectGrammar(null, null)).not.toThrow()
+        expect(-> atom.syntax.selectGrammar(null, '#!/usr/bin/ruby')).not.toThrow()
+        expect(-> atom.syntax.selectGrammar(null, '')).not.toThrow()
+        expect(-> atom.syntax.selectGrammar(null, null)).not.toThrow()
 
   describe ".removeGrammar(grammar)", ->
     it "removes the grammar, so it won't be returned by selectGrammar", ->
-      grammar = syntax.selectGrammar('foo.js')
-      syntax.removeGrammar(grammar)
-      expect(syntax.selectGrammar('foo.js').name).not.toBe grammar.name
+      grammar = atom.syntax.selectGrammar('foo.js')
+      atom.syntax.removeGrammar(grammar)
+      expect(atom.syntax.selectGrammar('foo.js').name).not.toBe grammar.name
 
   describe ".getProperty(scopeDescriptor)", ->
     it "returns the property with the most specific scope selector", ->
-      syntax.addProperties(".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
-      syntax.addProperties(".source .string.quoted.double", foo: bar: baz: 22)
-      syntax.addProperties(".source", foo: bar: baz: 11)
+      atom.syntax.addProperties(".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
+      atom.syntax.addProperties(".source .string.quoted.double", foo: bar: baz: 22)
+      atom.syntax.addProperties(".source", foo: bar: baz: 11)
 
-      expect(syntax.getProperty([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
-      expect(syntax.getProperty([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBe 22
-      expect(syntax.getProperty([".source.js", ".variable.assignment.js"], "foo.bar.baz")).toBe 11
-      expect(syntax.getProperty([".text"], "foo.bar.baz")).toBeUndefined()
+      expect(atom.syntax.getProperty([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
+      expect(atom.syntax.getProperty([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBe 22
+      expect(atom.syntax.getProperty([".source.js", ".variable.assignment.js"], "foo.bar.baz")).toBe 11
+      expect(atom.syntax.getProperty([".text"], "foo.bar.baz")).toBeUndefined()
 
     it "favors the most recently added properties in the event of a specificity tie", ->
-      syntax.addProperties(".source.coffee .string.quoted.single", foo: bar: baz: 42)
-      syntax.addProperties(".source.coffee .string.quoted.double", foo: bar: baz: 22)
+      atom.syntax.addProperties(".source.coffee .string.quoted.single", foo: bar: baz: 42)
+      atom.syntax.addProperties(".source.coffee .string.quoted.double", foo: bar: baz: 22)
 
-      expect(syntax.getProperty([".source.coffee", ".string.quoted.single"], "foo.bar.baz")).toBe 42
-      expect(syntax.getProperty([".source.coffee", ".string.quoted.single.double"], "foo.bar.baz")).toBe 22
+      expect(atom.syntax.getProperty([".source.coffee", ".string.quoted.single"], "foo.bar.baz")).toBe 42
+      expect(atom.syntax.getProperty([".source.coffee", ".string.quoted.single.double"], "foo.bar.baz")).toBe 22
 
   describe ".removeProperties(name)", ->
     it "allows properties to be removed by name", ->
-      syntax.addProperties("a", ".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
-      syntax.addProperties("b", ".source .string.quoted.double", foo: bar: baz: 22)
+      atom.syntax.addProperties("a", ".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
+      atom.syntax.addProperties("b", ".source .string.quoted.double", foo: bar: baz: 22)
 
-      syntax.removeProperties("b")
-      expect(syntax.getProperty([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBeUndefined()
-      expect(syntax.getProperty([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
+      atom.syntax.removeProperties("b")
+      expect(atom.syntax.getProperty([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBeUndefined()
+      expect(atom.syntax.getProperty([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42

--- a/spec/text-mate-grammar-spec.coffee
+++ b/spec/text-mate-grammar-spec.coffee
@@ -13,7 +13,7 @@ describe "TextMateGrammar", ->
     atom.activatePackage('language-html', sync: true)
     atom.activatePackage('language-php', sync: true)
     atom.activatePackage('language-python', sync: true)
-    grammar = syntax.selectGrammar("hello.coffee")
+    grammar = atom.syntax.selectGrammar("hello.coffee")
 
   describe "@loadSync(path)", ->
     it "loads grammars from plists", ->
@@ -49,7 +49,7 @@ describe "TextMateGrammar", ->
 
     describe "when the line doesn't match any patterns", ->
       it "returns the entire line as a single simple token with the grammar's scope", ->
-        textGrammar = syntax.selectGrammar('foo.txt')
+        textGrammar = atom.syntax.selectGrammar('foo.txt')
         {tokens} = textGrammar.tokenizeLine("abc def")
         expect(tokens.length).toBe 1
 
@@ -126,20 +126,20 @@ describe "TextMateGrammar", ->
 
     describe "when the line matches no patterns", ->
       it "does not infinitely loop", ->
-        grammar = syntax.selectGrammar("sample.txt")
+        grammar = atom.syntax.selectGrammar("sample.txt")
         {tokens} = grammar.tokenizeLine('hoo')
         expect(tokens.length).toBe 1
         expect(tokens[0]).toEqual value: 'hoo',  scopes: ["text.plain", "meta.paragraph.text"]
 
     describe "when the line matches a pattern with a 'contentName'", ->
       it "creates tokens using the content of contentName as the token name", ->
-        grammar = syntax.selectGrammar("sample.txt")
+        grammar = atom.syntax.selectGrammar("sample.txt")
         {tokens} = grammar.tokenizeLine('ok, cool')
         expect(tokens[0]).toEqual value: 'ok, cool',  scopes: ["text.plain", "meta.paragraph.text"]
 
     describe "when the line matches a pattern with no `name` or `contentName`", ->
       it "creates tokens without adding a new scope", ->
-        grammar = syntax.selectGrammar('foo.rb')
+        grammar = atom.syntax.selectGrammar('foo.rb')
         {tokens} = grammar.tokenizeLine('%w|oh \\look|')
         expect(tokens.length).toBe 5
         expect(tokens[0]).toEqual value: '%w|',  scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby", "punctuation.definition.string.begin.ruby"]
@@ -184,7 +184,7 @@ describe "TextMateGrammar", ->
 
       describe "when the end pattern contains a back reference", ->
         it "constructs the end rule based on its back-references to captures in the begin rule", ->
-          grammar = syntax.selectGrammar('foo.rb')
+          grammar = atom.syntax.selectGrammar('foo.rb')
           {tokens} = grammar.tokenizeLine('%w|oh|,')
           expect(tokens.length).toBe 4
           expect(tokens[0]).toEqual value: '%w|',  scopes: ["source.ruby", "string.quoted.other.literal.lower.ruby", "punctuation.definition.string.begin.ruby"]
@@ -193,7 +193,7 @@ describe "TextMateGrammar", ->
           expect(tokens[3]).toEqual value: ',',  scopes: ["source.ruby", "punctuation.separator.object.ruby"]
 
         it "allows the rule containing that end pattern to be pushed to the stack multiple times", ->
-          grammar = syntax.selectGrammar('foo.rb')
+          grammar = atom.syntax.selectGrammar('foo.rb')
           {tokens} = grammar.tokenizeLine('%Q+matz had some #{%Q-crazy ideas-} for ruby syntax+ # damn.')
           expect(tokens[0]).toEqual value: '%Q+', scopes: ["source.ruby","string.quoted.other.literal.upper.ruby","punctuation.definition.string.begin.ruby"]
           expect(tokens[1]).toEqual value: 'matz had some ', scopes: ["source.ruby","string.quoted.other.literal.upper.ruby"]
@@ -214,7 +214,7 @@ describe "TextMateGrammar", ->
             atom.activatePackage('language-html', sync: true)
             atom.activatePackage('language-ruby-on-rails', sync: true)
 
-            grammar = syntax.grammarForScopeName('text.html.ruby')
+            grammar = atom.syntax.grammarForScopeName('text.html.ruby')
             {tokens} = grammar.tokenizeLine("<div class='name'><%= User.find(2).full_name %></div>")
 
             expect(tokens[0]).toEqual value: '<', scopes: ["text.html.ruby","meta.tag.block.any.html","punctuation.definition.tag.begin.html"]
@@ -245,7 +245,7 @@ describe "TextMateGrammar", ->
             atom.activatePackage('language-html', sync: true)
             atom.activatePackage('language-ruby-on-rails', sync: true)
 
-            grammar = syntax.selectGrammar('foo.html.erb')
+            grammar = atom.syntax.selectGrammar('foo.html.erb')
             grammarUpdatedHandler = jasmine.createSpy("grammarUpdatedHandler")
             grammar.on 'grammar-updated', grammarUpdatedHandler
 
@@ -263,7 +263,7 @@ describe "TextMateGrammar", ->
             atom.deactivatePackage('language-html')
             atom.activatePackage('language-ruby-on-rails', sync: true)
 
-            grammar = syntax.grammarForScopeName('text.html.ruby')
+            grammar = atom.syntax.grammarForScopeName('text.html.ruby')
             {tokens} = grammar.tokenizeLine("<div class='name'><%= User.find(2).full_name %></div>")
             expect(tokens[0]).toEqual value: "<div class='name'>", scopes: ["text.html.ruby"]
             expect(tokens[1]).toEqual value: '<%=', scopes: ["text.html.ruby","source.ruby.rails.embedded.html","punctuation.section.embedded.ruby"]
@@ -308,7 +308,7 @@ describe "TextMateGrammar", ->
       expect(tokens[1].value).toBe " a singleLineComment"
 
     it "does not loop infinitely (regression)", ->
-      grammar = syntax.selectGrammar("hello.js")
+      grammar = atom.syntax.selectGrammar("hello.js")
       {tokens, ruleStack} = grammar.tokenizeLine("// line comment")
       {tokens, ruleStack} = grammar.tokenizeLine(" // second line comment with a single leading space", ruleStack)
 
@@ -317,12 +317,12 @@ describe "TextMateGrammar", ->
         atom.activatePackage('language-c', sync: true)
 
       it "correctly parses a method. (regression)", ->
-        grammar = syntax.selectGrammar("hello.c")
+        grammar = atom.syntax.selectGrammar("hello.c")
         {tokens, ruleStack} = grammar.tokenizeLine("if(1){m()}")
         expect(tokens[5]).toEqual value: "m", scopes: ["source.c", "meta.block.c", "meta.function-call.c", "support.function.any-method.c"]
 
       it "correctly parses nested blocks. (regression)", ->
-        grammar = syntax.selectGrammar("hello.c")
+        grammar = atom.syntax.selectGrammar("hello.c")
         {tokens, ruleStack} = grammar.tokenizeLine("if(1){if(1){m()}}")
         expect(tokens[5]).toEqual value: "if", scopes: ["source.c", "meta.block.c", "keyword.control.c"]
         expect(tokens[10]).toEqual value: "m", scopes: ["source.c", "meta.block.c", "meta.block.c", "meta.function-call.c", "support.function.any-method.c"]
@@ -331,7 +331,7 @@ describe "TextMateGrammar", ->
       it "aborts tokenization", ->
         spyOn(console, 'error')
         atom.activatePackage("package-with-infinite-loop-grammar")
-        grammar = syntax.selectGrammar("something.package-with-infinite-loop-grammar")
+        grammar = atom.syntax.selectGrammar("something.package-with-infinite-loop-grammar")
         {tokens} = grammar.tokenizeLine("abc")
         expect(tokens[0].value).toBe "a"
         expect(tokens[1].value).toBe "bc"
@@ -340,13 +340,13 @@ describe "TextMateGrammar", ->
     describe "when a grammar has a pattern that has back references in the match value", ->
       it "does not special handle the back references and instead allows oniguruma to resolve them", ->
         atom.activatePackage('language-sass', sync: true)
-        grammar = syntax.selectGrammar("style.scss")
+        grammar = atom.syntax.selectGrammar("style.scss")
         {tokens} = grammar.tokenizeLine("@mixin x() { -moz-selector: whatever; }")
         expect(tokens[9]).toEqual value: "-moz-selector", scopes: ["source.css.scss", "meta.property-list.scss", "meta.property-name.scss"]
 
     describe "when a line has more tokens than `maxTokensPerLine`", ->
       it "creates a final token with the remaining text and resets the ruleStack to match the begining of the line", ->
-        grammar = syntax.selectGrammar("hello.js")
+        grammar = atom.syntax.selectGrammar("hello.js")
         spyOn(grammar, 'getMaxTokensPerLine').andCallFake -> 5
         originalRuleStack = [grammar.initialRule, grammar.initialRule, grammar.initialRule]
         {tokens, ruleStack} = grammar.tokenizeLine("one(two(three(four(five(_param_)))))", originalRuleStack)
@@ -356,7 +356,7 @@ describe "TextMateGrammar", ->
 
     describe "when a grammar has a capture with patterns", ->
       it "matches the patterns and includes the scope specified as the pattern's match name", ->
-        grammar = syntax.selectGrammar("hello.php")
+        grammar = atom.syntax.selectGrammar("hello.php")
         {tokens} = grammar.tokenizeLine("<?php public final function meth() {} ?>")
 
         expect(tokens[2].value).toBe "public"
@@ -402,7 +402,7 @@ describe "TextMateGrammar", ->
 
     describe "when the grammar has injections", ->
       it "correctly includes the injected patterns when tokenizing", ->
-        grammar = syntax.selectGrammar("hello.php")
+        grammar = atom.syntax.selectGrammar("hello.php")
         {tokens} = grammar.tokenizeLine("<div><?php function hello() {} ?></div>")
 
         expect(tokens[3].value).toBe "<?php"
@@ -429,14 +429,14 @@ describe "TextMateGrammar", ->
     describe "when the grammar's pattern name has a group number in it", ->
       it "replaces the group number with the matched captured text", ->
         atom.activatePackage('language-hyperlink', sync: true)
-        grammar = syntax.grammarForScopeName("text.hyperlink")
+        grammar = atom.syntax.grammarForScopeName("text.hyperlink")
         {tokens} = grammar.tokenizeLine("https://github.com")
         expect(tokens[0].scopes).toEqual ["text.hyperlink", "markup.underline.link.https.hyperlink"]
 
     describe "when the grammar has an injection selector", ->
       it "includes the grammar's patterns when the selector matches the current scope in other grammars", ->
         atom.activatePackage('language-hyperlink', sync: true)
-        grammar = syntax.selectGrammar("text.js")
+        grammar = atom.syntax.selectGrammar("text.js")
         {tokens} = grammar.tokenizeLine("var i; // http://github.com")
 
         expect(tokens[0].value).toBe "var"
@@ -469,7 +469,7 @@ describe "TextMateGrammar", ->
           expect(tokens[1].value).toBe " SELECT * FROM OCTOCATS"
           expect(tokens[1].scopes).toEqual ["source.js", "comment.line.double-slash.js"]
 
-          syntax.addGrammar(new TextMateGrammar(
+          atom.syntax.addGrammar(new TextMateGrammar(
             name: "test"
             scopeName: "source.test"
             repository: {}
@@ -515,7 +515,7 @@ describe "TextMateGrammar", ->
 
       beforeEach ->
         atom.activatePackage('language-todo', sync: true)
-        grammar = syntax.selectGrammar('main.rb')
+        grammar = atom.syntax.selectGrammar('main.rb')
         lines = grammar.tokenizeLines "# TODO be nicer"
 
       it "replaces the number with the capture group and translates the text", ->
@@ -529,7 +529,7 @@ describe "TextMateGrammar", ->
     describe "Git commit messages", ->
       beforeEach ->
         atom.activatePackage('language-git', sync: true)
-        grammar = syntax.selectGrammar('COMMIT_EDITMSG')
+        grammar = atom.syntax.selectGrammar('COMMIT_EDITMSG')
         lines = grammar.tokenizeLines """
           longggggggggggggggggggggggggggggggggggggggggggggggg
           # Please enter the commit message for your changes. Lines starting
@@ -548,7 +548,7 @@ describe "TextMateGrammar", ->
     describe "C++", ->
       beforeEach ->
         atom.activatePackage('language-c', sync: true)
-        grammar = syntax.selectGrammar('includes.cc')
+        grammar = atom.syntax.selectGrammar('includes.cc')
         lines = grammar.tokenizeLines """
           #include "a.h"
           #include "b.h"
@@ -570,7 +570,7 @@ describe "TextMateGrammar", ->
 
     describe "Ruby", ->
       beforeEach ->
-        grammar = syntax.selectGrammar('hello.rb')
+        grammar = atom.syntax.selectGrammar('hello.rb')
         lines = grammar.tokenizeLines """
           a = {
             "b" => "c",
@@ -587,7 +587,7 @@ describe "TextMateGrammar", ->
       beforeEach ->
         atom.activatePackage('language-c', sync: true)
         atom.activatePackage('language-objective-c', sync: true)
-        grammar = syntax.selectGrammar('function.mm')
+        grammar = atom.syntax.selectGrammar('function.mm')
         lines = grammar.tokenizeLines """
           void test() {
           NSString *a = @"a\\nb";
@@ -613,7 +613,7 @@ describe "TextMateGrammar", ->
     describe "Java", ->
       beforeEach ->
         atom.activatePackage('language-java', sync: true)
-        grammar = syntax.selectGrammar('Function.java')
+        grammar = atom.syntax.selectGrammar('Function.java')
 
       it "correctly parses single line comments", ->
         lines = grammar.tokenizeLines """
@@ -636,7 +636,7 @@ describe "TextMateGrammar", ->
 
     describe "HTML (Ruby - ERB)", ->
       beforeEach ->
-        grammar = syntax.selectGrammar('page.erb')
+        grammar = atom.syntax.selectGrammar('page.erb')
         lines = grammar.tokenizeLines '<% page_title "My Page" %>'
 
       it "correctly parses strings inside tags", ->
@@ -652,7 +652,7 @@ describe "TextMateGrammar", ->
     describe "Unicode support", ->
       describe "Surrogate pair characters", ->
         beforeEach ->
-          grammar = syntax.selectGrammar('main.js')
+          grammar = atom.syntax.selectGrammar('main.js')
           lines = grammar.tokenizeLines "'\uD835\uDF97'"
 
         it "correctly parses JavaScript strings containing surrogate pair characters", ->
@@ -665,7 +665,7 @@ describe "TextMateGrammar", ->
       describe "when the line contains unicode characters", ->
         it "correctly parses tokens starting after them", ->
           atom.activatePackage('language-json', sync: true)
-          grammar = syntax.selectGrammar('package.json')
+          grammar = atom.syntax.selectGrammar('package.json')
           {tokens} = grammar.tokenizeLine '{"\u2026": 1}'
 
           expect(tokens.length).toBe 8
@@ -674,7 +674,7 @@ describe "TextMateGrammar", ->
 
     describe "python", ->
       it "parses import blocks correctly", ->
-        grammar = syntax.selectGrammar("file.py")
+        grammar = atom.syntax.selectGrammar("file.py")
         lines = grammar.tokenizeLines "import a\nimport b"
 
         line1 = lines[0]

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -8,7 +8,9 @@ describe "ThemeManager", ->
   themeManager = null
 
   beforeEach ->
-    themeManager = new ThemeManager(atom.packages)
+    themeManager = new ThemeManager
+      packageManager: atom.packages
+      resourcePath: window.resourcePath
 
   afterEach ->
     themeManager.deactivateThemes()

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -30,7 +30,7 @@ describe "ThemeManager", ->
 
   describe "getImportPaths()", ->
     it "returns the theme directories before the themes are loaded", ->
-      config.set('core.themes', ['atom-dark-syntax', 'atom-dark-ui', 'atom-light-ui'])
+      atom.config.set('core.themes', ['atom-dark-syntax', 'atom-dark-ui', 'atom-light-ui'])
 
       paths = themeManager.getImportPaths()
 
@@ -40,7 +40,7 @@ describe "ThemeManager", ->
       expect(paths[1]).toContain 'atom-light-ui'
 
     it "ignores themes that cannot be resolved to a directory", ->
-      config.set('core.themes', ['definitely-not-a-theme'])
+      atom.config.set('core.themes', ['definitely-not-a-theme'])
       expect(-> themeManager.getImportPaths()).not.toThrow()
 
   describe "when the core.themes config value changes", ->
@@ -49,24 +49,24 @@ describe "ThemeManager", ->
       spyOn(themeManager, 'getUserStylesheetPath').andCallFake -> null
       themeManager.activateThemes()
 
-      config.set('core.themes', [])
+      atom.config.set('core.themes', [])
       expect($('style.theme').length).toBe 0
       expect(reloadHandler).toHaveBeenCalled()
 
-      config.set('core.themes', ['atom-dark-syntax'])
+      atom.config.set('core.themes', ['atom-dark-syntax'])
       expect($('style.theme').length).toBe 1
       expect($('style.theme:eq(0)').attr('id')).toMatch /atom-dark-syntax/
 
-      config.set('core.themes', ['atom-light-syntax', 'atom-dark-syntax'])
+      atom.config.set('core.themes', ['atom-light-syntax', 'atom-dark-syntax'])
       expect($('style.theme').length).toBe 2
       expect($('style.theme:eq(0)').attr('id')).toMatch /atom-dark-syntax/
       expect($('style.theme:eq(1)').attr('id')).toMatch /atom-light-syntax/
 
-      config.set('core.themes', [])
+      atom.config.set('core.themes', [])
       expect($('style.theme').length).toBe 0
 
       # atom-dark-ui has an directory path, the syntax ones dont.
-      config.set('core.themes', ['atom-light-syntax', 'atom-dark-ui', 'atom-dark-syntax'])
+      atom.config.set('core.themes', ['atom-light-syntax', 'atom-dark-ui', 'atom-dark-syntax'])
       importPaths = themeManager.getImportPaths()
       expect(importPaths.length).toBe 1
       expect(importPaths[0]).toContain 'atom-dark-ui'
@@ -144,7 +144,7 @@ describe "ThemeManager", ->
       themeManager.activateThemes()
 
     it "loads the correct values from the theme's ui-variables file", ->
-      config.set('core.themes', ['theme-with-ui-variables'])
+      atom.config.set('core.themes', ['theme-with-ui-variables'])
 
       # an override loaded in the base css
       expect(rootView.css("background-color")).toBe "rgb(0, 0, 255)"

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -393,7 +393,7 @@ describe "TokenizedBuffer", ->
       buffer = project.bufferForPathSync()
       buffer.setText "<div class='name'><%= User.find(2).full_name %></div>"
       tokenizedBuffer = new TokenizedBuffer({buffer})
-      tokenizedBuffer.setGrammar(syntax.selectGrammar('test.erb'))
+      tokenizedBuffer.setGrammar(atom.syntax.selectGrammar('test.erb'))
       fullyTokenize(tokenizedBuffer)
 
       {tokens} = tokenizedBuffer.lineForScreenRow(0)

--- a/spec/window-spec.coffee
+++ b/spec/window-spec.coffee
@@ -84,7 +84,7 @@ describe "Window", ->
   describe ".unloadEditorWindow()", ->
     it "saves the serialized state of the window so it can be deserialized after reload", ->
       rootViewState = rootView.serialize()
-      syntaxState = syntax.serialize()
+      syntaxState = atom.syntax.serialize()
 
       window.unloadEditorWindow()
 

--- a/src/atom-package.coffee
+++ b/src/atom-package.coffee
@@ -105,9 +105,9 @@ class AtomPackage extends Package
     atom.keymap.add(keymapPath, map) for [keymapPath, map] in @keymaps
     atom.contextMenu.add(menuPath, map['context-menu']) for [menuPath, map] in @menus
     atom.menu.add(map.menu) for [menuPath, map] in @menus when map.menu
-    syntax.addGrammar(grammar) for grammar in @grammars
+    atom.syntax.addGrammar(grammar) for grammar in @grammars
     for [scopedPropertiesPath, selector, properties] in @scopedProperties
-      syntax.addProperties(scopedPropertiesPath, selector, properties)
+      atom.syntax.addProperties(scopedPropertiesPath, selector, properties)
 
   loadKeymaps: ->
     @keymaps = @getKeymapPaths().map (keymapPath) -> [keymapPath, CSON.readFileSync(keymapPath)]
@@ -180,8 +180,8 @@ class AtomPackage extends Package
     @configActivated = false
 
   deactivateResources: ->
-    syntax.removeGrammar(grammar) for grammar in @grammars
-    syntax.removeProperties(scopedPropertiesPath) for [scopedPropertiesPath] in @scopedProperties
+    atom.syntax.removeGrammar(grammar) for grammar in @grammars
+    atom.syntax.removeProperties(scopedPropertiesPath) for [scopedPropertiesPath] in @scopedProperties
     atom.keymap.remove(keymapPath) for [keymapPath] in @keymaps
     atom.themes.removeStylesheet(stylesheetPath) for [stylesheetPath] in @stylesheets
     @stylesheetsActivated = false

--- a/src/atom-package.coffee
+++ b/src/atom-package.coffee
@@ -89,7 +89,7 @@ class AtomPackage extends Package
 
     @requireMainModule()
     if @mainModule?
-      config.setDefaults(@name, @mainModule.configDefaults)
+      atom.config.setDefaults(@name, @mainModule.configDefaults)
       @mainModule.activateConfig?()
     @configActivated = true
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -62,7 +62,7 @@ class Atom
     @packages = new PackageManager({devMode, configDirPath, resourcePath})
 
     @subscribe @packages, 'activated', => @watchThemes()
-    @themes = new ThemeManager({packageManager: @packages, @resourcePath})
+    @themes = new ThemeManager({packageManager: @packages, resourcePath})
     @contextMenu = new ContextMenuManager(devMode)
     @menu = new MenuManager()
     @pasteboard = new Pasteboard()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -62,7 +62,7 @@ class Atom
     @packages = new PackageManager({devMode, configDirPath, resourcePath})
 
     @subscribe @packages, 'activated', => @watchThemes()
-    @themes = new ThemeManager(@packages)
+    @themes = new ThemeManager({packageManager: @packages, @resourcePath})
     @contextMenu = new ContextMenuManager(devMode)
     @menu = new MenuManager()
     @pasteboard = new Pasteboard()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -58,7 +58,7 @@ class Atom
     MenuManager = require './menu-manager'
 
     @config = new Config({configDirPath, resourcePath})
-    @keymap = new Keymap()
+    @keymap = new Keymap({configDirPath, resourcePath})
     @packages = new PackageManager({devMode, configDirPath, resourcePath})
 
     @subscribe @packages, 'activated', => @watchThemes()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -61,10 +61,6 @@ class Atom
     @keymap = new Keymap()
     @packages = new PackageManager({devMode, configDirPath, resourcePath})
 
-    #TODO Remove once packages have been updated to not touch atom.packageStates directly
-    @__defineGetter__ 'packageStates', => @packages.packageStates
-    @__defineSetter__ 'packageStates', (packageStates) => @packages.packageStates = packageStates
-
     @subscribe @packages, 'activated', => @watchThemes()
     @themes = new ThemeManager(@packages)
     @contextMenu = new ContextMenuManager(devMode)

--- a/src/config-observer.coffee
+++ b/src/config-observer.coffee
@@ -1,7 +1,7 @@
 module.exports =
   observeConfig: (keyPath, args...) ->
     @configSubscriptions ?= {}
-    @configSubscriptions[keyPath] = config.observe(keyPath, args...)
+    @configSubscriptions[keyPath] = atom.config.observe(keyPath, args...)
 
   unobserveConfig: ->
     if @configSubscriptions?

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -163,6 +163,15 @@ class Config
       @update()
     value
 
+  # Public: Toggle the value at the key path.
+  #
+  # The new value will be `true` if the value is currently falsy and will be
+  # `false` if the value is currently truthy.
+  #
+  # Returns the new value.
+  toggle: (keyPath) ->
+    @set(keyPath, !@get(keyPath))
+
   # Public: Push the value to the array at the key path.
   #
   # keyPath - The {String} key path.

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -37,10 +37,6 @@ class Config
     @bundledMenusDirPath = path.join(resourcePath, "menus")
     @nodeModulesDirPath = path.join(@resourcePath, "node_modules")
     @bundledPackageDirPaths = [@nodeModulesDirPath]
-    @lessSearchPaths = [
-      path.join(@resourcePath, 'static', 'variables')
-      path.join(@resourcePath, 'static')
-    ]
     @packageDirPaths = [path.join(@configDirPath, "packages")]
     if atom.getLoadSettings().devMode
       @packageDirPaths.unshift(path.join(@configDirPath, "dev", "packages"))

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -111,7 +111,7 @@ class Cursor
   # Returns a RegExp.
   wordRegExp: ({includeNonWordCharacters}={})->
     includeNonWordCharacters ?= true
-    nonWordCharacters = config.get('editor.nonWordCharacters')
+    nonWordCharacters = atom.config.get('editor.nonWordCharacters')
     segments = ["^[\t ]*$"]
     segments.push("[^\\s#{_.escapeRegExp(nonWordCharacters)}]+")
     if includeNonWordCharacters
@@ -153,7 +153,7 @@ class Cursor
     [before, after] = @editSession.getTextInBufferRange(range)
     return false if /\s/.test(before) or /\s/.test(after)
 
-    nonWordCharacters = config.get('editor.nonWordCharacters').split('')
+    nonWordCharacters = atom.config.get('editor.nonWordCharacters').split('')
     _.contains(nonWordCharacters, before) isnt _.contains(nonWordCharacters, after)
 
   # Public: Returns whether this cursor is between a word's start and end.

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -38,7 +38,7 @@ class DisplayBuffer
         version: @constructor.version
         id: @id
         tokenizedBuffer: @tokenizedBuffer.getState()
-        softWrap: softWrap ? config.get('editor.softWrap') ? false
+        softWrap: softWrap ? atom.config.get('editor.softWrap') ? false
         editorWidthInChars: editorWidthInChars
 
     @markers = {}
@@ -56,7 +56,7 @@ class DisplayBuffer
         @updateWrappedScreenLines()
 
     @observeConfig 'editor.preferredLineLength', callNow: false, =>
-      @updateWrappedScreenLines() if @getSoftWrap() and config.get('editor.softWrapAtPreferredLineLength')
+      @updateWrappedScreenLines() if @getSoftWrap() and atom.config.get('editor.softWrapAtPreferredLineLength')
 
     @observeConfig 'editor.softWrapAtPreferredLineLength', callNow: false, =>
       @updateWrappedScreenLines() if @getSoftWrap()
@@ -113,8 +113,8 @@ class DisplayBuffer
 
   getSoftWrapColumn: ->
     editorWidthInChars = @state.get('editorWidthInChars')
-    if config.get('editor.softWrapAtPreferredLineLength')
-      Math.min(editorWidthInChars, config.getPositiveInt('editor.preferredLineLength', editorWidthInChars))
+    if atom.config.get('editor.softWrapAtPreferredLineLength')
+      Math.min(editorWidthInChars, atom.config.getPositiveInt('editor.preferredLineLength', editorWidthInChars))
     else
       editorWidthInChars
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -33,7 +33,7 @@ class DisplayBuffer
       {@buffer, softWrap, editorWidthInChars} = optionsOrState
       @id = guid.create().toString()
       @tokenizedBuffer = new TokenizedBuffer(optionsOrState)
-      @state = site.createDocument
+      @state = atom.site.createDocument
         deserializer: @constructor.name
         version: @constructor.version
         id: @id

--- a/src/edit-session.coffee
+++ b/src/edit-session.coffee
@@ -80,7 +80,7 @@ class EditSession
       {buffer, displayBuffer, tabLength, softTabs, softWrap, suppressCursorCreation, initialLine} = optionsOrState
       @id = guid.create().toString()
       displayBuffer ?= new DisplayBuffer({buffer, tabLength, softWrap})
-      @state = site.createDocument
+      @state = atom.site.createDocument
         deserializer: @constructor.name
         version: @constructor.version
         id: @id

--- a/src/edit-session.coffee
+++ b/src/edit-session.coffee
@@ -85,7 +85,7 @@ class EditSession
         version: @constructor.version
         id: @id
         displayBuffer: displayBuffer.getState()
-        softTabs: buffer.usesSoftTabs() ? softTabs ? config.get('editor.softTabs') ? true
+        softTabs: buffer.usesSoftTabs() ? softTabs ? atom.config.get('editor.softTabs') ? true
         scrollTop: 0
         scrollLeft: 0
       @setBuffer(buffer)
@@ -567,7 +567,7 @@ class EditSession
   pasteText: (options={}) ->
     [text, metadata] = atom.pasteboard.read()
 
-    if config.get('editor.normalizeIndentOnPaste') and metadata
+    if atom.config.get('editor.normalizeIndentOnPaste') and metadata
       options.indentBasis ?= metadata.indentBasis
 
     @insertText(text, options)
@@ -1398,7 +1398,7 @@ class EditSession
 
   # Private:
   shouldAutoIndent: ->
-    config.get("editor.autoIndent")
+    atom.config.get("editor.autoIndent")
 
   # Public: Performs all editor actions from the given function within a single
   # undo step.

--- a/src/edit-session.coffee
+++ b/src/edit-session.coffee
@@ -565,7 +565,7 @@ class EditSession
   # * options:
   #    + A set of options equivalent to {Selection.insertText}.
   pasteText: (options={}) ->
-    [text, metadata] = pasteboard.read()
+    [text, metadata] = atom.pasteboard.read()
 
     if config.get('editor.normalizeIndentOnPaste') and metadata
       options.indentBasis ?= metadata.indentBasis

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -203,9 +203,9 @@ class Editor extends View
         'editor:move-line-down': @moveLineDown
         'editor:duplicate-line': @duplicateLine
         'editor:join-line': @joinLine
-        'editor:toggle-indent-guide': => config.set('editor.showIndentGuide', !config.get('editor.showIndentGuide'))
+        'editor:toggle-indent-guide': => atom.config.toggle('editor.showIndentGuide')
         'editor:save-debug-snapshot': @saveDebugSnapshot
-        'editor:toggle-line-numbers': =>  config.set('editor.showLineNumbers', !config.get('editor.showLineNumbers'))
+        'editor:toggle-line-numbers': =>  atom.config.toggle('editor.showLineNumbers')
         'editor:scroll-to-cursor': @scrollToCursorPosition
 
     documentation = {}

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1809,7 +1809,7 @@ class Editor extends View
   bindToKeyedEvent: (key, event, callback) ->
     binding = {}
     binding[key] = event
-    window.keymap.bindKeys '.editor', binding
+    atom.keymap.bindKeys '.editor', binding
     @on event, =>
       callback(this, event)
 

--- a/src/keymap.coffee
+++ b/src/keymap.coffee
@@ -30,16 +30,17 @@ class Keymap
   bindingSetsByFirstKeystroke: null
   queuedKeystrokes: null
 
-  constructor: ->
+  constructor: ({resourcePath, @configDirPath})->
+    @bundledKeymapsDirPath = path.join(resourcePath, "keymaps")
     @bindingSets = []
     @bindingSetsByFirstKeystroke = {}
 
   loadBundledKeymaps: ->
-    @loadDirectory(config.bundledKeymapsDirPath)
+    @loadDirectory(@bundledKeymapsDirPath)
     @emit('bundled-keymaps-loaded')
 
   loadUserKeymap: ->
-    userKeymapPath = CSON.resolve(path.join(config.configDirPath, 'keymap'))
+    userKeymapPath = CSON.resolve(path.join(@configDirPath, 'keymap'))
     @load(userKeymapPath) if userKeymapPath
 
   loadDirectory: (directoryPath) ->

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -38,7 +38,7 @@ class LanguageMode
   # Returns an {Array} of the commented {Ranges}.
   toggleLineCommentsForBufferRows: (start, end) ->
     scopes = @editSession.scopesForBufferPosition([start, 0])
-    properties = syntax.propertiesForScope(scopes, "editor.commentStart")[0]
+    properties = atom.syntax.propertiesForScope(scopes, "editor.commentStart")[0]
     return unless properties
 
     commentStartString = _.valueForKeyPath(properties, "editor.commentStart")
@@ -292,14 +292,15 @@ class LanguageMode
   tokenizeLine: (line, stack, firstLine) ->
     {tokens, stack} = @grammar.tokenizeLine(line, stack, firstLine)
 
+  getRegexForProperty: (scopes, property) ->
+    if pattern = atom.syntax.getProperty(scopes, property)
+      new OnigRegExp(pattern)
+
   increaseIndentRegexForScopes: (scopes) ->
-    if increaseIndentPattern = syntax.getProperty(scopes, 'editor.increaseIndentPattern')
-      new OnigRegExp(increaseIndentPattern)
+    @getRegexForProperty(scopes, 'editor.increaseIndentPattern')
 
   decreaseIndentRegexForScopes: (scopes) ->
-    if decreaseIndentPattern = syntax.getProperty(scopes, 'editor.decreaseIndentPattern')
-      new OnigRegExp(decreaseIndentPattern)
+    @getRegexForProperty(scopes, 'editor.decreaseIndentPattern')
 
   foldEndRegexForScopes: (scopes) ->
-    if foldEndPattern = syntax.getProperty(scopes, 'editor.foldEndPattern')
-      new OnigRegExp(foldEndPattern)
+    @getRegexForProperty(scopes, 'editor.foldEndPattern')

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -11,16 +11,21 @@ class LessCompileCache
 
   @cacheDir: path.join(tmpDir, 'atom-compile-cache', 'less')
 
-  constructor: ->
+  constructor: ({resourcePath})->
     @cache = new LessCache
       cacheDir: @constructor.cacheDir
       importPaths: @getImportPaths()
       resourcePath: window.resourcePath
-      fallbackDir: path.join(window.resourcePath, 'less-compile-cache')
+      fallbackDir: path.join(resourcePath, 'less-compile-cache')
+
+    @lessSearchPaths = [
+      path.join(resourcePath, 'static', 'variables')
+      path.join(resourcePath, 'static')
+    ]
 
     @subscribe atom.themes, 'reloaded', => @cache.setImportPaths(@getImportPaths())
 
-  getImportPaths: -> atom.themes.getImportPaths().concat(atom.config.lessSearchPaths)
+  getImportPaths: -> atom.themes.getImportPaths().concat(@lessSearchPaths)
 
   read: (stylesheetPath) -> @cache.readFileSync(stylesheetPath)
 

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -11,17 +11,17 @@ class LessCompileCache
 
   @cacheDir: path.join(tmpDir, 'atom-compile-cache', 'less')
 
-  constructor: ({resourcePath})->
+  constructor: ({resourcePath}) ->
+    @lessSearchPaths = [
+      path.join(resourcePath, 'static', 'variables')
+      path.join(resourcePath, 'static')
+    ]
+
     @cache = new LessCache
       cacheDir: @constructor.cacheDir
       importPaths: @getImportPaths()
       resourcePath: window.resourcePath
       fallbackDir: path.join(resourcePath, 'less-compile-cache')
-
-    @lessSearchPaths = [
-      path.join(resourcePath, 'static', 'variables')
-      path.join(resourcePath, 'static')
-    ]
 
     @subscribe atom.themes, 'reloaded', => @cache.setImportPaths(@getImportPaths())
 

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -20,7 +20,7 @@ class LessCompileCache
     @cache = new LessCache
       cacheDir: @constructor.cacheDir
       importPaths: @getImportPaths()
-      resourcePath: window.resourcePath
+      resourcePath: resourcePath
       fallbackDir: path.join(resourcePath, 'less-compile-cache')
 
     @subscribe atom.themes, 'reloaded', => @cache.setImportPaths(@getImportPaths())

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -20,7 +20,7 @@ class LessCompileCache
 
     @subscribe atom.themes, 'reloaded', => @cache.setImportPaths(@getImportPaths())
 
-  getImportPaths: -> atom.themes.getImportPaths().concat(config.lessSearchPaths)
+  getImportPaths: -> atom.themes.getImportPaths().concat(atom.config.lessSearchPaths)
 
   read: (stylesheetPath) -> @cache.readFileSync(stylesheetPath)
 

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -106,13 +106,13 @@ class PackageManager
 
   unobserveDisabledPackages: ->
     return unless @observingDisabledPackages
-    config.unobserve('core.disabledPackages')
+    atom.config.unobserve('core.disabledPackages')
     @observingDisabledPackages = false
 
   observeDisabledPackages: ->
     return if @observingDisabledPackages
 
-    config.observe 'core.disabledPackages', callNow: false, (disabledPackages, {previous}) =>
+    atom.config.observe 'core.disabledPackages', callNow: false, (disabledPackages, {previous}) =>
       packagesToEnable = _.difference(previous, disabledPackages)
       packagesToDisable = _.difference(disabledPackages, previous)
 
@@ -182,7 +182,7 @@ class PackageManager
     return packagePath if @isInternalPackage(packagePath)
 
   isPackageDisabled: (name) ->
-    _.include(config.get('core.disabledPackages') ? [], name)
+    _.include(atom.config.get('core.disabledPackages') ? [], name)
 
   isInternalPackage: (packagePath) ->
     {engines} = Package.loadMetadata(packagePath, true)

--- a/src/pane-axis.coffee
+++ b/src/pane-axis.coffee
@@ -14,7 +14,7 @@ class PaneAxis extends View
       @state = args[0]
       @state.get('children').each (child, index) => @addChild(deserialize(child), index, updateState: false)
     else
-      @state = site.createDocument(deserializer: @className(), children: [])
+      @state = atom.site.createDocument(deserializer: @className(), children: [])
       @addChild(child) for child in args
 
     @state.get('children').on 'changed', ({index, insertedValues, removedValues, siteId}) =>

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -25,7 +25,7 @@ class PaneContainer extends View
       @state = state
       @setRoot(deserialize(@state.get('root')))
     else
-      @state = site.createDocument(deserializer: 'PaneContainer')
+      @state = atom.site.createDocument(deserializer: 'PaneContainer')
 
     @subscribe @state, 'changed', ({newValues, siteId}) =>
       return if siteId is @state.siteId

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -36,7 +36,7 @@ class Pane extends View
       @items = _.compact(@state.get('items').map (item) -> deserialize(item))
     else
       @items = args
-      @state = site.createDocument
+      @state = atom.site.createDocument
         deserializer: 'Pane'
         items: @items.map (item) -> item.getState?() ? item.serialize()
 

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -78,7 +78,7 @@ class Project
         if buffer = deserialize(bufferState, project: this)
           @addBuffer(buffer, updateState: false)
     else
-      @state = site.createDocument(deserializer: @constructor.name, version: @constructor.version, buffers: [])
+      @state = atom.site.createDocument(deserializer: @constructor.name, version: @constructor.version, buffers: [])
       @setPath(pathOrState)
 
     @state.get('buffers').on 'changed', ({index, insertedValues, removedValues, siteId}) =>

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -34,7 +34,7 @@ class Project
   @pathForRepositoryUrl: (repoUrl) ->
     [repoName] = url.parse(repoUrl).path.split('/')[-1..]
     repoName = repoName.replace(/\.git$/, '')
-    path.join(config.get('core.projectHome'), repoName)
+    path.join(atom.config.get('core.projectHome'), repoName)
 
   rootDirectory: null
   editSessions: null
@@ -137,14 +137,14 @@ class Project
   # Public: Determines if a path is ignored via Atom configuration.
   isPathIgnored: (path) ->
     for segment in path.split("/")
-      ignoredNames = config.get("core.ignoredNames") or []
+      ignoredNames = atom.config.get("core.ignoredNames") or []
       return true if _.contains(ignoredNames, segment)
 
     @ignoreRepositoryPath(path)
 
   # Public: Determines if a given path is ignored via repository configuration.
   ignoreRepositoryPath: (repositoryPath) ->
-    config.get("core.hideGitIgnoredFiles") and @repo?.isPathIgnored(path.join(@getPath(), repositoryPath))
+    atom.config.get("core.hideGitIgnoredFiles") and @repo?.isPathIgnored(path.join(@getPath(), repositoryPath))
 
   # Public: Given a uri, this resolves it relative to the project directory. If
   # the path is already absolute or if it is prefixed with a scheme, it is
@@ -315,8 +315,8 @@ class Project
       ignoreCase: regex.ignoreCase
       inclusions: options.paths
       includeHidden: true
-      excludeVcsIgnores: config.get('core.excludeVcsIgnoredPaths')
-      exclusions: config.get('core.ignoredNames')
+      excludeVcsIgnores: atom.config.get('core.excludeVcsIgnoredPaths')
+      exclusions: atom.config.get('core.ignoredNames')
 
     task = Task.once require.resolve('./scan-handler'), @getPath(), regex.source, searchOptions, ->
       deferred.resolve()

--- a/src/root-view.coffee
+++ b/src/root-view.coffee
@@ -72,7 +72,7 @@ class RootView extends View
       panes = deserialize(state.get('panes'))
     else
       panes = new PaneContainer
-      @state = site.createDocument
+      @state = atom.site.createDocument
         deserializer: @constructor.name
         version: @constructor.version
         panes: panes.getState()

--- a/src/root-view.coffee
+++ b/src/root-view.coffee
@@ -107,22 +107,22 @@ class RootView extends View
 
     @command 'window:run-package-specs', => ipc.sendChannel('run-package-specs', path.join(project.getPath(), 'spec'))
     @command 'window:increase-font-size', =>
-      config.set("editor.fontSize", config.get("editor.fontSize") + 1)
+      atom.config.set("editor.fontSize", config.get("editor.fontSize") + 1)
 
     @command 'window:decrease-font-size', =>
       fontSize = config.get "editor.fontSize"
-      config.set("editor.fontSize", fontSize - 1) if fontSize > 1
+      atom.config.set("editor.fontSize", fontSize - 1) if fontSize > 1
 
     @command 'window:focus-next-pane', => @focusNextPane()
     @command 'window:focus-previous-pane', => @focusPreviousPane()
     @command 'window:save-all', => @saveAll()
     @command 'window:toggle-invisibles', =>
-      config.set("editor.showInvisibles", !config.get("editor.showInvisibles"))
+      atom.config.toggle("editor.showInvisibles")
     @command 'window:toggle-ignored-files', =>
-      config.set("core.hideGitIgnoredFiles", not config.core.hideGitIgnoredFiles)
+      atom.config.toggle("core.hideGitIgnoredFiles")
 
     @command 'window:toggle-auto-indent', =>
-      config.set("editor.autoIndent", !config.get("editor.autoIndent"))
+      atom.config.toggle("editor.autoIndent")
 
     @command 'pane:reopen-closed-item', =>
       @panes.reopenItem()

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -529,12 +529,12 @@ class Selection
     return if @isEmpty()
     text = @editSession.buffer.getTextInRange(@getBufferRange())
     if maintainPasteboard
-      [currentText, metadata] = pasteboard.read()
+      [currentText, metadata] = atom.pasteboard.read()
       text = currentText + '\n' + text
     else
       metadata = { indentBasis: @editSession.indentationForBufferRow(@getBufferRange().start.row) }
 
-    pasteboard.write(text, metadata)
+    atom.pasteboard.write(text, metadata)
 
   # Public: Creates a fold containing the current selection.
   fold: ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -52,7 +52,7 @@ class TextBuffer
       {@project, filePath} = optionsOrState
       @text = new telepath.String(initialText ? '', replicated: false)
       @id = guid.create().toString()
-      @state = site.createDocument
+      @state = atom.site.createDocument
         id: @id
         deserializer: @constructor.name
         version: @constructor.version

--- a/src/text-mate-grammar.coffee
+++ b/src/text-mate-grammar.coffee
@@ -68,14 +68,14 @@ class TextMateGrammar
   grammarUpdated: (scopeName) ->
     return false unless _.include(@includedGrammarScopes, scopeName)
     @clearRules()
-    syntax.grammarUpdated(@scopeName)
+    atom.syntax.grammarUpdated(@scopeName)
     @emit 'grammar-updated'
     true
 
   getScore: (filePath, contents) ->
     contents = fs.readFileSync(filePath, 'utf8') if not contents? and fs.isFileSync(filePath)
 
-    if syntax.grammarOverrideForPath(filePath) is @scopeName
+    if atom.syntax.grammarOverrideForPath(filePath) is @scopeName
       2 + (filePath?.length ? 0)
     else if @matchesContents(contents)
       1 + (filePath?.length ? 0)
@@ -288,7 +288,7 @@ class Rule
       results.push(result)
 
     scopes = scopesFromStack(ruleStack)
-    for injectionGrammar in _.without(syntax.injectionGrammars, @grammar, baseGrammar)
+    for injectionGrammar in _.without(atom.syntax.injectionGrammars, @grammar, baseGrammar)
       if injectionGrammar.injectionSelector.matches(scopes)
         scanner = injectionGrammar.getInitialRule().getScanner(injectionGrammar, position, firstLine)
         if result = scanner.findNextMatch(lineWithNewline, position)
@@ -409,7 +409,7 @@ class Pattern
       baseGrammar.getInitialRule()
     else
       @grammar.addIncludedGrammarScope(name)
-      syntax.grammarForScopeName(name)?.getInitialRule()
+      atom.syntax.grammarForScopeName(name)?.getInitialRule()
 
   getIncludedPatterns: (baseGrammar, included) ->
     if @include

--- a/src/text-mate-package.coffee
+++ b/src/text-mate-package.coffee
@@ -41,15 +41,15 @@ class TextMatePackage extends Package
 
   activate: ->
     @measure 'activateTime', =>
-      syntax.addGrammar(grammar) for grammar in @grammars
+      atom.syntax.addGrammar(grammar) for grammar in @grammars
       for { selector, properties } in @scopedProperties
-        syntax.addProperties(@path, selector, properties)
+        atom.syntax.addProperties(@path, selector, properties)
 
   activateConfig: -> # noop
 
   deactivate: ->
-    syntax.removeGrammar(grammar) for grammar in @grammars
-    syntax.removeProperties(@path)
+    atom.syntax.removeGrammar(grammar) for grammar in @grammars
+    atom.syntax.removeProperties(@path)
 
   legalGrammarExtensions: ['plist', 'tmLanguage', 'tmlanguage', 'json', 'cson']
 
@@ -77,7 +77,7 @@ class TextMatePackage extends Package
 
   addGrammar: (grammar) ->
     @grammars.push(grammar)
-    syntax.addGrammar(grammar) if @isActive()
+    atom.syntax.addGrammar(grammar) if @isActive()
 
   getGrammars: -> @grammars
 
@@ -98,38 +98,38 @@ class TextMatePackage extends Package
   loadScopedPropertiesSync: ->
     for grammar in @getGrammars()
       if properties = @propertiesFromTextMateSettings(grammar)
-        selector = syntax.cssSelectorFromScopeSelector(grammar.scopeName)
+        selector = atom.syntax.cssSelectorFromScopeSelector(grammar.scopeName)
         @scopedProperties.push({selector, properties})
 
     for preferencePath in fs.listSync(@getPreferencesPath())
       {scope, settings} = fs.readObjectSync(preferencePath)
       if properties = @propertiesFromTextMateSettings(settings)
-        selector = syntax.cssSelectorFromScopeSelector(scope) if scope?
+        selector = atom.syntax.cssSelectorFromScopeSelector(scope) if scope?
         @scopedProperties.push({selector, properties})
 
     if @isActive()
       for {selector, properties} in @scopedProperties
-        syntax.addProperties(@path, selector, properties)
+        atom.syntax.addProperties(@path, selector, properties)
 
   loadScopedProperties: (callback) ->
     scopedProperties = []
 
     for grammar in @getGrammars()
       if properties = @propertiesFromTextMateSettings(grammar)
-        selector = syntax.cssSelectorFromScopeSelector(grammar.scopeName)
+        selector = atom.syntax.cssSelectorFromScopeSelector(grammar.scopeName)
         scopedProperties.push({selector, properties})
 
     preferenceObjects = []
     done = =>
       for {scope, settings} in preferenceObjects
         if properties = @propertiesFromTextMateSettings(settings)
-          selector = syntax.cssSelectorFromScopeSelector(scope) if scope?
+          selector = atom.syntax.cssSelectorFromScopeSelector(scope) if scope?
           scopedProperties.push({selector, properties})
 
       @scopedProperties = scopedProperties
       if @isActive()
         for {selector, properties} in @scopedProperties
-          syntax.addProperties(@path, selector, properties)
+          atom.syntax.addProperties(@path, selector, properties)
       callback?()
     @loadTextMatePreferenceObjects(preferenceObjects, done)
 

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -17,7 +17,7 @@ module.exports =
 class ThemeManager
   Emitter.includeInto(this)
 
-  constructor: (@packageManager) ->
+  constructor: ({@packageManager, @resourcePath}) ->
     @lessCache = null
     @packageManager.registerPackageActivator(this, ['theme'])
 
@@ -148,7 +148,7 @@ class ThemeManager
   loadLessStylesheet: (lessStylesheetPath) ->
     unless lessCache?
       LessCompileCache = require './less-compile-cache'
-      @lessCache = new LessCompileCache()
+      @lessCache = new LessCompileCache({@resourcePath})
 
     try
       @lessCache.read(lessStylesheetPath)

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -64,7 +64,7 @@ class TokenizedBuffer
     @emit 'grammar-changed', grammar
 
   reloadGrammar: ->
-    if grammar = syntax.selectGrammar(@buffer.getPath(), @buffer.getText())
+    if grammar = atom.syntax.selectGrammar(@buffer.getPath(), @buffer.getText())
       @setGrammar(grammar)
     else
       throw new Error("No grammar found for path: #{path}")

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -37,7 +37,7 @@ class TokenizedBuffer
       @state = atom.site.createDocument
         deserializer: @constructor.name
         bufferPath: @buffer.getRelativePath()
-        tabLength: tabLength ? config.get('editor.tabLength') ? 2
+        tabLength: tabLength ? atom.config.get('editor.tabLength') ? 2
 
     @subscribe syntax, 'grammar-added grammar-updated', (grammar) =>
       if grammar.injectionSelector?

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -34,7 +34,7 @@ class TokenizedBuffer
       @buffer = project.bufferForPathSync(optionsOrState.get('bufferPath'))
     else
       { @buffer, tabLength } = optionsOrState
-      @state = site.createDocument
+      @state = atom.site.createDocument
         deserializer: @constructor.name
         bufferPath: @buffer.getRelativePath()
         tabLength: tabLength ? config.get('editor.tabLength') ? 2

--- a/src/window.coffee
+++ b/src/window.coffee
@@ -97,6 +97,7 @@ window.deserializeEditorWindow = ->
 window.onerror = ->
   atom.openDevTools()
 
+#TODO remove once all packages use the atom global
 window.registerDeserializers = (args...) ->
   atom.deserializers.add(args...)
 window.registerDeserializer = (args...) ->

--- a/src/window.coffee
+++ b/src/window.coffee
@@ -47,7 +47,7 @@ window.startEditorWindow = ->
     installApmCommand()
 
   windowEventHandler = new WindowEventHandler
-  restoreDimensions()
+  atom.restoreDimensions()
   atom.config.load()
   atom.keymap.loadBundledKeymaps()
   atom.themes.loadBaseStylesheets()
@@ -93,12 +93,6 @@ window.deserializeEditorWindow = ->
   window.project = atom.project
   atom.deserializeRootView()
   window.rootView = atom.rootView
-
-window.getDimensions = -> atom.getDimensions()
-
-window.setDimensions = (args...) -> atom.setDimensions(args...)
-
-window.restoreDimensions = (args...) -> atom.restoreDimensions(args...)
 
 window.onerror = ->
   atom.openDevTools()


### PR DESCRIPTION
Updates core to not use any shims.
- [x] Remove dimension shims
- [x] Don't use `window.config`
- [x] Don't use `window.keymap`
- [x] Don't use `window.pasteboard`
- [x] Don't use `window.site`
- [x] Don't use `window.syntax`

Refs #950 
