### PR TITLE
Improve generated editor docs

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -133,7 +133,7 @@
   'ctrl-cmd-up': 'editor:move-line-up'
   'ctrl-cmd-down': 'editor:move-line-down'
   'cmd-/': 'editor:toggle-line-comments'
-  'cmd-j': 'editor:join-line'
+  'cmd-j': 'editor:join-lines'
   'cmd-D': 'editor:duplicate-line'
   'cmd-L': 'editor:split-selections-into-lines'
 

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -80,7 +80,7 @@
   'ctrl-up': 'editor:move-line-up'
   'ctrl-down': 'editor:move-line-down'
   'ctrl-/': 'editor:toggle-line-comments'
-  'ctrl-j': 'editor:join-line'
+  'ctrl-j': 'editor:join-lines'
   'ctrl-D': 'editor:duplicate-line'
 
   'ctrl-alt-[': 'editor:fold-current-row'

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -66,7 +66,7 @@
           { label: 'Move Line Down', command: 'editor:move-line-down' }
           { label: 'Duplicate Line', command: 'editor:duplicate-line' }
           { label: 'Delete Line', command: 'editor:delete-line' }
-          { label: 'Join Lines', command: 'editor:join-line' }
+          { label: 'Join Lines', command: 'editor:join-lines' }
         ]
       }
       {

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -45,7 +45,7 @@
           { label: 'Move Line &Down', command: 'editor:move-line-down' }
           { label: 'Du&plicate Line', command: 'editor:duplicate-line' }
           { label: 'D&elete Line', command: 'editor:delete-line' }
-          { label: '&Join Lines', command: 'editor:join-line' }
+          { label: '&Join Lines', command: 'editor:join-lines' }
         ]
       }
       {

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -37,7 +37,7 @@ describe "DisplayBuffer", ->
       expect(displayBuffer2.isFoldedAtBufferRow(3)).toBeTruthy()
 
       # can diverge from origin
-      displayBuffer2.destroyFoldsContainingBufferRow(3)
+      displayBuffer2.unfoldBufferRow(3)
       expect(displayBuffer2.isFoldedAtBufferRow(3)).not.toBe displayBuffer.isFoldedAtBufferRow(3)
 
   describe "when the buffer changes", ->
@@ -495,7 +495,7 @@ describe "DisplayBuffer", ->
         expect(displayBuffer.bufferPositionForScreenPosition([5, 0])).toEqual [5, 0]
         expect(displayBuffer.bufferPositionForScreenPosition([9, 2])).toEqual [9, 2]
 
-    describe ".destroyFoldsContainingBufferRow(row)", ->
+    describe ".unfoldBufferRow(row)", ->
       it "destroys all folds containing the given row", ->
         displayBuffer.createFold(2, 4)
         displayBuffer.createFold(2, 6)
@@ -506,7 +506,7 @@ describe "DisplayBuffer", ->
         expect(displayBuffer.lineForRow(1).text).toBe '1'
         expect(displayBuffer.lineForRow(2).text).toBe '10'
 
-        displayBuffer.destroyFoldsContainingBufferRow(2)
+        displayBuffer.unfoldBufferRow(2)
         expect(displayBuffer.lineForRow(1).text).toBe '1'
         expect(displayBuffer.lineForRow(2).text).toBe '2'
         expect(displayBuffer.lineForRow(7).fold).toBeDefined()
@@ -684,7 +684,7 @@ describe "DisplayBuffer", ->
         }
         markerChangedHandler.reset()
 
-        displayBuffer.destroyFoldsContainingBufferRow(4)
+        displayBuffer.unfoldBufferRow(4)
         expect(markerChangedHandler).toHaveBeenCalled()
         expect(markerChangedHandler.argsForCall[0][0]).toEqual {
           oldHeadScreenPosition: [8, 23]
@@ -867,7 +867,7 @@ describe "DisplayBuffer", ->
           expect(marker.getHeadScreenPosition()).toEqual [8, 10]
           expect(marker.getTailScreenPosition()).toEqual [8, 4]
 
-        displayBuffer.destroyFoldsContainingBufferRow(4)
+        displayBuffer.unfoldBufferRow(4)
 
         expect(changeHandler).toHaveBeenCalled()
         expect(markerChangedHandler).toHaveBeenCalled()

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2635,18 +2635,18 @@ describe "Editor", ->
         editor.destroy()
         expect(buffer.getMarkerCount()).toBe 0
 
-    describe ".joinLine()", ->
+    describe ".joinLines()", ->
       describe "when no text is selected", ->
         describe "when the line below isn't empty", ->
           it "joins the line below with the current line separated by a space and moves the cursor to the start of line that was moved up", ->
-            editor.joinLine()
+            editor.joinLines()
             expect(editor.lineForBufferRow(0)).toBe 'var quicksort = function () { var sort = function(items) {'
             expect(editor.getCursorBufferPosition()).toEqual [0, 30]
 
         describe "when the line below is empty", ->
           it "deletes the line below and moves the cursor to the end of the line", ->
             editor.setCursorBufferPosition([9])
-            editor.joinLine()
+            editor.joinLines()
             expect(editor.lineForBufferRow(9)).toBe '  };'
             expect(editor.lineForBufferRow(10)).toBe '  return sort(Array.apply(this, arguments));'
             expect(editor.getCursorBufferPosition()).toEqual [9, 4]
@@ -2654,21 +2654,21 @@ describe "Editor", ->
         describe "when the cursor is on the last row", ->
           it "does nothing", ->
             editor.setCursorBufferPosition([Infinity, Infinity])
-            editor.joinLine()
+            editor.joinLines()
             expect(editor.lineForBufferRow(12)).toBe '};'
 
       describe "when text is selected", ->
         describe "when the selection does not span multiple lines", ->
           it "joins the line below with the current line separated by a space and retains the selected text", ->
             editor.setSelectedBufferRange([[0, 1], [0, 3]])
-            editor.joinLine()
+            editor.joinLines()
             expect(editor.lineForBufferRow(0)).toBe 'var quicksort = function () { var sort = function(items) {'
             expect(editor.getSelectedBufferRange()).toEqual [[0, 1], [0, 3]]
 
         describe "when the selection spans multiple lines", ->
           it "joins all selected lines separated by a space and retains the selected text", ->
             editor.setSelectedBufferRange([[9, 3], [12, 1]])
-            editor.joinLine()
+            editor.joinLines()
             expect(editor.lineForBufferRow(9)).toBe '  }; return sort(Array.apply(this, arguments)); };'
             expect(editor.getSelectedBufferRange()).toEqual [[9, 3], [9, 49]]
 

--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -285,21 +285,6 @@ describe "LanguageMode", ->
           expect(fold.getStartRow()).toBe 0
           expect(fold.getEndRow()).toBe 13
 
-    describe ".unfoldBufferRow(bufferRow)", ->
-      describe "when bufferRow can be unfolded", ->
-        it "destroys a fold based on the syntactic region starting at the given row", ->
-          languageMode.foldBufferRow(1)
-          expect(editor.lineForScreenRow(1).fold).toBeDefined()
-
-          languageMode.unfoldBufferRow(1)
-          expect(editor.lineForScreenRow(1).fold).toBeUndefined()
-
-      describe "when bufferRow can't be unfolded", ->
-        it "does not throw an error", ->
-          expect(editor.lineForScreenRow(1).fold).toBeUndefined()
-          languageMode.unfoldBufferRow(1)
-          expect(editor.lineForScreenRow(1).fold).toBeUndefined()
-
     describe ".isFoldableAtBufferRow(bufferRow)", ->
       it "returns true if the line starts a foldable row range", ->
         expect(languageMode.isFoldableAtBufferRow(0)).toBe true

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -169,7 +169,7 @@ class DisplayBuffer extends Model
   # Removes any folds found that contain the given buffer row.
   #
   # bufferRow - The buffer row {Number} to check against
-  destroyFoldsContainingBufferRow: (bufferRow) ->
+  unfoldBufferRow: (bufferRow) ->
     fold.destroy() for fold in @foldsContainingBufferRow(bufferRow)
 
   # Given a buffer row, this returns the largest fold that starts there.

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -210,7 +210,7 @@ class EditorView extends View
         'editor:move-line-up': => @editor.moveLineUp()
         'editor:move-line-down': => @editor.moveLineDown()
         'editor:duplicate-line': => @editor.duplicateLine()
-        'editor:join-line': => @editor.joinLine()
+        'editor:join-lines': => @editor.joinLines()
         'editor:toggle-indent-guide': => atom.config.toggle('editor.showIndentGuide')
         'editor:toggle-line-numbers': =>  atom.config.toggle('editor.showLineNumbers')
         'editor:scroll-to-cursor': => @scrollToCursorPosition()

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -193,7 +193,7 @@ class EditorView extends View
         'editor:unfold-all': => @editor.unfoldAll()
         'editor:fold-current-row': => @editor.foldCurrentRow()
         'editor:unfold-current-row': => @editor.unfoldCurrentRow()
-        'editor:fold-selection': => @editor.foldSelection()
+        'editor:fold-selection': => @editor.foldSelectedLines()
         'editor:fold-at-indent-level-1': => @editor.foldAllAtIndentLevel(0)
         'editor:fold-at-indent-level-2': => @editor.foldAllAtIndentLevel(1)
         'editor:fold-at-indent-level-3': => @editor.foldAllAtIndentLevel(2)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -759,10 +759,8 @@ class Editor extends Model
     bufferRow = @bufferPositionForScreenPosition(@getCursorScreenPosition()).row
     @unfoldBufferRow(bufferRow)
 
-  # For each selection, fold all rows it intersects.
-  #
-  # TODO: Rename to foldSelectedLines?
-  foldSelection: ->
+  # Public: For each selection, fold the rows it intersects.
+  foldSelectedLines: ->
     selection.fold() for selection in @getSelections()
 
   # Public: Fold all foldable lines.

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -27,7 +27,6 @@ TextMateScopeSelector = require('first-mate').ScopeSelector
 # be called with all current editor instances and also when any editor is
 # created in the future.
 #
-# ## Example
 # ```coffeescript
 #   atom.workspace.eachEditor (editor) ->
 #     editor.insertText('Hello World')

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1130,7 +1130,7 @@ class Editor extends Model
 
   # Public: Get current {Selection}s.
   #
-  # Returns: An {Array} of {Seletions}s.
+  # Returns: An {Array} of {Selection}s.
   getSelections: -> new Array(@selections...)
 
   # Public: Get the most recent {Selection} or the selection at the given
@@ -1151,7 +1151,7 @@ class Editor extends Model
   getLastSelection: ->
     _.last(@selections)
 
-  # Public: Gets all {Selections}, ordered by their position in the buffer
+  # Public: Get all {Selection}s, ordered by their position in the buffer
   # instead of the order in which they were added.
   #
   # Returns an {Array} of {Selection}s.
@@ -1566,7 +1566,7 @@ class Editor extends Model
   #
   # marker - A {DisplayBufferMarker}
   #
-  # Returns the selected {Range} or {undefined} if the marker is invalid.
+  # Returns the selected {Range} or `undefined` if the marker is invalid.
   selectMarker: (marker) ->
     if marker.isValid()
       range = marker.getBufferRange()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -788,14 +788,11 @@ class Editor extends Model
   foldBufferRow: (bufferRow) ->
     @languageMode.foldBufferRow(bufferRow)
 
-  # Destroy the largest fold containing the given row in buffer
-  # coordinates.
+  # Public: Unfold all folds containing the given row in buffer coordinates.
   #
   # bufferRow - A {Number}
-  #
-  # TODO: Should this destroy all folds containing the given buffer row?
   unfoldBufferRow: (bufferRow) ->
-    @languageMode.unfoldBufferRow(bufferRow)
+    @displayBuffer.unfoldBufferRow(bufferRow)
 
   # Public: Determine whether the given row in buffer coordinates is foldable.
   #
@@ -815,14 +812,10 @@ class Editor extends Model
   destroyFoldWithId: (id) ->
     @displayBuffer.destroyFoldWithId(id)
 
-  # {Delegates to: DisplayBuffer.destroyFoldsContainingBufferRow}
-  destroyFoldsContainingBufferRow: (bufferRow) ->
-    @displayBuffer.destroyFoldsContainingBufferRow(bufferRow)
-
   # Remove any {Fold}s found that intersect the given buffer row.
   destroyFoldsIntersectingBufferRange: (bufferRange) ->
     for row in [bufferRange.start.row..bufferRange.end.row]
-      @destroyFoldsContainingBufferRow(row)
+      @unfoldBufferRow(row)
 
   # Public: Fold the given buffer row if it isn't currently folded, and unfold
   # it otherwise.
@@ -904,7 +897,7 @@ class Editor extends Model
 
         # Make sure the inserted text doesn't go into an existing fold
         if fold = @displayBuffer.largestFoldStartingAtBufferRow(insertPosition.row)
-          @destroyFoldsContainingBufferRow(insertPosition.row)
+          @unfoldBufferRow(insertPosition.row)
           foldedRows.push(insertPosition.row + endRow - startRow + fold.getBufferRange().getRowCount())
 
         @buffer.insert(insertPosition, lines)
@@ -960,7 +953,7 @@ class Editor extends Model
 
         # Make sure the inserted text doesn't go into an existing fold
         if fold = @displayBuffer.largestFoldStartingAtBufferRow(insertPosition.row)
-          @destroyFoldsContainingBufferRow(insertPosition.row)
+          @unfoldBufferRow(insertPosition.row)
           foldedRows.push(insertPosition.row + fold.getBufferRange().getRowCount())
 
         @buffer.insert(insertPosition, lines)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -10,20 +10,19 @@ Cursor = require './cursor'
 Selection = require './selection'
 TextMateScopeSelector = require('first-mate').ScopeSelector
 
-# Public: The core model of Atom.
+# Public: Represents all essential editing state for a single {TextBuffer},
+# including cursor and selection positions, folds, and soft wraps. If you're
+# manipulating the state of an {Editor}, use this class. If you're interested in
+# the visual appearance of editors, use {EditorView} instead.
 #
-# An {Editor} represents a unique view of each document, with its own
-# {Cursor}s and scroll position.
+# A single {TextBuffer} can belong to multiple {Editor}s. For example, if the
+# same file is open in two different panes, Atom creates a separate {Editor} for
+# each pane. If the buffer is manipulated the changes are reflected in both
+# editors, but each maintains its own cursor position, folded lines, etc.
 #
-# For instance if a user creates a split, Atom creates a second {Editor}
-# but both {Editor}s interact with the same buffer underlying buffer. So
-# if you type in either buffer it immediately appears in both but if you scroll
-# in one it doesn't scroll the other.
-#
-# Almost all packages will interact primiarily with this class as it provides
-# access to objects you'll most commonly interact with. To access it you'll
-# want to register a callback on {WorkspaceView} which will be fired once for every
-# existing {Editor} as well as any future {Editor}s.
+# The easiest way to gain access to {Editor} objects is by registering a
+# callback on the `atom.workspace` global to be called with all current and
+# future {Editor}s:
 #
 # ## Example
 # ```coffeescript

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -49,6 +49,86 @@ TextMateScopeSelector = require('first-mate').ScopeSelector
 #
 # **When in doubt, just default to buffer coordinates**, then experiment with
 # soft wraps and folds to ensure your code interacts with them correctly.
+#
+# ## Common Tasks
+#
+# This is a subset of methods on this class. Refer to the complete summary for
+# its full capabilities.
+#
+# ### Cursors
+# - {::setCursorBufferPosition}
+# - {::setCursorScreenPosition}
+# - {::moveCursorUp}
+# - {::moveCursorDown}
+# - {::moveCursorLeft}
+# - {::moveCursorRight}
+# - {::moveCursorToBeginningOfWord}
+# - {::moveCursorToEndOfWord}
+# - {::moveCursorToPreviousWordBoundary}
+# - {::moveCursorToNextWordBoundary}
+# - {::moveCursorToBeginningOfNextWord}
+# - {::moveCursorToBeginningOfLine}
+# - {::moveCursorToEndOfLine}
+# - {::moveCursorToFirstCharacterOfLine}
+# - {::moveCursorToTop}
+# - {::moveCursorToBottom}
+#
+# ### Selections
+# - {::getSelectedBufferRange}
+# - {::getSelectedBufferRanges}
+# - {::setSelectedBufferRange}
+# - {::setSelectedBufferRanges}
+# - {::selectUp}
+# - {::selectDown}
+# - {::selectLeft}
+# - {::selectRight}
+# - {::selectToBeginningOfWord}
+# - {::selectToEndOfWord}
+# - {::selectToPreviousWordBoundary}
+# - {::selectToNextWordBoundary}
+# - {::selectWord}
+# - {::selectToBeginningOfLine}
+# - {::selectToEndOfLine}
+# - {::selectToFirstCharacterOfLine}
+# - {::selectToTop}
+# - {::selectToBottom}
+# - {::selectAll}
+# - {::addSelectionForBufferRange}
+# - {::addSelectionAbove}
+# - {::addSelectionBelow}
+# - {::splitSelectionsIntoLines}
+#
+# ### Manipulating Text
+# - {::getText}
+# - {::getSelectedText}
+# - {::setText}
+# - {::setTextInBufferRange}
+# - {::insertText}
+# - {::insertNewline}
+# - {::insertNewlineAbove}
+# - {::insertNewlineBelow}
+# - {::backspace}
+# - {::backspaceToBeginningOfWord}
+# - {::backspaceToBeginningOfLine}
+# - {::delete}
+# - {::deleteToEndOfWord}
+# - {::deleteLine}
+# - {::cutSelectedText}
+# - {::cutToEndOfLine}
+# - {::copySelectedText}
+# - {::pasteText}
+#
+# ### Undo, Redo, and Transactions
+# - {::undo}
+# - {::redo}
+# - {::transact}
+# - {::abortTransaction}
+#
+# ### Markers
+# - {::markBufferRange}
+# - {::markScreenRange}
+# - {::getMarker}
+# - {::findMarkers}
 module.exports =
 class Editor extends Model
   Serializable.includeInto(this)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -182,7 +182,7 @@ class Editor extends Model
       @getScrollLeft() == other.getScrollLeft() and
       @getCursorScreenPosition().isEqual(other.getCursorScreenPosition())
 
-  # Public: Controls visiblity based on the given Boolean.
+  # Controls visiblity based on the given Boolean.
   setVisible: (visible) -> @displayBuffer.setVisible(visible)
 
   # Deprecated: Use the ::scrollTop property directly

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -69,10 +69,9 @@ class Editor extends Model
   selections: null
   suppressSelectionMerging: false
 
-  @delegatesMethods 'foldAll', 'unfoldAll', 'foldAllAtIndentLevel', 'foldBufferRow',
-    'unfoldBufferRow', 'suggestedIndentForBufferRow', 'autoIndentBufferRow', 'autoIndentBufferRows',
+  @delegatesMethods 'suggestedIndentForBufferRow', 'autoIndentBufferRow', 'autoIndentBufferRows',
     'autoDecreaseIndentForBufferRow', 'toggleLineCommentForBufferRow', 'toggleLineCommentsForBufferRows',
-    'isFoldableAtBufferRow', toProperty: 'languageMode'
+    toProperty: 'languageMode'
 
   constructor: ({@softTabs, initialLine, tabLength, softWrap, @displayBuffer, buffer, registerEditor, suppressCursorCreation}) ->
     super
@@ -681,11 +680,57 @@ class Editor extends Model
     bufferRow = @bufferPositionForScreenPosition(@getCursorScreenPosition()).row
     @unfoldBufferRow(bufferRow)
 
-  # Public: For each selection, fold all rows it intersects.
+  # For each selection, fold all rows it intersects.
+  #
+  # TODO: Rename to foldSelectedLines?
   foldSelection: ->
     selection.fold() for selection in @getSelections()
 
-  # {Delegates to: DisplayBuffer.createFold}
+  # Public: Fold all foldable lines.
+  foldAll: ->
+    @languageMode.foldAll()
+
+  # Public: Unfold all existing folds.
+  unfoldAll: ->
+    @languageMode.unfoldAll()
+
+  # Public: Fold all foldable lines at the given indent level.
+  #
+  # level - A {Number}.
+  foldAllAtIndentLevel: (level) ->
+    @languageMode.foldAllAtIndentLevel(level)
+
+  # Fold the given row in buffer coordinates based on its indentation level.
+  #
+  # If the given row is foldable, the fold will begin there. Otherwise, it will
+  # begin at the first foldable row preceding the given row.
+  #
+  # bufferRow - A {Number}.
+  #
+  # TODO: Make public when ::unfoldBufferRow goes public
+  foldBufferRow: (bufferRow) ->
+    @languageMode.foldBufferRow(bufferRow)
+
+  # Destroy the largest fold containing the given row in buffer
+  # coordinates.
+  #
+  # bufferRow - A {Number}
+  #
+  # TODO: Should this destroy all folds containing the given buffer row?
+  unfoldBufferRow: (bufferRow) ->
+    @languageMode.unfoldBufferRow(bufferRow)
+
+  # Public: Determine whether the given row in buffer coordinates is foldable.
+  #
+  # A *foldable* row is a row that *starts* a row range that can be folded.
+  #
+  # bufferRow - A {Number}
+  #
+  # Returns a {Boolean}.
+  isFoldableAtBufferRow: (bufferRow) ->
+    @languageMode.isFoldableAtBufferRow(bufferRow)
+
+  # TODO: Rename to foldRowRange?
   createFold: (startRow, endRow) ->
     @displayBuffer.createFold(startRow, endRow)
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -777,14 +777,13 @@ class Editor extends Model
   foldAllAtIndentLevel: (level) ->
     @languageMode.foldAllAtIndentLevel(level)
 
-  # Fold the given row in buffer coordinates based on its indentation level.
+  # Public: Fold the given row in buffer coordinates based on its indentation
+  # level.
   #
   # If the given row is foldable, the fold will begin there. Otherwise, it will
   # begin at the first foldable row preceding the given row.
   #
   # bufferRow - A {Number}.
-  #
-  # TODO: Make public when ::unfoldBufferRow goes public
   foldBufferRow: (bufferRow) ->
     @languageMode.foldBufferRow(bufferRow)
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -12,17 +12,17 @@ TextMateScopeSelector = require('first-mate').ScopeSelector
 
 # Public: This class represents all essential editing state for a single
 # {TextBuffer}, including cursor and selection positions, folds, and soft wraps.
-# If you're manipulating the state of an {Editor}, use this class. If you're
+# If you're manipulating the state of an editor, use this class. If you're
 # interested in the visual appearance of editors, use {EditorView} instead.
 #
-# A single {TextBuffer} can belong to multiple {Editor}s. For example, if the
-# same file is open in two different panes, Atom creates a separate {Editor} for
+# A single {TextBuffer} can belong to multiple editors. For example, if the
+# same file is open in two different panes, Atom creates a separate editor for
 # each pane. If the buffer is manipulated the changes are reflected in both
 # editors, but each maintains its own cursor position, folded lines, etc.
 #
 # ## Accessing Editor Instances
 #
-# The easiest way to get hold of {Editor} objects is by registering a callback
+# The easiest way to get hold of `Editor` objects is by registering a callback
 # with `::eachEditor` on the `atom.workspace` global. Your callback will then
 # be called with all current editor instances and also when any editor is
 # created in the future.

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -337,7 +337,7 @@ class Editor extends Model
   # number of the editor.
   getLastBufferRow: -> @buffer.getLastRow()
 
-  # Public: Returns the range for the given buffer row.
+  # Returns the range for the given buffer row.
   #
   # row - A row {Number}.
   # options - An options hash with an `includeNewline` key.

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1599,10 +1599,6 @@ class Editor extends Model
   joinLine: ->
     @mutateSelectedText (selection) -> selection.joinLine()
 
-  # TODO: Remove unused method?
-  expandLastSelectionOverLine: ->
-    @getLastSelection().expandOverLine()
-
   # Public: Expand selections to the beginning of their containing word.
   #
   # Operates on all selections. Moves the cursor to the beginning of the
@@ -1627,10 +1623,6 @@ class Editor extends Model
   # Public: Select the word containing each cursor.
   selectWord: ->
     @expandSelectionsForward (selection) => selection.selectWord()
-
-  # TODO: Remove unused method?
-  expandLastSelectionOverWord: ->
-    @getLastSelection().expandOverWord()
 
   # Public: Select the range of the given marker if it is valid.
   #

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1593,10 +1593,8 @@ class Editor extends Model
   #
   # Joining a line means that multiple lines are converted to a single line with
   # the contents of each of the original non-empty lines separated by a space.
-  #
-  # TODO: Rename to joinLines?
-  joinLine: ->
-    @mutateSelectedText (selection) -> selection.joinLine()
+  joinLines: ->
+    @mutateSelectedText (selection) -> selection.joinLines()
 
   # Public: Expand selections to the beginning of their containing word.
   #

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -10,25 +10,46 @@ Cursor = require './cursor'
 Selection = require './selection'
 TextMateScopeSelector = require('first-mate').ScopeSelector
 
-# Public: Represents all essential editing state for a single {TextBuffer},
-# including cursor and selection positions, folds, and soft wraps. If you're
-# manipulating the state of an {Editor}, use this class. If you're interested in
-# the visual appearance of editors, use {EditorView} instead.
+# Public: This class represents all essential editing state for a single
+# {TextBuffer}, including cursor and selection positions, folds, and soft wraps.
+# If you're manipulating the state of an {Editor}, use this class. If you're
+# interested in the visual appearance of editors, use {EditorView} instead.
 #
 # A single {TextBuffer} can belong to multiple {Editor}s. For example, if the
 # same file is open in two different panes, Atom creates a separate {Editor} for
 # each pane. If the buffer is manipulated the changes are reflected in both
 # editors, but each maintains its own cursor position, folded lines, etc.
 #
-# The easiest way to gain access to {Editor} objects is by registering a
-# callback on the `atom.workspace` global to be called with all current and
-# future {Editor}s:
+# ## Accessing Editor Instances
+#
+# The easiest way to get hold of {Editor} objects is by registering a callback
+# with `::eachEditor` on the `atom.workspace` global. Your callback will then
+# be called with all current editor instances and also when any editor is
+# created in the future.
 #
 # ## Example
 # ```coffeescript
 #   atom.workspace.eachEditor (editor) ->
 #     editor.insertText('Hello World')
 # ```
+#
+# ## Buffer vs. Screen Coordinates
+#
+# Because editors support folds and soft-wrapping, the lines on screen don't
+# always match the lines in the buffer. For example, a long line that soft wraps
+# twice renders as three lines on screen, but only represents one line in the
+# buffer. Similarly, if rows 5-10 are folded, then row 6 on screen corresponds
+# to row 11 in the buffer.
+#
+# Your choice of coordinates systems will depend on what you're trying to
+# achieve. For example, if you're writing a command that jumps the cursor up or
+# down by 10 lines, you'll want to use screen coordinates because the user
+# probably wants to skip lines *on screen*. However, if you're writing a package
+# that jumps between method definitions, you'll want to work in buffer
+# coordinates.
+#
+# **When in doubt, just default to buffer coordinates**, then experiment with
+# soft wraps and folds to ensure your code interacts with them correctly.
 module.exports =
 class Editor extends Model
   Serializable.includeInto(this)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -166,7 +166,7 @@ class Editor extends Model
     else
       'untitled'
 
-  # Public: Compares two `Editor`s to determine equality.
+  # Compares two `Editor`s to determine equality.
   #
   # Equality is based on the condition that:
   #
@@ -590,7 +590,7 @@ class Editor extends Model
   destroyFoldsContainingBufferRow: (bufferRow) ->
     @displayBuffer.destroyFoldsContainingBufferRow(bufferRow)
 
-  # Public: Removes any {Fold}s found that intersect the given buffer row.
+  # Removes any {Fold}s found that intersect the given buffer row.
   destroyFoldsIntersectingBufferRange: (bufferRange) ->
     for row in [bufferRange.start.row..bufferRange.end.row]
       @destroyFoldsContainingBufferRow(row)
@@ -799,7 +799,7 @@ class Editor extends Model
   markBufferPosition: (args...) ->
     @displayBuffer.markBufferPosition(args...)
 
-  # Public: {Delegates to: DisplayBuffer.destroyMarker}
+  # {Delegates to: DisplayBuffer.destroyMarker}
   destroyMarker: (args...) ->
     @displayBuffer.destroyMarker(args...)
 
@@ -830,8 +830,7 @@ class Editor extends Model
     @markBufferPosition(bufferPosition, @getSelectionMarkerAttributes())
     @getLastSelection().cursor
 
-  # Public: Adds and returns a cursor at the given {DisplayBufferMarker}
-  # position.
+  # Adds and returns a cursor based on the given {DisplayBufferMarker}.
   addCursor: (marker) ->
     cursor = new Cursor(editor: this, marker: marker)
     @cursors.push(cursor)
@@ -842,7 +841,7 @@ class Editor extends Model
   removeCursor: (cursor) ->
     _.remove(@cursors, cursor)
 
-  # Public: Creates a new selection at the given marker.
+  # Adds and returns a {Selection} based on the given {DisplayBufferMarker}.
   #
   # marker  - The {DisplayBufferMarker} to highlight
   # options - An {Object} that pertains to the {Selection} constructor.

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -121,12 +121,6 @@ class LanguageMode
       fold = @editor.displayBuffer.largestFoldStartingAtBufferRow(startRow)
       return @editor.createFold(startRow, endRow) unless fold
 
-  # Given a buffer row, this unfolds it.
-  #
-  # bufferRow - A {Number} indicating the buffer row
-  unfoldBufferRow: (bufferRow) ->
-    @editor.displayBuffer.largestFoldContainingBufferRow(bufferRow)?.destroy()
-
   # Find the row range for a fold at a given bufferRow. Will handle comments
   # and code.
   #

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -282,7 +282,7 @@ class Selection
   #   :undo - if `skip`, skips the undo stack for this operation.
   insertText: (text, options={}) ->
     oldBufferRange = @getBufferRange()
-    @editor.destroyFoldsContainingBufferRow(oldBufferRange.end.row)
+    @editor.unfoldBufferRow(oldBufferRange.end.row)
     wasReversed = @isReversed()
     @clear()
     @cursor.needsAutoscroll = @cursor.isLastCursor()
@@ -334,11 +334,15 @@ class Selection
 
     normalizedLines.join('\n')
 
-  # Public: Indents the selection.
+  # Indent the current line(s).
+  #
+  # If the selection is empty, indents the current line if the cursor precedes
+  # non-whitespace characters, and otherwise inserts a tab. If the selection is
+  # non empty, calls {::indentSelectedRows}.
   #
   # options - A {Object} with the keys:
-  #   :autoIndent - If `true`, the indentation is performed appropriately.
-  #                 Otherwise, {Editor::getTabText} is used.
+  #   :autoIndent - If `true`, the line is indented to an automatically-inferred
+  #                 level. Otherwise, {Editor::getTabText} is inserted.
   indent: ({ autoIndent }={})->
     { row, column } = @cursor.getBufferPosition()
 

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -437,7 +437,7 @@ class Selection
   # Public: Joins the current line with the one below it.
   #
   # If there selection spans more than one line, all the lines are joined together.
-  joinLine: ->
+  joinLines: ->
     selectedRange = @getBufferRange()
     if selectedRange.isEmpty()
       return if selectedRange.start.row is @editor.buffer.getLastRow()


### PR DESCRIPTION
This PR does the following:
- Adds complete and correct documentation to all public methods on `Editor`
- Privatizes methods on `Editor` that we can all agree on. Kept a few methods private that need to be changed to handle multiple cursors.
- Renames `::joinLine` to `::joinLines`
- Removes metaprogrammed delegators for a few methods that need documentation.
- Make `::unfoldBufferRow` destroy all folds containing the given row, which I think would be the expected behavior.

Can you guys take a look and feel free to merge it in if you think it's ready? I think it's a big improvement overall.
