### PR TITLE
Upgrade to atom-shell@0.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "All Rights Reserved",
-  "atomShellVersion": "0.10.3",
+  "atomShellVersion": "0.10.4",
   "dependencies": {
     "async": "0.2.6",
     "bootstrap": "git://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",


### PR DESCRIPTION
- Fix unresponsive window when using alert().
- Suppress CFAllocator warning, fixes #1627.
- Fix a crash from node.
