### PR TITLE
Word movement uses `end-of-word` and `beginning-of-word`

### DIFF
--- a/keymaps/base.cson
+++ b/keymaps/base.cson
@@ -1,9 +1,9 @@
 '.editor':
   # Platform Bindings
-  'alt-left': 'editor:move-to-previous-word-boundary'
-  'alt-right': 'editor:move-to-next-word-boundary'
-  'alt-shift-left': 'editor:select-to-previous-word-boundary'
-  'alt-shift-right': 'editor:select-to-next-word-boundary'
+  'alt-left': 'editor:move-to-beginning-of-word'
+  'alt-right': 'editor:move-to-end-of-word'
+  'alt-shift-left': 'editor:select-to-beginning-of-word'
+  'alt-shift-right': 'editor:select-to-end-of-word'
   'home': 'editor:move-to-first-character-of-line'
   'end': 'editor:move-to-end-of-line'
   'shift-home': 'editor:select-to-first-character-of-line'


### PR DESCRIPTION
Changes the default bindings for `alt-left` and `alt-right` to better match the default behavior of Sublime and TextMate.

Closes #1253
