### PR TITLE
Fix folds with splits

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -351,10 +351,15 @@ describe "DisplayBuffer", ->
           expect(displayBuffer.tokenizedLineForScreenRow(1).text).toMatch /^10/
 
       describe "when there is another display buffer pointing to the same buffer", ->
-        it "does not create folds in the other display buffer", ->
+        it "does not consider folds to be nested inside of folds from the other display buffer", ->
           otherDisplayBuffer = new DisplayBuffer({buffer, tabLength})
+          otherDisplayBuffer.createFold(1, 5)
+
           displayBuffer.createFold(2, 4)
           expect(otherDisplayBuffer.foldsStartingAtBufferRow(2).length).toBe 0
+
+          expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe '2'
+          expect(displayBuffer.tokenizedLineForScreenRow(3).text).toBe '5'
 
     describe "when the buffer changes", ->
       [fold1, fold2] = []

--- a/src/fold.coffee
+++ b/src/fold.coffee
@@ -19,10 +19,9 @@ class Fold
 
   # Returns whether this fold is contained within another fold
   isInsideLargerFold: ->
-    if largestContainingFoldMarker = @displayBuffer.findMarker(class: 'fold', containsBufferRange: @getBufferRange())
-      not largestContainingFoldMarker.getBufferRange().isEqual(@getBufferRange())
-    else
-      false
+    largestContainingFoldMarker = @displayBuffer.findFoldMarker(containsRange: @getBufferRange())
+    largestContainingFoldMarker and
+      not largestContainingFoldMarker.getRange().isEqual(@getBufferRange())
 
   # Destroys this fold
   destroy: ->


### PR DESCRIPTION
The first commit fixes an error that caused #4099; we were accidentally comparing folds from two different `DisplayBuffer`s, on the same `TextBuffer`.

 The second commit is a refactor to make it easier to avoid this kind of error. It makes it so that any time a `DisplayBuffer` is used to find or create markers, they are associated with that `DisplayBuffer`.
