### PR TITLE
Upgrade to atom-shell@0.10.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "All Rights Reserved",
-  "atomShellVersion": "0.10.4",
+  "atomShellVersion": "0.10.5",
   "dependencies": {
     "async": "0.2.6",
     "bootstrap": "git://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",


### PR DESCRIPTION
Atom-Shell Changelog:
- Fix crashes caused by dialog API.
- Disable undocked devtools.
- Fix web security.
- Disable node integration in iframes by default.
- Add `activate-with-no-open-windows` event for app.
- Provide debug symbols on Linux.
