### PR TITLE
Fix editor occasionally going blank

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -74,6 +74,16 @@ describe "Editor", ->
 
       expect(editor.hiddenInput).toMatchSelector ':focus'
       expect($(editor[0]).scrollTop()).toBe 0
+      expect($(editor.scrollView[0]).scrollTop()).toBe 0
+
+      editor.moveCursorToBottom()
+      editor.hiddenInput.blur()
+      editor.scrollTop(0)
+      editor.focus()
+
+      expect(editor.hiddenInput).toMatchSelector ':focus'
+      expect($(editor[0]).scrollTop()).toBe 0
+      expect($(editor.scrollView[0]).scrollTop()).toBe 0
 
   describe "when the hidden input is focused / unfocused", ->
     it "assigns the isFocused flag on the editor and also adds/removes the .focused css class", ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -644,6 +644,7 @@ class Editor extends View
       false
 
     @hiddenInput.on 'focus', =>
+      @bringHiddenInputIntoView()
       @isFocused = true
       @addClass 'is-focused'
 


### PR DESCRIPTION
### Problem
1. Open a file that scrolls in the editor
2. Move the cursor to the bottom
3. Focus the find and replace view (cmd-f)
4. Scroll the editor to the top without focusing it (using the scroll wheel)
5. Hit escape to close the find and replace view
6. Editor goes blank with only line numbers displaying
### Solution

Bring the hidden input into view when the editor gets focus since the scroll position may have changed since the last `focusout` event.
