### PR TITLE
Use sudo when running npm ... -g

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Atom will automatically update when a new release is available.
   * Ubuntu LTS 12.04 64-bit is the recommended platform
   * [node.js](http://nodejs.org/)
   * `sudo apt-get install libgnome-keyring-dev`
-  * `npm config set python /usr/bin/python2 -g` to ensure that gyp uses Python 2
+  * `sudo npm config set python /usr/bin/python2 -g` to ensure that gyp uses Python 2
 
   ```sh
   git clone https://github.com/atom/atom


### PR DESCRIPTION
``` sh
$ npm config set python /usr/bin/python2 -g
npm ERR! Error: EACCES, mkdir '/usr/etc'
npm ERR!  { [Error: EACCES, mkdir '/usr/etc'] errno: 3, code: 'EACCES', path: '/usr/etc' }
npm ERR! 
npm ERR! Please try running this command again as root/Administrator.

npm ERR! System Linux 3.13.0-24-generic
npm ERR! command "/usr/bin/node" "/usr/bin/npm" "config" "set" "python" "/usr/bin/python2" "-g"
npm ERR! cwd /home/ionicabizau/Documents
npm ERR! node -v v0.10.28
npm ERR! npm -v 1.4.9
npm ERR! path /usr/etc
npm ERR! code EACCES
npm ERR! errno 3
npm ERR! stack Error: EACCES, mkdir '/usr/etc'
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/ionicabizau/Documents/npm-debug.log
npm ERR! not ok code 0
```

Added `sudo`.
