### PR TITLE
Add scoped defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "reactionary-atom-fork": "^1.0.0",
     "runas": "1.0.1",
     "scandal": "1.0.2",
-    "scoped-property-store": "^0.13.2",
+    "scoped-property-store": "^0.14.0",
     "scrollbar-style": "^1.0.2",
     "season": "^1.0.2",
     "semver": "1.1.4",

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -88,6 +88,19 @@ describe "Config", ->
       expect(atom.config.getDefault('foo.bar')).toEqual initialDefaultValue
       expect(atom.config.getDefault('foo.bar')).not.toBe initialDefaultValue
 
+    describe "when scoped settings are used", ->
+      it "returns the global default when no scoped default set", ->
+        atom.config.setDefaults("foo", bar: baz: 10)
+        expect(atom.config.getDefault('.source.coffee', 'foo.bar.baz')).toBe 10
+
+      it "returns the scoped default when a scoped default is set", ->
+        atom.config.setDefaults("foo", bar: baz: 10)
+        atom.config.addScopedSettings("default", ".source.coffee", foo: bar: baz: 42)
+        expect(atom.config.getDefault('.source.coffee', 'foo.bar.baz')).toBe 42
+
+        atom.config.set('.source.coffee', 'foo.bar.baz', 55)
+        expect(atom.config.getDefault('.source.coffee', 'foo.bar.baz')).toBe 42
+
   describe ".isDefault(keyPath)", ->
     it "returns true when the value of the key path is its default value", ->
       atom.config.setDefaults("foo", same: 1, changes: 1)

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -99,6 +99,16 @@ describe "Config", ->
       expect(atom.config.isDefault('foo.same')).toBe false
       expect(atom.config.isDefault('foo.changes')).toBe false
 
+    describe "when scoped settings are used", ->
+      it "returns false when a scoped setting was set by the user", ->
+        expect(atom.config.isDefault('.source.coffee', 'foo.bar.baz')).toBe true
+
+        atom.config.addScopedSettings("default", ".source.coffee", foo: bar: baz: 42)
+        expect(atom.config.isDefault('.source.coffee', 'foo.bar.baz')).toBe true
+
+        atom.config.set('.source.coffee', 'foo.bar.baz', 55)
+        expect(atom.config.isDefault('.source.coffee', 'foo.bar.baz')).toBe false
+
   describe ".toggle(keyPath)", ->
     it "negates the boolean value of the current key path value", ->
       atom.config.set('foo.a', 1)

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -153,6 +153,26 @@ describe "Config", ->
       atom.config.restoreDefault('a.c')
       expect(atom.config.get('a.c')).toBeUndefined()
 
+    describe "when scoped settings are used", ->
+      it "restores the global default when no scoped default set", ->
+        atom.config.setDefaults("foo", bar: baz: 10)
+        atom.config.set('.source.coffee', 'foo.bar.baz', 55)
+        expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 55
+
+        atom.config.restoreDefault('.source.coffee', 'foo.bar.baz')
+        expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 10
+
+      it "restores the scoped default when a scoped default is set", ->
+        atom.config.setDefaults("foo", bar: baz: 10)
+        atom.config.addScopedSettings("default", ".source.coffee", foo: bar: baz: 42)
+        atom.config.set('.source.coffee', 'foo.bar.baz', 55)
+        atom.config.set('.source.coffee', 'foo.bar.ok', 100)
+        expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 55
+
+        atom.config.restoreDefault('.source.coffee', 'foo.bar.baz')
+        expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 42
+        expect(atom.config.get(['.source.coffee'], 'foo.bar.ok')).toBe 100
+
   describe ".pushAtKeyPath(keyPath, value)", ->
     it "pushes the given value to the array at the key path and updates observers", ->
       atom.config.set("foo.bar.baz", ["a"])

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -173,6 +173,30 @@ describe "Config", ->
         expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 42
         expect(atom.config.get(['.source.coffee'], 'foo.bar.ok')).toBe 100
 
+  describe ".getSettings()", ->
+    it "returns all settings including defaults", ->
+      atom.config.setDefaults("foo", bar: baz: 10)
+      atom.config.set("foo.ok", 12)
+
+      expect(atom.config.getSettings().foo).toEqual
+        ok: 12
+        bar:
+          baz: 10
+
+    describe "when scoped settings are used", ->
+      it "returns all the scoped settings including all the defaults", ->
+        atom.config.setDefaults("foo", bar: baz: 10)
+        atom.config.set("foo.ok", 12)
+        atom.config.addScopedSettings("default", ".source.coffee", foo: bar: baz: 42)
+        atom.config.addScopedSettings("default", ".source.coffee", foo: bar: omg: 'omg')
+
+        expect(atom.config.getSettings(".source.coffee").foo).toEqual
+          ok: 12
+          bar:
+            baz: 42
+            omg: 'omg'
+
+
   describe ".pushAtKeyPath(keyPath, value)", ->
     it "pushes the given value to the array at the key path and updates observers", ->
       atom.config.set("foo.bar.baz", ["a"])

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -826,10 +826,10 @@ class Config
     @usersScopedSettings.add @scopedSettingsStore.addProperties('user-config', newScopedSettings)
     @emitter.emit 'did-change'
 
-  addScopedSettings: (name, selector, value) ->
+  addScopedSettings: (source, selector, value) ->
     settingsBySelector = {}
     settingsBySelector[selector] = value
-    disposable = @scopedSettingsStore.addProperties(name, settingsBySelector)
+    disposable = @scopedSettingsStore.addProperties(source, settingsBySelector)
     @emitter.emit 'did-change'
     new Disposable =>
       disposable.dispose()

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -847,11 +847,7 @@ class Config
     @emitter.emit 'did-change'
 
   getRawScopedValue: (scopeDescriptor, keyPath) ->
-    scopeChain = scopeDescriptor
-      .map (scope) ->
-        scope = ".#{scope}" unless scope[0] is '.'
-        scope
-      .join(' ')
+    scopeChain = @scopeChainForScopeDescriptor(scopeDescriptor)
     @scopedSettingsStore.getPropertyValue(scopeChain, keyPath)
 
   observeScopedKeyPath: (scopeDescriptor, keyPath, callback) ->
@@ -885,6 +881,13 @@ class Config
         scope
       .join(' ')
     @scopedSettingsStore.getProperties(scopeChain, keyPath)
+
+  scopeChainForScopeDescriptor: (scopeDescriptor) ->
+    scopeDescriptor
+      .map (scope) ->
+        scope = ".#{scope}" unless scope[0] is '.'
+        scope
+      .join(' ')
 
 # Base schema enforcers. These will coerce raw input into the specified type,
 # and will throw an error when the value cannot be coerced. Throwing the error

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -519,9 +519,20 @@ class Config
   # * `keyPath` The {String} name of the key.
   #
   # Returns the new value.
-  restoreDefault: (keyPath) ->
-    @set(keyPath, _.valueForKeyPath(@defaultSettings, keyPath))
-    @get(keyPath)
+  restoreDefault: (scopeSelector, keyPath) ->
+    if arguments.length == 1
+      keyPath = scopeSelector
+      scopeSelector = null
+
+    if scopeSelector?
+      settings = @scopedSettingsStore.propertiesForSourceAndSelector('user-config', scopeSelector)
+      @scopedSettingsStore.removePropertiesForSourceAndSelector('user-config', scopeSelector)
+      _.setValueForKeyPath(settings, keyPath, undefined)
+      @addScopedSettings('user-config', scopeSelector, settings)
+      @getDefault(scopeSelector, keyPath)
+    else
+      @set(keyPath, _.valueForKeyPath(@defaultSettings, keyPath))
+      @get(keyPath)
 
   # Extended: Get the global default value of the key path. _Please note_ that in most
   # cases calling this is not necessary! {::get} returns the default value when

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -530,8 +530,16 @@ class Config
   # * `keyPath` The {String} name of the key.
   #
   # Returns the default value.
-  getDefault: (keyPath) ->
-    defaultValue = _.valueForKeyPath(@defaultSettings, keyPath)
+  getDefault: (scopeSelector, keyPath) ->
+    if arguments.length == 1
+      keyPath = scopeSelector
+      scopeSelector = null
+
+    if scopeSelector?
+      defaultValue = @scopedSettingsStore.getPropertyValue(scopeSelector, keyPath, excludeSources: ['user-config'])
+      defaultValue ?= _.valueForKeyPath(@defaultSettings, keyPath)
+    else
+      defaultValue = _.valueForKeyPath(@defaultSettings, keyPath)
     _.deepClone(defaultValue)
 
   # Extended: Is the value at `keyPath` its default value?

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -540,8 +540,16 @@ class Config
   #
   # Returns a {Boolean}, `true` if the current value is the default, `false`
   # otherwise.
-  isDefault: (keyPath) ->
-    not _.valueForKeyPath(@settings, keyPath)?
+  isDefault: (scopeSelector, keyPath) ->
+    if arguments.length == 1
+      keyPath = scopeSelector
+      scopeSelector = null
+
+    if scopeSelector?
+      settings = @scopedSettingsStore.propertiesForSourceAndSelector('user-config', scopeSelector)
+      not _.valueForKeyPath(settings, keyPath)?
+    else
+      not _.valueForKeyPath(@settings, keyPath)?
 
   # Extended: Retrieve the schema for a specific key path. The schema will tell
   # you what type the keyPath expects, and other metadata about the config

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -538,6 +538,7 @@ class Config
   # cases calling this is not necessary! {::get} returns the default value when
   # a custom value is not specified.
   #
+  # * `scopeSelector` (optional) {String}. eg. '.source.ruby'
   # * `keyPath` The {String} name of the key.
   #
   # Returns the default value.
@@ -555,6 +556,7 @@ class Config
 
   # Extended: Is the value at `keyPath` its default value?
   #
+  # * `scopeSelector` (optional) {String}. eg. '.source.ruby'
   # * `keyPath` The {String} name of the key.
   #
   # Returns a {Boolean}, `true` if the current value is the default, `false`
@@ -587,7 +589,9 @@ class Config
     schema
 
   # Extended: Returns a new {Object} containing all of the global settings and
-  # defaults. This does not include scoped settings.
+  # defaults. Returns the scoped settings when a `scopeSelector` is specified.
+  #
+  # * `scopeSelector` (optional) {String}. eg. '.source.ruby'
   getSettings: (scopeSelector) ->
     settings = _.deepExtend(@settings, @defaultSettings)
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -588,8 +588,14 @@ class Config
 
   # Extended: Returns a new {Object} containing all of the global settings and
   # defaults. This does not include scoped settings.
-  getSettings: ->
-    _.deepExtend(@settings, @defaultSettings)
+  getSettings: (scopeSelector) ->
+    settings = _.deepExtend(@settings, @defaultSettings)
+
+    if scopeSelector?
+      scopedSettings = @scopedSettingsStore.propertiesForSelector(scopeSelector)
+      settings = _.deepExtend(scopedSettings, settings)
+
+    settings
 
   # Extended: Get the {String} path to the config file being used.
   getUserConfigPath: ->


### PR DESCRIPTION
The settings view needs to know if a given scoped property is set to the 'default' then be able to reset said property back to the 'default'.

Defaults are strange with scoped properties because scoped properties are additive. You can set `some.setting` 10 times with similar scopes creating a chain of properties that need to be evaluated against a scoped descriptor. Which one of those set is the default? The path through those scoped properties depends on ordering and specificity when matched against a scopeDescriptor.

Defaults here rely on some simplifications based on our use of scoped settings.
1. Every value set in the property store has a `source` property indicating where it came from. Each scoped setting set via the user config file or `Config::set`, has this `source` property set to `user-config`. Scoped defaults can be any scoped property who's `source` property is not `user-config`. So anything set by a package's `scoped-properties.cson` is a default, and anything the user sets is an override.
2. The settings view needs to check and reset the default values with the same scope selector used to initially set the properties. Currently these selectors are language scopes: `'.source.js'`, etc. eg. The way it's written in this PR, we cannot reset the default for the scope descriptor `['.source.js', '.meta.function.name']`, but we can for `['.source.js']` because `'.source.js'` is the way it went in.

For reason number 2, all the methods; `isDefault`, `getDefault`, `restoreDefault`, `getSettings`; take a `scopeSelector`, not a `scopeDescriptor`.

Depends on https://github.com/atom/scoped-property-store/pull/5
