### PR TITLE
Filter development dependencies from windows builds

### DIFF
--- a/tasks/build-task.coffee
+++ b/tasks/build-task.coffee
@@ -29,8 +29,13 @@ module.exports = (grunt) ->
       'vendor'
     ]
 
-    {devDependencies} = grunt.file.readJSON('package.json')
-    for child in fs.readdirSync('node_modules')
+    directories = fs.readdirSync('node_modules')
+    if process.platform is 'win32'
+      {devDependencies} = grunt.file.readJSON('package.json')
+      devDependencies = Object.keys(devDependencies)
+      directories = directories.filter((d) -> devDependencies.indexOf(d) == -1)
+
+    for child in directories
       directory = path.join('node_modules', child)
       if isAtomPackage(directory)
         packageDirectories.push(directory)


### PR DESCRIPTION
This is a temporary step so that we can create a working install executable on windows (currently test fixtures in some development packages have longer paths than windows allows).
