### PR TITLE
Add Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# VERSION:        0.1
+# DESCRIPTION:    Create the atom editor in a container 
+# AUTHOR:         Jessica Frazelle <jessie@docker.com>
+# COMMENTS:
+#   This file describes how to build the atom editor 
+#   in a container with all dependencies installed.
+#   Tested on Debian Jessie.
+# USAGE:
+#   # Download atom Dockerfile
+#   wget http://raw.githubusercontent.com/atom/atom/master/Dockerfile
+#
+#   # Build atom image
+#   docker build -t atom .
+#
+#   docker run -v /tmp/.X11-unix:/tmp/.X11-unix \
+#     -e DISPLAY=unix$DISPLAY atom
+#
+
+DOCKER-VERSION 1.3
+
+# Base docker image
+FROM debian:jessie
+MAINTAINER Jessica Frazelle <jessie@docker.com>
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    libasound2 \
+    libgconf-2-4 \
+    libgnome-keyring-dev \
+    libgtk2.0-0 \
+    libnss3 \
+    libxtst6 \
+    --no-install-recommends
+
+# install node
+RUN curl -sL https://deb.nodesource.com/setup | bash -
+RUN apt-get install -y nodejs
+
+# clone atom
+RUN git clone https://github.com/atom/atom /src
+WORKDIR /src
+RUN git fetch && git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
+RUN script/build && script/grunt install
+
+# Autorun atom
+CMD /usr/local/bin/atom --foreground --log-file /var/log/atom.log && tail -f /var/log/atom.log


### PR DESCRIPTION
I'm just going to leave this here.

You see I was trying to containerize a node webkit app, so I
thought why not atom. Except halfway through I realized it
actually _isn't_ a node webkit app. I finished it anyways
because I had already started. It mounts the X11 socket
so it's a containerized desktop app.
You can do what you want with it.

But since this is OSS, I am going to give you my opinion
anyway. So here it is:
You should take this and use it as a build script, because
it seems like building this is a real PITA.

Ok that's all, enjoy.
Also this file was written in vim.
No, I'm not sorry.

Signed-off-by: Jessica Frazelle jess@docker.com

![2014-10-21_2880x1800](https://cloud.githubusercontent.com/assets/1445228/4730664/4d6d4c94-599d-11e4-9126-39861e96001f.png)
