### PR TITLE
Add color support to config schema

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -24,7 +24,7 @@
     "grunt-peg": "~1.1.0",
     "grunt-shell": "~0.3.1",
     "harmony-collections": "~0.3.8",
-    "legal-eagle": "~0.7.0",
+    "legal-eagle": "~0.8.0",
     "minidump": "~0.8",
     "npm": "~1.4.5",
     "rcedit": "~0.3.0",

--- a/build/package.json
+++ b/build/package.json
@@ -24,7 +24,7 @@
     "grunt-peg": "~1.1.0",
     "grunt-shell": "~0.3.1",
     "harmony-collections": "~0.3.8",
-    "legal-eagle": "~0.6.0",
+    "legal-eagle": "~0.7.0",
     "minidump": "~0.8",
     "npm": "~1.4.5",
     "rcedit": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "clear-cut": "0.4.0",
     "coffee-script": "1.8.0",
     "coffeestack": "0.8.0",
+    "color": "^0.7.3",
     "delegato": "^1",
     "emissary": "^1.3.1",
     "event-kit": "^1.0.1",

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1291,7 +1291,7 @@ describe "Config", ->
         beforeEach ->
           schema =
             type: 'color'
-            default: true
+            default: 'white'
           atom.config.setSchema('foo.bar.aColor', schema)
 
         it 'coerces various types to a color object', ->
@@ -1305,6 +1305,13 @@ describe "Config", ->
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 1, green: 2, blue: 3, alpha: 1}
           atom.config.set('foo.bar.aColor', 'rgba(4,5,6,.7)')
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 4, green: 5, blue: 6, alpha: .7}
+
+        it 'reverts back to the default value when undefined is passed to set', ->
+          atom.config.set('foo.bar.aColor', 'rgb(255,255,255)')
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 255, blue: 255, alpha: 1}
+
+          atom.config.set('foo.bar.aColor', undefined)
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 255, blue: 255, alpha: 1}
 
       describe 'when the `enum` key is used', ->
         beforeEach ->

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1305,6 +1305,10 @@ describe "Config", ->
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 1, green: 2, blue: 3, alpha: 1}
           atom.config.set('foo.bar.aColor', 'rgba(4,5,6,.7)')
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 4, green: 5, blue: 6, alpha: .7}
+          atom.config.set('foo.bar.aColor', 'hsl(120,100%,50%)')
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 0, green: 255, blue: 0, alpha: 1}
+          atom.config.set('foo.bar.aColor', 'hsla(120,100%,50%,0.3)')
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 0, green: 255, blue: 0, alpha: .3}
 
         it 'reverts back to the default value when undefined is passed to set', ->
           atom.config.set('foo.bar.aColor', 'rgb(255,255,255)')

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1287,6 +1287,25 @@ describe "Config", ->
           atom.config.set 'foo.bar', ['2', '3', '4']
           expect(atom.config.get('foo.bar')).toEqual  [2, 3, 4]
 
+      describe 'when the value has a "color" type', ->
+        beforeEach ->
+          schema =
+            type: 'color'
+            default: true
+          atom.config.setSchema('foo.bar.aColor', schema)
+
+        it 'coerces various types to a color object', ->
+          atom.config.set('foo.bar.aColor', 'red')
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 0, blue: 0, alpha: 1}
+          atom.config.set('foo.bar.aColor', '#020')
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 0, green: 34, blue: 0, alpha: 1}
+          atom.config.set('foo.bar.aColor', '#abcdef')
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 171, green: 205, blue: 239, alpha: 1}
+          atom.config.set('foo.bar.aColor', 'rgb(1,2,3)')
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 1, green: 2, blue: 3, alpha: 1}
+          atom.config.set('foo.bar.aColor', 'rgba(4,5,6,.7)')
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 4, green: 5, blue: 6, alpha: .7}
+
       describe 'when the `enum` key is used', ->
         beforeEach ->
           schema =

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1309,6 +1309,10 @@ describe "Config", ->
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 0, green: 255, blue: 0, alpha: 1}
           atom.config.set('foo.bar.aColor', 'hsla(120,100%,50%,0.3)')
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 0, green: 255, blue: 0, alpha: .3}
+          atom.config.set('foo.bar.aColor', {red: 100, green: 255, blue: 2, alpha: .5})
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 100, green: 255, blue: 2, alpha: .5}
+          atom.config.set('foo.bar.aColor', {red: 255})
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 0, blue: 0, alpha: 1}
 
         it 'reverts back to the default value when undefined is passed to set', ->
           atom.config.set('foo.bar.aColor', 'rgb(255,255,255)')

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1322,9 +1322,6 @@ describe "Config", ->
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 0, green: 0, blue: 0, alpha: 1}
 
         it 'reverts back to the default value when undefined is passed to set', ->
-          atom.config.set('foo.bar.aColor', 'rgb(255,255,255)')
-          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 255, blue: 255, alpha: 1}
-
           atom.config.set('foo.bar.aColor', undefined)
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 255, blue: 255, alpha: 1}
 
@@ -1333,6 +1330,12 @@ describe "Config", ->
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 255, blue: 255, alpha: 1}
 
           atom.config.set('foo.bar.aColor', 'nope')
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 255, blue: 255, alpha: 1}
+
+          atom.config.set('foo.bar.aColor', 30)
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 255, blue: 255, alpha: 1}
+
+          atom.config.set('foo.bar.aColor', false)
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 255, blue: 255, alpha: 1}
 
       describe 'when the `enum` key is used', ->

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1060,6 +1060,9 @@ describe "Config", ->
           type: 'integer'
           default: 12
 
+        expect(atom.config.getSchema('foo.baz')).toBeUndefined()
+        expect(atom.config.getSchema('foo.bar.anInt.baz')).toBeUndefined()
+
       it "respects the schema for scoped settings", ->
         schema =
           type: 'string'

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1307,8 +1307,20 @@ describe "Config", ->
           color.blue = 0
           color.alpha = 0
           atom.config.set('foo.bar.aColor', color)
+
+          color = atom.config.get('foo.bar.aColor')
           expect(color.toHexString()).toBe '#000000'
           expect(color.toRGBAString()).toBe 'rgba(0, 0, 0, 0)'
+
+          color.red = 300
+          color.green = -200
+          color.blue = -1
+          color.alpha = 'not see through'
+          atom.config.set('foo.bar.aColor', color)
+
+          color = atom.config.get('foo.bar.aColor')
+          expect(color.toHexString()).toBe '#ff0000'
+          expect(color.toRGBAString()).toBe 'rgba(255, 0, 0, 1)'
 
         it 'coerces various types to a color object', ->
           atom.config.set('foo.bar.aColor', 'red')

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1313,6 +1313,13 @@ describe "Config", ->
           atom.config.set('foo.bar.aColor', undefined)
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 255, blue: 255, alpha: 1}
 
+        it 'will not set non-colors', ->
+          atom.config.set('foo.bar.aColor', null)
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 255, blue: 255, alpha: 1}
+
+          atom.config.set('foo.bar.aColor', 'nope')
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 255, blue: 255, alpha: 1}
+
       describe 'when the `enum` key is used', ->
         beforeEach ->
           schema =

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1297,6 +1297,19 @@ describe "Config", ->
             default: 'white'
           atom.config.setSchema('foo.bar.aColor', schema)
 
+        it 'returns a Color object', ->
+          color = atom.config.get('foo.bar.aColor')
+          expect(color.toHexString()).toBe '#ffffff'
+          expect(color.toRGBAString()).toBe 'rgba(255, 255, 255, 1)'
+
+          color.red = 0
+          color.green = 0
+          color.blue = 0
+          color.alpha = 0
+          atom.config.set('foo.bar.aColor', color)
+          expect(color.toHexString()).toBe '#000000'
+          expect(color.toRGBAString()).toBe 'rgba(0, 0, 0, 0)'
+
         it 'coerces various types to a color object', ->
           atom.config.set('foo.bar.aColor', 'red')
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 0, blue: 0, alpha: 1}

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1313,6 +1313,10 @@ describe "Config", ->
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 100, green: 255, blue: 2, alpha: .5}
           atom.config.set('foo.bar.aColor', {red: 255})
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 0, blue: 0, alpha: 1}
+          atom.config.set('foo.bar.aColor', {red: 1000})
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 0, blue: 0, alpha: 1}
+          atom.config.set('foo.bar.aColor', {red: 'dark'})
+          expect(atom.config.get('foo.bar.aColor')).toEqual {red: 0, green: 0, blue: 0, alpha: 1}
 
         it 'reverts back to the default value when undefined is passed to set', ->
           atom.config.set('foo.bar.aColor', 'rgb(255,255,255)')

--- a/src/color.coffee
+++ b/src/color.coffee
@@ -25,11 +25,6 @@ class Color
     new Color(parsedColor.red(), parsedColor.green(), parsedColor.blue(), parsedColor.alpha())
 
   constructor: (red, green, blue, alpha) ->
-    red = parseColor(red)
-    green = parseColor(green)
-    blue = parseColor(blue)
-    alpha = parseColor(alpha)
-
     Object.defineProperties this,
       red:
         set: (newRed) -> red = parseColor(newRed)
@@ -51,6 +46,11 @@ class Color
         get: -> alpha
         enumerable: true
         configurable: false
+
+    @red = red
+    @green = green
+    @blue = blue
+    @alpha = alpha
 
   # Esssential: Returns a {String} in the form `'#abcdef'`.
   toHexString: ->

--- a/src/color.coffee
+++ b/src/color.coffee
@@ -13,8 +13,7 @@ class Color
   #
   # Returns a {Color} or `null` if it cannot be parsed.
   @parse: (value) ->
-    return null if _.isArray(value)
-    return null if _.isFunction(value)
+    return null if _.isArray(value) or _.isFunction(value)
     return null unless _.isObject(value) or _.isString(value)
 
     try

--- a/src/color.coffee
+++ b/src/color.coffee
@@ -15,25 +15,39 @@ class Color
     catch error
       return null
 
-    new Color(parsedColor)
+    new Color(parsedColor.red(), parsedColor.green(), parsedColor.blue(), parsedColor.alpha())
 
-  constructor: (color) ->
-    @red = color.red()
-    @green = color.green()
-    @blue = color.blue()
-    @alpha = color.alpha()
+  constructor: (red, green, blue, alpha) ->
+    red = parseColor(red)
+    green = parseColor(green)
+    blue = parseColor(blue)
+    alpha = parseColor(alpha)
 
-    @red = 0 if isNaN(@red)
-    @green = 0 if isNaN(@green)
-    @blue = 0 if isNaN(@blue)
-    @alpha = 1 if isNaN(@alpha)
+    Object.defineProperties this,
+      'red':
+        set: (newRed) -> red = parseColor(newRed)
+        get: -> red
+        enumerable: true
+        configurable: false
+      'green':
+        set: (newGreen) -> green = parseColor(newGreen)
+        get: -> green
+        enumerable: true
+        configurable: false
+      'blue':
+        set: (newBlue) -> blue = parseColor(newBlue)
+        get: -> blue
+        enumerable: true
+        configurable: false
+      'alpha':
+        set: (newAlpha) -> alpha = parseAlpha(newAlpha)
+        get: -> alpha
+        enumerable: true
+        configurable: false
 
   # Public: Returns a {String} in the form `'#abcdef'`
   toHexString: ->
-    hexRed = if @red < 10 then "0#{@red.toString(16)}" else @red.toString(16)
-    hexGreen = if @green < 10 then "0#{@green.toString(16)}" else @green.toString(16)
-    hexBlue = if @blue < 10 then "0#{@blue.toString(16)}" else @blue.toString(16)
-    "##{hexRed}#{hexGreen}#{hexBlue}"
+    "##{numberToHexString(@red)}#{numberToHexString(@green)}#{numberToHexString(@blue)}"
 
   # Public: Returns a {String} in the form `'rgba(25, 50, 75, .9)'`
   toRGBAString: ->
@@ -44,3 +58,24 @@ class Color
     color = Color.parse(color) unless color instanceof Color
     return false unless color?
     color.red is @red and color.blue is @blue and color.green is @green and color.alpha is @alpha
+
+  clone: -> new Color(@red, @green, @blue, @alpha)
+
+parseColor = (color) ->
+  color = parseInt(color)
+  color = 0 if isNaN(color)
+  color = Math.max(color, 0)
+  color = Math.min(color, 255)
+  color
+
+parseAlpha = (alpha) ->
+  alpha = parseFloat(alpha)
+  alpha = 1 if isNaN(alpha)
+  alpha = Math.max(alpha, 1)
+  alpha = Math.min(alpha, 0)
+  alpha
+
+numberToHexString = (number) ->
+  hex = number.toString(16)
+  hex = "0#{hex}" if number < 10
+  hex

--- a/src/color.coffee
+++ b/src/color.coffee
@@ -31,22 +31,22 @@ class Color
     alpha = parseColor(alpha)
 
     Object.defineProperties this,
-      'red':
+      red:
         set: (newRed) -> red = parseColor(newRed)
         get: -> red
         enumerable: true
         configurable: false
-      'green':
+      green:
         set: (newGreen) -> green = parseColor(newGreen)
         get: -> green
         enumerable: true
         configurable: false
-      'blue':
+      blue:
         set: (newBlue) -> blue = parseColor(newBlue)
         get: -> blue
         enumerable: true
         configurable: false
-      'alpha':
+      alpha:
         set: (newAlpha) -> alpha = parseAlpha(newAlpha)
         get: -> alpha
         enumerable: true

--- a/src/color.coffee
+++ b/src/color.coffee
@@ -1,10 +1,17 @@
 _ = require 'underscore-plus'
 ParsedColor = require 'color'
 
-# Public: A simple Color class returned from `atom.config.get` when the value at
-# the key path is of type 'color'.
+# Essential: A simple Color class returned from `atom.config.get` when the value
+# at the key path is of type 'color'.
 module.exports =
 class Color
+  # Essential: Parse a {String} or {Object} into a {Color}
+  #
+  # * `value` - A {String} such as `'white'`, `#ff00ff`, or
+  #             `'rgba(255, 15, 60, .75)'` or an {Object} with `red`, `green`,
+  #             `blue`, and `alpha` properties.
+  #
+  # Returns a {Color} or `null` if it cannot be parsed.
   @parse: (value) ->
     return null if _.isArray(value)
     return null if _.isFunction(value)
@@ -45,11 +52,11 @@ class Color
         enumerable: true
         configurable: false
 
-  # Public: Returns a {String} in the form `'#abcdef'`
+  # Esssential: Returns a {String} in the form `'#abcdef'`
   toHexString: ->
     "##{numberToHexString(@red)}#{numberToHexString(@green)}#{numberToHexString(@blue)}"
 
-  # Public: Returns a {String} in the form `'rgba(25, 50, 75, .9)'`
+  # Esssential: Returns a {String} in the form `'rgba(25, 50, 75, .9)'`
   toRGBAString: ->
     "rgba(#{@red}, #{@green}, #{@blue}, #{@alpha})"
 

--- a/src/color.coffee
+++ b/src/color.coffee
@@ -52,11 +52,11 @@ class Color
         enumerable: true
         configurable: false
 
-  # Esssential: Returns a {String} in the form `'#abcdef'`
+  # Esssential: Returns a {String} in the form `'#abcdef'`.
   toHexString: ->
     "##{numberToHexString(@red)}#{numberToHexString(@green)}#{numberToHexString(@blue)}"
 
-  # Esssential: Returns a {String} in the form `'rgba(25, 50, 75, .9)'`
+  # Esssential: Returns a {String} in the form `'rgba(25, 50, 75, .9)'`.
   toRGBAString: ->
     "rgba(#{@red}, #{@green}, #{@blue}, #{@alpha})"
 

--- a/src/color.coffee
+++ b/src/color.coffee
@@ -1,7 +1,7 @@
 _ = require 'underscore-plus'
 ParsedColor = require 'color'
 
-# Essential: A simple Color class returned from `atom.config.get` when the value
+# Essential: A simple color class returned from {Config::get} when the value
 # at the key path is of type 'color'.
 module.exports =
 class Color

--- a/src/color.coffee
+++ b/src/color.coffee
@@ -5,7 +5,7 @@ ParsedColor = require 'color'
 # at the key path is of type 'color'.
 module.exports =
 class Color
-  # Essential: Parse a {String} or {Object} into a {Color}
+  # Essential: Parse a {String} or {Object} into a {Color}.
   #
   # * `value` - A {String} such as `'white'`, `#ff00ff`, or
   #             `'rgba(255, 15, 60, .75)'` or an {Object} with `red`, `green`,

--- a/src/color.coffee
+++ b/src/color.coffee
@@ -1,8 +1,8 @@
 _ = require 'underscore-plus'
 ParsedColor = require 'color'
 
-# A simple Color class returned from `atom.config.get` when the value at the
-# key path is of type 'color'.
+# Public: A simple Color class returned from `atom.config.get` when the value at
+# the key path is of type 'color'.
 module.exports =
 class Color
   @parse: (value) ->

--- a/src/color.coffee
+++ b/src/color.coffee
@@ -78,8 +78,8 @@ parseColor = (color) ->
 parseAlpha = (alpha) ->
   alpha = parseFloat(alpha)
   alpha = 1 if isNaN(alpha)
-  alpha = Math.max(alpha, 1)
-  alpha = Math.min(alpha, 0)
+  alpha = Math.max(alpha, 0)
+  alpha = Math.min(alpha, 1)
   alpha
 
 numberToHexString = (number) ->

--- a/src/color.coffee
+++ b/src/color.coffee
@@ -1,0 +1,46 @@
+_ = require 'underscore-plus'
+ParsedColor = require 'color'
+
+# A simple Color class returned from `atom.config.get` when the value at the
+# key path is of type 'color'.
+module.exports =
+class Color
+  @parse: (value) ->
+    return null if _.isArray(value)
+    return null if _.isFunction(value)
+    return null unless _.isObject(value) or _.isString(value)
+
+    try
+      parsedColor = new ParsedColor(value)
+    catch error
+      return null
+
+    new Color(parsedColor)
+
+  constructor: (color) ->
+    @red = color.red()
+    @green = color.green()
+    @blue = color.blue()
+    @alpha = color.alpha()
+
+    @red = 0 if isNaN(@red)
+    @green = 0 if isNaN(@green)
+    @blue = 0 if isNaN(@blue)
+    @alpha = 1 if isNaN(@alpha)
+
+  # Public: Returns a {String} in the form `'#abcdef'`
+  toHexString: ->
+    hexRed = if @red < 10 then "0#{@red.toString(16)}" else @red.toString(16)
+    hexGreen = if @green < 10 then "0#{@green.toString(16)}" else @green.toString(16)
+    hexBlue = if @blue < 10 then "0#{@blue.toString(16)}" else @blue.toString(16)
+    "##{hexRed}#{hexGreen}#{hexBlue}"
+
+  # Public: Returns a {String} in the form `'rgba(25, 50, 75, .9)'`
+  toRGBAString: ->
+    "rgba(#{@red}, #{@green}, #{@blue}, #{@alpha})"
+
+  isEqual: (color) ->
+    return true if this is color
+    color = Color.parse(color) unless color instanceof Color
+    return false unless color?
+    color.red is @red and color.blue is @blue and color.green is @green and color.alpha is @alpha

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -5,10 +5,10 @@ EmitterMixin = require('emissary').Emitter
 CSON = require 'season'
 path = require 'path'
 async = require 'async'
-Color = require './color'
 pathWatcher = require 'pathwatcher'
 Grim = require 'grim'
 
+Color = require './color'
 ScopedPropertyStore = require 'scoped-property-store'
 ScopeDescriptor = require './scope-descriptor'
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1126,10 +1126,16 @@ Config.addSchemaEnforcers
       catch error
         throw new Error("Validation failed at #{keyPath}, #{JSON.stringify(value)} cannot be coerced into a color")
 
-      red: color.red()
-      green: color.green()
-      blue: color.blue()
-      alpha: color.alpha()
+      value =
+        red: color.red()
+        green: color.green()
+        blue: color.blue()
+        alpha: color.alpha()
+      value.red = 0 if isNaN(value.red)
+      value.green = 0 if isNaN(value.green)
+      value.blue = 0 if isNaN(value.blue)
+      value.alpha = 1 if isNaN(value.alpha)
+      value
 
   '*':
     coerceMinimumAndMaximum: (keyPath, value, schema) ->

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -5,7 +5,7 @@ EmitterMixin = require('emissary').Emitter
 CSON = require 'season'
 path = require 'path'
 async = require 'async'
-Color = require 'color'
+Color = require './color'
 pathWatcher = require 'pathwatcher'
 Grim = require 'grim'
 
@@ -1121,23 +1121,10 @@ Config.addSchemaEnforcers
 
   'color':
     coerce: (keyPath, value, schema) ->
-      if isPlainObject(value) or typeof value is 'string'
-        try
-          color = new Color(value)
-
+      color = Color.parse(value)
       unless color?
         throw new Error("Validation failed at #{keyPath}, #{JSON.stringify(value)} cannot be coerced into a color")
-
-      value =
-        red: color.red()
-        green: color.green()
-        blue: color.blue()
-        alpha: color.alpha()
-      value.red = 0 if isNaN(value.red)
-      value.green = 0 if isNaN(value.green)
-      value.blue = 0 if isNaN(value.blue)
-      value.alpha = 1 if isNaN(value.alpha)
-      value
+      color
 
   '*':
     coerceMinimumAndMaximum: (keyPath, value, schema) ->

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -888,10 +888,16 @@ class Config
       defaultValue = _.valueForKeyPath(@defaultSettings, keyPath)
 
     if value?
-      value = _.deepClone(value)
-      _.defaults(value, defaultValue) if isPlainObject(value) and isPlainObject(defaultValue)
+      if value instanceof Color
+        value = value.clone()
+      else
+        value = _.deepClone(value)
+        _.defaults(value, defaultValue) if isPlainObject(value) and isPlainObject(defaultValue)
     else
-      value = _.deepClone(defaultValue)
+      if defaultValue instanceof Color
+        value = defaultValue.clone()
+      else
+        value = _.deepClone(defaultValue)
 
     value
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -703,7 +703,7 @@ class Config
     schema = @schema
     for key in keys
       break unless schema?
-      schema = schema.properties[key]
+      schema = schema.properties?[key]
     schema
 
   # Deprecated: Returns a new {Object} containing all of the global settings and

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -219,7 +219,7 @@ ScopeDescriptor = require './scope-descriptor'
 #
 # #### color
 #
-# Values will be coerced into an object with `red`, `green`, `blue`, and `alpha`
+# Values will be coerced into a {Color} with `red`, `green`, `blue`, and `alpha`
 # properties that all have numeric values. `red`, `green`, `blue` will be in
 # the range 0 to 255 and `value` will be in the range 0 to 1. Values can be any
 # valid CSS color format such as `#abc`, `#abcdef`, `white`,

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1121,9 +1121,11 @@ Config.addSchemaEnforcers
 
   'color':
     coerce: (keyPath, value, schema) ->
-      try
-        color = new Color(value)
-      catch error
+      if isPlainObject(value) or typeof value is 'string'
+        try
+          color = new Color(value)
+
+      unless color?
         throw new Error("Validation failed at #{keyPath}, #{JSON.stringify(value)} cannot be coerced into a color")
 
       value =

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -217,6 +217,21 @@ ScopeDescriptor = require './scope-descriptor'
 #         maximum: 11.5
 # ```
 #
+# #### color
+#
+# Values will be coerced into an object with `red`, `green`, `blue`, and `alpha`
+# properties that all have numeric values. `red`, `green`, `blue` will be in
+# the range 0 to 255 and `value` will be in the range 0 to 1. Values can be any
+# valid CSS color format such as `#abc`, `#abcdef`, `white`,
+# `rgb(50, 100, 150)`, and `rgba(25, 75, 125, .75)`.
+#
+# ```coffee
+# config:
+#   someSetting:
+#     type: 'color'
+#     default: 'white'
+# ```
+#
 # ### Other Supported Keys
 #
 # #### enum

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -5,6 +5,7 @@ EmitterMixin = require('emissary').Emitter
 CSON = require 'season'
 path = require 'path'
 async = require 'async'
+Color = require 'color'
 pathWatcher = require 'pathwatcher'
 Grim = require 'grim'
 
@@ -1102,6 +1103,18 @@ Config.addSchemaEnforcers
         newValue
       else
         value
+
+  'color':
+    coerce: (keyPath, value, schema) ->
+      try
+        color = new Color(value)
+      catch error
+        throw new Error("Validation failed at #{keyPath}, #{JSON.stringify(value)} cannot be coerced into a color")
+
+      red: color.red()
+      green: color.green()
+      blue: color.blue()
+      alpha: color.alpha()
 
   '*':
     coerceMinimumAndMaximum: (keyPath, value, schema) ->


### PR DESCRIPTION
This adds first-class support for colors in the config schema.

``` coffee
atom.config.set('my-package.aColor', 'khaki')
atom.config.get('my-package.aColor') # {red: 240, green: 230, blue: 140, alpha: 1}
atom.config.get('my-package.aColor').toHexString() # '#f0e68c'
atom.config.get('my-package.aColor').toRGBAString() # 'rgba(240, 230, 140, 1)'

atom.config.set('my-package.bColor', 'rgba(10,20, 30, .75)')
atom.config.get('my-package.bColor') # {red: 10, green: 20, blue: 30, alpha: .75}
```

This will be used to make themes adjustable by allowing colors to be changed in the settings view and those color changes will be reflected in Less variables in the loaded theme stylesheets.
