### PR TITLE
Rename soft-wrapped back to soft-wrap

### DIFF
--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -123,7 +123,7 @@ You can open this file in an editor from the _Atom > Open Your Config_ menu.
   - `showInvisibles`: Whether to render placeholders for invisible characters (defaults to `false`)
   - `showIndentGuide`: Show/hide indent indicators within the editor
   - `showLineNumbers`: Show/hide line numbers within the gutter
-  - `softWrapped`: Enable/disable soft wrapping of text within the editor
+  - `softWrap`: Enable/disable soft wrapping of text within the editor
   - `softWrapAtPreferredLineLength`: Enable/disable soft line wrapping at `preferredLineLength`
   - `tabLength`: Number of spaces within a tab (defaults to `2`)
 - `fuzzyFinder`

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -166,7 +166,7 @@
         ]
       }
       { type: 'separator' }
-      { label: 'Toggle Soft Wrap', command: 'editor:toggle-soft-wrapped' }
+      { label: 'Toggle Soft Wrap', command: 'editor:toggle-soft-wrap' }
     ]
   }
 

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -104,7 +104,7 @@
         ]
       }
       { type: 'separator' }
-      { label: 'Toggle Soft &Wrap', command: 'editor:toggle-soft-wrapped' }
+      { label: 'Toggle Soft &Wrap', command: 'editor:toggle-soft-wrap' }
     ]
   }
 

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -122,7 +122,7 @@
         ]
       }
       { type: 'separator' }
-      { label: 'Toggle Soft &Wrap', command: 'editor:toggle-soft-wrapped' }
+      { label: 'Toggle Soft &Wrap', command: 'editor:toggle-soft-wrap' }
     ]
   }
 

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -98,11 +98,11 @@ describe "Editor", ->
       expect(editor2.isFoldedAtBufferRow(4)).not.toBe editor.isFoldedAtBufferRow(4)
 
   describe "config defaults", ->
-    it "uses the `editor.tabLength`, `editor.softWrapped`, and `editor.softTabs` config values", ->
+    it "uses the `editor.tabLength`, `editor.softWrap`, and `editor.softTabs` config values", ->
       editor1 = null
       editor2 = null
       atom.config.set('editor.tabLength', 4)
-      atom.config.set('editor.softWrapped', true)
+      atom.config.set('editor.softWrap', true)
       atom.config.set('editor.softTabs', false)
 
       waitsForPromise ->
@@ -114,7 +114,7 @@ describe "Editor", ->
         expect(editor1.getSoftTabs()).toBe false
 
         atom.config.set('editor.tabLength', 100)
-        atom.config.set('editor.softWrapped', false)
+        atom.config.set('editor.softWrap', false)
         atom.config.set('editor.softTabs', true)
 
       waitsForPromise ->

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -45,7 +45,7 @@ class DisplayBuffer extends Model
 
     @emitter = new Emitter
 
-    @softWrapped ?= atom.config.get('editor.softWrapped') ? false
+    @softWrapped ?= atom.config.get('editor.softWrap') ? false
     @tokenizedBuffer ?= new TokenizedBuffer({tabLength, buffer, @invisibles})
     @buffer = @tokenizedBuffer.buffer
     @charWidthsByScope = {}

--- a/src/editor-component.coffee
+++ b/src/editor-component.coffee
@@ -478,7 +478,7 @@ EditorComponent = React.createClass
         'editor:add-selection-above': -> editor.addSelectionAbove()
         'editor:split-selections-into-lines': -> editor.splitSelectionsIntoLines()
         'editor:toggle-soft-tabs': -> editor.toggleSoftTabs()
-        'editor:toggle-soft-wrapped': -> editor.toggleSoftWrapped()
+        'editor:toggle-soft-wrap': -> editor.toggleSoftWrapped()
         'editor:fold-all': -> editor.foldAll()
         'editor:unfold-all': -> editor.unfoldAll()
         'editor:fold-current-row': -> editor.foldCurrentRow()

--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -47,7 +47,7 @@ class EditorView extends View
     nonWordCharacters: "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-"
     preferredLineLength: 80
     tabLength: 2
-    softWrapped: false
+    softWrap: false
     softTabs: true
     softWrapAtPreferredLineLength: false
     scrollSensitivity: 40


### PR DESCRIPTION
I recently renamed `Editor::setSoftWrap` and `::getSoftWrap` to `::setSoftWrapped` and `::isSoftWrapped`. I also renamed the config setting and command to match, but we've decided that wasn't a good idea.

This PR renames the config setting back to `editor.softWrap` and the command back to `editor:toggle-soft-wrap`.

Fixes #3531
