### PR TITLE
Move functionality from Project to Workspace

### DIFF
--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -43,56 +43,48 @@ describe "Project", ->
       expect(atom.project.getPath()).toBe path.dirname(tempFile)
 
   describe ".openSync(path)", ->
-    [absolutePath, newBufferHandler, newEditorHandler] = []
+    [absolutePath, newBufferHandler] = []
     beforeEach ->
       absolutePath = require.resolve('./fixtures/dir/a')
       newBufferHandler = jasmine.createSpy('newBufferHandler')
       atom.project.on 'buffer-created', newBufferHandler
-      newEditorHandler = jasmine.createSpy('newEditorHandler')
-      atom.project.on 'editor-created', newEditorHandler
 
     describe "when given an absolute path that hasn't been opened previously", ->
-      it "returns a new edit session for the given path and emits 'buffer-created' and 'editor-created' events", ->
+      it "returns a new edit session for the given path and emits 'buffer-created'", ->
         editor = atom.project.openSync(absolutePath)
         expect(editor.buffer.getPath()).toBe absolutePath
         expect(newBufferHandler).toHaveBeenCalledWith editor.buffer
-        expect(newEditorHandler).toHaveBeenCalledWith editor
 
     describe "when given a relative path that hasn't been opened previously", ->
-      it "returns a new edit session for the given path (relative to the project root) and emits 'buffer-created' and 'editor-created' events", ->
+      it "returns a new edit session for the given path (relative to the project root) and emits 'buffer-created'", ->
         editor = atom.project.openSync('a')
         expect(editor.buffer.getPath()).toBe absolutePath
         expect(newBufferHandler).toHaveBeenCalledWith editor.buffer
-        expect(newEditorHandler).toHaveBeenCalledWith editor
 
     describe "when passed the path to a buffer that has already been opened", ->
-      it "returns a new edit session containing previously opened buffer and emits a 'editor-created' event", ->
+      it "returns a new edit session containing previously opened buffer", ->
         editor = atom.project.openSync(absolutePath)
         newBufferHandler.reset()
         expect(atom.project.openSync(absolutePath).buffer).toBe editor.buffer
         expect(atom.project.openSync('a').buffer).toBe editor.buffer
         expect(newBufferHandler).not.toHaveBeenCalled()
-        expect(newEditorHandler).toHaveBeenCalledWith editor
 
     describe "when not passed a path", ->
-      it "returns a new edit session and emits 'buffer-created' and 'editor-created' events", ->
+      it "returns a new edit session and emits 'buffer-created'", ->
         editor = atom.project.openSync()
         expect(editor.buffer.getPath()).toBeUndefined()
         expect(newBufferHandler).toHaveBeenCalledWith(editor.buffer)
-        expect(newEditorHandler).toHaveBeenCalledWith editor
 
   describe ".open(path)", ->
-    [absolutePath, newBufferHandler, newEditorHandler] = []
+    [absolutePath, newBufferHandler] = []
 
     beforeEach ->
       absolutePath = require.resolve('./fixtures/dir/a')
       newBufferHandler = jasmine.createSpy('newBufferHandler')
       atom.project.on 'buffer-created', newBufferHandler
-      newEditorHandler = jasmine.createSpy('newEditorHandler')
-      atom.project.on 'editor-created', newEditorHandler
 
     describe "when given an absolute path that isn't currently open", ->
-      it "returns a new edit session for the given path and emits 'buffer-created' and 'editor-created' events", ->
+      it "returns a new edit session for the given path and emits 'buffer-created'", ->
         editor = null
         waitsForPromise ->
           atom.project.open(absolutePath).then (o) -> editor = o
@@ -100,10 +92,9 @@ describe "Project", ->
         runs ->
           expect(editor.buffer.getPath()).toBe absolutePath
           expect(newBufferHandler).toHaveBeenCalledWith editor.buffer
-          expect(newEditorHandler).toHaveBeenCalledWith editor
 
     describe "when given a relative path that isn't currently opened", ->
-      it "returns a new edit session for the given path (relative to the project root) and emits 'buffer-created' and 'editor-created' events", ->
+      it "returns a new edit session for the given path (relative to the project root) and emits 'buffer-created'", ->
         editor = null
         waitsForPromise ->
           atom.project.open(absolutePath).then (o) -> editor = o
@@ -111,10 +102,9 @@ describe "Project", ->
         runs ->
           expect(editor.buffer.getPath()).toBe absolutePath
           expect(newBufferHandler).toHaveBeenCalledWith editor.buffer
-          expect(newEditorHandler).toHaveBeenCalledWith editor
 
     describe "when passed the path to a buffer that is currently opened", ->
-      it "returns a new edit session containing currently opened buffer and emits a 'editor-created' event", ->
+      it "returns a new edit session containing currently opened buffer", ->
         editor = null
         waitsForPromise ->
           atom.project.open(absolutePath).then (o) -> editor = o
@@ -124,10 +114,9 @@ describe "Project", ->
           expect(atom.project.openSync(absolutePath).buffer).toBe editor.buffer
           expect(atom.project.openSync('a').buffer).toBe editor.buffer
           expect(newBufferHandler).not.toHaveBeenCalled()
-          expect(newEditorHandler).toHaveBeenCalledWith editor
 
     describe "when not passed a path", ->
-      it "returns a new edit session and emits 'buffer-created' and 'editor-created' events", ->
+      it "returns a new edit session and emits 'buffer-created'", ->
         editor = null
         waitsForPromise ->
           atom.project.open().then (o) -> editor = o
@@ -135,7 +124,6 @@ describe "Project", ->
         runs ->
           expect(editor.buffer.getPath()).toBeUndefined()
           expect(newBufferHandler).toHaveBeenCalledWith(editor.buffer)
-          expect(newEditorHandler).toHaveBeenCalledWith editor
 
     it "returns number of read bytes as progress indicator", ->
       filePath = atom.project.resolve 'a'

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -33,20 +33,6 @@ describe "Project", ->
       deserializedProject.getBuffers()[0].destroy()
       expect(deserializedProject.getBuffers().length).toBe 0
 
-  describe "when an edit session is destroyed", ->
-    it "removes edit session and calls destroy on buffer (if buffer is not referenced by other edit sessions)", ->
-      editor = atom.project.openSync("a")
-      anotherEditor = atom.project.openSync("a")
-
-      expect(atom.project.editors.length).toBe 2
-      expect(editor.buffer).toBe anotherEditor.buffer
-
-      editor.destroy()
-      expect(atom.project.editors.length).toBe 1
-
-      anotherEditor.destroy()
-      expect(atom.project.editors.length).toBe 0
-
   describe "when an edit session is saved and the project has no path", ->
     it "sets the project's path to the saved file's parent directory", ->
       tempFile = temp.openSync().path

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -33,7 +33,7 @@ describe "Project", ->
       deserializedProject.getBuffers()[0].destroy()
       expect(deserializedProject.getBuffers().length).toBe 0
 
-  describe "when an edit session is saved and the project has no path", ->
+  describe "when an editor is saved and the project has no path", ->
     it "sets the project's path to the saved file's parent directory", ->
       tempFile = temp.openSync().path
       atom.project.setPath(undefined)
@@ -41,22 +41,6 @@ describe "Project", ->
       editor = atom.project.openSync()
       editor.saveAs(tempFile)
       expect(atom.project.getPath()).toBe path.dirname(tempFile)
-
-  describe "when an edit session is copied", ->
-    it "emits an 'editor-created' event and stores the edit session", ->
-      handler = jasmine.createSpy('editorCreatedHandler')
-      atom.project.on 'editor-created', handler
-
-      editor1 = atom.project.openSync("a")
-      expect(handler.callCount).toBe 1
-      expect(atom.project.getEditors().length).toBe 1
-      expect(atom.project.getEditors()[0]).toBe editor1
-
-      editor2 = editor1.copy()
-      expect(handler.callCount).toBe 2
-      expect(atom.project.getEditors().length).toBe 2
-      expect(atom.project.getEditors()[0]).toBe editor1
-      expect(atom.project.getEditors()[1]).toBe editor2
 
   describe ".openSync(path)", ->
     [absolutePath, newBufferHandler, newEditorHandler] = []

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -257,3 +257,16 @@ describe "Workspace", ->
         expect(workspace.getEditors()).toHaveLength 1
         editor.destroy()
         expect(workspace.getEditors()).toHaveLength 0
+
+  describe "when an editor is copied", ->
+    it "emits an 'editor-created' event and stores the editor", ->
+      handler = jasmine.createSpy('editorCreatedHandler')
+      workspace.on 'editor-created', handler
+
+      editor1 = workspace.openSync("a")
+      expect(handler.callCount).toBe 1
+      expect(workspace.getEditors()).toEqual [editor1]
+
+      editor2 = editor1.copy()
+      expect(handler.callCount).toBe 2
+      expect(workspace.getEditors()).toEqual [editor1, editor2]

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -5,7 +5,7 @@ describe "Workspace", ->
 
   beforeEach ->
     atom.project.setPath(atom.project.resolve('dir'))
-    workspace = new Workspace
+    atom.workspace = workspace = new Workspace
 
   describe "::open(uri, options)", ->
     beforeEach ->

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -259,7 +259,7 @@ describe "Workspace", ->
       runs -> expect(workspace.activePaneItem.getText()).toMatch /Copyright/
 
   describe "when an editor is destroyed", ->
-    it "removes editor", ->
+    it "removes the editor", ->
       editor = null
 
       waitsForPromise ->

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -152,6 +152,18 @@ describe "Workspace", ->
           workspace.open("bar://baz").then (item) ->
             expect(item).toEqual { bar: "bar://baz" }
 
+    it "emits an 'editor-created' event", ->
+      absolutePath = require.resolve('./fixtures/dir/a')
+      newEditorHandler = jasmine.createSpy('newEditorHandler')
+      workspace.on 'editor-created', newEditorHandler
+
+      editor = null
+      waitsForPromise ->
+        workspace.open(absolutePath).then (e) -> editor = e
+
+      runs ->
+        expect(newEditorHandler).toHaveBeenCalledWith editor
+
   describe "::openSync(uri, options)", ->
     [activePane, initialItemCount] = []
 

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -245,3 +245,15 @@ describe "Workspace", ->
     it "opens the license as plain-text in a buffer", ->
       waitsForPromise -> workspace.openLicense()
       runs -> expect(workspace.activePaneItem.getText()).toMatch /Copyright/
+
+  describe "when an editor is destroyed", ->
+    it "removes editor", ->
+      editor = null
+
+      waitsForPromise ->
+        workspace.open("a").then (e) -> editor = e
+
+      runs ->
+        expect(workspace.getEditors()).toHaveLength 1
+        editor.destroy()
+        expect(workspace.getEditors()).toHaveLength 0

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -182,7 +182,7 @@ class Editor extends Model
     @subscribe @$scrollTop, (scrollTop) => @emit 'scroll-top-changed', scrollTop
     @subscribe @$scrollLeft, (scrollLeft) => @emit 'scroll-left-changed', scrollLeft
 
-    atom.project.addEditor(this) if registerEditor
+    atom.workspace.addEditor(this) if registerEditor
 
   serializeParams: ->
     id: @id
@@ -225,7 +225,7 @@ class Editor extends Model
     @buffer.release()
     @displayBuffer.destroy()
     @languageMode.destroy()
-    atom.project?.removeEditor(this)
+    atom.workspace?.removeEditor(this)
 
   # Create an {Editor} with its initial state based on this object
   copy: ->
@@ -237,7 +237,7 @@ class Editor extends Model
     newEditor.setScrollLeft(@getScrollLeft())
     for marker in @findMarkers(editorId: @id)
       marker.copy(editorId: newEditor.id, preserveFolds: true)
-    atom.project.addEditor(newEditor)
+    atom.workspace.addEditor(newEditor)
     newEditor
 
   # Public: Get the title the editor's title for display in other parts of the

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -31,7 +31,6 @@ class Project extends Model
 
   constructor: ({path, @buffers}={}) ->
     @buffers ?= []
-    @openers = []
 
     for buffer in @buffers
       do (buffer) =>
@@ -321,12 +320,12 @@ class Project extends Model
   # Deprecated: delegate
   registerOpener: (opener) ->
     deprecate("Use Workspace::registerOpener instead")
-    @openers.push(opener)
+    atom.workspace.registerOpener(opener)
 
   # Deprecated: delegate
   unregisterOpener: (opener) ->
     deprecate("Use Workspace::unregisterOpener instead")
-    _.remove(@openers, opener)
+    atom.workspace.unregisterOpener(opener)
 
   # Deprecated: delegate
   eachEditor: (callback) ->

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -36,7 +36,6 @@ class Project extends Model
       do (buffer) =>
         buffer.once 'destroyed', => @removeBuffer(buffer)
 
-    @editors = []
     @setPath(path)
 
   serializeParams: ->
@@ -48,7 +47,6 @@ class Project extends Model
     params
 
   destroyed: ->
-    editor.destroy() for editor in @getEditors()
     buffer.destroy() for buffer in @getBuffers()
     @destroyRepo()
 
@@ -130,15 +128,6 @@ class Project extends Model
     deprecate("Use Project::open instead")
     filePath = @resolve(filePath)
     @buildEditorForBuffer(@bufferForPathSync(filePath), options)
-
-  # Add the given {Editor}.
-  addEditor: (editor) ->
-    @editors.push editor
-    @emit 'editor-created', editor
-
-  # Return and removes the given {Editor}.
-  removeEditor: (editor) ->
-    _.remove(@editors, editor)
 
   # Retrieves all the {TextBuffer}s in the project; that is, the
   # buffers for all open files.
@@ -304,7 +293,7 @@ class Project extends Model
 
   buildEditorForBuffer: (buffer, editorOptions) ->
     editor = new Editor(_.extend({buffer}, editorOptions))
-    @addEditor(editor)
+    atom.workspace.addEditor(editor)
     editor
 
   eachBuffer: (args...) ->
@@ -335,4 +324,5 @@ class Project extends Model
   # Deprecated: delegate
   getEditors: ->
     deprecate("Use Workspace::getEditors instead")
+    atom.getEditors()
     new Array(@editors...)

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -330,8 +330,7 @@ class Project extends Model
   # Deprecated: delegate
   eachEditor: (callback) ->
     deprecate("Use Workspace::eachEditor instead")
-    callback(editor) for editor in @getEditors()
-    @on 'editor-created', (editor) -> callback(editor)
+    atom.workspace.eachEditor(callback)
 
   # Deprecated: delegate
   getEditors: ->

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -324,5 +324,4 @@ class Project extends Model
   # Deprecated: delegate
   getEditors: ->
     deprecate("Use Workspace::getEditors instead")
-    atom.getEditors()
-    new Array(@editors...)
+    atom.workspace.getEditors()

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -54,13 +54,11 @@ class Workspace extends Model
     paneContainer: @paneContainer.serialize()
     fullScreen: atom.isFullScreen()
 
-  # Return and add the given {Editor}.
   addEditor: (editor) ->
     @editors.push editor
     @emit 'editor-created', editor
     editor
 
-  # Return and removes the given {Editor}.
   removeEditor: (editor) ->
     remove(@editors, editor)
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -181,7 +181,7 @@ class Workspace extends Model
     _.remove(@openers, opener)
 
   getOpeners: ->
-    atom.project.openers
+    @openers
 
   # Public: Get the active {Pane}.
   #

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -77,7 +77,7 @@ class Workspace extends Model
   #
   # Returns an {Array} of {Editor}s.
   getEditors: ->
-    _.clone(@editors...)
+    _.clone(@editors)
 
   # Public: Open a given a URI in Atom asynchronously.
   #

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -179,7 +179,7 @@ class Workspace extends Model
 
   # Public: Unregister an opener registered with {::registerOpener}.
   unregisterOpener: (opener) ->
-    _.remove(@openers, opener)
+    remove(@openers, opener)
 
   getOpeners: ->
     @openers

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -61,7 +61,7 @@ class Workspace extends Model
   # unregister the callback.
   eachEditor: (callback) ->
     callback(editor) for editor in @getEditors()
-    @on 'editor-created', (editor) -> callback(editor)
+    @subscribe atom.project, 'editor-created', (editor) -> callback(editor)
 
   # Public: Get all current editors in the workspace.
   #

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -28,6 +28,8 @@ class Workspace extends Model
 
   constructor: ->
     super
+
+    @openers = []
     @subscribe @paneContainer, 'item-destroyed', @onPaneItemDestroyed
     @registerOpener (filePath) =>
       switch filePath
@@ -172,11 +174,11 @@ class Workspace extends Model
   #
   # opener - A {Function} to be called when a path is being opened.
   registerOpener: (opener) ->
-    atom.project.registerOpener(opener)
+    @openers.push(opener)
 
   # Public: Unregister an opener registered with {::registerOpener}.
   unregisterOpener: (opener) ->
-    atom.project.unregisterOpener(opener)
+    _.remove(@openers, opener)
 
   getOpeners: ->
     atom.project.openers

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -77,7 +77,7 @@ class Workspace extends Model
   #
   # Returns an {Array} of {Editor}s.
   getEditors: ->
-    new Array(@editors...)
+    _.clone(@editors...)
 
   # Public: Open a given a URI in Atom asynchronously.
   #

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -1,5 +1,5 @@
 {deprecate} = require 'grim'
-{remove, last} = require 'underscore-plus'
+_ = require 'underscore-plus'
 {join} = require 'path'
 {Model} = require 'theorist'
 Q = require 'q'
@@ -60,7 +60,7 @@ class Workspace extends Model
     editor
 
   removeEditor: (editor) ->
-    remove(@editors, editor)
+    _.remove(@editors, editor)
 
   # Public: Register a function to be called for every current and future
   # {Editor} in the workspace.
@@ -189,7 +189,7 @@ class Workspace extends Model
 
   # Public: Unregister an opener registered with {::registerOpener}.
   unregisterOpener: (opener) ->
-    remove(@openers, opener)
+    _.remove(@openers, opener)
 
   getOpeners: ->
     @openers
@@ -275,7 +275,7 @@ class Workspace extends Model
   # Removes the item's uri from the list of potential items to reopen.
   itemOpened: (item) ->
     if uri = item.getUri?()
-      remove(@destroyedItemUris, uri)
+      _.remove(@destroyedItemUris, uri)
 
   # Adds the destroyed item's uri to the list of items to reopen.
   onPaneItemDestroyed: (item) =>

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -60,7 +60,8 @@ class Workspace extends Model
   # Returns a subscription object with an `.off` method that you can call to
   # unregister the callback.
   eachEditor: (callback) ->
-    atom.project.eachEditor(callback)
+    callback(editor) for editor in @getEditors()
+    @on 'editor-created', (editor) -> callback(editor)
 
   # Public: Get all current editors in the workspace.
   #


### PR DESCRIPTION
Openers and editors were still being stored in Project. This moves the specs and the variables themselves over to Workspace.

Moving Buffers over is something else we could do, but I'm not sure how that fits with our multi-project plans.
