### PR TITLE
Fix slash in Windows build instructions

### DIFF
--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -16,7 +16,7 @@
   cd C:\
   git clone https://github.com/atom/atom/
   cd atom
-  script\build
+  script/build
   ```
 
 ## Why do I have to use GitHub for Windows?


### PR DESCRIPTION
This could be mildly confusing to some who are unfamiliar with using bash.
