### PR TITLE
Inline package metadata in main package.json file

### DIFF
--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -153,7 +153,7 @@ module.exports = (grunt) ->
       fs.writeFileSync path.join(appDir, 'node_modules', 'symbols-view', 'vendor', 'ctags-win32.exe.ignore'), ''
       fs.writeFileSync path.join(shellAppDir, 'atom.exe.gui'), ''
 
-    dependencies = ['compile', 'generate-license:save', 'generate-module-cache']
+    dependencies = ['compile', 'generate-license:save', 'generate-module-cache', 'compile-packages-slug']
     dependencies.push('copy-info-plist') if process.platform is 'darwin'
     dependencies.push('set-exe-icon') if process.platform is 'win32'
     grunt.task.run(dependencies...)

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -1,6 +1,7 @@
 path = require 'path'
 CSON = require 'season'
 fs = require 'fs-plus'
+_ = require 'underscore-plus'
 
 module.exports = (grunt) ->
   {spawn, rm} = require('./task-helpers')(grunt)
@@ -18,7 +19,10 @@ module.exports = (grunt) ->
       metadata = grunt.file.readJSON(metadataPath)
       continue unless metadata?.engines?.atom?
 
+      moduleCache = metadata._atomModuleCache ? {}
+
       rm metadataPath
+      _.remove(moduleCache.extensions?['.json'] ? [], 'package.json')
 
       for property in ['_from', '_id', 'dist', 'readme', 'readmeFilename']
         delete metadata[property]
@@ -36,6 +40,10 @@ module.exports = (grunt) ->
         rm menuPath
 
       packages[metadata.name] = pack
+
+      for extension, paths of moduleCache.extensions
+        if paths.length is 0
+          delete metadata._atomModuleCache?.extensions[extension]
 
     metadata = grunt.file.readJSON(path.join(appDir, 'package.json'))
     metadata._atomPackages = packages

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -47,7 +47,7 @@ module.exports = (grunt) ->
 
       for extension, paths of moduleCache.extensions
         if paths.length is 0
-          delete metadata._atomModuleCache?.extensions[extension]
+          delete moduleCache.extensions[extension]
 
     metadata = grunt.file.readJSON(path.join(appDir, 'package.json'))
     metadata._atomPackages = packages

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -1,0 +1,35 @@
+path = require 'path'
+CSON = require 'season'
+fs = require 'fs-plus'
+
+module.exports = (grunt) ->
+  {spawn} = require('./task-helpers')(grunt)
+
+  grunt.registerTask 'compile-packages-slug', 'Add package metadata information to to the main package.json file', ->
+    appDir = grunt.config.get('atom.appDir')
+
+    modulesDirectory = path.join(appDir, 'node_modules')
+    packages = {}
+
+    for moduleDirectory in fs.listSync(modulesDirectory)
+      continue if path.basename(moduleDirectory) is '.bin'
+
+      metadata = grunt.file.readJSON(path.join(moduleDirectory, 'package.json'))
+      continue unless metadata?.engines?.atom?
+
+      pack = {metadata, keymaps: {}, menus: {}}
+
+      for keymapPath in fs.listSync(path.join(moduleDirectory, 'keymaps'), ['.cson', '.json'])
+        keymapPath = path.relative(appDir, keymapPath)
+        pack.keymaps[keymapPath] = CSON.readFileSync(keymapPath)
+
+      for menuPath in fs.listSync(path.join(moduleDirectory, 'menus'), ['.cson', '.json'])
+        menuPath = path.relative(appDir, menuPath)
+        pack.menus[menuPath] = CSON.readFileSync(menuPath)
+
+      packages[metadata.name] = pack
+
+    metadata = grunt.file.readJSON(path.join(appDir, 'package.json'))
+    metadata._atomPackages = packages
+
+    grunt.file.write(path.join(appDir, 'package.json'), JSON.stringify(metadata, null, 2))

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -20,12 +20,12 @@ module.exports = (grunt) ->
       pack = {metadata, keymaps: {}, menus: {}}
 
       for keymapPath in fs.listSync(path.join(moduleDirectory, 'keymaps'), ['.cson', '.json'])
-        keymapPath = path.relative(appDir, keymapPath)
-        pack.keymaps[keymapPath] = CSON.readFileSync(keymapPath)
+        relativePath = path.relative(appDir, keymapPath)
+        pack.keymaps[relativePath] = CSON.readFileSync(keymapPath)
 
       for menuPath in fs.listSync(path.join(moduleDirectory, 'menus'), ['.cson', '.json'])
-        menuPath = path.relative(appDir, menuPath)
-        pack.menus[menuPath] = CSON.readFileSync(menuPath)
+        relativePath = path.relative(appDir, menuPath)
+        pack.menus[relativePath] = CSON.readFileSync(menuPath)
 
       packages[metadata.name] = pack
 

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -46,8 +46,7 @@ module.exports = (grunt) ->
       packages[metadata.name] = pack
 
       for extension, paths of moduleCache.extensions
-        if paths.length is 0
-          delete moduleCache.extensions[extension]
+        delete moduleCache.extensions[extension] if paths.length is 0
 
     metadata = grunt.file.readJSON(path.join(appDir, 'package.json'))
     metadata._atomPackages = packages

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -6,7 +6,7 @@ _ = require 'underscore-plus'
 module.exports = (grunt) ->
   {spawn, rm} = require('./task-helpers')(grunt)
 
-  grunt.registerTask 'compile-packages-slug', 'Add bundled package metadata information to to the main package.json file', ->
+  grunt.registerTask 'compile-packages-slug', 'Add bundled package metadata information to the main package.json file', ->
     appDir = fs.realpathSync(grunt.config.get('atom.appDir'))
 
     modulesDirectory = path.join(appDir, 'node_modules')

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -7,7 +7,7 @@ module.exports = (grunt) ->
   {spawn, rm} = require('./task-helpers')(grunt)
 
   grunt.registerTask 'compile-packages-slug', 'Add bundled package metadata information to to the main package.json file', ->
-    appDir = grunt.config.get('atom.appDir')
+    appDir = fs.realpathSync(grunt.config.get('atom.appDir'))
 
     modulesDirectory = path.join(appDir, 'node_modules')
     packages = {}
@@ -28,6 +28,10 @@ module.exports = (grunt) ->
         delete metadata[property]
 
       pack = {metadata, keymaps: {}, menus: {}}
+
+      if metadata.main
+        mainPath = require.resolve(path.resolve(moduleDirectory, metadata.main))
+        pack.main = path.relative(appDir, mainPath)
 
       for keymapPath in fs.listSync(path.join(moduleDirectory, 'keymaps'), ['.cson', '.json'])
         relativePath = path.relative(appDir, keymapPath)

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -5,7 +5,7 @@ fs = require 'fs-plus'
 module.exports = (grunt) ->
   {spawn} = require('./task-helpers')(grunt)
 
-  grunt.registerTask 'compile-packages-slug', 'Add package metadata information to to the main package.json file', ->
+  grunt.registerTask 'compile-packages-slug', 'Add bundled package metadata information to to the main package.json file', ->
     appDir = grunt.config.get('atom.appDir')
 
     modulesDirectory = path.join(appDir, 'node_modules')

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -20,6 +20,9 @@ module.exports = (grunt) ->
 
       rm metadataPath
 
+      for property in ['_from', '_id', 'dist', 'readme', 'readmeFilename']
+        delete metadata[property]
+
       pack = {metadata, keymaps: {}, menus: {}}
 
       for keymapPath in fs.listSync(path.join(moduleDirectory, 'keymaps'), ['.cson', '.json'])

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -32,4 +32,4 @@ module.exports = (grunt) ->
     metadata = grunt.file.readJSON(path.join(appDir, 'package.json'))
     metadata._atomPackages = packages
 
-    grunt.file.write(path.join(appDir, 'package.json'), JSON.stringify(metadata, null, 2))
+    grunt.file.write(path.join(appDir, 'package.json'), JSON.stringify(metadata))

--- a/build/tasks/generate-module-cache-task.coffee
+++ b/build/tasks/generate-module-cache-task.coffee
@@ -36,4 +36,4 @@ module.exports = (grunt) ->
         'react-atom-fork': metadata.dependencies['react-atom-fork']
       }
 
-    grunt.file.write(path.join(appDir, 'package.json'), JSON.stringify(metadata, null, 2))
+    grunt.file.write(path.join(appDir, 'package.json'), JSON.stringify(metadata))

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -32,7 +32,7 @@ module.exports = (grunt) ->
       binDir = path.join(installDir, 'bin')
       shareDir = path.join(installDir, 'share', 'atom')
 
-      iconName = path.join(shareDir,'resources','app','resources','atom.png')
+      iconName = path.join(shareDir,'resources', 'app', 'resources', 'atom.png')
 
       mkdir binDir
       cp 'atom.sh', path.join(binDir, 'atom')

--- a/build/tasks/set-version-task.coffee
+++ b/build/tasks/set-version-task.coffee
@@ -32,7 +32,7 @@ module.exports = (grunt) ->
       packageJsonPath = path.join(appDir, 'package.json')
       packageJson = require(packageJsonPath)
       packageJson.version = version
-      packageJsonString = JSON.stringify(packageJson, null, 2)
+      packageJsonString = JSON.stringify(packageJson)
       fs.writeFileSync(packageJsonPath, packageJsonString)
 
       if process.platform is 'darwin'

--- a/src/module-cache.coffee
+++ b/src/module-cache.coffee
@@ -128,7 +128,7 @@ loadExtensions = (modulePath, rootPath, rootMetadata, moduleCache) ->
 
   onDirectory = (childPath) ->
     # Don't include extensions from bundled packages
-    # These are generated and store in the package's own metadata cache
+    # These are generated and stored in the package's own metadata cache
     if rootMetadata.name is 'atom'
       parentPath = path.dirname(childPath)
       if parentPath is nodeModulesPath

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -29,11 +29,11 @@ module.exports =
 class PackageManager
   EmitterMixin.includeInto(this)
 
-  constructor: ({configDirPath, devMode, safeMode, @resourcePath}) ->
+  constructor: ({configDirPath, @devMode, safeMode, @resourcePath}) ->
     @emitter = new Emitter
     @packageDirPaths = []
     unless safeMode
-      if devMode
+      if @devMode
         @packageDirPaths.push(path.join(configDirPath, "dev", "packages"))
       @packageDirPaths.push(path.join(configDirPath, "packages"))
 

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -27,7 +27,7 @@ class Package
   @stylesheetsDir: 'stylesheets'
 
   @isBundledPackagePath: (packagePath) ->
-    @resourcePathWithTrailingSlash ?= path.join(atom.getLoadSettings().resourcePath, path.sep)
+    @resourcePathWithTrailingSlash ?= "#{atom.getLoadSettings().resourcePath}#{path.sep}"
     packagePath?.startsWith(@resourcePathWithTrailingSlash)
 
   @loadMetadata: (packagePath, ignoreErrors=false) ->

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -27,6 +27,9 @@ class Package
   @stylesheetsDir: 'stylesheets'
 
   @isBundledPackagePath: (packagePath) ->
+    if atom.packages.devMode
+      return atom.packages.resourcePath.startsWith("#{process.resourcesPath}#{path.sep}")
+
     @resourcePathWithTrailingSlash ?= "#{atom.packages.resourcePath}#{path.sep}"
     packagePath?.startsWith(@resourcePathWithTrailingSlash)
 

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -14,8 +14,8 @@ ModuleCache = require './module-cache'
 ScopedProperties = require './scoped-properties'
 
 try
-  packagesCache = require('../package.json')
-catch
+  packagesCache = require('../package.json')?._atomPackages ? {}
+catch error
   packagesCache = {}
 
 # Loads and activates a package's main module and resources such as

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -195,13 +195,13 @@ class Package
 
   loadKeymaps: ->
     if @bundledPackage and packagesCache[@name]?
-      @keymaps = (["#{@path}#{path.sep}#{keymapPath}", keymapObject] for keymapPath, keymapObject of packagesCache[@name].keymaps)
+      @keymaps = (["#{atom.packages.resourcePath}#{path.sep}#{keymapPath}", keymapObject] for keymapPath, keymapObject of packagesCache[@name].keymaps)
     else
       @keymaps = @getKeymapPaths().map (keymapPath) -> [keymapPath, CSON.readFileSync(keymapPath)]
 
   loadMenus: ->
     if @bundledPackage and packagesCache[@name]?
-      @menus = (["#{@path}#{path.sep}#{menuPath}", menuObject] for menuPath, menuObject of packagesCache[@name].menus)
+      @menus = (["#{atom.packages.resourcePath}#{path.sep}#{menuPath}", menuObject] for menuPath, menuObject of packagesCache[@name].menus)
     else
       @menus = @getMenuPaths().map (menuPath) -> [menuPath, CSON.readFileSync(menuPath)]
 

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -349,12 +349,19 @@ class Package
   getMainModulePath: ->
     return @mainModulePath if @resolvedMainModulePath
     @resolvedMainModulePath = true
-    mainModulePath =
-      if @metadata.main
-        path.join(@path, @metadata.main)
+
+    if @bundledPackage and packagesCache[@name]?
+      if packagesCache[@name].main
+        @mainModulePath = "#{atom.packages.resourcePath}#{path.sep}#{packagesCache[@name].main}"
       else
-        path.join(@path, 'index')
-    @mainModulePath = fs.resolveExtension(mainModulePath, ["", _.keys(require.extensions)...])
+        @mainModulePath = null
+    else
+      mainModulePath =
+        if @metadata.main
+          path.join(@path, @metadata.main)
+        else
+          path.join(@path, 'index')
+      @mainModulePath = fs.resolveExtension(mainModulePath, ["", _.keys(require.extensions)...])
 
   hasActivationCommands: ->
     for selector, commands of @getActivationCommands()

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -192,13 +192,13 @@ class Package
 
   loadKeymaps: ->
     if @bundledPackage and packagesCache[@name]?
-      @keymaps = ([keymapPath, keymapObject] for keymapPath, keymapObject of packagesCache[@name].keymaps)
+      @keymaps = (["#{@path}#{path.sep}#{keymapPath}", keymapObject] for keymapPath, keymapObject of packagesCache[@name].keymaps)
     else
       @keymaps = @getKeymapPaths().map (keymapPath) -> [keymapPath, CSON.readFileSync(keymapPath)]
 
   loadMenus: ->
     if @bundledPackage and packagesCache[@name]?
-      @menus = ([menuPath, menuObject] for menuPath, menuObject of packagesCache[@name].menus)
+      @menus = (["#{@path}#{path.sep}#{menuPath}", menuObject] for menuPath, menuObject of packagesCache[@name].menus)
     else
       @menus = @getMenuPaths().map (menuPath) -> [menuPath, CSON.readFileSync(menuPath)]
 

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -28,7 +28,7 @@ class Package
 
   @isBundledPackagePath: (packagePath) ->
     if atom.packages.devMode
-      return atom.packages.resourcePath.startsWith("#{process.resourcesPath}#{path.sep}")
+      return false unless atom.packages.resourcePath.startsWith("#{process.resourcesPath}#{path.sep}")
 
     @resourcePathWithTrailingSlash ?= "#{atom.packages.resourcePath}#{path.sep}"
     packagePath?.startsWith(@resourcePathWithTrailingSlash)

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -27,7 +27,7 @@ class Package
   @stylesheetsDir: 'stylesheets'
 
   @isBundledPackagePath: (packagePath) ->
-    @resourcePathWithTrailingSlash ?= "#{atom.getLoadSettings().resourcePath}#{path.sep}"
+    @resourcePathWithTrailingSlash ?= "#{atom.packages.resourcePath}#{path.sep}"
     packagePath?.startsWith(@resourcePathWithTrailingSlash)
 
   @loadMetadata: (packagePath, ignoreErrors=false) ->


### PR DESCRIPTION
Atom currently ships with 77 bundled packages.

So each time a window is opened, 77 `package.json` files are read/parsed, ~25 package keymap JSON files are read/parsed, and ~25 package menu JSON files are read/parsed.

In order to minimize the read/parse time during startup, inline all this content into the main `package.json` file under a special `_atomPackages` key.

For me this drops 25-50ms off of package load/activate time and should be more for slower machines and non-SSD drives.

Also this removes ~175 files/folders from the distribution which makes it a little leaner.
