### PR TITLE
Make getPaths() an async method that leverages repositoryForDirectory().

### DIFF
--- a/src/git-repository-provider.coffee
+++ b/src/git-repository-provider.coffee
@@ -1,0 +1,80 @@
+fs = require 'fs'
+GitRepository = require './git-repository'
+
+# Checks whether the specified directory has, or has a parent directory that
+# has, a valid .git folder, indicating the root of a Git repository.
+# If found, a Directory that corresponds to the .git folder will be returned.
+# Otherwise, returns `null`.
+#
+# * `directory` {Directory} to explore whether it is part of a Git repository.
+findGitDirectorySync = (directory) ->
+  # TODO: Fix node-pathwatcher/src/directory.coffee so the following methods
+  # can return cached values rather than always returning new objects:
+  # getParent(), getFile(), getSubdirectory().
+  gitDir = directory.getSubdirectory('.git')
+  if directoryExistsSync(gitDir) and isValidGitDirectorySync gitDir
+    gitDir
+  else if directory.isRoot()
+    return null
+  else
+    findGitDirectorySync directory.getParent()
+
+# Returns a boolean indicating whether the specified directory represents a Git
+# repository.
+#
+# * `directory` {Directory} whose base name is `.git`.
+isValidGitDirectorySync = (directory) ->
+  # To decide whether a directory has a valid .git folder, we use
+  # the heuristic adopted by the valid_repository_path() function defined in
+  # node_modules/git-utils/deps/libgit2/src/repository.c.
+  return directoryExistsSync(directory.getSubdirectory('objects')) and
+      directory.getFile('HEAD').exists() and
+      directoryExistsSync(directory.getSubdirectory('refs'))
+
+# Returns a boolean indicating whether the specified directory exists.
+#
+# * `directory` {Directory} to check for existence.
+directoryExistsSync = (directory) ->
+  # TODO: Directory should have its own existsSync() method. Currently, File has
+  # an exists() method, which is synchronous, so it may be tricky to achieve
+  # consistency between the File and Directory APIs. Once Directory has its own
+  # method, this function should be replaced with direct calls to existsSync().
+  return fs.existsSync(directory.getRealPathSync())
+
+# Provider that conforms to the atom.repository-provider@0.1.0 service.
+module.exports =
+class GitRepositoryProvider
+
+  constructor: (@project) ->
+    # Keys are real paths that end in `.git`.
+    # Values are the corresponding GitRepository objects.
+    @pathToRepository = {}
+
+  # Returns a {Promise} that resolves with either:
+  # * {GitRepository} if the given directory has a Git repository.
+  # * `null` if the given directory does not have a Git repository.
+  repositoryForDirectory: (directory) ->
+    # TODO: Currently, this method is designed to be async, but it relies on a
+    # synchronous API. It should be rewritten to be truly async.
+    Promise.resolve(@createRepositorySync(directory))
+
+  # Returns either:
+  # * {GitRepository} if the given directory has a Git repository.
+  # * `null` if the given directory does not have a Git repository.
+  createRepositorySync: (directory) ->
+    # Only one GitRepository should be created for each .git folder. Therefore,
+    # we must check directory and its parent directories to find the nearest
+    # .git folder.
+    gitDir = findGitDirectorySync(directory)
+    unless gitDir
+      return null
+
+    gitDirPath = gitDir.getRealPathSync()
+    repo = @pathToRepository[gitDirPath]
+    unless repo
+      repo = GitRepository.open(gitDirPath, project: @project)
+      repo.onDestroy(() => delete @pathToRepository[gitDirPath])
+      @pathToRepository[gitDirPath] = repo
+      repo.refreshIndex()
+      repo.refreshStatus()
+    repo


### PR DESCRIPTION
This changes `getPaths()` to be an async method that iterates over the `RepositoryProvider`
objects registered via `atom.repository-provider` and asks each one to try to create a `Repository`
for the `Directory` that corresponds to the path. This uses the async `repositoryForDirectory()` API
instead of the `createRepositorySync()` API that was used before.

Currently, `getPaths()` maps a path to a `Directory` asynchronously via the following basic logic:

```
Promise.resolve(new Directory(path))
```

But in a follow up diff, I'll introduce the `DirectoryProvider` described in
https://github.com/atom/atom/pull/5428, so it will be possible to register a custom handler
to map special paths, such as `ftp://`.

This builds on https://github.com/atom/atom/pull/5491.
