### PR TITLE
New config API

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -44,7 +44,8 @@ describe "Config", ->
         expect(atom.config.get("x.y", sources: ["a"], scope: [".foo"])).toBe 1
         expect(atom.config.get("x.y", sources: ["b"], scope: [".foo"])).toBe 2
         expect(atom.config.get("x.y", sources: ["c"], scope: [".foo"])).toBe 3
-        expect(atom.config.get("x.y", sources: ["x"], scope: [".foo"])).toBe 4
+        # Schema defaults never match a specific source. We could potentially add a special "schema" source.
+        expect(atom.config.get("x.y", sources: ["x"], scope: [".foo"])).toBeUndefined()
 
     describe "when an 'excludeSources' option is specified", ->
       it "only retrieves values from the specified sources", ->

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -175,21 +175,21 @@ describe "Config", ->
       it "restores the global default when no scoped default set", ->
         atom.config.setDefaults("foo", bar: baz: 10)
         atom.config.set('foo.bar.baz', 55, scopeSelector: '.source.coffee')
-        expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 55
+        expect(atom.config.get('foo.bar.baz', scope: ['.source.coffee'])).toBe 55
 
         atom.config.restoreDefault('.source.coffee', 'foo.bar.baz')
-        expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 10
+        expect(atom.config.get('foo.bar.baz', scope: ['.source.coffee'])).toBe 10
 
       it "restores the scoped default when a scoped default is set", ->
         atom.config.setDefaults("foo", bar: baz: 10)
         atom.config.addScopedSettings("default", ".source.coffee", foo: bar: baz: 42)
         atom.config.set('foo.bar.baz', 55, scopeSelector: '.source.coffee')
         atom.config.set('foo.bar.ok', 100, scopeSelector: '.source.coffee')
-        expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 55
+        expect(atom.config.get('foo.bar.baz', scope: ['.source.coffee'])).toBe 55
 
         atom.config.restoreDefault('.source.coffee', 'foo.bar.baz')
-        expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 42
-        expect(atom.config.get(['.source.coffee'], 'foo.bar.ok')).toBe 100
+        expect(atom.config.get('foo.bar.baz', scope: ['.source.coffee'])).toBe 42
+        expect(atom.config.get('foo.bar.ok', scope: ['.source.coffee'])).toBe 100
 
       it "calls ::save()", ->
         atom.config.setDefaults("foo", bar: baz: 10)
@@ -204,7 +204,7 @@ describe "Config", ->
         # see https://github.com/atom/atom/issues/4175
         atom.config.setDefaults("foo", bar: baz: 10)
         atom.config.restoreDefault('.source.coffee', 'foo.bar.baz')
-        expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 10
+        expect(atom.config.get('foo.bar.baz', scope: ['.source.coffee'])).toBe 10
 
         expect(atom.config.save).not.toHaveBeenCalled()
 
@@ -219,11 +219,11 @@ describe "Config", ->
         atom.config.set('foo.bar.baz', 55, scopeSelector: '.source.coffee')
         atom.config.set('foo.bar.zfoo', 20, scopeSelector: '.source.coffee')
         CSON.writeFileSync.reset()
-        expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 55
+        expect(atom.config.get('foo.bar.baz', scope: ['.source.coffee'])).toBe 55
 
         atom.config.restoreDefault('.source.coffee', 'foo.bar.baz')
-        expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 10
-        expect(atom.config.get(['.source.coffee'], 'foo.bar.zfoo')).toBe 20
+        expect(atom.config.get('foo.bar.baz', scope: ['.source.coffee'])).toBe 10
+        expect(atom.config.get('foo.bar.zfoo', scope: ['.source.coffee'])).toBe 20
         expect(CSON.writeFileSync).toHaveBeenCalled()
         properties = CSON.writeFileSync.mostRecentCall.args[1]
         expect(properties['.coffee.source']).toEqual
@@ -244,7 +244,7 @@ describe "Config", ->
 
         atom.config.restoreDefault('.source.coffee', 'foo.bar.ok')
         expect(atom.config.save).not.toHaveBeenCalled()
-        expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 55
+        expect(atom.config.get('foo.bar.baz', scope: ['.source.coffee'])).toBe 55
 
   describe ".getSettings()", ->
     it "returns all settings including defaults", ->
@@ -533,7 +533,7 @@ describe "Config", ->
 
       it "updates the config data based on the file contents", ->
         expect(atom.config.get("foo.bar")).toBe 'baz'
-        expect(atom.config.get(['.source.ruby'], "foo.bar")).toBe 'more-specific'
+        expect(atom.config.get("foo.bar", scope: ['.source.ruby'])).toBe 'more-specific'
 
     describe "when the config file contains valid cson", ->
       beforeEach ->
@@ -675,7 +675,7 @@ describe "Config", ->
           waitsFor 'update event', -> updatedHandler.callCount > 0
           runs ->
             expect(scopedSpy).toHaveBeenCalled()
-            expect(atom.config.get(['.source.ruby'], 'foo.scoped')).toBe false
+            expect(atom.config.get('foo.scoped', scope: ['.source.ruby'])).toBe false
 
         it "does not fire a change event for paths that did not change", ->
           atom.config.onDidChange ['.source.ruby'], 'foo.scoped', noChangeSpy = jasmine.createSpy()
@@ -691,8 +691,8 @@ describe "Config", ->
           waitsFor 'update event', -> updatedHandler.callCount > 0
           runs ->
             expect(noChangeSpy).not.toHaveBeenCalled()
-            expect(atom.config.get(['.source.ruby'], 'foo.bar')).toBe 'baz'
-            expect(atom.config.get(['.source.ruby'], 'foo.scoped')).toBe true
+            expect(atom.config.get('foo.bar', scope: ['.source.ruby'])).toBe 'baz'
+            expect(atom.config.get('foo.scoped', scope: ['.source.ruby'])).toBe true
 
     describe "when the config file changes to omit a setting with a default", ->
       it "resets the setting back to the default", ->
@@ -1095,8 +1095,8 @@ describe "Config", ->
 
       it 'it respects the scoped defaults', ->
         expect(atom.config.get('foo.bar.str')).toBe 'ok'
-        expect(atom.config.get(['.source.js'], 'foo.bar.str')).toBe 'omg'
-        expect(atom.config.get(['.source.coffee'], 'foo.bar.str')).toBe 'ok'
+        expect(atom.config.get('foo.bar.str', scope: ['.source.js'])).toBe 'omg'
+        expect(atom.config.get('foo.bar.str', scope: ['.source.coffee'])).toBe 'ok'
 
   describe "scoped settings", ->
     describe ".get(scopeDescriptor, keyPath)", ->
@@ -1105,29 +1105,29 @@ describe "Config", ->
         atom.config.addScopedSettings("config", ".source .string.quoted.double", foo: bar: baz: 22)
         atom.config.addScopedSettings("config", ".source", foo: bar: baz: 11)
 
-        expect(atom.config.get([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
-        expect(atom.config.get([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBe 22
-        expect(atom.config.get([".source.js", ".variable.assignment.js"], "foo.bar.baz")).toBe 11
-        expect(atom.config.get([".text"], "foo.bar.baz")).toBeUndefined()
+        expect(atom.config.get("foo.bar.baz", scope: [".source.coffee", ".string.quoted.double.coffee"])).toBe 42
+        expect(atom.config.get("foo.bar.baz", scope: [".source.js", ".string.quoted.double.js"])).toBe 22
+        expect(atom.config.get("foo.bar.baz", scope: [".source.js", ".variable.assignment.js"])).toBe 11
+        expect(atom.config.get("foo.bar.baz", scope: [".text"])).toBeUndefined()
 
       it "favors the most recently added properties in the event of a specificity tie", ->
         atom.config.addScopedSettings("config", ".source.coffee .string.quoted.single", foo: bar: baz: 42)
         atom.config.addScopedSettings("config", ".source.coffee .string.quoted.double", foo: bar: baz: 22)
 
-        expect(atom.config.get([".source.coffee", ".string.quoted.single"], "foo.bar.baz")).toBe 42
-        expect(atom.config.get([".source.coffee", ".string.quoted.single.double"], "foo.bar.baz")).toBe 22
+        expect(atom.config.get("foo.bar.baz", scope: [".source.coffee", ".string.quoted.single"])).toBe 42
+        expect(atom.config.get("foo.bar.baz", scope: [".source.coffee", ".string.quoted.single.double"])).toBe 22
 
       describe 'when there are global defaults', ->
         it 'falls back to the global when there is no scoped property specified', ->
           atom.config.setDefaults("foo", hasDefault: 'ok')
-          expect(atom.config.get([".source.coffee", ".string.quoted.single"], "foo.hasDefault")).toBe 'ok'
+          expect(atom.config.get("foo.hasDefault", scope: [".source.coffee", ".string.quoted.single"])).toBe 'ok'
 
       describe 'setting priority', ->
         describe 'when package settings are added after user settings', ->
           it "returns the user's setting because the user's setting has higher priority", ->
             atom.config.set("foo.bar.baz", 100, scopeSelector: ".source.coffee")
             atom.config.addScopedSettings("some-package", ".source.coffee", foo: bar: baz: 1)
-            expect(atom.config.get([".source.coffee"], "foo.bar.baz")).toBe 100
+            expect(atom.config.get("foo.bar.baz", scope: [".source.coffee"])).toBe 100
 
     describe ".set(scope, keyPath, value)", ->
       it "sets the value and overrides the others", ->
@@ -1135,10 +1135,10 @@ describe "Config", ->
         atom.config.addScopedSettings("config", ".source .string.quoted.double", foo: bar: baz: 22)
         atom.config.addScopedSettings("config", ".source", foo: bar: baz: 11)
 
-        expect(atom.config.get([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
+        expect(atom.config.get("foo.bar.baz", scope: [".source.coffee", ".string.quoted.double.coffee"])).toBe 42
 
         expect(atom.config.set("foo.bar.baz", 100, scopeSelector: ".source.coffee .string.quoted.double.coffee")).toBe true
-        expect(atom.config.get([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 100
+        expect(atom.config.get("foo.bar.baz", scope: [".source.coffee", ".string.quoted.double.coffee"])).toBe 100
 
     describe ".removeScopedSettingsForName(name)", ->
       it "allows properties to be removed by name", ->
@@ -1146,8 +1146,8 @@ describe "Config", ->
         disposable2 = atom.config.addScopedSettings("b", ".source .string.quoted.double", foo: bar: baz: 22)
 
         disposable2.dispose()
-        expect(atom.config.get([".source.js", ".string.quoted.double.js"], "foo.bar.baz")).toBeUndefined()
-        expect(atom.config.get([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
+        expect(atom.config.get("foo.bar.baz", scope: [".source.js", ".string.quoted.double.js"])).toBeUndefined()
+        expect(atom.config.get("foo.bar.baz", scope: [".source.coffee", ".string.quoted.double.coffee"])).toBe 42
 
     describe ".observe(scopeDescriptor, keyPath)", ->
       it 'calls the supplied callback when the value at the descriptor/keypath changes', ->

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -34,6 +34,30 @@ describe "Config", ->
       atom.config.setDefaults("bar", baz: 7)
       expect(atom.config.get("bar.baz")).toEqual {a: 3}
 
+    describe "when a 'sources' option is specified", ->
+      it "only retrieves values from the specified sources", ->
+        atom.config.set("x.y", 1, scopeSelector: ".foo", source: "a")
+        atom.config.set("x.y", 2, scopeSelector: ".foo", source: "b")
+        atom.config.set("x.y", 3, scopeSelector: ".foo", source: "c")
+        atom.config.setSchema("x.y", type: "integer", default: 4)
+
+        expect(atom.config.get("x.y", sources: ["a"], scope: [".foo"])).toBe 1
+        expect(atom.config.get("x.y", sources: ["b"], scope: [".foo"])).toBe 2
+        expect(atom.config.get("x.y", sources: ["c"], scope: [".foo"])).toBe 3
+        expect(atom.config.get("x.y", sources: ["x"], scope: [".foo"])).toBe 4
+
+    describe "when an 'excludeSources' option is specified", ->
+      it "only retrieves values from the specified sources", ->
+        atom.config.set("x.y", 1, scopeSelector: ".foo", source: "a")
+        atom.config.set("x.y", 2, scopeSelector: ".foo", source: "b")
+        atom.config.set("x.y", 3, scopeSelector: ".foo", source: "c")
+        atom.config.setSchema("x.y", type: "integer", default: 4)
+
+        expect(atom.config.get("x.y", excludeSources: ["a"], scope: [".foo"])).toBe 3
+        expect(atom.config.get("x.y", excludeSources: ["c"], scope: [".foo"])).toBe 2
+        expect(atom.config.get("x.y", excludeSources: ["b", "c"], scope: [".foo"])).toBe 1
+        expect(atom.config.get("x.y", excludeSources: ["b", "c", "a"], scope: [".foo"])).toBe 4
+
   describe ".set(keyPath, value)", ->
     it "allows a key path's value to be written", ->
       expect(atom.config.set("foo.bar.baz", 42)).toBe true

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -97,7 +97,7 @@ describe "Config", ->
         atom.config.addScopedSettings("default", ".source.coffee", foo: bar: baz: 42)
         expect(atom.config.getDefault('.source.coffee', 'foo.bar.baz')).toBe 42
 
-        atom.config.set('.source.coffee', 'foo.bar.baz', 55)
+        atom.config.set('foo.bar.baz', 55, scopeSelector: '.source.coffee')
         expect(atom.config.getDefault('.source.coffee', 'foo.bar.baz')).toBe 42
 
   describe ".isDefault(keyPath)", ->
@@ -118,7 +118,7 @@ describe "Config", ->
         atom.config.addScopedSettings("default", ".source.coffee", foo: bar: baz: 42)
         expect(atom.config.isDefault('.source.coffee', 'foo.bar.baz')).toBe true
 
-        atom.config.set('.source.coffee', 'foo.bar.baz', 55)
+        atom.config.set('foo.bar.baz', 55, scopeSelector: '.source.coffee')
         expect(atom.config.isDefault('.source.coffee', 'foo.bar.baz')).toBe false
 
   describe ".setDefaults(keyPath)", ->
@@ -174,7 +174,7 @@ describe "Config", ->
     describe "when scoped settings are used", ->
       it "restores the global default when no scoped default set", ->
         atom.config.setDefaults("foo", bar: baz: 10)
-        atom.config.set('.source.coffee', 'foo.bar.baz', 55)
+        atom.config.set('foo.bar.baz', 55, scopeSelector: '.source.coffee')
         expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 55
 
         atom.config.restoreDefault('.source.coffee', 'foo.bar.baz')
@@ -183,8 +183,8 @@ describe "Config", ->
       it "restores the scoped default when a scoped default is set", ->
         atom.config.setDefaults("foo", bar: baz: 10)
         atom.config.addScopedSettings("default", ".source.coffee", foo: bar: baz: 42)
-        atom.config.set('.source.coffee', 'foo.bar.baz', 55)
-        atom.config.set('.source.coffee', 'foo.bar.ok', 100)
+        atom.config.set('foo.bar.baz', 55, scopeSelector: '.source.coffee')
+        atom.config.set('foo.bar.ok', 100, scopeSelector: '.source.coffee')
         expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 55
 
         atom.config.restoreDefault('.source.coffee', 'foo.bar.baz')
@@ -194,7 +194,7 @@ describe "Config", ->
       it "calls ::save()", ->
         atom.config.setDefaults("foo", bar: baz: 10)
         atom.config.addScopedSettings("default", ".source.coffee", foo: bar: baz: 42)
-        atom.config.set('.source.coffee', 'foo.bar.baz', 55)
+        atom.config.set('foo.bar.baz', 55, scopeSelector: '.source.coffee')
         atom.config.save.reset()
 
         atom.config.restoreDefault('.source.coffee', 'foo.bar.baz')
@@ -216,8 +216,8 @@ describe "Config", ->
         jasmine.unspy atom.config, 'save'
 
         atom.config.setDefaults("foo", bar: baz: 10)
-        atom.config.set('.source.coffee', 'foo.bar.baz', 55)
-        atom.config.set('.source.coffee', 'foo.bar.zfoo', 20)
+        atom.config.set('foo.bar.baz', 55, scopeSelector: '.source.coffee')
+        atom.config.set('foo.bar.zfoo', 20, scopeSelector: '.source.coffee')
         CSON.writeFileSync.reset()
         expect(atom.config.get(['.source.coffee'], 'foo.bar.baz')).toBe 55
 
@@ -239,7 +239,7 @@ describe "Config", ->
 
       it "does not call ::save when the value is already at the default", ->
         atom.config.setDefaults("foo", bar: baz: 10)
-        atom.config.set('.source.coffee', 'foo.bar.baz', 55)
+        atom.config.set('foo.bar.baz', 55)
         atom.config.save.reset()
 
         atom.config.restoreDefault('.source.coffee', 'foo.bar.ok')
@@ -353,9 +353,9 @@ describe "Config", ->
 
     describe "when scoped settings are defined", ->
       it 'writes out explicitly set config settings', ->
-        atom.config.set('.source.ruby', 'foo.bar', 'ruby')
-        atom.config.set('.source.ruby', 'foo.omg', 'wow')
-        atom.config.set('.source.coffee', 'foo.bar', 'coffee')
+        atom.config.set('foo.bar', 'ruby', scopeSelector: '.source.ruby')
+        atom.config.set('foo.omg', 'wow', scopeSelector: '.source.ruby')
+        atom.config.set('foo.bar', 'coffee', scopeSelector: '.source.coffee')
 
         CSON.writeFileSync.reset()
         atom.config.save()
@@ -1125,7 +1125,7 @@ describe "Config", ->
       describe 'setting priority', ->
         describe 'when package settings are added after user settings', ->
           it "returns the user's setting because the user's setting has higher priority", ->
-            atom.config.set(".source.coffee", "foo.bar.baz", 100)
+            atom.config.set("foo.bar.baz", 100, scopeSelector: ".source.coffee")
             atom.config.addScopedSettings("some-package", ".source.coffee", foo: bar: baz: 1)
             expect(atom.config.get([".source.coffee"], "foo.bar.baz")).toBe 100
 
@@ -1137,7 +1137,7 @@ describe "Config", ->
 
         expect(atom.config.get([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 42
 
-        expect(atom.config.set(".source.coffee .string.quoted.double.coffee", "foo.bar.baz", 100)).toBe true
+        expect(atom.config.set("foo.bar.baz", 100, scopeSelector: ".source.coffee .string.quoted.double.coffee")).toBe true
         expect(atom.config.get([".source.coffee", ".string.quoted.double.coffee"], "foo.bar.baz")).toBe 100
 
     describe ".removeScopedSettingsForName(name)", ->

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -47,6 +47,8 @@ describe "Config", ->
         # Schema defaults never match a specific source. We could potentially add a special "schema" source.
         expect(atom.config.get("x.y", sources: ["x"], scope: [".foo"])).toBeUndefined()
 
+        expect(atom.config.get(null, sources: ['a'], scope: [".foo"]).x.y).toBe 1
+
     describe "when an 'excludeSources' option is specified", ->
       it "only retrieves values from the specified sources", ->
         atom.config.set("x.y", 1, scopeSelector: ".foo", source: "a")

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -75,7 +75,7 @@ describe "Config", ->
       expect(observeHandler).toHaveBeenCalledWith 42
 
     describe "when the value equals the default value", ->
-      it "does not store the value", ->
+      it "does not store the value in the user's config", ->
         atom.config.setDefaults "foo",
           same: 1
           changes: 1
@@ -91,10 +91,12 @@ describe "Config", ->
         atom.config.set('foo.null', undefined)
         atom.config.set('foo.undefined', null)
         atom.config.set('foo.sameObject', {b: 2, a: 1})
-        expect(atom.config.settings.foo).toEqual {changes: 2}
 
+        expect(atom.config.get("foo.same", sources: [atom.config.getUserConfigPath()])).toBeUndefined()
+
+        expect(atom.config.get("foo.changes", sources: [atom.config.getUserConfigPath()])).toBe 2
         atom.config.set('foo.changes', 1)
-        expect(atom.config.settings.foo).toEqual {}
+        expect(atom.config.get("foo.changes", sources: [atom.config.getUserConfigPath()])).toBeUndefined()
 
   describe ".getDefault(keyPath)", ->
     it "returns a clone of the default value", ->

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -114,20 +114,20 @@ describe "Config", ->
       spyOn(Grim, 'deprecate')
       expect(atom.config.getDefault('foo.same')).toBe 1
       expect(atom.config.getDefault('foo.changes')).toBe 1
-      expect(Grim.deprecate.callCount).toBe(2)
+      expect(Grim.deprecate.callCount).toBe 2
 
       atom.config.set('foo.same', 2)
       atom.config.set('foo.changes', 3)
 
       expect(atom.config.getDefault('foo.same')).toBe 1
       expect(atom.config.getDefault('foo.changes')).toBe 1
-      expect(Grim.deprecate.callCount).toBe(4)
+      expect(Grim.deprecate.callCount).toBe 4
 
       initialDefaultValue = [1, 2, 3]
       atom.config.setDefaults("foo", bar: initialDefaultValue)
       expect(atom.config.getDefault('foo.bar')).toEqual initialDefaultValue
       expect(atom.config.getDefault('foo.bar')).not.toBe initialDefaultValue
-      expect(Grim.deprecate.callCount).toBe(6)
+      expect(Grim.deprecate.callCount).toBe 6
 
     describe "when scoped settings are used", ->
       it "returns the global default when no scoped default set", ->
@@ -143,11 +143,11 @@ describe "Config", ->
 
         spyOn(Grim, 'deprecate')
         expect(atom.config.getDefault('.source.coffee', 'foo.bar.baz')).toBe 42
-        expect(Grim.deprecate.callCount).toBe(1)
+        expect(Grim.deprecate.callCount).toBe 1
 
         atom.config.set('foo.bar.baz', 55, scopeSelector: '.source.coffee')
         expect(atom.config.getDefault('.source.coffee', 'foo.bar.baz')).toBe 42
-        expect(Grim.deprecate.callCount).toBe(2)
+        expect(Grim.deprecate.callCount).toBe 2
 
   describe ".isDefault(keyPath)", ->
     it "returns true when the value of the key path is its default value", ->
@@ -156,28 +156,28 @@ describe "Config", ->
       spyOn(Grim, 'deprecate')
       expect(atom.config.isDefault('foo.same')).toBe true
       expect(atom.config.isDefault('foo.changes')).toBe true
-      expect(Grim.deprecate.callCount).toBe(2)
+      expect(Grim.deprecate.callCount).toBe 2
 
       atom.config.set('foo.same', 2)
       atom.config.set('foo.changes', 3)
 
       expect(atom.config.isDefault('foo.same')).toBe false
       expect(atom.config.isDefault('foo.changes')).toBe false
-      expect(Grim.deprecate.callCount).toBe(4)
+      expect(Grim.deprecate.callCount).toBe 4
 
     describe "when scoped settings are used", ->
       it "returns false when a scoped setting was set by the user", ->
         spyOn(Grim, 'deprecate')
         expect(atom.config.isDefault('.source.coffee', 'foo.bar.baz')).toBe true
-        expect(Grim.deprecate.callCount).toBe(1)
+        expect(Grim.deprecate.callCount).toBe 1
 
         atom.config.addScopedSettings("default", ".source.coffee", foo: bar: baz: 42)
         expect(atom.config.isDefault('.source.coffee', 'foo.bar.baz')).toBe true
-        expect(Grim.deprecate.callCount).toBe(2)
+        expect(Grim.deprecate.callCount).toBe 2
 
         atom.config.set('foo.bar.baz', 55, scopeSelector: '.source.coffee')
         expect(atom.config.isDefault('.source.coffee', 'foo.bar.baz')).toBe false
-        expect(Grim.deprecate.callCount).toBe(3)
+        expect(Grim.deprecate.callCount).toBe 3
 
   describe ".setDefaults(keyPath)", ->
     it "sets a default when the setting's key contains an escaped dot", ->
@@ -421,7 +421,7 @@ describe "Config", ->
         CSON.writeFileSync.reset()
         atom.config.save()
 
-        expect(CSON.writeFileSync.argsForCall[0][0]).toBe(path.join(atom.config.configDirPath, "atom.config.json"))
+        expect(CSON.writeFileSync.argsForCall[0][0]).toBe path.join(atom.config.configDirPath, "atom.config.json")
         writtenConfig = CSON.writeFileSync.argsForCall[0][1]
         expect(writtenConfig).toEqual global: atom.config.settings
 
@@ -436,7 +436,7 @@ describe "Config", ->
         CSON.writeFileSync.reset()
         atom.config.save()
 
-        expect(CSON.writeFileSync.argsForCall[0][0]).toBe(path.join(atom.config.configDirPath, "atom.config.cson"))
+        expect(CSON.writeFileSync.argsForCall[0][0]).toBe path.join(atom.config.configDirPath, "atom.config.cson")
         writtenConfig = CSON.writeFileSync.argsForCall[0][1]
         expect(writtenConfig).toEqual global: atom.config.settings
 

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -77,6 +77,9 @@ describe "Config", ->
       expect(atom.config.save).toHaveBeenCalled()
       expect(observeHandler).toHaveBeenCalledWith 42
 
+    it "does not allow a 'source' option without a 'scopeSelector'", ->
+      expect(-> atom.config.set("foo", 1, source: [".source.ruby"])).toThrow()
+
     describe "when the value equals the default value", ->
       it "does not store the value in the user's config", ->
         atom.config.setDefaults "foo",

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -367,7 +367,7 @@ describe "PackageManager", ->
             atom.packages.activatePackage("package-with-scoped-properties")
 
           runs ->
-            expect(atom.config.get ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
+            expect(atom.config.get 'editor.increaseIndentPattern', scope: ['.source.omg']).toBe '^a'
 
     describe "converted textmate packages", ->
       it "loads the package's grammars", ->
@@ -380,13 +380,13 @@ describe "PackageManager", ->
           expect(atom.grammars.selectGrammar("file.rb").name).toBe "Ruby"
 
       it "loads the translated scoped properties", ->
-        expect(atom.config.get(['.source.ruby'], 'editor.commentStart')).toBeUndefined()
+        expect(atom.config.get('editor.commentStart', scope: ['.source.ruby'])).toBeUndefined()
 
         waitsForPromise ->
           atom.packages.activatePackage('language-ruby')
 
         runs ->
-          expect(atom.config.get(['.source.ruby'], 'editor.commentStart')).toBe '# '
+          expect(atom.config.get('editor.commentStart', scope: ['.source.ruby'])).toBe '# '
 
   describe "::deactivatePackage(id)", ->
     afterEach ->
@@ -493,9 +493,9 @@ describe "PackageManager", ->
           atom.packages.activatePackage("package-with-scoped-properties")
 
         runs ->
-          expect(atom.config.get ['.source.omg'], 'editor.increaseIndentPattern').toBe '^a'
+          expect(atom.config.get 'editor.increaseIndentPattern', scope: ['.source.omg']).toBe '^a'
           atom.packages.deactivatePackage("package-with-scoped-properties")
-          expect(atom.config.get ['.source.omg'], 'editor.increaseIndentPattern').toBeUndefined()
+          expect(atom.config.get 'editor.increaseIndentPattern', scope: ['.source.omg']).toBeUndefined()
 
     describe "textmate packages", ->
       it "removes the package's grammars", ->

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -515,7 +515,7 @@ describe "PackageManager", ->
 
         runs ->
           atom.packages.deactivatePackage('language-ruby')
-          expect(atom.config.get(['.source.ruby'], 'editor.commentStart')).toBeUndefined()
+          expect(atom.config.get('editor.commentStart', scope: ['.source.ruby'])).toBeUndefined()
 
   describe "::activate()", ->
     packageActivator = null

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -2577,9 +2577,9 @@ describe "TextEditorComponent", ->
 
     describe 'soft wrap settings', ->
       beforeEach ->
-        atom.config.set '.source.coffee', 'editor.softWrap', true
-        atom.config.set '.source.coffee', 'editor.preferredLineLength', 17
-        atom.config.set '.source.coffee', 'editor.softWrapAtPreferredLineLength', true
+        atom.config.set 'editor.softWrap', true, scopeSelector: '.source.coffee'
+        atom.config.set 'editor.preferredLineLength', 17, scopeSelector: '.source.coffee'
+        atom.config.set 'editor.softWrapAtPreferredLineLength', true, scopeSelector: '.source.coffee'
 
         editor.setEditorWidthInChars(20)
         coffeeEditor.setEditorWidthInChars(20)
@@ -2589,18 +2589,18 @@ describe "TextEditorComponent", ->
         expect(coffeeEditor.lineTextForScreenRow(3)).toEqual '    return items '
 
       it 'updates the wrapped lines when editor.preferredLineLength changes', ->
-        atom.config.set '.source.coffee', 'editor.preferredLineLength', 20
+        atom.config.set 'editor.preferredLineLength', 20, scopeSelector: '.source.coffee'
         expect(coffeeEditor.lineTextForScreenRow(2)).toEqual '    return items if '
 
       it 'updates the wrapped lines when editor.softWrapAtPreferredLineLength changes', ->
-        atom.config.set '.source.coffee', 'editor.softWrapAtPreferredLineLength', false
+        atom.config.set 'editor.softWrapAtPreferredLineLength', false, scopeSelector: '.source.coffee'
         expect(coffeeEditor.lineTextForScreenRow(2)).toEqual '    return items if '
 
       it 'updates the wrapped lines when editor.softWrap changes', ->
-        atom.config.set '.source.coffee', 'editor.softWrap', false
+        atom.config.set 'editor.softWrap', false, scopeSelector: '.source.coffee'
         expect(coffeeEditor.lineTextForScreenRow(2)).toEqual '    return items if items.length <= 1'
 
-        atom.config.set '.source.coffee', 'editor.softWrap', true
+        atom.config.set 'editor.softWrap', true, scopeSelector: '.source.coffee'
         expect(coffeeEditor.lineTextForScreenRow(3)).toEqual '    return items '
 
       it 'updates the wrapped lines when the grammar changes', ->
@@ -2628,11 +2628,11 @@ describe "TextEditorComponent", ->
           tab: 'F'
           cr: 'E'
 
-        atom.config.set '.source.js', 'editor.showInvisibles', true
-        atom.config.set '.source.js', 'editor.invisibles', jsInvisibles
+        atom.config.set 'editor.showInvisibles', true, scopeSelector: '.source.js'
+        atom.config.set 'editor.invisibles', jsInvisibles, scopeSelector: '.source.js'
 
-        atom.config.set '.source.coffee', 'editor.showInvisibles', false
-        atom.config.set '.source.coffee', 'editor.invisibles', coffeeInvisibles
+        atom.config.set 'editor.showInvisibles', false, scopeSelector: '.source.coffee'
+        atom.config.set 'editor.invisibles', coffeeInvisibles, scopeSelector: '.source.coffee'
 
         editor.setText " a line with tabs\tand spaces \n"
         nextAnimationFrame()
@@ -2648,7 +2648,7 @@ describe "TextEditorComponent", ->
       it "re-renders the invisibles when the invisible settings change", ->
         jsGrammar = editor.getGrammar()
         editor.setGrammar(coffeeEditor.getGrammar())
-        atom.config.set '.source.coffee', 'editor.showInvisibles', true
+        atom.config.set 'editor.showInvisibles', true, scopeSelector: '.source.coffee'
         nextAnimationFrame()
         expect(component.lineNodeForScreenRow(0).textContent).toBe "#{coffeeInvisibles.space}a line with tabs#{coffeeInvisibles.tab}and spaces#{coffeeInvisibles.space}#{coffeeInvisibles.eol}"
 
@@ -2657,7 +2657,7 @@ describe "TextEditorComponent", ->
           space: 'E'
           tab: 'W'
           cr: 'I'
-        atom.config.set '.source.coffee', 'editor.invisibles', newInvisibles
+        atom.config.set 'editor.invisibles', newInvisibles, scopeSelector: '.source.coffee'
         nextAnimationFrame()
         expect(component.lineNodeForScreenRow(0).textContent).toBe "#{newInvisibles.space}a line with tabs#{newInvisibles.tab}and spaces#{newInvisibles.space}#{newInvisibles.eol}"
 
@@ -2667,8 +2667,8 @@ describe "TextEditorComponent", ->
 
     describe 'editor.showIndentGuide', ->
       beforeEach ->
-        atom.config.set '.source.js', 'editor.showIndentGuide', true
-        atom.config.set '.source.coffee', 'editor.showIndentGuide', false
+        atom.config.set 'editor.showIndentGuide', true, scopeSelector: '.source.js'
+        atom.config.set 'editor.showIndentGuide', false, scopeSelector: '.source.coffee'
 
       it "has an 'indent-guide' class when scoped editor.showIndentGuide is true, but not when scoped editor.showIndentGuide is false", ->
         line1LeafNodes = getLeafNodes(component.lineNodeForScreenRow(1))
@@ -2689,7 +2689,7 @@ describe "TextEditorComponent", ->
         expect(line1LeafNodes[0].classList.contains('indent-guide')).toBe true
         expect(line1LeafNodes[1].classList.contains('indent-guide')).toBe false
 
-        atom.config.set '.source.js', 'editor.showIndentGuide', false
+        atom.config.set 'editor.showIndentGuide', false, scopeSelector: '.source.js'
 
         line1LeafNodes = getLeafNodes(component.lineNodeForScreenRow(1))
         expect(line1LeafNodes[0].textContent).toBe '  '

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1327,7 +1327,7 @@ describe "TextEditor", ->
           coffeeEditor.selectWordsContainingCursors()
           expect(coffeeEditor.getSelectedBufferRange()).toEqual [[0, 6], [0, 15]]
 
-          atom.config.set '.source.coffee', 'editor.nonWordCharacters', 'qusort'
+          atom.config.set 'editor.nonWordCharacters', 'qusort', scopeSelector: '.source.coffee'
 
           coffeeEditor.setCursorBufferPosition [0, 9]
           coffeeEditor.selectWordsContainingCursors()
@@ -3276,7 +3276,7 @@ describe "TextEditor", ->
         atom.packages.unloadPackages()
 
       it 'returns correct values based on the scope of the set grammars', ->
-        atom.config.set '.source.coffee', 'editor.tabLength', 6
+        atom.config.set 'editor.tabLength', 6, scopeSelector: '.source.coffee'
 
         expect(editor.getTabLength()).toBe 2
         expect(coffeeEditor.getTabLength()).toBe 6
@@ -3298,12 +3298,12 @@ describe "TextEditor", ->
         expect(editor.getTabLength()).toBe 2
         expect(editor.tokenizedLineForScreenRow(5).tokens[0].firstNonWhitespaceIndex).toBe 2
 
-        atom.config.set '.source.js', 'editor.tabLength', 6
+        atom.config.set 'editor.tabLength', 6, scopeSelector: '.source.js'
         expect(editor.getTabLength()).toBe 6
         expect(editor.tokenizedLineForScreenRow(5).tokens[0].firstNonWhitespaceIndex).toBe 6
 
       it 'updates the tab length when the grammar changes', ->
-        atom.config.set '.source.coffee', 'editor.tabLength', 6
+        atom.config.set 'editor.tabLength', 6, scopeSelector: '.source.coffee'
 
         expect(editor.getTabLength()).toBe 2
         expect(editor.tokenizedLineForScreenRow(5).tokens[0].firstNonWhitespaceIndex).toBe 2
@@ -3473,8 +3473,8 @@ describe "TextEditor", ->
           atom.project.open('coffee.coffee', autoIndent: false).then (o) -> coffeeEditor = o
 
         runs ->
-          atom.config.set('.source.js', 'editor.autoIndent', true)
-          atom.config.set('.source.coffee', 'editor.autoIndent', false)
+          atom.config.set('editor.autoIndent', true, scopeSelector: '.source.js')
+          atom.config.set('editor.autoIndent', false, scopeSelector: '.source.coffee')
 
       afterEach: ->
         atom.packages.deactivatePackages()

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -457,7 +457,7 @@ class Config
   # file in the type specified by the configuration schema.
   get: ->
     if arguments.length > 1
-      if typeof arguments[0] is 'string'
+      if typeof arguments[0] is 'string' or not arguments[0]?
         keyPath = arguments[0]
         options = arguments[1]
         {scope} = options

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -504,13 +504,20 @@ class Config
   # Returns a {Boolean}
   # * `true` if the value was set.
   # * `false` if the value was not able to be coerced to the type specified in the setting's schema.
-  set: (scopeSelector, keyPath, value) ->
-    if arguments.length < 3
-      value = keyPath
-      keyPath = scopeSelector
-      scopeSelector = undefined
+  set: ->
+    if arguments[0][0] is '.'
+      Grim.deprecate """
+        Passing a scope selector as the first argument to Config::set is deprecated.
+        Pass a `scopeSelector` in an options hash as the final argument instead.
+      """
+      scopeSelector = arguments[0]
+      keyPath = arguments[1]
+      value = arguments[2]
+    else
+      [keyPath, value, options] = arguments
+      scopeSelector = options?.scopeSelector
 
-    unless value == undefined
+    unless value is undefined
       try
         value = @makeValueConformToSchema(keyPath, value)
       catch e

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -472,10 +472,10 @@ class Config
       keyPath = arguments[0]
 
     if scope?
-      value = @getRawScopedValue(scope, keyPath)
-      value ? @getRawValue(keyPath)
+      value = @getRawScopedValue(scope, keyPath, options)
+      value ? @getRawValue(keyPath, options)
     else
-      @getRawValue(keyPath)
+      @getRawValue(keyPath, options)
 
   # Essential: Sets the value for a configuration setting.
   #
@@ -806,7 +806,7 @@ class Config
       catch e
         console.warn("'#{keyPath}' could not be set. Attempted value: #{JSON.stringify(value)}; Schema: #{JSON.stringify(@getSchema(keyPath))}")
 
-  getRawValue: (keyPath) ->
+  getRawValue: (keyPath, options) ->
     value = _.valueForKeyPath(@settings, keyPath)
     defaultValue = _.valueForKeyPath(@defaultSettings, keyPath)
 
@@ -930,9 +930,9 @@ class Config
     @usersScopedSettings.add @scopedSettingsStore.addProperties(source, settingsBySelector, @usersScopedSettingPriority)
     @emitter.emit 'did-change'
 
-  getRawScopedValue: (scopeDescriptor, keyPath) ->
+  getRawScopedValue: (scopeDescriptor, keyPath, options) ->
     scopeDescriptor = ScopeDescriptor.fromObject(scopeDescriptor)
-    @scopedSettingsStore.getPropertyValue(scopeDescriptor.getScopeChain(), keyPath)
+    @scopedSettingsStore.getPropertyValue(scopeDescriptor.getScopeChain(), keyPath, options)
 
   observeScopedKeyPath: (scope, keyPath, callback) ->
     oldValue = @get(keyPath, {scope})

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -528,6 +528,9 @@ class Config
     else
       [keyPath, value, options] = arguments
       scopeSelector = options?.scopeSelector
+      source = options?.source
+
+    source ?= @getUserConfigPath()
 
     unless value is undefined
       try
@@ -536,7 +539,7 @@ class Config
         return false
 
     if scopeSelector?
-      @setRawScopedValue(scopeSelector, keyPath, value)
+      @setRawScopedValue(source, scopeSelector, keyPath, value)
     else
       @setRawValue(keyPath, value)
 
@@ -916,7 +919,7 @@ class Config
       disposable.dispose()
       @emitter.emit 'did-change'
 
-  setRawScopedValue: (selector, keyPath, value) ->
+  setRawScopedValue: (source, selector, keyPath, value) ->
     if keyPath?
       newValue = {}
       _.setValueForKeyPath(newValue, keyPath, value)
@@ -924,7 +927,7 @@ class Config
 
     settingsBySelector = {}
     settingsBySelector[selector] = value
-    @usersScopedSettings.add @scopedSettingsStore.addProperties(@getUserConfigPath(), settingsBySelector, @usersScopedSettingPriority)
+    @usersScopedSettings.add @scopedSettingsStore.addProperties(source, settingsBySelector, @usersScopedSettingPriority)
     @emitter.emit 'did-change'
 
   getRawScopedValue: (scopeDescriptor, keyPath) ->

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -808,7 +808,7 @@ class Config
 
   getRawValue: (keyPath, options) ->
     value = _.valueForKeyPath(@settings, keyPath)
-    defaultValue = _.valueForKeyPath(@defaultSettings, keyPath)
+    defaultValue = _.valueForKeyPath(@defaultSettings, keyPath) unless options?.sources?.length > 0
 
     if value?
       value = _.deepClone(value)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -557,12 +557,12 @@ class Config
       scopeSelector = null
 
     if scopeSelector?
-      settings = @scopedSettingsStore.propertiesForSourceAndSelector('user-config', scopeSelector)
+      settings = @scopedSettingsStore.propertiesForSourceAndSelector(@getUserConfigPath(), scopeSelector)
       if _.valueForKeyPath(settings, keyPath)?
-        @scopedSettingsStore.removePropertiesForSourceAndSelector('user-config', scopeSelector)
+        @scopedSettingsStore.removePropertiesForSourceAndSelector(@getUserConfigPath(), scopeSelector)
         _.setValueForKeyPath(settings, keyPath, undefined)
         settings = withoutEmptyObjects(settings)
-        @addScopedSettings('user-config', scopeSelector, settings, @usersScopedSettingPriority) if settings?
+        @addScopedSettings(@getUserConfigPath(), scopeSelector, settings, @usersScopedSettingPriority) if settings?
         @save() unless @configFileHasErrors
         @getDefault(scopeSelector, keyPath)
     else
@@ -583,7 +583,7 @@ class Config
       scopeSelector = null
 
     if scopeSelector?
-      defaultValue = @scopedSettingsStore.getPropertyValue(scopeSelector, keyPath, excludeSources: ['user-config'])
+      defaultValue = @scopedSettingsStore.getPropertyValue(scopeSelector, keyPath, excludeSources: [@getUserConfigPath()])
       defaultValue ?= _.valueForKeyPath(@defaultSettings, keyPath)
     else
       defaultValue = _.valueForKeyPath(@defaultSettings, keyPath)
@@ -602,7 +602,7 @@ class Config
       scopeSelector = null
 
     if scopeSelector?
-      settings = @scopedSettingsStore.propertiesForSourceAndSelector('user-config', scopeSelector)
+      settings = @scopedSettingsStore.propertiesForSourceAndSelector(@getUserConfigPath(), scopeSelector)
       not _.valueForKeyPath(settings, keyPath)?
     else
       not _.valueForKeyPath(@settings, keyPath)?
@@ -758,7 +758,7 @@ class Config
 
   save: ->
     allSettings = global: @settings
-    allSettings = _.extend allSettings, @scopedSettingsStore.propertiesForSource('user-config')
+    allSettings = _.extend allSettings, @scopedSettingsStore.propertiesForSource(@getUserConfigPath())
     CSON.writeFileSync(@configFilePath, allSettings)
 
   ###
@@ -904,7 +904,7 @@ class Config
   resetUserScopedSettings: (newScopedSettings) ->
     @usersScopedSettings?.dispose()
     @usersScopedSettings = new CompositeDisposable
-    @usersScopedSettings.add @scopedSettingsStore.addProperties('user-config', newScopedSettings, @usersScopedSettingPriority)
+    @usersScopedSettings.add @scopedSettingsStore.addProperties(@getUserConfigPath(), newScopedSettings, @usersScopedSettingPriority)
     @emitter.emit 'did-change'
 
   addScopedSettings: (source, selector, value, options) ->
@@ -924,7 +924,7 @@ class Config
 
     settingsBySelector = {}
     settingsBySelector[selector] = value
-    @usersScopedSettings.add @scopedSettingsStore.addProperties('user-config', settingsBySelector, @usersScopedSettingPriority)
+    @usersScopedSettings.add @scopedSettingsStore.addProperties(@getUserConfigPath(), settingsBySelector, @usersScopedSettingPriority)
     @emitter.emit 'did-change'
 
   getRawScopedValue: (scopeDescriptor, keyPath) ->

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -541,6 +541,9 @@ class Config
       scopeSelector = options?.scopeSelector
       source = options?.source
 
+    if source and not scopeSelector
+      throw new Error("::set with a 'source' and no 'sourceSelector' is not yet implemented!")
+
     source ?= @getUserConfigPath()
 
     unless value is undefined

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -623,7 +623,7 @@ class Config
   #
   # Returns the default value.
   getDefault: ->
-    Grim.deprecate("Use the `excludeSources` to ::get instead")
+    Grim.deprecate("Use `::get(keyPath, {scope, excludeSources: [atom.config.getUserConfigPath()]})` instead")
     if arguments.length is 1
       [keyPath] = arguments
     else
@@ -639,13 +639,13 @@ class Config
   # Returns a {Boolean}, `true` if the current value is the default, `false`
   # otherwise.
   isDefault: ->
-    Grim.deprecate("Use the `excludeSources` to ::get instead")
+    Grim.deprecate("Use `not ::get(keyPath, {scope, sources: [atom.config.getUserConfigPath()]})?` instead")
     if arguments.length is 1
       [keyPath] = arguments
     else
       [scopeSelector, keyPath] = arguments
       scope = [scopeSelector]
-    @get(keyPath, {scope}) is @get(keyPath, {scope, excludeSources: [@getUserConfigPath()]})
+    not @get(keyPath, {scope, sources: [@getUserConfigPath()]})?
 
   # Extended: Retrieve the schema for a specific key path. The schema will tell
   # you what type the keyPath expects, and other metadata about the config

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -393,12 +393,20 @@ class Config
   #
   # Returns a {Disposable} with the following keys on which you can call
   # `.dispose()` to unsubscribe.
-  onDidChange: (scopeDescriptor, keyPath, callback) ->
-    args = Array::slice.call(arguments)
+  onDidChange: ->
     if arguments.length is 1
-      [callback, scopeDescriptor, keyPath] = args
+      [callback] = arguments
     else if arguments.length is 2
-      [keyPath, callback, scopeDescriptor] = args
+      [keyPath, callback] = arguments
+    else if _.isArray(arguments[0]) or arguments[0] instanceof ScopeDescriptor
+      Grim.deprecate """
+        Passing a scope descriptor as the first argument to Config::onDidChange is deprecated.
+        Pass a `scope` in an options hash as the third argument instead.
+      """
+      [scopeDescriptor, keyPath, callback] = arguments
+    else
+      [keyPath, options, callback] = arguments
+      scopeDescriptor = options.scope
 
     if scopeDescriptor?
       @onDidChangeScopedKeyPath(scopeDescriptor, keyPath, callback)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -543,9 +543,7 @@ class Config
         Passing a scope selector as the first argument to Config::set is deprecated.
         Pass a `scopeSelector` in an options hash as the final argument instead.
       """
-      scopeSelector = arguments[0]
-      keyPath = arguments[1]
-      value = arguments[2]
+      [scopeSelector, keyPath, value] = arguments
     else
       [keyPath, value, options] = arguments
       scopeSelector = options?.scopeSelector

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -348,21 +348,24 @@ class Config
   #
   # Returns a {Disposable} with the following keys on which you can call
   # `.dispose()` to unsubscribe.
-  observe: (scopeDescriptor, keyPath, options, callback) ->
-    args = Array::slice.call(arguments)
-    if args.length is 2
-      # observe(keyPath, callback)
-      [keyPath, callback, scopeDescriptor, options] = args
-    else if args.length is 3 and (Array.isArray(scopeDescriptor) or scopeDescriptor instanceof ScopeDescriptor)
-      # observe(scopeDescriptor, keyPath, callback)
-      [scopeDescriptor, keyPath, callback, options] = args
-    else if args.length is 3 and _.isString(scopeDescriptor) and _.isObject(keyPath)
-      # observe(keyPath, options, callback) # Deprecated!
-      [keyPath, options, callback, scopeDescriptor] = args
-
-      message = ""
-      message = "`callNow` was set to false. Use ::onDidChange instead. Note that ::onDidChange calls back with different arguments." if options.callNow == false
-      Grim.deprecate "Config::observe no longer supports options; see https://atom.io/docs/api/latest/Config. #{message}"
+  observe: ->
+    if arguments.length is 2
+      [keyPath, callback] = arguments
+    else if arguments.length is 3 and (_.isArray(arguments[0]) or arguments[0] instanceof ScopeDescriptor)
+      Grim.deprecate """
+        Passing a scope descriptor as the first argument to Config::observe is deprecated.
+        Pass a `scope` in an options hash as the third argument instead.
+      """
+      [scopeDescriptor, keyPath, callback] = arguments
+    else if arguments.length is 3 and (_.isString(arguments[0]) and _.isObject(arguments[1]))
+      [keyPath, options, callback] = arguments
+      scopeDescriptor = options.scope
+      if options.callNow?
+        Grim.deprecate """
+          Config::observe no longer takes a `callNow` option. Use ::onDidChange instead.
+          Note that ::onDidChange passes its callback different arguments.
+          See https://atom.io/docs/api/latest/Config
+        """
     else
       console.error 'An unsupported form of Config::observe is being used. See https://atom.io/docs/api/latest/Config for details'
       return

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -202,7 +202,7 @@ class Cursor extends Model
     [before, after] = @editor.getTextInBufferRange(range)
     return false if /\s/.test(before) or /\s/.test(after)
 
-    nonWordCharacters = atom.config.get(@getScopeDescriptor(), 'editor.nonWordCharacters').split('')
+    nonWordCharacters = atom.config.get('editor.nonWordCharacters', scope: @getScopeDescriptor()).split('')
     _.contains(nonWordCharacters, before) isnt _.contains(nonWordCharacters, after)
 
   # Public: Returns whether this cursor is between a word's start and end.
@@ -636,7 +636,7 @@ class Cursor extends Model
   # Returns a {RegExp}.
   wordRegExp: ({includeNonWordCharacters}={}) ->
     includeNonWordCharacters ?= true
-    nonWordCharacters = atom.config.get(@getScopeDescriptor(), 'editor.nonWordCharacters')
+    nonWordCharacters = atom.config.get('editor.nonWordCharacters', scope: @getScopeDescriptor())
     segments = ["^[\t ]*$"]
     segments.push("[^\\s#{_.escapeRegExp(nonWordCharacters)}]+")
     if includeNonWordCharacters

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -67,10 +67,10 @@ class DisplayBuffer extends Model
 
     oldConfigSettings = @configSettings
     @configSettings =
-      scrollPastEnd: atom.config.get(scopeDescriptor, 'editor.scrollPastEnd')
-      softWrap: atom.config.get(scopeDescriptor, 'editor.softWrap')
-      softWrapAtPreferredLineLength: atom.config.get(scopeDescriptor, 'editor.softWrapAtPreferredLineLength')
-      preferredLineLength: atom.config.get(scopeDescriptor, 'editor.preferredLineLength')
+      scrollPastEnd: atom.config.get('editor.scrollPastEnd', scope: scopeDescriptor)
+      softWrap: atom.config.get('editor.softWrap', scope: scopeDescriptor)
+      softWrapAtPreferredLineLength: atom.config.get('editor.softWrapAtPreferredLineLength', scope: scopeDescriptor)
+      preferredLineLength: atom.config.get('editor.preferredLineLength', scope: scopeDescriptor)
 
     subscriptions.add atom.config.onDidChange scopeDescriptor, 'editor.softWrap', ({newValue}) =>
       @configSettings.softWrap = newValue
@@ -82,7 +82,7 @@ class DisplayBuffer extends Model
 
     subscriptions.add atom.config.onDidChange scopeDescriptor, 'editor.preferredLineLength', ({newValue}) =>
       @configSettings.preferredLineLength = newValue
-      @updateWrappedScreenLines() if @isSoftWrapped() and atom.config.get(scopeDescriptor, 'editor.softWrapAtPreferredLineLength')
+      @updateWrappedScreenLines() if @isSoftWrapped() and atom.config.get('editor.softWrapAtPreferredLineLength', scope: scopeDescriptor)
 
     subscriptions.add atom.config.observe scopeDescriptor, 'editor.scrollPastEnd', (value) =>
       @configSettings.scrollPastEnd = value

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -72,15 +72,15 @@ class DisplayBuffer extends Model
       softWrapAtPreferredLineLength: atom.config.get('editor.softWrapAtPreferredLineLength', scope: scopeDescriptor)
       preferredLineLength: atom.config.get('editor.preferredLineLength', scope: scopeDescriptor)
 
-    subscriptions.add atom.config.onDidChange scopeDescriptor, 'editor.softWrap', ({newValue}) =>
+    subscriptions.add atom.config.onDidChange 'editor.softWrap', scope: scopeDescriptor, ({newValue}) =>
       @configSettings.softWrap = newValue
       @updateWrappedScreenLines()
 
-    subscriptions.add atom.config.onDidChange scopeDescriptor, 'editor.softWrapAtPreferredLineLength', ({newValue}) =>
+    subscriptions.add atom.config.onDidChange 'editor.softWrapAtPreferredLineLength', scope: scopeDescriptor, ({newValue}) =>
       @configSettings.softWrapAtPreferredLineLength = newValue
       @updateWrappedScreenLines() if @isSoftWrapped()
 
-    subscriptions.add atom.config.onDidChange scopeDescriptor, 'editor.preferredLineLength', ({newValue}) =>
+    subscriptions.add atom.config.onDidChange 'editor.preferredLineLength', scope: scopeDescriptor, ({newValue}) =>
       @configSettings.preferredLineLength = newValue
       @updateWrappedScreenLines() if @isSoftWrapped() and atom.config.get('editor.softWrapAtPreferredLineLength', scope: scopeDescriptor)
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -84,7 +84,7 @@ class DisplayBuffer extends Model
       @configSettings.preferredLineLength = newValue
       @updateWrappedScreenLines() if @isSoftWrapped() and atom.config.get('editor.softWrapAtPreferredLineLength', scope: scopeDescriptor)
 
-    subscriptions.add atom.config.observe scopeDescriptor, 'editor.scrollPastEnd', (value) =>
+    subscriptions.add atom.config.observe 'editor.scrollPastEnd', scope: scopeDescriptor, (value) =>
       @configSettings.scrollPastEnd = value
 
     @updateWrappedScreenLines() if oldConfigSettings? and not _.isEqual(oldConfigSettings, @configSettings)

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -316,7 +316,7 @@ class LanguageMode
       @editor.setIndentationForBufferRow(bufferRow, desiredIndentLevel)
 
   getRegexForProperty: (scopeDescriptor, property) ->
-    if pattern = atom.config.get(scopeDescriptor, property)
+    if pattern = atom.config.get(property, scope: scopeDescriptor)
       new OnigRegExp(pattern)
 
   increaseIndentRegexForScopeDescriptor: (scopeDescriptor) ->

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -462,9 +462,9 @@ TextEditorComponent = React.createClass
 
     scopeDescriptor = editor.getRootScopeDescriptor()
 
-    subscriptions.add atom.config.observe scopeDescriptor, 'editor.showIndentGuide', @setShowIndentGuide
-    subscriptions.add atom.config.observe scopeDescriptor, 'editor.showLineNumbers', @setShowLineNumbers
-    subscriptions.add atom.config.observe scopeDescriptor, 'editor.scrollSensitivity', @setScrollSensitivity
+    subscriptions.add atom.config.observe 'editor.showIndentGuide', scope: scopeDescriptor, @setShowIndentGuide
+    subscriptions.add atom.config.observe 'editor.showLineNumbers', scope: scopeDescriptor, @setShowLineNumbers
+    subscriptions.add atom.config.observe 'editor.scrollSensitivity', scope: scopeDescriptor, @setScrollSensitivity
 
   focused: ->
     if @isMounted()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2812,17 +2812,17 @@ class TextEditor extends Model
   ###
 
   shouldAutoIndent: ->
-    atom.config.get(@getRootScopeDescriptor(), "editor.autoIndent")
+    atom.config.get("editor.autoIndent", scope: @getRootScopeDescriptor())
 
   shouldAutoIndentOnPaste: ->
-    atom.config.get(@getRootScopeDescriptor(), "editor.autoIndentOnPaste")
+    atom.config.get("editor.autoIndentOnPaste", scope: @getRootScopeDescriptor())
 
   shouldShowInvisibles: ->
-    not @mini and atom.config.get(@getRootScopeDescriptor(), 'editor.showInvisibles')
+    not @mini and atom.config.get('editor.showInvisibles', scope: @getRootScopeDescriptor())
 
   updateInvisibles: ->
     if @shouldShowInvisibles()
-      @displayBuffer.setInvisibles(atom.config.get(@getRootScopeDescriptor(), 'editor.invisibles'))
+      @displayBuffer.setInvisibles(atom.config.get('editor.invisibles', scope: @getRootScopeDescriptor()))
     else
       @displayBuffer.setInvisibles(null)
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -168,8 +168,8 @@ class TextEditor extends Model
 
     scopeDescriptor = @getRootScopeDescriptor()
 
-    subscriptions.add atom.config.onDidChange scopeDescriptor, 'editor.showInvisibles', => @updateInvisibles()
-    subscriptions.add atom.config.onDidChange scopeDescriptor, 'editor.invisibles', => @updateInvisibles()
+    subscriptions.add atom.config.onDidChange 'editor.showInvisibles', scope: scopeDescriptor, => @updateInvisibles()
+    subscriptions.add atom.config.onDidChange 'editor.invisibles', scope: scopeDescriptor, => @updateInvisibles()
 
   getViewClass: ->
     require './text-editor-view'

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -84,7 +84,7 @@ class TokenizedBuffer extends Model
     @currentGrammarScore = score ? grammar.getScore(@buffer.getPath(), @buffer.getText())
     @subscribe @grammar.onDidUpdate => @retokenizeLines()
 
-    @configSettings = tabLength: atom.config.get(@rootScopeDescriptor, 'editor.tabLength')
+    @configSettings = tabLength: atom.config.get('editor.tabLength', scope: @rootScopeDescriptor)
 
     @grammarTabLengthSubscription?.dispose()
     @grammarTabLengthSubscription = atom.config.onDidChange @rootScopeDescriptor, 'editor.tabLength', ({newValue}) =>

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -87,7 +87,7 @@ class TokenizedBuffer extends Model
     @configSettings = tabLength: atom.config.get('editor.tabLength', scope: @rootScopeDescriptor)
 
     @grammarTabLengthSubscription?.dispose()
-    @grammarTabLengthSubscription = atom.config.onDidChange @rootScopeDescriptor, 'editor.tabLength', ({newValue}) =>
+    @grammarTabLengthSubscription = atom.config.onDidChange 'editor.tabLength', scope: @rootScopeDescriptor, ({newValue}) =>
       @configSettings.tabLength = newValue
       @retokenizeLines()
     @subscribe @grammarTabLengthSubscription

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -645,7 +645,7 @@ class Workspace extends Model
 
   # Restore to a default editor font size.
   resetFontSize: ->
-    atom.config.restoreDefault("editor.fontSize")
+    atom.config.unset("editor.fontSize")
 
   # Removes the item's uri from the list of potential items to reopen.
   itemOpened: (item) ->


### PR DESCRIPTION
This PR updates the config API, but does not change the way global properties are stored. They still aren't stored in the scoped property store.

Refs #4567.
### Steps
- [x] Make `Config::get` and `::set` take trailing options hashes
- [x] Add a `source` option to `Config::set`
- [x] Use the user's settings file path as the default source in `::set`
- [x] Add `sources` and `excludeSources` options to `Config::get`
- [x] Fix remaining failing specs related to the user config using new source information
- [x] Add `Config::unset`
- [x] Make `Config::observe` and `::onDidChange` consistent with `::get` by taking a scope as an option instead of the first argument.
- [x] Throw exception when trying to specify a `source` without a scope selector (To be fixed by #4567).
- [x] Bugfix: only use special priority for settings w/ user's config file as source
- [x] Update docs
- [x]  Deprecate `::isDefault` and `::getDefault` in favor of using the `source` option to `::get`
- [ ] Add a way to get settings set from with a source _directory_ (needed by [this code](https://github.com/atom/settings-view/blob/master/lib/package-snippets-view.coffee#L26) in settings-view)
