### PR TITLE
Resolve symbolic links opened with atom cli

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -31,10 +31,10 @@ while getopts ":wtfvhs-:" opt; do
 done
 
 if [ $EXPECT_OUTPUT ]; then
-  $ATOM_BINARY --executed-from="$(pwd)" --pid=$$ $@
+  $ATOM_BINARY --executed-from="$(pwd -P)" --pid=$$ $@
   exit $?
 else
-  open -a $ATOM_PATH -n --args --executed-from="$(pwd)" --pid=$$ $@
+  open -a $ATOM_PATH -n --args --executed-from="$(pwd -P)" --pid=$$ $@
 fi
 
 # Used to exit process when atom is used as $EDITOR


### PR DESCRIPTION
I'm jotting this down so I remember it. A user [reported](http://discuss.atom.io/t/symbolic-link-directory-git-highlight-issue-and-other-issue-on-atom-shell-command/3324) there were some git highlighting issues when a symlinked directory was opened via the cli. Using `pwd -P` instead of `pwd` fixes this problem because it resolves the `executed-from` argument.

A possible better solution would be to use fs.readlink from main.coffee or atom-application.coffee.
