### PR TITLE
Use sudo for commands needing to copy within /tmp

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -17,7 +17,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
   cd atom
   script/build # Creates application at $TMPDIR/atom-build/Atom
   sudo script/grunt install # Installs command to /usr/local/bin/atom
-  script/grunt mkdeb # Generates a .deb package at $TMPDIR/atom-build
+  sudo script/grunt mkdeb # Generates a .deb package at $TMPDIR/atom-build
   ```
 
 ## Troubleshooting


### PR DESCRIPTION
Use `sudo script/grunt mkdeb` since it copies files within /tmp.
