### PR TITLE
Restore maximized state of window

### DIFF
--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -212,6 +212,7 @@ class Atom extends Model
   #   :height - The new height.
   #   :maximized - A {Boolean} for the maximized window state.
   setWindowDimensions: ({x, y, width, height, maximized}) ->
+    # Maximized state only applies on Windows and Linux
     if maximized and process.platform isnt 'darwin'
       @maximize()
     else

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -211,7 +211,7 @@ class Atom extends Model
   #   :width - The new width.
   #   :height - The new height.
   #   :maximized - A {Boolean} for the maximized window state.
-  setWindowDimensions: ({x, y, width, height}) ->
+  setWindowDimensions: ({x, y, width, height, maximized}) ->
     if maximized and process.platform isnt 'darwin'
       @maximize()
     else

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -313,7 +313,8 @@ class Atom extends Model
     @requireUserInitScript()
     @menu.update()
 
-    @displayWindow(maximize: dimensions?.maximized)
+    maximize = dimensions?.maximized and process.platform isnt 'darwin'
+    @displayWindow({maximize})
 
   unloadEditorWindow: ->
     return if not @project and not @workspaceView

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -460,7 +460,8 @@ class Atom extends Model
     setImmediate =>
       @show()
       @focus()
-      @setFullScreen(true) if @workspaceView.fullScreen
+      @setFullScreen(true) if @workspace.fullScreen
+      @maximize() if @workspace.maximized and process.platform isnt 'darwin'
 
   # Public: Close the current window.
   close: ->
@@ -497,6 +498,12 @@ class Atom extends Model
   # Public: Is the current window in full screen mode?
   isFullScreen: ->
     @getCurrentWindow().isFullScreen()
+
+  maximize: ->
+    ipc.send('call-window-method', 'maximize')
+
+  isMaximized: ->
+    @getCurrentWindow().isMaximized()
 
   # Public: Get the version of the Atom application.
   #

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -506,9 +506,6 @@ class Atom extends Model
   maximize: ->
     ipc.send('call-window-method', 'maximize')
 
-  isMaximized: ->
-    @getCurrentWindow().isMaximized()
-
   # Public: Get the version of the Atom application.
   #
   # Returns the version text {String}.

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -196,7 +196,8 @@ class Atom extends Model
     browserWindow = @getCurrentWindow()
     [x, y] = browserWindow.getPosition()
     [width, height] = browserWindow.getSize()
-    {x, y, width, height}
+    maximized = browserWindow.isMaximized()
+    {x, y, width, height, maximized}
 
   # Public: Set the dimensions of the window.
   #
@@ -209,13 +210,17 @@ class Atom extends Model
   #   :y - The new y coordinate.
   #   :width - The new width.
   #   :height - The new height.
+  #   :maximized - A {Boolean} for the maximized window state.
   setWindowDimensions: ({x, y, width, height}) ->
-    if width? and height?
-      @setSize(width, height)
-    if x? and y?
-      @setPosition(x, y)
+    if maximized and process.platform isnt 'darwin'
+      @maximize()
     else
-      @center()
+      if width? and height?
+        @setSize(width, height)
+      if x? and y?
+        @setPosition(x, y)
+      else
+        @center()
 
   # Returns true if the dimensions are useable, false if they should be ignored.
   # Work around for https://github.com/atom/atom-shell/issues/473
@@ -461,7 +466,6 @@ class Atom extends Model
       @show()
       @focus()
       @setFullScreen(true) if @workspace.fullScreen
-      @maximize() if @workspace.maximized and process.platform isnt 'darwin'
 
   # Public: Close the current window.
   close: ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -56,6 +56,7 @@ class Workspace extends Model
   serializeParams: ->
     paneContainer: @paneContainer.serialize()
     fullScreen: atom.isFullScreen()
+    maximized: atom.isMaximized()
     packagesWithActiveGrammars: @getPackageNamesWithActiveGrammars()
 
   getPackageNamesWithActiveGrammars: ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -56,7 +56,6 @@ class Workspace extends Model
   serializeParams: ->
     paneContainer: @paneContainer.serialize()
     fullScreen: atom.isFullScreen()
-    maximized: atom.isMaximized()
     packagesWithActiveGrammars: @getPackageNamesWithActiveGrammars()
 
   getPackageNamesWithActiveGrammars: ->


### PR DESCRIPTION
Restore the maximized state of the window on Windows and Linux, Mac OS X does not have a "maximized" state, just size and position that extends corner to corner.

Closes #2936
Closes #2951
