### PR TITLE
Allow multiple unsaved buffers

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -14,14 +14,24 @@ describe "Workspace", ->
     describe "when the 'searchAllPanes' option is false (default)", ->
       describe "when called without a uri", ->
         it "adds and activates an empty editor on the active pane", ->
-          editor = null
+          [editor1, editor2] = []
+
           waitsForPromise ->
-            workspace.open().then (o) -> editor = o
+            workspace.open().then (editor) -> editor1 = editor
 
           runs ->
-            expect(editor.getPath()).toBeUndefined()
-            expect(workspace.activePane.items).toEqual [editor]
-            expect(workspace.activePaneItem).toBe editor
+            expect(editor1.getPath()).toBeUndefined()
+            expect(workspace.activePane.items).toEqual [editor1]
+            expect(workspace.activePaneItem).toBe editor1
+            expect(workspace.activePane.activate).toHaveBeenCalled()
+
+          waitsForPromise ->
+            workspace.open().then (editor) -> editor2 = editor
+
+          runs ->
+            expect(editor2.getPath()).toBeUndefined()
+            expect(workspace.activePane.items).toEqual [editor1, editor2]
+            expect(workspace.activePaneItem).toBe editor2
             expect(workspace.activePane.activate).toHaveBeenCalled()
 
       describe "when called with a uri", ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -267,22 +267,6 @@ class Editor extends Model
     else
       'untitled'
 
-  # Compares two `Editor`s to determine equality.
-  #
-  # Equality is based on whether:
-  # * the two {TextBuffer}s are the same
-  # * the two `scrollTop` and `scrollLeft` property are the same
-  # * the most recent {Cursor}s are in the same position.
-  #
-  # Returns a {Boolean}.
-  isEqual: (other) ->
-    return false unless other instanceof Editor
-    @isAlive() == other.isAlive() and
-      @buffer.getPath() == other.buffer.getPath() and
-      @getScrollTop() == other.getScrollTop() and
-      @getScrollLeft() == other.getScrollLeft() and
-      @getCursorScreenPosition().isEqual(other.getCursorScreenPosition())
-
   # Controls visiblity based on the given {Boolean}.
   setVisible: (visible) -> @displayBuffer.setVisible(visible)
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -73,7 +73,7 @@ class Workspace extends Model
   #                     if the uri is already open (default: false)
   #
   # Returns a promise that resolves to the {Editor} for the file URI.
-  open: (uri='', options={}) ->
+  open: (uri, options={}) ->
     searchAllPanes = options.searchAllPanes
     split = options.split
     uri = atom.project.resolve(uri)
@@ -112,8 +112,8 @@ class Workspace extends Model
   openUriInPane: (uri, pane, options={}) ->
     changeFocus = options.changeFocus ? true
 
-    item = pane.itemForUri(uri)
-    if uri
+    if uri?
+      item = pane.itemForUri(uri)
       item ?= opener(atom.project.resolve(uri), options) for opener in @getOpeners() when !item
     item ?= atom.project.open(uri, options)
 


### PR DESCRIPTION
If `open` is called with no uri, we should always open a new unsaved buffer.

Refs #1600
