### PR TITLE
add dependency for arch-based systems

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -26,7 +26,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 
 ### Arch
 
-* `sudo pacman -S base-devel git nodejs libgnome-keyring python2`
+* `sudo pacman -S base-devel git nodejs libgnome-keyring python2 gconf`
 * `export PYTHON=/usr/bin/python2` before building Atom.
 
 ### Slackware


### PR DESCRIPTION
for manjaro (based on arch linux), I was getting this error after building & install atom: `/usr/local/share/atom/atom: error while loading shared libraries: libgconf-2.so.4: cannot open shared object file: No such file or directory`

after running `sudo pacman -S gconf`, i could open atom. hope this is of use to others.
