### PR TITLE
Install apm outside of node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ debug.log
 /atom-shell/
 docs/output
 spec/fixtures/evil-files/
+/apm

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 var safeExec = require('./utils/child-process-wrapper.js').safeExec;
+var fs = require('fs');
 var path = require('path');
 
 // OAuth token for atom-bot
@@ -22,13 +23,20 @@ function executeCommands(commands, done, index) {
     done(null);
 }
 
+var apmVendorPath = path.resolve(__dirname, '..', 'vendor', 'apm');
+var apmInstallPath = path.resolve(__dirname, '..', 'apm');
+if (!fs.existsSync(apmInstallPath))
+  fs.mkdirSync(apmInstallPath);
+if (!fs.existsSync(path.join(apmInstallPath, 'node_modules')))
+  fs.mkdirSync(path.join(apmInstallPath, 'node_modules'));
+
 var apmFlags = process.env.JANKY_SHA1 || process.argv.indexOf('--no-color') !== -1 ? '--no-color' : '';
 var echoNewLine = process.platform == 'win32' ? 'echo.' : 'echo';
 var commands = [
   'git submodule --quiet sync',
   'git submodule --quiet update --recursive --init',
-  {command: 'npm install --quiet .', options: {cwd: path.resolve(__dirname, '..', 'vendor', 'apm'), ignoreStdout: true}},
-  {command: 'npm install --quiet vendor/apm', options: {ignoreStdout: true}},
+  {command: 'npm install --quiet', options: {cwd: apmVendorPath, ignoreStdout: true}},
+  {command: 'npm install --quiet ' + apmVendorPath, options: {cwd: apmInstallPath, ignoreStdout: true}},
   echoNewLine,
   'node node_modules/atom-package-manager/bin/apm clean ' + apmFlags,
   'node node_modules/atom-package-manager/bin/apm install --quiet ' + apmFlags,

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -38,8 +38,8 @@ var commands = [
   {command: 'npm install --quiet', options: {cwd: apmVendorPath, ignoreStdout: true}},
   {command: 'npm install --quiet ' + apmVendorPath, options: {cwd: apmInstallPath, ignoreStdout: true}},
   echoNewLine,
-  'node node_modules/atom-package-manager/bin/apm clean ' + apmFlags,
-  'node node_modules/atom-package-manager/bin/apm install --quiet ' + apmFlags,
+  'node apm/node_modules/atom-package-manager/bin/apm clean ' + apmFlags,
+  'node apm/node_modules/atom-package-manager/bin/apm install --quiet ' + apmFlags,
 ];
 
 process.chdir(path.dirname(__dirname));

--- a/src/command-installer.coffee
+++ b/src/command-installer.coffee
@@ -64,5 +64,5 @@ module.exports =
       resourcePath = null
 
     resourcePath ?= atom.getLoadSettings().resourcePath
-    commandPath = path.join(resourcePath, 'node_modules', '.bin', 'apm')
+    commandPath = path.join(resourcePath, 'apm', 'node_modules', '.bin', 'apm')
     @install(commandPath, callback)

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -39,7 +39,7 @@ class PackageManager
 
   # Public: Get the path to the apm command
   getApmPath: ->
-    @apmPath ?= require.resolve('atom-package-manager/bin/apm')
+    @apmPath ?= require.resolve('../apm/node_modules/atom-package-manager/bin/apm')
 
   # Public: Get the paths being used to look for packages.
   #

--- a/tasks/build-task.coffee
+++ b/tasks/build-task.coffee
@@ -21,6 +21,7 @@ module.exports = (grunt) ->
 
     cp 'atom.sh', path.join(appDir, 'atom.sh')
     cp 'package.json', path.join(appDir, 'package.json')
+    cp 'apm', path.join(appDir, 'apm')
 
     packageDirectories = []
     nonPackageDirectories = [


### PR DESCRIPTION
Allows apm to start referencing native module such as keytar.

`vendor/apm` now installs to `apm/node_modules` during `script/bootstrap` instead of to `node_modules/`.
