### PR TITLE
Fix unresponsive text input after double-clicking

### DIFF
--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -462,8 +462,8 @@ EditorComponent = React.createClass
         when 3 then editor.selectLine()
 
     @selectToMousePositionUntilMouseUp(event)
-    e.preventDefault()
-    e.stopPropagation()
+    event.preventDefault()
+    event.stopPropagation()
 
   onStylesheetsChanged: (stylesheet) ->
     @refreshScrollbars() if @containsScrollbarSelector(stylesheet)

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -462,8 +462,8 @@ EditorComponent = React.createClass
         when 3 then editor.selectLine()
 
     @selectToMousePositionUntilMouseUp(event)
-    e.preventDefault();
-    e.stopPropagation();
+    e.preventDefault()
+    e.stopPropagation()
 
   onStylesheetsChanged: (stylesheet) ->
     @refreshScrollbars() if @containsScrollbarSelector(stylesheet)

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -462,6 +462,8 @@ EditorComponent = React.createClass
         when 3 then editor.selectLine()
 
     @selectToMousePositionUntilMouseUp(event)
+    e.preventDefault();
+    e.stopPropagation();
 
   onStylesheetsChanged: (stylesheet) ->
     @refreshScrollbars() if @containsScrollbarSelector(stylesheet)


### PR DESCRIPTION
This fixes the bug, but it raises some concerns as well. I'll go though how I debugged this in case it helps shed some more light on the problem.

TL;DR it is fixed but I don't know what was causing it.

Atom handles text input using a hidden input field. I suspected that the problem was this hidden input field was losing focus, so I added `setInterval((-> console.log document.activeElement), 1000)` to my `~/.atom/init.coffee` file. This logs if the hidden input loses focus. After double clicking around awhile the hidden input would lose focus and the body element would become focused.

I noticed the mouseDown event was being caught in an unknown parent of EditorComponent and would focus the body element. When the dev tools are used to look at what is bound to the mouseDown event you can see a react component is bound (expected) and a jquery object (unexpected):

![editor-component coffee - _users_corey_github_atom](https://cloud.githubusercontent.com/assets/596/3195476/3429481c-ed11-11e3-8a6a-0f7ac5467b94.jpg)

I solved this by making sure the mouseDown event in EditorComponent doesn't bubble. But I still wanted to know what event handler was causing this problem. I searched in Atom Core for mousedown handlers but none of those caused the problem. This led me to believe the problem was in a package, so I ran Atom in safe mode (`atom --safe`), which will start Atom with out any downloaded packages. In safe mode I could still recreate the problem. But the jquery mousedown event was no longer in the dev tools event viewer. I found out it was the color-viewer package that was adding the mousedown event handler to body, but removing that package didn't fix the problem.

So I'm left wondering what the problem was and why it only happened with the react editor.

Closes #2459
