### PR TITLE
Try to set the Project's repo if it does not have one when a new Reposit...

### DIFF
--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -15,12 +15,13 @@ describe "Project", ->
 
   describe "constructor", ->
     it "tries to update repositories when a new RepositoryProvider is registered", ->
-      atom.project.setPaths(["/tmp"])
+      tmp = temp.mkdirSync('atom-project')
+      atom.project.setPaths([tmp])
       expect(atom.project.getRepositories()).toEqual [null]
       expect(atom.project.repositoryProviders.length).toEqual 1
 
       # Register a new RepositoryProvider.
-      dummyRepository = destroy: () ->
+      dummyRepository = destroy: ->
       repositoryProvider =
         repositoryForDirectory: (directory) -> Promise.resolve(dummyRepository)
         repositoryForDirectorySync: (directory) -> dummyRepository
@@ -37,7 +38,7 @@ describe "Project", ->
       expect(repository).toBeTruthy()
 
       # Register a new RepositoryProvider.
-      dummyRepository = destroy: () ->
+      dummyRepository = destroy: ->
       repositoryProvider =
         repositoryForDirectory: (directory) -> Promise.resolve(dummyRepository)
         repositoryForDirectorySync: (directory) -> dummyRepository

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -13,6 +13,39 @@ describe "Project", ->
   beforeEach ->
     atom.project.setPaths([atom.project.getDirectories()[0]?.resolve('dir')])
 
+  describe "constructor", ->
+    it "tries to update repositories when a new RepositoryProvider is registered", ->
+      atom.project.setPaths(["/tmp"])
+      expect(atom.project.getRepositories()).toEqual [null]
+      expect(atom.project.repositoryProviders.length).toEqual 1
+
+      # Register a new RepositoryProvider.
+      dummyRepository = destroy: () ->
+      repositoryProvider =
+        repositoryForDirectory: (directory) -> Promise.resolve(dummyRepository)
+        repositoryForDirectorySync: (directory) -> dummyRepository
+      atom.packages.serviceHub.provide(
+        "atom.repository-provider", "0.1.0", repositoryProvider)
+
+      expect(atom.project.repositoryProviders.length).toBe 2
+      expect(atom.project.getRepositories()).toEqual [dummyRepository]
+
+    it "does not update @repositories if every path has a Repository", ->
+      repositories = atom.project.getRepositories()
+      expect(repositories.length).toEqual 1
+      [repository] = repositories
+      expect(repository).toBeTruthy()
+
+      # Register a new RepositoryProvider.
+      dummyRepository = destroy: () ->
+      repositoryProvider =
+        repositoryForDirectory: (directory) -> Promise.resolve(dummyRepository)
+        repositoryForDirectorySync: (directory) -> dummyRepository
+      atom.packages.serviceHub.provide(
+        "atom.repository-provider", "0.1.0", repositoryProvider)
+
+      expect(atom.project.getRepositories()).toBe repositories
+
   describe "serialization", ->
     deserializedProject = null
 

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -76,9 +76,9 @@ beforeEach ->
   $.fx.off = true
   documentTitle = null
   projectPath = specProjectPath ? path.join(@specDirectory, 'fixtures')
+  atom.packages.serviceHub = new ServiceHub
   atom.project = new Project(paths: [projectPath])
   atom.workspace = new Workspace()
-  atom.packages.serviceHub = new ServiceHub
   atom.keymaps.keyBindings = _.clone(keyBindingsToRestore)
   atom.commands.restoreSnapshot(commandsToRestore)
   atom.styles.restoreSnapshot(styleElementsToRestore)

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -53,7 +53,15 @@ class Project extends Model
     atom.packages.serviceHub.consume(
       'atom.repository-provider',
       '^0.1.0',
-      (provider) => @repositoryProviders.push(provider))
+      (provider) =>
+        @repositoryProviders.push(provider)
+
+        # If a path in getPaths() does not have a corresponding Repository, try
+        # to assign one by running through setPaths() again now that
+        # @repositoryProviders has been updated.
+        if null in @repositories
+          @setPaths(@getPaths())
+      )
 
     @subscribeToBuffer(buffer) for buffer in @buffers
 


### PR DESCRIPTION
...oryProvider is registered.

I tested this using my test `HgRepositoryProvider`. Now when I run the following from the
command line:

```
atom <path-to-directory-with-hg-repository>
```

And then run the following in the console:

```
atom.project.getRepositories()
```

I get an array with an `HgRepository` in it. Previously, I got an empty array because the
`Project`'s paths were set before my `HgRepositoryProvider` was registered.
