### PR TITLE
Update editor properly when line height or char width change via a stylesheet

### DIFF
--- a/spec/editor-view-spec.coffee
+++ b/spec/editor-view-spec.coffee
@@ -2923,6 +2923,10 @@ describe "EditorView", ->
         expect(editorView.measureToColumn.callCount).toBe 0
 
   describe "when stylesheets are changed", ->
+    afterEach ->
+      atom.themes.removeStylesheet 'line-height'
+      atom.themes.removeStylesheet 'char-width'
+
     it "updates the editor if the line height or character width changes due to a stylesheet change", ->
       editorView.attachToDom()
       editor.setCursorScreenPosition([1, 3])

--- a/spec/editor-view-spec.coffee
+++ b/spec/editor-view-spec.coffee
@@ -2922,6 +2922,26 @@ describe "EditorView", ->
         editorView.pixelPositionForScreenPosition([1, 5])
         expect(editorView.measureToColumn.callCount).toBe 0
 
+  describe "when stylesheets are changed", ->
+    it "updates the editor if the line height or character width changes due to a stylesheet change", ->
+      editorView.attachToDom()
+      editor.setCursorScreenPosition([1, 3])
+      expect(editorView.pixelPositionForScreenPosition([1, 3])).toEqual {top: 20, left: 30}
+      expect(editorView.getCursorView().position()).toEqual {top: 20, left: 30}
+
+      atom.themes.applyStylesheet 'line-height', """
+        .editor { line-height: 2; }
+      """
+
+      expect(editorView.pixelPositionForScreenPosition([1, 3])).toEqual {top: 32, left: 30}
+      expect(editorView.getCursorView().position()).toEqual {top: 32, left: 30}
+
+      atom.themes.applyStylesheet 'char-width', """
+        .editor { letter-spacing: 2px; }
+      """
+      expect(editorView.pixelPositionForScreenPosition([1, 3])).toEqual {top: 32, left: 36}
+      expect(editorView.getCursorView().position()).toEqual {top: 32, left: 36}
+
   describe "when the editor contains hard tabs", ->
     it "correctly calculates the the position left for a column", ->
       editor.setText('\ttest')

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -170,8 +170,11 @@ describe "ThemeManager", ->
       expect($(document.body).css('font-weight')).not.toBe("bold")
       themeManager.requireStylesheet(cssPath)
       expect($(document.body).css('font-weight')).toBe("bold")
+
+      themeManager.on 'stylesheets-changed', stylesheetsChangedHandler = jasmine.createSpy("stylesheetsChangedHandler")
       themeManager.removeStylesheet(cssPath)
       expect($(document.body).css('font-weight')).not.toBe("bold")
+      expect(stylesheetsChangedHandler).toHaveBeenCalled()
 
   describe "base stylesheet loading", ->
     beforeEach ->
@@ -204,12 +207,15 @@ describe "ThemeManager", ->
       fs.writeFileSync(userStylesheetPath, 'body {border-style: dotted !important;}')
 
       spyOn(themeManager, 'getUserStylesheetPath').andReturn userStylesheetPath
+      themeManager.on 'stylesheets-changed', stylesheetsChangedHandler = jasmine.createSpy("stylesheetsChangedHandler")
 
       waitsForPromise ->
         themeManager.activateThemes()
 
       runs ->
         expect($(document.body).css('border-style')).toBe 'dotted'
+        expect(stylesheetsChangedHandler).toHaveBeenCalled()
+        stylesheetsChangedHandler.reset()
         spyOn(themeManager, 'loadUserStylesheet').andCallThrough()
         fs.writeFileSync(userStylesheetPath, 'body {border-style: dashed}')
 
@@ -218,6 +224,8 @@ describe "ThemeManager", ->
 
       runs ->
         expect($(document.body).css('border-style')).toBe 'dashed'
+        expect(stylesheetsChangedHandler).toHaveBeenCalled()
+        stylesheetsChangedHandler.reset()
         fs.removeSync(userStylesheetPath)
 
       waitsFor ->
@@ -225,6 +233,7 @@ describe "ThemeManager", ->
 
       runs ->
         expect($(document.body).css('border-style')).toBe 'none'
+        expect(stylesheetsChangedHandler).toHaveBeenCalled()
 
   describe "when a non-existent theme is present in the config", ->
     it "logs a warning but does not throw an exception (regression)", ->

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -419,6 +419,8 @@ class EditorView extends View
     @scrollView.on 'overflowchanged', =>
       updateWidthInChars() if @[0].classList.contains('soft-wrap')
 
+    @subscribe atom.themes, 'stylesheets-changed', => @recalculateDimensions()
+
   handleInputEvents: ->
     @on 'cursor:moved', =>
       return unless @isFocused
@@ -880,6 +882,16 @@ class EditorView extends View
     @charHeight = charRect.height
     fragment.remove()
     @setHeightInLines()
+
+  recalculateDimensions: ->
+    oldCharWidth = @charWidth
+    oldLineHeight = @lineHeight
+
+    @calculateDimensions()
+
+    unless @charWidth is oldCharWidth and @lineHeight is oldLineHeight
+      @clearCharacterWidthCache()
+      @requestDisplayUpdate()
 
   updateLayerDimensions: ->
     height = @lineHeight * @editor.getScreenLineCount()

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -191,6 +191,7 @@ class ThemeManager
   removeStylesheet: (stylesheetPath) ->
     fullPath = @resolveStylesheet(stylesheetPath) ? stylesheetPath
     @stylesheetElementForId(@stringToId(fullPath)).remove()
+    @emit 'stylesheets-changed'
 
   applyStylesheet: (path, text, ttype = 'bundled', htmlElement=$('html')) ->
     styleElement = @stylesheetElementForId(@stringToId(path), htmlElement)
@@ -201,3 +202,4 @@ class ThemeManager
         htmlElement.find("head style.#{ttype}:last").after "<style class='#{ttype}' id='#{@stringToId(path)}'>#{text}</style>"
       else
         htmlElement.find("head").append "<style class='#{ttype}' id='#{@stringToId(path)}'>#{text}</style>"
+    @emit 'stylesheets-changed'


### PR DESCRIPTION
This PR adds a `stylesheets-changed` event to `atom.themes`. In the next commit, the editor view subscribes to this event and recalculates `::lineHeight` and `::charWidth` whenever the stylesheets change. If either value changes, the `Editor.charWidthCache` is cleared and a display update is requested.

Fixes #354
