### PR TITLE
Make React editor indent guide work like it did in the old editor

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -269,13 +269,11 @@ describe "EditorComponent", ->
 
         line2LeafNodes = getLeafNodes(component.lineNodeForScreenRow(2))
 
-        expect(line2LeafNodes.length).toBe 3
+        expect(line2LeafNodes.length).toBe 2
         expect(line2LeafNodes[0].textContent).toBe '  '
         expect(line2LeafNodes[0].classList.contains('indent-guide')).toBe true
         expect(line2LeafNodes[1].textContent).toBe '  '
         expect(line2LeafNodes[1].classList.contains('indent-guide')).toBe true
-        expect(line2LeafNodes[2].textContent).toBe '  '
-        expect(line2LeafNodes[2].classList.contains('indent-guide')).toBe true
 
       it "renders indent guides correctly on lines containing only whitespace", ->
         editor.getBuffer().insert([1, Infinity], '\n      ')
@@ -303,7 +301,7 @@ describe "EditorComponent", ->
       it "updates the indent guides on empty lines preceding an indentation change", ->
         editor.getBuffer().insert([12, 0], '\n')
         runSetImmediateCallbacks()
-        editor.getBuffer().insert([13, 0], '  ')
+        editor.getBuffer().insert([13, 0], '    ')
         runSetImmediateCallbacks()
 
         line12LeafNodes = getLeafNodes(component.lineNodeForScreenRow(12))
@@ -315,7 +313,7 @@ describe "EditorComponent", ->
       it "updates the indent guides on empty lines following an indentation change", ->
         editor.getBuffer().insert([12, 2], '\n')
         runSetImmediateCallbacks()
-        editor.getBuffer().insert([12, 0], '  ')
+        editor.getBuffer().insert([12, 0], '    ')
         runSetImmediateCallbacks()
 
         line13LeafNodes = getLeafNodes(component.lineNodeForScreenRow(13))

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -684,8 +684,8 @@ describe "TokenizedBuffer", ->
 
         expect(tokenizedBuffer.lineForScreenRow(5).indentLevel).toBe 3
         expect(tokenizedBuffer.lineForScreenRow(6).indentLevel).toBe 3
-        expect(tokenizedBuffer.lineForScreenRow(9).indentLevel).toBe 2
-        expect(tokenizedBuffer.lineForScreenRow(10).indentLevel).toBe 2
+        expect(tokenizedBuffer.lineForScreenRow(9).indentLevel).toBe 3
+        expect(tokenizedBuffer.lineForScreenRow(10).indentLevel).toBe 3
         expect(tokenizedBuffer.lineForScreenRow(11).indentLevel).toBe 2
 
         tokenizedBuffer.on "changed", changeHandler = jasmine.createSpy('changeHandler')
@@ -693,12 +693,12 @@ describe "TokenizedBuffer", ->
         buffer.setTextInRange([[7, 0], [8, 65]], '        one\n        two\n        three\n        four')
 
         delete changeHandler.argsForCall[0][0].bufferChange
-        expect(changeHandler).toHaveBeenCalledWith(start: 5, end: 8, delta: 2)
+        expect(changeHandler).toHaveBeenCalledWith(start: 5, end: 10, delta: 2)
 
         expect(tokenizedBuffer.lineForScreenRow(5).indentLevel).toBe 4
         expect(tokenizedBuffer.lineForScreenRow(6).indentLevel).toBe 4
-        expect(tokenizedBuffer.lineForScreenRow(11).indentLevel).toBe 2
-        expect(tokenizedBuffer.lineForScreenRow(12).indentLevel).toBe 2
+        expect(tokenizedBuffer.lineForScreenRow(11).indentLevel).toBe 4
+        expect(tokenizedBuffer.lineForScreenRow(12).indentLevel).toBe 4
         expect(tokenizedBuffer.lineForScreenRow(13).indentLevel).toBe 2
 
       it "updates the indentLevel of empty lines surrounding a change that removes lines", ->
@@ -711,7 +711,7 @@ describe "TokenizedBuffer", ->
         buffer.setTextInRange([[7, 0], [8, 65]], '    ok')
 
         delete changeHandler.argsForCall[0][0].bufferChange
-        expect(changeHandler).toHaveBeenCalledWith(start: 5, end: 8, delta: -1)
+        expect(changeHandler).toHaveBeenCalledWith(start: 5, end: 10, delta: -1)
 
         expect(tokenizedBuffer.lineForScreenRow(5).indentLevel).toBe 2
         expect(tokenizedBuffer.lineForScreenRow(6).indentLevel).toBe 2

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -158,7 +158,7 @@ LinesComponent = React.createClass
 
     if showIndentGuide and indentLevel > 0
       indentSpan = "<span class='indent-guide'>#{multiplyString(' ', tabLength)}</span>"
-      multiplyString(indentSpan, indentLevel + 1)
+      multiplyString(indentSpan, indentLevel)
     else
       "&nbsp;"
 

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -231,22 +231,27 @@ class TokenizedBuffer extends Model
 
   indentLevelForRow: (row) ->
     line = @buffer.lineForRow(row)
+    indentLevel = 0
 
     if line is ''
       nextRow = row + 1
       lineCount = @getLineCount()
       while nextRow < lineCount
         nextLine = @buffer.lineForRow(nextRow)
-        return @indentLevelForLine(nextLine) unless nextLine is ''
+        unless nextLine is ''
+          indentLevel = Math.ceil(@indentLevelForLine(nextLine))
+          break
         nextRow++
 
       previousRow = row - 1
       while previousRow >= 0
         previousLine = @buffer.lineForRow(previousRow)
-        return @indentLevelForLine(previousLine) unless previousLine is ''
+        unless previousLine is ''
+          indentLevel = Math.max(Math.ceil(@indentLevelForLine(previousLine)), indentLevel)
+          break
         previousRow--
 
-      0
+      indentLevel
     else
       @indentLevelForLine(line)
 


### PR DESCRIPTION
Fixes #2367
- The indent level of empty lines is the _max_ of the nearest non empty
  line, rather than favoring the level of the line below.
- An extra wrap guide is no longer rendered for empty lines

I didn't port the specs over because we already had good coverage at the
model level. It just needed to be updated for the preferred behavior.
