### PR TITLE
Allow rebinding keys that are bound to application menu items

### DIFF
--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -112,10 +112,24 @@ class ApplicationMenu
       item.metadata = {}
       if item.command
         item.accelerator = @acceleratorForCommand(item.command, keystrokesByCommand)
-        item.click = => global.atomApplication.sendCommand(item.command)
+        keystroke = @firstKeystrokeForCommand(item.command, keystrokesByCommand)
+        item.click = => global.atomApplication.sendCommandOrKeystroke(item.command, keystroke)
         item.metadata['windowSpecific'] = true unless /^application:/.test(item.command)
       @translateTemplate(item.submenu, keystrokesByCommand) if item.submenu
     template
+
+  # Private: Determine the first bound keystroke for the given command.
+  #
+  # * command:
+  #   The name of the command.
+  # * keystrokesByCommand:
+  #   An Object where the keys are commands and the values are Arrays containing
+  #   the keystroke.
+  #
+  # Returns a String containing the keystroke in the format used in Atom's
+  #   keymap CSON files.
+  firstKeystrokeForCommand: (command, keystrokesByCommand) ->
+    keystrokesByCommand[command]?[0]
 
   # Private: Determine the accelerator for a given command.
   #
@@ -128,7 +142,7 @@ class ApplicationMenu
   # Returns a String containing the keystroke in a format that can be interpreted
   #   by atom shell to provide nice icons where available.
   acceleratorForCommand: (command, keystrokesByCommand) ->
-    firstKeystroke = keystrokesByCommand[command]?[0]
+    firstKeystroke = @firstKeystrokeForCommand(command, keystrokesByCommand)
     return null unless firstKeystroke
 
     modifiers = firstKeystroke.split('-')

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -206,6 +206,24 @@ class AtomApplication
     unless @emit(command, args...)
       @focusedWindow()?.sendCommand(command, args...)
 
+  # Public: Executes the given command, or the command associated with the given
+  # keystroke.
+  #
+  # If the command isn't handled globally, then delegate the keystroke
+  # to the currently focused window.
+  #
+  # * command:
+  #   The string representing the command.
+  # * keystroke:
+  #   The keystroke, in Atom's keymap format used inside its keymap CSON,
+  #   to forward to the currently focused window if the command isn't handled
+  #   globally.
+  # * args:
+  #   The optional arguments to pass along.
+  sendCommandOrKeystroke: (command, keystroke, args...) ->
+    unless @emit(command, args...)
+      @focusedWindow()?.sendKeystrokeToBrowserWindow(keystroke, args...)
+
   # Public: Open the given path in the focused window when the event is
   # triggered.
   #

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -124,6 +124,9 @@ class AtomWindow
       unless @sendCommandToFirstResponder(command)
         @sendCommandToBrowserWindow(command, args...)
 
+  sendKeystrokeToBrowserWindow: (keystroke, args...) ->
+    ipc.sendChannel @browserWindow.getProcessId(), @browserWindow.getRoutingId(), 'keystroke', keystroke, args...
+
   sendCommandToBrowserWindow: (command, args...) ->
     action = if args[0]?.contextCommand then 'context-command' else 'command'
     ipc.sendChannel @browserWindow.getProcessId(), @browserWindow.getRoutingId(), action, command, args...

--- a/src/keymap.coffee
+++ b/src/keymap.coffee
@@ -164,9 +164,12 @@ class Keymap
       @keyBindings.push new KeyBinding(source, command, keystroke, selector)
 
   handleKeyEvent: (event) ->
+    keystroke = @keystrokeStringForEvent(event, @queuedKeystroke)
+    @handleKeystroke(keystroke, event)
+
+  handleKeystroke: (keystroke, event) ->
     element = event.target
     element = atom.workspaceView if element == document.body
-    keystroke = @keystrokeStringForEvent(event, @queuedKeystroke)
     keyBindings = @keyBindingsForKeystrokeMatchingElement(keystroke, element)
 
     if keyBindings.length == 0 and @queuedKeystroke

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -20,6 +20,13 @@ class WindowEventHandler
         activeElement = atom.workspaceView
       $(activeElement).trigger(command, args...)
 
+    @subscribe ipc, 'keystroke', (keystroke) ->
+      activeElement = document.activeElement
+      # Use root view if body has focus
+      if activeElement is document.body and atom.workspaceView?
+        activeElement = atom.workspaceView
+      $(activeElement).trigger('keystroke', keystroke)
+
     @subscribe ipc, 'context-command', (command, args...) ->
       $(atom.contextMenu.activeElement).trigger(command, args...)
 
@@ -56,6 +63,9 @@ class WindowEventHandler
 
     @subscribe $(document), 'keydown', (event) ->
       atom.keymap.handleKeyEvent(event)
+
+    @subscribe $(document), 'keystroke', (event, keystroke) ->
+      atom.keymap.handleKeystroke(keystroke, event)
 
     @subscribe $(document), 'drop', (e) ->
       e.preventDefault()


### PR DESCRIPTION
It appears that you cannot specify custom key bindings for items that appear in the application menu. I ran into the following issue while working on atom/tree-view#34; do the following to reproduce:
1. Clone [BinaryMuse/tree-view](https://github.com/BinaryMuse/tree-view) into `~/.atom/dev/packages/tree-view` and switch to the `bt-copy-paths` branch.
2. Fire up Atom with `atom -d` and, with a file open and focus in the editor, press `ctrl-C`. Notice that the path of the file has been copied into the clipboard by `editor:copy-path`.
3. Focus the tree view and select a different entry without changing the open file. With the tree view focused, press `ctrl-C`. Notice that the clipboard still contains the path to the currently open file, even though the `bkt-copy-paths` branch specifies that `ctrl-C` for `.tree-view` should execute `tree-view:copy-full-path`.

This happens because `ApplicationMenu` determines the specific command to execute when the menu item is clicked, without consulting the keymap specificity rules; this seems necessary for commands that are handled by `AtomApplication`.

This pull request introduces a change that sends the _keystroke_ to `WindowEventHandler`, instead of the command, in the case where `AtomApplication` does not handle the command itself.

Specs pass and things appear to work, but I'm not sure of the wider repercussions of this change, and would love to get some eyes on it. For one thing, since menu commands may now trigger different commands based on specificity, there may be a disconnect between what the menu item says and what it actually does. (This is okay for my example, where `ctrl-C` is bound to "Copy Path" in the menu, which makes sense in the new tree view context, but a user could easily rebind commands so that they no longer make sense--but maybe we don't care.)
