### PR TITLE
Explicitly test removal of flash class prior to next animation frame

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -989,18 +989,18 @@ describe "EditorComponent", ->
 
       describe "when ::flash is called again before the first has finished", ->
         it "removes the class from the decoration highlight before adding it for the second ::flash call", ->
+          delayAnimationFrames = true
+
           decoration.flash('flash-class', 10)
+          nextAnimationFrame()
           expect(highlightNode.classList.contains('flash-class')).toBe true
-
-          addClassSpy = spyOn(highlightNode.classList, 'add').andCallThrough()
-          removeClassSpy = spyOn(highlightNode.classList, 'remove').andCallThrough()
-
           advanceClock(2)
+
           decoration.flash('flash-class', 10)
+          # Removed for 1 frame to force CSS transition to restart
+          expect(highlightNode.classList.contains('flash-class')).toBe false
 
-          expect(removeClassSpy).toHaveBeenCalledWith('flash-class')
-          expect(addClassSpy).toHaveBeenCalledWith('flash-class')
-
+          nextAnimationFrame()
           expect(highlightNode.classList.contains('flash-class')).toBe true
 
           advanceClock(10)


### PR DESCRIPTION
@benogle 

We went back and forth about these specs in your previous pull. Fine that you merged it as it wasn't worth holding up the presses on since the previous approach did work, but I think this approach is better. The previous tests would have passed even if there was nothing to cause a reflow in between the removal and re-addition of the flashed class. This means the behavior could break when flashes begin before the previous flash ended without breaking the specs.
