### PR TITLE
Fix cursor and selection positioning when changing line height, font size, and font family

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -317,7 +317,7 @@ describe "EditorComponent", ->
       expect(cursorNodes[0].offsetWidth).toBe charWidth
       expect(cursorNodes[0].style['-webkit-transform']).toBe "translate3d(#{5 * charWidth}px, #{0 * lineHeightInPixels}px, 0px)"
 
-      cursor2 = editor.addCursorAtScreenPosition([6, 11])
+      cursor2 = editor.addCursorAtScreenPosition([8, 11])
       cursor3 = editor.addCursorAtScreenPosition([4, 10])
 
       cursorNodes = node.querySelectorAll('.cursor')
@@ -326,15 +326,15 @@ describe "EditorComponent", ->
       expect(cursorNodes[0].style['-webkit-transform']).toBe "translate3d(#{5 * charWidth}px, #{0 * lineHeightInPixels}px, 0px)"
       expect(cursorNodes[1].style['-webkit-transform']).toBe "translate3d(#{10 * charWidth}px, #{4 * lineHeightInPixels}px, 0px)"
 
-      verticalScrollbarNode.scrollTop = 2.5 * lineHeightInPixels
+      verticalScrollbarNode.scrollTop = 4.5 * lineHeightInPixels
       verticalScrollbarNode.dispatchEvent(new UIEvent('scroll'))
       horizontalScrollbarNode.scrollLeft = 3.5 * charWidth
       horizontalScrollbarNode.dispatchEvent(new UIEvent('scroll'))
 
       cursorNodes = node.querySelectorAll('.cursor')
       expect(cursorNodes.length).toBe 2
-      expect(cursorNodes[0].style['-webkit-transform']).toBe "translate3d(#{(11 - 3.5) * charWidth}px, #{(6 - 2.5) * lineHeightInPixels}px, 0px)"
-      expect(cursorNodes[1].style['-webkit-transform']).toBe "translate3d(#{(10 - 3.5) * charWidth}px, #{(4 - 2.5) * lineHeightInPixels}px, 0px)"
+      expect(cursorNodes[0].style['-webkit-transform']).toBe "translate3d(#{(11 - 3.5) * charWidth}px, #{(8 - 4.5) * lineHeightInPixels}px, 0px)"
+      expect(cursorNodes[1].style['-webkit-transform']).toBe "translate3d(#{(10 - 3.5) * charWidth}px, #{(4 - 4.5) * lineHeightInPixels}px, 0px)"
 
       cursor3.destroy()
       cursorNodes = node.querySelectorAll('.cursor')
@@ -364,6 +364,7 @@ describe "EditorComponent", ->
       expect(cursorsNode.classList.contains('blink-off')).toBe false
       advanceClock(component.props.cursorBlinkPeriod / 2)
       expect(cursorsNode.classList.contains('blink-off')).toBe true
+
       advanceClock(component.props.cursorBlinkPeriod / 2)
       expect(cursorsNode.classList.contains('blink-off')).toBe false
 

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -476,6 +476,20 @@ describe "EditorComponent", ->
       selectionNode = node.querySelector('.region')
       expect(selectionNode.offsetTop).toBe editor.getLineHeightInPixels()
 
+    it "updates selections when the font size changes", ->
+      editor.setSelectedBufferRange([[1, 6], [1, 10]])
+      component.setFontSize(10)
+      selectionNode = node.querySelector('.region')
+      expect(selectionNode.offsetTop).toBe editor.getLineHeightInPixels()
+      expect(selectionNode.offsetLeft).toBe 6 * editor.getDefaultCharWidth()
+
+    it "updates selections when the font family changes", ->
+      editor.setSelectedBufferRange([[1, 6], [1, 10]])
+      component.setFontFamily('sans-serif')
+      selectionNode = node.querySelector('.region')
+      expect(selectionNode.offsetTop).toBe editor.getLineHeightInPixels()
+      expect(selectionNode.offsetLeft).toBe editor.pixelPositionForScreenPosition([1, 6]).left
+
   describe "hidden input field", ->
     it "renders the hidden input field at the position of the last cursor if the cursor is on screen and the editor is focused", ->
       editor.setVerticalScrollMargin(0)

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -456,6 +456,12 @@ describe "EditorComponent", ->
 
       expect(node.querySelectorAll('.selection').length).toBe 1
 
+    it "updates selections when the line height changes", ->
+      editor.setSelectedBufferRange([[1, 6], [1, 10]])
+      component.setLineHeight(2)
+      selectionNode = node.querySelector('.region')
+      expect(selectionNode.offsetTop).toBe editor.getLineHeightInPixels()
+
   describe "hidden input field", ->
     it "renders the hidden input field at the position of the last cursor if the cursor is on screen and the editor is focused", ->
       editor.setVerticalScrollMargin(0)

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -389,6 +389,11 @@ describe "EditorComponent", ->
       component.setLineHeight(2)
       cursorNode = node.querySelector('.cursor')
       expect(cursorNode.style['-webkit-transform']).toBe "translate3d(#{10 * editor.getDefaultCharWidth()}px, #{editor.getLineHeightInPixels()}px, 0px)"
+
+    it "updates cursor positions when the font size changes", ->
+      editor.setCursorBufferPosition([1, 10])
+      component.setFontSize(10)
+      cursorNode = node.querySelector('.cursor')
       expect(cursorNode.style['-webkit-transform']).toBe "translate3d(#{10 * editor.getDefaultCharWidth()}px, #{editor.getLineHeightInPixels()}px, 0px)"
 
   describe "selection rendering", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -109,12 +109,12 @@ describe "EditorComponent", ->
     it "updates the top position of lines when the font family changes", ->
       # Can't find a font that changes the line height, but we think one might exist
       linesComponent = component.refs.lines
-      spyOn(linesComponent, 'measureLineHeightInPixelsAndCharWidth').andCallFake -> editor.setLineHeightInPixels(10)
+      spyOn(linesComponent, 'measureLineHeightAndDefaultCharWidth').andCallFake -> editor.setLineHeightInPixels(10)
 
       initialLineHeightInPixels = editor.getLineHeightInPixels()
       component.setFontFamily('sans-serif')
 
-      expect(linesComponent.measureLineHeightInPixelsAndCharWidth).toHaveBeenCalled()
+      expect(linesComponent.measureLineHeightAndDefaultCharWidth).toHaveBeenCalled()
       newLineHeightInPixels = editor.getLineHeightInPixels()
       expect(newLineHeightInPixels).not.toBe initialLineHeightInPixels
       expect(component.lineNodeForScreenRow(1).offsetTop).toBe 1 * newLineHeightInPixels
@@ -386,8 +386,9 @@ describe "EditorComponent", ->
 
     it "updates cursor positions when the line height changes", ->
       editor.setCursorBufferPosition([1, 10])
-      cursorNode = node.querySelector('.cursor')
       component.setLineHeight(2)
+      cursorNode = node.querySelector('.cursor')
+      expect(cursorNode.style['-webkit-transform']).toBe "translate3d(#{10 * editor.getDefaultCharWidth()}px, #{editor.getLineHeightInPixels()}px, 0px)"
       expect(cursorNode.style['-webkit-transform']).toBe "translate3d(#{10 * editor.getDefaultCharWidth()}px, #{editor.getLineHeightInPixels()}px, 0px)"
 
   describe "selection rendering", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -396,6 +396,14 @@ describe "EditorComponent", ->
       cursorNode = node.querySelector('.cursor')
       expect(cursorNode.style['-webkit-transform']).toBe "translate3d(#{10 * editor.getDefaultCharWidth()}px, #{editor.getLineHeightInPixels()}px, 0px)"
 
+    it "updates cursor positions when the font family changes", ->
+      editor.setCursorBufferPosition([1, 10])
+      component.setFontFamily('sans-serif')
+      cursorNode = node.querySelector('.cursor')
+
+      {left} = editor.pixelPositionForScreenPosition([1, 10])
+      expect(cursorNode.style['-webkit-transform']).toBe "translate3d(#{left}px, #{editor.getLineHeightInPixels()}px, 0px)"
+
   describe "selection rendering", ->
     [scrollViewNode, scrollViewClientLeft] = []
 

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -384,6 +384,12 @@ describe "EditorComponent", ->
       expect(cursorNodes.length).toBe 1
       expect(cursorNodes[0].style['-webkit-transform']).toBe "translate3d(#{8 * charWidth}px, #{6 * lineHeightInPixels}px, 0px)"
 
+    it "updates cursor positions when the line height changes", ->
+      editor.setCursorBufferPosition([1, 10])
+      cursorNode = node.querySelector('.cursor')
+      component.setLineHeight(2)
+      expect(cursorNode.style['-webkit-transform']).toBe "translate3d(#{10 * editor.getDefaultCharWidth()}px, #{editor.getLineHeightInPixels()}px, 0px)"
+
   describe "selection rendering", ->
     [scrollViewNode, scrollViewClientLeft] = []
 

--- a/src/cursor-component.coffee
+++ b/src/cursor-component.coffee
@@ -6,8 +6,8 @@ CursorComponent = React.createClass
   displayName: 'CursorComponent'
 
   render: ->
-    {cursor, scrollTop, scrollLeft} = @props
-    {top, left, height, width} = cursor.getPixelRect()
+    {editor, screenRange, scrollTop, scrollLeft} = @props
+    {top, left, height, width} = editor.pixelRectForScreenRange(screenRange)
     top -= scrollTop
     left -= scrollLeft
     WebkitTransform = "translate3d(#{left}px, #{top}px, 0px)"

--- a/src/cursors-component.coffee
+++ b/src/cursors-component.coffee
@@ -34,7 +34,7 @@ CursorsComponent = React.createClass
 
   shouldComponentUpdate: (newProps, newState) ->
     not newState.blinkOff is @state.blinkOff or
-      not isEqualForProperties(newProps, @props, 'cursorScreenRanges', 'scrollTop', 'scrollLeft', 'lineHeightInPixels')
+      not isEqualForProperties(newProps, @props, 'cursorScreenRanges', 'scrollTop', 'scrollLeft', 'lineHeightInPixels', 'defaultCharWidth')
 
   componentWillUpdate: (newProps) ->
     @pauseCursorBlinking() if @props.cursorScreenRanges and not isEqual(newProps.cursorScreenRanges, @props.cursorScreenRanges)

--- a/src/cursors-component.coffee
+++ b/src/cursors-component.coffee
@@ -33,8 +33,8 @@ CursorsComponent = React.createClass
     @stopBlinkingCursors()
 
   shouldComponentUpdate: (newProps, newState) ->
-    not isEqualForProperties(newProps, @props, 'cursorScreenRanges', 'scrollTop', 'scrollLeft') or
-      not newState.blinkOff is @state.blinkOff
+    not newState.blinkOff is @state.blinkOff or
+      not isEqualForProperties(newProps, @props, 'cursorScreenRanges', 'scrollTop', 'scrollLeft', 'lineHeightInPixels')
 
   componentWillUpdate: (newProps) ->
     @pauseCursorBlinking() if @props.cursorScreenRanges and not isEqual(newProps.cursorScreenRanges, @props.cursorScreenRanges)

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -85,7 +85,7 @@ EditorComponent = React.createClass
 
         CursorsComponent {
           editor, scrollTop, scrollLeft, cursorScreenRanges, cursorBlinkPeriod, cursorBlinkResumeDelay,
-          fontSize, fontFamily, lineHeightInPixels
+          lineHeightInPixels, defaultCharWidth
         }
         LinesComponent {
           ref: 'lines', editor, lineHeightInPixels, defaultCharWidth,

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -69,9 +69,8 @@ EditorComponent = React.createClass
 
     div className: className, style: {fontSize, lineHeight, fontFamily}, tabIndex: -1,
       GutterComponent {
-        ref: 'gutter', editor, renderedRowRange, maxLineNumberDigits,
-        scrollTop, scrollHeight, lineHeight, lineHeightInPixels, defaultCharWidth,
-        @pendingChanges, onWidthChanged: @onGutterWidthChanged, mouseWheelScreenRow
+        ref: 'gutter', editor, renderedRowRange, maxLineNumberDigits, scrollTop,
+        scrollHeight, lineHeightInPixels, @pendingChanges, mouseWheelScreenRow
       }
 
       div ref: 'scrollView', className: 'scroll-view', onMouseDown: @onMouseDown,
@@ -506,9 +505,6 @@ EditorComponent = React.createClass
   onCursorsMoved: ->
     @cursorsMoved = true
 
-  onGutterWidthChanged: (@gutterWidth) ->
-    @requestUpdate()
-
   selectToMousePositionUntilMouseUp: (event) ->
     {editor} = @props
     dragging = false
@@ -587,6 +583,7 @@ EditorComponent = React.createClass
 
         unless oldDefaultCharWidth is editor.getDefaultCharWidth()
           @remeasureCharacterWidths()
+          @measureGutter()
 
     else if @measureLineHeightAndDefaultCharWidthWhenShown and @state.visible and not prevState.visible
       @measureLineHeightAndDefaultCharWidth()
@@ -597,6 +594,11 @@ EditorComponent = React.createClass
 
   remeasureCharacterWidths: ->
     @refs.lines.remeasureCharacterWidths()
+
+  measureGutter: ->
+    oldGutterWidth = @gutterWidth
+    @gutterWidth = @refs.gutter.getDOMNode().offsetWidth
+    @requestUpdate() if @gutterWidth isnt oldGutterWidth
 
   measureScrollbars: ->
     @measuringScrollbars = false

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -575,15 +575,18 @@ EditorComponent = React.createClass
 
   measureLineHeightAndCharWidthsIfNeeded: (prevState) ->
     if not isEqualForProperties(prevState, @state, 'lineHeight', 'fontSize', 'fontFamily')
-      @props.editor.batchUpdates =>
+      {editor} = @props
+
+      editor.batchUpdates =>
+        oldDefaultCharWidth = editor.getDefaultCharWidth()
+
         if @state.visible
           @measureLineHeightAndDefaultCharWidth()
         else
           @measureLineHeightAndDefaultCharWidthWhenShown = true
 
-        unless isEqualForProperties(prevState, @state, 'fontSize', 'fontFamily')
-          @refs.lines.clearScopedCharWidths()
-          @refs.lines.measureCharactersInNewLines()
+        unless oldDefaultCharWidth is editor.getDefaultCharWidth()
+          @remeasureCharacterWidths()
 
     else if @measureLineHeightAndDefaultCharWidthWhenShown and @state.visible and not prevState.visible
       @measureLineHeightAndDefaultCharWidth()
@@ -591,6 +594,9 @@ EditorComponent = React.createClass
   measureLineHeightAndDefaultCharWidth: ->
     @measureLineHeightAndDefaultCharWidthWhenShown = false
     @refs.lines.measureLineHeightAndDefaultCharWidth()
+
+  remeasureCharacterWidths: ->
+    @refs.lines.remeasureCharacterWidths()
 
   measureScrollbars: ->
     @measuringScrollbars = false

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -70,7 +70,7 @@ EditorComponent = React.createClass
     div className: className, style: {fontSize, lineHeight, fontFamily}, tabIndex: -1,
       GutterComponent {
         ref: 'gutter', editor, renderedRowRange, maxLineNumberDigits,
-        scrollTop, scrollHeight, lineHeight, lineHeightInPixels, fontSize, fontFamily,
+        scrollTop, scrollHeight, lineHeight, lineHeightInPixels, defaultCharWidth,
         @pendingChanges, onWidthChanged: @onGutterWidthChanged, mouseWheelScreenRow
       }
 

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -148,10 +148,6 @@ EditorComponent = React.createClass
     @subscribe scrollbarStyle.changes, @refreshScrollbars
     @props.editor.setVisible(true)
 
-    scrollViewNode = @refs.scrollView.getDOMNode()
-    scrollViewNode.addEventListener 'overflowchanged', @onScrollViewOverflowChanged
-    scrollViewNode.addEventListener 'scroll', @onScrollViewScroll
-    window.addEventListener('resize', @onWindowResize)
     @measureScrollView()
 
     @requestUpdate()
@@ -244,6 +240,11 @@ EditorComponent = React.createClass
     node = @getDOMNode()
     node.addEventListener 'mousewheel', @onMouseWheel
     node.addEventListener 'focus', @onFocus # For some reason, React's built in focus events seem to bubble
+
+    scrollViewNode = @refs.scrollView.getDOMNode()
+    scrollViewNode.addEventListener 'overflowchanged', @onScrollViewOverflowChanged
+    scrollViewNode.addEventListener 'scroll', @onScrollViewScroll
+    window.addEventListener('resize', @onWindowResize)
 
   listenForCommands: ->
     {parentView, editor, mini} = @props

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -144,6 +144,7 @@ class Editor extends Model
   cursors: null
   selections: null
   suppressSelectionMerging: false
+  updateBatchDepth: 0
 
   @delegatesMethods 'suggestedIndentForBufferRow', 'autoIndentBufferRow', 'autoIndentBufferRows',
     'autoDecreaseIndentForBufferRow', 'toggleLineCommentForBufferRow', 'toggleLineCommentsForBufferRows',
@@ -1842,9 +1843,11 @@ class Editor extends Model
   abortTransaction: -> @buffer.abortTransaction()
 
   batchUpdates: (fn) ->
-    @emit 'batched-updates-started'
+    @emit 'batched-updates-started' if @updateBatchDepth is 0
+    @updateBatchDepth++
     result = fn()
-    @emit 'batched-updates-ended'
+    @updateBatchDepth--
+    @emit 'batched-updates-ended' if @updateBatchDepth is 0
     result
 
   inspect: ->

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -34,7 +34,7 @@ GutterComponent = React.createClass
   # visible row range.
   shouldComponentUpdate: (newProps) ->
     return true unless isEqualForProperties(newProps, @props,
-      'renderedRowRange', 'scrollTop', 'lineHeightInPixels', 'fontSize',
+      'renderedRowRange', 'scrollTop', 'lineHeightInPixels', 'defaultCharWidth',
       'mouseWheelScreenRow'
     )
 
@@ -49,7 +49,7 @@ GutterComponent = React.createClass
       @updateDummyLineNumber()
       @removeLineNumberNodes()
 
-    @measureWidth() unless @lastMeasuredWidth? and isEqualForProperties(oldProps, @props, 'maxLineNumberDigits', 'fontSize', 'fontFamily')
+    @measureWidth() unless @lastMeasuredWidth? and isEqualForProperties(oldProps, @props, 'maxLineNumberDigits', 'defaultCharWidth')
     @clearScreenRowCaches() unless oldProps.lineHeightInPixels is @props.lineHeightInPixels
     @updateLineNumbers()
 

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -162,7 +162,6 @@ GutterComponent = React.createClass
 
   measureWidth: ->
     lineNumberNode = @refs.lineNumbers.getDOMNode().firstChild
-    # return unless lineNumberNode?
 
     width = lineNumberNode.offsetWidth
     if width isnt @lastMeasuredWidth

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -10,7 +10,6 @@ GutterComponent = React.createClass
   displayName: 'GutterComponent'
   mixins: [SubscriberMixin]
 
-  lastMeasuredWidth: null
   dummyLineNumberNode: null
 
   render: ->
@@ -34,8 +33,7 @@ GutterComponent = React.createClass
   # visible row range.
   shouldComponentUpdate: (newProps) ->
     return true unless isEqualForProperties(newProps, @props,
-      'renderedRowRange', 'scrollTop', 'lineHeightInPixels', 'defaultCharWidth',
-      'mouseWheelScreenRow'
+      'renderedRowRange', 'scrollTop', 'lineHeightInPixels', 'mouseWheelScreenRow'
     )
 
     {renderedRowRange, pendingChanges} = newProps
@@ -49,7 +47,6 @@ GutterComponent = React.createClass
       @updateDummyLineNumber()
       @removeLineNumberNodes()
 
-    @measureWidth() unless @lastMeasuredWidth? and isEqualForProperties(oldProps, @props, 'maxLineNumberDigits', 'defaultCharWidth')
     @clearScreenRowCaches() unless oldProps.lineHeightInPixels is @props.lineHeightInPixels
     @updateLineNumbers()
 
@@ -159,10 +156,3 @@ GutterComponent = React.createClass
 
   lineNumberNodeForScreenRow: (screenRow) ->
     @lineNumberNodesById[@lineNumberIdsByScreenRow[screenRow]]
-
-  measureWidth: ->
-    lineNumberNode = @refs.lineNumbers.getDOMNode().firstChild
-
-    width = lineNumberNode.offsetWidth
-    if width isnt @lastMeasuredWidth
-      @props.onWidthChanged(@lastMeasuredWidth = width)

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -17,14 +17,14 @@ LinesComponent = React.createClass
 
   render: ->
     if @isMounted()
-      {editor, scrollTop, scrollLeft, scrollHeight, scrollWidth, lineHeightInPixels, scrollViewHeight} = @props
+      {editor, selectionScreenRanges, scrollTop, scrollLeft, scrollHeight, scrollWidth, lineHeightInPixels, scrollViewHeight} = @props
       style =
         height: Math.max(scrollHeight, scrollViewHeight)
         width: scrollWidth
         WebkitTransform: "translate3d(#{-scrollLeft}px, #{-scrollTop}px, 0px)"
 
     div {className: 'lines', style},
-      SelectionsComponent({editor, lineHeightInPixels}) if @isMounted()
+      SelectionsComponent({editor, selectionScreenRanges, lineHeightInPixels}) if @isMounted()
 
   componentWillMount: ->
     @measuredLines = new WeakSet
@@ -36,11 +36,10 @@ LinesComponent = React.createClass
     @measureLineHeightInPixelsAndCharWidth()
 
   shouldComponentUpdate: (newProps) ->
-    return true if newProps.selectionChanged
     return true unless isEqualForProperties(newProps, @props,
-      'renderedRowRange', 'fontSize', 'fontFamily', 'lineHeight', 'lineHeightInPixels',
-      'scrollTop', 'scrollLeft', 'showIndentGuide', 'scrollingVertically', 'invisibles',
-      'visible', 'scrollViewHeight', 'mouseWheelScreenRow'
+      'renderedRowRange', 'selectionScreenRanges', 'fontSize', 'fontFamily', 'lineHeight',
+      'lineHeightInPixels', 'scrollTop', 'scrollLeft', 'showIndentGuide', 'scrollingVertically',
+      'invisibles', 'visible', 'scrollViewHeight', 'mouseWheelScreenRow'
     )
 
     {renderedRowRange, pendingChanges} = newProps

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -15,14 +15,14 @@ LinesComponent = React.createClass
 
   render: ->
     if @isMounted()
-      {editor, selectionScreenRanges, scrollTop, scrollLeft, scrollHeight, scrollWidth, lineHeightInPixels, scrollViewHeight} = @props
+      {editor, selectionScreenRanges, scrollTop, scrollLeft, scrollHeight, scrollWidth, lineHeightInPixels, defaultCharWidth, scrollViewHeight} = @props
       style =
         height: Math.max(scrollHeight, scrollViewHeight)
         width: scrollWidth
         WebkitTransform: "translate3d(#{-scrollLeft}px, #{-scrollTop}px, 0px)"
 
     div {className: 'lines', style},
-      SelectionsComponent({editor, selectionScreenRanges, lineHeightInPixels}) if @isMounted()
+      SelectionsComponent({editor, selectionScreenRanges, lineHeightInPixels, defaultCharWidth}) if @isMounted()
 
   componentWillMount: ->
     @measuredLines = new WeakSet

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -13,8 +13,6 @@ module.exports =
 LinesComponent = React.createClass
   displayName: 'LinesComponent'
 
-  measureWhenShown: false
-
   render: ->
     if @isMounted()
       {editor, selectionScreenRanges, scrollTop, scrollLeft, scrollHeight, scrollWidth, lineHeightInPixels, scrollViewHeight} = @props
@@ -37,9 +35,9 @@ LinesComponent = React.createClass
 
   shouldComponentUpdate: (newProps) ->
     return true unless isEqualForProperties(newProps, @props,
-      'renderedRowRange', 'selectionScreenRanges', 'fontSize', 'fontFamily', 'lineHeight',
-      'lineHeightInPixels', 'scrollTop', 'scrollLeft', 'showIndentGuide', 'scrollingVertically',
-      'invisibles', 'visible', 'scrollViewHeight', 'mouseWheelScreenRow'
+      'renderedRowRange', 'selectionScreenRanges', 'lineHeightInPixels', 'defaultCharWidth',
+      'scrollTop', 'scrollLeft', 'showIndentGuide', 'scrollingVertically', 'invisibles', 'visible',
+      'scrollViewHeight', 'mouseWheelScreenRow'
     )
 
     {renderedRowRange, pendingChanges} = newProps
@@ -52,11 +50,9 @@ LinesComponent = React.createClass
   componentDidUpdate: (prevProps) ->
     {visible, scrollingVertically} = @props
 
-    @measureLineHeightInPixelsAndCharWidthIfNeeded(prevProps)
     @clearScreenRowCaches() unless prevProps.lineHeightInPixels is @props.lineHeightInPixels
     @removeLineNodes() unless isEqualForProperties(prevProps, @props, 'showIndentGuide', 'invisibles')
     @updateLines()
-    @clearScopedCharWidths() unless isEqualForProperties(prevProps, @props, 'fontSize', 'fontFamily')
     @measureCharactersInNewLines() if visible and not scrollingVertically
 
   clearScreenRowCaches: ->
@@ -203,16 +199,6 @@ LinesComponent = React.createClass
 
   lineNodeForScreenRow: (screenRow) ->
     @lineNodesByLineId[@lineIdsByScreenRow[screenRow]]
-
-  measureLineHeightInPixelsAndCharWidthIfNeeded: (prevProps) ->
-    {visible} = @props
-
-    unless isEqualForProperties(prevProps, @props, 'fontSize', 'fontFamily', 'lineHeight')
-      if visible
-        @measureLineHeightInPixelsAndCharWidth()
-      else
-        @measureWhenShown = true
-    @measureLineHeightInPixelsAndCharWidth() if visible and not prevProps.visible and @measureWhenShown
 
   measureLineHeightInPixelsAndCharWidth: ->
     @measureWhenShown = false

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -209,6 +209,10 @@ LinesComponent = React.createClass
       editor.setLineHeightInPixels(lineHeightInPixels)
       editor.setDefaultCharWidth(charWidth)
 
+  remeasureCharacterWidths: ->
+    @clearScopedCharWidths()
+    @measureCharactersInNewLines()
+
   measureCharactersInNewLines: ->
     [visibleStartRow, visibleEndRow] = @props.renderedRowRange
     node = @getDOMNode()

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -30,9 +30,6 @@ LinesComponent = React.createClass
     @screenRowsByLineId = {}
     @lineIdsByScreenRow = {}
 
-  componentDidMount: ->
-    @measureLineHeightInPixelsAndCharWidth()
-
   shouldComponentUpdate: (newProps) ->
     return true unless isEqualForProperties(newProps, @props,
       'renderedRowRange', 'selectionScreenRanges', 'lineHeightInPixels', 'defaultCharWidth',
@@ -200,8 +197,7 @@ LinesComponent = React.createClass
   lineNodeForScreenRow: (screenRow) ->
     @lineNodesByLineId[@lineIdsByScreenRow[screenRow]]
 
-  measureLineHeightInPixelsAndCharWidth: ->
-    @measureWhenShown = false
+  measureLineHeightAndDefaultCharWidth: ->
     node = @getDOMNode()
     node.appendChild(DummyLineNode)
     lineHeightInPixels = DummyLineNode.getBoundingClientRect().height
@@ -209,8 +205,9 @@ LinesComponent = React.createClass
     node.removeChild(DummyLineNode)
 
     {editor} = @props
-    editor.setLineHeightInPixels(lineHeightInPixels)
-    editor.setDefaultCharWidth(charWidth)
+    editor.batchUpdates ->
+      editor.setLineHeightInPixels(lineHeightInPixels)
+      editor.setDefaultCharWidth(charWidth)
 
   measureCharactersInNewLines: ->
     [visibleStartRow, visibleEndRow] = @props.renderedRowRange

--- a/src/selections-component.coffee
+++ b/src/selections-component.coffee
@@ -1,5 +1,6 @@
 React = require 'react-atom-fork'
 {div} = require 'reactionary-atom-fork'
+{isEqual} = require 'underscore-plus'
 SelectionComponent = require './selection-component'
 
 module.exports =
@@ -10,34 +11,15 @@ SelectionsComponent = React.createClass
     div className: 'selections', @renderSelections()
 
   renderSelections: ->
-    {editor, lineHeightInPixels} = @props
+    {editor, selectionScreenRanges, lineHeightInPixels} = @props
 
     selectionComponents = []
-    for selectionId, screenRange of @selectionRanges
+    for selectionId, screenRange of selectionScreenRanges
       selectionComponents.push(SelectionComponent({key: selectionId, screenRange, editor, lineHeightInPixels}))
     selectionComponents
 
   componentWillMount: ->
     @selectionRanges = {}
 
-  shouldComponentUpdate: ->
-    {editor} = @props
-    oldSelectionRanges = @selectionRanges
-    newSelectionRanges = {}
-    @selectionRanges = newSelectionRanges
-
-    for selection, index in editor.getSelections()
-      # Rendering artifacts occur on the lines GPU layer if we remove the last selection
-      if index is 0 or (not selection.isEmpty() and editor.selectionIntersectsVisibleRowRange(selection))
-        newSelectionRanges[selection.id] = selection.getScreenRange()
-
-    for id, range of newSelectionRanges
-      if oldSelectionRanges.hasOwnProperty(id)
-        return true unless range.isEqual(oldSelectionRanges[id])
-      else
-        return true
-
-    for id of oldSelectionRanges
-      return true unless newSelectionRanges.hasOwnProperty(id)
-
-    false
+  shouldComponentUpdate: (newProps) ->
+    not isEqual(newProps.selectionScreenRanges, @props.selectionScreenRanges)

--- a/src/selections-component.coffee
+++ b/src/selections-component.coffee
@@ -22,4 +22,4 @@ SelectionsComponent = React.createClass
     @selectionRanges = {}
 
   shouldComponentUpdate: (newProps) ->
-    not isEqualForProperties(newProps, @props, 'selectionScreenRanges', 'lineHeightInPixels')
+    not isEqualForProperties(newProps, @props, 'selectionScreenRanges', 'lineHeightInPixels', 'defaultCharWidth')

--- a/src/selections-component.coffee
+++ b/src/selections-component.coffee
@@ -1,6 +1,6 @@
 React = require 'react-atom-fork'
 {div} = require 'reactionary-atom-fork'
-{isEqual} = require 'underscore-plus'
+{isEqualForProperties} = require 'underscore-plus'
 SelectionComponent = require './selection-component'
 
 module.exports =
@@ -22,4 +22,4 @@ SelectionsComponent = React.createClass
     @selectionRanges = {}
 
   shouldComponentUpdate: (newProps) ->
-    not isEqual(newProps.selectionScreenRanges, @props.selectionScreenRanges)
+    not isEqualForProperties(newProps, @props, 'selectionScreenRanges', 'lineHeightInPixels')


### PR DESCRIPTION
In addition to fixing selection/cursor updates, this PR aims to clean up measurement and perform the minimal number of updates in response to changes that affect the line height and character width.

My goal is to centralize all decisions about measurement in the `EditorComponent` rather than scattering them through `componentDidUpdate` callbacks like they are currently. This will allow us to perform measurements when the line height, font size, and font family change without updating any components except the root component. Previously we were updating the lines component just to perform measurement, which resulting in multiple wasted update passes per change. This PR also batches the updates resulting from measurement together.
