### PR TITLE
Fix grunt install on Windows

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -30,6 +30,7 @@
     "rcedit": "~0.1.2",
     "request": "~2.27.0",
     "rimraf": "~2.2.2",
+    "runas": "~0.3.0",
     "unzip": "~0.1.9",
     "vm-compatibility-layer": "~0.1.0",
     "walkdir": "0.0.7"

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -1,18 +1,24 @@
 path = require 'path'
 
 module.exports = (grunt) ->
-  {cp, mkdir, rm} = require('./task-helpers')(grunt)
+  {cp, mkdir, rm, spawn} = require('./task-helpers')(grunt)
 
   grunt.registerTask 'install', 'Install the built application', ->
     installDir = grunt.config.get('atom.installDir')
     shellAppDir = grunt.config.get('atom.shellAppDir')
     if process.platform is 'win32'
+      done = @async()
+
       runas = require 'runas'
       copyFolder = path.resolve 'script', 'copy-folder.cmd'
       # cmd /c ""script" "source" "destination""
       arg = "/c \"\"#{copyFolder}\" \"#{shellAppDir}\" \"#{installDir}\"\""
       if runas('cmd', [arg], hide: true) isnt 0
-        throw new Error("Failed to copy #{shellAppDir} to #{installDir}")
+        done("Failed to copy #{shellAppDir} to #{installDir}")
+
+      createShortcut = path.resolve 'script', 'create-shortcut.cmd'
+      args = ['/c', createShortcut, path.join(installDir, 'atom.exe'), 'Atom']
+      spawn {cmd: 'cmd', args}, done
     else
       rm installDir
       mkdir path.dirname(installDir)

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -6,6 +6,14 @@ module.exports = (grunt) ->
   grunt.registerTask 'install', 'Install the built application', ->
     installDir = grunt.config.get('atom.installDir')
     shellAppDir = grunt.config.get('atom.shellAppDir')
-    rm installDir
-    mkdir path.dirname(installDir)
-    cp shellAppDir, installDir
+    if process.platform is 'win32'
+      runas = require 'runas'
+      copyFolder = path.resolve 'script', 'copy-folder.cmd'
+      # cmd /c ""script" "source" "destination""
+      arg = "/c \"\"#{copyFolder}\" \"#{shellAppDir}\" \"#{installDir}\"\""
+      if runas('cmd', [arg], hide: true) isnt 0
+        throw new Error("Failed to copy #{shellAppDir} to #{installDir}")
+    else
+      rm installDir
+      mkdir path.dirname(installDir)
+      cp shellAppDir, installDir

--- a/script/copy-folder.cmd
+++ b/script/copy-folder.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set USAGE="Usage: %0 source destination"
+set USAGE=Usage: %0 source destination
 
 if [%1] == [] (
   echo %USAGE%

--- a/script/copy-folder.cmd
+++ b/script/copy-folder.cmd
@@ -1,0 +1,18 @@
+@echo off
+
+set USAGE="Usage: %0 source destination"
+
+if [%1] == [] (
+  echo %USAGE%
+  exit 1
+)
+if [%2] == [] (
+  echo %USAGE%
+  exit 2
+)
+
+:: rm -rf %2
+if exist %2 rmdir %2 /s /q
+
+:: cp -rf %1 %2
+xcopy %1 %2 /e /h /c /i /y /r

--- a/script/create-shortcut.cmd
+++ b/script/create-shortcut.cmd
@@ -1,0 +1,23 @@
+@echo off
+
+set USAGE=Usage: %0 source name-on-desktop
+
+if [%1] == [] (
+  echo %USAGE%
+  exit 1
+)
+if [%2] == [] (
+  echo %USAGE%
+  exit 2
+)
+
+set SCRIPT="%TEMP%\%RANDOM%-%RANDOM%-%RANDOM%-%RANDOM%.vbs"
+
+echo Set oWS = WScript.CreateObject("WScript.Shell") >> %SCRIPT%
+echo sLinkFile = "%USERPROFILE%\Desktop\%2.lnk" >> %SCRIPT%
+echo Set oLink = oWS.CreateShortcut(sLinkFile) >> %SCRIPT%
+echo oLink.TargetPath = %1 >> %SCRIPT%
+echo oLink.Save >> %SCRIPT%
+
+cscript /nologo %SCRIPT%
+del %SCRIPT%


### PR DESCRIPTION
This PR uses node-runas to install Atom to `%PROGRAMFILES%\Atom` with administrator privilege, and also creates a desktop shortcut to `atom.exe`.
