### PR TITLE
Add atom.workspace to all specs

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -111,13 +111,13 @@ afterEach ->
 
   atom.workspaceView?.remove?()
   atom.workspaceView = null
+
+  atom.workspace?.destroy()
+  atom.workspace = null
   delete atom.state.workspace
 
   atom.project?.destroy?()
   atom.project = null
-
-  atom.workspace?.destroy()
-  atom.workspace = null
 
   delete atom.state.packageStates
 

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -111,9 +111,6 @@ afterEach ->
 
   atom.workspaceView?.remove?()
   atom.workspaceView = null
-
-  atom.workspace?.destroy()
-  atom.workspace = null
   delete atom.state.workspace
 
   atom.project?.destroy()

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -116,7 +116,7 @@ afterEach ->
   atom.workspace = null
   delete atom.state.workspace
 
-  atom.project?.destroy?()
+  atom.project?.destroy()
   atom.project = null
 
   delete atom.state.packageStates

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -49,8 +49,8 @@ if specDirectory
 beforeEach ->
   $.fx.off = true
   projectPath = specProjectPath ? path.join(@specDirectory, 'fixtures')
-  atom.workspace = new Workspace()
   atom.project = new Project(path: projectPath)
+  atom.workspace = new Workspace()
   atom.keymaps.keyBindings = _.clone(keyBindingsToRestore)
 
   window.resetTimeouts()

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -7,7 +7,7 @@ path = require 'path'
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
 KeymapManager = require '../src/keymap-extensions'
-{$, WorkspaceView} = require 'atom'
+{$, WorkspaceView, Workspace} = require 'atom'
 Config = require '../src/config'
 {Point} = require 'text-buffer'
 Project = require '../src/project'
@@ -49,6 +49,7 @@ if specDirectory
 beforeEach ->
   $.fx.off = true
   projectPath = specProjectPath ? path.join(@specDirectory, 'fixtures')
+  atom.workspace = new Workspace()
   atom.project = new Project(path: projectPath)
   atom.keymaps.keyBindings = _.clone(keyBindingsToRestore)
 
@@ -114,6 +115,9 @@ afterEach ->
 
   atom.project?.destroy?()
   atom.project = null
+
+  atom.workspace?.destroy()
+  atom.workspace = null
 
   delete atom.state.packageStates
 

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -78,7 +78,8 @@ class WorkspaceView extends View
           @div class: 'panes', outlet: 'panes'
 
   initialize: (@model) ->
-    @model ?= new Workspace
+    if not @model?
+      @model = atom.workspace ? new Workspace
 
     panes = new PaneContainerView(@model.paneContainer)
     @panes.replaceWith(panes)

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -78,8 +78,7 @@ class WorkspaceView extends View
           @div class: 'panes', outlet: 'panes'
 
   initialize: (@model) ->
-    if not @model?
-      @model = atom.workspace ? new Workspace
+    @model = atom.workspace ? new Workspace unless @model?
 
     panes = new PaneContainerView(@model.paneContainer)
     @panes.replaceWith(panes)

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -39,6 +39,9 @@ class Workspace extends Model
         when 'atom://.atom/init-script'
           @open(atom.getUserInitScriptPath())
 
+  destroy: ->
+    @unsubscribe()
+
   # Called by the Serializable mixin during deserialization
   deserializeParams: (params) ->
     params.paneContainer = PaneContainer.deserialize(params.paneContainer)

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -39,9 +39,6 @@ class Workspace extends Model
         when 'atom://.atom/init-script'
           @open(atom.getUserInitScriptPath())
 
-  destroy: ->
-    @unsubscribe()
-
   # Called by the Serializable mixin during deserialization
   deserializeParams: (params) ->
     params.paneContainer = PaneContainer.deserialize(params.paneContainer)


### PR DESCRIPTION
This is in preparation for moving the opener functionality from project to workspace. Since we add atom.project to every spec, it also makes sense that atom.workspace should be there as well.
