### PR TITLE
Make popover-list max-height relative to viewport

### DIFF
--- a/static/popover-list.less
+++ b/static/popover-list.less
@@ -8,5 +8,5 @@
 .select-list.popover-list ol.list-group {
   position: relative;
   overflow-y: scroll;
-  max-height: 200px;
+  max-height: 33vh;
 }


### PR DESCRIPTION
It's not really a bug, but I think the `max-height: 200px` is a bit arbitrary.  On small screens it may be too much, on large screens perhaps you could show some more. I think it would make sense to use the `vh` unit here.

PS. Ran into this when debugging a little layout issue in autocomplete-plus. https://github.com/atom-community/autocomplete-plus/issues/194
