### PR TITLE
Add leading/trailing whitespace classes to hard tab tokens

### DIFF
--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -197,6 +197,19 @@ describe "EditorComponent", ->
       nextAnimationFrame()
       expect(linesNode.style.backgroundColor).toBe 'rgb(255, 0, 0)'
 
+    it "applies .leading-whitespace for lines with leading spaces and/or tabs", ->
+      editor.setText(' a')
+      nextAnimationFrame()
+
+      leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
+      expect(leafNodes[0].classList.contains('leading-whitespace')).toBe true
+
+      editor.setText('\ta')
+      nextAnimationFrame()
+
+      leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
+      expect(leafNodes[0].classList.contains('leading-whitespace')).toBe true
+
     it "applies .trailing-whitespace for lines with trailing spaces and/or tabs", ->
       editor.setText('a ')
       nextAnimationFrame()
@@ -209,19 +222,6 @@ describe "EditorComponent", ->
 
       leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
       expect(leafNodes[0].classList.contains('trailing-whitespace')).toBe true
-
-    it "applies .leading-whitespace for lines with trailing spaces and/or tabs", ->
-      editor.setText(' a')
-      nextAnimationFrame()
-
-      leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
-      expect(leafNodes[0].classList.contains('leading-whitespace')).toBe true
-
-      editor.setText('\ta')
-      nextAnimationFrame()
-
-      leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
-      expect(leafNodes[0].classList.contains('leading-whitespace')).toBe true
 
     describe "when showInvisibles is enabled", ->
       invisibles = null

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -211,6 +211,18 @@ describe "EditorComponent", ->
       expect(leafNodes[0].classList.contains('leading-whitespace')).toBe true
 
     it "applies .trailing-whitespace for lines with trailing spaces and/or tabs", ->
+      editor.setText(' ')
+      nextAnimationFrame()
+
+      leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
+      expect(leafNodes[0].classList.contains('trailing-whitespace')).toBe true
+
+      editor.setText('\t')
+      nextAnimationFrame()
+
+      leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
+      expect(leafNodes[0].classList.contains('trailing-whitespace')).toBe true
+
       editor.setText('a ')
       nextAnimationFrame()
 

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -203,12 +203,14 @@ describe "EditorComponent", ->
 
       leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
       expect(leafNodes[0].classList.contains('leading-whitespace')).toBe true
+      expect(leafNodes[0].classList.contains('trailing-whitespace')).toBe false
 
       editor.setText('\ta')
       nextAnimationFrame()
 
       leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
       expect(leafNodes[0].classList.contains('leading-whitespace')).toBe true
+      expect(leafNodes[0].classList.contains('trailing-whitespace')).toBe false
 
     it "applies .trailing-whitespace for lines with trailing spaces and/or tabs", ->
       editor.setText(' ')
@@ -216,24 +218,28 @@ describe "EditorComponent", ->
 
       leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
       expect(leafNodes[0].classList.contains('trailing-whitespace')).toBe true
+      expect(leafNodes[0].classList.contains('leading-whitespace')).toBe false
 
       editor.setText('\t')
       nextAnimationFrame()
 
       leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
       expect(leafNodes[0].classList.contains('trailing-whitespace')).toBe true
+      expect(leafNodes[0].classList.contains('leading-whitespace')).toBe false
 
       editor.setText('a ')
       nextAnimationFrame()
 
       leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
       expect(leafNodes[0].classList.contains('trailing-whitespace')).toBe true
+      expect(leafNodes[0].classList.contains('leading-whitespace')).toBe false
 
       editor.setText('a\t')
       nextAnimationFrame()
 
       leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
       expect(leafNodes[0].classList.contains('trailing-whitespace')).toBe true
+      expect(leafNodes[0].classList.contains('leading-whitespace')).toBe false
 
     describe "when showInvisibles is enabled", ->
       invisibles = null

--- a/spec/editor-component-spec.coffee
+++ b/spec/editor-component-spec.coffee
@@ -197,6 +197,32 @@ describe "EditorComponent", ->
       nextAnimationFrame()
       expect(linesNode.style.backgroundColor).toBe 'rgb(255, 0, 0)'
 
+    it "applies .trailing-whitespace for lines with trailing spaces and/or tabs", ->
+      editor.setText('a ')
+      nextAnimationFrame()
+
+      leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
+      expect(leafNodes[0].classList.contains('trailing-whitespace')).toBe true
+
+      editor.setText('a\t')
+      nextAnimationFrame()
+
+      leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
+      expect(leafNodes[0].classList.contains('trailing-whitespace')).toBe true
+
+    it "applies .leading-whitespace for lines with trailing spaces and/or tabs", ->
+      editor.setText(' a')
+      nextAnimationFrame()
+
+      leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
+      expect(leafNodes[0].classList.contains('leading-whitespace')).toBe true
+
+      editor.setText('\ta')
+      nextAnimationFrame()
+
+      leafNodes = getLeafNodes(component.lineNodeForScreenRow(0))
+      expect(leafNodes[0].classList.contains('leading-whitespace')).toBe true
+
     describe "when showInvisibles is enabled", ->
       invisibles = null
 

--- a/src/token.coffee
+++ b/src/token.coffee
@@ -153,6 +153,8 @@ class Token
   getValueAsHtml: ({hasIndentGuide}) ->
     if @isHardTab
       classes = 'hard-tab'
+      classes += ' leading-whitespace' if @hasLeadingWhitespace()
+      classes += ' trailing-whitespace' if @hasTrailingWhitespace()
       classes += ' indent-guide' if hasIndentGuide
       classes += ' invisible-character' if @hasInvisibleCharacters
       html = "<span class='#{classes}'>#{@escapeString(@value)}</span>"


### PR DESCRIPTION
#2304 no longer cleanly merges but the issue is still present where leading/trailing hard tabs don't get a `trailing-whitespace` or `leading-whitespace` CSS class applied to them.

Closes #2304
