### PR TITLE
Add extension cache for installed packages

### DIFF
--- a/build/tasks/generate-module-cache-task.coffee
+++ b/build/tasks/generate-module-cache-task.coffee
@@ -36,23 +36,4 @@ module.exports = (grunt) ->
         'react-atom-fork': metadata.dependencies['react-atom-fork']
       }
 
-    validExtensions = ['.js', '.coffee', '.json', '.node']
-
-    extensions = {}
-    onFile = (filePath) ->
-      filePath = path.relative(appDir, filePath)
-      segments = filePath.split(path.sep)
-      return if segments.length > 1 and not (segments[0] in ['exports', 'node_modules', 'src', 'static', 'vendor'])
-
-      extension = path.extname(filePath)
-      if extension in validExtensions
-        extensions[extension] ?= []
-        extensions[extension].push(filePath)
-
-    onDirectory = -> true
-
-    files = fs.traverseTreeSync(appDir, onFile, onDirectory)
-
-    metadata._atomModuleCache.extensions = extensions
-
     grunt.file.write(path.join(appDir, 'package.json'), JSON.stringify(metadata, null, 2))

--- a/src/module-cache.coffee
+++ b/src/module-cache.coffee
@@ -290,11 +290,10 @@ exports.add = (directoryPath, metadata) ->
       else
         cache.folders[directoryPath] = entry.dependencies
 
-  if directoryPath is cache.resourcePath
-    for extension, paths of cacheToAdd.extensions
-      cache.extensions[extension] ?= new Set()
-      for filePath in paths
-        cache.extensions[extension].add("#{directoryPath}#{path.sep}#{filePath}")
+  for extension, paths of cacheToAdd.extensions
+    cache.extensions[extension] ?= new Set()
+    for filePath in paths
+      cache.extensions[extension].add("#{directoryPath}#{path.sep}#{filePath}")
 
   return
 


### PR DESCRIPTION
When #3761 was landed, there was an `extensions` object written to Atom's `package.json` file that was a map of extensions to files.

This was used to speed up load time of relative requires by knowing the extension ahead of time so one or more files wasn't stat-ed while it was being resolved.

Now that that has been released and appears to be having major upsides, add that same extension cache to all installed packages.

This should further reduce the count to `Module._findPath` for all the packages installed to `~/.atom/packages`.

These extensions will be added on the next `apm install` and `apm upgrade` for packages already installed, and can also be regenerated by running `apm rebuild-module-cache`.
