### PR TITLE
Wrong Reactionary dependence

### DIFF
--- a/exports/atom.coffee
+++ b/exports/atom.coffee
@@ -119,7 +119,7 @@ unless process.env.ATOM_SHELL_INTERNAL_RUN_AS_NODE
 
   Object.defineProperty module.exports, 'Reactionary', get: ->
     deprecate "Please require `reactionary` instead: `Reactionary = require 'reactionary'`. Add `\"reactionary\": \"^0.9\"` to your package dependencies."
-    require 'reactionary'
+    require 'reactionary-atom-fork'
 
 Object.defineProperty module.exports, 'Git', get: ->
   deprecate "Please require `GitRepository` instead of `Git`: `{GitRepository} = require 'atom'`"

--- a/exports/atom.coffee
+++ b/exports/atom.coffee
@@ -118,7 +118,7 @@ unless process.env.ATOM_SHELL_INTERNAL_RUN_AS_NODE
     require 'react-atom-fork'
 
   Object.defineProperty module.exports, 'Reactionary', get: ->
-    deprecate "Please require `reactionary` instead: `Reactionary = require 'reactionary'`. Add `\"reactionary\": \"^0.9\"` to your package dependencies."
+    deprecate "Please require `reactionary-atom-fork` instead: `Reactionary = require 'reactionary-atom-fork'`. Add `\"reactionary-atom-fork\": \"^0.9\"` to your package dependencies."
     require 'reactionary-atom-fork'
 
 Object.defineProperty module.exports, 'Git', get: ->


### PR DESCRIPTION
`exports/atom.coffee` requires package `reactionary` while atom only has `reactionary-atom-fork` as a dependence (https://github.com/atom/atom/blob/master/package.json#L53). Should require `reactionary-atom-fork` instead.

It's clear that `Reactionary` will soon be omitted from atom's module exports, but as long as fallbacks are provided, the `reactionary` package reference should be corrected. :)
