### PR TITLE
Add special paste behavior when copying/cutting w/ no selection

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2747,6 +2747,39 @@ describe "TextEditor", ->
               expect(editor.lineTextForBufferRow(0)).toBe "var quicksort"
               expect(editor.lineTextForBufferRow(1)).toBe "sort = function () {"
 
+        describe "when a full line was cut", ->
+          beforeEach ->
+            editor.setCursorBufferPosition([2, 13])
+            editor.cutSelectedText()
+            editor.setCursorBufferPosition([2, 13])
+
+          it "pastes the line above the cursor and retains the cursor's column", ->
+            editor.pasteText()
+            expect(editor.lineTextForBufferRow(2)).toBe("    if (items.length <= 1) return items;")
+            expect(editor.lineTextForBufferRow(3)).toBe("    var pivot = items.shift(), current, left = [], right = [];")
+            expect(editor.getCursorBufferPosition()).toEqual([3, 13])
+
+        describe "when a full line was copied", ->
+          beforeEach ->
+            editor.setCursorBufferPosition([2, 13])
+            editor.copySelectedText()
+
+          describe "when there is a selection", ->
+            it "overwrites the selection as with any copied text", ->
+              editor.setSelectedBufferRange([[1, 2], [1, Infinity]])
+              editor.pasteText()
+              expect(editor.lineTextForBufferRow(1)).toBe("  if (items.length <= 1) return items;")
+              expect(editor.lineTextForBufferRow(2)).toBe("  ")
+              expect(editor.lineTextForBufferRow(3)).toBe("    if (items.length <= 1) return items;")
+              expect(editor.getCursorBufferPosition()).toEqual([2, 2])
+
+          describe "when there is no selection", ->
+            it "pastes the line above the cursor and retains the cursor's column", ->
+              editor.pasteText()
+              expect(editor.lineTextForBufferRow(2)).toBe("    if (items.length <= 1) return items;")
+              expect(editor.lineTextForBufferRow(3)).toBe("    if (items.length <= 1) return items;")
+              expect(editor.getCursorBufferPosition()).toEqual([3, 13])
+
     describe ".indentSelectedRows()", ->
       describe "when nothing is selected", ->
         describe "when softTabs is enabled", ->

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -546,8 +546,8 @@ class Selection extends Model
   # Public: Copies the selection to the clipboard and then deletes it.
   #
   # * `maintainClipboard` {Boolean} (default: false) See {::copy}
-  cut: (maintainClipboard=false) ->
-    @copy(maintainClipboard)
+  cut: (maintainClipboard=false, fullLine=false) ->
+    @copy(maintainClipboard, fullLine)
     @delete()
 
   # Public: Copies the current selection to the clipboard.
@@ -556,7 +556,7 @@ class Selection extends Model
   #   is created to store each content copied to the clipboard. The clipboard
   #   `text` still contains the concatenation of the clipboard with the
   #   current selection. (default: false)
-  copy: (maintainClipboard=false) ->
+  copy: (maintainClipboard=false, fullLine=false) ->
     return if @isEmpty()
     selectionText = @editor.buffer.getTextInRange(@getBufferRange())
     selectionIndentation = @editor.indentationForBufferRow(@getBufferRange().start.row)
@@ -569,10 +569,17 @@ class Selection extends Model
           text: clipboardText,
           indentBasis: metadata.indentBasis,
         }]
-      metadata.selections.push(text: selectionText, indentBasis: selectionIndentation)
+      metadata.selections.push({
+        text: selectionText,
+        indentBasis: selectionIndentation,
+        fullLine: fullLine
+      })
       atom.clipboard.write([clipboardText, selectionText].join("\n"), metadata)
     else
-      atom.clipboard.write(selectionText, {indentBasis: selectionIndentation})
+      atom.clipboard.write(selectionText, {
+        indentBasis: selectionIndentation,
+        fullLine: fullLine
+      })
 
   # Public: Creates a fold containing the current selection.
   fold: ->


### PR DESCRIPTION
Addresses an issue pointed out by @dsandstrom in #4148.

@dsandstrom, @unDemian, if you wish to integrate this change into [clipboard-history](https://github.com/unDemian/clipboard-history), note that metadata field is called `fullLine`, not `fullline` as in @tekkub's [cut-line](https://github.com/tekkub/cut-line) package. I don't mean to be needlessly incompatible, but we always use camel-case identifiers, and I didn't want to break with that convention.
