### PR TITLE
Speed up `destroyFoldsIntersectingBufferRange`

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2776,8 +2776,11 @@ class TextEditor extends Model
 
   # Remove any {Fold}s found that intersect the given buffer row.
   destroyFoldsIntersectingBufferRange: (bufferRange) ->
-    for row in [bufferRange.start.row..bufferRange.end.row]
-      @unfoldBufferRow(row)
+    @unfoldBufferRow(bufferRange.start.row)
+    @unfoldBufferRow(bufferRange.end.row)
+
+    for row in [bufferRange.end.row..bufferRange.start.row]
+      fold.destroy() for fold in @displayBuffer.foldsStartingAtBufferRow(row)
 
   # {Delegates to: DisplayBuffer.largestFoldContainingBufferRow}
   largestFoldContainingBufferRow: (bufferRow) ->


### PR DESCRIPTION
Based on the work made in #5843, I decided to give optimizing `destroyFoldsIntersectingBufferRange` for every scenario (not only the whole buffer selection) a try.

A quick win was to simply iterate over the buffer range in reverse order: when destroying a fold, `DisplayBuffer#updateScreenLines` gets called unless the row is inside a larger fold; starting from the bottom helps reducing the amount of calls dramatically (moreover, this is how the rest of atom core handles folds traversal, so we win also in consistency :v:).

However, this was not enough to have acceptable performance because, for each row in the range, the buffer was traversed back and forth to find folds intersecting such rows. This is unnecessary, since we need only to perform such traversal on `start.row` and `end.row`, and simply destroy anything in between. This would catch any larger fold and the rest of them must be right inside `bufferRange` (outermost rows included). :racehorse: :racehorse: :racehorse: 

@nathansobo: I am wondering if we should remove [the previous optimization](https://github.com/atom/atom/pull/5843); after these changes we save a relatively short amount of time skipping `destroyFoldsIntersectingBufferRange` on `selectAll`. On the other hand, I am not entirely unhappy with keeping the further optimization there.

/cc: @izuzak
