### PR TITLE
Apply 'scrollbars-visible-always/when-scrolling' class to WorkspaceView

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "random-words": "0.0.1",
     "runas": "0.5.x",
     "scandal": "0.15.0",
+    "scrollbar-style": "^0.1.0",
     "season": ">=1.0.2 <2.0",
     "semver": "1.1.4",
     "serializable": "1.x",

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -242,10 +242,10 @@ describe "WorkspaceView", ->
       atom.workspaceView.trigger('core:close')
       expect(atom.workspaceView.getActivePane().getItems()).toHaveLength 0
 
-  describe "the scrollbar style class", ->
+  describe "the scrollbar visibility class", ->
     it "has a class based on the style of the scrollbar", ->
       scrollbarStyle = require 'scrollbar-style'
       scrollbarStyle.emitValue 'legacy'
-      expect(atom.workspaceView).toHaveClass 'scrollbar-style-legacy'
+      expect(atom.workspaceView).toHaveClass 'scrollbars-visible-always'
       scrollbarStyle.emitValue 'overlay'
-      expect(atom.workspaceView).toHaveClass 'scrollbar-style-overlay'
+      expect(atom.workspaceView).toHaveClass 'scrollbars-visible-when-scrolling'

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -241,3 +241,11 @@ describe "WorkspaceView", ->
       expect(atom.workspaceView.getActivePane().getItems()).toHaveLength 1
       atom.workspaceView.trigger('core:close')
       expect(atom.workspaceView.getActivePane().getItems()).toHaveLength 0
+
+  describe "the scrollbar style class", ->
+    it "has a class based on the style of the scrollbar", ->
+      scrollbarStyle = require 'scrollbar-style'
+      scrollbarStyle.emitValue 'legacy'
+      expect(atom.workspaceView).toHaveClass 'scrollbar-style-legacy'
+      scrollbarStyle.emitValue 'overlay'
+      expect(atom.workspaceView).toHaveClass 'scrollbar-style-overlay'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -83,9 +83,12 @@ class WorkspaceView extends View
     @subscribe @model, 'uri-opened', => @trigger 'uri-opened'
 
     @subscribe scrollbarStyle, (style) =>
-      @removeClass('scrollbar-style-legacy')
-      @removeClass('scrollbar-style-overlay')
-      @addClass("scrollbar-style-#{style}")
+      @removeClass('scrollbars-visible-always scrollbars-visible-when-scrolling')
+      switch style
+        when 'legacy'
+          @addClass("scrollbars-visible-always")
+        when 'overlay'
+          @addClass("scrollbars-visible-when-scrolling")
 
     @updateTitle()
 

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -82,7 +82,7 @@ class WorkspaceView extends View
 
     @subscribe @model, 'uri-opened', => @trigger 'uri-opened'
 
-    @subscribe scrollbarStyle.onValue (style) =>
+    @subscribe scrollbarStyle, (style) =>
       @removeClass('scrollbar-style-legacy')
       @removeClass('scrollbar-style-overlay')
       @addClass("scrollbar-style-#{style}")

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -3,6 +3,7 @@ path = require 'path'
 Q = require 'q'
 _ = require 'underscore-plus'
 Delegator = require 'delegato'
+scrollbarStyle = require 'scrollbar-style'
 {$, $$, View} = require './space-pen-extensions'
 fs = require 'fs-plus'
 Workspace = require './workspace'
@@ -80,6 +81,11 @@ class WorkspaceView extends View
     @panes = panes
 
     @subscribe @model, 'uri-opened', => @trigger 'uri-opened'
+
+    @subscribe scrollbarStyle.onValue (style) =>
+      @removeClass('scrollbar-style-legacy')
+      @removeClass('scrollbar-style-overlay')
+      @addClass("scrollbar-style-#{style}")
 
     @updateTitle()
 


### PR DESCRIPTION
As is discussed in #1672, styling scrollbars forces them to be visible. We want to be able to _only_ style scrollbars if the user's has chosen to have them always be visible to begin with, and otherwise leave the overlay behavior.

This PR adds a `scrollbars-visible-always` or `scrollbars-visible-when-scrolling` class to the workspace view so we can only enable scrollbar styles when scrollbars are visible "always". This should help us merge PRs like atom/atom-dark-ui#12.
