### PR TITLE
Cj move openers to workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "image-view": "0.19.0",
     "keybinding-resolver": "0.10.0",
     "link": "0.17.0",
-    "markdown-preview": "0.28.0",
+    "markdown-preview": "0.29.0",
     "metrics": "0.26.0",
     "package-generator": "0.26.0",
     "release-notes": "0.20.0",

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -126,6 +126,22 @@ describe "Workspace", ->
             expect(pane1.items).toEqual []
             expect(pane2.items).toEqual [editor]
 
+    describe "when passed a path that matches a custom opener", ->
+      it "returns the resource returned by the custom opener", ->
+        fooOpener = (pathToOpen, options) -> { foo: pathToOpen, options } if pathToOpen?.match(/\.foo/)
+        barOpener = (pathToOpen) -> { bar: pathToOpen } if pathToOpen?.match(/^bar:\/\//)
+        workspace.registerOpener(fooOpener)
+        workspace.registerOpener(barOpener)
+
+        waitsForPromise ->
+          pathToOpen = atom.project.relativize('a.foo')
+          workspace.open(pathToOpen, hey: "there").then (item) ->
+            expect(item).toEqual { foo: pathToOpen, options: {hey: "there"} }
+
+        waitsForPromise ->
+          workspace.open("bar://baz").then (item) ->
+            expect(item).toEqual { bar: "bar://baz" }
+
   describe "::openSync(uri, options)", ->
     [activePane, initialItemCount] = []
 

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -134,7 +134,7 @@ describe "Workspace", ->
         workspace.registerOpener(barOpener)
 
         waitsForPromise ->
-          pathToOpen = atom.project.relativize('a.foo')
+          pathToOpen = atom.project.resolve('a.foo')
           workspace.open(pathToOpen, hey: "there").then (item) ->
             expect(item).toEqual { foo: pathToOpen, options: {hey: "there"} }
 

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -128,11 +128,6 @@ class Project extends Model
     filePath = @resolve(filePath)
     @buildEditorForBuffer(@bufferForPathSync(filePath), options)
 
-  # Public: Retrieves all {Editor}s for all open files.
-  #
-  # Returns an {Array} of {Editor}s.
-  getEditors: ->
-    new Array(@editors...)
 
   # Public: Add the given {Editor}.
   addEditor: (editor) ->
@@ -305,10 +300,6 @@ class Project extends Model
     @addEditor(editor)
     editor
 
-  eachEditor: (callback) ->
-    callback(editor) for editor in @getEditors()
-    @on 'editor-created', (editor) -> callback(editor)
-
   eachBuffer: (args...) ->
     subscriber = args.shift() if args.length > 1
     callback = args.shift()
@@ -322,3 +313,5 @@ class Project extends Model
   # Deprecated delegates
   registerOpener: -> atom.workspaceView.model.registerOpener(arguments)
   unregisterOpener: -> atom.workspaceView.model.unregisterOpener(arguments)
+  eachEditor: -> atom.workspaceView.model.eachEditor(arguments)
+  getEditors: -> atom.workspaceView.model.getEditors(arguments)

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -128,13 +128,12 @@ class Project extends Model
     filePath = @resolve(filePath)
     @buildEditorForBuffer(@bufferForPathSync(filePath), options)
 
-
-  # Public: Add the given {Editor}.
+  # Add the given {Editor}.
   addEditor: (editor) ->
     @editors.push editor
     @emit 'editor-created', editor
 
-  # Public: Return and removes the given {Editor}.
+  # Return and removes the given {Editor}.
   removeEditor: (editor) ->
     _.remove(@editors, editor)
 

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -309,7 +309,7 @@ class Project extends Model
     else
       @on 'buffer-created', (buffer) -> callback(buffer)
 
-  # Deprecated delegates
+  # Deprecated: delegates
   registerOpener: -> atom.workspaceView.model.registerOpener(arguments...)
   unregisterOpener: -> atom.workspaceView.model.unregisterOpener(arguments...)
   eachEditor: -> atom.workspaceView.model.eachEditor(arguments...)

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -30,6 +30,8 @@ class Project extends Model
 
   constructor: ({path, @buffers}={}) ->
     @buffers ?= []
+    @openers = []
+
     for buffer in @buffers
       do (buffer) =>
         buffer.once 'destroyed', => @removeBuffer(buffer)
@@ -309,8 +311,19 @@ class Project extends Model
     else
       @on 'buffer-created', (buffer) -> callback(buffer)
 
-  # Deprecated: delegates
-  registerOpener: -> atom.workspaceView.model.registerOpener(arguments...)
-  unregisterOpener: -> atom.workspaceView.model.unregisterOpener(arguments...)
-  eachEditor: -> atom.workspaceView.model.eachEditor(arguments...)
-  getEditors: -> atom.workspaceView.model.getEditors(arguments...)
+  # Deprecated: delegate
+  registerOpener: (opener) ->
+    @openers.push(opener)
+    
+  # Deprecated: delegate
+  unregisterOpener: (opener) ->
+    _.remove(@openers, opener)
+  
+  # Deprecated: delegate
+  eachEditor: (callback) -> 
+    callback(editor) for editor in @getEditors()
+    @on 'editor-created', (editor) -> callback(editor)
+
+  # Deprecated: delegate
+  getEditors: ->
+    new Array(@editors...)

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -314,13 +314,13 @@ class Project extends Model
   # Deprecated: delegate
   registerOpener: (opener) ->
     @openers.push(opener)
-    
+
   # Deprecated: delegate
   unregisterOpener: (opener) ->
     _.remove(@openers, opener)
-  
+
   # Deprecated: delegate
-  eachEditor: (callback) -> 
+  eachEditor: (callback) ->
     callback(editor) for editor in @getEditors()
     @on 'editor-created', (editor) -> callback(editor)
 

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -310,7 +310,7 @@ class Project extends Model
       @on 'buffer-created', (buffer) -> callback(buffer)
 
   # Deprecated delegates
-  registerOpener: -> atom.workspaceView.model.registerOpener(arguments)
-  unregisterOpener: -> atom.workspaceView.model.unregisterOpener(arguments)
-  eachEditor: -> atom.workspaceView.model.eachEditor(arguments)
-  getEditors: -> atom.workspaceView.model.getEditors(arguments)
+  registerOpener: -> atom.workspaceView.model.registerOpener(arguments...)
+  unregisterOpener: -> atom.workspaceView.model.unregisterOpener(arguments...)
+  eachEditor: -> atom.workspaceView.model.eachEditor(arguments...)
+  getEditors: -> atom.workspaceView.model.getEditors(arguments...)

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -145,10 +145,12 @@ class Workspace extends Model
   # ```
   #
   # opener - A {Function} to be called when a path is being opened.
-  registerOpener: (opener) -> @openers.push(opener)
+  registerOpener: (opener) ->
+    @openers.push(opener)
 
   # Public: Remove a registered opener.
-  unregisterOpener: (opener) -> _.remove(@openers, opener)
+  unregisterOpener: (opener) ->
+    _.remove(@openers, opener)
 
   # Public: save the active item.
   saveActivePaneItem: ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -57,7 +57,7 @@ class Workspace extends Model
 
   # Public: Returns an {Array} of all open {Editor}s.
   getEditors: ->
-    atom.project.getEditors()    
+    atom.project.getEditors()
 
   # Public: Asynchronously opens a given a filepath in Atom.
   #
@@ -96,7 +96,7 @@ class Workspace extends Model
     # TODO: Remove deprecated changeFocus option
     activatePane = options.activatePane ? options.changeFocus ? true
     uri = atom.project.relativize(uri) ? ''
-  
+
     if uri?
       item = opener(atom.project.resolve(uri), options) for opener in @getOpeners() when !item
       editor = item ? @activePane.itemForUri(uri) ? atom.project.openSync(uri, {initialLine})
@@ -149,7 +149,7 @@ class Workspace extends Model
   # Public: Remove a registered opener.
   unregisterOpener: (opener) ->
     atom.project.unregisterOpener(opener)
-    
+
   getOpeners: ->
     atom.project.openers
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -97,34 +97,34 @@ class Workspace extends Model
     activatePane = options.activatePane ? options.changeFocus ? true
     uri = atom.project.relativize(uri) ? ''
 
-    editor = @activePane.itemForUri(uri)
+    item = @activePane.itemForUri(uri)
     if uri
-      editor ?= opener(atom.project.resolve(uri), options) for opener in @getOpeners() when !editor
-    editor ?= atom.project.openSync(uri, {initialLine})
+      item ?= opener(atom.project.resolve(uri), options) for opener in @getOpeners() when !item
+    item ?= atom.project.openSync(uri, {initialLine})
 
-    @activePane.activateItem(editor)
-    @itemOpened(editor)
+    @activePane.activateItem(item)
+    @itemOpened(item)
     @activePane.activate() if activatePane
-    editor
+    item
 
   openUriInPane: (uri, pane, options={}) ->
     changeFocus = options.changeFocus ? true
 
-    editor = pane.itemForUri(uri)
+    item = pane.itemForUri(uri)
     if uri
-      editor ?= opener(atom.project.resolve(uri), options) for opener in @getOpeners() when !editor
-    editor ?= atom.project.open(uri, options)
+      item ?= opener(atom.project.resolve(uri), options) for opener in @getOpeners() when !item
+    item ?= atom.project.open(uri, options)
 
-    Q(editor)
-      .then (editor) =>
+    Q(item)
+      .then (item) =>
         if not pane
-          pane = new Pane(items: [editor])
+          pane = new Pane(items: [item])
           @paneContainer.root = pane
-        @itemOpened(editor)
-        pane.activateItem(editor)
+        @itemOpened(item)
+        pane.activateItem(item)
         pane.activate() if changeFocus
         @emit "uri-opened"
-        editor
+        item
       .catch (error) ->
         console.error(error.stack ? error)
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -49,6 +49,18 @@ class Workspace extends Model
     paneContainer: @paneContainer.serialize()
     fullScreen: atom.isFullScreen()
 
+  # Public: Calls callback for every existing {Editor} and for all new {Editors}
+  # that are created.
+  #
+  # callback - A {Function} with an {Editor} as its only argument
+  eachEditor: (callback) ->
+    callback(editor) for editor in @getEditors()
+    @on 'editor-created', (editor) -> callback(editor)
+
+  # Public: Returns an {Array} of all open {Editor}s.
+  getEditors: ->
+    new Array(atom.project.editors...)
+
   # Public: Asynchronously opens a given a filepath in Atom.
   #
   # uri - A {String} uri.

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -97,11 +97,10 @@ class Workspace extends Model
     activatePane = options.activatePane ? options.changeFocus ? true
     uri = atom.project.relativize(uri) ? ''
 
-    if uri?
-      item = opener(atom.project.resolve(uri), options) for opener in @getOpeners() when !item
-      editor = item ? @activePane.itemForUri(uri) ? atom.project.openSync(uri, {initialLine})
-    else
-      editor = atom.project.openSync()
+    editor = @activePane.itemForUri(uri)
+    if uri
+      editor ?= opener(atom.project.resolve(uri), options) for opener in @getOpeners() when !editor
+    editor ?= atom.project.openSync(uri, {initialLine})
 
     @activePane.activateItem(editor)
     @itemOpened(editor)
@@ -110,10 +109,13 @@ class Workspace extends Model
 
   openUriInPane: (uri, pane, options={}) ->
     changeFocus = options.changeFocus ? true
-    item = opener(atom.project.resolve(uri), options) for opener in @getOpeners() when !item
-    promise = Q(item ? pane.itemForUri(uri) ? atom.project.open(uri, options))
 
-    promise
+    editor = pane.itemForUri(uri)
+    if uri
+      editor ?= opener(atom.project.resolve(uri), options) for opener in @getOpeners() when !editor
+    editor ?= atom.project.open(uri, options)
+
+    Q(editor)
       .then (editor) =>
         if not pane
           pane = new Pane(items: [editor])

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -96,7 +96,7 @@ class Workspace extends Model
     # TODO: Remove deprecated changeFocus option
     activatePane = options.activatePane ? options.changeFocus ? true
     uri = atom.project.relativize(uri) ? ''
-
+  
     if uri?
       item = opener(atom.project.resolve(uri), options) for opener in @getOpeners() when !item
       editor = item ? @activePane.itemForUri(uri) ? atom.project.openSync(uri, {initialLine})


### PR DESCRIPTION
This moves methods from Project to Workspace where they make more sense.

We should also move all buffer and editor state out of project, but there aren't any public API's that reference those. So I left them out of the PR.

Closes #1533
