### PR TITLE
Setting ATOM_HOME

### DIFF
--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -202,6 +202,9 @@ class Atom extends Model
     # Make react.js faster
     process.env.NODE_ENV ?= 'production' unless devMode
 
+    # Set Atom's home so packages don't have to guess it
+    process.env.ATOM_HOME = @getConfigDirPath()
+
     @config = new Config({configDirPath, resourcePath})
     @keymaps = new KeymapManager({configDirPath, resourcePath})
     @keymap = @keymaps # Deprecated


### PR DESCRIPTION
By default many packages (including apm) [discover config directory manually](https://github.com/atom/apm/blob/master/src/config.coffee#L11). Setting ATOM_HOME allows changing default config directory without breaking apm.
