### PR TITLE
Add autoUpdater shim for Windows

### DIFF
--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -535,3 +535,18 @@ describe "the `atom` global", ->
       expect(atom.isReleasedVersion()).toBe true
       version = '36b5518'
       expect(atom.isReleasedVersion()).toBe false
+
+  describe "window:update-available", ->
+    it "is triggered when the auto-updater sends the update-downloaded event", ->
+      updateAvailableHandler = jasmine.createSpy("update-available-handler")
+      atom.workspaceView.on 'window:update-available', updateAvailableHandler
+      autoUpdater = require('remote').require('auto-updater')
+      autoUpdater.emit 'update-downloaded', null, "notes", "version"
+
+      waitsFor ->
+        updateAvailableHandler.callCount > 0
+
+      runs ->
+        [event, version, notes] = updateAvailableHandler.mostRecentCall.args
+        expect(notes).toBe 'notes'
+        expect(version).toBe 'version'

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -138,6 +138,7 @@ class AtomWindow
           when 'window:reload' then @reload()
           when 'window:toggle-dev-tools' then @toggleDevTools()
           when 'window:close' then @close()
+          when 'window:update-available' then @sendCommandToBrowserWindow(command, args...) # For spec testing
     else if @isWebViewFocused()
       @sendCommandToBrowserWindow(command, args...)
     else

--- a/src/browser/auto-update-manager.coffee
+++ b/src/browser/auto-update-manager.coffee
@@ -22,9 +22,6 @@ class AutoUpdateManager
     if process.platform is 'win32'
       autoUpdater.checkForUpdates = => @checkForUpdatesShim()
 
-    # Only released versions should check for updates.
-    return if /\w{7}/.test(@version)
-
     autoUpdater.setFeedUrl @feedUrl
 
     autoUpdater.on 'checking-for-update', =>
@@ -44,7 +41,9 @@ class AutoUpdateManager
       @setState(UPDATE_AVAILABLE_STATE)
       @emitUpdateAvailableEvent(@getWindows()...)
 
-    @check(hidePopups: true)
+    # Only released versions should check for updates.
+    unless /\w{7}/.test(@version)
+      @check(hidePopups: true)
 
   # Windows doesn't have an auto-updater, so use this method to shim the events.
   checkForUpdatesShim: ->

--- a/src/browser/auto-update-manager.coffee
+++ b/src/browser/auto-update-manager.coffee
@@ -54,12 +54,12 @@ class AutoUpdateManager
         response.on 'data', (chunk) -> body += chunk
         response.on 'end', ->
           {notes, name} = JSON.parse(body)
-          autoUpdater.emit 'update-downloaded', notes, name
+          autoUpdater.emit 'update-downloaded', null, notes, name
       else
-        autoUpdater.emit 'update-not-available', notes, name
+        autoUpdater.emit 'update-not-available'
 
     request.on 'error', (error) ->
-      autoUpdater.emit 'error', error.message
+      autoUpdater.emit 'error', null, error.message
 
   emitUpdateAvailableEvent: (windows...) ->
     return unless @releaseVersion? and @releaseNotes


### PR DESCRIPTION
Auto Updating won't work for Windows. This will update the AutoUpdateManager to emit the appropriate events when an update is available.
