### PR TITLE
Ignore leading whitespace when auto-indenting a newline

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2529,6 +2529,16 @@ describe "Editor", ->
             expect(editor.indentationForBufferRow(1)).toBe 1
             expect(editor.indentationForBufferRow(2)).toBe 1
 
+          describe "when the cursor is before whitespace", ->
+            it "indents that whitespace properly in the next line", ->
+              editor.setText("  var sort = function() {}")
+              editor.setCursorScreenPosition([0, 23])
+              editor.insertNewline()
+
+              expect(buffer.lineForRow(0)).toBe '  var sort = function()'
+              expect(buffer.lineForRow(1)).toBe '   {}'
+              expect(editor.getCursorScreenPosition()).toEqual [1, 2]
+
         describe "when inserted text matches a decrease indent pattern", ->
           describe "when the preceding line matches an increase indent pattern", ->
             it "decreases the indentation to match that of the preceding line", ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2506,7 +2506,7 @@ describe "Editor", ->
 
           describe "when the line preceding the newline does't add a level of indentation", ->
             it "indents the new line to the same level a as the preceding line", ->
-              editor.setCursorBufferPosition([5, 13])
+              editor.setCursorBufferPosition([5, 14])
               editor.insertText('\n')
               expect(editor.indentationForBufferRow(6)).toBe editor.indentationForBufferRow(5)
 

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2530,7 +2530,7 @@ describe "Editor", ->
             expect(editor.indentationForBufferRow(2)).toBe 1
 
           describe "when the cursor is before whitespace", ->
-            it "indents that whitespace properly in the next line", ->
+            it "indents the whitespace properly on the new line", ->
               editor.setText("  var sort = function() {}")
               editor.setCursorScreenPosition([0, 23])
               editor.insertNewline()

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2530,7 +2530,7 @@ describe "Editor", ->
             expect(editor.indentationForBufferRow(2)).toBe 1
 
           describe "when the cursor is before whitespace", ->
-            it "indents the whitespace properly on the new line", ->
+            it "retains the whitespace following the cursor on the new line", ->
               editor.setText("  var sort = function() {}")
               editor.setCursorScreenPosition([0, 23])
               editor.insertNewline()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -374,8 +374,8 @@ class Editor extends Model
   # bufferRow - A {Number} indicating the buffer row.
   # newLevel - A {Number} indicating the new indentation level.
   # options - An {Object} with the following keys:
-  #   :preserveLeadingWhitespace - true to preserve any whitespace already on
-  #                                the line (default: false).
+  #   :preserveLeadingWhitespace - true to preserve any whitespace already at
+  #                                the beginning of the line (default: false).
   setIndentationForBufferRow: (bufferRow, newLevel, {preserveLeadingWhitespace}={}) ->
     if preserveLeadingWhitespace
       endColumn = 0

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -374,10 +374,10 @@ class Editor extends Model
   # bufferRow - A {Number} indicating the buffer row.
   # newLevel - A {Number} indicating the new indentation level.
   # options - An {Object} with the following keys:
-  #   :ignoreLeadingWhitespace - true to not replace any of the leading
-  #                              whitespace already on the line (default: false)
-  setIndentationForBufferRow: (bufferRow, newLevel, {ignoreLeadingWhitespace}={}) ->
-    if ignoreLeadingWhitespace
+  #   :preserveLeadingWhitespace - true to preserve any whitespace already on
+  #                                the line (default: false).
+  setIndentationForBufferRow: (bufferRow, newLevel, {preserveLeadingWhitespace}={}) ->
+    if preserveLeadingWhitespace
       endColumn = 0
     else
       endColumn = @lineForBufferRow(bufferRow).match(/^\s*/)[0].length

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -373,10 +373,16 @@ class Editor extends Model
   #
   # bufferRow - A {Number} indicating the buffer row.
   # newLevel - A {Number} indicating the new indentation level.
-  setIndentationForBufferRow: (bufferRow, newLevel) ->
-    currentIndentLength = @lineForBufferRow(bufferRow).match(/^\s*/)[0].length
+  # options - An {Object} with the following keys:
+  #   :ignoreLeadingWhitespace - true to not replace any of the leading
+  #                              whitespace already on the line (default: false)
+  setIndentationForBufferRow: (bufferRow, newLevel, {ignoreLeadingWhitespace}={}) ->
+    if ignoreLeadingWhitespace
+      endColumn = 0
+    else
+      endColumn = @lineForBufferRow(bufferRow).match(/^\s*/)[0].length
     newIndentString = @buildIndentString(newLevel)
-    @buffer.change([[bufferRow, 0], [bufferRow, currentIndentLength]], newIndentString)
+    @buffer.change([[bufferRow, 0], [bufferRow, endColumn]], newIndentString)
 
   # Public: Get the indentation level of the given line of text.
   #

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -266,7 +266,7 @@ class LanguageMode
   # Given a buffer row, this indents it.
   #
   # bufferRow - The row {Number}.
-  # options - An options {Object} to pass to {Editor::setIndentationForBufferRow}.
+  # options - An options {Object} to pass through to {Editor::setIndentationForBufferRow}.
   autoIndentBufferRow: (bufferRow, options) ->
     indentLevel = @suggestedIndentForBufferRow(bufferRow)
     @editor.setIndentationForBufferRow(bufferRow, indentLevel, options)

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -265,10 +265,11 @@ class LanguageMode
 
   # Given a buffer row, this indents it.
   #
-  # bufferRow - The row {Number}
-  autoIndentBufferRow: (bufferRow) ->
+  # bufferRow - The row {Number}.
+  # options - An options {Object} to pass to {Editor::setIndentationForBufferRow}.
+  autoIndentBufferRow: (bufferRow, options) ->
     indentLevel = @suggestedIndentForBufferRow(bufferRow)
-    @editor.setIndentationForBufferRow(bufferRow, indentLevel)
+    @editor.setIndentationForBufferRow(bufferRow, indentLevel, options)
 
   # Given a buffer row, this decreases the indentation.
   #

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -301,7 +301,7 @@ class Selection
     if options.autoIndent
       @editor.autoIndentBufferRow(row) for row in newBufferRange.getRows()
     else if options.autoIndentNewline and text == '\n'
-      @editor.autoIndentBufferRow(newBufferRange.end.row)
+      @editor.autoIndentBufferRow(newBufferRange.end.row, ignoreLeadingWhitespace: true)
     else if options.autoDecreaseIndent and /\S/.test text
       @editor.autoDecreaseIndentForBufferRow(newBufferRange.start.row)
 

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -301,7 +301,7 @@ class Selection
     if options.autoIndent
       @editor.autoIndentBufferRow(row) for row in newBufferRange.getRows()
     else if options.autoIndentNewline and text == '\n'
-      @editor.autoIndentBufferRow(newBufferRange.end.row, ignoreLeadingWhitespace: true)
+      @editor.autoIndentBufferRow(newBufferRange.end.row, preserveLeadingWhitespace: true)
     else if options.autoDecreaseIndent and /\S/.test text
       @editor.autoDecreaseIndentForBufferRow(newBufferRange.start.row)
 


### PR DESCRIPTION
See atom/language-less#1 for more details.

When inserting a newline, don't remove leading whitespace already on the line when auto-indenting.
