### PR TITLE
Move compile cache to ~/.atom/compile-cache

### DIFF
--- a/script/clean
+++ b/script/clean
@@ -23,9 +23,9 @@ var commands = [
   [home, '.atom', '.node-gyp'],
   [home, '.atom', 'storage'],
   [home, '.atom', '.npm'],
+  [home, '.atom', 'compile-cache'],
   [tmpdir, 'atom-build'],
   [tmpdir, 'atom-cached-atom-shells'],
-  [tmpdir, 'atom-compile-cache'],
 ];
 var run = function() {
   var next = commands.shift();

--- a/src/coffee-cache.coffee
+++ b/src/coffee-cache.coffee
@@ -19,7 +19,7 @@ getCachedJavaScript = (cachePath) ->
       fs.readFileSync(cachePath, 'utf8')
 
 compileCoffeeScript = (coffee, filePath, cachePath) ->
-  {js,v3SourceMap} = CoffeeScript.compile(coffee, filename: filePath, sourceMap: true)
+  {js, v3SourceMap} = CoffeeScript.compile(coffee, filename: filePath, sourceMap: true)
   # Include source map in the web page environment.
   if btoa? and JSON? and unescape? and encodeURIComponent?
     js = "#{js}\n//# sourceMappingURL=data:application/json;base64,#{btoa unescape encodeURIComponent v3SourceMap}\n//# sourceURL=#{filePath}"

--- a/src/coffee-cache.coffee
+++ b/src/coffee-cache.coffee
@@ -15,9 +15,9 @@ getCachePath = (coffee) ->
   path.join(coffeeCacheDir, "#{digest}.js")
 
 getCachedJavaScript = (cachePath) ->
-  if stat = fs.statSyncNoException(cachePath)
+  if fs.isFileSync(cachePath)
     try
-      fs.readFileSync(cachePath, 'utf8') if stat.isFile()
+      fs.readFileSync(cachePath, 'utf8')
 
 compileCoffeeScript = (coffee, filePath, cachePath) ->
   {js,v3SourceMap} = CoffeeScript.compile(coffee, filename: filePath, sourceMap: true)

--- a/src/coffee-cache.coffee
+++ b/src/coffee-cache.coffee
@@ -12,7 +12,7 @@ CSON.setCacheDir(path.join(cacheDir, 'cson'))
 
 getCachePath = (coffee) ->
   digest = crypto.createHash('sha1').update(coffee, 'utf8').digest('hex')
-  path.join(coffeeCacheDir, "#{digest}.coffee")
+  path.join(coffeeCacheDir, "#{digest}.js")
 
 getCachedJavaScript = (cachePath) ->
   if stat = fs.statSyncNoException(cachePath)

--- a/src/coffee-cache.coffee
+++ b/src/coffee-cache.coffee
@@ -1,14 +1,12 @@
 crypto = require 'crypto'
-fs = require 'fs'
 path = require 'path'
-os = require 'os'
 
 CoffeeScript = require 'coffee-script'
 CSON = require 'season'
+fs = require 'fs-plus'
 mkdir = require('mkdirp').sync
 
-tmpDir = if process.platform is 'win32' then os.tmpdir() else '/tmp'
-cacheDir = path.join(tmpDir, 'atom-compile-cache')
+cacheDir = path.join(fs.getHomeDirectory(), 'compile-cache')
 coffeeCacheDir = path.join(cacheDir, 'coffee')
 CSON.setCacheDir(path.join(cacheDir, 'cson'))
 

--- a/src/coffee-cache.coffee
+++ b/src/coffee-cache.coffee
@@ -4,7 +4,6 @@ path = require 'path'
 CoffeeScript = require 'coffee-script'
 CSON = require 'season'
 fs = require 'fs-plus'
-mkdir = require('mkdirp').sync
 
 cacheDir = path.join(fs.getHomeDirectory(), 'compile-cache')
 coffeeCacheDir = path.join(cacheDir, 'coffee')
@@ -25,7 +24,6 @@ compileCoffeeScript = (coffee, filePath, cachePath) ->
   if btoa? and JSON? and unescape? and encodeURIComponent?
     js = "#{js}\n//# sourceMappingURL=data:application/json;base64,#{btoa unescape encodeURIComponent v3SourceMap}\n//# sourceURL=#{filePath}"
   try
-    mkdir(path.dirname(cachePath))
     fs.writeFileSync(cachePath, js)
   js
 

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -1,16 +1,14 @@
 path = require 'path'
-os = require 'os'
+fs = require 'fs-plus'
 LessCache = require 'less-cache'
 {Subscriber} = require 'emissary'
-
-tmpDir = if process.platform is 'win32' then os.tmpdir() else '/tmp'
 
 # {LessCache} wrapper used by {ThemeManager} to read stylesheets.
 module.exports =
 class LessCompileCache
   Subscriber.includeInto(this)
 
-  @cacheDir: path.join(tmpDir, 'atom-compile-cache', 'less')
+  @cacheDir: path.join(fs.getHomeDirectory(), 'compile-cache', 'less')
 
   constructor: ({resourcePath, importPaths}) ->
     @lessSearchPaths = [


### PR DESCRIPTION
Storing it in `/tmp` hurts people using multiple user accounts on the same machine.

The cache is important enough to warrant storing in ~/.atom, mine was only `12M` and I last cleaned it out months ago, so we aren't talking about a lot of space. Compare that with `~/.atom/.node-gyp` which for me is `250M` and `~/.atom/.npm` which is `373M`

If space does become an issue we can always reap old files.

Fixes #1787
