### PR TITLE
Reverted atom.desktop.in

### DIFF
--- a/resources/linux/atom.desktop.in
+++ b/resources/linux/atom.desktop.in
@@ -2,7 +2,7 @@
 Name=Atom
 Comment=<%= description %>
 GenericName=Text Editor
-Exec=atom %U
+Exec=<%= installDir %>/share/atom/atom %U
 Icon=<%= iconName %>
 Type=Application
 StartupNotify=true


### PR DESCRIPTION
I realize the debian package build depends on this. Although it
probably won't break anything, I would rather implement a solution
that doesn't change the behavior of the debian installer.
