### PR TITLE
Clean up view registry API

### DIFF
--- a/spec/pane-view-spec.coffee
+++ b/spec/pane-view-spec.coffee
@@ -229,7 +229,7 @@ describe "PaneView", ->
 
     beforeEach ->
       pane2Model = paneModel.splitRight() # Can't destroy the last pane, so we add another
-      pane2 = containerModel.getView(pane2Model).__spacePenView
+      pane2 = atom.views.getView(pane2Model).__spacePenView
 
     it "triggers a 'pane:removed' event with the pane", ->
       removedHandler = jasmine.createSpy("removedHandler")
@@ -262,7 +262,7 @@ describe "PaneView", ->
 
     beforeEach ->
       pane2Model = paneModel.splitRight(items: [pane.copyActiveItem()])
-      pane2 = containerModel.getView(pane2Model).__spacePenView
+      pane2 = atom.views.getView(pane2Model).__spacePenView
       expect(pane2Model.isActive()).toBe true
 
     it "adds or removes the .active class as appropriate", ->
@@ -309,8 +309,8 @@ describe "PaneView", ->
       pane2Model = pane1Model.splitRight(items: [pane1Model.copyActiveItem()])
       pane3Model = pane2Model.splitDown(items: [pane2Model.copyActiveItem()])
       pane2 = pane2Model._view
-      pane2 = containerModel.getView(pane2Model).__spacePenView
-      pane3 = containerModel.getView(pane3Model).__spacePenView
+      pane2 = atom.views.getView(pane2Model).__spacePenView
+      pane3 = atom.views.getView(pane3Model).__spacePenView
 
       expect(container.find('> atom-pane-axis.horizontal > atom-pane').toArray()).toEqual [pane1[0]]
       expect(container.find('> atom-pane-axis.horizontal > atom-pane-axis.vertical > atom-pane').toArray()).toEqual [pane2[0], pane3[0]]

--- a/spec/panel-container-element-spec.coffee
+++ b/spec/panel-container-element-spec.coffee
@@ -20,15 +20,12 @@ describe "PanelContainerElement", ->
   beforeEach ->
     jasmineContent = document.body.querySelector('#jasmine-content')
 
-    atom.views.addViewProvider
-      modelConstructor: Panel
-      viewConstructor: PanelElement
-    atom.views.addViewProvider
-      modelConstructor: PanelContainer
-      viewConstructor: PanelContainerElement
-    atom.views.addViewProvider
-      modelConstructor: TestPanelContainerItem
-      viewConstructor: TestPanelContainerItemElement
+    atom.views.addViewProvider Panel, (model) ->
+      new PanelElement().initialize(model)
+    atom.views.addViewProvider PanelContainer, (model) ->
+      new PaneContainerElement().initialize(model)
+    atom.views.addViewProvider TestPanelContainerItem, (model) ->
+      new TestPanelContainerItemElement().initialize(model)
 
     container = new PanelContainer({location: 'left'})
     element = atom.views.getView(container)

--- a/spec/panel-container-element-spec.coffee
+++ b/spec/panel-container-element-spec.coffee
@@ -12,7 +12,9 @@ describe "PanelContainerElement", ->
   class TestPanelContainerItemElement extends HTMLElement
     createdCallback: ->
       @classList.add('test-root')
-    setModel: (@model) ->
+    initialize: (@model) ->
+      this
+
   TestPanelContainerItemElement = document.registerElement 'atom-test-container-item-element', prototype: TestPanelContainerItemElement.prototype
 
   beforeEach ->

--- a/spec/panel-container-element-spec.coffee
+++ b/spec/panel-container-element-spec.coffee
@@ -1,11 +1,10 @@
-ViewRegistry = require '../src/view-registry'
 Panel = require '../src/panel'
 PanelElement = require '../src/panel-element'
 PanelContainer = require '../src/panel-container'
 PanelContainerElement = require '../src/panel-container-element'
 
 describe "PanelContainerElement", ->
-  [jasmineContent, element, container, viewRegistry] = []
+  [jasmineContent, element, container] = []
 
   class TestPanelContainerItem
     constructior: ->
@@ -19,19 +18,18 @@ describe "PanelContainerElement", ->
   beforeEach ->
     jasmineContent = document.body.querySelector('#jasmine-content')
 
-    viewRegistry = new ViewRegistry
-    viewRegistry.addViewProvider
+    atom.views.addViewProvider
       modelConstructor: Panel
       viewConstructor: PanelElement
-    viewRegistry.addViewProvider
+    atom.views.addViewProvider
       modelConstructor: PanelContainer
       viewConstructor: PanelContainerElement
-    viewRegistry.addViewProvider
+    atom.views.addViewProvider
       modelConstructor: TestPanelContainerItem
       viewConstructor: TestPanelContainerItemElement
 
-    container = new PanelContainer({viewRegistry, location: 'left'})
-    element = container.getView()
+    container = new PanelContainer({location: 'left'})
+    element = atom.views.getView(container)
     jasmineContent.appendChild(element)
 
   it 'has a location class with value from the model', ->
@@ -44,9 +42,9 @@ describe "PanelContainerElement", ->
 
   describe "adding and removing panels", ->
     it "allows panels to be inserted at any position", ->
-      panel1 = new Panel({viewRegistry, item: new TestPanelContainerItem(), priority: 10})
-      panel2 = new Panel({viewRegistry, item: new TestPanelContainerItem(), priority: 5})
-      panel3 = new Panel({viewRegistry, item: new TestPanelContainerItem(), priority: 8})
+      panel1 = new Panel({item: new TestPanelContainerItem(), priority: 10})
+      panel2 = new Panel({item: new TestPanelContainerItem(), priority: 5})
+      panel3 = new Panel({item: new TestPanelContainerItem(), priority: 8})
 
       container.addPanel(panel1)
       container.addPanel(panel2)
@@ -60,7 +58,7 @@ describe "PanelContainerElement", ->
       it "adds atom-panel elements when a new panel is added to the container; removes them when the panels are destroyed", ->
         expect(element.childNodes.length).toBe 0
 
-        panel1 = new Panel({viewRegistry, item: new TestPanelContainerItem()})
+        panel1 = new Panel({item: new TestPanelContainerItem()})
         container.addPanel(panel1)
         expect(element.childNodes.length).toBe 1
         expect(element.childNodes[0]).toHaveClass 'left'
@@ -69,12 +67,12 @@ describe "PanelContainerElement", ->
 
         expect(element.childNodes[0].tagName).toBe 'ATOM-PANEL'
 
-        panel2 = new Panel({viewRegistry, item: new TestPanelContainerItem()})
+        panel2 = new Panel({item: new TestPanelContainerItem()})
         container.addPanel(panel2)
         expect(element.childNodes.length).toBe 2
 
-        expect(panel1.getView().style.display).not.toBe 'none'
-        expect(panel2.getView().style.display).not.toBe 'none'
+        expect(atom.views.getView(panel1).style.display).not.toBe 'none'
+        expect(atom.views.getView(panel2).style.display).not.toBe 'none'
 
         panel1.destroy()
         expect(element.childNodes.length).toBe 1
@@ -84,26 +82,26 @@ describe "PanelContainerElement", ->
 
     describe "when the container is at the bottom location", ->
       beforeEach ->
-        container = new PanelContainer({viewRegistry, location: 'bottom'})
-        element = container.getView()
+        container = new PanelContainer({location: 'bottom'})
+        element = atom.views.getView(container)
         jasmineContent.appendChild(element)
 
       it "adds atom-panel elements when a new panel is added to the container; removes them when the panels are destroyed", ->
         expect(element.childNodes.length).toBe 0
 
-        panel1 = new Panel({viewRegistry, item: new TestPanelContainerItem(), className: 'one'})
+        panel1 = new Panel({item: new TestPanelContainerItem(), className: 'one'})
         container.addPanel(panel1)
         expect(element.childNodes.length).toBe 1
         expect(element.childNodes[0]).toHaveClass 'bottom'
         expect(element.childNodes[0]).toHaveClass 'tool-panel' # legacy selector support
         expect(element.childNodes[0]).toHaveClass 'panel-bottom' # legacy selector support
         expect(element.childNodes[0].tagName).toBe 'ATOM-PANEL'
-        expect(panel1.getView()).toHaveClass 'one'
+        expect(atom.views.getView(panel1)).toHaveClass 'one'
 
-        panel2 = new Panel({viewRegistry, item: new TestPanelContainerItem(), className: 'two'})
+        panel2 = new Panel({item: new TestPanelContainerItem(), className: 'two'})
         container.addPanel(panel2)
         expect(element.childNodes.length).toBe 2
-        expect(panel2.getView()).toHaveClass 'two'
+        expect(atom.views.getView(panel2)).toHaveClass 'two'
 
         panel1.destroy()
         expect(element.childNodes.length).toBe 1
@@ -113,34 +111,34 @@ describe "PanelContainerElement", ->
 
   describe "when the container is modal", ->
     beforeEach ->
-      container = new PanelContainer({viewRegistry, location: 'modal'})
-      element = container.getView()
+      container = new PanelContainer({location: 'modal'})
+      element = atom.views.getView(container)
       jasmineContent.appendChild(element)
 
     it "allows only one panel to be visible at a time", ->
-      panel1 = new Panel({viewRegistry, item: new TestPanelContainerItem()})
+      panel1 = new Panel({item: new TestPanelContainerItem()})
       container.addPanel(panel1)
 
-      expect(panel1.getView().style.display).not.toBe 'none'
+      expect(atom.views.getView(panel1).style.display).not.toBe 'none'
 
-      panel2 = new Panel({viewRegistry, item: new TestPanelContainerItem()})
+      panel2 = new Panel({item: new TestPanelContainerItem()})
       container.addPanel(panel2)
 
-      expect(panel1.getView().style.display).toBe 'none'
-      expect(panel2.getView().style.display).not.toBe 'none'
+      expect(atom.views.getView(panel1).style.display).toBe 'none'
+      expect(atom.views.getView(panel2).style.display).not.toBe 'none'
 
       panel1.show()
 
-      expect(panel1.getView().style.display).not.toBe 'none'
-      expect(panel2.getView().style.display).toBe 'none'
+      expect(atom.views.getView(panel1).style.display).not.toBe 'none'
+      expect(atom.views.getView(panel2).style.display).toBe 'none'
 
     it "adds the 'modal' class to panels", ->
-      panel1 = new Panel({viewRegistry, item: new TestPanelContainerItem()})
+      panel1 = new Panel({item: new TestPanelContainerItem()})
       container.addPanel(panel1)
 
-      expect(panel1.getView()).toHaveClass 'modal'
+      expect(atom.views.getView(panel1)).toHaveClass 'modal'
 
       # legacy selector support
-      expect(panel1.getView()).not.toHaveClass 'tool-panel'
-      expect(panel1.getView()).toHaveClass 'overlay'
-      expect(panel1.getView()).toHaveClass 'from-top'
+      expect(atom.views.getView(panel1)).not.toHaveClass 'tool-panel'
+      expect(atom.views.getView(panel1)).toHaveClass 'overlay'
+      expect(atom.views.getView(panel1)).toHaveClass 'from-top'

--- a/spec/panel-container-spec.coffee
+++ b/spec/panel-container-spec.coffee
@@ -1,16 +1,14 @@
-ViewRegistry = require '../src/view-registry'
 Panel = require '../src/panel'
 PanelContainer = require '../src/panel-container'
 
 describe "PanelContainer", ->
-  [container, viewRegistry] = []
+  [container] = []
 
   class TestPanelItem
     constructior: ->
 
   beforeEach ->
-    viewRegistry = new ViewRegistry
-    container = new PanelContainer({viewRegistry})
+    container = new PanelContainer
 
   describe "::addPanel(panel)", ->
     it 'emits an onDidAddPanel event with the index the panel was inserted at', ->
@@ -46,7 +44,7 @@ describe "PanelContainer", ->
       [initialPanel] = []
       beforeEach ->
         # 'left' logic is the same as 'top'
-        container = new PanelContainer({viewRegistry, location: 'left'})
+        container = new PanelContainer({location: 'left'})
         initialPanel = new Panel(item: new TestPanelItem())
         container.addPanel(initialPanel)
 
@@ -75,7 +73,7 @@ describe "PanelContainer", ->
       [initialPanel] = []
       beforeEach ->
         # 'bottom' logic is the same as 'right'
-        container = new PanelContainer({viewRegistry, location: 'right'})
+        container = new PanelContainer({location: 'right'})
         initialPanel = new Panel(item: new TestPanelItem())
         container.addPanel(initialPanel)
 

--- a/spec/panel-element-spec.coffee
+++ b/spec/panel-element-spec.coffee
@@ -18,12 +18,10 @@ describe "PanelElement", ->
   beforeEach ->
     jasmineContent = document.body.querySelector('#jasmine-content')
 
-    atom.views.addViewProvider
-      modelConstructor: Panel
-      viewConstructor: PanelElement
-    atom.views.addViewProvider
-      modelConstructor: TestPanelItem
-      viewConstructor: TestPanelItemElement
+    atom.views.addViewProvider Panel, (model) ->
+      new PanelElement().initialize(model)
+    atom.views.addViewProvider TestPanelItem, (model) ->
+      new TestPanelItemElement().initialize(model)
 
   it 'removes the element when the panel is destroyed', ->
     panel = new Panel({item: new TestPanelItem})

--- a/spec/panel-element-spec.coffee
+++ b/spec/panel-element-spec.coffee
@@ -10,7 +10,9 @@ describe "PanelElement", ->
   class TestPanelItemElement extends HTMLElement
     createdCallback: ->
       @classList.add('test-root')
-    setModel: (@model) ->
+    initialize: (@model) ->
+      this
+
   TestPanelItemElement = document.registerElement 'atom-test-item-element', prototype: TestPanelItemElement.prototype
 
   beforeEach ->

--- a/spec/panel-element-spec.coffee
+++ b/spec/panel-element-spec.coffee
@@ -1,9 +1,8 @@
-ViewRegistry = require '../src/view-registry'
 Panel = require '../src/panel'
 PanelElement = require '../src/panel-element'
 
 describe "PanelElement", ->
-  [jasmineContent, element, panel, viewRegistry] = []
+  [jasmineContent, element, panel] = []
 
   class TestPanelItem
     constructior: ->
@@ -17,17 +16,16 @@ describe "PanelElement", ->
   beforeEach ->
     jasmineContent = document.body.querySelector('#jasmine-content')
 
-    viewRegistry = new ViewRegistry
-    viewRegistry.addViewProvider
+    atom.views.addViewProvider
       modelConstructor: Panel
       viewConstructor: PanelElement
-    viewRegistry.addViewProvider
+    atom.views.addViewProvider
       modelConstructor: TestPanelItem
       viewConstructor: TestPanelItemElement
 
   it 'removes the element when the panel is destroyed', ->
-    panel = new Panel({viewRegistry, item: new TestPanelItem})
-    element = panel.getView()
+    panel = new Panel({item: new TestPanelItem})
+    element = atom.views.getView(panel)
     jasmineContent.appendChild(element)
 
     expect(element.parentNode).toBe jasmineContent
@@ -36,15 +34,15 @@ describe "PanelElement", ->
 
   describe "changing panel visibility", ->
     it 'initially renders panel created with visibile: false', ->
-      panel = new Panel({viewRegistry, visible: false, item: new TestPanelItem})
-      element = panel.getView()
+      panel = new Panel({visible: false, item: new TestPanelItem})
+      element = atom.views.getView(panel)
       jasmineContent.appendChild(element)
 
       expect(element.style.display).toBe 'none'
 
     it 'hides and shows the panel element when Panel::hide() and Panel::show() are called', ->
-      panel = new Panel({viewRegistry, item: new TestPanelItem})
-      element = panel.getView()
+      panel = new Panel({item: new TestPanelItem})
+      element = atom.views.getView(panel)
       jasmineContent.appendChild(element)
 
       expect(element.style.display).not.toBe 'none'
@@ -57,8 +55,8 @@ describe "PanelElement", ->
 
   describe "when a class name is specified", ->
     it 'initially renders panel created with visibile: false', ->
-      panel = new Panel({viewRegistry, className: 'some classes', item: new TestPanelItem})
-      element = panel.getView()
+      panel = new Panel({className: 'some classes', item: new TestPanelItem})
+      element = atom.views.getView(panel)
       jasmineContent.appendChild(element)
 
       expect(element).toHaveClass 'some'

--- a/spec/view-registry-spec.coffee
+++ b/spec/view-registry-spec.coffee
@@ -25,47 +25,27 @@ describe "ViewRegistry", ->
 
     describe "when passed a model object", ->
       describe "when a view provider is registered matching the object's constructor", ->
-        describe "when the provider has a viewConstructor property", ->
-          it "constructs a view element and assigns the model on it", ->
-            class TestModel
+        it "constructs a view element and assigns the model on it", ->
+          class TestModel
 
-            class TestModelSubclass extends TestModel
+          class TestModelSubclass extends TestModel
 
-            class TestView
-              setModel: (@model) ->
+          class TestView
+            initialize: (@model) -> this
 
-            model = new TestModel
+          model = new TestModel
 
-            registry.addViewProvider
-              modelConstructor: TestModel
-              viewConstructor: TestView
+          registry.addViewProvider TestModel, (model) ->
+            new TestView().initialize(model)
 
-            view = registry.getView(model)
-            expect(view instanceof TestView).toBe true
-            expect(view.model).toBe model
+          view = registry.getView(model)
+          expect(view instanceof TestView).toBe true
+          expect(view.model).toBe model
 
-            subclassModel = new TestModelSubclass
-            view2 = registry.getView(subclassModel)
-            expect(view2 instanceof TestView).toBe true
-            expect(view2.model).toBe subclassModel
-
-        describe "when the provider has a createView method", ->
-          it "constructs a view element by calling the createView method with the model", ->
-            class TestModel
-            class TestView
-              setModel: (@model) ->
-
-            registry.addViewProvider
-              modelConstructor: TestModel
-              createView: (model) ->
-                view = new TestView
-                view.setModel(model)
-                view
-
-            model = new TestModel
-            view = registry.getView(model)
-            expect(view instanceof TestView).toBe true
-            expect(view.model).toBe model
+          subclassModel = new TestModelSubclass
+          view2 = registry.getView(subclassModel)
+          expect(view2 instanceof TestView).toBe true
+          expect(view2.model).toBe subclassModel
 
       describe "when no view provider is registered for the object's constructor", ->
         describe "when the object has a .getViewClass() method", ->
@@ -97,10 +77,10 @@ describe "ViewRegistry", ->
     it "returns a disposable that can be used to remove the provider", ->
       class TestModel
       class TestView
-        setModel: (@model) ->
-      disposable = registry.addViewProvider
-        modelConstructor: TestModel
-        viewConstructor: TestView
+        initialize: (@model) -> this
+
+      disposable = registry.addViewProvider TestModel, (model) ->
+        new TestView().initialize(model)
 
       expect(registry.getView(new TestModel) instanceof TestView).toBe true
       disposable.dispose()

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -482,7 +482,7 @@ describe "Workspace", ->
         expect(panel).toBeDefined()
         expect(addPanelSpy).toHaveBeenCalledWith({panel, index: 0})
 
-        itemView = atom.workspace.getLeftPanels()[0].getItemView()
+        itemView = atom.views.getView(atom.workspace.getLeftPanels()[0].getItem())
         expect(itemView instanceof TestItemElement).toBe(true)
         expect(itemView.getModel()).toBe(model)
 
@@ -497,7 +497,7 @@ describe "Workspace", ->
         expect(panel).toBeDefined()
         expect(addPanelSpy).toHaveBeenCalledWith({panel, index: 0})
 
-        itemView = atom.workspace.getRightPanels()[0].getItemView()
+        itemView = atom.views.getView(atom.workspace.getRightPanels()[0].getItem())
         expect(itemView instanceof TestItemElement).toBe(true)
         expect(itemView.getModel()).toBe(model)
 
@@ -512,7 +512,7 @@ describe "Workspace", ->
         expect(panel).toBeDefined()
         expect(addPanelSpy).toHaveBeenCalledWith({panel, index: 0})
 
-        itemView = atom.workspace.getTopPanels()[0].getItemView()
+        itemView = atom.views.getView(atom.workspace.getTopPanels()[0].getItem())
         expect(itemView instanceof TestItemElement).toBe(true)
         expect(itemView.getModel()).toBe(model)
 
@@ -527,7 +527,7 @@ describe "Workspace", ->
         expect(panel).toBeDefined()
         expect(addPanelSpy).toHaveBeenCalledWith({panel, index: 0})
 
-        itemView = atom.workspace.getBottomPanels()[0].getItemView()
+        itemView = atom.views.getView(atom.workspace.getBottomPanels()[0].getItem())
         expect(itemView instanceof TestItemElement).toBe(true)
         expect(itemView.getModel()).toBe(model)
 
@@ -542,6 +542,6 @@ describe "Workspace", ->
         expect(panel).toBeDefined()
         expect(addPanelSpy).toHaveBeenCalledWith({panel, index: 0})
 
-        itemView = atom.workspace.getModalPanels()[0].getItemView()
+        itemView = atom.views.getView(atom.workspace.getModalPanels()[0].getItem())
         expect(itemView instanceof TestItemElement).toBe(true)
         expect(itemView.getModel()).toBe(model)

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -466,10 +466,8 @@ describe "Workspace", ->
       getModel: -> @model
 
     beforeEach ->
-      atom.views.addViewProvider(
-        modelConstructor: TestItem
-        viewConstructor: TestItemElement
-      )
+      atom.views.addViewProvider TestItem, (model) ->
+        new TestItemElement().initialize(model)
 
     describe '::addLeftPanel(model)', ->
       it 'adds a panel to the correct panel container', ->

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -462,7 +462,7 @@ describe "Workspace", ->
 
     class TestItemElement extends HTMLElement
       constructor: ->
-      setModel: (@model) ->
+      initialize: (@model) -> this
       getModel: -> @model
 
     beforeEach ->

--- a/src/pane-axis-element.coffee
+++ b/src/pane-axis-element.coffee
@@ -8,7 +8,7 @@ class PaneAxisElement extends HTMLElement
   detachedCallback: ->
     @subscriptions.dispose()
 
-  setModel: (@model) ->
+  initialize: (@model) ->
     @subscriptions.add @model.onDidAddChild(@childAdded.bind(this))
     @subscriptions.add @model.onDidRemoveChild(@childRemoved.bind(this))
     @subscriptions.add @model.onDidReplaceChild(@childReplaced.bind(this))
@@ -20,6 +20,7 @@ class PaneAxisElement extends HTMLElement
         @classList.add('horizontal', 'pane-row')
       when 'vertical'
         @classList.add('vertical', 'pane-column')
+    this
 
   childAdded: ({child, index}) ->
     view = atom.views.getView(child)

--- a/src/pane-axis-element.coffee
+++ b/src/pane-axis-element.coffee
@@ -22,12 +22,12 @@ class PaneAxisElement extends HTMLElement
         @classList.add('vertical', 'pane-column')
 
   childAdded: ({child, index}) ->
-    view = @model.getView(child)
+    view = atom.views.getView(child)
     @insertBefore(view, @children[index])
     callAttachHooks(view) # for backward compatibility with SpacePen views
 
   childRemoved: ({child}) ->
-    view = @model.getView(child)
+    view = atom.views.getView(child)
     view.remove()
 
   childReplaced:  ({index, oldChild, newChild}) ->

--- a/src/pane-axis.coffee
+++ b/src/pane-axis.coffee
@@ -39,9 +39,6 @@ class PaneAxis extends Model
 
   getOrientation: -> @orientation
 
-  getView: (object) ->
-    @container.getView(object)
-
   getChildren: -> @children.slice()
 
   getPanes: ->

--- a/src/pane-container-element.coffee
+++ b/src/pane-container-element.coffee
@@ -19,7 +19,7 @@ class PaneContainerElement extends HTMLElement
     focusedElement = document.activeElement if @hasFocus()
     @firstChild?.remove()
     if root?
-      view = @model.getView(root)
+      view = atom.views.getView(root)
       @appendChild(view)
       callAttachHooks(view)
       focusedElement?.focus()
@@ -45,7 +45,7 @@ class PaneContainerElement extends HTMLElement
       y = pointB.y - pointA.y
       Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2))
 
-    paneView = @model.getView(@model.getActivePane())
+    paneView = atom.views.getView(@model.getActivePane())
     box = @boundingBoxForPaneView(paneView)
 
     paneViews = _.toArray(@querySelectorAll('atom-pane'))

--- a/src/pane-container-element.coffee
+++ b/src/pane-container-element.coffee
@@ -11,9 +11,10 @@ class PaneContainerElement extends HTMLElement
     PaneContainerView ?= require './pane-container-view'
     @__spacePenView = new PaneContainerView(this)
 
-  setModel: (@model) ->
+  initialize: (@model) ->
     @subscriptions.add @model.observeRoot(@rootChanged.bind(this))
     @__spacePenView.setModel(@model)
+    this
 
   rootChanged: (root) ->
     focusedElement = document.activeElement if @hasFocus()

--- a/src/pane-container-view.coffee
+++ b/src/pane-container-view.coffee
@@ -23,7 +23,7 @@ class PaneContainerView extends View
     @subscriptions.add @model.onDidChangeActivePaneItem(@onActivePaneItemChanged)
 
   getRoot: ->
-    view = @model.getView(@model.getRoot())
+    view = atom.views.getView(@model.getRoot())
     view.__spacePenView ? view
 
   onActivePaneItemChanged: (activeItem) =>
@@ -55,7 +55,7 @@ class PaneContainerView extends View
     @getActivePaneView()
 
   getActivePaneView: ->
-    @model.getView(@model.getActivePane()).__spacePenView
+    atom.views.getView(@model.getActivePane()).__spacePenView
 
   getActivePaneItem: ->
     @model.getActivePaneItem()
@@ -64,7 +64,7 @@ class PaneContainerView extends View
     @getActivePaneView()?.activeView
 
   paneForUri: (uri) ->
-    @model.getView(@model.paneForUri(uri)).__spacePenView
+    atom.views.getView(@model.paneForUri(uri)).__spacePenView
 
   focusNextPaneView: ->
     @model.activateNextPane()

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -56,21 +56,14 @@ class PaneContainer extends Model
     activePaneId: @activePane.id
 
   registerViewProviders: ->
-    atom.views.addViewProvider
-      modelConstructor: PaneContainer
-      viewConstructor: PaneContainerElement
-
-    atom.views.addViewProvider
-      modelConstructor: PaneAxis
-      viewConstructor: PaneAxisElement
-
-    atom.views.addViewProvider
-      modelConstructor: Pane
-      viewConstructor: PaneElement
-
-    atom.views.addViewProvider
-      modelConstructor: TextEditor
-      viewConstructor: TextEditorElement
+    atom.views.addViewProvider PaneContainer, (model) ->
+      new PaneContainerElement().initialize(model)
+    atom.views.addViewProvider PaneAxis, (model) ->
+      new PaneAxisElement().initialize(model)
+    atom.views.addViewProvider Pane, (model) ->
+      new PaneElement().initialize(model)
+    atom.views.addViewProvider TextEditor, (model) ->
+      new TextEditorElement().initialize(model)
 
   onDidChangeRoot: (fn) ->
     @emitter.on 'did-change-root', fn

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -9,7 +9,6 @@ PaneAxisElement = require './pane-axis-element'
 PaneAxis = require './pane-axis'
 TextEditor = require './text-editor'
 TextEditorElement = require './text-editor-element'
-ViewRegistry = require './view-registry'
 ItemRegistry = require './item-registry'
 
 module.exports =
@@ -36,7 +35,6 @@ class PaneContainer extends Model
     @subscriptions = new CompositeDisposable
 
     @itemRegistry = new ItemRegistry
-    @viewRegistry = params?.viewRegistry ? new ViewRegistry
     @registerViewProviders()
 
     @setRoot(params?.root ? new Pane)
@@ -58,24 +56,21 @@ class PaneContainer extends Model
     activePaneId: @activePane.id
 
   registerViewProviders: ->
-    @viewRegistry.addViewProvider
+    atom.views.addViewProvider
       modelConstructor: PaneContainer
       viewConstructor: PaneContainerElement
 
-    @viewRegistry.addViewProvider
+    atom.views.addViewProvider
       modelConstructor: PaneAxis
       viewConstructor: PaneAxisElement
 
-    @viewRegistry.addViewProvider
+    atom.views.addViewProvider
       modelConstructor: Pane
       viewConstructor: PaneElement
 
-    @viewRegistry.addViewProvider
+    atom.views.addViewProvider
       modelConstructor: TextEditor
       viewConstructor: TextEditorElement
-
-  getView: (object) ->
-    @viewRegistry.getView(object)
 
   onDidChangeRoot: (fn) ->
     @emitter.on 'did-change-root', fn

--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -66,7 +66,7 @@ class PaneElement extends HTMLElement
     return unless item?
 
     hasFocus = @hasFocus()
-    itemView = @model.getView(item)
+    itemView = atom.views.getView(item)
 
     unless @itemViews.contains(itemView)
       @itemViews.appendChild(itemView)
@@ -94,14 +94,14 @@ class PaneElement extends HTMLElement
       itemView.style.display = 'none'
 
   itemRemoved: ({item, index, destroyed}) ->
-    if viewToRemove = @model.getView(item)
+    if viewToRemove = atom.views.getView(item)
       callRemoveHooks(viewToRemove) if destroyed
       viewToRemove.remove()
 
   paneDestroyed: ->
     @subscriptions.dispose()
 
-  getActiveView: -> @model.getView(@model.getActiveItem())
+  getActiveView: -> atom.views.getView(@model.getActiveItem())
 
   hasFocus: ->
     this is document.activeElement or @contains(document.activeElement)

--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -43,15 +43,16 @@ class PaneElement extends HTMLElement
   createSpacePenShim: ->
     @__spacePenView = new PaneView(this)
 
-  getModel: -> @model
-
-  setModel: (@model) ->
+  initialize: (@model) ->
     @subscriptions.add @model.onDidActivate(@activated.bind(this))
     @subscriptions.add @model.observeActive(@activeStatusChanged.bind(this))
     @subscriptions.add @model.observeActiveItem(@activeItemChanged.bind(this))
     @subscriptions.add @model.onDidRemoveItem(@itemRemoved.bind(this))
     @subscriptions.add @model.onDidDestroy(@paneDestroyed.bind(this))
     @__spacePenView.setModel(@model)
+    this
+
+  getModel: -> @model
 
   activated: ->
     @focus()

--- a/src/pane-view.coffee
+++ b/src/pane-view.coffee
@@ -153,15 +153,15 @@ class PaneView extends View
   activeItemModifiedChanged: =>
     @trigger 'pane:active-item-modified-status-changed'
 
-  @::accessor 'activeView', -> @model.getView(@activeItem)?.__spacePenView
+  @::accessor 'activeView', -> atom.views.getView(@activeItem)?.__spacePenView
 
-  splitLeft: (items...) -> @model.getView(@model.splitLeft({items})).__spacePenView
+  splitLeft: (items...) -> atom.views.getView(@model.splitLeft({items})).__spacePenView
 
-  splitRight: (items...) -> @model.getView(@model.splitRight({items})).__spacePenView
+  splitRight: (items...) -> atom.views.getView(@model.splitRight({items})).__spacePenView
 
-  splitUp: (items...) -> @model.getView(@model.splitUp({items})).__spacePenView
+  splitUp: (items...) -> atom.views.getView(@model.splitUp({items})).__spacePenView
 
-  splitDown: (items...) -> @model.getView(@model.splitDown({items})).__spacePenView
+  splitDown: (items...) -> atom.views.getView(@model.splitDown({items})).__spacePenView
 
   getContainer: -> @closest('atom-pane-container').view()
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -53,9 +53,6 @@ class Pane extends Model
     params.activeItem = find params.items, (item) -> item.getUri?() is activeItemUri
     params
 
-  getView: (object) ->
-    @container.getView(object)
-
   getParent: -> @parent
 
   setParent: (@parent) -> @parent

--- a/src/panel-container-element.coffee
+++ b/src/panel-container-element.coffee
@@ -13,7 +13,7 @@ class PanelContainerElement extends HTMLElement
     @classList.add(@model.getLocation())
 
   panelAdded: ({panel, index}) ->
-    panelElement = panel.getView()
+    panelElement = atom.views.getView(panel)
     panelElement.classList.add(@model.getLocation())
     if @model.isModal()
       panelElement.classList.add("overlay", "from-top")
@@ -32,7 +32,7 @@ class PanelContainerElement extends HTMLElement
         @hideAllPanelsExcept(panel) if visible
 
   panelRemoved: ({panel, index}) ->
-    @removeChild(panel.getView())
+    @removeChild(atom.views.getView(panel))
 
   destroyed: ->
     @subscriptions.dispose()

--- a/src/panel-container-element.coffee
+++ b/src/panel-container-element.coffee
@@ -4,13 +4,14 @@ class PanelContainerElement extends HTMLElement
   createdCallback: ->
     @subscriptions = new CompositeDisposable
 
-  getModel: -> @model
-
-  setModel: (@model) ->
+  initialize: (@model) ->
     @subscriptions.add @model.onDidAddPanel(@panelAdded.bind(this))
     @subscriptions.add @model.onDidRemovePanel(@panelRemoved.bind(this))
     @subscriptions.add @model.onDidDestroy(@destroyed.bind(this))
     @classList.add(@model.getLocation())
+    this
+
+  getModel: -> @model
 
   panelAdded: ({panel, index}) ->
     panelElement = atom.views.getView(panel)

--- a/src/panel-container.coffee
+++ b/src/panel-container.coffee
@@ -2,7 +2,7 @@
 
 module.exports =
 class PanelContainer
-  constructor: ({@viewRegistry, @location}) ->
+  constructor: ({@location}={}) ->
     @emitter = new Emitter
     @subscriptions = new CompositeDisposable
     @panels = []
@@ -29,8 +29,6 @@ class PanelContainer
   ###
   Section: Panels
   ###
-
-  getView: -> @viewRegistry.getView(this)
 
   getLocation: -> @location
 

--- a/src/panel-element.coffee
+++ b/src/panel-element.coffee
@@ -8,15 +8,17 @@ class PanelElement extends HTMLElement
   getModel: -> @model
 
   setModel: (@model) ->
-    view = @model.getItemView()
-    @appendChild(view)
+    @appendChild(@getItemView())
 
     @classList.add(@model.getClassName().split(' ')...) if @model.getClassName()?
     @subscriptions.add @model.onDidChangeVisible(@visibleChanged.bind(this))
     @subscriptions.add @model.onDidDestroy(@destroyed.bind(this))
 
+  getItemView: ->
+    atom.views.getView(@model.getItem())
+
   attachedCallback: ->
-    callAttachHooks(@model.getItemView()) # for backward compatibility with SpacePen views
+    callAttachHooks(@getItemView()) # for backward compatibility with SpacePen views
     @visibleChanged(@model.isVisible())
 
   visibleChanged: (visible) ->

--- a/src/panel-element.coffee
+++ b/src/panel-element.coffee
@@ -5,14 +5,15 @@ class PanelElement extends HTMLElement
   createdCallback: ->
     @subscriptions = new CompositeDisposable
 
-  getModel: -> @model
-
-  setModel: (@model) ->
+  initialize: (@model) ->
     @appendChild(@getItemView())
 
     @classList.add(@model.getClassName().split(' ')...) if @model.getClassName()?
     @subscriptions.add @model.onDidChangeVisible(@visibleChanged.bind(this))
     @subscriptions.add @model.onDidDestroy(@destroyed.bind(this))
+    this
+
+  getModel: -> @model
 
   getItemView: ->
     atom.views.getView(@model.getItem())

--- a/src/panel.coffee
+++ b/src/panel.coffee
@@ -14,7 +14,7 @@ class Panel
   Section: Construction and Destruction
   ###
 
-  constructor: ({@viewRegistry, @item, @visible, @priority, @className}) ->
+  constructor: ({@item, @visible, @priority, @className}) ->
     @emitter = new Emitter
     @visible ?= true
     @priority ?= 100
@@ -50,15 +50,8 @@ class Panel
   Section: Panel Details
   ###
 
-  # Public: Gets this panel model's view DOM node.
-  #
-  # Returns an `<atom-panel>` {Element}
-  getView: -> @viewRegistry.getView(this)
-
-  # Public: Gets your panel contents view.
-  #
-  # Returns an {Element} or jQuery element, depeneding on how you created the panel.
-  getItemView: -> @viewRegistry.getView(@item)
+  # Public: Returns the panel's item.
+  getItem: -> @item
 
   # Public: Returns a {Number} indicating this panel's priority.
   getPriority: -> @priority

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -62,6 +62,10 @@ class TextEditorElement extends HTMLElement
     @component.checkForVisibilityChange()
     @focus() if @focusOnAttach
 
+  initialize: (model) ->
+    @setModel(model)
+    this
+
   setModel: (model) ->
     throw new Error("Model already assigned on TextEditorElement") if @model?
     return if model.isDestroyed()
@@ -70,8 +74,8 @@ class TextEditorElement extends HTMLElement
     @mountComponent()
     @addGrammarScopeAttribute()
     @addMiniAttributeIfNeeded()
-    @model.onDidChangeGrammar => @addGrammarScopeAttribute()
     @addEncodingAttribute()
+    @model.onDidChangeGrammar => @addGrammarScopeAttribute()
     @model.onDidChangeEncoding => @addEncodingAttribute()
     @model.onDidDestroy => @unmountComponent()
     @__spacePenView.setModel(@model)

--- a/src/view-registry.coffee
+++ b/src/view-registry.coffee
@@ -1,3 +1,4 @@
+Grim = require 'grim'
 {Disposable} = require 'event-kit'
 
 # Essential: `ViewRegistry` handles the association between model and view
@@ -76,10 +77,16 @@ class ViewRegistry
   #
   # Returns a {Disposable} on which `.dispose()` can be called to remove the
   # added provider.
-  addViewProvider: (providerSpec) ->
-    @providers.push(providerSpec)
+  addViewProvider: (modelConstructor, createView) ->
+    if arguments.length is 1
+      Grim.deprecate("atom.views.addViewProvider now takes 2 arguments: a model constructor and a createView function. See docs for details.")
+      provider = modelConstructor
+    else
+      provider = {modelConstructor, createView}
+
+    @providers.push(provider)
     new Disposable =>
-      @providers = @providers.filter (provider) -> provider isnt providerSpec
+      @providers = @providers.filter (p) -> p isnt provider
 
   # Essential: Get the view associated with an object in the workspace.
   #

--- a/src/view-registry.coffee
+++ b/src/view-registry.coffee
@@ -131,7 +131,7 @@ class ViewRegistry
       element = provider.createView?(object)
       unless element?
         element = new provider.viewConstructor
-        element.setModel(object)
+        element.initialize?(object) ? element.setModel?(object)
       element
     else if viewConstructor = object?.getViewClass?()
       view = new viewConstructor(object)

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -62,9 +62,7 @@ class WorkspaceElement extends HTMLElement
     WorkspaceView ?= require './workspace-view'
     @__spacePenView = new WorkspaceView(this)
 
-  getModel: -> @model
-
-  setModel: (@model) ->
+  initialize: (@model) ->
     @paneContainer = atom.views.getView(@model.paneContainer)
     @verticalAxis.appendChild(@paneContainer)
     @addEventListener 'focus', @handleFocus.bind(this)
@@ -85,6 +83,9 @@ class WorkspaceElement extends HTMLElement
     @appendChild(@panelContainers.modal)
 
     @__spacePenView.setModel(@model)
+    this
+
+  getModel: -> @model
 
   setTextEditorFontSize: (fontSize) ->
     @updateGlobalEditorStyle('font-size', fontSize + 'px')

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -70,11 +70,11 @@ class WorkspaceElement extends HTMLElement
     @addEventListener 'focus', @handleFocus.bind(this)
 
     @panelContainers =
-      top: @model.panelContainers.top.getView()
-      left: @model.panelContainers.left.getView()
-      right: @model.panelContainers.right.getView()
-      bottom: @model.panelContainers.bottom.getView()
-      modal: @model.panelContainers.modal.getView()
+      top: atom.views.getView(@model.panelContainers.top)
+      left: atom.views.getView(@model.panelContainers.left)
+      right: atom.views.getView(@model.panelContainers.right)
+      bottom: atom.views.getView(@model.panelContainers.bottom)
+      modal: atom.views.getView(@model.panelContainers.modal)
 
     @horizontalAxis.insertBefore(@panelContainers.left, @verticalAxis)
     @horizontalAxis.appendChild(@panelContainers.right)

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -66,17 +66,14 @@ class Workspace extends Model
         when 'atom://.atom/init-script'
           @open(atom.getUserInitScriptPath())
 
-    atom.views.addViewProvider
-      modelConstructor: Workspace
-      viewConstructor: WorkspaceElement
+    atom.views.addViewProvider Workspace, (model) ->
+      new WorkspaceElement().initialize(model)
 
-    atom.views.addViewProvider
-      modelConstructor: PanelContainer
-      viewConstructor: PanelContainerElement
+    atom.views.addViewProvider PanelContainer, (model) ->
+      new PanelContainerElement().initialize(model)
 
-    atom.views.addViewProvider
-      modelConstructor: Panel
-      viewConstructor: PanelElement
+    atom.views.addViewProvider Panel, (model) ->
+      new PanelElement().initialize(model)
 
   # Called by the Serializable mixin during deserialization
   deserializeParams: (params) ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -14,7 +14,6 @@ Panel = require './panel'
 PanelElement = require './panel-element'
 PanelContainer = require './panel-container'
 PanelContainerElement = require './panel-container-element'
-ViewRegistry = require './view-registry'
 WorkspaceElement = require './workspace-element'
 
 # Essential: Represents the state of the user interface for the entire window.
@@ -34,7 +33,6 @@ class Workspace extends Model
   @delegatesProperty 'activePane', 'activePaneItem', toProperty: 'paneContainer'
 
   @properties
-    viewRegistry: null
     paneContainer: null
     fullScreen: false
     destroyedItemUris: -> []
@@ -45,16 +43,15 @@ class Workspace extends Model
     @emitter = new Emitter
     @openers = []
 
-    viewRegistry = atom.views
-    @paneContainer ?= new PaneContainer({viewRegistry})
+    @paneContainer ?= new PaneContainer()
     @paneContainer.onDidDestroyPaneItem(@didDestroyPaneItem)
 
     @panelContainers =
-      top: new PanelContainer({viewRegistry, location: 'top'})
-      left: new PanelContainer({viewRegistry, location: 'left'})
-      right: new PanelContainer({viewRegistry, location: 'right'})
-      bottom: new PanelContainer({viewRegistry, location: 'bottom'})
-      modal: new PanelContainer({viewRegistry, location: 'modal'})
+      top: new PanelContainer({location: 'top'})
+      left: new PanelContainer({location: 'left'})
+      right: new PanelContainer({location: 'right'})
+      bottom: new PanelContainer({location: 'bottom'})
+      modal: new PanelContainer({location: 'modal'})
 
     @subscribeToActiveItem()
 
@@ -86,7 +83,6 @@ class Workspace extends Model
     for packageName in params.packagesWithActiveGrammars ? []
       atom.packages.getLoadedPackage(packageName)?.loadGrammarsSync()
 
-    params.paneContainer.viewRegistry = atom.views
     params.paneContainer = PaneContainer.deserialize(params.paneContainer)
     params
 
@@ -732,5 +728,4 @@ class Workspace extends Model
 
   addPanel: (location, options) ->
     options ?= {}
-    options.viewRegistry = atom.views
     @panelContainers[location].addPanel(new Panel(options))


### PR DESCRIPTION
After talking with the team, we've decided that instead of #4353, we'll just make some more minimal changes to the view registration system. This PR:
- Removes all view-related methods from the models.
- Simplifies the API for adding view providers to the view registry; you now always pass a model constructor and a function that returns a view.
