### PR TITLE
Bump max size to 2MB

### DIFF
--- a/src/project.coffee
+++ b/src/project.coffee
@@ -189,8 +189,8 @@ class Project extends Model
   #
   # Returns a promise that resolves to the {TextBuffer}.
   buildBuffer: (absoluteFilePath) ->
-    if fs.getSizeSync(absoluteFilePath) >= 1048576 # 1MB
-      throw new Error("Atom can only handle files < 1MB, for now.")
+    if fs.getSizeSync(absoluteFilePath) >= 2 * 1048576 # 2MB
+      throw new Error("Atom can only handle files < 2MB, for now.")
 
     buffer = new TextBuffer({filePath: absoluteFilePath})
     @addBuffer(buffer)


### PR DESCRIPTION
336 people have tried to open a file larger than 1MB 1345 times, let's bump it to 2MB and see what happens.
