### PR TITLE
Fix packages specs on Windows CI

### DIFF
--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -105,7 +105,4 @@ module.exports = (grunt) ->
       failures.push "atom core" if coreSpecFailed
 
       grunt.log.error("[Error]".red + " #{failures.join(', ')} spec(s) failed") if failures.length > 0
-      if process.platform is 'win32'
-        done() # TODO remove once all specs consistently pass
-      else
-        done(!coreSpecFailed and failedPackages.length == 0)
+      done(!coreSpecFailed and failedPackages.length == 0)

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "open-on-github": "0.28.0",
     "package-generator": "0.30.0",
     "release-notes": "0.32.0",
-    "settings-view": "0.125.0",
+    "settings-view": "0.126.0",
     "snippets": "0.45.0",
     "spell-check": "0.37.0",
     "status-bar": "0.40.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "open-on-github": "0.28.0",
     "package-generator": "0.30.0",
     "release-notes": "0.32.0",
-    "settings-view": "0.121.0",
+    "settings-view": "0.122.0",
     "snippets": "0.45.0",
     "spell-check": "0.37.0",
     "status-bar": "0.40.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "open-on-github": "0.28.0",
     "package-generator": "0.30.0",
     "release-notes": "0.32.0",
-    "settings-view": "0.122.0",
+    "settings-view": "0.123.0",
     "snippets": "0.45.0",
     "spell-check": "0.37.0",
     "status-bar": "0.40.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "open-on-github": "0.28.0",
     "package-generator": "0.30.0",
     "release-notes": "0.32.0",
-    "settings-view": "0.123.0",
+    "settings-view": "0.124.0",
     "snippets": "0.45.0",
     "spell-check": "0.37.0",
     "status-bar": "0.40.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "open-on-github": "0.28.0",
     "package-generator": "0.30.0",
     "release-notes": "0.32.0",
-    "settings-view": "0.124.0",
+    "settings-view": "0.125.0",
     "snippets": "0.45.0",
     "spell-check": "0.37.0",
     "status-bar": "0.40.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "image-view": "0.35.0",
     "keybinding-resolver": "0.18.0",
     "link": "0.22.0",
-    "markdown-preview": "0.79.0",
+    "markdown-preview": "0.80.0",
     "metrics": "0.32.0",
     "open-on-github": "0.28.0",
     "package-generator": "0.30.0",

--- a/script/cibuild
+++ b/script/cibuild
@@ -39,6 +39,7 @@ cp.safeExec.bind(global, 'npm install npm', {cwd: path.resolve(__dirname, '..', 
     if (error)
       process.exit(1);
     require('fs-plus').removeSync.bind(global, path.join(homeDir, '.atom'))
+    require('fs-plus').removeSync(path.resolve(__dirname, '..', 'spec', 'fixtures'))
     var async = require('async');
     var gruntPath = path.join('build', 'node_modules', '.bin', 'grunt') + (process.platform === 'win32' ? '.cmd' : '');
     var tasks = [

--- a/script/cibuild
+++ b/script/cibuild
@@ -39,7 +39,6 @@ cp.safeExec.bind(global, 'npm install npm', {cwd: path.resolve(__dirname, '..', 
     if (error)
       process.exit(1);
     require('fs-plus').removeSync.bind(global, path.join(homeDir, '.atom'))
-    require('fs-plus').removeSync(path.resolve(__dirname, '..', 'spec', 'fixtures'))
     var async = require('async');
     var gruntPath = path.join('build', 'node_modules', '.bin', 'grunt') + (process.platform === 'win32' ? '.cmd' : '');
     var tasks = [


### PR DESCRIPTION
This updates the remaining failing specs to pass on the Windows CI machine.

Unfortunately I still don't know why they failed, they passed on both my Windows 8 vm and on a Windows 8 Samsung Ultrabook.

So instead the specs were massaged a bit to get them passing consistently but functionally be the same.
