### PR TITLE
Fixed links in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,4 @@
 # Welcome to the Atom API Documentation  
-*Links that are ~~Struck Through~~ are broken*  
 
 ![Atom](https://cloud.githubusercontent.com/assets/72919/2874231/3af1db48-d3dd-11e3-98dc-6066f8bc766f.png)
 
@@ -7,7 +6,7 @@
 
 ### Where do I start?
 
-Check out ~~[EditorView][EditorView]~~ and ~~[Editor][Editor]~~ classes for a good
+Check out [EditorView][EditorView] and [Editor][Editor] classes for a good
 overview of the main editor API.
 
 ### How do I access these classes?
@@ -22,17 +21,17 @@ You can also require many of these classes in your package via:
 ```
 
 The classes available from `require 'atom'` are:
-  * ~~[BufferedProcess][BufferedProcess]~~
-  * ~~[BufferedNodeProcess][BufferedNodeProcess]~~
-  * ~~[EditorView][EditorView]~~
-  * ~~[Git][Git]~~
-  * ~~[Point][Point]~~
-  * ~~[Range][Range]~~
-  * ~~[ScrollView][ScrollView]~~
-  * ~~[SelectListView][SelectListView]~~
-  * ~~[View][View]~~
-  * ~~[WorkspaceView][WorkspaceView]~~
-  * ~~[Workspace][Workspace]~~
+  * [BufferedProcess][BufferedProcess]
+  * [BufferedNodeProcess][BufferedNodeProcess]
+  * [EditorView][EditorView]
+  * [Git][Git]
+  * [Point][Point]
+  * [Range][Range]
+  * [ScrollView][ScrollView]
+  * [SelectListView][SelectListView]
+  * [View][View]
+  * [WorkspaceView][WorkspaceView]
+  * [Workspace][Workspace]
 
 ### How do I create a package?
 
@@ -45,17 +44,17 @@ Atom ships with node 0.11.10 and the comprehensive node API docs are available
 [here][node-docs].
 
 [Atom]: ../classes/Atom.html
-[BufferedProcess]: ../classes/BufferedProcess.html
-[BufferedNodeProcess]: ../classes/BufferedNodeProcess.html
-[Editor]: ../classes/Editor.html
-[EditorView]: ../classes/EditorView.html
-[Git]: ../classes/Git.html
-[Point]: ../classes/Point.html
-[Range]: ../classes/Range.html
-[ScrollView]: ../classes/ScrollView.html
-[SelectListView]: ../classes/SelectListView.html
-[View]: ../classes/View.html
-[WorkspaceView]: ../classes/WorkspaceView.html
-[Workspace]: ../classes/Workspace.html
+[BufferedProcess]: https://atom.io/docs/api/v0.98.0/api/classes/BufferedProcess.html
+[BufferedNodeProcess]: https://atom.io/docs/api/v0.98.0/api/classes/BufferedNodeProcess.html
+[Editor]: https://atom.io/docs/api/v0.98.0/api/classes/Editor.html
+[EditorView]: https://atom.io/docs/api/v0.98.0/api/classes/EditorView.html
+[Git]: https://atom.io/docs/api/v0.98.0/api/classes/Git.html
+[Point]: https://atom.io/docs/api/v0.98.0/api/classes/Point.html
+[Range]: https://atom.io/docs/api/v0.98.0/api/classes/Range.html
+[ScrollView]: https://atom.io/docs/api/v0.98.0/api/classes/ScrollView.html
+[SelectListView]: https://atom.io/docs/api/v0.98.0/api/classes/SelectListView.html
+[View]: https://atom.io/docs/api/v0.98.0/api/classes/View.html
+[WorkspaceView]: https://atom.io/docs/api/v0.98.0/api/classes/WorkspaceView.html
+[Workspace]: https://atom.io/docs/api/v0.98.0/api/classes/Workspace.html
 [creating-a-package]: https://atom.io/docs/latest/creating-a-package
 [node-docs]: http://nodejs.org/docs/v0.11.10/api

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,3 @@
-<style>del{color: #A33;}</style>
 # Welcome to the Atom API Documentation  
 *Links that are ~~Struck Through~~ are broken*  
 
@@ -23,7 +22,7 @@ You can also require many of these classes in your package via:
 ```
 
 The classes available from `require 'atom'` are:
-  * <span style="color: #A33;">~~[BufferedProcess][BufferedProcess]~~</span>
+  * ~~[BufferedProcess][BufferedProcess]~~
   * ~~[BufferedNodeProcess][BufferedNodeProcess]~~
   * ~~[EditorView][EditorView]~~
   * ~~[Git][Git]~~

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
+<style>del{color: #A33;}</style>
 # Welcome to the Atom API Documentation  
 *Links that are ~~Struck Through~~ are broken*  
 
@@ -22,7 +23,7 @@ You can also require many of these classes in your package via:
 ```
 
 The classes available from `require 'atom'` are:
-  * ~~[BufferedProcess][BufferedProcess]~~
+  * <span style="color: #A33;">~~[BufferedProcess][BufferedProcess]~~</span>
   * ~~[BufferedNodeProcess][BufferedNodeProcess]~~
   * ~~[EditorView][EditorView]~~
   * ~~[Git][Git]~~

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,5 @@
-# Welcome to the Atom API Documentation
+# Welcome to the Atom API Documentation  
+*Links that are ~~Struck Through~~ are broken*  
 
 ![Atom](https://cloud.githubusercontent.com/assets/72919/2874231/3af1db48-d3dd-11e3-98dc-6066f8bc766f.png)
 
@@ -6,7 +7,7 @@
 
 ### Where do I start?
 
-Check out [EditorView][EditorView] and [Editor][Editor] classes for a good
+Check out ~~[EditorView][EditorView]~~ and ~~[Editor][Editor]~~ classes for a good
 overview of the main editor API.
 
 ### How do I access these classes?
@@ -21,17 +22,17 @@ You can also require many of these classes in your package via:
 ```
 
 The classes available from `require 'atom'` are:
-  * [BufferedProcess][BufferedProcess]
-  * [BufferedNodeProcess][BufferedNodeProcess]
-  * [EditorView][EditorView]
-  * [Git][Git]
-  * [Point][Point]
-  * [Range][Range]
-  * [ScrollView][ScrollView]
-  * [SelectListView][SelectListView]
-  * [View][View]
-  * [WorkspaceView][WorkspaceView]
-  * [Workspace][Workspace]
+  * ~~[BufferedProcess][BufferedProcess]~~
+  * ~~[BufferedNodeProcess][BufferedNodeProcess]~~
+  * ~~[EditorView][EditorView]~~
+  * ~~[Git][Git]~~
+  * ~~[Point][Point]~~
+  * ~~[Range][Range]~~
+  * ~~[ScrollView][ScrollView]~~
+  * ~~[SelectListView][SelectListView]~~
+  * ~~[View][View]~~
+  * ~~[WorkspaceView][WorkspaceView]~~
+  * ~~[Workspace][Workspace]~~
 
 ### How do I create a package?
 


### PR DESCRIPTION
The links in docs/README.md were relative links(ex: "../foo.html"). I made them absolute links(ex: "http://www.foo.com/foo.html") so they link correctly from Github, Atom.io, and the documentation viewer.
