### PR TITLE
Omit destroyed pane items

### DIFF
--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -37,6 +37,7 @@ class Pane extends View
       @items = _.compact @state.get('items').map (item) ->
         item = atom.deserializers.deserialize(item)
         item?.created?()
+        return if item?.state?.isDestroyed?()
         item
     else
       @items = args


### PR DESCRIPTION
This is an interim solution which enables atom/image-view#4 to correctly
deserialize when the path has been deleted both on atom master and in
atom/atom#1326.
