### PR TITLE
Tighten lint rules

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,14 +1,8 @@
 {
-  "indentation": {
-    "level": "ignore"
-  },
   "max_line_length": {
     "level": "ignore"
   },
   "no_empty_param_list": {
     "level": "error"
-  },
-  "no_unnecessary_fat_arrows": {
-    "level": "ignore"
   }
 }

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -4,5 +4,15 @@
   },
   "no_empty_param_list": {
     "level": "error"
+  },
+  "arrow_spacing": {
+    "level": "warn"
+  },
+  "line_endings": {
+    "level": "error",
+    "value": "unix"
+  },
+  "no_interpolation_in_single_quotes": {
+    "level": "error"
   }
 }

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -8,10 +8,6 @@
   "arrow_spacing": {
     "level": "error"
   },
-  "line_endings": {
-    "level": "error",
-    "value": "unix"
-  },
   "no_interpolation_in_single_quotes": {
     "level": "error"
   }

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -6,7 +6,7 @@
     "level": "error"
   },
   "arrow_spacing": {
-    "level": "warn"
+    "level": "error"
   },
   "line_endings": {
     "level": "error",

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -459,7 +459,7 @@ class Atom extends Model
   #
   # This is done in a next tick to prevent a white flicker from occurring
   # if called synchronously.
-  displayWindow: ({maximize}={})->
+  displayWindow: ({maximize}={}) ->
     setImmediate =>
       @show()
       @focus()

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -116,7 +116,7 @@ class ApplicationMenu
       item.metadata ?= {}
       if item.command
         item.accelerator = @acceleratorForCommand(item.command, keystrokesByCommand)
-        item.click = => global.atomApplication.sendCommand(item.command)
+        item.click = -> global.atomApplication.sendCommand(item.command)
         item.metadata['windowSpecific'] = true unless /^application:/.test(item.command)
       @translateTemplate(item.submenu, keystrokesByCommand) if item.submenu
     template

--- a/src/browser/auto-update-manager.coffee
+++ b/src/browser/auto-update-manager.coffee
@@ -74,7 +74,7 @@ class AutoUpdateManager
   getState: ->
     @state
 
-  check: ({hidePopups}={})->
+  check: ({hidePopups}={}) ->
     unless hidePopups
       autoUpdater.once 'update-not-available', @onUpdateNotAvailable
       autoUpdater.once 'error', @onUpdateError

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -150,7 +150,7 @@ class Token
       scopeClasses = scope.split('.')
       _.isSubset(targetClasses, scopeClasses)
 
-  getValueAsHtml: ({hasIndentGuide})->
+  getValueAsHtml: ({hasIndentGuide}) ->
     if @isHardTab
       classes = 'hard-tab'
       classes += ' indent-guide' if hasIndentGuide


### PR DESCRIPTION
coffeelint.json had some rules set to ignore, but since #3116 was merged there
are no violations of these rules in the code anymore. Tighten up the rules to
prevent those kinds of errors from creeping back in.

Test Plan:

Lint executes without finding any errors

```
$ ./script/grunt coffeelint
Running "coffeelint:src" (coffeelint) task
>> 80 files lint free.

Running "coffeelint:build" (coffeelint) task
>> 23 files lint free.

Running "coffeelint:test" (coffeelint) task
>> 40 files lint free.
Done, without errors.
```
