### PR TITLE
Split selection into lines

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -99,6 +99,7 @@
     submenu: [
       { label: 'Add Selection Above', command: 'editor:add-selection-above' }
       { label: 'Add Selection Below', command: 'editor:add-selection-below' }
+      { label: 'Split into Lines', command: 'editor:split-selection-into-lines'}
       { type: 'separator' }
       { label: 'Select to Top', command: 'core:select-to-top' }
       { label: 'Select to Bottom', command: 'core:select-to-bottom' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -106,6 +106,7 @@
     submenu: [
       { label: 'Add Selection &Above', command: 'editor:add-selection-above' }
       { label: 'Add Selection &Below', command: 'editor:add-selection-below' }
+      { label: 'S&plit into Lines', command: 'editor:split-selection-into-lines'}
       { type: 'separator' }
       { label: 'Select to &Top', command: 'core:select-to-top' }
       { label: 'Select to Botto&m', command: 'core:select-to-bottom' }

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1181,6 +1181,27 @@ describe "Editor", ->
               [[10, 0], [10, 0]]
             ]
 
+      describe ".splitSelectionIntoLines()", ->
+        it "splits all multi-line selections into one selection per line", ->
+          editor.setSelectedBufferRange([[0, 3], [2, 4]])
+          editor.splitSelectionIntoLines()
+          expect(editor.getSelectedBufferRanges()).toEqual [
+            [[0, 3], [0, 29]]
+            [[1, 0], [1, 30]]
+            [[2, 0], [2, 4]]
+          ]
+
+          editor.setSelectedBufferRange([[0, 3], [1, 10]])
+          editor.splitSelectionIntoLines()
+          expect(editor.getSelectedBufferRanges()).toEqual [
+            [[0, 3], [0, 29]]
+            [[1, 0], [1, 10]]
+          ]
+
+          editor.setSelectedBufferRange([[0, 0], [0, 3]])
+          editor.splitSelectionIntoLines()
+          expect(editor.getSelectedBufferRanges()).toEqual [[[0, 0], [0, 3]]]
+
       describe ".consolidateSelections()", ->
         it "destroys all selections but the most recent, returning true if any selections were destroyed", ->
           editor.setSelectedBufferRange([[3, 16], [3, 21]])

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1181,10 +1181,10 @@ describe "Editor", ->
               [[10, 0], [10, 0]]
             ]
 
-      describe ".splitSelectionIntoLines()", ->
+      describe ".splitSelectionsIntoLines()", ->
         it "splits all multi-line selections into one selection per line", ->
           editor.setSelectedBufferRange([[0, 3], [2, 4]])
-          editor.splitSelectionIntoLines()
+          editor.splitSelectionsIntoLines()
           expect(editor.getSelectedBufferRanges()).toEqual [
             [[0, 3], [0, 29]]
             [[1, 0], [1, 30]]
@@ -1192,14 +1192,14 @@ describe "Editor", ->
           ]
 
           editor.setSelectedBufferRange([[0, 3], [1, 10]])
-          editor.splitSelectionIntoLines()
+          editor.splitSelectionsIntoLines()
           expect(editor.getSelectedBufferRanges()).toEqual [
             [[0, 3], [0, 29]]
             [[1, 0], [1, 10]]
           ]
 
           editor.setSelectedBufferRange([[0, 0], [0, 3]])
-          editor.splitSelectionIntoLines()
+          editor.splitSelectionsIntoLines()
           expect(editor.getSelectedBufferRanges()).toEqual [[[0, 0], [0, 3]]]
 
       describe ".consolidateSelections()", ->

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -183,6 +183,7 @@ class EditorView extends View
         'editor:newline-above': @insertNewlineAbove
         'editor:add-selection-below': @addSelectionBelow
         'editor:add-selection-above': @addSelectionAbove
+        'editor:split-selection-into-lines': @splitSelectionIntoLines
         'editor:toggle-soft-tabs': @toggleSoftTabs
         'editor:toggle-soft-wrap': @toggleSoftWrap
         'editor:fold-all': @foldAll
@@ -374,6 +375,9 @@ class EditorView extends View
 
   # {Delegates to: Editor.addSelectionAbove}
   addSelectionAbove: -> @editor.addSelectionAbove()
+
+  # {Delegates to: Editor.splitSelectionIntoLines}
+  splitSelectionIntoLines: -> @editor.splitSelectionIntoLines()
 
   # {Delegates to: Editor.selectToBeginningOfWord}
   selectToBeginningOfWord: -> @editor.selectToBeginningOfWord()

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -183,7 +183,7 @@ class EditorView extends View
         'editor:newline-above': @insertNewlineAbove
         'editor:add-selection-below': @addSelectionBelow
         'editor:add-selection-above': @addSelectionAbove
-        'editor:split-selection-into-lines': @splitSelectionIntoLines
+        'editor:split-selection-into-lines': => @editor.splitSelectionsIntoLines()
         'editor:toggle-soft-tabs': @toggleSoftTabs
         'editor:toggle-soft-wrap': @toggleSoftWrap
         'editor:fold-all': @foldAll
@@ -375,9 +375,6 @@ class EditorView extends View
 
   # {Delegates to: Editor.addSelectionAbove}
   addSelectionAbove: -> @editor.addSelectionAbove()
-
-  # {Delegates to: Editor.splitSelectionIntoLines}
-  splitSelectionIntoLines: -> @editor.splitSelectionIntoLines()
 
   # {Delegates to: Editor.selectToBeginningOfWord}
   selectToBeginningOfWord: -> @editor.selectToBeginningOfWord()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1194,7 +1194,7 @@ class Editor extends Model
   #
   # This methods break apart all multi-line selections to create multiple
   # single-line selections that cumulatively cover the same original area.
-  splitSelectionIntoLines: ->
+  splitSelectionsIntoLines: ->
     for selection in @getSelections()
       range = selection.getBufferRange()
       continue if range.isSingleLine()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1194,8 +1194,6 @@ class Editor extends Model
   #
   # This methods break apart all multi-line selections to create multiple
   # single-line selections that cumulatively cover the same original area.
-  #
-  # This method will not affect any single line selections.
   splitSelectionIntoLines: ->
     for selection in @getSelections()
       range = selection.getBufferRange()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1192,9 +1192,8 @@ class Editor extends Model
 
   # Public: Split any multi-line selections into one selection per line.
   #
-  # This method breaks apart multi-line selections by adding new selections
-  # that select the entire line for all completely selected lines and leaves
-  # any partially selected lines at the start and end of the selection as-is.
+  # This methods break apart all multi-line selections to create multiple
+  # single-line selections that cumulatively cover the same original area.
   #
   # This method will not affect any single line selections.
   splitSelectionIntoLines: ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1190,6 +1190,26 @@ class Editor extends Model
   addSelectionAbove: ->
     @expandSelectionsBackward (selection) => selection.addSelectionAbove()
 
+  # Public: Split any multi-line selections into one selection per line.
+  #
+  # This method breaks apart multi-line selections by adding new selections
+  # that select the entire line for all completely selected lines and leaves
+  # any partially selected lines at the start and end of the selection as-is.
+  #
+  # This method will not affect any single line selections.
+  splitSelectionIntoLines: ->
+    for selection in @getSelections()
+      range = selection.getBufferRange()
+      continue if range.isSingleLine()
+
+      selection.destroy()
+      {start, end} = range
+      @addSelectionForBufferRange([start, [start.row, Infinity]])
+      {row} = start
+      while ++row < end.row
+        @addSelectionForBufferRange([[row, 0], [row, Infinity]])
+      @addSelectionForBufferRange([[end.row, 0], [end.row, end.column]])
+
   # Public: Transposes the current text selections.
   #
   # The text in each selection is reversed so `abcd` would become `dcba`. The


### PR DESCRIPTION
Take a multi-line selection and break it apart to create multiple single line selections covering the same area.

Refs #1365
