### PR TITLE
Overlay decorations

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1196,6 +1196,28 @@ describe "TextEditorComponent", ->
         expect(componentNode.querySelector('.test-highlight')).toBeFalsy()
         expect(componentNode.querySelector('.new-test-highlight')).toBeTruthy()
 
+  describe "overlay decoration rendering", ->
+    [marker, decoration, decorationParams, scrollViewClientLeft] = []
+    beforeEach ->
+      scrollViewClientLeft = componentNode.querySelector('.scroll-view').getBoundingClientRect().left
+
+    it "renders an overlay decoration when added and removes the overlay when the decoration is destroyed", ->
+      item = document.createElement('div')
+      item.classList.add 'my-overlay'
+
+      marker = editor.displayBuffer.markBufferRange([[2, 13], [2, 13]], invalidate: 'never')
+      decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+      nextAnimationFrame()
+
+      overlay = component.getTopmostDOMNode().querySelector('atom-overlay .my-overlay')
+      expect(overlay).toBe item
+
+      decoration.destroy()
+      nextAnimationFrame()
+
+      overlay = component.getTopmostDOMNode().querySelector('atom-overlay .my-overlay')
+      expect(overlay).toBe null
+
   describe "hidden input field", ->
     it "renders the hidden input field at the position of the last cursor if the cursor is on screen and the editor is focused", ->
       editor.setVerticalScrollMargin(0)

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1196,7 +1196,7 @@ describe "TextEditorComponent", ->
         expect(componentNode.querySelector('.test-highlight')).toBeFalsy()
         expect(componentNode.querySelector('.new-test-highlight')).toBeTruthy()
 
-  fdescribe "overlay decoration rendering", ->
+  describe "overlay decoration rendering", ->
     [item] = []
     beforeEach ->
       item = document.createElement('div')

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1197,9 +1197,8 @@ describe "TextEditorComponent", ->
         expect(componentNode.querySelector('.new-test-highlight')).toBeTruthy()
 
   describe "overlay decoration rendering", ->
-    [item, scrollViewClientLeft] = []
+    [item] = []
     beforeEach ->
-      scrollViewClientLeft = componentNode.querySelector('.scroll-view').getBoundingClientRect().left
       item = document.createElement('div')
       item.classList.add 'overlay-test'
 

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1319,6 +1319,57 @@ describe "TextEditorComponent", ->
         expect(overlay.style.left).toBe position.left + 'px'
         expect(overlay.style.top).toBe position.top - itemHeight + 'px'
 
+      describe "when the editor is very small", ->
+        beforeEach ->
+          gutterWidth = componentNode.querySelector('.gutter').offsetWidth
+          windowWidth = gutterWidth + 6 * editor.getDefaultCharWidth()
+          windowHeight = 6 * editor.getLineHeightInPixels()
+
+          wrapperNode.style.width = windowWidth + 'px'
+          wrapperNode.style.height = windowHeight + 'px'
+
+          component.measureHeightAndWidth()
+          nextAnimationFrame()
+
+        it "does not flip horizontally and force the overlay to have a negative left", ->
+          marker = editor.displayBuffer.markBufferRange([[0, 2], [0, 2]], invalidate: 'never')
+          decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+          nextAnimationFrame()
+
+          position = editor.pixelPositionForBufferPosition([0, 2])
+
+          overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
+          expect(overlay.style.left).toBe position.left + 'px'
+          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+          editor.insertText('a')
+          nextAnimationFrame()
+
+          position = editor.pixelPositionForBufferPosition([0, 3])
+
+          expect(overlay.style.left).toBe position.left + 'px'
+          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+        it "does not flip vertically and force the overlay to have a negative top", ->
+          marker = editor.displayBuffer.markBufferRange([[1, 0], [1, 0]], invalidate: 'never')
+          decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+          nextAnimationFrame()
+
+          position = editor.pixelPositionForBufferPosition([1, 0])
+
+          overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
+          expect(overlay.style.left).toBe position.left + 'px'
+          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+          editor.insertNewline()
+          nextAnimationFrame()
+
+          position = editor.pixelPositionForBufferPosition([2, 0])
+
+          expect(overlay.style.left).toBe position.left + 'px'
+          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+
       describe "when editor scroll position is not 0", ->
         it "flips horizontally when near the right edge", ->
           editor.setScrollLeft(2 * editor.getDefaultCharWidth())

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1262,7 +1262,7 @@ describe "TextEditorComponent", ->
         expect(overlay.style.left).toBe position.left + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
-    describe "positioning the overlay when near the edge of the window", ->
+    describe "positioning the overlay when near the edge of the editor", ->
       [itemWidth, itemHeight] = []
       beforeEach ->
         itemWidth = 4 * editor.getDefaultCharWidth()
@@ -1319,7 +1319,7 @@ describe "TextEditorComponent", ->
         expect(overlay.style.left).toBe position.left + 'px'
         expect(overlay.style.top).toBe position.top - itemHeight + 'px'
 
-      describe "when editor position is not 0", ->
+      describe "when editor scroll position is not 0", ->
         it "flips horizontally when near the right edge", ->
           editor.setScrollLeft(2 * editor.getDefaultCharWidth())
           marker = editor.displayBuffer.markBufferRange([[0, 28], [0, 28]], invalidate: 'never')

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1196,7 +1196,7 @@ describe "TextEditorComponent", ->
         expect(componentNode.querySelector('.test-highlight')).toBeFalsy()
         expect(componentNode.querySelector('.new-test-highlight')).toBeTruthy()
 
-  describe "overlay decoration rendering", ->
+  fdescribe "overlay decoration rendering", ->
     [item] = []
     beforeEach ->
       item = document.createElement('div')
@@ -1278,8 +1278,6 @@ describe "TextEditorComponent", ->
         wrapperNode.style.width = windowWidth + 'px'
         wrapperNode.style.height = windowHeight + 'px'
 
-        editor.setScrollTop(0)
-        editor.setScrollLeft(0)
         component.measureHeightAndWidth()
         nextAnimationFrame()
 

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1240,7 +1240,7 @@ describe "TextEditorComponent", ->
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
     describe "when the marker is not empty", ->
-      it "renders in the correct position", ->
+      it "renders at the head of the marker", ->
         marker = editor.displayBuffer.markBufferRange([[2, 5], [2, 10]], invalidate: 'never')
         decoration = editor.decorateMarker(marker, {type: 'overlay', item})
         nextAnimationFrame()
@@ -1251,7 +1251,7 @@ describe "TextEditorComponent", ->
         expect(overlay.style.left).toBe position.left + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
-      it "renders in the correct position when the marker is reversed", ->
+      it "renders at the head of the marker when the marker is reversed", ->
         marker = editor.displayBuffer.markBufferRange([[2, 5], [2, 10]], invalidate: 'never', reversed: true)
         decoration = editor.decorateMarker(marker, {type: 'overlay', item})
         nextAnimationFrame()

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1203,41 +1203,65 @@ describe "TextEditorComponent", ->
       item = document.createElement('div')
       item.classList.add 'overlay-test'
 
-    it "renders an overlay decoration when added and removes the overlay when the decoration is destroyed", ->
-      marker = editor.displayBuffer.markBufferRange([[2, 13], [2, 13]], invalidate: 'never')
-      decoration = editor.decorateMarker(marker, {type: 'overlay', item})
-      nextAnimationFrame()
+    describe "when the marker is empty", ->
+      it "renders an overlay decoration when added and removes the overlay when the decoration is destroyed", ->
+        marker = editor.displayBuffer.markBufferRange([[2, 13], [2, 13]], invalidate: 'never')
+        decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+        nextAnimationFrame()
 
-      overlay = component.getTopmostDOMNode().querySelector('atom-overlay .overlay-test')
-      expect(overlay).toBe item
+        overlay = component.getTopmostDOMNode().querySelector('atom-overlay .overlay-test')
+        expect(overlay).toBe item
 
-      decoration.destroy()
-      nextAnimationFrame()
+        decoration.destroy()
+        nextAnimationFrame()
 
-      overlay = component.getTopmostDOMNode().querySelector('atom-overlay .overlay-test')
-      expect(overlay).toBe null
+        overlay = component.getTopmostDOMNode().querySelector('atom-overlay .overlay-test')
+        expect(overlay).toBe null
 
-    it "renders in the correct position on initial display and when the marker moves", ->
-      editor.setCursorBufferPosition([2, 5])
+      it "renders in the correct position on initial display and when the marker moves", ->
+        editor.setCursorBufferPosition([2, 5])
 
-      marker = editor.getLastCursor().getMarker()
-      decoration = editor.decorateMarker(marker, {type: 'overlay', item})
-      nextAnimationFrame()
+        marker = editor.getLastCursor().getMarker()
+        decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+        nextAnimationFrame()
 
-      position = editor.pixelPositionForBufferPosition([2, 5])
+        position = editor.pixelPositionForBufferPosition([2, 5])
 
-      overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-      expect(overlay.style.left).toBe position.left + 'px'
-      expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+        overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
+        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
-      editor.moveRight()
-      editor.moveRight()
-      nextAnimationFrame()
+        editor.moveRight()
+        editor.moveRight()
+        nextAnimationFrame()
 
-      position = editor.pixelPositionForBufferPosition([2, 7])
+        position = editor.pixelPositionForBufferPosition([2, 7])
 
-      expect(overlay.style.left).toBe position.left + 'px'
-      expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+    describe "when the marker is not empty", ->
+      it "renders in the correct position", ->
+        marker = editor.displayBuffer.markBufferRange([[2, 5], [2, 10]], invalidate: 'never')
+        decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+        nextAnimationFrame()
+
+        position = editor.pixelPositionForBufferPosition([2, 10])
+
+        overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
+        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+      it "renders in the correct position when the marker is reversed", ->
+        marker = editor.displayBuffer.markBufferRange([[2, 5], [2, 10]], invalidate: 'never', reversed: true)
+        decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+        nextAnimationFrame()
+
+        position = editor.pixelPositionForBufferPosition([2, 5])
+
+        overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
+        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
   describe "hidden input field", ->
     it "renders the hidden input field at the position of the last cursor if the cursor is on screen and the editor is focused", ->

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1262,6 +1262,106 @@ describe "TextEditorComponent", ->
         expect(overlay.style.left).toBe position.left + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
+    describe "positioning the overlay when near the edge of the window", ->
+      [itemWidth, itemHeight] = []
+      beforeEach ->
+        itemWidth = 4 * editor.getDefaultCharWidth()
+        itemHeight = 4 * editor.getLineHeightInPixels()
+
+        gutterWidth = componentNode.querySelector('.gutter').offsetWidth
+        windowWidth = gutterWidth + 30 * editor.getDefaultCharWidth()
+        windowHeight = 9 * editor.getLineHeightInPixels()
+
+        item.style.width = itemWidth + 'px'
+        item.style.height = itemHeight + 'px'
+
+        wrapperNode.style.width = windowWidth + 'px'
+        wrapperNode.style.height = windowHeight + 'px'
+
+        editor.setScrollTop(0)
+        editor.setScrollLeft(0)
+        component.measureHeightAndWidth()
+        nextAnimationFrame()
+
+      it "flips horizontally when near the right edge", ->
+        marker = editor.displayBuffer.markBufferRange([[0, 26], [0, 26]], invalidate: 'never')
+        decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+        nextAnimationFrame()
+
+        position = editor.pixelPositionForBufferPosition([0, 26])
+
+        overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
+        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+        editor.insertText('a')
+        nextAnimationFrame()
+
+        position = editor.pixelPositionForBufferPosition([0, 27])
+
+        expect(overlay.style.left).toBe position.left - itemWidth + 'px'
+        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+      it "flips vertically when near the bottom edge", ->
+        marker = editor.displayBuffer.markBufferRange([[4, 0], [4, 0]], invalidate: 'never')
+        decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+        nextAnimationFrame()
+
+        position = editor.pixelPositionForBufferPosition([4, 0])
+
+        overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
+        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+        editor.insertNewline()
+        nextAnimationFrame()
+
+        position = editor.pixelPositionForBufferPosition([5, 0])
+
+        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.top).toBe position.top - itemHeight + 'px'
+
+      describe "when editor position is not 0", ->
+        it "flips horizontally when near the right edge", ->
+          editor.setScrollLeft(2 * editor.getDefaultCharWidth())
+          marker = editor.displayBuffer.markBufferRange([[0, 28], [0, 28]], invalidate: 'never')
+          decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+          nextAnimationFrame()
+
+          position = editor.pixelPositionForBufferPosition([0, 28])
+
+          overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
+          expect(overlay.style.left).toBe position.left + 'px'
+          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+          editor.insertText('a')
+          nextAnimationFrame()
+
+          position = editor.pixelPositionForBufferPosition([0, 29])
+
+          expect(overlay.style.left).toBe position.left - itemWidth + 'px'
+          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+        it "flips vertically when near the bottom edge", ->
+          editor.setScrollTop(2 * editor.getLineHeightInPixels())
+          marker = editor.displayBuffer.markBufferRange([[6, 0], [6, 0]], invalidate: 'never')
+          decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+          nextAnimationFrame()
+
+          position = editor.pixelPositionForBufferPosition([6, 0])
+
+          overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
+          expect(overlay.style.left).toBe position.left + 'px'
+          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+          editor.insertNewline()
+          nextAnimationFrame()
+
+          position = editor.pixelPositionForBufferPosition([7, 0])
+
+          expect(overlay.style.left).toBe position.left + 'px'
+          expect(overlay.style.top).toBe position.top - itemHeight + 'px'
+
   describe "hidden input field", ->
     it "renders the hidden input field at the position of the last cursor if the cursor is on screen and the editor is focused", ->
       editor.setVerticalScrollMargin(0)

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1197,26 +1197,47 @@ describe "TextEditorComponent", ->
         expect(componentNode.querySelector('.new-test-highlight')).toBeTruthy()
 
   describe "overlay decoration rendering", ->
-    [marker, decoration, decorationParams, scrollViewClientLeft] = []
+    [item, scrollViewClientLeft] = []
     beforeEach ->
       scrollViewClientLeft = componentNode.querySelector('.scroll-view').getBoundingClientRect().left
+      item = document.createElement('div')
+      item.classList.add 'overlay-test'
 
     it "renders an overlay decoration when added and removes the overlay when the decoration is destroyed", ->
-      item = document.createElement('div')
-      item.classList.add 'my-overlay'
-
       marker = editor.displayBuffer.markBufferRange([[2, 13], [2, 13]], invalidate: 'never')
       decoration = editor.decorateMarker(marker, {type: 'overlay', item})
       nextAnimationFrame()
 
-      overlay = component.getTopmostDOMNode().querySelector('atom-overlay .my-overlay')
+      overlay = component.getTopmostDOMNode().querySelector('atom-overlay .overlay-test')
       expect(overlay).toBe item
 
       decoration.destroy()
       nextAnimationFrame()
 
-      overlay = component.getTopmostDOMNode().querySelector('atom-overlay .my-overlay')
+      overlay = component.getTopmostDOMNode().querySelector('atom-overlay .overlay-test')
       expect(overlay).toBe null
+
+    it "renders in the correct position on initial display and when the marker moves", ->
+      editor.setCursorBufferPosition([2, 5])
+
+      marker = editor.getLastCursor().getMarker()
+      decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+      nextAnimationFrame()
+
+      position = editor.pixelPositionForBufferPosition([2, 5])
+
+      overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
+      expect(overlay.style.left).toBe position.left + 'px'
+      expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+      editor.moveRight()
+      editor.moveRight()
+      nextAnimationFrame()
+
+      position = editor.pixelPositionForBufferPosition([2, 7])
+
+      expect(overlay.style.left).toBe position.left + 'px'
+      expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
   describe "hidden input field", ->
     it "renders the hidden input field at the position of the last cursor if the cursor is on screen and the editor is focused", ->

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -17,7 +17,7 @@ class Cursor extends Model
   visible: true
   needsAutoscroll: null
 
-  # Instantiated by an {TextEditor}
+  # Instantiated by a {TextEditor}
   constructor: ({@editor, @marker, id}) ->
     @emitter = new Emitter
 

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -171,6 +171,10 @@ class Cursor extends Model
   Section: Cursor Position Details
   ###
 
+  # Public: Returns the underlying {Marker} for the cursor.
+  # Useful with overlay {Decoration}s.
+  getMarker: -> @marker
+
   # Public: Identifies if the cursor is surrounded by whitespace.
   #
   # "Surrounded" here means that the character directly before and after the

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -7,6 +7,7 @@ React = require 'react-atom-fork'
 Decoration = require './decoration'
 CursorsComponent = require './cursors-component'
 HighlightsComponent = require './highlights-component'
+OverlayManager = require './overlay-manager'
 
 DummyLineNode = $$(-> @div className: 'line', style: 'position: absolute; visibility: hidden;', => @span 'x')[0]
 AcceptFilter = {acceptNode: -> NodeFilter.FILTER_ACCEPT}
@@ -20,7 +21,7 @@ LinesComponent = React.createClass
     {performedInitialMeasurement, cursorBlinkPeriod, cursorBlinkResumeDelay} = @props
 
     if performedInitialMeasurement
-      {editor, highlightDecorations, scrollHeight, scrollWidth, placeholderText, backgroundColor} = @props
+      {editor, overlayDecorations, highlightDecorations, scrollHeight, scrollWidth, placeholderText, backgroundColor} = @props
       {lineHeightInPixels, defaultCharWidth, scrollViewHeight, scopedCharacterWidthsChangeCount} = @props
       {scrollTop, scrollLeft, cursorPixelRects, mini} = @props
       style =
@@ -63,10 +64,15 @@ LinesComponent = React.createClass
       insertionPoint.setAttribute('select', '.overlayer')
       @getDOMNode().appendChild(insertionPoint)
 
+      insertionPoint = document.createElement('content')
+      insertionPoint.setAttribute('select', 'atom-overlay')
+      @overlayManager = new OverlayManager()
+      @getDOMNode().appendChild(insertionPoint)
+
   shouldComponentUpdate: (newProps) ->
     return true unless isEqualForProperties(newProps, @props,
       'renderedRowRange', 'lineDecorations', 'highlightDecorations', 'lineHeightInPixels', 'defaultCharWidth',
-      'scrollTop', 'scrollLeft', 'showIndentGuide', 'scrollingVertically', 'visible',
+      'overlayDecorations', 'scrollTop', 'scrollLeft', 'showIndentGuide', 'scrollingVertically', 'visible',
       'scrollViewHeight', 'mouseWheelScreenRow', 'scopedCharacterWidthsChangeCount', 'lineWidth', 'useHardwareAcceleration',
       'placeholderText', 'performedInitialMeasurement', 'backgroundColor', 'cursorPixelRects'
     )
@@ -91,6 +97,8 @@ LinesComponent = React.createClass
     @removeLineNodes() unless isEqualForProperties(prevProps, @props, 'showIndentGuide')
     @updateLines(@props.lineWidth isnt prevProps.lineWidth)
     @measureCharactersInNewLines() if visible and not scrollingVertically
+
+    @overlayManager?.render(@props)
 
   clearScreenRowCaches: ->
     @screenRowsByLineId = {}

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -66,8 +66,10 @@ LinesComponent = React.createClass
 
       insertionPoint = document.createElement('content')
       insertionPoint.setAttribute('select', 'atom-overlay')
-      @overlayManager = new OverlayManager()
+      @overlayManager = new OverlayManager(@props.hostElement)
       @getDOMNode().appendChild(insertionPoint)
+    else
+      @overlayManager = new OverlayManager(@getDOMNode())
 
   shouldComponentUpdate: (newProps) ->
     return true unless isEqualForProperties(newProps, @props,

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -1,0 +1,31 @@
+module.exports = 
+class OverlayManager
+  constructor: ->
+    @overlays = {}
+
+  render: (props) ->
+    {hostElement, editor, overlayDecorations, lineHeightInPixels} = props
+
+    existingDecorations = null
+    for markerId, {startPixelPosition, endPixelPosition, decorations} of overlayDecorations
+      for decoration in decorations
+        @renderOverlay(hostElement, decoration, endPixelPosition)
+
+        existingDecorations ?= {}
+        existingDecorations[decoration.id] = true
+
+    for id, overlay of @overlays
+      unless existingDecorations? and id of existingDecorations
+        hostElement.removeChild(overlay)
+        delete @overlays[id]
+
+    return
+
+  renderOverlay: (hostElement, decoration, endPixelPosition) ->
+    unless overlay = @overlays[decoration.id]
+      overlay = @overlays[decoration.id] = document.createElement('atom-overlay')
+      overlay.appendChild(atom.views.getView(decoration.item))
+      hostElement.appendChild(overlay)
+
+    overlay.style.top = endPixelPosition.top + 'px'
+    overlay.style.left = endPixelPosition.left + 'px'

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -9,7 +9,7 @@ class OverlayManager
     existingDecorations = null
     for markerId, {startPixelPosition, endPixelPosition, decorations} of overlayDecorations
       for decoration in decorations
-        @renderOverlay(hostElement, decoration, endPixelPosition)
+        @renderOverlay(hostElement, decoration, endPixelPosition, lineHeightInPixels)
 
         existingDecorations ?= {}
         existingDecorations[decoration.id] = true
@@ -21,11 +21,11 @@ class OverlayManager
 
     return
 
-  renderOverlay: (hostElement, decoration, endPixelPosition) ->
+  renderOverlay: (hostElement, decoration, pixelPosition, lineHeightInPixels) ->
     unless overlay = @overlays[decoration.id]
       overlay = @overlays[decoration.id] = document.createElement('atom-overlay')
       overlay.appendChild(atom.views.getView(decoration.item))
       hostElement.appendChild(overlay)
 
-    overlay.style.top = endPixelPosition.top + 'px'
-    overlay.style.left = endPixelPosition.left + 'px'
+    overlay.style.top = pixelPosition.top + lineHeightInPixels + 'px'
+    overlay.style.left = pixelPosition.left + 'px'

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -1,6 +1,6 @@
 module.exports =
 class OverlayManager
-  constructor: (@container)->
+  constructor: (@container) ->
     @overlays = {}
 
   render: (props) ->

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -36,10 +36,12 @@ class OverlayManager
     itemHeight = item.offsetHeight
 
     left = pixelPosition.left
-    left -= itemWidth if left + itemWidth - editor.getScrollLeft() > editor.getWidth()
+    if left + itemWidth - editor.getScrollLeft() > editor.getWidth() and left - itemWidth >= editor.getScrollLeft()
+      left -= itemWidth
 
     top = pixelPosition.top + lineHeightInPixels
-    top -= itemHeight + lineHeightInPixels if top + itemHeight - editor.getScrollTop() > editor.getHeight()
+    if top + itemHeight - editor.getScrollTop() > editor.getHeight() and top - itemHeight - lineHeightInPixels >= editor.getScrollTop()
+      top -= itemHeight + lineHeightInPixels
 
     overlay.style.top = top + 'px'
     overlay.style.left = left + 'px'

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -1,4 +1,4 @@
-module.exports = 
+module.exports =
 class OverlayManager
   constructor: ->
     @overlays = {}

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -7,13 +7,9 @@ class OverlayManager
     {editor, overlayDecorations, lineHeightInPixels} = props
 
     existingDecorations = null
-    for markerId, {isMarkerReversed, startPixelPosition, endPixelPosition, decorations} of overlayDecorations
+    for markerId, {isMarkerReversed, headPixelPosition, decorations} of overlayDecorations
       for decoration in decorations
-        pixelPosition = if isMarkerReversed
-          startPixelPosition
-        else
-          endPixelPosition
-        @renderOverlay(editor, decoration, pixelPosition, lineHeightInPixels)
+        @renderOverlay(editor, decoration, headPixelPosition, lineHeightInPixels)
 
         existingDecorations ?= {}
         existingDecorations[decoration.id] = true

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -7,9 +7,13 @@ class OverlayManager
     {hostElement, editor, overlayDecorations, lineHeightInPixels} = props
 
     existingDecorations = null
-    for markerId, {startPixelPosition, endPixelPosition, decorations} of overlayDecorations
+    for markerId, {isMarkerReversed, startPixelPosition, endPixelPosition, decorations} of overlayDecorations
       for decoration in decorations
-        @renderOverlay(hostElement, decoration, endPixelPosition, lineHeightInPixels)
+        pixelPosition = if isMarkerReversed
+          startPixelPosition
+        else
+          endPixelPosition
+        @renderOverlay(hostElement, decoration, pixelPosition, lineHeightInPixels)
 
         existingDecorations ?= {}
         existingDecorations[decoration.id] = true

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -13,7 +13,7 @@ class OverlayManager
           startPixelPosition
         else
           endPixelPosition
-        @renderOverlay(hostElement, decoration, pixelPosition, lineHeightInPixels)
+        @renderOverlay(editor, hostElement, decoration, pixelPosition, lineHeightInPixels)
 
         existingDecorations ?= {}
         existingDecorations[decoration.id] = true
@@ -25,11 +25,21 @@ class OverlayManager
 
     return
 
-  renderOverlay: (hostElement, decoration, pixelPosition, lineHeightInPixels) ->
+  renderOverlay: (editor, hostElement, decoration, pixelPosition, lineHeightInPixels) ->
+    item = atom.views.getView(decoration.item)
     unless overlay = @overlays[decoration.id]
       overlay = @overlays[decoration.id] = document.createElement('atom-overlay')
-      overlay.appendChild(atom.views.getView(decoration.item))
+      overlay.appendChild(item)
       hostElement.appendChild(overlay)
 
-    overlay.style.top = pixelPosition.top + lineHeightInPixels + 'px'
-    overlay.style.left = pixelPosition.left + 'px'
+    itemWidth = item.offsetWidth
+    itemHeight = item.offsetHeight
+
+    left = pixelPosition.left
+    left -= itemWidth if left + itemWidth - editor.getScrollLeft() > editor.getWidth()
+
+    top = pixelPosition.top + lineHeightInPixels
+    top -= itemHeight + lineHeightInPixels if top + itemHeight - editor.getScrollTop() > editor.getHeight()
+
+    overlay.style.top = top + 'px'
+    overlay.style.left = left + 'px'

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -1,10 +1,10 @@
 module.exports =
 class OverlayManager
-  constructor: ->
+  constructor: (@container)->
     @overlays = {}
 
   render: (props) ->
-    {hostElement, editor, overlayDecorations, lineHeightInPixels} = props
+    {editor, overlayDecorations, lineHeightInPixels} = props
 
     existingDecorations = null
     for markerId, {isMarkerReversed, startPixelPosition, endPixelPosition, decorations} of overlayDecorations
@@ -13,24 +13,24 @@ class OverlayManager
           startPixelPosition
         else
           endPixelPosition
-        @renderOverlay(editor, hostElement, decoration, pixelPosition, lineHeightInPixels)
+        @renderOverlay(editor, decoration, pixelPosition, lineHeightInPixels)
 
         existingDecorations ?= {}
         existingDecorations[decoration.id] = true
 
     for id, overlay of @overlays
       unless existingDecorations? and id of existingDecorations
-        hostElement.removeChild(overlay)
+        @container.removeChild(overlay)
         delete @overlays[id]
 
     return
 
-  renderOverlay: (editor, hostElement, decoration, pixelPosition, lineHeightInPixels) ->
+  renderOverlay: (editor, decoration, pixelPosition, lineHeightInPixels) ->
     item = atom.views.getView(decoration.item)
     unless overlay = @overlays[decoration.id]
       overlay = @overlays[decoration.id] = document.createElement('atom-overlay')
       overlay.appendChild(item)
-      hostElement.appendChild(overlay)
+      @container.appendChild(overlay)
 
     itemWidth = item.offsetWidth
     itemHeight = item.offsetHeight

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -360,16 +360,14 @@ TextEditorComponent = React.createClass
     filteredDecorations = {}
     for markerId, decorations of decorationsByMarkerId
       marker = editor.getMarker(markerId)
-      screenRange = marker.getScreenRange()
+      headBufferPosition = marker.getHeadBufferPosition()
       if marker.isValid()
         for decoration in decorations
           if decoration.isType('overlay')
             decorationParams = decoration.getProperties()
             filteredDecorations[markerId] ?=
               id: markerId
-              isMarkerReversed: marker.isReversed()
-              startPixelPosition: editor.pixelPositionForScreenPosition(screenRange.start)
-              endPixelPosition: editor.pixelPositionForScreenPosition(screenRange.end)
+              headPixelPosition: editor.pixelPositionForScreenPosition(headBufferPosition)
               decorations: []
             filteredDecorations[markerId].decorations.push decorationParams
     filteredDecorations

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -367,6 +367,7 @@ TextEditorComponent = React.createClass
             decorationParams = decoration.getProperties()
             filteredDecorations[markerId] ?=
               id: markerId
+              isMarkerReversed: marker.isReversed()
               startPixelPosition: editor.pixelPositionForScreenPosition(screenRange.start)
               endPixelPosition: editor.pixelPositionForScreenPosition(screenRange.end)
               decorations: []

--- a/src/text-editor-view.coffee
+++ b/src/text-editor-view.coffee
@@ -77,7 +77,6 @@ class TextEditorView extends View
 
     @scrollView = @root.find('.scroll-view')
 
-
     if atom.config.get('editor.useShadowDOM')
       @underlayer = $("<div class='underlayer'></div>").appendTo(this)
       @overlayer = $("<div class='overlayer'></div>").appendTo(this)

--- a/static/text-editor-light.less
+++ b/static/text-editor-light.less
@@ -12,6 +12,12 @@ atom-text-editor.mini {
   max-height: @component-line-height + 2; // +2 for borders
 }
 
+atom-overlay {
+  position: absolute;
+  display: block;
+  z-index: 4;
+}
+
 // TODO: remove this when the shadow DOM is the default
 atom-text-editor .highlight {
   background: none;


### PR DESCRIPTION
It works:
![overlay-decoration](https://cloud.githubusercontent.com/assets/69169/4987275/9f4b251c-6948-11e4-9d7f-620eb073aa47.gif)

I want to position the `atom-overlay` element to fit within the editor window, so people dont have to think about it. @nathansobo, objections to that?

Closes #3747
### TODO
- [x] Overlay decorations display
- [x] Specs
- [x] Properly position up against the bounds of the window
- [x] Make work when shadow dom is disabled
