### PR TITLE
Don't show error messages for version and help cli options

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -20,7 +20,11 @@ while getopts ":wtfvhs-:" opt; do
         wait)
           WAIT=1
           ;;
-        help|version|foreground|test)
+        help|version)
+          REDIRECT_STDERR=1
+          EXPECT_OUTPUT=1
+          ;;
+        foreground|test)
           EXPECT_OUTPUT=1
           ;;
       esac
@@ -28,11 +32,19 @@ while getopts ":wtfvhs-:" opt; do
     w)
       WAIT=1
       ;;
-    h|v|f|t)
+    h|v)
+      REDIRECT_STDERR=1
+      EXPECT_OUTPUT=1
+      ;;
+    f|t)
       EXPECT_OUTPUT=1
       ;;
   esac
 done
+
+if [ $REDIRECT_STDERR ]; then
+  exec 2> /dev/null
+fi
 
 if [ $EXPECT_OUTPUT ]; then
   "$ATOM_PATH/$ATOM_APP_NAME/Contents/MacOS/Atom" --executed-from="$(pwd)" --pid=$$ "$@"

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -77,7 +77,7 @@ parseCommandLine = ->
   options.alias('h', 'help').boolean('h').describe('h', 'Print this usage message.')
   options.alias('l', 'log-file').string('l').describe('l', 'Log all output to file.')
   options.alias('n', 'new-window').boolean('n').describe('n', 'Open a new window.')
-  options.alias('s', 'spec-directory').string('s').describe('s', 'Set the directory from which specs are loaded (default: Atom\'s spec directory).')
+  options.alias('s', 'spec-directory').string('s').describe('s', 'Set the spec directory (default: Atom\'s spec directory).')
   options.alias('t', 'test').boolean('t').describe('t', 'Run the specified specs and exit with error code on failures.')
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')
   options.alias('w', 'wait').boolean('w').describe('w', 'Wait for window to be closed before returning.')


### PR DESCRIPTION
This redirects stderr to /dev/null when the --help or --version arguments are used. It also shortens the help text so it fits within 80 chars.
