### PR TITLE
Add mercurial directories to default list of ignored names

### DIFF
--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -64,7 +64,7 @@ class WorkspaceView extends View
   @version: 4
 
   @configDefaults:
-    ignoredNames: [".git", ".svn", ".DS_Store", "Thumbs.db"]
+    ignoredNames: [".git", ".hg", ".svn", ".DS_Store", "Thumbs.db"]
     excludeVcsIgnoredPaths: true
     disabledPackages: []
     themes: ['atom-dark-ui', 'atom-dark-syntax']


### PR DESCRIPTION
atom already ignored git and svn directories. It makes sense to ignore
mercurial (.hg) directories as well.
