### PR TITLE
Indentation respects tab stops now, fix #2672

### DIFF
--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -409,9 +409,10 @@ class Editor extends Model
     @displayBuffer.indentLevelForLine(line)
 
   # Constructs the string used for tabs.
-  buildIndentString: (number) ->
+  buildIndentString: (number, column=0) ->
     if @getSoftTabs()
-      _.multiplyString(" ", Math.floor(number * @getTabLength()))
+      tabStopViolation = column % @getTabLength()
+      _.multiplyString(" ", Math.floor(number * @getTabLength()) - tabStopViolation)
     else
       _.multiplyString("\t", Math.floor(number))
 

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -386,7 +386,7 @@ class Selection extends Model
       if autoIndent and delta > 0
         @insertText(@editor.buildIndentString(delta))
       else
-        @insertText(@editor.getTabText())
+        @insertText(@editor.buildIndentString(1, @cursor.getBufferColumn()))
     else
       @indentSelectedRows()
 


### PR DESCRIPTION
![gifrecord_2014-06-23_230105](https://cloud.githubusercontent.com/assets/5219415/3363937/ac3e74c4-fb19-11e3-8499-0781b5c94ae2.gif)

I choose a tab length of 7 (I use 2 in production, I promise!) to show how nicely it aligns now. I'm not sure if there are other occurrences this behaviour needs to be fixed so I added no specs yet.

:octocat:
