### PR TITLE
Default directory provider should handle only local filesystem directories

### DIFF
--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -78,6 +78,20 @@ describe "Project", ->
       expect(directories.length).toBe 1
       expect(directories[0].getPath()).toBe tmp
 
+    it "gets the parent directory from the default directory provider if it's a local directory", ->
+      tmp = temp.mkdirSync()
+      atom.project.setPaths([path.join(tmp, "not-existing")])
+      directories = atom.project.getDirectories()
+      expect(directories.length).toBe 1
+      expect(directories[0].getPath()).toBe tmp
+
+    it "only normalizes the directory path if it isn't on the local filesystem", ->
+      nonLocalFsDirectory = "custom_proto://abc/def"
+      atom.project.setPaths([nonLocalFsDirectory])
+      directories = atom.project.getDirectories()
+      expect(directories.length).toBe 1
+      expect(directories[0].getPath()).toBe path.normalize(nonLocalFsDirectory)
+
     it "tries to update repositories when a new RepositoryProvider is registered", ->
       tmp = temp.mkdirSync('atom-project')
       atom.project.setPaths([tmp])

--- a/src/default-directory-provider.coffee
+++ b/src/default-directory-provider.coffee
@@ -21,7 +21,10 @@ class DefaultDirectoryProvider
     else
       path.dirname(projectPath)
 
-    new Directory(directoryPath)
+    if fs.isDirectorySync(projectPath)
+      return new Directory(directoryPath)
+    else
+      return null
 
   # Public: Create a Directory that corresponds to the specified URI.
   #

--- a/src/default-directory-provider.coffee
+++ b/src/default-directory-provider.coffee
@@ -16,15 +16,12 @@ class DefaultDirectoryProvider
   directoryForURISync: (uri) ->
     projectPath = path.normalize(uri)
 
-    directoryPath = if fs.isDirectorySync(projectPath)
-      projectPath
-    else
+    directoryPath = if !fs.isDirectorySync(projectPath) and fs.isDirectorySync(path.dirname(projectPath))
       path.dirname(projectPath)
-
-    if fs.isDirectorySync(projectPath)
-      return new Directory(directoryPath)
     else
-      return null
+      projectPath
+
+    new Directory(directoryPath)
 
   # Public: Create a Directory that corresponds to the specified URI.
   #

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -205,7 +205,7 @@ class Project extends Model
       break if directory = provider.directoryForURISync?(projectPath)
     if directory is null
       # DefaultDirectoryProvider doesn't handle specific directory protocols
-      # Atom Packages may use packageDirectoryPaths to add thier own paths later.
+      # Atom Packages may use packageDirectoryPaths to add their own paths later.
       @packageRootDirectoryPaths.push(projectPath)
       return
     else

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -39,6 +39,7 @@ class Project extends Model
     @emitter = new Emitter
     @buffers ?= []
     @rootDirectories = []
+    @packageRootDirectoryPaths = []
     @repositories = []
 
     @directoryProviders = [new DefaultDirectoryProvider()]
@@ -203,10 +204,12 @@ class Project extends Model
     for provider in @directoryProviders
       break if directory = provider.directoryForURISync?(projectPath)
     if directory is null
-      # This should never happen because DefaultDirectoryProvider should always
-      # return a Directory.
-      throw new Error(projectPath + ' could not be resolved to a directory')
-    @rootDirectories.push(directory)
+      # DefaultDirectoryProvider doesn't handle specific directory protocols
+      # Atom Packages may use packageDirectoryPaths to add thier own paths later.
+      @packageRootDirectoryPaths.push(projectPath)
+      return
+    else
+      @rootDirectories.push(directory)
 
     repo = null
     for provider in @repositoryProviders

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -39,7 +39,6 @@ class Project extends Model
     @emitter = new Emitter
     @buffers ?= []
     @rootDirectories = []
-    @packageRootDirectoryPaths = []
     @repositories = []
 
     @directoryProviders = [new DefaultDirectoryProvider()]
@@ -204,12 +203,10 @@ class Project extends Model
     for provider in @directoryProviders
       break if directory = provider.directoryForURISync?(projectPath)
     if directory is null
-      # DefaultDirectoryProvider doesn't handle specific directory protocols
-      # Atom Packages may use packageDirectoryPaths to add their own paths later.
-      @packageRootDirectoryPaths.push(projectPath)
-      return
-    else
-      @rootDirectories.push(directory)
+      # This should never happen because DefaultDirectoryProvider should always
+      # return a Directory.
+      throw new Error(projectPath + ' could not be resolved to a directory')
+    @rootDirectories.push(directory)
 
     repo = null
     for provider in @repositoryProviders


### PR DESCRIPTION
I'm having an issue of:
When I add an atom directory provider with uri like: myuri://server:port/some_path and reload atom or close/open atom, the default directory provider normalizes my uri path (bc it calls path.normalize on it eve though it's not a local filesystem directory).
https://github.com/atom/atom/blob/master/src/default-directory-provider.coffee#L16-L24

How do you think about the following solution:
1- The deafult directory provider returns a directory only when it exists on the filesystem.
2- On deserializing and creating the project with paths, if a projectPath can't be handled by a directory provider, it's added to another array to be consumed later by atom packages, when they are loaded

That's trying to work-around the nature of atom core initializing before packages are loaded and able to provide their directory providers.
