### PR TITLE
Provide breakpad symbols of native modules

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -41,6 +41,7 @@ module.exports = (grunt) ->
     tmpDir = os.tmpdir()
     installRoot = process.env.ProgramFiles
     buildDir = grunt.option('build-dir') ? path.join(tmpDir, 'atom-build')
+    symbolsDir = path.join(buildDir, 'Atom.breakpad.syms')
     shellAppDir = path.join(buildDir, appName)
     contentsDir = shellAppDir
     appDir = path.join(shellAppDir, 'resources', 'app')
@@ -50,6 +51,7 @@ module.exports = (grunt) ->
     tmpDir = '/tmp'
     installRoot = '/Applications'
     buildDir = grunt.option('build-dir') ? path.join(tmpDir, 'atom-build')
+    symbolsDir = path.join(buildDir, 'Atom.breakpad.syms')
     shellAppDir = path.join(buildDir, appName)
     contentsDir = path.join(shellAppDir, 'Contents')
     appDir = path.join(contentsDir, 'Resources', 'app')
@@ -123,7 +125,7 @@ module.exports = (grunt) ->
   grunt.initConfig
     pkg: grunt.file.readJSON('package.json')
 
-    atom: {appDir, appName, buildDir, contentsDir, installDir, shellAppDir}
+    atom: {appDir, appName, symbolsDir, buildDir, contentsDir, installDir, shellAppDir}
 
     coffee: coffeeConfig
 

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -225,6 +225,6 @@ module.exports = (grunt) ->
   grunt.registerTask('compile', ['coffee', 'prebuild-less', 'cson', 'peg'])
   grunt.registerTask('lint', ['coffeelint', 'csslint', 'lesslint'])
   grunt.registerTask('test', ['shell:kill-atom', 'run-specs'])
-  grunt.registerTask('ci', ['output-disk-space', 'download-atom-shell', 'build', 'set-version', 'check-licenses', 'lint', 'test', 'codesign', 'publish-build'])
+  grunt.registerTask('ci', ['output-disk-space', 'download-atom-shell', 'build', 'dump-symbols', 'set-version', 'check-licenses', 'lint', 'test', 'codesign', 'publish-build'])
   grunt.registerTask('docs', ['markdown:guides', 'build-docs'])
   grunt.registerTask('default', ['download-atom-shell', 'build', 'set-version', 'install'])

--- a/build/package.json
+++ b/build/package.json
@@ -26,6 +26,7 @@
     "harmony-collections": "~0.3.8",
     "json-front-matter": "~0.1.3",
     "legal-eagle": "~0.3.0",
+    "minidump": "0.4.x",
     "rcedit": "~0.1.2",
     "request": "~2.27.0",
     "rimraf": "~2.2.2",

--- a/build/tasks/dump-symbols-task.coffee
+++ b/build/tasks/dump-symbols-task.coffee
@@ -1,0 +1,40 @@
+async = require 'async'
+fs = require 'fs-plus'
+path = require 'path'
+minidump = require 'minidump'
+
+module.exports = (grunt) ->
+  {mkdir, rm} = require('./task-helpers')(grunt)
+
+  dumpSymbolTo = (binaryPath, targetDirectory, callback) ->
+    minidump.dumpSymbol binaryPath, (error, content) ->
+      return callback(error) if error?
+
+      moduleLine = /MODULE [^ ]+ [^ ]+ ([0-9A-F]+) (.*)\n/.exec(content)
+      if moduleLine.length isnt 3
+        return callback("Invalid output when dumping symbol for #{binaryPath}")
+
+      filename = moduleLine[2]
+      targetPathDirname = path.join(targetDirectory, filename, moduleLine[1])
+      mkdir targetPathDirname
+
+      targetPath = path.join(targetPathDirname, "#{filename}.sym")
+      fs.writeFile(targetPath, content, callback)
+
+  grunt.registerTask 'dump-symbols', 'Dump symbols for native modules', ->
+    done = @async()
+
+    symbolsDir = grunt.config.get('atom.symbolsDir')
+    rm symbolsDir
+    mkdir symbolsDir
+
+    tasks = []
+    onFile = (binaryPath) ->
+      if /.*\.node$/.test(binaryPath)
+        tasks.push(dumpSymbolTo.bind(this, binaryPath, symbolsDir))
+    onDirectory = ->
+      true
+    fs.traverseTreeSync 'node_modules', onFile, onDirectory
+
+    async.parallel tasks, (error, results) ->
+      console.log error, results

--- a/build/tasks/dump-symbols-task.coffee
+++ b/build/tasks/dump-symbols-task.coffee
@@ -36,5 +36,4 @@ module.exports = (grunt) ->
       true
     fs.traverseTreeSync 'node_modules', onFile, onDirectory
 
-    async.parallel tasks, (error, results) ->
-      console.log error, results
+    async.parallel tasks, done

--- a/build/tasks/publish-build-task.coffee
+++ b/build/tasks/publish-build-task.coffee
@@ -9,8 +9,8 @@ request = require 'request'
 grunt = null
 maxReleases = 10
 assets = [
-  name: 'atom-mac.zip', source: 'Atom.app'
-  name: 'atom-mac-symbols.zip', source: 'Atom.breakpad.syms'
+  {assetName: 'atom-mac.zip', sourceName: 'Atom.app'}
+  {assetName: 'atom-mac-symbols.zip', sourceName: 'Atom.breakpad.syms'}
 ]
 commitSha = process.env.JANKY_SHA1
 token = process.env.ATOM_ACCESS_TOKEN
@@ -31,9 +31,9 @@ module.exports = (gruntObject) ->
     createBuildRelease (error, release) ->
       return done(error) if error?
 
-      for {name, source} in assets
-        assetPath = path.join(buildDir, name)
-        zipApp buildDir, source, name, (error) ->
+      for {assetName, sourceName} in assets
+        assetPath = path.join(buildDir, assetName)
+        zipApp sourceName, assetName, assetPath, (error) ->
           return done(error) if error?
           uploadAsset release, assetName, assetPath, (error) ->
             return done(error) if error?
@@ -50,8 +50,7 @@ logError = (message, error, details) ->
   grunt.log.error(error.message ? error) if error?
   grunt.log.error(details) if details
 
-zipApp = (buildDir, sourceName, assetName, callback) ->
-  assetPath = path.join(buildDir, assetName)
+zipApp = (sourceName, assetName, assetPath, callback) ->
   fs.removeSync(assetPath)
 
   options = {cwd: path.dirname(assetPath), maxBuffer: Infinity}

--- a/build/tasks/publish-build-task.coffee
+++ b/build/tasks/publish-build-task.coffee
@@ -2,6 +2,7 @@ child_process = require 'child_process'
 path = require 'path'
 
 _ = require 'underscore-plus'
+async = require 'async'
 fs = require 'fs-plus'
 GitHub = require 'github-releases'
 request = require 'request'
@@ -31,33 +32,37 @@ module.exports = (gruntObject) ->
     createBuildRelease (error, release) ->
       return done(error) if error?
 
-      for {assetName, sourceName} in assets
-        assetPath = path.join(buildDir, assetName)
-        zipApp sourceName, assetName, assetPath, (error) ->
+      zipApps buildDir, assets, (error) ->
+        return done(error) if error?
+        uploadAssets release, buildDir, assets, (error) ->
           return done(error) if error?
-          uploadAsset release, assetName, assetPath, (error) ->
+          publishRelease release, (error) ->
             return done(error) if error?
-            publishRelease release, (error) ->
+            getAtomDraftRelease (error, release) ->
               return done(error) if error?
-              getAtomDraftRelease (error, release) ->
+              assetNames = (asset.assetName for asset in assets)
+              deleteExistingAssets release, assetNames, (error) ->
                 return done(error) if error?
-                deleteExistingAsset release, assetName, (error) ->
-                  return done(error) if error?
-                  uploadAsset(release, assetName, assetPath, done)
+                uploadAssets(release, buildDir, assets, done)
 
 logError = (message, error, details) ->
   grunt.log.error(message)
   grunt.log.error(error.message ? error) if error?
   grunt.log.error(details) if details
 
-zipApp = (sourceName, assetName, assetPath, callback) ->
-  fs.removeSync(assetPath)
+zipApps = (buildDir, assets, callback) ->
+  zip = (directory, sourceName, assetName, callback) ->
+    options = {cwd: directory, maxBuffer: Infinity}
+    child_process.exec "zip -r --symlinks #{assetName} #{sourceName}", options, (error, stdout, stderr) ->
+      if error?
+        logError("Zipping #{sourceName} failed", error, stderr)
+      callback(error)
 
-  options = {cwd: path.dirname(assetPath), maxBuffer: Infinity}
-  child_process.exec "zip -r --symlinks #{assetName} #{sourceName}", options, (error, stdout, stderr) ->
-    if error?
-      logError("Zipping #{sourceName} failed", error, stderr)
-    callback(error)
+  tasks = []
+  for {assetName, sourceName} in assets
+    fs.removeSync(path.join(buildDir, assetName))
+    tasks.push(zip.bind(this, buildDir, sourceName, assetName))
+  async.parallel(tasks, callback)
 
 getRelease = (callback) ->
   options =
@@ -100,10 +105,12 @@ deleteRelease = (release) ->
     if error? or response.statusCode isnt 204
       logError('Deleting release failed', error, body)
 
-deleteExistingAsset = (release, assetName, callback) ->
-  for asset in release.assets when asset.name is assetName
+deleteExistingAssets = (release, assetNames, callback) ->
+  [callback, assetNames] = [assetNames, callback] if not callback?
+
+  deleteAsset = (url, callback) ->
     options =
-      uri: asset.url
+      uri: url
       method: 'DELETE'
       headers: defaultHeaders
     request options, (error, response, body='') ->
@@ -113,9 +120,10 @@ deleteExistingAsset = (release, assetName, callback) ->
       else
         callback()
 
-    return
-
-  callback()
+  tasks = []
+  for asset in release.assets when not assetNames? or asset.name in assetNames
+    tasks.push(deleteAsset.bind(this, asset.url))
+  async.parallel(tasks, callback)
 
 createBuildRelease = (callback) ->
   getRelease (error, release) ->
@@ -124,7 +132,7 @@ createBuildRelease = (callback) ->
       return
 
     if release?
-      deleteExistingAsset release, (error) ->
+      deleteExistingAssets release, (error) ->
         callback(error, release)
       return
 
@@ -146,23 +154,30 @@ createBuildRelease = (callback) ->
       else
         callback(null, release)
 
-uploadAsset = (release, assetName, assetPath, callback) ->
-  options =
-    uri: release.upload_url.replace(/\{.*$/, "?name=#{assetName}")
-    method: 'POST'
-    headers: _.extend({
-      'Content-Type': 'application/zip'
-      'Content-Length': fs.getSizeSync(assetPath)
-      }, defaultHeaders)
+uploadAssets = (release, buildDir, assets, callback) ->
+  upload = (release, assetName, assetPath, callback) ->
+    options =
+      uri: release.upload_url.replace(/\{.*$/, "?name=#{assetName}")
+      method: 'POST'
+      headers: _.extend({
+        'Content-Type': 'application/zip'
+        'Content-Length': fs.getSizeSync(assetPath)
+        }, defaultHeaders)
 
-  assetRequest = request options, (error, response, body='') ->
-    if error? or response.statusCode >= 400
-      logError('Upload release asset failed', error, body)
-      callback(error ? new Error(response.statusCode))
-    else
-      callback(null, release)
+    assetRequest = request options, (error, response, body='') ->
+      if error? or response.statusCode >= 400
+        logError("Upload release asset #{assetName} failed", error, body)
+        callback(error ? new Error(response.statusCode))
+      else
+        callback(null, release)
 
-  fs.createReadStream(assetPath).pipe(assetRequest)
+    fs.createReadStream(assetPath).pipe(assetRequest)
+
+  tasks = []
+  for {assetName, sourceName} in assets
+    assetPath = path.join(buildDir, assetName)
+    tasks.push(upload.bind(this, release, assetName, assetPath))
+  async.parallel(tasks, callback)
 
 publishRelease = (release, callback) ->
   options =


### PR DESCRIPTION
This PR adds the `dump-symbols` task which would generate debug symbols for all the native modules, and the symbols would be uploaded to GitHub Release when publishing build.

/cc @kevinsawicki I don't know how the official build is deployed, can you help make sure the `atom-mac-symbols.zip` is uploaded when publishing a release in atom/atom?
