### PR TITLE
Remove shutdown errors

### DIFF
--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -290,8 +290,3 @@ class WorkspaceView extends View
   # Called by SpacePen
   beforeRemove: ->
     @model.destroy()
-
-  # Destroys everything.
-  remove: ->
-    editorView.remove() for editorView in @getEditorViews()
-    super


### PR DESCRIPTION
Noticed this occurs often if you close Atom with two editors open:

```
TypeError: Cannot call method 'getBufferPosition' of undefined
  at Editor.module.exports.Editor.getCursorBufferPosition (/Users/kevin/github/atom/src/editor.coffee:992:18)
  at CursorPositionView.module.exports.CursorPositionView.updateCursorPositionText (/Users/kevin/github/atom/node_modules/status-bar/lib/cursor-position-view.coffee:17:5)
  at HTMLDivElement.<anonymous> (/Users/kevin/github/atom/node_modules/status-bar/lib/cursor-position-view.coffee:1:1)
  at HTMLDivElement.jQuery.event.dispatch (/Users/kevin/github/atom/node_modules/space-pen/vendor/jquery.js:4676:9)
  at HTMLDivElement.elemData.handle (/Users/kevin/github/atom/node_modules/space-pen/vendor/jquery.js:4360:28)
  at Object.jQuery.event.trigger (/Users/kevin/github/atom/node_modules/space-pen/vendor/jquery.js:4594:12)
  at HTMLDivElement.<anonymous> (/Users/kevin/github/atom/node_modules/space-pen/vendor/jquery.js:5119:17)
  at Function.jQuery.extend.each (/Users/kevin/github/atom/node_modules/space-pen/vendor/jquery.js:590:23)
  at CursorView.jQuery.fn.jQuery.each (/Users/kevin/github/atom/node_modules/space-pen/vendor/jquery.js:237:17)
  at CursorView.jQuery.fn.extend.trigger (/Users/kevin/github/atom/node_modules/space-pen/vendor/jquery.js:5118:15)
  at CursorView.module.exports.CursorView.updateDisplay (/Users/kevin/github/atom/src/cursor-view.coffee:56:8)
  at EditorView.module.exports.EditorView.updateCursorViews (/Users/kevin/github/atom/src/editor-view.coffee:935:20)
  at EditorView.module.exports.EditorView.updateDisplay (/Users/kevin/github/atom/src/editor-view.coffee:920:6)
  at EditorView.module.exports.EditorView.resetDisplay (/Users/kevin/github/atom/src/editor-view.coffee:900:6)
  at EditorView.module.exports.EditorView.afterAttach (/Users/kevin/github/atom/src/editor-view.coffee:492:6)
  at callAttachHook (/Users/kevin/github/atom/node_modules/space-pen/lib/space-pen.js:323:107)
  at [object Object].jQuery.fn.(anonymous function) [as append] (/Users/kevin/github/atom/node_modules/space-pen/lib/space-pen.js:339:9)
  at PaneView.module.exports.PaneView.onActiveItemChanged (/Users/kevin/github/atom/src/pane-view.coffee:138:16)
  at /Users/kevin/github/atom/src/pane-view.coffee:1:1
  at /Users/kevin/github/atom/node_modules/emissary/lib/emitter.js:134:30
  at Array.forEach (native)
  at Behavior.module.exports.Emitter.emit (/Users/kevin/github/atom/node_modules/emissary/lib/emitter.js:133:47)
  at Behavior.module.exports.Behavior.emit (/Users/kevin/github/atom/node_modules/emissary/lib/behavior.js:44:38)
  at Behavior.module.exports.Signal.emitValue (/Users/kevin/github/atom/node_modules/emissary/lib/signal.js:82:19)
  at Pane.module.exports.Model.set (/Users/kevin/github/atom/node_modules/theorist/lib/model.js:166:21)
  at Pane.accessor.set (/Users/kevin/github/atom/node_modules/theorist/lib/model.js:57:23)
  at Pane.module.exports.Pane.activateItem (/Users/kevin/github/atom/src/pane.coffee:132:7)
  at Pane.module.exports.Pane.activateItemAtIndex (/Users/kevin/github/atom/src/pane.coffee:126:6)
  at Pane.module.exports.Pane.activatePreviousItem (/Users/kevin/github/atom/src/pane.coffee:116:8)
  at Pane.module.exports.Pane.removeItem (/Users/kevin/github/atom/src/pane.coffee:172:10)
  at /Users/kevin/github/atom/src/pane.coffee:39:43
  at /Users/kevin/github/atom/node_modules/emissary/lib/emitter.js:134:30
  at Array.forEach (native)
  at Editor.module.exports.Emitter.emit (/Users/kevin/github/atom/node_modules/emissary/lib/emitter.js:133:47)
  at Editor.module.exports.Model.destroy (/Users/kevin/github/atom/node_modules/theorist/lib/model.js:226:19)
  at EditorView.module.exports.EditorView.beforeRemove (/Users/kevin/github/atom/src/editor-view.coffee:763:14)
  at jQuery.cleanData (/Users/kevin/github/atom/node_modules/space-pen/lib/space-pen.js:375:16)
  at Function.jQuery.cleanData (/Users/kevin/github/atom/src/space-pen-extensions.coffee:11:3)
  at EditorView.jQuery.fn.extend.remove (/Users/kevin/github/atom/node_modules/space-pen/vendor/jquery.js:5494:12)
  at EditorView.module.exports.EditorView.remove (/Users/kevin/github/atom/src/editor-view.coffee:757:5)
  at WorkspaceView.module.exports.WorkspaceView.remove (/Users/kevin/github/atom/src/workspace-view.coffee:296:16)
  at Atom.module.exports.Atom.unloadEditorWindow (/Users/kevin/github/atom/src/atom.coffee:289:20)
  at /Users/kevin/github/atom/src/atom.coffee:274:10
  at jQuery.event.dispatch (/Users/kevin/github/atom/node_modules/space-pen/vendor/jquery.js:4676:9)
  at elemData.handle (/Users/kevin/github/atom/node_modules/space-pen/vendor/jquery.js:4360:28)
```
