### PR TITLE
Upgrade fuzzaldrin

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "first-mate": "^2.0.5",
     "fs-plus": "^2.2.6",
     "fstream": "0.1.24",
-    "fuzzaldrin": "^1.1",
+    "fuzzaldrin": "^2.1",
     "git-utils": "^2.1.4",
     "grim": "0.12.0",
     "guid": "0.0.10",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "exception-reporting": "0.20.0",
     "feedback": "0.33.0",
     "find-and-replace": "0.132.0",
-    "fuzzy-finder": "0.57.0",
+    "fuzzy-finder": "0.58.0",
     "git-diff": "0.39.0",
     "go-to-line": "0.25.0",
     "grammar-selector": "0.29.0",


### PR DESCRIPTION
This includes a fix on Windows so that the library that scores matches displayed in the fuzzy finder (and elsewhere) uses the right native path separator so it should now display the same results on all platforms.

This also includes many other fuzzy scoring fixes that have come in the last couple months: https://github.com/atom/fuzzaldrin/compare/v1.1.0...v2.1.0

The results displayed in the fuzzy finder may have changed due to fixes but hopefully all the changes are an improvement and the best matches are still shown first.

If anyone has a chance to try this out (on Windows, and other platforms), that would be great.

Please comment here if you see any weird ordering or slowness when using the fuzzy finder, command palette, etc.
