### PR TITLE
Move the logic for opening empty initial buffer to the renderer process

### DIFF
--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -155,14 +155,8 @@ describe "the `atom` global", ->
 
   describe "openInitialEmptyEditorIfNecessary", ->
     describe "when there are no paths set", ->
-      oldPaths = null
-
       beforeEach ->
-        oldPaths = atom.project.getPaths()
-        atom.project.setPaths([])
-
-      afterEach ->
-        atom.project.setPaths(oldPaths)
+        spyOn(atom, 'getLoadSettings').andReturn(initialPaths: [])
 
       it "opens an empty buffer", ->
         spyOn(atom.workspace, 'open')
@@ -180,18 +174,9 @@ describe "the `atom` global", ->
 
     describe "when the project has a path", ->
       beforeEach ->
+        spyOn(atom, 'getLoadSettings').andReturn(initialPaths: ['something'])
         spyOn(atom.workspace, 'open')
 
       it "does not open an empty buffer", ->
-        atom.openInitialEmptyEditorIfNecessary()
-        expect(atom.workspace.open).not.toHaveBeenCalled()
-
-    describe "when there is already a buffer open", ->
-      beforeEach ->
-        waitsForPromise ->
-          atom.workspace.open()
-
-      it "does not open an empty buffer", ->
-        spyOn(atom.workspace, 'open')
         atom.openInitialEmptyEditorIfNecessary()
         expect(atom.workspace.open).not.toHaveBeenCalled()

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -152,3 +152,46 @@ describe "the `atom` global", ->
       loadSettings.initialPaths = [dir2, dir1]
       atom2 = Atom.loadOrCreate("editor")
       expect(atom2.state.stuff).toBe("cool")
+
+  describe "openInitialEmptyEditorIfNecessary", ->
+    describe "when there are no paths set", ->
+      oldPaths = null
+
+      beforeEach ->
+        oldPaths = atom.project.getPaths()
+        atom.project.setPaths([])
+
+      afterEach ->
+        atom.project.setPaths(oldPaths)
+
+      it "opens an empty buffer", ->
+        spyOn(atom.workspace, 'open')
+        atom.openInitialEmptyEditorIfNecessary()
+        expect(atom.workspace.open).toHaveBeenCalledWith(null, {isInitialEmptyEditor: true})
+
+      describe "when there is already a buffer open", ->
+        beforeEach ->
+          waitsForPromise -> atom.workspace.open()
+
+        it "does not open an empty buffer", ->
+          spyOn(atom.workspace, 'open')
+          atom.openInitialEmptyEditorIfNecessary()
+          expect(atom.workspace.open).not.toHaveBeenCalled()
+
+    describe "when the project has a path", ->
+      beforeEach ->
+        spyOn(atom.workspace, 'open')
+
+      it "does not open an empty buffer", ->
+        atom.openInitialEmptyEditorIfNecessary()
+        expect(atom.workspace.open).not.toHaveBeenCalled()
+
+    describe "when there is already a buffer open", ->
+      beforeEach ->
+        waitsForPromise ->
+          atom.workspace.open()
+
+      it "does not open an empty buffer", ->
+        spyOn(atom.workspace, 'open')
+        atom.openInitialEmptyEditorIfNecessary()
+        expect(atom.workspace.open).not.toHaveBeenCalled()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -632,7 +632,7 @@ class Atom extends Model
     @windowEventHandler?.unsubscribe()
 
   openInitialEmptyEditorIfNecessary: ->
-    if @project.getPaths().length is 0 and @workspace.getPaneItems().length is 0
+    if @getLoadSettings().initialPaths?.length is 0 and @workspace.getPaneItems().length is 0
       @workspace.open(null, {isInitialEmptyEditor: true})
 
   ###

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -605,6 +605,8 @@ class Atom extends Model
       @setAutoHideMenuBar(newValue)
     @setAutoHideMenuBar(true) if @config.get('core.autoHideMenuBar')
 
+    @openInitialEmptyEditorIfNecessary()
+
     maximize = dimensions?.maximized and process.platform isnt 'darwin'
     @displayWindow({maximize})
 
@@ -628,6 +630,10 @@ class Atom extends Model
     @project = null
 
     @windowEventHandler?.unsubscribe()
+
+  openInitialEmptyEditorIfNecessary: ->
+    if @project.getPaths().length is 0 and @workspace.getPaneItems().length is 0
+      @workspace.open(null, {isInitialEmptyEditor: true})
 
   ###
   Section: Messaging the User

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -73,7 +73,8 @@ class AtomWindow
     @browserWindow.loadUrl @getUrl(loadSettings)
     @browserWindow.focusOnWebView() if @isSpec
 
-    @openLocations(locationsToOpen) unless @isSpecWindow()
+    hasPathToOpen = not (locationsToOpen.length is 1 and not locationsToOpen[0].pathToOpen?)
+    @openLocations(locationsToOpen) if hasPathToOpen and not @isSpecWindow()
 
   getUrl: (loadSettingsObj) ->
     # Ignore the windowState when passing loadSettings via URL, since it could


### PR DESCRIPTION
Using this solution to atom/welcome#26 instead of #5812

Closes atom/welcome#26
