### PR TITLE
Add commands to open ~/.atom files

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -125,6 +125,7 @@
       { label: 'Reload', command: 'window:reload' }
       { label: 'Toggle Full Screen', command: 'window:toggle-full-screen' }
       { label: 'Open Your Stylesheet', command: 'window:open-your-stylesheet' }
+      { label: 'Open Your Keymap', command: 'window:open-your-keymap' }
       {
         label: 'Developer'
         submenu: [

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -7,6 +7,9 @@
       { label: "Install update", command: 'application:install-update', visible: false }
       { type: 'separator' }
       { label: 'Preferences...', command: 'application:show-settings' }
+      { label: 'Open Your Config', command: 'application:open-your-config' }
+      { label: 'Open Your Keymap', command: 'application:open-your-keymap' }
+      { label: 'Open Your Stylesheet', command: 'application:open-your-stylesheet' }
       { type: 'separator' }
       { label: 'Hide Atom', command: 'application:hide' }
       { label: 'Hide Others', command: 'application:hide-other-applications' }
@@ -133,10 +136,6 @@
           { label: 'Toggle Developer Tools', command: 'window:toggle-dev-tools' }
         ]
       }
-      { type: 'separator' }
-      { label: 'Open Your Config', command: 'application:open-your-config' }
-      { label: 'Open Your Keymap', command: 'application:open-your-keymap' }
-      { label: 'Open Your Stylesheet', command: 'application:open-your-stylesheet' }
       { type: 'separator' }
       { label: 'Toggle Soft Wrap', command: 'editor:toggle-soft-wrap' }
     ]

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -134,9 +134,9 @@
         ]
       }
       { type: 'separator' }
-      { label: 'Open Your Config', command: 'window:open-your-config' }
-      { label: 'Open Your Keymap', command: 'window:open-your-keymap' }
-      { label: 'Open Your Stylesheet', command: 'window:open-your-stylesheet' }
+      { label: 'Open Your Config', command: 'application:open-your-config' }
+      { label: 'Open Your Keymap', command: 'application:open-your-keymap' }
+      { label: 'Open Your Stylesheet', command: 'application:open-your-stylesheet' }
       { type: 'separator' }
       { label: 'Toggle Soft Wrap', command: 'editor:toggle-soft-wrap' }
     ]

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -124,8 +124,9 @@
     submenu: [
       { label: 'Reload', command: 'window:reload' }
       { label: 'Toggle Full Screen', command: 'window:toggle-full-screen' }
-      { label: 'Open Your Stylesheet', command: 'window:open-your-stylesheet' }
+      { label: 'Open Your Config', command: 'window:open-your-config' }
       { label: 'Open Your Keymap', command: 'window:open-your-keymap' }
+      { label: 'Open Your Stylesheet', command: 'window:open-your-stylesheet' }
       {
         label: 'Developer'
         submenu: [

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -124,6 +124,7 @@
     submenu: [
       { label: 'Reload', command: 'window:reload' }
       { label: 'Toggle Full Screen', command: 'window:toggle-full-screen' }
+      { label: 'Open Your Stylesheet', command: 'window:open-your-stylesheet' }
       {
         label: 'Developer'
         submenu: [

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -124,9 +124,6 @@
     submenu: [
       { label: 'Reload', command: 'window:reload' }
       { label: 'Toggle Full Screen', command: 'window:toggle-full-screen' }
-      { label: 'Open Your Config', command: 'window:open-your-config' }
-      { label: 'Open Your Keymap', command: 'window:open-your-keymap' }
-      { label: 'Open Your Stylesheet', command: 'window:open-your-stylesheet' }
       {
         label: 'Developer'
         submenu: [
@@ -136,6 +133,10 @@
           { label: 'Toggle Developer Tools', command: 'window:toggle-dev-tools' }
         ]
       }
+      { type: 'separator' }
+      { label: 'Open Your Config', command: 'window:open-your-config' }
+      { label: 'Open Your Keymap', command: 'window:open-your-keymap' }
+      { label: 'Open Your Stylesheet', command: 'window:open-your-stylesheet' }
       { type: 'separator' }
       { label: 'Toggle Soft Wrap', command: 'editor:toggle-soft-wrap' }
     ]

--- a/spec/keymap-spec.coffee
+++ b/spec/keymap-spec.coffee
@@ -369,3 +369,12 @@ describe "Keymap", ->
       runs ->
         keyBinding = keymap.keyBindingsForKeystroke('ctrl-l')[0]
         expect(keyBinding.command).toBe 'core:move-right'
+        keymap.loadUserKeymap.reset()
+        fs.removeSync(keymapFilePath)
+
+      waitsFor ->
+        keymap.loadUserKeymap.callCount > 0
+
+      runs ->
+        keyBinding = keymap.keyBindingsForKeystroke('ctrl-l')[0]
+        expect(keyBinding).toBeUndefined()

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -146,11 +146,11 @@ class AtomApplication
     @on 'application:inspect', ({x,y}) -> @focusedWindow().browserWindow.inspectElement(x, y)
     @on 'application:open-documentation', -> shell.openExternal('https://www.atom.io/docs/latest/?app')
     @on 'application:report-issue', -> shell.openExternal('https://github.com/atom/atom/issues/new')
-    @on 'application:show-settings', ->
-      if @focusedWindow()
-        @focusedWindow().openPath("atom://config")
-      else
-        @openPath(pathToOpen: "atom://config")
+
+    @openPathOnEvent('application:show-settings', 'atom://config')
+    @openPathOnEvent('application:open-your-stylesheet', 'atom://.atom/stylesheet')
+    @openPathOnEvent('application:open-your-keymap', 'atom://.atom/keymap')
+    @openPathOnEvent('application:open-your-config', 'atom://.atom/config')
 
     app.on 'window-all-closed', ->
       app.quit() if process.platform is 'win32'
@@ -202,6 +202,20 @@ class AtomApplication
   sendCommand: (command, args...) ->
     unless @emit(command, args...)
       @focusedWindow()?.sendCommand(command, args...)
+
+  # Public: Open the given path in the focused window when the event is
+  # triggered.
+  #
+  # A new window will be created if there is no currently focused window.
+  #
+  # * eventName: The event to listen for.
+  # * pathToOpen: The path to open when the event is triggered.
+  openPathOnEvent: (eventName, pathToOpen) ->
+    @on eventName, ->
+      if window = @focusedWindow()
+        window.openPath(pathToOpen)
+      else
+        @openPath({pathToOpen})
 
   # Private: Returns the {AtomWindow} for the given path.
   windowForPath: (pathToOpen) ->

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -98,6 +98,10 @@ class Config
     _.extend hash, defaults
     @update()
 
+  # Public: Get the path to the config file being used.
+  getUserConfigPath: ->
+    @configFilePath
+
   # Public: Returns a new {Object} containing all of settings and defaults.
   getSettings: ->
     _.deepExtend(@settings, @defaultSettings)

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -104,7 +104,7 @@ class ThemeManager
     if fs.isFileSync(stylesheetPath)
       stylesheetPath
     else
-      null
+      path.join(@configDirPath, 'user.less')
 
   #Private:
   unwatchUserStylesheet: ->

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -125,6 +125,7 @@ class WorkspaceView extends View
 
     @command 'window:open-your-stylesheet', => @model.openUserStylesheet()
     @command 'window:open-your-keymap', => @model.openUserKeymap()
+    @command 'window:open-your-config', => @model.openUserConfig()
 
   # Private:
   handleFocus: (e) ->

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -99,6 +99,7 @@ class WorkspaceView extends View
     @command 'application:minimize', -> ipc.sendChannel('command', 'application:minimize')
     @command 'application:zoom', -> ipc.sendChannel('command', 'application:zoom')
     @command 'application:bring-all-windows-to-front', -> ipc.sendChannel('command', 'application:bring-all-windows-to-front')
+    @command 'application:open-your-stylesheet', -> ipc.sendChannel('command', 'application:open-your-stylesheet')
 
     @command 'window:run-package-specs', => ipc.sendChannel('run-package-specs', path.join(atom.project.getPath(), 'spec'))
     @command 'window:increase-font-size', =>

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -124,6 +124,7 @@ class WorkspaceView extends View
     @command 'core:save-as', => @saveActivePaneItemAs()
 
     @command 'window:open-your-stylesheet', => @model.openUserStylesheet()
+    @command 'window:open-your-keymap', => @model.openUserKeymap()
 
   # Private:
   handleFocus: (e) ->

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -123,6 +123,8 @@ class WorkspaceView extends View
     @command 'core:save', => @saveActivePaneItem()
     @command 'core:save-as', => @saveActivePaneItemAs()
 
+    @command 'open-your-stylesheet', => @model.openUserStylesheet()
+
   # Private:
   handleFocus: (e) ->
     if @getActivePane()

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -99,6 +99,8 @@ class WorkspaceView extends View
     @command 'application:minimize', -> ipc.sendChannel('command', 'application:minimize')
     @command 'application:zoom', -> ipc.sendChannel('command', 'application:zoom')
     @command 'application:bring-all-windows-to-front', -> ipc.sendChannel('command', 'application:bring-all-windows-to-front')
+    @command 'application:open-your-config', -> ipc.sendChannel('command', 'application:open-your-config')
+    @command 'application:open-your-keymap', -> ipc.sendChannel('command', 'application:open-your-keymap')
     @command 'application:open-your-stylesheet', -> ipc.sendChannel('command', 'application:open-your-stylesheet')
 
     @command 'window:run-package-specs', => ipc.sendChannel('run-package-specs', path.join(atom.project.getPath(), 'spec'))
@@ -123,10 +125,6 @@ class WorkspaceView extends View
     @command 'core:close', => if @getActivePaneItem()? then @destroyActivePaneItem() else @destroyActivePane()
     @command 'core:save', => @saveActivePaneItem()
     @command 'core:save-as', => @saveActivePaneItemAs()
-
-    @command 'window:open-your-stylesheet', => @model.openUserStylesheet()
-    @command 'window:open-your-keymap', => @model.openUserKeymap()
-    @command 'window:open-your-config', => @model.openUserConfig()
 
   # Private:
   handleFocus: (e) ->

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -123,7 +123,7 @@ class WorkspaceView extends View
     @command 'core:save', => @saveActivePaneItem()
     @command 'core:save-as', => @saveActivePaneItemAs()
 
-    @command 'open-your-stylesheet', => @model.openUserStylesheet()
+    @command 'window:open-your-stylesheet', => @model.openUserStylesheet()
 
   # Private:
   handleFocus: (e) ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -27,6 +27,14 @@ class Workspace extends Model
   constructor: ->
     super
     @subscribe @paneContainer, 'item-destroyed', @onPaneItemDestroyed
+    atom.project.registerOpener (filePath) =>
+      switch filePath
+        when 'atom://.atom/stylesheet'
+          @open(atom.themes.getUserStylesheetPath())
+        when 'atom://.atom/keymap'
+          @open(atom.keymap.getUserKeymapPath())
+        when 'atom://.atom/config'
+          @open(atom.config.getUserConfigPath())
 
   # Private: Called by the Serializable mixin during deserialization
   deserializeParams: (params) ->
@@ -37,18 +45,6 @@ class Workspace extends Model
   serializeParams: ->
     paneContainer: @paneContainer.serialize()
     fullScreen: atom.isFullScreen()
-
-  # Private: Open ~/.atom/user.less or ~/.atom/user.css
-  openUserStylesheet: ->
-    @open(atom.themes.getUserStylesheetPath())
-
-  # Private: Open ~/.atom/keymap.cson or ~/.atom/keymap.json
-  openUserKeymap: ->
-    @open(atom.keymap.getUserKeymapPath())
-
-  # Private: Open ~/.atom/config.cson or ~/.atom/config.json
-  openUserConfig: ->
-    @open(atom.config.getUserConfigPath())
 
   # Public: Asynchronously opens a given a filepath in Atom.
   #

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -46,6 +46,10 @@ class Workspace extends Model
   openUserKeymap: ->
     @open(atom.keymap.getUserKeymapPath())
 
+  # Private: Open ~/.atom/config.cson or ~/.atom/config.json
+  openUserConfig: ->
+    @open(atom.config.getUserConfigPath())
+
   # Public: Asynchronously opens a given a filepath in Atom.
   #
   # * filePath: A file path

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -42,6 +42,10 @@ class Workspace extends Model
   openUserStylesheet: ->
     @open(atom.themes.getUserStylesheetPath())
 
+  # Private: Open ~/.atom/keymap.cson or ~/.atom/keymap.json
+  openUserKeymap: ->
+    @open(atom.keymap.getUserKeymapPath())
+
   # Public: Asynchronously opens a given a filepath in Atom.
   #
   # * filePath: A file path

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -38,6 +38,10 @@ class Workspace extends Model
     paneContainer: @paneContainer.serialize()
     fullScreen: atom.isFullScreen()
 
+  # Private: Open ~/.atom/user.less or ~/.atom.user.css
+  openUserStylesheet: ->
+    @open(atom.themes.getUserStylesheetPath())
+
   # Public: Asynchronously opens a given a filepath in Atom.
   #
   # * filePath: A file path

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -38,7 +38,7 @@ class Workspace extends Model
     paneContainer: @paneContainer.serialize()
     fullScreen: atom.isFullScreen()
 
-  # Private: Open ~/.atom/user.less or ~/.atom.user.css
+  # Private: Open ~/.atom/user.less or ~/.atom/user.css
   openUserStylesheet: ->
     @open(atom.themes.getUserStylesheetPath())
 


### PR DESCRIPTION
Makes opening `~/.atom/user.cson`, `~/.atom/user.less`, and `~/.atom/keymap.cson` easier.
