### PR TITLE
Changes cursor for scrollbars to default.

### DIFF
--- a/static/editor.less
+++ b/static/editor.less
@@ -30,12 +30,14 @@
     right: 0;
     bottom: 0;
 
+    cursor: default;
     height: 15px;
     overflow-x: auto;
     overflow-y: hidden;
     z-index: 3;
 
     .scrollbar-content {
+      cursor: default;
       height: 15px;
     }
   }


### PR DESCRIPTION
Only to fix the `cursor: text` value in editor when using scrollbars.

Sorry if is already addressed elsewhere. :) very bottom of the list of proposed changes, haha. First day downloaded, very excited.

Was originally going to only put with `.editor .vertical-scrollbar` but saw that the editor's horizontal uses the default horizontal scrollbar also used in file viewer.

Cheers,
Tom
