### PR TITLE
Respect ATOM_HOME env var for portability

### DIFF
--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "0.134.0"
+    "atom-package-manager": "0.135.0"
   }
 }

--- a/atom.sh
+++ b/atom.sh
@@ -75,9 +75,9 @@ elif [ $OS == 'Linux' ]; then
   SCRIPT=$(readlink -f "$0")
   USR_DIRECTORY=$(readlink -f $(dirname $SCRIPT)/..)
   ATOM_PATH="$USR_DIRECTORY/share/atom/atom"
-  DOT_ATOM_DIR="$HOME/.atom"
+  ATOM_HOME="${ATOM_HOME:-$HOME/.atom}"
 
-  mkdir -p "$DOT_ATOM_DIR"
+  mkdir -p "$ATOM_HOME"
 
   : ${TMPDIR:=/tmp}
 
@@ -88,9 +88,9 @@ elif [ $OS == 'Linux' ]; then
     exit $?
   else
     (
-    nohup "$ATOM_PATH" --executed-from="$(pwd)" --pid=$$ "$@" > "$DOT_ATOM_DIR/nohup.out" 2>&1
+    nohup "$ATOM_PATH" --executed-from="$(pwd)" --pid=$$ "$@" > "$ATOM_HOME/nohup.out" 2>&1
     if [ $? -ne 0 ]; then
-      cat "$DOT_ATOM_DIR/nohup.out"
+      cat "$ATOM_HOME/nohup.out"
       exit $?
     fi
     ) &

--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -100,6 +100,14 @@ namespaces: `core` and `editor`.
 
 You can open this file in an editor from the _Atom > Open Your Config_ menu.
 
+### Custom Configuration Location
+
+You can override the location that Atom stores configuration files and folders
+by setting the `ATOM_HOME` environment variable. The `ATOM_HOME` path will be
+used instead of `~/.atom` when it is set.
+
+This option can be useful when you want to make Atom portable across machines.
+
 ### Configuration Key Reference
 
 - `core`

--- a/docs/customizing-atom.md
+++ b/docs/customizing-atom.md
@@ -103,7 +103,7 @@ You can open this file in an editor from the _Atom > Open Your Config_ menu.
 ### Custom Configuration Location
 
 You can override the location that Atom stores configuration files and folders
-by setting the `ATOM_HOME` environment variable. The `ATOM_HOME` path will be
+in by setting the `ATOM_HOME` environment variable. The `ATOM_HOME` path will be
 used instead of `~/.atom` when it is set.
 
 This option can be useful when you want to make Atom portable across machines.

--- a/src/6to5.coffee
+++ b/src/6to5.coffee
@@ -96,7 +96,7 @@ getCachePath = (sourceCode) ->
 
   unless jsCacheDir?
     to5Version = require('6to5-core/package.json').version
-    cacheDir = path.join(fs.absolute('~/.atom'), 'compile-cache')
+    cacheDir = path.join(process.env.ATOM_HOME, 'compile-cache')
     jsCacheDir = path.join(cacheDir, 'js', '6to5', create6to5VersionAndOptionsDigest(to5Version, defaultOptions))
 
   path.join(jsCacheDir, "#{digest}.js")

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -263,9 +263,6 @@ class Atom extends Model
     # Make react.js faster
     process.env.NODE_ENV ?= 'production' unless devMode
 
-    # Set Atom's home so packages don't have to guess it
-    process.env.ATOM_HOME = configDirPath
-
     @config = new Config({configDirPath, resourcePath})
     @keymaps = new KeymapManager({configDirPath, resourcePath})
     @keymap = @keymaps # Deprecated

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -109,7 +109,7 @@ class Atom extends Model
   #
   # Returns the absolute path to ~/.atom
   @getConfigDirPath: ->
-    @configDirPath ?= fs.absolute('~/.atom')
+    @configDirPath ?= process.env.ATOM_HOME
 
   # Get the path to Atom's storage directory.
   #

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -416,7 +416,7 @@ class AtomApplication
       PackageManager = require '../package-manager'
       fs = require 'fs-plus'
       @packages = new PackageManager
-        configDirPath: fs.absolute('~/.atom')
+        configDirPath: process.env.ATOM_HOME
         devMode: devMode
         resourcePath: @resourcePath
 

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -84,6 +84,7 @@ setupAtomHome = ->
     if SquirrelUpdate.existsSync()
       atomPath = path.join(process.env.LOCALAPPDATA, 'atom').toLowerCase()
       if __dirname.toLowerCase().indexOf(atomPath) isnt 0
+        rootAtomFolder = path.resolve(process.execPath, '..', '..')
         process.env.ATOM_HOME = path.join(rootAtomFolder, '.atom')
         return
 

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -73,6 +73,15 @@ setupCoffeeScript = ->
     js = CoffeeScript.compile(coffee, filename: filePath)
     module._compile(js, filePath)
 
+setupAtomHome = ->
+  return if process.env.ATOM_HOME
+
+  if process.platform is 'win32'
+    home = process.env.USERPROFILE
+  else
+    home = process.env.HOME
+  process.env.ATOM_HOME = path.join(home, '.atom')
+
 parseCommandLine = ->
   version = app.getVersion()
   options = optimist(process.argv[1..])
@@ -149,4 +158,5 @@ parseCommandLine = ->
 
   {resourcePath, pathsToOpen, executedFrom, test, version, pidToKillWhenClosed, devMode, safeMode, newWindow, specDirectory, logFile}
 
+setupAtomHome()
 start()

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -77,8 +77,8 @@ setupCoffeeScript = ->
 setupAtomHome = ->
   return if process.env.ATOM_HOME
 
-  # Use install-relative .atom path on Windows when using the installer version
-  # in a non-default version. This enables an easy portable version.
+  # Use relative .atom path on Windows when using the installer version
+  # in a non-default location. This enables an easy portable version.
   if process.platform is 'win32'
     SquirrelUpdate = require './squirrel-update'
     if SquirrelUpdate.existsSync()

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -81,7 +81,10 @@ setupAtomHome = ->
     home = process.env.USERPROFILE
   else
     home = process.env.HOME
-  process.env.ATOM_HOME = path.join(home, '.atom')
+  atomHome = path.join(home, '.atom')
+  try
+    atomHome = fs.realpathSync(atomHome)
+  process.env.ATOM_HOME = atomHome
 
 parseCommandLine = ->
   version = app.getVersion()

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -14,6 +14,7 @@ process.on 'uncaughtException', (error={}) ->
   nslog(error.stack) if error.stack?
 
 start = ->
+  setupAtomHome()
   if process.platform is 'win32'
     SquirrelUpdate = require './squirrel-update'
     squirrelCommand = process.argv[1]
@@ -75,6 +76,16 @@ setupCoffeeScript = ->
 
 setupAtomHome = ->
   return if process.env.ATOM_HOME
+
+  # Use install-relative .atom path on Windows when using the installer version
+  # in a non-default version. This enables an easy portable version.
+  if process.platform is 'win32'
+    SquirrelUpdate = require './squirrel-update'
+    if SquirrelUpdate.existsSync()
+      atomPath = path.join(process.env.LOCALAPPDATA, 'atom').toLowerCase()
+      if __dirname.toLowerCase().indexOf(atomPath) isnt 0
+        process.env.ATOM_HOME = path.join(rootAtomFolder, '.atom')
+        return
 
   if process.platform is 'win32'
     home = process.env.USERPROFILE
@@ -162,5 +173,4 @@ parseCommandLine = ->
 
   {resourcePath, pathsToOpen, executedFrom, test, version, pidToKillWhenClosed, devMode, safeMode, newWindow, specDirectory, logFile}
 
-setupAtomHome()
 start()

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -98,8 +98,12 @@ parseCommandLine = ->
     opened or a new window if it hasn't.
 
     Environment Variables:
-    ATOM_DEV_RESOURCE_PATH  The path from which Atom loads source code in dev mode.
-                            Defaults to `~/github/atom`.
+
+      ATOM_DEV_RESOURCE_PATH  The path from which Atom loads source code in dev mode.
+                              Defaults to `~/github/atom`.
+
+      ATOM_HOME               The root path for all configuration files and folders.
+                              Default to `~/.atom`.
   """
   options.alias('d', 'dev').boolean('d').describe('d', 'Run in development mode.')
   options.alias('f', 'foreground').boolean('f').describe('f', 'Keep the browser process in the foreground.')

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -77,17 +77,6 @@ setupCoffeeScript = ->
 setupAtomHome = ->
   return if process.env.ATOM_HOME
 
-  # Use relative .atom path on Windows when using the installer version
-  # in a non-default location. This enables an easy portable version.
-  if process.platform is 'win32'
-    SquirrelUpdate = require './squirrel-update'
-    if SquirrelUpdate.existsSync() and process.env.LOCALAPPDATA
-      atomPath = path.join(process.env.LOCALAPPDATA, 'atom').toLowerCase()
-      if __dirname.toLowerCase().indexOf(atomPath) isnt 0
-        rootAtomFolder = path.resolve(process.execPath, '..', '..')
-        process.env.ATOM_HOME = path.join(rootAtomFolder, '.atom')
-        return
-
   if process.platform is 'win32'
     home = process.env.USERPROFILE
   else

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -81,7 +81,7 @@ setupAtomHome = ->
   # in a non-default location. This enables an easy portable version.
   if process.platform is 'win32'
     SquirrelUpdate = require './squirrel-update'
-    if SquirrelUpdate.existsSync()
+    if SquirrelUpdate.existsSync() and process.env.LOCALAPPDATA
       atomPath = path.join(process.env.LOCALAPPDATA, 'atom').toLowerCase()
       if __dirname.toLowerCase().indexOf(atomPath) isnt 0
         rootAtomFolder = path.resolve(process.execPath, '..', '..')

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -103,7 +103,7 @@ parseCommandLine = ->
                               Defaults to `~/github/atom`.
 
       ATOM_HOME               The root path for all configuration files and folders.
-                              Default to `~/.atom`.
+                              Defaults to `~/.atom`.
   """
   options.alias('d', 'dev').boolean('d').describe('d', 'Run in development mode.')
   options.alias('f', 'foreground').boolean('f').describe('f', 'Keep the browser process in the foreground.')

--- a/src/coffee-cache.coffee
+++ b/src/coffee-cache.coffee
@@ -5,7 +5,7 @@ CoffeeScript = require 'coffee-script'
 CSON = require 'season'
 fs = require 'fs-plus'
 
-cacheDir = path.join(fs.absolute('~/.atom'), 'compile-cache')
+cacheDir = path.join(process.env.ATOM_HOME, 'compile-cache')
 
 stats =
   hits: 0

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -1,13 +1,10 @@
 path = require 'path'
 fs = require 'fs-plus'
 LessCache = require 'less-cache'
-{Subscriber} = require 'emissary'
 
 # {LessCache} wrapper used by {ThemeManager} to read stylesheets.
 module.exports =
 class LessCompileCache
-  Subscriber.includeInto(this)
-
   @cacheDir: path.join(process.env.ATOM_HOME, 'compile-cache', 'less')
 
   constructor: ({resourcePath, importPaths}) ->
@@ -35,5 +32,3 @@ class LessCompileCache
 
   cssForFile: (stylesheetPath, lessContent) ->
     @cache.cssForFile(stylesheetPath, lessContent)
-
-  destroy: -> @unsubscribe()

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -1,5 +1,4 @@
 path = require 'path'
-fs = require 'fs-plus'
 LessCache = require 'less-cache'
 
 # {LessCache} wrapper used by {ThemeManager} to read stylesheets.

--- a/src/less-compile-cache.coffee
+++ b/src/less-compile-cache.coffee
@@ -8,7 +8,7 @@ module.exports =
 class LessCompileCache
   Subscriber.includeInto(this)
 
-  @cacheDir: path.join(require('./coffee-cache').cacheDir, 'less')
+  @cacheDir: path.join(process.env.ATOM_HOME, 'compile-cache', 'less')
 
   constructor: ({resourcePath, importPaths}) ->
     @lessSearchPaths = [


### PR DESCRIPTION
This PR unifies all references to use the `ATOM_HOME` environment variable as the location to store packages, compile caches, node headers, etc.

The location still defaults to `~/.atom` when unset.

This should make Atom portable meaning it will write no files outside this location.

Closes #2939
