### PR TITLE
Add better atom.cmd exe wrapper

### DIFF
--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -151,8 +151,8 @@ module.exports = (grunt) ->
           grunt.file.copy(sourcePath, path.resolve(appDir, '..', subDirectory, filename))
 
     if process.platform is 'win32'
-      cp path.join('win', 'resources', 'atom.cmd'), path.join(shellAppDir, 'cli', 'atom.cmd')
-      cp path.join('win', 'resources', 'atom.js'), path.join(shellAppDir, 'cli', 'atom.js')
+      cp path.join('resources', 'win', 'atom.cmd'), path.join(shellAppDir, 'cli', 'atom.cmd')
+      cp path.join('resources', 'win', 'atom.js'), path.join(shellAppDir, 'cli', 'atom.js')
 
     dependencies = ['compile', 'generate-license:save', 'generate-module-cache', 'compile-packages-slug']
     dependencies.push('copy-info-plist') if process.platform is 'darwin'

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -21,7 +21,9 @@ module.exports = (grunt) ->
 
     mkdir appDir
 
-    cp 'atom.sh', path.join(appDir, 'atom.sh')
+    if process.platform isnt 'win32'
+      cp 'atom.sh', path.join(appDir, 'atom.sh')
+
     cp 'package.json', path.join(appDir, 'package.json')
 
     packageDirectories = []

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -149,10 +149,8 @@ module.exports = (grunt) ->
           grunt.file.copy(sourcePath, path.resolve(appDir, '..', subDirectory, filename))
 
     if process.platform is 'win32'
-      # Set up chocolatey ignore and gui files
-      fs.writeFileSync path.join(appDir, 'apm', 'node_modules', 'atom-package-manager', 'bin', 'node.exe.ignore'), ''
-      fs.writeFileSync path.join(appDir, 'node_modules', 'symbols-view', 'vendor', 'ctags-win32.exe.ignore'), ''
-      fs.writeFileSync path.join(shellAppDir, 'atom.exe.gui'), ''
+      cp path.join('win', 'resources', 'atom.cmd'), path.join(shellAppDir, 'cli', 'atom.cmd')
+      cp path.join('win', 'resources', 'atom.js'), path.join(shellAppDir, 'cli', 'atom.js')
 
     dependencies = ['compile', 'generate-license:save', 'generate-module-cache', 'compile-packages-slug']
     dependencies.push('copy-info-plist') if process.platform is 'darwin'

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -151,8 +151,8 @@ module.exports = (grunt) ->
           grunt.file.copy(sourcePath, path.resolve(appDir, '..', subDirectory, filename))
 
     if process.platform is 'win32'
-      cp path.join('resources', 'win', 'atom.cmd'), path.join(shellAppDir, 'cli', 'atom.cmd')
-      cp path.join('resources', 'win', 'atom.js'), path.join(shellAppDir, 'cli', 'atom.js')
+      cp path.join('resources', 'win', 'atom.cmd'), path.join(shellAppDir, 'resources', 'cli', 'atom.cmd')
+      cp path.join('resources', 'win', 'atom.js'), path.join(shellAppDir, 'resources', 'cli', 'atom.js')
 
     dependencies = ['compile', 'generate-license:save', 'generate-module-cache', 'compile-packages-slug']
     dependencies.push('copy-info-plist') if process.platform is 'darwin'

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -1,2 +1,20 @@
 @echo off
-node "%~dp0\\atom.js" %* --executed-from=%CD%
+
+SET EXPECTOUTPUT=
+
+FOR %%a IN (%*) DO (
+  IF /I "%%a"=="-h"           SET EXPECTOUTPUT=YES
+  IF /I "%%a"=="--help"       SET EXPECTOUTPUT=YES
+  IF /I "%%a"=="-v"           SET EXPECTOUTPUT=YES
+  IF /I "%%a"=="--version"    SET EXPECTOUTPUT=YES
+  IF /I "%%a"=="-f"           SET EXPECTOUTPUT=YES
+  IF /I "%%a"=="--foreground" SET EXPECTOUTPUT=YES
+  IF /I "%%a"=="-w"           SET EXPECTOUTPUT=YES
+  IF /I "%%a"=="--wait"       SET EXPECTOUTPUT=YES
+)
+
+IF "%EXPECTOUTPUT%"=="YES" (
+  "C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe" %*
+) ELSE (
+  node "%~dp0\\atom.js" "C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe" %* --executed-from=%CD%
+)

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -14,7 +14,7 @@ FOR %%a IN (%*) DO (
 )
 
 IF "%EXPECTOUTPUT%"=="YES" (
-  "C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe" %*
+  "C:\Users\kevin\AppData\Local\atom\app-0.156.0\atom.exe" %*
 ) ELSE (
-  node "%~dp0\\atom.js" "C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe" %* --executed-from=%CD%
+  node "%~dp0\atom.js" "C:\Users\kevin\AppData\Local\atom\app-0.156.0\atom.exe" %* --executed-from=%CD%
 )

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -3,12 +3,14 @@
 SET EXPECT_OUTPUT=
 
 FOR %%a IN (%*) DO (
-  IF /I "%%a"=="-h"           SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="--help"       SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="-v"           SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="--version"    SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="-f"           SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="--foreground" SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="-h"           SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--help"       SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="-t"           SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--test"       SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="-v"           SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--version"    SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="-w"           SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="--wait"       SET EXPECT_OUTPUT=YES
 )

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -1,0 +1,2 @@
+@echo off
+node "%~dp0\\atom.js" %*

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -13,11 +13,8 @@ FOR %%a IN (%*) DO (
   IF /I "%%a"=="--wait"       SET EXPECT_OUTPUT=YES
 )
 
-SET ATOM_COMMAND="%~dp0\..\atom.exe"
-SET NODE_COMMAND="%~dp0\..\resources\app\apm\node_modules\atom-package-manager\bin\node.exe"
-
 IF "%EXPECT_OUTPUT%"=="YES" (
-  "%ATOM_COMMAND%" %*
+  "%~dp0\..\atom.exe" %*
 ) ELSE (
-  "%NODE_COMMAND%" "%~dp0\atom.js" "%ATOM_COMMAND%" %* --executed-from=%CD%
+  "%~dp0\..\resources\app\apm\node_modules\atom-package-manager\bin\node.exe" "%~dp0\atom.js" %*
 )

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -1,2 +1,2 @@
 @echo off
-node "%~dp0\\atom.js" %*
+node "%~dp0\\atom.js" %* --executed-from=%CD%

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -1,20 +1,23 @@
 @echo off
 
-SET EXPECTOUTPUT=
+SET EXPECT_OUTPUT=
 
 FOR %%a IN (%*) DO (
-  IF /I "%%a"=="-h"           SET EXPECTOUTPUT=YES
-  IF /I "%%a"=="--help"       SET EXPECTOUTPUT=YES
-  IF /I "%%a"=="-v"           SET EXPECTOUTPUT=YES
-  IF /I "%%a"=="--version"    SET EXPECTOUTPUT=YES
-  IF /I "%%a"=="-f"           SET EXPECTOUTPUT=YES
-  IF /I "%%a"=="--foreground" SET EXPECTOUTPUT=YES
-  IF /I "%%a"=="-w"           SET EXPECTOUTPUT=YES
-  IF /I "%%a"=="--wait"       SET EXPECTOUTPUT=YES
+  IF /I "%%a"=="-h"           SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--help"       SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="-v"           SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--version"    SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="-f"           SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--foreground" SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="-w"           SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--wait"       SET EXPECT_OUTPUT=YES
 )
 
-IF "%EXPECTOUTPUT%"=="YES" (
-  "C:\Users\kevin\AppData\Local\atom\app-0.156.0\atom.exe" %*
+SET ATOM_COMMAND="%~dp0\..\atom.exe"
+SET NODE_COMMAND="%~dp0\..\resources\app\apm\node_modules\atom-package-manager\bin\node.exe"
+
+IF "%EXPECT_OUTPUT%"=="YES" (
+  "%ATOM_COMMAND%" %*
 ) ELSE (
-  node "%~dp0\atom.js" "C:\Users\kevin\AppData\Local\atom\app-0.156.0\atom.exe" %* --executed-from=%CD%
+  "%NODE_COMMAND%" "%~dp0\atom.js" "%ATOM_COMMAND%" %* --executed-from=%CD%
 )

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -18,5 +18,5 @@ FOR %%a IN (%*) DO (
 IF "%EXPECT_OUTPUT%"=="YES" (
   "%~dp0\..\atom.exe" %*
 ) ELSE (
-  "%~dp0\..\resources\app\apm\node_modules\atom-package-manager\bin\node.exe" "%~dp0\atom.js" %*
+  "%~dp0\..\app\apm\node_modules\atom-package-manager\bin\node.exe" "%~dp0\atom.js" %*
 )

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -16,7 +16,7 @@ FOR %%a IN (%*) DO (
 )
 
 IF "%EXPECT_OUTPUT%"=="YES" (
-  "%~dp0\..\atom.exe" %*
+  "%~dp0\..\..\atom.exe" %*
 ) ELSE (
   "%~dp0\..\app\apm\node_modules\atom-package-manager\bin\node.exe" "%~dp0\atom.js" %*
 )

--- a/resources/win/atom.js
+++ b/resources/win/atom.js
@@ -1,0 +1,7 @@
+var spawn = require('child_process').spawn;
+
+var options = {
+  detached: true,
+  stdio: 'ignore'
+}
+spawn("C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe", [], options);

--- a/resources/win/atom.js
+++ b/resources/win/atom.js
@@ -5,3 +5,4 @@ var options = {
   stdio: 'ignore'
 }
 spawn("C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe", [], options).disconnect();
+process.exit();

--- a/resources/win/atom.js
+++ b/resources/win/atom.js
@@ -5,6 +5,7 @@ var options = {
   stdio: 'ignore'
 }
 
-console.log(process.argv);
-spawn("C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe", [], options);
-process.exit();
+var args = process.argv.slice(2);
+console.log(args);
+spawn("C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe", args, options);
+process.exit(0);

--- a/resources/win/atom.js
+++ b/resources/win/atom.js
@@ -1,11 +1,7 @@
 var spawn = require('child_process').spawn;
 
-var options = {
-  detached: true,
-  stdio: 'ignore'
-}
-
-var args = process.argv.slice(2);
-console.log(args);
-spawn("C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe", args, options);
+var atomCommandPath = process.argv[2];
+var arguments = process.argv.slice(3);
+var options = {detached: true, stdio: 'ignore'};
+spawn(atomCommandPath, arguments, options);
 process.exit(0);

--- a/resources/win/atom.js
+++ b/resources/win/atom.js
@@ -4,5 +4,7 @@ var options = {
   detached: true,
   stdio: 'ignore'
 }
+
+console.log(process.argv);
 spawn("C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe", [], options);
 process.exit();

--- a/resources/win/atom.js
+++ b/resources/win/atom.js
@@ -4,5 +4,5 @@ var options = {
   detached: true,
   stdio: 'ignore'
 }
-spawn("C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe", [], options).disconnect();
+spawn("C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe", [], options);
 process.exit();

--- a/resources/win/atom.js
+++ b/resources/win/atom.js
@@ -3,7 +3,7 @@ var spawn = require('child_process').spawn;
 
 var atomCommandPath = path.resolve(__dirname, '..', 'atom.exe');
 var arguments = process.argv.slice(2);
-arguments.push('--executed-from', process.cwd());
+arguments.unshift('--executed-from', process.cwd());
 var options = {detached: true, stdio: 'ignore'};
 spawn(atomCommandPath, arguments, options);
 process.exit(0);

--- a/resources/win/atom.js
+++ b/resources/win/atom.js
@@ -4,4 +4,4 @@ var options = {
   detached: true,
   stdio: 'ignore'
 }
-spawn("C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe", [], options);
+spawn("C:\\Users\\kevin\\AppData\\Local\\atom\\app-0.156.0\\atom.exe", [], options).disconnect();

--- a/resources/win/atom.js
+++ b/resources/win/atom.js
@@ -1,7 +1,9 @@
+var path  = require('path');
 var spawn = require('child_process').spawn;
 
-var atomCommandPath = process.argv[2];
-var arguments = process.argv.slice(3);
+var atomCommandPath = path.resolve(__dirname, '..', 'atom.exe');
+var arguments = process.argv.slice(2);
+arguments.push('--executed-from', process.cwd());
 var options = {detached: true, stdio: 'ignore'};
 spawn(atomCommandPath, arguments, options);
 process.exit(0);

--- a/resources/win/atom.js
+++ b/resources/win/atom.js
@@ -1,7 +1,7 @@
 var path  = require('path');
 var spawn = require('child_process').spawn;
 
-var atomCommandPath = path.resolve(__dirname, '..', 'atom.exe');
+var atomCommandPath = path.resolve(__dirname, '..', '..', 'atom.exe');
 var arguments = process.argv.slice(2);
 arguments.unshift('--executed-from', process.cwd());
 var options = {detached: true, stdio: 'ignore'};

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -112,10 +112,10 @@ uninstallContextMenu = (callback) ->
 addCommandsToPath = (callback) ->
   installCommands = (callback) ->
     atomCommandPath = path.join(binFolder, 'atom.cmd')
-    relativeCmdPath = path.relative(binFolder, path.join(appFolder, 'cli', 'atom.cmd'))
+    relativeAtomPath = path.relative(binFolder, path.join(appFolder, 'cli', 'atom.cmd'))
     atomCommand = """
       @echo off
-      "%~dp0\\#{relativeExePath}" %*
+      "%~dp0\\#{relativeAtomPath}" %*
     """
 
     apmCommandPath = path.join(binFolder, 'apm.cmd')

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -3,7 +3,8 @@ ChildProcess = require 'child_process'
 fs = require 'fs-plus'
 path = require 'path'
 
-rootAtomFolder = path.resolve(process.execPath, '..', '..')
+appFolder = path.resolve(process.execPath, '..')
+rootAtomFolder = path.resolve(appFolder, '..')
 binFolder = path.join(rootAtomFolder, 'bin')
 updateDotExe = path.join(rootAtomFolder, 'Update.exe')
 exeName = path.basename(process.execPath)
@@ -111,7 +112,7 @@ uninstallContextMenu = (callback) ->
 addCommandsToPath = (callback) ->
   installCommands = (callback) ->
     atomCommandPath = path.join(binFolder, 'atom.cmd')
-    relativeExePath = path.relative(binFolder, process.execPath)
+    relativeCmdPath = path.relative(binFolder, path.join(appFolder, 'cli', 'atom.cmd'))
     atomCommand = """
       @echo off
       "%~dp0\\#{relativeExePath}" %*

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -112,7 +112,7 @@ uninstallContextMenu = (callback) ->
 addCommandsToPath = (callback) ->
   installCommands = (callback) ->
     atomCommandPath = path.join(binFolder, 'atom.cmd')
-    relativeAtomPath = path.relative(binFolder, path.join(appFolder, 'cli', 'atom.cmd'))
+    relativeAtomPath = path.relative(binFolder, path.join(appFolder, 'resources', 'cli', 'atom.cmd'))
     atomCommand = """
       @echo off
       "%~dp0\\#{relativeAtomPath}" %*

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -113,17 +113,11 @@ addCommandsToPath = (callback) ->
   installCommands = (callback) ->
     atomCommandPath = path.join(binFolder, 'atom.cmd')
     relativeAtomPath = path.relative(binFolder, path.join(appFolder, 'resources', 'cli', 'atom.cmd'))
-    atomCommand = """
-      @echo off
-      "%~dp0\\#{relativeAtomPath}" %*
-    """
+    atomCommand = "@echo off\r\n\"%~dp0\\#{relativeAtomPath}\" %*"
 
     apmCommandPath = path.join(binFolder, 'apm.cmd')
     relativeApmPath = path.relative(binFolder, path.join(process.resourcesPath, 'app', 'apm', 'node_modules', 'atom-package-manager', 'bin', 'apm.cmd'))
-    apmCommand = """
-      @echo off
-      "%~dp0\\#{relativeApmPath}" %*
-    """
+    apmCommand = "@echo off\r\n\"%~dp0\\#{relativeApmPath}\" %*"
 
     fs.writeFile atomCommandPath, atomCommand, ->
       fs.writeFile apmCommandPath, apmCommand, ->


### PR DESCRIPTION
Adds an `atom.cmd` that is similar to the `atom.sh` in that it checks for flags that should synchronously show output and launch atom and launches it a different way in those cases.

This adds a `atom.js` wrapper that spawns `atom.exe` and immediately exits so that the output does not go to the console.

Fixes #4178
