### PR TITLE
Apply text to buffer via diff on reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "clear-cut": "0.2.0",
     "coffee-script": "1.6.3",
     "coffeestack": "0.6.0",
+    "diff": "git://github.com/benogle/jsdiff.git",
     "emissary": "0.19.0",
     "first-mate": "0.5.0",
     "fs-plus": "0.11.0",

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -462,36 +462,37 @@ describe 'TextBuffer', ->
       expect(event.newRange).toEqual [[0, 0], [1, 14]]
 
   describe ".setTextViaDiff(text)", ->
-    it "changes the entire contents of the buffer with smaller content with no newline at the end", ->
-      newText = "I know you are.\nBut what am I?"
-      buffer.setTextViaDiff(newText)
-      expect(buffer.getText()).toBe newText
-
-    it "changes the entire contents of the buffer with smaller content with newline at the end", ->
-      newText = "I know you are.\nBut what am I?\n"
-      buffer.setTextViaDiff(newText)
-      expect(buffer.getText()).toBe newText
-
-    it "changes a few lines at the beginning in the buffer", ->
-      newText = buffer.getText().replace(/function/g, 'omgwow')
-      buffer.setTextViaDiff(newText)
-      expect(buffer.getText()).toBe newText
-
-    it "changes a few lines in the middle of the buffer", ->
-      newText = buffer.getText().replace(/shift/g, 'omgwow')
-      buffer.setTextViaDiff(newText)
-      expect(buffer.getText()).toBe newText
-
-    it "adds a newline at the end", ->
-      newText = buffer.getText() + '\n'
-      buffer.setTextViaDiff(newText)
-      expect(buffer.getText()).toBe newText
-
-    it "changes all with no newlines", ->
+    it "can change the entire contents of the buffer when there are no newlines", ->
       buffer.setText('BUFFER CHANGE')
       newText = 'DISK CHANGE'
       buffer.setTextViaDiff(newText)
       expect(buffer.getText()).toBe newText
+
+    describe "with standard newlines", ->
+      it "can change the entire contents of the buffer with no newline at the end", ->
+        newText = "I know you are.\nBut what am I?"
+        buffer.setTextViaDiff(newText)
+        expect(buffer.getText()).toBe newText
+
+      it "can change the entire contents of the buffer with a newline at the end", ->
+        newText = "I know you are.\nBut what am I?\n"
+        buffer.setTextViaDiff(newText)
+        expect(buffer.getText()).toBe newText
+
+      it "can change a few lines at the beginning in the buffer", ->
+        newText = buffer.getText().replace(/function/g, 'omgwow')
+        buffer.setTextViaDiff(newText)
+        expect(buffer.getText()).toBe newText
+
+      it "can change a few lines in the middle of the buffer", ->
+        newText = buffer.getText().replace(/shift/g, 'omgwow')
+        buffer.setTextViaDiff(newText)
+        expect(buffer.getText()).toBe newText
+
+      it "can adds a newline at the end", ->
+        newText = buffer.getText() + '\n'
+        buffer.setTextViaDiff(newText)
+        expect(buffer.getText()).toBe newText
 
     describe "with windows newlines", ->
       beforeEach ->

--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -113,10 +113,17 @@ describe 'TextBuffer', ->
 
         runs ->
           [event] = changeHandler.argsForCall[0]
-          expect(event.oldRange).toEqual [[0, 0], [0, 5]]
+          expect(event.oldRange).toEqual [[0, 0], [0, 0]]
           expect(event.newRange).toEqual [[0, 0], [0, 6]]
-          expect(event.oldText).toBe "first"
+          expect(event.oldText).toBe ""
           expect(event.newText).toBe "second"
+
+          [event] = changeHandler.argsForCall[1]
+          expect(event.oldRange).toEqual [[0, 6], [0, 11]]
+          expect(event.newRange).toEqual [[0, 6], [0, 6]]
+          expect(event.oldText).toBe "first"
+          expect(event.newText).toBe ""
+
           expect(buffer.isModified()).toBeFalsy()
 
     describe "when the buffer's memory contents differ from the *previous* disk contents", ->
@@ -453,6 +460,67 @@ describe 'TextBuffer', ->
       expect(event.newText).toBe newText
       expect(event.oldRange).toEqual expectedPreRange
       expect(event.newRange).toEqual [[0, 0], [1, 14]]
+
+  describe ".setTextViaDiff(text)", ->
+    it "changes the entire contents of the buffer with smaller content with no newline at the end", ->
+      newText = "I know you are.\nBut what am I?"
+      buffer.setTextViaDiff(newText)
+      expect(buffer.getText()).toBe newText
+
+    it "changes the entire contents of the buffer with smaller content with newline at the end", ->
+      newText = "I know you are.\nBut what am I?\n"
+      buffer.setTextViaDiff(newText)
+      expect(buffer.getText()).toBe newText
+
+    it "changes a few lines at the beginning in the buffer", ->
+      newText = buffer.getText().replace(/function/g, 'omgwow')
+      buffer.setTextViaDiff(newText)
+      expect(buffer.getText()).toBe newText
+
+    it "changes a few lines in the middle of the buffer", ->
+      newText = buffer.getText().replace(/shift/g, 'omgwow')
+      buffer.setTextViaDiff(newText)
+      expect(buffer.getText()).toBe newText
+
+    it "adds a newline at the end", ->
+      newText = buffer.getText() + '\n'
+      buffer.setTextViaDiff(newText)
+      expect(buffer.getText()).toBe newText
+
+    it "changes all with no newlines", ->
+      buffer.setText('BUFFER CHANGE')
+      newText = 'DISK CHANGE'
+      buffer.setTextViaDiff(newText)
+      expect(buffer.getText()).toBe newText
+
+    describe "with windows newlines", ->
+      beforeEach ->
+        buffer.setText(buffer.getText().replace(/\n/g, '\r\n'))
+
+      it "adds a newline at the end", ->
+        newText = buffer.getText() + '\r\n'
+        buffer.setTextViaDiff(newText)
+        expect(buffer.getText()).toBe newText
+
+      it "changes the entire contents of the buffer with smaller content with no newline at the end", ->
+        newText = "I know you are.\r\nBut what am I?"
+        buffer.setTextViaDiff(newText)
+        expect(buffer.getText()).toBe newText
+
+      it "changes the entire contents of the buffer with smaller content with newline at the end", ->
+        newText = "I know you are.\r\nBut what am I?\r\n"
+        buffer.setTextViaDiff(newText)
+        expect(buffer.getText()).toBe newText
+
+      it "changes a few lines at the beginning in the buffer", ->
+        newText = buffer.getText().replace(/function/g, 'omgwow')
+        buffer.setTextViaDiff(newText)
+        expect(buffer.getText()).toBe newText
+
+      it "changes a few lines in the middle of the buffer", ->
+        newText = buffer.getText().replace(/shift/g, 'omgwow')
+        buffer.setTextViaDiff(newText)
+        expect(buffer.getText()).toBe newText
 
   describe ".save()", ->
     saveBuffer = null

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -694,25 +694,25 @@ class TextBuffer extends telepath.Model
     @transact =>
       row = 0
       column = 0
-      startPosition = [0, 0]
+      currentPosition = [0, 0]
 
       lineDiff = diff.diffLines(currentText, newText)
       changeOptions = normalizeLineEndings: false
 
       for change in lineDiff
         lineCount = change.value.match(/\n/g)?.length ? 0
-        startPosition[0] = row
-        startPosition[1] = column
+        currentPosition[0] = row
+        currentPosition[1] = column
 
         if change.added
-          @change([startPosition, startPosition], change.value, changeOptions)
+          @change([currentPosition, currentPosition], change.value, changeOptions)
           row += lineCount
           column = computeBufferColumn(change.value)
 
         else if change.removed
-          endBufferRow = row + lineCount
-          endBufferColumn = column + computeBufferColumn(change.value)
-          @change([startPosition, [endBufferRow, endBufferColumn]], '', changeOptions)
+          endRow = row + lineCount
+          endColumn = column + computeBufferColumn(change.value)
+          @change([currentPosition, [endRow, endColumn]], '', changeOptions)
 
         else
           row += lineCount

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -203,7 +203,47 @@ class TextBuffer extends telepath.Model
   #
   # text - A {String} containing the new buffer contents.
   setTextViaDiff: (text) ->
-    @applyDifferences(text)
+    currentText = @getText()
+    return if currentText == text
+
+    endsWithNewline = (str) ->
+      /[\r\n]+$/g.test(str)
+
+    computeBufferColumn = (str) ->
+      newlineIndex = Math.max(str.lastIndexOf('\n'), str.lastIndexOf('\r'))
+      if endsWithNewline(str)
+        0
+      else if newlineIndex == -1
+        str.length
+      else
+        str.length - newlineIndex - 1
+
+    @transact =>
+      row = 0
+      column = 0
+      currentPosition = [0, 0]
+
+      lineDiff = diff.diffLines(currentText, text)
+      changeOptions = normalizeLineEndings: false
+
+      for change in lineDiff
+        lineCount = change.value.match(/\n/g)?.length ? 0
+        currentPosition[0] = row
+        currentPosition[1] = column
+
+        if change.added
+          @change([currentPosition, currentPosition], change.value, changeOptions)
+          row += lineCount
+          column = computeBufferColumn(change.value)
+
+        else if change.removed
+          endRow = row + lineCount
+          endColumn = column + computeBufferColumn(change.value)
+          @change([currentPosition, [endRow, endColumn]], '', changeOptions)
+
+        else
+          row += lineCount
+          column = computeBufferColumn(change.value)
 
   # Gets the range of the buffer contents.
   #
@@ -674,46 +714,3 @@ class TextBuffer extends telepath.Model
     for row in [start..end]
       line = @lineForRow(row)
       console.log row, line, line.length
-
-  applyDifferences: (newText) ->
-    currentText = @getText()
-    return if currentText == newText
-
-    endsWithNewline = (str) ->
-      /[\r\n]+$/g.test(str)
-
-    computeBufferColumn = (str) ->
-      newlineIndex = Math.max(str.lastIndexOf('\n'), str.lastIndexOf('\r'))
-      if endsWithNewline(str)
-        0
-      else if newlineIndex == -1
-        str.length
-      else
-        str.length - newlineIndex - 1
-
-    @transact =>
-      row = 0
-      column = 0
-      currentPosition = [0, 0]
-
-      lineDiff = diff.diffLines(currentText, newText)
-      changeOptions = normalizeLineEndings: false
-
-      for change in lineDiff
-        lineCount = change.value.match(/\n/g)?.length ? 0
-        currentPosition[0] = row
-        currentPosition[1] = column
-
-        if change.added
-          @change([currentPosition, currentPosition], change.value, changeOptions)
-          row += lineCount
-          column = computeBufferColumn(change.value)
-
-        else if change.removed
-          endRow = row + lineCount
-          endColumn = column + computeBufferColumn(change.value)
-          @change([currentPosition, [endRow, endColumn]], '', changeOptions)
-
-        else
-          row += lineCount
-          column = computeBufferColumn(change.value)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -717,6 +717,3 @@ class TextBuffer extends telepath.Model
         else
           bufferRow += numberLines
           bufferColumn = computeBufferColumn(change.value)
-
-        # console.log 'after', bufferRow, bufferColumn, change
-        # console.log @getText()

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -199,7 +199,7 @@ class TextBuffer extends telepath.Model
   setText: (text) ->
     @change(@getRange(), text, normalizeLineEndings: false)
 
-  # Replaces the current buffer contents. Only apply the differences.
+  # Private: Replaces the current buffer contents. Only apply the differences.
   #
   # text - A {String} containing the new buffer contents.
   setTextViaDiff: (text) ->

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -700,20 +700,20 @@ class TextBuffer extends telepath.Model
       changeOptions = normalizeLineEndings: false
 
       for change in lineDiff
-        numberLines = change.value.match(/\n/g)?.length ? 0
+        lineCount = change.value.match(/\n/g)?.length ? 0
         startPosition[0] = bufferRow
         startPosition[1] = bufferColumn
 
         if change.added
           @change([startPosition, startPosition], change.value, changeOptions)
-          bufferRow += numberLines
+          bufferRow += lineCount
           bufferColumn = computeBufferColumn(change.value)
 
         else if change.removed
-          endBufferRow = bufferRow + numberLines
+          endBufferRow = bufferRow + lineCount
           endBufferColumn = bufferColumn + computeBufferColumn(change.value)
           @change([startPosition, [endBufferRow, endBufferColumn]], '', changeOptions)
 
         else
-          bufferRow += numberLines
+          bufferRow += lineCount
           bufferColumn = computeBufferColumn(change.value)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -692,8 +692,8 @@ class TextBuffer extends telepath.Model
         str.length - newlineIndex - 1
 
     @transact =>
-      bufferRow = 0
-      bufferColumn = 0
+      row = 0
+      column = 0
       startPosition = [0, 0]
 
       lineDiff = diff.diffLines(currentText, newText)
@@ -701,19 +701,19 @@ class TextBuffer extends telepath.Model
 
       for change in lineDiff
         lineCount = change.value.match(/\n/g)?.length ? 0
-        startPosition[0] = bufferRow
-        startPosition[1] = bufferColumn
+        startPosition[0] = row
+        startPosition[1] = column
 
         if change.added
           @change([startPosition, startPosition], change.value, changeOptions)
-          bufferRow += lineCount
-          bufferColumn = computeBufferColumn(change.value)
+          row += lineCount
+          column = computeBufferColumn(change.value)
 
         else if change.removed
-          endBufferRow = bufferRow + lineCount
-          endBufferColumn = bufferColumn + computeBufferColumn(change.value)
+          endBufferRow = row + lineCount
+          endBufferColumn = column + computeBufferColumn(change.value)
           @change([startPosition, [endBufferRow, endBufferColumn]], '', changeOptions)
 
         else
-          bufferRow += lineCount
-          bufferColumn = computeBufferColumn(change.value)
+          row += lineCount
+          column = computeBufferColumn(change.value)


### PR DESCRIPTION
Previously, it would blindly read from disk on reload, and set the text into the editor. This was problematic as it would mess with markers and folds. No longer. 

Fixes #1285 and fixes atom/bookmarks#3
