### PR TITLE
Fixes RPM install path and icon location

### DIFF
--- a/build/tasks/mkrpm-task.coffee
+++ b/build/tasks/mkrpm-task.coffee
@@ -30,9 +30,9 @@ module.exports = (grunt) ->
     rm rpmDir
     mkdir rpmDir
 
-    installDir = grunt.config.get('atom.installDir')
+    installDir = '/usr'
     shareDir = path.join(installDir, 'share', 'atom')
-    iconName = path.join(shareDir, 'resources', 'app', 'resources', 'atom.png')
+    iconName = 'atom'
 
     data = {name, version, description, installDir, iconName}
     specFilePath = fillTemplate(path.join('resources', 'linux', 'redhat', 'atom.spec'), data)

--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -5,23 +5,23 @@ Summary:        Atom is a hackable text editor for the 21st century
 License:        MIT
 URL:            https://atom.io/
 AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
-Prefix:         /usr/local
+Prefix:         /usr
 
 %description
 <%= description %>
 
 %install
-mkdir -p %{buildroot}/usr/local/share/atom
-cp -r /tmp/atom-build/Atom/* %{buildroot}/usr/local/share/atom
-mkdir -p %{buildroot}/usr/local/bin/
-ln -sf ../share/atom/resources/app/apm/node_modules/.bin/apm %{buildroot}/usr/local/bin/apm
-cp atom.sh %{buildroot}/usr/local/bin/atom
+mkdir -p %{buildroot}/usr/share/atom
+cp -r /tmp/atom-build/Atom/* %{buildroot}/usr/share/atom
+mkdir -p %{buildroot}/usr/bin/
+ln -sf ../share/atom/resources/app/apm/node_modules/.bin/apm %{buildroot}/usr/bin/apm
+cp atom.sh %{buildroot}/usr/bin/atom
 chmod 755 atom.sh
-mkdir -p %{buildroot}/usr/local/share/applications/
-mv atom.desktop %{buildroot}/usr/local/share/applications/
+mkdir -p %{buildroot}/usr/share/applications/
+mv atom.desktop %{buildroot}/usr/share/applications/
 
 %files
-/usr/local/bin/atom
-/usr/local/bin/apm
-/usr/local/share/atom/
-/usr/local/share/applications/atom.desktop
+/usr/bin/atom
+/usr/bin/apm
+/usr/share/atom/
+/usr/share/applications/atom.desktop


### PR DESCRIPTION
This makes Atom a better desktop citizen relocating to where the usual install
directory is (like on the debian package) and also fix the icon using absolute
paths, breaking icon-themes.

Fixes #5331
