### PR TITLE
Fix commenting on hard tab lines

### DIFF
--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -40,6 +40,10 @@ describe "LanguageMode", ->
         languageMode.toggleLineCommentsForBufferRows(0, 0)
         expect(buffer.lineForRow(0)).toBe "// var i;"
 
+        buffer.setText(' var i;')
+        languageMode.toggleLineCommentsForBufferRows(0, 0)
+        expect(buffer.lineForRow(0)).toBe " // var i;"
+
     describe "fold suggestion", ->
       describe ".doesBufferRowStartFold(bufferRow)", ->
         it "returns true only when the buffer row starts a foldable region", ->

--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -32,6 +32,10 @@ describe "LanguageMode", ->
         expect(buffer.lineForRow(6)).toBe "    //   current < pivot ? left.push(current) : right.push(current);"
         expect(buffer.lineForRow(7)).toBe "    // }"
 
+        buffer.setText('\tvar i;')
+        languageMode.toggleLineCommentsForBufferRows(0, 0)
+        expect(buffer.lineForRow(0)).toBe "\t// var i;"
+
     describe "fold suggestion", ->
       describe ".doesBufferRowStartFold(bufferRow)", ->
         it "returns true only when the buffer row starts a foldable region", ->

--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -36,6 +36,10 @@ describe "LanguageMode", ->
         languageMode.toggleLineCommentsForBufferRows(0, 0)
         expect(buffer.lineForRow(0)).toBe "\t// var i;"
 
+        buffer.setText('var i;')
+        languageMode.toggleLineCommentsForBufferRows(0, 0)
+        expect(buffer.lineForRow(0)).toBe "// var i;"
+
     describe "fold suggestion", ->
       describe ".doesBufferRowStartFold(bufferRow)", ->
         it "returns true only when the buffer row starts a foldable region", ->

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -84,8 +84,14 @@ class LanguageMode
       else
         indent = @minIndentLevelForRowRange(start, end)
         indentString = @editSession.buildIndentString(indent)
+        tabLength = @editSession.getTabLength()
+        indentRegex = new RegExp("(\t|[ ]{#{tabLength}}){#{Math.floor(indent)}}")
         for row in [start..end]
-          buffer.change([[row, 0], [row, indentString.length]], indentString + commentStartString)
+          line = buffer.lineForRow(row)
+          if indentLength = line.match(indentRegex)?[0].length
+            buffer.insert([row, indentLength], commentStartString)
+          else
+            buffer.change([[row, 0], [row, indentString.length]], indentString + commentStartString)
 
   # Folds all the foldable lines in the buffer.
   foldAll: ->


### PR DESCRIPTION
Previously commenting on hard tabs lines with soft tabs enabled would corrupt the text being commented.

See atom/language-c#1 for deets.
