### PR TITLE
Use squirrel as updater (instead of sparkle)

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -4,7 +4,8 @@
     submenu: [
       { label: 'About Atom', command: 'application:about' }
       { label: "VERSION", enabled: false }
-      { label: "Install update", command: 'application:install-update', visible: false }
+      { label: "Restart and Install Update", command: 'application:install-update', visible: false}
+      { label: "Check for Update", command: 'application:check-for-update'}
       { type: 'separator' }
       { label: 'Preferences...', command: 'application:show-settings' }
       { label: 'Open Your Config', command: 'application:open-your-config' }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "url": "http://github.com/atom/atom/raw/master/LICENSE.md"
     }
   ],
-  "atomShellVersion": "0.8.7",
+  "atomShellVersion": "0.9.0",
   "dependencies": {
     "async": "0.2.6",
     "bootstrap": "git://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -69,19 +69,13 @@ class ApplicationMenu
     if (item = _.find(@flattenMenuTemplate(template), (i) -> i.label == 'VERSION'))
       item.label = "Version #{@version}"
 
-  # Public: Makes the download menu item visible if available.
-  #
-  # Note: The update menu item's must match 'Install update' exactly otherwise
-  # this function will fail to work.
-  #
-  # * newVersion:
-  #   FIXME: Unused.
-  # * quitAndUpdateCallback:
-  #   Function to call when the install menu item has been clicked.
-  showDownloadUpdateItem: (newVersion, quitAndUpdateCallback) ->
-    if (item = _.find(@flattenMenuItems(@menu), (i) -> i.label == 'Install update'))
-      item.visible = true
-      item.click = quitAndUpdateCallback
+  showInstallUpdateItem: (visible=true) ->
+    if (item = _.find(@flattenMenuItems(@menu), (i) -> i.label == 'Restart and Install Update'))
+      item.visible = visible
+
+  showCheckForUpdateItem: (visible=true) ->
+    if (item = _.find(@flattenMenuItems(@menu), (i) -> i.label == 'Check for Update'))
+      item.visible = visible
 
   # Private: Default list of menu items.
   #

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -69,10 +69,12 @@ class ApplicationMenu
     if (item = _.find(@flattenMenuTemplate(template), (i) -> i.label == 'VERSION'))
       item.label = "Version #{@version}"
 
+  # Toggles Install Update Item
   showInstallUpdateItem: (visible=true) ->
     if (item = _.find(@flattenMenuItems(@menu), (i) -> i.label == 'Restart and Install Update'))
       item.visible = visible
 
+  # Toggles Check For Update Item
   showCheckForUpdateItem: (visible=true) ->
     if (item = _.find(@flattenMenuItems(@menu), (i) -> i.label == 'Check for Update'))
       item.visible = visible

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -134,7 +134,7 @@ class AtomApplication
       @applicationMenu.showCheckForUpdateItem(false)
       @updateVersion = releaseName
 
-    autoUpdater.on 'error', (event, message)=>
+    autoUpdater.on 'error', (event, message) =>
       @applicationMenu.showInstallUpdateItem(false)
       @applicationMenu.showCheckForUpdateItem(true)
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -140,6 +140,30 @@ class AtomApplication
 
     autoUpdater.checkForUpdates()
 
+  checkForUpdate: ->
+    autoUpdater.once 'update-available', ->
+      dialog.showMessageBox
+        type: 'info'
+        buttons: ['OK']
+        message: 'Update available.'
+        detail: 'A new update is being downloading.'
+
+    autoUpdater.once 'update-not-available', =>
+      dialog.showMessageBox
+        type: 'info'
+        buttons: ['OK']
+        message: 'No update available.'
+        detail: "Version #{@version} is the latest version."
+
+    autoUpdater.once 'error', (event, message)->
+      dialog.showMessageBox
+        type: 'warning'
+        buttons: ['OK']
+        message: 'There was an error checking for updates.'
+        detail: message
+
+    autoUpdater.checkForUpdates()
+
   # Private: Registers basic application commands, non-idempotent.
   handleEvents: ->
     @on 'application:about', -> Menu.sendActionToFirstResponder('orderFrontStandardAboutPanel:')
@@ -159,6 +183,8 @@ class AtomApplication
     @on 'application:inspect', ({x,y}) -> @focusedWindow().browserWindow.inspectElement(x, y)
     @on 'application:open-documentation', -> shell.openExternal('https://www.atom.io/docs/latest/?app')
     @on 'application:report-issue', -> shell.openExternal('https://github.com/atom/atom/issues/new')
+    @on 'application:install-update', -> autoUpdater.quitAndInstall()
+    @on 'application:check-for-update', => @checkForUpdate()
 
     @openPathOnEvent('application:show-settings', 'atom://config')
     @openPathOnEvent('application:open-your-config', 'atom://.atom/config')

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -118,7 +118,7 @@ class AtomApplication
 
   # Private: Enable updates unless running from a local build of Atom.
   setupAutoUpdater: ->
-    autoUpdater.setFeedUrl "http://localhost:9393/releases/latest?version=#{@version}"
+    autoUpdater.setFeedUrl "https://atom.io/api/updates?version=#{@version}"
 
     autoUpdater.on 'checking-for-update', =>
       @applicationMenu.showInstallUpdateItem(false)

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -1,6 +1,5 @@
 global.shellStartTime = Date.now()
 
-autoUpdater = require 'auto-updater'
 crashReporter = require 'crash-reporter'
 app = require 'app'
 fs = require 'fs'
@@ -42,7 +41,6 @@ start = ->
 
   app.on 'will-finish-launching', ->
     setupCrashReporter()
-    setupAutoUpdater()
 
   app.on 'finish-launching', ->
     app.removeListener 'open-file', addPathToOpen
@@ -65,9 +63,6 @@ global.devResourcePath = path.join(app.getHomeDir(), 'github', 'atom')
 
 setupCrashReporter = ->
   crashReporter.start(productName: 'Atom', companyName: 'GitHub')
-
-setupAutoUpdater = ->
-  autoUpdater.setFeedUrl 'https://speakeasy.githubapp.com/apps/27/appcast.xml'
 
 parseCommandLine = ->
   version = app.getVersion()


### PR DESCRIPTION
Atom will use squirrel to update instead of sparkle. 

Needs:
- [x] https://github.com/atom/atom-shell/pull/173 to be merged and published
- [x] Atom.io to use the squirrel update API
- [x] Atom to use the Atom.io update endpoint

Closes #1245
