### PR TITLE
Don't write .deb files in place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ debug.log
 docs/output
 docs/includes
 spec/fixtures/evil-files/
-resources/linux/Atom.desktop
-resources/linux/debian/control

--- a/build/package.json
+++ b/build/package.json
@@ -34,7 +34,6 @@
     "request": "~2.27.0",
     "rimraf": "~2.2.2",
     "runas": "0.5.x",
-    "temp": "^0.8.0",
     "underscore-plus": "1.x",
     "unzip": "~0.1.9",
     "vm-compatibility-layer": "~0.1.0"

--- a/build/package.json
+++ b/build/package.json
@@ -14,8 +14,8 @@
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.9",
     "grunt-coffeelint": "git+https://github.com/atom/grunt-coffeelint.git",
-    "grunt-contrib-csslint": "~0.1.2",
     "grunt-contrib-coffee": "~0.9.0",
+    "grunt-contrib-csslint": "~0.1.2",
     "grunt-contrib-less": "~0.8.0",
     "grunt-cson": "0.8.0",
     "grunt-download-atom-shell": "~0.8.0",
@@ -27,15 +27,16 @@
     "json-front-matter": "~0.1.3",
     "legal-eagle": "~0.4.0",
     "minidump": "~0.7",
-    "read-package-json": "1.1.8",
     "normalize-package-data": "0.2.12",
+    "npm": "~1.4.5",
     "rcedit": "~0.1.2",
+    "read-package-json": "1.1.8",
     "request": "~2.27.0",
     "rimraf": "~2.2.2",
     "runas": "0.5.x",
+    "temp": "^0.8.0",
     "underscore-plus": "1.x",
     "unzip": "~0.1.9",
-    "vm-compatibility-layer": "~0.1.0",
-    "npm": "~1.4.5"
+    "vm-compatibility-layer": "~0.1.0"
   }
 }

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -36,13 +36,14 @@ module.exports = (grunt) ->
 
       # Create Atom.desktop if installation not in temporary folder
       tmpDir = if process.env.TMPDIR? then process.env.TMPDIR else '/tmp'
-      desktopInstallFile = path.join(installDir, 'share', 'applications', 'Atom.desktop')
       if installDir.indexOf(tmpDir) isnt 0
         mkdir path.dirname(desktopInstallFile)
         {description} = grunt.file.readJSON('package.json')
         installDir = path.join(installDir,'.') # To prevent "Exec=/usr/local//share/atom/atom"
 
+        desktopInstallFile = path.join(installDir, 'share', 'applications', 'Atom.desktop')
         desktopFile = path.join('resources', 'linux', 'Atom.desktop.in')
+
         template = _.template(String(fs.readFileSync(desktopFile)))
         filled = template({description, installDir, iconName})
 

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -41,7 +41,7 @@ module.exports = (grunt) ->
         desktopInstallFile = path.join(installDir, 'share', 'applications', 'Atom.desktop')
 
         {description} = grunt.file.readJSON('package.json')
-        iconName = path.join(shareDir,'resources','app','resources','atom.png')
+        iconName = path.join(shareDir, 'resources', 'app', 'resources', 'atom.png')
         installDir = path.join(installDir, '.') # To prevent "Exec=/usr/local//share/atom/atom"
         template = _.template(String(fs.readFileSync(desktopFile)))
         filled = template({description, installDir, iconName})

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -40,8 +40,6 @@ module.exports = (grunt) ->
         desktopFile = path.join('resources', 'linux', 'Atom.desktop.in')
         desktopInstallFile = path.join(installDir, 'share', 'applications', 'Atom.desktop')
 
-        mkdir path.dirname(desktopInstallFile)
-
         {description} = grunt.file.readJSON('package.json')
         iconName = path.join(shareDir,'resources','app','resources','atom.png')
         installDir = path.join(installDir, '.') # To prevent "Exec=/usr/local//share/atom/atom"

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -4,11 +4,6 @@ _ = require 'underscore-plus'
 fs = require 'fs-plus'
 runas = null
 
-fillTemplate = (filePath, data) ->
-  template = _.template(String(fs.readFileSync(filePath + '.in')))
-  filled = template(data)
-  fs.writeFileSync(filePath, filled)
-
 module.exports = (grunt) ->
   {cp, mkdir, rm} = require('./task-helpers')(grunt)
 
@@ -32,7 +27,6 @@ module.exports = (grunt) ->
       shareDir = path.join(installDir, 'share', 'atom')
 
       iconName = path.join(shareDir,'resources','app','resources','atom.png')
-      desktopFile = path.join('resources', 'linux', 'Atom.desktop')
 
       mkdir binDir
       cp 'atom.sh', path.join(binDir, 'atom')
@@ -42,13 +36,17 @@ module.exports = (grunt) ->
 
       # Create Atom.desktop if installation not in temporary folder
       tmpDir = if process.env.TMPDIR? then process.env.TMPDIR else '/tmp'
-      desktopInstallFile = path.join(installDir,'share','applications','Atom.desktop')
+      desktopInstallFile = path.join(installDir, 'share', 'applications', 'Atom.desktop')
       if installDir.indexOf(tmpDir) isnt 0
         mkdir path.dirname(desktopInstallFile)
         {description} = grunt.file.readJSON('package.json')
         installDir = path.join(installDir,'.') # To prevent "Exec=/usr/local//share/atom/atom"
-        fillTemplate(desktopFile, {description, installDir, iconName})
-        cp desktopFile, desktopInstallFile
+
+        desktopFile = path.join('resources', 'linux', 'Atom.desktop.in')
+        template = _.template(String(fs.readFileSync(desktopFile)))
+        filled = template({description, installDir, iconName})
+
+        grunt.file.write(desktopInstallFile, filled)
 
       # Create relative symbol link for apm.
       process.chdir(binDir)

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -10,6 +10,7 @@ module.exports = (grunt) ->
   grunt.registerTask 'install', 'Install the built application', ->
     installDir = grunt.config.get('atom.installDir')
     shellAppDir = grunt.config.get('atom.shellAppDir')
+
     if process.platform is 'win32'
       runas ?= require 'runas'
       copyFolder = path.resolve 'script', 'copy-folder.cmd'

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -37,13 +37,14 @@ module.exports = (grunt) ->
       # Create Atom.desktop if installation not in temporary folder
       tmpDir = if process.env.TMPDIR? then process.env.TMPDIR else '/tmp'
       if installDir.indexOf(tmpDir) isnt 0
-        mkdir path.dirname(desktopInstallFile)
-        {description} = grunt.file.readJSON('package.json')
-        installDir = path.join(installDir,'.') # To prevent "Exec=/usr/local//share/atom/atom"
-
-        desktopInstallFile = path.join(installDir, 'share', 'applications', 'Atom.desktop')
         desktopFile = path.join('resources', 'linux', 'Atom.desktop.in')
+        desktopInstallFile = path.join(installDir, 'share', 'applications', 'Atom.desktop')
 
+        mkdir path.dirname(desktopInstallFile)
+
+        {description} = grunt.file.readJSON('package.json')
+        iconName = path.join(shareDir,'resources','app','resources','atom.png')
+        installDir = path.join(installDir, '.') # To prevent "Exec=/usr/local//share/atom/atom"
         template = _.template(String(fs.readFileSync(desktopFile)))
         filled = template({description, installDir, iconName})
 

--- a/build/tasks/mkdeb-task.coffee
+++ b/build/tasks/mkdeb-task.coffee
@@ -1,11 +1,17 @@
 fs = require 'fs'
 path = require 'path'
 _ = require 'underscore-plus'
+temp = require 'temp'
+
+tempResourcesFolder = temp.mkdirSync('atom-resources-')
 
 fillTemplate = (filePath, data) ->
-  template = _.template(String(fs.readFileSync(filePath + '.in')))
+  template = _.template(String(fs.readFileSync("#{filePath}.in")))
   filled = template(data)
-  fs.writeFileSync(filePath, filled)
+
+  outputPath = path.join(tempResourcesFolder, path.basename(filePath))
+  fs.writeFileSync(outputPath, filled)
+  outputPath
 
 module.exports = (grunt) ->
   {spawn} = require('./task-helpers')(grunt)
@@ -27,13 +33,11 @@ module.exports = (grunt) ->
     iconName = 'atom'
     data = {name, version, description, section, arch, maintainer, installDir, iconName}
 
-    control = path.join('resources', 'linux', 'debian', 'control')
-    fillTemplate(control, data)
-    desktop = path.join('resources', 'linux', 'Atom.desktop')
-    fillTemplate(desktop, data)
+    controlFilePath = fillTemplate(path.join('resources', 'linux', 'debian', 'control'), data)
+    desktopFilePath = fillTemplate(path.join('resources', 'linux', 'Atom.desktop'), data)
     icon = path.join('resources', 'atom.png')
     buildDir = grunt.config.get('atom.buildDir')
 
     cmd = path.join('script', 'mkdeb')
-    args = [version, arch, control, desktop, icon, buildDir]
+    args = [version, arch, controlFilePath, desktopFilePath, icon, buildDir]
     spawn({cmd, args}, done)

--- a/build/tasks/mkdeb-task.coffee
+++ b/build/tasks/mkdeb-task.coffee
@@ -10,7 +10,7 @@ module.exports = (grunt) ->
     filled = template(data)
 
     outputPath = path.join(grunt.config.get('atom.buildDir'), path.basename(filePath))
-    fs.writeFileSync(outputPath, filled)
+    grunt.file.write(outputPath, filled)
     outputPath
 
   grunt.registerTask 'mkdeb', 'Create debian package', ->

--- a/build/tasks/mkdeb-task.coffee
+++ b/build/tasks/mkdeb-task.coffee
@@ -1,21 +1,17 @@
 fs = require 'fs'
 path = require 'path'
 _ = require 'underscore-plus'
-temp = require 'temp'
-
-temp.track()
-tempResourcesFolder = temp.mkdirSync('atom-resources-')
-
-fillTemplate = (filePath, data) ->
-  template = _.template(String(fs.readFileSync("#{filePath}.in")))
-  filled = template(data)
-
-  outputPath = path.join(tempResourcesFolder, path.basename(filePath))
-  fs.writeFileSync(outputPath, filled)
-  outputPath
 
 module.exports = (grunt) ->
   {spawn} = require('./task-helpers')(grunt)
+
+  fillTemplate = (filePath, data) ->
+    template = _.template(String(fs.readFileSync("#{filePath}.in")))
+    filled = template(data)
+
+    outputPath = path.join(grunt.config.get('atom.buildDir'), path.basename(filePath))
+    fs.writeFileSync(outputPath, filled)
+    outputPath
 
   grunt.registerTask 'mkdeb', 'Create debian package', ->
     done = @async()

--- a/build/tasks/mkdeb-task.coffee
+++ b/build/tasks/mkdeb-task.coffee
@@ -3,6 +3,7 @@ path = require 'path'
 _ = require 'underscore-plus'
 temp = require 'temp'
 
+temp.track()
 tempResourcesFolder = temp.mkdirSync('atom-resources-')
 
 fillTemplate = (filePath, data) ->


### PR DESCRIPTION
Previously running `sudo script/grunt install` followed by `script/grunt mkdeb` would result in an error since the file created at `resources/linux/Atom.desktop` would be owned by root.

Now the control and desktop files are never written to the source tree and instead always written to the build folder and copied over.

Refs #2129
