### PR TITLE
:memo: Fix URL references for LESS.

### DIFF
--- a/docs/creating-a-package.md
+++ b/docs/creating-a-package.md
@@ -123,8 +123,8 @@ like you.
 
 Style sheets for your package should be placed in the _stylesheets_ directory.
 Any style sheets in this directory will be loaded and attached to the DOM when
-your package is activated. Style sheets can be written as CSS or [LESS] \(but
-LESS is recommended).
+your package is activated. Style sheets can be written as CSS or [LESS], but
+LESS is recommended.
 
 Ideally, you won't need much in the way of styling. We've provided a standard
 set of components which define both the colors and UI elements for any package

--- a/docs/creating-a-package.md
+++ b/docs/creating-a-package.md
@@ -123,7 +123,7 @@ like you.
 
 Style sheets for your package should be placed in the _stylesheets_ directory.
 Any style sheets in this directory will be loaded and attached to the DOM when
-your package is activated. Style sheets can be written as CSS or [LESS] (but
+your package is activated. Style sheets can be written as CSS or [LESS] \(but
 LESS is recommended).
 
 Ideally, you won't need much in the way of styling. We've provided a standard
@@ -418,7 +418,7 @@ all the other available commands.
 [underscore]: http://underscorejs.org/
 [jasmine]: http://jasmine.github.io
 [cson]: https://github.com/atom/season
-[less]: http://lesscss.org
+[LESS]: http://lesscss.org
 [ui-variables]: https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
 [first-package]: your-first-package.html
 [convert-bundle]: converting-a-text-mate-bundle.html

--- a/docs/creating-a-theme.md
+++ b/docs/creating-a-theme.md
@@ -1,6 +1,6 @@
 # Creating a Theme
 
-Atom's interface is rendered using HTML, and it's styled via [LESS] (a superset
+Atom's interface is rendered using HTML, and it's styled via [LESS] \(a superset
 of CSS). Don't worry if you haven't heard of LESS before; it's just like CSS,
 but with a few handy extensions.
 
@@ -131,7 +131,7 @@ _styleguide_, or use the shortcut `cmd-ctrl-shift-g`.
 ![styleguide-img]
 
 [atomio]: http://atom.io/packages
-[less]: http://lesscss.org/
+[LESS]: http://lesscss.org/
 [git]: http://git-scm.com/
 [atom]: https://atom.io/
 [package.json]: ./creating-a-package.html#package-json


### PR DESCRIPTION
There were two problems:
- In the URL lists, the reference was listed as `[less]`, but in the prose it was listed as `[LESS]`. I made it `[LESS]` in the URL lists, which seems to match the rest of the docs.
- In both cases in the prose, the reference `[LESS]` was followed by a prose parenthetical. Markdown treats these as literal URLs. Adding a quoting backslash before the open paren fixes this.
