### PR TITLE
Handle mousedown events only for left button in editors

### DIFF
--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -469,6 +469,8 @@ EditorComponent = React.createClass
       editor.insertText(char)
 
   onMouseDown: (event) ->
+    return unless event.button is 0 # only handle the left mouse button
+
     {editor} = @props
     {detail, shiftKey, metaKey} = event
     screenPosition = @screenPositionForMouseEvent(event)

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -368,6 +368,8 @@ class EditorView extends View
       false if @isFocused
 
     @overlayer.on 'mousedown', (e) =>
+      return unless e.which is 1 # only handle the left mouse button
+
       @overlayer.hide()
       clickedElement = document.elementFromPoint(e.pageX, e.pageY)
       @overlayer.show()


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/2350

This adds a check to the classic and react editor so that mousedown events are handled only for the left mouse button. Currently, handling events for the right mouse button causes selections to be canceled after a right click.

cc @nathansobo 
