### PR TITLE
Pass $PATH by command line

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -63,7 +63,7 @@ if [ $OS == 'Mac' ]; then
     "$ATOM_PATH/$ATOM_APP_NAME/Contents/MacOS/Atom" --executed-from="$(pwd)" --pid=$$ "$@"
     exit $?
   else
-    open -a "$ATOM_PATH/$ATOM_APP_NAME" -n --args --executed-from="$(pwd)" --pid=$$ "$@"
+    open -a "$ATOM_PATH/$ATOM_APP_NAME" -n --args --executed-from="$(pwd)" --pid=$$ --path-environment="$PATH" "$@"
   fi
 elif [ $OS == 'Linux' ]; then
   SCRIPT=$(readlink -f "$0")

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -134,6 +134,10 @@ parseCommandLine = ->
   unless fs.statSyncNoException(resourcePath)
     resourcePath = path.dirname(path.dirname(__dirname))
 
+  # On Yosemite the $PATH is not inherited by the "open" command, so we have to
+  # explicitly pass it by command line, see http://git.io/YC8_Ew.
+  process.env.PATH = args['path-environment'] if args['path-environment']
+
   {resourcePath, pathsToOpen, executedFrom, test, version, pidToKillWhenClosed, devMode, safeMode, newWindow, specDirectory, logFile}
 
 start()


### PR DESCRIPTION
On Yosemite the `$PATH` is not inherited by the `open` command, so we have to explicitly pass it by command line to make `atom` command inherit the `PATH` environment variable.

Fixes https://github.com/atom/atom-shell/issues/550.
