### PR TITLE
Load the default themes when configured themes don't exist

### DIFF
--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -308,24 +308,17 @@ describe "ThemeManager", ->
         expect(stylesheetsChangedHandler).toHaveBeenCalled()
 
   describe "when a non-existent theme is present in the config", ->
-    it "logs a warning but does not throw an exception (regression)", ->
-      reloaded = false
+    beforeEach ->
+      atom.config.set('core.themes', ['non-existent-dark-ui', 'non-existent-dark-syntax'])
 
       waitsForPromise ->
         themeManager.activateThemes()
 
-      runs ->
-        disposable = themeManager.onDidReloadAll ->
-          disposable.dispose()
-          reloaded = true
-        spyOn(console, 'warn')
-        expect(-> atom.config.set('core.themes', ['atom-light-ui', 'theme-really-does-not-exist'])).not.toThrow()
-
-      waitsFor -> reloaded
-
-      runs ->
-        expect(console.warn.callCount).toBe 1
-        expect(console.warn.argsForCall[0][0].length).toBeGreaterThan 0
+    it 'uses the default dark UI and syntax themes', ->
+      activeThemeNames = themeManager.getActiveNames()
+      expect(activeThemeNames.length).toBe(2)
+      expect(activeThemeNames).toContain('atom-dark-ui')
+      expect(activeThemeNames).toContain('atom-dark-syntax')
 
   describe "when in safe mode", ->
     beforeEach ->

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -161,9 +161,9 @@ class ThemeManager
     themeNames = themeNames.filter (themeName) ->
       themeName and typeof themeName is 'string'
 
-    # Use a built-in syntax and UI theme when in safe mode since themes
-    # installed to ~/.atom/packages will not be loaded.
-    if @safeMode
+    # Use a built-in syntax and UI theme any time the configured themes are not
+    # available.
+    if _.intersection(themeNames, atom.packages.getAvailablePackageNames()).length < 2
       builtInThemeNames = [
         'atom-dark-syntax'
         'atom-dark-ui'


### PR DESCRIPTION
This behavior is great for safe mode so I figured we could extend it to non-safe-mode when the configured themes aren't available for some reason. This will prevent the UI from looking wonky if things are mis-configured.
