### PR TITLE
Cj keybinding fixes

### DIFF
--- a/keymaps/base.cson
+++ b/keymaps/base.cson
@@ -5,7 +5,7 @@
   'alt-shift-left': 'editor:select-to-beginning-of-word'
   'alt-shift-right': 'editor:select-to-end-of-word'
   'home': 'editor:move-to-first-character-of-line'
-  'end': 'editor:move-to-end-of-line'
+  'end': 'editor:move-to-end-of-screen-line'
   'shift-home': 'editor:select-to-first-character-of-line'
   'shift-end': 'editor:select-to-end-of-line'
 

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -99,7 +99,7 @@
   'cmd-shift-right': 'editor:select-to-end-of-line'
   'alt-backspace': 'editor:backspace-to-beginning-of-word'
   'alt-delete': 'editor:delete-to-end-of-word'
-  'ctrl-a': 'editor:move-to-first-character-of-line'
+  'ctrl-a': 'editor:move-to-beginning-of-line'
   'ctrl-e': 'editor:move-to-end-of-line'
   'ctrl-k': 'editor:cut-to-end-of-line'
 

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -94,7 +94,7 @@
   'ctrl-A': 'editor:select-to-first-character-of-line'
   'ctrl-E': 'editor:select-to-end-of-line'
   'cmd-left': 'editor:move-to-first-character-of-line'
-  'cmd-right': 'editor:move-to-end-of-line'
+  'cmd-right': 'editor:move-to-end-of-screen-line'
   'cmd-shift-left': 'editor:select-to-first-character-of-line'
   'cmd-shift-right': 'editor:select-to-end-of-line'
   'alt-backspace': 'editor:backspace-to-beginning-of-word'

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -26,7 +26,7 @@
   'down': 'core:move-down'
   'left': 'core:move-left'
   'right': 'core:move-right'
-  'ctrl-alt-cmd-r': 'window:reload'
+  'ctrl-alt-cmd-l': 'window:reload'
   'alt-cmd-i': 'window:toggle-dev-tools'
   'cmd-alt-ctrl-p': 'window:run-package-specs'
 

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -361,13 +361,13 @@ describe "Editor", ->
           expect(editor.getCursors().length).toBe 1
           expect(editor.getCursorBufferPosition()).toEqual [12,2]
 
-      describe ".moveCursorToBeginningOfLine()", ->
+      describe ".moveCursorToBeginningOfScreenLine()", ->
         describe "when soft wrap is on", ->
           it "moves cursor to the beginning of the screen line", ->
             editor.setSoftWrap(true)
             editor.setEditorWidthInChars(10)
             editor.setCursorScreenPosition([1, 2])
-            editor.moveCursorToBeginningOfLine()
+            editor.moveCursorToBeginningOfScreenLine()
             cursor = editor.getCursor()
             expect(cursor.getScreenPosition()).toEqual [1, 0]
 
@@ -375,19 +375,19 @@ describe "Editor", ->
           it "moves cursor to the beginning of then line", ->
             editor.setCursorScreenPosition [0,5]
             editor.addCursorAtScreenPosition [1,7]
-            editor.moveCursorToBeginningOfLine()
+            editor.moveCursorToBeginningOfScreenLine()
             expect(editor.getCursors().length).toBe 2
             [cursor1, cursor2] = editor.getCursors()
             expect(cursor1.getBufferPosition()).toEqual [0,0]
             expect(cursor2.getBufferPosition()).toEqual [1,0]
 
-      describe ".moveCursorToEndOfLine()", ->
+      describe ".moveCursorToEndOfScreenLine()", ->
         describe "when soft wrap is on", ->
           it "moves cursor to the beginning of the screen line", ->
             editor.setSoftWrap(true)
             editor.setEditorWidthInChars(10)
             editor.setCursorScreenPosition([1, 2])
-            editor.moveCursorToEndOfLine()
+            editor.moveCursorToEndOfScreenLine()
             cursor = editor.getCursor()
             expect(cursor.getScreenPosition()).toEqual [1, 9]
 
@@ -395,11 +395,29 @@ describe "Editor", ->
           it "moves cursor to the end of line", ->
             editor.setCursorScreenPosition [0,0]
             editor.addCursorAtScreenPosition [1,0]
-            editor.moveCursorToEndOfLine()
+            editor.moveCursorToEndOfScreenLine()
             expect(editor.getCursors().length).toBe 2
             [cursor1, cursor2] = editor.getCursors()
             expect(cursor1.getBufferPosition()).toEqual [0,29]
             expect(cursor2.getBufferPosition()).toEqual [1,30]
+
+      describe ".moveCursorToBeginningOfLine()", ->
+        it "moves cursor to the beginning of the buffer line", ->
+          editor.setSoftWrap(true)
+          editor.setEditorWidthInChars(10)
+          editor.setCursorScreenPosition([1, 2])
+          editor.moveCursorToBeginningOfLine()
+          cursor = editor.getCursor()
+          expect(cursor.getScreenPosition()).toEqual [0, 0]
+
+      describe ".moveCursorToEndOfLine()", ->
+        it "moves cursor to the end of the buffer line", ->
+          editor.setSoftWrap(true)
+          editor.setEditorWidthInChars(10)
+          editor.setCursorScreenPosition([0, 2])
+          editor.moveCursorToEndOfLine()
+          cursor = editor.getCursor()
+          expect(cursor.getScreenPosition()).toEqual [3, 4]
 
       describe ".moveCursorToFirstCharacterOfLine()", ->
         describe "when soft wrap is on", ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -432,6 +432,13 @@ describe "Editor", ->
             expect(cursor1.getBufferPosition()).toEqual [0,0]
             expect(cursor2.getBufferPosition()).toEqual [1,0]
 
+          it "moves to the beginning of the line if it only contains whitespace ", ->
+            editor.setText("first\n    \nthird")
+            editor.setCursorScreenPosition [1,2]
+            editor.moveCursorToFirstCharacterOfLine()
+            cursor = editor.getCursor()
+            expect(cursor.getBufferPosition()).toEqual [1,0]
+
       describe ".moveCursorToBeginningOfWord()", ->
         it "moves the cursor to the beginning of the word", ->
           editor.setCursorBufferPosition [0, 8]

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -250,9 +250,13 @@ class Cursor
   moveToBottom: ->
     @setBufferPosition(@editor.getEofBufferPosition())
 
-  # Public: Moves the cursor to the beginning of the screen line.
-  moveToBeginningOfLine: ->
+  # Public: Moves the cursor to the beginning of the line.
+  moveToBeginningOfScreenLine: ->
     @setScreenPosition([@getScreenRow(), 0])
+
+  # Public: Moves the cursor to the beginning of the buffer line.
+  moveToBeginningOfLine: ->
+    @setBufferPosition([@getBufferRow(), 0])
 
   # Public: Moves the cursor to the beginning of the first character in the
   # line.
@@ -275,9 +279,13 @@ class Cursor
 
     @setBufferPosition(endOfLeadingWhitespace) if endOfLeadingWhitespace.isGreaterThan(position)
 
+  # Public: Moves the cursor to the end of the line.
+  moveToEndOfScreenLine: ->
+    @setScreenPosition([@getScreenRow(), Infinity])
+
   # Public: Moves the cursor to the end of the buffer line.
   moveToEndOfLine: ->
-    @setScreenPosition([@getScreenRow(), Infinity])
+    @setBufferPosition([@getBufferRow(), Infinity])
 
   # Public: Moves the cursor to the beginning of the word.
   moveToBeginningOfWord: ->

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -261,9 +261,7 @@ class Cursor
     screenline = @editor.lineForScreenRow(row)
 
     goalColumn = screenline.text.search(/\S/)
-    return if goalColumn == -1
-
-    goalColumn = 0 if goalColumn == column
+    goalColumn = 0 if goalColumn == column or goalColumn == -1
     @setScreenPosition([row, goalColumn])
 
   # Public: Moves the cursor to the beginning of the buffer line, skipping all

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -139,7 +139,9 @@ class EditorView extends View
       'editor:delete-to-end-of-word': @deleteToEndOfWord
       'editor:delete-line': @deleteLine
       'editor:cut-to-end-of-line': @cutToEndOfLine
+      'editor:move-to-beginning-of-screen-line': => @editor.moveCursorToBeginningOfScreenLine()
       'editor:move-to-beginning-of-line': @moveCursorToBeginningOfLine
+      'editor:move-to-end-of-screen-line': => @editor.moveCursorToEndOfScreenLine()
       'editor:move-to-end-of-line': @moveCursorToEndOfLine
       'editor:move-to-first-character-of-line': @moveCursorToFirstCharacterOfLine
       'editor:move-to-beginning-of-word': @moveCursorToBeginningOfWord

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1120,6 +1120,10 @@ class Editor extends Model
     @moveCursors (cursor) -> cursor.moveToBottom()
 
   # Public: Moves every local cursor to the beginning of the line.
+  moveCursorToBeginningOfScreenLine: ->
+    @moveCursors (cursor) -> cursor.moveToBeginningOfScreenLine()
+
+  # Public: Moves every local cursor to the beginning of the buffer line.
   moveCursorToBeginningOfLine: ->
     @moveCursors (cursor) -> cursor.moveToBeginningOfLine()
 
@@ -1128,6 +1132,10 @@ class Editor extends Model
     @moveCursors (cursor) -> cursor.moveToFirstCharacterOfLine()
 
   # Public: Moves every local cursor to the end of the line.
+  moveCursorToEndOfScreenLine: ->
+    @moveCursors (cursor) -> cursor.moveToEndOfScreenLine()
+
+  # Public: Moves every local cursor to the end of the buffer line.
   moveCursorToEndOfLine: ->
     @moveCursors (cursor) -> cursor.moveToEndOfLine()
 

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -216,7 +216,7 @@ class Selection
   # Public: Selects all the text from the current cursor position to the end of
   # the line.
   selectToEndOfLine: ->
-    @modifySelection => @cursor.moveToEndOfLine()
+    @modifySelection => @cursor.moveToEndOfScreenLine()
 
   # Public: Selects all the text from the current cursor position to the
   # beginning of the word.


### PR DESCRIPTION
This fixes a few keybinding issues people have opened. 

One change that might be annoying is `ctrl-a` now triggers `editor:move-to-beginning-of-line` instead of `editor:move-to-first-character-of-line`. But this matches the default OS X keybinding behavior.
