### PR TITLE
lineForRow changes

### DIFF
--- a/benchmark/benchmark-suite.coffee
+++ b/benchmark/benchmark-suite.coffee
@@ -103,7 +103,7 @@ describe "editorView.", ->
         benchmark "cache-entire-visible-area", 100, ->
           for i in [firstRow..lastRow]
             line = editorView.lineElementForScreenRow(i)[0]
-            editorView.positionLeftForLineAndColumn(line, i, Math.max(0, editorView.lineLengthForBufferRow(i)))
+            editorView.positionLeftForLineAndColumn(line, i, Math.max(0, editorView.getModel().lineTextForBufferRow(i).length))
 
     describe "text-rendering.", ->
       beforeEach ->

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -67,48 +67,48 @@ describe "DisplayBuffer", ->
         it "uses the preferred line length as the soft wrap column when it is less than the configured soft wrap column", ->
           atom.config.set('editor.preferredLineLength', 100)
           atom.config.set('editor.softWrapAtPreferredLineLength', true)
-          expect(displayBuffer.lineForRow(10).text).toBe '    return '
+          expect(displayBuffer.tokenizedLineForRow(10).text).toBe '    return '
 
           atom.config.set('editor.preferredLineLength', 5)
-          expect(displayBuffer.lineForRow(10).text).toBe 'funct'
+          expect(displayBuffer.tokenizedLineForRow(10).text).toBe 'funct'
 
           atom.config.set('editor.softWrapAtPreferredLineLength', false)
-          expect(displayBuffer.lineForRow(10).text).toBe '    return '
+          expect(displayBuffer.tokenizedLineForRow(10).text).toBe '    return '
 
       describe "when the line is shorter than the max line length", ->
         it "renders the line unchanged", ->
-          expect(displayBuffer.lineForRow(0).text).toBe buffer.lineForRow(0)
+          expect(displayBuffer.tokenizedLineForRow(0).text).toBe buffer.lineForRow(0)
 
       describe "when the line is empty", ->
         it "renders the empty line", ->
-          expect(displayBuffer.lineForRow(13).text).toBe ''
+          expect(displayBuffer.tokenizedLineForRow(13).text).toBe ''
 
       describe "when there is a non-whitespace character at the max length boundary", ->
         describe "when there is whitespace before the boundary", ->
           it "wraps the line at the end of the first whitespace preceding the boundary", ->
-            expect(displayBuffer.lineForRow(10).text).toBe '    return '
-            expect(displayBuffer.lineForRow(11).text).toBe 'sort(left).concat(pivot).concat(sort(right));'
+            expect(displayBuffer.tokenizedLineForRow(10).text).toBe '    return '
+            expect(displayBuffer.tokenizedLineForRow(11).text).toBe 'sort(left).concat(pivot).concat(sort(right));'
 
         describe "when there is no whitespace before the boundary", ->
           it "wraps the line exactly at the boundary since there's no more graceful place to wrap it", ->
             buffer.setTextInRange([[0, 0], [1, 0]], 'abcdefghijklmnopqrstuvwxyz\n')
             displayBuffer.setEditorWidthInChars(10)
-            expect(displayBuffer.lineForRow(0).text).toBe 'abcdefghij'
-            expect(displayBuffer.lineForRow(1).text).toBe 'klmnopqrst'
-            expect(displayBuffer.lineForRow(2).text).toBe 'uvwxyz'
+            expect(displayBuffer.tokenizedLineForRow(0).text).toBe 'abcdefghij'
+            expect(displayBuffer.tokenizedLineForRow(1).text).toBe 'klmnopqrst'
+            expect(displayBuffer.tokenizedLineForRow(2).text).toBe 'uvwxyz'
 
       describe "when there is a whitespace character at the max length boundary", ->
         it "wraps the line at the first non-whitespace character following the boundary", ->
-          expect(displayBuffer.lineForRow(3).text).toBe '    var pivot = items.shift(), current, left = [], '
-          expect(displayBuffer.lineForRow(4).text).toBe 'right = [];'
+          expect(displayBuffer.tokenizedLineForRow(3).text).toBe '    var pivot = items.shift(), current, left = [], '
+          expect(displayBuffer.tokenizedLineForRow(4).text).toBe 'right = [];'
 
       describe "when there are hard tabs", ->
         beforeEach ->
           buffer.setText(buffer.getText().replace(new RegExp('  ', 'g'), '\t'))
 
         it "correctly tokenizes the hard tabs", ->
-          expect(displayBuffer.lineForRow(3).tokens[0].isHardTab).toBeTruthy()
-          expect(displayBuffer.lineForRow(3).tokens[1].isHardTab).toBeTruthy()
+          expect(displayBuffer.tokenizedLineForRow(3).tokens[0].isHardTab).toBeTruthy()
+          expect(displayBuffer.tokenizedLineForRow(3).tokens[1].isHardTab).toBeTruthy()
 
     describe "when the buffer changes", ->
       describe "when buffer lines are updated", ->
@@ -121,8 +121,8 @@ describe "DisplayBuffer", ->
         describe "when the update makes a soft-wrapped line shorter than the max line length", ->
           it "rewraps the line and emits a change event", ->
             buffer.delete([[6, 24], [6, 42]])
-            expect(displayBuffer.lineForRow(7).text).toBe '      current < pivot ?  : right.push(current);'
-            expect(displayBuffer.lineForRow(8).text).toBe '    }'
+            expect(displayBuffer.tokenizedLineForRow(7).text).toBe '      current < pivot ?  : right.push(current);'
+            expect(displayBuffer.tokenizedLineForRow(8).text).toBe '    }'
 
             expect(changeHandler).toHaveBeenCalled()
             [[event]]= changeHandler.argsForCall
@@ -132,30 +132,30 @@ describe "DisplayBuffer", ->
         describe "when the update causes a line to softwrap an additional time", ->
           it "rewraps the line and emits a change event", ->
             buffer.insert([6, 28], '1234567890')
-            expect(displayBuffer.lineForRow(7).text).toBe '      current < pivot ? '
-            expect(displayBuffer.lineForRow(8).text).toBe 'left1234567890.push(current) : '
-            expect(displayBuffer.lineForRow(9).text).toBe 'right.push(current);'
-            expect(displayBuffer.lineForRow(10).text).toBe '    }'
+            expect(displayBuffer.tokenizedLineForRow(7).text).toBe '      current < pivot ? '
+            expect(displayBuffer.tokenizedLineForRow(8).text).toBe 'left1234567890.push(current) : '
+            expect(displayBuffer.tokenizedLineForRow(9).text).toBe 'right.push(current);'
+            expect(displayBuffer.tokenizedLineForRow(10).text).toBe '    }'
 
             expect(changeHandler).toHaveBeenCalledWith(start: 7, end: 8, screenDelta: 1, bufferDelta: 0)
 
       describe "when buffer lines are inserted", ->
         it "inserts / updates wrapped lines and emits a change event", ->
           buffer.insert([6, 21], '1234567890 abcdefghij 1234567890\nabcdefghij')
-          expect(displayBuffer.lineForRow(7).text).toBe '      current < pivot1234567890 abcdefghij '
-          expect(displayBuffer.lineForRow(8).text).toBe '1234567890'
-          expect(displayBuffer.lineForRow(9).text).toBe 'abcdefghij ? left.push(current) : '
-          expect(displayBuffer.lineForRow(10).text).toBe 'right.push(current);'
+          expect(displayBuffer.tokenizedLineForRow(7).text).toBe '      current < pivot1234567890 abcdefghij '
+          expect(displayBuffer.tokenizedLineForRow(8).text).toBe '1234567890'
+          expect(displayBuffer.tokenizedLineForRow(9).text).toBe 'abcdefghij ? left.push(current) : '
+          expect(displayBuffer.tokenizedLineForRow(10).text).toBe 'right.push(current);'
 
           expect(changeHandler).toHaveBeenCalledWith(start: 7, end: 8, screenDelta: 2, bufferDelta: 1)
 
       describe "when buffer lines are removed", ->
         it "removes lines and emits a change event", ->
           buffer.setTextInRange([[3, 21], [7, 5]], ';')
-          expect(displayBuffer.lineForRow(3).text).toBe '    var pivot = items;'
-          expect(displayBuffer.lineForRow(4).text).toBe '    return '
-          expect(displayBuffer.lineForRow(5).text).toBe 'sort(left).concat(pivot).concat(sort(right));'
-          expect(displayBuffer.lineForRow(6).text).toBe '  };'
+          expect(displayBuffer.tokenizedLineForRow(3).text).toBe '    var pivot = items;'
+          expect(displayBuffer.tokenizedLineForRow(4).text).toBe '    return '
+          expect(displayBuffer.tokenizedLineForRow(5).text).toBe 'sort(left).concat(pivot).concat(sort(right));'
+          expect(displayBuffer.tokenizedLineForRow(6).text).toBe '  };'
 
           expect(changeHandler).toHaveBeenCalledWith(start: 3, end: 9, screenDelta: -6, bufferDelta: -4)
 
@@ -169,9 +169,9 @@ describe "DisplayBuffer", ->
           buffer.delete([[0, Infinity], [1, 0]])
           buffer.insert([0, Infinity], '\n')
 
-          expect(displayBuffer.lineForRow(0).text).toBe "the quick brown fox jumps over "
-          expect(displayBuffer.lineForRow(1).text).toBe "the lazy dog."
-          expect(displayBuffer.lineForRow(2).text).toBe ""
+          expect(displayBuffer.tokenizedLineForRow(0).text).toBe "the quick brown fox jumps over "
+          expect(displayBuffer.tokenizedLineForRow(1).text).toBe "the lazy dog."
+          expect(displayBuffer.tokenizedLineForRow(2).text).toBe ""
 
     describe "position translation", ->
       it "translates positions accounting for wrapped lines", ->
@@ -204,9 +204,9 @@ describe "DisplayBuffer", ->
     describe ".setEditorWidthInChars(length)", ->
       it "changes the length at which lines are wrapped and emits a change event for all screen lines", ->
         displayBuffer.setEditorWidthInChars(40)
-        expect(tokensText displayBuffer.lineForRow(4).tokens).toBe 'left = [], right = [];'
-        expect(tokensText displayBuffer.lineForRow(5).tokens).toBe '    while(items.length > 0) {'
-        expect(tokensText displayBuffer.lineForRow(12).tokens).toBe 'sort(left).concat(pivot).concat(sort(rig'
+        expect(tokensText displayBuffer.tokenizedLineForRow(4).tokens).toBe 'left = [], right = [];'
+        expect(tokensText displayBuffer.tokenizedLineForRow(5).tokens).toBe '    while(items.length > 0) {'
+        expect(tokensText displayBuffer.tokenizedLineForRow(12).tokens).toBe 'sort(left).concat(pivot).concat(sort(rig'
         expect(changeHandler).toHaveBeenCalledWith(start: 0, end: 15, screenDelta: 3, bufferDelta: 0)
 
       it "only allows positive widths to be assigned", ->
@@ -342,8 +342,8 @@ describe "DisplayBuffer", ->
           fold2 = displayBuffer.createFold(4, 9)
           fold1 = displayBuffer.createFold(0, 4)
 
-          expect(displayBuffer.lineForRow(0).text).toMatch /^0/
-          expect(displayBuffer.lineForRow(1).text).toMatch /^10/
+          expect(displayBuffer.tokenizedLineForRow(0).text).toMatch /^0/
+          expect(displayBuffer.tokenizedLineForRow(1).text).toMatch /^10/
 
       describe "when there is another display buffer pointing to the same buffer", ->
         it "does not create folds in the other display buffer", ->
@@ -363,19 +363,19 @@ describe "DisplayBuffer", ->
           buffer.setTextInRange([[1, 0], [5, 1]], 'party!')
 
         it "removes the fold and replaces the selection with the new text", ->
-          expect(displayBuffer.lineForRow(0).text).toBe "0"
-          expect(displayBuffer.lineForRow(1).text).toBe "party!"
-          expect(displayBuffer.lineForRow(2).fold).toBe fold2
-          expect(displayBuffer.lineForRow(3).text).toMatch /^9-+/
+          expect(displayBuffer.tokenizedLineForRow(0).text).toBe "0"
+          expect(displayBuffer.tokenizedLineForRow(1).text).toBe "party!"
+          expect(displayBuffer.tokenizedLineForRow(2).fold).toBe fold2
+          expect(displayBuffer.tokenizedLineForRow(3).text).toMatch /^9-+/
 
           expect(changeHandler).toHaveBeenCalledWith(start: 1, end: 3, screenDelta: -2, bufferDelta: -4)
 
         describe "when the changes is subsequently undone", ->
           xit "restores destroyed folds", ->
             buffer.undo()
-            expect(displayBuffer.lineForRow(2).text).toBe '2'
-            expect(displayBuffer.lineForRow(2).fold).toBe fold1
-            expect(displayBuffer.lineForRow(3).text).toBe '5'
+            expect(displayBuffer.tokenizedLineForRow(2).text).toBe '2'
+            expect(displayBuffer.tokenizedLineForRow(2).fold).toBe fold1
+            expect(displayBuffer.tokenizedLineForRow(3).text).toBe '5'
 
       describe "when the old range surrounds two nested folds", ->
         it "removes both folds and replaces the selection with the new text", ->
@@ -384,9 +384,9 @@ describe "DisplayBuffer", ->
 
           buffer.setTextInRange([[1, 0], [10, 0]], 'goodbye')
 
-          expect(displayBuffer.lineForRow(0).text).toBe "0"
-          expect(displayBuffer.lineForRow(1).text).toBe "goodbye10"
-          expect(displayBuffer.lineForRow(2).text).toBe "11"
+          expect(displayBuffer.tokenizedLineForRow(0).text).toBe "0"
+          expect(displayBuffer.tokenizedLineForRow(1).text).toBe "goodbye10"
+          expect(displayBuffer.tokenizedLineForRow(2).text).toBe "11"
 
           expect(changeHandler).toHaveBeenCalledWith(start: 1, end: 3, screenDelta: -2, bufferDelta: -9)
 
@@ -403,42 +403,42 @@ describe "DisplayBuffer", ->
           it "updates the buffer and re-positions subsequent folds", ->
             buffer.setTextInRange([[0, 0], [1, 1]], 'abc')
 
-            expect(displayBuffer.lineForRow(0).text).toBe "abc"
-            expect(displayBuffer.lineForRow(1).fold).toBe fold1
-            expect(displayBuffer.lineForRow(2).text).toBe "5"
-            expect(displayBuffer.lineForRow(3).fold).toBe fold2
-            expect(displayBuffer.lineForRow(4).text).toMatch /^9-+/
+            expect(displayBuffer.tokenizedLineForRow(0).text).toBe "abc"
+            expect(displayBuffer.tokenizedLineForRow(1).fold).toBe fold1
+            expect(displayBuffer.tokenizedLineForRow(2).text).toBe "5"
+            expect(displayBuffer.tokenizedLineForRow(3).fold).toBe fold2
+            expect(displayBuffer.tokenizedLineForRow(4).text).toMatch /^9-+/
 
             expect(changeHandler).toHaveBeenCalledWith(start: 0, end: 1, screenDelta: -1, bufferDelta: -1)
             changeHandler.reset()
 
             fold1.destroy()
-            expect(displayBuffer.lineForRow(0).text).toBe "abc"
-            expect(displayBuffer.lineForRow(1).text).toBe "2"
-            expect(displayBuffer.lineForRow(3).text).toMatch /^4-+/
-            expect(displayBuffer.lineForRow(4).text).toBe "5"
-            expect(displayBuffer.lineForRow(5).fold).toBe fold2
-            expect(displayBuffer.lineForRow(6).text).toMatch /^9-+/
+            expect(displayBuffer.tokenizedLineForRow(0).text).toBe "abc"
+            expect(displayBuffer.tokenizedLineForRow(1).text).toBe "2"
+            expect(displayBuffer.tokenizedLineForRow(3).text).toMatch /^4-+/
+            expect(displayBuffer.tokenizedLineForRow(4).text).toBe "5"
+            expect(displayBuffer.tokenizedLineForRow(5).fold).toBe fold2
+            expect(displayBuffer.tokenizedLineForRow(6).text).toMatch /^9-+/
 
             expect(changeHandler).toHaveBeenCalledWith(start: 1, end: 1, screenDelta: 2, bufferDelta: 0)
 
       describe "when the old range straddles the beginning of a fold", ->
         it "destroys the fold", ->
           buffer.setTextInRange([[1, 1], [3, 0]], "a\nb\nc\nd\n")
-          expect(displayBuffer.lineForRow(1).text).toBe '1a'
-          expect(displayBuffer.lineForRow(2).text).toBe 'b'
-          expect(displayBuffer.lineForRow(2).fold).toBeUndefined()
-          expect(displayBuffer.lineForRow(3).text).toBe 'c'
+          expect(displayBuffer.tokenizedLineForRow(1).text).toBe '1a'
+          expect(displayBuffer.tokenizedLineForRow(2).text).toBe 'b'
+          expect(displayBuffer.tokenizedLineForRow(2).fold).toBeUndefined()
+          expect(displayBuffer.tokenizedLineForRow(3).text).toBe 'c'
 
       describe "when the old range follows a fold", ->
         it "re-positions the screen ranges for the change event based on the preceding fold", ->
           buffer.setTextInRange([[10, 0], [11, 0]], 'abc')
 
-          expect(displayBuffer.lineForRow(1).text).toBe "1"
-          expect(displayBuffer.lineForRow(2).fold).toBe fold1
-          expect(displayBuffer.lineForRow(3).text).toBe "5"
-          expect(displayBuffer.lineForRow(4).fold).toBe fold2
-          expect(displayBuffer.lineForRow(5).text).toMatch /^9-+/
+          expect(displayBuffer.tokenizedLineForRow(1).text).toBe "1"
+          expect(displayBuffer.tokenizedLineForRow(2).fold).toBe fold1
+          expect(displayBuffer.tokenizedLineForRow(3).text).toBe "5"
+          expect(displayBuffer.tokenizedLineForRow(4).fold).toBe fold2
+          expect(displayBuffer.tokenizedLineForRow(5).text).toMatch /^9-+/
 
           expect(changeHandler).toHaveBeenCalledWith(start: 6, end: 7, screenDelta: -1, bufferDelta: -1)
 
@@ -449,12 +449,12 @@ describe "DisplayBuffer", ->
             expect(fold1.getStartRow()).toBe 2
             expect(fold1.getEndRow()).toBe 5
 
-            expect(displayBuffer.lineForRow(1).text).toBe "1"
-            expect(displayBuffer.lineForRow(2).text).toBe "2"
-            expect(displayBuffer.lineForRow(2).fold).toBe fold1
-            expect(displayBuffer.lineForRow(3).text).toMatch "5"
-            expect(displayBuffer.lineForRow(4).fold).toBe fold2
-            expect(displayBuffer.lineForRow(5).text).toMatch /^9-+/
+            expect(displayBuffer.tokenizedLineForRow(1).text).toBe "1"
+            expect(displayBuffer.tokenizedLineForRow(2).text).toBe "2"
+            expect(displayBuffer.tokenizedLineForRow(2).fold).toBe fold1
+            expect(displayBuffer.tokenizedLineForRow(3).text).toMatch "5"
+            expect(displayBuffer.tokenizedLineForRow(4).fold).toBe fold2
+            expect(displayBuffer.tokenizedLineForRow(5).text).toMatch /^9-+/
 
             expect(changeHandler).toHaveBeenCalledWith(start: 2, end: 2, screenDelta: 0, bufferDelta: 1)
 
@@ -464,12 +464,12 @@ describe "DisplayBuffer", ->
             expect(fold1.getStartRow()).toBe 2
             expect(fold1.getEndRow()).toBe 7
 
-            expect(displayBuffer.lineForRow(1).text).toBe "1"
-            expect(displayBuffer.lineForRow(2).text).toBe "2"
-            expect(displayBuffer.lineForRow(2).fold).toBe fold1
-            expect(displayBuffer.lineForRow(3).text).toMatch "5"
-            expect(displayBuffer.lineForRow(4).fold).toBe fold2
-            expect(displayBuffer.lineForRow(5).text).toMatch /^9-+/
+            expect(displayBuffer.tokenizedLineForRow(1).text).toBe "1"
+            expect(displayBuffer.tokenizedLineForRow(2).text).toBe "2"
+            expect(displayBuffer.tokenizedLineForRow(2).fold).toBe fold1
+            expect(displayBuffer.tokenizedLineForRow(3).text).toMatch "5"
+            expect(displayBuffer.tokenizedLineForRow(4).fold).toBe fold2
+            expect(displayBuffer.tokenizedLineForRow(5).text).toMatch /^9-+/
 
             expect(changeHandler).toHaveBeenCalledWith(start: 2, end: 2, screenDelta: 0, bufferDelta: 3)
 
@@ -478,21 +478,21 @@ describe "DisplayBuffer", ->
           it "destroys the fold", ->
             fold2.destroy()
             buffer.setTextInRange([[3, 0], [6, 0]], 'a\n')
-            expect(displayBuffer.lineForRow(2).text).toBe '2'
-            expect(displayBuffer.lineForRow(2).fold).toBeUndefined()
-            expect(displayBuffer.lineForRow(3).text).toBe 'a'
-            expect(displayBuffer.lineForRow(4).text).toBe '6'
+            expect(displayBuffer.tokenizedLineForRow(2).text).toBe '2'
+            expect(displayBuffer.tokenizedLineForRow(2).fold).toBeUndefined()
+            expect(displayBuffer.tokenizedLineForRow(3).text).toBe 'a'
+            expect(displayBuffer.tokenizedLineForRow(4).text).toBe '6'
 
       describe "when the old range is contained to a single line in-between two folds", ->
         it "re-renders the line with the placeholder and re-positions the second fold", ->
           buffer.insert([5, 0], 'abc\n')
 
-          expect(displayBuffer.lineForRow(1).text).toBe "1"
-          expect(displayBuffer.lineForRow(2).fold).toBe fold1
-          expect(displayBuffer.lineForRow(3).text).toMatch "abc"
-          expect(displayBuffer.lineForRow(4).text).toBe "5"
-          expect(displayBuffer.lineForRow(5).fold).toBe fold2
-          expect(displayBuffer.lineForRow(6).text).toMatch /^9-+/
+          expect(displayBuffer.tokenizedLineForRow(1).text).toBe "1"
+          expect(displayBuffer.tokenizedLineForRow(2).fold).toBe fold1
+          expect(displayBuffer.tokenizedLineForRow(3).text).toMatch "abc"
+          expect(displayBuffer.tokenizedLineForRow(4).text).toBe "5"
+          expect(displayBuffer.tokenizedLineForRow(5).fold).toBe fold2
+          expect(displayBuffer.tokenizedLineForRow(6).text).toMatch /^9-+/
 
           expect(changeHandler).toHaveBeenCalledWith(start: 3, end: 3, screenDelta: 1, bufferDelta: 1)
 
@@ -545,15 +545,15 @@ describe "DisplayBuffer", ->
         displayBuffer.createFold(1, 9)
         displayBuffer.createFold(11, 12)
 
-        expect(displayBuffer.lineForRow(1).text).toBe '1'
-        expect(displayBuffer.lineForRow(2).text).toBe '10'
+        expect(displayBuffer.tokenizedLineForRow(1).text).toBe '1'
+        expect(displayBuffer.tokenizedLineForRow(2).text).toBe '10'
 
         displayBuffer.unfoldBufferRow(2)
-        expect(displayBuffer.lineForRow(1).text).toBe '1'
-        expect(displayBuffer.lineForRow(2).text).toBe '2'
-        expect(displayBuffer.lineForRow(7).fold).toBeDefined()
-        expect(displayBuffer.lineForRow(8).text).toMatch /^9-+/
-        expect(displayBuffer.lineForRow(10).fold).toBeDefined()
+        expect(displayBuffer.tokenizedLineForRow(1).text).toBe '1'
+        expect(displayBuffer.tokenizedLineForRow(2).text).toBe '2'
+        expect(displayBuffer.tokenizedLineForRow(7).fold).toBeDefined()
+        expect(displayBuffer.tokenizedLineForRow(8).text).toMatch /^9-+/
+        expect(displayBuffer.tokenizedLineForRow(10).fold).toBeDefined()
 
     describe ".outermostFoldsInBufferRowRange(startRow, endRow)", ->
       it "returns the outermost folds entirely contained in the given row range, exclusive of end row", ->

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -67,48 +67,48 @@ describe "DisplayBuffer", ->
         it "uses the preferred line length as the soft wrap column when it is less than the configured soft wrap column", ->
           atom.config.set('editor.preferredLineLength', 100)
           atom.config.set('editor.softWrapAtPreferredLineLength', true)
-          expect(displayBuffer.tokenizedLineForRow(10).text).toBe '    return '
+          expect(displayBuffer.tokenizedLineForScreenRow(10).text).toBe '    return '
 
           atom.config.set('editor.preferredLineLength', 5)
-          expect(displayBuffer.tokenizedLineForRow(10).text).toBe 'funct'
+          expect(displayBuffer.tokenizedLineForScreenRow(10).text).toBe 'funct'
 
           atom.config.set('editor.softWrapAtPreferredLineLength', false)
-          expect(displayBuffer.tokenizedLineForRow(10).text).toBe '    return '
+          expect(displayBuffer.tokenizedLineForScreenRow(10).text).toBe '    return '
 
       describe "when the line is shorter than the max line length", ->
         it "renders the line unchanged", ->
-          expect(displayBuffer.tokenizedLineForRow(0).text).toBe buffer.lineForRow(0)
+          expect(displayBuffer.tokenizedLineForScreenRow(0).text).toBe buffer.lineForRow(0)
 
       describe "when the line is empty", ->
         it "renders the empty line", ->
-          expect(displayBuffer.tokenizedLineForRow(13).text).toBe ''
+          expect(displayBuffer.tokenizedLineForScreenRow(13).text).toBe ''
 
       describe "when there is a non-whitespace character at the max length boundary", ->
         describe "when there is whitespace before the boundary", ->
           it "wraps the line at the end of the first whitespace preceding the boundary", ->
-            expect(displayBuffer.tokenizedLineForRow(10).text).toBe '    return '
-            expect(displayBuffer.tokenizedLineForRow(11).text).toBe 'sort(left).concat(pivot).concat(sort(right));'
+            expect(displayBuffer.tokenizedLineForScreenRow(10).text).toBe '    return '
+            expect(displayBuffer.tokenizedLineForScreenRow(11).text).toBe 'sort(left).concat(pivot).concat(sort(right));'
 
         describe "when there is no whitespace before the boundary", ->
           it "wraps the line exactly at the boundary since there's no more graceful place to wrap it", ->
             buffer.setTextInRange([[0, 0], [1, 0]], 'abcdefghijklmnopqrstuvwxyz\n')
             displayBuffer.setEditorWidthInChars(10)
-            expect(displayBuffer.tokenizedLineForRow(0).text).toBe 'abcdefghij'
-            expect(displayBuffer.tokenizedLineForRow(1).text).toBe 'klmnopqrst'
-            expect(displayBuffer.tokenizedLineForRow(2).text).toBe 'uvwxyz'
+            expect(displayBuffer.tokenizedLineForScreenRow(0).text).toBe 'abcdefghij'
+            expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe 'klmnopqrst'
+            expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe 'uvwxyz'
 
       describe "when there is a whitespace character at the max length boundary", ->
         it "wraps the line at the first non-whitespace character following the boundary", ->
-          expect(displayBuffer.tokenizedLineForRow(3).text).toBe '    var pivot = items.shift(), current, left = [], '
-          expect(displayBuffer.tokenizedLineForRow(4).text).toBe 'right = [];'
+          expect(displayBuffer.tokenizedLineForScreenRow(3).text).toBe '    var pivot = items.shift(), current, left = [], '
+          expect(displayBuffer.tokenizedLineForScreenRow(4).text).toBe 'right = [];'
 
       describe "when there are hard tabs", ->
         beforeEach ->
           buffer.setText(buffer.getText().replace(new RegExp('  ', 'g'), '\t'))
 
         it "correctly tokenizes the hard tabs", ->
-          expect(displayBuffer.tokenizedLineForRow(3).tokens[0].isHardTab).toBeTruthy()
-          expect(displayBuffer.tokenizedLineForRow(3).tokens[1].isHardTab).toBeTruthy()
+          expect(displayBuffer.tokenizedLineForScreenRow(3).tokens[0].isHardTab).toBeTruthy()
+          expect(displayBuffer.tokenizedLineForScreenRow(3).tokens[1].isHardTab).toBeTruthy()
 
     describe "when the buffer changes", ->
       describe "when buffer lines are updated", ->
@@ -121,8 +121,8 @@ describe "DisplayBuffer", ->
         describe "when the update makes a soft-wrapped line shorter than the max line length", ->
           it "rewraps the line and emits a change event", ->
             buffer.delete([[6, 24], [6, 42]])
-            expect(displayBuffer.tokenizedLineForRow(7).text).toBe '      current < pivot ?  : right.push(current);'
-            expect(displayBuffer.tokenizedLineForRow(8).text).toBe '    }'
+            expect(displayBuffer.tokenizedLineForScreenRow(7).text).toBe '      current < pivot ?  : right.push(current);'
+            expect(displayBuffer.tokenizedLineForScreenRow(8).text).toBe '    }'
 
             expect(changeHandler).toHaveBeenCalled()
             [[event]]= changeHandler.argsForCall
@@ -132,30 +132,30 @@ describe "DisplayBuffer", ->
         describe "when the update causes a line to softwrap an additional time", ->
           it "rewraps the line and emits a change event", ->
             buffer.insert([6, 28], '1234567890')
-            expect(displayBuffer.tokenizedLineForRow(7).text).toBe '      current < pivot ? '
-            expect(displayBuffer.tokenizedLineForRow(8).text).toBe 'left1234567890.push(current) : '
-            expect(displayBuffer.tokenizedLineForRow(9).text).toBe 'right.push(current);'
-            expect(displayBuffer.tokenizedLineForRow(10).text).toBe '    }'
+            expect(displayBuffer.tokenizedLineForScreenRow(7).text).toBe '      current < pivot ? '
+            expect(displayBuffer.tokenizedLineForScreenRow(8).text).toBe 'left1234567890.push(current) : '
+            expect(displayBuffer.tokenizedLineForScreenRow(9).text).toBe 'right.push(current);'
+            expect(displayBuffer.tokenizedLineForScreenRow(10).text).toBe '    }'
 
             expect(changeHandler).toHaveBeenCalledWith(start: 7, end: 8, screenDelta: 1, bufferDelta: 0)
 
       describe "when buffer lines are inserted", ->
         it "inserts / updates wrapped lines and emits a change event", ->
           buffer.insert([6, 21], '1234567890 abcdefghij 1234567890\nabcdefghij')
-          expect(displayBuffer.tokenizedLineForRow(7).text).toBe '      current < pivot1234567890 abcdefghij '
-          expect(displayBuffer.tokenizedLineForRow(8).text).toBe '1234567890'
-          expect(displayBuffer.tokenizedLineForRow(9).text).toBe 'abcdefghij ? left.push(current) : '
-          expect(displayBuffer.tokenizedLineForRow(10).text).toBe 'right.push(current);'
+          expect(displayBuffer.tokenizedLineForScreenRow(7).text).toBe '      current < pivot1234567890 abcdefghij '
+          expect(displayBuffer.tokenizedLineForScreenRow(8).text).toBe '1234567890'
+          expect(displayBuffer.tokenizedLineForScreenRow(9).text).toBe 'abcdefghij ? left.push(current) : '
+          expect(displayBuffer.tokenizedLineForScreenRow(10).text).toBe 'right.push(current);'
 
           expect(changeHandler).toHaveBeenCalledWith(start: 7, end: 8, screenDelta: 2, bufferDelta: 1)
 
       describe "when buffer lines are removed", ->
         it "removes lines and emits a change event", ->
           buffer.setTextInRange([[3, 21], [7, 5]], ';')
-          expect(displayBuffer.tokenizedLineForRow(3).text).toBe '    var pivot = items;'
-          expect(displayBuffer.tokenizedLineForRow(4).text).toBe '    return '
-          expect(displayBuffer.tokenizedLineForRow(5).text).toBe 'sort(left).concat(pivot).concat(sort(right));'
-          expect(displayBuffer.tokenizedLineForRow(6).text).toBe '  };'
+          expect(displayBuffer.tokenizedLineForScreenRow(3).text).toBe '    var pivot = items;'
+          expect(displayBuffer.tokenizedLineForScreenRow(4).text).toBe '    return '
+          expect(displayBuffer.tokenizedLineForScreenRow(5).text).toBe 'sort(left).concat(pivot).concat(sort(right));'
+          expect(displayBuffer.tokenizedLineForScreenRow(6).text).toBe '  };'
 
           expect(changeHandler).toHaveBeenCalledWith(start: 3, end: 9, screenDelta: -6, bufferDelta: -4)
 
@@ -169,9 +169,9 @@ describe "DisplayBuffer", ->
           buffer.delete([[0, Infinity], [1, 0]])
           buffer.insert([0, Infinity], '\n')
 
-          expect(displayBuffer.tokenizedLineForRow(0).text).toBe "the quick brown fox jumps over "
-          expect(displayBuffer.tokenizedLineForRow(1).text).toBe "the lazy dog."
-          expect(displayBuffer.tokenizedLineForRow(2).text).toBe ""
+          expect(displayBuffer.tokenizedLineForScreenRow(0).text).toBe "the quick brown fox jumps over "
+          expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe "the lazy dog."
+          expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe ""
 
     describe "position translation", ->
       it "translates positions accounting for wrapped lines", ->
@@ -204,9 +204,9 @@ describe "DisplayBuffer", ->
     describe ".setEditorWidthInChars(length)", ->
       it "changes the length at which lines are wrapped and emits a change event for all screen lines", ->
         displayBuffer.setEditorWidthInChars(40)
-        expect(tokensText displayBuffer.tokenizedLineForRow(4).tokens).toBe 'left = [], right = [];'
-        expect(tokensText displayBuffer.tokenizedLineForRow(5).tokens).toBe '    while(items.length > 0) {'
-        expect(tokensText displayBuffer.tokenizedLineForRow(12).tokens).toBe 'sort(left).concat(pivot).concat(sort(rig'
+        expect(tokensText displayBuffer.tokenizedLineForScreenRow(4).tokens).toBe 'left = [], right = [];'
+        expect(tokensText displayBuffer.tokenizedLineForScreenRow(5).tokens).toBe '    while(items.length > 0) {'
+        expect(tokensText displayBuffer.tokenizedLineForScreenRow(12).tokens).toBe 'sort(left).concat(pivot).concat(sort(rig'
         expect(changeHandler).toHaveBeenCalledWith(start: 0, end: 15, screenDelta: 3, bufferDelta: 0)
 
       it "only allows positive widths to be assigned", ->
@@ -342,8 +342,8 @@ describe "DisplayBuffer", ->
           fold2 = displayBuffer.createFold(4, 9)
           fold1 = displayBuffer.createFold(0, 4)
 
-          expect(displayBuffer.tokenizedLineForRow(0).text).toMatch /^0/
-          expect(displayBuffer.tokenizedLineForRow(1).text).toMatch /^10/
+          expect(displayBuffer.tokenizedLineForScreenRow(0).text).toMatch /^0/
+          expect(displayBuffer.tokenizedLineForScreenRow(1).text).toMatch /^10/
 
       describe "when there is another display buffer pointing to the same buffer", ->
         it "does not create folds in the other display buffer", ->
@@ -363,19 +363,19 @@ describe "DisplayBuffer", ->
           buffer.setTextInRange([[1, 0], [5, 1]], 'party!')
 
         it "removes the fold and replaces the selection with the new text", ->
-          expect(displayBuffer.tokenizedLineForRow(0).text).toBe "0"
-          expect(displayBuffer.tokenizedLineForRow(1).text).toBe "party!"
-          expect(displayBuffer.tokenizedLineForRow(2).fold).toBe fold2
-          expect(displayBuffer.tokenizedLineForRow(3).text).toMatch /^9-+/
+          expect(displayBuffer.tokenizedLineForScreenRow(0).text).toBe "0"
+          expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe "party!"
+          expect(displayBuffer.tokenizedLineForScreenRow(2).fold).toBe fold2
+          expect(displayBuffer.tokenizedLineForScreenRow(3).text).toMatch /^9-+/
 
           expect(changeHandler).toHaveBeenCalledWith(start: 1, end: 3, screenDelta: -2, bufferDelta: -4)
 
         describe "when the changes is subsequently undone", ->
           xit "restores destroyed folds", ->
             buffer.undo()
-            expect(displayBuffer.tokenizedLineForRow(2).text).toBe '2'
-            expect(displayBuffer.tokenizedLineForRow(2).fold).toBe fold1
-            expect(displayBuffer.tokenizedLineForRow(3).text).toBe '5'
+            expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe '2'
+            expect(displayBuffer.tokenizedLineForScreenRow(2).fold).toBe fold1
+            expect(displayBuffer.tokenizedLineForScreenRow(3).text).toBe '5'
 
       describe "when the old range surrounds two nested folds", ->
         it "removes both folds and replaces the selection with the new text", ->
@@ -384,9 +384,9 @@ describe "DisplayBuffer", ->
 
           buffer.setTextInRange([[1, 0], [10, 0]], 'goodbye')
 
-          expect(displayBuffer.tokenizedLineForRow(0).text).toBe "0"
-          expect(displayBuffer.tokenizedLineForRow(1).text).toBe "goodbye10"
-          expect(displayBuffer.tokenizedLineForRow(2).text).toBe "11"
+          expect(displayBuffer.tokenizedLineForScreenRow(0).text).toBe "0"
+          expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe "goodbye10"
+          expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe "11"
 
           expect(changeHandler).toHaveBeenCalledWith(start: 1, end: 3, screenDelta: -2, bufferDelta: -9)
 
@@ -403,42 +403,42 @@ describe "DisplayBuffer", ->
           it "updates the buffer and re-positions subsequent folds", ->
             buffer.setTextInRange([[0, 0], [1, 1]], 'abc')
 
-            expect(displayBuffer.tokenizedLineForRow(0).text).toBe "abc"
-            expect(displayBuffer.tokenizedLineForRow(1).fold).toBe fold1
-            expect(displayBuffer.tokenizedLineForRow(2).text).toBe "5"
-            expect(displayBuffer.tokenizedLineForRow(3).fold).toBe fold2
-            expect(displayBuffer.tokenizedLineForRow(4).text).toMatch /^9-+/
+            expect(displayBuffer.tokenizedLineForScreenRow(0).text).toBe "abc"
+            expect(displayBuffer.tokenizedLineForScreenRow(1).fold).toBe fold1
+            expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe "5"
+            expect(displayBuffer.tokenizedLineForScreenRow(3).fold).toBe fold2
+            expect(displayBuffer.tokenizedLineForScreenRow(4).text).toMatch /^9-+/
 
             expect(changeHandler).toHaveBeenCalledWith(start: 0, end: 1, screenDelta: -1, bufferDelta: -1)
             changeHandler.reset()
 
             fold1.destroy()
-            expect(displayBuffer.tokenizedLineForRow(0).text).toBe "abc"
-            expect(displayBuffer.tokenizedLineForRow(1).text).toBe "2"
-            expect(displayBuffer.tokenizedLineForRow(3).text).toMatch /^4-+/
-            expect(displayBuffer.tokenizedLineForRow(4).text).toBe "5"
-            expect(displayBuffer.tokenizedLineForRow(5).fold).toBe fold2
-            expect(displayBuffer.tokenizedLineForRow(6).text).toMatch /^9-+/
+            expect(displayBuffer.tokenizedLineForScreenRow(0).text).toBe "abc"
+            expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe "2"
+            expect(displayBuffer.tokenizedLineForScreenRow(3).text).toMatch /^4-+/
+            expect(displayBuffer.tokenizedLineForScreenRow(4).text).toBe "5"
+            expect(displayBuffer.tokenizedLineForScreenRow(5).fold).toBe fold2
+            expect(displayBuffer.tokenizedLineForScreenRow(6).text).toMatch /^9-+/
 
             expect(changeHandler).toHaveBeenCalledWith(start: 1, end: 1, screenDelta: 2, bufferDelta: 0)
 
       describe "when the old range straddles the beginning of a fold", ->
         it "destroys the fold", ->
           buffer.setTextInRange([[1, 1], [3, 0]], "a\nb\nc\nd\n")
-          expect(displayBuffer.tokenizedLineForRow(1).text).toBe '1a'
-          expect(displayBuffer.tokenizedLineForRow(2).text).toBe 'b'
-          expect(displayBuffer.tokenizedLineForRow(2).fold).toBeUndefined()
-          expect(displayBuffer.tokenizedLineForRow(3).text).toBe 'c'
+          expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe '1a'
+          expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe 'b'
+          expect(displayBuffer.tokenizedLineForScreenRow(2).fold).toBeUndefined()
+          expect(displayBuffer.tokenizedLineForScreenRow(3).text).toBe 'c'
 
       describe "when the old range follows a fold", ->
         it "re-positions the screen ranges for the change event based on the preceding fold", ->
           buffer.setTextInRange([[10, 0], [11, 0]], 'abc')
 
-          expect(displayBuffer.tokenizedLineForRow(1).text).toBe "1"
-          expect(displayBuffer.tokenizedLineForRow(2).fold).toBe fold1
-          expect(displayBuffer.tokenizedLineForRow(3).text).toBe "5"
-          expect(displayBuffer.tokenizedLineForRow(4).fold).toBe fold2
-          expect(displayBuffer.tokenizedLineForRow(5).text).toMatch /^9-+/
+          expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe "1"
+          expect(displayBuffer.tokenizedLineForScreenRow(2).fold).toBe fold1
+          expect(displayBuffer.tokenizedLineForScreenRow(3).text).toBe "5"
+          expect(displayBuffer.tokenizedLineForScreenRow(4).fold).toBe fold2
+          expect(displayBuffer.tokenizedLineForScreenRow(5).text).toMatch /^9-+/
 
           expect(changeHandler).toHaveBeenCalledWith(start: 6, end: 7, screenDelta: -1, bufferDelta: -1)
 
@@ -449,12 +449,12 @@ describe "DisplayBuffer", ->
             expect(fold1.getStartRow()).toBe 2
             expect(fold1.getEndRow()).toBe 5
 
-            expect(displayBuffer.tokenizedLineForRow(1).text).toBe "1"
-            expect(displayBuffer.tokenizedLineForRow(2).text).toBe "2"
-            expect(displayBuffer.tokenizedLineForRow(2).fold).toBe fold1
-            expect(displayBuffer.tokenizedLineForRow(3).text).toMatch "5"
-            expect(displayBuffer.tokenizedLineForRow(4).fold).toBe fold2
-            expect(displayBuffer.tokenizedLineForRow(5).text).toMatch /^9-+/
+            expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe "1"
+            expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe "2"
+            expect(displayBuffer.tokenizedLineForScreenRow(2).fold).toBe fold1
+            expect(displayBuffer.tokenizedLineForScreenRow(3).text).toMatch "5"
+            expect(displayBuffer.tokenizedLineForScreenRow(4).fold).toBe fold2
+            expect(displayBuffer.tokenizedLineForScreenRow(5).text).toMatch /^9-+/
 
             expect(changeHandler).toHaveBeenCalledWith(start: 2, end: 2, screenDelta: 0, bufferDelta: 1)
 
@@ -464,12 +464,12 @@ describe "DisplayBuffer", ->
             expect(fold1.getStartRow()).toBe 2
             expect(fold1.getEndRow()).toBe 7
 
-            expect(displayBuffer.tokenizedLineForRow(1).text).toBe "1"
-            expect(displayBuffer.tokenizedLineForRow(2).text).toBe "2"
-            expect(displayBuffer.tokenizedLineForRow(2).fold).toBe fold1
-            expect(displayBuffer.tokenizedLineForRow(3).text).toMatch "5"
-            expect(displayBuffer.tokenizedLineForRow(4).fold).toBe fold2
-            expect(displayBuffer.tokenizedLineForRow(5).text).toMatch /^9-+/
+            expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe "1"
+            expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe "2"
+            expect(displayBuffer.tokenizedLineForScreenRow(2).fold).toBe fold1
+            expect(displayBuffer.tokenizedLineForScreenRow(3).text).toMatch "5"
+            expect(displayBuffer.tokenizedLineForScreenRow(4).fold).toBe fold2
+            expect(displayBuffer.tokenizedLineForScreenRow(5).text).toMatch /^9-+/
 
             expect(changeHandler).toHaveBeenCalledWith(start: 2, end: 2, screenDelta: 0, bufferDelta: 3)
 
@@ -478,21 +478,21 @@ describe "DisplayBuffer", ->
           it "destroys the fold", ->
             fold2.destroy()
             buffer.setTextInRange([[3, 0], [6, 0]], 'a\n')
-            expect(displayBuffer.tokenizedLineForRow(2).text).toBe '2'
-            expect(displayBuffer.tokenizedLineForRow(2).fold).toBeUndefined()
-            expect(displayBuffer.tokenizedLineForRow(3).text).toBe 'a'
-            expect(displayBuffer.tokenizedLineForRow(4).text).toBe '6'
+            expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe '2'
+            expect(displayBuffer.tokenizedLineForScreenRow(2).fold).toBeUndefined()
+            expect(displayBuffer.tokenizedLineForScreenRow(3).text).toBe 'a'
+            expect(displayBuffer.tokenizedLineForScreenRow(4).text).toBe '6'
 
       describe "when the old range is contained to a single line in-between two folds", ->
         it "re-renders the line with the placeholder and re-positions the second fold", ->
           buffer.insert([5, 0], 'abc\n')
 
-          expect(displayBuffer.tokenizedLineForRow(1).text).toBe "1"
-          expect(displayBuffer.tokenizedLineForRow(2).fold).toBe fold1
-          expect(displayBuffer.tokenizedLineForRow(3).text).toMatch "abc"
-          expect(displayBuffer.tokenizedLineForRow(4).text).toBe "5"
-          expect(displayBuffer.tokenizedLineForRow(5).fold).toBe fold2
-          expect(displayBuffer.tokenizedLineForRow(6).text).toMatch /^9-+/
+          expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe "1"
+          expect(displayBuffer.tokenizedLineForScreenRow(2).fold).toBe fold1
+          expect(displayBuffer.tokenizedLineForScreenRow(3).text).toMatch "abc"
+          expect(displayBuffer.tokenizedLineForScreenRow(4).text).toBe "5"
+          expect(displayBuffer.tokenizedLineForScreenRow(5).fold).toBe fold2
+          expect(displayBuffer.tokenizedLineForScreenRow(6).text).toMatch /^9-+/
 
           expect(changeHandler).toHaveBeenCalledWith(start: 3, end: 3, screenDelta: 1, bufferDelta: 1)
 
@@ -545,15 +545,15 @@ describe "DisplayBuffer", ->
         displayBuffer.createFold(1, 9)
         displayBuffer.createFold(11, 12)
 
-        expect(displayBuffer.tokenizedLineForRow(1).text).toBe '1'
-        expect(displayBuffer.tokenizedLineForRow(2).text).toBe '10'
+        expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe '1'
+        expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe '10'
 
         displayBuffer.unfoldBufferRow(2)
-        expect(displayBuffer.tokenizedLineForRow(1).text).toBe '1'
-        expect(displayBuffer.tokenizedLineForRow(2).text).toBe '2'
-        expect(displayBuffer.tokenizedLineForRow(7).fold).toBeDefined()
-        expect(displayBuffer.tokenizedLineForRow(8).text).toMatch /^9-+/
-        expect(displayBuffer.tokenizedLineForRow(10).fold).toBeDefined()
+        expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe '1'
+        expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe '2'
+        expect(displayBuffer.tokenizedLineForScreenRow(7).fold).toBeDefined()
+        expect(displayBuffer.tokenizedLineForScreenRow(8).text).toMatch /^9-+/
+        expect(displayBuffer.tokenizedLineForScreenRow(10).fold).toBeDefined()
 
     describe ".outermostFoldsInBufferRowRange(startRow, endRow)", ->
       it "returns the outermost folds entirely contained in the given row range, exclusive of end row", ->

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -242,7 +242,7 @@ describe "DisplayBuffer", ->
           fold = displayBuffer.createFold(4, 7)
           expect(fold).toBeDefined()
 
-          [line4, line5] = displayBuffer.linesForRows(4, 5)
+          [line4, line5] = displayBuffer.tokenizedLinesForScreenRows(4, 5)
           expect(line4.fold).toBe fold
           expect(line4.text).toMatch /^4-+/
           expect(line5.text).toBe '8'
@@ -251,7 +251,7 @@ describe "DisplayBuffer", ->
           changeHandler.reset()
 
           fold.destroy()
-          [line4, line5] = displayBuffer.linesForRows(4, 5)
+          [line4, line5] = displayBuffer.tokenizedLinesForScreenRows(4, 5)
           expect(line4.fold).toBeUndefined()
           expect(line4.text).toMatch /^4-+/
           expect(line5.text).toBe '5'
@@ -262,7 +262,7 @@ describe "DisplayBuffer", ->
         it "renders a fold placeholder for the folded line but does not skip any lines", ->
           fold = displayBuffer.createFold(4, 4)
 
-          [line4, line5] = displayBuffer.linesForRows(4, 5)
+          [line4, line5] = displayBuffer.tokenizedLinesForScreenRows(4, 5)
           expect(line4.fold).toBe fold
           expect(line4.text).toMatch /^4-+/
           expect(line5.text).toBe '5'
@@ -275,7 +275,7 @@ describe "DisplayBuffer", ->
 
           fold.destroy()
 
-          [line4, line5] = displayBuffer.linesForRows(4, 5)
+          [line4, line5] = displayBuffer.tokenizedLinesForScreenRows(4, 5)
           expect(line4.fold).toBeUndefined()
           expect(line4.text).toMatch /^4-+/
           expect(line5.text).toBe '5'
@@ -287,13 +287,13 @@ describe "DisplayBuffer", ->
           innerFold = displayBuffer.createFold(6, 7)
           outerFold = displayBuffer.createFold(4, 8)
 
-          [line4, line5] = displayBuffer.linesForRows(4, 5)
+          [line4, line5] = displayBuffer.tokenizedLinesForScreenRows(4, 5)
           expect(line4.fold).toBe outerFold
           expect(line4.text).toMatch /4-+/
           expect(line5.text).toMatch /9-+/
 
           outerFold.destroy()
-          [line4, line5, line6, line7] = displayBuffer.linesForRows(4, 7)
+          [line4, line5, line6, line7] = displayBuffer.tokenizedLinesForScreenRows(4, 7)
           expect(line4.fold).toBeUndefined()
           expect(line4.text).toMatch /^4-+/
           expect(line5.text).toBe '5'
@@ -305,7 +305,7 @@ describe "DisplayBuffer", ->
           innerFold = displayBuffer.createFold(4, 6)
           outerFold = displayBuffer.createFold(4, 8)
 
-          [line4, line5] = displayBuffer.linesForRows(4, 5)
+          [line4, line5] = displayBuffer.tokenizedLinesForScreenRows(4, 5)
           expect(line4.fold).toBe outerFold
           expect(line4.text).toMatch /4-+/
           expect(line5.text).toMatch /9-+/
@@ -326,14 +326,14 @@ describe "DisplayBuffer", ->
 
           innerFold = displayBuffer.createFold(2, 5)
           expect(changeHandler).not.toHaveBeenCalled()
-          [line0, line1] = displayBuffer.linesForRows(0, 1)
+          [line0, line1] = displayBuffer.tokenizedLinesForScreenRows(0, 1)
           expect(line0.fold).toBe outerFold
           expect(line1.fold).toBeUndefined()
 
           changeHandler.reset()
           innerFold.destroy()
           expect(changeHandler).not.toHaveBeenCalled()
-          [line0, line1] = displayBuffer.linesForRows(0, 1)
+          [line0, line1] = displayBuffer.tokenizedLinesForScreenRows(0, 1)
           expect(line0.fold).toBe outerFold
           expect(line1.fold).toBeUndefined()
 

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -1783,28 +1783,28 @@ describe "EditorComponent", ->
     it "inserts the newest character in the input's value into the buffer", ->
       componentNode.dispatchEvent(buildTextInputEvent(data: 'x', target: inputNode))
       nextAnimationFrame()
-      expect(editor.lineForBufferRow(0)).toBe 'xvar quicksort = function () {'
+      expect(editor.lineTextForBufferRow(0)).toBe 'xvar quicksort = function () {'
 
       componentNode.dispatchEvent(buildTextInputEvent(data: 'y', target: inputNode))
       nextAnimationFrame()
-      expect(editor.lineForBufferRow(0)).toBe 'xyvar quicksort = function () {'
+      expect(editor.lineTextForBufferRow(0)).toBe 'xyvar quicksort = function () {'
 
     it "replaces the last character if the length of the input's value doesn't increase, as occurs with the accented character menu", ->
       componentNode.dispatchEvent(buildTextInputEvent(data: 'u', target: inputNode))
       nextAnimationFrame()
-      expect(editor.lineForBufferRow(0)).toBe 'uvar quicksort = function () {'
+      expect(editor.lineTextForBufferRow(0)).toBe 'uvar quicksort = function () {'
 
       # simulate the accented character suggestion's selection of the previous character
       inputNode.setSelectionRange(0, 1)
       componentNode.dispatchEvent(buildTextInputEvent(data: 'ü', target: inputNode))
       nextAnimationFrame()
-      expect(editor.lineForBufferRow(0)).toBe 'üvar quicksort = function () {'
+      expect(editor.lineTextForBufferRow(0)).toBe 'üvar quicksort = function () {'
 
     it "does not handle input events when input is disabled", ->
       component.setInputEnabled(false)
       componentNode.dispatchEvent(buildTextInputEvent(data: 'x', target: inputNode))
       expect(nextAnimationFrame).toBe noAnimationFrame
-      expect(editor.lineForBufferRow(0)).toBe 'var quicksort = function () {'
+      expect(editor.lineTextForBufferRow(0)).toBe 'var quicksort = function () {'
 
     describe "when IME composition is used to insert international characters", ->
       inputNode = null
@@ -1822,46 +1822,46 @@ describe "EditorComponent", ->
         it "inserts the chosen completion", ->
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionstart', target: inputNode))
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionupdate', data: 's', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe 'svar quicksort = function () {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'svar quicksort = function () {'
 
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionupdate', data: 'sd', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe 'sdvar quicksort = function () {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'sdvar quicksort = function () {'
 
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionend', target: inputNode))
           componentNode.dispatchEvent(buildTextInputEvent(data: '速度', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe '速度var quicksort = function () {'
+          expect(editor.lineTextForBufferRow(0)).toBe '速度var quicksort = function () {'
 
         it "reverts back to the original text when the completion helper is dismissed", ->
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionstart', target: inputNode))
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionupdate', data: 's', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe 'svar quicksort = function () {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'svar quicksort = function () {'
 
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionupdate', data: 'sd', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe 'sdvar quicksort = function () {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'sdvar quicksort = function () {'
 
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionend', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe 'var quicksort = function () {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'var quicksort = function () {'
 
         it "allows multiple accented character to be inserted with the ' on a US international layout", ->
           inputNode.value = "'"
           inputNode.setSelectionRange(0, 1)
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionstart', target: inputNode))
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionupdate', data: "'", target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe "'var quicksort = function () {"
+          expect(editor.lineTextForBufferRow(0)).toBe "'var quicksort = function () {"
 
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionend', target: inputNode))
           componentNode.dispatchEvent(buildTextInputEvent(data: 'á', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe "ávar quicksort = function () {"
+          expect(editor.lineTextForBufferRow(0)).toBe "ávar quicksort = function () {"
 
           inputNode.value = "'"
           inputNode.setSelectionRange(0, 1)
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionstart', target: inputNode))
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionupdate', data: "'", target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe "á'var quicksort = function () {"
+          expect(editor.lineTextForBufferRow(0)).toBe "á'var quicksort = function () {"
 
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionend', target: inputNode))
           componentNode.dispatchEvent(buildTextInputEvent(data: 'á', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe "áávar quicksort = function () {"
+          expect(editor.lineTextForBufferRow(0)).toBe "áávar quicksort = function () {"
 
       describe "when a string is selected", ->
         beforeEach ->
@@ -1870,25 +1870,25 @@ describe "EditorComponent", ->
         it "inserts the chosen completion", ->
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionstart', target: inputNode))
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionupdate', data: 's', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe 'var ssort = function () {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'var ssort = function () {'
 
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionupdate', data: 'sd', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe 'var sdsort = function () {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'var sdsort = function () {'
 
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionend', target: inputNode))
           componentNode.dispatchEvent(buildTextInputEvent(data: '速度', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe 'var 速度sort = function () {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'var 速度sort = function () {'
 
         it "reverts back to the original text when the completion helper is dismissed", ->
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionstart', target: inputNode))
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionupdate', data: 's', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe 'var ssort = function () {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'var ssort = function () {'
 
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionupdate', data: 'sd', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe 'var sdsort = function () {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'var sdsort = function () {'
 
           componentNode.dispatchEvent(buildIMECompositionEvent('compositionend', target: inputNode))
-          expect(editor.lineForBufferRow(0)).toBe 'var quicksort = function () {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'var quicksort = function () {'
 
   describe "commands", ->
     describe "editor:consolidate-selections", ->

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -65,9 +65,9 @@ describe "EditorComponent", ->
       linesNode = componentNode.querySelector('.lines')
       expect(linesNode.style['-webkit-transform']).toBe "translate3d(0px, 0px, 0px)"
       expect(componentNode.querySelectorAll('.line').length).toBe 6 + 2 # no margin above
-      expect(component.lineNodeForScreenRow(0).textContent).toBe editor.lineForScreenRow(0).text
+      expect(component.lineNodeForScreenRow(0).textContent).toBe editor.tokenizedLineForScreenRow(0).text
       expect(component.lineNodeForScreenRow(0).offsetTop).toBe 0
-      expect(component.lineNodeForScreenRow(5).textContent).toBe editor.lineForScreenRow(5).text
+      expect(component.lineNodeForScreenRow(5).textContent).toBe editor.tokenizedLineForScreenRow(5).text
       expect(component.lineNodeForScreenRow(5).offsetTop).toBe 5 * lineHeightInPixels
 
       verticalScrollbarNode.scrollTop = 4.5 * lineHeightInPixels
@@ -77,9 +77,9 @@ describe "EditorComponent", ->
       expect(linesNode.style['-webkit-transform']).toBe "translate3d(0px, #{-4.5 * lineHeightInPixels}px, 0px)"
       expect(componentNode.querySelectorAll('.line').length).toBe 6 + 4 # margin above and below
       expect(component.lineNodeForScreenRow(2).offsetTop).toBe 2 * lineHeightInPixels
-      expect(component.lineNodeForScreenRow(2).textContent).toBe editor.lineForScreenRow(2).text
+      expect(component.lineNodeForScreenRow(2).textContent).toBe editor.tokenizedLineForScreenRow(2).text
       expect(component.lineNodeForScreenRow(9).offsetTop).toBe 9 * lineHeightInPixels
-      expect(component.lineNodeForScreenRow(9).textContent).toBe editor.lineForScreenRow(9).text
+      expect(component.lineNodeForScreenRow(9).textContent).toBe editor.tokenizedLineForScreenRow(9).text
 
     it "updates the top position of subsequent lines when lines are inserted or removed", ->
       editor.getBuffer().deleteRows(0, 1)
@@ -111,11 +111,11 @@ describe "EditorComponent", ->
 
       buffer.insert([0, 0], '\n\n')
       nextAnimationFrame()
-      expect(component.lineNodeForScreenRow(3).textContent).toBe editor.lineForScreenRow(3).text
+      expect(component.lineNodeForScreenRow(3).textContent).toBe editor.tokenizedLineForScreenRow(3).text
 
       buffer.delete([[0, 0], [3, 0]])
       nextAnimationFrame()
-      expect(component.lineNodeForScreenRow(3).textContent).toBe editor.lineForScreenRow(3).text
+      expect(component.lineNodeForScreenRow(3).textContent).toBe editor.tokenizedLineForScreenRow(3).text
 
     it "updates the top position of lines when the line height changes", ->
       initialLineHeightInPixels = editor.getLineHeightInPixels()

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2777,6 +2777,7 @@ describe "Editor", ->
     it '.lineTextForScreenRow(row)', ->
       editor.foldBufferRow(4)
       expect(editor.lineTextForScreenRow(5)).toEqual '    return sort(left).concat(pivot).concat(sort(right));'
+      expect(editor.lineTextForScreenRow(100)).not.toBeDefined()
 
   describe ".deleteLine()", ->
     it "deletes the first line when the cursor is there", ->

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -2773,6 +2773,11 @@ describe "Editor", ->
         expect(cursor1.getBufferPosition()).toEqual [0,0]
         expect(cursor3.getBufferPosition()).toEqual [1,2]
 
+  describe 'reading text', ->
+    it '.lineTextForScreenRow(row)', ->
+      editor.foldBufferRow(4)
+      expect(editor.lineTextForScreenRow(5)).toEqual '    return sort(left).concat(pivot).concat(sort(right));'
+
   describe ".deleteLine()", ->
     it "deletes the first line when the cursor is there", ->
       editor.getLastCursor().moveToTop()

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1262,10 +1262,10 @@ describe "Editor", ->
           editor.createFold(10, 11)
 
           editor.setSelectedBufferRanges([[[2, 2], [3, 3]], [[6, 6], [7, 7]]])
-          expect(editor.lineForScreenRow(1).fold).toBeUndefined()
-          expect(editor.lineForScreenRow(2).fold).toBeUndefined()
-          expect(editor.lineForScreenRow(6).fold).toBeUndefined()
-          expect(editor.lineForScreenRow(10).fold).toBeDefined()
+          expect(editor.tokenizedLineForScreenRow(1).fold).toBeUndefined()
+          expect(editor.tokenizedLineForScreenRow(2).fold).toBeUndefined()
+          expect(editor.tokenizedLineForScreenRow(6).fold).toBeUndefined()
+          expect(editor.tokenizedLineForScreenRow(10).fold).toBeDefined()
 
       describe "when the 'preserveFolds' option is true", ->
         it "does not remove folds that contain the selections", ->
@@ -1653,7 +1653,7 @@ describe "Editor", ->
           editor.createFold(2,4)
           editor.setSelectedBufferRange([[1,0], [2,0]])
           editor.insertText('holy cow')
-          expect(editor.lineForScreenRow(2).fold).toBeUndefined()
+          expect(editor.tokenizedLineForScreenRow(2).fold).toBeUndefined()
 
       describe "when will-insert-text and did-insert-text events are used", ->
         beforeEach ->
@@ -1978,7 +1978,7 @@ describe "Editor", ->
             editor.backspace()
 
             expect(buffer.lineForRow(3)).toBe "    while(items.length > 0) {"
-            expect(editor.lineForScreenRow(3).fold).toBeDefined()
+            expect(editor.tokenizedLineForScreenRow(3).fold).toBeDefined()
 
       describe "when there are multiple selections", ->
         it "removes all selected text", ->
@@ -2116,7 +2116,7 @@ describe "Editor", ->
             editor.delete()
 
             expect(buffer.lineForRow(3)).toBe "    ar pivot = items.shift(), current, left = [], right = [];"
-            expect(editor.lineForScreenRow(4).fold).toBeDefined()
+            expect(editor.tokenizedLineForScreenRow(4).fold).toBeDefined()
             expect(editor.getCursorScreenPosition()).toEqual [3, 4]
 
         describe "when the cursor is on a folded line", ->
@@ -2128,8 +2128,8 @@ describe "Editor", ->
             oldLine8 = buffer.lineForRow(8)
 
             editor.delete()
-            expect(editor.lineForScreenRow(2).text).toBe oldLine7
-            expect(editor.lineForScreenRow(3).text).toBe oldLine8
+            expect(editor.tokenizedLineForScreenRow(2).text).toBe oldLine7
+            expect(editor.tokenizedLineForScreenRow(3).text).toBe oldLine8
 
       describe "when there are multiple cursors", ->
         describe "when cursors are on the same line", ->
@@ -2348,7 +2348,7 @@ describe "Editor", ->
             editor.setEditorWidthInChars(10)
             editor.setCursorScreenPosition([2, 2])
             editor.cutToEndOfLine()
-            expect(editor.lineForScreenRow(2).text).toBe '=  () {'
+            expect(editor.tokenizedLineForScreenRow(2).text).toBe '=  () {'
 
         describe "when soft wrap is off", ->
           describe "when nothing is selected", ->
@@ -2981,11 +2981,11 @@ describe "Editor", ->
 
       runs ->
         expect(editor.getGrammar()).toBe atom.syntax.nullGrammar
-        expect(editor.lineForScreenRow(0).tokens.length).toBe 1
+        expect(editor.tokenizedLineForScreenRow(0).tokens.length).toBe 1
 
         atom.syntax.addGrammar(jsGrammar)
         expect(editor.getGrammar()).toBe jsGrammar
-        expect(editor.lineForScreenRow(0).tokens.length).toBeGreaterThan 1
+        expect(editor.tokenizedLineForScreenRow(0).tokens.length).toBeGreaterThan 1
 
   describe "auto-indent", ->
     copyText = (text, {startColumn}={}) ->
@@ -3242,10 +3242,10 @@ describe "Editor", ->
       expect(editor.getSelectedBufferRanges()).toEqual [[[3, 5], [3, 5]], [[9, 0], [14, 0]]]
 
       # folds are also duplicated
-      expect(editor.lineForScreenRow(5).fold).toBeDefined()
-      expect(editor.lineForScreenRow(7).fold).toBeDefined()
-      expect(editor.lineForScreenRow(7).text).toBe "    while(items.length > 0) {"
-      expect(editor.lineForScreenRow(8).text).toBe "    return sort(left).concat(pivot).concat(sort(right));"
+      expect(editor.tokenizedLineForScreenRow(5).fold).toBeDefined()
+      expect(editor.tokenizedLineForScreenRow(7).fold).toBeDefined()
+      expect(editor.tokenizedLineForScreenRow(7).text).toBe "    while(items.length > 0) {"
+      expect(editor.tokenizedLineForScreenRow(8).text).toBe "    return sort(left).concat(pivot).concat(sort(right));"
 
     it "duplicates all folded lines for empty selections on folded lines", ->
       editor.foldBufferRow(4)
@@ -3394,7 +3394,7 @@ describe "Editor", ->
         runs ->
           editor.setText("// http://github.com")
 
-          {tokens} = editor.lineForScreenRow(0)
+          {tokens} = editor.tokenizedLineForScreenRow(0)
           expect(tokens[1].value).toBe " http://github.com"
           expect(tokens[1].scopes).toEqual ["source.js", "comment.line.double-slash.js"]
 
@@ -3402,7 +3402,7 @@ describe "Editor", ->
           atom.packages.activatePackage('language-hyperlink')
 
         runs ->
-          {tokens} = editor.lineForScreenRow(0)
+          {tokens} = editor.tokenizedLineForScreenRow(0)
           expect(tokens[2].value).toBe "http://github.com"
           expect(tokens[2].scopes).toEqual ["source.js", "comment.line.double-slash.js", "markup.underline.link.http.hyperlink"]
 
@@ -3414,7 +3414,7 @@ describe "Editor", ->
           runs ->
             editor.setText("// SELECT * FROM OCTOCATS")
 
-            {tokens} = editor.lineForScreenRow(0)
+            {tokens} = editor.tokenizedLineForScreenRow(0)
             expect(tokens[1].value).toBe " SELECT * FROM OCTOCATS"
             expect(tokens[1].scopes).toEqual ["source.js", "comment.line.double-slash.js"]
 
@@ -3422,7 +3422,7 @@ describe "Editor", ->
             atom.packages.activatePackage('package-with-injection-selector')
 
           runs ->
-            {tokens} = editor.lineForScreenRow(0)
+            {tokens} = editor.tokenizedLineForScreenRow(0)
             expect(tokens[1].value).toBe " SELECT * FROM OCTOCATS"
             expect(tokens[1].scopes).toEqual ["source.js", "comment.line.double-slash.js"]
 
@@ -3430,7 +3430,7 @@ describe "Editor", ->
             atom.packages.activatePackage('language-sql')
 
           runs ->
-            {tokens} = editor.lineForScreenRow(0)
+            {tokens} = editor.tokenizedLineForScreenRow(0)
             expect(tokens[2].value).toBe "SELECT"
             expect(tokens[2].scopes).toEqual ["source.js", "comment.line.double-slash.js", "keyword.other.DML.sql"]
 

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -1631,7 +1631,7 @@ describe "Editor", ->
             expect(selection1.isEmpty()).toBeTruthy()
             expect(selection2.isEmpty()).toBeTruthy()
 
-            expect(editor.lineForBufferRow(0)).toBe "var x = functix () {"
+            expect(editor.lineTextForBufferRow(0)).toBe "var x = functix () {"
 
         describe "when the selections are on different lines", ->
           it "replaces each selection with the given text, clears the selections, and places the cursor at the end of each selection's inserted text", ->
@@ -1738,10 +1738,10 @@ describe "Editor", ->
 
             editor.insertNewline()
 
-            expect(editor.lineForBufferRow(3)).toBe "    var pivot"
-            expect(editor.lineForBufferRow(4)).toBe " = items.shift(), current"
-            expect(editor.lineForBufferRow(5)).toBe ", left = [], right = [];"
-            expect(editor.lineForBufferRow(6)).toBe "    while(items.length > 0) {"
+            expect(editor.lineTextForBufferRow(3)).toBe "    var pivot"
+            expect(editor.lineTextForBufferRow(4)).toBe " = items.shift(), current"
+            expect(editor.lineTextForBufferRow(5)).toBe ", left = [], right = [];"
+            expect(editor.lineTextForBufferRow(6)).toBe "    while(items.length > 0) {"
 
             [cursor1, cursor2] = editor.getCursors()
             expect(cursor1.getBufferPosition()).toEqual [4, 0]
@@ -1753,13 +1753,13 @@ describe "Editor", ->
             editor.addCursorAtScreenPosition([6, 0])
 
             editor.insertText("\n")
-            expect(editor.lineForBufferRow(3)).toBe ""
-            expect(editor.lineForBufferRow(4)).toBe "    var pivot = items.shift(), current, left = [], right = [];"
-            expect(editor.lineForBufferRow(5)).toBe "    while(items.length > 0) {"
-            expect(editor.lineForBufferRow(6)).toBe "      current = items.shift();"
-            expect(editor.lineForBufferRow(7)).toBe ""
-            expect(editor.lineForBufferRow(8)).toBe "      current < pivot ? left.push(current) : right.push(current);"
-            expect(editor.lineForBufferRow(9)).toBe "    }"
+            expect(editor.lineTextForBufferRow(3)).toBe ""
+            expect(editor.lineTextForBufferRow(4)).toBe "    var pivot = items.shift(), current, left = [], right = [];"
+            expect(editor.lineTextForBufferRow(5)).toBe "    while(items.length > 0) {"
+            expect(editor.lineTextForBufferRow(6)).toBe "      current = items.shift();"
+            expect(editor.lineTextForBufferRow(7)).toBe ""
+            expect(editor.lineTextForBufferRow(8)).toBe "      current < pivot ? left.push(current) : right.push(current);"
+            expect(editor.lineTextForBufferRow(9)).toBe "    }"
 
             [cursor1, cursor2] = editor.getCursors()
             expect(cursor1.getBufferPosition()).toEqual [4,0]
@@ -1787,8 +1787,8 @@ describe "Editor", ->
           editor.setCursorBufferPosition([0])
           editor.insertNewlineAbove()
           expect(editor.getCursorBufferPosition()).toEqual [0,0]
-          expect(editor.lineForBufferRow(0)).toBe ''
-          expect(editor.lineForBufferRow(1)).toBe 'var quicksort = function () {'
+          expect(editor.lineTextForBufferRow(0)).toBe ''
+          expect(editor.lineTextForBufferRow(1)).toBe 'var quicksort = function () {'
           expect(editor.buffer.getLineCount()).toBe 14
 
       describe "when the cursor is not on the first line", ->
@@ -1796,8 +1796,8 @@ describe "Editor", ->
           editor.setCursorBufferPosition([3,4])
           editor.insertNewlineAbove()
           expect(editor.getCursorBufferPosition()).toEqual [3,0]
-          expect(editor.lineForBufferRow(3)).toBe ''
-          expect(editor.lineForBufferRow(4)).toBe '    var pivot = items.shift(), current, left = [], right = [];'
+          expect(editor.lineTextForBufferRow(3)).toBe ''
+          expect(editor.lineTextForBufferRow(4)).toBe '    var pivot = items.shift(), current, left = [], right = [];'
           expect(editor.buffer.getLineCount()).toBe 14
 
           editor.undo()
@@ -1811,33 +1811,33 @@ describe "Editor", ->
         editor.insertNewlineAbove()
 
         expect(editor.getCursorBufferPosition()).toEqual [0,2]
-        expect(editor.lineForBufferRow(0)).toBe '  '
-        expect(editor.lineForBufferRow(1)).toBe '  var test'
+        expect(editor.lineTextForBufferRow(0)).toBe '  '
+        expect(editor.lineTextForBufferRow(1)).toBe '  var test'
 
         editor.setText('\n  var test')
         editor.setCursorBufferPosition([1,2])
         editor.insertNewlineAbove()
 
         expect(editor.getCursorBufferPosition()).toEqual [1,2]
-        expect(editor.lineForBufferRow(0)).toBe ''
-        expect(editor.lineForBufferRow(1)).toBe '  '
-        expect(editor.lineForBufferRow(2)).toBe '  var test'
+        expect(editor.lineTextForBufferRow(0)).toBe ''
+        expect(editor.lineTextForBufferRow(1)).toBe '  '
+        expect(editor.lineTextForBufferRow(2)).toBe '  var test'
 
         editor.setText('function() {\n}')
         editor.setCursorBufferPosition([1,1])
         editor.insertNewlineAbove()
 
         expect(editor.getCursorBufferPosition()).toEqual [1,2]
-        expect(editor.lineForBufferRow(0)).toBe 'function() {'
-        expect(editor.lineForBufferRow(1)).toBe '  '
-        expect(editor.lineForBufferRow(2)).toBe '}'
+        expect(editor.lineTextForBufferRow(0)).toBe 'function() {'
+        expect(editor.lineTextForBufferRow(1)).toBe '  '
+        expect(editor.lineTextForBufferRow(2)).toBe '}'
 
     describe "when a new line is appended before a closing tag (e.g. by pressing enter before a selection)", ->
       it "moves the line down and keeps the indentation level the same when editor.autoIndent is true", ->
         atom.config.set('editor.autoIndent', true)
         editor.setCursorBufferPosition([9,2])
         editor.insertNewline()
-        expect(editor.lineForBufferRow(10)).toBe '  };'
+        expect(editor.lineTextForBufferRow(10)).toBe '  };'
 
     describe ".backspace()", ->
       describe "when there is a single cursor", ->
@@ -1921,7 +1921,7 @@ describe "Editor", ->
 
             editor.backspace()
 
-            expect(editor.lineForBufferRow(3)).toBe "    var pivo = items.shift(), curren, left = [], right = [];"
+            expect(editor.lineTextForBufferRow(3)).toBe "    var pivo = items.shift(), curren, left = [], right = [];"
 
             [cursor1, cursor2] = editor.getCursors()
             expect(cursor1.getBufferPosition()).toEqual [3, 12]
@@ -1939,8 +1939,8 @@ describe "Editor", ->
 
               editor.backspace()
 
-              expect(editor.lineForBufferRow(3)).toBe "    var pivo = items.shift(), current, left = [], right = [];"
-              expect(editor.lineForBufferRow(4)).toBe "    whileitems.length > 0) {"
+              expect(editor.lineTextForBufferRow(3)).toBe "    var pivo = items.shift(), current, left = [], right = [];"
+              expect(editor.lineTextForBufferRow(4)).toBe "    whileitems.length > 0) {"
 
               [cursor1, cursor2] = editor.getCursors()
               expect(cursor1.getBufferPosition()).toEqual [3, 12]
@@ -1956,10 +1956,10 @@ describe "Editor", ->
               editor.addCursorAtScreenPosition([6, 0])
 
               editor.backspace()
-              expect(editor.lineForBufferRow(2)).toBe "    if (items.length <= 1) return items;    var pivot = items.shift(), current, left = [], right = [];"
-              expect(editor.lineForBufferRow(3)).toBe "    while(items.length > 0) {"
-              expect(editor.lineForBufferRow(4)).toBe "      current = items.shift();      current < pivot ? left.push(current) : right.push(current);"
-              expect(editor.lineForBufferRow(5)).toBe "    }"
+              expect(editor.lineTextForBufferRow(2)).toBe "    if (items.length <= 1) return items;    var pivot = items.shift(), current, left = [], right = [];"
+              expect(editor.lineTextForBufferRow(3)).toBe "    while(items.length > 0) {"
+              expect(editor.lineTextForBufferRow(4)).toBe "      current = items.shift();      current < pivot ? left.push(current) : right.push(current);"
+              expect(editor.lineTextForBufferRow(5)).toBe "    }"
 
               [cursor1, cursor2] = editor.getCursors()
               expect(cursor1.getBufferPosition()).toEqual [2,40]
@@ -1984,7 +1984,7 @@ describe "Editor", ->
         it "removes all selected text", ->
           editor.setSelectedBufferRanges([[[0,4], [0,13]], [[0,16], [0,24]]])
           editor.backspace()
-          expect(editor.lineForBufferRow(0)).toBe 'var  =  () {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'var  =  () {'
 
     describe ".deleteToBeginningOfWord()", ->
       describe "when no text is selected", ->
@@ -2139,7 +2139,7 @@ describe "Editor", ->
 
             editor.delete()
 
-            expect(editor.lineForBufferRow(3)).toBe "    var pivot= items.shift(), current left = [], right = [];"
+            expect(editor.lineTextForBufferRow(3)).toBe "    var pivot= items.shift(), current left = [], right = [];"
 
             [cursor1, cursor2] = editor.getCursors()
             expect(cursor1.getBufferPosition()).toEqual [3, 13]
@@ -2157,8 +2157,8 @@ describe "Editor", ->
 
               editor.delete()
 
-              expect(editor.lineForBufferRow(3)).toBe "    var pivot= items.shift(), current, left = [], right = [];"
-              expect(editor.lineForBufferRow(4)).toBe "    while(tems.length > 0) {"
+              expect(editor.lineTextForBufferRow(3)).toBe "    var pivot= items.shift(), current, left = [], right = [];"
+              expect(editor.lineTextForBufferRow(4)).toBe "    while(tems.length > 0) {"
 
               [cursor1, cursor2] = editor.getCursors()
               expect(cursor1.getBufferPosition()).toEqual [3, 13]
@@ -2175,7 +2175,7 @@ describe "Editor", ->
 
               editor.delete()
 
-              expect(editor.lineForBufferRow(0)).toBe "var quicksort = function () {  var sort = function(items) {    if (items.length <= 1) return items;"
+              expect(editor.lineTextForBufferRow(0)).toBe "var quicksort = function () {  var sort = function(items) {    if (items.length <= 1) return items;"
 
               [cursor1, cursor2] = editor.getCursors()
               expect(cursor1.getBufferPosition()).toEqual [0,29]
@@ -2194,7 +2194,7 @@ describe "Editor", ->
           it "removes all selected text", ->
             editor.setSelectedBufferRanges([[[0,4], [0,13]], [[0,16], [0,24]]])
             editor.delete()
-            expect(editor.lineForBufferRow(0)).toBe 'var  =  () {'
+            expect(editor.lineTextForBufferRow(0)).toBe 'var  =  () {'
 
     describe ".deleteToEndOfWord()", ->
       describe "when no text is selected", ->
@@ -2389,27 +2389,27 @@ describe "Editor", ->
         it "pastes text into the buffer", ->
           atom.clipboard.write('first')
           editor.pasteText()
-          expect(editor.lineForBufferRow(0)).toBe "var first = function () {"
-          expect(editor.lineForBufferRow(1)).toBe "  var first = function(items) {"
+          expect(editor.lineTextForBufferRow(0)).toBe "var first = function () {"
+          expect(editor.lineTextForBufferRow(1)).toBe "  var first = function(items) {"
 
         describe 'when the clipboard has many selections', ->
           it "pastes each selection separately into the buffer", ->
             atom.clipboard.write('first\nsecond', {selections: ['first', 'second'] })
             editor.pasteText()
-            expect(editor.lineForBufferRow(0)).toBe "var first = function () {"
-            expect(editor.lineForBufferRow(1)).toBe "  var second = function(items) {"
+            expect(editor.lineTextForBufferRow(0)).toBe "var first = function () {"
+            expect(editor.lineTextForBufferRow(1)).toBe "  var second = function(items) {"
 
           describe 'and the selections count does not match', ->
             it "pastes the whole text into the buffer", ->
               atom.clipboard.write('first\nsecond\nthird', {selections: ['first', 'second', 'third'] })
               editor.pasteText()
-              expect(editor.lineForBufferRow(0)).toBe "var first"
-              expect(editor.lineForBufferRow(1)).toBe "second"
-              expect(editor.lineForBufferRow(2)).toBe "third = function () {"
+              expect(editor.lineTextForBufferRow(0)).toBe "var first"
+              expect(editor.lineTextForBufferRow(1)).toBe "second"
+              expect(editor.lineTextForBufferRow(2)).toBe "third = function () {"
 
-              expect(editor.lineForBufferRow(3)).toBe "  var first"
-              expect(editor.lineForBufferRow(4)).toBe "second"
-              expect(editor.lineForBufferRow(5)).toBe "third = function(items) {"
+              expect(editor.lineTextForBufferRow(3)).toBe "  var first"
+              expect(editor.lineTextForBufferRow(4)).toBe "second"
+              expect(editor.lineTextForBufferRow(5)).toBe "third = function(items) {"
 
     describe ".indentSelectedRows()", ->
       describe "when nothing is selected", ->
@@ -2889,13 +2889,13 @@ describe "Editor", ->
       editor.buffer.setText("abc")
       editor.setCursorScreenPosition([0, 1])
       editor.transpose()
-      expect(editor.lineForBufferRow(0)).toBe 'bac'
+      expect(editor.lineTextForBufferRow(0)).toBe 'bac'
 
     it "reverses a selection", ->
       editor.buffer.setText("xabcz")
       editor.setSelectedBufferRange([[0, 1], [0, 4]])
       editor.transpose()
-      expect(editor.lineForBufferRow(0)).toBe 'xcbaz'
+      expect(editor.lineTextForBufferRow(0)).toBe 'xcbaz'
 
   describe ".upperCase()", ->
     describe "when there is no selection", ->
@@ -2903,7 +2903,7 @@ describe "Editor", ->
         editor.buffer.setText("aBc")
         editor.setCursorScreenPosition([0, 1])
         editor.upperCase()
-        expect(editor.lineForBufferRow(0)).toBe 'ABC'
+        expect(editor.lineTextForBufferRow(0)).toBe 'ABC'
         expect(editor.getSelectedBufferRange()).toEqual [[0, 1], [0, 1]]
 
     describe "when there is a selection", ->
@@ -2911,7 +2911,7 @@ describe "Editor", ->
         editor.buffer.setText("abc")
         editor.setSelectedBufferRange([[0,0], [0,2]])
         editor.upperCase()
-        expect(editor.lineForBufferRow(0)).toBe 'ABc'
+        expect(editor.lineTextForBufferRow(0)).toBe 'ABc'
         expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [0, 2]]
 
   describe ".lowerCase()", ->
@@ -2920,7 +2920,7 @@ describe "Editor", ->
         editor.buffer.setText("aBC")
         editor.setCursorScreenPosition([0, 1])
         editor.lowerCase()
-        expect(editor.lineForBufferRow(0)).toBe 'abc'
+        expect(editor.lineTextForBufferRow(0)).toBe 'abc'
         expect(editor.getSelectedBufferRange()).toEqual [[0, 1], [0, 1]]
 
     describe "when there is a selection", ->
@@ -2928,7 +2928,7 @@ describe "Editor", ->
         editor.buffer.setText("ABC")
         editor.setSelectedBufferRange([[0,0], [0,2]])
         editor.lowerCase()
-        expect(editor.lineForBufferRow(0)).toBe 'abC'
+        expect(editor.lineTextForBufferRow(0)).toBe 'abC'
         expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [0, 2]]
 
   describe "soft-tabs detection", ->
@@ -3003,11 +3003,11 @@ describe "Editor", ->
           it "does not auto-indent the line", ->
             editor.setCursorBufferPosition([1, 30])
             editor.insertText("\n ")
-            expect(editor.lineForBufferRow(2)).toBe " "
+            expect(editor.lineTextForBufferRow(2)).toBe " "
 
             atom.config.set("editor.autoIndent", false)
             editor.indent()
-            expect(editor.lineForBufferRow(2)).toBe "  "
+            expect(editor.lineTextForBufferRow(2)).toBe "  "
 
       describe "when editor.autoIndent is true", ->
         beforeEach ->
@@ -3017,11 +3017,11 @@ describe "Editor", ->
           it "auto-indents the line", ->
             editor.setCursorBufferPosition([1, 30])
             editor.insertText("\n ")
-            expect(editor.lineForBufferRow(2)).toBe " "
+            expect(editor.lineTextForBufferRow(2)).toBe " "
 
             atom.config.set("editor.autoIndent", true)
             editor.indent()
-            expect(editor.lineForBufferRow(2)).toBe "    "
+            expect(editor.lineTextForBufferRow(2)).toBe "    "
 
         describe "when a newline is added", ->
           describe "when the line preceding the newline adds a new level of indentation", ->
@@ -3085,15 +3085,15 @@ describe "Editor", ->
             it "doesn't break when decreasing the indentation on a row that has no indentation", ->
               editor.setCursorBufferPosition([12, Infinity])
               editor.insertText("\n}; # too many closing brackets!")
-              expect(editor.lineForBufferRow(13)).toBe "}; # too many closing brackets!"
+              expect(editor.lineTextForBufferRow(13)).toBe "}; # too many closing brackets!"
 
         describe "when inserted text does not match a decrease indent pattern", ->
           it "does not decrease the indentation", ->
             editor.setCursorBufferPosition([12, 0])
             editor.insertText('  ')
-            expect(editor.lineForBufferRow(12)).toBe '  };'
+            expect(editor.lineTextForBufferRow(12)).toBe '  };'
             editor.insertText('\t\t')
-            expect(editor.lineForBufferRow(12)).toBe '  \t\t};'
+            expect(editor.lineTextForBufferRow(12)).toBe '  \t\t};'
 
         describe "when the current line does not match a decrease indent pattern", ->
           it "leaves the line unchanged", ->
@@ -3111,22 +3111,22 @@ describe "Editor", ->
         atom.config.set('editor.normalizeIndentOnPaste', false)
         editor.setCursorBufferPosition([5, 2])
         editor.pasteText()
-        expect(editor.lineForBufferRow(5)).toBe "     function() {"
-        expect(editor.lineForBufferRow(6)).toBe "var cool = 1;"
-        expect(editor.lineForBufferRow(7)).toBe "  }"
+        expect(editor.lineTextForBufferRow(5)).toBe "     function() {"
+        expect(editor.lineTextForBufferRow(6)).toBe "var cool = 1;"
+        expect(editor.lineTextForBufferRow(7)).toBe "  }"
 
       describe "when the inserted text contains no newlines", ->
         it "does not adjust the indentation level of the text", ->
           editor.setCursorBufferPosition([5, 2])
           editor.insertText("foo", indentBasis: 5)
-          expect(editor.lineForBufferRow(5)).toBe "  foo    current = items.shift();"
+          expect(editor.lineTextForBufferRow(5)).toBe "  foo    current = items.shift();"
 
         it "does not adjust the whitespace if there are preceding characters", ->
           copyText(" foo")
           editor.setCursorBufferPosition([5, 30])
           editor.pasteText()
 
-          expect(editor.lineForBufferRow(5)).toBe "      current = items.shift(); foo"
+          expect(editor.lineTextForBufferRow(5)).toBe "      current = items.shift(); foo"
 
       describe "when the inserted text contains newlines", ->
         describe "when the cursor is preceded only by whitespace characters", ->
@@ -3135,10 +3135,10 @@ describe "Editor", ->
             editor.setCursorBufferPosition([3, 4])
             editor.pasteText()
 
-            expect(editor.lineForBufferRow(3)).toBe "    while (true) {"
-            expect(editor.lineForBufferRow(4)).toBe "      foo();"
-            expect(editor.lineForBufferRow(5)).toBe "    }"
-            expect(editor.lineForBufferRow(6)).toBe "var pivot = items.shift(), current, left = [], right = [];"
+            expect(editor.lineTextForBufferRow(3)).toBe "    while (true) {"
+            expect(editor.lineTextForBufferRow(4)).toBe "      foo();"
+            expect(editor.lineTextForBufferRow(5)).toBe "    }"
+            expect(editor.lineTextForBufferRow(6)).toBe "var pivot = items.shift(), current, left = [], right = [];"
 
         describe "when the cursor is preceded by non-whitespace characters", ->
           it "normalizes the indentation level of all lines based on the level of the existing first line", ->
@@ -3146,10 +3146,10 @@ describe "Editor", ->
             editor.setCursorBufferPosition([1, Infinity])
             editor.pasteText()
 
-            expect(editor.lineForBufferRow(1)).toBe "  var sort = function(items) {while (true) {"
-            expect(editor.lineForBufferRow(2)).toBe "    foo();"
-            expect(editor.lineForBufferRow(3)).toBe "  }"
-            expect(editor.lineForBufferRow(4)).toBe ""
+            expect(editor.lineTextForBufferRow(1)).toBe "  var sort = function(items) {while (true) {"
+            expect(editor.lineTextForBufferRow(2)).toBe "    foo();"
+            expect(editor.lineTextForBufferRow(3)).toBe "  }"
+            expect(editor.lineTextForBufferRow(4)).toBe ""
 
     it "autoIndentSelectedRows auto-indents the selection", ->
       editor.setCursorBufferPosition([2, 0])
@@ -3157,10 +3157,10 @@ describe "Editor", ->
       editor.getLastSelection().setBufferRange([[2,0], [6,0]])
       editor.autoIndentSelectedRows()
 
-      expect(editor.lineForBufferRow(2)).toBe "    function() {"
-      expect(editor.lineForBufferRow(3)).toBe "      inside=true"
-      expect(editor.lineForBufferRow(4)).toBe "    }"
-      expect(editor.lineForBufferRow(5)).toBe "    i=1"
+      expect(editor.lineTextForBufferRow(2)).toBe "    function() {"
+      expect(editor.lineTextForBufferRow(3)).toBe "      inside=true"
+      expect(editor.lineTextForBufferRow(4)).toBe "    }"
+      expect(editor.lineTextForBufferRow(5)).toBe "    i=1"
 
   describe "soft and hard tabs", ->
     it "resets the tab style when tokenization is complete", ->
@@ -3185,36 +3185,36 @@ describe "Editor", ->
       describe "when the line below isn't empty", ->
         it "joins the line below with the current line separated by a space and moves the cursor to the start of line that was moved up", ->
           editor.joinLines()
-          expect(editor.lineForBufferRow(0)).toBe 'var quicksort = function () { var sort = function(items) {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'var quicksort = function () { var sort = function(items) {'
           expect(editor.getCursorBufferPosition()).toEqual [0, 30]
 
       describe "when the line below is empty", ->
         it "deletes the line below and moves the cursor to the end of the line", ->
           editor.setCursorBufferPosition([9])
           editor.joinLines()
-          expect(editor.lineForBufferRow(9)).toBe '  };'
-          expect(editor.lineForBufferRow(10)).toBe '  return sort(Array.apply(this, arguments));'
+          expect(editor.lineTextForBufferRow(9)).toBe '  };'
+          expect(editor.lineTextForBufferRow(10)).toBe '  return sort(Array.apply(this, arguments));'
           expect(editor.getCursorBufferPosition()).toEqual [9, 4]
 
       describe "when the cursor is on the last row", ->
         it "does nothing", ->
           editor.setCursorBufferPosition([Infinity, Infinity])
           editor.joinLines()
-          expect(editor.lineForBufferRow(12)).toBe '};'
+          expect(editor.lineTextForBufferRow(12)).toBe '};'
 
     describe "when text is selected", ->
       describe "when the selection does not span multiple lines", ->
         it "joins the line below with the current line separated by a space and retains the selected text", ->
           editor.setSelectedBufferRange([[0, 1], [0, 3]])
           editor.joinLines()
-          expect(editor.lineForBufferRow(0)).toBe 'var quicksort = function () { var sort = function(items) {'
+          expect(editor.lineTextForBufferRow(0)).toBe 'var quicksort = function () { var sort = function(items) {'
           expect(editor.getSelectedBufferRange()).toEqual [[0, 1], [0, 3]]
 
       describe "when the selection spans multiple lines", ->
         it "joins all selected lines separated by a space and retains the selected text", ->
           editor.setSelectedBufferRange([[9, 3], [12, 1]])
           editor.joinLines()
-          expect(editor.lineForBufferRow(9)).toBe '  }; return sort(Array.apply(this, arguments)); };'
+          expect(editor.lineTextForBufferRow(9)).toBe '  }; return sort(Array.apply(this, arguments)); };'
           expect(editor.getSelectedBufferRange()).toEqual [[9, 3], [9, 49]]
 
   describe ".duplicateLines()", ->

--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -275,46 +275,46 @@ describe "LanguageMode", ->
       it "folds every foldable line", ->
         languageMode.foldAll()
 
-        fold1 = editor.lineForScreenRow(0).fold
+        fold1 = editor.tokenizedLineForScreenRow(0).fold
         expect([fold1.getStartRow(), fold1.getEndRow()]).toEqual [0, 12]
         fold1.destroy()
 
-        fold2 = editor.lineForScreenRow(1).fold
+        fold2 = editor.tokenizedLineForScreenRow(1).fold
         expect([fold2.getStartRow(), fold2.getEndRow()]).toEqual [1, 9]
         fold2.destroy()
 
-        fold3 = editor.lineForScreenRow(4).fold
+        fold3 = editor.tokenizedLineForScreenRow(4).fold
         expect([fold3.getStartRow(), fold3.getEndRow()]).toEqual [4, 7]
 
     describe ".foldBufferRow(bufferRow)", ->
       describe "when bufferRow can be folded", ->
         it "creates a fold based on the syntactic region starting at the given row", ->
           languageMode.foldBufferRow(1)
-          fold = editor.lineForScreenRow(1).fold
+          fold = editor.tokenizedLineForScreenRow(1).fold
           expect(fold.getStartRow()).toBe 1
           expect(fold.getEndRow()).toBe 9
 
       describe "when bufferRow can't be folded", ->
         it "searches upward for the first row that begins a syntatic region containing the given buffer row (and folds it)", ->
           languageMode.foldBufferRow(8)
-          fold = editor.lineForScreenRow(1).fold
+          fold = editor.tokenizedLineForScreenRow(1).fold
           expect(fold.getStartRow()).toBe 1
           expect(fold.getEndRow()).toBe 9
 
       describe "when the bufferRow is already folded", ->
         it "searches upward for the first row that begins a syntatic region containing the folded row (and folds it)", ->
           languageMode.foldBufferRow(2)
-          expect(editor.lineForScreenRow(1).fold).toBeDefined()
-          expect(editor.lineForScreenRow(0).fold).not.toBeDefined()
+          expect(editor.tokenizedLineForScreenRow(1).fold).toBeDefined()
+          expect(editor.tokenizedLineForScreenRow(0).fold).not.toBeDefined()
 
           languageMode.foldBufferRow(1)
-          expect(editor.lineForScreenRow(0).fold).toBeDefined()
+          expect(editor.tokenizedLineForScreenRow(0).fold).toBeDefined()
 
       describe "when the bufferRow is in a multi-line comment", ->
         it "searches upward and downward for surrounding comment lines and folds them as a single fold", ->
           buffer.insert([1,0], "  //this is a comment\n  // and\n  //more docs\n\n//second comment")
           languageMode.foldBufferRow(1)
-          fold = editor.lineForScreenRow(1).fold
+          fold = editor.tokenizedLineForScreenRow(1).fold
           expect(fold.getStartRow()).toBe 1
           expect(fold.getEndRow()).toBe 3
 
@@ -322,7 +322,7 @@ describe "LanguageMode", ->
         it "searches upward for the first row that begins a syntatic region containing the folded row (and folds it)", ->
           buffer.insert([1,0], "  //this is a single line comment\n")
           languageMode.foldBufferRow(1)
-          fold = editor.lineForScreenRow(0).fold
+          fold = editor.tokenizedLineForScreenRow(0).fold
           expect(fold.getStartRow()).toBe 0
           expect(fold.getEndRow()).toBe 13
 
@@ -357,38 +357,38 @@ describe "LanguageMode", ->
       it "folds every foldable line", ->
         languageMode.foldAll()
 
-        fold1 = editor.lineForScreenRow(0).fold
+        fold1 = editor.tokenizedLineForScreenRow(0).fold
         expect([fold1.getStartRow(), fold1.getEndRow()]).toEqual [0, 19]
         fold1.destroy()
 
-        fold2 = editor.lineForScreenRow(1).fold
+        fold2 = editor.tokenizedLineForScreenRow(1).fold
         expect([fold2.getStartRow(), fold2.getEndRow()]).toEqual [1, 4]
 
-        fold3 = editor.lineForScreenRow(2).fold.destroy()
+        fold3 = editor.tokenizedLineForScreenRow(2).fold.destroy()
 
-        fold4 = editor.lineForScreenRow(3).fold
+        fold4 = editor.tokenizedLineForScreenRow(3).fold
         expect([fold4.getStartRow(), fold4.getEndRow()]).toEqual [6, 8]
 
     describe ".foldAllAtIndentLevel()", ->
       it "folds every foldable range at a given indentLevel", ->
         languageMode.foldAllAtIndentLevel(2)
 
-        fold1 = editor.lineForScreenRow(6).fold
+        fold1 = editor.tokenizedLineForScreenRow(6).fold
         expect([fold1.getStartRow(), fold1.getEndRow()]).toEqual [6, 8]
         fold1.destroy()
 
-        fold2 = editor.lineForScreenRow(11).fold
+        fold2 = editor.tokenizedLineForScreenRow(11).fold
         expect([fold2.getStartRow(), fold2.getEndRow()]).toEqual [11, 14]
         fold2.destroy()
 
       it "does not fold anything but the indentLevel", ->
         languageMode.foldAllAtIndentLevel(0)
 
-        fold1 = editor.lineForScreenRow(0).fold
+        fold1 = editor.tokenizedLineForScreenRow(0).fold
         expect([fold1.getStartRow(), fold1.getEndRow()]).toEqual [0, 19]
         fold1.destroy()
 
-        fold2 = editor.lineForScreenRow(5).fold
+        fold2 = editor.tokenizedLineForScreenRow(5).fold
         expect(fold2).toBeFalsy()
 
     describe ".isFoldableAtBufferRow(bufferRow)", ->

--- a/spec/random-editor-spec.coffee
+++ b/spec/random-editor-spec.coffee
@@ -83,7 +83,7 @@ describe "Editor", ->
       screenLines = []
       bufferRows = []
       for bufferRow in [0..tokenizedBuffer.getLastRow()]
-        for screenLine in softWrapLine(tokenizedBuffer.lineForScreenRow(bufferRow))
+        for screenLine in softWrapLine(tokenizedBuffer.tokenizedLineForRow(bufferRow))
           screenLines.push(screenLine)
           bufferRows.push(bufferRow)
     else

--- a/spec/random-editor-spec.coffee
+++ b/spec/random-editor-spec.coffee
@@ -35,7 +35,7 @@ describe "Editor", ->
         logLines()
         throw new Error("Invalid buffer row #{actualBufferRow} for screen row #{screenRow}", )
 
-      actualScreenLine = editor.lineForScreenRow(screenRow)
+      actualScreenLine = editor.tokenizedLineForScreenRow(screenRow)
       unless actualScreenLine.text is referenceScreenLine.text
         logLines()
         throw new Error("Invalid line text at screen row #{screenRow}")

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -49,38 +49,38 @@ describe "TokenizedBuffer", ->
 
     describe "on construction", ->
       it "initially creates un-tokenized screen lines, then tokenizes lines chunk at a time in the background", ->
-        line0 = tokenizedBuffer.lineForScreenRow(0)
+        line0 = tokenizedBuffer.tokenizedLineForRow(0)
         expect(line0.tokens.length).toBe 1
         expect(line0.tokens[0]).toEqual(value: line0.text, scopes: ['source.js'])
 
-        line11 = tokenizedBuffer.lineForScreenRow(11)
+        line11 = tokenizedBuffer.tokenizedLineForRow(11)
         expect(line11.tokens.length).toBe 2
         expect(line11.tokens[0]).toEqual(value: "  ", scopes: ['source.js'], isAtomic: true)
         expect(line11.tokens[1]).toEqual(value: "return sort(Array.apply(this, arguments));", scopes: ['source.js'])
 
         # background tokenization has not begun
-        expect(tokenizedBuffer.lineForScreenRow(0).ruleStack).toBeUndefined()
+        expect(tokenizedBuffer.tokenizedLineForRow(0).ruleStack).toBeUndefined()
 
         # tokenize chunk 1
         advanceClock()
-        expect(tokenizedBuffer.lineForScreenRow(0).ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.lineForScreenRow(4).ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.lineForScreenRow(5).ruleStack?).toBeFalsy()
+        expect(tokenizedBuffer.tokenizedLineForRow(0).ruleStack?).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLineForRow(4).ruleStack?).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLineForRow(5).ruleStack?).toBeFalsy()
         expect(changeHandler).toHaveBeenCalledWith(start: 0, end: 4, delta: 0)
         changeHandler.reset()
 
         # tokenize chunk 2
         advanceClock()
-        expect(tokenizedBuffer.lineForScreenRow(5).ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.lineForScreenRow(9).ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.lineForScreenRow(10).ruleStack?).toBeFalsy()
+        expect(tokenizedBuffer.tokenizedLineForRow(5).ruleStack?).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLineForRow(9).ruleStack?).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLineForRow(10).ruleStack?).toBeFalsy()
         expect(changeHandler).toHaveBeenCalledWith(start: 5, end: 9, delta: 0)
         changeHandler.reset()
 
         # tokenize last chunk
         advanceClock()
-        expect(tokenizedBuffer.lineForScreenRow(10).ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.lineForScreenRow(12).ruleStack?).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLineForRow(10).ruleStack?).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLineForRow(12).ruleStack?).toBeTruthy()
         expect(changeHandler).toHaveBeenCalledWith(start: 10, end: 12, delta: 0)
 
     describe "when the buffer is partially tokenized", ->
@@ -134,8 +134,8 @@ describe "TokenizedBuffer", ->
           expect(tokenizedBuffer.firstInvalidRow()).toBe 5
           buffer.setTextInRange([[6, 0], [7, 0]], "\n\n\n")
 
-          expect(tokenizedBuffer.lineForScreenRow(6).ruleStack?).toBeFalsy()
-          expect(tokenizedBuffer.lineForScreenRow(7).ruleStack?).toBeFalsy()
+          expect(tokenizedBuffer.tokenizedLineForRow(6).ruleStack?).toBeFalsy()
+          expect(tokenizedBuffer.tokenizedLineForRow(7).ruleStack?).toBeFalsy()
 
           changeHandler.reset()
           expect(tokenizedBuffer.firstInvalidRow()).toBe 5
@@ -149,10 +149,10 @@ describe "TokenizedBuffer", ->
           it "updates tokens to reflect the change", ->
             buffer.setTextInRange([[0, 0], [2, 0]], "foo()\n7\n")
 
-            expect(tokenizedBuffer.lineForScreenRow(0).tokens[1]).toEqual(value: '(', scopes: ['source.js', 'meta.brace.round.js'])
-            expect(tokenizedBuffer.lineForScreenRow(1).tokens[0]).toEqual(value: '7', scopes: ['source.js', 'constant.numeric.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[1]).toEqual(value: '(', scopes: ['source.js', 'meta.brace.round.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: '7', scopes: ['source.js', 'constant.numeric.js'])
             # line 2 is unchanged
-            expect(tokenizedBuffer.lineForScreenRow(2).tokens[2]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[2]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
 
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]
@@ -164,7 +164,7 @@ describe "TokenizedBuffer", ->
               buffer.insert([5, 30], '/* */')
               changeHandler.reset()
               buffer.insert([2, 0], '/*')
-              expect(tokenizedBuffer.lineForScreenRow(3).tokens[0].scopes).toEqual ['source.js']
+              expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js']
               expect(changeHandler).toHaveBeenCalled()
               [event] = changeHandler.argsForCall[0]
               delete event.bufferChange
@@ -172,9 +172,9 @@ describe "TokenizedBuffer", ->
               changeHandler.reset()
 
               advanceClock()
-              expect(tokenizedBuffer.lineForScreenRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-              expect(tokenizedBuffer.lineForScreenRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-              expect(tokenizedBuffer.lineForScreenRow(5).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+              expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+              expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+              expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
               expect(changeHandler).toHaveBeenCalled()
               [event] = changeHandler.argsForCall[0]
               delete event.bufferChange
@@ -185,23 +185,23 @@ describe "TokenizedBuffer", ->
             buffer.insert([5, 0], '*/')
 
             buffer.insert([1, 0], 'var ')
-            expect(tokenizedBuffer.lineForScreenRow(1).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
 
         describe "when lines are both updated and removed", ->
           it "updates tokens to reflect the change", ->
             buffer.setTextInRange([[1, 0], [3, 0]], "foo()")
 
             # previous line 0 remains
-            expect(tokenizedBuffer.lineForScreenRow(0).tokens[0]).toEqual(value: 'var', scopes: ['source.js', 'storage.modifier.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0]).toEqual(value: 'var', scopes: ['source.js', 'storage.modifier.js'])
 
             # previous line 3 should be combined with input to form line 1
-            expect(tokenizedBuffer.lineForScreenRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js'])
-            expect(tokenizedBuffer.lineForScreenRow(1).tokens[6]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[6]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
 
             # lines below deleted regions should be shifted upward
-            expect(tokenizedBuffer.lineForScreenRow(2).tokens[2]).toEqual(value: 'while', scopes: ['source.js', 'keyword.control.js'])
-            expect(tokenizedBuffer.lineForScreenRow(3).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
-            expect(tokenizedBuffer.lineForScreenRow(4).tokens[4]).toEqual(value: '<', scopes: ['source.js', 'keyword.operator.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[2]).toEqual(value: 'while', scopes: ['source.js', 'keyword.control.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[4]).toEqual(value: '<', scopes: ['source.js', 'keyword.operator.js'])
 
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]
@@ -214,8 +214,8 @@ describe "TokenizedBuffer", ->
             changeHandler.reset()
 
             buffer.setTextInRange([[2, 0], [3, 0]], '/*')
-            expect(tokenizedBuffer.lineForScreenRow(2).tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
-            expect(tokenizedBuffer.lineForScreenRow(3).tokens[0].scopes).toEqual ['source.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js']
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]
             delete event.bufferChange
@@ -223,8 +223,8 @@ describe "TokenizedBuffer", ->
             changeHandler.reset()
 
             advanceClock()
-            expect(tokenizedBuffer.lineForScreenRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.lineForScreenRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]
             delete event.bufferChange
@@ -235,19 +235,19 @@ describe "TokenizedBuffer", ->
             buffer.setTextInRange([[1, 0], [2, 0]], "foo()\nbar()\nbaz()\nquux()")
 
             # previous line 0 remains
-            expect(tokenizedBuffer.lineForScreenRow(0).tokens[0]).toEqual( value: 'var', scopes: ['source.js', 'storage.modifier.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0]).toEqual( value: 'var', scopes: ['source.js', 'storage.modifier.js'])
 
             # 3 new lines inserted
-            expect(tokenizedBuffer.lineForScreenRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js'])
-            expect(tokenizedBuffer.lineForScreenRow(2).tokens[0]).toEqual(value: 'bar', scopes: ['source.js'])
-            expect(tokenizedBuffer.lineForScreenRow(3).tokens[0]).toEqual(value: 'baz', scopes: ['source.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0]).toEqual(value: 'bar', scopes: ['source.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0]).toEqual(value: 'baz', scopes: ['source.js'])
 
             # previous line 2 is joined with quux() on line 4
-            expect(tokenizedBuffer.lineForScreenRow(4).tokens[0]).toEqual(value: 'quux', scopes: ['source.js'])
-            expect(tokenizedBuffer.lineForScreenRow(4).tokens[4]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0]).toEqual(value: 'quux', scopes: ['source.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[4]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
 
             # previous line 3 is pushed down to become line 5
-            expect(tokenizedBuffer.lineForScreenRow(5).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
 
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]
@@ -264,17 +264,17 @@ describe "TokenizedBuffer", ->
             [event] = changeHandler.argsForCall[0]
             delete event.bufferChange
             expect(event).toEqual(start: 2, end: 2, delta: 2)
-            expect(tokenizedBuffer.lineForScreenRow(2).tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
-            expect(tokenizedBuffer.lineForScreenRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.lineForScreenRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.lineForScreenRow(5).tokens[0].scopes).toEqual ['source.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].scopes).toEqual ['source.js']
             changeHandler.reset()
 
             advanceClock() # tokenize invalidated lines in background
-            expect(tokenizedBuffer.lineForScreenRow(5).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.lineForScreenRow(6).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.lineForScreenRow(7).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.lineForScreenRow(8).tokens[0].scopes).not.toBe ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(6).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(7).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(8).tokens[0].scopes).not.toBe ['source.js', 'comment.block.js']
 
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]
@@ -285,13 +285,13 @@ describe "TokenizedBuffer", ->
         it "tokenizes the initial chunk synchronously, then tokenizes the remaining lines in the background", ->
           commentBlock = _.multiplyString("// a comment\n", tokenizedBuffer.chunkSize + 2)
           buffer.insert([0,0], commentBlock)
-          expect(tokenizedBuffer.lineForScreenRow(0).ruleStack?).toBeTruthy()
-          expect(tokenizedBuffer.lineForScreenRow(4).ruleStack?).toBeTruthy()
-          expect(tokenizedBuffer.lineForScreenRow(5).ruleStack?).toBeFalsy()
+          expect(tokenizedBuffer.tokenizedLineForRow(0).ruleStack?).toBeTruthy()
+          expect(tokenizedBuffer.tokenizedLineForRow(4).ruleStack?).toBeTruthy()
+          expect(tokenizedBuffer.tokenizedLineForRow(5).ruleStack?).toBeFalsy()
 
           advanceClock()
-          expect(tokenizedBuffer.lineForScreenRow(5).ruleStack?).toBeTruthy()
-          expect(tokenizedBuffer.lineForScreenRow(6).ruleStack?).toBeTruthy()
+          expect(tokenizedBuffer.tokenizedLineForRow(5).ruleStack?).toBeTruthy()
+          expect(tokenizedBuffer.tokenizedLineForRow(6).ruleStack?).toBeTruthy()
 
       describe ".findOpeningBracket(closingBufferPosition)", ->
         it "returns the position of the matching bracket, skipping any nested brackets", ->
@@ -302,18 +302,18 @@ describe "TokenizedBuffer", ->
           expect(tokenizedBuffer.findClosingBracket([1, 29])).toEqual [9, 2]
 
       it "tokenizes leading whitespace based on the new tab length", ->
-        expect(tokenizedBuffer.lineForScreenRow(5).tokens[0].isAtomic).toBeTruthy()
-        expect(tokenizedBuffer.lineForScreenRow(5).tokens[0].value).toBe "  "
-        expect(tokenizedBuffer.lineForScreenRow(5).tokens[1].isAtomic).toBeTruthy()
-        expect(tokenizedBuffer.lineForScreenRow(5).tokens[1].value).toBe "  "
+        expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].isAtomic).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].value).toBe "  "
+        expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[1].isAtomic).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[1].value).toBe "  "
 
         tokenizedBuffer.setTabLength(4)
         fullyTokenize(tokenizedBuffer)
 
-        expect(tokenizedBuffer.lineForScreenRow(5).tokens[0].isAtomic).toBeTruthy()
-        expect(tokenizedBuffer.lineForScreenRow(5).tokens[0].value).toBe "    "
-        expect(tokenizedBuffer.lineForScreenRow(5).tokens[1].isAtomic).toBeFalsy()
-        expect(tokenizedBuffer.lineForScreenRow(5).tokens[1].value).toBe "  current "
+        expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].isAtomic).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].value).toBe "    "
+        expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[1].isAtomic).toBeFalsy()
+        expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[1].value).toBe "  current "
 
   describe "when the buffer contains hard-tabs", ->
     beforeEach ->
@@ -335,7 +335,7 @@ describe "TokenizedBuffer", ->
 
       it "renders each tab as its own atomic token with a value of size tabLength", ->
         tabAsSpaces = _.multiplyString(' ', tokenizedBuffer.getTabLength())
-        screenLine0 = tokenizedBuffer.lineForScreenRow(0)
+        screenLine0 = tokenizedBuffer.tokenizedLineForRow(0)
         expect(screenLine0.text).toBe "# Econ 101#{tabAsSpaces}"
         { tokens } = screenLine0
 
@@ -347,7 +347,7 @@ describe "TokenizedBuffer", ->
         expect(tokens[2].isAtomic).toBeTruthy()
         expect(tokens[3].value).toBe ""
 
-        expect(tokenizedBuffer.lineForScreenRow(2).text).toBe "#{tabAsSpaces} buy()#{tabAsSpaces}while supply > demand"
+        expect(tokenizedBuffer.tokenizedLineForRow(2).text).toBe "#{tabAsSpaces} buy()#{tabAsSpaces}while supply > demand"
 
       it "aligns the hard tabs to the correct tab stop column", ->
         buffer.setText """
@@ -359,62 +359,62 @@ describe "TokenizedBuffer", ->
         tokenizedBuffer.setTabLength(4)
         fullyTokenize(tokenizedBuffer)
 
-        expect(tokenizedBuffer.lineForScreenRow(0).text).toBe "1   2   3   4"
-        expect(tokenizedBuffer.lineForScreenRow(0).tokens[1].bufferDelta).toBe 1
-        expect(tokenizedBuffer.lineForScreenRow(0).tokens[1].screenDelta).toBe 3
+        expect(tokenizedBuffer.tokenizedLineForRow(0).text).toBe "1   2   3   4"
+        expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[1].bufferDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[1].screenDelta).toBe 3
 
-        expect(tokenizedBuffer.lineForScreenRow(1).text).toBe "12  3   4   5"
-        expect(tokenizedBuffer.lineForScreenRow(1).tokens[1].bufferDelta).toBe 1
-        expect(tokenizedBuffer.lineForScreenRow(1).tokens[1].screenDelta).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(1).text).toBe "12  3   4   5"
+        expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[1].bufferDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[1].screenDelta).toBe 2
 
-        expect(tokenizedBuffer.lineForScreenRow(2).text).toBe "123 4       5   6"
-        expect(tokenizedBuffer.lineForScreenRow(2).tokens[1].bufferDelta).toBe 1
-        expect(tokenizedBuffer.lineForScreenRow(2).tokens[1].screenDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(2).text).toBe "123 4       5   6"
+        expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[1].bufferDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[1].screenDelta).toBe 1
 
         tokenizedBuffer.setTabLength(3)
         fullyTokenize(tokenizedBuffer)
 
-        expect(tokenizedBuffer.lineForScreenRow(0).text).toBe "1  2  3  4"
-        expect(tokenizedBuffer.lineForScreenRow(0).tokens[1].bufferDelta).toBe 1
-        expect(tokenizedBuffer.lineForScreenRow(0).tokens[1].screenDelta).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(0).text).toBe "1  2  3  4"
+        expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[1].bufferDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[1].screenDelta).toBe 2
 
-        expect(tokenizedBuffer.lineForScreenRow(1).text).toBe "12 3     4  5"
-        expect(tokenizedBuffer.lineForScreenRow(1).tokens[1].bufferDelta).toBe 1
-        expect(tokenizedBuffer.lineForScreenRow(1).tokens[1].screenDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(1).text).toBe "12 3     4  5"
+        expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[1].bufferDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[1].screenDelta).toBe 1
 
-        expect(tokenizedBuffer.lineForScreenRow(2).text).toBe "123   4     5  6"
-        expect(tokenizedBuffer.lineForScreenRow(2).tokens[1].bufferDelta).toBe 1
-        expect(tokenizedBuffer.lineForScreenRow(2).tokens[1].screenDelta).toBe 3
+        expect(tokenizedBuffer.tokenizedLineForRow(2).text).toBe "123   4     5  6"
+        expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[1].bufferDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[1].screenDelta).toBe 3
 
         tokenizedBuffer.setTabLength(2)
         fullyTokenize(tokenizedBuffer)
 
-        expect(tokenizedBuffer.lineForScreenRow(0).text).toBe "1 2   3 4"
-        expect(tokenizedBuffer.lineForScreenRow(0).tokens[1].bufferDelta).toBe 1
-        expect(tokenizedBuffer.lineForScreenRow(0).tokens[1].screenDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(0).text).toBe "1 2   3 4"
+        expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[1].bufferDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[1].screenDelta).toBe 1
 
-        expect(tokenizedBuffer.lineForScreenRow(1).text).toBe "12  3   4 5"
-        expect(tokenizedBuffer.lineForScreenRow(1).tokens[1].bufferDelta).toBe 1
-        expect(tokenizedBuffer.lineForScreenRow(1).tokens[1].screenDelta).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(1).text).toBe "12  3   4 5"
+        expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[1].bufferDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[1].screenDelta).toBe 2
 
-        expect(tokenizedBuffer.lineForScreenRow(2).text).toBe "123 4     5 6"
-        expect(tokenizedBuffer.lineForScreenRow(2).tokens[1].bufferDelta).toBe 1
-        expect(tokenizedBuffer.lineForScreenRow(2).tokens[1].screenDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(2).text).toBe "123 4     5 6"
+        expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[1].bufferDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[1].screenDelta).toBe 1
 
         tokenizedBuffer.setTabLength(1)
         fullyTokenize(tokenizedBuffer)
 
-        expect(tokenizedBuffer.lineForScreenRow(0).text).toBe "1 2  3 4"
-        expect(tokenizedBuffer.lineForScreenRow(0).tokens[1].bufferDelta).toBe 1
-        expect(tokenizedBuffer.lineForScreenRow(0).tokens[1].screenDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(0).text).toBe "1 2  3 4"
+        expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[1].bufferDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[1].screenDelta).toBe 1
 
-        expect(tokenizedBuffer.lineForScreenRow(1).text).toBe "12 3   4 5"
-        expect(tokenizedBuffer.lineForScreenRow(1).tokens[1].bufferDelta).toBe 1
-        expect(tokenizedBuffer.lineForScreenRow(1).tokens[1].screenDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(1).text).toBe "12 3   4 5"
+        expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[1].bufferDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[1].screenDelta).toBe 1
 
-        expect(tokenizedBuffer.lineForScreenRow(2).text).toBe "123 4    5 6"
-        expect(tokenizedBuffer.lineForScreenRow(2).tokens[1].bufferDelta).toBe 1
-        expect(tokenizedBuffer.lineForScreenRow(2).tokens[1].screenDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(2).text).toBe "123 4    5 6"
+        expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[1].bufferDelta).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[1].screenDelta).toBe 1
 
   describe "when the buffer contains UTF-8 surrogate pairs", ->
     beforeEach ->
@@ -435,7 +435,7 @@ describe "TokenizedBuffer", ->
       buffer.release()
 
     it "renders each UTF-8 surrogate pair as its own atomic token", ->
-      screenLine0 = tokenizedBuffer.lineForScreenRow(0)
+      screenLine0 = tokenizedBuffer.tokenizedLineForRow(0)
       expect(screenLine0.text).toBe "'abc\uD835\uDF97def'"
       { tokens } = screenLine0
 
@@ -447,7 +447,7 @@ describe "TokenizedBuffer", ->
       expect(tokens[3].value).toBe "def"
       expect(tokens[4].value).toBe "'"
 
-      screenLine1 = tokenizedBuffer.lineForScreenRow(1)
+      screenLine1 = tokenizedBuffer.tokenizedLineForRow(1)
       expect(screenLine1.text).toBe "//\uD835\uDF97xyz"
       { tokens } = screenLine1
 
@@ -525,7 +525,7 @@ describe "TokenizedBuffer", ->
         tokenizedBuffer.setGrammar(atom.syntax.selectGrammar('test.erb'))
         fullyTokenize(tokenizedBuffer)
 
-        {tokens} = tokenizedBuffer.lineForScreenRow(0)
+        {tokens} = tokenizedBuffer.tokenizedLineForRow(0)
         expect(tokens[0]).toEqual value: "<div class='name'>", scopes: ["text.html.ruby"]
 
       waitsForPromise ->
@@ -533,7 +533,7 @@ describe "TokenizedBuffer", ->
 
       runs ->
         fullyTokenize(tokenizedBuffer)
-        {tokens} = tokenizedBuffer.lineForScreenRow(0)
+        {tokens} = tokenizedBuffer.tokenizedLineForRow(0)
         expect(tokens[0]).toEqual value: '<', scopes: ["text.html.ruby","meta.tag.block.any.html","punctuation.definition.tag.begin.html"]
 
   describe ".tokenForPosition(position)", ->
@@ -599,9 +599,9 @@ describe "TokenizedBuffer", ->
       tokenizedBuffer.setInvisibles(space: 'S', tab: 'T')
       fullyTokenize(tokenizedBuffer)
 
-      expect(tokenizedBuffer.lineForScreenRow(0).text).toBe "SST Sa line with tabsTand T spacesSTS"
+      expect(tokenizedBuffer.tokenizedLineForRow(0).text).toBe "SST Sa line with tabsTand T spacesSTS"
       # Also needs to work for copies
-      expect(tokenizedBuffer.lineForScreenRow(0).copy().text).toBe "SST Sa line with tabsTand T spacesSTS"
+      expect(tokenizedBuffer.tokenizedLineForRow(0).copy().text).toBe "SST Sa line with tabsTand T spacesSTS"
 
     it "assigns endOfLineInvisibles to tokenized lines", ->
       buffer = new TextBuffer(text: "a line that ends in a carriage-return-line-feed \r\na line that ends in just a line-feed\na line with no ending")
@@ -611,17 +611,17 @@ describe "TokenizedBuffer", ->
       tokenizedBuffer.setInvisibles(cr: 'R', eol: 'N')
       fullyTokenize(tokenizedBuffer)
 
-      expect(tokenizedBuffer.lineForScreenRow(0).endOfLineInvisibles).toEqual ['R', 'N']
-      expect(tokenizedBuffer.lineForScreenRow(1).endOfLineInvisibles).toEqual ['N']
+      expect(tokenizedBuffer.tokenizedLineForRow(0).endOfLineInvisibles).toEqual ['R', 'N']
+      expect(tokenizedBuffer.tokenizedLineForRow(1).endOfLineInvisibles).toEqual ['N']
 
       # Lines ending in soft wraps get no invisibles
-      [left, right] = tokenizedBuffer.lineForScreenRow(0).softWrapAt(20)
+      [left, right] = tokenizedBuffer.tokenizedLineForRow(0).softWrapAt(20)
       expect(left.endOfLineInvisibles).toBe null
       expect(right.endOfLineInvisibles).toEqual ['R', 'N']
 
       tokenizedBuffer.setInvisibles(cr: 'R', eol: false)
-      expect(tokenizedBuffer.lineForScreenRow(0).endOfLineInvisibles).toEqual ['R']
-      expect(tokenizedBuffer.lineForScreenRow(1).endOfLineInvisibles).toEqual []
+      expect(tokenizedBuffer.tokenizedLineForRow(0).endOfLineInvisibles).toEqual ['R']
+      expect(tokenizedBuffer.tokenizedLineForRow(1).endOfLineInvisibles).toEqual []
 
   describe "leading and trailing whitespace", ->
     beforeEach ->
@@ -630,41 +630,40 @@ describe "TokenizedBuffer", ->
       fullyTokenize(tokenizedBuffer)
 
     it "assigns ::firstNonWhitespaceIndex on tokens that have leading whitespace", ->
-      expect(tokenizedBuffer.lineForScreenRow(0).tokens[0].firstNonWhitespaceIndex).toBe null
-      expect(tokenizedBuffer.lineForScreenRow(1).tokens[0].firstNonWhitespaceIndex).toBe 2
-      expect(tokenizedBuffer.lineForScreenRow(1).tokens[1].firstNonWhitespaceIndex).toBe null
+      expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0].firstNonWhitespaceIndex).toBe null
+      expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0].firstNonWhitespaceIndex).toBe 2
+      expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[1].firstNonWhitespaceIndex).toBe null
 
-      expect(tokenizedBuffer.lineForScreenRow(2).tokens[0].firstNonWhitespaceIndex).toBe 2
-      expect(tokenizedBuffer.lineForScreenRow(2).tokens[1].firstNonWhitespaceIndex).toBe 2
-      expect(tokenizedBuffer.lineForScreenRow(2).tokens[2].firstNonWhitespaceIndex).toBe null
+      expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0].firstNonWhitespaceIndex).toBe 2
+      expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[1].firstNonWhitespaceIndex).toBe 2
+      expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[2].firstNonWhitespaceIndex).toBe null
 
       # The 4th token *has* leading whitespace, but isn't entirely whitespace
       buffer.insert([5, 0], ' ')
-      expect(tokenizedBuffer.lineForScreenRow(5).tokens[3].firstNonWhitespaceIndex).toBe 1
-      expect(tokenizedBuffer.lineForScreenRow(5).tokens[4].firstNonWhitespaceIndex).toBe null
+      expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[3].firstNonWhitespaceIndex).toBe 1
+      expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[4].firstNonWhitespaceIndex).toBe null
 
       # Lines that are *only* whitespace are not considered to have leading whitespace
       buffer.insert([10, 0], '  ')
-      expect(tokenizedBuffer.lineForScreenRow(10).tokens[0].firstNonWhitespaceIndex).toBe null
+      expect(tokenizedBuffer.tokenizedLineForRow(10).tokens[0].firstNonWhitespaceIndex).toBe null
 
     it "assigns ::firstTrailingWhitespaceIndex on tokens that have trailing whitespace", ->
       buffer.insert([0, Infinity], '  ')
-      expect(tokenizedBuffer.lineForScreenRow(0).tokens[11].firstTrailingWhitespaceIndex).toBe null
-      expect(tokenizedBuffer.lineForScreenRow(0).tokens[12].firstTrailingWhitespaceIndex).toBe 0
+      expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[11].firstTrailingWhitespaceIndex).toBe null
+      expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[12].firstTrailingWhitespaceIndex).toBe 0
 
       # The last token *has* trailing whitespace, but isn't entirely whitespace
       buffer.setTextInRange([[2, 39], [2, 40]], '  ')
-      expect(tokenizedBuffer.lineForScreenRow(2).tokens[14].firstTrailingWhitespaceIndex).toBe null
-      console.log tokenizedBuffer.lineForScreenRow(2).tokens[15]
-      expect(tokenizedBuffer.lineForScreenRow(2).tokens[15].firstTrailingWhitespaceIndex).toBe 6
+      expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[14].firstTrailingWhitespaceIndex).toBe null
+      expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[15].firstTrailingWhitespaceIndex).toBe 6
 
       # Lines that are *only* whitespace are considered to have trailing whitespace
       buffer.insert([10, 0], '  ')
-      expect(tokenizedBuffer.lineForScreenRow(10).tokens[0].firstTrailingWhitespaceIndex).toBe 0
+      expect(tokenizedBuffer.tokenizedLineForRow(10).tokens[0].firstTrailingWhitespaceIndex).toBe 0
 
     it "only marks trailing whitespace on the last segment of a soft-wrapped line", ->
       buffer.insert([0, Infinity], '  ')
-      tokenizedLine = tokenizedBuffer.lineForScreenRow(0)
+      tokenizedLine = tokenizedBuffer.tokenizedLineForRow(0)
       [segment1, segment2] = tokenizedLine.softWrapAt(16)
       expect(segment1.tokens[5].value).toBe ' '
       expect(segment1.tokens[5].firstTrailingWhitespaceIndex).toBe null
@@ -677,7 +676,7 @@ describe "TokenizedBuffer", ->
       tokenizedBuffer.setInvisibles(space: 'S', tab: 'T')
       fullyTokenize(tokenizedBuffer)
 
-      line = tokenizedBuffer.lineForScreenRow(0).copy()
+      line = tokenizedBuffer.tokenizedLineForRow(0).copy()
       expect(line.tokens[0].firstNonWhitespaceIndex).toBe 2
       expect(line.tokens[line.tokens.length - 1].firstTrailingWhitespaceIndex).toBe 0
 
@@ -704,55 +703,55 @@ describe "TokenizedBuffer", ->
 
     describe "when the line is non-empty", ->
       it "has an indent level based on the leading whitespace on the line", ->
-        expect(tokenizedBuffer.lineForScreenRow(0).indentLevel).toBe 0
-        expect(tokenizedBuffer.lineForScreenRow(1).indentLevel).toBe 1
-        expect(tokenizedBuffer.lineForScreenRow(2).indentLevel).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(0).indentLevel).toBe 0
+        expect(tokenizedBuffer.tokenizedLineForRow(1).indentLevel).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(2).indentLevel).toBe 2
         buffer.insert([2, 0], ' ')
-        expect(tokenizedBuffer.lineForScreenRow(2).indentLevel).toBe 2.5
+        expect(tokenizedBuffer.tokenizedLineForRow(2).indentLevel).toBe 2.5
 
     describe "when the line is empty", ->
       it "assumes the indentation level of the first non-empty line below or above if one exists", ->
         buffer.insert([12, 0], '    ')
         buffer.insert([12, Infinity], '\n\n')
-        expect(tokenizedBuffer.lineForScreenRow(13).indentLevel).toBe 2
-        expect(tokenizedBuffer.lineForScreenRow(14).indentLevel).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(13).indentLevel).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(14).indentLevel).toBe 2
 
         buffer.insert([1, Infinity], '\n\n')
-        expect(tokenizedBuffer.lineForScreenRow(2).indentLevel).toBe 2
-        expect(tokenizedBuffer.lineForScreenRow(3).indentLevel).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(2).indentLevel).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(3).indentLevel).toBe 2
 
         buffer.setText('\n\n\n')
-        expect(tokenizedBuffer.lineForScreenRow(1).indentLevel).toBe 0
+        expect(tokenizedBuffer.tokenizedLineForRow(1).indentLevel).toBe 0
 
     describe "when the changed lines are surrounded by whitespace-only lines", ->
       it "updates the indentLevel of empty lines that precede the change", ->
-        expect(tokenizedBuffer.lineForScreenRow(12).indentLevel).toBe 0
+        expect(tokenizedBuffer.tokenizedLineForRow(12).indentLevel).toBe 0
 
         buffer.insert([12, 0], '\n')
         buffer.insert([13, 0], '  ')
-        expect(tokenizedBuffer.lineForScreenRow(12).indentLevel).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(12).indentLevel).toBe 1
 
       it "updates empty line indent guides when the empty line is the last line", ->
         buffer.insert([12, 2], '\n')
 
         # The newline and he tab need to be in two different operations to surface the bug
         buffer.insert([12, 0], '  ')
-        expect(tokenizedBuffer.lineForScreenRow(13).indentLevel).toBe 1
+        expect(tokenizedBuffer.tokenizedLineForRow(13).indentLevel).toBe 1
 
         buffer.insert([12, 0], '  ')
-        expect(tokenizedBuffer.lineForScreenRow(13).indentLevel).toBe 2
-        expect(tokenizedBuffer.lineForScreenRow(14)).not.toBeDefined()
+        expect(tokenizedBuffer.tokenizedLineForRow(13).indentLevel).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(14)).not.toBeDefined()
 
       it "updates the indentLevel of empty lines surrounding a change that inserts lines", ->
         # create some new lines
         buffer.insert([7, 0], '\n\n')
         buffer.insert([5, 0], '\n\n')
 
-        expect(tokenizedBuffer.lineForScreenRow(5).indentLevel).toBe 3
-        expect(tokenizedBuffer.lineForScreenRow(6).indentLevel).toBe 3
-        expect(tokenizedBuffer.lineForScreenRow(9).indentLevel).toBe 3
-        expect(tokenizedBuffer.lineForScreenRow(10).indentLevel).toBe 3
-        expect(tokenizedBuffer.lineForScreenRow(11).indentLevel).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(5).indentLevel).toBe 3
+        expect(tokenizedBuffer.tokenizedLineForRow(6).indentLevel).toBe 3
+        expect(tokenizedBuffer.tokenizedLineForRow(9).indentLevel).toBe 3
+        expect(tokenizedBuffer.tokenizedLineForRow(10).indentLevel).toBe 3
+        expect(tokenizedBuffer.tokenizedLineForRow(11).indentLevel).toBe 2
 
         tokenizedBuffer.on "changed", changeHandler = jasmine.createSpy('changeHandler')
 
@@ -761,11 +760,11 @@ describe "TokenizedBuffer", ->
         delete changeHandler.argsForCall[0][0].bufferChange
         expect(changeHandler).toHaveBeenCalledWith(start: 5, end: 10, delta: 2)
 
-        expect(tokenizedBuffer.lineForScreenRow(5).indentLevel).toBe 4
-        expect(tokenizedBuffer.lineForScreenRow(6).indentLevel).toBe 4
-        expect(tokenizedBuffer.lineForScreenRow(11).indentLevel).toBe 4
-        expect(tokenizedBuffer.lineForScreenRow(12).indentLevel).toBe 4
-        expect(tokenizedBuffer.lineForScreenRow(13).indentLevel).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(5).indentLevel).toBe 4
+        expect(tokenizedBuffer.tokenizedLineForRow(6).indentLevel).toBe 4
+        expect(tokenizedBuffer.tokenizedLineForRow(11).indentLevel).toBe 4
+        expect(tokenizedBuffer.tokenizedLineForRow(12).indentLevel).toBe 4
+        expect(tokenizedBuffer.tokenizedLineForRow(13).indentLevel).toBe 2
 
       it "updates the indentLevel of empty lines surrounding a change that removes lines", ->
         # create some new lines
@@ -779,9 +778,9 @@ describe "TokenizedBuffer", ->
         delete changeHandler.argsForCall[0][0].bufferChange
         expect(changeHandler).toHaveBeenCalledWith(start: 5, end: 10, delta: -1)
 
-        expect(tokenizedBuffer.lineForScreenRow(5).indentLevel).toBe 2
-        expect(tokenizedBuffer.lineForScreenRow(6).indentLevel).toBe 2
-        expect(tokenizedBuffer.lineForScreenRow(7).indentLevel).toBe 2 # new text
-        expect(tokenizedBuffer.lineForScreenRow(8).indentLevel).toBe 2
-        expect(tokenizedBuffer.lineForScreenRow(9).indentLevel).toBe 2
-        expect(tokenizedBuffer.lineForScreenRow(10).indentLevel).toBe 2 # }
+        expect(tokenizedBuffer.tokenizedLineForRow(5).indentLevel).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(6).indentLevel).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(7).indentLevel).toBe 2 # new text
+        expect(tokenizedBuffer.tokenizedLineForRow(8).indentLevel).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(9).indentLevel).toBe 2
+        expect(tokenizedBuffer.tokenizedLineForRow(10).indentLevel).toBe 2 # }

--- a/spec/tokenized-line-spec.coffee
+++ b/spec/tokenized-line-spec.coffee
@@ -10,13 +10,13 @@ describe "TokenizedLine", ->
         atom.project.open('coffee.coffee').then (o) -> editor = o
 
     it "returns true when the line is only whitespace", ->
-      expect(editor.lineForScreenRow(3).isOnlyWhitespace()).toBe true
-      expect(editor.lineForScreenRow(7).isOnlyWhitespace()).toBe true
-      expect(editor.lineForScreenRow(23).isOnlyWhitespace()).toBe true
+      expect(editor.tokenizedLineForScreenRow(3).isOnlyWhitespace()).toBe true
+      expect(editor.tokenizedLineForScreenRow(7).isOnlyWhitespace()).toBe true
+      expect(editor.tokenizedLineForScreenRow(23).isOnlyWhitespace()).toBe true
 
     it "returns false when the line is not only whitespace", ->
-      expect(editor.lineForScreenRow(0).isOnlyWhitespace()).toBe false
-      expect(editor.lineForScreenRow(2).isOnlyWhitespace()).toBe false
+      expect(editor.tokenizedLineForScreenRow(0).isOnlyWhitespace()).toBe false
+      expect(editor.tokenizedLineForScreenRow(2).isOnlyWhitespace()).toBe false
 
   describe "::getScopeTree()", ->
     it "returns a tree whose inner nodes are scopes and whose leaf nodes are tokens in those scopes", ->
@@ -35,6 +35,6 @@ describe "TokenizedLine", ->
 
       runs ->
         tokenIndex = 0
-        tokens = editor.lineForScreenRow(1).tokens
-        scopeTree = editor.lineForScreenRow(1).getScopeTree()
+        tokens = editor.tokenizedLineForScreenRow(1).tokens
+        scopeTree = editor.tokenizedLineForScreenRow(1).getScopeTree()
         ensureValidScopeTree(scopeTree)

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -222,7 +222,7 @@ class Cursor extends Model
   # Public: Returns the cursor's current buffer row of text excluding its line
   # ending.
   getCurrentBufferLine: ->
-    @editor.lineForBufferRow(@getBufferRow())
+    @editor.lineTextForBufferRow(@getBufferRow())
 
   # Public: Moves the cursor up one screen row.
   moveUp: (rowCount=1, {moveToEndOfSelection}={}) ->
@@ -562,7 +562,7 @@ class Cursor extends Model
   # its current position.
   hasPrecedingCharactersOnLine: ->
     bufferPosition = @getBufferPosition()
-    line = @editor.lineForBufferRow(bufferPosition.row)
+    line = @editor.lineTextForBufferRow(bufferPosition.row)
     firstCharacterColumn = line.search(/\S/)
 
     if firstCharacterColumn is -1

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -377,10 +377,10 @@ class DisplayBuffer extends Model
 
   # Gets the screen line for the given screen row.
   #
-  # screenRow - A {Number} indicating the screen row.
+  # * `row` - A {Number} indicating the screen row.
   #
-  # Returns a {ScreenLine}.
-  lineForRow: (row) ->
+  # Returns {TokenizedLine}
+  tokenizedLineForRow: (row) ->
     @screenLines[row]
 
   # Gets the screen lines for the given screen row range.
@@ -388,13 +388,13 @@ class DisplayBuffer extends Model
   # startRow - A {Number} indicating the beginning screen row.
   # endRow - A {Number} indicating the ending screen row.
   #
-  # Returns an {Array} of {ScreenLine}s.
+  # Returns an {Array} of {TokenizedLine}s.
   linesForRows: (startRow, endRow) ->
     @screenLines[startRow..endRow]
 
   # Gets all the screen lines.
   #
-  # Returns an {Array} of {ScreenLines}s.
+  # Returns an {Array} of {TokenizedLine}s.
   getLines: ->
     new Array(@screenLines...)
 
@@ -555,7 +555,7 @@ class DisplayBuffer extends Model
     top = targetRow * @lineHeightInPixels
     left = 0
     column = 0
-    for token in @lineForRow(targetRow).tokens
+    for token in @tokenizedLineForRow(targetRow).tokens
       charWidths = @getScopedCharWidths(token.scopes)
       for char in token.value
         return {top, left} if column is targetColumn
@@ -573,7 +573,7 @@ class DisplayBuffer extends Model
 
     left = 0
     column = 0
-    for token in @lineForRow(row).tokens
+    for token in @tokenizedLineForRow(row).tokens
       charWidths = @getScopedCharWidths(token.scopes)
       for char in token.value
         charWidth = charWidths[char] ? defaultCharWidth
@@ -983,7 +983,7 @@ class DisplayBuffer extends Model
 
   logLines: (start=0, end=@getLastRow()) ->
     for row in [start..end]
-      line = @lineForRow(row).text
+      line = @tokenizedLineForRow(row).text
       console.log row, @bufferRowForScreenRow(row), line, line.length
 
   handleTokenizedBufferChange: (tokenizedBufferChange) =>

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -377,11 +377,11 @@ class DisplayBuffer extends Model
 
   # Gets the screen line for the given screen row.
   #
-  # * `row` - A {Number} indicating the screen row.
+  # * `screenRow` - A {Number} indicating the screen row.
   #
   # Returns {TokenizedLine}
-  tokenizedLineForRow: (row) ->
-    @screenLines[row]
+  tokenizedLineForScreenRow: (screenRow) ->
+    @screenLines[screenRow]
 
   # Gets the screen lines for the given screen row range.
   #
@@ -555,7 +555,7 @@ class DisplayBuffer extends Model
     top = targetRow * @lineHeightInPixels
     left = 0
     column = 0
-    for token in @tokenizedLineForRow(targetRow).tokens
+    for token in @tokenizedLineForScreenRow(targetRow).tokens
       charWidths = @getScopedCharWidths(token.scopes)
       for char in token.value
         return {top, left} if column is targetColumn
@@ -573,7 +573,7 @@ class DisplayBuffer extends Model
 
     left = 0
     column = 0
-    for token in @tokenizedLineForRow(row).tokens
+    for token in @tokenizedLineForScreenRow(row).tokens
       charWidths = @getScopedCharWidths(token.scopes)
       for char in token.value
         charWidth = charWidths[char] ? defaultCharWidth
@@ -983,7 +983,7 @@ class DisplayBuffer extends Model
 
   logLines: (start=0, end=@getLastRow()) ->
     for row in [start..end]
-      line = @tokenizedLineForRow(row).text
+      line = @tokenizedLineForScreenRow(row).text
       console.log row, @bufferRowForScreenRow(row), line, line.length
 
   handleTokenizedBufferChange: (tokenizedBufferChange) =>

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -395,7 +395,7 @@ class DisplayBuffer extends Model
   # Gets all the screen lines.
   #
   # Returns an {Array} of {TokenizedLine}s.
-  getLines: ->
+  getTokenizedLines: ->
     new Array(@screenLines...)
 
   indentLevelForLine: (line) ->

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -1024,7 +1024,7 @@ class DisplayBuffer extends Model
 
     bufferRow = startBufferRow
     while bufferRow < endBufferRow
-      tokenizedLine = @tokenizedBuffer.lineForScreenRow(bufferRow)
+      tokenizedLine = @tokenizedBuffer.tokenizedLineForRow(bufferRow)
 
       if fold = @largestFoldStartingAtBufferRow(bufferRow)
         foldLine = tokenizedLine.copy()

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -389,7 +389,7 @@ class DisplayBuffer extends Model
   # endRow - A {Number} indicating the ending screen row.
   #
   # Returns an {Array} of {TokenizedLine}s.
-  linesForRows: (startRow, endRow) ->
+  tokenizedLinesForScreenRows: (startRow, endRow) ->
     @screenLines[startRow..endRow]
 
   # Gets all the screen lines.

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -59,7 +59,7 @@ EditorComponent = React.createClass
       [renderedStartRow, renderedEndRow] = renderedRowRange
       cursorPixelRects = @getCursorPixelRects(renderedRowRange)
 
-      tokenizedLines = editor.linesForScreenRows(renderedStartRow, renderedEndRow - 1)
+      tokenizedLines = editor.tokenizedLinesForScreenRows(renderedStartRow, renderedEndRow - 1)
 
       decorations = editor.decorationsForScreenRowRange(renderedStartRow, renderedEndRow)
       highlightDecorations = @getHighlightDecorations(decorations)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -413,7 +413,10 @@ class Editor extends Model
   # given buffer row.
   #
   # * `row` A {Number} representing a zero-indexed buffer row.
-  lineForBufferRow: (row) -> @buffer.lineForRow(row)
+  lineTextForBufferRow: (row) -> @buffer.lineForRow(row)
+  lineForBufferRow: (row) ->
+    deprecate 'Use Editor::lineTextForBufferRow(row) instead'
+    @lineTextForBufferRow(row)
 
   # {Delegates to: DisplayBuffer.lineForRow}
   lineForScreenRow: (row) -> @displayBuffer.lineForRow(row)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -434,11 +434,13 @@ class Editor extends Model
     deprecate "Use Editor::tokenizedLinesForScreenRows instead"
     @tokenizedLinesForScreenRows(start, end)
 
-  # Public: Returns a {Number} representing the line length for the given
+  # Returns a {Number} representing the line length for the given
   # buffer row, exclusive of its line-ending character(s).
   #
   # * `row` A {Number} indicating the buffer row.
-  lineLengthForBufferRow: (row) -> @buffer.lineLengthForRow(row)
+  lineLengthForBufferRow: (row) ->
+    deprecate "Use editor.lineTextForBufferRow(row).length instead"
+    @lineTextForBufferRow(row).length
 
   bufferRowForScreenRow: (row) -> @displayBuffer.bufferRowForScreenRow(row)
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -422,7 +422,7 @@ class Editor extends Model
   # given screen row.
   #
   # * `screenRow` A {Number} representing a zero-indexed screen row.
-  lineTextForScreenRow: (screenRow) -> @displayBuffer.tokenizedLineForScreenRow(screenRow).text
+  lineTextForScreenRow: (screenRow) -> @displayBuffer.tokenizedLineForScreenRow(screenRow)?.text
 
   # Gets the screen line for the given screen row.
   #

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -837,7 +837,7 @@ class Editor extends Model
   # whitespace.
   usesSoftTabs: ->
     for bufferRow in [0..@buffer.getLastRow()]
-      continue if @displayBuffer.tokenizedBuffer.lineForScreenRow(bufferRow).isComment()
+      continue if @displayBuffer.tokenizedBuffer.tokenizedLineForRow(bufferRow).isComment()
 
       line = @buffer.lineForRow(bufferRow)
       return true  if line[0] is ' '

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -429,7 +429,10 @@ class Editor extends Model
     @tokenizedLineForScreenRow(screenRow)
 
   # {Delegates to: DisplayBuffer.tokenizedLinesForScreenRows}
-  linesForScreenRows: (start, end) -> @displayBuffer.tokenizedLinesForScreenRows(start, end)
+  tokenizedLinesForScreenRows: (start, end) -> @displayBuffer.tokenizedLinesForScreenRows(start, end)
+  linesForScreenRows: (start, end) ->
+    deprecate "Use Editor::tokenizedLinesForScreenRows instead"
+    @tokenizedLinesForScreenRows(start, end)
 
   # Public: Returns a {Number} representing the line length for the given
   # buffer row, exclusive of its line-ending character(s).

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -420,6 +420,15 @@ class Editor extends Model
 
   # {Delegates to: DisplayBuffer.lineForRow}
   lineForScreenRow: (row) -> @displayBuffer.lineForRow(row)
+  # Gets the screen line for the given screen row.
+  #
+  # * `screenRow` - A {Number} indicating the screen row.
+  #
+  # Returns {TokenizedLine}
+  tokenizedLineForScreenRow: (screenRow) -> @displayBuffer.tokenizedLineForScreenRow(screenRow)
+  lineForScreenRow: (screenRow) ->
+    deprecate "Editor::tokenizedLineForScreenRow(bufferRow) is the new name. But it's private. Try to use Editor::lineTextForScreenRow instead"
+    @tokenizedLineForScreenRow(screenRow)
 
   # {Delegates to: DisplayBuffer.tokenizedLinesForScreenRows}
   linesForScreenRows: (start, end) -> @displayBuffer.tokenizedLinesForScreenRows(start, end)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -418,6 +418,12 @@ class Editor extends Model
     deprecate 'Use Editor::lineTextForBufferRow(bufferRow) instead'
     @lineTextForBufferRow(bufferRow)
 
+  # Public: Returns a {String} representing the contents of the line at the
+  # given screen row.
+  #
+  # * `screenRow` A {Number} representing a zero-indexed screen row.
+  lineTextForScreenRow: (screenRow) -> @displayBuffer.tokenizedLineForScreenRow(screenRow).text
+
   # Gets the screen line for the given screen row.
   #
   # * `screenRow` - A {Number} indicating the screen row.

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -412,14 +412,12 @@ class Editor extends Model
   # Public: Returns a {String} representing the contents of the line at the
   # given buffer row.
   #
-  # * `row` A {Number} representing a zero-indexed buffer row.
-  lineTextForBufferRow: (row) -> @buffer.lineForRow(row)
-  lineForBufferRow: (row) ->
-    deprecate 'Use Editor::lineTextForBufferRow(row) instead'
-    @lineTextForBufferRow(row)
+  # * `bufferRow` A {Number} representing a zero-indexed buffer row.
+  lineTextForBufferRow: (bufferRow) -> @buffer.lineForRow(bufferRow)
+  lineForBufferRow: (bufferRow) ->
+    deprecate 'Use Editor::lineTextForBufferRow(bufferRow) instead'
+    @lineTextForBufferRow(bufferRow)
 
-  # {Delegates to: DisplayBuffer.lineForRow}
-  lineForScreenRow: (row) -> @displayBuffer.lineForRow(row)
   # Gets the screen line for the given screen row.
   #
   # * `screenRow` - A {Number} indicating the screen row.
@@ -923,7 +921,7 @@ class Editor extends Model
   #
   # Returns a {Number}.
   indentationForBufferRow: (bufferRow) ->
-    @indentLevelForLine(@lineForBufferRow(bufferRow))
+    @indentLevelForLine(@lineTextForBufferRow(bufferRow))
 
   # Public: Set the indentation level for the given buffer row.
   #
@@ -941,7 +939,7 @@ class Editor extends Model
     if preserveLeadingWhitespace
       endColumn = 0
     else
-      endColumn = @lineForBufferRow(bufferRow).match(/^\s*/)[0].length
+      endColumn = @lineTextForBufferRow(bufferRow).match(/^\s*/)[0].length
     newIndentString = @buildIndentString(newLevel)
     @buffer.setTextInRange([[bufferRow, 0], [bufferRow, endColumn]], newIndentString)
 
@@ -1188,7 +1186,7 @@ class Editor extends Model
 
   # Public: Determine if the given row is entirely a comment
   isBufferRowCommented: (bufferRow) ->
-    if match = @lineForBufferRow(bufferRow).match(/\S/)
+    if match = @lineTextForBufferRow(bufferRow).match(/\S/)
       scopes = @tokenForBufferPosition([bufferRow, match.index]).scopes
       new TextMateScopeSelector('comment.*').matches(scopes)
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -421,8 +421,8 @@ class Editor extends Model
   # {Delegates to: DisplayBuffer.lineForRow}
   lineForScreenRow: (row) -> @displayBuffer.lineForRow(row)
 
-  # {Delegates to: DisplayBuffer.linesForRows}
-  linesForScreenRows: (start, end) -> @displayBuffer.linesForRows(start, end)
+  # {Delegates to: DisplayBuffer.tokenizedLinesForScreenRows}
+  linesForScreenRows: (start, end) -> @displayBuffer.tokenizedLinesForScreenRows(start, end)
 
   # Public: Returns a {Number} representing the line length for the given
   # buffer row, exclusive of its line-ending character(s).

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -168,7 +168,7 @@ class LanguageMode
       continue if @editor.isBufferRowBlank(row)
       indentation = @editor.indentationForBufferRow(row)
       if indentation <= startIndentLevel
-        includeRowInFold = indentation == startIndentLevel and @foldEndRegexForScopes(scopes)?.searchSync(@editor.lineForBufferRow(row))
+        includeRowInFold = indentation == startIndentLevel and @foldEndRegexForScopes(scopes)?.searchSync(@editor.lineTextForBufferRow(row))
         foldEndRow = row if includeRowInFold
         break
 
@@ -207,7 +207,7 @@ class LanguageMode
   # Right now, a paragraph is a block of text bounded by and empty line or a
   # block of text that is not the same type (comments next to source code).
   rowRangeForParagraphAtBufferRow: (bufferRow) ->
-    return unless /\w/.test(@editor.lineForBufferRow(bufferRow))
+    return unless /\w/.test(@editor.lineTextForBufferRow(bufferRow))
 
     if @isLineCommentedAtBufferRow(bufferRow)
       isOriginalRowComment = true
@@ -220,14 +220,14 @@ class LanguageMode
     startRow = bufferRow
     while startRow > firstRow
       break if @isLineCommentedAtBufferRow(startRow - 1) != isOriginalRowComment
-      break unless /\w/.test(@editor.lineForBufferRow(startRow - 1))
+      break unless /\w/.test(@editor.lineTextForBufferRow(startRow - 1))
       startRow--
 
     endRow = bufferRow
     lastRow = @editor.getLastBufferRow()
     while endRow < lastRow
       break if @isLineCommentedAtBufferRow(endRow + 1) != isOriginalRowComment
-      break unless /\w/.test(@editor.lineForBufferRow(endRow + 1))
+      break unless /\w/.test(@editor.lineTextForBufferRow(endRow + 1))
       endRow++
 
     new Range([startRow, 0], [endRow, @editor.lineLengthForBufferRow(endRow)])

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -145,17 +145,17 @@ class LanguageMode
     rowRange
 
   rowRangeForCommentAtBufferRow: (bufferRow) ->
-    return unless @editor.displayBuffer.tokenizedBuffer.lineForScreenRow(bufferRow).isComment()
+    return unless @editor.displayBuffer.tokenizedBuffer.tokenizedLineForRow(bufferRow).isComment()
 
     startRow = bufferRow
     for currentRow in [bufferRow-1..0]
       break if @buffer.isRowBlank(currentRow)
-      break unless @editor.displayBuffer.tokenizedBuffer.lineForScreenRow(currentRow).isComment()
+      break unless @editor.displayBuffer.tokenizedBuffer.tokenizedLineForRow(currentRow).isComment()
       startRow = currentRow
     endRow = bufferRow
     for currentRow in [bufferRow+1..@buffer.getLastRow()]
       break if @buffer.isRowBlank(currentRow)
-      break unless @editor.displayBuffer.tokenizedBuffer.lineForScreenRow(currentRow).isComment()
+      break unless @editor.displayBuffer.tokenizedBuffer.tokenizedLineForRow(currentRow).isComment()
       endRow = currentRow
     return [startRow, endRow] if startRow isnt endRow
 
@@ -201,7 +201,7 @@ class LanguageMode
   # row is a comment.
   isLineCommentedAtBufferRow: (bufferRow) ->
     return false unless 0 <= bufferRow <= @editor.getLastBufferRow()
-    @editor.displayBuffer.tokenizedBuffer.lineForScreenRow(bufferRow).isComment()
+    @editor.displayBuffer.tokenizedBuffer.tokenizedLineForRow(bufferRow).isComment()
 
   # Find a row range for a 'paragraph' around specified bufferRow.
   # Right now, a paragraph is a block of text bounded by and empty line or a

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -230,7 +230,7 @@ class LanguageMode
       break unless /\w/.test(@editor.lineTextForBufferRow(endRow + 1))
       endRow++
 
-    new Range([startRow, 0], [endRow, @editor.lineLengthForBufferRow(endRow)])
+    new Range([startRow, 0], [endRow, @editor.lineTextForBufferRow(endRow).length])
 
   # Given a buffer row, this returns a suggested indentation level.
   #

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -221,10 +221,8 @@ class TokenizedBuffer extends Model
     {tokens, ruleStack} = @grammar.tokenizeLine(line, ruleStack, row is 0)
     new TokenizedLine({tokens, ruleStack, tabLength, lineEnding, indentLevel, @invisibles})
 
-  # FIXME: benogle says: These are actually buffer rows as all buffer rows are
-  # accounted for in @tokenizedLines
-  lineForScreenRow: (row) ->
-    @linesForScreenRows(row, row)[0]
+  tokenizedLineForRow: (bufferRow) ->
+    @tokenizedLines[bufferRow]
 
   # FIXME: benogle says: These are actually buffer rows as all buffer rows are
   # accounted for in @tokenizedLines

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -224,10 +224,6 @@ class TokenizedBuffer extends Model
   tokenizedLineForRow: (bufferRow) ->
     @tokenizedLines[bufferRow]
 
-  # FIXME: benogle says: These are actually buffer rows as all buffer rows are
-  # accounted for in @tokenizedLines
-  linesForScreenRows: (startRow, endRow) ->
-    @tokenizedLines[startRow..endRow]
 
   stackForRow: (row) ->
     @tokenizedLines[row]?.ruleStack

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -224,16 +224,15 @@ class TokenizedBuffer extends Model
   tokenizedLineForRow: (bufferRow) ->
     @tokenizedLines[bufferRow]
 
+  stackForRow: (bufferRow) ->
+    @tokenizedLines[bufferRow]?.ruleStack
 
-  stackForRow: (row) ->
-    @tokenizedLines[row]?.ruleStack
-
-  indentLevelForRow: (row) ->
-    line = @buffer.lineForRow(row)
+  indentLevelForRow: (bufferRow) ->
+    line = @buffer.lineForRow(bufferRow)
     indentLevel = 0
 
     if line is ''
-      nextRow = row + 1
+      nextRow = bufferRow + 1
       lineCount = @getLineCount()
       while nextRow < lineCount
         nextLine = @buffer.lineForRow(nextRow)
@@ -242,7 +241,7 @@ class TokenizedBuffer extends Model
           break
         nextRow++
 
-      previousRow = row - 1
+      previousRow = bufferRow - 1
       while previousRow >= 0
         previousLine = @buffer.lineForRow(previousRow)
         unless previousLine is ''

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -366,5 +366,5 @@ class TokenizedBuffer extends Model
 
   logLines: (start=0, end=@buffer.getLastRow()) ->
     for row in [start..end]
-      line = @lineForScreenRow(row).text
+      line = @tokenizedLineForRow(row).text
       console.log row, line, line.length


### PR DESCRIPTION
On `Editor`, we had 

``` coffee
::lineForScreenRow # -> Private; returns a TokenizedLine
::lineForBufferRow # -> returns a String
::lineLengthForBufferRow # -> returns an int
```

Deprecated all those and now we have

``` coffee
::tokenizedLineForScreenRow # -> Private; returns a TokenizedLine
::lineTextForBufferRow # -> returns a String
::lineTextForScreenRow # -> returns a String
```

The length can be had via `lineTextFor*Row(row).length`

It also renames several methods in DisplayBuffer and TokenizedBuffer for clarity (eg. TokenizedBuffer had a set of methods named like `lineForScreenRow` even though it took a buffer row as a param). Those entire classes are not public, so there are no deprecations on those methods.

The most interesting stuff is in `editor.coffee` if you want to look / feedback.
