### PR TITLE
Remove `_.nextTick` from atom exports

### DIFF
--- a/exports/atom.coffee
+++ b/exports/atom.coffee
@@ -1,9 +1,6 @@
 {Document, Point, Range, Site} = require 'telepath'
 _ = require 'underscore-plus'
 
-#TODO Remove once all packages have been updated
-_.nextTick = setImmediate
-
 module.exports =
   _: _
   BufferedNodeProcess: require '../src/buffered-node-process'

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "styleguide": "0.9.0",
     "symbols-view": "0.12.0",
     "tabs": "0.7.0",
-    "terminal": "0.13.0",
+    "terminal": "0.14.0",
     "timecop": "0.6.0",
     "to-the-hubs": "0.8.0",
     "toml": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "find-and-replace": "0.29.0",
     "fuzzy-finder": "0.15.0",
     "gfm": "0.5.0",
-    "git-diff": "0.11.0",
+    "git-diff": "0.12.0",
     "gists": "0.5.0",
     "github-sign-in": "0.8.0",
     "go-to-line": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "symbols-view": "0.12.0",
     "tabs": "0.7.0",
     "terminal": "0.14.0",
-    "timecop": "0.6.0",
+    "timecop": "0.7.0",
     "to-the-hubs": "0.8.0",
     "toml": "0.3.0",
     "tree-view": "0.19.0",


### PR DESCRIPTION
This has been deprecated and I've now removed it. If you're currently using `{_} = require 'atom'` and then calling `_.nextTick` you should use node's `setImmediate` instead.
