### PR TITLE
Make instructions for manual VS path more accurate

### DIFF
--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -35,7 +35,7 @@ and
 
 These two error messages can usually be ignored. The solution to these errors is to re-run `script\build`, possibly several times.
 
-If your Visual Studio is in a non-standard location, and you get the error `You must have Visual Studio 2010 or 2012 installed`, you need to modify `apm\node_modules\atom-package-manager\lib\config.js` around line 90 and replace the variable with your Visual Studio directory plus Common7/IDE.
+If your Visual Studio is in a non-standard location, and you get the error `You must have Visual Studio 2010 or 2012 installed`, you need to modify `apm\node_modules\atom-package-manager\lib\config.js` around line 110 and replace the variable with your Visual Studio directory plus Common7/IDE. Make sure your path does not contain unescaped backward slashes that appear in normal Windows paths.
 
 Example:
 


### PR DESCRIPTION
Move the line number for the variable close to the actual current location.
Add a note to not to include unescaped backward slashes as they would appear in normal Windows paths.
