### PR TITLE
:memo: Add solution for "TypeError: Unable to watch path"

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -10,6 +10,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
   * libgnome-keyring-dev `sudo apt-get install libgnome-keyring-dev` (refer to your distribution's manual on how to install packages if you are not on Debian or Ubuntu-based systems)
   * `npm config set python /usr/bin/python2 -g` to ensure that gyp uses Python 2
 
+
 ## Instructions
 
   ```sh
@@ -20,4 +21,29 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
   script/grunt mkdeb # Generates a .deb package at $TMPDIR/atom-build
   ```
 
+
 ## Troubleshooting
+
+
+### Exception: "TypeError: Unable to watch path"
+
+If you get following error with a big traceback right after Atom starts:
+
+  ```
+  TypeError: Unable to watch path
+  ```
+
+you have to increase number of watched files by inotify.  For testing if
+this is the reason for this error you can issue
+
+  ```sh
+  sudo sysctl fs.inotify.max_user_watches=32768
+  ```
+
+and restart Atom.  If Atom now works fine, you can make this setting permanent:
+
+  ```sh
+  echo 32768 > /proc/sys/fs/inotify/max_user_watches
+  ```
+
+See also https://github.com/atom/atom/issues/2082.


### PR DESCRIPTION
I run into issue #2082.  I think solution to this issue belongs into documentation.
