### PR TITLE
Fix atom engine semver in upgrading docs

### DIFF
--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -63,7 +63,7 @@ When you are deprecation free and all done converting, upgrade the `engines` fie
 ```json
 {
   "engines": {
-    "atom": ">=0.174.0, <2.0.0"
+    "atom": ">=0.174.0 <2.0.0"
   }
 }
 ```


### PR DESCRIPTION
This :trollface: me on two of my pacakges, as described in [this comment](https://github.com/izuzak/atom-pdf-view/issues/45#issuecomment-72206548).

apm uses `semver.validRange` to [determine if the semver of `engines.atom` is valid](https://github.com/atom/apm/blob/94d2dd96114cbbefc52ad728f5ec870d6d3ce4c6/src/install.coffee#L508), and if it isn't -- it skips that version of the package. Here's how that behaves for the recommended semver in the guide:

```
> semver.validRange(">=0.174.0, <2.0.0")

null
```

Here's how it behaves with the change suggested in this PR:

```
> semver.validRange(">=0.174.0 <2.0.0")

'>=0.174.0 <2.0.0'
```

Also, the range works as expected when testing whether a version is in that range:

```
> semver.satisfies("0.178.0", ">=0.174.0 <2.0.0")
true
> semver.satisfies("2.178.0", ">=0.174.0 <2.0.0")
false
> semver.satisfies("0.174.0", ">=0.174.0 <2.0.0")
true
> semver.satisfies("0.173.0", ">=0.174.0 <2.0.0")
false
```

As far as I can tell, this is also how ranges are explained in [`node-semver`](https://github.com/npm/node-semver#ranges).

cc @benogle
