### PR TITLE
Defer I/O for package requires until they're actually used

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "text-buffer": "0.13.0",
     "theorist": "~0.14.0",
     "underscore-plus": "0.6.1",
-    "vm-compatibility-layer": "0.1.0"
+    "vm-compatibility-layer": "0.1.0",
+    "deferred-require": "~0.2.0"
   },
   "packageDependencies": {
     "atom-dark-syntax": "0.10.0",

--- a/src/atom-package.coffee
+++ b/src/atom-package.coffee
@@ -1,3 +1,4 @@
+deferredRequire = require 'deferred-require'
 Package = require './package'
 fs = require 'fs-plus'
 path = require 'path'
@@ -191,7 +192,9 @@ class AtomPackage extends Package
   requireMainModule: ->
     return @mainModule if @mainModule?
     mainModulePath = @getMainModulePath()
-    @mainModule = require(mainModulePath) if fs.isFileSync(mainModulePath)
+
+    if fs.isFileSync(mainModulePath)
+      deferredRequire.run => @mainModule = require(mainModulePath)
 
   getMainModulePath: ->
     return @mainModulePath if @resolvedMainModulePath


### PR DESCRIPTION
This is an experiment that uses some harmony proxy magic to defer all require I/O until the moment the required modules are actually used. Harmony proxies have some instability when combined with so-called "irregular objects" such as arrays and Date objects, but 99% of the time the objects returned by `require` are not irregular. If it ends up being stable it may be worth it because it cuts our load time without bothering users much.

![screen shot 2014-01-16 at 9 51 09 pm](https://f.cloud.github.com/assets/1789/1937841/7816857c-7f33-11e3-94a4-fc04ba50506a.png)
