### PR TITLE
Rework DOM measurement to try to prevent measurement errors

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -1557,6 +1557,7 @@ describe "EditorComponent", ->
           height: 8px;
         }
       """
+      nextAnimationFrame()
 
       scrollbarCornerNode = componentNode.querySelector('.scrollbar-corner')
       expect(verticalScrollbarNode.offsetWidth).toBe 8

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -31,11 +31,11 @@ class DisplayBuffer extends Model
     scrollTop: 0
     scrollLeft: 0
     scrollWidth: 0
+    verticalScrollbarWidth: 15
+    horizontalScrollbarHeight: 15
 
   verticalScrollMargin: 2
   horizontalScrollMargin: 6
-  horizontalScrollbarHeight: 15
-  verticalScrollbarWidth: 15
   scopedCharacterWidthsChangeCount: 0
 
   constructor: ({tabLength, @editorWidthInChars, @tokenizedBuffer, buffer, @invisibles}={}) ->

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -833,7 +833,7 @@ EditorComponent = React.createClass
     if @fontSize isnt oldFontSize or @fontFamily isnt oldFontFamily or @lineHeight isnt oldLineHeight
       @measureLineHeightAndDefaultCharWidth()
 
-    if (@fontSize isnt oldFontSize or @fontFamily isnt oldFontFamily)
+    if (@fontSize isnt oldFontSize or @fontFamily isnt oldFontFamily) and @performedInitialMeasurement
       @remeasureCharacterWidths()
 
   sampleBackgroundColors: (suppressUpdate) ->

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -178,7 +178,7 @@ EditorComponent = React.createClass
     @subscribe scrollbarStyle.changes, @refreshScrollbars
 
     @domPollingIntervalId = setInterval(@pollDOM, @domPollingInterval)
-    @pollDOM()
+    @checkForVisibilityChange()
 
   componentWillUnmount: ->
     @props.parentView.trigger 'editor:will-be-removed', [@props.parentView]

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -854,20 +854,16 @@ EditorComponent = React.createClass
   measureLineHeightAndDefaultCharWidth: ->
     if @isVisible()
       @measureLineHeightAndDefaultCharWidthWhenShown = false
+      @refs.lines.measureLineHeightAndDefaultCharWidth()
     else
       @measureLineHeightAndDefaultCharWidthWhenShown = true
-      return
-
-    @refs.lines.measureLineHeightAndDefaultCharWidth()
 
   remeasureCharacterWidths: ->
     if @isVisible()
       @remeasureCharacterWidthsWhenShown = false
+      @refs.lines.remeasureCharacterWidths()
     else
       @remeasureCharacterWidthsWhenShown = true
-      return
-
-    @refs.lines.remeasureCharacterWidths()
 
   measureScrollbars: ->
     @measureScrollbarsWhenShown = false

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -157,7 +157,8 @@ class Editor extends Model
     toProperty: 'languageMode'
 
   @delegatesProperties '$lineHeightInPixels', '$defaultCharWidth', '$height', '$width',
-    '$scrollTop', '$scrollLeft', 'manageScrollPosition', toProperty: 'displayBuffer'
+    '$verticalScrollbarWidth', '$horizontalScrollbarHeight', '$scrollTop', '$scrollLeft',
+    'manageScrollPosition', toProperty: 'displayBuffer'
 
   constructor: ({@softTabs, initialLine, initialColumn, tabLength, softWrap, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini}) ->
     super

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -286,12 +286,14 @@ LinesComponent = React.createClass
     editor.setDefaultCharWidth(charWidth)
 
   remeasureCharacterWidths: ->
+    return unless @props.performedInitialMeasurement
+
     @clearScopedCharWidths()
     @measureCharactersInNewLines()
 
   measureCharactersInNewLines: ->
-    {editor} = @props
-    [visibleStartRow, visibleEndRow] = @props.renderedRowRange
+    {editor, renderedRowRange} = @props
+    [visibleStartRow, visibleEndRow] = renderedRowRange
     node = @getDOMNode()
 
     editor.batchCharacterMeasurement =>

--- a/src/scrollbar-component.coffee
+++ b/src/scrollbar-component.coffee
@@ -39,9 +39,9 @@ ScrollbarComponent = React.createClass
 
     switch @props.orientation
       when 'vertical'
-        not isEqualForProperties(newProps, @props, 'scrollHeight', 'scrollTop', 'scrollableInOppositeDirection')
+        not isEqualForProperties(newProps, @props, 'scrollHeight', 'scrollTop', 'scrollableInOppositeDirection', 'verticalScrollbarWidth')
       when 'horizontal'
-        not isEqualForProperties(newProps, @props, 'scrollWidth', 'scrollLeft', 'scrollableInOppositeDirection')
+        not isEqualForProperties(newProps, @props, 'scrollWidth', 'scrollLeft', 'scrollableInOppositeDirection', 'horizontalScrollbarHeight')
 
   componentDidUpdate: ->
     {orientation, scrollTop, scrollLeft} = @props


### PR DESCRIPTION
This is attempting to bugs like the following:

```
src/lines-component.js:426:35 [object Object].module.exports.React.createClass.measureCharactersInLine
src/display-buffer.js:439:7 DisplayBuffer.module.exports.DisplayBuffer.batchCharacterMeasurement
src/editor.js:2145:33 Editor.module.exports.Editor.batchCharacterMeasurement
src/lines-component.js:392:21 [object Object].module.exports.React.createClass.measureCharactersInNewLines
src/lines-component.js:385:19 [object Object].module.exports.React.createClass.remeasureCharacterWidths
src/editor-component.js:1446:32 [object Object].module.exports.React.createClass.remeasureCharacterWidths
src/editor-component.js:290:14 [object Object].module.exports.React.createClass.performInitialMeasurement
src/editor-component.js:1354:16 [object Object].module.exports.React.createClass.pollDOM
src/react-editor-view.js:267:22 ReactEditorView.module.exports.ReactEditorView.pollComponentDOM
src/react-editor-view.js:257:19 ReactEditorView.module.exports.ReactEditorView.show
src/pane-view.js:301:14 PaneView.module.exports.PaneView.onActiveItemChanged
src/pane.js:172:32 Pane.module.exports.Pane.activateItem
```

It seems like in some cases we're remeasuring character widths for lines that aren't on the screen yet.
- Simplify scrollbar refresh and measurement by using imperative DOM
  manipulation instead of React to hide/show scrollbars.
- Rename `::performInitialMeasurement` to `::becameVisible`
- Break `::checkForVisibilityChange` out of `::pollDOM` and use it in
  to check for the element becoming visible in `componentWillUpdate`.
- Don't rely on stored visibility state anywhere. Always check again.
  This could potentially be cached for an update cycle but being wrong
  about this is disastrous so I'm being conservative.
