### PR TITLE
Allow the gutter to show relative line numbers

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -122,6 +122,15 @@ module.exports =
       showLineNumbers:
         type: 'boolean'
         default: true
+      relativeLineNumbers:
+        type: 'object'
+        properties:
+          enabled:
+            type: 'boolean'
+            default: true
+          trueCurrentLineNumber:
+            type: 'boolean'
+            default: true
       autoIndent:
         type: 'boolean'
         default: true

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -127,7 +127,7 @@ module.exports =
         properties:
           enabled:
             type: 'boolean'
-            default: true
+            default: false
           trueCurrentLineNumber:
             type: 'boolean'
             default: true

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -3,8 +3,8 @@ React = require 'react-atom-fork'
 {div} = require 'reactionary-atom-fork'
 {isEqual, isEqualForProperties, multiplyString, toArray} = require 'underscore-plus'
 Decoration = require './decoration'
-SubscriberMixin = require './subscriber-mixin'
 {$} = require './space-pen-extensions'
+SubscriberMixin = require './subscriber-mixin'
 
 WrapperDiv = document.createElement('div')
 
@@ -100,6 +100,10 @@ GutterComponent = React.createClass
     {editor, renderedRowRange, scrollTop, maxLineNumberDigits, lineDecorations} = @props
     [startRow, endRow] = renderedRowRange
 
+    relativeLineNumbers = atom.config.get("editor.relativeLineNumbers")
+    if relativeLineNumbers?.enabled
+      cursorRow = editor.getCursorBufferPosition().row
+
     newLineNumberIds = null
     newLineNumbersHTML = null
     visibleLineNumberIds = new Set
@@ -107,7 +111,14 @@ GutterComponent = React.createClass
     wrapCount = 0
     for bufferRow, index in editor.bufferRowsForScreenRows(startRow, endRow - 1)
       screenRow = startRow + index
-      displayRow = bufferRow + 1
+      if relativeLineNumbers?.enabled
+        relativeRow = Math.abs(cursorRow - bufferRow)
+        if relativeRow is 0 and relativeLineNumbers.trueCurrentLineNumber
+          displayRow = cursorRow + 1
+        else
+          displayRow = relativeRow
+      else
+        displayRow = bufferRow + 1
 
       if bufferRow is lastBufferRow
         id = "#{bufferRow}-#{wrapCount++}"

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -3,7 +3,6 @@ React = require 'react-atom-fork'
 {div} = require 'reactionary-atom-fork'
 {isEqual, isEqualForProperties, multiplyString, toArray} = require 'underscore-plus'
 Decoration = require './decoration'
-{$} = require './space-pen-extensions'
 SubscriberMixin = require './subscriber-mixin'
 
 WrapperDiv = document.createElement('div')
@@ -202,7 +201,7 @@ GutterComponent = React.createClass
     previousDisplayRow = parseInt(node.dataset['displayRow'])
     if displayRow != previousDisplayRow
       node.dataset['displayRow'] = displayRow.toString()
-      $(node).html(@buildLineNumberInnerHTML(displayRow, softWrapped, maxLineNumberDigits))
+      node.innerHTML = @buildLineNumberInnerHTML(displayRow, softWrapped, maxLineNumberDigits)
 
     if editor.isFoldableAtBufferRow(bufferRow)
       node.classList.add('foldable')


### PR DESCRIPTION
Displays vim-like relative line numbers in gutter, with option to show true current line number instead of zero on current line
https://github.com/atom/atom/issues/1612
