### PR TITLE
download-atom-shell abort error solution

### DIFF
--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -32,3 +32,7 @@ probably need to fiddle with your system PATH.
 
   * If you just installed node you need to restart your computer before node is
   available on your Path.
+
+* `Running "download-atom-shell" task aborts due to warnings`
+  
+  * Run script/build again


### PR DESCRIPTION
For whatever reason, this error always pops up for me when building, and simply re-running the build completes the build fine.
