### PR TITLE
Tab selection fix

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -719,6 +719,14 @@ describe "DisplayBuffer", ->
       expect(displayBuffer.screenPositionForBufferPosition([100000, 0])).toEqual [12, 2]
       expect(displayBuffer.screenPositionForBufferPosition([100000, 100000])).toEqual [12, 2]
 
+    it "clips to the (left or right) edge of an atomic token without simply rounding up", ->
+      tabLength = 4
+      displayBuffer.setTabLength(tabLength)
+
+      buffer.insert([0, 0], '\t')
+      expect(displayBuffer.screenPositionForBufferPosition([0, 0])).toEqual [0, 0]
+      expect(displayBuffer.screenPositionForBufferPosition([0, 1])).toEqual [0, tabLength]
+
   describe "position translation in the presence of hard tabs", ->
     it "correctly translates positions on either side of a tab", ->
       buffer.setText('\t')

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -739,6 +739,17 @@ describe "DisplayBuffer", ->
       expect(displayBuffer.screenPositionForBufferPosition([0, 0])).toEqual [0, 0]
       expect(displayBuffer.screenPositionForBufferPosition([0, 1])).toEqual [0, tabLength]
 
+    it "clips to the edge closest to the given position when it's inside a soft tab", ->
+      tabLength = 4
+      displayBuffer.setTabLength(tabLength)
+
+      buffer.insert([0, 0], '    ')
+      expect(displayBuffer.screenPositionForBufferPosition([0, 0])).toEqual [0, 0]
+      expect(displayBuffer.screenPositionForBufferPosition([0, 1])).toEqual [0, 0]
+      expect(displayBuffer.screenPositionForBufferPosition([0, 2])).toEqual [0, 0]
+      expect(displayBuffer.screenPositionForBufferPosition([0, 3])).toEqual [0, 4]
+      expect(displayBuffer.screenPositionForBufferPosition([0, 4])).toEqual [0, 4]
+
   describe "position translation in the presence of hard tabs", ->
     it "correctly translates positions on either side of a tab", ->
       buffer.setText('\t')

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -305,7 +305,7 @@ class Cursor extends Model
         columnCount-- # subtract 1 for the row move
 
       column = column - columnCount
-      @setScreenPosition({row, column})
+      @setScreenPosition({row, column}, clip: 'backward')
 
   # Public: Moves the cursor right one screen column.
   #
@@ -332,7 +332,7 @@ class Cursor extends Model
         columnsRemainingInLine = rowLength
 
       column = column + columnCount
-      @setScreenPosition({row, column}, skipAtomicTokens: true, wrapBeyondNewlines: true, wrapAtSoftNewlines: true)
+      @setScreenPosition({row, column}, clip: 'forward', wrapBeyondNewlines: true, wrapAtSoftNewlines: true)
 
   # Public: Moves the cursor to the top of the buffer.
   moveToTop: ->

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -286,7 +286,6 @@ class Marker
   # * `screenPosition` The new {Point} to use
   # * `properties` (optional) {Object} properties to associate with the marker.
   setHeadScreenPosition: (screenPosition, properties) ->
-    screenPosition = @displayBuffer.clipScreenPosition(screenPosition, properties)
     @setHeadBufferPosition(@displayBuffer.bufferPositionForScreenPosition(screenPosition, properties))
 
   # Extended: Retrieves the buffer position of the marker's tail.
@@ -313,7 +312,6 @@ class Marker
   # * `screenPosition` The new {Point} to use
   # * `properties` (optional) {Object} properties to associate with the marker.
   setTailScreenPosition: (screenPosition, options) ->
-    screenPosition = @displayBuffer.clipScreenPosition(screenPosition, options)
     @setTailBufferPosition(@displayBuffer.bufferPositionForScreenPosition(screenPosition, options))
 
   # Extended: Returns a {Boolean} indicating whether the marker has a tail.

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -393,7 +393,7 @@ class Selection extends Model
     if options.select
       @setBufferRange(newBufferRange, reversed: wasReversed)
     else
-      @cursor.setBufferPosition(newBufferRange.end, skipAtomicTokens: true) if wasReversed
+      @cursor.setBufferPosition(newBufferRange.end, clip: 'forward') if wasReversed
 
     if autoIndentFirstLine
       @editor.setIndentationForBufferRow(oldBufferRange.start.row, desiredIndentLevel)

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -67,7 +67,7 @@ class TokenizedLine
     screenColumn = 0
     currentBufferColumn = 0
     for token in @tokens
-      break if currentBufferColumn > bufferColumn
+      break if currentBufferColumn + token.bufferDelta > bufferColumn
       screenColumn += token.screenDelta
       currentBufferColumn += token.bufferDelta
     @clipScreenColumn(screenColumn + (bufferColumn - currentBufferColumn))


### PR DESCRIPTION
These changes make selecting hard tabs work like it does in other editors. Currently in Atom, if you click in the middle of a hard tab the cursor always goes to the left edge. These changes make it go to the closest edge.

Tests have been updated, and new ones have been added for the new functionality.

I believe I've hit everything in the contribution guidelines. Let me know if I need to make any changes!
