### PR TITLE
Check selectors using webkitMatchesSelector

### DIFF
--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -36,6 +36,8 @@ class MenuManager
   includeSelector: (selector) ->
     return true if document.body.webkitMatchesSelector(selector)
 
+    # Simulate an .editor element attached to a body element that has the same
+    # classes as the current body element.
     unless @testEditor?
       @testEditor = document.createElement('div')
       @testEditor.classList.add('editor')

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -49,7 +49,6 @@ class MenuManager
   update: ->
     keystrokesByCommand = {}
     for binding in atom.keymap.getKeyBindings() when @includeSelector(binding.selector)
-      console.log binding.selector
       keystrokesByCommand[binding.command] ?= []
       keystrokesByCommand[binding.command].push binding.keystroke
     @sendToBrowserProcess(@template, keystrokesByCommand)

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -34,6 +34,8 @@ class MenuManager
   #
   # Returns true to include the selector, false otherwise.
   includeSelector: (selector) ->
+    return true if document.body.webkitMatchesSelector(selector)
+
     unless @testEditor?
       @testEditor = document.createElement('div')
       @testEditor.classList.add('editor')
@@ -41,7 +43,7 @@ class MenuManager
       testBody.classList.add(document.body.classList.toString().split(' ')...)
       testBody.appendChild(@testEditor)
 
-    document.body.webkitMatchesSelector(selector) or @testEditor.webkitMatchesSelector(selector)
+    @testEditor.webkitMatchesSelector(selector)
 
   # Public: Refreshes the currently visible menu.
   update: ->

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -27,11 +27,27 @@ class MenuManager
     @merge(@template, item) for item in items
     @update()
 
+  # Private: Should the binding for the given selector be included in the menu
+  # commands.
+  #
+  # * selector: A String selector to check.
+  #
+  # Returns true to include the selector, false otherwise.
+  includeSelector: (selector) ->
+    unless @testEditor?
+      @testEditor = document.createElement('div')
+      @testEditor.classList.add('editor')
+      testBody = document.createElement('body')
+      testBody.classList.add(document.body.classList.toString().split(' ')...)
+      testBody.appendChild(@testEditor)
+
+    document.body.webkitMatchesSelector(selector) or @testEditor.webkitMatchesSelector(selector)
+
   # Public: Refreshes the currently visible menu.
   update: ->
     keystrokesByCommand = {}
-    selectors = ['body', ".platform-#{process.platform}", '.editor', '.editor:not(.mini)']
-    for binding in atom.keymap.getKeyBindings() when binding.selector in selectors
+    for binding in atom.keymap.getKeyBindings() when @includeSelector(binding.selector)
+      console.log binding.selector
       keystrokesByCommand[binding.command] ?= []
       keystrokesByCommand[binding.command].push binding.keystroke
     @sendToBrowserProcess(@template, keystrokesByCommand)
@@ -40,8 +56,8 @@ class MenuManager
   loadPlatformItems: ->
     menusDirPath = path.join(@resourcePath, 'menus')
     platformMenuPath = fs.resolve(menusDirPath, process.platform, ['cson', 'json'])
-    data = CSON.readFileSync(platformMenuPath)
-    @add(data.menu)
+    {menu} = CSON.readFileSync(platformMenuPath)
+    @add(menu)
 
   # Private: Merges an item in a submenu aware way such that new items are always
   # appended to the bottom of existing menus where possible.


### PR DESCRIPTION
Previously the bindings to include used direct string comparison for inclusion.

This excluded things that were now using `body.platform-darwin editor:not(.mini)` since it wasn't an exact match such as move line up/down.

![screen shot 2013-11-21 at 2 21 59 pm](https://f.cloud.github.com/assets/671378/1596419/75e1e878-52fb-11e3-90c4-9e08a3f0bfd6.png)

Now the selector is directly tested against an `.editor` element or the actual `document.body` so the string comparisons aren't needed.

/cc @mcolyer Would love your thoughts on this.
