### PR TITLE
Fix running .cmd stubs through BufferedProcess

### DIFF
--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -39,7 +39,14 @@ class BufferedProcess
   #           containing the exit status (optional).
   constructor: ({command, args, options, stdout, stderr, exit}={}) ->
     options ?= {}
-    @process = ChildProcess.spawn(command, args, options)
+    # Quick hack. Killing @process will only kill cmd.exe, and not the child
+    # process and will just orphan it. Does not escape ^ (cmd's escape symbol).
+    # Related to joyent/node#2318
+    if process.platform is "win32"
+      @process = ChildProcess.spawn(process.env.comspec || "cmd.exe",
+        [ "/c", command ].concat(args), options)
+    else
+      @process = ChildProcess.spawn(command, args, options)
     @killed = false
 
     stdoutClosed = true


### PR DESCRIPTION
ChildProcess.spawn only will run .exe files on Windows, not .cmd, .bat, .anythingElse.

See joyent/node#2318 for more information.
