### PR TITLE
Add language-csharp to core packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "language-c": "0.38.0",
     "language-clojure": "0.10.0",
     "language-coffee-script": "0.39.0",
+    "language-csharp": "0.4.0",
     "language-css": "0.27.0",
     "language-gfm": "0.63.0",
     "language-git": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "language-c": "0.38.0",
     "language-clojure": "0.10.0",
     "language-coffee-script": "0.39.0",
-    "language-csharp": "0.4.0",
+    "language-csharp": "0.5.0",
     "language-css": "0.27.0",
     "language-gfm": "0.63.0",
     "language-git": "0.10.0",


### PR DESCRIPTION
C# is a pretty mainstream language to leave out of core. I think it at least meets the bar set by inclusion of language-clojure, language-mustache etc.
