### PR TITLE
Autoscroll to cursor on undo

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -792,6 +792,12 @@ describe "Editor", ->
         editor.insertNewline()
         expect(editor.getScrollBottom()).toBe 15 * 10
 
+      it "autoscrolls to the cursor when it moves due to undo", ->
+        editor.insertText('abc')
+        editor.setScrollTop(Infinity)
+        editor.undo()
+        expect(editor.getScrollTop()).toBe 0
+
   describe "selection", ->
     selection = null
 

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -28,6 +28,7 @@ class Cursor extends Model
 
       # Supports old editor view
       @needsAutoscroll ?= @isLastCursor() and !textChanged
+      @autoscroll() if @editor.manageScrollPosition and @isLastCursor() and textChanged
 
       @goalColumn = null
 

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -326,8 +326,6 @@ class Selection extends Model
 
     newBufferRange = @editor.buffer.setTextInRange(oldBufferRange, text, pick(options, 'undo'))
 
-    @cursor.autoscroll() if @editor.manageScrollPosition and @cursor.isLastCursor()
-
     if options.select
       @setBufferRange(newBufferRange, reversed: wasReversed)
     else


### PR DESCRIPTION
Fixes #2815

This commit changes our autoscroll strategy for cursors significantly.

Originally, we were autoscrolling whenever the cursor's marker changed
positions. This worked well, except we didn't end up autoscrolling when
the user _attempted_ to move the cursor to an invalid position, such as
moving down at the end of the buffer, due to the fact that the marker
wouldn't change.

Then, we moved to always requesting an autoscroll whenever a position
change was requested via Cursor::changePosition. This missed out on
moving the cursor when inserting text, so we then also added an explicit
autoscroll call when inserting text.

This had the problem of not autoscrolling due to undo. So finally, this
solution combines explicit autoscroll in ::changePosition to capture
intent, as well as implicit autoscrolling whenever the cursor's marker
position changes due to a textual change in the buffer. This captures
undo/redo correctly.
