### PR TITLE
Reload grammar in editor when path changes

### DIFF
--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -547,7 +547,6 @@ class EditorView extends View
       @showBufferConflictAlert(@editor)
 
     @subscribe @editor, "path-changed", =>
-      @editor.reloadGrammar()
       @trigger 'editor:path-changed'
 
     @subscribe @editor, "grammar-changed", =>

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -200,6 +200,8 @@ class Editor extends Model
         atom.project.setPath(path.dirname(@getPath()))
       @emit "title-changed"
       @emit "path-changed"
+      @reloadGrammar()
+
     @subscribe @buffer, "contents-modified", => @emit "contents-modified"
     @subscribe @buffer, "contents-conflicted", => @emit "contents-conflicted"
     @subscribe @buffer, "modified-status-changed", => @emit "modified-status-changed"

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -196,11 +196,11 @@ class Editor extends Model
   subscribeToBuffer: ->
     @buffer.retain()
     @subscribe @buffer, "path-changed", =>
+      @reloadGrammar()
       unless atom.project.getPath()?
         atom.project.setPath(path.dirname(@getPath()))
       @emit "title-changed"
       @emit "path-changed"
-      @reloadGrammar()
 
     @subscribe @buffer, "contents-modified", => @emit "contents-modified"
     @subscribe @buffer, "contents-conflicted", => @emit "contents-conflicted"

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -201,7 +201,6 @@ class Editor extends Model
         atom.project.setPath(path.dirname(@getPath()))
       @emit "title-changed"
       @emit "path-changed"
-
     @subscribe @buffer, "contents-modified", => @emit "contents-modified"
     @subscribe @buffer, "contents-conflicted", => @emit "contents-conflicted"
     @subscribe @buffer, "modified-status-changed", => @emit "modified-status-changed"

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -196,7 +196,6 @@ class Editor extends Model
   subscribeToBuffer: ->
     @buffer.retain()
     @subscribe @buffer, "path-changed", =>
-      @reloadGrammar()
       unless atom.project.getPath()?
         atom.project.setPath(path.dirname(@getPath()))
       @emit "title-changed"

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -31,7 +31,9 @@ class TokenizedBuffer extends Model
 
     @on 'grammar-changed grammar-updated', => @resetTokenizedLines()
     @subscribe @buffer, "changed", (e) => @handleBufferChange(e)
-    @subscribe @buffer, "path-changed", => @bufferPath = @buffer.getPath()
+    @subscribe @buffer, "path-changed", =>
+      @bufferPath = @buffer.getPath()
+      @reloadGrammar()
 
     @subscribe @$tabLength.changes, (tabLength) =>
       lastRow = @buffer.getLastRow()


### PR DESCRIPTION
Reloading of the grammar when the editor's path changed regressed in the react editor since it doesn't handle these events yet.

This probably should have always happened at the model anyway.

Closes #2385
