### PR TITLE
If atom.sh has non-zero exit show errors captured by nohup. Refers to #1814

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -76,7 +76,13 @@ elif [ $OS == 'Linux' ]; then
     "$ATOM_PATH" --executed-from="$(pwd)" --pid=$$ "$@"
     exit $?
   else
-    nohup "$ATOM_PATH" --executed-from="$(pwd)" --pid=$$ "$@" > /dev/null 2>&1 &
+    (
+    nohup "$ATOM_PATH" --executed-from="$(pwd)" --pid=$$ "$@" > /tmp/atom-nohup.out 2>&1
+    if [ $? -ne 0 ]; then
+      cat /tmp/atom-nohup.out
+      exit $?
+    fi
+    ) &
   fi
 fi
 


### PR DESCRIPTION
This is the only way I could figure out how to get the exit code from `nohup` _and_ still suppress output whilst notifying of the actual error.

EDIT: BTW this is useful because `atom` just silently fails if something goes wrong.
