### PR TITLE
Add ability to scroll past the end of the file

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1100,6 +1100,33 @@ describe "DisplayBuffer", ->
       expect(displayBuffer.setScrollTop(maxScrollTop + 50)).toBe maxScrollTop
       expect(displayBuffer.getScrollTop()).toBe maxScrollTop
 
+  describe "editor.scrollPastEnd", ->
+    describe "when editor.scrollPastEnd is false", ->
+      beforeEach ->
+        atom.config.set("editor.scrollPastEnd", false)
+        displayBuffer.manageScrollPosition = true
+        displayBuffer.setLineHeightInPixels(10)
+
+      it "does not add the height of the view to the scroll height", ->
+        lineHeight = displayBuffer.getLineHeightInPixels()
+        originalScrollHeight = displayBuffer.getScrollHeight()
+        displayBuffer.setHeight(50)
+
+        expect(displayBuffer.getScrollHeight()).toBe originalScrollHeight
+
+    describe "when editor.scrollPastEnd is true", ->
+      beforeEach ->
+        atom.config.set("editor.scrollPastEnd", true)
+        displayBuffer.manageScrollPosition = true
+        displayBuffer.setLineHeightInPixels(10)
+
+      it "adds the height of the view to the scroll height", ->
+        lineHeight = displayBuffer.getLineHeightInPixels()
+        originalScrollHeight = displayBuffer.getScrollHeight()
+        displayBuffer.setHeight(50)
+
+        expect(displayBuffer.getScrollHeight()).toEqual(originalScrollHeight + displayBuffer.height - (lineHeight * 3))
+
   describe "::setScrollLeft", ->
     beforeEach ->
       displayBuffer.manageScrollPosition = true

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -315,9 +315,14 @@ class DisplayBuffer extends Model
     @charWidthsByScope = {}
 
   getScrollHeight: ->
-    return 0 unless @getLineHeightInPixels() > 0
+    lineHeight = @getLineHeightInPixels()
+    return 0 unless lineHeight > 0
 
-    @getLineCount() * @getLineHeightInPixels()
+    scrollHeight = @getLineCount() * lineHeight
+    if @height? and atom.config.get('editor.scrollPastEnd')
+      scrollHeight = scrollHeight + @height - (lineHeight * 3)
+
+    scrollHeight
 
   getScrollWidth: ->
     @scrollWidth

--- a/src/text-editor-view.coffee
+++ b/src/text-editor-view.coffee
@@ -60,6 +60,7 @@ class TextEditorView extends View
       space: '\u00b7'
       tab: '\u00bb'
       cr: '\u00a4'
+    scrollPastEnd: false
 
   @content: (params) ->
     attributes = params.attributes ? {}


### PR DESCRIPTION
Fixes #3592 

Since @thedaniel [suggested](https://github.com/atom/atom/issues/3592#issuecomment-56398349) that this should be part of the default behavior, I took some of the code from the [scroll-past-end package](https://atom.io/packages/scroll-past-end) and added the functionality.
