### PR TITLE
Added missing keybind in linux.cson.

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -14,6 +14,7 @@
   'F11': 'window:toggle-full-screen'
 
   # Sublime Parity
+  'ctrl-,': 'application:show-settings'
   'ctrl-N': 'application:new-window'
   'ctrl-W': 'window:close'
   'ctrl-o': 'application:open-file'


### PR DESCRIPTION
`'ctrl-,': 'application:show-settings'` exists in `win32.cson` and `darwin32.cson`, it makes sense to exist in `linux.cson` too.

Question is how are the menu bars updated? 

It updates fine if the above keybind is in the user's keymap.cson, but it doesn't update if it's in linux.cson. (done after rebuild/reinstall) 

**Unrelated to pull request**:

Suggestion: `ctrl-alt-o` should be binded to `application:open-folder`. It's useful and many people will benefit from having this by default.

Discussion: however, _ctrl-alt_ doesn't make the most sense, _ctrl-shift_ does. As we (kind of) want to open multiple files (implicitly a folder) and that's usually what _shift_ key is related to. However, `'ctrl-shift-o': 'application:open-dev'` and `'ctrl-shift-i': 'window:toggle-dev-tools'` exist already. 

If we really want to use `ctrl-shift-o` as open folder, it wouldn't make the most sense to have `ctrl-shift-i` as dev tools. We must change both _open-dev_ and _toggle-dev-tools_ to be combined with _alt_ instead of _shift_. What do you think of this?
