### PR TITLE
Enable privilege escalation when install command

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -29,7 +29,7 @@
     "rcedit": "~0.1.2",
     "request": "~2.27.0",
     "rimraf": "~2.2.2",
-    "runas": "0.4.0",
+    "runas": "0.5.x",
     "underscore-plus": "1.x",
     "unzip": "~0.1.9",
     "vm-compatibility-layer": "~0.1.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "pegjs": "0.8.0",
     "property-accessors": "1.x",
     "q": "1.0.x",
-    "runas": "0.4.0",
+    "runas": "0.5.x",
     "scandal": "0.14.0",
     "season": "1.x",
     "semver": "1.1.4",

--- a/spec/command-installer-spec.coffee
+++ b/spec/command-installer-spec.coffee
@@ -20,7 +20,7 @@ describe "install(commandPath, callback)", ->
 
       installDone = false
       installError = null
-      installer.install commandFilePath, (error) ->
+      installer.install commandFilePath, false, (error) ->
         installDone = true
         installError = error
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -250,9 +250,9 @@ class Atom extends Model
   startEditorWindow: ->
     CommandInstaller = require './command-installer'
     resourcePath = atom.getLoadSettings().resourcePath
-    CommandInstaller.installAtomCommand resourcePath, (error) ->
+    CommandInstaller.installAtomCommand resourcePath, false, (error) ->
       console.warn error.message if error?
-    CommandInstaller.installApmCommand resourcePath, (error) ->
+    CommandInstaller.installApmCommand resourcePath, false, (error) ->
       console.warn error.message if error?
 
     @restoreWindowDimensions()

--- a/src/command-installer.coffee
+++ b/src/command-installer.coffee
@@ -34,13 +34,13 @@ module.exports =
   getInstallDirectory: ->
     "/usr/local/bin"
 
-  install: (commandPath, callback) ->
+  install: (commandPath, askForPrivilege, callback) ->
     return unless process.platform is 'darwin'
 
     commandName = path.basename(commandPath, path.extname(commandPath))
     destinationPath = path.join(@getInstallDirectory(), commandName)
     symlinkCommand commandPath, destinationPath, (error) =>
-      if error?.code is 'EACCES'
+      if askForPrivilege and error?.code is 'EACCES'
         try
           error = null
           symlinkCommandWithPrivilegeSync(commandPath, destinationPath)
@@ -48,10 +48,10 @@ module.exports =
 
       callback?(error)
 
-  installAtomCommand: (resourcePath, callback) ->
+  installAtomCommand: (resourcePath, askForPrivilege, callback) ->
     commandPath = path.join(resourcePath, 'atom.sh')
-    @install commandPath, callback
+    @install commandPath, askForPrivilege, callback
 
-  installApmCommand: (resourcePath, callback) ->
+  installApmCommand: (resourcePath, askForPrivilege, callback) ->
     commandPath = path.join(resourcePath, 'apm', 'node_modules', '.bin', 'apm')
-    @install commandPath, callback
+    @install commandPath, askForPrivilege, callback

--- a/src/command-installer.coffee
+++ b/src/command-installer.coffee
@@ -18,7 +18,7 @@ symlinkCommand = (sourcePath, destinationPath, callback) ->
             if error?
               callback(error)
             else
-              fs.chmod(destinationPath, 0o755, callback)
+              fs.chmod(destinationPath, '755', callback)
 
 symlinkCommandWithPrivilegeSync = (sourcePath, destinationPath) ->
   if runas('/bin/rm', ['-f', destinationPath], admin: true) != 0

--- a/src/command-installer.coffee
+++ b/src/command-installer.coffee
@@ -47,7 +47,7 @@ module.exports =
           error = null
 
         if error?
-          error = new Error "Could not remove file at #{destinationPath}." if error
+          error = new Error "Could not remove file at #{destinationPath}."
           callback?(error)
         else
           symlinkCommand commandPath, destinationPath, (error) =>
@@ -55,7 +55,7 @@ module.exports =
             if error?.code is 'EACCES' and symlinkCommandWithPrivilegeSync(commandPath, destinationPath)
               error = null
 
-            error = new Error "Failed to symlink #{commandPath} to #{destinationPath}." if error
+            error = new Error "Failed to symlink #{commandPath} to #{destinationPath}." if error?
             callback?(error)
     else
       error = new Error "Directory '#{directory} doesn't exist."

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -142,8 +142,8 @@ class WorkspaceView extends View
     showErrorDialog = (error) ->
       installDirectory = CommandInstaller.getInstallDirectory()
       atom.confirm
-        message: error.message
-        detailedMessage: "Make sure #{installDirectory} exists and is writable. Run 'sudo mkdir -p #{installDirectory} && sudo chown $USER #{installDirectory}' to fix this problem."
+        message: "Failed to install shell commands"
+        detailedMessage: error.message
 
     resourcePath = atom.getLoadSettings().resourcePath
     CommandInstaller.installAtomCommand resourcePath, (error) =>

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -146,11 +146,11 @@ class WorkspaceView extends View
         detailedMessage: error.message
 
     resourcePath = atom.getLoadSettings().resourcePath
-    CommandInstaller.installAtomCommand resourcePath, (error) =>
+    CommandInstaller.installAtomCommand resourcePath, true, (error) =>
       if error?
         showErrorDialog(error)
       else
-        CommandInstaller.installApmCommand resourcePath, (error) =>
+        CommandInstaller.installApmCommand resourcePath, true, (error) =>
           if error?
             showErrorDialog(error)
           else


### PR DESCRIPTION
This PR uses node-runas to run command with privilege when got EACESS error while installing command, fixes #1463.

One problem is that Atom tries to install command on startup, so Atom would keep asking for user's password on startup if current user doesn't have write permission to '/user/local/bin', which is quite annoying.
