### PR TITLE
Remove pathwatcher deprecations

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "bracket-matcher": "0.71.0",
     "command-palette": "0.34.0",
     "deprecation-cop": "0.37.0",
-    "dev-live-reload": "0.41.0",
+    "dev-live-reload": "0.42.0",
     "encoding-selector": "0.18.0",
     "exception-reporting": "0.24.0",
     "find-and-replace": "0.159.0",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "package-generator": "0.38.0",
     "release-notes": "0.51.0",
     "settings-view": "0.184.0",
-    "snippets": "0.79.0",
+    "snippets": "0.80.0",
     "spell-check": "0.55.0",
     "status-bar": "0.63.0",
     "styleguide": "0.44.0",

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -257,9 +257,9 @@ class ThemeManager
       @userStylesheetFile = new File(userStylesheetPath)
       @userStylsheetSubscriptions = new CompositeDisposable()
       reloadStylesheet = => @loadUserStylesheet()
-      @userStylsheetSubscriptions.add(@userStylesheetPath.onDidChange(reloadStylesheet))
-      @userStylsheetSubscriptions.add(@userStylesheetPath.onDidRename(reloadStylesheet))
-      @userStylsheetSubscriptions.add(@userStylesheetPath.onDidDelete(reloadStylesheet))
+      @userStylsheetSubscriptions.add(@userStylesheetFile.onDidChange(reloadStylesheet))
+      @userStylsheetSubscriptions.add(@userStylesheetFile.onDidRename(reloadStylesheet))
+      @userStylsheetSubscriptions.add(@userStylesheetFile.onDidDelete(reloadStylesheet))
     catch error
       message = """
         Unable to watch path: `#{path.basename(userStylesheetPath)}`. Make sure


### PR DESCRIPTION
While reviewing some symbols view code I noticed we weren't marking deprecations when doing things like:

``` coffee
file = new File('/foo/bar')
file.on 'moved removed contents-changed', ->
```

I updated `pathwatcher` and this PR updates core and affected packages that were using the deprecated File/Directory APIs
