### PR TITLE
Better BufferedProcess error handling

### DIFF
--- a/spec/buffered-process-spec.coffee
+++ b/spec/buffered-process-spec.coffee
@@ -1,0 +1,41 @@
+BufferedProcess  = require '../src/buffered-process'
+
+describe "BufferedProcess", ->
+  describe "when a bad command is specified", ->
+    [oldOnError] = []
+    beforeEach ->
+      oldOnError = window.onerror
+      window.onerror = jasmine.createSpy()
+
+    afterEach ->
+      window.onerror = oldOnError
+
+    describe "when there is an error handler specified", ->
+      it "calls the error handler and does not throw an exception", ->
+        process = new BufferedProcess
+          command: 'bad-command-nope'
+          args: ['nothing']
+          options: {}
+
+        process.onDidThrowError errorSpy = jasmine.createSpy()
+
+        waitsFor -> errorSpy.callCount > 0
+
+        runs ->
+          expect(window.onerror).not.toHaveBeenCalled()
+          expect(errorSpy).toHaveBeenCalled()
+          expect(errorSpy.mostRecentCall.args[0].message).toContain 'spawn bad-command-nope ENOENT'
+
+    describe "when there is not an error handler specified", ->
+      it "calls the error handler and does not throw an exception", ->
+        process = new BufferedProcess
+          command: 'bad-command-nope'
+          args: ['nothing']
+          options: {}
+
+        waitsFor -> window.onerror.callCount > 0
+
+        runs ->
+          expect(window.onerror).toHaveBeenCalled()
+          expect(window.onerror.mostRecentCall.args[0]).toContain 'Failed to spawn command `bad-command-nope`'
+          expect(window.onerror.mostRecentCall.args[4].name).toBe 'BufferedProcessError'

--- a/spec/buffered-process-spec.coffee
+++ b/spec/buffered-process-spec.coffee
@@ -17,14 +17,15 @@ describe "BufferedProcess", ->
           args: ['nothing']
           options: {}
 
-        process.onDidThrowError errorSpy = jasmine.createSpy()
+        errorSpy = jasmine.createSpy().andCallFake (error) -> error.handle()
+        process.onWillThrowError(errorSpy)
 
         waitsFor -> errorSpy.callCount > 0
 
         runs ->
           expect(window.onerror).not.toHaveBeenCalled()
           expect(errorSpy).toHaveBeenCalled()
-          expect(errorSpy.mostRecentCall.args[0].message).toContain 'spawn bad-command-nope ENOENT'
+          expect(errorSpy.mostRecentCall.args[0].error.message).toContain 'spawn bad-command-nope ENOENT'
 
     describe "when there is not an error handler specified", ->
       it "calls the error handler and does not throw an exception", ->

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -18,6 +18,10 @@ ChildProcess = require 'child_process'
 # ```
 module.exports =
 class BufferedProcess
+  ###
+  Section: Construction
+  ###
+
   # Public: Runs the given command by spawning a new child process.
   #
   # * `options` An {Object} with the following keys:
@@ -105,8 +109,20 @@ class BufferedProcess
         e.name = 'BufferedProcessError'
         throw e
 
+  ###
+  Section: Event Subscription
+  ###
+
+  # Public: Will call your callback when an error is raised by the process.
+  # Usually this is due to the command not being available or not on the PATH.
+  #
+  # Returns a {Disposable}
   onDidThrowError: (callback) ->
     @emitter.on 'did-throw-error', callback
+
+  ###
+  Section: Helper Methods
+  ###
 
   # Helper method to pass data line by line.
   #


### PR DESCRIPTION
We've had a lot of errors related to not having some binary installed. The errors are terrible: https://github.com/atom/atom/issues/4525

These packages are trying to [handle them](https://github.com/nickclaw/atom-grunt-runner/blob/master/lib/grunt-runner-view.coffee#L152), but there is no way without using `bufferedProcess.process.on 'error'` and that is obviously not discoverable. 

Notifications will catch the unhandled errors, and display something nice for them, rather than the fatal notification with a 'create issue' button.
- If there is a handler, just emit the event
- If no handler, throw an error
