### PR TITLE
Write text async to selection clipboard

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -2686,6 +2686,10 @@ describe "TextEditorComponent", ->
 
   describe "middle mouse paste on Linux", ->
     it "pastes the previously selected text", ->
+      spyOn(require('ipc'), 'send').andCallFake (eventName, selectedText) ->
+        if eventName is 'write-text-to-selection-clipboard'
+          require('clipboard').writeText(selectedText, 'selection')
+
       atom.clipboard.write('')
       component.listenForMiddleMousePaste()
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -238,6 +238,11 @@ class AtomApplication
       win = BrowserWindow.fromWebContents(event.sender)
       win[method](args...)
 
+    clipboard = null
+    ipc.on 'write-text-to-selection-clipboard', (event, selectedText) ->
+      clipboard ?= require 'clipboard'
+      clipboard.writeText(selectedText)
+
   # Public: Executes the given command.
   #
   # If it isn't handled globally, delegate to the currently focused window.

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -241,7 +241,7 @@ class AtomApplication
     clipboard = null
     ipc.on 'write-text-to-selection-clipboard', (event, selectedText) ->
       clipboard ?= require 'clipboard'
-      clipboard.writeText(selectedText)
+      clipboard.writeText(selectedText, 'selection')
 
   # Public: Executes the given command.
   #

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -445,6 +445,9 @@ TextEditorComponent = React.createClass
 
     @subscribe @props.editor.onDidChangeSelectionRange =>
       if selectedText = @props.editor.getSelectedText()
+        # This uses ipc.send instead of clipboard.writeText because
+        # clipboard.writeText is a sync ipc call on Linux and that
+        # will slow down selections.
         ipc.send('write-text-to-selection-clipboard', selectedText)
 
   observeConfig: ->

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -6,6 +6,7 @@ scrollbarStyle = require 'scrollbar-style'
 {Range, Point} = require 'text-buffer'
 grim = require 'grim'
 {CompositeDisposable} = require 'event-kit'
+ipc = require 'ipc'
 
 GutterComponent = require './gutter-component'
 InputComponent = require './input-component'
@@ -444,6 +445,7 @@ TextEditorComponent = React.createClass
 
     @subscribe @props.editor.onDidChangeSelectionRange =>
       if selectedText = @props.editor.getSelectedText()
+        ipc.send('write-text-to-selection-clipboard', selectedText)
         clipboard.writeText(selectedText, 'selection')
 
   observeConfig: ->

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -446,7 +446,6 @@ TextEditorComponent = React.createClass
     @subscribe @props.editor.onDidChangeSelectionRange =>
       if selectedText = @props.editor.getSelectedText()
         ipc.send('write-text-to-selection-clipboard', selectedText)
-        clipboard.writeText(selectedText, 'selection')
 
   observeConfig: ->
     @subscribe atom.config.observe 'editor.useHardwareAcceleration', @setUseHardwareAcceleration


### PR DESCRIPTION
Looks like Atom Shell's clipboard API uses sync ipc calls on Linux which causes the writing of selected text to the selection clipboard to add a non-trivial amount of time to the selection change event dispatch.

https://github.com/atom/atom-shell/blob/879de423728832cece6e798e3cbbb46e61738a16/atom/common/api/lib/clipboard.coffee#L3

Regarding this now being async, in my testing, this didn't change the behavior of middle mouse paste on Linux. The selection was still written to the clipboard before I could hit the paste button quick enough to paste the wrong text. But if this does present issues it could wait until the text is written before pasting the text on middle click.

Closes #4238
