### PR TITLE
Upgrade to atom-shell@0.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "All Rights Reserved",
-  "atomShellVersion": "0.11.2",
+  "atomShellVersion": "0.11.3",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^0.11.0",


### PR DESCRIPTION
Changelog:
- mac: Fix crash caused by closing window when showing context menu.
- Fix wrong unresponsive event caused by blocking js call.
