### PR TITLE
Support multiple separators in context menu

### DIFF
--- a/docs/creating-a-package.md
+++ b/docs/creating-a-package.md
@@ -227,15 +227,16 @@ or one of its parents has the `tree-view` class applied to it.
 
 You can also add separators and submenus to your context menus. To add a
 submenu, pass in another object instead of a command. To add a separator, use
-`-` for the name and command of the item.
+`-` for the command of the item.
 
 ```coffeescript
 'context-menu':
   '.workspace':
     'Inspect Element': 'core:inspect'
-    '-': '-'
+    'Separator': '-'
     'Text':
       'Select All': 'core:select-all'
+      'Another Separator': '-'
       'Deleted Selected Text': 'core:delete'
 ```
 

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -30,6 +30,16 @@ describe "ContextMenuManager", ->
       expect(contextMenu.definitions['.selector'][0].command).toEqual 'command'
       expect(contextMenu.definitions['.selector'].length).toBe 1
 
+    it 'allows multiple separators', ->
+      contextMenu.add 'file-path',
+        '.selector':
+          'separator1': '-'
+          'separator2': '-'
+
+      expect(contextMenu.definitions['.selector'].length).toBe 2
+      expect(contextMenu.definitions['.selector'][0].type).toEqual 'separator'
+      expect(contextMenu.definitions['.selector'][1].type).toEqual 'separator'
+
     it 'allows duplicate commands with different labels',  ->
       contextMenu.add 'file-path',
         '.selector':

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -44,7 +44,7 @@ class ContextMenuManager
           @addBySelector(selector, menuItem, {devMode})
 
   buildMenuItem: (label, command) ->
-    if label is command is '-'
+    if command is '-'
       {type: 'separator'}
     else
       {label, command}
@@ -60,7 +60,7 @@ class ContextMenuManager
   #              editor is in dev mode.
   addBySelector: (selector, definition, {devMode}={}) ->
     definitions = if devMode then @devModeDefinitions else @definitions
-    unless _.findWhere(definitions[selector], definition)
+    if not _.findWhere(definitions[selector], definition) or _.isEqual(definition, {type: 'separator'})
       (definitions[selector] ?= []).push(definition)
 
   # Returns definitions which match the element and devMode.


### PR DESCRIPTION
Fixes #2847 

This allows multiple separators in context menus by interpreting all objects with the value `-` as separators, rather than just objects which have `-` both as the key and the value. 

cc @kevinsawicki 
