### PR TITLE
Use buffer positions for char width cache

### DIFF
--- a/spec/editor-view-spec.coffee
+++ b/spec/editor-view-spec.coffee
@@ -2832,3 +2832,22 @@ describe "EditorView", ->
       setEditorWidthInChars(editorView, 100)
       $(window).trigger 'resize'
       expect(editorView.editor.getSoftWrapColumn()).toBe 100
+
+  describe "character width caching", ->
+    describe "when soft wrap is enabled", ->
+      it "correctly calculates the the position left for a column", ->
+        editor.setSoftWrap(true)
+        editorView.setText('lllll 00000')
+        editorView.setFontFamily('serif')
+        editorView.setFontSize(10)
+        editorView.attachToDom()
+        editorView.setWidthInChars(5)
+
+        expect(editorView.pixelPositionForScreenPosition([0, 5]).left).toEqual 15
+        expect(editorView.pixelPositionForScreenPosition([1, 5]).left).toEqual 25
+
+        # Check that widths are actually being cached
+        spyOn(editorView, 'measureToColumn').andCallThrough()
+        editorView.pixelPositionForScreenPosition([0, 5])
+        editorView.pixelPositionForScreenPosition([1, 5])
+        expect(editorView.measureToColumn.callCount).toBe 0

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -1611,14 +1611,6 @@ class EditorView extends View
         index++
     left
 
-  scopesForColumn: (tokenizedLine, bufferColumn) ->
-    index = 0
-    for token in tokenizedLine.tokens
-      for char in token.value
-        return token.scopes if index == bufferColumn
-        index++
-    null
-
   measureToColumn: (lineElement, tokenizedLine, screenColumn, lineStartBufferColumn) ->
     left = oldLeft = index = 0
     iterator = document.createNodeIterator(lineElement, NodeFilter.SHOW_TEXT, TextNodeFilter)
@@ -1639,7 +1631,7 @@ class EditorView extends View
         returnLeft = left if index == screenColumn
         oldLeft = left
 
-        scopes = @scopesForColumn(tokenizedLine, lineStartBufferColumn + index)
+        scopes = tokenizedLine.tokenAtBufferColumn(lineStartBufferColumn + index)?.scopes
         cachedCharWidth = @getCharacterWidthCache(scopes, char)
 
         if cachedCharWidth?


### PR DESCRIPTION
Wrapped lines were previously causing incorrect offsets to be cached causing the cursor to appear out of place as shown in #1096 
