### PR TITLE
Add support for changing editor encoding

### DIFF
--- a/build/tasks/license-overrides.coffee
+++ b/build/tasks/license-overrides.coffee
@@ -60,3 +60,17 @@ module.exports =
         ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
         IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
       """
+  'jschardet@1.1.0':
+    license: 'LGPL'
+    source: 'README.md in the repository'
+    sourceText: """
+      JsChardet
+      =========
+
+      Port of python's chardet (http://chardet.feedparser.org/).
+
+      License
+      -------
+
+      LGPL
+    """

--- a/build/tasks/license-overrides.coffee
+++ b/build/tasks/license-overrides.coffee
@@ -60,6 +60,7 @@ module.exports =
         ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
         IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
       """
+
   'jschardet@1.1.0':
     license: 'LGPL'
     source: 'README.md in the repository'

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "nslog": "^1.0.1",
     "oniguruma": "^3.0.4",
     "optimist": "0.4.0",
-    "pathwatcher": "^2.1.3",
+    "pathwatcher": "^2.3.1",
     "property-accessors": "^1",
     "q": "^1.0.1",
     "random-words": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "command-palette": "0.27.0",
     "deprecation-cop": "0.11.0",
     "dev-live-reload": "0.34.0",
+    "encoding-selector": "0.2.0",
     "exception-reporting": "0.20.0",
     "feedback": "0.33.0",
     "find-and-replace": "0.141.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "serializable": "^1",
     "space-pen": "3.8.0",
     "temp": "0.7.0",
-    "text-buffer": "^3.3.0",
+    "text-buffer": "^3.4",
     "theorist": "^1.0.2",
     "underscore-plus": "^1.6.1",
     "vm-compatibility-layer": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "nslog": "^1.0.1",
     "oniguruma": "^3.0.4",
     "optimist": "0.4.0",
-    "pathwatcher": "^2.3.1",
+    "pathwatcher": "^2.3.2",
     "property-accessors": "^1",
     "q": "^1.0.1",
     "random-words": "0.0.1",

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -157,6 +157,19 @@ describe "TextEditor", ->
 
       expect(observed).toEqual [__filename, undefined]
 
+  describe "encoding", ->
+    it "notifies ::onDidChangeEncoding observers when the editor encoding changes", ->
+      observed = []
+      editor.onDidChangeEncoding (encoding) -> observed.push(encoding)
+
+      editor.setEncoding('utf16le')
+      editor.setEncoding('utf16le')
+      editor.setEncoding('utf16be')
+      editor.setEncoding()
+      editor.setEncoding()
+
+      expect(observed).toEqual ['utf16le', 'utf16be', 'utf8']
+
   describe "cursor", ->
     describe ".getLastCursor()", ->
       it "returns the most recently created cursor", ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -568,6 +568,16 @@ class TextEditor extends Model
   # Essential: Returns the {String} path of this editor's text buffer.
   getPath: -> @buffer.getPath()
 
+  # Extended: Returns the {String} character set encoding of this editor's text
+  # buffer.
+  getEncoding: -> @buffer.getEncoding()
+
+  # Extended: Set the character set encoding to use in this editor's text
+  # buffer.
+  #
+  # * `encoding` The {String} character set encoding name such as 'utf8'
+  setEncoding: (encoding) -> @buffer.setEncoding(encoding)
+
   # Essential: Returns {Boolean} `true` if this editor has been modified.
   isModified: -> @buffer.isModified()
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2815,6 +2815,12 @@ class TextEditor extends Model
 
   pixelRectForScreenRange: (screenRange) -> @displayBuffer.pixelRectForScreenRange(screenRange)
 
+  setEncoding: (encoding) ->
+    {file} = @buffer
+    file.setEncoding(encoding)
+    file.read(true).then =>
+      file.emitter.emit('did-change')
+
   # Deprecated: Call {::joinLines} instead.
   joinLine: ->
     deprecate("Use TextEditor::joinLines() instead")

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -138,7 +138,7 @@ class TextEditor extends Model
       @emitter.emit 'did-change-encoding', @getEncoding()
     @subscribe @buffer.onDidDestroy => @destroy()
 
-    # TODO: remove these thwne we remove the deprecations. They are old events.
+    # TODO: remove these when we remove the deprecations. They are old events.
     @subscribe @buffer.onDidStopChanging => @emit "contents-modified"
     @subscribe @buffer.onDidConflict => @emit "contents-conflicted"
     @subscribe @buffer.onDidChangeModified => @emit "modified-status-changed"

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2815,12 +2815,6 @@ class TextEditor extends Model
 
   pixelRectForScreenRange: (screenRange) -> @displayBuffer.pixelRectForScreenRange(screenRange)
 
-  setEncoding: (encoding) ->
-    {file} = @buffer
-    file.setEncoding(encoding)
-    file.read(true).then =>
-      file.emitter.emit('did-change')
-
   # Deprecated: Call {::joinLines} instead.
   joinLine: ->
     deprecate("Use TextEditor::joinLines() instead")

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -134,6 +134,8 @@ class TextEditor extends Model
       @emitter.emit 'did-change-title', @getTitle()
       @emit "path-changed"
       @emitter.emit 'did-change-path', @getPath()
+    @subscribe @buffer.onDidChangeEncoding =>
+      @emitter.emit 'did-change-encoding', @getEncoding()
     @subscribe @buffer.onDidDestroy => @destroy()
 
     # TODO: remove these thwne we remove the deprecations. They are old events.
@@ -259,6 +261,14 @@ class TextEditor extends Model
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidChangeSoftWrapped: (callback) ->
     @displayBuffer.onDidChangeSoftWrapped(callback)
+
+  # Extended: Calls your `callback` when the buffer's encoding has changed.
+  #
+  # * `callback` {Function}
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidChangeEncoding: (callback) ->
+    @emitter.on 'did-change-encoding', callback
 
   # Extended: Calls your `callback` when the grammar that interprets and
   # colorizes the text has been changed. Immediately calls your callback with


### PR DESCRIPTION
- Upgrades pathwatcher and text-buffer for new encoding APIs
- Adds a new [encoding-selector](https://github.com/atom/encoding-selector) package that mirrors the grammar selector behavior
- Put the current encoding on the status bar
- Allow changing of the encoding
- Add auto detect option that uses [jschardet](https://github.com/aadsm/jschardet)

![encodings](https://cloud.githubusercontent.com/assets/671378/4818732/4680b1c8-5ef7-11e4-9ce2-8f68e58fb9a7.gif)

Closes #1806 
