### PR TITLE
Dedupe during bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -43,6 +43,7 @@ var commands = [
   echoNewLine,
   'node apm/node_modules/atom-package-manager/bin/apm clean ' + apmFlags,
   'node apm/node_modules/atom-package-manager/bin/apm install --quiet ' + apmFlags,
+  'node apm/node_modules/atom-package-manager/bin/apm dedupe --quiet ' + apmFlags,
 ];
 
 process.chdir(path.dirname(__dirname));


### PR DESCRIPTION
Deduplicate the `node_modules` folder to save some space

Refs #1376 
