### PR TITLE
Upload releases to atom/atom-master-builds repo

### DIFF
--- a/docs/setting-up-travis.md
+++ b/docs/setting-up-travis.md
@@ -7,6 +7,14 @@ Currently we have a [Travis Pro][travis-pro] account since the repositories
 are private.  This process will be simpler and have fewer steps once the
 package repos are made public.
 
+Each package builds using the [build-package][build-package] script, any
+changes to the build should be made in that script and will affect all
+package builds immediately.
+
+Each package builds against the latest successful build of atom@master. The
+master builds are stored in the [atom-master-builds][atom-master-builds] repo
+as releases named by the SHA-1 built.
+
 ## Configuring a package
 
 * Run `cd ~/github/my-package` to navigate to the package repo locally
@@ -18,9 +26,12 @@ package repos are made public.
 * Run `apm ci` to add a `.travis.yml` file to the repo and to configure Travis
 * Log into [Travis][travis-ci] as the `atom-build` user and you should now see
   the package listed and building
+  
 
 [apm]: https://github.com/atom/apm
+[build-package]: https://github.com/atom/apm/blob/master/script/build-package
 [atom-build]: https://github.com/atom-build
+[atom-master-builds]: https://github.com/atom/atom-master-builds/releases
 [atom-org]: https://github.com/atom
 [travis-ci]: https://magnum.travis-ci.com
 [travis-ci-team]: https://github.com/organizations/atom/teams/596636

--- a/script/upload-release
+++ b/script/upload-release
@@ -76,7 +76,7 @@ createRelease = (callback) ->
         tag_name: "v#{commitSha}"
         target_commitish: 'master'
         name: commitSha
-        body: "Build of [atom@#{commitSha.substring(0, 7)}](https://github.com/atom/atom/commit/#{process.env.commitSha})"
+        body: "Build of [atom@#{commitSha.substring(0, 7)}](https://github.com/atom/atom/commit/#{commitSha})"
         draft: true
     request options, (error, response, release={}) ->
       if error? or response.statusCode isnt 201

--- a/script/upload-release
+++ b/script/upload-release
@@ -1,16 +1,21 @@
 #!/usr/bin/env coffee
 
-return if process.env.JANKY_SHA1 and process.env.JANKY_BRANCH isnt 'master'
+return if process.env.JANKY_SHA1 and process.env.JANKY_BRANCH isnt 'ks-builds-repo'
 
 child_process = require 'child_process'
 path = require 'path'
 
+_ = require 'underscore-plus'
 fs = require 'fs-plus'
 GitHub = require 'github-releases'
 request = require 'request'
 
 assetPath = '/tmp/atom-build/atom-mac.zip'
+commitSha = process.env.JANKY_SHA1
 token = process.env.ATOM_ACCESS_TOKEN
+defaultHeaders =
+  Authorization: "token #{token}"
+  'User-Agent': 'Atom'
 
 zipApp = (callback) ->
   fs.removeSync(assetPath)
@@ -23,32 +28,28 @@ zipApp = (callback) ->
     else
       callback()
 
-getDraftRelease = (callback) ->
-  github = new GitHub({repo: 'atom/atom', token})
-  github.getReleases (error, releases=[]) ->
-    if error?
-      console.error('Fetching releases failed', error.message, error.stack)
+getRelease = (callback) ->
+  options =
+    uri: 'https://api.github.com/repos/atom/atom-master-builds/releases'
+    method: 'GET'
+    headers: defaultHeaders
+    json: true
+  request options, (error, response, releases=[]) ->
+    if error? or response.statusCode isnt 200
+      console.error('Fetching releases failed', error, releases)
       process.exit(1)
-
-    if releases.length is 0
-      console.error('No releases found in atom/atom repo')
-      process.exit(1)
-
-    for release in releases when release.draft
-      callback(release)
-      return
-
-    console.error('No draft release found in atom/atom repo')
-    process.exit(1)
+    else
+      for release in releases when release.name is commitSha
+        callback(release)
+        return
+      callback()
 
 deleteExistingAsset = (release, callback) ->
   for asset in release.assets when asset.name is path.basename(assetPath)
     options =
       uri: asset.url
       method: 'DELETE'
-      headers:
-        Authorization: "token #{token}"
-        'User-Agent': 'Atom'
+      headers: defaultHeaders
     request options, (error, response, body='') ->
       if error? or response.statusCode >= 400
         console.error('Deleting existing release asset failed', error, body)
@@ -60,24 +61,63 @@ deleteExistingAsset = (release, callback) ->
 
   callback()
 
-uploadAsset = (release) ->
+createRelease = (callback) ->
+  getRelease (release) ->
+    if release?
+      deleteExistingAsset release, ->
+        callback(release)
+      return
+
+    options =
+      uri: 'https://api.github.com/repos/atom/atom-master-builds/releases'
+      method: 'POST'
+      headers: defaultHeaders
+      json:
+        tag_name: "v#{commitSha}"
+        target_commitish: 'master'
+        name: commitSha
+        body: "Build of [atom@#{commitSha.substring(0, 7)}](https://github.com/atom/atom/commit/#{process.env.commitSha})"
+        draft: true
+    request options, (error, response, release={}) ->
+      if error? or response.statusCode isnt 201
+        console.error('Creating release failed', error, release)
+        process.exit(1)
+      else
+        callback(release)
+
+uploadAsset = (release, callback) ->
   options =
-    uri: "https://uploads.github.com/repos/atom/atom/releases/#{release.id}/assets?name=#{path.basename(assetPath)}"
+    uri: "https://uploads.github.com/repos/atom/atom-master-builds/releases/#{release.id}/assets?name=#{path.basename(assetPath)}"
     method: 'POST'
-    headers:
-      Authorization: "token #{token}"
+    headers: _.extend({
       'Content-Type': 'application/zip'
       'Content-Length': fs.getSizeSync(assetPath)
-      'User-Agent': 'Atom'
+      }, defaultHeaders)
 
   assetRequest = request options, (error, response, body='') ->
     if error? or response.statusCode >= 400
       console.error('Upload release asset failed', error, body)
       process.exit(1)
+    else
+      callback(release)
+
   fs.createReadStream(assetPath).pipe(assetRequest)
 
-getDraftRelease (release) ->
-  console.log("Uploading #{path.basename(assetPath)} asset to #{release.tag_name} (#{release.name}) release")
+publishRelease = (release) ->
+  options =
+    uri: release.url
+    method: 'POST'
+    headers:
+      Authorization: "token #{token}"
+      'User-Agent': 'Atom'
+    json:
+      draft: false
+  request options, (error, response, body={}) ->
+    if error? or response.statusCode isnt 200
+      console.error('Creating release failed', error, body)
+      process.exit(1)
+
+createRelease (release) ->
   zipApp ->
-    deleteExistingAsset release, ->
-      uploadAsset(release)
+    uploadAsset release, ->
+      publishRelease release

--- a/script/upload-release
+++ b/script/upload-release
@@ -1,6 +1,6 @@
 #!/usr/bin/env coffee
 
-return if process.env.JANKY_SHA1 and process.env.JANKY_BRANCH isnt 'ks-builds-repo'
+return if process.env.JANKY_SHA1 and process.env.JANKY_BRANCH isnt 'master'
 
 child_process = require 'child_process'
 path = require 'path'


### PR DESCRIPTION
Makes them reachable on travis, see them [here](https://github.com/atom/atom-master-builds/releases).

Previously they were uploaded to the draft release in this repo which made them inaccessible by travis since only people with push access can see draft releases, and the travis ci team only has pull access.
