### PR TITLE
Enable DirectWrite

### DIFF
--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -26,7 +26,7 @@ class AtomWindow
       show: false
       title: 'Atom'
       'web-preferences':
-        'direct-write': false
+        'direct-write': true
         'subpixel-font-scaling': false
     global.atomApplication.addWindow(this)
 


### PR DESCRIPTION
Chrome 39 proper now has DirectWrite as the default renderer on Windows, which makes a huge difference in text clarity, especially on High DPI monitors.
