### PR TITLE
Make package activation function optional

### DIFF
--- a/spec/fixtures/packages/package-with-no-activate/index.js
+++ b/spec/fixtures/packages/package-with-no-activate/index.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/spec/fixtures/packages/package-with-no-activate/package.json
+++ b/spec/fixtures/packages/package-with-no-activate/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-with-no-activate",
+  "version": "1.0.0"
+}

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -220,6 +220,17 @@ describe "PackageManager", ->
         expect(console.error).not.toHaveBeenCalled()
         expect(console.warn).not.toHaveBeenCalled()
 
+    describe "when the package does not export an activate function", ->
+      it "activates the package and does not throw an exception or log a warning", ->
+        spyOn(console, "warn")
+        expect(-> atom.packages.activatePackage('package-with-no-activate')).not.toThrow()
+
+        waitsFor ->
+          atom.packages.isPackageActive('package-with-no-activate')
+
+        runs ->
+          expect(console.warn).not.toHaveBeenCalled()
+
     it "passes the activate method the package's previously serialized state if it exists", ->
       pack = null
       waitsForPromise ->

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -157,7 +157,7 @@ class Package
       @activateConfig()
       @activateStylesheets()
       if @requireMainModule()
-        @mainModule.activate(atom.packages.getPackageState(@name) ? {})
+        @mainModule.activate?(atom.packages.getPackageState(@name) ? {})
         @mainActivated = true
         @activateServices()
     catch e


### PR DESCRIPTION
Now that we have services and config that both use other exported properties from the package's main module,  implementing and exporting an `activate` function should be optional.

`deactivate` was already optional so this makes the two consistent with each other.

Packages just using services will no longer need a no-op `activate` function exported.
