### PR TITLE
In devmode do not load incompatible modules from cache

### DIFF
--- a/src/package.coffee
+++ b/src/package.coffee
@@ -371,9 +371,10 @@ class Package
   # to minimize the impact on startup time.
   getIncompatibleNativeModules: ->
     localStorageKey = "installed-packages:#{@name}:#{@metadata.version}"
-    try
-      {incompatibleNativeModules} = JSON.parse(global.localStorage.getItem(localStorageKey)) ? {}
-    return incompatibleNativeModules if incompatibleNativeModules?
+    if not atom.inDevMode()
+      try
+        {incompatibleNativeModules} = JSON.parse(global.localStorage.getItem(localStorageKey)) ? {}
+      return incompatibleNativeModules if incompatibleNativeModules?
 
     incompatibleNativeModules = []
     for nativeModulePath in @getNativeModuleDependencyPaths()


### PR DESCRIPTION
Trying to update a module is quite a pain since you have to actually update the version before you can even see if you broke anything since atom will refuse to load the plugin.

I had to search quite a bit until I found the storage cache (since it's not under ~/.atom). I think it's okay if the load time in dev-mode is a little bit higher if we always check the native modules.
