### PR TITLE
Change shift-delete to trigger core:cut in Win32 and Linux

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -38,7 +38,7 @@
   'shift-pageup': 'core:select-page-up'
   'shift-pagedown': 'core:select-page-down'
   'delete': 'core:delete'
-  'shift-delete': 'core:delete'
+  'shift-delete': 'core:cut'
   'pageup': 'core:page-up'
   'pagedown': 'core:page-down'
   'backspace': 'core:backspace'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -41,7 +41,7 @@
   'shift-pageup': 'core:select-page-up'
   'shift-pagedown': 'core:select-page-down'
   'delete': 'core:delete'
-  'shift-delete': 'core:delete'
+  'shift-delete': 'core:cut'
   'pageup': 'core:page-up'
   'pagedown': 'core:page-down'
   'backspace': 'core:backspace'


### PR DESCRIPTION
This behavior is standard WIndows and Linux for shift-delete.

Previously shift-delete was a redundant mapping, anyway. So this brings it further in line with expected behavior for Windows and Linux users.
![image](https://cloud.githubusercontent.com/assets/7287076/3550681/6cae3d78-08dc-11e4-8ea4-61e81a35d5d5.png)
