### PR TITLE
Whitespace double click

### DIFF
--- a/spec/editor-view-spec.coffee
+++ b/spec/editor-view-spec.coffee
@@ -509,7 +509,7 @@ describe "EditorView", ->
 
         expect(editor.getSelectedBufferRange()).toEqual [[3, 10], [3, 12]]
 
-      describe "when clicking between a word and a non-word", ->
+      describe "when double-clicking between a word and a non-word", ->
         it "selects the word", ->
           expect(editor.getCursorScreenPosition()).toEqual(row: 0, column: 0)
           editorView.renderedLines.trigger mousedownEvent(editorView: editorView, point: [1, 21], originalEvent: {detail: 1})
@@ -532,7 +532,7 @@ describe "EditorView", ->
           editorView.renderedLines.trigger 'mouseup'
           expect(editor.getSelectedText()).toBe "{"
 
-      describe "when clicking in the middle of whitespace", ->
+      describe "when double-clicking on whitespace", ->
         it "selects all adjacent whitespace", ->
           editor.setText("   some  text    ")
           editor.setCursorBufferPosition([0, 2])

--- a/spec/editor-view-spec.coffee
+++ b/spec/editor-view-spec.coffee
@@ -532,6 +532,30 @@ describe "EditorView", ->
           editorView.renderedLines.trigger 'mouseup'
           expect(editor.getSelectedText()).toBe "{"
 
+      describe "when clicking in the middle of whitespace", ->
+        it "selects all adjacent whitespace", ->
+          editor.setText("   some  text    ")
+          editor.setCursorBufferPosition([0, 2])
+          editorView.renderedLines.trigger mousedownEvent(editorView: editorView, point: [0, 2], originalEvent: {detail: 1})
+          editorView.renderedLines.trigger 'mouseup'
+          editorView.renderedLines.trigger mousedownEvent(editorView: editorView, point: [0, 2], originalEvent: {detail: 2})
+          editorView.renderedLines.trigger 'mouseup'
+          expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [0, 3]]
+
+          editor.setCursorBufferPosition([0, 8])
+          editorView.renderedLines.trigger mousedownEvent(editorView: editorView, point: [0, 8], originalEvent: {detail: 1})
+          editorView.renderedLines.trigger 'mouseup'
+          editorView.renderedLines.trigger mousedownEvent(editorView: editorView, point: [0, 8], originalEvent: {detail: 2})
+          editorView.renderedLines.trigger 'mouseup'
+          expect(editor.getSelectedBufferRange()).toEqual [[0, 7], [0, 9]]
+
+          editor.setCursorBufferPosition([0, 14])
+          editorView.renderedLines.trigger mousedownEvent(editorView: editorView, point: [0, 14], originalEvent: {detail: 1})
+          editorView.renderedLines.trigger 'mouseup'
+          editorView.renderedLines.trigger mousedownEvent(editorView: editorView, point: [0, 14], originalEvent: {detail: 2})
+          editorView.renderedLines.trigger 'mouseup'
+          expect(editor.getSelectedBufferRange()).toEqual [[0, 13], [0, 17]]
+
     describe "triple/quardruple/etc-click", ->
       it "selects the line under the cursor", ->
         expect(editor.getCursorScreenPosition()).toEqual(row: 0, column: 0)

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -144,7 +144,7 @@ class Cursor extends Model
   # Returns a {Boolean}.
   isSurroundedByWhitespace: ->
     {row, column} = @getBufferPosition()
-    range = [[row, Math.max(0, column - 1)], [row, Math.max(0, column + 1)]]
+    range = [[row, column - 1], [row, column + 1]]
     /^\s+$/.test @editor.getTextInBufferRange(range)
 
   # Public: Returns whether the cursor is currently between a word and non-word

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -138,8 +138,8 @@ class Cursor extends Model
 
   # Public: Identifies if the cursor is surrounded by whitespace.
   #
-  # "Surrounded" here means that all characters before and after the cursor is
-  # whitespace.
+  # "Surrounded" here means that the character directly before and after the
+  # cursor are both whitespace.
   #
   # Returns a {Boolean}.
   isSurroundedByWhitespace: ->

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -144,7 +144,7 @@ class Cursor extends Model
   # Returns a {Boolean}.
   isSurroundedByWhitespace: ->
     {row, column} = @getBufferPosition()
-    range = [[row, Math.min(0, column - 1)], [row, Math.max(0, column + 1)]]
+    range = [[row, Math.max(0, column - 1)], [row, Math.max(0, column + 1)]]
     /^\s+$/.test @editor.getTextInBufferRange(range)
 
   # Public: Returns whether the cursor is currently between a word and non-word


### PR DESCRIPTION
I'm assuming `Cursor::isSurroundedByWhitespace` is supposed to only check the character directly before and directly after the cursor.

Previously it was always checking starting at column 0 for whitespace surrounding the cursor since `Math.min` was being used with `0`.

Now I've removed all range bounds corrections since `TextBuffer::getTextInRange` handles that automatically.

Fixes #1901
