### PR TITLE
Fix grunt build on Windows

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -32,7 +32,6 @@
     "runas": "~0.3.0",
     "underscore-plus": "1.x",
     "unzip": "~0.1.9",
-    "vm-compatibility-layer": "~0.1.0",
-    "walkdir": "0.0.7"
+    "vm-compatibility-layer": "~0.1.0"
   }
 }

--- a/build/tasks/task-helpers.coffee
+++ b/build/tasks/task-helpers.coffee
@@ -1,27 +1,35 @@
-fs = require 'fs'
+fs = require 'fs-plus'
 path = require 'path'
-walkdir = require 'walkdir'
 
 module.exports = (grunt) ->
   cp: (source, destination, {filter}={}) ->
     unless grunt.file.exists(source)
       grunt.fatal("Cannot copy non-existent #{source.cyan} to #{destination.cyan}")
 
-    try
-      walkdir.sync source, (sourcePath, stats) ->
-        return if filter?.test(sourcePath)
+    copyFile = (sourcePath, destinationPath) ->
+      return if filter?.test(sourcePath)
 
-        destinationPath = path.join(destination, path.relative(source, sourcePath))
-        if stats.isSymbolicLink()
-          grunt.file.mkdir(path.dirname(destinationPath))
-          fs.symlinkSync(fs.readlinkSync(sourcePath), destinationPath)
-        else if stats.isFile()
-          grunt.file.copy(sourcePath, destinationPath)
+      stats = fs.lstatSync(sourcePath)
+      if stats.isSymbolicLink()
+        grunt.file.mkdir(path.dirname(destinationPath))
+        fs.symlinkSync(fs.readlinkSync(sourcePath), destinationPath)
+      else if stats.isFile()
+        grunt.file.copy(sourcePath, destinationPath)
 
-        if grunt.file.exists(destinationPath)
-          fs.chmodSync(destinationPath, fs.statSync(sourcePath).mode)
-    catch error
-      grunt.fatal(error)
+      if grunt.file.exists(destinationPath)
+        fs.chmodSync(destinationPath, fs.statSync(sourcePath).mode)
+
+    if grunt.file.isFile(source)
+      copyFile(source, destination)
+    else
+      try
+        onFile = (sourcePath) ->
+          destinationPath = path.join(destination, path.relative(source, sourcePath))
+          copyFile(sourcePath, destinationPath)
+        onDirectory = -> true
+        fs.traverseTreeSync source, onFile, onDirectory
+      catch error
+        grunt.fatal(error)
 
     grunt.verbose.writeln("Copied #{source.cyan} to #{destination.cyan}.")
 


### PR DESCRIPTION
On Windows with node v0.11.x walkdir is ignoring files randomly sometimes, this PR replaced it with `fs.traverseTreeSync`.
