### PR TITLE
Shorten apm paths in bundle

### DIFF
--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -144,7 +144,11 @@ module.exports = (grunt) ->
     cp 'spec', path.join(appDir, 'spec')
     cp 'src', path.join(appDir, 'src'), filter: /.+\.(cson|coffee)$/
     cp 'static', path.join(appDir, 'static')
-    cp 'apm', path.join(appDir, 'apm'), filter: filterNodeModule
+
+    if process.platform is 'win32'
+      cp path.join('apm', 'node_modules', 'atom-package-manager'), path.join(appDir, 'apm'), filter: filterNodeModule
+    else
+      cp 'apm', path.join(appDir, 'apm'), filter: filterNodeModule
 
     if process.platform is 'darwin'
       grunt.file.recurse path.join('resources', 'mac'), (sourcePath, rootDirectory, subDirectory='', filename) ->

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -145,10 +145,9 @@ module.exports = (grunt) ->
     cp 'src', path.join(appDir, 'src'), filter: /.+\.(cson|coffee)$/
     cp 'static', path.join(appDir, 'static')
 
-    if process.platform is 'win32'
-      cp path.join('apm', 'node_modules', 'atom-package-manager'), path.join(appDir, 'apm'), filter: filterNodeModule
-    else
-      cp 'apm', path.join(appDir, 'apm'), filter: filterNodeModule
+    cp path.join('apm', 'node_modules', 'atom-package-manager'), path.join(appDir, 'apm'), filter: filterNodeModule
+    if process.platform isnt 'win32'
+      fs.symlinkSync(path.join('..', '..', 'bin', 'apm'), path.join(appDir, 'apm', 'node_modules', '.bin', 'apm'))
 
     if process.platform is 'darwin'
       grunt.file.recurse path.join('resources', 'mac'), (sourcePath, rootDirectory, subDirectory='', filename) ->

--- a/resources/win/apm.sh
+++ b/resources/win/apm.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-"$0/../../app/apm/node_modules/atom-package-manager/bin/node.exe" "$0/../../app/apm/node_modules/atom-package-manager/lib/cli.js" "$@"
+"$0/../../app/apm/bin/node.exe" "$0/../../app/apm/lib/cli.js" "$@"

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -18,5 +18,5 @@ FOR %%a IN (%*) DO (
 IF "%EXPECT_OUTPUT%"=="YES" (
   "%~dp0\..\..\atom.exe" %*
 ) ELSE (
-  "%~dp0\..\app\apm\node_modules\atom-package-manager\bin\node.exe" "%~dp0\atom.js" %*
+  "%~dp0\..\app\apm\bin\node.exe" "%~dp0\atom.js" %*
 )

--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -18,5 +18,5 @@ done
 if [ $EXPECT_OUTPUT ]; then
   "$0/../../../atom.exe" "$@"
 else
-  "$0/../../app/apm/node_modules/atom-package-manager/bin/node.exe" "$0/../atom.js" "$@"
+  "$0/../../app/apm/bin/node.exe" "$0/../atom.js" "$@"
 fi

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -125,7 +125,7 @@ addCommandsToPath = (callback) ->
     atomShCommand = "#!/bin/sh\r\n\"$0/../#{relativeAtomShPath.replace(/\\/g, '/')}\" \"$@\""
 
     apmCommandPath = path.join(binFolder, 'apm.cmd')
-    relativeApmPath = path.relative(binFolder, path.join(process.resourcesPath, 'app', 'apm', 'node_modules', 'atom-package-manager', 'bin', 'apm.cmd'))
+    relativeApmPath = path.relative(binFolder, path.join(process.resourcesPath, 'app', 'apm', 'bin', 'apm.cmd'))
     apmCommand = "@echo off\r\n\"%~dp0\\#{relativeApmPath}\" %*"
 
     apmShCommandPath = path.join(binFolder, 'apm')

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -128,9 +128,10 @@ class PackageManager
   #
   # Return a {String} file path to apm.
   getApmPath: ->
-    commandName = 'apm'
-    commandName += '.cmd' if process.platform is 'win32'
-    @apmPath ?= path.resolve(__dirname, '..', 'apm', 'node_modules', 'atom-package-manager', 'bin', commandName)
+    if process.platform is 'win32'
+      @apmPath ?= path.resolve(__dirname, '..', 'apm', 'bin', 'apm.cmd')
+    else
+      @apmPath ?= path.resolve(__dirname, '..', 'apm', 'node_modules', 'atom-package-manager', 'bin', 'apm')
 
   # Public: Get the paths being used to look for packages.
   #

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -128,10 +128,9 @@ class PackageManager
   #
   # Return a {String} file path to apm.
   getApmPath: ->
-    if process.platform is 'win32'
-      @apmPath ?= path.resolve(__dirname, '..', 'apm', 'bin', 'apm.cmd')
-    else
-      @apmPath ?= path.resolve(__dirname, '..', 'apm', 'node_modules', 'atom-package-manager', 'bin', 'apm')
+    commandName = 'apm'
+    commandName += '.cmd' if process.platform is 'win32'
+    @apmPath ?= path.resolve(__dirname, '..', 'apm', 'bin', commandName)
 
   # Public: Get the paths being used to look for packages.
   #

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -128,9 +128,15 @@ class PackageManager
   #
   # Return a {String} file path to apm.
   getApmPath: ->
+    return @apmPath if @apmPath?
+
     commandName = 'apm'
     commandName += '.cmd' if process.platform is 'win32'
-    @apmPath ?= path.resolve(__dirname, '..', 'apm', 'bin', commandName)
+    apmRoot = path.resolve(__dirname, '..', 'apm')
+    @apmPath = path.join(apmRoot, 'bin', commandName)
+    unless fs.isFileSync(@apmPath)
+      @apmPath = path.join(apmRoot, 'node_modules', 'atom-package-manager', 'bin', commandName)
+    @apmPath
 
   # Public: Get the paths being used to look for packages.
   #


### PR DESCRIPTION
Previously app was installed at `apm/node_modules/atom-package-manager` in the distribution.

This made the paths longer than they needed to be, so the `node_modules/atom-package-manager` folder now sits directly in the root `apm` folder.

All paths in the install are now under 200 characters so hopefully all long path install errors will no longer occur. You can run `script/grunt output-long-paths` to check this.

Closes #5109
