### PR TITLE
Add error event to atom global

### DIFF
--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -129,7 +129,7 @@ class Atom extends Model
   initialize: ->
     window.onerror = =>
       @openDevTools()
-      @emit 'error', arguments
+      @emit 'uncaught-error', arguments
 
     @unsubscribe()
     @setBodyPlatformClass()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -129,7 +129,7 @@ class Atom extends Model
   initialize: ->
     window.onerror = =>
       @openDevTools()
-      @emit 'uncaught-error', arguments
+      @emit 'uncaught-error', arguments...
 
     @unsubscribe()
     @setBodyPlatformClass()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -127,6 +127,10 @@ class Atom extends Model
   # (both spec and application). Call after this instance has been assigned to
   # the `atom` global.
   initialize: ->
+    window.onerror = =>
+      @openDevTools()
+      @emit 'error', arguments
+
     @unsubscribe()
     @setBodyPlatformClass()
 

--- a/src/window.coffee
+++ b/src/window.coffee
@@ -1,6 +1,3 @@
-window.onerror = ->
-  atom.openDevTools()
-
 # Public: Measure how long a function takes to run.
 #
 # * description:


### PR DESCRIPTION
This lets packages listen for unhandled exceptions. The only reason I made it a pull request was in case there are going to be issues with Atom emitting events.
