### PR TITLE
Add API for getting paths relative to project dirs

### DIFF
--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -438,22 +438,22 @@ describe "Project", ->
       randomPath = path.join("some", "random", "path")
       expect(atom.project.relativize(randomPath)).toBe randomPath
 
-  describe ".splitPath(path)", ->
+  describe ".relativizePath(path)", ->
     it "returns the root path that contains the given path, and the path relativized to that root path", ->
       atom.project.addPath(temp.mkdirSync("another-path"))
 
       rootPath = atom.project.getPaths()[0]
       childPath = path.join(rootPath, "some", "child", "directory")
-      expect(atom.project.splitPath(childPath)).toEqual [rootPath, path.join("some", "child", "directory")]
+      expect(atom.project.relativizePath(childPath)).toEqual [rootPath, path.join("some", "child", "directory")]
 
       rootPath = atom.project.getPaths()[1]
       childPath = path.join(rootPath, "some", "child", "directory")
-      expect(atom.project.splitPath(childPath)).toEqual [rootPath, path.join("some", "child", "directory")]
+      expect(atom.project.relativizePath(childPath)).toEqual [rootPath, path.join("some", "child", "directory")]
 
     describe "when the given path isn't inside of any of the project's path", ->
       it "returns null for the root path, and the given path unchanged", ->
         randomPath = path.join("some", "random", "path")
-        expect(atom.project.splitPath(randomPath)).toEqual [null, randomPath]
+        expect(atom.project.relativizePath(randomPath)).toEqual [null, randomPath]
 
   describe ".contains(path)", ->
     it "returns whether or not the given path is in one of the root directories", ->

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -438,6 +438,23 @@ describe "Project", ->
       randomPath = path.join("some", "random", "path")
       expect(atom.project.relativize(randomPath)).toBe randomPath
 
+  describe ".splitPath(path)", ->
+    it "returns the root path that contains the given path, and the path relativized to that root path", ->
+      atom.project.addPath(temp.mkdirSync("another-path"))
+
+      rootPath = atom.project.getPaths()[0]
+      childPath = path.join(rootPath, "some", "child", "directory")
+      expect(atom.project.splitPath(childPath)).toEqual [rootPath, path.join("some", "child", "directory")]
+
+      rootPath = atom.project.getPaths()[1]
+      childPath = path.join(rootPath, "some", "child", "directory")
+      expect(atom.project.splitPath(childPath)).toEqual [rootPath, path.join("some", "child", "directory")]
+
+    describe "when the given path isn't inside of any of the project's path", ->
+      it "returns null for the root path, and the given path unchanged", ->
+        randomPath = path.join("some", "random", "path")
+        expect(atom.project.splitPath(randomPath)).toEqual [null, randomPath]
+
   describe ".contains(path)", ->
     it "returns whether or not the given path is in one of the root directories", ->
       rootPath = atom.project.getPaths()[0]

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -270,7 +270,7 @@ class Project extends Model
   #
   # * `fullPath` {String} full path
   relativize: (fullPath) ->
-    @splitPath(fullPath)[1]
+    @relativizePath(fullPath)[1]
 
   # Public: Get the path to the project directory that contains the given path,
   # and the relative path from that project directory to the given path.
@@ -282,7 +282,7 @@ class Project extends Model
   #   given path, or `null` if none is found.
   # * `relativePath` {String} The relative path from the project directory to
   #   the given path.
-  splitPath: (fullPath) ->
+  relativizePath: (fullPath) ->
     return fullPath if fullPath?.match(/[A-Za-z0-9+-.]+:\/\//) # leave path alone if it has a scheme
     for rootDirectory in @rootDirectories
       relativePath = rootDirectory.relativize(fullPath)

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -266,15 +266,28 @@ class Project extends Model
       else
         undefined
 
-  # Public: Make the given path relative to the project directory.
+  # Public: Make the given path relative to a project directory.
   #
   # * `fullPath` {String} full path
   relativize: (fullPath) ->
+    @splitPath(fullPath)[1]
+
+  # Public: Get the path to the project directory that contains the given path,
+  # and the relative path from that project directory to the given path.
+  #
+  # * `fullPath` {String} An absolute path.
+  #
+  # Returns an {Array} with two elements:
+  # * `projectPath` The {String} path to the project directory that contains the
+  #   given path, or `null` if none is found.
+  # * `relativePath` {String} The relative path from the project directory to
+  #   the given path.
+  splitPath: (fullPath) ->
     return fullPath if fullPath?.match(/[A-Za-z0-9+-.]+:\/\//) # leave path alone if it has a scheme
     for rootDirectory in @rootDirectories
       relativePath = rootDirectory.relativize(fullPath)
-      return relativePath if relativePath isnt fullPath
-    fullPath
+      return [rootDirectory.getPath(), relativePath] unless relativePath is fullPath
+    [null, fullPath]
 
   # Public: Determines whether the given path (real or symbolic) is inside the
   # project's directory.

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -266,9 +266,6 @@ class Project extends Model
       else
         undefined
 
-  # Public: Make the given path relative to a project directory.
-  #
-  # * `fullPath` {String} full path
   relativize: (fullPath) ->
     @relativizePath(fullPath)[1]
 


### PR DESCRIPTION
In adding multi-folder support, a few packages have needed this, and I've had to write local helper functions:
- [tree-view](https://github.com/atom/tree-view/blob/master/lib/move-dialog.coffee#L23)
- [find-and-replace](https://github.com/atom/find-and-replace/blob/master/lib/project/result-view.coffee#L14)
- [fuzzy-finder](https://github.com/atom/fuzzy-finder/blob/d30e2b09988327d9436173386c22e918bd995901/lib/fuzzy-finder-view.coffee#L153)

I think before I write a fourth copy of this helper function for symbols-view, we should add _something_ like it to core. Any suggestions on this API or the naming? The way I have it, it's like this:

``` coffee
[rootPath, relativePath] = atom.project.splitPath(thePath)
if rootPath?
  console.log "#{thePath} is in project directory #{rootPath}. relative path: #{relativePath}"
else
  console.log "#{thePath} is not in any project directory"
```

/cc @nathansobo
