### PR TITLE
Refer to files containing key bindings as keymaps instead of the global

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "atomShellVersion": "0.11.4",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "^0.14.0-rc1",
+    "atom-keymap": "^0.14.0",
     "bootstrap": "git://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",
     "clear-cut": "0.4.0",
     "coffee-script": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "atomShellVersion": "0.11.4",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "^0.13.0",
+    "atom-keymap": "^0.14.0-rc1",
     "bootstrap": "git://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",
     "clear-cut": "0.4.0",
     "coffee-script": "1.7.0",

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -170,28 +170,28 @@ describe "the `atom` global", ->
               element2 = $$ -> @div class: 'test-2'
               element3 = $$ -> @div class: 'test-3'
 
-              expect(atom.keymap.keyBindingsForKeystrokeMatchingElement('ctrl-z', element1)).toHaveLength 0
-              expect(atom.keymap.keyBindingsForKeystrokeMatchingElement('ctrl-z', element2)).toHaveLength 0
-              expect(atom.keymap.keyBindingsForKeystrokeMatchingElement('ctrl-z', element3)).toHaveLength 0
+              expect(atom.keymaps.keyBindingsForKeystrokeMatchingElement('ctrl-z', element1)).toHaveLength 0
+              expect(atom.keymaps.keyBindingsForKeystrokeMatchingElement('ctrl-z', element2)).toHaveLength 0
+              expect(atom.keymaps.keyBindingsForKeystrokeMatchingElement('ctrl-z', element3)).toHaveLength 0
 
               atom.packages.activatePackage("package-with-keymaps")
 
-              expect(atom.keymap.keyBindingsForKeystrokeMatchingElement('ctrl-z', element1)[0].command).toBe "test-1"
-              expect(atom.keymap.keyBindingsForKeystrokeMatchingElement('ctrl-z', element2)[0].command).toBe "test-2"
-              expect(atom.keymap.keyBindingsForKeystrokeMatchingElement('ctrl-z', element3)).toHaveLength 0
+              expect(atom.keymaps.keyBindingsForKeystrokeMatchingElement('ctrl-z', element1)[0].command).toBe "test-1"
+              expect(atom.keymaps.keyBindingsForKeystrokeMatchingElement('ctrl-z', element2)[0].command).toBe "test-2"
+              expect(atom.keymaps.keyBindingsForKeystrokeMatchingElement('ctrl-z', element3)).toHaveLength 0
 
           describe "when the metadata contains a 'keymaps' manifest", ->
             it "loads only the keymaps specified by the manifest, in the specified order", ->
               element1 = $$ -> @div class: 'test-1'
               element3 = $$ -> @div class: 'test-3'
 
-              expect(atom.keymap.keyBindingsForKeystrokeMatchingElement('ctrl-z', element1)).toHaveLength 0
+              expect(atom.keymaps.keyBindingsForKeystrokeMatchingElement('ctrl-z', element1)).toHaveLength 0
 
               atom.packages.activatePackage("package-with-keymaps-manifest")
 
-              expect(atom.keymap.keyBindingsForKeystrokeMatchingElement('ctrl-z', element1)[0].command).toBe 'keymap-1'
-              expect(atom.keymap.keyBindingsForKeystrokeMatchingElement('ctrl-n', element1)[0].command).toBe 'keymap-2'
-              expect(atom.keymap.keyBindingsForKeystrokeMatchingElement('ctrl-y', element3)).toHaveLength 0
+              expect(atom.keymaps.keyBindingsForKeystrokeMatchingElement('ctrl-z', element1)[0].command).toBe 'keymap-1'
+              expect(atom.keymaps.keyBindingsForKeystrokeMatchingElement('ctrl-n', element1)[0].command).toBe 'keymap-2'
+              expect(atom.keymaps.keyBindingsForKeystrokeMatchingElement('ctrl-y', element3)).toHaveLength 0
 
         describe "menu loading", ->
           beforeEach ->
@@ -377,8 +377,8 @@ describe "the `atom` global", ->
 
           runs ->
             atom.packages.deactivatePackage('package-with-keymaps')
-            expect(atom.keymap.keyBindingsForKeystrokeMatchingElement('ctrl-z', $$ -> @div class: 'test-1')).toHaveLength 0
-            expect(atom.keymap.keyBindingsForKeystrokeMatchingElement('ctrl-z', $$ -> @div class: 'test-2')).toHaveLength 0
+            expect(atom.keymaps.keyBindingsForKeystrokeMatchingElement('ctrl-z', $$ -> @div class: 'test-1')).toHaveLength 0
+            expect(atom.keymaps.keyBindingsForKeystrokeMatchingElement('ctrl-z', $$ -> @div class: 'test-2')).toHaveLength 0
 
         it "removes the package's stylesheets", ->
           waitsForPromise ->

--- a/spec/editor-view-spec.coffee
+++ b/spec/editor-view-spec.coffee
@@ -2802,7 +2802,7 @@ describe "EditorView", ->
 
   describe "when the escape key is pressed on the editor view", ->
     it "clears multiple selections if there are any, and otherwise allows other bindings to be handled", ->
-      atom.keymap.bindKeys 'name', '.editor', {'escape': 'test-event'}
+      atom.keymaps.bindKeys 'name', '.editor', {'escape': 'test-event'}
       testEventHandler = jasmine.createSpy("testEventHandler")
 
       editorView.on 'test-event', testEventHandler

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -6,7 +6,7 @@ require '../vendor/jasmine-jquery'
 path = require 'path'
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
-Keymap = require '../src/keymap-extensions'
+KeymapManager = require '../src/keymap-extensions'
 {$, WorkspaceView} = require 'atom'
 Config = require '../src/config'
 {Point} = require 'text-buffer'
@@ -187,7 +187,7 @@ window.keydownEvent = (key, properties={}) ->
   originalEventProperties.cmd = properties.metaKey
   originalEventProperties.target = properties.target?[0] ? properties.target
   originalEventProperties.which = properties.which
-  originalEvent = Keymap.keydownEvent(key, originalEventProperties)
+  originalEvent = KeymapManager.keydownEvent(key, originalEventProperties)
   properties = $.extend({originalEvent}, properties)
   $.Event("keydown", properties)
 

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -22,8 +22,8 @@ atom.themes.requireStylesheet '../static/jasmine'
 
 fixturePackagesPath = path.resolve(__dirname, './fixtures/packages')
 atom.packages.packageDirPaths.unshift(fixturePackagesPath)
-atom.keymap.loadBundledKeymaps()
-keyBindingsToRestore = atom.keymap.getKeyBindings()
+atom.keymaps.loadBundledKeymaps()
+keyBindingsToRestore = atom.keymaps.getKeyBindings()
 
 $(window).on 'core:close', -> window.close()
 $(window).on 'unload', ->
@@ -50,7 +50,7 @@ beforeEach ->
   $.fx.off = true
   projectPath = specProjectPath ? path.join(@specDirectory, 'fixtures')
   atom.project = new Project(path: projectPath)
-  atom.keymap.keyBindings = _.clone(keyBindingsToRestore)
+  atom.keymaps.keyBindings = _.clone(keyBindingsToRestore)
 
   window.resetTimeouts()
   atom.packages.packageStates = {}
@@ -278,7 +278,7 @@ $.fn.resultOfTrigger = (type) ->
   event.result
 
 $.fn.enableKeymap = ->
-  @on 'keydown', (e) => atom.keymap.handleKeyEvent(e)
+  @on 'keydown', (e) => atom.keymaps.handleKeyEvent(e)
 
 $.fn.attachToDom = ->
   @appendTo($('#jasmine-content'))

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -111,7 +111,7 @@ describe "WorkspaceView", ->
       commandHandler = jasmine.createSpy('commandHandler')
       atom.workspaceView.on('foo-command', commandHandler)
 
-      atom.keymap.bindKeys('name', '*', 'x': 'foo-command')
+      atom.keymaps.bindKeys('name', '*', 'x': 'foo-command')
 
     describe "when a keydown event is triggered in the WorkspaceView", ->
       it "triggers matching keybindings for that event", ->

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -140,7 +140,7 @@ class Atom extends Model
     @loadTime = null
 
     Config = require './config'
-    Keymap = require './keymap-extensions'
+    KeymapManager = require './keymap-extensions'
     PackageManager = require './package-manager'
     Clipboard = require './clipboard'
     Syntax = require './syntax'
@@ -157,7 +157,7 @@ class Atom extends Model
     process.env.NODE_PATH = exportsPath
 
     @config = new Config({configDirPath, resourcePath})
-    @keymap = new Keymap({configDirPath, resourcePath})
+    @keymap = new KeymapManager({configDirPath, resourcePath})
     @packages = new PackageManager({devMode, configDirPath, resourcePath})
     @themes = new ThemeManager({packageManager: @packages, configDirPath, resourcePath})
     @contextMenu = new ContextMenuManager(devMode)

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -24,7 +24,7 @@ WindowEventHandler = require './window-event-handler'
 #  * `atom.config`        - A {Config} instance
 #  * `atom.contextMenu`   - A {ContextMenuManager} instance
 #  * `atom.deserializers` - A {DeserializerManager} instance
-#  * `atom.keymap`        - A {Keymap} instance
+#  * `atom.keymaps`        - A {Keymap} instance
 #  * `atom.menu`          - A {MenuManager} instance
 #  * `atom.packages`      - A {PackageManager} instance
 #  * `atom.project`       - A {Project} instance
@@ -157,7 +157,8 @@ class Atom extends Model
     process.env.NODE_PATH = exportsPath
 
     @config = new Config({configDirPath, resourcePath})
-    @keymap = new KeymapManager({configDirPath, resourcePath})
+    @keymaps = new KeymapManager({configDirPath, resourcePath})
+    @keymap = @keymaps # Deprecated
     @packages = new PackageManager({devMode, configDirPath, resourcePath})
     @themes = new ThemeManager({packageManager: @packages, configDirPath, resourcePath})
     @contextMenu = new ContextMenuManager(devMode)
@@ -244,7 +245,7 @@ class Atom extends Model
     WorkspaceView = require './workspace-view'
     @workspace = Workspace.deserialize(@state.workspace) ? new Workspace
     @workspaceView = new WorkspaceView(@workspace)
-    @keymap.defaultTarget = @workspaceView[0]
+    @keymaps.defaultTarget = @workspaceView[0]
     $(@workspaceViewParentSelector).append(@workspaceView)
 
   deserializePackageStates: ->
@@ -269,12 +270,12 @@ class Atom extends Model
     @config.load()
     @config.setDefaults('core', require('./workspace-view').configDefaults)
     @config.setDefaults('editor', require('./editor-view').configDefaults)
-    @keymap.loadBundledKeymaps()
+    @keymaps.loadBundledKeymaps()
     @themes.loadBaseStylesheets()
     @packages.loadPackages()
     @deserializeEditorWindow()
     @packages.activate()
-    @keymap.loadUserKeymap()
+    @keymaps.loadUserKeymap()
     @requireUserInitScript()
     @menu.update()
 
@@ -298,7 +299,7 @@ class Atom extends Model
     @workspaceView = null
     @project.destroy()
     @windowEventHandler?.unsubscribe()
-    @keymap.destroy()
+    @keymaps.destroy()
     @windowState = null
 
   loadThemes: ->

--- a/src/keymap-extensions.coffee
+++ b/src/keymap-extensions.coffee
@@ -1,27 +1,27 @@
 fs = require 'fs-plus'
 path = require 'path'
-Keymap = require 'atom-keymap'
+KeymapManager = require 'atom-keymap'
 CSON = require 'season'
 {jQuery} = require 'space-pen'
 
-Keymap::loadBundledKeymaps = ->
-  @loadKeyBindings(path.join(@resourcePath, 'keymaps'))
+KeymapManager::loadBundledKeymaps = ->
+  @loadKeymap(path.join(@resourcePath, 'keymaps'))
   @emit('bundled-keymaps-loaded')
 
-Keymap::getUserKeymapPath = ->
+KeymapManager::getUserKeymapPath = ->
   if userKeymapPath = CSON.resolve(path.join(@configDirPath, 'keymap'))
     userKeymapPath
   else
     path.join(@configDirPath, 'keymap.cson')
 
-Keymap::loadUserKeymap = ->
+KeymapManager::loadUserKeymap = ->
   userKeymapPath = @getUserKeymapPath()
   if fs.isFileSync(userKeymapPath)
-    @loadKeyBindings(userKeymapPath, watch: true, suppressErrors: true)
+    @loadKeymap(userKeymapPath, watch: true, suppressErrors: true)
 
 # This enables command handlers registered via jQuery to call
 # `.abortKeyBinding()` on the `jQuery.Event` object passed to the handler.
 jQuery.Event::abortKeyBinding = ->
   @originalEvent?.abortKeyBinding?()
 
-module.exports = Keymap
+module.exports = KeymapManager

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -14,7 +14,7 @@ class MenuManager
   constructor: ({@resourcePath}) ->
     @pendingUpdateOperation = null
     @template = []
-    atom.keymap.on 'bundled-keymaps-loaded', => @loadPlatformItems()
+    atom.keymaps.on 'bundled-keymaps-loaded', => @loadPlatformItems()
 
   # Public: Adds the given item definition to the existing template.
   #
@@ -75,7 +75,7 @@ class MenuManager
     clearImmediate(@pendingUpdateOperation) if @pendingUpdateOperation?
     @pendingUpdateOperation = setImmediate =>
       keystrokesByCommand = {}
-      for binding in atom.keymap.getKeyBindings() when @includeSelector(binding.selector)
+      for binding in atom.keymaps.getKeyBindings() when @includeSelector(binding.selector)
         keystrokesByCommand[binding.command] ?= []
         keystrokesByCommand[binding.command].unshift binding.keystroke
       @sendToBrowserProcess(@template, keystrokesByCommand)

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -124,7 +124,7 @@ class Package
     @stylesheetsActivated = true
 
   activateResources: ->
-    atom.keymap.add(keymapPath, map) for [keymapPath, map] in @keymaps
+    atom.keymaps.add(keymapPath, map) for [keymapPath, map] in @keymaps
     atom.contextMenu.add(menuPath, map['context-menu']) for [menuPath, map] in @menus
     atom.menu.add(map.menu) for [menuPath, map] in @menus when map.menu
 
@@ -232,7 +232,7 @@ class Package
   deactivateResources: ->
     grammar.deactivate() for grammar in @grammars
     scopedProperties.deactivate() for scopedProperties in @scopedProperties
-    atom.keymap.remove(keymapPath) for [keymapPath] in @keymaps
+    atom.keymaps.remove(keymapPath) for [keymapPath] in @keymaps
     atom.themes.removeStylesheet(stylesheetPath) for [stylesheetPath] in @stylesheets
     @stylesheetsActivated = false
     @grammarsActivated = false

--- a/src/space-pen-extensions.coffee
+++ b/src/space-pen-extensions.coffee
@@ -40,9 +40,9 @@ jQuery.fn.setTooltip = (tooltipOptions, {command, commandElement}={}) ->
   tooltipOptions = {title: tooltipOptions} if _.isString(tooltipOptions)
 
   if commandElement
-    bindings = atom.keymap.keyBindingsForCommandMatchingElement(command, commandElement)
+    bindings = atom.keymaps.keyBindingsForCommandMatchingElement(command, commandElement)
   else if command
-    bindings = atom.keymap.keyBindingsForCommand(command)
+    bindings = atom.keymaps.keyBindingsForCommand(command)
 
   tooltipOptions.title = "#{tooltipOptions.title} #{getKeystroke(bindings)}"
 

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -55,7 +55,7 @@ class WindowEventHandler
     @subscribeToCommand $(document), 'core:focus-previous', @focusPrevious
 
     @subscribe $(document), 'keydown', (event) ->
-      atom.keymap.handleKeyEvent(event)
+      atom.keymaps.handleKeyEvent(event)
 
     @subscribe $(document), 'drop', (e) ->
       e.preventDefault()

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -33,7 +33,7 @@ class Workspace extends Model
         when 'atom://.atom/stylesheet'
           @open(atom.themes.getUserStylesheetPath())
         when 'atom://.atom/keymap'
-          @open(atom.keymap.getUserKeymapPath())
+          @open(atom.keymaps.getUserKeymapPath())
         when 'atom://.atom/config'
           @open(atom.config.getUserConfigPath())
         when 'atom://.atom/init-script'


### PR DESCRIPTION
Previously, we referred to the global that contains all the key bindings as the "keymap". But there are folders in our packages called `keymaps/`, implying that these files are called keymaps. It's confusing to have one global thing called keymap that contains a bunch of smaller things that are _also_ called keymaps.

Instead, this PR updates `atom.keymap` to become `atom.keymaps` and the class to be called `KeymapManager`. Methods have been renamed to enforce the idea that files containing bindings are called keymaps.

I've left `atom.keymap` in place as a deprecated property. I'd like to merge this so I can publish the blog post and then start working on a deprecation mechanism that we can use to keep track of where we are using deprecated code paths.
