### PR TITLE
Don't fail create-installer if ATOM_ACCESS_TOKEN isn't set

### DIFF
--- a/build/tasks/create-installer.coffee
+++ b/build/tasks/create-installer.coffee
@@ -31,7 +31,7 @@ module.exports = (grunt) ->
 
     spawn {cmd, args}, (error, result, code) ->
       if error?
-        grunt.log.error "ATOM_ACCESS_TOKEN not set, can't download old releases; continuing anyways"
+        grunt.log.error "ATOM_ACCESS_TOKEN environment variable not set or invalid, can't download old releases; continuing anyways"
 
       cmd = 'build/windows/nuget.exe'
       args = ['pack', targetNuspecPath, '-BasePath', atomDir, '-OutputDirectory', buildDir]

--- a/build/tasks/create-installer.coffee
+++ b/build/tasks/create-installer.coffee
@@ -30,7 +30,8 @@ module.exports = (grunt) ->
     args = ['-r', releasesDir, '-u', 'https://github.com/atom/atom', '-t', atomGitHubToken]
 
     spawn {cmd, args}, (error, result, code) ->
-      return done(error) if error?
+      if error?
+        grunt.log.error "ATOM_ACCESS_TOKEN not set, can't download old releases; continuing anyways"
 
       cmd = 'build/windows/nuget.exe'
       args = ['pack', targetNuspecPath, '-BasePath', atomDir, '-OutputDirectory', buildDir]


### PR DESCRIPTION
This lets users create one-off installers locally without having to download every other release to create deltas.
