### PR TITLE
Don’t render decorations on the last empty line when selection not empty

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -439,7 +439,7 @@ describe "EditorComponent", ->
         expect(lineNumberHasClass(10, 'cursor-line')).toBe false
 
       it "adds cursor-line decorations to multiple lines when a selection is performed", ->
-        cursor.setScreenPosition([1, 0])
+        cursor.setScreenPosition([1, 5])
         editor.selectDown(2)
         expect(lineNumberHasClass(0, 'cursor-line')).toBe false
         expect(lineNumberHasClass(1, 'cursor-line')).toBe true
@@ -447,10 +447,18 @@ describe "EditorComponent", ->
         expect(lineNumberHasClass(3, 'cursor-line')).toBe true
         expect(lineNumberHasClass(4, 'cursor-line')).toBe false
 
+      it "does not render a curslor-line decoration for the last empty selected line in a multiline selection", ->
+        cursor.setScreenPosition([1, 0])
+        editor.selectDown(2)
+        expect(lineNumberHasClass(0, 'cursor-line')).toBe false
+        expect(lineNumberHasClass(1, 'cursor-line')).toBe true
+        expect(lineNumberHasClass(2, 'cursor-line')).toBe true
+        expect(lineNumberHasClass(3, 'cursor-line')).toBe false
+
     describe "when decorations are applied to markers", ->
       {marker, decoration} = {}
       beforeEach ->
-        marker = editor.displayBuffer.markBufferRange([[2, 13], [3, 15]], class: 'my-marker', invalidate: 'inside')
+        marker = editor.displayBuffer.markBufferRange([[2, 13], [3, 15]], invalidate: 'inside')
         decoration = {type: 'gutter', class: 'someclass'}
         editor.addDecorationForMarker(marker, decoration)
         waitsFor -> not component.decorationChangedImmediate?

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -447,7 +447,7 @@ describe "EditorComponent", ->
         expect(lineNumberHasClass(3, 'cursor-line')).toBe true
         expect(lineNumberHasClass(4, 'cursor-line')).toBe false
 
-      it "does not render a curslor-line decoration for the last empty selected line in a multiline selection", ->
+      it "does not render a cursor-line decoration for the last line of a multi-line selection of the selection ends at column 0", ->
         cursor.setScreenPosition([1, 0])
         editor.selectDown(2)
         expect(lineNumberHasClass(0, 'cursor-line')).toBe false

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -236,9 +236,13 @@ EditorComponent = React.createClass
         for decoration in decorations
           if editor.decorationMatchesType(decoration, 'gutter') or editor.decorationMatchesType(decoration, 'line')
             screenRange ?= marker.getScreenRange()
-            for screenRow in [screenRange.start.row..screenRange.end.row]
+            startRow = screenRange.start.row
+            endRow = screenRange.end.row
+            endRow-- if not screenRange.isEmpty() and screenRange.end.column == 0
+            for screenRow in [startRow..endRow]
               decorationsByScreenRow[screenRow] ?= []
               decorationsByScreenRow[screenRow].push decoration
+
     decorationsByScreenRow
 
   getHighlightDecorations: (decorationsByMarkerId) ->


### PR DESCRIPTION
Works like the old editor.

Fixes #2657 
