### PR TITLE
Respect initialLine and initialColumn options when reopening a file

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -78,6 +78,37 @@ describe "TextEditor", ->
         expect(editor.getLastCursor().getBufferPosition().row).toEqual 0
         expect(editor.getLastCursor().getBufferPosition().column).toEqual 8
 
+  describe "when the editor is reopened with an initialLine option", ->
+    it "positions the cursor on the specified line", ->
+      editor = null
+
+      waitsForPromise ->
+        atom.workspace.open('sample.less', initialLine: 5).then (o) -> editor = o
+
+      waitsForPromise ->
+        atom.workspace.open('sample.less', initialLine: 4).then (o) -> editor = o
+
+      runs ->
+        buffer = editor.buffer
+        expect(editor.getLastCursor().getBufferPosition().row).toEqual 4
+        expect(editor.getLastCursor().getBufferPosition().column).toEqual 0
+
+  describe "when the editor is reopened with an initialColumn option", ->
+    it "positions the cursor on the specified column", ->
+      editor = null
+
+      waitsForPromise ->
+        atom.workspace.open('sample.less', initialColumn: 8).then (o) -> editor = o
+
+      waitsForPromise ->
+        atom.workspace.open('sample.less', initialColumn: 7).then (o) -> editor = o
+
+      runs ->
+        buffer = editor.buffer
+        expect(editor.getLastCursor().getBufferPosition().row).toEqual 0
+        expect(editor.getLastCursor().getBufferPosition().column).toEqual 7
+
+
   describe ".copy()", ->
     it "returns a different edit session with the same initial state", ->
       editor.setSelectedBufferRange([[1, 2], [3, 4]])

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -89,7 +89,6 @@ describe "TextEditor", ->
         atom.workspace.open('sample.less', initialLine: 4).then (o) -> editor = o
 
       runs ->
-        buffer = editor.buffer
         expect(editor.getLastCursor().getBufferPosition().row).toEqual 4
         expect(editor.getLastCursor().getBufferPosition().column).toEqual 0
 
@@ -104,10 +103,8 @@ describe "TextEditor", ->
         atom.workspace.open('sample.less', initialColumn: 7).then (o) -> editor = o
 
       runs ->
-        buffer = editor.buffer
         expect(editor.getLastCursor().getBufferPosition().row).toEqual 0
         expect(editor.getLastCursor().getBufferPosition().column).toEqual 7
-
 
   describe ".copy()", ->
     it "returns a different edit session with the same initial state", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -62,7 +62,6 @@ describe "TextEditor", ->
         atom.workspace.open('sample.less', initialLine: 5).then (o) -> editor = o
 
       runs ->
-        buffer = editor.buffer
         expect(editor.getLastCursor().getBufferPosition().row).toEqual 5
         expect(editor.getLastCursor().getBufferPosition().column).toEqual 0
 
@@ -74,7 +73,6 @@ describe "TextEditor", ->
         atom.workspace.open('sample.less', initialColumn: 8).then (o) -> editor = o
 
       runs ->
-        buffer = editor.buffer
         expect(editor.getLastCursor().getBufferPosition().row).toEqual 0
         expect(editor.getLastCursor().getBufferPosition().column).toEqual 8
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -359,7 +359,7 @@ class AtomApplication
 
     if existingWindow?
       openedWindow = existingWindow
-      openedWindow.openPath(pathToOpen, initialLine)
+      openedWindow.openPath(pathToOpen, initialLine, initialColumn)
       if openedWindow.isMinimized()
         openedWindow.restore()
       else

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -456,7 +456,7 @@ class Workspace extends Model
         pane.activateItem(item)
         pane.activate() if activatePane
         if options.initialLine? or options.initialColumn?
-          item.setCursorBufferPosition([options.initialLine, options.initialColumn])
+          item.setCursorBufferPosition?([options.initialLine, options.initialColumn])
         index = pane.getActiveItemIndex()
         @emit "uri-opened"
         @emitter.emit 'did-open', {uri, pane, item, index}

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -455,6 +455,8 @@ class Workspace extends Model
         @itemOpened(item)
         pane.activateItem(item)
         pane.activate() if activatePane
+        if options.initialLine? or options.initialColumn?
+          item.setCursorBufferPosition([options.initialLine, options.initialColumn])
         index = pane.getActiveItemIndex()
         @emit "uri-opened"
         @emitter.emit 'did-open', {uri, pane, item, index}


### PR DESCRIPTION
Alright, first things first: Atom is awesome!

Second, I’m not completely happy with my pull request. I’ve used the patched Atom for two weeks - the problem seems to be fixed.

But.

It seems that [this line](https://github.com/alexandershov/atom/commit/229e7e03b2e7ad3f89ddb1e43ee2d237f6c754b7#diff-88caa33888e5345667751ee7182b4c36R459) works correctly (meaning "setting new cursor position and scrolling to it") only if it's placed after the code doing the pane creation/activation. It still works, but I have a hunch that programming by coincidence isn't a good practice ;)

Also, I couldn’t find specs for AtomApplication, which means that [this change](https://github.com/alexandershov/atom/commit/229e7e03b2e7ad3f89ddb1e43ee2d237f6c754b7#diff-9929202e800354a2caa775ed44c61bfeR362) is not covered by tests.

So, getting some advice from a smart person would be cool.
