### PR TITLE
Upgrade to Squirrel for Windows 0.8

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -206,6 +206,7 @@ module.exports = (grunt) ->
       authors: 'GitHub Inc.'
       loadingGif: path.resolve(__dirname, '..', 'resources', 'win', 'loading.gif')
       iconUrl: 'https://raw.githubusercontent.com/atom/atom/master/resources/win/atom.ico'
+      setupIcon: path.resolve(__dirname, '..', 'resources', 'win', 'atom.ico')
 
     shell:
       'kill-atom':

--- a/build/package.json
+++ b/build/package.json
@@ -12,7 +12,7 @@
     "fs-plus": "2.x",
     "github-releases": "~0.2.0",
     "grunt": "~0.4.1",
-    "grunt-atom-shell-installer": "^0.16.0",
+    "grunt-atom-shell-installer": "^0.18.0",
     "grunt-cli": "~0.1.9",
     "grunt-coffeelint": "git+https://github.com/atom/grunt-coffeelint.git#cfb99aa99811d52687969532bd5a98011ed95bfe",
     "grunt-contrib-coffee": "~0.12.0",

--- a/build/package.json
+++ b/build/package.json
@@ -12,7 +12,7 @@
     "fs-plus": "2.x",
     "github-releases": "~0.2.0",
     "grunt": "~0.4.1",
-    "grunt-atom-shell-installer": "^0.18.0",
+    "grunt-atom-shell-installer": "^0.19.0",
     "grunt-cli": "~0.1.9",
     "grunt-coffeelint": "git+https://github.com/atom/grunt-coffeelint.git#cfb99aa99811d52687969532bd5a98011ed95bfe",
     "grunt-contrib-coffee": "~0.12.0",


### PR DESCRIPTION
### Upside
- `--silent` is now supported to `AtomSetup.exe` so https://github.com/atom/chocolatey/pull/35 can be released after this comes out
- `AtomSetup.exe` will now have the Atom icon when downloaded
- [Other bug fixes](https://github.com/Squirrel/Squirrel.Windows/releases/tag/0.8.0)
