### PR TITLE
Add key binding for transpose to linux and win keymaps

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -96,6 +96,7 @@
   'ctrl-alt-shift-p': 'editor:log-cursor-scope'
   'ctrl-k ctrl-u': 'editor:upper-case'
   'ctrl-k ctrl-l': 'editor:lower-case'
+  'alt-t': 'editor:transpose'
 
 '.workspace .editor:not(.mini)':
   # Atom specific

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -93,6 +93,7 @@
   'ctrl-alt-shift-p': 'editor:log-cursor-scope'
   'ctrl-k ctrl-u': 'editor:upper-case'
   'ctrl-k ctrl-l': 'editor:lower-case'
+  'alt-t': 'editor:transpose'
 
 '.workspace .editor:not(.mini)':
   # Atom specific


### PR DESCRIPTION
I choose `alt-t`, but can change to whatever if people want something different.  Sublime 2 uses `ctrl-t`, but that is already used and `ctrl-shift-t` is already pretty crowded.
