### PR TITLE
Add Upgrading your package guide to docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,5 +25,6 @@
 
 ### Upgrading to 1.0 APIs
 
+* [Upgrading Your Package](upgrading/upgrading-your-package.md)
 * [Upgrading Your UI Theme Or Package Selectors](upgrading/upgrading-your-ui-theme.md)
 * [Upgrading Your Syntax Theme](upgrading/upgrading-your-syntax-theme.md)

--- a/docs/upgrading/upgrading-your-package.md
+++ b/docs/upgrading/upgrading-your-package.md
@@ -1,4 +1,4 @@
-# Upgrading your package to 1.0 APIs
+# Upgrading Your Package
 
 Atom is rapidly approaching 1.0. Much of the effort leading up to the 1.0 has been cleaning up APIs in an attempt to future proof, and make a more pleasant experience developing packages.
 


### PR DESCRIPTION
This adds the "Upgrading your package" guide :link: to the documentation index so that the guide is listed on the [docs page on atom.io](https://atom.io/docs/latest/) (currently, it's [not listed there](https://cloud.githubusercontent.com/assets/38924/6095897/13f38d3e-af74-11e4-8752-476e20f9d6c3.png) and is only reachable from [the blog post](http://blog.atom.io/2015/01/15/announcing-the-atom-1-api.html) or in [atom/atom on GitHub](https://github.com/atom/atom/blob/master/docs/upgrading/upgrading-your-package.md)). I'm guessing we just forgot to add it here in https://github.com/atom/atom/pull/4169 and it wasn't intentional.

cc @benogle (and :zap: again for writing that guide)
