### PR TITLE
Remove feedback package

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -191,6 +191,7 @@
       { label: 'Terms of Use', command: 'application:open-terms-of-use' }
       { label: 'Documentation', command: 'application:open-documentation' }
       { label: 'Community Discussions', command: 'application:open-discussions' }
+      { label: 'Roadmap', command: 'application:open-roadmap' }
       { type: 'separator' }
     ]
   }

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -192,6 +192,7 @@
       { label: 'Documentation', command: 'application:open-documentation' }
       { label: 'Community Discussions', command: 'application:open-discussions' }
       { label: 'Roadmap', command: 'application:open-roadmap' }
+      { label: 'Frequently Asked Questions', command: 'application:open-faq' }
       { type: 'separator' }
     ]
   }

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -190,6 +190,7 @@
     submenu: [
       { label: 'Terms of Use', command: 'application:open-terms-of-use' }
       { label: 'Documentation', command: 'application:open-documentation' }
+      { label: 'Community Discussions', command: 'application:open-discussions' }
       { type: 'separator' }
     ]
   }

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -194,6 +194,7 @@
       { label: 'Roadmap', command: 'application:open-roadmap' }
       { label: 'Frequently Asked Questions', command: 'application:open-faq' }
       { label: 'Report Issue', command: 'application:report-issue' }
+      { label: 'Search Issues', command: 'application:search-issues' }
       { type: 'separator' }
     ]
   }

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -190,9 +190,10 @@
     submenu: [
       { label: 'Terms of Use', command: 'application:open-terms-of-use' }
       { label: 'Documentation', command: 'application:open-documentation' }
-      { label: 'Community Discussions', command: 'application:open-discussions' }
       { label: 'Roadmap', command: 'application:open-roadmap' }
       { label: 'Frequently Asked Questions', command: 'application:open-faq' }
+      { type: 'separator' }
+      { label: 'Community Discussions', command: 'application:open-discussions' }
       { label: 'Report Issue', command: 'application:report-issue' }
       { label: 'Search Issues', command: 'application:search-issues' }
       { type: 'separator' }

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -193,6 +193,7 @@
       { label: 'Community Discussions', command: 'application:open-discussions' }
       { label: 'Roadmap', command: 'application:open-roadmap' }
       { label: 'Frequently Asked Questions', command: 'application:open-faq' }
+      { label: 'Report Issue', command: 'application:report-issue' }
       { type: 'separator' }
     ]
   }

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -151,6 +151,7 @@
       { label: 'Roadmap', command: 'application:open-roadmap' }
       { label: 'Frequently Asked Questions', command: 'application:open-faq' }
       { label: 'Report Issue', command: 'application:report-issue' }
+      { label: 'Search Issues', command: 'application:search-issues' }
       { type: 'separator' }
     ]
   }

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -147,9 +147,10 @@
       { label: "VERSION", enabled: false }
       { type: 'separator' }
       { label: '&Documentation', command: 'application:open-documentation' }
-      { label: 'Community Discussions', command: 'application:open-discussions' }
       { label: 'Roadmap', command: 'application:open-roadmap' }
       { label: 'Frequently Asked Questions', command: 'application:open-faq' }
+      { type: 'separator' }
+      { label: 'Community Discussions', command: 'application:open-discussions' }
       { label: 'Report Issue', command: 'application:report-issue' }
       { label: 'Search Issues', command: 'application:search-issues' }
       { type: 'separator' }

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -147,6 +147,10 @@
       { label: "VERSION", enabled: false }
       { type: 'separator' }
       { label: '&Documentation', command: 'application:open-documentation' }
+      { label: 'Community Discussions', command: 'application:open-discussions' }
+      { label: 'Roadmap', command: 'application:open-roadmap' }
+      { label: 'Frequently Asked Questions', command: 'application:open-faq' }
+      { label: 'Report Issue', command: 'application:report-issue' }
       { type: 'separator' }
     ]
   }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -165,6 +165,10 @@
       { label: "VERSION", enabled: false }
       { type: 'separator' }
       { label: '&Documentation', command: 'application:open-documentation' }
+      { label: 'Community Discussions', command: 'application:open-discussions' }
+      { label: 'Roadmap', command: 'application:open-roadmap' }
+      { label: 'Frequently Asked Questions', command: 'application:open-faq' }
+      { label: 'Report Issue', command: 'application:report-issue' }
       { type: 'separator' }
     ]
   }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -169,6 +169,7 @@
       { label: 'Roadmap', command: 'application:open-roadmap' }
       { label: 'Frequently Asked Questions', command: 'application:open-faq' }
       { label: 'Report Issue', command: 'application:report-issue' }
+      { label: 'Search Issues', command: 'application:search-issues' }
       { type: 'separator' }
     ]
   }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -165,9 +165,10 @@
       { label: "VERSION", enabled: false }
       { type: 'separator' }
       { label: '&Documentation', command: 'application:open-documentation' }
-      { label: 'Community Discussions', command: 'application:open-discussions' }
       { label: 'Roadmap', command: 'application:open-roadmap' }
       { label: 'Frequently Asked Questions', command: 'application:open-faq' }
+      { type: 'separator' }
+      { label: 'Community Discussions', command: 'application:open-discussions' }
       { label: 'Report Issue', command: 'application:report-issue' }
       { label: 'Search Issues', command: 'application:search-issues' }
       { type: 'separator' }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "dev-live-reload": "0.34.0",
     "encoding-selector": "0.4.0",
     "exception-reporting": "0.20.0",
-    "feedback": "0.33.0",
     "find-and-replace": "0.141.0",
     "fuzzy-finder": "0.60.0",
     "git-diff": "0.42.0",

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -155,6 +155,7 @@ class AtomApplication
       atomWindow?.browserWindow.inspectElement(x, y)
 
     @on 'application:open-documentation', -> require('shell').openExternal('https://atom.io/docs/latest/?app')
+    @on 'application:open-discussions', -> require('shell').openExternal('https://discuss.atom.io')
     @on 'application:open-terms-of-use', -> require('shell').openExternal('https://atom.io/terms')
     @on 'application:install-update', -> @autoUpdateManager.install()
     @on 'application:check-for-update', => @autoUpdateManager.check()

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -156,6 +156,7 @@ class AtomApplication
 
     @on 'application:open-documentation', -> require('shell').openExternal('https://atom.io/docs/latest/?app')
     @on 'application:open-discussions', -> require('shell').openExternal('https://discuss.atom.io')
+    @on 'application:open-roadmap', -> require('shell').openExternal('https://atom.io/roadmap?app')
     @on 'application:open-terms-of-use', -> require('shell').openExternal('https://atom.io/terms')
     @on 'application:install-update', -> @autoUpdateManager.install()
     @on 'application:check-for-update', => @autoUpdateManager.check()

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -159,6 +159,8 @@ class AtomApplication
     @on 'application:open-roadmap', -> require('shell').openExternal('https://atom.io/roadmap?app')
     @on 'application:open-faq', -> require('shell').openExternal('https://atom.io/faq')
     @on 'application:open-terms-of-use', -> require('shell').openExternal('https://atom.io/terms')
+    @on 'application:report-issue', -> require('shell').openExternal('https://github.com/atom/atom/issues/new')
+
     @on 'application:install-update', -> @autoUpdateManager.install()
     @on 'application:check-for-update', => @autoUpdateManager.check()
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -157,6 +157,7 @@ class AtomApplication
     @on 'application:open-documentation', -> require('shell').openExternal('https://atom.io/docs/latest/?app')
     @on 'application:open-discussions', -> require('shell').openExternal('https://discuss.atom.io')
     @on 'application:open-roadmap', -> require('shell').openExternal('https://atom.io/roadmap?app')
+    @on 'application:open-faq', -> require('shell').openExternal('https://atom.io/faq')
     @on 'application:open-terms-of-use', -> require('shell').openExternal('https://atom.io/terms')
     @on 'application:install-update', -> @autoUpdateManager.install()
     @on 'application:check-for-update', => @autoUpdateManager.check()

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -160,6 +160,7 @@ class AtomApplication
     @on 'application:open-faq', -> require('shell').openExternal('https://atom.io/faq')
     @on 'application:open-terms-of-use', -> require('shell').openExternal('https://atom.io/terms')
     @on 'application:report-issue', -> require('shell').openExternal('https://github.com/atom/atom/issues/new')
+    @on 'application:search-issues', -> require('shell').openExternal('https://github.com/issues?q=+is%3Aissue+user%3Aatom')
 
     @on 'application:install-update', -> @autoUpdateManager.install()
     @on 'application:check-for-update', => @autoUpdateManager.check()


### PR DESCRIPTION
I've had the feedback package disabled for months, for me it takes up valuable real estate on the status bar and draws attention to itself.

I think we are at the point where we can remove it and instead just add helpful items to the Help menu.

This PR removes the package and adds several new help menu items for faq, issues, roadmap, and discussions.

@lee-dohm any ideas for other helpful things to put in the help menu?
