### PR TITLE
Make command registry backward compatible with jQuery::on and ::trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "season": "^1.0.2",
     "semver": "1.1.4",
     "serializable": "^1",
-    "space-pen": "3.6.1",
+    "space-pen": "3.7.0",
     "temp": "0.7.0",
     "text-buffer": "^3.2.8",
     "theorist": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "atomShellVersion": "0.17.1",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "^2.2.0",
+    "atom-keymap": "^2.2.1",
     "bootstrap": "git+https://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",
     "clear-cut": "0.4.0",
     "coffee-script": "1.7.0",

--- a/spec/command-registry-spec.coffee
+++ b/spec/command-registry-spec.coffee
@@ -48,6 +48,16 @@ describe "CommandRegistry", ->
       grandchild.dispatchEvent(new CustomEvent('command', bubbles: true))
       expect(calls).toEqual ['child', 'parent']
 
+    it "invokes inline listeners prior to listeners applied via selectors", ->
+      calls = []
+      registry.add '.grandchild', 'command', -> calls.push('grandchild')
+      registry.add child, 'command', -> calls.push('child-inline')
+      registry.add '.child', 'command', -> calls.push('child')
+      registry.add '.parent', 'command', -> calls.push('parent')
+
+      grandchild.dispatchEvent(new CustomEvent('command', bubbles: true))
+      expect(calls).toEqual ['grandchild', 'child-inline', 'child', 'parent']
+
     it "orders multiple matching listeners for an element by selector specificity", ->
       child.classList.add('foo', 'bar')
       calls = []

--- a/spec/command-registry-spec.coffee
+++ b/spec/command-registry-spec.coffee
@@ -14,7 +14,10 @@ describe "CommandRegistry", ->
     parent.appendChild(child)
     document.querySelector('#jasmine-content').appendChild(parent)
 
-    registry = new CommandRegistry(parent)
+    registry = new CommandRegistry
+
+  afterEach ->
+    registry.destroy()
 
   describe "when a command event is dispatched on an element", ->
     it "invokes callbacks with selectors matching the target", ->
@@ -104,6 +107,16 @@ describe "CommandRegistry", ->
       spyOn(dispatchedEvent, 'preventDefault')
       grandchild.dispatchEvent(dispatchedEvent)
       expect(dispatchedEvent.preventDefault).toHaveBeenCalled()
+
+    it "forwards .abortKeyBinding() calls from the synthetic event to the original", ->
+      calls = []
+
+      registry.add '.child', 'command', (event) -> event.abortKeyBinding()
+
+      dispatchedEvent = new CustomEvent('command', bubbles: true)
+      dispatchedEvent.abortKeyBinding = jasmine.createSpy('abortKeyBinding')
+      grandchild.dispatchEvent(dispatchedEvent)
+      expect(dispatchedEvent.abortKeyBinding).toHaveBeenCalled()
 
     it "allows listeners to be removed via a disposable returned by ::add", ->
       calls = []

--- a/spec/command-registry-spec.coffee
+++ b/spec/command-registry-spec.coffee
@@ -16,7 +16,7 @@ describe "CommandRegistry", ->
 
     registry = new CommandRegistry(parent)
 
-  describe "command dispatch", ->
+  describe "when a command event is dispatched on an element", ->
     it "invokes callbacks with selectors matching the target", ->
       called = false
       registry.add '.grandchild', 'command', (event) ->

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -72,7 +72,6 @@ beforeEach ->
   atom.project = new Project(paths: [projectPath])
   atom.workspace = new Workspace()
   atom.keymaps.keyBindings = _.clone(keyBindingsToRestore)
-  atom.commands.setRootNode(document.body)
   atom.commands.restoreSnapshot(commandsToRestore)
 
   window.resetTimeouts()

--- a/spec/window-spec.coffee
+++ b/spec/window-spec.coffee
@@ -47,14 +47,6 @@ describe "Window", ->
       $(window).trigger 'window:close'
       expect(atom.close).toHaveBeenCalled()
 
-    it "emits the beforeunload event", ->
-      $(window).off 'beforeunload'
-      beforeunload = jasmine.createSpy('beforeunload').andReturn(false)
-      $(window).on 'beforeunload', beforeunload
-
-      $(window).trigger 'window:close'
-      expect(beforeunload).toHaveBeenCalled()
-
   describe "beforeunload event", ->
     [beforeUnloadEvent] = []
 

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -127,15 +127,11 @@ describe "WorkspaceView", ->
       expect(activePane).toHaveFocus()
 
   describe "keymap wiring", ->
-    commandHandler = null
-    beforeEach ->
-      commandHandler = jasmine.createSpy('commandHandler')
-      atom.workspaceView.on('foo-command', commandHandler)
-
-      atom.keymaps.add('name', '*': {'x': 'foo-command'})
-
     describe "when a keydown event is triggered in the WorkspaceView", ->
       it "triggers matching keybindings for that event", ->
+        commandHandler = jasmine.createSpy('commandHandler')
+        atom.workspaceView.on('foo-command', commandHandler)
+        atom.keymaps.add('name', '*': {'x': 'foo-command'})
         event = keydownEvent 'x', target: atom.workspaceView[0]
 
         atom.workspaceView.trigger(event)

--- a/src/command-registry.coffee
+++ b/src/command-registry.coffee
@@ -196,6 +196,8 @@ class CommandRegistry
     syntheticEvent = Object.create originalEvent,
       eventPhase: value: Event.BUBBLING_PHASE
       currentTarget: get: -> currentTarget
+      preventDefault: value: ->
+        originalEvent.preventDefault()
       stopPropagation: value: ->
         originalEvent.stopPropagation()
         propagationStopped = true

--- a/src/command-registry.coffee
+++ b/src/command-registry.coffee
@@ -186,8 +186,6 @@ class CommandRegistry
       @selectorBasedListenersByCommandName[commandName] = listeners.slice()
 
   handleCommandEvent: (originalEvent) =>
-    originalEvent.__handledByCommandRegistry = true
-
     propagationStopped = false
     immediatePropagationStopped = false
     matched = false

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -335,6 +335,7 @@ class Package
     for selector, commands of @getActivationCommands()
       for command in commands
         do (selector, command) =>
+          atom.commands.commandRegistered(command)
           @activationCommandSubscriptions.add(atom.commands.onWillDispatch (event) =>
             return unless event.type is command
             currentTarget = event.target

--- a/src/space-pen-extensions.coffee
+++ b/src/space-pen-extensions.coffee
@@ -64,7 +64,6 @@ jQuery.event.add = (elem, types, originalHandler, data, selector) ->
 
   HandlersByOriginalHandler.set(originalHandler, handler)
 
-  console.log "jquery.event.add...", elem, types if global.debug
   JQueryEventAdd.call(this, elem, types, handler, data, selector, AddEventListener if atom?.commands?)
 
 JQueryEventRemove = jQuery.event.remove

--- a/src/space-pen-extensions.coffee
+++ b/src/space-pen-extensions.coffee
@@ -10,6 +10,69 @@ jQuery.cleanData = (elements) ->
   jQuery(element).view()?.unsubscribe() for element in elements
   originalCleanData(elements)
 
+NativeEventNames = new Set
+NativeEventNames.add(nativeEvent) for nativeEvent in ["blur", "focus", "focusin",
+"focusout", "load", "resize", "scroll", "unload", "click", "dblclick", "mousedown",
+"mouseup", "mousemove", "mouseover", "mouseout", "mouseenter", "mouseleave", "change",
+"select", "submit", "keydown", "keypress", "keyup", "error", "contextmenu"]
+
+originalTrigger = jQuery.fn.trigger
+jQuery.fn.trigger = (eventName, data) ->
+  if NativeEventNames.has(eventName) or typeof eventName is 'object'
+    originalTrigger.call(this, eventName, data)
+  else
+    for element in this
+      atom.commands.dispatch(element, eventName, data)
+    this
+
+HandlersByOriginalHandler = new WeakMap
+CommandDisposablesByElement = new WeakMap
+
+AddEventListener = (element, type, listener) ->
+  if NativeEventNames.has(type)
+    element.addEventListener(type, listener)
+  else
+    disposable = atom.commands.add(element, type, listener)
+
+    unless disposablesByType = CommandDisposablesByElement.get(element)
+      disposablesByType = {}
+      CommandDisposablesByElement.set(element, disposablesByType)
+
+    unless disposablesByListener = disposablesByType[type]
+      disposablesByListener = new WeakMap
+      disposablesByType[type] = disposablesByListener
+
+    disposablesByListener.set(listener, disposable)
+
+RemoveEventListener = (element, type, listener) ->
+  if NativeEventNames.has(type)
+    element.removeEventListener(type, listener)
+  else
+    CommandDisposablesByElement.get(element)?[type]?.get(listener)?.dispose()
+
+JQueryEventAdd = jQuery.event.add
+jQuery.event.add = (elem, types, originalHandler, data, selector) ->
+  handler = (event) ->
+    if arguments.length is 1 and event.originalEvent?.detail?
+      {detail} = event.originalEvent
+      if Array.isArray(detail)
+        originalHandler.apply(this, [event].concat(detail))
+      else
+        originalHandler.call(this, event, detail)
+    else
+      originalHandler.apply(this, arguments)
+
+  HandlersByOriginalHandler.set(originalHandler, handler)
+
+  console.log "jquery.event.add...", elem, types if global.debug
+  JQueryEventAdd.call(this, elem, types, handler, data, selector, AddEventListener if atom?.commands?)
+
+JQueryEventRemove = jQuery.event.remove
+jQuery.event.remove = (elem, types, originalHandler, selector, mappedTypes) ->
+  if originalHandler?
+    handler = HandlersByOriginalHandler.get(originalHandler) ? originalHandler
+  JQueryEventRemove(elem, types, handler, selector, mappedTypes, RemoveEventListener if atom?.commands?)
+
 tooltipDefaults =
   delay:
     show: 1000

--- a/src/space-pen-extensions.coffee
+++ b/src/space-pen-extensions.coffee
@@ -5,10 +5,10 @@ spacePen = require 'space-pen'
 Subscriber.includeInto(spacePen.View)
 
 jQuery = spacePen.jQuery
-originalCleanData = jQuery.cleanData
+JQueryCleanData = jQuery.cleanData
 jQuery.cleanData = (elements) ->
   jQuery(element).view()?.unsubscribe() for element in elements
-  originalCleanData(elements)
+  JQueryCleanData(elements)
 
 NativeEventNames = new Set
 NativeEventNames.add(nativeEvent) for nativeEvent in ["blur", "focus", "focusin",
@@ -16,10 +16,10 @@ NativeEventNames.add(nativeEvent) for nativeEvent in ["blur", "focus", "focusin"
 "mouseup", "mousemove", "mouseover", "mouseout", "mouseenter", "mouseleave", "change",
 "select", "submit", "keydown", "keypress", "keyup", "error", "contextmenu"]
 
-originalTrigger = jQuery.fn.trigger
+JQueryTrigger = jQuery.fn.trigger
 jQuery.fn.trigger = (eventName, data) ->
   if NativeEventNames.has(eventName) or typeof eventName is 'object'
-    originalTrigger.call(this, eventName, data)
+    JQueryTrigger.call(this, eventName, data)
   else
     for element in this
       atom.commands.dispatch(element, eventName, data)

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -10,7 +10,6 @@ module.exports =
 class WorkspaceElement extends HTMLElement
   createdCallback: ->
     @subscriptions = new CompositeDisposable
-    atom.commands.setRootNode(this)
     @initializeContent()
     @observeScrollbarStyle()
     @observeTextEditorFontConfig()

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -55,60 +55,6 @@ class WorkspaceElement extends HTMLElement
     WorkspaceView ?= require './workspace-view'
     @__spacePenView = new WorkspaceView(this)
 
-    addCommands = (handlersByName) =>
-      for name, handler of handlersByName
-        do (handler) =>
-          @__spacePenView.command name, => handler.apply(this, arguments)
-
-    addCommands(
-      'window:increase-font-size': -> @getModel().increaseFontSize()
-      'window:decrease-font-size': -> @getModel().decreaseFontSize()
-      'window:reset-font-size': -> @getModel().resetFontSize()
-      'application:about': -> ipc.send('command', 'application:about')
-      'application:run-all-specs': -> ipc.send('command', 'application:run-all-specs')
-      'application:run-benchmarks': -> ipc.send('command', 'application:run-benchmarks')
-      'application:show-settings': -> ipc.send('command', 'application:show-settings')
-      'application:quit': -> ipc.send('command', 'application:quit')
-      'application:hide': -> ipc.send('command', 'application:hide')
-      'application:hide-other-applications': -> ipc.send('command', 'application:hide-other-applications')
-      'application:install-update': -> ipc.send('command', 'application:install-update')
-      'application:unhide-all-applications': -> ipc.send('command', 'application:unhide-all-applications')
-      'application:new-window': -> ipc.send('command', 'application:new-window')
-      'application:new-file': -> ipc.send('command', 'application:new-file')
-      'application:open': -> ipc.send('command', 'application:open')
-      'application:open-file': -> ipc.send('command', 'application:open-file')
-      'application:open-folder': -> ipc.send('command', 'application:open-folder')
-      'application:open-dev': -> ipc.send('command', 'application:open-dev')
-      'application:open-safe': -> ipc.send('command', 'application:open-safe')
-      'application:minimize': -> ipc.send('command', 'application:minimize')
-      'application:zoom': -> ipc.send('command', 'application:zoom')
-      'application:bring-all-windows-to-front': -> ipc.send('command', 'application:bring-all-windows-to-front')
-      'application:open-your-config': -> ipc.send('command', 'application:open-your-config')
-      'application:open-your-init-script': -> ipc.send('command', 'application:open-your-init-script')
-      'application:open-your-keymap': -> ipc.send('command', 'application:open-your-keymap')
-      'application:open-your-snippets': -> ipc.send('command', 'application:open-your-snippets')
-      'application:open-your-stylesheet': -> ipc.send('command', 'application:open-your-stylesheet')
-      'application:open-license': -> @getModel().openLicense()
-      'window:run-package-specs': -> ipc.send('run-package-specs', path.join(atom.project.getPath(), 'spec'))
-      'window:focus-next-pane': -> @getModel().activateNextPane()
-      'window:focus-previous-pane': -> @getModel().activatePreviousPane()
-      'window:focus-pane-above': -> @focusPaneViewAbove()
-      'window:focus-pane-below': -> @focusPaneViewBelow()
-      'window:focus-pane-on-left': -> @focusPaneViewOnLeft()
-      'window:focus-pane-on-right': -> @focusPaneViewOnRight()
-      'window:save-all': -> @getModel().saveAll()
-      'window:toggle-invisibles': -> atom.config.toggle("editor.showInvisibles")
-      'window:log-deprecation-warnings': -> Grim.logDeprecationWarnings()
-      'window:toggle-auto-indent': -> atom.config.toggle("editor.autoIndent")
-      'pane:reopen-closed-item': -> @getModel().reopenItem()
-      'core:close': -> @getModel().destroyActivePaneItemOrEmptyPane()
-      'core:save': -> @getModel().saveActivePaneItem()
-      'core:save-as': -> @getModel().saveActivePaneItemAs()
-    )
-
-    if process.platform is 'darwin'
-      addCommands 'window:install-shell-commands': -> @getModel().installShellCommands()
-
   getModel: -> @model
 
   setModel: (@model) ->
@@ -144,6 +90,54 @@ class WorkspaceElement extends HTMLElement
   focusPaneViewOnLeft: -> @paneContainer.focusPaneViewOnLeft()
 
   focusPaneViewOnRight: -> @paneContainer.focusPaneViewOnRight()
+
+atom.commands.add '.workspace',
+  'window:increase-font-size': -> @getModel().increaseFontSize()
+  'window:decrease-font-size': -> @getModel().decreaseFontSize()
+  'window:reset-font-size': -> @getModel().resetFontSize()
+  'application:about': -> ipc.send('command', 'application:about')
+  'application:run-all-specs': -> ipc.send('command', 'application:run-all-specs')
+  'application:run-benchmarks': -> ipc.send('command', 'application:run-benchmarks')
+  'application:show-settings': -> ipc.send('command', 'application:show-settings')
+  'application:quit': -> ipc.send('command', 'application:quit')
+  'application:hide': -> ipc.send('command', 'application:hide')
+  'application:hide-other-applications': -> ipc.send('command', 'application:hide-other-applications')
+  'application:install-update': -> ipc.send('command', 'application:install-update')
+  'application:unhide-all-applications': -> ipc.send('command', 'application:unhide-all-applications')
+  'application:new-window': -> ipc.send('command', 'application:new-window')
+  'application:new-file': -> ipc.send('command', 'application:new-file')
+  'application:open': -> ipc.send('command', 'application:open')
+  'application:open-file': -> ipc.send('command', 'application:open-file')
+  'application:open-folder': -> ipc.send('command', 'application:open-folder')
+  'application:open-dev': -> ipc.send('command', 'application:open-dev')
+  'application:open-safe': -> ipc.send('command', 'application:open-safe')
+  'application:minimize': -> ipc.send('command', 'application:minimize')
+  'application:zoom': -> ipc.send('command', 'application:zoom')
+  'application:bring-all-windows-to-front': -> ipc.send('command', 'application:bring-all-windows-to-front')
+  'application:open-your-config': -> ipc.send('command', 'application:open-your-config')
+  'application:open-your-init-script': -> ipc.send('command', 'application:open-your-init-script')
+  'application:open-your-keymap': -> ipc.send('command', 'application:open-your-keymap')
+  'application:open-your-snippets': -> ipc.send('command', 'application:open-your-snippets')
+  'application:open-your-stylesheet': -> ipc.send('command', 'application:open-your-stylesheet')
+  'application:open-license': -> @getModel().openLicense()
+  'window:run-package-specs': -> ipc.send('run-package-specs', path.join(atom.project.getPath(), 'spec'))
+  'window:focus-next-pane': -> @getModel().activateNextPane()
+  'window:focus-previous-pane': -> @getModel().activatePreviousPane()
+  'window:focus-pane-above': -> @focusPaneViewAbove()
+  'window:focus-pane-below': -> @focusPaneViewBelow()
+  'window:focus-pane-on-left': -> @focusPaneViewOnLeft()
+  'window:focus-pane-on-right': -> @focusPaneViewOnRight()
+  'window:save-all': -> @getModel().saveAll()
+  'window:toggle-invisibles': -> atom.config.toggle("editor.showInvisibles")
+  'window:log-deprecation-warnings': -> Grim.logDeprecationWarnings()
+  'window:toggle-auto-indent': -> atom.config.toggle("editor.autoIndent")
+  'pane:reopen-closed-item': -> @getModel().reopenItem()
+  'core:close': -> @getModel().destroyActivePaneItemOrEmptyPane()
+  'core:save': -> @getModel().saveActivePaneItem()
+  'core:save-as': -> @getModel().saveActivePaneItemAs()
+
+if process.platform is 'darwin'
+  atom.commands.add '.workspace', 'window:install-shell-commands', -> @getModel().installShellCommands()
 
 module.exports = WorkspaceElement = document.registerElement 'atom-workspace',
   prototype: WorkspaceElement.prototype


### PR DESCRIPTION
Closes #3731

This PR applies some surgical patching to jQuery so that commands registered with `atom.commands.add` integrate smoothly with jQuery event handlers registered with `$::on` and `$::command`. Now a jQuery handler can stop propagation to a command registry handler and vice-versa.
