### PR TITLE
Replace the lipstick emoji for formatting changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ For more information on how to work with Atom's official packages, see
 * Limit the first line to 72 characters or less
 * Reference issues and pull requests liberally
 * Consider starting the commit message with an applicable emoji:
-    * :lipstick: `:lipstick:` when improving the format/structure of the code
+    * :art: `:art:` when improving the format/structure of the code
     * :racehorse: `:racehorse:` when improving performance
     * :non-potable_water: `:non-potable_water:` when plugging memory leaks
     * :memo: `:memo:` when writing docs


### PR DESCRIPTION
With the aim of being a bit more inclusive, this PR changes the suggested emoji indicating a style or formatting change from :lipstick: to :art:.

Fixes #5111
