### PR TITLE
Add Config::getAll

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "reactionary-atom-fork": "^1.0.0",
     "runas": "1.0.1",
     "scandal": "1.0.3",
-    "scoped-property-store": "^0.15.5",
+    "scoped-property-store": "^0.16.0",
     "scrollbar-style": "^1.0.2",
     "season": "^1.0.2",
     "semver": "2.2.1",

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -95,6 +95,30 @@ describe "Config", ->
           atom.config.set("foo.bar.baz", 1, scopeSelector: ".source.coffee", source: "some-package")
           expect(atom.config.get("foo.bar.baz", scope: [".source.coffee"])).toBe 100
 
+  describe ".getAll(keyPath, {scope, sources, excludeSources})", ->
+    it "reads all of the values for a given key-path", ->
+      expect(atom.config.set("foo", 41)).toBe true
+      expect(atom.config.set("foo", 43, scopeSelector: ".a .b")).toBe true
+      expect(atom.config.set("foo", 42, scopeSelector: ".a")).toBe true
+      expect(atom.config.set("foo", 44, scopeSelector: ".a .b.c")).toBe true
+
+      expect(atom.config.set("foo", -44, scopeSelector: ".d")).toBe true
+
+      expect(atom.config.getAll("foo", scope: [".a", ".b.c"])).toEqual [
+        {scopeSelector: '.a .b.c', value: 44}
+        {scopeSelector: '.a .b', value: 43}
+        {scopeSelector: '.a', value: 42}
+        {scopeSelector: '*', value: 41}
+      ]
+
+    it "includes the schema's default value", ->
+      atom.config.setSchema("foo", type: 'number', default: 40)
+      expect(atom.config.set("foo", 43, scopeSelector: ".a .b")).toBe true
+      expect(atom.config.getAll("foo", scope: [".a", ".b.c"])).toEqual [
+        {scopeSelector: '.a .b', value: 43}
+        {scopeSelector: '*', value: 40}
+      ]
+
   describe ".set(keyPath, value, {source, scopeSelector})", ->
     it "allows a key path's value to be written", ->
       expect(atom.config.set("foo.bar.baz", 42)).toBe true

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -504,7 +504,7 @@ class Config
   # Returns an {Array} of {Object}s with the following keys:
   #  * `scopeSelector` The scope-selector {String} with which the value is associated
   #  * `value` The value for the key-path
-  getAll: (keyPath, options)->
+  getAll: (keyPath, options) ->
     {scope, sources} = options if options?
     result = []
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -495,6 +495,28 @@ class Config
     else
       @getRawValue(keyPath, options)
 
+  # Extended: Get all of the values for the given key-path, along with their
+  # associated scope selector.
+  #
+  # * `keyPath` The {String} name of the key to retrieve
+  # * `options` (optional) {Object} see the `options` argument to {::get}
+  #
+  # Returns an {Array} of {Object}s with the following keys:
+  #  * `scopeSelector` The scope-selector {String} with which the value is associated
+  #  * `value` The value for the key-path
+  getAll: (keyPath, options)->
+    {scope, sources} = options if options?
+    result = []
+
+    if scope?
+      scopeDescriptor = ScopeDescriptor.fromObject(scope)
+      result = result.concat @scopedSettingsStore.getAll(scopeDescriptor.getScopeChain(), keyPath, options)
+
+    if globalValue = @getRawValue(keyPath, options)
+      result.push(scopeSelector: '*', value: globalValue)
+
+    result
+
   # Essential: Sets the value for a configuration setting.
   #
   # This value is stored in Atom's internal configuration file.
@@ -987,10 +1009,8 @@ class Config
         oldValue = newValue
         callback(event)
 
-  # TODO: figure out how to change / remove this. The return value is awkward.
-  # * language mode uses it for one thing.
-  # * autocomplete uses it for editor.completions
   settingsForScopeDescriptor: (scopeDescriptor, keyPath) ->
+    Grim.deprecate("Use Config::getAll instead")
     scopeDescriptor = ScopeDescriptor.fromObject(scopeDescriptor)
     @scopedSettingsStore.getProperties(scopeDescriptor.getScopeChain(), keyPath)
 

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -67,5 +67,5 @@ class GrammarRegistry extends FirstMate.GrammarRegistry
     atom.config.getRawScopedValue(scope, keyPath)
 
   propertiesForScope: (scope, keyPath) ->
-    deprecate 'A direct (but private) replacement is available at atom.config.scopedSettingsForScopeDescriptor().'
+    deprecate 'Use atom.config.getAll instead.'
     atom.config.settingsForScopeDescriptor(scope, keyPath)

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -29,14 +29,15 @@ class LanguageMode
   #
   # Returns an {Array} of the commented {Ranges}.
   toggleLineCommentsForBufferRows: (start, end) ->
-    scopeDescriptor = @editor.scopeDescriptorForBufferPosition([start, 0])
-    properties = atom.config.settingsForScopeDescriptor(scopeDescriptor, 'editor.commentStart')[0]
-    return unless properties
+    scope = @editor.scopeDescriptorForBufferPosition([start, 0])
+    commentStartEntry = atom.config.getAll('editor.commentStart', {scope})[0]
 
-    commentStartString = _.valueForKeyPath(properties, 'editor.commentStart')
-    commentEndString = _.valueForKeyPath(properties, 'editor.commentEnd')
+    return unless commentStartEntry?
 
-    return unless commentStartString
+    commentEndEntry = atom.config.getAll('editor.commentEnd', {scope}).find (entry) ->
+      entry.scopeSelector is commentStartEntry.scopeSelector
+    commentStartString = commentStartEntry?.value
+    commentEndString = commentEndEntry?.value
 
     buffer = @editor.buffer
     commentStartRegexString = _.escapeRegExp(commentStartString).replace(/(\s+)$/, '(?:$1)?')

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -437,7 +437,7 @@ TextEditorComponent = React.createClass
   trackSelectionClipboard: ->
     timeoutId = null
     {editor} = @props
-    writeSelectedTextToSelectionClipboard = =>
+    writeSelectedTextToSelectionClipboard = ->
       return if editor.isDestroyed()
       if selectedText = editor.getSelectedText()
         # This uses ipc.send instead of clipboard.writeText because


### PR DESCRIPTION
This allows us to deprecate `::settingsForScopeDescriptor`.
