### PR TITLE
Tweak spec reporter styles

### DIFF
--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -23,6 +23,7 @@ formatStackTrace = (message='', stackTrace) ->
     prefixMatch = line.match(/at \[object Object\]\.<anonymous> \(([^\)]+)\)/)
     lines[index] = "at #{prefixMatch[1]}" if prefixMatch
 
+  lines = lines.map (line) -> line.trim()
   lines.join('\n')
 
 module.exports =

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -8,9 +8,11 @@ formatStackTrace = (message='', stackTrace) ->
   return stackTrace unless stackTrace
 
   jasminePattern = /^\s*at\s+.*\(?.*\/jasmine(-[^\/]*)?\.js:\d+:\d+\)?\s*$/
+  firstJasmineLinePattern = /^\s*at \/.*\/jasmine(-[^\/]*)?\.js:\d+:\d+\)?\s*$/
   convertedLines = []
   for line in stackTrace.split('\n')
     convertedLines.push(line) unless jasminePattern.test(line)
+    break if firstJasmineLinePattern.test(line)
 
   stackTrace = convertStackTrace(convertedLines.join('\n'), sourceMaps)
   lines = stackTrace.split('\n')

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -32,14 +32,14 @@ class AtomReporter extends View
       @div outlet: 'specPopup', class: "spec-popup"
       @div outlet: "suites"
       @div outlet: 'coreArea', =>
-        @div outlet: 'coreHeader', class: 'symbolHeader'
-        @ul outlet: 'coreSummary', class: 'symbolSummary list-unstyled'
+        @div outlet: 'coreHeader', class: 'symbol-header'
+        @ul outlet: 'coreSummary', class: 'symbol-summary list-unstyled'
       @div outlet: 'bundledArea', =>
-        @div outlet: 'bundledHeader', class: 'symbolHeader'
-        @ul outlet: 'bundledSummary', class: 'symbolSummary list-unstyled'
+        @div outlet: 'bundledHeader', class: 'symbol-header'
+        @ul outlet: 'bundledSummary', class: 'symbol-summary list-unstyled'
       @div outlet: 'userArea', =>
-        @div outlet: 'userHeader', class: 'symbolHeader'
-        @ul outlet: 'userSummary', class: 'symbolSummary list-unstyled'
+        @div outlet: 'userHeader', class: 'symbol-header'
+        @ul outlet: 'userSummary', class: 'symbol-summary list-unstyled'
       @div outlet: "status", class: 'status', =>
         @div outlet: "time", class: 'time'
         @div outlet: "specCount", class: 'spec-count'
@@ -229,7 +229,7 @@ class SpecResultView extends View
     for result in @spec.results().getItems() when not result.passed()
       stackTrace = formatStackTrace(result.message, result.trace.stack)
       @specFailures.append $$ ->
-        @div result.message, class: 'resultMessage fail'
+        @div result.message, class: 'result-message fail'
         @div stackTrace, class: 'stack-trace padded' if stackTrace
 
   attach: ->

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -168,7 +168,9 @@ class AtomReporter extends View
       @bundledArea.hide()
     if userPackageSpecs > 0
       if coreSpecs is 0 and bundledPackageSpecs is 0
-        packageFolderName = path.basename(path.dirname(specs[0].specDirectory))
+        # Package specs being run, show a more descriptive label
+        {specDirectory} = specs[0]
+        packageFolderName = path.basename(path.dirname(specDirectory))
         packageName = _.undasherize(_.uncamelcase(packageFolderName))
         @userHeader.text("#{packageName} Specs")
       else

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -158,15 +158,15 @@ class AtomReporter extends View
           @userSummary.append symbol
 
     if coreSpecs > 0
-      @coreHeader.text("Core Specs (#{coreSpecs}):")
+      @coreHeader.text("Core Specs (#{coreSpecs})")
     else
       @coreArea.hide()
     if bundledPackageSpecs > 0
-      @bundledHeader.text("Bundled Package Specs (#{bundledPackageSpecs}):")
+      @bundledHeader.text("Bundled Package Specs (#{bundledPackageSpecs})")
     else
       @bundledArea.hide()
     if userPackageSpecs > 0
-      @userHeader.text("User Package Specs (#{userPackageSpecs}):")
+      @userHeader.text("User Package Specs (#{userPackageSpecs})")
     else
       @userArea.hide()
 

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -1,6 +1,7 @@
-{View, $, $$} = require '../src/space-pen-extensions'
+path = require 'path'
 _ = require 'underscore-plus'
 {convertStackTrace} = require 'coffeestack'
+{View, $, $$} = require '../src/space-pen-extensions'
 
 sourceMaps = {}
 formatStackTrace = (message='', stackTrace) ->
@@ -166,7 +167,12 @@ class AtomReporter extends View
     else
       @bundledArea.hide()
     if userPackageSpecs > 0
-      @userHeader.text("User Package Specs (#{userPackageSpecs})")
+      if coreSpecs is 0 and bundledPackageSpecs is 0
+        packageFolderName = path.basename(path.dirname(specs[0].specDirectory))
+        packageName = _.undasherize(_.uncamelcase(packageFolderName))
+        @userHeader.text("#{packageName} Specs (#{userPackageSpecs})")
+      else
+        @userHeader.text("User Package Specs (#{userPackageSpecs})")
     else
       @userArea.hide()
 

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -117,7 +117,7 @@ class AtomReporter extends View
       element = $(currentTarget)
       specFailures = element.parent().find('.spec-failures')
       specFailures.toggle()
-      if specFailures.is(":visible") then element.text "\uf03d" else element.html "\uf03f"
+      element.toggleClass('folded')
       false
 
   updateSpecCounts: ->
@@ -224,7 +224,7 @@ class SuiteResultView extends View
 class SpecResultView extends View
   @content: ->
     @div class: 'spec', =>
-      @div "\uf03d", class: 'spec-toggle'
+      @div class: 'spec-toggle'
       @div outlet: 'description', class: 'description'
       @div outlet: 'specFailures', class: 'spec-failures'
   spec: null

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -16,7 +16,7 @@ formatStackTrace = (stackTrace) ->
 module.exports =
 class AtomReporter extends View
   @content: ->
-    @div id: 'HTMLReporter', class: 'jasmine_reporter', =>
+    @div id: 'HTMLReporter', class: 'jasmine_reporter spec-reporter', =>
       @div outlet: 'specPopup', class: "spec-popup"
       @div outlet: "suites"
       @div outlet: 'coreArea', =>
@@ -218,7 +218,7 @@ class SpecResultView extends View
       stackTrace = formatStackTrace(result.trace.stack)
       @specFailures.append $$ ->
         @div result.message, class: 'resultMessage fail'
-        @div stackTrace, class: 'stackTrace' if stackTrace
+        @div stackTrace, class: 'stack-trace padded' if stackTrace
 
   attach: ->
     @parentSuiteView().append this

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -32,7 +32,7 @@ formatStackTrace = (message='', stackTrace) ->
 module.exports =
 class AtomReporter extends View
   @content: ->
-    @div class: 'jasmine_reporter spec-reporter', =>
+    @div class: 'spec-reporter', =>
       @div outlet: "suites"
       @div outlet: 'coreArea', class: 'symbol-area', =>
         @div outlet: 'coreHeader', class: 'symbol-header'

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -170,7 +170,7 @@ class AtomReporter extends View
       if coreSpecs is 0 and bundledPackageSpecs is 0
         packageFolderName = path.basename(path.dirname(specs[0].specDirectory))
         packageName = _.undasherize(_.uncamelcase(packageFolderName))
-        @userHeader.text("#{packageName} Specs (#{userPackageSpecs})")
+        @userHeader.text("#{packageName} Specs")
       else
         @userHeader.text("User Package Specs (#{userPackageSpecs})")
     else

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -230,7 +230,7 @@ class SpecResultView extends View
       stackTrace = formatStackTrace(result.message, result.trace.stack)
       @specFailures.append $$ ->
         @div result.message, class: 'result-message fail'
-        @div stackTrace, class: 'stack-trace padded' if stackTrace
+        @pre stackTrace, class: 'stack-trace padded' if stackTrace
 
   attach: ->
     @parentSuiteView().append this

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -177,8 +177,6 @@ class SuiteResultView extends View
     @div class: 'suite', =>
       @div outlet: 'description', class: 'description'
 
-  suite: null
-
   initialize: (@suite) ->
     @attr('id', "suite-view-#{@suite.id}")
     @description.html @suite.description
@@ -201,7 +199,6 @@ class SpecResultView extends View
       @div class: 'spec-toggle'
       @div outlet: 'description', class: 'description'
       @div outlet: 'specFailures', class: 'spec-failures'
-  spec: null
 
   initialize: (@spec) ->
     @addClass("spec-view-#{@spec.id}")

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -61,7 +61,7 @@ class AtomReporter extends View
 
   reportRunnerStarting: (runner) ->
     @handleEvents()
-    @startedAt = new Date()
+    @startedAt = Date.now()
     specs = runner.specs()
     @totalSpecCount = specs.length
     @addSpecs(specs)
@@ -78,7 +78,7 @@ class AtomReporter extends View
 
   reportSpecResults: (spec) ->
     @completeSpecCount++
-    spec.endedAt = new Date().getTime()
+    spec.endedAt = Date.now()
     @specComplete(spec)
     @updateStatusView(spec)
 
@@ -139,7 +139,7 @@ class AtomReporter extends View
     rootSuite = rootSuite.parentSuite while rootSuite.parentSuite
     @message.text rootSuite.description
 
-    time = "#{Math.round((spec.endedAt - @startedAt.getTime()) / 10)}"
+    time = "#{Math.round((spec.endedAt - @startedAt) / 10)}"
     time = "0#{time}" if time.length < 3
     @time[0].textContent = "#{time[0...-2]}.#{time[-2..]}s"
 

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -84,19 +84,6 @@ class AtomReporter extends View
   reportSpecStarting: (spec) ->
     @specStarted(spec)
 
-  specFilter: (spec) ->
-    globalFocusPriority = jasmine.getEnv().focusPriority
-    parent = spec.parentSuite ? spec.suite
-
-    if !globalFocusPriority
-      true
-    else if spec.focusPriority >= globalFocusPriority
-      true
-    else if not parent
-      false
-    else
-      @specFilter(parent)
-
   handleEvents: ->
     $(document).on "click", ".spec-toggle", ({currentTarget}) =>
       element = $(currentTarget)

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -179,7 +179,7 @@ class SuiteResultView extends View
 
   initialize: (@suite) ->
     @attr('id', "suite-view-#{@suite.id}")
-    @description.html @suite.description
+    @description.text(@suite.description)
 
   attach: ->
     (@parentSuiteView() or $('.results')).append this

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -30,15 +30,15 @@ module.exports =
 class AtomReporter extends View
   @content: ->
     @div class: 'jasmine_reporter spec-reporter', =>
-      @div outlet: 'specPopup', class: "spec-popup"
+      @div outlet: 'specPopup', class: "spec-popup alert alert-info"
       @div outlet: "suites"
-      @div outlet: 'coreArea', =>
+      @div outlet: 'coreArea', class: 'symbol-area', =>
         @div outlet: 'coreHeader', class: 'symbol-header'
         @ul outlet: 'coreSummary', class: 'symbol-summary list-unstyled'
-      @div outlet: 'bundledArea', =>
+      @div outlet: 'bundledArea', class: 'symbol-area', =>
         @div outlet: 'bundledHeader', class: 'symbol-header'
         @ul outlet: 'bundledSummary', class: 'symbol-summary list-unstyled'
-      @div outlet: 'userArea', =>
+      @div outlet: 'userArea', class: 'symbol-area', =>
         @div outlet: 'userHeader', class: 'symbol-header'
         @ul outlet: 'userSummary', class: 'symbol-summary list-unstyled'
       @div outlet: "status", class: 'status alert alert-success', =>

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -28,7 +28,7 @@ formatStackTrace = (message='', stackTrace) ->
 module.exports =
 class AtomReporter extends View
   @content: ->
-    @div id: 'HTMLReporter', class: 'jasmine_reporter spec-reporter', =>
+    @div class: 'jasmine_reporter spec-reporter', =>
       @div outlet: 'specPopup', class: "spec-popup"
       @div outlet: "suites"
       @div outlet: 'coreArea', =>

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -69,9 +69,12 @@ class AtomReporter extends View
   reportRunnerResults: (runner) ->
     @updateSpecCounts()
     if @failedCount == 0
-      @message.text "Success!"
+      @message.text "Specs Passed"
     else
-      @message.text "Game Over"
+      if @failedCount is 1
+        @message.text "#{@failedCount} Failure"
+      else
+        @message.text "#{@failedCount} Failures"
 
   reportSuiteResults: (suite) ->
 

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -231,7 +231,10 @@ class SpecResultView extends View
 
   initialize: (@spec) ->
     @addClass("spec-view-#{@spec.id}")
-    @description.text @spec.description
+
+    description = @spec.description
+    description = "it #{description}" if description.indexOf('it ') isnt 0
+    @description.text(description)
 
     for result in @spec.results().getItems() when not result.passed()
       stackTrace = formatStackTrace(result.message, result.trace.stack)

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -41,7 +41,7 @@ class AtomReporter extends View
       @div outlet: 'userArea', =>
         @div outlet: 'userHeader', class: 'symbol-header'
         @ul outlet: 'userSummary', class: 'symbol-summary list-unstyled'
-      @div outlet: "status", class: 'status', =>
+      @div outlet: "status", class: 'status alert alert-success', =>
         @div outlet: "time", class: 'time'
         @div outlet: "specCount", class: 'spec-count'
         @div outlet: "message", class: 'message'
@@ -128,7 +128,7 @@ class AtomReporter extends View
 
   updateStatusView: (spec) ->
     if @failedCount > 0
-      @status.addClass('failed') unless @status.hasClass('failed')
+      @status.addClass('alert-danger').removeClass('alert-success')
 
     @updateSpecCounts()
 

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -68,13 +68,10 @@ class AtomReporter extends View
 
   reportRunnerResults: (runner) ->
     @updateSpecCounts()
-    if @failedCount == 0
-      @message.text "Specs Passed"
+    if @failedCount is 1
+      @message.text "#{@failedCount} failure"
     else
-      if @failedCount is 1
-        @message.text "#{@failedCount} Failure"
-      else
-        @message.text "#{@failedCount} Failures"
+      @message.text "#{@failedCount} failures"
 
   reportSuiteResults: (suite) ->
 

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -33,7 +33,6 @@ module.exports =
 class AtomReporter extends View
   @content: ->
     @div class: 'jasmine_reporter spec-reporter', =>
-      @div outlet: 'specPopup', class: "spec-popup alert alert-info"
       @div outlet: "suites"
       @div outlet: 'coreArea', class: 'symbol-area', =>
         @div outlet: 'coreHeader', class: 'symbol-header'
@@ -99,22 +98,6 @@ class AtomReporter extends View
       @specFilter(parent)
 
   handleEvents: ->
-    $(document).on "mouseover", ".spec-summary", ({currentTarget}) =>
-      element = $(currentTarget)
-      description = element.data("description")
-      return unless description
-
-      clearTimeout @timeoutId if @timeoutId?
-      @specPopup.show()
-      spec = _.find(window.timedSpecs, ({fullName}) -> description is fullName)
-      description = "#{description} #{spec.time}ms" if spec
-      @specPopup.text description
-      {left, top} = element.offset()
-      left += 20
-      top += 20
-      @specPopup.offset({left, top})
-      @timeoutId = setTimeout((=> @specPopup.hide()), 3000)
-
     $(document).on "click", ".spec-toggle", ({currentTarget}) =>
       element = $(currentTarget)
       specFailures = element.parent().find('.spec-failures')
@@ -186,7 +169,7 @@ class AtomReporter extends View
   specComplete: (spec) ->
     specSummaryElement = $("#spec-summary-#{spec.id}")
     specSummaryElement.removeClass('pending')
-    specSummaryElement.data("description", spec.getFullName())
+    specSummaryElement.setTooltip(title: spec.getFullName(), container: '.spec-reporter')
 
     results = spec.results()
     if results.skipped

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -5,12 +5,6 @@ body {
   padding: 0;
 }
 
-.spec-popup {
-  position: absolute;
-  font-size: 13px;
-  display: none;
-}
-
 .list-unstyled {
   list-style: none;
 }
@@ -151,5 +145,22 @@ body {
     color: #666;
     border: 1px solid #ddd;
     overflow: auto;
+  }
+
+  .tooltip {
+    .tooltip-inner {
+      border: 1px solid #ccc;
+      background: #fff;
+      color: #666;
+      max-width: 400px;
+    }
+
+    &.in {
+      opacity: 1;
+    }
+
+    .tooltip-arrow {
+      visibility: hidden;
+    }
   }
 }

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -26,7 +26,7 @@ body {
   }
 
   .symbol-header {
-    font-size: 16px;
+    font-size: 18px;
     font-weight: bold;
     margin: 0;
     padding-bottom: 10px;

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -31,7 +31,7 @@ body {
     right: 100%;
   }
 
-  .symbolHeader {
+  .symbol-header {
     background-color: #222;
     color: #c2c2c2;
     font-size: 12px;
@@ -39,41 +39,41 @@ body {
     padding: 5px 2px 2px 2px;
   }
 
-  .symbolSummary {
+  .symbol-summary {
     background-color: #222;
     overflow: hidden;
     margin: 0;
-  }
 
-  .symbolSummary li {
-    float: left;
-    line-height: 10px;
-    height: 10px;
-    width: 10px;
-    font-size: 10px;
+    li {
+      float: left;
+      line-height: 10px;
+      height: 10px;
+      width: 10px;
+      font-size: 10px;
 
-    &.passed {
-      color: #63AD75;
-    }
+      &.passed {
+        color: #63AD75;
+      }
 
-    &.failed {
-      color: #FF3F05;
-    }
+      &.failed {
+        color: #FF3F05;
+      }
 
-    &.skipped {
-      color: #444
-    }
+      &.skipped {
+        color: #444
+      }
 
-    &.pending {
-      color: #111;
-    }
+      &.pending {
+        color: #111;
+      }
 
-    &:before {
-      content: "\02022";
-    }
+      &:before {
+        content: "\02022";
+      }
 
-    &:hover {
-      color: white;
+      &:hover {
+        color: white;
+      }
     }
   }
 
@@ -174,7 +174,7 @@ body {
     }
   }
 
-  .resultMessage {
+  .result-message {
     padding-top: 5px;
     color: #fff;
     font-size: 15px

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -1,12 +1,13 @@
 @import "octicon-mixins";
 
+#jasmine_content {
+  position: fixed;
+  right: 100%;
+}
+
 body {
   background-color: #fff;
   padding: 0;
-}
-
-.list-unstyled {
-  list-style: none;
 }
 
 .spec-reporter {
@@ -14,9 +15,8 @@ body {
   line-height: 1.6em;
   color: #333;
 
-  #jasmine_content {
-    position: fixed;
-    right: 100%;
+  .list-unstyled {
+    list-style: none;
   }
 
   .symbol-header {

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -166,15 +166,16 @@ body {
   font-size: 15px
 }
 
-#HTMLReporter .stackTrace {
-  font-size: 12px;
-  padding: 5px;
-  margin: 5px 0 0 0;
-  border-radius: 2px;
-  line-height: 18px;
-  color: #666666;
-  border: 1px solid #ddd;
-  background: white;
-  white-space: pre;
-  overflow: auto;
+.spec-reporter {
+  .stack-trace {
+    font-size: 12px;
+    margin: 5px 0 0 0;
+    border-radius: 2px;
+    line-height: 18px;
+    color: #666666;
+    border: 1px solid #ddd;
+    background: white;
+    white-space: pre;
+    overflow: auto;
+  }
 }

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -28,16 +28,14 @@ body {
   }
 
   .symbol-header {
-    font-size: 12px;
+    font-size: 16px;
+    font-weight: bold;
     margin: 0;
-    padding-bottom: 5px;
+    padding-bottom: 10px;
   }
 
   .symbol-area {
-    margin: 10px;
     padding: 10px;
-    border: 1px solid #ddd;
-    border-radius: 2px;
   }
 
   .symbol-summary {

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -1,7 +1,5 @@
 @import "octicon-mixins";
 
-@font-face { .octicon-font(); }
-
 body {
   background-color: #fff;
   padding: 0;
@@ -112,12 +110,15 @@ body {
       border-left: 3px solid #d9534f;
 
       .spec-toggle {
-        font-family: Octicons Regular;
-        font-size: 20px;
+        .octicon(fold);
         float: right;
         cursor: pointer;
         opacity: 0;
         color: #999;
+
+        &.folded {
+          .octicon(unfold);
+        }
       }
 
       .spec-toggle:hover {

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -1,17 +1,14 @@
-@import "octicon-mixins.less";
+@import "octicon-mixins";
 
 @font-face { .octicon-font(); }
 
 body {
-  background-color: #ddd;
+  background-color: #fff;
   padding: 0;
 }
 
 .spec-popup {
   position: absolute;
-  background-color: #ddd;
-  border: 2px solid black;
-  padding: 5px;
   font-size: 13px;
   display: none;
 }
@@ -22,9 +19,8 @@ body {
 
 .spec-reporter {
   font-size: 11px;
-  font-family: Monaco, Consolas, monospace;
   line-height: 1.6em;
-  color: #333333;
+  color: #333;
 
   #jasmine_content {
     position: fixed;
@@ -32,19 +28,24 @@ body {
   }
 
   .symbol-header {
-    background-color: #222;
-    color: #c2c2c2;
     font-size: 12px;
     margin: 0;
-    padding: 5px 2px 2px 2px;
+    padding-bottom: 5px;
+  }
+
+  .symbol-area {
+    margin: 10px;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 2px;
   }
 
   .symbol-summary {
-    background-color: #222;
     overflow: hidden;
     margin: 0;
 
     li {
+      font-family: Monaco, Consolas, monospace;
       float: left;
       line-height: 10px;
       height: 10px;
@@ -52,46 +53,34 @@ body {
       font-size: 10px;
 
       &.passed {
-        color: #63AD75;
+        color: #5cb85c;
       }
 
       &.failed {
-        color: #FF3F05;
+        color: #d9534f;
       }
 
       &.skipped {
-        color: #444
+        color: #ddd;
       }
 
       &.pending {
-        color: #111;
+        color: #eee;
       }
 
       &:before {
         content: "\02022";
-      }
-
-      &:hover {
-        color: white;
       }
     }
   }
 
   .status {
     font-size: 20px;
-    color: #222;
-    background-color: #E5FFC0;
     line-height: 2em;
-    padding: 2px;
-    border: 2px solid #222;
-    border-left: 0;
-    border-right: 0;
+    padding: 5px;
+    border-radius: 0;
+    margin: 0;
     text-align: center;
-
-    &.failed {
-      color: white;
-      background-color: rgba(204,51,63,1.0);
-    }
 
     .spec-count {
       float: left;
@@ -103,81 +92,56 @@ body {
   }
 
   .results {
-    .suite + .suite,
-    .spec + .spec {
-      border-radius: 0;
+    padding: 10px;
+
+    .description {
+      font-size: 16px;
+      padding: 5px 0 5px 0;
     }
 
-    .suite,
-    .spec {
-      border: 2px solid #222;
-      border-radius: 7px 0 0 0;
-      border-right: none;
-      border-bottom: none;
-      padding: 5px;
-      padding-right: 0;
-      padding-bottom: 0;
-    }
+    > .suite {
+      > .description {
+        font-size: 18px;
+        font-weight: bold;
+      }
 
-    .suite:first-child {
-      border-radius: 0;
-      border: 2px solid #6A4A3C;
-      border-top: 0;
-      border-left: 0;
-      border-right: 0;
-    }
-
-    .suite {
-      border: 2px solid #6A4A3C;
-      border-radius: 7px 0 0 0;
-      border-right: none;
-      border-bottom: none;
-      padding: 5px;
-      padding-right: 0;
-      padding-bottom: 0;
-      background-color:rgba(204,51,63,0.33);
+      margin-bottom: 20px;
     }
 
     .spec {
-      padding: 10px;
-      background-color:rgba(204,51,63,1.0);
+      margin-top: 5px;
+      padding: 0 10px 10px 10px;
+      border-left: 3px solid #d9534f;
+
+      .spec-toggle {
+        font-family: Octicons Regular;
+        font-size: 20px;
+        float: right;
+        cursor: pointer;
+        opacity: 0;
+        color: #999;
+      }
+
+      .spec-toggle:hover {
+        color: #333;
+      }
+
+      &:hover .spec-toggle {
+        opacity: 1;
+      }
     }
 
     .suite > .suite,
     .suite > .spec {
-      margin-left: 5px
-    }
-
-    .description {
-      color: white;
-      font-size: 15px;
-      padding-bottom: 10px
-    }
-
-    .spec .spec-toggle {
-      font-family: Octicons Regular;
-      color: white;
-      font-size: 20px;
-      float: right;
-      cursor: pointer;
-      text-shadow: 3px 3px #222;
-      opacity: 0;
-    }
-
-    .spec .spec-toggle:hover {
-      text-shadow: none;
-      padding-top: 3px;
-    }
-
-    .spec:hover .spec-toggle {
-      opacity: 1;
+      margin-left: 10px;
     }
   }
 
   .result-message {
-    padding-top: 5px;
-    color: #fff;
-    font-size: 15px
+    font-size: 16px;
+    font-weight: bold;
+    color: #d9534f;
+    padding: 5px 0 5px 0;
   }
 
   .stack-trace {
@@ -185,10 +149,8 @@ body {
     margin: 5px 0 0 0;
     border-radius: 2px;
     line-height: 18px;
-    color: #666666;
+    color: #666;
     border: 1px solid #ddd;
-    background: white;
-    white-space: pre;
     overflow: auto;
   }
 }

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -20,8 +20,17 @@ body {
   list-style: none;
 }
 
-#HTMLReporter { font-size: 11px; font-family: Monaco, Consolas, monospace; line-height: 1.6em; color: #333333; }
-#HTMLReporter #jasmine_content { position: fixed; right: 100%; }
+#HTMLReporter {
+  font-size: 11px;
+  font-family: Monaco, Consolas, monospace;
+  line-height: 1.6em;
+  color: #333333;
+}
+
+#HTMLReporter #jasmine_content {
+  position: fixed;
+  right: 100%;
+}
 
 #HTMLReporter .symbolHeader {
   background-color: #222;

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -20,153 +20,166 @@ body {
   list-style: none;
 }
 
-#HTMLReporter {
+.spec-reporter {
   font-size: 11px;
   font-family: Monaco, Consolas, monospace;
   line-height: 1.6em;
   color: #333333;
-}
 
-#HTMLReporter #jasmine_content {
-  position: fixed;
-  right: 100%;
-}
+  #jasmine_content {
+    position: fixed;
+    right: 100%;
+  }
 
-#HTMLReporter .symbolHeader {
-  background-color: #222;
-  color: #c2c2c2;
-  font-size: 12px;
-  margin: 0;
-  padding: 5px 2px 2px 2px;
-}
+  .symbolHeader {
+    background-color: #222;
+    color: #c2c2c2;
+    font-size: 12px;
+    margin: 0;
+    padding: 5px 2px 2px 2px;
+  }
 
-#HTMLReporter .symbolSummary {
-  background-color: #222;
-  overflow: hidden;
-  margin: 0;
-}
+  .symbolSummary {
+    background-color: #222;
+    overflow: hidden;
+    margin: 0;
+  }
 
-#HTMLReporter .symbolSummary li {
-  float: left;
-  line-height: 10px;
-  height: 10px;
-  width: 10px;
-  font-size: 10px;
-}
+  .symbolSummary li {
+    float: left;
+    line-height: 10px;
+    height: 10px;
+    width: 10px;
+    font-size: 10px;
 
-#HTMLReporter .symbolSummary li.passed { color: #63AD75 }
-#HTMLReporter .symbolSummary li.failed { color: #FF3F05 }
-#HTMLReporter .symbolSummary li.skipped { color: #444 }
-#HTMLReporter .symbolSummary li.pending { color: #111 }
+    &.passed {
+      color: #63AD75;
+    }
 
-#HTMLReporter .symbolSummary li:before { content: "\02022"; }
+    &.failed {
+      color: #FF3F05;
+    }
 
-#HTMLReporter .symbolSummary li:hover {
-  color: white;
-}
+    &.skipped {
+      color: #444
+    }
 
-#HTMLReporter .status {
-  font-size: 20px;
-  color: #222;
-  background-color: #E5FFC0;
-  line-height: 2em;
-  padding: 2px;
-  border: 2px solid #222;
-  border-left: 0;
-  border-right: 0;
-  text-align: center;
-}
+    &.pending {
+      color: #111;
+    }
 
-#HTMLReporter .status.failed {
-  color: white;
-  background-color: rgba(204,51,63,1.0);
-}
+    &:before {
+      content: "\02022";
+    }
 
-#HTMLReporter .status .spec-count {
-  float: left;
-}
+    &:hover {
+      color: white;
+    }
+  }
 
-#HTMLReporter .status .message {
-}
+  .status {
+    font-size: 20px;
+    color: #222;
+    background-color: #E5FFC0;
+    line-height: 2em;
+    padding: 2px;
+    border: 2px solid #222;
+    border-left: 0;
+    border-right: 0;
+    text-align: center;
 
-#HTMLReporter .status .time {
-  float: right;
-}
+    &.failed {
+      color: white;
+      background-color: rgba(204,51,63,1.0);
+    }
 
-#HTMLReporter .results .suite + .suite, #HTMLReporter .results .spec + .spec {
-  border-radius: 0;
-}
+    .spec-count {
+      float: left;
+    }
 
-#HTMLReporter .results .suite, #HTMLReporter .results .spec {
-  border: 2px solid #222;
-  border-radius: 7px 0 0 0;
-  border-right: none;
-  border-bottom: none;
-  padding: 5px;
-  padding-right: 0;
-  padding-bottom: 0;
-}
+    .time {
+      float: right;
+    }
+  }
 
-#HTMLReporter .results .suite:first-child {
-  border-radius: 0;
-  border: 2px solid #6A4A3C;
-  border-top: 0;
-  border-left: 0;
-  border-right: 0;
-}
+  .results {
+    .suite + .suite,
+    .spec + .spec {
+      border-radius: 0;
+    }
 
-#HTMLReporter .results .suite {
-  border: 2px solid #6A4A3C;
-  border-radius: 7px 0 0 0;
-  border-right: none;
-  border-bottom: none;
-  padding: 5px;
-  padding-right: 0;
-  padding-bottom: 0;
-  background-color:rgba(204,51,63,0.33);
-}
+    .suite,
+    .spec {
+      border: 2px solid #222;
+      border-radius: 7px 0 0 0;
+      border-right: none;
+      border-bottom: none;
+      padding: 5px;
+      padding-right: 0;
+      padding-bottom: 0;
+    }
 
-#HTMLReporter .results .spec {
-  padding: 10px;
-  background-color:rgba(204,51,63,1.0);
-}
+    .suite:first-child {
+      border-radius: 0;
+      border: 2px solid #6A4A3C;
+      border-top: 0;
+      border-left: 0;
+      border-right: 0;
+    }
 
-#HTMLReporter .results .suite > .suite, #HTMLReporter .results .suite > .spec {
-  margin-left: 5px
-}
+    .suite {
+      border: 2px solid #6A4A3C;
+      border-radius: 7px 0 0 0;
+      border-right: none;
+      border-bottom: none;
+      padding: 5px;
+      padding-right: 0;
+      padding-bottom: 0;
+      background-color:rgba(204,51,63,0.33);
+    }
 
-#HTMLReporter .results .description {
-  color: white;
-  font-size: 15px;
-  padding-bottom: 10px
-}
+    .spec {
+      padding: 10px;
+      background-color:rgba(204,51,63,1.0);
+    }
 
-#HTMLReporter .results .spec .spec-toggle {
-  font-family: Octicons Regular;
-  color: white;
-  font-size: 20px;
-  float: right;
-  cursor: pointer;
-  text-shadow: 3px 3px #222;
-  opacity: 0;
-}
+    .suite > .suite,
+    .suite > .spec {
+      margin-left: 5px
+    }
 
-#HTMLReporter .results .spec .spec-toggle:hover {
-  text-shadow: none;
-  padding-top: 3px;
-}
+    .description {
+      color: white;
+      font-size: 15px;
+      padding-bottom: 10px
+    }
 
-#HTMLReporter .results .spec:hover .spec-toggle {
-  opacity: 1;
-}
+    .spec .spec-toggle {
+      font-family: Octicons Regular;
+      color: white;
+      font-size: 20px;
+      float: right;
+      cursor: pointer;
+      text-shadow: 3px 3px #222;
+      opacity: 0;
+    }
 
-#HTMLReporter .resultMessage {
-  padding-top: 5px;
-  color: #fff;
-  font-size: 15px
-}
+    .spec .spec-toggle:hover {
+      text-shadow: none;
+      padding-top: 3px;
+    }
 
-.spec-reporter {
+    .spec:hover .spec-toggle {
+      opacity: 1;
+    }
+  }
+
+  .resultMessage {
+    padding-top: 5px;
+    color: #fff;
+    font-size: 15px
+  }
+
   .stack-trace {
     font-size: 12px;
     margin: 5px 0 0 0;

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -22,7 +22,6 @@ body {
   .symbol-header {
     font-size: 18px;
     font-weight: bold;
-    margin: 0;
     padding-bottom: 10px;
   }
 
@@ -69,7 +68,6 @@ body {
     line-height: 2em;
     padding: 5px;
     border-radius: 0;
-    margin: 0;
     text-align: center;
 
     .spec-count {


### PR DESCRIPTION
- [x] Use tweaks from jasmine-focused to simplify stack traces
- [x] Use bootstrap styles
- [x] Show package name at top of runner
- [x] Prefix failure descriptions with _it_ so that they read better
- [x] Use fold/unfold octicons

The motivation here is that this is a piece of the Atom UI that package authors will use constantly so let's give it a little polish.
### Before

![screen shot 2014-02-10 at 6 43 45 pm](https://f.cloud.github.com/assets/671378/2133511/6dd42bae-92c6-11e3-8afb-4ba9a299f995.png)
### After

![screen shot 2014-02-10 at 7 20 13 pm](https://f.cloud.github.com/assets/671378/2133691/83fc6c84-92cb-11e3-9084-260e620646f9.png)
