### PR TITLE
Bump status-bar@0.62.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "settings-view": "0.184.0",
     "snippets": "0.79.0",
     "spell-check": "0.55.0",
-    "status-bar": "0.60.0",
+    "status-bar": "0.62.0",
     "styleguide": "0.44.0",
     "symbols-view": "0.86.0",
     "tabs": "0.67.0",


### PR DESCRIPTION
Now use `status-bar@0.62.0` which doesn't make deprecations. 
