### PR TITLE
Add ._* to ignored file names

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -9,7 +9,7 @@ module.exports =
     properties:
       ignoredNames:
         type: 'array'
-        default: [".git", ".hg", ".svn", ".DS_Store", "Thumbs.db"]
+        default: [".git", ".hg", ".svn", ".DS_Store", "._*", "Thumbs.db"]
         items:
           type: 'string'
       excludeVcsIgnoredPaths:


### PR DESCRIPTION
Macs generate ._ files when saving to a filesystem other then HFS
In shared environments this is a big problem
