### PR TITLE
Remove lintian errors

### DIFF
--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -6,3 +6,4 @@ Architecture: <%= arch %>
 Installed-Size: <%= installedSize %>
 Maintainer: <%= maintainer %>
 Description: <%= description %>
+ Atom is a free and open source text editor that is modern, approachable, and hackable to the core.

--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,5 +1,6 @@
 Package: <%= name %>
 Version: <%= version %>
+Depends: python (>= 2.6)
 Section: <%= section %>
 Priority: optional
 Architecture: <%= arch %>

--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= name %>
 Version: <%= version %>
-Depends: python (>= 2.6)
+Depends: python (>= 2.6), libc6
 Section: <%= section %>
 Priority: optional
 Architecture: <%= arch %>

--- a/resources/linux/debian/lintian-overrides
+++ b/resources/linux/debian/lintian-overrides
@@ -1,1 +1,7 @@
+atom: arch-dependent-file-in-usr-share
+atom: changelog-file-missing-in-native-package
+atom: copyright-file-contains-full-apache-2-license
+atom: copyright-should-refer-to-common-license-file-for-apache-2
+atom: embedded-library
+atom: package-installs-python-bytecode
 atom: unstripped-binary-or-object

--- a/resources/linux/debian/lintian-overrides
+++ b/resources/linux/debian/lintian-overrides
@@ -1,0 +1,1 @@
+atom: unstripped-binary-or-object

--- a/script/mkdeb
+++ b/script/mkdeb
@@ -35,6 +35,10 @@ cp "$ICON_FILE" "$TARGET/usr/share/pixmaps"
 mkdir -m $FILE_MODE -p "$TARGET/usr/share/doc/atom"
 cp "$TARGET/usr/share/atom/resources/app/LICENSE.md" "$TARGET/usr/share/doc/atom/copyright"
 
+# Add lintian overrides
+mkdir -m $FILE_MODE -p "$TARGET/usr/share/lintian/overrides"
+cp "$ROOT/resources/linux/debian/lintian-overrides" "$TARGET/usr/share/lintian/overrides/atom"
+
 # Remove executable bit from .node files
 find "$TARGET" -type f -name "*.node" -exec chmod a-x {} \;
 

--- a/script/mkdeb
+++ b/script/mkdeb
@@ -31,6 +31,6 @@ cp "$DESKTOP_FILE" "$TARGET/usr/share/applications"
 mkdir -m $FILE_MODE -p "$TARGET/usr/share/pixmaps"
 cp "$ICON_FILE" "$TARGET/usr/share/pixmaps"
 
-dpkg-deb -b "$TARGET"
+fakeroot dpkg-deb -b "$TARGET"
 mv "$TARGET_ROOT/atom-$VERSION-$ARCH.deb" "$DEB_PATH"
 rm -rf "$TARGET_ROOT"

--- a/script/mkdeb
+++ b/script/mkdeb
@@ -16,7 +16,7 @@ DEB_PATH="$6"
 FILE_MODE=755
 
 TARGET_ROOT="`mktemp -d`"
-chmod 755 "$TARGET_ROOT"
+chmod $FILE_MODE "$TARGET_ROOT"
 TARGET="$TARGET_ROOT/atom-$VERSION-$ARCH"
 
 mkdir -m $FILE_MODE -p "$TARGET/usr"

--- a/script/mkdeb
+++ b/script/mkdeb
@@ -31,6 +31,9 @@ cp "$DESKTOP_FILE" "$TARGET/usr/share/applications"
 mkdir -m $FILE_MODE -p "$TARGET/usr/share/pixmaps"
 cp "$ICON_FILE" "$TARGET/usr/share/pixmaps"
 
+# Remove executable bit from .node files
+find "$TARGET" -type f -name "*.node" -exec chmod a-x {} \;
+
 fakeroot dpkg-deb -b "$TARGET"
 mv "$TARGET_ROOT/atom-$VERSION-$ARCH.deb" "$DEB_PATH"
 rm -rf "$TARGET_ROOT"

--- a/script/mkdeb
+++ b/script/mkdeb
@@ -31,6 +31,10 @@ cp "$DESKTOP_FILE" "$TARGET/usr/share/applications"
 mkdir -m $FILE_MODE -p "$TARGET/usr/share/pixmaps"
 cp "$ICON_FILE" "$TARGET/usr/share/pixmaps"
 
+# Copy generated LICENSE.md to /usr/share/doc/atom/copyright
+mkdir -m $FILE_MODE -p "$TARGET/usr/share/doc/atom"
+cp "$TARGET/usr/share/atom/resources/app/LICENSE.md" "$TARGET/usr/share/doc/atom/copyright"
+
 # Remove executable bit from .node files
 find "$TARGET" -type f -name "*.node" -exec chmod a-x {} \;
 

--- a/script/mkdeb
+++ b/script/mkdeb
@@ -33,4 +33,4 @@ cp "$ICON_FILE" "$TARGET/usr/share/pixmaps"
 
 dpkg-deb -b "$TARGET"
 mv "$TARGET_ROOT/atom-$VERSION-$ARCH.deb" "$DEB_PATH"
-rm -rf $TARGET_ROOT
+rm -rf "$TARGET_ROOT"


### PR DESCRIPTION
Correct errors generated when running lintian against the deb package.
- [x] arch-dependent-file-in-usr-share
- [x] changelog-file-missing-in-native-package
- [x] embedded-library
- [x] extended-description-is-empty
- [x] no-copyright-file
- [x] python-script-but-no-python-dep
- [x] shlib-with-executable-bit
- [x] unstripped-binary-or-object
- [x] wrong-file-owner-uid-or-gid

Closes #3596
