### PR TITLE
Fixes additional quotes on win32 in BufferedProcess

### DIFF
--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -55,7 +55,10 @@ class BufferedProcess
             "\"#{arg.replace(/"/g, '\\"')}\""
       else
         cmdArgs = []
-      cmdArgs.unshift("\"#{command}\"")
+      if /\s/.test(command)
+        cmdArgs.unshift("\"#{command}\"")
+      else
+        cmdArgs.unshift(command)
       cmdArgs = ['/s', '/c', "\"#{cmdArgs.join(' ')}\""]
       cmdOptions = _.clone(options)
       cmdOptions.windowsVerbatimArguments = true


### PR DESCRIPTION
Fixes issue https://github.com/atom/atom/issues/3200 by putting quotes on the 'command' var only if it contains white space. This allows command paths with white space to still be executed but at the same time allows also commands like 'grunt' to work by not putting unnecessary quotes around the command.

Signed-off-by: Luca Moser moser.luca@gmail.com
