### PR TITLE
Avoid firing repeated config events while packages are loaded

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -492,6 +492,26 @@ describe "Config", ->
       atom.config.set('foo.bar.baz', "value 10")
       expect(bazCatHandler).not.toHaveBeenCalled()
 
+  describe ".transact(callback)", ->
+    changeSpy = null
+
+    beforeEach ->
+      changeSpy = jasmine.createSpy('onDidChange callback')
+      atom.config.onDidChange("foo.bar.baz", changeSpy)
+
+    it "allows only one change event for the duration of the given callback", ->
+      atom.config.transact ->
+        atom.config.set("foo.bar.baz", 1)
+        atom.config.set("foo.bar.baz", 2)
+        atom.config.set("foo.bar.baz", 3)
+
+      expect(changeSpy.callCount).toBe(1)
+      expect(changeSpy.argsForCall[0][0]).toEqual(newValue: 3, oldValue: undefined)
+
+    it "does not emit an event if no changes occur while paused", ->
+      atom.config.transact ->
+      expect(changeSpy).not.toHaveBeenCalled()
+
   describe ".initializeConfigDirectory()", ->
     beforeEach ->
       if fs.existsSync(dotAtomPath)

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -406,11 +406,11 @@ describe "Config", ->
       it "fires the callback every time the observed value changes", ->
         observeHandler.reset() # clear the initial call
         atom.config.set('foo.bar.baz', "value 2")
-        expect(observeHandler).toHaveBeenCalledWith({newValue: 'value 2', oldValue: 'value 1', keyPath: 'foo.bar.baz'})
+        expect(observeHandler).toHaveBeenCalledWith({newValue: 'value 2', oldValue: 'value 1'})
         observeHandler.reset()
 
         atom.config.set('foo.bar.baz', "value 1")
-        expect(observeHandler).toHaveBeenCalledWith({newValue: 'value 1', oldValue: 'value 2', keyPath: 'foo.bar.baz'})
+        expect(observeHandler).toHaveBeenCalledWith({newValue: 'value 1', oldValue: 'value 2'})
 
     describe 'when a keyPath is not specified', ->
       beforeEach ->
@@ -424,15 +424,21 @@ describe "Config", ->
       it "fires the callback every time any value changes", ->
         observeHandler.reset() # clear the initial call
         atom.config.set('foo.bar.baz', "value 2")
-        expect(observeHandler).toHaveBeenCalledWith({newValue: 'value 2', oldValue: 'value 1', keyPath: 'foo.bar.baz'})
+        expect(observeHandler).toHaveBeenCalled()
+        expect(observeHandler.mostRecentCall.args[0].newValue.foo.bar.baz).toBe("value 2")
+        expect(observeHandler.mostRecentCall.args[0].oldValue.foo.bar.baz).toBe("value 1")
 
         observeHandler.reset()
         atom.config.set('foo.bar.baz', "value 1")
-        expect(observeHandler).toHaveBeenCalledWith({newValue: 'value 1', oldValue: 'value 2', keyPath: 'foo.bar.baz'})
+        expect(observeHandler).toHaveBeenCalled()
+        expect(observeHandler.mostRecentCall.args[0].newValue.foo.bar.baz).toBe("value 1")
+        expect(observeHandler.mostRecentCall.args[0].oldValue.foo.bar.baz).toBe("value 2")
 
         observeHandler.reset()
         atom.config.set('foo.bar.int', 1)
-        expect(observeHandler).toHaveBeenCalledWith({newValue: 1, oldValue: undefined, keyPath: 'foo.bar.int'})
+        expect(observeHandler).toHaveBeenCalled()
+        expect(observeHandler.mostRecentCall.args[0].newValue.foo.bar.int).toBe(1)
+        expect(observeHandler.mostRecentCall.args[0].oldValue.foo.bar.int).toBe(undefined)
 
   describe ".observe(keyPath)", ->
     [observeHandler, observeSubscription] = []
@@ -453,6 +459,10 @@ describe "Config", ->
 
       atom.config.set('foo.bar.baz', "value 1")
       expect(observeHandler).toHaveBeenCalledWith("value 1")
+
+      observeHandler.reset()
+      atom.config.loadUserConfig()
+      expect(observeHandler).toHaveBeenCalledWith(undefined)
 
     it "fires the callback when the observed value is deleted", ->
       observeHandler.reset() # clear the initial call
@@ -1185,25 +1195,25 @@ describe "Config", ->
         atom.config.onDidChange [".source.coffee", ".string.quoted.double.coffee"], keyPath, changeSpy = jasmine.createSpy()
 
         atom.config.set("foo.bar.baz", 12)
-        expect(changeSpy).toHaveBeenCalledWith({oldValue: undefined, newValue: 12, keyPath})
+        expect(changeSpy).toHaveBeenCalledWith({oldValue: undefined, newValue: 12})
         changeSpy.reset()
 
         disposable1 = atom.config.addScopedSettings("a", ".source .string.quoted.double", foo: bar: baz: 22)
-        expect(changeSpy).toHaveBeenCalledWith({oldValue: 12, newValue: 22, keyPath})
+        expect(changeSpy).toHaveBeenCalledWith({oldValue: 12, newValue: 22})
         changeSpy.reset()
 
         disposable2 = atom.config.addScopedSettings("b", ".source.coffee .string.quoted.double.coffee", foo: bar: baz: 42)
-        expect(changeSpy).toHaveBeenCalledWith({oldValue: 22, newValue: 42, keyPath})
+        expect(changeSpy).toHaveBeenCalledWith({oldValue: 22, newValue: 42})
         changeSpy.reset()
 
         disposable2.dispose()
-        expect(changeSpy).toHaveBeenCalledWith({oldValue: 42, newValue: 22, keyPath})
+        expect(changeSpy).toHaveBeenCalledWith({oldValue: 42, newValue: 22})
         changeSpy.reset()
 
         disposable1.dispose()
-        expect(changeSpy).toHaveBeenCalledWith({oldValue: 22, newValue: 12, keyPath})
+        expect(changeSpy).toHaveBeenCalledWith({oldValue: 22, newValue: 12})
         changeSpy.reset()
 
         atom.config.set("foo.bar.baz", undefined)
-        expect(changeSpy).toHaveBeenCalledWith({oldValue: 12, newValue: undefined, keyPath})
+        expect(changeSpy).toHaveBeenCalledWith({oldValue: 12, newValue: undefined})
         changeSpy.reset()

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -329,7 +329,8 @@ class PackageManager
     @packageActivators.push([activator, types])
 
   activatePackages: (packages) ->
-    @activatePackage(pack.name) for pack in packages
+    atom.config.transact =>
+      @activatePackage(pack.name) for pack in packages
     @observeDisabledPackages()
 
   # Activate a single package by name
@@ -344,7 +345,8 @@ class PackageManager
 
   # Deactivate all packages
   deactivatePackages: ->
-    @deactivatePackage(pack.name) for pack in @getLoadedPackages()
+    atom.config.transact =>
+      @deactivatePackage(pack.name) for pack in @getLoadedPackages()
     @unobserveDisabledPackages()
 
   # Deactivate the package with the given name


### PR DESCRIPTION
Refs #4666.
#### Problem

Currently, each scoped settings file or snippets file that is loaded from a package causes expensive events to be emitted on `atom.config`. Emitting these events is expensive because:
- The act of adding scoped settings clears the scoped settings cache
- Callbacks registered via `atom.config::onDidChange` or `::observe` receive the new property value as an argument. Computing the new value requires re-merging the scoped properties with an _empty cache_.

Merging scoped properties recently became more expensive due to deep-merging.
#### Solution

This adds a new method to `Config` called `::transact` which allow multiple config changes to be 'rolled up', firing only one change event.

Currently, I only use `::transact` in `PackageManager` when activating and deactivating packages. I think the snippets package should also use it when loading snippets files from packages.

/cc @benogle @kevinsawicki
