### PR TITLE
Don't override antialiasing in markdown

### DIFF
--- a/static/markdown.less
+++ b/static/markdown.less
@@ -1,7 +1,5 @@
 .source {
   .gfm {
-    -webkit-font-smoothing: antialiased;
-
     .markup.heading {
       font-weight: bold;
     }
@@ -16,10 +14,6 @@
 
     .comment.quote {
       font-style: italic;
-    }
-
-    .raw {
-      -webkit-font-smoothing: subpixel-antialiased;
     }
   }
 }


### PR DESCRIPTION
Not sure if there is a reason for these.
