### PR TITLE
[Gutter] Implement API for Creating Custom Gutters

### DIFF
--- a/spec/custom-gutter-component-spec.coffee
+++ b/spec/custom-gutter-component-spec.coffee
@@ -2,28 +2,28 @@ CustomGutterComponent = require '../src/custom-gutter-component'
 Gutter = require '../src/gutter'
 
 describe "CustomGutterComponent", ->
-  [customGutterComponent, gutter] = []
+  [gutterComponent, gutter] = []
 
   beforeEach ->
     mockGutterContainer = {}
     gutter = new Gutter(mockGutterContainer, {name: 'test-gutter'})
-    customGutterComponent = new CustomGutterComponent({gutter})
+    gutterComponent = new CustomGutterComponent({gutter})
 
   it "creates a gutter DOM node with only an empty 'custom-decorations' child node when it is initialized", ->
-    expect(customGutterComponent.getDomNode().classList.contains('gutter')).toBe true
-    expect(customGutterComponent.getDomNode().getAttribute('gutter-name')).toBe 'test-gutter'
-    expect(customGutterComponent.getDomNode().children.length).toBe 1
-    decorationsWrapperNode = customGutterComponent.getDomNode().children.item(0)
+    expect(gutterComponent.getDomNode().classList.contains('gutter')).toBe true
+    expect(gutterComponent.getDomNode().getAttribute('gutter-name')).toBe 'test-gutter'
+    expect(gutterComponent.getDomNode().children.length).toBe 1
+    decorationsWrapperNode = gutterComponent.getDomNode().children.item(0)
     expect(decorationsWrapperNode.classList.contains('custom-decorations')).toBe true
 
   it "makes its view accessible from the view registry", ->
-    expect(customGutterComponent.getDomNode()).toBe atom.views.getView(gutter)
+    expect(gutterComponent.getDomNode()).toBe atom.views.getView(gutter)
 
   it "hides its DOM node when ::hideNode is called, and shows its DOM node when ::showNode is called", ->
-    customGutterComponent.hideNode()
-    expect(customGutterComponent.getDomNode().style.display).toBe 'none'
-    customGutterComponent.showNode()
-    expect(customGutterComponent.getDomNode().style.display).toBe ''
+    gutterComponent.hideNode()
+    expect(gutterComponent.getDomNode().style.display).toBe 'none'
+    gutterComponent.showNode()
+    expect(gutterComponent.getDomNode().style.display).toBe ''
 
   describe "::updateSync", ->
     decorationItem1 = document.createElement('div')
@@ -42,12 +42,12 @@ describe "CustomGutterComponent", ->
       mockTestState
 
     it "sets the custom-decoration wrapper's scrollHeight, scrollTop, and background color", ->
-      decorationsWrapperNode = customGutterComponent.getDomNode().children.item(0)
+      decorationsWrapperNode = gutterComponent.getDomNode().children.item(0)
       expect(decorationsWrapperNode.style.height).toBe ''
       expect(decorationsWrapperNode.style['-webkit-transform']).toBe ''
       expect(decorationsWrapperNode.style.backgroundColor).toBe ''
 
-      customGutterComponent.updateSync(buildTestState({}))
+      gutterComponent.updateSync(buildTestState({}))
       expect(decorationsWrapperNode.style.height).not.toBe ''
       expect(decorationsWrapperNode.style['-webkit-transform']).not.toBe ''
       expect(decorationsWrapperNode.style.backgroundColor).not.toBe ''
@@ -60,8 +60,8 @@ describe "CustomGutterComponent", ->
           item: decorationItem1
           class: 'test-class-1'
 
-      customGutterComponent.updateSync(buildTestState(customDecorations))
-      decorationsWrapperNode = customGutterComponent.getDomNode().children.item(0)
+      gutterComponent.updateSync(buildTestState(customDecorations))
+      decorationsWrapperNode = gutterComponent.getDomNode().children.item(0)
       expect(decorationsWrapperNode.children.length).toBe 1
 
       decorationNode = decorationsWrapperNode.children.item(0)
@@ -81,8 +81,8 @@ describe "CustomGutterComponent", ->
           height: 10
           item: decorationItem1
           class: 'test-class-1'
-      customGutterComponent.updateSync(buildTestState(initialCustomDecorations))
-      initialDecorationNode = customGutterComponent.getDomNode().children.item(0).children.item(0)
+      gutterComponent.updateSync(buildTestState(initialCustomDecorations))
+      initialDecorationNode = gutterComponent.getDomNode().children.item(0).children.item(0)
 
       # Change the dimensions and item, remove the class.
       decorationItem2 = document.createElement('div')
@@ -91,8 +91,8 @@ describe "CustomGutterComponent", ->
           top: 10
           height: 20
           item: decorationItem2
-      customGutterComponent.updateSync(buildTestState(changedCustomDecorations))
-      changedDecorationNode = customGutterComponent.getDomNode().children.item(0).children.item(0)
+      gutterComponent.updateSync(buildTestState(changedCustomDecorations))
+      changedDecorationNode = gutterComponent.getDomNode().children.item(0).children.item(0)
       expect(changedDecorationNode).toBe initialDecorationNode
       expect(changedDecorationNode.style.top).toBe '10px'
       expect(changedDecorationNode.style.height).toBe '20px'
@@ -108,8 +108,8 @@ describe "CustomGutterComponent", ->
           top: 10
           height: 20
           class: 'test-class-2'
-      customGutterComponent.updateSync(buildTestState(changedCustomDecorations))
-      changedDecorationNode = customGutterComponent.getDomNode().children.item(0).children.item(0)
+      gutterComponent.updateSync(buildTestState(changedCustomDecorations))
+      changedDecorationNode = gutterComponent.getDomNode().children.item(0).children.item(0)
       expect(changedDecorationNode).toBe initialDecorationNode
       expect(changedDecorationNode.style.top).toBe '10px'
       expect(changedDecorationNode.style.height).toBe '20px'
@@ -123,10 +123,10 @@ describe "CustomGutterComponent", ->
           top: 0
           height: 10
           class: 'test-class-1'
-      customGutterComponent.updateSync(buildTestState(customDecorations))
-      decorationsWrapperNode = customGutterComponent.getDomNode().children.item(0)
+      gutterComponent.updateSync(buildTestState(customDecorations))
+      decorationsWrapperNode = gutterComponent.getDomNode().children.item(0)
       expect(decorationsWrapperNode.children.length).toBe 1
 
       emptyCustomDecorations = 'test-gutter': {}
-      customGutterComponent.updateSync(buildTestState(emptyCustomDecorations))
+      gutterComponent.updateSync(buildTestState(emptyCustomDecorations))
       expect(decorationsWrapperNode.children.length).toBe 0

--- a/spec/custom-gutter-component-spec.coffee
+++ b/spec/custom-gutter-component-spec.coffee
@@ -1,0 +1,132 @@
+CustomGutterComponent = require '../src/custom-gutter-component'
+Gutter = require '../src/gutter'
+
+describe "CustomGutterComponent", ->
+  [customGutterComponent, gutter] = []
+
+  beforeEach ->
+    mockGutterContainer = {}
+    gutter = new Gutter(mockGutterContainer, {name: 'test-gutter'})
+    customGutterComponent = new CustomGutterComponent({gutter})
+
+  it "creates a gutter DOM node with only an empty 'custom-decorations' child node when it is initialized", ->
+    expect(customGutterComponent.getDomNode().classList.contains('gutter')).toBe true
+    expect(customGutterComponent.getDomNode().getAttribute('gutter-name')).toBe 'test-gutter'
+    expect(customGutterComponent.getDomNode().children.length).toBe 1
+    decorationsWrapperNode = customGutterComponent.getDomNode().children.item(0)
+    expect(decorationsWrapperNode.classList.contains('custom-decorations')).toBe true
+
+  it "makes its view accessible from the view registry", ->
+    expect(customGutterComponent.getDomNode()).toBe atom.views.getView(gutter)
+
+  it "hides its DOM node when ::hideNode is called, and shows its DOM node when ::showNode is called", ->
+    customGutterComponent.hideNode()
+    expect(customGutterComponent.getDomNode().style.display).toBe 'none'
+    customGutterComponent.showNode()
+    expect(customGutterComponent.getDomNode().style.display).toBe ''
+
+  describe "::updateSync", ->
+    decorationItem1 = document.createElement('div')
+
+    buildTestState = (customDecorations) ->
+      mockTestState =
+        gutters:
+          scrollHeight: 100
+          scrollTop: 10
+          backgroundColor: 'black'
+          sortedDescriptions: [{gutter, visible: true}]
+          customDecorations: customDecorations
+        lineNumberGutter:
+          maxLineNumberDigits: 10
+          lineNumbers: {}
+      mockTestState
+
+    it "sets the custom-decoration wrapper's scrollHeight, scrollTop, and background color", ->
+      decorationsWrapperNode = customGutterComponent.getDomNode().children.item(0)
+      expect(decorationsWrapperNode.style.height).toBe ''
+      expect(decorationsWrapperNode.style['-webkit-transform']).toBe ''
+      expect(decorationsWrapperNode.style.backgroundColor).toBe ''
+
+      customGutterComponent.updateSync(buildTestState({}))
+      expect(decorationsWrapperNode.style.height).not.toBe ''
+      expect(decorationsWrapperNode.style['-webkit-transform']).not.toBe ''
+      expect(decorationsWrapperNode.style.backgroundColor).not.toBe ''
+
+    it "creates a new DOM node for a new decoration and adds it to the gutter at the right place", ->
+      customDecorations = 'test-gutter':
+        'decoration-id-1':
+          top: 0
+          height: 10
+          item: decorationItem1
+          class: 'test-class-1'
+
+      customGutterComponent.updateSync(buildTestState(customDecorations))
+      decorationsWrapperNode = customGutterComponent.getDomNode().children.item(0)
+      expect(decorationsWrapperNode.children.length).toBe 1
+
+      decorationNode = decorationsWrapperNode.children.item(0)
+      expect(decorationNode.style.top).toBe '0px'
+      expect(decorationNode.style.height).toBe '10px'
+      expect(decorationNode.classList.contains('test-class-1')).toBe true
+      expect(decorationNode.classList.contains('decoration')).toBe true
+      expect(decorationNode.children.length).toBe 1
+
+      decorationItem = decorationNode.children.item(0)
+      expect(decorationItem).toBe decorationItem1
+
+    it "updates the existing DOM node for a decoration that existed but has new properties", ->
+      initialCustomDecorations = 'test-gutter':
+        'decoration-id-1':
+          top: 0
+          height: 10
+          item: decorationItem1
+          class: 'test-class-1'
+      customGutterComponent.updateSync(buildTestState(initialCustomDecorations))
+      initialDecorationNode = customGutterComponent.getDomNode().children.item(0).children.item(0)
+
+      # Change the dimensions and item, remove the class.
+      decorationItem2 = document.createElement('div')
+      changedCustomDecorations = 'test-gutter':
+        'decoration-id-1':
+          top: 10
+          height: 20
+          item: decorationItem2
+      customGutterComponent.updateSync(buildTestState(changedCustomDecorations))
+      changedDecorationNode = customGutterComponent.getDomNode().children.item(0).children.item(0)
+      expect(changedDecorationNode).toBe initialDecorationNode
+      expect(changedDecorationNode.style.top).toBe '10px'
+      expect(changedDecorationNode.style.height).toBe '20px'
+      expect(changedDecorationNode.classList.contains('test-class-1')).toBe false
+      expect(changedDecorationNode.classList.contains('decoration')).toBe true
+      expect(changedDecorationNode.children.length).toBe 1
+      decorationItem = changedDecorationNode.children.item(0)
+      expect(decorationItem).toBe decorationItem2
+
+      # Remove the item, add a class.
+      changedCustomDecorations = 'test-gutter':
+        'decoration-id-1':
+          top: 10
+          height: 20
+          class: 'test-class-2'
+      customGutterComponent.updateSync(buildTestState(changedCustomDecorations))
+      changedDecorationNode = customGutterComponent.getDomNode().children.item(0).children.item(0)
+      expect(changedDecorationNode).toBe initialDecorationNode
+      expect(changedDecorationNode.style.top).toBe '10px'
+      expect(changedDecorationNode.style.height).toBe '20px'
+      expect(changedDecorationNode.classList.contains('test-class-2')).toBe true
+      expect(changedDecorationNode.classList.contains('decoration')).toBe true
+      expect(changedDecorationNode.children.length).toBe 0
+
+    it "removes any decorations that existed previously but aren't in the latest update", ->
+      customDecorations = 'test-gutter':
+        'decoration-id-1':
+          top: 0
+          height: 10
+          class: 'test-class-1'
+      customGutterComponent.updateSync(buildTestState(customDecorations))
+      decorationsWrapperNode = customGutterComponent.getDomNode().children.item(0)
+      expect(decorationsWrapperNode.children.length).toBe 1
+
+      emptyCustomDecorations = 'test-gutter': {}
+      customGutterComponent.updateSync(buildTestState(emptyCustomDecorations))
+      expect(decorationsWrapperNode.children.length).toBe 0

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1208,7 +1208,7 @@ describe "DisplayBuffer", ->
 
         {oldProperties, newProperties} = updatedSpy.mostRecentCall.args[0]
         expect(oldProperties).toEqual decorationProperties
-        expect(newProperties).toEqual type: 'line-number', class: 'two', id: decoration.id
+        expect(newProperties).toEqual type: 'line-number', gutterName: 'line-number', class: 'two', id: decoration.id
 
     describe "::getDecorations(properties)", ->
       it "returns decorations matching the given optional properties", ->
@@ -1367,3 +1367,26 @@ describe "DisplayBuffer", ->
       displayBuffer.setScrollTop(60)
 
       expect(displayBuffer.getVisibleRowRange()).toEqual [0, 13]
+
+  describe "::decorateMarker", ->
+    describe "when decorating gutters", ->
+      [marker] = []
+
+      beforeEach ->
+        marker = displayBuffer.markBufferRange([[1, 0], [1, 0]]);
+
+      it "creates a decoration that is both of 'line-number' and 'gutter' type when called with the 'line-number' type", ->
+        decorationProperties = {type: 'line-number', class: 'one'}
+        decoration = displayBuffer.decorateMarker(marker, decorationProperties)
+        expect(decoration.isType('line-number')).toBe true
+        expect(decoration.isType('gutter')).toBe true
+        expect(decoration.getProperties().gutterName).toBe 'line-number'
+        expect(decoration.getProperties().class).toBe 'one'
+
+      it "creates a decoration that is only of 'gutter' type if called with the 'gutter' type and a 'gutterName'", ->
+        decorationProperties = {type: 'gutter', gutterName:'test-gutter', class: 'one'}
+        decoration = displayBuffer.decorateMarker(marker, decorationProperties)
+        expect(decoration.isType('gutter')).toBe true
+        expect(decoration.isType('line-number')).toBe false
+        expect(decoration.getProperties().gutterName).toBe 'test-gutter'
+        expect(decoration.getProperties().class).toBe 'one'

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1373,7 +1373,7 @@ describe "DisplayBuffer", ->
       [marker] = []
 
       beforeEach ->
-        marker = displayBuffer.markBufferRange([[1, 0], [1, 0]]);
+        marker = displayBuffer.markBufferRange([[1, 0], [1, 0]])
 
       it "creates a decoration that is both of 'line-number' and 'gutter' type when called with the 'line-number' type", ->
         decorationProperties = {type: 'line-number', class: 'one'}
@@ -1384,7 +1384,7 @@ describe "DisplayBuffer", ->
         expect(decoration.getProperties().class).toBe 'one'
 
       it "creates a decoration that is only of 'gutter' type if called with the 'gutter' type and a 'gutterName'", ->
-        decorationProperties = {type: 'gutter', gutterName:'test-gutter', class: 'one'}
+        decorationProperties = {type: 'gutter', gutterName: 'test-gutter', class: 'one'}
         decoration = displayBuffer.decorateMarker(marker, decorationProperties)
         expect(decoration.isType('gutter')).toBe true
         expect(decoration.isType('line-number')).toBe false

--- a/spec/gutter-container-component-spec.coffee
+++ b/spec/gutter-container-component-spec.coffee
@@ -1,0 +1,142 @@
+Gutter = require '../src/gutter'
+GutterContainerComponent = require '../src/gutter-container-component'
+
+describe "GutterContainerComponent", ->
+  [gutterContainerComponent] = []
+  mockGutterContainer = {}
+
+  buildTestState = (sortedDescriptions) ->
+    mockTestState =
+      gutters:
+        scrollHeight: 100
+        scrollTop: 10
+        backgroundColor: 'black'
+        sortedDescriptions: sortedDescriptions
+        customDecorations: {}
+      lineNumberGutter:
+        maxLineNumberDigits: 10
+        lineNumbers: {}
+    mockTestState
+
+  beforeEach ->
+    mockEditor = {}
+    mockMouseDown = ->
+    gutterContainerComponent = new GutterContainerComponent({editor: mockEditor, onMouseDown: mockMouseDown})
+
+  it "creates a DOM node with no child gutter nodes when it is initialized", ->
+    expect(gutterContainerComponent.getDomNode() instanceof HTMLElement).toBe true
+    expect(gutterContainerComponent.getDomNode().children.length).toBe 0
+
+  describe "when updated with state that contains a new line-number gutter", ->
+    it "adds a LineNumberGutterComponent to its children", ->
+      lineNumberGutter = new Gutter(mockGutterContainer, {name: 'line-number'})
+      testState = buildTestState([{gutter: lineNumberGutter, visible: true}])
+
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 0
+      gutterContainerComponent.updateSync(testState)
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 1
+      expectedGutterNode = gutterContainerComponent.getDomNode().children.item(0)
+      expect(expectedGutterNode.classList.contains('gutter')).toBe true
+      expectedLineNumbersNode = expectedGutterNode.children.item(0)
+      expect(expectedLineNumbersNode.classList.contains('line-numbers')).toBe true
+
+      expect(gutterContainerComponent.getLineNumberGutterComponent().getDomNode()).toBe expectedGutterNode
+
+  describe "when updated with state that contains a new custom gutter", ->
+    it "adds a CustomGutterComponent to its children", ->
+      customGutter = new Gutter(mockGutterContainer, {name: 'custom'})
+      testState = buildTestState([{gutter: customGutter, visible: true}])
+
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 0
+      gutterContainerComponent.updateSync(testState)
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 1
+      expectedGutterNode = gutterContainerComponent.getDomNode().children.item(0)
+      expect(expectedGutterNode.classList.contains('gutter')).toBe true
+      expectedCustomDecorationsNode = expectedGutterNode.children.item(0)
+      expect(expectedCustomDecorationsNode.classList.contains('custom-decorations')).toBe true
+
+  describe "when updated with state that contains a new gutter that is not visible", ->
+    it "creates the gutter view but hides it, and unhides it when it is later updated to be visible", ->
+      customGutter = new Gutter(mockGutterContainer, {name: 'custom'})
+      testState = buildTestState([{gutter: customGutter, visible: false}])
+
+      gutterContainerComponent.updateSync(testState)
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 1
+      expectedCustomGutterNode = gutterContainerComponent.getDomNode().children.item(0)
+      expect(expectedCustomGutterNode.style.display).toBe 'none'
+
+      testState = buildTestState([{gutter: customGutter, visible: true}])
+      gutterContainerComponent.updateSync(testState)
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 1
+      expectedCustomGutterNode = gutterContainerComponent.getDomNode().children.item(0)
+      expect(expectedCustomGutterNode.style.display).toBe ''
+
+  describe "when updated with a gutter that already exists", ->
+    it "reuses the existing gutter view, instead of recreating it", ->
+      customGutter = new Gutter(mockGutterContainer, {name: 'custom'})
+      testState = buildTestState([{gutter: customGutter, visible: true}])
+
+      gutterContainerComponent.updateSync(testState)
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 1
+      expectedCustomGutterNode = gutterContainerComponent.getDomNode().children.item(0)
+
+      testState = buildTestState([{gutter: customGutter, visible: true}])
+      gutterContainerComponent.updateSync(testState)
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 1
+      expect(gutterContainerComponent.getDomNode().children.item(0)).toBe expectedCustomGutterNode
+
+  it "removes a gutter from the DOM if it does not appear in the latest state update", ->
+      lineNumberGutter = new Gutter(mockGutterContainer, {name: 'line-number'})
+      testState = buildTestState([{gutter: lineNumberGutter, visible: true}])
+      gutterContainerComponent.updateSync(testState)
+
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 1
+      testState = buildTestState([])
+      gutterContainerComponent.updateSync(testState)
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 0
+
+  describe "when updated with multiple gutters", ->
+    it "positions (and repositions) the gutters to match the order they appear in each state update", ->
+      lineNumberGutter = new Gutter(mockGutterContainer, {name: 'line-number'})
+      customGutter1 = new Gutter(mockGutterContainer, {name: 'custom', priority: -100})
+      testState = buildTestState([{gutter: customGutter1, visible: true}, {gutter: lineNumberGutter, visible: true}])
+
+      gutterContainerComponent.updateSync(testState)
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 2
+      expectedCustomGutterNode = gutterContainerComponent.getDomNode().children.item(0)
+      expect(expectedCustomGutterNode).toBe atom.views.getView(customGutter1)
+      expectedLineNumbersNode = gutterContainerComponent.getDomNode().children.item(1)
+      expect(expectedLineNumbersNode).toBe atom.views.getView(lineNumberGutter)
+
+      # Add a gutter.
+      customGutter2 = new Gutter(mockGutterContainer, {name: 'custom2', priority: -10})
+      testState = buildTestState([
+        {gutter: customGutter1, visible: true},
+        {gutter: customGutter2, visible: true},
+        {gutter: lineNumberGutter, visible: true}
+      ])
+      gutterContainerComponent.updateSync(testState)
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 3
+      expectedCustomGutterNode1 = gutterContainerComponent.getDomNode().children.item(0)
+      expect(expectedCustomGutterNode1).toBe atom.views.getView(customGutter1)
+      expectedCustomGutterNode2 = gutterContainerComponent.getDomNode().children.item(1)
+      expect(expectedCustomGutterNode2).toBe atom.views.getView(customGutter2)
+      expectedLineNumbersNode = gutterContainerComponent.getDomNode().children.item(2)
+      expect(expectedLineNumbersNode).toBe atom.views.getView(lineNumberGutter)
+
+      # Hide one gutter, reposition one gutter, remove one gutter; and add a new gutter.
+      customGutter3 = new Gutter(mockGutterContainer, {name: 'custom3', priority: 100})
+      testState = buildTestState([
+        {gutter: customGutter2, visible: false},
+        {gutter: customGutter1, visible: true},
+        {gutter: customGutter3, visible: true}
+      ])
+      gutterContainerComponent.updateSync(testState)
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 3
+      expectedCustomGutterNode2 = gutterContainerComponent.getDomNode().children.item(0)
+      expect(expectedCustomGutterNode2).toBe atom.views.getView(customGutter2)
+      expect(expectedCustomGutterNode2.style.display).toBe 'none'
+      expectedCustomGutterNode1 = gutterContainerComponent.getDomNode().children.item(1)
+      expect(expectedCustomGutterNode1).toBe atom.views.getView(customGutter1)
+      expectedCustomGutterNode3 = gutterContainerComponent.getDomNode().children.item(2)
+      expect(expectedCustomGutterNode3).toBe atom.views.getView(customGutter3)

--- a/spec/gutter-container-component-spec.coffee
+++ b/spec/gutter-container-component-spec.coffee
@@ -86,14 +86,14 @@ describe "GutterContainerComponent", ->
       expect(gutterContainerComponent.getDomNode().children.item(0)).toBe expectedCustomGutterNode
 
   it "removes a gutter from the DOM if it does not appear in the latest state update", ->
-      lineNumberGutter = new Gutter(mockGutterContainer, {name: 'line-number'})
-      testState = buildTestState([{gutter: lineNumberGutter, visible: true}])
-      gutterContainerComponent.updateSync(testState)
+    lineNumberGutter = new Gutter(mockGutterContainer, {name: 'line-number'})
+    testState = buildTestState([{gutter: lineNumberGutter, visible: true}])
+    gutterContainerComponent.updateSync(testState)
 
-      expect(gutterContainerComponent.getDomNode().children.length).toBe 1
-      testState = buildTestState([])
-      gutterContainerComponent.updateSync(testState)
-      expect(gutterContainerComponent.getDomNode().children.length).toBe 0
+    expect(gutterContainerComponent.getDomNode().children.length).toBe 1
+    testState = buildTestState([])
+    gutterContainerComponent.updateSync(testState)
+    expect(gutterContainerComponent.getDomNode().children.length).toBe 0
 
   describe "when updated with multiple gutters", ->
     it "positions (and repositions) the gutters to match the order they appear in each state update", ->

--- a/spec/gutter-container-component-spec.coffee
+++ b/spec/gutter-container-component-spec.coffee
@@ -13,9 +13,9 @@ describe "GutterContainerComponent", ->
         backgroundColor: 'black'
         sortedDescriptions: sortedDescriptions
         customDecorations: {}
-      lineNumberGutter:
-        maxLineNumberDigits: 10
-        lineNumbers: {}
+        lineNumberGutter:
+          maxLineNumberDigits: 10
+          lineNumbers: {}
     mockTestState
 
   beforeEach ->

--- a/spec/gutter-container-spec.coffee
+++ b/spec/gutter-container-spec.coffee
@@ -1,0 +1,49 @@
+Gutter = require '../src/gutter'
+GutterContainer = require '../src/gutter-container'
+
+describe 'GutterContainer', ->
+  gutterContainer = null
+  beforeEach ->
+    gutterContainer = new GutterContainer
+
+  describe 'when initialized', ->
+    it 'it has no gutters', ->
+      expect(gutterContainer.getGutters().length).toBe 0
+
+  describe '::addGutter', ->
+    it 'creates a new gutter', ->
+      newGutter = gutterContainer.addGutter {'test-gutter', priority: 1}
+      expect(gutterContainer.getGutters()).toEqual [newGutter]
+      expect(newGutter.priority).toBe 1
+
+    it 'throws an error if the provided gutter name is already in use', ->
+      name = 'test-gutter'
+      gutterContainer.addGutter {name}
+      expect(gutterContainer.addGutter.bind(null, {name})).toThrow()
+
+    it 'keeps added gutters sorted by ascending priority', ->
+      gutter1 = gutterContainer.addGutter {name: 'first', priority: 1}
+      gutter3 = gutterContainer.addGutter {name: 'third', priority: 3}
+      gutter2 = gutterContainer.addGutter {name: 'second', priority: 2}
+      expect(gutterContainer.getGutters()).toEqual [gutter1, gutter2, gutter3]
+
+  describe '::removeGutter', ->
+    removedGutters = null
+
+    beforeEach ->
+      gutterContainer = new GutterContainer
+      removedGutters = []
+      gutterContainer.onDidRemoveGutter (gutterName) ->
+        removedGutters.push gutterName
+
+    it 'removes the gutter if it is contained by this GutterContainer', ->
+      gutter = gutterContainer.addGutter {'test-gutter'}
+      expect(gutterContainer.getGutters()).toEqual [gutter]
+      gutterContainer.removeGutter gutter
+      expect(gutterContainer.getGutters().length).toBe 0
+      expect(removedGutters).toEqual [gutter.name]
+
+    it 'throws an error if the gutter is not within this GutterContainer', ->
+      otherGutterContainer = new GutterContainer
+      gutter = new Gutter 'gutter-name', otherGutterContainer
+      expect(gutterContainer.removeGutter.bind(null, gutter)).toThrow()

--- a/spec/gutter-container-spec.coffee
+++ b/spec/gutter-container-spec.coffee
@@ -3,8 +3,10 @@ GutterContainer = require '../src/gutter-container'
 
 describe 'GutterContainer', ->
   gutterContainer = null
+  fakeTextEditor = {}
+
   beforeEach ->
-    gutterContainer = new GutterContainer
+    gutterContainer = new GutterContainer fakeTextEditor
 
   describe 'when initialized', ->
     it 'it has no gutters', ->
@@ -31,7 +33,7 @@ describe 'GutterContainer', ->
     removedGutters = null
 
     beforeEach ->
-      gutterContainer = new GutterContainer
+      gutterContainer = new GutterContainer fakeTextEditor
       removedGutters = []
       gutterContainer.onDidRemoveGutter (gutterName) ->
         removedGutters.push gutterName
@@ -44,6 +46,7 @@ describe 'GutterContainer', ->
       expect(removedGutters).toEqual [gutter.name]
 
     it 'throws an error if the gutter is not within this GutterContainer', ->
-      otherGutterContainer = new GutterContainer
+      fakeOtherTextEditor = {}
+      otherGutterContainer = new GutterContainer fakeOtherTextEditor
       gutter = new Gutter 'gutter-name', otherGutterContainer
       expect(gutterContainer.removeGutter.bind(null, gutter)).toThrow()

--- a/spec/gutter-spec.coffee
+++ b/spec/gutter-spec.coffee
@@ -46,9 +46,9 @@ describe 'Gutter', ->
     [mockGutterContainer, mockGutterContainerRemovedGutters] = []
 
     beforeEach ->
-      mockGutterContainerRemovedGutters = [];
+      mockGutterContainerRemovedGutters = []
       mockGutterContainer = removeGutter: (destroyedGutter) ->
-         mockGutterContainerRemovedGutters.push destroyedGutter
+        mockGutterContainerRemovedGutters.push destroyedGutter
 
     it 'removes the gutter from its container.', ->
       gutter = new Gutter mockGutterContainer, {name}

--- a/spec/gutter-spec.coffee
+++ b/spec/gutter-spec.coffee
@@ -62,3 +62,7 @@ describe 'Gutter', ->
         didDestroy = true
       gutter.destroy()
       expect(didDestroy).toBe true
+
+    it 'does not allow destroying the line-number gutter', ->
+      gutter = new Gutter mockGutterContainer, {name: 'line-number'}
+      expect(gutter.destroy).toThrow()

--- a/spec/gutter-spec.coffee
+++ b/spec/gutter-spec.coffee
@@ -1,0 +1,64 @@
+Gutter = require '../src/gutter'
+
+describe 'Gutter', ->
+  fakeGutterContainer = {}
+  name = 'name'
+
+  describe '::hide', ->
+    it 'hides the gutter if it is visible.', ->
+      options =
+        name: name
+        visible: true
+      gutter = new Gutter fakeGutterContainer, options
+      events = []
+      gutter.onDidChangeVisible (gutter) ->
+        events.push gutter.isVisible()
+
+      expect(gutter.isVisible()).toBe true
+      gutter.hide()
+      expect(gutter.isVisible()).toBe false
+      expect(events).toEqual [false]
+      gutter.hide()
+      expect(gutter.isVisible()).toBe false
+      # An event should only be emitted when the visibility changes.
+      expect(events.length).toBe 1
+
+  describe '::show', ->
+    it 'shows the gutter if it is hidden.', ->
+      options =
+        name: name
+        visible: false
+      gutter = new Gutter fakeGutterContainer, options
+      events = []
+      gutter.onDidChangeVisible (gutter) ->
+        events.push gutter.isVisible()
+
+      expect(gutter.isVisible()).toBe false
+      gutter.show()
+      expect(gutter.isVisible()).toBe true
+      expect(events).toEqual [true]
+      gutter.show()
+      expect(gutter.isVisible()).toBe true
+      # An event should only be emitted when the visibility changes.
+      expect(events.length).toBe 1
+
+  describe '::destroy', ->
+    [mockGutterContainer, mockGutterContainerRemovedGutters] = []
+
+    beforeEach ->
+      mockGutterContainerRemovedGutters = [];
+      mockGutterContainer = removeGutter: (destroyedGutter) ->
+         mockGutterContainerRemovedGutters.push destroyedGutter
+
+    it 'removes the gutter from its container.', ->
+      gutter = new Gutter mockGutterContainer, {name}
+      gutter.destroy()
+      expect(mockGutterContainerRemovedGutters).toEqual([gutter])
+
+    it 'calls all callbacks registered on ::onDidDestroy.', ->
+      gutter = new Gutter mockGutterContainer, {name}
+      didDestroy = false
+      gutter.onDidDestroy ->
+        didDestroy = true
+      gutter.destroy()
+      expect(didDestroy).toBe true

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -578,10 +578,10 @@ describe "TextEditorComponent", ->
       nextAnimationFrame()
       expect(lineNumbersNode.style.backgroundColor).toBe 'rgb(255, 0, 0)'
 
-    it "hides or shows the gutter based on the '::isGutterVisible' property on the model and the global 'editor.showLineNumbers' config setting", ->
+    it "hides or shows the gutter based on the '::isLineNumberGutterVisible' property on the model and the global 'editor.showLineNumbers' config setting", ->
       expect(component.gutterComponent?).toBe true
 
-      editor.setGutterVisible(false)
+      editor.setLineNumberGutterVisible(false)
       nextAnimationFrame()
 
       expect(componentNode.querySelector('.gutter')).toBeNull()
@@ -591,7 +591,7 @@ describe "TextEditorComponent", ->
 
       expect(componentNode.querySelector('.gutter')).toBeNull()
 
-      editor.setGutterVisible(true)
+      editor.setLineNumberGutterVisible(true)
       nextAnimationFrame()
 
       expect(componentNode.querySelector('.gutter')).toBeNull()

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -579,7 +579,7 @@ describe "TextEditorComponent", ->
       expect(lineNumbersNode.style.backgroundColor).toBe 'rgb(255, 0, 0)'
 
     it "hides or shows the gutter based on the '::isLineNumberGutterVisible' property on the model and the global 'editor.showLineNumbers' config setting", ->
-      expect(component.gutterComponent?).toBe true
+      expect(component.gutterContainerComponent.getLineNumberGutterComponent()?).toBe true
 
       editor.setLineNumberGutterVisible(false)
       nextAnimationFrame()

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -584,22 +584,22 @@ describe "TextEditorComponent", ->
       editor.setLineNumberGutterVisible(false)
       nextAnimationFrame()
 
-      expect(componentNode.querySelector('.gutter')).toBeNull()
+      expect(componentNode.querySelector('.gutter').style.display).toBe 'none'
 
       atom.config.set("editor.showLineNumbers", false)
       nextAnimationFrame()
 
-      expect(componentNode.querySelector('.gutter')).toBeNull()
+      expect(componentNode.querySelector('.gutter').style.display).toBe 'none'
 
       editor.setLineNumberGutterVisible(true)
       nextAnimationFrame()
 
-      expect(componentNode.querySelector('.gutter')).toBeNull()
+      expect(componentNode.querySelector('.gutter').style.display).toBe 'none'
 
       atom.config.set("editor.showLineNumbers", true)
       nextAnimationFrame()
 
-      expect(componentNode.querySelector('.gutter')).toBeDefined()
+      expect(componentNode.querySelector('.gutter').style.display).toBe ''
       expect(component.lineNumberNodeForScreenRow(3)?).toBe true
 
     describe "fold decorations", ->

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -46,7 +46,7 @@ describe "TextEditorComponent", ->
 
       lineHeightInPixels = editor.getLineHeightInPixels()
       charWidth = editor.getDefaultCharWidth()
-      componentNode = component.domNode
+      componentNode = component.getDomNode()
       verticalScrollbarNode = componentNode.querySelector('.vertical-scrollbar')
       horizontalScrollbarNode = componentNode.querySelector('.horizontal-scrollbar')
 
@@ -2392,7 +2392,7 @@ describe "TextEditorComponent", ->
         wrapperView.appendTo(hiddenParent)
 
         {component} = wrapperView
-        componentNode = component.domNode
+        componentNode = component.getDomNode()
         expect(componentNode.querySelectorAll('.line').length).toBe 0
 
         hiddenParent.style.display = 'block'
@@ -2599,7 +2599,7 @@ describe "TextEditorComponent", ->
       expect(wrapperNode.classList.contains('mini')).toBe true
 
     it "does not have an opaque background on lines", ->
-      expect(component.linesComponent.domNode.getAttribute('style')).not.toContain 'background-color'
+      expect(component.linesComponent.getDomNode().getAttribute('style')).not.toContain 'background-color'
 
     it "does not render invisible characters", ->
       atom.config.set('editor.invisibles', eol: 'E')

--- a/spec/text-editor-element-spec.coffee
+++ b/spec/text-editor-element-spec.coffee
@@ -23,7 +23,7 @@ describe "TextEditorElement", ->
     it "honors the 'gutter-hidden' attribute", ->
       jasmineContent.innerHTML = "<atom-text-editor gutter-hidden>"
       element = jasmineContent.firstChild
-      expect(element.getModel().isGutterVisible()).toBe false
+      expect(element.getModel().isLineNumberGutterVisible()).toBe false
 
     it "honors the text content", ->
       jasmineContent.innerHTML = "<atom-text-editor>testing</atom-text-editor>"

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -2483,9 +2483,11 @@ describe "TextEditorPresenter", ->
           decorationState = decorationStateForGutterName(presenter, 'test-gutter')
           expect(decorationState[decoration1.id].top).toBe oldDimensionsForDecoration1.top
           expect(decorationState[decoration1.id].height).not.toBe oldDimensionsForDecoration1.height
+          # Due to the issue described here: https://github.com/atom/atom/issues/6454, decoration2
+          # will be bumped up to the row that was folded and still made visible, instead of being
+          # entirely collapsed. (The same thing will happen to decoration3.)
           expect(decorationState[decoration2.id].top).not.toBe oldDimensionsForDecoration2.top
           expect(decorationState[decoration2.id].height).not.toBe oldDimensionsForDecoration2.height
-          expect(decorationState[decoration3.id]).toBeUndefined()
 
   # disabled until we fix an issue with display buffer markers not updating when
   # they are moved on screen but not in the buffer

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -1771,10 +1771,10 @@ describe "TextEditorPresenter", ->
         it "is set to the number of digits used by the greatest line number", ->
           presenter = buildPresenter()
           expect(editor.getLastBufferRow()).toBe 12
-          expect(presenter.getState().lineNumberGutter.maxLineNumberDigits).toBe 2
+          expect(presenter.getState().gutters.lineNumberGutter.maxLineNumberDigits).toBe 2
 
           editor.setText("1\n2\n3")
-          expect(presenter.getState().lineNumberGutter.maxLineNumberDigits).toBe 1
+          expect(presenter.getState().gutters.lineNumberGutter.maxLineNumberDigits).toBe 1
 
       describe ".lineNumbers", ->
         lineNumberStateForScreenRow = (presenter, screenRow) ->
@@ -1786,7 +1786,7 @@ describe "TextEditorPresenter", ->
           else
             key = bufferRow
 
-          presenter.getState().lineNumberGutter.lineNumbers[key]
+          presenter.getState().gutters.lineNumberGutter.lineNumbers[key]
 
         it "contains states for line numbers that are visible on screen, plus and minus the overdraw margin", ->
           editor.foldBufferRow(4)

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -2468,19 +2468,6 @@ describe "TextEditorPresenter", ->
           expect(decorationState[decoration3.id]).toBeUndefined()
           expect(decorationState[decoration4.id].top).toBeDefined()
 
-        it "does not update when a gutter is destroyed (because it's unnecessary)", ->
-          gutter.destroy()
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-          expect(decorationState[decoration1.id].top).toBeDefined()
-          expect(decorationState[decoration2.id].top).toBeDefined()
-          expect(decorationState[decoration3.id]).toBeUndefined()
-
-          # However, the decoration state of the destroyed gutter should be
-          # cleared whenever ::updateCustomGutterDecorationState is next called.
-          expectStateUpdate presenter, -> editor.addGutter({name: 'a-different-gutter'})
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-          expect(decorationState).toBeUndefined()
-
         it "updates when editor lines are folded", ->
           oldDimensionsForDecoration1 =
             top: lineHeight * marker1.getScreenRange().start.row

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -2191,9 +2191,9 @@ describe "TextEditorPresenter", ->
         expect(presenter.getState().focused).toBe false
 
     describe ".gutters", ->
-      describe ".sortedDescriptions", ->
+      describe ".sortedModels", ->
         gutterDescriptionWithName = (presenter, name) ->
-          for gutterDesc in presenter.getState().gutters.sortedDescriptions
+          for gutterDesc in presenter.getState().gutters.sortedModels
             return gutterDesc if gutterDesc.name is name
           undefined
 
@@ -2235,13 +2235,10 @@ describe "TextEditorPresenter", ->
 
         it "updates when gutters are added to the editor model, and keeps the gutters sorted by priority", ->
           presenter = buildPresenter()
-          editor.addGutter({name: 'test-gutter-1', priority: -100, visible: true})
+          gutter1 = editor.addGutter({name: 'test-gutter-1', priority: -100, visible: true})
           editor.addGutter({name: 'test-gutter-2', priority: 100, visible: false})
-          expectedState = [
-            {name: 'test-gutter-1'},
-            {name: 'line-number'},
-          ]
-          expect(presenter.getState().gutters.sortedDescriptions).toEqual expectedState
+          expectedState = [gutter1, editor.gutterWithName('line-number')]
+          expect(presenter.getState().gutters.sortedModels).toEqual expectedState
 
         it "updates when the visibility of a gutter changes", ->
           presenter = buildPresenter()

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -1767,97 +1767,6 @@ describe "TextEditorPresenter", ->
               }
 
     describe ".lineNumberGutter", ->
-      describe ".scrollHeight", ->
-        it "is initialized based on ::lineHeight, the number of lines, and ::explicitHeight", ->
-          presenter = buildPresenter()
-          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe editor.getScreenLineCount() * 10
-
-          presenter = buildPresenter(explicitHeight: 500)
-          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe 500
-
-        it "updates when the ::lineHeight changes", ->
-          presenter = buildPresenter()
-          expectStateUpdate presenter, -> presenter.setLineHeight(20)
-          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe editor.getScreenLineCount() * 20
-
-        it "updates when the line count changes", ->
-          presenter = buildPresenter()
-          expectStateUpdate presenter, -> editor.getBuffer().append("\n\n\n")
-          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe editor.getScreenLineCount() * 10
-
-        it "updates when ::explicitHeight changes", ->
-          presenter = buildPresenter()
-          expectStateUpdate presenter, -> presenter.setExplicitHeight(500)
-          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe 500
-
-        it "adds the computed clientHeight to the computed scrollHeight if editor.scrollPastEnd is true", ->
-          presenter = buildPresenter(scrollTop: 10, explicitHeight: 50, horizontalScrollbarHeight: 10)
-          expectStateUpdate presenter, -> presenter.setScrollTop(300)
-          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe presenter.contentHeight
-
-          expectStateUpdate presenter, -> atom.config.set("editor.scrollPastEnd", true)
-          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe presenter.contentHeight + presenter.clientHeight - (presenter.lineHeight * 3)
-
-          expectStateUpdate presenter, -> atom.config.set("editor.scrollPastEnd", false)
-          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe presenter.contentHeight
-
-      describe ".scrollTop", ->
-        it "tracks the value of ::scrollTop", ->
-          presenter = buildPresenter(scrollTop: 10, explicitHeight: 20)
-          expect(presenter.getState().lineNumberGutter.scrollTop).toBe 10
-          expectStateUpdate presenter, -> presenter.setScrollTop(50)
-          expect(presenter.getState().lineNumberGutter.scrollTop).toBe 50
-
-        it "never exceeds the computed scrollHeight minus the computed clientHeight", ->
-          presenter = buildPresenter(scrollTop: 10, explicitHeight: 50, horizontalScrollbarHeight: 10)
-          expectStateUpdate presenter, -> presenter.setScrollTop(100)
-          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
-
-          expectStateUpdate presenter, -> presenter.setExplicitHeight(60)
-          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
-
-          expectStateUpdate presenter, -> presenter.setHorizontalScrollbarHeight(5)
-          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
-
-          expectStateUpdate presenter, -> editor.getBuffer().delete([[8, 0], [12, 0]])
-          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
-
-          # Scroll top only gets smaller when needed as dimensions change, never bigger
-          scrollTopBefore = presenter.getState().verticalScrollbar.scrollTop
-          expectStateUpdate presenter, -> editor.getBuffer().insert([9, Infinity], '\n\n\n')
-          expect(presenter.getState().lineNumberGutter.scrollTop).toBe scrollTopBefore
-
-        it "never goes negative", ->
-          presenter = buildPresenter(scrollTop: 10, explicitHeight: 50, horizontalScrollbarHeight: 10)
-          expectStateUpdate presenter, -> presenter.setScrollTop(-100)
-          expect(presenter.getState().lineNumberGutter.scrollTop).toBe 0
-
-        it "adds the computed clientHeight to the computed scrollHeight if editor.scrollPastEnd is true", ->
-          presenter = buildPresenter(scrollTop: 10, explicitHeight: 50, horizontalScrollbarHeight: 10)
-          expectStateUpdate presenter, -> presenter.setScrollTop(300)
-          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.contentHeight - presenter.clientHeight
-
-          atom.config.set("editor.scrollPastEnd", true)
-          expectStateUpdate presenter, -> presenter.setScrollTop(300)
-          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.contentHeight - (presenter.lineHeight * 3)
-
-          expectStateUpdate presenter, -> atom.config.set("editor.scrollPastEnd", false)
-          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.contentHeight - presenter.clientHeight
-
-      describe ".backgroundColor", ->
-        it "is assigned to ::gutterBackgroundColor if present, and to ::backgroundColor otherwise", ->
-          presenter = buildPresenter(backgroundColor: "rgba(255, 0, 0, 0)", gutterBackgroundColor: "rgba(0, 255, 0, 0)")
-          expect(presenter.getState().lineNumberGutter.backgroundColor).toBe "rgba(0, 255, 0, 0)"
-
-          expectStateUpdate presenter, -> presenter.setGutterBackgroundColor("rgba(0, 0, 255, 0)")
-          expect(presenter.getState().lineNumberGutter.backgroundColor).toBe "rgba(0, 0, 255, 0)"
-
-          expectStateUpdate presenter, -> presenter.setGutterBackgroundColor("rgba(0, 0, 0, 0)")
-          expect(presenter.getState().lineNumberGutter.backgroundColor).toBe "rgba(255, 0, 0, 0)"
-
-          expectStateUpdate presenter, -> presenter.setBackgroundColor("rgba(0, 0, 255, 0)")
-          expect(presenter.getState().lineNumberGutter.backgroundColor).toBe "rgba(0, 0, 255, 0)"
-
       describe ".maxLineNumberDigits", ->
         it "is set to the number of digits used by the greatest line number", ->
           presenter = buildPresenter()
@@ -2191,6 +2100,97 @@ describe "TextEditorPresenter", ->
         expect(presenter.getState().focused).toBe false
 
     describe ".gutters", ->
+      describe ".scrollHeight", ->
+        it "is initialized based on ::lineHeight, the number of lines, and ::explicitHeight", ->
+          presenter = buildPresenter()
+          expect(presenter.getState().gutters.scrollHeight).toBe editor.getScreenLineCount() * 10
+
+          presenter = buildPresenter(explicitHeight: 500)
+          expect(presenter.getState().gutters.scrollHeight).toBe 500
+
+        it "updates when the ::lineHeight changes", ->
+          presenter = buildPresenter()
+          expectStateUpdate presenter, -> presenter.setLineHeight(20)
+          expect(presenter.getState().gutters.scrollHeight).toBe editor.getScreenLineCount() * 20
+
+        it "updates when the line count changes", ->
+          presenter = buildPresenter()
+          expectStateUpdate presenter, -> editor.getBuffer().append("\n\n\n")
+          expect(presenter.getState().gutters.scrollHeight).toBe editor.getScreenLineCount() * 10
+
+        it "updates when ::explicitHeight changes", ->
+          presenter = buildPresenter()
+          expectStateUpdate presenter, -> presenter.setExplicitHeight(500)
+          expect(presenter.getState().gutters.scrollHeight).toBe 500
+
+        it "adds the computed clientHeight to the computed scrollHeight if editor.scrollPastEnd is true", ->
+          presenter = buildPresenter(scrollTop: 10, explicitHeight: 50, horizontalScrollbarHeight: 10)
+          expectStateUpdate presenter, -> presenter.setScrollTop(300)
+          expect(presenter.getState().gutters.scrollHeight).toBe presenter.contentHeight
+
+          expectStateUpdate presenter, -> atom.config.set("editor.scrollPastEnd", true)
+          expect(presenter.getState().gutters.scrollHeight).toBe presenter.contentHeight + presenter.clientHeight - (presenter.lineHeight * 3)
+
+          expectStateUpdate presenter, -> atom.config.set("editor.scrollPastEnd", false)
+          expect(presenter.getState().gutters.scrollHeight).toBe presenter.contentHeight
+
+      describe ".scrollTop", ->
+        it "tracks the value of ::scrollTop", ->
+          presenter = buildPresenter(scrollTop: 10, explicitHeight: 20)
+          expect(presenter.getState().gutters.scrollTop).toBe 10
+          expectStateUpdate presenter, -> presenter.setScrollTop(50)
+          expect(presenter.getState().gutters.scrollTop).toBe 50
+
+        it "never exceeds the computed scrollHeight minus the computed clientHeight", ->
+          presenter = buildPresenter(scrollTop: 10, explicitHeight: 50, horizontalScrollbarHeight: 10)
+          expectStateUpdate presenter, -> presenter.setScrollTop(100)
+          expect(presenter.getState().gutters.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
+
+          expectStateUpdate presenter, -> presenter.setExplicitHeight(60)
+          expect(presenter.getState().gutters.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
+
+          expectStateUpdate presenter, -> presenter.setHorizontalScrollbarHeight(5)
+          expect(presenter.getState().gutters.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
+
+          expectStateUpdate presenter, -> editor.getBuffer().delete([[8, 0], [12, 0]])
+          expect(presenter.getState().gutters.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
+
+          # Scroll top only gets smaller when needed as dimensions change, never bigger
+          scrollTopBefore = presenter.getState().verticalScrollbar.scrollTop
+          expectStateUpdate presenter, -> editor.getBuffer().insert([9, Infinity], '\n\n\n')
+          expect(presenter.getState().gutters.scrollTop).toBe scrollTopBefore
+
+        it "never goes negative", ->
+          presenter = buildPresenter(scrollTop: 10, explicitHeight: 50, horizontalScrollbarHeight: 10)
+          expectStateUpdate presenter, -> presenter.setScrollTop(-100)
+          expect(presenter.getState().gutters.scrollTop).toBe 0
+
+        it "adds the computed clientHeight to the computed scrollHeight if editor.scrollPastEnd is true", ->
+          presenter = buildPresenter(scrollTop: 10, explicitHeight: 50, horizontalScrollbarHeight: 10)
+          expectStateUpdate presenter, -> presenter.setScrollTop(300)
+          expect(presenter.getState().gutters.scrollTop).toBe presenter.contentHeight - presenter.clientHeight
+
+          atom.config.set("editor.scrollPastEnd", true)
+          expectStateUpdate presenter, -> presenter.setScrollTop(300)
+          expect(presenter.getState().gutters.scrollTop).toBe presenter.contentHeight - (presenter.lineHeight * 3)
+
+          expectStateUpdate presenter, -> atom.config.set("editor.scrollPastEnd", false)
+          expect(presenter.getState().gutters.scrollTop).toBe presenter.contentHeight - presenter.clientHeight
+
+      describe ".backgroundColor", ->
+        it "is assigned to ::gutterBackgroundColor if present, and to ::backgroundColor otherwise", ->
+          presenter = buildPresenter(backgroundColor: "rgba(255, 0, 0, 0)", gutterBackgroundColor: "rgba(0, 255, 0, 0)")
+          expect(presenter.getState().gutters.backgroundColor).toBe "rgba(0, 255, 0, 0)"
+
+          expectStateUpdate presenter, -> presenter.setGutterBackgroundColor("rgba(0, 0, 255, 0)")
+          expect(presenter.getState().gutters.backgroundColor).toBe "rgba(0, 0, 255, 0)"
+
+          expectStateUpdate presenter, -> presenter.setGutterBackgroundColor("rgba(0, 0, 0, 0)")
+          expect(presenter.getState().gutters.backgroundColor).toBe "rgba(255, 0, 0, 0)"
+
+          expectStateUpdate presenter, -> presenter.setBackgroundColor("rgba(0, 0, 255, 0)")
+          expect(presenter.getState().gutters.backgroundColor).toBe "rgba(0, 0, 255, 0)"
+
       describe ".sortedDescriptions", ->
         gutterDescriptionWithName = (presenter, name) ->
           for gutterDesc in presenter.getState().gutters.sortedDescriptions

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -2166,10 +2166,10 @@ describe "TextEditorPresenter", ->
             expect(lineNumberStateForScreenRow(presenter, 11).foldable).toBe false
 
       describe ".visible", ->
-        it "is true iff the editor isn't mini, ::isGutterVisible is true on the editor, and 'editor.showLineNumbers' is enabled in config", ->
+        it "is true iff the editor isn't mini, ::isLineNumberGutterVisible is true on the editor, and 'editor.showLineNumbers' is enabled in config", ->
           presenter = buildPresenter()
 
-          expect(editor.isGutterVisible()).toBe true
+          expect(editor.isLineNumberGutterVisible()).toBe true
           expect(presenter.getState().gutter.visible).toBe true
 
           expectStateUpdate presenter, -> editor.setMini(true)
@@ -2178,10 +2178,10 @@ describe "TextEditorPresenter", ->
           expectStateUpdate presenter, -> editor.setMini(false)
           expect(presenter.getState().gutter.visible).toBe true
 
-          expectStateUpdate presenter, -> editor.setGutterVisible(false)
+          expectStateUpdate presenter, -> editor.setLineNumberGutterVisible(false)
           expect(presenter.getState().gutter.visible).toBe false
 
-          expectStateUpdate presenter, -> editor.setGutterVisible(true)
+          expectStateUpdate presenter, -> editor.setLineNumberGutterVisible(true)
           expect(presenter.getState().gutter.visible).toBe true
 
           expectStateUpdate presenter, -> atom.config.set('editor.showLineNumbers', false)

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -2191,10 +2191,10 @@ describe "TextEditorPresenter", ->
         expect(presenter.getState().focused).toBe false
 
     describe ".gutters", ->
-      describe ".sortedModels", ->
+      describe ".sortedDescriptions", ->
         gutterDescriptionWithName = (presenter, name) ->
-          for gutterDesc in presenter.getState().gutters.sortedModels
-            return gutterDesc if gutterDesc.name is name
+          for gutterDesc in presenter.getState().gutters.sortedDescriptions
+            return gutterDesc if gutterDesc.gutter.name is name
           undefined
 
         describe "the line-number gutter", ->
@@ -2202,28 +2202,28 @@ describe "TextEditorPresenter", ->
             presenter = buildPresenter()
 
             expect(editor.isLineNumberGutterVisible()).toBe true
-            expect(gutterDescriptionWithName(presenter, 'line-number')).toBeDefined()
+            expect(gutterDescriptionWithName(presenter, 'line-number').visible).toBe true
 
             expectStateUpdate presenter, -> editor.setMini(true)
             expect(gutterDescriptionWithName(presenter, 'line-number')).toBeUndefined()
 
             expectStateUpdate presenter, -> editor.setMini(false)
-            expect(gutterDescriptionWithName(presenter, 'line-number')).toBeDefined()
+            expect(gutterDescriptionWithName(presenter, 'line-number').visible).toBe true
 
             expectStateUpdate presenter, -> editor.setLineNumberGutterVisible(false)
-            expect(gutterDescriptionWithName(presenter, 'line-number')).toBeUndefined()
+            expect(gutterDescriptionWithName(presenter, 'line-number').visible).toBe false
 
             expectStateUpdate presenter, -> editor.setLineNumberGutterVisible(true)
-            expect(gutterDescriptionWithName(presenter, 'line-number')).toBeDefined()
+            expect(gutterDescriptionWithName(presenter, 'line-number').visible).toBe true
 
             expectStateUpdate presenter, -> atom.config.set('editor.showLineNumbers', false)
-            expect(gutterDescriptionWithName(presenter, 'line-number')).toBeUndefined()
+            expect(gutterDescriptionWithName(presenter, 'line-number').visible).toBe false
 
           it "gets updated when the editor's grammar changes", ->
             presenter = buildPresenter()
 
             atom.config.set('editor.showLineNumbers', false, scopeSelector: '.source.js')
-            expect(gutterDescriptionWithName(presenter, 'line-number')).toBeDefined()
+            expect(gutterDescriptionWithName(presenter, 'line-number').visible).toBe true
             stateUpdated = false
             presenter.onDidUpdateState -> stateUpdated = true
 
@@ -2231,26 +2231,30 @@ describe "TextEditorPresenter", ->
 
             runs ->
               expect(stateUpdated).toBe true
-              expect(gutterDescriptionWithName(presenter, 'line-number')).toBeUndefined()
+              expect(gutterDescriptionWithName(presenter, 'line-number').visible).toBe false
 
         it "updates when gutters are added to the editor model, and keeps the gutters sorted by priority", ->
           presenter = buildPresenter()
           gutter1 = editor.addGutter({name: 'test-gutter-1', priority: -100, visible: true})
-          editor.addGutter({name: 'test-gutter-2', priority: 100, visible: false})
-          expectedState = [gutter1, editor.gutterWithName('line-number')]
-          expect(presenter.getState().gutters.sortedModels).toEqual expectedState
+          gutter2 = editor.addGutter({name: 'test-gutter-2', priority: 100, visible: false})
+          expectedState = [
+            {gutter: gutter1, visible: true},
+            {gutter: editor.gutterWithName('line-number'), visible: true},
+            {gutter: gutter2, visible: false},
+          ]
+          expect(presenter.getState().gutters.sortedDescriptions).toEqual expectedState
 
         it "updates when the visibility of a gutter changes", ->
           presenter = buildPresenter()
           gutter = editor.addGutter({name: 'test-gutter', visible: true})
-          expect(gutterDescriptionWithName(presenter, 'test-gutter')).toBeDefined()
+          expect(gutterDescriptionWithName(presenter, 'test-gutter').visible).toBe true
           gutter.hide()
-          expect(gutterDescriptionWithName(presenter, 'test-gutter')).toBeUndefined()
+          expect(gutterDescriptionWithName(presenter, 'test-gutter').visible).toBe false
 
         it "updates when a gutter is removed", ->
           presenter = buildPresenter()
           gutter = editor.addGutter({name: 'test-gutter', visible: true})
-          expect(gutterDescriptionWithName(presenter, 'test-gutter')).toBeDefined()
+          expect(gutterDescriptionWithName(presenter, 'test-gutter').visible).toBe true
           gutter.destroy()
           expect(gutterDescriptionWithName(presenter, 'test-gutter')).toBeUndefined()
 

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -1766,107 +1766,106 @@ describe "TextEditorPresenter", ->
                 pixelPosition: {top: 10, left: 0}
               }
 
-
-    describe ".gutter", ->
+    describe ".lineNumberGutter", ->
       describe ".scrollHeight", ->
         it "is initialized based on ::lineHeight, the number of lines, and ::explicitHeight", ->
           presenter = buildPresenter()
-          expect(presenter.getState().gutter.scrollHeight).toBe editor.getScreenLineCount() * 10
+          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe editor.getScreenLineCount() * 10
 
           presenter = buildPresenter(explicitHeight: 500)
-          expect(presenter.getState().gutter.scrollHeight).toBe 500
+          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe 500
 
         it "updates when the ::lineHeight changes", ->
           presenter = buildPresenter()
           expectStateUpdate presenter, -> presenter.setLineHeight(20)
-          expect(presenter.getState().gutter.scrollHeight).toBe editor.getScreenLineCount() * 20
+          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe editor.getScreenLineCount() * 20
 
         it "updates when the line count changes", ->
           presenter = buildPresenter()
           expectStateUpdate presenter, -> editor.getBuffer().append("\n\n\n")
-          expect(presenter.getState().gutter.scrollHeight).toBe editor.getScreenLineCount() * 10
+          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe editor.getScreenLineCount() * 10
 
         it "updates when ::explicitHeight changes", ->
           presenter = buildPresenter()
           expectStateUpdate presenter, -> presenter.setExplicitHeight(500)
-          expect(presenter.getState().gutter.scrollHeight).toBe 500
+          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe 500
 
         it "adds the computed clientHeight to the computed scrollHeight if editor.scrollPastEnd is true", ->
           presenter = buildPresenter(scrollTop: 10, explicitHeight: 50, horizontalScrollbarHeight: 10)
           expectStateUpdate presenter, -> presenter.setScrollTop(300)
-          expect(presenter.getState().gutter.scrollHeight).toBe presenter.contentHeight
+          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe presenter.contentHeight
 
           expectStateUpdate presenter, -> atom.config.set("editor.scrollPastEnd", true)
-          expect(presenter.getState().gutter.scrollHeight).toBe presenter.contentHeight + presenter.clientHeight - (presenter.lineHeight * 3)
+          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe presenter.contentHeight + presenter.clientHeight - (presenter.lineHeight * 3)
 
           expectStateUpdate presenter, -> atom.config.set("editor.scrollPastEnd", false)
-          expect(presenter.getState().gutter.scrollHeight).toBe presenter.contentHeight
+          expect(presenter.getState().lineNumberGutter.scrollHeight).toBe presenter.contentHeight
 
       describe ".scrollTop", ->
         it "tracks the value of ::scrollTop", ->
           presenter = buildPresenter(scrollTop: 10, explicitHeight: 20)
-          expect(presenter.getState().gutter.scrollTop).toBe 10
+          expect(presenter.getState().lineNumberGutter.scrollTop).toBe 10
           expectStateUpdate presenter, -> presenter.setScrollTop(50)
-          expect(presenter.getState().gutter.scrollTop).toBe 50
+          expect(presenter.getState().lineNumberGutter.scrollTop).toBe 50
 
         it "never exceeds the computed scrollHeight minus the computed clientHeight", ->
           presenter = buildPresenter(scrollTop: 10, explicitHeight: 50, horizontalScrollbarHeight: 10)
           expectStateUpdate presenter, -> presenter.setScrollTop(100)
-          expect(presenter.getState().gutter.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
+          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
 
           expectStateUpdate presenter, -> presenter.setExplicitHeight(60)
-          expect(presenter.getState().gutter.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
+          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
 
           expectStateUpdate presenter, -> presenter.setHorizontalScrollbarHeight(5)
-          expect(presenter.getState().gutter.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
+          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
 
           expectStateUpdate presenter, -> editor.getBuffer().delete([[8, 0], [12, 0]])
-          expect(presenter.getState().gutter.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
+          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.scrollHeight - presenter.clientHeight
 
           # Scroll top only gets smaller when needed as dimensions change, never bigger
           scrollTopBefore = presenter.getState().verticalScrollbar.scrollTop
           expectStateUpdate presenter, -> editor.getBuffer().insert([9, Infinity], '\n\n\n')
-          expect(presenter.getState().gutter.scrollTop).toBe scrollTopBefore
+          expect(presenter.getState().lineNumberGutter.scrollTop).toBe scrollTopBefore
 
         it "never goes negative", ->
           presenter = buildPresenter(scrollTop: 10, explicitHeight: 50, horizontalScrollbarHeight: 10)
           expectStateUpdate presenter, -> presenter.setScrollTop(-100)
-          expect(presenter.getState().gutter.scrollTop).toBe 0
+          expect(presenter.getState().lineNumberGutter.scrollTop).toBe 0
 
         it "adds the computed clientHeight to the computed scrollHeight if editor.scrollPastEnd is true", ->
           presenter = buildPresenter(scrollTop: 10, explicitHeight: 50, horizontalScrollbarHeight: 10)
           expectStateUpdate presenter, -> presenter.setScrollTop(300)
-          expect(presenter.getState().gutter.scrollTop).toBe presenter.contentHeight - presenter.clientHeight
+          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.contentHeight - presenter.clientHeight
 
           atom.config.set("editor.scrollPastEnd", true)
           expectStateUpdate presenter, -> presenter.setScrollTop(300)
-          expect(presenter.getState().gutter.scrollTop).toBe presenter.contentHeight - (presenter.lineHeight * 3)
+          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.contentHeight - (presenter.lineHeight * 3)
 
           expectStateUpdate presenter, -> atom.config.set("editor.scrollPastEnd", false)
-          expect(presenter.getState().gutter.scrollTop).toBe presenter.contentHeight - presenter.clientHeight
+          expect(presenter.getState().lineNumberGutter.scrollTop).toBe presenter.contentHeight - presenter.clientHeight
 
       describe ".backgroundColor", ->
         it "is assigned to ::gutterBackgroundColor if present, and to ::backgroundColor otherwise", ->
           presenter = buildPresenter(backgroundColor: "rgba(255, 0, 0, 0)", gutterBackgroundColor: "rgba(0, 255, 0, 0)")
-          expect(presenter.getState().gutter.backgroundColor).toBe "rgba(0, 255, 0, 0)"
+          expect(presenter.getState().lineNumberGutter.backgroundColor).toBe "rgba(0, 255, 0, 0)"
 
           expectStateUpdate presenter, -> presenter.setGutterBackgroundColor("rgba(0, 0, 255, 0)")
-          expect(presenter.getState().gutter.backgroundColor).toBe "rgba(0, 0, 255, 0)"
+          expect(presenter.getState().lineNumberGutter.backgroundColor).toBe "rgba(0, 0, 255, 0)"
 
           expectStateUpdate presenter, -> presenter.setGutterBackgroundColor("rgba(0, 0, 0, 0)")
-          expect(presenter.getState().gutter.backgroundColor).toBe "rgba(255, 0, 0, 0)"
+          expect(presenter.getState().lineNumberGutter.backgroundColor).toBe "rgba(255, 0, 0, 0)"
 
           expectStateUpdate presenter, -> presenter.setBackgroundColor("rgba(0, 0, 255, 0)")
-          expect(presenter.getState().gutter.backgroundColor).toBe "rgba(0, 0, 255, 0)"
+          expect(presenter.getState().lineNumberGutter.backgroundColor).toBe "rgba(0, 0, 255, 0)"
 
       describe ".maxLineNumberDigits", ->
         it "is set to the number of digits used by the greatest line number", ->
           presenter = buildPresenter()
           expect(editor.getLastBufferRow()).toBe 12
-          expect(presenter.getState().gutter.maxLineNumberDigits).toBe 2
+          expect(presenter.getState().lineNumberGutter.maxLineNumberDigits).toBe 2
 
           editor.setText("1\n2\n3")
-          expect(presenter.getState().gutter.maxLineNumberDigits).toBe 1
+          expect(presenter.getState().lineNumberGutter.maxLineNumberDigits).toBe 1
 
       describe ".lineNumbers", ->
         lineNumberStateForScreenRow = (presenter, screenRow) ->
@@ -1878,7 +1877,7 @@ describe "TextEditorPresenter", ->
           else
             key = bufferRow
 
-          presenter.getState().gutter.lineNumbers[key]
+          presenter.getState().lineNumberGutter.lineNumbers[key]
 
         it "contains states for line numbers that are visible on screen, plus and minus the overdraw margin", ->
           editor.foldBufferRow(4)
@@ -2170,28 +2169,28 @@ describe "TextEditorPresenter", ->
           presenter = buildPresenter()
 
           expect(editor.isLineNumberGutterVisible()).toBe true
-          expect(presenter.getState().gutter.visible).toBe true
+          expect(presenter.getState().lineNumberGutter.visible).toBe true
 
           expectStateUpdate presenter, -> editor.setMini(true)
-          expect(presenter.getState().gutter.visible).toBe false
+          expect(presenter.getState().lineNumberGutter.visible).toBe false
 
           expectStateUpdate presenter, -> editor.setMini(false)
-          expect(presenter.getState().gutter.visible).toBe true
+          expect(presenter.getState().lineNumberGutter.visible).toBe true
 
           expectStateUpdate presenter, -> editor.setLineNumberGutterVisible(false)
-          expect(presenter.getState().gutter.visible).toBe false
+          expect(presenter.getState().lineNumberGutter.visible).toBe false
 
           expectStateUpdate presenter, -> editor.setLineNumberGutterVisible(true)
-          expect(presenter.getState().gutter.visible).toBe true
+          expect(presenter.getState().lineNumberGutter.visible).toBe true
 
           expectStateUpdate presenter, -> atom.config.set('editor.showLineNumbers', false)
-          expect(presenter.getState().gutter.visible).toBe false
+          expect(presenter.getState().lineNumberGutter.visible).toBe false
 
         it "updates when the editor's grammar changes", ->
           presenter = buildPresenter()
 
           atom.config.set('editor.showLineNumbers', false, scopeSelector: '.source.js')
-          expect(presenter.getState().gutter.visible).toBe true
+          expect(presenter.getState().lineNumberGutter.visible).toBe true
           stateUpdated = false
           presenter.onDidUpdateState -> stateUpdated = true
 
@@ -2199,7 +2198,7 @@ describe "TextEditorPresenter", ->
 
           runs ->
             expect(stateUpdated).toBe true
-            expect(presenter.getState().gutter.visible).toBe false
+            expect(presenter.getState().lineNumberGutter.visible).toBe false
 
     describe ".height", ->
       it "tracks the computed content height if ::autoHeight is true so the editor auto-expands vertically", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4244,12 +4244,22 @@ describe "TextEditor", ->
         waitsForPromise -> editor.checkoutHeadRevision()
 
   describe 'gutters', ->
+    describe 'the TextEditor constructor', ->
+      it 'creates a line-number gutter', ->
+        expect(editor.getGutters().length).toBe 1
+        lineNumberGutter = editor.gutterWithName('line-number')
+        expect(lineNumberGutter.name).toBe 'line-number'
+        expect(lineNumberGutter.priority).toBe 0
+
     describe '::addGutter', ->
       it 'can add a gutter', ->
-        expect(editor.getGutters().length).toBe 0
+        expect(editor.getGutters().length).toBe 1 # line-number gutter
         options =
           name: 'test-gutter'
           priority: 1
         gutter = editor.addGutter options
-        expect(editor.getGutters().length).toBe 1
-        expect(editor.getGutters()[0]).toBe gutter
+        expect(editor.getGutters().length).toBe 2
+        expect(editor.getGutters()[1]).toBe gutter
+
+      it "does not allow a custom gutter with the 'line-number' name.", ->
+        expect(editor.addGutter.bind(editor, {name: 'line-number'})).toThrow()

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4242,3 +4242,14 @@ describe "TextEditor", ->
         editor.checkoutHeadRevision()
 
         waitsForPromise -> editor.checkoutHeadRevision()
+
+  describe 'gutters', ->
+    describe '::addGutter', ->
+      it 'can add a gutter', ->
+        expect(editor.getGutters().length).toBe 0
+        options =
+          name: 'test-gutter'
+          priority: 1
+        gutter = editor.addGutter options
+        expect(editor.getGutters().length).toBe 1
+        expect(editor.getGutters()[0]).toBe gutter

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4263,3 +4263,17 @@ describe "TextEditor", ->
 
       it "does not allow a custom gutter with the 'line-number' name.", ->
         expect(editor.addGutter.bind(editor, {name: 'line-number'})).toThrow()
+
+  describe '::decorateMarker', ->
+    [marker] = []
+
+    beforeEach ->
+      marker = editor.markBufferRange([[1, 0], [1, 0]])
+
+    it "casts 'gutter' type to 'line-number' unless a gutter name is specified.", ->
+      lineNumberDecoration = editor.decorateMarker(marker, {type: 'gutter'})
+      customGutterDecoration = editor.decorateMarker(marker, {type: 'gutter', gutterName: 'custom'})
+      expect(lineNumberDecoration.getProperties().type).toBe 'line-number'
+      expect(lineNumberDecoration.getProperties().gutterName).toBe 'line-number'
+      expect(customGutterDecoration.getProperties().type).toBe 'gutter'
+      expect(customGutterDecoration.getProperties().gutterName).toBe 'custom'

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4296,3 +4296,77 @@ describe "TextEditor", ->
         class: 'test-class'
       expect(gutterDecorations.length).toBe 1
       expect(gutterDecorations[0]).toBe decoration
+
+  describe '::observeGutters', ->
+    [payloads, callback] = []
+
+    beforeEach ->
+      payloads = []
+      callback = (payload) ->
+        payloads.push(payload)
+
+    it 'calls the callback immediately with each existing gutter, and with each added gutter after that.', ->
+      lineNumberGutter = editor.gutterWithName('line-number')
+      editor.observeGutters(callback)
+      expect(payloads).toEqual [lineNumberGutter]
+      gutter1 = editor.addGutter({name: 'test-gutter-1'})
+      expect(payloads).toEqual [lineNumberGutter, gutter1]
+      gutter2 = editor.addGutter({name: 'test-gutter-2'})
+      expect(payloads).toEqual [lineNumberGutter, gutter1, gutter2]
+
+    it 'does not call the callback when a gutter is removed.', ->
+      gutter = editor.addGutter({name: 'test-gutter'})
+      editor.observeGutters(callback)
+      payloads = []
+      gutter.destroy()
+      expect(payloads).toEqual []
+
+    it 'does not call the callback after the subscription has been disposed.', ->
+      subscription = editor.observeGutters(callback)
+      payloads = []
+      subscription.dispose()
+      editor.addGutter({name: 'test-gutter'})
+      expect(payloads).toEqual []
+
+  describe '::onDidAddGutter', ->
+    [payloads, callback] = []
+
+    beforeEach ->
+      payloads = []
+      callback = (payload) ->
+        payloads.push(payload)
+
+    it 'calls the callback with each newly-added gutter, but not with existing gutters.', ->
+      editor.onDidAddGutter(callback)
+      expect(payloads).toEqual []
+      gutter = editor.addGutter({name: 'test-gutter'})
+      expect(payloads).toEqual [gutter]
+
+    it 'does not call the callback after the subscription has been disposed.', ->
+      subscription = editor.onDidAddGutter(callback)
+      payloads = []
+      subscription.dispose()
+      editor.addGutter({name: 'test-gutter'})
+      expect(payloads).toEqual []
+
+  describe '::onDidRemoveGutter', ->
+    [payloads, callback] = []
+
+    beforeEach ->
+      payloads = []
+      callback = (payload) ->
+        payloads.push(payload)
+
+    it 'calls the callback when a gutter is removed.', ->
+      gutter = editor.addGutter({name: 'test-gutter'})
+      editor.onDidRemoveGutter(callback)
+      expect(payloads).toEqual []
+      gutter.destroy()
+      expect(payloads).toEqual ['test-gutter']
+
+    it 'does not call the callback after the subscription has been disposed.', ->
+      gutter = editor.addGutter({name: 'test-gutter'})
+      subscription = editor.onDidRemoveGutter(callback)
+      subscription.dispose()
+      gutter.destroy()
+      expect(payloads).toEqual []

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4277,3 +4277,22 @@ describe "TextEditor", ->
       expect(lineNumberDecoration.getProperties().gutterName).toBe 'line-number'
       expect(customGutterDecoration.getProperties().type).toBe 'gutter'
       expect(customGutterDecoration.getProperties().gutterName).toBe 'custom'
+
+    it 'reflects an added decoration when one of its custom gutters is decorated.', ->
+      gutter = editor.addGutter {'name': 'custom-gutter'}
+      decoration = gutter.decorateMarker marker, {class: 'custom-class'}
+      gutterDecorations = editor.getDecorations
+        type: 'gutter'
+        gutterName: 'custom-gutter'
+        class: 'custom-class'
+      expect(gutterDecorations.length).toBe 1
+      expect(gutterDecorations[0]).toBe decoration
+
+    it 'reflects an added decoration when its line-number gutter is decorated.', ->
+      decoration = editor.gutterWithName('line-number').decorateMarker marker, {class: 'test-class'}
+      gutterDecorations = editor.getDecorations
+        type: 'line-number'
+        gutterName: 'line-number'
+        class: 'test-class'
+      expect(gutterDecorations.length).toBe 1
+      expect(gutterDecorations[0]).toBe decoration

--- a/src/cursors-component.coffee
+++ b/src/cursors-component.coffee
@@ -7,6 +7,9 @@ class CursorsComponent
     @domNode = document.createElement('div')
     @domNode.classList.add('cursors')
 
+  getDomNode: ->
+    @domNode
+
   updateSync: (state) ->
     newState = state.content
     @oldState ?= {cursors: {}}

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -17,9 +17,6 @@ class CustomGutterComponent
   getDomNode: ->
     @domNode
 
-  getName: ->
-    @gutter.name
-
   hideNode: ->
     if @visible
       @domNode.style.display = 'none'
@@ -36,7 +33,7 @@ class CustomGutterComponent
     setDimensionsAndBackground(@oldDimensionsAndBackgroundState, newDimensionsAndBackgroundState, @decorationsNode)
 
     @oldDecorationPositionState ?= {};
-    decorationState = state.gutters.customDecorations[@getName()]
+    decorationState = state.gutters.customDecorations[@gutter.name]
 
     updatedDecorationIds = new Set
     for decorationId, decorationInfo of decorationState

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -43,9 +43,9 @@ class CustomGutterComponent
       updatedDecorationIds.add(decorationId)
       existingDecoration = @decorationNodesById[decorationId]
       if existingDecoration
-        @updateDecorationHTML(existingDecoration, decorationId, decorationInfo)
+        @updateDecorationNode(existingDecoration, decorationId, decorationInfo)
       else
-        newNode = @buildDecorationHTML(decorationId, decorationInfo)
+        newNode = @buildDecorationNode(decorationId, decorationInfo)
         @decorationNodesById[decorationId] = newNode
         @decorationsNode.appendChild(newNode)
 
@@ -61,7 +61,7 @@ class CustomGutterComponent
   ###
 
   # Builds and returns an HTMLElement to represent the specified decoration.
-  buildDecorationHTML: (decorationId, decorationInfo) ->
+  buildDecorationNode: (decorationId, decorationInfo) ->
     @oldDecorationPositionState[decorationId] = positionState = {};
     newNode = document.createElement('div')
     newNode.classList.add('decoration')
@@ -77,7 +77,7 @@ class CustomGutterComponent
 
   # Updates the existing HTMLNode with the new decoration info. Attempts to
   # minimize changes to the DOM.
-  updateDecorationHTML: (existingNode, decorationId, newDecorationInfo) ->
+  updateDecorationNode: (existingNode, decorationId, newDecorationInfo) ->
     oldPositionState = @oldDecorationPositionState[decorationId];
 
     if oldPositionState.top isnt newDecorationInfo.top + 'px'

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -1,3 +1,5 @@
+{setDimensionsAndBackground} = require './gutter-component-helpers'
+
 # This class represents a gutter other than the 'line-numbers' gutter.
 # The contents of this gutter may be specified by Decorations.
 
@@ -33,15 +35,7 @@ class CustomGutterComponent
     decorationState = state.gutters.customDecorations[@getName()]
     @oldState ?= {}
 
-    # TODO (jessicalin) Factor this out (also in LineNumberGutterComponent).
-    # Also, set backgroundColor?
-    if gutterProps.scrollHeight isnt @oldState.scrollHeight
-      @decorationsNode.style.height = gutterProps.scrollHeight + 'px'
-      @oldState.scrollHeight = gutterProps.scrollHeight
-
-    if gutterProps.scrollTop isnt @oldState.scrollTop
-      @decorationsNode.style['-webkit-transform'] = "translate3d(0px, #{-gutterProps.scrollTop}px, 0px)"
-      @oldState.scrollTop = gutterProps.scrollTop
+    setDimensionsAndBackground(@oldState, gutterProps, @decorationsNode)
 
     return if !decorationState
 

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -26,7 +26,7 @@ class CustomGutterComponent
       @visible = false
 
   showNode: ->
-    if !@visible
+    if not @visible
       @domNode.style.removeProperty('display')
       @visible = true
 
@@ -50,7 +50,7 @@ class CustomGutterComponent
         @decorationsNode.appendChild(newNode)
 
     for decorationId, decorationNode of @decorationNodesById
-      if !updatedDecorationIds.has(decorationId)
+      if not updatedDecorationIds.has(decorationId)
         decorationNode.remove()
         delete @decorationNodesById[decorationId]
         delete @decorationItemsById[decorationId]
@@ -88,10 +88,10 @@ class CustomGutterComponent
       existingNode.style.height = newDecorationInfo.height + 'px'
       oldPositionState.height = newDecorationInfo.height + 'px'
 
-    if newDecorationInfo.class and !existingNode.classList.contains(newDecorationInfo.class)
+    if newDecorationInfo.class and not existingNode.classList.contains(newDecorationInfo.class)
       existingNode.className = 'decoration'
       existingNode.classList.add(newDecorationInfo.class)
-    else if !newDecorationInfo.class
+    else if not newDecorationInfo.class
       existingNode.className = 'decoration'
 
     @setDecorationItem(newDecorationInfo.item, newDecorationInfo.height, decorationId, existingNode)

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -36,7 +36,6 @@ class CustomGutterComponent
     setDimensionsAndBackground(@oldDimensionsAndBackgroundState, newDimensionsAndBackgroundState, @decorationsNode)
 
     decorationState = state.gutters.customDecorations[@getName()]
-    return if !decorationState
 
     updatedDecorationIds = new Set
     for decorationId, decorationInfo of decorationState

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -1,0 +1,118 @@
+# This class represents a gutter other than the 'line-numbers' gutter.
+# The contents of this gutter may be specified by Decorations.
+
+# TODO (jssln) Remove these (testing-only).
+TEMP_MIN_WIDTH = 25
+TEMP_DECOR_WIDTH = '50px'
+TEMP_DECOR_BACKGROUND = 'white'
+
+module.exports =
+class CustomGutterComponent
+
+  constructor: ({@name}) ->
+    @decorationNodesById = {}
+    @decorationItemsById = {}
+
+    @domNode = document.createElement('div')
+    @domNode.classList.add('gutter')
+    @domNode.setAttribute('gutter-name', @name)
+    @decorationsNode = document.createElement('div')
+    @decorationsNode.classList.add('custom-decorations')
+    @domNode.appendChild(@decorationsNode)
+
+    @domNode.style['width'] = '' + TEMP_MIN_WIDTH + 'px'
+
+  getDomNode: ->
+    @domNode
+
+  getName: ->
+    @name
+
+  updateSync: (state) ->
+    gutterProps = state.lineNumberGutter
+    decorationState = state.gutters.customDecorations[@getName()]
+    @oldState ?= {}
+
+    # TODO (jessicalin) Factor this out (also in LineNumberGutterComponent).
+    # Also, set backgroundColor?
+    if gutterProps.scrollHeight isnt @oldState.scrollHeight
+      @decorationsNode.style.height = gutterProps.scrollHeight + 'px'
+      @oldState.scrollHeight = gutterProps.scrollHeight
+
+    if gutterProps.scrollTop isnt @oldState.scrollTop
+      @decorationsNode.style['-webkit-transform'] = "translate3d(0px, #{-gutterProps.scrollTop}px, 0px)"
+      @oldState.scrollTop = gutterProps.scrollTop
+
+    return if !decorationState
+
+    updatedDecorationIds = new Set
+    for decorationId, decorationInfo of decorationState
+      updatedDecorationIds.add(decorationId)
+      existingDecoration = @decorationNodesById[decorationId]
+      if existingDecoration
+        @updateDecorationHTML(existingDecoration, decorationId, decorationInfo)
+      else
+        newNode = @buildDecorationHTML(decorationId, decorationInfo)
+        @decorationNodesById[decorationId] = newNode
+        @decorationsNode.appendChild(newNode)
+
+    for decorationId, decorationNode of @decorationNodesById
+      if !updatedDecorationIds.has(decorationId)
+        decorationNode.remove()
+        delete @decorationNodesById[decorationId]
+        delete @decorationItemsById[decorationId]
+
+  ###
+  Section: Private Methods
+  ###
+
+  # Builds and returns an HTMLElement to represent the specified decoration.
+  buildDecorationHTML: (decorationId, decorationInfo) ->
+    newNode = document.createElement('div')
+    newNode.classList.add('decoration')
+    newNode.style.top = decorationInfo.top + 'px'
+    newNode.style.height = decorationInfo.height + 'px'
+    newNode.style.position = 'absolute'
+    newNode.style['background-color'] = TEMP_DECOR_BACKGROUND
+    newNode.style.width = TEMP_DECOR_WIDTH
+    if decorationInfo.class
+      newNode.classList.add(decorationInfo.class)
+    @setDecorationItem(decorationInfo.item, decorationInfo.height, decorationId, newNode)
+    newNode
+
+  # Updates the existing HTMLNode with the new decoration info. Attempts to
+  # minimize changes to the DOM.
+  updateDecorationHTML: (existingNode, decorationId, newDecorationInfo) ->
+    if existingNode.style.top isnt newDecorationInfo.top + 'px'
+      existingNode.style.top = newDecorationInfo.top + 'px'
+
+    if existingNode.style.height isnt newDecorationInfo.height + 'px'
+      existingNode.style.height = newDecorationInfo.height + 'px'
+
+    if newDecorationInfo.class and !existingNode.classList.contains(newDecorationInfo.class)
+      existingNode.className = 'decoration'
+      existingNode.classList.add(newDecorationInfo.class)
+    else if !newDecorationInfo.class
+      existingNode.className = 'decoration'
+
+    @setDecorationItem(newDecorationInfo.item, newDecorationInfo.height, decorationId, existingNode)
+
+  # Sets the decorationItem on the decorationNode.
+  # If `decorationItem` is undefined, the decorationNode's child item will be cleared.
+  setDecorationItem: (newItem, decorationHeight, decorationId, decorationNode) ->
+    if newItem isnt @decorationItemsById[decorationId]
+      while decorationNode.firstChild
+        decorationNode.removeChild(decorationNode.firstChild)
+      delete @decorationItemsById[decorationId]
+
+      if newItem
+        # `item` should be either an HTMLElement or a space-pen View.
+        newItemNode = null
+        if newItem instanceof HTMLElement
+          newItemNode = newItem
+        else
+          newItemNode = newItem.element
+
+        newItemNode.style.height = decorationHeight + 'px'
+        decorationNode.appendChild(newItemNode)
+        @decorationItemsById[decorationId] = newItem

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -14,6 +14,7 @@ class CustomGutterComponent
   constructor: ({@gutter}) ->
     @decorationNodesById = {}
     @decorationItemsById = {}
+    @visible = true
 
     @domNode = atom.views.getView(@gutter)
     @decorationsNode = @domNode.firstChild
@@ -25,6 +26,16 @@ class CustomGutterComponent
 
   getName: ->
     @gutter.name
+
+  hideNode: ->
+    if @visible
+      @domNode.style.display = 'none'
+      @visible = false
+
+  showNode: ->
+    if !@visible
+      @domNode.style.removeProperty('display')
+      @visible = true
 
   updateSync: (state) ->
     gutterProps = state.lineNumberGutter

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -11,16 +11,12 @@ TEMP_DECOR_BACKGROUND = 'white'
 module.exports =
 class CustomGutterComponent
 
-  constructor: ({@name}) ->
+  constructor: ({@gutter}) ->
     @decorationNodesById = {}
     @decorationItemsById = {}
 
-    @domNode = document.createElement('div')
-    @domNode.classList.add('gutter')
-    @domNode.setAttribute('gutter-name', @name)
-    @decorationsNode = document.createElement('div')
-    @decorationsNode.classList.add('custom-decorations')
-    @domNode.appendChild(@decorationsNode)
+    @domNode = atom.views.getView(@gutter)
+    @decorationsNode = @domNode.firstChild
 
     @domNode.style['width'] = '' + TEMP_MIN_WIDTH + 'px'
 
@@ -28,7 +24,7 @@ class CustomGutterComponent
     @domNode
 
   getName: ->
-    @name
+    @gutter.name
 
   updateSync: (state) ->
     gutterProps = state.lineNumberGutter

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -35,6 +35,7 @@ class CustomGutterComponent
     newDimensionsAndBackgroundState = state.gutters
     setDimensionsAndBackground(@oldDimensionsAndBackgroundState, newDimensionsAndBackgroundState, @decorationsNode)
 
+    @oldDecorationPositionState ?= {};
     decorationState = state.gutters.customDecorations[@getName()]
 
     updatedDecorationIds = new Set
@@ -53,6 +54,7 @@ class CustomGutterComponent
         decorationNode.remove()
         delete @decorationNodesById[decorationId]
         delete @decorationItemsById[decorationId]
+        delete @oldDecorationPositionState[decorationId]
 
   ###
   Section: Private Methods
@@ -60,10 +62,13 @@ class CustomGutterComponent
 
   # Builds and returns an HTMLElement to represent the specified decoration.
   buildDecorationHTML: (decorationId, decorationInfo) ->
+    @oldDecorationPositionState[decorationId] = positionState = {};
     newNode = document.createElement('div')
     newNode.classList.add('decoration')
     newNode.style.top = decorationInfo.top + 'px'
+    positionState.top = decorationInfo.top + 'px'
     newNode.style.height = decorationInfo.height + 'px'
+    positionState.height = decorationInfo.height + 'px'
     newNode.style.position = 'absolute'
     if decorationInfo.class
       newNode.classList.add(decorationInfo.class)
@@ -73,11 +78,15 @@ class CustomGutterComponent
   # Updates the existing HTMLNode with the new decoration info. Attempts to
   # minimize changes to the DOM.
   updateDecorationHTML: (existingNode, decorationId, newDecorationInfo) ->
-    if existingNode.style.top isnt newDecorationInfo.top + 'px'
-      existingNode.style.top = newDecorationInfo.top + 'px'
+    oldPositionState = @oldDecorationPositionState[decorationId];
 
-    if existingNode.style.height isnt newDecorationInfo.height + 'px'
+    if oldPositionState.top isnt newDecorationInfo.top + 'px'
+      existingNode.style.top = newDecorationInfo.top + 'px'
+      oldPositionState.top = newDecorationInfo.top + 'px'
+
+    if oldPositionState.height isnt newDecorationInfo.height + 'px'
       existingNode.style.height = newDecorationInfo.height + 'px'
+      oldPositionState.height = newDecorationInfo.height + 'px'
 
     if newDecorationInfo.class and !existingNode.classList.contains(newDecorationInfo.class)
       existingNode.className = 'decoration'

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -38,12 +38,11 @@ class CustomGutterComponent
       @visible = true
 
   updateSync: (state) ->
-    gutterProps = state.lineNumberGutter
+    @oldDimensionsAndBackgroundState ?= {}
+    newDimensionsAndBackgroundState = state.gutters
+    setDimensionsAndBackground(@oldDimensionsAndBackgroundState, newDimensionsAndBackgroundState, @decorationsNode)
+
     decorationState = state.gutters.customDecorations[@getName()]
-    @oldState ?= {}
-
-    setDimensionsAndBackground(@oldState, gutterProps, @decorationsNode)
-
     return if !decorationState
 
     updatedDecorationIds = new Set

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -3,11 +3,6 @@
 # This class represents a gutter other than the 'line-numbers' gutter.
 # The contents of this gutter may be specified by Decorations.
 
-# TODO (jssln) Remove these (testing-only).
-TEMP_MIN_WIDTH = 25
-TEMP_DECOR_WIDTH = '50px'
-TEMP_DECOR_BACKGROUND = 'white'
-
 module.exports =
 class CustomGutterComponent
 
@@ -18,8 +13,6 @@ class CustomGutterComponent
 
     @domNode = atom.views.getView(@gutter)
     @decorationsNode = @domNode.firstChild
-
-    @domNode.style['width'] = '' + TEMP_MIN_WIDTH + 'px'
 
   getDomNode: ->
     @domNode
@@ -73,8 +66,6 @@ class CustomGutterComponent
     newNode.style.top = decorationInfo.top + 'px'
     newNode.style.height = decorationInfo.height + 'px'
     newNode.style.position = 'absolute'
-    newNode.style['background-color'] = TEMP_DECOR_BACKGROUND
-    newNode.style.width = TEMP_DECOR_WIDTH
     if decorationInfo.class
       newNode.classList.add(decorationInfo.class)
     @setDecorationItem(decorationInfo.item, decorationInfo.height, decorationId, newNode)

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -32,7 +32,7 @@ class CustomGutterComponent
     newDimensionsAndBackgroundState = state.gutters
     setDimensionsAndBackground(@oldDimensionsAndBackgroundState, newDimensionsAndBackgroundState, @decorationsNode)
 
-    @oldDecorationPositionState ?= {};
+    @oldDecorationPositionState ?= {}
     decorationState = state.gutters.customDecorations[@gutter.name]
 
     updatedDecorationIds = new Set
@@ -59,7 +59,7 @@ class CustomGutterComponent
 
   # Builds and returns an HTMLElement to represent the specified decoration.
   buildDecorationNode: (decorationId, decorationInfo) ->
-    @oldDecorationPositionState[decorationId] = {};
+    @oldDecorationPositionState[decorationId] = {}
     newNode = document.createElement('div')
     newNode.style.position = 'absolute'
     @updateDecorationNode(newNode, decorationId, decorationInfo)
@@ -68,7 +68,7 @@ class CustomGutterComponent
   # Updates the existing HTMLNode with the new decoration info. Attempts to
   # minimize changes to the DOM.
   updateDecorationNode: (node, decorationId, newDecorationInfo) ->
-    oldPositionState = @oldDecorationPositionState[decorationId];
+    oldPositionState = @oldDecorationPositionState[decorationId]
 
     if oldPositionState.top isnt newDecorationInfo.top + 'px'
       node.style.top = newDecorationInfo.top + 'px'

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -62,39 +62,32 @@ class CustomGutterComponent
 
   # Builds and returns an HTMLElement to represent the specified decoration.
   buildDecorationNode: (decorationId, decorationInfo) ->
-    @oldDecorationPositionState[decorationId] = positionState = {};
+    @oldDecorationPositionState[decorationId] = {};
     newNode = document.createElement('div')
-    newNode.classList.add('decoration')
-    newNode.style.top = decorationInfo.top + 'px'
-    positionState.top = decorationInfo.top + 'px'
-    newNode.style.height = decorationInfo.height + 'px'
-    positionState.height = decorationInfo.height + 'px'
     newNode.style.position = 'absolute'
-    if decorationInfo.class
-      newNode.classList.add(decorationInfo.class)
-    @setDecorationItem(decorationInfo.item, decorationInfo.height, decorationId, newNode)
+    @updateDecorationNode(newNode, decorationId, decorationInfo)
     newNode
 
   # Updates the existing HTMLNode with the new decoration info. Attempts to
   # minimize changes to the DOM.
-  updateDecorationNode: (existingNode, decorationId, newDecorationInfo) ->
+  updateDecorationNode: (node, decorationId, newDecorationInfo) ->
     oldPositionState = @oldDecorationPositionState[decorationId];
 
     if oldPositionState.top isnt newDecorationInfo.top + 'px'
-      existingNode.style.top = newDecorationInfo.top + 'px'
+      node.style.top = newDecorationInfo.top + 'px'
       oldPositionState.top = newDecorationInfo.top + 'px'
 
     if oldPositionState.height isnt newDecorationInfo.height + 'px'
-      existingNode.style.height = newDecorationInfo.height + 'px'
+      node.style.height = newDecorationInfo.height + 'px'
       oldPositionState.height = newDecorationInfo.height + 'px'
 
-    if newDecorationInfo.class and not existingNode.classList.contains(newDecorationInfo.class)
-      existingNode.className = 'decoration'
-      existingNode.classList.add(newDecorationInfo.class)
+    if newDecorationInfo.class and not node.classList.contains(newDecorationInfo.class)
+      node.className = 'decoration'
+      node.classList.add(newDecorationInfo.class)
     else if not newDecorationInfo.class
-      existingNode.className = 'decoration'
+      node.className = 'decoration'
 
-    @setDecorationItem(newDecorationInfo.item, newDecorationInfo.height, decorationId, existingNode)
+    @setDecorationItem(newDecorationInfo.item, newDecorationInfo.height, decorationId, node)
 
   # Sets the decorationItem on the decorationNode.
   # If `decorationItem` is undefined, the decorationNode's child item will be cleared.

--- a/src/gutter-component-helpers.coffee
+++ b/src/gutter-component-helpers.coffee
@@ -1,0 +1,16 @@
+# Helper methods shared among GutterComponent classes.
+
+module.exports =
+  # Sets scrollHeight, scrollTop, and backgroundColor on the given domNode.
+  setDimensionsAndBackground: (oldState, newState, domNode) ->
+    if newState.scrollHeight isnt oldState.scrollHeight
+      domNode.style.height = newState.scrollHeight + 'px'
+      oldState.scrollHeight = newState.scrollHeight
+
+    if newState.scrollTop isnt oldState.scrollTop
+      domNode.style['-webkit-transform'] = "translate3d(0px, #{-newState.scrollTop}px, 0px)"
+      oldState.scrollTop = newState.scrollTop
+
+    if newState.backgroundColor isnt oldState.backgroundColor
+      domNode.style.backgroundColor = newState.backgroundColor
+      oldState.backgroundColor = newState.backgroundColor

--- a/src/gutter-component-helpers.coffee
+++ b/src/gutter-component-helpers.coffee
@@ -1,6 +1,18 @@
 # Helper methods shared among GutterComponent classes.
 
 module.exports =
+  createGutterView: (gutterModel) ->
+    domNode = document.createElement('div')
+    domNode.classList.add('gutter')
+    domNode.setAttribute('gutter-name', gutterModel.name)
+    childNode = document.createElement('div')
+    if gutterModel.name is 'line-number'
+      childNode.classList.add('line-numbers')
+    else
+      childNode.classList.add('custom-decorations')
+    domNode.appendChild(childNode)
+    domNode
+
   # Sets scrollHeight, scrollTop, and backgroundColor on the given domNode.
   setDimensionsAndBackground: (oldState, newState, domNode) ->
     if newState.scrollHeight isnt oldState.scrollHeight

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -6,7 +6,7 @@ module.exports =
 class GutterComponent
   dummyLineNumberNode: null
 
-  constructor: ({@presenter, @onMouseDown, @editor}) ->
+  constructor: ({@onMouseDown, @editor}) ->
     @lineNumberNodesById = {}
 
     @domNode = document.createElement('div')

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -19,7 +19,7 @@ class GutterComponent
     @domNode.addEventListener 'mousedown', @onMouseDown
 
   updateSync: (state) ->
-    @newState = state.gutter
+    @newState = state.lineNumberGutter
     @oldState ?= {lineNumbers: {}}
 
     @appendDummyLineNumber() unless @dummyLineNumberNode?

--- a/src/gutter-container-component.coffee
+++ b/src/gutter-container-component.coffee
@@ -1,0 +1,82 @@
+LineNumberGutterComponent = require './line-number-gutter-component'
+
+# The GutterContainerComponent manages the GutterComponents of a particular
+# TextEditorComponent.
+
+module.exports =
+class GutterContainerComponent
+
+  constructor: ({@onLineNumberGutterMouseDown, @editor}) ->
+    @gutterComponents = []
+    @gutterComponentsByGutterName = {}
+    @lineNumberGutterComponent = null
+
+    @domNode = document.createElement('div')
+    @domNode.classList.add('gutter-container')
+
+  getDomNode: ->
+    @domNode
+
+  getLineNumberGutterComponent: ->
+    @lineNumberGutterComponent
+
+  updateSync: (state) ->
+    # The GutterContainerComponent expects the gutters to be sorted in the order
+    # they should appear.
+    newState = state.gutters.sortedDescriptions
+
+    newGutterComponents = []
+    newGutterComponentsByGutterName = {}
+    for gutter in newState
+      gutterComponent = @gutterComponentsByGutterName[gutter.name]
+      if !gutterComponent
+        if gutter.name is 'line-number'
+          gutterComponent = new LineNumberGutterComponent({onMouseDown: @onLineNumberGutterMouseDown, @editor, name: gutter.name})
+          @lineNumberGutterComponent = gutterComponent
+        else
+          # TODO (jessicalin) Implement non-line-number gutters.
+          continue
+      newGutterComponents.push(gutterComponent)
+      newGutterComponentsByGutterName[gutter.name] = gutterComponent
+
+    @updateChildGutters(state, newGutterComponents, newGutterComponentsByGutterName)
+
+    @gutterComponents = newGutterComponents
+    @gutterComponentsByGutterName = newGutterComponentsByGutterName
+
+  ###
+  Section: Private Methods
+  ###
+
+  updateChildGutters: (state, newGutterComponents, newGutterComponentsByGutterName) ->
+    # First, insert new gutters into the DOM.
+    indexInOldGutters = 0
+    oldGuttersLength = @gutterComponents.length
+    for gutterComponent in newGutterComponents
+      gutterComponent.updateSync(state)
+      if @gutterComponentsByGutterName[gutterComponent.getName()]
+        # If the gutter existed previously, we first try to move the cursor to
+        # the point at which it occurs in the previous gutters.
+        matchingGutterFound = false
+        while indexInOldGutters < oldGuttersLength
+          existingGutterComponent = @gutterComponents[indexInOldGutters]
+          indexInOldGutters++
+          if existingGutterComponent.getName() == gutterComponent.getName()
+            matchingGutterFound = true
+            break
+        if !matchingGutterFound
+          # If we've reached this point, the gutter previously existed, but its
+          # position has moved. Remove it from the DOM and re-insert it.
+          gutterComponent.getDomNode().remove()
+          @domNode.appendChild(gutterComponent.getDomNode())
+
+      else
+        if indexInOldGutters == oldGuttersLength
+          @domNode.appendChild(gutterComponent.getDomNode())
+        else
+          @domNode.insertBefore(gutterComponent.getDomNode(), @domNode.children[indexInOldGutters])
+
+    # Remove any gutters that were not present in the new gutters state.
+    for gutterComponent in @gutterComponents
+      if !newGutterComponentsByGutterName[gutterComponent.getName()]
+        gutterComponent.getDomNode().remove()

--- a/src/gutter-container-component.coffee
+++ b/src/gutter-container-component.coffee
@@ -31,7 +31,7 @@ class GutterContainerComponent
     newGutterComponentsByGutterName = {}
     for {gutter, visible} in newState
       gutterComponent = @gutterComponentsByGutterName[gutter.name]
-      if !gutterComponent
+      if not gutterComponent
         if gutter.name is 'line-number'
           gutterComponent = new LineNumberGutterComponent({onMouseDown: @onLineNumberGutterMouseDown, @editor, gutter})
           @lineNumberGutterComponent = gutterComponent
@@ -66,7 +66,7 @@ class GutterContainerComponent
           if existingGutterComponent.getName() == gutterComponent.getName()
             matchingGutterFound = true
             break
-        if !matchingGutterFound
+        if not matchingGutterFound
           # If we've reached this point, the gutter previously existed, but its
           # position has moved. Remove it from the DOM and re-insert it.
           gutterComponent.getDomNode().remove()
@@ -80,5 +80,5 @@ class GutterContainerComponent
 
     # Remove any gutters that were not present in the new gutters state.
     for gutterComponent in @gutterComponents
-      if !newGutterComponentsByGutterName[gutterComponent.getName()]
+      if not newGutterComponentsByGutterName[gutterComponent.getName()]
         gutterComponent.getDomNode().remove()

--- a/src/gutter-container-component.coffee
+++ b/src/gutter-container-component.coffee
@@ -1,3 +1,4 @@
+CustomGutterComponent = require './custom-gutter-component'
 LineNumberGutterComponent = require './line-number-gutter-component'
 
 # The GutterContainerComponent manages the GutterComponents of a particular
@@ -13,6 +14,7 @@ class GutterContainerComponent
 
     @domNode = document.createElement('div')
     @domNode.classList.add('gutter-container')
+    @domNode.style.display = 'flex';
 
   getDomNode: ->
     @domNode
@@ -34,8 +36,7 @@ class GutterContainerComponent
           gutterComponent = new LineNumberGutterComponent({onMouseDown: @onLineNumberGutterMouseDown, @editor, name: gutter.name})
           @lineNumberGutterComponent = gutterComponent
         else
-          # TODO (jessicalin) Implement non-line-number gutters.
-          continue
+          gutterComponent = new CustomGutterComponent({name: gutter.name})
       newGutterComponents.push(gutterComponent)
       newGutterComponentsByGutterName[gutter.name] = gutterComponent
 

--- a/src/gutter-container-component.coffee
+++ b/src/gutter-container-component.coffee
@@ -38,10 +38,11 @@ class GutterContainerComponent
         else
           gutterComponent = new CustomGutterComponent({gutter})
       if visible then gutterComponent.showNode() else gutterComponent.hideNode()
+      gutterComponent.updateSync(state)
       newGutterComponents.push(gutterComponent)
       newGutterComponentsByGutterName[gutter.name] = gutterComponent
 
-    @updateChildGutters(state, newGutterComponents, newGutterComponentsByGutterName)
+    @reorderGutters(newGutterComponents, newGutterComponentsByGutterName)
 
     @gutterComponents = newGutterComponents
     @gutterComponentsByGutterName = newGutterComponentsByGutterName
@@ -50,12 +51,12 @@ class GutterContainerComponent
   Section: Private Methods
   ###
 
-  updateChildGutters: (state, newGutterComponents, newGutterComponentsByGutterName) ->
+  reorderGutters: (newGutterComponents, newGutterComponentsByGutterName) ->
     # First, insert new gutters into the DOM.
     indexInOldGutters = 0
     oldGuttersLength = @gutterComponents.length
+
     for gutterComponent in newGutterComponents
-      gutterComponent.updateSync(state)
       if @gutterComponentsByGutterName[gutterComponent.getName()]
         # If the gutter existed previously, we first try to move the cursor to
         # the point at which it occurs in the previous gutters.

--- a/src/gutter-container-component.coffee
+++ b/src/gutter-container-component.coffee
@@ -72,7 +72,7 @@ class GutterContainerComponent
           existingGutterComponentDescription = @gutterComponents[indexInOldGutters]
           existingGutterComponent = existingGutterComponentDescription.component
           indexInOldGutters++
-          if existingGutterComponent == gutterComponent
+          if existingGutterComponent is gutterComponent
             matchingGutterFound = true
             break
         if not matchingGutterFound
@@ -82,7 +82,7 @@ class GutterContainerComponent
           @domNode.appendChild(gutterComponent.getDomNode())
 
       else
-        if indexInOldGutters == oldGuttersLength
+        if indexInOldGutters is oldGuttersLength
           @domNode.appendChild(gutterComponent.getDomNode())
         else
           @domNode.insertBefore(gutterComponent.getDomNode(), @domNode.children[indexInOldGutters])

--- a/src/gutter-container-component.coffee
+++ b/src/gutter-container-component.coffee
@@ -25,11 +25,11 @@ class GutterContainerComponent
   updateSync: (state) ->
     # The GutterContainerComponent expects the gutters to be sorted in the order
     # they should appear.
-    newState = state.gutters.sortedModels
+    newState = state.gutters.sortedDescriptions
 
     newGutterComponents = []
     newGutterComponentsByGutterName = {}
-    for gutter in newState
+    for {gutter, visible} in newState
       gutterComponent = @gutterComponentsByGutterName[gutter.name]
       if !gutterComponent
         if gutter.name is 'line-number'
@@ -37,6 +37,7 @@ class GutterContainerComponent
           @lineNumberGutterComponent = gutterComponent
         else
           gutterComponent = new CustomGutterComponent({gutter})
+      if visible then gutterComponent.showNode() else gutterComponent.hideNode()
       newGutterComponents.push(gutterComponent)
       newGutterComponentsByGutterName[gutter.name] = gutterComponent
 

--- a/src/gutter-container-component.coffee
+++ b/src/gutter-container-component.coffee
@@ -33,10 +33,10 @@ class GutterContainerComponent
       gutterComponent = @gutterComponentsByGutterName[gutter.name]
       if !gutterComponent
         if gutter.name is 'line-number'
-          gutterComponent = new LineNumberGutterComponent({onMouseDown: @onLineNumberGutterMouseDown, @editor, name: gutter.name})
+          gutterComponent = new LineNumberGutterComponent({onMouseDown: @onLineNumberGutterMouseDown, @editor, gutter})
           @lineNumberGutterComponent = gutterComponent
         else
-          gutterComponent = new CustomGutterComponent({name: gutter.name})
+          gutterComponent = new CustomGutterComponent({gutter})
       newGutterComponents.push(gutterComponent)
       newGutterComponentsByGutterName[gutter.name] = gutterComponent
 

--- a/src/gutter-container-component.coffee
+++ b/src/gutter-container-component.coffee
@@ -25,7 +25,7 @@ class GutterContainerComponent
   updateSync: (state) ->
     # The GutterContainerComponent expects the gutters to be sorted in the order
     # they should appear.
-    newState = state.gutters.sortedDescriptions
+    newState = state.gutters.sortedModels
 
     newGutterComponents = []
     newGutterComponentsByGutterName = {}

--- a/src/gutter-container.coffee
+++ b/src/gutter-container.coffee
@@ -31,10 +31,10 @@ class GutterContainer
     options = options ? {}
     gutterName = options.name
     if gutterName == null
-      throw new Error 'A name is required to create a gutter.'
-    if @gutterWithName gutterName
-      throw new Error 'Tried to create a gutter with a name that is already in use.'
-    newGutter = new Gutter this, options
+      throw new Error('A name is required to create a gutter.')
+    if @gutterWithName(gutterName)
+      throw new Error('Tried to create a gutter with a name that is already in use.')
+    newGutter = new Gutter(this, options)
 
     inserted = false
     # Insert the gutter into the gutters array, sorted in ascending order by 'priority'.
@@ -81,7 +81,7 @@ class GutterContainer
   # Processes the destruction of the gutter. Throws an error if this gutter is
   # not within this gutterContainer.
   removeGutter: (gutter) ->
-    index = @gutters.indexOf gutter
+    index = @gutters.indexOf(gutter)
     if index > -1
       @gutters.splice(index, 1)
       @unsubscribe gutter
@@ -97,4 +97,4 @@ class GutterContainer
     else
       options.type = 'gutter'
     options.gutterName = gutter.name
-    @textEditor.decorateMarker marker, options
+    @textEditor.decorateMarker(marker, options)

--- a/src/gutter-container.coffee
+++ b/src/gutter-container.coffee
@@ -1,12 +1,10 @@
 {Emitter} = require 'event-kit'
-{Subscriber} = require 'emissary'
 Gutter = require './gutter'
 
 # This class encapsulates the logic for adding and modifying a set of gutters.
 
 module.exports =
 class GutterContainer
-  Subscriber.includeInto(this)
 
   # * `textEditor` The {TextEditor} to which this {GutterContainer} belongs.
   constructor: (textEditor) ->
@@ -17,7 +15,6 @@ class GutterContainer
   destroy: ->
     @gutters = null
     @emitter.dispose()
-    @unsubscribe()
 
   # Creates and returns a {Gutter}.
   # * `options` An {Object} with the following fields:
@@ -84,7 +81,6 @@ class GutterContainer
     index = @gutters.indexOf(gutter)
     if index > -1
       @gutters.splice(index, 1)
-      @unsubscribe gutter
       @emitter.emit 'did-remove-gutter', gutter.name
     else
       throw new Error 'The given gutter cannot be removed because it is not ' +

--- a/src/gutter-container.coffee
+++ b/src/gutter-container.coffee
@@ -30,7 +30,7 @@ class GutterContainer
   addGutter: (options) ->
     options = options ? {}
     gutterName = options.name
-    if gutterName == null
+    if gutterName is null
       throw new Error('A name is required to create a gutter.')
     if @gutterWithName(gutterName)
       throw new Error('Tried to create a gutter with a name that is already in use.')
@@ -54,7 +54,7 @@ class GutterContainer
 
   gutterWithName: (name) ->
     for gutter in @gutters
-      if gutter.name == name then return gutter
+      if gutter.name is name then return gutter
     null
 
   ###

--- a/src/gutter-container.coffee
+++ b/src/gutter-container.coffee
@@ -44,7 +44,7 @@ class GutterContainer
         @gutters.splice(i, 0, newGutter)
         inserted = true
         break
-    if !inserted
+    if not inserted
       @gutters.push newGutter
     @emitter.emit 'did-add-gutter', newGutter
     return newGutter

--- a/src/gutter-container.coffee
+++ b/src/gutter-container.coffee
@@ -1,0 +1,78 @@
+{Emitter} = require 'event-kit'
+{Subscriber} = require 'emissary'
+Gutter = require './gutter'
+
+# This class encapsulates the logic for adding and modifying a set of gutters.
+
+module.exports =
+class GutterContainer
+  Subscriber.includeInto(this)
+  constructor: ->
+    @gutters = []
+    @emitter = new Emitter
+
+  destroy: ->
+    @gutters = null
+    @emitter.dispose()
+    @unsubscribe()
+
+  # Creates and returns a {Gutter}.
+  # * `options` An {Object} with the following fields:
+  #   * `name` (required) A unique {String} to identify this gutter.
+  #   * `priority` (optional) A {Number} that determines stacking order between
+  #       gutters. Lower priority items are forced closer to the edges of the
+  #       window. (default: -100)
+  #   * `visible` (optional) {Boolean} specifying whether the gutter is visible
+  #       initially after being created. (default: true)
+  addGutter: (options) ->
+    options = options ? {}
+    gutterName = options.name
+    if gutterName == null
+      throw new Error 'A name is required to create a gutter.'
+    if @gutterWithName gutterName
+      throw new Error 'Tried to create a gutter with a name that is already in use.'
+    newGutter = new Gutter this, options
+
+    inserted = false
+    # Insert the gutter into the gutters array, sorted in ascending order by 'priority'.
+    # This could be optimized, but there are unlikely to be many gutters.
+    for i in [0...@gutters.length]
+      if @gutters[i].priority >= newGutter.priority
+        @gutters.splice(i, 0, newGutter)
+        inserted = true
+        break
+    if !inserted
+      @gutters.push newGutter
+    return newGutter
+
+  getGutters: ->
+    @gutters.slice()
+
+  gutterWithName: (name) ->
+    for gutter in @gutters
+      if gutter.name == name then return gutter
+    null
+
+  ###
+  Section: Event Subscription
+  ###
+
+  # @param callback: function( nameOfRemovedGutter )
+  onDidRemoveGutter: (callback) ->
+    @emitter.on 'did-remove-gutter', callback
+
+  ###
+  Section: Private Methods
+  ###
+
+  # Processes the destruction of the gutter. Throws an error if this gutter is
+  # not within this gutterContainer.
+  removeGutter: (gutter) ->
+    index = @gutters.indexOf gutter
+    if index > -1
+      @gutters.splice(index, 1)
+      @unsubscribe gutter
+      @emitter.emit 'did-remove-gutter', gutter.name
+    else
+      throw new Error 'The given gutter cannot be removed because it is not ' +
+          'within this GutterContainer.'

--- a/src/gutter-container.coffee
+++ b/src/gutter-container.coffee
@@ -7,8 +7,11 @@ Gutter = require './gutter'
 module.exports =
 class GutterContainer
   Subscriber.includeInto(this)
-  constructor: ->
+
+  # * `textEditor` The {TextEditor} to which this {GutterContainer} belongs.
+  constructor: (textEditor) ->
     @gutters = []
+    @textEditor = textEditor
     @emitter = new Emitter
 
   destroy: ->
@@ -76,3 +79,12 @@ class GutterContainer
     else
       throw new Error 'The given gutter cannot be removed because it is not ' +
           'within this GutterContainer.'
+
+  # The public interface is Gutter::decorateMarker or TextEditor::decorateMarker.
+  addGutterDecoration: (gutter, marker, options) ->
+    if gutter.name is 'line-number'
+      options.type = 'line-number'
+    else
+      options.type = 'gutter'
+    options.gutterName = gutter.name
+    @textEditor.decorateMarker marker, options

--- a/src/gutter-container.coffee
+++ b/src/gutter-container.coffee
@@ -46,6 +46,7 @@ class GutterContainer
         break
     if !inserted
       @gutters.push newGutter
+    @emitter.emit 'did-add-gutter', newGutter
     return newGutter
 
   getGutters: ->
@@ -60,7 +61,16 @@ class GutterContainer
   Section: Event Subscription
   ###
 
-  # @param callback: function( nameOfRemovedGutter )
+  # See {TextEditor::observeGutters} for details.
+  observeGutters: (callback) ->
+    callback(gutter) for gutter in @getGutters()
+    @onDidAddGutter callback
+
+  # See {TextEditor::onDidAddGutter} for details.
+  onDidAddGutter: (callback) ->
+    @emitter.on 'did-add-gutter', callback
+
+  # See {TextEditor::onDidRemoveGutter} for details.
   onDidRemoveGutter: (callback) ->
     @emitter.on 'did-remove-gutter', callback
 

--- a/src/gutter.coffee
+++ b/src/gutter.coffee
@@ -49,7 +49,7 @@ class Gutter
   #   * `item` (optional) A model {Object} with a corresponding view registered,
   #     or an {HTMLElement}.
   decorateMarker: (marker, options) ->
-    @gutterContainer.addGutterDecoration this, marker, options
+    @gutterContainer.addGutterDecoration(this, marker, options)
 
   # Calls your `callback` when the {Gutter}'s' visibility changes.
   #

--- a/src/gutter.coffee
+++ b/src/gutter.coffee
@@ -1,0 +1,58 @@
+{Emitter} = require 'event-kit'
+
+# Public: This class represents a gutter within a TextEditor.
+
+DefaultPriority = -100
+
+module.exports =
+class Gutter
+  # * `gutterContainer` The {GutterContainer} object to which this gutter belongs.
+  # * `options` An {Object} with the following fields:
+  #   * `name` (required) A unique {String} to identify this gutter.
+  #   * `priority` (optional) A {Number} that determines stacking order between
+  #       gutters. Lower priority items are forced closer to the edges of the
+  #       window. (default: -100)
+  #   * `visible` (optional) {Boolean} specifying whether the gutter is visible
+  #       initially after being created. (default: true)
+  constructor: (gutterContainer, options) ->
+    @gutterContainer = gutterContainer
+    @name = options?.name
+    @priority = options?.priority ? DefaultPriority
+    @visible = options?.visible ? true
+
+    @emitter = new Emitter
+
+  destroy: ->
+    @gutterContainer.removeGutter(this)
+    @emitter.emit 'did-destroy'
+    @emitter.dispose()
+
+  hide: ->
+    if @visible
+      @visible = false
+      @emitter.emit 'did-change-visible', this
+
+  show: ->
+    if not @visible
+      @visible = true
+      @emitter.emit 'did-change-visible', this
+
+  isVisible: ->
+    @visible
+
+  # Calls your `callback` when the {Gutter}'s' visibility changes.
+  #
+  # * `callback` {Function}
+  #  * `gutter` The {Gutter} whose visibility changed.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidChangeVisible: (callback) ->
+    @emitter.on 'did-change-visible', callback
+
+  # Calls your `callback` when the {Gutter} is destroyed
+  #
+  # * `callback` {Function}
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidDestroy: (callback) ->
+    @emitter.on 'did-destroy', callback

--- a/src/gutter.coffee
+++ b/src/gutter.coffee
@@ -43,6 +43,14 @@ class Gutter
   isVisible: ->
     @visible
 
+  # * `marker` (required) A Marker object.
+  # * `options` (optional) An object with the following fields:
+  #   * `class` (optional)
+  #   * `item` (optional) A model {Object} with a corresponding view registered,
+  #     or an {HTMLElement}.
+  decorateMarker: (marker, options) ->
+    @gutterContainer.addGutterDecoration this, marker, options
+
   # Calls your `callback` when the {Gutter}'s' visibility changes.
   #
   # * `callback` {Function}

--- a/src/gutter.coffee
+++ b/src/gutter.coffee
@@ -23,9 +23,12 @@ class Gutter
     @emitter = new Emitter
 
   destroy: ->
-    @gutterContainer.removeGutter(this)
-    @emitter.emit 'did-destroy'
-    @emitter.dispose()
+    if @name is 'line-number'
+      throw new Error('The line-number gutter cannot be destroyed.')
+    else
+      @gutterContainer.removeGutter(this)
+      @emitter.emit 'did-destroy'
+      @emitter.dispose()
 
   hide: ->
     if @visible

--- a/src/highlights-component.coffee
+++ b/src/highlights-component.coffee
@@ -17,6 +17,9 @@ class HighlightsComponent
       insertionPoint.setAttribute('select', '.underlayer')
       @domNode.appendChild(insertionPoint)
 
+  getDomNode: ->
+    @domNode
+
   updateSync: (state) ->
     newState = state.content.highlights
     @oldState ?= {}

--- a/src/input-component.coffee
+++ b/src/input-component.coffee
@@ -7,6 +7,9 @@ class InputComponent
     @domNode.style['-webkit-transform'] = 'translateZ(0)'
     @domNode.addEventListener 'paste', (event) -> event.preventDefault()
 
+  getDomNode: ->
+    @domNode
+
   updateSync: (state) ->
     @oldState ?= {}
     newState = state.hiddenInput

--- a/src/line-number-gutter-component.coffee
+++ b/src/line-number-gutter-component.coffee
@@ -6,7 +6,7 @@ module.exports =
 class LineNumberGutterComponent
   dummyLineNumberNode: null
 
-  constructor: ({@onMouseDown, @editor}) ->
+  constructor: ({@onMouseDown, @editor, @name}) ->
     @lineNumberNodesById = {}
 
     @domNode = document.createElement('div')
@@ -17,6 +17,9 @@ class LineNumberGutterComponent
 
     @domNode.addEventListener 'click', @onClick
     @domNode.addEventListener 'mousedown', @onMouseDown
+
+  getName: ->
+    @name
 
   updateSync: (state) ->
     @newState = state.lineNumberGutter

--- a/src/line-number-gutter-component.coffee
+++ b/src/line-number-gutter-component.coffee
@@ -39,7 +39,8 @@ class LineNumberGutterComponent
 
     @appendDummyLineNumber() unless @dummyLineNumberNode?
 
-    setDimensionsAndBackground(@oldState, @newState, @lineNumbersNode)
+    newDimensionsAndBackgroundState = state.gutters
+    setDimensionsAndBackground(@oldState, newDimensionsAndBackgroundState, @lineNumbersNode)
 
     if @newState.maxLineNumberDigits isnt @oldState.maxLineNumberDigits
       @updateDummyLineNumber()

--- a/src/line-number-gutter-component.coffee
+++ b/src/line-number-gutter-component.coffee
@@ -9,6 +9,7 @@ class LineNumberGutterComponent
 
   constructor: ({@onMouseDown, @editor, @gutter}) ->
     @lineNumberNodesById = {}
+    @visible = true
 
     @domNode = atom.views.getView(@gutter)
     @lineNumbersNode = @domNode.firstChild
@@ -21,6 +22,16 @@ class LineNumberGutterComponent
 
   getName: ->
     @gutter.name
+
+  hideNode: ->
+    if @visible
+      @domNode.style.display = 'none'
+      @visible = false
+
+  showNode: ->
+    if !@visible
+      @domNode.style.removeProperty('display')
+      @visible = true
 
   updateSync: (state) ->
     @newState = state.lineNumberGutter

--- a/src/line-number-gutter-component.coffee
+++ b/src/line-number-gutter-component.coffee
@@ -29,7 +29,7 @@ class LineNumberGutterComponent
       @visible = false
 
   showNode: ->
-    if !@visible
+    if not @visible
       @domNode.style.removeProperty('display')
       @visible = true
 

--- a/src/line-number-gutter-component.coffee
+++ b/src/line-number-gutter-component.coffee
@@ -20,9 +20,6 @@ class LineNumberGutterComponent
   getDomNode: ->
     @domNode
 
-  getName: ->
-    @gutter.name
-
   hideNode: ->
     if @visible
       @domNode.style.display = 'none'

--- a/src/line-number-gutter-component.coffee
+++ b/src/line-number-gutter-component.coffee
@@ -7,14 +7,11 @@ module.exports =
 class LineNumberGutterComponent
   dummyLineNumberNode: null
 
-  constructor: ({@onMouseDown, @editor, @name}) ->
+  constructor: ({@onMouseDown, @editor, @gutter}) ->
     @lineNumberNodesById = {}
 
-    @domNode = document.createElement('div')
-    @domNode.classList.add('gutter')
-    @lineNumbersNode = document.createElement('div')
-    @lineNumbersNode.classList.add('line-numbers')
-    @domNode.appendChild(@lineNumbersNode)
+    @domNode = atom.views.getView(@gutter)
+    @lineNumbersNode = @domNode.firstChild
 
     @domNode.addEventListener 'click', @onClick
     @domNode.addEventListener 'mousedown', @onMouseDown
@@ -23,7 +20,7 @@ class LineNumberGutterComponent
     @domNode
 
   getName: ->
-    @name
+    @gutter.name
 
   updateSync: (state) ->
     @newState = state.lineNumberGutter

--- a/src/line-number-gutter-component.coffee
+++ b/src/line-number-gutter-component.coffee
@@ -3,7 +3,7 @@ _ = require 'underscore-plus'
 WrapperDiv = document.createElement('div')
 
 module.exports =
-class GutterComponent
+class LineNumberGutterComponent
   dummyLineNumberNode: null
 
   constructor: ({@onMouseDown, @editor}) ->

--- a/src/line-number-gutter-component.coffee
+++ b/src/line-number-gutter-component.coffee
@@ -1,4 +1,5 @@
 _ = require 'underscore-plus'
+{setDimensionsAndBackground} = require './gutter-component-helpers'
 
 WrapperDiv = document.createElement('div')
 
@@ -30,17 +31,7 @@ class LineNumberGutterComponent
 
     @appendDummyLineNumber() unless @dummyLineNumberNode?
 
-    if @newState.scrollHeight isnt @oldState.scrollHeight
-      @lineNumbersNode.style.height = @newState.scrollHeight + 'px'
-      @oldState.scrollHeight = @newState.scrollHeight
-
-    if @newState.scrollTop isnt @oldState.scrollTop
-      @lineNumbersNode.style['-webkit-transform'] = "translate3d(0px, #{-@newState.scrollTop}px, 0px)"
-      @oldState.scrollTop = @newState.scrollTop
-
-    if @newState.backgroundColor isnt @oldState.backgroundColor
-      @lineNumbersNode.style.backgroundColor = @newState.backgroundColor
-      @oldState.backgroundColor = @newState.backgroundColor
+    setDimensionsAndBackground(@oldState, @newState, @lineNumbersNode)
 
     if @newState.maxLineNumberDigits isnt @oldState.maxLineNumberDigits
       @updateDummyLineNumber()

--- a/src/line-number-gutter-component.coffee
+++ b/src/line-number-gutter-component.coffee
@@ -18,6 +18,9 @@ class LineNumberGutterComponent
     @domNode.addEventListener 'click', @onClick
     @domNode.addEventListener 'mousedown', @onMouseDown
 
+  getDomNode: ->
+    @domNode
+
   getName: ->
     @name
 
@@ -46,6 +49,10 @@ class LineNumberGutterComponent
       @lineNumberNodesById = {}
 
     @updateLineNumbers()
+
+  ###
+  Section: Private Methods
+  ###
 
   # This dummy line number element holds the gutter to the appropriate width,
   # since the real line numbers are absolutely positioned for performance reasons.

--- a/src/line-number-gutter-component.coffee
+++ b/src/line-number-gutter-component.coffee
@@ -34,7 +34,7 @@ class LineNumberGutterComponent
       @visible = true
 
   updateSync: (state) ->
-    @newState = state.lineNumberGutter
+    @newState = state.gutters.lineNumberGutter
     @oldState ?= {lineNumbers: {}}
 
     @appendDummyLineNumber() unless @dummyLineNumberNode?

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -29,15 +29,18 @@ class LinesComponent
     @domNode.classList.add('lines')
 
     @cursorsComponent = new CursorsComponent(@presenter)
-    @domNode.appendChild(@cursorsComponent.domNode)
+    @domNode.appendChild(@cursorsComponent.getDomNode())
 
     @highlightsComponent = new HighlightsComponent(@presenter)
-    @domNode.appendChild(@highlightsComponent.domNode)
+    @domNode.appendChild(@highlightsComponent.getDomNode())
 
     if @useShadowDOM
       insertionPoint = document.createElement('content')
       insertionPoint.setAttribute('select', '.overlayer')
       @domNode.appendChild(insertionPoint)
+
+  getDomNode: ->
+    @domNode
 
   updateSync: (state) ->
     @newState = state.content

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -2,6 +2,8 @@
 Grim = require 'grim'
 {Emitter, CompositeDisposable} = require 'event-kit'
 Serializable = require 'serializable'
+{createGutterView} = require './gutter-component-helpers'
+Gutter = require './gutter'
 Model = require './model'
 Pane = require './pane'
 PaneElement = require './pane-element'
@@ -60,6 +62,7 @@ class PaneContainer extends Model
       new PaneElement().initialize(model)
     atom.views.addViewProvider TextEditor, (model) ->
       new TextEditorElement().initialize(model)
+    atom.views.addViewProvider(Gutter, createGutterView)
 
   onDidChangeRoot: (fn) ->
     @emitter.on 'did-change-root', fn

--- a/src/scrollbar-component.coffee
+++ b/src/scrollbar-component.coffee
@@ -12,6 +12,9 @@ class ScrollbarComponent
 
     @domNode.addEventListener 'scroll', @onScrollCallback
 
+  getDomNode: ->
+    @domNode
+
   updateSync: (state) ->
     @oldState ?= {}
     switch @orientation

--- a/src/scrollbar-corner-component.coffee
+++ b/src/scrollbar-corner-component.coffee
@@ -7,6 +7,9 @@ class ScrollbarCornerComponent
     @contentNode = document.createElement('div')
     @domNode.appendChild(@contentNode)
 
+  getDomNode: ->
+    @domNode
+
   updateSync: (state) ->
     @oldState ?= {}
     @newState ?= {}

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -73,19 +73,19 @@ class TextEditorComponent
     @mountGutterContainerComponent() if @presenter.getState().gutters.sortedDescriptions.length
 
     @hiddenInputComponent = new InputComponent
-    @scrollViewNode.appendChild(@hiddenInputComponent.domNode)
+    @scrollViewNode.appendChild(@hiddenInputComponent.getDomNode())
 
     @linesComponent = new LinesComponent({@presenter, @hostElement, @useShadowDOM})
-    @scrollViewNode.appendChild(@linesComponent.domNode)
+    @scrollViewNode.appendChild(@linesComponent.getDomNode())
 
     @horizontalScrollbarComponent = new ScrollbarComponent({orientation: 'horizontal', onScroll: @onHorizontalScroll})
-    @scrollViewNode.appendChild(@horizontalScrollbarComponent.domNode)
+    @scrollViewNode.appendChild(@horizontalScrollbarComponent.getDomNode())
 
     @verticalScrollbarComponent = new ScrollbarComponent({orientation: 'vertical', onScroll: @onVerticalScroll})
-    @domNode.appendChild(@verticalScrollbarComponent.domNode)
+    @domNode.appendChild(@verticalScrollbarComponent.getDomNode())
 
     @scrollbarCornerComponent = new ScrollbarCornerComponent
-    @domNode.appendChild(@scrollbarCornerComponent.domNode)
+    @domNode.appendChild(@scrollbarCornerComponent.getDomNode())
 
     @observeEditor()
     @listenForDOMEvents()
@@ -107,6 +107,9 @@ class TextEditorComponent
     @disposables.dispose()
     @presenter.destroy()
     window.removeEventListener 'resize', @requestHeightAndWidthMeasurement
+
+  getDomNode: ->
+    @domNode
 
   updateSync: ->
     @oldState ?= {}
@@ -138,7 +141,7 @@ class TextEditorComponent
       @mountGutterContainerComponent() unless @gutterContainerComponent?
       @gutterContainerComponent.updateSync(@newState)
     else
-      @gutterContainerComponent?.domNode?.remove()
+      @gutterContainerComponent?.getDomNode()?.remove()
       @gutterContainerComponent = null
 
     @hiddenInputComponent.updateSync(@newState)
@@ -163,7 +166,7 @@ class TextEditorComponent
 
   mountGutterContainerComponent: ->
     @gutterContainerComponent = new GutterContainerComponent({@editor, @onLineNumberGutterMouseDown})
-    @domNode.insertBefore(@gutterContainerComponent.domNode, @domNode.firstChild)
+    @domNode.insertBefore(@gutterContainerComponent.getDomNode(), @domNode.firstChild)
 
   becameVisible: ->
     @updatesPaused = true
@@ -282,7 +285,7 @@ class TextEditorComponent
   focused: ->
     if @mounted
       @presenter.setFocused(true)
-      @hiddenInputComponent.domNode.focus()
+      @hiddenInputComponent.getDomNode().focus()
 
   blurred: ->
     if @mounted
@@ -646,7 +649,7 @@ class TextEditorComponent
 
     lineNumberGutter = @gutterContainerComponent?.getLineNumberGutterComponent()
     if lineNumberGutter
-      gutterBackgroundColor = getComputedStyle(lineNumberGutter.domNode).backgroundColor
+      gutterBackgroundColor = getComputedStyle(lineNumberGutter.getDomNode()).backgroundColor
       @presenter.setGutterBackgroundColor(gutterBackgroundColor)
 
   measureLineHeightAndDefaultCharWidth: ->
@@ -666,7 +669,7 @@ class TextEditorComponent
   measureScrollbars: ->
     @measureScrollbarsWhenShown = false
 
-    cornerNode = @scrollbarCornerComponent.domNode
+    cornerNode = @scrollbarCornerComponent.getDomNode()
     originalDisplayValue = cornerNode.style.display
 
     cornerNode.style.display = 'block'
@@ -692,9 +695,9 @@ class TextEditorComponent
       @measureScrollbarsWhenShown = true
       return
 
-    verticalNode = @verticalScrollbarComponent.domNode
-    horizontalNode = @horizontalScrollbarComponent.domNode
-    cornerNode = @scrollbarCornerComponent.domNode
+    verticalNode = @verticalScrollbarComponent.getDomNode()
+    horizontalNode = @horizontalScrollbarComponent.getDomNode()
+    cornerNode = @scrollbarCornerComponent.getDomNode()
 
     originalVerticalDisplayValue = verticalNode.style.display
     originalHorizontalDisplayValue = horizontalNode.style.display
@@ -764,7 +767,7 @@ class TextEditorComponent
   pixelPositionForMouseEvent: (event) ->
     {clientX, clientY} = event
 
-    linesClientRect = @linesComponent.domNode.getBoundingClientRect()
+    linesClientRect = @linesComponent.getDomNode().getBoundingClientRect()
     top = clientY - linesClientRect.top
     left = clientX - linesClientRect.left
     {top, left}

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -6,7 +6,7 @@ grim = require 'grim'
 ipc = require 'ipc'
 
 TextEditorPresenter = require './text-editor-presenter'
-GutterComponent = require './gutter-component'
+LineNumberGutterComponent = require './line-number-gutter-component'
 InputComponent = require './input-component'
 LinesComponent = require './lines-component'
 ScrollbarComponent = require './scrollbar-component'
@@ -162,7 +162,7 @@ class TextEditorComponent
     @overlayManager?.measureOverlays()
 
   mountGutterComponent: ->
-    @gutterComponent = new GutterComponent({@editor, onMouseDown: @onGutterMouseDown})
+    @gutterComponent = new LineNumberGutterComponent({@editor, onMouseDown: @onGutterMouseDown})
     @domNode.insertBefore(@gutterComponent.domNode, @domNode.firstChild)
 
   becameVisible: ->

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -70,7 +70,7 @@ class TextEditorComponent
     @scrollViewNode.classList.add('scroll-view')
     @domNode.appendChild(@scrollViewNode)
 
-    @mountGutterContainerComponent() if @presenter.getState().gutters.sortedDescriptions.length
+    @mountGutterContainerComponent() if @presenter.getState().gutters.sortedModels.length
 
     @hiddenInputComponent = new InputComponent
     @scrollViewNode.appendChild(@hiddenInputComponent.domNode)
@@ -134,7 +134,7 @@ class TextEditorComponent
         else
           @domNode.style.height = ''
 
-    if @newState.gutters.sortedDescriptions.length
+    if @newState.gutters.sortedModels.length
       @mountGutterContainerComponent() unless @gutterContainerComponent?
       @gutterContainerComponent.updateSync(@newState)
     else

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -70,7 +70,7 @@ class TextEditorComponent
     @scrollViewNode.classList.add('scroll-view')
     @domNode.appendChild(@scrollViewNode)
 
-    @mountGutterContainerComponent() if @presenter.getState().gutters.sortedModels.length
+    @mountGutterContainerComponent() if @presenter.getState().gutters.sortedDescriptions.length
 
     @hiddenInputComponent = new InputComponent
     @scrollViewNode.appendChild(@hiddenInputComponent.domNode)
@@ -134,7 +134,7 @@ class TextEditorComponent
         else
           @domNode.style.height = ''
 
-    if @newState.gutters.sortedModels.length
+    if @newState.gutters.sortedDescriptions.length
       @mountGutterContainerComponent() unless @gutterContainerComponent?
       @gutterContainerComponent.updateSync(@newState)
     else

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -70,7 +70,7 @@ class TextEditorComponent
     @scrollViewNode.classList.add('scroll-view')
     @domNode.appendChild(@scrollViewNode)
 
-    @mountGutterComponent() if @presenter.getState().gutter.visible
+    @mountGutterComponent() if @presenter.getState().lineNumberGutter.visible
 
     @hiddenInputComponent = new InputComponent
     @scrollViewNode.appendChild(@hiddenInputComponent.domNode)
@@ -134,7 +134,7 @@ class TextEditorComponent
         else
           @domNode.style.height = ''
 
-    if @newState.gutter.visible
+    if @newState.lineNumberGutter.visible
       @mountGutterComponent() unless @gutterComponent?
       @gutterComponent.updateSync(@newState)
     else

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -113,12 +113,12 @@ class TextEditorElement extends HTMLElement
       lineOverdrawMargin: @lineOverdrawMargin
       useShadowDOM: @useShadowDOM
     )
-    @rootElement.appendChild(@component.domNode)
+    @rootElement.appendChild(@component.getDomNode())
 
     if @useShadowDOM
       @shadowRoot.addEventListener('blur', @shadowRootBlurred.bind(this), true)
     else
-      inputNode = @component.hiddenInputComponent.domNode
+      inputNode = @component.hiddenInputComponent.getDomNode()
       inputNode.addEventListener 'focus', @focused.bind(this)
       inputNode.addEventListener 'blur', => @dispatchEvent(new FocusEvent('blur', bubbles: false))
 
@@ -126,7 +126,7 @@ class TextEditorElement extends HTMLElement
     callRemoveHooks(this)
     if @component?
       @component.destroy()
-      @component.domNode.remove()
+      @component.getDomNode().remove()
       @component = null
 
   focused: ->
@@ -134,7 +134,7 @@ class TextEditorElement extends HTMLElement
 
   blurred: (event) ->
     unless @useShadowDOM
-      if event.relatedTarget is @component.hiddenInputComponent.domNode
+      if event.relatedTarget is @component.hiddenInputComponent.getDomNode()
         event.stopImmediatePropagation()
         return
 

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -100,7 +100,7 @@ class TextEditorElement extends HTMLElement
       tabLength: 2
       softTabs: true
       mini: @hasAttribute('mini')
-      gutterVisible: not @hasAttribute('gutter-hidden')
+      lineNumberGutterVisible: not @hasAttribute('gutter-hidden')
       placeholderText: @getAttribute('placeholder-text')
     ))
 

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -654,8 +654,8 @@ class TextEditorPresenter
     return decorations if @model.isMini() or gutterName is 'line-number' or
       not @customGutterDecorationsByGutterNameAndScreenRow[gutterName]
 
-    for bufferRow in @model.bufferRowsForScreenRows(@startRow, @endRow - 1)
-      for id, decoration of @customGutterDecorationsByGutterNameAndScreenRow[gutterName][bufferRow]
+    for screenRow in [@startRow..@endRow - 1]
+      for id, decoration of @customGutterDecorationsByGutterNameAndScreenRow[gutterName][screenRow]
         decorations.add(decoration)
     decorations
 

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -434,7 +434,7 @@ class TextEditorPresenter
       for gutter in @model.getGutters()
         gutterName = gutter.name
         @state.gutters.customDecorations[gutterName] = {}
-        return if !@gutterIsVisible(gutter)
+        return if not @gutterIsVisible(gutter)
 
         relevantDecorations = @customGutterDecorationsInRange(gutterName, @startRow, @endRow - 1)
         relevantDecorations.forEach (decoration) =>
@@ -448,7 +448,7 @@ class TextEditorPresenter
   gutterIsVisible: (gutterModel) ->
     isVisible = gutterModel.isVisible()
     if gutterModel.name is 'line-number'
-      isVisible = isVisible && @showLineNumbers
+      isVisible = isVisible and @showLineNumbers
     isVisible
 
   updateLineNumbersState: -> @batch "shouldUpdateLineNumbersState", ->
@@ -649,7 +649,7 @@ class TextEditorPresenter
     decorations = new Set
 
     return decorations if @model.isMini() or gutterName is 'line-number' or
-      !@customGutterDecorationsByGutterNameAndScreenRow[gutterName]
+      not @customGutterDecorationsByGutterNameAndScreenRow[gutterName]
 
     for bufferRow in @model.bufferRowsForScreenRows(@startRow, @endRow - 1)
       for id, decoration of @customGutterDecorationsByGutterNameAndScreenRow[gutterName][bufferRow]
@@ -995,8 +995,8 @@ class TextEditorPresenter
         @updateLinesState()
       if decoration.isType('line-number') or Decoration.isType(oldProperties, 'line-number')
         @updateLineNumbersState()
-      if (decoration.isType('gutter') and !decoration.isType('line-number')) or
-      (Decoration.isType(oldProperties, 'gutter') and !Decoration.isType(oldProperties, 'line-number'))
+      if (decoration.isType('gutter') and not decoration.isType('line-number')) or
+      (Decoration.isType(oldProperties, 'gutter') and not Decoration.isType(oldProperties, 'line-number'))
         @updateCustomGutterDecorationState()
     else if decoration.isType('overlay')
       @updateOverlaysState()

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -87,7 +87,7 @@ class TextEditorPresenter
     @updateLinesState() if @shouldUpdateLinesState
     @updateCursorsState() if @shouldUpdateCursorsState
     @updateOverlaysState() if @shouldUpdateOverlaysState
-    @updateGutterState() if @shouldUpdateGutterState
+    @updateLineNumberGutterState() if @shouldUpdateLineNumberGutterState
     @updateLineNumbersState() if @shouldUpdateLineNumbersState
 
     @updating = false
@@ -105,7 +105,7 @@ class TextEditorPresenter
       @updateContentState()
       @updateDecorations()
       @updateLinesState()
-      @updateGutterState()
+      @updateLineNumberGutterState()
       @updateLineNumbersState()
     @disposables.add @model.onDidChangeGrammar(@didChangeGrammar.bind(this))
     @disposables.add @model.onDidChangePlaceholderText(@updateContentState.bind(this))
@@ -115,10 +115,10 @@ class TextEditorPresenter
       @updateContentState()
       @updateDecorations()
       @updateLinesState()
-      @updateGutterState()
+      @updateLineNumberGutterState()
       @updateLineNumbersState()
     @disposables.add @model.onDidChangeLineNumberGutterVisible =>
-      @updateGutterState()
+      @updateLineNumberGutterState()
     @disposables.add @model.onDidAddDecoration(@didAddDecoration.bind(this))
     @disposables.add @model.onDidAddCursor(@didAddCursor.bind(this))
     @disposables.add @model.onDidChangeScrollTop(@setScrollTop.bind(this))
@@ -151,12 +151,12 @@ class TextEditorPresenter
       @updateScrollbarsState()
     @configDisposables.add atom.config.onDidChange 'editor.showLineNumbers', configParams, ({newValue}) =>
       @showLineNumbers = newValue
-      @updateGutterState()
+      @updateLineNumberGutterState()
 
   didChangeGrammar: ->
     @observeConfig()
     @updateContentState()
-    @updateGutterState()
+    @updateLineNumberGutterState()
 
   buildState: ->
     @state =
@@ -190,7 +190,7 @@ class TextEditorPresenter
     @updateLinesState()
     @updateCursorsState()
     @updateOverlaysState()
-    @updateGutterState()
+    @updateLineNumberGutterState()
     @updateLineNumbersState()
 
   updateFocusedState: -> @batch "shouldUpdateFocusedState", ->
@@ -363,7 +363,7 @@ class TextEditorPresenter
 
     return
 
-  updateGutterState: -> @batch "shouldUpdateGutterState", ->
+  updateLineNumberGutterState: -> @batch "shouldUpdateLineNumberGutterState", ->
     @state.gutter.visible = not @model.isMini() and (@model.isLineNumberGutterVisible() ? true) and @showLineNumbers
     @state.gutter.maxLineNumberDigits = @model.getLineCount().toString().length
     @state.gutter.backgroundColor = if @gutterBackgroundColor isnt "rgba(0, 0, 0, 0)"
@@ -708,12 +708,12 @@ class TextEditorPresenter
     unless @backgroundColor is backgroundColor
       @backgroundColor = backgroundColor
       @updateContentState()
-      @updateGutterState()
+      @updateLineNumberGutterState()
 
   setGutterBackgroundColor: (gutterBackgroundColor) ->
     unless @gutterBackgroundColor is gutterBackgroundColor
       @gutterBackgroundColor = gutterBackgroundColor
-      @updateGutterState()
+      @updateLineNumberGutterState()
 
   setLineHeight: (lineHeight) ->
     unless @lineHeight is lineHeight

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -392,6 +392,7 @@ class TextEditorPresenter
     gutterDisposables = new CompositeDisposable
     gutterDisposables.add gutter.onDidChangeVisible =>
       @updateCustomGutterState()
+      @updateCustomGutterDecorationState()
     gutterDisposables.add gutter.onDidDestroy =>
       @disposables.remove(gutterDisposables)
       gutterDisposables.dispose()
@@ -409,9 +410,7 @@ class TextEditorPresenter
       if @model.isMini()
         return
       for gutter in @model.getGutters()
-        isVisible = gutter.isVisible()
-        if gutter.name is 'line-number'
-          isVisible = isVisible && @showLineNumbers
+        isVisible = @gutterIsVisible(gutter)
         @state.gutters.sortedDescriptions.push({gutter, visible: isVisible})
 
   # Updates the decoration state for the gutter with the given gutterName.
@@ -434,6 +433,8 @@ class TextEditorPresenter
         @state.gutters.customDecorations[gutterName] = {}
         gutterState = @state.gutters.customDecorations[gutterName]
 
+        return if !@gutterIsVisible(gutter)
+
         relevantDecorations = @customGutterDecorationsInRange(gutterName, @startRow, @endRow - 1)
         return if !relevantDecorations
 
@@ -444,6 +445,12 @@ class TextEditorPresenter
             height: @lineHeight * decorationRange.getRowCount()
             item: decoration.getProperties().item
             class: decoration.getProperties().class
+
+  gutterIsVisible: (gutterModel) ->
+    isVisible = gutterModel.isVisible()
+    if gutterModel.name is 'line-number'
+      isVisible = isVisible && @showLineNumbers
+    isVisible
 
   updateLineNumbersState: -> @batch "shouldUpdateLineNumbersState", ->
     return unless @startRow? and @endRow? and @lineHeight?

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -401,6 +401,9 @@ class TextEditorPresenter
       @disposables.remove(gutterDisposables)
       gutterDisposables.dispose()
       @updateCustomGutterState()
+      # It is not necessary to @updateCustomGutterDecorationState here.
+      # The destroyed gutter will be removed from the list of gutters in @state,
+      # and thus will be removed from the DOM.
     @disposables.add(gutterDisposables)
     @updateCustomGutterState()
     @updateCustomGutterDecorationState()

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -182,7 +182,7 @@ class TextEditorPresenter
       lineNumberGutter:
         lineNumbers: {}
       gutters:
-        sortedModels: []
+        sortedDescriptions: []
         customDecorations: {}
     @updateState()
 
@@ -405,15 +405,14 @@ class TextEditorPresenter
       # For now, just match the background color of the line-number gutter.
       # TODO: Allow gutters to have different background colors. (?)
       @state.gutters.backgroundColor = @getGutterBackgroundColor()
-      @state.gutters.sortedModels = []
+      @state.gutters.sortedDescriptions = []
       if @model.isMini()
         return
       for gutter in @model.getGutters()
         isVisible = gutter.isVisible()
         if gutter.name is 'line-number'
           isVisible = isVisible && @showLineNumbers
-        if isVisible
-          @state.gutters.sortedModels.push(gutter)
+        @state.gutters.sortedDescriptions.push({gutter, visible: isVisible})
 
   # Updates the decoration state for the gutter with the given gutterName.
   # @state.gutters.customDecorations is an {Object}, with the form:

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -121,10 +121,12 @@ class TextEditorPresenter
       @updateLinesState()
       @updateLineNumberGutterState()
       @updateLineNumbersState()
+      @updateCommonGutterState()
       @updateCustomGutterState()
       @updateCustomGutterDecorationState()
     @disposables.add @model.onDidChangeLineNumberGutterVisible =>
       @updateLineNumberGutterState()
+      @updateCommonGutterState()
       @updateCustomGutterState()
     @disposables.add @model.onDidAddDecoration(@didAddDecoration.bind(this))
     @disposables.add @model.onDidAddCursor(@didAddCursor.bind(this))
@@ -160,12 +162,14 @@ class TextEditorPresenter
     @configDisposables.add atom.config.onDidChange 'editor.showLineNumbers', configParams, ({newValue}) =>
       @showLineNumbers = newValue
       @updateLineNumberGutterState()
+      @updateCommonGutterState()
       @updateCustomGutterState()
 
   didChangeGrammar: ->
     @observeConfig()
     @updateContentState()
     @updateLineNumberGutterState()
+    @updateCommonGutterState()
     @updateCustomGutterState()
 
   buildState: ->
@@ -205,6 +209,7 @@ class TextEditorPresenter
     @updateOverlaysState()
     @updateLineNumberGutterState()
     @updateLineNumbersState()
+    @updateCommonGutterState()
     @updateCustomGutterState()
     @updateCustomGutterDecorationState()
 
@@ -219,11 +224,11 @@ class TextEditorPresenter
 
   updateVerticalScrollState: -> @batch "shouldUpdateVerticalScrollState", ->
     @state.content.scrollHeight = @scrollHeight
-    @state.lineNumberGutter.scrollHeight = @scrollHeight
+    @state.gutters.scrollHeight = @scrollHeight
     @state.verticalScrollbar.scrollHeight = @scrollHeight
 
     @state.content.scrollTop = @scrollTop
-    @state.lineNumberGutter.scrollTop = @scrollTop
+    @state.gutters.scrollTop = @scrollTop
     @state.verticalScrollbar.scrollTop = @scrollTop
 
   updateHorizontalScrollState: -> @batch "shouldUpdateHorizontalScrollState", ->
@@ -380,13 +385,12 @@ class TextEditorPresenter
 
   updateLineNumberGutterState: -> @batch "shouldUpdateLineNumberGutterState", ->
     @state.lineNumberGutter.maxLineNumberDigits = @model.getLineCount().toString().length
-    @state.lineNumberGutter.backgroundColor = @getGutterBackgroundColor()
 
-  getGutterBackgroundColor: ->
-    if @gutterBackgroundColor isnt "rgba(0, 0, 0, 0)"
-      @gutterBackgroundColor
-    else
-      @backgroundColor
+  updateCommonGutterState: ->
+    @state.gutters.backgroundColor = if @gutterBackgroundColor isnt "rgba(0, 0, 0, 0)"
+        @gutterBackgroundColor
+      else
+        @backgroundColor
 
   didAddGutter: (gutter) ->
     gutterDisposables = new CompositeDisposable
@@ -403,9 +407,6 @@ class TextEditorPresenter
 
   updateCustomGutterState: ->
     @batch "shouldUpdateCustomGutterState", ->
-      # For now, just match the background color of the line-number gutter.
-      # TODO: Allow gutters to have different background colors. (?)
-      @state.gutters.backgroundColor = @getGutterBackgroundColor()
       @state.gutters.sortedDescriptions = []
       if @model.isMini()
         return
@@ -808,12 +809,14 @@ class TextEditorPresenter
       @backgroundColor = backgroundColor
       @updateContentState()
       @updateLineNumberGutterState()
+      @updateCommonGutterState()
       @updateCustomGutterState()
 
   setGutterBackgroundColor: (gutterBackgroundColor) ->
     unless @gutterBackgroundColor is gutterBackgroundColor
       @gutterBackgroundColor = gutterBackgroundColor
       @updateLineNumberGutterState()
+      @updateCommonGutterState()
       @updateCustomGutterState()
 
   setLineHeight: (lineHeight) ->

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -183,11 +183,11 @@ class TextEditorPresenter
         lines: {}
         highlights: {}
         overlays: {}
-      lineNumberGutter:
-        lineNumbers: {}
       gutters:
         sortedDescriptions: []
         customDecorations: {}
+        lineNumberGutter:
+          lineNumbers: {}
     @updateState()
 
   updateState: ->
@@ -384,7 +384,7 @@ class TextEditorPresenter
     return
 
   updateLineNumberGutterState: -> @batch "shouldUpdateLineNumberGutterState", ->
-    @state.lineNumberGutter.maxLineNumberDigits = @model.getLineCount().toString().length
+    @state.gutters.lineNumberGutter.maxLineNumberDigits = @model.getLineCount().toString().length
 
   updateCommonGutterState: ->
     @state.gutters.backgroundColor = if @gutterBackgroundColor isnt "rgba(0, 0, 0, 0)"
@@ -481,7 +481,7 @@ class TextEditorPresenter
         decorationClasses = @lineNumberDecorationClassesForRow(screenRow)
         foldable = @model.isFoldableAtScreenRow(screenRow)
 
-        @state.lineNumberGutter.lineNumbers[id] = {screenRow, bufferRow, softWrapped, top, decorationClasses, foldable}
+        @state.gutters.lineNumberGutter.lineNumbers[id] = {screenRow, bufferRow, softWrapped, top, decorationClasses, foldable}
         visibleLineNumberIds[id] = true
 
     if @mouseWheelScreenRow?
@@ -491,8 +491,8 @@ class TextEditorPresenter
       id += '-' + wrapCount if wrapCount > 0
       visibleLineNumberIds[id] = true
 
-    for id of @state.lineNumberGutter.lineNumbers
-      delete @state.lineNumberGutter.lineNumbers[id] unless visibleLineNumberIds[id]
+    for id of @state.gutters.lineNumberGutter.lineNumbers
+      delete @state.gutters.lineNumberGutter.lineNumbers[id] unless visibleLineNumberIds[id]
 
     return
 

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -989,7 +989,7 @@ class TextEditorPresenter
   decorationPropertiesDidChange: (decoration, event) ->
     {oldProperties} = event
     if decoration.isType('line') or decoration.isType('gutter')
-      @removeDecorationInfoFromLineDecorationCaches(
+      @removePropertiesFromLineDecorationCaches(
         decoration.id,
         oldProperties,
         decoration.getMarker().getScreenRange())
@@ -1066,9 +1066,9 @@ class TextEditorPresenter
     return
 
   removeFromLineDecorationCaches: (decoration, range) ->
-    @removeDecorationInfoFromLineDecorationCaches(decoration.id, decoration.getProperties(), range)
+    @removePropertiesFromLineDecorationCaches(decoration.id, decoration.getProperties(), range)
 
-  removeDecorationInfoFromLineDecorationCaches: (decorationId, decorationProperties, range) ->
+  removePropertiesFromLineDecorationCaches: (decorationId, decorationProperties, range) ->
     gutterName = decorationProperties.gutterName
     for row in [range.start.row..range.end.row] by 1
       delete @lineDecorationsByScreenRow[row]?[decorationId]

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -388,9 +388,9 @@ class TextEditorPresenter
 
   updateCommonGutterState: ->
     @state.gutters.backgroundColor = if @gutterBackgroundColor isnt "rgba(0, 0, 0, 0)"
-        @gutterBackgroundColor
-      else
-        @backgroundColor
+      @gutterBackgroundColor
+    else
+      @backgroundColor
 
   didAddGutter: (gutter) ->
     gutterDisposables = new CompositeDisposable

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -424,30 +424,26 @@ class TextEditorPresenter
   #       class (optional): {String} class
   #     }
   #   }
-  updateCustomGutterDecorationState: () ->
+  updateCustomGutterDecorationState: ->
     @batch 'shouldUpdateCustomGutterDecorationState', =>
       return unless @startRow? and @endRow? and @lineHeight?
 
+      @state.gutters.customDecorations = {}
       for gutter in @model.getGutters()
         gutterName = gutter.name
-        @state.gutters.customDecorations[gutterName] ?= {}
+        @state.gutters.customDecorations[gutterName] = {}
         gutterState = @state.gutters.customDecorations[gutterName]
-        visibleDecorationIds = {}
 
         relevantDecorations = @customGutterDecorationsInRange(gutterName, @startRow, @endRow - 1)
         return if !relevantDecorations
 
         relevantDecorations.forEach (decoration) =>
-          visibleDecorationIds[decoration.id] = true
           decorationRange = decoration.getMarker().getScreenRange()
           gutterState[decoration.id] =
             top: @lineHeight * decorationRange.start.row
             height: @lineHeight * decorationRange.getRowCount()
             item: decoration.getProperties().item
             class: decoration.getProperties().class
-
-        for decorationId of gutterState
-          delete gutterState[decorationId] unless visibleDecorationIds[decorationId]
 
   updateLineNumbersState: -> @batch "shouldUpdateLineNumbersState", ->
     return unless @startRow? and @endRow? and @lineHeight?

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -644,7 +644,6 @@ class TextEditorPresenter
       decorationClasses.push(decoration.getProperties().class)
     decorationClasses
 
-  # TODO (jssln) This needs tests.
   # Returns a {Set} of {Decoration}s on the given custom gutter from startRow to endRow (inclusive).
   customGutterDecorationsInRange: (gutterName, startRow, endRow) ->
     decorations = new Set

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -434,16 +434,12 @@ class TextEditorPresenter
       for gutter in @model.getGutters()
         gutterName = gutter.name
         @state.gutters.customDecorations[gutterName] = {}
-        gutterState = @state.gutters.customDecorations[gutterName]
-
         return if !@gutterIsVisible(gutter)
 
         relevantDecorations = @customGutterDecorationsInRange(gutterName, @startRow, @endRow - 1)
-        return if !relevantDecorations
-
         relevantDecorations.forEach (decoration) =>
           decorationRange = decoration.getMarker().getScreenRange()
-          gutterState[decoration.id] =
+          @state.gutters.customDecorations[gutterName][decoration.id] =
             top: @lineHeight * decorationRange.start.row
             height: @lineHeight * decorationRange.getRowCount()
             item: decoration.getProperties().item
@@ -651,10 +647,10 @@ class TextEditorPresenter
   # TODO (jssln) This needs tests.
   # Returns a {Set} of {Decoration}s on the given custom gutter from startRow to endRow (inclusive).
   customGutterDecorationsInRange: (gutterName, startRow, endRow) ->
-    return null if @model.isMini() or gutterName is 'line-number'
-
     decorations = new Set
-    return decorations if !@customGutterDecorationsByGutterNameAndScreenRow[gutterName]
+
+    return decorations if @model.isMini() or gutterName is 'line-number' or
+      !@customGutterDecorationsByGutterNameAndScreenRow[gutterName]
 
     for bufferRow in @model.bufferRowsForScreenRows(@startRow, @endRow - 1)
       for id, decoration of @customGutterDecorationsByGutterNameAndScreenRow[gutterName][bufferRow]

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -90,7 +90,7 @@ class TextEditorPresenter
     @updateOverlaysState() if @shouldUpdateOverlaysState
     @updateLineNumberGutterState() if @shouldUpdateLineNumberGutterState
     @updateLineNumbersState() if @shouldUpdateLineNumbersState
-    @updateCustomGutterState() if @shouldUpdateCustomGutterState
+    @updateGutterOrderState() if @shouldUpdateGutterOrderState
     @updateCustomGutterDecorationState() if @shouldUpdateCustomGutterDecorationState
     @updating = false
 
@@ -109,7 +109,7 @@ class TextEditorPresenter
       @updateLinesState()
       @updateLineNumberGutterState()
       @updateLineNumbersState()
-      @updateCustomGutterState()
+      @updateGutterOrderState()
       @updateCustomGutterDecorationState()
     @disposables.add @model.onDidChangeGrammar(@didChangeGrammar.bind(this))
     @disposables.add @model.onDidChangePlaceholderText(@updateContentState.bind(this))
@@ -122,12 +122,12 @@ class TextEditorPresenter
       @updateLineNumberGutterState()
       @updateLineNumbersState()
       @updateCommonGutterState()
-      @updateCustomGutterState()
+      @updateGutterOrderState()
       @updateCustomGutterDecorationState()
     @disposables.add @model.onDidChangeLineNumberGutterVisible =>
       @updateLineNumberGutterState()
       @updateCommonGutterState()
-      @updateCustomGutterState()
+      @updateGutterOrderState()
     @disposables.add @model.onDidAddDecoration(@didAddDecoration.bind(this))
     @disposables.add @model.onDidAddCursor(@didAddCursor.bind(this))
     @disposables.add @model.onDidChangeScrollTop(@setScrollTop.bind(this))
@@ -163,14 +163,14 @@ class TextEditorPresenter
       @showLineNumbers = newValue
       @updateLineNumberGutterState()
       @updateCommonGutterState()
-      @updateCustomGutterState()
+      @updateGutterOrderState()
 
   didChangeGrammar: ->
     @observeConfig()
     @updateContentState()
     @updateLineNumberGutterState()
     @updateCommonGutterState()
-    @updateCustomGutterState()
+    @updateGutterOrderState()
 
   buildState: ->
     @state =
@@ -210,7 +210,7 @@ class TextEditorPresenter
     @updateLineNumberGutterState()
     @updateLineNumbersState()
     @updateCommonGutterState()
-    @updateCustomGutterState()
+    @updateGutterOrderState()
     @updateCustomGutterDecorationState()
 
   updateFocusedState: -> @batch "shouldUpdateFocusedState", ->
@@ -395,21 +395,21 @@ class TextEditorPresenter
   didAddGutter: (gutter) ->
     gutterDisposables = new CompositeDisposable
     gutterDisposables.add gutter.onDidChangeVisible =>
-      @updateCustomGutterState()
+      @updateGutterOrderState()
       @updateCustomGutterDecorationState()
     gutterDisposables.add gutter.onDidDestroy =>
       @disposables.remove(gutterDisposables)
       gutterDisposables.dispose()
-      @updateCustomGutterState()
+      @updateGutterOrderState()
       # It is not necessary to @updateCustomGutterDecorationState here.
       # The destroyed gutter will be removed from the list of gutters in @state,
       # and thus will be removed from the DOM.
     @disposables.add(gutterDisposables)
-    @updateCustomGutterState()
+    @updateGutterOrderState()
     @updateCustomGutterDecorationState()
 
-  updateCustomGutterState: ->
-    @batch "shouldUpdateCustomGutterState", ->
+  updateGutterOrderState: ->
+    @batch "shouldUpdateGutterOrderState", ->
       @state.gutters.sortedDescriptions = []
       if @model.isMini()
         return
@@ -808,14 +808,14 @@ class TextEditorPresenter
       @updateContentState()
       @updateLineNumberGutterState()
       @updateCommonGutterState()
-      @updateCustomGutterState()
+      @updateGutterOrderState()
 
   setGutterBackgroundColor: (gutterBackgroundColor) ->
     unless @gutterBackgroundColor is gutterBackgroundColor
       @gutterBackgroundColor = gutterBackgroundColor
       @updateLineNumberGutterState()
       @updateCommonGutterState()
-      @updateCustomGutterState()
+      @updateGutterOrderState()
 
   setLineHeight: (lineHeight) ->
     unless @lineHeight is lineHeight

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -117,7 +117,7 @@ class TextEditorPresenter
       @updateLinesState()
       @updateGutterState()
       @updateLineNumbersState()
-    @disposables.add @model.onDidChangeGutterVisible =>
+    @disposables.add @model.onDidChangeLineNumberGutterVisible =>
       @updateGutterState()
     @disposables.add @model.onDidAddDecoration(@didAddDecoration.bind(this))
     @disposables.add @model.onDidAddCursor(@didAddCursor.bind(this))
@@ -364,7 +364,7 @@ class TextEditorPresenter
     return
 
   updateGutterState: -> @batch "shouldUpdateGutterState", ->
-    @state.gutter.visible = not @model.isMini() and (@model.isGutterVisible() ? true) and @showLineNumbers
+    @state.gutter.visible = not @model.isMini() and (@model.isLineNumberGutterVisible() ? true) and @showLineNumbers
     @state.gutter.maxLineNumberDigits = @model.getLineCount().toString().length
     @state.gutter.backgroundColor = if @gutterBackgroundColor isnt "rgba(0, 0, 0, 0)"
       @gutterBackgroundColor

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -169,7 +169,7 @@ class TextEditorPresenter
         lines: {}
         highlights: {}
         overlays: {}
-      gutter:
+      lineNumberGutter:
         lineNumbers: {}
     @updateState()
 
@@ -204,11 +204,11 @@ class TextEditorPresenter
 
   updateVerticalScrollState: -> @batch "shouldUpdateVerticalScrollState", ->
     @state.content.scrollHeight = @scrollHeight
-    @state.gutter.scrollHeight = @scrollHeight
+    @state.lineNumberGutter.scrollHeight = @scrollHeight
     @state.verticalScrollbar.scrollHeight = @scrollHeight
 
     @state.content.scrollTop = @scrollTop
-    @state.gutter.scrollTop = @scrollTop
+    @state.lineNumberGutter.scrollTop = @scrollTop
     @state.verticalScrollbar.scrollTop = @scrollTop
 
   updateHorizontalScrollState: -> @batch "shouldUpdateHorizontalScrollState", ->
@@ -364,9 +364,9 @@ class TextEditorPresenter
     return
 
   updateLineNumberGutterState: -> @batch "shouldUpdateLineNumberGutterState", ->
-    @state.gutter.visible = not @model.isMini() and (@model.isLineNumberGutterVisible() ? true) and @showLineNumbers
-    @state.gutter.maxLineNumberDigits = @model.getLineCount().toString().length
-    @state.gutter.backgroundColor = if @gutterBackgroundColor isnt "rgba(0, 0, 0, 0)"
+    @state.lineNumberGutter.visible = not @model.isMini() and (@model.isLineNumberGutterVisible() ? true) and @showLineNumbers
+    @state.lineNumberGutter.maxLineNumberDigits = @model.getLineCount().toString().length
+    @state.lineNumberGutter.backgroundColor = if @gutterBackgroundColor isnt "rgba(0, 0, 0, 0)"
       @gutterBackgroundColor
     else
       @backgroundColor
@@ -401,7 +401,7 @@ class TextEditorPresenter
         decorationClasses = @lineNumberDecorationClassesForRow(screenRow)
         foldable = @model.isFoldableAtScreenRow(screenRow)
 
-        @state.gutter.lineNumbers[id] = {screenRow, bufferRow, softWrapped, top, decorationClasses, foldable}
+        @state.lineNumberGutter.lineNumbers[id] = {screenRow, bufferRow, softWrapped, top, decorationClasses, foldable}
         visibleLineNumberIds[id] = true
 
     if @mouseWheelScreenRow?
@@ -411,8 +411,8 @@ class TextEditorPresenter
       id += '-' + wrapCount if wrapCount > 0
       visibleLineNumberIds[id] = true
 
-    for id of @state.gutter.lineNumbers
-      delete @state.gutter.lineNumbers[id] unless visibleLineNumberIds[id]
+    for id of @state.lineNumberGutter.lineNumbers
+      delete @state.lineNumberGutter.lineNumbers[id] unless visibleLineNumberIds[id]
 
     return
 

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -182,7 +182,7 @@ class TextEditorPresenter
       lineNumberGutter:
         lineNumbers: {}
       gutters:
-        sortedDescriptions: []
+        sortedModels: []
         customDecorations: {}
     @updateState()
 
@@ -405,7 +405,7 @@ class TextEditorPresenter
       # For now, just match the background color of the line-number gutter.
       # TODO: Allow gutters to have different background colors. (?)
       @state.gutters.backgroundColor = @getGutterBackgroundColor()
-      @state.gutters.sortedDescriptions = []
+      @state.gutters.sortedModels = []
       if @model.isMini()
         return
       for gutter in @model.getGutters()
@@ -413,7 +413,7 @@ class TextEditorPresenter
         if gutter.name is 'line-number'
           isVisible = isVisible && @showLineNumbers
         if isVisible
-          @state.gutters.sortedDescriptions.push({name: gutter.name})
+          @state.gutters.sortedModels.push(gutter)
 
   # Updates the decoration state for the gutter with the given gutterName.
   # @state.gutters.customDecorations is an {Object}, with the form:

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -428,6 +428,8 @@ class TextEditorPresenter
       return unless @startRow? and @endRow? and @lineHeight?
 
       @state.gutters.customDecorations = {}
+      return if @model.isMini()
+
       for gutter in @model.getGutters()
         gutterName = gutter.name
         @state.gutters.customDecorations[gutterName] = {}

--- a/src/text-editor-view.coffee
+++ b/src/text-editor-view.coffee
@@ -125,7 +125,7 @@ class TextEditorView extends View
   Object.defineProperty @::, 'firstRenderedScreenRow', get: -> @component.getRenderedRowRange()[0]
   Object.defineProperty @::, 'lastRenderedScreenRow', get: -> @component.getRenderedRowRange()[1]
   Object.defineProperty @::, 'active', get: -> @is(@getPaneView()?.activeView)
-  Object.defineProperty @::, 'isFocused', get: -> document.activeElement is @element or document.activeElement is @element.component?.hiddenInputComponent?.domNode
+  Object.defineProperty @::, 'isFocused', get: -> document.activeElement is @element or document.activeElement is @element.component?.hiddenInputComponent?.getDomNode()
   Object.defineProperty @::, 'mini', get: -> @model?.isMini()
   Object.defineProperty @::, 'component', get: -> @element?.component
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1275,10 +1275,12 @@ class TextEditor extends Model
   #   * `position` (optional) Only applicable to decorations of type `overlay`,
   #     controls where the overlay view is positioned relative to the marker.
   #     Values can be `'head'` (the default), or `'tail'`.
+  #   * `gutterName` (optional) Only applicable to the `gutter` type. If provided,
+  #     the decoration will be applied to the gutter with the specified name.
   #
   # Returns a {Decoration} object
   decorateMarker: (marker, decorationParams) ->
-    if includeDeprecatedAPIs and decorationParams.type is 'gutter'
+    if decorationParams.type is 'gutter' && !decorationParams.gutterName
       deprecate("Decorations of `type: 'gutter'` have been renamed to `type: 'line-number'`.")
       decorationParams.type = 'line-number'
     @displayBuffer.decorateMarker(marker, decorationParams)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -73,7 +73,7 @@ class TextEditor extends Model
     'autoDecreaseIndentForBufferRow', 'toggleLineCommentForBufferRow', 'toggleLineCommentsForBufferRows',
     toProperty: 'languageMode'
 
-  constructor: ({@softTabs, initialLine, initialColumn, tabLength, softWrapped, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini, @placeholderText, @gutterVisible}) ->
+  constructor: ({@softTabs, initialLine, initialColumn, tabLength, softWrapped, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini, @placeholderText, @lineNumberGutterVisible}) ->
     super
 
     @emitter = new Emitter
@@ -488,16 +488,16 @@ class TextEditor extends Model
   onDidChangeMini: (callback) ->
     @emitter.on 'did-change-mini', callback
 
-  setGutterVisible: (gutterVisible) ->
-    unless gutterVisible is @gutterVisible
-      @gutterVisible = gutterVisible
-      @emitter.emit 'did-change-gutter-visible', @gutterVisible
-    @gutterVisible
+  setLineNumberGutterVisible: (lineNumberGutterVisible) ->
+    unless lineNumberGutterVisible is @lineNumberGutterVisible
+      @lineNumberGutterVisible = lineNumberGutterVisible
+      @emitter.emit 'did-change-line-number-gutter-visible', @lineNumberGutterVisible
+    @lineNumberGutterVisible
 
-  isGutterVisible: -> @gutterVisible ? true
+  isLineNumberGutterVisible: -> @lineNumberGutterVisible ? true
 
-  onDidChangeGutterVisible: (callback) ->
-    @emitter.on 'did-change-gutter-visible', callback
+  onDidChangeLineNumberGutterVisible: (callback) ->
+    @emitter.on 'did-change-line-number-gutter-visible', callback
 
   # Set the number of characters that can be displayed horizontally in the
   # editor.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1308,7 +1308,7 @@ class TextEditor extends Model
   #
   # Returns a {Decoration} object
   decorateMarker: (marker, decorationParams) ->
-    if decorationParams.type is 'gutter' and not decorationParams.gutterName
+    if includeDeprecatedAPIs and decorationParams.type is 'gutter' and not decorationParams.gutterName
       deprecate("Decorations of `type: 'gutter'` have been renamed to `type: 'line-number'`.")
       decorationParams.type = 'line-number'
     @displayBuffer.decorateMarker(marker, decorationParams)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1308,7 +1308,7 @@ class TextEditor extends Model
   #
   # Returns a {Decoration} object
   decorateMarker: (marker, decorationParams) ->
-    if decorationParams.type is 'gutter' && !decorationParams.gutterName
+    if decorationParams.type is 'gutter' and not decorationParams.gutterName
       deprecate("Decorations of `type: 'gutter'` have been renamed to `type: 'line-number'`.")
       decorationParams.type = 'line-number'
     @displayBuffer.decorateMarker(marker, decorationParams)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -114,7 +114,7 @@ class TextEditor extends Model
       @emit 'scroll-left-changed', scrollLeft if includeDeprecatedAPIs
       @emitter.emit 'did-change-scroll-left', scrollLeft
 
-    @gutterContainer = new GutterContainer
+    @gutterContainer = new GutterContainer this
     @lineNumberGutter = @gutterContainer.addGutter
       name: 'line-number'
       priority: 0

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -75,7 +75,7 @@ class TextEditor extends Model
     'autoDecreaseIndentForBufferRow', 'toggleLineCommentForBufferRow', 'toggleLineCommentsForBufferRows',
     toProperty: 'languageMode'
 
-  constructor: ({@softTabs, initialLine, initialColumn, tabLength, softWrapped, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini, @placeholderText, @lineNumberGutterVisible}) ->
+  constructor: ({@softTabs, initialLine, initialColumn, tabLength, softWrapped, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini, @placeholderText, lineNumberGutterVisible}) ->
     super
 
     @emitter = new Emitter
@@ -115,6 +115,10 @@ class TextEditor extends Model
       @emitter.emit 'did-change-scroll-left', scrollLeft
 
     @gutterContainer = new GutterContainer
+    @lineNumberGutter = @gutterContainer.addGutter
+      name: 'line-number'
+      priority: 0
+      visible: lineNumberGutterVisible
 
     atom.workspace?.editorAdded(this) if registerEditor
 
@@ -494,12 +498,15 @@ class TextEditor extends Model
     @emitter.on 'did-change-mini', callback
 
   setLineNumberGutterVisible: (lineNumberGutterVisible) ->
-    unless lineNumberGutterVisible is @lineNumberGutterVisible
-      @lineNumberGutterVisible = lineNumberGutterVisible
-      @emitter.emit 'did-change-line-number-gutter-visible', @lineNumberGutterVisible
-    @lineNumberGutterVisible
+    unless lineNumberGutterVisible is @lineNumberGutter.isVisible()
+      if lineNumberGutterVisible
+        @lineNumberGutter.show()
+      else
+        @lineNumberGutter.hide()
+      @emitter.emit 'did-change-line-number-gutter-visible', @lineNumberGutter.isVisible()
+    @lineNumberGutter.isVisible()
 
-  isLineNumberGutterVisible: -> @lineNumberGutterVisible ? true
+  isLineNumberGutterVisible: -> @lineNumberGutter.isVisible()
 
   onDidChangeLineNumberGutterVisible: (callback) ->
     @emitter.on 'did-change-line-number-gutter-visible', callback
@@ -512,6 +519,10 @@ class TextEditor extends Model
   # Public: Returns the {Array} of all gutters on this editor.
   getGutters: ->
     @gutterContainer.getGutters()
+
+  # Public: Returns the {Gutter} with the given name, or null if it doesn't exist.
+  gutterWithName: (name) ->
+    @gutterContainer.gutterWithName name
 
   # Set the number of characters that can be displayed horizontally in the
   # editor.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -12,6 +12,7 @@ Model = require './model'
 Selection = require './selection'
 TextMateScopeSelector = require('first-mate').ScopeSelector
 {Directory} = require "pathwatcher"
+GutterContainer = require './gutter-container'
 
 # Public: This class represents all essential editing state for a single
 # {TextBuffer}, including cursor and selection positions, folds, and soft wraps.
@@ -68,6 +69,7 @@ class TextEditor extends Model
   suppressSelectionMerging: false
   updateBatchDepth: 0
   selectionFlashDuration: 500
+  gutterContainer: null
 
   @delegatesMethods 'suggestedIndentForBufferRow', 'autoIndentBufferRow', 'autoIndentBufferRows',
     'autoDecreaseIndentForBufferRow', 'toggleLineCommentForBufferRow', 'toggleLineCommentsForBufferRows',
@@ -111,6 +113,8 @@ class TextEditor extends Model
     @disposables.add @displayBuffer.onDidChangeScrollLeft (scrollLeft) =>
       @emit 'scroll-left-changed', scrollLeft if includeDeprecatedAPIs
       @emitter.emit 'did-change-scroll-left', scrollLeft
+
+    @gutterContainer = new GutterContainer
 
     atom.workspace?.editorAdded(this) if registerEditor
 
@@ -181,6 +185,7 @@ class TextEditor extends Model
     @buffer.release()
     @displayBuffer.destroy()
     @languageMode.destroy()
+    @gutterContainer.destroy()
     @emitter.emit 'did-destroy'
 
   ###
@@ -498,6 +503,15 @@ class TextEditor extends Model
 
   onDidChangeLineNumberGutterVisible: (callback) ->
     @emitter.on 'did-change-line-number-gutter-visible', callback
+
+  # Public: Creates and returns a {Gutter}.
+  # See {GutterContainer::addGutter} for more details.
+  addGutter: (options) ->
+    @gutterContainer.addGutter options
+
+  # Public: Returns the {Array} of all gutters on this editor.
+  getGutters: ->
+    @gutterContainer.getGutters()
 
   # Set the number of characters that can be displayed horizontally in the
   # editor.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -114,7 +114,7 @@ class TextEditor extends Model
       @emit 'scroll-left-changed', scrollLeft if includeDeprecatedAPIs
       @emitter.emit 'did-change-scroll-left', scrollLeft
 
-    @gutterContainer = new GutterContainer this
+    @gutterContainer = new GutterContainer(this)
     @lineNumberGutter = @gutterContainer.addGutter
       name: 'line-number'
       priority: 0
@@ -514,7 +514,7 @@ class TextEditor extends Model
   # Public: Creates and returns a {Gutter}.
   # See {GutterContainer::addGutter} for more details.
   addGutter: (options) ->
-    @gutterContainer.addGutter options
+    @gutterContainer.addGutter(options)
 
   # Public: Returns the {Array} of all gutters on this editor.
   getGutters: ->
@@ -522,7 +522,7 @@ class TextEditor extends Model
 
   # Public: Returns the {Gutter} with the given name, or null if it doesn't exist.
   gutterWithName: (name) ->
-    @gutterContainer.gutterWithName name
+    @gutterContainer.gutterWithName(name)
 
   # Calls your `callback` when a {Gutter} is added to the editor.
   # Immediately calls your callback for each existing gutter.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -524,6 +524,34 @@ class TextEditor extends Model
   gutterWithName: (name) ->
     @gutterContainer.gutterWithName name
 
+  # Calls your `callback` when a {Gutter} is added to the editor.
+  # Immediately calls your callback for each existing gutter.
+  #
+  # * `callback` {Function}
+  #   * `gutter` {Gutter} that currently exists/was added.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  observeGutters: (callback) ->
+    @gutterContainer.observeGutters callback
+
+  # Calls your `callback` when a {Gutter} is added to the editor.
+  #
+  # * `callback` {Function}
+  #   * `gutter` {Gutter} that was added.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidAddGutter: (callback) ->
+    @gutterContainer.onDidAddGutter callback
+
+  # Calls your `callback` when a {Gutter} is removed from the editor.
+  #
+  # * `callback` {Function}
+  #   * `name` The name of the {Gutter} that was removed.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidRemoveGutter: (callback) ->
+    @gutterContainer.onDidRemoveGutter callback
+
   # Set the number of characters that can be displayed horizontally in the
   # editor.
   #


### PR DESCRIPTION
Summary: This implements the gutter API described in https://github.com/atom/atom/issues/5038.

Test Plan: Added unit tests. Tested manually as well -- if you rebase before the commit "Remove test-only CSS", there is some default CSS that makes gutters and decorations obviously visible when you add them via commands in the console. Example test commands, on top of this default CSS:

``` javascript
var e = atom.workspace.getActiveEditor()
var g = e.addGutter({name: 'test'})

var m = e.markBufferRange([[1, 0], [10, 0]])
var d = e.decorateMarker(m, {type: 'gutter', gutterName: 'test', class: 'test-class'})

var item = document.createElement('div')
item.className = 'test-item'
item.style['background-color'] = 'green'
var m2 = e.markBufferRange([[12, 0], [20, 0]])
var di = e.decorateMarker(m2, {type: 'gutter', gutterName: 'test', class: 'test-class', item: item})
```

Updating:

``` javascript
var item2 = document.createElement('div')
item2.className = 'test-item2'
item2.style['background-color'] = 'red'
di.setProperties({type: 'gutter', gutterName: 'test', class: 'test-class2', item: item2})

g.hide()
g.show()
g.destroy()
g = e.addGutter({name: 'test'})
```
