### PR TITLE
Really kill buffered processes on windows

### DIFF
--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -40,8 +40,6 @@ class BufferedProcess
   #           containing the exit status (optional).
   constructor: ({command, args, options, stdout, stderr, exit}={}) ->
     options ?= {}
-    # Quick hack. Killing @process will only kill cmd.exe, and not the child
-    # process and will just orphan it. Does not escape ^ (cmd's escape symbol).
     # Related to joyent/node#2318
     if process.platform is "win32"
       # Quote all arguments and escapes inner quotes

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -138,7 +138,10 @@ class BufferedProcess
                     .filter (pid) -> /^\d+$/.test(pid)
                     .map (pid) -> parseInt(pid)
                     .filter (pid) -> pid isnt parentPid and 0 < pid < Infinity
-      process.kill(pid) for pid in pidsToKill
+
+      for pid in pidsToKill
+        try
+          process.kill(pid)
       @killProcess()
 
   killProcess: ->

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -134,7 +134,7 @@ class BufferedProcess
     output = ''
     wmicProcess.stdout.on 'data', (data) -> output += data
     wmicProcess.stdout.on 'close', =>
-      pidsToKill = output.split('\n')
+      pidsToKill = output.split(/\s+/)
                     .filter (pid) -> /^\d+$/.test(pid)
                     .map (pid) -> parseInt(pid)
                     .filter (pid) -> not pid is parentPid

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -137,7 +137,7 @@ class BufferedProcess
       pidsToKill = output.split(/\s+/)
                     .filter (pid) -> /^\d+$/.test(pid)
                     .map (pid) -> parseInt(pid)
-                    .filter (pid) -> not pid is parentPid
+                    .filter (pid) -> pid isnt parentPid and 0 < pid < Infinity
       process.kill(pid) for pid in pidsToKill
       @killProcess()
 

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -131,6 +131,7 @@ class BufferedProcess
     ]
 
     wmicProcess = ChildProcess.spawn(cmd, args)
+    wmicProcess.on 'error', -> # ignore errors
     output = ''
     wmicProcess.stdout.on 'data', (data) -> output += data
     wmicProcess.stdout.on 'close', =>

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -154,3 +154,5 @@ class BufferedProcess
       @killOnWindows()
     else
       @killProcess()
+
+    undefined


### PR DESCRIPTION
Kills all the child processes of the buffered process on Windows.

Closes #3209
