### PR TITLE
Enable automatic graphics switching

### DIFF
--- a/resources/mac/atom-Info.plist
+++ b/resources/mac/atom-Info.plist
@@ -32,6 +32,8 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>AtomApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 	<key>SUPublicDSAKeyFile</key>
 	<string>speakeasy.pem</string>
 	<key>SUScheduledCheckInterval</key>


### PR DESCRIPTION
Atom currently forces my Macbook Pro to use the discrete graphics card 100% of the time. This has a non-insubstantial impact on battery life, and probably isn't necessary for an editor.

This PR allows the app to use the integrated GPU, as per [Apple's docs](https://developer.apple.com/library/mac/qa/qa1734/_index.html)

Chromium itself also [sets this now](https://chromium.googlesource.com/chromium/chromium/+/trunk/chrome/app/app-Info.plist), so I can't see why we wouldn't.
