### PR TITLE
Update getLongTitle to be project relative

### DIFF
--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -259,7 +259,7 @@ class Editor extends Model
   getLongTitle: ->
     if sessionPath = @getPath()
       fileName = path.basename(sessionPath)
-      directory = path.basename(path.dirname(sessionPath))
+      directory = atom.project.relativize(path.dirname(sessionPath))
       "#{fileName} - #{directory}"
     else
       'untitled'

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -260,6 +260,7 @@ class Editor extends Model
     if sessionPath = @getPath()
       fileName = path.basename(sessionPath)
       directory = atom.project.relativize(path.dirname(sessionPath))
+      directory = if directory.length > 0 then directory else path.basename(path.dirname(sessionPath))
       "#{fileName} - #{directory}"
     else
       'untitled'


### PR DESCRIPTION
TabView uses getLongTitle to provide a less ambiguous file title should multiple files have the same name.  However if these files also happen to be in a sub folder of the same name the ambiguity remains.

By increasing the long title to be relative from the project root this ambiguity is removed.

Before:
![screen shot 2014-05-22 at 21 33 36](https://cloud.githubusercontent.com/assets/196630/3060049/902dcd96-e1f3-11e3-91d0-d98b71bed480.png)

After:
![screen shot 2014-05-22 at 21 38 46](https://cloud.githubusercontent.com/assets/196630/3060054/9d317b14-e1f3-11e3-9632-94b7253c32e1.png)

Applies to atom/tabs#57
