### PR TITLE
Fix atom.sh when running from directory with space

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -50,7 +50,7 @@ if [ $OS == 'Mac' ]; then
 
   # If ATOM_PATH isn't a executable file, use spotlight to search for Atom
   if [ ! -x "$ATOM_PATH/$ATOM_APP_NAME" ]; then
-    ATOM_PATH="$(mdfind "kMDItemCFBundleIdentifier == 'com.github.atom'" | grep -v ShipIt | sed '{s#/[^/]*$##; q; }')"
+    ATOM_PATH="$(mdfind "kMDItemCFBundleIdentifier == 'com.github.atom'" | grep -v ShipIt | head -1 | xargs -0 dirname)"
   fi
 
   # Exit if Atom can't be found

--- a/atom.sh
+++ b/atom.sh
@@ -45,12 +45,12 @@ if [ $REDIRECT_STDERR ]; then
 fi
 
 if [ $OS == 'Mac' ]; then
-  ATOM_PATH=${ATOM_PATH:-/Applications} # Set ATOM_PATH unless it is already set
+  ATOM_PATH="${ATOM_PATH:-/Applications}" # Set ATOM_PATH unless it is already set
   ATOM_APP_NAME=Atom.app
 
   # If ATOM_PATH isn't a executable file, use spotlight to search for Atom
   if [ ! -x "$ATOM_PATH/$ATOM_APP_NAME" ]; then
-    ATOM_PATH=$(mdfind "kMDItemCFBundleIdentifier == 'com.github.atom'" | grep -v ShipIt | head -1 | xargs dirname)
+    ATOM_PATH="$(mdfind "kMDItemCFBundleIdentifier == 'com.github.atom'" | grep -v ShipIt | sed '{s#/[^/]*$##; q; }')"
   fi
 
   # Exit if Atom can't be found


### PR DESCRIPTION
Deal with ATOM_PATH having a space by proper quoting, and not passing
the directory name to dirname.

Fixes atom/atom#4336
