### PR TITLE
Fix pageUp and pageDown in the react editor

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -3211,24 +3211,29 @@ describe "Editor", ->
       expect(editor.getScrollRight()).toBe (9 + editor.getHorizontalScrollMargin()) * 10
 
   describe ".pageUp/Down()", ->
-    it "scrolls one screen height up or down", ->
+    it "scrolls one screen height up or down and moves the cursor one page length", ->
       editor.manageScrollPosition = true
 
       editor.setLineHeightInPixels(10)
       editor.setHeight(50)
       expect(editor.getScrollHeight()).toBe 130
+      expect(editor.getCursorBufferPosition().row).toBe 0
 
       editor.pageDown()
       expect(editor.getScrollTop()).toBe 50
+      expect(editor.getCursorBufferPosition().row).toBe 5
 
       editor.pageDown()
       expect(editor.getScrollTop()).toBe 80
+      expect(editor.getCursorBufferPosition().row).toBe 10
 
       editor.pageUp()
       expect(editor.getScrollTop()).toBe 30
+      expect(editor.getCursorBufferPosition().row).toBe 5
 
       editor.pageUp()
       expect(editor.getScrollTop()).toBe 0
+      expect(editor.getCursorBufferPosition().row).toBe 0
 
   describe "decorations", ->
     decoration = null

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1605,10 +1605,18 @@ class Editor extends Model
     @getCursor().autoscroll()
 
   pageUp: ->
-    @setScrollTop(@getScrollTop() - @getHeight())
+    newScrollTop = @getScrollTop() - @getHeight()
+    @moveCursorUp(@getRowsPerPage())
+    @setScrollTop(newScrollTop)
 
   pageDown: ->
-    @setScrollTop(@getScrollTop() + @getHeight())
+    newScrollTop = @getScrollTop() + @getHeight()
+    @moveCursorDown(@getRowsPerPage())
+    @setScrollTop(newScrollTop)
+
+  # Returns the number of rows per page
+  getRowsPerPage: ->
+    Math.max(1, Math.ceil(@getHeight() / @getLineHeightInPixels()))
 
   moveCursors: (fn) ->
     @movingCursors = true


### PR DESCRIPTION
This moves the cursor on pageUp / pageDown

Previously it was only moving the scrollTop, but not the cursors. 

Refs #2423
