### PR TITLE
Open file paths in focused window

### DIFF
--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -371,7 +371,8 @@ class Atom extends Model
   #                  cloned repository and also loads all the packages in
   #                  ~/.atom/dev/packages
   #   :safeMode    - A {Boolean}, true to open the window in safe mode. Safe
-  #                  mode prevents installed packages from loading
+  #                  mode prevents all packages installed to ~/.atom/packages
+  #                  from loading.
   open: (options) ->
     ipc.send('open', options)
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -363,7 +363,15 @@ class Atom extends Model
   # a file/folder to open in the new window.
   #
   # options - An {Object} with the following keys:
-  #   :pathsToOpen -  An {Array} of {String} paths to open.
+  #   :pathsToOpen - An {Array} of {String} paths to open.
+  #   :newWindow   - A {Boolean}, true to always open a new window instead of
+  #                  reusing existing windows depending on the paths to open.
+  #   :devMode     - A {Boolean}, true to open the window in development mode.
+  #                  Development mode loads the Atom source from the locally
+  #                  cloned repository and also loads all the packages in
+  #                  ~/.atom/dev/packages
+  #   :safeMode    - A {Boolean}, true to open the window in safe mode. Safe
+  #                  mode prevents installed packages from loading
   open: (options) ->
     ipc.send('open', options)
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -308,6 +308,9 @@ class Atom extends Model
     @themes.loadBaseStylesheets()
     @packages.loadPackages()
     @deserializeEditorWindow()
+
+    @watchProjectPath()
+
     @packages.activate()
     @keymaps.loadUserKeymap()
     @requireUserInitScript()
@@ -346,6 +349,13 @@ class Atom extends Model
       for pack in @packages.getActivePackages() when pack.getType() isnt 'theme'
         pack.reloadStylesheets?()
       null
+
+  # Notify the browser project of the window's current project path
+  watchProjectPath: ->
+    onProjectPathChanged = =>
+      ipc.send('window-command', 'project-path-changed', @project.getPath())
+    @subscribe @project, 'path-changed', onProjectPathChanged
+    onProjectPathChanged()
 
   # Public: Open a new Atom window using the given options.
   #

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -326,8 +326,8 @@ class AtomApplication
   openPath: ({pathToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, windowDimensions, window}={}) ->
     {pathToOpen, initialLine, initialColumn} = @locationForPathToOpen(pathToOpen)
 
-    # Open files in the focused window
     unless pidToKillWhenClosed or newWindow
+      # Open files in the specified window or the last focused window
       if fs.statSyncNoException(pathToOpen).isFile?()
         existingWindow = window ? @topWindow
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -331,6 +331,7 @@ class AtomApplication
       if fs.statSyncNoException(pathToOpen).isFile?()
         existingWindow = window ? @topWindow
 
+      # Don't reuse windows in dev mode
       existingWindow ?= @windowForPath(pathToOpen) unless devMode
 
     if existingWindow?

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -351,7 +351,7 @@ class AtomApplication
     if pidToKillWhenClosed?
       @pidsToOpenWindows[pidToKillWhenClosed] = openedWindow
 
-    openedWindow.browserWindow.on 'closed', =>
+    openedWindow.browserWindow.once 'closed', =>
       @killProcessForWindow(openedWindow)
 
   # Kill all processes associated with opened windows.

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -289,8 +289,7 @@ class AtomApplication
 
   # Returns the {AtomWindow} for the given path.
   windowForPath: (pathToOpen) ->
-    for atomWindow in @windows
-      return atomWindow if atomWindow.containsPath(pathToOpen)
+    _.find @windows, (atomWindow) -> atomWindow.containsPath(pathToOpen)
 
   # Returns the {AtomWindow} for the given ipc event.
   windowForEvent: ({sender}) ->

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -103,10 +103,10 @@ class AtomApplication
     window.once 'window:loaded', =>
       @autoUpdateManager.emitUpdateAvailableEvent(window)
 
-    focusHandler = => @topWindow = window
+    focusHandler = => @lastFocusedWindow = window
     window.browserWindow.on 'focus', focusHandler
     window.browserWindow.once 'closed', =>
-      @topWindow = null if window is @topWindow
+      @lastFocusedWindow = null if window is @lastFocusedWindow
       window.browserWindow.removeListener 'focus', focusHandler
 
   # Creates server to listen for additional atom application launches.
@@ -330,7 +330,7 @@ class AtomApplication
       pathToOpenStat = fs.statSyncNoException(pathToOpen)
 
       # Default to using the specified window or the last focused window
-      currentWindow = window ? @topWindow
+      currentWindow = window ? @lastFocusedWindow
 
       if pathToOpenStat.isFile?()
         # Open the file in the current window

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -327,9 +327,17 @@ class AtomApplication
     {pathToOpen, initialLine, initialColumn} = @locationForPathToOpen(pathToOpen)
 
     unless pidToKillWhenClosed or newWindow
-      # Open files in the specified window or the last focused window
-      if fs.statSyncNoException(pathToOpen).isFile?()
-        existingWindow = window ? @topWindow
+      pathToOpenStat = fs.statSyncNoException(pathToOpen)
+
+      # Default to using the specified window or the last focused window
+      currentWindow = window ? @topWindow
+
+      if pathToOpenStat.isFile?()
+        # Open the file in the current window
+        existingWindow = currentWindow
+      else if pathToOpenStat.isDirectory?()
+        # Open the folder in the current window if it doesn't have a path
+        existingWindow = currentWindow unless currentWindow?.hasProjectPath()
 
       # Don't reuse windows in dev mode
       existingWindow ?= @windowForPath(pathToOpen) unless devMode

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -49,6 +49,8 @@ class AtomWindow
       @emit 'window:loaded'
       @loaded = true
 
+    @browserWindow.on 'project-path-changed', (@projectPath) =>
+
     @browserWindow.loadUrl @getUrl(loadSettings)
     @browserWindow.focusOnWebView() if @isSpec
 
@@ -65,6 +67,8 @@ class AtomWindow
       pathname: "#{@resourcePath}/static/index.html"
       slashes: true
       query: {loadSettings: JSON.stringify(loadSettings)}
+
+  hasProjectPath: -> @projectPath?.length > 0
 
   getInitialPath: ->
     @browserWindow.loadSettings.initialPath

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -25,9 +25,9 @@ class AtomWindow
     # Normalize to make sure drive letter case is consistent on Windows
     @resourcePath = path.normalize(@resourcePath) if @resourcePath
 
+    @browserWindow = new BrowserWindow show: false, title: 'Atom', icon: @constructor.iconPath
     global.atomApplication.addWindow(this)
 
-    @browserWindow = new BrowserWindow show: false, title: 'Atom', icon: @constructor.iconPath
     @handleEvents()
 
     loadSettings = _.extend({}, settings)

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -63,7 +63,14 @@ parseCommandLine = ->
   options.usage """
     Atom Editor v#{version}
 
-    Usage: atom [options] [file ...]
+    Usage: atom [options] [path ...]
+
+    One or more paths to files or folders to open may be specified.
+
+    File paths will open in the current window.
+
+    Folder paths will open in an existing window if that folder has already been
+    opened or a new window if it hasn't.
   """
   options.alias('d', 'dev').boolean('d').describe('d', 'Run in development mode.')
   options.alias('f', 'foreground').boolean('f').describe('f', 'Keep the browser process in the foreground.')

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -28,7 +28,9 @@ class WindowEventHandler
     @subscribe $(window), 'blur', -> document.body.classList.add('is-blurred')
 
     @subscribe $(window), 'window:open-path', (event, {pathToOpen, initialLine, initialColumn}) ->
-      unless fs.isDirectorySync(pathToOpen)
+      if fs.isDirectorySync(pathToOpen)
+        atom.project.setPath(pathToOpen) unless atom.project.getPath()
+      else
         atom.workspace?.open(pathToOpen, {initialLine, initialColumn})
 
     @subscribe $(window), 'beforeunload', =>


### PR DESCRIPTION
## Summary

Instead of opening file paths in a new window based on the file's parent directory, open file paths in the current window.

Also open folders in the current window when the current window doesn't already have a project path. This will affect untitled windows that were launched from the dock or by pressing `cmd-shift-N`.

You can still always force a new window from the command line by running `atom -n package.json` or `atom --new-window package.json`.

Multi-folder project support is still planned though via #770.
## File behavior changes
### Files opened using the `atom` command open in the currently focused window

![file-cli](https://cloud.githubusercontent.com/assets/671378/4016849/7fd61c08-2a39-11e4-830a-1feab5b7161c.gif)
### Dropping a file onto a window opens it in that window

![file-drop](https://cloud.githubusercontent.com/assets/671378/4016139/5a16e7de-2a31-11e4-8dfb-151f7b8c7dc1.gif)
### Selecting a file from the path chooser (cmd-o) opens that path in the current window

![file-open](https://cloud.githubusercontent.com/assets/671378/4016161/a415b130-2a31-11e4-9b30-34b494dda2e0.gif)
### Files dropped on the Mac OS X dock icon will open in the last focused window

![file-dock](https://cloud.githubusercontent.com/assets/671378/4016825/3a0815d2-2a39-11e4-939e-be6a3bd86e46.gif)
## Folder behavior changes
### Folders opened using the `atom` command will open in the currently focused window if it doesn't already have a project path

![folder-cli](https://cloud.githubusercontent.com/assets/671378/4016877/e013f6e4-2a39-11e4-806a-8bc004a0a567.gif)
### Dropping a folder onto an untitled window sets that window's project path to the dropped folder's path

![folder-drop](https://cloud.githubusercontent.com/assets/671378/4016898/2dbc2c36-2a3a-11e4-9000-464e11963ba6.gif)
### Selecting a folder from the path chooser (cmd-o) opens that folder in the current window if it doesn't already have a project path

![folder-open](https://cloud.githubusercontent.com/assets/671378/4016912/514a7522-2a3a-11e4-9197-38bdaf71fc5f.gif)

Closes #1722
