### PR TITLE
Improve middle mouse paste on Linux

### DIFF
--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -442,7 +442,7 @@ TextEditorComponent = React.createClass
         # clipboard.writeText is a sync ipc call on Linux and that
         # will slow down selections.
         ipc.send('write-text-to-selection-clipboard', selectedText)
-    @subscribe @props.editor.onDidChangeSelectionRange =>
+    @subscribe @props.editor.onDidChangeSelectionRange ->
       clearTimeout(timeoutId)
       timeoutId = setTimeout(writeSelectedTextToSelectionClipboard)
 

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -554,7 +554,11 @@ TextEditorComponent = React.createClass
       scrollViewNode.scrollLeft = 0
 
   onMouseDown: (event) ->
-    return unless event.button is 0 # only handle the left mouse button
+    unless event.button is 0 or (event.button is 1 and process.platform is 'linux')
+      # Only handle mouse down events for left mouse button on all platforms
+      # and middle mouse button on Linux since it pastes the selection clipboard
+      return
+
     return if event.target?.classList.contains('horizontal-scrollbar')
 
     {editor} = @props

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -436,13 +436,15 @@ TextEditorComponent = React.createClass
   # in the selection clipboard. This is only applicable on Linux.
   trackSelectionClipboard: ->
     timeoutId = null
+    {editor} = @props
     writeSelectedTextToSelectionClipboard = =>
-      if selectedText = @props.editor.getSelectedText()
+      return if editor.isDestroyed()
+      if selectedText = editor.getSelectedText()
         # This uses ipc.send instead of clipboard.writeText because
         # clipboard.writeText is a sync ipc call on Linux and that
         # will slow down selections.
         ipc.send('write-text-to-selection-clipboard', selectedText)
-    @subscribe @props.editor.onDidChangeSelectionRange ->
+    @subscribe editor.onDidChangeSelectionRange ->
       clearTimeout(timeoutId)
       timeoutId = setTimeout(writeSelectedTextToSelectionClipboard)
 
@@ -782,7 +784,7 @@ TextEditorComponent = React.createClass
       window.removeEventListener('mouseup', onMouseUp)
 
     pasteSelectionClipboard = (event) ->
-      if event.which is 2 and process.platform is 'linux'
+      if event?.which is 2 and process.platform is 'linux'
         if selection = require('clipboard').readText('selection')
           editor.insertText(selection)
 

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -435,12 +435,16 @@ TextEditorComponent = React.createClass
   # Listen for selection changes and store the currently selected text
   # in the selection clipboard. This is only applicable on Linux.
   trackSelectionClipboard: ->
-    @subscribe @props.editor.onDidChangeSelectionRange =>
+    timeoutId = null
+    writeSelectedTextToSelectionClipboard = =>
       if selectedText = @props.editor.getSelectedText()
         # This uses ipc.send instead of clipboard.writeText because
         # clipboard.writeText is a sync ipc call on Linux and that
         # will slow down selections.
         ipc.send('write-text-to-selection-clipboard', selectedText)
+    @subscribe @props.editor.onDidChangeSelectionRange =>
+      clearTimeout(timeoutId)
+      timeoutId = setTimeout(writeSelectedTextToSelectionClipboard)
 
   observeConfig: ->
     @subscribe atom.config.observe 'editor.useHardwareAcceleration', @setUseHardwareAcceleration


### PR DESCRIPTION
- Moves the cursor to the clicked location
- Ensures operations like backspace don't write to the selection clipboard

Closes #4296
Closes #4638
Closes #4677
