### PR TITLE
Fix width too wide when softwrap enabled when editor can vertical scroll

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -258,7 +258,7 @@ describe "EditorComponent", ->
           editor.setText "a line that wraps "
           editor.setSoftWrap(true)
           runSetImmediateCallbacks()
-          componentNode.style.width = 16 * charWidth + 'px'
+          componentNode.style.width = 16 * charWidth + editor.getVerticalScrollbarWidth() + 'px'
           component.measureHeightAndWidth()
           runSetImmediateCallbacks()
 
@@ -2003,7 +2003,7 @@ describe "EditorComponent", ->
       expect(componentNode.querySelectorAll('.line')).toHaveLength(4 + lineOverdrawMargin + 1)
 
       gutterWidth = componentNode.querySelector('.gutter').offsetWidth
-      componentNode.style.width = gutterWidth + 14 * charWidth + 'px'
+      componentNode.style.width = gutterWidth + 14 * charWidth + editor.getVerticalScrollbarWidth() + 'px'
       advanceClock(component.domPollingInterval)
       runSetImmediateCallbacks()
       expect(componentNode.querySelector('.line').textContent).toBe "var quicksort "

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -356,8 +356,10 @@ class DisplayBuffer extends Model
       if editorWidthInChars isnt previousWidthInChars and @softWrap
         @updateWrappedScreenLines()
 
+  # Returns the editor width in characters for soft wrap.
   getEditorWidthInChars: ->
-    width = @getWidth()
+    width = @width ? @getScrollWidth()
+    width -= @getVerticalScrollbarWidth()
     if width? and @defaultCharWidth > 0
       Math.floor(width / @defaultCharWidth)
     else


### PR DESCRIPTION
1. Enable softwrap on a longish md file. 
2. Scroll to the right
3. Editor twerk

![softwrap-wiggle](https://cloud.githubusercontent.com/assets/69169/3546128/d15e581e-087f-11e4-9356-9620c83851b7.gif)

`DisplayBuffer::getEditorWidthInChars()` is not taking into account the width of the scrollbar when the editor can vertically scroll.

This fix takes the scrollbar width into account all the time, even when it cannot scroll vertically. 

It might be cool to take the scrollbar into account only when the scrollbar is visible. But there are a couple problems:
- UX: when it switches from able to scroll to not able to scroll, it would reset the column, and reflow some lines. 
- It's a chicken and egg problem. Basically, to figure out if we need the scrollbar, we need to know all the screenlines, and to build the screenlines we need to know the softwrap column. But to figure out the softwrap column, we need to know if we show the scrollbar.

Here's what happens on resize of the editor in softwrap:

![screen shot 2014-07-10 at 3 29 37 pm](https://cloud.githubusercontent.com/assets/69169/3546309/b89fa66e-0881-11e4-93c7-310c8c499314.png)

`UpdateAllScreenLines` [deletes all the old screen lines](https://github.com/atom/atom/blob/master/src/display-buffer.coffee#L94) then [figures out the softwrap column](https://github.com/atom/atom/blob/master/src/display-buffer.coffee#L366), so it cannot know whether or not there should be a vert scrollbar. 

Here are the ways I can think to get the proper column:
- We keep the old screenlines around, and determine scrollability based on those. Though there might be cases where it does the wrong thing because the screen lines changed drastically (say a huge resize).
- We compute the screen lines twice. Once with the scrollbar, if it isnt scrollable, then compute again without the scrollbar.
- Just account for the scrollbar all the time (as this pull does)

I'd prefer to merge this pull. Curious about your thoughts
