### PR TITLE
Restore correct indent behavior when inserting newlines

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3438,6 +3438,16 @@ describe "TextEditor", ->
             editor.insertText('\n')
             expect(editor.indentationForBufferRow(1)).toBe 2
 
+        describe "when the line preceding the newline contains only whitespace", ->
+          it "bases the new line's indentation on only the preceding line", ->
+            editor.setCursorBufferPosition([6, Infinity])
+            editor.insertText("\n  ")
+            expect(editor.getCursorBufferPosition()).toEqual([7, 2])
+
+            editor.insertNewline()
+            editor.logScreenLines()
+            expect(editor.lineTextForBufferRow(8)).toBe("  ")
+
         it "does not indent the line preceding the newline", ->
           editor.setCursorBufferPosition([2, 0])
           editor.insertText('  var this-line-should-be-indented-more\n')

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -244,14 +244,18 @@ class LanguageMode
   # bufferRow - A {Number} indicating the buffer row
   #
   # Returns a {Number}.
-  suggestedIndentForBufferRow: (bufferRow) ->
+  suggestedIndentForBufferRow: (bufferRow, options) ->
     currentIndentLevel = @editor.indentationForBufferRow(bufferRow)
     scopeDescriptor = @editor.scopeDescriptorForBufferPosition([bufferRow, 0])
     return currentIndentLevel unless increaseIndentRegex = @increaseIndentRegexForScopeDescriptor(scopeDescriptor)
 
     currentLine = @buffer.lineForRow(bufferRow)
-    precedingRow = @buffer.previousNonBlankRow(bufferRow)
-    return 0 unless precedingRow?
+    if options?.skipBlankLines ? true
+      precedingRow = @buffer.previousNonBlankRow(bufferRow)
+      return 0 unless precedingRow?
+    else
+      precedingRow = bufferRow - 1
+      return currentIndentLevel if precedingRow < 0
 
     precedingLine = @buffer.lineForRow(precedingRow)
     desiredIndentLevel = @editor.indentationForBufferRow(precedingRow)
@@ -285,7 +289,7 @@ class LanguageMode
   # bufferRow - The row {Number}.
   # options - An options {Object} to pass through to {TextEditor::setIndentationForBufferRow}.
   autoIndentBufferRow: (bufferRow, options) ->
-    indentLevel = @suggestedIndentForBufferRow(bufferRow)
+    indentLevel = @suggestedIndentForBufferRow(bufferRow, options)
     @editor.setIndentationForBufferRow(bufferRow, indentLevel, options)
 
   # Given a buffer row, this decreases the indentation.

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -376,7 +376,7 @@ class Selection extends Model
       @editor.autoIndentBufferRow(row) for row, i in newBufferRange.getRows() when i > 0
     else if options.autoIndentNewline and text == '\n'
       currentIndentation = @editor.indentationForBufferRow(newBufferRange.start.row)
-      @editor.autoIndentBufferRow(newBufferRange.end.row, preserveLeadingWhitespace: true)
+      @editor.autoIndentBufferRow(newBufferRange.end.row, preserveLeadingWhitespace: true, skipBlankLines: false)
       if @editor.indentationForBufferRow(newBufferRange.end.row) < currentIndentation
         @editor.setIndentationForBufferRow(newBufferRange.end.row, currentIndentation)
     else if options.autoDecreaseIndent and NonWhitespaceRegExp.test(text)


### PR DESCRIPTION
When explicitly auto-indenting and when pasting, indentation is based
on the previous non-blank line. When simply inserting newlines,
the previous line is used, even if it is blank.
