### PR TITLE
Fix "check for update" crash

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -7,6 +7,7 @@
       { label: "VERSION", enabled: false }
       { label: "Restart and Install Update", command: 'application:install-update', visible: false}
       { label: "Check for Update", command: 'application:check-for-update', visible: false}
+      { label: "Downloading Update", command: 'application:check-for-update', enabled: false, visible: false}
       { type: 'separator' }
       { label: 'Preferences...', command: 'application:show-settings' }
       { label: 'Open Your Config', command: 'application:open-your-config' }

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -74,6 +74,11 @@ class ApplicationMenu
     if (item = _.find(@flattenMenuItems(@menu), (i) -> i.label == 'Restart and Install Update'))
       item.visible = visible
 
+  # Toggles Downloading Update Item
+  showDownloadingUpdateItem: (visible=true) ->
+    if (item = _.find(@flattenMenuItems(@menu), (i) -> i.label == 'Downloading Update'))
+      item.visible = visible
+
   # Toggles Check For Update Item
   showCheckForUpdateItem: (visible=true) ->
     if (item = _.find(@flattenMenuItems(@menu), (i) -> i.label == 'Check for Update'))

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -71,16 +71,28 @@ class ApplicationMenu
 
   # Toggles Install Update Item
   showInstallUpdateItem: (visible=true) ->
+    if visible
+      @showDownloadingUpdateItem(false)
+      @showCheckForUpdateItem(false)
+
     if (item = _.find(@flattenMenuItems(@menu), (i) -> i.label == 'Restart and Install Update'))
       item.visible = visible
 
   # Toggles Downloading Update Item
   showDownloadingUpdateItem: (visible=true) ->
+    if visible
+      @showInstallUpdateItem(false)
+      @showCheckForUpdateItem(false)
+
     if (item = _.find(@flattenMenuItems(@menu), (i) -> i.label == 'Downloading Update'))
       item.visible = visible
 
   # Toggles Check For Update Item
   showCheckForUpdateItem: (visible=true) ->
+    if visible
+      @showDownloadingUpdateItem(false)
+      @showInstallUpdateItem(false)
+
     if (item = _.find(@flattenMenuItems(@menu), (i) -> i.label == 'Check for Update'))
       item.visible = visible
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -155,16 +155,12 @@ class AtomApplication
     setTimeout((-> autoUpdater.checkForUpdates()), 5000)
 
   checkForUpdate: ->
-    removeListeners = =>
-      autoUpdater.removeListener 'update-not-available', @onUpdateNotAvailable
-      autoUpdater.removeListener 'error', @onUpdateError
-
     @onUpdateNotAvailable ?= =>
-      removeListeners()
+      autoUpdater.removeListener 'error', @onUpdateError
       dialog.showMessageBox type: 'info', buttons: ['OK'], message: 'No update available.', detail: "Version #{@version} is the latest version."
 
     @onUpdateError ?= (event, message) =>
-      removeListeners()
+      autoUpdater.removeListener 'update-not-available', @onUpdateNotAvailable
       dialog.showMessageBox type: 'warning', buttons: ['OK'], message: 'There was an error checking for updates.', detail: message
 
     autoUpdater.on 'update-not-available', @onUpdateNotAvailable

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -133,20 +133,29 @@ class AtomApplication
     autoUpdater.setFeedUrl "https://atom.io/api/updates?version=#{@version}"
 
     autoUpdater.on 'checking-for-update', =>
+      @applicationMenu.showDownloadingUpdateItem(false)
       @applicationMenu.showInstallUpdateItem(false)
       @applicationMenu.showCheckForUpdateItem(false)
 
     autoUpdater.on 'update-not-available', =>
+      @applicationMenu.showDownloadingUpdateItem(false)
       @applicationMenu.showInstallUpdateItem(false)
       @applicationMenu.showCheckForUpdateItem(true)
 
+    autoUpdater.on 'update-available', =>
+      @applicationMenu.showDownloadingUpdateItem(true)
+      @applicationMenu.showInstallUpdateItem(false)
+      @applicationMenu.showCheckForUpdateItem(false)
+
     autoUpdater.on 'update-downloaded', (event, releaseNotes, releaseName, releaseDate, releaseURL) =>
       atomWindow.sendCommand('window:update-available', [releaseName, releaseNotes]) for atomWindow in @windows
+      @applicationMenu.showDownloadingUpdateItem(false)
       @applicationMenu.showInstallUpdateItem(true)
       @applicationMenu.showCheckForUpdateItem(false)
       @updateVersion = releaseName
 
     autoUpdater.on 'error', (event, message) =>
+      @applicationMenu.showDownloadingUpdateItem(false)
       @applicationMenu.showInstallUpdateItem(false)
       @applicationMenu.showCheckForUpdateItem(true)
 
@@ -155,13 +164,8 @@ class AtomApplication
 
   checkForUpdate: ->
     removeListeners = =>
-      autoUpdater.removeListener 'update-available', @onUpdateAvailable
       autoUpdater.removeListener 'update-not-available', @onUpdateNotAvailable
       autoUpdater.removeListener 'error', @onUpdateError
-
-    @onUpdateAvailable ?= =>
-      removeListeners()
-      dialog.showMessageBox type: 'info', buttons: ['OK'], message: 'Update available.', detail: 'A new update is being downloaded.'
 
     @onUpdateNotAvailable ?= =>
       removeListeners()
@@ -171,7 +175,6 @@ class AtomApplication
       removeListeners()
       dialog.showMessageBox type: 'warning', buttons: ['OK'], message: 'There was an error checking for updates.', detail: message
 
-    autoUpdater.on 'update-available', @onUpdateAvailable
     autoUpdater.on 'update-not-available', @onUpdateNotAvailable
     autoUpdater.on 'error', @onUpdateError
     @applicationMenu.showCheckForUpdateItem(false)

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -165,7 +165,6 @@ class AtomApplication
 
     autoUpdater.on 'update-not-available', @onUpdateNotAvailable
     autoUpdater.on 'error', @onUpdateError
-    @applicationMenu.showCheckForUpdateItem(false)
     autoUpdater.checkForUpdates()
 
   # Registers basic application commands, non-idempotent.

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -138,25 +138,17 @@ class AtomApplication
       @applicationMenu.showCheckForUpdateItem(false)
 
     autoUpdater.on 'update-not-available', =>
-      @applicationMenu.showDownloadingUpdateItem(false)
-      @applicationMenu.showInstallUpdateItem(false)
       @applicationMenu.showCheckForUpdateItem(true)
 
     autoUpdater.on 'update-available', =>
       @applicationMenu.showDownloadingUpdateItem(true)
-      @applicationMenu.showInstallUpdateItem(false)
-      @applicationMenu.showCheckForUpdateItem(false)
 
     autoUpdater.on 'update-downloaded', (event, releaseNotes, releaseName, releaseDate, releaseURL) =>
       atomWindow.sendCommand('window:update-available', [releaseName, releaseNotes]) for atomWindow in @windows
-      @applicationMenu.showDownloadingUpdateItem(false)
       @applicationMenu.showInstallUpdateItem(true)
-      @applicationMenu.showCheckForUpdateItem(false)
       @updateVersion = releaseName
 
     autoUpdater.on 'error', (event, message) =>
-      @applicationMenu.showDownloadingUpdateItem(false)
-      @applicationMenu.showInstallUpdateItem(false)
       @applicationMenu.showCheckForUpdateItem(true)
 
     # Check for update after Atom has fully started and the menus are created


### PR DESCRIPTION
Click "Check for update" was causing Atom to crash when the dialog appeared. I wasn't able to fix the dialog problem because it seems to be a deeper atom-shell issue. Instead I replace the "Check for Update" menu item with a "Downloading Update" menu item.
