### PR TITLE
Include injection grammars in active list

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -347,13 +347,18 @@ describe "Workspace", ->
       atom.packages.activatePackage('language-coffee-script')
 
     waitsForPromise ->
+      atom.packages.activatePackage('language-todo')
+
+    waitsForPromise ->
       atom.workspace.open('sample.coffee')
 
     runs ->
-      atom.workspace.getActiveEditor().setText('i = /test/;')
+      atom.workspace.getActiveEditor().setText """
+        i = /test/; #FIXME
+      """
 
       state = atom.workspace.serialize()
-      expect(state.packagesWithActiveGrammars).toEqual ['language-coffee-script', 'language-javascript']
+      expect(state.packagesWithActiveGrammars).toEqual ['language-coffee-script', 'language-javascript', 'language-todo']
 
       jsPackage = atom.packages.getLoadedPackage('language-javascript')
       coffeePackage = atom.packages.getLoadedPackage('language-coffee-script')

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -75,7 +75,13 @@ class Workspace extends Model
       for scopeName in includedGrammarScopes ? []
         addGrammar(atom.syntax.grammarForScopeName(scopeName))
 
-    addGrammar(editor.getGrammar()) for editor in @getTextEditors()
+    editors = @getTextEditors()
+    addGrammar(editor.getGrammar()) for editor in editors
+
+    if editors.length > 0
+      for grammar in atom.syntax.grammars when grammar.injectionSelector
+        addGrammar(grammar)
+
     _.uniq(packageNames)
 
   editorAdded: (editor) ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -79,7 +79,7 @@ class Workspace extends Model
     addGrammar(editor.getGrammar()) for editor in editors
 
     if editors.length > 0
-      for grammar in atom.syntax.grammars when grammar.injectionSelector
+      for grammar in atom.syntax.getGrammars() when grammar.injectionSelector
         addGrammar(grammar)
 
     _.uniq(packageNames)


### PR DESCRIPTION
I had been noticing a flicker sometimes when reopening Atom with open editors, tracked it down to files that had injection selector matches since previously we weren't store injection selector grammars in the active list.

Show below is a GIF of the issue, I'm refreshing and you notice the flicker after it reopens, caused by the hyperlink on the first line causing a re-tokenizing.

![injection-flicker](https://cloud.githubusercontent.com/assets/671378/4158142/330378ae-3488-11e4-9f79-5cf9265d8d14.gif)
