### PR TITLE
Speedup scoped config

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "reactionary-atom-fork": "^1.0.0",
     "runas": "1.0.1",
     "scandal": "1.0.2",
-    "scoped-property-store": "^0.13.1",
+    "scoped-property-store": "^0.13.2",
     "scrollbar-style": "^1.0.2",
     "season": "^1.0.2",
     "semver": "1.1.4",

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -441,7 +441,9 @@ class Config
   # file in the type specified by the configuration schema.
   get: (scopeDescriptor, keyPath) ->
     if arguments.length == 1
-      @getRawValue(scopeDescriptor)
+      # cannot assign to keyPath for the sake of v8 optimization 
+      globalKeyPath = scopeDescriptor
+      @getRawValue(globalKeyPath)
     else
       value = @getRawScopedValue(scopeDescriptor, keyPath)
       value ?= @getRawValue(keyPath)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -441,7 +441,7 @@ class Config
   # file in the type specified by the configuration schema.
   get: (scopeDescriptor, keyPath) ->
     if arguments.length == 1
-      # cannot assign to keyPath for the sake of v8 optimization 
+      # cannot assign to keyPath for the sake of v8 optimization
       globalKeyPath = scopeDescriptor
       @getRawValue(globalKeyPath)
     else

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -441,14 +441,11 @@ class Config
   # file in the type specified by the configuration schema.
   get: (scopeDescriptor, keyPath) ->
     if arguments.length == 1
-      keyPath = scopeDescriptor
-      scopeDescriptor = undefined
-
-    if scopeDescriptor?
+      @getRawValue(scopeDescriptor)
+    else
       value = @getRawScopedValue(scopeDescriptor, keyPath)
-      return value if value?
-
-    @getRawValue(keyPath)
+      value ?= @getRawValue(keyPath)
+      value
 
   # Essential: Sets the value for a configuration setting.
   #

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -82,12 +82,16 @@ class TokenizedBuffer extends Model
     @grammarScopeDescriptor = [@grammar.scopeName]
     @currentGrammarScore = score ? grammar.getScore(@buffer.getPath(), @buffer.getText())
     @subscribe @grammar.onDidUpdate => @retokenizeLines()
-    @retokenizeLines()
+
+    @configSettings = tabLength: atom.config.get(@grammarScopeDescriptor, 'editor.tabLength')
 
     @grammarTabLengthSubscription?.dispose()
-    @grammarTabLengthSubscription = atom.config.onDidChange @grammarScopeDescriptor, 'editor.tabLength', =>
+    @grammarTabLengthSubscription = atom.config.onDidChange @grammarScopeDescriptor, 'editor.tabLength', ({newValue}) =>
+      @configSettings.tabLength = newValue
       @retokenizeLines()
     @subscribe @grammarTabLengthSubscription
+
+    @retokenizeLines()
 
     @emit 'grammar-changed', grammar
     @emitter.emit 'did-change-grammar', grammar
@@ -118,7 +122,7 @@ class TokenizedBuffer extends Model
     @tokenizeInBackground() if @visible
 
   getTabLength: ->
-    @tabLength ? atom.config.get(@grammarScopeDescriptor, 'editor.tabLength')
+    @tabLength ? @configSettings.tabLength
 
   setTabLength: (@tabLength) ->
     @retokenizeLines()


### PR DESCRIPTION
Turns out `atom.config.get()` is called a ton when rendering the editor. This pull fixed some of it: https://github.com/atom/scoped-property-store/pull/4

But it was still noticeably slower when opening a tab. Here are some profiles:

Before:
![screen shot 2014-10-10 at 12 33 45 pm](https://cloud.githubusercontent.com/assets/69169/4619076/f477ef64-5310-11e4-87bd-5df284015c60.png)

After. No more config junk at the top of the list
![screen shot 2014-10-13 at 12 35 03 pm](https://cloud.githubusercontent.com/assets/69169/4619086/013be066-5311-11e4-9acf-8c359f092450.png)

It also feels much better.
