### PR TITLE
Actually return the new grammar, as per the API

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2838,7 +2838,7 @@ class TextEditor extends Model
     @subscribeToScopedConfigSettings()
     @unfoldAll()
     @emit 'grammar-changed'
-    @emitter.emit 'did-change-grammar'
+    @emitter.emit 'did-change-grammar', @getGrammar()
 
   handleMarkerCreated: (marker) =>
     if marker.matchesProperties(@getSelectionMarkerAttributes())


### PR DESCRIPTION
Previously, the emitter didn't return the new type of grammar, just an undefined to signal when the grammar changed. This patch makes it so that the type of grammar is returned when the texteditor's grammar changes, as per what the API says it does
