### PR TITLE
Fix error when running `checkout-head-revision`

### DIFF
--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -500,7 +500,7 @@ EditorComponent = React.createClass
         'editor:fold-at-indent-level-9': -> editor.foldAllAtIndentLevel(8)
         'editor:toggle-line-comments': -> editor.toggleLineCommentsInSelection()
         'editor:log-cursor-scope': -> editor.logCursorScope()
-        'editor:checkout-head-revision': -> editor.checkoutHead()
+        'editor:checkout-head-revision': -> atom.project.getRepo()?.checkoutHeadForEditor(editor)
         'editor:copy-path': -> editor.copyPathToClipboard()
         'editor:move-line-up': -> editor.moveLineUp()
         'editor:move-line-down': -> editor.moveLineDown()


### PR DESCRIPTION
I got the following error when running `checkout-head-revision`:

```
Uncaught TypeError: undefined is not a function /Applications/Atom.app/Contents/Resources/app/src/editor-component.js:804
addCommandListeners.editor:checkout-head-revision /Applications/Atom.app/Contents/Resources/app/src/editor-component.js:804
(anonymous function) /Applications/Atom.app/Contents/Resources/app/src/editor-component.js:840
jQuery.event.dispatch /Applications/Atom.app/Contents/Resources/app/node_modules/space-pen/vendor/jquery.js:4676
elemData.handle /Applications/Atom.app/Contents/Resources/app/node_modules/space-pen/vendor/jquery.js:4360
module.exports.KeymapManager.dispatchCommandEvent /Applications/Atom.app/Contents/Resources/app/node_modules/atom-keymap/lib/keymap-manager.js:400
module.exports.KeymapManager.handleKeyboardEvent /Applications/Atom.app/Contents/Resources/app/node_modules/atom-keymap/lib/keymap-manager.js:181
module.exports.WindowEventHandler.onKeydown
```

It looks like it was caused by a bad merge conflict resolution in 0eaec57.

Test Plan:

Built new Atom and pressed `cmd-alt-z` and didn't get an error.

Looked at a side-by-side diff to check for any other merge issues:

```
git difftool -t opendiff 32e59ce..32e59ce^ src/editor-component.coffee
```
