### PR TITLE
Common core commands to workspaceView

### DIFF
--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -299,19 +299,6 @@ describe "Pane", ->
         pane2.showItemAtIndex(1)
         expect(pane2.activeView.data('preservative')).toBe 1234
 
-  describe "core:close", ->
-    it "destroys the active item and does not bubble the event", ->
-      containerCloseHandler = jasmine.createSpy("containerCloseHandler")
-      container.on 'core:close', containerCloseHandler
-
-      pane.showItem(editor1)
-      initialItemCount = pane.getItems().length
-      pane.trigger 'core:close'
-      expect(pane.getItems().length).toBe initialItemCount - 1
-      expect(editor1.destroyed).toBeTruthy()
-
-      expect(containerCloseHandler).not.toHaveBeenCalled()
-
   describe "pane:close", ->
     it "destroys all items and removes the pane", ->
       pane.showItem(editor1)

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -314,20 +314,20 @@ describe "Pane", ->
       expect(editor2.destroyed).toBeTruthy()
       expect(pane.getItems()).toEqual [editor1]
 
-  describe "core:save", ->
+  describe "saveActiveItem", ->
     describe "when the current item has a uri", ->
       describe "when the current item has a save method", ->
         it "saves the current item", ->
           spyOn(editor2, 'save')
           pane.showItem(editor2)
-          pane.trigger 'core:save'
+          pane.saveActiveItem()
           expect(editor2.save).toHaveBeenCalled()
 
       describe "when the current item has no save method", ->
         it "does nothing", ->
           pane.activeItem.getUri = -> 'you are eye'
           expect(pane.activeItem.save).toBeUndefined()
-          pane.trigger 'core:save'
+          pane.saveActiveItem()
 
     describe "when the current item has no uri", ->
       beforeEach ->
@@ -339,7 +339,7 @@ describe "Pane", ->
           spyOn(newEditor, 'saveAs')
           pane.showItem(newEditor)
 
-          pane.trigger 'core:save'
+          pane.saveActiveItem()
 
           expect(atom.showSaveDialogSync).toHaveBeenCalled()
           expect(newEditor.saveAs).toHaveBeenCalledWith('/selected/path')
@@ -347,10 +347,10 @@ describe "Pane", ->
       describe "when the current item has no saveAs method", ->
         it "does nothing", ->
           expect(pane.activeItem.saveAs).toBeUndefined()
-          pane.trigger 'core:save'
+          pane.saveActiveItem()
           expect(atom.showSaveDialogSync).not.toHaveBeenCalled()
 
-  describe "core:save-as", ->
+  describe "saveActiveItemAs", ->
     beforeEach ->
       spyOn(atom, 'showSaveDialogSync').andReturn('/selected/path')
 
@@ -359,7 +359,7 @@ describe "Pane", ->
         spyOn(editor2, 'saveAs')
         pane.showItem(editor2)
 
-        pane.trigger 'core:save-as'
+        pane.saveActiveItemAs()
 
         expect(atom.showSaveDialogSync).toHaveBeenCalledWith(path.dirname(editor2.getPath()))
         expect(editor2.saveAs).toHaveBeenCalledWith('/selected/path')
@@ -367,7 +367,7 @@ describe "Pane", ->
     describe "when the current item does not have a saveAs method", ->
       it "does nothing", ->
         expect(pane.activeItem.saveAs).toBeUndefined()
-        pane.trigger 'core:save-as'
+        pane.saveActiveItemAs()
         expect(atom.showSaveDialogSync).not.toHaveBeenCalled()
 
   describe "pane:show-next-item and pane:show-previous-item", ->

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -28,11 +28,11 @@ describe "Pane", ->
   afterEach ->
     atom.deserializers.remove(TestView)
 
-  describe ".initialize(items...)", ->
+  describe "::initialize(items...)", ->
     it "displays the first item in the pane", ->
       expect(pane.itemViews.find('#view-1')).toExist()
 
-  describe ".showItem(item)", ->
+  describe "::showItem(item)", ->
     it "hides all item views except the one being shown and sets the activeItem", ->
       expect(pane.activeItem).toBe view1
       pane.showItem(view2)
@@ -138,7 +138,7 @@ describe "Pane", ->
         expect(pane.itemViews.find('#view-2')).toExist()
         expect(pane.activeView).toBe view2
 
-  describe ".destroyItem(item)", ->
+  describe "::destroyItem(item)", ->
     describe "if the item is not modified", ->
       it "removes the item and tries to call destroy on it", ->
         pane.destroyItem(editor2)
@@ -196,7 +196,7 @@ describe "Pane", ->
           expect(pane.getItems().indexOf(editor2)).not.toBe -1
           expect(editor2.destroyed).toBeFalsy()
 
-  describe ".removeItem(item)", ->
+  describe "::removeItem(item)", ->
     it "removes the item from the items list and shows the next item if it was showing", ->
       pane.removeItem(view1)
       expect(pane.getItems()).toEqual [editor1, view2, editor2]
@@ -244,7 +244,7 @@ describe "Pane", ->
         pane.removeItem(editor1)
         expect(pane.itemViews.find('.editor')).not.toExist()
 
-  describe ".moveItem(item, index)", ->
+  describe "::moveItem(item, index)", ->
     it "moves the item to the given index and emits a 'pane:item-moved' event with the item and the new index", ->
       itemMovedHandler = jasmine.createSpy("itemMovedHandler")
       pane.on 'pane:item-moved', itemMovedHandler
@@ -267,7 +267,7 @@ describe "Pane", ->
       expect(itemMovedHandler.argsForCall[0][1..2]).toEqual [editor1, 1]
       itemMovedHandler.reset()
 
-  describe ".moveItemToPane(item, pane, index)", ->
+  describe "::moveItemToPane(item, pane, index)", ->
     [pane2, view3] = []
 
     beforeEach ->
@@ -314,7 +314,7 @@ describe "Pane", ->
       expect(editor2.destroyed).toBeTruthy()
       expect(pane.getItems()).toEqual [editor1]
 
-  describe "saveActiveItem", ->
+  describe "::saveActiveItem()", ->
     describe "when the current item has a uri", ->
       describe "when the current item has a save method", ->
         it "saves the current item", ->
@@ -350,7 +350,7 @@ describe "Pane", ->
           pane.saveActiveItem()
           expect(atom.showSaveDialogSync).not.toHaveBeenCalled()
 
-  describe "saveActiveItemAs", ->
+  describe "::saveActiveItemAs()", ->
     beforeEach ->
       spyOn(atom, 'showSaveDialogSync').andReturn('/selected/path')
 
@@ -420,7 +420,7 @@ describe "Pane", ->
       waitsFor ->
         pane.items.length == 4
 
-  describe ".remove()", ->
+  describe "::remove()", ->
     it "destroys all the pane's items", ->
       pane.remove()
       expect(editor1.destroyed).toBeTruthy()
@@ -489,7 +489,7 @@ describe "Pane", ->
           pane.remove()
           expect(atom.workspaceView.focus).not.toHaveBeenCalled()
 
-  describe ".getNextPane()", ->
+  describe "::getNextPane()", ->
     it "returns the next pane if one exists, wrapping around from the last pane to the first", ->
       pane.showItem(editor1)
       expect(pane.getNextPane()).toBeUndefined
@@ -670,7 +670,7 @@ describe "Pane", ->
       expect(container.children('.pane').length).toBe 1
       expect(pane1.outerWidth()).toBe container.width()
 
-  describe ".itemForUri(uri)", ->
+  describe "::itemForUri(uri)", ->
     it "returns the item for which a call to .getUri() returns the given uri", ->
       expect(pane.itemForUri(editor1.getUri())).toBe editor1
       expect(pane.itemForUri(editor2.getUri())).toBe editor2

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -553,3 +553,12 @@ describe "WorkspaceView", ->
       expect(workspace.getActivePaneItem().getUri()).toBe 'b'
       workspace.reopenItemSync()
       expect(workspace.getActivePaneItem().getUri()).toBe 'a'
+
+  describe "core:close", ->
+    it "closes the active editor until there are none", ->
+      atom.project.openSync('../sample.txt')
+      expect(atom.workspaceView.getActivePane().getItems()).toHaveLength 1
+      atom.workspaceView.trigger('core:close')
+      expect(atom.workspaceView.getActivePane()).not.toBeDefined()
+      atom.workspaceView.trigger('core:close')
+      expect(atom.workspaceView.getActivePane()).not.toBeDefined()

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -562,3 +562,22 @@ describe "WorkspaceView", ->
       expect(atom.workspaceView.getActivePane()).not.toBeDefined()
       atom.workspaceView.trigger('core:close')
       expect(atom.workspaceView.getActivePane()).not.toBeDefined()
+
+  describe "core:save", ->
+    it "saves active editor until there are none", ->
+      editor = atom.project.openSync('../sample.txt')
+      spyOn(editor, 'save')
+      atom.workspaceView.getActivePane().showItem(editor)
+      atom.workspaceView.trigger('core:save')
+      expect(editor.save).toHaveBeenCalled()
+
+  describe "core:save-as", ->
+    beforeEach ->
+      spyOn(atom, 'showSaveDialogSync').andReturn('/selected/path')
+
+    it "saves active editor until there are none", ->
+      editor = atom.project.openSync('../sample.txt')
+      spyOn(editor, 'saveAs')
+      atom.workspaceView.getActivePane().showItem(editor)
+      atom.workspaceView.trigger('core:save-as')
+      expect(editor.saveAs).toHaveBeenCalled()

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -63,8 +63,6 @@ class Pane extends View
     unless activeItemUri? and @showItemForUri(activeItemUri)
       @showItem(@items[0]) if @items.length > 0
 
-    @command 'core:save', @saveActiveItem
-    @command 'core:save-as', @saveActiveItemAs
     @command 'pane:save-items', @saveItems
     @command 'pane:show-next-item', @showNextItem
     @command 'pane:show-previous-item', @showPreviousItem

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -63,7 +63,6 @@ class Pane extends View
     unless activeItemUri? and @showItemForUri(activeItemUri)
       @showItem(@items[0]) if @items.length > 0
 
-    @command 'core:close', @destroyActiveItem
     @command 'core:save', @saveActiveItem
     @command 'core:save-as', @saveActiveItemAs
     @command 'pane:save-items', @saveItems

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -125,7 +125,10 @@ class WorkspaceView extends View
       atom.config.toggle("editor.autoIndent")
 
     @command 'pane:reopen-closed-item', => @reopenItemSync()
+
     @command 'core:close', => @destroyActivePaneItem()
+    @command 'core:save', => @saveActivePaneItem()
+    @command 'core:save-as', => @saveActivePaneItemAs()
 
   # Private:
   serialize: ->
@@ -284,6 +287,14 @@ class WorkspaceView extends View
   # Public: destroy/close the active item.
   destroyActivePaneItem: ->
     @getActivePane()?.destroyActiveItem()
+
+  # Public: save the active item.
+  saveActivePaneItem: ->
+    @getActivePane()?.saveActiveItem()
+
+  # Public: save the active item as.
+  saveActivePaneItemAs: ->
+    @getActivePane()?.saveActiveItemAs()
 
   # Public: Focuses the previous pane by id.
   focusPreviousPane: -> @panes.focusPreviousPane()

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -125,6 +125,7 @@ class WorkspaceView extends View
       atom.config.toggle("editor.autoIndent")
 
     @command 'pane:reopen-closed-item', => @reopenItemSync()
+    @command 'core:close', => @destroyActivePaneItem()
 
   # Private:
   serialize: ->
@@ -279,6 +280,10 @@ class WorkspaceView extends View
   # Public: Returns the view of the currently focused item.
   getActiveView: ->
     @panes.getActiveView()
+
+  # Public: destroy/close the active item.
+  destroyActivePaneItem: ->
+    @getActivePane()?.destroyActiveItem()
 
   # Public: Focuses the previous pane by id.
   focusPreviousPane: -> @panes.focusPreviousPane()


### PR DESCRIPTION
When focused on places like the tree-view and find and replace, we should be able to use a few commands like `cmd-w` and `cmd-s`. This pull moves these things to be handled in the workspaceView.
