### PR TITLE
Update soft wrap column on editor resize

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1656,6 +1656,7 @@ describe "Editor", ->
 
   describe "when soft-wrap is enabled", ->
     beforeEach ->
+      jasmine.unspy(window, 'setTimeout')
       editSession.setSoftWrap(true)
       editor.attachToDom()
       setEditorHeightInLines(editor, 20)
@@ -1734,6 +1735,19 @@ describe "Editor", ->
       otherEditor.simulateDomAttachment()
       expect(otherEditor.setWidthInChars).toHaveBeenCalled()
       otherEditor.remove()
+
+    describe "when the editor's width changes", ->
+      it "updates the width in characters on the edit session", ->
+        previousSoftWrapColumn = editSession.getSoftWrapColumn()
+
+        spyOn(editor, 'setWidthInChars').andCallThrough()
+        editor.width(editor.width() / 2)
+
+        waitsFor ->
+          editor.setWidthInChars.callCount > 0
+
+        runs ->
+          expect(editSession.getSoftWrapColumn()).toBeLessThan previousSoftWrapColumn
 
   describe "gutter rendering", ->
     beforeEach ->

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -106,8 +106,10 @@ class DisplayBuffer
   #
   # editorWidthInChars - A {Number} of characters.
   setEditorWidthInChars: (editorWidthInChars) ->
+    previousWidthInChars = @state.get('editorWidthInChars')
     @state.set('editorWidthInChars', editorWidthInChars)
-    @updateWrappedScreenLines() if @getSoftWrap()
+    if editorWidthInChars isnt previousWidthInChars and @getSoftWrap()
+      @updateWrappedScreenLines()
 
   getSoftWrapColumn: ->
     editorWidthInChars = @state.get('editorWidthInChars')

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -707,7 +707,7 @@ class Editor extends View
 
     # Listen for overflow events to detect when the editor's width changes
     # to update the soft wrap column.
-    updateWidthInChars = _.debounce((=> @setWidthInChars()), 1)
+    updateWidthInChars = _.debounce((=> @setWidthInChars()), 100)
     @scrollView.on 'overflowchanged', =>
       updateWidthInChars() if @[0].classList.contains('soft-wrap')
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -704,6 +704,13 @@ class Editor extends View
       else
         @gutter.addClass('drop-shadow')
 
+
+    # Listen for overflow events to detect when the editor's width changes
+    # to update the soft wrap column.
+    updateWidthInChars = _.debounce((=> @setWidthInChars()), 1)
+    @scrollView.on 'overflowchanged', =>
+      updateWidthInChars() if @[0].classList.contains('soft-wrap')
+
   handleInputEvents: ->
     @on 'cursor:moved', =>
       return unless @isFocused

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -704,7 +704,6 @@ class Editor extends View
       else
         @gutter.addClass('drop-shadow')
 
-
     # Listen for overflow events to detect when the editor's width changes
     # to update the soft wrap column.
     updateWidthInChars = _.debounce((=> @setWidthInChars()), 100)


### PR DESCRIPTION
Use the `overflowchanged` event to detect when the editor's size changes and update the soft wrap column accordingly.

The soft wrap column should now update properly when resizing the window, hiding/showing/resizing the tree view, and when splitting the editor.
