### PR TITLE
Add manual package install directions to Atom docs

### DIFF
--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -19,13 +19,11 @@ Themes` section on the `Packages` tab within the Settings panel.
 You can install non-bundled packages by going to the `Available Packages`
 section on the `Packages` tab within the Settings panel (`cmd-,`).
 
-To manually install a package from [atom.io](http://atom-io.dev/packages) (emmet, in this example), run this in your shell:
+To manually install a package or theme...
 
-`$ apm install emmet`
+`apm install <package_name>`
 
-If you want to install a specific version of a package, you can do so like this:
-
-`$ apm install emmet@0.1.5`
+`apm install <package_name>@<package_version>`. For example `apm install emmet@0.1.5` installs the `0.1.5` release of Emmet into Atom.
 
 ## Customizing Key Bindings
 

--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -19,6 +19,14 @@ Themes` section on the `Packages` tab within the Settings panel.
 You can install non-bundled packages by going to the `Available Packages`
 section on the `Packages` tab within the Settings panel (`cmd-,`).
 
+To manually install a package from [atom.io](http://atom-io.dev/packages) (emmet, in this example), run this in your shell:
+
+`$ apm install emmet`
+
+If you want to install a specific version of a package, you can do so like this:
+
+`$ apm install emmet@0.1.5`
+
 ## Customizing Key Bindings
 
 Atom keymaps work similarly to stylesheets. Just as stylesheets use selectors

--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -19,11 +19,15 @@ Themes` section on the `Packages` tab within the Settings panel.
 You can install non-bundled packages by going to the `Available Packages`
 section on the `Packages` tab within the Settings panel (`cmd-,`).
 
-To manually install a package or theme...
+You can also install packages from the command line using the
+[apm](https://github.com/atom/apm) command:
 
-`apm install <package_name>`
+`apm install <package_name>` to install the latest version.
 
-`apm install <package_name>@<package_version>`. For example `apm install emmet@0.1.5` installs the `0.1.5` release of Emmet into Atom.
+`apm install <package_name>@<package_version>` to install a specific version.
+
+For example `apm install emmet@0.1.5`  installs the `0.1.5` release of the
+[Emmet](https://github.com/atom/emmet) package into `~/.atom/packages`.
 
 ## Customizing Key Bindings
 

--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -26,7 +26,7 @@ You can also install packages from the command line using the
 
 `apm install <package_name>@<package_version>` to install a specific version.
 
-For example `apm install emmet@0.1.5`  installs the `0.1.5` release of the
+For example `apm install emmet@0.1.5` installs the `0.1.5` release of the
 [Emmet](https://github.com/atom/emmet) package into `~/.atom/packages`.
 
 ## Customizing Key Bindings


### PR DESCRIPTION
The Atom package pages currently link to the Atom package installation section of the docs to explain how to install specific versions of packages. This adds that content.

cc @gjtorikian for quality
