### PR TITLE
fix .deb  file for debian and ubuntu 14.04TLS comfortability 

### DIFF
--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= name %>
 Version: <%= version %>
-Depends: git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11, libnotify4, libxtst6, libnss3, python, gvfs-bin, xdg-utils
+Depends: git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, python, gvfs-bin, xdg-utils
 Suggests: libgnome-keyring0, gir1.2-gnomekeyring-1.0
 Section: <%= section %>
 Priority: optional


### PR DESCRIPTION
fix .deb file  for Debian (SID/JESSY versions)  and Ubuntu 14.04TLS comfortability 
