### PR TITLE
Remove space pen views from docs

### DIFF
--- a/build/tasks/docs-task.coffee
+++ b/build/tasks/docs-task.coffee
@@ -6,12 +6,18 @@ _ = require 'underscore-plus'
 donna = require 'donna'
 tello = require 'tello'
 
+moduleBlacklist = [
+  'space-pen'
+]
+
 module.exports = (grunt) ->
   getClassesToInclude = ->
     modulesPath = path.resolve(__dirname, '..', '..', 'node_modules')
     classes = {}
     fs.traverseTreeSync modulesPath, (modulePath) ->
       return false if modulePath.match(/node_modules/g).length > 1 # dont need the dependencies of the dependencies
+      for moduleName in moduleBlacklist
+        return false if path.basename(modulePath) is moduleName
       return true unless path.basename(modulePath) is 'package.json'
       return true unless fs.isFileSync(modulePath)
 

--- a/build/tasks/docs-task.coffee
+++ b/build/tasks/docs-task.coffee
@@ -16,8 +16,7 @@ module.exports = (grunt) ->
     classes = {}
     fs.traverseTreeSync modulesPath, (modulePath) ->
       return false if modulePath.match(/node_modules/g).length > 1 # dont need the dependencies of the dependencies
-      for moduleName in moduleBlacklist
-        return false if path.basename(modulePath) is moduleName
+      return false if path.basename(modulePath) in moduleBlacklist
       return true unless path.basename(modulePath) is 'package.json'
       return true unless fs.isFileSync(modulePath)
 

--- a/src/scroll-view.coffee
+++ b/src/scroll-view.coffee
@@ -1,6 +1,6 @@
 {View} = require './space-pen-extensions'
 
-# Extended: Represents a view that scrolls.
+# Deprecated: Represents a view that scrolls.
 #
 # Handles several core events to update scroll position:
 #

--- a/src/select-list-view.coffee
+++ b/src/select-list-view.coffee
@@ -2,7 +2,7 @@
 TextEditorView = require './text-editor-view'
 fuzzyFilter = require('fuzzaldrin').filter
 
-# Essential: Provides a view that renders a list of items with an editor that
+# Deprecated: Provides a view that renders a list of items with an editor that
 # filters the items. Used by many packages such as the fuzzy-finder,
 # command-palette, symbols-view and autocomplete.
 #

--- a/src/text-editor-view.coffee
+++ b/src/text-editor-view.coffee
@@ -7,7 +7,7 @@ TextEditorElement = require './text-editor-element'
 TextEditorComponent = require './text-editor-component'
 {deprecate} = require 'grim'
 
-# Public: Represents the entire visual pane in Atom.
+# Deprecated: Represents the entire visual pane in Atom.
 #
 # The TextEditorView manages the {TextEditor}, which manages the file buffers.
 # `TextEditorView` is intentionally sparse. Most of the things you'll want

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -12,7 +12,7 @@ PaneView = require './pane-view'
 PaneContainerView = require './pane-container-view'
 TextEditor = require './text-editor'
 
-# Extended: The top-level view for the entire window. An instance of this class is
+# Deprecated: The top-level view for the entire window. An instance of this class is
 # available via the `atom.workspaceView` global.
 #
 # It is backed by a model object, an instance of {Workspace}, which is available


### PR DESCRIPTION
They are now available at https://github.com/atom/space-pen and https://github.com/atom/atom-space-pen-views/blob/master/lib/scroll-view.coffee but will not be included in core in the 1.0.
