### PR TITLE
Removing core treeview settings

### DIFF
--- a/static/panels.less
+++ b/static/panels.less
@@ -20,13 +20,6 @@
   }
 }
 
-.focusable-panel {
-  opacity: 0.8;
-  &:focus {
-    opacity: 1;
-  }
-}
-
 .panel-heading {
   margin: 0;
 


### PR DESCRIPTION
Removing .focusable-pannel from the core app and adding to default themes with a more subtle transition. cc @benogle 
