### PR TITLE
Support 32bit build on Linux

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -18,7 +18,7 @@
     "grunt-contrib-coffee": "~0.9.0",
     "grunt-contrib-less": "~0.8.0",
     "grunt-cson": "0.8.0",
-    "grunt-download-atom-shell": "~0.7.2",
+    "grunt-download-atom-shell": "~0.8.0",
     "grunt-lesslint": "0.13.0",
     "grunt-markdown": "~0.4.0",
     "grunt-peg": "~1.1.0",

--- a/build/tasks/mkdeb-task.coffee
+++ b/build/tasks/mkdeb-task.coffee
@@ -13,9 +13,15 @@ module.exports = (grunt) ->
   grunt.registerTask 'mkdeb', 'Create debian package', ->
     done = @async()
 
+    if process.arch is 'ia32'
+      arch = 'i386'
+    else if process.arch is 'x64'
+      arch = 'amd64'
+    else
+      return done("Unsupported arch #{process.arch}")
+
     {name, version, description} = grunt.file.readJSON('package.json')
     section = 'devel'
-    arch = 'amd64'
     maintainer = 'GitHub <atom@github.com>'
     data = {name, version, description, section, arch, maintainer}
 
@@ -27,5 +33,5 @@ module.exports = (grunt) ->
     buildDir = grunt.config.get('atom.buildDir')
 
     cmd = path.join('script', 'mkdeb')
-    args = [version, control, desktop, icon, buildDir]
+    args = [version, arch, control, desktop, icon, buildDir]
     spawn({cmd, args}, done)

--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -4,7 +4,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 
 ## Requirements
 
-  * OS with 64-bit architecture
+  * OS with 64-bit or 32-bit architecture
   * [node.js](http://nodejs.org/download/) v0.10.x
   * [npm](http://www.npmjs.org/) v1.4.x  
   * libgnome-keyring-dev

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "url": "http://github.com/atom/atom/raw/master/LICENSE.md"
     }
   ],
-  "atomShellVersion": "0.12.7",
+  "atomShellVersion": "0.13.0",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^0.26.0",

--- a/script/mkdeb
+++ b/script/mkdeb
@@ -8,14 +8,15 @@ ROOT=`readlink -f $(dirname $SCRIPT)/..`
 cd $ROOT
 
 VERSION="$1"
-CONTROL_FILE="$2"
-DESKTOP_FILE="$3"
-ICON_FILE="$4"
-DEB_PATH="$5"
+ARCH="$2"
+CONTROL_FILE="$3"
+DESKTOP_FILE="$4"
+ICON_FILE="$5"
+DEB_PATH="$6"
 
 TARGET_ROOT="`mktemp -d`"
 chmod 755 "$TARGET_ROOT"
-TARGET="$TARGET_ROOT/atom-$VERSION-amd64"
+TARGET="$TARGET_ROOT/atom-$VERSION-$ARCH"
 
 mkdir -p "$TARGET/usr"
 env INSTALL_PREFIX="$TARGET/usr" script/grunt install
@@ -30,5 +31,5 @@ mkdir -p "$TARGET/usr/share/pixmaps"
 cp "$ICON_FILE" "$TARGET/usr/share/pixmaps"
 
 dpkg-deb -b "$TARGET"
-mv "$TARGET_ROOT/atom-$VERSION-amd64.deb" "$DEB_PATH"
+mv "$TARGET_ROOT/atom-$VERSION-$ARCH.deb" "$DEB_PATH"
 rm -rf $TARGET_ROOT


### PR DESCRIPTION
This PR updates atom-shell to v0.13.0 which has support for 32bit Linux, it also enables `./script/grunt mkdeb` to generate `i386` package.
