### PR TITLE
:bug: Do not modify excess whitespace when modifying indentation

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2852,6 +2852,16 @@ describe "TextEditor", ->
               # Preserve the indentation of the next row
               expect(editor.indentationForBufferRow(8)).toBe(3)
 
+            it "auto-indents without losing alignment spaces", ->
+              expect(editor.indentationForBufferRow(5)).toBe(3)
+
+              atom.clipboard.write("/**\n * PHPDoc\n * End\n */\na(x);\n  b(x);\n", indentBasis: 0)
+              editor.setCursorBufferPosition([5, 0])
+              editor.pasteText()
+
+              # Do not lose the alignment spaces
+              expect(editor.lineTextForBufferRow(6)).toBe("       * PHPDoc")
+
           describe "when non-whitespace characters precede the cursor", ->
             it "does not auto-indent the first line being pasted", ->
               editor.setText """
@@ -3583,7 +3593,7 @@ describe "TextEditor", ->
   describe ".indentLevelForLine(line)", ->
     it "returns the indent level when the line has only leading whitespace", ->
       expect(editor.indentLevelForLine("    hello")).toBe(2)
-      expect(editor.indentLevelForLine("   hello")).toBe(1.5)
+      expect(editor.indentLevelForLine("   hello")).toBe(1)
 
     it "returns the indent level when the line has only leading tabs", ->
       expect(editor.indentLevelForLine("\t\thello")).toBe(2)
@@ -3591,8 +3601,9 @@ describe "TextEditor", ->
     it "returns the indent level when the line has mixed leading whitespace and tabs", ->
       expect(editor.indentLevelForLine("\t  hello")).toBe(2)
       expect(editor.indentLevelForLine("  \thello")).toBe(2)
-      expect(editor.indentLevelForLine("  \t hello")).toBe(2.5)
-      expect(editor.indentLevelForLine("  \t \thello")).toBe(3.5)
+      expect(editor.indentLevelForLine("  \t hello")).toBe(2)
+      expect(editor.indentLevelForLine("  \t \thello")).toBe(3)
+      expect(editor.indentLevelForLine(" \t \t \thello")).toBe(3)
 
   describe "when the buffer is reloaded", ->
     it "preserves the current cursor position", ->
@@ -4008,6 +4019,48 @@ describe "TextEditor", ->
       expect(editor.getCursorBufferPosition()).toEqual [0, 2]
       editor.moveLeft()
       expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
+  describe ".modifyIndentWhitespace", ->
+    it "sets, increases or descreases soft tab indentation", ->
+      expect(editor.modifyIndentWhitespace("  ", 4)).toBe("        ")
+      expect(editor.modifyIndentWhitespace("  ", 0)).toBe("")
+      expect(editor.modifyIndentWhitespace("    ", 1, 2)).toBe("      ")
+      expect(editor.modifyIndentWhitespace("    ", undefined, 1)).toBe("      ")
+      expect(editor.modifyIndentWhitespace("    ", undefined, -1)).toBe("  ")
+
+      # Leave alone excess spacing that may be aligning text (such as in /**/ blocks)
+      expect(editor.modifyIndentWhitespace("   ", 0)).toBe(" ")
+      expect(editor.modifyIndentWhitespace("    ", 0)).toBe("")
+
+    it "sets, increases or descreases hard tab indentation", ->
+      editor.setSoftTabs(false)
+      expect(editor.modifyIndentWhitespace("\t", 4)).toBe("\t\t\t\t")
+      expect(editor.modifyIndentWhitespace("\t", 0)).toBe("")
+      expect(editor.modifyIndentWhitespace("\t\t", 1, 2)).toBe("\t\t\t")
+      expect(editor.modifyIndentWhitespace("\t\t", undefined, 1)).toBe("\t\t\t")
+      expect(editor.modifyIndentWhitespace("\t\t", undefined, -1)).toBe("\t")
+
+      # Leave alone excess spacing that may be aligning text (such as in /**/ blocks)
+      expect(editor.modifyIndentWhitespace("\t ", 0)).toBe(" ")
+      expect(editor.modifyIndentWhitespace("\t  ", 0)).toBe("")
+
+  describe ".modifyIndentLevelForRow", ->
+    it "modifies a buffer row's indentation", ->
+      editor.setSoftTabs(false)
+      editor.setText("\t1\n\t\t2")
+      editor.modifyIndentLevelForRow(1, undefined, 1)
+      expect(editor.getText()).toBe("\t1\n\t\t\t2")
+      editor.modifyIndentLevelForRow(1, 1)
+      expect(editor.getText()).toBe("\t1\n\t2")
+
+  describe ".modifyIndentLevelForLine", ->
+    it "modifies a buffer row's indentation", ->
+      editor.setSoftTabs(false)
+      line = "\t\t2"
+      result = editor.modifyIndentLevelForLine(line, undefined, 1)
+      expect(result).toBe("\t\t\t2")
+      result = editor.modifyIndentLevelForLine(line, 1)
+      expect(result).toBe("\t2")
 
   describe ".setIndentationForBufferRow", ->
     describe "when the editor uses soft tabs but the row has hard tabs", ->

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -722,7 +722,7 @@ describe "TokenizedBuffer", ->
         expect(tokenizedBuffer.tokenizedLineForRow(1).indentLevel).toBe 1
         expect(tokenizedBuffer.tokenizedLineForRow(2).indentLevel).toBe 2
         buffer.insert([2, 0], ' ')
-        expect(tokenizedBuffer.tokenizedLineForRow(2).indentLevel).toBe 2.5
+        expect(tokenizedBuffer.tokenizedLineForRow(2).indentLevel).toBe 2
 
     describe "when the line is empty", ->
       it "assumes the indentation level of the first non-empty line below or above if one exists", ->
@@ -900,3 +900,35 @@ describe "TokenizedBuffer", ->
       expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0].value).toBe 'b'
       expect(tokenizedBuffer.tokenizedLineForRow(2).tokens.length).toBe 1
       expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0].value).toBe 'c'
+
+  describe ".parseIndentation(leadingWhitespace)", ->
+    it "parses the indentation correctly", ->
+      buffer = atom.project.bufferForPathSync('sample-with-tabs-and-initial-comment.js')
+      tokenizedBuffer = new TokenizedBuffer({buffer})
+      fullyTokenize(tokenizedBuffer)
+
+      parseIndentation = (bufferRow) ->
+        leadingWhitespace = tokenizedBuffer.tokenizedLineForRow(bufferRow).text.match(/^[\t ]*/)[0]
+        tokenizedBuffer.parseIndentation(leadingWhitespace)
+
+      parsed = parseIndentation(0)
+      expect(parsed.indentLevel).toBe 0
+      expect(parsed.excessSpace).toBe 0
+      parsed = parseIndentation(1)
+      expect(parsed.indentLevel).toBe 0
+      expect(parsed.excessSpace).toBe 1
+      parsed = parseIndentation(2)
+      expect(parsed.indentLevel).toBe 0
+      expect(parsed.excessSpace).toBe 1
+      parsed = parseIndentation(3)
+      expect(parsed.indentLevel).toBe 0
+      expect(parsed.excessSpace).toBe 1
+      parsed = parseIndentation(4)
+      expect(parsed.indentLevel).toBe 0
+      expect(parsed.excessSpace).toBe 0
+      parsed = parseIndentation(5)
+      expect(parsed.indentLevel).toBe 0
+      expect(parsed.excessSpace).toBe 0
+      parsed = parseIndentation(6)
+      expect(parsed.indentLevel).toBe 1
+      expect(parsed.excessSpace).toBe 0

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -496,6 +496,9 @@ class DisplayBuffer extends Model
   indentLevelForLine: (line) ->
     @tokenizedBuffer.indentLevelForLine(line)
 
+  parseIndentation: (leadingWhitespace) ->
+    @tokenizedBuffer.parseIndentation(leadingWhitespace)
+
   # Given starting and ending screen rows, this returns an array of the
   # buffer rows corresponding to every screen row in the range
   #

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -606,9 +606,7 @@ class Selection extends Model
       else if indentAdjustment > 0
         lines[i] = @editor.buildIndentString(indentAdjustment) + line
       else
-        currentIndentLevel = @editor.indentLevelForLine(lines[i])
-        indentLevel = Math.max(0, currentIndentLevel + indentAdjustment)
-        lines[i] = line.replace(/^[\t ]+/, @editor.buildIndentString(indentLevel))
+        lines[i] = @editor.modifyIndentLevelForLine(line, undefined, indentAdjustment)
     return
 
   # Indent the current line(s).

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -348,12 +348,22 @@ class TokenizedBuffer extends Model
 
   indentLevelForLine: (line) ->
     if match = line.match(/^[\t ]+/)
-      leadingWhitespace = match[0]
-      tabCount = leadingWhitespace.match(/\t/g)?.length ? 0
-      spaceCount = leadingWhitespace.match(/[ ]/g)?.length ? 0
-      tabCount + (spaceCount / @getTabLength())
+      {indentLevel} = @parseIndentation(match[0])
+      indentLevel
     else
       0
+
+  parseIndentation: (leadingWhitespace) ->
+    tabLength = @getTabLength()
+    columnCount = 0
+    for c in leadingWhitespace
+      if c is '\t'
+        columnCount += tabLength - (columnCount % tabLength)
+      else
+        columnCount += 1
+    excessSpace = columnCount % tabLength
+
+    {indentLevel: (columnCount - excessSpace) / tabLength, excessSpace: excessSpace}
 
   scopeDescriptorForPosition: (position) ->
     new ScopeDescriptor(scopes: @tokenForPosition(position).scopes)


### PR DESCRIPTION
This is a proposal for fixing #5642 and I'd welcome feedback on if this is the right approach or not?

The problem, is copying pasting PHPDoc code at an indented level, with hard tabs on, loses the asterisk alignment:

![example](https://cloud.githubusercontent.com/assets/939815/6273202/41e81dbe-b865-11e4-8ea5-a5354bdbb50c.gif)

**Root Cause**

Seems inside Atom, in the case of encountering soft tabs in a hard tab file... it can return a _floating point_ indentation level, such as 1.5 in this instance (tab+half-tab). When rebuilding the indentation (it calls setIndentationForBufferRow for each line), this calls @buildIndentString with 1.5 which gets converted to integer: 1. ALL leading whitespace is then replaced by this new indentation - so we lose the space that aligns the asterisk.

The tests seem to point to floating point indentation levels being allowed. Yet I can find nowhere where it is useful. Most places just Math.ceil(). And with hard tabs it doesn't even make sense.

This patch attempts to remove all the floating points (it leaves the Math.ceil calls - they're harmless and can be cleaned later if this turns out the right approach.). It then has a function for "modifying" whitespace to change its indentation level, while paying attention to straggling spacing like that in the PHPDoc comments in the image above. It also adds a couple API for handling indentation changes that can be used elsewhere.

Only thing I'm not too happy with is the overlap between my "setIndentLevelForRow" and the existing "setIndentationForBufferRow" - I'm sure mine follows correct naming convention but existing doesn't. It is the existing one that is called when pasting though.
