### PR TITLE
Fix getOriginUrl calling itself

### DIFF
--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -33,7 +33,7 @@ Task = require './task'
 #
 # ```coffee
 # git = atom.project.getRepo()
-# console.log git.getOriginUrl()
+# console.log git.getOriginURL()
 # ```
 #
 # ### Requiring in packages
@@ -234,8 +234,8 @@ class GitRepository
   #   for, only needed if the repository has submodules.
   getOriginURL: (path) -> @getConfigValue('remote.origin.url', path)
   getOriginUrl: (path) ->
-    deprecate("Use ::getOriginURL instead.")
-    @getOriginUrl()
+    deprecate 'Use ::getOriginURL instead.'
+    @getOriginURL(path)
 
   # Public: Returns the upstream branch for the current HEAD, or null if there
   # is no upstream branch for the current HEAD.


### PR DESCRIPTION
I see this error when using `git-blame` package which is using the deprecated method `getOriginUrl`. Since it's the method is referring to itself, it's causing `Maximum call stack size` (https://github.com/alexcorre/git-blame/issues/56).
