### PR TITLE
Upgrade core to space-pen 5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "semver": "2.2.1",
     "serializable": "^1",
     "service-hub": "^0.2.0",
-    "space-pen": "3.8.2",
+    "space-pen": "^5.1",
     "stacktrace-parser": "0.1.1",
     "temp": "0.7.0",
     "text-buffer": "^3.10.0",

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -37,7 +37,7 @@ function bootstrap() {
   var initialNpmCommand = fs.existsSync(npmPath) ? npmPath : 'npm';
   var npmFlags = ' --userconfig=' + path.resolve('.npmrc') + ' ';
 
-  var packagesToDedupe = ['fs-plus', 'humanize-plus', 'oniguruma', 'roaster', 'season', 'grim'];
+  var packagesToDedupe = ['fs-plus', 'humanize-plus', 'oniguruma', 'roaster', 'season', 'grim', 'space-pen'];
 
   var buildInstallCommand = initialNpmCommand + npmFlags + 'install';
   var buildInstallOptions = {cwd: path.resolve(__dirname, '..', 'build')};

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -611,7 +611,7 @@ class Atom extends Model
     @project?.destroy()
     @project = null
 
-    @windowEventHandler?.unsubscribe()
+    @windowEventHandler?.destroy()
 
   ###
   Section: Messaging the User


### PR DESCRIPTION
Previously core was on space-pen 3.8 which meant it wasn't getting deduped across packages and so we were shipping 28 versions of it in the app.

This also upgrades Atom to jQuery 2.1.3 via https://github.com/atom/space-pen/pull/63
