### PR TITLE
Cast opened paths to string

### DIFF
--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -42,7 +42,7 @@ start = ->
     app.removeListener 'open-url', addUrlToOpen
 
     args.pathsToOpen = args.pathsToOpen.map (pathToOpen) ->
-      path.resolve(args.executedFrom ? process.cwd(), "#{pathToOpen}")
+      path.resolve(args.executedFrom ? process.cwd(), pathToOpen.toString())
 
     require('coffee-script').register()
     if args.devMode

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -42,7 +42,7 @@ start = ->
     app.removeListener 'open-url', addUrlToOpen
 
     args.pathsToOpen = args.pathsToOpen.map (pathToOpen) ->
-      path.resolve(args.executedFrom ? process.cwd(), pathToOpen)
+      path.resolve(args.executedFrom ? process.cwd(), "#{pathToOpen}")
 
     require('coffee-script').register()
     if args.devMode


### PR DESCRIPTION
Fix #2152: path.resolve() was throwing an exception if given path was not a string.
When iterating through all given paths, each entry is casted by JS to
most suitable type and paths in form of a number (i.e. '1234') were
cast to Number, hence the bug.
