### PR TITLE
Warn new users we are using a little known format (cson), not the more popular json doc notation.

### DIFF
--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -19,3 +19,5 @@
 # You can find more information about keymaps in these guides:
 # * https://atom.io/docs/latest/customizing-atom#customizing-key-bindings
 # * https://atom.io/docs/latest/advanced/keymaps
+#
+# Bindings not working? Be aware that son follows CoffeeScript notation with differs with json. 

--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -20,4 +20,4 @@
 # * https://atom.io/docs/latest/customizing-atom#customizing-key-bindings
 # * https://atom.io/docs/latest/advanced/keymaps
 #
-# Bindings not working? Be aware that son follows CoffeeScript notation with differs with json. 
+# Bindings not working? Be aware that cson follows CoffeeScript notation with differs with json. 

--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -20,4 +20,4 @@
 # * https://atom.io/docs/latest/customizing-atom#customizing-key-bindings
 # * https://atom.io/docs/latest/advanced/keymaps
 #
-# Bindings not working? Be aware that cson follows CoffeeScript notation with differs with json. 
+# Bindings not working? Be aware that cson follows CoffeeScript notation with differs from json. 


### PR DESCRIPTION
improper trailing and leading spaces can cause your bindings to fail.Since cson has very little adoption relative to json, I think it's important to warn new users that they need to understand CoffeeScript notation or else a single space could break their file. I spent one full hour today trying to get an auto-indent mapping to work. The solution involved adding one leading space!
