### PR TITLE
Updated doc to specify package language

### DIFF
--- a/docs/creating-a-package.md
+++ b/docs/creating-a-package.md
@@ -1,6 +1,6 @@
 # Creating Packages
 
-Packages are at the core of Atom. Nearly everything outside of the main editor
+Packages are at the core of Atom. You can write a package in Javascript or CoffeeScript. Nearly everything outside of the main editor
 is handled by a package. That includes "core" pieces like the [file tree][file-tree],
 [status bar][status-bar], [syntax highlighting][cs-syntax], and more.
 


### PR DESCRIPTION
I just added a sentence in the first paragraph: "You can write a package in Javascript or CoffeeScript."

This doesn't seem to be declared anywhere. We can apparently write packages in JS but the word 'Javascript' is nowhere in the doc. index.coffee would presumably imply to readers that packages are written in CoffeeScript, but this should be stated explicitly, and early. (And the JS option will be hugely important to many.)
