### PR TITLE
Render line decorations

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "temp": "0.7.0",
     "text-buffer": "^2.4.2",
     "theorist": "^1",
-    "underscore-plus": "^1.4.1",
+    "underscore-plus": "^1.5.0",
     "vm-compatibility-layer": "0.1.0"
   },
   "packageDependencies": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "feedback": "0.33.0",
     "find-and-replace": "0.120.0",
     "fuzzy-finder": "0.55.0",
-    "git-diff": "0.33.0",
+    "git-diff": "0.34.0",
     "go-to-line": "0.23.0",
     "grammar-selector": "0.27.0",
     "image-view": "0.35.0",

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -174,11 +174,11 @@ GutterComponent = React.createClass
 
     if previousDecorations?
       for decoration in previousDecorations
-        node.classList.remove(decoration.class) if editor.decorationMatchesType(decoration, 'gutter') and not contains(decorations, decoration)
+        node.classList.remove(decoration.class) if editor.decorationMatchesType(decoration, 'gutter') and not _.deepContains(decorations, decoration)
 
     if decorations?
       for decoration in decorations
-        if editor.decorationMatchesType(decoration, 'gutter') and not contains(previousDecorations, decoration)
+        if editor.decorationMatchesType(decoration, 'gutter') and not _.deepContains(previousDecorations, decoration)
           node.classList.add(decoration.class)
 
     unless @screenRowsByLineNumberId[lineNumberId] is screenRow
@@ -211,10 +211,3 @@ GutterComponent = React.createClass
     unless width is @measuredWidth
       @measuredWidth = width
       @props.onWidthChanged?(width)
-
-# Created because underscore uses === not _.isEqual, which we need
-contains = (array, target) ->
-  return false unless array?
-  for object in array
-    return true if _.isEqual(object, target)
-  false

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -215,11 +215,11 @@ LinesComponent = React.createClass
 
     if previousDecorations = @renderedDecorationsByLineId[line.id]
       for decoration in previousDecorations
-        lineNode.classList.remove(decoration.class) if editor.decorationMatchesType(decoration, 'line') and not contains(decorations, decoration)
+        lineNode.classList.remove(decoration.class) if editor.decorationMatchesType(decoration, 'line') and not _.deepContains(decorations, decoration)
 
     if decorations = lineDecorations[screenRow]
       for decoration in decorations
-        if editor.decorationMatchesType(decoration, 'line') and not contains(previousDecorations, decoration)
+        if editor.decorationMatchesType(decoration, 'line') and not _.deepContains(previousDecorations, decoration)
           lineNode.classList.add(decoration.class)
 
     return
@@ -292,10 +292,3 @@ LinesComponent = React.createClass
   clearScopedCharWidths: ->
     @measuredLines.clear()
     @props.editor.clearScopedCharWidths()
-
-# Created because underscore uses === not _.isEqual, which we need
-contains = (array, target) ->
-  return false unless array?
-  for object in array
-    return true if _.isEqual(object, target)
-  false

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -204,14 +204,7 @@ LinesComponent = React.createClass
 
   updateLineNode: (line, screenRow) ->
     {editor, lineHeightInPixels, lineDecorations} = @props
-
     lineNode = @lineNodesByLineId[line.id]
-
-    unless @screenRowsByLineId[line.id] is screenRow
-      lineNode.style.top = screenRow * lineHeightInPixels + 'px'
-      lineNode.dataset.screenRow = screenRow
-      @screenRowsByLineId[line.id] = screenRow
-      @lineIdsByScreenRow[screenRow] = line.id
 
     if previousDecorations = @renderedDecorationsByLineId[line.id]
       for decoration in previousDecorations
@@ -222,7 +215,11 @@ LinesComponent = React.createClass
         if editor.decorationMatchesType(decoration, 'line') and not _.deepContains(previousDecorations, decoration)
           lineNode.classList.add(decoration.class)
 
-    return
+    unless @screenRowsByLineId[line.id] is screenRow
+      lineNode.style.top = screenRow * lineHeightInPixels + 'px'
+      lineNode.dataset.screenRow = screenRow
+      @screenRowsByLineId[line.id] = screenRow
+      @lineIdsByScreenRow[screenRow] = line.id
 
   lineNodeForScreenRow: (screenRow) ->
     @lineNodesByLineId[@lineIdsByScreenRow[screenRow]]


### PR DESCRIPTION
This adds support for `type: 'line'` decorations. Decorations of `type: 'line'` will add a class to the relevant screen lines.

Closes #2569
