### PR TITLE
Address issues with PackageManager

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -34,6 +34,14 @@ describe "PackageManager", ->
       expect(console.warn.callCount).toBe(1)
       expect(console.warn.argsForCall[0][0]).toContain("Could not resolve")
 
+    it "invokes ::onDidLoadPackage listeners with the loaded package", ->
+      loadedPackage = null
+      atom.packages.onDidLoadPackage (pack) -> loadedPackage = pack
+
+      atom.packages.loadPackage("package-with-main")
+
+      expect(loadedPackage.name).toBe "package-with-main"
+
   describe "::unloadPackage(name)", ->
     describe "when the package is active", ->
       it "throws an error", ->
@@ -60,6 +68,13 @@ describe "PackageManager", ->
         expect(atom.packages.isPackageLoaded(pack.name)).toBeTruthy()
         atom.packages.unloadPackage(pack.name)
         expect(atom.packages.isPackageLoaded(pack.name)).toBeFalsy()
+
+    it "invokes ::onDidUnloadPackage listeners with the unloaded package", ->
+      atom.packages.loadPackage('package-with-main')
+      unloadedPackage = null
+      atom.packages.onDidUnloadPackage (pack) -> unloadedPackage = pack
+      atom.packages.unloadPackage('package-with-main')
+      expect(unloadedPackage.name).toBe 'package-with-main'
 
   describe "::activatePackage(id)", ->
     describe "when called multiple times", ->

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -213,6 +213,16 @@ describe "PackageManager", ->
         runs ->
           expect(pack.mainModule.activate).toHaveBeenCalledWith({someNumber: 77})
 
+    it "invokes ::onDidActivatePackage listeners with the activated package", ->
+      activatedPackage = null
+      atom.packages.onDidActivatePackage (pack) ->
+        activatedPackage = pack
+
+      atom.packages.activatePackage('package-with-main')
+
+      waitsFor -> activatedPackage?
+      runs -> expect(activatedPackage.name).toBe 'package-with-main'
+
     describe "when the package throws an error while loading", ->
       it "logs a warning instead of throwing an exception", ->
         atom.config.set("core.disabledPackages", [])

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -538,6 +538,16 @@ describe "PackageManager", ->
         atom.packages.deactivatePackage("package-with-settings")
         expect(atom.config.get 'editor.increaseIndentPattern', scope: ['.source.omg']).toBeUndefined()
 
+    it "invokes ::onDidDeactivatePackage listeners with the deactivated package", ->
+      waitsForPromise ->
+        atom.packages.activatePackage("package-with-main")
+
+      runs ->
+        deactivatedPackage = null
+        atom.packages.onDidDeactivatePackage (pack) -> deactivatedPackage = pack
+        atom.packages.deactivatePackage("package-with-main")
+        expect(deactivatedPackage.name).toBe "package-with-main"
+
   describe "::activate()", ->
     beforeEach ->
       jasmine.snapshotDeprecations()

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -434,130 +434,109 @@ describe "PackageManager", ->
     afterEach ->
       atom.packages.unloadPackages()
 
-    describe "atom packages", ->
-      it "calls `deactivate` on the package's main module if activate was successful", ->
-        pack = null
-        waitsForPromise ->
-          atom.packages.activatePackage("package-with-deactivate").then (p) -> pack = p
+    it "calls `deactivate` on the package's main module if activate was successful", ->
+      pack = null
+      waitsForPromise ->
+        atom.packages.activatePackage("package-with-deactivate").then (p) -> pack = p
 
-        runs ->
-          expect(atom.packages.isPackageActive("package-with-deactivate")).toBeTruthy()
-          spyOn(pack.mainModule, 'deactivate').andCallThrough()
+      runs ->
+        expect(atom.packages.isPackageActive("package-with-deactivate")).toBeTruthy()
+        spyOn(pack.mainModule, 'deactivate').andCallThrough()
 
-          atom.packages.deactivatePackage("package-with-deactivate")
-          expect(pack.mainModule.deactivate).toHaveBeenCalled()
-          expect(atom.packages.isPackageActive("package-with-module")).toBeFalsy()
+        atom.packages.deactivatePackage("package-with-deactivate")
+        expect(pack.mainModule.deactivate).toHaveBeenCalled()
+        expect(atom.packages.isPackageActive("package-with-module")).toBeFalsy()
 
-          spyOn(console, 'warn')
-
-        badPack = null
-        waitsForPromise ->
-          atom.packages.activatePackage("package-that-throws-on-activate").then (p) -> badPack = p
-
-        runs ->
-          expect(atom.packages.isPackageActive("package-that-throws-on-activate")).toBeTruthy()
-          spyOn(badPack.mainModule, 'deactivate').andCallThrough()
-
-          atom.packages.deactivatePackage("package-that-throws-on-activate")
-          expect(badPack.mainModule.deactivate).not.toHaveBeenCalled()
-          expect(atom.packages.isPackageActive("package-that-throws-on-activate")).toBeFalsy()
-
-      it "does not serialize packages that have not been activated called on their main module", ->
         spyOn(console, 'warn')
-        badPack = null
-        waitsForPromise ->
-          atom.packages.activatePackage("package-that-throws-on-activate").then (p) -> badPack = p
 
-        runs ->
-          spyOn(badPack.mainModule, 'serialize').andCallThrough()
+      badPack = null
+      waitsForPromise ->
+        atom.packages.activatePackage("package-that-throws-on-activate").then (p) -> badPack = p
 
-          atom.packages.deactivatePackage("package-that-throws-on-activate")
-          expect(badPack.mainModule.serialize).not.toHaveBeenCalled()
+      runs ->
+        expect(atom.packages.isPackageActive("package-that-throws-on-activate")).toBeTruthy()
+        spyOn(badPack.mainModule, 'deactivate').andCallThrough()
 
-      it "absorbs exceptions that are thrown by the package module's serialize method", ->
-        spyOn(console, 'error')
+        atom.packages.deactivatePackage("package-that-throws-on-activate")
+        expect(badPack.mainModule.deactivate).not.toHaveBeenCalled()
+        expect(atom.packages.isPackageActive("package-that-throws-on-activate")).toBeFalsy()
 
-        waitsForPromise ->
-          atom.packages.activatePackage('package-with-serialize-error')
+    it "does not serialize packages that have not been activated called on their main module", ->
+      spyOn(console, 'warn')
+      badPack = null
+      waitsForPromise ->
+        atom.packages.activatePackage("package-that-throws-on-activate").then (p) -> badPack = p
 
-        waitsForPromise ->
-          atom.packages.activatePackage('package-with-serialization')
+      runs ->
+        spyOn(badPack.mainModule, 'serialize').andCallThrough()
 
-        runs ->
-          atom.packages.deactivatePackages()
-          expect(atom.packages.packageStates['package-with-serialize-error']).toBeUndefined()
-          expect(atom.packages.packageStates['package-with-serialization']).toEqual someNumber: 1
-          expect(console.error).toHaveBeenCalled()
+        atom.packages.deactivatePackage("package-that-throws-on-activate")
+        expect(badPack.mainModule.serialize).not.toHaveBeenCalled()
 
-      it "absorbs exceptions that are thrown by the package module's deactivate method", ->
-        spyOn(console, 'error')
+    it "absorbs exceptions that are thrown by the package module's serialize method", ->
+      spyOn(console, 'error')
 
-        waitsForPromise ->
-          atom.packages.activatePackage("package-that-throws-on-deactivate")
+      waitsForPromise ->
+        atom.packages.activatePackage('package-with-serialize-error')
 
-        runs ->
-          expect(-> atom.packages.deactivatePackage("package-that-throws-on-deactivate")).not.toThrow()
-          expect(console.error).toHaveBeenCalled()
+      waitsForPromise ->
+        atom.packages.activatePackage('package-with-serialization')
 
-      it "removes the package's grammars", ->
-        waitsForPromise ->
-          atom.packages.activatePackage('package-with-grammars')
+      runs ->
+        atom.packages.deactivatePackages()
+        expect(atom.packages.packageStates['package-with-serialize-error']).toBeUndefined()
+        expect(atom.packages.packageStates['package-with-serialization']).toEqual someNumber: 1
+        expect(console.error).toHaveBeenCalled()
 
-        runs ->
-          atom.packages.deactivatePackage('package-with-grammars')
-          expect(atom.grammars.selectGrammar('a.alot').name).toBe 'Null Grammar'
-          expect(atom.grammars.selectGrammar('a.alittle').name).toBe 'Null Grammar'
+    it "absorbs exceptions that are thrown by the package module's deactivate method", ->
+      spyOn(console, 'error')
 
-      it "removes the package's keymaps", ->
-        waitsForPromise ->
-          atom.packages.activatePackage('package-with-keymaps')
+      waitsForPromise ->
+        atom.packages.activatePackage("package-that-throws-on-deactivate")
 
-        runs ->
-          atom.packages.deactivatePackage('package-with-keymaps')
-          expect(atom.keymaps.findKeyBindings(keystrokes:'ctrl-z', target: ($$ -> @div class: 'test-1')[0])).toHaveLength 0
-          expect(atom.keymaps.findKeyBindings(keystrokes:'ctrl-z', target: ($$ -> @div class: 'test-2')[0])).toHaveLength 0
+      runs ->
+        expect(-> atom.packages.deactivatePackage("package-that-throws-on-deactivate")).not.toThrow()
+        expect(console.error).toHaveBeenCalled()
 
-      it "removes the package's stylesheets", ->
-        waitsForPromise ->
-          atom.packages.activatePackage('package-with-stylesheets')
+    it "removes the package's grammars", ->
+      waitsForPromise ->
+        atom.packages.activatePackage('package-with-grammars')
 
-        runs ->
-          atom.packages.deactivatePackage('package-with-stylesheets')
-          one = require.resolve("./fixtures/packages/package-with-stylesheets-manifest/stylesheets/1.css")
-          two = require.resolve("./fixtures/packages/package-with-stylesheets-manifest/stylesheets/2.less")
-          three = require.resolve("./fixtures/packages/package-with-stylesheets-manifest/stylesheets/3.css")
-          expect(atom.themes.stylesheetElementForId(one)).not.toExist()
-          expect(atom.themes.stylesheetElementForId(two)).not.toExist()
-          expect(atom.themes.stylesheetElementForId(three)).not.toExist()
+      runs ->
+        atom.packages.deactivatePackage('package-with-grammars')
+        expect(atom.grammars.selectGrammar('a.alot').name).toBe 'Null Grammar'
+        expect(atom.grammars.selectGrammar('a.alittle').name).toBe 'Null Grammar'
 
-      it "removes the package's scoped-properties", ->
-        waitsForPromise ->
-          atom.packages.activatePackage("package-with-settings")
+    it "removes the package's keymaps", ->
+      waitsForPromise ->
+        atom.packages.activatePackage('package-with-keymaps')
 
-        runs ->
-          expect(atom.config.get 'editor.increaseIndentPattern', scope: ['.source.omg']).toBe '^a'
-          atom.packages.deactivatePackage("package-with-settings")
-          expect(atom.config.get 'editor.increaseIndentPattern', scope: ['.source.omg']).toBeUndefined()
+      runs ->
+        atom.packages.deactivatePackage('package-with-keymaps')
+        expect(atom.keymaps.findKeyBindings(keystrokes:'ctrl-z', target: ($$ -> @div class: 'test-1')[0])).toHaveLength 0
+        expect(atom.keymaps.findKeyBindings(keystrokes:'ctrl-z', target: ($$ -> @div class: 'test-2')[0])).toHaveLength 0
 
-    describe "textmate packages", ->
-      it "removes the package's grammars", ->
-        expect(atom.grammars.selectGrammar("file.rb").name).toBe "Null Grammar"
+    it "removes the package's stylesheets", ->
+      waitsForPromise ->
+        atom.packages.activatePackage('package-with-stylesheets')
 
-        waitsForPromise ->
-          atom.packages.activatePackage('language-ruby')
+      runs ->
+        atom.packages.deactivatePackage('package-with-stylesheets')
+        one = require.resolve("./fixtures/packages/package-with-stylesheets-manifest/stylesheets/1.css")
+        two = require.resolve("./fixtures/packages/package-with-stylesheets-manifest/stylesheets/2.less")
+        three = require.resolve("./fixtures/packages/package-with-stylesheets-manifest/stylesheets/3.css")
+        expect(atom.themes.stylesheetElementForId(one)).not.toExist()
+        expect(atom.themes.stylesheetElementForId(two)).not.toExist()
+        expect(atom.themes.stylesheetElementForId(three)).not.toExist()
 
-        runs ->
-          expect(atom.grammars.selectGrammar("file.rb").name).toBe "Ruby"
-          atom.packages.deactivatePackage('language-ruby')
-          expect(atom.grammars.selectGrammar("file.rb").name).toBe "Null Grammar"
+    it "removes the package's scoped-properties", ->
+      waitsForPromise ->
+        atom.packages.activatePackage("package-with-settings")
 
-      it "removes the package's scoped properties", ->
-        waitsForPromise ->
-          atom.packages.activatePackage('language-ruby')
-
-        runs ->
-          atom.packages.deactivatePackage('language-ruby')
-          expect(atom.config.get('editor.commentStart', scope: ['.source.ruby'])).toBeUndefined()
+      runs ->
+        expect(atom.config.get 'editor.increaseIndentPattern', scope: ['.source.omg']).toBe '^a'
+        atom.packages.deactivatePackage("package-with-settings")
+        expect(atom.config.get 'editor.increaseIndentPattern', scope: ['.source.omg']).toBeUndefined()
 
   describe "::activate()", ->
     beforeEach ->

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -645,7 +645,7 @@ describe "PackageManager", ->
         expect(console.warn.callCount).toBe 1
 
     describe "with themes", ->
-      reloadedHandler = null
+      didChangeActiveThemesHandler = null
 
       beforeEach ->
         waitsForPromise ->
@@ -670,17 +670,18 @@ describe "PackageManager", ->
           expect(atom.config.get('core.themes')).toContain packageName
           expect(atom.config.get('core.disabledPackages')).not.toContain packageName
 
-          reloadedHandler = jasmine.createSpy('reloadedHandler')
-          reloadedHandler.reset()
-          atom.themes.onDidReloadAll reloadedHandler
+          didChangeActiveThemesHandler = jasmine.createSpy('didChangeActiveThemesHandler')
+          didChangeActiveThemesHandler.reset()
+          atom.themes.onDidChangeActiveThemes didChangeActiveThemesHandler
 
           pack = atom.packages.disablePackage(packageName)
 
         waitsFor ->
-          reloadedHandler.callCount is 1
+          didChangeActiveThemesHandler.callCount is 1
 
         runs ->
           expect(atom.packages.getActivePackages()).not.toContain pack
           expect(atom.config.get('core.themes')).not.toContain packageName
           expect(atom.config.get('core.themes')).not.toContain packageName
           expect(atom.config.get('core.disabledPackages')).not.toContain packageName
+          

--- a/spec/text-editor-element-spec.coffee
+++ b/spec/text-editor-element-spec.coffee
@@ -107,7 +107,7 @@ describe "TextEditorElement", ->
 
       spyOn(atom.themes, 'isInitialLoadComplete').andCallFake ->
         initialThemeLoadComplete
-      spyOn(atom.themes, 'onDidReloadAll').andCallFake (fn) ->
+      spyOn(atom.themes, 'onDidChangeActiveThemes').andCallFake (fn) ->
         themeReloadCallback = fn
 
       atom.config.set("editor.useShadowDOM", false)

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -73,54 +73,54 @@ describe "ThemeManager", ->
 
   describe "when the core.themes config value changes", ->
     it "add/removes stylesheets to reflect the new config value", ->
-      themeManager.onDidReloadAll reloadHandler = jasmine.createSpy()
+      themeManager.onDidChangeActiveThemes didChangeActiveThemesHandler = jasmine.createSpy()
       spyOn(atom.styles, 'getUserStyleSheetPath').andCallFake -> null
 
       waitsForPromise ->
         themeManager.activateThemes()
 
       runs ->
-        reloadHandler.reset()
+        didChangeActiveThemesHandler.reset()
         atom.config.set('core.themes', [])
 
       waitsFor ->
-        reloadHandler.callCount == 1
+        didChangeActiveThemesHandler.callCount == 1
 
       runs ->
-        reloadHandler.reset()
+        didChangeActiveThemesHandler.reset()
         expect($('style.theme')).toHaveLength 0
         atom.config.set('core.themes', ['atom-dark-ui'])
 
       waitsFor ->
-        reloadHandler.callCount == 1
+        didChangeActiveThemesHandler.callCount == 1
 
       runs ->
-        reloadHandler.reset()
+        didChangeActiveThemesHandler.reset()
         expect($('style[priority=1]')).toHaveLength 2
         expect($('style[priority=1]:eq(0)').attr('source-path')).toMatch /atom-dark-ui/
         atom.config.set('core.themes', ['atom-light-ui', 'atom-dark-ui'])
 
       waitsFor ->
-        reloadHandler.callCount == 1
+        didChangeActiveThemesHandler.callCount == 1
 
       runs ->
-        reloadHandler.reset()
+        didChangeActiveThemesHandler.reset()
         expect($('style[priority=1]')).toHaveLength 2
         expect($('style[priority=1]:eq(0)').attr('source-path')).toMatch /atom-dark-ui/
         expect($('style[priority=1]:eq(1)').attr('source-path')).toMatch /atom-light-ui/
         atom.config.set('core.themes', [])
 
       waitsFor ->
-        reloadHandler.callCount == 1
+        didChangeActiveThemesHandler.callCount == 1
 
       runs ->
-        reloadHandler.reset()
+        didChangeActiveThemesHandler.reset()
         expect($('style[priority=1]')).toHaveLength 2
         # atom-dark-ui has an directory path, the syntax one doesn't
         atom.config.set('core.themes', ['theme-with-index-less', 'atom-dark-ui'])
 
       waitsFor ->
-        reloadHandler.callCount == 1
+        didChangeActiveThemesHandler.callCount == 1
 
       runs ->
         expect($('style[priority=1]')).toHaveLength 2
@@ -130,7 +130,7 @@ describe "ThemeManager", ->
 
     it 'adds theme-* classes to the workspace for each active theme', ->
       workspaceElement = atom.views.getView(atom.workspace)
-      themeManager.onDidReloadAll reloadHandler = jasmine.createSpy()
+      themeManager.onDidChangeActiveThemes didChangeActiveThemesHandler = jasmine.createSpy()
 
       waitsForPromise ->
         themeManager.activateThemes()
@@ -138,11 +138,11 @@ describe "ThemeManager", ->
       runs ->
         expect(workspaceElement).toHaveClass 'theme-atom-dark-ui'
 
-        themeManager.onDidReloadAll reloadHandler = jasmine.createSpy()
+        themeManager.onDidChangeActiveThemes didChangeActiveThemesHandler = jasmine.createSpy()
         atom.config.set('core.themes', ['theme-with-ui-variables', 'theme-with-syntax-variables'])
 
       waitsFor ->
-        reloadHandler.callCount > 0
+        didChangeActiveThemesHandler.callCount > 0
 
       runs ->
         # `theme-` twice as it prefixes the name with `theme-`
@@ -259,11 +259,11 @@ describe "ThemeManager", ->
         themeManager.activateThemes()
 
     it "loads the correct values from the theme's ui-variables file", ->
-      themeManager.onDidReloadAll reloadHandler = jasmine.createSpy()
+      themeManager.onDidChangeActiveThemes didChangeActiveThemesHandler = jasmine.createSpy()
       atom.config.set('core.themes', ['theme-with-ui-variables', 'theme-with-syntax-variables'])
 
       waitsFor ->
-        reloadHandler.callCount > 0
+        didChangeActiveThemesHandler.callCount > 0
 
       runs ->
         # an override loaded in the base css
@@ -276,11 +276,11 @@ describe "ThemeManager", ->
 
     describe "when there is a theme with incomplete variables", ->
       it "loads the correct values from the fallback ui-variables", ->
-        themeManager.onDidReloadAll reloadHandler = jasmine.createSpy()
+        themeManager.onDidChangeActiveThemes didChangeActiveThemesHandler = jasmine.createSpy()
         atom.config.set('core.themes', ['theme-with-incomplete-ui-variables', 'theme-with-syntax-variables'])
 
         waitsFor ->
-          reloadHandler.callCount > 0
+          didChangeActiveThemesHandler.callCount > 0
 
         runs ->
           # an override loaded in the base css

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -721,7 +721,7 @@ class Atom extends Model
     @themes.load()
 
   watchThemes: ->
-    @themes.onDidReloadAll =>
+    @themes.onDidChangeActiveThemes =>
       # Only reload stylesheets from non-theme packages
       for pack in @packages.getActivePackages() when pack.getType() isnt 'theme'
         pack.reloadStylesheets?()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -280,7 +280,7 @@ class Atom extends Model
       deprecate "The atom.syntax global is deprecated. Use atom.grammars instead."
       @grammars
 
-    @subscribe @packages.onDidActivateAll => @watchThemes()
+    @subscribe @packages.onDidActivateInitialPackages => @watchThemes()
 
     Project = require './project'
     TextBuffer = require 'text-buffer'

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -61,7 +61,7 @@ class MenuManager
     @pendingUpdateOperation = null
     @template = []
     atom.keymaps.onDidLoadBundledKeymaps => @loadPlatformItems()
-    atom.packages.onDidActivateAll => @sortPackagesMenu()
+    atom.packages.onDidActivateInitialPackages => @sortPackagesMenu()
 
   # Public: Adds the given items to the application menu.
   #

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -113,7 +113,7 @@ class PackageManager
   on: (eventName) ->
     switch eventName
       when 'loaded'
-        Grim.deprecate 'Use PackageManager::onDidLoadAll instead'
+        Grim.deprecate 'Use PackageManager::onDidLoadInitialPackages instead'
       when 'activated'
         Grim.deprecate 'Use PackageManager::onDidActivateInitialPackages instead'
       else

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -72,6 +72,15 @@ class PackageManager
     Grim.deprecate("Use `::onDidActivateInitialPackages` instead.")
     @onDidActivateInitialPackages(callback)
 
+  # Public: Invoke the given callback when a package is activated.
+  #
+  # * `callback` A {Function} to be invoked when a package is activated.
+  #   * `package` The {Package} that was activated.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidActivatePackage: (callback) ->
+    @emitter.on 'did-activate-package', callback
+
   on: (eventName) ->
     switch eventName
       when 'loaded'
@@ -354,6 +363,7 @@ class PackageManager
     else if pack = @loadPackage(name)
       pack.activate().then =>
         @activePackages[pack.name] = pack
+        @emitter.emit 'did-activate-package', pack
         pack
     else
       Q.reject(new Error("Failed to load package '#{name}'"))

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -81,6 +81,15 @@ class PackageManager
   onDidActivatePackage: (callback) ->
     @emitter.on 'did-activate-package', callback
 
+  # Public: Invoke the given callback when a package is deactivated.
+  #
+  # * `callback` A {Function} to be invoked when a package is deactivated.
+  #   * `package` The {Package} that was deactivated.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidDeactivatePackage: (callback) ->
+    @emitter.on 'did-deactivate-package', callback
+
   on: (eventName) ->
     switch eventName
       when 'loaded'
@@ -381,3 +390,4 @@ class PackageManager
       @setPackageState(pack.name, state) if state = pack.serialize?()
     pack.deactivate()
     delete @activePackages[pack.name]
+    @emitter.emit 'did-deactivate-package', pack

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -55,6 +55,7 @@ class PackageManager
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidLoadInitialPackages: (callback) ->
     @emitter.on 'did-load-initial-packages', callback
+    @emitter.on 'did-load-all', callback # TODO: Remove once deprecated pre-1.0 APIs are gone
 
   onDidLoadAll: (callback) ->
     Grim.deprecate("Use `::onDidLoadInitialPackages` instead.")
@@ -67,6 +68,7 @@ class PackageManager
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidActivateInitialPackages: (callback) ->
     @emitter.on 'did-activate-initial-packages', callback
+    @emitter.on 'did-activate-all', callback # TODO: Remove once deprecated pre-1.0 APIs are gone
 
   onDidActivateAll: (callback) ->
     Grim.deprecate("Use `::onDidActivateInitialPackages` instead.")

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -90,6 +90,24 @@ class PackageManager
   onDidDeactivatePackage: (callback) ->
     @emitter.on 'did-deactivate-package', callback
 
+  # Public: Invoke the given callback when a package is loaded.
+  #
+  # * `callback` A {Function} to be invoked when a package is loaded.
+  #   * `package` The {Package} that was loaded.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidLoadPackage: (callback) ->
+    @emitter.on 'did-load-package', callback
+
+  # Public: Invoke the given callback when a package is unloaded.
+  #
+  # * `callback` A {Function} to be invoked when a package is unloaded.
+  #   * `package` The {Package} that was unloaded.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidUnloadPackage: (callback) ->
+    @emitter.on 'did-unload-package', callback
+
   on: (eventName) ->
     switch eventName
       when 'loaded'
@@ -321,6 +339,7 @@ class PackageManager
           pack = new Package(packagePath, metadata)
         pack.load()
         @loadedPackages[pack.name] = pack
+        @emitter.emit 'did-load-package', pack
         return pack
       catch error
         console.warn "Failed to load package.json '#{path.basename(packagePath)}'", error.stack ? error
@@ -338,6 +357,7 @@ class PackageManager
 
     if pack = @getLoadedPackage(name)
       delete @loadedPackages[pack.name]
+      @emitter.emit 'did-unload-package', pack
     else
       throw new Error("No loaded package for name '#{name}'")
 

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -53,8 +53,12 @@ class PackageManager
   # * `callback` {Function}
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidLoadInitialPackages: (callback) ->
+    @emitter.on 'did-load-initial-packages', callback
+
   onDidLoadAll: (callback) ->
-    @emitter.on 'did-load-all', callback
+    Grim.deprecate("Use `::onDidLoadInitialPackages` instead.")
+    @onDidLoadInitialPackages(callback)
 
   # Public: Invoke the given callback when all packages have been activated.
   #
@@ -278,7 +282,7 @@ class PackageManager
     packagePaths = _.uniq packagePaths, (packagePath) -> path.basename(packagePath)
     @loadPackage(packagePath) for packagePath in packagePaths
     @emit 'loaded'
-    @emitter.emit 'did-load-all'
+    @emitter.emit 'did-load-initial-packages'
 
   loadPackage: (nameOrPath) ->
     return pack if pack = @getLoadedPackage(nameOrPath)

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -5,7 +5,7 @@ EmitterMixin = require('emissary').Emitter
 {Emitter} = require 'event-kit'
 fs = require 'fs-plus'
 Q = require 'q'
-{deprecate} = require 'grim'
+Grim = require 'grim'
 
 Package = require './package'
 ThemePackage = require './theme-package'
@@ -111,11 +111,11 @@ class PackageManager
   on: (eventName) ->
     switch eventName
       when 'loaded'
-        deprecate 'Use PackageManager::onDidLoadAll instead'
+        Grim.deprecate 'Use PackageManager::onDidLoadAll instead'
       when 'activated'
-        deprecate 'Use PackageManager::onDidActivateInitialPackages instead'
+        Grim.deprecate 'Use PackageManager::onDidActivateInitialPackages instead'
       else
-        deprecate 'PackageManager::on is deprecated. Use event subscription methods instead.'
+        Grim.deprecate 'PackageManager::on is deprecated. Use event subscription methods instead.'
     EmitterMixin::on.apply(this, arguments)
 
   ###

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -65,15 +65,19 @@ class PackageManager
   # * `callback` {Function}
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidActivateInitialPackages: (callback) ->
+    @emitter.on 'did-activate-initial-packages', callback
+
   onDidActivateAll: (callback) ->
-    @emitter.on 'did-activate-all', callback
+    Grim.deprecate("Use `::onDidActivateInitialPackages` instead.")
+    @onDidActivateInitialPackages(callback)
 
   on: (eventName) ->
     switch eventName
       when 'loaded'
         deprecate 'Use PackageManager::onDidLoadAll instead'
       when 'activated'
-        deprecate 'Use PackageManager::onDidActivateAll instead'
+        deprecate 'Use PackageManager::onDidActivateInitialPackages instead'
       else
         deprecate 'PackageManager::on is deprecated. Use event subscription methods instead.'
     EmitterMixin::on.apply(this, arguments)
@@ -325,7 +329,7 @@ class PackageManager
       packages = @getLoadedPackagesForTypes(types)
       activator.activatePackages(packages)
     @emit 'activated'
-    @emitter.emit 'did-activate-all'
+    @emitter.emit 'did-activate-initial-packages'
 
   # another type of package manager can handle other package types.
   # See ThemeManager

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -185,7 +185,7 @@ TextEditorComponent = React.createClass
     @subscribe stylesElement.onDidUpdateStyleElement @onStylesheetsChanged
     @subscribe stylesElement.onDidRemoveStyleElement @onStylesheetsChanged
     unless atom.themes.isInitialLoadComplete()
-      @subscribe atom.themes.onDidReloadAll @onAllThemesLoaded
+      @subscribe atom.themes.onDidChangeActiveThemes @onAllThemesLoaded
     @subscribe scrollbarStyle.changes, @refreshScrollbars
 
     @domPollingIntervalId = setInterval(@pollDOM, @domPollingInterval)

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -61,8 +61,12 @@ class ThemeManager
   # updating the list of active themes have completed.
   #
   # * `callback` {Function}
+  onDidChangeActiveThemes: (callback) ->
+    @emitter.on 'did-change-active-themes', callback
+
   onDidReloadAll: (callback) ->
-    @emitter.on 'did-reload-all', callback
+    Grim.deprecate("Use `::onDidChangeActiveThemes` instead.")
+    @onDidChangeActiveThemes(callback)
 
   # Deprecated: Invoke `callback` when a stylesheet has been added to the dom.
   #
@@ -132,8 +136,12 @@ class ThemeManager
   ###
 
   # Public: Get an array of all the loaded theme names.
-  getLoadedNames: ->
+  getLoadedThemeNames: ->
     theme.name for theme in @getLoadedThemes()
+
+  getLoadedNames: ->
+    Grim.deprecate("Use `::getLoadedThemeNames` instead.")
+    @getLoadedThemeNames()
 
   # Public: Get an array of all the loaded themes.
   getLoadedThemes: ->
@@ -144,8 +152,12 @@ class ThemeManager
   ###
 
   # Public: Get an array of all the active theme names.
-  getActiveNames: ->
+  getActiveThemeNames: ->
     theme.name for theme in @getActiveThemes()
+
+  getActiveNames: ->
+    Grim.deprecate("Use `::getActiveThemeNames` instead.")
+    @getActiveThemeNames()
 
   # Public: Get an array of all the active themes.
   getActiveThemes: ->
@@ -323,7 +335,7 @@ class ThemeManager
         @reloadBaseStylesheets()
         @initialLoadComplete = true
         @emit 'reloaded'
-        @emitter.emit 'did-reload-all'
+        @emitter.emit 'did-change-active-themes'
         deferred.resolve()
 
     deferred.promise

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -111,7 +111,7 @@ class ThemeManager
   on: (eventName) ->
     switch eventName
       when 'reloaded'
-        Grim.deprecate 'Use ThemeManager::onDidReloadAll instead'
+        Grim.deprecate 'Use ThemeManager::onDidChangeActiveThemes instead'
       when 'stylesheet-added'
         Grim.deprecate 'Use ThemeManager::onDidAddStylesheet instead'
       when 'stylesheet-removed'

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -63,6 +63,7 @@ class ThemeManager
   # * `callback` {Function}
   onDidChangeActiveThemes: (callback) ->
     @emitter.on 'did-change-active-themes', callback
+    @emitter.on 'did-reload-all', callback # TODO: Remove once deprecated pre-1.0 APIs are gone
 
   onDidReloadAll: (callback) ->
     Grim.deprecate("Use `::onDidChangeActiveThemes` instead.")

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -195,10 +195,11 @@ class ThemeManager
     # the first/top theme to override later themes in the stack.
     themeNames.reverse()
 
-  # Public: Set the list of enabled themes.
+  # Set the list of enabled themes.
   #
   # * `enabledThemeNames` An {Array} of {String} theme names.
   setEnabledThemes: (enabledThemeNames) ->
+    Grim.deprecate("Use `atom.config.set('core.themes', arrayOfThemeNames)` instead")
     atom.config.set('core.themes', enabledThemeNames)
 
   ###


### PR DESCRIPTION
Package manager wasn't invoking `::onDidActivateAll` listeners at the appropriate time. This PR fixes that issue and updates several method names in `PackageManager` and `ThemeManager` for clarity and consistency.
- `PackageManager`
  - `onDidActivateAll` => `onDidActivateInitialPackages`
  - `onDidLoadAll` => `onDidLoadInitialPackages`
- `ThemeManager`
  - `onDidReloadAll` => `onDidChangeActiveThemes`
  - `getActiveNames` => `getActiveThemeNames`
  - `getLoadedNames` => `getLoadedThemeNames`
  - `setEnabledThemes` => deprecated, use `config.set`
