### PR TITLE
Change ctrl-a binding to editor:move-to-first-character-of-line on Mac

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -119,7 +119,7 @@
   'cmd-shift-right': 'editor:select-to-end-of-line'
   'alt-backspace': 'editor:delete-to-beginning-of-word'
   'alt-delete': 'editor:delete-to-end-of-word'
-  'ctrl-a': 'editor:move-to-beginning-of-line'
+  'ctrl-a': 'editor:move-to-first-character-of-line'
   'ctrl-e': 'editor:move-to-end-of-line'
   'ctrl-k': 'editor:cut-to-end-of-line'
 


### PR DESCRIPTION
Considering that the entire Atom core team has ctrl-a bound to move to the first character and it's also the the default behavior of Sublime, this seems like a more sensible and useful default option even though it deviates from text editing norms on OS X.
