### PR TITLE
Don't null out the model of a pane item view when removing it

### DIFF
--- a/src/pane-view.coffee
+++ b/src/pane-view.coffee
@@ -154,7 +154,6 @@ class PaneView extends View
       @viewsByItem.delete(item)
 
     if viewToRemove?
-      viewToRemove.setModel?(null)
       if destroyed
         viewToRemove.remove()
       else


### PR DESCRIPTION
We used to assign a pane view's model to null when removing it, but I'm not sure why anymore. Something has changed in the order of operations post pane models that is leading the nulled out model to be a probable cause of #1422.
