### PR TITLE
Install Atom.desktop when installing to /usr/local

### DIFF
--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -42,7 +42,8 @@ module.exports = (grunt) ->
 
       # Create Atom.desktop if installation in '/usr/local'
       applicationsDir = path.join('/usr','share','applications')
-      if installDir is '/usr/local' and fs.isDirectorySync(applicationsDir)
+      tmpDir = if process.env.TMPDIR? then process.env.TMPDIR else '/tmp';
+      if installDir.indexOf(tmpDir) isnt 0 and fs.isDirectorySync(applicationsDir)
         {description} = grunt.file.readJSON('package.json')
         fillTemplate(desktopFile, {description, installDir, iconName})
         cp desktopFile, path.join(applicationsDir,'Atom.desktop')

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -1,7 +1,13 @@
 fs = require 'fs'
 path = require 'path'
+_ = require 'underscore-plus'
 fs = require 'fs-plus'
 runas = null
+
+fillTemplate = (filePath, data) ->
+  template = _.template(String(fs.readFileSync(filePath + '.in')))
+  filled = template(data)
+  fs.writeFileSync(filePath, filled)
 
 module.exports = (grunt) ->
   {cp, mkdir, rm} = require('./task-helpers')(grunt)
@@ -25,11 +31,21 @@ module.exports = (grunt) ->
       binDir = path.join(installDir, 'bin')
       shareDir = path.join(installDir, 'share', 'atom')
 
+      iconName = path.join(shareDir,'resources','app','resources','atom.png')
+      desktopFile = path.join('resources', 'linux', 'Atom.desktop')
+
       mkdir binDir
       cp 'atom.sh', path.join(binDir, 'atom')
       rm shareDir
       mkdir path.dirname(shareDir)
       cp shellAppDir, shareDir
+
+      # Create Atom.desktop if installation in '/usr/local'
+      applicationsDir = path.join('/usr','share','applications')
+      if installDir is '/usr/local' and fs.isDirectorySync(applicationsDir)
+        {description} = grunt.file.readJSON('package.json')
+        fillTemplate(desktopFile, {description, installDir, iconName})
+        cp desktopFile, path.join(applicationsDir,'Atom.desktop')
 
       # Create relative symbol link for apm.
       process.chdir(binDir)

--- a/build/tasks/mkdeb-task.coffee
+++ b/build/tasks/mkdeb-task.coffee
@@ -23,7 +23,9 @@ module.exports = (grunt) ->
     {name, version, description} = grunt.file.readJSON('package.json')
     section = 'devel'
     maintainer = 'GitHub <atom@github.com>'
-    data = {name, version, description, section, arch, maintainer}
+    installDir = '/usr'
+    iconName = 'atom'
+    data = {name, version, description, section, arch, maintainer, installDir, iconName}
 
     control = path.join('resources', 'linux', 'debian', 'control')
     fillTemplate(control, data)

--- a/resources/linux/Atom.desktop.in
+++ b/resources/linux/Atom.desktop.in
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Name=Atom
 Comment=<%= description %>
-Exec=/usr/share/atom/atom %U
-Icon=atom
+Exec=<%= installDir %>/share/atom/atom %U
+Icon=<%= iconName %>
 Type=Application
 StartupNotify=true
 Categories=GNOME;GTK;Utility;TextEditor;


### PR DESCRIPTION
Fixes #1969
Running `sudo script/grunt install` also installs a desktop-file for atom in `/usr/share/applications`
