### PR TITLE
Load atom://assets/ urls from ~/.atom/assets

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -70,7 +70,7 @@ class AtomApplication
 
     @autoUpdateManager = new AutoUpdateManager(@version)
     @applicationMenu = new ApplicationMenu(@version)
-    @atomProtocolHandler = new AtomProtocolHandler(@resourcePath)
+    @atomProtocolHandler = new AtomProtocolHandler(@resourcePath, @safeMode)
 
     @listenForArgumentsFromNewProcess()
     @setupJavaScriptArguments()

--- a/src/browser/atom-protocol-handler.coffee
+++ b/src/browser/atom-protocol-handler.coffee
@@ -10,18 +10,20 @@ protocol = require 'protocol'
 #
 # The following directories are searched in order:
 #   * ~/.atom/assets
-#   * ~/.atom/dev/packages
+#   * ~/.atom/dev/packages (unless in safe mode)
 #   * ~/.atom/packages
 #   * RESOURCE_PATH/node_modules
 #
 module.exports =
 class AtomProtocolHandler
-  constructor: (@resourcePath) ->
-    @loadPaths = [
-      path.join(app.getHomeDir(), '.atom', 'dev', 'packages')
-      path.join(app.getHomeDir(), '.atom', 'packages')
-      path.join(@resourcePath, 'node_modules')
-    ]
+  constructor: (@resourcePath, safeMode) ->
+    @loadPaths = []
+
+    unless safeMode
+      @loadPaths.push(path.join(app.getHomeDir(), '.atom', 'dev', 'packages'))
+
+    @loadPaths.push(path.join(app.getHomeDir(), '.atom', 'packages'))
+    @loadPaths.push(path.join(@resourcePath, 'node_modules'))
 
     @registerAtomProtocol()
 

--- a/src/browser/atom-protocol-handler.coffee
+++ b/src/browser/atom-protocol-handler.coffee
@@ -34,8 +34,7 @@ class AtomProtocolHandler
 
       if relativePath.indexOf('assets/') is 0
         assetsPath = path.join(app.getHomeDir(), '.atom', relativePath)
-        if fs.statSyncNoException(assetsPath).isFile?()
-          filePath = assetsPath
+        filePath = assetsPath if fs.statSyncNoException(assetsPath).isFile?()
 
       unless filePath
         for loadPath in @loadPaths

--- a/src/browser/atom-protocol-handler.coffee
+++ b/src/browser/atom-protocol-handler.coffee
@@ -18,11 +18,12 @@ module.exports =
 class AtomProtocolHandler
   constructor: (@resourcePath, safeMode) ->
     @loadPaths = []
+    @dotAtomDirectory = path.join(app.getHomeDir(), '.atom')
 
     unless safeMode
-      @loadPaths.push(path.join(app.getHomeDir(), '.atom', 'dev', 'packages'))
+      @loadPaths.push(path.join(@dotAtomDirectory, 'dev', 'packages'))
 
-    @loadPaths.push(path.join(app.getHomeDir(), '.atom', 'packages'))
+    @loadPaths.push(path.join(@dotAtomDirectory, 'packages'))
     @loadPaths.push(path.join(@resourcePath, 'node_modules'))
 
     @registerAtomProtocol()
@@ -33,7 +34,7 @@ class AtomProtocolHandler
       relativePath = path.normalize(request.url.substr(7))
 
       if relativePath.indexOf('assets/') is 0
-        assetsPath = path.join(app.getHomeDir(), '.atom', relativePath)
+        assetsPath = path.join(@dotAtomDirectory, relativePath)
         filePath = assetsPath if fs.statSyncNoException(assetsPath).isFile?()
 
       unless filePath

--- a/src/browser/atom-protocol-handler.coffee
+++ b/src/browser/atom-protocol-handler.coffee
@@ -16,7 +16,7 @@ protocol = require 'protocol'
 #
 module.exports =
 class AtomProtocolHandler
-  constructor: (@resourcePath, safeMode) ->
+  constructor: (resourcePath, safeMode) ->
     @loadPaths = []
     @dotAtomDirectory = path.join(app.getHomeDir(), '.atom')
 
@@ -24,7 +24,7 @@ class AtomProtocolHandler
       @loadPaths.push(path.join(@dotAtomDirectory, 'dev', 'packages'))
 
     @loadPaths.push(path.join(@dotAtomDirectory, 'packages'))
-    @loadPaths.push(path.join(@resourcePath, 'node_modules'))
+    @loadPaths.push(path.join(resourcePath, 'node_modules'))
 
     @registerAtomProtocol()
 


### PR DESCRIPTION
Maps URLs like `atom://assets/my-background.png` to `~/.atom/assets/my-background.png` so you can put something like this in your `~/.atom/styles.less`:

``` css
.item-views:empty {
  background-image: url(atom://assets/my-background.png);
  background-repeat: no-repeat;
  background-position: center;
  background-size: 90% 90%;
}
```

And have it be portable across machines and easily stored in a dotfiles repo.

Fixes #4010
