### PR TITLE
Add Config::getDefault API

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -72,6 +72,17 @@ describe "Config", ->
       expect(atom.config.getDefault('foo.bar')).toEqual initialDefaultValue
       expect(atom.config.getDefault('foo.bar')).not.toBe initialDefaultValue
 
+  describe ".isDefault(keyPath)", ->
+    it "returns true when the value of the key path is its default value", ->
+      atom.config.setDefaults("foo", same: 1, changes: 1)
+      expect(atom.config.isDefault('foo.same')).toBe true
+      expect(atom.config.isDefault('foo.changes')).toBe true
+
+      atom.config.set('foo.same', 2)
+      atom.config.set('foo.changes', 3)
+      expect(atom.config.isDefault('foo.same')).toBe false
+      expect(atom.config.isDefault('foo.changes')).toBe false
+
   describe ".toggle(keyPath)", ->
     it "negates the boolean value of the current key path value", ->
       atom.config.set('foo.a', 1)

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -43,8 +43,8 @@ describe "Config", ->
           sameObject: {a: 1, b: 2}
           null: null
           undefined: undefined
-
         expect(atom.config.settings.foo).toBeUndefined()
+
         atom.config.set('foo.same', 1)
         atom.config.set('foo.changes', 2)
         atom.config.set('foo.sameArray', [1, 2, 3])

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -57,7 +57,7 @@ describe "Config", ->
         expect(atom.config.settings.foo).toEqual {}
 
   describe ".getDefault(keyPath)", ->
-    it "returns the default value", ->
+    it "returns a clone of the default value", ->
       atom.config.setDefaults("foo", same: 1, changes: 1)
       expect(atom.config.getDefault('foo.same')).toBe 1
       expect(atom.config.getDefault('foo.changes')).toBe 1
@@ -67,7 +67,6 @@ describe "Config", ->
       expect(atom.config.getDefault('foo.same')).toBe 1
       expect(atom.config.getDefault('foo.changes')).toBe 1
 
-    it "returns a clone of the default value", ->
       initialDefaultValue = [1, 2, 3]
       atom.config.setDefaults("foo", bar: initialDefaultValue)
       expect(atom.config.getDefault('foo.bar')).toEqual initialDefaultValue

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -36,10 +36,13 @@ describe "Config", ->
 
     describe "when the value equals the default value", ->
       it "does not store the value", ->
-        atom.config.setDefaults("foo", same: 1, changes: 1)
+        atom.config.setDefaults("foo", same: 1, changes: 1, sameArray: [1, 2, 3], null: null, undefined: undefined)
         expect(atom.config.settings.foo).toBeUndefined()
         atom.config.set('foo.same', 1)
         atom.config.set('foo.changes', 2)
+        atom.config.set('foo.sameArray', [1, 2, 3])
+        atom.config.set('foo.null', undefined)
+        atom.config.set('foo.undefined', null)
         expect(atom.config.settings.foo).toEqual {changes: 2}
 
         atom.config.set('foo.changes', 1)

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -36,13 +36,21 @@ describe "Config", ->
 
     describe "when the value equals the default value", ->
       it "does not store the value", ->
-        atom.config.setDefaults("foo", same: 1, changes: 1, sameArray: [1, 2, 3], null: null, undefined: undefined)
+        atom.config.setDefaults "foo",
+          same: 1
+          changes: 1
+          sameArray: [1, 2, 3]
+          sameObject: {a: 1, b: 2}
+          null: null
+          undefined: undefined
+
         expect(atom.config.settings.foo).toBeUndefined()
         atom.config.set('foo.same', 1)
         atom.config.set('foo.changes', 2)
         atom.config.set('foo.sameArray', [1, 2, 3])
         atom.config.set('foo.null', undefined)
         atom.config.set('foo.undefined', null)
+        atom.config.set('foo.sameObject', {b: 2, a: 1})
         expect(atom.config.settings.foo).toEqual {changes: 2}
 
         atom.config.set('foo.changes', 1)

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -45,6 +45,23 @@ describe "Config", ->
         atom.config.set('foo.changes', 1)
         expect(atom.config.settings.foo).toEqual {}
 
+  describe ".getDefault(keyPath)", ->
+    it "returns the default value", ->
+      atom.config.setDefaults("foo", same: 1, changes: 1)
+      expect(atom.config.getDefault('foo.same')).toBe 1
+      expect(atom.config.getDefault('foo.changes')).toBe 1
+
+      atom.config.set('foo.same', 2)
+      atom.config.set('foo.changes', 3)
+      expect(atom.config.getDefault('foo.same')).toBe 1
+      expect(atom.config.getDefault('foo.changes')).toBe 1
+
+    it "returns a clone of the default value", ->
+      initialDefaultValue = [1, 2, 3]
+      atom.config.setDefaults("foo", bar: initialDefaultValue)
+      expect(atom.config.getDefault('foo.bar')).toEqual initialDefaultValue
+      expect(atom.config.getDefault('foo.bar')).not.toBe initialDefaultValue
+
   describe ".toggle(keyPath)", ->
     it "negates the boolean value of the current key path value", ->
       atom.config.set('foo.a', 1)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -88,7 +88,7 @@ class Config
     _.extend hash, defaults
     @emit 'updated'
 
-  # Public: Get the path to the config file being used.
+  # Public: Get the {String} path to the config file being used.
   getUserConfigPath: ->
     @configFilePath
 
@@ -98,10 +98,10 @@ class Config
 
   # Public: Retrieves the setting for the given key.
   #
-  # keyPath - The {String} name of the key to retrieve
+  # keyPath - The {String} name of the key to retrieve.
   #
-  # Returns the value from Atom's default settings, the user's configuration file,
-  # or `null` if the key doesn't exist in either.
+  # Returns the value from Atom's default settings, the user's configuration
+  # file, or `null` if the key doesn't exist in either.
   get: (keyPath) ->
     value = _.valueForKeyPath(@settings, keyPath) ? _.valueForKeyPath(@defaultSettings, keyPath)
     _.deepClone(value)
@@ -110,8 +110,8 @@ class Config
   #
   # keyPath - The {String} name of the key to retrieve
   #
-  # Returns the value from Atom's default settings, the user's configuration file,
-  # or `NaN` if the key doesn't exist in either.
+  # Returns the value from Atom's default settings, the user's configuration
+  # file, or `NaN` if the key doesn't exist in either.
   getInt: (keyPath) ->
     parseInt(@get(keyPath))
 
@@ -121,8 +121,8 @@ class Config
   # defaultValue - The integer {Number} to fall back to if the value isn't
   #                positive, defaults to 0.
   #
-  # Returns the value from Atom's default settings, the user's configuration file,
-  # or `defaultValue` if the key value isn't greater than zero.
+  # Returns the value from Atom's default settings, the user's configuration
+  # file, or `defaultValue` if the key value isn't greater than zero.
   getPositiveInt: (keyPath, defaultValue=0) ->
     Math.max(@getInt(keyPath), 0) or defaultValue
 
@@ -130,8 +130,8 @@ class Config
   #
   # This value is stored in Atom's internal configuration file.
   #
-  # keyPath - The {String} name of the key
-  # value - The value of the setting
+  # keyPath - The {String} name of the key.
+  # value - The value of the setting.
   #
   # Returns the `value`.
   set: (keyPath, value) ->
@@ -146,6 +146,8 @@ class Config
   #
   # The new value will be `true` if the value is currently falsy and will be
   # `false` if the value is currently truthy.
+  #
+  # keyPath - The {String} name of the key.
   #
   # Returns the new value.
   toggle: (keyPath) ->
@@ -170,6 +172,8 @@ class Config
 
   # Public: Is the key path value its default value?
   #
+  # keyPath - The {String} name of the key.
+  #
   # Returns a {Boolean}, `true` if the current value is the default, `false`
   # otherwise.
   isDefault: (keyPath) ->
@@ -180,7 +184,7 @@ class Config
   # keyPath - The {String} key path.
   # value - The value to push to the array.
   #
-  # Returns the new array length of the setting.
+  # Returns the new array length {Number} of the setting.
   pushAtKeyPath: (keyPath, value) ->
     arrayValue = @get(keyPath) ? []
     result = arrayValue.push(value)
@@ -192,7 +196,7 @@ class Config
   # keyPath - The {String} key path.
   # value - The value to shift onto the array.
   #
-  # Returns the new array length of the setting.
+  # Returns the new array length {Number} of the setting.
   unshiftAtKeyPath: (keyPath, value) ->
     arrayValue = @get(keyPath) ? []
     result = arrayValue.unshift(value)
@@ -242,9 +246,9 @@ class Config
     callback(value) if options.callNow ? true
     subscription
 
-  # Public: Unobserve all callbacks on a given key
+  # Public: Unobserve all callbacks on a given key.
   #
-  # keyPath - The {String} name of the key to unobserve
+  # keyPath - The {String} name of the key to unobserve.
   unobserve: (keyPath) ->
     @off("updated.#{keyPath.replace(/\./, '-')}")
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -158,6 +158,15 @@ class Config
   restoreDefault: (keyPath) ->
     @set(keyPath, _.valueForKeyPath(@defaultSettings, keyPath))
 
+  # Public: Get the default value of the key path.
+  #
+  # keyPath - The {String} name of the key.
+  #
+  # Returns the default value.
+  getDefault: (keyPath) ->
+    value = _.valueForKeyPath(@defaultSettings, keyPath)
+    _.deepClone(value)
+
   # Public: Push the value to the array at the key path.
   #
   # keyPath - The {String} key path.

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -168,6 +168,13 @@ class Config
     defaultValue = _.valueForKeyPath(@defaultSettings, keyPath)
     _.deepClone(defaultValue)
 
+  # Public: Is the key path value its default value?
+  #
+  # Returns a {Boolean}, `true` if the current value is the default, `false`
+  # otherwise.
+  isDefault: (keyPath) ->
+    not _.valueForKeyPath(@settings, keyPath)?
+
   # Public: Push the value to the array at the key path.
   #
   # keyPath - The {String} key path.

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -18,9 +18,9 @@ pathWatcher = require 'pathwatcher'
 # ## Example
 #
 # ```coffeescript
-# atom.config.set('myplugin.key', 'value')
-# atom.config.observe 'myplugin.key', ->
-#   console.log 'My configuration changed:', atom.config.get('myplugin.key')
+# atom.config.set('my-package.key', 'value')
+# atom.config.observe 'my-package.key', ->
+#   console.log 'My configuration changed:', atom.config.get('my-package.key')
 # ```
 module.exports =
 class Config

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -135,8 +135,9 @@ class Config
   #
   # Returns the `value`.
   set: (keyPath, value) ->
-    if @get(keyPath) != value
-      value = undefined if _.valueForKeyPath(@defaultSettings, keyPath) == value
+    if @get(keyPath) isnt value
+      defaultValue = _.valueForKeyPath(@defaultSettings, keyPath)
+      value = undefined if _.isEqual(defaultValue, value)
       _.setValueForKeyPath(@settings, keyPath, value)
       @update()
     value

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -165,8 +165,8 @@ class Config
   #
   # Returns the default value.
   getDefault: (keyPath) ->
-    value = _.valueForKeyPath(@defaultSettings, keyPath)
-    _.deepClone(value)
+    defaultValue = _.valueForKeyPath(@defaultSettings, keyPath)
+    _.deepClone(defaultValue)
 
   # Public: Push the value to the array at the key path.
   #


### PR DESCRIPTION
This will allow the settings view to know the default value so atom/settings-view#104 can be fixed.

I believe also fixes a longstanding bug where defaults sometimes were written to the config file.  Looks like previously we were using `==` to compare the new value against the default value to know whether it should be omitted from the stored settings when it should be using `_.isEqual` instead to handle objects, arrays, etc.
### New Public APIs
- `atom.config.getDefault(keyPath)` - returns a clone of the default value
- `atom.config.isDefault(keyPath)` - returns `true` if the key path value is its default
