### PR TITLE
Support submodules in Git class

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fs-plus": ">=2.0.4 < 3.0",
     "fstream": "0.1.24",
     "fuzzaldrin": "~1.1",
-    "git-utils": "^1.1",
+    "git-utils": "^1.1.1",
     "guid": "0.0.10",
     "jasmine-tagged": ">=1.1.1 <2.0",
     "mkdirp": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fs-plus": ">=2.0.4 < 3.0",
     "fstream": "0.1.24",
     "fuzzaldrin": "~1.1",
-    "git-utils": "^1.0.1",
+    "git-utils": "^1.1",
     "guid": "0.0.10",
     "jasmine-tagged": ">=1.1.1 <2.0",
     "mkdirp": "0.3.5",

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -102,10 +102,10 @@ class Git
 
   # Returns the corresponding {Repository}
   getRepo: (path) ->
-    unless @repo?
+    if @repo?
+      @repo.submoduleForPath(path) ? @repo
+    else
       throw new Error("Repository has been destroyed")
-
-    @repo.submoduleForPath(path) ? @repo
 
   # Reread the index to update any values that have changed since the
   # last time the index was read.

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -223,7 +223,11 @@ class Git
   # Returns a {Boolean}.
   isSubmodule: (path) ->
     repo = @getRepo(path)
-    repo.isSubmodule(repo.relativize(path)) or @getRepo().isSubmodule(@relativize(path))
+    if repo.isSubmodule(repo.relativize(path))
+      true
+    else
+      # Check if the path is a working directory in a repo that isn't the root.
+      path is repo.getWorkingDirectory() and repo isnt @getRepo()
 
   # Public: Get the status of a directory in the repository's working directory.
   #

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -306,7 +306,7 @@ class Git
   getAheadBehindCount: (reference, path) ->
     @getRepo(path).getAheadBehindCount(reference)
 
-  # Public: Get the cache ahead/behind commit counts for the current branch's
+  # Public: Get the cached ahead/behind commit counts for the current branch's
   # upstream branch.
   #
   # path - An optional {String} path in the repository to get this information

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -258,10 +258,16 @@ class Git
     repo.getLineDiffs(repo.relativize(path), text, options)
 
   # Public: Returns the git configuration value specified by the key.
-  getConfigValue: (key) -> @getRepo().getConfigValue(key)
+  #
+  # path - An optional {String} path in the repository to get this information
+  #        for, only needed if the repository has submodules.
+  getConfigValue: (key, path) -> @getRepo(path).getConfigValue(key)
 
   # Public: Returns the origin url of the repository.
-  getOriginUrl: -> @getConfigValue('remote.origin.url')
+  #
+  # path - An optional {String} path in the repository to get this information
+  #        for, only needed if the repository has submodules.
+  getOriginUrl: (path) -> @getConfigValue('remote.origin.url', path)
 
   # Public: Returns the upstream branch for the current HEAD, or null if there
   # is no upstream branch for the current HEAD.
@@ -274,17 +280,22 @@ class Git
 
   # Public: Returns the current SHA for the given reference.
   #
+  # reference - The {String} reference to get the target of.
   # path - An optional {String} path in the repo to get the reference target
   #        for. Only needed if the repository contains submodules.
-  getReferenceTarget: (reference) -> @getRepo().getReferenceTarget(reference)
+  getReferenceTarget: (reference, path) ->
+    @getRepo(path).getReferenceTarget(reference)
 
   # Public: Gets all the local and remote references.
+  #
+  # path - An optional {String} path in the repository to get this information
+  #        for, only needed if the repository has submodules.
   #
   # Returns an {Object} with the following keys:
   #  :heads - An {Array} of head reference names.
   #  :remotes - An {Array} of remote reference names.
   #  :tags - An {Array} of tag reference names.
-  getReferences: -> @getRepo().getReferences()
+  getReferences: (path) -> @getRepo(path).getReferences()
 
   # Public: Returns the number of commits behind the current branch is from the
   # its upstream remote branch.

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -212,14 +212,18 @@ class Git
   # Returns an {Object} with the following keys:
   #   :added - The {Number} of added lines.
   #   :deleted - The {Number} of deleted lines.
-  getDiffStats: (path) -> @getRepo().getDiffStats(@relativize(path))
+  getDiffStats: (path) ->
+    repo = @getRepo(path)
+    repo.getDiffStats(repo.relativize(path))
 
   # Public: Is the given path a submodule in the repository?
   #
   # path - The {String} path to check.
   #
   # Returns a {Boolean}.
-  isSubmodule: (path) -> @getRepo().isSubmodule(@relativize(path))
+  isSubmodule: (path) ->
+    repo = @getRepo(path)
+    repo.isSubmodule(repo.relativize(path))
 
   # Public: Get the status of a directory in the repository's working directory.
   #

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -223,7 +223,7 @@ class Git
   # Returns a {Boolean}.
   isSubmodule: (path) ->
     repo = @getRepo(path)
-    repo.isSubmodule(repo.relativize(path))
+    repo.isSubmodule(repo.relativize(path)) or @getRepo().isSubmodule(@relativize(path))
 
   # Public: Get the status of a directory in the repository's working directory.
   #

--- a/src/repository-status-handler.coffee
+++ b/src/repository-status-handler.coffee
@@ -6,8 +6,17 @@ module.exports = (repoPath) ->
   if repo?
     workingDirectoryPath = repo.getWorkingDirectory()
     statuses = {}
+
+    # Statuses in main repo
     for filePath, status of repo.getStatus()
       statuses[path.join(workingDirectoryPath, filePath)] = status
+
+    # Statuses in submodules
+    for submodulePath, submoduleRepo of repo.submodules
+      workingDirectoryPath = submoduleRepo.getWorkingDirectory()
+      for filePath, status of submoduleRepo.getStatus()
+        statuses[path.join(workingDirectoryPath, filePath)] = status
+
     upstream = repo.getAheadBehindCount()
     branch = repo.getHead()
     repo.release()

--- a/src/repository-status-handler.coffee
+++ b/src/repository-status-handler.coffee
@@ -18,8 +18,8 @@ module.exports = (repoPath) ->
     # Statuses in submodules
     for submodulePath, submoduleRepo of repo.submodules
       submodules[submodulePath] =
-        upstream: submoduleRepo.getAheadBehindCount()
         branch: submoduleRepo.getHead()
+        upstream: submoduleRepo.getAheadBehindCount()
 
       workingDirectoryPath = submoduleRepo.getWorkingDirectory()
       for filePath, status of submoduleRepo.getStatus()

--- a/src/repository-status-handler.coffee
+++ b/src/repository-status-handler.coffee
@@ -3,16 +3,24 @@ path = require 'path'
 
 module.exports = (repoPath) ->
   repo = Git.open(repoPath)
-  if repo?
-    workingDirectoryPath = repo.getWorkingDirectory()
-    statuses = {}
 
+  upstream = {}
+  statuses = {}
+  submodules = {}
+  branch = null
+
+  if repo?
     # Statuses in main repo
+    workingDirectoryPath = repo.getWorkingDirectory()
     for filePath, status of repo.getStatus()
       statuses[path.join(workingDirectoryPath, filePath)] = status
 
     # Statuses in submodules
     for submodulePath, submoduleRepo of repo.submodules
+      submodules[submodulePath] =
+        upstream: submoduleRepo.getAheadBehindCount()
+        branch: submoduleRepo.getHead()
+
       workingDirectoryPath = submoduleRepo.getWorkingDirectory()
       for filePath, status of submoduleRepo.getStatus()
         statuses[path.join(workingDirectoryPath, filePath)] = status
@@ -20,9 +28,5 @@ module.exports = (repoPath) ->
     upstream = repo.getAheadBehindCount()
     branch = repo.getHead()
     repo.release()
-  else
-    upstream = {}
-    statuses = {}
-    branch = null
 
-  {statuses, upstream, branch}
+  {statuses, upstream, branch, submodules}


### PR DESCRIPTION
Several repos have issues about things not working properly for files in submodules such as line diffs, status bar, checkout head revision, open on GitHub, etc.

This adds core API support for it by taking a `path` argument to the `Git` class methods that will use the right underlying repository if the parent repository has submodules in it.

This PR plus a few minor changes to the packages should get submodules working pretty well.

The underlying `git-utils` library now auto-opens submodules when the parent repository is opened.
### In action

A submodule inside a submodule with line diffs displaying:

![screen shot 2014-03-20 at 4 37 07 pm](https://f.cloud.github.com/assets/671378/2478842/9e677872-b088-11e3-8a24-90d06dcecfa3.png)
