### PR TITLE
Copy docs into atom io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![atom](https://s3.amazonaws.com/speakeasy/apps/icons/27/medium/7db16e44-ba57-11e2-8c6f-981faf658e00.png)
 
-Check out our [guides](https://atom-docs.githubapp.com/v26.0/index.html) and [API documentation](https://atom-docs.githubapp.com/v26.0/api/index.html).
+Check out our [guides](https://www.atom.io/docs/latest/) and [API documentation](https://www.atom.io/docs/api/v34.0.0/api/)
 
 ## Installing
 

--- a/docs/template.jst
+++ b/docs/template.jst
@@ -137,8 +137,7 @@
         </div>
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a href="/<%= tag %>/index.html">Guides</a></li>
-            <li><a href="/<%= tag %>/api/index.html">API</a></li>
+            <li><a href="/docs/api/<%= tag %>/api/index.html">API</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1694,12 +1694,12 @@ class Editor extends View
   getGrammar: ->
     @activeEditSession.getGrammar()
 
-   # {Delegates to: EditSession.setGrammar}
+  # {Delegates to: EditSession.setGrammar}
   setGrammar: (grammar) ->
     throw new Error("Only mini-editors can explicity set their grammar") unless @mini
     @activeEditSession.setGrammar(grammar)
 
-   # {Delegates to: EditSession.reloadGrammar}
+  # {Delegates to: EditSession.reloadGrammar}
   reloadGrammar: ->
     @activeEditSession.reloadGrammar()
 

--- a/tasks/docs-task.coffee
+++ b/tasks/docs-task.coffee
@@ -7,8 +7,6 @@ module.exports = (grunt) ->
     stdio: 'inherit'
 
   grunt.registerTask 'build-docs', 'Builds the API docs in src/app', ->
-    grunt.task.run('markdown:guides')
-
     done = @async()
     args = [commonArgs..., '--title', 'Atom API Documentation', '-o', 'docs/output/api', 'src/', 'vendor/telepath/lib/range.coffee', 'vendor/telepath/lib/point.coffee']
     grunt.util.spawn({cmd, args, opts}, done)
@@ -33,11 +31,11 @@ module.exports = (grunt) ->
         if error?
           callback(error)
         else
-          callback(null, String(result).trim().split('.')[0..1].join('.'))
+          callback(null, String(result).trim())
 
     copyDocs = (tag, callback) ->
       cmd = 'cp'
-      args = ['-r', 'docs/output/', "../atom-docs/public/#{tag}/"]
+      args = ['-r', 'docs/output/', "../atom.io/public/docs/api/#{tag}/"]
 
       grunt.util.spawn {cmd, args}, (error, result) ->
         if error?

--- a/tasks/docs-task.coffee
+++ b/tasks/docs-task.coffee
@@ -1,4 +1,5 @@
 path = require 'path'
+fs = require 'fs'
 
 module.exports = (grunt) ->
   cmd = path.join('node_modules', '.bin', 'coffee')
@@ -37,11 +38,16 @@ module.exports = (grunt) ->
       cmd = 'cp'
       args = ['-r', 'docs/output/', "../atom.io/public/docs/api/#{tag}/"]
 
-      grunt.util.spawn {cmd, args}, (error, result) ->
-        if error?
-          callback(error)
+      fs.exists "../atom.io/public/docs/api/", (exists) ->
+        if exists
+          grunt.util.spawn {cmd, args}, (error, result) ->
+            if error?
+              callback(error)
+            else
+              callback(null, tag)
         else
-          callback(null, tag)
+          grunt.log.error "../atom.io/public/docs/api/ doesn't exist"
+          return false
 
     grunt.util.async.waterfall [fetchTag, copyDocs], done
 

--- a/tasks/docs-task.coffee
+++ b/tasks/docs-task.coffee
@@ -9,7 +9,7 @@ module.exports = (grunt) ->
 
   grunt.registerTask 'build-docs', 'Builds the API docs in src/app', ->
     done = @async()
-    args = [commonArgs..., '--title', 'Atom API Documentation', '-o', 'docs/output/api', 'src/', 'vendor/telepath/lib/range.coffee', 'vendor/telepath/lib/point.coffee']
+    args = [commonArgs..., '--title', 'Atom API Documentation', '-o', 'docs/output/api', 'src/', '../telepath/src/range.coffee', '../telepath/src/point.coffee', '../telepath/src/string-marker.coffee']
     grunt.util.spawn({cmd, args, opts}, done)
 
   grunt.registerTask 'lint-docs', 'Generate stats about the doc coverage', ->


### PR DESCRIPTION
A couple simple changes to build the docs into the atom.io repo:
- check if `../atom.io` exists
- skip building guides as they get imported into the DB and indexed for search
