### PR TITLE
Handle themes with padding on the scroll view

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "tree-view": "0.28.0",
     "visual-bell": "0.3.0",
     "whitespace": "0.8.0",
-    "wrap-guide": "0.4.0",
+    "wrap-guide": "0.5.0",
 
     "language-c": "0.2.0",
     "language-clojure": "0.1.0",

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1330,7 +1330,7 @@ describe "Editor", ->
           expect(editor.renderedLines.find(".line:first").text()).toBe buffer.lineForRow(0)
           expect(editor.renderedLines.find(".line:last").text()).toBe buffer.lineForRow(6)
 
-      ffit "increases the width of the rendered lines element to be either the width of the longest line or the width of the scrollView (whichever is longer)", ->
+      it "increases the width of the rendered lines element to be either the width of the longest line or the width of the scrollView (whichever is longer)", ->
         maxLineLength = editor.getMaxScreenLineLength()
         setEditorWidthInChars(editor, maxLineLength)
         widthBefore = editor.renderedLines.width()

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -777,6 +777,9 @@ describe "Editor", ->
           # resizes with the editor
           expect(editor.width()).toBeLessThan(800)
           editor.width(800)
+          editor.resize() # call to trigger the resize event.
+
+          region2 = selectionView.regions[1]
           expect(region2.width()).toBe(editor.renderedLines.outerWidth())
 
           region3 = selectionView.regions[2]
@@ -1332,7 +1335,7 @@ describe "Editor", ->
         setEditorWidthInChars(editor, maxLineLength)
         widthBefore = editor.renderedLines.width()
         expect(widthBefore).toBe editor.scrollView.width() + 20
-        buffer.change([[12,0], [12,0]], [1..maxLineLength*2].join(''))
+        buffer.change([[12,0], [12,0]], [1..maxLineLength*10].join(''))
         expect(editor.renderedLines.width()).toBeGreaterThan widthBefore
 
     describe "when lines are removed", ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1330,12 +1330,12 @@ describe "Editor", ->
           expect(editor.renderedLines.find(".line:first").text()).toBe buffer.lineForRow(0)
           expect(editor.renderedLines.find(".line:last").text()).toBe buffer.lineForRow(6)
 
-      it "increases the width of the rendered lines element to be either the width of the longest line or the width of the scrollView (whichever is longer)", ->
+      ffit "increases the width of the rendered lines element to be either the width of the longest line or the width of the scrollView (whichever is longer)", ->
         maxLineLength = editor.getMaxScreenLineLength()
         setEditorWidthInChars(editor, maxLineLength)
         widthBefore = editor.renderedLines.width()
         expect(widthBefore).toBe editor.scrollView.width() + 20
-        buffer.change([[12,0], [12,0]], [1..maxLineLength*10].join(''))
+        buffer.change([[12,0], [12,0]], [1..maxLineLength*2].join(''))
         expect(editor.renderedLines.width()).toBeGreaterThan widthBefore
 
     describe "when lines are removed", ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -773,8 +773,8 @@ class Editor extends View
     @subscribe $(window), "resize.editor-#{@id}", =>
       @setHeightInLines()
       @setWidthInChars()
-      @requestDisplayUpdate()
       @updateLayerDimensions()
+      @requestDisplayUpdate()
     @focus() if @isFocused
 
     if pane = @getPane()
@@ -1156,7 +1156,7 @@ class Editor extends View
       @verticalScrollbarContent.height(@layerHeight)
       @scrollBottom(height) if @scrollBottom() > height
 
-    minWidth = @scrollView.width()
+    minWidth = Math.max(@charWidth * @getMaxScreenLineLength() + 20, @scrollView.width())
     unless @layerMinWidth == minWidth
       @renderedLines.css('min-width', minWidth)
       @underlayer.css('min-width', minWidth)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -774,6 +774,7 @@ class Editor extends View
       @setHeightInLines()
       @setWidthInChars()
       @requestDisplayUpdate()
+      @updateLayerDimensions()
     @focus() if @isFocused
 
     if pane = @getPane()
@@ -1155,7 +1156,7 @@ class Editor extends View
       @verticalScrollbarContent.height(@layerHeight)
       @scrollBottom(height) if @scrollBottom() > height
 
-    minWidth = @charWidth * @getMaxScreenLineLength() + 20
+    minWidth = @scrollView.width()
     unless @layerMinWidth == minWidth
       @renderedLines.css('min-width', minWidth)
       @underlayer.css('min-width', minWidth)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1596,6 +1596,9 @@ class Editor extends View
 
     returnLeft = null
 
+    offsetLeft = @scrollView.offset().left
+    paddingLeft = parseInt(@scrollView.css('padding-left'))
+
     while textNode = iterator.nextNode()
       content = textNode.textContent
 
@@ -1618,7 +1621,7 @@ class Editor extends View
           MeasureRange.collapse()
           rects = MeasureRange.getClientRects()
           return 0 if rects.length == 0
-          left = rects[0].left - Math.floor(@scrollView.offset().left) + Math.floor(@scrollLeft())
+          left = rects[0].left - Math.floor(offsetLeft) + Math.floor(@scrollLeft()) - paddingLeft
 
           if scopes?
             cachedCharWidth = left - oldLeft

--- a/static/editor.less
+++ b/static/editor.less
@@ -101,12 +101,6 @@
   overflow-x: hidden;
 }
 
-.editor .underlayer,
-.editor .lines,
-.editor .overlayer {
-  width: 100%;
-}
-
 .editor .underlayer {
   z-index: 0;
   position: absolute;


### PR DESCRIPTION
In the tomorrow dark theme, the code is jammed up against the gutter. We should be able to use padding on the scroll view and have the editor gracefully handle. 

This: 
![screen shot 2013-11-05 at 6 41 45 pm](https://f.cloud.github.com/assets/69169/1479756/0d482d38-468d-11e3-97a7-e9072d5906ff.png)

Not this:
![screen shot 2013-11-05 at 6 42 04 pm](https://f.cloud.github.com/assets/69169/1479757/11acc564-468d-11e3-9955-f968515cd52f.png)

Here are some changes that need to happen in order to make this happen.
