### PR TITLE
Upgrade to telepath 0.70.0 for undefined marker timestamp fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "season": "0.14.0",
     "semver": "1.1.4",
     "space-pen": "2.0.1",
-    "telepath": "0.68.0",
+    "telepath": "0.70.0",
     "temp": "0.5.0",
     "underscore-plus": "0.5.0"
   },


### PR DESCRIPTION
This upgrades the serialization version of telepath documents because
for a window of time we were storing undefined timestamps. It also
adds dev-mode assertions that raise when the index of a solo marker
exceeds the array length. I think that issue should actually be resolved
and if we don't see an assertion failure here for a while we can remove
the Math.min shim.

Closes atom/telepath#7
