### PR TITLE
Throw on non-release builds if translating positions on destroyed editor

### DIFF
--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -736,6 +736,10 @@ class DisplayBuffer extends Model
   #
   # Returns a {Point}.
   screenPositionForBufferPosition: (bufferPosition, options) ->
+    # TODO: Expand this exception to cover all versions once we burn it in on non-release builds
+    if @isDestroyed() and not atom.isReleasedVersion()
+      throw new Error("This TextEditor has been destroyed")
+
     { row, column } = @buffer.clipPosition(bufferPosition)
     [startScreenRow, endScreenRow] = @rowMap.screenRowRangeForBufferRow(row)
     for screenRow in [startScreenRow...endScreenRow]
@@ -1073,7 +1077,7 @@ class DisplayBuffer extends Model
       marker.notifyObservers(textChanged: false)
 
   destroyed: ->
-    marker.unsubscribe() for marker in @getMarkers()
+    marker.unsubscribe() for id, marker of @markers
     @tokenizedBuffer.destroy()
     @unsubscribe()
 

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -37,6 +37,8 @@ class TextEditorElement extends HTMLElement
 
   setModel: (model) ->
     throw new Error("Model already assigned on TextEditorElement") if @model?
+    return if model.isDestroyed()
+
     @model = model
     @mountComponent()
     @addGrammarScopeAttribute()


### PR DESCRIPTION
References #3789

It’s possible that bundled packages stray into this corner case, so I’d like us to catch and fix misbehaving packages before exposing users to any exceptions. Once we go one release with this turned on, we can enable the exception for all builds.
