### PR TITLE
Add source map support in dev mode

### DIFF
--- a/src/coffee-cache.coffee
+++ b/src/coffee-cache.coffee
@@ -22,7 +22,10 @@ getCachedJavaScript = (cachePath) ->
       fs.readFileSync(cachePath, 'utf8') if stat.isFile()
 
 compileCoffeeScript = (coffee, filePath, cachePath) ->
-  js = CoffeeScript.compile(coffee, filename: filePath)
+  {js,v3SourceMap} = CoffeeScript.compile(coffee, filename: filePath, sourceMap: true)
+  # Include source map in the web page environment.
+  if btoa? and JSON? and unescape? and encodeURIComponent?
+    js = "#{js}\n//# sourceMappingURL=data:application/json;base64,#{btoa unescape encodeURIComponent v3SourceMap}\n//# sourceURL=#{filePath}"
   try
     mkdir(path.dirname(cachePath))
     fs.writeFileSync(cachePath, js)


### PR DESCRIPTION
The translated js files would be shown under `(no domain)` and original coffee script source would be shown under `file://` in devtools' sources panel. Fixes #1448.

![source-map](https://f.cloud.github.com/assets/639601/1971567/0d6f976a-8332-11e3-80b3-4cee9c26b614.gif)
