### PR TITLE
Remove event deprecations from core

### DIFF
--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -520,7 +520,7 @@ describe "the `atom` global", ->
 
             reloadedHandler = jasmine.createSpy('reloadedHandler')
             reloadedHandler.reset()
-            atom.themes.on('reloaded', reloadedHandler)
+            atom.themes.onDidReloadAll reloadedHandler
 
             pack = atom.packages.disablePackage(packageName)
 

--- a/spec/pane-view-spec.coffee
+++ b/spec/pane-view-spec.coffee
@@ -179,7 +179,7 @@ describe "PaneView", ->
         pane.activateItem(view2)
         pane.activateItem(view1)
 
-      fffit "emits pane:active-item-title-changed", ->
+      it "emits pane:active-item-title-changed", ->
         activeItemTitleChangedHandler = jasmine.createSpy("activeItemTitleChangedHandler")
         pane.on 'pane:active-item-title-changed', activeItemTitleChangedHandler
 

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -42,7 +42,7 @@ describe "WorkspaceView", ->
         runs ->
           editorView1 = atom.workspaceView.getActiveView()
           buffer = editorView1.getEditor().getBuffer()
-          editorView1.splitRight()
+          editorView1.getPaneView().getModel().splitRight(copyActiveItem: true)
           expect(atom.workspaceView.getActivePaneView()).toBe atom.workspaceView.getPaneViews()[1]
 
           simulateReload()
@@ -196,7 +196,8 @@ describe "WorkspaceView", ->
       atom.workspaceView.attachToDom()
       rightEditorView = atom.workspaceView.getActiveView()
       rightEditorView.getEditor().setText("\t  \n")
-      leftEditorView = rightEditorView.splitLeft()
+      rightEditorView.getPaneView().getModel().splitLeft(copyActiveItem: true)
+      leftEditorView = atom.workspaceView.getActiveView()
       expect(rightEditorView.find(".line:first").text()).toBe "    "
       expect(leftEditorView.find(".line:first").text()).toBe "    "
 
@@ -207,14 +208,16 @@ describe "WorkspaceView", ->
       expect(rightEditorView.find(".line:first").text()).toBe withInvisiblesShowing
       expect(leftEditorView.find(".line:first").text()).toBe withInvisiblesShowing
 
-      lowerLeftEditorView = leftEditorView.splitDown()
+      leftEditorView.getPaneView().getModel().splitDown(copyActiveItem: true)
+      lowerLeftEditorView = atom.workspaceView.getActiveView()
       expect(lowerLeftEditorView.find(".line:first").text()).toBe withInvisiblesShowing
 
       atom.workspaceView.trigger "window:toggle-invisibles"
       expect(rightEditorView.find(".line:first").text()).toBe "    "
       expect(leftEditorView.find(".line:first").text()).toBe "    "
 
-      lowerRightEditorView = rightEditorView.splitDown()
+      rightEditorView.getPaneView().getModel().splitDown(copyActiveItem: true)
+      lowerRightEditorView = atom.workspaceView.getActiveView()
       expect(lowerRightEditorView.find(".line:first").text()).toBe "    "
 
   describe ".eachEditorView(callback)", ->
@@ -241,7 +244,7 @@ describe "WorkspaceView", ->
       atom.workspaceView.eachEditorView(callback)
       count = 0
       callbackEditor = null
-      atom.workspaceView.getActiveView().splitRight()
+      atom.workspaceView.getActiveView().getPaneView().getModel().splitRight(copyActiveItem: true)
       expect(count).toBe 1
       expect(callbackEditor).toBe atom.workspaceView.getActiveView()
 
@@ -259,10 +262,10 @@ describe "WorkspaceView", ->
 
       subscription = atom.workspaceView.eachEditorView(callback)
       expect(count).toBe 1
-      atom.workspaceView.getActiveView().splitRight()
+      atom.workspaceView.getActiveView().getPaneView().getModel().splitRight(copyActiveItem: true)
       expect(count).toBe 2
       subscription.off()
-      atom.workspaceView.getActiveView().splitRight()
+      atom.workspaceView.getActiveView().getPaneView().getModel().splitRight(copyActiveItem: true)
       expect(count).toBe 2
 
   describe "core:close", ->
@@ -271,7 +274,7 @@ describe "WorkspaceView", ->
 
       paneView1 = atom.workspaceView.getActivePaneView()
       editorView = atom.workspaceView.getActiveView()
-      editorView.splitRight()
+      editorView.getPaneView().getModel().splitRight(copyActiveItem: true)
       paneView2 = atom.workspaceView.getActivePaneView()
 
       expect(paneView1).not.toBe paneView2

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -373,7 +373,7 @@ class Atom extends Model
     @themes.load()
 
   watchThemes: ->
-    @themes.on 'reloaded', =>
+    @themes.onDidReloadAll =>
       # Only reload stylesheets from non-theme packages
       for pack in @packages.getActivePackages() when pack.getType() isnt 'theme'
         pack.reloadStylesheets?()

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -24,7 +24,7 @@ class ContextMenuManager
         @commandOptions = x: e.pageX, y: e.pageY
     ]
 
-    atom.keymaps.on 'bundled-keymaps-loaded', => @loadPlatformItems()
+    atom.keymaps.onDidLoadBundledKeymaps => @loadPlatformItems()
 
   loadPlatformItems: ->
     menusDirPath = path.join(@resourcePath, 'menus')

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -177,6 +177,7 @@ EditorComponent = React.createClass
     @listenForCommands()
 
     @subscribe atom.themes.onDidAddStylesheet @onStylesheetsChanged
+    @subscribe atom.themes.onDidUpdateStylesheet @onStylesheetsChanged
     @subscribe atom.themes.onDidRemoveStylesheet @onStylesheetsChanged
     @subscribe scrollbarStyle.changes, @refreshScrollbars
 

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -176,7 +176,8 @@ EditorComponent = React.createClass
     @listenForDOMEvents()
     @listenForCommands()
 
-    @subscribe atom.themes, 'stylesheet-added stylesheet-removed stylesheet-updated', @onStylesheetsChanged
+    @subscribe atom.themes.onDidAddStylesheet @onStylesheetsChanged
+    @subscribe atom.themes.onDidRemoveStylesheet @onStylesheetsChanged
     @subscribe scrollbarStyle.changes, @refreshScrollbars
 
     @domPollingIntervalId = setInterval(@pollDOM, @domPollingInterval)

--- a/src/keymap-extensions.coffee
+++ b/src/keymap-extensions.coffee
@@ -4,9 +4,13 @@ KeymapManager = require 'atom-keymap'
 CSON = require 'season'
 {jQuery} = require 'space-pen'
 
+KeymapManager::onDidLoadBundledKeymaps = (callback) ->
+  @emitter.on 'did-load-bundled-keymaps', callback
+
 KeymapManager::loadBundledKeymaps = ->
   @loadKeymap(path.join(@resourcePath, 'keymaps'))
-  @emit('bundled-keymaps-loaded')
+  @emit 'bundled-keymaps-loaded'
+  @emitter.emit 'did-load-bundled-keymaps'
 
 KeymapManager::getUserKeymapPath = ->
   if userKeymapPath = CSON.resolve(path.join(@configDirPath, 'keymap'))

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -14,7 +14,7 @@ class MenuManager
   constructor: ({@resourcePath}) ->
     @pendingUpdateOperation = null
     @template = []
-    atom.keymaps.on 'bundled-keymaps-loaded', => @loadPlatformItems()
+    atom.keymaps.onDidLoadBundledKeymaps => @loadPlatformItems()
     atom.packages.onDidActivateAll => @sortPackagesMenu()
 
   # Public: Adds the given items to the application menu.

--- a/src/pane-view.coffee
+++ b/src/pane-view.coffee
@@ -162,8 +162,8 @@ class PaneView extends View
       deprecate 'Please return a Disposable object from your ::onDidChangeTitle method!' unless disposable?.dispose?
       @activeItemDisposables.add(disposable) if disposable?.dispose?
     else if item.on?
+      deprecate '::on methods for items are no longer supported. If you would like your item to title change behavior, please implement a ::onDidChangeTitle() method.'
       disposable = item.on('title-changed', @activeItemTitleChanged)
-      deprecate 'Please return a Disposable object from your ::on method. Your ::off method will not be called soon!' unless disposable?.dispose?
       @activeItemDisposables.add(disposable) if disposable?.dispose?
 
     if item.onDidChangeModified?
@@ -171,8 +171,8 @@ class PaneView extends View
       deprecate 'Please return a Disposable object from your ::onDidChangeModified method!' unless disposable?.dispose?
       @activeItemDisposables.add(disposable) if disposable?.dispose?
     else if item.on?
+      deprecate '::on methods for items are no longer supported. If you would like your item to support modified behavior, please implement a ::onDidChangeModified() method.'
       item.on('modified-status-changed', @activeItemModifiedChanged)
-      deprecate 'Please return a Disposable object from your ::on method. Your ::off method will not be called soon!' unless disposable?.dispose?
       @activeItemDisposables.add(disposable) if disposable?.dispose?
 
     view = @viewForItem(item)

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -84,7 +84,7 @@ class ThemeManager
     EmitterMixin::on.apply(this, arguments)
 
   ###
-  Section: Methods
+  Section: Instance Methods
   ###
 
   getAvailableNames: ->
@@ -332,5 +332,19 @@ class ThemeManager
 
     @emit 'stylesheet-added', styleElement.sheet
     @emitter.emit 'did-add-stylesheet', styleElement.sheet
+    @emit 'stylesheets-changed'
+    @emitter.emit 'did-change-stylesheets'
+
+  updateGlobalEditorStyle: (property, value) ->
+    unless styleNode = @stylesheetElementForId('global-editor-styles')
+      @applyStylesheet('global-editor-styles', '.editor {}')
+      styleNode = @stylesheetElementForId('global-editor-styles')
+
+    {sheet} = styleNode
+    editorRule = sheet.cssRules[0]
+    editorRule.style[property] = value
+
+    @emit 'stylesheet-updated', sheet
+    @emitter.emit 'did-update-stylesheet', sheet
     @emit 'stylesheets-changed'
     @emitter.emit 'did-change-stylesheets'

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -50,6 +50,15 @@ class ThemeManager
   onDidRemoveStylesheet: (callback) ->
     @emitter.on 'did-remove-stylesheet', callback
 
+  # Essential: Invoke `callback` when a stylesheet has been updated.
+  #
+  # * `callback` {Function}
+  #   * `stylesheet` {StyleSheet} the style node
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidUpdateStylesheet: (callback) ->
+    @emitter.on 'did-update-stylesheet', callback
+
   # Essential: Invoke `callback` when any stylesheet has been updated, added, or removed.
   #
   # * `callback` {Function}
@@ -66,6 +75,8 @@ class ThemeManager
         deprecate 'Use ThemeManager::onDidAddStylesheet instead'
       when 'stylesheet-removed'
         deprecate 'Use ThemeManager::onDidRemoveStylesheet instead'
+      when 'stylesheet-updated'
+        deprecate 'Use ThemeManager::onDidUpdateStylesheet instead'
       when 'stylesheets-changed'
         deprecate 'Use ThemeManager::onDidChangeStylesheets instead'
       else

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -373,24 +373,13 @@ class WorkspaceView extends View
     @model.destroy()
 
   setEditorFontSize: (fontSize) =>
-    @setEditorStyle('font-size', fontSize + 'px')
+    atom.themes.updateGlobalEditorStyle('font-size', fontSize + 'px')
 
   setEditorFontFamily: (fontFamily) =>
-    @setEditorStyle('font-family', fontFamily)
+    atom.themes.updateGlobalEditorStyle('font-family', fontFamily)
 
   setEditorLineHeight: (lineHeight) =>
-    @setEditorStyle('line-height', lineHeight)
-
-  setEditorStyle: (property, value) ->
-    unless styleNode = atom.themes.stylesheetElementForId('global-editor-styles')
-      atom.themes.applyStylesheet('global-editor-styles', '.editor {}')
-      styleNode = atom.themes.stylesheetElementForId('global-editor-styles')
-
-    {sheet} = styleNode
-    editorRule = sheet.cssRules[0]
-    editorRule.style[property] = value
-    atom.themes.emit 'stylesheet-updated', sheet
-    atom.themes.emit 'stylesheets-changed'
+    atom.themes.updateGlobalEditorStyle('line-height', lineHeight)
 
   # Deprecated
   eachPane: (callback) ->


### PR DESCRIPTION
This removes all of them but one major one: https://github.com/atom/atom/blob/master/src/pane-view.coffee#L159-L160

I wasnt sure how we wanted to handle this, as pane items can be anything. Do we still want to support the path-changed event on random pane items? Do we want to enforce an `onDidChangeTitle` method? This is one case where string events are really nice.
