### PR TITLE
Make cursor visible when over indent guides

### DIFF
--- a/static/editor.less
+++ b/static/editor.less
@@ -17,7 +17,7 @@
   }
 
   .cursor {
-    z-index: 1;
+    z-index: 2;
   }
 
   &.is-focused .cursors.blink-off .cursor {


### PR DESCRIPTION
Cursor was invisible when over the indent guides. Super frustrating! Not sure if this is the best way to do this @nathansobo 
