### PR TITLE
Make React editor backward compatible with find-and-replace marker views

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "dev-live-reload": "0.30.0",
     "exception-reporting": "0.17.0",
     "feedback": "0.33.0",
-    "find-and-replace": "0.106.0",
+    "find-and-replace": "0.107.0",
     "fuzzy-finder": "0.52.0",
     "git-diff": "0.28.0",
     "go-to-line": "0.21.0",

--- a/src/react-editor-view.coffee
+++ b/src/react-editor-view.coffee
@@ -16,6 +16,8 @@ class ReactEditorView extends View
 
   Object.defineProperty @::, 'lineHeight', get: -> @editor.getLineHeightInPixels()
   Object.defineProperty @::, 'charWidth', get: -> @editor.getDefaultCharWidth()
+  Object.defineProperty @::, 'firstRenderedScreenRow', get: -> @component.getRenderedRowRange()[0]
+  Object.defineProperty @::, 'lastRenderedScreenRow', get: -> @component.getRenderedRowRange()[1]
 
   scrollTop: (scrollTop) ->
     if scrollTop?
@@ -90,3 +92,5 @@ class ReactEditorView extends View
   show: ->
     super
     @component.show()
+
+  requestDisplayUpdate: -> # No-op shim for find-and-replace


### PR DESCRIPTION
Fixes #2343

Had to detect whether the view was an editor using a class check rather than `instanceof` in `find-and-replace` and add 3 shim methods. We should still switch `find-and-replace` over to marker views but it's no longer a blocker for switching.

![screenshot 2014-05-23 18 57 52](https://cloud.githubusercontent.com/assets/1789/3073231/6040706e-e2e0-11e3-90d3-56c312cdb4db.png)
