### PR TITLE
Import base *-variables files as fallback vars when loading packages/themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grim": "0.11.0",
     "guid": "0.0.10",
     "jasmine-tagged": "^1.1.2",
-    "less-cache": "0.12.0",
+    "less-cache": "0.13.0",
     "mixto": "^1",
     "mkdirp": "0.3.5",
     "nslog": "0.5.0",

--- a/spec/fixtures/packages/theme-with-incomplete-ui-variables/package.json
+++ b/spec/fixtures/packages/theme-with-incomplete-ui-variables/package.json
@@ -1,0 +1,4 @@
+{
+  "theme": "ui",
+  "stylesheets": ["editor.less"]
+}

--- a/spec/fixtures/packages/theme-with-incomplete-ui-variables/stylesheets/editor.less
+++ b/spec/fixtures/packages/theme-with-incomplete-ui-variables/stylesheets/editor.less
@@ -1,0 +1,10 @@
+@import "ui-variables";
+
+.editor {
+  padding-top: @component-padding;
+  padding-right: @component-padding;
+  padding-bottom: @component-padding;
+
+  color: @input-background-color;
+  background-color: @background-color-info; // From the fallback variables, not overridden
+}

--- a/spec/fixtures/packages/theme-with-incomplete-ui-variables/stylesheets/ui-variables.less
+++ b/spec/fixtures/packages/theme-with-incomplete-ui-variables/stylesheets/ui-variables.less
@@ -1,0 +1,3 @@
+// This does not contain all of the ui-variables available.
+@app-background-color: #00f; // Changed
+@input-background-color: #f00; // Changed

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -232,6 +232,21 @@ describe "ThemeManager", ->
         expect($(".editor").css("padding-right")).toBe "150px"
         expect($(".editor").css("padding-bottom")).toBe "150px"
 
+    describe "when there is a theme with incomplete variables", ->
+      it "loads the correct values from the fallback ui-variables", ->
+        themeManager.on 'reloaded', reloadHandler = jasmine.createSpy()
+        atom.config.set('core.themes', ['theme-with-incomplete-ui-variables'])
+
+        waitsFor ->
+          reloadHandler.callCount > 0
+
+        runs ->
+          # an override loaded in the base css
+          expect(atom.workspaceView.css("background-color")).toBe "rgb(0, 0, 255)"
+
+          # from within the theme itself
+          expect($(".editor").css("background-color")).toBe "rgb(0, 152, 255)"
+
   describe "when the user stylesheet changes", ->
     it "reloads it", ->
       [stylesheetRemovedHandler, stylesheetAddedHandler, stylesheetsChangedHandler] = []

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -30,6 +30,10 @@ class LessCompileCache
   setImportPaths: (importPaths=[]) ->
     @cache.setImportPaths(importPaths.concat(@lessSearchPaths))
 
-  read: (stylesheetPath) -> @cache.readFileSync(stylesheetPath)
+  read: (stylesheetPath) ->
+    @cache.readFileSync(stylesheetPath)
+
+  cssForFile: (stylesheetPath, lessContent) ->
+    @cache.cssForFile(stylesheetPath, lessContent)
 
   destroy: -> @unsubscribe()

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -158,7 +158,7 @@ class Package
 
   loadStylesheets: ->
     @stylesheets = @getStylesheetPaths().map (stylesheetPath) ->
-      [stylesheetPath, atom.themes.loadStylesheet(stylesheetPath)]
+      [stylesheetPath, atom.themes.loadStylesheet(stylesheetPath, true)]
 
   getStylesheetsPath: ->
     path.join(@path, @constructor.stylesheetsDir)

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -181,8 +181,8 @@ class ThemeManager
     try
       if importFallbackVariables
         baseVarImports = """
-        @import "#{path.join(@resourcePath, 'static', 'variables', 'ui-variables')}";
-        @import "#{path.join(@resourcePath, 'static', 'variables', 'syntax-variables')}";
+        @import "variables/ui-variables";
+        @import "variables/syntax-variables";
         """
         less = fs.readFileSync(lessStylesheetPath, 'utf8')
         @lessCache.cssForFile(lessStylesheetPath, [baseVarImports, less].join('\n'))
@@ -190,7 +190,7 @@ class ThemeManager
         @lessCache.read(lessStylesheetPath)
     catch e
       console.error """
-        Error compiling less stylesheet: #{importFallbackVariables} #{lessStylesheetPath}
+        Error compiling less stylesheet: #{lessStylesheetPath}
         Line number: #{e.line}
         #{e.message}
       """

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -128,7 +128,7 @@ class ThemeManager
     @userStylesheetFile = new File(userStylesheetPath)
     @userStylesheetFile.on 'contents-changed moved removed', =>
       @loadUserStylesheet()
-    userStylesheetContents = @loadStylesheet(userStylesheetPath)
+    userStylesheetContents = @loadStylesheet(userStylesheetPath, true)
     @applyStylesheet(userStylesheetPath, userStylesheetContents, 'userTheme')
 
   loadBaseStylesheets: ->

--- a/static/atom.less
+++ b/static/atom.less
@@ -1,7 +1,9 @@
 // Import from the syntax theme's variables with a fallback to ./variables/syntax-variables.less
+@import "./variables/syntax-variables";
 @import "syntax-variables";
 
 // Import from the ui theme's variables with a fallback to ./variables/ui-variables.less
+@import "./variables/ui-variables";
 @import "ui-variables";
 
 @import "octicon-utf-codes";


### PR DESCRIPTION
Previous to this, theme authors needed to replicate the entire `ui-variables` or `syntax-variables` files in their themes. This pull makes it so they can just include the variables they want to override in their version of the `*-variables` file.

It didnt work like this previously because we would just pass a stack of import directories to the less compiler, and the first variables file won. If something used a variable not defined in that winning `*-variables` file, it'd die. 

This pull always imports the [fallback variables](https://github.com/atom/atom/tree/master/static/variables) on all package / theme files before importing anything else.

Fixes #2892; Requires atom/less-cache#3
