### PR TITLE
Check if files are accessible during deserialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "nslog": "^1.0.1",
     "oniguruma": "^3.0.6",
     "optimist": "0.4.0",
-    "pathwatcher": "^2.6.0",
+    "pathwatcher": "^2.6.1",
     "property-accessors": "^1",
     "q": "^1.0.1",
     "random-words": "0.0.1",

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -50,6 +50,19 @@ describe "Project", ->
         deserializedProject = atom.project.testSerialization()
         expect(deserializedProject.getBuffers().length).toBe 0
 
+    it "does not deserialize buffers when their path is inaccessible", ->
+      pathToOpen = path.join(temp.mkdirSync(), 'file.txt')
+      fs.writeFileSync(pathToOpen, '')
+
+      waitsForPromise ->
+        atom.project.open(pathToOpen)
+
+      runs ->
+        expect(atom.project.getBuffers().length).toBe 1
+        fs.chmodSync(pathToOpen, '000')
+        deserializedProject = atom.project.testSerialization()
+        expect(deserializedProject.getBuffers().length).toBe 0
+
   describe "when an editor is saved and the project has no path", ->
     it "sets the project's path to the saved file's parent directory", ->
       tempFile = temp.openSync().path

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -38,7 +38,7 @@ describe "Project", ->
         expect(deserializedProject.getBuffers().length).toBe 0
 
 
-    it "does not deserialize buffers when the path is a directory", ->
+    it "does not deserialize buffers when their path is a directory that exists", ->
       pathToOpen = path.join(temp.mkdirSync(), 'file.txt')
 
       waitsForPromise ->

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -37,6 +37,19 @@ describe "Project", ->
         deserializedProject.getBuffers()[0].destroy()
         expect(deserializedProject.getBuffers().length).toBe 0
 
+
+    it "does not deserialize buffers when the path is a directory", ->
+      pathToOpen = path.join(temp.mkdirSync(), 'file.txt')
+
+      waitsForPromise ->
+        atom.project.open(pathToOpen)
+
+      runs ->
+        expect(atom.project.getBuffers().length).toBe 1
+        fs.mkdirSync(pathToOpen)
+        deserializedProject = atom.project.testSerialization()
+        expect(deserializedProject.getBuffers().length).toBe 0
+
   describe "when an editor is saved and the project has no path", ->
     it "sets the project's path to the saved file's parent directory", ->
       tempFile = temp.openSync().path

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -226,8 +226,7 @@ class Project extends Model
 
     if filePath?
       try
-        fileDescriptor = fs.openSync(filePath, 'r+')
-        fs.closeSync(fileDescriptor)
+        fs.closeSync(fs.openSync(filePath, 'r+'))
       catch error
         # allow ENOENT errors to create an editor for paths that dont exist
         throw error unless error.code is 'ENOENT'

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -67,11 +67,14 @@ class Project extends Model
 
   deserializeParams: (params) ->
     params.buffers = _.compact params.buffers.map (bufferState) ->
-      try
-        atom.deserializers.deserialize(bufferState)
-      catch error
-        # Ignore buffers whose previous paths are now folders
-        throw error unless error.code is 'EISDIR'
+      # Check that buffer's file path is accessible
+      if bufferState.filePath
+        try
+          fs.closeSync(fs.openSync(bufferState.filePath, 'r+'))
+        catch error
+          return unless error.code is 'ENOENT'
+
+      atom.deserializers.deserialize(bufferState)
     params
 
   ###

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -66,7 +66,12 @@ class Project extends Model
     buffers: _.compact(@buffers.map (buffer) -> buffer.serialize() if buffer.isRetained())
 
   deserializeParams: (params) ->
-    params.buffers = params.buffers.map (bufferState) -> atom.deserializers.deserialize(bufferState)
+    params.buffers = _.compact params.buffers.map (bufferState) ->
+      try
+        atom.deserializers.deserialize(bufferState)
+      catch error
+        # Ignore buffers for files that are now folders
+        throw error unless error.code is 'EISDIR'
     params
 
 

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -70,7 +70,7 @@ class Project extends Model
       try
         atom.deserializers.deserialize(bufferState)
       catch error
-        # Ignore buffers for files that are now folders
+        # Ignore buffers whose previous paths are now folders
         throw error unless error.code is 'EISDIR'
     params
 

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -74,7 +74,6 @@ class Project extends Model
         throw error unless error.code is 'EISDIR'
     params
 
-
   ###
   Section: Event Subscription
   ###


### PR DESCRIPTION
If a buffer's serialized path was a directory upon deserialization then Atom would previously fail to launch.

Now these invalid buffers are ignored and deserialization can complete successfully.

Fixes #4199
Fixes #4939
Fixes #5084
