### PR TITLE
Use DOM APIs to apply stylesheets

### DIFF
--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -241,15 +241,15 @@ describe "the `atom` global", ->
               two = atom.themes.stringToId(two)
               three = atom.themes.stringToId(three)
 
-              expect(atom.themes.stylesheetElementForId(one)).not.toExist()
-              expect(atom.themes.stylesheetElementForId(two)).not.toExist()
-              expect(atom.themes.stylesheetElementForId(three)).not.toExist()
+              expect(atom.themes.stylesheetElementForId(one)).toBeNull()
+              expect(atom.themes.stylesheetElementForId(two)).toBeNull()
+              expect(atom.themes.stylesheetElementForId(three)).toBeNull()
 
               atom.packages.activatePackage("package-with-stylesheets-manifest")
 
-              expect(atom.themes.stylesheetElementForId(one)).toExist()
-              expect(atom.themes.stylesheetElementForId(two)).toExist()
-              expect(atom.themes.stylesheetElementForId(three)).not.toExist()
+              expect(atom.themes.stylesheetElementForId(one)).not.toBeNull()
+              expect(atom.themes.stylesheetElementForId(two)).not.toBeNull()
+              expect(atom.themes.stylesheetElementForId(three)).toBeNull()
               expect($('#jasmine-content').css('font-size')).toBe '1px'
 
           describe "when the metadata does not contain a 'stylesheets' manifest", ->
@@ -263,14 +263,14 @@ describe "the `atom` global", ->
               two = atom.themes.stringToId(two)
               three = atom.themes.stringToId(three)
 
-              expect(atom.themes.stylesheetElementForId(one)).not.toExist()
-              expect(atom.themes.stylesheetElementForId(two)).not.toExist()
-              expect(atom.themes.stylesheetElementForId(three)).not.toExist()
+              expect(atom.themes.stylesheetElementForId(one)).toBeNull()
+              expect(atom.themes.stylesheetElementForId(two)).toBeNull()
+              expect(atom.themes.stylesheetElementForId(three)).toBeNull()
 
               atom.packages.activatePackage("package-with-stylesheets")
-              expect(atom.themes.stylesheetElementForId(one)).toExist()
-              expect(atom.themes.stylesheetElementForId(two)).toExist()
-              expect(atom.themes.stylesheetElementForId(three)).toExist()
+              expect(atom.themes.stylesheetElementForId(one)).not.toBeNull()
+              expect(atom.themes.stylesheetElementForId(two)).not.toBeNull()
+              expect(atom.themes.stylesheetElementForId(three)).not.toBeNull()
               expect($('#jasmine-content').css('font-size')).toBe '3px'
 
         describe "grammar loading", ->

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -207,7 +207,7 @@ class ThemeManager
 
   # Public: Resolve and apply the stylesheet specified by the path.
   #
-  # This supports both CSS and LESS stylsheets.
+  # This supports both CSS and Less stylsheets.
   #
   # * `stylesheetPath` A {String} path to the stylesheet that can be an absolute
   #   path or a relative path that will be resolved against the load path.
@@ -245,7 +245,7 @@ class ThemeManager
         @lessCache.read(lessStylesheetPath)
     catch error
       console.error """
-        Error compiling less stylesheet: #{lessStylesheetPath}
+        Error compiling Less stylesheet: #{lessStylesheetPath}
         Line number: #{error.line}
         #{error.message}
       """

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -2,11 +2,11 @@ path = require 'path'
 
 _ = require 'underscore-plus'
 {Emitter} = require 'emissary'
+{File} = require 'pathwatcher'
 fs = require 'fs-plus'
 Q = require 'q'
 
 Package = require './package'
-{File} = require 'pathwatcher'
 
 # Extended: Handles loading and activating available themes.
 #

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -16,23 +16,23 @@ Package = require './package'
 #
 # ### reloaded
 #
-# Extended: Emit when all styles have been reloaded.
+# Extended: Emitted when all styles have been reloaded.
 #
 # ### stylesheet-added
 #
-# Extended: Emit when a stylesheet has been added.
+# Extended: Emitted when a stylesheet has been added.
 #
 # * `stylesheet` {StyleSheet} object that was removed
 #
 # ### stylesheet-removed
 #
-# Extended: Emit when a stylesheet has been removed.
+# Extended: Emitted when a stylesheet has been removed.
 #
 # * `stylesheet` {StyleSheet} object that was removed
 #
 # ### stylesheets-changed
 #
-# Extended: Emit anytime any style sheet is added or removed from the editor
+# Extended: Emitted anytime any style sheet is added or removed from the editor
 #
 module.exports =
 class ThemeManager

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -243,11 +243,11 @@ class ThemeManager
         @lessCache.cssForFile(lessStylesheetPath, [baseVarImports, less].join('\n'))
       else
         @lessCache.read(lessStylesheetPath)
-    catch e
+    catch error
       console.error """
         Error compiling less stylesheet: #{lessStylesheetPath}
-        Line number: #{e.line}
-        #{e.message}
+        Line number: #{error.line}
+        #{error.message}
       """
 
   stringToId: (string) ->

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -263,10 +263,9 @@ class ThemeManager
       @emit 'stylesheets-changed'
 
   applyStylesheet: (path, text, type='bundled') ->
-    styleElement = null
-
     styleId = @stringToId(path)
     styleElement = @stylesheetElementForId(styleId)
+
     if styleElement?
       @emit 'stylesheet-removed', styleElement.sheet
       styleElement.textContent = text

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -5,7 +5,6 @@ _ = require 'underscore-plus'
 fs = require 'fs-plus'
 Q = require 'q'
 
-{$} = require './space-pen-extensions'
 Package = require './package'
 {File} = require 'pathwatcher'
 

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -258,8 +258,9 @@ class ThemeManager
     fullPath = @resolveStylesheet(stylesheetPath) ? stylesheetPath
     element = @stylesheetElementForId(@stringToId(fullPath))
     if element?
+      {sheet} = element
       element.remove()
-      @emit 'stylesheet-removed', element.sheet
+      @emit 'stylesheet-removed', sheet
       @emit 'stylesheets-changed'
 
   applyStylesheet: (path, text, type='bundled') ->

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -275,9 +275,10 @@ class ThemeManager
       styleElement.setAttribute('class', type)
       styleElement.setAttribute('id', styleId)
       styleElement.textContent = text
-      parentElement = _.last(document.head.querySelectorAll("style.#{type}"))?.parentElement
-      if parentElement?
-        parentElement.appendChild(styleElement)
+
+      elementToInsertBefore = _.last(document.head.querySelectorAll("style.#{type}"))?.nextElementSibling
+      if elementToInsertBefore?
+        document.head.insertBefore(styleElement, elementToInsertBefore)
       else
         document.head.appendChild(styleElement)
 

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -381,9 +381,9 @@ class WorkspaceView extends View
     @setEditorStyle('line-height', lineHeight)
 
   setEditorStyle: (property, value) ->
-    unless styleNode = atom.themes.stylesheetElementForId('global-editor-styles')[0]
+    unless styleNode = atom.themes.stylesheetElementForId('global-editor-styles')
       atom.themes.applyStylesheet('global-editor-styles', '.editor {}')
-      styleNode = atom.themes.stylesheetElementForId('global-editor-styles')[0]
+      styleNode = atom.themes.stylesheetElementForId('global-editor-styles')
 
     {sheet} = styleNode
     editorRule = sheet.cssRules[0]


### PR DESCRIPTION
Previously jQuery was used, but using the DOM APIs directly takes 1/3 of the time.

For me this dropped the time taken to loads all stylesheets from `60ms` to `20ms` which is synchronously done at startup.
