### PR TITLE
Check for Python27 on path when building on Win32

### DIFF
--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -10,7 +10,11 @@
     [Windows 7 64-bit SDK](http://www.microsoft.com/en-us/download/details.aspx?id=8279).
     You may also need the [compiler update for the Windows SDK 7.1](http://www.microsoft.com/en-us/download/details.aspx?id=4422)
 
-  * [Python](http://www.python.org/download/) v2.7.x
+  * [Python](http://www.python.org/download/) v2.7.x. It is required by node-gyp. You can ensure atom's build process can find python by:
+    * Installing Python to the suggested default directory: `C:\Python27`
+    * Including Python's installed directory in your path
+    * Setting the `PYTHON` env variable
+
   * [GitHub for Windows](http://windows.github.com/)
 
 ### On Windows 8


### PR DESCRIPTION
#### the (not a big deal) problem

Previous to 0b5b741db4d5b03d6b97cc217ae2c40df892fa62 i was building atom on Win32 fine. The other day i fetched new commits from atom and my builds wouldn't work anymore :cry:

```
H:\src\atom [master]> .\script\build
You must have Python 2.7 installed at 'C:\Python27\'
```

i thought i broke something. i commented out that check and everything built fine because i do have python on my machine and its installed location on my path.
## EDIT: See this much more better restatement of the problem

See [this comment](https://github.com/atom/atom/pull/2351#issuecomment-44435957) for a better statement of the problem.
#### i propose

This PR adds a check for Python27 on the path on win32 machines and if it isn't, `script/build` says:

> You must have Python 2.7 in your path

My initial solution is just to tell win32 builders that Python should be on the path. It may not be the best way, but it seems like a step forward to me. That seems like a reasonable thing to ask someone trying to build this :smile:. i wish i knew about a `which python`-like solution for node.
#### history and previous discussions

i'm conscious of [this conversation](https://github.com/atom/atom/commit/0b5b741db4d5b03d6b97cc217ae2c40df892fa62#diff-be3d85f44f8c9d04e5ce9becabab892b) and [this one](https://github.com/atom/atom/commit/f30c56c237dd157e0a12e21e86c832ec393a03d6#diff-be3d85f44f8c9d04e5ce9becabab892b), both mentioning that Python isn't installed on the path by default, so i'm aware that this isn't a perfect solution or may not be what you're looking for (the idea has already been floated for what i've done).

If this isn't the way to go about it, maybe we can :hammer: that out here?
#### A brief aside

This isn't a big deal for me, and i could be wrong, so i'll quote Mr. Paul Betts's [comment](https://github.com/atom/atom/commit/0b5b741db4d5b03d6b97cc217ae2c40df892fa62#commitcomment-6336933) out of context:

> If you don't have a C: drive, you're smart enough to figure out what to patch, :-1: to considering this

This isn't hard for me to patch on my own. i'm :cool: with just doing that.

_For much personal improvement's sake_: Next time i'm just going to install python in the default directory!
