### PR TITLE
Use special compile cache when sudo-ing as root

### DIFF
--- a/src/coffee-cache.coffee
+++ b/src/coffee-cache.coffee
@@ -6,6 +6,11 @@ CSON = require 'season'
 fs = require 'fs-plus'
 
 cacheDir = path.join(fs.absolute('~/.atom'), 'compile-cache')
+
+# Use separate compile cache when sudo'ing as root to avoid permission issues
+if process.env.USER is 'root' and process.env.SUDO_USER and process.env.SUDO_USER isnt process.env.USER
+  cacheDir = path.join(cacheDir, 'root')
+
 coffeeCacheDir = path.join(cacheDir, 'coffee')
 CSON.setCacheDir(path.join(cacheDir, 'cson'))
 
@@ -40,11 +45,13 @@ requireCoffeeScript = (module, filePath) ->
 
 module.exports =
   cacheDir: cacheDir
+
   register: ->
     Object.defineProperty(require.extensions, '.coffee', {
       writable: false
       value: requireCoffeeScript
     })
+
   addPathToCache: (filePath) ->
     extension = path.extname(filePath)
     if extension is '.coffee'

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -8,7 +8,7 @@ module.exports =
 class LessCompileCache
   Subscriber.includeInto(this)
 
-  @cacheDir: path.join(atom.getConfigDirPath(), 'compile-cache', 'less')
+  @cacheDir: path.join(require('./coffee-cache').cacheDir, 'less')
 
   constructor: ({resourcePath, importPaths}) ->
     @lessSearchPaths = [


### PR DESCRIPTION
Create a special compile cache for when sudo'ing as root so file permissions don't get messed up when folders are created by root and then written to by another user.

Closes #3082
