### PR TITLE
Keyboard shortcut to open folder on Windows

### DIFF
--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -14,6 +14,7 @@
   'ctrl-alt-i': 'window:toggle-dev-tools'
   'ctrl-alt-p': 'window:run-package-specs'
   'ctrl-alt-s': 'application:run-all-specs'
+  'ctrl-shift-o': 'application:open-folder'
   'F11': 'window:toggle-full-screen'
 
   # Sublime Parity


### PR DESCRIPTION
Added a keyboard shortcut for the "Open folder" action found in the file menu, based on the behaviour in the Linux version of Atom: Ctrl + Shift + O. Also logical because the keyboard shortcut for the secondary saving option (save as) is set to the original shortcut plus Shift.

PRed after discussion in [this thread at discuss.atom.io](https://discuss.atom.io/t/keyboard-shortcut-to-open-folder-on-windows/13080?u=jpelgrom).
