### PR TITLE
Add OS default fonts for Ubuntu (Unity) and Fedora (GNOME 3)

### DIFF
--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -82,4 +82,4 @@
 
 // Other
 
-@font-family: 'Lucida Grande', 'Segoe UI', sans-serif;
+@font-family: 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;


### PR DESCRIPTION
This PR adds OS default fonts for the Linux distros Ubuntu and Fedora (or anyone else using GNOME 3). Since Lucida Grande and Segoe UI are generally only available in their native OSes (OS X and Windows respectively), the `sans-serif` fallback was being used as the main UI font:

![screenshot from 2014-12-12 14 10 30](https://cloud.githubusercontent.com/assets/823545/5417562/b789d5d2-8208-11e4-9f4a-d10aefff3122.png)

With these two additional fonts, the UI should look more native in Unity and GNOME 3 (Unity below):

![screenshot from 2014-12-12 14 09 56](https://cloud.githubusercontent.com/assets/823545/5417586/dd83360c-8208-11e4-92c5-4628651b732c.png)
