### PR TITLE
Allow context menu to work without focus

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -140,7 +140,9 @@ class AtomApplication
     @on 'application:open-file', -> @promptForPath(type: 'file')
     @on 'application:open-folder', -> @promptForPath(type: 'folder')
     @on 'application:open-dev', -> @promptForPath(devMode: true)
-    @on 'application:inspect', ({x,y}) -> @focusedWindow().browserWindow.inspectElement(x, y)
+    @on 'application:inspect', ({x,y}, atomWindow=@focusedWindow()) ->
+      atomWindow?.browserWindow?.inspectElement(x, y)
+
     @on 'application:open-documentation', -> shell.openExternal('https://atom.io/docs/latest/?app')
     @on 'application:install-update', -> @autoUpdateManager.install()
     @on 'application:check-for-update', => @autoUpdateManager.check()
@@ -225,6 +227,18 @@ class AtomApplication
       focusedWindow = @focusedWindow()
       if focusedWindow?
         focusedWindow.sendCommand(command, args...)
+      else
+        @sendCommandToFirstResponder(command)
+
+  # Public: Executes the given command on the given window.
+  #
+  # command - The string representing the command.
+  # atomWindow - The {AtomWindow} to send the command to.
+  # args - The optional arguments to pass along.
+  sendCommandToWindow: (command, atomWindow, args...) ->
+    unless @emit(command, args..., atomWindow)
+      if atomWindow?
+        atomWindow.sendCommand(command, args...)
       else
         @sendCommandToFirstResponder(command)
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -142,7 +142,7 @@ class AtomApplication
     @on 'application:open-dev', -> @promptForPath(devMode: true)
     @on 'application:inspect', ({x,y, atomWindow}) ->
       atomWindow ?= @focusedWindow()
-      atomWindow?.browserWindow?.inspectElement(x, y)
+      atomWindow?.browserWindow.inspectElement(x, y)
 
     @on 'application:open-documentation', -> shell.openExternal('https://atom.io/docs/latest/?app')
     @on 'application:install-update', -> @autoUpdateManager.install()

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -140,7 +140,8 @@ class AtomApplication
     @on 'application:open-file', -> @promptForPath(type: 'file')
     @on 'application:open-folder', -> @promptForPath(type: 'folder')
     @on 'application:open-dev', -> @promptForPath(devMode: true)
-    @on 'application:inspect', ({x,y}, atomWindow=@focusedWindow()) ->
+    @on 'application:inspect', ({x,y, atomWindow}) ->
+      atomWindow ?= @focusedWindow()
       atomWindow?.browserWindow?.inspectElement(x, y)
 
     @on 'application:open-documentation', -> shell.openExternal('https://atom.io/docs/latest/?app')
@@ -236,7 +237,7 @@ class AtomApplication
   # atomWindow - The {AtomWindow} to send the command to.
   # args - The optional arguments to pass along.
   sendCommandToWindow: (command, atomWindow, args...) ->
-    unless @emit(command, args..., atomWindow)
+    unless @emit(command, args...)
       if atomWindow?
         atomWindow.sendCommand(command, args...)
       else

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -107,7 +107,7 @@ class AtomWindow
         when 1 then @browserWindow.restart()
 
     @browserWindow.on 'context-menu', (menuTemplate) =>
-      new ContextMenu(menuTemplate, @browserWindow)
+      new ContextMenu(menuTemplate, this)
 
     if @isSpec
       # Spec window's web view should always have focus

--- a/src/browser/context-menu.coffee
+++ b/src/browser/context-menu.coffee
@@ -13,7 +13,9 @@ class ContextMenu
   createClickHandlers: (template) ->
     for item in template
       if item.command
-        (item.commandOptions ?= {}).contextCommand = true
+        item.commandOptions ?= {}
+        item.commandOptions.contextCommand = true
+        item.commandOptions.atomWindow = @atomWindow
         do (item) =>
           item.click = =>
             global.atomApplication.sendCommandToWindow(item.command, @atomWindow, item.commandOptions)

--- a/src/browser/context-menu.coffee
+++ b/src/browser/context-menu.coffee
@@ -2,10 +2,10 @@ Menu = require 'menu'
 
 module.exports =
 class ContextMenu
-  constructor: (template, browserWindow) ->
+  constructor: (template, @atomWindow) ->
     template = @createClickHandlers(template)
     menu = Menu.buildFromTemplate(template)
-    menu.popup(browserWindow)
+    menu.popup(@atomWindow.browserWindow)
 
   # It's necessary to build the event handlers in this process, otherwise
   # closures are drug across processes and failed to be garbage collected
@@ -14,6 +14,7 @@ class ContextMenu
     for item in template
       if item.command
         (item.commandOptions ?= {}).contextCommand = true
-        item.click = do (item) ->
-          => global.atomApplication.sendCommand(item.command, item.commandOptions)
+        do (item) =>
+          item.click = =>
+            global.atomApplication.sendCommandToWindow(item.command, @atomWindow, item.commandOptions)
       item

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -18,7 +18,7 @@ class ContextMenuManager
       label: 'Inspect Element'
       command: 'application:inspect'
       executeAtBuild: (e) ->
-        @.commandOptions = x: e.pageX, y: e.pageY
+        @commandOptions = x: e.pageX, y: e.pageY
     ]
 
   # Public: Creates menu definitions from the object specified by the menu


### PR DESCRIPTION
Use the window that the menu was created on when sending commands.

Previously this would fail since `focusedWindow()` would be null.

Closes atom/tree-view#102
