### PR TITLE
Emit tokenized-lines signal if lines tokenized

### DIFF
--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -44,6 +44,14 @@ class TokenizedBuffer extends Model
 
     @reloadGrammar()
 
+  # Public: interface for token creation, see class Token for arguments
+  createToken: ->
+    new Token.apply(undefined, arguments)
+
+  # Public: interface for tokenized line creation
+  createTokenizedLine: ->
+    new TokenizedLine.apply(undefined, arguments)
+
   serializeParams: ->
     bufferPath: @buffer.getPath()
     tabLength: @tabLength
@@ -120,6 +128,8 @@ class TokenizedBuffer extends Model
 
       @validateRow(row)
       @invalidateRow(row + 1) unless filledRegion
+
+      @emit "tokenized-lines", { tokenizedBuffer: @, start: invalidRow, end: row, delta: 0}
       @emit "changed", { start: invalidRow, end: row, delta: 0 }
 
     @tokenizeInBackground() if @firstInvalidRow()?
@@ -159,6 +169,7 @@ class TokenizedBuffer extends Model
     if newEndStack and not _.isEqual(newEndStack, previousEndStack)
       @invalidateRow(end + delta + 1)
 
+    @emit "tokenized-lines", { tokenizedBuffer: @, start, end, delta, bufferChange: e }
     @emit "changed", { start, end, delta, bufferChange: e }
 
   buildTokenizedLinesForRows: (startRow, endRow, startingStack) ->

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -129,7 +129,7 @@ class TokenizedBuffer extends Model
       @validateRow(row)
       @invalidateRow(row + 1) unless filledRegion
 
-      @emit "tokenized-lines", { tokenizedBuffer: @, start: invalidRow, end: row, delta: 0}
+      atom.syntax.emit "tokenized-lines", { tokenizedBuffer: @, start: invalidRow, end: row, delta: 0}
       @emit "changed", { start: invalidRow, end: row, delta: 0 }
 
     @tokenizeInBackground() if @firstInvalidRow()?
@@ -169,7 +169,7 @@ class TokenizedBuffer extends Model
     if newEndStack and not _.isEqual(newEndStack, previousEndStack)
       @invalidateRow(end + delta + 1)
 
-    @emit "tokenized-lines", { tokenizedBuffer: @, start, end, delta, bufferChange: e }
+    atom.syntax.emit "tokenized-lines", { tokenizedBuffer: @, start, end, delta, bufferChange: e }
     @emit "changed", { start, end, delta, bufferChange: e }
 
   buildTokenizedLinesForRows: (startRow, endRow, startingStack) ->


### PR DESCRIPTION
Enables grammar developers to inject scope names on a higher level.
This would enable grammars for like restructured text and markdodwn
to insert correct scopenames for constructs like:

```
    Headline
    ========
```

Usually it would be tokenized as

``` json
   [ [ value: "Headline", scopes: [ 'text.restructuredtext', 'meta.paragraph.restructuredtext' ],
    [ value: "========", scopes: ["text.restructuredtext", "meta.paragraph.restructuredtext", "markup.heading.restructuredtext", "punctuation.definition.heading.restructuredtext"]  ]
```

Having the opportunity to look at tokenization on a multiline-base, you can insert "markup.heading.restructuredtext" at
headlines marked as paragraphs.
