### PR TITLE
Allow setting editor text content in HTML

### DIFF
--- a/spec/text-editor-element-spec.coffee
+++ b/spec/text-editor-element-spec.coffee
@@ -20,6 +20,11 @@ describe "TextEditorElement", ->
       element = jasmineContent.firstChild
       expect(element.getModel().getPlaceholderText()).toBe 'testing'
 
+    it "honors the text content", ->
+      jasmineContent.innerHTML = "<atom-text-editor>testing</atom-text-editor>"
+      element = jasmineContent.firstChild
+      expect(element.getModel().getText()).toBe 'testing'
+
   describe "when the model is assigned", ->
     it "adds the 'mini' attribute if .isMini() returns true on the model", ->
       element = new TextEditorElement

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -86,7 +86,7 @@ class TextEditorElement extends HTMLElement
 
   buildModel: ->
     @setModel(new TextEditor(
-      buffer: new TextBuffer
+      buffer: new TextBuffer(@textContent)
       softWrapped: false
       tabLength: 2
       softTabs: true


### PR DESCRIPTION
This will be useful when updating the [styleguide's examples](https://github.com/atom/styleguide/blob/master/lib/styleguide-view.coffee#L48) to use custom elements.
