### PR TITLE
Use `*` instead of `global` as the global selector in user settings

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -599,7 +599,7 @@ describe "Config", ->
 
           expect(CSON.writeFileSync.argsForCall[0][0]).toBe atom.config.configFilePath
           writtenConfig = CSON.writeFileSync.argsForCall[0][1]
-          expect(writtenConfig).toEqual global: atom.config.settings
+          expect(writtenConfig).toEqual '*': atom.config.settings
 
       describe "when ~/.atom/config.json doesn't exist", ->
         it "writes any non-default properties to ~/.atom/config.cson", ->
@@ -613,7 +613,7 @@ describe "Config", ->
 
           expect(CSON.writeFileSync.argsForCall[0][0]).toBe path.join(atom.config.configDirPath, "atom.config.cson")
           writtenConfig = CSON.writeFileSync.argsForCall[0][1]
-          expect(writtenConfig).toEqual global: atom.config.settings
+          expect(writtenConfig).toEqual '*': atom.config.settings
 
       describe "when scoped settings are defined", ->
         it 'writes out explicitly set config settings', ->
@@ -626,7 +626,7 @@ describe "Config", ->
 
           writtenConfig = CSON.writeFileSync.argsForCall[0][1]
           expect(writtenConfig).toEqualJson
-            global:
+            '*':
               atom.config.settings
             '.ruby.source':
               foo:
@@ -655,7 +655,7 @@ describe "Config", ->
       describe "when the config file contains scoped settings", ->
         beforeEach ->
           fs.writeFileSync atom.config.configFilePath, """
-            global:
+            '*':
               foo:
                 bar: 'baz'
 
@@ -752,7 +752,7 @@ describe "Config", ->
 
         expect(fs.existsSync(atom.config.configDirPath)).toBeFalsy()
         fs.writeFileSync atom.config.configFilePath, """
-          global:
+          '*':
             foo:
               bar: 'baz'
               scoped: false
@@ -817,7 +817,7 @@ describe "Config", ->
             atom.config.onDidChange('foo.scoped', scope: ['.source.ruby'], scopedSpy)
 
             writeConfigFile """
-              global:
+              '*':
                 foo:
                   scoped: false
             """
@@ -832,7 +832,7 @@ describe "Config", ->
             atom.config.onDidChange('foo.scoped', scope: ['.source.ruby'], noChangeSpy)
 
             writeConfigFile """
-              global:
+              '*':
                 foo:
                   bar: 'baz'
               '.source.ruby':

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -837,7 +837,7 @@ class Config
     console.error detail
 
   save: ->
-    allSettings = global: @settings
+    allSettings = {'*': @settings}
     allSettings = _.extend allSettings, @scopedSettingsStore.propertiesForSource(@getUserConfigPath())
     CSON.writeFileSync(@configFilePath, allSettings)
 
@@ -852,9 +852,13 @@ class Config
       return
 
     if newSettings.global?
+      newSettings['*'] = newSettings.global
+      delete newSettings.global
+
+    if newSettings['*']?
       scopedSettings = newSettings
-      newSettings = newSettings.global
-      delete scopedSettings.global
+      newSettings = newSettings['*']
+      delete scopedSettings['*']
       @resetUserScopedSettings(scopedSettings)
 
     @transact =>


### PR DESCRIPTION
Our scoped settings system is based on the idea that all settings get associated with a selector. In light of this, the `global` key is idiosyncratic. We should just use the standard global selector, `*`, which is what we actually use in the scoped properties store.
