### PR TITLE
append .cmd to apm in package-manager.coffee if platform is win32

### DIFF
--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -4,7 +4,6 @@ _ = require 'underscore-plus'
 {Emitter} = require 'emissary'
 fs = require 'fs-plus'
 Q = require 'q'
-os = require 'os'
 
 Package = require './package'
 ThemePackage = require './theme-package'
@@ -44,10 +43,10 @@ class PackageManager
 
   # Public: Get the path to the apm command
   getApmPath: ->
-    @commandName = 'apm'
-    if os.platform() == 'win32'
-      @commandName += '.cmd'
-    @apmPath ?= path.resolve(__dirname, '..', 'apm', 'node_modules', 'atom-package-manager', 'bin', @commandName)
+    commandName = 'apm'
+    if process.platform == 'win32'
+      commandName += '.cmd'
+    @apmPath ?= path.resolve(__dirname, '..', 'apm', 'node_modules', 'atom-package-manager', 'bin', commandName)
 
   # Public: Get the paths being used to look for packages.
   #

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -4,6 +4,7 @@ _ = require 'underscore-plus'
 {Emitter} = require 'emissary'
 fs = require 'fs-plus'
 Q = require 'q'
+os = require 'os'
 
 Package = require './package'
 ThemePackage = require './theme-package'
@@ -43,7 +44,10 @@ class PackageManager
 
   # Public: Get the path to the apm command
   getApmPath: ->
-    @apmPath ?= path.resolve(__dirname, '..', 'apm', 'node_modules', 'atom-package-manager', 'bin', 'apm')
+    @commandName = 'apm'
+    if os.platform() == 'win32'
+      @commandName += '.cmd'
+    @apmPath ?= path.resolve(__dirname, '..', 'apm', 'node_modules', 'atom-package-manager', 'bin', @commandName)
 
   # Public: Get the paths being used to look for packages.
   #


### PR DESCRIPTION
avoids NOENT error when searching for packages
