### PR TITLE
Replace jQuery-based tooltip API with atom.tooltips global

### DIFF
--- a/spec/tooltip-manager-spec.coffee
+++ b/spec/tooltip-manager-spec.coffee
@@ -64,3 +64,15 @@ describe "TooltipManager", ->
           hover element, ->
             tooltipElement = document.body.querySelector(".tooltip")
             expect(tooltipElement).toHaveText "⌃X ⌃Y"
+
+    describe "when .dispose() is called on the returned disposable", ->
+      it "no longer displays the tooltip on hover", ->
+        disposable = manager.add element, title: "Title"
+
+        hover element, ->
+          expect(document.body.querySelector(".tooltip")).toHaveText("Title")
+
+        disposable.dispose()
+
+        hover element, ->
+          expect(document.body.querySelector(".tooltip")).toBeNull()

--- a/spec/tooltip-manager-spec.coffee
+++ b/spec/tooltip-manager-spec.coffee
@@ -1,0 +1,54 @@
+TooltipManager = require '../src/tooltip-manager'
+{$} = require '../src/space-pen-extensions'
+
+describe "TooltipManager", ->
+  [manager, element] = []
+
+  beforeEach ->
+    manager = new TooltipManager
+    element = document.createElement('div')
+    element.classList.add('foo')
+    jasmine.attachToDOM(element)
+
+  hover = (element, fn) ->
+    $(element).trigger 'mouseenter'
+    advanceClock(manager.defaults.delay.show)
+    fn()
+    $(element).trigger 'mouseleave'
+    advanceClock(manager.defaults.delay.hide)
+
+  describe "::add(target, options)", ->
+    describe "when the target is an element", ->
+      it "creates a tooltip based on the given options when hovering over the target element", ->
+        manager.add element, title: "Title"
+        hover element, ->
+          expect(document.body.querySelector(".tooltip")).toHaveText("Title")
+
+    describe "when the target is a selector", ->
+      it "creates a tooltip based on the given options when hovering over an element matching the target selector", ->
+        manager.add ".foo", title: "Title"
+        hover element, ->
+          expect(document.body.querySelector(".tooltip")).toHaveText("Title")
+
+    describe "when a keyBindingCommand is specified", ->
+      describe "when a title is specified", ->
+        it "appends the key binding corresponding to the command to the title", ->
+          atom.keymaps.add 'test',
+            '.bar': 'ctrl-x ctrl-z': 'test-command'
+            '.foo': 'ctrl-x ctrl-y': 'test-command'
+
+          manager.add element, title: "Title", keyBindingCommand: 'test-command'
+
+          hover element, ->
+            tooltipElement = document.body.querySelector(".tooltip")
+            expect(tooltipElement).toHaveText "Title ⌃X ⌃Y"
+
+      describe "when no title is specified", ->
+        it "shows the key binding corresponding to the command alone", ->
+          atom.keymaps.add 'test', '.foo': 'ctrl-x ctrl-y': 'test-command'
+
+          manager.add element, keyBindingCommand: 'test-command'
+
+          hover element, ->
+            tooltipElement = document.body.querySelector(".tooltip")
+            expect(tooltipElement).toHaveText "⌃X ⌃Y"

--- a/spec/tooltip-manager-spec.coffee
+++ b/spec/tooltip-manager-spec.coffee
@@ -24,12 +24,6 @@ describe "TooltipManager", ->
         hover element, ->
           expect(document.body.querySelector(".tooltip")).toHaveText("Title")
 
-    describe "when the target is a selector", ->
-      it "creates a tooltip based on the given options when hovering over an element matching the target selector", ->
-        manager.add ".foo", title: "Title"
-        hover element, ->
-          expect(document.body.querySelector(".tooltip")).toHaveText("Title")
-
     describe "when a keyBindingCommand is specified", ->
       describe "when a title is specified", ->
         it "appends the key binding corresponding to the command to the title", ->

--- a/spec/tooltip-manager-spec.coffee
+++ b/spec/tooltip-manager-spec.coffee
@@ -34,8 +34,8 @@ describe "TooltipManager", ->
       describe "when a title is specified", ->
         it "appends the key binding corresponding to the command to the title", ->
           atom.keymaps.add 'test',
-            '.bar': 'ctrl-x ctrl-z': 'test-command'
             '.foo': 'ctrl-x ctrl-y': 'test-command'
+            '.bar': 'ctrl-x ctrl-z': 'test-command'
 
           manager.add element, title: "Title", keyBindingCommand: 'test-command'
 
@@ -48,6 +48,18 @@ describe "TooltipManager", ->
           atom.keymaps.add 'test', '.foo': 'ctrl-x ctrl-y': 'test-command'
 
           manager.add element, keyBindingCommand: 'test-command'
+
+          hover element, ->
+            tooltipElement = document.body.querySelector(".tooltip")
+            expect(tooltipElement).toHaveText "⌃X ⌃Y"
+
+      describe "when a keyBindingTarget is specified", ->
+        it "looks up the key binding relative to the target", ->
+          atom.keymaps.add 'test',
+            '.bar': 'ctrl-x ctrl-z': 'test-command'
+            '.foo': 'ctrl-x ctrl-y': 'test-command'
+
+          manager.add element, keyBindingCommand: 'test-command', keyBindingTarget: element
 
           hover element, ->
             tooltipElement = document.body.querySelector(".tooltip")

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -125,6 +125,9 @@ class Atom extends Model
   # Public: A {KeymapManager} instance
   keymaps: null
 
+  # Public: A {TooltipManager} instance
+  tooltips: null
+
   # Public: A {Project} instance
   project: null
 
@@ -201,6 +204,7 @@ class Atom extends Model
     KeymapManager = require './keymap-extensions'
     ViewRegistry = require './view-registry'
     CommandRegistry = require './command-registry'
+    TooltipManager = require './tooltip-manager'
     PackageManager = require './package-manager'
     Clipboard = require './clipboard'
     Syntax = require './syntax'
@@ -226,6 +230,7 @@ class Atom extends Model
     @config = new Config({configDirPath, resourcePath})
     @keymaps = new KeymapManager({configDirPath, resourcePath})
     @keymap = @keymaps # Deprecated
+    @tooltips = new TooltipManager
     @commands = new CommandRegistry
     @views = new ViewRegistry
     @packages = new PackageManager({devMode, configDirPath, resourcePath, safeMode})

--- a/src/tooltip-manager.coffee
+++ b/src/tooltip-manager.coffee
@@ -14,10 +14,9 @@ class TooltipManager
     placement: 'auto top'
     viewportPadding: 2
 
-  # Essential: Add a tooltip to the given element or all elements matching the
-  # given selector.
+  # Essential: Add a tooltip to the given element.
   #
-  # * `target` An `HTMLElement` or {String} containing a selector.
+  # * `target` An `HTMLElement`
   # * `options` See http://getbootstrap.com/javascript/#tooltips for a full list
   #   of options. You can also supply the following additional options:
   #   * `keyBindingCommand` A {String} containing a command name. If you specify
@@ -37,10 +36,6 @@ class TooltipManager
         options.title += " " + getKeystroke(bindings)
       else
         options.title = getKeystroke(bindings)
-
-    if typeof target is 'string'
-      options.selector = target
-      target = document.body
 
     $target = $(target)
     $target.tooltip(_.defaults(options, @defaults))

--- a/src/tooltip-manager.coffee
+++ b/src/tooltip-manager.coffee
@@ -1,0 +1,45 @@
+_ = require 'underscore-plus'
+{$} = require './space-pen-extensions'
+
+module.exports =
+class TooltipManager
+  defaults:
+    delay:
+      show: 1000
+      hide: 100
+    container: 'body'
+    html: true
+    placement: 'auto top'
+    viewportPadding: 2
+
+  add: (target, options) ->
+    requireBootstrapTooltip()
+
+    {keyBindingCommand} = options
+
+    if keyBindingCommand?
+      keyBindingTarget = target unless typeof target is 'string'
+      bindings = atom.keymaps.findKeyBindings(command: keyBindingCommand, target: keyBindingTarget)
+      if options.title?
+        options.title += " " + getKeystroke(bindings)
+      else
+        options.title = getKeystroke(bindings)
+
+    if typeof target is 'string'
+      options.selector = target
+      target = document.body
+
+    $(target).tooltip(_.defaults(options, @defaults))
+
+humanizeKeystrokes = (keystroke) ->
+  keystrokes = keystroke.split(' ')
+  keystrokes = (_.humanizeKeystroke(stroke) for stroke in keystrokes)
+  keystrokes.join(' ')
+
+getKeystroke = (bindings) ->
+  if bindings?.length
+    "<span class=\"keystroke\">#{humanizeKeystrokes(bindings[0].keystrokes)}</span>"
+  else
+
+requireBootstrapTooltip = _.once ->
+  atom.requireWithGlobals('bootstrap/js/tooltip', {jQuery: $})

--- a/src/tooltip-manager.coffee
+++ b/src/tooltip-manager.coffee
@@ -1,6 +1,7 @@
 _ = require 'underscore-plus'
 {$} = require './space-pen-extensions'
 
+# Essential: Associates tooltips with HTML elements or selectors.
 module.exports =
 class TooltipManager
   defaults:
@@ -12,6 +13,18 @@ class TooltipManager
     placement: 'auto top'
     viewportPadding: 2
 
+  # Essential: Add a tooltip to the given element or all elements matching the
+  # given selector.
+  #
+  # * `target` An `HTMLElement` or {String} containing a selector.
+  # * `options` See http://getbootstrap.com/javascript/#tooltips for a full list
+  #   of options. You can also supply the following additional options:
+  #   * `keyBindingCommand` A {String} containing a command name. If you specify
+  #     this option and a key binding exists that matches the command, it will
+  #     be appended to the title or rendered alone if no title is specified.
+  #   * `keyBindingTarget` An `HTMLElement` on which to look up the key binding.
+  #     If this option is not supplied, the first of all matching key bindings
+  #     for the given command will be rendered.
   add: (target, options) ->
     requireBootstrapTooltip()
 

--- a/src/tooltip-manager.coffee
+++ b/src/tooltip-manager.coffee
@@ -25,6 +25,9 @@ class TooltipManager
   #   * `keyBindingTarget` An `HTMLElement` on which to look up the key binding.
   #     If this option is not supplied, the first of all matching key bindings
   #     for the given command will be rendered.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to remove the
+  # tooltip.
   add: (target, options) ->
     requireBootstrapTooltip()
 

--- a/src/tooltip-manager.coffee
+++ b/src/tooltip-manager.coffee
@@ -15,10 +15,9 @@ class TooltipManager
   add: (target, options) ->
     requireBootstrapTooltip()
 
-    {keyBindingCommand} = options
+    {keyBindingCommand, keyBindingTarget} = options
 
     if keyBindingCommand?
-      keyBindingTarget = target unless typeof target is 'string'
       bindings = atom.keymaps.findKeyBindings(command: keyBindingCommand, target: keyBindingTarget)
       if options.title?
         options.title += " " + getKeystroke(bindings)

--- a/src/tooltip-manager.coffee
+++ b/src/tooltip-manager.coffee
@@ -1,4 +1,5 @@
 _ = require 'underscore-plus'
+{Disposable} = require 'event-kit'
 {$} = require './space-pen-extensions'
 
 # Essential: Associates tooltips with HTML elements or selectors.
@@ -41,7 +42,10 @@ class TooltipManager
       options.selector = target
       target = document.body
 
-    $(target).tooltip(_.defaults(options, @defaults))
+    $target = $(target)
+    $target.tooltip(_.defaults(options, @defaults))
+
+    new Disposable -> $target.tooltip('destroy')
 
 humanizeKeystrokes = (keystroke) ->
   keystrokes = keystroke.split(' ')


### PR DESCRIPTION
It still uses Bootstrap underneath the hood to save us the trouble of implementing tooltips, but the new API works with raw DOM nodes and does not require any access to jQuery. Since we're no longer exporting the version of jQuery that has the tooltip API, this is the only way to provide the tooltip facility now.
