### PR TITLE
Clear conflict on save

### DIFF
--- a/spec/text-buffer-spec.coffee
+++ b/spec/text-buffer-spec.coffee
@@ -571,6 +571,23 @@ describe 'TextBuffer', ->
         saveBuffer.reload()
         expect(events).toEqual ['will-reload', 'reloaded']
 
+      it "no longer reports being in conflict", ->
+        saveBuffer.setText('a')
+        saveBuffer.save()
+        saveBuffer.setText('ab')
+
+        fs.writeFileSync(saveBuffer.getPath(), 'c')
+        conflictHandler = jasmine.createSpy('conflictHandler')
+        saveBuffer.on 'contents-conflicted', conflictHandler
+
+        waitsFor ->
+          conflictHandler.callCount > 0
+
+        runs ->
+          expect(saveBuffer.isInConflict()).toBe true
+          saveBuffer.save()
+          expect(saveBuffer.isInConflict()).toBe false
+
     describe "when the buffer has no path", ->
       it "throws an exception", ->
         saveBuffer = atom.project.bufferForPathSync(null)

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -165,14 +165,14 @@ class TextBuffer extends TextBufferCore
 
   # Sets the path for the file.
   #
-  # path - A {String} representing the new file path
-  setPath: (path) ->
-    return if path == @getPath()
+  # filePath - A {String} representing the new file path
+  setPath: (filePath) ->
+    return if filePath == @getPath()
 
     @file?.off()
 
-    if path
-      @file = new File(path)
+    if filePath
+      @file = new File(filePath)
       @subscribeToFile()
     else
       @file = null
@@ -188,12 +188,12 @@ class TextBuffer extends TextBufferCore
 
   # Saves the buffer at a specific path.
   #
-  # path - The path to save at.
-  saveAs: (path) ->
-    unless path then throw new Error("Can't save buffer with no file path")
+  # filePath - The path to save at.
+  saveAs: (filePath) ->
+    unless filePath then throw new Error("Can't save buffer with no file path")
 
     @emit 'will-be-saved', this
-    @setPath(path)
+    @setPath(filePath)
     @cachedDiskContents = @getText()
     @file.write(@getText())
     @conflict = false

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -196,6 +196,7 @@ class TextBuffer extends TextBufferCore
     @setPath(path)
     @cachedDiskContents = @getText()
     @file.write(@getText())
+    @conflict = false
     @emitModifiedStatusChanged(false)
     @emit 'saved', this
 

--- a/src/text-buffer.coffee
+++ b/src/text-buffer.coffee
@@ -213,7 +213,10 @@ class TextBuffer extends TextBufferCore
     else
       not @isEmpty()
 
-  # Identifies if a buffer is in a git conflict with `HEAD`.
+  # Is the buffer's text in conflict with the text on disk?
+  #
+  # This occurs when the buffer's file changes on disk while the buffer has
+  # unsaved changes.
   #
   # Returns a {Boolean}.
   isInConflict: -> @conflict


### PR DESCRIPTION
This is a problem I see happen occasionally but I only recently found reproduction steps to make it happen consistently.
1. Open a file that is in a Git repo
2. Modify the buffer
3. Save the buffer
4. Modify the buffer
5. Run `cmd-option-z` (Git reset command)
6. Hit cancel from the dialog prompting you to reload
7. Save the buffer
8. Run `cmd-option-z` (Git reset command)
9. Reload dialog shows appears again

I'm assuming the reload dialog in step 9 shouldn't appear since once you save a buffer it should no longer report being in conflict, so the next reset command should occur cleanly.
