### PR TITLE
Fix caching of gutter's previous decorations

### DIFF
--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -144,7 +144,7 @@ GutterComponent = React.createClass
     innerHTML = @buildLineNumberInnerHTML(bufferRow, softWrapped, maxLineNumberDigits)
 
     classes = ''
-    if lineDecorations and decorations = lineDecorations[screenRow]
+    if lineDecorations? and decorations = lineDecorations[screenRow]
       for decoration in decorations
         if editor.decorationMatchesType(decoration, 'gutter')
           classes += decoration.class + ' '

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -80,6 +80,7 @@ LinesComponent = React.createClass
         delete @lineNodesByLineId[lineId]
         delete @lineIdsByScreenRow[screenRow] if @lineIdsByScreenRow[screenRow] is lineId
         delete @screenRowsByLineId[lineId]
+        delete @renderedDecorationsByLineId[lineId]
         node.removeChild(lineNode)
 
   appendOrUpdateVisibleLineNodes: (visibleLines, startRow) ->

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -207,11 +207,14 @@ LinesComponent = React.createClass
     {editor, lineHeightInPixels, lineDecorations} = @props
     lineNode = @lineNodesByLineId[line.id]
 
-    if previousDecorations = @renderedDecorationsByLineId[line.id]
+    decorations = lineDecorations[screenRow]
+    previousDecorations = @renderedDecorationsByLineId[line.id]
+
+    if previousDecorations?
       for decoration in previousDecorations
         lineNode.classList.remove(decoration.class) if editor.decorationMatchesType(decoration, 'line') and not _.deepContains(decorations, decoration)
 
-    if decorations = lineDecorations[screenRow]
+    if decorations?
       for decoration in decorations
         if editor.decorationMatchesType(decoration, 'line') and not _.deepContains(previousDecorations, decoration)
           lineNode.classList.add(decoration.class)


### PR DESCRIPTION
If some operation (folding?) changes the screen rows and the decorations at the same time, the previous decorations can no longer be diffed against the decorations to-be-rendered to figure out what to classes to add/remove.

So rather than index by screenRow, this indexes by `lineNumberId`.

@nathansobo check it out
