### PR TITLE
Fix ordering of panels in panel containers

### DIFF
--- a/spec/panel-container-element-spec.coffee
+++ b/spec/panel-container-element-spec.coffee
@@ -43,6 +43,19 @@ describe "PanelContainerElement", ->
     expect(element.parentNode).not.toBe jasmineContent
 
   describe "adding and removing panels", ->
+    it "allows panels to be inserted at any position", ->
+      panel1 = new Panel({viewRegistry, item: new TestPanelContainerItem(), priority: 10})
+      panel2 = new Panel({viewRegistry, item: new TestPanelContainerItem(), priority: 5})
+      panel3 = new Panel({viewRegistry, item: new TestPanelContainerItem(), priority: 8})
+
+      container.addPanel(panel1)
+      container.addPanel(panel2)
+      container.addPanel(panel3)
+
+      expect(element.childNodes[2].getModel()).toBe(panel1)
+      expect(element.childNodes[1].getModel()).toBe(panel3)
+      expect(element.childNodes[0].getModel()).toBe(panel2)
+
     describe "when the container is at the left location", ->
       it "adds atom-panel elements when a new panel is added to the container; removes them when the panels are destroyed", ->
         expect(element.childNodes.length).toBe 0

--- a/src/panel-container-element.coffee
+++ b/src/panel-container-element.coffee
@@ -18,7 +18,7 @@ class PanelContainerElement extends HTMLElement
     if index >= @childNodes.length
       @appendChild(panelElement)
     else
-      referenceItem = @childNodes[index + 1]
+      referenceItem = @childNodes[index]
       @insertBefore(panelElement, referenceItem)
 
     if @model.isModal()


### PR DESCRIPTION
An off-by-one error caused new panels to be inserted later in the document than intended.

This caused the find-and-replace panel to appear below the status bar.
