### PR TITLE
:lipstick: Removes last reference to obsolete term 'Activation Events'.

### DIFF
--- a/docs/your-first-package.md
+++ b/docs/your-first-package.md
@@ -72,7 +72,7 @@ command palette or by pressing `ctrl-alt-cmd-l`.
 
 Now open the command panel and search for the `ascii-art:convert` command. But
 it's not there! To fix this, open _package.json_ and find the property called
-`activationCommands`. Activation Events speed up load time by allowing Atom to
+`activationCommands`. Activation Commands speed up Atom's load time by allowing it to
 delay a package's activation until it's needed. So remove the existing command
 and add `ascii-art:convert` to the `activationCommands` array:
 


### PR DESCRIPTION
A minor improvement to the "Your First Package" guide.
