### PR TITLE
Remove duplicate addUrlToOpen() in browser/main.coffee

### DIFF
--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -27,10 +27,6 @@ start = ->
     event.preventDefault()
     args.urlsToOpen.push(urlToOpen)
 
-  app.on 'open-url', (event, urlToOpen) ->
-    event.preventDefault()
-    args.urlsToOpen.push(urlToOpen)
-
   app.on 'open-file', addPathToOpen
   app.on 'open-url', addUrlToOpen
 


### PR DESCRIPTION
I don't think that this was the desired behaviour.
I do not know if that caused a bug.
