### PR TITLE
Add classic copy/paste to Linux and Win32 keymaps

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -29,6 +29,8 @@
   'ctrl-x': 'core:cut'
   'ctrl-c': 'core:copy'
   'ctrl-v': 'core:paste'
+  'ctrl-insert': 'core:copy'
+  'shift-insert': 'core:paste'
   'shift-up': 'core:select-up'
   'shift-down': 'core:select-down'
   'shift-left': 'core:select-left'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -31,6 +31,8 @@
   'ctrl-x': 'core:cut'
   'ctrl-c': 'core:copy'
   'ctrl-v': 'core:paste'
+  'ctrl-insert': 'core:copy'
+  'shift-insert': 'core:paste'
   'shift-up': 'core:select-up'
   'shift-down': 'core:select-down'
   'shift-left': 'core:select-left'


### PR DESCRIPTION
For issue:  "Paste via Shift+Insert not working (Windows)" #2546
This has been added to the linux and win32 keymaps.

:memo: 

```
Ctrl+Insert: Copy
Shift+Insert: Paste
```

![image](https://cloud.githubusercontent.com/assets/7287076/3217351/9eef6c88-efde-11e3-9e26-3e04d7b06bac.png)
