### PR TITLE
Fix updater bug

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -30,7 +30,6 @@ socketPath =
 module.exports =
 class AtomApplication
   _.extend @prototype, EventEmitter.prototype
-  updateVersion: null
 
   # Public: The entry point into the Atom application.
   @open: (options) ->
@@ -144,9 +143,8 @@ class AtomApplication
       @applicationMenu.showDownloadingUpdateItem(true)
 
     autoUpdater.on 'update-downloaded', (event, releaseNotes, releaseVersion, releaseDate, releaseURL) =>
-      @applicationMenu.showInstallUpdateItem(true)
-      @updateVersion = releaseVersion
       atomWindow.sendCommand('window:update-available', [releaseVersion, releaseNotes]) for atomWindow in @windows
+      @applicationMenu.showInstallUpdateItem(true)
 
     autoUpdater.on 'error', (event, message) =>
       @applicationMenu.showCheckForUpdateItem(true)
@@ -417,8 +415,3 @@ class AtomApplication
   promptForPath: ({devMode}={}) ->
     dialog.showOpenDialog title: 'Open', properties: ['openFile', 'openDirectory', 'multiSelections', 'createDirectory'], (pathsToOpen) =>
       @openPaths({pathsToOpen, devMode})
-
-  # Public: If an update is available, it returns the new version string
-  # otherwise it returns null.
-  getUpdateVersion: ->
-    @updateVersion

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -143,10 +143,10 @@ class AtomApplication
     autoUpdater.on 'update-available', =>
       @applicationMenu.showDownloadingUpdateItem(true)
 
-    autoUpdater.on 'update-downloaded', (event, releaseNotes, releaseName, releaseDate, releaseURL) =>
-      atomWindow.sendCommand('window:update-available', [releaseName, releaseNotes]) for atomWindow in @windows
+    autoUpdater.on 'update-downloaded', (event, releaseNotes, releaseVersion, releaseDate, releaseURL) =>
       @applicationMenu.showInstallUpdateItem(true)
-      @updateVersion = releaseName
+      @updateVersion = releaseVersion
+      atomWindow.sendCommand('window:update-available', [releaseVersion, releaseNotes]) for atomWindow in @windows
 
     autoUpdater.on 'error', (event, message) =>
       @applicationMenu.showCheckForUpdateItem(true)

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -129,6 +129,8 @@ class AtomApplication
 
   # Enable updates unless running from a local build of Atom.
   setupAutoUpdater: ->
+    return if /\w{7}/.test(@version) # Only released versions should check for updates.
+
     autoUpdater.setFeedUrl "https://atom.io/api/updates?version=#{@version}"
 
     autoUpdater.on 'checking-for-update', =>

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -121,7 +121,6 @@ class AtomWindow
     if @loaded
       @focus()
       @sendCommand('window:open-path', {pathToOpen, initialLine})
-      @sendCommand('window:update-available', global.atomApplication.getUpdateVersion()) if global.atomApplication.getUpdateVersion()
     else
       @browserWindow.once 'window:loaded', => @openPath(pathToOpen, initialLine)
 


### PR DESCRIPTION
The [release-notes](https://github.com/atom/release-notes) package had a bug where people would see `undefined` for the release notes. This is because when a new window opened after Atom was updated the release notes were unavailable. 

In the future we can store the release notes, but since anything related to updates and the browser process takes a lot of time to fix I'm holding off on that improvement because it seems like a low priority.
