### PR TITLE
Add license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright 2013 GitHub Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
   "bugs": {
     "url": "https://github.com/atom/atom/issues"
   },
+  "licenses": [
+    {
+      "type": "Apache",
+      "url": "http://github.com/atom/atom/raw/master/LICENSE.md"
+    }
+  ],
   "atomShellVersion": "0.6.12",
   "dependencies": {
     "async": "0.2.6",


### PR DESCRIPTION
We should probably decide on a license before the private alpha starts.

This PR is an attempt at that with an initial choice of the MIT license.

Once we agree on one for atom/atom, I'll update all other package repos with the same license.

/cc @hoolio @defunkt 
