### PR TITLE
More useful split-selection-into-lines

### DIFF
--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1762,7 +1762,8 @@ class Editor extends Model
       {row} = start
       while ++row < end.row
         @addSelectionForBufferRange([[row, 0], [row, Infinity]])
-      @addSelectionForBufferRange([[end.row, 0], [end.row, end.column]])
+      unless end.column is 0
+        @addSelectionForBufferRange([[end.row, 0], [end.row, end.column]])
 
   # Public: For each selection, transpose the selected text.
   #


### PR DESCRIPTION
Changes `split-selection-into-lines` to work the same way as Sublime Text.

Fixes #1704.

Test Plan:
- Ran `script/build`
- Opened a new instance of Atom
- Selected some lines via the gutter
- Executed `split-selection-into-lines`
- Saw one selection for each line that was visually highlighted
- Selected some lines with the mouse, including a partial one at the end
- Executed `split-selection-into-lines`
- Saw one selection for each line that was visually highlighted
