### PR TITLE
Move ~/.atom to XDG directories on Linux

### DIFF
--- a/docs/advanced/configuration.md
+++ b/docs/advanced/configuration.md
@@ -50,7 +50,7 @@ class MyClass
 
 ### Writing Config Settings
 
-The `atom.config` database is populated on startup from `[AtomConfDir](user-dirs.md)/config.cson`,
+The `atom.config` database is populated on startup from <tt>[AtomConfDir](../user-dirs.md)/config.cson</tt>,
 but you can programmatically write to it with `atom.config.set`:
 
 ```coffeescript

--- a/docs/advanced/configuration.md
+++ b/docs/advanced/configuration.md
@@ -50,7 +50,7 @@ class MyClass
 
 ### Writing Config Settings
 
-The `atom.config` database is populated on startup from `~/.atom/config.cson`,
+The `atom.config` database is populated on startup from `[AtomConfDir](user-dirs.md)/config.cson`,
 but you can programmatically write to it with `atom.config.set`:
 
 ```coffeescript

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -51,7 +51,7 @@ which is normally bound to `cmd-shift-o`. You can also run dev mode from the
 command line with `atom --dev`.
 
 To load your package in development mode, create a symlink to it in
-`~/.atom/dev/packages`. This occurs automatically when you clone the package
+`[AtomConfDir](user-dirs.md)/dev/packages`. This occurs automatically when you clone the package
 with `apm develop`. You can also run `apm link --dev` and `apm unlink --dev`
 from the package directory to create and remove dev-mode symlinks.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -51,7 +51,7 @@ which is normally bound to `cmd-shift-o`. You can also run dev mode from the
 command line with `atom --dev`.
 
 To load your package in development mode, create a symlink to it in
-`[AtomConfDir](user-dirs.md)/dev/packages`. This occurs automatically when you clone the package
+<tt>[AtomConfDir](user-dirs.md)/dev/packages</tt>. This occurs automatically when you clone the package
 with `apm develop`. You can also run `apm link --dev` and `apm unlink --dev`
 from the package directory to create and remove dev-mode symlinks.
 

--- a/docs/converting-a-text-mate-bundle.md
+++ b/docs/converting-a-text-mate-bundle.md
@@ -33,7 +33,7 @@ You can convert the R bundle with the following command:
 apm init --package ~/.atom/packages/language-r --convert https://github.com/textmate/r.tmbundle
 ```
 
-You can now browse to `[AtomConfDir](user-dirs.md)/packages/language-r` to see the converted bundle.
+You can now browse to <tt>[AtomConfDir](user-dirs.md)/packages/language-r</tt> to see the converted bundle.
 
 :tada: Your new package is now ready to use, launch Atom and open a `.r` file in
 the editor to see it in action!

--- a/docs/converting-a-text-mate-bundle.md
+++ b/docs/converting-a-text-mate-bundle.md
@@ -33,7 +33,7 @@ You can convert the R bundle with the following command:
 apm init --package ~/.atom/packages/language-r --convert https://github.com/textmate/r.tmbundle
 ```
 
-You can now browse to `~/.atom/packages/language-r` to see the converted bundle.
+You can now browse to `[AtomConfDir](user-dirs.md)/packages/language-r` to see the converted bundle.
 
 :tada: Your new package is now ready to use, launch Atom and open a `.r` file in
 the editor to see it in action!

--- a/docs/converting-a-text-mate-theme.md
+++ b/docs/converting-a-text-mate-theme.md
@@ -40,14 +40,14 @@ Now, let's say you've downloaded the theme to `~/Downloads/MyTheme.tmTheme`,
 you can convert the theme with the following command:
 
 ```sh
-apm init --theme [AtomConfDir](user-dirs.md)/packages/my-theme --convert ~/Downloads/MyTheme.tmTheme
+apm init --theme ~/.atom/packages/my-theme --convert ~/Downloads/MyTheme.tmTheme
 ```
 
-You can browse to `[AtomConfDir](user-dirs.md)/packages/my-theme` to see the converted theme.
+You can browse to <tt>[AtomConfDir](user-dirs.md)/packages/my-theme</tt> to see the converted theme.
 
 ### Activate the Theme
 
-Now that your theme is installed to `[AtomConfDir](user-dirs.md)/packages` you can enable it
+Now that your theme is installed to <tt>[AtomConfDir](user-dirs.md)/packages</tt> you can enable it
 by launching Atom and selecting the _Atom > Preferences..._ menu.
 
 Select the _Themes_ link on the left side and choose _My Theme_ from the

--- a/docs/converting-a-text-mate-theme.md
+++ b/docs/converting-a-text-mate-theme.md
@@ -40,14 +40,14 @@ Now, let's say you've downloaded the theme to `~/Downloads/MyTheme.tmTheme`,
 you can convert the theme with the following command:
 
 ```sh
-apm init --theme ~/.atom/packages/my-theme --convert ~/Downloads/MyTheme.tmTheme
+apm init --theme [AtomConfDir](user-dirs.md)/packages/my-theme --convert ~/Downloads/MyTheme.tmTheme
 ```
 
-You can browse to `~/.atom/packages/my-theme` to see the converted theme.
+You can browse to `[AtomConfDir](user-dirs.md)/packages/my-theme` to see the converted theme.
 
 ### Activate the Theme
 
-Now that your theme is installed to `~/.atom/packages` you can enable it
+Now that your theme is installed to `[AtomConfDir](user-dirs.md)/packages` you can enable it
 by launching Atom and selecting the _Atom > Preferences..._ menu.
 
 Select the _Themes_ link on the left side and choose _My Theme_ from the

--- a/docs/creating-a-package.md
+++ b/docs/creating-a-package.md
@@ -315,7 +315,7 @@ protocol URLs to load resources in the package.
 The URLs should be in the format of
 `atom://package-name/relative-path-to-package-of-resource`, for example, the
 `atom://image-view/images/transparent-background.gif` would be equivalent to
-`~/.atom/packages/image-view/images/transparent-background.gif`.
+`[AtomConfDir](user-dirs.md)/packages/image-view/images/transparent-background.gif`.
 
 You can also use the `atom` protocol URLs in themes.
 

--- a/docs/creating-a-package.md
+++ b/docs/creating-a-package.md
@@ -315,7 +315,7 @@ protocol URLs to load resources in the package.
 The URLs should be in the format of
 `atom://package-name/relative-path-to-package-of-resource`, for example, the
 `atom://image-view/images/transparent-background.gif` would be equivalent to
-`[AtomConfDir](user-dirs.md)/packages/image-view/images/transparent-background.gif`.
+<tt>[AtomConfDir](user-dirs.md)/packages/image-view/images/transparent-background.gif</tt>.
 
 You can also use the `atom` protocol URLs in themes.
 

--- a/docs/creating-a-theme.md
+++ b/docs/creating-a-theme.md
@@ -75,7 +75,7 @@ To create an interface UI theme, do the following:
    terminal or use the _View > Developer > Open in Dev Mode_ menu
 5. Change the name of the theme in the theme's `package.json` file
 6. Name your theme end with a `-ui`. i.e. `super-white-ui`
-7. Run `apm link` to symlink your repository to `[AtomConfDir](user-dirs.md)/packages`
+7. Run `apm link` to symlink your repository to <tt>[AtomConfDir](user-dirs.md)/packages</tt>
 8. Reload Atom using `cmd-alt-ctrl-L`
 9. Enable the theme via _UI Theme_ drop-down in the _Themes_ section of the
    settings view

--- a/docs/creating-a-theme.md
+++ b/docs/creating-a-theme.md
@@ -75,7 +75,7 @@ To create an interface UI theme, do the following:
    terminal or use the _View > Developer > Open in Dev Mode_ menu
 5. Change the name of the theme in the theme's `package.json` file
 6. Name your theme end with a `-ui`. i.e. `super-white-ui`
-7. Run `apm link` to symlink your repository to `~/.atom/packages`
+7. Run `apm link` to symlink your repository to `[AtomConfDir](user-dirs.md)/packages`
 8. Reload Atom using `cmd-alt-ctrl-L`
 9. Enable the theme via _UI Theme_ drop-down in the _Themes_ section of the
    settings view

--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -44,7 +44,7 @@ You can also install packages by using the `apm install` command:
 * `apm install <package_name>@<package_version>` to install a specific version.
 
 For example `apm install emmet@0.1.5` installs the `0.1.5` release of the
-[Emmet](https://github.com/atom/emmet) package into `[AtomConfDir](user-dirs.md)/packages`.
+[Emmet](https://github.com/atom/emmet) package into <tt>[AtomConfDir](user-dirs.md)/packages</tt>.
 
 You can also use `apm` to find new packages to install:
 
@@ -73,7 +73,7 @@ the editor to insert a newline. But if the same keystroke occurs inside of a
 select list's mini-editor, it instead emits the `core:confirm` event based on
 the binding in the more-specific selector.
 
-By default, `[AtomConfDir](user-dirs.md)/keymap.cson` is loaded when Atom is started. It will always
+By default, <tt>[AtomConfDir](user-dirs.md)/keymap.cson</tt> is loaded when Atom is started. It will always
 be loaded last, giving you the chance to override bindings that are defined by
 Atom's core keymaps or third-party packages.
 

--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -44,7 +44,7 @@ You can also install packages by using the `apm install` command:
 * `apm install <package_name>@<package_version>` to install a specific version.
 
 For example `apm install emmet@0.1.5` installs the `0.1.5` release of the
-[Emmet](https://github.com/atom/emmet) package into `~/.atom/packages`.
+[Emmet](https://github.com/atom/emmet) package into `[AtomConfDir](user-dirs.md)/packages`.
 
 You can also use `apm` to find new packages to install:
 
@@ -73,7 +73,7 @@ the editor to insert a newline. But if the same keystroke occurs inside of a
 select list's mini-editor, it instead emits the `core:confirm` event based on
 the binding in the more-specific selector.
 
-By default, `~/.atom/keymap.cson` is loaded when Atom is started. It will always
+By default, `[AtomConfDir](user-dirs.md)/keymap.cson` is loaded when Atom is started. It will always
 be loaded last, giving you the chance to override bindings that are defined by
 Atom's core keymaps or third-party packages.
 
@@ -85,7 +85,7 @@ currently in use.
 
 ## Advanced Configuration
 
-Atom loads configuration settings from the `config.cson` file in your _~/.atom_
+Atom loads configuration settings from the `config.cson` file in your _[AtomConfDir](user-dirs.md)_
 directory, which contains [CoffeeScript-style JSON][CSON] (CSON):
 
 ```coffee
@@ -139,7 +139,7 @@ You can open this file in an editor from the _Atom > Open Your Config_ menu.
 
 ### init.coffee
 
-When Atom finishes loading, it will evaluate _init.coffee_ in your _~/.atom_
+When Atom finishes loading, it will evaluate _init.coffee_ in your _[AtomConfDir](user-dirs.md)_
 directory, giving you a chance to run arbitrary personal [CoffeeScript][] code to
 make customizations. You have full access to Atom's API from code in this file.
 If customizations become extensive, consider [creating a package][creating-a-package].
@@ -148,7 +148,7 @@ You can open this file in an editor from the _Atom > Open Your Init Script_
 menu.
 
 For example, if you have the Audio Beep configuration setting enabled, you
-could add the following code to your _~/.atom/init.coffee_ file to have Atom
+could add the following code to your _[AtomConfDir](user-dirs.md)/init.coffee_ file to have Atom
 greet you with an audio beep every time it loads:
 
 ```coffee
@@ -161,12 +161,12 @@ This file can also be named _init.js_ and contain JavaScript code.
 
 If you want to apply quick-and-dirty personal styling changes without creating
 an entire theme that you intend to publish, you can add styles to the
-_styles.less_ file in your _~/.atom_ directory.
+_styles.less_ file in your _[AtomConfDir](user-dirs.md)_ directory.
 
 You can open this file in an editor from the _Atom > Open Your Stylesheet_ menu.
 
 For example, to change the color of the cursor, you could add the following
-rule to your _~/.atom/styles.less_ file:
+rule to your _[AtomConfDir](user-dirs.md)/styles.less_ file:
 
 ```less
 .editor .cursor {

--- a/docs/user-dirs.md
+++ b/docs/user-dirs.md
@@ -1,0 +1,16 @@
+# User Directories by OS
+
+Different OSes have different locations for config files, cache files
+etc. Wherever Atom docs mention [AtomConfDir](#config-directory), use the
+directory relevant to your OS.
+
+### Config Directory  
+
+- Mac OS X: `~/.atom`
+- Linux: `$XDG_CONFIG_HOME/atom` (which defaults to `~/.config/atom`)
+- Windows: `APPDATA + /Atom` (which defaults to
+  `C:/Users/<username>/AppData/Local/Atom`)
+
+### Cache Directory  
+
+The build process uses `~/.atom` as a cache on all platforms.

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -93,7 +93,7 @@ class Atom extends Model
     else if process.platform is 'darwin'
       dir = '~/.atom'
     else
-      dir = (process.env.XDG_CONFIG_HOME) ? '~/.config/atom'
+      dir = (process.env.XDG_CONFIG_HOME ? '~/.config') + '/atom'
     @configDirPath ?= fs.absolute(dir)
 
   # Get the path to Atom's storage directory.

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -86,13 +86,19 @@ class Atom extends Model
 
   # Get the directory path to Atom's configuration area.
   #
-  # Returns the absolute path to ~/.atom
+  # Returns the absolute path to ~/.atom according to platform standards
   @getConfigDirPath: ->
-    @configDirPath ?= fs.absolute('~/.atom')
+    if process.platform is 'win32'
+      dir = process.env.APPDATA + '/Atom'
+    else if process.platform is 'darwin'
+      dir = '~/.atom'
+    else
+      dir = (process.env.XDG_CONFIG_HOME) ? '~/.config/atom'
+    @configDirPath ?= fs.absolute(dir)
 
   # Get the path to Atom's storage directory.
   #
-  # Returns the absolute path to ~/.atom/storage
+  # Returns the absolute path to @configDirPath/storage
   @getStorageDirPath: ->
     @storageDirPath ?= path.join(@getConfigDirPath(), 'storage')
 


### PR DESCRIPTION
From feedesktop.org:

$XDG_CONFIG_HOME defines the base directory relative to which user specific configuration files should be stored. If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used.

Source: http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
