### PR TITLE
Dedupe modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "editor-stats": "0.12.0",
     "exception-reporting": "0.11.0",
     "feedback": "0.22.0",
-    "find-and-replace": "0.76.0",
+    "find-and-replace": "0.77.0",
     "fuzzy-finder": "0.31.0",
     "gists": "0.15.0",
     "git-diff": "0.22.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "scandal": "0.13.0",
     "season": "0.14.0",
     "semver": "1.1.4",
-    "serializable": "0.3.0",
+    "serializable": "1.x",
     "space-pen": "3.1.0",
     "temp": "0.5.0",
     "text-buffer": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "less-cache": "0.10.0",
     "mixto": "1.x",
     "nslog": "0.3.0",
-    "oniguruma": "0.26.0",
+    "oniguruma": "1.x",
     "optimist": "0.4.0",
     "pathwatcher": "0.14.2",
     "pegjs": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "season": "0.14.0",
     "semver": "1.1.4",
     "serializable": "1.x",
-    "space-pen": "3.1.0",
+    "space-pen": "3.1.1",
     "temp": "0.5.0",
     "text-buffer": "0.14.0",
     "theorist": "1.x",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "space-pen": "3.1.0",
     "temp": "0.5.0",
     "text-buffer": "0.13.0",
-    "theorist": "~0.14.0",
+    "theorist": "1.x",
     "underscore-plus": "1.x",
     "vm-compatibility-layer": "0.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "grammar-selector": "0.17.0",
     "image-view": "0.15.0",
     "keybinding-resolver": "0.9.0",
-    "link": "0.13.0",
+    "link": "0.14.0",
     "markdown-preview": "0.25.1",
     "metrics": "0.21.0",
     "package-generator": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "temp": "0.5.0",
     "text-buffer": "0.13.0",
     "theorist": "~0.14.0",
-    "underscore-plus": "0.6.1",
+    "underscore-plus": "1.x",
     "vm-compatibility-layer": "0.1.0"
   },
   "packageDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "optimist": "0.4.0",
     "pathwatcher": "0.14.2",
     "pegjs": "0.8.0",
-    "property-accessors": "~0.1.0",
+    "property-accessors": "1.x",
     "q": "0.9.7",
     "scandal": "0.13.0",
     "season": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "serializable": "1.x",
     "space-pen": "3.1.0",
     "temp": "0.5.0",
-    "text-buffer": "0.13.0",
+    "text-buffer": "0.14.0",
     "theorist": "1.x",
     "underscore-plus": "1.x",
     "vm-compatibility-layer": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "grammar-selector": "0.17.0",
     "image-view": "0.15.0",
     "keybinding-resolver": "0.9.0",
+    "link": "0.13.0",
     "markdown-preview": "0.25.1",
     "metrics": "0.21.0",
     "package-generator": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "coffeestack": "0.6.0",
     "delegato": "1.x",
     "emissary": "1.x",
-    "first-mate": "0.17.0",
+    "first-mate": "1.x",
     "fs-plus": "1.x",
     "fstream": "0.1.24",
     "fuzzaldrin": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jasmine-tagged": "0.3.0",
     "mkdirp": "0.3.5",
     "keytar": "0.15.1",
-    "less-cache": "0.10.0",
+    "less-cache": "0.11.0",
     "mixto": "1.x",
     "nslog": "0.3.0",
     "oniguruma": "1.x",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "metrics": "0.21.0",
     "package-generator": "0.24.0",
     "release-notes": "0.15.1",
-    "settings-view": "0.56.1",
+    "settings-view": "0.57.0",
     "snippets": "0.19.0",
     "spell-check": "0.20.0",
     "status-bar": "0.32.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "base16-tomorrow-dark-theme": "0.8.0",
     "solarized-dark-syntax": "0.6.0",
     "solarized-light-syntax": "0.2.0",
-    "archive-view": "0.20.0",
+    "archive-view": "0.21.0",
     "autocomplete": "0.20.0",
     "autoflow": "0.12.0",
     "autosave": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "coffee-script": "1.6.3",
     "coffeestack": "0.6.0",
     "delegato": "1.x",
-    "emissary": "0.31.0",
+    "emissary": "1.x",
     "first-mate": "0.17.0",
     "fs-plus": "1.x",
     "fstream": "0.1.24",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "clear-cut": "0.2.0",
     "coffee-script": "1.6.3",
     "coffeestack": "0.6.0",
-    "delegato": "~0.4.0",
+    "delegato": "1.x",
     "emissary": "0.31.0",
     "first-mate": "0.17.0",
     "fs-plus": "1.x",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "serializable": "1.x",
     "space-pen": "3.1.1",
     "temp": "0.5.0",
-    "text-buffer": "0.14.0",
+    "text-buffer": "0.15.0",
     "theorist": "1.x",
     "underscore-plus": "1.x",
     "vm-compatibility-layer": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "bracket-matcher": "0.19.0",
     "command-logger": "0.10.0",
     "command-palette": "0.14.0",
-    "dev-live-reload": "0.22.0",
+    "dev-live-reload": "0.23.0",
     "editor-stats": "0.12.0",
     "exception-reporting": "0.11.0",
     "feedback": "0.22.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "github-sign-in": "0.16.0",
     "go-to-line": "0.15.0",
     "grammar-selector": "0.17.0",
-    "image-view": "0.15.0",
+    "image-view": "0.16.0",
     "keybinding-resolver": "0.9.0",
     "link": "0.14.0",
     "markdown-preview": "0.25.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "terminal": "0.26.0",
     "timecop": "0.13.0",
     "to-the-hubs": "0.17.0",
-    "tree-view": "0.62.0",
+    "tree-view": "0.63.0",
     "visual-bell": "0.6.0",
     "welcome": "0.4.0",
     "whitespace": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "delegato": "~0.4.0",
     "emissary": "0.31.0",
     "first-mate": "0.17.0",
-    "fs-plus": "0.14.0",
+    "fs-plus": "1.x",
     "fstream": "0.1.24",
     "fuzzaldrin": "0.6.0",
     "git-utils": "0.33.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "package-generator": "0.24.0",
     "release-notes": "0.15.1",
     "settings-view": "0.57.0",
-    "snippets": "0.19.0",
+    "snippets": "0.20.0",
     "spell-check": "0.20.0",
     "status-bar": "0.32.0",
     "styleguide": "0.19.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mkdirp": "0.3.5",
     "keytar": "0.15.1",
     "less-cache": "0.10.0",
-    "mixto": "~0.4.0",
+    "mixto": "1.x",
     "nslog": "0.3.0",
     "oniguruma": "0.26.0",
     "optimist": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "styleguide": "0.19.0",
     "symbols-view": "0.29.0",
     "tabs": "0.17.0",
-    "terminal": "0.25.0",
+    "terminal": "0.26.0",
     "timecop": "0.13.0",
     "to-the-hubs": "0.17.0",
     "tree-view": "0.62.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "find-and-replace": "0.77.0",
     "fuzzy-finder": "0.31.0",
     "gists": "0.15.0",
-    "git-diff": "0.22.0",
+    "git-diff": "0.23.0",
     "github-sign-in": "0.16.0",
     "go-to-line": "0.15.0",
     "grammar-selector": "0.17.0",


### PR DESCRIPTION
This updates our dependencies on our own libraries to use `1.x` style version strings so we can reduce duplication in the `node_modules` folder when installing and running `apm dedupe`.

This will speed up require time (and therefore startup time) since more dependencies will be shared and only need to be required once such as:
- underscore-plus
- fs-plus
- theorist
- emissary
### Results

Modules installed in 0.46.0: **759** totaling **137M**

Modules installed on this branch: **653** totaling **127M**
