### PR TITLE
Add a ScopeDescriptor object

### DIFF
--- a/docs/advanced/scopes-and-scope-descriptors.md
+++ b/docs/advanced/scopes-and-scope-descriptors.md
@@ -84,4 +84,4 @@ valueForLanguage = atom.config.get(editor.getRootScopeDescriptor(), 'my-package.
 [editor-scopeDescriptorForBufferPosition]:https://atom.io/docs/api/latest/TextEditor#instance-scopeDescriptorForBufferPosition
 
 [cursor-getScopeDescriptor]:https://atom.io/docs/api/latest/Cursor#instance-getScopeDescriptor
-[scope-desctiptor]:https://atom.io/docs/api/latest/ScopeDescriptor
+[scope-descriptor]:https://atom.io/docs/api/latest/ScopeDescriptor

--- a/docs/advanced/scopes-and-scope-descriptors.md
+++ b/docs/advanced/scopes-and-scope-descriptors.md
@@ -42,7 +42,9 @@ atom.config.set('.source.js .function.name', 'my-package.my-setting', 'special v
 
 ## Scope Descriptors
 
-A scope descriptor is an `Array` of `String`s describing a path from the root of the syntax tree to a token including _all_ scope names for the entire path.
+A scope descriptor is an [Object][scope-descriptor] that wraps an `Array` of
+`String`s. The Array describes a path from the root of the syntax tree to a
+token including _all_ scope names for the entire path.
 
 In our JavaScript example above, a scope descriptor for the function name token would be:
 
@@ -82,3 +84,4 @@ valueForLanguage = atom.config.get(editor.getRootScopeDescriptor(), 'my-package.
 [editor-scopeDescriptorForBufferPosition]:https://atom.io/docs/api/latest/TextEditor#instance-scopeDescriptorForBufferPosition
 
 [cursor-getScopeDescriptor]:https://atom.io/docs/api/latest/Cursor#instance-getScopeDescriptor
+[scope-desctiptor]:https://atom.io/docs/api/latest/ScopeDescriptor

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3660,10 +3660,10 @@ describe "TextEditor", ->
         {tokens} = grammar.tokenizeLine("var i; // http://github.com")
 
         expect(tokens[0].value).toBe "var"
-        expect(tokens[0].scopeDescriptor).toEqual ["source.js", "storage.modifier.js"]
+        expect(tokens[0].scopes).toEqual ["source.js", "storage.modifier.js"]
 
         expect(tokens[6].value).toBe "http://github.com"
-        expect(tokens[6].scopeDescriptor).toEqual ["source.js", "comment.line.double-slash.js", "markup.underline.link.http.hyperlink"]
+        expect(tokens[6].scopes).toEqual ["source.js", "comment.line.double-slash.js", "markup.underline.link.http.hyperlink"]
 
     describe "when the grammar is added", ->
       it "retokenizes existing buffers that contain tokens that match the injection selector", ->
@@ -3675,7 +3675,7 @@ describe "TextEditor", ->
 
           {tokens} = editor.tokenizedLineForScreenRow(0)
           expect(tokens[1].value).toBe " http://github.com"
-          expect(tokens[1].scopeDescriptor).toEqual ["source.js", "comment.line.double-slash.js"]
+          expect(tokens[1].scopes).toEqual ["source.js", "comment.line.double-slash.js"]
 
         waitsForPromise ->
           atom.packages.activatePackage('language-hyperlink')
@@ -3683,7 +3683,7 @@ describe "TextEditor", ->
         runs ->
           {tokens} = editor.tokenizedLineForScreenRow(0)
           expect(tokens[2].value).toBe "http://github.com"
-          expect(tokens[2].scopeDescriptor).toEqual ["source.js", "comment.line.double-slash.js", "markup.underline.link.http.hyperlink"]
+          expect(tokens[2].scopes).toEqual ["source.js", "comment.line.double-slash.js", "markup.underline.link.http.hyperlink"]
 
       describe "when the grammar is updated", ->
         it "retokenizes existing buffers that contain tokens that match the injection selector", ->
@@ -3695,7 +3695,7 @@ describe "TextEditor", ->
 
             {tokens} = editor.tokenizedLineForScreenRow(0)
             expect(tokens[1].value).toBe " SELECT * FROM OCTOCATS"
-            expect(tokens[1].scopeDescriptor).toEqual ["source.js", "comment.line.double-slash.js"]
+            expect(tokens[1].scopes).toEqual ["source.js", "comment.line.double-slash.js"]
 
           waitsForPromise ->
             atom.packages.activatePackage('package-with-injection-selector')
@@ -3703,7 +3703,7 @@ describe "TextEditor", ->
           runs ->
             {tokens} = editor.tokenizedLineForScreenRow(0)
             expect(tokens[1].value).toBe " SELECT * FROM OCTOCATS"
-            expect(tokens[1].scopeDescriptor).toEqual ["source.js", "comment.line.double-slash.js"]
+            expect(tokens[1].scopes).toEqual ["source.js", "comment.line.double-slash.js"]
 
           waitsForPromise ->
             atom.packages.activatePackage('language-sql')
@@ -3711,7 +3711,7 @@ describe "TextEditor", ->
           runs ->
             {tokens} = editor.tokenizedLineForScreenRow(0)
             expect(tokens[2].value).toBe "SELECT"
-            expect(tokens[2].scopeDescriptor).toEqual ["source.js", "comment.line.double-slash.js", "keyword.other.DML.sql"]
+            expect(tokens[2].scopes).toEqual ["source.js", "comment.line.double-slash.js", "keyword.other.DML.sql"]
 
   describe ".normalizeTabsInBufferRange()", ->
     it "normalizes tabs depending on the editor's soft tab/tab length settings", ->

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -51,12 +51,12 @@ describe "TokenizedBuffer", ->
       it "initially creates un-tokenized screen lines, then tokenizes lines chunk at a time in the background", ->
         line0 = tokenizedBuffer.tokenizedLineForRow(0)
         expect(line0.tokens.length).toBe 1
-        expect(line0.tokens[0]).toEqual(value: line0.text, scopeDescriptor: ['source.js'])
+        expect(line0.tokens[0]).toEqual(value: line0.text, scopes: ['source.js'])
 
         line11 = tokenizedBuffer.tokenizedLineForRow(11)
         expect(line11.tokens.length).toBe 2
-        expect(line11.tokens[0]).toEqual(value: "  ", scopeDescriptor: ['source.js'], isAtomic: true)
-        expect(line11.tokens[1]).toEqual(value: "return sort(Array.apply(this, arguments));", scopeDescriptor: ['source.js'])
+        expect(line11.tokens[0]).toEqual(value: "  ", scopes: ['source.js'], isAtomic: true)
+        expect(line11.tokens[1]).toEqual(value: "return sort(Array.apply(this, arguments));", scopes: ['source.js'])
 
         # background tokenization has not begun
         expect(tokenizedBuffer.tokenizedLineForRow(0).ruleStack).toBeUndefined()
@@ -149,10 +149,10 @@ describe "TokenizedBuffer", ->
           it "updates tokens to reflect the change", ->
             buffer.setTextInRange([[0, 0], [2, 0]], "foo()\n7\n")
 
-            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[1]).toEqual(value: '(', scopeDescriptor: ['source.js', 'meta.brace.round.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: '7', scopeDescriptor: ['source.js', 'constant.numeric.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[1]).toEqual(value: '(', scopes: ['source.js', 'meta.brace.round.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: '7', scopes: ['source.js', 'constant.numeric.js'])
             # line 2 is unchanged
-            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[2]).toEqual(value: 'if', scopeDescriptor: ['source.js', 'keyword.control.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[2]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
 
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]
@@ -164,7 +164,7 @@ describe "TokenizedBuffer", ->
               buffer.insert([5, 30], '/* */')
               changeHandler.reset()
               buffer.insert([2, 0], '/*')
-              expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopeDescriptor).toEqual ['source.js']
+              expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js']
               expect(changeHandler).toHaveBeenCalled()
               [event] = changeHandler.argsForCall[0]
               delete event.bufferChange
@@ -172,9 +172,9 @@ describe "TokenizedBuffer", ->
               changeHandler.reset()
 
               advanceClock()
-              expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopeDescriptor).toEqual ['source.js', 'comment.block.js']
-              expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0].scopeDescriptor).toEqual ['source.js', 'comment.block.js']
-              expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].scopeDescriptor).toEqual ['source.js', 'comment.block.js']
+              expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+              expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+              expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
               expect(changeHandler).toHaveBeenCalled()
               [event] = changeHandler.argsForCall[0]
               delete event.bufferChange
@@ -185,23 +185,23 @@ describe "TokenizedBuffer", ->
             buffer.insert([5, 0], '*/')
 
             buffer.insert([1, 0], 'var ')
-            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0].scopeDescriptor).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
 
         describe "when lines are both updated and removed", ->
           it "updates tokens to reflect the change", ->
             buffer.setTextInRange([[1, 0], [3, 0]], "foo()")
 
             # previous line 0 remains
-            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0]).toEqual(value: 'var', scopeDescriptor: ['source.js', 'storage.modifier.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0]).toEqual(value: 'var', scopes: ['source.js', 'storage.modifier.js'])
 
             # previous line 3 should be combined with input to form line 1
-            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: 'foo', scopeDescriptor: ['source.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[6]).toEqual(value: '=', scopeDescriptor: ['source.js', 'keyword.operator.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[6]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
 
             # lines below deleted regions should be shifted upward
-            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[2]).toEqual(value: 'while', scopeDescriptor: ['source.js', 'keyword.control.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[4]).toEqual(value: '=', scopeDescriptor: ['source.js', 'keyword.operator.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[4]).toEqual(value: '<', scopeDescriptor: ['source.js', 'keyword.operator.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[2]).toEqual(value: 'while', scopes: ['source.js', 'keyword.control.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[4]).toEqual(value: '<', scopes: ['source.js', 'keyword.operator.js'])
 
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]
@@ -214,8 +214,8 @@ describe "TokenizedBuffer", ->
             changeHandler.reset()
 
             buffer.setTextInRange([[2, 0], [3, 0]], '/*')
-            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0].scopeDescriptor).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopeDescriptor).toEqual ['source.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js']
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]
             delete event.bufferChange
@@ -223,8 +223,8 @@ describe "TokenizedBuffer", ->
             changeHandler.reset()
 
             advanceClock()
-            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopeDescriptor).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0].scopeDescriptor).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]
             delete event.bufferChange
@@ -235,19 +235,19 @@ describe "TokenizedBuffer", ->
             buffer.setTextInRange([[1, 0], [2, 0]], "foo()\nbar()\nbaz()\nquux()")
 
             # previous line 0 remains
-            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0]).toEqual( value: 'var', scopeDescriptor: ['source.js', 'storage.modifier.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0]).toEqual( value: 'var', scopes: ['source.js', 'storage.modifier.js'])
 
             # 3 new lines inserted
-            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: 'foo', scopeDescriptor: ['source.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0]).toEqual(value: 'bar', scopeDescriptor: ['source.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0]).toEqual(value: 'baz', scopeDescriptor: ['source.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0]).toEqual(value: 'bar', scopes: ['source.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0]).toEqual(value: 'baz', scopes: ['source.js'])
 
             # previous line 2 is joined with quux() on line 4
-            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0]).toEqual(value: 'quux', scopeDescriptor: ['source.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[4]).toEqual(value: 'if', scopeDescriptor: ['source.js', 'keyword.control.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0]).toEqual(value: 'quux', scopes: ['source.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[4]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
 
             # previous line 3 is pushed down to become line 5
-            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[4]).toEqual(value: '=', scopeDescriptor: ['source.js', 'keyword.operator.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
 
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]
@@ -264,17 +264,17 @@ describe "TokenizedBuffer", ->
             [event] = changeHandler.argsForCall[0]
             delete event.bufferChange
             expect(event).toEqual(start: 2, end: 2, delta: 2)
-            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0].scopeDescriptor).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopeDescriptor).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0].scopeDescriptor).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].scopeDescriptor).toEqual ['source.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].scopes).toEqual ['source.js']
             changeHandler.reset()
 
             advanceClock() # tokenize invalidated lines in background
-            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].scopeDescriptor).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(6).tokens[0].scopeDescriptor).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(7).tokens[0].scopeDescriptor).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(8).tokens[0].scopeDescriptor).not.toBe ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(6).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(7).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLineForRow(8).tokens[0].scopes).not.toBe ['source.js', 'comment.block.js']
 
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]
@@ -343,7 +343,7 @@ describe "TokenizedBuffer", ->
         expect(tokens[0].value).toBe "#"
         expect(tokens[1].value).toBe " Econ 101"
         expect(tokens[2].value).toBe tabAsSpaces
-        expect(tokens[2].scopeDescriptor).toEqual tokens[1].scopeDescriptor
+        expect(tokens[2].scopes).toEqual tokens[1].scopes
         expect(tokens[2].isAtomic).toBeTruthy()
         expect(tokens[3].value).toBe ""
 
@@ -526,7 +526,7 @@ describe "TokenizedBuffer", ->
         fullyTokenize(tokenizedBuffer)
 
         {tokens} = tokenizedBuffer.tokenizedLineForRow(0)
-        expect(tokens[0]).toEqual value: "<div class='name'>", scopeDescriptor: ["text.html.ruby"]
+        expect(tokens[0]).toEqual value: "<div class='name'>", scopes: ["text.html.ruby"]
 
       waitsForPromise ->
         atom.packages.activatePackage('language-html')
@@ -534,7 +534,7 @@ describe "TokenizedBuffer", ->
       runs ->
         fullyTokenize(tokenizedBuffer)
         {tokens} = tokenizedBuffer.tokenizedLineForRow(0)
-        expect(tokens[0]).toEqual value: '<', scopeDescriptor: ["text.html.ruby","meta.tag.block.any.html","punctuation.definition.tag.begin.html"]
+        expect(tokens[0]).toEqual value: '<', scopes: ["text.html.ruby","meta.tag.block.any.html","punctuation.definition.tag.begin.html"]
 
   describe ".tokenForPosition(position)", ->
     afterEach ->
@@ -545,9 +545,9 @@ describe "TokenizedBuffer", ->
       buffer = atom.project.bufferForPathSync('sample.js')
       tokenizedBuffer = new TokenizedBuffer({buffer})
       fullyTokenize(tokenizedBuffer)
-      expect(tokenizedBuffer.tokenForPosition([1,0]).scopeDescriptor).toEqual ["source.js"]
-      expect(tokenizedBuffer.tokenForPosition([1,1]).scopeDescriptor).toEqual ["source.js"]
-      expect(tokenizedBuffer.tokenForPosition([1,2]).scopeDescriptor).toEqual ["source.js", "storage.modifier.js"]
+      expect(tokenizedBuffer.tokenForPosition([1,0]).scopes).toEqual ["source.js"]
+      expect(tokenizedBuffer.tokenForPosition([1,1]).scopes).toEqual ["source.js"]
+      expect(tokenizedBuffer.tokenForPosition([1,2]).scopes).toEqual ["source.js", "storage.modifier.js"]
 
   describe ".bufferRangeForScopeAtPosition(selector, position)", ->
     beforeEach ->

--- a/spec/tokenized-line-spec.coffee
+++ b/spec/tokenized-line-spec.coffee
@@ -28,7 +28,7 @@ describe "TokenizedLine", ->
             ensureValidScopeTree(child, scopeDescriptor.concat([scopeTree.scope]))
         else
           expect(scopeTree).toBe tokens[tokenIndex++]
-          expect(scopeDescriptor).toEqual scopeTree.scopeDescriptor
+          expect(scopeDescriptor).toEqual scopeTree.scopes
 
       waitsForPromise ->
         atom.project.open('coffee.coffee').then (o) -> editor = o

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -878,7 +878,7 @@ class Config
     @emitter.emit 'did-change'
 
   getRawScopedValue: (scopeDescriptor, keyPath) ->
-    scopeDescriptor = ScopeDescriptor.create(scopeDescriptor)
+    scopeDescriptor = ScopeDescriptor.fromObject(scopeDescriptor)
     @scopedSettingsStore.getPropertyValue(scopeDescriptor.getScopeChain(), keyPath)
 
   observeScopedKeyPath: (scopeDescriptor, keyPath, callback) ->
@@ -906,7 +906,7 @@ class Config
   # * language mode uses it for one thing.
   # * autocomplete uses it for editor.completions
   settingsForScopeDescriptor: (scopeDescriptor, keyPath) ->
-    scopeDescriptor = ScopeDescriptor.create(scopeDescriptor)
+    scopeDescriptor = ScopeDescriptor.fromObject(scopeDescriptor)
     @scopedSettingsStore.getProperties(scopeDescriptor.getScopeChain(), keyPath)
 
 # Base schema enforcers. These will coerce raw input into the specified type,

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -352,7 +352,7 @@ class Config
     if args.length is 2
       # observe(keyPath, callback)
       [keyPath, callback, scopeDescriptor, options] = args
-    else if args.length is 3 and Array.isArray(scopeDescriptor)
+    else if args.length is 3 and (Array.isArray(scopeDescriptor) or scopeDescriptor instanceof ScopeDescriptor)
       # observe(scopeDescriptor, keyPath, callback)
       [scopeDescriptor, keyPath, callback, options] = args
     else if args.length is 3 and _.isString(scopeDescriptor) and _.isObject(keyPath)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -9,6 +9,7 @@ pathWatcher = require 'pathwatcher'
 {deprecate} = require 'grim'
 
 ScopedPropertyStore = require 'scoped-property-store'
+ScopeDescriptor = require './scope-descriptor'
 
 # Essential: Used to access all of Atom's configuration details.
 #
@@ -335,7 +336,7 @@ class Config
   #   # do stuff with value
   # ```
   #
-  # * `scopeDescriptor` (optional) {Array} of {String}s describing a path from
+  # * `scopeDescriptor` (optional) {ScopeDescriptor} describing a path from
   #   the root of the syntax tree to a token. Get one by calling
   #   {editor.getLastCursor().getScopeDescriptor()}. See {::get} for examples.
   #   See [the scopes docs](https://atom.io/docs/latest/advanced/scopes-and-scope-descriptors)
@@ -373,7 +374,7 @@ class Config
   # Essential: Add a listener for changes to a given key path. If `keyPath` is
   # not specified, your callback will be called on changes to any key.
   #
-  # * `scopeDescriptor` (optional) {Array} of {String}s describing a path from
+  # * `scopeDescriptor` (optional) {ScopeDescriptor} describing a path from
   #   the root of the syntax tree to a token. Get one by calling
   #   {editor.getLastCursor().getScopeDescriptor()}. See {::get} for examples.
   #   See [the scopes docs](https://atom.io/docs/latest/advanced/scopes-and-scope-descriptors)
@@ -444,7 +445,7 @@ class Config
   # atom.config.get(scopeDescriptor, 'editor.tabLength') # => 2
   # ```
   #
-  # * `scopeDescriptor` (optional) {Array} of {String}s describing a path from
+  # * `scopeDescriptor` (optional) {ScopeDescriptor} describing a path from
   #   the root of the syntax tree to a token. Get one by calling
   #   {editor.getLastCursor().getScopeDescriptor()}
   #   See [the scopes docs](https://atom.io/docs/latest/advanced/scopes-and-scope-descriptors)
@@ -877,8 +878,8 @@ class Config
     @emitter.emit 'did-change'
 
   getRawScopedValue: (scopeDescriptor, keyPath) ->
-    scopeChain = @scopeChainForScopeDescriptor(scopeDescriptor)
-    @scopedSettingsStore.getPropertyValue(scopeChain, keyPath)
+    scopeDescriptor = ScopeDescriptor.create(scopeDescriptor)
+    @scopedSettingsStore.getPropertyValue(scopeDescriptor.getScopeChain(), keyPath)
 
   observeScopedKeyPath: (scopeDescriptor, keyPath, callback) ->
     oldValue = @get(scopeDescriptor, keyPath)
@@ -905,19 +906,8 @@ class Config
   # * language mode uses it for one thing.
   # * autocomplete uses it for editor.completions
   settingsForScopeDescriptor: (scopeDescriptor, keyPath) ->
-    scopeChain = scopeDescriptor
-      .map (scope) ->
-        scope = ".#{scope}" unless scope[0] is '.'
-        scope
-      .join(' ')
-    @scopedSettingsStore.getProperties(scopeChain, keyPath)
-
-  scopeChainForScopeDescriptor: (scopeDescriptor) ->
-    scopeDescriptor
-      .map (scope) ->
-        scope = ".#{scope}" unless scope[0] is '.'
-        scope
-      .join(' ')
+    scopeDescriptor = ScopeDescriptor.create(scopeDescriptor)
+    @scopedSettingsStore.getProperties(scopeDescriptor.getScopeChain(), keyPath)
 
 # Base schema enforcers. These will coerce raw input into the specified type,
 # and will throw an error when the value cannot be coerced. Throwing the error

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -221,7 +221,7 @@ class Cursor extends Model
     @editor.scopeDescriptorForBufferPosition(@getBufferPosition())
   getScopes: ->
     Grim.deprecate 'Use Cursor::getScopeDescriptor() instead'
-    @getScopeDescriptor()
+    @getScopeDescriptor().getScopesArray()
 
   # Public: Returns true if this cursor has no non-whitespace characters before
   # its current position.

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -216,7 +216,7 @@ class Cursor extends Model
 
   # Public: Retrieves the scope descriptor for the cursor's current position.
   #
-  # Returns an {Array} of {String}s.
+  # Returns a {ScopeDescriptor}
   getScopeDescriptor: ->
     @editor.scopeDescriptorForBufferPosition(@getBufferPosition())
   getScopes: ->

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -757,7 +757,7 @@ class DisplayBuffer extends Model
   #
   # bufferPosition - A {Point} in the {TextBuffer}
   #
-  # Returns an {Array} of {String}s.
+  # Returns a {ScopeDescriptor}.
   scopeDescriptorForBufferPosition: (bufferPosition) ->
     @tokenizedBuffer.scopeDescriptorForPosition(bufferPosition)
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -650,7 +650,7 @@ class DisplayBuffer extends Model
     left = 0
     column = 0
     for token in @tokenizedLineForScreenRow(targetRow).tokens
-      charWidths = @getScopedCharWidths(token.scopeDescriptor)
+      charWidths = @getScopedCharWidths(token.scopes)
       for char in token.value
         return {top, left} if column is targetColumn
         left += charWidths[char] ? defaultCharWidth unless char is '\0'
@@ -669,7 +669,7 @@ class DisplayBuffer extends Model
     left = 0
     column = 0
     for token in @tokenizedLineForScreenRow(row).tokens
-      charWidths = @getScopedCharWidths(token.scopeDescriptor)
+      charWidths = @getScopedCharWidths(token.scopes)
       for char in token.value
         charWidth = charWidths[char] ? defaultCharWidth
         break if targetLeft <= left + (charWidth / 2)

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -200,7 +200,7 @@ LinesComponent = React.createClass
     firstTrailingWhitespacePosition = text.search(/\s*$/)
     lineIsWhitespaceOnly = firstTrailingWhitespacePosition is 0
     for token in tokens
-      innerHTML += @updateScopeStack(scopeStack, token.scopeDescriptor)
+      innerHTML += @updateScopeStack(scopeStack, token.scopes)
       hasIndentGuide = not mini and showIndentGuide and (token.hasLeadingWhitespace() or (token.hasTrailingWhitespace() and lineIsWhitespaceOnly))
       innerHTML += token.getValueAsHtml({hasIndentGuide})
 

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -308,8 +308,8 @@ LinesComponent = React.createClass
     iterator = null
     charIndex = 0
 
-    for {value, scopeDescriptor}, tokenIndex in tokenizedLine.tokens
-      charWidths = editor.getScopedCharWidths(scopeDescriptor)
+    for {value, scopes}, tokenIndex in tokenizedLine.tokens
+      charWidths = editor.getScopedCharWidths(scopes)
 
       for char in value
         continue if char is '\0'
@@ -331,7 +331,7 @@ LinesComponent = React.createClass
           rangeForMeasurement.setStart(textNode, i)
           rangeForMeasurement.setEnd(textNode, i + 1)
           charWidth = rangeForMeasurement.getBoundingClientRect().width
-          editor.setScopedCharWidth(scopeDescriptor, char, charWidth)
+          editor.setScopedCharWidth(scopes, char, charWidth)
 
         charIndex++
 

--- a/src/scope-descriptor.coffee
+++ b/src/scope-descriptor.coffee
@@ -2,6 +2,9 @@
 # root of the syntax tree to a token including _all_ scope names for the entire
 # path.
 #
+# Methods that take a `ScopeDescriptor` will also accept an {Array} of {Strings}
+# scope names e.g. `['.source.js']`.
+#
 # You can use `ScopeDescriptor`s to get language-specific config settings via
 # {Config::get}.
 #

--- a/src/scope-descriptor.coffee
+++ b/src/scope-descriptor.coffee
@@ -16,11 +16,11 @@
 # for more information.
 module.exports =
 class ScopeDescriptor
-  @fromObject: (descriptor) ->
-    if descriptor instanceof ScopeDescriptor
-      descriptor
+  @fromObject: (scopes) ->
+    if scopes instanceof ScopeDescriptor
+      scopes
     else
-      new ScopeDescriptor({descriptor})
+      new ScopeDescriptor({scopes})
 
   ###
   Section: Construction and Destruction
@@ -29,11 +29,14 @@ class ScopeDescriptor
   # Public: Create a {ScopeDescriptor} object.
   #
   # * `object` {Object}
-  #   * `descriptor` {Array} of {String}s
-  constructor: ({@descriptor}) ->
+  #   * `scopes` {Array} of {String}s
+  constructor: ({@scopes}) ->
+
+  # Public: Returns an {Array} of {String}s
+  getScopesArray: -> @scopes
 
   getScopeChain: ->
-    @descriptor
+    @scopes
       .map (scope) ->
         scope = ".#{scope}" unless scope[0] is '.'
         scope

--- a/src/scope-descriptor.coffee
+++ b/src/scope-descriptor.coffee
@@ -1,5 +1,19 @@
-
-# Extended:
+# Extended: Wraps an {Array} of `String`s. The Array describes a path from the
+# root of the syntax tree to a token including _all_ scope names for the entire
+# path.
+#
+# You can use `ScopeDescriptor`s to get language-specific config settings via
+# {Config::get}.
+#
+# You should not need to create a `ScopeDescriptor` directly.
+#
+# * {Editor::getRootScopeDescriptor} to get the language's descriptor.
+# * {Editor::scopeDescriptorForBufferPosition} to get the descriptor at a
+#   specific position in the buffer.
+# * {Cursor::getScopeDescriptor} to get a cursor's descriptor based on position.
+#
+# See the [scopes and scope descriptor guide](https://atom.io/docs/v0.138.0/advanced/scopes-and-scope-descriptors)
+# for more information.
 module.exports =
 class ScopeDescriptor
   @create: (descriptor) ->
@@ -12,7 +26,10 @@ class ScopeDescriptor
   Section: Construction and Destruction
   ###
 
-  # Public:
+  # Public: Create a {ScopeDescriptor} object.
+  #
+  # * `object` {Object}
+  #   * `descriptor` {Array} of {String}s
   constructor: ({@descriptor}) ->
 
   getScopeChain: ->

--- a/src/scope-descriptor.coffee
+++ b/src/scope-descriptor.coffee
@@ -16,7 +16,7 @@
 # for more information.
 module.exports =
 class ScopeDescriptor
-  @create: (descriptor) ->
+  @fromObject: (descriptor) ->
     if descriptor instanceof ScopeDescriptor
       descriptor
     else

--- a/src/scope-descriptor.coffee
+++ b/src/scope-descriptor.coffee
@@ -1,0 +1,23 @@
+
+# Extended:
+module.exports =
+class ScopeDescriptor
+  @create: (descriptor) ->
+    if descriptor instanceof ScopeDescriptor
+      descriptor
+    else
+      new ScopeDescriptor({descriptor})
+
+  ###
+  Section: Construction and Destruction
+  ###
+
+  # Public:
+  constructor: ({@descriptor}) ->
+
+  getScopeChain: ->
+    @descriptor
+      .map (scope) ->
+        scope = ".#{scope}" unless scope[0] is '.'
+        scope
+      .join(' ')

--- a/src/syntax.coffee
+++ b/src/syntax.coffee
@@ -32,7 +32,7 @@ class Syntax extends GrammarRegistry
   serialize: ->
     {deserializer: @constructor.name, @grammarOverridesByPath}
 
-  createToken: (value, scopeDescriptor) -> new Token({value, scopeDescriptor})
+  createToken: (value, scopes) -> new Token({value, scopes})
 
   # Deprecated: Used by settings-view to display snippets for packages
   @::accessor 'propertyStore', ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -487,7 +487,7 @@ class TextEditor extends Model
       when 'decoration-updated'
         deprecate("Use Decoration::onDidChangeProperties instead. You will get the decoration back from `TextEditor::decorateMarker()`")
       when 'decoration-changed'
-        deprecate("Use Marker::onDidChange instead. eg. `editor::decorateMarker(...).getMarker().onDidChange()`")
+        deprecate("Use Marker::onDidChange instead. e.g. `editor::decorateMarker(...).getMarker().onDidChange()`")
 
       when 'screen-lines-changed'
         deprecate("Use TextEditor::onDidChange instead")
@@ -1216,7 +1216,7 @@ class TextEditor extends Model
   # ## Arguments
   #
   # * `marker` A {Marker} you want this decoration to follow.
-  # * `decorationParams` An {Object} representing the decoration eg. `{type: 'gutter', class: 'linter-error'}`
+  # * `decorationParams` An {Object} representing the decoration e.g. `{type: 'gutter', class: 'linter-error'}`
   #   * `type` There are a few supported decoration types: `gutter`, `line`, and `highlight`
   #   * `class` This CSS class will be applied to the decorated line number,
   #     line, or highlight.
@@ -2371,7 +2371,7 @@ class TextEditor extends Model
   ###
 
   # Essential: Returns a {ScopeDescriptor} that includes this editor's language.
-  # eg. `['.source.ruby']`, or `['.source.coffee']`. You can use this with
+  # e.g. `['.source.ruby']`, or `['.source.coffee']`. You can use this with
   # {Config::get} to get language specific config values.
   getRootScopeDescriptor: ->
     @displayBuffer.getRootScopeDescriptor()
@@ -2398,7 +2398,7 @@ class TextEditor extends Model
   # For example, if you wanted to find the string surrounding the cursor, you
   # could call `editor.bufferRangeForScopeAtCursor(".string.quoted")`.
   #
-  # * `scopeSelector` {String} selector. eg. `'.source.ruby'`
+  # * `scopeSelector` {String} selector. e.g. `'.source.ruby'`
   #
   # Returns a {Range}.
   bufferRangeForScopeAtCursor: (scopeSelector) ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2407,7 +2407,7 @@ class TextEditor extends Model
   # Extended: Determine if the given row is entirely a comment
   isBufferRowCommented: (bufferRow) ->
     if match = @lineTextForBufferRow(bufferRow).match(/\S/)
-      scopeDescriptor = @tokenForBufferPosition([bufferRow, match.index]).scopeDescriptor
+      scopeDescriptor = @tokenForBufferPosition([bufferRow, match.index]).scopes
       @commentScopeSelector ?= new TextMateScopeSelector('comment.*')
       @commentScopeSelector.matches(scopeDescriptor)
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2370,8 +2370,8 @@ class TextEditor extends Model
   Section: Managing Syntax Scopes
   ###
 
-  # Essential: Returns the scope descriptor that includes the language. eg.
-  # `['.source.ruby']`, or `['.source.coffee']`. You can use this with
+  # Essential: Returns a {ScopeDescriptor} that includes this editor's language.
+  # eg. `['.source.ruby']`, or `['.source.coffee']`. You can use this with
   # {Config::get} to get language specific config values.
   getRootScopeDescriptor: ->
     @displayBuffer.getRootScopeDescriptor()
@@ -2385,7 +2385,7 @@ class TextEditor extends Model
   #
   # * `bufferPosition` A {Point} or {Array} of [row, column].
   #
-  # Returns an {Array} of {String}s.
+  # Returns a {ScopeDescriptor}.
   scopeDescriptorForBufferPosition: (bufferPosition) -> @displayBuffer.scopeDescriptorForBufferPosition(bufferPosition)
   scopesForBufferPosition: (bufferPosition) ->
     deprecate 'Use ::scopeDescriptorForBufferPosition instead'
@@ -2397,9 +2397,11 @@ class TextEditor extends Model
   # For example, if you wanted to find the string surrounding the cursor, you
   # could call `editor.bufferRangeForScopeAtCursor(".string.quoted")`.
   #
+  # * `scopeSelector` {String} selector. eg. `'.source.ruby'`
+  #
   # Returns a {Range}.
-  bufferRangeForScopeAtCursor: (selector) ->
-    @displayBuffer.bufferRangeForScopeAtPosition(selector, @getCursorBufferPosition())
+  bufferRangeForScopeAtCursor: (scopeSelector) ->
+    @displayBuffer.bufferRangeForScopeAtPosition(scopeSelector, @getCursorBufferPosition())
 
   # Extended: Determine if the given row is entirely a comment
   isBufferRowCommented: (bufferRow) ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2386,10 +2386,11 @@ class TextEditor extends Model
   # * `bufferPosition` A {Point} or {Array} of [row, column].
   #
   # Returns a {ScopeDescriptor}.
-  scopeDescriptorForBufferPosition: (bufferPosition) -> @displayBuffer.scopeDescriptorForBufferPosition(bufferPosition)
+  scopeDescriptorForBufferPosition: (bufferPosition) ->
+    @displayBuffer.scopeDescriptorForBufferPosition(bufferPosition)
   scopesForBufferPosition: (bufferPosition) ->
-    deprecate 'Use ::scopeDescriptorForBufferPosition instead'
-    @scopeDescriptorForBufferPosition(bufferPosition)
+    deprecate 'Use ::scopeDescriptorForBufferPosition instead. The return value has changed! It now returns a `ScopeDescriptor`'
+    @scopeDescriptorForBufferPosition(bufferPosition).getScopesArray()
 
   # Extended: Get the range in buffer coordinates of all tokens surrounding the
   # cursor that match the given scope selector.
@@ -2417,11 +2418,11 @@ class TextEditor extends Model
   tokenForBufferPosition: (bufferPosition) -> @displayBuffer.tokenForBufferPosition(bufferPosition)
 
   scopesAtCursor: ->
-    deprecate 'Use editor.getLastCursor().scopesAtCursor() instead'
-    @getLastCursor().getScopeDescriptor()
+    deprecate 'Use editor.getLastCursor().getScopeDescriptor() instead'
+    @getLastCursor().getScopeDescriptor().getScopesArray()
   getCursorScopes: ->
-    deprecate 'Use editor.getLastCursor().scopesAtCursor() instead'
-    @scopesAtCursor()
+    deprecate 'Use editor.getLastCursor().getScopeDescriptor() instead'
+    @scopesAtCursor().getScopesArray()
 
   ###
   Section: Clipboard Operations

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2422,7 +2422,7 @@ class TextEditor extends Model
     @getLastCursor().getScopeDescriptor().getScopesArray()
   getCursorScopes: ->
     deprecate 'Use editor.getLastCursor().getScopeDescriptor() instead'
-    @scopesAtCursor().getScopesArray()
+    @scopesAtCursor()
 
   ###
   Section: Clipboard Operations

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -106,7 +106,7 @@ class TokenizedBuffer extends Model
   hasTokenForSelector: (selector) ->
     for {tokens} in @tokenizedLines
       for token in tokens
-        return true if selector.matches(token.scopeDescriptor)
+        return true if selector.matches(token.scopes)
     false
 
   retokenizeLines: ->
@@ -248,7 +248,7 @@ class TokenizedBuffer extends Model
 
   buildPlaceholderTokenizedLineForRow: (row) ->
     line = @buffer.lineForRow(row)
-    tokens = [new Token(value: line, scopeDescriptor: [@grammar.scopeName])]
+    tokens = [new Token(value: line, scopes: [@grammar.scopeName])]
     tabLength = @getTabLength()
     indentLevel = @indentLevelForRow(row)
     lineEnding = @buffer.lineEndingForRow(row)
@@ -304,7 +304,7 @@ class TokenizedBuffer extends Model
       0
 
   scopeDescriptorForPosition: (position) ->
-    new ScopeDescriptor(scopes: @tokenForPosition(position).scopeDescriptor)
+    new ScopeDescriptor(scopes: @tokenForPosition(position).scopes)
 
   tokenForPosition: (position) ->
     {row, column} = Point.fromObject(position)

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -80,7 +80,7 @@ class TokenizedBuffer extends Model
     return if grammar is @grammar
     @unsubscribe(@grammar) if @grammar
     @grammar = grammar
-    @rootScopeDescriptor = new ScopeDescriptor(descriptor: [@grammar.scopeName])
+    @rootScopeDescriptor = new ScopeDescriptor(scopes: [@grammar.scopeName])
     @currentGrammarScore = score ? grammar.getScore(@buffer.getPath(), @buffer.getText())
     @subscribe @grammar.onDidUpdate => @retokenizeLines()
 
@@ -304,7 +304,7 @@ class TokenizedBuffer extends Model
       0
 
   scopeDescriptorForPosition: (position) ->
-    new ScopeDescriptor(descriptor: @tokenForPosition(position).scopeDescriptor)
+    new ScopeDescriptor(scopes: @tokenForPosition(position).scopeDescriptor)
 
   tokenForPosition: (position) ->
     {row, column} = Point.fromObject(position)

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -6,6 +6,7 @@ EmitterMixin = require('emissary').Emitter
 Serializable = require 'serializable'
 TokenizedLine = require './tokenized-line'
 Token = require './token'
+ScopeDescriptor = require './scope-descriptor'
 Grim = require 'grim'
 
 module.exports =
@@ -303,7 +304,7 @@ class TokenizedBuffer extends Model
       0
 
   scopeDescriptorForPosition: (position) ->
-    new ScopeDescriptor descriptor: @tokenForPosition(position).scopeDescriptor
+    new ScopeDescriptor(descriptor: @tokenForPosition(position).scopeDescriptor)
 
   tokenForPosition: (position) ->
     {row, column} = Point.fromObject(position)

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -79,7 +79,7 @@ class TokenizedBuffer extends Model
     return if grammar is @grammar
     @unsubscribe(@grammar) if @grammar
     @grammar = grammar
-    @rootScopeDescriptor = [@grammar.scopeName]
+    @rootScopeDescriptor = new ScopeDescriptor(descriptor: [@grammar.scopeName])
     @currentGrammarScore = score ? grammar.getScore(@buffer.getPath(), @buffer.getText())
     @subscribe @grammar.onDidUpdate => @retokenizeLines()
 
@@ -303,7 +303,7 @@ class TokenizedBuffer extends Model
       0
 
   scopeDescriptorForPosition: (position) ->
-    @tokenForPosition(position).scopeDescriptor
+    new ScopeDescriptor descriptor: @tokenForPosition(position).scopeDescriptor
 
   tokenForPosition: (position) ->
     {row, column} = Point.fromObject(position)

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -194,9 +194,9 @@ class TokenizedLine
 
   isComment: ->
     for token in @tokens
-      continue if token.scopeDescriptor.length is 1
+      continue if token.scopes.length is 1
       continue if token.isOnlyWhitespace()
-      for scope in token.scopeDescriptor
+      for scope in token.scopes
         return true if _.contains(scope.split('.'), 'comment')
       break
     false
@@ -226,7 +226,7 @@ class TokenizedLine
 
     scopeStack = []
     for token in @tokens
-      @updateScopeStack(scopeStack, token.scopeDescriptor)
+      @updateScopeStack(scopeStack, token.scopes)
       _.last(scopeStack).children.push(token)
 
     @scopeTree = scopeStack[0]


### PR DESCRIPTION
Adding this as a future-proof. At some point we would like to be able to scope settings to a particular file path (or something else? See https://github.com/atom/atom/issues/3751). The ScopeDescriptor object will be a container for these kinds of things. The `ScopedDescriptor`s returned from the editor can contain the file path, which config can deal with accordingly. 

This is added in a pretty non intrusive way. Similar to text-buffer `Range`, there is a `fromObject` method. So everything that takes a `ScopeDescriptor`, can still take an array of strings. 

Closes #3751
