### PR TITLE
Blink all cursors in same interval

### DIFF
--- a/src/cursor-view.coffee
+++ b/src/cursor-view.coffee
@@ -64,8 +64,7 @@ class CursorView extends View
 
   # Override for speed. The base function checks the computedStyle
   isHidden: ->
-    style = this[0].style
-    if style.display == 'none' or not @isOnDom()
+    if this[0].style.display is 'none' or not @isOnDom()
       true
     else
       false
@@ -80,7 +79,7 @@ class CursorView extends View
     @editorView.pixelPositionForScreenPosition(@getScreenPosition())
 
   setVisible: (visible) ->
-    unless @visible == visible
+    unless @visible is visible
       @visible = visible
       @toggle(@visible)
 

--- a/src/cursor-view.coffee
+++ b/src/cursor-view.coffee
@@ -64,10 +64,7 @@ class CursorView extends View
 
   # Override for speed. The base function checks the computedStyle
   isHidden: ->
-    if this[0].style.display is 'none' or not @isOnDom()
-      true
-    else
-      false
+    this[0].style.display is 'none' or not @isOnDom()
 
   needsAutoscroll: ->
     @cursor.needsAutoscroll

--- a/src/cursor-view.coffee
+++ b/src/cursor-view.coffee
@@ -33,7 +33,7 @@ class CursorView extends View
       @needsUpdate = true
       @shouldPauseBlinking = true
 
-    @subscribe @cursor, 'visibility-changed', (visible) =>
+    @subscribe @cursor, 'visibility-changed', =>
       @needsUpdate = true
 
     @subscribe @cursor, 'autoscrolled', =>

--- a/src/cursor-view.coffee
+++ b/src/cursor-view.coffee
@@ -7,10 +7,24 @@ class CursorView extends View
   @content: ->
     @div class: 'cursor idle', => @raw '&nbsp;'
 
-  blinkPeriod: 800
-  editorView: null
-  visible: true
+  @blinkPeriod: 800
 
+  @blinkCursors: ->
+    element.classList.toggle('blink-off') for [element] in @cursorViews
+
+  @startBlinking: (cursorView) ->
+    @cursorViews ?= []
+    @cursorViews.push(cursorView)
+    if @cursorViews.length is 1
+      @blinkInterval = setInterval(@blinkCursors.bind(@), @blinkPeriod / 2)
+
+  @stopBlinking: (cursorView) ->
+    cursorView[0].classList.remove('blink-off')
+    _.remove(@cursorViews, cursorView)
+    clearInterval(@blinkInterval) if @cursorViews.length is 0
+
+  blinking: false
+  visible: true
   needsUpdate: true
   needsRemoval: false
   shouldPauseBlinking: false
@@ -73,14 +87,12 @@ class CursorView extends View
       @toggle(@visible)
 
   stopBlinking: ->
-    clearInterval(@blinkInterval) if @blinkInterval
-    @blinkInterval = null
-    this[0].classList.remove('blink-off')
+    @constructor.stopBlinking(this) if @blinking
+    @blinking = false
 
   startBlinking: ->
-    return if @blinkInterval?
-    blink = => @toggleClass('blink-off')
-    @blinkInterval = setInterval(blink, @blinkPeriod / 2)
+    @constructor.startBlinking(this) unless @blinking
+    @blinking = true
 
   resetBlinking: ->
     @stopBlinking()

--- a/src/cursor-view.coffee
+++ b/src/cursor-view.coffee
@@ -29,22 +29,21 @@ class CursorView extends View
   shouldPauseBlinking: false
 
   initialize: (@cursor, @editorView) ->
-    @cursor.on 'moved.cursor-view', =>
+    @subscribe @cursor, 'moved', =>
       @needsUpdate = true
       @shouldPauseBlinking = true
 
-    @cursor.on 'visibility-changed.cursor-view', (visible) =>
+    @subscribe @cursor, 'visibility-changed', (visible) =>
       @needsUpdate = true
 
-    @cursor.on 'autoscrolled.cursor-view', =>
+    @subscribe @cursor, 'autoscrolled', =>
       @editorView.requestDisplayUpdate()
 
-    @cursor.on 'destroyed.cursor-view', =>
+    @subscribe @cursor, 'destroyed', =>
       @needsRemoval = true
 
   beforeRemove: ->
     @editorView.removeCursorView(this)
-    @cursor.off('.cursor-view')
     @stopBlinking()
 
   updateDisplay: ->

--- a/src/cursor-view.coffee
+++ b/src/cursor-view.coffee
@@ -16,7 +16,7 @@ class CursorView extends View
     @cursorViews ?= []
     @cursorViews.push(cursorView)
     if @cursorViews.length is 1
-      @blinkInterval = setInterval(@blinkCursors.bind(@), @blinkPeriod / 2)
+      @blinkInterval = setInterval(@blinkCursors.bind(this), @blinkPeriod / 2)
 
   @stopBlinking: (cursorView) ->
     cursorView[0].classList.remove('blink-off')

--- a/src/cursor-view.coffee
+++ b/src/cursor-view.coffee
@@ -1,5 +1,4 @@
 {View} = require './space-pen-extensions'
-{Point, Range} = require 'text-buffer'
 _ = require 'underscore-plus'
 
 module.exports =


### PR DESCRIPTION
Prevents cursor blink from going out of sync by using a single interval to update all current cursors.

Closes #1504 
