### PR TITLE
Update atom-shell to v0.7.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       "url": "http://github.com/atom/atom/raw/master/LICENSE.md"
     }
   ],
-  "atomShellVersion": "0.6.12",
+  "atomShellVersion": "0.7.2",
   "dependencies": {
     "async": "0.2.6",
     "bootstrap": "git://github.com/benogle/bootstrap.git",

--- a/spec/spec-bootstrap.coffee
+++ b/spec/spec-bootstrap.coffee
@@ -1,3 +1,6 @@
+# Start the crash reporter before anything else.
+require('crash-reporter').start(productName: 'Atom', companyName: 'GitHub')
+
 try
   require '../src/window'
   Atom = require '../src/atom'

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -67,9 +67,7 @@ delegate.browserMainParts.preMainMessageLoopRun = ->
 global.devResourcePath = path.join(app.getHomeDir(), 'github', 'atom')
 
 setupCrashReporter = ->
-  crashReporter.setCompanyName 'GitHub'
-  crashReporter.setSubmissionUrl 'https://speakeasy.githubapp.com/submit_crash_log'
-  crashReporter.setAutoSubmit true
+  crashReporter.start(productName: 'Atom', companyName: 'GitHub')
 
 setupAutoUpdater = ->
   autoUpdater.setFeedUrl 'https://speakeasy.githubapp.com/apps/27/appcast.xml'

--- a/src/window-bootstrap.coffee
+++ b/src/window-bootstrap.coffee
@@ -1,6 +1,9 @@
 # Like sands through the hourglass, so are the days of our lives.
 startTime = Date.now()
 
+# Start the crash reporter before anything else.
+require('crash-reporter').start(productName: 'Atom', companyName: 'GitHub')
+
 require './window'
 
 Atom = require './atom'


### PR DESCRIPTION
From atom-shell v0.7.2 we are using the new [breakpad](https://code.google.com/p/google-breakpad/wiki/GettingStartedWithBreakpad) crash reporter on both Windows and OS X, it doesn't require any symbol files to be present on users' machine, and we can generate nice stack traces on the server.

The crash reports submission url is temporarily set to the default one (http://54.249.141.255:1127), which is my ec2 machine running the [atom/mini-breakpad-server](https://github.com/atom/mini-breakpad-server).

Currently the operating system libraries' symbols were not resolved on the server side, since we need to generate breakpad symbols for all system libraries on all versions of operation systems. On Windows it's possible to generate the symbols from Microsoft's debugging symbols server, and Mozilla [has a script to do it](https://wiki.mozilla.org/Breakpad:Symbols#Windows_system_symbols). On OS X we can just manually generate the symbols on 10.9 and 10.8.
