### PR TITLE
Add installation step of "C++ Toolchain" on Fedora

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -7,6 +7,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
   * OS with 64-bit or 32-bit architecture
   * C++ toolchain
     * on Ubuntu/Debian: `sudo apt-get install build-essential`
+    * on Fedora: `sudo yum --assumeyes install make gcc gcc-c++ glibc-devel`
   * [node.js](http://nodejs.org/download/) v0.10.x
     * [Ubuntu/Debian/Mint instructions](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#ubuntu-mint-elementary-os)
     * [Fedora instructions](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#fedora)


### PR DESCRIPTION
I derived the installation step for Fedora from the contents of the required Debian package. My Fedora 20 has all the listed packages installed and can compile atom, so this is an upper bound for the necessary packages in this step. Uninstalling any of the listed packages would require uninstalling a lot of other packages, so I did not test that.

References:
- [Debian's "Build-Essential" package](https://packages.debian.org/de/wheezy/build-essential)
- [StackOverflow Q&A on a "Build-Essential" equivalent on Fedora](http://unix.stackexchange.com/questions/1338/what-is-the-fedora-equivalent-of-the-debian-build-essential-package)
