### PR TITLE
Fix jitter in React editor

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -84,7 +84,6 @@ describe "EditorComponent", ->
 
       verticalScrollbarNode.scrollTop = 4.5 * lineHeightInPixels
       verticalScrollbarNode.dispatchEvent(new UIEvent('scroll'))
-      runSetImmediateCallbacks()
 
       expect(linesNode.style['-webkit-transform']).toBe "translate3d(0px, #{-4.5 * lineHeightInPixels}px, 0px)"
       expect(node.querySelectorAll('.line').length).toBe 6 + 4 # margin above and below
@@ -329,7 +328,6 @@ describe "EditorComponent", ->
 
       verticalScrollbarNode.scrollTop = 2.5 * lineHeightInPixels
       verticalScrollbarNode.dispatchEvent(new UIEvent('scroll'))
-      runSetImmediateCallbacks()
 
       expect(node.querySelectorAll('.line-number').length).toBe 6 + 4 + 1 # line overdraw margin above/below + dummy line number
 
@@ -520,7 +518,6 @@ describe "EditorComponent", ->
       verticalScrollbarNode.dispatchEvent(new UIEvent('scroll'))
       horizontalScrollbarNode.scrollLeft = 3.5 * charWidth
       horizontalScrollbarNode.dispatchEvent(new UIEvent('scroll'))
-      runSetImmediateCallbacks()
 
       cursorNodes = node.querySelectorAll('.cursor')
       expect(cursorNodes.length).toBe 2
@@ -877,7 +874,6 @@ describe "EditorComponent", ->
 
       verticalScrollbarNode.scrollTop = 3.5 * lineHeightInPixels
       verticalScrollbarNode.dispatchEvent(new UIEvent('scroll'))
-      runSetImmediateCallbacks()
 
       regions = node.querySelectorAll('.some-highlight .region')
 
@@ -1397,36 +1393,30 @@ describe "EditorComponent", ->
         expect(horizontalScrollbarNode.scrollLeft).toBe 0
 
         node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: -5, wheelDeltaY: -10))
-        runSetImmediateCallbacks()
         expect(verticalScrollbarNode.scrollTop).toBe 10
         expect(horizontalScrollbarNode.scrollLeft).toBe 0
 
         node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: -15, wheelDeltaY: -5))
-        runSetImmediateCallbacks()
         expect(verticalScrollbarNode.scrollTop).toBe 10
         expect(horizontalScrollbarNode.scrollLeft).toBe 15
 
       it "updates the scrollLeft or scrollTop according to the scroll sensitivity", ->
         atom.config.set('editor.scrollSensitivity', 50)
         node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: -5, wheelDeltaY: -10))
-        runSetImmediateCallbacks()
         expect(horizontalScrollbarNode.scrollLeft).toBe 0
 
         node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: -15, wheelDeltaY: -5))
-        runSetImmediateCallbacks()
         expect(verticalScrollbarNode.scrollTop).toBe 5
         expect(horizontalScrollbarNode.scrollLeft).toBe 7
 
       it "uses the previous scrollSensitivity when the value is not an int", ->
         atom.config.set('editor.scrollSensitivity', 'nope')
         node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: 0, wheelDeltaY: -10))
-        runSetImmediateCallbacks()
         expect(verticalScrollbarNode.scrollTop).toBe 10
 
       it "parses negative scrollSensitivity values as positive", ->
         atom.config.set('editor.scrollSensitivity', -50)
         node.dispatchEvent(new WheelEvent('mousewheel', wheelDeltaX: 0, wheelDeltaY: -10))
-        runSetImmediateCallbacks()
         expect(verticalScrollbarNode.scrollTop).toBe 5
 
     describe "when the mousewheel event's target is a line", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -724,11 +724,11 @@ describe "EditorComponent", ->
       # Add decorations that are out of range
       marker2 = editor.displayBuffer.markBufferRange([[9, 0], [9, 0]])
       editor.addDecorationForMarker(marker2, type: ['gutter', 'line'], class: 'b')
+      runSetImmediateCallbacks()
 
       # Scroll decorations into view
       verticalScrollbarNode.scrollTop = 2.5 * lineHeightInPixels
       verticalScrollbarNode.dispatchEvent(new UIEvent('scroll'))
-      runSetImmediateCallbacks()
       expect(lineAndLineNumberHaveClass(9, 'b')).toBe true
 
       # Fold a line to move the decorations

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -183,8 +183,6 @@ EditorComponent = React.createClass
     clearInterval(@scrollViewMeasurementIntervalId)
     @scrollViewMeasurementIntervalId = null
 
-  componentWillUpdate: ->
-
   componentDidUpdate: (prevProps, prevState) ->
     cursorsMoved = @cursorsMoved
     selectionChanged = @selectionChanged

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -219,6 +219,7 @@ EditorComponent = React.createClass
 
   requestAnimationFrame: (fn) ->
     @updatesPaused = true
+    @pauseScrollViewMeasurement()
     requestAnimationFrame =>
       fn()
       @updatesPaused = false
@@ -533,7 +534,6 @@ EditorComponent = React.createClass
     animationFramePending = @pendingScrollTop?
     @pendingScrollTop = scrollTop
     unless animationFramePending
-      @pauseScrollViewMeasurement()
       @requestAnimationFrame =>
         pendingScrollTop = @pendingScrollTop
         @pendingScrollTop = null
@@ -547,7 +547,6 @@ EditorComponent = React.createClass
     animationFramePending = @pendingScrollLeft?
     @pendingScrollLeft = scrollLeft
     unless animationFramePending
-      @pauseScrollViewMeasurement()
       @requestAnimationFrame =>
         @props.editor.setScrollLeft(@pendingScrollLeft)
         @pendingScrollLeft = null
@@ -569,7 +568,6 @@ EditorComponent = React.createClass
       @clearMouseWheelScreenRowAfterDelay()
 
     unless animationFramePending
-      @pauseScrollViewMeasurement()
       @requestAnimationFrame =>
         {editor} = @props
         editor.setScrollTop(editor.getScrollTop() + @pendingVerticalScrollDelta)
@@ -698,7 +696,6 @@ EditorComponent = React.createClass
     dragging = false
     lastMousePosition = {}
     animationLoop = =>
-      @pauseScrollViewMeasurement()
       @requestAnimationFrame =>
         if dragging
           screenPosition = @screenPositionForMouseEvent(lastMousePosition)
@@ -740,7 +737,7 @@ EditorComponent = React.createClass
     return if @scrollViewMeasurementRequested
 
     @scrollViewMeasurementRequested = true
-    @requestAnimationFrame =>
+    requestAnimationFrame =>
       @scrollViewMeasurementRequested = false
       @measureScrollView()
 

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -529,7 +529,7 @@ EditorComponent = React.createClass
   onVerticalScroll: (scrollTop) ->
     {editor} = @props
 
-    return if scrollTop is editor.getScrollTop()
+    return if @updateRequested or scrollTop is editor.getScrollTop()
 
     animationFramePending = @pendingScrollTop?
     @pendingScrollTop = scrollTop
@@ -542,7 +542,7 @@ EditorComponent = React.createClass
   onHorizontalScroll: (scrollLeft) ->
     {editor} = @props
 
-    return if scrollLeft is editor.getScrollLeft()
+    return if @updateRequested or scrollLeft is editor.getScrollLeft()
 
     animationFramePending = @pendingScrollLeft?
     @pendingScrollLeft = scrollLeft


### PR DESCRIPTION
Fixes #2797
Refs #2769

I previously thought that using `setImmediate` instead of `nextTick` fixed our jitter issues when requesting updates from animation frames, but it seems I was wrong. This PR returns to a strategy of updating synchronously in animation frames, so we never mix calls to `requestAnimationFrame` with `setImmediate`.

This PR also fixes an issue where we would handle stale `scroll` events emitted by the scrollbar elements while we were in the middle of updates, which was another source of jitter. Now we no longer get this kind of unintentional feedback when setting the scroll position in the model.

@Flannelhead: Could you try this out when it lands to see if it addresses #2769 on Linux?
