### PR TITLE
Return disposables from MenuManager::add and add specs

### DIFF
--- a/spec/menu-manager-spec.coffee
+++ b/spec/menu-manager-spec.coffee
@@ -35,3 +35,9 @@ describe "MenuManager", ->
 
       disposable1.dispose()
       expect(atom.menu.template.length).toBe originalItemCount
+
+    it "does not add duplicate labels to the same menu", ->
+      originalItemCount = atom.menu.template.length
+      atom.menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
+      atom.menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
+      expect(atom.menu.template[originalItemCount]).toEqual {label: "A", submenu: [{label: "B", command: "b"}]}

--- a/spec/menu-manager-spec.coffee
+++ b/spec/menu-manager-spec.coffee
@@ -7,7 +7,7 @@ describe "MenuManager", ->
       disposable.dispose()
       expect(atom.menu.template.length).toBe originalItemCount
 
-    it "can submenu items to existing menus that can be removed with the returned disposable", ->
+    it "can add submenu items to existing menus that can be removed with the returned disposable", ->
       originalItemCount = atom.menu.template.length
       disposable1 = atom.menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
       disposable2 = atom.menu.add [{label: "A", submenu: [{label: "C", submenu: [{label: "D", command: 'd'}]}]}]

--- a/spec/menu-manager-spec.coffee
+++ b/spec/menu-manager-spec.coffee
@@ -1,0 +1,37 @@
+describe "MenuManager", ->
+  describe "::add(items)", ->
+    it "can add new menus that can be removed with the returned disposable", ->
+      originalItemCount = atom.menu.template.length
+      disposable = atom.menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
+      expect(atom.menu.template[originalItemCount]).toEqual {label: "A", submenu: [{label: "B", command: "b"}]}
+      disposable.dispose()
+      expect(atom.menu.template.length).toBe originalItemCount
+
+    it "can submenu items to existing menus that can be removed with the returned disposable", ->
+      originalItemCount = atom.menu.template.length
+      disposable1 = atom.menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
+      disposable2 = atom.menu.add [{label: "A", submenu: [{label: "C", submenu: [{label: "D", command: 'd'}]}]}]
+      disposable3 = atom.menu.add [{label: "A", submenu: [{label: "C", submenu: [{label: "E", command: 'e'}]}]}]
+
+      expect(atom.menu.template[originalItemCount]).toEqual {
+        label: "A",
+        submenu: [
+          {label: "B", command: "b"},
+          {label: "C", submenu: [{label: 'D', command: 'd'}, {label: 'E', command: 'e'}]}
+        ]
+      }
+
+      disposable3.dispose()
+      expect(atom.menu.template[originalItemCount]).toEqual {
+        label: "A",
+        submenu: [
+          {label: "B", command: "b"},
+          {label: "C", submenu: [{label: 'D', command: 'd'}]}
+        ]
+      }
+
+      disposable2.dispose()
+      expect(atom.menu.template[originalItemCount]).toEqual {label: "A", submenu: [{label: "B", command: "b"}]}
+
+      disposable1.dispose()
+      expect(atom.menu.template.length).toBe originalItemCount

--- a/spec/menu-manager-spec.coffee
+++ b/spec/menu-manager-spec.coffee
@@ -1,43 +1,48 @@
+MenuManager = require '../src/menu-manager'
+
 describe "MenuManager", ->
+  menu = null
+
+  beforeEach ->
+    menu = new MenuManager(resourcePath: atom.getLoadSettings().resourcePath)
+
   describe "::add(items)", ->
     it "can add new menus that can be removed with the returned disposable", ->
-      originalItemCount = atom.menu.template.length
-      disposable = atom.menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
-      expect(atom.menu.template[originalItemCount]).toEqual {label: "A", submenu: [{label: "B", command: "b"}]}
+      disposable = menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
+      expect(menu.template).toEqual [{label: "A", submenu: [{label: "B", command: "b"}]}]
       disposable.dispose()
-      expect(atom.menu.template.length).toBe originalItemCount
+      expect(menu.template).toEqual []
 
     it "can add submenu items to existing menus that can be removed with the returned disposable", ->
-      originalItemCount = atom.menu.template.length
-      disposable1 = atom.menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
-      disposable2 = atom.menu.add [{label: "A", submenu: [{label: "C", submenu: [{label: "D", command: 'd'}]}]}]
-      disposable3 = atom.menu.add [{label: "A", submenu: [{label: "C", submenu: [{label: "E", command: 'e'}]}]}]
+      disposable1 = menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
+      disposable2 = menu.add [{label: "A", submenu: [{label: "C", submenu: [{label: "D", command: 'd'}]}]}]
+      disposable3 = menu.add [{label: "A", submenu: [{label: "C", submenu: [{label: "E", command: 'e'}]}]}]
 
-      expect(atom.menu.template[originalItemCount]).toEqual {
+      expect(menu.template).toEqual [{
         label: "A",
         submenu: [
           {label: "B", command: "b"},
           {label: "C", submenu: [{label: 'D', command: 'd'}, {label: 'E', command: 'e'}]}
         ]
-      }
+      }]
 
       disposable3.dispose()
-      expect(atom.menu.template[originalItemCount]).toEqual {
+      expect(menu.template).toEqual [{
         label: "A",
         submenu: [
           {label: "B", command: "b"},
           {label: "C", submenu: [{label: 'D', command: 'd'}]}
         ]
-      }
+      }]
 
       disposable2.dispose()
-      expect(atom.menu.template[originalItemCount]).toEqual {label: "A", submenu: [{label: "B", command: "b"}]}
+      expect(menu.template).toEqual [{label: "A", submenu: [{label: "B", command: "b"}]}]
 
       disposable1.dispose()
-      expect(atom.menu.template.length).toBe originalItemCount
+      expect(menu.template).toEqual []
 
     it "does not add duplicate labels to the same menu", ->
-      originalItemCount = atom.menu.template.length
-      atom.menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
-      atom.menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
-      expect(atom.menu.template[originalItemCount]).toEqual {label: "A", submenu: [{label: "B", command: "b"}]}
+      originalItemCount = menu.template.length
+      menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
+      menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
+      expect(menu.template[originalItemCount]).toEqual {label: "A", submenu: [{label: "B", command: "b"}]}

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -106,8 +106,9 @@ class MenuManager
     item = _.deepClone(item)
     matchingItem = @findMatchingItem(menu, item)
 
-    if matchingItem? and item.submenu?
-      @merge(matchingItem.submenu, submenuItem) for submenuItem in item.submenu
+    if matchingItem?
+      if item.submenu?
+        @merge(matchingItem.submenu, submenuItem) for submenuItem in item.submenu
     else
       menu.push(item)
 

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -35,6 +35,9 @@ class MenuManager
   #   * `submenu` An optional {Array} of sub menu items.
   #   * `command` An optional {String} command to trigger when the item is
   #     clicked.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to remove the
+  # added menu items.
   add: (items) ->
     @merge(@template, item) for item in items
     @update()


### PR DESCRIPTION
This is part of the initiative to return disposables in any place we add something we may later want to remove. I'll be opening PRs for each specific subsystem to keep things small.
