### PR TITLE
Compute pixel rects of cursors and highlights in EditorComponent

### DIFF
--- a/src/cursor-component.coffee
+++ b/src/cursor-component.coffee
@@ -1,5 +1,6 @@
 React = require 'react-atom-fork'
 {div} = require 'reactionary-atom-fork'
+{isEqualForProperties} = require 'underscore-plus'
 
 module.exports =
 CursorComponent = React.createClass
@@ -14,3 +15,6 @@ CursorComponent = React.createClass
     WebkitTransform = "translate3d(#{left}px, #{top}px, 0px)"
 
     div className: 'cursor', style: {height, width, WebkitTransform}
+
+  shouldComponentUpdate: (prevProps) ->
+    not isEqualForProperties(prevProps, @props, 'pixelRect', 'scrollTop', 'scrollLeft', 'defaultCharWidth')

--- a/src/cursor-component.coffee
+++ b/src/cursor-component.coffee
@@ -6,8 +6,8 @@ CursorComponent = React.createClass
   displayName: 'CursorComponent'
 
   render: ->
-    {editor, screenRange, scrollTop, scrollLeft, defaultCharWidth} = @props
-    {top, left, height, width} = editor.pixelRectForScreenRange(screenRange)
+    {pixelRect, scrollTop, scrollLeft, defaultCharWidth} = @props
+    {top, left, height, width} = pixelRect
     top -= scrollTop
     left -= scrollLeft
     width = defaultCharWidth if width is 0

--- a/src/cursor-component.coffee
+++ b/src/cursor-component.coffee
@@ -16,5 +16,5 @@ CursorComponent = React.createClass
 
     div className: 'cursor', style: {height, width, WebkitTransform}
 
-  shouldComponentUpdate: (prevProps) ->
-    not isEqualForProperties(prevProps, @props, 'pixelRect', 'scrollTop', 'scrollLeft', 'defaultCharWidth')
+  shouldComponentUpdate: (newProps) ->
+    not isEqualForProperties(newProps, @props, 'pixelRect', 'scrollTop', 'scrollLeft', 'defaultCharWidth')

--- a/src/cursors-component.coffee
+++ b/src/cursors-component.coffee
@@ -37,7 +37,11 @@ CursorsComponent = React.createClass
       not isEqualForProperties(newProps, @props, 'cursorPixelRects', 'scrollTop', 'scrollLeft', 'defaultCharWidth')
 
   componentWillUpdate: (newProps) ->
-    @pauseCursorBlinking() if @props.cursorPixelRects? and not isEqual(newProps.cursorPixelRects, @props.cursorPixelRects)
+    cursorsMoved = @props.cursorPixelRects? and
+      isEqualForProperties(newProps, @props, 'defaultCharWidth', 'scopedCharacterWidthsChangeCount') and
+      not isEqual(newProps.cursorPixelRects, @props.cursorPixelRects)
+
+    @pauseCursorBlinking() if cursorsMoved
 
   startBlinkingCursors: ->
     @toggleCursorBlinkHandle = setInterval(@toggleCursorBlink, @props.cursorBlinkPeriod / 2) if @isMounted()

--- a/src/cursors-component.coffee
+++ b/src/cursors-component.coffee
@@ -12,7 +12,7 @@ CursorsComponent = React.createClass
   cursorBlinkIntervalHandle: null
 
   render: ->
-    {editor, cursorScreenRanges, scrollTop, scrollLeft, defaultCharWidth} = @props
+    {cursorPixelRects, scrollTop, scrollLeft, defaultCharWidth} = @props
     {blinkOff} = @state
 
     className = 'cursors'
@@ -20,8 +20,8 @@ CursorsComponent = React.createClass
 
     div {className},
       if @isMounted()
-        for key, screenRange of cursorScreenRanges
-          CursorComponent({key, editor, screenRange, scrollTop, scrollLeft, defaultCharWidth})
+        for key, pixelRect of cursorPixelRects
+          CursorComponent({key, pixelRect, scrollTop, scrollLeft, defaultCharWidth})
 
   getInitialState: ->
     blinkOff: false
@@ -34,10 +34,7 @@ CursorsComponent = React.createClass
 
   shouldComponentUpdate: (newProps, newState) ->
     not newState.blinkOff is @state.blinkOff or
-      not isEqualForProperties(newProps, @props,
-        'cursorScreenRanges', 'scrollTop', 'scrollLeft', 'lineHeightInPixels',
-        'defaultCharWidth', 'scopedCharacterWidthsChangeCount'
-      )
+      not isEqualForProperties(newProps, @props, 'cursorPixelRects', 'scrollTop', 'scrollLeft', 'defaultCharWidth')
 
   componentWillUpdate: (newProps) ->
     @pauseCursorBlinking() if @props.cursorScreenRanges and not isEqual(newProps.cursorScreenRanges, @props.cursorScreenRanges)

--- a/src/cursors-component.coffee
+++ b/src/cursors-component.coffee
@@ -37,7 +37,7 @@ CursorsComponent = React.createClass
       not isEqualForProperties(newProps, @props, 'cursorPixelRects', 'scrollTop', 'scrollLeft', 'defaultCharWidth')
 
   componentWillUpdate: (newProps) ->
-    @pauseCursorBlinking() if @props.cursorScreenRanges and not isEqual(newProps.cursorScreenRanges, @props.cursorScreenRanges)
+    @pauseCursorBlinking() if @props.cursorPixelRects? and not isEqual(newProps.cursorPixelRects, @props.cursorPixelRects)
 
   startBlinkingCursors: ->
     @toggleCursorBlinkHandle = setInterval(@toggleCursorBlink, @props.cursorBlinkPeriod / 2) if @isMounted()

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -12,7 +12,7 @@ ScrollbarComponent = require './scrollbar-component'
 ScrollbarCornerComponent = require './scrollbar-corner-component'
 SubscriberMixin = require './subscriber-mixin'
 
-DummyHighlightDecoration = {id: 'dummy', screenRange: new Range(new Point(0, 0), new Point(0, 0)), decorations: [{class: 'dummy'}]}
+DummyHighlightDecoration = {id: 'dummy', startPixelPosition: {top: 0, left: 0}, endPixelPosition: {top: 0, left: 0}, decorations: [{class: 'dummy'}]}
 
 module.exports =
 EditorComponent = React.createClass
@@ -289,10 +289,15 @@ EditorComponent = React.createClass
     filteredDecorations = {}
     for markerId, decorations of decorationsByMarkerId
       marker = editor.getMarker(markerId)
-      if marker.isValid() and not marker.getScreenRange().isEmpty()
+      screenRange = marker.getScreenRange()
+      if marker.isValid() and not screenRange.isEmpty()
         for decoration in decorations
           if editor.decorationMatchesType(decoration, 'highlight')
-            filteredDecorations[markerId] ?= {id: markerId, screenRange: marker.getScreenRange(), decorations: []}
+            filteredDecorations[markerId] ?=
+              id: markerId
+              startPixelPosition: editor.pixelPositionForScreenPosition(screenRange.start)
+              endPixelPosition: editor.pixelPositionForScreenPosition(screenRange.end)
+              decorations: []
             filteredDecorations[markerId].decorations.push decoration
 
     # At least in Chromium 31, removing the last highlight causes a rendering

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -55,7 +55,7 @@ EditorComponent = React.createClass
     if @isMounted()
       renderedRowRange = @getRenderedRowRange()
       [renderedStartRow, renderedEndRow] = renderedRowRange
-      cursorScreenRanges = @getCursorScreenRanges(renderedRowRange)
+      cursorPixelRects = @getCursorPixelRects(renderedRowRange)
 
       decorations = editor.decorationsForScreenRowRange(renderedStartRow, renderedEndRow)
       highlightDecorations = @getHighlightDecorations(decorations)
@@ -101,7 +101,7 @@ EditorComponent = React.createClass
           onBlur: @onInputBlurred
 
         CursorsComponent {
-          editor, scrollTop, scrollLeft, cursorScreenRanges, cursorBlinkPeriod, cursorBlinkResumeDelay,
+          scrollTop, scrollLeft, cursorPixelRects, cursorBlinkPeriod, cursorBlinkResumeDelay,
           lineHeightInPixels, defaultCharWidth, @scopedCharacterWidthsChangeCount
         }
         LinesComponent {
@@ -252,6 +252,18 @@ EditorComponent = React.createClass
       if renderedStartRow <= screenRange.start.row < renderedEndRow
         cursorScreenRanges[cursor.id] = screenRange
     cursorScreenRanges
+
+  getCursorPixelRects: (renderedRowRange) ->
+    {editor} = @props
+    [renderedStartRow, renderedEndRow] = renderedRowRange
+
+    cursorPixelRects = {}
+    for selection in editor.getSelections() when selection.isEmpty()
+      {cursor} = selection
+      screenRange = cursor.getScreenRange()
+      if renderedStartRow <= screenRange.start.row < renderedEndRow
+        cursorPixelRects[cursor.id] = editor.pixelRectForScreenRange(screenRange)
+    cursorPixelRects
 
   getLineDecorations: (decorationsByMarkerId) ->
     {editor} = @props

--- a/src/highlight-component.coffee
+++ b/src/highlight-component.coffee
@@ -6,22 +6,18 @@ HighlightComponent = React.createClass
   displayName: 'HighlightComponent'
 
   render: ->
-    {editor, screenRange, decoration} = @props
-    {start, end} = screenRange
-    rowCount = end.row - start.row + 1
-    startPixelPosition = editor.pixelPositionForScreenPosition(start)
-    endPixelPosition = editor.pixelPositionForScreenPosition(end)
+    {startPixelPosition, endPixelPosition, decoration} = @props
 
     className = 'highlight'
     className += " #{decoration.class}" if decoration.class?
     div {className},
-      if rowCount is 1
-        @renderSingleLineRegions(startPixelPosition, endPixelPosition)
+      if endPixelPosition.top is startPixelPosition.top
+        @renderSingleLineRegions()
       else
-        @renderMultiLineRegions(startPixelPosition, endPixelPosition, rowCount)
+        @renderMultiLineRegions()
 
-  renderSingleLineRegions: (startPixelPosition, endPixelPosition) ->
-    {lineHeightInPixels} = @props
+  renderSingleLineRegions: ->
+    {startPixelPosition, endPixelPosition, lineHeightInPixels} = @props
 
     [
       div className: 'region', key: 0, style:
@@ -31,8 +27,8 @@ HighlightComponent = React.createClass
         width: endPixelPosition.left - startPixelPosition.left
     ]
 
-  renderMultiLineRegions: (startPixelPosition, endPixelPosition, rowCount) ->
-    {lineHeightInPixels} = @props
+  renderMultiLineRegions: ->
+    {startPixelPosition, endPixelPosition, lineHeightInPixels} = @props
     regions = []
     index = 0
 
@@ -46,11 +42,11 @@ HighlightComponent = React.createClass
     )
 
     # Middle rows, extending from left side to right side of screen
-    if rowCount > 2
+    if endPixelPosition.top - startPixelPosition.top > lineHeightInPixels
       regions.push(
         div className: 'region', key: index++, style:
           top: startPixelPosition.top + lineHeightInPixels
-          height: (rowCount - 2) * lineHeightInPixels
+          height: endPixelPosition.top - startPixelPosition.top - lineHeightInPixels
           left: 0
           right: 0
       )

--- a/src/highlight-component.coffee
+++ b/src/highlight-component.coffee
@@ -1,5 +1,6 @@
 React = require 'react-atom-fork'
 {div} = require 'reactionary-atom-fork'
+{isEqualForProperties} = require 'underscore-plus'
 
 module.exports =
 HighlightComponent = React.createClass
@@ -61,3 +62,6 @@ HighlightComponent = React.createClass
     )
 
     regions
+
+  shouldComponentUpdate: (newProps) ->
+    not isEqualForProperties(newProps, @props, 'startPixelPosition', 'endPixelPosition', 'lineHeightInPixels')

--- a/src/highlights-component.coffee
+++ b/src/highlights-component.coffee
@@ -12,12 +12,12 @@ HighlightsComponent = React.createClass
       @renderHighlights() if @isMounted()
 
   renderHighlights: ->
-    {editor, highlightDecorations, lineHeightInPixels} = @props
+    {highlightDecorations, lineHeightInPixels} = @props
 
     highlightComponents = []
-    for markerId, {screenRange, decorations} of highlightDecorations
+    for markerId, {startPixelPosition, endPixelPosition, decorations} of highlightDecorations
       for decoration in decorations
-        highlightComponents.push(HighlightComponent({key: "#{markerId}-#{decoration.class}", screenRange, decoration, editor, lineHeightInPixels}))
+        highlightComponents.push(HighlightComponent({key: "#{markerId}-#{decoration.class}", startPixelPosition, endPixelPosition, decoration, lineHeightInPixels}))
 
     highlightComponents
 


### PR DESCRIPTION
Fixes #2726

Previously, we were passing the screen ranges of highlights and cursors into their components, then using editor to convert these ranges to pixel positions. This worked for the most part, but when the cursor blinked it could sometimes get out of sync with changes to the model, meaning we asked for a pixel position for a screen position that didn't exist.

This PR changes things to precompute the raw pixel positions for cursors and highlights in the root component and pass it down. When the cursor blinks, we don't need to recompute a pixel position because it's a property that is passed in from the outside and doesn't change in this case.

This kind of approach seems to be what React wants: Compute an immutable snapshot of the model in the root component and pass it down from the top.
