### PR TITLE
Add legacy panel classes for theme support

### DIFF
--- a/spec/panel-container-element-spec.coffee
+++ b/spec/panel-container-element-spec.coffee
@@ -51,6 +51,7 @@ describe "PanelContainerElement", ->
         container.addPanel(panel1)
         expect(element.childNodes.length).toBe 1
         expect(element.childNodes[0]).toHaveClass 'left'
+        expect(element.childNodes[0]).toHaveClass 'tool-panel' # legacy selector support
         expect(element.childNodes[0]).toHaveClass 'panel-left' # legacy selector support
 
         expect(element.childNodes[0].tagName).toBe 'ATOM-PANEL'
@@ -81,6 +82,7 @@ describe "PanelContainerElement", ->
         container.addPanel(panel1)
         expect(element.childNodes.length).toBe 1
         expect(element.childNodes[0]).toHaveClass 'bottom'
+        expect(element.childNodes[0]).toHaveClass 'tool-panel' # legacy selector support
         expect(element.childNodes[0]).toHaveClass 'panel-bottom' # legacy selector support
         expect(element.childNodes[0].tagName).toBe 'ATOM-PANEL'
         expect(panel1.getView()).toHaveClass 'one'
@@ -124,5 +126,8 @@ describe "PanelContainerElement", ->
       container.addPanel(panel1)
 
       expect(panel1.getView()).toHaveClass 'modal'
-      expect(panel1.getView()).toHaveClass 'overlay' # legacy selector support
-      expect(panel1.getView()).toHaveClass 'from-top' # legacy selector support
+
+      # legacy selector support
+      expect(panel1.getView()).not.toHaveClass 'tool-panel'
+      expect(panel1.getView()).toHaveClass 'overlay'
+      expect(panel1.getView()).toHaveClass 'from-top'

--- a/spec/panel-container-element-spec.coffee
+++ b/spec/panel-container-element-spec.coffee
@@ -51,6 +51,7 @@ describe "PanelContainerElement", ->
         container.addPanel(panel1)
         expect(element.childNodes.length).toBe 1
         expect(element.childNodes[0]).toHaveClass 'left'
+        expect(element.childNodes[0]).toHaveClass 'panel-left' # legacy selector support
 
         expect(element.childNodes[0].tagName).toBe 'ATOM-PANEL'
 
@@ -80,6 +81,7 @@ describe "PanelContainerElement", ->
         container.addPanel(panel1)
         expect(element.childNodes.length).toBe 1
         expect(element.childNodes[0]).toHaveClass 'bottom'
+        expect(element.childNodes[0]).toHaveClass 'panel-bottom' # legacy selector support
         expect(element.childNodes[0].tagName).toBe 'ATOM-PANEL'
         expect(panel1.getView()).toHaveClass 'one'
 
@@ -116,3 +118,11 @@ describe "PanelContainerElement", ->
 
       expect(panel1.getView().style.display).not.toBe 'none'
       expect(panel2.getView().style.display).toBe 'none'
+
+    it "adds the 'modal' class to panels", ->
+      panel1 = new Panel({viewRegistry, item: new TestPanelContainerItem()})
+      container.addPanel(panel1)
+
+      expect(panel1.getView()).toHaveClass 'modal'
+      expect(panel1.getView()).toHaveClass 'overlay' # legacy selector support
+      expect(panel1.getView()).toHaveClass 'from-top' # legacy selector support

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -500,4 +500,3 @@ describe "Workspace", ->
 
         expect(panel).toBeDefined()
         expect(addPanelSpy).toHaveBeenCalledWith({panel, index: 0})
-        expect(panel.getClassName()).toBe 'overlay from-top' # the default

--- a/src/panel-container-element.coffee
+++ b/src/panel-container-element.coffee
@@ -18,7 +18,7 @@ class PanelContainerElement extends HTMLElement
     if @model.isModal()
       panelElement.classList.add("overlay", "from-top")
     else
-      panelElement.classList.add("panel-#{@model.getLocation()}")
+      panelElement.classList.add("tool-panel", "panel-#{@model.getLocation()}")
 
     if index >= @childNodes.length
       @appendChild(panelElement)

--- a/src/panel-container-element.coffee
+++ b/src/panel-container-element.coffee
@@ -16,7 +16,7 @@ class PanelContainerElement extends HTMLElement
     panelElement = panel.getView()
     panelElement.classList.add(@model.getLocation())
     if @model.isModal()
-      panelElement.classList.add("overlay")
+      panelElement.classList.add("overlay", "from-top")
     else
       panelElement.classList.add("panel-#{@model.getLocation()}")
 

--- a/src/panel-container-element.coffee
+++ b/src/panel-container-element.coffee
@@ -15,6 +15,11 @@ class PanelContainerElement extends HTMLElement
   panelAdded: ({panel, index}) ->
     panelElement = panel.getView()
     panelElement.classList.add(@model.getLocation())
+    if @model.isModal()
+      panelElement.classList.add("overlay")
+    else
+      panelElement.classList.add("panel-#{@model.getLocation()}")
+
     if index >= @childNodes.length
       @appendChild(panelElement)
     else

--- a/src/panel-element.coffee
+++ b/src/panel-element.coffee
@@ -12,6 +12,7 @@ class PanelElement extends HTMLElement
     @appendChild(view)
     callAttachHooks(view) # for backward compatibility with SpacePen views
 
+    @classList.add("tool-panel")
     @classList.add(@model.getClassName().split(' ')...) if @model.getClassName()?
     @subscriptions.add @model.onDidChangeVisible(@visibleChanged.bind(this))
     @subscriptions.add @model.onDidDestroy(@destroyed.bind(this))

--- a/src/panel-element.coffee
+++ b/src/panel-element.coffee
@@ -12,7 +12,6 @@ class PanelElement extends HTMLElement
     @appendChild(view)
     callAttachHooks(view) # for backward compatibility with SpacePen views
 
-    @classList.add("tool-panel")
     @classList.add(@model.getClassName().split(' ')...) if @model.getClassName()?
     @subscriptions.add @model.onDidChangeVisible(@visibleChanged.bind(this))
     @subscriptions.add @model.onDidDestroy(@destroyed.bind(this))

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -682,8 +682,6 @@ class Workspace extends Model
   #
   # Returns a {Panel}
   addModalPanel: (options={}) ->
-    # TODO: remove these default classes. They are to supoprt existing themes.
-    options.className ?= 'overlay from-top'
     @addPanel('modal', options)
 
   addPanel: (location, options) ->


### PR DESCRIPTION
All panels need to support outdated theme selectors for the time being. We were attempting to add these classes on a per-package basis but that's onerous for package authors. It will be easier to just add them in core and remove them when the time comes.
