### PR TITLE
Subscribe to commands in TextEditorComponent so they are unsubscribed!

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -2264,6 +2264,10 @@ describe "TextEditorComponent", ->
       wrapperView.detach()
       wrapperView.attachToDom()
 
+      wrapperView.trigger('core:move-right')
+
+      expect(editor.getCursorBufferPosition()).toEqual [0, 1]
+
   buildMouseEvent = (type, properties...) ->
     properties = extend({bubbles: true, cancelable: true}, properties...)
     properties.detail ?= 1

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -514,8 +514,8 @@ TextEditorComponent = React.createClass
   addCommandListeners: (listenersByCommandName) ->
     {parentView} = @props
 
-    addListener = (command, listener) ->
-      parentView.command command, (event) ->
+    addListener = (command, listener) =>
+      @subscribe parentView.command command, (event) ->
         event.stopPropagation()
         listener(event)
 


### PR DESCRIPTION
We need to unsubscribe when the editor is removed. This causes #3651

On master see the issue by moving an editor from one pane to another. All the commands will be duplicated.
