### PR TITLE
Include Terms of Use in the help menu

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -185,6 +185,7 @@
   {
     label: 'Help'
     submenu: [
+      { label: 'Terms of Use', command: 'application:open-terms-of-use' }
       { label: 'Documentation', command: 'application:open-documentation' }
       { type: 'separator' }
     ]

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -145,6 +145,7 @@
   {
     label: '&Help'
     submenu: [
+      { label: 'View &Terms of Use', command: 'application:open-terms-of-use' }
       { label: 'View &License', command: 'application:open-license' }
       { label: "VERSION", enabled: false }
       { type: 'separator' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -165,6 +165,7 @@
     label: '&Help'
     submenu: [
       { label: '&About Atom...', command: 'application:about' }
+      { label: 'View &Terms of Use', command: 'application:open-terms-of-use' }
       { label: 'View &License', command: 'application:open-license' }
       { label: "VERSION", enabled: false }
       { label: "Install &update", command: 'application:install-update', visible: false }

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -146,6 +146,7 @@ class AtomApplication
       atomWindow?.browserWindow.inspectElement(x, y)
 
     @on 'application:open-documentation', -> shell.openExternal('https://atom.io/docs/latest/?app')
+    @on 'application:open-terms-of-use', -> shell.openExternal('https://atom.io/terms')
     @on 'application:install-update', -> @autoUpdateManager.install()
     @on 'application:check-for-update', => @autoUpdateManager.check()
 


### PR DESCRIPTION
This adds a shortcut to the Terms of Use to the help menu.

Presumptions:
- When I run this with `--dev`, it doesn't include the release notes in the menu. I assume that get added automatically when it is published?
- I assume the `&` characters indicate hotkeys for those items? I tried to follow what I saw elsewhere.
