### PR TITLE
Make atom build behind firewalls

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^0.19.0",
-    "bootstrap": "git://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",
+    "bootstrap": "git+https://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",
     "clear-cut": "0.4.0",
     "coffee-script": "1.7.0",
     "coffeestack": "0.7.0",


### PR DESCRIPTION
This is to get install to work behind firewalls where `git://` is blocked.
