### PR TITLE
Delta Packages for Windows + Update Squirrel.Windows

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -207,6 +207,7 @@ module.exports = (grunt) ->
       loadingGif: path.resolve(__dirname, '..', 'resources', 'win', 'loading.gif')
       iconUrl: 'https://raw.githubusercontent.com/atom/atom/master/resources/win/atom.ico'
       setupIcon: path.resolve(__dirname, '..', 'resources', 'win', 'atom.ico')
+      remoteReleases: 'https://atom.io/api/updates'
 
     shell:
       'kill-atom':

--- a/build/package.json
+++ b/build/package.json
@@ -12,7 +12,7 @@
     "fs-plus": "2.x",
     "github-releases": "~0.2.0",
     "grunt": "~0.4.1",
-    "grunt-atom-shell-installer": "^0.20.0",
+    "grunt-atom-shell-installer": "^0.21.0",
     "grunt-cli": "~0.1.9",
     "grunt-coffeelint": "git+https://github.com/atom/grunt-coffeelint.git#cfb99aa99811d52687969532bd5a98011ed95bfe",
     "grunt-contrib-coffee": "~0.12.0",

--- a/build/tasks/publish-build-task.coffee
+++ b/build/tasks/publish-build-task.coffee
@@ -68,7 +68,7 @@ getAssets = ->
       ]
     when 'win32'
       assets = [{assetName: 'atom-windows.zip', sourcePath: 'Atom'}]
-      for squirrelAsset in ['AtomSetup.exe', 'RELEASES', "atom-#{version}-full.nupkg"]
+      for squirrelAsset in ['AtomSetup.exe', 'RELEASES', "atom-#{version}-full.nupkg", "atom-#{version}-delta.nupkg"]
         cp path.join(buildDir, 'installer', squirrelAsset), path.join(buildDir, squirrelAsset)
         assets.push({assetName: squirrelAsset, sourcePath: assetName})
       assets


### PR DESCRIPTION
This PR enables creating / publishing delta packages for Atom updates, which vastly decreases the amount of data users have to download for every Atom release. Typical delta package sizes for JavaScript-only changes (i.e. not the upcoming release because of Chrome 40) are around 800k-2MB.

This PR also updates us to Squirrel.Windows 0.8.3 which fixes a bunch of issues, see https://github.com/atom/grunt-atom-shell-installer/pull/6 for more info
## TODO:
- [x] Triple-check install + update
- [x] Wait for `grunt-atom-shell-installer@0.21.0` to be published
