### PR TITLE
Autoscroll on undo/redo

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -958,6 +958,16 @@ describe "Editor", ->
           editor.insertText('\n\n')
           expect(editor.scrollToPixelPosition.callCount).toBe 1
 
+        it "autoscrolls on undo/redo", ->
+          editor.getCursor().clearAutoscroll()
+          spyOn(editor, 'scrollToPixelPosition').andCallThrough()
+          editor.insertText('\n\n')
+          expect(editor.scrollToPixelPosition.callCount).toBe 1
+          editor.undo()
+          expect(editor.scrollToPixelPosition.callCount).toBe 2
+          editor.redo()
+          expect(editor.scrollToPixelPosition.callCount).toBe 3
+
         describe "when the last cursor exceeds the upper or lower scroll margins", ->
           describe "when the editor is taller than twice the vertical scroll margin", ->
             it "sets the scrollTop so the cursor remains within the scroll margin", ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -959,8 +959,7 @@ describe "Editor", ->
           expect(editor.scrollToPixelPosition.callCount).toBe 1
 
         it "autoscrolls on undo/redo", ->
-          editor.getCursor().clearAutoscroll()
-          spyOn(editor, 'scrollToPixelPosition').andCallThrough()
+          spyOn(editor, 'scrollToPixelPosition')
           editor.insertText('\n\n')
           expect(editor.scrollToPixelPosition.callCount).toBe 1
           editor.undo()

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -27,7 +27,7 @@ class Cursor
       {textChanged} = e
       return if oldHeadScreenPosition.isEqual(newHeadScreenPosition)
 
-      @needsAutoscroll ?= @isLastCursor() and !textChanged
+      @needsAutoscroll ?= @isLastCursor()
 
       movedEvent =
         oldBufferPosition: oldHeadBufferPosition

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -27,7 +27,7 @@ class Cursor
       {textChanged} = e
       return if oldHeadScreenPosition.isEqual(newHeadScreenPosition)
 
-      @needsAutoscroll ?= @isLastCursor()
+      @needsAutoscroll ?= @isLastCursor() and !textChanged
 
       movedEvent =
         oldBufferPosition: oldHeadBufferPosition

--- a/src/edit-session.coffee
+++ b/src/edit-session.coffee
@@ -574,14 +574,12 @@ class EditSession
 
   # Public: Undoes the last change.
   undo: ->
-    cursor = @getCursor()
-    cursor.needsAutoscroll = cursor.isLastCursor()
+    @getCursor().needsAutoscroll = true
     @buffer.undo(this)
 
   # Pulic: Redoes the last change.
   redo: ->
-    cursor = @getCursor()
-    cursor.needsAutoscroll = cursor.isLastCursor()
+    @getCursor().needsAutoscroll = true
     @buffer.redo(this)
 
   # Public: Folds all the rows.

--- a/src/edit-session.coffee
+++ b/src/edit-session.coffee
@@ -574,10 +574,14 @@ class EditSession
 
   # Public: Undoes the last change.
   undo: ->
+    cursor = @getCursor()
+    cursor.needsAutoscroll = cursor.isLastCursor()
     @buffer.undo(this)
 
   # Pulic: Redoes the last change.
   redo: ->
+    cursor = @getCursor()
+    cursor.needsAutoscroll = cursor.isLastCursor()
     @buffer.redo(this)
 
   # Public: Folds all the rows.


### PR DESCRIPTION
The editor does not autoscroll on undo/redo since telepath was introduced.

This is one possible approach to fixing it by marking the last cursor for autoscroll when calling undo/redo on the edit session.

Closes #984 
