### PR TITLE
Reset all user config values when the schema changes

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1135,8 +1135,16 @@ describe "Config", ->
               int:
                 type: 'integer'
                 default: 2
+              bar:
+                type: 'string'
+                default: 'def'
 
-        it 'the values set respect the new schema', ->
+        it "the values set respect the new schema", ->
+          expect(atom.config.set('foo.bar.bar', 'globalBar')).toBe true
+          expect(atom.config.set('foo.bar.bar', 'scopedBar', scopeSelector: '.source.js')).toBe true
+          expect(atom.config.get('foo.bar.bar')).toBe 'globalBar'
+          expect(atom.config.get('foo.bar.bar', scope: ['.source.js'])).toBe 'scopedBar'
+
           expect(atom.config.set('foo.bar.int', 'nope')).toBe true
           expect(atom.config.set('foo.bar.int', 'notanint', scopeSelector: '.source.js')).toBe true
           expect(atom.config.set('foo.bar.int', 23, scopeSelector: '.source.coffee')).toBe true
@@ -1146,11 +1154,14 @@ describe "Config", ->
 
           atom.config.setSchema('foo.bar', schema)
 
+          expect(atom.config.get('foo.bar.bar')).toBe 'globalBar'
+          expect(atom.config.get('foo.bar.bar', scope: ['.source.js'])).toBe 'scopedBar'
+
           expect(atom.config.get('foo.bar.int')).toBe 2
           expect(atom.config.get('foo.bar.int', scope: ['.source.js'])).toBe 2
           expect(atom.config.get('foo.bar.int', scope: ['.source.coffee'])).toBe 23
 
-        it 'doesnt mess it up', ->
+        it "sets all values that adhere to the schema", ->
           expect(atom.config.set('foo.bar.int', 10)).toBe true
           expect(atom.config.set('foo.bar.int', 15, scopeSelector: '.source.js')).toBe true
           expect(atom.config.set('foo.bar.int', 23, scopeSelector: '.source.coffee')).toBe true

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -699,6 +699,26 @@ describe "Config", ->
           expect(atom.config.get("foo.bar")).toBe 'baz'
           expect(atom.config.get("foo.bar", scope: ['.source.ruby'])).toBe 'more-specific'
 
+      describe "when the config file does not conform to the schema", ->
+        beforeEach ->
+          fs.writeFileSync atom.config.configFilePath, """
+            '*':
+              foo:
+                bar: 'omg'
+                int: 'baz'
+            '.source.ruby':
+              foo:
+                bar: 'scoped'
+                int: 'nope'
+          """
+
+        it "validates and does not load the incorrect values", ->
+          atom.config.loadUserConfig()
+          expect(atom.config.get("foo.int")).toBe 12
+          expect(atom.config.get("foo.bar")).toBe 'omg'
+          expect(atom.config.get("foo.int", scope: ['.source.ruby'])).toBe 12
+          expect(atom.config.get("foo.bar", scope: ['.source.ruby'])).toBe 'scoped'
+
       describe "when the config file contains valid cson", ->
         beforeEach ->
           fs.writeFileSync(atom.config.configFilePath, "foo: bar: 'baz'")

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1145,6 +1145,11 @@ describe "Config", ->
           expect(atom.config.get('foo.bar.str')).toBe 'global'
           expect(atom.config.get('foo.bar.str', scope: ['.source.js'])).toBe 'scoped'
 
+          expect(atom.config.set('foo.bar.noschema', 'nsGlobal')).toBe true
+          expect(atom.config.set('foo.bar.noschema', 'nsScoped', scopeSelector: '.source.js')).toBe true
+          expect(atom.config.get('foo.bar.noschema')).toBe 'nsGlobal'
+          expect(atom.config.get('foo.bar.noschema', scope: ['.source.js'])).toBe 'nsScoped'
+
           expect(atom.config.set('foo.bar.int', 'nope')).toBe true
           expect(atom.config.set('foo.bar.int', 'notanint', scopeSelector: '.source.js')).toBe true
           expect(atom.config.set('foo.bar.int', 23, scopeSelector: '.source.coffee')).toBe true
@@ -1156,6 +1161,8 @@ describe "Config", ->
 
           expect(atom.config.get('foo.bar.str')).toBe 'global'
           expect(atom.config.get('foo.bar.str', scope: ['.source.js'])).toBe 'scoped'
+          expect(atom.config.get('foo.bar.noschema')).toBe 'nsGlobal'
+          expect(atom.config.get('foo.bar.noschema', scope: ['.source.js'])).toBe 'nsScoped'
 
           expect(atom.config.get('foo.bar.int')).toBe 2
           expect(atom.config.get('foo.bar.int', scope: ['.source.js'])).toBe 2

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1139,7 +1139,7 @@ describe "Config", ->
                 type: 'string'
                 default: 'def'
 
-        it "the values set respect the new schema", ->
+        it "respects the new schema when values are set", ->
           expect(atom.config.set('foo.bar.str', 'global')).toBe true
           expect(atom.config.set('foo.bar.str', 'scoped', scopeSelector: '.source.js')).toBe true
           expect(atom.config.get('foo.bar.str')).toBe 'global'

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1135,15 +1135,15 @@ describe "Config", ->
               int:
                 type: 'integer'
                 default: 2
-              bar:
+              str:
                 type: 'string'
                 default: 'def'
 
         it "the values set respect the new schema", ->
-          expect(atom.config.set('foo.bar.bar', 'globalBar')).toBe true
-          expect(atom.config.set('foo.bar.bar', 'scopedBar', scopeSelector: '.source.js')).toBe true
-          expect(atom.config.get('foo.bar.bar')).toBe 'globalBar'
-          expect(atom.config.get('foo.bar.bar', scope: ['.source.js'])).toBe 'scopedBar'
+          expect(atom.config.set('foo.bar.str', 'global')).toBe true
+          expect(atom.config.set('foo.bar.str', 'scoped', scopeSelector: '.source.js')).toBe true
+          expect(atom.config.get('foo.bar.str')).toBe 'global'
+          expect(atom.config.get('foo.bar.str', scope: ['.source.js'])).toBe 'scoped'
 
           expect(atom.config.set('foo.bar.int', 'nope')).toBe true
           expect(atom.config.set('foo.bar.int', 'notanint', scopeSelector: '.source.js')).toBe true
@@ -1154,8 +1154,8 @@ describe "Config", ->
 
           atom.config.setSchema('foo.bar', schema)
 
-          expect(atom.config.get('foo.bar.bar')).toBe 'globalBar'
-          expect(atom.config.get('foo.bar.bar', scope: ['.source.js'])).toBe 'scopedBar'
+          expect(atom.config.get('foo.bar.str')).toBe 'global'
+          expect(atom.config.get('foo.bar.str', scope: ['.source.js'])).toBe 'scoped'
 
           expect(atom.config.get('foo.bar.int')).toBe 2
           expect(atom.config.get('foo.bar.int', scope: ['.source.js'])).toBe 2

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1106,6 +1106,44 @@ describe "Config", ->
         expect(atom.config.get('foo.bar.str', scope: ['.source.js'])).toBe 'omg'
         expect(atom.config.get('foo.bar.str', scope: ['.source.coffee'])).toBe 'ok'
 
+      describe 'when a schema is added after config values have been set', ->
+        schema = null
+        beforeEach ->
+          schema =
+            type: 'object'
+            properties:
+              int:
+                type: 'integer'
+                default: 2
+
+        it 'the values set respect the new schema', ->
+          expect(atom.config.set('foo.bar.int', 'nope')).toBe true
+          expect(atom.config.set('foo.bar.int', 'notanint', scopeSelector: '.source.js')).toBe true
+          expect(atom.config.set('foo.bar.int', 23, scopeSelector: '.source.coffee')).toBe true
+          expect(atom.config.get('foo.bar.int')).toBe 'nope'
+          expect(atom.config.get('foo.bar.int', scope: ['.source.js'])).toBe 'notanint'
+          expect(atom.config.get('foo.bar.int', scope: ['.source.coffee'])).toBe 23
+
+          atom.config.setSchema('foo.bar', schema)
+
+          expect(atom.config.get('foo.bar.int')).toBe 2
+          expect(atom.config.get('foo.bar.int', scope: ['.source.js'])).toBe 2
+          expect(atom.config.get('foo.bar.int', scope: ['.source.coffee'])).toBe 23
+
+        it 'doesnt mess it up', ->
+          expect(atom.config.set('foo.bar.int', 10)).toBe true
+          expect(atom.config.set('foo.bar.int', 15, scopeSelector: '.source.js')).toBe true
+          expect(atom.config.set('foo.bar.int', 23, scopeSelector: '.source.coffee')).toBe true
+          expect(atom.config.get('foo.bar.int')).toBe 10
+          expect(atom.config.get('foo.bar.int', scope: ['.source.js'])).toBe 15
+          expect(atom.config.get('foo.bar.int', scope: ['.source.coffee'])).toBe 23
+
+          atom.config.setSchema('foo.bar', schema)
+
+          expect(atom.config.get('foo.bar.int')).toBe 10
+          expect(atom.config.get('foo.bar.int', scope: ['.source.js'])).toBe 15
+          expect(atom.config.get('foo.bar.int', scope: ['.source.coffee'])).toBe 23
+
       describe 'when the value has an "integer" type', ->
         beforeEach ->
           schema =

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -602,7 +602,7 @@ class Config
         return false
 
     if scopeSelector?
-      @setRawScopedValue(source, scopeSelector, keyPath, value)
+      @setRawScopedValue(keyPath, value, source, scopeSelector)
     else
       @setRawValue(keyPath, value)
 
@@ -1057,7 +1057,7 @@ class Config
       disposable.dispose()
       @emitChangeEvent()
 
-  setRawScopedValue: (source, selector, keyPath, value) ->
+  setRawScopedValue: (keyPath, value, source, selector, options) ->
     if keyPath?
       newValue = {}
       _.setValueForKeyPath(newValue, keyPath, value)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1032,8 +1032,19 @@ class Config
 
   resetUserScopedSettings: (newScopedSettings) ->
     source = @getUserConfigPath()
+    priority = @priorityForSource(source)
     @scopedSettingsStore.removePropertiesForSource(source)
-    @scopedSettingsStore.addProperties(source, newScopedSettings, priority: @priorityForSource(source))
+
+    for scopeSelector, settings of newScopedSettings
+      validatedSettings = {}
+      try
+        settings = withoutEmptyObjects(@makeValueConformToSchema(null, settings))
+        validatedSettings[scopeSelector] = settings
+      catch e
+        ;
+
+      @scopedSettingsStore.addProperties(source, validatedSettings, {priority}) if validatedSettings[scopeSelector]
+
     @emitChangeEvent()
 
   addScopedSettings: (source, selector, value, options) ->

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1041,9 +1041,9 @@ class Config
         settings = withoutEmptyObjects(@makeValueConformToSchema(null, settings))
         validatedSettings[scopeSelector] = settings
       catch e
-        ;
+        validatedSettings[scopeSelector] = null
 
-      @scopedSettingsStore.addProperties(source, validatedSettings, {priority}) if validatedSettings[scopeSelector]
+      @scopedSettingsStore.addProperties(source, validatedSettings, {priority}) if validatedSettings[scopeSelector]?
 
     @emitChangeEvent()
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1010,7 +1010,7 @@ class Config
       value
 
   # When the schema is changed / added, there may be values set in the config
-  # that do not conform to the config. This will reset make them conform.
+  # that do not conform to the schema. This will reset make them conform.
   resetSettingsForSchemaChange: (source=@getUserConfigPath()) ->
     @transact =>
       @settings = @makeValueConformToSchema(null, @settings, suppressException: true)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1144,12 +1144,17 @@ Config.addSchemaEnforcers
       return value unless schema.properties?
 
       newValue = {}
-      for prop, childSchema of schema.properties
-        continue unless value.hasOwnProperty(prop)
-        try
-          newValue[prop] = @executeSchemaEnforcers("#{keyPath}.#{prop}", value[prop], childSchema)
-        catch error
-          console.warn "Error setting item in object: #{error.message}"
+      for prop, propValue of value
+        childSchema = schema.properties[prop]
+        if childSchema?
+          try
+            newValue[prop] = @executeSchemaEnforcers("#{keyPath}.#{prop}", propValue, childSchema)
+          catch error
+            console.warn "Error setting item in object: #{error.message}"
+        else
+          # Just pass through un-schema'd values
+          newValue[prop] = propValue
+
       newValue
 
   'array':


### PR DESCRIPTION
What's happening? A value in the user's config file is not run through the config schemas
- The user config is loaded from disk, and sets without running through the schemas
- The user config is loaded before package schemas are read

I had a couple options
1. Just run the value through the correct schema on `get`. This is not intrusive, but it slows down reads. And reads happen a lot
2. Split up initial config load to loading core config, loading package schemas, then loading the rest of the config values
3. Reset the all values in the user config on schema changes to take advantage of the new schemas

I opted for option 3 as it should keep the config in sync as packages are activated/deactivated/installed, etc. This may have an impact on startup time because the user config is reset (though, without save) for each schema addition. 

Closes #5219 
Closes #5306 
