### PR TITLE
Opt out of command registration for textInput events

### DIFF
--- a/src/space-pen-extensions.coffee
+++ b/src/space-pen-extensions.coffee
@@ -19,7 +19,8 @@ NativeEventNames = new Set
 NativeEventNames.add(nativeEvent) for nativeEvent in ["blur", "focus", "focusin",
 "focusout", "load", "resize", "scroll", "unload", "click", "dblclick", "mousedown",
 "mouseup", "mousemove", "mouseover", "mouseout", "mouseenter", "mouseleave", "change",
-"select", "submit", "keydown", "keypress", "keyup", "error", "contextmenu"]
+"select", "submit", "keydown", "keypress", "keyup", "error", "contextmenu", "textInput",
+"textinput"]
 
 JQueryTrigger = jQuery.fn.trigger
 jQuery.fn.trigger = (eventName, data) ->


### PR DESCRIPTION
There seems to be issues capturing them when they are programmatically
dispatched via dispatchEvent. This was causing problems for the vim-mode
specs. This event belongs among the native events that aren’t treated
as commands anyway.
