### PR TITLE
Properly unmount the component when the shadow DOM is enabled

### DIFF
--- a/spec/text-editor-element-spec.coffee
+++ b/spec/text-editor-element-spec.coffee
@@ -32,6 +32,31 @@ describe "TextEditorElement", ->
       element.setModel(model)
       expect(element.hasAttribute('mini')).toBe true
 
+  describe "when the editor is attached to the DOM", ->
+    describe "when the editor.useShadowDOM config option is true", ->
+      it "mounts the react component and unmounts when removed from the dom", ->
+        atom.config.set('editor.useShadowDOM', true)
+
+        element = new TextEditorElement
+        jasmine.attachToDOM(element)
+
+        component = element.component
+        expect(component.isMounted()).toBe true
+        element.getModel().destroy()
+        expect(component.isMounted()).toBe false
+
+    describe "when the editor.useShadowDOM config option is false", ->
+      it "mounts the react component and unmounts when removed from the dom", ->
+        atom.config.set('editor.useShadowDOM', false)
+
+        element = new TextEditorElement
+        jasmine.attachToDOM(element)
+
+        component = element.component
+        expect(component.isMounted()).toBe true
+        element.getModel().destroy()
+        expect(component.isMounted()).toBe false
+
   describe "focus and blur handling", ->
     describe "when the editor.useShadowDOM config option is true", ->
       it "proxies focus/blur events to/from the hidden input inside the shadow root", ->

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -123,7 +123,7 @@ class TextEditorElement extends HTMLElement
   unmountComponent: ->
     return unless @component?.isMounted()
     callRemoveHooks(this)
-    React.unmountComponentAtNode(this)
+    React.unmountComponentAtNode(@rootElement)
     @component = null
 
   focused: ->


### PR DESCRIPTION
!!

This was fine with the shadow DOM disabled.

@nathansobo this feels like a big deal, but maybe there were actually no memory leaks caused.
