### PR TITLE
Add `TextEditorElement` methods needed to replace deprecated APIs

### DIFF
--- a/spec/text-editor-element-spec.coffee
+++ b/spec/text-editor-element-spec.coffee
@@ -124,3 +124,13 @@ describe "TextEditorElement", ->
       element.getModel().setText("goodbye")
       expect(window.requestAnimationFrame).not.toHaveBeenCalled()
       expect(element.shadowRoot.textContent).toContain "goodbye"
+
+  describe "::getDefaultCharacterWidth", ->
+    it "throws an exception if the editor is not attached", ->
+      element = new TextEditorElement
+      expect(-> element.getDefaultCharacterWidth()).toThrow("The editor must be attached to get the default character width")
+
+    it "returns the width of a character in the root scope", ->
+      element = new TextEditorElement
+      jasmine.attachToDOM(element)
+      expect(element.getDefaultCharacterWidth()).toBeGreaterThan(0)

--- a/spec/text-editor-element-spec.coffee
+++ b/spec/text-editor-element-spec.coffee
@@ -104,6 +104,27 @@ describe "TextEditorElement", ->
       scrollbarWidth = verticalScrollbarNode.offsetWidth - verticalScrollbarNode.clientWidth
       expect(scrollbarWidth).toEqual(8)
 
+  describe "::onDidAttach and ::onDidDetach", ->
+    it "invokes callbacks when the element is attached and detached", ->
+      element = new TextEditorElement
+
+      attachedCallback = jasmine.createSpy("attachedCallback")
+      detachedCallback = jasmine.createSpy("detachedCallback")
+
+      element.onDidAttach(attachedCallback)
+      element.onDidDetach(detachedCallback)
+
+      jasmine.attachToDOM(element)
+
+      expect(attachedCallback).toHaveBeenCalled()
+      expect(detachedCallback).not.toHaveBeenCalled()
+
+      attachedCallback.reset()
+      element.remove()
+
+      expect(attachedCallback).not.toHaveBeenCalled()
+      expect(detachedCallback).toHaveBeenCalled()
+
   describe "::setUpdatedSynchronously", ->
     it "controls whether the text editor is updated synchronously", ->
       spyOn(window, 'requestAnimationFrame').andCallFake (fn) -> fn()

--- a/spec/text-editor-element-spec.coffee
+++ b/spec/text-editor-element-spec.coffee
@@ -147,9 +147,9 @@ describe "TextEditorElement", ->
       expect(element.shadowRoot.textContent).toContain "goodbye"
 
   describe "::getDefaultCharacterWidth", ->
-    it "throws an exception if the editor is not attached", ->
+    it "returns null before the element is attached", ->
       element = new TextEditorElement
-      expect(-> element.getDefaultCharacterWidth()).toThrow("The editor must be attached to get the default character width")
+      expect(element.getDefaultCharacterWidth()).toBeNull()
 
     it "returns the width of a character in the root scope", ->
       element = new TextEditorElement

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -13,6 +13,7 @@ class TextEditorElement extends HTMLElement
   model: null
   componentDescriptor: null
   component: null
+  attached: false
   lineOverdrawMargin: null
   focusOnAttach: false
 
@@ -57,10 +58,14 @@ class TextEditorElement extends HTMLElement
     @__spacePenView = new TextEditorView(this)
 
   attachedCallback: ->
+    @attached = true
     @buildModel() unless @getModel()?
     @mountComponent() unless @component?.isMounted()
     @component.checkForVisibilityChange()
     @focus() if @focusOnAttach
+
+  detachedCallback: ->
+    @attached = false
 
   initialize: (model) ->
     @setModel(model)
@@ -159,6 +164,10 @@ class TextEditorElement extends HTMLElement
   setUpdatedSynchronously: (@updatedSynchronously) -> @updatedSynchronously
 
   isUpdatedSynchronously: -> @updatedSynchronously
+
+  getDefaultCharacterWidth: ->
+    throw new Error("The editor must be attached to get the default character width") unless @attached
+    @getModel().getDefaultCharWidth()
 
 stopEventPropagation = (commandListeners) ->
   newCommandListeners = {}

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -1,3 +1,4 @@
+{Emitter} = require 'event-kit'
 {View, $, callRemoveHooks} = require 'space-pen'
 React = require 'react-atom-fork'
 Path = require 'path'
@@ -18,6 +19,7 @@ class TextEditorElement extends HTMLElement
   focusOnAttach: false
 
   createdCallback: ->
+    @emitter = new Emitter
     @initializeContent()
     @createSpacePenShim()
     @addEventListener 'focus', @focused.bind(this)
@@ -63,9 +65,11 @@ class TextEditorElement extends HTMLElement
     @mountComponent() unless @component?.isMounted()
     @component.checkForVisibilityChange()
     @focus() if @focusOnAttach
+    @emitter.emit("did-attach")
 
   detachedCallback: ->
     @attached = false
+    @emitter.emit("did-detach")
 
   initialize: (model) ->
     @setModel(model)
@@ -168,6 +172,12 @@ class TextEditorElement extends HTMLElement
   getDefaultCharacterWidth: ->
     throw new Error("The editor must be attached to get the default character width") unless @attached
     @getModel().getDefaultCharWidth()
+
+  onDidAttach: (callback) ->
+    @emitter.on("did-attach", callback)
+
+  onDidDetach: (callback) ->
+    @emitter.on("did-detach", callback)
 
 stopEventPropagation = (commandListeners) ->
   newCommandListeners = {}

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -169,13 +169,22 @@ class TextEditorElement extends HTMLElement
 
   isUpdatedSynchronously: -> @updatedSynchronously
 
+  # Extended: get the width of a character of text displayed in this element.
+  #
+  # Returns a {Number} of pixels.
   getDefaultCharacterWidth: ->
     throw new Error("The editor must be attached to get the default character width") unless @attached
     @getModel().getDefaultCharWidth()
 
+  # Extended: call the given `callback` when the editor is attached to the DOM.
+  #
+  # * `callback` {Function}
   onDidAttach: (callback) ->
     @emitter.on("did-attach", callback)
 
+  # Extended: call the given `callback` when the editor is detached from the DOM.
+  #
+  # * `callback` {Function}
   onDidDetach: (callback) ->
     @emitter.on("did-detach", callback)
 

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -60,7 +60,6 @@ class TextEditorElement extends HTMLElement
     @__spacePenView = new TextEditorView(this)
 
   attachedCallback: ->
-    @attached = true
     @buildModel() unless @getModel()?
     @mountComponent() unless @component?.isMounted()
     @component.checkForVisibilityChange()
@@ -68,7 +67,6 @@ class TextEditorElement extends HTMLElement
     @emitter.emit("did-attach")
 
   detachedCallback: ->
-    @attached = false
     @emitter.emit("did-detach")
 
   initialize: (model) ->
@@ -173,7 +171,6 @@ class TextEditorElement extends HTMLElement
   #
   # Returns a {Number} of pixels.
   getDefaultCharacterWidth: ->
-    throw new Error("The editor must be attached to get the default character width") unless @attached
     @getModel().getDefaultCharWidth()
 
   # Extended: call the given `callback` when the editor is attached to the DOM.


### PR DESCRIPTION
In order to avoid using deprecated APIs, the wrap-guide package needs to be able to:
- perform adjustments when a text editor element is attached to the DOM
- know a text editor element's default character width
