### PR TITLE
Use tokenized event to determine tab style

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2876,6 +2876,18 @@ describe "Editor", ->
       expect(editor.lineForBufferRow(4)).toBe "    }"
       expect(editor.lineForBufferRow(5)).toBe "    i=1"
 
+  describe "soft and hard tabs", ->
+    it "resets the tab style when tokenization is complete", ->
+      editor.destroy()
+      atom.project.open('sample-with-tabs-and-leading-comment.coffee').then (o) -> editor = o
+      expect(editor.softTabs).toBe true
+
+      waitsForPromise ->
+        atom.packages.activatePackage('language-coffee-script')
+
+      runs ->
+        expect(editor.softTabs).toBe false
+
   describe ".destroy()", ->
     it "destroys all markers associated with the edit session", ->
       expect(buffer.getMarkerCount()).toBeGreaterThan 0

--- a/spec/fixtures/sample-with-tabs-and-leading-comment.coffee
+++ b/spec/fixtures/sample-with-tabs-and-leading-comment.coffee
@@ -1,0 +1,4 @@
+  # This is a comment
+if this.studyingEconomics
+	buy()	while supply > demand
+		sell() until supply > demand

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -414,19 +414,29 @@ describe "TokenizedBuffer", ->
         editor.getBuffer().insert([0, 0], "'")
         fullyTokenize(tokenizedBuffer)
         expect(tokenizedHandler).not.toHaveBeenCalled()
-      buffer = null
+
+  describe "when the grammar is updated because a grammar it includes is activated", ->
+    it "re-emits the `tokenized` event", ->
+      editor = null
       tokenizedBuffer = null
       tokenizedHandler = jasmine.createSpy("tokenized handler")
 
       waitsForPromise ->
-        atom.project.open('sample.js').then (editor) -> buffer = editor.getBuffer()
+        atom.project.open('coffee.coffee').then (o) -> editor = o
 
       runs ->
-        tokenizedBuffer = new TokenizedBuffer({buffer})
+        tokenizedBuffer = editor.displayBuffer.tokenizedBuffer
         tokenizedBuffer.on 'tokenized', tokenizedHandler
         fullyTokenize(tokenizedBuffer)
+        tokenizedHandler.reset()
+
+      waitsForPromise ->
+        atom.packages.activatePackage('language-coffee-script')
+
+      runs ->
+        fullyTokenize(tokenizedBuffer)
         expect(tokenizedHandler.callCount).toBe(1)
-  describe "when the grammar is updated because a grammar it includes is activated", ->
+
     it "retokenizes the buffer", ->
 
       waitsForPromise ->

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -385,6 +385,20 @@ describe "TokenizedBuffer", ->
       expect(tokens[1].value).toBeTruthy()
       expect(tokens[2].value).toBe 'xyz'
 
+  describe "when the grammar tokenized", ->
+    it "emits the `tokenized` event", ->
+      buffer = null
+      tokenizedBuffer = null
+      tokenizedHandler = jasmine.createSpy("tokenized handler")
+
+      waitsForPromise ->
+        atom.project.open('sample.js').then (editor) -> buffer = editor.getBuffer()
+
+      runs ->
+        tokenizedBuffer = new TokenizedBuffer({buffer})
+        tokenizedBuffer.on 'tokenized', tokenizedHandler
+        fullyTokenize(tokenizedBuffer)
+        expect(tokenizedHandler.callCount).toBe(1)
   describe "when the grammar is updated because a grammar it includes is activated", ->
     it "retokenizes the buffer", ->
 

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -387,6 +387,17 @@ describe "TokenizedBuffer", ->
 
   describe "when the grammar tokenized", ->
     it "emits the `tokenized` event", ->
+      editor = null
+      tokenizedHandler = jasmine.createSpy("tokenized handler")
+
+      waitsForPromise ->
+        atom.project.open('sample.js').then (o) -> editor = o
+
+      runs ->
+        tokenizedBuffer = editor.displayBuffer.tokenizedBuffer
+        tokenizedBuffer.on 'tokenized', tokenizedHandler
+        fullyTokenize(tokenizedBuffer)
+        expect(tokenizedHandler.callCount).toBe(1)
       buffer = null
       tokenizedBuffer = null
       tokenizedHandler = jasmine.createSpy("tokenized handler")

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -385,7 +385,7 @@ describe "TokenizedBuffer", ->
       expect(tokens[1].value).toBeTruthy()
       expect(tokens[2].value).toBe 'xyz'
 
-  describe "when the grammar tokenized", ->
+  describe "when the grammar is tokenized", ->
     it "emits the `tokenized` event", ->
       editor = null
       tokenizedHandler = jasmine.createSpy("tokenized handler")
@@ -399,7 +399,7 @@ describe "TokenizedBuffer", ->
         fullyTokenize(tokenizedBuffer)
         expect(tokenizedHandler.callCount).toBe(1)
 
-    it "doesn't re-emit the `tokenized` event when a line is edited", ->
+    it "doesn't re-emit the `tokenized` event when it is re-tokenized", ->
       editor = null
       tokenizedHandler = jasmine.createSpy("tokenized handler")
 

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -398,6 +398,22 @@ describe "TokenizedBuffer", ->
         tokenizedBuffer.on 'tokenized', tokenizedHandler
         fullyTokenize(tokenizedBuffer)
         expect(tokenizedHandler.callCount).toBe(1)
+
+    it "doesn't re-emit the `tokenized` event when a line is edited", ->
+      editor = null
+      tokenizedHandler = jasmine.createSpy("tokenized handler")
+
+      waitsForPromise ->
+        atom.project.open('sample.js').then (o) -> editor = o
+
+      runs ->
+        tokenizedBuffer = editor.displayBuffer.tokenizedBuffer
+        fullyTokenize(tokenizedBuffer)
+
+        tokenizedBuffer.on 'tokenized', tokenizedHandler
+        editor.getBuffer().insert([0, 0], "'")
+        fullyTokenize(tokenizedBuffer)
+        expect(tokenizedHandler).not.toHaveBeenCalled()
       buffer = null
       tokenizedBuffer = null
       tokenizedHandler = jasmine.createSpy("tokenized handler")

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -46,6 +46,7 @@ class DisplayBuffer extends Model
     @updateAllScreenLines()
     @createFoldForMarker(marker) for marker in @buffer.findMarkers(@getFoldMarkerAttributes())
     @subscribe @tokenizedBuffer, 'grammar-changed', (grammar) => @emit 'grammar-changed', grammar
+    @subscribe @tokenizedBuffer, 'tokenized', => @emit 'tokenized'
     @subscribe @tokenizedBuffer, 'changed', @handleTokenizedBufferChange
     @subscribe @buffer, 'markers-updated', @handleBufferMarkersUpdated
     @subscribe @buffer, 'marker-created', @handleBufferMarkerCreated

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -211,6 +211,7 @@ class Editor extends Model
     @subscribe @displayBuffer, "changed", (e) => @emit 'screen-lines-changed', e
     @subscribe @displayBuffer, "markers-updated", => @mergeIntersectingSelections()
     @subscribe @displayBuffer, 'grammar-changed', => @handleGrammarChange()
+    @subscribe @displayBuffer, 'tokenized', => @handleTokenization()
     @subscribe @displayBuffer, 'soft-wrap-changed', (args...) => @emit 'soft-wrap-changed', args...
 
   getViewClass: ->
@@ -1849,6 +1850,9 @@ class Editor extends Model
     "<Editor #{@id}>"
 
   logScreenLines: (start, end) -> @displayBuffer.logLines(start, end)
+
+  handleTokenization: ->
+    @softTabs = @usesSoftTabs() ? @softTabs
 
   handleGrammarChange: ->
     @unfoldAll()

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -124,7 +124,10 @@ class TokenizedBuffer extends Model
       @invalidateRow(row + 1) unless filledRegion
       @emit "changed", { start: invalidRow, end: row, delta: 0 }
 
-    @tokenizeInBackground() if @firstInvalidRow()?
+    if @firstInvalidRow()?
+      @tokenizeInBackground()
+    else
+      @emit "tokenized"
 
   firstInvalidRow: ->
     @invalidRows[0]

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -78,6 +78,7 @@ class TokenizedBuffer extends Model
     @tokenizedLines = @buildPlaceholderTokenizedLinesForRows(0, @buffer.getLastRow())
     @invalidRows = []
     @invalidateRow(0)
+    @fullyTokenized = false
 
   setVisible: (@visible) ->
     @tokenizeInBackground() if @visible
@@ -127,7 +128,8 @@ class TokenizedBuffer extends Model
     if @firstInvalidRow()?
       @tokenizeInBackground()
     else
-      @emit "tokenized"
+      @emit "tokenized" unless @fullyTokenized
+      @fullyTokenized = true
 
   firstInvalidRow: ->
     @invalidRows[0]


### PR DESCRIPTION
`TokenizedBuffer` (and `DisplayBuffer`) now emit a `tokenized` event once a buffer is fully tokenized. They also emit a `tokenized` event when the buffer's grammar changes and is re-tokenized.

`Editor` uses this event as a trigger to determine if a file should use hard or soft tabs. The tokenization event is needed because comments at the top of a file may contain different tab styles than the code and should not be used to determine the tab state. This information is only available after the buffer is tokenized.

Closes #2421
