### PR TITLE
Fix data gutter add class to line

### DIFF
--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -131,7 +131,7 @@ GutterComponent = React.createClass
       style = "visibility: hidden;"
     innerHTML = @buildLineNumberInnerHTML(bufferRow, softWrapped, maxLineNumberDigits)
 
-    "<div class=\"line-number\" style=\"#{style}\" data-screen-row=\"#{screenRow}\">#{innerHTML}</div>"
+    "<div class=\"line-number\" style=\"#{style}\" data-buffer-row=\"#{bufferRow}\" data-screen-row=\"#{screenRow}\">#{innerHTML}</div>"
 
   buildLineNumberInnerHTML: (bufferRow, softWrapped, maxLineNumberDigits) ->
     if softWrapped

--- a/src/react-editor-view.coffee
+++ b/src/react-editor-view.coffee
@@ -54,7 +54,7 @@ class ReactEditorView extends View
       @gutter.find('.line-number').removeClass(klass)
 
     @gutter.addClassToLine = (bufferRow, klass) =>
-      lines = @gutter.find("[data-buffer-row='#{bufferRow}']");
+      lines = @gutter.find("[data-buffer-row='#{bufferRow}']")
       lines.addClass(klass)
       lines.length > 0
 

--- a/src/react-editor-view.coffee
+++ b/src/react-editor-view.coffee
@@ -54,7 +54,7 @@ class ReactEditorView extends View
       @gutter.find('.line-number').removeClass(klass)
 
     @gutter.addClassToLine = (bufferRow, klass) =>
-      lines = @gutter.find(".line-number-#{bufferRow}")
+      lines = @gutter.find("[data-buffer-row='#{bufferRow}']");
       lines.addClass(klass)
       lines.length > 0
 


### PR DESCRIPTION
This makes git-diff work again by fixing the gutter.addClassToLine shim.

@nathansobo I thought it mad sense to have data-buffer-row and data-screen-row on the node. Let me know if it doesn't.
