### PR TITLE
Dont re-atomicize atomic tokens

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -90,6 +90,14 @@ describe "DisplayBuffer", ->
           expect(displayBuffer.lineForRow(3).text).toBe '    var pivot = items.shift(), current, left = [], '
           expect(displayBuffer.lineForRow(4).text).toBe 'right = [];'
 
+      describe "when there are hard tabs", ->
+        beforeEach ->
+          buffer.setText(buffer.getText().replace(new RegExp('  ', 'g'), '	'))
+
+        it "correctly tokenizes the hard tabs", ->
+          expect(displayBuffer.lineForRow(3).tokens[0].isHardTab).toBeTruthy()
+          expect(displayBuffer.lineForRow(3).tokens[1].isHardTab).toBeTruthy()
+
     describe "when the buffer changes", ->
       describe "when buffer lines are updated", ->
         describe "when whitespace is added after the max line length", ->

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -92,7 +92,7 @@ describe "DisplayBuffer", ->
 
       describe "when there are hard tabs", ->
         beforeEach ->
-          buffer.setText(buffer.getText().replace(new RegExp('  ', 'g'), '	'))
+          buffer.setText(buffer.getText().replace(new RegExp('  ', 'g'), '\t'))
 
         it "correctly tokenizes the hard tabs", ->
           expect(displayBuffer.lineForRow(3).tokens[0].isHardTab).toBeTruthy()

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -57,7 +57,7 @@ class Token
 
       outputTokens
     else
-      return [this] if this.isAtomic
+      return [this] if @isAtomic
 
       if breakOutLeadingWhitespace
         return [this] unless /^[ ]|\t/.test(@value)

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -57,6 +57,8 @@ class Token
 
       outputTokens
     else
+      return [this] if this.isAtomic
+
       if breakOutLeadingWhitespace
         return [this] unless /^[ ]|\t/.test(@value)
       else


### PR DESCRIPTION
On soft-wrapped lines with hard tabs, it would convert the hard tabs to soft tabs when it split the tokens into multiple lines.

Fixes #1318
