### PR TITLE
Prevent React editor's scroll view from being auto-scrolled by Chromium

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -375,25 +375,6 @@ describe "EditorComponent", ->
       advanceClock(component.props.cursorBlinkPeriod / 2)
       expect(cursorsNode.classList.contains('blink-off')).toBe true
 
-    it "renders the hidden input field at the position of the last cursor if it is on screen", ->
-      inputNode = node.querySelector('.hidden-input')
-      node.style.height = 5 * lineHeightInPixels + 'px'
-      node.style.width = 10 * charWidth + 'px'
-      component.measureHeightAndWidth()
-
-      expect(editor.getCursorScreenPosition()).toEqual [0, 0]
-      editor.setScrollTop(3 * lineHeightInPixels)
-      editor.setScrollLeft(3 * charWidth)
-      expect(inputNode.offsetTop).toBe 0
-      expect(inputNode.offsetLeft).toBe 0
-
-      editor.setCursorBufferPosition([5, 5])
-      cursorRect = editor.getCursor().getPixelRect()
-      cursorTop = cursorRect.top
-      cursorLeft = cursorRect.left
-      expect(inputNode.offsetTop).toBe cursorTop - editor.getScrollTop()
-      expect(inputNode.offsetLeft).toBe cursorLeft - editor.getScrollLeft()
-
     it "does not render cursors that are associated with non-empty selections", ->
       editor.setSelectedScreenRange([[0, 4], [4, 6]])
       editor.addCursorAtScreenPosition([6, 8])
@@ -467,6 +448,48 @@ describe "EditorComponent", ->
       expect(editor.getSelection(1).isEmpty()).toBe true
 
       expect(node.querySelectorAll('.selection').length).toBe 1
+
+  describe "hidden input field", ->
+    it "renders the hidden input field at the position of the last cursor if the cursor is on screen and the editor is focused", ->
+      editor.setVerticalScrollMargin(0)
+      editor.setHorizontalScrollMargin(0)
+
+      inputNode = node.querySelector('.hidden-input')
+      node.style.height = 5 * lineHeightInPixels + 'px'
+      node.style.width = 10 * charWidth + 'px'
+      component.measureHeightAndWidth()
+
+      expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+      editor.setScrollTop(3 * lineHeightInPixels)
+      editor.setScrollLeft(3 * charWidth)
+
+      expect(inputNode.offsetTop).toBe 0
+      expect(inputNode.offsetLeft).toBe 0
+
+      # In bounds, not focused
+      editor.setCursorBufferPosition([5, 4])
+      expect(inputNode.offsetTop).toBe 0
+      expect(inputNode.offsetLeft).toBe 0
+
+      # In bounds and focused
+      inputNode.focus()
+      expect(inputNode.offsetTop).toBe (5 * lineHeightInPixels) - editor.getScrollTop()
+      expect(inputNode.offsetLeft).toBe (4 * charWidth) - editor.getScrollLeft()
+
+      # In bounds, not focused
+      inputNode.blur()
+      expect(inputNode.offsetTop).toBe 0
+      expect(inputNode.offsetLeft).toBe 0
+
+      # Out of bounds, not focused
+      editor.setCursorBufferPosition([1, 2])
+      expect(inputNode.offsetTop).toBe 0
+      expect(inputNode.offsetLeft).toBe 0
+
+      # Out of bounds, focused
+      inputNode.focus()
+      expect(inputNode.offsetTop).toBe 0
+      expect(inputNode.offsetLeft).toBe 0
 
   describe "mouse interactions", ->
     linesNode = null

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -65,7 +65,7 @@ EditorComponent = React.createClass
         scrollTop, scrollLeft, scrollHeight, scrollWidth, @scrollingVertically,
         @cursorsMoved, @selectionChanged, @selectionAdded, cursorBlinkPeriod,
         cursorBlinkResumeDelay, @onInputFocused, @onInputBlurred, @mouseWheelScreenRow,
-        invisibles, visible, scrollViewHeight
+        invisibles, visible, scrollViewHeight, focused
       }
 
       ScrollbarComponent

--- a/src/editor-scroll-view-component.coffee
+++ b/src/editor-scroll-view-component.coffee
@@ -45,6 +45,11 @@ EditorScrollViewComponent = React.createClass
     @getDOMNode().addEventListener 'overflowchanged', @onOverflowChanged
     window.addEventListener('resize', @onWindowResize)
 
+    node.addEventListener 'scroll', ->
+      console.warn "EditorScrollView scroll position changed, and it shouldn't have. If you can reproduce this, please report it."
+      node.scrollTop = 0
+      node.scrollLeft = 0
+
     @measureHeightAndWidth()
 
   componentDidUnmount: ->

--- a/src/editor-scroll-view-component.coffee
+++ b/src/editor-scroll-view-component.coffee
@@ -42,7 +42,9 @@ EditorScrollViewComponent = React.createClass
       }
 
   componentDidMount: ->
-    @getDOMNode().addEventListener 'overflowchanged', @onOverflowChanged
+    node = @getDOMNode()
+
+    node.addEventListener 'overflowchanged', @onOverflowChanged
     window.addEventListener('resize', @onWindowResize)
 
     node.addEventListener 'scroll', ->
@@ -163,15 +165,14 @@ EditorScrollViewComponent = React.createClass
     {top, left}
 
   getHiddenInputPosition: ->
-    {editor} = @props
-    return {top: 0, left: 0} unless @isMounted() and editor.getCursor()?
+    {editor, focused} = @props
+    return {top: 0, left: 0} unless @isMounted() and focused and editor.getCursor()?
 
     {top, left, height, width} = editor.getCursor().getPixelRect()
-    top = top - editor.getScrollTop()
+    top -= editor.getScrollTop()
+    left -= editor.getScrollLeft()
     top = Math.max(0, Math.min(editor.getHeight() - height, top))
-    left = left - editor.getScrollLeft()
     left = Math.max(0, Math.min(editor.getWidth() - width, left))
-
     {top, left}
 
   # Measure explicitly-styled height and width and relay them to the model. If

--- a/src/editor-scroll-view-component.coffee
+++ b/src/editor-scroll-view-component.coffee
@@ -169,6 +169,7 @@ EditorScrollViewComponent = React.createClass
     return {top: 0, left: 0} unless @isMounted() and focused and editor.getCursor()?
 
     {top, left, height, width} = editor.getCursor().getPixelRect()
+    width = 2 if width is 0 # Prevent autoscroll at the end of longest line
     top -= editor.getScrollTop()
     left -= editor.getScrollLeft()
     top = Math.max(0, Math.min(editor.getHeight() - height, top))


### PR DESCRIPTION
Because we need to draw content before scrolling to it, the editor's scrolling behavior is completely synthetic. We use `translate3d` to move the `.lines` div around and never actually set the `scrollTop` or `scrollLeft` of the `.scroll-view` that contains them.

However, if the hidden input field ever gets out of the visible area of the scroll view, the browser tries to be helpful and scroll it into view, which changes the `scrollTop` and `scrollLeft` and ruins everything. This PR tries to stop that.
- If we do scroll, we log a warning and auto-correct the problem. I'd like to remove this stop gap once we don't see warnings for a long enough time, but it's better than leaving the editor in a busted state.
- When the editor is blurred, we always park the hidden input at 0, 0. This eliminates some cases where the editor could autoscroll after changing size while unfocused and then being focused.
- Allow 2px for the hidden input when the cursor reaches the end of the longest line. This ensures we don't autoscroll to the right when moving the cursor to the right edge of the editor.
