### PR TITLE
Outdent only if a tab is matched at the start of the line

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2258,6 +2258,15 @@ describe "Editor", ->
           editor.outdentSelectedRows()
           expect(buffer.lineForRow(0)).toBe "var quicksort = function () {"
 
+        it "outdents only up to the first non-space non-tab character", ->
+          editor.insertText(' \tfoo\t ')
+          editor.outdentSelectedRows()
+          expect(buffer.lineForRow(0)).toBe "\tfoo\t var quicksort = function () {"
+          editor.outdentSelectedRows()
+          expect(buffer.lineForRow(0)).toBe "foo\t var quicksort = function () {"
+          editor.outdentSelectedRows()
+          expect(buffer.lineForRow(0)).toBe "foo\t var quicksort = function () {"
+
       describe "when one line is selected", ->
         it "outdents line and retains editor", ->
           editor.setSelectedBufferRange([[1,4], [1,14]])

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -495,7 +495,7 @@ class Selection extends Model
   outdentSelectedRows: ->
     [start, end] = @getBufferRowRange()
     buffer = @editor.buffer
-    leadingTabRegex = new RegExp("^ {1,#{@editor.getTabLength()}}|\t")
+    leadingTabRegex = new RegExp("^( {1,#{@editor.getTabLength()}}|\t)")
     for row in [start..end]
       if matchLength = buffer.lineForRow(row).match(leadingTabRegex)?[0].length
         buffer.delete [[row, 0], [row, matchLength]]


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/2560. 

When outdenting, the `leadingTabRegex` currently matches spaces only at the beginning of the line, while tabs are matched anywhere in the line. As a result, the outdent method would eat up legit characters on lines which contain tabs after the beginning of the line.

This change tweaks the regex so that tabs are matched only at the beginning of the line.

cc @probablycorey @kevinsawicki  
