### PR TITLE
Use 'priority' to correctly order style sheets rather than 'group'

### DIFF
--- a/spec/style-manager-spec.coffee
+++ b/spec/style-manager-spec.coffee
@@ -53,29 +53,6 @@ describe "StyleManager", ->
         expect(addEvents[0].getAttribute('source-path')).toBe '/foo/bar'
         expect(addEvents[0].textContent).toBe "a {color: yellow;}"
 
-    describe "when a group parameter is specified", ->
-      it "inserts the stylesheet at the end of any existing stylesheets for the same group", ->
-        manager.addStyleSheet("a {color: red}", group: 'a')
-        manager.addStyleSheet("a {color: blue}", group: 'b')
-        manager.addStyleSheet("a {color: green}", group: 'a')
-
-        expect(manager.getStyleElements().map (elt) -> elt.textContent).toEqual [
-          "a {color: red}"
-          "a {color: green}"
-          "a {color: blue}"
-        ]
-
-      it "assigns priorities to 'bundled', 'theme', and 'user' groups that place them in the proper order", ->
-        manager.addStyleSheet("a {color: red}", group: 'user')
-        manager.addStyleSheet("a {color: blue}", group: 'bundled')
-        manager.addStyleSheet("a {color: green}", group: 'theme')
-
-        expect(manager.getStyleElements().map (elt) -> elt.textContent).toEqual [
-          "a {color: blue}"
-          "a {color: green}"
-          "a {color: red}"
-        ]
-
     describe "when a priority parameter is specified", ->
       it "inserts the style sheet based on the priority", ->
         manager.addStyleSheet("a {color: red}", priority: 1)

--- a/spec/style-manager-spec.coffee
+++ b/spec/style-manager-spec.coffee
@@ -65,6 +65,17 @@ describe "StyleManager", ->
           "a {color: blue}"
         ]
 
+      it "assigns priorities to 'bundled', 'theme', and 'user' groups that place them in the proper order", ->
+        manager.addStyleSheet("a {color: red}", group: 'user')
+        manager.addStyleSheet("a {color: blue}", group: 'bundled')
+        manager.addStyleSheet("a {color: green}", group: 'theme')
+
+        expect(manager.getStyleElements().map (elt) -> elt.textContent).toEqual [
+          "a {color: blue}"
+          "a {color: green}"
+          "a {color: red}"
+        ]
+
     describe "when a priority parameter is specified", ->
       it "inserts the style sheet based on the priority", ->
         manager.addStyleSheet("a {color: red}", priority: 1)

--- a/spec/style-manager-spec.coffee
+++ b/spec/style-manager-spec.coffee
@@ -64,3 +64,17 @@ describe "StyleManager", ->
           "a {color: green}"
           "a {color: blue}"
         ]
+
+    describe "when a priority parameter is specified", ->
+      it "inserts the style sheet based on the priority", ->
+        manager.addStyleSheet("a {color: red}", priority: 1)
+        manager.addStyleSheet("a {color: blue}", priority: 0)
+        manager.addStyleSheet("a {color: green}", priority: 2)
+        manager.addStyleSheet("a {color: yellow}", priority: 1)
+
+        expect(manager.getStyleElements().map (elt) -> elt.textContent).toEqual [
+          "a {color: blue}"
+          "a {color: red}"
+          "a {color: yellow}"
+          "a {color: green}"
+        ]

--- a/spec/styles-element-spec.coffee
+++ b/spec/styles-element-spec.coffee
@@ -45,17 +45,6 @@ describe "StylesElement", ->
     expect(element.children[initialChildCount + 2].textContent).toBe "a {color: yellow}"
     expect(element.children[initialChildCount + 3].textContent).toBe "a {color: green}"
 
-  it "orders style elements by group", ->
-    initialChildCount = element.children.length
-
-    atom.styles.addStyleSheet("a {color: red}", group: 'a')
-    atom.styles.addStyleSheet("a {color: blue}", group: 'b')
-    atom.styles.addStyleSheet("a {color: green}", group: 'a')
-
-    expect(element.children[initialChildCount].textContent).toBe "a {color: red}"
-    expect(element.children[initialChildCount + 1].textContent).toBe "a {color: green}"
-    expect(element.children[initialChildCount + 2].textContent).toBe "a {color: blue}"
-
   it "updates existing style nodes when style elements are updated", ->
     initialChildCount = element.children.length
 

--- a/spec/styles-element-spec.coffee
+++ b/spec/styles-element-spec.coffee
@@ -32,6 +32,19 @@ describe "StylesElement", ->
     expect(element.children[initialChildCount].textContent).toBe "a {color: blue;}"
     expect(removedStyleElements).toEqual [addedStyleElements[0]]
 
+  it "orders style elements by priority", ->
+    initialChildCount = element.children.length
+
+    atom.styles.addStyleSheet("a {color: red}", priority: 1)
+    atom.styles.addStyleSheet("a {color: blue}", priority: 0)
+    atom.styles.addStyleSheet("a {color: green}", priority: 2)
+    atom.styles.addStyleSheet("a {color: yellow}", priority: 1)
+
+    expect(element.children[initialChildCount].textContent).toBe "a {color: blue}"
+    expect(element.children[initialChildCount + 1].textContent).toBe "a {color: red}"
+    expect(element.children[initialChildCount + 2].textContent).toBe "a {color: yellow}"
+    expect(element.children[initialChildCount + 3].textContent).toBe "a {color: green}"
+
   it "orders style elements by group", ->
     initialChildCount = element.children.length
 

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -96,8 +96,8 @@ describe "ThemeManager", ->
 
       runs ->
         reloadHandler.reset()
-        expect($('style[group=theme]')).toHaveLength 2
-        expect($('style[group=theme]:eq(0)').attr('source-path')).toMatch /atom-dark-ui/
+        expect($('style[priority=1]')).toHaveLength 2
+        expect($('style[priority=1]:eq(0)').attr('source-path')).toMatch /atom-dark-ui/
         atom.config.set('core.themes', ['atom-light-ui', 'atom-dark-ui'])
 
       waitsFor ->
@@ -105,9 +105,9 @@ describe "ThemeManager", ->
 
       runs ->
         reloadHandler.reset()
-        expect($('style[group=theme]')).toHaveLength 2
-        expect($('style[group=theme]:eq(0)').attr('source-path')).toMatch /atom-dark-ui/
-        expect($('style[group=theme]:eq(1)').attr('source-path')).toMatch /atom-light-ui/
+        expect($('style[priority=1]')).toHaveLength 2
+        expect($('style[priority=1]:eq(0)').attr('source-path')).toMatch /atom-dark-ui/
+        expect($('style[priority=1]:eq(1)').attr('source-path')).toMatch /atom-light-ui/
         atom.config.set('core.themes', [])
 
       waitsFor ->
@@ -115,7 +115,7 @@ describe "ThemeManager", ->
 
       runs ->
         reloadHandler.reset()
-        expect($('style[group=theme]')).toHaveLength 2
+        expect($('style[priority=1]')).toHaveLength 2
         # atom-dark-ui has an directory path, the syntax one doesn't
         atom.config.set('core.themes', ['theme-with-index-less', 'atom-dark-ui'])
 
@@ -123,7 +123,7 @@ describe "ThemeManager", ->
         reloadHandler.callCount == 1
 
       runs ->
-        expect($('style[group=theme]')).toHaveLength 2
+        expect($('style[priority=1]')).toHaveLength 2
         importPaths = themeManager.getImportPaths()
         expect(importPaths.length).toBe 1
         expect(importPaths[0]).toContain 'atom-dark-ui'

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -109,7 +109,7 @@ class Package
 
   getType: -> 'atom'
 
-  getStylesheetType: -> 'bundled'
+  getStyleSheetPriority: -> 0
 
   load: ->
     @measure 'loadTime', =>
@@ -175,8 +175,9 @@ class Package
   activateStylesheets: ->
     return if @stylesheetsActivated
 
-    group = @getStylesheetType()
     @stylesheetDisposables = new CompositeDisposable
+
+    priority = @getStyleSheetPriority()
     for [sourcePath, source] in @stylesheets
       if match = path.basename(sourcePath).match(/[^.]*\.([^.]*)\./)
         context = match[1]
@@ -185,7 +186,7 @@ class Package
       else
         context = undefined
 
-      @stylesheetDisposables.add(atom.styles.addStyleSheet(source, {sourcePath, group, context}))
+      @stylesheetDisposables.add(atom.styles.addStyleSheet(source, {sourcePath, priority, context}))
     @stylesheetsActivated = true
 
   activateResources: ->

--- a/src/style-manager.coffee
+++ b/src/style-manager.coffee
@@ -92,12 +92,7 @@ class StyleManager
   addStyleSheet: (source, params) ->
     sourcePath = params?.sourcePath
     context = params?.context
-    group = params?.group
-    priority = params?.priority ?
-      switch group
-        when 'bundled' then 0
-        when 'theme' then 1
-        when 'user' then 2
+    priority = params?.priority
 
     if sourcePath? and styleElement = @styleElementsBySourcePath[sourcePath]
       updated = true
@@ -110,10 +105,6 @@ class StyleManager
       if context?
         styleElement.context = context
         styleElement.setAttribute('context', context)
-
-      if group?
-        styleElement.group = group
-        styleElement.setAttribute('group', group)
 
       if priority?
         styleElement.priority = priority
@@ -129,14 +120,7 @@ class StyleManager
     new Disposable => @removeStyleElement(styleElement)
 
   addStyleElement: (styleElement) ->
-    {sourcePath, group, priority} = styleElement
-
-    if group?
-      for existingElement, index in @styleElements
-        if existingElement.group is group
-          insertIndex = index + 1
-        else
-          break if insertIndex?
+    {sourcePath, priority} = styleElement
 
     if priority?
       for existingElement, index in @styleElements

--- a/src/style-manager.coffee
+++ b/src/style-manager.coffee
@@ -93,7 +93,11 @@ class StyleManager
     sourcePath = params?.sourcePath
     context = params?.context
     group = params?.group
-    priority = params?.priority
+    priority = params?.priority ?
+      switch group
+        when 'bundled' then 0
+        when 'theme' then 1
+        when 'user' then 2
 
     if sourcePath? and styleElement = @styleElementsBySourcePath[sourcePath]
       updated = true

--- a/src/style-manager.coffee
+++ b/src/style-manager.coffee
@@ -125,7 +125,7 @@ class StyleManager
     new Disposable => @removeStyleElement(styleElement)
 
   addStyleElement: (styleElement) ->
-    {sourcePath, group} = styleElement
+    {sourcePath, group, priority} = styleElement
 
     if group?
       for existingElement, index in @styleElements
@@ -133,6 +133,13 @@ class StyleManager
           insertIndex = index + 1
         else
           break if insertIndex?
+
+    if priority?
+      for existingElement, index in @styleElements
+        if existingElement.priority > priority
+          insertIndex = index
+          break
+
     insertIndex ?= @styleElements.length
 
     @styleElements.splice(insertIndex, 0, styleElement)

--- a/src/style-manager.coffee
+++ b/src/style-manager.coffee
@@ -93,6 +93,7 @@ class StyleManager
     sourcePath = params?.sourcePath
     context = params?.context
     group = params?.group
+    priority = params?.priority
 
     if sourcePath? and styleElement = @styleElementsBySourcePath[sourcePath]
       updated = true
@@ -109,6 +110,10 @@ class StyleManager
       if group?
         styleElement.group = group
         styleElement.setAttribute('group', group)
+
+      if priority?
+        styleElement.priority = priority
+        styleElement.setAttribute('priority', priority)
 
     styleElement.textContent = source
 

--- a/src/styles-element.coffee
+++ b/src/styles-element.coffee
@@ -56,13 +56,6 @@ class StylesElement extends HTMLElement
     styleElementClone.priority = styleElement.priority
     @styleElementClonesByOriginalElement.set(styleElement, styleElementClone)
 
-    group = styleElement.getAttribute('group')
-    if group?
-      for child in @children
-        if child.getAttribute('group') is group and child.nextSibling?.getAttribute('group') isnt group
-          insertBefore = child.nextSibling
-          break
-
     priority = styleElement.priority
     if priority?
       for child in @children

--- a/src/styles-element.coffee
+++ b/src/styles-element.coffee
@@ -53,6 +53,7 @@ class StylesElement extends HTMLElement
     styleElementClone = styleElement.cloneNode(true)
     styleElementClone.sourcePath = styleElement.sourcePath
     styleElementClone.context = styleElement.context
+    styleElementClone.priority = styleElement.priority
     @styleElementClonesByOriginalElement.set(styleElement, styleElementClone)
 
     group = styleElement.getAttribute('group')
@@ -60,6 +61,13 @@ class StylesElement extends HTMLElement
       for child in @children
         if child.getAttribute('group') is group and child.nextSibling?.getAttribute('group') isnt group
           insertBefore = child.nextSibling
+          break
+
+    priority = styleElement.priority
+    if priority?
+      for child in @children
+        if child.priority > priority
+          insertBefore = child
           break
 
     @insertBefore(styleElementClone, insertBefore)

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -240,7 +240,7 @@ class ThemeManager
     @userStylesheetFile = new File(userStylesheetPath)
     @userStylesheetFile.on 'contents-changed moved removed', => @loadUserStylesheet()
     userStylesheetContents = @loadStylesheet(userStylesheetPath, true)
-    @applyStylesheet(userStylesheetPath, userStylesheetContents, 'userTheme')
+    @applyStylesheet(userStylesheetPath, userStylesheetContents, 'user')
 
   loadBaseStylesheets: ->
     @requireStylesheet('../static/bootstrap')

--- a/src/theme-package.coffee
+++ b/src/theme-package.coffee
@@ -5,7 +5,7 @@ module.exports =
 class ThemePackage extends Package
   getType: -> 'theme'
 
-  getStylesheetType: -> 'theme'
+  getStyleSheetPriority: -> 1
 
   enable: ->
     atom.config.unshiftAtKeyPath('core.themes', @name)


### PR DESCRIPTION
The `group` parameter was previously used to ensure style sheets from core, packages, themes, and the user's `.atom` directory cascaded in the correct order. The weakness with this approach is that it depended on the load order of the first style sheet from each group. This caused a bug where the context-targeted style sheets for atom-text-editor would get out of order with the bundled style sheets coming _after_ the theme style sheets, causing the bracket matcher styling to be wrong. Using numbers explicitly ensures that style sheets always land in the expected order. Floating point values can be used at a later point to precisely position style sheets into the cascade if desired. I did a full scan of all packages and did not detect a dependency on the grouping API, which is private anyway.
