### PR TITLE
Refine scrollbar interactions

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -979,6 +979,7 @@ describe "DisplayBuffer", ->
   describe "::setScrollLeft", ->
     beforeEach ->
       displayBuffer.manageScrollPosition = true
+      displayBuffer.setLineHeight(10)
       displayBuffer.setDefaultCharWidth(10)
 
     it "disallows negative values", ->
@@ -1001,6 +1002,7 @@ describe "DisplayBuffer", ->
       displayBuffer.manageScrollPosition = true
       displayBuffer.setLineHeight(10)
       displayBuffer.setDefaultCharWidth(10)
+      displayBuffer.setHorizontalScrollbarHeight(0)
 
       displayBuffer.setHeight(50)
       displayBuffer.setWidth(50)

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -1,4 +1,4 @@
-{extend, flatten, toArray} = require 'underscore-plus'
+{extend, flatten, toArray, last} = require 'underscore-plus'
 ReactEditorView = require '../src/react-editor-view'
 nbsp = String.fromCharCode(160)
 
@@ -528,6 +528,25 @@ describe "EditorComponent", ->
       horizontalScrollbarNode.dispatchEvent(new UIEvent('scroll'))
 
       expect(editor.getScrollLeft()).toBe 100
+
+    it "does not obscure the last line with the horizontal scrollbar", ->
+      node.style.height = 4.5 * lineHeightInPixels + 'px'
+      node.style.width = 10 * charWidth + 'px'
+      component.measureHeightAndWidth()
+      editor.setScrollBottom(editor.getScrollHeight())
+      lastLineNode = last(node.querySelectorAll('.line'))
+      bottomOfLastLine = lastLineNode.getBoundingClientRect().bottom
+      topOfHorizontalScrollbar = horizontalScrollbarNode.getBoundingClientRect().top
+      expect(bottomOfLastLine).toBe topOfHorizontalScrollbar
+
+      # Render no space below the last line when there's no horizontal scrollbar
+      node.style.width = 100 * charWidth + 'px'
+      component.measureHeightAndWidth()
+      editor.setScrollBottom(editor.getScrollHeight())
+      lastLineNode = last(node.querySelectorAll('.line'))
+      bottomOfLastLine = lastLineNode.getBoundingClientRect().bottom
+      bottomOfEditor = node.getBoundingClientRect().bottom
+      expect(bottomOfLastLine).toBe bottomOfEditor
 
     describe "when a mousewheel event occurs on the editor", ->
       it "updates the horizontal or vertical scrollbar depending on which delta is greater (x or y)", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -580,6 +580,13 @@ describe "EditorComponent", ->
       expect(verticalScrollbarNode.style.overflowX).toBe ''
       expect(horizontalScrollbarNode.style.overflowY).toBe 'hidden'
 
+    it "accounts for the width of the gutter in the scrollWidth of the horizontal scrollbar", ->
+      gutterNode = node.querySelector('.gutter')
+      node.style.width = 10 * charWidth + 'px'
+      component.measureHeightAndWidth()
+
+      expect(horizontalScrollbarNode.scrollWidth).toBe gutterNode.offsetWidth + editor.getScrollWidth()
+
     describe "when a mousewheel event occurs on the editor", ->
       it "updates the horizontal or vertical scrollbar depending on which delta is greater (x or y)", ->
         node.style.height = 4.5 * lineHeightInPixels + 'px'

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -603,6 +603,21 @@ describe "EditorComponent", ->
       expect(verticalScrollbarNode.style.display).toBe 'none'
       expect(horizontalScrollbarNode.style.display).toBe ''
 
+    it "makes the dummy scrollbar divs only as tall/wide as the actual scrollbars", ->
+      atom.themes.applyStylesheet "test", """
+        ::-webkit-scrollbar {
+          width: 8px;
+          height: 8px;
+        }
+      """
+
+      node.style.height = 4 * lineHeightInPixels + 'px'
+      node.style.width = 10 * charWidth + 'px'
+      component.measureHeightAndWidth()
+
+      expect(verticalScrollbarNode.offsetWidth).toBe 8
+      expect(horizontalScrollbarNode.offsetHeight).toBe 8
+
     it "assigns the bottom/right of the scrollbars to the width of the opposite scrollbar if it is visible", ->
       scrollbarCornerNode = node.querySelector('.scrollbar-corner')
 

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -580,6 +580,29 @@ describe "EditorComponent", ->
 
       expect(rightOfLongestLine).toBe leftOfVerticalScrollbar - 1 # Leave 1 px so the cursor is visible on the end of the line
 
+    it "only displays dummy scrollbars when scrollable in that direction", ->
+      expect(verticalScrollbarNode.style.display).toBe 'none'
+      expect(horizontalScrollbarNode.style.display).toBe 'none'
+
+      node.style.height = 4.5 * lineHeightInPixels + 'px'
+      node.style.width = '1000px'
+      component.measureHeightAndWidth()
+
+      expect(verticalScrollbarNode.style.display).toBe ''
+      expect(horizontalScrollbarNode.style.display).toBe 'none'
+
+      node.style.width = 10 * charWidth + 'px'
+      component.measureHeightAndWidth()
+
+      expect(verticalScrollbarNode.style.display).toBe ''
+      expect(horizontalScrollbarNode.style.display).toBe ''
+
+      node.style.height = 20 * lineHeightInPixels + 'px'
+      component.measureHeightAndWidth()
+
+      expect(verticalScrollbarNode.style.display).toBe 'none'
+      expect(horizontalScrollbarNode.style.display).toBe ''
+
     it "assigns the bottom/right of the scrollbars to the width of the opposite scrollbar if it is visible", ->
       scrollbarCornerNode = node.querySelector('.scrollbar-corner')
 

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -564,7 +564,6 @@ describe "EditorComponent", ->
     it "assigns the overflow to 'hidden' in the opposite direction unless the editor scrollable in that direction", ->
       expect(verticalScrollbarNode.style.overflowX).toBe 'hidden'
       expect(horizontalScrollbarNode.style.overflowY).toBe 'hidden'
-      return
 
       node.style.height = 4.5 * lineHeightInPixels + 'px'
       component.measureHeightAndWidth()

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -561,24 +561,38 @@ describe "EditorComponent", ->
       bottomOfEditor = node.getBoundingClientRect().bottom
       expect(bottomOfLastLine).toBe bottomOfEditor
 
-    it "assigns the overflow to 'hidden' in the opposite direction unless the editor scrollable in that direction", ->
-      expect(verticalScrollbarNode.style.overflowX).toBe 'hidden'
-      expect(horizontalScrollbarNode.style.overflowY).toBe 'hidden'
+    it "does not obscure the last character of the longest line with the vertical scrollbar", ->
+      node.style.height = 7 * lineHeightInPixels + 'px'
+      node.style.width = 10 * charWidth + 'px'
+      component.measureHeightAndWidth()
+
+      editor.setScrollLeft(Infinity)
+
+      lineNodes = node.querySelectorAll('.line')
+      rightOfLongestLine = lineNodes[6].getBoundingClientRect().right
+      leftOfVerticalScrollbar = verticalScrollbarNode.getBoundingClientRect().left
+
+      expect(rightOfLongestLine).toBe leftOfVerticalScrollbar - 1 # Leave 1 px so the cursor is visible on the end of the line
+
+    it "assigns the bottom/right of the scrollbars to the width of the opposite scrollbar if it is visible", ->
+      expect(verticalScrollbarNode.style.bottom).toBe ''
+      expect(horizontalScrollbarNode.style.right).toBe ''
 
       node.style.height = 4.5 * lineHeightInPixels + 'px'
+      node.style.width = '1000px'
       component.measureHeightAndWidth()
-      expect(verticalScrollbarNode.style.overflowX).toBe 'hidden'
-      expect(horizontalScrollbarNode.style.overflowY).toBe ''
+      expect(verticalScrollbarNode.style.bottom).toBe ''
+      expect(horizontalScrollbarNode.style.right).toBe verticalScrollbarNode.offsetWidth + 'px'
 
       node.style.width = 10 * charWidth + 'px'
       component.measureHeightAndWidth()
-      expect(verticalScrollbarNode.style.overflowX).toBe ''
-      expect(horizontalScrollbarNode.style.overflowY).toBe ''
+      expect(verticalScrollbarNode.style.bottom).toBe horizontalScrollbarNode.offsetHeight + 'px'
+      expect(horizontalScrollbarNode.style.right).toBe verticalScrollbarNode.offsetWidth + 'px'
 
       node.style.height = 20 * lineHeightInPixels + 'px'
       component.measureHeightAndWidth()
-      expect(verticalScrollbarNode.style.overflowX).toBe ''
-      expect(horizontalScrollbarNode.style.overflowY).toBe 'hidden'
+      expect(verticalScrollbarNode.style.bottom).toBe horizontalScrollbarNode.offsetHeight + 'px'
+      expect(horizontalScrollbarNode.style.right).toBe ''
 
     it "accounts for the width of the gutter in the scrollWidth of the horizontal scrollbar", ->
       gutterNode = node.querySelector('.gutter')

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -581,6 +581,8 @@ describe "EditorComponent", ->
       expect(rightOfLongestLine).toBe leftOfVerticalScrollbar - 1 # Leave 1 px so the cursor is visible on the end of the line
 
     it "assigns the bottom/right of the scrollbars to the width of the opposite scrollbar if it is visible", ->
+      scrollbarCornerNode = node.querySelector('.scrollbar-corner')
+
       expect(verticalScrollbarNode.style.bottom).toBe ''
       expect(horizontalScrollbarNode.style.right).toBe ''
 
@@ -589,16 +591,19 @@ describe "EditorComponent", ->
       component.measureHeightAndWidth()
       expect(verticalScrollbarNode.style.bottom).toBe ''
       expect(horizontalScrollbarNode.style.right).toBe verticalScrollbarNode.offsetWidth + 'px'
+      expect(scrollbarCornerNode.style.display).toBe 'none'
 
       node.style.width = 10 * charWidth + 'px'
       component.measureHeightAndWidth()
       expect(verticalScrollbarNode.style.bottom).toBe horizontalScrollbarNode.offsetHeight + 'px'
       expect(horizontalScrollbarNode.style.right).toBe verticalScrollbarNode.offsetWidth + 'px'
+      expect(scrollbarCornerNode.style.display).toBe ''
 
       node.style.height = 20 * lineHeightInPixels + 'px'
       component.measureHeightAndWidth()
       expect(verticalScrollbarNode.style.bottom).toBe horizontalScrollbarNode.offsetHeight + 'px'
       expect(horizontalScrollbarNode.style.right).toBe ''
+      expect(scrollbarCornerNode.style.display).toBe 'none'
 
     it "accounts for the width of the gutter in the scrollWidth of the horizontal scrollbar", ->
       gutterNode = node.querySelector('.gutter')

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -604,6 +604,10 @@ describe "EditorComponent", ->
       expect(horizontalScrollbarNode.style.display).toBe ''
 
     it "makes the dummy scrollbar divs only as tall/wide as the actual scrollbars", ->
+      node.style.height = 4 * lineHeightInPixels + 'px'
+      node.style.width = 10 * charWidth + 'px'
+      component.measureHeightAndWidth()
+
       atom.themes.applyStylesheet "test", """
         ::-webkit-scrollbar {
           width: 8px;
@@ -611,12 +615,11 @@ describe "EditorComponent", ->
         }
       """
 
-      node.style.height = 4 * lineHeightInPixels + 'px'
-      node.style.width = 10 * charWidth + 'px'
-      component.measureHeightAndWidth()
-
+      scrollbarCornerNode = node.querySelector('.scrollbar-corner')
       expect(verticalScrollbarNode.offsetWidth).toBe 8
       expect(horizontalScrollbarNode.offsetHeight).toBe 8
+      expect(scrollbarCornerNode.offsetWidth).toBe 8
+      expect(scrollbarCornerNode.offsetHeight).toBe 8
 
     it "assigns the bottom/right of the scrollbars to the width of the opposite scrollbar if it is visible", ->
       scrollbarCornerNode = node.querySelector('.scrollbar-corner')

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -188,6 +188,20 @@ describe "EditorComponent", ->
       expect(lines[4].textContent).toBe "#{nbsp}3"
       expect(lines[5].textContent).toBe "#{nbsp}•"
 
+    it "pads line numbers to be right justified based on the maximum number of line number digits", ->
+      editor.getBuffer().setText([1..10].join('\n'))
+      lineNumberNodes = toArray(node.querySelectorAll('.line-number'))
+
+      for node, i in lineNumberNodes[0..8]
+        expect(node.textContent).toBe "#{nbsp}#{i + 1}"
+      expect(lineNumberNodes[9].textContent).toBe '10'
+
+      # Removes padding when the max number of digits goes down
+      editor.getBuffer().delete([[1, 0], [2, 0]])
+      lineNumberNodes = toArray(node.querySelectorAll('.line-number'))
+      for node, i in lineNumberNodes
+        expect(node.textContent).toBe "#{i + 1}"
+
   describe "cursor rendering", ->
     it "renders the currently visible cursors", ->
       cursor1 = editor.getCursor()

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -547,6 +547,26 @@ describe "EditorComponent", ->
       bottomOfEditor = node.getBoundingClientRect().bottom
       expect(bottomOfLastLine).toBe bottomOfEditor
 
+    it "assigns the overflow to 'hidden' in the opposite direction unless the editor scrollable in that direction", ->
+      expect(verticalScrollbarNode.style.overflowX).toBe 'hidden'
+      expect(horizontalScrollbarNode.style.overflowY).toBe 'hidden'
+      return
+
+      node.style.height = 4.5 * lineHeightInPixels + 'px'
+      component.measureHeightAndWidth()
+      expect(verticalScrollbarNode.style.overflowX).toBe 'hidden'
+      expect(horizontalScrollbarNode.style.overflowY).toBe ''
+
+      node.style.width = 10 * charWidth + 'px'
+      component.measureHeightAndWidth()
+      expect(verticalScrollbarNode.style.overflowX).toBe ''
+      expect(horizontalScrollbarNode.style.overflowY).toBe ''
+
+      node.style.height = 20 * lineHeightInPixels + 'px'
+      component.measureHeightAndWidth()
+      expect(verticalScrollbarNode.style.overflowX).toBe ''
+      expect(horizontalScrollbarNode.style.overflowY).toBe 'hidden'
+
     describe "when a mousewheel event occurs on the editor", ->
       it "updates the horizontal or vertical scrollbar depending on which delta is greater (x or y)", ->
         node.style.height = 4.5 * lineHeightInPixels + 'px'

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -3,7 +3,7 @@ ReactEditorView = require '../src/react-editor-view'
 nbsp = String.fromCharCode(160)
 
 describe "EditorComponent", ->
-  [editor, wrapperView, component, node, verticalScrollbarNode, horizontalScrollbarNode] = []
+  [contentNode, editor, wrapperView, component, node, verticalScrollbarNode, horizontalScrollbarNode] = []
   [lineHeightInPixels, charWidth, delayAnimationFrames, nextAnimationFrame] = []
 
   beforeEach ->
@@ -26,6 +26,9 @@ describe "EditorComponent", ->
       atom.project.open('sample.js').then (o) -> editor = o
 
     runs ->
+      contentNode = document.querySelector('#jasmine-content')
+      contentNode.style.width = '1000px'
+
       wrapperView = new ReactEditorView(editor)
       wrapperView.attachToDom()
       {component} = wrapperView
@@ -37,6 +40,9 @@ describe "EditorComponent", ->
       node = component.getDOMNode()
       verticalScrollbarNode = node.querySelector('.vertical-scrollbar')
       horizontalScrollbarNode = node.querySelector('.horizontal-scrollbar')
+
+  afterEach ->
+    contentNode.style.width = ''
 
   describe "line rendering", ->
     it "renders only the currently-visible lines", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -539,10 +539,9 @@ describe "EditorComponent", ->
       topOfHorizontalScrollbar = horizontalScrollbarNode.getBoundingClientRect().top
       expect(bottomOfLastLine).toBe topOfHorizontalScrollbar
 
-      # Render no space below the last line when there's no horizontal scrollbar
+      # Scroll so there's no space below the last line when the horizontal scrollbar disappears
       node.style.width = 100 * charWidth + 'px'
       component.measureHeightAndWidth()
-      editor.setScrollBottom(editor.getScrollHeight())
       lastLineNode = last(node.querySelectorAll('.line'))
       bottomOfLastLine = lastLineNode.getBoundingClientRect().bottom
       bottomOfEditor = node.getBoundingClientRect().bottom

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -698,6 +698,7 @@ describe "Editor", ->
         editor.setHorizontalScrollMargin(2)
         editor.setLineHeight(10)
         editor.setDefaultCharWidth(10)
+        editor.setHorizontalScrollbarHeight(0)
         editor.setHeight(5.5 * 10)
         editor.setWidth(5.5 * 10)
 
@@ -1138,6 +1139,7 @@ describe "Editor", ->
           editor.setDefaultCharWidth(10)
           editor.setHeight(50)
           editor.setWidth(50)
+          editor.setHorizontalScrollbarHeight(0)
           expect(editor.getScrollTop()).toBe 0
 
           editor.setSelectedBufferRange([[5, 6], [6, 8]], autoscroll: true)
@@ -3098,6 +3100,7 @@ describe "Editor", ->
       editor.setDefaultCharWidth(10)
       editor.setHeight(50)
       editor.setWidth(50)
+      editor.setHorizontalScrollbarHeight(0)
       expect(editor.getScrollTop()).toBe 0
       expect(editor.getScrollLeft()).toBe 0
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -157,7 +157,6 @@ class DisplayBuffer extends Model
   setScrollLeft: (scrollLeft) ->
     if @manageScrollPosition
       @scrollLeft = Math.max(0, Math.min(@getScrollWidth() - @getWidth(), scrollLeft))
-      console.log @scrollLeft
       @scrollLeft
     else
       @scrollLeft = scrollLeft

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -130,6 +130,7 @@ class DisplayBuffer extends Model
     oldWidth = @width
     @width = newWidth
     @updateWrappedScreenLines() if newWidth isnt oldWidth and @softWrap
+    @setScrollTop(@getScrollTop()) # Ensure scrollTop is still valid in case horizontal scrollbar disappeared
     @width
 
   getScrollTop: -> @scrollTop

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -123,9 +123,14 @@ class DisplayBuffer extends Model
   horizontallyScrollable: ->
     not @getSoftWrap() and @getScrollWidth() > @getWidth()
 
+  verticallyScrollable: ->
+    @getScrollHeight() > @getClientHeight()
+
   getHorizontalScrollbarHeight: -> 15
 
-  getWidth: -> @width ? @getScrollWidth()
+  getWidth: ->
+    @width ? @getScrollWidth()
+
   setWidth: (newWidth) ->
     oldWidth = @width
     @width = newWidth
@@ -149,6 +154,8 @@ class DisplayBuffer extends Model
   setScrollLeft: (scrollLeft) ->
     if @manageScrollPosition
       @scrollLeft = Math.max(0, Math.min(@getScrollWidth() - @getWidth(), scrollLeft))
+      console.log @scrollLeft
+      @scrollLeft
     else
       @scrollLeft = scrollLeft
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -32,6 +32,7 @@ class DisplayBuffer extends Model
 
   verticalScrollMargin: 2
   horizontalScrollMargin: 6
+  horizontalScrollbarHeight: 15
 
   constructor: ({tabLength, @editorWidthInChars, @tokenizedBuffer, buffer}={}) ->
     super
@@ -126,7 +127,9 @@ class DisplayBuffer extends Model
   verticallyScrollable: ->
     @getScrollHeight() > @getClientHeight()
 
-  getHorizontalScrollbarHeight: -> 15
+  getHorizontalScrollbarHeight: -> @horizontalScrollbarHeight
+
+  setHorizontalScrollbarHeight: (@horizontalScrollbarHeight) -> @horizontalScrollbarHeight
 
   getWidth: ->
     @width ? @getScrollWidth()

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -239,7 +239,7 @@ class DisplayBuffer extends Model
     unless @getLineHeight() > 0
       throw new Error("You must assign a non-zero lineHeight before calling ::getVisibleRowRange()")
 
-    heightInLines = Math.ceil(@getClientHeight() / @getLineHeight()) + 1
+    heightInLines = Math.ceil(@getHeight() / @getLineHeight()) + 1
     startRow = Math.floor(@getScrollTop() / @getLineHeight())
     endRow = Math.min(@getLineCount(), Math.ceil(startRow + heightInLines))
     [startRow, endRow]

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -114,6 +114,17 @@ class DisplayBuffer extends Model
   getHeight: -> @height ? @getScrollHeight()
   setHeight: (@height) -> @height
 
+  getClientHeight: ->
+    if @horizontallyScrollable()
+      @getHeight() - @getHorizontalScrollbarHeight()
+    else
+      @getHeight()
+
+  horizontallyScrollable: ->
+    not @getSoftWrap() and @getScrollWidth() > @getWidth()
+
+  getHorizontalScrollbarHeight: -> 15
+
   getWidth: -> @width ? @getScrollWidth()
   setWidth: (newWidth) ->
     oldWidth = @width
@@ -124,13 +135,13 @@ class DisplayBuffer extends Model
   getScrollTop: -> @scrollTop
   setScrollTop: (scrollTop) ->
     if @manageScrollPosition
-      @scrollTop = Math.max(0, Math.min(@getScrollHeight() - @getHeight(), scrollTop))
+      @scrollTop = Math.max(0, Math.min(@getScrollHeight() - @getClientHeight(), scrollTop))
     else
       @scrollTop = scrollTop
 
   getScrollBottom: -> @scrollTop + @height
   setScrollBottom: (scrollBottom) ->
-    @setScrollTop(scrollBottom - @height)
+    @setScrollTop(scrollBottom - @getClientHeight())
     @getScrollBottom()
 
   getScrollLeft: -> @scrollLeft
@@ -184,7 +195,7 @@ class DisplayBuffer extends Model
     unless @getLineHeight() > 0
       throw new Error("You must assign a non-zero lineHeight before calling ::getVisibleRowRange()")
 
-    heightInLines = Math.ceil(@getHeight() / @getLineHeight()) + 1
+    heightInLines = Math.ceil(@getClientHeight() / @getLineHeight()) + 1
     startRow = Math.floor(@getScrollTop() / @getLineHeight())
     endRow = Math.min(@getLineCount(), Math.ceil(startRow + heightInLines))
     [startRow, endRow]

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -34,6 +34,8 @@ EditorComponent = React.createClass
       scrollTop = editor.getScrollTop()
       scrollLeft = editor.getScrollLeft()
       lineHeightInPixels = editor.getLineHeight()
+      horizontalScrollbarHeight = editor.getHorizontalScrollbarHeight()
+      verticalScrollbarWidth = editor.getVerticalScrollbarWidth()
 
     className = 'editor editor-colors react'
     className += ' is-focused' if focused
@@ -60,6 +62,7 @@ EditorComponent = React.createClass
         scrollTop: scrollTop
         scrollHeight: scrollHeight
         scrollableInOppositeDirection: editor.horizontallyScrollable() if @isMounted()
+        horizontalScrollbarHeight: horizontalScrollbarHeight
 
       ScrollbarComponent
         ref: 'horizontalScrollbar'
@@ -69,6 +72,7 @@ EditorComponent = React.createClass
         scrollLeft: scrollLeft
         scrollWidth: scrollWidth + @gutterWidth
         scrollableInOppositeDirection: editor.verticallyScrollable() if @isMounted()
+        verticalScrollbarWidth: verticalScrollbarWidth
 
   getRenderedRowRange: ->
     renderedRowRange = @props.editor.getVisibleRowRange()

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -114,7 +114,7 @@ EditorComponent = React.createClass
     @listenForDOMEvents()
     @listenForCommands()
     @measureScrollbars()
-    @subscribe atom.themes, 'stylesheets-changed', @onStylesheetsChanged
+    @subscribe atom.themes, 'stylesheet-added stylsheet-removed', @onStylesheetsChanged
     @props.editor.setVisible(true)
     @requestUpdate()
 
@@ -326,7 +326,10 @@ EditorComponent = React.createClass
 
     event.preventDefault()
 
-  onStylesheetsChanged: ->
+  onStylesheetsChanged: (stylesheet) ->
+    # Only update when the scrollbar is changed
+    return unless @containsScrollbarSelector(stylesheet)
+
     # Believe it or not, proper handling of changes to scrollbar styles requires
     # three DOM updates.
 
@@ -345,6 +348,12 @@ EditorComponent = React.createClass
     # Finally, we restore the scrollbars based on the newly-measured dimensions
     # if the editor's content and dimensions require them to be visible.
     @requestUpdate()
+
+  containsScrollbarSelector: (stylesheet) ->
+    for rule in stylesheet.cssRules
+      if rule.selectorText?.indexOf('scrollbar') > -1
+        return true
+    false
 
   clearPreservedRowRange: ->
     @preservedRowRange = null

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -55,6 +55,7 @@ EditorComponent = React.createClass
         onScroll: @onVerticalScroll
         scrollTop: scrollTop
         scrollHeight: scrollHeight
+        scrollableInOppositeDirection: editor.horizontallyScrollable() if @isMounted()
 
       ScrollbarComponent
         ref: 'horizontalScrollbar'
@@ -63,6 +64,7 @@ EditorComponent = React.createClass
         onScroll: @onHorizontalScroll
         scrollLeft: scrollLeft
         scrollWidth: scrollWidth
+        scrollableInOppositeDirection: editor.verticallyScrollable() if @isMounted()
 
   getRenderedRowRange: ->
     renderedRowRange = @props.editor.getVisibleRowRange()

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -20,10 +20,13 @@ EditorComponent = React.createClass
   cursorsMoved: false
   preservedRowRange: null
   scrollingVertically: false
+  gutterWidth: 0
 
   render: ->
     {focused, fontSize, lineHeight, fontFamily, showIndentGuide} = @state
     {editor, cursorBlinkPeriod, cursorBlinkResumeDelay} = @props
+    maxLineNumberDigits = editor.getScreenLineCount().toString().length
+
     if @isMounted()
       renderedRowRange = @getRenderedRowRange()
       scrollHeight = editor.getScrollHeight()
@@ -37,8 +40,9 @@ EditorComponent = React.createClass
 
     div className: className, style: {fontSize, lineHeight, fontFamily}, tabIndex: -1,
       GutterComponent {
-        editor, renderedRowRange, scrollTop, scrollHeight,
-        lineHeight: lineHeightInPixels, @pendingChanges
+        editor, renderedRowRange, maxLineNumberDigits, scrollTop, scrollHeight,
+        lineHeight: lineHeightInPixels, fontSize, fontFamily, @pendingChanges,
+        onWidthChanged: @onGutterWidthChanged
       }
 
       EditorScrollViewComponent {
@@ -63,7 +67,7 @@ EditorComponent = React.createClass
         orientation: 'horizontal'
         onScroll: @onHorizontalScroll
         scrollLeft: scrollLeft
-        scrollWidth: scrollWidth
+        scrollWidth: scrollWidth + @gutterWidth
         scrollableInOppositeDirection: editor.verticallyScrollable() if @isMounted()
 
   getRenderedRowRange: ->
@@ -326,6 +330,9 @@ EditorComponent = React.createClass
 
   onCursorsMoved: ->
     @cursorsMoved = true
+
+  onGutterWidthChanged: (@gutterWidth) ->
+    @requestUpdate()
 
   requestUpdate: ->
     if @batchingUpdates

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -266,8 +266,10 @@ EditorComponent = React.createClass
 
     {editor} = @props
     scrollbarCornerNode = @refs.scrollbarCorner.getDOMNode()
-    editor.setVerticalScrollbarWidth(scrollbarCornerNode.offsetWidth - scrollbarCornerNode.clientWidth)
-    editor.setHorizontalScrollbarHeight(scrollbarCornerNode.offsetHeight - scrollbarCornerNode.clientHeight)
+    width = (scrollbarCornerNode.offsetWidth - scrollbarCornerNode.clientWidth) or 15
+    height = (scrollbarCornerNode.offsetHeight - scrollbarCornerNode.clientHeight) or 15
+    editor.setVerticalScrollbarWidth(width)
+    editor.setHorizontalScrollbarHeight(height)
 
   setFontSize: (fontSize) ->
     @setState({fontSize})

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -64,6 +64,7 @@ EditorComponent = React.createClass
         onScroll: @onVerticalScroll
         scrollTop: scrollTop
         scrollHeight: scrollHeight
+        visible: verticallyScrollable
         scrollableInOppositeDirection: horizontallyScrollable
         horizontalScrollbarHeight: horizontalScrollbarHeight
 
@@ -74,6 +75,7 @@ EditorComponent = React.createClass
         onScroll: @onHorizontalScroll
         scrollLeft: scrollLeft
         scrollWidth: scrollWidth + @gutterWidth
+        visible: horizontallyScrollable
         scrollableInOppositeDirection: verticallyScrollable
         verticalScrollbarWidth: verticalScrollbarWidth
 

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -5,6 +5,7 @@ React = require 'react'
 GutterComponent = require './gutter-component'
 EditorScrollViewComponent = require './editor-scroll-view-component'
 ScrollbarComponent = require './scrollbar-component'
+ScrollbarCornerComponent = require './scrollbar-corner-component'
 SubscriberMixin = require './subscriber-mixin'
 
 module.exports =
@@ -36,6 +37,8 @@ EditorComponent = React.createClass
       lineHeightInPixels = editor.getLineHeight()
       horizontalScrollbarHeight = editor.getHorizontalScrollbarHeight()
       verticalScrollbarWidth = editor.getVerticalScrollbarWidth()
+      verticallyScrollable = editor.verticallyScrollable()
+      horizontallyScrollable = editor.horizontallyScrollable()
 
     className = 'editor editor-colors react'
     className += ' is-focused' if focused
@@ -61,7 +64,7 @@ EditorComponent = React.createClass
         onScroll: @onVerticalScroll
         scrollTop: scrollTop
         scrollHeight: scrollHeight
-        scrollableInOppositeDirection: editor.horizontallyScrollable() if @isMounted()
+        scrollableInOppositeDirection: horizontallyScrollable
         horizontalScrollbarHeight: horizontalScrollbarHeight
 
       ScrollbarComponent
@@ -71,8 +74,13 @@ EditorComponent = React.createClass
         onScroll: @onHorizontalScroll
         scrollLeft: scrollLeft
         scrollWidth: scrollWidth + @gutterWidth
-        scrollableInOppositeDirection: editor.verticallyScrollable() if @isMounted()
+        scrollableInOppositeDirection: verticallyScrollable
         verticalScrollbarWidth: verticalScrollbarWidth
+
+      ScrollbarCornerComponent
+        visible: horizontallyScrollable and verticallyScrollable
+        height: horizontalScrollbarHeight
+        width: verticalScrollbarWidth
 
   getRenderedRowRange: ->
     renderedRowRange = @props.editor.getVisibleRowRange()

--- a/src/editor-scroll-view-component.coffee
+++ b/src/editor-scroll-view-component.coffee
@@ -182,17 +182,19 @@ EditorScrollViewComponent = React.createClass
   measureHeightAndWidth: ->
     return unless @isMounted()
 
-    node = @getDOMNode()
-    computedStyle = getComputedStyle(node)
     {editor} = @props
+    node = @getDOMNode()
+    editorNode = node.parentNode
+    {position} = getComputedStyle(editorNode)
+    {width, height} = editorNode.style
 
-    unless computedStyle.height is '0px'
-      clientHeight = node.clientHeight
+    if position is 'absolute' or height
+      clientHeight =  node.clientHeight
       editor.setHeight(clientHeight) if clientHeight > 0
 
-    unless computedStyle.width is '0px'
+    if position is 'absolute' or width
       clientWidth = node.clientWidth
-      editor.setWidth(clientWidth) if clientHeight > 0
+      editor.setWidth(clientWidth) if clientWidth > 0
 
   focus: ->
     @refs.input.focus()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1895,7 +1895,11 @@ class Editor extends Model
 
   verticallyScrollable: -> @displayBuffer.verticallyScrollable()
 
+  getHorizontalScrollbarHeight: -> @displayBuffer.getHorizontalScrollbarHeight()
   setHorizontalScrollbarHeight: (height) -> @displayBuffer.setHorizontalScrollbarHeight(height)
+
+  getVerticalScrollbarWidth: -> @displayBuffer.getVerticalScrollbarWidth()
+  setVerticalScrollbarWidth: (width) -> @displayBuffer.setVerticalScrollbarWidth(width)
 
   # Deprecated: Call {::joinLines} instead.
   joinLine: ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1895,6 +1895,8 @@ class Editor extends Model
 
   verticallyScrollable: -> @displayBuffer.verticallyScrollable()
 
+  setHorizontalScrollbarHeight: (height) -> @displayBuffer.setHorizontalScrollbarHeight(height)
+
   # Deprecated: Call {::joinLines} instead.
   joinLine: ->
     deprecate("Use Editor::joinLines() instead")

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1851,6 +1851,8 @@ class Editor extends Model
   setHeight: (height) -> @displayBuffer.setHeight(height)
   getHeight: -> @displayBuffer.getHeight()
 
+  getClientHeight: -> @displayBuffer.getClientHeight()
+
   setWidth: (width) -> @displayBuffer.setWidth(width)
   getWidth: -> @displayBuffer.getWidth()
 
@@ -1888,6 +1890,10 @@ class Editor extends Model
   scrollToScreenPosition: (screenPosition) -> @displayBuffer.scrollToScreenPosition(screenPosition)
 
   scrollToBufferPosition: (bufferPosition) -> @displayBuffer.scrollToBufferPosition(bufferPosition)
+
+  horizontallyScrollable: -> @displayBuffer.horizontallyScrollable()
+
+  verticallyScrollable: -> @displayBuffer.verticallyScrollable()
 
   # Deprecated: Call {::joinLines} instead.
   joinLine: ->

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -17,7 +17,7 @@ GutterComponent = React.createClass
     [startRow, endRow] = renderedRowRange
     charWidth = editor.getDefaultCharWidth()
     lineHeight = editor.getLineHeight()
-    maxDigits = editor.getLastBufferRow().toString().length
+    maxDigits = editor.getScreenLineCount().toString().length
     style =
       width: charWidth * (maxDigits + 1.5)
       height: scrollHeight
@@ -76,4 +76,4 @@ LineNumberComponent = React.createClass
   iconDivHTML: '<div class="icon-right"></div>'
 
   shouldComponentUpdate: (newProps) ->
-    not isEqualForProperties(newProps, @props, 'lineHeight', 'screenRow')
+    not isEqualForProperties(newProps, @props, 'lineHeight', 'screenRow', 'maxDigits')

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -8,18 +8,19 @@ GutterComponent = React.createClass
   displayName: 'GutterComponent'
   mixins: [SubscriberMixin]
 
+  lastMeasuredWidth: null
+
   render: ->
     div className: 'gutter',
       @renderLineNumbers() if @isMounted()
 
   renderLineNumbers: ->
-    {editor, renderedRowRange, scrollTop, scrollHeight} = @props
+    {editor, renderedRowRange, maxLineNumberDigits, scrollTop, scrollHeight} = @props
     [startRow, endRow] = renderedRowRange
     charWidth = editor.getDefaultCharWidth()
     lineHeight = editor.getLineHeight()
-    maxDigits = editor.getScreenLineCount().toString().length
     style =
-      width: charWidth * (maxDigits + 1.5)
+      width: charWidth * (maxLineNumberDigits + 1.5)
       height: scrollHeight
       WebkitTransform: "translate3d(0, #{-scrollTop}px, 0)"
 
@@ -35,7 +36,7 @@ GutterComponent = React.createClass
 
       key = tokenizedLines[i].id
       screenRow = startRow + i
-      lineNumbers.push(LineNumberComponent({key, lineNumber, maxDigits, bufferRow, screenRow, lineHeight}))
+      lineNumbers.push(LineNumberComponent({key, lineNumber, maxLineNumberDigits, bufferRow, screenRow, lineHeight}))
       lastBufferRow = bufferRow
 
     div className: 'line-numbers', style: style,
@@ -45,13 +46,20 @@ GutterComponent = React.createClass
   # non-zero-delta change to the screen lines has occurred within the current
   # visible row range.
   shouldComponentUpdate: (newProps) ->
-    return true unless isEqualForProperties(newProps, @props, 'renderedRowRange', 'scrollTop', 'lineHeight')
+    return true unless isEqualForProperties(newProps, @props, 'renderedRowRange', 'scrollTop', 'lineHeight', 'fontSize')
 
     {renderedRowRange, pendingChanges} = newProps
     for change in pendingChanges when change.screenDelta > 0 or change.bufferDelta > 0
       return true unless change.end <= renderedRowRange.start or renderedRowRange.end <= change.start
 
     false
+
+  componentDidUpdate: (oldProps) ->
+    unless @lastMeasuredWidth? and isEqualForProperties(oldProps, @props, 'maxLineNumberDigits', 'fontSize', 'fontFamily')
+      width = @getDOMNode().offsetWidth
+      if width isnt @lastMeasuredWidth
+        @lastMeasuredWidth = width
+        @props.onWidthChanged(width)
 
 LineNumberComponent = React.createClass
   displayName: 'LineNumberComponent'
@@ -66,9 +74,9 @@ LineNumberComponent = React.createClass
       dangerouslySetInnerHTML: {__html: @buildInnerHTML()}
 
   buildInnerHTML: ->
-    {lineNumber, maxDigits} = @props
-    if lineNumber.length < maxDigits
-      padding = multiplyString('&nbsp;', maxDigits - lineNumber.length)
+    {lineNumber, maxLineNumberDigits} = @props
+    if lineNumber.length < maxLineNumberDigits
+      padding = multiplyString('&nbsp;', maxLineNumberDigits - lineNumber.length)
       padding + lineNumber + @iconDivHTML
     else
       lineNumber + @iconDivHTML
@@ -76,4 +84,4 @@ LineNumberComponent = React.createClass
   iconDivHTML: '<div class="icon-right"></div>'
 
   shouldComponentUpdate: (newProps) ->
-    not isEqualForProperties(newProps, @props, 'lineHeight', 'screenRow', 'maxDigits')
+    not isEqualForProperties(newProps, @props, 'lineHeight', 'screenRow', 'maxLineNumberDigits')

--- a/src/scrollbar-component.coffee
+++ b/src/scrollbar-component.coffee
@@ -1,13 +1,20 @@
 React = require 'react'
 {div} = require 'reactionary'
-{isEqualForProperties} = require 'underscore-plus'
+{extend, isEqualForProperties} = require 'underscore-plus'
 
 module.exports =
 ScrollbarComponent = React.createClass
   render: ->
-    {orientation, className, scrollHeight, scrollWidth} = @props
+    {orientation, className, scrollHeight, scrollWidth, scrollableInOppositeDirection} = @props
 
-    div {className, @onScroll},
+    style = {}
+    switch orientation
+      when 'vertical'
+        style.overflowX = 'hidden' unless scrollableInOppositeDirection
+      when 'horizontal'
+        style.overflowY = 'hidden' unless scrollableInOppositeDirection
+
+    div {className, style, @onScroll},
       switch orientation
         when 'vertical'
           div className: 'scrollbar-content', style: {height: scrollHeight}
@@ -23,9 +30,9 @@ ScrollbarComponent = React.createClass
   shouldComponentUpdate: (newProps) ->
     switch @props.orientation
       when 'vertical'
-        not isEqualForProperties(newProps, @props, 'scrollHeight', 'scrollTop')
+        not isEqualForProperties(newProps, @props, 'scrollHeight', 'scrollTop', 'scrollableInOppositeDirection')
       when 'horizontal'
-        not isEqualForProperties(newProps, @props, 'scrollWidth', 'scrollLeft')
+        not isEqualForProperties(newProps, @props, 'scrollWidth', 'scrollLeft', 'scrollableInOppositeDirection')
 
   componentDidUpdate: ->
     {orientation, scrollTop, scrollLeft} = @props

--- a/src/scrollbar-component.coffee
+++ b/src/scrollbar-component.coffee
@@ -5,10 +5,11 @@ React = require 'react'
 module.exports =
 ScrollbarComponent = React.createClass
   render: ->
-    {orientation, className, scrollHeight, scrollWidth} = @props
+    {orientation, className, scrollHeight, scrollWidth, visible} = @props
     {scrollableInOppositeDirection, horizontalScrollbarHeight, verticalScrollbarWidth} = @props
 
     style = {}
+    style.display = 'none' unless visible
     switch orientation
       when 'vertical'
         style.bottom = horizontalScrollbarHeight if scrollableInOppositeDirection
@@ -29,6 +30,8 @@ ScrollbarComponent = React.createClass
       throw new Error("Must specify an orientation property of 'vertical' or 'horizontal'")
 
   shouldComponentUpdate: (newProps) ->
+    return true if newProps.visible isnt @props.visible
+
     switch @props.orientation
       when 'vertical'
         not isEqualForProperties(newProps, @props, 'scrollHeight', 'scrollTop', 'scrollableInOppositeDirection')

--- a/src/scrollbar-component.coffee
+++ b/src/scrollbar-component.coffee
@@ -5,14 +5,15 @@ React = require 'react'
 module.exports =
 ScrollbarComponent = React.createClass
   render: ->
-    {orientation, className, scrollHeight, scrollWidth, scrollableInOppositeDirection} = @props
+    {orientation, className, scrollHeight, scrollWidth} = @props
+    {scrollableInOppositeDirection, horizontalScrollbarHeight, verticalScrollbarWidth} = @props
 
     style = {}
     switch orientation
       when 'vertical'
-        style.overflowX = 'hidden' unless scrollableInOppositeDirection
+        style.bottom = horizontalScrollbarHeight if scrollableInOppositeDirection
       when 'horizontal'
-        style.overflowY = 'hidden' unless scrollableInOppositeDirection
+        style.right = verticalScrollbarWidth if scrollableInOppositeDirection
 
     div {className, style, @onScroll},
       switch orientation

--- a/src/scrollbar-component.coffee
+++ b/src/scrollbar-component.coffee
@@ -12,8 +12,10 @@ ScrollbarComponent = React.createClass
     style.display = 'none' unless visible
     switch orientation
       when 'vertical'
+        style.width = verticalScrollbarWidth
         style.bottom = horizontalScrollbarHeight if scrollableInOppositeDirection
       when 'horizontal'
+        style.height = horizontalScrollbarHeight
         style.right = verticalScrollbarWidth if scrollableInOppositeDirection
 
     div {className, style, @onScroll},

--- a/src/scrollbar-corner-component.coffee
+++ b/src/scrollbar-corner-component.coffee
@@ -1,0 +1,13 @@
+React = require 'react'
+{div} = require 'reactionary'
+
+module.exports =
+ScrollbarComponent = React.createClass
+  render: ->
+    {visible, width, height} = @props
+    display = 'none' unless visible
+
+    div className: 'scrollbar-corner', style: {display, width, height},
+      div style:
+        height: height + 1
+        width: width + 1

--- a/src/scrollbar-corner-component.coffee
+++ b/src/scrollbar-corner-component.coffee
@@ -4,7 +4,12 @@ React = require 'react'
 module.exports =
 ScrollbarComponent = React.createClass
   render: ->
-    {visible, width, height} = @props
+    {visible, measuringScrollbars, width, height} = @props
+
+    if measuringScrollbars
+      height = 25
+      width = 25
+
     display = 'none' unless visible
 
     div className: 'scrollbar-corner', style: {display, width, height},

--- a/static/editor.less
+++ b/static/editor.less
@@ -24,7 +24,6 @@
 
     height: 15px;
     overflow-x: auto;
-    overflow-y: hidden;
     z-index: 3;
 
     .scrollbar-content {

--- a/static/editor.less
+++ b/static/editor.less
@@ -24,11 +24,16 @@
 
     height: 15px;
     overflow-x: auto;
+    overflow-y: hidden;
     z-index: 3;
 
     .scrollbar-content {
       height: 15px;
     }
+  }
+
+  .vertical-scrollbar {
+    overflow-x: hidden;
   }
 
   .scroll-view {

--- a/static/editor.less
+++ b/static/editor.less
@@ -36,6 +36,13 @@
     overflow-x: hidden;
   }
 
+  .scrollbar-corner {
+    position: absolute;
+    overflow: auto;
+    bottom: 0;
+    right: 0;
+  }
+
   .scroll-view {
     overflow: hidden;
   }


### PR DESCRIPTION
The previous editor had a host of scrollbar-related issues that are addressed in this PR:
- The horizontal scrollbar would obscure the last line.
- The vertical scrollbar would obscure the last character.
- The horizontal scrollbar didn't extend the entire width of the editor.
- The dummy scrollbars were always 15px wide rather than the true width of a scrollbar based on the stylesheet.
- The dummy scrollbars remained visible even when content was not scrollable, interfering with mouse clicks.
- Scrollbars didn't respond to stylesheet changes until they were hidden and redisplayed.
