### PR TITLE
Upgrade and dedupe q

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "optimist": "0.4.0",
     "pathwatcher": "^3.1.0",
     "property-accessors": "^1",
-    "q": "^1.0.1",
+    "q": "^1.1.2",
     "random-words": "0.0.1",
     "react-atom-fork": "^0.11.5",
     "reactionary-atom-fork": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nslog": "^2.0.0",
     "oniguruma": "^4.0.0",
     "optimist": "0.4.0",
-    "pathwatcher": "^3.1.0",
+    "pathwatcher": "^3.1.1",
     "property-accessors": "^1",
     "q": "^1.1.2",
     "random-words": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "space-pen": "3.8.2",
     "stacktrace-parser": "0.1.1",
     "temp": "0.7.0",
-    "text-buffer": "^4.0.0",
+    "text-buffer": "^4.1.1",
     "theorist": "^1.0.2",
     "underscore-plus": "^1.6.6",
     "vm-compatibility-layer": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "open-on-github": "0.32.0",
     "package-generator": "0.37.0",
     "release-notes": "0.47.0",
-    "settings-view": "0.175.0",
+    "settings-view": "0.176.0",
     "snippets": "0.72.0",
     "spell-check": "0.54.0",
     "status-bar": "0.59.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "spell-check": "0.54.0",
     "status-bar": "0.59.0",
     "styleguide": "0.44.0",
-    "symbols-view": "0.81.0",
+    "symbols-view": "0.82.0",
     "tabs": "0.65.0",
     "timecop": "0.29.0",
     "tree-view": "0.154.0",

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -37,7 +37,7 @@ function bootstrap() {
   var initialNpmCommand = fs.existsSync(npmPath) ? npmPath : 'npm';
   var npmFlags = ' --userconfig=' + path.resolve('.npmrc') + ' ';
 
-  var packagesToDedupe = ['fs-plus', 'humanize-plus', 'oniguruma', 'roaster', 'season', 'grim'];
+  var packagesToDedupe = ['fs-plus', 'humanize-plus', 'oniguruma', 'roaster', 'season', 'grim', 'q'];
 
   var buildInstallCommand = initialNpmCommand + npmFlags + 'install';
   var buildInstallOptions = {cwd: path.resolve(__dirname, '..', 'build')};


### PR DESCRIPTION
In dev mode there is no module caching and so a bunch of versions of [q](https://github.com/kriskowal/q) are getting required since packages and modules were using a variety of versions.

Requiring q in dev mode is pretty slow since it create and inspects an error which causes source maps to load and a CoffeeScript compile to occur. Requiring it multiple times makes that even worse.

This PR speeds up dev mode by ensuring q is required only once.  It also allows 1 version of q to ship in the actual app bundle instead of 5.

This also upgrades Atom to the latest q version, 1.1.2
