### PR TITLE
Fix NPM verification failures after `script/clean` on Win32

### DIFF
--- a/script/utils/verify-requirements.js
+++ b/script/utils/verify-requirements.js
@@ -43,7 +43,10 @@ function verifyNpm(cb) {
   var localNpmPath = path.resolve(__dirname, '..', '..', 'build', 'node_modules', '.bin', 'npm');
   if (process.platform === 'win32')
     localNpmPath += ".cmd";
+
   var npmCommand = fs.existsSync(localNpmPath) ? localNpmPath : 'npm';
+  if (npmCommand === 'npm' && process.platform === 'win32')
+    npmCommand += ".cmd";
 
   childProcess.execFile(npmCommand, ['-v'], { env: process.env }, function(err, stdout) {
     if (err)


### PR DESCRIPTION
I think npm verification is failing unfairly on me when I try to build Atom on my Windows machine.

```
C:\Users\james_000\Documents\src\atom> .\script\bootstrap
npm 1.4 is required to build Atom. An error (Error: spawn ENOENT) occured when checking the version.
C:\Users\james_000\Documents\src\atom> npm -v
1.4.9
```

After a `script/clean` on my machine, there's no local copy of npm and therefore the npm verification script defaults to `npm`, which for some reason doesn't seem to resolve correctly to the `npm.cmd`. I'm not sure why but that seems to be the behavior I'm seeing.

Using my proposed changes I see:

```
C:\Users\james_000\Documents\src\atom> .\script\bootstrap
Node: v0.10.28
npm: v1.4.9
Python: v2.7.6
```
