### PR TITLE
Optimize auto-indent on paste

### DIFF
--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -309,6 +309,14 @@ class TokenizedBuffer extends Model
     {tokens, ruleStack} = @grammar.tokenizeLine(line, ruleStack, row is 0)
     new TokenizedLine({tokens, ruleStack, tabLength, lineEnding, indentLevel, @invisibles})
 
+  buildTokenizedLineForRowWithText: (row, line) ->
+    ruleStack = @stackForRow(row - 1)
+    lineEnding = @buffer.lineEndingForRow(row)
+    tabLength = @getTabLength()
+    indentLevel = @indentLevelForRow(row)
+    {tokens, ruleStack} = @grammar.tokenizeLine(line, ruleStack, row is 0)
+    new TokenizedLine({tokens, ruleStack, tabLength, lineEnding, indentLevel, @invisibles})
+
   tokenizedLineForRow: (bufferRow) ->
     @tokenizedLines[bufferRow]
 

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -302,15 +302,9 @@ class TokenizedBuffer extends Model
     new TokenizedLine({tokens, tabLength, indentLevel, @invisibles, lineEnding})
 
   buildTokenizedLineForRow: (row, ruleStack) ->
-    line = @buffer.lineForRow(row)
-    lineEnding = @buffer.lineEndingForRow(row)
-    tabLength = @getTabLength()
-    indentLevel = @indentLevelForRow(row)
-    {tokens, ruleStack} = @grammar.tokenizeLine(line, ruleStack, row is 0)
-    new TokenizedLine({tokens, ruleStack, tabLength, lineEnding, indentLevel, @invisibles})
+    @buildTokenizedLineForRowWithText(row, @buffer.lineForRow(row), ruleStack)
 
-  buildTokenizedLineForRowWithText: (row, line) ->
-    ruleStack = @stackForRow(row - 1)
+  buildTokenizedLineForRowWithText: (row, line, ruleStack = @stackForRow(row - 1)) ->
     lineEnding = @buffer.lineEndingForRow(row)
     tabLength = @getTabLength()
     indentLevel = @indentLevelForRow(row)


### PR DESCRIPTION
Previously, auto-indent-on-paste updated pasted text _after_ inserting it into the buffer, causing tons of buffer changes events to be emitted, which is very expensive. Now, we adjust all but the first line of the inserted text before inserting it into the buffer. The first line still needs to be post-processed in case it requires indentation to be less than the insertion column.

Fixes #5529
Fixes #5411
