### PR TITLE
Adding link to blog post with Travis CI instructions

### DIFF
--- a/docs/writing-specs.md
+++ b/docs/writing-specs.md
@@ -127,3 +127,7 @@ describe "when a test is written", ->
     expect("apples").toEqual("apples")
     expect("oranges").not.toEqual("apples")
 ```
+
+### Runnning on Travis CI
+
+it is now easy to run the specs in a CI environment like Travis. See [CI For Your Packages](http://blog.atom.io/2014/04/25/ci-for-your-packages.html) for more details


### PR DESCRIPTION
Here is an example of adding it to an Package https://github.com/jacogr/atom-lcov-info/issues/18
