### PR TITLE
Make ctrl+click add a new cursor in Linux and Windows, fixes #2105

### DIFF
--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -387,7 +387,7 @@ class EditorView extends View
 
       screenPosition = @screenPositionFromMouseEvent(e)
       if clickCount == 1
-        if e.metaKey
+        if e.metaKey or (process.platform isnt 'darwin' and e.ctrlKey)
           @editor.addCursorAtScreenPosition(screenPosition)
         else if e.shiftKey
           @editor.selectToScreenPosition(screenPosition)


### PR DESCRIPTION
In Chromium the metaKey property of a mousedown event might never get set to true on Linux and Windows as there is no special, well defined meta key on the keyboard (see this [issue](https://code.google.com/p/chromium/issues/detail?id=95874)). Hence I made editor-view.coffee check for e.ctrlKey instead if the platform is not Mac, which makes ctrl+click to add a cursor as desired.
