### PR TITLE
Save state during beforeunload event

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -28,7 +28,7 @@ atom.keymaps.loadBundledKeymaps()
 keyBindingsToRestore = atom.keymaps.getKeyBindings()
 
 $(window).on 'core:close', -> window.close()
-$(window).on 'unload', ->
+$(window).on 'beforeunload', ->
   atom.storeWindowDimensions()
   atom.saveSync()
 $('html,body').css('overflow', 'auto')

--- a/spec/window-spec.coffee
+++ b/spec/window-spec.coffee
@@ -113,6 +113,7 @@ describe "Window", ->
       expect(atom.state.project).toEqual projectState
       expect(atom.saveSync).toHaveBeenCalled()
 
+  describe ".removeEditorWindow()", ->
     it "unsubscribes from all buffers", ->
       waitsForPromise ->
         atom.workspace.open("sample.js")
@@ -123,7 +124,7 @@ describe "Window", ->
         pane.splitRight(pane.copyActiveItem())
         expect(atom.workspaceView.find('.editor').length).toBe 2
 
-        atom.unloadEditorWindow()
+        atom.removeEditorWindow()
 
         expect(buffer.getSubscriptionCount()).toBe 0
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -322,12 +322,17 @@ class Atom extends Model
     @packages.deactivatePackages()
     @state.packageStates = @packages.packageStates
     @saveSync()
-    @workspaceView.remove()
-    @workspaceView = null
-    @project.destroy()
-    @windowEventHandler?.unsubscribe()
-    @keymaps.destroy()
     @windowState = null
+
+  removeEditorWindow: ->
+    return if not @project and not @workspaceView
+
+    @workspaceView?.remove()
+    @workspaceView = null
+    @project?.destroy()
+    @project = null
+
+    @windowEventHandler?.unsubscribe()
 
   loadThemes: ->
     @themes.load()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -311,11 +311,6 @@ class Atom extends Model
     @requireUserInitScript()
     @menu.update()
 
-    $(window).on 'beforeunload', =>
-      $(document.body).css('visibility', 'hidden')
-      @unloadEditorWindow()
-      null
-
     @displayWindow()
 
   unloadEditorWindow: ->

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -311,10 +311,10 @@ class Atom extends Model
     @requireUserInitScript()
     @menu.update()
 
-    $(window).on 'unload', =>
+    $(window).on 'beforeunload', =>
       $(document.body).css('visibility', 'hidden')
       @unloadEditorWindow()
-      false
+      null
 
     @displayWindow()
 

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -35,15 +35,17 @@ class WindowEventHandler
       confirmed = atom.workspaceView?.confirmClose()
       atom.hide() if confirmed and not @reloadRequested and atom.getCurrentWindow().isWebViewFocused()
       @reloadRequested = false
+
+      atom.storeDefaultWindowDimensions()
+      atom.storeWindowDimensions()
+
+      if confirmed
+        $(document.body).css('visibility', 'hidden')
+        atom.unloadEditorWindow()
+
       confirmed
 
-    @subscribe $(window), 'blur beforeunload', ->
-      atom.storeDefaultWindowDimensions()
-      null
-
-    @subscribe $(window), 'beforeunload', ->
-      atom.storeWindowDimensions()
-      null
+    @subscribe $(window), 'blur', -> atom.storeDefaultWindowDimensions()
 
     @subscribeToCommand $(window), 'window:toggle-full-screen', -> atom.toggleFullScreen()
 

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -38,10 +38,7 @@ class WindowEventHandler
 
       atom.storeDefaultWindowDimensions()
       atom.storeWindowDimensions()
-
-      if confirmed
-        $(document.body).css('visibility', 'hidden')
-        atom.unloadEditorWindow()
+      atom.unloadEditorWindow() if confirmed
 
       confirmed
 

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -37,11 +37,13 @@ class WindowEventHandler
       @reloadRequested = false
       confirmed
 
-    @subscribe $(window), 'blur unload', ->
+    @subscribe $(window), 'blur beforeunload', ->
       atom.storeDefaultWindowDimensions()
+      null
 
-    @subscribe $(window), 'unload', ->
+    @subscribe $(window), 'beforeunload', ->
       atom.storeWindowDimensions()
+      null
 
     @subscribeToCommand $(window), 'window:toggle-full-screen', -> atom.toggleFullScreen()
 

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -47,6 +47,8 @@ class WindowEventHandler
 
     @subscribe $(window), 'blur', -> atom.storeDefaultWindowDimensions()
 
+    @subscribe $(window), 'unload', -> atom.removeEditorWindow()
+
     @subscribeToCommand $(window), 'window:toggle-full-screen', -> atom.toggleFullScreen()
 
     @subscribeToCommand $(window), 'window:close', -> atom.close()

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -23,9 +23,9 @@ class WindowEventHandler
     @subscribe ipc, 'context-command', (command, args...) ->
       $(atom.contextMenu.activeElement).trigger(command, args...)
 
-    @subscribe $(window), 'focus', -> $("body").removeClass('is-blurred')
+    @subscribe $(window), 'focus', -> document.body.classList.remove('is-blurred')
 
-    @subscribe $(window), 'blur', -> $("body").addClass('is-blurred')
+    @subscribe $(window), 'blur', -> document.body.classList.add('is-blurred')
 
     @subscribe $(window), 'window:open-path', (event, {pathToOpen, initialLine, initialColumn}) ->
       unless fs.isDirectorySync(pathToOpen)


### PR DESCRIPTION
The window `unload` event is now async in Chrome 36, see #3144 for more details, so saving needs to be done during a `beforeunload` to ensure that on window reload the new render process is using the state saved from the previous render process.

This splits unload into two steps, the serializing/saving is done in a `beforeunload` while the workspace view and project are destroyed in the `unload` handler.

Fixes #3144
