### PR TITLE
Set up the atom.repository-provider service and implement GitRepositoryP...

### DIFF
--- a/spec/git-repository-provider-spec.coffee
+++ b/spec/git-repository-provider-spec.coffee
@@ -8,17 +8,13 @@ describe "GitRepositoryProvider", ->
 
     describe "when specified a Directory with a Git repository", ->
       it "returns a Promise that resolves to a GitRepository", ->
-        provider = new GitRepositoryProvider atom.project
-        theResult = null
-
         waitsForPromise ->
+          provider = new GitRepositoryProvider atom.project
           directory = new Directory path.join(__dirname, 'fixtures/git/master.git')
-          provider.repositoryForDirectory(directory).then (result) -> theResult = result
-
-        runs ->
-          expect(theResult).toBeInstanceOf GitRepository
-          expect(provider.pathToRepository[theResult.getPath()]).toBeTruthy()
-          expect(theResult.statusTask).toBeTruthy()
+          provider.repositoryForDirectory(directory).then (result) ->
+            expect(result).toBeInstanceOf GitRepository
+            expect(provider.pathToRepository[result.getPath()]).toBeTruthy()
+            expect(result.statusTask).toBeTruthy()
 
       it "returns the same GitRepository for different Directory objects in the same repo", ->
         provider = new GitRepositoryProvider atom.project
@@ -38,13 +34,9 @@ describe "GitRepositoryProvider", ->
           expect(firstRepo).toBe secondRepo
 
     describe "when specified a Directory without a Git repository", ->
-      provider = new GitRepositoryProvider atom.project
-      theResult = 'dummy_value'
-
       it "returns a Promise that resolves to null", ->
         waitsForPromise ->
+          provider = new GitRepositoryProvider atom.project
           directory = new Directory '/tmp'
-          provider.repositoryForDirectory(directory).then (result) -> theResult = result
-
-      runs ->
-        expect(theResult).toBe null
+          provider.repositoryForDirectory(directory).then (result) ->
+            expect(result).toBe null

--- a/spec/git-repository-provider-spec.coffee
+++ b/spec/git-repository-provider-spec.coffee
@@ -1,0 +1,42 @@
+path = require 'path'
+{Directory} = require 'pathwatcher'
+GitRepository = require '../src/git-repository'
+GitRepositoryProvider = require '../src/git-repository-provider'
+
+describe "GitRepositoryProvider", ->
+  describe ".repositoryForDirectory(directory)", ->
+
+    describe "when specified a Directory with a Git repository", ->
+      provider = new GitRepositoryProvider atom.project
+      the_result = 'dummy_value'
+      the_second_result = 'dummy_value2'
+
+      it "returns a Promise that resolves to a GitRepository", ->
+        waitsForPromise ->
+          directory = new Directory path.join(__dirname, 'fixtures/git/master.git')
+          provider.repositoryForDirectory(directory).then (result) -> the_result = result
+
+        runs ->
+          expect(the_result).toBeInstanceOf GitRepository
+          expect(provider.pathToRepository[the_result.getPath()]).toBeTruthy()
+          expect(the_result.statusTask).toBeTruthy()
+
+        waitsForPromise ->
+          directory = new Directory path.join(__dirname, 'fixtures/git/master.git/objects')
+          provider.repositoryForDirectory(directory).then (result) -> the_second_result = result
+
+        runs ->
+          expect(the_second_result).toBeInstanceOf GitRepository
+          expect(the_second_result).toBe the_result
+
+    describe "when specified a Directory without a Git repository", ->
+      provider = new GitRepositoryProvider atom.project
+      the_result = 'dummy_value'
+
+      it "returns a Promise that resolves to null", ->
+        waitsForPromise ->
+          directory = new Directory '/tmp'
+          provider.repositoryForDirectory(directory).then (result) -> the_result = result
+
+      runs ->
+        expect(the_result).toBe null

--- a/spec/git-repository-provider-spec.coffee
+++ b/spec/git-repository-provider-spec.coffee
@@ -8,35 +8,35 @@ describe "GitRepositoryProvider", ->
 
     describe "when specified a Directory with a Git repository", ->
       provider = new GitRepositoryProvider atom.project
-      the_result = 'dummy_value'
-      the_second_result = 'dummy_value2'
+      theResult = 'dummy_value'
+      theSecondResult = 'dummy_value2'
 
       it "returns a Promise that resolves to a GitRepository", ->
         waitsForPromise ->
           directory = new Directory path.join(__dirname, 'fixtures/git/master.git')
-          provider.repositoryForDirectory(directory).then (result) -> the_result = result
+          provider.repositoryForDirectory(directory).then (result) -> theResult = result
 
         runs ->
-          expect(the_result).toBeInstanceOf GitRepository
-          expect(provider.pathToRepository[the_result.getPath()]).toBeTruthy()
-          expect(the_result.statusTask).toBeTruthy()
+          expect(theResult).toBeInstanceOf GitRepository
+          expect(provider.pathToRepository[theResult.getPath()]).toBeTruthy()
+          expect(theResult.statusTask).toBeTruthy()
 
         waitsForPromise ->
           directory = new Directory path.join(__dirname, 'fixtures/git/master.git/objects')
-          provider.repositoryForDirectory(directory).then (result) -> the_second_result = result
+          provider.repositoryForDirectory(directory).then (result) -> theSecondResult = result
 
         runs ->
-          expect(the_second_result).toBeInstanceOf GitRepository
-          expect(the_second_result).toBe the_result
+          expect(theSecondResult).toBeInstanceOf GitRepository
+          expect(theSecondResult).toBe theResult
 
     describe "when specified a Directory without a Git repository", ->
       provider = new GitRepositoryProvider atom.project
-      the_result = 'dummy_value'
+      theResult = 'dummy_value'
 
       it "returns a Promise that resolves to null", ->
         waitsForPromise ->
           directory = new Directory '/tmp'
-          provider.repositoryForDirectory(directory).then (result) -> the_result = result
+          provider.repositoryForDirectory(directory).then (result) -> theResult = result
 
       runs ->
-        expect(the_result).toBe null
+        expect(theResult).toBe null

--- a/spec/git-repository-provider-spec.coffee
+++ b/spec/git-repository-provider-spec.coffee
@@ -7,11 +7,10 @@ describe "GitRepositoryProvider", ->
   describe ".repositoryForDirectory(directory)", ->
 
     describe "when specified a Directory with a Git repository", ->
-      provider = new GitRepositoryProvider atom.project
-      theResult = 'dummy_value'
-      theSecondResult = 'dummy_value2'
-
       it "returns a Promise that resolves to a GitRepository", ->
+        provider = new GitRepositoryProvider atom.project
+        theResult = null
+
         waitsForPromise ->
           directory = new Directory path.join(__dirname, 'fixtures/git/master.git')
           provider.repositoryForDirectory(directory).then (result) -> theResult = result
@@ -21,13 +20,22 @@ describe "GitRepositoryProvider", ->
           expect(provider.pathToRepository[theResult.getPath()]).toBeTruthy()
           expect(theResult.statusTask).toBeTruthy()
 
+      it "returns the same GitRepository for different Directory objects in the same repo", ->
+        provider = new GitRepositoryProvider atom.project
+        firstRepo = null
+        secondRepo = null
+
+        waitsForPromise ->
+          directory = new Directory path.join(__dirname, 'fixtures/git/master.git')
+          provider.repositoryForDirectory(directory).then (result) -> firstRepo = result
+
         waitsForPromise ->
           directory = new Directory path.join(__dirname, 'fixtures/git/master.git/objects')
-          provider.repositoryForDirectory(directory).then (result) -> theSecondResult = result
+          provider.repositoryForDirectory(directory).then (result) -> secondRepo = result
 
         runs ->
-          expect(theSecondResult).toBeInstanceOf GitRepository
-          expect(theSecondResult).toBe theResult
+          expect(firstRepo).toBeInstanceOf GitRepository
+          expect(firstRepo).toBe secondRepo
 
     describe "when specified a Directory without a Git repository", ->
       provider = new GitRepositoryProvider atom.project

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -214,19 +214,18 @@ describe "Project", ->
 
     it "resolves to a GitRepository and is cached when the given directory is a Git repo", ->
       the_result = "dummy_value"
-      the_promise = null
       directory = new Directory(path.join(__dirname, '..'))
 
       waitsForPromise ->
-        the_promise = atom.project.repositoryForDirectory(directory)
-        the_promise.then (result) -> the_result = result
+        atom.project.repositoryForDirectory(directory).then (result) -> the_result = result
 
       runs ->
         dirPath = directory.getRealPathSync()
         expect(the_result).toBeInstanceOf GitRepository
         expect(the_result.getPath()).toBe path.join(dirPath, '.git')
-        expect(atom.project.repositoryPromisesByPath.size).toBe 1
-        expect(atom.project.repositoryPromisesByPath.get dirPath).toBe the_promise
+
+        # Verify that the result is cached.
+        expect(atom.project.repositoryForDirectory(directory)).toBe(atom.project.repositoryForDirectory(directory))
 
   describe ".setPaths(path)", ->
     describe "when path is a file", ->

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -205,7 +205,7 @@ describe "Project", ->
     # be different than the atom.project used in a subsequent it(). To work
     # around this issue, we use runs() instead of it().
 
-    describe "there is no repository for /tmp even though there are RepositoryProviders", ->
+    it "there is no repository for /tmp even though there are RepositoryProviders", ->
       the_result = "dummy_value"
 
       waitsForPromise ->
@@ -218,7 +218,7 @@ describe "Project", ->
         expect(the_result).toBe null
         expect(atom.project.repositoryPromisesByPath.size).toBe 0
 
-    describe "when Git repository for directory, promise resolves to Atom's GitRepository and is cached", ->
+    it "when Git repository for directory, promise resolves to Atom's GitRepository and is cached", ->
       the_result = "dummy_value"
       the_promise = null
       directory = new Directory(path.join(__dirname, '..'))

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -200,34 +200,31 @@ describe "Project", ->
             expect(anotherBuffer).not.toBe buffer
 
   describe ".repositoryForDirectory(directory)", ->
-    it "there is no repository for /tmp even though there are RepositoryProviders", ->
+    it "resolves to null when the directory does not have a repository", ->
       the_result = "dummy_value"
 
       waitsForPromise ->
         directory = new Directory("/tmp")
-        atom.project.repositoryForDirectory(directory).then (result) ->
-          the_result = result
+        atom.project.repositoryForDirectory(directory).then (result) -> the_result = result
 
       runs ->
         expect(atom.project.repositoryProviders.length).toBeGreaterThan 0
         expect(the_result).toBe null
         expect(atom.project.repositoryPromisesByPath.size).toBe 0
 
-    it "when Git repository for directory, promise resolves to Atom's GitRepository and is cached", ->
+    it "resolves to a GitRepository and is cached when the given directory is a Git repo", ->
       the_result = "dummy_value"
       the_promise = null
       directory = new Directory(path.join(__dirname, '..'))
 
       waitsForPromise ->
         the_promise = atom.project.repositoryForDirectory(directory)
-        the_promise.then (result) ->
-          the_result = result
+        the_promise.then (result) -> the_result = result
 
       runs ->
         dirPath = directory.getRealPathSync()
         expect(the_result).toBeInstanceOf GitRepository
         expect(the_result.getPath()).toBe path.join(dirPath, '.git')
-
         expect(atom.project.repositoryPromisesByPath.size).toBe 1
         expect(atom.project.repositoryPromisesByPath.get dirPath).toBe the_promise
 

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -200,11 +200,6 @@ describe "Project", ->
             expect(anotherBuffer).not.toBe buffer
 
   describe ".repositoryForDirectory(directory)", ->
-    # it() causes beforeEach() in spec-helper.coffee to be run, which reassigns
-    # atom.project. Therefore, the atom.project used in waitsForPromise() will
-    # be different than the atom.project used in a subsequent it(). To work
-    # around this issue, we use runs() instead of it().
-
     it "there is no repository for /tmp even though there are RepositoryProviders", ->
       the_result = "dummy_value"
 

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -201,31 +201,23 @@ describe "Project", ->
 
   describe ".repositoryForDirectory(directory)", ->
     it "resolves to null when the directory does not have a repository", ->
-      theResult = "dummy_value"
-
       waitsForPromise ->
         directory = new Directory("/tmp")
-        atom.project.repositoryForDirectory(directory).then (result) -> theResult = result
-
-      runs ->
-        expect(atom.project.repositoryProviders.length).toBeGreaterThan 0
-        expect(theResult).toBe null
-        expect(atom.project.repositoryPromisesByPath.size).toBe 0
+        atom.project.repositoryForDirectory(directory).then (result) ->
+          expect(result).toBeNull()
+          expect(atom.project.repositoryProviders.length).toBeGreaterThan 0
+          expect(atom.project.repositoryPromisesByPath.size).toBe 0
 
     it "resolves to a GitRepository and is cached when the given directory is a Git repo", ->
-      theResult = "dummy_value"
-      directory = new Directory(path.join(__dirname, '..'))
-
       waitsForPromise ->
-        atom.project.repositoryForDirectory(directory).then (result) -> theResult = result
+        directory = new Directory(path.join(__dirname, '..'))
+        atom.project.repositoryForDirectory(directory).then (result) ->
+          expect(result).toBeInstanceOf GitRepository
+          dirPath = directory.getRealPathSync()
+          expect(result.getPath()).toBe path.join(dirPath, '.git')
 
-      runs ->
-        dirPath = directory.getRealPathSync()
-        expect(theResult).toBeInstanceOf GitRepository
-        expect(theResult.getPath()).toBe path.join(dirPath, '.git')
-
-        # Verify that the result is cached.
-        expect(atom.project.repositoryForDirectory(directory)).toBe(atom.project.repositoryForDirectory(directory))
+          # Verify that the result is cached.
+          expect(atom.project.repositoryForDirectory(directory)).toBe(atom.project.repositoryForDirectory(directory))
 
   describe ".setPaths(path)", ->
     describe "when path is a file", ->

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -231,7 +231,7 @@ describe "Project", ->
       runs ->
         dirPath = directory.getRealPathSync()
         expect(the_result).toBeInstanceOf GitRepository
-        expect(the_result.getWorkingDirectory()).toBe path.join(dirPath, '.git')
+        expect(the_result.getPath()).toBe path.join(dirPath, '.git')
 
         expect(atom.project.repositoryPromisesByPath.size).toBe 1
         expect(atom.project.repositoryPromisesByPath.get dirPath).toBe the_promise

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -201,28 +201,28 @@ describe "Project", ->
 
   describe ".repositoryForDirectory(directory)", ->
     it "resolves to null when the directory does not have a repository", ->
-      the_result = "dummy_value"
+      theResult = "dummy_value"
 
       waitsForPromise ->
         directory = new Directory("/tmp")
-        atom.project.repositoryForDirectory(directory).then (result) -> the_result = result
+        atom.project.repositoryForDirectory(directory).then (result) -> theResult = result
 
       runs ->
         expect(atom.project.repositoryProviders.length).toBeGreaterThan 0
-        expect(the_result).toBe null
+        expect(theResult).toBe null
         expect(atom.project.repositoryPromisesByPath.size).toBe 0
 
     it "resolves to a GitRepository and is cached when the given directory is a Git repo", ->
-      the_result = "dummy_value"
+      theResult = "dummy_value"
       directory = new Directory(path.join(__dirname, '..'))
 
       waitsForPromise ->
-        atom.project.repositoryForDirectory(directory).then (result) -> the_result = result
+        atom.project.repositoryForDirectory(directory).then (result) -> theResult = result
 
       runs ->
         dirPath = directory.getRealPathSync()
-        expect(the_result).toBeInstanceOf GitRepository
-        expect(the_result.getPath()).toBe path.join(dirPath, '.git')
+        expect(theResult).toBeInstanceOf GitRepository
+        expect(theResult.getPath()).toBe path.join(dirPath, '.git')
 
         # Verify that the result is cached.
         expect(atom.project.repositoryForDirectory(directory)).toBe(atom.project.repositoryForDirectory(directory))

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -211,13 +211,14 @@ describe "Project", ->
     it "resolves to a GitRepository and is cached when the given directory is a Git repo", ->
       waitsForPromise ->
         directory = new Directory(path.join(__dirname, '..'))
-        atom.project.repositoryForDirectory(directory).then (result) ->
+        promise = atom.project.repositoryForDirectory(directory)
+        promise.then (result) ->
           expect(result).toBeInstanceOf GitRepository
           dirPath = directory.getRealPathSync()
           expect(result.getPath()).toBe path.join(dirPath, '.git')
 
           # Verify that the result is cached.
-          expect(atom.project.repositoryForDirectory(directory)).toBe(atom.project.repositoryForDirectory(directory))
+          expect(atom.project.repositoryForDirectory(directory)).toBe(promise)
 
   describe ".setPaths(path)", ->
     describe "when path is a file", ->

--- a/src/git-repository-provider.coffee
+++ b/src/git-repository-provider.coffee
@@ -1,0 +1,80 @@
+fs = require 'fs'
+GitRepository = require './git-repository'
+
+# Checks whether the specified directory has, or has a parent directory that
+# has, a valid .git folder, indicating the root of a Git repository.
+# If found, a Directory that corresponds to the .git folder will be returned.
+# Otherwise, returns `null`.
+#
+# * `directory` {Directory} to explore whether it is part of a Git repository.
+findGitDirectorySync = (directory) ->
+  # TODO: Fix node-pathwatcher/src/directory.coffee so the following methods
+  # can return cached values rather than always returning new objects:
+  # getParent(), getFile(), getSubdirectory().
+  gitDir = directory.getSubdirectory('.git')
+  if directoryExistsSync(gitDir) and isValidGitDirectorySync gitDir
+    gitDir
+  else if directory.isRoot()
+    return null
+  else
+    findGitDirectorySync directory.getParent()
+
+# Returns a boolean indicating whether the specified directory represents a Git
+# repository.
+#
+# * `directory` {Directory} whose base name is `.git`.
+isValidGitDirectorySync = (directory) ->
+  # To decide whether a directory has a valid .git folder, we use
+  # the heuristic adopted by the valid_repository_path() function defined in
+  # node_modules/git-utils/deps/libgit2/src/repository.c.
+  return directoryExistsSync(directory.getSubdirectory('objects')) and
+      directory.getFile('HEAD').exists() and
+      directoryExistsSync(directory.getSubdirectory('refs'))
+
+# Returns a boolean indicating whether the specified directory exists.
+#
+# * `directory` {Directory} to check for existence.
+directoryExistsSync = (directory) ->
+  # TODO: Directory should have its own existsSync() method. Currently, File has
+  # an exists() method, which is synchronous, so it may be tricky to achieve
+  # consistency between the File and Directory APIs. Once Directory has its own
+  # method, this function should be replaced with direct calls to existsSync().
+  return fs.existsSync(directory.getRealPathSync())
+
+# Provider that conforms to the atom.repository-provider@0.1.0 service.
+module.exports =
+class GitRepositoryProvider
+
+  constructor: (@project) ->
+    # Keys are real paths that end in `.git`.
+    # Values are the corresponding GitRepository objects.
+    @pathToRepository = {}
+
+  # Returns a {Promise} that resolves with either:
+  # * {GitRepository} if the given directory has a Git repository.
+  # * `null` if the given directory does not have a Git repository.
+  repositoryForDirectory: (directory) ->
+    # TODO: Currently, this method is designed to be async, but it relies on a
+    # synchronous API. It should be rewritten to be truly async.
+    Promise.resolve(@createRepositorySync(directory))
+
+  # Returns either:
+  # * {GitRepository} if the given directory has a Git repository.
+  # * `null` if the given directory does not have a Git repository.
+  createRepositorySync: (directory) ->
+    # Only one GitRepository should be created for each .git folder. Therefore,
+    # we must check directory and its parent directories to find the nearest
+    # .git folder.
+    gitDir = findGitDirectorySync(directory)
+    unless gitDir
+      return null
+
+    gitDirPath = gitDir.getRealPathSync()
+    repo = @pathToRepository[gitDirPath]
+    unless repo
+      repo = GitRepository.open(gitDirPath, project: @project)
+      repo.onDestroy(() => delete @pathToRepository[gitDirPath])
+      @pathToRepository[gitDirPath] = repo
+      repo.refreshIndex()
+      repo.refreshStatus()
+    repo

--- a/src/git-repository-provider.coffee
+++ b/src/git-repository-provider.coffee
@@ -1,10 +1,9 @@
 fs = require 'fs'
 GitRepository = require './git-repository'
 
-# Checks whether the specified directory has, or has a parent directory that
-# has, a valid .git folder, indicating the root of a Git repository.
-# If found, a Directory that corresponds to the .git folder will be returned.
-# Otherwise, returns `null`.
+# Checks whether a valid `.git` directory is contained within the given
+# directory or one of its ancestors. If so, a Directory that corresponds to the
+# `.git` folder will be returned. Otherwise, returns `null`.
 #
 # * `directory` {Directory} to explore whether it is part of a Git repository.
 findGitDirectorySync = (directory) ->
@@ -56,12 +55,12 @@ class GitRepositoryProvider
   repositoryForDirectory: (directory) ->
     # TODO: Currently, this method is designed to be async, but it relies on a
     # synchronous API. It should be rewritten to be truly async.
-    Promise.resolve(@createRepositorySync(directory))
+    Promise.resolve(@repositoryForDirectorySync(directory))
 
   # Returns either:
   # * {GitRepository} if the given directory has a Git repository.
   # * `null` if the given directory does not have a Git repository.
-  createRepositorySync: (directory) ->
+  repositoryForDirectorySync: (directory) ->
     # Only one GitRepository should be created for each .git folder. Therefore,
     # we must check directory and its parent directories to find the nearest
     # .git folder.
@@ -73,7 +72,7 @@ class GitRepositoryProvider
     repo = @pathToRepository[gitDirPath]
     unless repo
       repo = GitRepository.open(gitDirPath, project: @project)
-      repo.onDestroy(() => delete @pathToRepository[gitDirPath])
+      repo.onDidDestroy(() => delete @pathToRepository[gitDirPath])
       @pathToRepository[gitDirPath] = repo
       repo.refreshIndex()
       repo.refreshStatus()

--- a/src/git-repository-provider.coffee
+++ b/src/git-repository-provider.coffee
@@ -38,7 +38,7 @@ directoryExistsSync = (directory) ->
   # an exists() method, which is synchronous, so it may be tricky to achieve
   # consistency between the File and Directory APIs. Once Directory has its own
   # method, this function should be replaced with direct calls to existsSync().
-  return fs.existsSync(directory.getRealPathSync())
+  return fs.existsSync(directory.getPath())
 
 # Provider that conforms to the atom.repository-provider@0.1.0 service.
 module.exports =
@@ -68,7 +68,7 @@ class GitRepositoryProvider
     unless gitDir
       return null
 
-    gitDirPath = gitDir.getRealPathSync()
+    gitDirPath = gitDir.getPath()
     repo = @pathToRepository[gitDirPath]
     unless repo
       repo = GitRepository.open(gitDirPath, project: @project)

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -105,7 +105,7 @@ class GitRepository
   destroy: ->
     if @emitter?
       @emitter.emit 'did-destroy'
-      @emitter.off()
+      @emitter.dispose()
       @emitter = null
 
     if @statusTask?
@@ -122,7 +122,7 @@ class GitRepository
 
   # Public: Invoke the given callback when this GitRepository's destroy() method
   # is invoked.
-  onDestroy: (callback) ->
+  onDidDestroy: (callback) ->
     @emitter.on 'did-destroy', callback
 
   ###

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -43,7 +43,7 @@ class Project extends Model
     # to either a {Repository} or null. Ideally, the {Directory} would be used
     # as the key; however, there can be multiple {Directory} objects created for
     # the same real path, so it is not a good key.
-    @repositoryPromisesByDirectory = new Map();
+    @repositoryPromisesByPath = new Map();
 
     # Note that the GitRepositoryProvider is registered synchronously so that
     # it is available immediately on startup.
@@ -132,7 +132,7 @@ class Project extends Model
   # * `null` if no repository can be created for the given directory.
   repositoryForDirectory: (directory) ->
     path = directory.getRealPathSync()
-    promise = @repositoryPromisesByDirectory.get(path)
+    promise = @repositoryPromisesByPath.get(path)
     unless promise
       promises = @repositoryProviders.map (provider) ->
           provider.repositoryForDirectory directory
@@ -142,13 +142,13 @@ class Project extends Model
           repo = repos[0] or null
 
           # If no repository is found, remove the entry in for the directory in
-          # @repositoryPromisesByDirectory in case some other RepositoryProvider is
+          # @repositoryPromisesByPath in case some other RepositoryProvider is
           # registered in the future that could supply a Repository for the
           # directory.
           if repo is null
-            @repositoryPromisesByDirectory.delete path
+            @repositoryPromisesByPath.delete path
           repo
-      @repositoryPromisesByDirectory.set(path, promise)
+      @repositoryPromisesByPath.set(path, promise)
     promise
 
   ###

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -131,8 +131,8 @@ class Project extends Model
   # * {Repository} if a repository can be created for the given directory
   # * `null` if no repository can be created for the given directory.
   repositoryForDirectory: (directory) ->
-    path = directory.getRealPathSync()
-    promise = @repositoryPromisesByPath.get(path)
+    pathForDirectory = directory.getRealPathSync()
+    promise = @repositoryPromisesByPath.get(pathForDirectory)
     unless promise
       promises = @repositoryProviders.map (provider) ->
           provider.repositoryForDirectory directory
@@ -146,9 +146,9 @@ class Project extends Model
           # registered in the future that could supply a Repository for the
           # directory.
           if repo is null
-            @repositoryPromisesByPath.delete path
+            @repositoryPromisesByPath.delete pathForDirectory
           repo
-      @repositoryPromisesByPath.set(path, promise)
+      @repositoryPromisesByPath.set(pathForDirectory, promise)
     promise
 
   ###


### PR DESCRIPTION
...rovider.

I tested this by creating a dummy implementation of an `HgRepositoryProvider`
(with the optional `createRepositorySync()` method implemented) and an `HgRepository`
in an Atom package with the following stanza in the `package.json`:

```
  "providedServices": {
    "atom.repository-provider": {
      "versions": {
        "0.1.0": "createHgRepositoryProvider"
      }
    }
  },
```

I opened a path with an Hg repository from the command line using Atom.
I verified that `atom.project.repositoryProviders` contains both a
`GitRepositoryProvider` and an `HgRepositoryProvider`.

I also verified that running the following printed out an `HgRepository`:

```
var Directory = require('pathwatcher').Directory;
atom.project.repositoryForDirectory(
    new Directory(atom.project.getPath(), /* symlink */ false)).then(
        function(repo) { console.log('repo: %o', repo); });
```

One thing that stands out to me about the current API for the
atom.repository-provider service is that the function used to create
a `RepositoryProvider` does not receive any arguments. If the creation
of the `GitRepositoryProvider` were done via the service, this would
be a problem because it needs a reference to `atom.project`, which is
not defined when it is created. (We work around this because it is
created in `Project`'s constructor, so it can pass `this` to
`new GitRepositoryProvider()`.)

We would have to create a `RepositoryProviderFactory` or something if
we wanted to specify arguments when creating a `RepositoryProvider`,
in general. Maybe that's too crazy / not an issue, in practice.

Though note that `GitRepository` cannot access `atom.project` lazily
because it uses it in its constructor to do the following:

```
if @project?
  @subscriptions.add @project.eachBuffer (buffer) => @subscribeToBuffer(buffer)
```

So long as we can guarantee that `atom.project` is defined before the
other providers are initialized, I think we should be OK.

Follow-up work:
- Replace the use of `RepositoryProvider.createRepositorySync()` with
  `RepositoryProvider.repositoryForDirectory()` in `Project.setPaths()`.
- Replace all uses of `Project.getRepositories()` with
  `Project.repositoryForDirectory()` in packages that are bundled with Atom
  by default.
- Implement `Directory.exists()` and/or `Directory.existsSync()` and update
  `git-repositor-provider.coffee`, as appropriate.
- Eliminate `GitRepositoryProvider.repositoryForDirectory()`'s use of
  synchronous methods.
- Somewhat orthogonal to this diff, but the following fields need to be
  removed from `Project` because they enforce the idea of a single root:
  `path`, `rootDirectory`, and `repo`. This has implications around the
  existing use of `@rootDirectory?.off()` and `@destroyRepo()`.
