### PR TITLE
Use os.tmpdir() insted of /tmp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,7 @@ in the proper package's repository.
   * Beware of platform differences
     * Use `require('atom').fs.getHomeDirectory()` to get the home directory.
     * Use `path.join()` to concatenate filenames.
-    * Temporary directory is not `/tmp` on Windows, use `os.tmpdir()` when
-      possible
+    * Use `os.tmpdir()` instead of `/tmp
 
 ## Git Commit Messages
   * Use the present tense

--- a/atom.sh
+++ b/atom.sh
@@ -70,16 +70,18 @@ elif [ $OS == 'Linux' ]; then
   USR_DIRECTORY=$(readlink -f $(dirname $SCRIPT)/..)
   ATOM_PATH="$USR_DIRECTORY/share/atom/atom"
 
-  [ -x "$ATOM_PATH" ] || ATOM_PATH='/tmp/atom-build/Atom/atom'
+  : ${TMPDIR:=/tmp}
+
+  [ -x "$ATOM_PATH" ] || ATOM_PATH="$TMPDIR/atom-build/Atom/atom"
 
   if [ $EXPECT_OUTPUT ]; then
     "$ATOM_PATH" --executed-from="$(pwd)" --pid=$$ "$@"
     exit $?
   else
     (
-    nohup "$ATOM_PATH" --executed-from="$(pwd)" --pid=$$ "$@" > /tmp/atom-nohup.out 2>&1
+    nohup "$ATOM_PATH" --executed-from="$(pwd)" --pid=$$ "$@" > "$TMPDIR/atom-nohup.out" 2>&1
     if [ $? -ne 0 ]; then
-      cat /tmp/atom-nohup.out
+      cat "$TMPDIR/atom-nohup.out"
       exit $?
     fi
     ) &

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -37,22 +37,20 @@ module.exports = (grunt) ->
 
   [major, minor, patch] = packageJson.version.split('.')
   tmpDir = os.tmpdir()
+  appName = if process.platform is 'darwin' then 'Atom.app' else 'Atom'
   buildDir = grunt.option('build-dir') ? path.join(tmpDir, 'atom-build')
   atomShellDownloadDir = path.join(os.tmpdir(), 'atom-cached-atom-shells')
   symbolsDir = path.join(buildDir, 'Atom.breakpad.syms')
   shellAppDir = path.join(buildDir, appName)
   if process.platform is 'win32'
-    appName = 'Atom'
     contentsDir = shellAppDir
     appDir = path.join(shellAppDir, 'resources', 'app')
     installDir = path.join(process.env.ProgramFiles, appName)
   else if process.platform is 'darwin'
-    appName = 'Atom.app'
     contentsDir = path.join(shellAppDir, 'Contents')
     appDir = path.join(contentsDir, 'Resources', 'app')
     installDir = path.join('/Applications', appName)
   else
-    appName = 'Atom'
     contentsDir = shellAppDir
     appDir = path.join(shellAppDir, 'resources', 'app')
     installDir = process.env.INSTALL_PREFIX ? '/usr/local'

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -58,13 +58,13 @@ module.exports = (grunt) ->
     installDir = path.join('/Applications', appName)
   else
     appName = 'Atom'
-    tmpDir = '/tmp'
+    tmpDir = os.tmpdir()
     buildDir = grunt.option('build-dir') ? path.join(tmpDir, 'atom-build')
     symbolsDir = path.join(buildDir, 'Atom.breakpad.syms')
     shellAppDir = path.join(buildDir, appName)
     contentsDir = shellAppDir
     appDir = path.join(shellAppDir, 'resources', 'app')
-    atomShellDownloadDir = '/tmp/atom-cached-atom-shells'
+    atomShellDownloadDir = path.join(tmpDir, 'atom-cached-atom-shells')
     installDir = process.env.INSTALL_PREFIX ? '/usr/local'
 
   coffeeConfig =

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -48,13 +48,13 @@ module.exports = (grunt) ->
     installDir = path.join(process.env.ProgramFiles, appName)
   else if process.platform is 'darwin'
     appName = 'Atom.app'
-    tmpDir = '/tmp'
+    tmpDir = os.tmpdir()
     buildDir = grunt.option('build-dir') ? path.join(tmpDir, 'atom-build')
     symbolsDir = path.join(buildDir, 'Atom.breakpad.syms')
     shellAppDir = path.join(buildDir, appName)
     contentsDir = path.join(shellAppDir, 'Contents')
     appDir = path.join(contentsDir, 'Resources', 'app')
-    atomShellDownloadDir = '/tmp/atom-cached-atom-shells'
+    atomShellDownloadDir = path.join(os.tmpdir(), 'atom-cached-atom-shells')
     installDir = path.join('/Applications', appName)
   else
     appName = 'Atom'

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -36,35 +36,25 @@ module.exports = (grunt) ->
     grunt.log.write = (args...) -> grunt.log
 
   [major, minor, patch] = packageJson.version.split('.')
+  tmpDir = os.tmpdir()
+  buildDir = grunt.option('build-dir') ? path.join(tmpDir, 'atom-build')
+  atomShellDownloadDir = path.join(os.tmpdir(), 'atom-cached-atom-shells')
+  symbolsDir = path.join(buildDir, 'Atom.breakpad.syms')
+  shellAppDir = path.join(buildDir, appName)
   if process.platform is 'win32'
     appName = 'Atom'
-    tmpDir = os.tmpdir()
-    buildDir = grunt.option('build-dir') ? path.join(tmpDir, 'atom-build')
-    symbolsDir = path.join(buildDir, 'Atom.breakpad.syms')
-    shellAppDir = path.join(buildDir, appName)
     contentsDir = shellAppDir
     appDir = path.join(shellAppDir, 'resources', 'app')
-    atomShellDownloadDir = path.join(os.tmpdir(), 'atom-cached-atom-shells')
     installDir = path.join(process.env.ProgramFiles, appName)
   else if process.platform is 'darwin'
     appName = 'Atom.app'
-    tmpDir = os.tmpdir()
-    buildDir = grunt.option('build-dir') ? path.join(tmpDir, 'atom-build')
-    symbolsDir = path.join(buildDir, 'Atom.breakpad.syms')
-    shellAppDir = path.join(buildDir, appName)
     contentsDir = path.join(shellAppDir, 'Contents')
     appDir = path.join(contentsDir, 'Resources', 'app')
-    atomShellDownloadDir = path.join(os.tmpdir(), 'atom-cached-atom-shells')
     installDir = path.join('/Applications', appName)
   else
     appName = 'Atom'
-    tmpDir = os.tmpdir()
-    buildDir = grunt.option('build-dir') ? path.join(tmpDir, 'atom-build')
-    symbolsDir = path.join(buildDir, 'Atom.breakpad.syms')
-    shellAppDir = path.join(buildDir, appName)
     contentsDir = shellAppDir
     appDir = path.join(shellAppDir, 'resources', 'app')
-    atomShellDownloadDir = path.join(tmpDir, 'atom-cached-atom-shells')
     installDir = process.env.INSTALL_PREFIX ? '/usr/local'
 
   coffeeConfig =

--- a/build/tasks/clean-task.coffee
+++ b/build/tasks/clean-task.coffee
@@ -5,7 +5,7 @@ module.exports = (grunt) ->
   {rm} = require('./task-helpers')(grunt)
 
   grunt.registerTask 'partial-clean', 'Delete some of the build files', ->
-    tmpdir = if process.platform is 'win32' then os.tmpdir() else '/tmp'
+    tmpdir = os.tmpdir()
 
     rm grunt.config.get('atom.buildDir')
     rm require('../src/coffee-cache').cacheDir

--- a/docs/build-instructions/freebsd.md
+++ b/docs/build-instructions/freebsd.md
@@ -15,7 +15,7 @@ FreeBSD -RELEASE 64-bit is the recommended platform.
   ```sh
   git clone https://github.com/atom/atom
   cd atom
-  script/build # Creates application at /tmp/atom-build/Atom
+  script/build # Creates application at $TMPDIR/atom-build/Atom
   sudo script/grunt install # Installs command to /usr/local/bin/atom
   ```
 

--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -15,9 +15,9 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
   ```sh
   git clone https://github.com/atom/atom
   cd atom
-  script/build # Creates application at /tmp/atom-build/Atom
+  script/build # Creates application at $TMPDIR/atom-build/Atom
   sudo script/grunt install # Installs command to /usr/local/bin/atom
-  script/grunt mkdeb # Generates a .deb package at /tmp/atom-build
+  script/grunt mkdeb # Generates a .deb package at $TMPDIR/atom-build
   ```
 
 ## Troubleshooting

--- a/script/clean
+++ b/script/clean
@@ -8,7 +8,7 @@ var productName = require('../package.json').productName;
 
 process.chdir(path.dirname(__dirname));
 var home = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
-var tmpdir = process.platform !== 'darwin' ? os.tmpdir() : '/tmp';
+var tmpdir = os.tmpdir();
 
 // Windows: Use START as a way to ignore error if Atom.exe isnt running
 var killatom = process.platform === 'win32' ? 'START taskkill /F /IM ' + productName + '.exe' : 'pkill -9 ' + productName + ' || true';

--- a/script/clean
+++ b/script/clean
@@ -8,7 +8,7 @@ var productName = require('../package.json').productName;
 
 process.chdir(path.dirname(__dirname));
 var home = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
-var tmpdir = process.platform === 'win32' ? os.tmpdir() : '/tmp';
+var tmpdir = process.platform !== 'darwin' ? os.tmpdir() : '/tmp';
 
 // Windows: Use START as a way to ignore error if Atom.exe isnt running
 var killatom = process.platform === 'win32' ? 'START taskkill /F /IM ' + productName + '.exe' : 'pkill -9 ' + productName + ' || true';


### PR DESCRIPTION
`/tmp` isn't always available, is on precious [RAM-backed fs that is cleared at boot](https://www.kernel.org/doc/Documentation/filesystems/tmpfs.txt) or simply not
what the user has set his `$TMPDIR` to. According to specifications, we
should use `$TMPDIR`, which node lets us find through `os.tmpdir()`.

Also, [contributing.md](https://github.com/atom/atom/blob/master/docs/contributing.md#code-guidelines) isn't in favour of using platform-dependent code.

This PR focuses only on Linux for now, and invites discussion for OS X code's use of `/tmp`.
