### PR TITLE
Fix case insensitive issues with Git

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "settings-view": "0.102.0",
     "snippets": "0.40.0",
     "spell-check": "0.31.0",
-    "status-bar": "0.37.0",
+    "status-bar": "0.38.0",
     "styleguide": "0.26.0",
     "symbols-view": "0.46.0",
     "tabs": "0.31.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "delegato": "1.x",
     "emissary": "^1.2",
     "first-mate": ">=1.4.2 <2.0",
-    "fs-plus": ">=2.0.4 < 3.0",
+    "fs-plus": "^2.2",
     "fstream": "0.1.24",
     "fuzzaldrin": "~1.1",
     "git-utils": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fs-plus": "^2.2",
     "fstream": "0.1.24",
     "fuzzaldrin": "~1.1",
-    "git-utils": "^1.1.1",
+    "git-utils": "^1.2",
     "guid": "0.0.10",
     "jasmine-tagged": ">=1.1.1 <2.0",
     "keytar": "1.x",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "nslog": "0.5.0",
     "oniguruma": "^1.0.4",
     "optimist": "0.4.0",
-    "pathwatcher": "^1.1",
+    "pathwatcher": "^1.1.1",
     "property-accessors": "1.x",
     "q": "^1.0.1",
     "random-words": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "symbols-view": "0.46.0",
     "tabs": "0.31.0",
     "timecop": "0.17.0",
-    "tree-view": "0.84.0",
+    "tree-view": "0.85.0",
     "update-package-dependencies": "0.6.0",
     "welcome": "0.12.0",
     "whitespace": "0.21.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "exception-reporting": "0.17.0",
     "feedback": "0.28.0",
     "find-and-replace": "0.93.0",
-    "fuzzy-finder": "0.42.0",
+    "fuzzy-finder": "0.43.0",
     "git-diff": "0.26.0",
     "go-to-line": "0.18.0",
     "grammar-selector": "0.23.0",

--- a/spec/git-spec.coffee
+++ b/spec/git-spec.coffee
@@ -177,6 +177,24 @@ describe "Git", ->
       status = repo.getPathStatus(filePath)
       expect(statusHandler.callCount).toBe 1
 
+  describe ".getDirectoryStatus(path)", ->
+    [directoryPath, filePath, originalPathText] = []
+
+    beforeEach ->
+      repo = new Git(path.join(__dirname, 'fixtures', 'git', 'working-dir'))
+      directoryPath = path.join(__dirname, 'fixtures', 'git', 'working-dir', 'dir')
+      filePath = require.resolve('./fixtures/git/working-dir/dir/b.txt')
+      originalPathText = fs.readFileSync(filePath, 'utf8')
+
+    afterEach ->
+      fs.writeFileSync(filePath, originalPathText)
+
+    it "gets the status based on the files inside the directory", ->
+      expect(repo.isStatusModified(repo.getDirectoryStatus(directoryPath))).toBe false
+      fs.writeFileSync(filePath, 'abc')
+      repo.getPathStatus(filePath)
+      expect(repo.isStatusModified(repo.getDirectoryStatus(directoryPath))).toBe true
+
   describe ".refreshStatus()", ->
     [newPath, modifiedPath, cleanPath, originalModifiedPathText] = []
 

--- a/spec/git-spec.coffee
+++ b/spec/git-spec.coffee
@@ -203,10 +203,9 @@ describe "Git", ->
         statusHandler.callCount > 0
 
       runs ->
-        statuses = repo.statuses
-        expect(statuses[cleanPath]).toBeUndefined()
-        expect(repo.isStatusNew(statuses[newPath])).toBeTruthy()
-        expect(repo.isStatusModified(statuses[modifiedPath])).toBeTruthy()
+        expect(repo.getCachedPathStatus(cleanPath)).toBeUndefined()
+        expect(repo.isStatusNew(repo.getCachedPathStatus(newPath))).toBeTruthy()
+        expect(repo.isStatusModified(repo.getCachedPathStatus(modifiedPath))).toBeTruthy()
 
   describe "buffer events", ->
     [originalContent, editor] = []

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -1,4 +1,4 @@
-{join} = require 'path'
+{join, sep} = require 'path'
 
 _ = require 'underscore-plus'
 {Emitter, Subscriber} = require 'emissary'
@@ -240,8 +240,7 @@ class Git
   # Returns a {Number} representing the status. This value can be passed to
   # {::isStatusModified} or {::isStatusNew} to get more information.
   getDirectoryStatus: (directoryPath)  ->
-    {sep} = require 'path'
-    directoryPath = "#{directoryPath}#{sep}"
+    directoryPath = "#{@relativize(directoryPath)}#{sep}"
     directoryStatus = 0
     for path, status of @statuses
       directoryStatus |= status if path.indexOf(directoryPath) is 0

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -330,7 +330,7 @@ class Git
   #
   # path - A {String} path in the repository, relative or absolute.
   #
-  # Returns a status {Number} or null if path is not in the cache.
+  # Returns a status {Number} or null if the path is not in the cache.
   getCachedPathStatus: (path) ->
     @statuses[@relativize(path)]
 

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -1,8 +1,11 @@
+{join} = require 'path'
+
 _ = require 'underscore-plus'
-fs = require 'fs-plus'
-Task = require './task'
 {Emitter, Subscriber} = require 'emissary'
+fs = require 'fs-plus'
 GitUtils = require 'git-utils'
+
+Task = require './task'
 
 # Public: Represents the underlying git operations performed by Atom.
 #
@@ -125,13 +128,14 @@ class Git
   # Returns a {Number} representing the status. This value can be passed to
   # {::isStatusModified} or {::isStatusNew} to get more information.
   getPathStatus: (path) ->
-    currentPathStatus = @statuses[path] ? 0
     repo = @getRepo(path)
+    relativePath = @relativize(path)
+    currentPathStatus = @statuses[relativePath] ? 0
     pathStatus = repo.getStatus(repo.relativize(path)) ? 0
     if pathStatus > 0
-      @statuses[path] = pathStatus
+      @statuses[relativePath] = pathStatus
     else
-      delete @statuses[path]
+      delete @statuses[relativePath]
     if currentPathStatus isnt pathStatus
       @emit 'status-changed', path, pathStatus
     pathStatus
@@ -321,6 +325,14 @@ class Git
   #   :behind - The {Number} of commits behind.
   getCachedUpstreamAheadBehindCount: (path) ->
     @getRepo(path).upstream ? @upstream
+
+  # Public: Get the cached status for the given path.
+  #
+  # path - A {String} path in the repository, relative or absolute.
+  #
+  # Returns a status {Number} or null if path is not in the cache.
+  getCachedPathStatus: (path) ->
+    @statuses[@relativize(path)]
 
   # Public: Returns true if the given branch exists.
   hasBranch: (branch) -> @getReferenceTarget("refs/heads/#{branch}")?

--- a/src/repository-status-handler.coffee
+++ b/src/repository-status-handler.coffee
@@ -23,7 +23,10 @@ module.exports = (repoPath) ->
 
       workingDirectoryPath = submoduleRepo.getWorkingDirectory()
       for filePath, status of submoduleRepo.getStatus()
-        statuses[repo.relativize(path.join(workingDirectoryPath, filePath))] = status
+        absolutePath = path.join(workingDirectoryPath, filePath)
+        # Make path relative to parent repository
+        relativePath = repo.relativize(absolutePath)
+        statuses[relativePath] = status
 
     upstream = repo.getAheadBehindCount()
     branch = repo.getHead()

--- a/src/repository-status-handler.coffee
+++ b/src/repository-status-handler.coffee
@@ -13,7 +13,7 @@ module.exports = (repoPath) ->
     # Statuses in main repo
     workingDirectoryPath = repo.getWorkingDirectory()
     for filePath, status of repo.getStatus()
-      statuses[path.join(workingDirectoryPath, filePath)] = status
+      statuses[filePath] = status
 
     # Statuses in submodules
     for submodulePath, submoduleRepo of repo.submodules
@@ -23,7 +23,7 @@ module.exports = (repoPath) ->
 
       workingDirectoryPath = submoduleRepo.getWorkingDirectory()
       for filePath, status of submoduleRepo.getStatus()
-        statuses[path.join(workingDirectoryPath, filePath)] = status
+        statuses[repo.relativize(path.join(workingDirectoryPath, filePath))] = status
 
     upstream = repo.getAheadBehindCount()
     branch = repo.getHead()


### PR DESCRIPTION
`atom.project.getPath()` can sometimes not equal `atom.project.getRepo().getWorkingDirectory()` since libgit2 always provides the path is the case on disk while `atom.project.getPath()` may differ in case to the path on disk on case insensitive filesystems.

Most of the fixes will be in underlying libraries to handle this but a few bundled packages need updating.
- [x] Update status-bar
- [x] Update tree-view
- [x] Update fuzzy-finder
### New Public APIs
- `Git::getCachedPathStatus(path)` - This replaces using `atom.project.getRepo().statuses` directly by adding an API that properly relativizes paths since statuses are now stored relative to the repository root to prevent casing problems.
