### PR TITLE
Handle invisibles at the token level to fix char width measurement

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -23,6 +23,18 @@ describe "Config", ->
       retrievedValue.array[1].b = 2.1
       expect(atom.config.get('value')).toEqual(array: [1, b: 2, 3])
 
+    it "merges defaults into the returned value if both the assigned value and the default value are objects", ->
+      atom.config.setDefaults("foo", a: 1, b: 2)
+      atom.config.set("foo", a: 3)
+      expect(atom.config.get("foo")).toEqual {a: 3, b: 2}
+
+      atom.config.set("foo", 7)
+      expect(atom.config.get("foo")).toBe 7
+
+      atom.config.set("bar.baz", a: 3)
+      atom.config.setDefaults("bar", baz: 7)
+      expect(atom.config.get("bar.baz")).toEqual {a: 3}
+
   describe ".set(keyPath, value)", ->
     it "allows a key path's value to be written", ->
       expect(atom.config.set("foo.bar.baz", 42)).toBe 42

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -2116,8 +2116,9 @@ describe "EditorComponent", ->
       expect(component.refs.lines.getDOMNode().getAttribute('style')).not.toContain 'background-color'
 
     it "does not render invisible characters", ->
-      component.setInvisibles(eol: 'E')
-      component.setShowInvisibles(true)
+      atom.config.set('editor.invisibles', eol: 'E')
+      atom.config.set('editor.showInvisibles', true)
+      nextAnimationFrame()
       expect(component.lineNodeForScreenRow(0).textContent).toBe 'var quicksort = function () {'
 
     it "does not assign an explicit line-height on the editor contents", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -221,10 +221,14 @@ describe "EditorComponent", ->
         atom.config.set("editor.showInvisibles", true)
         expect(component.lineNodeForScreenRow(0).textContent).toBe "#{invisibles.space}a line with tabs#{invisibles.tab}and spaces#{invisibles.space}#{invisibles.eol}"
 
-      it "displays spaces, tabs, and newlines as visible characters", ->
+      it "displays leading/trailing spaces, tabs, and newlines as visible characters", ->
         editor.setText " a line with tabs\tand spaces "
         nextAnimationFrame()
         expect(component.lineNodeForScreenRow(0).textContent).toBe "#{invisibles.space}a line with tabs#{invisibles.tab}and spaces#{invisibles.space}#{invisibles.eol}"
+
+        leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
+        expect(leafNodes[0].classList.contains('invisible-character')).toBe true
+        expect(leafNodes[leafNodes.length - 1].classList.contains('invisible-character')).toBe true
 
       it "displays newlines as their own token outside of the other tokens' scopes", ->
         editor.setText "var"

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -248,10 +248,12 @@ describe "EditorComponent", ->
 
       it "renders an nbsp on empty lines when the line-ending character is an empty string", ->
         atom.config.set("editor.invisibles", eol: '')
+        nextAnimationFrame()
         expect(component.lineNodeForScreenRow(10).textContent).toBe nbsp
 
-      it "renders an nbsp on empty lines when no line-ending character is defined", ->
-        atom.config.set("editor.invisibles", eol: null)
+      it "renders an nbsp on empty lines when the line-ending character is false", ->
+        atom.config.set("editor.invisibles", eol: false)
+        nextAnimationFrame()
         expect(component.lineNodeForScreenRow(10).textContent).toBe nbsp
 
       it "interleaves invisible line-ending characters with indent guides on empty lines", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -209,6 +209,7 @@ describe "EditorComponent", ->
 
         atom.config.set("editor.showInvisibles", true)
         atom.config.set("editor.invisibles", invisibles)
+        nextAnimationFrame()
 
       it "re-renders the lines when the showInvisibles config option changes", ->
         editor.setText " a line with tabs\tand spaces \n"

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -216,9 +216,11 @@ describe "EditorComponent", ->
         expect(component.lineNodeForScreenRow(0).textContent).toBe "#{invisibles.space}a line with tabs#{invisibles.tab}and spaces#{invisibles.space}#{invisibles.eol}"
 
         atom.config.set("editor.showInvisibles", false)
+        nextAnimationFrame()
         expect(component.lineNodeForScreenRow(0).textContent).toBe " a line with tabs and spaces "
 
         atom.config.set("editor.showInvisibles", true)
+        nextAnimationFrame()
         expect(component.lineNodeForScreenRow(0).textContent).toBe "#{invisibles.space}a line with tabs#{invisibles.tab}and spaces#{invisibles.space}#{invisibles.eol}"
 
       it "displays leading/trailing spaces, tabs, and newlines as visible characters", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -211,7 +211,7 @@ describe "EditorComponent", ->
         atom.config.set("editor.invisibles", invisibles)
 
       it "re-renders the lines when the showInvisibles config option changes", ->
-        editor.setText " a line with tabs\tand spaces "
+        editor.setText " a line with tabs\tand spaces \n"
         nextAnimationFrame()
         expect(component.lineNodeForScreenRow(0).textContent).toBe "#{invisibles.space}a line with tabs#{invisibles.tab}and spaces#{invisibles.space}#{invisibles.eol}"
 
@@ -222,7 +222,7 @@ describe "EditorComponent", ->
         expect(component.lineNodeForScreenRow(0).textContent).toBe "#{invisibles.space}a line with tabs#{invisibles.tab}and spaces#{invisibles.space}#{invisibles.eol}"
 
       it "displays leading/trailing spaces, tabs, and newlines as visible characters", ->
-        editor.setText " a line with tabs\tand spaces "
+        editor.setText " a line with tabs\tand spaces \n"
         nextAnimationFrame()
         expect(component.lineNodeForScreenRow(0).textContent).toBe "#{invisibles.space}a line with tabs#{invisibles.tab}and spaces#{invisibles.space}#{invisibles.eol}"
 
@@ -231,7 +231,7 @@ describe "EditorComponent", ->
         expect(leafNodes[leafNodes.length - 1].classList.contains('invisible-character')).toBe true
 
       it "displays newlines as their own token outside of the other tokens' scopes", ->
-        editor.setText "var"
+        editor.setText "var\n"
         nextAnimationFrame()
         expect(component.lineNodeForScreenRow(0).innerHTML).toBe "<span class=\"source js\"><span class=\"storage modifier js\">var</span></span><span class=\"invisible-character\">#{invisibles.eol}</span>"
 
@@ -272,7 +272,7 @@ describe "EditorComponent", ->
 
       describe "when soft wrapping is enabled", ->
         beforeEach ->
-          editor.setText "a line that wraps "
+          editor.setText "a line that wraps \n"
           editor.setSoftWrap(true)
           nextAnimationFrame()
           componentNode.style.width = 16 * charWidth + editor.getVerticalScrollbarWidth() + 'px'

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -499,6 +499,15 @@ describe "Editor", ->
           cursor = editor.getCursor()
           expect(cursor.getBufferPosition()).toEqual [1,0]
 
+        describe "when invisible characters are enabled", ->
+          it "moves to the first character of the current line without being confused by the invisible characters", ->
+            atom.config.set('editor.showInvisibles', true)
+            editor.setCursorScreenPosition [1,7]
+            editor.moveCursorToFirstCharacterOfLine()
+            expect(editor.getCursorBufferPosition()).toEqual [1,2]
+            editor.moveCursorToFirstCharacterOfLine()
+            expect(editor.getCursorBufferPosition()).toEqual [1,0]
+
     describe ".moveCursorToBeginningOfWord()", ->
       it "moves the cursor to the beginning of the word", ->
         editor.setCursorBufferPosition [0, 8]

--- a/spec/editor-view-spec.coffee
+++ b/spec/editor-view-spec.coffee
@@ -2998,8 +2998,8 @@ describe "EditorView", ->
         expect(editorView.lineElementForScreenRow(rowNumber).text()).toBe buffer.lineForRow(rowNumber)
 
     it "correctly calculates the position left for non-monospaced invisibles", ->
-      editorView.setShowInvisibles(true)
-      editorView.setInvisibles tab: '♘'
+      atom.config.set('editor.showInvisibles', true)
+      atom.config.set('editor.invisibles', tab: '♘')
       editor.setText('\tx')
 
       editorView.setFontFamily('serif')

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -604,6 +604,26 @@ describe "TokenizedBuffer", ->
       # Also needs to work for copies
       expect(tokenizedBuffer.lineForScreenRow(0).copy().text).toBe "SST Sa line with tabsTand T spacesSTS"
 
+    it "assigns endOfLineInvisibles to tokenized lines", ->
+      buffer = new TextBuffer(text: "a line that ends in a carriage-return-line-feed \r\na line that ends in just a line-feed\na line with no ending")
+      tokenizedBuffer = new TokenizedBuffer({buffer})
+
+      atom.config.set('editor.showInvisibles', true)
+      atom.config.set('editor.invisibles', cr: 'R', eol: 'N')
+      fullyTokenize(tokenizedBuffer)
+
+      expect(tokenizedBuffer.lineForScreenRow(0).endOfLineInvisibles).toEqual ['R', 'N']
+      expect(tokenizedBuffer.lineForScreenRow(1).endOfLineInvisibles).toEqual ['N']
+
+      # Lines ending in soft wraps get no invisibles
+      [left, right] = tokenizedBuffer.lineForScreenRow(0).softWrapAt(20)
+      expect(left.endOfLineInvisibles).toBe null
+      expect(right.endOfLineInvisibles).toEqual ['R', 'N']
+
+      atom.config.set('editor.invisibles', cr: 'R', eol: false)
+      expect(tokenizedBuffer.lineForScreenRow(0).endOfLineInvisibles).toEqual ['R']
+      expect(tokenizedBuffer.lineForScreenRow(1).endOfLineInvisibles).toEqual []
+
   describe "leading and trailing whitespace", ->
     beforeEach ->
       buffer = atom.project.bufferForPathSync('sample.js')

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -1,4 +1,5 @@
 TokenizedBuffer = require '../src/tokenized-buffer'
+TextBuffer = require 'text-buffer'
 _ = require 'underscore-plus'
 
 describe "TokenizedBuffer", ->
@@ -11,6 +12,9 @@ describe "TokenizedBuffer", ->
 
     waitsForPromise ->
       atom.packages.activatePackage('language-javascript')
+
+  afterEach ->
+    tokenizedBuffer?.destroy()
 
   startTokenizing = (tokenizedBuffer) ->
     tokenizedBuffer.setVisible(true)
@@ -583,6 +587,20 @@ describe "TokenizedBuffer", ->
       expect(tokenizedBuffer.tokenForPosition([0,0]).value).toBe ' '
       atom.config.set('editor.tabLength', 0)
       expect(tokenizedBuffer.tokenForPosition([0,0]).value).toBe '  '
+
+  describe "when the editor.showInvisibles and editor.invisibles config values change", ->
+    beforeEach ->
+
+    it "updates the tokens with the appropriate invisible characters", ->
+      buffer = new TextBuffer(text: "  \t a line with tabs\tand \tspaces \t ")
+      tokenizedBuffer = new TokenizedBuffer({buffer})
+      fullyTokenize(tokenizedBuffer)
+
+      atom.config.set('editor.invisibles', space: 'S', tab: 'T')
+      atom.config.set('editor.showInvisibles', true)
+      fullyTokenize(tokenizedBuffer)
+
+      expect(tokenizedBuffer.lineForScreenRow(0).text).toBe "SST Sa line with tabsTand T spacesSTS"
 
   describe "leading and trailing whitespace", ->
     beforeEach ->

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -608,36 +608,54 @@ describe "TokenizedBuffer", ->
       tokenizedBuffer = new TokenizedBuffer({buffer})
       fullyTokenize(tokenizedBuffer)
 
-    it "sets ::hasLeadingWhitespace to true on tokens that have leading whitespace", ->
+    it "sets ::hasLeadingWhitespace to true and assigns ::firstNonWhitespaceIndex on tokens that have leading whitespace", ->
       expect(tokenizedBuffer.lineForScreenRow(0).tokens[0].hasLeadingWhitespace).toBe false
+      expect(tokenizedBuffer.lineForScreenRow(0).tokens[0].firstNonWhitespaceIndex).toBe null
+
       expect(tokenizedBuffer.lineForScreenRow(1).tokens[0].hasLeadingWhitespace).toBe true
+      expect(tokenizedBuffer.lineForScreenRow(1).tokens[0].firstNonWhitespaceIndex).toBe 2
+
       expect(tokenizedBuffer.lineForScreenRow(1).tokens[1].hasLeadingWhitespace).toBe false
+      expect(tokenizedBuffer.lineForScreenRow(1).tokens[1].firstNonWhitespaceIndex).toBe null
+
       expect(tokenizedBuffer.lineForScreenRow(2).tokens[0].hasLeadingWhitespace).toBe true
+      expect(tokenizedBuffer.lineForScreenRow(2).tokens[0].firstNonWhitespaceIndex).toBe 2
       expect(tokenizedBuffer.lineForScreenRow(2).tokens[1].hasLeadingWhitespace).toBe true
+      expect(tokenizedBuffer.lineForScreenRow(2).tokens[1].firstNonWhitespaceIndex).toBe 2
       expect(tokenizedBuffer.lineForScreenRow(2).tokens[2].hasLeadingWhitespace).toBe false
+      expect(tokenizedBuffer.lineForScreenRow(2).tokens[2].firstNonWhitespaceIndex).toBe null
 
       # The 4th token *has* leading whitespace, but isn't entirely whitespace
       buffer.insert([5, 0], ' ')
       expect(tokenizedBuffer.lineForScreenRow(5).tokens[3].hasLeadingWhitespace).toBe true
+      expect(tokenizedBuffer.lineForScreenRow(5).tokens[3].firstNonWhitespaceIndex).toBe 1
       expect(tokenizedBuffer.lineForScreenRow(5).tokens[4].hasLeadingWhitespace).toBe false
+      expect(tokenizedBuffer.lineForScreenRow(5).tokens[4].firstNonWhitespaceIndex).toBe null
 
       # Lines that are *only* whitespace are not considered to have leading whitespace
       buffer.insert([10, 0], '  ')
       expect(tokenizedBuffer.lineForScreenRow(10).tokens[0].hasLeadingWhitespace).toBe false
+      expect(tokenizedBuffer.lineForScreenRow(10).tokens[0].firstNonWhitespaceIndex).toBe null
 
-    it "sets ::hasTrailingWhitespace to true on tokens that have trailing whitespace", ->
+    it "sets ::hasTrailingWhitespace to true and assigns ::firstTrailingWhitespaceIndex on tokens that have trailing whitespace", ->
       buffer.insert([0, Infinity], '  ')
       expect(tokenizedBuffer.lineForScreenRow(0).tokens[11].hasTrailingWhitespace).toBe false
+      expect(tokenizedBuffer.lineForScreenRow(0).tokens[11].firstTrailingWhitespaceIndex).toBe null
       expect(tokenizedBuffer.lineForScreenRow(0).tokens[12].hasTrailingWhitespace).toBe true
+      expect(tokenizedBuffer.lineForScreenRow(0).tokens[12].firstTrailingWhitespaceIndex).toBe 0
 
       # The last token *has* trailing whitespace, but isn't entirely whitespace
       buffer.setTextInRange([[2, 39], [2, 40]], '  ')
       expect(tokenizedBuffer.lineForScreenRow(2).tokens[14].hasTrailingWhitespace).toBe false
+      expect(tokenizedBuffer.lineForScreenRow(2).tokens[14].firstTrailingWhitespaceIndex).toBe null
       expect(tokenizedBuffer.lineForScreenRow(2).tokens[15].hasTrailingWhitespace).toBe true
+      console.log tokenizedBuffer.lineForScreenRow(2).tokens[15]
+      expect(tokenizedBuffer.lineForScreenRow(2).tokens[15].firstTrailingWhitespaceIndex).toBe 6
 
       # Lines that are *only* whitespace are considered to have trailing whitespace
       buffer.insert([10, 0], '  ')
       expect(tokenizedBuffer.lineForScreenRow(10).tokens[0].hasTrailingWhitespace).toBe true
+      expect(tokenizedBuffer.lineForScreenRow(10).tokens[0].firstTrailingWhitespaceIndex).toBe 0
 
     it "only marks trailing whitespace on the last segment of a soft-wrapped line", ->
       buffer.insert([0, Infinity], '  ')
@@ -645,8 +663,10 @@ describe "TokenizedBuffer", ->
       [segment1, segment2] = tokenizedLine.softWrapAt(16)
       expect(segment1.tokens[5].value).toBe ' '
       expect(segment1.tokens[5].hasTrailingWhitespace).toBe false
+      expect(segment1.tokens[5].firstTrailingWhitespaceIndex).toBe null
       expect(segment2.tokens[6].value).toBe '  '
       expect(segment2.tokens[6].hasTrailingWhitespace).toBe true
+      expect(segment2.tokens[6].firstTrailingWhitespaceIndex).toBe 0
 
   describe "indent level", ->
     beforeEach ->

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -588,7 +588,7 @@ describe "TokenizedBuffer", ->
       atom.config.set('editor.tabLength', 0)
       expect(tokenizedBuffer.tokenForPosition([0,0]).value).toBe '  '
 
-  describe "when the editor.showInvisibles and editor.invisibles config values change", ->
+  describe "when the invisibles value changes", ->
     beforeEach ->
 
     it "updates the tokens with the appropriate invisible characters", ->
@@ -596,8 +596,7 @@ describe "TokenizedBuffer", ->
       tokenizedBuffer = new TokenizedBuffer({buffer})
       fullyTokenize(tokenizedBuffer)
 
-      atom.config.set('editor.invisibles', space: 'S', tab: 'T')
-      atom.config.set('editor.showInvisibles', true)
+      tokenizedBuffer.setInvisibles(space: 'S', tab: 'T')
       fullyTokenize(tokenizedBuffer)
 
       expect(tokenizedBuffer.lineForScreenRow(0).text).toBe "SST Sa line with tabsTand T spacesSTS"
@@ -609,7 +608,7 @@ describe "TokenizedBuffer", ->
       tokenizedBuffer = new TokenizedBuffer({buffer})
 
       atom.config.set('editor.showInvisibles', true)
-      atom.config.set('editor.invisibles', cr: 'R', eol: 'N')
+      tokenizedBuffer.setInvisibles(cr: 'R', eol: 'N')
       fullyTokenize(tokenizedBuffer)
 
       expect(tokenizedBuffer.lineForScreenRow(0).endOfLineInvisibles).toEqual ['R', 'N']
@@ -620,7 +619,7 @@ describe "TokenizedBuffer", ->
       expect(left.endOfLineInvisibles).toBe null
       expect(right.endOfLineInvisibles).toEqual ['R', 'N']
 
-      atom.config.set('editor.invisibles', cr: 'R', eol: false)
+      tokenizedBuffer.setInvisibles(cr: 'R', eol: false)
       expect(tokenizedBuffer.lineForScreenRow(0).endOfLineInvisibles).toEqual ['R']
       expect(tokenizedBuffer.lineForScreenRow(1).endOfLineInvisibles).toEqual []
 
@@ -692,8 +691,8 @@ describe "TokenizedBuffer", ->
 
     it "sets leading and trailing whitespace correctly on a line with invisible characters that is copied", ->
       buffer.setText("  \t a line with tabs\tand \tspaces \t ")
-      atom.config.set('editor.invisibles', space: 'S', tab: 'T')
-      atom.config.set('editor.showInvisibles', true)
+
+      tokenizedBuffer.setInvisibles(space: 'S', tab: 'T')
       fullyTokenize(tokenizedBuffer)
 
       line = tokenizedBuffer.lineForScreenRow(0).copy()

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -601,6 +601,8 @@ describe "TokenizedBuffer", ->
       fullyTokenize(tokenizedBuffer)
 
       expect(tokenizedBuffer.lineForScreenRow(0).text).toBe "SST Sa line with tabsTand T spacesSTS"
+      # Also needs to work for copies
+      expect(tokenizedBuffer.lineForScreenRow(0).copy().text).toBe "SST Sa line with tabsTand T spacesSTS"
 
   describe "leading and trailing whitespace", ->
     beforeEach ->
@@ -667,6 +669,16 @@ describe "TokenizedBuffer", ->
       expect(segment2.tokens[6].value).toBe '  '
       expect(segment2.tokens[6].hasTrailingWhitespace).toBe true
       expect(segment2.tokens[6].firstTrailingWhitespaceIndex).toBe 0
+
+    it "sets leading and trailing whitespace correctly on a line with invisible characters that is copied", ->
+      buffer.setText("  \t a line with tabs\tand \tspaces \t ")
+      atom.config.set('editor.invisibles', space: 'S', tab: 'T')
+      atom.config.set('editor.showInvisibles', true)
+      fullyTokenize(tokenizedBuffer)
+
+      line = tokenizedBuffer.lineForScreenRow(0).copy()
+      expect(line.tokens[0].hasLeadingWhitespace).toBe true
+      expect(line.tokens[line.tokens.length - 1].hasTrailingWhitespace).toBe true
 
   describe "indent level", ->
     beforeEach ->

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -195,13 +195,12 @@ describe "WorkspaceView", ->
       atom.workspaceView.height(200)
       atom.workspaceView.attachToDom()
       rightEditorView = atom.workspaceView.getActiveView()
-      rightEditorView.getEditor().setText("\t  ")
+      rightEditorView.getEditor().setText("\t  \n")
       leftEditorView = rightEditorView.splitLeft()
       expect(rightEditorView.find(".line:first").text()).toBe "    "
       expect(leftEditorView.find(".line:first").text()).toBe "    "
 
-      {invisibles} = rightEditorView.component.state
-      {space, tab, eol} = invisibles
+      {space, tab, eol} = atom.config.get('editor.invisibles')
       withInvisiblesShowing = "#{tab} #{space}#{space}#{eol}"
 
       atom.workspaceView.trigger "window:toggle-invisibles"

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -103,8 +103,16 @@ class Config
   # Returns the value from Atom's default settings, the user's configuration
   # file, or `null` if the key doesn't exist in either.
   get: (keyPath) ->
-    value = _.valueForKeyPath(@settings, keyPath) ? _.valueForKeyPath(@defaultSettings, keyPath)
-    _.deepClone(value)
+    value = _.valueForKeyPath(@settings, keyPath)
+    defaultValue = _.valueForKeyPath(@defaultSettings, keyPath)
+
+    if value?
+      value = _.deepClone(value)
+      _.defaults(value, defaultValue) if typeof defaultValue is 'object'
+    else
+      value = _.deepClone(defaultValue)
+
+    value
 
   # Public: Retrieves the setting for the given key as an integer.
   #

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -108,7 +108,10 @@ class Config
 
     if value?
       value = _.deepClone(value)
-      _.defaults(value, defaultValue) if typeof defaultValue is 'object'
+      valueIsObject = _.isObject(value) and not _.isArray(value)
+      defaultValueIsObject = _.isObject(defaultValue) and not _.isArray(defaultValue)
+      if valueIsObject and defaultValueIsObject
+        _.defaults(value, defaultValue)
     else
       value = _.deepClone(defaultValue)
 

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -273,9 +273,10 @@ class Cursor extends Model
   # line.
   moveToFirstCharacterOfLine: ->
     {row, column} = @getScreenPosition()
-    screenline = @editor.lineForScreenRow(row)
 
-    goalColumn = screenline.text.search(/\S/)
+    bufferRange = @editor.bufferRangeForScreenRange([[row, 0], [row, Infinity]])
+    screenLineText = @editor.getTextInBufferRange(bufferRange)
+    goalColumn = screenLineText.search(/\S/)
     goalColumn = 0 if goalColumn == column or goalColumn == -1
     @setScreenPosition([row, goalColumn])
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -38,10 +38,10 @@ class DisplayBuffer extends Model
   verticalScrollbarWidth: 15
   scopedCharacterWidthsChangeCount: 0
 
-  constructor: ({tabLength, @editorWidthInChars, @tokenizedBuffer, buffer}={}) ->
+  constructor: ({tabLength, @editorWidthInChars, @tokenizedBuffer, buffer, @invisibles}={}) ->
     super
     @softWrap ?= atom.config.get('editor.softWrap') ? false
-    @tokenizedBuffer ?= new TokenizedBuffer({tabLength, buffer})
+    @tokenizedBuffer ?= new TokenizedBuffer({tabLength, buffer, @invisibles})
     @buffer = @tokenizedBuffer.buffer
     @charWidthsByScope = {}
     @markers = {}
@@ -81,7 +81,7 @@ class DisplayBuffer extends Model
     params
 
   copy: ->
-    newDisplayBuffer = new DisplayBuffer({@buffer, tabLength: @getTabLength()})
+    newDisplayBuffer = new DisplayBuffer({@buffer, tabLength: @getTabLength(), @invisibles})
     newDisplayBuffer.setScrollTop(@getScrollTop())
     newDisplayBuffer.setScrollLeft(@getScrollLeft())
 
@@ -339,6 +339,9 @@ class DisplayBuffer extends Model
   # tabLength - A {Number} that defines the new tab length.
   setTabLength: (tabLength) ->
     @tokenizedBuffer.setTabLength(tabLength)
+
+  setInvisibles: (@invisibles) ->
+    @tokenizedBuffer.setInvisibles(@invisibles)
 
   # Deprecated: Use the softWrap property directly
   setSoftWrap: (@softWrap) -> @softWrap

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -48,10 +48,9 @@ EditorComponent = React.createClass
   domPollingPaused: false
 
   render: ->
-    {focused, showIndentGuide, showInvisibles, showLineNumbers, visible} = @state
+    {focused, showIndentGuide, showLineNumbers, visible} = @state
     {editor, mini, cursorBlinkPeriod, cursorBlinkResumeDelay} = @props
     maxLineNumberDigits = editor.getLineCount().toString().length
-    invisibles = if showInvisibles and not mini then @state.invisibles else {}
     hasSelection = editor.getSelection()? and !editor.getSelection().isEmpty()
     style = {}
 
@@ -109,7 +108,7 @@ EditorComponent = React.createClass
           ref: 'lines',
           editor, lineHeightInPixels, defaultCharWidth, lineDecorations, highlightDecorations,
           showIndentGuide, renderedRowRange, @pendingChanges, scrollTop, scrollLeft,
-          @scrollingVertically, scrollHeight, scrollWidth, mouseWheelScreenRow, invisibles,
+          @scrollingVertically, scrollHeight, scrollWidth, mouseWheelScreenRow,
           @visible, scrollViewHeight, @scopedCharacterWidthsChangeCount, lineWidth, @useHardwareAcceleration,
           placeholderText, @performedInitialMeasurement, @backgroundColor, cursorPixelRects,
           cursorBlinkPeriod, cursorBlinkResumeDelay, mini
@@ -522,8 +521,6 @@ EditorComponent = React.createClass
 
   observeConfig: ->
     @subscribe atom.config.observe 'editor.showIndentGuide', @setShowIndentGuide
-    @subscribe atom.config.observe 'editor.invisibles', @setInvisibles
-    @subscribe atom.config.observe 'editor.showInvisibles', @setShowInvisibles
     @subscribe atom.config.observe 'editor.showLineNumbers', @setShowLineNumbers
     @subscribe atom.config.observe 'editor.scrollSensitivity', @setScrollSensitivity
     @subscribe atom.config.observe 'editor.useHardwareAcceleration', @setUseHardwareAcceleration
@@ -944,24 +941,13 @@ EditorComponent = React.createClass
   setShowIndentGuide: (showIndentGuide) ->
     @setState({showIndentGuide})
 
-  # Public: Defines which characters are invisible.
-  #
-  # invisibles - An {Object} defining the invisible characters:
-  #   :eol   - The end of line invisible {String} (default: `\u00ac`).
-  #   :space - The space invisible {String} (default: `\u00b7`).
-  #   :tab   - The tab invisible {String} (default: `\u00bb`).
-  #   :cr    - The carriage return invisible {String} (default: `\u00a4`).
+  # Deprecated
   setInvisibles: (invisibles={}) ->
-    defaults invisibles,
-      eol: '\u00ac'
-      space: '\u00b7'
-      tab: '\u00bb'
-      cr: '\u00a4'
+    atom.config.set('editor.invisibles', invisibles)
 
-    @setState({invisibles})
-
+  # Deprecated
   setShowInvisibles: (showInvisibles) ->
-    @setState({showInvisibles})
+    atom.config.set('editor.showInvisibles', showInvisibles)
 
   setShowLineNumbers: (showLineNumbers) ->
     @setState({showLineNumbers})

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -191,6 +191,9 @@ EditorComponent = React.createClass
     @domPollingIntervalId = null
     @props.editor.destroy()
 
+  componentWillReceiveProps: (newProps) ->
+    @props.editor.setMini(newProps.mini)
+
   componentWillUpdate: ->
     wasVisible = @visible
     @visible = @isVisible()

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -3,6 +3,7 @@ React = require 'react-atom-fork'
 {debounce, defaults, isEqualForProperties} = require 'underscore-plus'
 scrollbarStyle = require 'scrollbar-style'
 {Range, Point} = require 'text-buffer'
+grim = require 'grim'
 
 GutterComponent = require './gutter-component'
 InputComponent = require './input-component'
@@ -943,6 +944,7 @@ EditorComponent = React.createClass
 
   # Deprecated
   setInvisibles: (invisibles={}) ->
+    grim.deprecate "Use config.set('editor.invisibles', invisibles) instead"
     atom.config.set('editor.invisibles', invisibles)
 
   # Deprecated

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -59,6 +59,11 @@ class EditorView extends View
     scrollSensitivity: 40
     useHardwareAcceleration: true
     confirmCheckoutHead: true
+    invisibles:
+      eol: '\u00ac'
+      space: '\u00b7'
+      tab: '\u00bb'
+      cr: '\u00a4'
 
   @nextEditorId: 1
 

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -60,7 +60,7 @@ LinesComponent = React.createClass
   shouldComponentUpdate: (newProps) ->
     return true unless isEqualForProperties(newProps, @props,
       'renderedRowRange', 'lineDecorations', 'highlightDecorations', 'lineHeightInPixels', 'defaultCharWidth',
-      'scrollTop', 'scrollLeft', 'showIndentGuide', 'scrollingVertically', 'invisibles', 'visible',
+      'scrollTop', 'scrollLeft', 'showIndentGuide', 'scrollingVertically', 'visible',
       'scrollViewHeight', 'mouseWheelScreenRow', 'scopedCharacterWidthsChangeCount', 'lineWidth', 'useHardwareAcceleration',
       'placeholderText', 'performedInitialMeasurement', 'backgroundColor', 'cursorPixelRects'
     )
@@ -82,7 +82,7 @@ LinesComponent = React.createClass
     return unless performedInitialMeasurement
 
     @clearScreenRowCaches() unless prevProps.lineHeightInPixels is @props.lineHeightInPixels
-    @removeLineNodes() unless isEqualForProperties(prevProps, @props, 'showIndentGuide', 'invisibles')
+    @removeLineNodes() unless isEqualForProperties(prevProps, @props, 'showIndentGuide')
     @updateLines(@props.lineWidth isnt prevProps.lineWidth)
     @measureCharactersInNewLines() if visible and not scrollingVertically
 
@@ -170,34 +170,30 @@ LinesComponent = React.createClass
     lineHTML
 
   buildEmptyLineInnerHTML: (line) ->
-    {showIndentGuide, invisibles} = @props
-    {cr, eol} = invisibles
-    {indentLevel, tabLength} = line
+    {showIndentGuide} = @props
+    {indentLevel, tabLength, endOfLineInvisibles} = line
 
     if showIndentGuide and indentLevel > 0
-      invisiblesToRender = []
-      invisiblesToRender.push(cr) if cr? and line.lineEnding is '\r\n'
-      invisiblesToRender.push(eol) if eol?
-
+      invisibleIndex = 0
       lineHTML = ''
       for i in [0...indentLevel]
         lineHTML += "<span class='indent-guide'>"
         for j in [0...tabLength]
-          if invisible = invisiblesToRender.shift()
+          if invisible = endOfLineInvisibles?[invisibleIndex++]
             lineHTML += "<span class='invisible-character'>#{invisible}</span>"
           else
             lineHTML += ' '
         lineHTML += "</span>"
 
-      while invisiblesToRender.length
-        lineHTML += "<span class='invisible-character'>#{invisiblesToRender.shift()}</span>"
+      while invisibleIndex < endOfLineInvisibles?.length
+        lineHTML += "<span class='invisible-character'>#{line.endOfLineInvisibles[invisibleIndex++]}</span>"
 
       lineHTML
     else
-      @buildEndOfLineHTML(line, @props.invisibles) or '&nbsp;'
+      @buildEndOfLineHTML(line) or '&nbsp;'
 
   buildLineInnerHTML: (line) ->
-    {invisibles, mini, showIndentGuide, invisibles} = @props
+    {mini, showIndentGuide, invisibles} = @props
     {tokens, text} = line
     innerHTML = ""
 
@@ -210,20 +206,16 @@ LinesComponent = React.createClass
       innerHTML += token.getValueAsHtml({invisibles, hasIndentGuide})
 
     innerHTML += @popScope(scopeStack) while scopeStack.length > 0
-    innerHTML += @buildEndOfLineHTML(line, invisibles)
+    innerHTML += @buildEndOfLineHTML(line)
     innerHTML
 
-  buildEndOfLineHTML: (line, invisibles) ->
-    return '' if @props.mini or line.isSoftWrapped()
+  buildEndOfLineHTML: (line) ->
+    {endOfLineInvisibles} = line
 
     html = ''
-    # Note the lack of '?' in the character checks. A user can set the chars
-    # to an empty string which we will interpret as not-set
-    if invisibles.cr and line.lineEnding is '\r\n'
-      html += "<span class='invisible-character'>#{invisibles.cr}</span>"
-    if invisibles.eol
-      html += "<span class='invisible-character'>#{invisibles.eol}</span>"
-
+    if endOfLineInvisibles?
+      for invisible in endOfLineInvisibles
+        html += "<span class='invisible-character'>#{invisible}</span>"
     html
 
   updateScopeStack: (scopeStack, desiredScopes) ->

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -193,7 +193,7 @@ LinesComponent = React.createClass
       @buildEndOfLineHTML(line) or '&nbsp;'
 
   buildLineInnerHTML: (line) ->
-    {mini, showIndentGuide, invisibles} = @props
+    {mini, showIndentGuide} = @props
     {tokens, text} = line
     innerHTML = ""
 
@@ -203,7 +203,7 @@ LinesComponent = React.createClass
     for token in tokens
       innerHTML += @updateScopeStack(scopeStack, token.scopes)
       hasIndentGuide = not mini and showIndentGuide and (token.hasLeadingWhitespace or (token.hasTrailingWhitespace and lineIsWhitespaceOnly))
-      innerHTML += token.getValueAsHtml({invisibles, hasIndentGuide})
+      innerHTML += token.getValueAsHtml({hasIndentGuide})
 
     innerHTML += @popScope(scopeStack) while scopeStack.length > 0
     innerHTML += @buildEndOfLineHTML(line)

--- a/src/react-editor-view.coffee
+++ b/src/react-editor-view.coffee
@@ -30,6 +30,7 @@ class ReactEditorView extends View
         softWrap: false
         tabLength: 2
         softTabs: true
+        mini: mini
 
     props = defaults({@editor, parentView: this}, props)
     @component = React.renderComponent(EditorComponent(props), @element)

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -20,6 +20,7 @@ class Token
   hasTrailingWhitespace: false
   firstNonWhitespaceIndex: null
   firstTrailingWhitespaceIndex: null
+  hasInvisibleCharacters: false
 
   constructor: ({@value, @scopes, @isAtomic, @bufferDelta, @isHardTab}) ->
     @screenDelta = @value.length
@@ -134,12 +135,11 @@ class Token
       scopeClasses = scope.split('.')
       _.isSubset(targetClasses, scopeClasses)
 
-  getValueAsHtml: ({invisibles, hasIndentGuide})->
-    invisibles ?= {}
+  getValueAsHtml: ({hasIndentGuide})->
     if @isHardTab
       classes = 'hard-tab'
       classes += ' indent-guide' if hasIndentGuide
-      classes += ' invisible-character' if invisibles.tab
+      classes += ' invisible-character' if @hasInvisibleCharacters
       html = "<span class='#{classes}'>#{@escapeString(@value)}</span>"
     else
       startIndex = 0
@@ -153,7 +153,7 @@ class Token
 
         classes = 'leading-whitespace'
         classes += ' indent-guide' if hasIndentGuide
-        classes += ' invisible-character' if invisibles.space
+        classes += ' invisible-character' if @hasInvisibleCharacters
 
         leadingHtml = "<span class='#{classes}'>#{leadingWhitespace}</span>"
         startIndex = @firstNonWhitespaceIndex
@@ -164,7 +164,7 @@ class Token
 
         classes = 'trailing-whitespace'
         classes += ' indent-guide' if hasIndentGuide and not @hasLeadingWhitespace and tokenIsOnlyWhitespace
-        classes += ' invisible-character' if invisibles.space
+        classes += ' invisible-character' if @hasInvisibleCharacters
 
         trailingHtml = "<span class='#{classes}'>#{trailingWhitespace}</span>"
 

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -2,11 +2,7 @@ _ = require 'underscore-plus'
 textUtils = require './text-utils'
 
 WhitespaceRegexesByTabLength = {}
-LeadingSpaceRegex = /^[ ]+/
-TrailingSpaceRegex = /[ ]+$/
 EscapeRegex = /[&"'<>]/g
-CharacterRegex = /./g
-StartCharacterRegex = /^./
 StartDotRegex = /^\.?/
 WhitespaceRegex = /\S/
 
@@ -22,6 +18,8 @@ class Token
   isHardTab: null
   hasLeadingWhitespace: false
   hasTrailingWhitespace: false
+  firstNonWhitespaceIndex: null
+  firstTrailingWhitespaceIndex: null
 
   constructor: ({@value, @scopes, @isAtomic, @bufferDelta, @isHardTab}) ->
     @screenDelta = @value.length
@@ -150,24 +148,27 @@ class Token
       leadingHtml = ''
       trailingHtml = ''
 
-      if @hasLeadingWhitespace and match = LeadingSpaceRegex.exec(@value)
+      if @hasLeadingWhitespace
+        leadingWhitespace = @value.substring(0, @firstNonWhitespaceIndex)
+
         classes = 'leading-whitespace'
         classes += ' indent-guide' if hasIndentGuide
         classes += ' invisible-character' if invisibles.space
 
-        leadingHtml = "<span class='#{classes}'>#{match[0]}</span>"
+        leadingHtml = "<span class='#{classes}'>#{leadingWhitespace}</span>"
+        startIndex = @firstNonWhitespaceIndex
 
-        startIndex = match[0].length
+      if @hasTrailingWhitespace
+        tokenIsOnlyWhitespace = @firstTrailingWhitespaceIndex is 0
+        trailingWhitespace = @value.substring(@firstTrailingWhitespaceIndex)
 
-      if @hasTrailingWhitespace and match = TrailingSpaceRegex.exec(@value)
-        tokenIsOnlyWhitespace = match[0].length is @value.length
         classes = 'trailing-whitespace'
         classes += ' indent-guide' if hasIndentGuide and not @hasLeadingWhitespace and tokenIsOnlyWhitespace
         classes += ' invisible-character' if invisibles.space
 
-        trailingHtml = "<span class='#{classes}'>#{match[0]}</span>"
+        trailingHtml = "<span class='#{classes}'>#{trailingWhitespace}</span>"
 
-        endIndex = match.index
+        endIndex = @firstTrailingWhitespaceIndex
 
       html = leadingHtml
       if @value.length > MaxTokenLength

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -142,8 +142,7 @@ class Token
       classes = 'hard-tab'
       classes += ' indent-guide' if hasIndentGuide
       classes += ' invisible-character' if invisibles.tab
-      value = if invisibles.tab then @value.replace(StartCharacterRegex, invisibles.tab) else @value
-      html = "<span class='#{classes}'>#{@escapeString(value)}</span>"
+      html = "<span class='#{classes}'>#{@escapeString(@value)}</span>"
     else
       startIndex = 0
       endIndex = @value.length
@@ -156,7 +155,6 @@ class Token
         classes += ' indent-guide' if hasIndentGuide
         classes += ' invisible-character' if invisibles.space
 
-        match[0] = match[0].replace(CharacterRegex, invisibles.space) if invisibles.space
         leadingHtml = "<span class='#{classes}'>#{match[0]}</span>"
 
         startIndex = match[0].length
@@ -167,7 +165,6 @@ class Token
         classes += ' indent-guide' if hasIndentGuide and not @hasLeadingWhitespace and tokenIsOnlyWhitespace
         classes += ' invisible-character' if invisibles.space
 
-        match[0] = match[0].replace(CharacterRegex, invisibles.space) if invisibles.space
         trailingHtml = "<span class='#{classes}'>#{match[0]}</span>"
 
         endIndex = match.index

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -225,8 +225,9 @@ class TokenizedBuffer extends Model
     tokens = [new Token(value: line, scopes: [@grammar.scopeName])]
     tabLength = @getTabLength()
     indentLevel = @indentLevelForRow(row)
+    lineEnding = @buffer.lineEndingForRow(row)
     invisibles = @invisibles if @showInvisibles
-    new TokenizedLine({tokens, tabLength, indentLevel, invisibles})
+    new TokenizedLine({tokens, tabLength, indentLevel, invisibles, lineEnding})
 
   buildTokenizedTokenizedLineForRow: (row, ruleStack) ->
     line = @buffer.lineForRow(row)

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -104,14 +104,7 @@ class TokenizedBuffer extends Model
 
   setShowInvisibles: (@showInvisibles) ->
 
-  setInvisibles: (invisibles={}) ->
-    _.defaults invisibles,
-      eol: '\u00ac'
-      space: '\u00b7'
-      tab: '\u00bb'
-      cr: '\u00a4'
-
-    @invisibles = invisibles
+  setInvisibles: (@invisibles={}) ->
 
   tokenizeInBackground: ->
     return if not @visible or @pendingChunk or not @isAlive()

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -138,15 +138,17 @@ class TokenizedLine
     outputTokens
 
   markLeadingAndTrailingWhitespaceTokens: ->
-    firstNonWhitespacePosition = @text.search(NonWhitespaceRegex)
-    firstTrailingWhitespacePosition = @text.search(TrailingWhitespaceRegex)
-    lineIsWhitespaceOnly = firstTrailingWhitespacePosition is 0
-    position = 0
-    for token, i in @tokens
-      token.hasLeadingWhitespace =  position < firstNonWhitespacePosition
+    firstNonWhitespaceIndex = @text.search(NonWhitespaceRegex)
+    firstTrailingWhitespaceIndex = @text.search(TrailingWhitespaceRegex)
+    lineIsWhitespaceOnly = firstTrailingWhitespaceIndex is 0
+    index = 0
+    for token in @tokens
+      if token.hasLeadingWhitespace =  index < firstNonWhitespaceIndex
+        token.firstNonWhitespaceIndex = firstNonWhitespaceIndex - index
       # Only the *last* segment of a soft-wrapped line can have trailing whitespace
-      token.hasTrailingWhitespace = @lineEnding? and (position + token.value.length > firstTrailingWhitespacePosition)
-      position += token.value.length
+      if token.hasTrailingWhitespace = @lineEnding? and (index + token.value.length > firstTrailingWhitespaceIndex)
+        token.firstTrailingWhitespaceIndex = Math.max(0, firstTrailingWhitespaceIndex - index)
+      index += token.value.length
 
   substituteInvisibleCharacters: ->
     invisibles = @invisibles

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -166,16 +166,19 @@ class TokenizedLine
       if token.isHardTab
         if invisibles.tab
           token.value = invisibles.tab + token.value.substring(invisibles.tab.length)
+          token.hasInvisibleCharacters = true
           changedText = true
       else
         if invisibles.space
           if token.hasLeadingWhitespace
             token.value = token.value.replace LeadingWhitespaceRegex, (leadingWhitespace) ->
               leadingWhitespace.replace RepeatedSpaceRegex, invisibles.space
+            token.hasInvisibleCharacters = true
             changedText = true
           if token.hasTrailingWhitespace
             token.value = token.value.replace TrailingWhitespaceRegex, (leadingWhitespace) ->
               leadingWhitespace.replace RepeatedSpaceRegex, invisibles.space
+            token.hasInvisibleCharacters = true
             changedText = true
 
     @text = @buildText() if changedText

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -143,10 +143,12 @@ class TokenizedLine
     lineIsWhitespaceOnly = firstTrailingWhitespaceIndex is 0
     index = 0
     for token in @tokens
-      if token.hasLeadingWhitespace =  index < firstNonWhitespaceIndex
-        token.firstNonWhitespaceIndex = firstNonWhitespaceIndex - index
+      if index < firstNonWhitespaceIndex
+        token.hasLeadingWhitespace = true
+        token.firstNonWhitespaceIndex = Math.min(index + token.value.length, firstNonWhitespaceIndex - index)
       # Only the *last* segment of a soft-wrapped line can have trailing whitespace
-      if token.hasTrailingWhitespace = @lineEnding? and (index + token.value.length > firstTrailingWhitespaceIndex)
+      if @lineEnding? and (index + token.value.length > firstTrailingWhitespaceIndex)
+        token.hasTrailingWhitespace = true
         token.firstTrailingWhitespaceIndex = Math.max(0, firstTrailingWhitespaceIndex - index)
       index += token.value.length
 
@@ -159,7 +161,6 @@ class TokenizedLine
         if invisibles.tab
           token.value = invisibles.tab + token.value.substring(invisibles.tab.length)
           changedText = true
-
       else
         if invisibles.space
           if token.hasLeadingWhitespace


### PR DESCRIPTION
- [x] Get cursor position working correctly
- [x] Fix specs
- [x] Fix leading/trailing whitespace styling
- [x] Handle end of line invisibles in the model as well for consistency
- [x] Fix `editor:move-to-first-character-of-line`
- [x] Disable invisibles in mini editors

Fixes #3188
Fixes #2785 
