### PR TITLE
Ignore generated files in resources/linux.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ debug.log
 docs/output
 docs/includes
 spec/fixtures/evil-files/
+resources/linux/Atom.desktop
+resources/linux/debian/control


### PR DESCRIPTION
Running `sudo script/grunt install` from a fresh clone generates an untracked file in `resources/linux`:

``` bash
smash@winter ~/code/atom (master=) $ sudo script/grunt install
[sudo] password for smash: 
Running "install" task
Done, without errors.
smash@winter ~/code/atom (master %=) $ git status
# On branch master
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#   resources/linux/Atom.desktop
nothing added to commit but untracked files present (use "git add" to track)
```

This is a tiny patch to `.gitignore` the generated resource. I added `resources/linux/debian/control` from `mkdeb` while I was at it.
