### PR TITLE
Log scopes to notification instead of console

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -944,6 +944,15 @@ describe "TextEditor", ->
         editor.undo()
         expect(editor.getScrollTop()).toBe 0
 
+    describe '.logCursorScope()', ->
+      beforeEach ->
+        spyOn(atom.notifications, 'addInfo')
+
+      it 'opens a notification', ->
+        editor.logCursorScope()
+
+        expect(atom.notifications.addInfo).toHaveBeenCalled()
+
   describe "selection", ->
     selection = null
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2522,7 +2522,11 @@ class TextEditor extends Model
 
   logCursorScope: ->
     scopeDescriptor = @getLastCursor().getScopeDescriptor()
-    console.log scopeDescriptor.scopes, scopeDescriptor
+    list = scopeDescriptor.scopes.toString().split(',')
+    list = _.map list, (item) -> "* #{item}"
+    content = "Scopes at Cursor\n#{list.join('\n')}"
+
+    atom.notifications.addInfo(content, dismissable: true)
 
   # {Delegates to: DisplayBuffer.tokenForBufferPosition}
   tokenForBufferPosition: (bufferPosition) -> @displayBuffer.tokenForBufferPosition(bufferPosition)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2523,7 +2523,7 @@ class TextEditor extends Model
   logCursorScope: ->
     scopeDescriptor = @getLastCursor().getScopeDescriptor()
     list = scopeDescriptor.scopes.toString().split(',')
-    list = _.map list, (item) -> "* #{item}"
+    list = list.map (item) -> "* #{item}"
     content = "Scopes at Cursor\n#{list.join('\n')}"
 
     atom.notifications.addInfo(content, dismissable: true)


### PR DESCRIPTION
Fixes #4969

See: https://discuss.atom.io/t/how-to-see-what-syntax-markup-is-being-used/14172

![screen shot 2015-01-09 at 4 31 11 pm](https://cloud.githubusercontent.com/assets/1038121/5689622/d6acfdb0-981d-11e4-9ea9-cf38e08f8da6.png)
