### PR TITLE
Remove npm warnings

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -10,7 +10,7 @@
     "biscotto": "0.6.0",
     "first-mate": "1.x",
     "formidable": "~1.0.14",
-    "fs-plus": "1.x",
+    "fs-plus": "2.x",
     "github-releases": "~0.2.0",
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.9",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "delegato": "1.x",
     "emissary": "1.x",
     "first-mate": ">=1.1.4 <2.0",
-    "fs-plus": "1.x",
+    "fs-plus": "2.x",
     "fstream": "0.1.24",
     "fuzzaldrin": "1.x",
     "git-utils": "1.x",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "image-view": "0.24.0",
     "keybinding-resolver": "0.10.0",
     "link": "0.17.0",
-    "markdown-preview": "0.29.0",
+    "markdown-preview": "0.30.0",
     "metrics": "0.26.0",
     "package-generator": "0.26.0",
     "release-notes": "0.20.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "spell-check": "0.25.0",
     "status-bar": "0.32.0",
     "styleguide": "0.24.0",
-    "symbols-view": "0.34.0",
+    "symbols-view": "0.35.0",
     "tabs": "0.19.0",
     "terminal": "0.27.0",
     "timecop": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "package-generator": "0.26.0",
     "release-notes": "0.20.0",
     "settings-view": "0.73.0",
-    "snippets": "0.27.0",
+    "snippets": "0.28.0",
     "spell-check": "0.25.0",
     "status-bar": "0.32.0",
     "styleguide": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "metrics": "0.26.0",
     "package-generator": "0.26.0",
     "release-notes": "0.20.0",
-    "settings-view": "0.73.0",
+    "settings-view": "0.74.0",
     "snippets": "0.29.0",
     "spell-check": "0.25.0",
     "status-bar": "0.32.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "coffeestack": "0.7.0",
     "delegato": "1.x",
     "emissary": "1.x",
-    "first-mate": ">=1.1.4 <2.0",
+    "first-mate": ">=1.1.5 <2.0",
     "fs-plus": "2.x",
     "fstream": "0.1.24",
     "fuzzaldrin": "1.x",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "keytar": "0.15.1",
     "less-cache": "0.11.0",
     "mixto": "1.x",
-    "nslog": "0.4.0",
+    "nslog": "0.5.0",
     "oniguruma": "1.x",
     "optimist": "0.4.0",
     "pathwatcher": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "package-generator": "0.26.0",
     "release-notes": "0.20.0",
     "settings-view": "0.73.0",
-    "snippets": "0.28.0",
+    "snippets": "0.29.0",
     "spell-check": "0.25.0",
     "status-bar": "0.32.0",
     "styleguide": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jasmine-tagged": "1.x",
     "mkdirp": "0.3.5",
     "keytar": "0.15.1",
-    "less-cache": "0.11.0",
+    "less-cache": "0.12.0",
     "mixto": "1.x",
     "nslog": "0.5.0",
     "oniguruma": "1.x",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "github-sign-in": "0.19.0",
     "go-to-line": "0.16.0",
     "grammar-selector": "0.20.0",
-    "image-view": "0.23.0",
+    "image-view": "0.24.0",
     "keybinding-resolver": "0.10.0",
     "link": "0.17.0",
     "markdown-preview": "0.29.0",

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -31,7 +31,7 @@ if (!fs.existsSync(path.join(apmInstallPath, 'node_modules')))
   fs.mkdirSync(path.join(apmInstallPath, 'node_modules'));
 
 var apmFlags = process.env.JANKY_SHA1 || process.argv.indexOf('--no-color') !== -1 ? '--no-color' : '';
-var packagesToDedupe = ['fs-plus', 'humanize-plus', 'nan', 'oniguruma', 'roaster', 'season'];
+var packagesToDedupe = ['fs-plus', 'humanize-plus', 'oniguruma', 'roaster', 'season'];
 var echoNewLine = process.platform == 'win32' ? 'echo.' : 'echo';
 var commands = [
   'git submodule --quiet sync',

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -41,7 +41,7 @@ specProjectPath = null
 if specDirectory
   specPackagePath = path.resolve(specDirectory, '..')
   try
-    specPackageName = fs.readObjectSync(path.join(specPackagePath, 'package.json'))?.name
+    specPackageName = JSON.parse(fs.readFileSync(path.join(specPackagePath, 'package.json')))?.name
   specProjectPath = path.join(specDirectory, 'fixtures')
 
 beforeEach ->

--- a/src/scoped-properties.coffee
+++ b/src/scoped-properties.coffee
@@ -1,9 +1,9 @@
-fs = require 'fs-plus'
+CSON = require 'season'
 
 module.exports =
 class ScopedProperties
   @load: (scopedPropertiesPath, callback) ->
-    fs.readObject scopedPropertiesPath, (error, scopedProperties={}) ->
+    CSON.readFile scopedPropertiesPath, (error, scopedProperties={}) ->
       if error?
         callback(error)
       else


### PR DESCRIPTION
Stop these from happening in the CI output:

```
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/vendor/apm/node_modules/npm/node_modules/npm-registry-client requires semver@'^2.2.1' but will load
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/vendor/apm/node_modules/npm/node_modules/semver,
npm WARN unmet dependency which is version 2.2.1
npm WARN package.json github-url-from-git@1.1.1 No repository field.
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/apm/node_modules/atom-package-manager/node_modules/npm/node_modules/npm-registry-client requires semver@'^2.2.1' but will load
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/apm/node_modules/atom-package-manager/node_modules/npm/node_modules/semver,
npm WARN unmet dependency which is version 2.2.1
npm WARN package.json nslog@0.4.0 No description
npm WARN package.json github-url-from-git@1.1.1 No repository field.
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/fs-plus requires season@'~0.14.0' but will load
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/season,
npm WARN unmet dependency which is version 1.0.0
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/oniguruma requires nan@'0.7.0' but will load
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/nan,
npm WARN unmet dependency which is version 0.8.0
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/snippets requires season@'~0.13.0' but will load
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/season,
npm WARN unmet dependency which is version 1.0.0
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/spell-check/node_modules/spellchecker requires nan@'0.7.0' but will load
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/nan,
npm WARN unmet dependency which is version 0.8.0
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/terminal/node_modules/pty.js requires nan@'0.7.0' but will load
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/nan,
npm WARN unmet dependency which is version 0.8.0
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/symbols-view/node_modules/ctags requires nan@'0.7.0' but will load
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/nan,
npm WARN unmet dependency which is version 0.8.0
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/atom-package-manager/node_modules/npm/node_modules/npm-registry-client requires semver@'^2.2.1' but will load
npm WARN unmet dependency /private/var/lib/jenkins/workspace/atom-615ee4b3dc03/node_modules/atom-package-manager/node_modules/npm/node_modules/semver,
npm WARN unmet dependency which is version 2.2.1
```
