### PR TITLE
Converts keystrokes with alpha chars using shift

### DIFF
--- a/spec/keymap-spec.coffee
+++ b/spec/keymap-spec.coffee
@@ -270,6 +270,14 @@ describe "Keymap", ->
       expect(result).toBe(false)
       expect(fooHandler).toHaveBeenCalled()
 
+    it "normalizes bindings that use an upper case alpha char without shift", ->
+      fooHandler = jasmine.createSpy('fooHandler')
+      fragment.on 'foo', fooHandler
+      keymap.bindKeys 'name', '*', 'ctrl-L': 'foo'
+      result = keymap.handleKeyEvent(keydownEvent('l', ctrlKey: true, altKey: false, shiftKey: true, target: fragment[0]))
+      expect(result).toBe(false)
+      expect(fooHandler).toHaveBeenCalled()
+
     it "normalizes the key patterns in the hash to put the modifiers in alphabetical order", ->
       fooHandler = jasmine.createSpy('fooHandler')
       fragment.on 'foo', fooHandler
@@ -322,7 +330,7 @@ describe "Keymap", ->
 
     describe "when shift is pressed when a non-modifer key", ->
       it "returns a string that identifies the key pressed", ->
-        expect(keymap.keystrokeStringForEvent(keydownEvent('A', shiftKey: true))).toBe 'A'
+        expect(keymap.keystrokeStringForEvent(keydownEvent('A', shiftKey: true))).toBe 'shift-A'
         expect(keymap.keystrokeStringForEvent(keydownEvent('{', shiftKey: true))).toBe '{'
         expect(keymap.keystrokeStringForEvent(keydownEvent('left', shiftKey: true))).toBe 'shift-left'
         expect(keymap.keystrokeStringForEvent(keydownEvent('Left', shiftKey: true))).toBe 'shift-left'

--- a/spec/keymap-spec.coffee
+++ b/spec/keymap-spec.coffee
@@ -254,7 +254,7 @@ describe "Keymap", ->
         it "favors the more specific complete match", ->
 
   describe ".bindKeys(name, selector, bindings)", ->
-    it "normalizes bindings that use shift with lower case alpha chars", ->
+    it "normalizes bindings that use shift with lower case alpha char", ->
       fooHandler = jasmine.createSpy('fooHandler')
       fragment.on 'foo', fooHandler
       keymap.bindKeys 'name', '*', 'ctrl-shift-l': 'foo'
@@ -262,7 +262,7 @@ describe "Keymap", ->
       expect(result).toBe(false)
       expect(fooHandler).toHaveBeenCalled()
 
-    it "normalizes bindings that use shift with upper case alpha chars", ->
+    it "normalizes bindings that use shift with upper case alpha char", ->
       fooHandler = jasmine.createSpy('fooHandler')
       fragment.on 'foo', fooHandler
       keymap.bindKeys 'name', '*', 'ctrl-shift-L': 'foo'

--- a/spec/keymap-spec.coffee
+++ b/spec/keymap-spec.coffee
@@ -254,6 +254,22 @@ describe "Keymap", ->
         it "favors the more specific complete match", ->
 
   describe ".bindKeys(name, selector, bindings)", ->
+    it "normalizes bindings that use shift with lower case alpha chars", ->
+      fooHandler = jasmine.createSpy('fooHandler')
+      fragment.on 'foo', fooHandler
+      keymap.bindKeys 'name', '*', 'ctrl-shift-l': 'foo'
+      result = keymap.handleKeyEvent(keydownEvent('l', ctrlKey: true, altKey: false, shiftKey: true, target: fragment[0]))
+      expect(result).toBe(false)
+      expect(fooHandler).toHaveBeenCalled()
+
+    it "normalizes bindings that use shift with upper case alpha chars", ->
+      fooHandler = jasmine.createSpy('fooHandler')
+      fragment.on 'foo', fooHandler
+      keymap.bindKeys 'name', '*', 'ctrl-shift-L': 'foo'
+      result = keymap.handleKeyEvent(keydownEvent('l', ctrlKey: true, altKey: false, shiftKey: true, target: fragment[0]))
+      expect(result).toBe(false)
+      expect(fooHandler).toHaveBeenCalled()
+
     it "normalizes the key patterns in the hash to put the modifiers in alphabetical order", ->
       fooHandler = jasmine.createSpy('fooHandler')
       fragment.on 'foo', fooHandler

--- a/src/key-binding.coffee
+++ b/src/key-binding.coffee
@@ -23,9 +23,9 @@ class KeyBinding
       modifiers.sort()
       key = _.last(keys)
 
-      # Uppercase alpha chars if the shift modifer is pressed
-      if 'shift' in modifiers and /^[a-z]$/i.test(key)
-        modifiers = _.without(modifiers, 'shift')
+      # Add the shift modifier if the key is an uppercased alpha char
+      if /^[A-Z]$/.test(key) or 'shift' in modifiers
+        modifiers.push 'shift' unless 'shift' in modifiers
         key = key.toUpperCase()
       [modifiers..., key].join('-')
 

--- a/src/key-binding.coffee
+++ b/src/key-binding.coffee
@@ -23,10 +23,9 @@ class KeyBinding
       modifiers.sort()
       key = _.last(keys)
 
-      # Add the shift modifier if the key is an uppercased alpha char
-      if /^[A-Z]$/.test(key) or 'shift' in modifiers
-        modifiers.push 'shift' unless 'shift' in modifiers
-        key = key.toUpperCase()
+      modifiers.push 'shift' if /^[A-Z]$/.test(key) and 'shift' not in modifiers
+      key = key.toUpperCase() if /^[a-z]$/.test(key) and 'shift' in modifiers
+
       [modifiers..., key].join('-')
 
     normalizedKeystroke.join(' ')

--- a/src/key-binding.coffee
+++ b/src/key-binding.coffee
@@ -21,7 +21,14 @@ class KeyBinding
       keys = @parseKeystroke(keystroke)
       modifiers = keys[0...-1]
       modifiers.sort()
-      [modifiers..., _.last(keys)].join('-')
+      key = _.last(keys)
+
+      # Uppercase alpha chars if the shift modifer is pressed
+      if 'shift' in modifiers and /^[a-z]$/i.test(key)
+        modifiers = _.without(modifiers, 'shift')
+        key = key.toUpperCase()
+      [modifiers..., key].join('-')
+
     normalizedKeystroke.join(' ')
 
   @parseKeystroke: (keystroke) ->

--- a/src/keymap.coffee
+++ b/src/keymap.coffee
@@ -99,10 +99,12 @@ class Keymap
       modifiers.push 'cmd'
     if event.ctrlKey and key not in Modifiers
       modifiers.push 'ctrl'
-
     if event.shiftKey and key not in Modifiers
-      isNamedKey = key.length > 1
-      modifiers.push 'shift' if isNamedKey
+      # Don't push the shift modifier on single letter non-alpha keys (e.g. { or ')
+      modifiers.push 'shift' unless /^[^a-z]$/i.test(key)
+
+    if 'shift' in modifiers and /^[a-z]$/i.test(key)
+      key = key.toUpperCase()
     else
       key = key.toLowerCase()
 


### PR DESCRIPTION
Currently, keystrokes that use shift and an alpha char aren't handled correctly. For example, if you put...

``` coffeescript
'.editor':
  'cmd-shift-u': 'editor:select-line'
```

...into your keymap file it wouldn't trigger, but `cmd-U` would. This pull normalizes all keystrokes that use alpha chars and the shift key so they match the pattern `modifier-capitalLetter`
