### PR TITLE
Uprade to atom-shell@0.15.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "url": "http://github.com/atom/atom/raw/master/LICENSE.md"
     }
   ],
-  "atomShellVersion": "0.15.5",
+  "atomShellVersion": "0.15.6",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^2",


### PR DESCRIPTION
Fixes the crash of auto updater.
