### PR TITLE
Fix max scroll width in react editor

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1038,6 +1038,7 @@ describe "DisplayBuffer", ->
       displayBuffer.manageScrollPosition = true
       displayBuffer.setLineHeightInPixels(10)
       displayBuffer.setDefaultCharWidth(10)
+      displayBuffer.updateAllScreenLines()
 
     it "disallows negative values", ->
       displayBuffer.setWidth(displayBuffer.getScrollWidth() + 100)
@@ -1062,6 +1063,7 @@ describe "DisplayBuffer", ->
       displayBuffer.setHorizontalScrollbarHeight(0)
       displayBuffer.setHeight(50)
       displayBuffer.setWidth(50)
+      displayBuffer.updateAllScreenLines()
 
     it "sets the scroll top and scroll left so the given screen position is in view", ->
       displayBuffer.scrollToScreenPosition([8, 20])

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1038,7 +1038,6 @@ describe "DisplayBuffer", ->
       displayBuffer.manageScrollPosition = true
       displayBuffer.setLineHeightInPixels(10)
       displayBuffer.setDefaultCharWidth(10)
-      displayBuffer.updateAllScreenLines()
 
     it "disallows negative values", ->
       displayBuffer.setWidth(displayBuffer.getScrollWidth() + 100)
@@ -1063,7 +1062,6 @@ describe "DisplayBuffer", ->
       displayBuffer.setHorizontalScrollbarHeight(0)
       displayBuffer.setHeight(50)
       displayBuffer.setWidth(50)
-      displayBuffer.updateAllScreenLines()
 
     it "sets the scroll top and scroll left so the given screen position is in view", ->
       displayBuffer.scrollToScreenPosition([8, 20])
@@ -1079,3 +1077,21 @@ describe "DisplayBuffer", ->
       it "does not scroll vertically if the position is already in view", ->
         displayBuffer.scrollToScreenPosition([4, 20], center: true)
         expect(displayBuffer.getScrollTop()).toBe 0
+
+  describe "scroll width", ->
+    cursorWidth = 1
+    beforeEach ->
+      displayBuffer.setDefaultCharWidth(10)
+
+    it "recomputes the scroll width when the default character width changes", ->
+      expect(displayBuffer.getScrollWidth()).toBe 10 * 65 + cursorWidth
+
+      displayBuffer.setDefaultCharWidth(12)
+      expect(displayBuffer.getScrollWidth()).toBe 12 * 65 + cursorWidth
+
+    it "recomputes the scroll width when the max line length changes", ->
+      buffer.insert([6, 12], ' ')
+      expect(displayBuffer.getScrollWidth()).toBe 10 * 66 + cursorWidth
+
+      buffer.delete([[6, 10], [6, 12]], ' ')
+      expect(displayBuffer.getScrollWidth()).toBe 10 * 64 + cursorWidth

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -62,7 +62,6 @@ describe "EditorComponent", ->
 
       node.style.height = editor.getLineCount() * lineHeightInPixels + 'px'
       node.style.width = '1000px'
-      editor.displayBuffer.updateAllScreenLines()
       component.measureScrollView()
       nextTick()
 

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -62,6 +62,7 @@ describe "EditorComponent", ->
 
       node.style.height = editor.getLineCount() * lineHeightInPixels + 'px'
       node.style.width = '1000px'
+      editor.displayBuffer.updateAllScreenLines()
       component.measureScrollView()
       nextTick()
 

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -733,6 +733,7 @@ describe "Editor", ->
         editor.setHorizontalScrollbarHeight(0)
         editor.setHeight(5.5 * 10)
         editor.setWidth(5.5 * 10)
+        editor.displayBuffer.updateAllScreenLines()
 
       it "scrolls down when the last cursor gets closer than ::verticalScrollMargin to the bottom of the editor", ->
         expect(editor.getScrollTop()).toBe 0
@@ -1196,6 +1197,8 @@ describe "Editor", ->
           editor.setHeight(50)
           editor.setWidth(50)
           editor.setHorizontalScrollbarHeight(0)
+          editor.displayBuffer.updateAllScreenLines()
+
           expect(editor.getScrollTop()).toBe 0
 
           editor.setSelectedBufferRange([[5, 6], [6, 8]], autoscroll: true)
@@ -1230,6 +1233,7 @@ describe "Editor", ->
         editor.setDefaultCharWidth(10)
         editor.setHeight(50)
         editor.setWidth(50)
+        editor.displayBuffer.updateAllScreenLines()
 
         editor.addSelectionForBufferRange([[8, 10], [8, 15]])
         expect(editor.getScrollTop()).toBe 75

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -733,7 +733,6 @@ describe "Editor", ->
         editor.setHorizontalScrollbarHeight(0)
         editor.setHeight(5.5 * 10)
         editor.setWidth(5.5 * 10)
-        editor.displayBuffer.updateAllScreenLines()
 
       it "scrolls down when the last cursor gets closer than ::verticalScrollMargin to the bottom of the editor", ->
         expect(editor.getScrollTop()).toBe 0
@@ -1197,7 +1196,6 @@ describe "Editor", ->
           editor.setHeight(50)
           editor.setWidth(50)
           editor.setHorizontalScrollbarHeight(0)
-          editor.displayBuffer.updateAllScreenLines()
 
           expect(editor.getScrollTop()).toBe 0
 
@@ -1233,7 +1231,6 @@ describe "Editor", ->
         editor.setDefaultCharWidth(10)
         editor.setHeight(50)
         editor.setWidth(50)
-        editor.displayBuffer.updateAllScreenLines()
 
         editor.addSelectionForBufferRange([[8, 10], [8, 15]])
         expect(editor.getScrollTop()).toBe 75

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -239,7 +239,7 @@ class DisplayBuffer extends Model
     @getLineCount() * @getLineHeightInPixels()
 
   getScrollWidth: ->
-    (@getMaxLineLength() * @getDefaultCharWidth()) + @getCursorWidth()
+    @scrollWidth
 
   getVisibleRowRange: ->
     return [0, 0] unless @getLineHeightInPixels() > 0
@@ -980,6 +980,9 @@ class DisplayBuffer extends Model
     @rowMap.spliceRegions(startBufferRow, endBufferRow - startBufferRow, regions)
     @findMaxLineLength(startScreenRow, endScreenRow, screenLines)
 
+    if startBufferRow <= @longestScreenRow < endScreenRow
+      @computeScrollWidth()
+
     return if options.suppressChangeEvent
 
     changeEvent =
@@ -1056,6 +1059,8 @@ class DisplayBuffer extends Model
         @longestScreenRow = maxLengthCandidatesStartRow + screenRow
         @maxLineLength = length
 
+  computeScrollWidth: ->
+    @scrollWidth = @pixelPositionForScreenPosition([@longestScreenRow, @maxLineLength]).left + 1
   handleBufferMarkersUpdated: =>
     if event = @pendingChangeEvent
       @pendingChangeEvent = null

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -208,7 +208,11 @@ class DisplayBuffer extends Model
   setLineHeightInPixels: (@lineHeightInPixels) -> @lineHeightInPixels
 
   getDefaultCharWidth: -> @defaultCharWidth
-  setDefaultCharWidth: (@defaultCharWidth) -> @defaultCharWidth
+  setDefaultCharWidth: (defaultCharWidth) ->
+    if defaultCharWidth isnt @defaultCharWidth
+      @defaultCharWidth = defaultCharWidth
+      @computeScrollWidth()
+    defaultCharWidth
 
   getCursorWidth: -> 1
 
@@ -981,9 +985,6 @@ class DisplayBuffer extends Model
     @rowMap.spliceRegions(startBufferRow, endBufferRow - startBufferRow, regions)
     @findMaxLineLength(startScreenRow, endScreenRow, screenLines)
 
-    if startBufferRow <= @longestScreenRow < endScreenRow
-      @computeScrollWidth()
-
     return if options.suppressChangeEvent
 
     changeEvent =
@@ -1045,6 +1046,8 @@ class DisplayBuffer extends Model
     {screenLines, regions}
 
   findMaxLineLength: (startScreenRow, endScreenRow, newScreenLines) ->
+    oldMaxLineLength = @maxLineLength
+
     if startScreenRow <= @longestScreenRow < endScreenRow
       @longestScreenRow = 0
       @maxLineLength = 0
@@ -1060,7 +1063,7 @@ class DisplayBuffer extends Model
         @longestScreenRow = maxLengthCandidatesStartRow + screenRow
         @maxLineLength = length
 
-    return
+    @computeScrollWidth() if oldMaxLineLength isnt @maxLineLength
 
   computeScrollWidth: ->
     @scrollWidth = @pixelPositionForScreenPosition([@longestScreenRow, @maxLineLength]).left + 1

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -1059,6 +1059,8 @@ class DisplayBuffer extends Model
         @longestScreenRow = maxLengthCandidatesStartRow + screenRow
         @maxLineLength = length
 
+    return
+
   computeScrollWidth: ->
     @scrollWidth = @pixelPositionForScreenPosition([@longestScreenRow, @maxLineLength]).left + 1
   handleBufferMarkersUpdated: =>

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -29,6 +29,7 @@ class DisplayBuffer extends Model
     width: null
     scrollTop: 0
     scrollLeft: 0
+    scrollWidth: 0
 
   verticalScrollMargin: 2
   horizontalScrollMargin: 6

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -227,13 +227,21 @@ class DisplayBuffer extends Model
     scope.charWidths ?= {}
     scope.charWidths
 
+  batchCharacterMeasurement: (fn) ->
+    oldChangeCount = @scopedCharacterWidthsChangeCount
+    @batchingCharacterMeasurement = true
+    fn()
+    @batchingCharacterMeasurement = false
+    @characterWidthsChanged() if oldChangeCount isnt @scopedCharacterWidthsChangeCount
+
   setScopedCharWidth: (scopeNames, char, width) ->
     @getScopedCharWidths(scopeNames)[char] = width
-    @emit 'character-widths-changed', @scopedCharacterWidthsChangeCount++
+    @scopedCharacterWidthsChangeCount++
+    @characterWidthsChanged() unless @batchingCharacterMeasurement
 
-  setScopedCharWidths: (scopeNames, charWidths) ->
-    _.extend(@getScopedCharWidths(scopeNames), charWidths)
-    @emit 'character-widths-changed', @scopedCharacterWidthsChangeCount++
+  characterWidthsChanged: ->
+    @computeScrollWidth()
+    @emit 'character-widths-changed', @scopedCharacterWidthsChangeCount
 
   clearScopedCharWidths: ->
     @charWidthsByScope = {}

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -1064,6 +1064,7 @@ class DisplayBuffer extends Model
 
   computeScrollWidth: ->
     @scrollWidth = @pixelPositionForScreenPosition([@longestScreenRow, @maxLineLength]).left + 1
+
   handleBufferMarkersUpdated: =>
     if event = @pendingChangeEvent
       @pendingChangeEvent = null

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1975,6 +1975,8 @@ class Editor extends Model
   getLineHeightInPixels: -> @displayBuffer.getLineHeightInPixels()
   setLineHeightInPixels: (lineHeightInPixels) -> @displayBuffer.setLineHeightInPixels(lineHeightInPixels)
 
+  batchCharacterMeasurement: (fn) -> @displayBuffer.batchCharacterMeasurement(fn)
+
   getScopedCharWidth: (scopeNames, char) -> @displayBuffer.getScopedCharWidth(scopeNames, char)
   setScopedCharWidth: (scopeNames, char, width) -> @displayBuffer.setScopedCharWidth(scopeNames, char, width)
 

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -248,10 +248,12 @@ LinesComponent = React.createClass
     [visibleStartRow, visibleEndRow] = @props.renderedRowRange
     node = @getDOMNode()
 
-    for tokenizedLine in editor.linesForScreenRows(visibleStartRow, visibleEndRow - 1)
-      unless @measuredLines.has(tokenizedLine)
-        lineNode = @lineNodesByLineId[tokenizedLine.id]
-        @measureCharactersInLine(tokenizedLine, lineNode)
+    editor.batchCharacterMeasurement =>
+      for tokenizedLine in editor.linesForScreenRows(visibleStartRow, visibleEndRow - 1)
+        unless @measuredLines.has(tokenizedLine)
+          lineNode = @lineNodesByLineId[tokenizedLine.id]
+          @measureCharactersInLine(tokenizedLine, lineNode)
+      return
 
   measureCharactersInLine: (tokenizedLine, lineNode) ->
     {editor} = @props


### PR DESCRIPTION
This should fix #2666 

It basically calculates the scrollWidth by measuring the longest line. 

It feels dirty, though, because I have to change a bunch of tests to first call `DisplayBuffer.updateAllScreenRows`. Why is this? It seems `updateAllScreenRows` is called in the DisplayBuffer's constructor. I'm looking more into this. How can I make this not suck @nathansobo?

It fixes #2666 except in one case: initial load. I assume this is because lines are measured before styling has been applied. Looking into this as well...
