### PR TITLE
Fix CSON syntax for keybinding example in docs

### DIFF
--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -63,9 +63,8 @@ built-in keymaps:
 '.editor':
   'enter': 'editor:newline'
 
-'body':
-  'ctrl-b': 'core:move-left'
-  'ctrl-f': 'core:move-right'
+'.mini.editor input':
+  'enter': 'core:confirm'
 ```
 
 This keymap defines the meaning of `enter` in two different contexts. In a


### PR DESCRIPTION
From support/d444cb549f4c11e38d9e02537bbc77fe

The prose and the syntax in this article don't match.
