### PR TITLE
Add `fullscreen` class to body when in full screen

### DIFF
--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -473,6 +473,7 @@ class Atom extends Model
   # Public: Set the full screen state of the current window.
   setFullScreen: (fullScreen=false) ->
     ipc.send('call-window-method', 'setFullScreen', fullScreen)
+    if fullScreen then document.body.classList.add("fullscreen") else document.body.classList.remove("fullscreen")
 
   # Public: Is the current window in full screen mode?
   isFullScreen: ->


### PR DESCRIPTION
Add a `fullscreen` class to body when full screen is triggered, as suggested
by in #1694.

This would allow for specific styles when in full screen mode.
