### PR TITLE
Add scoped settings to config

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -902,9 +902,9 @@ describe "Config", ->
 
     describe ".removeScopedSettingsForName(name)", ->
       it "allows properties to be removed by name", ->
-        atom.config.addScopedDefaults("a", ".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
-        atom.config.addScopedDefaults("b", ".source .string.quoted.double", foo: bar: baz: 22)
+        disposable1 = atom.config.addScopedDefaults("a", ".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
+        disposable2 = atom.config.addScopedDefaults("b", ".source .string.quoted.double", foo: bar: baz: 22)
 
-        atom.config.removeScopedSettingsForName("b")
+        disposable2.dispose()
         expect(atom.config.get([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBeUndefined()
         expect(atom.config.get([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -908,3 +908,62 @@ describe "Config", ->
         disposable2.dispose()
         expect(atom.config.get([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBeUndefined()
         expect(atom.config.get([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
+
+    describe ".observe(scopeDescriptor, keyPath)", ->
+      it 'calls the supplied callback when the value at the descriptor/keypath changes', ->
+        atom.config.observe [".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz", changeSpy = jasmine.createSpy()
+        expect(changeSpy).toHaveBeenCalledWith(undefined)
+        changeSpy.reset()
+
+        atom.config.set("foo.bar.baz", 12)
+        expect(changeSpy).toHaveBeenCalledWith(12)
+        changeSpy.reset()
+
+        disposable1 = atom.config.addScopedSettings(".source .string.quoted.double", foo: bar: baz: 22)
+        expect(changeSpy).toHaveBeenCalledWith(22)
+        changeSpy.reset()
+
+        disposable2 = atom.config.addScopedSettings("a", ".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
+        expect(changeSpy).toHaveBeenCalledWith(42)
+        changeSpy.reset()
+
+        disposable2.dispose()
+        expect(changeSpy).toHaveBeenCalledWith(22)
+        changeSpy.reset()
+
+        disposable1.dispose()
+        expect(changeSpy).toHaveBeenCalledWith(12)
+        changeSpy.reset()
+
+        atom.config.set("foo.bar.baz", undefined)
+        expect(changeSpy).toHaveBeenCalledWith(undefined)
+        changeSpy.reset()
+
+    describe ".onDidChange(scopeDescriptor, keyPath)", ->
+      it 'calls the supplied callback when the value at the descriptor/keypath changes', ->
+        keyPath = "foo.bar.baz"
+        atom.config.onDidChange [".source.coffee", ".string.quoted.double.coffee"], keyPath, changeSpy = jasmine.createSpy()
+
+        atom.config.set("foo.bar.baz", 12)
+        expect(changeSpy).toHaveBeenCalledWith({oldValue: undefined, newValue: 12, keyPath})
+        changeSpy.reset()
+
+        disposable1 = atom.config.addScopedSettings(".source .string.quoted.double", foo: bar: baz: 22)
+        expect(changeSpy).toHaveBeenCalledWith({oldValue: 12, newValue: 22, keyPath})
+        changeSpy.reset()
+
+        disposable2 = atom.config.addScopedSettings("a", ".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
+        expect(changeSpy).toHaveBeenCalledWith({oldValue: 22, newValue: 42, keyPath})
+        changeSpy.reset()
+
+        disposable2.dispose()
+        expect(changeSpy).toHaveBeenCalledWith({oldValue: 42, newValue: 22, keyPath})
+        changeSpy.reset()
+
+        disposable1.dispose()
+        expect(changeSpy).toHaveBeenCalledWith({oldValue: 22, newValue: 12, keyPath})
+        changeSpy.reset()
+
+        atom.config.set("foo.bar.baz", undefined)
+        expect(changeSpy).toHaveBeenCalledWith({oldValue: 12, newValue: undefined, keyPath})
+        changeSpy.reset()

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -866,9 +866,9 @@ describe "Config", ->
   describe "scoped settings", ->
     describe ".get(scopeDescriptor, keyPath)", ->
       it "returns the property with the most specific scope selector", ->
-        atom.config.addScopedDefaults(".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
-        atom.config.addScopedDefaults(".source .string.quoted.double", foo: bar: baz: 22)
-        atom.config.addScopedDefaults(".source", foo: bar: baz: 11)
+        atom.config.addScopedSettings(".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
+        atom.config.addScopedSettings(".source .string.quoted.double", foo: bar: baz: 22)
+        atom.config.addScopedSettings(".source", foo: bar: baz: 11)
 
         expect(atom.config.get([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
         expect(atom.config.get([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBe 22
@@ -876,8 +876,8 @@ describe "Config", ->
         expect(atom.config.get([".text"], "foo.bar.baz")).toBeUndefined()
 
       it "favors the most recently added properties in the event of a specificity tie", ->
-        atom.config.addScopedDefaults(".source.coffee .string.quoted.single", foo: bar: baz: 42)
-        atom.config.addScopedDefaults(".source.coffee .string.quoted.double", foo: bar: baz: 22)
+        atom.config.addScopedSettings(".source.coffee .string.quoted.single", foo: bar: baz: 42)
+        atom.config.addScopedSettings(".source.coffee .string.quoted.double", foo: bar: baz: 22)
 
         expect(atom.config.get([".source.coffee", ".string.quoted.single"], "foo.bar.baz")).toBe 42
         expect(atom.config.get([".source.coffee", ".string.quoted.single.double"], "foo.bar.baz")).toBe 22
@@ -891,9 +891,9 @@ describe "Config", ->
 
     describe ".set(scope, keyPath, value)", ->
       it "sets the value and overrides the others", ->
-        atom.config.addScopedDefaults(".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
-        atom.config.addScopedDefaults(".source .string.quoted.double", foo: bar: baz: 22)
-        atom.config.addScopedDefaults(".source", foo: bar: baz: 11)
+        atom.config.addScopedSettings(".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
+        atom.config.addScopedSettings(".source .string.quoted.double", foo: bar: baz: 22)
+        atom.config.addScopedSettings(".source", foo: bar: baz: 11)
 
         expect(atom.config.get([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
 
@@ -902,8 +902,8 @@ describe "Config", ->
 
     describe ".removeScopedSettingsForName(name)", ->
       it "allows properties to be removed by name", ->
-        disposable1 = atom.config.addScopedDefaults("a", ".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
-        disposable2 = atom.config.addScopedDefaults("b", ".source .string.quoted.double", foo: bar: baz: 22)
+        disposable1 = atom.config.addScopedSettings("a", ".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
+        disposable2 = atom.config.addScopedSettings("b", ".source .string.quoted.double", foo: bar: baz: 22)
 
         disposable2.dispose()
         expect(atom.config.get([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBeUndefined()

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -883,10 +883,8 @@ describe "Config", ->
         expect(atom.config.get([".source.coffee", ".string.quoted.single.double"], "foo.bar.baz")).toBe 22
 
       describe 'when there are global defaults', ->
-        beforeEach ->
-          atom.config.setDefaults("foo", hasDefault: 'ok')
-
         it 'falls back to the global when there is no scoped property specified', ->
+          atom.config.setDefaults("foo", hasDefault: 'ok')
           expect(atom.config.get([".source.coffee", ".string.quoted.single"], "foo.hasDefault")).toBe 'ok'
 
     describe ".set(scope, keyPath, value)", ->

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -313,7 +313,7 @@ describe "PackageManager", ->
             atom.packages.activatePackage("package-with-scoped-properties")
 
           runs ->
-            expect(atom.syntax.getProperty ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
+            expect(atom.config.get ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
 
     describe "converted textmate packages", ->
       it "loads the package's grammars", ->
@@ -326,13 +326,13 @@ describe "PackageManager", ->
           expect(atom.syntax.selectGrammar("file.rb").name).toBe "Ruby"
 
       it "loads the translated scoped properties", ->
-        expect(atom.syntax.getProperty(['.source.ruby'], 'editor.commentStart')).toBeUndefined()
+        expect(atom.config.get(['.source.ruby'], 'editor.commentStart')).toBeUndefined()
 
         waitsForPromise ->
           atom.packages.activatePackage('language-ruby')
 
         runs ->
-          expect(atom.syntax.getProperty(['.source.ruby'], 'editor.commentStart')).toBe '# '
+          expect(atom.config.get(['.source.ruby'], 'editor.commentStart')).toBe '# '
 
   describe "::deactivatePackage(id)", ->
     describe "atom packages", ->
@@ -436,9 +436,9 @@ describe "PackageManager", ->
           atom.packages.activatePackage("package-with-scoped-properties")
 
         runs ->
-          expect(atom.syntax.getProperty ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
+          expect(atom.config.get ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
           atom.packages.deactivatePackage("package-with-scoped-properties")
-          expect(atom.syntax.getProperty ['.source.omg'], 'editor.increaseIndentPattern').toBeUndefined()
+          expect(atom.config.get ['.source.omg'], 'editor.increaseIndentPattern').toBeUndefined()
 
     describe "textmate packages", ->
       it "removes the package's grammars", ->
@@ -458,7 +458,7 @@ describe "PackageManager", ->
 
         runs ->
           atom.packages.deactivatePackage('language-ruby')
-          expect(atom.syntax.getProperty(['.source.ruby'], 'editor.commentStart')).toBeUndefined()
+          expect(atom.config.get(['.source.ruby'], 'editor.commentStart')).toBeUndefined()
 
   describe "::activate()", ->
     packageActivator = null

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -335,6 +335,9 @@ describe "PackageManager", ->
           expect(atom.config.get(['.source.ruby'], 'editor.commentStart')).toBe '# '
 
   describe "::deactivatePackage(id)", ->
+    afterEach ->
+      atom.packages.unloadPackages()
+
     describe "atom packages", ->
       it "calls `deactivate` on the package's main module if activate was successful", ->
         pack = null

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -82,7 +82,6 @@ beforeEach ->
 
   spyOn(atom, 'saveSync')
   atom.syntax.clearGrammarOverrides()
-  atom.config.clearScopedSettings()
 
   spy = spyOn(atom.packages, 'resolvePackagePath').andCallFake (packageName) ->
     if specPackageName and packageName is specPackageName

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -82,7 +82,7 @@ beforeEach ->
 
   spyOn(atom, 'saveSync')
   atom.syntax.clearGrammarOverrides()
-  atom.syntax.clearProperties()
+  atom.config.clearScopedSettings()
 
   spy = spyOn(atom.packages, 'resolvePackagePath').andCallFake (packageName) ->
     if specPackageName and packageName is specPackageName

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -38,6 +38,19 @@ module.exports =
   editor:
     type: 'object'
     properties:
+      # These settings are used in scoped fashion only. No defaults.
+      commentStart:
+        type: 'string'
+      commentEnd:
+        type: 'string'
+      increaseIndentPattern:
+        type: 'string'
+      decreaseIndentPattern:
+        type: 'string'
+      foldEndPattern:
+        type: 'string'
+
+      # These can be used as globals or scoped, thus defaults.
       fontFamily:
         type: 'string'
         default: ''

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -1,7 +1,8 @@
 path = require 'path'
 fs = require 'fs-plus'
 
-# This is loaded by atom.coffee
+# This is loaded by atom.coffee. See https://atom.io/docs/api/latest/Config for
+# more information about config schemas.
 module.exports =
   core:
     type: 'object'

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -41,15 +41,15 @@ module.exports =
     properties:
       # These settings are used in scoped fashion only. No defaults.
       commentStart:
-        type: 'string'
+        type: ['string', 'null']
       commentEnd:
-        type: 'string'
+        type: ['string', 'null']
       increaseIndentPattern:
-        type: 'string'
+        type: ['string', 'null']
       decreaseIndentPattern:
-        type: 'string'
+        type: ['string', 'null']
       foldEndPattern:
-        type: 'string'
+        type: ['string', 'null']
 
       # These can be used as globals or scoped, thus defaults.
       fontFamily:

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -394,16 +394,16 @@ class Config
   # * `true` if the value was set.
   # * `false` if the value was not able to be coerced to the type specified in the setting's schema.
   set: (scope, keyPath, value) ->
+    if arguments.length < 3
+      value = keyPath
+      keyPath = scope
+      scope = undefined
+
     unless value == undefined
       try
         value = @makeValueConformToSchema(keyPath, value)
       catch e
         return false
-
-    if arguments.length < 3
-      value = keyPath
-      keyPath = scope
-      scope = undefined
 
     if scope?
       @addRawScopedValue(scope, keyPath, value)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -707,7 +707,7 @@ class Config
       .join(' ')
     @scopedSettingsStore.getPropertyValue(scopeChain, keyPath)
 
-  # TODO: figure out how to change / remove this. The return value is awkward. 
+  # TODO: figure out how to change / remove this. The return value is awkward.
   # * language mode uses it for one thing.
   # * autocomplete uses it for editor.completions
   settingsForScopeDescriptor: (scopeDescriptor, keyPath) ->
@@ -717,9 +717,6 @@ class Config
         scope
       .join(' ')
     @scopedSettingsStore.getProperties(scopeChain, keyPath)
-
-  clearScopedSettings: ->
-    @scopedSettingsStore = new ScopedPropertyStore
 
 # Base schema enforcers. These will coerce raw input into the specified type,
 # and will throw an error when the value cannot be coerced. Throwing the error

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -707,6 +707,17 @@ class Config
       .join(' ')
     @scopedSettingsStore.getPropertyValue(scopeChain, keyPath)
 
+  # TODO: figure out how to change / remove this. The return value is awkward. 
+  # * language mode uses it for one thing.
+  # * autocomplete uses it for editor.completions
+  settingsForScopeDescriptor: (scopeDescriptor, keyPath) ->
+    scopeChain = scopeDescriptor
+      .map (scope) ->
+        scope = ".#{scope}" unless scope[0] is '.'
+        scope
+      .join(' ')
+    @scopedSettingsStore.getProperties(scopeChain, keyPath)
+
   clearScopedSettings: ->
     @scopedSettingsStore = new ScopedPropertyStore
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -709,7 +709,7 @@ class Config
     @scopedSettingsStore.getPropertyValue(scopeChain, keyPath)
 
   # TODO: figure out how to remove this. Only language mode uses it for one thing.
-  settingsForScopeDescriptor: (scopeDescriptor, keyPath) ->
+  scopedSettingsForScopeDescriptor: (scopeDescriptor, keyPath) ->
     scopeChain = scopeDescriptor
       .map (scope) ->
         scope = ".#{scope}" unless scope[0] is '.'

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -708,15 +708,6 @@ class Config
       .join(' ')
     @scopedSettingsStore.getPropertyValue(scopeChain, keyPath)
 
-  # TODO: figure out how to remove this. Only language mode uses it for one thing.
-  scopedSettingsForScopeDescriptor: (scopeDescriptor, keyPath) ->
-    scopeChain = scopeDescriptor
-      .map (scope) ->
-        scope = ".#{scope}" unless scope[0] is '.'
-        scope
-      .join(' ')
-    @scopedSettingsStore.getProperties(scopeChain, keyPath)
-
   clearScopedSettings: ->
     @scopedSettingsStore = new ScopedPropertyStore
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -337,9 +337,7 @@ class Config
       message = "`callNow` was set to false. Use ::onDidChange instead. Note that ::onDidChange calls back with different arguments." if options.callNow == false
       deprecate "Config::observe no longer supports options. #{message}"
 
-    callback(_.clone(@get(keyPath))) unless options.callNow == false
-    @emitter.on 'did-change', (event) ->
-      callback(event.newValue) if keyPath? and keyPath.indexOf(event?.keyPath) is 0
+    @observeKeyPath(keyPath, options ? {}, callback)
 
   # Essential: Add a listener for changes to a given key path. If `keyPath` is
   # not specified, your callback will be called on changes to any key.
@@ -358,8 +356,7 @@ class Config
       callback = keyPath
       keyPath = undefined
 
-    @emitter.on 'did-change', (event) ->
-      callback(event) if not keyPath? or (keyPath? and keyPath.indexOf(event?.keyPath) is 0)
+    @onDidChangeKeyPath(keyPath, callback)
 
   ###
   Section: Managing Settings
@@ -642,6 +639,15 @@ class Config
     _.setValueForKeyPath(@settings, keyPath, value)
     newValue = @get(keyPath)
     @emitter.emit 'did-change', {oldValue, newValue, keyPath} unless _.isEqual(newValue, oldValue)
+
+  observeKeyPath: (keyPath, options, callback) ->
+    callback(_.clone(@get(keyPath))) unless options.callNow == false
+    @emitter.on 'did-change', (event) ->
+      callback(event.newValue) if keyPath? and keyPath.indexOf(event?.keyPath) is 0
+
+  onDidChangeKeyPath: (keyPath, callback) ->
+    @emitter.on 'did-change', (event) ->
+      callback(event) if not keyPath? or (keyPath? and keyPath.indexOf(event?.keyPath) is 0)
 
   setRawDefault: (keyPath, value) ->
     oldValue = _.clone(@get(keyPath))

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -685,7 +685,6 @@ class Config
       selector = name
       name = null
 
-    name = "#{name ? ''}+default"
     settingsBySelector = {}
     settingsBySelector[selector] = value
     @scopedSettingsStore.addProperties(name, settingsBySelector)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -628,7 +628,7 @@ class Config
 
     if value?
       value = _.deepClone(value)
-      _.defaults(value, defaultValue) if isPlainObject(defaultValue) and isPlainObject(defaultValue)
+      _.defaults(value, defaultValue) if isPlainObject(value) and isPlainObject(defaultValue)
     else
       value = _.deepClone(defaultValue)
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -708,9 +708,21 @@ class Config
       .join(' ')
     @scopedSettingsStore.getPropertyValue(scopeChain, keyPath)
 
+  # TODO: figure out how to remove this. Only language mode uses it for one thing.
+  settingsForScopeDescriptor: (scopeDescriptor, keyPath) ->
+    scopeChain = scopeDescriptor
+      .map (scope) ->
+        scope = ".#{scope}" unless scope[0] is '.'
+        scope
+      .join(' ')
+    @scopedSettingsStore.getProperties(scopeChain, keyPath)
+
   removeScopedSettingsForName: (name) ->
     @scopedSettingsStore.removeProperties(name)
     @scopedSettingsStore.removeProperties("#{name}+default")
+
+  clearScopedSettings: ->
+    @scopedSettingsStore = new ScopedPropertyStore
 
 # Base schema enforcers. These will coerce raw input into the specified type,
 # and will throw an error when the value cannot be coerced. Throwing the error

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -717,10 +717,6 @@ class Config
       .join(' ')
     @scopedSettingsStore.getProperties(scopeChain, keyPath)
 
-  removeScopedSettingsForName: (name) ->
-    @scopedSettingsStore.removeProperties(name)
-    @scopedSettingsStore.removeProperties("#{name}+default")
-
   clearScopedSettings: ->
     @scopedSettingsStore = new ScopedPropertyStore
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -679,7 +679,7 @@ class Config
   Section: Private Scoped Settings
   ###
 
-  addScopedDefaults: (name, selector, value) ->
+  addScopedSettings: (name, selector, value) ->
     if arguments.length < 3
       value = selector
       selector = name

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -357,7 +357,7 @@ class Config
       message = "`callNow` was set to false. Use ::onDidChange instead. Note that ::onDidChange calls back with different arguments." if options.callNow == false
       deprecate "Config::observe no longer supports options; see https://atom.io/docs/api/latest/Config. #{message}"
     else
-      console.warn 'An unsupported form of Config::observe is being used. See https://atom.io/docs/api/latest/Config for details'
+      console.error 'An unsupported form of Config::observe is being used. See https://atom.io/docs/api/latest/Config for details'
       return
 
     if scopeDescriptor?

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -499,7 +499,7 @@ class Config
         return false
 
     if scope?
-      @addRawScopedValue(scope, keyPath, value)
+      @setRawScopedValue(scope, keyPath, value)
     else
       @setRawValue(keyPath, value)
 
@@ -796,7 +796,7 @@ class Config
       disposable.dispose()
       @emitter.emit 'did-change'
 
-  addRawScopedValue: (selector, keyPath, value) ->
+  setRawScopedValue: (selector, keyPath, value) ->
     if keyPath?
       newValue = {}
       _.setValueForKeyPath(newValue, keyPath, value)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -334,7 +334,9 @@ class Config
   #   # do stuff with value
   # ```
   #
-  # * `scopeDescriptor` (optional) {Array} of {String}s. See {::get} for examples
+  # * `scopeDescriptor` (optional) {Array} of {String}s describing a path from
+  #   the root of the syntax tree to a token. Get one by calling
+  #   {TextEditor::scopesAtCursor}. See {::get} for examples.
   # * `keyPath` {String} name of the key to observe
   # * `callback` {Function} to call when the value of the key changes.
   #   * `value` the new value of the key
@@ -368,7 +370,9 @@ class Config
   # Essential: Add a listener for changes to a given key path. If `keyPath` is
   # not specified, your callback will be called on changes to any key.
   #
-  # * `scopeDescriptor` (optional) {Array} of {String}s. See {::get} for examples
+  # * `scopeDescriptor` (optional) {Array} of {String}s describing a path from
+  #   the root of the syntax tree to a token. Get one by calling
+  #   {TextEditor::scopesAtCursor}. See {::get} for examples.
   # * `keyPath` (optional) {String} name of the key to observe. Must be
   #   specified if `scopeDescriptor` is specified.
   # * `callback` {Function} to call when the value of the key changes.
@@ -423,11 +427,13 @@ class Config
   # Additionally, you can get the setting at the specific cursor position.
   #
   # ```coffee
-  # scopeDescriptor = @editor.scopesForBufferPosition(@editor.getCursorBufferPosition())
+  # scopeDescriptor = @editor.scopesAtCursor()
   # atom.config.get(scopeDescriptor, 'editor.tabLength') # => 2
   # ```
   #
-  # * `scopeDescriptor` (optional) {Array} of {String}s.
+  # * `scopeDescriptor` (optional) {Array} of {String}s describing a path from
+  #   the root of the syntax tree to a token. Get one by calling
+  #   {TextEditor::scopesAtCursor}
   # * `keyPath` The {String} name of the key to retrieve.
   #
   # Returns the value from Atom's default settings, the user's configuration

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -882,7 +882,7 @@ Config.addSchemaEnforcers
   'null':
     # null sort of isnt supported. It will just unset in this case
     coerce: (keyPath, value, schema) ->
-      throw new Error("Validation failed at #{keyPath}, #{JSON.stringify(value)} must be null") unless value == null
+      throw new Error("Validation failed at #{keyPath}, #{JSON.stringify(value)} must be null") unless value in [undefined, null]
       value
 
   'object':

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -30,11 +30,11 @@ class LanguageMode
   # Returns an {Array} of the commented {Ranges}.
   toggleLineCommentsForBufferRows: (start, end) ->
     scopes = @editor.scopesForBufferPosition([start, 0])
-    properties = atom.config.get(scopes, "editor")
-    return unless properties.commentStart
+    properties = atom.config.settingsForScopeDescriptor(scopes, "editor.commentStart")[0]
+    return unless properties
 
-    commentStartString = properties.commentStart
-    commentEndString = properties.commentEnd
+    commentStartString = _.valueForKeyPath(properties, 'editor.commentStart')
+    commentEndString = _.valueForKeyPath(properties, 'editor.commentEnd')
 
     return unless commentStartString
 

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -30,11 +30,11 @@ class LanguageMode
   # Returns an {Array} of the commented {Ranges}.
   toggleLineCommentsForBufferRows: (start, end) ->
     scopes = @editor.scopesForBufferPosition([start, 0])
-    properties = atom.syntax.propertiesForScope(scopes, "editor.commentStart")[0]
-    return unless properties
+    properties = atom.config.get(scopes, "editor")
+    return unless properties.commentStart
 
-    commentStartString = _.valueForKeyPath(properties, "editor.commentStart")
-    commentEndString = _.valueForKeyPath(properties, "editor.commentEnd")
+    commentStartString = properties.commentStart
+    commentEndString = properties.commentEnd
 
     return unless commentStartString
 

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -312,7 +312,7 @@ class LanguageMode
       @editor.setIndentationForBufferRow(bufferRow, desiredIndentLevel)
 
   getRegexForProperty: (scopes, property) ->
-    if pattern = atom.syntax.getProperty(scopes, property)
+    if pattern = atom.config.get(scopes, property)
       new OnigRegExp(pattern)
 
   increaseIndentRegexForScopes: (scopes) ->

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -30,7 +30,7 @@ class LanguageMode
   # Returns an {Array} of the commented {Ranges}.
   toggleLineCommentsForBufferRows: (start, end) ->
     scopes = @editor.scopesForBufferPosition([start, 0])
-    properties = atom.config.settingsForScopeDescriptor(scopes, "editor.commentStart")[0]
+    properties = atom.config.settingsForScopeDescriptor(scopes, 'editor.commentStart')[0]
     return unless properties
 
     commentStartString = _.valueForKeyPath(properties, 'editor.commentStart')

--- a/src/scoped-properties.coffee
+++ b/src/scoped-properties.coffee
@@ -15,7 +15,7 @@ class ScopedProperties
 
   activate: ->
     for selector, properties of @scopedProperties
-      @propertyDisposable.add atom.config.addScopedDefaults(@path, selector, properties)
+      @propertyDisposable.add atom.config.addScopedSettings(@path, selector, properties)
     return
 
   deactivate: ->

--- a/src/scoped-properties.coffee
+++ b/src/scoped-properties.coffee
@@ -13,7 +13,7 @@ class ScopedProperties
 
   activate: ->
     for selector, properties of @scopedProperties
-      atom.syntax.addProperties(@path, selector, properties)
+      atom.config.addScopedDefaults(@path, selector, properties)
 
   deactivate: ->
-    atom.syntax.removeProperties(@path)
+    atom.config.removeScopedSettingsForName(@path)

--- a/src/scoped-properties.coffee
+++ b/src/scoped-properties.coffee
@@ -1,4 +1,5 @@
 CSON = require 'season'
+{CompositeDisposable} = require 'event-kit'
 
 module.exports =
 class ScopedProperties
@@ -10,10 +11,12 @@ class ScopedProperties
         callback(null, new ScopedProperties(scopedPropertiesPath, scopedProperties))
 
   constructor: (@path, @scopedProperties) ->
+    @propertyDisposable = new CompositeDisposable
 
   activate: ->
     for selector, properties of @scopedProperties
-      atom.config.addScopedDefaults(@path, selector, properties)
+      @propertyDisposable.add atom.config.addScopedDefaults(@path, selector, properties)
+    return
 
   deactivate: ->
-    atom.config.removeScopedSettingsForName(@path)
+    @propertyDisposable.dispose()

--- a/src/syntax.coffee
+++ b/src/syntax.coffee
@@ -44,8 +44,8 @@ class Syntax extends GrammarRegistry
     atom.config.addScopedDefaults(args...)
 
   removeProperties: (name) ->
-    deprecate 'A direct (but private) replacement is available at atom.config.removeScopedSettingsForName().'
-    atom.config.removeScopedSettingsForName(name)
+    deprecate 'atom.config.addScopedDefaults() now returns a disposable you can call .dispose() on'
+    atom.config.scopedSettingsStore.removeProperties(name)
 
   clearProperties: ->
     deprecate 'A direct (but private) replacement is available at atom.config.clearScopedSettings().'

--- a/src/syntax.coffee
+++ b/src/syntax.coffee
@@ -82,6 +82,3 @@ class Syntax extends GrammarRegistry
       .join(' ')
 
     @propertyStore.getProperties(scopeChain, keyPath)
-
-  cssSelectorFromScopeSelector: (scopeSelector) ->
-    new ScopeSelector(scopeSelector).toCssSelector()

--- a/src/syntax.coffee
+++ b/src/syntax.coffee
@@ -28,7 +28,6 @@ class Syntax extends GrammarRegistry
 
   constructor: ->
     super(maxTokensPerLine: 100)
-    @propertyStore = new ScopedPropertyStore
 
   serialize: ->
     {deserializer: @constructor.name, @grammarOverridesByPath}
@@ -41,44 +40,16 @@ class Syntax extends GrammarRegistry
     @propertyStore.propertySets
 
   addProperties: (args...) ->
-    name = args.shift() if args.length > 2
-    [selector, properties] = args
-    propertiesBySelector = {}
-    propertiesBySelector[selector] = properties
-    @propertyStore.addProperties(name, propertiesBySelector)
+    atom.config.addScopedDefaults(args...)
 
   removeProperties: (name) ->
-    @propertyStore.removeProperties(name)
+    atom.config.removeScopedSettingsForName(name)
 
   clearProperties: ->
-    @propertyStore = new ScopedPropertyStore
+    atom.config.clearScopedSettings()
 
-  # Public: Get a property for the given scope and key path.
-  #
-  # ## Examples
-  #
-  # ```coffee
-  # comment = atom.syntax.getProperty(['.source.ruby'], 'editor.commentStart')
-  # console.log(comment) # '# '
-  # ```
-  #
-  # * `scope` An {Array} of {String} scopes.
-  # * `keyPath` A {String} key path.
-  #
-  # Returns a {String} property value or undefined.
   getProperty: (scope, keyPath) ->
-    scopeChain = scope
-      .map (scope) ->
-        scope = ".#{scope}" unless scope[0] is '.'
-        scope
-      .join(' ')
-    @propertyStore.getPropertyValue(scopeChain, keyPath)
+    atom.config.getRawScopedValue(scope, keyPath)
 
   propertiesForScope: (scope, keyPath) ->
-    scopeChain = scope
-      .map (scope) ->
-        scope = ".#{scope}" unless scope[0] is '.'
-        scope
-      .join(' ')
-
-    @propertyStore.getProperties(scopeChain, keyPath)
+    atom.config.settingsForScopeDescriptor(scope, keyPath)

--- a/src/syntax.coffee
+++ b/src/syntax.coffee
@@ -40,16 +40,21 @@ class Syntax extends GrammarRegistry
     @propertyStore.propertySets
 
   addProperties: (args...) ->
+    deprecate 'Consider using atom.config.set() instead. A direct (but private) replacement is available at atom.config.addScopedDefaults().'
     atom.config.addScopedDefaults(args...)
 
   removeProperties: (name) ->
+    deprecate 'A direct (but private) replacement is available at atom.config.removeScopedSettingsForName().'
     atom.config.removeScopedSettingsForName(name)
 
   clearProperties: ->
+    deprecate 'A direct (but private) replacement is available at atom.config.clearScopedSettings().'
     atom.config.clearScopedSettings()
 
   getProperty: (scope, keyPath) ->
+    deprecate 'A direct (but private) replacement is available at atom.config.getRawScopedValue().'
     atom.config.getRawScopedValue(scope, keyPath)
 
   propertiesForScope: (scope, keyPath) ->
+    deprecate 'A direct (but private) replacement is available at atom.config.settingsForScopeDescriptor().'
     atom.config.settingsForScopeDescriptor(scope, keyPath)

--- a/src/syntax.coffee
+++ b/src/syntax.coffee
@@ -57,4 +57,4 @@ class Syntax extends GrammarRegistry
 
   propertiesForScope: (scope, keyPath) ->
     deprecate 'A direct (but private) replacement is available at atom.config.scopedSettingsForScopeDescriptor().'
-    atom.config.scopedSettingsForScopeDescriptor(scope, keyPath)
+    atom.config.settingsForScopeDescriptor(scope, keyPath)

--- a/src/syntax.coffee
+++ b/src/syntax.coffee
@@ -40,11 +40,11 @@ class Syntax extends GrammarRegistry
     atom.config.scopedSettingsStore
 
   addProperties: (args...) ->
-    deprecate 'Consider using atom.config.set() instead. A direct (but private) replacement is available at atom.config.addScopedDefaults().'
-    atom.config.addScopedDefaults(args...)
+    deprecate 'Consider using atom.config.set() instead. A direct (but private) replacement is available at atom.config.addScopedSettings().'
+    atom.config.addScopedSettings(args...)
 
   removeProperties: (name) ->
-    deprecate 'atom.config.addScopedDefaults() now returns a disposable you can call .dispose() on'
+    deprecate 'atom.config.addScopedSettings() now returns a disposable you can call .dispose() on'
     atom.config.scopedSettingsStore.removeProperties(name)
 
   getProperty: (scope, keyPath) ->

--- a/src/syntax.coffee
+++ b/src/syntax.coffee
@@ -35,9 +35,9 @@ class Syntax extends GrammarRegistry
   createToken: (value, scopes) -> new Token({value, scopes})
 
   # Deprecated: Used by settings-view to display snippets for packages
-  @::accessor 'scopedProperties', ->
-    deprecate("Use Syntax::getProperty instead")
-    @propertyStore.propertySets
+  @::accessor 'propertyStore', ->
+    deprecate("Do not use this. Use a public method on Config")
+    atom.config.scopedSettingsStore
 
   addProperties: (args...) ->
     deprecate 'Consider using atom.config.set() instead. A direct (but private) replacement is available at atom.config.addScopedDefaults().'

--- a/src/syntax.coffee
+++ b/src/syntax.coffee
@@ -47,10 +47,6 @@ class Syntax extends GrammarRegistry
     deprecate 'atom.config.addScopedDefaults() now returns a disposable you can call .dispose() on'
     atom.config.scopedSettingsStore.removeProperties(name)
 
-  clearProperties: ->
-    deprecate 'A direct (but private) replacement is available at atom.config.clearScopedSettings().'
-    atom.config.clearScopedSettings()
-
   getProperty: (scope, keyPath) ->
     deprecate 'A direct (but private) replacement is available at atom.config.getRawScopedValue().'
     atom.config.getRawScopedValue(scope, keyPath)

--- a/src/syntax.coffee
+++ b/src/syntax.coffee
@@ -56,5 +56,5 @@ class Syntax extends GrammarRegistry
     atom.config.getRawScopedValue(scope, keyPath)
 
   propertiesForScope: (scope, keyPath) ->
-    deprecate 'A direct (but private) replacement is available at atom.config.settingsForScopeDescriptor().'
-    atom.config.settingsForScopeDescriptor(scope, keyPath)
+    deprecate 'A direct (but private) replacement is available at atom.config.scopedSettingsForScopeDescriptor().'
+    atom.config.scopedSettingsForScopeDescriptor(scope, keyPath)


### PR DESCRIPTION
Status: looking for feedback :eyes: 

This moves the scoped properties from syntax into config and merges them with the 'global' config. 
### TODO
- [x] Add optional selectors to `Config::get/set`
- [x] Forward deprecated writes to `atom.syntax` to `atom.config`
- [x] Forward deprecated reads on `atom.syntax` to `atom.config`
- [x] Read from `atom.config` instead of `atom.syntax`
- [x] Register scoped properties with `atom.config` instead of `atom.syntax` when loading packages.
- [x] Allow scoped settings to be observed
- [x] Update docs to explain the scope descriptors

Closes https://github.com/atom/atom/issues/3674
