### PR TITLE
Never allow partial pixel values for scroll

### DIFF
--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -181,9 +181,9 @@ class DisplayBuffer extends Model
   getScrollTop: -> @scrollTop
   setScrollTop: (scrollTop) ->
     if @manageScrollPosition
-      @scrollTop = Math.max(0, Math.min(@getScrollHeight() - @getClientHeight(), scrollTop))
+      @scrollTop = Math.round(Math.max(0, Math.min(@getScrollHeight() - @getClientHeight(), scrollTop)))
     else
-      @scrollTop = scrollTop
+      @scrollTop = Math.round(scrollTop)
 
   getScrollBottom: -> @scrollTop + @height
   setScrollBottom: (scrollBottom) ->
@@ -193,10 +193,10 @@ class DisplayBuffer extends Model
   getScrollLeft: -> @scrollLeft
   setScrollLeft: (scrollLeft) ->
     if @manageScrollPosition
-      @scrollLeft = Math.max(0, Math.min(@getScrollWidth() - @getClientWidth(), scrollLeft))
+      @scrollLeft = Math.round(Math.max(0, Math.min(@getScrollWidth() - @getClientWidth(), scrollLeft)))
       @scrollLeft
     else
-      @scrollLeft = scrollLeft
+      @scrollLeft = Math.round(scrollLeft)
 
   getScrollRight: -> @scrollLeft + @width
   setScrollRight: (scrollRight) ->


### PR DESCRIPTION
I was getting partial pixels for `scrollTop`/`Left` which were making things really blurry. This does a `Math.round`. Check it:

![screen shot 2014-06-24 at 6 10 11 pm](https://cloud.githubusercontent.com/assets/69169/3380409/84bdb06c-fc05-11e3-946e-1ef0a591d747.png)

I was able to consistently repro on an external display, full height with `display-buffer.coffee` open, and doing a symbol search for `pixelPositionForScreenRow`.
