### PR TITLE
Add editor.useHardwareAcceleration option to allow React editor to not use GPU layers

### DIFF
--- a/src/cursor-component.coffee
+++ b/src/cursor-component.coffee
@@ -7,14 +7,23 @@ CursorComponent = React.createClass
   displayName: 'CursorComponent'
 
   render: ->
-    {pixelRect, scrollTop, scrollLeft, defaultCharWidth} = @props
-    {top, left, height, width} = pixelRect
-    top -= scrollTop
-    left -= scrollLeft
+    {pixelRect, defaultCharWidth} = @props
+    {height, width} = pixelRect
     width = defaultCharWidth if width is 0
-    WebkitTransform = "translate3d(#{left}px, #{top}px, 0px)"
+    WebkitTransform = @getTransform()
 
     div className: 'cursor', style: {height, width, WebkitTransform}
+
+  getTransform: ->
+    {pixelRect, scrollTop, scrollLeft, gpuDisabled} = @props
+    {top, left} = pixelRect
+    top -= scrollTop
+    left -= scrollLeft
+
+    if gpuDisabled
+      "translate(#{left}px, #{top}px)"
+    else
+      "translate3d(#{left}px, #{top}px, 0px)"
 
   shouldComponentUpdate: (newProps) ->
     not isEqualForProperties(newProps, @props, 'pixelRect', 'scrollTop', 'scrollLeft', 'defaultCharWidth')

--- a/src/cursor-component.coffee
+++ b/src/cursor-component.coffee
@@ -15,15 +15,15 @@ CursorComponent = React.createClass
     div className: 'cursor', style: {height, width, WebkitTransform}
 
   getTransform: ->
-    {pixelRect, scrollTop, scrollLeft, gpuDisabled} = @props
+    {pixelRect, scrollTop, scrollLeft, useHardwareAcceleration} = @props
     {top, left} = pixelRect
     top -= scrollTop
     left -= scrollLeft
 
-    if gpuDisabled
-      "translate(#{left}px, #{top}px)"
-    else
+    if useHardwareAcceleration
       "translate3d(#{left}px, #{top}px, 0px)"
+    else
+      "translate(#{left}px, #{top}px)"
 
   shouldComponentUpdate: (newProps) ->
     not isEqualForProperties(newProps, @props, 'pixelRect', 'scrollTop', 'scrollLeft', 'defaultCharWidth')

--- a/src/cursors-component.coffee
+++ b/src/cursors-component.coffee
@@ -12,7 +12,7 @@ CursorsComponent = React.createClass
   cursorBlinkIntervalHandle: null
 
   render: ->
-    {cursorPixelRects, scrollTop, scrollLeft, defaultCharWidth} = @props
+    {cursorPixelRects, scrollTop, scrollLeft, defaultCharWidth, gpuDisabled} = @props
     {blinkOff} = @state
 
     className = 'cursors'
@@ -34,7 +34,7 @@ CursorsComponent = React.createClass
 
   shouldComponentUpdate: (newProps, newState) ->
     not newState.blinkOff is @state.blinkOff or
-      not isEqualForProperties(newProps, @props, 'cursorPixelRects', 'scrollTop', 'scrollLeft', 'defaultCharWidth')
+      not isEqualForProperties(newProps, @props, 'cursorPixelRects', 'scrollTop', 'scrollLeft', 'defaultCharWidth', 'gpuDisabled')
 
   componentWillUpdate: (newProps) ->
     cursorsMoved = @props.cursorPixelRects? and

--- a/src/cursors-component.coffee
+++ b/src/cursors-component.coffee
@@ -12,7 +12,7 @@ CursorsComponent = React.createClass
   cursorBlinkIntervalHandle: null
 
   render: ->
-    {cursorPixelRects, scrollTop, scrollLeft, defaultCharWidth, gpuDisabled} = @props
+    {cursorPixelRects, scrollTop, scrollLeft, defaultCharWidth, useHardwareAcceleration} = @props
     {blinkOff} = @state
 
     className = 'cursors'
@@ -34,7 +34,7 @@ CursorsComponent = React.createClass
 
   shouldComponentUpdate: (newProps, newState) ->
     not newState.blinkOff is @state.blinkOff or
-      not isEqualForProperties(newProps, @props, 'cursorPixelRects', 'scrollTop', 'scrollLeft', 'defaultCharWidth', 'gpuDisabled')
+      not isEqualForProperties(newProps, @props, 'cursorPixelRects', 'scrollTop', 'scrollLeft', 'defaultCharWidth', 'useHardwareAcceleration')
 
   componentWillUpdate: (newProps) ->
     cursorsMoved = @props.cursorPixelRects? and

--- a/src/cursors-component.coffee
+++ b/src/cursors-component.coffee
@@ -21,7 +21,7 @@ CursorsComponent = React.createClass
     div {className},
       if @isMounted()
         for key, pixelRect of cursorPixelRects
-          CursorComponent({key, pixelRect, scrollTop, scrollLeft, defaultCharWidth})
+          CursorComponent({key, pixelRect, scrollTop, scrollLeft, defaultCharWidth, useHardwareAcceleration})
 
   getInitialState: ->
     blinkOff: false

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -74,7 +74,7 @@ EditorComponent = React.createClass
       verticallyScrollable = editor.verticallyScrollable()
       horizontallyScrollable = editor.horizontallyScrollable()
       hiddenInputStyle = @getHiddenInputPosition()
-      hiddenInputStyle.WebkitTransform = 'translateZ(0)' unless @gpuDisabled
+      hiddenInputStyle.WebkitTransform = 'translateZ(0)' if @useHardwareAcceleration
       if @mouseWheelScreenRow? and not (renderedStartRow <= @mouseWheelScreenRow < renderedEndRow)
         mouseWheelScreenRow = @mouseWheelScreenRow
 
@@ -87,7 +87,7 @@ EditorComponent = React.createClass
         GutterComponent {
           ref: 'gutter', onMouseDown: @onGutterMouseDown, onWidthChanged: @onGutterWidthChanged,
           lineDecorations, defaultCharWidth, editor, renderedRowRange, maxLineNumberDigits, scrollViewHeight,
-          scrollTop, scrollHeight, lineHeightInPixels, @pendingChanges, mouseWheelScreenRow, @gpuDisabled
+          scrollTop, scrollHeight, lineHeightInPixels, @pendingChanges, mouseWheelScreenRow, @useHardwareAcceleration
         }
 
       div ref: 'scrollView', className: 'scroll-view', onMouseDown: @onMouseDown,
@@ -100,14 +100,14 @@ EditorComponent = React.createClass
 
         CursorsComponent {
           scrollTop, scrollLeft, cursorPixelRects, cursorBlinkPeriod, cursorBlinkResumeDelay,
-          lineHeightInPixels, defaultCharWidth, @scopedCharacterWidthsChangeCount, @gpuDisabled
+          lineHeightInPixels, defaultCharWidth, @scopedCharacterWidthsChangeCount, @useHardwareAcceleration
         }
         LinesComponent {
           ref: 'lines',
           editor, lineHeightInPixels, defaultCharWidth, lineDecorations, highlightDecorations,
           showIndentGuide, renderedRowRange, @pendingChanges, scrollTop, scrollLeft,
           @scrollingVertically, scrollHeight, scrollWidth, mouseWheelScreenRow, invisibles,
-          visible, scrollViewHeight, @scopedCharacterWidthsChangeCount, lineWidth, @gpuDisabled
+          visible, scrollViewHeight, @scopedCharacterWidthsChangeCount, lineWidth, @useHardwareAcceleration
         }
 
       ScrollbarComponent
@@ -481,7 +481,7 @@ EditorComponent = React.createClass
     @subscribe atom.config.observe 'editor.showInvisibles', @setShowInvisibles
     @subscribe atom.config.observe 'editor.showLineNumbers', @setShowLineNumbers
     @subscribe atom.config.observe 'editor.scrollSensitivity', @setScrollSensitivity
-    @subscribe atom.config.observe 'editor.gpuDisabled', @setGPUDisabled
+    @subscribe atom.config.observe 'editor.useHardwareAcceleration', @setuseHardwareAcceleration
 
   onFocus: ->
     @refs.input.focus()
@@ -874,9 +874,9 @@ EditorComponent = React.createClass
     if scrollSensitivity = parseInt(scrollSensitivity)
       @scrollSensitivity = Math.abs(scrollSensitivity) / 100
 
-  setGPUDisabled: (gpuDisabled) ->
-    unless @gpuDisabled is gpuDisabled
-      @gpuDisabled = gpuDisabled
+  setuseHardwareAcceleration: (useHardwareAcceleration) ->
+    unless @useHardwareAcceleration is useHardwareAcceleration
+      @useHardwareAcceleration = useHardwareAcceleration
       @requestUpdate()
 
   screenPositionForMouseEvent: (event) ->

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -74,7 +74,7 @@ EditorComponent = React.createClass
       verticallyScrollable = editor.verticallyScrollable()
       horizontallyScrollable = editor.horizontallyScrollable()
       hiddenInputStyle = @getHiddenInputPosition()
-      hiddenInputStyle.WebkitTransform = 'translateZ(0)'
+      hiddenInputStyle.WebkitTransform = 'translateZ(0)' unless @gpuDisabled
       if @mouseWheelScreenRow? and not (renderedStartRow <= @mouseWheelScreenRow < renderedEndRow)
         mouseWheelScreenRow = @mouseWheelScreenRow
 
@@ -87,7 +87,7 @@ EditorComponent = React.createClass
         GutterComponent {
           ref: 'gutter', onMouseDown: @onGutterMouseDown, onWidthChanged: @onGutterWidthChanged,
           lineDecorations, defaultCharWidth, editor, renderedRowRange, maxLineNumberDigits, scrollViewHeight,
-          scrollTop, scrollHeight, lineHeightInPixels, @pendingChanges, mouseWheelScreenRow
+          scrollTop, scrollHeight, lineHeightInPixels, @pendingChanges, mouseWheelScreenRow, @gpuDisabled
         }
 
       div ref: 'scrollView', className: 'scroll-view', onMouseDown: @onMouseDown,
@@ -100,14 +100,14 @@ EditorComponent = React.createClass
 
         CursorsComponent {
           scrollTop, scrollLeft, cursorPixelRects, cursorBlinkPeriod, cursorBlinkResumeDelay,
-          lineHeightInPixels, defaultCharWidth, @scopedCharacterWidthsChangeCount
+          lineHeightInPixels, defaultCharWidth, @scopedCharacterWidthsChangeCount, @gpuDisabled
         }
         LinesComponent {
           ref: 'lines',
           editor, lineHeightInPixels, defaultCharWidth, lineDecorations, highlightDecorations,
           showIndentGuide, renderedRowRange, @pendingChanges, scrollTop, scrollLeft,
           @scrollingVertically, scrollHeight, scrollWidth, mouseWheelScreenRow, invisibles,
-          visible, scrollViewHeight, @scopedCharacterWidthsChangeCount, lineWidth
+          visible, scrollViewHeight, @scopedCharacterWidthsChangeCount, lineWidth, @gpuDisabled
         }
 
       ScrollbarComponent
@@ -481,6 +481,7 @@ EditorComponent = React.createClass
     @subscribe atom.config.observe 'editor.showInvisibles', @setShowInvisibles
     @subscribe atom.config.observe 'editor.showLineNumbers', @setShowLineNumbers
     @subscribe atom.config.observe 'editor.scrollSensitivity', @setScrollSensitivity
+    @subscribe atom.config.observe 'editor.gpuDisabled', @setGPUDisabled
 
   onFocus: ->
     @refs.input.focus()
@@ -872,6 +873,11 @@ EditorComponent = React.createClass
   setScrollSensitivity: (scrollSensitivity) ->
     if scrollSensitivity = parseInt(scrollSensitivity)
       @scrollSensitivity = Math.abs(scrollSensitivity) / 100
+
+  setGPUDisabled: (gpuDisabled) ->
+    unless @gpuDisabled is gpuDisabled
+      @gpuDisabled = gpuDisabled
+      @requestUpdate()
 
   screenPositionForMouseEvent: (event) ->
     pixelPosition = @pixelPositionForMouseEvent(event)

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -481,7 +481,7 @@ EditorComponent = React.createClass
     @subscribe atom.config.observe 'editor.showInvisibles', @setShowInvisibles
     @subscribe atom.config.observe 'editor.showLineNumbers', @setShowLineNumbers
     @subscribe atom.config.observe 'editor.scrollSensitivity', @setScrollSensitivity
-    @subscribe atom.config.observe 'editor.useHardwareAcceleration', @setuseHardwareAcceleration
+    @subscribe atom.config.observe 'editor.useHardwareAcceleration', @setUseHardwareAcceleration
 
   onFocus: ->
     @refs.input.focus()
@@ -874,7 +874,7 @@ EditorComponent = React.createClass
     if scrollSensitivity = parseInt(scrollSensitivity)
       @scrollSensitivity = Math.abs(scrollSensitivity) / 100
 
-  setuseHardwareAcceleration: (useHardwareAcceleration) ->
+  setUseHardwareAcceleration: (useHardwareAcceleration=true) ->
     unless @useHardwareAcceleration is useHardwareAcceleration
       @useHardwareAcceleration = useHardwareAcceleration
       @requestUpdate()

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -57,7 +57,7 @@ class EditorView extends View
     softTabs: true
     softWrapAtPreferredLineLength: false
     scrollSensitivity: 40
-    gpuDisabled: false
+    useHardwareAcceleration: true
 
   @nextEditorId: 1
 

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -57,6 +57,7 @@ class EditorView extends View
     softTabs: true
     softWrapAtPreferredLineLength: false
     scrollSensitivity: 40
+    gpuDisabled: false
 
   @nextEditorId: 1
 

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -25,12 +25,12 @@ GutterComponent = React.createClass
         WebkitTransform: @getTransform()
 
   getTransform: ->
-    {scrollTop, gpuDisabled} = @props
+    {scrollTop, useHardwareAcceleration} = @props
 
-    if gpuDisabled
-      "translate(0px, #{-scrollTop}px)"
-    else
+    if useHardwareAcceleration
       "translate3d(0px, #{-scrollTop}px, 0px)"
+    else
+      "translate(0px, #{-scrollTop}px)"
 
   componentWillMount: ->
     @lineNumberNodesById = {}
@@ -47,7 +47,7 @@ GutterComponent = React.createClass
   shouldComponentUpdate: (newProps) ->
     return true unless isEqualForProperties(newProps, @props,
       'renderedRowRange', 'scrollTop', 'lineHeightInPixels', 'mouseWheelScreenRow', 'lineDecorations',
-      'scrollViewHeight', 'gpuDisabled'
+      'scrollViewHeight', 'useHardwareAcceleration'
     )
 
     {renderedRowRange, pendingChanges, lineDecorations} = newProps

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -15,14 +15,22 @@ GutterComponent = React.createClass
   measuredWidth: null
 
   render: ->
-    {scrollHeight, scrollViewHeight, scrollTop, onMouseDown} = @props
+    {scrollHeight, scrollViewHeight, onMouseDown} = @props
 
     div className: 'gutter', onClick: @onClick, onMouseDown: onMouseDown,
       # The line-numbers div must have the 'editor-colors' class so it has an
       # opaque background to avoid sub-pixel anti-aliasing problems on the GPU
       div className: 'gutter line-numbers editor-colors', ref: 'lineNumbers', style:
         height: Math.max(scrollHeight, scrollViewHeight)
-        WebkitTransform: "translate3d(0px, #{-scrollTop}px, 0px)"
+        WebkitTransform: @getTransform()
+
+  getTransform: ->
+    {scrollTop, gpuDisabled} = @props
+
+    if gpuDisabled
+      "translate(0px, #{-scrollTop}px)"
+    else
+      "translate3d(0px, #{-scrollTop}px, 0px)"
 
   componentWillMount: ->
     @lineNumberNodesById = {}
@@ -39,7 +47,7 @@ GutterComponent = React.createClass
   shouldComponentUpdate: (newProps) ->
     return true unless isEqualForProperties(newProps, @props,
       'renderedRowRange', 'scrollTop', 'lineHeightInPixels', 'mouseWheelScreenRow', 'lineDecorations',
-      'scrollViewHeight'
+      'scrollViewHeight', 'gpuDisabled'
     )
 
     {renderedRowRange, pendingChanges, lineDecorations} = newProps

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -16,17 +16,25 @@ LinesComponent = React.createClass
 
   render: ->
     if @isMounted()
-      {editor, highlightDecorations, scrollTop, scrollLeft, scrollHeight, scrollWidth} = @props
+      {editor, highlightDecorations, scrollHeight, scrollWidth} = @props
       {lineHeightInPixels, defaultCharWidth, scrollViewHeight, scopedCharacterWidthsChangeCount} = @props
       style =
         height: Math.max(scrollHeight, scrollViewHeight)
         width: scrollWidth
-        WebkitTransform: "translate3d(#{-scrollLeft}px, #{-scrollTop}px, 0px)"
+        WebkitTransform: @getTransform()
 
     # The lines div must have the 'editor-colors' class so it has an opaque
     # background to avoid sub-pixel anti-aliasing problems on the GPU
     div {className: 'lines editor-colors', style},
       HighlightsComponent({editor, highlightDecorations, lineHeightInPixels, defaultCharWidth, scopedCharacterWidthsChangeCount})
+
+  getTransform: ->
+    {scrollTop, scrollLeft, gpuDisabled} = @props
+
+    if gpuDisabled
+      "translate(#{-scrollLeft}px, #{-scrollTop}px)"
+    else
+      "translate3d(#{-scrollLeft}px, #{-scrollTop}px, 0px)"
 
   componentWillMount: ->
     @measuredLines = new WeakSet
@@ -39,7 +47,7 @@ LinesComponent = React.createClass
     return true unless isEqualForProperties(newProps, @props,
       'renderedRowRange', 'lineDecorations', 'highlightDecorations', 'lineHeightInPixels', 'defaultCharWidth',
       'scrollTop', 'scrollLeft', 'showIndentGuide', 'scrollingVertically', 'invisibles', 'visible',
-      'scrollViewHeight', 'mouseWheelScreenRow', 'scopedCharacterWidthsChangeCount', 'lineWidth'
+      'scrollViewHeight', 'mouseWheelScreenRow', 'scopedCharacterWidthsChangeCount', 'lineWidth', 'gpuDisabled'
     )
 
     {renderedRowRange, pendingChanges} = newProps

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -29,12 +29,12 @@ LinesComponent = React.createClass
       HighlightsComponent({editor, highlightDecorations, lineHeightInPixels, defaultCharWidth, scopedCharacterWidthsChangeCount})
 
   getTransform: ->
-    {scrollTop, scrollLeft, gpuDisabled} = @props
+    {scrollTop, scrollLeft, useHardwareAcceleration} = @props
 
-    if gpuDisabled
-      "translate(#{-scrollLeft}px, #{-scrollTop}px)"
-    else
+    if useHardwareAcceleration
       "translate3d(#{-scrollLeft}px, #{-scrollTop}px, 0px)"
+    else
+      "translate(#{-scrollLeft}px, #{-scrollTop}px)"
 
   componentWillMount: ->
     @measuredLines = new WeakSet
@@ -47,7 +47,7 @@ LinesComponent = React.createClass
     return true unless isEqualForProperties(newProps, @props,
       'renderedRowRange', 'lineDecorations', 'highlightDecorations', 'lineHeightInPixels', 'defaultCharWidth',
       'scrollTop', 'scrollLeft', 'showIndentGuide', 'scrollingVertically', 'invisibles', 'visible',
-      'scrollViewHeight', 'mouseWheelScreenRow', 'scopedCharacterWidthsChangeCount', 'lineWidth', 'gpuDisabled'
+      'scrollViewHeight', 'mouseWheelScreenRow', 'scopedCharacterWidthsChangeCount', 'lineWidth', 'useHardwareAcceleration'
     )
 
     {renderedRowRange, pendingChanges} = newProps


### PR DESCRIPTION
The following issues fixed by this PR have to do with using the GPU for rendering.
- Fixes #2511. Font rendering is a bit different on OS X when the GPU is employed due to issues with subpixel anti-aliasing, so this allows it to be disabled at the cost of performance if the user truly can't stand it. If we get a lot of complaints, we may want to auto-disable the GPU on non-retina displays.
- Fixes #2769. It seems like there are bugs on Linux with certain graphics drivers. A quick workaround is just disabling the GPU entirely. Hopefully these issues will be addressed as Chromium evolves.

![gpu-disabled](https://cloud.githubusercontent.com/assets/1789/3447052/1d6c4bd2-0149-11e4-9ee0-3048230eb77c.gif)
