### PR TITLE
Fixed activateNow when no activation promise

### DIFF
--- a/src/package.coffee
+++ b/src/package.coffee
@@ -105,7 +105,7 @@ class Package
     catch e
       console.warn "Failed to activate package named '#{@name}'", e.stack
 
-    @activationDeferred.resolve()
+    @activationDeferred?.resolve()
 
   activateConfig: ->
     return if @configActivated


### PR DESCRIPTION
If you call `Package::activateNow` when Atom is waiting for a command to activate it, then `activateNow` blows up expecting a promise.  This fixes that and allows `activateNow` to be used at any time on a loaded package.
