### PR TITLE
Use double colons for "before" and "after" pseudo-elements

### DIFF
--- a/static/icons.less
+++ b/static/icons.less
@@ -1,6 +1,6 @@
 @import "ui-variables";
 
-.icon:before {
+.icon::before {
   margin-right: @component-icon-padding;
 }
 

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -68,7 +68,7 @@ body {
         color: #eee;
       }
 
-      &:before {
+      &::before {
         content: "\02022";
       }
     }

--- a/static/lists.less
+++ b/static/lists.less
@@ -25,10 +25,10 @@
     white-space: nowrap;
   }
 
-  // The background highlight uses :before rather than the item background so
+  // The background highlight uses ::before rather than the item background so
   // it can span the entire width of the parent container rather than the size
   // of the list item.
-  .selected:before {
+  .selected::before {
     content: '';
     background-color: @background-color-selected;
     position: absolute;
@@ -42,7 +42,7 @@
     position: relative;
   }
 
-  .icon:before {
+  .icon::before {
     margin-right: @component-icon-padding;
     position: relative;
     top: 1px;
@@ -73,7 +73,7 @@
     // Nested items always get disclosure arrows
     .list-nested-item > .list-item {
       .octicon(chevron-down, @disclosure-arrow-size);
-      &:before{
+      &::before{
         position: relative;
         top: -1px;
         margin-right: @component-icon-padding;
@@ -81,7 +81,7 @@
     }
     .list-nested-item.collapsed > .list-item {
       .octicon(chevron-right, @disclosure-arrow-size);
-      &:before{
+      &::before{
         left: 1px;
       }
     }

--- a/static/select-list.less
+++ b/static/select-list.less
@@ -6,7 +6,7 @@
     .loading-message {
       .octicon(hourglass);
 
-      &:before {
+      &::before {
         font-size: 1.1em;
         width: 1.1em;
         height: 1.1em;

--- a/static/text-editor-light.less
+++ b/static/text-editor-light.less
@@ -62,7 +62,7 @@ atom-text-editor {
       opacity: .6;
       padding: 0 .4em;
 
-      &:before {
+      &::before {
         text-align: center;
       }
     }
@@ -84,7 +84,7 @@ atom-text-editor {
 
       visibility: visible;
 
-      &:before {
+      &::before {
         position: relative;
         left: -.1em;
       }
@@ -129,7 +129,7 @@ atom-text-editor {
   .line {
     white-space: pre;
 
-    &.cursor-line .fold-marker:after {
+    &.cursor-line .fold-marker::after {
       opacity: 1;
     }
   }
@@ -137,7 +137,7 @@ atom-text-editor {
   .fold-marker {
     cursor: default;
 
-    &:after {
+    &::after {
       .icon(0.8em, inline);
 
       content: @ellipsis;

--- a/static/text-editor-shadow.less
+++ b/static/text-editor-shadow.less
@@ -44,7 +44,7 @@
     opacity: .6;
     padding: 0 .4em;
 
-    &:before {
+    &::before {
       text-align: center;
     }
   }
@@ -66,7 +66,7 @@
 
     visibility: visible;
 
-    &:before {
+    &::before {
       position: relative;
       left: -.1em;
     }
@@ -111,7 +111,7 @@
 .line {
   white-space: pre;
 
-  &.cursor-line .fold-marker:after {
+  &.cursor-line .fold-marker::after {
     opacity: 1;
   }
 }
@@ -119,7 +119,7 @@
 .fold-marker {
   cursor: default;
 
-  &:after {
+  &::after {
     .icon(0.8em, inline);
 
     content: @ellipsis;

--- a/static/variables/octicon-mixins.less
+++ b/static/variables/octicon-mixins.less
@@ -18,7 +18,7 @@
 
 .octicon(@name, @size: 16px) {
   @import "octicon-utf-codes.less";
-  &:before {
+  &::before {
     .icon(@size);
     content: @@name
   }
@@ -26,7 +26,7 @@
 
 .mega-octicon(@name, @size: 32px) {
   @import "octicon-utf-codes.less";
-  &:before {
+  &::before {
     .icon(@size);
     content: @@name
   }


### PR DESCRIPTION
In CSS3, single colon for pseudo-elements is deprecated.
