### PR TITLE
:penguin: Make "Developer Tools" key binding match Chrome

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -8,7 +8,7 @@
   'left': 'core:move-left'
   'right': 'core:move-right'
   'ctrl-alt-r': 'window:reload'
-  'ctrl-alt-i': 'window:toggle-dev-tools'
+  'ctrl-shift-i': 'window:toggle-dev-tools'
   'ctrl-alt-p': 'window:run-package-specs'
   'ctrl-alt-s': 'application:run-all-specs'
   'ctrl-shift-o': 'application:open-dev'


### PR DESCRIPTION
In Chrome on Linux, the Developer Tools open with <kbd>Ctrl+Shift+I</kbd>. Since many Linux devs have that shortcut hardwired into their brain, it makes a lot of sense for Atom to use it too.
