### PR TITLE
Add linux support for test suite

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -233,7 +233,10 @@ module.exports = (grunt) ->
   grunt.registerTask('test', (mode) ->
     # use dynamic alias to pass the argument to run-specs task
     specTask = 'run-specs'
-    specTask += ':' + mode if mode
+    if mode
+      specTask += ':' + mode
+    else if process.platform is 'win32'
+      specTask += ':ci'
     grunt.task.run(['shell:kill-atom', specTask]))
   grunt.registerTask('ci', ['output-disk-space', 'download-atom-shell', 'build', 'dump-symbols', 'set-version', 'check-licenses', 'lint', 'test:ci', 'codesign', 'publish-build'])
   grunt.registerTask('docs', ['markdown:guides', 'build-docs'])

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -230,8 +230,12 @@ module.exports = (grunt) ->
 
   grunt.registerTask('compile', ['coffee', 'prebuild-less', 'cson', 'peg'])
   grunt.registerTask('lint', ['coffeelint', 'csslint', 'lesslint'])
-  grunt.registerTask('test', ['shell:kill-atom', 'run-specs'])
-  grunt.registerTask('ci', ['output-disk-space', 'download-atom-shell', 'build', 'dump-symbols', 'set-version', 'check-licenses', 'lint', 'test', 'codesign', 'publish-build'])
+  grunt.registerTask('test', (mode) ->
+    # use dynamic alias to pass the argument to run-specs task
+    specTask = 'run-specs'
+    specTask += ':' + mode if mode
+    grunt.task.run(['shell:kill-atom', specTask]))
+  grunt.registerTask('ci', ['output-disk-space', 'download-atom-shell', 'build', 'dump-symbols', 'set-version', 'check-licenses', 'lint', 'test:ci', 'codesign', 'publish-build'])
   grunt.registerTask('docs', ['markdown:guides', 'build-docs'])
 
   defaultTasks = ['download-atom-shell', 'build', 'set-version']

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -82,4 +82,5 @@ module.exports = (grunt) ->
     dependencies = ['compile', "generate-license:save"]
     dependencies.push('copy-info-plist') if process.platform is 'darwin'
     dependencies.push('set-exe-icon') if process.platform is 'win32'
+    dependencies.push('fix-permissions:755') if process.platform is 'linux'
     grunt.task.run(dependencies...)

--- a/build/tasks/fix-permissions-task.coffee
+++ b/build/tasks/fix-permissions-task.coffee
@@ -1,0 +1,7 @@
+fs = require 'fs'
+path = require 'path'
+
+module.exports = (grunt) ->
+
+  grunt.registerTask 'fix-permissions', 'Fix permissions on binary generated in build directory', (mode) ->
+      fs.chmodSync(path.join(grunt.config.get('atom.contentsDir'), 'atom'), mode)

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -35,5 +35,3 @@ module.exports = (grunt) ->
       process.chdir(binDir)
       rm('apm')
       fs.symlinkSync(path.join('..', 'share', 'atom', 'resources', 'app', 'apm', 'node_modules', '.bin', 'apm'), 'apm')
-
-      fs.chmodSync(path.join(shareDir, 'atom'), "755")

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -8,8 +8,6 @@ async = require 'async'
 module.exports = (grunt) ->
   {isAtomPackage, spawn} = require('./task-helpers')(grunt)
 
-  packageSpecQueue = null
-
   runPackageSpecs = (callback) ->
     failedPackages = []
     rootDir = grunt.config.get('atom.shellAppDir')
@@ -19,6 +17,8 @@ module.exports = (grunt) ->
       appPath = path.join(contentsDir, 'MacOS', 'Atom')
     else if process.platform is 'win32'
       appPath = path.join(contentsDir, 'atom.exe')
+    else
+      appPath = path.join(contentsDir, 'atom')
 
     packageSpecQueue = async.queue (packagePath, callback) ->
       if process.platform is 'darwin'
@@ -31,7 +31,15 @@ module.exports = (grunt) ->
       else if process.platform is 'win32'
         options =
           cmd: process.env.comspec
+          # FIXME: CI settings should have their own flag
           args: ['/c', appPath, '--test', "--resource-path=#{resourcePath}", "--spec-directory=#{path.join(packagePath, 'spec')}", "--log-file=ci.log"]
+          opts:
+            cwd: packagePath
+            env: _.extend({}, process.env, ATOM_PATH: rootDir)
+      else
+        options =
+          cmd: appPath
+          args: ['--test', "--resource-path=#{resourcePath}", "--spec-directory=#{path.join(packagePath, 'spec')}"]
           opts:
             cwd: packagePath
             env: _.extend({}, process.env, ATOM_PATH: rootDir)
@@ -39,23 +47,32 @@ module.exports = (grunt) ->
       grunt.verbose.writeln "Launching #{path.basename(packagePath)} specs."
       spawn options, (error, results, code) ->
         if process.platform is 'win32'
+          # FIXME: This is CI dependent, not platform dependent
           process.stderr.write(fs.readFileSync(path.join(packagePath, 'ci.log')))
           fs.unlinkSync(path.join(packagePath, 'ci.log'))
 
         failedPackages.push path.basename(packagePath) if error
         callback()
 
+    # TODO: Check concurrency on other platforms
+    if process.platform is 'win32'
+      packageSpecQueue.concurrency = 2
+    else
+      packageSpecQueue.concurrency = 1
+
+    # When all specs are finished, report the results
+    packageSpecQueue.drain = -> callback(null, failedPackages)
+    # First gather package specs
+    tasks = []
     modulesDirectory = path.resolve('node_modules')
     for packageDirectory in fs.readdirSync(modulesDirectory)
       packagePath = path.join(modulesDirectory, packageDirectory)
       continue unless grunt.file.isDir(path.join(packagePath, 'spec'))
       continue unless isAtomPackage(packagePath)
-      packageSpecQueue.push(packagePath)
-
-    # TODO: Restore concurrency on Windows
-    packageSpecQueue.concurrency = 1 unless process.platform is 'win32'
-
-    packageSpecQueue.drain = -> callback(null, failedPackages)
+      tasks.push(packagePath)
+    # Now add them all in one go to avoid race conditions between pushing and
+    # drain
+    packageSpecQueue.push(tasks)
 
   runCoreSpecs = (callback) ->
     contentsDir = grunt.config.get('atom.contentsDir')
@@ -63,25 +80,25 @@ module.exports = (grunt) ->
       appPath = path.join(contentsDir, 'MacOS', 'Atom')
     else if process.platform is 'win32'
       appPath = path.join(contentsDir, 'atom.exe')
+    else
+      appPath = path.join(contentsDir, 'atom')
     resourcePath = process.cwd()
     coreSpecsPath = path.resolve('spec')
 
-    if process.platform is 'darwin'
-      options =
-        cmd: appPath
-        args: ['--test', "--resource-path=#{resourcePath}", "--spec-directory=#{coreSpecsPath}"]
-    else if process.platform is 'win32'
+    if process.platform is 'win32'
       options =
         cmd: process.env.comspec
         args: ['/c', appPath, '--test', "--resource-path=#{resourcePath}", "--spec-directory=#{coreSpecsPath}", "--log-file=ci.log"]
+    else
+      options =
+        cmd: appPath
+        args: ['--test', "--resource-path=#{resourcePath}", "--spec-directory=#{coreSpecsPath}"]
 
     spawn options, (error, results, code) ->
       if process.platform is 'win32'
+        # FIXME: This is CI dependent, not platform dependent
         process.stderr.write(fs.readFileSync('ci.log'))
         fs.unlinkSync('ci.log')
-      else
-        # TODO: Restore concurrency on Windows
-        packageSpecQueue.concurrency = 2
 
       callback(null, error)
 
@@ -93,7 +110,7 @@ module.exports = (grunt) ->
     # fixtures step on each others toes currently.
     if process.platform is 'darwin'
       method = async.parallel
-    else if process.platform is 'win32'
+    else
       method = async.series
 
     method [runCoreSpecs, runPackageSpecs], (error, results) ->
@@ -106,7 +123,7 @@ module.exports = (grunt) ->
       grunt.log.error("[Error]".red + " #{failures.join(', ')} spec(s) failed") if failures.length > 0
 
       # TODO: Mark the build as green on Windows until specs pass.
-      if process.platform is 'darwin'
-        done(!coreSpecFailed and failedPackages.length == 0)
-      else if process.platform is 'win32'
+      if process.platform is 'win32'
         done(true)
+      else
+        done(!coreSpecFailed and failedPackages.length == 0)


### PR DESCRIPTION
I've noticed that the `test` grunt task failed to run on linux completely, hence no spec could be run. I've refactored the tasks a bit to allow running all test cases on a linux machine (tested on Linux Mint 16 x64). 
Another thing is the usage of `--log-file=ci.log` flag that smells to me like CI (haven't looked any deeper) and I thought that it would be a waste to enable it only on windows, so I have changed it to a separate switch to `test` task. I'm not sure it that's the best way to do it (maybe a command line option would be better?) but I wanted to make this change compatible with other behavior so that all scripts that are already using it won't break.
