### PR TITLE
Use $(...) for command substitution, not backticks

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-if [ "`uname`" == 'Darwin' ]; then
+if [ "$(uname)" == 'Darwin' ]; then
   OS='Mac'
-elif [ "`expr substr $(uname -s) 1 5`" == 'Linux' ]; then
+elif [ "$(expr substr $(uname -s) 1 5)" == 'Linux' ]; then
   OS='Linux'
-elif [ "`expr substr $(uname -s) 1 10`" == 'MINGW32_NT' ]; then
+elif [ "$(expr substr $(uname -s) 1 10)" == 'MINGW32_NT' ]; then
   OS='Cygwin'
 else
-  echo "Your platform (`uname -a`) is not supported."
+  echo "Your platform ($(uname -a)) is not supported."
   exit 1
 fi
 
@@ -66,8 +66,8 @@ if [ $OS == 'Mac' ]; then
     open -a "$ATOM_PATH/$ATOM_APP_NAME" -n --args --executed-from="$(pwd)" --pid=$$ "$@"
   fi
 elif [ $OS == 'Linux' ]; then
-  SCRIPT=`readlink -f "$0"`
-  USR_DIRECTORY=`readlink -f $(dirname $SCRIPT)/..`
+  SCRIPT=$(readlink -f "$0")
+  USR_DIRECTORY=$(readlink -f $(dirname $SCRIPT)/..)
   ATOM_PATH="$USR_DIRECTORY/share/atom/atom"
 
   [ -x "$ATOM_PATH" ] || ATOM_PATH='/tmp/atom-build/Atom/atom'


### PR DESCRIPTION
Currently both `...` and `$(...)` are used for command substitution. It's better to chose just one and stick to it, to avoid confusion.

Some arguments favoring `$(...)`:
- **Easier to read.** The backtick is easily confused with apostrophes and quotes.
- **Easier to nest.** Nesting backticks commands is an escaping nightmare. Using parenthesis is natural: `$(foo $(bar))`
