### PR TITLE
Advanced context menu

### DIFF
--- a/docs/creating-a-package.md
+++ b/docs/creating-a-package.md
@@ -226,7 +226,7 @@ In the example above, the `Add file` item will only appear when the focused item
 or one of its parents has the `tree-view` class applied to it.
 
 You can also add separators and submenus to your context menus.
-To add a submenu, pass in context menu object instead of a command:
+To add a submenu, pass in a `context-menu` object instead of a command:
 
 ```coffeescript
 'context-menu':
@@ -237,7 +237,7 @@ To add a submenu, pass in context menu object instead of a command:
     'Inspect Element': 'core:inspect'
 ```
 
-To add a separator, use the '-': '-' structure:
+To add a separator, use a `'-': '-'` structure:
 
 ```coffeescript
 'context-menu':

--- a/docs/creating-a-package.md
+++ b/docs/creating-a-package.md
@@ -225,6 +225,30 @@ elements until reaching the top of the DOM tree.
 In the example above, the `Add file` item will only appear when the focused item
 or one of its parents has the `tree-view` class applied to it.
 
+You can also add separators and submenus to your context menus.
+To add a submenu, pass in context menu object instead of a command:
+
+```coffeescript
+'context-menu':
+  '.tree-view':
+    'Files':
+      'Add file': 'tree-view:add-file'
+  '.workspace':
+    'Inspect Element': 'core:inspect'
+```
+
+To add a separator, use the '-': '-' structure:
+
+```coffeescript
+'context-menu':
+  '.tree-view':
+    'Add file': 'tree-view:add-file'
+    '-': '-'
+    'Remove file': 'tree-view:remove-file'
+  '.workspace':
+    'Inspect Element': 'core:inspect'
+```
+
 ## Snippets
 
 An extension can supply language snippets in the _snippets_ directory which

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -24,9 +24,7 @@ describe "ContextMenuManager", ->
             'child-1': 'child-1:trigger'
             'child-2': 'child-1:trigger'
           ]
-          'parent-2': 'parent-2:trigger'   
-
-
+          'parent-2': 'parent-2:trigger'
 
     describe 'dev mode', ->
       it 'loads',  ->
@@ -130,4 +128,3 @@ describe "ContextMenuManager", ->
 
       expect(buildFn).toHaveBeenCalled()
       expect(buildFn.mostRecentCall.args[0]).toBe event
-

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -15,15 +15,14 @@ describe "ContextMenuManager", ->
           'label': 'command'
 
       expect(contextMenu.definitions['.selector'][0].label).toEqual 'label'
-      expect(contextMenu.definitions['.selector'][0].command).toEqual 'command'
+      expect(contextMenu.definitions['.selector'][0].commandOrSubmenu).toEqual 'command'
 
     it "loads submenus", ->
       contextMenu.add 'file-path',
         '.selector':
-          'parent': [
+          'parent':
             'child-1': 'child-1:trigger'
             'child-2': 'child-1:trigger'
-          ]
           'parent-2': 'parent-2:trigger'
 
     describe 'dev mode', ->
@@ -34,7 +33,7 @@ describe "ContextMenuManager", ->
         , devMode: true
 
         expect(contextMenu.devModeDefinitions['.selector'][0].label).toEqual 'label'
-        expect(contextMenu.devModeDefinitions['.selector'][0].command).toEqual 'command'
+        expect(contextMenu.devModeDefinitions['.selector'][0].commandOrSubmenu).toEqual 'command'
 
   describe "building a menu template", ->
     beforeEach ->

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -17,6 +17,17 @@ describe "ContextMenuManager", ->
       expect(contextMenu.definitions['.selector'][0].label).toEqual 'label'
       expect(contextMenu.definitions['.selector'][0].command).toEqual 'command'
 
+    it "loads submenus", ->
+      contextMenu.add 'file-path',
+        '.selector':
+          'parent': [
+            'child-1': 'child-1:trigger'
+            'child-2': 'child-1:trigger'
+          ]
+          'parent-2': 'parent-2:trigger'   
+
+
+
     describe 'dev mode', ->
       it 'loads',  ->
         contextMenu.add 'file-path',

--- a/src/browser/context-menu.coffee
+++ b/src/browser/context-menu.coffee
@@ -19,4 +19,6 @@ class ContextMenu
         do (item) =>
           item.click = =>
             global.atomApplication.sendCommandToWindow(item.command, @atomWindow, item.commandOptions)
+      else if item.submenu
+        @createClickHandlers(item.submenu)
       item

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -33,11 +33,11 @@ class ContextMenuManager
   # Returns nothing.
   add: (name, object, {devMode}={}) ->
     for selector, items of object
-      for label, command of items
-        if (typeof command == 'object')
-          @addBySelector(selector, command, {devMode})
+      for label, commandOrSubmenu of items
+        if (typeof commandOrSubmenu == 'object')
+          @addBySelector(selector, commandOrSubmenu, {devMode})
         else
-          @addBySelector(selector, {label, command}, {devMode})
+          @addBySelector(selector, {label, commandOrSubmenu}, {devMode})
 
   # Registers a command to be displayed when the relevant item is right
   # clicked.

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -35,9 +35,15 @@ class ContextMenuManager
     for selector, items of object
       for label, commandOrSubmenu of items
         if typeof commandOrSubmenu is 'object'
-          @addBySelector(selector, commandOrSubmenu, {devMode})
+          submenu = [];
+          for submenuLabel, command of commandOrSubmenu
+            submenu.push({label: submenuLabel, command: command})
+          @addBySelector(selector, {label: label, submenu: submenu}, {devMode})
         else
-          @addBySelector(selector, {label, commandOrSubmenu}, {devMode})
+          if label is commandOrSubmenu is '-'
+            @addBySelector(selector, {type: 'separator'}, {devMode})
+          else
+            @addBySelector(selector, {label: label, command: commandOrSubmenu}, {devMode})
 
   # Registers a command to be displayed when the relevant item is right
   # clicked.

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -34,7 +34,7 @@ class ContextMenuManager
   add: (name, object, {devMode}={}) ->
     for selector, items of object
       for label, commandOrSubmenu of items
-        if (typeof commandOrSubmenu == 'object')
+        if typeof commandOrSubmenu is 'object'
           @addBySelector(selector, commandOrSubmenu, {devMode})
         else
           @addBySelector(selector, {label, commandOrSubmenu}, {devMode})

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -37,7 +37,10 @@ class ContextMenuManager
         if typeof commandOrSubmenu is 'object'
           submenu = [];
           for submenuLabel, command of commandOrSubmenu
-            submenu.push({label: submenuLabel, command: command})
+            if submenuLabel is command is '-'
+              submenu.push({type: 'separator'});
+            else 
+              submenu.push({label: submenuLabel, command: command})
           @addBySelector(selector, {label: label, submenu: submenu}, {devMode})
         else
           if label is commandOrSubmenu is '-'

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -52,8 +52,6 @@ class ContextMenuManager
     definitions = if devMode then @devModeDefinitions else @definitions
     (definitions[selector] ?= []).push(definition)
 
-
-
   # Returns definitions which match the element and devMode.
   definitionsForElement: (element, {devMode}={}) ->
     definitions = if devMode then @devModeDefinitions else @definitions

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -34,7 +34,10 @@ class ContextMenuManager
   add: (name, object, {devMode}={}) ->
     for selector, items of object
       for label, command of items
-        @addBySelector(selector, {label, command}, {devMode})
+        if (typeof command == 'object')
+          @addBySelector(selector, command, {devMode})
+        else
+          @addBySelector(selector, {label, command}, {devMode})
 
   # Registers a command to be displayed when the relevant item is right
   # clicked.
@@ -48,6 +51,8 @@ class ContextMenuManager
   addBySelector: (selector, definition, {devMode}={}) ->
     definitions = if devMode then @devModeDefinitions else @definitions
     (definitions[selector] ?= []).push(definition)
+
+
 
   # Returns definitions which match the element and devMode.
   definitionsForElement: (element, {devMode}={}) ->


### PR DESCRIPTION
When creating a Package for Atom, I realized I needed submenus in Context menus.

This mod allows Context menus to accept the same JSON/CSON structure as regular menus, while still allowing the old structure.

Example:

```
'context-menu':
  '.workspace': [
    { 'type' : 'separator' }
    {
      'label' : 'Test submenu'
      'submenu': [
        { 'label': 'test', 'command': 'test-submenu:toggle' }
      ]
    }
    { 'type' : 'separator' }
    { 'label' : 'Lala', 'command': 'test-submenu:toggle'}
  ]
```

Feel free to comment. This is my first time ever touching Coffeescript.

Tested on Ubuntu 14.04.

![Screenshot](https://cloud.githubusercontent.com/assets/2339213/2934564/b22c2902-d7d4-11e3-9044-7b8f4728a5bd.png)
