### PR TITLE
Prefer 'organization' over 'org'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ to propose changes to this document in a pull request.
 
 This is the repository for the core Atom editor only. Atom comes bundled with
 many packages and themes that are stored in other repos under the
-[atom org](https://github.com/atom) such as [tabs](https://github.com/atom/tabs),
+[atom organization](https://github.com/atom) such as [tabs](https://github.com/atom/tabs),
 [find-and-replace](https://github.com/atom/find-and-replace),
 [language-javascript](https://github.com/atom/language-javascript),
 and [atom-light-ui](http://github.com/atom/atom-light-ui).


### PR DESCRIPTION
Per the Style Guide @ https://github.com/styleguide/words.

<img src="http://themavesite.com/TMS-Pictures/Epic/Memes/Monocle.png" height="150">
