### PR TITLE
Preserve indentation when commenting

### DIFF
--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -184,13 +184,13 @@ describe "LanguageMode", ->
         languageMode.toggleLineCommentsForBufferRows(2, 2)
         expect(buffer.lineForRow(0)).toBe "/*body {"
         expect(buffer.lineForRow(1)).toBe "  font-size: 1234px;*/"
-        expect(buffer.lineForRow(2)).toBe "/*  width: 110%;*/"
+        expect(buffer.lineForRow(2)).toBe "  /*width: 110%;*/"
         expect(buffer.lineForRow(3)).toBe "  font-weight: bold !important;"
 
         languageMode.toggleLineCommentsForBufferRows(0, 1)
         expect(buffer.lineForRow(0)).toBe "body {"
         expect(buffer.lineForRow(1)).toBe "  font-size: 1234px;"
-        expect(buffer.lineForRow(2)).toBe "/*  width: 110%;*/"
+        expect(buffer.lineForRow(2)).toBe "  /*width: 110%;*/"
         expect(buffer.lineForRow(3)).toBe "  font-weight: bold !important;"
 
       it "uncomments lines with leading whitespace", ->

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -60,7 +60,8 @@ class LanguageMode
             buffer.setTextInRange([[end, endColumn], [end, endLength]], "")
       else
         buffer.transact ->
-          buffer.insert([start, 0], commentStartString)
+          indentLength = buffer.lineForRow(start).match(/^\s*/)?[0].length ? 0
+          buffer.insert([start, indentLength], commentStartString)
           buffer.insert([end, buffer.lineLengthForRow(end)], commentEndString)
     else
       if shouldUncomment and start isnt end


### PR DESCRIPTION
This was already happening when there was only a comment start pattern, but not when there was a comment end pattern.

Fixes atom/language-html#23
