### PR TITLE
Clean up context menu API

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -196,18 +196,19 @@
 ]
 
 'context-menu':
-  '.overlayer':
-    'Undo': 'core:undo'
-    'Redo': 'core:redo'
-    'separator1': '-'
-    'Cut': 'core:cut'
-    'Copy': 'core:copy'
-    'Paste': 'core:paste'
-    'Delete': 'core:delete'
-    'Select All': 'core:select-all'
-    'separator2': '-'
-    'Split Up': 'pane:split-up'
-    'Split Down': 'pane:split-down'
-    'Split Left': 'pane:split-left'
-    'Split Right': 'pane:split-right'
-    'separator3': '-'
+  '.editor': [
+    {label: 'Undo', command: 'core:undo'}
+    {label: 'Redo', command: 'core:redo'}
+    {type: 'separator'}
+    {label: 'Cut', command: 'core:cut'}
+    {label: 'Copy', command: 'core:copy'}
+    {label: 'Paste', command: 'core:paste'}
+    {label: 'Delete', command: 'core:delete'}
+    {label: 'Select All', command: 'core:select-all'}
+    {type: 'separator'}
+    {label: 'Split Up', command: 'pane:split-up'}
+    {label: 'Split Down', command: 'pane:split-down'}
+    {label: 'Split Left', command: 'pane:split-left'}
+    {label: 'Split Right', command: 'pane:split-right'}
+    {type: 'separator'}
+  ]

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -196,7 +196,7 @@
 ]
 
 'context-menu':
-  '.editor': [
+  '.overlayer': [
     {label: 'Undo', command: 'core:undo'}
     {label: 'Redo', command: 'core:redo'}
     {type: 'separator'}

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -212,3 +212,11 @@
     {label: 'Split Right', command: 'pane:split-right'}
     {type: 'separator'}
   ]
+  '.pane': [
+    {type: 'separator'}
+    {label: 'Split Up', command: 'pane:split-up'}
+    {label: 'Split Down', command: 'pane:split-down'}
+    {label: 'Split Left', command: 'pane:split-left'}
+    {label: 'Split Right', command: 'pane:split-right'}
+    {type: 'separator'}
+  ]

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -153,18 +153,19 @@
 ]
 
 'context-menu':
-  '.overlayer':
-    'Undo': 'core:undo'
-    'Redo': 'core:redo'
-    'separator1': '-'
-    'Cut': 'core:cut'
-    'Copy': 'core:copy'
-    'Paste': 'core:paste'
-    'Delete': 'core:delete'
-    'Select All': 'core:select-all'
-    'separator2': '-'
-    'Split Up': 'pane:split-up'
-    'Split Down': 'pane:split-down'
-    'Split Left': 'pane:split-left'
-    'Split Right': 'pane:split-right'
-    'separator3': '-'
+  '.editor': [
+    {label: 'Undo', command: 'core:undo'}
+    {label: 'Redo', command: 'core:redo'}
+    {type: 'separator'}
+    {label: 'Cut', command: 'core:cut'}
+    {label: 'Copy', command: 'core:copy'}
+    {label: 'Paste', command: 'core:paste'}
+    {label: 'Delete', command: 'core:delete'}
+    {label: 'Select All', command: 'core:select-all'}
+    {type: 'separator'}
+    {label: 'Split Up', command: 'pane:split-up'}
+    {label: 'Split Down', command: 'pane:split-down'}
+    {label: 'Split Left', command: 'pane:split-left'}
+    {label: 'Split Right', command: 'pane:split-right'}
+    {type: 'separator'}
+  ]

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -153,7 +153,7 @@
 ]
 
 'context-menu':
-  '.editor': [
+  '.overlayer': [
     {label: 'Undo', command: 'core:undo'}
     {label: 'Redo', command: 'core:redo'}
     {type: 'separator'}

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -169,3 +169,11 @@
     {label: 'Split Right', command: 'pane:split-right'}
     {type: 'separator'}
   ]
+  '.pane': [
+    {type: 'separator'}
+    {label: 'Split Up', command: 'pane:split-up'}
+    {label: 'Split Down', command: 'pane:split-down'}
+    {label: 'Split Left', command: 'pane:split-left'}
+    {label: 'Split Right', command: 'pane:split-right'}
+    {type: 'separator'}
+  ]

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -171,18 +171,19 @@
 ]
 
 'context-menu':
-  '.overlayer':
-    'Undo': 'core:undo'
-    'Redo': 'core:redo'
-    'separator1': '-'
-    'Cut': 'core:cut'
-    'Copy': 'core:copy'
-    'Paste': 'core:paste'
-    'Delete': 'core:delete'
-    'Select All': 'core:select-all'
-    'separator2': '-'
-    'Split Up': 'pane:split-up'
-    'Split Down': 'pane:split-down'
-    'Split Left': 'pane:split-left'
-    'Split Right': 'pane:split-right'
-    'separator3': '-'
+  '.editor': [
+    {label: 'Undo', command: 'core:undo'}
+    {label: 'Redo', command: 'core:redo'}
+    {type: 'separator'}
+    {label: 'Cut', command: 'core:cut'}
+    {label: 'Copy', command: 'core:copy'}
+    {label: 'Paste', command: 'core:paste'}
+    {label: 'Delete', command: 'core:delete'}
+    {label: 'Select All', command: 'core:select-all'}
+    {type: 'separator'}
+    {label: 'Split Up', command: 'pane:split-up'}
+    {label: 'Split Down', command: 'pane:split-down'}
+    {label: 'Split Left', command: 'pane:split-left'}
+    {label: 'Split Right', command: 'pane:split-right'}
+    {type: 'separator'}
+  ]

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -171,7 +171,7 @@
 ]
 
 'context-menu':
-  '.editor': [
+  '.overlayer': [
     {label: 'Undo', command: 'core:undo'}
     {label: 'Redo', command: 'core:redo'}
     {type: 'separator'}

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -187,3 +187,11 @@
     {label: 'Split Right', command: 'pane:split-right'}
     {type: 'separator'}
   ]
+  '.pane': [
+    {type: 'separator'}
+    {label: 'Split Up', command: 'pane:split-up'}
+    {label: 'Split Down', command: 'pane:split-down'}
+    {label: 'Split Left', command: 'pane:split-left'}
+    {label: 'Split Right', command: 'pane:split-right'}
+    {type: 'separator'}
+  ]

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -82,12 +82,14 @@ describe "ContextMenuManager", ->
       disposable1.dispose()
       expect(contextMenu.templateForElement(grandchild)).toEqual [{label: 'A', command: 'd'}]
 
-    it "allows multiple separators", ->
+    it "allows multiple separators, but not adjacent to each other", ->
       contextMenu.add
         '.grandchild': [
           {label: 'A', command: 'a'},
           {type: 'separator'},
+          {type: 'separator'},
           {label: 'B', command: 'b'},
+          {type: 'separator'},
           {type: 'separator'},
           {label: 'C', command: 'c'}
         ]

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -122,17 +122,24 @@ describe "ContextMenuManager", ->
       expect(item.command).toBe 'a' # doesn't modify original item template
       expect(createdEvent).toBe dispatchedEvent
 
-  describe "executeBuildHandlers", ->
-    menuTemplate = [
-        label: 'label'
-        executeAtBuild: ->
-      ]
-    event =
-      target: null
+    it "allows items to be associated with `shouldDisplay` hooks which are invoked on construction to determine whether the item should be included", ->
+      shouldDisplayEvent = null
+      shouldDisplay = true
 
-    it 'should invoke the executeAtBuild fn', ->
-      buildFn = spyOn(menuTemplate[0], 'executeAtBuild')
-      contextMenu.executeBuildHandlers(event, menuTemplate)
+      item = {
+        label: 'A',
+        command: 'a',
+        shouldDisplay: (event) ->
+          @foo = 'bar'
+          shouldDisplayEvent = event
+          shouldDisplay
+      }
+      contextMenu.add('.grandchild': [item])
 
-      expect(buildFn).toHaveBeenCalled()
-      expect(buildFn.mostRecentCall.args[0]).toBe event
+      dispatchedEvent = {target: grandchild}
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual [{label: 'A', command: 'a'}]
+      expect(item.foo).toBeUndefined() # doesn't modify original item template
+      expect(shouldDisplayEvent).toBe dispatchedEvent
+
+      shouldDisplay = false
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual []

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -104,6 +104,24 @@ describe "ContextMenuManager", ->
       contextMenu.devMode = true
       expect(contextMenu.templateForElement(grandchild)).toEqual [{label: 'A', command: 'a'}, {label: 'B', command: 'b'}]
 
+    it "allows items to be associated with `created` hooks which are invoked on template construction with the item and event", ->
+      createdEvent = null
+
+      item = {
+        label: 'A',
+        command: 'a',
+        created: (event) ->
+          @command = 'b'
+          createdEvent = event
+      }
+
+      contextMenu.add('.grandchild': [item])
+
+      dispatchedEvent = {target: grandchild}
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual [{label: 'A', command: 'b'}]
+      expect(item.command).toBe 'a' # doesn't modify original item template
+      expect(createdEvent).toBe dispatchedEvent
+
   describe "executeBuildHandlers", ->
     menuTemplate = [
         label: 'label'

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -3,161 +3,97 @@
 ContextMenuManager = require '../src/context-menu-manager'
 
 describe "ContextMenuManager", ->
-  [contextMenu] = []
+  [contextMenu, parent, child, grandchild] = []
 
   beforeEach ->
     {resourcePath} = atom.getLoadSettings()
     contextMenu = new ContextMenuManager({resourcePath})
 
-  describe "adding definitions", ->
-    it 'loads',  ->
-      contextMenu.add 'file-path',
-        '.selector':
-          'label': 'command'
+    parent = document.createElement("div")
+    child = document.createElement("div")
+    grandchild = document.createElement("div")
+    parent.classList.add('parent')
+    child.classList.add('child')
+    grandchild.classList.add('grandchild')
+    child.appendChild(grandchild)
+    parent.appendChild(child)
 
-      expect(contextMenu.definitions['.selector'][0].label).toEqual 'label'
-      expect(contextMenu.definitions['.selector'][0].command).toEqual 'command'
+  describe "::add(itemsBySelector)", ->
+    it "can add top-level menu items that can be removed with the returned disposable", ->
+      disposable = contextMenu.add
+        '.parent': [{label: 'A', command: 'a'}]
+        '.child': [{label: 'B', command: 'b'}]
+        '.grandchild': [{label: 'C', command: 'c'}]
 
-    it 'does not add duplicate menu items',  ->
-      contextMenu.add 'file-path',
-        '.selector':
-          'label': 'command'
+      expect(contextMenu.templateForElement(grandchild)).toEqual [
+        {label: 'C', command: 'c'}
+        {label: 'B', command: 'b'}
+        {label: 'A', command: 'a'}
+      ]
 
-      contextMenu.add 'file-path',
-        '.selector':
-          'label': 'command'
+      disposable.dispose()
+      expect(contextMenu.templateForElement(grandchild)).toEqual []
 
-      expect(contextMenu.definitions['.selector'][0].label).toEqual 'label'
-      expect(contextMenu.definitions['.selector'][0].command).toEqual 'command'
-      expect(contextMenu.definitions['.selector'].length).toBe 1
+    it "can add submenu items to existing menus that can be removed with the returned disposable", ->
+      disposable1 = contextMenu.add
+        '.grandchild': [{label: 'A', submenu: [{label: 'B', command: 'b'}]}]
+      disposable2 = contextMenu.add
+        '.grandchild': [{label: 'A', submenu: [{label: 'C', command: 'c'}]}]
 
-    it 'allows multiple separators', ->
-      contextMenu.add 'file-path',
-        '.selector':
-          'separator1': '-'
-          'separator2': '-'
-
-      expect(contextMenu.definitions['.selector'].length).toBe 2
-      expect(contextMenu.definitions['.selector'][0].type).toEqual 'separator'
-      expect(contextMenu.definitions['.selector'][1].type).toEqual 'separator'
-
-    it 'allows duplicate commands with different labels',  ->
-      contextMenu.add 'file-path',
-        '.selector':
-          'label': 'command'
-
-      contextMenu.add 'file-path',
-        '.selector':
-          'another label': 'command'
-
-      expect(contextMenu.definitions['.selector'][0].label).toEqual 'label'
-      expect(contextMenu.definitions['.selector'][0].command).toEqual 'command'
-      expect(contextMenu.definitions['.selector'][1].label).toEqual 'another label'
-      expect(contextMenu.definitions['.selector'][1].command).toEqual 'command'
-
-    it "loads submenus", ->
-      contextMenu.add 'file-path',
-        '.selector':
-          'parent':
-            'child-1': 'child-1:trigger'
-            'child-2': 'child-2:trigger'
-          'parent-2': 'parent-2:trigger'
-
-      expect(contextMenu.definitions['.selector'].length).toBe 2
-      expect(contextMenu.definitions['.selector'][0].label).toEqual 'parent'
-      expect(contextMenu.definitions['.selector'][0].submenu.length).toBe 2
-      expect(contextMenu.definitions['.selector'][0].submenu[0].label).toBe 'child-1'
-      expect(contextMenu.definitions['.selector'][0].submenu[0].command).toBe 'child-1:trigger'
-      expect(contextMenu.definitions['.selector'][0].submenu[1].label).toBe 'child-2'
-      expect(contextMenu.definitions['.selector'][0].submenu[1].command).toBe 'child-2:trigger'
-
-    describe 'dev mode', ->
-      it 'loads',  ->
-        contextMenu.add 'file-path',
-          '.selector':
-            'label': 'command'
-        , devMode: true
-
-        expect(contextMenu.devModeDefinitions['.selector'][0].label).toEqual 'label'
-        expect(contextMenu.devModeDefinitions['.selector'][0].command).toEqual 'command'
-
-  describe "building a menu template", ->
-    beforeEach ->
-      contextMenu.definitions = {
-        '.parent':[
-          label: 'parent'
-          command: 'command-p'
-         ]
-        '.child': [
-          label: 'child'
-          command: 'command-c'
+      expect(contextMenu.templateForElement(grandchild)).toEqual [{
+        label: 'A',
+        submenu: [
+          {label: 'C', command: 'c'}
+          {label: 'B', command: 'b'}
         ]
-      }
+      }]
 
-      contextMenu.devModeDefinitions =
-        '.parent': [
-          label: 'dev-label'
-          command: 'dev-command'
+      disposable2.dispose()
+      expect(contextMenu.templateForElement(grandchild)).toEqual [{
+        label: 'A',
+        submenu: [
+          {label: 'B', command: 'b'}
+        ]
+      }]
+
+      disposable1.dispose()
+      expect(contextMenu.templateForElement(grandchild)).toEqual []
+
+    it "favors the most specific / recently added item in the case of a duplicate label", ->
+      grandchild.classList.add('foo')
+
+      disposable1 = contextMenu.add
+        '.grandchild': [{label: 'A', command: 'a'}]
+      disposable2 = contextMenu.add
+        '.grandchild.foo': [{label: 'A', command: 'b'}]
+      disposable3 = contextMenu.add
+        '.grandchild': [{label: 'A', command: 'c'}]
+
+      expect(contextMenu.templateForElement(grandchild)).toEqual [{label: 'A', command: 'b'}]
+
+      disposable2.dispose()
+      expect(contextMenu.templateForElement(grandchild)).toEqual [{label: 'A', command: 'c'}]
+
+      disposable3.dispose()
+      expect(contextMenu.templateForElement(grandchild)).toEqual [{label: 'A', command: 'a'}]
+
+    it "allows multiple separators", ->
+      contextMenu.add
+        '.grandchild': [
+          {label: 'A', command: 'a'},
+          {type: 'separator'},
+          {label: 'B', command: 'b'},
+          {type: 'separator'},
+          {label: 'C', command: 'c'}
         ]
 
-    describe "on a single element", ->
-      [element] = []
-
-      beforeEach ->
-        element = ($$ -> @div class: 'parent')[0]
-
-      it "creates a menu with a single item", ->
-        menu = contextMenu.combinedMenuTemplateForElement(element)
-
-        expect(menu[0].label).toEqual 'parent'
-        expect(menu[0].command).toEqual 'command-p'
-        expect(menu[1]).toBeUndefined()
-
-      describe "in devMode", ->
-        beforeEach -> contextMenu.devMode = true
-
-        it "creates a menu with development items", ->
-          menu = contextMenu.combinedMenuTemplateForElement(element)
-
-          expect(menu[0].label).toEqual 'parent'
-          expect(menu[0].command).toEqual 'command-p'
-          expect(menu[1].type).toEqual 'separator'
-          expect(menu[2].label).toEqual 'dev-label'
-          expect(menu[2].command).toEqual 'dev-command'
-
-
-    describe "on multiple elements", ->
-      [element] = []
-
-      beforeEach ->
-        element = $$ ->
-          @div class: 'parent', =>
-            @div class: 'child'
-
-        element = element.find('.child')[0]
-
-      it "creates a menu with a two items", ->
-        menu = contextMenu.combinedMenuTemplateForElement(element)
-
-        expect(menu[0].label).toEqual 'child'
-        expect(menu[0].command).toEqual 'command-c'
-        expect(menu[1].label).toEqual 'parent'
-        expect(menu[1].command).toEqual 'command-p'
-        expect(menu[2]).toBeUndefined()
-
-      describe "in devMode", ->
-        beforeEach -> contextMenu.devMode = true
-
-        xit "creates a menu with development items", ->
-          menu = contextMenu.combinedMenuTemplateForElement(element)
-
-          expect(menu[0].label).toEqual 'child'
-          expect(menu[0].command).toEqual 'command-c'
-          expect(menu[1].label).toEqual 'parent'
-          expect(menu[1].command).toEqual 'command-p'
-          expect(menu[2].label).toEqual 'dev-label'
-          expect(menu[2].command).toEqual 'dev-command'
-          expect(menu[3]).toBeUndefined()
+      expect(contextMenu.templateForElement(grandchild)).toEqual [
+        {label: 'A', command: 'a'},
+        {type: 'separator'},
+        {label: 'B', command: 'b'},
+        {type: 'separator'},
+        {label: 'C', command: 'c'}
+      ]
 
   describe "executeBuildHandlers", ->
     menuTemplate = [

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -68,6 +68,8 @@ describe "ContextMenuManager", ->
         '.grandchild.foo': [{label: 'A', command: 'b'}]
       disposable3 = contextMenu.add
         '.grandchild': [{label: 'A', command: 'c'}]
+      disposable4 = contextMenu.add
+        '.child': [{label: 'A', command: 'd'}]
 
       expect(contextMenu.templateForElement(grandchild)).toEqual [{label: 'A', command: 'b'}]
 
@@ -76,6 +78,9 @@ describe "ContextMenuManager", ->
 
       disposable3.dispose()
       expect(contextMenu.templateForElement(grandchild)).toEqual [{label: 'A', command: 'a'}]
+
+      disposable1.dispose()
+      expect(contextMenu.templateForElement(grandchild)).toEqual [{label: 'A', command: 'd'}]
 
     it "allows multiple separators", ->
       contextMenu.add

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -43,8 +43,8 @@ describe "ContextMenuManager", ->
       expect(contextMenu.templateForElement(grandchild)).toEqual [{
         label: 'A',
         submenu: [
-          {label: 'C', command: 'c'}
           {label: 'B', command: 'b'}
+          {label: 'C', command: 'c'}
         ]
       }]
 

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -95,6 +95,15 @@ describe "ContextMenuManager", ->
         {label: 'C', command: 'c'}
       ]
 
+    it "excludes items marked for display in devMode unless in dev mode", ->
+      disposable1 = contextMenu.add
+        '.grandchild': [{label: 'A', command: 'a', devMode: true}, {label: 'B', command: 'b', devMode: false}]
+
+      expect(contextMenu.templateForElement(grandchild)).toEqual [{label: 'B', command: 'b'}]
+
+      contextMenu.devMode = true
+      expect(contextMenu.templateForElement(grandchild)).toEqual [{label: 'A', command: 'a'}, {label: 'B', command: 'b'}]
+
   describe "executeBuildHandlers", ->
     menuTemplate = [
         label: 'label'

--- a/spec/fixtures/packages/package-with-menus/menus/menu-1.cson
+++ b/spec/fixtures/packages/package-with-menus/menus/menu-1.cson
@@ -1,7 +1,8 @@
 'menu': [
-  { 'label': 'Second to Last' }
+  {'label': 'Second to Last'}
 ]
 
 'context-menu':
-  '.test-1':
-    'Menu item 1': 'command-1'
+  '.test-1': [
+    {label: 'Menu item 1', command: 'command-1'}
+  ]

--- a/spec/fixtures/packages/package-with-menus/menus/menu-2.cson
+++ b/spec/fixtures/packages/package-with-menus/menus/menu-2.cson
@@ -3,5 +3,6 @@
 ]
 
 'context-menu':
-  '.test-1':
-    'Menu item 2': 'command-2'
+  '.test-1': [
+    {label: 'Menu item 2', command: 'command-2'}
+  ]

--- a/spec/fixtures/packages/package-with-menus/menus/menu-3.cson
+++ b/spec/fixtures/packages/package-with-menus/menus/menu-3.cson
@@ -3,5 +3,6 @@
 ]
 
 'context-menu':
-  '.test-1':
-    'Menu item 3': 'command-3'
+  '.test-1': [
+    {label: 'Menu item 3', command: 'command-3'}
+  ]

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -230,30 +230,30 @@ describe "PackageManager", ->
           it "loads all the .cson/.json files in the menus directory", ->
             element = ($$ -> @div class: 'test-1')[0]
 
-            expect(atom.contextMenu.definitionsForElement(element)).toEqual []
+            expect(atom.contextMenu.templateForElement(element)).toEqual []
 
             atom.packages.activatePackage("package-with-menus")
 
             expect(atom.menu.template.length).toBe 2
             expect(atom.menu.template[0].label).toBe "Second to Last"
             expect(atom.menu.template[1].label).toBe "Last"
-            expect(atom.contextMenu.definitionsForElement(element)[0].label).toBe "Menu item 1"
-            expect(atom.contextMenu.definitionsForElement(element)[1].label).toBe "Menu item 2"
-            expect(atom.contextMenu.definitionsForElement(element)[2].label).toBe "Menu item 3"
+            expect(atom.contextMenu.templateForElement(element)[0].label).toBe "Menu item 3"
+            expect(atom.contextMenu.templateForElement(element)[1].label).toBe "Menu item 2"
+            expect(atom.contextMenu.templateForElement(element)[2].label).toBe "Menu item 1"
 
         describe "when the metadata contains a 'menus' manifest", ->
           it "loads only the menus specified by the manifest, in the specified order", ->
             element = ($$ -> @div class: 'test-1')[0]
 
-            expect(atom.contextMenu.definitionsForElement(element)).toEqual []
+            expect(atom.contextMenu.templateForElement(element)).toEqual []
 
             atom.packages.activatePackage("package-with-menus-manifest")
 
             expect(atom.menu.template[0].label).toBe "Second to Last"
             expect(atom.menu.template[1].label).toBe "Last"
-            expect(atom.contextMenu.definitionsForElement(element)[0].label).toBe "Menu item 2"
-            expect(atom.contextMenu.definitionsForElement(element)[1].label).toBe "Menu item 1"
-            expect(atom.contextMenu.definitionsForElement(element)[2]).toBeUndefined()
+            expect(atom.contextMenu.templateForElement(element)[0].label).toBe "Menu item 1"
+            expect(atom.contextMenu.templateForElement(element)[1].label).toBe "Menu item 2"
+            expect(atom.contextMenu.templateForElement(element)[2]).toBeUndefined()
 
       describe "stylesheet loading", ->
         describe "when the metadata contains a 'stylesheets' manifest", ->

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -237,9 +237,9 @@ describe "PackageManager", ->
             expect(atom.menu.template.length).toBe 2
             expect(atom.menu.template[0].label).toBe "Second to Last"
             expect(atom.menu.template[1].label).toBe "Last"
-            expect(atom.contextMenu.templateForElement(element)[0].label).toBe "Menu item 3"
+            expect(atom.contextMenu.templateForElement(element)[0].label).toBe "Menu item 1"
             expect(atom.contextMenu.templateForElement(element)[1].label).toBe "Menu item 2"
-            expect(atom.contextMenu.templateForElement(element)[2].label).toBe "Menu item 1"
+            expect(atom.contextMenu.templateForElement(element)[2].label).toBe "Menu item 3"
 
         describe "when the metadata contains a 'menus' manifest", ->
           it "loads only the menus specified by the manifest, in the specified order", ->
@@ -251,8 +251,8 @@ describe "PackageManager", ->
 
             expect(atom.menu.template[0].label).toBe "Second to Last"
             expect(atom.menu.template[1].label).toBe "Last"
-            expect(atom.contextMenu.templateForElement(element)[0].label).toBe "Menu item 1"
-            expect(atom.contextMenu.templateForElement(element)[1].label).toBe "Menu item 2"
+            expect(atom.contextMenu.templateForElement(element)[0].label).toBe "Menu item 2"
+            expect(atom.contextMenu.templateForElement(element)[1].label).toBe "Menu item 1"
             expect(atom.contextMenu.templateForElement(element)[2]).toBeUndefined()
 
       describe "stylesheet loading", ->

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -125,6 +125,7 @@ beforeEach ->
 afterEach ->
   atom.packages.deactivatePackages()
   atom.menu.template = []
+  atom.contextMenu.clear()
 
   atom.workspaceView?.remove?()
   atom.workspaceView = null

--- a/src/browser/context-menu.coffee
+++ b/src/browser/context-menu.coffee
@@ -13,12 +13,12 @@ class ContextMenu
   createClickHandlers: (template) ->
     for item in template
       if item.command
-        item.commandOptions ?= {}
-        item.commandOptions.contextCommand = true
-        item.commandOptions.atomWindow = @atomWindow
+        item.commandDetail ?= {}
+        item.commandDetail.contextCommand = true
+        item.commandDetail.atomWindow = @atomWindow
         do (item) =>
           item.click = =>
-            global.atomApplication.sendCommandToWindow(item.command, @atomWindow, item.commandOptions)
+            global.atomApplication.sendCommandToWindow(item.command, @atomWindow, item.commandDetail)
       else if item.submenu
         @createClickHandlers(item.submenu)
       item

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -27,6 +27,7 @@ class ContextMenuManager
     @add '.workspace': [{
       label: 'Inspect Element'
       command: 'application:inspect'
+      devMode: true
       created: (event) ->
         {pageX, pageY} = event
         @commandOptions = {x: pageX, y: pageY}

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -97,7 +97,9 @@ class ContextMenuManager
 
     new Disposable =>
       for itemSet in addedItemSets
+        console.log "removing", itemSet, @itemSets.indexOf(itemSet)
         @itemSets.splice(@itemSets.indexOf(itemSet), 1)
+        console.log "remaining", @itemSets.slice()
 
   templateForElement: (target) ->
     @templateForEvent({target})
@@ -119,8 +121,7 @@ class ContextMenuManager
           if typeof item.shouldDisplay is 'function'
             continue unless item.shouldDisplay(event)
           item.created?(event)
-          templateItem = _.pick(item, 'type', 'label', 'command', 'submenu', 'commandOptions')
-          MenuHelpers.merge(template, templateItem)
+          MenuHelpers.merge(template, MenuHelpers.cloneMenuItem(item))
 
       currentTarget = currentTarget.parentElement
 
@@ -170,6 +171,7 @@ class ContextMenuItemSet
     @specificity = (SpecificityCache[@selector] ?= specificity(@selector))
     @sequenceNumber = SequenceCount++
 
+  # more specific / recent item sets sort later, because we clobber existing menu items
   compare: (other) ->
-    other.specificity - @specificity  or
-      other.sequenceNumber - @sequenceNumber
+    @specificity - other.specificity or
+      @sequenceNumber - other.sequenceNumber

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -38,7 +38,7 @@ class ContextMenuManager
     menusDirPath = path.join(@resourcePath, 'menus')
     platformMenuPath = fs.resolve(menusDirPath, process.platform, ['cson', 'json'])
     map = CSON.readFileSync(platformMenuPath)
-    atom.contextMenu.add(platformMenuPath, map['context-menu'])
+    atom.contextMenu.add(map['context-menu'])
 
   # Public: Add context menu items scoped by CSS selectors.
   #

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -39,14 +39,50 @@ class ContextMenuManager
     map = CSON.readFileSync(platformMenuPath)
     atom.contextMenu.add(platformMenuPath, map['context-menu'])
 
-  # Public: Creates menu definitions from the object specified by the menu
-  # JSON API.
+  # Public: Add context menu items scoped by CSS selectors.
   #
-  # * `name` The path of the file that contains the menu definitions.
-  # * `object` The 'context-menu' object specified in the menu JSON API.
-  # * `options` An optional {Object} with the following keys:
-  #   * `devMode` Determines whether the entries should only be shown when
-  #     the window is in dev mode.
+  # ## Examples
+  #
+  # To add a context menu, pass a selector matching the elements to which you
+  # want the menu to apply as the top level key, followed by a menu descriptor.
+  # The invocation below adds a global 'Help' context menu item and a 'History'
+  # submenu on the editor supporting undo/redo. This is just for example
+  # purposes and not the way the menu is actually configured in Atom by default.
+  #
+  # ```coffee
+  # atom.contextMenu.add {
+  #   '.workspace': [{label: 'Help', command: 'application:open-documentation'}]
+  #   '.editor':    [{
+  #     label: 'History',
+  #     submenu: [
+  #       {label: 'Undo': command:'core:undo'}
+  #       {label: 'Redo': command:'core:redo'}
+  #     ]
+  #   }]
+  # }
+  # ```
+  #
+  # ## Arguments
+  #
+  # * `items` An {Object} whose keys are CSS selectors and whose values are
+  #   {Array}s of item {Object}s containing the following keys:
+  #   * `label` (Optional) A {String} containing the menu item's label.
+  #   * `command` (Optional) A {String} containing the command to invoke on the
+  #     target of the right click that invoked the context menu.
+  #   * `submenu` (Optional) An {Array} of additional items.
+  #   * `type` (Optional) If you want to create a separator, provide an item
+  #      with `type: 'separator'` and no other keys.
+  #   * `created` (Optional) A {Function} that is called on the item each time a
+  #     context menu is created via a right click. You can assign properties to
+  #    `this` to dynamically compute the command, label, etc. This method is
+  #    actually called on a clone of the original item template to prevent state
+  #    from leaking across context menu deployments. Called with the following
+  #    argument:
+  #     * `event` The click event that deployed the context menu.
+  #   * `shouldDisplay` (Optional) A {Function} that is called to determine
+  #     whether to display this item on a given context menu deployment. Called
+  #     with the following argument:
+  #     * `event` The click event that deployed the context menu.
   add: (items) ->
     unless typeof arguments[0] is 'object'
       legacyItems = arguments[1]

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -20,18 +20,8 @@ SequenceCount = 0
 module.exports =
 class ContextMenuManager
   constructor: ({@resourcePath, @devMode}) ->
-    @activeElement = null
-    @itemSets = []
     @definitions = {'.overlayer': []} # TODO: Remove once color picker package stops touching private data
-
-    @add '.workspace': [{
-      label: 'Inspect Element'
-      command: 'application:inspect'
-      devMode: true
-      created: (event) ->
-        {pageX, pageY} = event
-        @commandOptions = {x: pageX, y: pageY}
-    }]
+    @clear()
 
     atom.keymaps.onDidLoadBundledKeymaps => @loadPlatformItems()
 
@@ -162,6 +152,18 @@ class ContextMenuManager
     return unless menuTemplate?.length > 0
     remote.getCurrentWindow().emit('context-menu', menuTemplate)
     return
+
+  clear: ->
+    @activeElement = null
+    @itemSets = []
+    @add '.workspace': [{
+      label: 'Inspect Element'
+      command: 'application:inspect'
+      devMode: true
+      created: (event) ->
+        {pageX, pageY} = event
+        @commandOptions = {x: pageX, y: pageY}
+    }]
 
 class ContextMenuItemSet
   constructor: (@selector, @items) ->

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -82,7 +82,9 @@ class ContextMenuManager
       for {items} in matchingItemSets
         for item in items
           continue if item.devMode and not @devMode
-          item = _.clone(item)
+          item = Object.create(item)
+          if typeof item.shouldDisplay is 'function'
+            continue unless item.shouldDisplay(event)
           item.created?(event)
           templateItem = _.pick(item, 'type', 'label', 'command', 'submenu', 'commandOptions')
           MenuHelpers.merge(template, templateItem)

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -162,7 +162,7 @@ class ContextMenuManager
       devMode: true
       created: (event) ->
         {pageX, pageY} = event
-        @commandOptions = {x: pageX, y: pageY}
+        @commandDetail = {x: pageX, y: pageY}
     }]
 
 class ContextMenuItemSet

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -4,6 +4,12 @@ remote = require 'remote'
 path = require 'path'
 CSON = require 'season'
 fs = require 'fs-plus'
+{specificity} = require 'clear-cut'
+{Disposable} = require 'event-kit'
+MenuHelpers = require './menu-helpers'
+
+SpecificityCache = {}
+SequenceCount = 0
 
 # Extended: Provides a registry for commands that you'd like to appear in the
 # context menu.
@@ -13,16 +19,17 @@ fs = require 'fs-plus'
 module.exports =
 class ContextMenuManager
   constructor: ({@resourcePath, @devMode}) ->
-    @definitions = {}
-    @devModeDefinitions = {}
+    @definitions = {'.overlayer': []} # TODO: Remove once color picker package stops touching private data
     @activeElement = null
 
-    @devModeDefinitions['.workspace'] = [
-      label: 'Inspect Element'
-      command: 'application:inspect'
-      executeAtBuild: (e) ->
-        @commandOptions = x: e.pageX, y: e.pageY
-    ]
+    @itemSets = []
+
+    # @devModeDefinitions['.workspace'] = [
+    #   label: 'Inspect Element'
+    #   command: 'application:inspect'
+    #   executeAtBuild: (e) ->
+    #     @commandOptions = x: e.pageX, y: e.pageY
+    # ]
 
     atom.keymaps.onDidLoadBundledKeymaps => @loadPlatformItems()
 
@@ -41,91 +48,72 @@ class ContextMenuManager
   #   * `devMode` Determines whether the entries should only be shown when
   #     the window is in dev mode.
   add: (name, object, {devMode}={}) ->
-    for selector, items of object
-      for label, commandOrSubmenu of items
+    unless typeof arguments[0] is 'object'
+      return @add(@convertLegacyItems(object), {devMode})
+
+    itemsBySelector = _.deepClone(arguments[0])
+    devMode = arguments[1]?.devMode ? false
+    addedItemSets = []
+
+    for selector, items of itemsBySelector
+      itemSet = new ContextMenuItemSet(selector, items)
+      addedItemSets.push(itemSet)
+      @itemSets.push(itemSet)
+
+    new Disposable =>
+      for itemSet in addedItemSets
+        @itemSets.splice(@itemSets.indexOf(itemSet), 1)
+
+  templateForElement: (element) ->
+    template = []
+    currentTarget = element
+
+    while currentTarget?
+      matchingItemSets =
+        @itemSets
+          .filter (itemSet) -> currentTarget.webkitMatchesSelector(itemSet.selector)
+          .sort (a, b) -> a.compare(b)
+
+      for {items} in matchingItemSets
+        MenuHelpers.merge(template, item) for item in items
+
+      currentTarget = currentTarget.parentElement
+
+    template
+
+  convertLegacyItems: (legacyItems) ->
+    itemsBySelector = {}
+
+    for selector, commandsByLabel of legacyItems
+      itemsBySelector[selector] = items = []
+
+      for label, commandOrSubmenu of commandsByLabel
         if typeof commandOrSubmenu is 'object'
-          submenu = []
-          for submenuLabel, command of commandOrSubmenu
-            submenu.push(@buildMenuItem(submenuLabel, command))
-          @addBySelector(selector, {label: label, submenu: submenu}, {devMode})
+          items.push({label, submenu: @convertLegacyItems(commandOrSubmenu)})
+        else if commandOrSubmenu is '-'
+          items.push({type: 'separator'})
         else
-          menuItem = @buildMenuItem(label, commandOrSubmenu)
-          @addBySelector(selector, menuItem, {devMode})
+          items.push({label, command: commandOrSubmenu})
 
-    undefined
-
-  buildMenuItem: (label, command) ->
-    if command is '-'
-      {type: 'separator'}
-    else
-      {label, command}
-
-  # Registers a command to be displayed when the relevant item is right
-  # clicked.
-  #
-  # * `selector` The css selector for the active element which should include
-  #   the given command in its context menu.
-  # * `definition` The object containing keys which match the menu template API.
-  # * `options` An optional {Object} with the following keys:
-  #   * `devMode` Indicates whether this command should only appear while the
-  #     editor is in dev mode.
-  addBySelector: (selector, definition, {devMode}={}) ->
-    definitions = if devMode then @devModeDefinitions else @definitions
-    if not _.findWhere(definitions[selector], definition) or _.isEqual(definition, {type: 'separator'})
-      (definitions[selector] ?= []).push(definition)
-
-  # Returns definitions which match the element and devMode.
-  definitionsForElement: (element, {devMode}={}) ->
-    definitions = if devMode then @devModeDefinitions else @definitions
-    matchedDefinitions = []
-    for selector, items of definitions when element.webkitMatchesSelector(selector)
-      matchedDefinitions.push(_.clone(item)) for item in items
-
-    matchedDefinitions
-
-  # Used to generate the context menu for a specific element and it's
-  # parents.
-  #
-  # The menu items are sorted such that menu items that match closest to the
-  # active element are listed first. The further down the list you go, the higher
-  # up the ancestor hierarchy they match.
-  #
-  # * `element` The DOM element to generate the menu template for.
-  menuTemplateForMostSpecificElement: (element, {devMode}={}) ->
-    menuTemplate = @definitionsForElement(element, {devMode})
-    if element.parentElement
-      menuTemplate.concat(@menuTemplateForMostSpecificElement(element.parentElement, {devMode}))
-    else
-      menuTemplate
-
-  # Returns a menu template for both normal entries as well as
-  # development mode entries.
-  combinedMenuTemplateForElement: (element) ->
-    normalItems = @menuTemplateForMostSpecificElement(element)
-    devItems = if @devMode then @menuTemplateForMostSpecificElement(element, devMode: true) else []
-
-    menuTemplate = normalItems
-    menuTemplate.push({ type: 'separator' }) if normalItems.length > 0 and devItems.length > 0
-    menuTemplate.concat(devItems)
-
-  # Executes `executeAtBuild` if defined for each menu item with
-  # the provided event and then removes the `executeAtBuild` property from
-  # the menu item.
-  #
-  # This is useful for commands that need to provide data about the event
-  # to the command.
-  executeBuildHandlers: (event, menuTemplate) ->
-    for template in menuTemplate
-      template?.executeAtBuild?.call(template, event)
-      delete template.executeAtBuild
+    itemsBySelector
 
   # Public: Request a context menu to be displayed.
   #
   # * `event` A DOM event.
   showForEvent: (event) ->
     @activeElement = event.target
-    menuTemplate = @combinedMenuTemplateForElement(event.target)
+    menuTemplate = @templateForElement(@activeElement)
+
     return unless menuTemplate?.length > 0
-    @executeBuildHandlers(event, menuTemplate)
+    # @executeBuildHandlers(event, menuTemplate)
     remote.getCurrentWindow().emit('context-menu', menuTemplate)
-    undefined
+    return
+
+class ContextMenuItemSet
+  constructor: (@selector, @items) ->
+    @specificity = (SpecificityCache[@selector] ?= specificity(@selector))
+    @sequenceNumber = SequenceCount++
+
+  compare: (other) ->
+    other.specificity - @specificity  or
+      other.sequenceNumber - @sequenceNumber

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -27,9 +27,9 @@ class ContextMenuManager
     @add '.workspace': [{
       label: 'Inspect Element'
       command: 'application:inspect'
-      created: (item, event) ->
+      created: (event) ->
         {pageX, pageY} = event
-        item.commandOptions = {x: pageX, y: pageY}
+        @commandOptions = {x: pageX, y: pageY}
     }]
 
     atom.keymaps.onDidLoadBundledKeymaps => @loadPlatformItems()

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -65,8 +65,8 @@ class ContextMenuManager
   #
   # ## Arguments
   #
-  # * `items` An {Object} whose keys are CSS selectors and whose values are
-  #   {Array}s of item {Object}s containing the following keys:
+  # * `itemsBySelector` An {Object} whose keys are CSS selectors and whose
+  #   values are {Array}s of item {Object}s containing the following keys:
   #   * `label` (Optional) A {String} containing the menu item's label.
   #   * `command` (Optional) A {String} containing the command to invoke on the
   #     target of the right click that invoked the context menu.
@@ -84,15 +84,19 @@ class ContextMenuManager
   #     whether to display this item on a given context menu deployment. Called
   #     with the following argument:
   #     * `event` The click event that deployed the context menu.
-  add: (items) ->
-    unless typeof arguments[0] is 'object'
+  add: (itemsBySelector) ->
+    # Detect deprecated file path as first argument
+    unless typeof itemsBySelector is 'object'
       Grim.deprecate("ContextMenuManage::add has changed to take a single object as its argument. Please consult the documentation.")
-      legacyItems = arguments[1]
+      itemsBySelector = arguments[1]
       devMode = arguments[2]?.devMode
-      return @add(@convertLegacyItems(legacyItems, devMode))
 
-    itemsBySelector = arguments[0]
-    devMode = arguments[1]?.devMode ? false
+    # Detect deprecated format for items object
+    for key, value of itemsBySelector
+      unless _.isArray(value)
+        Grim.deprecate("The format for declaring context menu items has changed. Please consult the documentation.")
+        itemsBySelector = @convertLegacyItems(itemsBySelector, devMode)
+
     addedItemSets = []
 
     for selector, items of itemsBySelector

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -160,7 +160,6 @@ class ContextMenuManager
     menuTemplate = @templateForEvent(event)
 
     return unless menuTemplate?.length > 0
-    # @executeBuildHandlers(event, menuTemplate)
     remote.getCurrentWindow().emit('context-menu', menuTemplate)
     return
 

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -6,6 +6,7 @@ CSON = require 'season'
 fs = require 'fs-plus'
 {specificity} = require 'clear-cut'
 {Disposable} = require 'event-kit'
+Grim = require 'grim'
 MenuHelpers = require './menu-helpers'
 
 SpecificityCache = {}
@@ -85,6 +86,7 @@ class ContextMenuManager
   #     * `event` The click event that deployed the context menu.
   add: (items) ->
     unless typeof arguments[0] is 'object'
+      Grim.deprecate("ContextMenuManage::add has changed to take a single object as its argument. Please consult the documentation.")
       legacyItems = arguments[1]
       devMode = arguments[2]?.devMode
       return @add(@convertLegacyItems(legacyItems, devMode))

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -97,9 +97,7 @@ class ContextMenuManager
 
     new Disposable =>
       for itemSet in addedItemSets
-        console.log "removing", itemSet, @itemSets.indexOf(itemSet)
         @itemSets.splice(@itemSets.indexOf(itemSet), 1)
-        console.log "remaining", @itemSets.slice()
 
   templateForElement: (target) ->
     @templateForEvent({target})

--- a/src/menu-helpers.coffee
+++ b/src/menu-helpers.coffee
@@ -44,7 +44,7 @@ normalizeLabel = (label) ->
 
 
 cloneMenuItem = (item) ->
-  item = _.pick(item, 'type', 'label', 'command', 'submenu', 'commandOptions')
+  item = _.pick(item, 'type', 'label', 'command', 'submenu', 'commandDetail')
   if item.submenu?
     item.submenu = item.submenu.map (submenuItem) -> cloneMenuItem(submenuItem)
   item

--- a/src/menu-helpers.coffee
+++ b/src/menu-helpers.coffee
@@ -1,14 +1,18 @@
 _ = require 'underscore-plus'
 
-merge = (menu, item) ->
+ItemSpecificities = new WeakMap
+
+merge = (menu, item, itemSpecificity=Infinity) ->
+  ItemSpecificities.set(item, itemSpecificity) if itemSpecificity
   matchingItemIndex = findMatchingItemIndex(menu, item)
   matchingItem = menu[matchingItemIndex] unless matchingItemIndex is - 1
 
   if matchingItem?
     if item.submenu?
-      merge(matchingItem.submenu, submenuItem) for submenuItem in item.submenu
-    else
-      menu[matchingItemIndex] = item
+      merge(matchingItem.submenu, submenuItem, itemSpecificity) for submenuItem in item.submenu
+    else if itemSpecificity
+      unless itemSpecificity < ItemSpecificities.get(matchingItem)
+        menu[matchingItemIndex] = item
   else
     menu.push(item)
 

--- a/src/menu-helpers.coffee
+++ b/src/menu-helpers.coffee
@@ -15,11 +15,12 @@ unmerge = (menu, item) ->
     unless matchingItem.submenu?.length > 0
       menu.splice(menu.indexOf(matchingItem), 1)
 
-findMatchingItem = (menu, {label, submenu}) ->
+findMatchingItem = (menu, {type, label, submenu}) ->
+  return if type is 'separator'
   for item in menu
     if normalizeLabel(item.label) is normalizeLabel(label) and item.submenu? is submenu?
       return item
-  null
+  return
 
 normalizeLabel = (label) ->
   return undefined unless label?

--- a/src/menu-helpers.coffee
+++ b/src/menu-helpers.coffee
@@ -13,7 +13,7 @@ merge = (menu, item, itemSpecificity=Infinity) ->
     else if itemSpecificity
       unless itemSpecificity < ItemSpecificities.get(matchingItem)
         menu[matchingItemIndex] = item
-  else
+  else unless item.type is 'separator' and _.last(menu)?.type is 'separator'
     menu.push(item)
 
 unmerge = (menu, item) ->

--- a/src/menu-helpers.coffee
+++ b/src/menu-helpers.coffee
@@ -1,0 +1,32 @@
+merge = (menu, item) ->
+  matchingItem = findMatchingItem(menu, item)
+
+  if matchingItem?
+    if item.submenu?
+      merge(matchingItem.submenu, submenuItem) for submenuItem in item.submenu
+  else
+    menu.push(item)
+
+unmerge = (menu, item) ->
+  if matchingItem = findMatchingItem(menu, item)
+    if item.submenu?
+      unmerge(matchingItem.submenu, submenuItem) for submenuItem in item.submenu
+
+    unless matchingItem.submenu?.length > 0
+      menu.splice(menu.indexOf(matchingItem), 1)
+
+findMatchingItem = (menu, {label, submenu}) ->
+  for item in menu
+    if normalizeLabel(item.label) is normalizeLabel(label) and item.submenu? is submenu?
+      return item
+  null
+
+normalizeLabel = (label) ->
+  return undefined unless label?
+
+  if process.platform is 'darwin'
+    label
+  else
+    label.replace(/\&/g, '')
+
+module.exports = {merge, unmerge, findMatchingItem, normalizeLabel}

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -6,6 +6,8 @@ CSON = require 'season'
 fs = require 'fs-plus'
 {Disposable} = require 'event-kit'
 
+MenuHelpers = require './menu-helpers'
+
 # Extended: Provides a registry for menu items that you'd like to appear in the
 # application menu.
 #
@@ -39,6 +41,7 @@ class MenuManager
   # Returns a {Disposable} on which `.dispose()` can be called to remove the
   # added menu items.
   add: (items) ->
+    items = _.deepClone(items)
     @merge(@template, item) for item in items
     @update()
     new Disposable => @remove(items)
@@ -103,30 +106,10 @@ class MenuManager
   # Merges an item in a submenu aware way such that new items are always
   # appended to the bottom of existing menus where possible.
   merge: (menu, item) ->
-    item = _.deepClone(item)
-    matchingItem = @findMatchingItem(menu, item)
-
-    if matchingItem?
-      if item.submenu?
-        @merge(matchingItem.submenu, submenuItem) for submenuItem in item.submenu
-    else
-      menu.push(item)
+    MenuHelpers.merge(menu, item)
 
   unmerge: (menu, item) ->
-    if matchingItem = @findMatchingItem(menu, item)
-      if item.submenu?
-        @unmerge(matchingItem.submenu, submenuItem) for submenuItem in item.submenu
-
-      unless matchingItem.submenu?.length > 0
-        menu.splice(menu.indexOf(matchingItem), 1)
-
-  # find an existing menu item matching the given item
-  findMatchingItem: (menu, {label, submenu}) ->
-    debugger unless menu?
-    for item in menu
-      if @normalizeLabel(item.label) is @normalizeLabel(label) and item.submenu? is submenu?
-        return item
-    null
+    MenuHelpers.unmerge(menu, item)
 
   # OSX can't handle displaying accelerators for multiple keystrokes.
   # If they are sent across, it will stop processing accelerators for the rest
@@ -145,25 +128,17 @@ class MenuManager
     keystrokesByCommand = @filterMultipleKeystroke(keystrokesByCommand)
     ipc.send 'update-application-menu', template, keystrokesByCommand
 
-  normalizeLabel: (label) ->
-    return undefined unless label?
-
-    if process.platform is 'darwin'
-      label
-    else
-      label.replace(/\&/g, '')
-
   # Get an {Array} of {String} classes for the given element.
   classesForElement: (element) ->
     element?.classList.toString().split(' ') ? []
 
   sortPackagesMenu: ->
-    packagesMenu = @template.find ({label}) => @normalizeLabel(label) is 'Packages'
+    packagesMenu = @template.find ({label}) => MenuHelpers.normalizeLabel(label) is 'Packages'
     return unless packagesMenu?.submenu?
 
     packagesMenu.submenu.sort (item1, item2) =>
       if item1.label and item2.label
-        @normalizeLabel(item1.label).localeCompare(@normalizeLabel(item2.label))
+        MenuHelpers.normalizeLabel(item1.label).localeCompare(MenuHelpers.normalizeLabel(item2.label))
       else
         0
     @update()

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -163,7 +163,7 @@ class Package
 
   activateResources: ->
     atom.keymaps.add(keymapPath, map) for [keymapPath, map] in @keymaps
-    atom.contextMenu.add(menuPath, map['context-menu']) for [menuPath, map] in @menus
+    atom.contextMenu.add(map['context-menu']) for [menuPath, map] in @menus
     atom.menu.add(map.menu) for [menuPath, map] in @menus when map.menu
 
     unless @grammarsActivated


### PR DESCRIPTION
## Consistent API

I initially set out to return `Disposable` instances from `atom.contextMenu.add`, but then I noticed that the format for expressing items didn't match up with `atom.menu.add`. This PR corrects that. You can now add context menus with the same format as adding application menus, with selectors mapping to arrays containing menu items as follows:

``` coffee
atom.contextMenu.add '.editor': [
  {label: 'Undo', command: 'core:undo'}
  {label: 'Redo', command: 'core:redo'}
  {label: 'Other', submenu: [
    {label: 'Transpose', command: 'editor:transpose'}
    ]
  }
]
```
## Created and Should Display Hooks

There's also a new `shouldDisplay` hook to address a use case I saw in color-picker, which is currently digging into `ContextMenuManager` internals to conditionally display a menu item. This is a sketch of how the API could be used, but not real code from the actual color-picker.

``` coffee
atom.contextMenu.add '.editor': [{
  label: 'Pick Color',
  command: 'color-picker:',
  shouldDisplay: (event) -> # use the right click event to decide...
}]
```

The `executeAtBuild` hook has been replaced with `created`. I couldn't find anyone using this other than us because it wasn't exposed in our API, so I went ahead and just renamed it without shimming. Here's the `created` hook being used to add the `x` and `y` of the click event to the command.

``` coffee
atom.contextMenu.add '.workspace': [{
  label: 'Inspect Element'
  command: 'application:inspect'
  devMode: true
  created: (event) ->
    {pageX, pageY} = event
    @commandOptions = {x: pageX, y: pageY}
}]
```
## Dev Mode

Dev-mode-only items were formerly expressed with a trailing options hash on the entire call to `::add`. Now each individual item can contain a `devMode` field indicating whether it should only display in dev mode. You can see this in the `Inspect Element` example above.
## Disposables

Finally, `::add` now returns a disposable on which `::dispose` can be called to remove the added item descriptors.
## Outreach

We should probably talk to the author of color-picker and any other packages that dig into context menu internals to get them to switch to the new API. We may even want to send them a PR before merging this if the number is manageable.

/cc @atom/core 
