### PR TITLE
Upgrade keymap to support 'abort!' directive in keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "atomShellVersion": "0.13.3",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "^0.27.0",
+    "atom-keymap": "^0.28.0",
     "bootstrap": "git+https://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",
     "clear-cut": "0.4.0",
     "coffee-script": "1.7.0",


### PR DESCRIPTION
Closes atom/vim-mode#348. See that issue for more explanation.
