### PR TITLE
Default buffer encoding to core.fileEncoding config

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -98,12 +98,13 @@ describe "TextEditor", ->
       expect(editor2.isFoldedAtBufferRow(4)).not.toBe editor.isFoldedAtBufferRow(4)
 
   describe "config defaults", ->
-    it "uses the `editor.tabLength`, `editor.softWrap`, and `editor.softTabs` config values", ->
+    it "uses the `editor.tabLength`, `editor.softWrap`, and `editor.softTabs`, and `core.fileEncoding` config values", ->
       editor1 = null
       editor2 = null
       atom.config.set('editor.tabLength', 4)
       atom.config.set('editor.softWrap', true)
       atom.config.set('editor.softTabs', false)
+      atom.config.set('core.fileEncoding', 'utf16le')
 
       waitsForPromise ->
         atom.workspace.open('a').then (o) -> editor1 = o
@@ -112,10 +113,12 @@ describe "TextEditor", ->
         expect(editor1.getTabLength()).toBe 4
         expect(editor1.isSoftWrapped()).toBe true
         expect(editor1.getSoftTabs()).toBe false
+        expect(editor1.getEncoding()).toBe 'utf16le'
 
         atom.config.set('editor.tabLength', 8)
         atom.config.set('editor.softWrap', false)
         atom.config.set('editor.softTabs', true)
+        atom.config.set('core.fileEncoding', 'macroman')
 
       waitsForPromise ->
         atom.workspace.open('b').then (o) -> editor2 = o
@@ -124,6 +127,7 @@ describe "TextEditor", ->
         expect(editor2.getTabLength()).toBe 8
         expect(editor2.isSoftWrapped()).toBe false
         expect(editor2.getSoftTabs()).toBe true
+        expect(editor2.getEncoding()).toBe 'macroman'
 
   describe "title", ->
     describe ".getTitle()", ->

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -66,7 +66,6 @@ module.exports =
           'utf16le',
           'utf8',
           'windows1250',
-          'windows1250',
           'windows1251',
           'windows1253',
           'windows1254',

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -35,6 +35,47 @@ module.exports =
       destroyEmptyPanes:
         type: 'boolean'
         default: true
+      fileEncoding:
+        description: 'Default character set encoding to use when reading and writing files.'
+        type: 'string'
+        default: 'utf8'
+        enum: [
+          'cp437',
+          'eucjp',
+          'euckr',
+          'gbk',
+          'iso88591',
+          'iso885910',
+          'iso885913',
+          'iso885914',
+          'iso885915',
+          'iso885916',
+          'iso88592',
+          'iso88593',
+          'iso88594',
+          'iso88595',
+          'iso88596',
+          'iso88597',
+          'iso88597',
+          'iso88598',
+          'koi8r',
+          'koi8u',
+          'macroman',
+          'shiftjis',
+          'utf16be',
+          'utf16le',
+          'utf8',
+          'windows1250',
+          'windows1250',
+          'windows1251',
+          'windows1253',
+          'windows1254',
+          'windows1255',
+          'windows1256',
+          'windows1257',
+          'windows1258',
+          'windows866'
+        ]
 
   editor:
     type: 'object'

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -67,6 +67,7 @@ module.exports =
           'utf8',
           'windows1250',
           'windows1251',
+          'windows1252',
           'windows1253',
           'windows1254',
           'windows1255',

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -323,6 +323,7 @@ class Project extends Model
   # Still needed when deserializing a tokenized buffer
   buildBufferSync: (absoluteFilePath) ->
     buffer = new TextBuffer({filePath: absoluteFilePath})
+    buffer.setEncoding(atom.config.get('core.fileEncoding'))
     @addBuffer(buffer)
     buffer.loadSync()
     buffer
@@ -338,6 +339,7 @@ class Project extends Model
       throw new Error("Atom can only handle files < 2MB for now.")
 
     buffer = new TextBuffer({filePath: absoluteFilePath})
+    buffer.setEncoding(atom.config.get('core.fileEncoding'))
     @addBuffer(buffer)
     buffer.load()
       .then((buffer) -> buffer)


### PR DESCRIPTION
Adds `core.fileEncoding` which will be used as the editor/buffer's default encoding when reading/writing.

I went with `core` instead of the `editor` for the prefix since this default should be respected for any packages reading/writing files, regardless of whether they are using the editor/buffer API or not.

![screen shot 2014-11-10 at 5 59 01 pm](https://cloud.githubusercontent.com/assets/671378/4987134/655ab9dc-6946-11e4-93a4-dc3252134c3e.png)

Closes atom/encoding-selector#3
