### PR TITLE
Get rid of ANSI escape sequences in Constructicon output

### DIFF
--- a/script/constructicon/build
+++ b/script/constructicon/build
@@ -8,7 +8,7 @@ set -ex
 cd "$(dirname "$0")/../.."
 rm -fr node_modules
 ./script/bootstrap
-./node_modules/.bin/grunt --build-dir="$BUILT_PRODUCTS_DIR" deploy
+./node_modules/.bin/grunt --no-color --build-dir="$BUILT_PRODUCTS_DIR" deploy
 
 echo "TARGET_BUILD_DIR=$BUILT_PRODUCTS_DIR"
 echo "FULL_PRODUCT_NAME=Atom.app"


### PR DESCRIPTION
Passing --no-color to grunt should get rid of these.
