### PR TITLE
Upgrade to atom-shell@0.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "url": "http://github.com/atom/atom/raw/master/LICENSE.md"
     }
   ],
-  "atomShellVersion": "0.18.2",
+  "atomShellVersion": "0.19.0",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "url": "http://github.com/atom/atom/raw/master/LICENSE.md"
     }
   ],
-  "atomShellVersion": "0.19.0",
+  "atomShellVersion": "0.19.1",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^2.2.1",


### PR DESCRIPTION
@kevinsawicki From atom-shell v0.19.0 all custom security restrictions on `iframe` have been dropped, and package authors need to use [`<webview>` tag](https://github.com/atom/atom-shell/blob/master/docs/api/web-view-tag.md) for embedded external contents instead, we may need to put a notice in Atom's release notes.
