### PR TITLE
Add confirmation dialog to checkoutHead

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -3378,3 +3378,24 @@ describe "Editor", ->
       editor.selectPageUp()
       expect(editor.getScrollTop()).toBe 0
       expect(editor.getSelectedBufferRanges()).toEqual [[[0,0], [12,2]]]
+
+  describe ".checkoutHead()", ->
+    [repo] = []
+
+    beforeEach ->
+      repo = jasmine.createSpyObj('repo', ['checkoutHead'])
+      spyOn(atom.project, "getRepo").andReturn(repo)
+
+    it "displays a confirmation dialog by default", ->
+      spyOn(atom, "confirm")
+      editor.checkoutHead()
+
+      args = atom.confirm.mostRecentCall.args[0]
+      expect(Object.keys(args.buttons)).toEqual ["Revert", "Cancel"]
+
+    it "does not display a dialog when confirmation is disabled", ->
+      spyOn(atom, "confirm")
+      atom.config.set("editor.confirmCheckoutHead", false)
+      editor.checkoutHead()
+
+      expect(atom.confirm).not.toHaveBeenCalled()

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -58,6 +58,7 @@ class EditorView extends View
     softWrapAtPreferredLineLength: false
     scrollSensitivity: 40
     useHardwareAcceleration: true
+    confirmCheckoutHead: true
 
   @nextEditorId: 1
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -436,8 +436,14 @@ class Editor extends Model
   saveAs: (filePath) -> @buffer.saveAs(filePath)
 
   checkoutHead: ->
-    if filePath = @getPath()
-      atom.project.getRepo()?.checkoutHead(filePath)
+    if (filePath = @getPath()) and (repo = atom.project.getRepo())
+      atom.confirm
+        message: "Are you sure you want to revert this file to the last Git commit?"
+        detailedMessage: "You are reverting: #{filePath}"
+        buttons:
+          "Revert": ->
+            repo.checkoutHead(filePath)
+          "Cancel": null
 
   # Copies the current file path to the native clipboard.
   copyPathToClipboard: ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -450,7 +450,9 @@ class Editor extends Model
       else
         confirmed = true
 
-      repo.checkoutHead(filePath) if confirmed
+      if confirmed
+        @buffer.reload() if @buffer.isModified()
+        repo.checkoutHead(filePath)
 
   # Copies the current file path to the native clipboard.
   copyPathToClipboard: ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -437,13 +437,20 @@ class Editor extends Model
 
   checkoutHead: ->
     if (filePath = @getPath()) and (repo = atom.project.getRepo())
-      atom.confirm
-        message: "Are you sure you want to revert this file to the last Git commit?"
-        detailedMessage: "You are reverting: #{filePath}"
-        buttons:
-          "Revert": ->
-            repo.checkoutHead(filePath)
-          "Cancel": null
+      confirmed = false
+
+      if atom.config.get("editor.confirmCheckoutHead")
+        atom.confirm
+          message: "Are you sure you want to revert this file to the last Git commit?"
+          detailedMessage: "You are reverting: #{filePath}"
+          buttons:
+            "Revert": ->
+              confirmed = true
+            "Cancel": null
+      else
+        confirmed = true
+
+      repo.checkoutHead(filePath) if confirmed
 
   # Copies the current file path to the native clipboard.
   copyPathToClipboard: ->


### PR DESCRIPTION
There have been a few reports of files mysteriously going back to the last version in the tree. My theory is that it is because of people fat-fingering the Undo command because the default keyboard mapping is too similar. This will at least prevent most accidental data loss.

Fixes atom/atom#3168
