### PR TITLE
Detached, centered overlays

### DIFF
--- a/src/select-list-view.coffee
+++ b/src/select-list-view.coffee
@@ -259,7 +259,7 @@ class SelectListView extends View
   #
   # This method should be called if the overlay produced is the detached, centered
   # version, right after the call to `atom.workspaceView.append(this)`. Works in
-  # conjunction with the `.overlay.center` class.
+  # conjunction with the `.overlay.centered` class.
   centerOverlay: ->
     $(this).css "margin-top", $(this).height() / -2
 

--- a/src/select-list-view.coffee
+++ b/src/select-list-view.coffee
@@ -255,6 +255,14 @@ class SelectListView extends View
   # Returns the property name to fuzzy filter by.
   getFilterKey: ->
 
+  # Public: Center the overlay vertically.
+  #
+  # This method should be called if the overlay produced is the detached, centered
+  # version, right after the call to `atom.workspaceView.append(this)`. Works in
+  # conjunction with the `.overlay.center` class.
+  centerOverlay: ->
+    $(this).css "margin-top", $(this).height() / -2
+
   # Public: Focus the fuzzy filter editor view.
   focusFilterEditor: ->
     @filterEditorView.focus()

--- a/static/overlay.less
+++ b/static/overlay.less
@@ -52,6 +52,10 @@
   border-bottom-right-radius: 0;
 }
 
+.overlay.centered {
+  top: 50%;
+}
+
 .overlay.floating {
   left: auto;
 }


### PR DESCRIPTION
First steps for issue/feature #964. This provides basic alignment and styling for creating centered overlays.

To create a centered overlay, use the `centered` class instead of the `from-top` class, and call `centerOverlay()` after attaching to the workspace:

``` coffeescript
initialize: ->
  ...  
  @addClass('command-palette overlay centered')
  atom.workspaceView.command 'command-palette:toggle', => @toggle()

...

attach: ->
  ...
  atom.workspaceView.append(this)
  @centerOverlay()
  @focusFilterEditor()
```
