### PR TITLE
Wait for themes to load before measuring

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -21,6 +21,7 @@ clipboard = require 'clipboard'
 
 atom.themes.loadBaseStylesheets()
 atom.themes.requireStylesheet '../static/jasmine'
+atom.themes.initialLoadComplete = true
 
 fixturePackagesPath = path.resolve(__dirname, './fixtures/packages')
 atom.packages.packageDirPaths.unshift(fixturePackagesPath)

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -712,7 +712,7 @@ EditorComponent = React.createClass
     return unless @performedInitialMeasurement
     return unless atom.themes.isInitialLoadComplete()
 
-    @refreshScrollbars() if not stylesheet or @containsScrollbarSelector(stylesheet)
+    @refreshScrollbars() if not stylesheet? or @containsScrollbarSelector(stylesheet)
     @sampleFontStyling()
     @sampleBackgroundColors()
     @remeasureCharacterWidths()

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -712,7 +712,7 @@ EditorComponent = React.createClass
     return unless @performedInitialMeasurement
     return unless atom.themes.isInitialLoadComplete()
 
-    @refreshScrollbars() if @containsScrollbarSelector(stylesheet)
+    @refreshScrollbars() if not stylesheet or @containsScrollbarSelector(stylesheet)
     @sampleFontStyling()
     @sampleBackgroundColors()
     @remeasureCharacterWidths()

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -179,6 +179,8 @@ EditorComponent = React.createClass
     @subscribe atom.themes.onDidAddStylesheet @onStylesheetsChanged
     @subscribe atom.themes.onDidUpdateStylesheet @onStylesheetsChanged
     @subscribe atom.themes.onDidRemoveStylesheet @onStylesheetsChanged
+    unless atom.themes.isInitialLoadComplete()
+      @subscribe atom.themes.onDidReloadAll @onStylesheetsChanged
     @subscribe scrollbarStyle.changes, @refreshScrollbars
 
     @domPollingIntervalId = setInterval(@pollDOM, @domPollingInterval)
@@ -708,6 +710,7 @@ EditorComponent = React.createClass
 
   onStylesheetsChanged: (stylesheet) ->
     return unless @performedInitialMeasurement
+    return unless atom.themes.isInitialLoadComplete()
 
     @refreshScrollbars() if @containsScrollbarSelector(stylesheet)
     @sampleFontStyling()

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -107,7 +107,7 @@ class ThemeManager
   getLoadedThemes: ->
     pack for pack in @packageManager.getLoadedPackages() when pack.isTheme()
 
-  activatePackages: (themePackages) -> @activateThemes()
+  activatePackages: -> @activateThemes()
 
   # Get the enabled theme names from the config.
   #

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -20,6 +20,7 @@ class ThemeManager
   constructor: ({@packageManager, @resourcePath, @configDirPath, @safeMode}) ->
     @emitter = new Emitter
     @lessCache = null
+    @initialLoadComplete = false
     @packageManager.registerPackageActivator(this, ['theme'])
 
   ###
@@ -165,6 +166,7 @@ class ThemeManager
         @refreshLessCache() # Update cache again now that @getActiveThemes() is populated
         @loadUserStylesheet()
         @reloadBaseStylesheets()
+        @initialLoadComplete = true
         @emit 'reloaded'
         @emitter.emit 'did-reload-all'
         deferred.resolve()
@@ -176,6 +178,8 @@ class ThemeManager
     @unwatchUserStylesheet()
     @packageManager.deactivatePackage(pack.name) for pack in @getActiveThemes()
     null
+
+  isInitialLoadComplete: -> @initialLoadComplete
 
   addActiveThemeClasses: ->
     for pack in @getActiveThemes()


### PR DESCRIPTION
While profiling I noticed that `EditorComponent::onStylesheetsChanged` was called around **25 times**, as each theme stylesheet was loaded, taking a total **200-300 milliseconds**, when an editor was open at startup.

Now the component waits for the initial theme load to complete before measuring so it is only called once at startup and removes **200-300 millseconds** from startup time when an editor is open.

/cc @nathansobo and @benogle for :eyes: 
