### PR TITLE
Add "Checking for Update" to menu

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -7,6 +7,7 @@
       { label: 'VERSION', enabled: false }
       { label: 'Restart and Install Update', command: 'application:install-update', visible: false}
       { label: 'Check for Update', command: 'application:check-for-update', visible: false}
+      { label: 'Checking for Update', enabled: false, visible: false}
       { label: 'Downloading Update', enabled: false, visible: false}
       { type: 'separator' }
       { label: 'Preferences...', command: 'application:show-settings' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -166,6 +166,7 @@
       { label: 'VERSION', enabled: false }
       { label: 'Restart and Install Update', command: 'application:install-update', visible: false}
       { label: 'Check for Update', command: 'application:check-for-update', visible: false}
+      { label: 'Checking for Update', enabled: false, visible: false}
       { label: 'Downloading Update', enabled: false, visible: false}
       { type: 'separator' }
       { label: '&Documentation', command: 'application:open-documentation' }

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -92,19 +92,23 @@ class ApplicationMenu
   # Sets the proper visible state the update menu items
   showUpdateMenuItem: (state) ->
     checkForUpdateItem = _.find(@flattenMenuItems(@menu), ({label}) -> label == 'Check for Update')
+    checkingForUpdateItem = _.find(@flattenMenuItems(@menu), ({label}) -> label == 'Checking for Update')
     downloadingUpdateItem = _.find(@flattenMenuItems(@menu), ({label}) -> label == 'Downloading Update')
     installUpdateItem = _.find(@flattenMenuItems(@menu), ({label}) -> label == 'Restart and Install Update')
 
-    return unless checkForUpdateItem? and downloadingUpdateItem? and installUpdateItem?
+    return unless checkForUpdateItem? and checkingForUpdateItem? and downloadingUpdateItem? and installUpdateItem?
 
     checkForUpdateItem.visible = false
+    checkingForUpdateItem.visible = false
     downloadingUpdateItem.visible = false
     installUpdateItem.visible = false
 
     switch state
       when 'idle', 'error', 'no-update-available'
         checkForUpdateItem.visible = true
-      when 'checking', 'downloading'
+      when 'checking'
+        checkingForUpdateItem.visible = true
+      when 'downloading'
         downloadingUpdateItem.visible = true
       when 'update-available'
         installUpdateItem.visible = true


### PR DESCRIPTION
When state is “checking”, menu should say “Checking for Update” instead of "Downloading Update".  This solves the issue of a slow network connection where it incorrectly shows "Downloading Update" even before it has been determined if an update is available.
