### PR TITLE
Give scoped user settings a priority

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "reactionary-atom-fork": "^1.0.0",
     "runas": "1.0.1",
     "scandal": "1.0.3",
-    "scoped-property-store": "^0.14.0",
+    "scoped-property-store": "^0.15.0",
     "scrollbar-style": "^1.0.2",
     "season": "^1.0.2",
     "semver": "2.2.1",

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1075,6 +1075,13 @@ describe "Config", ->
           atom.config.setDefaults("foo", hasDefault: 'ok')
           expect(atom.config.get([".source.coffee", ".string.quoted.single"], "foo.hasDefault")).toBe 'ok'
 
+      describe 'setting priority', ->
+        describe 'when package settings are added after user settings', ->
+          it "returns the user's setting because the user's setting has higher priority", ->
+            atom.config.set(".source.coffee", "foo.bar.baz", 100)
+            atom.config.addScopedSettings("some-package", ".source.coffee", foo: bar: baz: 1)
+            expect(atom.config.get([".source.coffee"], "foo.bar.baz")).toBe 100
+
     describe ".set(scope, keyPath, value)", ->
       it "sets the value and overrides the others", ->
         atom.config.addScopedSettings("config", ".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -314,6 +314,7 @@ class Config
     @settings = {}
     @scopedSettingsStore = new ScopedPropertyStore
     @usersScopedSettings = new CompositeDisposable
+    @usersScopedSettingPriority = {indexBase: 1000}
     @configFileHasErrors = false
     @configFilePath = fs.resolve(@configDirPath, 'config', ['json', 'cson'])
     @configFilePath ?= path.join(@configDirPath, 'config.cson')
@@ -537,7 +538,7 @@ class Config
       settings = @scopedSettingsStore.propertiesForSourceAndSelector('user-config', scopeSelector)
       @scopedSettingsStore.removePropertiesForSourceAndSelector('user-config', scopeSelector)
       _.setValueForKeyPath(settings, keyPath, undefined)
-      @addScopedSettings('user-config', scopeSelector, settings)
+      @addScopedSettings('user-config', scopeSelector, settings, @usersScopedSettingPriority)
       @save() unless @configFileHasErrors
       @getDefault(scopeSelector, keyPath)
     else
@@ -881,13 +882,13 @@ class Config
   resetUserScopedSettings: (newScopedSettings) ->
     @usersScopedSettings?.dispose()
     @usersScopedSettings = new CompositeDisposable
-    @usersScopedSettings.add @scopedSettingsStore.addProperties('user-config', newScopedSettings)
+    @usersScopedSettings.add @scopedSettingsStore.addProperties('user-config', newScopedSettings, @usersScopedSettingPriority)
     @emitter.emit 'did-change'
 
-  addScopedSettings: (source, selector, value) ->
+  addScopedSettings: (source, selector, value, options) ->
     settingsBySelector = {}
     settingsBySelector[selector] = value
-    disposable = @scopedSettingsStore.addProperties(source, settingsBySelector)
+    disposable = @scopedSettingsStore.addProperties(source, settingsBySelector, options)
     @emitter.emit 'did-change'
     new Disposable =>
       disposable.dispose()
@@ -901,7 +902,7 @@ class Config
 
     settingsBySelector = {}
     settingsBySelector[selector] = value
-    @usersScopedSettings.add @scopedSettingsStore.addProperties('user-config', settingsBySelector)
+    @usersScopedSettings.add @scopedSettingsStore.addProperties('user-config', settingsBySelector, @usersScopedSettingPriority)
     @emitter.emit 'did-change'
 
   getRawScopedValue: (scopeDescriptor, keyPath) ->

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -314,7 +314,7 @@ class Config
     @settings = {}
     @scopedSettingsStore = new ScopedPropertyStore
     @usersScopedSettings = new CompositeDisposable
-    @usersScopedSettingPriority = {indexBase: 1000}
+    @usersScopedSettingPriority = {priority: 1000}
     @configFileHasErrors = false
     @configFilePath = fs.resolve(@configDirPath, 'config', ['json', 'cson'])
     @configFilePath ?= path.join(@configDirPath, 'config.cson')


### PR DESCRIPTION
Currently, the user's config file is loaded, then when each package loads, their config settings are loaded on top. Packages that define scoped settings will have priority over the user settings because they are loaded last. Example: atom/settings-view#267 We have a few options:
- Load the user config _after_ all the packages. 
  - This produces a period of time when atom has no styles.
  - Requires adding a pretty awkward method on PackageManager to get a callback when the scoped settings are all loaded
- Load the config as it is today, then reload the user config 
  - Requires adding a pretty awkward method on PackageManager to get a callback when the scoped settings are all loaded
  - Loads the file 2x
- Keep track of the read config file, and reload the scoped properties when the packages load 
  - Requires that awkward method
  - Seems like it would add some complexity to config
- Give the user configs an explicit higher priority
  - This PR

This feels like the cleanest, least intrusive way to do it. 

Closes atom/settings-view#267
Depends on https://github.com/atom/scoped-property-store/pull/6
