### PR TITLE
Move functionality from Project to Workspace Part II

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -271,14 +271,12 @@ describe "Workspace", ->
         expect(workspace.getEditors()).toHaveLength 0
 
   describe "when an editor is copied", ->
-    it "emits an 'editor-created' event and stores the editor", ->
+    it "emits an 'editor-created' event", ->
       handler = jasmine.createSpy('editorCreatedHandler')
       workspace.on 'editor-created', handler
 
       editor1 = workspace.openSync("a")
       expect(handler.callCount).toBe 1
-      expect(workspace.getEditors()).toEqual [editor1]
 
       editor2 = editor1.copy()
       expect(handler.callCount).toBe 2
-      expect(workspace.getEditors()).toEqual [editor1, editor2]

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -5,7 +5,7 @@ describe "Workspace", ->
 
   beforeEach ->
     atom.project.setPath(atom.project.resolve('dir'))
-    workspace = new Workspace
+    atom.workspace = workspace = new Workspace
 
   describe "::open(uri, options)", ->
     beforeEach ->
@@ -152,6 +152,18 @@ describe "Workspace", ->
           workspace.open("bar://baz").then (item) ->
             expect(item).toEqual { bar: "bar://baz" }
 
+    it "emits an 'editor-created' event", ->
+      absolutePath = require.resolve('./fixtures/dir/a')
+      newEditorHandler = jasmine.createSpy('newEditorHandler')
+      workspace.on 'editor-created', newEditorHandler
+
+      editor = null
+      waitsForPromise ->
+        workspace.open(absolutePath).then (e) -> editor = e
+
+      runs ->
+        expect(newEditorHandler).toHaveBeenCalledWith editor
+
   describe "::openSync(uri, options)", ->
     [activePane, initialItemCount] = []
 
@@ -245,3 +257,28 @@ describe "Workspace", ->
     it "opens the license as plain-text in a buffer", ->
       waitsForPromise -> workspace.openLicense()
       runs -> expect(workspace.activePaneItem.getText()).toMatch /Copyright/
+
+  describe "when an editor is destroyed", ->
+    it "removes the editor", ->
+      editor = null
+
+      waitsForPromise ->
+        workspace.open("a").then (e) -> editor = e
+
+      runs ->
+        expect(workspace.getEditors()).toHaveLength 1
+        editor.destroy()
+        expect(workspace.getEditors()).toHaveLength 0
+
+  describe "when an editor is copied", ->
+    it "emits an 'editor-created' event and stores the editor", ->
+      handler = jasmine.createSpy('editorCreatedHandler')
+      workspace.on 'editor-created', handler
+
+      editor1 = workspace.openSync("a")
+      expect(handler.callCount).toBe 1
+      expect(workspace.getEditors()).toEqual [editor1]
+
+      editor2 = editor1.copy()
+      expect(handler.callCount).toBe 2
+      expect(workspace.getEditors()).toEqual [editor1, editor2]

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -182,7 +182,7 @@ class Editor extends Model
     @subscribe @$scrollTop, (scrollTop) => @emit 'scroll-top-changed', scrollTop
     @subscribe @$scrollLeft, (scrollLeft) => @emit 'scroll-left-changed', scrollLeft
 
-    atom.project.addEditor(this) if registerEditor
+    atom.workspace.addEditor(this) if registerEditor
 
   serializeParams: ->
     id: @id
@@ -225,7 +225,7 @@ class Editor extends Model
     @buffer.release()
     @displayBuffer.destroy()
     @languageMode.destroy()
-    atom.project?.removeEditor(this)
+    atom.workspace?.removeEditor(this)
 
   # Create an {Editor} with its initial state based on this object
   copy: ->
@@ -237,7 +237,7 @@ class Editor extends Model
     newEditor.setScrollLeft(@getScrollLeft())
     for marker in @findMarkers(editorId: @id)
       marker.copy(editorId: newEditor.id, preserveFolds: true)
-    atom.project.addEditor(newEditor)
+    atom.workspace.addEditor(newEditor)
     newEditor
 
   # Public: Get the title the editor's title for display in other parts of the

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -182,7 +182,7 @@ class Editor extends Model
     @subscribe @$scrollTop, (scrollTop) => @emit 'scroll-top-changed', scrollTop
     @subscribe @$scrollLeft, (scrollLeft) => @emit 'scroll-left-changed', scrollLeft
 
-    atom.workspace.addEditor(this) if registerEditor
+    atom.workspace.editorAdded(this) if registerEditor
 
   serializeParams: ->
     id: @id
@@ -225,19 +225,17 @@ class Editor extends Model
     @buffer.release()
     @displayBuffer.destroy()
     @languageMode.destroy()
-    atom.workspace?.removeEditor(this)
 
   # Create an {Editor} with its initial state based on this object
   copy: ->
     tabLength = @getTabLength()
     displayBuffer = @displayBuffer.copy()
     softTabs = @getSoftTabs()
-    newEditor = new Editor({@buffer, displayBuffer, tabLength, softTabs, suppressCursorCreation: true})
+    newEditor = new Editor({@buffer, displayBuffer, tabLength, softTabs, suppressCursorCreation: true, registerEditor: true})
     newEditor.setScrollTop(@getScrollTop())
     newEditor.setScrollLeft(@getScrollLeft())
     for marker in @findMarkers(editorId: @id)
       marker.copy(editorId: newEditor.id, preserveFolds: true)
-    atom.workspace.addEditor(newEditor)
     newEditor
 
   # Public: Get the title the editor's title for display in other parts of the

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -182,7 +182,7 @@ class Editor extends Model
     @subscribe @$scrollTop, (scrollTop) => @emit 'scroll-top-changed', scrollTop
     @subscribe @$scrollLeft, (scrollLeft) => @emit 'scroll-left-changed', scrollLeft
 
-    atom.workspace.editorAdded(this) if registerEditor
+    atom.workspace?.editorAdded(this) if registerEditor
 
   serializeParams: ->
     id: @id

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -31,13 +31,11 @@ class Project extends Model
 
   constructor: ({path, @buffers}={}) ->
     @buffers ?= []
-    @openers = []
 
     for buffer in @buffers
       do (buffer) =>
         buffer.once 'destroyed', => @removeBuffer(buffer)
 
-    @editors = []
     @setPath(path)
 
   serializeParams: ->
@@ -49,7 +47,6 @@ class Project extends Model
     params
 
   destroyed: ->
-    editor.destroy() for editor in @getEditors()
     buffer.destroy() for buffer in @getBuffers()
     @destroyRepo()
 
@@ -131,15 +128,6 @@ class Project extends Model
     deprecate("Use Project::open instead")
     filePath = @resolve(filePath)
     @buildEditorForBuffer(@bufferForPathSync(filePath), options)
-
-  # Add the given {Editor}.
-  addEditor: (editor) ->
-    @editors.push editor
-    @emit 'editor-created', editor
-
-  # Return and removes the given {Editor}.
-  removeEditor: (editor) ->
-    _.remove(@editors, editor)
 
   # Retrieves all the {TextBuffer}s in the project; that is, the
   # buffers for all open files.
@@ -305,7 +293,7 @@ class Project extends Model
 
   buildEditorForBuffer: (buffer, editorOptions) ->
     editor = new Editor(_.extend({buffer}, editorOptions))
-    @addEditor(editor)
+    atom.workspace.addEditor(editor)
     editor
 
   eachBuffer: (args...) ->
@@ -321,20 +309,19 @@ class Project extends Model
   # Deprecated: delegate
   registerOpener: (opener) ->
     deprecate("Use Workspace::registerOpener instead")
-    @openers.push(opener)
+    atom.workspace.registerOpener(opener)
 
   # Deprecated: delegate
   unregisterOpener: (opener) ->
     deprecate("Use Workspace::unregisterOpener instead")
-    _.remove(@openers, opener)
+    atom.workspace.unregisterOpener(opener)
 
   # Deprecated: delegate
   eachEditor: (callback) ->
     deprecate("Use Workspace::eachEditor instead")
-    callback(editor) for editor in @getEditors()
-    @on 'editor-created', (editor) -> callback(editor)
+    atom.workspace.eachEditor(callback)
 
   # Deprecated: delegate
   getEditors: ->
     deprecate("Use Workspace::getEditors instead")
-    new Array(@editors...)
+    atom.workspace.getEditors()

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -141,7 +141,7 @@ class Project extends Model
     @findBufferForPath(@resolve(filePath))?.isModified()
 
   findBufferForPath: (filePath) ->
-   _.find @buffers, (buffer) -> buffer.getPath() == filePath
+    _.find @buffers, (buffer) -> buffer.getPath() == filePath
 
   # Only to be used in specs
   bufferForPathSync: (filePath) ->

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -292,8 +292,7 @@ class Project extends Model
     deferred.promise
 
   buildEditorForBuffer: (buffer, editorOptions) ->
-    editor = new Editor(_.extend({buffer}, editorOptions))
-    atom.workspace.addEditor(editor)
+    editor = new Editor(_.extend({buffer, registerEditor: true}, editorOptions))
     editor
 
   eachBuffer: (args...) ->


### PR DESCRIPTION
A continuation of https://github.com/atom/atom/pull/1844

There was a deserialization problem. Workspace stores editor instances using `Workspace::addEditor`. But when a workspace is deserialized, editors are created before the `atom.workspace` variable is created, so `Editor` can't call `atom.workspace.addEditor`. This worked before because project is separate from editor creation.

It makes me think storing editors on Workspace isn't a good idea, but I'm not sure of a better place to store them. An alternative is to decouple Pane deserialization from Workspace deserialization. 
