### PR TITLE
Remove github auth token methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "grim": "0.6.0",
     "guid": "0.0.10",
     "jasmine-tagged": "^1.1.1",
-    "keytar": "1.x",
     "less-cache": "0.12.0",
     "mixto": "1.x",
     "mkdirp": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "command-palette": "0.20.0",
     "dev-live-reload": "0.30.0",
     "exception-reporting": "0.17.0",
-    "feedback": "0.29.0",
+    "feedback": "0.30.0",
     "find-and-replace": "0.97.0",
     "fuzzy-finder": "0.49.0",
     "git-diff": "0.28.0",

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -1,6 +1,5 @@
 crypto = require 'crypto'
 ipc = require 'ipc'
-keytar = require 'keytar'
 os = require 'os'
 path = require 'path'
 remote = require 'remote'
@@ -483,17 +482,6 @@ class Atom extends Model
   # Public: Determine whether the current version is an official release.
   isReleasedVersion: ->
     @constructor.isReleasedVersion()
-
-  getGitHubAuthTokenName: ->
-    'Atom GitHub API Token'
-
-  # Public: Set the the github token in the keychain
-  setGitHubAuthToken: (token) ->
-    keytar.replacePassword(@getGitHubAuthTokenName(), 'github', token)
-
-  # Public: Get the github token from the keychain
-  getGitHubAuthToken: ->
-    keytar.getPassword(@getGitHubAuthTokenName(), 'github')
 
   # Public: Get the directory path to Atom's configuration area.
   #


### PR DESCRIPTION
We don't use these right now. Let's remove these methods until we need them.
