### PR TITLE
remove duplicate context menu entries

### DIFF
--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -24,11 +24,25 @@ describe "ContextMenuManager", ->
 
       contextMenu.add 'file-path',
         '.selector':
-          'another label': 'command'
+          'label': 'command'
 
       expect(contextMenu.definitions['.selector'][0].label).toEqual 'label'
       expect(contextMenu.definitions['.selector'][0].command).toEqual 'command'
       expect(contextMenu.definitions['.selector'][1]).toBeUndefined()
+
+    it 'allows duplicate commands with different labels',  ->
+      contextMenu.add 'file-path',
+        '.selector':
+          'label': 'command'
+
+      contextMenu.add 'file-path',
+        '.selector':
+          'another label': 'command'
+
+      expect(contextMenu.definitions['.selector'][0].label).toEqual 'label'
+      expect(contextMenu.definitions['.selector'][0].command).toEqual 'command'
+      expect(contextMenu.definitions['.selector'][1].label).toEqual 'another label'
+      expect(contextMenu.definitions['.selector'][1].command).toEqual 'command'
 
     it "loads submenus", ->
       contextMenu.add 'file-path',

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -17,7 +17,7 @@ describe "ContextMenuManager", ->
       expect(contextMenu.definitions['.selector'][0].label).toEqual 'label'
       expect(contextMenu.definitions['.selector'][0].command).toEqual 'command'
 
-    it 'does not load duplicates',  ->
+    it 'does not add duplicate menu items',  ->
       contextMenu.add 'file-path',
         '.selector':
           'label': 'command'
@@ -28,7 +28,7 @@ describe "ContextMenuManager", ->
 
       expect(contextMenu.definitions['.selector'][0].label).toEqual 'label'
       expect(contextMenu.definitions['.selector'][0].command).toEqual 'command'
-      expect(contextMenu.definitions['.selector'][1]).toBeUndefined()
+      expect(contextMenu.definitions['.selector'].length).toBe 1
 
     it 'allows duplicate commands with different labels',  ->
       contextMenu.add 'file-path',

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -17,6 +17,19 @@ describe "ContextMenuManager", ->
       expect(contextMenu.definitions['.selector'][0].label).toEqual 'label'
       expect(contextMenu.definitions['.selector'][0].command).toEqual 'command'
 
+    it 'does not load duplicates',  ->
+      contextMenu.add 'file-path',
+        '.selector':
+          'label': 'command'
+
+      contextMenu.add 'file-path',
+        '.selector':
+          'another label': 'command'
+
+      expect(contextMenu.definitions['.selector'][0].label).toEqual 'label'
+      expect(contextMenu.definitions['.selector'][0].command).toEqual 'command'
+      expect(contextMenu.definitions['.selector'][1]).toBeUndefined()
+
     it "loads submenus", ->
       contextMenu.add 'file-path',
         '.selector':

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -60,7 +60,8 @@ class ContextMenuManager
   #              editor is in dev mode.
   addBySelector: (selector, definition, {devMode}={}) ->
     definitions = if devMode then @devModeDefinitions else @definitions
-    (definitions[selector] ?= []).push(definition)
+    unless _.findWhere(definitions[selector], command: definition.command)
+      (definitions[selector] ?= []).push(definition)
 
   # Returns definitions which match the element and devMode.
   definitionsForElement: (element, {devMode}={}) ->

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -60,7 +60,7 @@ class ContextMenuManager
   #              editor is in dev mode.
   addBySelector: (selector, definition, {devMode}={}) ->
     definitions = if devMode then @devModeDefinitions else @definitions
-    unless _.findWhere(definitions[selector], command: definition.command)
+    unless _.findWhere(definitions[selector], definition)
       (definitions[selector] ?= []).push(definition)
 
   # Returns definitions which match the element and devMode.


### PR DESCRIPTION
Fixes atom/tree-view#131 and refs #2601.

I was unable to reproduce #2601 but this may fix the problem in general. atom/tree-view#131 occurs when disabling the Tree View package, re-enabling it, and then context clicking in the Editor pane.
