### PR TITLE
Improve cursor movement and typing latency a bit

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "coffee-script": "1.7.0",
     "coffeestack": "0.7.0",
     "delegato": "^1",
-    "emissary": "^1.2.1",
+    "emissary": "^1.2.2",
     "first-mate": "^2.0.1",
     "fs-plus": "^2.2.6",
     "fstream": "0.1.24",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "atomShellVersion": "0.15.1",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "^1.0.0",
+    "atom-keymap": "^1.0.2",
     "bootstrap": "git+https://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",
     "clear-cut": "0.4.0",
     "coffee-script": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "grammar-selector": "0.27.0",
     "image-view": "0.36.0",
     "incompatible-packages": "0.5.0",
-    "keybinding-resolver": "0.18.0",
+    "keybinding-resolver": "0.19.0",
     "link": "0.25.0",
     "markdown-preview": "0.94.0",
     "metrics": "0.33.0",

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -524,6 +524,12 @@ EditorComponent = React.createClass
     @refs.input.focus()
 
   onTextInput: (event) ->
+    event.stopPropagation()
+
+    # If we prevent the insertion of a space character, then the browser
+    # interprets the spacebar keypress as a page-down command.
+    event.preventDefault() unless event.data is ' '
+
     return unless @isInputEnabled()
 
     {editor} = @props
@@ -539,9 +545,6 @@ EditorComponent = React.createClass
     editor.insertText(event.data)
     inputNode.value = event.data
 
-    # If we prevent the insertion of a space character, then the browser
-    # interprets the spacebar keypress as a page-down command.
-    event.preventDefault() unless event.data is ' '
 
   onInputFocused: ->
     @setState(focused: true)

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -57,8 +57,7 @@ class WindowEventHandler
 
     @subscribeToCommand $(document), 'core:focus-previous', @focusPrevious
 
-    @subscribe $(document), 'keydown', (event) ->
-      atom.keymaps.handleKeyboardEvent(event.originalEvent)
+    document.addEventListener 'keydown', @onKeydown
 
     @subscribe $(document), 'drop', (e) ->
       e.preventDefault()
@@ -94,6 +93,10 @@ class WindowEventHandler
     bindCommandToAction('core:undo', 'undo:')
     bindCommandToAction('core:redo', 'redo:')
     bindCommandToAction('core:select-all', 'selectAll:')
+
+  onKeydown: (event) ->
+    atom.keymaps.handleKeyboardEvent(event)
+    event.stopImmediatePropagation()
 
   openLink: ({target, currentTarget}) ->
     location = target?.getAttribute('href') or currentTarget?.getAttribute('href')


### PR DESCRIPTION
This PR combines a few small optimizations I found. It saves 1-2 ms per keystroke by:
- Avoiding invoking React's synthetic event handler for `keydown` and `textInput` events.
- Allowing `Emitter::emit` to be optimized by v8 by removing `args...` from the common path.
- Using raw DOM APIs instead of jQuery to receive keydown events
- Avoiding some temp objects in `atom-keymap`'s `keystrokeForKeyboardEvent` method.
