### PR TITLE
Add "Open Folder" menu on Linux and Windows

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -16,7 +16,7 @@
   # Sublime Parity
   'ctrl-N': 'application:new-window'
   'ctrl-W': 'window:close'
-  'ctrl-o': 'application:open'
+  'ctrl-o': 'application:open-file'
   'ctrl-q': 'application:quit'
   'ctrl-T': 'pane:reopen-closed-item'
   'ctrl-n': 'application:new-file'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -14,7 +14,7 @@
   # Sublime Parity
   'ctrl-N': 'application:new-window'
   'ctrl-W': 'window:close'
-  'ctrl-o': 'application:open'
+  'ctrl-o': 'application:open-file'
   'ctrl-T': 'pane:reopen-closed-item'
   'ctrl-n': 'application:new-file'
   'ctrl-s': 'core:save'

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -4,7 +4,8 @@
     submenu: [
       { label: 'New &Window', command: 'application:new-window' }
       { label: '&New File', command: 'application:new-file' }
-      { label: '&Open...', command: 'application:open' }
+      { label: '&Open File...', command: 'application:open-file' }
+      { label: 'Open Folder...', command: 'application:open-folder' }
       { label: 'Reopen Last &Item', command: 'pane:reopen-closed-item' }
       { type: 'separator' }
       { label: '&Preferences...', command: 'application:show-settings' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -4,7 +4,8 @@
     submenu: [
       { label: 'New &Window', command: 'application:new-window' }
       { label: '&New File', command: 'application:new-file' }
-      { label: '&Open...', command: 'application:open' }
+      { label: '&Open File...', command: 'application:open-file' }
+      { label: 'Open Folder...', command: 'application:open-folder' }
       { label: 'Reopen Last &Item', command: 'pane:reopen-closed-item' }
       { type: 'separator' }
       { label: '&Preferences...', command: 'application:show-settings' }

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -135,7 +135,9 @@ class AtomApplication
     @on 'application:quit', -> app.quit()
     @on 'application:new-window', -> @openPath(windowDimensions: @focusedWindow()?.getDimensions())
     @on 'application:new-file', -> (@focusedWindow() ? this).openPath()
-    @on 'application:open', -> @promptForPath()
+    @on 'application:open', -> @promptForPath(type: 'all')
+    @on 'application:open-file', -> @promptForPath(type: 'file')
+    @on 'application:open-folder', -> @promptForPath(type: 'folder')
     @on 'application:open-dev', -> @promptForPath(devMode: true)
     @on 'application:inspect', ({x,y}) -> @focusedWindow().browserWindow.inspectElement(x, y)
     @on 'application:open-documentation', -> shell.openExternal('https://atom.io/docs/latest/?app')
@@ -407,9 +409,19 @@ class AtomApplication
   # Once paths are selected, they're opened in a new or existing {AtomWindow}s.
   #
   # * options
+  #    + type:
+  #      A String which specifies the type of the dialog, could be 'file',
+  #      'folder' or 'all'. The 'all' is only available on OS X.
   #    + devMode:
   #      A Boolean which controls whether any newly opened windows should  be in
   #      dev mode or not.
-  promptForPath: ({devMode}={}) ->
-    dialog.showOpenDialog title: 'Open', properties: ['openFile', 'openDirectory', 'multiSelections', 'createDirectory'], (pathsToOpen) =>
+  promptForPath: ({type, devMode}={}) ->
+    type ?= 'all'
+    properties =
+      switch type
+        when 'file' then ['openFile']
+        when 'folder' then ['openDirectory']
+        when 'all' then ['openFile', 'openDirectory']
+        else throw new Error("#{type} is an invalid type for promptForPath")
+    dialog.showOpenDialog title: 'Open', properties: properties.concat(['multiSelections', 'createDirectory']), (pathsToOpen) =>
       @openPaths({pathsToOpen, devMode})

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -116,6 +116,8 @@ class WorkspaceView extends View
     @command 'application:new-window', -> ipc.sendChannel('command', 'application:new-window')
     @command 'application:new-file', -> ipc.sendChannel('command', 'application:new-file')
     @command 'application:open', -> ipc.sendChannel('command', 'application:open')
+    @command 'application:open-file', -> ipc.sendChannel('command', 'application:open-file')
+    @command 'application:open-folder', -> ipc.sendChannel('command', 'application:open-folder')
     @command 'application:open-dev', -> ipc.sendChannel('command', 'application:open-dev')
     @command 'application:minimize', -> ipc.sendChannel('command', 'application:minimize')
     @command 'application:zoom', -> ipc.sendChannel('command', 'application:zoom')


### PR DESCRIPTION
On Linux and Windows a open dialog can only choose either files or folders, and never both, so we have to provide a separate menu item to open folders.
