### PR TITLE
Better save notifications

### DIFF
--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -299,16 +299,12 @@ describe "WorkspaceView", ->
   describe "saving the active item", ->
     describe "saveActivePaneItem", ->
       describe "when there is an error", ->
-        beforeEach ->
-
         it "emits a warning notification when the file cannot be saved", ->
           spyOn(Pane::, 'saveActiveItem').andCallFake ->
             throw new Error("'/some/file' is a directory")
 
           atom.notifications.onDidAddNotification addedSpy = jasmine.createSpy()
-
           atom.workspace.saveActivePaneItem()
-
           expect(addedSpy).toHaveBeenCalled()
           expect(addedSpy.mostRecentCall.args[0].getType()).toBe 'warning'
 
@@ -317,7 +313,6 @@ describe "WorkspaceView", ->
             throw new Error("ENOTDIR, not a directory '/Some/dir/and-a-file.js'")
 
           atom.notifications.onDidAddNotification addedSpy = jasmine.createSpy()
-
           atom.workspace.saveActivePaneItem()
           expect(addedSpy).toHaveBeenCalled()
           expect(addedSpy.mostRecentCall.args[0].getType()).toBe 'warning'

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -3,6 +3,7 @@ Q = require 'q'
 path = require 'path'
 temp = require 'temp'
 TextEditorView = require '../src/text-editor-view'
+Pane = require '../src/pane'
 PaneView = require '../src/pane-view'
 Workspace = require '../src/workspace'
 
@@ -294,3 +295,26 @@ describe "WorkspaceView", ->
 
       modalContainer = workspaceElement.querySelector('atom-panel-container.modal')
       expect(modalContainer.parentNode).toBe workspaceElement
+
+  describe "saving the active item", ->
+    describe "saveActivePaneItem", ->
+      describe "when there is an error", ->
+        beforeEach ->
+
+        it "emits a warning notification when the file cannot be saved", ->
+          spyOn(Pane::, 'saveActiveItem').andCallFake ->
+            throw new Error("'/some/file' is a directory")
+
+          atom.notifications.onDidAddNotification addedSpy = jasmine.createSpy()
+
+          atom.workspace.saveActivePaneItem()
+
+          expect(addedSpy).toHaveBeenCalled()
+          expect(addedSpy.mostRecentCall.args[0].getType()).toBe 'warning'
+
+        it "emits a warning notification when the file cannot be saved", ->
+          spyOn(Pane::, 'saveActiveItem').andCallFake ->
+            throw new Error("no one knows")
+
+          save = -> atom.workspace.saveActivePaneItem()
+          expect(save).toThrow()

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -319,7 +319,15 @@ describe "WorkspaceView", ->
           atom.notifications.onDidAddNotification addedSpy = jasmine.createSpy()
 
           atom.workspace.saveActivePaneItem()
+          expect(addedSpy).toHaveBeenCalled()
+          expect(addedSpy.mostRecentCall.args[0].getType()).toBe 'warning'
 
+        it "emits a warning notification when the user does not have permission", ->
+          spyOn(Pane::, 'saveActiveItem').andCallFake ->
+            throw new Error("EACCES, permission denied '/Some/dir/and-a-file.js'")
+
+          atom.notifications.onDidAddNotification addedSpy = jasmine.createSpy()
+          atom.workspace.saveActivePaneItem()
           expect(addedSpy).toHaveBeenCalled()
           expect(addedSpy.mostRecentCall.args[0].getType()).toBe 'warning'
 

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -296,7 +296,7 @@ describe "WorkspaceView", ->
       modalContainer = workspaceElement.querySelector('atom-panel-container.modal')
       expect(modalContainer.parentNode).toBe workspaceElement
 
-  fdescribe "saving the active item", ->
+  describe "saving the active item", ->
     describe "saveActivePaneItem", ->
       describe "when there is an error", ->
         beforeEach ->

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -296,39 +296,38 @@ describe "WorkspaceView", ->
       modalContainer = workspaceElement.querySelector('atom-panel-container.modal')
       expect(modalContainer.parentNode).toBe workspaceElement
 
-  describe "saving the active item", ->
-    describe "saveActivePaneItem", ->
-      describe "when there is an error", ->
-        it "emits a warning notification when the file cannot be saved", ->
-          spyOn(Pane::, 'saveActiveItem').andCallFake ->
-            throw new Error("'/some/file' is a directory")
+  describe "::saveActivePaneItem()", ->
+    describe "when there is an error", ->
+      it "emits a warning notification when the file cannot be saved", ->
+        spyOn(Pane::, 'saveActiveItem').andCallFake ->
+          throw new Error("'/some/file' is a directory")
 
-          atom.notifications.onDidAddNotification addedSpy = jasmine.createSpy()
-          atom.workspace.saveActivePaneItem()
-          expect(addedSpy).toHaveBeenCalled()
-          expect(addedSpy.mostRecentCall.args[0].getType()).toBe 'warning'
+        atom.notifications.onDidAddNotification addedSpy = jasmine.createSpy()
+        atom.workspace.saveActivePaneItem()
+        expect(addedSpy).toHaveBeenCalled()
+        expect(addedSpy.mostRecentCall.args[0].getType()).toBe 'warning'
 
-        it "emits a warning notification when the directory cannot be written to", ->
-          spyOn(Pane::, 'saveActiveItem').andCallFake ->
-            throw new Error("ENOTDIR, not a directory '/Some/dir/and-a-file.js'")
+      it "emits a warning notification when the directory cannot be written to", ->
+        spyOn(Pane::, 'saveActiveItem').andCallFake ->
+          throw new Error("ENOTDIR, not a directory '/Some/dir/and-a-file.js'")
 
-          atom.notifications.onDidAddNotification addedSpy = jasmine.createSpy()
-          atom.workspace.saveActivePaneItem()
-          expect(addedSpy).toHaveBeenCalled()
-          expect(addedSpy.mostRecentCall.args[0].getType()).toBe 'warning'
+        atom.notifications.onDidAddNotification addedSpy = jasmine.createSpy()
+        atom.workspace.saveActivePaneItem()
+        expect(addedSpy).toHaveBeenCalled()
+        expect(addedSpy.mostRecentCall.args[0].getType()).toBe 'warning'
 
-        it "emits a warning notification when the user does not have permission", ->
-          spyOn(Pane::, 'saveActiveItem').andCallFake ->
-            throw new Error("EACCES, permission denied '/Some/dir/and-a-file.js'")
+      it "emits a warning notification when the user does not have permission", ->
+        spyOn(Pane::, 'saveActiveItem').andCallFake ->
+          throw new Error("EACCES, permission denied '/Some/dir/and-a-file.js'")
 
-          atom.notifications.onDidAddNotification addedSpy = jasmine.createSpy()
-          atom.workspace.saveActivePaneItem()
-          expect(addedSpy).toHaveBeenCalled()
-          expect(addedSpy.mostRecentCall.args[0].getType()).toBe 'warning'
+        atom.notifications.onDidAddNotification addedSpy = jasmine.createSpy()
+        atom.workspace.saveActivePaneItem()
+        expect(addedSpy).toHaveBeenCalled()
+        expect(addedSpy.mostRecentCall.args[0].getType()).toBe 'warning'
 
-        it "emits a warning notification when the file cannot be saved", ->
-          spyOn(Pane::, 'saveActiveItem').andCallFake ->
-            throw new Error("no one knows")
+      it "emits a warning notification when the file cannot be saved", ->
+        spyOn(Pane::, 'saveActiveItem').andCallFake ->
+          throw new Error("no one knows")
 
-          save = -> atom.workspace.saveActivePaneItem()
-          expect(save).toThrow()
+        save = -> atom.workspace.saveActivePaneItem()
+        expect(save).toThrow()

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -296,7 +296,7 @@ describe "WorkspaceView", ->
       modalContainer = workspaceElement.querySelector('atom-panel-container.modal')
       expect(modalContainer.parentNode).toBe workspaceElement
 
-  describe "saving the active item", ->
+  fdescribe "saving the active item", ->
     describe "saveActivePaneItem", ->
       describe "when there is an error", ->
         beforeEach ->
@@ -304,6 +304,17 @@ describe "WorkspaceView", ->
         it "emits a warning notification when the file cannot be saved", ->
           spyOn(Pane::, 'saveActiveItem').andCallFake ->
             throw new Error("'/some/file' is a directory")
+
+          atom.notifications.onDidAddNotification addedSpy = jasmine.createSpy()
+
+          atom.workspace.saveActivePaneItem()
+
+          expect(addedSpy).toHaveBeenCalled()
+          expect(addedSpy.mostRecentCall.args[0].getType()).toBe 'warning'
+
+        it "emits a warning notification when the directory cannot be written to", ->
+          spyOn(Pane::, 'saveActiveItem').andCallFake ->
+            throw new Error("ENOTDIR, not a directory '/Some/dir/and-a-file.js'")
 
           atom.notifications.onDidAddNotification addedSpy = jasmine.createSpy()
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -571,9 +571,11 @@ class Workspace extends Model
     catch error
       if error.message.endsWith('is a directory')
         atom.notifications.addWarning("Unable to save file: #{error.message}")
+      else if error.message.startsWith('EACCES,')
+        atom.notifications.addWarning("Unable to save file: #{error.message.replace('EACCES, ', '')}")
       else if errorMatch = /ENOTDIR, not a directory '([^']+)'/.exec(error.message)
         fileName = errorMatch[1]
-        atom.notifications.addWarning("Unable to save file: A directory in the path '#{fileName}' could not be written to.")
+        atom.notifications.addWarning("Unable to save file: A directory in the path '#{fileName}' could not be written to")
       else
         throw error
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -555,7 +555,7 @@ class Workspace extends Model
   # {::saveActivePaneItemAs} # will be called instead. This method does nothing
   # if the active item does not implement a `.save` method.
   saveActivePaneItem: ->
-    @getActivePane().saveActiveItem()
+    @saveActivePaneItemAndReportErrors('saveActiveItem')
 
   # Prompt the user for a path and save the active pane item to it.
   #
@@ -563,7 +563,16 @@ class Workspace extends Model
   # `.saveAs` on the item with the selected path. This method does nothing if
   # the active item does not implement a `.saveAs` method.
   saveActivePaneItemAs: ->
-    @getActivePane().saveActiveItemAs()
+    @saveActivePaneItemAndReportErrors('saveActiveItemAs')
+
+  saveActivePaneItemAndReportErrors: (method) ->
+    try
+      @getActivePane()[method]()
+    catch error
+      if error.message.endsWith('is a directory')
+        atom.notifications.addWarning("Unable to save file: #{error.message}")
+      else
+        throw error
 
   # Destroy (close) the active pane item.
   #

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -571,6 +571,9 @@ class Workspace extends Model
     catch error
       if error.message.endsWith('is a directory')
         atom.notifications.addWarning("Unable to save file: #{error.message}")
+      else if errorMatch = /ENOTDIR, not a directory '([^']+)'/.exec(error.message)
+        fileName = errorMatch[1]
+        atom.notifications.addWarning("Unable to save file: A directory in the path '#{fileName}' could not be written to.")
       else
         throw error
 


### PR DESCRIPTION
We dont handle saving errors very well. Say when someone tries to save, and it cannot write for some reason, permissions, lack of directory, trying to overwrite a directory, etc. This will kick out a warning notification rather than a fatal error.

This will fix:
- #4607 
- #4616 
- #4495 
