### PR TITLE
Writing docs and specs for spec-helper

### DIFF
--- a/docs/writing-specs.md
+++ b/docs/writing-specs.md
@@ -133,17 +133,44 @@ describe "when a test is written", ->
 
 # Spec Helpers
 
-Atom provides a few global spec helpers:
+Atom provides a few global helper functions in specs:
 
-<!-- TODO: Write this documentation! -->
+# `advanceClock(delta=1)`
 
- * `window.setTimeout`
- * `window.clearTimeout`
+Advances the clock by `delta` milliseconds. Can be used to execute events
+dependent on `setTimeout()`.
 
-As well, it mocks the following methods.
+This works because Atom sets [Jasmine spies][jspies] on the globals
+`setTimeout()` and `clearTimeout()` to implement its own event loop. This
+means that specs may use `advanceClock` to artificially advance the
+clock anywhere that these two globals are used. This also means that
+tests that would have run asynchronously using only `setTimeout` can be run
+synchronously:
 
- * `TextEditorView::requestDisplayUpdate`
- * `File::requestDisplayUpdate`
+```coffee
+describe 'when a test uses advanceClock()', ->
+  it 'can synchronously call setTimeout callbacks in the future', ->
+    futureCallback = jasmine.createSpy('futureCallback')
+
+    setTimeout(futureCallback, 1000)
+    advanceClock(1001)
+
+    expect(futureCallback).toHaveBeenCalled()
+
+  it 'allows timeouts to be cleared', ->
+    futureCallback = jasmine.createSpy('futureCallback')
+
+    id = setTimeout(futureCallback, 1000)
+    advanceClock(999)
+    clearTimeout(id)
+
+    advanceClock(1000)
+    expect(futureCallback).not.toHaveBeenCalled()
+```
+
+
+Atom mocks the following methods in specs:
+
  * `TextEditor::shouldPromptToSave` -- always False
 
  * `clipboard.writeText` -- Does not interact with the system clipboard.

--- a/docs/writing-specs.md
+++ b/docs/writing-specs.md
@@ -47,6 +47,9 @@ Atom uses [Jasmine](http://jasmine.github.io/2.0/introduction.html) as its spec 
       expect("oranges").not.toEqual("apples")
   ```
 
+Atom also includes some [custom matchers](#Custom-Matchers) that can be
+used in package specs.
+
 ## Asynchronous specs
 
 Writing Asynchronous specs can be tricky at first. Some examples.
@@ -127,3 +130,84 @@ describe "when a test is written", ->
     expect("apples").toEqual("apples")
     expect("oranges").not.toEqual("apples")
 ```
+
+# Spec Helpers
+
+Atom provides a few global spec helpers:
+
+<!-- TODO: Write this documentation! -->
+
+ * `window.setTimeout`
+ * `window.clearTimeout`
+
+As well, it mocks the following methods.
+
+ * `TextEditorView::requestDisplayUpdate`
+ * `File::requestDisplayUpdate`
+ * `TextEditor::shouldPromptToSave` -- always False
+
+ * `clipboard.writeText` -- Does not interact with the system clipboard.
+ * `clipboard.readText` -- Initial a placeholder value: `'initial clipboard content'`
+
+# Custom Matchers
+
+<!-- TODO: Write documentation on these! -->
+
+##  `toBeInstanceOf(constructor)`
+
+Tests the expected value against its argument using `instanceof`:
+
+  ```coffee
+  describe "The 'toBeInstanceOf' matcher", ->
+    it "should test an object against its type", ->
+      expect({}).toBeInstanceOf Object
+      expect([]).toBeInstanceOf Array
+      expect(->).toBeInstanceOf Function
+      expect(/ab+/).toBeInstanceOf RegExp
+
+      class BaseContrivedTestClass
+      class ContrivedTestClass extends BaseContrivedTestClass
+      expect(new ContrivedTestClass).toBeInstanceOf BaseContrivedTestClass
+
+      expect(new Number(42)).toBeInstanceOf Number
+
+    it "does NOT work with primitive values", ->
+      expect("hello").not.toBeInstanceOf String
+      expect(1).not.toBeInstanceOf Number
+  ```
+
+## `toExistOnDisk(filePath)`
+
+Tests if the given file path exists on the filesystem.
+
+<!-- TODO: spec! -->
+
+## `toHaveFocus()`
+
+Tests given that the given element (either `jQuery` or a DOM object)
+has focus.
+
+<!-- TODO: spec! -->
+
+## `toHaveLength(number)`
+
+Tests that the length property of the value is the number given.
+
+  ```coffee
+  describe "the 'toHaveLength' matcher", ->
+    it "should test that an array has the given length", ->
+      expect([1,2,3]).toHaveLength 3
+      expect({length: 5}).toHaveLength 5
+
+    it "should fail a test if it does not the expected length", ->
+      expect([]).not.toHaveLength 1
+
+    it "should fail if the given value has no length property", ->
+      expect(null).not.toHaveLength 1
+      expect(1).not.toHaveLength 3
+  ```
+
+## `toShow`
+
+<!-- TODO: spec! -->
+

--- a/docs/writing-specs.md
+++ b/docs/writing-specs.md
@@ -187,26 +187,6 @@ Tests if the given file path exists on the filesystem.
 Tests given that the given element (either `jQuery` or a DOM object)
 has focus.
 
-<!-- TODO: spec! -->
-
-## `toHaveLength(number)`
-
-Tests that the length property of the value is the number given.
-
-  ```coffee
-  describe "the 'toHaveLength' matcher", ->
-    it "should test that an array has the given length", ->
-      expect([1,2,3]).toHaveLength 3
-      expect({length: 5}).toHaveLength 5
-
-    it "should fail a test if it does not the expected length", ->
-      expect([]).not.toHaveLength 1
-
-    it "should fail if the given value has no length property", ->
-      expect(null).not.toHaveLength 1
-      expect(1).not.toHaveLength 3
-  ```
-
 ## `toShow`
 
 <!-- TODO: spec! -->

--- a/spec/custom-matcher-spec.coffee
+++ b/spec/custom-matcher-spec.coffee
@@ -24,16 +24,7 @@ describe "Custom matchers:", ->
   describe "The 'toHaveFocus' matcher", ->
 
 
-  describe "the 'toHaveLength' matcher", ->
-    it "should test that an array has the given length", ->
-      expect([1,2,3]).toHaveLength 3
-      expect({length: 5}).toHaveLength 5
 
-    it "should fail a test if it does not the expected length", ->
-      expect([]).not.toHaveLength 1
 
-    it "should fail if the given value has no length property", ->
-      expect(null).not.toHaveLength 1
-      expect(1).not.toHaveLength 3
 
   describe "The 'toShow' matcher", ->

--- a/spec/custom-matcher-spec.coffee
+++ b/spec/custom-matcher-spec.coffee
@@ -1,0 +1,39 @@
+# Tests the custom matchers defined in `./spec-helper.coffee`
+
+describe "Custom matchers:", ->
+
+  describe "The 'toBeInstanceOf' matcher", ->
+    it "should test an object against its type", ->
+      expect({}).toBeInstanceOf Object
+      expect([]).toBeInstanceOf Array
+      expect(->).toBeInstanceOf Function
+      expect(/ab+/).toBeInstanceOf RegExp
+
+      class BaseContrivedTestClass
+      class ContrivedTestClass extends BaseContrivedTestClass
+      expect(new ContrivedTestClass).toBeInstanceOf BaseContrivedTestClass
+
+      expect(new Number(42)).toBeInstanceOf Number
+
+    it "does NOT work with primitive values", ->
+      expect("hello").not.toBeInstanceOf String
+      expect(1).not.toBeInstanceOf Number
+
+
+  describe "The 'toExistOnDisk' matcher", ->
+  describe "The 'toHaveFocus' matcher", ->
+
+
+  describe "the 'toHaveLength' matcher", ->
+    it "should test that an array has the given length", ->
+      expect([1,2,3]).toHaveLength 3
+      expect({length: 5}).toHaveLength 5
+
+    it "should fail a test if it does not the expected length", ->
+      expect([]).not.toHaveLength 1
+
+    it "should fail if the given value has no length property", ->
+      expect(null).not.toHaveLength 1
+      expect(1).not.toHaveLength 3
+
+  describe "The 'toShow' matcher", ->

--- a/spec/ready-to-merge-spec.coffee
+++ b/spec/ready-to-merge-spec.coffee
@@ -1,0 +1,7 @@
+# THIS FILE INTENTIONALLY BREAKS THE CI BUILD!
+# Delete this file when doc changes are ready to merge!
+
+readyToMerge = no
+describe "This pull request", ->
+  it "should be ready to merge", ->
+    expect(readyToMerge).toBeTruthy()

--- a/spec/spec-helper-spec.coffee
+++ b/spec/spec-helper-spec.coffee
@@ -1,0 +1,23 @@
+# TODO: Come up with a less ridiculous name for this file.
+
+describe "The spec helpers:", ->
+  
+  describe 'when a test uses advanceClock()', ->
+    [futureCallback] = []
+    beforeEach ->
+      futureCallback = jasmine.createSpy('futureCallback')
+
+    it 'can synchronously call setTimeout callbacks in the future', ->
+      setTimeout(futureCallback, 1000)
+      advanceClock(1001)
+
+      expect(futureCallback).toHaveBeenCalled()
+
+    it 'allows timeouts to be cleared', ->
+      id = setTimeout(futureCallback, 1000)
+      advanceClock(999)
+      clearTimeout(id)
+
+      advanceClock(1000)
+      expect(futureCallback).not.toHaveBeenCalled()
+

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -199,7 +199,7 @@ addCustomMatchers = (spec) ->
 
     toHaveLength: (expected) ->
       if not @actual?
-        this.message = => "Expected object #{@actual} has no length method"
+        this.message = => "Expected object #{@actual} has no length property"
         false
       else
         notText = if @isNot then " not" else ""

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -311,6 +311,11 @@ window.fakeSetInterval = (callback, ms) ->
 window.fakeClearInterval = (idToClear) ->
   window.fakeClearTimeout(@intervalTimeouts[idToClear])
 
+# Spec: Advances the clock by a given amount of milliseconds.
+#
+# Can be used to execute events dependent on `setTimeout()` synchronously.
+#
+# * `delta` {Number} milliseconds to advance by (default: 1).
 window.advanceClock = (delta=1) ->
   window.now += delta
   callbacks = []


### PR DESCRIPTION
I've started writing documentation for the goodies that `spec-helper.coffee` adds to all Atom specs. This addresses my comment in #3399.

@benogle, I've finally had time to work on this, but I just started so it's not ready to merge. I added specs for the custom matchers, as they prove to be useful in documenting the matchers, much like Jasmine documents [its own matchers](http://jasmine.github.io/1.3/introduction.html#section-Included_Matchers).

Let me know if I'm on the right track with regards to organization and style. I'll be pushing some more commits soon.
