### PR TITLE
Upgrade Telepath hoping to fix undefined timestamp exceptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "season": "0.14.0",
     "semver": "1.1.4",
     "space-pen": "2.0.1",
-    "telepath": "0.67.0",
+    "telepath": "0.68.0",
     "temp": "0.5.0",
     "underscore-plus": "0.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "season": "0.14.0",
     "semver": "1.1.4",
     "space-pen": "2.0.1",
-    "telepath": "0.66.0",
+    "telepath": "0.67.0",
     "temp": "0.5.0",
     "underscore-plus": "0.5.0"
   },

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -438,3 +438,11 @@ describe "the `atom` global", ->
           expect(atom.config.get('core.themes')).not.toContain packageName
           expect(atom.config.get('core.themes')).not.toContain packageName
           expect(atom.config.get('core.disabledPackages')).not.toContain packageName
+
+  describe ".isReleasedVersion()", ->
+    it "returns false if the version is a SHA and true otherwise", ->
+      version = '0.1.0'
+      spyOn(atom, 'getVersion').andCallFake -> version
+      expect(atom.isReleasedVersion()).toBe true
+      version = '36b5518'
+      expect(atom.isReleasedVersion()).toBe false

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -9,7 +9,8 @@ dialog = remote.require 'dialog'
 app = remote.require 'app'
 
 _ = require 'underscore-plus'
-{Document} = require 'telepath'
+telepath = require 'telepath'
+{Document} = telepath
 fs = require 'fs-plus'
 {Subscriber} = require 'emissary'
 
@@ -52,6 +53,8 @@ class Atom
 
     {devMode, resourcePath} = atom.getLoadSettings()
     configDirPath = @getConfigDirPath()
+
+    telepath.devMode = not @isReleasedVersion()
 
     Config = require './config'
     Keymap = require './keymap'

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -361,6 +361,10 @@ class Atom
   getVersion: ->
     app.getVersion()
 
+  # Public: Determine whether the current version is an official release.
+  isReleasedVersion: ->
+    not /\w{7}/.test(@getVersion()) # Check if the release is a 7-character SHA prefix
+
   getGitHubAuthTokenName: ->
     'Atom GitHub API Token'
 


### PR DESCRIPTION
This enables a dev mode flag on Telepath when we aren't on releases to help us diagnose how markers are getting into a state where they don't have a timestamp to begin with. These won't run on official releases, and I added a null guard that should hopefully shield end users from this issue.
