### PR TITLE
Set up Windows font fallbacks

### DIFF
--- a/static/editor.less
+++ b/static/editor.less
@@ -8,7 +8,7 @@
   -webkit-user-select: none;
   position: relative;
   z-index: 0;
-  font-family: Inconsolata, Monaco, Courier;
+  font-family: Inconsolata, Monaco, Consolas, Courier;
   line-height: 1.3;
 }
 

--- a/static/editor.less
+++ b/static/editor.less
@@ -8,7 +8,7 @@
   -webkit-user-select: none;
   position: relative;
   z-index: 0;
-  font-family: Inconsolata, Monaco, Consolas, Courier;
+  font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier;
   line-height: 1.3;
 }
 

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -20,7 +20,7 @@ body {
   list-style: none;
 }
 
-#HTMLReporter { font-size: 11px; font-family: Monaco, monospace; line-height: 1.6em; color: #333333; }
+#HTMLReporter { font-size: 11px; font-family: Monaco, Consolas, monospace; line-height: 1.6em; color: #333333; }
 #HTMLReporter #jasmine_content { position: fixed; right: 100%; }
 
 #HTMLReporter .symbolHeader {

--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -81,4 +81,4 @@
 
 // Other
 
-@font-family: 'Lucida Grande', Arial, sans-serif;
+@font-family: 'Lucida Grande', 'Segoe UI', sans-serif;


### PR DESCRIPTION
Most people don't have Inconsolata or Monaco installed on their boxes, here's a hack at getting the Windows equivalents (ignore my unactivated Windows install lol):

**Settings:**
![image](https://f.cloud.github.com/assets/1396/1586463/560129f6-5229-11e3-9f1c-2682083a8e5e.png)

**Main View:**
![image](https://f.cloud.github.com/assets/1396/1586473/7d0649b4-5229-11e3-9bbd-822873efa631.png)
