### PR TITLE
Smaller Windows build

### DIFF
--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -61,10 +61,9 @@ module.exports = (grunt) ->
     ]
     ignoredPaths = ignoredPaths.map (ignoredPath) -> _.escapeRegExp(ignoredPath)
 
-    # Put patterns here that shouldn't be escaped
-    ignoredPaths.push _.escapeRegExp(path.join('build', 'Release') + path.sep) + '.*\\.pdb'
     # Add .* to avoid matching hunspell_dictionaries.
     ignoredPaths.push _.escapeRegExp(path.join('spellchecker', 'vendor', 'hunspell') + path.sep) + ".*"
+    ignoredPaths.push _.escapeRegExp(path.join('build', 'Release') + path.sep) + '.*\\.pdb'
 
     # Hunspell dictionaries are only not needed on OS X.
     if process.platform is 'darwin'

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -1,5 +1,6 @@
 fs = require 'fs'
 path = require 'path'
+_ = require 'underscore-plus'
 
 module.exports = (grunt) ->
   {cp, isAtomPackage, mkdir, rm} = require('./task-helpers')(grunt)
@@ -49,18 +50,22 @@ module.exports = (grunt) ->
       path.join('bootstrap', 'examples')
       path.join('pegjs', 'examples')
       path.join('plist', 'tests')
-      # Add .* to avoid matching hunspell_dictionaries.
-      path.join('spellchecker', 'vendor', 'hunspell', '.*')
       path.join('xmldom', 'test')
       path.join('jasmine-reporters', 'ext')
       path.join('build', 'Release', 'obj.target')
       path.join('build', 'Release', 'obj')
       path.join('build', 'Release', '.deps')
-      path.join('build', 'Release', '.*\\.pdb')
       path.join('vendor', 'apm')
       path.join('resources', 'mac')
       path.join('resources', 'win')
     ]
+    ignoredPaths = ignoredPaths.map (ignoredPath) -> _.escapeRegExp(ignoredPath)
+
+    # Put patterns here that shouldn't be escaped
+    ignoredPaths.push _.escapeRegExp(path.join('build', 'Release') + path.sep) + '.*\\.pdb'
+    # Add .* to avoid matching hunspell_dictionaries.
+    ignoredPaths.push _.escapeRegExp(path.join('spellchecker', 'vendor', 'hunspell') + path.sep) + ".*"
+
     # Hunspell dictionaries are only not needed on OS X.
     if process.platform is 'darwin'
       ignoredPaths.push path.join('spellchecker', 'vendor', 'hunspell_dictionaries')

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -56,6 +56,7 @@ module.exports = (grunt) ->
       path.join('build', 'Release', 'obj.target')
       path.join('build', 'Release', 'obj')
       path.join('build', 'Release', '.deps')
+      path.join('build', 'Release', '.*\\.pdb')
       path.join('vendor', 'apm')
       path.join('resources', 'mac')
       path.join('resources', 'win')

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -54,6 +54,7 @@ module.exports = (grunt) ->
       path.join('xmldom', 'test')
       path.join('jasmine-reporters', 'ext')
       path.join('build', 'Release', 'obj.target')
+      path.join('build', 'Release', 'obj')
       path.join('build', 'Release', '.deps')
       path.join('vendor', 'apm')
       path.join('resources', 'mac')

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -48,6 +48,7 @@ module.exports = (grunt) ->
       path.join('bootstrap', 'docs')
       path.join('bootstrap', 'examples')
       path.join('pegjs', 'examples')
+      path.join('plist', 'tests')
       # Add .* to avoid matching hunspell_dictionaries.
       path.join('spellchecker', 'vendor', 'hunspell', '.*')
       path.join('xmldom', 'test')

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -62,8 +62,8 @@ module.exports = (grunt) ->
     ignoredPaths = ignoredPaths.map (ignoredPath) -> _.escapeRegExp(ignoredPath)
 
     # Add .* to avoid matching hunspell_dictionaries.
-    ignoredPaths.push _.escapeRegExp(path.join('spellchecker', 'vendor', 'hunspell') + path.sep) + ".*"
-    ignoredPaths.push _.escapeRegExp(path.join('build', 'Release') + path.sep) + '.*\\.pdb'
+    ignoredPaths.push "#{_.escapeRegExp(path.join('spellchecker', 'vendor', 'hunspell') + path.sep)}.*"
+    ignoredPaths.push "#{_.escapeRegExp(path.join('build', 'Release') + path.sep)}.*\\.pdb"
 
     # Hunspell dictionaries are only not needed on OS X.
     if process.platform is 'darwin'


### PR DESCRIPTION
This reduces the built `.zip` file from ~100MB to ~65MB.

Previously the ignored paths weren't properly being escaped so they weren't matching any of the paths.

Also I added ignoring of `build/Release/obj` and `build/Release/*.pdb` similar to the `build/Release/obj.target` ignore that was already done on Mac OS X.

Fixes #2624 
