### PR TITLE
Fix Windows build

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -19,7 +19,7 @@
     "grunt-contrib-coffee": "~0.7.0",
     "grunt-contrib-less": "~0.8.0",
     "grunt-cson": "0.5.0",
-    "grunt-download-atom-shell": "git+https://atom-bot:362295be4c5258d3f7b967bbabae662a455ca2a7@github.com/atom/grunt-download-atom-shell#v0.5.0",
+    "grunt-download-atom-shell": "git+https://atom-bot:362295be4c5258d3f7b967bbabae662a455ca2a7@github.com/atom/grunt-download-atom-shell#v0.6.0",
     "grunt-lesslint": "0.13.0",
     "grunt-markdown": "~0.4.0",
     "grunt-peg": "~1.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "keytar": "0.15.1",
     "less-cache": "0.11.0",
     "mixto": "1.x",
-    "nslog": "0.3.0",
+    "nslog": "0.4.0",
     "oniguruma": "1.x",
     "optimist": "0.4.0",
     "pathwatcher": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "styleguide": "0.21.0",
     "symbols-view": "0.29.0",
     "tabs": "0.18.0",
-    "terminal": "0.26.0",
+    "terminal": "0.27.0",
     "timecop": "0.13.0",
     "to-the-hubs": "0.17.0",
     "tree-view": "0.65.0",

--- a/script/grunt
+++ b/script/grunt
@@ -2,8 +2,8 @@
 var cp = require('./utils/child-process-wrapper.js');
 var path = require('path');
 
-// node build/node_modules/grunt-cli/bin/grunt "$@"
-var gruntPath = path.resolve(__dirname, '..', 'build', 'node_modules', 'grunt-cli', 'bin', 'grunt') + (process.platform === 'win32' ? '.cmd' : '');
-var args = [gruntPath, '--gruntfile', path.resolve('build', 'Gruntfile.coffee')];
+// node build/node_modules/.bin/grunt "$@"
+var gruntPath = path.resolve(__dirname, '..', 'build', 'node_modules', '.bin', 'grunt') + (process.platform === 'win32' ? '.cmd' : '');
+var args = ['--gruntfile', path.resolve('build', 'Gruntfile.coffee')];
 args = args.concat(process.argv.slice(2));
-cp.safeSpawn(process.execPath, args, process.exit);
+cp.safeSpawn(gruntPath, args, process.exit);

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -7,16 +7,14 @@ fs = require 'fs'
 module = require 'module'
 path = require 'path'
 optimist = require 'optimist'
-# TODO: NSLog is missing .lib on windows
-nslog = require 'nslog' unless process.platform is 'win32'
+nslog = require 'nslog'
 dialog = require 'dialog'
 
 console.log = (args...) ->
   # TODO: Make NSLog work as expected
   output = args.map((arg) -> JSON.stringify(arg)).join(" ")
-  if process.platform == 'darwin'
-    nslog(output)
-  else
+  nslog(output)
+  if process.platform isnt 'darwin'
     fs.writeFileSync('debug.log', output, flag: 'a')
 
 process.on 'uncaughtException', (error={}) ->


### PR DESCRIPTION
:no_bicycles: Not done yet :no_bicycles: 
- [x] Terminal package install failure.
- [x] Node-unzip doesn't work under node v0.11.x. (https://github.com/atom/node-ls-archive/issues/1 <del>https://github.com/atom/grunt-download-atom-shell/issues/2</del>)
- [ ] Use named pipe instead of unix file socket in the startup code on Windows
- [ ] It's very  hard to open command palette by key
- [ ] Some key shortcuts seem to be invoked for twice when typing
- [ ] The keybindings' icon in command palette doesn't show
- [ ] Add `atom.cmd`
- [ ] Make `grunt install` work
- [ ] Terminal package doesn't work
- [ ] High-DPI support
- [ ] Make all specs pass.
