### PR TITLE
Upgrade to atom-shell@0.15.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "url": "http://github.com/atom/atom/raw/master/LICENSE.md"
     }
   ],
-  "atomShellVersion": "0.15.3",
+  "atomShellVersion": "0.15.4",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "url": "http://github.com/atom/atom/raw/master/LICENSE.md"
     }
   ],
-  "atomShellVersion": "0.15.4",
+  "atomShellVersion": "0.15.5",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^1.0.2",

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -27,7 +27,7 @@ class AtomWindow
 
     global.atomApplication.addWindow(this)
 
-    @browserWindow = new BrowserWindow show: false, title: 'Atom', icon: @constructor.iconPath, 'auto-hide-menu-bar': true
+    @browserWindow = new BrowserWindow show: false, title: 'Atom', icon: @constructor.iconPath
     @handleEvents()
 
     loadSettings = _.extend({}, settings)

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -27,7 +27,7 @@ class AtomWindow
 
     global.atomApplication.addWindow(this)
 
-    @browserWindow = new BrowserWindow show: false, title: 'Atom', icon: @constructor.iconPath
+    @browserWindow = new BrowserWindow show: false, title: 'Atom', icon: @constructor.iconPath, 'auto-hide-menu-bar': true
     @handleEvents()
 
     loadSettings = _.extend({}, settings)


### PR DESCRIPTION
In atom-shell I have added a new `auto-hide-menu-bar` option for `BrowserWindow`, which hides the menu bar on Windows and Linux unless <kbd>Alt</kbd> is pressed.

I activated this option in this PR, but I'm not sure whether it should be default. /cc @kevinsawicki @nathansobo 
