### PR TITLE
Upgrade scandal to handle file read errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-atom-fork": "^0.10.0",
     "reactionary-atom-fork": "^0.9.0",
     "runas": "0.5.4",
-    "scandal": "0.15.3",
+    "scandal": "0.16.0",
     "scoped-property-store": "^0.9.0",
     "scrollbar-style": "^0.4.0",
     "season": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "dev-live-reload": "0.31.0",
     "exception-reporting": "0.18.0",
     "feedback": "0.33.0",
-    "find-and-replace": "0.121.0",
+    "find-and-replace": "0.122.0",
     "fuzzy-finder": "0.56.0",
     "git-diff": "0.34.0",
     "go-to-line": "0.23.0",

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -205,6 +205,17 @@ describe "Project", ->
       fs.writeFileSync(filePath, sampleContent)
       fs.writeFileSync(commentFilePath, sampleCommentContent)
 
+    describe "when a file doesnt exist", ->
+      it "calls back with an error", ->
+        errors = []
+        waitsForPromise ->
+          atom.project.replace /items/gi, 'items', ['/not-a-file.js'], (result, error) ->
+            errors.push(error)
+
+        runs ->
+          expect(errors).toHaveLength 1
+          expect(errors[0].path).toBe '/not-a-file.js'
+
     describe "when called with unopened files", ->
       it "replaces properly", ->
         results = []

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -205,7 +205,7 @@ describe "Project", ->
       fs.writeFileSync(filePath, sampleContent)
       fs.writeFileSync(commentFilePath, sampleCommentContent)
 
-    describe "when a file doesnt exist", ->
+    describe "when a file doesn't exist", ->
       it "calls back with an error", ->
         errors = []
         waitsForPromise ->

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -239,7 +239,7 @@ class Project extends Model
     task.on 'scan:result-found', (result) =>
       iterator(result) unless @isPathModified(result.filePath)
 
-    task.on 'scan:file-error', (error) =>
+    task.on 'scan:file-error', (error) ->
       iterator(null, error)
 
     if _.isFunction(options.onPathsSearched)

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -239,6 +239,9 @@ class Project extends Model
     task.on 'scan:result-found', (result) =>
       iterator(result) unless @isPathModified(result.filePath)
 
+    task.on 'scan:file-error', (error) =>
+      iterator(null, error)
+
     if _.isFunction(options.onPathsSearched)
       task.on 'scan:paths-searched', (numberOfPathsSearched) ->
         options.onPathsSearched(numberOfPathsSearched)
@@ -283,6 +286,7 @@ class Project extends Model
         checkFinished()
 
       task.on 'replace:path-replaced', iterator
+      task.on 'replace:file-error', (error) -> iterator(null, error)
 
     for buffer in @getBuffers()
       continue unless buffer.getPath() in filePaths

--- a/src/replace-handler.coffee
+++ b/src/replace-handler.coffee
@@ -6,8 +6,11 @@ module.exports = (filePaths, regexSource, regexFlags, replacementText) ->
   replacer = new PathReplacer()
   regex = new RegExp(regexSource, regexFlags)
 
+  replacer.on 'file-error', (e) ->
+    error = {code: e.code, path: e.path, message: e.message}
+    emit('replace:file-error', error)
+
   replacer.on 'path-replaced', (result) ->
     emit('replace:path-replaced', result)
 
-  replacer.replacePaths regex, replacementText, filePaths, ->
-    callback()
+  replacer.replacePaths(regex, replacementText, filePaths, -> callback())

--- a/src/replace-handler.coffee
+++ b/src/replace-handler.coffee
@@ -6,9 +6,8 @@ module.exports = (filePaths, regexSource, regexFlags, replacementText) ->
   replacer = new PathReplacer()
   regex = new RegExp(regexSource, regexFlags)
 
-  replacer.on 'file-error', (e) ->
-    error = {code: e.code, path: e.path, message: e.message}
-    emit('replace:file-error', error)
+  replacer.on 'file-error', ({code, path, message}) ->
+    emit('replace:file-error', {code, path, message})
 
   replacer.on 'path-replaced', (result) ->
     emit('replace:path-replaced', result)

--- a/src/scan-handler.coffee
+++ b/src/scan-handler.coffee
@@ -9,6 +9,10 @@ module.exports = (rootPath, regexSource, options) ->
   searcher = new PathSearcher()
   scanner = new PathScanner(rootPath, options)
 
+  searcher.on 'file-error', (e) ->
+    error = {code: e.code, path: e.path, message: e.message}
+    emit('scan:file-error', error)
+
   searcher.on 'results-found', (result) ->
     emit('scan:result-found', result)
 

--- a/src/scan-handler.coffee
+++ b/src/scan-handler.coffee
@@ -9,9 +9,8 @@ module.exports = (rootPath, regexSource, options) ->
   searcher = new PathSearcher()
   scanner = new PathScanner(rootPath, options)
 
-  searcher.on 'file-error', (e) ->
-    error = {code: e.code, path: e.path, message: e.message}
-    emit('scan:file-error', error)
+  searcher.on 'file-error', ({code, path, message}) ->
+    emit('scan:file-error', {code, path, message})
 
   searcher.on 'results-found', (result) ->
     emit('scan:result-found', result)


### PR DESCRIPTION
Right now, if find-and-replace / scandal encounters a bogus or unreadable file, it just doesnt finish. No good. This bubbles errors up from the new scandal to the consumer of the `project.scan` and `project.replace`.

I need help testing this. Testing the replace is easy as we pass in a list of paths, so I can just pass a bogus path in there. Testing `project.scan` is harder because it wont try to open any files that dont exist, and I dont know how to reliably (across machines) get it to scan a file the test user cant access. If you have ideas, let me know.

See atom/scandal#15 and atom/find-and-replace#243

Fixes atom/find-and-replace#192
Fixes atom/find-and-replace#197
Fixes atom/find-and-replace#242
