### PR TITLE
Prefer npm created node_modules/.bin/grunt

### DIFF
--- a/script/build
+++ b/script/build
@@ -5,8 +5,7 @@ var path = require('path');
 process.chdir(path.dirname(__dirname));
 
 cp.safeExec('node script/bootstrap', function() {
-  // node node_modules/grunt-cli/bin/grunt "$@"
-  var gruntPath = path.join('node_modules', 'grunt-cli', 'bin', 'grunt');
-  var args = [gruntPath].concat(process.argv.slice(2));
-  cp.safeSpawn(process.execPath, args, process.exit);
+  // node_modules/.bin/grunt "$@"
+  var gruntPath = path.join('node_modules', '.bin', 'grunt') + (process.platform === 'win32' ? '.cmd' : '');
+  cp.safeSpawn(gruntPath, process.argv.slice(2), process.exit);
 });

--- a/script/cibuild
+++ b/script/cibuild
@@ -29,10 +29,11 @@ cp.safeExec.bind(global, 'node script/bootstrap', function(error) {
   if (error)
     process.exit(1);
   var async = require('async');
+  var gruntPath = path.join('node_modules', '.bin', 'grunt') + (process.platform === 'win32' ? '.cmd' : '');
   async.series([
     require('rimraf').bind(global, path.join(homeDir, '.atom')),
     cp.safeExec.bind(global, 'git clean -dff'),
-    cp.safeExec.bind(global, 'node node_modules/grunt-cli/bin/grunt ci --stack --no-color'),
+    cp.safeExec.bind(global, gruntPath + ' ci --stack --no-color'),
     cp.safeExec.bind(global, 'node_modules/.bin/coffee script/upload-release')
   ], function(error) {
     process.exit(error ? 1 : 0);

--- a/script/test
+++ b/script/test
@@ -5,5 +5,6 @@ var path = require('path');
 process.chdir(path.dirname(__dirname));
 
 safeExec('node script/bootstrap', function() {
-  safeExec('node node_modules/grunt-cli/bin/grunt ci --stack --no-color', process.exit);
+  var gruntPath = path.join('node_modules', '.bin', 'grunt') + (process.platform === 'win32' ? '.cmd' : '');
+  safeExec(gruntPath + ' ci --stack --no-color', process.exit);
 });


### PR DESCRIPTION
It is more reliable to use the `grunt` binary created by npm in the `node_modules/.bin/` folder. This way if the path or name of the binary gets updated or installed another way (see gruntjs/grunt#943), the path `node_modules/.bin/grunt` will always remain the same.
