### PR TITLE
Fix typos in API docs

### DIFF
--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -803,7 +803,7 @@ class Atom extends Model
   # require completes.
   #
   # * `id` The {String} module name or path.
-  # * `globals` An optinal {Object} to set as globals during require.
+  # * `globals` An optional {Object} to set as globals during require.
   requireWithGlobals: (id, globals={}) ->
     existingGlobals = {}
     for key, value of globals

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -59,7 +59,7 @@ class GitRepository
   # Public: Creates a new GitRepository instance.
   #
   # * `path` The {String} path to the Git repository to open.
-  # * `options` An optinal {Object} with the following keys:
+  # * `options` An optional {Object} with the following keys:
   #   * `refreshOnWindowFocus` A {Boolean}, `true` to refresh the index and
   #     statuses when the window is focused.
   #


### PR DESCRIPTION
The word `optional` was misspelled as `optinal` two times in the API docs. This PR corrects those errors.
