### PR TITLE
Allow scoped default File Encoding

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -155,6 +155,25 @@ describe "TextEditor", ->
         expect(editor2.getSoftTabs()).toBe true
         expect(editor2.getEncoding()).toBe 'macroman'
 
+    it "uses scoped `core.fileEncoding` values"
+      editor1 = null
+      editor2 = null
+
+      atom.config.set('core.fileEncoding', 'utf16le')
+      atom.config.set('core.fileEncoding', 'macroman', { scopeSelector: '.javascript' })
+
+      waitsForPromise ->
+        atom.workspace.open('a').then (o) -> editor1 = o
+
+      runs ->
+        expect(editor1.getEncoding()).toBe 'utf16le'
+
+      waitsForPromise ->
+        atom.workspace.open('test.js').then (o) -> editor2 = o
+
+      runs ->
+        expect(editor2.getEncoding()).toBe 'macroman'
+
   describe "title", ->
     describe ".getTitle()", ->
       it "uses the basename of the buffer's path as its title, or 'untitled' if the path is undefined", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -155,7 +155,7 @@ describe "TextEditor", ->
         expect(editor2.getSoftTabs()).toBe true
         expect(editor2.getEncoding()).toBe 'macroman'
 
-    it "uses scoped `core.fileEncoding` values"
+    it "uses scoped `core.fileEncoding` values", ->
       editor1 = null
       editor2 = null
 

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -160,7 +160,7 @@ describe "TextEditor", ->
       editor2 = null
 
       atom.config.set('core.fileEncoding', 'utf16le')
-      atom.config.set('core.fileEncoding', 'macroman', { scopeSelector: '.js' })
+      atom.config.set('core.fileEncoding', 'macroman', scopeSelector: '.js')
 
       waitsForPromise ->
         atom.workspace.open('a').then (o) -> editor1 = o

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -160,7 +160,7 @@ describe "TextEditor", ->
       editor2 = null
 
       atom.config.set('core.fileEncoding', 'utf16le')
-      atom.config.set('core.fileEncoding', 'macroman', { scopeSelector: '.javascript' })
+      atom.config.set('core.fileEncoding', 'macroman', { scopeSelector: '.js' })
 
       waitsForPromise ->
         atom.workspace.open('a').then (o) -> editor1 = o

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -266,7 +266,6 @@ class Project extends Model
   # Still needed when deserializing a tokenized buffer
   buildBufferSync: (absoluteFilePath) ->
     buffer = new TextBuffer({filePath: absoluteFilePath})
-    buffer.setEncoding(atom.config.get('core.fileEncoding'))
     @addBuffer(buffer)
     buffer.loadSync()
     buffer
@@ -282,7 +281,6 @@ class Project extends Model
       throw new Error("Atom can only handle files < 2MB for now.")
 
     buffer = new TextBuffer({filePath: absoluteFilePath})
-    buffer.setEncoding(atom.config.get('core.fileEncoding'))
     @addBuffer(buffer)
     buffer.load()
       .then((buffer) -> buffer)
@@ -311,6 +309,7 @@ class Project extends Model
 
   buildEditorForBuffer: (buffer, editorOptions) ->
     editor = new TextEditor(_.extend({buffer, registerEditor: true}, editorOptions))
+    editor.setEncoding(atom.config.get(editor.getRootScopeDescriptor(), "core.fileEncoding"))
     editor
 
   eachBuffer: (args...) ->

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -309,7 +309,6 @@ class Project extends Model
 
   buildEditorForBuffer: (buffer, editorOptions) ->
     editor = new TextEditor(_.extend({buffer, registerEditor: true}, editorOptions))
-    editor.setEncoding(atom.config.get(editor.getRootScopeDescriptor(), "core.fileEncoding"))
     editor
 
   eachBuffer: (args...) ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -105,7 +105,7 @@ class TextEditor extends Model
 
     @languageMode = new LanguageMode(this)
 
-    @setEncoding(atom.config.get("core.fileEncoding", { scope: @getRootScopeDescriptor() }))
+    @setEncoding(atom.config.get("core.fileEncoding", scope: @getRootScopeDescriptor() ))
 
     @subscribe @$scrollTop, (scrollTop) =>
       @emit 'scroll-top-changed', scrollTop

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -105,7 +105,7 @@ class TextEditor extends Model
 
     @languageMode = new LanguageMode(this)
 
-    @setEncoding(atom.config.get(@getRootScopeDescriptor(), "core.fileEncoding"))
+    @setEncoding(atom.config.get("core.fileEncoding", { scope: @getRootScopeDescriptor() }))
 
     @subscribe @$scrollTop, (scrollTop) =>
       @emit 'scroll-top-changed', scrollTop

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -105,6 +105,8 @@ class TextEditor extends Model
 
     @languageMode = new LanguageMode(this)
 
+    @setEncoding(atom.config.get(@getRootScopeDescriptor(), "core.fileEncoding"))
+
     @subscribe @$scrollTop, (scrollTop) =>
       @emit 'scroll-top-changed', scrollTop
       @emitter.emit 'did-change-scroll-top', scrollTop


### PR DESCRIPTION
This pull request allows custom configuration for file encoding based on scope descriptors.

For example (my original issue), setting powershell files to UTF16-BE:

```
".powershell":
  core:
    fileEncoding: "utf16be"
```

I have created a package to do this (https://atom.io/packages/default-encoding) which works, however I added this pull request if you guys think it will be useful.

Note this is not in lieu of auto detection, just another way to customise atom.

Thanks
