### PR TITLE
Make Directory::getEntries asynchronous

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "terminal": "0.23.0",
     "timecop": "0.11.0",
     "to-the-hubs": "0.16.0",
-    "tree-view": "0.56.0",
+    "tree-view": "0.57.0",
     "visual-bell": "0.6.0",
     "welcome": "0.4.0",
     "whitespace": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "diff": "git://github.com/benogle/jsdiff.git",
     "emissary": "0.19.0",
     "first-mate": "0.11.0",
-    "fs-plus": "0.13.0",
+    "fs-plus": "0.14.0",
     "fstream": "0.1.24",
     "fuzzaldrin": "0.1.0",
     "git-utils": "0.29.0",

--- a/spec/directory-spec.coffee
+++ b/spec/directory-spec.coffee
@@ -82,7 +82,7 @@ describe "Directory", ->
       waitsFor -> callback.callCount is 1
 
       runs ->
-        entries = callback.mostRecentCall.args[0]
+        entries = callback.mostRecentCall.args[1]
         for entry in entries
           name = entry.getBaseName()
           if name is 'symlink-to-dir' or name is 'symlink-to-file'

--- a/spec/directory-spec.coffee
+++ b/spec/directory-spec.coffee
@@ -76,6 +76,20 @@ describe "Directory", ->
         else
           expect(entry.symlink).toBeFalsy()
 
+      callback = jasmine.createSpy('getEntries')
+      directory.getEntries(callback)
+
+      waitsFor -> callback.callCount is 1
+
+      runs ->
+        entries = callback.mostRecentCall.args[0]
+        for entry in entries
+          name = entry.getBaseName()
+          if name is 'symlink-to-dir' or name is 'symlink-to-file'
+            expect(entry.symlink).toBeTruthy()
+          else
+            expect(entry.symlink).toBeFalsy()
+
   describe ".relativize(path)", ->
     describe "on #darwin or #linux", ->
       it "returns a relative path based on the directory's path", ->

--- a/spec/directory-spec.coffee
+++ b/spec/directory-spec.coffee
@@ -68,7 +68,7 @@ describe "Directory", ->
 
   describe "on #darwin or #linux", ->
     it "includes symlink information about entries", ->
-      entries = directory.getEntries()
+      entries = directory.getEntriesSync()
       for entry in entries
         name = entry.getBaseName()
         if name is 'symlink-to-dir' or name is 'symlink-to-file'

--- a/src/directory.coffee
+++ b/src/directory.coffee
@@ -122,7 +122,7 @@ class Directory
             callback()
 
       async.eachLimit entries, 1, statEntry, ->
-        callback(directories.concat(files))
+        callback(null, directories.concat(files))
 
   # Private:
   subscribeToNativeChangeEvents: ->

--- a/src/directory.coffee
+++ b/src/directory.coffee
@@ -44,7 +44,7 @@ class Directory
   #
   # All relative directory entries are removed and symlinks are resolved to
   # their final destination.
-  getRealPath: ->
+  getRealPathSync: ->
     unless @realPath?
       try
         @realPath = fs.realpathSync(@path)
@@ -59,7 +59,7 @@ class Directory
 
     if pathToCheck.indexOf(path.join(@getPath(), path.sep)) is 0
       true
-    else if pathToCheck.indexOf(path.join(@getRealPath(), path.sep)) is 0
+    else if pathToCheck.indexOf(path.join(@getRealPathSync(), path.sep)) is 0
       true
     else
       false
@@ -75,10 +75,10 @@ class Directory
       ''
     else if fullPath.indexOf(path.join(@getPath(), path.sep)) is 0
       fullPath.substring(@getPath().length + 1)
-    else if fullPath is @getRealPath()
+    else if fullPath is @getRealPathSync()
       ''
-    else if fullPath.indexOf(path.join(@getRealPath(), path.sep)) is 0
-      fullPath.substring(@getRealPath().length + 1)
+    else if fullPath.indexOf(path.join(@getRealPathSync(), path.sep)) is 0
+      fullPath.substring(@getRealPathSync().length + 1)
     else
       fullPath
 

--- a/src/directory.coffee
+++ b/src/directory.coffee
@@ -79,12 +79,12 @@ class Directory
     else
       fullPath
 
-  # Public: Reads file entries in this directory from disk.
+  # Public: Reads file entries in this directory from disk synchronously.
   #
   # Note: It follows symlinks.
   #
-  # Returns an Array of {Files}.
-  getEntries: ->
+  # Returns an Array of {File} and {Directory} objects.
+  getEntriesSync: ->
     directories = []
     files = []
     for entryPath in fs.listSync(@path)


### PR DESCRIPTION
Renames `getEntries` to `getEntriesSync`.

This will enable adding a little :racehorse: to the tree view.

Also updates `getRealPath` to `getRealPathSync` for consistency since under the hood it uses `fs.realpathSync`.
