### PR TITLE
Upgrade to atom-shell@0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "All Rights Reserved",
-  "atomShellVersion": "0.11.1",
+  "atomShellVersion": "0.11.2",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^0.10.0",


### PR DESCRIPTION
Changelog:
- gtk: Ask whether window is active from WM.
- mac: Build .dSYM for node modules.
- Close devtools completely instead of hiding it.
