### PR TITLE
Port chocolatey install actions to squirrel events

### DIFF
--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -71,7 +71,6 @@ updatePath = (callback) ->
       @echo off
       "%~dp0\\#{relativeExePath}" %*
     """
-    fs.writeFile(atomCommandPath, atomCommand, callback)
 
     apmCommandPath = path.join(binFolder, 'apm.cmd')
     relativeApmPath = path.relative(binFolder, path.join(process.resourcesPath, 'app', 'apm', 'node_modules', 'atom-package-manager', 'bin', 'apm.cmd'))
@@ -79,7 +78,10 @@ updatePath = (callback) ->
       @echo off
       "%~dp0\\#{relativeApmPath}" %*
     """
-    fs.writeFile(apmCommandPath, apmCommand, callback)
+
+    fs.writeFile atomCommandPath, atomCommand, ->
+      fs.writeFile apmCommandPath, apmCommand, ->
+        callback()
 
   getPath = (callback) ->
     spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout) ->

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -73,6 +73,14 @@ updatePath = (callback) ->
     """
     fs.writeFile(atomCommandPath, atomCommand, callback)
 
+    apmCommandPath = path.join(binFolder, 'apm.cmd')
+    relativeApmPath = path.relative(binFolder, path.join(process.resourcesPath, 'app', 'apm', 'node_modules', 'atom-package-manager', 'bin', 'atom.cmd'))
+    apmCommand = """
+      @echo off
+      "%~dp0\\#{relativeApmPath}" %*
+    """
+    fs.writeFile(apmCommandPath, apmCommand, callback)
+
   getPath = (callback) ->
     spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout) ->
       return callback(error) if error?

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -32,6 +32,7 @@ installContextMenu = (callback) ->
   fileKeyPath = 'HKCU\\Software\\Classes\\*\\shell\\Atom'
 
   spawnReg = (args) ->
+    args.unshift('add')
     regProcess = ChildProcess.spawn('reg.exe', args)
     console.log args
 

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -93,11 +93,11 @@ updatePath = (callback) ->
   getPath = (callback) ->
     spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout) ->
       if error?
-        # The query failed so the Path does not exist yet in the registry
-        return callback(null, '') if error.code is 1
-      else
-        return callback(error)
-
+        if error.code is 1
+          # The query failed so the Path does not exist yet in the registry
+          return callback(null, '')
+        else
+          return callback(error)
 
       lines = stdout.split(/[\r\n]+/).filter (line) -> line
       segments = lines[lines.length - 1]?.split('    ')

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -54,11 +54,11 @@ installContextMenu = (callback) ->
 
   installMenu = (keyPath, callback) ->
     args = [keyPath, '/ve', '/d', 'Open with Atom']
-    spawnReg args, ->
+    addToRegistry args, ->
       args = [keyPath, '/v', 'Icon', '/d', process.execPath]
-      spawnReg args, ->
+      addToRegistry args, ->
         args = ["#{keyPath}\\command", '/ve', '/d', process.execPath]
-        spawnReg(args, callback)
+        addToRegistry(args, callback)
 
   installMenu fileKeyPath, ->
     installMenu directoryKeyPath, ->

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -18,7 +18,9 @@ spawn = (command, args, callback) ->
   spawnedProcess = ChildProcess.spawn(command, args)
 
   stdout = ''
+  stderr = ''
   spawnedProcess.stdout.on 'data', (data) -> stdout += data
+  spawnedProcess.stderr.on 'data', (data) -> stderr += data
 
   error = null
   spawnedProcess.on 'error', (processError) -> error ?= processError
@@ -26,7 +28,8 @@ spawn = (command, args, callback) ->
     error ?= new Error("Command failed: #{signal ? code}") if code isnt 0
     error?.code ?= code
     error?.stdout ?= stdout
-    callback(error, stdout)
+    error?.stderr ?= stderr
+    callback(error, stdout, stderr)
 
 # Spawn reg.exe and callback when it completes
 spawnReg = (args, callback) ->
@@ -91,9 +94,8 @@ updatePath = (callback) ->
         callback()
 
   getPath = (callback) ->
-    spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout) ->
-      console.log error
-      console.log stdout
+    spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout, stderr) ->
+      console.log stderr
       return callback(error) if error?
 
       lines = stdout.split(/[\r\n]+/).filter (line) -> line

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -67,6 +67,9 @@ updatePath = (callback) ->
   installCommands = (callback) ->
     atomCommandPath = path.join(binFolder, 'atom.cmd')
     relativeExePath = path.relative(binFolder, process.execPath)
+    console.log 'installing'
+    console.log atomCommandPath
+    console.log relativeExePath
     fs.writeFile(atomCommandPath, "\"%~dp0/#{relativeExePath}\" %*", callback)
 
   getPath = (callback) ->

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -10,41 +10,30 @@ exeName = path.basename(process.execPath)
 fileKeyPath = 'HKCU\\Software\\Classes\\*\\shell\\Atom'
 directoryKeyPath = 'HKCU\\Software\\Classes\\directory\\shell\\Atom'
 backgroundKeyPath = 'HKCU\\Software\\Classes\\directory\\background\\shell\\Atom'
+environmentKeyPath = 'HKCU\\Environment'
 
-# Spawn reg.exe and callback when it completes
-spawnReg = (args, callback) ->
-  regProcess = ChildProcess.spawn('reg.exe', args)
-
-  error = null
-  regProcess.on 'error', (processError) -> error ?= processError
-  regProcess.on 'close', (code, signal) ->
-    error ?= new Error("Command failed: #{signal ? code}") if code isnt 0
-    error?.code ?= code
-    callback(error)
-
-  undefined
-
-# Spawn the Update.exe with the given arguments and invoke the callback when
-# the command completes.
-exports.spawn = (args, callback) ->
-  updateProcess = ChildProcess.spawn(updateDotExe, args)
+spawn = (command, args, callback) ->
+  spawnedProcess = ChildProcess.spawn('reg.exe', args)
 
   stdout = ''
-  updateProcess.stdout.on 'data', (data) -> stdout += data
+  spawnedProcess.stdout.on 'data', (data) -> stdout += data
 
   error = null
-  updateProcess.on 'error', (processError) -> error ?= processError
-  updateProcess.on 'close', (code, signal) ->
+  spawnedProcess.on 'error', (processError) -> error ?= processError
+  spawnedProcess.on 'close', (code, signal) ->
     error ?= new Error("Command failed: #{signal ? code}") if code isnt 0
     error?.code ?= code
     error?.stdout ?= stdout
     callback(error, stdout)
 
-  undefined
+# Spawn reg.exe and callback when it completes
+spawnReg = (args, callback) ->
+  spawn('reg.exe', args, callback)
 
-# Is the Update.exe installed with Atom?
-exports.existsSync = ->
-  fs.existsSync(updateDotExe)
+# Spawn the Update.exe with the given arguments and invoke the callback when
+# the command completes.
+spawnUpdate = (args, callback) ->
+  spawn(updateDotExe, args, callback)
 
 installContextMenu = (callback) ->
   addToRegistry = (args, callback) ->
@@ -72,13 +61,28 @@ uninstallContextMenu = (callback) ->
     deleteFromRegistry directoryKeyPath, ->
       deleteFromRegistry(backgroundKeyPath, callback)
 
+updatePath = (callback) ->
+  getPath = (callback) ->
+    spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout) ->
+      lines = stdout.split('\n')
+      segments = lines[lines.length - 1].split('    ')
+      pathSegment = segments[3..].join('    ')
+      console.log pathSegment
+
+exports.spawn = spawnUpdate
+
+# Is the Update.exe installed with Atom?
+exports.existsSync = ->
+  fs.existsSync(updateDotExe)
+
 # Handle squirrel events denoted by --squirrel-* command line arguments.
 exports.handleStartupEvent = ->
   switch process.argv[1]
     when '--squirrel-install', '--squirrel-updated'
       exports.spawn ['--createShortcut', exeName], ->
         installContextMenu ->
-          app.quit()
+          updatePath ->
+            app.quit()
       true
     when '--squirrel-uninstall'
       exports.spawn ['--removeShortcut', exeName], ->

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -30,6 +30,8 @@ exports.existsSync = ->
 
 installContextMenu = (callback) ->
   fileKeyPath = 'HKCU\\Software\\Classes\\*\\shell\\Atom'
+  directoryKeyPath = 'HKCU\\Software\\Classes\\directory\\shell\\Atom'
+  backgroundKeyPath = 'HKCU\\Software\\Classes\\directory\\background\\shell\\Atom'
 
   spawnReg = (args, callback) ->
     args.unshift('add')
@@ -41,6 +43,18 @@ installContextMenu = (callback) ->
       error ?= new Error("Command failed: #{signal ? code}") if code isnt 0
       error?.code ?= code
       callback(error)
+
+  installMenu = (keyPath, callback) ->
+    args = [keyPath, '/ve', '/d', 'Open with Atom', '/f']
+    spawnReg args, ->
+      args = [keyPath, '/v', 'Icon', '/d', process.execPath, '/f']
+      spawnReg args, ->
+        args = ["#{keyPath}\\command", '/ve', '/d', process.execPath, '/f']
+        spawnReg(args, callback)
+
+  installMenu fileKeyPath, ->
+    installMenu directoryKeyPath, ->
+      installMenu(backgroundKeyPath, callback)
 
   installFileMenu = (callback) ->
     args = [fileKeyPath, '/ve', '/d', 'Open with Atom', '/f']

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -46,6 +46,7 @@ installContextMenu = (callback) ->
   installFileMenu = ->
     args = [fileKeyPath, '/ve', '/d', 'Open with Atom', '/f']
     spawnReg args, (error) ->
+      console.log 'done'
       # return callback(error) if error?
 
       args = [fileKeyPath, '/v', 'Icon', '/d', process.execPath, '/f']
@@ -63,7 +64,7 @@ exports.handleStartupEvent = ->
     when '--squirrel-install', '--squirrel-updated'
       exports.spawn ['--createShortcut', exeName], ->
         installContextMenu (error) ->
-          console.log(error)
+          console.log(error) if error?
           app.quit()
       true
     when '--squirrel-uninstall'

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -37,6 +37,7 @@ spawnReg = (args, callback) ->
 spawnUpdate = (args, callback) ->
   spawn(updateDotExe, args, callback)
 
+# Install the Open with Atom explorer context menu items via the registry.
 installContextMenu = (callback) ->
   addToRegistry = (args, callback) ->
     args.unshift('add')
@@ -55,6 +56,7 @@ installContextMenu = (callback) ->
     installMenu directoryKeyPath, ->
       installMenu(backgroundKeyPath, callback)
 
+# Uninstall the Open with Atom explorer context menu items via the registry.
 uninstallContextMenu = (callback) ->
   deleteFromRegistry = (keyPath, callback) ->
     spawnReg(['delete', keyPath, '/f'], callback)
@@ -63,6 +65,11 @@ uninstallContextMenu = (callback) ->
     deleteFromRegistry directoryKeyPath, ->
       deleteFromRegistry(backgroundKeyPath, callback)
 
+# Add apm and atom.exe to the PATH
+#
+# This is done by adding .cmd shims to the root bin folder in the Atom
+# install directory that point to the newly installed versions inside
+# the versioned app directories.
 updatePath = (callback) ->
   installCommands = (callback) ->
     atomCommandPath = path.join(binFolder, 'atom.cmd')

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -92,6 +92,8 @@ updatePath = (callback) ->
 
   getPath = (callback) ->
     spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout) ->
+      console.log error
+      console.log stdoutg
       return callback(error) if error?
 
       lines = stdout.split(/[\r\n]+/).filter (line) -> line

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -90,25 +90,25 @@ updatePath = (callback) ->
       lines = stdout.split(/[\r\n]+/).filter (line) -> line
       segments = lines[lines.length - 1]?.split('    ')
       if segments[1] is 'Path' and segments.length >= 3
-        envPath = segments?[3..].join('    ')
-        callback(null, envPath)
+        pathEnv = segments?[3..].join('    ')
+        callback(null, pathEnv)
       else
         callback(new Error('Registry query for PATH failed'))
 
-  addBinToPath = (envSegments, callback) ->
-    envSegments.push(binFolder)
-    args = ['setx', 'Path', envSegments.join(';')]
-    spawnReg(args, callback)
+  addBinToPath = (pathSegments, callback) ->
+    pathSegments.push(binFolder)
+    newPathEnv = pathSegments.join(';')
+    spawn('setx', ['Path', newPathEnv], callback)
 
   installCommands (error) ->
     return callback(error) if error?
 
-    getPath (error, envPath) ->
+    getPath (error, pathEnv) ->
       return callback(error) if error?
 
-      envSegments = envPath.split(';')
-      if envSegments.indexOf(binFolder) is -1
-        addBinToPath(envSegments, callback)
+      pathSegments = pathEnv.split(';')
+      if pathSegments.indexOf(binFolder) is -1
+        addBinToPath(pathSegments, callback)
       else
         callback()
 

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -4,7 +4,7 @@ fs = require 'fs-plus'
 path = require 'path'
 
 rootAtomFolder = path.resolve(process.execPath, '..', '..')
-binFolder = path.resolve(process.execPath, 'bin')
+binFolder = path.join(rootAtomFolder, 'bin')
 updateDotExe = path.join(rootAtomFolder, 'Update.exe')
 exeName = path.basename(process.execPath)
 

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -33,6 +33,7 @@ installContextMenu = (callback) ->
 
   spawnReg = (args) ->
     regProcess = ChildProcess.spawn('reg.exe', args)
+    console.log args
 
     error = null
     regProcess.on 'error', (processError) -> error ?= processError

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -79,10 +79,13 @@ updatePath = (callback) ->
     if error?
       callback(error)
     else
+      console.log envPath
       segments = envPath.split(';')
       if segments.indexOf(binFolder) is -1
         segments.push(binFolder)
 
+        console.log 'updating'
+        console.log segments.join(';')
         args = ['add', pathKeyPath, segments.join(';'), '/f']
         spawnReg(args, callback)
 

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -115,7 +115,7 @@ updatePath = (callback) ->
     getPath (error, pathEnv) ->
       return callback(error) if error?
 
-      pathSegments = pathEnv.split(';')
+      pathSegments = pathEnv.split(/;+/).filter (pathSegment) -> pathSegment
       if pathSegments.indexOf(binFolder) is -1
         addBinToPath(pathSegments, callback)
       else

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -8,6 +8,14 @@ binFolder = path.join(rootAtomFolder, 'bin')
 updateDotExe = path.join(rootAtomFolder, 'Update.exe')
 exeName = path.basename(process.execPath)
 
+if process.env.SystemRoot
+  system32Path = path.join(process.env.SystemRoot, 'System32')
+  regPath = path.join(system32Path, 'reg.exe')
+  setxPath = path.join(system32Path, 'setx.exe')
+else
+  regPath = 'reg.exe'
+  setxPath = 'setx.exe'
+
 # Registry keys used for context menu
 fileKeyPath = 'HKCU\\Software\\Classes\\*\\shell\\Atom'
 directoryKeyPath = 'HKCU\\Software\\Classes\\directory\\shell\\Atom'
@@ -32,18 +40,10 @@ spawn = (command, args, callback) ->
 
 # Spawn reg.exe and callback when it completes
 spawnReg = (args, callback) ->
-  if process.env.SystemRoot
-    regPath = path.join(process.env.SystemRoot, 'System32', 'reg.exe')
-  else
-    regPath = 'reg.exe'
   spawn(regPath, args, callback)
 
 # Spawn setx.exe and callback when it completes
 spawnSetx = (args, callback) ->
-  if process.env.SystemRoot
-    setxPath = path.join(process.env.SystemRoot, 'System32', 'setx.exe')
-  else
-    setxPath = 'setx.exe'
   spawn(setxPath, args, callback)
 
 # Spawn the Update.exe with the given arguments and invoke the callback when

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -85,7 +85,7 @@ updatePath = (callback) ->
 
         console.log 'updating'
         console.log segments.join(';')
-        args = ['add', environmentKeyPath, '/v', 'Path', segments.join(';'), '/f']
+        args = ['add', environmentKeyPath, '/v', 'Path', '/d', segments.join(';'), '/f']
         spawnReg(args, callback)
 
 exports.spawn = spawnUpdate

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -67,10 +67,10 @@ updatePath = (callback) ->
   installCommands = (callback) ->
     atomCommandPath = path.join(binFolder, 'atom.cmd')
     relativeExePath = path.relative(binFolder, process.execPath)
-    console.log 'installing'
-    console.log atomCommandPath
-    console.log relativeExePath
-    fs.writeFile(atomCommandPath, "\"%~dp0/#{relativeExePath}\" %*", callback)
+    atomCommand = """
+      "%~dp0\\#{relativeExePath}" %*
+    """
+    fs.writeFile(atomCommandPath, atomCommand, callback)
 
   getPath = (callback) ->
     spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout) ->

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -1,6 +1,6 @@
 app = require 'app'
 ChildProcess = require 'child_process'
-fs = require 'fs'
+fs = require 'fs-plus'
 path = require 'path'
 
 rootAtomFolder = path.resolve(process.execPath, '..', '..')

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -81,8 +81,6 @@ updatePath = (callback) ->
     return callback() unless segments.indexOf(binFolder) is -1
 
     segments.push(binFolder)
-    console.log 'updating'
-    console.log segments.join(';')
     args = ['add', environmentKeyPath, '/v', 'Path', '/d', segments.join(';'), '/f']
     spawnReg(args, callback)
 

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -46,11 +46,11 @@ installContextMenu = (callback) ->
   installFileMenu = ->
     args = [fileKeyPath, '/ve', '/d', 'Open with Atom', '/f']
     spawnReg args, (error) ->
-      return callback(error) if error?
+      # return callback(error) if error?
 
       args = [fileKeyPath, '/v', 'Icon', '/d', process.execPath, '/f']
       spawnReg args, (error) ->
-        return callback(error) if error?
+        # return callback(error) if error?
 
         args = ["#{fileKeyPath}\\command", '/ve', '/d', process.execPath, '/f']
         spawnReg(args, callback)

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -17,7 +17,7 @@ exports.spawn = (args, callback) ->
   error = null
   updateProcess.on 'error', (processError) -> error ?= processError
   updateProcess.on 'close', (code, signal) ->
-    error ?= new Error("Command failed: #{signal}") if code isnt 0
+    error ?= new Error("Command failed: #{signal ? code}") if code isnt 0
     error?.code ?= code
     error?.stdout ?= stdout
     callback(error, stdout)
@@ -37,7 +37,7 @@ installContextMenu = (callback) ->
     error = null
     regProcess.on 'error', (processError) -> error ?= processError
     regProcess.on 'close', (code, signal) ->
-      error ?= new Error("Command failed: #{signal}") if code isnt 0
+      error ?= new Error("Command failed: #{signal ? code}") if code isnt 0
       error?.code ?= code
       callback(error)
 
@@ -59,8 +59,7 @@ installContextMenu = (callback) ->
 exports.handleStartupEvent = ->
   switch process.argv[1]
     when '--squirrel-install', '--squirrel-updated'
-      exports.spawn ['--createShortcut', exeName], (error) ->
-        console.log(error)
+      exports.spawn ['--createShortcut', exeName], ->
         installContextMenu (error) ->
           console.log(error)
           app.quit()

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -59,8 +59,10 @@ installContextMenu = (callback) ->
 exports.handleStartupEvent = ->
   switch process.argv[1]
     when '--squirrel-install', '--squirrel-updated'
-      exports.spawn ['--createShortcut', exeName], ->
-        installContextMenu ->
+      exports.spawn ['--createShortcut', exeName], (error) ->
+        console.log(error)
+        installContextMenu (error) ->
+          console.log(error)
           app.quit()
       true
     when '--squirrel-uninstall'

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -89,7 +89,7 @@ uninstallContextMenu = (callback) ->
     deleteFromRegistry directoryKeyPath, ->
       deleteFromRegistry(backgroundKeyPath, callback)
 
-# Add apm and atom.exe to the PATH
+# Add atom and apm to the PATH
 #
 # This is done by adding .cmd shims to the root bin folder in the Atom
 # install directory that point to the newly installed versions inside
@@ -131,6 +131,7 @@ addCommandsToPath = (callback) ->
       else
         callback()
 
+# Remove atom and apm from the PATH
 removeCommandsFromPath = (callback) ->
   getPath (error, pathEnv) ->
     return callback(error) if error?

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -56,20 +56,6 @@ installContextMenu = (callback) ->
     installMenu directoryKeyPath, ->
       installMenu(backgroundKeyPath, callback)
 
-  installFileMenu = (callback) ->
-    args = [fileKeyPath, '/ve', '/d', 'Open with Atom', '/f']
-    spawnReg args, (error) ->
-      return callback(error) if error?
-
-      args = [fileKeyPath, '/v', 'Icon', '/d', process.execPath, '/f']
-      spawnReg args, (error) ->
-        return callback(error) if error?
-
-        args = ["#{fileKeyPath}\\command", '/ve', '/d', process.execPath, '/f']
-        spawnReg(args, callback)
-
-  installFileMenu(callback)
-
 # Handle squirrel events denoted by --squirrel-* command line arguments.
 exports.handleStartupEvent = ->
   switch process.argv[1]

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -14,6 +14,8 @@ directoryKeyPath = 'HKCU\\Software\\Classes\\directory\\shell\\Atom'
 backgroundKeyPath = 'HKCU\\Software\\Classes\\directory\\background\\shell\\Atom'
 environmentKeyPath = 'HKCU\\Environment'
 
+# Spawn a command and invoke the callback when it completes with an error
+# and the output from standard out.
 spawn = (command, args, callback) ->
   spawnedProcess = ChildProcess.spawn(command, args)
 

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -66,6 +66,8 @@ uninstallContextMenu = (callback) ->
 updatePath = (callback) ->
   getPath = (callback) ->
     spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout) ->
+      return callback(error) if error?
+
       lines = stdout.split(/[\r\n]+/).filter (line) -> line
       segments = lines[lines.length - 1]?.split('    ')
       if segments[1] is 'Path' and segments.length >= 3

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -32,7 +32,19 @@ spawn = (command, args, callback) ->
 
 # Spawn reg.exe and callback when it completes
 spawnReg = (args, callback) ->
-  spawn('reg.exe', args, callback)
+  if process.env.SystemRoot
+    regPath = path.join(process.env.SystemRoot, 'System32', 'reg.exe')
+  else
+    regPath = 'reg.exe'
+  spawn(regPath, args, callback)
+
+# Spawn setx.exe and callback when it completes
+spawnSetx = (args, callback) ->
+  if process.env.SystemRoot
+    setxPath = path.join(process.env.SystemRoot, 'System32', 'setx.exe')
+  else
+    setxPath = 'setx.exe'
+  spawn(setxPath, args, callback)
 
 # Spawn the Update.exe with the given arguments and invoke the callback when
 # the command completes.
@@ -119,7 +131,7 @@ addCommandsToPath = (callback) ->
   addBinToPath = (pathSegments, callback) ->
     pathSegments.push(binFolder)
     newPathEnv = pathSegments.join(';')
-    spawn('setx', ['Path', newPathEnv], callback)
+    spawnSetx(['Path', newPathEnv], callback)
 
   installCommands (error) ->
     return callback(error) if error?
@@ -143,7 +155,7 @@ removeCommandsFromPath = (callback) ->
     newPathEnv = pathSegments.join(';')
 
     if pathEnv isnt newPathEnv
-      spawn('setx', ['Path', newPathEnv], callback)
+      spawnSetx(['Path', newPathEnv], callback)
     else
       callback()
 

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -13,7 +13,7 @@ backgroundKeyPath = 'HKCU\\Software\\Classes\\directory\\background\\shell\\Atom
 environmentKeyPath = 'HKCU\\Environment'
 
 spawn = (command, args, callback) ->
-  spawnedProcess = ChildProcess.spawn('reg.exe', args)
+  spawnedProcess = ChildProcess.spawn(command, args)
 
   stdout = ''
   spawnedProcess.stdout.on 'data', (data) -> stdout += data

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -86,7 +86,7 @@ updatePath = (callback) ->
 
   addBinToPath = (envSegments, callback) ->
     envSegments.push(binFolder)
-    args = ['add', environmentKeyPath, '/v', 'Path', '/d', envSegments.join(';'), '/f']
+    args = ['setx', 'Path', envSegments.join(';')]
     spawnReg(args, callback)
 
   installCommands (error) ->

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -13,7 +13,6 @@ fileKeyPath = 'HKCU\\Software\\Classes\\*\\shell\\Atom'
 directoryKeyPath = 'HKCU\\Software\\Classes\\directory\\shell\\Atom'
 backgroundKeyPath = 'HKCU\\Software\\Classes\\directory\\background\\shell\\Atom'
 environmentKeyPath = 'HKCU\\Environment'
-pathKeyPath = "#{environmentKeyPath}\\Path"
 
 spawn = (command, args, callback) ->
   spawnedProcess = ChildProcess.spawn(command, args)
@@ -86,7 +85,7 @@ updatePath = (callback) ->
 
         console.log 'updating'
         console.log segments.join(';')
-        args = ['add', pathKeyPath, segments.join(';'), '/f']
+        args = ['add', environmentKeyPath, '/v', 'Path', segments.join(';'), '/f']
         spawnReg(args, callback)
 
 exports.spawn = spawnUpdate

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -74,7 +74,7 @@ updatePath = (callback) ->
     fs.writeFile(atomCommandPath, atomCommand, callback)
 
     apmCommandPath = path.join(binFolder, 'apm.cmd')
-    relativeApmPath = path.relative(binFolder, path.join(process.resourcesPath, 'app', 'apm', 'node_modules', 'atom-package-manager', 'bin', 'atom.cmd'))
+    relativeApmPath = path.relative(binFolder, path.join(process.resourcesPath, 'app', 'apm', 'node_modules', 'atom-package-manager', 'bin', 'apm.cmd'))
     apmCommand = """
       @echo off
       "%~dp0\\#{relativeApmPath}" %*

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -93,7 +93,7 @@ updatePath = (callback) ->
   getPath = (callback) ->
     spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout) ->
       console.log error
-      console.log stdoutg
+      console.log stdout
       return callback(error) if error?
 
       lines = stdout.split(/[\r\n]+/).filter (line) -> line

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -58,17 +58,17 @@ installContextMenu = (callback) ->
     args.push('/f')
     spawnReg(args, callback)
 
-  installMenu = (keyPath, callback) ->
+  installMenu = (keyPath, arg, callback) ->
     args = [keyPath, '/ve', '/d', 'Open with Atom']
     addToRegistry args, ->
       args = [keyPath, '/v', 'Icon', '/d', process.execPath]
       addToRegistry args, ->
-        args = ["#{keyPath}\\command", '/ve', '/d', process.execPath]
+        args = ["#{keyPath}\\command", '/ve', '/d', "#{process.execPath} \"#{arg}\""]
         addToRegistry(args, callback)
 
-  installMenu fileKeyPath, ->
-    installMenu directoryKeyPath, ->
-      installMenu(backgroundKeyPath, callback)
+  installMenu fileKeyPath, '%1' ->
+    installMenu directoryKeyPath, '%1', ->
+      installMenu(backgroundKeyPath, '%V', callback)
 
 # Get the user's PATH environment variable registry value.
 getPath = (callback) ->

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -75,18 +75,16 @@ updatePath = (callback) ->
         callback(new Error('Registry query for PATH failed'))
 
   getPath (error, envPath) ->
-    if error?
-      callback(error)
-    else
-      console.log envPath
-      segments = envPath.split(';')
-      if segments.indexOf(binFolder) is -1
-        segments.push(binFolder)
+    return callback(error) if error?
 
-        console.log 'updating'
-        console.log segments.join(';')
-        args = ['add', environmentKeyPath, '/v', 'Path', '/d', segments.join(';'), '/f']
-        spawnReg(args, callback)
+    segments = envPath.split(';')
+    return callback() unless segments.indexOf(binFolder) is -1
+
+    segments.push(binFolder)
+    console.log 'updating'
+    console.log segments.join(';')
+    args = ['add', environmentKeyPath, '/v', 'Path', '/d', segments.join(';'), '/f']
+    spawnReg(args, callback)
 
 exports.spawn = spawnUpdate
 

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -68,6 +68,7 @@ updatePath = (callback) ->
       segments = lines[lines.length - 1].split('    ')
       pathSegment = segments[3..].join('    ')
       console.log pathSegment
+      callback()
 
   getPath(callback)
 

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -64,9 +64,7 @@ uninstallContextMenu = (callback) ->
 updatePath = (callback) ->
   getPath = (callback) ->
     spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout) ->
-      console.log error
-      console.log stdout
-      lines = stdout.split(/[\r\n]+/)
+      lines = stdout.split(/[\r\n]+/).filter (line) -> line
       console.log lines
       segments = lines[lines.length - 1]?.split('    ')
       pathSegment = segments?[3..].join('    ')

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -31,7 +31,7 @@ exports.existsSync = ->
 installContextMenu = (callback) ->
   fileKeyPath = 'HKCU\\Software\\Classes\\*\\shell\\Atom'
 
-  spawnReg = (args) ->
+  spawnReg = (args, callback) ->
     args.unshift('add')
     regProcess = ChildProcess.spawn('reg.exe', args)
     console.log args
@@ -43,7 +43,7 @@ installContextMenu = (callback) ->
       error?.code ?= code
       callback(error)
 
-  installFileMenu = ->
+  installFileMenu = (callback) ->
     args = [fileKeyPath, '/ve', '/d', 'Open with Atom', '/f']
     spawnReg args, (error) ->
       console.log 'done'

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -64,6 +64,8 @@ uninstallContextMenu = (callback) ->
 updatePath = (callback) ->
   getPath = (callback) ->
     spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout) ->
+      console.log error
+      console.log stdout
       lines = stdout.split('\n')
       segments = lines[lines.length - 1].split('    ')
       pathSegment = segments[3..].join('    ')

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -68,6 +68,7 @@ updatePath = (callback) ->
     atomCommandPath = path.join(binFolder, 'atom.cmd')
     relativeExePath = path.relative(binFolder, process.execPath)
     atomCommand = """
+      @echo off
       "%~dp0\\#{relativeExePath}" %*
     """
     fs.writeFile(atomCommandPath, atomCommand, callback)

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -66,7 +66,7 @@ installContextMenu = (callback) ->
         args = ["#{keyPath}\\command", '/ve', '/d', "#{process.execPath} \"#{arg}\""]
         addToRegistry(args, callback)
 
-  installMenu fileKeyPath, '%1' ->
+  installMenu fileKeyPath, '%1', ->
     installMenu directoryKeyPath, '%1', ->
       installMenu(backgroundKeyPath, '%V', callback)
 

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -34,7 +34,6 @@ installContextMenu = (callback) ->
   spawnReg = (args, callback) ->
     args.unshift('add')
     regProcess = ChildProcess.spawn('reg.exe', args)
-    console.log args
 
     error = null
     regProcess.on 'error', (processError) -> error ?= processError
@@ -46,12 +45,11 @@ installContextMenu = (callback) ->
   installFileMenu = (callback) ->
     args = [fileKeyPath, '/ve', '/d', 'Open with Atom', '/f']
     spawnReg args, (error) ->
-      console.log 'done'
-      # return callback(error) if error?
+      return callback(error) if error?
 
       args = [fileKeyPath, '/v', 'Icon', '/d', process.execPath, '/f']
       spawnReg args, (error) ->
-        # return callback(error) if error?
+        return callback(error) if error?
 
         args = ["#{fileKeyPath}\\command", '/ve', '/d', process.execPath, '/f']
         spawnReg(args, callback)
@@ -63,8 +61,7 @@ exports.handleStartupEvent = ->
   switch process.argv[1]
     when '--squirrel-install', '--squirrel-updated'
       exports.spawn ['--createShortcut', exeName], ->
-        installContextMenu (error) ->
-          console.log(error) if error?
+        installContextMenu ->
           app.quit()
       true
     when '--squirrel-uninstall'

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -66,9 +66,10 @@ updatePath = (callback) ->
     spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout) ->
       console.log error
       console.log stdout
-      lines = stdout.split('\n')
-      segments = lines[lines.length - 1].split('    ')
-      pathSegment = segments[3..].join('    ')
+      lines = stdout.split(/[\r\n]+/)
+      console.log lines
+      segments = lines[lines.length - 1]?.split('    ')
+      pathSegment = segments?[3..].join('    ')
       console.log pathSegment
       callback()
 

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -42,15 +42,15 @@ installContextMenu = (callback) ->
       callback(error)
 
   installFileMenu = ->
-    args = [fileKeyPath, '/ve', '/d', 'Open with Atom']
+    args = [fileKeyPath, '/ve', '/d', 'Open with Atom', '/f']
     spawnReg args, (error) ->
       return callback(error) if error?
 
-      args = [fileKeyPath, '/v', 'Icon', '/d', process.execPath]
+      args = [fileKeyPath, '/v', 'Icon', '/d', process.execPath, '/f']
       spawnReg args, (error) ->
         return callback(error) if error?
 
-        args = ["#{fileKeyPath}\\command", '/ve', '/d', process.execPath]
+        args = ["#{fileKeyPath}\\command", '/ve', '/d', process.execPath, '/f']
         spawnReg(args, callback)
 
   installFileMenu(callback)

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -69,6 +69,8 @@ updatePath = (callback) ->
       pathSegment = segments[3..].join('    ')
       console.log pathSegment
 
+  getPath(callback)
+
 exports.spawn = spawnUpdate
 
 # Is the Update.exe installed with Atom?

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -66,6 +66,12 @@ getPath = (callback) ->
       else
         return callback(error)
 
+    # Registry query output is in the form:
+    #
+    # HKEY_CURRENT_USER\Environment
+    #     Path    REG_SZ    C:\a\folder\on\the\path;C\another\folder
+    #
+
     lines = stdout.split(/[\r\n]+/).filter (line) -> line
     segments = lines[lines.length - 1]?.split('    ')
     if segments[1] is 'Path' and segments.length >= 3


### PR DESCRIPTION
The new squirrel installer installs to `%UserProfile%\AppData\Local\atom` and currently only handles creating start menu and desktop shortcuts.

This PR adds the remaining items that were previously managed by the chocolatey install script.
- Adds an **Open with Atom** file context menu.
- Adds an **Open with Atom** folder context menu.
- Adds `%UserProfile%\AppData\Local\atom\bin` to the `Path` environment variable.
  - Uses `setx` to set the `Path` in the registry.
- Adds a command shim from `%UserProfile%\AppData\Local\atom\bin\atom.cmd` to the latest installed `atom.exe` version since `atom.exe` changes paths on each update.
- Adds a command shim from `%UserProfile%\AppData\Local\atom\bin\apm.cmd` to the latest installed `apm.cmd` version since `apm.cmd` changes paths on each update.

Once Atom ships with this and any bumps are smoothed out, this will be extracted into Atom Shell and added as helper on the `auto-updater` module.

Closes #4180
