### PR TITLE
:apple: try ~/Applications before using mdfind

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -45,18 +45,24 @@ if [ $REDIRECT_STDERR ]; then
 fi
 
 if [ $OS == 'Mac' ]; then
-  ATOM_PATH="${ATOM_PATH:-/Applications}" # Set ATOM_PATH unless it is already set
   ATOM_APP_NAME=Atom.app
 
-  # If ATOM_PATH isn't a executable file, use spotlight to search for Atom
-  if [ ! -x "$ATOM_PATH/$ATOM_APP_NAME" ]; then
-    ATOM_PATH="$(mdfind "kMDItemCFBundleIdentifier == 'com.github.atom'" | grep -v ShipIt | head -1 | xargs -0 dirname)"
-  fi
+  if [ -z "${ATOM_PATH}" ]; then
+    # If ATOM_PATH isnt set, check /Applications and then ~/Applications for Atom.app
+    if [ -x "/Applications/$ATOM_APP_NAME" ]; then
+      ATOM_PATH="/Applications"
+    elif [ -x "$HOME/Applications/$ATOM_APP_NAME" ]; then
+      ATOM_PATH="$HOME/Applications"
+    else
+      # We havent found an Atom.app, use spotlight to search for Atom
+      ATOM_PATH="$(mdfind "kMDItemCFBundleIdentifier == 'com.github.atom'" | grep -v ShipIt | head -1 | xargs -0 dirname)"
 
-  # Exit if Atom can't be found
-  if [ -z "$ATOM_PATH" ]; then
-    echo "Cannot locate Atom.app, it is usually located in /Applications. Set the ATOM_PATH environment variable to the directory containing Atom.app."
-    exit 1
+      # Exit if Atom can't be found
+      if [ ! -x "$ATOM_PATH/$ATOM_APP_NAME" ]; then
+        echo "Cannot locate Atom.app, it is usually located in /Applications. Set the ATOM_PATH environment variable to the directory containing Atom.app."
+        exit 1
+      fi
+    fi
   fi
 
   if [ $EXPECT_OUTPUT ]; then


### PR DESCRIPTION
When Atom is installed with [Homebrew](https://github.com/Homebrew/homebrew), it will be in `~/Applications` instead of `/Applications`. This change updates the `atom.sh` startup script to check both `/Applications` and `~/Applications` before falling back to a metadata search.

Behavior is unchanged when `$ATOM_PATH` is unset or empty.
