### PR TITLE
Tab reorder in linux

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -12,6 +12,8 @@
   'ctrl-alt-s': 'application:run-all-specs'
   'ctrl-alt-o': 'application:open-dev'
   'ctrl-shift-o': 'application:open-folder'
+  'ctrl-shift-pageup': 'pane:move-item-to-left'
+  'ctrl-shift-pagedown': 'pane:move-item-to-right'
   'F11': 'window:toggle-full-screen'
 
   # Sublime Parity

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -151,16 +151,18 @@ describe "Pane", ->
       pane = new Pane(items: [new Item("A"), new Item("B"), new Item("C")])
       [item1, item2, item3] = pane.getItems()
 
+      pane.activateItemAtIndex(0)
       expect(pane.getActiveItem()).toBe item1
       pane.moveItemToLeft()
       expect(pane.getItems()).toEqual [item1, item2, item3]
-
       pane.moveItemToRight()
       expect(pane.getItems()).toEqual [item2, item1, item3]
-
+      pane.moveItemToLeft()
+      expect(pane.getItems()).toEqual [item1, item2, item3]
+      pane.activateItemAtIndex(2)
+      expect(pane.getActiveItem()).toBe item3
       pane.moveItemToRight()
-      pane.moveItemToRight()
-      expect(pane.getItems()).toEqual [item2, item3, item1]
+      expect(pane.getItems()).toEqual [item1, item2, item3]
 
   describe "::activateItemAtIndex(index)", ->
     it "activates the item at the given index", ->

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -146,6 +146,22 @@ describe "Pane", ->
       pane.activateNextItem()
       expect(pane.getActiveItem()).toBe item1
 
+  describe "::moveItemToRight() and ::moveItemToLeft()", ->
+    it "moves the active item to the right/left item, without looping around at either end", ->
+      pane = new Pane(items: [new Item("A"), new Item("B"), new Item("C")])
+      [item1, item2, item3] = pane.getItems()
+
+      expect(pane.getActiveItem()).toBe item1
+      pane.moveItemToLeft()
+      expect(pane.getItems()).toEqual [item1, item2, item3]
+
+      pane.moveItemToRight()
+      expect(pane.getItems()).toEqual [item2, item1, item3]
+
+      pane.moveItemToRight()
+      pane.moveItemToRight()
+      expect(pane.getItems()).toEqual [item2, item3, item1]
+
   describe "::activateItemAtIndex(index)", ->
     it "activates the item at the given index", ->
       pane = new Pane(items: [new Item("A"), new Item("B"), new Item("C")])

--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -61,6 +61,8 @@ class PaneElement extends HTMLElement
       'pane:show-item-7': -> @getModel().activateItemAtIndex(6)
       'pane:show-item-8': -> @getModel().activateItemAtIndex(7)
       'pane:show-item-9': -> @getModel().activateItemAtIndex(8)
+      'pane:move-item-to-right': -> @getModel().moveItemToRight()
+      'pane:move-item-to-left': -> @getModel().moveItemToLeft()
       'pane:split-left': -> @getModel().splitLeft(copyActiveItem: true)
       'pane:split-right': -> @getModel().splitRight(copyActiveItem: true)
       'pane:split-up': -> @getModel().splitUp(copyActiveItem: true)

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -289,6 +289,18 @@ class Pane extends Model
     else
       @activateItemAtIndex(@items.length - 1)
 
+  # Public: Move the active tab to the right.
+  moveItemToRight: ->
+    index = @getActiveItemIndex()
+    rightItemIndex = index + 1
+    @moveItem(@getActiveItem(), rightItemIndex) unless rightItemIndex > @items.length - 1
+
+  # Public: Move the active tab to the left
+  moveItemToLeft: ->
+    index = @getActiveItemIndex()
+    leftItemIndex = index - 1
+    @moveItem(@getActiveItem(), leftItemIndex) unless leftItemIndex < 0
+
   # Public: Get the index of the active item.
   #
   # Returns a {Number}.


### PR DESCRIPTION
In Chrome Linux and the Gnome environment (at least Gnome 3), `ctrl-shift-pagedown` and `ctrl-shift-pageup` are shortcuts to reorder tabs.
Here is the Chrome example:
![chrome-tabs](https://cloud.githubusercontent.com/assets/6003742/4966247/a300e9cc-67b7-11e4-96df-7b6f3cfdd8ed.gif)

Anytime I get back to Atom I tried to reorder some tabs just like with Chrome, but it was missing this shortcut. I thought it would be nice to have it. Here is how it looks:
![atom](https://cloud.githubusercontent.com/assets/6003742/4966259/67bf84a8-67b8-11e4-91c4-c21e056d2fd9.gif)

You may have noticed that Chrome has a nice animation, which I didn't try to implement, but if you would like to have it then let me know what are your thoughts on that so maybe I can start working on it.

Thank you
