### PR TITLE
Add OS X proxy icon to title bar

### DIFF
--- a/src/pane-view.coffee
+++ b/src/pane-view.coffee
@@ -141,13 +141,18 @@ class PaneView extends View
     @activeItem
 
   onActiveItemChanged: (item) =>
-    @previousActiveItem?.off? 'title-changed', @activeItemTitleChanged
+    if @previousActiveItem?.off?
+      @previousActiveItem.off 'title-changed', @activeItemTitleChanged
+      @previousActiveItem.off 'modified-status-changed',
+                              @activeItemModifiedChanged
     @previousActiveItem = item
 
     return unless item?
 
     hasFocus = @hasFocus()
-    item.on? 'title-changed', @activeItemTitleChanged
+    if item.on?
+      item.on 'title-changed', @activeItemTitleChanged
+      item.on 'modified-status-changed', @activeItemModifiedChanged
     view = @viewForItem(item)
     otherView.hide() for otherView in @itemViews.children().not(view).views()
     @itemViews.append(view) unless view.parent().is(@itemViews)
@@ -182,6 +187,9 @@ class PaneView extends View
 
   activeItemTitleChanged: =>
     @trigger 'pane:active-item-title-changed'
+
+  activeItemModifiedChanged: =>
+    @trigger 'pane:active-item-modified-changed'
 
   viewForItem: (item) ->
     return unless item?

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -210,19 +210,23 @@ class WorkspaceView extends View
   confirmClose: ->
     @panes.confirmClose()
 
-  # Updates the application's title, based on whichever file is open.
+  # Updates the application's title and proxy icon based on whichever file is
+  # open.
   updateTitle: ->
     if projectPath = atom.project.getPath()
       if item = @getModel().getActivePaneItem()
-        @setTitle("#{item.getTitle?() ? 'untitled'} - #{projectPath}")
+        title = "#{item.getTitle?() ? 'untitled'} - #{projectPath}"
+        path = item.getPath?() ? projectPath
+        @setTitle(title, path)
       else
-        @setTitle(projectPath)
+        @setTitle(projectPath, projectPath)
     else
       @setTitle('untitled')
 
-  # Sets the application's title.
-  setTitle: (title) ->
+  # Sets the application's title (and the proxy icon on OS X)
+  setTitle: (title, path) ->
     document.title = title
+    atom.getCurrentWindow().setRepresentedFilename(path ? '')
 
   # Get all editor views.
   #

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -216,17 +216,17 @@ class WorkspaceView extends View
     if projectPath = atom.project.getPath()
       if item = @getModel().getActivePaneItem()
         title = "#{item.getTitle?() ? 'untitled'} - #{projectPath}"
-        path = item.getPath?() ? projectPath
-        @setTitle(title, path)
+        proxyIconPath = item.getPath?() ? projectPath
+        @setTitle(title, proxyIconPath)
       else
         @setTitle(projectPath, projectPath)
     else
       @setTitle('untitled')
 
   # Sets the application's title (and the proxy icon on OS X)
-  setTitle: (title, path) ->
+  setTitle: (title, proxyIconPath) ->
     document.title = title
-    atom.getCurrentWindow().setRepresentedFilename(path ? '')
+    atom.getCurrentWindow().setRepresentedFilename(proxyIconPath ? '')
 
   # Get all editor views.
   #

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -217,7 +217,7 @@ class WorkspaceView extends View
     if projectPath = atom.project.getPath()
       if item = @getModel().getActivePaneItem()
         title = "#{item.getTitle?() ? 'untitled'} - #{projectPath}"
-        proxyIconPath = item.getPath?() ? projectPath
+        proxyIconPath = item.getPath?() ? ''
         @setTitle(title, proxyIconPath)
       else
         @setTitle(projectPath, projectPath)

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -110,6 +110,7 @@ class WorkspaceView extends View
     atom.project.on 'path-changed', => @updateTitle()
     @on 'pane-container:active-pane-item-changed', => @updateTitle()
     @on 'pane:active-item-title-changed', '.active.pane', => @updateTitle()
+    @on 'pane:active-item-modified-changed', '.active.pane', => @updateDocumentEdited()
 
     @command 'application:about', -> ipc.send('command', 'application:about')
     @command 'application:run-all-specs', -> ipc.send('command', 'application:run-all-specs')
@@ -227,6 +228,12 @@ class WorkspaceView extends View
   setTitle: (title, proxyIconPath) ->
     document.title = title
     atom.getCurrentWindow().setRepresentedFilename(proxyIconPath ? '')
+
+  # On OS X, fades the application window's proxy icon when the current file
+  # has been modified.
+  updateDocumentEdited: ->
+    modified = @getModel().getActivePaneItem()?.isModified?() ? false
+    atom.getCurrentWindow().setDocumentEdited modified
 
   # Get all editor views.
   #


### PR DESCRIPTION
![image](http://i.imgur.com/0WCzYA7.gif)

Fixes #1891.

Test Plan:
- Opened Atom window in directory, verified directory icon shows up
- Opened a file and verified icon changed
- Right clicked icon, verified menu appears
- Drag file to terminal and it pastes the file path (yay)
- Opened a new Atom window and opened some files in that to make sure that
  it didn't change the original window

I didn't add any specs for this - advice welcome here. I also haven't tested
on Windows or Linux but it looks like `setRepresentedFilename` is a noop on
those platforms.
