### PR TITLE
Build on Windows 8.1 with msysgit

### DIFF
--- a/docs/build-instructions/windows-81-msysgit-shell.md
+++ b/docs/build-instructions/windows-81-msysgit-shell.md
@@ -40,8 +40,8 @@ For some reason, the install script pulls a lot of libraries from npmjs.org as m
 
 This seems to be an issue the team should solve by ensuring a proper download and caching of the necessary libraries, but it may currently cause problems.
 
-[1]: http://nodejs.org/download/				"Node.js"
-[2]: http://www.python.org/download/			"Python"
-[3]: https://github.com/TooTallNate/node-gyp	"node-gyp"
+[1]: http://nodejs.org/download/                "Node.js"
+[2]: http://www.python.org/download/            "Python"
+[3]: https://github.com/TooTallNate/node-gyp    "node-gyp"
 [4]: http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs#DownloadFamilies_2 "Visual Studio Express 2013 for Desktop"
-[5]: http://msysgit.github.io/					"msysgit"
+[5]: http://msysgit.github.io/                  "msysgit"

--- a/docs/build-instructions/windows-81-msysgit-shell.md
+++ b/docs/build-instructions/windows-81-msysgit-shell.md
@@ -1,0 +1,41 @@
+# Building Atom in Windows 8.1 using the msysgit shell
+
+You can build atom on Windows 8.1 using a fully self-contained msysgit bash shell. That is, when installing msysgit, do not let it add commands to the system path, use the system cmd program, or anything that changes the default operation of the Windows system. Use all the default options to install msysgit.
+
+## Install dependencies
+Install the following programs that atom depends on:
+* Python 2.7.x
+* Node.js v0.10.x
+
+## Temporarily add folders to the PATH environment variable
+AFTER dependency installation, open up the msysgit shell (causing it to read the new PATH environment variable).
+Temporarily add the following directories to the git shell's PATH variable:
+*	/c/Program Files (x86)/Git/bin
+*	/c/Program Files (x86)/Git/libexec/git-core
+*	/c/Program Files/nodejs/node_modules/npm/bin/node-gyp-bin
+
+To add them temporarily, type:
+```
+PATH=$PATH:/c/Program Files (x86)/Git/bin:/c/Program Files (x86)/Git/libexec/git-core:/c/Program Files/nodejs/node_modules/npm/bin/node-gyp-bin
+export PATH
+```
+
+#### Notes:
+* These paths may change depending on where you installed the packages on your own system.
+* When combining the paths into a single string, ensure that you place a : between each path.
+* If you close the git shell, the PATH will revert to the system's default PATH.
+
+## Run the build script
+After all the installs, move to the scripts directory and run build:
+```
+cd atom/scripts
+./build
+```
+
+### !!!ATTENTION!!!
+You might get syntax errors!
+For some reason, the install script pulls a lot of libraries from npmjs.org as mentioned in the final few comments of https://github.com/atom/atom/issues/2580. If you get syntax errors, try rerunning the build script over and over until it magically works.
+
+This seems to be an issue the team should solve by ensuring a proper download and caching of the necessary libraries, but it may currently cause problems.
+
+1:[http://nodejs.org/download/]

--- a/docs/build-instructions/windows-81-msysgit-shell.md
+++ b/docs/build-instructions/windows-81-msysgit-shell.md
@@ -4,6 +4,7 @@ You can build atom on Windows 8.1 using a fully self-contained msysgit bash shel
 
 ## Install dependencies
 Install the following programs that atom depends on:
+* [msysgit][5] - Git for Windows
 * [Python][2] 2.7.x (required by [node-gyp][3])
 * [Node.js][1] v0.10.x
 * [Visual Studio 2013 Express for Desktop][4]
@@ -43,3 +44,4 @@ This seems to be an issue the team should solve by ensuring a proper download an
 [2]: http://www.python.org/download/			"Python"
 [3]: https://github.com/TooTallNate/node-gyp	"node-gyp"
 [4]: http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs#DownloadFamilies_2 "Visual Studio Express 2013 for Desktop"
+[5]: http://msysgit.github.io/					"msysgit"

--- a/docs/build-instructions/windows-81-msysgit-shell.md
+++ b/docs/build-instructions/windows-81-msysgit-shell.md
@@ -2,6 +2,11 @@
 
 You can build atom on Windows 8.1 using a fully self-contained msysgit bash shell. That is, when installing msysgit, do not let it add commands to the system path, use the system cmd program, or anything that changes the default operation of the Windows system. Use all the default options to install msysgit.
 
+
+>**NOTE:** Installing with this method may cause Atom's package manager to fail when trying to install packages from the settings window.
+
+>This is because the git commands do not exist in the PATH environment variable outside your current instance of the git shell. If you want to use the package manager, for now you need to install git to use the default command prompt.
+
 ## Install dependencies
 Install the following programs that atom depends on:
 * [msysgit][5] - Git for Windows
@@ -32,6 +37,11 @@ After all the installs, move to the scripts directory and run build:
 ```
 cd atom/scripts
 ./build
+```
+
+By default, this will install Atom in C:\Program Files\Atom. If you want to specify a custom path to install into then run this instead:
+```
+./build --install-dir C:\some\folder\Atom
 ```
 
 ### !!!ATTENTION!!!

--- a/docs/build-instructions/windows-81-msysgit-shell.md
+++ b/docs/build-instructions/windows-81-msysgit-shell.md
@@ -4,8 +4,9 @@ You can build atom on Windows 8.1 using a fully self-contained msysgit bash shel
 
 ## Install dependencies
 Install the following programs that atom depends on:
-* Python 2.7.x
-* Node.js v0.10.x
+* [Python][2] 2.7.x (required by [node-gyp][3])
+* [Node.js][1] v0.10.x
+* [Visual Studio 2013 Express for Desktop][4]
 
 ## Temporarily add folders to the PATH environment variable
 AFTER dependency installation, open up the msysgit shell (causing it to read the new PATH environment variable).
@@ -38,4 +39,7 @@ For some reason, the install script pulls a lot of libraries from npmjs.org as m
 
 This seems to be an issue the team should solve by ensuring a proper download and caching of the necessary libraries, but it may currently cause problems.
 
-1:[http://nodejs.org/download/]
+[1]: http://nodejs.org/download/				"Node.js"
+[2]: http://www.python.org/download/			"Python"
+[3]: https://github.com/TooTallNate/node-gyp	"node-gyp"
+[4]: http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs#DownloadFamilies_2 "Visual Studio Express 2013 for Desktop"

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -40,6 +40,8 @@ easier to set up. You need to have Posix tools in your `%PATH%` (i.e. `grep`,
 `sed`, et al.), which isn't the default configuration when you install Git. To
 fix this, you probably need to fiddle with your system PATH.
 
+[Read this][1] for specific instructions on Windows 8.1 with msysgit.
+
 ## Troubleshooting
 
 ### Common Errors
@@ -64,3 +66,5 @@ fix this, you probably need to fiddle with your system PATH.
 
 ### Windows build error reports in atom/atom
 * Use [this search](https://github.com/atom/atom/search?q=label%3Abuild-error+label%3Awindows&type=Issues) to get a list of reports about build errors on Windows.
+
+[1]: https://github.com/damccull/atom/blob/master/docs/build-instructions/windows-81-msysgit-shell.md "Windows 8.1 with msysgit instructions"


### PR DESCRIPTION
More detailed documentation on how to build on windows 8.1 with msysgit. One issue I've found with this is that the package manager doesn't download packages right because of git not being on the path. I'll update as I figure it out.

If anyone knows how to specify the location of git binaries without having it on the path, please let me know.
