### PR TITLE
Deep merge of 'object' config defaults

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -38,6 +38,10 @@ describe "Config", ->
       atom.config.setDefaults("bar", baz: 7)
       expect(atom.config.get("bar.baz")).toEqual {a: 3}
 
+      atom.config.set("merge.foo", 4)
+      atom.config.setDefaults("merge", foo: 2, bar: 1)
+      expect(atom.config.get("merge")).toEqual {foo:4, bar:1}
+
     describe "when a 'sources' option is specified", ->
       it "only retrieves values from the specified sources", ->
         atom.config.set("x.y", 1, scopeSelector: ".foo", source: "a")

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -901,7 +901,10 @@ class Config
 
     if value?
       value = @deepClone(value)
-      _.defaults(value, defaultValue) if isPlainObject(value) and isPlainObject(defaultValue)
+      if isPlainObject(value) and isPlainObject(defaultValue)
+          _.defaults(value, defaultValue)
+          for key of defaultValue
+              value[key] = @getRawValue([keyPath, key].join('.'), options)
     else
       value = @deepClone(defaultValue)
 


### PR DESCRIPTION
I have an object config value like (taken from my config rewrite for https://github.com/mattberkowitz/autoclose-html/tree/new-config):

```
    neverClose:
        type: 'object'
        properties:
            elements:
                title: 'Never Close Elements'
                description: 'Comma delimited list of elements to never close'
                type: 'array'
                default: ['br', 'hr', 'img', 'input', 'link', 'meta', 'area', 'base', 'col', 'command', 'embed', 'keygen', 'param', 'source', 'track', 'wbr']
            makeSelfClosing:
                title: 'Make Never Close Elements Self-Closing'
                description: 'Closes elements with " />" (ie <br> becomes <br />)'
                type: 'boolean'
                default: true
```

If I change the default value for one of the properties, such that my entry in config.cson looks like:

```
  "autoclose-html":
    neverClose:
      makeSelfClosing: false
```

The other property wont show up in the plugins config panel, thus not allowing the user to set a value for it. This is due to the fact that `_.defaults()` does not do deep merging

This change loops over the defaultValues keys, and recursively sets to `getRawValue` for each key's path.
