### PR TITLE
Make sure gyp uses Python 2 (#1933)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Atom will automatically update when a new release is available.
   * Ubuntu LTS 12.04 64-bit is the recommended platform
   * [node.js](http://nodejs.org/)
   * `sudo apt-get install libgnome-keyring-dev`
+  * `npm config set python /usr/bin/python2 -g` to ensure that gyp uses Python 2
 
   ```sh
   git clone https://github.com/atom/atom


### PR DESCRIPTION
gyp/npm uses /usr/bin/python to build, which is a problem on systems where
/usr/bin/python is Python 3 or higher.  Fortunately, you can tell npm which
Python to use.
