### PR TITLE
Add Workspace::onWillOpen 

### DIFF
--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -152,3 +152,46 @@ describe "the `atom` global", ->
       loadSettings.initialPaths = [dir2, dir1]
       atom2 = Atom.loadOrCreate("editor")
       expect(atom2.state.stuff).toBe("cool")
+
+  describe "openInitialEmptyEditorIfNecessary", ->
+    describe "when there are no paths set", ->
+      oldPaths = null
+
+      beforeEach ->
+        oldPaths = atom.project.getPaths()
+        atom.project.setPaths([])
+
+      afterEach ->
+        atom.project.setPaths(oldPaths)
+
+      it "opens an empty buffer", ->
+        spyOn(atom.workspace, 'open')
+        atom.openInitialEmptyEditorIfNecessary()
+        expect(atom.workspace.open).toHaveBeenCalledWith(null, {isInitialEmptyEditor: true})
+
+      describe "when there is already a buffer open", ->
+        beforeEach ->
+          waitsForPromise -> atom.workspace.open()
+
+        it "does not open an empty buffer", ->
+          spyOn(atom.workspace, 'open')
+          atom.openInitialEmptyEditorIfNecessary()
+          expect(atom.workspace.open).not.toHaveBeenCalled()
+
+    describe "when the project has a path", ->
+      beforeEach ->
+        spyOn(atom.workspace, 'open')
+
+      it "does not open an empty buffer", ->
+        atom.openInitialEmptyEditorIfNecessary()
+        expect(atom.workspace.open).not.toHaveBeenCalled()
+
+    describe "when there is already a buffer open", ->
+      beforeEach ->
+        waitsForPromise ->
+          atom.workspace.open()
+
+      it "does not open an empty buffer", ->
+        spyOn(atom.workspace, 'open')
+        atom.openInitialEmptyEditorIfNecessary()
+        expect(atom.workspace.open).not.toHaveBeenCalled()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -605,6 +605,8 @@ class Atom extends Model
       @setAutoHideMenuBar(newValue)
     @setAutoHideMenuBar(true) if @config.get('core.autoHideMenuBar')
 
+    @openInitialEmptyEditorIfNecessary()
+
     maximize = dimensions?.maximized and process.platform isnt 'darwin'
     @displayWindow({maximize})
 
@@ -628,6 +630,10 @@ class Atom extends Model
     @project = null
 
     @windowEventHandler?.unsubscribe()
+
+  openInitialEmptyEditorIfNecessary: ->
+    if @project.getPaths().length is 0 and @workspace.getPaneItems().length is 0
+      @workspace.open(null, {isInitialEmptyEditor: true})
 
   ###
   Section: Messaging the User

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -73,7 +73,8 @@ class AtomWindow
     @browserWindow.loadUrl @getUrl(loadSettings)
     @browserWindow.focusOnWebView() if @isSpec
 
-    @openLocations(locationsToOpen) unless @isSpecWindow()
+    hasPathToOpen = not (locationsToOpen.length is 1 and not locationsToOpen[0].pathToOpen?)
+    @openLocations(locationsToOpen) if hasPathToOpen and not @isSpecWindow()
 
   getUrl: (loadSettingsObj) ->
     # Ignore the windowState when passing loadSettings via URL, since it could


### PR DESCRIPTION
This will add an `Workspace::onWillOpen` event to allow fixing https://github.com/atom/welcome/issues/26. Usage would look something like this

``` coffee
# Suppress the opening of the initial empty buffer
atom.workspace.onWillOpen ({uri, options, cancel}) ->
  cancel() if options.isInitialEmptyBuffer
```

Refs https://github.com/atom/welcome/issues/26

How do you guys feel about this approach?
