### PR TITLE
Move serialization of active pane from Pane to PaneContainer

### DIFF
--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -8,6 +8,8 @@ class PaneContainer extends Model
   atom.deserializers.add(this)
   Serializable.includeInto(this)
 
+  @version: 1
+
   @properties
     root: -> new Pane
     activePane: null
@@ -27,10 +29,12 @@ class PaneContainer extends Model
   deserializeParams: (params) ->
     params.root = atom.deserializers.deserialize(params.root, container: this)
     params.destroyEmptyPanes = atom.config.get('core.destroyEmptyPanes')
+    params.activePane = params.root.getPanes().find (pane) -> pane.id is params.activePaneId
     params
 
   serializeParams: (params) ->
     root: @root?.serialize()
+    activePaneId: @activePane.id
 
   replaceChild: (oldChild, newChild) ->
     throw new Error("Replacing non-existent child") if oldChild isnt @root

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -40,14 +40,12 @@ class Pane extends Model
     @subscribe @items.onRemoval (item, index) =>
       @unsubscribe item if typeof item.on is 'function'
 
-    @activate() if params?.active
-
   # Called by the Serializable mixin during serialization.
   serializeParams: ->
+    id: @id
     items: compact(@items.map((item) -> item.serialize?()))
     activeItemUri: @activeItem?.getUri?()
     focused: @focused
-    active: @active
 
   # Called by the Serializable mixin during deserialization.
   deserializeParams: (params) ->


### PR DESCRIPTION
Fixes #2694
Fixes #2853

Previously, we were storing an `active` boolean for each pane. We've had some strange bugs where every pane is serializing `active: false`, which causes exceptions when loading up the stored data.

This new approach serializes the activePaneId on the PaneContainer itself. Since the PaneContainer is the source of truth regarding the active pane, it makes more sense to handle it here.

This unfortunately changes the serialization version for the PaneContainer, so people won't have their pane state persisted after upgrading. But it seems better than leaving cruft to handle the old serialization situation.

/cc @kevinsawicki since this is a critical change.
