### PR TITLE
Disable folding if isFoldEnabled config is false.

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "wrap-guide": "0.22.0",
     "language-c": "0.28.0",
     "language-coffee-script": "0.35.0",
-    "language-css": "0.18.0",
+    "language-css": "0.19.0",
     "language-gfm": "0.51.0",
     "language-git": "0.9.0",
     "language-go": "0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom",
   "productName": "Atom",
-  "version": "0.136.0",
+  "version": "0.137.0",
   "description": "A hackable text editor for the 21st Century.",
   "main": "./src/browser/main.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "language-source": "0.8.0",
     "language-sql": "0.11.0",
     "language-text": "0.6.0",
-    "language-todo": "0.12.0",
+    "language-todo": "0.13.0",
     "language-toml": "0.12.0",
     "language-xml": "0.22.0",
     "language-yaml": "0.18.0"

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -128,3 +128,7 @@ module.exports =
           cr:
             type: ['boolean', 'string']
             default: '\u00a4'
+      enableFolding:
+          type: 'boolean'
+          default: true
+          title: 'Enable Code Folding'

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -40,6 +40,7 @@ GutterComponent = React.createClass
     @lineNumberIdsByScreenRow = {}
     @screenRowsByLineNumberId = {}
     @renderedDecorationsByLineNumberId = {}
+    @observeConfig()
 
   componentDidMount: ->
     @appendDummyLineNumber()
@@ -234,3 +235,9 @@ GutterComponent = React.createClass
         editor.unfoldBufferRow(bufferRow)
       else
         editor.foldBufferRow(bufferRow)
+
+  observeConfig: ->
+    @subscribe atom.config.observe 'editor.enableFolding', @setEnableFolding
+
+  setEnableFolding: (enableFolding=true) ->
+    @updateLineNumbers() if @props.performedInitialMeasurement

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -185,6 +185,8 @@ class LanguageMode
   # foldable row range. Rows that are "foldable" have a fold icon next to their
   # icon in the gutter in the default configuration.
   isFoldableAtBufferRow: (bufferRow) ->
+    isFoldEnabled = editor.config.get('editor.isFoldEnabled')
+    return false if isFoldEnabled? and isFoldEnabled is false
     @isFoldableCodeAtBufferRow(bufferRow) or @isFoldableCommentAtBufferRow(bufferRow)
 
   # Returns a {Boolean} indicating whether the given buffer row starts

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -185,8 +185,8 @@ class LanguageMode
   # foldable row range. Rows that are "foldable" have a fold icon next to their
   # icon in the gutter in the default configuration.
   isFoldableAtBufferRow: (bufferRow) ->
-    isFoldEnabled = editor.config.get('editor.isFoldEnabled')
-    return false if isFoldEnabled? and isFoldEnabled is false
+    enableFolding = editor.config.get('editor.enableFolding')
+    return false if enableFolding? and enableFolding is false
     @isFoldableCodeAtBufferRow(bufferRow) or @isFoldableCommentAtBufferRow(bufferRow)
 
   # Returns a {Boolean} indicating whether the given buffer row starts

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -185,7 +185,7 @@ class LanguageMode
   # foldable row range. Rows that are "foldable" have a fold icon next to their
   # icon in the gutter in the default configuration.
   isFoldableAtBufferRow: (bufferRow) ->
-    enableFolding = editor.config.get('editor.enableFolding')
+    enableFolding = atom.config.get('editor.enableFolding')
     return false if enableFolding? and enableFolding is false
     @isFoldableCodeAtBufferRow(bufferRow) or @isFoldableCommentAtBufferRow(bufferRow)
 

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -528,6 +528,7 @@ TextEditorComponent = React.createClass
     @subscribe atom.config.observe 'editor.showLineNumbers', @setShowLineNumbers
     @subscribe atom.config.observe 'editor.scrollSensitivity', @setScrollSensitivity
     @subscribe atom.config.observe 'editor.useHardwareAcceleration', @setUseHardwareAcceleration
+    @subscribe atom.config.observe 'editor.enableFolding', @setEnableFolding
 
   onFocus: ->
     @refs.input.focus() if @isMounted()
@@ -1046,6 +1047,9 @@ TextEditorComponent = React.createClass
   setUseHardwareAcceleration: (useHardwareAcceleration=true) ->
     unless @useHardwareAcceleration is useHardwareAcceleration
       @useHardwareAcceleration = useHardwareAcceleration
+      @requestUpdate()
+
+  setEnableFolding: (enableFolding=true) ->
       @requestUpdate()
 
   screenPositionForMouseEvent: (event) ->

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -1050,6 +1050,8 @@ TextEditorComponent = React.createClass
       @requestUpdate()
 
   setEnableFolding: (enableFolding=true) ->
+      if not(enableFolding)
+        @props.editor.unfoldAll()
       @requestUpdate()
 
   screenPositionForMouseEvent: (event) ->


### PR DESCRIPTION
Allows the disabling of Code Folding. This attempts to solve Issue #3709.

This PR adds a config to check if folding is disabled.

Tasks:
- [x] Disable Code Folding in Gutter if config item is set to be disabled
- [ ] Disable/hide Folding menu if config item is set to be disabled
- [x] Add place to configure if folding is enabled or not - this can be added to users' config file.
- [ ] Add scoped configuration
- [ ] Ensure no other places enable folding...
