### PR TITLE
In panel-element, call space pen attach hooks after attached

### DIFF
--- a/src/panel-element.coffee
+++ b/src/panel-element.coffee
@@ -10,13 +10,13 @@ class PanelElement extends HTMLElement
   setModel: (@model) ->
     view = @model.getItemView()
     @appendChild(view)
-    callAttachHooks(view) # for backward compatibility with SpacePen views
 
     @classList.add(@model.getClassName().split(' ')...) if @model.getClassName()?
     @subscriptions.add @model.onDidChangeVisible(@visibleChanged.bind(this))
     @subscriptions.add @model.onDidDestroy(@destroyed.bind(this))
 
   attachedCallback: ->
+    callAttachHooks(@model.getItemView()) # for backward compatibility with SpacePen views
     @visibleChanged(@model.isVisible())
 
   visibleChanged: (visible) ->


### PR DESCRIPTION
Currently, the attach callbacks are called before the panel item is actually attached to the DOM, so if they try to read/modify things like focus, it won't work.
