### PR TITLE
Add troubleshoot info about missing https helpers

### DIFF
--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -47,4 +47,4 @@ fix this, you probably need to fiddle with your system PATH.
 
 * `npm ERR! Error: Command failed: fatal: Unable to find remote helper for 'https'`
 
-  * In this case use the windows `cmd.exe` and execute `script\build` (pay attention to the baskslash!).
+  * In this case use the windows `cmd.exe` and execute `script\build` (pay attention to the backslash!).

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -44,3 +44,7 @@ fix this, you probably need to fiddle with your system PATH.
 
   * If you just installed node you need to restart your computer before node is
   available on your Path.
+
+* `npm ERR! Error: Command failed: fatal: Unable to find remote helper for 'https'`
+
+  * In this case use the windows `cmd.exe` and execute `script\build` (pay attention to the baskslash!).


### PR DESCRIPTION
I'm using Win7 x64 with the git-bash with version 1.9.2.msysgit.0.
For some reason I can't build the package because it can't find the https helpers.
I found [this atom issue](https://github.com/atom/atom/issues/2206#issuecomment-43443805) which helped me a lot and I thought I need to add this information in the build readme.

Here is my error log for reference. 

```
 (master) /c/OWN/SCM-Store/GitHub/atom/atom$ script/build

Installing modules ✗

> atom@0.99.0 preinstall C:\OWN\SCM-Store\GitHub\atom\atom
> node -e 'process.exit(0)'


npm ERR! git fetch -a origin (https://github.com/atom/bootstrap.git) fatal: Unable to find remote helper for 'https'
npm ERR! Error: Command failed: fatal: Unable to find remote helper for 'https'
npm ERR!
npm ERR!     at ChildProcess.exithandler (child_process.js:637:15)
npm ERR!     at ChildProcess.EventEmitter.emit (events.js:98:17)
npm ERR!     at maybeClose (child_process.js:743:16)
npm ERR!     at Process.ChildProcess._handle.onexit (child_process.js:810:5)
npm ERR! If you need help, you may report this *entire* log,
npm ERR! including the npm and node versions, at:
npm ERR!     <http://github.com/npm/npm/issues>

npm ERR! System Windows_NT 6.1.7601
npm ERR! command "C:\\OWN\\SCM-Store\\GitHub\\atom\\atom\\apm\\node_modules\\atom-package-manager\\bin\\node.exe" "C:\\OWN\\SCM-Store\\GitHub\\atom\\atom\\apm\\node_modules\\atom-package-manager\\node_modules\\npm\\bin\\npm-cli.js" "--globalconfig" "C:\\OWN\\SCM-Store\\GitHub\\atom\\atom\\apm\\node_modules\\atom-package-manager\\.apmrc" "--userconfig" "C:\\Users\\root\\.atom\\.apmrc" "install" "--target=0.11.10" "--arch=ia32" "--quiet" "--msvs_version=2010"
npm ERR! cwd C:\OWN\SCM-Store\GitHub\atom\atom
npm ERR! node -v v0.10.26
npm ERR! npm -v 1.4.4
npm ERR! code 128
npm
 (master) /c/OWN/SCM-Store/GitHub/atom/atom$
```
