### PR TITLE
Upgrade to telepath 0.65.0. Fixes #1197

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "season": "0.14.0",
     "semver": "1.1.4",
     "space-pen": "2.0.1",
-    "telepath": "0.61.0",
+    "telepath": "0.65.0",
     "temp": "0.5.0",
     "underscore-plus": "0.3.0"
   },


### PR DESCRIPTION
I now have a real solution in place. Whenever we invert a patch that updates a non replicated array, we also include updates for any markers with timestamps that are newer than the patch being inverted. This prevents us from failing to update markers that are newer than the operation we are undoing.
