### PR TITLE
Add auto-indent when pasting

### DIFF
--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -96,12 +96,13 @@ describe "LanguageMode", ->
         buffer.setText("//this is a single line comment")
         expect(languageMode.rowRangeForCommentAtBufferRow(0)).toBeUndefined()
 
-    describe "suggestedIndentForBufferRow", ->
-      it "returns the suggested indentation based on auto-indent/outdent rules", ->
+    describe ".suggestedIndentForBufferRow", ->
+      it "bases indentation off of the previous non-blank line", ->
         expect(languageMode.suggestedIndentForBufferRow(0)).toBe 0
         expect(languageMode.suggestedIndentForBufferRow(1)).toBe 1
         expect(languageMode.suggestedIndentForBufferRow(2)).toBe 2
         expect(languageMode.suggestedIndentForBufferRow(9)).toBe 1
+        expect(languageMode.suggestedIndentForBufferRow(11)).toBe 1
 
     describe "rowRangeForParagraphAtBufferRow", ->
       describe "with code and comments", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3340,6 +3340,13 @@ describe "TextEditor", ->
             editor.insertText('foo')
             expect(editor.indentationForBufferRow(2)).toBe editor.indentationForBufferRow(1) + 1
 
+        describe "when pasting", ->
+          it "auto-indents the pasted text", ->
+            atom.clipboard.write("console.log(x);\n")
+            editor.setCursorBufferPosition([5, 2])
+            editor.pasteText()
+            expect(editor.lineTextForBufferRow(5)).toBe("      console.log(x);")
+
       describe 'when scoped settings are used', ->
         coffeeEditor = null
         beforeEach ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3341,11 +3341,26 @@ describe "TextEditor", ->
             expect(editor.indentationForBufferRow(2)).toBe editor.indentationForBufferRow(1) + 1
 
         describe "when pasting", ->
-          it "auto-indents the pasted text", ->
-            atom.clipboard.write("console.log(x);\n")
-            editor.setCursorBufferPosition([5, 2])
-            editor.pasteText()
-            expect(editor.lineTextForBufferRow(5)).toBe("      console.log(x);")
+          describe "when only whitespace precedes the cursor", ->
+            it "auto-indents the lines spanned by the pasted text", ->
+              atom.clipboard.write("console.log(x);\nconsole.log(y);\n")
+              editor.setCursorBufferPosition([5, 2])
+              editor.pasteText()
+              expect(editor.lineTextForBufferRow(5)).toBe("      console.log(x);")
+              expect(editor.lineTextForBufferRow(6)).toBe("      console.log(y);")
+
+          describe "when non-whitespace characters precede the cursor", ->
+            it "does not auto-indent the first line being pasted", ->
+              editor.setText """
+                if (x) {
+                    y();
+                }
+              """
+
+              atom.clipboard.write(" z();")
+              editor.setCursorBufferPosition([1, Infinity])
+              editor.pasteText()
+              expect(editor.lineTextForBufferRow(1)).toBe("    y(); z();")
 
       describe 'when scoped settings are used', ->
         coffeeEditor = null

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3379,7 +3379,6 @@ describe "TextEditor", ->
             editor.insertText('foo')
             expect(editor.indentationForBufferRow(2)).toBe editor.indentationForBufferRow(1) + 1
 
-
       describe 'when scoped settings are used', ->
         coffeeEditor = null
         beforeEach ->

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -115,6 +115,7 @@ module.exports =
       autoIndent:
         type: 'boolean'
         default: true
+        description: 'Auto-ident when inserting newlines'
       autoIndentOnPaste:
         type: 'boolean'
         default: true

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -115,7 +115,7 @@ module.exports =
       autoIndent:
         type: 'boolean'
         default: true
-        description: 'Auto-ident when inserting newlines'
+        description: 'Automatically indent the cursor when inserting a newline'
       autoIndentOnPaste:
         type: 'boolean'
         default: true

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -115,6 +115,9 @@ module.exports =
       autoIndent:
         type: 'boolean'
         default: true
+      autoIndentOnPaste:
+        type: 'boolean'
+        default: true
       normalizeIndentOnPaste:
         type: 'boolean'
         default: true

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -250,8 +250,8 @@ class LanguageMode
     return currentIndentLevel unless increaseIndentRegex = @increaseIndentRegexForScopeDescriptor(scopeDescriptor)
 
     currentLine = @buffer.lineForRow(bufferRow)
-    precedingRow = if bufferRow > 0 then bufferRow - 1 else null
-    return currentIndentLevel unless precedingRow?
+    precedingRow = @buffer.previousNonBlankRow(bufferRow)
+    return 0 unless precedingRow?
 
     precedingLine = @buffer.lineForRow(precedingRow)
     desiredIndentLevel = @editor.indentationForBufferRow(precedingRow)

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -4,6 +4,8 @@
 {Emitter} = require 'event-kit'
 Grim = require 'grim'
 
+NonWhitespaceRegExp = /\S/
+
 # Extended: Represents a selection in the {TextEditor}.
 module.exports =
 class Selection extends Model
@@ -368,13 +370,16 @@ class Selection extends Model
       @cursor.setBufferPosition(newBufferRange.end, skipAtomicTokens: true) if wasReversed
 
     if options.autoIndent
-      @editor.autoIndentBufferRow(row) for row in newBufferRange.getRows()
+      precedingText = @editor.getTextInBufferRange([[newBufferRange.start.row, 0], newBufferRange.start])
+      unless NonWhitespaceRegExp.test(precedingText)
+        @editor.autoIndentBufferRow(newBufferRange.getRows()[0])
+      @editor.autoIndentBufferRow(row) for row, i in newBufferRange.getRows() when i > 0
     else if options.autoIndentNewline and text == '\n'
       currentIndentation = @editor.indentationForBufferRow(newBufferRange.start.row)
       @editor.autoIndentBufferRow(newBufferRange.end.row, preserveLeadingWhitespace: true)
       if @editor.indentationForBufferRow(newBufferRange.end.row) < currentIndentation
         @editor.setIndentationForBufferRow(newBufferRange.end.row, currentIndentation)
-    else if options.autoDecreaseIndent and /\S/.test text
+    else if options.autoDecreaseIndent and NonWhitespaceRegExp.test(text)
       @editor.autoDecreaseIndentForBufferRow(newBufferRange.start.row)
 
     newBufferRange

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2507,6 +2507,7 @@ class TextEditor extends Model
       if containsNewlines or !@getLastCursor().hasPrecedingCharactersOnLine()
         options.indentBasis ?= metadata.indentBasis
 
+    options.autoIndent = @shouldAutoIndent()
     @insertText(text, options)
 
   # Public: For each selection, if the selection is empty, cut all characters

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2507,7 +2507,7 @@ class TextEditor extends Model
       if containsNewlines or !@getLastCursor().hasPrecedingCharactersOnLine()
         options.indentBasis ?= metadata.indentBasis
 
-    options.autoIndent = @shouldAutoIndent()
+    options.autoIndent = @shouldAutoIndentOnPaste()
     @insertText(text, options)
 
   # Public: For each selection, if the selection is empty, cut all characters
@@ -2723,6 +2723,9 @@ class TextEditor extends Model
 
   shouldAutoIndent: ->
     atom.config.get(@getRootScopeDescriptor(), "editor.autoIndent")
+
+  shouldAutoIndentOnPaste: ->
+    atom.config.get(@getRootScopeDescriptor(), "editor.autoIndentOnPaste")
 
   shouldShowInvisibles: ->
     not @mini and atom.config.get(@getRootScopeDescriptor(), 'editor.showInvisibles')


### PR DESCRIPTION
Currently, auto-indent is not used when pasting. This makes sense for coffeescript and other indentation-sensitive languages, because in those languages, auto-indent would often make the indentation worse. This adds a separate config option, `autoIndentOnPaste` that allows auto-indentation to be used when pasting.

@atom/core Do you guys think there's anything we need to do make it clear that `autoIndentOnPaste` completely supercedes `normalizeIndentOnPaste`?

Closes #1407
- [x] auto-indent pasted text
- [x] in `::suggestedIndentForBufferRow`, base indentation on previous non-blank line
- [x] don't auto-indent when pasting after non-whitespace characters
- [x] make a separate config option, `editor.autoIndentOnPaste` for auto-indenting pasted text
- [x] add a description to the original `autoIndent` config option, differentiating it from `autoIndentOnPaste`
