### PR TITLE
Swap out application menus on focus

### DIFF
--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -10,8 +10,7 @@ _ = require 'underscore-plus'
 module.exports =
 class ApplicationMenu
   constructor: (@version) ->
-    @menu = Menu.buildFromTemplate @getDefaultTemplate()
-    Menu.setApplicationMenu @menu
+    @setActiveTemplate(@getDefaultTemplate())
     global.atomApplication.autoUpdateManager.on 'state-changed', (state) =>
       @showUpdateMenuItem(state)
 
@@ -23,10 +22,13 @@ class ApplicationMenu
   update: (template, keystrokesByCommand) ->
     @translateTemplate(template, keystrokesByCommand)
     @substituteVersion(template)
-    @menu = Menu.buildFromTemplate(template)
-    Menu.setApplicationMenu(@menu)
+    @setActiveTemplate(template)
 
     @showUpdateMenuItem(global.atomApplication.autoUpdateManager.getState())
+
+  setActiveTemplate: (template) ->
+    @menu = Menu.buildFromTemplate(template)
+    Menu.setApplicationMenu(@menu)
 
   # Flattens the given menu and submenu items into an single Array.
   #

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -17,7 +17,7 @@ class ApplicationMenu
 
   # Public: Updates the entire menu with the given keybindings.
   #
-  # window - The BrowserWindow this menu is associated with.
+  # window - The BrowserWindow this menu template is associated with.
   # template - The Object which describes the menu to display.
   # keystrokesByCommand - An Object where the keys are commands and the values
   #                       are Arrays containing the keystroke.

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -10,18 +10,23 @@ _ = require 'underscore-plus'
 module.exports =
 class ApplicationMenu
   constructor: (@version) ->
+    @windowTemplates = new WeakMap()
     @setActiveTemplate(@getDefaultTemplate())
     global.atomApplication.autoUpdateManager.on 'state-changed', (state) =>
       @showUpdateMenuItem(state)
 
   # Public: Updates the entire menu with the given keybindings.
   #
+  # window - The BrowserWindow this menu is associated with.
   # template - The Object which describes the menu to display.
   # keystrokesByCommand - An Object where the keys are commands and the values
   #                       are Arrays containing the keystroke.
-  update: (template, keystrokesByCommand) ->
+  update: (window, template, keystrokesByCommand) ->
+    return unless window is @lastFocusedWindow
+
     @translateTemplate(template, keystrokesByCommand)
     @substituteVersion(template)
+    @windowTemplates.set(window, template)
     @setActiveTemplate(template)
 
     @showUpdateMenuItem(global.atomApplication.autoUpdateManager.getState())
@@ -29,6 +34,22 @@ class ApplicationMenu
   setActiveTemplate: (template) ->
     @menu = Menu.buildFromTemplate(_.deepClone(template))
     Menu.setApplicationMenu(@menu)
+
+  # Register a BrowserWindow with this application menu.
+  addWindow: (window) ->
+    @lastFocusedWindow ?= window
+
+    focusHandler = =>
+      @lastFocusedWindow = window
+      if template = @windowTemplates.get(window)
+        @setActiveTemplate(template)
+
+    window.on 'focus', focusHandler
+    window.once 'closed', =>
+      @windowTemplates.delete(window)
+      window.removeListener 'focus', focusHandler
+
+    @enableWindowSpecificItems(true)
 
   # Flattens the given menu and submenu items into an single Array.
   #

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -32,8 +32,10 @@ class ApplicationMenu
     @showUpdateMenuItem(global.atomApplication.autoUpdateManager.getState())
 
   setActiveTemplate: (template) ->
-    @menu = Menu.buildFromTemplate(_.deepClone(template))
-    Menu.setApplicationMenu(@menu)
+    unless _.isEqual(template, @activeTemplate)
+      @activeTemplate = template
+      @menu = Menu.buildFromTemplate(_.deepClone(template))
+      Menu.setApplicationMenu(@menu)
 
   # Register a BrowserWindow with this application menu.
   addWindow: (window) ->

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -27,7 +27,7 @@ class ApplicationMenu
     @showUpdateMenuItem(global.atomApplication.autoUpdateManager.getState())
 
   setActiveTemplate: (template) ->
-    @menu = Menu.buildFromTemplate(template)
+    @menu = Menu.buildFromTemplate(_.deepClone(template))
     Menu.setApplicationMenu(@menu)
 
   # Flattens the given menu and submenu items into an single Array.

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -97,7 +97,7 @@ class AtomApplication
   # Public: Adds the {AtomWindow} to the global window list.
   addWindow: (window) ->
     @windows.push window
-    @applicationMenu?.enableWindowSpecificItems(true)
+    @applicationMenu?.addWindow(window.browserWindow)
     window.once 'window:loaded', =>
       @autoUpdateManager.emitUpdateAvailableEvent(window)
 
@@ -215,7 +215,8 @@ class AtomApplication
         @promptForPath({window})
 
     ipc.on 'update-application-menu', (event, template, keystrokesByCommand) =>
-      @applicationMenu.update(template, keystrokesByCommand)
+      win = BrowserWindow.fromWebContents(event.sender)
+      @applicationMenu.update(win, template, keystrokesByCommand)
 
     ipc.on 'run-package-specs', (event, specDirectory) =>
       @runSpecs({resourcePath: global.devResourcePath, specDirectory: specDirectory, exitWhenDone: false})


### PR DESCRIPTION
Now that package menus properly destroy themselves during deactivation, the window's application menu should be tracked and restored when the window gains focus.

Without this, a bunch of menus are getting destroyed when a window is closed, even if another window is still open.

Fixes #3806 
