### PR TITLE
:memo: a little hint added for 'Building from source for linux'

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -18,6 +18,9 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 
 * `sudo apt-get install build-essential git libgnome-keyring-dev fakeroot`
 * Instructions for  [Node.js](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#ubuntu-mint-elementary-os).
+  * Make sure the command `node` is available after Node.js installation (some sytems install it as `nodejs`).
+  * `which node` to check it.
+    * If output is emtpy run `sudo ln -s /usr/bin/nodejs /usr/bin/node` to fix this.
 
 ### Fedora / CentOS / RHEL
 


### PR DESCRIPTION
_script/build_ has the shebang #!/usr/bin/env node. On some system this command is no available but nodejs (e.g. on debian).
The softlink fixes this problem, and all the other steps work fine.
