### PR TITLE
Update syntax color variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "atom-light-syntax": "0.14.0",
     "atom-light-ui": "0.22.0",
     "base16-tomorrow-dark-theme": "0.13.0",
-    "solarized-dark-syntax": "0.10.0",
+    "solarized-dark-syntax": "0.11.0",
     "solarized-light-syntax": "0.6.0",
     "archive-view": "0.26.0",
     "autocomplete": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "atom-dark-ui": "0.23.0",
     "atom-light-syntax": "0.14.0",
     "atom-light-ui": "0.22.0",
-    "base16-tomorrow-dark-theme": "0.12.0",
+    "base16-tomorrow-dark-theme": "0.13.0",
     "solarized-dark-syntax": "0.10.0",
     "solarized-light-syntax": "0.6.0",
     "archive-view": "0.26.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "packageDependencies": {
     "atom-dark-syntax": "0.15.0",
     "atom-dark-ui": "0.23.0",
-    "atom-light-syntax": "0.14.0",
+    "atom-light-syntax": "0.15.0",
     "atom-light-ui": "0.22.0",
     "base16-tomorrow-dark-theme": "0.13.0",
     "solarized-dark-syntax": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "atom-light-ui": "0.22.0",
     "base16-tomorrow-dark-theme": "0.13.0",
     "solarized-dark-syntax": "0.11.0",
-    "solarized-light-syntax": "0.6.0",
+    "solarized-light-syntax": "0.7.0",
     "archive-view": "0.26.0",
     "autocomplete": "0.24.0",
     "autoflow": "0.15.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "vm-compatibility-layer": "0.1.0"
   },
   "packageDependencies": {
-    "atom-dark-syntax": "0.14.0",
+    "atom-dark-syntax": "0.15.0",
     "atom-dark-ui": "0.23.0",
     "atom-light-syntax": "0.14.0",
     "atom-light-ui": "0.22.0",

--- a/static/variables/syntax-variables.less
+++ b/static/variables/syntax-variables.less
@@ -7,6 +7,7 @@
 @syntax-selection-color: #69c;
 @syntax-background-color: #fff;
 
+// Guide colors
 @syntax-wrap-guide-color: #ccc;
 @syntax-indent-guide-color: #ccc;
 @syntax-invisible-character-color: #ccc;

--- a/static/variables/syntax-variables.less
+++ b/static/variables/syntax-variables.less
@@ -3,9 +3,12 @@
 
 // General colors
 @syntax-text-color: #333;
-@syntax-background-color: #fff;
 @syntax-cursor-color: #333;
 @syntax-selection-color: #69c;
+@syntax-background-color: #fff;
+
+@syntax-wrap-guide-color: #ccc;
+@syntax-indent-guide-color: #ccc;
 @syntax-invisible-character-color: #ccc;
 
 // For find and replace markers

--- a/static/variables/syntax-variables.less
+++ b/static/variables/syntax-variables.less
@@ -1,8 +1,25 @@
-// This file has fallback variables. It specifies the syntax variables that
-// themes must implement.
+// This file has fallback variables. It specifies all syntax variables that
+// themes must implement if they include a syntax-variables.less file.
 
-// Colors
+// General colors
+@syntax-text-color: #333;
+@syntax-background-color: #fff;
+@syntax-cursor-color: #333;
+@syntax-selection-color: #69c;
+@syntax-invisible-character-color: #ccc;
 
-@syntax-color-added: #5293d8;
-@syntax-color-modified: #f78a46;
-@syntax-color-removed: #c00;
+// For find and replace markers
+@syntax-result-marker-color: #444;
+@syntax-result-marker-color-selected: #000;
+
+// Gutter colors
+@syntax-gutter-text-color: #333;
+@syntax-gutter-text-color-selected: #000;
+@syntax-gutter-background-color: #ccc;
+@syntax-gutter-background-color-selected: #eee;
+
+// For git diff info. i.e. in the gutter
+@syntax-color-added: green;
+@syntax-color-modified: orange;
+@syntax-color-removed: red;
+@syntax-color-renamed: blue;


### PR DESCRIPTION
My proposal for new syntax variables. Fixes #1609 
- New syntax themes would have this file generated for them

I want your feedback on naming. Am I missing something? I will be updating all the themes to include these...

Part of me wants to have things like `@comment-color` and `@string-color`, but maybe we stick to only colors that are common in every syntax theme. 
