### PR TITLE
:penguin: Add Category 'Development' to linux desktop file

### DIFF
--- a/resources/linux/Atom.desktop.in
+++ b/resources/linux/Atom.desktop.in
@@ -5,4 +5,4 @@ Exec=<%= installDir %>/share/atom/atom %U
 Icon=<%= iconName %>
 Type=Application
 StartupNotify=true
-Categories=GNOME;GTK;Utility;TextEditor;
+Categories=GNOME;GTK;Utility;TextEditor;Development;


### PR DESCRIPTION
This pull request adds application Atom into category "Development" on Linux desktops.

This behavior is familiar with most Text editors and IDE's aiming software developers on Linux desktops.

Category "Development" is part of freedesktop standards: http://standards.freedesktop.org/menu-spec/latest/apa.html
