### PR TITLE
openSingletonSync()

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "dev-live-reload": "0.13.0",
     "editor-stats": "0.5.0",
     "exception-reporting": "0.5.0",
-    "find-and-replace": "0.33.0",
+    "find-and-replace": "0.33.1",
     "fuzzy-finder": "0.15.1",
     "gists": "0.6.0",
     "git-diff": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "editor-stats": "0.5.0",
     "exception-reporting": "0.5.0",
     "find-and-replace": "0.33.0",
-    "fuzzy-finder": "0.15.0",
+    "fuzzy-finder": "0.15.1",
     "gists": "0.6.0",
     "git-diff": "0.13.0",
     "github-sign-in": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "status-bar": "0.15.0",
     "styleguide": "0.9.0",
     "symbols-view": "0.15.0",
-    "tabs": "0.7.1",
+    "tabs": "0.7.2",
     "terminal": "0.15.0",
     "timecop": "0.9.0",
     "to-the-hubs": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "status-bar": "0.15.0",
     "styleguide": "0.9.0",
     "symbols-view": "0.15.0",
-    "tabs": "0.7.0",
+    "tabs": "0.7.1",
     "terminal": "0.15.0",
     "timecop": "0.9.0",
     "to-the-hubs": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "settings-view": "0.36.0",
     "snippets": "0.12.0",
     "spell-check": "0.9.0",
-    "status-bar": "0.15.0",
+    "status-bar": "0.15.1",
     "styleguide": "0.9.0",
     "symbols-view": "0.15.0",
     "tabs": "0.7.2",

--- a/spec/pane-container-spec.coffee
+++ b/spec/pane-container-spec.coffee
@@ -80,7 +80,7 @@ describe "PaneContainer", ->
       expect(panes).toEqual [pane1, pane2, pane3]
 
       panes = []
-      pane4 = pane3.splitRight()
+      pane4 = pane3.splitRight(pane3.copyActiveItem())
       expect(panes).toEqual [pane4]
 
       panes = []

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -545,7 +545,7 @@ describe "Pane", ->
     describe "splitRight(items...)", ->
       it "builds a row if needed, then appends a new pane after itself", ->
         # creates the new pane with a copy of the active item if none are given
-        pane2 = pane1.splitRight()
+        pane2 = pane1.splitRight(pane1.copyActiveItem())
         expect(container.find('.row .pane').toArray()).toEqual [pane1[0], pane2[0]]
         expect(pane2.items).toEqual [editSession1]
         expect(pane2.activeItem).not.toBe editSession1 # it's a copy
@@ -554,10 +554,22 @@ describe "Pane", ->
         expect(pane3.getItems()).toEqual [view3, view4]
         expect(container.find('.row .pane').toArray()).toEqual [pane[0], pane2[0], pane3[0]]
 
-    describe "splitRight(items...)", ->
+      it "builds a row if needed, then appends a new pane after itself ", ->
+        # creates the new pane with a copy of the active item if none are given
+        pane2 = pane1.splitRight()
+        expect(container.find('.row .pane').toArray()).toEqual [pane1[0], pane2[0]]
+        expect(pane2.items).toEqual []
+        expect(pane2.activeItem).toBe null
+
+        pane3 = pane2.splitRight()
+        expect(container.find('.row .pane').toArray()).toEqual [pane1[0], pane2[0], pane3[0]]
+        expect(pane3.items).toEqual []
+        expect(pane3.activeItem).toBe null
+
+    describe "splitLeft(items...)", ->
       it "builds a row if needed, then appends a new pane before itself", ->
         # creates the new pane with a copy of the active item if none are given
-        pane2 = pane.splitLeft()
+        pane2 = pane.splitLeft(pane1.copyActiveItem())
         expect(container.find('.row .pane').toArray()).toEqual [pane2[0], pane[0]]
         expect(pane2.items).toEqual [editSession1]
         expect(pane2.activeItem).not.toBe editSession1 # it's a copy
@@ -569,7 +581,7 @@ describe "Pane", ->
     describe "splitDown(items...)", ->
       it "builds a column if needed, then appends a new pane after itself", ->
         # creates the new pane with a copy of the active item if none are given
-        pane2 = pane.splitDown()
+        pane2 = pane.splitDown(pane1.copyActiveItem())
         expect(container.find('.column .pane').toArray()).toEqual [pane[0], pane2[0]]
         expect(pane2.items).toEqual [editSession1]
         expect(pane2.activeItem).not.toBe editSession1 # it's a copy
@@ -581,7 +593,7 @@ describe "Pane", ->
     describe "splitUp(items...)", ->
       it "builds a column if needed, then appends a new pane before itself", ->
         # creates the new pane with a copy of the active item if none are given
-        pane2 = pane.splitUp()
+        pane2 = pane.splitUp(pane1.copyActiveItem())
         expect(container.find('.column .pane').toArray()).toEqual [pane2[0], pane[0]]
         expect(pane2.items).toEqual [editSession1]
         expect(pane2.activeItem).not.toBe editSession1 # it's a copy

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -439,8 +439,8 @@ describe "Pane", ->
 
       beforeEach ->
         pane.showItem(editSession1)
-        paneToLeft = pane.splitLeft()
-        paneToRight = pane.splitRight()
+        paneToLeft = pane.splitLeft(pane.copyActiveItem())
+        paneToRight = pane.splitRight(pane.copyActiveItem())
         container.attachToDom()
 
       describe "when the removed pane is focused", ->
@@ -494,7 +494,7 @@ describe "Pane", ->
     it "returns the next pane if one exists, wrapping around from the last pane to the first", ->
       pane.showItem(editSession1)
       expect(pane.getNextPane()).toBeUndefined
-      pane2 = pane.splitRight()
+      pane2 = pane.splitRight(pane.copyActiveItem())
       expect(pane.getNextPane()).toBe pane2
       expect(pane2.getNextPane()).toBe pane
 
@@ -529,7 +529,7 @@ describe "Pane", ->
       expect(pane.isActive()).toBeFalsy()
       pane.focusin()
       expect(pane.isActive()).toBeTruthy()
-      pane.splitRight()
+      pane.splitRight(pane.copyActiveItem())
       expect(pane.isActive()).toBeFalsy()
 
       expect(becameInactiveHandler.callCount).toBe 1

--- a/spec/root-view-spec.coffee
+++ b/spec/root-view-spec.coffee
@@ -210,7 +210,7 @@ describe "RootView", ->
       rootView.trigger 'window:decrease-font-size'
       expect(config.get('editor.fontSize')).toBe 1
 
-  describe ".open(filePath, options)", ->
+  describe ".openSync(filePath, options)", ->
     describe "when there is no active pane", ->
       beforeEach ->
         spyOn(Pane.prototype, 'focus')
@@ -241,6 +241,12 @@ describe "RootView", ->
         it "does not focus the new pane", ->
           editSession = rootView.openSync('b', changeFocus: false)
           expect(rootView.getActivePane().focus).not.toHaveBeenCalled()
+
+      describe "when the split option is 'right'", ->
+        it "creates a new pane and opens the file in said pane", ->
+          editSession = rootView.openSync('b', split: 'right')
+          expect(rootView.getActivePane().activeItem).toBe editSession
+          expect(editSession.getPath()).toBe require.resolve('./fixtures/dir/b')
 
     describe "when there is an active pane", ->
       [activePane, initialItemCount] = []
@@ -284,7 +290,55 @@ describe "RootView", ->
           editSession = rootView.openSync('b', changeFocus: false)
           expect(activePane.focus).not.toHaveBeenCalled()
 
-  describe ".openAsync(filePath)", ->
+      describe "when the split option is 'right'", ->
+        it "creates a new pane and opens the file in said pane", ->
+          pane1 = rootView.getActivePane()
+
+          editSession = rootView.openSync('b', split: 'right')
+          pane2 = rootView.getActivePane()
+          expect(pane2[0]).not.toBe pane1[0]
+          expect(editSession.getPath()).toBe require.resolve('./fixtures/dir/b')
+
+          expect(rootView.panes.find('.row .pane').toArray()).toEqual [pane1[0], pane2[0]]
+
+          editSession = rootView.openSync('file1', split: 'right')
+          pane3 = rootView.getActivePane()
+          expect(pane3[0]).toBe pane2[0]
+          expect(editSession.getPath()).toBe require.resolve('./fixtures/dir/file1')
+
+          expect(rootView.panes.find('.row .pane').toArray()).toEqual [pane1[0], pane2[0]]
+
+  describe ".openSingletonSync(filePath, options)", ->
+    describe "when there is an active pane", ->
+      [pane1] = []
+      beforeEach ->
+        spyOn(Pane.prototype, 'focus').andCallFake -> @makeActive()
+        pane1 = rootView.getActivePane()
+
+      it "creates a new pane and reuses the file when already open", ->
+        rootView.openSingletonSync('b', split: 'right')
+        pane2 = rootView.getActivePane()
+        expect(pane2[0]).not.toBe pane1[0]
+        expect(pane1.itemForUri('b')).toBeFalsy()
+        expect(pane2.itemForUri('b')).not.toBeFalsy()
+        expect(rootView.panes.find('.row .pane').toArray()).toEqual [pane1[0], pane2[0]]
+
+        pane1.focus()
+        expect(rootView.getActivePane()[0]).toBe pane1[0]
+
+        rootView.openSingletonSync('b', split: 'right')
+        pane3 = rootView.getActivePane()
+        expect(pane3[0]).toBe pane2[0]
+        expect(pane1.itemForUri('b')).toBeFalsy()
+        expect(pane2.itemForUri('b')).not.toBeFalsy()
+        expect(rootView.panes.find('.row .pane').toArray()).toEqual [pane1[0], pane2[0]]
+
+      it "reuses the file when already open", ->
+        rootView.openSync('b')
+        rootView.openSingletonSync('b', split: 'right')
+        expect(rootView.panes.find('.pane').toArray()).toEqual [pane1[0]]
+
+  describe ".open(filePath)", ->
     beforeEach ->
       spyOn(Pane.prototype, 'focus')
 

--- a/spec/window-spec.coffee
+++ b/spec/window-spec.coffee
@@ -95,7 +95,8 @@ describe "Window", ->
     it "unsubscribes from all buffers", ->
       rootView.openSync('sample.js')
       buffer = rootView.getActivePaneItem().buffer
-      rootView.getActivePane().splitRight()
+      pane = rootView.getActivePane()
+      pane.splitRight(pane.copyActiveItem())
       expect(window.rootView.find('.editor').length).toBe 2
 
       window.unloadEditorWindow()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1014,17 +1014,21 @@ class Editor extends View
     @updateLayerDimensions()
     @requestDisplayUpdate()
 
-  splitLeft: (items...) ->
-    @getPane()?.splitLeft(items...).activeView
+  splitLeft: ->
+    pane = @getPane()
+    pane?.splitLeft(pane?.copyActiveItem()).activeView
 
-  splitRight: (items...) ->
-    @getPane()?.splitRight(items...).activeView
+  splitRight: ->
+    pane = @getPane()
+    pane?.splitRight(pane?.copyActiveItem()).activeView
 
-  splitUp: (items...) ->
-    @getPane()?.splitUp(items...).activeView
+  splitUp: ->
+    pane = @getPane()
+    pane?.splitUp(pane?.copyActiveItem()).activeView
 
-  splitDown: (items...) ->
-    @getPane()?.splitDown(items...).activeView
+  splitDown: ->
+    pane = @getPane()
+    pane?.splitDown(pane?.copyActiveItem()).activeView
 
   # Retrieve's the `Editor`'s pane.
   #

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -161,6 +161,12 @@ class PaneContainer extends View
   getActiveView: ->
     @getActivePane()?.activeView
 
+  paneForUri: (uri) ->
+    for pane in @getPanes()
+      view = pane.itemForUri(uri)
+      return pane if view?
+    null
+
   adjustPaneDimensions: ->
     if root = @getRoot()
       root.css(width: '100%', height: '100%', top: 0, left: 0)

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -73,10 +73,10 @@ class Pane extends View
     @command 'pane:show-item-8', => @showItemAtIndex(7)
     @command 'pane:show-item-9', => @showItemAtIndex(8)
 
-    @command 'pane:split-left', => @splitLeft()
-    @command 'pane:split-right', => @splitRight()
-    @command 'pane:split-up', => @splitUp()
-    @command 'pane:split-down', => @splitDown()
+    @command 'pane:split-left', => @splitLeft(@copyActiveItem())
+    @command 'pane:split-right', => @splitRight(@copyActiveItem())
+    @command 'pane:split-up', => @splitUp(@copyActiveItem())
+    @command 'pane:split-down', => @splitDown(@copyActiveItem())
     @command 'pane:close', => @destroyItems()
     @command 'pane:close-other-items', => @destroyInactiveItems()
     @on 'focus', => @activeView?.focus(); false
@@ -395,7 +395,6 @@ class Pane extends View
       axis.addChild(this)
       parent = axis
 
-    items = [@copyActiveItem()] unless items.length
     newPane = new Pane(items...)
 
     switch side

--- a/src/root-view.coffee
+++ b/src/root-view.coffee
@@ -221,17 +221,17 @@ class RootView extends View
     pane.focus() if changeFocus
     paneItem
 
-  openSingletonSync: (uri, {split}={}) ->
+  openSingletonSync: (uri, {changeFocus, initialLine, split}={}) ->
     uri = project.relativize(uri)
     pane = @panes.paneForUri(uri)
 
     if pane
       paneItem = pane.itemForUri(uri)
       pane.showItem(paneItem)
-      pane.focus()
+      pane.focus() if changeFocus
       paneItem
     else
-      @openSync(uri, {split})
+      @openSync(uri, {changeFocus, initialLine, split})
 
   # Public: Updates the application's title, based on whichever file is open.
   updateTitle: ->

--- a/src/root-view.coffee
+++ b/src/root-view.coffee
@@ -194,23 +194,44 @@ class RootView extends View
       editSession
 
   # Private: Only used in specs
-  openSync: (filePath, options = {}) ->
-    changeFocus = options.changeFocus ? true
-    initialLine = options.initialLine
-    filePath = project.relativize(filePath)
-    if activePane = @getActivePane()
-      if filePath
-        editSession = activePane.itemForUri(filePath) ? project.openSync(filePath, {initialLine})
-      else
-        editSession = project.openSync()
-      activePane.showItem(editSession)
-    else
-      editSession = project.openSync(filePath, {initialLine})
-      activePane = new Pane(editSession)
-      @panes.setRoot(activePane)
+  openSync: (uri, {changeFocus, initialLine, pane, split}={}) ->
+    changeFocus ?= true
+    pane ?= @getActivePane()
+    uri = project.relativize(uri)
 
-    activePane.focus() if changeFocus
-    editSession
+    if pane
+      if uri
+        paneItem = pane.itemForUri(uri) ? project.openSync(uri, {initialLine})
+      else
+        paneItem = project.openSync()
+
+      if split
+        panes = @getPanes()
+        if panes.length == 1
+          pane = panes[0].splitRight()
+        else
+          pane = _.last(panes)
+
+      pane.showItem(paneItem)
+    else
+      paneItem = project.openSync(uri, {initialLine})
+      pane = new Pane(paneItem)
+      @panes.setRoot(pane)
+
+    pane.focus() if changeFocus
+    paneItem
+
+  openSingletonSync: (uri, {split}={}) ->
+    uri = project.relativize(uri)
+    pane = @panes.paneForUri(uri)
+
+    if pane
+      paneItem = pane.itemForUri(uri)
+      pane.showItem(paneItem)
+      pane.focus()
+      paneItem
+    else
+      @openSync(uri, {split})
 
   # Public: Updates the application's title, based on whichever file is open.
   updateTitle: ->

--- a/src/root-view.coffee
+++ b/src/root-view.coffee
@@ -222,6 +222,7 @@ class RootView extends View
     paneItem
 
   openSingletonSync: (uri, {changeFocus, initialLine, split}={}) ->
+    changeFocus ?= true
     uri = project.relativize(uri)
     pane = @panes.paneForUri(uri)
 


### PR DESCRIPTION
Allows me to open a resource as a singleton: only one of them can be open in any of the panes. 
- also add `split` option to `openSync()` that will open the resource in the rightmost split, or create the split if it doesnt already exist.

Suggestions welcome.
