### PR TITLE
Rename 'gutter' decorations to 'line-number'

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1063,7 +1063,7 @@ describe "DisplayBuffer", ->
     [marker, decoration, decorationProperties] = []
     beforeEach ->
       marker = displayBuffer.markBufferRange([[2, 13], [3, 15]])
-      decorationProperties = {type: 'gutter', class: 'one'}
+      decorationProperties = {type: 'line-number', class: 'one'}
       decoration = displayBuffer.decorateMarker(marker, decorationProperties)
 
     it "can add decorations associated with markers and remove them", ->
@@ -1084,11 +1084,11 @@ describe "DisplayBuffer", ->
     describe "when a decoration is updated via Decoration::update()", ->
       it "emits an 'updated' event containing the new and old params", ->
         decoration.onDidChangeProperties updatedSpy = jasmine.createSpy()
-        decoration.setProperties type: 'gutter', class: 'two'
+        decoration.setProperties type: 'line-number', class: 'two'
 
         {oldProperties, newProperties} = updatedSpy.mostRecentCall.args[0]
         expect(oldProperties).toEqual decorationProperties
-        expect(newProperties).toEqual type: 'gutter', class: 'two', id: decoration.id
+        expect(newProperties).toEqual type: 'line-number', class: 'two', id: decoration.id
 
     describe "::getDecorations(properties)", ->
       it "returns decorations matching the given optional properties", ->

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -931,7 +931,7 @@ describe "TextEditorComponent", ->
 
     beforeEach ->
       marker = editor.displayBuffer.markBufferRange([[2, 13], [3, 15]], invalidate: 'inside')
-      decorationParams = {type: ['gutter', 'line'], class: 'a'}
+      decorationParams = {type: ['line-number', 'line'], class: 'a'}
       decoration = editor.decorateMarker(marker, decorationParams)
       nextAnimationFrame()
 
@@ -946,7 +946,7 @@ describe "TextEditorComponent", ->
 
       # Add decorations that are out of range
       marker2 = editor.displayBuffer.markBufferRange([[9, 0], [9, 0]])
-      editor.decorateMarker(marker2, type: ['gutter', 'line'], class: 'b')
+      editor.decorateMarker(marker2, type: ['line-number', 'line'], class: 'b')
       nextAnimationFrame()
 
       # Scroll decorations into view
@@ -970,7 +970,7 @@ describe "TextEditorComponent", ->
 
       marker.destroy()
       marker = editor.markBufferRange([[0, 0], [0, 2]])
-      editor.decorateMarker(marker, type: ['gutter', 'line'], class: 'b')
+      editor.decorateMarker(marker, type: ['line-number', 'line'], class: 'b')
       nextAnimationFrame()
       expect(lineNumberHasClass(0, 'b')).toBe true
       expect(lineNumberHasClass(1, 'b')).toBe false
@@ -1039,7 +1039,7 @@ describe "TextEditorComponent", ->
 
     describe "when the decoration's 'onlyHead' property is true", ->
       it "only applies the decoration's class to lines containing the marker's head", ->
-        editor.decorateMarker(marker, type: ['gutter', 'line'], class: 'only-head', onlyHead: true)
+        editor.decorateMarker(marker, type: ['line-number', 'line'], class: 'only-head', onlyHead: true)
         nextAnimationFrame()
         expect(lineAndLineNumberHaveClass(1, 'only-head')).toBe false
         expect(lineAndLineNumberHaveClass(2, 'only-head')).toBe false
@@ -1048,7 +1048,7 @@ describe "TextEditorComponent", ->
 
     describe "when the decoration's 'onlyEmpty' property is true", ->
       it "only applies the decoration when its marker is empty", ->
-        editor.decorateMarker(marker, type: ['gutter', 'line'], class: 'only-empty', onlyEmpty: true)
+        editor.decorateMarker(marker, type: ['line-number', 'line'], class: 'only-empty', onlyEmpty: true)
         nextAnimationFrame()
         expect(lineAndLineNumberHaveClass(2, 'only-empty')).toBe false
         expect(lineAndLineNumberHaveClass(3, 'only-empty')).toBe false
@@ -1060,7 +1060,7 @@ describe "TextEditorComponent", ->
 
     describe "when the decoration's 'onlyNonEmpty' property is true", ->
       it "only applies the decoration when its marker is non-empty", ->
-        editor.decorateMarker(marker, type: ['gutter', 'line'], class: 'only-non-empty', onlyNonEmpty: true)
+        editor.decorateMarker(marker, type: ['line-number', 'line'], class: 'only-non-empty', onlyNonEmpty: true)
         nextAnimationFrame()
         expect(lineAndLineNumberHaveClass(2, 'only-non-empty')).toBe true
         expect(lineAndLineNumberHaveClass(3, 'only-non-empty')).toBe true

--- a/src/decoration.coffee
+++ b/src/decoration.coffee
@@ -34,8 +34,8 @@ class Decoration
 
   # Private: Check if the `decorationProperties.type` matches `type`
   #
-  # * `decorationProperties` {Object} eg. `{type: 'gutter', class: 'my-new-class'}`
-  # * `type` {String} type like `'gutter'`, `'line'`, etc. `type` can also
+  # * `decorationProperties` {Object} eg. `{type: 'line-number', class: 'my-new-class'}`
+  # * `type` {String} type like `'line-number'`, `'line'`, etc. `type` can also
   #   be an {Array} of {String}s, where it will return true if the decoration's
   #   type matches any in the array.
   #
@@ -107,7 +107,7 @@ class Decoration
 
   # Public: Check if this decoration is of type `type`
   #
-  # * `type` {String} type like `'gutter'`, `'line'`, etc. `type` can also
+  # * `type` {String} type like `'line-number'`, `'line'`, etc. `type` can also
   #   be an {Array} of {String}s, where it will return true if the decoration's
   #   type matches any in the array.
   #
@@ -131,10 +131,10 @@ class Decoration
   # ## Examples
   #
   # ```coffee
-  # decoration.update({type: 'gutter', class: 'my-new-class'})
+  # decoration.update({type: 'line-number', class: 'my-new-class'})
   # ```
   #
-  # * `newProperties` {Object} eg. `{type: 'gutter', class: 'my-new-class'}`
+  # * `newProperties` {Object} eg. `{type: 'line-number', class: 'my-new-class'}`
   setProperties: (newProperties) ->
     return if @destroyed
     oldProperties = @properties

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -898,7 +898,7 @@ class DisplayBuffer extends Model
     @getDecorations(propertyFilter).filter (decoration) -> decoration.isType('line')
 
   getGutterDecorations: (propertyFilter) ->
-    @getDecorations(propertyFilter).filter (decoration) -> decoration.isType('gutter')
+    @getDecorations(propertyFilter).filter (decoration) -> decoration.isType('line-number')
 
   getHighlightDecorations: (propertyFilter) ->
     @getDecorations(propertyFilter).filter (decoration) -> decoration.isType('highlight')
@@ -1222,7 +1222,7 @@ class DisplayBuffer extends Model
       @emitter.emit 'did-create-marker', marker
 
   createFoldForMarker: (marker) ->
-    @decorateMarker(marker, type: 'gutter', class: 'folded')
+    @decorateMarker(marker, type: 'line-number', class: 'folded')
     new Fold(this, marker)
 
   foldForMarker: (marker) ->

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -163,7 +163,7 @@ GutterComponent = React.createClass
     classes = ''
     if lineDecorations? and decorations = lineDecorations[screenRow]
       for id, decoration of decorations
-        if Decoration.isType(decoration, 'gutter')
+        if Decoration.isType(decoration, 'line-number')
           classes += decoration.class + ' '
 
     classes += "foldable " if bufferRow >= 0 and editor.isFoldableAtBufferRow(bufferRow)
@@ -195,12 +195,12 @@ GutterComponent = React.createClass
 
     if previousDecorations?
       for id, decoration of previousDecorations
-        if Decoration.isType(decoration, 'gutter') and not @hasDecoration(decorations, decoration)
+        if Decoration.isType(decoration, 'line-number') and not @hasDecoration(decorations, decoration)
           node.classList.remove(decoration.class)
 
     if decorations?
       for id, decoration of decorations
-        if Decoration.isType(decoration, 'gutter') and not @hasDecoration(previousDecorations, decoration)
+        if Decoration.isType(decoration, 'line-number') and not @hasDecoration(previousDecorations, decoration)
           node.classList.add(decoration.class)
 
     unless @screenRowsByLineNumberId[lineNumberId] is screenRow

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -312,7 +312,7 @@ TextEditorComponent = React.createClass
       headScreenRow = null
       if marker.isValid()
         for decoration in decorations
-          if decoration.isType('gutter') or decoration.isType('line')
+          if decoration.isType('line-number') or decoration.isType('line')
             decorationParams = decoration.getProperties()
             screenRange ?= marker.getScreenRange()
             headScreenRow ?= marker.getHeadScreenPosition().row

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1311,6 +1311,9 @@ class TextEditor extends Model
   #
   # Returns a {Decoration} object
   decorateMarker: (marker, decorationParams) ->
+    if decorationParams.type is 'gutter'
+      deprecate("Decorations of `type: 'gutter'` have been renamed to `type: 'line-number'`.")
+      decorationParams.type = 'line-number'
     @displayBuffer.decorateMarker(marker, decorationParams)
 
   # Public: Get all the decorations within a screen row range.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1282,7 +1282,7 @@ class TextEditor extends Model
   #
   # * `marker` A {Marker} you want this decoration to follow.
   # * `decorationParams` An {Object} representing the decoration e.g.
-  #   `{type: 'gutter', class: 'linter-error'}`
+  #   `{type: 'line-number', class: 'linter-error'}`
   #   * `type` There are a few supported decoration types: `gutter`, `line`,
   #     `highlight`, and `overlay`. The behavior of the types are as follows:
   #     * `gutter` Adds the given `class` to the line numbers overlapping the
@@ -1319,7 +1319,7 @@ class TextEditor extends Model
   # * `endScreenRow` the {Number} end screen row (inclusive)
   #
   # Returns an {Object} of decorations in the form
-  #  `{1: [{id: 10, type: 'gutter', class: 'someclass'}], 2: ...}`
+  #  `{1: [{id: 10, type: 'line-number', class: 'someclass'}], 2: ...}`
   #   where the keys are {Marker} IDs, and the values are an array of decoration
   #   params objects attached to the marker.
   # Returns an empty object when no decorations are found
@@ -1344,7 +1344,7 @@ class TextEditor extends Model
   getLineDecorations: (propertyFilter) ->
     @displayBuffer.getLineDecorations(propertyFilter)
 
-  # Extended: Get all decorations of type 'gutter'.
+  # Extended: Get all decorations of type 'line-number'.
   #
   # * `propertyFilter` (optional) An {Object} containing key value pairs that
   #   the returned decorations' properties must match.
@@ -1747,8 +1747,8 @@ class TextEditor extends Model
   addCursor: (marker) ->
     cursor = new Cursor(editor: this, marker: marker)
     @cursors.push(cursor)
-    @decorateMarker(marker, type: 'gutter', class: 'cursor-line')
-    @decorateMarker(marker, type: 'gutter', class: 'cursor-line-no-selection', onlyHead: true, onlyEmpty: true)
+    @decorateMarker(marker, type: 'line-number', class: 'cursor-line')
+    @decorateMarker(marker, type: 'line-number', class: 'cursor-line-no-selection', onlyHead: true, onlyEmpty: true)
     @decorateMarker(marker, type: 'line', class: 'cursor-line', onlyEmpty: true)
     @emit 'cursor-added', cursor
     @emitter.emit 'did-add-cursor', cursor


### PR DESCRIPTION
We're talking about adding APIs for multiple gutters, so the name 'gutter' for these decorations doesn't really make sense. What we're actually decorating is the _line numbers_, which will be just one of the potential gutters on an atom editor.
