### PR TITLE
Faster `mergeIntersectingSelections`

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2206,11 +2206,18 @@ class TextEditor extends Model
       result = fn()
       @suppressSelectionMerging = false
 
+    findIntersectingSelection = (elements, selection) ->
+      return if elements.length == 0
+
+      otherSelection = _.last(elements)
+      exclusive = not selection.isEmpty() and not otherSelection.isEmpty()
+      intersects = otherSelection.intersectsWith(selection, exclusive)
+
+      return otherSelection if intersects
+
+
     reducer = (disjointSelections, selection) ->
-      intersectingSelection = _.find disjointSelections, (otherSelection) ->
-        exclusive = not selection.isEmpty() and not otherSelection.isEmpty()
-        intersects = otherSelection.intersectsWith(selection, exclusive)
-        intersects
+      intersectingSelection = findIntersectingSelection(disjointSelections, selection)
 
       if intersectingSelection?
         intersectingSelection.merge(selection, options)
@@ -2218,7 +2225,7 @@ class TextEditor extends Model
       else
         disjointSelections.concat([selection])
 
-    _.reduce(@getSelections(), reducer, [])
+    _.reduce(@getSelectionsOrderedByBufferPosition(), reducer, [])
 
   # Add a {Selection} based on the given {Marker}.
   #

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2206,26 +2206,19 @@ class TextEditor extends Model
       result = fn()
       @suppressSelectionMerging = false
 
-    findIntersectingSelection = (elements, selection) ->
-      return if elements.length == 0
-
-      otherSelection = _.last(elements)
-      exclusive = not selection.isEmpty() and not otherSelection.isEmpty()
-      intersects = otherSelection.intersectsWith(selection, exclusive)
-
-      return otherSelection if intersects
-
-
     reducer = (disjointSelections, selection) ->
-      intersectingSelection = findIntersectingSelection(disjointSelections, selection)
+      adjacentSelection = _.last(disjointSelections)
+      exclusive = not selection.isEmpty() and not adjacentSelection.isEmpty()
+      intersects = adjacentSelection.intersectsWith(selection, exclusive)
 
-      if intersectingSelection?
-        intersectingSelection.merge(selection, options)
+      if intersects
+        adjacentSelection.merge(selection, options)
         disjointSelections
       else
         disjointSelections.concat([selection])
 
-    _.reduce(@getSelectionsOrderedByBufferPosition(), reducer, [])
+    [head, tail...] = @getSelectionsOrderedByBufferPosition()
+    _.reduce(tail, reducer, [head])
 
   # Add a {Selection} based on the given {Marker}.
   #


### PR DESCRIPTION
This pull-request introduces a performance improvement in `mergeIntersectingSelection`. Before changing it the cost of this function was `O(n^2)`: selections were accessed always and in sparse order, causing the traversing time to increase exponentially as more and more selections were added. 

Before merging selections, we now order them first and try to intersect the current selection with the previous one only. This brings the cost of `mergeIntersectingSelections` down to `O(n log n)`, changing this:

![screen shot 2015-02-22 at 14 01 32](https://cloud.githubusercontent.com/assets/482957/6318610/5c48188e-ba9b-11e4-9470-5ce9becff76f.png)

To this:

![screen shot 2015-02-22 at 14 00 31](https://cloud.githubusercontent.com/assets/482957/6318618/b80862aa-ba9b-11e4-9ea7-eafbf7fe32e1.png)

:racehorse: :racehorse: :racehorse: 

_(Benchmarks based on splitting into lines the entire selection of a 400 lines file)_

All the specs are green, therefore this "new algorithm" shouldn't have changed the behavior of `mergeIntersectingSelections`. It would be great to have some more :eyes: to detect any possible regression.

Hopefully, this should be a significant step forward towards #5163 :smile: 
