### PR TITLE
WIP: Add a way to duplicate selected text instead of lines only

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3643,6 +3643,22 @@ describe "TextEditor", ->
       """
       expect(editor.getSelectedBufferRange()).toEqual [[13, 0], [14, 2]]
 
+  describe ".duplicateSelections()", ->
+    it "duplicates the current selected text", ->
+      editor.setSelectedBufferRange([[1, 6], [1, 10]], preserveFolds: true)
+      editor.addSelectionForBufferRange([[4, 15], [4, 15]], preserveFolds: true)
+      editor.addSelectionForBufferRange([[8, 11], [8, 22]], preserveFolds: true)
+
+      editor.duplicateSelections()
+
+      [selection1, selection2, selection3] = editor.getSelections()
+      expect(buffer.lineForRow(1)).toEqual('  var sortsort = function(items) {')
+      expect(selection1.getBufferRange()).toEqual [[1, 10], [1, 14]]
+      expect(buffer.lineForRow(4)).toEqual('    while(items.length > 0) {')
+      expect(selection2.getBufferRange()).toEqual [[4, 15], [4, 15]]
+      expect(buffer.lineForRow(8)).toEqual('    return sort(left).sort(left).concat(pivot).concat(sort(right));')
+      expect(selection3.getBufferRange()).toEqual [[8, 22], [8, 33]]
+
   describe ".shouldPromptToSave()", ->
     it "returns false when an edit session's buffer is in use by more than one session", ->
       jasmine.unspy(editor, 'shouldPromptToSave')

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -937,6 +937,19 @@ class TextEditor extends Model
     deprecate("Use TextEditor::duplicateLines() instead")
     @duplicateLines()
 
+  # Duplicate the selections.
+  duplicateSelections: ->
+    @transact =>
+      for selection in @getSelectionsOrderedByBufferPosition().reverse()
+        continue if selection.isEmpty()
+
+        textToDuplicate = selection.getText()
+        selectedTextLength = textToDuplicate.length
+        selectedBufferRange = selection.getBufferRange()
+        @setTextInBufferRange([selectedBufferRange.start, selectedBufferRange.start], textToDuplicate)
+        newBufferRangeStart = [selectedBufferRange.start.row, selectedBufferRange.start.column + selectedTextLength]
+        selection.setBufferRange(selectedBufferRange.translate([0, selectedTextLength]))
+
   replaceSelectedText: (options={}, fn) ->
     {selectWordIfEmpty} = options
     @mutateSelectedText (selection) ->


### PR DESCRIPTION
This is a feature I miss from another text editor.
1. When the selection is only on one line, `ctrl-shift-d` duplicates the text to the right
2. When the selection takes up more than one line, `ctrl-shift-d` duplicates text down

Right now you have `editor.duplicateLines()` to accomplish 2.  But, I would like to add support for 1.  I added a function `editor.duplicateSelections()` instead of adding to the current function because I wanted to get feedback and get something working.
