### PR TITLE
Handle native commands in render process

### DIFF
--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -79,14 +79,11 @@ class WindowEventHandler
   # for elements with the `.native-key-bindings` class.
   handleNativeKeybindings: ->
     menu = null
-    sendActionToFirstResponder = (element, action) ->
-      if element.webkitMatchesSelector('.native-key-bindings')
-        menu ?= require('remote').require('menu')
-        menu.sendActionToFirstResponder(action)
-
     bindCommandToAction = (command, action) =>
       @subscribe $(document), command, (event) ->
-        sendActionToFirstResponder(event.target, action)
+        if element.webkitMatchesSelector('.native-key-bindings')
+          menu ?= require('remote').require('menu')
+          menu.sendActionToFirstResponder(action)
 
     bindCommandToAction('core:copy', 'copy:')
     bindCommandToAction('core:paste', 'paste:')

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -73,6 +73,27 @@ class WindowEventHandler
       e.preventDefault()
       atom.contextMenu.showForEvent(e)
 
+    @handleNativeKeybindings()
+
+  # Private: Wire commands that should be handled by the native menu
+  # for elements with the `.native-key-bindings` class.
+  handleNativeKeybindings: ->
+    menu = null
+    sendActionToFirstResponder = (element, action) ->
+      if element.webkitMatchesSelector('.native-key-bindings')
+        menu ?= require('remote').require('menu')
+        menu.sendActionToFirstResponder(action)
+
+    bindCommandToAction = (command, action) =>
+      @subscribe $(document), command, (event) ->
+        sendActionToFirstResponder(event.target, action)
+
+    bindCommandToAction('core:copy', 'copy:')
+    bindCommandToAction('core:paste', 'paste:')
+    bindCommandToAction('core:undo', 'undo:')
+    bindCommandToAction('core:redo', 'redo:')
+    bindCommandToAction('core:select-all', 'selectAll:')
+
   openLink: (event) =>
     location = $(event.target).attr('href')
     if location and location[0] isnt '#' and /^https?:\/\//.test(location)

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -84,6 +84,7 @@ class WindowEventHandler
         if element.webkitMatchesSelector('.native-key-bindings')
           menu ?= require('remote').require('menu')
           menu.sendActionToFirstResponder(action)
+        true
 
     bindCommandToAction('core:copy', 'copy:')
     bindCommandToAction('core:paste', 'paste:')

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -81,7 +81,7 @@ class WindowEventHandler
     menu = null
     bindCommandToAction = (command, action) =>
       @subscribe $(document), command, (event) ->
-        if element.webkitMatchesSelector('.native-key-bindings')
+        if event.target.webkitMatchesSelector('.native-key-bindings')
           menu ?= require('remote').require('menu')
           menu.sendActionToFirstResponder(action)
         true


### PR DESCRIPTION
This gets copy, paste, etc. working again in elements with the `native-key-bindings` class.

This does duplicate some code with the browser process but that still needs to handle the first responder forwarding for the spec window and when the dev tools is focused.

Closes #1203
