### PR TITLE
Add start/end timestamps for timecop/profiling

### DIFF
--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -38,7 +38,9 @@ class AtomWindow
     # Only send to the first non-spec window created
     if @constructor.includeShellLoadTime and not @isSpec
       @constructor.includeShellLoadTime = false
-      loadSettings.shellLoadTime ?= Date.now() - global.shellStartTime
+      loadSettings.shellLoadTimeEnd ?= Date.now()
+      loadSettings.shellLoadTimeStart ?= global.shellStartTime
+      loadSettings.shellLoadTime ?= loadSettings.shellLoadTimeEnd - loadSettings.shellLoadTimeStart
 
     loadSettings.initialPath = pathToOpen
     if fs.statSyncNoException(pathToOpen).isFile?()

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -54,7 +54,10 @@ class Package
   measure: (key, fn) ->
     startTime = Date.now()
     value = fn()
-    @[key] = Date.now() - startTime
+    endTime = Date.now()
+    @[key + 'Start'] = startTime
+    @[key + 'End'] = endTime
+    @[key] = endTime - startTime
     value
 
   getType: -> 'atom'

--- a/src/window-bootstrap.coffee
+++ b/src/window-bootstrap.coffee
@@ -7,5 +7,8 @@ Atom = require './atom'
 window.atom = Atom.loadOrCreate('editor')
 atom.initialize()
 atom.startEditorWindow()
-window.atom.loadTime = Date.now() - startTime
+endTime = Date.now()
+atom.loadTimeStart = startTime
+atom.loadTimeEnd = endTime
+atom.loadTime = endTime - startTime
 console.log "Window load time: #{atom.getWindowLoadTime()}ms"


### PR DESCRIPTION
Keep the old variables for backwards compatibility, but store the `Date.now()` timestamps in `[variable]Start` `[variable]End` for measured durations.

Adds:
- `atom.getLoadSettings().shellLoadTimeStart`
- `atom.getLoadSettings().shellLoadTimeEnd`
- `atom.loadTimeStart`
- `atom.loadTimeEnd`
- `Package.loadTimeStart`
- `Package.loadTimeEnd`
- `Package.activateTimeStart`
- `Package.activateTimeEnd`

With this I was able to generate a timeline graph that you might be interested in seeing.

![](http://i.imgur.com/2XRpfe5.png)

It confirmed what I suspected (that shellLoadTime + windowLoadTime != totalLoadTime).

There's still the overhead of actually getting to `src/browser/main.js` to map out though.
