### PR TITLE
Make react the default editor

### DIFF
--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -71,7 +71,7 @@ class WorkspaceView extends View
     projectHome: path.join(fs.getHomeDirectory(), 'github')
     audioBeep: true
     destroyEmptyPanes: true
-    useReactEditor: false
+    useReactEditor: true
 
   @content: ->
     @div class: 'workspace', tabindex: -1, =>


### PR DESCRIPTION
This will make react the default editor.

All issues related to the react editor: https://github.com/atom/atom/issues?labels=react-editor-bug
## Todo

These are the blockers to releasing the react editor as the default
- [ ] Do a pass on React updates and see if we can boost cursor and text insertion performance
## Completed Tasks
- [x] Show code folding markers in gutter #1984 #2464
- [x] Shift + Backspace renders deleted characters #2159 
- [x] Lines sometimes duplicated or not removed #2429
- [x] Make autocomplete-plus work with the react editor #2318
- [x] Fix broken context menus #2442
- [x] Missing API on ReactEditorView #2428 (PR #2497)
- [x] React editor cannot open this file  bug react-editor #2392 
- [x] Closing find occasionally causes buffer rendering issues #2237 
- [x] Get the build green with react turned on in specs
- [x] Fix selection problems #2459
- [x] Fix problems with spellcheck #2460
- [x] Fix issues with find and replace atom/find-and-replace#232
- [x] Scroll speed is too fast
- [x] Selections become hidden behind tool-panels #2578 
- [x] Add back IME composition events 184068dc55d2cc2f3aaa9e43c7aa9aa54946b53d
- [x] Add highlight decorations #2605 
- [x] Gutter styles don't extend to the bottom of the editor #2596 
- [x] With React editor turned on line numbers are always on #2707 
- [x] Decorations not updated when markers move #2705 #2727 
- [x] ctrl+click to add a cursor doesn't work on linux #2105 
- [x] ReactEditorView has no method resetDisplay #2674 
- [x] Mouse selection seems to be off-by-one in React Editor #2668
- [x] Editor scroll width is miscalculated when longest line has variable-width characters #2666 
- [x] Cursor line highlights don't go full width and show with selections #2701 #2757  
- [x] Create blog post about the React Editor change atom/blog.atom.io#48
- [x] Soft wrap issues #2842 #2844 
- [x] Character widths aren't invalidated when stylesheets are changed #2845 
- [x] Not autoscrolling when cursor moves due to undo #2815
- [x] Indent guide is wrong #2367
- [x] Update the decoration API #2819
- [x] Characters are measured as 0 width when editor is hidden during theme change #2856 
- [x] Accent circonflexe removes previous char #2716 
- [x] End-of-line invisibles not visible on empty lines with indent guides in React editor #2857
- [x] Scrolling is sluggish when there a large numbers of folds #2848 
## Fixes these issues

Fixes #2443
Fixes #1850
Fixes #1790 
Fixes #1711
Fixes #2778
Fixes #2764
Fixed #2710 
Fixed #2785
Fixed atom/find-and-replace#245
Fixes #2375
