### PR TITLE
Update scroll position when opening from command line with line specified

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -102,6 +102,9 @@ class TextEditor extends Model
       initialLine = Math.max(parseInt(initialLine) or 0, 0)
       initialColumn = Math.max(parseInt(initialColumn) or 0, 0)
       @addCursorAtBufferPosition([initialLine, initialColumn])
+      subscription = @displayBuffer.onDidChange =>
+        @scrollToCursorPosition()
+        subscription.dispose()
 
     @languageMode = new LanguageMode(this)
 


### PR DESCRIPTION
Attempt to fix #4780.  

The event listener solution is probably hacky.  I mostly don't quite know when the DisplayBuffer is fully "initialized"/has a height, width, etc.  As of right now if I attempt to call @scrollToCursorPosition() in TextEditor's constructor (at say line 105), the DisplayBuffer has no size information when it gets to scrollToScreenRange() and no scrolling occurs.
