### PR TITLE
Add cut/copy/paste built-in context menu items

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -192,3 +192,9 @@
     ]
   }
 ]
+
+'context-menu':
+  '.overlayer':
+    'Cut': 'core:cut'
+    'Copy': 'core:copy'
+    'Paste': 'core:paste'

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -195,6 +195,10 @@
 
 'context-menu':
   '.overlayer':
+    'Undo': 'core:undo'
+    'Redo': 'core:redo'
     'Cut': 'core:cut'
     'Copy': 'core:copy'
     'Paste': 'core:paste'
+    'Delete': 'core:delete'
+    'Select All': 'core:select-all'

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -148,6 +148,10 @@
 
 'context-menu':
   '.overlayer':
+    'Undo': 'core:undo'
+    'Redo': 'core:redo'
     'Cut': 'core:cut'
     'Copy': 'core:copy'
     'Paste': 'core:paste'
+    'Delete': 'core:delete'
+    'Select All': 'core:select-all'

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -145,3 +145,9 @@
     ]
   }
 ]
+
+'context-menu':
+  '.overlayer':
+    'Cut': 'core:cut'
+    'Copy': 'core:copy'
+    'Paste': 'core:paste'

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -172,6 +172,10 @@
 
 'context-menu':
   '.overlayer':
+    'Undo': 'core:undo'
+    'Redo': 'core:redo'
     'Cut': 'core:cut'
     'Copy': 'core:copy'
     'Paste': 'core:paste'
+    'Delete': 'core:delete'
+    'Select All': 'core:select-all'

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -169,3 +169,9 @@
     ]
   }
 ]
+
+'context-menu':
+  '.overlayer':
+    'Cut': 'core:cut'
+    'Copy': 'core:copy'
+    'Paste': 'core:paste'

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -6,7 +6,7 @@ describe "ContextMenuManager", ->
   [contextMenu] = []
 
   beforeEach ->
-    resourcePath = atom.getLoadSettings().resourcePath
+    {resourcePath} = atom.getLoadSettings()
     contextMenu = new ContextMenuManager({resourcePath})
 
   describe "adding definitions", ->

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -6,7 +6,8 @@ describe "ContextMenuManager", ->
   [contextMenu] = []
 
   beforeEach ->
-    contextMenu = new ContextMenuManager
+    resourcePath = atom.getLoadSettings().resourcePath
+    contextMenu = new ContextMenuManager({resourcePath})
 
   describe "adding definitions", ->
     it 'loads',  ->

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -159,7 +159,7 @@ class Atom extends Model
     @keymap = @keymaps # Deprecated
     @packages = new PackageManager({devMode, configDirPath, resourcePath, safeMode})
     @themes = new ThemeManager({packageManager: @packages, configDirPath, resourcePath, safeMode})
-    @contextMenu = new ContextMenuManager(devMode)
+    @contextMenu = new ContextMenuManager({resourcePath, devMode})
     @menu = new MenuManager({resourcePath})
     @clipboard = new Clipboard()
 

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -1,6 +1,9 @@
 {$} = require './space-pen-extensions'
 _ = require 'underscore-plus'
 remote = require 'remote'
+path = require 'path'
+CSON = require 'season'
+fs = require 'fs-plus'
 
 # Public: Provides a registry for commands that you'd like to appear in the
 # context menu.
@@ -9,7 +12,7 @@ remote = require 'remote'
 # global.
 module.exports =
 class ContextMenuManager
-  constructor: (@devMode=false) ->
+  constructor: ({@resourcePath, @devMode}) ->
     @definitions = {}
     @devModeDefinitions = {}
     @activeElement = null
@@ -20,6 +23,14 @@ class ContextMenuManager
       executeAtBuild: (e) ->
         @commandOptions = x: e.pageX, y: e.pageY
     ]
+
+    atom.keymaps.on 'bundled-keymaps-loaded', => @loadPlatformItems()
+
+  loadPlatformItems: ->
+    menusDirPath = path.join(@resourcePath, 'menus')
+    platformMenuPath = fs.resolve(menusDirPath, process.platform, ['cson', 'json'])
+    map = CSON.readFileSync(platformMenuPath)
+    atom.contextMenu.add(platformMenuPath, map['context-menu'])
 
   # Public: Creates menu definitions from the object specified by the menu
   # cson API.


### PR DESCRIPTION
Closes https://github.com/atom/atom/issues/1638

This change allows built-in context menu commands to be defined in Atom's menu config files (096255f) and adds the core copy/cut/paste commands to the context menu (776a8e9).

The built-in context menu commands are defined in the same way as they are in packages -- there's a `context-menu` key, and commands scoped to a selector. 

Here's the menu in action:

![copy](https://cloud.githubusercontent.com/assets/38924/4059313/487fc4fe-2de3-11e4-8a47-699219c332ab.gif)

cc @kevinsawicki for :eyes: 
