### PR TITLE
Allow core specs from command line in atom repository regardless of its location

### DIFF
--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -80,11 +80,11 @@ parseCommandLine = ->
     opened or a new window if it hasn't.
   """
   options.alias('d', 'dev').boolean('d').describe('d', 'Run in development mode.')
-  options.alias('r', 'resource-path').string('r').describe('r', 'Set the path to the Atom source directory and enable dev-mode.')
   options.alias('f', 'foreground').boolean('f').describe('f', 'Keep the browser process in the foreground.')
   options.alias('h', 'help').boolean('h').describe('h', 'Print this usage message.')
   options.alias('l', 'log-file').string('l').describe('l', 'Log all output to file.')
   options.alias('n', 'new-window').boolean('n').describe('n', 'Open a new window.')
+  options.alias('r', 'resource-path').string('r').describe('r', 'Set the path to the Atom source directory and enable dev-mode.')
   options.alias('s', 'spec-directory').string('s').describe('s', 'Set the directory from which to run package specs (default: Atom\'s spec directory).')
   options.boolean('safe').describe('safe', 'Do not load packages from ~/.atom/packages or ~/.atom/dev/packages.')
   options.alias('t', 'test').boolean('t').describe('t', 'Run the specified specs and exit with error code on failures.')

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -123,7 +123,7 @@ parseCommandLine = ->
     devMode = true
     resourcePath = args['resource-path']
   else
-    # Set resourcePath based on to specDirectory if running specs on atom core
+    # Set resourcePath based on the specDirectory if running specs on atom core
     if specDirectory?
       packageDirectoryPath = path.join(specDirectory, '..')
       packageManifestPath = path.join(packageDirectoryPath, 'package.json')

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -78,6 +78,10 @@ parseCommandLine = ->
 
     Folder paths will open in an existing window if that folder has already been
     opened or a new window if it hasn't.
+
+    Environment Variables:
+    ATOM_DEV_RESOURCE_PATH  The path from which Atom loads source code in dev mode.
+                            Defaults to `~/github/atom`.
   """
   options.alias('d', 'dev').boolean('d').describe('d', 'Run in development mode.')
   options.alias('f', 'foreground').boolean('f').describe('f', 'Keep the browser process in the foreground.')
@@ -94,14 +98,6 @@ parseCommandLine = ->
 
   if args.help
     process.stdout.write(options.help())
-    process.stdout.write """
-
-      Environment Variables:
-      ATOM_DEV_RESOURCE_PATH  The path from which Atom loads source code in dev mode.
-                              Defaults to `~/github/atom`.
-
-    """
-
     process.exit(0)
 
   if args.version

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -94,6 +94,14 @@ parseCommandLine = ->
 
   if args.help
     process.stdout.write(options.help())
+    process.stdout.write """
+
+      Environment Variables:
+      ATOM_DEV_RESOURCE_PATH  The path from which Atom loads source code in dev mode.
+                              Defaults to `~/github/atom`.
+
+    """
+
     process.exit(0)
 
   if args.version

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -85,7 +85,7 @@ parseCommandLine = ->
   options.alias('h', 'help').boolean('h').describe('h', 'Print this usage message.')
   options.alias('l', 'log-file').string('l').describe('l', 'Log all output to file.')
   options.alias('n', 'new-window').boolean('n').describe('n', 'Open a new window.')
-  options.alias('s', 'spec-directory').string('s').describe('s', 'Set the spec directory (default: Atom\'s spec directory).')
+  options.alias('s', 'spec-directory').string('s').describe('s', 'Set the directory from which to run package specs (default: Atom\'s spec directory).')
   options.boolean('safe').describe('safe', 'Do not load packages from ~/.atom/packages or ~/.atom/dev/packages.')
   options.alias('t', 'test').boolean('t').describe('t', 'Run the specified specs and exit with error code on failures.')
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -80,6 +80,7 @@ parseCommandLine = ->
     opened or a new window if it hasn't.
   """
   options.alias('d', 'dev').boolean('d').describe('d', 'Run in development mode.')
+  options.alias('r', 'resource-path').string('r').describe('r', 'Set the path from which Atom loads internal resources and enable dev-mode.')
   options.alias('f', 'foreground').boolean('f').describe('f', 'Keep the browser process in the foreground.')
   options.alias('h', 'help').boolean('h').describe('h', 'Print this usage message.')
   options.alias('l', 'log-file').string('l').describe('l', 'Log all output to file.')

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -129,7 +129,7 @@ parseCommandLine = ->
       packageManifestPath = path.join(packageDirectoryPath, 'package.json')
       if fs.statSyncNoException(packageManifestPath)
         try
-          packageManifest = JSON.parse(fs.readFileSync(packageManifestPath, 'utf8'))
+          packageManifest = JSON.parse(fs.readFileSync(packageManifestPath))
           resourcePath = packageDirectoryPath if packageManifest.name is 'atom'
 
     if devMode

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -80,7 +80,7 @@ parseCommandLine = ->
     opened or a new window if it hasn't.
   """
   options.alias('d', 'dev').boolean('d').describe('d', 'Run in development mode.')
-  options.alias('r', 'resource-path').string('r').describe('r', 'Set the path from which Atom loads internal resources and enable dev-mode.')
+  options.alias('r', 'resource-path').string('r').describe('r', 'Set the path to the Atom source directory and enable dev-mode.')
   options.alias('f', 'foreground').boolean('f').describe('f', 'Keep the browser process in the foreground.')
   options.alias('h', 'help').boolean('h').describe('h', 'Print this usage message.')
   options.alias('l', 'log-file').string('l').describe('l', 'Log all output to file.')
@@ -114,8 +114,18 @@ parseCommandLine = ->
   if args['resource-path']
     devMode = true
     resourcePath = args['resource-path']
-  else if devMode
-    resourcePath = global.devResourcePath
+  else
+    # Set resourcePath based on to specDirectory if running specs on atom core
+    if specDirectory?
+      packageDirectoryPath = path.join(specDirectory, '..')
+      packageManifestPath = path.join(packageDirectoryPath, 'package.json')
+      if fs.statSyncNoException(packageManifestPath)
+        try
+          packageManifest = JSON.parse(fs.readFileSync(packageManifestPath, 'utf8'))
+          resourcePath = packageDirectoryPath if packageManifest.name is 'atom'
+
+    if devMode
+      resourcePath ?= global.devResourcePath
 
   unless fs.statSyncNoException(resourcePath)
     resourcePath = path.dirname(path.dirname(__dirname))


### PR DESCRIPTION
Previously, when running `apm test` inside the package directory worked fine because it set the `spec-directory` argument to the executable and just ran the core specs. However, if the repository was located somewhere other than `~/github/atom` and no `ATOM_DEV_RESOURCE_PATH` environment variable was defined, it would _first_ load a bunch of core files out of the application bundle. Now that we're using custom elements, these leads to errors due to redundant element definition, so we need a new approach.

Now when you run `apm test` in the atom repository, we will automatically assign the resource path to the directory containing the specs unless one is otherwise specified.

Closes #3872

/cc @kevinsawicki since you are the lord of startup. :snowflake::boot: 
