### PR TITLE
Don't show foldable icon on soft wrapped lines

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -637,6 +637,18 @@ describe "TextEditorComponent", ->
           nextAnimationFrame()
           expect(lineNumberHasClass(5, 'folded')).toBe false
 
+        describe "when soft wrapping is enabled", ->
+          beforeEach ->
+            editor.setSoftWrapped(true)
+            nextAnimationFrame()
+            componentNode.style.width = 16 * charWidth + editor.getVerticalScrollbarWidth() + 'px'
+            component.measureHeightAndWidth()
+            nextAnimationFrame()
+
+          it "doesn't add the foldable class for soft-wrapped lines", ->
+            expect(lineNumberHasClass(0, 'foldable')).toBe true
+            expect(lineNumberHasClass(1, 'foldable')).toBe false
+
       describe "mouse interactions with fold indicators", ->
         [gutterNode] = []
 

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -124,10 +124,10 @@ class GutterComponent
       oldLineNumberState.top = newLineNumberState.top
       oldLineNumberState.screenRow = newLineNumberState.screenRow
 
-  buildLineNumberClassName: ({bufferRow, foldable, decorationClasses}) ->
+  buildLineNumberClassName: ({bufferRow, foldable, decorationClasses, softWrapped}) ->
     className = "line-number line-number-#{bufferRow}"
     className += " " + decorationClasses.join(' ') if decorationClasses?
-    className += " foldable" if foldable
+    className += " foldable" if foldable and not softWrapped
     className
 
   lineNumberNodeForScreenRow: (screenRow) ->


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/5739.
-  574158d adds a failing spec to demonstrate the problem. Running the specs results in this (expected) output:
  
  ```
  TextEditorComponent
  gutter rendering
    fold decorations
      rendering fold decorations
        when soft wrapping is enabled
          it doesn't add the foldable class for soft-wrapped lines
            Expected true to be false. (spec/text-editor-component-spec.coffee:650:55)
  ```
- 09ed657 adds a check in the GutterComponent so that fold icons are added only on the first physical line of soft wrapped lines. Running the specs doesn't trigger the failure above. 

Before :tv::

![foldy2](https://cloud.githubusercontent.com/assets/38924/6414319/b256fdae-be96-11e4-9d66-41d966d1c8c0.gif)

After :tv::

![foldy](https://cloud.githubusercontent.com/assets/38924/6414246/351efff8-be96-11e4-84e6-7813df93647c.gif)

cc @benogle @nathansobo for :eyes:
