### PR TITLE
Add grammar scope to EditorView

### DIFF
--- a/spec/editor-view-spec.coffee
+++ b/spec/editor-view-spec.coffee
@@ -3050,7 +3050,7 @@ describe "EditorView", ->
     it "adds and updates the grammar data attribute based on the current grammar", ->
       editorView.attachToDom()
       editor.setGrammar(atom.syntax.grammarForScopeName('text.plain'))
-      expect(editorView.attr('data-grammar')).toEqual 'text.plain'
+      expect(editorView.attr('data-grammar')).toBe 'text plain'
 
-      editor.setGrammar(atom.syntax.grammarForScopeName('source.javascript'))
-      expect(editorView.attr('data-grammar')).toEqual 'source.javascript'
+      editor.setGrammar(atom.syntax.grammarForScopeName('source.js'))
+      expect(editorView.attr('data-grammar')).toBe 'source js'

--- a/spec/editor-view-spec.coffee
+++ b/spec/editor-view-spec.coffee
@@ -3045,3 +3045,12 @@ describe "EditorView", ->
       editorView.pixelPositionForScreenPosition([0, editor.getTabLength()])
       editorView.pixelPositionForScreenPosition([0, editor.getTabLength() + 1])
       expect(editorView.measureToColumn.callCount).toBe 0
+
+  describe "grammar data attributes", ->
+    it "adds and updates the grammar data attribute based on the current grammar", ->
+      editorView.attachToDom()
+      editor.setGrammar(atom.syntax.grammarForScopeName('text.plain'))
+      expect(editorView.attr('data-grammar')).toEqual 'text.plain'
+
+      editor.setGrammar(atom.syntax.grammarForScopeName('source.javascript'))
+      expect(editorView.attr('data-grammar')).toEqual 'source.javascript'

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -560,6 +560,7 @@ class EditorView extends View
       @trigger 'editor:path-changed'
 
     @subscribe @editor, "grammar-changed", =>
+      @addGrammarScopeClasses()
       @trigger 'editor:grammar-changed'
 
     @subscribe @editor, 'selection-added', (selection) =>
@@ -584,6 +585,11 @@ class EditorView extends View
 
     if @attached and @editor.buffer.isInConflict()
       _.defer => @showBufferConflictAlert(@editor) # Display after editor has a chance to display
+
+  addGrammarScopeClasses: ->
+    scopeParts = @editor.getGrammar()?.scopeName?.split('.')
+    classes = scopeParts.join(' ') if scopeParts?.length
+    @addClass(classes) if classes?
 
   getModel: ->
     @editor

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -582,6 +582,7 @@ class EditorView extends View
 
     @trigger 'editor:path-changed'
     @resetDisplay()
+    @addGrammarScopeAttribute()
 
     if @attached and @editor.buffer.isInConflict()
       _.defer => @showBufferConflictAlert(@editor) # Display after editor has a chance to display

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -560,7 +560,7 @@ class EditorView extends View
       @trigger 'editor:path-changed'
 
     @subscribe @editor, "grammar-changed", =>
-      @addGrammarScopeClasses()
+      @addGrammarScopeAttribute()
       @trigger 'editor:grammar-changed'
 
     @subscribe @editor, 'selection-added', (selection) =>
@@ -586,10 +586,9 @@ class EditorView extends View
     if @attached and @editor.buffer.isInConflict()
       _.defer => @showBufferConflictAlert(@editor) # Display after editor has a chance to display
 
-  addGrammarScopeClasses: ->
-    scopeParts = @editor.getGrammar()?.scopeName?.split('.')
-    classes = scopeParts.join(' ') if scopeParts?.length
-    @addClass(classes) if classes?
+  addGrammarScopeAttribute: ->
+    grammarScope = @editor.getGrammar()?.scopeName?.replace(/\./g, ' ')
+    @attr('data-scope', grammarScope)
 
   getModel: ->
     @editor

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -589,7 +589,7 @@ class EditorView extends View
 
   addGrammarScopeAttribute: ->
     grammarScope = @editor.getGrammar()?.scopeName?.replace(/\./g, ' ')
-    @attr('data-scope', grammarScope)
+    @attr('data-grammar', grammarScope)
 
   getModel: ->
     @editor

--- a/src/react-editor-view.coffee
+++ b/src/react-editor-view.coffee
@@ -81,7 +81,16 @@ class ReactEditorView extends View
     @attached = true
     @component.pollDOM()
     @focus() if @focusOnAttach
+
+    @addGrammarScopeAttribute()
+    @subscribe @editor, 'grammar-changed', =>
+      @addGrammarScopeAttribute()
+
     @trigger 'editor:attached', [this]
+
+  addGrammarScopeAttribute: ->
+    grammarScope = @editor.getGrammar()?.scopeName?.replace(/\./g, ' ')
+    @attr('data-scope', grammarScope)
 
   scrollTop: (scrollTop) ->
     if scrollTop?

--- a/src/react-editor-view.coffee
+++ b/src/react-editor-view.coffee
@@ -90,7 +90,7 @@ class ReactEditorView extends View
 
   addGrammarScopeAttribute: ->
     grammarScope = @editor.getGrammar()?.scopeName?.replace(/\./g, ' ')
-    @attr('data-scope', grammarScope)
+    @attr('data-grammar', grammarScope)
 
   scrollTop: (scrollTop) ->
     if scrollTop?


### PR DESCRIPTION
**NOTE: This pull request is still work in progress. I just wanted to open it early to keep my intent and progress public, and discoverable.**

The sole purpose of this pull request is to add grammar scope information to `EditorView` instances, so that e.g. editor key bindings can trigger based on grammar. Useful if you want to invoke different build or formatting commands in various packages, for different types of grammars.

Right now I'm solving this by appending CSS classes to the view, but I'm leaning towards adding a `data-scope` attribute instead, to prevent pollution and potential conflicts that might cause all manner of mayhem.
