### PR TITLE
Fix for source tarballs error on 'set-version' (not a git repository)

### DIFF
--- a/build/tasks/set-version-task.coffee
+++ b/build/tasks/set-version-task.coffee
@@ -5,7 +5,7 @@ module.exports = (grunt) ->
   {spawn} = require('./task-helpers')(grunt)
 
   getVersion = (callback) ->
-    if process.env.JANKY_SHA1 and process.env.JANKY_BRANCH is 'master'
+    if !fs.existsSync('../../.git') or (process.env.JANKY_SHA1 and process.env.JANKY_BRANCH is 'master')
       {version} = require(path.join(grunt.config.get('atom.appDir'), 'package.json'))
       callback(null, version)
     else


### PR DESCRIPTION
The current source tarballs fail to build when the 'set-version' task wants to obtain the version number through git.
This fix attempts to avoid this, using the package.json version when no .git directory is found in the root of the sources.
