### PR TITLE
Fix for missing titlebar menu on OS X.

### DIFF
--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -212,8 +212,11 @@ class WorkspaceView extends View
 
   # Updates the application's title, based on whichever file is open.
   updateTitle: ->
+    item = @getModel().getActivePaneItem()
+    atom.getCurrentWindow().setRepresentedFilename(item?.getPath?() ? "")
+
     if projectPath = atom.project.getPath()
-      if item = @getModel().getActivePaneItem()
+      if item?
         @setTitle("#{item.getTitle?() ? 'untitled'} - #{projectPath}")
       else
         @setTitle(projectPath)


### PR DESCRIPTION
On OS X, if you command click the title of a window that's associated with a document, you get a menu where each item is a parent of its path. (You can try this in Pages, Finder, Sublime, even Safari). This is currently missing in Atom. The fix is pretty straightforward, just call setRepresentedFilename (which is implemented to do nothing on other platforms in atom-shell).

![title-bar-menu](https://cloud.githubusercontent.com/assets/23753/3914633/7abea85c-234a-11e4-8baa-97228ab50c5a.gif)

Reviewed by @tolmasky.
