### PR TITLE
Don’t merge adjacent non-empty selections

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "serializable": "^1",
     "space-pen": "3.4.6",
     "temp": "0.7.0",
-    "text-buffer": "^3.0.4",
+    "text-buffer": "^3.1.0",
     "theorist": "^1.0.2",
     "underscore-plus": "^1.5.1",
     "vm-compatibility-layer": "0.1.0"

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -881,14 +881,13 @@ describe "Editor", ->
         [selection1, selection2] = editor.getSelections()
 
         editor.selectUp()
-
         expect(editor.getSelections().length).toBe 1
         expect(editor.getSelections()).toEqual [selection1]
         expect(selection1.getScreenRange()).toEqual([[0, 0], [1, 20]])
         expect(selection1.isReversed()).toBeTruthy()
 
       it "merges selections when they intersect when moving left", ->
-        editor.setSelectedBufferRanges([[[0,9], [0,13]], [[0,14], [1,20]]], reversed: true)
+        editor.setSelectedBufferRanges([[[0,9], [0,13]], [[0,13], [1,20]]], reversed: true)
         [selection1, selection2] = editor.getSelections()
 
         editor.selectLeft()
@@ -897,7 +896,7 @@ describe "Editor", ->
         expect(selection1.isReversed()).toBeTruthy()
 
       it "merges selections when they intersect when moving right", ->
-        editor.setSelectedBufferRanges([[[0,9], [0,13]], [[0,14], [1,20]]])
+        editor.setSelectedBufferRanges([[[0,9], [0,14]], [[0,14], [1,20]]])
         [selection1, selection2] = editor.getSelections()
 
         editor.selectRight()
@@ -1209,6 +1208,10 @@ describe "Editor", ->
       it "merges intersecting selections", ->
         editor.setSelectedBufferRanges([[[2, 2], [3, 3]], [[3, 0], [5, 5]]])
         expect(editor.getSelectedBufferRanges()).toEqual [[[2, 2], [5, 5]]]
+
+      it "does not merge non-empty adjacent selections", ->
+        editor.setSelectedBufferRanges([[[2, 2], [3, 3]], [[3, 3], [5, 5]]])
+        expect(editor.getSelectedBufferRanges()).toEqual [[[2, 2], [3, 3]], [[3, 3], [5, 5]]]
 
       it "recyles existing selection instances", ->
         selection = editor.getSelection()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -2097,7 +2097,11 @@ class Editor extends Model
       @suppressSelectionMerging = false
 
     reducer = (disjointSelections, selection) ->
-      intersectingSelection = _.find(disjointSelections, (s) -> s.intersectsWith(selection))
+      intersectingSelection = _.find disjointSelections, (otherSelection) ->
+        exclusive = not selection.isEmpty() and not otherSelection.isEmpty()
+        intersects = otherSelection.intersectsWith(selection, exclusive)
+        intersects
+
       if intersectingSelection?
         intersectingSelection.merge(selection, options)
         disjointSelections

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -629,8 +629,8 @@ class Selection extends Model
   # * `otherSelection` A {Selection} to check against.
   #
   # Returns a {Boolean}
-  intersectsWith: (otherSelection) ->
-    @getBufferRange().intersectsWith(otherSelection.getBufferRange())
+  intersectsWith: (otherSelection, exclusive) ->
+    @getBufferRange().intersectsWith(otherSelection.getBufferRange(), exclusive)
 
   # Public: Combines the given selection into this selection and then destroys
   # the given selection.


### PR DESCRIPTION
This improves the behavior of #3433 by allowing selections to be dragged adjacent to other selections in the gutter.
