### PR TITLE
fix #5602

### DIFF
--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -34,8 +34,7 @@ class PackageManager
     @emitter = new Emitter
     @packageDirPaths = []
     unless safeMode
-      if @devMode
-        @packageDirPaths.push(path.join(configDirPath, "dev", "packages"))
+      @packageDirPaths.push(path.join(configDirPath, "dev", "packages"))
       @packageDirPaths.push(path.join(configDirPath, "packages"))
 
     @loadedPackages = {}


### PR DESCRIPTION
Issue #5602 is that packages that are `apm link --dev`ed are undefined and unusable in a normal `atom` session. While reading through the `PackageManager` source today, I noticed that the path `~/.atom/dev/packages` is only added to the package search path when in `devMode`. This tiny fix should resolve that issue.
