### PR TITLE
Fold comment with empty line inside of it (Fix #4140)

### DIFF
--- a/spec/fixtures/sample-with-comments.js
+++ b/spec/fixtures/sample-with-comments.js
@@ -9,10 +9,21 @@ var quicksort = function () {
     // Wowza
     if (items.length <= 1) return items;
     var pivot = items.shift(), current, left = [], right = [];
+    /*
+      This is a multiline comment block with
+      an empty line inside of it.
+
+      Awesome.
+    */
     while(items.length > 0) {
       current = items.shift();
       current < pivot ? left.push(current) : right.push(current);
     }
+    // This is a collection of
+    // single line comments
+
+    // ...with an empty line
+    // among it, geez!
     return sort(left).concat(pivot).concat(sort(right));
   };
   // this is a single-line comment

--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -1,4 +1,4 @@
-fdescribe "LanguageMode", ->
+describe "LanguageMode", ->
   [editor, buffer, languageMode] = []
 
   afterEach ->

--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -1,4 +1,4 @@
-describe "LanguageMode", ->
+fdescribe "LanguageMode", ->
   [editor, buffer, languageMode] = []
 
   afterEach ->
@@ -418,7 +418,7 @@ describe "LanguageMode", ->
         languageMode.foldAll()
 
         fold1 = editor.tokenizedLineForScreenRow(0).fold
-        expect([fold1.getStartRow(), fold1.getEndRow()]).toEqual [0, 19]
+        expect([fold1.getStartRow(), fold1.getEndRow()]).toEqual [0, 30]
         fold1.destroy()
 
         fold2 = editor.tokenizedLineForScreenRow(1).fold
@@ -429,6 +429,14 @@ describe "LanguageMode", ->
         fold4 = editor.tokenizedLineForScreenRow(3).fold
         expect([fold4.getStartRow(), fold4.getEndRow()]).toEqual [6, 8]
 
+        fold5 = editor.tokenizedLineForScreenRow(6).fold
+        expect([fold5.getStartRow(), fold5.getEndRow()]).toEqual [11, 16]
+        fold5.destroy();
+
+        fold6 = editor.tokenizedLineForScreenRow(13).fold
+        expect([fold6.getStartRow(), fold6.getEndRow()]).toEqual [21, 22]
+        fold6.destroy();
+
     describe ".foldAllAtIndentLevel()", ->
       it "folds every foldable range at a given indentLevel", ->
         languageMode.foldAllAtIndentLevel(2)
@@ -438,14 +446,26 @@ describe "LanguageMode", ->
         fold1.destroy()
 
         fold2 = editor.tokenizedLineForScreenRow(11).fold
-        expect([fold2.getStartRow(), fold2.getEndRow()]).toEqual [11, 14]
+        expect([fold2.getStartRow(), fold2.getEndRow()]).toEqual [11, 16]
         fold2.destroy()
+
+        fold3 = editor.tokenizedLineForScreenRow(17).fold
+        expect([fold3.getStartRow(), fold3.getEndRow()]).toEqual [17, 20]
+        fold3.destroy()
+
+        fold4 = editor.tokenizedLineForScreenRow(21).fold
+        expect([fold4.getStartRow(), fold4.getEndRow()]).toEqual [21, 22]
+        fold4.destroy()
+
+        fold5 = editor.tokenizedLineForScreenRow(24).fold
+        expect([fold5.getStartRow(), fold5.getEndRow()]).toEqual [24, 25]
+        fold5.destroy()
 
       it "does not fold anything but the indentLevel", ->
         languageMode.foldAllAtIndentLevel(0)
 
         fold1 = editor.tokenizedLineForScreenRow(0).fold
-        expect([fold1.getStartRow(), fold1.getEndRow()]).toEqual [0, 19]
+        expect([fold1.getStartRow(), fold1.getEndRow()]).toEqual [0, 30]
         fold1.destroy()
 
         fold2 = editor.tokenizedLineForScreenRow(5).fold
@@ -455,7 +475,13 @@ describe "LanguageMode", ->
       it "returns true if the line starts a multi-line comment", ->
         expect(languageMode.isFoldableAtBufferRow(1)).toBe true
         expect(languageMode.isFoldableAtBufferRow(6)).toBe true
-        expect(languageMode.isFoldableAtBufferRow(17)).toBe false
+        expect(languageMode.isFoldableAtBufferRow(8)).toBe false
+        expect(languageMode.isFoldableAtBufferRow(11)).toBe true
+        expect(languageMode.isFoldableAtBufferRow(15)).toBe false
+        expect(languageMode.isFoldableAtBufferRow(17)).toBe true
+        expect(languageMode.isFoldableAtBufferRow(21)).toBe true
+        expect(languageMode.isFoldableAtBufferRow(24)).toBe true
+        expect(languageMode.isFoldableAtBufferRow(28)).toBe false
 
       it "does not return true for a line in the middle of a comment that's followed by an indented line", ->
         expect(languageMode.isFoldableAtBufferRow(7)).toBe false

--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -431,11 +431,11 @@ describe "LanguageMode", ->
 
         fold5 = editor.tokenizedLineForScreenRow(6).fold
         expect([fold5.getStartRow(), fold5.getEndRow()]).toEqual [11, 16]
-        fold5.destroy();
+        fold5.destroy()
 
         fold6 = editor.tokenizedLineForScreenRow(13).fold
         expect([fold6.getStartRow(), fold6.getEndRow()]).toEqual [21, 22]
-        fold6.destroy();
+        fold6.destroy()
 
     describe ".foldAllAtIndentLevel()", ->
       it "folds every foldable range at a given indentLevel", ->

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -146,13 +146,11 @@ class LanguageMode
 
     if bufferRow > 0
       for currentRow in [bufferRow-1..0]
-        break if @buffer.isRowBlank(currentRow)
         break unless @editor.displayBuffer.tokenizedBuffer.tokenizedLineForRow(currentRow).isComment()
         startRow = currentRow
 
     if bufferRow < @buffer.getLastRow()
       for currentRow in [bufferRow+1..@buffer.getLastRow()]
-        break if @buffer.isRowBlank(currentRow)
         break unless @editor.displayBuffer.tokenizedBuffer.tokenizedLineForRow(currentRow).isComment()
         endRow = currentRow
 

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -490,7 +490,6 @@ class TokenizedLine
     while iterator.next()
       scopes = iterator.getScopes()
       continue if scopes.length is 1
-      continue unless NonWhitespaceRegex.test(iterator.getText())
       for scope in scopes
         return true if CommentScopeRegex.test(scope)
       break


### PR DESCRIPTION
I need this fixed and I tried to fix it.

This also changes the behavior of TokenizedLine.isComment(), which is not documented in API docs and I believe this is not harmful... It now treats empty lines inside a block comment (not a single-line comment) as a comment. Thanks.

Fix #4140
