### PR TITLE
Improve Config API with regard to scoped settings

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -158,10 +158,10 @@ describe "Config", ->
       expect(atom.config.isDefault('foo.changes')).toBe true
       expect(Grim.deprecate.callCount).toBe 2
 
-      atom.config.set('foo.same', 2)
+      atom.config.set('foo.same', 1)
       atom.config.set('foo.changes', 3)
 
-      expect(atom.config.isDefault('foo.same')).toBe false
+      expect(atom.config.isDefault('foo.same')).toBe true
       expect(atom.config.isDefault('foo.changes')).toBe false
       expect(Grim.deprecate.callCount).toBe 4
 

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -367,7 +367,7 @@ describe "PackageManager", ->
             atom.packages.activatePackage("package-with-scoped-properties")
 
           runs ->
-            expect(atom.config.get ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
+            expect(atom.config.get 'editor.increaseIndentPattern', scope: ['.source.omg']).toBe '^a'
 
     describe "converted textmate packages", ->
       it "loads the package's grammars", ->
@@ -380,13 +380,13 @@ describe "PackageManager", ->
           expect(atom.grammars.selectGrammar("file.rb").name).toBe "Ruby"
 
       it "loads the translated scoped properties", ->
-        expect(atom.config.get(['.source.ruby'], 'editor.commentStart')).toBeUndefined()
+        expect(atom.config.get('editor.commentStart', scope: ['.source.ruby'])).toBeUndefined()
 
         waitsForPromise ->
           atom.packages.activatePackage('language-ruby')
 
         runs ->
-          expect(atom.config.get(['.source.ruby'], 'editor.commentStart')).toBe '# '
+          expect(atom.config.get('editor.commentStart', scope: ['.source.ruby'])).toBe '# '
 
   describe "::deactivatePackage(id)", ->
     afterEach ->
@@ -493,9 +493,9 @@ describe "PackageManager", ->
           atom.packages.activatePackage("package-with-scoped-properties")
 
         runs ->
-          expect(atom.config.get ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
+          expect(atom.config.get 'editor.increaseIndentPattern', scope: ['.source.omg']).toBe '^a'
           atom.packages.deactivatePackage("package-with-scoped-properties")
-          expect(atom.config.get ['.source.omg'], 'editor.increaseIndentPattern').toBeUndefined()
+          expect(atom.config.get 'editor.increaseIndentPattern', scope: ['.source.omg']).toBeUndefined()
 
     describe "textmate packages", ->
       it "removes the package's grammars", ->
@@ -515,7 +515,7 @@ describe "PackageManager", ->
 
         runs ->
           atom.packages.deactivatePackage('language-ruby')
-          expect(atom.config.get(['.source.ruby'], 'editor.commentStart')).toBeUndefined()
+          expect(atom.config.get('editor.commentStart', scope: ['.source.ruby'])).toBeUndefined()
 
   describe "::activate()", ->
     packageActivator = null

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -2593,9 +2593,9 @@ describe "TextEditorComponent", ->
 
     describe 'soft wrap settings', ->
       beforeEach ->
-        atom.config.set '.source.coffee', 'editor.softWrap', true
-        atom.config.set '.source.coffee', 'editor.preferredLineLength', 17
-        atom.config.set '.source.coffee', 'editor.softWrapAtPreferredLineLength', true
+        atom.config.set 'editor.softWrap', true, scopeSelector: '.source.coffee'
+        atom.config.set 'editor.preferredLineLength', 17, scopeSelector: '.source.coffee'
+        atom.config.set 'editor.softWrapAtPreferredLineLength', true, scopeSelector: '.source.coffee'
 
         editor.setEditorWidthInChars(20)
         coffeeEditor.setEditorWidthInChars(20)
@@ -2605,18 +2605,18 @@ describe "TextEditorComponent", ->
         expect(coffeeEditor.lineTextForScreenRow(3)).toEqual '    return items '
 
       it 'updates the wrapped lines when editor.preferredLineLength changes', ->
-        atom.config.set '.source.coffee', 'editor.preferredLineLength', 20
+        atom.config.set 'editor.preferredLineLength', 20, scopeSelector: '.source.coffee'
         expect(coffeeEditor.lineTextForScreenRow(2)).toEqual '    return items if '
 
       it 'updates the wrapped lines when editor.softWrapAtPreferredLineLength changes', ->
-        atom.config.set '.source.coffee', 'editor.softWrapAtPreferredLineLength', false
+        atom.config.set 'editor.softWrapAtPreferredLineLength', false, scopeSelector: '.source.coffee'
         expect(coffeeEditor.lineTextForScreenRow(2)).toEqual '    return items if '
 
       it 'updates the wrapped lines when editor.softWrap changes', ->
-        atom.config.set '.source.coffee', 'editor.softWrap', false
+        atom.config.set 'editor.softWrap', false, scopeSelector: '.source.coffee'
         expect(coffeeEditor.lineTextForScreenRow(2)).toEqual '    return items if items.length <= 1'
 
-        atom.config.set '.source.coffee', 'editor.softWrap', true
+        atom.config.set 'editor.softWrap', true, scopeSelector: '.source.coffee'
         expect(coffeeEditor.lineTextForScreenRow(3)).toEqual '    return items '
 
       it 'updates the wrapped lines when the grammar changes', ->
@@ -2644,11 +2644,11 @@ describe "TextEditorComponent", ->
           tab: 'F'
           cr: 'E'
 
-        atom.config.set '.source.js', 'editor.showInvisibles', true
-        atom.config.set '.source.js', 'editor.invisibles', jsInvisibles
+        atom.config.set 'editor.showInvisibles', true, scopeSelector: '.source.js'
+        atom.config.set 'editor.invisibles', jsInvisibles, scopeSelector: '.source.js'
 
-        atom.config.set '.source.coffee', 'editor.showInvisibles', false
-        atom.config.set '.source.coffee', 'editor.invisibles', coffeeInvisibles
+        atom.config.set 'editor.showInvisibles', false, scopeSelector: '.source.coffee'
+        atom.config.set 'editor.invisibles', coffeeInvisibles, scopeSelector: '.source.coffee'
 
         editor.setText " a line with tabs\tand spaces \n"
         nextAnimationFrame()
@@ -2664,7 +2664,7 @@ describe "TextEditorComponent", ->
       it "re-renders the invisibles when the invisible settings change", ->
         jsGrammar = editor.getGrammar()
         editor.setGrammar(coffeeEditor.getGrammar())
-        atom.config.set '.source.coffee', 'editor.showInvisibles', true
+        atom.config.set 'editor.showInvisibles', true, scopeSelector: '.source.coffee'
         nextAnimationFrame()
         expect(component.lineNodeForScreenRow(0).textContent).toBe "#{coffeeInvisibles.space}a line with tabs#{coffeeInvisibles.tab}and spaces#{coffeeInvisibles.space}#{coffeeInvisibles.eol}"
 
@@ -2673,7 +2673,7 @@ describe "TextEditorComponent", ->
           space: 'E'
           tab: 'W'
           cr: 'I'
-        atom.config.set '.source.coffee', 'editor.invisibles', newInvisibles
+        atom.config.set 'editor.invisibles', newInvisibles, scopeSelector: '.source.coffee'
         nextAnimationFrame()
         expect(component.lineNodeForScreenRow(0).textContent).toBe "#{newInvisibles.space}a line with tabs#{newInvisibles.tab}and spaces#{newInvisibles.space}#{newInvisibles.eol}"
 
@@ -2683,8 +2683,8 @@ describe "TextEditorComponent", ->
 
     describe 'editor.showIndentGuide', ->
       beforeEach ->
-        atom.config.set '.source.js', 'editor.showIndentGuide', true
-        atom.config.set '.source.coffee', 'editor.showIndentGuide', false
+        atom.config.set 'editor.showIndentGuide', true, scopeSelector: '.source.js'
+        atom.config.set 'editor.showIndentGuide', false, scopeSelector: '.source.coffee'
 
       it "has an 'indent-guide' class when scoped editor.showIndentGuide is true, but not when scoped editor.showIndentGuide is false", ->
         line1LeafNodes = getLeafNodes(component.lineNodeForScreenRow(1))
@@ -2705,7 +2705,7 @@ describe "TextEditorComponent", ->
         expect(line1LeafNodes[0].classList.contains('indent-guide')).toBe true
         expect(line1LeafNodes[1].classList.contains('indent-guide')).toBe false
 
-        atom.config.set '.source.js', 'editor.showIndentGuide', false
+        atom.config.set 'editor.showIndentGuide', false, scopeSelector: '.source.js'
 
         line1LeafNodes = getLeafNodes(component.lineNodeForScreenRow(1))
         expect(line1LeafNodes[0].textContent).toBe '  '

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1327,7 +1327,7 @@ describe "TextEditor", ->
           coffeeEditor.selectWordsContainingCursors()
           expect(coffeeEditor.getSelectedBufferRange()).toEqual [[0, 6], [0, 15]]
 
-          atom.config.set '.source.coffee', 'editor.nonWordCharacters', 'qusort'
+          atom.config.set 'editor.nonWordCharacters', 'qusort', scopeSelector: '.source.coffee'
 
           coffeeEditor.setCursorBufferPosition [0, 9]
           coffeeEditor.selectWordsContainingCursors()
@@ -3276,7 +3276,7 @@ describe "TextEditor", ->
         atom.packages.unloadPackages()
 
       it 'returns correct values based on the scope of the set grammars', ->
-        atom.config.set '.source.coffee', 'editor.tabLength', 6
+        atom.config.set 'editor.tabLength', 6, scopeSelector: '.source.coffee'
 
         expect(editor.getTabLength()).toBe 2
         expect(coffeeEditor.getTabLength()).toBe 6
@@ -3298,12 +3298,12 @@ describe "TextEditor", ->
         expect(editor.getTabLength()).toBe 2
         expect(editor.tokenizedLineForScreenRow(5).tokens[0].firstNonWhitespaceIndex).toBe 2
 
-        atom.config.set '.source.js', 'editor.tabLength', 6
+        atom.config.set 'editor.tabLength', 6, scopeSelector: '.source.js'
         expect(editor.getTabLength()).toBe 6
         expect(editor.tokenizedLineForScreenRow(5).tokens[0].firstNonWhitespaceIndex).toBe 6
 
       it 'updates the tab length when the grammar changes', ->
-        atom.config.set '.source.coffee', 'editor.tabLength', 6
+        atom.config.set 'editor.tabLength', 6, scopeSelector: '.source.coffee'
 
         expect(editor.getTabLength()).toBe 2
         expect(editor.tokenizedLineForScreenRow(5).tokens[0].firstNonWhitespaceIndex).toBe 2
@@ -3473,8 +3473,8 @@ describe "TextEditor", ->
           atom.project.open('coffee.coffee', autoIndent: false).then (o) -> coffeeEditor = o
 
         runs ->
-          atom.config.set('.source.js', 'editor.autoIndent', true)
-          atom.config.set('.source.coffee', 'editor.autoIndent', false)
+          atom.config.set('editor.autoIndent', true, scopeSelector: '.source.js')
+          atom.config.set('editor.autoIndent', false, scopeSelector: '.source.coffee')
 
       afterEach: ->
         atom.packages.deactivatePackages()

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -809,9 +809,10 @@ class Config
     console.error detail
 
   save: ->
-    allSettings = global: @settings
-    allSettings = _.extend allSettings, @scopedSettingsStore.propertiesForSource(@getUserConfigPath())
-    CSON.writeFileSync(@configFilePath, allSettings)
+    settings = @scopedSettingsStore.propertiesForSource(@getUserConfigPath())
+    settings.global = settings['*']
+    delete settings['*']
+    CSON.writeFileSync(@configFilePath, settings)
 
   ###
   Section: Private methods managing global settings

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -641,10 +641,11 @@ class Config
     Grim.deprecate("Use `not ::get(keyPath, {scope, sources: [atom.config.getUserConfigPath()]})?` instead")
     if arguments.length is 1
       [keyPath] = arguments
+      scopeSelector = '*'
     else
       [scopeSelector, keyPath] = arguments
-      scope = [scopeSelector]
-    not @get(keyPath, {scope, sources: [@getUserConfigPath()]})?
+
+    not @get(keyPath, {scope: [scopeSelector], sources: [@getUserConfigPath()]})?
 
   # Extended: Retrieve the schema for a specific key path. The schema will tell
   # you what type the keyPath expects, and other metadata about the config

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -202,7 +202,7 @@ class Cursor extends Model
     [before, after] = @editor.getTextInBufferRange(range)
     return false if /\s/.test(before) or /\s/.test(after)
 
-    nonWordCharacters = atom.config.get(@getScopeDescriptor(), 'editor.nonWordCharacters').split('')
+    nonWordCharacters = atom.config.get('editor.nonWordCharacters', scope: @getScopeDescriptor()).split('')
     _.contains(nonWordCharacters, before) isnt _.contains(nonWordCharacters, after)
 
   # Public: Returns whether this cursor is between a word's start and end.
@@ -636,7 +636,7 @@ class Cursor extends Model
   # Returns a {RegExp}.
   wordRegExp: ({includeNonWordCharacters}={}) ->
     includeNonWordCharacters ?= true
-    nonWordCharacters = atom.config.get(@getScopeDescriptor(), 'editor.nonWordCharacters')
+    nonWordCharacters = atom.config.get('editor.nonWordCharacters', scope: @getScopeDescriptor())
     segments = ["^[\t ]*$"]
     segments.push("[^\\s#{_.escapeRegExp(nonWordCharacters)}]+")
     if includeNonWordCharacters

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -67,24 +67,24 @@ class DisplayBuffer extends Model
 
     oldConfigSettings = @configSettings
     @configSettings =
-      scrollPastEnd: atom.config.get(scopeDescriptor, 'editor.scrollPastEnd')
-      softWrap: atom.config.get(scopeDescriptor, 'editor.softWrap')
-      softWrapAtPreferredLineLength: atom.config.get(scopeDescriptor, 'editor.softWrapAtPreferredLineLength')
-      preferredLineLength: atom.config.get(scopeDescriptor, 'editor.preferredLineLength')
+      scrollPastEnd: atom.config.get('editor.scrollPastEnd', scope: scopeDescriptor)
+      softWrap: atom.config.get('editor.softWrap', scope: scopeDescriptor)
+      softWrapAtPreferredLineLength: atom.config.get('editor.softWrapAtPreferredLineLength', scope: scopeDescriptor)
+      preferredLineLength: atom.config.get('editor.preferredLineLength', scope: scopeDescriptor)
 
-    subscriptions.add atom.config.onDidChange scopeDescriptor, 'editor.softWrap', ({newValue}) =>
+    subscriptions.add atom.config.onDidChange 'editor.softWrap', scope: scopeDescriptor, ({newValue}) =>
       @configSettings.softWrap = newValue
       @updateWrappedScreenLines()
 
-    subscriptions.add atom.config.onDidChange scopeDescriptor, 'editor.softWrapAtPreferredLineLength', ({newValue}) =>
+    subscriptions.add atom.config.onDidChange 'editor.softWrapAtPreferredLineLength', scope: scopeDescriptor, ({newValue}) =>
       @configSettings.softWrapAtPreferredLineLength = newValue
       @updateWrappedScreenLines() if @isSoftWrapped()
 
-    subscriptions.add atom.config.onDidChange scopeDescriptor, 'editor.preferredLineLength', ({newValue}) =>
+    subscriptions.add atom.config.onDidChange 'editor.preferredLineLength', scope: scopeDescriptor, ({newValue}) =>
       @configSettings.preferredLineLength = newValue
-      @updateWrappedScreenLines() if @isSoftWrapped() and atom.config.get(scopeDescriptor, 'editor.softWrapAtPreferredLineLength')
+      @updateWrappedScreenLines() if @isSoftWrapped() and atom.config.get('editor.softWrapAtPreferredLineLength', scope: scopeDescriptor)
 
-    subscriptions.add atom.config.observe scopeDescriptor, 'editor.scrollPastEnd', (value) =>
+    subscriptions.add atom.config.observe 'editor.scrollPastEnd', scope: scopeDescriptor, (value) =>
       @configSettings.scrollPastEnd = value
 
     @updateWrappedScreenLines() if oldConfigSettings? and not _.isEqual(oldConfigSettings, @configSettings)

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -316,7 +316,7 @@ class LanguageMode
       @editor.setIndentationForBufferRow(bufferRow, desiredIndentLevel)
 
   getRegexForProperty: (scopeDescriptor, property) ->
-    if pattern = atom.config.get(scopeDescriptor, property)
+    if pattern = atom.config.get(property, scope: scopeDescriptor)
       new OnigRegExp(pattern)
 
   increaseIndentRegexForScopeDescriptor: (scopeDescriptor) ->

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -462,9 +462,9 @@ TextEditorComponent = React.createClass
 
     scopeDescriptor = editor.getRootScopeDescriptor()
 
-    subscriptions.add atom.config.observe scopeDescriptor, 'editor.showIndentGuide', @setShowIndentGuide
-    subscriptions.add atom.config.observe scopeDescriptor, 'editor.showLineNumbers', @setShowLineNumbers
-    subscriptions.add atom.config.observe scopeDescriptor, 'editor.scrollSensitivity', @setScrollSensitivity
+    subscriptions.add atom.config.observe 'editor.showIndentGuide', scope: scopeDescriptor, @setShowIndentGuide
+    subscriptions.add atom.config.observe 'editor.showLineNumbers', scope: scopeDescriptor, @setShowLineNumbers
+    subscriptions.add atom.config.observe 'editor.scrollSensitivity', scope: scopeDescriptor, @setScrollSensitivity
 
   focused: ->
     if @isMounted()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -168,8 +168,8 @@ class TextEditor extends Model
 
     scopeDescriptor = @getRootScopeDescriptor()
 
-    subscriptions.add atom.config.onDidChange scopeDescriptor, 'editor.showInvisibles', => @updateInvisibles()
-    subscriptions.add atom.config.onDidChange scopeDescriptor, 'editor.invisibles', => @updateInvisibles()
+    subscriptions.add atom.config.onDidChange 'editor.showInvisibles', scope: scopeDescriptor, => @updateInvisibles()
+    subscriptions.add atom.config.onDidChange 'editor.invisibles', scope: scopeDescriptor, => @updateInvisibles()
 
   getViewClass: ->
     require './text-editor-view'
@@ -2812,17 +2812,17 @@ class TextEditor extends Model
   ###
 
   shouldAutoIndent: ->
-    atom.config.get(@getRootScopeDescriptor(), "editor.autoIndent")
+    atom.config.get("editor.autoIndent", scope: @getRootScopeDescriptor())
 
   shouldAutoIndentOnPaste: ->
-    atom.config.get(@getRootScopeDescriptor(), "editor.autoIndentOnPaste")
+    atom.config.get("editor.autoIndentOnPaste", scope: @getRootScopeDescriptor())
 
   shouldShowInvisibles: ->
-    not @mini and atom.config.get(@getRootScopeDescriptor(), 'editor.showInvisibles')
+    not @mini and atom.config.get('editor.showInvisibles', scope: @getRootScopeDescriptor())
 
   updateInvisibles: ->
     if @shouldShowInvisibles()
-      @displayBuffer.setInvisibles(atom.config.get(@getRootScopeDescriptor(), 'editor.invisibles'))
+      @displayBuffer.setInvisibles(atom.config.get('editor.invisibles', scope: @getRootScopeDescriptor()))
     else
       @displayBuffer.setInvisibles(null)
 

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -84,10 +84,10 @@ class TokenizedBuffer extends Model
     @currentGrammarScore = score ? grammar.getScore(@buffer.getPath(), @buffer.getText())
     @subscribe @grammar.onDidUpdate => @retokenizeLines()
 
-    @configSettings = tabLength: atom.config.get(@rootScopeDescriptor, 'editor.tabLength')
+    @configSettings = tabLength: atom.config.get('editor.tabLength', scope: @rootScopeDescriptor)
 
     @grammarTabLengthSubscription?.dispose()
-    @grammarTabLengthSubscription = atom.config.onDidChange @rootScopeDescriptor, 'editor.tabLength', ({newValue}) =>
+    @grammarTabLengthSubscription = atom.config.onDidChange 'editor.tabLength', scope: @rootScopeDescriptor, ({newValue}) =>
       @configSettings.tabLength = newValue
       @retokenizeLines()
     @subscribe @grammarTabLengthSubscription

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -645,7 +645,7 @@ class Workspace extends Model
 
   # Restore to a default editor font size.
   resetFontSize: ->
-    atom.config.restoreDefault("editor.fontSize")
+    atom.config.unset("editor.fontSize")
 
   # Removes the item's uri from the list of potential items to reopen.
   itemOpened: (item) ->


### PR DESCRIPTION
This may be able to supplant #4558.

/cc @maxbrunsfeld: I got the get/set API looking good.
### Problems with Config API

The Config API still has some awkwardness leftover from when scoped settings were merged in. It would be nice to make the API more coherent considering the expanded role of settings.
- We're using a private method, `::addScopedSettings` in packages. We need a public equivalent. The main difference is that `::addScopedSettings` takes a `source` argument. The `source` is used to distinguish between user settings and package settings internally, so it's important.
- Methods related to defaults don't make sense in the presence of scoped settings. The methods `::isDefault`, `::restoreDefault`, and `::getDefault` don't actually deal with true _default_ values from the schemas. Instead they consider a value "default" if its source isn't the user's `config.cson`
### Proposed Solution

We can eliminate `::addScopedSettings` and the methods that deal with defaults from the API. Instead, we replace them with the ability to talk about the _source_ of a given setting when getting and setting it. Then the settings view can make decisions based on the source being the user's `config.cson`, rather than exposing a murky conception of "default" in settings.

We propose to replace the following methods:
- getDefault
- isDefault
- restoreDefault
- addScopedSettings

With these new signatures for get and set
- set(keyPath, value, [{scopeSelector, source}])
- get(keyPath, [{scope, sources, excludeSources}])

Plus the new `unset` method... which can be used to remove a single key path or all key paths from a given scope.
- unset([keyPath], [{source}])

If we need to know if a value is assigned in the user's settings, we specify the desired _source_ in our getter. If we get no value back, we can assume we're using some other value (maybe a schema default, mabye from a package). If we want to determine the non-user-assigned value, we exclude it as a source when getting the setting.
### Steps
- [x] Store global settings in the scoped property store under `*` so they're associated with a source
- [ ] Refactor the scoped-property-store to allow mutating values without always adding new entries to the cascade (atom/scoped-property-store#8).
- [ ] Bugfix: Ensure the most recently assigned setting is honored when there is a specificity tie.
