### PR TITLE
Replaced xcopy with robocopy

### DIFF
--- a/script/copy-folder.cmd
+++ b/script/copy-folder.cmd
@@ -15,4 +15,4 @@ if [%2] == [] (
 if exist %2 rmdir %2 /s /q
 
 :: cp -rf %1 %2
-xcopy %1 %2 /e /h /c /i /y /r
+(robocopy %1 %2 /e) ^& IF %ERRORLEVEL% LEQ 1 exit 0


### PR DESCRIPTION
xcopy [doesn't handle paths longer than 254 characters](http://www.terminally-incoherent.com/blog/2007/02/05/xcopy-insufficient-memory/) and it's recommended to use [robocopy](http://technet.microsoft.com/en-us/library/cc733145.aspx) (available on Windows 7, Windows 8, Windows Server 2008, Windows Server 2008 R2, Windows Server 2012) instead.
