### PR TITLE
Use current indent level for newline above

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1424,6 +1424,17 @@ describe "Editor", ->
           editor.undo()
           expect(editor.getCursorBufferPosition()).toEqual [3,4]
 
+      it "indents the new line to the same indent level as the current line when editor.autoIndent is true", ->
+        atom.config.set('editor.autoIndent', true)
+        editor.setText('\n  var test')
+        editor.setCursorBufferPosition([1,2])
+        editor.insertNewlineAbove()
+
+        expect(editor.getCursorBufferPosition()).toEqual [1,2]
+        expect(editor.lineForBufferRow(0)).toBe ''
+        expect(editor.lineForBufferRow(1)).toBe '  '
+        expect(editor.lineForBufferRow(2)).toBe '  var test'
+
     describe ".backspace()", ->
       describe "when there is a single cursor", ->
         changeScreenRangeHandler = null

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1426,6 +1426,15 @@ describe "Editor", ->
 
       it "indents the new line to the same indent level as the current line when editor.autoIndent is true", ->
         atom.config.set('editor.autoIndent', true)
+
+        editor.setText('  var test')
+        editor.setCursorBufferPosition([0,2])
+        editor.insertNewlineAbove()
+
+        expect(editor.getCursorBufferPosition()).toEqual [0,2]
+        expect(editor.lineForBufferRow(0)).toBe '  '
+        expect(editor.lineForBufferRow(1)).toBe '  var test'
+
         editor.setText('\n  var test')
         editor.setCursorBufferPosition([1,2])
         editor.insertNewlineAbove()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -625,11 +625,15 @@ class Editor extends Model
       bufferRow = @getCursorBufferPosition().row
       indentLevel = @indentationForBufferRow(bufferRow)
       onFirstLine = bufferRow is 0
+
       @moveCursorToBeginningOfLine()
       @moveCursorLeft()
       @insertNewline()
       @setIndentationForBufferRow(bufferRow, indentLevel) if @shouldAutoIndent()
-      @moveCursorUp() if onFirstLine
+
+      if onFirstLine
+        @moveCursorUp()
+        @moveCursorToEndOfLine()
 
   # Indent all lines intersecting selections. See {Selection::indent} for more
   # information.

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -622,10 +622,13 @@ class Editor extends Model
   # Public: For each cursor, insert a newline at the end of the preceding line.
   insertNewlineAbove: ->
     @transact =>
-      onFirstLine = @getCursorBufferPosition().row is 0
+      bufferRow = @getCursorBufferPosition().row
+      indentLevel = @indentationForBufferRow(bufferRow)
+      onFirstLine = bufferRow is 0
       @moveCursorToBeginningOfLine()
       @moveCursorLeft()
       @insertNewline()
+      @setIndentationForBufferRow(bufferRow, indentLevel) if @shouldAutoIndent()
       @moveCursorUp() if onFirstLine
 
   # Indent all lines intersecting selections. See {Selection::indent} for more


### PR DESCRIPTION
Previously newline above with empty lines preceding the current line didn't use the correct indent level.

http://discuss.atom.io/t/insert-line-above-should-respect-indentation/6919
