### PR TITLE
Linux tests

### DIFF
--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -6,7 +6,7 @@ _ = require 'underscore-plus'
 async = require 'async'
 
 module.exports = (grunt) ->
-  {isAtomPackage, spawn} = require('./task-helpers')(grunt)
+  {isAtomPackage, spawn, withPlatform} = require('./task-helpers')(grunt)
 
   packageSpecQueue = null
 
@@ -15,21 +15,26 @@ module.exports = (grunt) ->
     rootDir = grunt.config.get('atom.shellAppDir')
     contentsDir = grunt.config.get('atom.contentsDir')
     resourcePath = process.cwd()
-    if process.platform is 'darwin'
-      appPath = path.join(contentsDir, 'MacOS', 'Atom')
-    else if process.platform is 'win32'
-      appPath = path.join(contentsDir, 'atom.exe')
+    appPath = withPlatform
+      darwin: -> path.join(contentsDir, 'MacOS', 'Atom')
+      linux: -> path.join(contentsDir, 'atom')
+      win32: -> path.join(contentsDir, 'atom.exe')
 
     packageSpecQueue = async.queue (packagePath, callback) ->
-      if process.platform is 'darwin'
-        options =
+      options = withPlatform
+        darwin: ->
           cmd: appPath
           args: ['--test', "--resource-path=#{resourcePath}", "--spec-directory=#{path.join(packagePath, 'spec')}"]
           opts:
             cwd: packagePath
             env: _.extend({}, process.env, ATOM_PATH: rootDir)
-      else if process.platform is 'win32'
-        options =
+        linux: ->
+          cmd: appPath
+          args: ['--test', "--resource-path=#{resourcePath}", "--spec-directory=#{path.join(packagePath, 'spec')}"]
+          opts:
+            cwd: packagePath
+            env: _.extend({}, process.env, ATOM_PATH: rootDir)
+        win32: ->
           cmd: process.env.comspec
           args: ['/c', appPath, '--test', "--resource-path=#{resourcePath}", "--spec-directory=#{path.join(packagePath, 'spec')}", "--log-file=ci.log"]
           opts:
@@ -58,29 +63,35 @@ module.exports = (grunt) ->
 
   runCoreSpecs = (callback) ->
     contentsDir = grunt.config.get('atom.contentsDir')
-    if process.platform is 'darwin'
-      appPath = path.join(contentsDir, 'MacOS', 'Atom')
-    else if process.platform is 'win32'
-      appPath = path.join(contentsDir, 'atom.exe')
+
+    appPath = withPlatform
+      darwin: -> path.join(contentsDir, 'MacOS', 'Atom')
+      win32: -> path.join(contentsDir, 'atom.exe')
+      linux: -> path.join(contentsDir, 'atom')
+
     resourcePath = process.cwd()
     coreSpecsPath = path.resolve('spec')
 
-    if process.platform is 'darwin'
-      options =
+    options = withPlatform
+      darwin: ->
         cmd: appPath
         args: ['--test', "--resource-path=#{resourcePath}", "--spec-directory=#{coreSpecsPath}"]
-    else if process.platform is 'win32'
-      options =
+      linux: ->
+        cmd: appPath
+        args: ['--test', "--resource-path=#{resourcePath}", "--spec-directory=#{coreSpecsPath}"]
+      win32: ->
         cmd: process.env.comspec
         args: ['/c', appPath, '--test', "--resource-path=#{resourcePath}", "--spec-directory=#{coreSpecsPath}", "--log-file=ci.log"]
 
     spawn options, (error, results, code) ->
-      if process.platform is 'win32'
-        process.stderr.write(fs.readFileSync('ci.log')) if error
-        fs.unlinkSync('ci.log')
-      else
-        # TODO: Restore concurrency on Windows
-        packageSpecQueue.concurrency = 2
+      withPlatform
+        darwin: ->
+          # TODO: Restore concurrency on Windows
+          packageSpecQueue.concurrency = 2
+        linux: ->
+        win32: ->
+          process.stderr.write(fs.readFileSync('ci.log')) if error
+          fs.unlinkSync('ci.log')
 
       callback(null, error)
 
@@ -90,10 +101,10 @@ module.exports = (grunt) ->
 
     # TODO: This should really be parallel on both platforms, however our
     # fixtures step on each others toes currently.
-    if process.platform is 'darwin'
-      method = async.parallel
-    else if process.platform is 'win32'
-      method = async.series
+    method = withPlatform
+      darwin: -> async.parallel
+      linux: -> async.series
+      win32: -> async.series
 
     method [runCoreSpecs, runPackageSpecs], (error, results) ->
       [coreSpecFailed, failedPackages] = results

--- a/build/tasks/task-helpers.coffee
+++ b/build/tasks/task-helpers.coffee
@@ -66,7 +66,7 @@ module.exports = (grunt) ->
     catch error
       false
 
-  withPlatform: (callbacks) ->
+  platformSwitch: (callbacks) ->
     callbacks.unsupported ?= ->
       grunt.warn new Error("Unsupported platform: #{process.platform}!")
 

--- a/build/tasks/task-helpers.coffee
+++ b/build/tasks/task-helpers.coffee
@@ -65,3 +65,10 @@ module.exports = (grunt) ->
       engines?.atom?
     catch error
       false
+
+  withPlatform: (callbacks) ->
+    callbacks.unsupported ?= ->
+      grunt.warn new Error("Unsupported platform: #{process.platform}!")
+
+    chosen = callbacks[process.platform] or callbacks.unsupported
+    chosen()


### PR DESCRIPTION
I've added :penguin: Linux support for `script/grunt test`... and _now_ I see that #2273 does the same thing! Whoops. I'll push this out anyway, I've made some different decisions and it might be interesting to pick and choose from each.

There are currently a small number of failures, which I've pasted into [a gist](https://gist.github.com/smashwilson/700a0e7368b85c450ec8). Attempting to build packages in parallel adds a few more.

Here are my system specs:

```
smash@winter ~/code/atom (linux-tests %=) $ uname -a
Linux winter 3.11.0-12-generic #19-Ubuntu SMP Wed Oct 9 16:20:46 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
smash@winter ~/code/atom (linux-tests %=) $ cat /etc/lsb-release 
DISTRIB_ID=LinuxMint
DISTRIB_RELEASE=16
DISTRIB_CODENAME=petra
DISTRIB_DESCRIPTION="Linux Mint 16 Petra"
smash@winter ~/code/atom (linux-tests %=) $ cat /etc/os-release 
NAME="Ubuntu"
VERSION="13.10, Saucy Salamander"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 13.10"
VERSION_ID="13.10"
HOME_URL="http://www.ubuntu.com/"
SUPPORT_URL="http://help.ubuntu.com/"
BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
```
