### PR TITLE
Use RxJS observables in workspace API

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-atom-fork": "^0.11.1",
     "reactionary-atom-fork": "^1.0.0",
     "runas": "1.0.1",
+    "rx": "^2.3.4",
     "scandal": "1.0.0",
     "scoped-property-store": "^0.9.0",
     "scrollbar-style": "^1.0.2",
@@ -109,7 +110,6 @@
     "welcome": "0.17.0",
     "whitespace": "0.25.0",
     "wrap-guide": "0.21.0",
-
     "language-c": "0.28.0",
     "language-coffee-script": "0.30.0",
     "language-css": "0.17.0",

--- a/spec/pane-container-spec.coffee
+++ b/spec/pane-container-spec.coffee
@@ -65,3 +65,17 @@ describe "PaneContainer", ->
       pane1.destroy()
       expect(container.getRoot()).toBe pane1
       expect(pane1.isDestroyed()).toBe false
+
+  describe "::getActivePane::observeActivePaneItem()", ->
+    it "tracks the active item of the active pane", ->
+      container = new PaneContainer(root: new Pane(items: [new Object]))
+      container.getRoot().splitRight(items: [new Object, new Object])
+      [pane1, pane2] = container.getPanes()
+
+      observed = []
+      container.observeActivePaneItem (item) -> observed.push(item)
+
+      pane2.activateNextItem()
+      pane1.activate()
+
+      expect(observed).toEqual [pane2.itemAtIndex(0), pane2.itemAtIndex(1), pane1.itemAtIndex(0)]

--- a/spec/pane-container-spec.coffee
+++ b/spec/pane-container-spec.coffee
@@ -66,7 +66,7 @@ describe "PaneContainer", ->
       expect(container.getRoot()).toBe pane1
       expect(pane1.isDestroyed()).toBe false
 
-  describe "::getActivePane::observeActivePaneItem()", ->
+  describe "::observeActivePaneItem()", ->
     it "tracks the active item of the active pane", ->
       container = new PaneContainer(root: new Pane(items: [new Object]))
       container.getRoot().splitRight(items: [new Object, new Object])

--- a/spec/pane-container-spec.coffee
+++ b/spec/pane-container-spec.coffee
@@ -26,8 +26,7 @@ describe "PaneContainer", ->
       expect(pane3B.isFocused()).toBe true
 
     it "preserves the active pane across serialization, independent of focus", ->
-      pane3A.activate()
-      expect(containerA.activePane).toBe pane3A
+      expect(containerA.getActivePane()).toBe pane3A
 
       containerB = containerA.testSerialization()
       [pane1B, pane2B, pane3B] = containerB.getPanes()

--- a/spec/pane-container-spec.coffee
+++ b/spec/pane-container-spec.coffee
@@ -23,7 +23,7 @@ describe "PaneContainer", ->
 
       containerB = containerA.testSerialization()
       [pane1B, pane2B, pane3B] = containerB.getPanes()
-      expect(pane3B.focused).toBe true
+      expect(pane3B.isFocused()).toBe true
 
     it "preserves the active pane across serialization, independent of focus", ->
       pane3A.activate()
@@ -31,38 +31,38 @@ describe "PaneContainer", ->
 
       containerB = containerA.testSerialization()
       [pane1B, pane2B, pane3B] = containerB.getPanes()
-      expect(containerB.activePane).toBe pane3B
+      expect(containerB.getActivePane()).toBe pane3B
 
-  describe "::activePane", ->
+  describe "::getActivePane()", ->
     [container, pane1, pane2] = []
 
     beforeEach ->
       container = new PaneContainer
-      pane1 = container.root
+      pane1 = container.getRoot()
 
-    it "references the first pane if no pane has been made active", ->
-      expect(container.activePane).toBe pane1
-      expect(pane1.active).toBe true
+    it "returns first pane if no pane has been explicitly activated", ->
+      expect(container.getActivePane()).toBe pane1
+      expect(pane1.isActive()).toBe true
 
-    it "references the most pane on which ::activate was most recently called", ->
+    it "returns the pane on which ::activate() was most recently called", ->
       pane2 = pane1.splitRight()
       pane2.activate()
-      expect(container.activePane).toBe pane2
-      expect(pane1.active).toBe false
-      expect(pane2.active).toBe true
+      expect(container.getActivePane()).toBe pane2
+      expect(pane1.isActive()).toBe false
+      expect(pane2.isActive()).toBe true
       pane1.activate()
-      expect(container.activePane).toBe pane1
-      expect(pane1.active).toBe true
-      expect(pane2.active).toBe false
+      expect(container.getActivePane()).toBe pane1
+      expect(pane1.isActive()).toBe true
+      expect(pane2.isActive()).toBe false
 
     it "is reassigned to the next pane if the current active pane is destroyed", ->
       pane2 = pane1.splitRight()
       pane2.activate()
       pane2.destroy()
-      expect(container.activePane).toBe pane1
-      expect(pane1.active).toBe true
+      expect(container.getActivePane()).toBe pane1
+      expect(pane1.isActive()).toBe true
 
     it "does not allow the root pane to be destroyed", ->
       pane1.destroy()
-      expect(container.root).toBe pane1
+      expect(container.getRoot()).toBe pane1
       expect(pane1.isDestroyed()).toBe false

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -28,6 +28,43 @@ describe "Pane", ->
       expect(pane.getItems().length).toBe 2
       expect(pane.getActiveItem()).toBe pane.itemAtIndex(0)
 
+  describe "::activate()", ->
+    [container, pane1, pane2] = []
+
+    beforeEach ->
+      container = new PaneContainer(root: new Pane(items: ["A"]))
+      container.getRoot().splitRight()
+      [pane1, pane2] = container.getPanes()
+
+    it "sets the active pane on the container", ->
+      expect(container.getActivePane()).toBe pane2
+      expect(pane1.isActive()).toBe false
+      expect(pane2.isActive()).toBe true
+      pane1.activate()
+      expect(container.getActivePane()).toBe pane1
+      expect(pane1.isActive()).toBe true
+      expect(pane2.isActive()).toBe false
+      pane2.activate()
+      expect(container.getActivePane()).toBe pane2
+      expect(pane1.isActive()).toBe false
+      expect(pane2.isActive()).toBe true
+
+    it "notifies ::observeActivePane subscribers on the container", ->
+      observed = []
+      container.observeActivePane (activePane) -> observed.push(activePane)
+
+      pane1.activate()
+      pane2.activate()
+      expect(observed).toEqual [pane2, pane1, pane2]
+
+    it "notifies ::observeActive subscribers on the pane", ->
+      observed = []
+      pane1.observeActive (active) -> observed.push(active)
+
+      pane1.activate()
+      pane2.activate()
+      expect(observed).toEqual [false, true, false]
+
   describe "::addItem(item, index)", ->
     it "adds the item at the given index", ->
       pane = new Pane(items: [new Item("A"), new Item("B")])
@@ -44,7 +81,7 @@ describe "Pane", ->
       pane.addItem(item4)
       expect(pane.getItems()).toEqual [item1, item2, item4, item3]
 
-    it "invokes ::onDidAddItem observers with the item and the index", ->
+    it "notifies ::onDidAddItem subscribers with the item and the index", ->
       events = []
       pane = new Pane
       item1 = new Item("A")
@@ -82,7 +119,7 @@ describe "Pane", ->
       expect(item in pane.getItems()).toBe true
       expect(pane.getActiveItem()).toBe item
 
-    it "invokes ::observeActiveItem observers with the active item", ->
+    it "notifies ::observeActiveItem subscribers with the active item", ->
       observed = []
       pane.observeActiveItem (activeItem) -> observed.push(activeItem)
       [item1, item2] = pane.getItems()

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -111,50 +111,50 @@ describe "Pane", ->
   describe "::activateItemAtIndex(index)", ->
     it "activates the item at the given index", ->
       pane = new Pane(items: [new Item("A"), new Item("B"), new Item("C")])
-      [item1, item2, item3] = pane.items
+      [item1, item2, item3] = pane.getItems()
       pane.activateItemAtIndex(2)
-      expect(pane.activeItem).toBe item3
+      expect(pane.getActiveItem()).toBe item3
       pane.activateItemAtIndex(1)
-      expect(pane.activeItem).toBe item2
+      expect(pane.getActiveItem()).toBe item2
       pane.activateItemAtIndex(0)
-      expect(pane.activeItem).toBe item1
+      expect(pane.getActiveItem()).toBe item1
 
       # Doesn't fail with out-of-bounds indices
       pane.activateItemAtIndex(100)
-      expect(pane.activeItem).toBe item1
+      expect(pane.getActiveItem()).toBe item1
       pane.activateItemAtIndex(-1)
-      expect(pane.activeItem).toBe item1
+      expect(pane.getActiveItem()).toBe item1
 
   describe "::destroyItem(item)", ->
     [pane, item1, item2, item3] = []
 
     beforeEach ->
       pane = new Pane(items: [new Item("A"), new Item("B"), new Item("C")])
-      [item1, item2, item3] = pane.items
+      [item1, item2, item3] = pane.getItems()
 
     it "removes the item from the items list", ->
-      expect(pane.activeItem).toBe item1
+      expect(pane.getActiveItem()).toBe item1
       pane.destroyItem(item2)
-      expect(item2 in pane.items).toBe false
-      expect(pane.activeItem).toBe item1
+      expect(item2 in pane.getItems()).toBe false
+      expect(pane.getActiveItem()).toBe item1
 
       pane.destroyItem(item1)
-      expect(item1 in pane.items).toBe false
+      expect(item1 in pane.getItems()).toBe false
 
     describe "when the destroyed item is the active item and is the first item", ->
       it "activates the next item", ->
-        expect(pane.activeItem).toBe item1
+        expect(pane.getActiveItem()).toBe item1
         pane.destroyItem(item1)
-        expect(pane.activeItem).toBe item2
+        expect(pane.getActiveItem()).toBe item2
 
     describe "when the destroyed item is the active item and is not the first item", ->
       beforeEach ->
         pane.activateItem(item2)
 
       it "activates the previous item", ->
-        expect(pane.activeItem).toBe item2
+        expect(pane.getActiveItem()).toBe item2
         pane.destroyItem(item2)
-        expect(pane.activeItem).toBe item1
+        expect(pane.getActiveItem()).toBe item1
 
     it "emits 'item-removed' with the item, its index, and true indicating the item is being destroyed", ->
       pane.on 'item-removed', itemRemovedHandler = jasmine.createSpy("itemRemovedHandler")
@@ -178,7 +178,7 @@ describe "Pane", ->
             pane.destroyItem(item1)
 
             expect(item1.save).toHaveBeenCalled()
-            expect(item1 in pane.items).toBe false
+            expect(item1 in pane.getItems()).toBe false
             expect(item1.isDestroyed()).toBe true
 
         describe "when the item has no uri", ->
@@ -191,7 +191,7 @@ describe "Pane", ->
 
             expect(atom.showSaveDialogSync).toHaveBeenCalled()
             expect(item1.saveAs).toHaveBeenCalledWith("/selected/path")
-            expect(item1 in pane.items).toBe false
+            expect(item1 in pane.getItems()).toBe false
             expect(item1.isDestroyed()).toBe true
 
       describe "if the [Don't Save] option is selected", ->
@@ -200,7 +200,7 @@ describe "Pane", ->
           pane.destroyItem(item1)
 
           expect(item1.save).not.toHaveBeenCalled()
-          expect(item1 in pane.items).toBe false
+          expect(item1 in pane.getItems()).toBe false
           expect(item1.isDestroyed()).toBe true
 
       describe "if the [Cancel] option is selected", ->
@@ -209,7 +209,7 @@ describe "Pane", ->
           pane.destroyItem(item1)
 
           expect(item1.save).not.toHaveBeenCalled()
-          expect(item1 in pane.items).toBe true
+          expect(item1 in pane.getItems()).toBe true
           expect(item1.isDestroyed()).toBe false
 
     describe "when the last item is destroyed", ->
@@ -218,7 +218,7 @@ describe "Pane", ->
           expect(atom.config.get('core.destroyEmptyPanes')).toBe false
           pane.destroyItem(item) for item in pane.getItems()
           expect(pane.isDestroyed()).toBe false
-          expect(pane.activeItem).toBeUndefined()
+          expect(pane.getActiveItem()).toBeUndefined()
           expect(-> pane.saveActiveItem()).not.toThrow()
           expect(-> pane.saveActiveItemAs()).not.toThrow()
 
@@ -231,10 +231,10 @@ describe "Pane", ->
   describe "::destroyActiveItem()", ->
     it "destroys the active item", ->
       pane = new Pane(items: [new Item("A"), new Item("B")])
-      activeItem = pane.activeItem
+      activeItem = pane.getActiveItem()
       pane.destroyActiveItem()
       expect(activeItem.isDestroyed()).toBe true
-      expect(activeItem in pane.items).toBe false
+      expect(activeItem in pane.getItems()).toBe false
 
     it "does not throw an exception if there are no more items", ->
       pane = new Pane
@@ -243,7 +243,7 @@ describe "Pane", ->
   describe "::destroyItems()", ->
     it "destroys all items", ->
       pane = new Pane(items: [new Item("A"), new Item("B"), new Item("C")])
-      [item1, item2, item3] = pane.items
+      [item1, item2, item3] = pane.getItems()
       pane.destroyItems()
       expect(item1.isDestroyed()).toBe true
       expect(item2.isDestroyed()).toBe true
@@ -253,14 +253,14 @@ describe "Pane", ->
   describe "when an item emits a destroyed event", ->
     it "removes it from the list of items", ->
       pane = new Pane(items: [new Item("A"), new Item("B"), new Item("C")])
-      [item1, item2, item3] = pane.items
+      [item1, item2, item3] = pane.getItems()
       pane.items[1].destroy()
       expect(pane.items).toEqual [item1, item3]
 
   describe "::destroyInactiveItems()", ->
     it "destroys all items but the active item", ->
       pane = new Pane(items: [new Item("A"), new Item("B"), new Item("C")])
-      [item1, item2, item3] = pane.items
+      [item1, item2, item3] = pane.getItems()
       pane.activateItem(item2)
       pane.destroyInactiveItems()
       expect(pane.items).toEqual [item2]
@@ -325,7 +325,7 @@ describe "Pane", ->
   describe "::itemForUri(uri)", ->
     it "returns the item for which a call to .getUri() returns the given uri", ->
       pane = new Pane(items: [new Item("A"), new Item("B"), new Item("C"), new Item("D")])
-      [item1, item2, item3] = pane.items
+      [item1, item2, item3] = pane.getItems()
       item1.uri = "a"
       item2.uri = "b"
       expect(pane.itemForUri("a")).toBe item1
@@ -335,7 +335,7 @@ describe "Pane", ->
   describe "::moveItem(item, index)", ->
     it "moves the item to the given index and emits an 'item-moved' event with the item and its new index", ->
       pane = new Pane(items: [new Item("A"), new Item("B"), new Item("C"), new Item("D")])
-      [item1, item2, item3, item4] = pane.items
+      [item1, item2, item3, item4] = pane.getItems()
       pane.on 'item-moved', itemMovedHandler = jasmine.createSpy("itemMovedHandler")
 
       pane.moveItem(item1, 2)
@@ -365,8 +365,8 @@ describe "Pane", ->
 
     it "moves the item to the given pane at the given index", ->
       pane1.moveItemToPane(item2, pane2, 1)
-      expect(pane1.items).toEqual [item1, item3]
-      expect(pane2.items).toEqual [item4, item2, item5]
+      expect(pane1.getItems()).toEqual [item1, item3]
+      expect(pane2.getItems()).toEqual [item4, item2, item5]
 
     describe "when the moved item the last item in the source pane", ->
       beforeEach ->
@@ -397,68 +397,68 @@ describe "Pane", ->
         it "replaces itself with a row and inserts a new pane to the left of itself", ->
           pane2 = pane1.splitLeft(items: ["B"])
           pane3 = pane1.splitLeft(items: ["C"])
-          expect(container.root.orientation).toBe 'horizontal'
-          expect(container.root.children).toEqual [pane2, pane3, pane1]
+          expect(container.getRoot().getOrientation()).toBe 'horizontal'
+          expect(container.getRoot().getChildren()).toEqual [pane2, pane3, pane1]
 
       describe "when the parent is a column", ->
         it "replaces itself with a row and inserts a new pane to the left of itself", ->
           pane1.splitDown()
           pane2 = pane1.splitLeft(items: ["B"])
           pane3 = pane1.splitLeft(items: ["C"])
-          row = container.root.children[0]
-          expect(row.orientation).toBe 'horizontal'
-          expect(row.children).toEqual [pane2, pane3, pane1]
+          row = container.getRoot().childAtIndex(0)
+          expect(row.getOrientation()).toBe 'horizontal'
+          expect(row.getChildren()).toEqual [pane2, pane3, pane1]
 
     describe "::splitRight(params)", ->
       describe "when the parent is the container root", ->
         it "replaces itself with a row and inserts a new pane to the right of itself", ->
           pane2 = pane1.splitRight(items: ["B"])
           pane3 = pane1.splitRight(items: ["C"])
-          expect(container.root.orientation).toBe 'horizontal'
-          expect(container.root.children).toEqual [pane1, pane3, pane2]
+          expect(container.getRoot().getOrientation()).toBe 'horizontal'
+          expect(container.getRoot().getChildren()).toEqual [pane1, pane3, pane2]
 
       describe "when the parent is a column", ->
         it "replaces itself with a row and inserts a new pane to the right of itself", ->
           pane1.splitDown()
           pane2 = pane1.splitRight(items: ["B"])
           pane3 = pane1.splitRight(items: ["C"])
-          row = container.root.children[0]
-          expect(row.orientation).toBe 'horizontal'
-          expect(row.children).toEqual [pane1, pane3, pane2]
+          row = container.getRoot().childAtIndex(0)
+          expect(row.getOrientation()).toBe 'horizontal'
+          expect(row.getChildren()).toEqual [pane1, pane3, pane2]
 
     describe "::splitUp(params)", ->
       describe "when the parent is the container root", ->
         it "replaces itself with a column and inserts a new pane above itself", ->
           pane2 = pane1.splitUp(items: ["B"])
           pane3 = pane1.splitUp(items: ["C"])
-          expect(container.root.orientation).toBe 'vertical'
-          expect(container.root.children).toEqual [pane2, pane3, pane1]
+          expect(container.getRoot().getOrientation()).toBe 'vertical'
+          expect(container.getRoot().getChildren()).toEqual [pane2, pane3, pane1]
 
       describe "when the parent is a row", ->
         it "replaces itself with a column and inserts a new pane above itself", ->
           pane1.splitRight()
           pane2 = pane1.splitUp(items: ["B"])
           pane3 = pane1.splitUp(items: ["C"])
-          column = container.root.children[0]
-          expect(column.orientation).toBe 'vertical'
-          expect(column.children).toEqual [pane2, pane3, pane1]
+          column = container.getRoot().childAtIndex(0)
+          expect(column.getOrientation()).toBe 'vertical'
+          expect(column.getChildren()).toEqual [pane2, pane3, pane1]
 
     describe "::splitDown(params)", ->
       describe "when the parent is the container root", ->
         it "replaces itself with a column and inserts a new pane below itself", ->
           pane2 = pane1.splitDown(items: ["B"])
           pane3 = pane1.splitDown(items: ["C"])
-          expect(container.root.orientation).toBe 'vertical'
-          expect(container.root.children).toEqual [pane1, pane3, pane2]
+          expect(container.getRoot().getOrientation()).toBe 'vertical'
+          expect(container.getRoot().getChildren()).toEqual [pane1, pane3, pane2]
 
       describe "when the parent is a row", ->
         it "replaces itself with a column and inserts a new pane below itself", ->
           pane1.splitRight()
           pane2 = pane1.splitDown(items: ["B"])
           pane3 = pane1.splitDown(items: ["C"])
-          column = container.root.children[0]
-          expect(column.orientation).toBe 'vertical'
-          expect(column.children).toEqual [pane1, pane3, pane2]
+          column = container.getRoot().childAtIndex(0)
+          expect(column.getOrientation()).toBe 'vertical'
+          expect(column.getChildren()).toEqual [pane1, pane3, pane2]
 
     it "activates the new pane", ->
       expect(pane1.isActive()).toBe true
@@ -471,12 +471,12 @@ describe "Pane", ->
 
     beforeEach ->
       container = new PaneContainer
-      pane1 = container.root
+      pane1 = container.getRoot()
       pane1.addItems([new Item("A"), new Item("B")])
       pane2 = pane1.splitRight()
 
     it "destroys the pane's destroyable items", ->
-      [item1, item2] = pane1.items
+      [item1, item2] = pane1.getItems()
       pane1.destroy()
       expect(item1.isDestroyed()).toBe true
       expect(item2.isDestroyed()).toBe true
@@ -499,12 +499,12 @@ describe "Pane", ->
       it "replaces the parent with its last remaining child", ->
         pane3 = pane2.splitDown()
 
-        expect(container.root.children[0]).toBe pane1
-        expect(container.root.children[1].children).toEqual [pane2, pane3]
+        expect(container.getRoot().childAtIndex(0)).toBe pane1
+        expect(container.getRoot().childAtIndex(1).getChildren()).toEqual [pane2, pane3]
         pane3.destroy()
-        expect(container.root.children).toEqual [pane1, pane2]
+        expect(container.getRoot().getChildren()).toEqual [pane1, pane2]
         pane2.destroy()
-        expect(container.root).toBe pane1
+        expect(container.getRoot()).toBe pane1
 
   describe "serialization", ->
     pane = null
@@ -514,12 +514,12 @@ describe "Pane", ->
 
     it "can serialize and deserialize the pane and all its items", ->
       newPane = pane.testSerialization()
-      expect(newPane.items).toEqual pane.items
+      expect(newPane.getItems()).toEqual pane.getItems()
 
     it "restores the active item on deserialization", ->
       pane.activateItemAtIndex(1)
       newPane = pane.testSerialization()
-      expect(newPane.activeItem).toEqual newPane.items[1]
+      expect(newPane.getActiveItem()).toEqual newPane.itemAtIndex(1)
 
     it "does not include items that cannot be deserialized", ->
       spyOn(console, 'warn')
@@ -527,10 +527,10 @@ describe "Pane", ->
       pane.activateItem(unserializable)
 
       newPane = pane.testSerialization()
-      expect(newPane.activeItem).toEqual pane.items[0]
-      expect(newPane.items.length).toBe pane.items.length - 1
+      expect(newPane.getActiveItem()).toEqual pane.itemAtIndex(0)
+      expect(newPane.getItems().length).toBe pane.getItems().length - 1
 
     it "includes the pane's focus state in the serialized state", ->
       pane.focus()
       newPane = pane.testSerialization()
-      expect(newPane.focused).toBe true
+      expect(newPane.isFocused()).toBe true

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -198,6 +198,13 @@ describe "Pane", ->
       pane.destroyItem(item2)
       expect(itemRemovedHandler).toHaveBeenCalledWith(item2, 1, true)
 
+    it "notifies ::onDidRemoveItem observers", ->
+      events = []
+      pane.onDidRemoveItem (event) -> events.push(event)
+
+      pane.destroyItem(item2)
+      expect(events).toEqual [{item: item2, index: 1, destroyed: true}]
+
     describe "if the item is modified", ->
       itemUri = null
 

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -65,6 +65,15 @@ describe "Pane", ->
       pane2.activate()
       expect(observed).toEqual [false, true, false]
 
+    it "notifies ::onDidActivate subscribers on the pane", ->
+      eventCount = 0
+      pane1.onDidActivate -> eventCount++
+
+      pane1.activate()
+      pane2.activate()
+      pane1.activate()
+      expect(eventCount).toBe 2
+
   describe "::addItem(item, index)", ->
     it "adds the item at the given index", ->
       pane = new Pane(items: [new Item("A"), new Item("B")])
@@ -198,7 +207,7 @@ describe "Pane", ->
       pane.destroyItem(item2)
       expect(itemRemovedHandler).toHaveBeenCalledWith(item2, 1, true)
 
-    it "notifies ::onDidRemoveItem observers", ->
+    it "notifies ::onDidRemoveItem subscribers", ->
       events = []
       pane.onDidRemoveItem (event) -> events.push(event)
 
@@ -396,7 +405,7 @@ describe "Pane", ->
       expect(pane.getItems()).toEqual [item3, item2, item1, item4]
       expect(itemMovedHandler).toHaveBeenCalledWith(item2, 1)
 
-    it "notifies ::onDidMoveItem observers with the item and its old and new indices", ->
+    it "notifies ::onDidMoveItem subscribers with the item and its old and new indices", ->
       pane = new Pane(items: [new Item("A"), new Item("B"), new Item("C"), new Item("D")])
       [item1, item2, item3, item4] = pane.getItems()
       events = []

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -207,6 +207,13 @@ describe "Pane", ->
       pane.destroyItem(item2)
       expect(itemRemovedHandler).toHaveBeenCalledWith(item2, 1, true)
 
+    it "notifies ::onWillDestroyItem subscribers", ->
+      events = []
+      pane.onWillDestroyItem (event) -> events.push(event)
+
+      pane.destroyItem(item2)
+      expect(events).toEqual [{item: item2}]
+
     it "notifies ::onDidRemoveItem subscribers", ->
       events = []
       pane.onDidRemoveItem (event) -> events.push(event)

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -458,6 +458,26 @@ describe "Pane", ->
           expect(pane2.isDestroyed()).toBe true
           expect(item4.isDestroyed()).toBe false
 
+  describe "::observeItems()", ->
+    it "invokes subscribers with all current and future items", ->
+      observed = []
+
+      pane = new Pane(items: [new Item("A"), new Item("B")])
+      [item1, item2] = pane.getItems()
+      item3 = new Item("C")
+      item4 = new Item("D")
+
+      subscription = pane.observeItems (item) -> observed.push(item)
+      expect(observed).toEqual [item1, item2]
+
+      pane.addItem(item3)
+      expect(observed).toEqual [item1, item2, item3]
+
+      console.log subscription
+      subscription.dispose()
+      pane.addItem(item4)
+      expect(observed).toEqual [item1, item2, item3]
+
   describe "split methods", ->
     [pane1, container] = []
 

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -396,6 +396,19 @@ describe "Pane", ->
       expect(pane.getItems()).toEqual [item3, item2, item1, item4]
       expect(itemMovedHandler).toHaveBeenCalledWith(item2, 1)
 
+    it "notifies ::onDidMoveItem observers with the item and its old and new indices", ->
+      pane = new Pane(items: [new Item("A"), new Item("B"), new Item("C"), new Item("D")])
+      [item1, item2, item3, item4] = pane.getItems()
+      events = []
+      pane.onDidMoveItem (event) -> events.push(event)
+
+      pane.moveItem(item1, 2)
+      pane.moveItem(item2, 3)
+      expect(events).toEqual [
+        {item: item1, oldIndex: 0, newIndex: 2}
+        {item: item2, oldIndex: 0, newIndex: 3}
+      ]
+
   describe "::moveItemToPane(item, pane, index)", ->
     [container, pane1, pane2] = []
     [item1, item2, item3, item4, item5] = []

--- a/src/array-subject.coffee
+++ b/src/array-subject.coffee
@@ -1,0 +1,15 @@
+Rx = require 'rx'
+
+module.exports =
+class ArraySubject extends Rx.Observable
+  constructor: (@array) ->
+    @observers = []
+    super (observer) ->
+      observer.onNext(element) for element in @array.slice()
+      @observers.push(observer)
+      Rx.Disposable.create =>
+        @observers.splice(@observers.indexOf(observer), 1)
+
+  onNext: (element) ->
+    for observer in @observers.slice()
+      observer.onNext(element)

--- a/src/pane-axis.coffee
+++ b/src/pane-axis.coffee
@@ -10,12 +10,15 @@ class PaneAxis extends Model
   atom.deserializers.add(this)
   Serializable.includeInto(this)
 
+  parent: null
+  container: null
+
   constructor: ({@container, @orientation, children}) ->
     @children = Sequence.fromArray(children ? [])
 
     @subscribe @children.onEach (child) =>
-      child.parent = this
-      child.container = @container
+      child.setParent(this)
+      child.setContainer(@container)
       @subscribe child, 'destroyed', => @removeChild(child)
 
     @subscribe @children.onRemoval (child) => @unsubscribe(child)
@@ -31,6 +34,14 @@ class PaneAxis extends Model
   serializeParams: ->
     children: @children.map (child) -> child.serialize()
     orientation: @orientation
+
+  getParent: -> @parent
+
+  setParent: (@parent) -> @parent
+
+  getContainer: -> @container
+
+  setContainer: (@container) -> @container
 
   getOrientation: -> @orientation
 

--- a/src/pane-axis.coffee
+++ b/src/pane-axis.coffee
@@ -58,9 +58,6 @@ class PaneAxis extends Model
   getPanes: ->
     flatten(@children.map (child) -> child.getPanes())
 
-  addChild: (child, index=@children.length) ->
-    @children.splice(index, 0, child)
-
   removeChild: (child) ->
     index = @children.indexOf(child)
     throw new Error("Removing non-existent child") if index is -1

--- a/src/pane-axis.coffee
+++ b/src/pane-axis.coffee
@@ -32,6 +32,12 @@ class PaneAxis extends Model
     children: @children.map (child) -> child.serialize()
     orientation: @orientation
 
+  getOrientation: -> @orientation
+
+  getChildren: -> @children.slice()
+
+  childAtIndex: (index) -> @children[index]
+
   getViewClass: ->
     if @orientation is 'vertical'
       PaneColumnView ?= require './pane-column-view'

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -36,6 +36,8 @@ class PaneContainer extends Model
     root: @root?.serialize()
     activePaneId: @activePane.id
 
+  getRoot: -> @root
+
   replaceChild: (oldChild, newChild) ->
     throw new Error("Replacing non-existent child") if oldChild isnt @root
     @root = newChild

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -98,7 +98,7 @@ class PaneContainer extends Model
     root.setParent(this)
     root.setContainer(this)
 
-    @activePane ?= root if root instanceof Pane
+    @setActivePane(root) if not @activePane? and root instanceof Pane
 
   destroyEmptyPanes: ->
     pane.destroy() for pane in @getPanes() when pane.items.length is 0

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -95,9 +95,8 @@ class PaneContainer extends Model
       @setActivePane(null)
       return
 
-    root.parent = this
-    root.container = this
-
+    root.setParent(this)
+    root.setContainer(this)
 
     @activePane ?= root if root instanceof Pane
 

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -16,6 +16,7 @@ class PaneContainer extends Model
     activePane: null
 
   previousRoot: null
+  activePaneItemObservable: null
 
   @behavior 'activePaneItem', ->
     @$activePane
@@ -59,6 +60,14 @@ class PaneContainer extends Model
       @activePaneSubject.subscribe(fn)
     else
       @activePaneSubject
+
+  observeActivePaneItem: (fn) ->
+    @activePaneItemObservable ?=
+      @observeActivePane().flatMapLatest (activePane) -> activePane.observeActiveItem()
+    if fn?
+      @activePaneItemObservable.subscribe(fn)
+    else
+      @activePaneItemObservable
 
   paneForUri: (uri) ->
     find @getPanes(), (pane) -> pane.itemForUri(uri)?

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -1,6 +1,7 @@
 {find} = require 'underscore-plus'
 {Model} = require 'theorist'
 Serializable = require 'serializable'
+Rx = require 'rx'
 Pane = require './pane'
 
 module.exports =
@@ -45,8 +46,19 @@ class PaneContainer extends Model
   getPanes: ->
     @root?.getPanes() ? []
 
+  setActivePane: (@activePane) ->
+    @activePaneSubject?.onNext(@activePane)
+    @activePane
+
   getActivePane: ->
     @activePane
+
+  observeActivePane: (fn) ->
+    @activePaneSubject ?= new Rx.BehaviorSubject(@getActivePane())
+    if fn?
+      @activePaneSubject.subscribe(fn)
+    else
+      @activePaneSubject
 
   paneForUri: (uri) ->
     find @getPanes(), (pane) -> pane.itemForUri(uri)?
@@ -80,7 +92,7 @@ class PaneContainer extends Model
     @previousRoot = root
 
     unless root?
-      @activePane = null
+      @setActivePane(null)
       return
 
     root.parent = this

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -21,6 +21,7 @@ class Pane extends Model
 
   onDidAddItemSubject: null
   onDidRemoveItemSubject: null
+  onDidMoveItemSubject: null
   activeItemSubject: null
   activeObservable: null
 
@@ -199,6 +200,7 @@ class Pane extends Model
     @items.splice(oldIndex, 1)
     @items.splice(newIndex, 0, item)
     @emit 'item-moved', item, newIndex
+    @onDidMoveItemSubject?.onNext({item, oldIndex, newIndex})
 
   # Public: Moves the given item to the given index at another pane.
   moveItemToPane: (item, pane, index) ->
@@ -398,6 +400,13 @@ class Pane extends Model
       @onDidRemoveItemSubject.subscribe(fn)
     else
       @onDidRemoveItemSubject
+
+  onDidMoveItem: (fn) ->
+    @onDidMoveItemSubject ?= new Rx.Subject
+    if fn?
+      @onDidMoveItemSubject.subscribe(fn)
+    else
+      @onDidMoveItemSubject
 
   observeActiveItem: (fn) ->
     @activeItemSubject ?= new Rx.BehaviorSubject(@getActiveItem())

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -60,6 +60,8 @@ class Pane extends Model
 
   isActive: -> @active
 
+  isFocused: -> @focused
+
   # Called by the view layer to indicate that the pane has gained focus.
   focus: ->
     @focused = true

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -4,6 +4,7 @@ Serializable = require 'serializable'
 Rx = require 'rx'
 PaneAxis = require './pane-axis'
 Editor = require './editor'
+ArraySubject = require './array-subject'
 PaneView = null
 
 # Public: A container for multiple items, one of which is *active* at a given
@@ -26,6 +27,7 @@ class Pane extends Model
   onDidMoveItemSubject: null
   onWillDestroyItemSubject: null
   activeItemSubject: null
+  itemsSubject: null
   activeObservable: null
 
   # Public: Only one pane is considered *active* at a time. A pane is activated
@@ -111,6 +113,13 @@ class Pane extends Model
   getItems: ->
     @items.slice()
 
+  observeItems: (fn) ->
+    @itemsSubject ?= new ArraySubject(@items)
+    if fn?
+      @itemsSubject.subscribe(fn)
+    else
+      @itemsSubject
+
   # Public: Get the active pane item in this pane.
   #
   # Returns a pane item.
@@ -172,6 +181,7 @@ class Pane extends Model
 
     @items.splice(index, 0, item)
     @onDidAddItemSubject?.onNext({item, index})
+    @itemsSubject?.onNext(item)
     @emit 'item-added', item, index
     @setActiveItem(item) unless @getActiveItem()?
     item

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -15,9 +15,11 @@ class Pane extends Model
   Serializable.includeInto(this)
 
   @properties
-    container: undefined
     activeItem: undefined
     focused: false
+
+  parent: null
+  container: null
 
   onDidAddItemSubject: null
   onDidRemoveItemSubject: null
@@ -64,6 +66,14 @@ class Pane extends Model
 
   # Called by the view layer to construct a view for this model.
   getViewClass: -> PaneView ?= require './pane-view'
+
+  getParent: -> @parent
+
+  setParent: (@parent) -> @parent
+
+  getContainer: -> @container
+
+  setContainer: (@container) -> @container
 
   isActive: -> @container?.getActivePane() is this
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -191,7 +191,7 @@ class Pane extends Model
         @activatePreviousItem()
     @items.splice(index, 1)
     @emit 'item-removed', item, index, destroyed
-    @onDidRemoveItemSubject.onNext {item, index, destroyed}
+    @onDidRemoveItemSubject?.onNext {item, index, destroyed}
     @container?.itemDestroyed(item) if destroyed
     @destroy() if @items.length is 0 and atom.config.get('core.destroyEmptyPanes')
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -58,7 +58,7 @@ class Pane extends Model
   # Called by the view layer to construct a view for this model.
   getViewClass: -> PaneView ?= require './pane-view'
 
-  isActive: -> @active
+  isActive: -> @container?.getActivePane() is this
 
   isFocused: -> @focused
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -15,11 +15,11 @@ class Pane extends Model
   Serializable.includeInto(this)
 
   @properties
+    container: null
     activeItem: undefined
     focused: false
 
   parent: null
-  container: null
 
   onDidAddItemSubject: null
   onDidRemoveItemSubject: null

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -90,6 +90,7 @@ class Pane extends Model
   activate: ->
     @container?.setActivePane(this)
     @emit 'activated'
+    @onDidActivateSubject?.onNext()
 
   getPanes: -> [this]
 
@@ -386,6 +387,13 @@ class Pane extends Model
         rightmostSibling
     else
       @splitRight()
+
+  onDidActivate: (fn) ->
+    @onDidActivateSubject ?= new Rx.Subject
+    if fn?
+      @onDidActivateSubject.subscribe(fn)
+    else
+      @onDidActivateSubject
 
   onDidAddItem: (fn) ->
     @onDidAddItemSubject ?= new Rx.Subject

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -22,6 +22,7 @@ class Pane extends Model
   onDidAddItemSubject: null
   onDidRemoveItemSubject: null
   onDidMoveItemSubject: null
+  onWillDestroyItemSubject: null
   activeItemSubject: null
   activeObservable: null
 
@@ -218,6 +219,7 @@ class Pane extends Model
   destroyItem: (item) ->
     if item?
       @emit 'before-item-destroyed', item
+      @onWillDestroyItemSubject?.onNext({item})
       if @promptToSaveItem(item)
         @removeItem(item, true)
         item.destroy?()
@@ -415,6 +417,13 @@ class Pane extends Model
       @onDidMoveItemSubject.subscribe(fn)
     else
       @onDidMoveItemSubject
+
+  onWillDestroyItem: (fn) ->
+    @onWillDestroyItemSubject ?= new Rx.Subject
+    if fn?
+      @onWillDestroyItemSubject.subscribe(fn)
+    else
+      @onWillDestroyItemSubject
 
   observeActiveItem: (fn) ->
     @activeItemSubject ?= new Rx.BehaviorSubject(@getActiveItem())


### PR DESCRIPTION
## Abstract

We have many situations where we need to subscribe to streams of events, such as discrete events like `did-insert-text`, properties with values that change over time, and collections with contents that change over time. The concept of _observables_ unifies all these callback-oriented patterns in a single compositional framework. The [RxJS](https://github.com/Reactive-Extensions/RxJS) library provides a mature and full-featured implementation of the observables concept, and I'd like to try using it in workspace. If it works well, we can consider using it for our events across the board.
## Tasks
- [ ] Benchmark to make sure overhead is acceptable in simple use cases
- [ ] :wrench: Replace workspace events with `::onX` methods that return observables
- [ ] :wrench: Replace workspace behaviors with `::observeX` that return observables
- [ ] Replace workspace `::eachX` methods with `::observeX` methods
## Description
### Events

We currently implement events via emissary's `Emitter` mixin. In the following example, we use `::on` to subscribe to all changes and `::once` to subscribe to the next change. Both methods return subscriptions which can be disposed with

``` coffee
subscription = editor.on 'text-did-change', -> # ...
subscription = editor.once 'text-did-change', -> # ...
```

Subscribing to events with strings is fragile and difficult to document, shim, and deprecate. We've discussed changing the API to use methods instead, such as `::onTextDidChange`, but there were concerns about losing `::once`. Returning an Rx observable gives us the ability to use `::once` semantics and also ton more.

Our `::on*` methods can be overloaded, so they subscribe if passed a callback and return an observable if no callback is passed.

``` coffee
# If a callback is passed, subscribe as normal
subscription = editor.onTextDidChange -> # ...

# If no callback is passed, return an observable
observable = editor.onTextDidChange()

# You can subscribe to observables
subscription = observable.subscribe -> # ...

# But you can also apply operators, such as `::take`.
# This is equivalent to `::once` from the example above.
subscription = observable.take(1).subscribe -> # ...

# You can also apply other operators, such as `::throttle`
# Here we will not handle text changes more often than once per 500ms
subscription = editor.onTextDidChange().throttle(500).subscribe -> # ...
```
### Properties That Change

In addition to events, we also need to track values that change over time. Observables are a great tool for this as well, and could replace `emissary` behaviors. For any model property `foo`, we could have an `observeFoo` method along with `getFoo` and `setFoo`. This would return an observable based on the current value of the property. Whenever someone subscribed, the `onNext` callback would be called immediately with the current value, then again whenever the value changed.

``` coffee
# Just like with `::on*` methods, `::observe*` can be passed a callback.
subscription = pane.observeActiveItem -> # ...

# Observe methods return an observable when called without a callback.
observable = pane.observeActiveItem()
subscription = observable.subscribe -> # ...

# If you only want changes and not the current value, skip it
# This is similar to passing `callNow: false` to config.observe,
# and could replace it
subscription = pane.observeActiveItem().skip(1).subscribe(@onActiveItemChanged)
```

Compositional operators can also be used to derive more advanced behaviors, such as `PaneContainer::observeActivePaneItem`, which will be based on the active item of the active pane.

``` coffee
class Workspace
  observeActivePaneItem: ->
    @observeActivePane().selectSwitch (activePane) ->
      activePane.observeActiveItem()
```
### Collections That Change

In addition to properties that change, we also deal with collections that change, such as the current panes, pane items, text editors, etc. These can also be modeled as observables. In the following example, `::observePanes` returns an observable that yields every current and future pane to observers.

``` coffee
# Can be called with a callback to subscribe immediately
subscription = atom.workspace.observePanes -> # ...

# When called without a callback, returns an observable
subscription = atom.workspace.observePanes().subscribe -> # ...
```

Again, the compositional nature of observables allows us to easily build derived collections, such as a collection based on all pane items.

``` coffee
class Workspace
  observePaneItems: ->
    @observePanes().flatMap (pane) -> pane.observeItems()
```

Such a method could filter on optional type selectors, allowing you to observe only a certain subset of panes.

``` coffee
class Workspace
  observeTextEditors: ->
    @observePaneItems('.text, .source')

  # The filter step would probably go in Pane::observeItems, but this
  # illustrates the concept.
  observePaneItems: (selector) ->
    @observePanes().flatMap (pane) ->
      pane.observeItems().filter (item) ->
        item.getTypeDescriptor?().matches(selector)
```
### Conclusion

RxJS provides a rich, seemingly mature library for working with streaming data in a compositional manner. We can utilize it in the following scenarios:
- For events, by adding `::onFoo` methods that return an observable when they aren't passed a callback.
- For changing properties and collections, by adding `::observeFoo` methods that return observables that invoke subscribers with current and future values.

It seems worth exploring as a robust solution to event handling in Atom that can slot in next to simpler approaches.
