### PR TITLE
Extract style manager from theme manager

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -74,6 +74,7 @@ beforeEach ->
   atom.workspace = new Workspace()
   atom.keymaps.keyBindings = _.clone(keyBindingsToRestore)
   atom.commands.restoreSnapshot(commandsToRestore)
+  atom.styles.clear()
 
   window.resetTimeouts()
   atom.packages.packageStates = {}

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -29,6 +29,7 @@ atom.packages.packageDirPaths.unshift(fixturePackagesPath)
 atom.keymaps.loadBundledKeymaps()
 keyBindingsToRestore = atom.keymaps.getKeyBindings()
 commandsToRestore = atom.commands.getSnapshot()
+styleElementsToRestore = atom.styles.getSnapshot()
 
 window.addEventListener 'core:close', -> window.close()
 window.addEventListener 'beforeunload', ->
@@ -74,7 +75,7 @@ beforeEach ->
   atom.workspace = new Workspace()
   atom.keymaps.keyBindings = _.clone(keyBindingsToRestore)
   atom.commands.restoreSnapshot(commandsToRestore)
-  atom.styles.clear()
+  atom.styles.restoreSnapshot(styleElementsToRestore)
 
   window.resetTimeouts()
   atom.packages.packageStates = {}

--- a/spec/style-manager-spec.coffee
+++ b/spec/style-manager-spec.coffee
@@ -1,28 +1,24 @@
 StyleManager = require '../src/style-manager'
 
 describe "StyleManager", ->
-  manager = null
+  [manager, addEvents, removeEvents, updateEvents] = []
 
   beforeEach ->
     manager = new StyleManager
+    addEvents = []
+    removeEvents = []
+    updateEvents = []
+
+    manager.onDidAddStyleElement (event) -> addEvents.push(event)
+    manager.onDidRemoveStyleElement (event) -> removeEvents.push(event)
+    manager.onDidUpdateStyleElement (event) -> updateEvents.push(event)
 
   describe "::addStyleSheet(source, params)", ->
-    [addEvents, removeEvents, updateEvents] = []
-
-    beforeEach ->
-      addEvents = []
-      removeEvents = []
-      updateEvents = []
-
-      manager.onDidAddStyleSheet (event) -> addEvents.push(event)
-      manager.onDidRemoveStyleSheet (event) -> removeEvents.push(event)
-      manager.onDidUpdateStyleSheet (event) -> updateEvents.push(event)
-
     it "adds a stylesheet based on the given source and returns a disposable allowing it to be removed", ->
       disposable = manager.addStyleSheet("a {color: red;}")
 
       expect(addEvents.length).toBe 1
-      expect(addEvents[0].styleElement.textContent).toBe "a {color: red;}"
+      expect(addEvents[0].textContent).toBe "a {color: red;}"
 
       styleElements = manager.getStyleElements()
       expect(styleElements.length).toBe 1
@@ -31,7 +27,7 @@ describe "StyleManager", ->
       disposable.dispose()
 
       expect(removeEvents.length).toBe 1
-      expect(removeEvents[0].styleElement.textContent).toBe "a {color: red;}"
+      expect(removeEvents[0].textContent).toBe "a {color: red;}"
       expect(manager.getStyleElements().length).toBe 0
 
     describe "when a sourcePath parameter is specified", ->
@@ -46,7 +42,7 @@ describe "StyleManager", ->
         expect(addEvents.length).toBe 1
         expect(updateEvents.length).toBe 1
         expect(updateEvents[0].sourcePath).toBe '/foo/bar'
-        expect(updateEvents[0].styleElement.textContent).toBe "a {color: blue;}"
+        expect(updateEvents[0].textContent).toBe "a {color: blue;}"
 
         disposable2.dispose()
         addEvents = []
@@ -55,7 +51,7 @@ describe "StyleManager", ->
 
         expect(addEvents.length).toBe 1
         expect(addEvents[0].sourcePath).toBe '/foo/bar'
-        expect(addEvents[0].styleElement.textContent).toBe "a {color: yellow;}"
+        expect(addEvents[0].textContent).toBe "a {color: yellow;}"
 
     describe "when a group parameter is specified", ->
       it "inserts the stylesheet at the end of any existing stylesheets for the same group", ->

--- a/spec/style-manager-spec.coffee
+++ b/spec/style-manager-spec.coffee
@@ -35,13 +35,13 @@ describe "StyleManager", ->
         disposable1 = manager.addStyleSheet("a {color: red;}", sourcePath: '/foo/bar')
 
         expect(addEvents.length).toBe 1
-        expect(addEvents[0].sourcePath).toBe '/foo/bar'
+        expect(addEvents[0].getAttribute('source-path')).toBe '/foo/bar'
 
         disposable2 = manager.addStyleSheet("a {color: blue;}", sourcePath: '/foo/bar')
 
         expect(addEvents.length).toBe 1
         expect(updateEvents.length).toBe 1
-        expect(updateEvents[0].sourcePath).toBe '/foo/bar'
+        expect(updateEvents[0].getAttribute('source-path')).toBe '/foo/bar'
         expect(updateEvents[0].textContent).toBe "a {color: blue;}"
 
         disposable2.dispose()
@@ -50,7 +50,7 @@ describe "StyleManager", ->
         manager.addStyleSheet("a {color: yellow;}", sourcePath: '/foo/bar')
 
         expect(addEvents.length).toBe 1
-        expect(addEvents[0].sourcePath).toBe '/foo/bar'
+        expect(addEvents[0].getAttribute('source-path')).toBe '/foo/bar'
         expect(addEvents[0].textContent).toBe "a {color: yellow;}"
 
     describe "when a group parameter is specified", ->

--- a/spec/style-manager-spec.coffee
+++ b/spec/style-manager-spec.coffee
@@ -1,0 +1,29 @@
+StyleManager = require '../src/style-manager'
+
+describe "StyleManager", ->
+  manager = null
+
+  beforeEach ->
+    manager = new StyleManager
+
+  describe "::addStyleSheet(source, params)", ->
+    it "adds a stylesheet based on the given source and returns a disposable allowing it to be removed", ->
+      addEvents = []
+      removeEvents = []
+      manager.onDidAddStyleSheet (event) -> addEvents.push(event)
+      manager.onDidRemoveStyleSheet (event) -> removeEvents.push(event)
+
+      disposable = manager.addStyleSheet("a {color: red;}")
+
+      expect(addEvents.length).toBe 1
+      expect(addEvents[0].styleElement.textContent).toBe "a {color: red;}"
+
+      styleElements = manager.getStyleElements()
+      expect(styleElements.length).toBe 1
+      expect(styleElements[0].textContent).toBe "a {color: red;}"
+
+      disposable.dispose()
+
+      expect(removeEvents.length).toBe 1
+      expect(removeEvents[0].styleElement.textContent).toBe "a {color: red;}"
+      expect(manager.getStyleElements().length).toBe 0

--- a/spec/style-manager-spec.coffee
+++ b/spec/style-manager-spec.coffee
@@ -56,3 +56,15 @@ describe "StyleManager", ->
         expect(addEvents.length).toBe 1
         expect(addEvents[0].sourcePath).toBe '/foo/bar'
         expect(addEvents[0].styleElement.textContent).toBe "a {color: yellow;}"
+
+    describe "when a group parameter is specified", ->
+      it "inserts the stylesheet at the end of any existing stylesheets for the same group", ->
+        manager.addStyleSheet("a {color: red}", group: 'a')
+        manager.addStyleSheet("a {color: blue}", group: 'b')
+        manager.addStyleSheet("a {color: green}", group: 'a')
+
+        expect(manager.getStyleElements().map (elt) -> elt.textContent).toEqual [
+          "a {color: red}"
+          "a {color: green}"
+          "a {color: blue}"
+        ]

--- a/spec/style-manager-spec.coffee
+++ b/spec/style-manager-spec.coffee
@@ -7,12 +7,18 @@ describe "StyleManager", ->
     manager = new StyleManager
 
   describe "::addStyleSheet(source, params)", ->
-    it "adds a stylesheet based on the given source and returns a disposable allowing it to be removed", ->
+    [addEvents, removeEvents, updateEvents] = []
+
+    beforeEach ->
       addEvents = []
       removeEvents = []
+      updateEvents = []
+
       manager.onDidAddStyleSheet (event) -> addEvents.push(event)
       manager.onDidRemoveStyleSheet (event) -> removeEvents.push(event)
+      manager.onDidUpdateStyleSheet (event) -> updateEvents.push(event)
 
+    it "adds a stylesheet based on the given source and returns a disposable allowing it to be removed", ->
       disposable = manager.addStyleSheet("a {color: red;}")
 
       expect(addEvents.length).toBe 1
@@ -27,3 +33,26 @@ describe "StyleManager", ->
       expect(removeEvents.length).toBe 1
       expect(removeEvents[0].styleElement.textContent).toBe "a {color: red;}"
       expect(manager.getStyleElements().length).toBe 0
+
+    describe "when a sourcePath parameter is specified", ->
+      it "ensures a maximum of one style element for the given source path, updating a previous if it exists", ->
+        disposable1 = manager.addStyleSheet("a {color: red;}", sourcePath: '/foo/bar')
+
+        expect(addEvents.length).toBe 1
+        expect(addEvents[0].sourcePath).toBe '/foo/bar'
+
+        disposable2 = manager.addStyleSheet("a {color: blue;}", sourcePath: '/foo/bar')
+
+        expect(addEvents.length).toBe 1
+        expect(updateEvents.length).toBe 1
+        expect(updateEvents[0].sourcePath).toBe '/foo/bar'
+        expect(updateEvents[0].styleElement.textContent).toBe "a {color: blue;}"
+
+        disposable2.dispose()
+        addEvents = []
+
+        manager.addStyleSheet("a {color: yellow;}", sourcePath: '/foo/bar')
+
+        expect(addEvents.length).toBe 1
+        expect(addEvents[0].sourcePath).toBe '/foo/bar'
+        expect(addEvents[0].styleElement.textContent).toBe "a {color: yellow;}"

--- a/spec/styles-element-spec.coffee
+++ b/spec/styles-element-spec.coffee
@@ -2,15 +2,17 @@ StylesElement = require '../src/styles-element'
 StyleManager = require '../src/style-manager'
 
 describe "StylesElement", ->
-  [element, addedStyleElements, removedStyleElements] = []
+  [element, addedStyleElements, removedStyleElements, updatedStyleElements] = []
 
   beforeEach ->
     element = new StylesElement
     document.querySelector('#jasmine-content').appendChild(element)
     addedStyleElements = []
     removedStyleElements = []
+    updatedStyleElements = []
     element.onDidAddStyleElement (element) -> addedStyleElements.push(element)
     element.onDidRemoveStyleElement (element) -> removedStyleElements.push(element)
+    element.onDidUpdateStyleElement (element) -> updatedStyleElements.push(element)
 
   it "renders a style tag for all currently active stylesheets in the style manager", ->
     initialChildCount = element.children.length
@@ -40,3 +42,13 @@ describe "StylesElement", ->
     expect(element.children[initialChildCount].textContent).toBe "a {color: red}"
     expect(element.children[initialChildCount + 1].textContent).toBe "a {color: green}"
     expect(element.children[initialChildCount + 2].textContent).toBe "a {color: blue}"
+
+  it "updates existing style nodes when style elements are updated", ->
+    initialChildCount = element.children.length
+
+    atom.styles.addStyleSheet("a {color: red;}", sourcePath: '/foo/bar')
+    atom.styles.addStyleSheet("a {color: blue;}", sourcePath: '/foo/bar')
+
+    expect(element.children.length).toBe initialChildCount + 1
+    expect(element.children[initialChildCount].textContent).toBe "a {color: blue;}"
+    expect(updatedStyleElements).toEqual [element.children[initialChildCount]]

--- a/spec/styles-element-spec.coffee
+++ b/spec/styles-element-spec.coffee
@@ -9,27 +9,27 @@ describe "StylesElement", ->
     document.querySelector('#jasmine-content').appendChild(element)
 
   it "renders a style tag for all currently active stylesheets in the style manager", ->
-    expect(element.children.length).toBe 0
+    initialChildCount = element.children.length
 
     disposable1 = atom.styles.addStyleSheet("a {color: red;}")
-    expect(element.children.length).toBe 1
-    expect(element.children[0].textContent).toBe "a {color: red;}"
+    expect(element.children.length).toBe initialChildCount + 1
+    expect(element.children[initialChildCount].textContent).toBe "a {color: red;}"
 
     disposable2 = atom.styles.addStyleSheet("a {color: blue;}")
-    expect(element.children.length).toBe 2
-    expect(element.children[1].textContent).toBe "a {color: blue;}"
+    expect(element.children.length).toBe initialChildCount + 2
+    expect(element.children[initialChildCount + 1].textContent).toBe "a {color: blue;}"
 
     disposable1.dispose()
-    expect(element.children.length).toBe 1
-    expect(element.children[0].textContent).toBe "a {color: blue;}"
+    expect(element.children.length).toBe initialChildCount + 1
+    expect(element.children[initialChildCount].textContent).toBe "a {color: blue;}"
 
   it "orders style elements by group", ->
-    expect(element.children.length).toBe 0
+    initialChildCount = element.children.length
 
     atom.styles.addStyleSheet("a {color: red}", group: 'a')
     atom.styles.addStyleSheet("a {color: blue}", group: 'b')
     atom.styles.addStyleSheet("a {color: green}", group: 'a')
 
-    expect(element.children[0].textContent).toBe "a {color: red}"
-    expect(element.children[1].textContent).toBe "a {color: green}"
-    expect(element.children[2].textContent).toBe "a {color: blue}"
+    expect(element.children[initialChildCount].textContent).toBe "a {color: red}"
+    expect(element.children[initialChildCount + 1].textContent).toBe "a {color: green}"
+    expect(element.children[initialChildCount + 2].textContent).toBe "a {color: blue}"

--- a/spec/styles-element-spec.coffee
+++ b/spec/styles-element-spec.coffee
@@ -2,11 +2,15 @@ StylesElement = require '../src/styles-element'
 StyleManager = require '../src/style-manager'
 
 describe "StylesElement", ->
-  element = null
+  [element, addedStyleElements, removedStyleElements] = []
 
   beforeEach ->
     element = new StylesElement
     document.querySelector('#jasmine-content').appendChild(element)
+    addedStyleElements = []
+    removedStyleElements = []
+    element.onDidAddStyleElement (element) -> addedStyleElements.push(element)
+    element.onDidRemoveStyleElement (element) -> removedStyleElements.push(element)
 
   it "renders a style tag for all currently active stylesheets in the style manager", ->
     initialChildCount = element.children.length
@@ -14,14 +18,17 @@ describe "StylesElement", ->
     disposable1 = atom.styles.addStyleSheet("a {color: red;}")
     expect(element.children.length).toBe initialChildCount + 1
     expect(element.children[initialChildCount].textContent).toBe "a {color: red;}"
+    expect(addedStyleElements).toEqual [element.children[initialChildCount]]
 
     disposable2 = atom.styles.addStyleSheet("a {color: blue;}")
     expect(element.children.length).toBe initialChildCount + 2
     expect(element.children[initialChildCount + 1].textContent).toBe "a {color: blue;}"
+    expect(addedStyleElements).toEqual [element.children[initialChildCount], element.children[initialChildCount + 1]]
 
     disposable1.dispose()
     expect(element.children.length).toBe initialChildCount + 1
     expect(element.children[initialChildCount].textContent).toBe "a {color: blue;}"
+    expect(removedStyleElements).toEqual [addedStyleElements[0]]
 
   it "orders style elements by group", ->
     initialChildCount = element.children.length

--- a/spec/styles-element-spec.coffee
+++ b/spec/styles-element-spec.coffee
@@ -1,0 +1,35 @@
+StylesElement = require '../src/styles-element'
+StyleManager = require '../src/style-manager'
+
+describe "StylesElement", ->
+  element = null
+
+  beforeEach ->
+    element = new StylesElement
+    document.querySelector('#jasmine-content').appendChild(element)
+
+  it "renders a style tag for all currently active stylesheets in the style manager", ->
+    expect(element.children.length).toBe 0
+
+    disposable1 = atom.styles.addStyleSheet("a {color: red;}")
+    expect(element.children.length).toBe 1
+    expect(element.children[0].textContent).toBe "a {color: red;}"
+
+    disposable2 = atom.styles.addStyleSheet("a {color: blue;}")
+    expect(element.children.length).toBe 2
+    expect(element.children[1].textContent).toBe "a {color: blue;}"
+
+    disposable1.dispose()
+    expect(element.children.length).toBe 1
+    expect(element.children[0].textContent).toBe "a {color: blue;}"
+
+  it "orders style elements by group", ->
+    expect(element.children.length).toBe 0
+
+    atom.styles.addStyleSheet("a {color: red}", group: 'a')
+    atom.styles.addStyleSheet("a {color: blue}", group: 'b')
+    atom.styles.addStyleSheet("a {color: green}", group: 'a')
+
+    expect(element.children[0].textContent).toBe "a {color: red}"
+    expect(element.children[1].textContent).toBe "a {color: green}"
+    expect(element.children[2].textContent).toBe "a {color: blue}"

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -92,8 +92,8 @@ describe "ThemeManager", ->
 
       runs ->
         reloadHandler.reset()
-        expect($('style.theme')).toHaveLength 1
-        expect($('style.theme:eq(0)').attr('id')).toMatch /atom-dark-syntax/
+        expect($('style[group=theme]')).toHaveLength 1
+        expect($('style[group=theme]:eq(0)').attr('source-path')).toMatch /atom-dark-syntax/
         atom.config.set('core.themes', ['atom-light-syntax', 'atom-dark-syntax'])
 
       waitsFor ->
@@ -101,9 +101,9 @@ describe "ThemeManager", ->
 
       runs ->
         reloadHandler.reset()
-        expect($('style.theme')).toHaveLength 2
-        expect($('style.theme:eq(0)').attr('id')).toMatch /atom-dark-syntax/
-        expect($('style.theme:eq(1)').attr('id')).toMatch /atom-light-syntax/
+        expect($('style[group=theme]')).toHaveLength 2
+        expect($('style[group=theme]:eq(0)').attr('source-path')).toMatch /atom-dark-syntax/
+        expect($('style[group=theme]:eq(1)').attr('source-path')).toMatch /atom-light-syntax/
         atom.config.set('core.themes', [])
 
       waitsFor ->
@@ -111,7 +111,7 @@ describe "ThemeManager", ->
 
       runs ->
         reloadHandler.reset()
-        expect($('style.theme')).toHaveLength 0
+        expect($('style[group=theme]')).toHaveLength 0
         # atom-dark-ui has an directory path, the syntax one doesn't
         atom.config.set('core.themes', ['theme-with-index-less', 'atom-dark-ui'])
 
@@ -119,7 +119,7 @@ describe "ThemeManager", ->
         reloadHandler.callCount == 1
 
       runs ->
-        expect($('style.theme')).toHaveLength 2
+        expect($('style[group=theme]')).toHaveLength 2
         importPaths = themeManager.getImportPaths()
         expect(importPaths.length).toBe 1
         expect(importPaths[0]).toContain 'atom-dark-ui'
@@ -142,8 +142,8 @@ describe "ThemeManager", ->
       expect(stylesheetAddedHandler).toHaveBeenCalled()
       expect(stylesheetsChangedHandler).toHaveBeenCalled()
 
-      element = $('head style[id*="css.css"]')
-      expect(element.attr('id')).toBe themeManager.stringToId(cssPath)
+      element = $('head style[source-path*="css.css"]')
+      expect(element.attr('source-path')).toBe themeManager.stringToId(cssPath)
       expect(element.text()).toBe fs.readFileSync(cssPath, 'utf8')
       expect(element[0].sheet).toBe stylesheetAddedHandler.argsForCall[0][0]
 
@@ -159,8 +159,8 @@ describe "ThemeManager", ->
       themeManager.requireStylesheet(lessPath)
       expect($('head style').length).toBe lengthBefore + 1
 
-      element = $('head style[id*="sample.less"]')
-      expect(element.attr('id')).toBe themeManager.stringToId(lessPath)
+      element = $('head style[source-path*="sample.less"]')
+      expect(element.attr('source-path')).toBe themeManager.stringToId(lessPath)
       expect(element.text()).toBe """
       #header {
         color: #4d926f;
@@ -178,9 +178,9 @@ describe "ThemeManager", ->
 
     it "supports requiring css and less stylesheets without an explicit extension", ->
       themeManager.requireStylesheet path.join(__dirname, 'fixtures', 'css')
-      expect($('head style[id*="css.css"]').attr('id')).toBe themeManager.stringToId(atom.project.resolve('css.css'))
+      expect($('head style[source-path*="css.css"]').attr('source-path')).toBe themeManager.stringToId(atom.project.resolve('css.css'))
       themeManager.requireStylesheet path.join(__dirname, 'fixtures', 'sample')
-      expect($('head style[id*="sample.less"]').attr('id')).toBe themeManager.stringToId(atom.project.resolve('sample.less'))
+      expect($('head style[source-path*="sample.less"]').attr('source-path')).toBe themeManager.stringToId(atom.project.resolve('sample.less'))
 
       $('head style[id*="css.css"]').remove()
       $('head style[id*="sample.less"]').remove()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -14,6 +14,7 @@ fs = require 'fs-plus'
 
 {$} = require './space-pen-extensions'
 WindowEventHandler = require './window-event-handler'
+StylesElement = require './styles-element'
 
 # Essential: Atom global for dealing with packages, themes, menus, and the window.
 #
@@ -202,8 +203,8 @@ class Atom extends Model
     @keymap = @keymaps # Deprecated
     @commands = new CommandRegistry
     @packages = new PackageManager({devMode, configDirPath, resourcePath, safeMode})
+    @styles = new StyleManager
     @themes = new ThemeManager({packageManager: @packages, configDirPath, resourcePath, safeMode})
-    @styles = new StyleManager({resourcePath})
     @contextMenu = new ContextMenuManager({resourcePath, devMode})
     @menu = new MenuManager({resourcePath})
     @clipboard = new Clipboard()
@@ -220,6 +221,8 @@ class Atom extends Model
     TextEditor = require './text-editor'
 
     @windowEventHandler = new WindowEventHandler
+
+    document.head.appendChild(new StylesElement)
 
   ###
   Section: Event Subscription

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -204,6 +204,7 @@ class Atom extends Model
     @commands = new CommandRegistry
     @packages = new PackageManager({devMode, configDirPath, resourcePath, safeMode})
     @styles = new StyleManager
+    document.head.appendChild(new StylesElement)
     @themes = new ThemeManager({packageManager: @packages, configDirPath, resourcePath, safeMode})
     @contextMenu = new ContextMenuManager({resourcePath, devMode})
     @menu = new MenuManager({resourcePath})
@@ -221,8 +222,6 @@ class Atom extends Model
     TextEditor = require './text-editor'
 
     @windowEventHandler = new WindowEventHandler
-
-    document.head.appendChild(new StylesElement)
 
   ###
   Section: Event Subscription

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -182,6 +182,7 @@ class Atom extends Model
     Clipboard = require './clipboard'
     Syntax = require './syntax'
     ThemeManager = require './theme-manager'
+    StyleManager = require './style-manager'
     ContextMenuManager = require './context-menu-manager'
     MenuManager = require './menu-manager'
     {devMode, safeMode, resourcePath} = @getLoadSettings()
@@ -202,6 +203,7 @@ class Atom extends Model
     @commands = new CommandRegistry
     @packages = new PackageManager({devMode, configDirPath, resourcePath, safeMode})
     @themes = new ThemeManager({packageManager: @packages, configDirPath, resourcePath, safeMode})
+    @styles = new StyleManager({resourcePath})
     @contextMenu = new ContextMenuManager({resourcePath, devMode})
     @menu = new MenuManager({resourcePath})
     @clipboard = new Clipboard()

--- a/src/style-manager.coffee
+++ b/src/style-manager.coffee
@@ -5,6 +5,7 @@ class StyleManager
   constructor: ->
     @emitter = new Emitter
     @styleElements = []
+    @styleElementsBySourcePath = {}
 
   onDidAddStyleSheet: (callback) ->
     @emitter.on 'did-add-style-sheet', callback
@@ -12,19 +13,35 @@ class StyleManager
   onDidRemoveStyleSheet: (callback) ->
     @emitter.on 'did-remove-style-sheet', callback
 
+  onDidUpdateStyleSheet: (callback) ->
+    @emitter.on 'did-update-style-sheet', callback
+
   getStyleElements: ->
     @styleElements.slice()
 
-  addStyleSheet: (source) ->
-    styleElement = document.createElement('style')
+  addStyleSheet: (source, params) ->
+    sourcePath = params?.sourcePath
+    if sourcePath? and styleElement = @styleElementsBySourcePath[sourcePath]
+      updated = true
+    else
+      styleElement = document.createElement('style')
+
     styleElement.textContent = source
+
     @styleElements.push(styleElement)
-    @emitter.emit 'did-add-style-sheet', {styleElement}
+    @styleElementsBySourcePath[sourcePath] ?= styleElement if sourcePath?
 
-    new Disposable => @removeStyleElement(styleElement)
+    if updated
+      @emitter.emit 'did-update-style-sheet', {styleElement, sourcePath}
+    else
+      @emitter.emit 'did-add-style-sheet', {styleElement, sourcePath}
 
-  removeStyleElement: (styleElement) ->
+    new Disposable => @removeStyleElement(styleElement, params)
+
+  removeStyleElement: (styleElement, params) ->
     index = @styleElements.indexOf(styleElement)
     unless index is -1
       @styleElements.splice(index, 1)
+      sourcePath = params?.sourcePath
+      delete @styleElementsBySourcePath[sourcePath] if sourcePath?
       @emitter.emit 'did-remove-style-sheet', {styleElement}

--- a/src/style-manager.coffee
+++ b/src/style-manager.coffee
@@ -21,20 +21,31 @@ class StyleManager
 
   addStyleSheet: (source, params) ->
     sourcePath = params?.sourcePath
+    group = params?.group
+
     if sourcePath? and styleElement = @styleElementsBySourcePath[sourcePath]
       updated = true
     else
       styleElement = document.createElement('style')
+      styleElement.group = group if group?
 
     styleElement.textContent = source
 
-    @styleElements.push(styleElement)
+    if group?
+      for existingElement, index in @styleElements
+        if existingElement.group is group
+          insertIndex = index + 1
+        else
+          break if insertIndex?
+    insertIndex ?= @styleElements.length
+
+    @styleElements.splice(insertIndex, 0, styleElement)
     @styleElementsBySourcePath[sourcePath] ?= styleElement if sourcePath?
 
     if updated
-      @emitter.emit 'did-update-style-sheet', {styleElement, sourcePath}
+      @emitter.emit 'did-update-style-sheet', {styleElement, sourcePath, group}
     else
-      @emitter.emit 'did-add-style-sheet', {styleElement, sourcePath}
+      @emitter.emit 'did-add-style-sheet', {styleElement, sourcePath, group}
 
     new Disposable => @removeStyleElement(styleElement, params)
 

--- a/src/style-manager.coffee
+++ b/src/style-manager.coffee
@@ -7,14 +7,18 @@ class StyleManager
     @styleElements = []
     @styleElementsBySourcePath = {}
 
-  onDidAddStyleSheet: (callback) ->
-    @emitter.on 'did-add-style-sheet', callback
+  observeStyleElements: (callback) ->
+    callback(styleElement) for styleElement in @getStyleElements()
+    @onDidAddStyleElement(callback)
 
-  onDidRemoveStyleSheet: (callback) ->
-    @emitter.on 'did-remove-style-sheet', callback
+  onDidAddStyleElement: (callback) ->
+    @emitter.on 'did-add-style-element', callback
 
-  onDidUpdateStyleSheet: (callback) ->
-    @emitter.on 'did-update-style-sheet', callback
+  onDidRemoveStyleElement: (callback) ->
+    @emitter.on 'did-remove-style-element', callback
+
+  onDidUpdateStyleElement: (callback) ->
+    @emitter.on 'did-update-style-element', callback
 
   getStyleElements: ->
     @styleElements.slice()
@@ -27,6 +31,7 @@ class StyleManager
       updated = true
     else
       styleElement = document.createElement('style')
+      styleElement.sourcePath = sourcePath if sourcePath?
       styleElement.group = group if group?
 
     styleElement.textContent = source
@@ -43,9 +48,9 @@ class StyleManager
     @styleElementsBySourcePath[sourcePath] ?= styleElement if sourcePath?
 
     if updated
-      @emitter.emit 'did-update-style-sheet', {styleElement, sourcePath, group}
+      @emitter.emit 'did-update-style-element', styleElement
     else
-      @emitter.emit 'did-add-style-sheet', {styleElement, sourcePath, group}
+      @emitter.emit 'did-add-style-element', styleElement
 
     new Disposable => @removeStyleElement(styleElement, params)
 
@@ -55,4 +60,4 @@ class StyleManager
       @styleElements.splice(index, 1)
       sourcePath = params?.sourcePath
       delete @styleElementsBySourcePath[sourcePath] if sourcePath?
-      @emitter.emit 'did-remove-style-sheet', {styleElement}
+      @emitter.emit 'did-remove-style-element', styleElement

--- a/src/style-manager.coffee
+++ b/src/style-manager.coffee
@@ -1,0 +1,30 @@
+{Emitter, Disposable} = require 'event-kit'
+
+module.exports =
+class StyleManager
+  constructor: ->
+    @emitter = new Emitter
+    @styleElements = []
+
+  onDidAddStyleSheet: (callback) ->
+    @emitter.on 'did-add-style-sheet', callback
+
+  onDidRemoveStyleSheet: (callback) ->
+    @emitter.on 'did-remove-style-sheet', callback
+
+  getStyleElements: ->
+    @styleElements.slice()
+
+  addStyleSheet: (source) ->
+    styleElement = document.createElement('style')
+    styleElement.textContent = source
+    @styleElements.push(styleElement)
+    @emitter.emit 'did-add-style-sheet', {styleElement}
+
+    new Disposable => @removeStyleElement(styleElement)
+
+  removeStyleElement: (styleElement) ->
+    index = @styleElements.indexOf(styleElement)
+    unless index is -1
+      @styleElements.splice(index, 1)
+      @emitter.emit 'did-remove-style-sheet', {styleElement}

--- a/src/style-manager.coffee
+++ b/src/style-manager.coffee
@@ -61,3 +61,7 @@ class StyleManager
       sourcePath = params?.sourcePath
       delete @styleElementsBySourcePath[sourcePath] if sourcePath?
       @emitter.emit 'did-remove-style-element', styleElement
+
+  clear: ->
+    @styleElements = []
+    @styleElementsBySourcePath = {}

--- a/src/styles-element.coffee
+++ b/src/styles-element.coffee
@@ -1,0 +1,30 @@
+{CompositeDisposable} = require 'event-kit'
+
+class StylesElement extends HTMLElement
+  attachedCallback: ->
+    @subscriptions = new CompositeDisposable
+    @styleElementClonesByOriginalElement = new WeakMap
+    @subscriptions.add atom.styles.observeStyleElements(@styleElementAdded.bind(this))
+    @subscriptions.add atom.styles.onDidRemoveStyleElement(@styleElementRemoved.bind(this))
+
+  styleElementAdded: (styleElement) ->
+    {group} = styleElement
+    styleElementClone = styleElement.cloneNode(true)
+    styleElementClone.group = group
+    @styleElementClonesByOriginalElement.set(styleElement, styleElementClone)
+
+    if group?
+      for child in @children
+        if child.group is group and child.nextSibling?.group isnt group
+          insertBefore = child.nextSibling
+          break
+
+    @insertBefore(styleElementClone, insertBefore)
+
+  styleElementRemoved: (styleElement) ->
+    @styleElementClonesByOriginalElement.get(styleElement).remove()
+
+  detachedCallback: ->
+    @subscriptions.dispose()
+
+module.exports = StylesElement = document.registerElement 'atom-styles', prototype: StylesElement.prototype

--- a/src/styles-element.coffee
+++ b/src/styles-element.coffee
@@ -1,6 +1,15 @@
-{CompositeDisposable} = require 'event-kit'
+{Emitter, CompositeDisposable} = require 'event-kit'
 
 class StylesElement extends HTMLElement
+  createdCallback: ->
+    @emitter = new Emitter
+
+  onDidAddStyleElement: (callback) ->
+    @emitter.on 'did-add-style-element', callback
+
+  onDidRemoveStyleElement: (callback) ->
+    @emitter.on 'did-remove-style-element', callback
+
   attachedCallback: ->
     @subscriptions = new CompositeDisposable
     @styleElementClonesByOriginalElement = new WeakMap
@@ -19,9 +28,12 @@ class StylesElement extends HTMLElement
           break
 
     @insertBefore(styleElementClone, insertBefore)
+    @emitter.emit 'did-add-style-element', styleElementClone
 
   styleElementRemoved: (styleElement) ->
-    @styleElementClonesByOriginalElement.get(styleElement).remove()
+    styleElementClone = @styleElementClonesByOriginalElement.get(styleElement)
+    styleElementClone.remove()
+    @emitter.emit 'did-remove-style-element', styleElementClone
 
   detachedCallback: ->
     @subscriptions.dispose()

--- a/src/styles-element.coffee
+++ b/src/styles-element.coffee
@@ -8,14 +8,13 @@ class StylesElement extends HTMLElement
     @subscriptions.add atom.styles.onDidRemoveStyleElement(@styleElementRemoved.bind(this))
 
   styleElementAdded: (styleElement) ->
-    {group} = styleElement
     styleElementClone = styleElement.cloneNode(true)
-    styleElementClone.group = group
     @styleElementClonesByOriginalElement.set(styleElement, styleElementClone)
 
+    group = styleElement.getAttribute('group')
     if group?
       for child in @children
-        if child.group is group and child.nextSibling?.group isnt group
+        if child.getAttribute('group') is group and child.nextSibling?.getAttribute('group') isnt group
           insertBefore = child.nextSibling
           break
 

--- a/src/styles-element.coffee
+++ b/src/styles-element.coffee
@@ -10,11 +10,15 @@ class StylesElement extends HTMLElement
   onDidRemoveStyleElement: (callback) ->
     @emitter.on 'did-remove-style-element', callback
 
+  onDidUpdateStyleElement: (callback) ->
+    @emitter.on 'did-update-style-element', callback
+
   attachedCallback: ->
     @subscriptions = new CompositeDisposable
     @styleElementClonesByOriginalElement = new WeakMap
     @subscriptions.add atom.styles.observeStyleElements(@styleElementAdded.bind(this))
     @subscriptions.add atom.styles.onDidRemoveStyleElement(@styleElementRemoved.bind(this))
+    @subscriptions.add atom.styles.onDidUpdateStyleElement(@styleElementUpdated.bind(this))
 
   styleElementAdded: (styleElement) ->
     styleElementClone = styleElement.cloneNode(true)
@@ -34,6 +38,11 @@ class StylesElement extends HTMLElement
     styleElementClone = @styleElementClonesByOriginalElement.get(styleElement)
     styleElementClone.remove()
     @emitter.emit 'did-remove-style-element', styleElementClone
+
+  styleElementUpdated: (styleElement) ->
+    styleElementClone = @styleElementClonesByOriginalElement.get(styleElement)
+    styleElementClone.textContent = styleElement.textContent
+    @emitter.emit 'did-update-style-element', styleElementClone
 
   detachedCallback: ->
     @subscriptions.dispose()

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -23,19 +23,23 @@ class ThemeManager
     @lessCache = null
     @initialLoadComplete = false
     @packageManager.registerPackageActivator(this, ['theme'])
+    @sheetsByStyleElement = new WeakMap
 
     stylesElement = document.head.querySelector('atom-styles')
     stylesElement.onDidAddStyleElement @styleElementAdded.bind(this)
     stylesElement.onDidRemoveStyleElement @styleElementRemoved.bind(this)
     stylesElement.onDidUpdateStyleElement @styleElementUpdated.bind(this)
 
-  styleElementAdded: ({sheet}) ->
+  styleElementAdded: (styleElement) ->
+    {sheet} = styleElement
+    @sheetsByStyleElement.set(styleElement, sheet)
     @emit 'stylesheet-added', sheet
     @emitter.emit 'did-add-stylesheet', sheet
     @emit 'stylesheets-changed'
     @emitter.emit 'did-change-stylesheets'
 
-  styleElementRemoved: ({sheet}) ->
+  styleElementRemoved: (styleElement) ->
+    sheet = @sheetsByStyleElement.get(styleElement)
     @emit 'stylesheet-removed', sheet
     @emitter.emit 'did-remove-stylesheet', sheet
     @emit 'stylesheets-changed'

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -24,36 +24,30 @@ class ThemeManager
     @initialLoadComplete = false
     @packageManager.registerPackageActivator(this, ['theme'])
 
-    atom.styles.onDidAddStyleElement @styleElementAdded.bind(this)
-    atom.styles.onDidRemoveStyleElement @styleElementRemoved.bind(this)
-    atom.styles.onDidUpdateStyleElement @styleElementUpdated.bind(this)
+    stylesElement = document.head.querySelector('atom-styles')
+    stylesElement.onDidAddStyleElement @styleElementAdded.bind(this)
+    stylesElement.onDidRemoveStyleElement @styleElementRemoved.bind(this)
+    stylesElement.onDidUpdateStyleElement @styleElementUpdated.bind(this)
 
-  styleElementAdded: (element) ->
-    sheet = @styleSheetForElement(element)
+  styleElementAdded: ({sheet}) ->
     @emit 'stylesheet-added', sheet
     @emitter.emit 'did-add-stylesheet', sheet
     @emit 'stylesheets-changed'
     @emitter.emit 'did-change-stylesheets'
 
-  styleElementRemoved: (element) ->
-    sheet = @styleSheetForElement(element)
+  styleElementRemoved: ({sheet}) ->
     @emit 'stylesheet-removed', sheet
     @emitter.emit 'did-remove-stylesheet', sheet
     @emit 'stylesheets-changed'
     @emitter.emit 'did-change-stylesheets'
 
-  styleElementUpdated: (element) ->
-    sheet = @styleSheetForElement(element)
+  styleElementUpdated: ({sheet}) ->
     @emit 'stylesheet-removed', sheet
     @emitter.emit 'did-remove-stylesheet', sheet
     @emit 'stylesheet-added', sheet
     @emitter.emit 'did-add-stylesheet', sheet
     @emit 'stylesheets-changed'
     @emitter.emit 'did-change-stylesheets'
-
-  styleSheetForElement: (element) ->
-    @stylesElement ?= document.head.querySelector('atom-styles')
-    @stylesElement.styleElementClonesByOriginalElement.get(element)?.sheet
 
   ###
   Section: Event Subscription


### PR DESCRIPTION
This is a step toward updating the text editor to use the shadow DOM (#3677).

Previously our style sheets were managed globally, but with the introduction of the shadow DOM we now need to be able to load stylesheets into specific contexts and not others. The theme manager was previously mutating the DOM directly when stylesheets were applied, which clashed with our requirement of loading specific stylesheets in specific contexts. This PR now introduces a new custom element `<atom-styles>`, which interacts with the style manager at `atom.styles` to render the stylesheets in our head.

The next step will introduce targeting stylesheets to specific contexts. When an `<atom-styles>` element is appended to a shadow root, it will only add child style elements that are targeted for that shadow root. If stylesheets are targeted with a specific context, they won't be loaded in the document's head.

Currently, the new style manager only focuses on _applying_ stylesheets. Loading is still handled in the theme manager. It should probably be moved so the theme manager only deals with themes, not stylesheet loading and compilation.
