### PR TITLE
Expand buffer range in Selection::selectLine

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -819,6 +819,11 @@ describe "Editor", ->
           editor.selectLine()
           expect(editor.getSelectedBufferRange()).toEqual [[12,0], [12,2]]
 
+          editor.setCursorBufferPosition([0, 2])
+          editor.selectLine()
+          editor.selectLine()
+          expect(editor.getSelectedBufferRange()).toEqual [[0,0], [2,0]]
+
       describe ".selectToBeginningOfWord()", ->
         it "selects text from cusor position to beginning of word", ->
           editor.setCursorScreenPosition [0,13]

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -132,7 +132,7 @@ class Selection
   #   The line Number to select (default: the row of the cursor)
   selectLine: (row=@cursor.getBufferPosition().row) ->
     range = @editor.bufferRangeForBufferRow(row, includeNewline: true)
-    @setBufferRange(range)
+    @setBufferRange(@getBufferRange().union(range))
     @linewise = true
     @wordwise = false
     @initialScreenRange = @getScreenRange()


### PR DESCRIPTION
This allows the selection to grown line-wise as you hit `cmd-l` multiple times.
