### PR TITLE
Remove rpm package dependencies

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -4,9 +4,6 @@ Release:        0.1%{?dist}
 Summary:        Atom is a hackable text editor for the 21st century
 License:        MIT
 URL:            https://atom.io/
-BuildConflicts: gyp
-BuildRequires:  make, gcc, gcc-c++, glibc-devel, git-core, libgnome-keyring-devel
-Requires:       libgnome-keyring
 AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 
 %description


### PR DESCRIPTION
This is an attempt to fix Issues #4015 #4008.

Seems like CentOS and Red Hat are not providing `libgnome-keyring` to their official yum repository, and since the spec has `Requires: libgnome-keyring` it doesn't let them install without resolving the dependency.

In this PR, I removed all package dependencies with the assumption that those are all `build dependencies` (including libgnome-keyring) and if they are not installed then the build process (`script/build`) will fail, therefore we can't build rpm yet. In other words, rpm-build does not need to check those dependencies if they are all `build dependencies`.

Thank you.
