### PR TITLE
Force visibility-change checking in EditorView's afterAttach method

### DIFF
--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -144,6 +144,11 @@ class EditorView extends View
     return if @attached
     @attached = true
     @component.pollDOM()
+
+    # Ensure that editor measurements like lineHeight are taken here, even if pollDOM() was a no-op
+    # because an update was requested.
+    @component.checkForVisibilityChange()
+
     @focus() if @focusOnAttach
 
     @addGrammarScopeAttribute()


### PR DESCRIPTION
When an `EditorView` becomes attached, if hardware acceleration is enabled, the call to `pollDOM` is a no-op because there's already a refresh pending. This can cause problems, because then the initial measurements don't happen and (for example) the lineHeight is left as null - it'll be set on the next rendering, but not before subscribers to `workspaceView.eachEditorView` are notified.

I just ran into this working on smashwilson/merge-conflicts#77.

I left the original `pollDOM` call in so that everything else that it does still happens if there's no refresh waiting. If the other stuff should _also_ happen on that first render, a better solution might be to add a `force` parameter to `pollDOM`, instead? Let me know what you think.
