### PR TITLE
Deprecate `Config::addScopedProperties`

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -112,6 +112,13 @@ describe "Config", ->
     it "does not allow a 'source' option without a 'scopeSelector'", ->
       expect(-> atom.config.set("foo", 1, source: [".source.ruby"])).toThrow()
 
+    describe "when the key-path is null", ->
+      it "sets the root object", ->
+        expect(atom.config.set(null, editor: tabLength: 6)).toBe true
+        expect(atom.config.get("editor.tabLength")).toBe 6
+        expect(atom.config.set(null, editor: tabLength: 8, scopeSelector: ['.source.js'])).toBe true
+        expect(atom.config.get("editor.tabLength", scope: ['.source.js'])).toBe 8
+
     describe "when the value equals the default value", ->
       it "does not store the value in the user's config", ->
         atom.config.setDefaults "foo",

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -193,8 +193,14 @@ describe "Config", ->
       atom.config.unset('a.c')
       expect(atom.config.save.callCount).toBe 1
 
-    it "throws when called with a source but no scope", ->
-      expect(-> atom.config.unset("a.b", source: "the-source")).toThrow()
+    describe "when a 'source' and no 'scopeSelector' is given", ->
+      it "removes all scoped settings with the given source", ->
+        atom.config.set("foo.bar.baz", 1, scopeSelector: ".a", source: "source-a")
+        atom.config.set("foo.bar.quux", 2, scopeSelector: ".b", source: "source-a")
+        expect(atom.config.get("foo.bar", scope: [".a.b"])).toEqual(baz: 1, quux: 2)
+
+        atom.config.unset(null, source: "source-a")
+        expect(atom.config.get("foo.bar", scope: [".a"])).toEqual(baz: 0, ok: 0)
 
     describe "when a 'scopeSelector' is given", ->
       it "restores the global default when no scoped default set", ->

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -98,6 +98,11 @@ module.exports =
         type: ['string', 'null']
 
       # These can be used as globals or scoped, thus defaults.
+      completions:
+        type: "array"
+        items:
+          type: "string"
+        default: []
       fontFamily:
         type: 'string'
         default: ''

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -972,16 +972,8 @@ class Config
     @scopedSettingsStore.getPropertyValue(scopeDescriptor.getScopeChain(), keyPath, options)
 
   observeScopedKeyPath: (scope, keyPath, callback) ->
-    oldValue = @get(keyPath, {scope})
-
-    callback(oldValue)
-
-    didChange = =>
-      newValue = @get(keyPath, {scope})
-      callback(newValue) unless _.isEqual(oldValue, newValue)
-      oldValue = newValue
-
-    @emitter.on 'did-change', didChange
+    callback(@get(keyPath, {scope}))
+    @onDidChangeScopedKeyPath scope, keyPath, (event) -> callback(event.newValue)
 
   onDidChangeScopedKeyPath: (scope, keyPath, callback) ->
     oldValue = @get(keyPath, {scope})

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -585,9 +585,6 @@ class Config
     else
       {scopeSelector, source} = options ? {}
 
-    if source and not scopeSelector
-      throw new Error("::unset with a 'source' and no 'sourceSelector' is not yet implemented!")
-
     source ?= @getUserConfigPath()
 
     if scopeSelector?
@@ -603,7 +600,10 @@ class Config
         @scopedSettingsStore.removePropertiesForSource(source)
         @emitChangeEvent()
     else
-      @set(keyPath, _.valueForKeyPath(@defaultSettings, keyPath))
+      @scopedSettingsStore.removePropertiesForSource(source)
+      if keyPath?
+        @set(keyPath, _.valueForKeyPath(@defaultSettings, keyPath))
+
 
   # Extended: Get an {Array} of all of the `source` {String}s with which
   # settings have been added via {::set}.

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -539,7 +539,7 @@ class Config
   # * `true` if the value was set.
   # * `false` if the value was not able to be coerced to the type specified in the setting's schema.
   set: ->
-    if arguments[0][0] is '.'
+    if arguments[0]?[0] is '.'
       Grim.deprecate """
         Passing a scope selector as the first argument to Config::set is deprecated.
         Pass a `scopeSelector` in an options hash as the final argument instead.
@@ -856,7 +856,10 @@ class Config
     defaultValue = _.valueForKeyPath(@defaultSettings, keyPath)
     value = undefined if _.isEqual(defaultValue, value)
 
-    _.setValueForKeyPath(@settings, keyPath, value)
+    if keyPath?
+      _.setValueForKeyPath(@settings, keyPath, value)
+    else
+      @settings = value
     @emitChangeEvent()
 
   observeKeyPath: (keyPath, options, callback) ->

--- a/src/scoped-properties.coffee
+++ b/src/scoped-properties.coffee
@@ -11,12 +11,13 @@ class ScopedProperties
         callback(null, new ScopedProperties(scopedPropertiesPath, scopedProperties))
 
   constructor: (@path, @scopedProperties) ->
-    @propertyDisposable = new CompositeDisposable
 
   activate: ->
     for selector, properties of @scopedProperties
-      @propertyDisposable.add atom.config.addScopedSettings(@path, selector, properties)
+      atom.config.set(null, properties, scopeSelector: selector, source: @path)
     return
 
   deactivate: ->
-    @propertyDisposable.dispose()
+    for selector of @scopedProperties
+      atom.config.unset(null, scopeSelector: selector, source: @path)
+    return


### PR DESCRIPTION
Use `::set` instead.

This drove out fixing some things about `Config::set`:
- With a null key-path, it now sets the root object
- `::unset` now works with a `source` but no `scopeSelector`
- `editor.completions` now needs to be part of the built-in schema, because many packages write to that key-path as a scoped property.
