### PR TITLE
Remove apm from node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "markdown-preview": "0.44.0",
     "metrics": "0.30.0",
     "open-on-github": "0.23.0",
-    "package-generator": "0.29.0",
+    "package-generator": "0.30.0",
     "release-notes": "0.26.0",
     "settings-view": "0.88.0",
     "snippets": "0.33.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "open-on-github": "0.23.0",
     "package-generator": "0.30.0",
     "release-notes": "0.26.0",
-    "settings-view": "0.88.0",
+    "settings-view": "0.89.0",
     "snippets": "0.33.0",
     "spell-check": "0.26.0",
     "status-bar": "0.35.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "tabs": "0.27.0",
     "timecop": "0.17.0",
     "tree-view": "0.74.0",
-    "update-package-dependencies": "0.4.0",
+    "update-package-dependencies": "0.5.0",
     "welcome": "0.11.0",
     "whitespace": "0.16.0",
     "wrap-guide": "0.16.0",

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -36,8 +36,6 @@ var commands = [
   {command: npmCommand + 'install --quiet', options: {cwd: path.resolve(__dirname, '..', 'build'), ignoreStdout: true}},
   {command: npmCommand + 'install --quiet', options: {cwd: apmVendorPath, ignoreStdout: true}},
   {command: npmCommand + 'install --quiet ' + apmVendorPath, options: {cwd: apmInstallPath, ignoreStdout: true}},
-  {command: npmCommand + 'install --quiet ' + apmVendorPath, options: {ignoreStdout: true}},
-  {command: '../../' + apmPath + ' rebuild', options: {cwd: path.resolve('node_modules', 'atom-package-manager'), ignoreStdout: true}},
   echoNewLine,
   apmPath + ' clean ' + apmFlags,
   apmPath + ' install --quiet ' + apmFlags,

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -41,7 +41,7 @@ class PackageManager
 
   # Public: Get the path to the apm command
   getApmPath: ->
-    @apmPath ?= require.resolve('atom-package-manager/lib/cli')
+    @apmPath ?= path.resolve(__dirname, '..', 'apm', 'node_modules', 'atom-package-manager', 'bin', 'apm')
 
   # Public: Get the paths being used to look for packages.
   #


### PR DESCRIPTION
Now that `apm` ships node we no longer need to copies of it distributed with atom, one for the CLI and one when spawned from the settings view, package generator, etc.

This breaks backwards compatibility since `atom.packages.getApmPath()` now requires spawning it using `BufferedProcess` instead of a `BufferedNodeProcess`.
