### PR TITLE
Group paired settings

### DIFF
--- a/spec/fixtures/packages/package-with-scoped-properties/scoped-properties/omg.cson
+++ b/spec/fixtures/packages/package-with-scoped-properties/scoped-properties/omg.cson
@@ -1,3 +1,5 @@
 '.source.omg':
   'editor':
     'increaseIndentPattern': '^a'
+    'commentStart': '/*'
+    'commentEnd': '*/'

--- a/spec/fixtures/packages/package-with-scoped-properties/scoped-properties/omg.cson
+++ b/spec/fixtures/packages/package-with-scoped-properties/scoped-properties/omg.cson
@@ -1,5 +1,6 @@
 '.source.omg':
   'editor':
     'increaseIndentPattern': '^a'
+    'decreaseIndentPattern': '^z'
     'commentStart': '/*'
     'commentEnd': '*/'

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -369,7 +369,7 @@ describe "PackageManager", ->
             atom.packages.activatePackage("package-with-scoped-properties")
 
           runs ->
-            expect(atom.config.get ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
+            expect(atom.config.get ['.source.omg'], 'editor.indent.increasePattern').toBe '^a'
 
         it "combines 'editor.commentStart' and 'editor.commentEnd' strings under the 'editor.comment' key path", ->
           if atom.packages.isPackageLoaded("package-with-scoped-properties")
@@ -381,6 +381,18 @@ describe "PackageManager", ->
           runs ->
             expect(atom.config.get ['.source.omg'], 'editor.comment.start').toBe '/*'
             expect(atom.config.get ['.source.omg'], 'editor.comment.end').toBe '*/'
+            expect(Grim.deprecate).toHaveBeenCalled()
+
+        it "combines 'editor.increaseIndentPattern' and 'editor.decreaseIndentPattern' strings under the 'editor.indent' key path", ->
+          if atom.packages.isPackageLoaded("package-with-scoped-properties")
+            atom.packages.unloadPackage("package-with-scoped-properties")
+
+          waitsForPromise ->
+            atom.packages.activatePackage("package-with-scoped-properties")
+
+          runs ->
+            expect(atom.config.get ['.source.omg'], 'editor.indent.increasePattern').toBe '^a'
+            expect(atom.config.get ['.source.omg'], 'editor.indent.decreasePattern').toBe '^z'
             expect(Grim.deprecate).toHaveBeenCalled()
 
     describe "converted textmate packages", ->
@@ -507,9 +519,9 @@ describe "PackageManager", ->
           atom.packages.activatePackage("package-with-scoped-properties")
 
         runs ->
-          expect(atom.config.get ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
+          expect(atom.config.get ['.source.omg'], 'editor.indent.increasePattern').toBe '^a'
           atom.packages.deactivatePackage("package-with-scoped-properties")
-          expect(atom.config.get ['.source.omg'], 'editor.increaseIndentPattern').toBeUndefined()
+          expect(atom.config.get ['.source.omg'], 'editor.indent.increasePattern').toBeUndefined()
 
     describe "textmate packages", ->
       it "removes the package's grammars", ->

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -88,10 +88,13 @@ module.exports =
             type: ['string', 'null']
           end:
             type: ['string', 'null']
-      increaseIndentPattern:
-        type: ['string', 'null']
-      decreaseIndentPattern:
-        type: ['string', 'null']
+      indent:
+        type: 'object'
+        properties:
+          increasePattern:
+            type: ['string', 'null']
+          decreasePattern:
+            type: ['string', 'null']
       foldEndPattern:
         type: ['string', 'null']
 

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -81,10 +81,13 @@ module.exports =
     type: 'object'
     properties:
       # These settings are used in scoped fashion only. No defaults.
-      commentStart:
-        type: ['string', 'null']
-      commentEnd:
-        type: ['string', 'null']
+      comment:
+        type: 'object'
+        properties:
+          start:
+            type: ['string', 'null']
+          end:
+            type: ['string', 'null']
       increaseIndentPattern:
         type: ['string', 'null']
       decreaseIndentPattern:

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -249,7 +249,14 @@ class LanguageMode
   suggestedIndentForBufferRow: (bufferRow, options) ->
     currentIndentLevel = @editor.indentationForBufferRow(bufferRow)
     scopeDescriptor = @editor.scopeDescriptorForBufferPosition([bufferRow, 0])
-    return currentIndentLevel unless increaseIndentRegex = @increaseIndentRegexForScopeDescriptor(scopeDescriptor)
+
+    indentPatterns = atom.config.get(scopeDescriptor, 'editor.indent')
+    if indentPatterns?.increasePattern?
+      increaseIndentRegex = new OnigRegExp(indentPatterns.increasePattern)
+    if indentPatterns?.decreasePattern?
+      decreaseIndentRegex = new OnigRegExp(indentPatterns.decreasePattern)
+
+    return currentIndentLevel unless increaseIndentRegex?
 
     currentLine = @buffer.lineForRow(bufferRow)
     if options?.skipBlankLines ? true
@@ -263,7 +270,7 @@ class LanguageMode
     desiredIndentLevel = @editor.indentationForBufferRow(precedingRow)
     desiredIndentLevel += 1 if increaseIndentRegex.testSync(precedingLine) and not @editor.isBufferRowCommented(precedingRow)
 
-    return desiredIndentLevel unless decreaseIndentRegex = @decreaseIndentRegexForScopeDescriptor(scopeDescriptor)
+    return desiredIndentLevel unless decreaseIndentRegex?
     desiredIndentLevel -= 1 if decreaseIndentRegex.testSync(currentLine)
 
     Math.max(desiredIndentLevel, 0)
@@ -299,8 +306,13 @@ class LanguageMode
   # bufferRow - The row {Number}
   autoDecreaseIndentForBufferRow: (bufferRow) ->
     scopeDescriptor = @editor.scopeDescriptorForBufferPosition([bufferRow, 0])
-    increaseIndentRegex = @increaseIndentRegexForScopeDescriptor(scopeDescriptor)
-    decreaseIndentRegex = @decreaseIndentRegexForScopeDescriptor(scopeDescriptor)
+
+    indentPatterns = atom.config.get(scopeDescriptor, 'editor.indent')
+    if indentPatterns?.increasePattern?
+      increaseIndentRegex = new OnigRegExp(indentPatterns.increasePattern)
+    if indentPatterns?.decreasePattern?
+      decreaseIndentRegex = new OnigRegExp(indentPatterns.decreasePattern)
+
     return unless increaseIndentRegex and decreaseIndentRegex
 
     line = @buffer.lineForRow(bufferRow)
@@ -320,12 +332,6 @@ class LanguageMode
   getRegexForProperty: (scopeDescriptor, property) ->
     if pattern = atom.config.get(scopeDescriptor, property)
       new OnigRegExp(pattern)
-
-  increaseIndentRegexForScopeDescriptor: (scopeDescriptor) ->
-    @getRegexForProperty(scopeDescriptor, 'editor.increaseIndentPattern')
-
-  decreaseIndentRegexForScopeDescriptor: (scopeDescriptor) ->
-    @getRegexForProperty(scopeDescriptor, 'editor.decreaseIndentPattern')
 
   foldEndRegexForScopeDescriptor: (scopeDescriptor) ->
     @getRegexForProperty(scopeDescriptor, 'editor.foldEndPattern')

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -30,13 +30,15 @@ class LanguageMode
   # Returns an {Array} of the commented {Ranges}.
   toggleLineCommentsForBufferRows: (start, end) ->
     scopeDescriptor = @editor.scopeDescriptorForBufferPosition([start, 0])
-    properties = atom.config.settingsForScopeDescriptor(scopeDescriptor, 'editor.commentStart')[0]
-    return unless properties
 
-    commentStartString = _.valueForKeyPath(properties, 'editor.commentStart')
-    commentEndString = _.valueForKeyPath(properties, 'editor.commentEnd')
+    commentStrings = atom.config.get(scopeDescriptor, 'editor.comment')
 
-    return unless commentStartString
+    return unless commentStrings?
+
+    commentStartString = commentStrings.start
+    commentEndString = commentStrings.end
+
+    return unless commentStartString?
 
     buffer = @editor.buffer
     commentStartRegexString = _.escapeRegExp(commentStartString).replace(/(\s+)$/, '(?:$1)?')

--- a/src/scoped-properties.coffee
+++ b/src/scoped-properties.coffee
@@ -25,6 +25,18 @@ class ScopedProperties
         delete properties.editor.commentEnd
         Grim.deprecate("The 'editor.commentEnd' setting has been moved to 'editor.comment.end'. Please update `#{@path}`.")
 
+      if properties.editor?.increaseIndentPattern?
+        properties.editor.indent ?= {}
+        properties.editor.indent.increasePattern ?= properties.editor.increaseIndentPattern
+        delete properties.editor.increaseIndentPattern
+        Grim.deprecate("The 'editor.increaseIndentPattern' setting has been moved to 'editor.indent.increasePattern'.  Please update `#{@path}`.")
+
+      if properties.editor?.decreaseIndentPattern?
+        properties.editor.indent ?= {}
+        properties.editor.indent.decreasePattern ?= properties.editor.decreaseIndentPattern
+        delete properties.editor.decreaseIndentPattern
+        Grim.deprecate("The 'editor.decreaseIndentPattern' setting has been moved to 'editor.indent.decreasePattern'.  Please update `#{@path}`.")
+
     @propertyDisposable = new CompositeDisposable
 
   activate: ->

--- a/src/scoped-properties.coffee
+++ b/src/scoped-properties.coffee
@@ -1,3 +1,4 @@
+Grim = require 'grim'
 CSON = require 'season'
 {CompositeDisposable} = require 'event-kit'
 
@@ -11,6 +12,19 @@ class ScopedProperties
         callback(null, new ScopedProperties(scopedPropertiesPath, scopedProperties))
 
   constructor: (@path, @scopedProperties) ->
+    for selector, properties of @scopedProperties
+      if properties.editor?.commentStart?
+        properties.editor.comment ?= {}
+        properties.editor.comment.start ?= properties.editor.commentStart
+        delete properties.editor.commentStart
+        Grim.deprecate("The 'editor.commentStart' setting has been moved to 'editor.comment.start'.  Please update `#{@path}`.")
+
+      if properties.editor?.commentEnd?
+        properties.editor.comment ?= {}
+        properties.editor.comment.end ?= properties.editor.commentEnd
+        delete properties.editor.commentEnd
+        Grim.deprecate("The 'editor.commentEnd' setting has been moved to 'editor.comment.end'. Please update `#{@path}`.")
+
     @propertyDisposable = new CompositeDisposable
 
   activate: ->


### PR DESCRIPTION
Refs #4518

This includes grouping of comment strings, indent patterns, and fold patterns so we always retrieve them from the same scope.
- [x] group comment strings under `editor.comment`
- [x] group indent strings under `editor.indent`
- [ ] group fold patterns under `editor.fold`
