### PR TITLE
Shift backspace keymap

### DIFF
--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -33,6 +33,7 @@
   'pageup': 'core:page-up'
   'pagedown': 'core:page-down'
   'backspace': 'core:backspace'
+  'shift-backspace': 'core:backspace'
   'ctrl-tab': 'pane:show-next-item'
   'ctrl-shift-tab': 'pane:show-previous-item'
   'ctrl-shift-up': 'core:move-up'


### PR DESCRIPTION
Within windows build shift-backspace currently does nothing. Behaviour
untested in linux (perhaps linux.cson should be modified too?)
