### PR TITLE
added delete to end of line

### DIFF
--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -291,6 +291,7 @@ EditorComponent = React.createClass
       'editor:consolidate-selections': @consolidateSelections
       'editor:delete-to-beginning-of-word': => editor.deleteToBeginningOfWord()
       'editor:delete-to-beginning-of-line': => editor.deleteToBeginningOfLine()
+      'editor:delete-to-end-of-line': => editor.deleteToEndOfLine()
       'editor:delete-to-end-of-word': => editor.deleteToEndOfWord()
       'editor:delete-line': => editor.deleteLine()
       'editor:cut-to-end-of-line': => editor.cutToEndOfLine()

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -157,6 +157,7 @@ class EditorView extends View
       'editor:consolidate-selections': (event) => @consolidateSelections(event)
       'editor:delete-to-beginning-of-word': => @editor.deleteToBeginningOfWord()
       'editor:delete-to-beginning-of-line': => @editor.deleteToBeginningOfLine()
+      'editor:delete-to-end-of-line': => @editor.deleteToEndOfLine()
       'editor:delete-to-end-of-word': => @editor.deleteToEndOfWord()
       'editor:delete-line': => @editor.deleteLine()
       'editor:cut-to-end-of-line': => @editor.cutToEndOfLine()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -112,6 +112,7 @@ TextMateScopeSelector = require('first-mate').ScopeSelector
 # - {::deleteToBeginningOfWord}
 # - {::deleteToBeginningOfLine}
 # - {::delete}
+# - {::deleteToEndOfLine}
 # - {::deleteToEndOfWord}
 # - {::deleteLine}
 # - {::cutSelectedText}
@@ -688,6 +689,13 @@ class Editor extends Model
   # preceding the cursor. Otherwise delete the selected text.
   delete: ->
     @mutateSelectedText (selection) -> selection.delete()
+
+  # Public: For each selection, if the selection is empty, delete all characters
+  # of the containing line following the cursor. Otherwise delete the selected
+  # text.
+  deleteToEndOfLine: ->
+    @mutateSelectedText (selection) -> selection.deleteToEndOfLine()
+
 
   # Public: For each selection, if the selection is empty, delete all characters
   # of the containing word following the cursor. Otherwise delete the selected

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -431,6 +431,12 @@ class Selection extends Model
     @deleteSelectedText()
 
   # Public: Removes the selection or all characters from the start of the
+  # selection to the end of the current line if nothing is selected.
+  deleteToEndOfLine: ->
+    @selectToEndOfLine() if @isEmpty()
+    @deleteSelectedText()
+
+  # Public: Removes the selection or all characters from the start of the
   # selection to the end of the current word if nothing is selected.
   deleteToEndOfWord: ->
     @selectToEndOfWord() if @isEmpty()


### PR DESCRIPTION
Hey guys, I wanted to add the ability to delete to the end of the line, but not cut (i.e. not modify the clipboard). This is the behavior that `Ctrl-K` has in Sublime Text, and what I'm used to.

~~these changes did not work for me~~ They work now! So consider this a legit pull req :)
