### PR TITLE
CSS snippet needs `!important` to work properly

### DIFF
--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -170,7 +170,7 @@ rule to your _~/.atom/styles.less_ file:
 
 ```less
 .editor .cursor {
-  border-color: pink;
+  border-color: pink !important;
 }
 ```
 


### PR DESCRIPTION
`.editor .cursor` doesn't override default border color so `!important` is needed (or more specific rule)
