### PR TITLE
Add matching of Atom.app more stable

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -50,7 +50,7 @@ if [ $OS == 'Mac' ]; then
 
   # If ATOM_PATH isn't a executable file, use spotlight to search for Atom
   if [ ! -x "$ATOM_PATH/$ATOM_APP_NAME" ]; then
-    ATOM_PATH=$(mdfind "kMDItemCFBundleIdentifier == 'com.github.atom'" | head -1 | xargs dirname)
+    ATOM_PATH=$(mdfind "kMDItemCFBundleIdentifier == 'com.github.atom'" | grep -v ShipIt | head -1 | xargs dirname)
   fi
 
   # Exit if Atom can't be found


### PR DESCRIPTION
I have this file on my Mac `/Users/timosand/Library/Application Support/com.github.atom.ShipIt/update.85PyXs3/Atom.app` and my `mdfind` returns it. It seems to be a common one, so I thought to remove it from the list to be sure that it selects the right Atom.app
