### PR TITLE
Make Editor::mutateSelectedText public

### DIFF
--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1002,6 +1002,13 @@ class Editor extends Model
     deprecate("Use Editor::duplicateLines() instead")
     @duplicateLines()
 
+  # Public: Mutate the text of all the selections in a single transaction.
+  #
+  # All the changes made inside the given {Function} can be reverted with a
+  # single call to {::undo}.
+  #
+  # fn - A {Function} to call once per selection with the {Selection} as the
+  #      first argument.
   mutateSelectedText: (fn) ->
     @transact => fn(selection) for selection in @getSelections()
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1007,8 +1007,7 @@ class Editor extends Model
   # All the changes made inside the given {Function} can be reverted with a
   # single call to {::undo}.
   #
-  # fn - A {Function} to call once per selection with the {Selection} as the
-  #      first argument.
+  # fn - A {Function} that will be called with each {Selection}.
   mutateSelectedText: (fn) ->
     @transact => fn(selection) for selection in @getSelections()
 


### PR DESCRIPTION
Someone wanted to use this in a bracket-matcher PR and was asking why it wasn't doc'ed.

Seems useful to have in the public API since it handles the transaction for you.

https://github.com/atom/bracket-matcher/pull/25
