### PR TITLE
Fix for jank measurement when `letter-spacing` is set.

### DIFF
--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -309,7 +309,9 @@ LinesComponent = React.createClass
       for char in value
         continue if char is '\0'
 
-        unless charWidths[char]?
+        if charWidths[char]?
+          previousCharRect = null
+        else
           unless textNode?
             rangeForMeasurement ?= document.createRange()
             iterator =  document.createNodeIterator(lineNode, NodeFilter.SHOW_TEXT, AcceptFilter)

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -305,7 +305,7 @@ LinesComponent = React.createClass
 
     for {value, scopes}, tokenIndex in tokenizedLine.tokens
       charWidths = editor.getScopedCharWidths(scopes)
-
+      previousCharRect = null
       for char in value
         continue if char is '\0'
 
@@ -325,8 +325,17 @@ LinesComponent = React.createClass
           i = charIndex - textNodeIndex
           rangeForMeasurement.setStart(textNode, i)
           rangeForMeasurement.setEnd(textNode, i + 1)
-          charWidth = rangeForMeasurement.getBoundingClientRect().width
+
+          charRect = rangeForMeasurement.getBoundingClientRect()
+          charWidth = charRect.width
+
+          # Chrome is misreporting widths in some cases so we compensate
+          # https://github.com/atom/atom/issues/3054#issuecomment-49987029
+          if previousCharRect? and previousCharRect?.right != charRect.left
+            charWidth += charRect.left - previousCharRect.right
+
           editor.setScopedCharWidth(scopes, char, charWidth)
+          previousCharRect = charRect
 
         charIndex++
 


### PR DESCRIPTION
@nathansobo This doesnt really work. It only works if we measure all the characters in the line all the time.  Even then, though, there are cases it's off a little bit. Ugh. If you have any suggestions, glad to hear them, but thinking i'll just wontfix #3054 and have them use `px`.
