### PR TITLE
:memo: Update .workspace class with custom element

### DIFF
--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -12,7 +12,7 @@
 # 'atom-text-editor':
 #   'enter': 'editor:newline'
 #
-# '.workspace':
+# 'atom-workspace':
 #   'ctrl-shift-p': 'core:move-up'
 #   'ctrl-p': 'core:move-down'
 #


### PR DESCRIPTION
Because of the update with the custom elements, i noticed that `.workspace` hasn't been updated in the `keymap.cson`, but `.editor` has (to `atom-text-editor`).
