### PR TITLE
Introduce ProjectRoot.

### DIFF
--- a/src/project-root.coffee
+++ b/src/project-root.coffee
@@ -1,0 +1,20 @@
+# A root folder of {Project}.
+#
+module.exports =
+class ProjectRoot
+  constructor: (@directory, @repo) ->
+
+  # Public: Returns the {Directory} that corresponds to the project root.
+  getDirectory: -> @directory
+
+  # Public: Returns the {GitRepository} for the project root or {null}.
+  getRepository: -> @repo
+
+  destroy: ->
+    @directory.off()
+    @destroyRepo()
+
+  destroyRepo: ->
+    if @repo
+      @repo.destroy()
+      @repo = null

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -8,6 +8,7 @@ Q = require 'q'
 {Model} = require 'theorist'
 {Subscriber} = require 'emissary'
 {Emitter} = require 'event-kit'
+ProjectRoot = require './project-root'
 Serializable = require 'serializable'
 TextBuffer = require 'text-buffer'
 {Directory} = require 'pathwatcher'
@@ -47,12 +48,6 @@ class Project extends Model
 
   destroyed: ->
     buffer.destroy() for buffer in @getBuffers()
-    @destroyRepo()
-
-  destroyRepo: ->
-    if @repo?
-      @repo.destroy()
-      @repo = null
 
   destroyUnretainedBuffers: ->
     buffer.destroy() for buffer in @getBuffers() when not buffer.isRetained()
@@ -91,27 +86,39 @@ class Project extends Model
     super
 
   ###
+  Going forward, this should be the starting point for getting information about
+  the root folders in the project. It should replace getRepositories(),
+  getPaths(), and getDirectories(). Note how those methods are currently
+  implemented in terms of this one.
+
+  TODO: Make it possible to programmatically add a ProjectRoot.
+  ###
+  getProjectRoots: ->
+    return if @projectRoot then [@projectRoot] else []
+
+  ###
   Section: Accessing the git repository
   ###
 
   # Public: Get an {Array} of {GitRepository}s associated with the project's
   # directories.
-  getRepositories: -> _.compact([@repo])
+  getRepositories: ->
+    projectRoot?.getRepository() for projectRoot in @getProjectRoots() when projectRoot?.getRepository()
   getRepo: ->
     Grim.deprecate("Use ::getRepositories instead")
-    @repo
+    @projectRoot?.getRepository()
 
   ###
   Section: Managing Paths
   ###
 
-
   # Public: Get an {Array} of {String}s containing the paths of the project's
   # directories.
-  getPaths: -> _.compact([@rootDirectory?.path])
+  getPaths: ->
+    directory.getPath() for directory in @getDirectories()
   getPath: ->
     Grim.deprecate("Use ::getPaths instead")
-    @rootDirectory?.path
+    @projectRoot?.getDirectory()?.path
 
   # Public: Set the paths of the project's directories.
   #
@@ -120,17 +127,16 @@ class Project extends Model
     [projectPath] = projectPaths
     projectPath = path.normalize(projectPath) if projectPath
     @path = projectPath
-    @rootDirectory?.off()
+    @projectRoot?.destroy()
 
-    @destroyRepo()
     if projectPath?
       directory = if fs.isDirectorySync(projectPath) then projectPath else path.dirname(projectPath)
-      @rootDirectory = new Directory(directory)
-      if @repo = GitRepository.open(directory, project: this)
-        @repo.refreshIndex()
-        @repo.refreshStatus()
+      if repo = GitRepository.open(directory, project: this)
+        repo.refreshIndex()
+        repo.refreshStatus()
+      @projectRoot = new ProjectRoot(new Directory(directory), repo)
     else
-      @rootDirectory = null
+      @projectRoot = null
 
     @emit "path-changed"
     @emitter.emit 'did-change-paths', projectPaths
@@ -140,10 +146,10 @@ class Project extends Model
 
   # Public: Get an {Array} of {Directory}s associated with this project.
   getDirectories: ->
-    [@rootDirectory]
+    projectRoot?.getDirectory() for projectRoot in @getProjectRoots() when projectRoot?.getDirectory()
   getRootDirectory: ->
     Grim.deprecate("Use ::getDirectories instead")
-    @rootDirectory
+    @projectRoot?.getDirectory()
 
   resolve: (uri) ->
     Grim.deprecate("Use `Project::getDirectories()[0]?.resolve()` instead")
@@ -167,7 +173,7 @@ class Project extends Model
   # * `fullPath` {String} full path
   relativize: (fullPath) ->
     return fullPath if fullPath?.match(/[A-Za-z0-9+-.]+:\/\//) # leave path alone if it has a scheme
-    @rootDirectory?.relativize(fullPath) ? fullPath
+    @projectRoot?.getDirectory()?.relativize(fullPath) ? fullPath
 
   # Public: Determines whether the given path (real or symbolic) is inside the
   # project's directory.
@@ -197,7 +203,7 @@ class Project extends Model
   #
   # Returns whether the path is inside the project's root directory.
   contains: (pathToCheck) ->
-    @rootDirectory?.contains(pathToCheck) ? false
+    @projectRoot?.getDirectory()?.contains(pathToCheck) ? false
 
   ###
   Section: Searching and Replacing


### PR DESCRIPTION
Introduce ProjectRoot.

Today, Project has three methods that return parallel arrays:

```
getPaths()
getDirectories()
getRepositories()
```

Instead, there should be one type, `ProjectRoot`, that encapsulates
all of this information. Then these three methods can be replaced
with one method:

```
getProjectRoots()
```

This commit introduces the `ProjectRoot` type and the `getProjectRoots()`
method. The other three methods are now defined in terms of `getProjectRoots()`.

Note that there are two outstanding methods on `Project` that assume a single
root that seem out of place:

```
relativize(fullPath)
contains(pathToCheck)
```
