### PR TITLE
Autoscroll cursor when attempting to move it, even if it doesn't move

### DIFF
--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -29,9 +29,6 @@ class Cursor extends Model
       # Supports old editor view
       @needsAutoscroll ?= @isLastCursor() and !textChanged
 
-      # Supports react editor view
-      @autoscroll() if @needsAutoscroll and @editor.manageScrollPosition
-
       @goalColumn = null
 
       movedEvent =
@@ -55,8 +52,10 @@ class Cursor extends Model
   changePosition: (options, fn) ->
     @clearSelection()
     @needsAutoscroll = options.autoscroll ? @isLastCursor()
-    unless fn()
-      @emit 'autoscrolled' if @needsAutoscroll
+    fn()
+    if @needsAutoscroll
+      @emit 'autoscrolled' # Support legacy editor
+      @autoscroll() if @needsAutoscroll and @editor.manageScrollPosition # Support react editor view
 
   getPixelRect: ->
     @editor.pixelRectForScreenRange(@getScreenRange())


### PR DESCRIPTION
Fixes #2723

The model-level autoscroll should always have sat next to the place we emit the 'autoscrolled' event. We should autoscroll even if the cursor doesn't actually move, for example when trying to move down at the end of the file.
