### PR TITLE
Speed up `selectAll` on a buffer with many folded lines

### DIFF
--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -251,7 +251,8 @@ class Selection extends Model
 
   # Public: Selects all the text in the buffer.
   selectAll: ->
-    @setBufferRange(@editor.buffer.getRange(), autoscroll: false)
+    @editor.unfoldAll()
+    @setBufferRange(@editor.buffer.getRange(), autoscroll: false, preserveFolds: true)
 
   # Public: Selects all the text from the current cursor position to the
   # beginning of the line.


### PR DESCRIPTION
As pointed out on #5791, selecting the whole buffer with many folded lines caused a serious performance degradation. I tracked down the issue to `Selection#selectAll` trying to unfold those lines which contained the selected buffer range. However, since we know in advance that we're going to select the whole text, we can make the clever assumption that everything would be unfolded anyways, thus calling the faster `@editor.unfoldAll` (e.g. faster because it simply scans each line one by one, instead of traversing the buffer back and forth for each line in the selection).

So, we go from this:

![screen shot 2015-03-04 at 23 49 43](https://cloud.githubusercontent.com/assets/482957/6495499/1f4851be-c2cb-11e4-866f-4f036962cc78.png)

To this:

![screen shot 2015-03-04 at 23 50 05](https://cloud.githubusercontent.com/assets/482957/6495500/20553cac-c2cb-11e4-8ccc-a87822042c4c.png)

_(Benchmark performed on `benchmark/fixtures/huge.js`, on my machine it's 70% faster)_

With this change, `selectAll` on a buffer with many folded lines takes no longer than unfolding everything :racehorse: :racehorse: :racehorse: 

Close #5791 

/cc: @nathansobo @izuzak 
