### PR TITLE
Fix `grunt download-atom-shell` on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "language-toml": "0.7.0",
     "language-xml": "0.2.0",
     "language-yaml": "0.1.0",
-    "grunt-download-atom-shell": "0.1.3"
+    "grunt-download-atom-shell": "0.2.0"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
Fixed a missing unzip dependency so that we can download atom-shell on windows again.

@paulcbetts this should get you back to building atom master again.
