### PR TITLE
Report deprecation warning when 'use 6to5' is used instead of 'use babel'.

### DIFF
--- a/spec/babel-spec.coffee
+++ b/spec/babel-spec.coffee
@@ -40,7 +40,7 @@ describe "Babel transpiler support", ->
       expect(grim.getDeprecationsLength()).toBe 0
 
   describe "when a .js file starts with 'use 6to5';", ->
-    it "transpiles it using babel and adds a deprecation", ->
+    it "transpiles it using babel and adds a pragma deprecation", ->
       expect(grim.getDeprecationsLength()).toBe 0
       transpiled = require('./fixtures/babel/6to5-single-quotes.js')
       expect(transpiled(3)).toBe 4
@@ -53,7 +53,7 @@ describe "Babel transpiler support", ->
       expect(grim.getDeprecationsLength()).toBe 0
 
   describe 'when a .js file starts with "use 6to5";', ->
-    it "transpiles it using babel", ->
+    it "transpiles it using babel and adds a pragma deprecation", ->
       expect(grim.getDeprecationsLength()).toBe 0
       transpiled = require('./fixtures/babel/6to5-double-quotes.js')
       expect(transpiled(3)).toBe 4

--- a/spec/babel-spec.coffee
+++ b/spec/babel-spec.coffee
@@ -1,7 +1,14 @@
 babel = require '../src/babel'
 crypto = require 'crypto'
+grim = require 'grim'
 
 describe "Babel transpiler support", ->
+  beforeEach ->
+    jasmine.snapshotDeprecations()
+
+  afterEach ->
+    jasmine.restoreDeprecationsSnapshot()
+
   describe "::createBabelVersionAndOptionsDigest", ->
     it "returns a digest for the library version and specified options", ->
       defaultOptions =
@@ -30,21 +37,27 @@ describe "Babel transpiler support", ->
     it "transpiles it using babel", ->
       transpiled = require('./fixtures/babel/babel-single-quotes.js')
       expect(transpiled(3)).toBe 4
+      expect(grim.getDeprecationsLength()).toBe 0
 
   describe "when a .js file starts with 'use 6to5';", ->
-    it "transpiles it using 6to5", ->
+    it "transpiles it using babel and adds a deprecation", ->
+      expect(grim.getDeprecationsLength()).toBe 0
       transpiled = require('./fixtures/babel/6to5-single-quotes.js')
       expect(transpiled(3)).toBe 4
+      expect(grim.getDeprecationsLength()).toBe 1
 
   describe 'when a .js file starts with "use babel";', ->
     it "transpiles it using babel", ->
       transpiled = require('./fixtures/babel/babel-double-quotes.js')
       expect(transpiled(3)).toBe 4
+      expect(grim.getDeprecationsLength()).toBe 0
 
   describe 'when a .js file starts with "use 6to5";', ->
     it "transpiles it using babel", ->
+      expect(grim.getDeprecationsLength()).toBe 0
       transpiled = require('./fixtures/babel/6to5-double-quotes.js')
       expect(transpiled(3)).toBe 4
+      expect(grim.getDeprecationsLength()).toBe 1
 
   describe "when a .js file does not start with 'use 6to6';", ->
     it "does not transpile it using babel", ->

--- a/src/babel.coffee
+++ b/src/babel.coffee
@@ -8,6 +8,7 @@ crypto = require 'crypto'
 fs = require 'fs-plus'
 path = require 'path'
 babel = null # Defer until used
+Grim = null # Defer until used
 
 stats =
   hits: 0
@@ -127,15 +128,33 @@ transpile = (sourceCode, filePath, cachePath) ->
 
   js
 
+isRoot = (filePath) ->
+  parts = path.parse(filePath)
+  parts.root == filePath
+
 # Function that obeys the contract of an entry in the require.extensions map.
 # Returns the transpiled version of the JavaScript code at filePath, which is
 # either generated on the fly or pulled from cache.
 loadFile = (module, filePath) ->
   sourceCode = fs.readFileSync(filePath, 'utf8')
-  return module._compile(sourceCode, filePath) unless sourceCode.startsWith('"use 6to5"') or
-    sourceCode.startsWith("'use 6to5'") or
-    sourceCode.startsWith('"use babel"') or
-    sourceCode.startsWith("'use babel'")
+  if sourceCode.startsWith('"use babel"') or sourceCode.startsWith("'use babel'")
+    # Continue.
+  else if sourceCode.startsWith('"use 6to5"') or sourceCode.startsWith("'use 6to5'")
+    packageName
+    directory = filePath
+    until packageName
+      directory = path.dirname(directory)
+      manifest = path.join(directory, 'package.json')
+      if fs.existsSync(manifest)
+        json = JSON.parse(fs.readFileSync(manifest))
+        packageName = json.name
+      else if isRoot(directory)
+        break
+
+    Grim ?= require 'grim'
+    Grim.deprecate("Use the 'use babel' pragma instead of 'use 6to5' in #{filePath}", {packageName})
+  else
+    return module._compile(sourceCode, filePath)
 
   cachePath = getCachePath(sourceCode)
   js = getCachedJavaScript(cachePath) ? transpile(sourceCode, filePath, cachePath)

--- a/src/babel.coffee
+++ b/src/babel.coffee
@@ -128,10 +128,6 @@ transpile = (sourceCode, filePath, cachePath) ->
 
   js
 
-isRoot = (filePath) ->
-  parts = path.parse(filePath)
-  parts.root == filePath
-
 # Function that obeys the contract of an entry in the require.extensions map.
 # Returns the transpiled version of the JavaScript code at filePath, which is
 # either generated on the fly or pulled from cache.


### PR DESCRIPTION
In Deprecation Cop, the warning is associated with `atom core` rather than the package that loaded the file with the old pragma.

Also, even though the deprecation message is parameterized by `filePath`, multiple deprecation warnings about the 6to5 pragma appear to be coalesced into a single warning under `atom core`.
