### PR TITLE
Integrate notifications into core

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "package-generator": "0.32.0",
     "release-notes": "0.36.0",
     "settings-view": "0.161.0",
-    "snippets": "0.56.0",
+    "snippets": "0.57.0",
     "spell-check": "0.44.0",
     "status-bar": "0.48.0",
     "styleguide": "0.30.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "atomShellVersion": "0.19.4",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "^2.2.2",
+    "atom-keymap": "^2.3.0",
     "bootstrap": "git+https://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",
     "clear-cut": "0.4.0",
     "coffee-script": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "link": "0.26.0",
     "markdown-preview": "0.110.0",
     "metrics": "0.39.0",
-    "notifications": "0.1.0",
+    "notifications": "0.2.0",
     "open-on-github": "0.30.0",
     "package-generator": "0.32.0",
     "release-notes": "0.36.0",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "link": "0.26.0",
     "markdown-preview": "0.110.0",
     "metrics": "0.39.0",
+    "notifications": "0.1.0",
     "open-on-github": "0.30.0",
     "package-generator": "0.32.0",
     "release-notes": "0.36.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "link": "0.26.0",
     "markdown-preview": "0.110.0",
     "metrics": "0.39.0",
-    "notifications": "0.3.0",
+    "notifications": "0.4.0",
     "open-on-github": "0.30.0",
     "package-generator": "0.32.0",
     "release-notes": "0.36.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "link": "0.26.0",
     "markdown-preview": "0.110.0",
     "metrics": "0.39.0",
-    "notifications": "0.2.0",
+    "notifications": "0.3.0",
     "open-on-github": "0.30.0",
     "package-generator": "0.32.0",
     "release-notes": "0.36.0",

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -554,11 +554,13 @@ describe "Config", ->
     describe "when the config file contains invalid cson", ->
       beforeEach ->
         spyOn(console, 'error')
+        spyOn(atom.notifications, 'addError')
         fs.writeFileSync(atom.config.configFilePath, "{{{{{")
 
       it "logs an error to the console and does not overwrite the config file on a subsequent save", ->
         atom.config.loadUserConfig()
         expect(console.error).toHaveBeenCalled()
+        expect(atom.notifications.addError.callCount).toBe 1
         atom.config.set("hair", "blonde") # trigger a save
         expect(atom.config.save).not.toHaveBeenCalled()
 
@@ -691,7 +693,6 @@ describe "Config", ->
             expect(noChangeSpy).not.toHaveBeenCalled()
             expect(atom.config.get(['.source.ruby'], 'foo.bar')).toBe 'baz'
             expect(atom.config.get(['.source.ruby'], 'foo.scoped')).toBe true
-
 
     describe "when the config file changes to omit a setting with a default", ->
       it "resets the setting back to the default", ->

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -249,6 +249,7 @@ class Atom extends Model
     @config = new Config({configDirPath, resourcePath})
     @keymaps = new KeymapManager({configDirPath, resourcePath})
     @keymap = @keymaps # Deprecated
+    @keymaps.subscribeToFileReadFailure()
     @tooltips = new TooltipManager
     @notifications = new NotificationManager
     @commands = new CommandRegistry

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -724,20 +724,25 @@ class Config
       @configFileHasErrors = false
     catch error
       @configFileHasErrors = true
-      console.error "Failed to load user config '#{@configFilePath}'", error.message
-      console.error error.stack
+      @notifyFailure('Failed to load user config', error)
 
   observeUserConfig: ->
     try
       @watchSubscription ?= pathWatcher.watch @configFilePath, (eventType) =>
         @loadUserConfig() if eventType is 'change' and @watchSubscription?
     catch error
-      console.error "Failed to watch user config '#{@configFilePath}'", error.message
-      console.error error.stack
+      @notifyFailure('Failed to watch user config', error)
 
   unobserveUserConfig: ->
     @watchSubscription?.close()
     @watchSubscription = null
+
+  notifyFailure: (errorMessage, error) ->
+    message = "#{errorMessage}"
+    detail = error.stack
+    atom.notifications.addError(message, {detail, closable: true})
+    console.error message
+    console.error detail
 
   save: ->
     allSettings = global: @settings

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -724,7 +724,7 @@ class Config
       @configFileHasErrors = false
     catch error
       @configFileHasErrors = true
-      @notifyFailure('Failed to load user config', error)
+      @notifyFailure('Failed to load config.cson', error)
 
   observeUserConfig: ->
     try

--- a/src/keymap-extensions.coffee
+++ b/src/keymap-extensions.coffee
@@ -23,6 +23,10 @@ KeymapManager::loadUserKeymap = ->
   if fs.isFileSync(userKeymapPath)
     @loadKeymap(userKeymapPath, watch: true, suppressErrors: true)
 
+KeymapManager::subscribeToFileReadFailure = ->
+  this.onDidFailToReadFile (error) ->
+    atom.notifications.addError('Failed to load keymap.cson', {detail: error.stack, closable: true})
+
 # This enables command handlers registered via jQuery to call
 # `.abortKeyBinding()` on the `jQuery.Event` object passed to the handler.
 jQuery.Event::abortKeyBinding = ->

--- a/src/notification.coffee
+++ b/src/notification.coffee
@@ -13,7 +13,7 @@ class Notification
 
   getTimestamp: -> @timestamp
 
-  getDetail: -> @optons.detail
+  getDetail: -> @options.detail
 
   isClosable: ->
     !!@options.closable

--- a/src/notification.coffee
+++ b/src/notification.coffee
@@ -15,6 +15,11 @@ class Notification
 
   getDetail: -> @options.detail
 
+  isEqual: (other) ->
+    @getMessage() == other.getMessage() \
+      and @getType() == other.getType() \
+      and @getDetail() == other.getDetail()
+
   isClosable: ->
     !!@options.closable
 

--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -83,3 +83,4 @@
 // Other
 
 @font-family: 'Lucida Grande', 'Segoe UI', sans-serif;
+@font-family-monospace: Consolas, "Liberation Mono", Menlo, Courier, monospace;

--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -83,4 +83,3 @@
 // Other
 
 @font-family: 'Lucida Grande', 'Segoe UI', sans-serif;
-@font-family-monospace: Consolas, "Liberation Mono", Menlo, Courier, monospace;


### PR DESCRIPTION
This does 2 things:
- Make the notifications package a bundled package
- Add notifications (Errors) for issues when loading files (config, keymap, snippets)

There is an issue on error where two messages are displayed. 

![screen shot 2014-11-24 at 5 21 01 pm](https://cloud.githubusercontent.com/assets/69169/5176450/4c2aa1bc-73fe-11e4-9c40-a6602b794f7e.png)

This is caused by https://github.com/atom/node-pathwatcher/issues/50. I've worked around it in the notifications package by not displaying duplicates until after some amount of time https://github.com/atom/notifications/commit/c9f17d1db6ebab36f61526ead3fc83608549b585.

Closes #4212 
Closes #3524
