### PR TITLE
Minor documentation tweaks/fixes

### DIFF
--- a/docs/creating-a-package.md
+++ b/docs/creating-a-package.md
@@ -338,7 +338,7 @@ code depending on whether the tests passed or failed.
 
 ## Publishing
 
-Atom bundles a command line utility called [apm] which can be used to publish
+Atom bundles a command line utility called apm which can be used to publish
 Atom packages to the public registry.
 
 Once your package is written and ready for distribution you can run the
@@ -361,7 +361,6 @@ all the other available commands.
 [cs-syntax]: https://github.com/atom/language-coffee-script
 [npm]: http://en.wikipedia.org/wiki/Npm_(software)
 [npm-keys]: https://npmjs.org/doc/json.html
-[apm]: https://github.com/atom/apm
 [git-tag]: http://git-scm.com/book/en/Git-Basics-Tagging
 [wrap-guide]: https://github.com/atom/wrap-guide/
 [keymaps]: advanced/keymaps.md

--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -148,6 +148,14 @@ If customizations become extensive, consider [creating a package][creating-a-pac
 You can open this file in an editor from the _Atom > Open Your Init Script_
 menu.
 
+For example, if you have the Audio Beep configuration setting enabled, you
+could add the following code to your _~/.atom/init.coffee_ file to have Atom
+greet you with an audio beep every time it loads:
+
+```coffee
+atom.beep()
+```
+
 This file can also be named _init.js_ and contain JavaScript code.
 
 ### styles.less

--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -141,7 +141,7 @@ You can open this file in an editor from the _Atom > Open Your Config_ menu.
 ### init.coffee
 
 When Atom finishes loading, it will evaluate _init.coffee_ in your _~/.atom_
-directory, giving you a chance to run arbitrary personal CoffeeScript code to
+directory, giving you a chance to run arbitrary personal [CoffeeScript][] code to
 make customizations. You have full access to Atom's API from code in this file.
 If customizations become extensive, consider [creating a package][creating-a-package].
 
@@ -175,3 +175,4 @@ This file can also be named _styles.css_ and contain CSS.
 [create-theme]: creating-a-theme.md
 [LESS]: http://www.lesscss.org
 [CSON]: https://github.com/bevry/cson
+[CoffeeScript]: http://coffeescript.org/

--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -86,7 +86,7 @@ currently in use.
 ## Advanced Configuration
 
 Atom loads configuration settings from the `config.cson` file in your _~/.atom_
-directory, which contains CoffeeScript-style JSON:
+directory, which contains [CoffeeScript-style JSON][CSON] (CSON):
 
 ```coffee
 'core':
@@ -174,3 +174,4 @@ This file can also be named _styles.css_ and contain CSS.
 [creating-a-package]: creating-a-package.md
 [create-theme]: creating-a-theme.md
 [LESS]: http://www.lesscss.org
+[CSON]: https://github.com/bevry/cson

--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -1,7 +1,7 @@
 # Customizing Atom
 
 To change a setting, configure a theme, or install a package just open the
-Settings view in the current window by pressing `cmd+,`.
+Settings view in the current window by pressing `cmd-,`.
 
 ## Changing The Theme
 


### PR DESCRIPTION
A few tweaks to the docs:
- fixed one instance where "+" was used instead of "-" in a keybord shortcut
- added links to CSON and CoffeeScript to the docs (a link to LESS was already there)
- removed a public link to the apm repository which is currently private
- added a short init.coffee example, to go with the [short styles.less example](https://atom.io/docs/latest/customizing-atom#stylesless)
