### PR TITLE
Use React components for lines and line numbers

### DIFF
--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -141,15 +141,6 @@ LineNumberComponent = React.createClass
     iconHTML = '<div class="icon-right"></div>'
     padding + lineNumber + iconHTML
 
-    if softWrapped
-      lineNumber = "•"
-    else
-      lineNumber = (bufferRow + 1).toString()
-
-    padding = multiplyString('&nbsp;', maxLineNumberDigits - lineNumber.length)
-    iconHTML = '<div class="icon-right"></div>'
-    padding + lineNumber + iconHTML
-
   shouldComponentUpdate: (newProps) ->
     not isEqualForProperties(newProps, @props, 'screenRow', 'lineHeightInPixels', 'maxLineNumberDigits')
 

--- a/src/selections-component.coffee
+++ b/src/selections-component.coffee
@@ -7,7 +7,8 @@ SelectionsComponent = React.createClass
   displayName: 'SelectionsComponent'
 
   render: ->
-    div className: 'selections', @renderSelections()
+    div className: 'selections',
+      @renderSelections() if @isMounted()
 
   renderSelections: ->
     {editor, lineHeightInPixels} = @props


### PR DESCRIPTION
This PR switches back to React components for lines and line numbers. There is a ~14% performance penalty at larger scroll sizes, but the code is a lot easier to reason about. I would love input from @petehunt or another member of the React team regarding improving the performance.

As you can see below, the overhead appears to be significant over the current manual DOM manipulation approach. The first part of the timeline is an accelerating scroll in two different versions of the editor, the first full react from this PR, the second with manual DOM manipulation from master. Note the larger amount of yellow JS time in the first timeline.
