### PR TITLE
Change line commenting to uncomment if all non-blank lines are commented out

### DIFF
--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -52,11 +52,16 @@ describe "LanguageMode", ->
         languageMode.toggleLineCommentsForBufferRows(0, 0)
         expect(buffer.lineForRow(0)).toBe "  // "
 
-        buffer.setText ('    a\n  \n    b')
+        buffer.setText('    a\n  \n    b')
         languageMode.toggleLineCommentsForBufferRows(0, 2)
         expect(buffer.lineForRow(0)).toBe "    // a"
         expect(buffer.lineForRow(1)).toBe "    // "
         expect(buffer.lineForRow(2)).toBe "    // b"
+
+        buffer.setText('    \n    // var i;')
+        languageMode.toggleLineCommentsForBufferRows(0, 1)
+        expect(buffer.lineForRow(0)).toBe '    '
+        expect(buffer.lineForRow(1)).toBe '    var i;'
 
     describe ".rowRangeForCodeFoldAtBufferRow(bufferRow)", ->
       it "returns the start/end rows of the foldable region starting at the given row", ->

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -64,15 +64,15 @@ class LanguageMode
           buffer.insert([start, indentLength], commentStartString)
           buffer.insert([end, buffer.lineLengthForRow(end)], commentEndString)
     else
-      blankRegex = new OnigRegExp("^\\s*$")
-
       allBlank = true
-      allBlankOrCommented = [start..end].every (row) ->
-        line = buffer.lineForRow(row)
-        blank = not line or blankRegex.test(line)
+      allBlankOrCommented = true
 
-        allBlank = allBlank and blank
-        blank or commentStartRegex.test(line)
+      for row in [start..end]
+        line = buffer.lineForRow(row)
+        blank = line?.match(/^\s*$/)
+
+        allBlank = false unless blank
+        allBlankOrCommented = false unless blank or commentStartRegex.test(line)
 
       shouldUncomment = allBlankOrCommented and not allBlank
 

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -41,9 +41,9 @@ class LanguageMode
     buffer = @editor.buffer
     commentStartRegexString = _.escapeRegExp(commentStartString).replace(/(\s+)$/, '(?:$1)?')
     commentStartRegex = new OnigRegExp("^(\\s*)(#{commentStartRegexString})")
-    shouldUncomment = commentStartRegex.test(buffer.lineForRow(start))
 
     if commentEndString
+      shouldUncomment = commentStartRegex.test(buffer.lineForRow(start))
       if shouldUncomment
         commentEndRegexString = _.escapeRegExp(commentEndString).replace(/^(\s+)/, '(?:$1)?')
         commentEndRegex = new OnigRegExp("(#{commentEndRegexString})(\\s*)$")
@@ -64,10 +64,18 @@ class LanguageMode
           buffer.insert([start, indentLength], commentStartString)
           buffer.insert([end, buffer.lineLengthForRow(end)], commentEndString)
     else
-      if shouldUncomment and start isnt end
-        shouldUncomment = [start+1..end].every (row) ->
-          line = buffer.lineForRow(row)
-          not line or commentStartRegex.test(line)
+      blankRegex = new OnigRegExp("^\\s*$")
+
+      allBlank = true
+      allBlankOrCommented = [start..end].every (row) ->
+        line = buffer.lineForRow(row)
+        blank = not line or blankRegex.test(line)
+
+        allBlank = allBlank and blank
+        blank or commentStartRegex.test(line)
+
+      shouldUncomment = allBlankOrCommented and not allBlank
+
       if shouldUncomment
         for row in [start..end]
           if match = commentStartRegex.search(buffer.lineForRow(row))


### PR DESCRIPTION
Fixes #2526

This slightly alters the heuristic for deciding whether to uncomment or to comment blocks of code. Previously, it would key off the first line of code and only if that was commented would it check the other lines. Now it checks all lines of code and uncomments the block if all non-blank lines are commented out.
