### PR TITLE
Move gutter member into a showLineNumbers observe block

### DIFF
--- a/src/react-editor-view.coffee
+++ b/src/react-editor-view.coffee
@@ -38,17 +38,20 @@ class ReactEditorView extends View
     @overlayer = $(node).find('.lines').addClass('overlayer')
     @hiddenInput = $(node).find('.hidden-input')
 
-    @gutter = $(node).find('.gutter')
-    @gutter.removeClassFromAllLines = (klass) =>
-      @gutter.find('.line-number').removeClass(klass)
+    # FIXME: there should be a better way to deal with the gutter element
+    @subscribe atom.config.observe 'editor.showLineNumbers', =>
+      @gutter = $(node).find('.gutter')
 
-    @gutter.getLineNumberElement = (bufferRow) =>
-      @gutter.find("[data-buffer-row='#{bufferRow}']")
+      @gutter.removeClassFromAllLines = (klass) =>
+        @gutter.find('.line-number').removeClass(klass)
 
-    @gutter.addClassToLine = (bufferRow, klass) =>
-      lines = @gutter.find("[data-buffer-row='#{bufferRow}']")
-      lines.addClass(klass)
-      lines.length > 0
+      @gutter.getLineNumberElement = (bufferRow) =>
+        @gutter.find("[data-buffer-row='#{bufferRow}']")
+
+      @gutter.addClassToLine = (bufferRow, klass) =>
+        lines = @gutter.find("[data-buffer-row='#{bufferRow}']")
+        lines.addClass(klass)
+        lines.length > 0
 
     @focus() if @focusOnAttach
 


### PR DESCRIPTION
When `editor.showLineNumbers` is toggled, the `ReactEditorView.gutter` member becomes stale. This moves it under an observer for `editor.showLineNumbers` so when it is toggled, the `gutter` member is reinstated. 

This is required for atom/git-diff#30. Ideally there would be a way to decorate a node similarly to decorations so we didnt have to do this hackery and related bs in git-diff. Something like `decorateObject('gutter', {class: 'blah'})`.
