### PR TITLE
Fix indenting of HTML tags for instance. Fix #1294

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1616,6 +1616,13 @@ describe "Editor", ->
         expect(editor.lineForBufferRow(1)).toBe '  '
         expect(editor.lineForBufferRow(2)).toBe '}'
 
+    describe "when a new line is appended before a closing tag (e.g. by pressing enter before a selection)", ->
+      it "moves the line down and keeps the indentation level the same when editor.autoIndent is true", ->
+        atom.config.set('editor.autoIndent', true)
+        editor.setCursorBufferPosition([9,2])
+        editor.insertNewline()
+        expect(editor.lineForBufferRow(10)).toBe '  };'
+        
     describe ".backspace()", ->
       describe "when there is a single cursor", ->
         changeScreenRangeHandler = null

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -305,7 +305,10 @@ class Selection extends Model
     if options.autoIndent
       @editor.autoIndentBufferRow(row) for row in newBufferRange.getRows()
     else if options.autoIndentNewline and text == '\n'
+      currentIndentation = @editor.indentationForBufferRow(newBufferRange.start.row)
       @editor.autoIndentBufferRow(newBufferRange.end.row, preserveLeadingWhitespace: true)
+      if @editor.indentationForBufferRow(newBufferRange.end.row) < currentIndentation
+        @editor.setIndentationForBufferRow(newBufferRange.end.row, currentIndentation)
     else if options.autoDecreaseIndent and /\S/.test text
       @editor.autoDecreaseIndentForBufferRow(newBufferRange.start.row)
 


### PR DESCRIPTION
## Commit Summary

If you press ENTER before a line, a new line is introduced by appending "\n" before it.
Therefor a previous line of "" is appended before the <TAG>-line.
This line remains unindented, causing a wrong indentation for the next line.
Basically this is fixed by indenting this line (oldBuffer.end.row = newBuffer.start.row).
## Bug Description

As in #1294: If you put the cursor before a tag and press ENTER the indentation get's messed up.
## Current Behavior

![current_behavior](https://cloud.githubusercontent.com/assets/1194855/2938230/e0334d08-d8fb-11e3-80f3-3896fdc44896.gif)
## Expected (Fixed) Behavior

![fixed_and_expected_behavior](https://cloud.githubusercontent.com/assets/1194855/2938232/075e9018-d8fc-11e3-925a-34176bcaae63.gif)
