### PR TITLE
Render long lines

### DIFF
--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1591,7 +1591,11 @@ class Editor extends View
       for char, i in content
 
         # Dont return right away, finish caching the whole line
-        returnLeft = left if index == column
+        if index == column
+          returnLeft = left
+
+          # Don't cache lines longer than 100 chars
+          return returnLeft if lineElement.innerText.length > 160
         oldLeft = left
 
         scopes = @scopesForColumn(tokenizedLine, index)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1598,10 +1598,10 @@ class Editor extends View
         oldLeft = left
 
         scopes = @scopesForColumn(tokenizedLine, index)
-        cachedVal = @getCharacterWidthCache(scopes, char)
+        cachedCharWidth = @getCharacterWidthCache(scopes, char)
 
-        if cachedVal?
-          left = oldLeft + cachedVal
+        if cachedCharWidth?
+          left = oldLeft + cachedCharWidth
         else
           # i + 1 to measure to the end of the current character
           MeasureRange.setEnd(textNode, i + 1)
@@ -1611,12 +1611,12 @@ class Editor extends View
           left = rects[0].left - Math.floor(@scrollView.offset().left) + Math.floor(@scrollLeft())
 
           if scopes?
-            cachedVal = left - oldLeft
-            @setCharacterWidthCache(scopes, char, cachedVal)
+            cachedCharWidth = left - oldLeft
+            @setCharacterWidthCache(scopes, char, cachedCharWidth)
 
         # Assume all the characters are the same width when dealing with long
         # lines :racehorse:
-        return column * cachedVal if index > LongLineLength
+        return column * cachedCharWidth if index > LongLineLength
 
         index++
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1614,10 +1614,9 @@ class Editor extends View
             cachedVal = left - oldLeft
             @setCharacterWidthCache(scopes, char, cachedVal)
 
-        # Assume all the charachters are the same width when dealing with long
+        # Assume all the characters are the same width when dealing with long
         # lines :racehorse:
         return column * cachedVal if index > LongLineLength
-
 
         index++
 

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -10,6 +10,8 @@ StartCharacterRegex = /^./
 StartDotRegex = /^\.?/
 WhitespaceRegex = /\S/
 
+maxTokenLength = 20000
+
 # Private: Represents a single unit of text as selected by a grammar.
 module.exports =
 class Token
@@ -165,9 +167,18 @@ class Token
 
         endIndex = match.index
 
-      html = leadingHtml + @escapeString(html, startIndex, endIndex) + trailingHtml
+      fragments = [leadingHtml]
 
-    html
+      if @value.length > maxTokenLength
+        while startIndex < endIndex
+          fragments.push "<span>" + @escapeString(html, startIndex, startIndex + maxTokenLength) + "</span>"
+          startIndex += maxTokenLength
+      else
+        fragments.push @escapeString(html, startIndex, endIndex)
+
+      fragments.push trailingHtml
+
+    fragments.join('')
 
   escapeString: (str, startIndex, endIndex) ->
     strLength = str.length

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -10,7 +10,7 @@ StartCharacterRegex = /^./
 StartDotRegex = /^\.?/
 WhitespaceRegex = /\S/
 
-maxTokenLength = 20000
+MaxTokenLength = 20000
 
 # Private: Represents a single unit of text as selected by a grammar.
 module.exports =
@@ -167,10 +167,10 @@ class Token
 
       fragments = [leadingHtml]
 
-      if @value.length > maxTokenLength
+      if @value.length > MaxTokenLength
         while startIndex < endIndex
-          fragments.push "<span>" + @escapeString(@value, startIndex, startIndex + maxTokenLength) + "</span>"
-          startIndex += maxTokenLength
+          fragments.push "<span>" + @escapeString(@value, startIndex, startIndex + MaxTokenLength) + "</span>"
+          startIndex += MaxTokenLength
       else
         fragments.push @escapeString(@value, startIndex, endIndex)
 

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -131,23 +131,21 @@ class Token
 
   getValueAsHtml: ({invisibles, hasLeadingWhitespace, hasTrailingWhitespace, hasIndentGuide})->
     invisibles ?= {}
-    html = @value
-
     if @isHardTab
       classes = 'hard-tab'
       classes += ' indent-guide' if hasIndentGuide
       classes += ' invisible-character' if invisibles.tab
-      html = html.replace StartCharacterRegex, (match) =>
+      html = @value.replace StartCharacterRegex, (match) =>
         match = invisibles.tab ? match
         "<span class='#{classes}'>#{@escapeString(match)}</span>"
     else
       startIndex = 0
-      endIndex = html.length
+      endIndex = @value.length
 
       leadingHtml = ''
       trailingHtml = ''
 
-      if hasLeadingWhitespace and match = LeadingWhitespaceRegex.exec(html)
+      if hasLeadingWhitespace and match = LeadingWhitespaceRegex.exec(@value)
         classes = 'leading-whitespace'
         classes += ' indent-guide' if hasIndentGuide
         classes += ' invisible-character' if invisibles.space
@@ -157,7 +155,7 @@ class Token
 
         startIndex = match[0].length
 
-      if hasTrailingWhitespace and match = TrailingWhitespaceRegex.exec(html)
+      if hasTrailingWhitespace and match = TrailingWhitespaceRegex.exec(@value)
         classes = 'trailing-whitespace'
         classes += ' indent-guide' if hasIndentGuide and not hasLeadingWhitespace
         classes += ' invisible-character' if invisibles.space
@@ -171,14 +169,14 @@ class Token
 
       if @value.length > maxTokenLength
         while startIndex < endIndex
-          fragments.push "<span>" + @escapeString(html, startIndex, startIndex + maxTokenLength) + "</span>"
+          fragments.push "<span>" + @escapeString(@value, startIndex, startIndex + maxTokenLength) + "</span>"
           startIndex += maxTokenLength
       else
-        fragments.push @escapeString(html, startIndex, endIndex)
+        fragments.push @escapeString(@value, startIndex, endIndex)
 
       fragments.push trailingHtml
-
-    fragments.join('')
+      html = fragments.join('')
+    html
 
   escapeString: (str, startIndex, endIndex) ->
     strLength = str.length

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -165,17 +165,15 @@ class Token
 
         endIndex = match.index
 
-      fragments = [leadingHtml]
-
+      html = leadingHtml
       if @value.length > MaxTokenLength
         while startIndex < endIndex
-          fragments.push "<span>" + @escapeString(@value, startIndex, startIndex + MaxTokenLength) + "</span>"
+          html += "<span>" + @escapeString(@value, startIndex, startIndex + MaxTokenLength) + "</span>"
           startIndex += MaxTokenLength
       else
-        fragments.push @escapeString(@value, startIndex, endIndex)
+        html += @escapeString(@value, startIndex, endIndex)
 
-      fragments.push trailingHtml
-      html = fragments.join('')
+      html += trailingHtml
     html
 
   escapeString: (str, startIndex, endIndex) ->


### PR DESCRIPTION
This fixes two problems based on #979 

1) Chrome doesn't render lines with more than 2^16 chars in a single span.
2) Moving the cursor on long lines (> 1,000 chars) created a long pause or crashed Atom.
