### PR TITLE
Remove check for deprecated function calls

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -138,7 +138,6 @@ afterEach ->
   jasmine.unspy(atom, 'saveSync')
   ensureNoPathSubscriptions()
   atom.syntax.off()
-  ensureNoDeprecatedFunctionsCalled() if isCoreSpec
   waits(0) # yield to ui thread to make screen update more frequently
 
 ensureNoPathSubscriptions = ->


### PR DESCRIPTION
This is causing CI to fail currently: see https://janky.githubapp.com/1664307/output

cc @kevinsawicki @benogle 
