### PR TITLE
Rename atom.syntax to atom.grammars

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -349,8 +349,8 @@ describe "PackageManager", ->
             atom.packages.activatePackage('package-with-grammars')
 
           runs ->
-            expect(atom.syntax.selectGrammar('a.alot').name).toBe 'Alot'
-            expect(atom.syntax.selectGrammar('a.alittle').name).toBe 'Alittle'
+            expect(atom.grammars.selectGrammar('a.alot').name).toBe 'Alot'
+            expect(atom.grammars.selectGrammar('a.alittle').name).toBe 'Alittle'
 
       describe "scoped-property loading", ->
         it "loads the scoped properties", ->
@@ -362,13 +362,13 @@ describe "PackageManager", ->
 
     describe "converted textmate packages", ->
       it "loads the package's grammars", ->
-        expect(atom.syntax.selectGrammar("file.rb").name).toBe "Null Grammar"
+        expect(atom.grammars.selectGrammar("file.rb").name).toBe "Null Grammar"
 
         waitsForPromise ->
           atom.packages.activatePackage('language-ruby')
 
         runs ->
-          expect(atom.syntax.selectGrammar("file.rb").name).toBe "Ruby"
+          expect(atom.grammars.selectGrammar("file.rb").name).toBe "Ruby"
 
       it "loads the translated scoped properties", ->
         expect(atom.config.get(['.source.ruby'], 'editor.commentStart')).toBeUndefined()
@@ -454,8 +454,8 @@ describe "PackageManager", ->
 
         runs ->
           atom.packages.deactivatePackage('package-with-grammars')
-          expect(atom.syntax.selectGrammar('a.alot').name).toBe 'Null Grammar'
-          expect(atom.syntax.selectGrammar('a.alittle').name).toBe 'Null Grammar'
+          expect(atom.grammars.selectGrammar('a.alot').name).toBe 'Null Grammar'
+          expect(atom.grammars.selectGrammar('a.alittle').name).toBe 'Null Grammar'
 
       it "removes the package's keymaps", ->
         waitsForPromise ->
@@ -490,15 +490,15 @@ describe "PackageManager", ->
 
     describe "textmate packages", ->
       it "removes the package's grammars", ->
-        expect(atom.syntax.selectGrammar("file.rb").name).toBe "Null Grammar"
+        expect(atom.grammars.selectGrammar("file.rb").name).toBe "Null Grammar"
 
         waitsForPromise ->
           atom.packages.activatePackage('language-ruby')
 
         runs ->
-          expect(atom.syntax.selectGrammar("file.rb").name).toBe "Ruby"
+          expect(atom.grammars.selectGrammar("file.rb").name).toBe "Ruby"
           atom.packages.deactivatePackage('language-ruby')
-          expect(atom.syntax.selectGrammar("file.rb").name).toBe "Null Grammar"
+          expect(atom.grammars.selectGrammar("file.rb").name).toBe "Null Grammar"
 
       it "removes the package's scoped properties", ->
         waitsForPromise ->
@@ -527,7 +527,7 @@ describe "PackageManager", ->
       atom.packages.unloadPackages()
 
       GrammarRegistry = require '../src/grammar-registry'
-      atom.syntax = window.syntax = new GrammarRegistry()
+      atom.grammars = window.syntax = new GrammarRegistry()
 
     it "activates all the packages, and none of the themes", ->
       atom.packages.activate()

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -526,8 +526,8 @@ describe "PackageManager", ->
       atom.packages.deactivatePackages()
       atom.packages.unloadPackages()
 
-      Syntax = require '../src/syntax'
-      atom.syntax = window.syntax = new Syntax()
+      GrammarRegistry = require '../src/grammar-registry'
+      atom.syntax = window.syntax = new GrammarRegistry()
 
     it "activates all the packages, and none of the themes", ->
       atom.packages.activate()

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -82,7 +82,7 @@ beforeEach ->
   serializedWindowState = null
 
   spyOn(atom, 'saveSync')
-  atom.syntax.clearGrammarOverrides()
+  atom.grammars.clearGrammarOverrides()
 
   spy = spyOn(atom.packages, 'resolvePackagePath').andCallFake (packageName) ->
     if specPackageName and packageName is specPackageName
@@ -150,7 +150,7 @@ afterEach ->
 
   jasmine.unspy(atom, 'saveSync')
   ensureNoPathSubscriptions()
-  atom.syntax.clearObservers()
+  atom.grammars.clearObservers()
   waits(0) # yield to ui thread to make screen update more frequently
 
 ensureNoPathSubscriptions = ->

--- a/spec/syntax-spec.coffee
+++ b/spec/syntax-spec.coffee
@@ -23,10 +23,10 @@ describe "the `syntax` global", ->
   describe "serialization", ->
     it "remembers grammar overrides by path", ->
       filePath = '/foo/bar/file.js'
-      expect(atom.syntax.selectGrammar(filePath).name).not.toBe 'Ruby'
-      atom.syntax.setGrammarOverrideForPath(filePath, 'source.ruby')
-      syntax2 = atom.deserializers.deserialize(atom.syntax.serialize())
-      syntax2.addGrammar(grammar) for grammar in atom.syntax.grammars when grammar isnt atom.syntax.nullGrammar
+      expect(atom.grammars.selectGrammar(filePath).name).not.toBe 'Ruby'
+      atom.grammars.setGrammarOverrideForPath(filePath, 'source.ruby')
+      syntax2 = atom.deserializers.deserialize(atom.grammars.serialize())
+      syntax2.addGrammar(grammar) for grammar in atom.grammars.grammars when grammar isnt atom.grammars.nullGrammar
       expect(syntax2.selectGrammar(filePath).name).toBe 'Ruby'
 
   describe ".selectGrammar(filePath)", ->
@@ -35,15 +35,15 @@ describe "the `syntax` global", ->
         atom.packages.activatePackage('language-git')
 
       runs ->
-        expect(atom.syntax.selectGrammar("file.js").name).toBe "JavaScript" # based on extension (.js)
-        expect(atom.syntax.selectGrammar(path.join(temp.dir, '.git', 'config')).name).toBe "Git Config" # based on end of the path (.git/config)
-        expect(atom.syntax.selectGrammar("Rakefile").name).toBe "Ruby" # based on the file's basename (Rakefile)
-        expect(atom.syntax.selectGrammar("curb").name).toBe "Null Grammar"
-        expect(atom.syntax.selectGrammar("/hu.git/config").name).toBe "Null Grammar"
+        expect(atom.grammars.selectGrammar("file.js").name).toBe "JavaScript" # based on extension (.js)
+        expect(atom.grammars.selectGrammar(path.join(temp.dir, '.git', 'config')).name).toBe "Git Config" # based on end of the path (.git/config)
+        expect(atom.grammars.selectGrammar("Rakefile").name).toBe "Ruby" # based on the file's basename (Rakefile)
+        expect(atom.grammars.selectGrammar("curb").name).toBe "Null Grammar"
+        expect(atom.grammars.selectGrammar("/hu.git/config").name).toBe "Null Grammar"
 
     it "uses the filePath's shebang line if the grammar cannot be determined by the extension or basename", ->
       filePath = require.resolve("./fixtures/shebang")
-      expect(atom.syntax.selectGrammar(filePath).name).toBe "Ruby"
+      expect(atom.grammars.selectGrammar(filePath).name).toBe "Ruby"
 
     it "uses the number of newlines in the first line regex to determine the number of lines to test against", ->
       waitsForPromise ->
@@ -51,28 +51,28 @@ describe "the `syntax` global", ->
 
       runs ->
         fileContent = "first-line\n<html>"
-        expect(atom.syntax.selectGrammar("dummy.coffee", fileContent).name).toBe "CoffeeScript"
+        expect(atom.grammars.selectGrammar("dummy.coffee", fileContent).name).toBe "CoffeeScript"
 
         fileContent = '<?xml version="1.0" encoding="UTF-8"?>'
-        expect(atom.syntax.selectGrammar("grammar.tmLanguage", fileContent).name).toBe "Null Grammar"
+        expect(atom.grammars.selectGrammar("grammar.tmLanguage", fileContent).name).toBe "Null Grammar"
 
         fileContent += '\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
-        expect(atom.syntax.selectGrammar("grammar.tmLanguage", fileContent).name).toBe "Property List (XML)"
+        expect(atom.grammars.selectGrammar("grammar.tmLanguage", fileContent).name).toBe "Property List (XML)"
 
     it "doesn't read the file when the file contents are specified", ->
       filePath = require.resolve("./fixtures/shebang")
       filePathContents = fs.readFileSync(filePath, 'utf8')
       spyOn(fs, 'read').andCallThrough()
-      expect(atom.syntax.selectGrammar(filePath, filePathContents).name).toBe "Ruby"
+      expect(atom.grammars.selectGrammar(filePath, filePathContents).name).toBe "Ruby"
       expect(fs.read).not.toHaveBeenCalled()
 
     it "allows the default grammar to be overridden for a path", ->
       filePath = '/foo/bar/file.js'
-      expect(atom.syntax.selectGrammar(filePath).name).not.toBe 'Ruby'
-      atom.syntax.setGrammarOverrideForPath(filePath, 'source.ruby')
-      expect(atom.syntax.selectGrammar(filePath).name).toBe 'Ruby'
-      atom.syntax.clearGrammarOverrideForPath(filePath)
-      expect(atom.syntax.selectGrammar(filePath).name).not.toBe 'Ruby'
+      expect(atom.grammars.selectGrammar(filePath).name).not.toBe 'Ruby'
+      atom.grammars.setGrammarOverrideForPath(filePath, 'source.ruby')
+      expect(atom.grammars.selectGrammar(filePath).name).toBe 'Ruby'
+      atom.grammars.clearGrammarOverrideForPath(filePath)
+      expect(atom.grammars.selectGrammar(filePath).name).not.toBe 'Ruby'
 
     describe "when multiple grammars have matching fileTypes", ->
       it "selects the grammar with the longest fileType match", ->
@@ -82,8 +82,8 @@ describe "the `syntax` global", ->
           scopeName: 'source1'
           fileTypes: ['test']
         )
-        grammar1 = atom.syntax.loadGrammarSync(grammarPath1)
-        expect(atom.syntax.selectGrammar('more.test', '')).toBe grammar1
+        grammar1 = atom.grammars.loadGrammarSync(grammarPath1)
+        expect(atom.grammars.selectGrammar('more.test', '')).toBe grammar1
 
         grammarPath2 = temp.path(suffix: '.json')
         fs.writeFileSync grammarPath2, JSON.stringify(
@@ -91,44 +91,44 @@ describe "the `syntax` global", ->
           scopeName: 'source2'
           fileTypes: ['test', 'more.test']
         )
-        grammar2 = atom.syntax.loadGrammarSync(grammarPath2)
-        expect(atom.syntax.selectGrammar('more.test', '')).toBe grammar2
+        grammar2 = atom.grammars.loadGrammarSync(grammarPath2)
+        expect(atom.grammars.selectGrammar('more.test', '')).toBe grammar2
 
     describe "when there is no file path", ->
       it "does not throw an exception (regression)", ->
-        expect(-> atom.syntax.selectGrammar(null, '#!/usr/bin/ruby')).not.toThrow()
-        expect(-> atom.syntax.selectGrammar(null, '')).not.toThrow()
-        expect(-> atom.syntax.selectGrammar(null, null)).not.toThrow()
+        expect(-> atom.grammars.selectGrammar(null, '#!/usr/bin/ruby')).not.toThrow()
+        expect(-> atom.grammars.selectGrammar(null, '')).not.toThrow()
+        expect(-> atom.grammars.selectGrammar(null, null)).not.toThrow()
 
   describe ".removeGrammar(grammar)", ->
     it "removes the grammar, so it won't be returned by selectGrammar", ->
-      grammar = atom.syntax.selectGrammar('foo.js')
-      atom.syntax.removeGrammar(grammar)
-      expect(atom.syntax.selectGrammar('foo.js').name).not.toBe grammar.name
+      grammar = atom.grammars.selectGrammar('foo.js')
+      atom.grammars.removeGrammar(grammar)
+      expect(atom.grammars.selectGrammar('foo.js').name).not.toBe grammar.name
 
   describe ".getProperty(scopeDescriptor)", ->
     it "returns the property with the most specific scope selector", ->
-      atom.syntax.addProperties(".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
-      atom.syntax.addProperties(".source .string.quoted.double", foo: bar: baz: 22)
-      atom.syntax.addProperties(".source", foo: bar: baz: 11)
+      atom.grammars.addProperties(".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
+      atom.grammars.addProperties(".source .string.quoted.double", foo: bar: baz: 22)
+      atom.grammars.addProperties(".source", foo: bar: baz: 11)
 
-      expect(atom.syntax.getProperty([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
-      expect(atom.syntax.getProperty([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBe 22
-      expect(atom.syntax.getProperty([".source.js", ".variable.assignment.js"], "foo.bar.baz")).toBe 11
-      expect(atom.syntax.getProperty([".text"], "foo.bar.baz")).toBeUndefined()
+      expect(atom.grammars.getProperty([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
+      expect(atom.grammars.getProperty([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBe 22
+      expect(atom.grammars.getProperty([".source.js", ".variable.assignment.js"], "foo.bar.baz")).toBe 11
+      expect(atom.grammars.getProperty([".text"], "foo.bar.baz")).toBeUndefined()
 
     it "favors the most recently added properties in the event of a specificity tie", ->
-      atom.syntax.addProperties(".source.coffee .string.quoted.single", foo: bar: baz: 42)
-      atom.syntax.addProperties(".source.coffee .string.quoted.double", foo: bar: baz: 22)
+      atom.grammars.addProperties(".source.coffee .string.quoted.single", foo: bar: baz: 42)
+      atom.grammars.addProperties(".source.coffee .string.quoted.double", foo: bar: baz: 22)
 
-      expect(atom.syntax.getProperty([".source.coffee", ".string.quoted.single"], "foo.bar.baz")).toBe 42
-      expect(atom.syntax.getProperty([".source.coffee", ".string.quoted.single.double"], "foo.bar.baz")).toBe 22
+      expect(atom.grammars.getProperty([".source.coffee", ".string.quoted.single"], "foo.bar.baz")).toBe 42
+      expect(atom.grammars.getProperty([".source.coffee", ".string.quoted.single.double"], "foo.bar.baz")).toBe 22
 
   describe ".removeProperties(name)", ->
     it "allows properties to be removed by name", ->
-      atom.syntax.addProperties("a", ".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
-      atom.syntax.addProperties("b", ".source .string.quoted.double", foo: bar: baz: 22)
+      atom.grammars.addProperties("a", ".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
+      atom.grammars.addProperties("b", ".source .string.quoted.double", foo: bar: baz: 22)
 
-      atom.syntax.removeProperties("b")
-      expect(atom.syntax.getProperty([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBeUndefined()
-      expect(atom.syntax.getProperty([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
+      atom.grammars.removeProperties("b")
+      expect(atom.grammars.getProperty([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBeUndefined()
+      expect(atom.grammars.getProperty([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -2532,7 +2532,7 @@ describe "TextEditorComponent", ->
   describe "grammar data attributes", ->
     it "adds and updates the grammar data attribute based on the current grammar", ->
       expect(wrapperNode.dataset.grammar).toBe 'source js'
-      editor.setGrammar(atom.syntax.nullGrammar)
+      editor.setGrammar(atom.grammars.nullGrammar)
       expect(wrapperNode.dataset.grammar).toBe 'text plain null-grammar'
 
   describe "encoding data attributes", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3357,17 +3357,17 @@ describe "TextEditor", ->
     it "switches to the better-matched grammar and re-tokenizes the buffer", ->
       editor.destroy()
 
-      jsGrammar = atom.syntax.selectGrammar('a.js')
-      atom.syntax.removeGrammar(jsGrammar)
+      jsGrammar = atom.grammars.selectGrammar('a.js')
+      atom.grammars.removeGrammar(jsGrammar)
 
       waitsForPromise ->
         atom.workspace.open('sample.js', autoIndent: false).then (o) -> editor = o
 
       runs ->
-        expect(editor.getGrammar()).toBe atom.syntax.nullGrammar
+        expect(editor.getGrammar()).toBe atom.grammars.nullGrammar
         expect(editor.tokenizedLineForScreenRow(0).tokens.length).toBe 1
 
-        atom.syntax.addGrammar(jsGrammar)
+        atom.grammars.addGrammar(jsGrammar)
         expect(editor.getGrammar()).toBe jsGrammar
         expect(editor.tokenizedLineForScreenRow(0).tokens.length).toBeGreaterThan 1
 
@@ -3787,7 +3787,7 @@ describe "TextEditor", ->
 
     it "updates the grammar based on grammar overrides", ->
       expect(editor.getGrammar().name).toBe 'JavaScript'
-      atom.syntax.setGrammarOverrideForPath(editor.getPath(), 'source.coffee')
+      atom.grammars.setGrammarOverrideForPath(editor.getPath(), 'source.coffee')
       editor.reloadGrammar()
       expect(editor.getGrammar().name).toBe 'CoffeeScript'
 
@@ -3805,7 +3805,7 @@ describe "TextEditor", ->
         atom.packages.activatePackage('language-hyperlink')
 
       runs ->
-        grammar = atom.syntax.selectGrammar("text.js")
+        grammar = atom.grammars.selectGrammar("text.js")
         {tokens} = grammar.tokenizeLine("var i; // http://github.com")
 
         expect(tokens[0].value).toBe "var"

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -522,7 +522,7 @@ describe "TokenizedBuffer", ->
         buffer = atom.project.bufferForPathSync()
         buffer.setText "<div class='name'><%= User.find(2).full_name %></div>"
         tokenizedBuffer = new TokenizedBuffer({buffer})
-        tokenizedBuffer.setGrammar(atom.syntax.selectGrammar('test.erb'))
+        tokenizedBuffer.setGrammar(atom.grammars.selectGrammar('test.erb'))
         fullyTokenize(tokenizedBuffer)
 
         {tokens} = tokenizedBuffer.tokenizedLineForRow(0)

--- a/spec/window-spec.coffee
+++ b/spec/window-spec.coffee
@@ -101,7 +101,7 @@ describe "Window", ->
       atom.unloadEditorWindow()
 
       expect(atom.state.workspace).toEqual workspaceState
-      expect(atom.state.syntax).toEqual syntaxState
+      expect(atom.state.grammars).toEqual syntaxState
       expect(atom.state.project).toEqual projectState
       expect(atom.saveSync).toHaveBeenCalled()
 

--- a/spec/window-spec.coffee
+++ b/spec/window-spec.coffee
@@ -95,7 +95,7 @@ describe "Window", ->
   describe ".unloadEditorWindow()", ->
     it "saves the serialized state of the window so it can be deserialized after reload", ->
       workspaceState = atom.workspace.serialize()
-      syntaxState = atom.syntax.serialize()
+      syntaxState = atom.grammars.serialize()
       projectState = atom.project.serialize()
 
       atom.unloadEditorWindow()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -207,7 +207,7 @@ class Atom extends Model
     TooltipManager = require './tooltip-manager'
     PackageManager = require './package-manager'
     Clipboard = require './clipboard'
-    Syntax = require './syntax'
+    GrammarRegistry = require './grammar-registry'
     ThemeManager = require './theme-manager'
     StyleManager = require './style-manager'
     ContextMenuManager = require './context-menu-manager'
@@ -241,7 +241,7 @@ class Atom extends Model
     @menu = new MenuManager({resourcePath})
     @clipboard = new Clipboard()
 
-    @syntax = @deserializers.deserialize(@state.syntax) ? new Syntax()
+    @syntax = @deserializers.deserialize(@state.syntax) ? new GrammarRegistry()
 
     @subscribe @packages.onDidActivateAll => @watchThemes()
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -131,8 +131,8 @@ class Atom extends Model
   # Public: A {Project} instance
   project: null
 
-  # Public: A {Syntax} instance
-  syntax: null
+  # Public: A {GrammarRegistry} instance
+  grammars: null
 
   # Public: A {PackageManager} instance
   packages: null
@@ -241,7 +241,11 @@ class Atom extends Model
     @menu = new MenuManager({resourcePath})
     @clipboard = new Clipboard()
 
-    @syntax = @deserializers.deserialize(@state.syntax) ? new GrammarRegistry()
+    @grammars = @deserializers.deserialize(@state.grammars ? @state.syntax) ? new GrammarRegistry()
+
+    Object.defineProperty this, 'syntax', get: ->
+      deprecate "The atom.syntax global is deprecated. Use atom.grammars instead."
+      @grammars
 
     @subscribe @packages.onDidActivateAll => @watchThemes()
 
@@ -554,7 +558,7 @@ class Atom extends Model
   unloadEditorWindow: ->
     return if not @project and not @workspaceView
 
-    @state.syntax = @syntax.serialize()
+    @state.grammars = @grammars.serialize()
     @state.project = @project.serialize()
     @state.workspace = @workspace.serialize()
     @packages.deactivatePackages()

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -23,9 +23,9 @@ class GrammarRegistry extends FirstMate.GrammarRegistry
   atom.deserializers.add(this)
 
   @deserialize: ({grammarOverridesByPath}) ->
-    syntax = new GrammarRegistry()
-    syntax.grammarOverridesByPath = grammarOverridesByPath
-    syntax
+    grammarRegistry = new GrammarRegistry()
+    grammarRegistry.grammarOverridesByPath = grammarOverridesByPath
+    grammarRegistry
 
   constructor: ->
     super(maxTokensPerLine: 100)

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -35,6 +35,17 @@ class GrammarRegistry extends FirstMate.GrammarRegistry
 
   createToken: (value, scopes) -> new Token({value, scopes})
 
+  # Extended: Select a grammar for the given file path and file contents.
+  #
+  # This picks the best match by checking the file path and contents against
+  # each grammar.
+  #
+  # * `filePath` A {String} file path.
+  # * `fileContents` A {String} of text for the file path.
+  #
+  # Returns a {Grammar}, never null.
+  selectGrammar: (filePath, fileContents) -> super
+
   # Deprecated: Used by settings-view to display snippets for packages
   @::accessor 'propertyStore', ->
     deprecate("Do not use this. Use a public method on Config")

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -2,7 +2,8 @@ _ = require 'underscore-plus'
 {deprecate} = require 'grim'
 {specificity} = require 'clear-cut'
 {Subscriber} = require 'emissary'
-{GrammarRegistry, ScopeSelector} = require 'first-mate'
+FirstMate = require 'first-mate'
+{ScopeSelector} = FirstMate
 ScopedPropertyStore = require 'scoped-property-store'
 PropertyAccessors = require 'property-accessors'
 
@@ -16,13 +17,13 @@ Token = require './token'
 # The Syntax class also contains properties for things such as the
 # language-specific comment regexes. See {::getProperty} for more details.
 module.exports =
-class Syntax extends GrammarRegistry
+class GrammarRegistry extends FirstMate.GrammarRegistry
   PropertyAccessors.includeInto(this)
   Subscriber.includeInto(this)
   atom.deserializers.add(this)
 
   @deserialize: ({grammarOverridesByPath}) ->
-    syntax = new Syntax()
+    syntax = new GrammarRegistry()
     syntax.grammarOverridesByPath = grammarOverridesByPath
     syntax
 

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -12,7 +12,7 @@ Token = require './token'
 
 # Extended: Syntax class holding the grammars used for tokenizing.
 #
-# An instance of this class is always available as the `atom.syntax` global.
+# An instance of this class is always available as the `atom.grammars` global.
 #
 # The Syntax class also contains properties for things such as the
 # language-specific comment regexes. See {::getProperty} for more details.

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -254,7 +254,7 @@ class Package
     grammarPaths = fs.listSync(grammarsDirPath, ['json', 'cson'])
     for grammarPath in grammarPaths
       try
-        grammar = atom.syntax.readGrammarSync(grammarPath)
+        grammar = atom.grammars.readGrammarSync(grammarPath)
         grammar.packageName = @name
         @grammars.push(grammar)
         grammar.activate()
@@ -268,7 +268,7 @@ class Package
     return Q() if @grammarsLoaded
 
     loadGrammar = (grammarPath, callback) =>
-      atom.syntax.readGrammar grammarPath, (error, grammar) =>
+      atom.grammars.readGrammar grammarPath, (error, grammar) =>
         if error?
           console.warn("Failed to load grammar: #{grammarPath}", error.stack ? error)
         else

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -26,8 +26,8 @@ class TokenizedBuffer extends Model
   constructor: ({@buffer, @tabLength, @invisibles}) ->
     @emitter = new Emitter
 
-    @subscribe atom.syntax.onDidAddGrammar(@grammarAddedOrUpdated)
-    @subscribe atom.syntax.onDidUpdateGrammar(@grammarAddedOrUpdated)
+    @subscribe atom.grammars.onDidAddGrammar(@grammarAddedOrUpdated)
+    @subscribe atom.grammars.onDidUpdateGrammar(@grammarAddedOrUpdated)
 
     @subscribe @buffer.preemptDidChange (e) => @handleBufferChange(e)
     @subscribe @buffer.onDidChangePath (@bufferPath) => @reloadGrammar()
@@ -98,7 +98,7 @@ class TokenizedBuffer extends Model
     @emitter.emit 'did-change-grammar', grammar
 
   reloadGrammar: ->
-    if grammar = atom.syntax.selectGrammar(@buffer.getPath(), @buffer.getText())
+    if grammar = atom.grammars.selectGrammar(@buffer.getPath(), @buffer.getText())
       @setGrammar(grammar)
     else
       throw new Error("No grammar found for path: #{path}")

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -105,13 +105,13 @@ class Workspace extends Model
 
       packageNames.push(packageName)
       for scopeName in includedGrammarScopes ? []
-        addGrammar(atom.syntax.grammarForScopeName(scopeName))
+        addGrammar(atom.grammars.grammarForScopeName(scopeName))
 
     editors = @getTextEditors()
     addGrammar(editor.getGrammar()) for editor in editors
 
     if editors.length > 0
-      for grammar in atom.syntax.getGrammars() when grammar.injectionSelector
+      for grammar in atom.grammars.getGrammars() when grammar.injectionSelector
         addGrammar(grammar)
 
     _.uniq(packageNames)


### PR DESCRIPTION
Previously, `atom.syntax` was public but contained no public methods. I was considering removing it entirely when I noticed that we use `atom.syntax.selectGrammar` in some package specs, so I decided to make it officially public. The name `syntax` feels pretty vague now, and in the spirit of focusing our global objects on specific tasks, I think the name `grammars` blends in better with the rest of our global services.
