### PR TITLE
Fix for installation of desktop file

### DIFF
--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -40,13 +40,14 @@ module.exports = (grunt) ->
       mkdir path.dirname(shareDir)
       cp shellAppDir, shareDir
 
-      # Create Atom.desktop if installation in '/usr/local'
-      applicationsDir = path.join('/usr','share','applications')
+      # Create Atom.desktop if installation not in temporary folder
       tmpDir = if process.env.TMPDIR? then process.env.TMPDIR else '/tmp'
-      if installDir.indexOf(tmpDir) isnt 0 and fs.isDirectorySync(applicationsDir)
+      desktopInstallFile = path.join(installDir,'share','applications','Atom.desktop')
+      if installDir.indexOf(tmpDir) isnt 0
+        mkdir path.dirname(desktopInstallFile)
         {description} = grunt.file.readJSON('package.json')
         fillTemplate(desktopFile, {description, installDir, iconName})
-        cp desktopFile, path.join(applicationsDir,'Atom.desktop')
+        cp desktopFile, desktopInstallFile
 
       # Create relative symbol link for apm.
       process.chdir(binDir)

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -46,6 +46,7 @@ module.exports = (grunt) ->
       if installDir.indexOf(tmpDir) isnt 0
         mkdir path.dirname(desktopInstallFile)
         {description} = grunt.file.readJSON('package.json')
+        installDir = path.join(installDir,'.') # To prevent "Exec=/usr/local//share/atom/atom"
         fillTemplate(desktopFile, {description, installDir, iconName})
         cp desktopFile, desktopInstallFile
 


### PR DESCRIPTION
Continues  #2630
Fixes #2647
Installs desktop file with respect to `INSTALL_PREFIX`.
- `sudo script/grunt install` will install `Atom.desktop` to `/usr/local/share/applications` instead of `/usr/share/applications/`
- When a custom `INSTALL_PREFIX` is set the user will have to install the desktop file manually by copying `$INSTALL_PREFIX/share/applications/Atom.desktop` to `/usr/local/share/applications`
- Fix when `INSTALL_PREFIX` ends with `/`
