### PR TITLE
Remove deprecations from core

### DIFF
--- a/benchmark/benchmark-helper.coffee
+++ b/benchmark/benchmark-helper.coffee
@@ -1,7 +1,8 @@
 require '../spec/spec-helper'
 
 path = require 'path'
-{$, Point} = require 'atom'
+{$} = require '../src/space-pen-extensions'
+{Point} = require 'atom'
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
 Project = require '../src/project'

--- a/benchmark/benchmark-suite.coffee
+++ b/benchmark/benchmark-suite.coffee
@@ -1,5 +1,7 @@
 require './benchmark-helper'
-{$, _, WorkspaceView} = require 'atom'
+{$} = require '../src/space-pen-extensions'
+_ = require 'underscore-plus'
+{WorkspaceView} = require 'atom'
 TokenizedBuffer = require '../src/tokenized-buffer'
 
 describe "editorView.", ->

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "serializable": "^1",
     "space-pen": "3.8.2",
     "temp": "0.7.0",
-    "text-buffer": "^3.7.2",
+    "text-buffer": "^3.8.0",
     "theorist": "^1.0.2",
     "underscore-plus": "^1.6.1",
     "vm-compatibility-layer": "0.1.0"

--- a/spec/atom-protocol-handler-spec.coffee
+++ b/spec/atom-protocol-handler-spec.coffee
@@ -1,4 +1,4 @@
-{$} = require 'atom'
+{$} = require '../src/space-pen-extensions'
 
 describe '"atom" protocol URL', ->
   it 'sends the file relative in the package as response', ->

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -1,10 +1,10 @@
-{$, $$, WorkspaceView}  = require 'atom'
+{$, $$}  = require '../src/space-pen-extensions'
 Exec = require('child_process').exec
 path = require 'path'
 Package = require '../src/package'
 ThemeManager = require '../src/theme-manager'
 
-describe "the `atom` global", ->
+fdescribe "the `atom` global", ->
   describe 'window sizing methods', ->
     describe '::getPosition and ::setPosition', ->
       it 'sets the position of the window, and can retrieve the position just set', ->

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -30,13 +30,16 @@ describe "the `atom` global", ->
       version = '36b5518'
       expect(atom.isReleasedVersion()).toBe false
 
-  describe "window:update-available", ->
-    it "is triggered when the auto-updater sends the update-downloaded event", ->
-      # FIXME: We need to figure out a way minus workspaceView to handle update-available events.
-      atom.workspaceView = atom.views.getView(atom.workspace).__spacePenView
+  describe "when an update becomes available", ->
+    subscription = null
 
+    afterEach ->
+      subscription?.dispose()
+
+    it "invokes onUpdateAvailable listeners", ->
       updateAvailableHandler = jasmine.createSpy("update-available-handler")
-      atom.workspaceView.on 'window:update-available', updateAvailableHandler
+      subscription = atom.onUpdateAvailable updateAvailableHandler
+
       autoUpdater = require('remote').require('auto-updater')
       autoUpdater.emit 'update-downloaded', null, "notes", "version"
 
@@ -44,9 +47,9 @@ describe "the `atom` global", ->
         updateAvailableHandler.callCount > 0
 
       runs ->
-        [event, version, notes] = updateAvailableHandler.mostRecentCall.args
-        expect(notes).toBe 'notes'
-        expect(version).toBe 'version'
+        {releaseVersion, releaseNotes} = updateAvailableHandler.mostRecentCall.args[0]
+        expect(releaseVersion).toBe 'version'
+        expect(releaseNotes).toBe 'notes'
 
   describe "loading default config", ->
     it 'loads the default core config', ->

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -4,7 +4,7 @@ path = require 'path'
 Package = require '../src/package'
 ThemeManager = require '../src/theme-manager'
 
-fdescribe "the `atom` global", ->
+describe "the `atom` global", ->
   describe 'window sizing methods', ->
     describe '::getPosition and ::setPosition', ->
       it 'sets the position of the window, and can retrieve the position just set', ->

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -128,6 +128,12 @@ describe "Config", ->
       expect(atom.config.get("foo")).toEqual 'a\\.b': 1, b: 2
 
   describe ".toggle(keyPath)", ->
+    beforeEach ->
+      jasmine.snapshotDeprecations()
+
+    afterEach ->
+      jasmine.restoreDeprecationsSnapshot()
+
     it "negates the boolean value of the current key path value", ->
       atom.config.set('foo.a', 1)
       atom.config.toggle('foo.a')
@@ -298,6 +304,12 @@ describe "Config", ->
       expect(observeHandler).toHaveBeenCalledWith atom.config.get("foo.bar.baz")
 
   describe ".getPositiveInt(keyPath, defaultValue)", ->
+    beforeEach ->
+      jasmine.snapshotDeprecations()
+
+    afterEach ->
+      jasmine.restoreDeprecationsSnapshot()
+
     it "returns the proper coerced value", ->
       atom.config.set('editor.preferredLineLength', 0)
       expect(atom.config.getPositiveInt('editor.preferredLineLength', 80)).toBe 1
@@ -470,7 +482,7 @@ describe "Config", ->
 
     it "does not fire the callback once the observe subscription is off'ed", ->
       observeHandler.reset() # clear the initial call
-      observeSubscription.off()
+      observeSubscription.dispose()
       atom.config.set('foo.bar.baz', "value 2")
       expect(observeHandler).not.toHaveBeenCalled()
 

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -1,4 +1,4 @@
-{$$} = require 'atom'
+{$$} = require '../src/space-pen-extensions'
 
 ContextMenuManager = require '../src/context-menu-manager'
 

--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -151,24 +151,31 @@ describe "ContextMenuManager", ->
       shouldDisplay = false
       expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual []
 
-    it "allows items to be specified in the legacy format for now", ->
-      contextMenu.add '.parent':
-        'A': 'a'
-        'Separator 1': '-'
-        'B':
-          'C': 'c'
-          'Separator 2': '-'
-          'D': 'd'
+    describe "when the menus are specified in a legacy format", ->
+      beforeEach ->
+        jasmine.snapshotDeprecations()
 
-      expect(contextMenu.templateForElement(parent)).toEqual [
-        {label: 'A', command: 'a'}
-        {type: 'separator'}
-        {
-          label: 'B'
-          submenu: [
-            {label: 'C', command: 'c'}
-            {type: 'separator'}
-            {label: 'D', command: 'd'}
-          ]
-        }
-      ]
+      afterEach ->
+        jasmine.restoreDeprecationsSnapshot()
+
+      it "allows items to be specified in the legacy format for now", ->
+        contextMenu.add '.parent':
+          'A': 'a'
+          'Separator 1': '-'
+          'B':
+            'C': 'c'
+            'Separator 2': '-'
+            'D': 'd'
+
+        expect(contextMenu.templateForElement(parent)).toEqual [
+          {label: 'A', command: 'a'}
+          {type: 'separator'}
+          {
+            label: 'B'
+            submenu: [
+              {label: 'C', command: 'c'}
+              {type: 'separator'}
+              {label: 'D', command: 'd'}
+            ]
+          }
+        ]

--- a/spec/fixtures/packages/package-with-menus-manifest/menus/menu-1.cson
+++ b/spec/fixtures/packages/package-with-menus-manifest/menus/menu-1.cson
@@ -3,5 +3,6 @@
 ]
 
 'context-menu':
-  '.test-1':
-    'Menu item 1': 'command-1'
+  '.test-1': [
+    {label: 'Menu item 1', command: 'command-1'}
+  ]

--- a/spec/fixtures/packages/package-with-menus-manifest/menus/menu-2.cson
+++ b/spec/fixtures/packages/package-with-menus-manifest/menus/menu-2.cson
@@ -3,5 +3,6 @@
 ]
 
 'context-menu':
-  '.test-1':
-    'Menu item 2': 'command-2'
+  '.test-1': [
+    {label: 'Menu item 2', command: 'command-2'}
+  ]

--- a/spec/fixtures/packages/package-with-menus-manifest/menus/menu-3.cson
+++ b/spec/fixtures/packages/package-with-menus-manifest/menus/menu-3.cson
@@ -1,3 +1,4 @@
 'context-menu':
-  '.test-1':
-    'Menu item 3': 'command-3'
+  '.test-1': [
+    {label: 'Menu item 3', command: 'command-3'}
+  ]

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -98,15 +98,23 @@ describe "PackageManager", ->
             expect(atom.config.set('package-with-config-schema.numbers.one', '10')).toBe true
             expect(atom.config.get('package-with-config-schema.numbers.one')).toBe 10
 
-        it "still assigns configDefaults from the module though deprecated", ->
-          expect(atom.config.get('package-with-config-defaults.numbers.one')).toBeUndefined()
+        describe "when a package has configDefaults", ->
+          beforeEach ->
+            jasmine.snapshotDeprecations()
 
-          waitsForPromise ->
-            atom.packages.activatePackage('package-with-config-defaults')
+          afterEach ->
+            jasmine.restoreDeprecationsSnapshot()
 
-          runs ->
-            expect(atom.config.get('package-with-config-defaults.numbers.one')).toBe 1
-            expect(atom.config.get('package-with-config-defaults.numbers.two')).toBe 2
+          it "still assigns configDefaults from the module though deprecated", ->
+
+            expect(atom.config.get('package-with-config-defaults.numbers.one')).toBeUndefined()
+
+            waitsForPromise ->
+              atom.packages.activatePackage('package-with-config-defaults')
+
+            runs ->
+              expect(atom.config.get('package-with-config-defaults.numbers.one')).toBe 1
+              expect(atom.config.get('package-with-config-defaults.numbers.two')).toBe 2
 
         describe "when the package metadata includes `activationCommands`", ->
           [mainModule, promise, workspaceCommandListener] = []

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -522,6 +522,7 @@ describe "PackageManager", ->
     themeActivator = null
 
     beforeEach ->
+      jasmine.snapshotDeprecations()
       spyOn(console, 'warn')
       atom.packages.loadPackages()
 
@@ -537,6 +538,7 @@ describe "PackageManager", ->
 
       GrammarRegistry = require '../src/grammar-registry'
       atom.grammars = window.syntax = new GrammarRegistry()
+      jasmine.restoreDeprecationsSnapshot()
 
     it "activates all the packages, and none of the themes", ->
       atom.packages.activate()

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -1,4 +1,5 @@
-{$, $$, WorkspaceView}  = require 'atom'
+{$, $$} = require '../src/space-pen-extensions'
+{WorkspaceView}  = require 'atom'
 Package = require '../src/package'
 
 describe "PackageManager", ->

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -1,5 +1,4 @@
 {$, $$} = require '../src/space-pen-extensions'
-{WorkspaceView}  = require 'atom'
 Package = require '../src/package'
 
 describe "PackageManager", ->

--- a/spec/package-spec.coffee
+++ b/spec/package-spec.coffee
@@ -1,4 +1,4 @@
-{$} = require 'atom'
+{$} = require '../src/space-pen-extensions'
 path = require 'path'
 Package = require '../src/package'
 ThemePackage = require '../src/theme-package'

--- a/spec/pane-container-view-spec.coffee
+++ b/spec/pane-container-view-spec.coffee
@@ -3,6 +3,7 @@ temp = require 'temp'
 PaneContainer = require '../src/pane-container'
 PaneContainerView = require '../src/pane-container-view'
 PaneView = require '../src/pane-view'
+{Disposable} = require 'event-kit'
 {$, View, $$} = require '../src/space-pen-extensions'
 
 describe "PaneContainerView", ->
@@ -18,6 +19,8 @@ describe "PaneContainerView", ->
       getUri: -> path.join(temp.dir, @name)
       save: -> @saved = true
       isEqual: (other) -> @name is other?.name
+      onDidChangeTitle: -> new Disposable(->)
+      onDidChangeModified: -> new Disposable(->)
 
     container = atom.views.getView(atom.workspace.paneContainer).__spacePenView
     pane1 = container.getRoot()

--- a/spec/pane-container-view-spec.coffee
+++ b/spec/pane-container-view-spec.coffee
@@ -3,7 +3,7 @@ temp = require 'temp'
 PaneContainer = require '../src/pane-container'
 PaneContainerView = require '../src/pane-container-view'
 PaneView = require '../src/pane-view'
-{$, View, $$} = require 'atom'
+{$, View, $$} = require '../src/space-pen-extensions'
 
 describe "PaneContainerView", ->
   [TestView, container, pane1, pane2, pane3, deserializerDisposable] = []

--- a/spec/pane-view-spec.coffee
+++ b/spec/pane-view-spec.coffee
@@ -24,6 +24,8 @@ describe "PaneView", ->
     onDidChangeModified: -> new Disposable(->)
 
   beforeEach ->
+    jasmine.snapshotDeprecations()
+
     deserializerDisposable = atom.deserializers.add(TestView)
     container = atom.views.getView(new PaneContainer).__spacePenView
     containerModel = container.model
@@ -42,6 +44,7 @@ describe "PaneView", ->
 
   afterEach ->
     deserializerDisposable.dispose()
+    jasmine.restoreDeprecationsSnapshot()
 
   describe "when the active pane item changes", ->
     it "hides all item views except the active one", ->

--- a/spec/pane-view-spec.coffee
+++ b/spec/pane-view-spec.coffee
@@ -1,7 +1,7 @@
 PaneContainer = require '../src/pane-container'
 PaneView = require '../src/pane-view'
 fs = require 'fs-plus'
-{Emitter} = require 'event-kit'
+{Emitter, Disposable} = require 'event-kit'
 {$, View} = require '../src/space-pen-extensions'
 path = require 'path'
 temp = require 'temp'
@@ -21,6 +21,7 @@ describe "PaneView", ->
       @emitter.emit 'did-change-title', 'title'
     onDidChangeTitle: (callback) ->
       @emitter.on 'did-change-title', callback
+    onDidChangeModified: -> new Disposable(->)
 
   beforeEach ->
     deserializerDisposable = atom.deserializers.add(TestView)
@@ -155,13 +156,18 @@ describe "PaneView", ->
       expect(view1.is(':visible')).toBe true
 
   describe "when the title of the active item changes", ->
-    describe 'when there is no onDidChangeTitle method', ->
+    describe 'when there is no onDidChangeTitle method (deprecated)', ->
       beforeEach ->
+        jasmine.snapshotDeprecations()
+
         view1.onDidChangeTitle = null
         view2.onDidChangeTitle = null
 
         pane.activateItem(view2)
         pane.activateItem(view1)
+
+      afterEach ->
+        jasmine.restoreDeprecationsSnapshot()
 
       it "emits pane:active-item-title-changed", ->
         activeItemTitleChangedHandler = jasmine.createSpy("activeItemTitleChangedHandler")

--- a/spec/pane-view-spec.coffee
+++ b/spec/pane-view-spec.coffee
@@ -2,7 +2,7 @@ PaneContainer = require '../src/pane-container'
 PaneView = require '../src/pane-view'
 fs = require 'fs-plus'
 {Emitter} = require 'event-kit'
-{$, View} = require 'atom'
+{$, View} = require '../src/space-pen-extensions'
 path = require 'path'
 temp = require 'temp'
 

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -170,7 +170,7 @@ describe "Project", ->
         absolutePath = fs.absolute(__dirname)
         expect(atom.project.resolve(absolutePath)).toBe absolutePath
 
-  describe ".setPath(path)", ->
+  describe ".setPaths(path)", ->
     describe "when path is a file", ->
       it "sets its path to the files parent directory and updates the root directory", ->
         atom.project.setPaths([require.resolve('./fixtures/dir/a')])

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -175,25 +175,25 @@ describe "Project", ->
       it "sets its path to the files parent directory and updates the root directory", ->
         atom.project.setPaths([require.resolve('./fixtures/dir/a')])
         expect(atom.project.getPaths()[0]).toEqual path.dirname(require.resolve('./fixtures/dir/a'))
-        expect(atom.project.getRootDirectory().path).toEqual path.dirname(require.resolve('./fixtures/dir/a'))
+        expect(atom.project.getDirectories()[0].path).toEqual path.dirname(require.resolve('./fixtures/dir/a'))
 
     describe "when path is a directory", ->
       it "sets its path to the directory and updates the root directory", ->
         directory = fs.absolute(path.join(__dirname, 'fixtures', 'dir', 'a-dir'))
         atom.project.setPaths([directory])
         expect(atom.project.getPaths()[0]).toEqual directory
-        expect(atom.project.getRootDirectory().path).toEqual directory
+        expect(atom.project.getDirectories()[0].path).toEqual directory
 
     describe "when path is null", ->
       it "sets its path and root directory to null", ->
         atom.project.setPaths([])
         expect(atom.project.getPaths()[0]?).toBeFalsy()
-        expect(atom.project.getRootDirectory()?).toBeFalsy()
+        expect(atom.project.getDirectories()[0]?).toBeFalsy()
 
     it "normalizes the path to remove consecutive slashes, ., and .. segments", ->
       atom.project.setPaths(["#{require.resolve('./fixtures/dir/a')}#{path.sep}b#{path.sep}#{path.sep}.."])
       expect(atom.project.getPaths()[0]).toEqual path.dirname(require.resolve('./fixtures/dir/a'))
-      expect(atom.project.getRootDirectory().path).toEqual path.dirname(require.resolve('./fixtures/dir/a'))
+      expect(atom.project.getDirectories()[0].path).toEqual path.dirname(require.resolve('./fixtures/dir/a'))
 
   describe ".replace()", ->
     [filePath, commentFilePath, sampleContent, sampleCommentContent] = []

--- a/spec/select-list-view-spec.coffee
+++ b/spec/select-list-view-spec.coffee
@@ -1,5 +1,5 @@
 SelectListView = require '../src/select-list-view'
-{$, $$} = require 'atom'
+{$, $$} = require '../src/space-pen-extensions'
 
 describe "SelectListView", ->
   [selectList, items, list, filterEditorView] = []

--- a/spec/space-pen-extensions-spec.coffee
+++ b/spec/space-pen-extensions-spec.coffee
@@ -1,4 +1,4 @@
-{View, $, $$} = require 'atom'
+{View, $, $$} = require '../src/space-pen-extensions'
 
 describe "SpacePen extensions", ->
   class TestView extends View

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -9,11 +9,14 @@ _ = require 'underscore-plus'
 fs = require 'fs-plus'
 Grim = require 'grim'
 KeymapManager = require '../src/keymap-extensions'
-Workspace = require '../src/workspace'
+
+# FIXME: Remove jquery from this
 {$} = require '../src/space-pen-extensions'
+
 Config = require '../src/config'
 {Point} = require 'text-buffer'
 Project = require '../src/project'
+Workspace = require '../src/workspace'
 TextEditor = require '../src/text-editor'
 TextEditorView = require '../src/text-editor-view'
 TokenizedBuffer = require '../src/tokenized-buffer'

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -200,6 +200,13 @@ jasmine.attachToDOM = (element) ->
   jasmineContent = document.querySelector('#jasmine-content')
   jasmineContent.appendChild(element) unless jasmineContent.contains(element)
 
+deprecationsSnapshot = null
+jasmine.snapshotDeprecations = ->
+  deprecationsSnapshot = Grim.getDeprecations() # suppress deprecations!!
+
+jasmine.restoreDeprecationsSnapshot = ->
+  Grim.grimDeprecations = deprecationsSnapshot
+
 addCustomMatchers = (spec) ->
   spec.addMatchers
     toBeInstanceOf: (expected) ->

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -80,6 +80,8 @@ beforeEach ->
   atom.commands.restoreSnapshot(commandsToRestore)
   atom.styles.restoreSnapshot(styleElementsToRestore)
 
+  atom.workspaceViewParentSelector = '#jasmine-content'
+
   window.resetTimeouts()
   atom.packages.packageStates = {}
 

--- a/spec/syntax-spec.coffee
+++ b/spec/syntax-spec.coffee
@@ -105,30 +105,3 @@ describe "the `syntax` global", ->
       grammar = atom.grammars.selectGrammar('foo.js')
       atom.grammars.removeGrammar(grammar)
       expect(atom.grammars.selectGrammar('foo.js').name).not.toBe grammar.name
-
-  describe ".getProperty(scopeDescriptor)", ->
-    it "returns the property with the most specific scope selector", ->
-      atom.grammars.addProperties(".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
-      atom.grammars.addProperties(".source .string.quoted.double", foo: bar: baz: 22)
-      atom.grammars.addProperties(".source", foo: bar: baz: 11)
-
-      expect(atom.grammars.getProperty([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
-      expect(atom.grammars.getProperty([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBe 22
-      expect(atom.grammars.getProperty([".source.js", ".variable.assignment.js"], "foo.bar.baz")).toBe 11
-      expect(atom.grammars.getProperty([".text"], "foo.bar.baz")).toBeUndefined()
-
-    it "favors the most recently added properties in the event of a specificity tie", ->
-      atom.grammars.addProperties(".source.coffee .string.quoted.single", foo: bar: baz: 42)
-      atom.grammars.addProperties(".source.coffee .string.quoted.double", foo: bar: baz: 22)
-
-      expect(atom.grammars.getProperty([".source.coffee", ".string.quoted.single"], "foo.bar.baz")).toBe 42
-      expect(atom.grammars.getProperty([".source.coffee", ".string.quoted.single.double"], "foo.bar.baz")).toBe 22
-
-  describe ".removeProperties(name)", ->
-    it "allows properties to be removed by name", ->
-      atom.grammars.addProperties("a", ".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
-      atom.grammars.addProperties("b", ".source .string.quoted.double", foo: bar: baz: 22)
-
-      atom.grammars.removeProperties("b")
-      expect(atom.grammars.getProperty([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBeUndefined()
-      expect(atom.grammars.getProperty([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -302,7 +302,7 @@ describe "TextEditorComponent", ->
 
       it "interleaves invisible line-ending characters with indent guides on empty lines", ->
         component.setShowIndentGuide(true)
-        editor.setTextInBufferRange([[10, 0], [11, 0]], "\r\n", false)
+        editor.setTextInBufferRange([[10, 0], [11, 0]], "\r\n", normalizeLineEndings: false)
         nextAnimationFrame()
         expect(component.lineNodeForScreenRow(10).innerHTML).toBe '<span class="indent-guide"><span class="invisible-character">C</span><span class="invisible-character">E</span></span>'
 

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3014,18 +3014,16 @@ describe "TextEditor", ->
         expect(editor.isFoldedAtBufferRow(1)).toBeFalsy()
         expect(editor.isFoldedAtBufferRow(2)).toBeTruthy()
 
-    describe "begin/commitTransaction()", ->
+    describe "::transact", ->
       it "restores the selection when the transaction is undone/redone", ->
         buffer.setText('1234')
         editor.setSelectedBufferRange([[0, 1], [0, 3]])
-        editor.beginTransaction()
 
-        editor.delete()
-        editor.moveToEndOfLine()
-        editor.insertText('5')
-        expect(buffer.getText()).toBe '145'
-
-        editor.commitTransaction()
+        editor.transact ->
+          editor.delete()
+          editor.moveToEndOfLine()
+          editor.insertText('5')
+          expect(buffer.getText()).toBe '145'
 
         editor.undo()
         expect(buffer.getText()).toBe '1234'

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -616,7 +616,7 @@ describe "TextEditor", ->
         describe "when invisible characters are enabled with hard tabs", ->
           it "moves to the first character of the current line without being confused by the invisible characters", ->
             atom.config.set('editor.showInvisibles', true)
-            buffer.setTextInRange([[1, 0], [1, Infinity]], '\t\t\ta', false)
+            buffer.setTextInRange([[1, 0], [1, Infinity]], '\t\t\ta', normalizeLineEndings: false)
 
             editor.setCursorScreenPosition [1,7]
             editor.moveToFirstCharacterOfLine()

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -1,7 +1,6 @@
 path = require 'path'
 
 {$, $$} = require '../src/space-pen-extensions'
-{WorkspaceView} = require 'atom'
 fs = require 'fs-plus'
 temp = require 'temp'
 

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -20,7 +20,11 @@ describe "ThemeManager", ->
 
   describe "theme getters and setters", ->
     beforeEach ->
+      jasmine.snapshotDeprecations()
       atom.packages.loadPackages()
+
+    afterEach ->
+      jasmine.restoreDeprecationsSnapshot()
 
     it 'getLoadedThemes get all the loaded themes', ->
       themes = themeManager.getLoadedThemes()

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -134,15 +134,24 @@ describe "ThemeManager", ->
       expect(-> atom.packages.activatePackage('a-theme-that-will-not-be-found')).toThrow()
 
   describe "::requireStylesheet(path)", ->
+    beforeEach ->
+      jasmine.snapshotDeprecations()
+
+    afterEach ->
+      jasmine.restoreDeprecationsSnapshot()
+
     it "synchronously loads css at the given path and installs a style tag for it in the head", ->
+      atom.styles.onDidAddStyleElement styleElementAddedHandler = jasmine.createSpy("styleElementAddedHandler")
       themeManager.onDidChangeStylesheets stylesheetsChangedHandler = jasmine.createSpy("stylesheetsChangedHandler")
       themeManager.onDidAddStylesheet stylesheetAddedHandler = jasmine.createSpy("stylesheetAddedHandler")
+
       cssPath = atom.project.resolve('css.css')
       lengthBefore = $('head style').length
 
       themeManager.requireStylesheet(cssPath)
       expect($('head style').length).toBe lengthBefore + 1
 
+      expect(styleElementAddedHandler).toHaveBeenCalled()
       expect(stylesheetAddedHandler).toHaveBeenCalled()
       expect(stylesheetsChangedHandler).toHaveBeenCalled()
 
@@ -152,8 +161,10 @@ describe "ThemeManager", ->
       expect(element[0].sheet).toBe stylesheetAddedHandler.argsForCall[0][0]
 
       # doesn't append twice
+      styleElementAddedHandler.reset()
       themeManager.requireStylesheet(cssPath)
       expect($('head style').length).toBe lengthBefore + 1
+      expect(styleElementAddedHandler).not.toHaveBeenCalled()
 
       $('head style[id*="css.css"]').remove()
 
@@ -196,6 +207,7 @@ describe "ThemeManager", ->
       disposable = themeManager.requireStylesheet(cssPath)
       expect($(document.body).css('font-weight')).toBe("bold")
 
+      atom.styles.onDidRemoveStyleElement styleElementRemovedHandler = jasmine.createSpy("styleElementRemovedHandler")
       themeManager.onDidRemoveStylesheet stylesheetRemovedHandler = jasmine.createSpy("stylesheetRemovedHandler")
       themeManager.onDidChangeStylesheets stylesheetsChangedHandler = jasmine.createSpy("stylesheetsChangedHandler")
 
@@ -203,6 +215,7 @@ describe "ThemeManager", ->
 
       expect($(document.body).css('font-weight')).not.toBe("bold")
 
+      expect(styleElementRemovedHandler).toHaveBeenCalled()
       expect(stylesheetRemovedHandler).toHaveBeenCalled()
       stylesheet = stylesheetRemovedHandler.argsForCall[0][0]
       expect(stylesheet instanceof CSSStyleSheet).toBe true
@@ -213,12 +226,17 @@ describe "ThemeManager", ->
   describe "base stylesheet loading", ->
     workspaceElement = null
     beforeEach ->
+      jasmine.snapshotDeprecations()
+
       workspaceElement = atom.views.getView(atom.workspace)
       jasmine.attachToDOM(workspaceElement)
       workspaceElement.appendChild document.createElement('atom-text-editor')
 
       waitsForPromise ->
         themeManager.activateThemes()
+
+    beforeEach ->
+      jasmine.restoreDeprecationsSnapshot()
 
     it "loads the correct values from the theme's ui-variables file", ->
       themeManager.onDidReloadAll reloadHandler = jasmine.createSpy()
@@ -269,7 +287,14 @@ describe "ThemeManager", ->
           expect(workspaceElement).not.toHaveClass 'theme-atom-dark-syntax'
 
   describe "when the user stylesheet changes", ->
+    beforeEach ->
+      jasmine.snapshotDeprecations()
+
+    afterEach ->
+      jasmine.restoreDeprecationsSnapshot()
+
     it "reloads it", ->
+      [styleElementAddedHandler, styleElementRemovedHandler] = []
       [stylesheetRemovedHandler, stylesheetAddedHandler, stylesheetsChangedHandler] = []
       userStylesheetPath = path.join(temp.mkdirSync("atom"), 'styles.less')
       fs.writeFileSync(userStylesheetPath, 'body {border-style: dotted !important;}')
@@ -279,6 +304,9 @@ describe "ThemeManager", ->
         themeManager.activateThemes()
 
       runs ->
+        atom.styles.onDidRemoveStyleElement styleElementRemovedHandler = jasmine.createSpy("styleElementRemovedHandler")
+        atom.styles.onDidAddStyleElement styleElementAddedHandler = jasmine.createSpy("styleElementAddedHandler")
+
         themeManager.onDidChangeStylesheets stylesheetsChangedHandler = jasmine.createSpy("stylesheetsChangedHandler")
         themeManager.onDidRemoveStylesheet stylesheetRemovedHandler = jasmine.createSpy("stylesheetRemovedHandler")
         themeManager.onDidAddStylesheet stylesheetAddedHandler = jasmine.createSpy("stylesheetAddedHandler")
@@ -293,14 +321,19 @@ describe "ThemeManager", ->
       runs ->
         expect($(document.body).css('border-style')).toBe 'dashed'
 
+        expect(styleElementRemovedHandler).toHaveBeenCalled()
+        expect(styleElementRemovedHandler.argsForCall[0][0].textContent).toContain 'dotted'
         expect(stylesheetRemovedHandler).toHaveBeenCalled()
         expect(stylesheetRemovedHandler.argsForCall[0][0].cssRules[0].style.border).toBe 'dotted'
 
+        expect(styleElementAddedHandler).toHaveBeenCalled()
+        expect(styleElementAddedHandler.argsForCall[0][0].textContent).toContain 'dashed'
         expect(stylesheetAddedHandler).toHaveBeenCalled()
         expect(stylesheetAddedHandler.argsForCall[0][0].cssRules[0].style.border).toBe 'dashed'
 
         expect(stylesheetsChangedHandler).toHaveBeenCalled()
 
+        styleElementRemovedHandler.reset()
         stylesheetRemovedHandler.reset()
         stylesheetsChangedHandler.reset()
         fs.removeSync(userStylesheetPath)
@@ -309,6 +342,8 @@ describe "ThemeManager", ->
         themeManager.loadUserStylesheet.callCount is 2
 
       runs ->
+        expect(styleElementRemovedHandler).toHaveBeenCalled()
+        expect(styleElementRemovedHandler.argsForCall[0][0].textContent).toContain 'dashed'
         expect(stylesheetRemovedHandler).toHaveBeenCalled()
         expect(stylesheetRemovedHandler.argsForCall[0][0].cssRules[0].style.border).toBe 'dashed'
         expect($(document.body).css('border-style')).toBe 'none'

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -1,6 +1,7 @@
 path = require 'path'
 
-{$, $$, WorkspaceView} = require 'atom'
+{$, $$} = require '../src/space-pen-extensions'
+{WorkspaceView} = require 'atom'
 fs = require 'fs-plus'
 temp = require 'temp'
 

--- a/spec/window-spec.coffee
+++ b/spec/window-spec.coffee
@@ -1,4 +1,4 @@
-{$, $$} = require 'atom'
+{$, $$} = require '../src/space-pen-extensions'
 path = require 'path'
 TextEditor = require '../src/text-editor'
 WindowEventHandler = require '../src/window-event-handler'

--- a/spec/window-spec.coffee
+++ b/spec/window-spec.coffee
@@ -259,24 +259,23 @@ describe "Window", ->
 
       describe "when the opened path exists", ->
         it "sets the project path to the opened path", ->
-          $(window).trigger('window:open-path', [{pathToOpen: __filename}])
-
+          atom.getCurrentWindow().send 'message', 'open-path', pathToOpen: __filename
           expect(atom.project.getPaths()[0]).toBe __dirname
 
       describe "when the opened path does not exist but its parent directory does", ->
         it "sets the project path to the opened path's parent directory", ->
-          $(window).trigger('window:open-path', [{pathToOpen: path.join(__dirname, 'this-path-does-not-exist.txt')}])
-
+          pathToOpen = path.join(__dirname, 'this-path-does-not-exist.txt')
+          atom.getCurrentWindow().send 'message', 'open-path', {pathToOpen}
           expect(atom.project.getPaths()[0]).toBe __dirname
 
     describe "when the opened path is a file", ->
       it "opens it in the workspace", ->
-        $(window).trigger('window:open-path', [{pathToOpen: __filename}])
+        atom.getCurrentWindow().send 'message', 'open-path', pathToOpen: __filename
 
         expect(atom.workspace.open.mostRecentCall.args[0]).toBe __filename
 
     describe "when the opened path is a directory", ->
       it "does not open it in the workspace", ->
-        $(window).trigger('window:open-path', [{pathToOpen: __dirname}])
+        atom.getCurrentWindow().send 'message', 'open-path', pathToOpen: __dirname
 
         expect(atom.workspace.open.callCount).toBe 0

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -375,7 +375,7 @@ describe "Workspace", ->
   describe "document.title", ->
     describe "when the project has no path", ->
       it "sets the title to 'untitled'", ->
-        atom.project.setPath(undefined)
+        atom.project.setPaths([])
         expect(document.title).toBe 'untitled - Atom'
 
     describe "when the project has a path", ->

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -1,5 +1,4 @@
 {$, $$, View} = require '../src/space-pen-extensions'
-{WorkspaceView} = require 'atom'
 Q = require 'q'
 path = require 'path'
 temp = require 'temp'
@@ -11,6 +10,8 @@ describe "WorkspaceView", ->
   pathToOpen = null
 
   beforeEach ->
+    jasmine.snapshotDeprecations()
+
     atom.project.setPaths([atom.project.resolve('dir')])
     pathToOpen = atom.project.resolve('a')
     atom.workspace = new Workspace
@@ -20,6 +21,9 @@ describe "WorkspaceView", ->
 
     waitsForPromise ->
       atom.workspace.open(pathToOpen)
+
+  afterEach ->
+    jasmine.restoreDeprecationsSnapshot()
 
   describe "@deserialize()", ->
     viewState = null

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -1,4 +1,5 @@
-{$, $$, WorkspaceView, View} = require 'atom'
+{$, $$, View} = require '../src/space-pen-extensions'
+{WorkspaceView} = require 'atom'
 Q = require 'q'
 path = require 'path'
 temp = require 'temp'

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -783,6 +783,12 @@ class Atom extends Model
       else
         window[key] = value
 
+  onUpdateAvailable: (callback) ->
+    @emitter.on 'update-available', callback
+
+  updateAvailable: (details) ->
+    @emitter.emit 'update-available', details
+
   # Deprecated: Callers should be converted to use atom.deserializers
   registerRepresentationClass: ->
     deprecate("Callers should be converted to use atom.deserializers")

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -58,7 +58,7 @@ class AtomWindow
     @browserWindow.loadUrl @getUrl(loadSettings)
     @browserWindow.focusOnWebView() if @isSpec
 
-    @openPath(pathToOpen, initialLine, initialColumn)
+    @openPath(pathToOpen, initialLine, initialColumn) unless @isSpecWindow()
 
   getUrl: (loadSettingsObj) ->
     # Ignore the windowState when passing loadSettings via URL, since it could

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -143,9 +143,12 @@ class AtomWindow
   openPath: (pathToOpen, initialLine, initialColumn) ->
     if @loaded
       @focus()
-      @sendCommand('window:open-path', {pathToOpen, initialLine, initialColumn})
+      @sendMessage 'open-path', {pathToOpen, initialLine, initialColumn}
     else
       @browserWindow.once 'window:loaded', => @openPath(pathToOpen, initialLine, initialColumn)
+
+  sendMessage: (message, detail) ->
+    @browserWindow.webContents.send 'message', message, detail
 
   sendCommand: (command, args...) ->
     if @isSpecWindow()
@@ -154,7 +157,6 @@ class AtomWindow
           when 'window:reload' then @reload()
           when 'window:toggle-dev-tools' then @toggleDevTools()
           when 'window:close' then @close()
-          when 'window:update-available' then @sendCommandToBrowserWindow(command, args...) # For spec testing
     else if @isWebViewFocused()
       @sendCommandToBrowserWindow(command, args...)
     else

--- a/src/browser/auto-update-manager.coffee
+++ b/src/browser/auto-update-manager.coffee
@@ -56,7 +56,7 @@ class AutoUpdateManager
   emitUpdateAvailableEvent: (windows...) ->
     return unless @releaseVersion? and @releaseNotes
     for atomWindow in windows
-      atomWindow.sendCommand('window:update-available', [@releaseVersion, @releaseNotes])
+      atomWindow.sendMessage('update-available', {@releaseVersion, @releaseNotes})
 
   setState: (state) ->
     return if @state is state

--- a/src/browser/context-menu.coffee
+++ b/src/browser/context-menu.coffee
@@ -8,7 +8,7 @@ class ContextMenu
     menu.popup(@atomWindow.browserWindow)
 
   # It's necessary to build the event handlers in this process, otherwise
-  # closures are drug across processes and failed to be garbage collected
+  # closures are dragged across processes and failed to be garbage collected
   # appropriately.
   createClickHandlers: (template) ->
     for item in template

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -64,7 +64,7 @@ class Project extends Model
   ###
 
   serializeParams: ->
-    path: @path
+    paths: @getPaths()
     buffers: _.compact(@buffers.map (buffer) -> buffer.serialize() if buffer.isRetained())
 
   deserializeParams: (params) ->

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -31,9 +31,9 @@ class WindowEventHandler
     @subscribe $(window), 'blur', -> document.body.classList.add('is-blurred')
 
     @subscribeToCommand $(window), 'window:open-path', (event, {pathToOpen, initialLine, initialColumn}) ->
-      unless atom.project?.getPath()
+      unless atom.project?.getPaths().length
         if fs.existsSync(pathToOpen) or fs.existsSync(path.dirname(pathToOpen))
-          atom.project?.setPath(pathToOpen)
+          atom.project?.setPaths([pathToOpen])
 
       unless fs.isDirectorySync(pathToOpen)
         atom.workspace?.open(pathToOpen, {initialLine, initialColumn})

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -14,8 +14,27 @@ class WindowEventHandler
   constructor: ->
     @reloadRequested = false
 
-    @subscribe ipc, 'command', (command, args...) ->
+    @subscribe ipc, 'message', (message, detail) ->
+      switch message
+        when 'open-path'
+          {pathToOpen, initialLine, initialColumn} = detail
 
+          unless atom.project?.getPaths().length
+            if fs.existsSync(pathToOpen) or fs.existsSync(path.dirname(pathToOpen))
+              atom.project?.setPaths([pathToOpen])
+
+          unless fs.isDirectorySync(pathToOpen)
+            atom.workspace?.open(pathToOpen, {initialLine, initialColumn})
+
+        when 'update-available'
+          atom.updateAvailable(detail)
+
+          # FIXME: Remove this when deprecations are removed
+          {releaseVersion, releaseNotes} = detail
+          detail = [releaseVersion, releaseNotes]
+          atom.commands.dispatch atom.views.getView(atom.workspace), "window:update-available", detail
+
+    @subscribe ipc, 'command', (command, args...) ->
       activeElement = document.activeElement
       # Use the workspace element view if body has focus
       if activeElement is document.body and workspaceElement = atom.views.getView(atom.workspace)
@@ -29,14 +48,6 @@ class WindowEventHandler
     @subscribe $(window), 'focus', -> document.body.classList.remove('is-blurred')
 
     @subscribe $(window), 'blur', -> document.body.classList.add('is-blurred')
-
-    @subscribeToCommand $(window), 'window:open-path', (event, {pathToOpen, initialLine, initialColumn}) ->
-      unless atom.project?.getPaths().length
-        if fs.existsSync(pathToOpen) or fs.existsSync(path.dirname(pathToOpen))
-          atom.project?.setPaths([pathToOpen])
-
-      unless fs.isDirectorySync(pathToOpen)
-        atom.workspace?.open(pathToOpen, {initialLine, initialColumn})
 
     @subscribe $(window), 'beforeunload', =>
       confirmed = atom.workspace?.confirmClose()


### PR DESCRIPTION
In progress. Feel free to take bits of it if you'd like.
### TODO
- [ ] Remove `Point.translate` calls, use `Point.add`? See `text-editor-spec` and `text-editor-component-spec`, @nathansobo a while ago, I swapped `add` for `translate` and specs were failing. 
- [ ] Use checkpoints rather than transactions? See `text-editor-spec` and `text-editor-component-spec`. @nathansobo or @maxbrunsfeld 
- [ ] Upgrade the theme manager specs. Several events are asking for using something on atom.styles. Not sure if we want to test these or suppress. @nathansobo this is your domain.
