### PR TITLE
Added linux open-folder keybind.

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -10,7 +10,8 @@
   'ctrl-shift-i': 'window:toggle-dev-tools'
   'ctrl-alt-p': 'window:run-package-specs'
   'ctrl-alt-s': 'application:run-all-specs'
-  'ctrl-shift-o': 'application:open-dev'
+  'ctrl-alt-o': 'application:open-dev'
+  'ctrl-shift-o': 'application:open-folder'
   'F11': 'window:toggle-full-screen'
 
   # Sublime Parity


### PR DESCRIPTION
Moved `application:open-dev` to _ctrl-alt-o_.

Now, should `window:toggle-dev-tools` remain on _ctrl-shift-i_ or be moved to _ctrl-alt-i_, which would make more sense if other dev keybinds are combined with alt.

![dev_tools](https://cloud.githubusercontent.com/assets/6031925/4074658/1bc1b2bc-2ea4-11e4-8c42-7f7b7f0db67e.png)
Note: in the screenshot, Atom isn't prebuilded yet.
