### PR TITLE
Do not hang on soft wrapping when editor is very small

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -80,6 +80,14 @@ describe "DisplayBuffer", ->
           atom.config.set('editor.softWrapAtPreferredLineLength', false)
           expect(displayBuffer.tokenizedLineForScreenRow(10).text).toBe '    return '
 
+      describe "when editor width is negative", ->
+        it "does not hang while wrapping", ->
+          displayBuffer.setDefaultCharWidth(1)
+          displayBuffer.setWidth(-1)
+
+          expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe "  "
+          expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe "  var sort = function(items) {"
+
       describe "when the line is shorter than the max line length", ->
         it "renders the line unchanged", ->
           expect(displayBuffer.tokenizedLineForScreenRow(0).text).toBe buffer.lineForRow(0)

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -458,7 +458,7 @@ class DisplayBuffer extends Model
     width = @width ? @getScrollWidth()
     width -= @getVerticalScrollbarWidth()
     if width? and @defaultCharWidth > 0
-      Math.floor(width / @defaultCharWidth)
+      Math.max(0, Math.floor(width / @defaultCharWidth))
     else
       @editorWidthInChars
 


### PR DESCRIPTION
It appears that #5567 solved #3999 too, with a minor bug that happens during that scenario. This PR attempts to solve it, so that we can close #3999 once for all.

Current behavior (master):

![soft-wrapping-before](https://cloud.githubusercontent.com/assets/482957/6388178/0b6bc678-bd97-11e4-87a6-e7efc6d77392.gif)

After these changes:

![soft-wrapping-after](https://cloud.githubusercontent.com/assets/482957/6388180/1332d932-bd97-11e4-9b4a-b3f51a7a200f.gif)

_(the editor doesn't flash like this, it's a LICEcap issue I guess)_

Unfortunately I have found quite difficult to reproduce the issue via a test (so that we can guard against this regression), probably because when resizing the buffer we need to have a pane (like the tree-view). Any ideas how we can write one? Should we write one at all?

Thanks!
