### PR TITLE
Add package upgrade guide

### DIFF
--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -141,6 +141,8 @@ Sometimes it is as simple as converting the requires at the top of each view pag
 
 ### Upgrading classes extending any space-pen View
 
+#### `afterAttach` and `beforeRemove` updated
+
 The `afterAttach` and `beforeRemove` hooks have been replaced with
 `attached` and `detached` and the semantics have changed.
 
@@ -170,6 +172,10 @@ class MyView extends View
   detached: ->
     #...
 ```
+
+#### `subscribe` and `subscribeToCommand` methods removed
+
+Additionally, the `subscribe` and `subscribeToCommand` methods have been removed. See the Eventing and Disposables section for more info.
 
 ### Upgrading to the new TextEditorView
 

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -547,7 +547,12 @@ class Something
     @emitter.on 'did-change', callback
 
   methodThatFiresAChange: ->
-    @emitter.emit 'did-change'
+    @emitter.emit 'did-change', {data: 2}
+
+something = new Something
+something.onDidChange (eventObject) ->
+  console.log eventObject.data # => 2
+something.methodThatFiresAChange()
 ```
 
 ## Subscribing To Commands
@@ -568,7 +573,9 @@ atom.workspaceView.command 'core:close core:cancel', ->
   'core:close': ->
   'core:cancel': ->
 
-# When in a View class, you should have a `@element` object available. `@element` is a raw HTML element
+# You can register commands directly on individual DOM elements in addition to
+# using selectors. When in a View class, you should have a `@element` object
+# available. `@element` is a plain HTMLElement object
 @disposables.add atom.commands.add @element,
   'core:close': ->
   'core:cancel': ->

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -397,15 +397,15 @@ We're going to use `atom.views.getView()` again to get the editor element. As in
 ```coffee
 # New!
 describe 'Something', ->
-  [editor, editorView] = []
+  [editor, editorElement] = []
   beforeEach ->
     editor = atom.workspace.getActiveTextEditor()
-    editorView = atom.views.getView(editor)
+    editorElement = atom.views.getView(editor)
 ```
 
 ### Dispatching commands
 
-Since the `editorView` objects are no longer `jQuery` objects, they no longer support `trigger()`. Additionally, Atom has a new command dispatcher, `atom.commands`, that we use rather than commandeering jQuery's `trigger` method.
+Since the `editorElement` objects are no longer `jQuery` objects, they no longer support `trigger()`. Additionally, Atom has a new command dispatcher, `atom.commands`, that we use rather than commandeering jQuery's `trigger` method.
 
 From this:
 
@@ -420,14 +420,14 @@ To this:
 ```coffee
 # New!
 atom.commands.dispatch workspaceElement, 'a-package:toggle'
-atom.commands.dispatch editorView, 'find-and-replace:show'
+atom.commands.dispatch editorElement, 'find-and-replace:show'
 ```
 
 ## Eventing and Disposables
 
 A couple large things changed with respect to events:
 
-1. All model events are now methods that return a [`Disposable`][disposable] object
+1. All model events are now exposed as event subscription methods that return [`Disposable`][disposable] objects
 1. The `subscribe()` method is no longer available on `space-pen` `View` objects
 1. An Emitter is now provided from `require 'atom'`
 

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -193,7 +193,7 @@ class CommandPaletteView extends SelectListView
     @panel?.hide()
 ```
 
-See the [SelectListView docs][SelectListView] for all the options.
+See the [SelectListView docs][SelectListView] for all the options. And check out the [conversion of CommandPaletteView][selectlistview-example] as a real-world example.
 
 ## Specs
 
@@ -203,3 +203,4 @@ TODO: come up with patterns for converting away from using `workspaceView` and `
 [texteditorview]:https://github.com/atom/atom-space-pen-views#texteditorview
 [scrollview]:https://github.com/atom/atom-space-pen-views#scrollview
 [selectlistview]:https://github.com/atom/atom-space-pen-views#selectlistview
+[selectlistview-example]:https://github.com/atom/command-palette/pull/19/files

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -22,9 +22,7 @@ TODO: image of deprecations in DepCop
 
 ## Views
 
-### The Old
-
-Previous to 1.0, views in packages were baked into Atom core. These views were based on jQuery and `space-pen`. They look something like this:
+Previous to 1.0, views in packages were baked into Atom core. These views were based on jQuery and `space-pen`. They looked something like this:
 
 ```coffee
 {$, TextEditorView, View} = require 'atom'
@@ -75,29 +73,32 @@ SelectListView
 
 `Workspace` and `WorkspaceView` are _no longer provided_ in any capacity. They should be unnecessary
 
-#### jQuery
+### Adding the module dependencies
 
-If you do not need `space-pen`, you can require jQuery directly. In your `package.json` add this to the `dependencies` object:
-
-```js
-"jquery": "^2"
-```
-
-#### NPM dependencies
+To use the new views, you need to specify a couple modules in your package dependencies in your `package.json` file:
 
 ```js
 {
   "dependencies": {
-    "jquery": "^2" // if you want to include jquery directly
     "space-pen": "^3"
     "atom-space-pen-views": "^0"
   }
 }
 ```
 
-#### Converting your views
+`space-pen` bundles jQuery. If you do not need `space-pen`, you can require jQuery directly.
 
-Sometimes it should be as simple as converting the requires at the top of each view page. In the case of our above example, you can just convert them to the following:
+```js
+{
+  "dependencies": {
+    "jquery": "^2"
+  }
+}
+```
+
+### Converting your views
+
+Sometimes it is as simple as converting the requires at the top of each view page. In the case of our above example, you can just convert them to the following:
 
 ```coffee
 {$, View} = require 'space-pen'

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -1,0 +1,109 @@
+# Upgrading your package to 1.0 APIs
+
+Atom is rapidly approaching 1.0. Much of the effort leading up to the 1.0 has been cleaning up APIs in an attempt to future proof, and make a more pleasant experience developing packages.
+
+This document will guide you through the large bits of upgrading your package to work with 1.0 APIs.
+
+## Deprecations
+
+All of the methods that have changes emit deprecation messages when called. These messages are shown in two places: your package specs, and in Deprecation Cop.
+
+### Specs
+
+Just run your specs, and all the deprecations will be displayed in yellow.
+
+TODO: image of deprecations in specs
+
+### Deprecation Cop
+
+Run an atom window in dev mode (`atom -d`) with your package loaded, and open Deprecation Cop (search for `deprecation` in the command palette).
+
+TODO: image of deprecations in DepCop
+
+## Views
+
+### The Old
+
+Previous to 1.0, views in packages were baked into Atom core. These views were based on jQuery and `space-pen`. They look something like this:
+
+```coffee
+{$, TextEditorView, View} = require 'atom'
+
+module.exports =
+class SomeView extends View
+  @content: ->
+    @div class: 'find-and-replace', =>
+      @div class: 'block', =>
+        @subview 'myEditor', new TextEditorView(mini: true)
+  #...
+```
+
+Requiring `atom` used to provide the following view helpers:
+
+```
+$
+$$
+$$$
+View
+TextEditorView
+ScrollView
+SelectListView
+Workspace
+WorkspaceView
+```
+
+### The New
+
+Atom no longer provides these view helpers baked in. They are now available from two npm packages: `space-pen`, and `atom-space-pen-views`
+
+`space-pen` now provides
+
+```
+$
+$$
+$$$
+View
+```
+
+`atom-space-pen-views` now provides
+
+```
+TextEditorView
+ScrollView
+SelectListView
+```
+
+`Workspace` and `WorkspaceView` are _no longer provided_ in any capacity. They should be unnecessary
+
+#### jQuery
+
+If you do not need `space-pen`, you can require jQuery directly. In your `package.json` add this to the `dependencies` object:
+
+```js
+"jquery": "^2"
+```
+
+#### NPM dependencies
+
+```js
+{
+  "dependencies": {
+    "jquery": "^2" // if you want to include jquery directly
+    "space-pen": "^3"
+    "atom-space-pen-views": "^0"
+  }
+}
+```
+
+#### Converting your views
+
+Sometimes it should be as simple as converting the requires at the top of each view page. In the case of our above example, you can just convert them to the following:
+
+```coffee
+{$, View} = require 'space-pen'
+{TextEditorView} = require 'atom-space-pen-views'
+```
+
+## Specs
+
+TODO: come up with patterns for

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -159,24 +159,71 @@ To use the new views, you need to specify the `atom-space-pen-views` module in y
 
 ### Converting your views
 
-Sometimes it is as simple as converting the requires at the top of each view page. In the case of our above example, you can just convert them to the following:
+Sometimes it is as simple as converting the requires at the top of each view page. I assume you read the 'TL;DR' section and have updated all of your requires.
+
+### Upgrading classes extending any space-pen View
+
+The `afterAttach` and `beforeRemove` hooks have been replaced with
+`attached` and `detached` and their semantics have been altered. `attached` will only be called when all parents of the View are attached to the DOM.
 
 ```coffee
-{$, View} = require 'space-pen'
-{TextEditorView} = require 'atom-space-pen-views'
+# Old way
+{View} = require 'atom'
+class MyView extends View
+  afterAttach: (onDom) ->
+    #...
+
+  beforeRemove: ->
+    #...
 ```
 
-If you are using the lifecycle hooks, you will need to update code as well.
+```coffee
+# New way
+{View} = require 'atom-space-pen-views'
+class MyView extends View
+  attached: ->
+    # Always called with the equivalent of @afterAttach(true)!
+    #...
 
-### Upgrading to space-pen's TextEditorView
+  removed: ->
+    #...
+```
+
+### Upgrading to the new TextEditorView
 
 You should not need to change anything to use the new `TextEditorView`! See the [docs][TextEditorView] for more info.
 
-### Upgrading to space-pen's ScrollView
+### Upgrading to classes extending ScrollView
 
-See the [docs][ScrollView] for all the options.
+The `ScrollView` has very minor changes.
 
-### Upgrading to space-pen's SelectListView
+You can no longer use `@off` to remove default behavior for `core:move-up`, `core:move-down`, etc.
+
+```coffee
+# Old way to turn off default behavior
+class ResultsView extends ScrollView
+  initialize: (@model) ->
+    super
+    # turn off default scrolling behavior from ScrollView
+    @off 'core:move-up'
+    @off 'core:move-down'
+    @off 'core:move-left'
+    @off 'core:move-right'
+```
+
+```coffee
+# New way to turn off default behavior
+class ResultsView extends ScrollView
+  initialize: (@model) ->
+    disposable = super()
+    # turn off default scrolling behavior from ScrollView
+    disposable.dispose()
+```
+
+* Check out [an example](https://github.com/atom/find-and-replace/pull/311/files#diff-9) from find-and-replace.
+* See the [docs][ScrollView] for all the options.
+
+### Upgrading to classes extending SelectListView
 
 Your SelectListView might look something like this:
 
@@ -254,7 +301,8 @@ class CommandPaletteView extends SelectListView
     @panel?.hide()
 ```
 
-See the [SelectListView docs][SelectListView] for all the options. And check out the [conversion of CommandPaletteView][selectlistview-example] as a real-world example.
+* And check out the [conversion of CommandPaletteView][selectlistview-example] as a real-world example.
+* See the [SelectListView docs][SelectListView] for all options.
 
 ## Specs
 

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -4,9 +4,65 @@ Atom is rapidly approaching 1.0. Much of the effort leading up to the 1.0 has be
 
 This document will guide you through the large bits of upgrading your package to work with 1.0 APIs.
 
+## TL;DR
+
+We've set deprecation messages and errors in strategic places to help make sure you dont miss anything. You should be able to get 95% of the way to an updated package just by fixing errors and deprecations. There are a couple of things you need to do to enable all these errors and deprecations.
+
+### Use atom-space-pen-views
+
+Add the `atom-space-pen-views` module to your package's `package.json` file's dependencies:
+
+```js
+{
+  "dependencies": {
+    "atom-space-pen-views": "^0.21"
+  }
+}
+```
+
+Then run `apm install` in your package directory.
+
+### Require views from atom-space-pen-views
+
+Anywhere you are requiring one of the following from `atom` you need to require them from `atom-space-pen-views` instead.
+
+```js
+// require these from 'atom-space-pen-views' rather than 'atom'
+$
+$$
+$$$
+View
+TextEditorView
+ScrollView
+SelectListView
+```
+
+So this:
+
+```coffee
+# Old way
+{$, TextEditorView, View, GitRepository} = require 'atom'
+```
+
+Would be replaced with this:
+
+```coffee
+# New way
+{GitRepository} = require 'atom'
+{$, TextEditorView, View} = require 'atom-space-pen-views'
+```
+
+### Run specs and test your package
+
+You wrote specs, right!? Here's where they shine. Run them with `cmd-shift-P`, and search for `run package specs`. It will show all the deprecation messages and errors.
+
+### Examples
+
+We have upgraded all the core packages. Please see [this issue](https://github.com/atom/atom/issues/4011) for a link to all the upgrade PRs.
+
 ## Deprecations
 
-All of the methods that have changes emit deprecation messages when called. These messages are shown in two places: your package specs, and in Deprecation Cop.
+All of the methods in core that have changes will emit deprecation messages when called. These messages are shown in two places: your **package specs**, and in **Deprecation Cop**.
 
 ### Specs
 

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -70,17 +70,20 @@ Just run your specs, and all the deprecations will be displayed in yellow.
 
 TODO: image of deprecations in specs
 
+TODO: Comand line spec deprecation image?
+
 ### Deprecation Cop
 
 Run an atom window in dev mode (`atom -d`) with your package loaded, and open Deprecation Cop (search for `deprecation` in the command palette).
 
 TODO: image of deprecations in DepCop
 
-## Views
+## View Changes
 
 Previous to 1.0, views in packages were baked into Atom core. These views were based on jQuery and `space-pen`. They looked something like this:
 
 ```coffee
+# The old way: getting views from atom
 {$, TextEditorView, View} = require 'atom'
 
 module.exports =
@@ -92,7 +95,7 @@ class SomeView extends View
   #...
 ```
 
-Requiring `atom` used to provide the following view helpers:
+Requiring `atom` _used to_ provide the following view helpers:
 
 ```
 $
@@ -102,13 +105,11 @@ View
 TextEditorView
 ScrollView
 SelectListView
-Workspace
-WorkspaceView
 ```
 
 ### The New
 
-Atom no longer provides these view helpers baked in. They are now available from two npm packages: `space-pen`, and `atom-space-pen-views`
+Atom no longer provides these view helpers baked in. Atom core is now 'view agnostic'. The preexisting view system is available from two npm packages: `space-pen`, and `atom-space-pen-views`
 
 `space-pen` now provides
 
@@ -119,30 +120,34 @@ $$$
 View
 ```
 
-`atom-space-pen-views` now provides
+`atom-space-pen-views` now provides all of `space-pen`, plus Atom specific views:
 
-```
+```js
+// Passed through from space-pen
+$
+$$
+$$$
+View
+
+// Atom specific views
 TextEditorView
 ScrollView
 SelectListView
 ```
 
-`Workspace` and `WorkspaceView` are _no longer provided_ in any capacity. They should be unnecessary
-
 ### Adding the module dependencies
 
-To use the new views, you need to specify a couple modules in your package dependencies in your `package.json` file:
+To use the new views, you need to specify the `atom-space-pen-views` module in your package's `package.json` file's dependencies:
 
 ```js
 {
   "dependencies": {
-    "space-pen": "^3"
-    "atom-space-pen-views": "^0"
+    "atom-space-pen-views": "^0.21"
   }
 }
 ```
 
-`space-pen` bundles jQuery. If you do not need `space-pen`, you can require jQuery directly.
+`space-pen` bundles jQuery. If you do not need `space-pen` or any of the views, you can require jQuery directly.
 
 ```js
 {

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -442,7 +442,7 @@ class Something
     @disposables.dispose()
 ```
 
-### Removing View::subscribe calls
+### Removing View::subscribe and Subscriber::subscribe calls
 
 There were a couple permutations of `subscribe()`. In these examples, a `CompositeDisposable` is used as it will commonly be useful where conversion is necessary.
 
@@ -527,9 +527,32 @@ class Something
 
 ## Subscribing To Commands
 
+`$.fn.command` and `View::subscribeToCommand` are no longer available. Now we use `atom.commands.add`, and collect the results in a `CompositeDisposable`. See [the docs][commands-add] for more info.
+
+```coffee
+# Old!
+atom.workspaceView.command 'core:close core:cancel', ->
+
+# When inside a View class, you might see this
+@subscribeToCommand 'core:close core:cancel', ->
+```
+
+```coffee
+# New!
+@disposables.add atom.commands.add 'atom-workspace',
+  'core:close': ->
+  'core:cancel': ->
+
+# When in a View class, you should have a `@element` object available. `@element` is a raw HTML element
+@disposables.add atom.commands.add @element,
+  'core:close': ->
+  'core:cancel': ->
+```
+
 [texteditorview]:https://github.com/atom/atom-space-pen-views#texteditorview
 [scrollview]:https://github.com/atom/atom-space-pen-views#scrollview
 [selectlistview]:https://github.com/atom/atom-space-pen-views#selectlistview
 [selectlistview-example]:https://github.com/atom/command-palette/pull/19/files
 [emitter]:https://atom.io/docs/api/latest/Emitter
 [disposable]:https://atom.io/docs/api/latest/Disposable
+[commands-add]:https://atom.io/docs/api/latest/CommandRegistry#instance-add

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -549,6 +549,10 @@ atom.workspaceView.command 'core:close core:cancel', ->
   'core:cancel': ->
 ```
 
+## Upgrading your stylesheet's selectors
+
+See [Upgrading Your Package Selectors guide][upgrading-selectors] for more information.
+
 [texteditorview]:https://github.com/atom/atom-space-pen-views#texteditorview
 [scrollview]:https://github.com/atom/atom-space-pen-views#scrollview
 [selectlistview]:https://github.com/atom/atom-space-pen-views#selectlistview
@@ -556,3 +560,4 @@ atom.workspaceView.command 'core:close core:cancel', ->
 [emitter]:https://atom.io/docs/api/latest/Emitter
 [disposable]:https://atom.io/docs/api/latest/Disposable
 [commands-add]:https://atom.io/docs/api/latest/CommandRegistry#instance-add
+[upgrading-selectors]:upgrading-your-ui-theme

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -10,7 +10,7 @@ We've set deprecation messages and errors in strategic places to help make sure 
 
 ### Use atom-space-pen-views
 
-Add the `atom-space-pen-views` module to your package's `package.json` file's dependencies:
+If you use any class from `require 'atom'` with a `$` or `View` in the name, add the `atom-space-pen-views` module to your package's `package.json` file's dependencies:
 
 ```js
 {
@@ -62,7 +62,7 @@ We have upgraded all the core packages. Please see [this issue](https://github.c
 
 ## Deprecations
 
-All of the methods in core that have changes will emit deprecation messages when called. These messages are shown in two places: your **package specs**, and in **Deprecation Cop**.
+All of the methods in Atom core that have changes will emit deprecation messages when called. These messages are shown in two places: your **package specs**, and in **Deprecation Cop**.
 
 ### Specs
 
@@ -78,9 +78,9 @@ Run an atom window in dev mode (`atom -d`) with your package loaded, and open De
 
 TODO: image of deprecations in DepCop
 
-## View Changes
+## Upgrading your Views
 
-Previous to 1.0, views in packages were baked into Atom core. These views were based on jQuery and `space-pen`. They looked something like this:
+Previous to 1.0, views were baked into Atom core. These views were based on jQuery and `space-pen`. They looked something like this:
 
 ```coffee
 # The old way: getting views from atom
@@ -228,6 +228,7 @@ class ResultsView extends ScrollView
 Your SelectListView might look something like this:
 
 ```coffee
+# Old!
 class CommandPaletteView extends SelectListView
   initialize: ->
     super
@@ -262,6 +263,7 @@ This attaches and detaches itself from the dom when toggled, canceling magically
 Using the new APIs it should look like this:
 
 ```coffee
+# New!
 class CommandPaletteView extends SelectListView
   initialize: ->
     super

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -242,7 +242,7 @@ class CommandPaletteView extends SelectListView
 
 This attaches and detaches itself from the dom when toggled, canceling magically detaches it from the DOM, and it uses the classes `overlay` and `from-top`.
 
-Using the new APIs it should look like this:
+The new SelectListView no longer automatically detaches itself from the DOM when cancelled. It's up to you to implement whatever cancel beahavior you want. Using the new APIs to mimic the sematics of the old class, it should look like this:
 
 ```coffee
 # New!

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -413,6 +413,7 @@ You can group multiple disposables into a single disposable with a `CompositeDis
 
 class Something
   constructor: ->
+    editor = atom.workspace.getActiveTextEditor()
     @disposables.add editor.onDidChange ->
     @disposables.add editor.onDidChangePath ->
 

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -72,9 +72,11 @@ Just run your specs, and all the deprecations will be displayed in yellow.
 
 ### Deprecation Cop
 
-Run an atom window in dev mode (`atom -d`) with your package loaded, and open Deprecation Cop (search for `deprecation` in the command palette).
+Run an atom window in dev mode (`atom -d`) with your package loaded, and open Deprecation Cop (search for `deprecation` in the command palette). Deprecated methods will be appear in Deprecation Cop only after they have been called.
 
 ![dep-cop](https://cloud.githubusercontent.com/assets/69169/5637914/6e702fa2-95b5-11e4-92cc-a236ddacee21.png)
+
+When deprecation cop is open, and deprecated methods are called, a `Refresh` button will appear in the top right of the Deprecation Cop interface. So exercise your package, then come back to Deprecation Cop and click the `Refresh` button.
 
 ## Upgrading your Views
 

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -99,17 +99,15 @@ class SomeView extends View
 
 `require 'atom'` no longer provides view helpers or jQuery. Atom core is now 'view agnostic'. The preexisting view system is available from a new npm package: `atom-space-pen-views`.
 
-`atom-space-pen-views` now provides jQuery, `space-pen` views, plus Atom specific views:
+`atom-space-pen-views` now provides jQuery, `space-pen` views, and Atom specific views:
 
 
-```js
-// Passed through from space-pen
+```coffee
+# These are now provided by atom-space-pen-views
 $
 $$
 $$$
 View
-
-// Atom specific views
 TextEditorView
 ScrollView
 SelectListView
@@ -144,7 +142,7 @@ Sometimes it is as simple as converting the requires at the top of each view pag
 ### Upgrading classes extending any space-pen View
 
 The `afterAttach` and `beforeRemove` hooks have been replaced with
-`attached` and `detached` and their semantics have been altered. `attached` will only be called when all parents of the View are attached to the DOM.
+`attached` and `detached`. The `attached` method semantics have changed: it will only be called when all parents of the View are attached to the DOM. The `detached` semantics have not changed.
 
 ```coffee
 # Old way
@@ -165,7 +163,7 @@ class MyView extends View
     # Always called with the equivalent of @afterAttach(true)!
     #...
 
-  removed: ->
+  detached: ->
     #...
 ```
 

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -6,7 +6,7 @@ This document will guide you through the large bits of upgrading your package to
 
 ## TL;DR
 
-We've set deprecation messages and errors in strategic places to help make sure you dont miss anything. You should be able to get 95% of the way to an updated package just by fixing errors and deprecations. There are a couple of things you need to do to enable all these errors and deprecations.
+We've set deprecation messages and errors in strategic places to help make sure you don't miss anything. You should be able to get 95% of the way to an updated package just by fixing errors and deprecations. There are a couple of things you need to do to enable all these errors and deprecations.
 
 ### Use atom-space-pen-views
 

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -68,15 +68,15 @@ All of the methods in Atom core that have changes will emit deprecation messages
 
 Just run your specs, and all the deprecations will be displayed in yellow.
 
-TODO: image of deprecations in specs
+![spec-deps](https://cloud.githubusercontent.com/assets/69169/5637943/b85114ba-95b5-11e4-8681-b81ea8f556d7.png)
 
-TODO: Comand line spec deprecation image?
+
 
 ### Deprecation Cop
 
 Run an atom window in dev mode (`atom -d`) with your package loaded, and open Deprecation Cop (search for `deprecation` in the command palette).
 
-TODO: image of deprecations in DepCop
+![dep-cop](https://cloud.githubusercontent.com/assets/69169/5637914/6e702fa2-95b5-11e4-92cc-a236ddacee21.png)
 
 ## Upgrading your Views
 

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -173,7 +173,7 @@ class MyView extends View
 
 ### Upgrading to the new TextEditorView
 
-You should not need to change anything to use the new `TextEditorView`! See the [docs][TextEditorView] for more info.
+All of the atom-specific methods available on the `TextEditorView` have been moved to the `TextEditor`, available via `TextEditorView::getModel`. See the [`TextEditorView` docs][TextEditorView] and [`TextEditor` docs][TextEditor] for more info.
 
 ### Upgrading classes extending ScrollView
 
@@ -543,6 +543,7 @@ See [Upgrading Your Package Selectors guide][upgrading-selectors] for more infor
 [selectlistview]:https://github.com/atom/atom-space-pen-views#selectlistview
 [selectlistview-example]:https://github.com/atom/command-palette/pull/19/files
 [emitter]:https://atom.io/docs/api/latest/Emitter
+[texteditor]:https://atom.io/docs/api/latest/TextEditor
 [disposable]:https://atom.io/docs/api/latest/Disposable
 [commands-add]:https://atom.io/docs/api/latest/CommandRegistry#instance-add
 [upgrading-selectors]:upgrading-your-ui-theme

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -95,32 +95,12 @@ class SomeView extends View
   #...
 ```
 
-Requiring `atom` _used to_ provide the following view helpers:
-
-```
-$
-$$
-$$$
-View
-TextEditorView
-ScrollView
-SelectListView
-```
-
 ### The New
 
-Atom no longer provides these view helpers baked in. Atom core is now 'view agnostic'. The preexisting view system is available from two npm packages: `space-pen`, and `atom-space-pen-views`
+`require 'atom'` no longer provides view helpers or jQuery. Atom core is now 'view agnostic'. The preexisting view system is available from a new npm package: `atom-space-pen-views`.
 
-`space-pen` now provides
+`atom-space-pen-views` now provides jQuery, `space-pen` views, plus Atom specific views:
 
-```
-$
-$$
-$$$
-View
-```
-
-`atom-space-pen-views` now provides all of `space-pen`, plus Atom specific views:
 
 ```js
 // Passed through from space-pen

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -142,7 +142,11 @@ Sometimes it is as simple as converting the requires at the top of each view pag
 ### Upgrading classes extending any space-pen View
 
 The `afterAttach` and `beforeRemove` hooks have been replaced with
-`attached` and `detached`. The `attached` method semantics have changed: it will only be called when all parents of the View are attached to the DOM. The `detached` semantics have not changed.
+`attached` and `detached` and the semantics have changed.
+
+`afterAttach` was called whenever the node was attached to another DOM node, even if that node itself wasn't present in the document. `afterAttach` also was called with a boolean indicating whether or not the element and its parents were on the DOM. Now the `attached` hook is only called when the node and all of its parents are actually on the DOM, and is not called with a boolean.
+
+`beforeRemove` was only called when `$.fn.remove` was called, which was typically used when the node was completely removed from the DOM. The `detached` hook is called whenever the DOM node is _detached_, which could happen if the node is being detached for reattachment later. In short, if `beforeRemove` is called the node is never coming back. With `detached` it might be attached again later.
 
 ```coffee
 # Old way

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -288,9 +288,49 @@ class CommandPaletteView extends SelectListView
 * And check out the [conversion of CommandPaletteView][selectlistview-example] as a real-world example.
 * See the [SelectListView docs][SelectListView] for all options.
 
+## Using the model layer rather than the view layer
+
+The API no longer exposes any view objects or view classes. `atom.workspaceView`, and all the view classes: `WorkspaceView`, `EditorView`, `PaneView`, etc. have been globally deprecated.
+
+Nearly all of the atom-specific actions performed by the old view objects can now be managed via the model layer. For example, here's adding a panel to the interface using the `atom.workspace` model instead of the `workspaceView`:
+
+```coffee
+# Old!
+div = document.createElement('div')
+atom.workspaceView.appendToTop(div)
+```
+
+```coffee
+# New!
+div = document.createElement('div')
+atom.workspace.addTopPanel(item: div)
+```
+
+For actions that still require the view, such as dispatching commands or munging css classes, you'll access the view via the `atom.views.getView()` method. This will return a subclass of `HTMLElement` rather than a jQuery object or an instance of a deprecated view class (e.g. `WorkspaceView`).
+
+```coffee
+# Old!
+workspaceView = atom.workspaceView
+editorView = workspaceView.getActiveEditorView()
+paneView = editorView.getPaneView()
+```
+
+```coffee
+# New!
+# Generally, just use the models
+workspace = atom.workspace
+editor = workspace.getActiveTextEditor()
+pane = editor.getPane()
+
+# If you need views, get them with `getView`
+workspaceElement = atom.views.getView(atom.workspace)
+editorElement = atom.views.getView(editor)
+paneElement = atom.views.getView(pane)
+```
+
 ## Updating Specs
 
-`WorkspaceView` and `EditorView` have been deprecated. These two objects are used heavily throughout specs, mostly to dispatch events and commands. This section will explain how to remove them while still retaining the ability to dispatch events and commands.
+`atom.workspaceView`, the `WorkspaceView` class and the `EditorView` class have been deprecated. These two objects are used heavily throughout specs, mostly to dispatch events and commands. This section will explain how to remove them while still retaining the ability to dispatch events and commands.
 
 ### Removing WorkspaceView references
 

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -224,7 +224,7 @@ class CommandPaletteView extends SelectListView
   attach: ->
     @storeFocusedElement()
 
-    items = # build items
+    items = [] # TODO: build items
     @setItems(items)
 
     atom.workspaceView.append(this)

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -169,7 +169,7 @@ class MyView extends View
 
 You should not need to change anything to use the new `TextEditorView`! See the [docs][TextEditorView] for more info.
 
-### Upgrading to classes extending ScrollView
+### Upgrading classes extending ScrollView
 
 The `ScrollView` has very minor changes.
 
@@ -199,7 +199,7 @@ class ResultsView extends ScrollView
 * Check out [an example](https://github.com/atom/find-and-replace/pull/311/files#diff-9) from find-and-replace.
 * See the [docs][ScrollView] for all the options.
 
-### Upgrading to classes extending SelectListView
+### Upgrading classes extending SelectListView
 
 Your SelectListView might look something like this:
 

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -26,8 +26,8 @@ Then run `apm install` in your package directory.
 
 Anywhere you are requiring one of the following from `atom` you need to require them from `atom-space-pen-views` instead.
 
-```js
-// require these from 'atom-space-pen-views' rather than 'atom'
+```coffee
+# require these from 'atom-space-pen-views' rather than 'atom'
 $
 $$
 $$$

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -15,7 +15,7 @@ If you use any class from `require 'atom'` with a `$` or `View` in the name, add
 ```js
 {
   "dependencies": {
-    "atom-space-pen-views": "^0.21"
+    "atom-space-pen-views": "^2.0.2"
   }
 }
 ```
@@ -122,7 +122,7 @@ To use the new views, you need to specify the `atom-space-pen-views` module in y
 ```js
 {
   "dependencies": {
-    "atom-space-pen-views": "^0.21"
+    "atom-space-pen-views": "^2.0.2"
   }
 }
 ```

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -44,7 +44,7 @@ So this:
 {$, TextEditorView, View, GitRepository} = require 'atom'
 ```
 
-Would be replaced with this:
+Would be replaced by this:
 
 ```coffee
 # New way

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -70,8 +70,6 @@ Just run your specs, and all the deprecations will be displayed in yellow.
 
 ![spec-deps](https://cloud.githubusercontent.com/assets/69169/5637943/b85114ba-95b5-11e4-8681-b81ea8f556d7.png)
 
-
-
 ### Deprecation Cop
 
 Run an atom window in dev mode (`atom -d`) with your package loaded, and open Deprecation Cop (search for `deprecation` in the command palette).

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -378,9 +378,9 @@ jasmine.attachToDOM(workspaceElement)
 
 ### Removing EditorView references
 
-Like `WorkspaceView`, `EditorView` has been deprecated. Everything you needed to do on the view you are now able to do on the `Editor` model.
+Like `WorkspaceView`, `EditorView` has been deprecated. Everything you needed to do on the view you are now able to do on the `TextEditor` model.
 
-In many cases, you will not even need to get the editor's view anymore. Any of those instances should be updated to use the `Editor` instance. You should really only need the editor's view when you plan on triggering a command on the view in a spec.
+In many cases, you will not even need to get the editor's view anymore. Any of those instances should be updated to use the `TextEditor` instance instead. You should really only need the editor's view when you plan on triggering a command on the view in a spec.
 
 Your specs might contain something like this:
 
@@ -392,7 +392,7 @@ describe 'Something', ->
     editorView = atom.workspaceView.getActiveView()
 ```
 
-We're going to use `atom.views.getView()` again to get the editor element. As in the case of the `workspaceElement`, `getView` will return a plain `HTMLElement` rather than an `EditorView` or jQuery object.
+We're going to use `atom.views.getView()` again to get the editor element. As in the case of the `workspaceElement`, `getView` will return a subclass of `HTMLElement` rather than an `EditorView` or jQuery object.
 
 ```coffee
 # New!

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -179,7 +179,7 @@ You can no longer use `@off` to remove default behavior for `core:move-up`, `cor
 # Old way to turn off default behavior
 class ResultsView extends ScrollView
   initialize: (@model) ->
-    super
+    super()
     # turn off default scrolling behavior from ScrollView
     @off 'core:move-up'
     @off 'core:move-down'
@@ -207,7 +207,7 @@ Your SelectListView might look something like this:
 # Old!
 class CommandPaletteView extends SelectListView
   initialize: ->
-    super
+    super()
     @addClass('command-palette overlay from-top')
     atom.workspaceView.command 'command-palette:toggle', => @toggle()
 
@@ -242,10 +242,10 @@ Using the new APIs it should look like this:
 # New!
 class CommandPaletteView extends SelectListView
   initialize: ->
-    super
+    super()
     # no more need for the `overlay` and `from-top` classes
     @addClass('command-palette')
-    atom.workspaceView.command 'command-palette:toggle', => @toggle()
+    atom.commands.add 'atom-workspace', 'command-palette:toggle', => @toggle()
 
   # You need to implement the `cancelled` method and hide.
   cancelled: ->
@@ -270,7 +270,7 @@ class CommandPaletteView extends SelectListView
 
     @storeFocusedElement()
 
-    items = # build items
+    items = [] # TODO: build items
     @setItems(items)
 
     @focusFilterEditor()
@@ -351,10 +351,10 @@ We're going to use `atom.views.getView()` again to get the editor element. As in
 ```coffee
 # New!
 describe 'Something', ->
-  [editor, editorElement] = []
+  [editor, editorView] = []
   beforeEach ->
     editor = atom.workspace.getActiveTextEditor()
-    editorElement = atom.views.getView(editor)
+    editorView = atom.views.getView(editor)
 ```
 
 ### Dispatching commands
@@ -374,7 +374,7 @@ To this:
 ```coffee
 # New!
 atom.commands.dispatch workspaceElement, 'a-package:toggle'
-atom.commands.dispatch editorElement, 'find-and-replace:show'
+atom.commands.dispatch editorView, 'find-and-replace:show'
 ```
 
 ## Eventing and Disposables

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -15,7 +15,7 @@ If you use any class from `require 'atom'` with a `$` or `View` in the name, add
 ```js
 {
   "dependencies": {
-    "atom-space-pen-views": "^2.0.2"
+    "atom-space-pen-views": "^2.0.3"
   }
 }
 ```
@@ -120,7 +120,7 @@ To use the new views, you need to specify the `atom-space-pen-views` module in y
 ```js
 {
   "dependencies": {
-    "atom-space-pen-views": "^2.0.2"
+    "atom-space-pen-views": "^2.0.3"
   }
 }
 ```

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -56,6 +56,18 @@ Would be replaced by this:
 
 You wrote specs, right!? Here's where they shine. Run them with `cmd-shift-P`, and search for `run package specs`. It will show all the deprecation messages and errors.
 
+### Update the engines field in package.json
+
+When you are deprecation free and all done converting, upgrade the `engines` field in your package.json:
+
+```json
+{
+  "engines": {
+    "atom": ">=0.x.0, <2.0.0"
+  }
+}
+```
+
 ### Examples
 
 We have upgraded all the core packages. Please see [this issue](https://github.com/atom/atom/issues/4011) for a link to all the upgrade PRs.

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -593,6 +593,13 @@ atom.workspaceView.command 'core:close core:cancel', ->
 
 Many selectors have changed, and we have introduced the [Shadow DOM][shadowdom] to the editor. See [Upgrading Your Package Selectors guide][upgrading-selectors] for more information in upgrading your package stylesheets.
 
+## Help us improve this guide!
+
+Did you hit something painful that wasn't in here? Want to reword some bit of it? Find something incorrect? Please edit [this file][guide], and send a pull request. Contributions are greatly appreciated.
+
+
+
+
 [texteditorview]:https://github.com/atom/atom-space-pen-views#texteditorview
 [scrollview]:https://github.com/atom/atom-space-pen-views#scrollview
 [selectlistview]:https://github.com/atom/atom-space-pen-views#selectlistview
@@ -603,3 +610,4 @@ Many selectors have changed, and we have introduced the [Shadow DOM][shadowdom] 
 [commands-add]:https://atom.io/docs/api/latest/CommandRegistry#instance-add
 [upgrading-selectors]:upgrading-your-ui-theme
 [shadowdom]:http://blog.atom.io/2014/11/18/avoiding-style-pollution-with-the-shadow-dom.html
+[guide]:https://github.com/atom/atom/blob/master/docs/upgrading/upgrading-your-package.md

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -146,9 +146,9 @@ Sometimes it is as simple as converting the requires at the top of each view pag
 The `afterAttach` and `beforeRemove` hooks have been replaced with
 `attached` and `detached` and the semantics have changed.
 
-`afterAttach` was called whenever the node was attached to another DOM node, even if that node itself wasn't present in the document. `afterAttach` also was called with a boolean indicating whether or not the element and its parents were on the DOM. Now the `attached` hook is only called when the node and all of its parents are actually on the DOM, and is not called with a boolean.
+`afterAttach` was called whenever the node was attached to another DOM node, even if that parent node wasn't present in the DOM. `afterAttach` also was called with a boolean indicating whether or not the element and its parents were on the DOM. Now the `attached` hook is _only_ called when the node and all of its parents are actually on the DOM, and is not called with a boolean.
 
-`beforeRemove` was only called when `$.fn.remove` was called, which was typically used when the node was completely removed from the DOM. The `detached` hook is called whenever the DOM node is _detached_, which could happen if the node is being detached for reattachment later. In short, if `beforeRemove` is called the node is never coming back. With `detached` it might be attached again later.
+`beforeRemove` was only called when `$.fn.remove` was called, which was typically used when the node was completely removed from the DOM. The new `detached` hook is called whenever the DOM node is _detached_, which could happen if the node is being detached for reattachment later. In short, if `beforeRemove` is called the node is never coming back. With `detached` it might be attached again later.
 
 ```coffee
 # Old way
@@ -175,7 +175,7 @@ class MyView extends View
 
 #### `subscribe` and `subscribeToCommand` methods removed
 
-Additionally, the `subscribe` and `subscribeToCommand` methods have been removed. See the Eventing and Disposables section for more info.
+The `subscribe` and `subscribeToCommand` methods have been removed. See the Eventing and Disposables section for more info.
 
 ### Upgrading to the new TextEditorView
 
@@ -296,7 +296,7 @@ class CommandPaletteView extends SelectListView
 
 ## Using the model layer rather than the view layer
 
-The API no longer exposes any view objects or view classes. `atom.workspaceView`, and all the view classes: `WorkspaceView`, `EditorView`, `PaneView`, etc. have been globally deprecated.
+The API no longer exposes any specialized view objects or view classes. `atom.workspaceView`, and all the view classes: `WorkspaceView`, `EditorView`, `PaneView`, etc. have been globally deprecated.
 
 Nearly all of the atom-specific actions performed by the old view objects can now be managed via the model layer. For example, here's adding a panel to the interface using the `atom.workspace` model instead of the `workspaceView`:
 
@@ -466,6 +466,7 @@ You can group multiple disposables into a single disposable with a `CompositeDis
 class Something
   constructor: ->
     editor = atom.workspace.getActiveTextEditor()
+    @disposables = new CompositeDisposable
     @disposables.add editor.onDidChange ->
     @disposables.add editor.onDidChangePath ->
 
@@ -536,7 +537,7 @@ disposables.add new Disposable ->
 
 ### Providing Events: Using the Emitter
 
-You no longer need to require emissary to get an emitter. We now provide an `Emitter` class from `require 'atom'`. We have a specific pattern for use of the `Emitter`. Rather than mixing it in, we instantiate a member variable, and create explicit subscription methods. For more information see the [`Emitter` docs][emitter].
+You no longer need to require `emissary` to get an emitter. We now provide an `Emitter` class from `require 'atom'`. We have a specific pattern for use of the `Emitter`. Rather than mixing it in, we instantiate a member variable, and create explicit subscription methods. For more information see the [`Emitter` docs][emitter].
 
 ```coffee
 # New!
@@ -555,6 +556,7 @@ class Something
   methodThatFiresAChange: ->
     @emitter.emit 'did-change', {data: 2}
 
+# Using the evented class
 something = new Something
 something.onDidChange (eventObject) ->
   console.log eventObject.data # => 2
@@ -589,7 +591,7 @@ atom.workspaceView.command 'core:close core:cancel', ->
 
 ## Upgrading your stylesheet's selectors
 
-See [Upgrading Your Package Selectors guide][upgrading-selectors] for more information.
+Many selectors have changed, and we have introduced the [Shadow DOM][shadowdom] to the editor. See [Upgrading Your Package Selectors guide][upgrading-selectors] for more information in upgrading your package stylesheets.
 
 [texteditorview]:https://github.com/atom/atom-space-pen-views#texteditorview
 [scrollview]:https://github.com/atom/atom-space-pen-views#scrollview
@@ -600,3 +602,4 @@ See [Upgrading Your Package Selectors guide][upgrading-selectors] for more infor
 [disposable]:https://atom.io/docs/api/latest/Disposable
 [commands-add]:https://atom.io/docs/api/latest/CommandRegistry#instance-add
 [upgrading-selectors]:upgrading-your-ui-theme
+[shadowdom]:http://blog.atom.io/2014/11/18/avoiding-style-pollution-with-the-shadow-dom.html

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -6,7 +6,7 @@ This document will guide you through the large bits of upgrading your package to
 
 ## TL;DR
 
-We've set deprecation messages and errors in strategic places to help make sure you don't miss anything. You should be able to get 95% of the way to an updated package just by fixing errors and deprecations. There are a couple of things you need to do to enable all these errors and deprecations.
+We've set deprecation messages and errors in strategic places to help make sure you don't miss anything. You should be able to get 95% of the way to an updated package just by fixing errors and deprecations. There are a couple of things you can do to get the full effect of all the errors and deprecations.
 
 ### Use atom-space-pen-views
 


### PR DESCRIPTION
This is an initial draft of docs for converting your packages. Initially i'm thinking we want to have 3 docs
### To Write
- [x] TL;DR
- [x] Viewing Deprecations
- [x] Updating Views
- [x] Updating Specs
- [x] Eventing changes + Disposables
- [x] Updating commands
- [x] A little bit about the stylesheets, linking back to the theme guides

My vision for them is written around specific patterns with short explanations and links to examples. Like "I have a SelectListView view, how do I do this with the new APIs?". And we can link to our [PRs for conversion](https://github.com/atom/command-palette/pull/19/files). Deprecations will get all the nits, but there are definite patterns we will find. 

The themes are handled in https://github.com/atom/atom/pull/4214
