### PR TITLE
Map key for full screen on windows

### DIFF
--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -10,6 +10,7 @@
   'ctrl-alt-i': 'window:toggle-dev-tools'
   'ctrl-alt-p': 'window:run-package-specs'
   'ctrl-alt-s': 'application:run-all-specs'
+  'F11': 'window:toggle-full-screen'
 
   # Sublime Parity
   'ctrl-N': 'application:new-window'


### PR DESCRIPTION
Just a small note:
- The full screen option in darwin.cson is located under `#sublime-parity`
- However, the full screen option in linux.cson is located under `#atom-specific`

This is making me feel a bit unorganized. There is nothing major though, so I guess its all fine for now...
