### PR TITLE
Slow the scroll speed

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -1083,21 +1083,46 @@ describe "EditorComponent", ->
       expect(horizontalScrollbarNode.scrollWidth).toBe gutterNode.offsetWidth + editor.getScrollWidth()
 
   describe "mousewheel events", ->
-    it "updates the scrollLeft or scrollTop on mousewheel events depending on which delta is greater (x or y)", ->
-      node.style.height = 4.5 * lineHeightInPixels + 'px'
-      node.style.width = 20 * charWidth + 'px'
-      component.measureScrollView()
+    beforeEach ->
+      atom.config.set('editor.scrollSensitivity', 100)
 
-      expect(verticalScrollbarNode.scrollTop).toBe 0
-      expect(horizontalScrollbarNode.scrollLeft).toBe 0
+    describe "updating scrollTop and scrollLeft", ->
+      beforeEach ->
+        node.style.height = 4.5 * lineHeightInPixels + 'px'
+        node.style.width = 20 * charWidth + 'px'
+        component.measureScrollView()
 
-      node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: -5, wheelDeltaY: -10))
-      expect(verticalScrollbarNode.scrollTop).toBe 10
-      expect(horizontalScrollbarNode.scrollLeft).toBe 0
+      it "updates the scrollLeft or scrollTop on mousewheel events depending on which delta is greater (x or y)", ->
+        expect(verticalScrollbarNode.scrollTop).toBe 0
+        expect(horizontalScrollbarNode.scrollLeft).toBe 0
 
-      node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: -15, wheelDeltaY: -5))
-      expect(verticalScrollbarNode.scrollTop).toBe 10
-      expect(horizontalScrollbarNode.scrollLeft).toBe 15
+        node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: -5, wheelDeltaY: -10))
+        expect(verticalScrollbarNode.scrollTop).toBe 10
+        expect(horizontalScrollbarNode.scrollLeft).toBe 0
+
+        node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: -15, wheelDeltaY: -5))
+        expect(verticalScrollbarNode.scrollTop).toBe 10
+        expect(horizontalScrollbarNode.scrollLeft).toBe 15
+
+      it "updates the scrollLeft or scrollTop according to the scroll sensitivity", ->
+        atom.config.set('editor.scrollSensitivity', 50)
+        node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: -5, wheelDeltaY: -10))
+        expect(verticalScrollbarNode.scrollTop).toBe 5
+        expect(horizontalScrollbarNode.scrollLeft).toBe 0
+
+        node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: -15, wheelDeltaY: -5))
+        expect(verticalScrollbarNode.scrollTop).toBe 5
+        expect(horizontalScrollbarNode.scrollLeft).toBe 7
+
+      it "uses the previous scrollSensitivity when the value is not an int", ->
+        atom.config.set('editor.scrollSensitivity', 'nope')
+        node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: 0, wheelDeltaY: -10))
+        expect(verticalScrollbarNode.scrollTop).toBe 10
+
+      it "parses negative scrollSensitivity values as positive", ->
+        atom.config.set('editor.scrollSensitivity', -50)
+        node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: 0, wheelDeltaY: -10))
+        expect(verticalScrollbarNode.scrollTop).toBe 5
 
     describe "when the mousewheel event's target is a line", ->
       it "keeps the line on the DOM if it is scrolled off-screen", ->

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -33,6 +33,7 @@ EditorComponent = React.createClass
   pendingHorizontalScrollDelta: 0
   mouseWheelScreenRow: null
   mouseWheelScreenRowClearDelay: 150
+  scrollSensitivity: 0.4
   scrollViewMeasurementRequested: false
   measureLineHeightAndDefaultCharWidthWhenShown: false
   inputEnabled: true
@@ -141,6 +142,7 @@ EditorComponent = React.createClass
     @pendingChanges = []
     @props.editor.manageScrollPosition = true
     @observeConfig()
+    @setScrollSensitivity(atom.config.get('editor.scrollSensitivity'))
 
   componentDidMount: ->
     {editor} = @props
@@ -383,6 +385,7 @@ EditorComponent = React.createClass
     @subscribe atom.config.observe 'editor.showIndentGuide', @setShowIndentGuide
     @subscribe atom.config.observe 'editor.invisibles', @setInvisibles
     @subscribe atom.config.observe 'editor.showInvisibles', @setShowInvisibles
+    @subscribe atom.config.observe 'editor.scrollSensitivity', @setScrollSensitivity
 
   onFocus: ->
     @refs.input.focus()
@@ -425,10 +428,10 @@ EditorComponent = React.createClass
     {wheelDeltaX, wheelDeltaY} = event
     if Math.abs(wheelDeltaX) > Math.abs(wheelDeltaY)
       # Scrolling horizontally
-      @pendingHorizontalScrollDelta -= Math.round(wheelDeltaX * .4)
+      @pendingHorizontalScrollDelta -= Math.round(wheelDeltaX * @scrollSensitivity)
     else
       # Scrolling vertically
-      @pendingVerticalScrollDelta -= Math.round(wheelDeltaY * .4)
+      @pendingVerticalScrollDelta -= Math.round(wheelDeltaY * @scrollSensitivity)
       @mouseWheelScreenRow = @screenRowForNode(event.target)
       @clearMouseWheelScreenRowAfterDelay ?= debounce(@clearMouseWheelScreenRow, @mouseWheelScreenRowClearDelay)
       @clearMouseWheelScreenRowAfterDelay()
@@ -731,6 +734,10 @@ EditorComponent = React.createClass
 
   setShowInvisibles: (showInvisibles) ->
     @setState({showInvisibles})
+
+  setScrollSensitivity: (scrollSensitivity) ->
+    if scrollSensitivity = parseInt(scrollSensitivity)
+      @scrollSensitivity = Math.abs(scrollSensitivity) / 100
 
   screenPositionForMouseEvent: (event) ->
     pixelPosition = @pixelPositionForMouseEvent(event)

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -425,10 +425,10 @@ EditorComponent = React.createClass
     {wheelDeltaX, wheelDeltaY} = event
     if Math.abs(wheelDeltaX) > Math.abs(wheelDeltaY)
       # Scrolling horizontally
-      @pendingHorizontalScrollDelta -= wheelDeltaX
+      @pendingHorizontalScrollDelta -= Math.round(wheelDeltaX * .4)
     else
       # Scrolling vertically
-      @pendingVerticalScrollDelta -= wheelDeltaY
+      @pendingVerticalScrollDelta -= Math.round(wheelDeltaY * .4)
       @mouseWheelScreenRow = @screenRowForNode(event.target)
       @clearMouseWheelScreenRowAfterDelay ?= debounce(@clearMouseWheelScreenRow, @mouseWheelScreenRowClearDelay)
       @clearMouseWheelScreenRowAfterDelay()

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -56,6 +56,7 @@ class EditorView extends View
     softWrap: false
     softTabs: true
     softWrapAtPreferredLineLength: false
+    scrollSensitivity: 40
 
   @nextEditorId: 1
 


### PR DESCRIPTION
Folks have been complaining about the mousewheel scroll speed -- it's too fast. It is really really sensitive. Turns out the deltas from the mousewheel event are generally regarded as [too fast](https://github.com/brandonaaron/jquery-mousewheel/issues/36). 

In my tests, the browser scroll speed is somewhere between 30 and 40% of atom's scroll speed. So I've slowed it down by that much. It feels way better. 

[MDN](https://developer.mozilla.org/en-US/docs/DOM/DOM_event_reference/mousewheel) says the values are different depending on system and attached mouse. Anyone have an actual windows machine they can test this out on? @kevinsawicki are you using a real windows machine?

It is an option called `editor.scrollSensitivity`. Not sure what the units should be. I have it as a percentage of the original value, so the default is 40. It depends on what this feels like on windows.

Refs #1906
