### PR TITLE
Add an API for decorations; render stuff in the gutter again

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -319,8 +319,12 @@ describe "EditorComponent", ->
         expect(component.lineNumberNodeForScreenRow(9).classList.contains('nope-class')).toBeFalsy()
 
       it "handles updates to gutter-class decorations", ->
+        gutter = component.refs.gutter
+
         editor.addDecorationForBufferRow(2, {type: 'gutter-class', class: 'fancy-class'})
         editor.addDecorationForBufferRow(2, {type: 'someother-type', class: 'nope-class'})
+
+        advanceClock(gutter.decorationRenderDelay)
 
         expect(component.lineNumberNodeForScreenRow(2).classList.contains('fancy-class')).toBeTruthy()
         expect(component.lineNumberNodeForScreenRow(2).classList.contains('nope-class')).toBeFalsy()
@@ -328,10 +332,13 @@ describe "EditorComponent", ->
         editor.removeDecorationForBufferRow(2, {type: 'gutter-class', class: 'fancy-class'})
         editor.removeDecorationForBufferRow(2, {type: 'someother-type', class: 'nope-class'})
 
+        advanceClock(gutter.decorationRenderDelay)
+
         expect(component.lineNumberNodeForScreenRow(2).classList.contains('fancy-class')).toBeFalsy()
         expect(component.lineNumberNodeForScreenRow(2).classList.contains('nope-class')).toBeFalsy()
 
       it "handles softWrap decorations", ->
+        gutter = component.refs.gutter
         editor.addDecorationForBufferRow(1, {type: 'gutter-class', class: 'no-wrap'})
         editor.addDecorationForBufferRow(1, {type: 'gutter-class', class: 'wrap-me', softWrap: true})
 
@@ -348,6 +355,7 @@ describe "EditorComponent", ->
         # should remove the wrapped decorations
         editor.removeDecorationForBufferRow(1, {type: 'gutter-class', class: 'no-wrap'})
         editor.removeDecorationForBufferRow(1, {type: 'gutter-class', class: 'wrap-me'})
+        advanceClock(gutter.decorationRenderDelay)
 
         expect(component.lineNumberNodeForScreenRow(2).classList.contains 'no-wrap').toBeFalsy()
         expect(component.lineNumberNodeForScreenRow(2).classList.contains 'wrap-me').toBeFalsy()
@@ -357,6 +365,7 @@ describe "EditorComponent", ->
         # should add them back when the nodes are not recreated
         editor.addDecorationForBufferRow(1, {type: 'gutter-class', class: 'no-wrap'})
         editor.addDecorationForBufferRow(1, {type: 'gutter-class', class: 'wrap-me', softWrap: true})
+        advanceClock(gutter.decorationRenderDelay)
 
         expect(component.lineNumberNodeForScreenRow(2).classList.contains 'no-wrap').toBeTruthy()
         expect(component.lineNumberNodeForScreenRow(2).classList.contains 'wrap-me').toBeTruthy()

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -303,79 +303,80 @@ describe "EditorComponent", ->
       expect(gutterNode.offsetWidth).toBe initialGutterWidth
 
     describe "when decorations are used", ->
-      {lineHasClass, gutter} = {}
+      {lineNumberHasClass, gutter} = {}
       beforeEach ->
-        gutter = component.refs.gutter
-        lineHasClass = (screenRow, klass) ->
+        {gutter} = component.refs
+        lineNumberHasClass = (screenRow, klass) ->
           component.lineNumberNodeForScreenRow(screenRow).classList.contains(klass)
 
-      it "renders the gutter decorations", ->
-        node.style.height = 4.5 * lineHeightInPixels + 'px'
-        component.measureScrollView()
+      describe "when decorations are applied to buffer rows", ->
+        it "renders line number classes based on the decorations on their buffer row", ->
+          node.style.height = 4.5 * lineHeightInPixels + 'px'
+          component.measureScrollView()
 
-        expect(component.lineNumberNodeForScreenRow(9)).toBeFalsy()
+          expect(component.lineNumberNodeForScreenRow(9)).not.toBeDefined()
 
-        editor.addDecorationToBufferRow(9, {type: 'gutter', class: 'fancy-class'})
-        editor.addDecorationToBufferRow(9, {type: 'someother-type', class: 'nope-class'})
+          editor.addDecorationToBufferRow(9, type: 'gutter', class: 'fancy-class')
+          editor.addDecorationToBufferRow(9, type: 'someother-type', class: 'nope-class')
 
-        verticalScrollbarNode.scrollTop = 2.5 * lineHeightInPixels
-        verticalScrollbarNode.dispatchEvent(new UIEvent('scroll'))
+          verticalScrollbarNode.scrollTop = 2.5 * lineHeightInPixels
+          verticalScrollbarNode.dispatchEvent(new UIEvent('scroll'))
 
-        expect(lineHasClass(9, 'fancy-class')).toBeTruthy()
-        expect(lineHasClass(9, 'nope-class')).toBeFalsy()
+          expect(lineNumberHasClass(9, 'fancy-class')).toBe true
+          expect(lineNumberHasClass(9, 'nope-class')).toBe false
 
-      it "handles updates to gutter decorations", ->
-        editor.addDecorationToBufferRow(2, {type: 'gutter', class: 'fancy-class'})
-        editor.addDecorationToBufferRow(2, {type: 'someother-type', class: 'nope-class'})
+        it "handles updates to gutter decorations", ->
+          editor.addDecorationToBufferRow(2, type: 'gutter', class: 'fancy-class')
+          editor.addDecorationToBufferRow(2, type: 'someother-type', class: 'nope-class')
 
-        advanceClock(gutter.decorationRenderDelay)
+          advanceClock(gutter.decorationRenderDelay)
 
-        expect(lineHasClass(2, 'fancy-class')).toBeTruthy()
-        expect(lineHasClass(2, 'nope-class')).toBeFalsy()
+          expect(lineNumberHasClass(2, 'fancy-class')).toBe true
+          expect(lineNumberHasClass(2, 'nope-class')).toBe false
 
-        editor.removeDecorationFromBufferRow(2, {type: 'gutter', class: 'fancy-class'})
-        editor.removeDecorationFromBufferRow(2, {type: 'someother-type', class: 'nope-class'})
+          editor.removeDecorationFromBufferRow(2, type: 'gutter', class: 'fancy-class')
+          editor.removeDecorationFromBufferRow(2, type: 'someother-type', class: 'nope-class')
 
-        advanceClock(gutter.decorationRenderDelay)
+          advanceClock(gutter.decorationRenderDelay)
 
-        expect(lineHasClass(2, 'fancy-class')).toBeFalsy()
-        expect(lineHasClass(2, 'nope-class')).toBeFalsy()
+          expect(lineNumberHasClass(2, 'fancy-class')).toBe false
+          expect(lineNumberHasClass(2, 'nope-class')).toBe false
 
-      it "handles softWrap decorations", ->
-        editor.addDecorationToBufferRow(1, {type: 'gutter', class: 'no-wrap'})
-        editor.addDecorationToBufferRow(1, {type: 'gutter', class: 'wrap-me', softWrap: true})
+        it "renders decorations on soft-wrapped line numbers when softWrap is true", ->
+          editor.addDecorationToBufferRow(1, type: 'gutter', class: 'no-wrap')
+          editor.addDecorationToBufferRow(1, type: 'gutter', class: 'wrap-me', softWrap: true)
 
-        editor.setSoftWrap(true)
-        node.style.height = 4.5 * lineHeightInPixels + 'px'
-        node.style.width = 30 * charWidth + 'px'
-        component.measureScrollView()
+          editor.setSoftWrap(true)
+          node.style.height = 4.5 * lineHeightInPixels + 'px'
+          node.style.width = 30 * charWidth + 'px'
+          component.measureScrollView()
 
-        expect(lineHasClass(2, 'no-wrap')).toBeTruthy()
-        expect(lineHasClass(2, 'wrap-me')).toBeTruthy()
-        expect(lineHasClass(3, 'no-wrap')).toBeFalsy()
-        expect(lineHasClass(3, 'wrap-me')).toBeTruthy()
+          expect(lineNumberHasClass(2, 'no-wrap')).toBe true
+          expect(lineNumberHasClass(2, 'wrap-me')).toBe true
+          expect(lineNumberHasClass(3, 'no-wrap')).toBe false
+          expect(lineNumberHasClass(3, 'wrap-me')).toBe true
 
-        # should remove the wrapped decorations
-        editor.removeDecorationFromBufferRow(1, {type: 'gutter', class: 'no-wrap'})
-        editor.removeDecorationFromBufferRow(1, {type: 'gutter', class: 'wrap-me'})
-        advanceClock(gutter.decorationRenderDelay)
+          # should remove the wrapped decorations
+          editor.removeDecorationFromBufferRow(1, type: 'gutter', class: 'no-wrap')
+          editor.removeDecorationFromBufferRow(1, type: 'gutter', class: 'wrap-me')
+          advanceClock(gutter.decorationRenderDelay)
 
-        expect(lineHasClass(2, 'no-wrap')).toBeFalsy()
-        expect(lineHasClass(2, 'wrap-me')).toBeFalsy()
-        expect(lineHasClass(3, 'no-wrap')).toBeFalsy()
-        expect(lineHasClass(3, 'wrap-me')).toBeFalsy()
+          expect(lineNumberHasClass(2, 'no-wrap')).toBe false
+          expect(lineNumberHasClass(2, 'wrap-me')).toBe false
+          expect(lineNumberHasClass(3, 'no-wrap')).toBe false
+          expect(lineNumberHasClass(3, 'wrap-me')).toBe false
 
-        # should add them back when the nodes are not recreated
-        editor.addDecorationToBufferRow(1, {type: 'gutter', class: 'no-wrap'})
-        editor.addDecorationToBufferRow(1, {type: 'gutter', class: 'wrap-me', softWrap: true})
-        advanceClock(gutter.decorationRenderDelay)
+          # should add them back when the nodes are not recreated
+          editor.addDecorationToBufferRow(1, type: 'gutter', class: 'no-wrap')
+          editor.addDecorationToBufferRow(1, type: 'gutter', class: 'wrap-me', softWrap: true)
+          advanceClock(gutter.decorationRenderDelay)
 
-        expect(lineHasClass(2, 'no-wrap')).toBeTruthy()
-        expect(lineHasClass(2, 'wrap-me')).toBeTruthy()
-        expect(lineHasClass(3, 'no-wrap')).toBeFalsy()
-        expect(lineHasClass(3, 'wrap-me')).toBeTruthy()
+          expect(lineNumberHasClass(2, 'no-wrap')).toBe true
+          expect(lineNumberHasClass(2, 'wrap-me')).toBe true
+          expect(lineNumberHasClass(3, 'no-wrap')).toBe false
+          expect(lineNumberHasClass(3, 'wrap-me')).toBe true
 
-      describe "when markers are used", ->
+      describe "when decorations are applied to markers", ->
         {marker, decoration} = {}
         beforeEach ->
           marker = editor.displayBuffer.markBufferRange([[2, 13], [3, 15]], class: 'my-marker', invalidate: 'inside')
@@ -383,72 +384,69 @@ describe "EditorComponent", ->
           editor.addDecorationForMarker(marker, decoration)
           advanceClock(gutter.decorationRenderDelay)
 
-        it "tracks the marker's movements", ->
-          expect(lineHasClass(1, 'someclass')).toBeFalsy()
-          expect(lineHasClass(2, 'someclass')).toBeTruthy()
-          expect(lineHasClass(3, 'someclass')).toBeTruthy()
-          expect(lineHasClass(4, 'someclass')).toBeFalsy()
+        it "updates line number classes when the marker moves", ->
+          expect(lineNumberHasClass(1, 'someclass')).toBe false
+          expect(lineNumberHasClass(2, 'someclass')).toBe true
+          expect(lineNumberHasClass(3, 'someclass')).toBe true
+          expect(lineNumberHasClass(4, 'someclass')).toBe false
 
           editor.getBuffer().insert([0, 0], '\n')
           advanceClock(gutter.decorationRenderDelay)
 
-          expect(lineHasClass(2, 'someclass')).toBeFalsy()
-          expect(lineHasClass(3, 'someclass')).toBeTruthy()
-          expect(lineHasClass(4, 'someclass')).toBeTruthy()
-          expect(lineHasClass(5, 'someclass')).toBeFalsy()
+          expect(lineNumberHasClass(2, 'someclass')).toBe false
+          expect(lineNumberHasClass(3, 'someclass')).toBe true
+          expect(lineNumberHasClass(4, 'someclass')).toBe true
+          expect(lineNumberHasClass(5, 'someclass')).toBe false
 
           editor.getBuffer().deleteRows(0, 1)
           advanceClock(gutter.decorationRenderDelay)
 
-          expect(lineHasClass(0, 'someclass')).toBeFalsy()
-          expect(lineHasClass(1, 'someclass')).toBeTruthy()
-          expect(lineHasClass(2, 'someclass')).toBeTruthy()
-          expect(lineHasClass(3, 'someclass')).toBeFalsy()
+          expect(lineNumberHasClass(0, 'someclass')).toBe false
+          expect(lineNumberHasClass(1, 'someclass')).toBe true
+          expect(lineNumberHasClass(2, 'someclass')).toBe true
+          expect(lineNumberHasClass(3, 'someclass')).toBe false
 
-        it "removes the classes when marker is invalidated", ->
-          t = editor.getBuffer().getText()
-          # invalidate this thing
+        it "removes line number classes when a decoration's marker is invalidated", ->
           editor.getBuffer().insert([3, 2], 'n')
           advanceClock(gutter.decorationRenderDelay)
 
-          expect(marker.isValid()).toBeFalsy()
-          expect(lineHasClass(1, 'someclass')).toBeFalsy()
-          expect(lineHasClass(2, 'someclass')).toBeFalsy()
-          expect(lineHasClass(3, 'someclass')).toBeFalsy()
-          expect(lineHasClass(4, 'someclass')).toBeFalsy()
+          expect(marker.isValid()).toBe false
+          expect(lineNumberHasClass(1, 'someclass')).toBe false
+          expect(lineNumberHasClass(2, 'someclass')).toBe false
+          expect(lineNumberHasClass(3, 'someclass')).toBe false
+          expect(lineNumberHasClass(4, 'someclass')).toBe false
 
-          # Back to valid
           editor.getBuffer().undo()
           advanceClock(gutter.decorationRenderDelay)
 
-          expect(marker.isValid()).toBeTruthy()
-          expect(lineHasClass(1, 'someclass')).toBeFalsy()
-          expect(lineHasClass(2, 'someclass')).toBeTruthy()
-          expect(lineHasClass(3, 'someclass')).toBeTruthy()
-          expect(lineHasClass(4, 'someclass')).toBeFalsy()
+          expect(marker.isValid()).toBe true
+          expect(lineNumberHasClass(1, 'someclass')).toBe false
+          expect(lineNumberHasClass(2, 'someclass')).toBe true
+          expect(lineNumberHasClass(3, 'someclass')).toBe true
+          expect(lineNumberHasClass(4, 'someclass')).toBe false
 
         it "removes the classes and unsubscribes from the marker when decoration is removed", ->
           editor.removeDecorationForMarker(marker, decoration)
           advanceClock(gutter.decorationRenderDelay)
 
-          expect(lineHasClass(1, 'someclass')).toBeFalsy()
-          expect(lineHasClass(2, 'someclass')).toBeFalsy()
-          expect(lineHasClass(3, 'someclass')).toBeFalsy()
-          expect(lineHasClass(4, 'someclass')).toBeFalsy()
+          expect(lineNumberHasClass(1, 'someclass')).toBe false
+          expect(lineNumberHasClass(2, 'someclass')).toBe false
+          expect(lineNumberHasClass(3, 'someclass')).toBe false
+          expect(lineNumberHasClass(4, 'someclass')).toBe false
 
           editor.getBuffer().insert([0, 0], '\n')
           advanceClock(gutter.decorationRenderDelay)
-          expect(lineHasClass(2, 'someclass')).toBeFalsy()
-          expect(lineHasClass(3, 'someclass')).toBeFalsy()
+          expect(lineNumberHasClass(2, 'someclass')).toBe false
+          expect(lineNumberHasClass(3, 'someclass')).toBe false
 
-        it "removes the decoration when the marker is destroyed", ->
+        it "removes the line number classes when the decoration's marker is destroyed", ->
           marker.destroy()
           advanceClock(gutter.decorationRenderDelay)
 
-          expect(lineHasClass(1, 'someclass')).toBeFalsy()
-          expect(lineHasClass(2, 'someclass')).toBeFalsy()
-          expect(lineHasClass(3, 'someclass')).toBeFalsy()
-          expect(lineHasClass(4, 'someclass')).toBeFalsy()
+          expect(lineNumberHasClass(1, 'someclass')).toBe false
+          expect(lineNumberHasClass(2, 'someclass')).toBe false
+          expect(lineNumberHasClass(3, 'someclass')).toBe false
+          expect(lineNumberHasClass(4, 'someclass')).toBe false
 
   describe "cursor rendering", ->
     it "renders the currently visible cursors, translated relative to the scroll position", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -302,7 +302,7 @@ describe "EditorComponent", ->
       expect(component.lineNumberNodeForScreenRow(9).textContent).toBe "10"
       expect(gutterNode.offsetWidth).toBe initialGutterWidth
 
-    fdescribe "when decorations are used", ->
+    describe "when decorations are used", ->
       {lineHasClass, gutter} = {}
       beforeEach ->
         gutter = component.refs.gutter

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -329,18 +329,18 @@ describe "EditorComponent", ->
           editor.addDecorationToBufferRow(2, type: 'gutter', class: 'fancy-class')
           editor.addDecorationToBufferRow(2, type: 'someother-type', class: 'nope-class')
 
-          advanceClock(gutter.decorationRenderDelay)
+          waitsFor -> not gutter.decorationRenderImmediate?
+          runs ->
+            expect(lineNumberHasClass(2, 'fancy-class')).toBe true
+            expect(lineNumberHasClass(2, 'nope-class')).toBe false
 
-          expect(lineNumberHasClass(2, 'fancy-class')).toBe true
-          expect(lineNumberHasClass(2, 'nope-class')).toBe false
+            editor.removeDecorationFromBufferRow(2, type: 'gutter', class: 'fancy-class')
+            editor.removeDecorationFromBufferRow(2, type: 'someother-type', class: 'nope-class')
 
-          editor.removeDecorationFromBufferRow(2, type: 'gutter', class: 'fancy-class')
-          editor.removeDecorationFromBufferRow(2, type: 'someother-type', class: 'nope-class')
-
-          advanceClock(gutter.decorationRenderDelay)
-
-          expect(lineNumberHasClass(2, 'fancy-class')).toBe false
-          expect(lineNumberHasClass(2, 'nope-class')).toBe false
+          waitsFor -> not gutter.decorationRenderImmediate?
+          runs ->
+            expect(lineNumberHasClass(2, 'fancy-class')).toBe false
+            expect(lineNumberHasClass(2, 'nope-class')).toBe false
 
         it "renders decorations on soft-wrapped line numbers when softWrap is true", ->
           editor.addDecorationToBufferRow(1, type: 'gutter', class: 'no-wrap')
@@ -359,22 +359,24 @@ describe "EditorComponent", ->
           # should remove the wrapped decorations
           editor.removeDecorationFromBufferRow(1, type: 'gutter', class: 'no-wrap')
           editor.removeDecorationFromBufferRow(1, type: 'gutter', class: 'wrap-me')
-          advanceClock(gutter.decorationRenderDelay)
 
-          expect(lineNumberHasClass(2, 'no-wrap')).toBe false
-          expect(lineNumberHasClass(2, 'wrap-me')).toBe false
-          expect(lineNumberHasClass(3, 'no-wrap')).toBe false
-          expect(lineNumberHasClass(3, 'wrap-me')).toBe false
+          waitsFor -> not gutter.decorationRenderImmediate?
+          runs ->
+            expect(lineNumberHasClass(2, 'no-wrap')).toBe false
+            expect(lineNumberHasClass(2, 'wrap-me')).toBe false
+            expect(lineNumberHasClass(3, 'no-wrap')).toBe false
+            expect(lineNumberHasClass(3, 'wrap-me')).toBe false
 
-          # should add them back when the nodes are not recreated
-          editor.addDecorationToBufferRow(1, type: 'gutter', class: 'no-wrap')
-          editor.addDecorationToBufferRow(1, type: 'gutter', class: 'wrap-me', softWrap: true)
-          advanceClock(gutter.decorationRenderDelay)
+            # should add them back when the nodes are not recreated
+            editor.addDecorationToBufferRow(1, type: 'gutter', class: 'no-wrap')
+            editor.addDecorationToBufferRow(1, type: 'gutter', class: 'wrap-me', softWrap: true)
 
-          expect(lineNumberHasClass(2, 'no-wrap')).toBe true
-          expect(lineNumberHasClass(2, 'wrap-me')).toBe true
-          expect(lineNumberHasClass(3, 'no-wrap')).toBe false
-          expect(lineNumberHasClass(3, 'wrap-me')).toBe true
+          waitsFor -> not gutter.decorationRenderImmediate?
+          runs ->
+            expect(lineNumberHasClass(2, 'no-wrap')).toBe true
+            expect(lineNumberHasClass(2, 'wrap-me')).toBe true
+            expect(lineNumberHasClass(3, 'no-wrap')).toBe false
+            expect(lineNumberHasClass(3, 'wrap-me')).toBe true
 
       describe "when decorations are applied to markers", ->
         {marker, decoration} = {}
@@ -382,7 +384,7 @@ describe "EditorComponent", ->
           marker = editor.displayBuffer.markBufferRange([[2, 13], [3, 15]], class: 'my-marker', invalidate: 'inside')
           decoration = {type: 'gutter', class: 'someclass'}
           editor.addDecorationForMarker(marker, decoration)
-          advanceClock(gutter.decorationRenderDelay)
+          waitsFor -> not gutter.decorationRenderImmediate?
 
         it "updates line number classes when the marker moves", ->
           expect(lineNumberHasClass(1, 'someclass')).toBe false
@@ -391,62 +393,71 @@ describe "EditorComponent", ->
           expect(lineNumberHasClass(4, 'someclass')).toBe false
 
           editor.getBuffer().insert([0, 0], '\n')
-          advanceClock(gutter.decorationRenderDelay)
 
-          expect(lineNumberHasClass(2, 'someclass')).toBe false
-          expect(lineNumberHasClass(3, 'someclass')).toBe true
-          expect(lineNumberHasClass(4, 'someclass')).toBe true
-          expect(lineNumberHasClass(5, 'someclass')).toBe false
+          waitsFor -> not gutter.decorationRenderImmediate?
+          runs ->
+            expect(lineNumberHasClass(2, 'someclass')).toBe false
+            expect(lineNumberHasClass(3, 'someclass')).toBe true
+            expect(lineNumberHasClass(4, 'someclass')).toBe true
+            expect(lineNumberHasClass(5, 'someclass')).toBe false
 
-          editor.getBuffer().deleteRows(0, 1)
-          advanceClock(gutter.decorationRenderDelay)
+            editor.getBuffer().deleteRows(0, 1)
 
-          expect(lineNumberHasClass(0, 'someclass')).toBe false
-          expect(lineNumberHasClass(1, 'someclass')).toBe true
-          expect(lineNumberHasClass(2, 'someclass')).toBe true
-          expect(lineNumberHasClass(3, 'someclass')).toBe false
+          waitsFor -> not gutter.decorationRenderImmediate?
+          runs ->
+            expect(lineNumberHasClass(0, 'someclass')).toBe false
+            expect(lineNumberHasClass(1, 'someclass')).toBe true
+            expect(lineNumberHasClass(2, 'someclass')).toBe true
+            expect(lineNumberHasClass(3, 'someclass')).toBe false
 
         it "removes line number classes when a decoration's marker is invalidated", ->
           editor.getBuffer().insert([3, 2], 'n')
-          advanceClock(gutter.decorationRenderDelay)
 
-          expect(marker.isValid()).toBe false
-          expect(lineNumberHasClass(1, 'someclass')).toBe false
-          expect(lineNumberHasClass(2, 'someclass')).toBe false
-          expect(lineNumberHasClass(3, 'someclass')).toBe false
-          expect(lineNumberHasClass(4, 'someclass')).toBe false
+          waitsFor -> not gutter.decorationRenderImmediate?
+          runs ->
 
-          editor.getBuffer().undo()
-          advanceClock(gutter.decorationRenderDelay)
+            expect(marker.isValid()).toBe false
+            expect(lineNumberHasClass(1, 'someclass')).toBe false
+            expect(lineNumberHasClass(2, 'someclass')).toBe false
+            expect(lineNumberHasClass(3, 'someclass')).toBe false
+            expect(lineNumberHasClass(4, 'someclass')).toBe false
 
-          expect(marker.isValid()).toBe true
-          expect(lineNumberHasClass(1, 'someclass')).toBe false
-          expect(lineNumberHasClass(2, 'someclass')).toBe true
-          expect(lineNumberHasClass(3, 'someclass')).toBe true
-          expect(lineNumberHasClass(4, 'someclass')).toBe false
+            editor.getBuffer().undo()
+
+          waitsFor -> not gutter.decorationRenderImmediate?
+          runs ->
+            expect(marker.isValid()).toBe true
+            expect(lineNumberHasClass(1, 'someclass')).toBe false
+            expect(lineNumberHasClass(2, 'someclass')).toBe true
+            expect(lineNumberHasClass(3, 'someclass')).toBe true
+            expect(lineNumberHasClass(4, 'someclass')).toBe false
 
         it "removes the classes and unsubscribes from the marker when decoration is removed", ->
           editor.removeDecorationForMarker(marker, decoration)
-          advanceClock(gutter.decorationRenderDelay)
 
-          expect(lineNumberHasClass(1, 'someclass')).toBe false
-          expect(lineNumberHasClass(2, 'someclass')).toBe false
-          expect(lineNumberHasClass(3, 'someclass')).toBe false
-          expect(lineNumberHasClass(4, 'someclass')).toBe false
+          waitsFor -> not gutter.decorationRenderImmediate?
+          runs ->
+            expect(lineNumberHasClass(1, 'someclass')).toBe false
+            expect(lineNumberHasClass(2, 'someclass')).toBe false
+            expect(lineNumberHasClass(3, 'someclass')).toBe false
+            expect(lineNumberHasClass(4, 'someclass')).toBe false
 
           editor.getBuffer().insert([0, 0], '\n')
-          advanceClock(gutter.decorationRenderDelay)
-          expect(lineNumberHasClass(2, 'someclass')).toBe false
-          expect(lineNumberHasClass(3, 'someclass')).toBe false
+
+          waitsFor -> not gutter.decorationRenderImmediate?
+          runs ->
+            expect(lineNumberHasClass(2, 'someclass')).toBe false
+            expect(lineNumberHasClass(3, 'someclass')).toBe false
 
         it "removes the line number classes when the decoration's marker is destroyed", ->
           marker.destroy()
-          advanceClock(gutter.decorationRenderDelay)
 
-          expect(lineNumberHasClass(1, 'someclass')).toBe false
-          expect(lineNumberHasClass(2, 'someclass')).toBe false
-          expect(lineNumberHasClass(3, 'someclass')).toBe false
-          expect(lineNumberHasClass(4, 'someclass')).toBe false
+          waitsFor -> not gutter.decorationRenderImmediate?
+          runs ->
+            expect(lineNumberHasClass(1, 'someclass')).toBe false
+            expect(lineNumberHasClass(2, 'someclass')).toBe false
+            expect(lineNumberHasClass(3, 'someclass')).toBe false
+            expect(lineNumberHasClass(4, 'someclass')).toBe false
 
   describe "cursor rendering", ->
     it "renders the currently visible cursors, translated relative to the scroll position", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -309,14 +309,14 @@ describe "EditorComponent", ->
         lineHasClass = (screenRow, klass) ->
           component.lineNumberNodeForScreenRow(screenRow).classList.contains(klass)
 
-      it "renders the gutter-class decorations", ->
+      it "renders the gutter decorations", ->
         node.style.height = 4.5 * lineHeightInPixels + 'px'
         component.measureScrollView()
 
         expect(component.lineNumberNodeForScreenRow(9)).toBeFalsy()
 
-        editor.addDecorationForBufferRow(9, {type: 'gutter-class', class: 'fancy-class'})
-        editor.addDecorationForBufferRow(9, {type: 'someother-type', class: 'nope-class'})
+        editor.addDecorationToBufferRow(9, {type: 'gutter', class: 'fancy-class'})
+        editor.addDecorationToBufferRow(9, {type: 'someother-type', class: 'nope-class'})
 
         verticalScrollbarNode.scrollTop = 2.5 * lineHeightInPixels
         verticalScrollbarNode.dispatchEvent(new UIEvent('scroll'))
@@ -324,17 +324,17 @@ describe "EditorComponent", ->
         expect(lineHasClass(9, 'fancy-class')).toBeTruthy()
         expect(lineHasClass(9, 'nope-class')).toBeFalsy()
 
-      it "handles updates to gutter-class decorations", ->
-        editor.addDecorationForBufferRow(2, {type: 'gutter-class', class: 'fancy-class'})
-        editor.addDecorationForBufferRow(2, {type: 'someother-type', class: 'nope-class'})
+      it "handles updates to gutter decorations", ->
+        editor.addDecorationToBufferRow(2, {type: 'gutter', class: 'fancy-class'})
+        editor.addDecorationToBufferRow(2, {type: 'someother-type', class: 'nope-class'})
 
         advanceClock(gutter.decorationRenderDelay)
 
         expect(lineHasClass(2, 'fancy-class')).toBeTruthy()
         expect(lineHasClass(2, 'nope-class')).toBeFalsy()
 
-        editor.removeDecorationForBufferRow(2, {type: 'gutter-class', class: 'fancy-class'})
-        editor.removeDecorationForBufferRow(2, {type: 'someother-type', class: 'nope-class'})
+        editor.removeDecorationFromBufferRow(2, {type: 'gutter', class: 'fancy-class'})
+        editor.removeDecorationFromBufferRow(2, {type: 'someother-type', class: 'nope-class'})
 
         advanceClock(gutter.decorationRenderDelay)
 
@@ -342,8 +342,8 @@ describe "EditorComponent", ->
         expect(lineHasClass(2, 'nope-class')).toBeFalsy()
 
       it "handles softWrap decorations", ->
-        editor.addDecorationForBufferRow(1, {type: 'gutter-class', class: 'no-wrap'})
-        editor.addDecorationForBufferRow(1, {type: 'gutter-class', class: 'wrap-me', softWrap: true})
+        editor.addDecorationToBufferRow(1, {type: 'gutter', class: 'no-wrap'})
+        editor.addDecorationToBufferRow(1, {type: 'gutter', class: 'wrap-me', softWrap: true})
 
         editor.setSoftWrap(true)
         node.style.height = 4.5 * lineHeightInPixels + 'px'
@@ -356,8 +356,8 @@ describe "EditorComponent", ->
         expect(lineHasClass(3, 'wrap-me')).toBeTruthy()
 
         # should remove the wrapped decorations
-        editor.removeDecorationForBufferRow(1, {type: 'gutter-class', class: 'no-wrap'})
-        editor.removeDecorationForBufferRow(1, {type: 'gutter-class', class: 'wrap-me'})
+        editor.removeDecorationFromBufferRow(1, {type: 'gutter', class: 'no-wrap'})
+        editor.removeDecorationFromBufferRow(1, {type: 'gutter', class: 'wrap-me'})
         advanceClock(gutter.decorationRenderDelay)
 
         expect(lineHasClass(2, 'no-wrap')).toBeFalsy()
@@ -366,8 +366,8 @@ describe "EditorComponent", ->
         expect(lineHasClass(3, 'wrap-me')).toBeFalsy()
 
         # should add them back when the nodes are not recreated
-        editor.addDecorationForBufferRow(1, {type: 'gutter-class', class: 'no-wrap'})
-        editor.addDecorationForBufferRow(1, {type: 'gutter-class', class: 'wrap-me', softWrap: true})
+        editor.addDecorationToBufferRow(1, {type: 'gutter', class: 'no-wrap'})
+        editor.addDecorationToBufferRow(1, {type: 'gutter', class: 'wrap-me', softWrap: true})
         advanceClock(gutter.decorationRenderDelay)
 
         expect(lineHasClass(2, 'no-wrap')).toBeTruthy()
@@ -379,7 +379,7 @@ describe "EditorComponent", ->
         {marker, decoration} = {}
         beforeEach ->
           marker = editor.displayBuffer.markBufferRange([[2, 13], [3, 15]], class: 'my-marker', invalidate: 'inside')
-          decoration = {type: 'gutter-class', class: 'someclass'}
+          decoration = {type: 'gutter', class: 'someclass'}
           editor.addDecorationForMarker(marker, decoration)
           advanceClock(gutter.decorationRenderDelay)
 

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -359,7 +359,7 @@ describe "EditorComponent", ->
           editor.addDecorationToBufferRow(2, type: 'gutter', class: 'fancy-class')
           editor.addDecorationToBufferRow(2, type: 'someother-type', class: 'nope-class')
 
-          waitsFor -> not gutter.decorationRenderImmediate?
+          waitsFor -> not component.decorationChangedImmediate?
           runs ->
             expect(lineNumberHasClass(2, 'fancy-class')).toBe true
             expect(lineNumberHasClass(2, 'nope-class')).toBe false
@@ -367,7 +367,7 @@ describe "EditorComponent", ->
             editor.removeDecorationFromBufferRow(2, type: 'gutter', class: 'fancy-class')
             editor.removeDecorationFromBufferRow(2, type: 'someother-type', class: 'nope-class')
 
-          waitsFor -> not gutter.decorationRenderImmediate?
+          waitsFor -> not component.decorationChangedImmediate?
           runs ->
             expect(lineNumberHasClass(2, 'fancy-class')).toBe false
             expect(lineNumberHasClass(2, 'nope-class')).toBe false
@@ -390,7 +390,7 @@ describe "EditorComponent", ->
           editor.removeDecorationFromBufferRow(1, type: 'gutter', class: 'no-wrap')
           editor.removeDecorationFromBufferRow(1, type: 'gutter', class: 'wrap-me')
 
-          waitsFor -> not gutter.decorationRenderImmediate?
+          waitsFor -> not component.decorationChangedImmediate?
           runs ->
             expect(lineNumberHasClass(2, 'no-wrap')).toBe false
             expect(lineNumberHasClass(2, 'wrap-me')).toBe false
@@ -401,7 +401,7 @@ describe "EditorComponent", ->
             editor.addDecorationToBufferRow(1, type: 'gutter', class: 'no-wrap')
             editor.addDecorationToBufferRow(1, type: 'gutter', class: 'wrap-me', softWrap: true)
 
-          waitsFor -> not gutter.decorationRenderImmediate?
+          waitsFor -> not component.decorationChangedImmediate?
           runs ->
             expect(lineNumberHasClass(2, 'no-wrap')).toBe true
             expect(lineNumberHasClass(2, 'wrap-me')).toBe true
@@ -414,7 +414,7 @@ describe "EditorComponent", ->
           marker = editor.displayBuffer.markBufferRange([[2, 13], [3, 15]], class: 'my-marker', invalidate: 'inside')
           decoration = {type: 'gutter', class: 'someclass'}
           editor.addDecorationForMarker(marker, decoration)
-          waitsFor -> not gutter.decorationRenderImmediate?
+          waitsFor -> not component.decorationChangedImmediate?
 
         it "updates line number classes when the marker moves", ->
           expect(lineNumberHasClass(1, 'someclass')).toBe false
@@ -424,7 +424,7 @@ describe "EditorComponent", ->
 
           editor.getBuffer().insert([0, 0], '\n')
 
-          waitsFor -> not gutter.decorationRenderImmediate?
+          waitsFor -> not component.decorationChangedImmediate?
           runs ->
             expect(lineNumberHasClass(2, 'someclass')).toBe false
             expect(lineNumberHasClass(3, 'someclass')).toBe true
@@ -433,7 +433,7 @@ describe "EditorComponent", ->
 
             editor.getBuffer().deleteRows(0, 1)
 
-          waitsFor -> not gutter.decorationRenderImmediate?
+          waitsFor -> not component.decorationChangedImmediate?
           runs ->
             expect(lineNumberHasClass(0, 'someclass')).toBe false
             expect(lineNumberHasClass(1, 'someclass')).toBe true
@@ -443,7 +443,7 @@ describe "EditorComponent", ->
         it "removes line number classes when a decoration's marker is invalidated", ->
           editor.getBuffer().insert([3, 2], 'n')
 
-          waitsFor -> not gutter.decorationRenderImmediate?
+          waitsFor -> not component.decorationChangedImmediate?
           runs ->
 
             expect(marker.isValid()).toBe false
@@ -454,7 +454,7 @@ describe "EditorComponent", ->
 
             editor.getBuffer().undo()
 
-          waitsFor -> not gutter.decorationRenderImmediate?
+          waitsFor -> not component.decorationChangedImmediate?
           runs ->
             expect(marker.isValid()).toBe true
             expect(lineNumberHasClass(1, 'someclass')).toBe false
@@ -465,7 +465,7 @@ describe "EditorComponent", ->
         it "removes the classes and unsubscribes from the marker when decoration is removed", ->
           editor.removeDecorationForMarker(marker, decoration)
 
-          waitsFor -> not gutter.decorationRenderImmediate?
+          waitsFor -> not component.decorationChangedImmediate?
           runs ->
             expect(lineNumberHasClass(1, 'someclass')).toBe false
             expect(lineNumberHasClass(2, 'someclass')).toBe false
@@ -474,7 +474,7 @@ describe "EditorComponent", ->
 
           editor.getBuffer().insert([0, 0], '\n')
 
-          waitsFor -> not gutter.decorationRenderImmediate?
+          waitsFor -> not component.decorationChangedImmediate?
           runs ->
             expect(lineNumberHasClass(2, 'someclass')).toBe false
             expect(lineNumberHasClass(3, 'someclass')).toBe false
@@ -482,7 +482,7 @@ describe "EditorComponent", ->
         it "removes the line number classes when the decoration's marker is destroyed", ->
           marker.destroy()
 
-          waitsFor -> not gutter.decorationRenderImmediate?
+          waitsFor -> not component.decorationChangedImmediate?
           runs ->
             expect(lineNumberHasClass(1, 'someclass')).toBe false
             expect(lineNumberHasClass(2, 'someclass')).toBe false

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -378,6 +378,47 @@ describe "EditorComponent", ->
           lineNumber.dispatchEvent(buildClickEvent(lineNumber))
           expect(lineNumberHasClass(1, 'folded')).toBe false
 
+    describe "cursor-line decorations", ->
+      cursor = null
+      beforeEach ->
+        cursor = editor.getCursor()
+
+      it "modifies the cursor-line decoration when the cursor moves", ->
+        cursor.setScreenPosition([0, 0])
+        expect(lineNumberHasClass(0, 'cursor-line')).toBe true
+
+        cursor.setScreenPosition([1, 0])
+        expect(lineNumberHasClass(0, 'cursor-line')).toBe false
+        expect(lineNumberHasClass(1, 'cursor-line')).toBe true
+
+      it "updates cursor-line decorations for multiple cursors", ->
+        cursor.setScreenPosition([2, 0])
+        cursor2 = editor.addCursorAtScreenPosition([8, 0])
+        cursor3 = editor.addCursorAtScreenPosition([10, 0])
+
+        expect(lineNumberHasClass(2, 'cursor-line')).toBe true
+        expect(lineNumberHasClass(8, 'cursor-line')).toBe true
+        expect(lineNumberHasClass(10, 'cursor-line')).toBe true
+
+        cursor2.destroy()
+        expect(lineNumberHasClass(2, 'cursor-line')).toBe true
+        expect(lineNumberHasClass(8, 'cursor-line')).toBe false
+        expect(lineNumberHasClass(10, 'cursor-line')).toBe true
+
+        cursor3.destroy()
+        expect(lineNumberHasClass(2, 'cursor-line')).toBe true
+        expect(lineNumberHasClass(8, 'cursor-line')).toBe false
+        expect(lineNumberHasClass(10, 'cursor-line')).toBe false
+
+      it "adds cursor-line decorations to multiple lines when a selection is performed", ->
+        cursor.setScreenPosition([1, 0])
+        editor.selectDown(2)
+        expect(lineNumberHasClass(0, 'cursor-line')).toBe false
+        expect(lineNumberHasClass(1, 'cursor-line')).toBe true
+        expect(lineNumberHasClass(2, 'cursor-line')).toBe true
+        expect(lineNumberHasClass(3, 'cursor-line')).toBe true
+        expect(lineNumberHasClass(4, 'cursor-line')).toBe false
+
     describe "when decorations are used", ->
       describe "when decorations are applied to buffer rows", ->
         it "renders line number classes based on the decorations on their buffer row", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -165,7 +165,7 @@ describe "EditorComponent", ->
         beforeEach ->
           editor.setText "a line that wraps "
           editor.setSoftWrap(true)
-          node.style.width = 15 * charWidth + 'px'
+          node.style.width = 16 * charWidth + 'px'
           component.measureScrollView()
 
         it "doesn't show end of line invisibles at the end of wrapped lines", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -374,7 +374,8 @@ describe "EditorComponent", ->
           expect(lineNumberHasClass(1, 'folded')).toBe false
 
         it "does not fold when the line number node is clicked", ->
-          component.onClickGutter(buildClickEvent(component.lineNumberNodeForScreenRow(1)))
+          lineNumber = component.lineNumberNodeForScreenRow(1)
+          lineNumber.dispatchEvent(buildClickEvent(lineNumber))
           expect(lineNumberHasClass(1, 'folded')).toBe false
 
     describe "when decorations are used", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -329,6 +329,15 @@ describe "EditorComponent", ->
           expect(lineNumberHasClass(5, 'foldable')).toBe true
           expect(lineNumberHasClass(6, 'foldable')).toBe false
 
+        it "updates the foldable class on a line number that becomes foldable", ->
+          expect(lineNumberHasClass(11, 'foldable')).toBe false
+
+          editor.getBuffer().insert([11, 44], '\n    fold me')
+          expect(lineNumberHasClass(11, 'foldable')).toBe true
+
+          editor.undo()
+          expect(lineNumberHasClass(11, 'foldable')).toBe false
+
         it "adds, updates and removes the folded class on the correct line number nodes", ->
           editor.foldBufferRow(4)
           expect(lineNumberHasClass(4, 'folded')).toBe true

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -916,6 +916,22 @@ describe "EditorComponent", ->
       inputNode.blur()
       expect(node.classList.contains('is-focused')).toBe false
 
+  describe "selection handling", ->
+    cursor = null
+
+    beforeEach ->
+      cursor = editor.getCursor()
+      cursor.setScreenPosition([0, 0])
+
+    it "adds the 'has-selection' class to the editor when there is a selection", ->
+      expect(node.classList.contains('has-selection')).toBe false
+
+      editor.selectDown()
+      expect(node.classList.contains('has-selection')).toBe true
+
+      cursor.moveDown()
+      expect(node.classList.contains('has-selection')).toBe false
+
   describe "scrolling", ->
     it "updates the vertical scrollbar when the scrollTop is changed in the model", ->
       node.style.height = 4.5 * lineHeightInPixels + 'px'

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -3207,7 +3207,7 @@ describe "Editor", ->
       expect(editor.getScrollTop()).toBe 0
 
   fdescribe "decorations", ->
-    it "can add decorations", ->
+    it "can add and remove decorations", ->
       decoration = {type: 'gutter-class', class: 'one'}
       editor.addDecorationForBufferRow(2, decoration)
       editor.addDecorationForBufferRow(2, decoration)
@@ -3215,3 +3215,7 @@ describe "Editor", ->
       decorations = editor.decorationsForBufferRow(2)
       expect(decorations).toHaveLength 1
       expect(decorations).toContain decoration
+
+      editor.removeDecorationForBufferRow(2, decoration)
+      decorations = editor.decorationsForBufferRow(2)
+      expect(decorations).toHaveLength 0

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -3208,14 +3208,14 @@ describe "Editor", ->
 
   describe "decorations", ->
     it "can add and remove decorations", ->
-      decoration = {type: 'gutter-class', class: 'one'}
-      editor.addDecorationForBufferRow(2, decoration)
-      editor.addDecorationForBufferRow(2, decoration)
+      decoration = {type: 'gutter', class: 'one'}
+      editor.addDecorationToBufferRow(2, decoration)
+      editor.addDecorationToBufferRow(2, decoration)
 
       decorations = editor.decorationsForBufferRow(2)
       expect(decorations).toHaveLength 1
       expect(decorations).toContain decoration
 
-      editor.removeDecorationForBufferRow(2, decoration)
+      editor.removeDecorationFromBufferRow(2, decoration)
       decorations = editor.decorationsForBufferRow(2)
       expect(decorations).toHaveLength 0

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -3206,7 +3206,7 @@ describe "Editor", ->
       editor.pageUp()
       expect(editor.getScrollTop()).toBe 0
 
-  fdescribe "decorations", ->
+  describe "decorations", ->
     it "can add and remove decorations", ->
       decoration = {type: 'gutter-class', class: 'one'}
       editor.addDecorationForBufferRow(2, decoration)

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1622,7 +1622,7 @@ describe "Editor", ->
         editor.setCursorBufferPosition([9,2])
         editor.insertNewline()
         expect(editor.lineForBufferRow(10)).toBe '  };'
-        
+
     describe ".backspace()", ->
       describe "when there is a single cursor", ->
         changeScreenRangeHandler = null
@@ -3205,3 +3205,13 @@ describe "Editor", ->
 
       editor.pageUp()
       expect(editor.getScrollTop()).toBe 0
+
+  fdescribe "decorations", ->
+    it "can add decorations", ->
+      decoration = {type: 'gutter-class', class: 'one'}
+      editor.addDecorationForBufferRow(2, decoration)
+      editor.addDecorationForBufferRow(2, decoration)
+
+      decorations = editor.decorationsForBufferRow(2)
+      expect(decorations).toHaveLength 1
+      expect(decorations).toContain decoration

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -3207,8 +3207,11 @@ describe "Editor", ->
       expect(editor.getScrollTop()).toBe 0
 
   describe "decorations", ->
-    it "can add and remove decorations", ->
+    decoration = null
+    beforeEach ->
       decoration = {type: 'gutter', class: 'one'}
+
+    it "can add decorations to buffer rows and remove them", ->
       editor.addDecorationToBufferRow(2, decoration)
       editor.addDecorationToBufferRow(2, decoration)
 
@@ -3219,3 +3222,47 @@ describe "Editor", ->
       editor.removeDecorationFromBufferRow(2, decoration)
       decorations = editor.decorationsForBufferRow(2)
       expect(decorations).toHaveLength 0
+
+    it "can add decorations to buffer row ranges and remove them", ->
+      editor.addDecorationToBufferRowRange(2, 4, decoration)
+      expect(editor.decorationsForBufferRow 2).toContain decoration
+      expect(editor.decorationsForBufferRow 3).toContain decoration
+      expect(editor.decorationsForBufferRow 4).toContain decoration
+
+      editor.removeDecorationFromBufferRowRange(3, 5, decoration)
+      expect(editor.decorationsForBufferRow 2).toContain decoration
+      expect(editor.decorationsForBufferRow 3).not.toContain decoration
+      expect(editor.decorationsForBufferRow 4).not.toContain decoration
+
+    it "can add decorations associated with markers and remove them", ->
+      marker = editor.displayBuffer.markBufferRange([[2, 13], [3, 15]], class: 'my-marker', invalidate: 'inside')
+
+      editor.addDecorationForMarker(marker, decoration)
+      expect(editor.decorationsForBufferRow 1).not.toContain decoration
+      expect(editor.decorationsForBufferRow 2).toContain decoration
+      expect(editor.decorationsForBufferRow 3).toContain decoration
+      expect(editor.decorationsForBufferRow 4).not.toContain decoration
+
+      editor.getBuffer().insert([0, 0], '\n')
+      expect(editor.decorationsForBufferRow 2).not.toContain decoration
+      expect(editor.decorationsForBufferRow 3).toContain decoration
+      expect(editor.decorationsForBufferRow 4).toContain decoration
+      expect(editor.decorationsForBufferRow 5).not.toContain decoration
+
+      editor.getBuffer().insert([4, 2], 'n')
+      expect(editor.decorationsForBufferRow 2).not.toContain decoration
+      expect(editor.decorationsForBufferRow 3).not.toContain decoration
+      expect(editor.decorationsForBufferRow 4).not.toContain decoration
+      expect(editor.decorationsForBufferRow 5).not.toContain decoration
+
+      editor.getBuffer().undo()
+      expect(editor.decorationsForBufferRow 2).not.toContain decoration
+      expect(editor.decorationsForBufferRow 3).toContain decoration
+      expect(editor.decorationsForBufferRow 4).toContain decoration
+      expect(editor.decorationsForBufferRow 5).not.toContain decoration
+
+      editor.removeDecorationForMarker(marker, decoration)
+      expect(editor.decorationsForBufferRow 2).not.toContain decoration
+      expect(editor.decorationsForBufferRow 3).not.toContain decoration
+      expect(editor.decorationsForBufferRow 4).not.toContain decoration
+      expect(editor.decorationsForBufferRow 5).not.toContain decoration

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -3266,3 +3266,53 @@ describe "Editor", ->
       expect(editor.decorationsForBufferRow 3).not.toContain decoration
       expect(editor.decorationsForBufferRow 4).not.toContain decoration
       expect(editor.decorationsForBufferRow 5).not.toContain decoration
+
+    describe "decorationsForBufferRow", ->
+      one = {type: 'one', class: 'one'}
+      two = {type: 'two', class: 'two'}
+      typeless = {class: 'typeless'}
+
+      beforeEach ->
+        editor.addDecorationToBufferRow(2, one)
+        editor.addDecorationToBufferRow(2, two)
+        editor.addDecorationToBufferRow(2, typeless)
+
+      it "returns all decorations with no decorationType specified", ->
+        decorations = editor.decorationsForBufferRow(2)
+        expect(decorations).toContain one
+        expect(decorations).toContain two
+        expect(decorations).toContain typeless
+
+      it "returns typeless decorations with all decorationTypes", ->
+        decorations = editor.decorationsForBufferRow(2, 'one')
+        expect(decorations).toContain one
+        expect(decorations).not.toContain two
+        expect(decorations).toContain typeless
+
+    describe "decorationsForBufferRowRange", ->
+      one = {type: 'one', class: 'one'}
+      two = {type: 'two', class: 'two'}
+      typeless = {class: 'typeless'}
+
+      it "returns an object of decorations based on the decorationType", ->
+        editor.addDecorationToBufferRow(2, one)
+        editor.addDecorationToBufferRow(3, one)
+        editor.addDecorationToBufferRow(5, one)
+
+        editor.addDecorationToBufferRow(3, two)
+        editor.addDecorationToBufferRow(4, two)
+
+        editor.addDecorationToBufferRow(3, typeless)
+        editor.addDecorationToBufferRow(5, typeless)
+
+        decorations = editor.decorationsForBufferRowRange(2, 5, 'one')
+        expect(decorations[2]).toContain one
+
+        expect(decorations[3]).toContain one
+        expect(decorations[3]).not.toContain two
+        expect(decorations[3]).toContain typeless
+
+        expect(decorations[4]).toHaveLength 0
+
+        expect(decorations[5]).toContain one
+        expect(decorations[5]).toContain typeless

--- a/src/display-buffer-marker.coffee
+++ b/src/display-buffer-marker.coffee
@@ -111,6 +111,34 @@ class DisplayBufferMarker
   setTailBufferPosition: (bufferPosition) ->
     @bufferMarker.setTailPosition(bufferPosition)
 
+  # Retrieves the screen position of the marker's start. This will always be
+  # less than or equal to the result of {DisplayBufferMarker::getEndScreenPosition}.
+  #
+  # Returns a {Point}.
+  getStartScreenPosition: ->
+    @displayBuffer.screenPositionForBufferPosition(@getStartBufferPosition(), wrapAtSoftNewlines: true)
+
+  # Retrieves the buffer position of the marker's start. This will always be
+  # less than or equal to the result of {DisplayBufferMarker::getEndBufferPosition}.
+  #
+  # Returns a {Point}.
+  getStartBufferPosition: ->
+    @bufferMarker.getStartPosition()
+
+  # Retrieves the screen position of the marker's end. This will always be
+  # greater than or equal to the result of {DisplayBufferMarker::getStartScreenPosition}.
+  #
+  # Returns a {Point}.
+  getEndScreenPosition: ->
+    @displayBuffer.screenPositionForBufferPosition(@getEndBufferPosition(), wrapAtSoftNewlines: true)
+
+  # Retrieves the buffer position of the marker's end. This will always be
+  # greater than or equal to the result of {DisplayBufferMarker::getStartBufferPosition}.
+  #
+  # Returns a {Point}.
+  getEndBufferPosition: ->
+    @bufferMarker.getEndPosition()
+
   # Sets the marker's tail to the same position as the marker's head.
   #
   # This only works if there isn't already a tail position.

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -719,8 +719,10 @@ class DisplayBuffer extends Model
   rangeForAllLines: ->
     new Range([0, 0], @clipScreenPosition([Infinity, Infinity]))
 
-  decorationsForBufferRow: (bufferRow) ->
-    @decorations[bufferRow] ? []
+  decorationsForBufferRow: (bufferRow, decorationType) ->
+    decorations = @decorations[bufferRow] ? []
+    decorations = (dec for dec in decorations when dec.type == decorationType) if decorationType?
+    decorations
 
   addDecorationForBufferRow: (bufferRow, decoration) ->
     @decorations[bufferRow] ?= []

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -43,6 +43,7 @@ class DisplayBuffer extends Model
     @charWidthsByScope = {}
     @markers = {}
     @foldsByMarkerId = {}
+    @decorations = {}
     @updateAllScreenLines()
     @createFoldForMarker(marker) for marker in @buffer.findMarkers(@getFoldMarkerAttributes())
     @subscribe @tokenizedBuffer, 'grammar-changed', (grammar) => @emit 'grammar-changed', grammar
@@ -717,6 +718,30 @@ class DisplayBuffer extends Model
   # Returns a {Range}.
   rangeForAllLines: ->
     new Range([0, 0], @clipScreenPosition([Infinity, Infinity]))
+
+  decorationsForBufferRow: (bufferRow) ->
+    @decorations[bufferRow] ? []
+
+  addDecorationForBufferRow: (bufferRow, decoration) ->
+    @decorations[bufferRow] ?= []
+    for current in @decorations[bufferRow]
+      return if _.isEqual(current, decoration)
+    @decorations[bufferRow].push(decoration)
+    @emit 'decoration-changed', {bufferRow, add: decoration}
+
+  removeDecorationForBufferRow: (bufferRow, decoration) ->
+    return unless @decorations[bufferRow]
+
+    removed = @findDecorationsForBufferRow(bufferRow, decoration)
+    @decorations[bufferRow] = _.without(@decorations, removed)
+    @emit 'decoration-changed', {bufferRow, remove: removed}
+
+  findDecorationsForBufferRow: (bufferRow, options) ->
+    return unless @decorations[bufferRow]
+    (dec for dec in @decorations[bufferRow] when _.isEqual(options, _.pick(decoration, _.keys(options))))
+
+  addGutterClassForMarker: (bufferRow) ->
+  removeGutterClassForMarker: (bufferRow) ->
 
   # Retrieves a {DisplayBufferMarker} based on its id.
   #

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -725,14 +725,14 @@ class DisplayBuffer extends Model
     decorations = (dec for dec in decorations when dec.type == decorationType) if decorationType?
     decorations
 
-  addDecorationForBufferRow: (bufferRow, decoration) ->
+  addDecorationToBufferRow: (bufferRow, decoration) ->
     @decorations[bufferRow] ?= []
     for current in @decorations[bufferRow]
       return if _.isEqual(current, decoration)
     @decorations[bufferRow].push(decoration)
     @emit 'decoration-changed', {bufferRow, decoration, action: 'add'}
 
-  removeDecorationForBufferRow: (bufferRow, decoration) ->
+  removeDecorationFromBufferRow: (bufferRow, decoration) ->
     return unless @decorations[bufferRow]
 
     removed = @findDecorationsForBufferRow(bufferRow, decoration)
@@ -753,7 +753,7 @@ class DisplayBuffer extends Model
     tail = marker.getTailBufferPosition().row
     [tail, head] = [head, tail] if head > tail
     while head <= tail
-      @addDecorationForBufferRow(head++, decoration)
+      @addDecorationToBufferRow(head++, decoration)
 
     changedSubscription = @subscribe marker, 'changed', (e) =>
       oldHead = e.oldHeadBufferPosition.row
@@ -772,11 +772,11 @@ class DisplayBuffer extends Model
       # overlap was not visible.
 
       while oldHead <= oldTail
-        @removeDecorationForBufferRow(oldHead, decoration)
+        @removeDecorationFromBufferRow(oldHead, decoration)
         oldHead++
 
       while e.isValid and newHead <= newTail
-        @addDecorationForBufferRow(newHead, decoration)
+        @addDecorationToBufferRow(newHead, decoration)
         newHead++
 
     destroyedSubscription = @subscribe marker, 'destroyed', (e) =>
@@ -792,7 +792,7 @@ class DisplayBuffer extends Model
     tail = marker.getTailBufferPosition().row
     [tail, head] = [head, tail] if head > tail
     while head <= tail
-      @removeDecorationForBufferRow(head++, decoration)
+      @removeDecorationFromBufferRow(head++, decoration)
 
     for sub in _.clone(@decorationMarkerSubscriptions[marker.id])
       if @decorationEqualsPattern(sub.decoration, decoration)

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -727,18 +727,20 @@ class DisplayBuffer extends Model
     for current in @decorations[bufferRow]
       return if _.isEqual(current, decoration)
     @decorations[bufferRow].push(decoration)
-    @emit 'decoration-changed', {bufferRow, add: decoration}
+    @emit 'decoration-changed', {bufferRow, decoration, action: 'add'}
 
   removeDecorationForBufferRow: (bufferRow, decoration) ->
     return unless @decorations[bufferRow]
 
     removed = @findDecorationsForBufferRow(bufferRow, decoration)
-    @decorations[bufferRow] = _.without(@decorations, removed)
-    @emit 'decoration-changed', {bufferRow, remove: removed}
+    @decorations[bufferRow] = _.without(@decorations[bufferRow], removed...)
+
+    for decoration in removed
+      @emit 'decoration-changed', {bufferRow, decoration, action: 'remove'}
 
   findDecorationsForBufferRow: (bufferRow, options) ->
     return unless @decorations[bufferRow]
-    (dec for dec in @decorations[bufferRow] when _.isEqual(options, _.pick(decoration, _.keys(options))))
+    (dec for dec in @decorations[bufferRow] when _.isEqual(options, _.pick(dec, _.keys(options))))
 
   addGutterClassForMarker: (bufferRow) ->
   removeGutterClassForMarker: (bufferRow) ->

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -725,6 +725,12 @@ class DisplayBuffer extends Model
     decorations = (dec for dec in decorations when dec.type is decorationType) if decorationType?
     decorations
 
+  decorationsForBufferRowRange: (startBufferRow, endBufferRow, decorationType) ->
+    decorations = {}
+    for bufferRow in [startBufferRow..endBufferRow]
+      decorations[bufferRow] = @decorationsForBufferRow(bufferRow, decorationType)
+    decorations
+
   addDecorationToBufferRow: (bufferRow, decoration) ->
     @decorations[bufferRow] ?= []
     for current in @decorations[bufferRow]
@@ -742,12 +748,12 @@ class DisplayBuffer extends Model
       @emit 'decoration-changed', {bufferRow, decoration, action: 'remove'}
 
   addDecorationToBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
-    while startBufferRow <= endBufferRow
-      @addDecorationToBufferRow(startBufferRow++, decoration)
+    for bufferRow in [startBufferRow..endBufferRow]
+      @addDecorationToBufferRow(bufferRow, decoration)
 
   removeDecorationFromBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
-    while startBufferRow <= endBufferRow
-      @removeDecorationFromBufferRow(startBufferRow++, decoration)
+    for bufferRow in [startBufferRow..endBufferRow]
+      @removeDecorationFromBufferRow(bufferRow, decoration)
 
   findDecorationsForBufferRow: (bufferRow, decorationPattern) ->
     return unless @decorations[bufferRow]
@@ -785,8 +791,7 @@ class DisplayBuffer extends Model
 
     startRow = marker.getStartBufferPosition().row
     endRow = marker.getEndBufferPosition().row
-    while startRow <= endRow
-      @removeDecorationFromBufferRow(startRow++, decoration)
+    @removeDecorationFromBufferRowRange(startRow, endRow, decoration)
 
     for subscription in _.clone(@decorationMarkerSubscriptions[marker.id])
       if @decorationMatchesPattern(subscription.decoration, decoration)

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -722,7 +722,7 @@ class DisplayBuffer extends Model
 
   decorationsForBufferRow: (bufferRow, decorationType) ->
     decorations = @decorations[bufferRow] ? []
-    decorations = (dec for dec in decorations when dec.type == decorationType) if decorationType?
+    decorations = (dec for dec in decorations when dec.type is decorationType) if decorationType?
     decorations
 
   addDecorationToBufferRow: (bufferRow, decoration) ->

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -741,6 +741,14 @@ class DisplayBuffer extends Model
     for decoration in removed
       @emit 'decoration-changed', {bufferRow, decoration, action: 'remove'}
 
+  addDecorationToBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
+    while startBufferRow <= endBufferRow
+      @addDecorationToBufferRow(startBufferRow++, decoration)
+
+  removeDecorationFromBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
+    while startBufferRow <= endBufferRow
+      @removeDecorationFromBufferRow(startBufferRow++, decoration)
+
   findDecorationsForBufferRow: (bufferRow, decorationPattern) ->
     return unless @decorations[bufferRow]
     decoration for decoration in @decorations[bufferRow] when @decorationMatchesPattern(decoration, decorationPattern)
@@ -751,8 +759,7 @@ class DisplayBuffer extends Model
   addDecorationForMarker: (marker, decoration) ->
     startRow = marker.getStartBufferPosition().row
     endRow = marker.getEndBufferPosition().row
-    while startRow <= endRow
-      @addDecorationToBufferRow(startRow++, decoration)
+    @addDecorationToBufferRowRange(startRow, endRow, decoration)
 
     changedSubscription = @subscribe marker, 'changed', (e) =>
       oldStartRow = e.oldHeadBufferPosition.row
@@ -770,11 +777,8 @@ class DisplayBuffer extends Model
       # all decorations, then when markers becoming valid, some of the
       # overlap was not visible.
 
-      while oldStartRow <= oldEndRow
-        @removeDecorationFromBufferRow(oldStartRow++, decoration)
-
-      while e.isValid and newStartRow <= newEndRow
-        @addDecorationToBufferRow(newStartRow++, decoration)
+      @removeDecorationFromBufferRowRange(oldStartRow, oldEndRow, decoration)
+      @addDecorationToBufferRowRange(newStartRow, newEndRow, decoration) if e.isValid
 
     destroyedSubscription = @subscribe marker, 'destroyed', (e) =>
       @removeDecorationForMarker(marker, decoration)

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -771,12 +771,6 @@ class DisplayBuffer extends Model
       [oldEndRow, oldStartRow] = [oldStartRow, oldEndRow] if oldStartRow > oldEndRow
       [newEndRow, newStartRow] = [newStartRow, newEndRow] if newStartRow > newEndRow
 
-      # TODO: we could only update the rows that change by tracking an overlap,
-      # then update only those outside of the overlap. I had something to do
-      # this, but it's complicated by marker validity. When invlaid, I removed
-      # all decorations, then when markers becoming valid, some of the
-      # overlap was not visible.
-
       @removeDecorationFromBufferRowRange(oldStartRow, oldEndRow, decoration)
       @addDecorationToBufferRowRange(newStartRow, newEndRow, decoration) if e.isValid
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -758,6 +758,12 @@ class DisplayBuffer extends Model
       @removeDecorationFromBufferRow(bufferRow, decoration)
     return
 
+  # Finds all decorations on a buffer row that match a `decorationPattern`
+  #
+  # bufferRow - the {int} buffer row
+  # decorationPattern - the {Object} decoration type to filter by eg. `{type: 'gutter', class: 'linter-error'}`
+  #
+  # Returns an {Array} of the matching decorations
   findDecorationsForBufferRow: (bufferRow, decorationPattern) ->
     return unless @decorations[bufferRow]
     decoration for decoration in @decorations[bufferRow] when @decorationMatchesPattern(decoration, decorationPattern)

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -738,22 +738,25 @@ class DisplayBuffer extends Model
     @decorations[bufferRow].push(decoration)
     @emit 'decoration-changed', {bufferRow, decoration, action: 'add'}
 
-  removeDecorationFromBufferRow: (bufferRow, decoration) ->
+  removeDecorationFromBufferRow: (bufferRow, decorationPattern) ->
     return unless @decorations[bufferRow]
 
-    removed = @findDecorationsForBufferRow(bufferRow, decoration)
+    removed = @findDecorationsForBufferRow(bufferRow, decorationPattern)
     @decorations[bufferRow] = _.without(@decorations[bufferRow], removed...)
 
     for decoration in removed
       @emit 'decoration-changed', {bufferRow, decoration, action: 'remove'}
 
+    removed
   addDecorationToBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
     for bufferRow in [startBufferRow..endBufferRow]
       @addDecorationToBufferRow(bufferRow, decoration)
+    return
 
   removeDecorationFromBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
     for bufferRow in [startBufferRow..endBufferRow]
       @removeDecorationFromBufferRow(bufferRow, decoration)
+    return
 
   findDecorationsForBufferRow: (bufferRow, decorationPattern) ->
     return unless @decorations[bufferRow]
@@ -786,15 +789,15 @@ class DisplayBuffer extends Model
     @decorationMarkerSubscriptions[marker.id] ?= []
     @decorationMarkerSubscriptions[marker.id].push {decoration, changedSubscription, destroyedSubscription}
 
-  removeDecorationForMarker: (marker, decoration) ->
+  removeDecorationForMarker: (marker, decorationPattern) ->
     return unless @decorationMarkerSubscriptions[marker.id]?
 
     startRow = marker.getStartBufferPosition().row
     endRow = marker.getEndBufferPosition().row
-    @removeDecorationFromBufferRowRange(startRow, endRow, decoration)
+    @removeDecorationFromBufferRowRange(startRow, endRow, decorationPattern)
 
     for subscription in _.clone(@decorationMarkerSubscriptions[marker.id])
-      if @decorationMatchesPattern(subscription.decoration, decoration)
+      if @decorationMatchesPattern(subscription.decoration, decorationPattern)
         subscription.changedSubscription.off()
         subscription.destroyedSubscription.off()
         @decorationMarkerSubscriptions[marker.id] = _.without(@decorationMarkerSubscriptions[marker.id], subscription)

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -1053,6 +1053,8 @@ class DisplayBuffer extends Model
     @emit 'marker-created', @getMarker(marker.id)
 
   createFoldForMarker: (marker) ->
+    bufferMarker = new DisplayBufferMarker({bufferMarker: marker, displayBuffer: this})
+    @addDecorationForMarker(bufferMarker, type: 'gutter', class: 'folded')
     new Fold(this, marker)
 
   foldForMarker: (marker) ->

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -722,7 +722,7 @@ class DisplayBuffer extends Model
 
   decorationsForBufferRow: (bufferRow, decorationType) ->
     decorations = @decorations[bufferRow] ? []
-    decorations = (dec for dec in decorations when dec.type is decorationType) if decorationType?
+    decorations = (dec for dec in decorations when not dec.type? or dec.type is decorationType) if decorationType?
     decorations
 
   decorationsForBufferRowRange: (startBufferRow, endBufferRow, decorationType) ->

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -177,9 +177,7 @@ EditorComponent = React.createClass
     if @batchingUpdates
       @updateRequested = true
     else
-      @willUpdate ?= setImmediate =>
-        @forceUpdate()
-        @willUpdate = null
+      @forceUpdate()
 
   getRenderedRowRange: ->
     {editor, lineOverdrawMargin} = @props
@@ -528,7 +526,10 @@ EditorComponent = React.createClass
     @cursorsMoved = true
 
   onDecorationChanged: ->
-    @requestUpdate()
+    return if @decorationChangedImmediate?
+    @decorationChangedImmediate = setImmediate =>
+      @requestUpdate()
+      @decorationChangedImmediate = null
 
   selectToMousePositionUntilMouseUp: (event) ->
     {editor} = @props

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -237,7 +237,6 @@ EditorComponent = React.createClass
     for bufferRow in bufferRows
       decorations[bufferRow] = editor.decorationsForBufferRow(bufferRow, 'gutter')
       decorations[bufferRow].push {class: 'foldable'} if editor.isFoldableAtBufferRow(bufferRow)
-      decorations[bufferRow].push {class: 'folded'} if editor.isFoldedAtBufferRow(bufferRow)
     decorations
 
   observeEditor: ->

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -480,7 +480,6 @@ EditorComponent = React.createClass
     @selectToMousePositionUntilMouseUp(event)
 
   onClickGutter: (event) ->
-    console.log 'gutter click', event
     {editor} = @props
     {target} = event
     lineNumber = target.parentNode

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -528,8 +528,7 @@ EditorComponent = React.createClass
     @cursorsMoved = true
 
   onDecorationChanged: ->
-    return if @decorationChangedImmediate?
-    @decorationChangedImmediate = setImmediate =>
+    @decorationChangedImmediate ?= setImmediate =>
       @requestUpdate()
       @decorationChangedImmediate = null
 

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -538,6 +538,7 @@ EditorComponent = React.createClass
     @cursorsMoved = true
 
   onDecorationChanged: ->
+    return if @decorationChangedImmediate?
     @decorationChangedImmediate = setImmediate =>
       @requestUpdate()
       @decorationChangedImmediate = null

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -71,7 +71,7 @@ EditorComponent = React.createClass
 
     div className: className, style: {fontSize, lineHeight, fontFamily}, tabIndex: -1,
       GutterComponent {
-        ref: 'gutter', onClick: @onClickGutter, editor, renderedRowRange, maxLineNumberDigits, scrollTop,
+        ref: 'gutter', editor, renderedRowRange, maxLineNumberDigits, scrollTop,
         scrollHeight, lineHeightInPixels, @pendingChanges, mouseWheelScreenRow,
         decorations
       }
@@ -477,18 +477,6 @@ EditorComponent = React.createClass
         when 3 then editor.selectLine()
 
     @selectToMousePositionUntilMouseUp(event)
-
-  onClickGutter: (event) ->
-    {editor} = @props
-    {target} = event
-    lineNumber = target.parentNode
-
-    if target.classList.contains('icon-right') and lineNumber.classList.contains('foldable')
-      bufferRow = parseInt(lineNumber.getAttribute('data-buffer-row'))
-      if lineNumber.classList.contains('folded')
-        editor.unfoldBufferRow(bufferRow)
-      else
-        editor.foldBufferRow(bufferRow)
 
   onStylesheetsChanged: (stylesheet) ->
     @refreshScrollbars() if @containsScrollbarSelector(stylesheet)

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -177,7 +177,9 @@ EditorComponent = React.createClass
     if @batchingUpdates
       @updateRequested = true
     else
-      @forceUpdate()
+      @willUpdate ?= setImmediate =>
+        @forceUpdate()
+        @willUpdate = null
 
   getRenderedRowRange: ->
     {editor, lineOverdrawMargin} = @props
@@ -526,10 +528,7 @@ EditorComponent = React.createClass
     @cursorsMoved = true
 
   onDecorationChanged: ->
-    return if @decorationChangedImmediate?
-    @decorationChangedImmediate = setImmediate =>
-      @requestUpdate()
-      @decorationChangedImmediate = null
+    @requestUpdate()
 
   selectToMousePositionUntilMouseUp: (event) ->
     {editor} = @props

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -71,7 +71,7 @@ EditorComponent = React.createClass
 
     div className: className, style: {fontSize, lineHeight, fontFamily}, tabIndex: -1,
       GutterComponent {
-        ref: 'gutter', editor, renderedRowRange, maxLineNumberDigits, scrollTop,
+        ref: 'gutter', onClick: @onClickGutter, editor, renderedRowRange, maxLineNumberDigits, scrollTop,
         scrollHeight, lineHeightInPixels, @pendingChanges, mouseWheelScreenRow,
         decorations
       }
@@ -478,6 +478,19 @@ EditorComponent = React.createClass
         when 3 then editor.selectLine()
 
     @selectToMousePositionUntilMouseUp(event)
+
+  onClickGutter: (event) ->
+    console.log 'gutter click', event
+    {editor} = @props
+    {target} = event
+    lineNumber = target.parentNode
+
+    if target.classList.contains('icon-right') and lineNumber.classList.contains('foldable')
+      bufferRow = parseInt(lineNumber.getAttribute('data-buffer-row'))
+      if lineNumber.classList.contains('folded')
+        editor.unfoldBufferRow(bufferRow)
+      else
+        editor.foldBufferRow(bufferRow)
 
   onStylesheetsChanged: (stylesheet) ->
     @refreshScrollbars() if @containsScrollbarSelector(stylesheet)

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -43,6 +43,7 @@ EditorComponent = React.createClass
     {editor, cursorBlinkPeriod, cursorBlinkResumeDelay} = @props
     maxLineNumberDigits = editor.getScreenLineCount().toString().length
     invisibles = if showInvisibles then @state.invisibles else {}
+    hasSelection = editor.getSelection()? and !editor.getSelection().isEmpty()
 
     if @isMounted()
       renderedRowRange = @getRenderedRowRange()
@@ -68,6 +69,7 @@ EditorComponent = React.createClass
 
     className = 'editor-contents editor-colors'
     className += ' is-focused' if focused
+    className += ' has-selection' if hasSelection
 
     div className: className, style: {fontSize, lineHeight, fontFamily}, tabIndex: -1,
       GutterComponent {

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1067,6 +1067,9 @@ class Editor extends Model
   removeDecorationForBufferRow: (bufferRow, decoration) ->
     @displayBuffer.removeDecorationForBufferRow(bufferRow, decoration)
 
+  addDecorationForMarker: (marker, decoration) ->
+    @displayBuffer.addDecorationForMarker(marker, decoration)
+
   # Public: Get the {DisplayBufferMarker} for the given marker id.
   getMarker: (id) ->
     @displayBuffer.getMarker(id)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1061,11 +1061,11 @@ class Editor extends Model
   decorationsForBufferRow: (bufferRow, decorationType) ->
     @displayBuffer.decorationsForBufferRow(bufferRow, decorationType)
 
-  addDecorationForBufferRow: (bufferRow, decoration) ->
-    @displayBuffer.addDecorationForBufferRow(bufferRow, decoration)
+  addDecorationToBufferRow: (bufferRow, decoration) ->
+    @displayBuffer.addDecorationToBufferRow(bufferRow, decoration)
 
-  removeDecorationForBufferRow: (bufferRow, decoration) ->
-    @displayBuffer.removeDecorationForBufferRow(bufferRow, decoration)
+  removeDecorationFromBufferRow: (bufferRow, decoration) ->
+    @displayBuffer.removeDecorationFromBufferRow(bufferRow, decoration)
 
   addDecorationForMarker: (marker, decoration) ->
     @displayBuffer.addDecorationForMarker(marker, decoration)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1057,6 +1057,15 @@ class Editor extends Model
       selection.insertText(fn(text))
       selection.setBufferRange(range)
 
+  decorationsForBufferRow: (bufferRow) ->
+    @displayBuffer.decorationsForBufferRow(bufferRow)
+
+  addDecorationForBufferRow: (bufferRow, decoration) ->
+    @displayBuffer.addDecorationForBufferRow(bufferRow, decoration)
+
+  removeDecorationForBufferRow: (bufferRow, decoration) ->
+    @displayBuffer.removeDecorationForBufferRow(bufferRow, decoration)
+
   # Public: Get the {DisplayBufferMarker} for the given marker id.
   getMarker: (id) ->
     @displayBuffer.getMarker(id)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1070,6 +1070,9 @@ class Editor extends Model
   addDecorationForMarker: (marker, decoration) ->
     @displayBuffer.addDecorationForMarker(marker, decoration)
 
+  removeDecorationForMarker: (marker, decoration) ->
+    @displayBuffer.removeDecorationForMarker(marker, decoration)
+
   # Public: Get the {DisplayBufferMarker} for the given marker id.
   getMarker: (id) ->
     @displayBuffer.getMarker(id)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -214,6 +214,7 @@ class Editor extends Model
     @subscribe @displayBuffer, 'grammar-changed', => @handleGrammarChange()
     @subscribe @displayBuffer, 'tokenized', => @handleTokenization()
     @subscribe @displayBuffer, 'soft-wrap-changed', (args...) => @emit 'soft-wrap-changed', args...
+    @subscribe @displayBuffer, "decoration-changed", (e) => @emit 'decoration-changed', e
 
   getViewClass: ->
     if atom.config.get('core.useReactEditor')

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1058,8 +1058,8 @@ class Editor extends Model
       selection.insertText(fn(text))
       selection.setBufferRange(range)
 
-  decorationsForBufferRow: (bufferRow) ->
-    @displayBuffer.decorationsForBufferRow(bufferRow)
+  decorationsForBufferRow: (bufferRow, decorationType) ->
+    @displayBuffer.decorationsForBufferRow(bufferRow, decorationType)
 
   addDecorationForBufferRow: (bufferRow, decoration) ->
     @displayBuffer.addDecorationForBufferRow(bufferRow, decoration)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1061,6 +1061,9 @@ class Editor extends Model
   decorationsForBufferRow: (bufferRow, decorationType) ->
     @displayBuffer.decorationsForBufferRow(bufferRow, decorationType)
 
+  decorationsForBufferRowRange: (startBufferRow, endBufferRow, decorationType) ->
+    @displayBuffer.decorationsForBufferRowRange(startBufferRow, endBufferRow, decorationType)
+
   addDecorationToBufferRow: (bufferRow, decoration) ->
     @displayBuffer.addDecorationToBufferRow(bufferRow, decoration)
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1067,6 +1067,12 @@ class Editor extends Model
   removeDecorationFromBufferRow: (bufferRow, decoration) ->
     @displayBuffer.removeDecorationFromBufferRow(bufferRow, decoration)
 
+  addDecorationToBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
+    @displayBuffer.addDecorationToBufferRowRange(startBufferRow, endBufferRow, decoration)
+
+  removeDecorationFromBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
+    @displayBuffer.removeDecorationFromBufferRowRange(startBufferRow, endBufferRow, decoration)
+
   addDecorationForMarker: (marker, decoration) ->
     @displayBuffer.addDecorationForMarker(marker, decoration)
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1115,8 +1115,8 @@ class Editor extends Model
   # decorationPattern - the {Object} decoration type to filter by eg. `{type: 'gutter', class: 'linter-error'}`
   #
   # Returns an {Array} of the removed decorations
-  removeDecorationFromBufferRow: (bufferRow, decoration) ->
-    @displayBuffer.removeDecorationFromBufferRow(bufferRow, decoration)
+  removeDecorationFromBufferRow: (bufferRow, decorationPattern) ->
+    @displayBuffer.removeDecorationFromBufferRow(bufferRow, decorationPattern)
 
   # Public: Adds a decoration to line numbers in a buffer row range
   #
@@ -1155,8 +1155,8 @@ class Editor extends Model
   # decorationPattern - the {Object} decoration type to filter by eg. `{type: 'gutter', class: 'linter-error'}`
   #
   # Returns nothing
-  removeDecorationForMarker: (marker, decoration) ->
-    @displayBuffer.removeDecorationForMarker(marker, decoration)
+  removeDecorationForMarker: (marker, decorationPattern) ->
+    @displayBuffer.removeDecorationForMarker(marker, decorationPattern)
 
   # Public: Get the {DisplayBufferMarker} for the given marker id.
   getMarker: (id) ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1058,27 +1058,103 @@ class Editor extends Model
       selection.insertText(fn(text))
       selection.setBufferRange(range)
 
+  # Public: Get all the decorations for a buffer row.
+  #
+  # bufferRow - the {int} buffer row
+  # decorationType - the {String} decoration type to filter by eg. 'gutter'
+  #
+  # Returns an {Array} of decorations in the form `[{type: 'gutter', class: 'someclass'}, ...]`
+  # Returns an empty array when no decorations are found
   decorationsForBufferRow: (bufferRow, decorationType) ->
     @displayBuffer.decorationsForBufferRow(bufferRow, decorationType)
 
+  # Public: Get all the decorations for a range of buffer rows (inclusive)
+  #
+  # startBufferRow - the {int} start of the buffer row range
+  # endBufferRow - the {int} end of the buffer row range (inclusive)
+  # decorationType - the {String} decoration type to filter by eg. 'gutter'
+  #
+  # Returns an {Object} of decorations in the form `{23: [{type: 'gutter', class: 'someclass'}, ...], 24: [...]}`
+  # Returns an {Object} with keyed with all buffer rows in the range containing empty {Array}s when no decorations are found
   decorationsForBufferRowRange: (startBufferRow, endBufferRow, decorationType) ->
     @displayBuffer.decorationsForBufferRowRange(startBufferRow, endBufferRow, decorationType)
 
+  # Public: Adds a decoration to a buffer row. For example, use to mark a gutter
+  # line number with a class by using the form `{type: 'gutter', class: 'linter-error'}`
+  #
+  # bufferRow - the {int} buffer row
+  # decoration - the {Object} decoration type to filter by eg. `{type: 'gutter', class: 'linter-error'}`
+  #
+  # Returns nothing
   addDecorationToBufferRow: (bufferRow, decoration) ->
     @displayBuffer.addDecorationToBufferRow(bufferRow, decoration)
 
+  # Public: Removes a decoration from a buffer row.
+  #
+  # ```coffee
+  # editor.removeDecorationFromBufferRow(2, {type: 'gutter', class: 'linter-error'})
+  # ```
+  #
+  # All decorations matching a pattern will be removed. For example, you might
+  # have decorations with a namespace like this attached to a row:
+  #
+  # ```coffee
+  # [
+  #   {type: 'gutter', namespace: 'myns', class: 'something'},
+  #   {type: 'gutter', namespace: 'myns', class: 'something-else'}
+  # ]
+  # ```
+  #
+  # You can remove both with:
+  #
+  # ```coffee
+  # editor.removeDecorationFromBufferRow(2, {namespace: 'myns'})
+  # ```
+  #
+  # bufferRow - the {int} buffer row
+  # decorationPattern - the {Object} decoration type to filter by eg. `{type: 'gutter', class: 'linter-error'}`
+  #
+  # Returns an {Array} of the removed decorations
   removeDecorationFromBufferRow: (bufferRow, decoration) ->
     @displayBuffer.removeDecorationFromBufferRow(bufferRow, decoration)
 
+  # Public: Adds a decoration to line numbers in a buffer row range
+  #
+  # startBufferRow - the {int} start of the buffer row range
+  # endBufferRow - the {int} end of the buffer row range (inclusive)
+  # decoration - the {Object} decoration type to filter by eg. `{type: 'gutter', class: 'linter-error'}`
+  #
+  # Returns nothing
   addDecorationToBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
     @displayBuffer.addDecorationToBufferRowRange(startBufferRow, endBufferRow, decoration)
 
+  # Public: Removes a decoration from line numbers in a buffer row range
+  #
+  # startBufferRow - the {int} start of the buffer row range
+  # endBufferRow - the {int} end of the buffer row range (inclusive)
+  # decoration - the {Object} decoration type to filter by eg. `{type: 'gutter', class: 'linter-error'}`
+  #
+  # Returns nothing
   removeDecorationFromBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
     @displayBuffer.removeDecorationFromBufferRowRange(startBufferRow, endBufferRow, decoration)
 
+  # Public: Adds a decoration that tracks a {Marker}. When the marker moves,
+  # is invalidated, or is destroyed, the decoration will be updated to reflect the marker's state.
+  #
+  # marker - the {Marker} you want this decoration to follow
+  # decoration - the {Object} decoration type to filter by eg. `{type: 'gutter', class: 'linter-error'}`
+  #
+  # Returns nothing
   addDecorationForMarker: (marker, decoration) ->
     @displayBuffer.addDecorationForMarker(marker, decoration)
 
+  # Public: Removes all decorations associated with a {Marker} that match a
+  # `decorationPattern` and stop tracking the {Marker}.
+  #
+  # marker - the {Marker} to detach from
+  # decorationPattern - the {Object} decoration type to filter by eg. `{type: 'gutter', class: 'linter-error'}`
+  #
+  # Returns nothing
   removeDecorationForMarker: (marker, decoration) ->
     @displayBuffer.removeDecorationForMarker(marker, decoration)
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1263,6 +1263,7 @@ class Editor extends Model
   addCursor: (marker) ->
     cursor = new Cursor(editor: this, marker: marker)
     @cursors.push(cursor)
+    @addDecorationForMarker(marker, {class: 'cursor-line'})
     @emit 'cursor-added', cursor
     cursor
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1126,7 +1126,8 @@ class Editor extends Model
   #
   # Returns nothing
   addDecorationToBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
-    @displayBuffer.addDecorationToBufferRowRange(startBufferRow, endBufferRow, decoration)
+    @batchUpdates =>
+      @displayBuffer.addDecorationToBufferRowRange(startBufferRow, endBufferRow, decoration)
 
   # Public: Removes a decoration from line numbers in a buffer row range
   #
@@ -1136,7 +1137,8 @@ class Editor extends Model
   #
   # Returns nothing
   removeDecorationFromBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
-    @displayBuffer.removeDecorationFromBufferRowRange(startBufferRow, endBufferRow, decoration)
+    @batchUpdates =>
+      @displayBuffer.removeDecorationFromBufferRowRange(startBufferRow, endBufferRow, decoration)
 
   # Public: Adds a decoration that tracks a {Marker}. When the marker moves,
   # is invalidated, or is destroyed, the decoration will be updated to reflect the marker's state.

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1126,8 +1126,7 @@ class Editor extends Model
   #
   # Returns nothing
   addDecorationToBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
-    @batchUpdates =>
-      @displayBuffer.addDecorationToBufferRowRange(startBufferRow, endBufferRow, decoration)
+    @displayBuffer.addDecorationToBufferRowRange(startBufferRow, endBufferRow, decoration)
 
   # Public: Removes a decoration from line numbers in a buffer row range
   #
@@ -1137,8 +1136,7 @@ class Editor extends Model
   #
   # Returns nothing
   removeDecorationFromBufferRowRange: (startBufferRow, endBufferRow, decoration) ->
-    @batchUpdates =>
-      @displayBuffer.removeDecorationFromBufferRowRange(startBufferRow, endBufferRow, decoration)
+    @displayBuffer.removeDecorationFromBufferRowRange(startBufferRow, endBufferRow, decoration)
 
   # Public: Adds a decoration that tracks a {Marker}. When the marker moves,
   # is invalidated, or is destroyed, the decoration will be updated to reflect the marker's state.

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -10,6 +10,7 @@ GutterComponent = React.createClass
   displayName: 'GutterComponent'
   mixins: [SubscriberMixin]
   decorationType: 'gutter-class'
+  decorationRenderDelay: 100
 
   dummyLineNumberNode: null
 
@@ -194,4 +195,11 @@ GutterComponent = React.createClass
     if change.decoration.type == @decorationType
       @decoratorUpdates[change.bufferRow] ?= []
       @decoratorUpdates[change.bufferRow].push change
+      @renderDecorations()
+
+  renderDecorations: ->
+    clearTimeout(@decorationRenderTimeout) if @decorationRenderTimeout
+    render = =>
       @forceUpdate()
+      @decorationRenderTimeout = null
+    @decorationRenderTimeout = setTimeout(render, @decorationRenderDelay)

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -162,9 +162,10 @@ GutterComponent = React.createClass
       for decoration in previousDecorations
         node.classList.remove(decoration.class) if not contains(decorations, decoration)
 
-    for decoration in decorations
-      if not contains(previousDecorations, decoration) and (not softWrapped or softWrapped and decoration.softWrap)
-        node.classList.add(decoration.class)
+    if decorations?
+      for decoration in decorations
+        if not contains(previousDecorations, decoration) and (not softWrapped or softWrapped and decoration.softWrap)
+          node.classList.add(decoration.class)
 
     unless @screenRowsByLineNumberId[lineNumberId] is screenRow
       {lineHeightInPixels} = @props

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -9,7 +9,6 @@ module.exports =
 GutterComponent = React.createClass
   displayName: 'GutterComponent'
   mixins: [SubscriberMixin]
-  decorationType: 'gutter'
   decorationRenderDelay: 100
 
   dummyLineNumberNode: null
@@ -146,7 +145,7 @@ GutterComponent = React.createClass
     classes.push 'foldable' if not softWrapped and @props.editor.isFoldableAtBufferRow(bufferRow)
     classes.push 'folded' if @props.editor.isFoldedAtBufferRow(bufferRow)
 
-    decorations = @props.editor.decorationsForBufferRow(bufferRow, @decorationType)
+    decorations = @props.editor.decorationsForBufferRow(bufferRow, 'gutter')
     for decoration in decorations
       classes.push(decoration.class) if not softWrapped or softWrapped and decoration.softWrap
 
@@ -192,7 +191,7 @@ GutterComponent = React.createClass
     if condition then node.classList.add(klass) else node.classList.remove(klass)
 
   onDecorationChanged: (change) ->
-    if change.decoration.type == @decorationType
+    if change.decoration.type is 'gutter'
       @decoratorUpdates[change.bufferRow] ?= []
       @decoratorUpdates[change.bufferRow].push change
       @renderDecorations()

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -9,7 +9,6 @@ module.exports =
 GutterComponent = React.createClass
   displayName: 'GutterComponent'
   mixins: [SubscriberMixin]
-  decorationRenderDelay: 100
 
   dummyLineNumberNode: null
 
@@ -197,8 +196,8 @@ GutterComponent = React.createClass
       @renderDecorations()
 
   renderDecorations: ->
-    clearTimeout(@decorationRenderTimeout) if @decorationRenderTimeout
+    clearImmediate(@decorationRenderImmediate) if @decorationRenderImmediate
     render = =>
       @forceUpdate()
-      @decorationRenderTimeout = null
-    @decorationRenderTimeout = setTimeout(render, @decorationRenderDelay)
+      @decorationRenderImmediate = null
+    @decorationRenderImmediate = setImmediate(render)

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -9,7 +9,7 @@ module.exports =
 GutterComponent = React.createClass
   displayName: 'GutterComponent'
   mixins: [SubscriberMixin]
-  decorationType: 'gutter-class'
+  decorationType: 'gutter'
   decorationRenderDelay: 100
 
   dummyLineNumberNode: null

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -27,6 +27,13 @@ GutterComponent = React.createClass
 
   componentDidMount: ->
     @appendDummyLineNumber()
+    @subscribeToEditor()
+
+  componentWillUnmount: ->
+    @unsubscribe()
+
+  subscribeToEditor: ->
+    @subscribe @props.editor, 'decoration-changed', @onDecorationChanged
 
   # Only update the gutter if the visible row range has changed or if a
   # non-zero-delta change to the screen lines has occurred within the current
@@ -168,3 +175,5 @@ GutterComponent = React.createClass
   toggleClass: (node, klass, condition) ->
     if condition then node.classList.add(klass) else node.classList.remove(klass)
 
+  onDecorationChanged: (change) ->
+    @forceUpdate()

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -14,9 +14,9 @@ GutterComponent = React.createClass
   dummyLineNumberNode: null
 
   render: ->
-    {scrollHeight, scrollTop, onClick} = @props
+    {scrollHeight, scrollTop} = @props
 
-    div className: 'gutter', onClick: onClick,
+    div className: 'gutter', onClick: @onClick,
       div className: 'line-numbers', ref: 'lineNumbers', style:
         height: scrollHeight
         WebkitTransform: "translate3d(0px, #{-scrollTop}px, 0px)"
@@ -179,6 +179,18 @@ GutterComponent = React.createClass
 
   lineNumberNodeForScreenRow: (screenRow) ->
     @lineNumberNodesById[@lineNumberIdsByScreenRow[screenRow]]
+
+  onClick: (event) ->
+    {editor} = @props
+    {target} = event
+    lineNumber = target.parentNode
+
+    if target.classList.contains('icon-right') and lineNumber.classList.contains('foldable')
+      bufferRow = parseInt(lineNumber.getAttribute('data-buffer-row'))
+      if lineNumber.classList.contains('folded')
+        editor.unfoldBufferRow(bufferRow)
+      else
+        editor.foldBufferRow(bufferRow)
 
 # Created because underscore uses === not _.isEqual, which we need
 contains = (array, target) ->

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -14,9 +14,9 @@ GutterComponent = React.createClass
   dummyLineNumberNode: null
 
   render: ->
-    {scrollHeight, scrollTop} = @props
+    {scrollHeight, scrollTop, onClick} = @props
 
-    div className: 'gutter',
+    div className: 'gutter', onClick: onClick,
       div className: 'line-numbers', ref: 'lineNumbers', style:
         height: scrollHeight
         WebkitTransform: "translate3d(0px, #{-scrollTop}px, 0px)"

--- a/src/react-editor-view.coffee
+++ b/src/react-editor-view.coffee
@@ -1,4 +1,5 @@
 {View, $} = require 'space-pen'
+Grim = require 'Grim'
 React = require 'react-atom-fork'
 EditorComponent = require './editor-component'
 {defaults} = require 'underscore-plus'
@@ -53,9 +54,11 @@ class ReactEditorView extends View
 
     @gutter = $(node).find('.gutter')
     @gutter.removeClassFromAllLines = (klass) =>
+      Grim.deprecate 'You no longer need to manually add and remove classes. Use `Editor::removeDecorationFromBufferRow()` and related functions'
       @gutter.find('.line-number').removeClass(klass)
 
     @gutter.addClassToLine = (bufferRow, klass) =>
+      Grim.deprecate 'You no longer need to manually add and remove classes. Use `Editor::addDecorationToBufferRow()` and related functions'
       lines = @gutter.find("[data-buffer-row='#{bufferRow}']")
       lines.addClass(klass)
       lines.length > 0

--- a/static/editor.less
+++ b/static/editor.less
@@ -69,11 +69,13 @@
   .gutter {
     .line-number {
       white-space: nowrap;
-      padding: 0 .5em;
+      padding-left: .5em;
 
       .icon-right {
-        padding: 0;
-        padding-left: .1em;
+        padding: 0 .4em;
+        &:before {
+          text-align: center;
+        }
       }
     }
   }
@@ -121,7 +123,7 @@
   visibility: hidden;
   padding-left: .1em;
   padding-right: .5em;
-  opacity: .7;
+  opacity: .6;
 }
 
 .editor .gutter:hover .line-number.foldable .icon-right {


### PR DESCRIPTION
A decoration is an object attached to a buffer row. Here's a decoration:

``` js
{type: 'gutter', class: 'my-sweet-class'}
```

And here is how to attach it to a buffer row:

``` coffee
editor.addDecorationToBufferRow(1, {type: 'gutter', class: 'my-sweet-class'})
```

Currently the only thing that renders a decoration is the `GutterComponent` and it only cares about decorations with `type: 'gutter'`. It will add the decoration's `class` property as a class to the proper line-number node in the gutter. 

The neat thing is that the `GutterComponent` handles all the bs with updating as line number nodes are added and removed. So no more watching the `display-updated` event and manually updating classes in packages like `git-diff` and `bookmarks`.
### Markers

There is a marker API as well. Packages like `bookmarks` should not be watching the markers and updating their decorations manually. 

``` coffee
marker = editor.displayBuffer.markBufferRange([[2, 13], [3, 15]], class: 'my-marker', invalidate: 'inside')
decoration = {type: 'gutter', class: 'marker-class'}
editor.addDecorationToMarker(marker, decoration)
```

The class `marker-class` will properly track the marker's rows on the gutter.
### Options

Sometimes you might want a decoration to show on wrapped lines (git-diff), and sometimes you dont (bookmarks), so there is an option: `softWrap`. Like so: `{type: 'gutter', class: 'marker-class', softWrap: true}`. If you have ideas on how better to pass options, let me know.
### Removing decorations

Currently you can only remove them on each buffer row. Like finding markers, it will remove any decoration that matches the pattern.

``` coffee
editor.addDecorationToBufferRow(1, {type: 'gutter', class: 'my-sweet-class', namespace: 'cats'})
editor.addDecorationToBufferRow(1, {type: 'gutter', class: 'my-other-class', namespace: 'cats'})

# this will remove the previous two
editor.removeDecorationFromBufferRow(1, {namespace: 'cats'})

# usually you'll probably just have one class and do this
editor.removeDecorationFromBufferRow(1, {type: 'gutter', class: 'my-other-class'})
```

The api works the same for marker decorations. 
### TODO
- [x] Deprecate the old gutter methods
- [x] Figure out where to put this api. @nathansobo on the `ReactEditorView`? Now its on `Editor`.
- [x] Maybe pull the folds out to be decorations??
- [x] Docs
- [x] Tests for `cursor-line` decoration
- [x] Add a `cursor-line-no-selection` decoration
- [x] Tests for 'typeless' decorations

Fixes #1984
