### PR TITLE
Open to initial column

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -43,6 +43,19 @@ describe "Editor", ->
       runs ->
         buffer = editor.buffer
         expect(editor.getCursor().getBufferPosition().row).toEqual 5
+        expect(editor.getCursor().getBufferPosition().column).toEqual 0
+
+  describe "when the editor is constructed with an initialColumn option", ->
+    it "positions the cursor on the specified column", ->
+      editor = null
+
+      waitsForPromise ->
+        atom.workspace.open('sample.less', initialColumn: 8).then (o) -> editor = o
+
+      runs ->
+        buffer = editor.buffer
+        expect(editor.getCursor().getBufferPosition().row).toEqual 0
+        expect(editor.getCursor().getBufferPosition().column).toEqual 8
 
   describe ".copy()", ->
     it "returns a different edit session with the same initial state", ->

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -301,10 +301,12 @@ class AtomApplication
   #   :windowDimensions - Object with height and width keys.
   openPath: ({pathToOpen, pidToKillWhenClosed, newWindow, devMode, windowDimensions}={}) ->
     if pathToOpen
-      [basename, initialLine] = path.basename(pathToOpen).split(':')
-      if initialLine
-        pathToOpen = "#{path.dirname(pathToOpen)}/#{basename}"
-        initialLine -= 1 # Convert line numbers to a base of 0
+      [basename, initialLine, initialColumn] = path.basename(pathToOpen).split(':')
+      pathToOpen = "#{path.dirname(pathToOpen)}/#{basename}" if initialLine
+
+      # Convert line numbers to a base of 0
+      initialLine -= 1 if initialLine
+      initialColumn -= 1 if initialColumn
 
     unless devMode
       existingWindow = @windowForPath(pathToOpen) unless pidToKillWhenClosed or newWindow
@@ -320,7 +322,7 @@ class AtomApplication
 
       bootstrapScript ?= require.resolve('../window-bootstrap')
       resourcePath ?= @resourcePath
-      openedWindow = new AtomWindow({pathToOpen, initialLine, bootstrapScript, resourcePath, devMode, windowDimensions})
+      openedWindow = new AtomWindow({pathToOpen, initialLine, initialColumn, bootstrapScript, resourcePath, devMode, windowDimensions})
 
     if pidToKillWhenClosed?
       @pidsToOpenWindows[pidToKillWhenClosed] = openedWindow

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -302,7 +302,7 @@ class AtomApplication
   openPath: ({pathToOpen, pidToKillWhenClosed, newWindow, devMode, windowDimensions}={}) ->
     if pathToOpen
       [basename, initialLine, initialColumn] = path.basename(pathToOpen).split(':')
-      pathToOpen = "#{path.dirname(pathToOpen)}/#{basename}" if initialLine
+      pathToOpen = path.join(path.dirname(pathToOpen), basename) if initialLine
 
       # Convert line numbers to a base of 0
       initialLine -= 1 if initialLine

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -20,7 +20,7 @@ class AtomWindow
   isSpec: null
 
   constructor: (settings={}) ->
-    {@resourcePath, pathToOpen, initialLine, @isSpec, @exitWhenDone} = settings
+    {@resourcePath, pathToOpen, initialLine, initialColumn, @isSpec, @exitWhenDone} = settings
     global.atomApplication.addWindow(this)
 
     @browserWindow = new BrowserWindow show: false, title: 'Atom', icon: @constructor.iconPath
@@ -47,7 +47,7 @@ class AtomWindow
     @browserWindow.loadUrl @getUrl(loadSettings)
     @browserWindow.focusOnWebView() if @isSpec
 
-    @openPath(pathToOpen, initialLine)
+    @openPath(pathToOpen, initialLine, initialColumn)
 
   getUrl: (loadSettingsObj) ->
     # Ignore the windowState when passing loadSettings via URL, since it could
@@ -113,12 +113,12 @@ class AtomWindow
       @browserWindow.on 'blur', =>
         @browserWindow.focusOnWebView()
 
-  openPath: (pathToOpen, initialLine) ->
+  openPath: (pathToOpen, initialLine, initialColumn) ->
     if @loaded
       @focus()
-      @sendCommand('window:open-path', {pathToOpen, initialLine})
+      @sendCommand('window:open-path', {pathToOpen, initialLine, initialColumn})
     else
-      @browserWindow.once 'window:loaded', => @openPath(pathToOpen, initialLine)
+      @browserWindow.once 'window:loaded', => @openPath(pathToOpen, initialLine, initialColumn)
 
   sendCommand: (command, args...) ->
     if @isSpecWindow()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -152,7 +152,7 @@ class Editor extends Model
   @delegatesProperties '$lineHeight', '$defaultCharWidth', '$height', '$width',
     '$scrollTop', '$scrollLeft', 'manageScrollPosition', toProperty: 'displayBuffer'
 
-  constructor: ({@softTabs, initialLine, tabLength, softWrap, @displayBuffer, buffer, registerEditor, suppressCursorCreation}) ->
+  constructor: ({@softTabs, initialLine, initialColumn, tabLength, softWrap, @displayBuffer, buffer, registerEditor, suppressCursorCreation}) ->
     super
 
     @cursors = []
@@ -170,11 +170,9 @@ class Editor extends Model
     @subscribeToDisplayBuffer()
 
     if @getCursors().length is 0 and not suppressCursorCreation
-      if initialLine
-        position = [initialLine, 0]
-      else
-        position = [0, 0]
-      @addCursorAtBufferPosition(position)
+      initialLine = Math.max(parseInt(initialLine) or 0, 0)
+      initialColumn = Math.max(parseInt(initialColumn) or 0, 0)
+      @addCursorAtBufferPosition([initialLine, initialColumn])
 
     @languageMode = new LanguageMode(this)
 

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -27,9 +27,9 @@ class WindowEventHandler
 
     @subscribe $(window), 'blur', -> $("body").addClass('is-blurred')
 
-    @subscribe $(window), 'window:open-path', (event, {pathToOpen, initialLine}) ->
+    @subscribe $(window), 'window:open-path', (event, {pathToOpen, initialLine, initialColumn}) ->
       unless fs.isDirectorySync(pathToOpen)
-        atom.workspaceView?.open(pathToOpen, {initialLine})
+        atom.workspaceView?.open(pathToOpen, {initialLine, initialColumn})
 
     @subscribe $(window), 'beforeunload', =>
       confirmed = atom.workspaceView?.confirmClose()

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -29,7 +29,7 @@ class WindowEventHandler
 
     @subscribe $(window), 'window:open-path', (event, {pathToOpen, initialLine, initialColumn}) ->
       unless fs.isDirectorySync(pathToOpen)
-        atom.workspaceView?.open(pathToOpen, {initialLine, initialColumn})
+        atom.workspace?.open(pathToOpen, {initialLine, initialColumn})
 
     @subscribe $(window), 'beforeunload', =>
       confirmed = atom.workspaceView?.confirmClose()

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -84,6 +84,8 @@ class Workspace extends Model
   # options  - An optional options {Object}
   #   :initialLine - A {Number} indicating which row to move the cursor to
   #                  initially. Defaults to `0`.
+  #   :initialColumn - A {Number} indicating which column to move the cursor to
+  #                    initially. Defaults to `0`.
   #   :split - Either 'left' or 'right'. If 'left', the item will be opened in
   #            leftmost pane of the current active pane's row. If 'right', the
   #            item will be opened in the rightmost pane of the current active
@@ -124,12 +126,14 @@ class Workspace extends Model
   # options  - An optional options {Object}
   #   :initialLine - A {Number} indicating which row to move the cursor to
   #                  initially. Defaults to `0`.
+  #   :initialColumn - A {Number} indicating which column to move the cursor to
+  #                    initially. Defaults to `0`.
   #   :activatePane - A {Boolean} indicating whether to call {Pane::activate} on
   #                   the containing pane. Defaults to `true`.
   openSync: (uri='', options={}) ->
     deprecate("Don't use the `changeFocus` option") if options.changeFocus?
 
-    {initialLine} = options
+    {initialLine, initialColumn} = options
     # TODO: Remove deprecated changeFocus option
     activatePane = options.activatePane ? options.changeFocus ? true
     uri = atom.project.resolve(uri)
@@ -137,7 +141,7 @@ class Workspace extends Model
     item = @activePane.itemForUri(uri)
     if uri
       item ?= opener(uri, options) for opener in @getOpeners() when !item
-    item ?= atom.project.openSync(uri, {initialLine})
+    item ?= atom.project.openSync(uri, {initialLine, initialColumn})
 
     @activePane.activateItem(item)
     @itemOpened(item)


### PR DESCRIPTION
Adds an `initialColumn` option to `Workspace::open`

Fixes #1880
