### PR TITLE
Fix double pasting with ctrl-v on linux

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -27,7 +27,6 @@
   'ctrl-y': 'core:redo'
   'ctrl-x': 'core:cut'
   'ctrl-c': 'core:copy'
-  'ctrl-v': 'core:paste'
   'shift-up': 'core:select-up'
   'shift-down': 'core:select-down'
   'shift-left': 'core:select-left'


### PR DESCRIPTION
Should fix #1945
Weird, but removing the keymap assignment of `ctrl-v` to `core:paste` stops the duplication of the paste.

It doesn't seem to break anything else other than the mention to `ctrl-v` in the edit menu disappears.
