### PR TITLE
Dont handle ctrl+click mouse events on OSX

### DIFF
--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -610,6 +610,10 @@ EditorComponent = React.createClass
 
     {editor} = @props
     {detail, shiftKey, metaKey, ctrlKey} = event
+
+    # CTRL+click brings up the context menu on OSX, so don't handle those either
+    return if ctrlKey and process.platform is 'darwin'
+
     screenPosition = @screenPositionForMouseEvent(event)
 
     if event.target?.classList.contains('fold-marker')

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -375,6 +375,9 @@ class EditorView extends View
     @overlayer.on 'mousedown', (e) =>
       return unless e.which is 1 # only handle the left mouse button
 
+      # CTRL+click brings up the context menu on OSX, so don't handle those either
+      return if e.ctrlKey and process.platform is 'darwin'
+
       @overlayer.hide()
       clickedElement = document.elementFromPoint(e.pageX, e.pageY)
       @overlayer.show()


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/3308.

Ctrl+click on OSX brings up the context menu. In that case, handling the click event deselects any selection, and that shouldn't happen.

cc @nathansobo @benogle I don't have any better ideas about fixing these kinds of issues. If you have suggestions -- let me know.
