### PR TITLE
Properly exit when render process crashes if exitWhenDone option is true

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -52,6 +52,8 @@ class AtomApplication
   resourcePath: null
   version: null
 
+  exit: (status) -> app.exit(status)
+
   constructor: (options) ->
     {@resourcePath, @version, @devMode} = options
     global.atomApplication = this

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -18,7 +18,7 @@ class AtomWindow
   isSpec: null
 
   constructor: (settings={}) ->
-    {@resourcePath, pathToOpen, initialLine, @isSpec} = settings
+    {@resourcePath, pathToOpen, initialLine, @isSpec, @exitWhenDone} = settings
     global.atomApplication.addWindow(this)
 
     @setupNodePath(@resourcePath)
@@ -82,7 +82,7 @@ class AtomWindow
       @browserWindow.destroy() if chosen is 0
 
     @browserWindow.on 'crashed', =>
-      atom.exit(100) if @isSpec
+      global.atomApplication.exit(100) if @exitWhenDone
 
       chosen = dialog.showMessageBox @browserWindow,
         type: 'warning'


### PR DESCRIPTION
This PR fixes two problems:
- When a render process crash occured in specs, we were trying to exit via an undefined atom global and throwing a confusing exception in the process.
- We probably don't want to exit the application unless we're running _headless_ specs, so I've switched this to check the ::exitWhenDone setting.
