### PR TITLE
ignore Thumbs.db in workspace-view and in actual atom gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.swp
 *~
 .DS_Store
+Thumbs.db
 .project
 .svn
 .nvm-version

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -64,7 +64,7 @@ class WorkspaceView extends View
   @version: 4
 
   @configDefaults:
-    ignoredNames: [".git", ".svn", ".DS_Store"]
+    ignoredNames: [".git", ".svn", ".DS_Store", "Thumbs.db"]
     excludeVcsIgnoredPaths: true
     disabledPackages: []
     themes: ['atom-dark-ui', 'atom-dark-syntax']


### PR DESCRIPTION
Since you ignore `.DS_Store` I think it's appropriate to ignore `Thumbs.db` in the editor too now since Windows users can also use Atom. These two files are functionally identical between the operating systems and are just clutter.

I also threw Thumbs.db into the gitignore since Windows developers could accidentally commit it when contributing to Atom. (which you might see more of since it's open source now)
