### PR TITLE
Implements multiple selections clipboard paste

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2070,31 +2070,31 @@ describe "Editor", ->
             'sort'
           ])
 
-      describe ".pasteText()", ->
+      fdescribe ".pasteText()", ->
         it "pastes text into the buffer", ->
           atom.clipboard.write('first')
           editor.pasteText()
-          expect(editor.buffer.lineForRow(0)).toBe "var first = function () {"
-          expect(buffer.lineForRow(1)).toBe "  var first = function(items) {"
+          expect(editor.lineForBufferRow(0)).toBe "var first = function () {"
+          expect(editor.lineForBufferRow(1)).toBe "  var first = function(items) {"
 
         describe 'when the clipboard has many selections', ->
           it "pastes each selection separately into the buffer", ->
             atom.clipboard.write('first\nsecond', {selections: ['first', 'second'] })
             editor.pasteText()
-            expect(editor.buffer.lineForRow(0)).toBe "var first = function () {"
-            expect(buffer.lineForRow(1)).toBe "  var second = function(items) {"
+            expect(editor.lineForBufferRow(0)).toBe "var first = function () {"
+            expect(editor.lineForBufferRow(1)).toBe "  var second = function(items) {"
 
           describe 'and the selections count does not match', ->
             it "pastes the whole text into the buffer", ->
               atom.clipboard.write('first\nsecond\nthird', {selections: ['first', 'second', 'third'] })
               editor.pasteText()
-              expect(editor.buffer.lineForRow(0)).toBe "var first"
-              expect(buffer.lineForRow(1)).toBe "second"
-              expect(buffer.lineForRow(2)).toBe "third = function () {"
+              expect(editor.lineForBufferRow(0)).toBe "var first"
+              expect(editor.lineForBufferRow(1)).toBe "second"
+              expect(editor.lineForBufferRow(2)).toBe "third = function () {"
 
-              expect(editor.buffer.lineForRow(3)).toBe "  var first"
-              expect(buffer.lineForRow(4)).toBe "second"
-              expect(buffer.lineForRow(5)).toBe "third = function(items) {"
+              expect(editor.lineForBufferRow(3)).toBe "  var first"
+              expect(editor.lineForBufferRow(4)).toBe "second"
+              expect(editor.lineForBufferRow(5)).toBe "third = function(items) {"
 
     describe ".indentSelectedRows()", ->
       describe "when nothing is selected", ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2077,7 +2077,7 @@ describe "Editor", ->
           expect(editor.buffer.lineForRow(0)).toBe "var first = function () {"
           expect(buffer.lineForRow(1)).toBe "  var first = function(items) {"
 
-        describe 'when the clipboard have many selections', ->
+        describe 'when the clipboard has many selections', ->
           it "pastes each selection separately into the buffer", ->
             atom.clipboard.write('first\nsecond', {selections: ['first', 'second'] })
             editor.pasteText()

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2065,6 +2065,10 @@ describe "Editor", ->
           expect(buffer.lineForRow(0)).toBe "var quicksort = function () {"
           expect(buffer.lineForRow(1)).toBe "  var sort = function(items) {"
           expect(clipboard.readText()).toBe 'quicksort\nsort'
+          expect(atom.clipboard.readWithMetadata().metadata.selections).toEqual([
+            'quicksort'
+            'sort'
+          ])
 
       describe ".pasteText()", ->
         it "pastes text into the buffer", ->
@@ -2072,6 +2076,25 @@ describe "Editor", ->
           editor.pasteText()
           expect(editor.buffer.lineForRow(0)).toBe "var first = function () {"
           expect(buffer.lineForRow(1)).toBe "  var first = function(items) {"
+
+        describe 'when the clipboard have many selections', ->
+          it "pastes each selection separately into the buffer", ->
+            atom.clipboard.write('first\nsecond', {selections: ['first', 'second'] })
+            editor.pasteText()
+            expect(editor.buffer.lineForRow(0)).toBe "var first = function () {"
+            expect(buffer.lineForRow(1)).toBe "  var second = function(items) {"
+
+          describe 'and the selections count does not match', ->
+            it "pastes the whole text into the buffer", ->
+              atom.clipboard.write('first\nsecond\nthird', {selections: ['first', 'second', 'third'] })
+              editor.pasteText()
+              expect(editor.buffer.lineForRow(0)).toBe "var first"
+              expect(buffer.lineForRow(1)).toBe "second"
+              expect(buffer.lineForRow(2)).toBe "third = function () {"
+
+              expect(editor.buffer.lineForRow(3)).toBe "  var first"
+              expect(buffer.lineForRow(4)).toBe "second"
+              expect(buffer.lineForRow(5)).toBe "third = function(items) {"
 
     describe ".indentSelectedRows()", ->
       describe "when nothing is selected", ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2070,7 +2070,7 @@ describe "Editor", ->
             'sort'
           ])
 
-      fdescribe ".pasteText()", ->
+      describe ".pasteText()", ->
         it "pastes text into the buffer", ->
           atom.clipboard.write('first')
           editor.pasteText()

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2061,13 +2061,17 @@ describe "Editor", ->
 
       describe ".copySelectedText()", ->
         it "copies selected text onto the clipboard", ->
+          editor.setSelectedBufferRanges([[[0,4], [0,13]], [[1,6], [1, 10]], [[2,8], [2, 13]]])
+
           editor.copySelectedText()
           expect(buffer.lineForRow(0)).toBe "var quicksort = function () {"
           expect(buffer.lineForRow(1)).toBe "  var sort = function(items) {"
-          expect(clipboard.readText()).toBe 'quicksort\nsort'
+          expect(buffer.lineForRow(2)).toBe "    if (items.length <= 1) return items;"
+          expect(clipboard.readText()).toBe 'quicksort\nsort\nitems'
           expect(atom.clipboard.readWithMetadata().metadata.selections).toEqual([
             'quicksort'
             'sort'
+            'items'
           ])
 
       describe ".pasteText()", ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -725,7 +725,7 @@ class Editor extends Model
   # Public: For each selection, replace the selected text with the contents of
   # the clipboard.
   #
-  # If the clipboard contains the same number of selection as the current
+  # If the clipboard contains the same number of selections as the current
   # editor, each selection will be replaced with the content of the
   # corresponding clipboard selection text.
   #

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -736,7 +736,7 @@ class Editor extends Model
     containsNewlines = text.indexOf('\n') isnt -1
 
     if metadata?.selections? and metadata.selections.length is @getSelections().length
-      @mutateSelectedText (selection, index) =>
+      @mutateSelectedText (selection, index) ->
         text = metadata.selections[index]
         selection.insertText(text, options)
 

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -514,8 +514,8 @@ class Selection extends Model
     if maintainClipboard
       {text: clipboardText, metadata} = atom.clipboard.readWithMetadata()
 
-      if clipboardMetadata? and clipboardMetadata.selections?
-        clipboardMetadata.selections.push(text)
+      if metadata? and metadata.selections?
+        metadata.selections.push(text)
       else
         metadata = { selections: [clipboardText, text] }
 

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -503,11 +503,24 @@ class Selection extends Model
     @delete()
 
   # Public: Copies the current selection to the clipboard.
+  #
+  # If the `maintainClipboard` is set to `true`, a specific metadata property
+  # is created to store each content copied to the clipboard. The clipboard
+  # `text` still contains the concatenation of the clipboard with the
+  # current selection.
   copy: (maintainClipboard=false) ->
     return if @isEmpty()
     text = @editor.buffer.getTextInRange(@getBufferRange())
     if maintainClipboard
-      text = "#{atom.clipboard.read()}\n#{text}"
+      {text: clipboardText, metadata: clipboardMetadata} = atom.clipboard.readWithMetadata()
+
+      if clipboardMetadata? and clipboardMetadata.selections?
+        metadata = clipboardMetadata
+        clipboardMetadata.selections.push(text)
+      else
+        metadata = { selections: [clipboardText, text] }
+
+      text = "" + (clipboardText) + "\n" + text
     else
       metadata = { indentBasis: @editor.indentationForBufferRow(@getBufferRange().start.row) }
 

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -512,10 +512,9 @@ class Selection extends Model
     return if @isEmpty()
     text = @editor.buffer.getTextInRange(@getBufferRange())
     if maintainClipboard
-      {text: clipboardText, metadata: clipboardMetadata} = atom.clipboard.readWithMetadata()
+      {text: clipboardText, metadata} = atom.clipboard.readWithMetadata()
 
       if clipboardMetadata? and clipboardMetadata.selections?
-        metadata = clipboardMetadata
         clipboardMetadata.selections.push(text)
       else
         metadata = { selections: [clipboardText, text] }

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -514,7 +514,7 @@ class Selection extends Model
     if maintainClipboard
       {text: clipboardText, metadata} = atom.clipboard.readWithMetadata()
 
-      if metadata? and metadata.selections?
+      if metadata?.selections?
         metadata.selections.push(text)
       else
         metadata = { selections: [clipboardText, text] }


### PR DESCRIPTION
It provides the fix for #1928.

Includes:
- Passing the selection index in the `Editor::mutateSelectedText`
  method callback
- Storing all the selections content on many calls of
  `Selection::copy` with `maintainClipboard = true` in a metadata
  `selections` array
- Handling clipboard with a `selections` metadata in
  the`Editor::pasteText` method
