### PR TITLE
:bug: Fix regression in indent-guide in React editor

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -344,11 +344,29 @@ describe "EditorComponent", ->
         expect(line13LeafNodes[1].textContent).toBe '  '
         expect(line13LeafNodes[1].classList.contains('indent-guide')).toBe true
 
-      getLeafNodes = (node) ->
-        if node.children.length > 0
-          flatten(toArray(node.children).map(getLeafNodes))
-        else
-          [node]
+    describe "when indent guides are disabled", ->
+      beforeEach ->
+        component.setShowIndentGuide(false)
+        runSetImmediateCallbacks()
+
+      it "does not render indent guides on lines containing only whitespace", ->
+        editor.getBuffer().insert([1, Infinity], '\n      ')
+        runSetImmediateCallbacks()
+
+        line2LeafNodes = getLeafNodes(component.lineNodeForScreenRow(2))
+        expect(line2LeafNodes.length).toBe 3
+        expect(line2LeafNodes[0].textContent).toBe '  '
+        expect(line2LeafNodes[0].classList.contains('indent-guide')).toBe false
+        expect(line2LeafNodes[1].textContent).toBe '  '
+        expect(line2LeafNodes[1].classList.contains('indent-guide')).toBe false
+        expect(line2LeafNodes[2].textContent).toBe '  '
+        expect(line2LeafNodes[2].classList.contains('indent-guide')).toBe false
+
+    getLeafNodes = (node) ->
+      if node.children.length > 0
+        flatten(toArray(node.children).map(getLeafNodes))
+      else
+        [node]
 
     describe "when the buffer contains null bytes", ->
       it "excludes the null byte from character measurement", ->

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -189,7 +189,7 @@ LinesComponent = React.createClass
     lineIsWhitespaceOnly = firstTrailingWhitespacePosition is 0
     for token in tokens
       innerHTML += @updateScopeStack(scopeStack, token.scopes)
-      hasIndentGuide = not mini and showIndentGuide and token.hasLeadingWhitespace or (token.hasTrailingWhitespace and lineIsWhitespaceOnly)
+      hasIndentGuide = not mini and showIndentGuide and (token.hasLeadingWhitespace or (token.hasTrailingWhitespace and lineIsWhitespaceOnly))
       innerHTML += token.getValueAsHtml({invisibles, hasIndentGuide})
 
     innerHTML += @popScope(scopeStack) while scopeStack.length > 0


### PR DESCRIPTION
Previously the indent guide was always showing on the whitespace only lines in the React editor. This is the same behavior as in the old editor and had the same fix, just ported to `LinesComponent`.

Still TODO:
- [x] Figure out how to port over the test from @kevinsawicki's change

See: 314833bbac33bdb7c45594550d8d10559dd2de9c
Fixes #2274
