### PR TITLE
Don't quote certain explorer arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "symbols-view": "0.60.0",
     "tabs": "0.45.0",
     "timecop": "0.21.0",
-    "tree-view": "0.109.0",
+    "tree-view": "0.110.0",
     "update-package-dependencies": "0.6.0",
     "welcome": "0.17.0",
     "whitespace": "0.24.0",

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -49,7 +49,7 @@ class BufferedProcess
         cmdArgs = args.map (arg) ->
           if command in ['explorer.exe', 'explorer'] and /^\/[a-zA-Z]+,.*$/.test(arg)
             # Don't wrap /root,C:\folder style arguments to explorer calls in
-            # quotes # since they will not be interpreted correctly if they are
+            # quotes since they will not be interpreted correctly if they are
             arg
           else
             "\"#{arg.replace(/"/g, '\\"')}\""

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -46,7 +46,13 @@ class BufferedProcess
     if process.platform is "win32"
       # Quote all arguments and escapes inner quotes
       if args?
-        cmdArgs = args.map (arg) -> "\"#{arg.replace(/"/g, '\\"')}\""
+        cmdArgs = args.map (arg) ->
+          if command in ['explorer.exe', 'explorer'] and /^\/[a-zA-Z]+,.*$/.test(arg)
+            # Don't wrap /root,C:\folder style arguments to explorer calls in
+            # quotes # since they will not be interpreted correctly if they are
+            arg
+          else
+            "\"#{arg.replace(/"/g, '\\"')}\""
       else
         cmdArgs = []
       cmdArgs.unshift("\"#{command}\"")


### PR DESCRIPTION
This seems to be required since wrapping the common `/root,` and `/select,` arguments in quotes causes them to not be interpreted correctly.

Refs atom/tree-view#180
