### PR TITLE
Add integration test to cover browser-side code

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -222,7 +222,7 @@ module.exports = (grunt) ->
   grunt.registerTask('test', ['shell:kill-atom', 'run-specs'])
   grunt.registerTask('docs', ['markdown:guides', 'build-docs'])
 
-  ciTasks = ['output-disk-space', 'download-atom-shell', 'build']
+  ciTasks = ['output-disk-space', 'download-atom-shell', 'download-atom-shell-chromedriver', 'build']
   ciTasks.push('dump-symbols') if process.platform isnt 'win32'
   ciTasks.push('set-version', 'check-licenses', 'lint')
   ciTasks.push('mkdeb') if process.platform is 'linux'
@@ -232,6 +232,6 @@ module.exports = (grunt) ->
   ciTasks.push('publish-build')
   grunt.registerTask('ci', ciTasks)
 
-  defaultTasks = ['download-atom-shell', 'build', 'set-version']
+  defaultTasks = ['download-atom-shell', 'download-atom-shell-chromedriver', 'build', 'set-version']
   defaultTasks.push 'install' unless process.platform is 'linux'
   grunt.registerTask('default', defaultTasks)

--- a/build/package.json
+++ b/build/package.json
@@ -19,7 +19,7 @@
     "grunt-contrib-csslint": "~0.1.2",
     "grunt-contrib-less": "~0.8.0",
     "grunt-cson": "0.14.0",
-    "grunt-download-atom-shell": "~0.11.0",
+    "grunt-download-atom-shell": "~0.12.0",
     "grunt-lesslint": "0.13.0",
     "grunt-peg": "~1.1.0",
     "grunt-shell": "~0.3.1",

--- a/build/package.json
+++ b/build/package.json
@@ -31,11 +31,11 @@
     "request": "~2.27.0",
     "rimraf": "~2.2.2",
     "runas": "~1.0.1",
-    "selenium-webdriver": "^2.44.0",
     "tello": "1.0.4",
     "temp": "~0.8.1",
     "underscore-plus": "1.x",
     "unzip": "~0.1.9",
-    "vm-compatibility-layer": "~0.1.0"
+    "vm-compatibility-layer": "~0.1.0",
+    "webdriverio": "^2.4.5"
   }
 }

--- a/build/package.json
+++ b/build/package.json
@@ -31,6 +31,7 @@
     "request": "~2.27.0",
     "rimraf": "~2.2.2",
     "runas": "~1.0.1",
+    "selenium-webdriver": "^2.44.0",
     "tello": "1.0.4",
     "temp": "~0.8.1",
     "underscore-plus": "1.x",

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -85,15 +85,27 @@ module.exports = (grunt) ->
     appPath = getAppPath()
     resourcePath = process.cwd()
     coreSpecsPath = path.resolve('spec')
+    chromedriverPath = path.join(resourcePath, "atom-shell", "chromedriver")
 
     if process.platform in ['darwin', 'linux']
       options =
         cmd: appPath
         args: ['--test', "--resource-path=#{resourcePath}", "--spec-directory=#{coreSpecsPath}"]
+        opts:
+          env: _.extend({}, process.env,
+            ATOM_INTEGRATION_TESTS_ENABLED: true
+            PATH: [process.env.path, chromedriverPath].join(":")
+          )
+
     else if process.platform is 'win32'
       options =
         cmd: process.env.comspec
         args: ['/c', appPath, '--test', "--resource-path=#{resourcePath}", "--spec-directory=#{coreSpecsPath}", "--log-file=ci.log"]
+        opts:
+          env: _.extend({}, process.env,
+            ATOM_INTEGRATION_TESTS_ENABLED: true
+            PATH: [process.env.path, chromedriverPath].join(";")
+          )
 
     spawn options, (error, results, code) ->
       if process.platform is 'win32'

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "scoped-property-store": "^0.16.2",
     "scrollbar-style": "^2.0.0",
     "season": "^5.1.2",
+    "selenium-webdriver": "^2.44.0",
     "semver": "2.2.1",
     "serializable": "^1",
     "service-hub": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "scoped-property-store": "^0.16.2",
     "scrollbar-style": "^2.0.0",
     "season": "^5.1.2",
-    "selenium-webdriver": "^2.44.0",
     "semver": "2.2.1",
     "serializable": "^1",
     "service-hub": "^0.2.0",

--- a/spec/integration/fixtures/atom-home/config.cson
+++ b/spec/integration/fixtures/atom-home/config.cson
@@ -1,0 +1,5 @@
+"*":
+  welcome:
+    showOnStartup: false
+  "exception-reporting":
+    userId: "7c0a3c52-795c-5e20-5323-64efcf91f212"

--- a/spec/integration/helpers/atom-launcher.sh
+++ b/spec/integration/helpers/atom-launcher.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This script wraps the `Atom` binary, allowing the `chromedriver` server to
+# execute it with positional arguments. `chromedriver` only allows 'switches'
+# to be specified when starting a browser, not positional arguments, so this
+# script accepts two special switches:
+#
+# * `atom-path` The path to the `Atom` binary
+# * `atom-args` A space-separated list of positional arguments to pass to Atom.
+#
+# Any other switches will be passed through to `Atom`.
+
+atom_path=""
+atom_switches=()
+atom_args=()
+
+for arg in "$@"; do
+  case $arg in
+    --atom-path=*)
+      atom_path="${arg#*=}"
+      ;;
+
+    --atom-args=*)
+      atom_args_string="${arg#*=}"
+      for atom_arg in $atom_args_string; do
+        atom_args+=($atom_arg)
+      done
+      ;;
+
+    *)
+      atom_switches+=($arg)
+      ;;
+  esac
+done
+
+exec $atom_path "${atom_switches[@]}" "${atom_args[@]}"

--- a/spec/integration/helpers/atom-launcher.sh
+++ b/spec/integration/helpers/atom-launcher.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
 # This script wraps the `Atom` binary, allowing the `chromedriver` server to
-# execute it with positional arguments. `chromedriver` only allows 'switches'
-# to be specified when starting a browser, not positional arguments, so this
-# script accepts two special switches:
+# execute it with positional arguments and environment variables. `chromedriver`
+# only allows 'switches' to be specified when starting a browser, not positional
+# arguments, so this script accepts the following special switches:
 #
-# * `atom-path` The path to the `Atom` binary
-# * `atom-args` A space-separated list of positional arguments to pass to Atom.
+# * `atom-path`: The path to the `Atom` binary.
+# * `atom-arg`:  A positional argument to pass to Atom. This flag can be specified
+#                multiple times.
+# * `atom-env`:  A key=value environment variable to set for Atom. This flag can
+#                be specified multiple times.
 #
 # Any other switches will be passed through to `Atom`.
 
@@ -20,11 +23,12 @@ for arg in "$@"; do
       atom_path="${arg#*=}"
       ;;
 
-    --atom-args=*)
-      atom_args_string="${arg#*=}"
-      for atom_arg in $atom_args_string; do
-        atom_args+=($atom_arg)
-      done
+    --atom-arg=*)
+      atom_args+=(${arg#*=})
+      ;;
+
+    --atom-env=*)
+      export ${arg#*=}
       ;;
 
     *)
@@ -33,4 +37,7 @@ for arg in "$@"; do
   esac
 done
 
-exec $atom_path "${atom_switches[@]}" "${atom_args[@]}"
+echo "Launching Atom" >&2
+echo ${atom_path} ${atom_args[@]} ${atom_switches[@]} >&2
+
+exec ${atom_path} ${atom_args[@]} ${atom_switches[@]}

--- a/spec/integration/helpers/start-atom.coffee
+++ b/spec/integration/helpers/start-atom.coffee
@@ -1,4 +1,3 @@
-os = require "os"
 path = require "path"
 temp = require("temp").track()
 remote = require "remote"
@@ -9,7 +8,7 @@ async = require "async"
 
 AtomPath = remote.process.argv[0]
 AtomLauncherPath = path.join(__dirname, "..", "helpers", "atom-launcher.sh")
-SocketPath = path.join(os.tmpdir(), "atom-integration-test.sock")
+SocketPath = path.join(temp.mkdirSync("socket-dir"), "atom.sock")
 ChromedriverPort = 9515
 
 module.exports =

--- a/spec/integration/helpers/start-atom.coffee
+++ b/spec/integration/helpers/start-atom.coffee
@@ -1,0 +1,86 @@
+os = require "os"
+path = require "path"
+temp = require("temp").track()
+remote = require "remote"
+{spawn, spawnSync} = require "child_process"
+webdriverio = require "../../../build/node_modules/webdriverio"
+async = require "async"
+
+AtomPath = remote.process.argv[0]
+AtomLauncherPath = path.join(__dirname, "..", "helpers", "atom-launcher.sh")
+SocketPath = path.join(os.tmpdir(), "atom-integration-test.sock")
+ChromedriverPort = 9515
+
+module.exports =
+  driverTest: (fn) ->
+    chromedriver = spawn("chromedriver", [
+      "--verbose",
+      "--port=#{ChromedriverPort}",
+      "--url-base=/wd/hub"
+    ])
+
+    logs = []
+    errorCode = null
+    chromedriver.on "exit", (code, signal) ->
+      errorCode = code unless signal?
+    chromedriver.stderr.on "data", (log) ->
+      logs.push(log.toString())
+    chromedriver.stderr.on "close", ->
+      if errorCode?
+        jasmine.getEnv().currentSpec.fail "Chromedriver exited. code: #{errorCode}. Logs: #{logs.join("\n")}"
+
+    waitsFor "webdriver steps to complete", (done) ->
+      fn()
+        .catch((error) -> jasmine.getEnv().currentSpec.fail(err.message))
+        .end()
+        .call(done)
+    , 30000
+
+    runs -> chromedriver.kill()
+
+  # Start Atom using chromedriver.
+  startAtom: (args...) ->
+    webdriverio.remote(
+      host: 'localhost'
+      port: ChromedriverPort
+      desiredCapabilities:
+        browserName: "atom"
+        chromeOptions:
+          binary: AtomLauncherPath
+          args: [
+            "atom-path=#{AtomPath}"
+            "atom-args=#{args.join(" ")}"
+            "dev"
+            "safe"
+            "user-data-dir=#{temp.mkdirSync('integration-spec-')}"
+            "socket-path=#{SocketPath}"
+          ])
+      .init()
+      .addCommand "waitForCondition", (conditionFn, timeout, cb) ->
+        timedOut = succeeded = false
+        pollingInterval = Math.min(timeout, 100)
+
+        setTimeout((-> timedOut = true), timeout)
+
+        async.until(
+          (-> succeeded or timedOut),
+          ((next) =>
+            setTimeout(=>
+              conditionFn.call(this).then(
+                ((result) ->
+                  succeeded = result
+                  next()),
+                ((err) -> next(err))
+              )
+            , pollingInterval)),
+          ((err) -> cb(err, succeeded))
+        )
+
+  # Once one `Atom` window is open, subsequent invocations of `Atom` will exit
+  # immediately.
+  startAnotherAtom: (args...) ->
+    spawnSync(AtomPath, args.concat([
+      "--dev",
+      "--safe",
+      "--socket-path=#{SocketPath}"
+    ]))

--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -6,6 +6,7 @@ return unless process.env.ATOM_INTEGRATION_TESTS_ENABLED
 fs = require "fs"
 path = require "path"
 temp = require("temp").track()
+AtomHome = path.join(__dirname, "fixtures", "atom-home")
 {startAtom, startAnotherAtom, driverTest} = require("./helpers/start-atom")
 
 describe "Starting Atom", ->
@@ -24,7 +25,7 @@ describe "Starting Atom", ->
       driverTest ->
 
         # Opening a new file creates one window with one empty text editor.
-        startAtom(path.join(tempDirPath, "new-file"))
+        startAtom([path.join(tempDirPath, "new-file")], ATOM_HOME: AtomHome)
           .waitForExist("atom-text-editor", 5000)
           .then((exists) -> expect(exists).toBe true)
           .windowHandles()
@@ -42,7 +43,7 @@ describe "Starting Atom", ->
 
           # Opening an existing file in the same directory reuses the window and
           # adds a new tab for the file.
-          .call(-> startAnotherAtom(tempFilePath))
+          .call(-> startAnotherAtom([tempFilePath], ATOM_HOME: AtomHome))
           .waitForCondition(
             (-> @execute((-> atom.workspace.getActivePane().getItems().length)).then ({value}) -> value is 2),
             5000)
@@ -52,7 +53,7 @@ describe "Starting Atom", ->
 
           # Opening a different directory creates a second window with no
           # tabs open.
-          .call(-> startAnotherAtom(temp.mkdirSync("another-empty-dir")))
+          .call(-> startAnotherAtom([temp.mkdirSync("another-empty-dir")], ATOM_HOME: AtomHome))
           .waitForCondition(
             (-> @windowHandles().then(({value}) -> value.length is 2)),
             5000)

--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -26,7 +26,7 @@ describe "Starting Atom", ->
       chromeDriver = spawn "chromedriver", ["--verbose", "--port=#{ChromeDriverPort}"]
       chromeDriver.on "error", (error) ->
         throw new Error("chromedriver failed to start: #{error.message}")
-      chromeDriver.stderr.on "data", -> done()
+      chromeDriver.stdout.on "data", -> done()
 
   afterEach ->
     waitsForPromise -> driver.quit().thenFinally(-> chromeDriver.kill())

--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -28,7 +28,7 @@ describe "Starting Atom", ->
   afterEach ->
     waitsForPromise -> driver.quit().thenFinally(-> chromeDriver.kill())
 
-  startAtom = (args=[]) ->
+  startAtom = (args...) ->
     driver = new Builder()
       .usingServer("http://localhost:#{ChromeDriverPort}")
       .withCapabilities(
@@ -50,7 +50,7 @@ describe "Starting Atom", ->
       driver.wait ->
         driver.getTitle().then (title) -> title.indexOf("Atom") >= 0
 
-  startAnotherAtom = (args=[]) ->
+  startAnotherAtom = (args...) ->
     spawnSync(AtomPath, args.concat([
       "--dev",
       "--safe",
@@ -63,7 +63,7 @@ describe "Starting Atom", ->
     beforeEach ->
       tempFilePath = path.join(tempDirPath, "an-existing-file")
       fs.writeFileSync(tempFilePath, "This was already here.")
-      startAtom([path.join(tempDirPath, "new-file")])
+      startAtom(path.join(tempDirPath, "new-file"))
 
     it "opens a new window with an empty text editor", ->
       waitsForPromise ->
@@ -80,7 +80,7 @@ describe "Starting Atom", ->
       # Opening another existing file in the same directory reuses the window,
       # and opens a new tab for the file.
       waitsForPromise ->
-        startAnotherAtom([tempFilePath])
+        startAnotherAtom(tempFilePath)
         driver.wait ->
           driver.executeScript(-> atom.workspace.getActivePane().getItems().length).then (length) ->
             length is 2
@@ -89,14 +89,14 @@ describe "Starting Atom", ->
 
       # Opening a different directory creates a new window.
       waitsForPromise ->
-        startAnotherAtom([temp.mkdirSync("another-empty-dir")])
+        startAnotherAtom(temp.mkdirSync("another-empty-dir"))
         driver.wait ->
           driver.getAllWindowHandles().then (handles) ->
             handles.length is 2
 
   describe "when given the name of a directory that exists", ->
     beforeEach ->
-      startAtom([tempDirPath])
+      startAtom(tempDirPath)
 
     it "opens a new window no text editors open", ->
       waitsForPromise ->

--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -12,7 +12,7 @@ SocketPath = path.join(os.tmpdir(), "atom-integration-test.sock")
 ChromeDriverPort = 9515
 
 describe "Starting Atom", ->
-  if spawnSync("type", ["-P", "chromedriver"]).status isnt 0
+  if spawnSync("which", ["chromedriver"]).status isnt 0
     console.log "Skipping integration tests because the `chromedriver` executable was not found."
     return
 

--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -4,7 +4,7 @@ path = require "path"
 remote = require "remote"
 temp = require("temp").track()
 {spawn, spawnSync} = require "child_process"
-{Builder, By} = require("selenium-webdriver")
+{Builder, By} = require "../../build/node_modules/selenium-webdriver"
 
 AtomPath = remote.process.argv[0]
 AtomLauncherPath = path.join(__dirname, "helpers", "atom-launcher.sh")

--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -1,0 +1,85 @@
+os = require "os"
+fs = require "fs"
+path = require "path"
+remote = require "remote"
+temp = require("temp").track()
+{spawn, spawnSync} = require "child_process"
+{Builder, By} = require("selenium-webdriver")
+
+AtomPath = remote.process.argv[0]
+AtomLauncherPath = path.join(__dirname, "helpers", "atom-launcher.sh")
+SocketPath = path.join(os.tmpdir(), "atom-integration-test.sock")
+ChromeDriverPort = 9515
+
+describe "Starting Atom", ->
+  if spawnSync("type", ["-P", "chromedriver"]).status isnt 0
+    console.log "Skipping integration tests because the `chromedriver` executable was not found."
+    return
+
+  [chromeDriver, driver, tempDirPath] = []
+
+  beforeEach ->
+    tempDirPath = temp.mkdirSync("empty-dir")
+    chromeDriver = spawn "chromedriver", ["--verbose", "--port=#{ChromeDriverPort}"]
+
+    # Uncomment to see chromedriver debug output
+    # chromeDriver.stderr.on "data", (d) -> console.log(d.toString())
+
+  afterEach ->
+    waitsForPromise -> driver.quit().thenFinally(-> chromeDriver.kill())
+
+  startAtom = (args=[]) ->
+    driver = new Builder()
+      .usingServer("http://localhost:#{ChromeDriverPort}")
+      .withCapabilities(
+        chromeOptions:
+          binary: AtomLauncherPath
+          args: [
+            "atom-path=#{AtomPath}"
+            "atom-args=#{args.join(" ")}"
+            "dev"
+            "safe"
+            "user-data-dir=#{temp.mkdirSync('integration-spec-')}"
+            "socket-path=#{SocketPath}"
+          ]
+      )
+      .forBrowser('atom')
+      .build()
+
+    waitsForPromise ->
+      driver.wait ->
+        driver.getTitle().then (title) -> title.indexOf("Atom") >= 0
+
+  describe "when given the name of a file that doesn't exist", ->
+    beforeEach ->
+      startAtom([path.join(tempDirPath, "new-file")])
+
+    it "opens a new window with an empty text editor", ->
+      waitsForPromise ->
+        driver.executeScript(-> atom.workspace.getActiveTextEditor().getText()).then (text) ->
+          expect(text).toBe("")
+
+        driver.findElement(By.tagName("atom-text-editor")).sendKeys("Hello world!")
+
+        driver.executeScript(-> atom.workspace.getActiveTextEditor().getText()).then (text) ->
+          expect(text).toBe("Hello world!")
+
+  describe "when given the name of a file that exists", ->
+    beforeEach ->
+      existingFilePath = path.join(tempDirPath, "existing-file")
+      fs.writeFileSync(existingFilePath, "This was already here.")
+      startAtom([existingFilePath])
+
+    it "opens a new window with a text editor for the given file", ->
+      waitsForPromise ->
+        driver.executeScript(-> atom.workspace.getActiveTextEditor().getText()).then (text) ->
+          expect(text).toBe("This was already here.")
+
+  describe "when given the name of a directory that exists", ->
+    beforeEach ->
+      startAtom([tempDirPath])
+
+    it "opens a new window no text editors open", ->
+      waitsForPromise ->
+        driver.executeScript(-> atom.workspace.getActiveTextEditor()).then (editor) ->
+          expect(editor).toBeNull()

--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -50,30 +50,49 @@ describe "Starting Atom", ->
       driver.wait ->
         driver.getTitle().then (title) -> title.indexOf("Atom") >= 0
 
+  startAnotherAtom = (args=[]) ->
+    spawnSync(AtomPath, args.concat([
+      "--dev",
+      "--safe",
+      "--socket-path=#{SocketPath}"
+    ]))
+
   describe "when given the name of a file that doesn't exist", ->
+    tempFilePath = null
+
     beforeEach ->
+      tempFilePath = path.join(tempDirPath, "an-existing-file")
+      fs.writeFileSync(tempFilePath, "This was already here.")
       startAtom([path.join(tempDirPath, "new-file")])
 
     it "opens a new window with an empty text editor", ->
       waitsForPromise ->
+        driver.getAllWindowHandles().then (handles) ->
+          expect(handles.length).toBe 1
+        driver.executeScript(-> atom.workspace.getActivePane().getItems().length).then (length) ->
+          expect(length).toBe 1
         driver.executeScript(-> atom.workspace.getActiveTextEditor().getText()).then (text) ->
           expect(text).toBe("")
-
         driver.findElement(By.tagName("atom-text-editor")).sendKeys("Hello world!")
-
         driver.executeScript(-> atom.workspace.getActiveTextEditor().getText()).then (text) ->
-          expect(text).toBe("Hello world!")
+          expect(text).toBe "Hello world!"
 
-  describe "when given the name of a file that exists", ->
-    beforeEach ->
-      existingFilePath = path.join(tempDirPath, "existing-file")
-      fs.writeFileSync(existingFilePath, "This was already here.")
-      startAtom([existingFilePath])
-
-    it "opens a new window with a text editor for the given file", ->
+      # Opening another existing file in the same directory reuses the window,
+      # and opens a new tab for the file.
       waitsForPromise ->
+        startAnotherAtom([tempFilePath])
+        driver.wait ->
+          driver.executeScript(-> atom.workspace.getActivePane().getItems().length).then (length) ->
+            length is 2
         driver.executeScript(-> atom.workspace.getActiveTextEditor().getText()).then (text) ->
-          expect(text).toBe("This was already here.")
+          expect(text).toBe "This was already here."
+
+      # Opening a different directory creates a new window.
+      waitsForPromise ->
+        startAnotherAtom([temp.mkdirSync("another-empty-dir")])
+        driver.wait ->
+          driver.getAllWindowHandles().then (handles) ->
+            handles.length is 2
 
   describe "when given the name of a directory that exists", ->
     beforeEach ->

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -305,13 +305,13 @@ window.waitsForPromise = (args...) ->
   window.waitsFor timeout, (moveOn) ->
     promise = fn()
     if shouldReject
-      promise.catch(moveOn)
+      (promise.catch ? promise.thenCatch).call(promise, moveOn)
       promise.then ->
         jasmine.getEnv().currentSpec.fail("Expected promise to be rejected, but it was resolved")
         moveOn()
     else
       promise.then(moveOn)
-      promise.catch (error) ->
+      (promise.catch ? promise.thenCatch).call promise, (error) ->
         jasmine.getEnv().currentSpec.fail("Expected promise to be resolved, but it was rejected with #{jasmine.pp(error)}")
         moveOn()
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -14,7 +14,7 @@ url = require 'url'
 {EventEmitter} = require 'events'
 _ = require 'underscore-plus'
 
-socketPath =
+DEFAULT_SOCKET_PATH =
   if process.platform is 'win32'
     '\\\\.\\pipe\\atom-sock'
   else
@@ -31,17 +31,20 @@ class AtomApplication
 
   # Public: The entry point into the Atom application.
   @open: (options) ->
+    options.socketPath ?= DEFAULT_SOCKET_PATH
+
     createAtomApplication = -> new AtomApplication(options)
 
     # FIXME: Sometimes when socketPath doesn't exist, net.connect would strangely
     # take a few seconds to trigger 'error' event, it could be a bug of node
     # or atom-shell, before it's fixed we check the existence of socketPath to
     # speedup startup.
-    if (process.platform isnt 'win32' and not fs.existsSync socketPath) or options.test
+    if (process.platform isnt 'win32' and not fs.existsSync options.socketPath) or options.test
       createAtomApplication()
       return
 
-    client = net.connect {path: socketPath}, ->
+
+    client = net.connect {path: options.socketPath}, ->
       client.write JSON.stringify(options), ->
         client.end()
         app.terminate()
@@ -57,7 +60,7 @@ class AtomApplication
   exit: (status) -> app.exit(status)
 
   constructor: (options) ->
-    {@resourcePath, @version, @devMode, @safeMode} = options
+    {@resourcePath, @version, @devMode, @safeMode, @socketPath} = options
 
     # Normalize to make sure drive letter case is consistent on Windows
     @resourcePath = path.normalize(@resourcePath) if @resourcePath
@@ -119,15 +122,15 @@ class AtomApplication
       connection.on 'data', (data) =>
         @openWithOptions(JSON.parse(data))
 
-    server.listen socketPath
+    server.listen @socketPath
     server.on 'error', (error) -> console.error 'Application server failed', error
 
   deleteSocketFile: ->
     return if process.platform is 'win32'
 
-    if fs.existsSync(socketPath)
+    if fs.existsSync(@socketPath)
       try
-        fs.unlinkSync(socketPath)
+        fs.unlinkSync(@socketPath)
       catch error
         # Ignore ENOENT errors in case the file was deleted between the exists
         # check and the call to unlink sync. This occurred occasionally on CI

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -14,7 +14,7 @@ url = require 'url'
 {EventEmitter} = require 'events'
 _ = require 'underscore-plus'
 
-DEFAULT_SOCKET_PATH =
+DefaultSocketPath =
   if process.platform is 'win32'
     '\\\\.\\pipe\\atom-sock'
   else
@@ -31,7 +31,7 @@ class AtomApplication
 
   # Public: The entry point into the Atom application.
   @open: (options) ->
-    options.socketPath ?= DEFAULT_SOCKET_PATH
+    options.socketPath ?= DefaultSocketPath
 
     createAtomApplication = -> new AtomApplication(options)
 

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -120,6 +120,7 @@ parseCommandLine = ->
   options.alias('t', 'test').boolean('t').describe('t', 'Run the specified specs and exit with error code on failures.')
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')
   options.alias('w', 'wait').boolean('w').describe('w', 'Wait for window to be closed before returning.')
+  options.string('socket-path')
   args = options.argv
 
   if args.help
@@ -140,6 +141,7 @@ parseCommandLine = ->
   newWindow = args['new-window']
   pidToKillWhenClosed = args['pid'] if args['wait']
   logFile = args['log-file']
+  socketPath = args['socket-path']
 
   if args['resource-path']
     devMode = true
@@ -164,6 +166,6 @@ parseCommandLine = ->
   # explicitly pass it by command line, see http://git.io/YC8_Ew.
   process.env.PATH = args['path-environment'] if args['path-environment']
 
-  {resourcePath, pathsToOpen, executedFrom, test, version, pidToKillWhenClosed, devMode, safeMode, newWindow, specDirectory, logFile}
+  {resourcePath, pathsToOpen, executedFrom, test, version, pidToKillWhenClosed, devMode, safeMode, newWindow, specDirectory, logFile, socketPath}
 
 start()


### PR DESCRIPTION
This adds an integration test, `spec/integration/startup-spec.coffee` that tests Atom's handling of different command-line arguments. Currently, only a few simple cases are tested.

Questions:
- [x] Currently, `selenium-webdriver` has been added to the `dependencies`. We probably shouldn't require this module to be installed unless the user is running tests. Can we use `devDependencies`? _Moved the dependency to build/package.json_
- [x] Currently, the tests are skipped if `chromedriver` is not installed. Should we install `chromedriver` on CI? _We won't need to if we download it as part of the build; see below_
- [x] Should this test live in a separate suite so that it isn't run by default. The integration tests take about 14 seconds to run on my macbook pro. _Yes_
- [x] Is this even a good idea? I feel like something along these lines will help us in the future when developing the browser-side code. _Yes_
- [x] Make integration specs runnable separately from the main spec suite
  - [x] Make the integration specs _not_ run as part of the normal spec suite
  - [x] Make build script download `chromedriver` to the same location as `Atom.app`
  - [x] Make `run-specs` grunt task run the integration tests
  - [x] Publish new `grunt-download-atom-shell` version and upgrade it in atom
- [x] Fix the tests' flakiness

/cc @atom/core 
