### PR TITLE
Fix scripts on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "json-front-matter": "~0.1.3",
     "grunt-shell": "~0.3.1",
     "jasmine-node": "git://github.com/kevinsawicki/jasmine-node.git#short-stacks",
-    "request": "~2.27.0"
+    "request": "~2.27.0",
+    "unzip": "~0.1.9"
   },
   "packageDependencies" : {
     "atom-light-ui": "0.5.0",

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -24,7 +24,7 @@ var commands = [
   joinCommands('cd vendor/apm', 'npm install --silent .'),
   'npm install --silent vendor/apm',
   echoNewLine,
-  'node node_modules/.bin/apm install --silent'
+  'node vendor/apm/bin/apm install --silent',
 ];
 
 process.chdir(path.dirname(__dirname));

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -24,7 +24,7 @@ var commands = [
   joinCommands('cd vendor/apm', 'npm install --silent .'),
   'npm install --silent vendor/apm',
   echoNewLine,
-  'node vendor/apm/bin/apm install --silent',
+  'node node_modules/atom-package-manager/bin/apm install --silent',
 ];
 
 process.chdir(path.dirname(__dirname));

--- a/script/build
+++ b/script/build
@@ -5,8 +5,8 @@ var path = require('path');
 process.chdir(path.dirname(__dirname));
 
 cp.safeExec('node script/bootstrap', function() {
-  // ./node_modules/.bin/grunt "$@"
-  var gruntPath = path.join('node_modules', '.bin', 'grunt');
+  // node node_modules/grunt-cli/bin/grunt "$@"
+  var gruntPath = path.join('node_modules', 'grunt-cli', 'bin', 'grunt');
   var args = [gruntPath].concat(process.argv.slice(2));
   cp.safeSpawn(process.execPath, args, process.exit);
 });

--- a/script/cibuild
+++ b/script/cibuild
@@ -32,8 +32,8 @@ cp.safeExec.bind(global, 'node script/bootstrap', function(error) {
   async.series([
     require('rimraf').bind(global, path.join(homeDir, '.atom')),
     cp.safeExec.bind(global, 'git clean -dff'),
-    cp.safeExec.bind(global, 'node node_modules/.bin/apm clean'),
-    cp.safeExec.bind(global, 'node node_modules/.bin/grunt ci --stack --no-color'),
+    cp.safeExec.bind(global, 'node vendor/apm/bin/apm clean'),
+    cp.safeExec.bind(global, 'node node_modules/grunt-cli/bin/grunt ci --stack --no-color'),
   ], function(error) {
     process.exit(error ? 1 : 0);
   });

--- a/script/cibuild
+++ b/script/cibuild
@@ -32,7 +32,7 @@ cp.safeExec.bind(global, 'node script/bootstrap', function(error) {
   async.series([
     require('rimraf').bind(global, path.join(homeDir, '.atom')),
     cp.safeExec.bind(global, 'git clean -dff'),
-    cp.safeExec.bind(global, 'node vendor/apm/bin/apm clean'),
+    cp.safeExec.bind(global, 'node node_modules/atom-package-manager/bin/apm clean'),
     cp.safeExec.bind(global, 'node node_modules/grunt-cli/bin/grunt ci --stack --no-color'),
   ], function(error) {
     process.exit(error ? 1 : 0);

--- a/script/test
+++ b/script/test
@@ -5,5 +5,5 @@ var path = require('path');
 process.chdir(path.dirname(__dirname));
 
 safeExec('node script/bootstrap', function() {
-  safeExec('node node_modules/.bin/grunt ci --stack --no-color', process.exit);
+  safeExec('node node_modules/grunt-cli/bin/grunt ci --stack --no-color', process.exit);
 });


### PR DESCRIPTION
This fixed some errors when running `grunt`, `build`, `test` and `bootstrap` on Windows.
