### PR TITLE
Don't call Config::save when setting defaults

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -170,6 +170,13 @@ describe "Config", ->
       expect(atom.config.get("foo.quux.x")).toBe 0
       expect(atom.config.get("foo.quux.y")).toBe 1
 
+    it "emits an updated event", ->
+      updatedCallback = jasmine.createSpy('updated')
+      atom.config.observe('foo.bar.baz.a', callNow: false, updatedCallback)
+      expect(updatedCallback.callCount).toBe 0
+      atom.config.setDefaults("foo.bar.baz", a: 2)
+      expect(updatedCallback.callCount).toBe 1
+
   describe ".observe(keyPath)", ->
     [observeHandler, observeSubscription] = []
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -86,7 +86,7 @@ class Config
       hash = hash[key]
 
     _.extend hash, defaults
-    @update()
+    @emit 'updated'
 
   # Public: Get the path to the config file being used.
   getUserConfigPath: ->


### PR DESCRIPTION
Previously `Config::setDefaults` called `Config::update` which calls `Config::save`.

This was being called roughly ~30 times during startup since many packages have default values, adding about ~30ms to startup.

I think `Config::update` was being called for the emitting of an `update` event so instead just emit it directly from `Config::setDefaults`.
