### PR TITLE
Make block cursor cover character underneath it

### DIFF
--- a/src/cursor-view.coffee
+++ b/src/cursor-view.coffee
@@ -4,7 +4,9 @@ _ = require 'underscore-plus'
 module.exports =
 class CursorView extends View
   @content: ->
-    @div class: 'cursor idle', => @raw '&nbsp;'
+    @div class: 'cursor idle', =>
+      @div outlet: 'cursorValue', style: 'visibility:hidden;', =>
+        @raw '&nbsp;'
 
   @blinkPeriod: 800
 
@@ -45,6 +47,9 @@ class CursorView extends View
   beforeRemove: ->
     @editorView.removeCursorView(this)
     @stopBlinking()
+
+  setCursorValue: (value) ->
+    @cursorValue.html value
 
   updateDisplay: ->
     screenPosition = @getScreenPosition()

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -423,12 +423,28 @@ class EditorView extends View
 
     @subscribe atom.themes, 'stylesheets-changed', => @recalculateDimensions()
 
+  getCharAtCursor: ->
+    editor = @getEditor()
+    range = Range.fromPointWithDelta editor.getCursorBufferPosition(), 0, 1
+    editor.getBuffer().getTextInRange range
+
+  convertCharToCursorValue: (ch) ->
+    switch ch
+      when '', '\n', '\r', ' '
+        ch = '&nbsp;'
+      when '\t'
+        ch = '&nbsp;'
+        for i in [1...@getEditor().getTabLength()]
+          ch += '&nbsp;'
+    ch
+
   handleInputEvents: ->
     @on 'cursor:moved', =>
       return unless @isFocused
       cursorView = @getCursorView()
 
       if cursorView.isVisible()
+        cursorView.setCursorValue @convertCharToCursorValue @getCharAtCursor()
         # This is an order of magnitude faster than checking .offset().
         style = cursorView[0].style
         @hiddenInput[0].style.top = style.top


### PR DESCRIPTION
The block cursor does not completely cover characters that are wider than a non-breaking space (the width is set at one single "&nbsp;"), such as CJK characters.

This change updates the `CursorView` with the character under the cursor whenever it moves (i.e., "`cursor:moved`").

(from atom/vim-mode#187)
-  CJK Character
  -  Before: ![image](https://f.cloud.github.com/assets/189989/2460955/d4844204-af71-11e3-9a48-da85b2474e39.png)
  -  After: ![image](https://f.cloud.github.com/assets/189989/2460996/390aa7fe-af72-11e3-9ac4-3ffe93523c3e.png)
-  Tab
  -  Before: ![image](https://f.cloud.github.com/assets/189989/2461189/6e0b44ca-af74-11e3-8f77-5a3db21c7dcc.png)
  -  After: ![image](https://f.cloud.github.com/assets/189989/2461183/56305ce6-af74-11e3-985a-ddc437efae2a.png)

I still have to figure out how to write the specs for this, though...
