### PR TITLE
Explain capital letters in keystrokes in default keymap.cson comments

### DIFF
--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -13,10 +13,8 @@
 #   'enter': 'editor:newline'
 #
 # '.workspace':
-#   'ctrl-P': 'core:move-up'
+#   'ctrl-shift-p': 'core:move-up'
 #   'ctrl-p': 'core:move-down'
-#
-# In the example above, 'ctrl-P' is equivalent to 'ctrl-shift-p'.
 #
 # You can find more information about keymaps in these guides:
 # * https://atom.io/docs/latest/customizing-atom#customizing-key-bindings

--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -16,3 +16,4 @@
 #   'ctrl-P': 'core:move-up'
 #   'ctrl-p': 'core:move-down'
 #
+# In the example above, 'ctrl-P' is equivalent to 'ctrl-shift-p'.

--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -17,3 +17,7 @@
 #   'ctrl-p': 'core:move-down'
 #
 # In the example above, 'ctrl-P' is equivalent to 'ctrl-shift-p'.
+#
+# You can find more information about keymaps in these guides:
+# * https://atom.io/docs/latest/customizing-atom#customizing-key-bindings
+# * https://atom.io/docs/latest/advanced/keymaps


### PR DESCRIPTION
Closes https://github.com/atom/atom/issues/3463. 

This adds a line to explicitly state that `ctrl-P` is interpreted as `ctrl-shift-p`, so that user don't get trolled. 
Also, added links to relevant guides where users can learn more about keymaps and keybindings. Should be helpful.
