### PR TITLE
Allow grammars to specify tab style

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -17,6 +17,19 @@ describe "Editor", ->
     waitsForPromise ->
       atom.packages.activatePackage('language-javascript')
 
+  describe "when a grammar requires hard tabs", ->
+    it "always inserts hard tabs when indent is called", ->
+      waitsForPromise ->
+        atom.packages.activatePackage('package-hard-tab-grammar')
+
+      runs ->
+        editor.setText("1\n  <- these are spaces\n")
+        editor.getCursor().setBufferPosition([2, 0])
+        editor.setGrammar(atom.syntax.selectGrammar('.hard-tabs'))
+        editor.indent()
+        text = editor.getBuffer().getTextInRange([[2, 0], [2, Infinity]])
+        expect(text).toBe "\t"
+
   describe "when the editor is deserialized", ->
     it "restores selections and folds based on markers in the buffer", ->
       editor.setSelectedBufferRange([[1, 2], [3, 4]])

--- a/spec/fixtures/packages/package-hard-tab-grammar/grammars/hard-tabs.cson
+++ b/spec/fixtures/packages/package-hard-tab-grammar/grammars/hard-tabs.cson
@@ -1,0 +1,10 @@
+'fileTypes': ['hard-tabs']
+'name': 'Tabs like diamonds'
+'scopeName': 'source.hard-tabs'
+
+'patterns': [
+  {
+    'name': 'keyword.word'
+    'match': '\\w+'
+  }
+]

--- a/spec/fixtures/packages/package-hard-tab-grammar/scoped-properties/hard-tabs.cson
+++ b/spec/fixtures/packages/package-hard-tab-grammar/scoped-properties/hard-tabs.cson
@@ -1,0 +1,3 @@
+'.source.hard-tabs':
+  'editor':
+    'enforceHardTabs': true

--- a/spec/fixtures/packages/package-hard-tab-grammar/scoped-properties/hard-tabs.cson
+++ b/spec/fixtures/packages/package-hard-tab-grammar/scoped-properties/hard-tabs.cson
@@ -1,3 +1,3 @@
 '.source.hard-tabs':
   'editor':
-    'enforceHardTabs': true
+    'requireHardTabs': true

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -163,6 +163,7 @@ class Editor extends Model
 
     @displayBuffer ?= new DisplayBuffer({buffer, tabLength, softWrap})
     @buffer = @displayBuffer.buffer
+    @languageMode = new LanguageMode(this)
     @setSoftTabs(@doesBufferUseSoftTabs() ? @softTabs ? atom.config.get('editor.softTabs') ? true)
 
     for marker in @findMarkers(@getSelectionMarkerAttributes())
@@ -177,7 +178,6 @@ class Editor extends Model
       initialColumn = Math.max(parseInt(initialColumn) or 0, 0)
       @addCursorAtBufferPosition([initialLine, initialColumn])
 
-    @languageMode = new LanguageMode(this)
 
     @subscribe @$scrollTop, (scrollTop) => @emit 'scroll-top-changed', scrollTop
     @subscribe @$scrollLeft, (scrollLeft) => @emit 'scroll-left-changed', scrollLeft
@@ -295,7 +295,11 @@ class Editor extends Model
   # Public: Enable or disable soft tabs for this editor.
   #
   # softTabs - A {Boolean}
-  setSoftTabs: (@softTabs) -> @softTabs
+  setSoftTabs: (softTabs) ->
+    if @languageMode?.enforceHardTabs() is true
+      @softTabs = false
+    else
+      @softTabs = softTabs
 
   # Public: Toggle soft tabs for this editor
   toggleSoftTabs: -> @setSoftTabs(not @getSoftTabs())

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -163,7 +163,7 @@ class Editor extends Model
 
     @displayBuffer ?= new DisplayBuffer({buffer, tabLength, softWrap})
     @buffer = @displayBuffer.buffer
-    @softTabs = @usesSoftTabs() ? @softTabs ? atom.config.get('editor.softTabs') ? true
+    @setSoftTabs(@doesBufferUseSoftTabs() ? @softTabs ? atom.config.get('editor.softTabs') ? true)
 
     for marker in @findMarkers(@getSelectionMarkerAttributes())
       marker.setAttributes(preserveFolds: true)
@@ -333,7 +333,7 @@ class Editor extends Model
   # with a space character. Returns `false` if it starts with a hard tab (`\t`).
   #
   # Returns a {Boolean},
-  usesSoftTabs: ->
+  doesBufferUseSoftTabs: ->
     for bufferRow in [0..@buffer.getLastRow()]
       continue if @displayBuffer.tokenizedBuffer.lineForScreenRow(bufferRow).isComment()
       if match = @buffer.lineForRow(bufferRow).match(/^\s/)
@@ -1937,7 +1937,7 @@ class Editor extends Model
   logScreenLines: (start, end) -> @displayBuffer.logLines(start, end)
 
   handleTokenization: ->
-    @softTabs = @usesSoftTabs() ? @softTabs
+    @setSoftTabs(@doesBufferUseSoftTabs() ? @softTabs)
 
   handleGrammarChange: ->
     @unfoldAll()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -296,7 +296,7 @@ class Editor extends Model
   #
   # softTabs - A {Boolean}
   setSoftTabs: (softTabs) ->
-    if @languageMode?.enforceHardTabs() is true
+    if @languageMode?.requireHardTabs() is true
       @softTabs = false
     else
       @softTabs = softTabs

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -318,3 +318,7 @@ class LanguageMode
 
   foldEndRegexForScopes: (scopes) ->
     @getRegexForProperty(scopes, 'editor.foldEndPattern')
+
+  enforceHardTabs: ->
+    scopes = [@editor.getGrammar().scopeName]
+    atom.syntax.getProperty(scopes, 'editor.enforceHardTabs')

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -319,6 +319,6 @@ class LanguageMode
   foldEndRegexForScopes: (scopes) ->
     @getRegexForProperty(scopes, 'editor.foldEndPattern')
 
-  enforceHardTabs: ->
+  requireHardTabs: ->
     scopes = [@editor.getGrammar().scopeName]
-    atom.syntax.getProperty(scopes, 'editor.enforceHardTabs')
+    atom.syntax.getProperty(scopes, 'editor.requireHardTabs')


### PR DESCRIPTION
GNU Make requires the use of hard tabs, but our current setup doesn't allow grammars to specify tab styles. This PR will allow grammars to specify 'requiresHardTabs' which will override any other softTab preference.

**BUT**

I'm wondering if this approach is too shortsighted. I like what @jtkiley recommends in https://github.com/atom/settings-view/issues/122#issuecomment-44845687. But that will clash with the grammar approach I took here.

Started because of https://github.com/atom/language-make/issues/3 and https://github.com/atom/language-make/pull/8/files
