### PR TITLE
Add spec task on Linux

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -60,7 +60,7 @@ module.exports = (grunt) ->
     contentsDir = shellAppDir
     appDir = path.join(shellAppDir, 'resources', 'app')
     installDir ?= process.env.INSTALL_PREFIX ? '/usr/local'
-    killCommand ='pkill -9 Atom'
+    killCommand ='pkill -9 atom'
 
   coffeeConfig =
     glob_to_multiple:

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -25,6 +25,9 @@ module.exports = (grunt) ->
     resourcePath = process.cwd()
     appPath = getAppPath()
 
+    # Ensure application is executable on Linux
+    fs.chmodSync(appPath, '755') if process.platform is 'linux'
+
     packageSpecQueue = async.queue (packagePath, callback) ->
       if process.platform in ['darwin', 'linux']
         options =


### PR DESCRIPTION
Get `script/grunt test` running on Linux.

Closes #2273 
Refs #3312
