### PR TITLE
Make cursor / selection events consistent

### DIFF
--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -174,6 +174,20 @@ describe "Editor", ->
         editor.moveDown()
         expect(editor.getCursorBufferPosition()).toEqual [1, 1]
 
+      it "emits an event with the old position, new position, and the cursor that moved", ->
+        editor.onDidChangeCursorPosition positionChangedHandler = jasmine.createSpy()
+
+        editor.setCursorBufferPosition([2, 4])
+
+        expect(positionChangedHandler).toHaveBeenCalled()
+        eventObject = positionChangedHandler.mostRecentCall.args[0]
+
+        expect(eventObject.oldBufferPosition).toEqual [0, 0]
+        expect(eventObject.oldScreenPosition).toEqual [0, 0]
+        expect(eventObject.newBufferPosition).toEqual [2, 4]
+        expect(eventObject.newScreenPosition).toEqual [2, 4]
+        expect(eventObject.cursor).toBe editor.getLastCursor()
+
     describe ".setCursorScreenPosition(screenPosition)", ->
       it "clears a goal column established by vertical movement", ->
         # set a goal column by moving down

--- a/spec/editor-spec.coffee
+++ b/spec/editor-spec.coffee
@@ -901,6 +901,22 @@ describe "Editor", ->
     beforeEach ->
       selection = editor.getLastSelection()
 
+    describe "when the selection range changes", ->
+      it "emits an event with the old range, new range, and the selection that moved", ->
+        editor.setSelectedBufferRange([[3, 0], [4, 5]])
+
+        editor.onDidChangeSelectionRange rangeChangedHandler = jasmine.createSpy()
+        editor.selectToBufferPosition([6, 2])
+
+        expect(rangeChangedHandler).toHaveBeenCalled()
+        eventObject = rangeChangedHandler.mostRecentCall.args[0]
+
+        expect(eventObject.oldBufferRange).toEqual [[3, 0], [4, 5]]
+        expect(eventObject.oldScreenRange).toEqual [[3, 0], [4, 5]]
+        expect(eventObject.newBufferRange).toEqual [[3, 0], [6, 2]]
+        expect(eventObject.newScreenRange).toEqual [[3, 0], [6, 2]]
+        expect(eventObject.selection).toBe selection
+
     describe ".selectUp/Down/Left/Right()", ->
       it "expands each selection to its cursor's new location", ->
         editor.setSelectedBufferRanges([[[0,9], [0,13]], [[3,16], [3,21]]])

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -46,7 +46,7 @@ class Cursor extends Model
 
       @emit 'moved', movedEvent
       @emitter.emit 'did-change-position'
-      @editor.cursorMoved(this, movedEvent)
+      @editor.cursorMoved(movedEvent)
     @marker.onDidDestroy =>
       @destroyed = true
       @editor.removeCursor(this)

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -42,6 +42,7 @@ class Cursor extends Model
         newBufferPosition: newHeadBufferPosition
         newScreenPosition: newHeadScreenPosition
         textChanged: textChanged
+        cursor: this
 
       @emit 'moved', movedEvent
       @emitter.emit 'did-change-position'

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -71,6 +71,7 @@ class Cursor extends Model
   #     * `newBufferPosition` {Point}
   #     * `newScreenPosition` {Point}
   #     * `textChanged` {Boolean}
+  #     * `Cursor` {Cursor} that triggered the event
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidChangePosition: (callback) ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -1604,7 +1604,7 @@ class Editor extends Model
     fn(cursor) for cursor in @getCursors()
     @mergeCursors()
 
-  cursorMoved: (cursor, event) ->
+  cursorMoved: (event) ->
     @emit 'cursor-moved', event
     @emitter.emit 'did-change-cursor-position', event
 

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -2088,9 +2088,9 @@ class Editor extends Model
       false
 
   # Called by the selection
-  selectionRangeChanged: (selection) ->
-    @emit 'selection-screen-range-changed', selection
-    @emitter.emit 'did-change-selection-range', selection
+  selectionRangeChanged: (event) ->
+    @emit 'selection-screen-range-changed', event
+    @emitter.emit 'did-change-selection-range', event
 
   ###
   Section: Searching and Replacing

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -235,7 +235,12 @@ class Editor extends Model
   # Essential: Calls your `callback` when a selection's screen range changes.
   #
   # * `callback` {Function}
-  #   * `selection` {Selection} that moved
+  #   * `event` {Object}
+  #     * `oldBufferRange` {Range}
+  #     * `oldScreenRange` {Range}
+  #     * `newBufferRange` {Range}
+  #     * `newScreenRange` {Range}
+  #     * `selection` {Selection} that triggered the event
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidChangeSelectionRange: (callback) ->

--- a/src/editor.coffee
+++ b/src/editor.coffee
@@ -226,6 +226,7 @@ class Editor extends Model
   #     * `newBufferPosition` {Point}
   #     * `newScreenPosition` {Point}
   #     * `textChanged` {Boolean}
+  #     * `cursor` {Cursor} that triggered the event
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidChangeCursorPosition: (callback) ->

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -40,7 +40,12 @@ class Selection extends Model
   # Extended: Calls your `callback` when the selection was moved.
   #
   # * `callback` {Function}
-  #   * `screenRange` {Range} indicating the new screenrange
+  #   * `event` {Object}
+  #     * `oldBufferRange` {Range}
+  #     * `oldScreenRange` {Range}
+  #     * `newBufferRange` {Range}
+  #     * `newScreenRange` {Range}
+  #     * `selection` {Selection} that triggered the event
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidChangeRange: (callback) ->

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -21,7 +21,7 @@ class Selection extends Model
     @cursor.selection = this
     @decoration = @editor.decorateMarker(@marker, type: 'highlight', class: 'selection')
 
-    @marker.onDidChange => @screenRangeChanged()
+    @marker.onDidChange (e) => @screenRangeChanged(e)
     @marker.onDidDestroy =>
       unless @editor.isDestroyed()
         @destroyed = true
@@ -686,10 +686,20 @@ class Selection extends Model
   Section: Private Utilities
   ###
 
-  screenRangeChanged: ->
-    @emit 'screen-range-changed', @getScreenRange()
+  screenRangeChanged: (e) ->
+    {oldHeadBufferPosition, oldTailBufferPosition} = e
+    {oldHeadScreenPosition, oldTailScreenPosition} = e
+
+    eventObject =
+      oldBufferRange: new Range(oldHeadBufferPosition, oldTailBufferPosition)
+      oldScreenRange: new Range(oldHeadScreenPosition, oldTailScreenPosition)
+      newBufferRange: @getBufferRange()
+      newScreenRange: @getScreenRange()
+      selection: this
+
+    @emit 'screen-range-changed', @getScreenRange() # old event
     @emitter.emit 'did-change-range'
-    @editor.selectionRangeChanged(this)
+    @editor.selectionRangeChanged(eventObject)
 
   finalize: ->
     @initialScreenRange = null unless @initialScreenRange?.isEqual(@getScreenRange())


### PR DESCRIPTION
`onDidChangeSelectionRange` and `onDidChangeCursorPosition` passed different data to their call backs. This makes them consistent.
