### PR TITLE
Make i18n support a setting

### DIFF
--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -32,6 +32,7 @@ class EditorView extends View
     softWrap: false
     softTabs: true
     softWrapAtPreferredLineLength: false
+    enableI18nSupport: false
 
   @nextEditorId: 1
 
@@ -651,6 +652,7 @@ class EditorView extends View
     @observeConfig 'editor.invisibles', (invisibles) => @setInvisibles(invisibles)
     @observeConfig 'editor.fontSize', (fontSize) => @setFontSize(fontSize)
     @observeConfig 'editor.fontFamily', (fontFamily) => @setFontFamily(fontFamily)
+    @observeConfig 'editor.enableI18nSupport', (enabled) => @setEnableI18NSupport(enabled)
 
   handleEvents: ->
     @on 'focus', =>
@@ -1023,6 +1025,15 @@ class EditorView extends View
     @clearCharacterWidthCache()
 
     @redraw()
+
+  # Set whether internationalization support is enabled on the editor view.
+  #
+  # Enabling this will display the IME popup dialog when a character is held
+  # down and also the ability to use alt-n/alt-e to type accented characters in
+  # two keystrokes.
+  setEnableI18NSupport: (enabled) ->
+    type = if enabled then 'text' else 'password'
+    @hiddenInput.attr('type', type)
 
   # Gets the font family for the editor.
   #

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -32,7 +32,7 @@ class EditorView extends View
     softWrap: false
     softTabs: true
     softWrapAtPreferredLineLength: false
-    enableI18nSupport: false
+    i18nSupport: false
 
   @nextEditorId: 1
 
@@ -652,7 +652,7 @@ class EditorView extends View
     @observeConfig 'editor.invisibles', (invisibles) => @setInvisibles(invisibles)
     @observeConfig 'editor.fontSize', (fontSize) => @setFontSize(fontSize)
     @observeConfig 'editor.fontFamily', (fontFamily) => @setFontFamily(fontFamily)
-    @observeConfig 'editor.enableI18nSupport', (enabled) => @setEnableI18NSupport(enabled)
+    @observeConfig 'editor.i18nSupport', (i18nSupport) => @setI18NSupport(i18nSupport)
 
   handleEvents: ->
     @on 'focus', =>
@@ -1031,7 +1031,7 @@ class EditorView extends View
   # Enabling this will display the IME popup dialog when a character is held
   # down and also allow alt-e/i/n/u to be used to type accented characters in
   # two keystrokes.
-  setEnableI18NSupport: (enabled) ->
+  setI18NSupport: (enabled) ->
     type = if enabled then 'text' else 'password'
     @hiddenInput.attr('type', type)
 

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -1031,8 +1031,8 @@ class EditorView extends View
   # Enabling this will display the IME popup dialog when a character is held
   # down and also allow alt-e/i/n/u to be used to type accented characters in
   # two keystrokes.
-  setI18NSupport: (enabled) ->
-    type = if enabled then 'text' else 'password'
+  setI18NSupport: (i18nSupport) ->
+    type = if i18nSupport then 'text' else 'password'
     @hiddenInput.attr('type', type)
 
   # Gets the font family for the editor.

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -1029,7 +1029,7 @@ class EditorView extends View
   # Set whether internationalization support is enabled on the editor view.
   #
   # Enabling this will display the IME popup dialog when a character is held
-  # down and also the ability to use alt-n/alt-e to type accented characters in
+  # down and also allow alt-e/i/n/u to be used to type accented characters in
   # two keystrokes.
   setEnableI18NSupport: (enabled) ->
     type = if enabled then 'text' else 'password'


### PR DESCRIPTION
Several keybindings are currently unusable since Mac OS X maps them to multi-keystroke accents.

Such as:
- `alt-n` followed by an `a` types an `ã`
- `alt-e` followed by an `e` types an `é`.

This is useful if you are typing these characters but also makes the `alt-e` and `alt-n` keybindings unusable in a keymap since they generate the same key event `alt-å` and you can't distinguish between two in code. Type `alt-n` in the editor with the keybindings-resolver open to see for yourself.

One possible fix for this is to set type `password` on the hidden input since these characters can't be typed into password fields in this manner and so the key events go back to "normal" and `alt-e` and `alt-n` can now be used again in keymaps.

This PR adds a preference `editor.enableI18nSupport` that toggles the hidden input between `text` and `password`.

Other ideas/approaches are welcome, this is just an initial stab at it after @benburkert reported not being able to use `alt-n` in his keymaps file.
