### PR TITLE
Sublime keybindings

### DIFF
--- a/keymaps/apple.cson
+++ b/keymaps/apple.cson
@@ -5,16 +5,24 @@
   'meta-shift-down': 'core:select-to-bottom'
 
 '.editor':
+  'meta-left': 'editor:move-to-first-character-of-line'
   'meta-right': 'editor:move-to-end-of-line'
-  'meta-left': 'editor:move-to-beginning-of-line'
-  'alt-left': 'editor:move-to-beginning-of-word'
-  'alt-right': 'editor:move-to-end-of-word'
-  'meta-shift-left': 'editor:select-to-beginning-of-line'
+  'meta-shift-left': 'editor:select-to-first-character-of-line'
   'meta-shift-right': 'editor:select-to-end-of-line'
-  'alt-shift-left': 'editor:select-to-beginning-of-word'
-  'alt-shift-right': 'editor:select-to-end-of-word'
+
+  'home': 'editor:move-to-first-character-of-line'
+  'end': 'editor:move-to-end-of-line'
+  'shift-home': 'editor:select-to-first-character-of-line'
+  'shift-end': 'editor:select-to-end-of-line'
+
+  'alt-left': 'editor:move-to-previous-word-boundary'
+  'alt-right': 'editor:move-to-next-word-boundary'
+  'alt-shift-left': 'editor:select-to-previous-word-boundary'
+  'alt-shift-right': 'editor:select-to-next-word-boundary'
+
   'alt-backspace': 'editor:backspace-to-beginning-of-word'
   'meta-backspace': 'editor:backspace-to-beginning-of-line'
+
   'alt-delete': 'editor:delete-to-end-of-word'
   'ctrl-t': 'editor:transpose'
   'ctrl-A': 'editor:select-to-first-character-of-line'

--- a/keymaps/atom.cson
+++ b/keymaps/atom.cson
@@ -29,6 +29,7 @@
   'shift-backspace': 'core:backspace'
   'delete': 'core:delete'
   'meta-z': 'core:undo'
+  'meta-Z': 'core:redo'
   'meta-y': 'core:redo'
   'meta-x': 'core:cut'
   'meta-c': 'core:copy'

--- a/keymaps/atom.cson
+++ b/keymaps/atom.cson
@@ -29,7 +29,7 @@
   'shift-backspace': 'core:backspace'
   'delete': 'core:delete'
   'meta-z': 'core:undo'
-  'meta-Z': 'core:redo'
+  'meta-y': 'core:redo'
   'meta-x': 'core:cut'
   'meta-c': 'core:copy'
   'meta-v': 'core:paste'

--- a/keymaps/editor.cson
+++ b/keymaps/editor.cson
@@ -1,5 +1,5 @@
 '.editor':
-  'meta-d': 'editor:delete-line'
+  'ctrl-K': 'editor:delete-line'
   'ctrl-W': 'editor:select-word'
   'meta-alt-p': 'editor:log-cursor-scope'
   'meta-u': 'editor:upper-case'

--- a/keymaps/editor.cson
+++ b/keymaps/editor.cson
@@ -38,7 +38,7 @@
   'ctrl-meta-up': 'editor:move-line-up'
   'ctrl-meta-down': 'editor:move-line-down'
   'meta-D': 'editor:duplicate-line'
-  'ctrl-J': 'editor:join-line'
+  'meta-j': 'editor:join-line'
   'meta-<': 'editor:scroll-to-cursor'
 
 '.editor.mini':

--- a/menus/base.cson
+++ b/menus/base.cson
@@ -95,6 +95,25 @@
   }
 
   {
+    label: 'Selection'
+    submenu: [
+      { label: 'Add Selection Above', command: 'editor:add-selection-above' }
+      { label: 'Add Selection Below', command: 'editor:add-selection-below' }
+      { type: 'separator' }
+      { label: 'Select to Top', command: 'core:select-to-top' }
+      { label: 'Select to Bottom', command: 'core:select-to-bottom' }
+      { type: 'separator' }
+      { label: 'Select Line', command: 'editor:select-line' }
+      { label: 'Select Word', command: 'editor:select-word' }
+      { label: 'Select to Beginning of Word', command: 'editor:select-to-beginning-of-word' }
+      { label: 'Select to Beginning of Line', command: 'editor:select-to-beginning-of-line' }
+      { label: 'Select to First Character of Line', command: 'editor:select-to-first-character-of-line' }
+      { label: 'Select to End of Word', command: 'editor:select-to-end-of-word' }
+      { label: 'Select to End of Line', command: 'editor:select-to-end-of-line' }
+    ]
+  }
+
+  {
     label: 'View'
     submenu: [
       { label: 'Reload', command: 'window:reload' }

--- a/menus/base.cson
+++ b/menus/base.cson
@@ -45,17 +45,50 @@
       { label: 'Paste', command: 'core:paste' }
       { label: 'Select All', command: 'core:select-all' }
       { type: 'separator' }
+      { label: 'Toggle Comments', command: 'editor:toggle-line-comments' }
       {
         label: 'Lines',
         submenu: [
           { label: 'Indent', command: 'editor:indent-selected-rows' }
           { label: 'Outdent', command: 'editor:outdent-selected-rows' }
           { label: 'Auto Indent', command: 'editor:auto-indent' }
+          { type: 'separator' }
           { label: 'Move Line Up', command: 'editor:move-line-up' }
           { label: 'Move Line Down', command: 'editor:move-line-down' }
           { label: 'Duplicate Line', command: 'editor:duplicate-line' }
           { label: 'Delete Line', command: 'editor:delete-line' }
           { label: 'Join Lines', command: 'editor:join-line' }
+        ]
+      }
+      {
+        label: 'Text',
+        submenu: [
+          { label: 'Upper Case', command: 'editor:upper-case' }
+          { label: 'Lower Case', command: 'editor:lower-case' }
+          { type: 'separator' }
+          { label: 'Delete to End of Word', command: 'editor:delete-to-end-of-word' }
+          { label: 'Delete Line', command: 'editor:delete-line' }
+          { type: 'separator' }
+          { label: 'Transpose', command: 'editor:transpose' }
+        ]
+      }
+      {
+        label: 'Folding',
+        submenu: [
+          { label: 'Fold', command: 'editor:fold-current-row' }
+          { label: 'Unfold', command: 'editor:unfold-current-row' }
+          { label: 'Unfold All', command: 'editor:unfold-all' }
+          { type: 'separator' }
+          { label: 'Fold All', command: 'editor:fold-all' }
+          { label: 'Fold Level 1', command: 'editor:fold-at-indent-level-1' }
+          { label: 'Fold Level 2', command: 'editor:fold-at-indent-level-2' }
+          { label: 'Fold Level 3', command: 'editor:fold-at-indent-level-3' }
+          { label: 'Fold Level 4', command: 'editor:fold-at-indent-level-4' }
+          { label: 'Fold Level 5', command: 'editor:fold-at-indent-level-5' }
+          { label: 'Fold Level 6', command: 'editor:fold-at-indent-level-6' }
+          { label: 'Fold Level 7', command: 'editor:fold-at-indent-level-7' }
+          { label: 'Fold Level 8', command: 'editor:fold-at-indent-level-8' }
+          { label: 'Fold Level 9', command: 'editor:fold-at-indent-level-9' }
         ]
       }
     ]

--- a/menus/base.cson
+++ b/menus/base.cson
@@ -45,6 +45,19 @@
       { label: 'Paste', command: 'core:paste' }
       { label: 'Select All', command: 'core:select-all' }
       { type: 'separator' }
+      {
+        label: 'Lines',
+        submenu: [
+          { label: 'Indent', command: 'editor:indent-selected-rows' }
+          { label: 'Outdent', command: 'editor:outdent-selected-rows' }
+          { label: 'Auto Indent', command: 'editor:auto-indent' }
+          { label: 'Move Line Up', command: 'editor:move-line-up' }
+          { label: 'Move Line Down', command: 'editor:move-line-down' }
+          { label: 'Duplicate Line', command: 'editor:duplicate-line' }
+          { label: 'Delete Line', command: 'editor:delete-line' }
+          { label: 'Join Lines', command: 'editor:join-line' }
+        ]
+      }
     ]
   }
 

--- a/menus/base.cson
+++ b/menus/base.cson
@@ -114,6 +114,23 @@
   }
 
   {
+    label: 'Movement'
+    submenu: [
+      { label: 'Move to Top', command: 'core:move-to-top' }
+      { label: 'Move to Bottom', command: 'core:move-to-bottom' }
+      { type: 'separator' }
+      { label: 'Move to Beginning of Line', command: 'editor:move-to-beginning-of-line' }
+      { label: 'Move to First Character of Line', command: 'editor:move-to-first-character-of-line' }
+      { label: 'Move to End of Line', command: 'editor:move-to-end-of-line' }
+      { type: 'separator' }
+      { label: 'Move to Beginning of Word', command: 'editor:move-to-beginning-of-word' }
+      { label: 'Move to End of Word', command: 'editor:move-to-end-of-word' }
+      { label: 'Move to Next Word', command: 'editor:move-to-next-word-boundary' }
+      { label: 'Move to Previous Word', command: 'editor:move-to-previous-word-boundary' }
+    ]
+  }
+
+  {
     label: 'View'
     submenu: [
       { label: 'Reload', command: 'window:reload' }

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -67,7 +67,6 @@ class MenuManager
         continue if binding.indexOf('-down') != -1
         continue if binding.indexOf('tab') != -1
 
-        console.log binding if binding.indexOf('alt-meta') !=-1
         filtered[key] ?= []
         filtered[key].push(binding)
     filtered

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -61,10 +61,8 @@ class MenuManager
       for binding in bindings
         continue if binding.indexOf(' ') != -1
 
-        # Currently being implemented in atom-shell
-        continue if binding.indexOf('-=') != -1
-        continue if binding.indexOf('-up') != -1
-        continue if binding.indexOf('-down') != -1
+        # To be fixed in atom-shell
+        continue if binding.indexOf('f2') != -1
         continue if binding.indexOf('tab') != -1
 
         filtered[key] ?= []

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -61,10 +61,6 @@ class MenuManager
       for binding in bindings
         continue if binding.indexOf(' ') != -1
 
-        # To be fixed in atom-shell
-        continue if binding.indexOf('f2') != -1
-        continue if binding.indexOf('tab') != -1
-
         filtered[key] ?= []
         filtered[key].push(binding)
     filtered


### PR DESCRIPTION
Make our default keybindings similar to Sublime's.
## Highlights
- Adds missing accelerators to menus that weren't on `.body`
- Adds `Edit > Lines`, we had the functionality but not the menu.
- Delete line `meta-d` -> `ctrl-K`
- Join line `ctrl-J` -> `meta-j`
## TODO
- Folding, Upper Case and Lower Case all use compound bindings, do we want to follow that?
