### PR TITLE
Correct visible row range calculation.

### DIFF
--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -352,7 +352,7 @@ class DisplayBuffer extends Model
   getVisibleRowRange: ->
     return [0, 0] unless @getLineHeightInPixels() > 0
 
-    heightInLines = Math.ceil(@getHeight() / @getLineHeightInPixels()) + 1
+    heightInLines = Math.ceil(@getHeight() / @getLineHeightInPixels())
     startRow = Math.floor(@getScrollTop() / @getLineHeightInPixels())
     endRow = Math.min(@getLineCount(), startRow + heightInLines)
 


### PR DESCRIPTION
Fixes issue #4596.

There was already Math.ceil so no need for +1.

Example:
If
  height = 2.5, line height = 1
then
  heightInLines is 3 and not 4
