### PR TITLE
Only emit the marker-created event when the marker exists

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1037,6 +1037,19 @@ describe "DisplayBuffer", ->
         expect(start.top).toBe 5 * 20
         expect(start.left).toBe (4 * 10) + (6 * 11)
 
+    describe 'when there are multiple DisplayBuffers for a buffer', ->
+      describe 'when a marker is created', ->
+        it 'the second display buffer will not emit a marker-created event when the marker has been deleted in the first marker-created event', ->
+          displayBuffer2 = new DisplayBuffer({buffer, tabLength})
+          displayBuffer.on 'marker-created', markerCreated1 = jasmine.createSpy().andCallFake (marker) ->
+            marker.destroy()
+          displayBuffer2.on 'marker-created', markerCreated2 = jasmine.createSpy()
+
+          displayBuffer.markBufferRange([[0, 0], [1, 5]], {})
+
+          expect(markerCreated1).toHaveBeenCalled()
+          expect(markerCreated2).not.toHaveBeenCalled()
+
   describe "decorations", ->
     [marker, decoration, decorationParams] = []
     beforeEach ->

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -1097,7 +1097,10 @@ class DisplayBuffer extends Model
 
   handleBufferMarkerCreated: (marker) =>
     @createFoldForMarker(marker) if marker.matchesAttributes(@getFoldMarkerAttributes())
-    @emit 'marker-created', @getMarker(marker.id)
+    if displayBufferMarker = @getMarker(marker.id)
+      # The marker might have been removed in some other handler called before
+      # this one. Only emit when the marker still exists.
+      @emit 'marker-created', displayBufferMarker
 
   createFoldForMarker: (marker) ->
     @decorateMarker(marker, type: 'gutter', class: 'folded')


### PR DESCRIPTION
This caused problems in the case of find-and-replace:select-all with multiple editors into the same file. #3364
- a marker is created on the TextBuffer capturing the selection
- DisplayBuffer:create-marker is fired from the first DisplayBuffer. The marker is turned into a selection which is merged into the current selection, deleting the marker that was created.
- DisplayBuffer::handleBufferMarkerCreated is called on the second DisplayBuffer. The marker has been destroyed at this point, so it emits DisplayBuffer:create-marker with undefined. 
- ERROR

Closes #3364
