### PR TITLE
Remove number pad support

### DIFF
--- a/keymaps/base.cson
+++ b/keymaps/base.cson
@@ -12,7 +12,6 @@
   # Sublime Parity
   'tab': 'editor:indent'
   'enter': 'editor:newline'
-  'num-enter': 'editor:newline'
   'shift-tab': 'editor:outdent-selected-rows'
   'ctrl-K': 'editor:delete-line'
 
@@ -27,7 +26,6 @@
   'tab': 'core:focus-next'
   'shift-tab': 'core:focus-previous'
   'enter': 'native!'
-  'num-enter': 'native!'
   'backspace': 'native!'
   'shift-backspace': 'native!'
   'delete': 'native!'

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -21,7 +21,6 @@
   'cmd-O': 'application:open-dev'
   'cmd-alt-ctrl-s': 'application:run-all-specs'
   'enter': 'core:confirm'
-  'num-enter': 'core:confirm'
   'escape': 'core:cancel'
   'up': 'core:move-up'
   'down': 'core:move-down'

--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -1,7 +1,6 @@
 'body':
   # Atom Specific
   'enter': 'core:confirm'
-  'num-enter': 'core:confirm'
   'escape': 'core:cancel'
   'up': 'core:move-up'
   'down': 'core:move-down'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -5,7 +5,6 @@
 
   # Atom Specific
   'enter': 'core:confirm'
-  'num-enter': 'core:confirm'
   'escape': 'core:cancel'
   'up': 'core:move-up'
   'down': 'core:move-down'

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "atomShellVersion": "0.15.5",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "^1.0.2",
+    "atom-keymap": "^2",
     "bootstrap": "git+https://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",
     "clear-cut": "0.4.0",
     "coffee-script": "1.7.0",


### PR DESCRIPTION
This was confusing to people and a burden to package authors to have number pad keys behave differently than their equivalent key elsewhere on the keyboard.

See https://github.com/atom/atom-keymap/issues/42 for more details.

Closes #2527
Closes #2921
Closes #2972
Closes #3232
