### PR TITLE
:memo: Document process for hacking node module components

### DIFF
--- a/docs/advanced/node-modules.md
+++ b/docs/advanced/node-modules.md
@@ -1,0 +1,24 @@
+## Developing Node Modules
+
+Atom contains a number of packages that are Node modules instead of Atom packages. If you want to
+make changes to the Node modules, for instance `atom-keymap`, you have to link them into the
+development environment differently than you would a normal Atom package.
+
+### Linking a Node Module Into Your Atom Dev Environment
+
+Here are the steps to run a local version of a node module *not an apm* within Atom. We're using
+`atom-keymap` as an example:
+
+```bash
+$ git clone https://github.com/atom/atom-keymap.git
+$ cd atom-keymap
+$ npm install
+$ npm link
+$ apm rebuild # This is the special step, it makes the npm work with Atom's version of Node
+$ cd WHERE-YOU-CLONED-ATOM
+$ npm link atom-keymap
+$ atom # Should work!
+```
+
+After this, you'll have to `npm install` and `apm rebuild` when you make a change to the node
+module's code.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@
 ### Advanced Topics
 
 * [Configuration](advanced/configuration.md)
+* [Developing Node Modules](advanced/node-modules.md)
 * [Keymaps](advanced/keymaps.md)
 * [Serialization](advanced/serialization.md)
 * [View System](advanced/view-system.md)


### PR DESCRIPTION
@ProbablyCorey documented this process on Discuss and I figured it should be added to the official documentation. I hope that I was able to match the documentation practices the Atom team uses for general documentation.

See: http://discuss.atom.io/t/how-to-setup-development-for-core-modules-like-atom-keymap/9221/18?u=leedohm
