### PR TITLE
Move reactCompat option to transform as per 6to5 deprecation warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "atomShellVersion": "0.21.0",
   "dependencies": {
-    "6to5-core": "^3.0.14",
+    "6to5-core": "^3.6.0",
     "async": "0.2.6",
     "atom-keymap": "^3.1.2",
     "bootstrap": "git+https://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",

--- a/src/6to5.coffee
+++ b/src/6to5.coffee
@@ -18,11 +18,6 @@ defaultOptions =
   # when the source map is inlined.
   sourceMap: 'inline'
 
-  # Because Atom is currently packaged with a fork of React v0.11,
-  # it makes sense to use the --react-compat option so the React
-  # JSX transformer produces pre-v0.12 code.
-  reactCompat: true
-
   # Blacklisted features do not get transpiled. Features that are
   # natively supported in the target environment should be listed
   # here. Because Atom uses a bleeding edge version of Node/io.js,
@@ -40,6 +35,11 @@ defaultOptions =
     # Target a version of the regenerator runtime that
     # supports yield so the transpiled code is cleaner/smaller.
     'asyncToGenerator'
+
+    # Because Atom is currently packaged with a fork of React v0.11,
+    # it makes sense to use the reactCompat transform so the React
+    # JSX transformer produces pre-v0.12 code.
+    'reactCompat'
   ]
 
 ###


### PR DESCRIPTION
Bumped the version of 6to5-core to `^3.6.0` to ensure `reactCompat` is
available as a transform rather than an option.

Verified that the deprecation warning went away in my console and that a
package that uses JSX+React still works as expected.
