### PR TITLE
Allow pure custom element pane item views

### DIFF
--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -111,16 +111,9 @@ class PaneElement extends HTMLElement
     itemView.style.display = 'none'
 
   itemRemoved: ({item, index, destroyed}) ->
-    if item instanceof $
-      viewToRemove = item
-    else
-      viewToRemove = @model.getView(item).__spacePenView
-
-    if viewToRemove?
-      if destroyed
-        viewToRemove.remove()
-      else
-        viewToRemove.detach()
+    if viewToRemove = @model.getView(item)
+      callRemoveHooks(viewToRemove)
+      viewToRemove.remove()
 
   paneDestroyed: ->
     @subscriptions.dispose()


### PR DESCRIPTION
Status: PR ready for merge once we get a green build.

The workspace has already been converted to custom elements, but [`PaneElement::activeItemChanged`](https://github.com/atom/atom/blob/master/src/pane-element.coffee#L55) still expects all pane item views to have `.__spacePenView` shim properties and attaches, hides, and shows the views with jQuery. This needs to be converted to support raw custom elements that are attached, hidden, and shown via native DOM APIs. Whil doing this, it also still needs to support `afterAttach` and `beforeRemove` lifecycle hooks for any SpacePen wrappers for those elements. 
