### PR TITLE
Add Config::getSources

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -335,6 +335,21 @@ describe "Config", ->
 
         expect(atom.config.get('foo.bar.baz', scope: ['.source.coffee'])).toBe 10
 
+  describe ".getSources()", ->
+    it "returns an array of all of the config's source names", ->
+      expect(atom.config.getSources()).toEqual([])
+
+      atom.config.set("a.b", 1, scopeSelector: ".x1", source: "source-1")
+      atom.config.set("a.c", 1, scopeSelector: ".x1", source: "source-1")
+      atom.config.set("a.b", 2, scopeSelector: ".x2", source: "source-2")
+      atom.config.set("a.b", 1, scopeSelector: ".x3", source: "source-3")
+
+      expect(atom.config.getSources()).toEqual([
+        "source-1"
+        "source-2"
+        "source-3"
+      ])
+
   describe ".getSettings()", ->
     it "returns all settings including defaults", ->
       atom.config.setDefaults("foo", bar: baz: 10)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -605,6 +605,11 @@ class Config
     else
       @set(keyPath, _.valueForKeyPath(@defaultSettings, keyPath))
 
+  # Extended: Get an {Array} of all of the `source` {String}s with which
+  # settings have been added via {::set}.
+  getSources: ->
+    _.uniq(_.pluck(@scopedSettingsStore.propertySets, 'source')).sort()
+
   # Deprecated: Restore the global setting at `keyPath` to its default value.
   #
   # Returns the new value.


### PR DESCRIPTION
The settings-view needs this so that it can display snippets associated with packages.
Right now it [uses private properties on Config](https://github.com/atom/settings-view/blob/master/lib/package-snippets-view.coffee#L32).

Refs atom/settings-view#294
