### PR TITLE
Move coffeelint settings to external file

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -144,12 +144,7 @@ module.exports = (grunt) ->
 
     coffeelint:
       options:
-        no_empty_param_list:
-          level: 'error'
-        max_line_length:
-          level: 'ignore'
-        indentation:
-          level: 'ignore'
+        configFile: 'coffeelint.json'
       src: [
         'dot-atom/**/*.coffee'
         'exports/**/*.coffee'

--- a/build/package.json
+++ b/build/package.json
@@ -13,7 +13,7 @@
     "github-releases": "~0.2.0",
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.9",
-    "grunt-coffeelint": "git+https://github.com/atom/grunt-coffeelint.git",
+    "grunt-coffeelint": "0.0.13",
     "grunt-contrib-coffee": "~0.9.0",
     "grunt-contrib-csslint": "~0.1.2",
     "grunt-contrib-less": "~0.8.0",

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,11 @@
+{
+  "indentation": {
+    "level": "ignore"
+  },
+  "max_line_length": {
+    "level": "ignore"
+  },
+  "no_empty_param_list": {
+    "level": "error"
+  }
+}

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -7,5 +7,8 @@
   },
   "no_empty_param_list": {
     "level": "error"
+  },
+  "no_unnecessary_fat_arrows": {
+    "level": "ignore"
   }
 }


### PR DESCRIPTION
Depends on atom/grunt-coffeelint#2

The motivation is for this is to allow `coffeelint` config to be shared by
`script/grunt coffeelint`, global `coffeelint` and inline linting via
`AtomLinter`.

Test Plan:

Made some deliberate lint errors then ran `script/grunt coffeelint` and
verified the output looked the same with and without this change.
