### PR TITLE
:bug: Prevent call to `getCursorScreenRow` if there's no cursor

### DIFF
--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -864,6 +864,7 @@ class Editor extends Model
   #
   # Returns a {Boolean}.
   isFoldedAtCursorRow: ->
+    return false unless @getCursor()?
     @isFoldedAtScreenRow(@getCursorScreenRow())
 
   # Public: Determine whether the given row in buffer coordinates is folded.


### PR DESCRIPTION
I got this error randomly when closing tabs. The `bracket-matcher` package still try to update after the tab destruction, calling `isFoldedAtCursorRow` on an editor that no longer have a cursor.

```
Uncaught TypeError: Cannot call method 'getScreenRow' of undefined /Applications/Atom.app/Contents/Resources/app/src/editor.js:1311
module.exports.Editor.getCursorScreenRow /Applications/Atom.app/Contents/Resources/app/src/editor.js:1311
module.exports.Editor.isFoldedAtCursorRow /Applications/Atom.app/Contents/Resources/app/src/editor.js:819
module.exports.BracketMatcherView.updateMatch /Applications/Atom.app/Contents/Resources/app/node_modules/bracket-matcher/lib/bracket-matcher-view…:138
(anonymous function) /Applications/Atom.app/Contents/Resources/app/node_modules/bracket-matcher/lib/bracket-matcher-view…:123
(anonymous function) /Applications/Atom.app/Contents/Resources/app/node_modules/emissary/lib/emitter.js:133
module.exports.Emitter.emit /Applications/Atom.app/Contents/Resources/app/node_modules/emissary/lib/emitter.js:132
(anonymous function) /Applications/Atom.app/Contents/Resources/app/src/cursor.js:62
(anonymous function) /Applications/Atom.app/Contents/Resources/app/node_modules/emissary/lib/emitter.js:133
module.exports.Emitter.emit /Applications/Atom.app/Contents/Resources/app/node_modules/emissary/lib/emitter.js:132
module.exports.DisplayBufferMarker.destroyed /Applications/Atom.app/Contents/Resources/app/src/display-buffer-marker.js:170
(anonymous function) /Applications/Atom.app/Contents/Resources/app/src/display-buffer-marker.js:37
(anonymous function) /Applications/Atom.app/Contents/Resources/app/node_modules/emissary/lib/emitter.js:133
module.exports.Emitter.emit /Applications/Atom.app/Contents/Resources/app/node_modules/emissary/lib/emitter.js:132
module.exports.Marker.destroy /Applications/Atom.app/Contents/Resources/app/node_modules/text-buffer/lib/marker.js:291
module.exports.DisplayBufferMarker.destroy /Applications/Atom.app/Contents/Resources/app/src/display-buffer-marker.js:149
module.exports.Selection.destroy /Applications/Atom.app/Contents/Resources/app/src/selection.js:49
module.exports.Editor.destroyed /Applications/Atom.app/Contents/Resources/app/src/editor.js:205
module.exports.Model.destroy /Applications/Atom.app/Contents/Resources/app/node_modules/theorist/lib/model.js:218
module.exports.EditorView.beforeRemove /Applications/Atom.app/Contents/Resources/app/src/editor-view.js:1422
jQuery.cleanData /Applications/Atom.app/Contents/Resources/app/node_modules/space-pen/lib/space-pen.js:395
jQuery.cleanData /Applications/Atom.app/Contents/Resources/app/src/space-pen-extensions.js:24
jQuery.fn.extend.remove /Applications/Atom.app/Contents/Resources/app/node_modules/space-pen/vendor/jquery.js:5494
module.exports.EditorView.remove /Applications/Atom.app/Contents/Resources/app/src/editor-view.js:1413
module.exports.PaneView.onItemRemoved /Applications/Atom.app/Contents/Resources/app/src/pane-view.js:321
(anonymous function) /Applications/Atom.app/Contents/Resources/app/src/pane-view.js:3
(anonymous function) /Applications/Atom.app/Contents/Resources/app/node_modules/emissary/lib/emitter.js:133
module.exports.Emitter.emit /Applications/Atom.app/Contents/Resources/app/node_modules/emissary/lib/emitter.js:132
module.exports.Pane.removeItem /Applications/Atom.app/Contents/Resources/app/src/pane.js:227
module.exports.Pane.destroyItem /Applications/Atom.app/Contents/Resources/app/src/pane.js:260
module.exports.Pane.destroyActiveItem /Applications/Atom.app/Contents/Resources/app/src/pane.js:252
module.exports.Workspace.destroyActivePaneItem /Applications/Atom.app/Contents/Resources/app/src/workspace.js:296
_results.push._this.(anonymous function) /Applications/Atom.app/Contents/Resources/app/node_modules/delegato/lib/delegator.js:67
(anonymous function) /Applications/Atom.app/Contents/Resources/app/src/workspace-view.js:299
jQuery.event.dispatch /Applications/Atom.app/Contents/Resources/app/node_modules/space-pen/vendor/jquery.js:4676
elemData.handle /Applications/Atom.app/Contents/Resources/app/node_modules/space-pen/vendor/jquery.js:4360
module.exports.KeymapManager.dispatchCommandEvent /Applications/Atom.app/Contents/Resources/app/node_modules/atom-keymap/lib/keymap-manager.js:395
module.exports.KeymapManager.handleKeyboardEvent /Applications/Atom.app/Contents/Resources/app/node_modules/atom-keymap/lib/keymap-manager.js:176
(anonymous function) /Applications/Atom.app/Contents/Resources/app/src/window-event-handler.js:90
jQuery.event.dispatch /Applications/Atom.app/Contents/Resources/app/node_modules/space-pen/vendor/jquery.js:4676
elemData.handle
```

This patch forces the `isFoldedAtCursorRow` method to return false if there's no cursor available.
