### PR TITLE
License type is definitely not Apache.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "licenses": [
     {
-      "type": "Apache",
+      "type": "Copyright 2014 GitHub, Inc.",
       "url": "http://github.com/atom/atom/raw/master/LICENSE.md"
     }
   ],


### PR DESCRIPTION
Not sure if there's a package.json specific identifier to use, there's nothing listed in teh SPDX license identifier list (because those are all open licenses)
