### PR TITLE
Allow opening of readonly files

### DIFF
--- a/src/project.coffee
+++ b/src/project.coffee
@@ -70,7 +70,7 @@ class Project extends Model
       # Check that buffer's file path is accessible
       if bufferState.filePath
         try
-          fs.closeSync(fs.openSync(bufferState.filePath, 'r+'))
+          fs.closeSync(fs.openSync(bufferState.filePath, 'r'))
         catch error
           return unless error.code is 'ENOENT'
 
@@ -226,7 +226,7 @@ class Project extends Model
 
     if filePath?
       try
-        fs.closeSync(fs.openSync(filePath, 'r+'))
+        fs.closeSync(fs.openSync(filePath, 'r'))
       catch error
         # allow ENOENT errors to create an editor for paths that dont exist
         throw error unless error.code is 'ENOENT'

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -68,6 +68,7 @@ class Project extends Model
   deserializeParams: (params) ->
     params.buffers = _.compact params.buffers.map (bufferState) ->
       # Check that buffer's file path is accessible
+      return if fs.isDirectorySync(bufferState.filePath)
       if bufferState.filePath
         try
           fs.closeSync(fs.openSync(bufferState.filePath, 'r'))

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -456,6 +456,8 @@ class Workspace extends Model
           atom.notifications.addWarning("#{error.message} Large file support is being tracked at [atom/atom#307](https://github.com/atom/atom/issues/307).")
         when 'EACCES'
           atom.notifications.addWarning("Permission denied '#{error.path}'")
+        when 'EPERM'
+          atom.notifications.addWarning("Unable to open '#{error.path}'", detail: error.message)
         else
           throw error
       return Q()
@@ -625,6 +627,8 @@ class Workspace extends Model
         atom.notifications.addWarning("Unable to save file: #{error.message}")
       else if error.code is 'EACCES' and error.path?
         atom.notifications.addWarning("Unable to save file: Permission denied '#{error.path}'")
+      else if error.code is 'EPERM' and error.path?
+        atom.notifications.addWarning("Unable to save file '#{error.path}'", detail: error.message)
       else if errorMatch = /ENOTDIR, not a directory '([^']+)'/.exec(error.message)
         fileName = errorMatch[1]
         atom.notifications.addWarning("Unable to save file: A directory in the path '#{fileName}' could not be written to")

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -458,6 +458,8 @@ class Workspace extends Model
           atom.notifications.addWarning("Permission denied '#{error.path}'")
         when 'EPERM'
           atom.notifications.addWarning("Unable to open '#{error.path}'", detail: error.message)
+        when 'EBUSY'
+          atom.notifications.addWarning("Unable to open '#{error.path}'", detail: error.message)
         else
           throw error
       return Q()
@@ -628,6 +630,8 @@ class Workspace extends Model
       else if error.code is 'EACCES' and error.path?
         atom.notifications.addWarning("Unable to save file: Permission denied '#{error.path}'")
       else if error.code is 'EPERM' and error.path?
+        atom.notifications.addWarning("Unable to save file '#{error.path}'", detail: error.message)
+      else if error.code is 'EBUSY' and error.path?
         atom.notifications.addWarning("Unable to save file '#{error.path}'", detail: error.message)
       else if errorMatch = /ENOTDIR, not a directory '([^']+)'/.exec(error.message)
         fileName = errorMatch[1]

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -456,9 +456,7 @@ class Workspace extends Model
           atom.notifications.addWarning("#{error.message} Large file support is being tracked at [atom/atom#307](https://github.com/atom/atom/issues/307).")
         when 'EACCES'
           atom.notifications.addWarning("Permission denied '#{error.path}'")
-        when 'EPERM'
-          atom.notifications.addWarning("Unable to open '#{error.path}'", detail: error.message)
-        when 'EBUSY'
+        when 'EPERM', 'EBUSY'
           atom.notifications.addWarning("Unable to open '#{error.path}'", detail: error.message)
         else
           throw error


### PR DESCRIPTION
- Checks that it can open as read rather than read/write; this will fix the `EPERM` and `EBUSY` errors on read.
- Makes the error better for `EPERM` and `EBUSY` errors when they do happen on save

Closes #5102 
Closes #5107 
Closes #5112 
Closes #3231
