### PR TITLE
Deprecate custom DOM events

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -3229,6 +3229,13 @@ describe "Editor", ->
       editor.destroy()
       expect(buffer.getMarkerCount()).toBe 0
 
+    it "notifies ::onDidDestroy observers when the editor is destroyed", ->
+      destroyObserverCalled = false
+      editor.onDidDestroy -> destroyObserverCalled = true
+
+      editor.destroy()
+      expect(destroyObserverCalled).toBe true
+
   describe ".joinLines()", ->
     describe "when no text is selected", ->
       describe "when the line below isn't empty", ->

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -8,6 +8,7 @@ shell = require 'shell'
 
 _ = require 'underscore-plus'
 {deprecate} = require 'grim'
+{Emitter} = require 'event-kit'
 {Model} = require 'theorist'
 fs = require 'fs-plus'
 
@@ -147,6 +148,7 @@ class Atom extends Model
 
   # Call .loadOrCreate instead
   constructor: (@state) ->
+    @emitter = new Emitter
     {@mode} = @state
     DeserializerManager = require './deserializer-manager'
     @deserializers = new DeserializerManager()
@@ -210,6 +212,18 @@ class Atom extends Model
     Editor = require './editor'
 
     @windowEventHandler = new WindowEventHandler
+
+  ###
+  Section: Event Subscription
+  ###
+
+  # Extended: Invoke the given callback whenever {::beep} is called.
+  #
+  # * `callback` {Function} to be called whenever {::beep} is called.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidBeep: (callback) ->
+    @emitter.on 'did-beep', callback
 
   ###
   Section: Atom Metadata
@@ -493,6 +507,7 @@ class Atom extends Model
   beep: ->
     shell.beep() if @config.get('core.audioBeep')
     @workspaceView.trigger 'beep'
+    @emitter.emit 'did-beep'
 
   # Essential: A flexible way to open a dialog akin to an alert dialog.
   #

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -172,6 +172,7 @@ class Editor extends Model
     @displayBuffer.destroy()
     @languageMode.destroy()
     @emitter.emit 'did-destroy'
+    @emitter.dispose()
 
   ###
   Section: Event Subscription

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -172,7 +172,6 @@ class Editor extends Model
     @displayBuffer.destroy()
     @languageMode.destroy()
     @emitter.emit 'did-destroy'
-    @emitter.dispose()
 
   ###
   Section: Event Subscription

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -171,6 +171,7 @@ class Editor extends Model
     @buffer.release()
     @displayBuffer.destroy()
     @languageMode.destroy()
+    @emitter.emit 'did-destroy'
 
   ###
   Section: Event Subscription
@@ -303,6 +304,14 @@ class Editor extends Model
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidSave: (callback) ->
     @getBuffer().onDidSave(callback)
+
+  # Public: Invoke the given callback when the editor is destroyed.
+  #
+  # * `callback` {Function} to be called when the editor is destroyed.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidDestroy: (callback) ->
+    @emitter.on 'did-destroy', callback
 
   # Extended: Calls your `callback` when a {Cursor} is added to the editor.
   # Immediately calls your callback for each existing cursor.

--- a/src/pane-view.coffee
+++ b/src/pane-view.coffee
@@ -162,7 +162,7 @@ class PaneView extends View
       deprecate 'Please return a Disposable object from your ::onDidChangeTitle method!' unless disposable?.dispose?
       @activeItemDisposables.add(disposable) if disposable?.dispose?
     else if item.on?
-      deprecate '::on methods for items are no longer supported. If you would like your item to title change behavior, please implement a ::onDidChangeTitle() method.'
+      deprecate '::on methods for items are no longer supported. If you would like your item to support title change behavior, please implement a ::onDidChangeTitle() method.'
       disposable = item.on('title-changed', @activeItemTitleChanged)
       @activeItemDisposables.add(disposable) if disposable?.dispose?
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -518,6 +518,7 @@ class Pane extends Model
   destroyed: ->
     @container.activateNextPane() if @isActive()
     @emitter.emit 'did-destroy'
+    @emitter.dispose()
     item.destroy?() for item in @items.slice()
 
   ###

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -418,6 +418,8 @@ class WorkspaceView extends View
 
     @on = (eventName) =>
       switch eventName
+        when 'beep'
+          deprecate('Use Atom::onDidBeep instead')
         when 'cursor:moved'
           deprecate('Use Editor::onDidChangeCursorPosition instead')
         when 'editor:attached'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -175,7 +175,9 @@ class WorkspaceView extends View
     @on = (eventName) =>
       switch eventName
         when 'pane:removed'
-          deprecate("Use Pane::onDidDestroy instead")
+          deprecate('Use Pane::onDidDestroy instead')
+        when 'cursor:moved'
+          deprecate('Use Editor::onDidChangeCursorPosition instead')
       originalOn.apply(this, arguments)
 
   ###

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -178,6 +178,8 @@ class WorkspaceView extends View
           deprecate('Use Pane::onDidDestroy instead')
         when 'cursor:moved'
           deprecate('Use Editor::onDidChangeCursorPosition instead')
+        when 'selection:changed'
+          deprecate('Use Editor::onDidChangeSelectionRange instead')
       originalOn.apply(this, arguments)
 
   ###

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -178,6 +178,8 @@ class WorkspaceView extends View
           deprecate('Use Editor::onDidChangeCursorPosition instead')
         when 'pane:active-item-changed'
           deprecate('Use Pane::onDidChangeActiveItem instead')
+        when 'pane:became-active'
+          deprecate('Use Pane::onDidActivate instead')
         when 'pane:removed'
           deprecate('Use Pane::onDidDestroy instead')
         when 'pane-container:active-pane-item-changed'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -420,6 +420,8 @@ class WorkspaceView extends View
       switch eventName
         when 'cursor:moved'
           deprecate('Use Editor::onDidChangeCursorPosition instead')
+        when 'editor:attached'
+          deprecate('Use Editor::onDidAddTextEditor instead')
         when 'editor:will-be-removed'
           deprecate('Use Editor::onDidDestroy instead')
         when 'pane:active-item-changed'
@@ -456,6 +458,8 @@ class WorkspaceView extends View
       switch eventName
         when 'cursor:moved'
           deprecate('Use Editor::onDidChangeCursorPosition instead')
+        when 'editor:attached'
+          deprecate('Use Editor::onDidAddTextEditor instead')
         when 'editor:will-be-removed'
           deprecate('Use Editor::onDidDestroy instead')
         when 'selection:changed'
@@ -467,6 +471,8 @@ class WorkspaceView extends View
       switch eventName
         when 'cursor:moved'
           deprecate('Use Editor::onDidChangeCursorPosition instead')
+        when 'editor:attached'
+          deprecate('Use Editor::onDidAddTextEditor instead')
         when 'editor:will-be-removed'
           deprecate('Use Editor::onDidDestroy instead')
         when 'pane:active-item-changed'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -217,6 +217,8 @@ class WorkspaceView extends View
           deprecate('Use Editor::onDidChangeCursorPosition instead')
         when 'pane:active-item-changed'
           deprecate('Use Pane::onDidChangeActiveItem instead')
+        when 'pane:active-item-title-changed'
+          deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeTitle on the active item instead')
         when 'pane:became-active'
           deprecate('Use Pane::onDidActivate instead')
         when 'pane:became-inactive'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -184,6 +184,8 @@ class WorkspaceView extends View
           deprecate('Use Pane::onDidChangeActive instead')
         when 'pane:item-added'
           deprecate('Use Pane::onDidAddItem instead')
+        when 'pane:item-removed'
+          deprecate('Use Pane::onDidRemoveItem instead')
         when 'pane:removed'
           deprecate('Use Pane::onDidDestroy instead')
         when 'pane-container:active-pane-item-changed'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -180,6 +180,8 @@ class WorkspaceView extends View
           deprecate('Use Pane::onDidChangeActiveItem instead')
         when 'pane:became-active'
           deprecate('Use Pane::onDidActivate instead')
+        when 'pane:became-inactive'
+          depcreate('Use Pane::onDidChangeActive instead')
         when 'pane:removed'
           deprecate('Use Pane::onDidDestroy instead')
         when 'pane-container:active-pane-item-changed'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -182,6 +182,8 @@ class WorkspaceView extends View
           deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeModified on the active item instead')
         when 'pane:active-item-title-changed'
           deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeTitle on the active item instead')
+        when 'pane:attached'
+          deprecate('Use Workspace::onDidAddPane instead')
         when 'pane:became-active'
           deprecate('Use Pane::onDidActivate instead')
         when 'pane:became-inactive'
@@ -223,6 +225,8 @@ class WorkspaceView extends View
           deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeModified on the active item instead')
         when 'pane:active-item-title-changed'
           deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeTitle on the active item instead')
+        when 'pane:attached'
+          deprecate('Use Workspace::onDidAddPane instead')
         when 'pane:became-active'
           deprecate('Use Pane::onDidActivate instead')
         when 'pane:became-inactive'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -178,6 +178,8 @@ class WorkspaceView extends View
           deprecate('Use Editor::onDidChangeCursorPosition instead')
         when 'pane:active-item-changed'
           deprecate('Use Pane::onDidChangeActiveItem instead')
+        when 'pane:active-item-modified-status-changed'
+          deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeModified on the active item instead')
         when 'pane:active-item-title-changed'
           deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeTitle on the active item instead')
         when 'pane:became-active'
@@ -217,6 +219,8 @@ class WorkspaceView extends View
           deprecate('Use Editor::onDidChangeCursorPosition instead')
         when 'pane:active-item-changed'
           deprecate('Use Pane::onDidChangeActiveItem instead')
+        when 'pane:active-item-modified-status-changed'
+          deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeModified on the active item instead')
         when 'pane:active-item-title-changed'
           deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeTitle on the active item instead')
         when 'pane:became-active'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -181,7 +181,9 @@ class WorkspaceView extends View
         when 'pane:became-active'
           deprecate('Use Pane::onDidActivate instead')
         when 'pane:became-inactive'
-          depcreate('Use Pane::onDidChangeActive instead')
+          deprecate('Use Pane::onDidChangeActive instead')
+        when 'pane:item-added'
+          deprecate('Use Pane::onDidAddItem instead')
         when 'pane:removed'
           deprecate('Use Pane::onDidDestroy instead')
         when 'pane-container:active-pane-item-changed'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -422,6 +422,8 @@ class WorkspaceView extends View
           deprecate('Use Editor::onDidChangeCursorPosition instead')
         when 'editor:attached'
           deprecate('Use Editor::onDidAddTextEditor instead')
+        when 'editor:detached'
+          deprecate('Use Editor::onDidDestroy instead')
         when 'editor:will-be-removed'
           deprecate('Use Editor::onDidDestroy instead')
         when 'pane:active-item-changed'
@@ -460,6 +462,8 @@ class WorkspaceView extends View
           deprecate('Use Editor::onDidChangeCursorPosition instead')
         when 'editor:attached'
           deprecate('Use Editor::onDidAddTextEditor instead')
+        when 'editor:detached'
+          deprecate('Use Editor::onDidDestroy instead')
         when 'editor:will-be-removed'
           deprecate('Use Editor::onDidDestroy instead')
         when 'selection:changed'
@@ -473,6 +477,8 @@ class WorkspaceView extends View
           deprecate('Use Editor::onDidChangeCursorPosition instead')
         when 'editor:attached'
           deprecate('Use Editor::onDidAddTextEditor instead')
+        when 'editor:detached'
+          deprecate('Use Editor::onDidDestroy instead')
         when 'editor:will-be-removed'
           deprecate('Use Editor::onDidDestroy instead')
         when 'pane:active-item-changed'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -167,9 +167,9 @@ class WorkspaceView extends View
     @command 'core:save', => @saveActivePaneItem()
     @command 'core:save-as', => @saveActivePaneItemAs()
 
-    @setupViewEventDeprecations()
+    @deprecatedViewEvents()
 
-  setupViewEventDeprecations: ->
+  deprecatedViewEvents: ->
     originalOn = @on
 
     @on = (eventName) =>

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -169,86 +169,6 @@ class WorkspaceView extends View
 
     @deprecatedViewEvents()
 
-  deprecatedViewEvents: ->
-    originalWorkspaceViewOn = @on
-
-    @on = (eventName) =>
-      switch eventName
-        when 'cursor:moved'
-          deprecate('Use Editor::onDidChangeCursorPosition instead')
-        when 'editor:will-be-removed'
-          deprecate('Use Editor::onDidDestroy instead')
-        when 'pane:active-item-changed'
-          deprecate('Use Pane::onDidChangeActiveItem instead')
-        when 'pane:active-item-modified-status-changed'
-          deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeModified on the active item instead')
-        when 'pane:active-item-title-changed'
-          deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeTitle on the active item instead')
-        when 'pane:attached'
-          deprecate('Use Workspace::onDidAddPane instead')
-        when 'pane:became-active'
-          deprecate('Use Pane::onDidActivate instead')
-        when 'pane:became-inactive'
-          deprecate('Use Pane::onDidChangeActive instead')
-        when 'pane:item-added'
-          deprecate('Use Pane::onDidAddItem instead')
-        when 'pane:item-moved'
-          deprecate('Use Pane::onDidMoveItem instead')
-        when 'pane:item-removed'
-          deprecate('Use Pane::onDidRemoveItem instead')
-        when 'pane:removed'
-          deprecate('Use Pane::onDidDestroy instead')
-        when 'pane-container:active-pane-item-changed'
-          deprecate('Use Workspace::onDidChangeActivePaneItem instead')
-        when 'selection:changed'
-          deprecate('Use Editor::onDidChangeSelectionRange instead')
-        when 'uri-opened'
-          deprecate('Use Workspace::onDidOpen instead')
-      originalWorkspaceViewOn.apply(this, arguments)
-
-    EditorView = require './editor-view'
-    originalEditorViewOn = EditorView::on
-    EditorView::on = (eventName) ->
-      switch eventName
-        when 'cursor:moved'
-          deprecate('Use Editor::onDidChangeCursorPosition instead')
-        when 'editor:will-be-removed'
-          deprecate('Use Editor::onDidDestroy instead')
-        when 'selection:changed'
-          deprecate('Use Editor::onDidChangeSelectionRange instead')
-      originalEditorViewOn.apply(this, arguments)
-
-    originalPaneViewOn = PaneView::on
-    PaneView::on = (eventName) ->
-      switch eventName
-        when 'cursor:moved'
-          deprecate('Use Editor::onDidChangeCursorPosition instead')
-        when 'editor:will-be-removed'
-          deprecate('Use Editor::onDidDestroy instead')
-        when 'pane:active-item-changed'
-          deprecate('Use Pane::onDidChangeActiveItem instead')
-        when 'pane:active-item-modified-status-changed'
-          deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeModified on the active item instead')
-        when 'pane:active-item-title-changed'
-          deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeTitle on the active item instead')
-        when 'pane:attached'
-          deprecate('Use Workspace::onDidAddPane instead')
-        when 'pane:became-active'
-          deprecate('Use Pane::onDidActivate instead')
-        when 'pane:became-inactive'
-          deprecate('Use Pane::onDidChangeActive instead')
-        when 'pane:item-added'
-          deprecate('Use Pane::onDidAddItem instead')
-        when 'pane:item-moved'
-          deprecate('Use Pane::onDidMoveItem instead')
-        when 'pane:item-removed'
-          deprecate('Use Pane::onDidRemoveItem instead')
-        when 'pane:removed'
-          deprecate('Use Pane::onDidDestroy instead')
-        when 'selection:changed'
-          deprecate('Use Editor::onDidChangeSelectionRange instead')
-      originalPaneViewOn.apply(this, arguments)
-
   ###
   Section: Accessing the Workspace Model
   ###
@@ -492,6 +412,86 @@ class WorkspaceView extends View
   ###
   Section: Deprecated
   ###
+
+  deprecatedViewEvents: ->
+    originalWorkspaceViewOn = @on
+
+    @on = (eventName) =>
+      switch eventName
+        when 'cursor:moved'
+          deprecate('Use Editor::onDidChangeCursorPosition instead')
+        when 'editor:will-be-removed'
+          deprecate('Use Editor::onDidDestroy instead')
+        when 'pane:active-item-changed'
+          deprecate('Use Pane::onDidChangeActiveItem instead')
+        when 'pane:active-item-modified-status-changed'
+          deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeModified on the active item instead')
+        when 'pane:active-item-title-changed'
+          deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeTitle on the active item instead')
+        when 'pane:attached'
+          deprecate('Use Workspace::onDidAddPane instead')
+        when 'pane:became-active'
+          deprecate('Use Pane::onDidActivate instead')
+        when 'pane:became-inactive'
+          deprecate('Use Pane::onDidChangeActive instead')
+        when 'pane:item-added'
+          deprecate('Use Pane::onDidAddItem instead')
+        when 'pane:item-moved'
+          deprecate('Use Pane::onDidMoveItem instead')
+        when 'pane:item-removed'
+          deprecate('Use Pane::onDidRemoveItem instead')
+        when 'pane:removed'
+          deprecate('Use Pane::onDidDestroy instead')
+        when 'pane-container:active-pane-item-changed'
+          deprecate('Use Workspace::onDidChangeActivePaneItem instead')
+        when 'selection:changed'
+          deprecate('Use Editor::onDidChangeSelectionRange instead')
+        when 'uri-opened'
+          deprecate('Use Workspace::onDidOpen instead')
+      originalWorkspaceViewOn.apply(this, arguments)
+
+    EditorView = require './editor-view'
+    originalEditorViewOn = EditorView::on
+    EditorView::on = (eventName) ->
+      switch eventName
+        when 'cursor:moved'
+          deprecate('Use Editor::onDidChangeCursorPosition instead')
+        when 'editor:will-be-removed'
+          deprecate('Use Editor::onDidDestroy instead')
+        when 'selection:changed'
+          deprecate('Use Editor::onDidChangeSelectionRange instead')
+      originalEditorViewOn.apply(this, arguments)
+
+    originalPaneViewOn = PaneView::on
+    PaneView::on = (eventName) ->
+      switch eventName
+        when 'cursor:moved'
+          deprecate('Use Editor::onDidChangeCursorPosition instead')
+        when 'editor:will-be-removed'
+          deprecate('Use Editor::onDidDestroy instead')
+        when 'pane:active-item-changed'
+          deprecate('Use Pane::onDidChangeActiveItem instead')
+        when 'pane:active-item-modified-status-changed'
+          deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeModified on the active item instead')
+        when 'pane:active-item-title-changed'
+          deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeTitle on the active item instead')
+        when 'pane:attached'
+          deprecate('Use Workspace::onDidAddPane instead')
+        when 'pane:became-active'
+          deprecate('Use Pane::onDidActivate instead')
+        when 'pane:became-inactive'
+          deprecate('Use Pane::onDidChangeActive instead')
+        when 'pane:item-added'
+          deprecate('Use Pane::onDidAddItem instead')
+        when 'pane:item-moved'
+          deprecate('Use Pane::onDidMoveItem instead')
+        when 'pane:item-removed'
+          deprecate('Use Pane::onDidRemoveItem instead')
+        when 'pane:removed'
+          deprecate('Use Pane::onDidDestroy instead')
+        when 'selection:changed'
+          deprecate('Use Editor::onDidChangeSelectionRange instead')
+      originalPaneViewOn.apply(this, arguments)
 
   # Deprecated
   eachPane: (callback) ->

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -174,6 +174,8 @@ class WorkspaceView extends View
 
     @on = (eventName) =>
       switch eventName
+        when 'pane:active-item-changed'
+          deprecate('Use Pane::onDidChangeActiveItem instead')
         when 'pane:removed'
           deprecate('Use Pane::onDidDestroy instead')
         when 'pane-container:active-pane-item-changed'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -188,6 +188,8 @@ class WorkspaceView extends View
           deprecate('Use Workspace::onDidChangeActivePaneItem instead')
         when 'selection:changed'
           deprecate('Use Editor::onDidChangeSelectionRange instead')
+        when 'uri-opened'
+          deprecate('Use Workspace::onDidOpen instead')
       originalOn.apply(this, arguments)
 
   ###

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -176,6 +176,8 @@ class WorkspaceView extends View
       switch eventName
         when 'pane:removed'
           deprecate('Use Pane::onDidDestroy instead')
+        when 'pane-container:active-pane-item-changed'
+          deprecate('Use Workspace::onDidChangeActivePaneItem instead')
         when 'cursor:moved'
           deprecate('Use Editor::onDidChangeCursorPosition instead')
         when 'selection:changed'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -170,7 +170,7 @@ class WorkspaceView extends View
     @deprecatedViewEvents()
 
   deprecatedViewEvents: ->
-    originalOn = @on
+    originalWorkspaceViewOn = @on
 
     @on = (eventName) =>
       switch eventName
@@ -196,17 +196,40 @@ class WorkspaceView extends View
           deprecate('Use Editor::onDidChangeSelectionRange instead')
         when 'uri-opened'
           deprecate('Use Workspace::onDidOpen instead')
-      originalOn.apply(this, arguments)
+      originalWorkspaceViewOn.apply(this, arguments)
 
     EditorView = require './editor-view'
-    originalEditorOn = EditorView::on
+    originalEditorViewOn = EditorView::on
     EditorView::on = (eventName) ->
       switch eventName
         when 'cursor:moved'
           deprecate('Use Editor::onDidChangeCursorPosition instead')
         when 'selection:changed'
           deprecate('Use Editor::onDidChangeSelectionRange instead')
-      originalEditorOn.apply(this, arguments)
+      originalEditorViewOn.apply(this, arguments)
+
+    originalPaneViewOn = PaneView::on
+    PaneView::on = (eventName) ->
+      switch eventName
+        when 'cursor:moved'
+          deprecate('Use Editor::onDidChangeCursorPosition instead')
+        when 'pane:active-item-changed'
+          deprecate('Use Pane::onDidChangeActiveItem instead')
+        when 'pane:became-active'
+          deprecate('Use Pane::onDidActivate instead')
+        when 'pane:became-inactive'
+          deprecate('Use Pane::onDidChangeActive instead')
+        when 'pane:item-added'
+          deprecate('Use Pane::onDidAddItem instead')
+        when 'pane:item-moved'
+          deprecate('Use Pane::onDidMoveItem instead')
+        when 'pane:item-removed'
+          deprecate('Use Pane::onDidRemoveItem instead')
+        when 'pane:removed'
+          deprecate('Use Pane::onDidDestroy instead')
+        when 'selection:changed'
+          deprecate('Use Editor::onDidChangeSelectionRange instead')
+      originalPaneViewOn.apply(this, arguments)
 
   ###
   Section: Accessing the Workspace Model

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -176,6 +176,8 @@ class WorkspaceView extends View
       switch eventName
         when 'cursor:moved'
           deprecate('Use Editor::onDidChangeCursorPosition instead')
+        when 'editor:will-be-removed'
+          deprecate('Use Editor::onDidDestroy instead')
         when 'pane:active-item-changed'
           deprecate('Use Pane::onDidChangeActiveItem instead')
         when 'pane:active-item-modified-status-changed'
@@ -210,6 +212,8 @@ class WorkspaceView extends View
       switch eventName
         when 'cursor:moved'
           deprecate('Use Editor::onDidChangeCursorPosition instead')
+        when 'editor:will-be-removed'
+          deprecate('Use Editor::onDidDestroy instead')
         when 'selection:changed'
           deprecate('Use Editor::onDidChangeSelectionRange instead')
       originalEditorViewOn.apply(this, arguments)
@@ -219,6 +223,8 @@ class WorkspaceView extends View
       switch eventName
         when 'cursor:moved'
           deprecate('Use Editor::onDidChangeCursorPosition instead')
+        when 'editor:will-be-removed'
+          deprecate('Use Editor::onDidDestroy instead')
         when 'pane:active-item-changed'
           deprecate('Use Pane::onDidChangeActiveItem instead')
         when 'pane:active-item-modified-status-changed'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -178,6 +178,8 @@ class WorkspaceView extends View
           deprecate('Use Editor::onDidChangeCursorPosition instead')
         when 'pane:active-item-changed'
           deprecate('Use Pane::onDidChangeActiveItem instead')
+        when 'pane:active-item-title-changed'
+          deprecate('Use Pane::onDidChangeActiveItem and call onDidChangeTitle on the active item instead')
         when 'pane:became-active'
           deprecate('Use Pane::onDidActivate instead')
         when 'pane:became-inactive'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -198,6 +198,16 @@ class WorkspaceView extends View
           deprecate('Use Workspace::onDidOpen instead')
       originalOn.apply(this, arguments)
 
+    EditorView = require './editor-view'
+    originalEditorOn = EditorView::on
+    EditorView::on = (eventName) ->
+      switch eventName
+        when 'cursor:moved'
+          deprecate('Use Editor::onDidChangeCursorPosition instead')
+        when 'selection:changed'
+          deprecate('Use Editor::onDidChangeSelectionRange instead')
+      originalEditorOn.apply(this, arguments)
+
   ###
   Section: Accessing the Workspace Model
   ###

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -167,6 +167,17 @@ class WorkspaceView extends View
     @command 'core:save', => @saveActivePaneItem()
     @command 'core:save-as', => @saveActivePaneItemAs()
 
+    @setupViewEventDeprecations()
+
+  setupViewEventDeprecations: ->
+    originalOn = @on
+
+    @on = (eventName) =>
+      switch eventName
+        when 'pane:removed'
+          deprecate("Use Pane::onDidDestroy instead")
+      originalOn.apply(this, arguments)
+
   ###
   Section: Accessing the Workspace Model
   ###

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -184,6 +184,8 @@ class WorkspaceView extends View
           deprecate('Use Pane::onDidChangeActive instead')
         when 'pane:item-added'
           deprecate('Use Pane::onDidAddItem instead')
+        when 'pane:item-moved'
+          deprecate('Use Pane::onDidMoveItem instead')
         when 'pane:item-removed'
           deprecate('Use Pane::onDidRemoveItem instead')
         when 'pane:removed'

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -174,14 +174,14 @@ class WorkspaceView extends View
 
     @on = (eventName) =>
       switch eventName
+        when 'cursor:moved'
+          deprecate('Use Editor::onDidChangeCursorPosition instead')
         when 'pane:active-item-changed'
           deprecate('Use Pane::onDidChangeActiveItem instead')
         when 'pane:removed'
           deprecate('Use Pane::onDidDestroy instead')
         when 'pane-container:active-pane-item-changed'
           deprecate('Use Workspace::onDidChangeActivePaneItem instead')
-        when 'cursor:moved'
-          deprecate('Use Editor::onDidChangeCursorPosition instead')
         when 'selection:changed'
           deprecate('Use Editor::onDidChangeSelectionRange instead')
       originalOn.apply(this, arguments)

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -104,7 +104,7 @@ class Workspace extends Model
     @onDidAddTextEditor ({textEditor}) -> callback(textEditor)
 
   # Essential: Invoke the given callback whenever an item is opened. Unlike
-  # ::onDidAddPaneItem, observers will be notified for items that are already
+  # {::onDidAddPaneItem}, observers will be notified for items that are already
   # present in the workspace when they are reopened.
   #
   # * `callback` {Function} to be called whenever an item is opened.


### PR DESCRIPTION
### Deprecated view events

The following events will now be deprecated when calling `.on` on these views with information about the corresponding model event that should be used instead.
#### WorkspaceView (atom.workspaceView)
- beep (added `Atom::onDidBeep`)
- cursor:moved
- editor:attached
- editor:detached
- editor:will-be-removed
- pane:active-item-changed
- pane:active-item-modified-status-changed
- pane:active-item-title-changed
- pane:attached
- pane:became-active
- pane:became-inactive
- pane:item-added
- pane:item-moved
- pane:item-removed
- pane:removed
- pane-container:active-pane-item-changed
- selection:changed
- uri-opened
#### EditorView
- cursor:moved
- editor:attached
- editor:detached
- editor:will-be-removed
- selection:changed
#### PaneView
- cursor:moved
- editor:attached
- editor:detached
- editor:will-be-removed
- pane:active-item-changed
- pane:active-item-modified-status-changed
- pane:active-item-title-changed
- pane:attached
- pane:became-active
- pane:became-inactive
- pane:item-added
- pane:item-moved
- pane:item-removed
- pane:removed
- selection:changed
### Remaining custom view events
#### EditorView
- editor:display-updated
