### PR TITLE
Fix typo in EditorView documentation

### DIFF
--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -28,7 +28,7 @@ LongLineLength = 1000
 # ## Iterating over the open editor views
 #
 # ```coffee
-# for editorView in atom.workspace.getEditorViews()
+# for editorView in atom.workspaceView.getEditorViews()
 #   console.log(editorView.getEditor().getPath())
 # ```
 #


### PR DESCRIPTION
Incorrect usage of `atom.workspace.getEditorViews()` fixed with `atom.workspaceView.getEditorViews()`.

As a side note, this example should ideally be moved to the `Editor` class and changed to

``` coffeescript
for editor in atom.workspace.getEditors()
  console.log(editor.getPath())
```

given the nature of the example, lest we change the `console.log` statement to something else that doesn't rely on `Editor` as opposed to `EditorView`.
