### PR TITLE
Validate window dimensions

### DIFF
--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -227,7 +227,7 @@ class Atom extends Model
 
   # Returns true if the dimensions are useable, false if they should be ignored.
   # Work around for https://github.com/atom/atom-shell/issues/473
-  isValidDimensions: ({x, y, width, height}={})->
+  isValidDimensions: ({x, y, width, height}={}) ->
     width > 0 and height > 0 and x + width > 0 and y + height > 0
 
   storeDefaultWindowDimensions: ->

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -225,10 +225,9 @@ class Atom extends Model
     else
       @center()
 
-  # Returns true if dimensions are useable, false if they should be ignored.
+  # Returns true if the dimensions are useable, false if they should be ignored.
+  # Work around for https://github.com/atom/atom-shell/issues/473
   isValidDimensions: ({x, y, width, height}={})->
-    # Work around https://github.com/atom/atom-shell/issues/473
-    # Invalidate dimensions that are completely offscreen
     width > 0 and height > 0 and x + width > 0 and y + height > 0
 
   storeDefaultWindowDimensions: ->

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -248,7 +248,15 @@ class Atom extends Model
     @setWindowDimensions(windowDimensions)
 
   storeWindowDimensions: ->
-    @state.windowDimensions = @getWindowDimensions()
+    windowDimensions = @getWindowDimensions()
+
+    if process.platform is 'win32'
+      # Work around https://github.com/atom/atom-shell/issues/473
+      # Don't store the window if its dimensions are completely offscreen
+      return if windowDimensions.x + windowDimensions.width <= 0
+      return if windowDimensions.height + windowDimensions.height <= 0
+
+    @state.windowDimensions = windowDimensions
 
   # Public: Get the load settings for the current window.
   #

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -226,7 +226,7 @@ class Atom extends Model
       @center()
 
   storeDefaultWindowDimensions: ->
-    dimensions = JSON.stringify(atom.getWindowDimensions())
+    dimensions = JSON.stringify(@getWindowDimensions())
     localStorage.setItem("defaultWindowDimensions", dimensions)
 
   getDefaultWindowDimensions: ->


### PR DESCRIPTION
Because of atom/atom-shell#473 there are invalid window dimensions in the serialized state for people using Atom on Windows.

Instead of bumping the version and throwing away the bad state, I'd rather just validate the dimensions on save/restore so that the Atom window is never shown off screen.

This PR adds two checks before using the dimensions, height and width greater than 0 and that the window isn't completely offscreen by checking if x+width and y+height are both greater than 0.

Closes #2872
