### PR TITLE
Let Linux packages fully determine executable path

### DIFF
--- a/build/tasks/mkdeb-task.coffee
+++ b/build/tasks/mkdeb-task.coffee
@@ -36,8 +36,9 @@ module.exports = (grunt) ->
     maintainer = 'GitHub <atom@github.com>'
     installDir = '/usr'
     iconName = 'atom'
+    executable = path.join(installDir, 'share', 'atom', 'atom')
     getInstalledSize buildDir, (error, installedSize) ->
-      data = {name, version, description, section, arch, maintainer, installDir, iconName, installedSize}
+      data = {name, version, description, section, arch, maintainer, installDir, iconName, installedSize, executable}
       controlFilePath = fillTemplate(path.join('resources', 'linux', 'debian', 'control'), data)
       desktopFilePath = fillTemplate(path.join('resources', 'linux', 'atom.desktop'), data)
       icon = path.join('resources', 'atom.png')

--- a/build/tasks/mkrpm-task.coffee
+++ b/build/tasks/mkrpm-task.coffee
@@ -33,7 +33,7 @@ module.exports = (grunt) ->
     installDir = grunt.config.get('atom.installDir')
     shareDir = path.join(installDir, 'share', 'atom')
     iconName = path.join(shareDir, 'resources', 'app', 'resources', 'atom.png')
-    executable = path.join(shareDir, 'atom')
+    executable = 'atom'
 
     data = {name, version, description, installDir, iconName, executable}
     specFilePath = fillTemplate(path.join('resources', 'linux', 'redhat', 'atom.spec'), data)

--- a/build/tasks/mkrpm-task.coffee
+++ b/build/tasks/mkrpm-task.coffee
@@ -33,8 +33,9 @@ module.exports = (grunt) ->
     installDir = grunt.config.get('atom.installDir')
     shareDir = path.join(installDir, 'share', 'atom')
     iconName = path.join(shareDir, 'resources', 'app', 'resources', 'atom.png')
+    executable = path.join(shareDir, 'atom')
 
-    data = {name, version, description, installDir, iconName}
+    data = {name, version, description, installDir, iconName, executable}
     specFilePath = fillTemplate(path.join('resources', 'linux', 'redhat', 'atom.spec'), data)
     desktopFilePath = fillTemplate(path.join('resources', 'linux', 'atom.desktop'), data)
 

--- a/resources/linux/atom.desktop.in
+++ b/resources/linux/atom.desktop.in
@@ -2,7 +2,7 @@
 Name=Atom
 Comment=<%= description %>
 GenericName=Text Editor
-Exec=<%= installDir %>/share/atom/atom %U
+Exec=<%= executable %> %U
 Icon=<%= iconName %>
 Type=Application
 StartupNotify=true


### PR DESCRIPTION
:penguin: It is no longer hard coded into the atom.desktop.in file; the individual grunt tasks now determine how the executable path is built and accessed.
