### PR TITLE
:memo: Fix PackageManager::onDidLoadAll description

### DIFF
--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -48,7 +48,7 @@ class PackageManager
   Section: Event Subscription
   ###
 
-  # Public: Invoke the given callback when all packages have been activated.
+  # Public: Invoke the given callback when all packages have been loaded.
   #
   # * `callback` {Function}
   #


### PR DESCRIPTION
It invokes the callback when packages are loaded, not activated.
