### PR TITLE
Support middle mouse paste on Linux

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -2686,7 +2686,14 @@ describe "TextEditorComponent", ->
 
   describe "middle mouse paste on Linux", ->
     it "pastes the previously selected text", ->
+      atom.clipboard.write('')
       component.listenForMiddleMousePaste()
+
+      editor.setCursorBufferPosition([10, 0])
+      componentNode.querySelector('.scroll-view').dispatchEvent(buildMouseEvent('mouseup', which: 2))
+
+      expect(atom.clipboard.read()).toBe ''
+      expect(editor.lineTextForBufferRow(10)).toBe ''
 
       editor.setSelectedBufferRange([[1, 6], [1, 10]])
       editor.setCursorBufferPosition([10, 0])

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -2684,6 +2684,17 @@ describe "TextEditorComponent", ->
         expect(line1LeafNodes[0].classList.contains('indent-guide')).toBe false
         expect(line1LeafNodes[1].classList.contains('indent-guide')).toBe false
 
+  describe "middle mouse paste on Linux", ->
+    it "pastes the previously selected text", ->
+      component.listenForMiddleMousePaste()
+
+      editor.setSelectedBufferRange([[1, 6], [1, 10]])
+      editor.setCursorBufferPosition([10, 0])
+      componentNode.querySelector('.scroll-view').dispatchEvent(buildMouseEvent('mouseup', which: 2))
+
+      expect(atom.clipboard.read()).toBe 'sort'
+      expect(editor.lineTextForBufferRow(10)).toBe 'sort'
+
   buildMouseEvent = (type, properties...) ->
     properties = extend({bubbles: true, cancelable: true}, properties...)
     properties.detail ?= 1

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -405,6 +405,7 @@ TextEditorComponent = React.createClass
     window.addEventListener 'resize', @requestHeightAndWidthMeasurement
 
     @listenForIMEEvents()
+    @listenForMiddleMousePaste() if process.platform is 'linux'
 
   listenForIMEEvents: ->
     node = @getDOMNode()
@@ -431,6 +432,19 @@ TextEditorComponent = React.createClass
     node.addEventListener 'compositionend', (event) ->
       editor.insertText(selectedText, select: true, undo: 'skip')
       event.target.value = ''
+
+  listenForMiddleMousePaste: ->
+    clipboard = require 'clipboard'
+
+    @refs.scrollView.getDOMNode().addEventListener 'mouseup', =>
+      if selection = clipboard.readText('selection')
+        {editor} = @props
+        editor.insertText(selection)
+
+    @subscribe @props.editor.onDidChangeSelectionRange =>
+      {editor} = @props
+      if selectedText = editor.getSelectedText()
+        clipboard.writeText(selectedText, 'selection')
 
   observeConfig: ->
     @subscribe atom.config.observe 'editor.useHardwareAcceleration', @setUseHardwareAcceleration

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -440,12 +440,10 @@ TextEditorComponent = React.createClass
       return unless which is 2
 
       if selection = clipboard.readText('selection')
-        {editor} = @props
-        editor.insertText(selection)
+        @props.editor.insertText(selection)
 
     @subscribe @props.editor.onDidChangeSelectionRange =>
-      {editor} = @props
-      if selectedText = editor.getSelectedText()
+      if selectedText = @props.editor.getSelectedText()
         clipboard.writeText(selectedText, 'selection')
 
   observeConfig: ->

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -436,7 +436,9 @@ TextEditorComponent = React.createClass
   listenForMiddleMousePaste: ->
     clipboard = require 'clipboard'
 
-    @refs.scrollView.getDOMNode().addEventListener 'mouseup', =>
+    @refs.scrollView.getDOMNode().addEventListener 'mouseup', ({which}) =>
+      return unless which is 2
+
       if selection = clipboard.readText('selection')
         {editor} = @props
         editor.insertText(selection)


### PR DESCRIPTION
Adds for pasting the selection clipboard on middle mouse button on Linux.

Pastes on `mouseup` instead of `mousedown` which seemed to be consistent with of native inputs in Firefox and Chromium as well as Sublime on Ubuntu 14.04.

Copies all selection changes instead of just mouse driven selection changes so that things like `ctrl-D` and `ctrl-L` go to the selection clipboard.

Closes #2244
Closes #2272
Closes #3027
