### PR TITLE
Protect from exceptions when attaching editor views w/ dead editors

### DIFF
--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -780,6 +780,14 @@ class EditorView extends View
 
   afterAttach: (onDom) ->
     return unless onDom
+
+    # TODO: Remove this guard when we understand why this is happening
+    unless @editor.isAlive()
+      if atom.isReleasedVersion()
+        return
+      else
+        throw new Error("Assertion failure: EditorView is getting attached to a dead editor. Why?")
+
     @redraw() if @redrawOnReattach
     return if @attached
     @attached = true


### PR DESCRIPTION
Addresses #1306

We still need to know why this is happening, so I left an exception in
non-release builds. Since the pane system is about to change a lot I
think this is good enough for now.
