### PR TITLE
Horizontal scrollbar no longer covers the gutter

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -1565,7 +1565,27 @@ describe "EditorComponent", ->
       component.measureHeightAndWidth()
       runSetImmediateCallbacks()
 
-      expect(horizontalScrollbarNode.scrollWidth).toBe gutterNode.offsetWidth + editor.getScrollWidth()
+      expect(horizontalScrollbarNode.scrollWidth).toBe editor.getScrollWidth()
+      expect(horizontalScrollbarNode.style.left).toBe gutterNode.offsetWidth + 'px'
+
+    it "updates the position and width of the horizontal scrollbar when editor.showLineNumbers is toggled", ->
+      componentNode.style.width = 10 * charWidth + 'px'
+      component.measureHeightAndWidth()
+      runSetImmediateCallbacks()
+
+      gutterNode = componentNode.querySelector('.gutter')
+      expect(horizontalScrollbarNode.scrollWidth).toBe editor.getScrollWidth()
+      expect(horizontalScrollbarNode.style.left).toBe gutterNode.offsetWidth + 'px'
+
+      atom.config.set("editor.showLineNumbers", false)
+      gutterNode = componentNode.querySelector('.gutter')
+      expect(horizontalScrollbarNode.scrollWidth).toBe editor.getScrollWidth()
+      expect(horizontalScrollbarNode.style.left).toBe '0px'
+
+      atom.config.set("editor.showLineNumbers", true)
+      gutterNode = componentNode.querySelector('.gutter')
+      expect(horizontalScrollbarNode.scrollWidth).toBe editor.getScrollWidth()
+      expect(horizontalScrollbarNode.style.left).toBe gutterNode.offsetWidth + 'px'
 
   describe "mousewheel events", ->
     beforeEach ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -1566,57 +1566,7 @@ describe "EditorComponent", ->
       runSetImmediateCallbacks()
 
       expect(horizontalScrollbarNode.scrollWidth).toBe editor.getScrollWidth()
-
-    it "updates the position and width of the horizontal scrollbar when editor.showLineNumbers is toggled", ->
-      componentNode.style.width = 10 * charWidth + 'px'
-      component.measureHeightAndWidth()
-      runSetImmediateCallbacks()
-
-      gutterNode = componentNode.querySelector('.gutter')
-      expect(horizontalScrollbarNode.scrollWidth).toBe editor.getScrollWidth()
-      expect(horizontalScrollbarNode.style.left).toBe gutterNode.offsetWidth + 'px'
-
-      atom.config.set("editor.showLineNumbers", false)
-      runSetImmediateCallbacks()
-      gutterNode = componentNode.querySelector('.gutter')
-      expect(horizontalScrollbarNode.scrollWidth).toBe editor.getScrollWidth()
       expect(horizontalScrollbarNode.style.left).toBe '0px'
-
-      atom.config.set("editor.showLineNumbers", true)
-      runSetImmediateCallbacks()
-      gutterNode = componentNode.querySelector('.gutter')
-      expect(horizontalScrollbarNode.scrollWidth).toBe editor.getScrollWidth()
-      expect(horizontalScrollbarNode.style.left).toBe gutterNode.offsetWidth + 'px'
-
-    describe "when the editor is hidden", ->
-      hideEditorView = ->
-        wrapperNode.style.display = 'none'
-        expect(component.isVisible()).toBe false
-
-      showEditorView = ->
-        wrapperNode.style.display = 'block'
-        expect(component.isVisible()).toBe true
-
-      it "updates the position of the horizontal scrollbar only when the editor is visible", ->
-        # toggling gutter off
-        hideEditorView()
-        atom.config.set("editor.showLineNumbers", false)
-
-        showEditorView()
-        component.forceUpdate()
-        runSetImmediateCallbacks()
-        gutterNode = componentNode.querySelector('.gutter')
-        expect(horizontalScrollbarNode.style.left).toBe '0px'
-
-        # toggling gutter back on
-        hideEditorView()
-        atom.config.set("editor.showLineNumbers", true)
-
-        showEditorView()
-        component.forceUpdate()
-        runSetImmediateCallbacks()
-        gutterNode = componentNode.querySelector('.gutter')
-        expect(horizontalScrollbarNode.style.left).toBe gutterNode.offsetWidth + 'px'
 
   describe "mousewheel events", ->
     beforeEach ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -1578,11 +1578,13 @@ describe "EditorComponent", ->
       expect(horizontalScrollbarNode.style.left).toBe gutterNode.offsetWidth + 'px'
 
       atom.config.set("editor.showLineNumbers", false)
+      runSetImmediateCallbacks()
       gutterNode = componentNode.querySelector('.gutter')
       expect(horizontalScrollbarNode.scrollWidth).toBe editor.getScrollWidth()
       expect(horizontalScrollbarNode.style.left).toBe '0px'
 
       atom.config.set("editor.showLineNumbers", true)
+      runSetImmediateCallbacks()
       gutterNode = componentNode.querySelector('.gutter')
       expect(horizontalScrollbarNode.scrollWidth).toBe editor.getScrollWidth()
       expect(horizontalScrollbarNode.style.left).toBe gutterNode.offsetWidth + 'px'

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -1589,6 +1589,36 @@ describe "EditorComponent", ->
       expect(horizontalScrollbarNode.scrollWidth).toBe editor.getScrollWidth()
       expect(horizontalScrollbarNode.style.left).toBe gutterNode.offsetWidth + 'px'
 
+    describe "when the editor is hidden", ->
+      hideEditorView = ->
+        wrapperNode.style.display = 'none'
+        expect(component.isVisible()).toBe false
+
+      showEditorView = ->
+        wrapperNode.style.display = 'block'
+        expect(component.isVisible()).toBe true
+
+      it "updates the position of the horizontal scrollbar only when the editor is visible", ->
+        # toggling gutter off
+        hideEditorView()
+        atom.config.set("editor.showLineNumbers", false)
+
+        showEditorView()
+        component.forceUpdate()
+        runSetImmediateCallbacks()
+        gutterNode = componentNode.querySelector('.gutter')
+        expect(horizontalScrollbarNode.style.left).toBe '0px'
+
+        # toggling gutter back on
+        hideEditorView()
+        atom.config.set("editor.showLineNumbers", true)
+
+        showEditorView()
+        component.forceUpdate()
+        runSetImmediateCallbacks()
+        gutterNode = componentNode.querySelector('.gutter')
+        expect(horizontalScrollbarNode.style.left).toBe gutterNode.offsetWidth + 'px'
+
   describe "mousewheel events", ->
     beforeEach ->
       atom.config.set('editor.scrollSensitivity', 100)

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -138,8 +138,9 @@ EditorComponent = React.createClass
         className: 'horizontal-scrollbar'
         orientation: 'horizontal'
         onScroll: @onHorizontalScroll
+        gutterWidth: @gutterWidth
         scrollLeft: scrollLeft
-        scrollWidth: scrollWidth + @gutterWidth
+        scrollWidth: scrollWidth
         visible: horizontallyScrollable and not @refreshingScrollbars and not @measuringScrollbars
         scrollableInOppositeDirection: verticallyScrollable
         verticalScrollbarWidth: verticalScrollbarWidth
@@ -668,6 +669,7 @@ EditorComponent = React.createClass
         editor.setSelectedScreenRange([tailPosition, [dragRow + 1, 0]])
 
   onStylesheetsChanged: (stylesheet) ->
+    @refs.gutter.measureWidth()
     @refreshScrollbars() if @containsScrollbarSelector(stylesheet)
     @remeasureCharacterWidthsIfVisibleAfterNextUpdate = true
     @requestUpdate() if @visible

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -63,11 +63,11 @@ GutterComponent = React.createClass
       @updateDummyLineNumber()
       @removeLineNumberNodes()
 
-    unless isEqualForProperties(oldProps, @props, 'maxLineNumberDigits', 'defaultCharWidth')
-      @measureWidth()
-
     @clearScreenRowCaches() unless oldProps.lineHeightInPixels is @props.lineHeightInPixels
     @updateLineNumbers()
+
+    unless isEqualForProperties(oldProps, @props, 'maxLineNumberDigits', 'defaultCharWidth')
+      @measureWidth()
 
   clearScreenRowCaches: ->
     @lineNumberIdsByScreenRow = {}

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -66,9 +66,6 @@ GutterComponent = React.createClass
     @clearScreenRowCaches() unless oldProps.lineHeightInPixels is @props.lineHeightInPixels
     @updateLineNumbers()
 
-    unless isEqualForProperties(oldProps, @props, 'maxLineNumberDigits', 'defaultCharWidth')
-      @measureWidth()
-
   clearScreenRowCaches: ->
     @lineNumberIdsByScreenRow = {}
     @screenRowsByLineNumberId = {}
@@ -223,9 +220,3 @@ GutterComponent = React.createClass
         editor.unfoldBufferRow(bufferRow)
       else
         editor.foldBufferRow(bufferRow)
-
-  measureWidth: ->
-    width = @getDOMNode().offsetWidth
-    unless width is @measuredWidth
-      @measuredWidth = width
-      @props.onWidthChanged?(width)

--- a/src/scrollbar-component.coffee
+++ b/src/scrollbar-component.coffee
@@ -7,7 +7,7 @@ ScrollbarComponent = React.createClass
   displayName: 'ScrollbarComponent'
 
   render: ->
-    {orientation, className, scrollHeight, scrollWidth, gutterWidth, visible} = @props
+    {orientation, className, scrollHeight, scrollWidth, visible} = @props
     {scrollableInOppositeDirection, horizontalScrollbarHeight, verticalScrollbarWidth} = @props
 
     style = {}
@@ -17,9 +17,9 @@ ScrollbarComponent = React.createClass
         style.width = verticalScrollbarWidth
         style.bottom = horizontalScrollbarHeight if scrollableInOppositeDirection
       when 'horizontal'
-        style.height = horizontalScrollbarHeight
+        style.left = 0
         style.right = verticalScrollbarWidth if scrollableInOppositeDirection
-        style.left = gutterWidth
+        style.height = horizontalScrollbarHeight
 
     div {className, style, @onScroll},
       switch orientation
@@ -41,7 +41,7 @@ ScrollbarComponent = React.createClass
       when 'vertical'
         not isEqualForProperties(newProps, @props, 'scrollHeight', 'scrollTop', 'scrollableInOppositeDirection')
       when 'horizontal'
-        not isEqualForProperties(newProps, @props, 'scrollWidth', 'scrollLeft', 'gutterWidth', 'scrollableInOppositeDirection')
+        not isEqualForProperties(newProps, @props, 'scrollWidth', 'scrollLeft', 'scrollableInOppositeDirection')
 
   componentDidUpdate: ->
     {orientation, scrollTop, scrollLeft} = @props

--- a/src/scrollbar-component.coffee
+++ b/src/scrollbar-component.coffee
@@ -7,7 +7,7 @@ ScrollbarComponent = React.createClass
   displayName: 'ScrollbarComponent'
 
   render: ->
-    {orientation, className, scrollHeight, scrollWidth, visible} = @props
+    {orientation, className, scrollHeight, scrollWidth, gutterWidth, visible} = @props
     {scrollableInOppositeDirection, horizontalScrollbarHeight, verticalScrollbarWidth} = @props
 
     style = {}
@@ -19,6 +19,7 @@ ScrollbarComponent = React.createClass
       when 'horizontal'
         style.height = horizontalScrollbarHeight
         style.right = verticalScrollbarWidth if scrollableInOppositeDirection
+        style.left = gutterWidth
 
     div {className, style, @onScroll},
       switch orientation
@@ -40,7 +41,7 @@ ScrollbarComponent = React.createClass
       when 'vertical'
         not isEqualForProperties(newProps, @props, 'scrollHeight', 'scrollTop', 'scrollableInOppositeDirection')
       when 'horizontal'
-        not isEqualForProperties(newProps, @props, 'scrollWidth', 'scrollLeft', 'scrollableInOppositeDirection')
+        not isEqualForProperties(newProps, @props, 'scrollWidth', 'scrollLeft', 'gutterWidth', 'scrollableInOppositeDirection')
 
   componentDidUpdate: ->
     {orientation, scrollTop, scrollLeft} = @props


### PR DESCRIPTION
Handles toggling of `editor.showLineNumbers` as well.

I moved the `gutterWidth` into the `EditorComponent` state as react takes care of forcing updates when the state changes.

Fixes #3039
