### PR TITLE
Add Git for Windows as Windows build requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Atom will automatically update when a new release is available.
   * [node.js - 32bit](http://nodejs.org/)
   * [Python 2.7.x](http://www.python.org/download/)
   * [GitHub for Windows](http://windows.github.com/)
+  * [Git for Windows](http://git-scm.com/download/win)
+  * * When installing, select the option "**Use Git from the Windows Command Prompt**" (Git needs to be in your `PATH`)
   * Clone [atom/atom](https://github.com/atom/atom/) to `C:\Users\<user>\github\atom\`
   * Add `C:\Python27;C:\Program Files\nodejs;C:\Users\<user>\github\atom\node_modules\`
     to your PATH


### PR DESCRIPTION
Windows instructions were missing "Git" prerequisite (users were getting "Git not found in PATH" errors from npm).
