### PR TITLE
Fix memory leaks introduced by changes for API freeze

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "season": "^1.0.2",
     "semver": "2.2.1",
     "serializable": "^1",
-    "space-pen": "3.8.1",
+    "space-pen": "3.8.2",
     "temp": "0.7.0",
     "text-buffer": "^3.6.1",
     "theorist": "^1.0.2",

--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -95,7 +95,7 @@ class PaneElement extends HTMLElement
 
   itemRemoved: ({item, index, destroyed}) ->
     if viewToRemove = @model.getView(item)
-      callRemoveHooks(viewToRemove)
+      callRemoveHooks(viewToRemove) if destroyed
       viewToRemove.remove()
 
   paneDestroyed: ->

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -199,7 +199,6 @@ TextEditorComponent = React.createClass
   componentWillUnmount: ->
     {editor, hostElement} = @props
 
-    hostElement.__spacePenView.trigger 'editor:will-be-removed', [hostElement.__spacePenView]
     @unsubscribe()
     @scopedConfigSubscriptions.dispose()
     window.removeEventListener 'resize', @requestHeightAndWidthMeasurement

--- a/src/text-editor-view.coffee
+++ b/src/text-editor-view.coffee
@@ -138,6 +138,7 @@ class TextEditorView extends View
 
   beforeRemove: ->
     @trigger 'editor:detached', [this]
+    @trigger 'editor:will-be-removed', [this]
     @attached = false
 
   remove: (selector, keepData) ->


### PR DESCRIPTION
Some memory leaks have slipped through during the various contortions required for the API freeze:
- The updates to `GitRepository` subscriptions introduced a bug that caused to not unsubscribe correctly from `TextBuffer`s when they were destroyed.
- The jQuery shims weren't having `cleanData` called on them when the underlying custom element was removed, causing handlers which are held by global jQuery data structures to leak.
