### PR TITLE
Added note about nodejs on ubuntu 14.04, related to #2025

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -21,3 +21,5 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
   ```
 
 ## Troubleshooting
+
+  * On Ubuntu 14.04 you will also need `nodejs-legacy`


### PR DESCRIPTION
Just added a note regarding the missing "node" command on Ubuntu 14.04, which can be solved with the `nodejs-legacy` package
