### PR TITLE
Deprecate font-size, font-family, line-height, invisibles, indent guide methods on EditorView

### DIFF
--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -282,40 +282,28 @@ class EditorView extends View
     deprecate 'Use Editor::getLastVisibleScreenRow instead. You can get the editor via editorView.getModel()'
     @editor.getLastVisibleScreenRow()
 
-  # Public: Gets the font family for the editor.
-  #
-  # Returns a {String} identifying the CSS `font-family`.
   getFontFamily: ->
+    deprecate 'This is going away. Use atom.config.get("editor.fontFamily") instead'
     @component?.getFontFamily()
 
-  # Public: Sets the font family for the editor.
-  #
-  # * `fontFamily` A {String} identifying the CSS `font-family`.
   setFontFamily: (fontFamily) ->
+    deprecate 'This is going away. Use atom.config.set("editor.fontFamily", "my-font") instead'
     @component?.setFontFamily(fontFamily)
 
-  # Public: Retrieves the font size for the editor.
-  #
-  # Returns a {Number} indicating the font size in pixels.
   getFontSize: ->
+    deprecate 'This is going away. Use atom.config.get("editor.fontSize") instead'
     @component?.getFontSize()
 
-  # Public: Sets the font size for the editor.
-  #
-  # * `fontSize` A {Number} indicating the font size in pixels.
   setFontSize: (fontSize) ->
+    deprecate 'This is going away. Use atom.config.set("editor.fontSize", 12) instead'
     @component?.setFontSize(fontSize)
+
+  setLineHeight: (lineHeight) ->
+    deprecate 'This is going away. Use atom.config.set("editor.lineHeight", 1.5) instead'
+    @component.setLineHeight(lineHeight)
 
   setWidthInChars: (widthInChars) ->
     @component.getDOMNode().style.width = (@editor.getDefaultCharWidth() * widthInChars) + 'px'
-
-  # Public: Sets the line height of the editor.
-  #
-  # Calling this method has no effect when called on a mini editor.
-  #
-  # * `lineHeight` A {Number} without a unit suffix identifying the CSS `line-height`.
-  setLineHeight: (lineHeight) ->
-    @component.setLineHeight(lineHeight)
 
   # Public: Sets whether you want to show the indentation guides.
   #

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -305,11 +305,8 @@ class EditorView extends View
   setWidthInChars: (widthInChars) ->
     @component.getDOMNode().style.width = (@editor.getDefaultCharWidth() * widthInChars) + 'px'
 
-  # Public: Sets whether you want to show the indentation guides.
-  #
-  # * `showIndentGuide` A {Boolean} you can set to `true` if you want to see the
-  #   indentation guides.
   setShowIndentGuide: (showIndentGuide) ->
+    deprecate 'This is going away. Use atom.config.set("editor.showIndentGuide", true|false) instead'
     @component.setShowIndentGuide(showIndentGuide)
 
   setSoftWrap: (softWrapped) ->

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -313,10 +313,8 @@ class EditorView extends View
     deprecate 'Use Editor::setSoftWrapped instead. You can get the editor via editorView.getModel()'
     @editor.setSoftWrapped(softWrapped)
 
-  # Public: Set whether invisible characters are shown.
-  #
-  # * `showInvisibles` A {Boolean} which, if `true`, show invisible characters.
   setShowInvisibles: (showInvisibles) ->
+    deprecate 'This is going away. Use atom.config.set("editor.showInvisibles", true|false) instead'
     @component.setShowInvisibles(showInvisibles)
 
   getText: ->


### PR DESCRIPTION
In an effort to strip down the EditorView, these will be removed. 

Nothing really seems to use these anyway: https://github.com/atom/api/blob/master/current-api.txt#L160-L168
