### PR TITLE
Use default OS X keyboard shortcut to hide other apps

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -2,7 +2,7 @@
   # Apple specific
   'cmd-q': 'application:quit'
   'cmd-h': 'application:hide'
-  'cmd-H': 'application:hide-other-applications'
+  'cmd-alt-h': 'application:hide-other-applications'
   'cmd-m': 'application:minimize'
   'alt-cmd-ctrl-m': 'application:zoom'
 


### PR DESCRIPTION
Update the keymap to use the [default OS X keyboard shortcut](http://support.apple.com/kb/ht1343) (Command+Option+h) to hide other apps.

![](https://f.cloud.github.com/assets/2988/1814619/660d8cc0-6efa-11e3-99d0-d755b426f8f2.png)
