### PR TITLE
Show low disk space errors when running CI

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -210,7 +210,7 @@ module.exports = (grunt) ->
   grunt.registerTask('compile', ['coffee', 'prebuild-less', 'cson'])
   grunt.registerTask('lint', ['coffeelint', 'csslint', 'lesslint'])
   grunt.registerTask('test', ['shell:kill-atom', 'run-specs'])
-  grunt.registerTask('ci', ['download-atom-shell', 'build', 'set-development-version', 'lint', 'test', 'publish-build'])
+  grunt.registerTask('ci', ['output-disk-space', 'download-atom-shell', 'build', 'set-development-version', 'lint', 'test', 'publish-build'])
   grunt.registerTask('deploy', ['partial-clean', 'download-atom-shell', 'build', 'codesign'])
   grunt.registerTask('docs', ['markdown:guides', 'build-docs'])
   grunt.registerTask('default', ['download-atom-shell', 'build', 'set-development-version', 'install'])

--- a/build/tasks/output-disk-space.coffee
+++ b/build/tasks/output-disk-space.coffee
@@ -1,0 +1,25 @@
+module.exports = (grunt) ->
+  {spawn} = require('./task-helpers')(grunt)
+
+  grunt.registerTask 'output-disk-space', 'Print diskspace available', ->
+    return unless process.platform is 'darwin'
+
+    done = @async()
+
+    cmd = 'df'
+    args = ['-Hl']
+    spawn {cmd, args}, (error, result, code) ->
+      return done(error) if error?
+
+      lines = result.stdout.split("\n")
+
+      for line in lines[1..]
+        [filesystem, size, used, avail, capacity, extra] = line.split(/\s+/)
+        capacity = parseInt(capacity)
+
+        if capacity > 90
+          grunt.log.error("#{filesystem} is at #{capacity}% capacity!")
+        else if capacity > 80
+          grunt.log.error("#{filesystem} is at #{capacity}% capacity.")
+
+      done()

--- a/build/tasks/output-disk-space.coffee
+++ b/build/tasks/output-disk-space.coffee
@@ -20,6 +20,6 @@ module.exports = (grunt) ->
         if capacity > 90
           grunt.log.error("#{filesystem} is at #{capacity}% capacity!")
         else if capacity > 80
-          grunt.log.error("#{filesystem} is at #{capacity}% capacity.")
+          grunt.log.ok("#{filesystem} is at #{capacity}% capacity.")
 
       done()

--- a/build/tasks/task-helpers.coffee
+++ b/build/tasks/task-helpers.coffee
@@ -39,7 +39,7 @@ module.exports = (grunt) ->
     proc = childProcess.spawn(options.cmd, options.args, options.opts)
     proc.stdout.on 'data', (data) -> stdout.push(data.toString())
     proc.stderr.on 'data', (data) -> stderr.push(data.toString())
-    proc.on 'exit', (exitCode, signal) ->
+    proc.on 'close', (exitCode, signal) ->
       error = new Error(signal) if exitCode != 0
       results = {stderr: stderr.join(''), stdout: stdout.join(''), code: exitCode}
       grunt.log.error results.stderr if exitCode != 0


### PR DESCRIPTION
When the CI servers have low disk space, things get cray. This will log either an error or warning depending on how much disk space is left.

``` sh
Running "output-disk-space" task
>> /dev/disk1 is at 96% capacity!
```
