### PR TITLE
Issue with mkdeb

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -32,7 +32,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
   cd atom
   script/build # Creates application at $TMPDIR/atom-build/Atom
   sudo script/grunt install # Installs command to /usr/local/bin/atom
-  script/grunt mkdeb # Generates a .deb package at $TMPDIR/atom-build
+  sudo script/grunt mkdeb # Generates a .deb package at $TMPDIR/atom-build
   ```
 
 ## Troubleshooting


### PR DESCRIPTION
script/grunt mkdeb # Generates a .deb package at $TMPDIR/atom-build

Need sudo.

sudo script/grunt mkdeb # Generates a .deb package at $TMPDIR/atom-build
