### PR TITLE
Use Workspace::observeTextEditors in init script example

### DIFF
--- a/dot-atom/init.coffee
+++ b/dot-atom/init.coffee
@@ -8,7 +8,6 @@
 #
 # path = require 'path'
 #
-# atom.workspaceView.eachEditorView (editorView) ->
-#   editor = editorView.getEditor()
+# atom.workspace.observeTextEditors (editor) ->
 #   if path.extname(editor.getPath()) is '.md'
 #     editor.setSoftWrapped(true)


### PR DESCRIPTION
No need to go through the view to get the editor instance.
