### PR TITLE
Hide the cursor with cursor-hidden class rather than element.style

### DIFF
--- a/src/cursor-view.coffee
+++ b/src/cursor-view.coffee
@@ -78,7 +78,11 @@ class CursorView extends View
   setVisible: (visible) ->
     unless @visible is visible
       @visible = visible
-      @toggle(@visible)
+      hiddenCursor = 'hidden-cursor'
+      if visible
+        @removeClass hiddenCursor
+      else
+        @addClass hiddenCursor
 
   stopBlinking: ->
     @constructor.stopBlinking(this) if @blinking

--- a/static/editor.less
+++ b/static/editor.less
@@ -226,6 +226,10 @@
   visibility: visible;
 }
 
+.cursor.hidden-cursor {
+  display: none;
+}
+
 .editor .hidden-input {
   padding: 0;
   border: 0;


### PR DESCRIPTION
Implements @bhuga's suggestion here: https://github.com/atom/atom/issues/2204

Allows packages to override the default hiding of the cursor when selecting text.
