### PR TITLE
Add links to build error reports in build docs

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -47,3 +47,6 @@ and restart Atom.  If Atom now works fine, you can make this setting permanent:
   ```
 
 See also https://github.com/atom/atom/issues/2082.
+
+### Linux build error reports in atom/atom
+* Use [this search](https://github.com/atom/atom/search?q=label%3Abuild-error+label%3Alinux&type=Issues) to get a list of reports about build errors on Linux.

--- a/docs/build-instructions/os-x.md
+++ b/docs/build-instructions/os-x.md
@@ -15,3 +15,6 @@
   ```
 
 ## Troubleshooting
+
+### OSX build error reports in atom/atom
+* Use [this search](https://github.com/atom/atom/search?q=label%3Abuild-error+label%3Aos-x&type=Issues) to get a list of reports about build errors on OSX.

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -44,3 +44,6 @@ fix this, you probably need to fiddle with your system PATH.
 
   * If you just installed node you need to restart your computer before node is
   available on your Path.
+
+### Windows build error reports in atom/atom
+* Use [this search](https://github.com/atom/atom/search?q=label%3Abuild-error+label%3Awindows&type=Issues) to get a list of reports about build errors on Windows.


### PR DESCRIPTION
Adds search links to build docs for Linux/Windows/OSX so that it's easier to find other build error reports.
