### PR TITLE
Deprecate obvious EditorView methods

### DIFF
--- a/benchmark/benchmark-suite.coffee
+++ b/benchmark/benchmark-suite.coffee
@@ -62,8 +62,8 @@ describe "editorView.", ->
     describe "empty-vs-set-innerHTML.", ->
       [firstRow, lastRow] = []
       beforeEach ->
-        firstRow = editorView.getFirstVisibleScreenRow()
-        lastRow = editorView.getLastVisibleScreenRow()
+        firstRow = editorView.getModel().getFirstVisibleScreenRow()
+        lastRow = editorView.getModel().getLastVisibleScreenRow()
 
       benchmark "build-gutter-html.", 1000, ->
         editorView.gutter.renderLineNumbers(null, firstRow, lastRow)
@@ -97,8 +97,8 @@ describe "editorView.", ->
       describe "multiple-lines.", ->
         [firstRow, lastRow] = []
         beforeEach ->
-          firstRow = editorView.getFirstVisibleScreenRow()
-          lastRow = editorView.getLastVisibleScreenRow()
+          firstRow = editorView.getModel().getFirstVisibleScreenRow()
+          lastRow = editorView.getModel().getLastVisibleScreenRow()
 
         benchmark "cache-entire-visible-area", 100, ->
           for i in [firstRow..lastRow]

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -173,23 +173,16 @@ class EditorView extends View
   scrollToBottom: ->
     @editor.setScrollBottom(Infinity)
 
-  # Public: Scrolls the editor to the given screen position.
-  #
-  # * `screenPosition` An object that represents a buffer position. It can be either
-  #    an {Object} (`{row, column}`), {Array} (`[row, column]`), or {Point}
-  # * `options` (optional) {Object} matching the options available to {::scrollToScreenPosition}
   scrollToScreenPosition: (screenPosition, options) ->
+    deprecate 'Use Editor::scrollToScreenPosition instead. You can get the editor via editorView.getModel()'
     @editor.scrollToScreenPosition(screenPosition, options)
 
-  # Public: Scrolls the editor to the given buffer position.
-  #
-  # * `bufferPosition` An object that represents a buffer position. It can be either
-  #   an {Object} (`{row, column}`), {Array} (`[row, column]`), or {Point}
-  # * `options` (optional) {Object} matching the options available to {::scrollToBufferPosition}
   scrollToBufferPosition: (bufferPosition, options) ->
+    deprecate 'Use Editor::scrollToBufferPosition instead. You can get the editor via editorView.getModel()'
     @editor.scrollToBufferPosition(bufferPosition, options)
 
   scrollToCursorPosition: ->
+    deprecate 'Use Editor::scrollToCursorPosition instead. You can get the editor via editorView.getModel()'
     @editor.scrollToCursorPosition()
 
   # Public: Converts a buffer position to a pixel position.

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -101,7 +101,6 @@ class EditorView extends View
     @overlayer = $(node).find('.lines').addClass('overlayer')
     @hiddenInput = $(node).find('.hidden-input')
 
-    # FIXME: there should be a better way to deal with the gutter element
     @subscribe atom.config.observe 'editor.showLineNumbers', =>
       @gutter = $(node).find('.gutter')
 

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -185,22 +185,12 @@ class EditorView extends View
     deprecate 'Use Editor::scrollToCursorPosition instead. You can get the editor via editorView.getModel()'
     @editor.scrollToCursorPosition()
 
-  # Public: Converts a buffer position to a pixel position.
-  #
-  # * `bufferPosition` An object that represents a buffer position. It can be either
-  #   an {Object} (`{row, column}`), {Array} (`[row, column]`), or {Point}
-  #
-  # Returns an {Object} with two values: `top` and `left`, representing the pixel positions.
   pixelPositionForBufferPosition: (bufferPosition) ->
+    deprecate 'Use Editor::pixelPositionForBufferPosition instead. You can get the editor via editorView.getModel()'
     @editor.pixelPositionForBufferPosition(bufferPosition)
 
-  # Public: Converts a screen position to a pixel position.
-  #
-  # * `screenPosition` An object that represents a screen position. It can be either
-  #   an {Object} (`{row, column}`), {Array} (`[row, column]`), or {Point}
-  #
-  # Returns an object with two values: `top` and `left`, representing the pixel positions.
   pixelPositionForScreenPosition: (screenPosition) ->
+    deprecate 'Use Editor::pixelPositionForScreenPosition instead. You can get the editor via editorView.getModel()'
     @editor.pixelPositionForScreenPosition(screenPosition)
 
   appendToLinesView: (view) ->

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -306,10 +306,8 @@ class EditorView extends View
   setShowIndentGuide: (showIndentGuide) ->
     @component.setShowIndentGuide(showIndentGuide)
 
-  # Public: Enables/disables soft wrap on the editor.
-  #
-  # * `softWrap` A {Boolean} which, if `true`, enables soft wrap
   setSoftWrap: (softWrap) ->
+    deprecate 'Use Editor::setSoftWrap instead. You can get the editor via editorView.getModel()'
     @editor.setSoftWrap(softWrap)
 
   # Public: Set whether invisible characters are shown.

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -169,8 +169,8 @@ class EditorView extends View
     else
       @editor.getScrollLeft()
 
-  # Public: Scrolls the editor to the bottom.
   scrollToBottom: ->
+    deprecate 'Use Editor::scrollToBottom instead. You can get the editor via editorView.getModel()'
     @editor.setScrollBottom(Infinity)
 
   scrollToScreenPosition: (screenPosition, options) ->

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -256,19 +256,13 @@ class EditorView extends View
     deprecate('Use editorView.getModel().pageUp()')
     @editor.pageUp()
 
-  # Public: Retrieves the number of the row that is visible and currently at the
-  # top of the editor.
-  #
-  # Returns a {Number}.
   getFirstVisibleScreenRow: ->
-    @editor.getVisibleRowRange()[0]
+    deprecate 'Use Editor::getFirstVisibleScreenRow instead. You can get the editor via editorView.getModel()'
+    @editor.getFirstVisibleScreenRow()
 
-  # Public: Retrieves the number of the row that is visible and currently at the
-  # bottom of the editor.
-  #
-  # Returns a {Number}.
   getLastVisibleScreenRow: ->
-    @editor.getVisibleRowRange()[1]
+    deprecate 'Use Editor::getLastVisibleScreenRow instead. You can get the editor via editorView.getModel()'
+    @editor.getLastVisibleScreenRow()
 
   # Public: Gets the font family for the editor.
   #

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -2293,13 +2293,43 @@ class Editor extends Model
   Section: Scrolling the Editor
   ###
 
-  # Public: Scroll the editor to reveal the most recently added cursor if it is
+  # Essential: Scroll the editor to reveal the most recently added cursor if it is
   # off-screen.
   #
   # * `options` (optional) {Object}
-  #   * `center` Center the editor around the cursor if possible. Defauls to true.
+  #   * `center` Center the editor around the cursor if possible. (default: true)
   scrollToCursorPosition: (options) ->
     @getLastCursor().autoscroll(center: options?.center ? true)
+
+  # Essential: Scrolls the editor to the given buffer position.
+  #
+  # * `bufferPosition` An object that represents a buffer position. It can be either
+  #   an {Object} (`{row, column}`), {Array} (`[row, column]`), or {Point}
+  # * `options` (optional) {Object}
+  #   * `center` Center the editor around the position if possible. (default: false)
+  scrollToBufferPosition: (bufferPosition, options) ->
+    @displayBuffer.scrollToBufferPosition(bufferPosition, options)
+
+  # Essential: Scrolls the editor to the given screen position.
+  #
+  # * `screenPosition` An object that represents a buffer position. It can be either
+  #    an {Object} (`{row, column}`), {Array} (`[row, column]`), or {Point}
+  # * `options` (optional) {Object}
+  #   * `center` Center the editor around the position if possible. (default: false)
+  scrollToScreenPosition: (screenPosition, options) ->
+    @displayBuffer.scrollToScreenPosition(screenPosition, options)
+
+  scrollToScreenRange: (screenRange, options) -> @displayBuffer.scrollToScreenRange(screenRange, options)
+
+  horizontallyScrollable: -> @displayBuffer.horizontallyScrollable()
+
+  verticallyScrollable: -> @displayBuffer.verticallyScrollable()
+
+  getHorizontalScrollbarHeight: -> @displayBuffer.getHorizontalScrollbarHeight()
+  setHorizontalScrollbarHeight: (height) -> @displayBuffer.setHorizontalScrollbarHeight(height)
+
+  getVerticalScrollbarWidth: -> @displayBuffer.getVerticalScrollbarWidth()
+  setVerticalScrollbarWidth: (width) -> @displayBuffer.setVerticalScrollbarWidth(width)
 
   pageUp: ->
     newScrollTop = @getScrollTop() - @getHeight()
@@ -2418,22 +2448,6 @@ class Editor extends Model
   screenPositionForPixelPosition: (pixelPosition) -> @displayBuffer.screenPositionForPixelPosition(pixelPosition)
 
   pixelRectForScreenRange: (screenRange) -> @displayBuffer.pixelRectForScreenRange(screenRange)
-
-  scrollToScreenRange: (screenRange, options) -> @displayBuffer.scrollToScreenRange(screenRange, options)
-
-  scrollToScreenPosition: (screenPosition, options) -> @displayBuffer.scrollToScreenPosition(screenPosition, options)
-
-  scrollToBufferPosition: (bufferPosition, options) -> @displayBuffer.scrollToBufferPosition(bufferPosition, options)
-
-  horizontallyScrollable: -> @displayBuffer.horizontallyScrollable()
-
-  verticallyScrollable: -> @displayBuffer.verticallyScrollable()
-
-  getHorizontalScrollbarHeight: -> @displayBuffer.getHorizontalScrollbarHeight()
-  setHorizontalScrollbarHeight: (height) -> @displayBuffer.setHorizontalScrollbarHeight(height)
-
-  getVerticalScrollbarWidth: -> @displayBuffer.getVerticalScrollbarWidth()
-  setVerticalScrollbarWidth: (width) -> @displayBuffer.setVerticalScrollbarWidth(width)
 
   # Deprecated: Call {::joinLines} instead.
   joinLine: ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -2319,6 +2319,10 @@ class Editor extends Model
   scrollToScreenPosition: (screenPosition, options) ->
     @displayBuffer.scrollToScreenPosition(screenPosition, options)
 
+  # Essential: Scrolls the editor to the top
+  scrollToTop: ->
+    @setScrollTop(0)
+
   # Essential: Scrolls the editor to the bottom
   scrollToBottom: ->
     @setScrollBottom(Infinity)

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -2396,7 +2396,21 @@ class Editor extends Model
   Section: Editor Rendering
   ###
 
-  # Public: Converts a buffer position to a pixel position.
+  # Extended: Retrieves the number of the row that is visible and currently at the
+  # top of the editor.
+  #
+  # Returns a {Number}.
+  getFirstVisibleScreenRow: ->
+    @getVisibleRowRange()[0]
+
+  # Extended: Retrieves the number of the row that is visible and currently at the
+  # bottom of the editor.
+  #
+  # Returns a {Number}.
+  getLastVisibleScreenRow: ->
+    @getVisibleRowRange()[1]
+
+  # Extended: Converts a buffer position to a pixel position.
   #
   # * `bufferPosition` An object that represents a buffer position. It can be either
   #   an {Object} (`{row, column}`), {Array} (`[row, column]`), or {Point}

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -2319,6 +2319,10 @@ class Editor extends Model
   scrollToScreenPosition: (screenPosition, options) ->
     @displayBuffer.scrollToScreenPosition(screenPosition, options)
 
+  # Essential: Scrolls the editor to the bottom
+  scrollToBottom: ->
+    @setScrollBottom(Infinity)
+
   scrollToScreenRange: (screenRange, options) -> @displayBuffer.scrollToScreenRange(screenRange, options)
 
   horizontallyScrollable: -> @displayBuffer.horizontallyScrollable()

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -2396,6 +2396,22 @@ class Editor extends Model
   Section: Editor Rendering
   ###
 
+  # Public: Converts a buffer position to a pixel position.
+  #
+  # * `bufferPosition` An object that represents a buffer position. It can be either
+  #   an {Object} (`{row, column}`), {Array} (`[row, column]`), or {Point}
+  #
+  # Returns an {Object} with two values: `top` and `left`, representing the pixel positions.
+  pixelPositionForBufferPosition: (bufferPosition) -> @displayBuffer.pixelPositionForBufferPosition(bufferPosition)
+
+  # Extended: Converts a screen position to a pixel position.
+  #
+  # * `screenPosition` An object that represents a screen position. It can be either
+  #   an {Object} (`{row, column}`), {Array} (`[row, column]`), or {Point}
+  #
+  # Returns an {Object} with two values: `top` and `left`, representing the pixel positions.
+  pixelPositionForScreenPosition: (screenPosition) -> @displayBuffer.pixelPositionForScreenPosition(screenPosition)
+
   getSelectionMarkerAttributes: ->
     type: 'selection', editorId: @id, invalidate: 'never'
 
@@ -2448,10 +2464,6 @@ class Editor extends Model
   intersectsVisibleRowRange: (startRow, endRow) -> @displayBuffer.intersectsVisibleRowRange(startRow, endRow)
 
   selectionIntersectsVisibleRowRange: (selection) -> @displayBuffer.selectionIntersectsVisibleRowRange(selection)
-
-  pixelPositionForScreenPosition: (screenPosition) -> @displayBuffer.pixelPositionForScreenPosition(screenPosition)
-
-  pixelPositionForBufferPosition: (bufferPosition) -> @displayBuffer.pixelPositionForBufferPosition(bufferPosition)
 
   screenPositionForPixelPosition: (pixelPosition) -> @displayBuffer.screenPositionForPixelPosition(pixelPosition)
 


### PR DESCRIPTION
This deprecates all the methods that already had counterparts in Editor. There is more to do, but they will be separate units of work. 
