### PR TITLE
Handle textInput events in a way that works with autocomplete-plus

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -1174,28 +1174,31 @@ describe "EditorComponent", ->
     beforeEach ->
       inputNode = node.querySelector('.hidden-input')
 
+    buildTextInputEvent = ({data, target}) ->
+      event = new Event('textInput')
+      event.data = data
+      Object.defineProperty(event, 'target', get: -> target)
+      event
+
     it "inserts the newest character in the input's value into the buffer", ->
-      inputNode.value = 'x'
-      inputNode.dispatchEvent(new Event('input'))
+      node.dispatchEvent(buildTextInputEvent(data: 'x', target: inputNode))
       expect(editor.lineForBufferRow(0)).toBe 'xvar quicksort = function () {'
 
-      inputNode.value = 'xy'
-      inputNode.dispatchEvent(new Event('input'))
+      node.dispatchEvent(buildTextInputEvent(data: 'y', target: inputNode))
       expect(editor.lineForBufferRow(0)).toBe 'xyvar quicksort = function () {'
 
     it "replaces the last character if the length of the input's value doesn't increase, as occurs with the accented character menu", ->
-      inputNode.value = 'u'
-      inputNode.dispatchEvent(new Event('input'))
+      node.dispatchEvent(buildTextInputEvent(data: 'u', target: inputNode))
       expect(editor.lineForBufferRow(0)).toBe 'uvar quicksort = function () {'
 
-      inputNode.value = 'ü'
-      inputNode.dispatchEvent(new Event('input'))
+      # simulate the accented character suggestion's selection of the previous character
+      inputNode.setSelectionRange(0, 1)
+      node.dispatchEvent(buildTextInputEvent(data: 'ü', target: inputNode))
       expect(editor.lineForBufferRow(0)).toBe 'üvar quicksort = function () {'
 
     it "does not handle input events when input is disabled", ->
       component.setInputEnabled(false)
-      inputNode.value = 'x'
-      inputNode.dispatchEvent(new Event('input'))
+      node.dispatchEvent(buildTextInputEvent(data: 'x', target: inputNode))
       expect(editor.lineForBufferRow(0)).toBe 'var quicksort = function () {'
 
   describe "commands", ->

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -403,7 +403,9 @@ EditorComponent = React.createClass
     editor.insertText(event.data)
     inputNode.value = event.data
 
-    event.preventDefault()
+    # If we prevent the insertion of a space character, then the browser
+    # interprets the spacebar keypress as a page-down command.
+    event.preventDefault() unless event.data is ' '
 
   onInputFocused: ->
     @setState(focused: true)

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -82,7 +82,6 @@ EditorComponent = React.createClass
           ref: 'input'
           className: 'hidden-input'
           style: hiddenInputStyle
-          onInput: @onInput
           onFocus: @onInputFocused
           onBlur: @onInputBlurred
 
@@ -262,6 +261,7 @@ EditorComponent = React.createClass
     node = @getDOMNode()
     node.addEventListener 'mousewheel', @onMouseWheel
     node.addEventListener 'focus', @onFocus # For some reason, React's built in focus events seem to bubble
+    node.addEventListener 'textInput', @onTextInput
 
     scrollViewNode = @refs.scrollView.getDOMNode()
     scrollViewNode.addEventListener 'overflowchanged', @onScrollViewOverflowChanged
@@ -387,6 +387,24 @@ EditorComponent = React.createClass
   onFocus: ->
     @refs.input.focus()
 
+  onTextInput: (event) ->
+    return unless @isInputEnabled()
+
+    {editor} = @props
+    inputNode = event.target
+
+    # Work around of the accented character suggestion feature in OS X.
+    # Text input fires before a character is inserted, and if the browser is
+    # replacing the previous un-accented character with an accented variant, it
+    # will select backward over it.
+    selectedLength = inputNode.selectionEnd - inputNode.selectionStart
+    editor.selectLeft() if selectedLength is 1
+
+    editor.insertText(event.data)
+    inputNode.value = event.data
+
+    event.preventDefault()
+
   onInputFocused: ->
     @setState(focused: true)
 
@@ -452,18 +470,6 @@ EditorComponent = React.createClass
     scrollViewNode = @refs.scrollView.getDOMNode()
     scrollViewNode.scrollTop = 0
     scrollViewNode.scrollLeft = 0
-
-  onInput: (char, replaceLastCharacter) ->
-    return unless @inputEnabled
-
-    {editor} = @props
-
-    if replaceLastCharacter
-      editor.transact ->
-        editor.selectLeft()
-        editor.insertText(char)
-    else
-      editor.insertText(char)
 
   onMouseDown: (event) ->
     {editor} = @props

--- a/src/input-component.coffee
+++ b/src/input-component.coffee
@@ -1,4 +1,3 @@
-punycode = require 'punycode'
 {last, isEqual} = require 'underscore-plus'
 React = require 'react-atom-fork'
 {input} = require 'reactionary-atom-fork'
@@ -17,7 +16,6 @@ InputComponent = React.createClass
 
   componentDidMount: ->
     @getDOMNode().addEventListener 'paste', @onPaste
-    @getDOMNode().addEventListener 'input', @onInput
     @getDOMNode().addEventListener 'compositionupdate', @onCompositionUpdate
 
   # Don't let text accumulate in the input forever, but avoid excessive reflows
@@ -35,15 +33,6 @@ InputComponent = React.createClass
 
   onPaste: (e) ->
     e.preventDefault()
-
-  onInput: (e) ->
-    e.stopPropagation()
-    valueCharCodes = punycode.ucs2.decode(@getDOMNode().value)
-    valueLength = valueCharCodes.length
-    replaceLastChar = valueLength is @lastValueLength
-    @lastValueLength = valueLength
-    lastChar = String.fromCharCode(last(valueCharCodes))
-    @props.onInput?(lastChar, replaceLastChar)
 
   onFocus: ->
     @props.onFocus?()


### PR DESCRIPTION
Fixes #2318

This commit also changes input handling to be more like it was in the previous editor. We're using textInput rather than input events because they are emitted _before_ characters are inserted, enabling much simpler detection of characters inserted via the accented-character menu on OS X.

We're also handling these events on the editor instead of the input component, which allows events to bubble from autocomplete-plus's hidden input element.

Previously I avoided this because something about it was causing reflows in the old editor, but in this editor that doesn't seem to be a problem, and it's actually faster.
