### PR TITLE
Deprecate EditorView::split* methods

### DIFF
--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -459,22 +459,27 @@ describe "Pane", ->
     [pane1, container] = []
 
     beforeEach ->
-      pane1 = new Pane(items: ["A"])
+      pane1 = new Pane(items: [new Item("A")])
       container = new PaneContainer(root: pane1)
 
     describe "::splitLeft(params)", ->
       describe "when the parent is the container root", ->
         it "replaces itself with a row and inserts a new pane to the left of itself", ->
-          pane2 = pane1.splitLeft(items: ["B"])
-          pane3 = pane1.splitLeft(items: ["C"])
+          pane2 = pane1.splitLeft(items: [new Item("B")])
+          pane3 = pane1.splitLeft(items: [new Item("C")])
           expect(container.root.orientation).toBe 'horizontal'
           expect(container.root.children).toEqual [pane2, pane3, pane1]
+
+      describe "when `copyActiveItem: true` is passed in the params", ->
+        it "duplicates the active item", ->
+          pane2 = pane1.splitLeft(copyActiveItem: true)
+          expect(pane2.getActiveItem()).toEqual pane1.getActiveItem()
 
       describe "when the parent is a column", ->
         it "replaces itself with a row and inserts a new pane to the left of itself", ->
           pane1.splitDown()
-          pane2 = pane1.splitLeft(items: ["B"])
-          pane3 = pane1.splitLeft(items: ["C"])
+          pane2 = pane1.splitLeft(items: [new Item("B")])
+          pane3 = pane1.splitLeft(items: [new Item("C")])
           row = container.root.children[0]
           expect(row.orientation).toBe 'horizontal'
           expect(row.children).toEqual [pane2, pane3, pane1]
@@ -482,16 +487,21 @@ describe "Pane", ->
     describe "::splitRight(params)", ->
       describe "when the parent is the container root", ->
         it "replaces itself with a row and inserts a new pane to the right of itself", ->
-          pane2 = pane1.splitRight(items: ["B"])
-          pane3 = pane1.splitRight(items: ["C"])
+          pane2 = pane1.splitRight(items: [new Item("B")])
+          pane3 = pane1.splitRight(items: [new Item("C")])
           expect(container.root.orientation).toBe 'horizontal'
           expect(container.root.children).toEqual [pane1, pane3, pane2]
+
+      describe "when `copyActiveItem: true` is passed in the params", ->
+        it "duplicates the active item", ->
+          pane2 = pane1.splitRight(copyActiveItem: true)
+          expect(pane2.getActiveItem()).toEqual pane1.getActiveItem()
 
       describe "when the parent is a column", ->
         it "replaces itself with a row and inserts a new pane to the right of itself", ->
           pane1.splitDown()
-          pane2 = pane1.splitRight(items: ["B"])
-          pane3 = pane1.splitRight(items: ["C"])
+          pane2 = pane1.splitRight(items: [new Item("B")])
+          pane3 = pane1.splitRight(items: [new Item("C")])
           row = container.root.children[0]
           expect(row.orientation).toBe 'horizontal'
           expect(row.children).toEqual [pane1, pane3, pane2]
@@ -499,16 +509,21 @@ describe "Pane", ->
     describe "::splitUp(params)", ->
       describe "when the parent is the container root", ->
         it "replaces itself with a column and inserts a new pane above itself", ->
-          pane2 = pane1.splitUp(items: ["B"])
-          pane3 = pane1.splitUp(items: ["C"])
+          pane2 = pane1.splitUp(items: [new Item("B")])
+          pane3 = pane1.splitUp(items: [new Item("C")])
           expect(container.root.orientation).toBe 'vertical'
           expect(container.root.children).toEqual [pane2, pane3, pane1]
+
+      describe "when `copyActiveItem: true` is passed in the params", ->
+        it "duplicates the active item", ->
+          pane2 = pane1.splitUp(copyActiveItem: true)
+          expect(pane2.getActiveItem()).toEqual pane1.getActiveItem()
 
       describe "when the parent is a row", ->
         it "replaces itself with a column and inserts a new pane above itself", ->
           pane1.splitRight()
-          pane2 = pane1.splitUp(items: ["B"])
-          pane3 = pane1.splitUp(items: ["C"])
+          pane2 = pane1.splitUp(items: [new Item("B")])
+          pane3 = pane1.splitUp(items: [new Item("C")])
           column = container.root.children[0]
           expect(column.orientation).toBe 'vertical'
           expect(column.children).toEqual [pane2, pane3, pane1]
@@ -516,16 +531,21 @@ describe "Pane", ->
     describe "::splitDown(params)", ->
       describe "when the parent is the container root", ->
         it "replaces itself with a column and inserts a new pane below itself", ->
-          pane2 = pane1.splitDown(items: ["B"])
-          pane3 = pane1.splitDown(items: ["C"])
+          pane2 = pane1.splitDown(items: [new Item("B")])
+          pane3 = pane1.splitDown(items: [new Item("C")])
           expect(container.root.orientation).toBe 'vertical'
           expect(container.root.children).toEqual [pane1, pane3, pane2]
+
+      describe "when `copyActiveItem: true` is passed in the params", ->
+        it "duplicates the active item", ->
+          pane2 = pane1.splitDown(copyActiveItem: true)
+          expect(pane2.getActiveItem()).toEqual pane1.getActiveItem()
 
       describe "when the parent is a row", ->
         it "replaces itself with a column and inserts a new pane below itself", ->
           pane1.splitRight()
-          pane2 = pane1.splitDown(items: ["B"])
-          pane3 = pane1.splitDown(items: ["C"])
+          pane2 = pane1.splitDown(items: [new Item("B")])
+          pane3 = pane1.splitDown(items: [new Item("C")])
           column = container.root.children[0]
           expect(column.orientation).toBe 'vertical'
           expect(column.children).toEqual [pane1, pane3, pane2]

--- a/spec/pane-view-spec.coffee
+++ b/spec/pane-view-spec.coffee
@@ -29,7 +29,7 @@ describe "PaneView", ->
 
     runs ->
       pane = container.getRoot()
-      paneModel = pane.model
+      paneModel = pane.getModel()
       paneModel.addItems([view1, editor1, view2, editor2])
 
   afterEach ->
@@ -259,7 +259,7 @@ describe "PaneView", ->
   describe "when a pane is split", ->
     it "builds the appropriate pane-row and pane-column views", ->
       pane1 = pane
-      pane1Model = pane.model
+      pane1Model = pane.getModel()
       pane.activateItem(editor1)
 
       pane2Model = pane1Model.splitRight(items: [pane1Model.copyActiveItem()])

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -214,22 +214,38 @@ class EditorView extends View
     React.unmountComponentAtNode(@element) if @component.isMounted()
 
   splitLeft: ->
-    deprecate 'Use Pane::splitLeft instead. To duplicate this editor into the split use: editorView.getPane().splitLeft(editorView.getPane().copyActiveItem())'
+    deprecate """
+      Use Pane::splitLeft instead.
+      To duplicate this editor into the split use:
+      editorView.getPaneView().getModel().splitLeft(copyActiveItem: true)
+    """
     pane = @getPane()
     pane?.splitLeft(pane?.copyActiveItem()).activeView
 
   splitRight: ->
-    deprecate 'Use Pane::splitRight instead. To duplicate this editor into the split use: editorView.getPane().splitRight(editorView.getPane().copyActiveItem())'
+    deprecate """
+      Use Pane::splitRight instead.
+      To duplicate this editor into the split use:
+      editorView.getPaneView().getModel().splitRight(copyActiveItem: true)
+    """
     pane = @getPane()
     pane?.splitRight(pane?.copyActiveItem()).activeView
 
   splitUp: ->
-    deprecate 'Use Pane::splitUp instead. To duplicate this editor into the split use: editorView.getPane().splitUp(editorView.getPane().copyActiveItem())'
+    deprecate """
+      Use Pane::splitUp instead.
+      To duplicate this editor into the split use:
+      editorView.getPaneView().getModel().splitUp(copyActiveItem: true)
+    """
     pane = @getPane()
     pane?.splitUp(pane?.copyActiveItem()).activeView
 
   splitDown: ->
-    deprecate 'Use Pane::splitDown instead. To duplicate this editor into the split use: editorView.getPane().splitDown(editorView.getPane().copyActiveItem())'
+    deprecate """
+      Use Pane::splitDown instead.
+      To duplicate this editor into the split use:
+      editorView.getPaneView().getModel().splitDown(copyActiveItem: true)
+    """
     pane = @getPane()
     pane?.splitDown(pane?.copyActiveItem()).activeView
 

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -233,11 +233,14 @@ class EditorView extends View
     pane = @getPane()
     pane?.splitDown(pane?.copyActiveItem()).activeView
 
-  # Public: Get this view's pane.
+  # Public: Get this {EditorView}'s {PaneView}.
   #
-  # Returns a {Pane}.
-  getPane: ->
+  # Returns a {PaneView}
+  getPaneView: ->
     @parent('.item-views').parents('.pane').view()
+  getPane: ->
+    deprecate 'Use EditorView::getPaneView() instead'
+    @getPaneView()
 
   show: ->
     super

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -213,23 +213,23 @@ class EditorView extends View
   unmountComponent: ->
     React.unmountComponentAtNode(@element) if @component.isMounted()
 
-  # Public: Split the editor view left.
   splitLeft: ->
+    deprecate 'Use Pane::splitLeft instead. To duplicate this editor into the split use: editorView.getPane().splitLeft(editorView.getPane().copyActiveItem())'
     pane = @getPane()
     pane?.splitLeft(pane?.copyActiveItem()).activeView
 
-  # Public: Split the editor view right.
   splitRight: ->
+    deprecate 'Use Pane::splitRight instead. To duplicate this editor into the split use: editorView.getPane().splitRight(editorView.getPane().copyActiveItem())'
     pane = @getPane()
     pane?.splitRight(pane?.copyActiveItem()).activeView
 
-  # Public: Split the editor view up.
   splitUp: ->
+    deprecate 'Use Pane::splitUp instead. To duplicate this editor into the split use: editorView.getPane().splitUp(editorView.getPane().copyActiveItem())'
     pane = @getPane()
     pane?.splitUp(pane?.copyActiveItem()).activeView
 
-  # Public: Split the editor view down.
   splitDown: ->
+    deprecate 'Use Pane::splitDown instead. To duplicate this editor into the split use: editorView.getPane().splitDown(editorView.getPane().copyActiveItem())'
     pane = @getPane()
     pane?.splitDown(pane?.copyActiveItem()).activeView
 

--- a/src/pane-view.coffee
+++ b/src/pane-view.coffee
@@ -75,10 +75,10 @@ class PaneView extends View
     @command 'pane:show-item-8', => @activateItemAtIndex(7)
     @command 'pane:show-item-9', => @activateItemAtIndex(8)
 
-    @command 'pane:split-left', => @splitLeft(@copyActiveItem())
-    @command 'pane:split-right', => @splitRight(@copyActiveItem())
-    @command 'pane:split-up', => @splitUp(@copyActiveItem())
-    @command 'pane:split-down', => @splitDown(@copyActiveItem())
+    @command 'pane:split-left', => @model.splitLeft(copyActiveItem: true)
+    @command 'pane:split-right', => @model.splitRight(copyActiveItem: true)
+    @command 'pane:split-up', => @model.splitUp(copyActiveItem: true)
+    @command 'pane:split-down', => @model.splitDown(copyActiveItem: true)
     @command 'pane:close', =>
       @model.destroyItems()
       @model.destroy()

--- a/src/pane-view.coffee
+++ b/src/pane-view.coffee
@@ -84,6 +84,9 @@ class PaneView extends View
       @model.destroy()
     @command 'pane:close-other-items', => @destroyInactiveItems()
 
+  # Essential: Returns the {Pane} model underlying this pane view
+  getModel: -> @model
+
   # Deprecated: Use ::destroyItem
   removeItem: (item) ->
     deprecate("Use PaneView::destroyItem instead")

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -528,6 +528,7 @@ class Pane extends Model
   #
   # * `params` (optional) {Object} with the following keys:
   #   * `items` (optional) {Array} of items to add to the new pane.
+  #   * `copyActiveItem` (optional) {Boolean} true will copy the active item into the new split pane
   #
   # Returns the new {Pane}.
   splitLeft: (params) ->
@@ -537,6 +538,7 @@ class Pane extends Model
   #
   # * `params` (optional) {Object} with the following keys:
   #   * `items` (optional) {Array} of items to add to the new pane.
+  #   * `copyActiveItem` (optional) {Boolean} true will copy the active item into the new split pane
   #
   # Returns the new {Pane}.
   splitRight: (params) ->
@@ -546,6 +548,7 @@ class Pane extends Model
   #
   # * `params` (optional) {Object} with the following keys:
   #   * `items` (optional) {Array} of items to add to the new pane.
+  #   * `copyActiveItem` (optional) {Boolean} true will copy the active item into the new split pane
   #
   # Returns the new {Pane}.
   splitUp: (params) ->
@@ -555,12 +558,17 @@ class Pane extends Model
   #
   # * `params` (optional) {Object} with the following keys:
   #   * `items` (optional) {Array} of items to add to the new pane.
+  #   * `copyActiveItem` (optional) {Boolean} true will copy the active item into the new split pane
   #
   # Returns the new {Pane}.
   splitDown: (params) ->
     @split('vertical', 'after', params)
 
   split: (orientation, side, params) ->
+    if params?.copyActiveItem
+      params.items ?= []
+      params.items.push(@copyActiveItem())
+
     if @parent.orientation isnt orientation
       @parent.replaceChild(this, new PaneAxis({@container, orientation, children: [this]}))
 


### PR DESCRIPTION
This adds a new `copyActiveItem` option to the `Pane::split*` methods, and suggest the users use that instead of the editorView implementations. 
