### PR TITLE
Add section on "composed" commands to Advanced Keymap document

### DIFF
--- a/docs/advanced/keymaps.md
+++ b/docs/advanced/keymaps.md
@@ -67,6 +67,30 @@ given focus context. Commands are "humanized" following a simple algorithm, so a
 command like `editor:fold-current-row` would appear as "Editor: Fold Current
 Row".
 
+### "Composed" Commands
+
+A common question is, "How do I make a single keybinding execute two or more
+commands?" There isn't any direct support for this in Atom, but it can be
+achieved by creating a custom command that performs the multiple actions
+you desire and then creating a keybinding for that command. For example, let's
+say I want to create a "composed" command that performs a Select Line followed
+by Cut. You could add the following to your `init.coffee`:
+
+```coffee
+atom.commands.add 'atom-text-editor', 'custom:cut-line', ->
+  editor = atom.workspace.getActiveTextEditor()
+  editor.selectLinesContainingCursors()
+  editor.cutSelectedText()
+```
+
+Then let's say we want to map this custom command to `alt-ctrl-z`, you could
+add the following to your keymap:
+
+```coffee
+'atom-text-editor':
+  'alt-ctrl-z': 'custom:cut-line'
+```
+
 ### Specificity and Cascade Order
 
 As is the case with CSS applying styles, when multiple bindings match for a

--- a/docs/advanced/keymaps.md
+++ b/docs/advanced/keymaps.md
@@ -49,19 +49,17 @@ can be expressed as keystroke patterns separated by spaces.
 Commands are custom DOM events that are triggered when a keystroke matches a
 binding. This allows user interface code to listen for named commands without
 specifying the specific keybinding that triggers it. For example, the following
-code sets up {EditorView} to listen for commands to move the cursor to the first
-character of the current line:
+code creates a command to insert the current date in an editor:
 
 ```coffee
-class EditorView
-  listenForEvents: ->
-    @command 'editor:move-to-first-character-of-line', =>
-      @editor.moveToFirstCharacterOfLine()
+atom.commands.add 'atom-text-editor',
+  'user:insert-date': (event) ->
+    editor = @getModel()
+    editor.insertText(new Date().toLocaleString())
 ```
 
-The `::command` method is basically an enhanced version of jQuery's `::on`
-method that listens for a custom DOM event and adds some metadata to the DOM,
-which is read by the command palette.
+`atom.commands` refers to the global {CommandRegistry} instance where all commands
+are set and consequently picked up by the command palette.
 
 When you are looking to bind new keys, it is often useful to use the command
 palette (`ctrl-shift-p`) to discover what commands are being listened for in a


### PR DESCRIPTION
This is intended to address the commonly-asked question about making a keybinding execute multiple commands.

It also updates the example code for a command by removing the reference to the deprecated `EditorView` and just using the example from the `CommandRegistry` documentation.
