### PR TITLE
Stop uploading to atom-master-builds

### DIFF
--- a/build/tasks/publish-build-task.coffee
+++ b/build/tasks/publish-build-task.coffee
@@ -29,21 +29,18 @@ module.exports = (gruntObject) ->
     done = @async()
     buildDir = grunt.config.get('atom.buildDir')
 
-    createBuildRelease (error, release) ->
+    zipApps buildDir, assets, (error) ->
       return done(error) if error?
-
-      zipApps buildDir, assets, (error) ->
+      uploadAssets release, buildDir, assets, (error) ->
         return done(error) if error?
-        uploadAssets release, buildDir, assets, (error) ->
+        publishRelease release, (error) ->
           return done(error) if error?
-          publishRelease release, (error) ->
+          getAtomDraftRelease (error, release) ->
             return done(error) if error?
-            getAtomDraftRelease (error, release) ->
+            assetNames = (asset.assetName for asset in assets)
+            deleteExistingAssets release, assetNames, (error) ->
               return done(error) if error?
-              assetNames = (asset.assetName for asset in assets)
-              deleteExistingAssets release, assetNames, (error) ->
-                return done(error) if error?
-                uploadAssets(release, buildDir, assets, done)
+              uploadAssets(release, buildDir, assets, done)
 
 logError = (message, error, details) ->
   grunt.log.error(message)
@@ -63,25 +60,6 @@ zipApps = (buildDir, assets, callback) ->
     fs.removeSync(path.join(buildDir, assetName))
     tasks.push(zip.bind(this, buildDir, sourceName, assetName))
   async.parallel(tasks, callback)
-
-getRelease = (callback) ->
-  options =
-    uri: 'https://api.github.com/repos/atom/atom-master-builds/releases'
-    method: 'GET'
-    headers: defaultHeaders
-    json: true
-  request options, (error, response, releases=[]) ->
-    if error? or response.statusCode isnt 200
-      logError('Fetching releases failed', error, releases)
-      callback(error ? new Error(response.statusCode))
-    else
-      if releases.length > maxReleases
-        deleteRelease(release) for release in releases[maxReleases..]
-
-      for release in releases when release.name is commitSha
-        callback(null, release)
-        return
-      callback()
 
 getAtomDraftRelease = (callback) ->
   atomRepo = new GitHub({repo: 'atom/atom', token})
@@ -124,35 +102,6 @@ deleteExistingAssets = (release, assetNames, callback) ->
   for asset in release.assets when not assetNames? or asset.name in assetNames
     tasks.push(deleteAsset.bind(this, asset.url))
   async.parallel(tasks, callback)
-
-createBuildRelease = (callback) ->
-  getRelease (error, release) ->
-    if error?
-      callback(error)
-      return
-
-    if release?
-      deleteExistingAssets release, (error) ->
-        callback(error, release)
-      return
-
-    options =
-      uri: 'https://api.github.com/repos/atom/atom-master-builds/releases'
-      method: 'POST'
-      headers: defaultHeaders
-      json:
-        tag_name: "v#{commitSha}"
-        target_commitish: 'master'
-        name: commitSha
-        body: "Build of [atom@#{commitSha.substring(0, 7)}](https://github.com/atom/atom/commits/#{commitSha})"
-        draft: true
-        prerelease: true
-    request options, (error, response, release={}) ->
-      if error? or response.statusCode isnt 201
-        logError('Creating release failed', error, release)
-        callback(error ? new Error(response.statusCode))
-      else
-        callback(null, release)
 
 uploadAssets = (release, buildDir, assets, callback) ->
   upload = (release, assetName, assetPath, callback) ->


### PR DESCRIPTION
This PR cleans up the infrastructure setup to build packages against the latest master build which is no longer used.
- [x] Delete the `atom-public` team
- [x] Remove the `atom-public` user from the atom org.
- [x] Merge this PR
- [x] Delete the `atom-master-builds` repo
