### PR TITLE
Fix LanguageMode::foldAllAtIndentLevel

### DIFF
--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -381,6 +381,23 @@ describe "LanguageMode", ->
         expect(languageMode.isFoldableAtBufferRow(3)).toBe false
         expect(languageMode.isFoldableAtBufferRow(4)).toBe true
 
+    describe ".foldAllAtIndentLevel(indentLevel)", ->
+      it "folds blocks of text at the given indentation level", ->
+        languageMode.foldAllAtIndentLevel(0)
+        expect(editor.lineTextForScreenRow(0)).toBe "var quicksort = function () {"
+        expect(editor.getLastScreenRow()).toBe 0
+
+        languageMode.foldAllAtIndentLevel(1)
+        expect(editor.lineTextForScreenRow(0)).toBe "var quicksort = function () {"
+        expect(editor.lineTextForScreenRow(1)).toBe "  var sort = function(items) {"
+        expect(editor.getLastScreenRow()).toBe 4
+
+        languageMode.foldAllAtIndentLevel(2)
+        expect(editor.lineTextForScreenRow(0)).toBe "var quicksort = function () {"
+        expect(editor.lineTextForScreenRow(1)).toBe "  var sort = function(items) {"
+        expect(editor.lineTextForScreenRow(2)).toBe "    if (items.length <= 1) return items;"
+        expect(editor.getLastScreenRow()).toBe 9
+
   describe "folding with comments", ->
     beforeEach ->
       waitsForPromise ->

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -113,6 +113,7 @@ class LanguageMode
   #
   # indentLevel - A {Number} indicating indentLevel; 0 based.
   foldAllAtIndentLevel: (indentLevel) ->
+    @unfoldAll()
     for currentRow in [0..@buffer.getLastRow()]
       [startRow, endRow] = @rowRangeForFoldAtBufferRow(currentRow) ? []
       continue unless startRow?


### PR DESCRIPTION
Currently, after folding at indent level `n`, folding at any indent level > `n` doesn't work. This fixes that.
