### PR TITLE
Allow backspace to beginning of word on first line

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1596,6 +1596,11 @@ describe "Editor", ->
           expect(cursor1.getBufferPosition()).toEqual [1, 13]
           expect(cursor2.getBufferPosition()).toEqual [2, 34]
 
+          editor.setText('  var sort')
+          editor.setCursorBufferPosition([0, 2])
+          editor.backspaceToBeginningOfWord()
+          expect(buffer.lineForRow(0)).toBe 'var sort'
+
       describe "when text is selected", ->
         it "deletes only selected text", ->
           editor.setSelectedBufferRanges([[[1, 24], [1, 27]], [[2, 0], [2, 4]]])

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -315,12 +315,14 @@ class Cursor
   #   :includeNonWordCharacters - A {Boolean} indicating whether to include
   #                               non-word characters in the default word regex.
   #                               Has no effect if wordRegex is set.
+  #   :allowPrevious - A {Boolean} indicating whether the beginning of the
+  #                    previous word can be returned.
   #
   # Returns a {Range}.
   getBeginningOfCurrentWordBufferPosition: (options = {}) ->
     allowPrevious = options.allowPrevious ? true
     currentBufferPosition = @getBufferPosition()
-    previousNonBlankRow = @editor.buffer.previousNonBlankRow(currentBufferPosition.row)
+    previousNonBlankRow = @editor.buffer.previousNonBlankRow(currentBufferPosition.row) ? 0
     scanRange = [[previousNonBlankRow, 0], currentBufferPosition]
 
     beginningOfWordPosition = null
@@ -330,7 +332,12 @@ class Cursor
       if not beginningOfWordPosition?.isEqual(currentBufferPosition)
         stop()
 
-    beginningOfWordPosition or currentBufferPosition
+    if beginningOfWordPosition?
+      beginningOfWordPosition
+    else if allowPrevious
+      new Point(0, 0)
+    else
+      currentBufferPosition
 
   # Public: Retrieves buffer position of previous word boundary. It might be on
   # the current word, or the previous word.


### PR DESCRIPTION
Steps to reproduce issue:
-  Create a file with the text (leading whitespace before the `var`):

```
    var sort
```
- Put cursor before the `v`
- Press `alt-delete` (editor:backspace-to-beginning-of-word)
- Whitespace isn't deleted
