### PR TITLE
Show Tree View when opening a folder path

### DIFF
--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -30,6 +30,9 @@ class WindowEventHandler
     @subscribe $(window), 'window:open-path', (event, {pathToOpen, initialLine, initialColumn}) ->
       if fs.isDirectorySync(pathToOpen)
         atom.project.setPath(pathToOpen) unless atom.project.getPath()
+        treeView = atom.workspaceView?.find(".tree-view").view()
+        if not treeView? or treeView.is(':hidden')
+          atom.workspaceView.trigger 'tree-view:toggle'
       else
         atom.workspace?.open(pathToOpen, {initialLine, initialColumn})
 


### PR DESCRIPTION
When opening a folder path, it seems logical that the tree view should always show since the usual next step would be to open a file within that folder. Showing it automatically saves a step of manually toggling the tree view open. Atom already auto-showed the tree view when opening a folder path in a new window, but it wasn't when opening a folder path in an existing window.

![show-tree-view](https://cloud.githubusercontent.com/assets/944302/4080588/fc77024a-2edf-11e4-8c5d-4f80c7f156b7.gif)
