### PR TITLE
Remove unused 's' option from getopts

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -11,7 +11,7 @@ else
   exit 1
 fi
 
-while getopts ":wtfvhs-:" opt; do
+while getopts ":wtfvh-:" opt; do
   case "$opt" in
     -)
       case "${OPTARG}" in


### PR DESCRIPTION
This option is not handled by the next `case` command.
