### PR TITLE
start develop portable version atom

### DIFF
--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -154,7 +154,7 @@ module.exports = (grunt) ->
       fs.writeFileSync path.join(appDir, 'node_modules', 'symbols-view', 'vendor', 'ctags-win32.exe.ignore'), ''
       fs.writeFileSync path.join(shellAppDir, 'atom.exe.gui'), ''
 
-    dependencies = ['compile', 'generate-license:save', 'generate-module-cache', 'compile-packages-slug']
+    dependencies = ['symlinks', 'compile', 'generate-license:save', 'generate-module-cache', 'compile-packages-slug']
     dependencies.push('copy-info-plist') if process.platform is 'darwin'
     dependencies.push('set-exe-icon') if process.platform is 'win32'
     grunt.task.run(dependencies...)

--- a/build/tasks/symlinks.coffee
+++ b/build/tasks/symlinks.coffee
@@ -1,0 +1,12 @@
+fs = require 'fs'
+path = require 'path'
+
+module.exports = (grunt) ->
+  grunt.registerTask 'symlinks', 'create docapp project', ->
+    shellAppDir = grunt.config.get('atom.shellAppDir')
+    configDir = grunt.option 'portable'
+    projectDir = grunt.option 'project'
+    if shellAppDir and configDir and projectDir
+      fs.symlinkSync configDir, path.join(shellAppDir, '.atom'), 'dir'
+      fs.symlinkSync projectDir, path.join(shellAppDir, 'project'), 'dir'
+

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -96,7 +96,7 @@ class Atom extends Model
   #
   # Returns the absolute path to ~/.atom
   @getConfigDirPath: ->
-    @configDirPath ?= fs.absolute('~/.atom')
+    @configDirPath ?= remote.process.env.ATOM_HOME
 
   # Get the path to Atom's storage directory.
   #

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -410,7 +410,7 @@ class AtomApplication
       PackageManager = require '../package-manager'
       fs = require 'fs-plus'
       @packages = new PackageManager
-        configDirPath: fs.absolute('~/.atom')
+        configDirPath: process.env.ATOM_HOME
         devMode: devMode
         resourcePath: @resourcePath
 

--- a/src/browser/atom-protocol-handler.coffee
+++ b/src/browser/atom-protocol-handler.coffee
@@ -18,7 +18,7 @@ module.exports =
 class AtomProtocolHandler
   constructor: (resourcePath, safeMode) ->
     @loadPaths = []
-    @dotAtomDirectory = path.join(app.getHomeDir(), '.atom')
+    @dotAtomDirectory = process.env.ATOM_HOME
 
     unless safeMode
       @loadPaths.push(path.join(@dotAtomDirectory, 'dev', 'packages'))

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -52,6 +52,7 @@ start = ->
     args.pathsToOpen = args.pathsToOpen.map (pathToOpen) ->
       path.resolve(args.executedFrom ? process.cwd(), pathToOpen.toString())
 
+    setupConfigDirPath()
     setupCoffeeScript()
     if args.devMode
       require(path.join(args.resourcePath, 'src', 'coffee-cache')).register()
@@ -77,6 +78,15 @@ setupCoffeeScript = ->
     coffee = fs.readFileSync(filePath, 'utf8')
     js = CoffeeScript.compile(coffee, filename: filePath)
     module._compile(js, filePath)
+
+# Set Atom's home in process.env.ATOM_HOME
+setupConfigDirPath = ->
+  portablePath = process.resourcesPath.slice(0, -10) + '/.atom'
+  process.env.ATOM_HOME =
+    if fs.existsSync(portablePath)
+      portablePath
+    else
+      fs.absolute('~/.atom')
 
 parseCommandLine = ->
   version = app.getVersion()

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -86,7 +86,7 @@ setupConfigDirPath = ->
     if fs.existsSync(portablePath)
       portablePath
     else
-      fs.absolute('~/.atom')
+      path.join(app.getHomeDir(), '.atom')
 
 parseCommandLine = ->
   version = app.getVersion()

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -81,7 +81,11 @@ setupCoffeeScript = ->
 
 # Set Atom's home in process.env.ATOM_HOME
 setupConfigDirPath = ->
-  portablePath = process.resourcesPath.slice(0, -10) + '/.atom'
+  portablePath =
+    if process.platform == 'darwin'
+      process.resourcesPath.slice(0, -19) + '/.atom'
+    else
+      process.resourcesPath.slice(0, -10) + '/.atom'
   process.env.ATOM_HOME =
     if fs.existsSync(portablePath)
       portablePath

--- a/src/coffee-cache.coffee
+++ b/src/coffee-cache.coffee
@@ -5,7 +5,8 @@ CoffeeScript = require 'coffee-script'
 CSON = require 'season'
 fs = require 'fs-plus'
 
-cacheDir = path.join(fs.absolute('~/.atom'), 'compile-cache')
+homeDir = process.env.ATOM_HOME ?= require('remote').process.env.ATOM_HOME
+cacheDir = path.join(homeDir, 'compile-cache')
 coffeeCacheDir = path.join(cacheDir, 'coffee')
 CSON.setCacheDir(path.join(cacheDir, 'cson'))
 

--- a/static/index.html
+++ b/static/index.html
@@ -3,8 +3,6 @@
 <head>
   <title></title>
 
-  <meta http-equiv="Content-Security-Policy" content="default-src *; script-src 'self'; style-src 'self' 'unsafe-inline';">
-
   <script src="index.js"></script>
 </head>
 <body tabindex="-1">


### PR DESCRIPTION
If an .atom folder is present within the installation directory it will be used.
#2939,  #3320

next steps:
- add --portable flag to build script
- update https://github.com/atom/atom/blob/master/src/config.coffee#L700, copy from dot-atom to portable folder, when folder missing. Mayby add to core settings portable flag when atom build? 

how you look at it?
