### PR TITLE
Safe mode

### DIFF
--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -148,7 +148,7 @@ class Atom extends Model
     ThemeManager = require './theme-manager'
     ContextMenuManager = require './context-menu-manager'
     MenuManager = require './menu-manager'
-    {devMode, resourcePath} = @getLoadSettings()
+    {devMode, safeMode, resourcePath} = @getLoadSettings()
     configDirPath = @getConfigDirPath()
 
     # Add 'src/exports' to module search path.
@@ -163,7 +163,7 @@ class Atom extends Model
     @config = new Config({configDirPath, resourcePath})
     @keymaps = new KeymapManager({configDirPath, resourcePath})
     @keymap = @keymaps # Deprecated
-    @packages = new PackageManager({devMode, configDirPath, resourcePath})
+    @packages = new PackageManager({devMode, configDirPath, resourcePath, safeMode})
     @themes = new ThemeManager({packageManager: @packages, configDirPath, resourcePath})
     @contextMenu = new ContextMenuManager(devMode)
     @menu = new MenuManager({resourcePath})

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -140,6 +140,7 @@ class AtomApplication
     @on 'application:open-file', -> @promptForPath(type: 'file')
     @on 'application:open-folder', -> @promptForPath(type: 'folder')
     @on 'application:open-dev', -> @promptForPath(devMode: true)
+    @on 'application:open-safe', -> @promptForPath(safeMode: true)
     @on 'application:inspect', ({x,y, atomWindow}) ->
       atomWindow ?= @focusedWindow()
       atomWindow?.browserWindow.inspectElement(x, y)
@@ -420,8 +421,10 @@ class AtomApplication
   #   :type - A String which specifies the type of the dialog, could be 'file',
   #           'folder' or 'all'. The 'all' is only available on OS X.
   #   :devMode - A Boolean which controls whether any newly opened windows
-  #              should  be in dev mode or not.
-  promptForPath: ({type, devMode}={}) ->
+  #              should be in dev mode or not.
+  #   :safeMode - A Boolean which controls whether any newly opened windows
+  #               should be in safe mode or not.
+  promptForPath: ({type, devMode, safeMode}={}) ->
     type ?= 'all'
     properties =
       switch type
@@ -430,4 +433,4 @@ class AtomApplication
         when 'all' then ['openFile', 'openDirectory']
         else throw new Error("#{type} is an invalid type for promptForPath")
     dialog.showOpenDialog title: 'Open', properties: properties.concat(['multiSelections', 'createDirectory']), (pathsToOpen) =>
-      @openPaths({pathsToOpen, devMode})
+      @openPaths({pathsToOpen, devMode, safeMode})

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -73,6 +73,7 @@ parseCommandLine = ->
   options.alias('l', 'log-file').string('l').describe('l', 'Log all output to file.')
   options.alias('n', 'new-window').boolean('n').describe('n', 'Open a new window.')
   options.alias('s', 'spec-directory').string('s').describe('s', 'Set the spec directory (default: Atom\'s spec directory).')
+  options.boolean('safe').describe('safe', 'Do not load any packages from ~/.atom/packages or ~/.atom/dev/packages.')
   options.alias('t', 'test').boolean('t').describe('t', 'Run the specified specs and exit with error code on failures.')
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')
   options.alias('w', 'wait').boolean('w').describe('w', 'Wait for window to be closed before returning.')
@@ -88,6 +89,7 @@ parseCommandLine = ->
 
   executedFrom = args['executed-from']
   devMode = args['dev']
+  safeMode = args['safe']
   pathsToOpen = args._
   pathsToOpen = [executedFrom] if executedFrom and pathsToOpen.length is 0
   test = args['test']
@@ -107,6 +109,6 @@ parseCommandLine = ->
   catch
     resourcePath = path.dirname(path.dirname(__dirname))
 
-  {resourcePath, pathsToOpen, executedFrom, test, version, pidToKillWhenClosed, devMode, newWindow, specDirectory, logFile}
+  {resourcePath, pathsToOpen, executedFrom, test, version, pidToKillWhenClosed, devMode, safeMode, newWindow, specDirectory, logFile}
 
 start()

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -73,7 +73,7 @@ parseCommandLine = ->
   options.alias('l', 'log-file').string('l').describe('l', 'Log all output to file.')
   options.alias('n', 'new-window').boolean('n').describe('n', 'Open a new window.')
   options.alias('s', 'spec-directory').string('s').describe('s', 'Set the spec directory (default: Atom\'s spec directory).')
-  options.boolean('safe').describe('safe', 'Do not load any packages from ~/.atom/packages or ~/.atom/dev/packages.')
+  options.boolean('safe').describe('safe', 'Do not load packages from ~/.atom/packages or ~/.atom/dev/packages.')
   options.alias('t', 'test').boolean('t').describe('t', 'Run the specified specs and exit with error code on failures.')
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')
   options.alias('w', 'wait').boolean('w').describe('w', 'Wait for window to be closed before returning.')

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -27,10 +27,12 @@ module.exports =
 class PackageManager
   Emitter.includeInto(this)
 
-  constructor: ({configDirPath, devMode, @resourcePath}) ->
-    @packageDirPaths = [path.join(configDirPath, "packages")]
-    if devMode
-      @packageDirPaths.unshift(path.join(configDirPath, "dev", "packages"))
+  constructor: ({configDirPath, devMode, safeMode, @resourcePath}) ->
+    @packageDirPaths = []
+    unless safeMode
+      if devMode
+        @packageDirPaths.push(path.join(configDirPath, "dev", "packages"))
+      @packageDirPaths.push(path.join(configDirPath, "packages"))
 
     @loadedPackages = {}
     @activePackages = {}

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -120,6 +120,7 @@ class WorkspaceView extends View
     @command 'application:open-file', -> ipc.send('command', 'application:open-file')
     @command 'application:open-folder', -> ipc.send('command', 'application:open-folder')
     @command 'application:open-dev', -> ipc.send('command', 'application:open-dev')
+    @command 'application:open-safe', -> ipc.send('command', 'application:open-safe')
     @command 'application:minimize', -> ipc.send('command', 'application:minimize')
     @command 'application:zoom', -> ipc.send('command', 'application:zoom')
     @command 'application:bring-all-windows-to-front', -> ipc.send('command', 'application:bring-all-windows-to-front')


### PR DESCRIPTION
Adds `--safe` command line option to not load any packages from `~/.atom/packages` or `~/.atom/dev/packages`.

Closes atom/settings-view#67
