### PR TITLE
Only set a font-size in the root

### DIFF
--- a/static/bootstrap-overrides.less
+++ b/static/bootstrap-overrides.less
@@ -21,3 +21,8 @@ h5,
 h6 {
   font-family: inherit; // inherit from themes
 }
+
+body {
+  font-family: inherit; // inherit from html
+  font-size: inherit; // inherit from html
+}

--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -3,13 +3,16 @@
 
 @font-face { .octicon-font(); }
 
+html {
+  font-family: @font-family;
+  font-size: @font-size;
+}
+
 html,
 body {
   width: 100%;
   height: 100%;
   overflow: hidden;
-  font-family: @font-family;
-  font-size: @font-size;
 }
 
 atom-workspace {


### PR DESCRIPTION
No need to select `html` and `body` when trying to override it.

Issue: #5735