### PR TITLE
better script/clean removal for windows

### DIFF
--- a/script/clean
+++ b/script/clean
@@ -3,7 +3,7 @@ var cp = require('./utils/child-process-wrapper.js');
 var path = require('path');
 var os = require('os');
 
-var removeCommand = process.platform === 'win32' ? 'del /F /Q /S ' : 'rm -rf ';
+var removeCommand = process.platform === 'win32' ? 'rmdir /S /Q ' : 'rm -rf ';
 var productName = require('../package.json').productName;
 
 process.chdir(path.dirname(__dirname));


### PR DESCRIPTION
Now `script/clean` uses `del /F /Q /S` to cleanup the folders but `del /S` deletes specified files from all subdirectories, so if we pass a folder as a parameter it will only delete the files within the folder and all subfolders recursively but not the actual folders. And this can cause problems, see Issue #2487

A better way is to use `rmdir /S /Q` as it takes care of the folder itself and it's contents.
/S - removes all directories and files in the specified directory in addition to the directory itself. (removes the directory tree)
/Q - obvious this is quite mode

I tested this approach on a couple machines that needed a clean before building and works OK with `rmdir`. It might give a warning in the console like `The system cannot find the file specified.` because not all of them are there but it can be ignored as the script will finish running.
