### PR TITLE
Remove unnecessary params from Editor::getScrollWidth

### DIFF
--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -2040,7 +2040,7 @@ class Editor extends Model
   setScrollRight: (scrollRight) -> @displayBuffer.setScrollRight(scrollRight)
 
   getScrollHeight: -> @displayBuffer.getScrollHeight()
-  getScrollWidth: (scrollWidth) -> @displayBuffer.getScrollWidth(scrollWidth)
+  getScrollWidth: -> @displayBuffer.getScrollWidth()
 
   getVisibleRowRange: -> @displayBuffer.getVisibleRowRange()
 


### PR DESCRIPTION
The getScrollWidth function in editor.coffee has extra, unnecessary function parameters.
