### PR TITLE
Upgrade to atom-shell@0.19.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "url": "http://github.com/atom/atom/raw/master/LICENSE.md"
     }
   ],
-  "atomShellVersion": "0.19.1",
+  "atomShellVersion": "0.19.2",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^2.2.2",


### PR DESCRIPTION
Changelog:
- Add `plugins` attribute for `<webview>`
- Add `preload` attribute for `<webview>`
- Add `httpreferrer` attribute for `<webview>`
- Add `crashRepoter.getLastCrashReport` API
- Add `original-fs` module
- Add `preload` option for BrowserWindow
- Add APIs to toggle menu bar for BrowserWindow
- Fix wrong string when using `Buffer` for WebKit’s external string

**Linux**
- Use system window frame for undocked devtools

**Windows**
- Upload PDB files to symbol server
- Use native frame for `BrowserWindow` when DWM is off
- Fix setting default path for file dialogs

**Windows & Linux**
- Fix crash when showing error dialog on early initialization stage
- Make `auto-hide-menu-bar` work when number lock is on
