### PR TITLE
Adding underscore to default non-word characters

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -79,7 +79,7 @@ module.exports =
         default: true
       nonWordCharacters:
         type: 'string'
-        default: "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-"
+        default: "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-_"
       preferredLineLength:
         type: 'integer'
         default: 80


### PR DESCRIPTION
I'm using undescores regularly in ruby, where you would usually write them like `SOME_MADE_UP_CONSTANT = true`, jumping between words in that variable works nicer (for me, that is) when i can navigate the individual words.
