### PR TITLE
Support automatically hiding the menu bar

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "async": "~0.2.9",
-    "donna": "1.0.6",
+    "donna": "1.0.7",
     "formidable": "~1.0.14",
     "fs-plus": "2.x",
     "github-releases": "~0.2.0",

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -94,6 +94,7 @@
     submenu: [
       { label: '&Reload', command: 'window:reload' }
       { label: 'Toggle &Full Screen', command: 'window:toggle-full-screen' }
+      { label: 'Toggle Menu Bar', command: 'window:toggle-menu-bar' }
       {
         label: 'Developer'
         submenu: [

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -93,6 +93,7 @@
     submenu: [
       { label: '&Reload', command: 'window:reload' }
       { label: 'Toggle &Full Screen', command: 'window:toggle-full-screen' }
+      { label: 'Toggle Menu Bar', command: 'window:toggle-menu-bar' }
       {
         label: 'Panes'
         submenu: [

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -730,3 +730,5 @@ class Atom extends Model
 
   setAutoHideMenuBar: (autoHide) ->
     ipc.send('call-window-method', 'setAutoHideMenuBar', autoHide)
+    unless autoHide
+      ipc.send('call-window-method', 'setMenuBarVisibility', true)

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -503,7 +503,11 @@ class Atom extends Model
     @packages.activate()
     @keymaps.loadUserKeymap()
     @requireUserInitScript() unless safeMode
+
     @menu.update()
+    @subscribe @config.onDidChange 'core.autoHideMenuBar', ({newValue}) =>
+      @setAutoHideMenuBar(newValue)
+    @setAutoHideMenuBar(true) if @config.get('core.autoHideMenuBar')
 
     maximize = dimensions?.maximized and process.platform isnt 'darwin'
     @displayWindow({maximize})
@@ -723,3 +727,6 @@ class Atom extends Model
 
   setBodyPlatformClass: ->
     document.body.classList.add("platform-#{process.platform}")
+
+  setAutoHideMenuBar: (autoHide) ->
+    ipc.send('call-window-method', 'setAutoHideMenuBar', autoHide)

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -730,5 +730,4 @@ class Atom extends Model
 
   setAutoHideMenuBar: (autoHide) ->
     ipc.send('call-window-method', 'setAutoHideMenuBar', autoHide)
-    unless autoHide
-      ipc.send('call-window-method', 'setMenuBarVisibility', true)
+    ipc.send('call-window-method', 'setMenuBarVisibility', !autoHide)

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -192,4 +192,4 @@ if process.platform in ['win32', 'linux']
   module.exports.core.autoHideMenuBar =
     type: 'boolean'
     default: false
-    title: 'Automatically hide the menu bar. This is only supported on Linux and Windows'
+    description: 'Automatically hide the menu bar. This is only supported on Linux and Windows'

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -192,4 +192,4 @@ if process.platform in ['win32', 'linux']
   module.exports.core.properties.autoHideMenuBar =
     type: 'boolean'
     default: false
-    description: 'Automatically hide the menu bar. This is only supported on Linux and Windows'
+    description: 'Automatically hide the menu bar and show it when Alt is pressed. This is only supported on Linux and Windows'

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -187,3 +187,9 @@ module.exports =
         type: 'boolean'
         default: process.platform isnt 'darwin'
         description: 'Increase/decrease the editor font size when pressing the Ctrl key and scrolling the mouse up/down.'
+
+if process.platform in ['win32', 'linux']
+  module.exports.core.autoHideMenuBar =
+    type: 'boolean'
+    default: false
+    title: 'Automatically hide the menu bar. This is only supported on Linux and Windows'

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -192,4 +192,4 @@ if process.platform in ['win32', 'linux']
   module.exports.core.properties.autoHideMenuBar =
     type: 'boolean'
     default: false
-    description: 'Automatically hide the menu bar and toggle it by pressing Alt. This is only supported on Linux and Windows'
+    description: 'Automatically hide the menu bar and toggle it by pressing Alt. This is only supported on Windows & Linux.'

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -189,7 +189,7 @@ module.exports =
         description: 'Increase/decrease the editor font size when pressing the Ctrl key and scrolling the mouse up/down.'
 
 if process.platform in ['win32', 'linux']
-  module.exports.core.autoHideMenuBar =
+  module.exports.core.properties.autoHideMenuBar =
     type: 'boolean'
     default: false
     description: 'Automatically hide the menu bar. This is only supported on Linux and Windows'

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -192,4 +192,4 @@ if process.platform in ['win32', 'linux']
   module.exports.core.properties.autoHideMenuBar =
     type: 'boolean'
     default: false
-    description: 'Automatically hide the menu bar and show it when Alt is pressed. This is only supported on Linux and Windows'
+    description: 'Automatically hide the menu bar and toggle it by pressing Alt. This is only supported on Linux and Windows'

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -60,6 +60,8 @@ class WindowEventHandler
       atom.reload()
 
     @subscribeToCommand $(window), 'window:toggle-dev-tools', -> atom.toggleDevTools()
+    @subscribeToCommand $(window), 'window:toggle-menu-bar', ->
+      atom.config.set('core.autoHideMenuBar', !atom.config.get('core.autoHideMenuBar'))
 
     @subscribeToCommand $(document), 'core:focus-next', @focusNext
 

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -60,8 +60,10 @@ class WindowEventHandler
       atom.reload()
 
     @subscribeToCommand $(window), 'window:toggle-dev-tools', -> atom.toggleDevTools()
-    @subscribeToCommand $(window), 'window:toggle-menu-bar', ->
-      atom.config.set('core.autoHideMenuBar', !atom.config.get('core.autoHideMenuBar'))
+
+    if process.platform in ['win32', 'linux']
+      @subscribeToCommand $(window), 'window:toggle-menu-bar', ->
+        atom.config.set('core.autoHideMenuBar', !atom.config.get('core.autoHideMenuBar'))
 
     @subscribeToCommand $(document), 'core:focus-next', @focusNext
 


### PR DESCRIPTION
Adds a `core.autoHideMenuBar` config setting to auto hide the menu bar on Linux and Windows. `Alt` will bring show the menu bar in this mode.

![auto-hide](https://cloud.githubusercontent.com/assets/671378/5079234/493f802c-6e67-11e4-9614-4ab547197e54.gif)

This new command `window:toggle-menu-bar` will also be available from the command palette and the `View` menu.

Closes #2914
