### PR TITLE
Add a hook so packages can support more version control systems

### DIFF
--- a/src/project.coffee
+++ b/src/project.coffee
@@ -120,9 +120,18 @@ class Project extends Model
     if projectPath?
       directory = if fs.isDirectorySync(projectPath) then projectPath else path.dirname(projectPath)
       @rootDirectory = new Directory(directory)
-      if @repo = GitRepository.open(directory, project: this)
-        @repo.refreshIndex()
-        @repo.refreshStatus()
+
+      vcsList = [GitRepository]
+      for atomPackage in atom.packages.getLoadedPackages()
+        if atomPackage.metadata['vcs-package'] is true
+          implementation = atomPackage.metadata['vcs-implementation'] ? atomPackage.name
+          vcsList.push(require "#{atomPackage.path}/lib/#{implementation}")
+
+      for vcs in vcsList
+        if @repo = vcs.open(directory, project: this)
+          @repo.refreshIndex()
+          @repo.refreshStatus()
+          break
     else
       @rootDirectory = null
 


### PR DESCRIPTION
The project API currently only supports Git. This diff makes it possible for 3rd-party packages to add support for other version control systems, addressing issue https://github.com/atom/atom/issues/4138.

Here's an example of a preliminary package that adds support for Mercurial: https://github.com/oclbdk/vcs-hg

Here's a demo of it in action:

![vcs-hg demo](http://i.imgur.com/3vOhrml.gif)
