### PR TITLE
Add a splash of color to commit messages

### DIFF
--- a/static/atom.less
+++ b/static/atom.less
@@ -19,5 +19,6 @@
 @import "markdown";
 @import "editor";
 @import "select-list";
+@import "syntax";
 @import "utilities";
 @import "octicons";

--- a/static/atom.less
+++ b/static/atom.less
@@ -1,5 +1,9 @@
-// Import from the theme's variables with a fallback to /static/variables/ui-variables.less
+// Import from the syntax theme's variables with a fallback to ./variables/syntax-variables.less
+@import "syntax-variables";
+
+// Import from the ui theme's variables with a fallback to ./variables/ui-variables.less
 @import "ui-variables";
+
 @import "octicon-utf-codes";
 @import "octicon-mixins";
 

--- a/static/editor.less
+++ b/static/editor.less
@@ -11,6 +11,22 @@
   z-index: 0;
   font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier;
   line-height: 1.3;
+
+  .markup {
+    &.git-commit {
+      &.changed {
+        color: @text-color-warning;
+      }
+
+      &.deleted {
+        color: @text-color-error;
+      }
+
+      &.inserted {
+        color: @text-color-info;
+      }
+    }
+  }
 }
 
 .editor .gutter .line-number.cursor-line {

--- a/static/editor.less
+++ b/static/editor.less
@@ -11,22 +11,6 @@
   z-index: 0;
   font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier;
   line-height: 1.3;
-
-  .markup {
-    &.git-commit {
-      &.changed {
-        color: @text-color-warning;
-      }
-
-      &.deleted {
-        color: @text-color-error;
-      }
-
-      &.inserted {
-        color: @text-color-info;
-      }
-    }
-  }
 }
 
 .editor .gutter .line-number.cursor-line {

--- a/static/syntax.less
+++ b/static/syntax.less
@@ -1,4 +1,4 @@
-@import "ui-variables";
+@import "syntax-variables";
 
 .editor {
   .lines {

--- a/static/syntax.less
+++ b/static/syntax.less
@@ -1,0 +1,21 @@
+@import "ui-variables";
+
+.editor {
+  .lines {
+    .markup {
+      &.git-commit {
+        &.changed {
+          color: @syntax-color-modified;
+        }
+
+        &.deleted {
+          color: @syntax-color-removed;
+        }
+
+        &.inserted {
+          color: @syntax-color-added;
+        }
+      }
+    }
+  }
+}

--- a/static/variables/syntax-variables.less
+++ b/static/variables/syntax-variables.less
@@ -4,7 +4,7 @@
 // Colors
 
 @syntax-background-color: #fff;
-@syntax-text-color: #333;
+@syntax-color: #333;
 
 @syntax-color-added: #00f;
 @syntax-color-ignored: #333;

--- a/static/variables/syntax-variables.less
+++ b/static/variables/syntax-variables.less
@@ -3,6 +3,6 @@
 
 // Colors
 
-@syntax-color-added: #00f;
-@syntax-color-modified: #0f0;
-@syntax-color-removed: #f00;
+@syntax-color-added: #5293d8;
+@syntax-color-modified: #f78a46;
+@syntax-color-removed: #c00;

--- a/static/variables/syntax-variables.less
+++ b/static/variables/syntax-variables.less
@@ -3,11 +3,6 @@
 
 // Colors
 
-@syntax-background-color: #fff;
-@syntax-color: #333;
-
 @syntax-color-added: #00f;
-@syntax-color-ignored: #333;
 @syntax-color-modified: #0f0;
-@syntax-color-renamed: #333;
 @syntax-color-removed: #f00;

--- a/static/variables/syntax-variables.less
+++ b/static/variables/syntax-variables.less
@@ -1,0 +1,8 @@
+// This file has fallback variables. It specifies the syntax variables that
+// themes must implement.
+
+// Colors
+
+@syntax-color-added: #00f;
+@syntax-color-modified: #0f0;
+@syntax-color-removed: #f00;

--- a/static/variables/syntax-variables.less
+++ b/static/variables/syntax-variables.less
@@ -3,6 +3,11 @@
 
 // Colors
 
+@syntax-background-color: #fff;
+@syntax-text-color: #333;
+
 @syntax-color-added: #00f;
+@syntax-color-ignored: #333;
 @syntax-color-modified: #0f0;
+@syntax-color-renamed: #333;
 @syntax-color-removed: #f00;


### PR DESCRIPTION
@benogle This felt like it belonged in `editor.less` since it just used the variables directly, instead of in each syntax theme independently, let me know what you think.

The colors just match the ones used in the gutter by the git-diff package, feedback welcome.

![screen shot 2013-12-06 at 9 46 24 am](https://f.cloud.github.com/assets/671378/1694282/63eefe86-5e9e-11e3-92f4-bbb9ac0e090c.png)
