### PR TITLE
Never assume that the project only has one root directory or repository

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4018,3 +4018,25 @@ describe "TextEditor", ->
       editor.setPlaceholderText('OK')
       expect(handler).toHaveBeenCalledWith 'OK'
       expect(editor.getPlaceholderText()).toBe 'OK'
+
+  describe ".checkoutHeadRevision()", ->
+    it "reverts to the version of its file checked into the project repository", ->
+      atom.config.set("editor.confirmCheckoutHeadRevision", false)
+
+      editor.setCursorBufferPosition([0, 0])
+      editor.insertText("---\n")
+      expect(editor.lineTextForBufferRow(0)).toBe "---"
+
+      waitsForPromise ->
+        editor.checkoutHeadRevision()
+
+      runs ->
+        expect(editor.lineTextForBufferRow(0)).toBe "var quicksort = function () {"
+
+    describe "when there's no repository for the editor's file", ->
+      it "doesn't do anything", ->
+        editor = new TextEditor({})
+        editor.setText("stuff")
+        editor.checkoutHeadRevision()
+
+        waitsForPromise -> editor.checkoutHeadRevision()

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -337,7 +337,7 @@ atom.commands.add 'atom-text-editor:not([mini])', stopEventPropagationAndGroupUn
   'editor:newline-below': -> @insertNewlineBelow()
   'editor:newline-above': -> @insertNewlineAbove()
   'editor:toggle-line-comments': -> @toggleLineCommentsInSelection()
-  'editor:checkout-head-revision': -> atom.project.getRepositories()[0]?.checkoutHeadForEditor(this)
+  'editor:checkout-head-revision': -> @checkoutHeadRevision()
   'editor:move-line-up': -> @moveLineUp()
   'editor:move-line-down': -> @moveLineDown()
   'editor:duplicate-lines': -> @duplicateLines()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -12,6 +12,7 @@ DisplayBuffer = require './display-buffer'
 Cursor = require './cursor'
 Selection = require './selection'
 TextMateScopeSelector = require('first-mate').ScopeSelector
+{Directory} = require "pathwatcher"
 
 # Public: This class represents all essential editing state for a single
 # {TextBuffer}, including cursor and selection positions, folds, and soft wraps.
@@ -646,6 +647,14 @@ class TextEditor extends Model
       @isModified()
     else
       @isModified() and not @buffer.hasMultipleEditors()
+
+  checkoutHeadRevision: ->
+    if filePath = this.getPath()
+      atom.project.repositoryForDirectory(new Directory(path.dirname(filePath)))
+        .then (repository) =>
+          repository?.checkoutHeadForEditor(this)
+    else
+      Promise.resolve(false)
 
   ###
   Section: Reading Text

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -132,7 +132,7 @@ class TextEditor extends Model
   subscribeToBuffer: ->
     @buffer.retain()
     @subscribe @buffer.onDidChangePath =>
-      unless atom.project.getPaths()[0]?
+      unless atom.project.getPaths().length > 0
         atom.project.setPaths([path.dirname(@getPath())])
       @emit "title-changed"
       @emitter.emit 'did-change-title', @getTitle()

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -870,8 +870,7 @@ class Workspace extends Model
       exclusions: atom.config.get('core.ignoredNames')
       follow: atom.config.get('core.followSymlinks')
 
-    # TODO: need to support all paths in @getPaths()
-    task = Task.once require.resolve('./scan-handler'), atom.project.getPaths()[0], regex.source, searchOptions, ->
+    task = Task.once require.resolve('./scan-handler'), atom.project.getPaths(), regex.source, searchOptions, ->
       deferred.resolve()
 
     task.on 'scan:result-found', (result) ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -159,16 +159,24 @@ class Workspace extends Model
   # open.
   updateWindowTitle: =>
     appName = 'Atom'
-    if projectPath = atom.project?.getPaths()[0]
-      if item = @getActivePaneItem()
-        document.title = "#{item.getTitle?() ? 'untitled'} - #{projectPath} - #{appName}"
-        atom.setRepresentedFilename(item.getPath?() ? projectPath)
-      else
-        document.title = "#{projectPath} - #{appName}"
-        atom.setRepresentedFilename(projectPath)
+    projectPaths = atom.project?.getPaths() ? []
+    if item = @getActivePaneItem()
+      itemPath = item.getPath?()
+      itemTitle = item.getTitle?()
+      projectPath = _.find projectPaths, (projectPath) ->
+        itemPath is projectPath or itemPath?.startsWith(projectPath + path.sep)
+    itemTitle ?= "untitled"
+    projectPath ?= projectPaths[0]
+
+    if item? and projectPath?
+      document.title = "#{itemTitle} - #{projectPath} - #{appName}"
+      atom.setRepresentedFilename(itemPath ? projectPath)
+    else if projectPath?
+      document.title = "#{projectPath} - #{appName}"
+      atom.setRepresentedFilename(projectPath)
     else
-      document.title = "untitled - #{appName}"
-      atom.setRepresentedFilename('')
+      document.title = "#{itemTitle} - #{appName}"
+      atom.setRepresentedFilename("")
 
   # On OS X, fades the application window's proxy icon when the current file
   # has been modified.


### PR DESCRIPTION
Refs #770.
- [x] Workspace::scan
- [x] 'editor:checkout-head-revision' command
- [x] When text-buffers [change paths](https://github.com/atom/atom/blob/master/src/text-editor.coffee#L134)
- [x] The [document title](https://github.com/atom/atom/blob/4a20dc907957567994010ee754d6025e23baf4ab/src/workspace.coffee#L162)
