### PR TITLE
Make cmd-delete delete to end of line.

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -111,8 +111,8 @@
 
   # Apple Specific
   'cmd-backspace': 'editor:delete-to-beginning-of-line'
-  'cmd-shift-backspace': 'editor:delete-to-beginning-of-line'
-  'cmd-delete': 'editor:delete-to-beginning-of-line'
+  'cmd-shift-backspace': 'editor:delete-to-end-of-line'
+  'cmd-delete': 'editor:delete-to-end-of-line'
   'ctrl-A': 'editor:select-to-first-character-of-line'
   'ctrl-E': 'editor:select-to-end-of-line'
   'cmd-left': 'editor:move-to-first-character-of-line'

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -111,7 +111,7 @@
 
   # Apple Specific
   'cmd-backspace': 'editor:delete-to-beginning-of-line'
-  'cmd-shift-backspace': 'editor:delete-to-end-of-line'
+  'cmd-shift-backspace': 'editor:delete-to-beginning-of-line'
   'cmd-delete': 'editor:delete-to-end-of-line'
   'ctrl-A': 'editor:select-to-first-character-of-line'
   'ctrl-E': 'editor:select-to-end-of-line'


### PR DESCRIPTION
The expected behaviour of cmd-delete is that it deletes to end of line,
with cmd acting as a modifier to delete.
