### PR TITLE
Add a public way of setting config values associated with a source

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "temp": "0.7.0",
     "text-buffer": "^3.8.2",
     "theorist": "^1.0.2",
-    "underscore-plus": "^1.6.1",
+    "underscore-plus": "^1.6.2",
     "vm-compatibility-layer": "0.1.0"
   },
   "packageDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "reactionary-atom-fork": "^1.0.0",
     "runas": "1.0.1",
     "scandal": "1.0.3",
-    "scoped-property-store": "^0.15.0",
+    "scoped-property-store": "^0.16.0",
     "scrollbar-style": "^1.0.2",
     "season": "^1.0.2",
     "semver": "2.2.1",

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -3,7 +3,7 @@ temp = require 'temp'
 CSON = require 'season'
 fs = require 'fs-plus'
 
-describe "Config", ->
+fdescribe "Config", ->
   dotAtomPath = path.join(temp.dir, 'dot-atom-dir')
   dotAtomPath = null
 

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -35,6 +35,14 @@ describe "Config", ->
       atom.config.setDefaults("bar", baz: 7)
       expect(atom.config.get("bar.baz")).toEqual {a: 3}
 
+    describe "when a 'sources' option is specified", ->
+      it "only returns assigned values that were assigned from the specified source", ->
+        atom.config.setFromSource("source-a", ".foo", "x.y", 1)
+        atom.config.setFromSource("source-b", ".foo", "x.y", 2)
+
+        expect(atom.config.get([".foo"], "x.y", sources: ["source-a"])).toBe 1
+        expect(atom.config.get([".foo"], "x.y", sources: ["source-b"])).toBe 2
+
   describe ".set(keyPath, value)", ->
     it "allows a key path's value to be written", ->
       expect(atom.config.set("foo.bar.baz", 42)).toBeTruthy()

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -12,7 +12,7 @@ describe "Config", ->
 
   describe ".get(keyPath)", ->
     it "allows a key path's value to be read", ->
-      expect(atom.config.set("foo.bar.baz", 42)).toBe true
+      expect(atom.config.set("foo.bar.baz", 42)).toBeTruthy()
       expect(atom.config.get("foo.bar.baz")).toBe 42
       expect(atom.config.get("bogus.key.path")).toBeUndefined()
 
@@ -37,7 +37,7 @@ describe "Config", ->
 
   describe ".set(keyPath, value)", ->
     it "allows a key path's value to be written", ->
-      expect(atom.config.set("foo.bar.baz", 42)).toBe true
+      expect(atom.config.set("foo.bar.baz", 42)).toBeTruthy()
       expect(atom.config.get("foo.bar.baz")).toBe 42
 
     it "updates observers and saves when a key path is set", ->
@@ -979,19 +979,19 @@ describe "Config", ->
         expect(atom.config.get('foo.bar.aString')).toBe 'yep'
 
       it 'will only set strings', ->
-        expect(atom.config.set('foo.bar.aString', 123)).toBe false
+        expect(atom.config.set('foo.bar.aString', 123)).toBeNull()
         expect(atom.config.get('foo.bar.aString')).toBe 'ok'
 
-        expect(atom.config.set('foo.bar.aString', true)).toBe false
+        expect(atom.config.set('foo.bar.aString', true)).toBeNull()
         expect(atom.config.get('foo.bar.aString')).toBe 'ok'
 
-        expect(atom.config.set('foo.bar.aString', null)).toBe false
+        expect(atom.config.set('foo.bar.aString', null)).toBeNull()
         expect(atom.config.get('foo.bar.aString')).toBe 'ok'
 
-        expect(atom.config.set('foo.bar.aString', [])).toBe false
+        expect(atom.config.set('foo.bar.aString', [])).toBeNull()
         expect(atom.config.get('foo.bar.aString')).toBe 'ok'
 
-        expect(atom.config.set('foo.bar.aString', nope: 'nope')).toBe false
+        expect(atom.config.set('foo.bar.aString', nope: 'nope')).toBeNull()
         expect(atom.config.get('foo.bar.aString')).toBe 'ok'
 
     describe 'when the value has an "object" type', ->
@@ -1025,7 +1025,7 @@ describe "Config", ->
           anInt: 'nope'
           nestedObject:
             nestedBool: true
-        ).toBe true
+        ).toBeTruthy()
         expect(atom.config.get('foo.bar.anInt')).toEqual 12
         expect(atom.config.get('foo.bar.nestedObject.nestedBool')).toEqual true
 
@@ -1065,24 +1065,24 @@ describe "Config", ->
         atom.config.setSchema('foo.bar', schema)
 
       it 'will only set a string when the string is in the enum values', ->
-        expect(atom.config.set('foo.bar.str', 'nope')).toBe false
+        expect(atom.config.set('foo.bar.str', 'nope')).toBeNull()
         expect(atom.config.get('foo.bar.str')).toBe 'ok'
 
-        expect(atom.config.set('foo.bar.str', 'one')).toBe true
+        expect(atom.config.set('foo.bar.str', 'one')).toBeTruthy()
         expect(atom.config.get('foo.bar.str')).toBe 'one'
 
       it 'will only set an integer when the integer is in the enum values', ->
-        expect(atom.config.set('foo.bar.int', '400')).toBe false
+        expect(atom.config.set('foo.bar.int', '400')).toBeNull()
         expect(atom.config.get('foo.bar.int')).toBe 2
 
-        expect(atom.config.set('foo.bar.int', '3')).toBe true
+        expect(atom.config.set('foo.bar.int', '3')).toBeTruthy()
         expect(atom.config.get('foo.bar.int')).toBe 3
 
       it 'will only set an array when the array values are in the enum values', ->
-        expect(atom.config.set('foo.bar.arr', ['one', 'five'])).toBe true
+        expect(atom.config.set('foo.bar.arr', ['one', 'five'])).toBeTruthy()
         expect(atom.config.get('foo.bar.arr')).toEqual ['one']
 
-        expect(atom.config.set('foo.bar.arr', ['two', 'three'])).toBe true
+        expect(atom.config.set('foo.bar.arr', ['two', 'three'])).toBeTruthy()
         expect(atom.config.get('foo.bar.arr')).toEqual ['two', 'three']
 
     describe "when scoped settings are used", ->
@@ -1138,7 +1138,7 @@ describe "Config", ->
         atom.config.setFromSource("config", ".source", "foo.bar.baz", 11)
         expect(atom.config.get([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
 
-        expect(atom.config.set(".source.coffee .string.quoted.double.coffee", "foo.bar.baz", 100)).toBe true
+        expect(atom.config.set(".source.coffee .string.quoted.double.coffee", "foo.bar.baz", 100)).toBeTruthy()
         expect(atom.config.get([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 100
 
       it "allows properties to be removed by name", ->

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -94,8 +94,8 @@ describe "PackageManager", ->
             expect(atom.config.get('package-with-config-schema.numbers.one')).toBe 1
             expect(atom.config.get('package-with-config-schema.numbers.two')).toBe 2
 
-            expect(atom.config.set('package-with-config-schema.numbers.one', 'nope')).toBe false
-            expect(atom.config.set('package-with-config-schema.numbers.one', '10')).toBe true
+            expect(atom.config.set('package-with-config-schema.numbers.one', 'nope')).toBeNull()
+            expect(atom.config.set('package-with-config-schema.numbers.one', '10')).toBeTruthy()
             expect(atom.config.get('package-with-config-schema.numbers.one')).toBe 10
 
         describe "when a package has configDefaults", ->

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -93,6 +93,11 @@ module.exports =
         type: ['string', 'null']
 
       # These can be used as globals or scoped, thus defaults.
+      completions:
+        type: "array"
+        items:
+          type: "string"
+        default: []
       fontFamily:
         type: 'string'
         default: ''

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -501,13 +501,13 @@ class Config
   # * `value` The value of the setting. Passing `undefined` will revert the
   #   setting to the default value.
   #
-  # Returns a {Boolean}
-  # * `true` if the value was set.
-  # * `false` if the value was not able to be coerced to the type specified in the setting's schema.
+  # Returns:
+  # * a {Disposable} that can be used to remove the setting, if the value was set.
+  # * `null` if the value was not able to be coerced to the type specified in the schema.
   set: (args...) ->
     disposable = @setFromSource('user-config', args...)
     @usersScopedSettings.add(disposable)
-    disposable?
+    disposable
 
   # Extended: Sets the value for a configuration setting and associates
   # the value with a given source.

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -455,15 +455,18 @@ class Config
   #
   # Returns the value from Atom's default settings, the user's configuration
   # file in the type specified by the configuration schema.
-  get: (scopeDescriptor, keyPath) ->
-    if arguments.length == 1
-      # cannot assign to keyPath for the sake of v8 optimization
-      globalKeyPath = scopeDescriptor
-      @getRawValue(globalKeyPath)
-    else
-      value = @getRawScopedValue(scopeDescriptor, keyPath)
+  get: ->
+    argIndex = arguments.length - 1
+    options = arguments[argIndex--] if isPlainObject(arguments[argIndex])
+    keyPath = arguments[argIndex--]
+    scopeDescriptor = arguments[argIndex--]
+
+    if scopeDescriptor?
+      value = @getRawScopedValue(scopeDescriptor, keyPath, options)
       value ?= @getRawValue(keyPath)
       value
+    else
+      @getRawValue(keyPath)
 
   # Essential: Sets the value for a configuration setting.
   #
@@ -925,9 +928,9 @@ class Config
       disposable.dispose()
       @emitter.emit 'did-change'
 
-  getRawScopedValue: (scopeDescriptor, keyPath) ->
+  getRawScopedValue: (scopeDescriptor, keyPath, options) ->
     scopeDescriptor = ScopeDescriptor.fromObject(scopeDescriptor)
-    @scopedSettingsStore.getPropertyValue(scopeDescriptor.getScopeChain(), keyPath)
+    @scopedSettingsStore.getPropertyValue(scopeDescriptor.getScopeChain(), keyPath, options)
 
   observeScopedKeyPath: (scopeDescriptor, keyPath, callback) ->
     oldValue = @get(scopeDescriptor, keyPath)

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -53,13 +53,16 @@ class GrammarRegistry extends FirstMate.GrammarRegistry
     deprecate("Do not use this. Use a public method on Config")
     atom.config.scopedSettingsStore
 
-  addProperties: (args...) ->
-    args.unshift(null) if args.length == 2
-    deprecate 'Consider using atom.config.set() instead. A direct (but private) replacement is available at atom.config.addScopedSettings().'
-    atom.config.addScopedSettings(args...)
+  addProperties: (sourceName, selector, properties) ->
+    deprecate 'Use atom.config.setFromSource instead'
+    if args.length == 2
+      properties = selector
+      selector = sourceName
+      sourceName = null
+    atom.config.setFromSource(sourceName, selector, null, properties)
 
   removeProperties: (name) ->
-    deprecate 'atom.config.addScopedSettings() now returns a disposable you can call .dispose() on'
+    deprecate 'atom.config.setFromSource now returns a disposable you can call .dispose() on'
     atom.config.scopedSettingsStore.removeProperties(name)
 
   getProperty: (scope, keyPath) ->

--- a/src/scoped-properties.coffee
+++ b/src/scoped-properties.coffee
@@ -15,7 +15,7 @@ class ScopedProperties
 
   activate: ->
     for selector, properties of @scopedProperties
-      @propertyDisposable.add atom.config.addScopedSettings(@path, selector, properties)
+      @propertyDisposable.add atom.config.setFromSource(@path, selector, null, properties)
     return
 
   deactivate: ->


### PR DESCRIPTION
:warning: WIP :warning:
- [ ] Eliminate disposable returned from `Config::set`
- [ ] Associate all settings with a source regardless of whether or not they are scoped
- [ ] Add a `Config::unsetFromSource` public method to remove settings from a given source
- [ ] Add `sources` option to `Config::get`
- [ ] Add `excludeSources` option to `Config::get`
- [ ] Use actual user settings path as the user settings source
- [ ] Add `Config::unset` to remove a setting from the user-config source
- [ ] Add `Config::unsetFromSource` to remove all settings or one setting from a given source
- [ ] Deprecate `is/get/restoreDefault` methods and replace with `get` and `set` plus `source` options

Previously, the private method `::addScopedSettings` was used to associate config settings with a source other than the user's config file. It bypassed schema validation.

This is being driven out by changes made in atom/snippets#86; to fix deprecation warnings required calling private methods on Config.
