### PR TITLE
fix onWillDispatch asymmetry

### DIFF
--- a/src/command-registry.coffee
+++ b/src/command-registry.coffee
@@ -174,6 +174,9 @@ class CommandRegistry
 
   onWillDispatch: (callback) ->
     @emitter.on 'will-dispatch', callback
+  
+  onDidDispatch: (callback) ->
+    @emitter.on 'did-dispatch', callback
 
   getSnapshot: ->
     snapshot = {}
@@ -223,6 +226,7 @@ class CommandRegistry
       for listener in listeners
         break if immediatePropagationStopped
         listener.callback.call(currentTarget, syntheticEvent)
+        @emitter.emit 'did-dispatch', syntheticEvent
 
       break if currentTarget is window
       break if propagationStopped


### PR DESCRIPTION
This PR come coupled with two questions for the core team. The first is `CommandRegistry::onWillDispatch` is undocumented, so does that mean it is either not a part of the public API, or soon to be deprecated? If so then please ignore this proposal. The second question, assuming this method is meant to be public, is doesn't it make sense to have a matching `::onDidDispatch`? I have a particular use case for this event. I'm currently writing a terminal emulator for Atom, and in it I'm defining a special `atom` builtin. It is essentially a small wrapper around `atom.commands.dispatch` that allows a user to send commands directly to atom via the command line. It works great, except that after the command has executed, my input element loses focus. This hook would allow me to do something like:

``` coffeescript
atom.commands.onDidDispatch -> document.querySelector('#quantum-shell-input').focus()
```

to return focus to my package after the command has executed.
