### PR TITLE
Add token dealings to atom core

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "guid": "0.0.10",
     "jasmine-focused": "~0.15.0",
     "mkdirp": "0.3.5",
+    "keytar": "0.13.0",
     "less-cache": "0.10.0",
     "nslog": "0.1.0",
     "oniguruma": "0.24.0",

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -353,13 +353,16 @@ class Atom
   getVersion: ->
     app.getVersion()
 
+  getGitHubAuthTokenName: ->
+    'Atom GitHub API Token'
+
   # Public: Set the the github token in the keychain
   setGitHubAuthToken: (token) ->
-    keytar.replacePassword('Atom GitHub API Token', 'github', token)
+    keytar.replacePassword(@getGitHubAuthTokenName(), 'github', token)
 
   # Public: Get the github token from the keychain
   getGitHubAuthToken: ->
-    keytar.getPassword('Atom GitHub API Token', 'github')
+    keytar.getPassword(@getGitHubAuthTokenName(), 'github')
 
   # Public: Get the directory path to Atom's configuration area.
   #

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -1,5 +1,6 @@
 crypto = require 'crypto'
 ipc = require 'ipc'
+keytar = require 'keytar'
 os = require 'os'
 path = require 'path'
 remote = require 'remote'
@@ -352,9 +353,13 @@ class Atom
   getVersion: ->
     app.getVersion()
 
-  # Public: Get the name of the github token in the keychain
-  getGitHubTokenName: ->
-    'Atom GitHub API Token'
+  # Public: Set the the github token in the keychain
+  setGitHubAuthToken: (token) ->
+    keytar.replacePassword('Atom GitHub API Token', 'github', token)
+
+  # Public: Get the github token from the keychain
+  getGitHubAuthToken: ->
+    keytar.getPassword('Atom GitHub API Token', 'github')
 
   # Public: Get the directory path to Atom's configuration area.
   #

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -352,6 +352,10 @@ class Atom
   getVersion: ->
     app.getVersion()
 
+  # Public: Get the name of the github token in the keychain
+  getGitHubTokenName: ->
+    'Atom GitHub API Token'
+
   # Public: Get the directory path to Atom's configuration area.
   #
   # Returns the absolute path to ~/.atom


### PR DESCRIPTION
So more and more packages are using the auth token. I want a unified way to deal with this thing. So far, what I have (`atom.getGitHubTokenName()`) is the minimum IMO I want in there. But we could include keytar and have access to the token in the core. Like:

``` coffeescript
setGitHubAuthToken: (token) ->
  keytar.replacePassword('Atom GitHub API Token', 'github', token)

getGitHubAuthToken: ->
  keytar.getPassword('Atom GitHub API Token', 'github')

deleteGitHubAuthToken: ->
  keytar.deletePassword('Atom GitHub API Token', 'github')
```

WDYT? Good? Bad? Ugly?
