### PR TITLE
Improve some Win32 ctrl keybindings

### DIFF
--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -1,4 +1,8 @@
 'body':
+  # Platform Bindings
+  'ctrl-pageup': 'pane:show-previous-item'
+  'ctrl-pagedown': 'pane:show-next-item'
+
   # Atom Specific
   'enter': 'core:confirm'
   'escape': 'core:cancel'
@@ -10,8 +14,6 @@
   'ctrl-alt-i': 'window:toggle-dev-tools'
   'ctrl-alt-p': 'window:run-package-specs'
   'ctrl-alt-s': 'application:run-all-specs'
-  'ctrl-pageup': 'pane:show-previous-item'
-  'ctrl-pagedown': 'pane:show-next-item'
 
   # Sublime Parity
   'ctrl-N': 'application:new-window'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -64,7 +64,7 @@
   'ctrl-shift-left': 'editor:select-to-beginning-of-word'
   'ctrl-shift-right': 'editor:select-to-end-of-word'
   'ctrl-backspace': 'editor:backspace-to-beginning-of-word'
-  'ctrl-delete': 'editor:backspace-to-beginning-of-word'
+  'ctrl-delete': 'editor:delete-to-end-of-word'
   'ctrl-home': 'core:move-to-top'
   'ctrl-end': 'core:move-to-bottom'
 

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -65,6 +65,8 @@
   'ctrl-shift-right': 'editor:select-to-end-of-word'
   'ctrl-backspace': 'editor:backspace-to-beginning-of-word'
   'ctrl-delete': 'editor:backspace-to-beginning-of-word'
+  'ctrl-home': 'core:move-to-top'
+  'ctrl-end': 'core:move-to-bottom'
 
   # Sublime Parity
   'ctrl-a': 'core:select-all'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -10,6 +10,8 @@
   'ctrl-alt-i': 'window:toggle-dev-tools'
   'ctrl-alt-p': 'window:run-package-specs'
   'ctrl-alt-s': 'application:run-all-specs'
+  'ctrl-pageup': 'pane:show-previous-item'
+  'ctrl-pagedown': 'pane:show-next-item'
 
   # Sublime Parity
   'ctrl-N': 'application:new-window'


### PR DESCRIPTION
Similar to #2166, this tries to get Win32 bindings feeling a more native for me.
- [x] `ctrl-home` should go to the beginning of the file
- [x] `ctrl-end` should go to the end of the file
- [x] `ctrl-delete` should delete the _next word_, not the previous word. i've used this for a long time, but i had to find some proof to make sure it wasn't something i just customized for myself. Here's a [reference](http://blogs.msdn.com/b/saraford/archive/2007/09/21/did-you-know-ctrl-delete-deletes-the-preceding-word-and-ctrl-backspace-deletes-the-proceeding-word.aspx) to back up that ctrl-delete should delete the following word and not the previous one.
- [x] `ctrl-pageup` goes to next tab
- [x] `ctrl-pagedown` goes to previous tab
