### PR TITLE
Don't assume Atom is in /Applications when using the CLI

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -1,11 +1,17 @@
 #!/bin/sh
-ATOM_PATH=${ATOM_PATH-/Applications/Atom.app}
-ATOM_BINARY=$ATOM_PATH/Contents/MacOS/Atom
+ATOM_APP_NAME=Atom.app
 
-if [ ! -d $ATOM_PATH ]; then sleep 5; fi # Wait for Atom to reappear, Sparkle may be replacing it.
+if [ -z "$ATOM_PATH" ]; then
+  for i in /Applications ~/Applications /Applications/Utilities ~/Applications/Utilities/ ~/Downloads; do
+    if [ -x "$i/$ATOM_APP_NAME" ]; then
+      ATOM_PATH="$i"
+      break
+    fi
+  done
+fi
 
-if [ ! -d $ATOM_PATH ]; then
-  echo "Atom application not found at '$ATOM_PATH'" >&2
+if [ -z "$ATOM_PATH" ]; then
+  echo "Cannot locate Atom.app, it is usually located in /Applications. Set the ATOM_PATH environment variable to the directory containing Atom.app."
   exit 1
 fi
 
@@ -31,10 +37,11 @@ while getopts ":wtfvhs-:" opt; do
 done
 
 if [ $EXPECT_OUTPUT ]; then
-  $ATOM_BINARY --executed-from="$(pwd)" --pid=$$ "$@"
+  "$ATOM_PATH/$ATOM_APP_NAME/Contents/MacOS/Atom" --executed-from="$(pwd)" --pid=$$ "$@"
   exit $?
 else
-  open -a $ATOM_PATH -n --args --executed-from="$(pwd)" --pid=$$ "$@"
+  echo "$ATOM_PATH/$ATOM_APP_NAME"
+  open -a "$ATOM_PATH/$ATOM_APP_NAME" -n --args --executed-from="$(pwd)" --pid=$$ "$@"
 fi
 
 # Used to exit process when atom is used as $EDITOR

--- a/atom.sh
+++ b/atom.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
-ATOM_PATH=${ATOM_PATH:-/Applications}
+ATOM_PATH=${ATOM_PATH:-/Applications} # Set ATOM_PATH unless it is already set
 ATOM_APP_NAME=Atom.app
 
+# If ATOM_PATH isn't a executable file, use spotlight to search for Atom
 if [ ! -x "$ATOM_PATH/$ATOM_APP_NAME" ]; then
   ATOM_PATH=$(mdfind "kMDItemCFBundleIdentifier == 'com.github.atom'" | head -1 | xargs dirname)
 fi
 
+# Exit if Atom can't be found
 if [ -z "$ATOM_PATH" ]; then
   echo "Cannot locate Atom.app, it is usually located in /Applications. Set the ATOM_PATH environment variable to the directory containing Atom.app."
   exit 1
@@ -40,12 +42,13 @@ else
   open -a "$ATOM_PATH/$ATOM_APP_NAME" -n --args --executed-from="$(pwd)" --pid=$$ "$@"
 fi
 
-# Used to exit process when atom is used as $EDITOR
+# Exits this process when Atom is used as $EDITOR
 on_die() {
   exit 0
 }
 trap 'on_die' SIGQUIT SIGTERM
 
+# If the wait flag is set, don't exit this process until Atom tells it to.
 if [ $WAIT ]; then
   while true; do
     sleep 1

--- a/atom.sh
+++ b/atom.sh
@@ -2,7 +2,7 @@
 ATOM_APP_NAME=Atom.app
 
 if [ -z "$ATOM_PATH" ]; then
-  for i in /Applications ~/Applications /Applications/Utilities ~/Applications/Utilities/ ~/Downloads; do
+  for i in /Applications ~/Applications /Applications/Utilities ~/Applications/Utilities/ ~/Downloads ~/Desktop; do
     if [ -x "$i/$ATOM_APP_NAME" ]; then
       ATOM_PATH="$i"
       break

--- a/atom.sh
+++ b/atom.sh
@@ -1,13 +1,9 @@
 #!/bin/sh
+ATOM_PATH=${ATOM_PATH:-/Applications}
 ATOM_APP_NAME=Atom.app
 
-if [ -z "$ATOM_PATH" ]; then
-  for i in /Applications ~/Applications /Applications/Utilities ~/Applications/Utilities/ ~/Downloads ~/Desktop; do
-    if [ -x "$i/$ATOM_APP_NAME" ]; then
-      ATOM_PATH="$i"
-      break
-    fi
-  done
+if [ ! -x "$ATOM_PATH/$ATOM_APP_NAME" ]; then
+  ATOM_PATH=$(mdfind "kMDItemCFBundleIdentifier == 'com.github.atom'" | head -1 | xargs dirname)
 fi
 
 if [ -z "$ATOM_PATH" ]; then


### PR DESCRIPTION
It now looks in /Applications, ~/Applications, /Applications/Utilities, ~/Applications/Utilities/, and ~/Downloads

Sorta closes #1595
