### PR TITLE
Extract the devPackagePath from PackageManager.

### DIFF
--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -28,10 +28,12 @@ class PackageManager
   Emitter.includeInto(this)
 
   constructor: ({configDirPath, devMode, safeMode, @resourcePath}) ->
+    @devPackagePath = path.join(configDirPath, "dev", "packages")
+
     @packageDirPaths = []
     unless safeMode
       if devMode
-        @packageDirPaths.push(path.join(configDirPath, "dev", "packages"))
+        @packageDirPaths.push(path.join(@devPackagePath)
       @packageDirPaths.push(path.join(configDirPath, "packages"))
 
     @loadedPackages = {}
@@ -53,6 +55,13 @@ class PackageManager
   # Returns an Array of String directory paths.
   getPackageDirPaths: ->
     _.clone(@packageDirPaths)
+
+  # Public: Get the path that's used to store packages that are only loaded in
+  # dev mode.
+  #
+  # Returns a String containing the absolute path of the dev package directory.
+  getDevPackagePath: ->
+    @devPackagePath
 
   getPackageState: (name) ->
     @packageStates[name]

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -33,7 +33,7 @@ class PackageManager
     @packageDirPaths = []
     unless safeMode
       if devMode
-        @packageDirPaths.push(path.join(@devPackagePath)
+        @packageDirPaths.push(@devPackagePath)
       @packageDirPaths.push(path.join(configDirPath, "packages"))
 
     @loadedPackages = {}


### PR DESCRIPTION
Give the development-mode package path its own variable and accessor from `PackageManager`. My ulterior motive here is to make a follow-on PR against package-generator, to put generated packages into `.atom/dev/packages` instead of `.atom/packages` by default.
