### PR TITLE
Update also @startRow and @endRow on `getState`

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -56,6 +56,17 @@ describe "TextEditorComponent", ->
   afterEach ->
     contentNode.style.width = ''
 
+  describe "async updates", ->
+    it "handles corrupted state gracefully", ->
+      # trigger state updates, e.g. presenter.updateLinesState
+      editor.insertNewline()
+
+      # simulate state corruption
+      component.presenter.startRow = -1
+      component.presenter.endRow = 9999
+
+      expect(nextAnimationFrame).not.toThrow()
+
   describe "line rendering", ->
     it "renders the currently-visible lines plus the overdraw margin", ->
       wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -61,6 +61,7 @@ class TextEditorPresenter
       @[flagName] = true
     else
       fn.apply(this)
+      @[flagName] = false
 
     @emitDidUpdateState()
 
@@ -68,6 +69,11 @@ class TextEditorPresenter
   # Returns a state {Object}, useful for rendering to screen.
   getState: ->
     @updating = true
+
+    @updateContentDimensions()
+    @updateScrollbarDimensions()
+    @updateStartRow()
+    @updateEndRow()
 
     @updateFocusedState() if @shouldUpdateFocusedState
     @updateHeightState() if @shouldUpdateHeightState
@@ -82,20 +88,6 @@ class TextEditorPresenter
     @updateOverlaysState() if @shouldUpdateOverlaysState
     @updateGutterState() if @shouldUpdateGutterState
     @updateLineNumbersState() if @shouldUpdateLineNumbersState
-
-    @shouldUpdateFocusedState = false
-    @shouldUpdateHeightState = false
-    @shouldUpdateVerticalScrollState = false
-    @shouldUpdateHorizontalScrollState = false
-    @shouldUpdateScrollbarsState = false
-    @shouldUpdateHiddenInputState = false
-    @shouldUpdateContentState = false
-    @shouldUpdateDecorations = false
-    @shouldUpdateLinesState = false
-    @shouldUpdateCursorsState = false
-    @shouldUpdateOverlaysState = false
-    @shouldUpdateGutterState = false
-    @shouldUpdateLineNumbersState = false
 
     @updating = false
 


### PR DESCRIPTION
Close #5883 
Close #5667

Thanks to @izuzak for making this issue reproducible for everyone. Great job, seriously! :clap: 

Unfortunately, #5883 is caused by something different than #5667: if you try to checkout `v0.180` (where the issue originally appeared) you'll find out that the reproducing steps provided by @izuzak won't cause any problem. Therefore, I'd like to apologize with every Atom user for this issue (I am truly sorry if this has caused headaches to you :pray:), because this has been caused by our batching strategy. 

When there is only one pane, everything goes smoothly and no error occurs. However, when there's more than one (and with some particular packages enabled), our `TextEditorPresenter` goes out-of-sync, thus causing that annoying `No line exists for row #{row}. Last screen row: #{@model.getLastScreenRow()}` error. This happens because:
- Something change in the underlying buffer
- `getState` gets called before `updateStartRow` and `updateEndRow` (which would be triggered by a change in the buffer)
- `updateLinesState` tries to traverse an obsolete row range

For symmetry with `@updateState`, I opted to simply include `@updateContentDimensions`, `@updateScrollbarDimensions`, `@updateStartRow` and `@updateEndRow` right before performing any change to the actual state in `@getState`. I didn't batch these methods because they are used also by other non-batched operations (see `@updateHighlightState`) and therefore need to be updated every time. On the other hand they are very fast, and it should be quite cheap to call them.

This should solve once for all any issue that arise from the presenter going out-of-sync with the underlying model because of the async nature of the updates. As a result, I believe that the original issue can be closed as well.

Once again, sorry if this has caused problems to you!

/cc: @nathansobo 
