### PR TITLE
Fix indent guide

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -285,19 +285,29 @@ describe "EditorComponent", ->
         expect(line0LeafNodes[1].textContent).toBe '  '
         expect(line0LeafNodes[1].classList.contains('indent-guide')).toBe false
 
-      it "updates empty line indent guides when the guides change as a result of another line", ->
+      it "updates the indent guides on empty lines preceding an indentation change", ->
         editor.getBuffer().insert([12, 0], '\n')
-        nextTick()
-
-        # The newline and he tab need to be in two different operations to surface the bug
+        runSetImmediateCallbacks()
         editor.getBuffer().insert([13, 0], '  ')
-        nextTick()
+        runSetImmediateCallbacks()
 
         line12LeafNodes = getLeafNodes(component.lineNodeForScreenRow(12))
         expect(line12LeafNodes[0].textContent).toBe '  '
         expect(line12LeafNodes[0].classList.contains('indent-guide')).toBe true
         expect(line12LeafNodes[1].textContent).toBe '  '
         expect(line12LeafNodes[1].classList.contains('indent-guide')).toBe true
+
+      it "updates the indent guides on empty lines following an indentation change", ->
+        editor.getBuffer().insert([12, 2], '\n')
+        runSetImmediateCallbacks()
+        editor.getBuffer().insert([12, 0], '  ')
+        runSetImmediateCallbacks()
+
+        line13LeafNodes = getLeafNodes(component.lineNodeForScreenRow(13))
+        expect(line13LeafNodes[0].textContent).toBe '  '
+        expect(line13LeafNodes[0].classList.contains('indent-guide')).toBe true
+        expect(line13LeafNodes[1].textContent).toBe '  '
+        expect(line13LeafNodes[1].classList.contains('indent-guide')).toBe true
 
       getLeafNodes = (node) ->
         if node.children.length > 0

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -285,6 +285,19 @@ describe "EditorComponent", ->
         expect(line0LeafNodes[1].textContent).toBe '  '
         expect(line0LeafNodes[1].classList.contains('indent-guide')).toBe false
 
+      it "updates empty line indent guides when the guides change as a result of another line", ->
+        editor.getBuffer().insert([12, 0], '\n')
+        nextTick()
+
+        editor.getBuffer().insert([13, 0], '  ')
+        nextTick()
+
+        line12LeafNodes = getLeafNodes(component.lineNodeForScreenRow(12))
+        expect(line12LeafNodes[0].textContent).toBe '  '
+        expect(line12LeafNodes[0].classList.contains('indent-guide')).toBe true
+        expect(line12LeafNodes[1].textContent).toBe '  '
+        expect(line12LeafNodes[1].classList.contains('indent-guide')).toBe true
+
       getLeafNodes = (node) ->
         if node.children.length > 0
           flatten(toArray(node.children).map(getLeafNodes))

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -289,6 +289,7 @@ describe "EditorComponent", ->
         editor.getBuffer().insert([12, 0], '\n')
         nextTick()
 
+        # The newline and he tab need to be in two different operations to surface the bug
         editor.getBuffer().insert([13, 0], '  ')
         nextTick()
 

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -688,7 +688,12 @@ describe "TokenizedBuffer", ->
         expect(tokenizedBuffer.lineForScreenRow(10).indentLevel).toBe 2
         expect(tokenizedBuffer.lineForScreenRow(11).indentLevel).toBe 2
 
+        tokenizedBuffer.on "changed", changeHandler = jasmine.createSpy('changeHandler')
+
         buffer.setTextInRange([[7, 0], [8, 65]], '        one\n        two\n        three\n        four')
+
+        changeEvent = _.pick(changeHandler.mostRecentCall.args[0], 'start', 'end', 'delta')
+        expect(changeEvent).toEqual(start: 5, end: 8, delta: 2)
 
         expect(tokenizedBuffer.lineForScreenRow(5).indentLevel).toBe 4
         expect(tokenizedBuffer.lineForScreenRow(6).indentLevel).toBe 4
@@ -701,7 +706,12 @@ describe "TokenizedBuffer", ->
         buffer.insert([7, 0], '\n\n')
         buffer.insert([5, 0], '\n\n')
 
+        tokenizedBuffer.on "changed", changeHandler = jasmine.createSpy('changeHandler')
+
         buffer.setTextInRange([[7, 0], [8, 65]], '    ok')
+
+        changeEvent = _.pick(changeHandler.mostRecentCall.args[0], 'start', 'end', 'delta')
+        expect(changeEvent).toEqual(start: 5, end: 8, delta: -1)
 
         expect(tokenizedBuffer.lineForScreenRow(5).indentLevel).toBe 2
         expect(tokenizedBuffer.lineForScreenRow(6).indentLevel).toBe 2

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -692,8 +692,8 @@ describe "TokenizedBuffer", ->
 
         buffer.setTextInRange([[7, 0], [8, 65]], '        one\n        two\n        three\n        four')
 
-        changeEvent = _.pick(changeHandler.mostRecentCall.args[0], 'start', 'end', 'delta')
-        expect(changeEvent).toEqual(start: 5, end: 8, delta: 2)
+        delete changeHandler.argsForCall[0][0].bufferChange
+        expect(changeHandler).toHaveBeenCalledWith(start: 5, end: 8, delta: 2)
 
         expect(tokenizedBuffer.lineForScreenRow(5).indentLevel).toBe 4
         expect(tokenizedBuffer.lineForScreenRow(6).indentLevel).toBe 4
@@ -710,8 +710,8 @@ describe "TokenizedBuffer", ->
 
         buffer.setTextInRange([[7, 0], [8, 65]], '    ok')
 
-        changeEvent = _.pick(changeHandler.mostRecentCall.args[0], 'start', 'end', 'delta')
-        expect(changeEvent).toEqual(start: 5, end: 8, delta: -1)
+        delete changeHandler.argsForCall[0][0].bufferChange
+        expect(changeHandler).toHaveBeenCalledWith(start: 5, end: 8, delta: -1)
 
         expect(tokenizedBuffer.lineForScreenRow(5).indentLevel).toBe 2
         expect(tokenizedBuffer.lineForScreenRow(6).indentLevel).toBe 2

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -657,3 +657,57 @@ describe "TokenizedBuffer", ->
 
         buffer.setText('\n\n\n')
         expect(tokenizedBuffer.lineForScreenRow(1).indentLevel).toBe 0
+
+    describe "when the line changed is surrounded by whitespace lines", ->
+      it "updates empty line indent guides above a line that is indented", ->
+        expect(tokenizedBuffer.lineForScreenRow(12).indentLevel).toBe 0
+
+        buffer.insert([12, 0], '\n')
+
+        # The newline and he tab need to be in two different operations to surface the bug
+        buffer.insert([13, 0], '  ')
+        expect(tokenizedBuffer.lineForScreenRow(12).indentLevel).toBe 1
+
+      it "updates empty line indent guides when the empty line is the last line", ->
+        buffer.insert([12, 2], '\n')
+
+        # The newline and he tab need to be in two different operations to surface the bug
+        buffer.insert([12, 0], '  ')
+        expect(tokenizedBuffer.lineForScreenRow(13).indentLevel).toBe 1
+
+        buffer.insert([12, 0], '  ')
+        expect(tokenizedBuffer.lineForScreenRow(13).indentLevel).toBe 2
+        expect(tokenizedBuffer.lineForScreenRow(14)).not.toBeDefined()
+
+      it "updates empty lines surrounding a change encompasing more lines than the old text", ->
+        # create some new lines
+        buffer.insert([7, 0], '\n\n')
+        buffer.insert([5, 0], '\n\n')
+
+        expect(tokenizedBuffer.lineForScreenRow(5).indentLevel).toBe 3
+        expect(tokenizedBuffer.lineForScreenRow(6).indentLevel).toBe 3
+        expect(tokenizedBuffer.lineForScreenRow(9).indentLevel).toBe 2
+        expect(tokenizedBuffer.lineForScreenRow(10).indentLevel).toBe 2
+        expect(tokenizedBuffer.lineForScreenRow(11).indentLevel).toBe 2
+
+        buffer.setTextInRange([[7, 0], [8, 65]], '        one\n        two\n        three\n        four')
+
+        expect(tokenizedBuffer.lineForScreenRow(5).indentLevel).toBe 4
+        expect(tokenizedBuffer.lineForScreenRow(6).indentLevel).toBe 4
+        expect(tokenizedBuffer.lineForScreenRow(11).indentLevel).toBe 2
+        expect(tokenizedBuffer.lineForScreenRow(12).indentLevel).toBe 2
+        expect(tokenizedBuffer.lineForScreenRow(13).indentLevel).toBe 2
+
+      it "updates empty lines surrounding a change encompasing less lines than the old text", ->
+        # create some new lines
+        buffer.insert([7, 0], '\n\n')
+        buffer.insert([5, 0], '\n\n')
+
+        buffer.setTextInRange([[7, 0], [8, 65]], '    ok')
+
+        expect(tokenizedBuffer.lineForScreenRow(5).indentLevel).toBe 2
+        expect(tokenizedBuffer.lineForScreenRow(6).indentLevel).toBe 2
+        expect(tokenizedBuffer.lineForScreenRow(7).indentLevel).toBe 2 # new text
+        expect(tokenizedBuffer.lineForScreenRow(8).indentLevel).toBe 2
+        expect(tokenizedBuffer.lineForScreenRow(9).indentLevel).toBe 2
+        expect(tokenizedBuffer.lineForScreenRow(10).indentLevel).toBe 2 # }

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -658,13 +658,11 @@ describe "TokenizedBuffer", ->
         buffer.setText('\n\n\n')
         expect(tokenizedBuffer.lineForScreenRow(1).indentLevel).toBe 0
 
-    describe "when the line changed is surrounded by whitespace lines", ->
-      it "updates empty line indent guides above a line that is indented", ->
+    describe "when the changed lines are surrounded by whitespace-only lines", ->
+      it "updates the indentLevel of empty lines that precede the change", ->
         expect(tokenizedBuffer.lineForScreenRow(12).indentLevel).toBe 0
 
         buffer.insert([12, 0], '\n')
-
-        # The newline and he tab need to be in two different operations to surface the bug
         buffer.insert([13, 0], '  ')
         expect(tokenizedBuffer.lineForScreenRow(12).indentLevel).toBe 1
 
@@ -679,7 +677,7 @@ describe "TokenizedBuffer", ->
         expect(tokenizedBuffer.lineForScreenRow(13).indentLevel).toBe 2
         expect(tokenizedBuffer.lineForScreenRow(14)).not.toBeDefined()
 
-      it "updates empty lines surrounding a change encompasing more lines than the old text", ->
+      it "updates the indentLevel of empty lines surrounding a change that inserts lines", ->
         # create some new lines
         buffer.insert([7, 0], '\n\n')
         buffer.insert([5, 0], '\n\n')
@@ -698,7 +696,7 @@ describe "TokenizedBuffer", ->
         expect(tokenizedBuffer.lineForScreenRow(12).indentLevel).toBe 2
         expect(tokenizedBuffer.lineForScreenRow(13).indentLevel).toBe 2
 
-      it "updates empty lines surrounding a change encompasing less lines than the old text", ->
+      it "updates the indentLevel of empty lines surrounding a change that removes lines", ->
         # create some new lines
         buffer.insert([7, 0], '\n\n')
         buffer.insert([5, 0], '\n\n')

--- a/spec/tokenized-line-spec.coffee
+++ b/spec/tokenized-line-spec.coffee
@@ -4,6 +4,20 @@ describe "TokenizedLine", ->
   beforeEach ->
     waitsForPromise -> atom.packages.activatePackage('language-coffee-script')
 
+  describe "::isOnlyWhitespace()", ->
+    beforeEach ->
+      waitsForPromise ->
+        atom.project.open('coffee.coffee').then (o) -> editor = o
+
+    it "returns true when the line is only whitespace", ->
+      expect(editor.lineForScreenRow(3).isOnlyWhitespace()).toBe true
+      expect(editor.lineForScreenRow(7).isOnlyWhitespace()).toBe true
+      expect(editor.lineForScreenRow(23).isOnlyWhitespace()).toBe true
+
+    it "returns false when the line is only whitespace", ->
+      expect(editor.lineForScreenRow(0).isOnlyWhitespace()).toBe false
+      expect(editor.lineForScreenRow(2).isOnlyWhitespace()).toBe false
+
   describe "::getScopeTree()", ->
     it "returns a tree whose inner nodes are scopes and whose leaf nodes are tokens in those scopes", ->
       [tokens, tokenIndex] = []

--- a/spec/tokenized-line-spec.coffee
+++ b/spec/tokenized-line-spec.coffee
@@ -14,7 +14,7 @@ describe "TokenizedLine", ->
       expect(editor.lineForScreenRow(7).isOnlyWhitespace()).toBe true
       expect(editor.lineForScreenRow(23).isOnlyWhitespace()).toBe true
 
-    it "returns false when the line is only whitespace", ->
+    it "returns false when the line is not only whitespace", ->
       expect(editor.lineForScreenRow(0).isOnlyWhitespace()).toBe false
       expect(editor.lineForScreenRow(2).isOnlyWhitespace()).toBe false
 

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -177,8 +177,8 @@ class TokenizedBuffer extends Model
 
   invalidateChangedWhitespaceRows: (row, increment) ->
     line = @tokenizedLines[row]
-    if line? and line.isOnlyWhitespace() and @indentLevelForRow(row) != line.indentLevel
-      while line? and line.isOnlyWhitespace()
+    if line?.isOnlyWhitespace() and @indentLevelForRow(row) != line.indentLevel
+      while line?.isOnlyWhitespace()
         @invalidateRow(row)
         row += increment
         line = @tokenizedLines[row]

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -157,32 +157,29 @@ class TokenizedBuffer extends Model
     end = oldRange.end.row
     delta = newRange.end.row - oldRange.end.row
 
-    @invalidateSurroundingChangedWhitespaceRows(start, end)
     @updateInvalidRows(start, end, delta)
     previousEndStack = @stackForRow(end) # used in spill detection below
     newTokenizedLines = @buildTokenizedLinesForRows(start, end + delta, @stackForRow(start - 1))
     _.spliceWithArray(@tokenizedLines, start, end - start + 1, newTokenizedLines)
-    newEndStack = @stackForRow(end + delta)
 
+    start = @retokenizeWhitespaceRowsIfIndentLevelChanged(start - 1, -1)
+    end = @retokenizeWhitespaceRowsIfIndentLevelChanged(newRange.end.row + 1, 1) - delta
+
+    newEndStack = @stackForRow(end + delta)
     if newEndStack and not _.isEqual(newEndStack, previousEndStack)
       @invalidateRow(end + delta + 1)
 
     @emit "changed", { start, end, delta, bufferChange: e }
 
-  invalidateSurroundingChangedWhitespaceRows: (startRow, endRow) ->
-    # Indent levels might change when something else in the buffer changes.
-    # If they do, invalidate those rows.
-    @invalidateChangedWhitespaceRows(startRow - 1, -1)
-    @invalidateChangedWhitespaceRows(endRow + 1, 1)
-
-  invalidateChangedWhitespaceRows: (row, increment) ->
+  retokenizeWhitespaceRowsIfIndentLevelChanged: (row, increment) ->
     line = @tokenizedLines[row]
-    if line?.isOnlyWhitespace() and @indentLevelForRow(row) != line.indentLevel
+    if line?.isOnlyWhitespace() and @indentLevelForRow(row) isnt line.indentLevel
       while line?.isOnlyWhitespace()
-        @invalidateRow(row)
+        @tokenizedLines[row] = @buildTokenizedTokenizedLineForRow(row, @stackForRow(row - 1))
         row += increment
         line = @tokenizedLines[row]
-    return
+
+    row - increment
 
   buildTokenizedLinesForRows: (startRow, endRow, startingStack) ->
     ruleStack = startingStack

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -152,6 +152,14 @@ class TokenizedLine
       break
     false
 
+  isOnlyWhitespace: ->
+    if @text == ''
+      true
+    else
+      for token in @tokens
+        return false unless token.isOnlyWhitespace()
+      true
+
   tokenAtIndex: (index) ->
     @tokens[index]
 


### PR DESCRIPTION
This fixes the indent guide when lines around the whitespace lines change. It will check whitespace lines surrounding a change. If their indent level changes, it will invalidate the whitespace lines.

Fixes this issue:

![ba4df5ea-f898-11e3-9fcd-686fe9e0ea2c](https://cloud.githubusercontent.com/assets/69169/3378927/0bd7fa88-fbea-11e3-8427-0256ec8fa576.png)

@nathansobo will you check the changes in tokenized-buffer and make sure it's legit? Also, let me know if there are benchmarks I can run to make sure typing is ok.

ref #2367
