### PR TITLE
Show detailed React errors/warnings in devMode

### DIFF
--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -150,7 +150,7 @@ class Atom extends Model
     process.env.NODE_PATH = exportsPath
 
     # Make react.js faster
-    process.env.NODE_ENV ?= 'production'
+    process.env.NODE_ENV ?= 'production' unless devMode
 
     @config = new Config({configDirPath, resourcePath})
     @keymaps = new KeymapManager({configDirPath, resourcePath})


### PR DESCRIPTION
Fixes #3099.

React development mode has a lot of useful warnings and exceptions. These don't
show up in production mode. This change puts React into dev mode when Atom is
run via `atom --dev`.
