### PR TITLE
Proper Linux second clipboard support

### DIFF
--- a/src/clipboard.coffee
+++ b/src/clipboard.coffee
@@ -21,19 +21,26 @@ class Clipboard
   #
   # The metadata associated with the text is available by calling
   # {::readWithMetadata}.
-  #
   # text - The {String} to store.
+  #
   # metadata - The additional info to associate with the text.
-  write: (text, metadata) ->
+  #
+  # type - Optional parameter defining a clipboard name. Useful for X11 platforms
+  #        where there is possible to have multiple clipboard buffers.
+  #
+  write: (text, metadata, type) ->
     @signatureForMetadata = @md5(text)
     @metadata = metadata
-    clipboard.writeText(text)
+    clipboard.writeText(text, type)
 
   # Public: Read the text from the clipboard.
   #
+  # type - Optional parameter defining a clipboard name. Useful for X11 platforms
+  #        where there is possible to have multiple clipboard buffers.
+  #
   # Returns a {String}.
-  read: ->
-    clipboard.readText()
+  read: (type) ->
+    clipboard.readText(type)
 
   # Public: Read the text from the clipboard and return both the text and the
   # associated metadata.

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -471,6 +471,19 @@ class EditorView extends View
         @hiddenInput.val(lastInput)
         false
 
+    # Linux second clipboard handling
+    if process.platform is 'linux'
+      @on "mousedown", (e) =>
+        if e.which is 2
+          # Change current cursor position to the click position
+          clickedElement = document.elementFromPoint(e.pageX, e.pageY)
+          e.target = clickedElement
+          e.which = 1
+          $(clickedElement).trigger(e)
+
+          # Paste here
+          @editor.insertText(atom.clipboard.read('selection'))
+
     # Ignore paste event, on Linux is wrongly emitted when user presses ctrl-v.
     @on "paste", -> false
 
@@ -489,6 +502,12 @@ class EditorView extends View
         @editor.mergeIntersectingSelections(reversed: @editor.getLastSelection().isReversed())
         @editor.finalizeSelections()
         @syncCursorAnimations()
+
+        # Linux second clipboard handling
+        if process.platform is 'linux'
+          text = @editor.getSelection().getText()
+          if text.length > 0
+            atom.clipboard.write(text, {}, "selection")
 
     moveHandler = (event = lastMoveEvent) =>
       return unless event?


### PR DESCRIPTION
CC: #2272 #2244

My implementation follows the traditional X11 behaviour as closely as possible:
1. The main clipboard (Ctrl+C, Ctrl+V) is a different one than the second one (select, middle-click) which I'm implementing here. That means, by copying to one, the second one is left intact.
2. When pasting, the text cursor goes to a position under the mouse, then the second clipboard data are pasted (ie. it ignores and overwrites the previous cursor position and selection).
3. When copying, text is copied to the second clipboard only if I select the text with a mouse (not with a keyboard, not if the text is selected with some kind of automatic behaviour). This also includes double-click and triple-click selection.
4. When I deselect the text (this is why I check the length), the second keyboard is left intact.
5. The second clipboard should work between applications.
6. The paste should take place on mousedown, not on mouseup.
