### PR TITLE
Remove File/Directory exports

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,9 +23,7 @@ You can also require many of these classes in your package via:
 The classes available from `require 'atom'` are:
   * [BufferedProcess][BufferedProcess]
   * [BufferedNodeProcess][BufferedNodeProcess]
-  * [Directory][Directory]
   * [EditorView][EditorView]
-  * [File][File]
   * [Git][Git]
   * [Point][Point]
   * [Range][Range]
@@ -47,10 +45,8 @@ Atom ships with node 0.11.10 and the comprehensive node API docs are available
 [Atom]: ../classes/Atom.html
 [BufferedProcess]: ../classes/BufferedProcess.html
 [BufferedNodeProcess]: ../classes/BufferedNodeProcess.html
-[Directory]: ../classes/Directory.html
 [Editor]: ../classes/Editor.html
 [EditorView]: ../classes/EditorView.html
-[File]: ../classes/File.html
 [Git]: ../classes/Git.html
 [Point]: ../classes/Point.html
 [Range]: ../classes/Range.html

--- a/exports/atom.coffee
+++ b/exports/atom.coffee
@@ -1,12 +1,9 @@
 {Point, Range} = require 'text-buffer'
-{File, Directory} = require 'pathwatcher'
 
 module.exports =
   _: require 'underscore-plus'
   BufferedNodeProcess: require '../src/buffered-node-process'
   BufferedProcess: require '../src/buffered-process'
-  Directory: Directory
-  File: File
   fs: require 'fs-plus'
   Git: require '../src/git'
   Point: Point

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "package-generator": "0.26.0",
     "release-notes": "0.20.0",
     "settings-view": "0.74.0",
-    "snippets": "0.29.0",
+    "snippets": "0.30.0",
     "spell-check": "0.25.0",
     "status-bar": "0.32.0",
     "styleguide": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "bracket-matcher": "0.20.0",
     "command-logger": "0.11.0",
     "command-palette": "0.17.0",
-    "dev-live-reload": "0.24.0",
+    "dev-live-reload": "0.25.0",
     "editor-stats": "0.13.0",
     "exception-reporting": "0.13.0",
     "feedback": "0.23.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "base16-tomorrow-dark-theme": "0.11.0",
     "solarized-dark-syntax": "0.9.0",
     "solarized-light-syntax": "0.5.0",
-    "archive-view": "0.22.0",
+    "archive-view": "0.23.0",
     "autocomplete": "0.23.0",
     "autoflow": "0.14.0",
     "autosave": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "image-view": "0.24.0",
     "keybinding-resolver": "0.10.0",
     "link": "0.17.0",
-    "markdown-preview": "0.31.0",
+    "markdown-preview": "0.32.0",
     "metrics": "0.26.0",
     "open-on-github": "0.20.0",
     "package-generator": "0.26.0",

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -4,7 +4,7 @@ atom.restoreWindowDimensions()
 
 require '../vendor/jasmine-jquery'
 path = require 'path'
-{_, $, File, WorkspaceView, fs} = require 'atom'
+{_, $, WorkspaceView, fs} = require 'atom'
 Keymap = require '../src/keymap'
 Config = require '../src/config'
 {Point} = require 'text-buffer'
@@ -88,7 +88,7 @@ beforeEach ->
   spyOn(WorkspaceView.prototype, 'setTitle').andCallFake (@title) ->
   spyOn(window, "setTimeout").andCallFake window.fakeSetTimeout
   spyOn(window, "clearTimeout").andCallFake window.fakeClearTimeout
-  spyOn(File.prototype, "detectResurrectionAfterDelay").andCallFake -> @detectResurrection()
+  spyOn(pathwatcher.File.prototype, "detectResurrectionAfterDelay").andCallFake -> @detectResurrection()
   spyOn(Editor.prototype, "shouldPromptToSave").andReturn false
 
   # make tokenization synchronous


### PR DESCRIPTION
Packages now directly depend on `pathwatcher` to obtain `File` and `Directory` classes.

Follow on to #1553 
