### PR TITLE
Improve reporting of display buffer errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "bracket-matcher": "0.22.0",
     "command-palette": "0.18.0",
     "dev-live-reload": "0.28.0",
-    "exception-reporting": "0.15.0",
+    "exception-reporting": "0.16.0",
     "feedback": "0.27.0",
     "find-and-replace": "0.85.0",
     "fuzzy-finder": "0.37.0",

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -10,6 +10,11 @@ Fold = require './fold'
 Token = require './token'
 DisplayBufferMarker = require './display-buffer-marker'
 
+class BufferToScreenConversionError extends Error
+  constructor: (@message, @metadata) ->
+    super
+    Error.captureStackTrace(this, arguments.callee)
+
 module.exports =
 class DisplayBuffer extends Model
   Serializable.includeInto(this)
@@ -291,12 +296,14 @@ class DisplayBuffer extends Model
     { row, column } = @buffer.clipPosition(bufferPosition)
     [startScreenRow, endScreenRow] = @rowMap.screenRowRangeForBufferRow(row)
     for screenRow in [startScreenRow...endScreenRow]
-      unless screenLine = @screenLines[screenRow]
-        throw new Error """
-          No screen line exists when converting a buffer row to a screen row
-          Soft wrap enabled?: #{@getSoftWrap()}
-          Folds exist?: #{@findFoldMarkers().length > 0}
-        """
+      screenLine = @screenLines[screenRow]
+      unless screenLine?
+        throw new BufferToScreenConversionError "No screen line exists when converting buffer row to screen row",
+          softWrapEnabled: @getSoftWrap()
+          foldCount: @findFoldMarkers().length
+          lastBufferRow: @buffer.getLastRow()
+          lastScreenRow: @getLastRow()
+
       maxBufferColumn = screenLine.getMaxBufferColumn()
       if screenLine.isSoftWrapped() and column > maxBufferColumn
         continue

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -13,7 +13,7 @@ DisplayBufferMarker = require './display-buffer-marker'
 class BufferToScreenConversionError extends Error
   constructor: (@message, @metadata) ->
     super
-    Error.captureStackTrace(this, arguments.callee)
+    Error.captureStackTrace(this, BufferToScreenConversionError)
 
 module.exports =
 class DisplayBuffer extends Model

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -297,6 +297,7 @@ class DisplayBuffer extends Model
     [startScreenRow, endScreenRow] = @rowMap.screenRowRangeForBufferRow(row)
     for screenRow in [startScreenRow...endScreenRow]
       screenLine = @screenLines[screenRow]
+
       unless screenLine?
         throw new BufferToScreenConversionError "No screen line exists when converting buffer row to screen row",
           softWrapEnabled: @getSoftWrap()


### PR DESCRIPTION
Previously, lots of situation-specific information was being baked into the error message, which is also used as the grouping mechanism for errors on bugsnag. This PR adds a custom error class for translation errors and pushes situation specific information into a metadata field which is now sent to Bugsnag by [exception-reporting 0.16.0](https://github.com/atom/exception-reporting/releases/tag/v0.16.0).
