### PR TITLE
Toggle Line Comment update (Linux.cson)

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -91,7 +91,7 @@
   'ctrl-[': 'editor:outdent-selected-rows'
   'ctrl-up': 'editor:move-line-up'
   'ctrl-down': 'editor:move-line-down'
-  'ctrl-/': 'editor:toggle-line-comments'
+  'ctrl-shift-/': 'editor:toggle-line-comments'
   'ctrl-j': 'editor:join-lines'
   'ctrl-D': 'editor:duplicate-lines'
   'alt-shift-up': 'editor:add-selection-above'


### PR DESCRIPTION
I saw that ctrl+/ doesn work in my Atom in linux (Elementary OS Luna). The Key Bindeng Resolver shown me an ctrl+shift+/ press when trying to toggle comment.. So I propuse this update un te linux Key Binding cson.
