### PR TITLE
Search modified buffers

### DIFF
--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -429,3 +429,16 @@ describe "Project", ->
 
         runs ->
           expect(resultHandler).not.toHaveBeenCalled()
+
+      it "scans buffer contents if the buffer is modified", ->
+        editSession = project.openSync("a")
+        editSession.setText("Elephant")
+        results = []
+        waitsForPromise ->
+          project.scan /a|Elephant/, (result) -> results.push result
+
+        runs ->
+          expect(results).toHaveLength 3
+          resultForA = _.find results, ({filePath}) -> path.basename(filePath) == 'a'
+          expect(resultForA.matches).toHaveLength 1
+          expect(resultForA.matches[0].matchText).toBe 'Elephant'

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -425,7 +425,6 @@ describe "Project", ->
         resultHandler = jasmine.createSpy("result found")
         waitsForPromise ->
           project.scan /dollar/, (results) ->
-            console.log results
             resultHandler()
 
         runs ->


### PR DESCRIPTION
`Project::scan` will scan a buffer's contents (instead of on disk contents) if the buffer is modified.

Fixes issue #487 
