### PR TITLE
Add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+See https://atom.io/releases


### PR DESCRIPTION
If you start with GitHub as an entry point for Atom (as opposed to https://atom.io), it can be a bit difficult to find Atom's release notes quickly. If you're lucky you might come across the `release-notes` package, but that too doesn't contain the release notes (somewhat paradoxically). Of course, you could always browse through the Releases on GitHub, but that also has a bit more noise if all you want to see are the changes.

This adds a CHANGELOG.md that literally just links to https://atom.io/releases to avoid duplication and to make Atom's release notes a bit more discoverable.
