### PR TITLE
Add ‘position’ option to overlay decorations

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1247,7 +1247,7 @@ describe "TextEditorComponent", ->
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
     describe "when the marker is not empty", ->
-      it "renders at the head of the marker", ->
+      it "renders at the head of the marker by default", ->
         marker = editor.displayBuffer.markBufferRange([[2, 5], [2, 10]], invalidate: 'never')
         decoration = editor.decorateMarker(marker, {type: 'overlay', item})
         nextAnimationFrame()
@@ -1261,6 +1261,17 @@ describe "TextEditorComponent", ->
       it "renders at the head of the marker when the marker is reversed", ->
         marker = editor.displayBuffer.markBufferRange([[2, 5], [2, 10]], invalidate: 'never', reversed: true)
         decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+        nextAnimationFrame()
+
+        position = editor.pixelPositionForBufferPosition([2, 5])
+
+        overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
+        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+      it "renders at the tail of the marker when the 'position' option is 'tail'", ->
+        marker = editor.displayBuffer.markBufferRange([[2, 5], [2, 10]], invalidate: 'never')
+        decoration = editor.decorateMarker(marker, {type: 'overlay', position: 'tail', item})
         nextAnimationFrame()
 
         position = editor.pixelPositionForBufferPosition([2, 5])

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -7,9 +7,12 @@ class OverlayManager
     {editor, overlayDecorations, lineHeightInPixels} = props
 
     existingDecorations = null
-    for markerId, {isMarkerReversed, headPixelPosition, decorations} of overlayDecorations
+    for markerId, {headPixelPosition, tailPixelPosition, decorations} of overlayDecorations
       for decoration in decorations
-        @renderOverlay(editor, decoration, headPixelPosition, lineHeightInPixels)
+        pixelPosition =
+          if decoration.position is 'tail' then tailPixelPosition else headPixelPosition
+
+        @renderOverlay(editor, decoration, pixelPosition, lineHeightInPixels)
 
         existingDecorations ?= {}
         existingDecorations[decoration.id] = true

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -364,6 +364,7 @@ TextEditorComponent = React.createClass
     for markerId, decorations of decorationsByMarkerId
       marker = editor.getMarker(markerId)
       headScreenPosition = marker.getHeadScreenPosition()
+      tailScreenPosition = marker.getTailScreenPosition()
       if marker.isValid()
         for decoration in decorations
           if decoration.isType('overlay')
@@ -371,6 +372,7 @@ TextEditorComponent = React.createClass
             filteredDecorations[markerId] ?=
               id: markerId
               headPixelPosition: editor.pixelPositionForScreenPosition(headScreenPosition)
+              tailPixelPosition: editor.pixelPositionForScreenPosition(tailScreenPosition)
               decorations: []
             filteredDecorations[markerId].decorations.push decorationParams
     filteredDecorations


### PR DESCRIPTION
/cc @benogle

By default overlays are positioned at the head of the given marker. This option allows them to be positioned at the tail instead by passing `position: ’tail’` when creating the decoration, which is useful for autocomplete.

I tried various other approaches for positioning the overlay in autocomplete without adding this option, but the complexity of the text manipulation (due to the fact that the case of the prefix and suffix can be altered) meant that any other markers I created were always getting moved to undesirable places. Since we restore the selections following the text manipulation, simply positioning the overlay at the tail is the most convenient and simple approach.
