### PR TITLE
Export Atom's version of React and Reactionary

### DIFF
--- a/exports/atom.coffee
+++ b/exports/atom.coffee
@@ -25,3 +25,5 @@ unless process.env.ATOM_SHELL_INTERNAL_RUN_AS_NODE
   module.exports.View = View
   module.exports.WorkspaceView = require '../src/workspace-view'
   module.exports.Workspace = require '../src/workspace'
+  module.exports.React = require 'react-atom-fork'
+  module.exports.Reactionary = require 'reactionary-atom-fork'


### PR DESCRIPTION
Fixes #3101 and works around facebook/react#1939.

This is needed for packages to use React until that React bug is fixed. If packages bundle their own copy of React, it will generate `reactid`s that conflict with core editor components. This breaks events.
