### PR TITLE
added delete to end of line

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1831,6 +1831,32 @@ describe "Editor", ->
           expect(buffer.lineForRow(1)).toBe '  var sort = function(it) {'
           expect(buffer.lineForRow(2)).toBe 'if (items.length <= 1) return items;'
 
+    describe '.deleteToEndOfLine()', ->
+      describe 'when no text is selected', ->
+        it 'deletes all text between the cursor and the end of the line', ->
+          editor.setCursorBufferPosition([1, 24])
+          editor.addCursorAtBufferPosition([2, 5])
+          [cursor1, cursor2] = editor.getCursors()
+
+          editor.deleteToEndOfLine()
+          expect(buffer.lineForRow(1)).toBe '  var sort = function(it'
+          expect(buffer.lineForRow(2)).toBe '    i'
+          expect(cursor1.getBufferPosition()).toEqual [1, 24]
+          expect(cursor2.getBufferPosition()).toEqual [2, 5]
+
+        describe 'when at the end of the line', ->
+          it 'deletes the next newline', ->
+            editor.setCursorBufferPosition([1, 30])
+            editor.deleteToEndOfLine()
+            expect(buffer.lineForRow(1)).toBe '  var sort = function(items) {    if (items.length <= 1) return items;'
+
+      describe 'when text is selected', ->
+        it 'deletes all text to end of the line starting from selection', ->
+          editor.setSelectedBufferRanges([[[1, 24], [1, 27]], [[2, 0], [2, 4]]])
+          editor.deleteToEndOfLine()
+          expect(buffer.lineForRow(1)).toBe '  var sort = function(it'
+          expect(buffer.lineForRow(2)).toBe ''
+
     describe ".deleteToBeginningOfLine()", ->
       describe "when no text is selected", ->
         it "deletes all text between the cursor and the beginning of the line", ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1851,11 +1851,11 @@ describe "Editor", ->
             expect(buffer.lineForRow(1)).toBe '  var sort = function(items) {    if (items.length <= 1) return items;'
 
       describe 'when text is selected', ->
-        it 'deletes all text to end of the line starting from selection', ->
+        it 'deletes only the text in the selection', ->
           editor.setSelectedBufferRanges([[[1, 24], [1, 27]], [[2, 0], [2, 4]]])
           editor.deleteToEndOfLine()
-          expect(buffer.lineForRow(1)).toBe '  var sort = function(it'
-          expect(buffer.lineForRow(2)).toBe ''
+          expect(buffer.lineForRow(1)).toBe '  var sort = function(it) {'
+          expect(buffer.lineForRow(2)).toBe 'if (items.length <= 1) return items;'
 
     describe ".deleteToBeginningOfLine()", ->
       describe "when no text is selected", ->

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -291,6 +291,7 @@ EditorComponent = React.createClass
       'editor:consolidate-selections': @consolidateSelections
       'editor:delete-to-beginning-of-word': => editor.deleteToBeginningOfWord()
       'editor:delete-to-beginning-of-line': => editor.deleteToBeginningOfLine()
+      'editor:delete-to-end-of-line': => editor.deleteToEndOfLine()
       'editor:delete-to-end-of-word': => editor.deleteToEndOfWord()
       'editor:delete-line': => editor.deleteLine()
       'editor:cut-to-end-of-line': => editor.cutToEndOfLine()

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -157,6 +157,7 @@ class EditorView extends View
       'editor:consolidate-selections': (event) => @consolidateSelections(event)
       'editor:delete-to-beginning-of-word': => @editor.deleteToBeginningOfWord()
       'editor:delete-to-beginning-of-line': => @editor.deleteToBeginningOfLine()
+      'editor:delete-to-end-of-line': => @editor.deleteToEndOfLine()
       'editor:delete-to-end-of-word': => @editor.deleteToEndOfWord()
       'editor:delete-line': => @editor.deleteLine()
       'editor:cut-to-end-of-line': => @editor.cutToEndOfLine()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -691,8 +691,9 @@ class Editor extends Model
     @mutateSelectedText (selection) -> selection.delete()
 
   # Public: For each selection, if the selection is empty, delete all characters
-  # of the containing line following the cursor. Otherwise delete the selected
-  # text.
+  # of the containing line following the cursor, or if the cursor is at the end
+  # of the line, delete the following newline. If not empty, delete the
+  # selected text.
   deleteToEndOfLine: ->
     @mutateSelectedText (selection) -> selection.deleteToEndOfLine()
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -112,6 +112,7 @@ TextMateScopeSelector = require('first-mate').ScopeSelector
 # - {::deleteToBeginningOfWord}
 # - {::deleteToBeginningOfLine}
 # - {::delete}
+# - {::deleteToEndOfLine}
 # - {::deleteToEndOfWord}
 # - {::deleteLine}
 # - {::cutSelectedText}
@@ -688,6 +689,12 @@ class Editor extends Model
   # preceding the cursor. Otherwise delete the selected text.
   delete: ->
     @mutateSelectedText (selection) -> selection.delete()
+
+  # Public: For each selection, if the selection is empty, delete all characters
+  # of the containing line following the cursor. Otherwise delete the selected
+  # text.
+  deleteToEndOfLine: ->
+    @mutateSelectedText (selection) -> selection.deleteToEndOfLine()
 
   # Public: For each selection, if the selection is empty, delete all characters
   # of the containing word following the cursor. Otherwise delete the selected

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -690,10 +690,10 @@ class Editor extends Model
   delete: ->
     @mutateSelectedText (selection) -> selection.delete()
 
-  # Public: For each selection, if the selection is empty, delete all characters
-  # of the containing line following the cursor, or if the cursor is at the end
-  # of the line, delete the following newline. If not empty, delete the
-  # selected text.
+  # Public: For each selection, if the selection is not empty, deletes the
+  # selection; otherwise, deletes all characters of the containing line
+  # following the cursor. If the cursor is already at the end of the line,
+  # deletes the following newline.
   deleteToEndOfLine: ->
     @mutateSelectedText (selection) -> selection.deleteToEndOfLine()
 

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -430,15 +430,14 @@ class Selection extends Model
         @selectRight()
     @deleteSelectedText()
 
-  # Public: Removes all characters from the end of the selection to the end of
-  # the current line (if no selection then the rest of the line).
-  # If the cursor is at the end of the line, deletes the newline.
+  # Public: If nothing selected, removes all characters from cursor
+  # until the end of the current line, unless already at the end of
+  # the line, in which case removes the following newline.
+  # If there is a selection, deletes only the selection.
   deleteToEndOfLine: ->
-    if @isEmpty() and @cursor.isAtEndOfLine()
-      @delete()
-    else
-      @selectToEndOfLine()
-      @deleteSelectedText()
+    return @delete() if @isEmpty() and @cursor.isAtEndOfLine()
+    @selectToEndOfLine() if @isEmpty()
+    @deleteSelectedText()
 
   # Public: Removes the selection or all characters from the start of the
   # selection to the end of the current word if nothing is selected.

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -430,10 +430,10 @@ class Selection extends Model
         @selectRight()
     @deleteSelectedText()
 
-  # Public: If nothing selected, removes all characters from cursor
-  # until the end of the current line, unless already at the end of
-  # the line, in which case removes the following newline.
-  # If there is a selection, deletes only the selection.
+  # Public: If the selection is empty, removes all text from the cursor to the
+  # end of the line. If the cursor is already at the end of the line, it
+  # removes the following newline. If the selection isn't empty, only deletes
+  # the contents of the selection.
   deleteToEndOfLine: ->
     return @delete() if @isEmpty() and @cursor.isAtEndOfLine()
     @selectToEndOfLine() if @isEmpty()

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -430,6 +430,16 @@ class Selection extends Model
         @selectRight()
     @deleteSelectedText()
 
+  # Public: Removes all characters from the end of the selection to the end of
+  # the current line (if no selection then the rest of the line).
+  # If the cursor is at the end of the line, deletes the newline.
+  deleteToEndOfLine: ->
+    if @isEmpty() and @cursor.isAtEndOfLine()
+      @delete()
+    else
+      @selectToEndOfLine()
+      @deleteSelectedText()
+
   # Public: Removes the selection or all characters from the start of the
   # selection to the end of the current word if nothing is selected.
   deleteToEndOfWord: ->


### PR DESCRIPTION
This adds a command to delete text to the end of the line, without modifying the clipboard. This is the behavior in Sublime Text and what I was used to.

I'm not sure how to run the tests (`npm test` throws a whole bunch of weird errors unrelated to this commit). Perhaps someone familiar with this can run them, and/or tell me how to, in case I need to fix something? It does have the behavior I expected using it on my own.
