### PR TITLE
Use `.workspace` rather than `body` for keybindings

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -1,4 +1,4 @@
-'body.platform-darwin':
+'.workspace-darwin':
   # Apple specific
   'meta-q': 'application:quit'
   'meta-h': 'application:hide'
@@ -87,7 +87,7 @@
   'meta-8': 'pane:show-item-8'
   'meta-9': 'pane:show-item-9'
 
-'.platform-darwin .editor':
+'.workspace-darwin .editor':
   # Apple Specific
   'meta-backspace': 'editor:backspace-to-beginning-of-line'
   'meta-delete': 'editor:backspace-to-beginning-of-line'

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -1,4 +1,4 @@
-'.workspace-darwin':
+'.platform-darwin':
   # Apple specific
   'meta-q': 'application:quit'
   'meta-h': 'application:hide'
@@ -87,7 +87,7 @@
   'meta-8': 'pane:show-item-8'
   'meta-9': 'pane:show-item-9'
 
-'.workspace-darwin .editor':
+'.platform-darwin .editor':
   # Apple Specific
   'meta-backspace': 'editor:backspace-to-beginning-of-line'
   'meta-delete': 'editor:backspace-to-beginning-of-line'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -1,4 +1,4 @@
-'.workspace-win32':
+'.platform-win32':
   # Atom Specific
   'enter': 'core:confirm'
   'escape': 'core:cancel'
@@ -50,6 +50,6 @@
   'ctrl-k meta-left': 'window:focus-previous-pane'
   'ctrl-k meta-right': 'window:focus-next-pane'
 
-'.workspace-win32 .editor':
+'.platform-win32 .editor':
   # Windows specific
   'ctrl-delete': 'editor:backspace-to-beginning-of-word'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -1,4 +1,4 @@
-'body.platform-win32':
+'.workspace-win32':
   # Atom Specific
   'enter': 'core:confirm'
   'escape': 'core:cancel'
@@ -50,6 +50,6 @@
   'ctrl-k meta-left': 'window:focus-previous-pane'
   'ctrl-k meta-right': 'window:focus-next-pane'
 
-'.platform-win32 .editor':
+'.workspace-win32 .editor':
   # Windows specific
   'ctrl-delete': 'editor:backspace-to-beginning-of-word'

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -65,7 +65,7 @@ class Atom
 
   # Private:
   setBodyPlatformClass: ->
-    document.body.classList.add("platform-#{process.platform}")
+    document.body.classList.add("workspace-#{process.platform}")
 
   getCurrentWindow: ->
     remote.getCurrentWindow()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -65,7 +65,7 @@ class Atom
 
   # Private:
   setBodyPlatformClass: ->
-    document.body.classList.add("workspace-#{process.platform}")
+    document.body.classList.add("platform-#{process.platform}")
 
   getCurrentWindow: ->
     remote.getCurrentWindow()

--- a/static/index.html
+++ b/static/index.html
@@ -22,6 +22,6 @@
     }
   </script>
 </head>
-<body tabindex="-1">
+<body class="workspace" tabindex="-1">
 </body>
 </html>


### PR DESCRIPTION
Integrating this change will require users to update their keymaps to reference `.workspace` where they previously referenced `body`. That way our new platform specific key bindings won't override user configured bindings.
