### PR TITLE
Safe CSON during build

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -17,7 +17,7 @@
     "grunt-contrib-csslint": "~0.1.2",
     "grunt-contrib-coffee": "~0.9.0",
     "grunt-contrib-less": "~0.8.0",
-    "grunt-cson": "0.6.0",
+    "grunt-cson": "0.8.0",
     "grunt-download-atom-shell": "git+https://atom-bot:467bac80a0017b96fb5be5cfc686f5e0cc607b10@github.com/atom/grunt-download-atom-shell#v0.6.0",
     "grunt-lesslint": "0.13.0",
     "grunt-markdown": "~0.4.0",


### PR DESCRIPTION
A [cson parser](https://github.com/groupon/cson-safe) now exists so no more `CoffeeScript.eval` to "compile" CSON file.

This updates the `grunt-cson` version to one that uses the new parser.
