### PR TITLE
Disable folding if enableFolding config is false.

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -131,5 +131,5 @@ module.exports =
       enableFolding:
         type: 'boolean'
         default: true
-        description: 'Enable Code Folding'
+        title: 'Enable Folding'
         

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -128,3 +128,8 @@ module.exports =
           cr:
             type: ['boolean', 'string']
             default: '\u00a4'
+      enableFolding:
+        type: 'boolean'
+        default: true
+        description: 'Enable Code Folding'
+        

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -40,6 +40,7 @@ GutterComponent = React.createClass
     @lineNumberIdsByScreenRow = {}
     @screenRowsByLineNumberId = {}
     @renderedDecorationsByLineNumberId = {}
+    @observeConfig()
 
   componentDidMount: ->
     @appendDummyLineNumber()
@@ -234,3 +235,9 @@ GutterComponent = React.createClass
         editor.unfoldBufferRow(bufferRow)
       else
         editor.foldBufferRow(bufferRow)
+
+  observeConfig: ->
+    @subscribe atom.config.observe 'editor.enableFolding', @setEnableFolding
+
+  setEnableFolding: (enableFolding=true) ->
+    @updateLineNumbers() if @props.performedInitialMeasurement

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -185,6 +185,8 @@ class LanguageMode
   # foldable row range. Rows that are "foldable" have a fold icon next to their
   # icon in the gutter in the default configuration.
   isFoldableAtBufferRow: (bufferRow) ->
+    enableFolding = atom.config.get('editor.enableFolding')
+    return false if enableFolding? and enableFolding is false
     @isFoldableCodeAtBufferRow(bufferRow) or @isFoldableCommentAtBufferRow(bufferRow)
 
   # Returns a {Boolean} indicating whether the given buffer row starts

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -1049,8 +1049,28 @@ TextEditorComponent = React.createClass
       @useHardwareAcceleration = useHardwareAcceleration
       @requestUpdate()
 
+  # Flattens the given menu template into an single Array.
+  #
+  # template - An object describing the menu item.
+  #
+  # Returns an Array of native menu items.
+  flattenMenuTemplate: (template) ->
+    items = []
+    for item in template
+      items.push(item)
+      items = items.concat(@flattenMenuTemplate(item.submenu)) if item.submenu
+    items
+
+  findMenuTemplateItem: (label) ->
+    for index, item of @flattenMenuTemplate(atom.menu.template)
+      return item if item.label is label
+
   setEnableFolding: (enableFolding=true) ->
     @props.editor.unfoldAll() if enableFolding is false
+    foldMenuItem = @findMenuTemplateItem("Folding")
+    if foldMenuItem?
+      foldMenuItem.enabled = enableFolding
+      atom.menu.update()
     @requestUpdate()
 
   screenPositionForMouseEvent: (event) ->

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -528,6 +528,7 @@ TextEditorComponent = React.createClass
     @subscribe atom.config.observe 'editor.showLineNumbers', @setShowLineNumbers
     @subscribe atom.config.observe 'editor.scrollSensitivity', @setScrollSensitivity
     @subscribe atom.config.observe 'editor.useHardwareAcceleration', @setUseHardwareAcceleration
+    @subscribe atom.config.observe 'editor.enableFolding', @setEnableFolding
 
   onFocus: ->
     @refs.input.focus() if @isMounted()
@@ -1047,6 +1048,10 @@ TextEditorComponent = React.createClass
     unless @useHardwareAcceleration is useHardwareAcceleration
       @useHardwareAcceleration = useHardwareAcceleration
       @requestUpdate()
+
+  setEnableFolding: (enableFolding=true) ->
+    @props.editor.unfoldAll() if enableFolding is false
+    @requestUpdate()
 
   screenPositionForMouseEvent: (event) ->
     pixelPosition = @pixelPositionForMouseEvent(event)


### PR DESCRIPTION
(This replaces previous PR #3740).

Allows the disabling of Code Folding. This attempts to solve Issue #3709.

This PR adds a config to check if folding is disabled.

Tasks:
- [x] Disable Code Folding in Gutter if config item is set to be disabled (and unfold all when disabled to show all code)
- [x] Add place to configure if folding is enabled or not - this can be added to users' config file (added to config-schema)
- [x] Ensure no other places enable folding...
- [x] Disable/hide Folding menu if config item is set to be disabled
- [ ] Add scoped configuration
- [ ] Add specs
