### PR TITLE
Disable pathwatcher

### DIFF
--- a/src/config.coffee
+++ b/src/config.coffee
@@ -96,6 +96,7 @@ class Config
 
   # Private:
   observeUserConfig: ->
+    return false
     @watchSubscription ?= pathWatcher.watch @configFilePath, (eventType) =>
       @loadUserConfig() if eventType is 'change' and @watchSubscription?
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -96,7 +96,7 @@ class Config
 
   # Private:
   observeUserConfig: ->
-    return false
+    return if process.platform is 'win32'
     @watchSubscription ?= pathWatcher.watch @configFilePath, (eventType) =>
       @loadUserConfig() if eventType is 'change' and @watchSubscription?
 

--- a/src/directory.coffee
+++ b/src/directory.coffee
@@ -100,7 +100,7 @@ class Directory
 
   # Private:
   subscribeToNativeChangeEvents: ->
-    return false
+    return if process.platform is 'win32'
     unless @watchSubscription?
       @watchSubscription = pathWatcher.watch @path, (eventType) =>
         @emit "contents-changed" if eventType is "change"

--- a/src/directory.coffee
+++ b/src/directory.coffee
@@ -100,6 +100,7 @@ class Directory
 
   # Private:
   subscribeToNativeChangeEvents: ->
+    return false
     unless @watchSubscription?
       @watchSubscription = pathWatcher.watch @path, (eventType) =>
         @emit "contents-changed" if eventType is "change"

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -146,7 +146,7 @@ class File
 
   # Private:
   subscribeToNativeChangeEvents: ->
-    return false
+    return if process.platform is 'win32'
     unless @watchSubscription?
       @watchSubscription = pathWatcher.watch @path, (eventType, path) =>
         @handleNativeChangeEvent(eventType, path)

--- a/src/file.coffee
+++ b/src/file.coffee
@@ -146,6 +146,7 @@ class File
 
   # Private:
   subscribeToNativeChangeEvents: ->
+    return false
     unless @watchSubscription?
       @watchSubscription = pathWatcher.watch @path, (eventType, path) =>
         @handleNativeChangeEvent(eventType, path)


### PR DESCRIPTION
Kills path watching functionality for now, until we get #1045 working. 

Useful for not having atom crash right away. I'll make it conditional soon.
