### PR TITLE
Fix indent guides missing on whitespace only lines with invisible characters

### DIFF
--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -213,8 +213,7 @@ LinesComponent = React.createClass
     innerHTML = ""
 
     scopeStack = []
-    firstTrailingWhitespacePosition = text.search(/\s*$/)
-    lineIsWhitespaceOnly = firstTrailingWhitespacePosition is 0
+    lineIsWhitespaceOnly = line.isOnlyWhitespace()
     for token in tokens
       innerHTML += @updateScopeStack(scopeStack, token.scopes)
       hasIndentGuide = not editor.isMini() and showIndentGuide and (token.hasLeadingWhitespace() or (token.hasTrailingWhitespace() and lineIsWhitespaceOnly))

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -9,6 +9,7 @@ idCounter = 1
 module.exports =
 class TokenizedLine
   endOfLineInvisibles: null
+  lineIsWhitespaceOnly: false
 
   constructor: ({tokens, @lineEnding, @ruleStack, @startBufferColumn, @fold, @tabLength, @indentLevel, @invisibles}) ->
     @startBufferColumn ?= 0
@@ -146,7 +147,7 @@ class TokenizedLine
   markLeadingAndTrailingWhitespaceTokens: ->
     firstNonWhitespaceIndex = @text.search(NonWhitespaceRegex)
     firstTrailingWhitespaceIndex = @text.search(TrailingWhitespaceRegex)
-    lineIsWhitespaceOnly = firstTrailingWhitespaceIndex is 0
+    @lineIsWhitespaceOnly = firstTrailingWhitespaceIndex is 0
     index = 0
     for token in @tokens
       if index < firstNonWhitespaceIndex
@@ -202,12 +203,7 @@ class TokenizedLine
     false
 
   isOnlyWhitespace: ->
-    if @text == ''
-      true
-    else
-      for token in @tokens
-        return false unless token.isOnlyWhitespace()
-      true
+    @lineIsWhitespaceOnly
 
   tokenAtIndex: (index) ->
     @tokens[index]


### PR DESCRIPTION
Using 0.175.0 on Mac OS X 10.10.2 (though likely affecting all platforms), the indent guides are missing on whitespace only lines. So when you start a new line which auto-indents the indent guides are visibly missing. Snapshot below:

![screen shot 2015-02-01 at 17 59 23](https://cloud.githubusercontent.com/assets/939815/5993100/77e73eea-aa3c-11e4-8812-82568431c5ab.png)

This is down the fact that the "isWhitespaceOnly" detection only works if invisible characters is disabled. With invisible characters enabled, it sees the invisible characters and thinks the line does not contain only whitespace, thus disabling the guides.

This patch also means the whitespace only flag is stored, and there's no need to run any regex again when re-rendering the HTML for the line.

Snapshot after applying the patch:

![screen shot 2015-02-01 at 18 01 01](https://cloud.githubusercontent.com/assets/939815/5993127/7490fad2-aa3d-11e4-909d-30c187ba6f9e.png)
