### PR TITLE
Add the ability to cancel project.scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "pathwatcher": "0.11.0",
     "pegjs": "0.7.0",
     "q": "0.9.7",
-    "scandal": "0.8.0",
+    "scandal": "0.9.0",
     "season": "0.14.0",
     "semver": "1.1.4",
     "space-pen": "2.0.2",

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -275,7 +275,7 @@ class Project extends Model
       excludeVcsIgnores: atom.config.get('core.excludeVcsIgnoredPaths')
       exclusions: atom.config.get('core.ignoredNames')
 
-    task = Task.once require.resolve('./scan-handler'), @getPath(), regex.source, searchOptions, =>
+    task = Task.once require.resolve('./scan-handler'), @getPath(), regex.source, searchOptions, ->
       deferred.resolve()
 
     task.on 'scan:result-found', (result) =>

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -275,8 +275,7 @@ class Project extends Model
       excludeVcsIgnores: atom.config.get('core.excludeVcsIgnoredPaths')
       exclusions: atom.config.get('core.ignoredNames')
 
-    if @scanTask?
-      @scanTask.terminate()
+    @cancelScan()
 
     @scanTask = Task.once require.resolve('./scan-handler'), @getPath(), regex.source, searchOptions, =>
       @scanTask = null
@@ -296,6 +295,12 @@ class Project extends Model
       iterator {filePath, matches} if matches.length > 0
 
     deferred.promise
+
+  # Public: Cancels the current scan task if there is one running.
+  cancelScan: ->
+    if @scanTask?
+      @scanTask.terminate()
+      @scanTask = null
 
   # Public: Performs a replace across all the specified files in the project.
   #

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -276,7 +276,6 @@ class Project extends Model
       exclusions: atom.config.get('core.ignoredNames')
 
     if @scanTask?
-      console.log 'terminating!'
       @scanTask.terminate()
 
     @scanTask = Task.once require.resolve('./scan-handler'), @getPath(), regex.source, searchOptions, =>


### PR DESCRIPTION
A search might need to be cancelled. This pull does 2 things
- When project scan is run again, any previous search is cancelled
- `Project::cancelScan()` function was added
