### PR TITLE
Update os-x.md

### DIFF
--- a/docs/build-instructions/os-x.md
+++ b/docs/build-instructions/os-x.md
@@ -9,7 +9,7 @@
 ## Instructions
 
   ```sh
-  git clone https://github.com/atom/atom
+  git clone https://github.com/atom/atom.git
   cd atom
   script/build # Creates application at /Applications/Atom.app
   ```


### PR DESCRIPTION
With the original URL, git would throw this error:

```
fatal: unable to access 'https://github.com/atom/atom/': The requested URL returned error: 500
```
