### PR TITLE
Ship 32-bit node with apm on Windows

### DIFF
--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "0.75.0"
+    "atom-package-manager": "0.76.0"
   }
 }

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -57,6 +57,9 @@ function bootstrap() {
     apmInstallOptions.ignoreStdout = true;
   }
 
+  if (process.env.JANKY_SHA1 && process.platform === 'win32')
+    apmInstallCommand += ' --arch=ia32';
+
   var commands = [
     {
       command: buildInstallCommand,

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -57,6 +57,8 @@ function bootstrap() {
     apmInstallOptions.ignoreStdout = true;
   }
 
+  // apm ships with 32-bit node so make sure its native modules are compiled
+  // for a 32-bit target architecture
   if (process.env.JANKY_SHA1 && process.platform === 'win32')
     apmInstallCommand += ' --arch=ia32';
 


### PR DESCRIPTION
Ship 32-bit node and build apm's modules in 32-bit mode.

Closes #2896
