### PR TITLE
Add will-insert-event with cancel() function

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1578,14 +1578,14 @@ describe "Editor", ->
 
           options = willInsertSpy.mostRecentCall.args[0]
           expect(options.text).toBe 'xxx'
-          expect(options.preventDefault).toBeDefined()
+          expect(options.cancel).toBeDefined()
 
           options = didInsertSpy.mostRecentCall.args[0]
           expect(options.text).toBe 'xxx'
 
-        it "text insertion is prevented when preventDefault is called from a will-insert-text handler", ->
-          willInsertSpy = jasmine.createSpy().andCallFake ({preventDefault}) ->
-            preventDefault()
+        it "text insertion is prevented when cancel is called from a will-insert-text handler", ->
+          willInsertSpy = jasmine.createSpy().andCallFake ({cancel}) ->
+            cancel()
 
           didInsertSpy = jasmine.createSpy()
 

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1470,6 +1470,15 @@ describe "Editor", ->
 
   describe "buffer manipulation", ->
     describe ".insertText(text)", ->
+      describe "when there is a single selection", ->
+        beforeEach ->
+          editor.setSelectedBufferRange([[1, 0], [1, 2]])
+
+        it "will-insert-text and did-insert-text events are emitted when inserting text", ->
+          range = editor.insertText('xxx')
+          expect(range).toEqual [ [[1, 0], [1, 3]] ]
+          expect(buffer.lineForRow(1)).toBe 'xxxvar sort = function(items) {'
+
       describe "when there are multiple empty selections", ->
         describe "when the cursors are on the same line", ->
           it "inserts the given text at the location of each cursor and moves the cursors to the end of each cursor's inserted text", ->
@@ -1561,7 +1570,7 @@ describe "Editor", ->
           editor.on('will-insert-text', willInsertSpy)
           editor.on('did-insert-text', didInsertSpy)
 
-          expect(editor.insertText('xxx')).toBe true
+          expect(editor.insertText('xxx')).toBeTruthy()
           expect(buffer.lineForRow(1)).toBe 'xxxvar sort = function(items) {'
 
           expect(willInsertSpy).toHaveBeenCalled()

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -522,7 +522,7 @@ EditorComponent = React.createClass
     @subscribe atom.config.observe 'editor.useHardwareAcceleration', @setUseHardwareAcceleration
 
   onFocus: ->
-    @refs.input.focus()
+    @refs.input.focus() if @isMounted()
 
   onTextInput: (event) ->
     event.stopPropagation()

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -543,8 +543,7 @@ EditorComponent = React.createClass
     selectedLength = inputNode.selectionEnd - inputNode.selectionStart
     editor.selectLeft() if selectedLength is 1
 
-    editor.insertText(event.data)
-    inputNode.value = event.data
+    inputNode.value = event.data if editor.insertText(event.data)
 
 
   onInputFocused: ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -647,10 +647,11 @@ class Editor extends Model
       options.autoIndentNewline ?= @shouldAutoIndent()
       options.autoDecreaseIndent ?= @shouldAutoIndent()
       @mutateSelectedText (selection) =>
-        selection.insertText(text, options)
-        @emit('did-insert-text', {text})
-
-    willInsert
+        range = selection.insertText(text, options)
+        @emit('did-insert-text', {text, range})
+        range
+    else
+      false
 
   # Public: For each selection, replace the selected text with a newline.
   insertNewline: ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -629,8 +629,8 @@ class Editor extends Model
 
   # Public: For each selection, replace the selected text with the given text.
   #
-  # Emits: `will-insert-text -> ({text, preventDefault})` before the text has
-  # been inserted. Calling `preventDefault` will prevent the text from being
+  # Emits: `will-insert-text -> ({text, cancel})` before the text has
+  # been inserted. Calling `cancel` will prevent the text from being
   # inserted.
   # Emits: `did-insert-text -> ({text})` after the text has been inserted.
   #
@@ -640,8 +640,8 @@ class Editor extends Model
   # Returns a {Bool} indicating whether or not the text was inserted.
   insertText: (text, options={}) ->
     willInsert = true
-    preventDefault = -> willInsert = false
-    @emit('will-insert-text', {preventDefault, text})
+    cancel = -> willInsert = false
+    @emit('will-insert-text', {cancel, text})
 
     if willInsert
       options.autoIndentNewline ?= @shouldAutoIndent()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1305,7 +1305,7 @@ class Editor extends Model
   addSelectionForBufferRange: (bufferRange, options={}) ->
     @markBufferRange(bufferRange, _.defaults(@getSelectionMarkerAttributes(), options))
     selection = @getLastSelection()
-    selection.autoscroll() if @manageScrollPosition
+    selection?.autoscroll() if @manageScrollPosition
     selection
 
   # Public: Set the selected range in buffer coordinates. If there are multiple

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1306,7 +1306,7 @@ class Editor extends Model
   addSelectionForBufferRange: (bufferRange, options={}) ->
     @markBufferRange(bufferRange, _.defaults(@getSelectionMarkerAttributes(), options))
     selection = @getLastSelection()
-    selection?.autoscroll() if @manageScrollPosition
+    selection.autoscroll() if @manageScrollPosition
     selection
 
   # Public: Set the selected range in buffer coordinates. If there are multiple

--- a/src/react-editor-view.coffee
+++ b/src/react-editor-view.coffee
@@ -169,9 +169,6 @@ class ReactEditorView extends View
   pageUp: ->
     @editor.pageUp()
 
-  getModel: ->
-    @editor
-
   getFirstVisibleScreenRow: ->
     @editor.getVisibleRowRange()[0]
 

--- a/src/react-editor-view.coffee
+++ b/src/react-editor-view.coffee
@@ -170,7 +170,7 @@ class ReactEditorView extends View
     @editor.pageUp()
 
   getModel: ->
-    @component?.getModel()
+    @editor
 
   getFirstVisibleScreenRow: ->
     @editor.getVisibleRowRange()[0]


### PR DESCRIPTION
autocomplete and go-to-line both preempt the `textInput` event to prevent character insertion. 

This pull provides the editor with a `will-insert-text` event that passes a `cancel()` function as a param. The consumer can call `cancel()` when it wants to prevent the insertion. No more preempt!

This was originally in #3132, but was pulled out as it is necessary for proper mini-editor behavior. 

See atom/autocomplete#40 and atom/go-to-line#9 for package fixes.

Refs #3075
