### PR TITLE
Revert unsaved changes when checking out HEAD

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2561,6 +2561,13 @@ describe "Editor", ->
         expect(editor.isFoldedAtBufferRow(1)).toBeFalsy()
         expect(editor.isFoldedAtBufferRow(2)).toBeTruthy()
 
+    describe "checkoutHead", ->
+      it "reverts unsaved changes too", ->
+        prevText = buffer.getText()
+        buffer.setText('changed')
+        editor.checkoutHead()
+        expect(buffer.getText()).toBe prevText
+
     describe "begin/commitTransaction()", ->
       it "restores the selection when the transaction is undone/redone", ->
         buffer.setText('1234')

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -436,6 +436,10 @@ class Editor extends Model
   saveAs: (filePath) -> @buffer.saveAs(filePath)
 
   checkoutHead: ->
+    # repo.checkoutHead won't work if there are unsaved modifications, so
+    # revert those first
+    @buffer.reload() if @buffer.isModified()
+
     if filePath = @getPath()
       atom.project.getRepo()?.checkoutHead(filePath)
 


### PR DESCRIPTION
Fix #2909.

Test Plan:
- Edited a file. Ran `editor:checkout-head-revision` and it reverted.
- Edited a file, saved it, then edited again. Running
  `editor:checkout-head-revision` reverts the lot.
- Ran undo afterwards and the edits come back, so that still works.
