### PR TITLE
Closing a tab activates the wrong tab

### DIFF
--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -111,7 +111,7 @@ describe "Pane", ->
       pane = new Pane(items: [new Item("A"), new Item("B"), new Item("C")])
       [item1, item2, item3] = pane.items
 
-    it "removes the item from the items list and activates the next item if it was the active item", ->
+    it "removes the item from the items list", ->
       expect(pane.activeItem).toBe item1
       pane.destroyItem(item2)
       expect(item2 in pane.items).toBe false
@@ -119,7 +119,21 @@ describe "Pane", ->
 
       pane.destroyItem(item1)
       expect(item1 in pane.items).toBe false
-      expect(pane.activeItem).toBe item3
+
+    describe "when the destroyed item is the active item and is the first item", ->
+      it "activates the next item", ->
+        expect(pane.activeItem).toBe item1
+        pane.destroyItem(item1)
+        expect(pane.activeItem).toBe item2
+
+    describe "when the destroyed item is the active item and is not the first item", ->
+      beforeEach ->
+        pane.activateItem(item2)
+
+      it "activates the previous item", ->
+        expect(pane.activeItem).toBe item2
+        pane.destroyItem(item2)
+        expect(pane.activeItem).toBe item1
 
     it "emits 'item-removed' with the item, its index, and true indicating the item is being destroyed", ->
       pane.on 'item-removed', itemRemovedHandler = jasmine.createSpy("itemRemovedHandler")

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -429,23 +429,23 @@ describe "WorkspaceView", ->
       expect(workspace.getActivePaneItem().getUri()).not.toBeUndefined()
 
       # destroy all items
-      expect(workspace.getActivePaneItem().getUri()).toBe 'a'
+      expect(workspace.getActivePaneItem().getUri()).toBe 'file1'
       pane.destroyActiveItem()
       expect(workspace.getActivePaneItem().getUri()).toBe 'b'
       pane.destroyActiveItem()
-      expect(workspace.getActivePaneItem().getUri()).toBe 'file1'
+      expect(workspace.getActivePaneItem().getUri()).toBe 'a'
       pane.destroyActiveItem()
 
       # reopens items with uris
       expect(workspace.getActivePaneItem()).toBeUndefined()
       workspace.reopenItemSync()
-      expect(workspace.getActivePaneItem().getUri()).toBe 'file1'
+      expect(workspace.getActivePaneItem().getUri()).toBe 'a'
 
       # does not reopen items that are already open
       workspace.openSync('b')
       expect(workspace.getActivePaneItem().getUri()).toBe 'b'
       workspace.reopenItemSync()
-      expect(workspace.getActivePaneItem().getUri()).toBe 'a'
+      expect(workspace.getActivePaneItem().getUri()).toBe 'file1'
 
   describe "core:close", ->
     it "closes the active pane item until all that remains is a single empty pane", ->

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -158,8 +158,10 @@ class Pane extends Model
     if item is @activeItem
       if @items.length is 1
         @activeItem = undefined
-      else
+      else if index is 0
         @activateNextItem()
+      else
+        @activatePreviousItem()
     @items.splice(index, 1)
     @emit 'item-removed', item, index, destroying
     @container?.itemDestroyed(item) if destroying


### PR DESCRIPTION
I'm guessing that this is more of a personal preference thing, but it's bugged me several times so I thought I'd start a conversation around it.

I think it would be more natural for the tab to the _left_ of your active tab to activate when you close your active tab instead of the one to the right. This is especially true when you open a file with `cmd+t`, make a quick change, and then close it; I would expect to be back where I was before I opened the file, but instead I'm a tab over.
