### PR TITLE
Expand command registry to handle native events

### DIFF
--- a/spec/command-registry-spec.coffee
+++ b/spec/command-registry-spec.coffee
@@ -181,6 +181,20 @@ describe "CommandRegistry", ->
       expect(registry.dispatch(grandchild, 'bogus')).toBe false
       expect(registry.dispatch(parent, 'command')).toBe false
 
+    it "allows an event object to be passed instead of an event name", ->
+      called = false
+      registry.add '.grandchild', 'command', (event) ->
+        expect(this).toBe grandchild
+        expect(event.type).toBe 'command'
+        expect(event.eventPhase).toBe Event.BUBBLING_PHASE
+        expect(event.target).toBe grandchild
+        expect(event.currentTarget).toBe grandchild
+        expect(event.detail).toEqual {a: 1}
+        called = true
+
+      registry.dispatch(grandchild, new CustomEvent('command', bubbles: true), {a: 1})
+      expect(called).toBe true
+
   describe "::getSnapshot and ::restoreSnapshot", ->
     it "removes all command handlers except for those in the snapshot", ->
       registry.add '.parent', 'namespace:command-1', ->

--- a/spec/command-registry-spec.coffee
+++ b/spec/command-registry-spec.coffee
@@ -125,7 +125,6 @@ describe "CommandRegistry", ->
       spyOn(dispatchedEvent, 'stopPropagation')
       grandchild.dispatchEvent(dispatchedEvent)
       expect(calls).toEqual ['child-1', 'child-2']
-      expect(dispatchedEvent.stopPropagation).toHaveBeenCalled()
 
     it "stops invoking callbacks when .stopImmediatePropagation() is called on the event", ->
       calls = []
@@ -138,7 +137,6 @@ describe "CommandRegistry", ->
       spyOn(dispatchedEvent, 'stopImmediatePropagation')
       grandchild.dispatchEvent(dispatchedEvent)
       expect(calls).toEqual ['child-1']
-      expect(dispatchedEvent.stopImmediatePropagation).toHaveBeenCalled()
 
     it "forwards .preventDefault() calls from the synthetic event to the original", ->
       registry.listen '.child', 'command', (event) -> event.preventDefault()
@@ -296,3 +294,10 @@ describe "CommandRegistry", ->
       calls = []
       grandchild.dispatchEvent(new CustomEvent('command', bubbles: true))
       expect(calls).toEqual ['grandchild', 'child', 'parent']
+
+    it "invokes handlers on detached DOM nodes", ->
+      detachedNode = document.createElement('div')
+      called = false
+      detachedNode.addEventListener 'command', -> called = true
+      detachedNode.dispatchEvent(new CustomEvent('command', bubbles: true))
+      expect(called).toBe true

--- a/spec/command-registry-spec.coffee
+++ b/spec/command-registry-spec.coffee
@@ -72,6 +72,16 @@ describe "CommandRegistry", ->
       grandchild.dispatchEvent(new CustomEvent('command', bubbles: true))
       expect(calls).toEqual ['.foo.bar', '.bar', '.foo']
 
+    it "does not bubble the event if the ::bubbles property is false on the dispatched event", ->
+      calls = []
+
+      registry.add '.grandchild', 'command', -> calls.push('grandchild')
+      registry.add '.child', 'command', -> calls.push('child')
+      registry.add '.parent', 'command', -> calls.push('parent')
+
+      grandchild.dispatchEvent(new CustomEvent('command', bubbles: false))
+      expect(calls).toEqual ['grandchild']
+
     it "stops bubbling through ancestors when .stopPropagation() is called on the event", ->
       calls = []
 

--- a/spec/command-registry-spec.coffee
+++ b/spec/command-registry-spec.coffee
@@ -191,6 +191,16 @@ describe "CommandRegistry", ->
       expect(registry.dispatch(grandchild, 'bogus')).toBe false
       expect(registry.dispatch(parent, 'command')).toBe false
 
+    it "does not perform bubbling for native event names that should not bubble", ->
+      calls = []
+
+      registry.add '.grandchild', 'focus', -> calls.push('grandchild')
+      registry.add '.child', 'focus', -> calls.push('child')
+      registry.add '.parent', 'focus', -> calls.push('parent')
+
+      registry.dispatch(grandchild, 'focus')
+      expect(calls).toEqual ['grandchild']
+
     it "allows an event object to be passed instead of an event name", ->
       called = false
       registry.add '.grandchild', 'command', (event) ->

--- a/spec/fixtures/packages/package-with-activation-commands/index.coffee
+++ b/spec/fixtures/packages/package-with-activation-commands/index.coffee
@@ -6,7 +6,7 @@ module.exports =
   activate: ->
     @activateCallCount++
 
-    atom.commands.add 'atom-workspace', 'activation-command', =>
+    atom.commands.listen 'atom-workspace', 'activation-command', =>
       @activationCommandCallCount++
 
     atom.workspaceView.getActiveView()?.command 'activation-command', =>

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -118,7 +118,7 @@ describe "PackageManager", ->
             spyOn(Package.prototype, 'requireMainModule').andCallThrough()
 
             workspaceCommandListener = jasmine.createSpy('workspaceCommandListener')
-            atom.commands.add '.workspace', 'activation-command', workspaceCommandListener
+            atom.commands.listen '.workspace', 'activation-command', workspaceCommandListener
 
             promise = atom.packages.activatePackage('package-with-activation-commands')
 
@@ -138,7 +138,7 @@ describe "PackageManager", ->
               legacyCommandListener = jasmine.createSpy("legacyCommandListener")
               editorView.command 'activation-command', legacyCommandListener
               editorCommandListener = jasmine.createSpy("editorCommandListener")
-              atom.commands.add 'atom-text-editor', 'activation-command', editorCommandListener
+              atom.commands.listen 'atom-text-editor', 'activation-command', editorCommandListener
               editorView[0].dispatchEvent(new CustomEvent('activation-command', bubbles: true))
               expect(mainModule.activate.callCount).toBe 1
               expect(mainModule.legacyActivationCommandCallCount).toBe 1

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -351,11 +351,7 @@ $.fn.resultOfTrigger = (type) ->
   event.result
 
 $.fn.enableKeymap = ->
-  @on 'keydown', (e) ->
-    originalEvent = e.originalEvent ? e
-    Object.defineProperty(originalEvent, 'target', get: -> e.target) unless originalEvent.target?
-    atom.keymaps.handleKeyboardEvent(originalEvent)
-    not e.originalEvent.defaultPrevented
+  @element.addEventListener 'keydown', (event) -> atom.keymaps.handleKeyboardEvent(event)
 
 $.fn.attachToDom = ->
   @appendTo($('#jasmine-content')) unless @isOnDom()

--- a/spec/window-spec.coffee
+++ b/spec/window-spec.coffee
@@ -14,13 +14,8 @@ describe "Window", ->
       loadSettings.initialPath = initialPath
       loadSettings
     atom.project.destroy()
-    windowEventHandler = new WindowEventHandler()
     atom.deserializeEditorWindow()
     projectPath = atom.project.getPaths()[0]
-
-  afterEach ->
-    windowEventHandler.unsubscribe()
-    $(window).off 'beforeunload'
 
   describe "when the window is loaded", ->
     it "doesn't have .is-blurred on the body tag", ->
@@ -107,6 +102,8 @@ describe "Window", ->
 
   describe ".removeEditorWindow()", ->
     it "unsubscribes from all buffers", ->
+      spyOn(atom.windowEventHandler, 'unsubscribe') # don't unsubscribe from window events
+
       waitsForPromise ->
         atom.workspace.open("sample.js")
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -209,6 +209,7 @@ class Atom extends Model
     @keymaps = new KeymapManager({configDirPath, resourcePath})
     @keymap = @keymaps # Deprecated
     @commands = new CommandRegistry
+    @commands.patchDOMEventMethods()
     @packages = new PackageManager({devMode, configDirPath, resourcePath, safeMode})
     @styles = new StyleManager
     document.head.appendChild(new StylesElement)

--- a/src/command-registry.coffee
+++ b/src/command-registry.coffee
@@ -228,6 +228,7 @@ class CommandRegistry
         break if immediatePropagationStopped
         listener.callback.call(currentTarget, syntheticEvent)
 
+      break unless originalEvent.bubbles
       break if currentTarget is window
       break if propagationStopped
       currentTarget = currentTarget.parentNode ? window

--- a/src/command-registry.coffee
+++ b/src/command-registry.coffee
@@ -1,6 +1,7 @@
 {Emitter, Disposable, CompositeDisposable} = require 'event-kit'
 {specificity} = require 'clear-cut'
 _ = require 'underscore-plus'
+Grim = require 'grim'
 {$} = require './space-pen-extensions'
 
 SequenceCount = 0
@@ -22,10 +23,10 @@ NativeEventBubbling = {
 
 module.exports =
 
-# Public: Associates listener functions with commands in a
-# context-sensitive way using CSS selectors. You can access a global instance of
-# this class via `atom.commands`, and commands registered there will be
-# presented in the command palette.
+# Public: Associates listener functions with commands in a context-sensitive way
+# using CSS selectors. You can access a global instance of this class via
+# `atom.commands`, and commands registered there will be presented in the
+# command palette.
 #
 # The global command registry facilitates a style of event handling known as
 # *event delegation* that was popularized by jQuery. Atom commands are expressed
@@ -49,7 +50,7 @@ module.exports =
 # Here is a command that inserts the current date in an editor:
 #
 # ```coffee
-# atom.commands.add 'atom-text-editor',
+# atom.commands.listen 'atom-text-editor',
 #   'user:insert-date': (event) ->
 #     editor = $(this).view().getModel()
 #     # soon the above above line will be:
@@ -93,18 +94,22 @@ class CommandRegistry
   #
   # Returns a {Disposable} on which `.dispose()` can be called to remove the
   # added command handler(s).
-  add: (target, commandName, callback) ->
+  listen: (target, commandName, callback) ->
     if typeof commandName is 'object'
       commands = commandName
       disposable = new CompositeDisposable
       for commandName, callback of commands
-        disposable.add @add(target, commandName, callback)
+        disposable.add @listen(target, commandName, callback)
       return disposable
 
     if typeof target is 'string'
       @addSelectorBasedListener(target, commandName, callback)
     else
       @addInlineListener(target, commandName, callback)
+
+  add: (target, commandName, callback) ->
+    Grim.deprecate("Use CommandRegistry::listen instead")
+    @listen(target, commandName, callback)
 
   addSelectorBasedListener: (selector, commandName, callback) ->
     @selectorBasedListenersByCommandName[commandName] ?= []

--- a/src/command-registry.coffee
+++ b/src/command-registry.coffee
@@ -160,11 +160,17 @@ class CommandRegistry
   # processed.
   #
   # * `target` The DOM node at which to start bubbling the command event.
-  # * `commandName` {String} indicating the name of the command to dispatch.
-  dispatch: (target, commandName, detail) ->
-    event = new CustomEvent(commandName, {bubbles: true, detail})
+  # * `event` {String} indicating the name of the command to dispatch or a
+  #     DOM event object.
+  # * `detail` The detail to associate with the dispatched DOM event. If present
+  #     overrides the `detail` of the `event` if it is a DOM event object.
+  dispatch: (target, event, detail) ->
+    if typeof event is 'string'
+      event = new CustomEvent(event, {bubbles: true})
+
     eventWithTarget = Object.create event,
       target: value: target
+      detail: value: detail ? event.detail
       preventDefault: value: ->
       stopPropagation: value: ->
       stopImmediatePropagation: value: ->

--- a/src/command-registry.coffee
+++ b/src/command-registry.coffee
@@ -6,6 +6,22 @@ _ = require 'underscore-plus'
 SequenceCount = 0
 SpecificityCache = {}
 
+NativeEventBubbling = {
+  'abort': false
+  'blur': false
+  'error': false
+  'focus': false
+  'load': false
+  'mouseenter': false
+  'mouseleave': false
+  'resize': false
+  'scroll': false
+  'unload': false
+}
+
+
+module.exports =
+
 # Public: Associates listener functions with commands in a
 # context-sensitive way using CSS selectors. You can access a global instance of
 # this class via `atom.commands`, and commands registered there will be
@@ -166,7 +182,7 @@ class CommandRegistry
   #     overrides the `detail` of the `event` if it is a DOM event object.
   dispatch: (target, event, detail) ->
     if typeof event is 'string'
-      event = new CustomEvent(event, {bubbles: true})
+      event = new CustomEvent(event, {bubbles: NativeEventBubbling[event] ? true})
 
     eventWithTarget = Object.create event,
       target: value: target

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -375,7 +375,7 @@ class Package
         do (selector, command) =>
           # Add dummy command so it appears in menu.
           # The real command will be registered on package activation
-          @activationCommandSubscriptions.add atom.commands.add selector, command, ->
+          @activationCommandSubscriptions.add atom.commands.listen selector, command, ->
           @activationCommandSubscriptions.add atom.commands.onWillDispatch (event) =>
             return unless event.type is command
             currentTarget = event.target

--- a/src/space-pen-extensions.coffee
+++ b/src/space-pen-extensions.coffee
@@ -48,7 +48,7 @@ HandlersByOriginalHandler = new WeakMap
 CommandDisposablesByElement = new WeakMap
 
 AddEventListener = (element, type, listener) ->
-  disposable = atom.commands.add(element, type, listener)
+  disposable = atom.commands.listen(element, type, listener)
 
   unless disposablesByType = CommandDisposablesByElement.get(element)
     disposablesByType = {}

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -103,7 +103,7 @@ stopCommandEventPropagation = (commandListeners) ->
         commandListener.call(this, event)
   newCommandListeners
 
-atom.commands.add 'atom-text-editor', stopCommandEventPropagation(
+atom.commands.listen 'atom-text-editor', stopCommandEventPropagation(
   'core:move-left': -> @getModel().moveLeft()
   'core:move-right': -> @getModel().moveRight()
   'core:select-left': -> @getModel().selectLeft()
@@ -153,7 +153,7 @@ atom.commands.add 'atom-text-editor', stopCommandEventPropagation(
   'editor:lower-case': -> @getModel().lowerCase()
 )
 
-atom.commands.add 'atom-text-editor:not(.mini)', stopCommandEventPropagation(
+atom.commands.listen 'atom-text-editor:not(.mini)', stopCommandEventPropagation(
   'core:move-up': -> @getModel().moveUp()
   'core:move-down': -> @getModel().moveDown()
   'core:move-to-top': -> @getModel().moveToTop()

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -65,7 +65,7 @@ class WindowEventHandler
 
     @subscribeToCommand $(document), 'core:focus-previous', @focusPrevious
 
-    atom.commands.add window, 'keydown', @onKeydown
+    atom.commands.listen window, 'keydown', @onKeydown
 
     @subscribe $(document), 'drop', (e) ->
       e.preventDefault()

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -65,7 +65,7 @@ class WindowEventHandler
 
     @subscribeToCommand $(document), 'core:focus-previous', @focusPrevious
 
-    document.addEventListener 'keydown', @onKeydown
+    atom.commands.add window, 'keydown', @onKeydown
 
     @subscribe $(document), 'drop', (e) ->
       e.preventDefault()

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -114,7 +114,7 @@ class WorkspaceElement extends HTMLElement
 
   focusPaneViewOnRight: -> @paneContainer.focusPaneViewOnRight()
 
-atom.commands.add 'atom-workspace',
+atom.commands.listen 'atom-workspace',
   'window:increase-font-size': -> @getModel().increaseFontSize()
   'window:decrease-font-size': -> @getModel().decreaseFontSize()
   'window:reset-font-size': -> @getModel().resetFontSize()
@@ -160,6 +160,6 @@ atom.commands.add 'atom-workspace',
   'core:save-as': -> @getModel().saveActivePaneItemAs()
 
 if process.platform is 'darwin'
-  atom.commands.add 'atom-workspace', 'window:install-shell-commands', -> @getModel().installShellCommands()
+  atom.commands.listen 'atom-workspace', 'window:install-shell-commands', -> @getModel().installShellCommands()
 
 module.exports = WorkspaceElement = document.registerElement 'atom-workspace', prototype: WorkspaceElement.prototype


### PR DESCRIPTION
As we explored the overall API for creating views in packages (#3752), we realized that it's awkward to have two different mechanisms for subscribing to command events and native events in packages. It would be nice to use the same pattern to subscribe to things like `core:cancel` and `click`. Currently click handlers need to be registered with `addEventListener`.

We've decided to expand the role of the command registry, renaming it to the event registry and using it to register event handlers for both native and custom events. This will ensure a consistent event subscription experience for package authors:
## Tasks
- [x] Expand jQuery on/trigger retrofit to cover all event types
  - [ ] Ensure vim mode specs still pass
- [ ] Honor `::bubbles` property for native events
- [ ] Allow event capture in addition to bubbling
- [ ] Retrofit addEventListener to add events to event registry
- [ ] Rename to `EventRegistry`
- [ ] Assign to `atom.events` and deprecate `atom.commands`
