### PR TITLE
Added a hint about the required Python path.

### DIFF
--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -11,6 +11,7 @@
     You may also need the [compiler update for the Windows SDK 7.1](http://www.microsoft.com/en-us/download/details.aspx?id=4422)
 
   * [Python](http://www.python.org/download/) v2.7.x
+    * Note: Python.exe must be available at: `%SystemDrive%\Python27\python.exe`. If it is installed elsewhere, create a symbolic link to the directory containing python.exe (like so: `mklink /d %SystemDrive%\Python27 D:\elsewhere\Python27`).
   * [GitHub for Windows](http://windows.github.com/)
 
 ### On Windows 8


### PR DESCRIPTION
In order to alert users that the Atom build scripts expect to find Python in the default installation folder.
