### PR TITLE
Is atom really incompatible with the newer version of nodejs?

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,8 +3,7 @@
 var nodeVersion = process.versions.node.split('.')
 var nodeMajorVersion = +nodeVersion[0]
 var nodeMinorVersion = +nodeVersion[1]
-// TODO: replace that when node 1.0 come around
-if (nodeMajorVersion !== 0 || nodeMinorVersion < 10) {
+if (nodeMajorVersion === 0 && nodeMinorVersion < 10) {
   console.warn("You must run script/bootstrap and script/build with node v0.10 or above");
   process.exit(1);
 }

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 var nodeMinorVersion = process.versions.node.split('.')[1]
-if (nodeMinorVersion !== '10') {
-  console.warn("You must run script/bootstrap and script/build with node v0.10.x");
+if (nodeMinorVersion < '10') {
+  console.warn("You must run script/bootstrap and script/build with node v0.10.x or above");
   process.exit(1);
 }
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
-var nodeMinorVersion = process.versions.node.split('.')[1]
-if (nodeMinorVersion < '10') {
-  console.warn("You must run script/bootstrap and script/build with node v0.10.x or above");
+var nodeVersion = process.versions.node.split('.')
+var nodeMajorVersion = +nodeVersion[0]
+var nodeMinorVersion = +nodeVersion[1]
+// TODO: replace that when node 1.0 come around
+if (nodeMajorVersion !== 0 || nodeMinorVersion < 10) {
+  console.warn("You must run script/bootstrap and script/build with node v0.10 or above");
   process.exit(1);
 }
 


### PR DESCRIPTION
`script/bootstrap` reads `if (nodeMinorVersion !== '10') {`, shouldn't that be a `< 10`?

This script currently prevents me from building `atom` with nodejs v0.11, but I doubt that was intended.
