### PR TITLE
Update mkdeb, README.md: update debian packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,21 @@ Atom will automatically update when a new release is available.
   * You have to edit resource/linux/debian/control.in first
   
   example:
+
+
   ```Package: atom
   Version: 0.00-build20140507-140514
   Section: editors
   Priority: optional
   Architecture: amd64
-  Installed-Size: `du -ks usr|cut -f 1`
+  Installed-Size: \`du -ks usr|cut -f 1\`
   Maintainer: John Doe <johndoe@example.com>
   Description: atom editor
   ```
+  
   * And then run command like this, in the cloned atom repository
+  
+
   ``` script/mkdeb 0.00-build20140507-140514 resources/linux/debian/control.in resources/linux/Atom.desktop.in resources/atom.png ../
   ```
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ Atom will automatically update when a new release is available.
   sudo script/grunt install # Installs command to /usr/local/bin/atom
   script/grunt mkdeb # Generates a .deb package at /tmp/atom-build
   ```
+#### Packaging into .deb package
+  * You have to edit resource/linux/debian/control.in first
+  
+  example:
+  ```Package: atom
+  Version: 0.00-build20140507-140514
+  Section: editors
+  Priority: optional
+  Architecture: amd64
+  Installed-Size: `du -ks usr|cut -f 1`
+  Maintainer: John Doe <johndoe@example.com>
+  Description: atom editor
+  ```
+  * And then run command like this, in the cloned atom repository
+  ``` script/mkdeb 0.00-build20140507-140514 resources/linux/debian/control.in resources/linux/Atom.desktop.in resources/atom.png ../
+  ```
 
 ### Windows Requirements
   * Windows 7 or later

--- a/README.md
+++ b/README.md
@@ -50,22 +50,22 @@ Atom will automatically update when a new release is available.
   
   example:
 
-
-  ```Package: atom
-  Version: 0.00-build20140507-140514
-  Section: editors
-  Priority: optional
-  Architecture: amd64
-  Installed-Size: \`du -ks usr|cut -f 1\`
-  Maintainer: John Doe <johndoe@example.com>
-  Description: atom editor
-  ```
+      Package: atom
+      Version: 0.00-build20140507-140514
+      Section: editors
+      Priority: optional
+      Architecture: amd64
+      Installed-Size: \`du -ks usr|cut -f 1\`
+      Maintainer: John Doe <johndoe@example.com>
+      Description: atom editor
   
   * And then run command like this, in the cloned atom repository
-  
 
-  ``` script/mkdeb 0.00-build20140507-140514 resources/linux/debian/control.in resources/linux/Atom.desktop.in resources/atom.png ../
-  ```
+  command:
+  
+      script/mkdeb 0.00-build20140507-140514 resources/linux/debian/control.in \
+      resources/linux/Atom.desktop.in resources/atom.png ../
+      
 
 ### Windows Requirements
   * Windows 7 or later

--- a/README.md
+++ b/README.md
@@ -61,11 +61,16 @@ Atom will automatically update when a new release is available.
   
   * And then run command like this, in the cloned atom repository
 
-  command:
+  commands:
   
       script/mkdeb 0.00-build20140507-140514 resources/linux/debian/control.in \
       resources/linux/Atom.desktop.in resources/atom.png ../
-      
+  
+  * After packaging, you can install it with dpkg
+  
+  commmands:
+
+      sudo dpkg -i atom-0.00-build20140507-140514-amd64.deb
 
 ### Windows Requirements
   * Windows 7 or later

--- a/script/mkdeb
+++ b/script/mkdeb
@@ -8,6 +8,15 @@ SCRIPT=`readlink -f "$0"`
 ROOT=`readlink -f $(dirname $SCRIPT)/..`
 cd $ROOT
 
+# parameter check
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+[ "$#" -eq 5 ] || die " Usage: mkdeb version control-file-path desktop-file-path \
+icon-file-path deb-file-path"
+
 VERSION="$1"
 CONTROL_FILE="$2"
 DESKTOP_FILE="$3"

--- a/script/mkdeb
+++ b/script/mkdeb
@@ -1,5 +1,8 @@
 #!/bin/bash
-# mkdeb version control-file-path deb-file-path
+# Usage: mkdeb version control-file-path desktop-file-path \
+#         icon-file-path deb-file-path
+# 
+# You must edit control file under resource/linux/debian directory 
 
 SCRIPT=`readlink -f "$0"`
 ROOT=`readlink -f $(dirname $SCRIPT)/..`
@@ -18,10 +21,10 @@ mkdir -p "$TARGET/usr"
 env INSTALL_PREFIX="$TARGET/usr" script/grunt install
 
 mkdir -p "$TARGET/DEBIAN"
-mv "$CONTROL_FILE" "$TARGET/DEBIAN/control"
+cp "$CONTROL_FILE" "$TARGET/DEBIAN/control"
 
 mkdir -p "$TARGET/usr/share/applications"
-mv "$DESKTOP_FILE" "$TARGET/usr/share/applications"
+cp "$DESKTOP_FILE" "$TARGET/usr/share/applications"
 
 mkdir -p "$TARGET/usr/share/pixmaps"
 cp "$ICON_FILE" "$TARGET/usr/share/pixmaps"


### PR DESCRIPTION
changed comment AND cp to mv

fixing mkdeb cannot be run properly after run once.
and also added script to check the number of parameters

also added some information about debian packaging
