### PR TITLE
Fix split option errors

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -127,6 +127,22 @@ describe "Workspace", ->
             expect(pane1.items).toEqual [editor]
             expect(pane2.items).toEqual []
 
+      describe "when a pane axis is to the left of the current pane", ->
+        it "opens the new item in the current pane", ->
+          editor = null
+          pane1 = workspace.activePane
+          pane2 = pane1.splitLeft()
+          pane3 = pane2.splitDown()
+          pane1.activate()
+          expect(workspace.activePane).toBe pane1
+
+          waitsForPromise ->
+            workspace.open('a', split: 'left').then (o) -> editor = o
+
+          runs ->
+            expect(workspace.activePane).toBe pane1
+            expect(pane1.items).toEqual [editor]
+
       describe "when the 'split' option is 'right'", ->
         it "opens the editor in the rightmost pane of the current pane axis", ->
           editor = null

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -151,6 +151,26 @@ describe "Workspace", ->
             expect(pane1.items).toEqual []
             expect(pane2.items).toEqual [editor]
 
+        describe "when a pane axis is to the right of the current pane", ->
+          it "opens the new item in a new pane split to the right of the current pane", ->
+            editor = null
+            pane1 = workspace.activePane
+            pane2 = pane1.splitRight()
+            pane3 = pane2.splitDown()
+            pane1.activate()
+            expect(workspace.activePane).toBe pane1
+            pane4 = null
+
+            waitsForPromise ->
+              workspace.open('a', split: 'right').then (o) -> editor = o
+
+            runs ->
+              pane4 = workspace.getPanes().filter((p) -> p != pane1)[0]
+              expect(workspace.activePane).toBe pane4
+              expect(pane4.items).toEqual [editor]
+              expect(workspace.paneContainer.root.children[0]).toBe pane1
+              expect(workspace.paneContainer.root.children[1]).toBe pane4
+
     describe "when passed a path that matches a custom opener", ->
       it "returns the resource returned by the custom opener", ->
         fooOpener = (pathToOpen, options) -> { foo: pathToOpen, options } if pathToOpen?.match(/\.foo/)

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -127,7 +127,7 @@ describe "Workspace", ->
             expect(pane1.items).toEqual [editor]
             expect(pane2.items).toEqual []
 
-      describe "when a pane axis is to the left of the current pane", ->
+      describe "when a pane axis is the leftmost sibling of the current pane", ->
         it "opens the new item in the current pane", ->
           editor = null
           pane1 = workspace.activePane
@@ -167,7 +167,7 @@ describe "Workspace", ->
             expect(pane1.items).toEqual []
             expect(pane2.items).toEqual [editor]
 
-        describe "when a pane axis is to the right of the current pane", ->
+        describe "when a pane axis is the rightmost sibling of the current pane", ->
           it "opens the new item in a new pane split to the right of the current pane", ->
             editor = null
             pane1 = workspace.activePane

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -351,6 +351,10 @@ class Pane extends Model
   # otherwise returns a new pane created by splitting this pane rightward.
   findOrCreateRightmostSibling: ->
     if @parent.orientation is 'horizontal'
-      last(@parent.children)
+      rightmostSibling = last(@parent.children)
+      if rightmostSibling instanceof PaneAxis
+        @splitRight()
+      else
+        rightmostSibling
     else
       @splitRight()

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -339,15 +339,19 @@ class Pane extends Model
     newPane.activate()
     newPane
 
-  # If the parent is a horizontal axis, returns its first child;
-  # otherwise this pane.
+  # If the parent is a horizontal axis, returns its first child if it is a pane;
+  # otherwise returns this pane.
   findLeftmostSibling: ->
     if @parent.orientation is 'horizontal'
-      @parent.children[0]
+      [leftmostSibling] = @parent.children
+      if leftmostSibling instanceof PaneAxis
+        this
+      else
+        leftmostSibling
     else
       this
 
-  # If the parent is a horizontal axis, returns its last child;
+  # If the parent is a horizontal axis, returns its last child if it is a pane;
   # otherwise returns a new pane created by splitting this pane rightward.
   findOrCreateRightmostSibling: ->
     if @parent.orientation is 'horizontal'


### PR DESCRIPTION
The pane sibling methods were throwing errors when the left or rightmost sibling was a `PaneAxis` instead of a `Pane`.

Closes #1917
