### PR TITLE
Only load the bootstrap styles we need

### DIFF
--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -241,7 +241,7 @@ class ThemeManager
     @applyStylesheet(userStylesheetPath, userStylesheetContents, 'userTheme')
 
   loadBaseStylesheets: ->
-    @requireStylesheet('bootstrap/less/bootstrap')
+    @requireStylesheet('../static/bootstrap')
     @reloadBaseStylesheets()
 
   reloadBaseStylesheets: ->

--- a/static/atom.less
+++ b/static/atom.less
@@ -10,7 +10,7 @@
 @import "octicon-mixins";
 
 @import "workspace-view";
-@import "bootstrap";
+@import "bootstrap-overrides";
 @import "buttons";
 @import "icons";
 @import "links";

--- a/static/bootstrap-overrides.less
+++ b/static/bootstrap-overrides.less
@@ -1,0 +1,14 @@
+@import "ui-variables";
+
+.nav {
+  > li > a {
+    border-radius: @component-border-radius;
+  }
+  > li > a:hover {
+    background-color: @background-color-highlight;
+  }
+
+  &.nav-pills > li.active > a {
+    background-color: @background-color-selected;
+  }
+}

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -1,14 +1,30 @@
-@import "ui-variables";
+// Core variables and mixins
+@import "../node_modules/bootstrap/less/variables.less";
+@import "../node_modules/bootstrap/less/mixins.less";
 
-.nav {
-  > li > a {
-    border-radius: @component-border-radius;
-  }
-  > li > a:hover {
-    background-color: @background-color-highlight;
-  }
+// Reset
+@import "../node_modules/bootstrap/less/normalize.less";
 
-  &.nav-pills > li.active > a {
-    background-color: @background-color-selected;
-  }
-}
+// Core CSS
+@import "../node_modules/bootstrap/less/scaffolding.less";
+@import "../node_modules/bootstrap/less/type.less";
+@import "../node_modules/bootstrap/less/code.less";
+@import "../node_modules/bootstrap/less/grid.less";
+@import "../node_modules/bootstrap/less/tables.less";
+@import "../node_modules/bootstrap/less/forms.less";
+@import "../node_modules/bootstrap/less/buttons.less";
+
+// Components
+@import "../node_modules/bootstrap/less/button-groups.less";
+@import "../node_modules/bootstrap/less/input-groups.less";
+@import "../node_modules/bootstrap/less/navs.less";
+@import "../node_modules/bootstrap/less/labels.less";
+@import "../node_modules/bootstrap/less/badges.less";
+@import "../node_modules/bootstrap/less/alerts.less";
+@import "../node_modules/bootstrap/less/list-group.less";
+
+// Components w/ JavaScript
+@import "../node_modules/bootstrap/less/tooltip.less";
+
+// Utility classes
+@import "../node_modules/bootstrap/less/utilities.less";


### PR DESCRIPTION
I was having some conflicts in the modal panel stuff I was doing. Turns out we dont need a lot of bootstrap. This loads the bits we need. 
