### PR TITLE
Fail focused specs on CI

### DIFF
--- a/spec/jasmine-helper.coffee
+++ b/spec/jasmine-helper.coffee
@@ -7,6 +7,8 @@ module.exports.runSpecSuite = (specSuite, logFile, logErrors=true) ->
 
   {TerminalReporter} = require 'jasmine-tagged'
 
+  disableFocusMethods() if process.env.JANKY_SHA1
+
   TimeReporter = require './time-reporter'
   timeReporter = new TimeReporter()
 
@@ -38,3 +40,10 @@ module.exports.runSpecSuite = (specSuite, logFile, logErrors=true) ->
   $('body').append $$ -> @div id: 'jasmine-content'
 
   jasmineEnv.execute()
+
+disableFocusMethods = ->
+  ['fdescribe', 'ffdescribe', 'fffdescribe', 'fit', 'ffit', 'fffit'].forEach (methodName) ->
+    focusMethod = window[methodName]
+    window[methodName] = (description) ->
+      error = new Error('Focused spec is running on CI')
+      focusMethod description, -> throw error


### PR DESCRIPTION
This ensures focused specs never end up as green builds on PRs and will fail master builds when focused specs are pushed to master.

/cc @nathansobo @benogle You guys okays with this? Today we had another focused spec checked in and it seems like it happens enough that we should just just fail them immediately on CI when they are checked in.
