### PR TITLE
Add dark-theme for gtk+3

### DIFF
--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -30,6 +30,7 @@ class AtomWindow
       'web-preferences':
         'direct-write': false
         'subpixel-font-scaling': false
+      'dark-theme': true
     global.atomApplication.addWindow(this)
 
     @handleEvents()


### PR DESCRIPTION
In Ubuntu, the default theme is dark gray, so it is a nice match for the Atom dark default theme. However, in gnome-3 the default theme is white and it kind of contradicts with Atom dark theme. Here is how it looks:

![atom-white-theme](https://cloud.githubusercontent.com/assets/6003742/5467932/69d1b3c4-857c-11e4-936a-d217355b8061.png)

Since atom-shell is now supporting [dark theme in gtk3+](https://github.com/atom/atom-shell/blob/master/docs/api/browser-window.md#class-browserwindow) I thought it would be nice to have the dark theme by default, however there is an open issue [#765](https://github.com/atom/atom-shell/issues/765) in atom-shell where the menu bar will still be white while the top bar is black. Here is how it looks:

![atom-gnome-dark-1](https://cloud.githubusercontent.com/assets/6003742/5425488/d428c002-82cd-11e4-930e-1688794001ba.png)

I am going to leave this here so we can review it, and once the issue is resolved, you may want to merge it.

Thank you.
