### PR TITLE
Update packages to use new language-* package naming scheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "grammar-selector": "0.7.0",
     "image-view": "0.7.0",
     "link": "0.7.0",
-    "markdown-preview": "0.10.0",
+    "markdown-preview": "0.11.0",
     "metrics": "0.8.0",
     "package-generator": "0.13.0",
     "release-notes": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "package-generator": "0.13.0",
     "release-notes": "0.8.0",
     "settings-view": "0.29.0",
-    "snippets": "0.10.0",
+    "snippets": "0.11.0",
     "spell-check": "0.8.0",
     "status-bar": "0.15.0",
     "styleguide": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "grammar-selector": "0.7.0",
     "image-view": "0.7.0",
     "link": "0.6.0",
-    "markdown-preview": "0.9.0",
+    "markdown-preview": "0.10.0",
     "metrics": "0.8.0",
     "package-generator": "0.13.0",
     "release-notes": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "release-notes": "0.8.0",
     "settings-view": "0.29.0",
     "snippets": "0.10.0",
-    "spell-check": "0.7.0",
+    "spell-check": "0.8.0",
     "status-bar": "0.15.0",
     "styleguide": "0.9.0",
     "symbols-view": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "go-to-line": "0.8.0",
     "grammar-selector": "0.7.0",
     "image-view": "0.7.0",
-    "link": "0.6.0",
+    "link": "0.7.0",
     "markdown-preview": "0.10.0",
     "metrics": "0.8.0",
     "package-generator": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "gists": "0.5.0",
     "github-sign-in": "0.8.0",
     "go-to-line": "0.8.0",
-    "grammar-selector": "0.7.0",
+    "grammar-selector": "0.8.0",
     "image-view": "0.7.0",
     "link": "0.7.0",
     "markdown-preview": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "settings-view": "0.29.0",
     "snippets": "0.10.0",
     "spell-check": "0.7.0",
-    "status-bar": "0.14.0",
+    "status-bar": "0.15.0",
     "styleguide": "0.9.0",
     "symbols-view": "0.12.0",
     "tabs": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "solarized-dark-syntax": "0.3.0",
 
     "archive-view": "0.11.0",
-    "autocomplete": "0.10.0",
+    "autocomplete": "0.11.0",
     "autoflow": "0.5.0",
     "bookmarks": "0.8.0",
     "bracket-matcher": "0.7.0",

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -94,13 +94,6 @@ class PackageManager
     packagePath = path.join(@resourcePath, 'node_modules', name)
     return packagePath if @isInternalPackage(packagePath)
 
-    #TODO Remove once all package specs have been updated
-    if match = /(.+)-tmbundle$/.exec(name)
-      if name is 'hyperlink-helper-tmbundle'
-        @resolvePackagePath('language-hyperlink')
-      else
-        @resolvePackagePath("language-#{match[1]}")
-
   isInternalPackage: (packagePath) ->
     {engines} = Package.loadMetadata(packagePath, true)
     engines?.atom?


### PR DESCRIPTION
Follow on to #1012 

Remove the package activation shim and update all the packages that were previously activating packages using the `*-tmbundle` scheme.
