### PR TITLE
Add support for scoped defaults in config schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "temp": "0.7.0",
     "text-buffer": "^3.2.9",
     "theorist": "^1.0.2",
-    "underscore-plus": "^1.5.1",
+    "underscore-plus": "^1.6.0",
     "vm-compatibility-layer": "0.1.0"
   },
   "packageDependencies": {

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -122,6 +122,11 @@ describe "Config", ->
         atom.config.set('.source.coffee', 'foo.bar.baz', 55)
         expect(atom.config.isDefault('.source.coffee', 'foo.bar.baz')).toBe false
 
+  describe ".setDefaults(keyPath)", ->
+    it "sets a default when the setting's key contains an escaped dot", ->
+      atom.config.setDefaults("foo", 'a\\.b': 1, b: 2)
+      expect(atom.config.get("foo")).toEqual 'a\\.b': 1, b: 2
+
   describe ".toggle(keyPath)", ->
     it "negates the boolean value of the current key path value", ->
       atom.config.set('foo.a', 1)
@@ -212,7 +217,6 @@ describe "Config", ->
           bar:
             baz: 42
             omg: 'omg'
-
 
   describe ".pushAtKeyPath(keyPath, value)", ->
     it "pushes the given value to the array at the key path and updates observers", ->

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1032,6 +1032,21 @@ describe "Config", ->
         expect(atom.config.set('foo.bar.arr', ['two', 'three'])).toBe true
         expect(atom.config.get('foo.bar.arr')).toEqual ['two', 'three']
 
+    describe "when scoped settings are used", ->
+      beforeEach ->
+        schema =
+          type: 'string'
+          default: 'ok'
+          scopes:
+            '.source.js':
+              default: 'omg'
+        atom.config.setSchema('foo.bar.str', schema)
+
+      it 'it respects the scoped defaults', ->
+        expect(atom.config.get('foo.bar.str')).toBe 'ok'
+        expect(atom.config.get(['.source.js'], 'foo.bar.str')).toBe 'omg'
+        expect(atom.config.get(['.source.coffee'], 'foo.bar.str')).toBe 'ok'
+
   describe "scoped settings", ->
     describe ".get(scopeDescriptor, keyPath)", ->
       it "returns the property with the most specific scope selector", ->

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -853,7 +853,7 @@ class Config
       @scopedSettingsStore.addProperties('schema-default', scopedDefaults)
 
     if schema.type is 'object' and schema.properties? and isPlainObject(schema.properties)
-      keys = if keyPath? then keyPath.split('.') else []
+      keys = splitKeyPath(keyPath)
       for key, childValue of schema.properties
         continue unless schema.properties.hasOwnProperty(key)
         @setScopedDefaultsFromSchema(keys.concat([key]).join('.'), childValue)


### PR DESCRIPTION
With this, schemas can specify defaults for scopes:

``` coffee
type: 'string'
default: 'ok'
scopes:
  '.source.js':
    default: 'omg' 
```

This structure allows for a separate schema for each scope in the future, but for now, I'm only using the `default` key.

Refs #3898 
