### PR TITLE
Don't write the config to disk so darn often

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -9,6 +9,8 @@ describe "Config", ->
 
   beforeEach ->
     dotAtomPath = temp.path('dot-atom-dir')
+    atom.config.configDirPath = dotAtomPath
+    atom.config.configFilePath = path.join(atom.config.configDirPath, "atom.config.cson")
 
   describe ".get(keyPath, {scope, sources, excludeSources})", ->
     it "allows a key path's value to be read", ->
@@ -553,7 +555,6 @@ describe "Config", ->
 
       describe "when ~/.atom/config.json exists", ->
         it "writes any non-default properties to ~/.atom/config.json", ->
-          atom.config.configFilePath = path.join(atom.config.configDirPath, "atom.config.json")
           atom.config.set("a.b.c", 1)
           atom.config.set("a.b.d", 2)
           atom.config.set("x.y.z", 3)
@@ -562,13 +563,12 @@ describe "Config", ->
           CSON.writeFileSync.reset()
           atom.config.save()
 
-          expect(CSON.writeFileSync.argsForCall[0][0]).toBe path.join(atom.config.configDirPath, "atom.config.json")
+          expect(CSON.writeFileSync.argsForCall[0][0]).toBe atom.config.configFilePath
           writtenConfig = CSON.writeFileSync.argsForCall[0][1]
           expect(writtenConfig).toEqual global: atom.config.settings
 
       describe "when ~/.atom/config.json doesn't exist", ->
         it "writes any non-default properties to ~/.atom/config.cson", ->
-          atom.config.configFilePath = path.join(atom.config.configDirPath, "atom.config.cson")
           atom.config.set("a.b.c", 1)
           atom.config.set("a.b.d", 2)
           atom.config.set("x.y.z", 3)
@@ -604,8 +604,6 @@ describe "Config", ->
 
     describe ".loadUserConfig()", ->
       beforeEach ->
-        atom.config.configDirPath = dotAtomPath
-        atom.config.configFilePath = path.join(atom.config.configDirPath, "atom.config.cson")
         expect(fs.existsSync(atom.config.configDirPath)).toBeFalsy()
         atom.config.setSchema 'foo',
           type: 'object'
@@ -709,8 +707,6 @@ describe "Config", ->
               type: 'integer'
               default: 12
 
-        atom.config.configDirPath = dotAtomPath
-        atom.config.configFilePath = path.join(atom.config.configDirPath, "atom.config.cson")
         expect(fs.existsSync(atom.config.configDirPath)).toBeFalsy()
         fs.writeFileSync atom.config.configFilePath, """
           global:

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -110,6 +110,10 @@ describe "Config", ->
       expect(atom.config.save).toHaveBeenCalled()
       expect(observeHandler).toHaveBeenCalledWith 42
 
+    it "does not save when a non-default 'source' is given", ->
+      atom.config.set("foo.bar.baz", 42, source: 'some-other-source', scopeSelector: '.a')
+      expect(atom.config.save).not.toHaveBeenCalled()
+
     it "does not allow a 'source' option without a 'scopeSelector'", ->
       expect(-> atom.config.set("foo", 1, source: [".source.ruby"])).toThrow()
 

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -102,18 +102,20 @@ describe "Config", ->
       expect(atom.config.set("foo.bar.baz", 42)).toBe true
       expect(atom.config.get("foo.bar.baz")).toBe 42
 
-    it "updates observers and saves when a key path is set", ->
-      observeHandler = jasmine.createSpy "observeHandler"
-      atom.config.observe "foo.bar.baz", observeHandler
-      observeHandler.reset()
-
+    it "saves the user's config to disk after it stops changing", ->
       atom.config.set("foo.bar.baz", 42)
-
+      advanceClock(50)
+      expect(atom.config.save).not.toHaveBeenCalled()
+      atom.config.set("foo.bar.baz", 43)
+      advanceClock(50)
+      expect(atom.config.save).not.toHaveBeenCalled()
+      atom.config.set("foo.bar.baz", 44)
+      advanceClock(150)
       expect(atom.config.save).toHaveBeenCalled()
-      expect(observeHandler).toHaveBeenCalledWith 42
 
     it "does not save when a non-default 'source' is given", ->
       atom.config.set("foo.bar.baz", 42, source: 'some-other-source', scopeSelector: '.a')
+      advanceClock(500)
       expect(atom.config.save).not.toHaveBeenCalled()
 
     it "does not allow a 'source' option without a 'scopeSelector'", ->
@@ -197,6 +199,7 @@ describe "Config", ->
       atom.config.save.reset()
 
       atom.config.unset('a.c')
+      advanceClock(500)
       expect(atom.config.save.callCount).toBe 1
 
     describe "when a 'source' and no 'scopeSelector' is given", ->
@@ -234,6 +237,7 @@ describe "Config", ->
         atom.config.save.reset()
 
         atom.config.unset('foo.bar.baz', scopeSelector: '.source.coffee')
+        advanceClock(150)
         expect(atom.config.save.callCount).toBe 1
 
       it "allows removing settings for a specific source and scope selector", ->
@@ -267,26 +271,32 @@ describe "Config", ->
 
       it "removes the scoped value when it was the only set value on the object", ->
         spyOn(CSON, 'writeFileSync')
-        jasmine.unspy atom.config, 'save'
+        atom.config.save.andCallThrough()
 
         atom.config.setDefaults("foo", bar: baz: 10)
         atom.config.set('foo.bar.baz', 55, scopeSelector: '.source.coffee')
         atom.config.set('foo.bar.ok', 20, scopeSelector: '.source.coffee')
-        CSON.writeFileSync.reset()
         expect(atom.config.get('foo.bar.baz', scope: ['.source.coffee'])).toBe 55
+
+        advanceClock(150)
+        CSON.writeFileSync.reset()
 
         atom.config.unset('foo.bar.baz', scopeSelector: '.source.coffee')
         expect(atom.config.get('foo.bar.baz', scope: ['.source.coffee'])).toBe 10
         expect(atom.config.get('foo.bar.ok', scope: ['.source.coffee'])).toBe 20
+
+        advanceClock(150)
         expect(CSON.writeFileSync).toHaveBeenCalled()
         properties = CSON.writeFileSync.mostRecentCall.args[1]
         expect(properties['.coffee.source']).toEqual
           foo:
             bar:
               ok: 20
-
         CSON.writeFileSync.reset()
+
         atom.config.unset('foo.bar.ok', scopeSelector: '.source.coffee')
+
+        advanceClock(150)
         expect(CSON.writeFileSync).toHaveBeenCalled()
         properties = CSON.writeFileSync.mostRecentCall.args[1]
         expect(properties['.coffee.source']).toBeUndefined()
@@ -692,6 +702,15 @@ describe "Config", ->
     describe ".observeUserConfig()", ->
       updatedHandler = null
 
+      writeConfigFile = (data) ->
+        previousSetTimeoutCallCount = setTimeout.callCount
+        runs ->
+          fs.writeFileSync(atom.config.configFilePath, data)
+        waitsFor "debounced config file load", ->
+          setTimeout.callCount > previousSetTimeoutCallCount
+        runs ->
+          advanceClock(1000)
+
       beforeEach ->
         atom.config.setSchema 'foo',
           type: 'object'
@@ -728,7 +747,7 @@ describe "Config", ->
 
       describe "when the config file changes to contain valid cson", ->
         it "updates the config data", ->
-          fs.writeFileSync(atom.config.configFilePath, "foo: { bar: 'quux', baz: 'bar'}")
+          writeConfigFile("foo: { bar: 'quux', baz: 'bar'}")
           waitsFor 'update event', -> updatedHandler.callCount > 0
           runs ->
             expect(atom.config.get('foo.bar')).toBe 'quux'
@@ -737,8 +756,9 @@ describe "Config", ->
         it "does not fire a change event for paths that did not change", ->
           atom.config.onDidChange 'foo.bar', noChangeSpy = jasmine.createSpy()
 
-          fs.writeFileSync(atom.config.configFilePath, "foo: { bar: 'baz', baz: 'ok'}")
+          writeConfigFile("foo: { bar: 'baz', baz: 'ok'}")
           waitsFor 'update event', -> updatedHandler.callCount > 0
+
           runs ->
             expect(noChangeSpy).not.toHaveBeenCalled()
             expect(atom.config.get('foo.bar')).toBe 'baz'
@@ -750,7 +770,8 @@ describe "Config", ->
               type: 'array'
               items:
                 type: 'string'
-            fs.writeFileSync(atom.config.configFilePath, "foo: { bar: ['baz', 'ok']}")
+
+            writeConfigFile("foo: { bar: ['baz', 'ok']}")
             waitsFor 'update event', -> updatedHandler.callCount > 0
             runs -> updatedHandler.reset()
 
@@ -758,8 +779,9 @@ describe "Config", ->
             noChangeSpy = jasmine.createSpy()
             atom.config.onDidChange('foo.bar', noChangeSpy)
 
-            fs.writeFileSync(atom.config.configFilePath, "foo: { bar: ['baz', 'ok'], baz: 'another'}")
+            writeConfigFile("foo: { bar: ['baz', 'ok'], baz: 'another'}")
             waitsFor 'update event', -> updatedHandler.callCount > 0
+
             runs ->
               expect(noChangeSpy).not.toHaveBeenCalled()
               expect(atom.config.get('foo.bar')).toEqual ['baz', 'ok']
@@ -770,12 +792,13 @@ describe "Config", ->
             scopedSpy = jasmine.createSpy()
             atom.config.onDidChange('foo.scoped', scope: ['.source.ruby'], scopedSpy)
 
-            fs.writeFileSync atom.config.configFilePath, """
+            writeConfigFile """
               global:
                 foo:
                   scoped: false
             """
             waitsFor 'update event', -> updatedHandler.callCount > 0
+
             runs ->
               expect(scopedSpy).toHaveBeenCalled()
               expect(atom.config.get('foo.scoped', scope: ['.source.ruby'])).toBe false
@@ -784,7 +807,7 @@ describe "Config", ->
             noChangeSpy = jasmine.createSpy()
             atom.config.onDidChange('foo.scoped', scope: ['.source.ruby'], noChangeSpy)
 
-            fs.writeFileSync atom.config.configFilePath, """
+            writeConfigFile """
               global:
                 foo:
                   bar: 'baz'
@@ -793,6 +816,7 @@ describe "Config", ->
                   scoped: true
             """
             waitsFor 'update event', -> updatedHandler.callCount > 0
+
             runs ->
               expect(noChangeSpy).not.toHaveBeenCalled()
               expect(atom.config.get('foo.bar', scope: ['.source.ruby'])).toBe 'baz'
@@ -800,7 +824,7 @@ describe "Config", ->
 
       describe "when the config file changes to omit a setting with a default", ->
         it "resets the setting back to the default", ->
-          fs.writeFileSync(atom.config.configFilePath, "foo: { baz: 'new'}")
+          writeConfigFile("foo: { baz: 'new'}")
           waitsFor 'update event', -> updatedHandler.callCount > 0
           runs ->
             expect(atom.config.get('foo.bar')).toBe 'def'
@@ -808,19 +832,20 @@ describe "Config", ->
 
       describe "when the config file changes to be empty", ->
         beforeEach ->
-          fs.writeFileSync(atom.config.configFilePath, "")
+          writeConfigFile("")
           waitsFor 'update event', -> updatedHandler.callCount > 0
 
         it "resets all settings back to the defaults", ->
           expect(updatedHandler.callCount).toBe 1
           expect(atom.config.get('foo.bar')).toBe 'def'
           atom.config.set("hair", "blonde") # trigger a save
+          advanceClock(500)
           expect(atom.config.save).toHaveBeenCalled()
 
         describe "when the config file subsequently changes again to contain configuration", ->
           beforeEach ->
             updatedHandler.reset()
-            fs.writeFileSync(atom.config.configFilePath, "foo: bar: 'newVal'")
+            writeConfigFile("foo: bar: 'newVal'")
             waitsFor 'update event', -> updatedHandler.callCount > 0
 
           it "sets the setting to the value specified in the config file", ->
@@ -829,7 +854,7 @@ describe "Config", ->
       describe "when the config file changes to contain invalid cson", ->
         beforeEach ->
           spyOn(console, 'error')
-          fs.writeFileSync(atom.config.configFilePath, "}}}")
+          writeConfigFile("}}}")
           waitsFor "error to be logged", -> console.error.callCount > 0
 
         it "logs a warning and does not update config data", ->
@@ -840,11 +865,12 @@ describe "Config", ->
 
         describe "when the config file subsequently changes again to contain valid cson", ->
           beforeEach ->
-            fs.writeFileSync(atom.config.configFilePath, "foo: bar: 'newVal'")
+            writeConfigFile("foo: bar: 'newVal'")
             waitsFor 'update event', -> updatedHandler.callCount > 0
 
           it "updates the config data and resumes saving", ->
             atom.config.set("hair", "blonde")
+            advanceClock(500)
             expect(atom.config.save).toHaveBeenCalled()
 
     describe ".initializeConfigDirectory()", ->

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -106,9 +106,9 @@ beforeEach ->
   spyOn(atom.menu, 'sendToBrowserProcess')
 
   # reset config before each spec; don't load or save from/to `config.json`
+  spyOn(Config::, 'load')
+  spyOn(Config::, 'save')
   config = new Config({resourcePath, configDirPath: atom.getConfigDirPath()})
-  spyOn(config, 'load')
-  spyOn(config, 'save')
   atom.config = config
   atom.loadConfig()
   config.set "core.destroyEmptyPanes", false
@@ -118,6 +118,7 @@ beforeEach ->
   config.set "core.disabledPackages", ["package-that-throws-an-exception",
     "package-with-broken-package-json", "package-with-broken-keymap"]
   config.set "editor.useShadowDOM", true
+  advanceClock(1000)
   config.load.reset()
   config.save.reset()
 

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -84,6 +84,10 @@ beforeEach ->
   atom.workspaceViewParentSelector = '#jasmine-content'
 
   window.resetTimeouts()
+  spyOn(_._, "now").andCallFake -> window.now
+  spyOn(window, "setTimeout").andCallFake window.fakeSetTimeout
+  spyOn(window, "clearTimeout").andCallFake window.fakeClearTimeout
+
   atom.packages.packageStates = {}
 
   serializedWindowState = null
@@ -121,8 +125,6 @@ beforeEach ->
   TextEditorElement::setUpdatedSynchronously(true)
 
   spyOn(atom, "setRepresentedFilename")
-  spyOn(window, "setTimeout").andCallFake window.fakeSetTimeout
-  spyOn(window, "clearTimeout").andCallFake window.fakeClearTimeout
   spyOn(pathwatcher.File.prototype, "detectResurrectionAfterDelay").andCallFake -> @detectResurrection()
   spyOn(TextEditor.prototype, "shouldPromptToSave").andReturn false
 

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -755,7 +755,6 @@ describe "TextEditorComponent", ->
       expect(cursorNode.offsetWidth).toBe charWidth
 
     it "blinks cursors when they aren't moving", ->
-      spyOn(_._, 'now').andCallFake -> window.now # Ensure _.debounce is based on our fake spec timeline
       cursorsNode = componentNode.querySelector('.cursors')
 
       expect(cursorsNode.classList.contains('blink-off')).toBe false
@@ -2048,8 +2047,6 @@ describe "TextEditorComponent", ->
         expect(component.mouseWheelScreenRow).toBe null
 
       it "clears the mouseWheelScreenRow after a delay even if the event does not cause scrolling", ->
-        spyOn(_._, 'now').andCallFake -> window.now # Ensure _.debounce is based on our fake spec timeline
-
         expect(editor.getScrollTop()).toBe 0
 
         lineNode = componentNode.querySelector('.line')

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -548,6 +548,7 @@ class Config
       [keyPath, value, options] = arguments
       scopeSelector = options?.scopeSelector
       source = options?.source
+      shouldSave = options?.save ? true
 
     if source and not scopeSelector
       throw new Error("::set with a 'source' and no 'sourceSelector' is not yet implemented!")
@@ -565,7 +566,7 @@ class Config
     else
       @setRawValue(keyPath, value)
 
-    @save() unless @configFileHasErrors or options?.save is false
+    @save() if source is @getUserConfigPath() and shouldSave and not @configFileHasErrors
     true
 
   # Essential: Restore the setting at `keyPath` to its default value.


### PR DESCRIPTION
Two problems:
- When we started using `Config::set` for all settings (rather than `::addScopedProperties` et al), we accidentally introduced a lot more writes of the config to disk, particularly when initially loading packages. We shouldn't be saving the user's config to disk when we're using a `source` other than the user's config file.
- The settings-view calls `::set` _a lot_. This ought to be ok. We don't need to synchronously save the config every time set is called. We should throttle the writes.

Fixes #4770.
