### PR TITLE
Rename workspace view pane methods

### DIFF
--- a/spec/pane-container-view-spec.coffee
+++ b/spec/pane-container-view-spec.coffee
@@ -240,30 +240,30 @@ describe "PaneContainerView", ->
         pane2.remove()
         expect(activeItemChangedHandler).not.toHaveBeenCalled()
 
-  describe ".focusNextPane()", ->
+  describe ".focusNextPaneView()", ->
     it "focuses the pane following the focused pane or the first pane if no pane has focus", ->
       container.attachToDom()
-      container.focusNextPane()
+      container.focusNextPaneView()
       expect(pane1.activeItem).toMatchSelector ':focus'
-      container.focusNextPane()
+      container.focusNextPaneView()
       expect(pane2.activeItem).toMatchSelector ':focus'
-      container.focusNextPane()
+      container.focusNextPaneView()
       expect(pane3.activeItem).toMatchSelector ':focus'
-      container.focusNextPane()
+      container.focusNextPaneView()
       expect(pane1.activeItem).toMatchSelector ':focus'
 
-  describe ".focusPreviousPane()", ->
+  describe ".focusPreviousPaneView()", ->
     it "focuses the pane preceding the focused pane or the last pane if no pane has focus", ->
       container.attachToDom()
       container.getPaneViews()[0].focus() # activate first pane
 
-      container.focusPreviousPane()
+      container.focusPreviousPaneView()
       expect(pane3.activeItem).toMatchSelector ':focus'
-      container.focusPreviousPane()
+      container.focusPreviousPaneView()
       expect(pane2.activeItem).toMatchSelector ':focus'
-      container.focusPreviousPane()
+      container.focusPreviousPaneView()
       expect(pane1.activeItem).toMatchSelector ':focus'
-      container.focusPreviousPane()
+      container.focusPreviousPaneView()
       expect(pane3.activeItem).toMatchSelector ':focus'
 
   describe "changing focus directionally between panes", ->
@@ -300,54 +300,54 @@ describe "PaneContainerView", ->
       container.width(400)
       container.attachToDom()
 
-    describe ".focusPaneAbove()", ->
+    describe ".focusPaneViewAbove()", ->
       describe "when there are multiple rows above the focused pane", ->
         it "focuses up to the adjacent row", ->
           pane8.focus()
-          container.focusPaneAbove()
+          container.focusPaneViewAbove()
           expect(pane5.activeItem).toMatchSelector ':focus'
 
       describe "when there are no rows above the focused pane", ->
         it "keeps the current pane focused", ->
           pane2.focus()
-          container.focusPaneAbove()
+          container.focusPaneViewAbove()
           expect(pane2.activeItem).toMatchSelector ':focus'
 
-    describe ".focusPaneBelow()", ->
+    describe ".focusPaneViewBelow()", ->
       describe "when there are multiple rows below the focused pane", ->
         it "focuses down to the adjacent row", ->
           pane2.focus()
-          container.focusPaneBelow()
+          container.focusPaneViewBelow()
           expect(pane5.activeItem).toMatchSelector ':focus'
 
       describe "when there are no rows below the focused pane", ->
         it "keeps the current pane focused", ->
           pane8.focus()
-          container.focusPaneBelow()
+          container.focusPaneViewBelow()
           expect(pane8.activeItem).toMatchSelector ':focus'
 
-    describe ".focusPaneOnLeft()", ->
+    describe ".focusPaneViewOnLeft()", ->
       describe "when there are multiple columns to the left of the focused pane", ->
         it "focuses left to the adjacent column", ->
           pane6.focus()
-          container.focusPaneOnLeft()
+          container.focusPaneViewOnLeft()
           expect(pane5.activeItem).toMatchSelector ':focus'
 
       describe "when there are no columns to the left of the focused pane", ->
         it "keeps the current pane focused", ->
           pane4.focus()
-          container.focusPaneOnLeft()
+          container.focusPaneViewOnLeft()
           expect(pane4.activeItem).toMatchSelector ':focus'
 
-    describe ".focusPaneOnRight()", ->
+    describe ".focusPaneViewOnRight()", ->
       describe "when there are multiple columns to the right of the focused pane", ->
         it "focuses right to the adjacent column", ->
           pane4.focus()
-          container.focusPaneOnRight()
+          container.focusPaneViewOnRight()
           expect(pane5.activeItem).toMatchSelector ':focus'
 
       describe "when there are no columns to the right of the focused pane", ->
         it "keeps the current pane focused", ->
           pane6.focus()
-          container.focusPaneOnRight()
+          container.focusPaneViewOnRight()
           expect(pane6.activeItem).toMatchSelector ':focus'

--- a/spec/pane-container-view-spec.coffee
+++ b/spec/pane-container-view-spec.coffee
@@ -45,10 +45,10 @@ describe "PaneContainerView", ->
       expect(container.getFocusedPane()).toBe pane3
       expect(container.getActivePane()).toBe pane3
 
-  describe ".eachPane(callback)", ->
+  describe ".eachPaneView(callback)", ->
     it "runs the callback with all current and future panes until the subscription is cancelled", ->
       panes = []
-      subscription = container.eachPane (pane) -> panes.push(pane)
+      subscription = container.eachPaneView (pane) -> panes.push(pane)
       expect(panes).toEqual [pane1, pane2, pane3]
 
       panes = []

--- a/spec/pane-container-view-spec.coffee
+++ b/spec/pane-container-view-spec.coffee
@@ -66,7 +66,7 @@ describe "PaneContainerView", ->
 
       container.saveAll()
 
-      for pane in container.getPanes()
+      for pane in container.getPaneViews()
         for item in pane.getItems()
           expect(item.saved).toBeTruthy()
 
@@ -255,7 +255,7 @@ describe "PaneContainerView", ->
   describe ".focusPreviousPane()", ->
     it "focuses the pane preceding the focused pane or the last pane if no pane has focus", ->
       container.attachToDom()
-      container.getPanes()[0].focus() # activate first pane
+      container.getPaneViews()[0].focus() # activate first pane
 
       container.focusPreviousPane()
       expect(pane3.activeItem).toMatchSelector ':focus'

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -36,12 +36,12 @@ describe "WorkspaceView", ->
         editorView1 = atom.workspaceView.getActiveView()
         buffer = editorView1.getEditor().getBuffer()
         editorView1.splitRight()
-        expect(atom.workspaceView.getActivePane()).toBe atom.workspaceView.getPanes()[1]
+        expect(atom.workspaceView.getActivePane()).toBe atom.workspaceView.getPaneViews()[1]
 
         simulateReload()
 
         expect(atom.workspaceView.getEditorViews().length).toBe 2
-        expect(atom.workspaceView.getActivePane()).toBe atom.workspaceView.getPanes()[1]
+        expect(atom.workspaceView.getActivePane()).toBe atom.workspaceView.getPaneViews()[1]
         expect(atom.workspaceView.title).toBe "untitled - #{atom.project.getPath()}"
 
     describe "when there are open editors", ->

--- a/src/pane-container-view.coffee
+++ b/src/pane-container-view.coffee
@@ -91,22 +91,22 @@ class PaneContainerView extends View
   paneForUri: (uri) ->
     @viewForModel(@model.paneForUri(uri))
 
-  focusNextPane: ->
+  focusNextPaneView: ->
     @model.activateNextPane()
 
-  focusPreviousPane: ->
+  focusPreviousPaneView: ->
     @model.activatePreviousPane()
 
-  focusPaneAbove: ->
+  focusPaneViewAbove: ->
     @nearestPaneInDirection('above')?.focus()
 
-  focusPaneBelow: ->
+  focusPaneViewBelow: ->
     @nearestPaneInDirection('below')?.focus()
 
-  focusPaneOnLeft: ->
+  focusPaneViewOnLeft: ->
     @nearestPaneInDirection('left')?.focus()
 
-  focusPaneOnRight: ->
+  focusPaneViewOnRight: ->
     @nearestPaneInDirection('right')?.focus()
 
   nearestPaneInDirection: (direction) ->

--- a/src/pane-container-view.coffee
+++ b/src/pane-container-view.coffee
@@ -54,24 +54,24 @@ class PaneContainerView extends View
 
   confirmClose: ->
     saved = true
-    for pane in @getPanes()
+    for pane in @getPaneViews()
       for item in pane.getItems()
         if not pane.promptToSaveItem(item)
           saved = false
           break
     saved
 
-  getPanes: ->
+  getPaneViews: ->
     @find('.pane').views()
 
   indexOfPane: (pane) ->
-    @getPanes().indexOf(pane.view())
+    @getPaneViews().indexOf(pane.view())
 
   paneAtIndex: (index) ->
-    @getPanes()[index]
+    @getPaneViews()[index]
 
   eachPaneView: (callback) ->
-    callback(pane) for pane in @getPanes()
+    callback(pane) for pane in @getPaneViews()
     paneAttached = (e) -> callback($(e.target).view())
     @on 'pane:attached', paneAttached
     off: => @off 'pane:attached', paneAttached
@@ -117,7 +117,7 @@ class PaneContainerView extends View
 
     pane = @getActivePane()
     box = @boundingBoxForPane(pane)
-    panes = @getPanes()
+    panes = @getPaneViews()
       .filter (otherPane) =>
         otherBox = @boundingBoxForPane(otherPane)
         switch direction
@@ -143,3 +143,6 @@ class PaneContainerView extends View
     right: {x: boundingBox.right, y: boundingBox.top}
     top: {x: boundingBox.left, y: boundingBox.top}
     bottom: {x: boundingBox.left, y: boundingBox.bottom}
+
+  getPanes: ->
+    @getPaneViews()

--- a/src/pane-container-view.coffee
+++ b/src/pane-container-view.coffee
@@ -70,7 +70,7 @@ class PaneContainerView extends View
   paneAtIndex: (index) ->
     @getPanes()[index]
 
-  eachPane: (callback) ->
+  eachPaneView: (callback) ->
     callback(pane) for pane in @getPanes()
     paneAttached = (e) -> callback($(e.target).view())
     @on 'pane:attached', paneAttached

--- a/src/pane-container-view.coffee
+++ b/src/pane-container-view.coffee
@@ -144,5 +144,6 @@ class PaneContainerView extends View
     top: {x: boundingBox.left, y: boundingBox.top}
     bottom: {x: boundingBox.left, y: boundingBox.bottom}
 
+  # Deprecated
   getPanes: ->
     @getPaneViews()

--- a/src/pane-view.coffee
+++ b/src/pane-view.coffee
@@ -117,7 +117,7 @@ class PaneView extends View
 
   # Public: Returns the next pane, ordered by creation.
   getNextPane: ->
-    panes = @container?.getPanes()
+    panes = @container?.getPaneViews()
     return unless panes.length > 1
     nextIndex = (panes.indexOf(this) + 1) % panes.length
     panes[nextIndex]

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -272,8 +272,8 @@ class WorkspaceView extends View
   eachPaneView: (callback) ->
     @panes.eachPaneView(callback)
 
-  # Public: Returns an Array of all open {PaneView}s.
-  getPanes: ->
+  # Returns an Array of all open {PaneView}s.
+  getPaneViews: ->
     @panes.getPanes()
 
   # Public: Return the id of the given a {PaneView}
@@ -294,3 +294,7 @@ class WorkspaceView extends View
   # Deprecated:
   eachPane: (callback) ->
     @eachPaneView(callback)
+
+  # Deprecated:
+  getPanes: ->
+    @getPaneViews()

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -267,10 +267,6 @@ class WorkspaceView extends View
   getPaneViews: ->
     @panes.getPanes()
 
-  # Public: Return the id of the given a {PaneView}
-  indexOfPane: (pane) ->
-    @panes.indexOfPane(pane)
-
   # Public: Fires a callback on each open {EditorView}.
   eachEditorView: (callback) ->
     callback(editor) for editor in @getEditorViews()

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -269,8 +269,8 @@ class WorkspaceView extends View
   getFocusedPane: -> @panes.getFocusedPane()
 
   # Public: Fires a callback on each open {PaneView}.
-  eachPane: (callback) ->
-    @panes.eachPane(callback)
+  eachPaneView: (callback) ->
+    @panes.eachPaneView(callback)
 
   # Public: Returns an Array of all open {PaneView}s.
   getPanes: ->
@@ -290,3 +290,7 @@ class WorkspaceView extends View
   # Called by SpacePen
   beforeRemove: ->
     @model.destroy()
+
+  # Deprecated:
+  eachPane: (callback) ->
+    @eachPaneView(callback)

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -233,10 +233,6 @@ class WorkspaceView extends View
   getActivePaneView: ->
     @panes.getActivePane()
 
-  # Deprecated: Returns the currently focused {PaneView}.
-  getActivePane: ->
-    @getActivePaneView()
-
   # Public: Returns the currently focused item from within the focused {PaneView}
   getActivePaneItem: ->
     @model.activePaneItem
@@ -291,10 +287,14 @@ class WorkspaceView extends View
   beforeRemove: ->
     @model.destroy()
 
-  # Deprecated:
+  # Deprecated
   eachPane: (callback) ->
     @eachPaneView(callback)
 
-  # Deprecated:
+  # Deprecated
   getPanes: ->
     @getPaneViews()
+
+  # Deprecated
+  getActivePane: ->
+    @getActivePaneView()

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -119,12 +119,12 @@ class WorkspaceView extends View
     @command 'window:decrease-font-size', => @decreaseFontSize()
     @command 'window:reset-font-size', => @model.resetFontSize()
 
-    @command 'window:focus-next-pane', => @focusNextPane()
-    @command 'window:focus-previous-pane', => @focusPreviousPane()
-    @command 'window:focus-pane-above', => @focusPaneAbove()
-    @command 'window:focus-pane-below', => @focusPaneBelow()
-    @command 'window:focus-pane-on-left', => @focusPaneOnLeft()
-    @command 'window:focus-pane-on-right', => @focusPaneOnRight()
+    @command 'window:focus-next-pane', => @focusNextPaneView()
+    @command 'window:focus-previous-pane', => @focusPreviousPaneView()
+    @command 'window:focus-pane-above', => @focusPaneViewAbove()
+    @command 'window:focus-pane-below', => @focusPaneViewBelow()
+    @command 'window:focus-pane-on-left', => @focusPaneViewOnLeft()
+    @command 'window:focus-pane-on-right', => @focusPaneViewOnRight()
     @command 'window:save-all', => @saveAll()
     @command 'window:toggle-invisibles', =>
       atom.config.toggle("editor.showInvisibles")
@@ -246,22 +246,22 @@ class WorkspaceView extends View
     @panes.getActiveView()
 
   # Public: Focuses the previous pane by id.
-  focusPreviousPane: -> @model.activatePreviousPane()
+  focusPreviousPaneView: -> @model.activatePreviousPane()
 
   # Public: Focuses the next pane by id.
-  focusNextPane: -> @model.activateNextPane()
+  focusNextPaneView: -> @model.activateNextPane()
 
   # Public: Focuses the pane directly above the active pane.
-  focusPaneAbove: -> @panes.focusPaneAbove()
+  focusPaneViewAbove: -> @panes.focusPaneViewAbove()
 
   # Public: Focuses the pane directly below the active pane.
-  focusPaneBelow: -> @panes.focusPaneBelow()
+  focusPaneViewBelow: -> @panes.focusPaneViewBelow()
 
   # Public: Focuses the pane directly to the left of the active pane.
-  focusPaneOnLeft: -> @panes.focusPaneOnLeft()
+  focusPaneViewOnLeft: -> @panes.focusPaneViewOnLeft()
 
   # Public: Focuses the pane directly to the right of the active pane.
-  focusPaneOnRight: -> @panes.focusPaneOnRight()
+  focusPaneViewOnRight: -> @panes.focusPaneViewOnRight()
 
   # Public:
   #

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -259,11 +259,6 @@ class WorkspaceView extends View
   # Public: Focuses the pane directly to the right of the active pane.
   focusPaneViewOnRight: -> @panes.focusPaneViewOnRight()
 
-  # Public:
-  #
-  # FIXME: Difference between active and focused pane?
-  getFocusedPane: -> @panes.getFocusedPane()
-
   # Public: Fires a callback on each open {PaneView}.
   eachPaneView: (callback) ->
     @panes.eachPaneView(callback)


### PR DESCRIPTION
This renames methods on WorkspaceView that return PaneViews. Previously it appeared like the methods returned Pane objects. Now the methods are named so it is clear that they return PaneViews.
