### PR TITLE
this commit make Atom open files in the pane view that files was dropped into

### DIFF
--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -1,6 +1,7 @@
 {CompositeDisposable} = require 'event-kit'
 {$, callAttachHooks, callRemoveHooks} = require './space-pen-extensions'
 PaneView = require './pane-view'
+_ = require 'underscore-plus'
 
 class PaneElement extends HTMLElement
   attached: false
@@ -37,8 +38,21 @@ class PaneElement extends HTMLElement
     handleBlur = (event) =>
       @model.blur() unless @contains(event.relatedTarget)
 
+    handleDragOver = (event) =>
+      event.preventDefault()
+      event.stopPropagation()
+
+    handleDrop = (event) =>
+      event.preventDefault()
+      event.stopPropagation()
+      @getModel().activate()
+      pathsToOpen = _.pluck(event.dataTransfer.files, 'path')
+      atom.open({pathsToOpen}) if pathsToOpen.length > 0
+
     @addEventListener 'focus', handleFocus, true
     @addEventListener 'blur', handleBlur, true
+    @addEventListener 'dragover', handleDragOver
+    @addEventListener 'drop', handleDrop
 
   createSpacePenShim: ->
     @__spacePenView = new PaneView(this)

--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -1,7 +1,6 @@
 {CompositeDisposable} = require 'event-kit'
 {$, callAttachHooks, callRemoveHooks} = require './space-pen-extensions'
 PaneView = require './pane-view'
-_ = require 'underscore-plus'
 
 class PaneElement extends HTMLElement
   attached: false
@@ -46,7 +45,7 @@ class PaneElement extends HTMLElement
       event.preventDefault()
       event.stopPropagation()
       @getModel().activate()
-      pathsToOpen = _.pluck(event.dataTransfer.files, 'path')
+      pathsToOpen = Array::map.call event.dataTransfer.files, (file) -> file.path
       atom.open({pathsToOpen}) if pathsToOpen.length > 0
 
     @addEventListener 'focus', handleFocus, true

--- a/src/pane-resize-handle-view.coffee
+++ b/src/pane-resize-handle-view.coffee
@@ -10,8 +10,6 @@ class PaneResizeHandleView extends View
 
   attached: ->
     @isHorizontal = @parent().hasClass("horizontal")
-    @prevPane = @prev()
-    @nextPane = @next()
 
   detached: ->
 
@@ -23,8 +21,8 @@ class PaneResizeHandleView extends View
 
   resizeToFitContent: ->
     # clear flex-grow css style of both pane
-    @prevPane.css('flexGrow', '')
-    @nextPane.css('flexGrow', '')
+    @prev().css('flexGrow', '')
+    @next().css('flexGrow', '')
 
   resizeStarted: (e)->
     e.stopPropagation()
@@ -39,10 +37,10 @@ class PaneResizeHandleView extends View
     parseFloat element.css('flexGrow')
 
   setFlexGrow: (prevSize, nextSize) ->
-    flexGrow = @getFlexGrow(@prevPane) + @getFlexGrow(@nextPane)
+    flexGrow = @getFlexGrow(@prev()) + @getFlexGrow(@next())
     flexGrows = @calcRatio(prevSize, nextSize, flexGrow)
-    @prevPane.css('flexGrow', flexGrows[0].toString())
-    @nextPane.css('flexGrow', flexGrows[1].toString())
+    @prev().css('flexGrow', flexGrows[0].toString())
+    @next().css('flexGrow', flexGrows[1].toString())
 
   fixInRange: (val, minValue, maxValue) ->
     Math.min(Math.max(val, minValue), maxValue)
@@ -51,16 +49,16 @@ class PaneResizeHandleView extends View
     return @resizeStopped() unless which is 1
 
     if @isHorizontal
-      totalWidth = @prevPane.outerWidth() + @nextPane.outerWidth()
+      totalWidth = @prev().outerWidth() + @next().outerWidth()
       #get the left and right width after move the resize view
-      leftWidth = @fixInRange(pageX - @prevPane.offset().left, 0, totalWidth)
+      leftWidth = @fixInRange(pageX - @prev().offset().left, 0, totalWidth)
       rightWidth = totalWidth - leftWidth
       # set the flex grow by the ratio of left width and right width
       # to change pane width
       @setFlexGrow(leftWidth, rightWidth)
     else
-      totalHeight = @prevPane.outerHeight() + @nextPane.outerHeight()
-      topHeight = @fixInRange(pageY - @prevPane.offset().top, 0, totalHeight)
+      totalHeight = @prev().outerHeight() + @next().outerHeight()
+      topHeight = @fixInRange(pageY - @prev().offset().top, 0, totalHeight)
       bottomHeight = totalHeight - topHeight
       @setFlexGrow(topHeight, bottomHeight)
 

--- a/src/pane-resize-handle-view.coffee
+++ b/src/pane-resize-handle-view.coffee
@@ -1,0 +1,69 @@
+{$, View} = require 'atom-space-pen-views'
+
+module.exports =
+class PaneResizeHandleView extends View
+  @content: ->
+    @div class: 'pane-resize-handle'
+
+  initialize: ->
+    @handleEvents()
+
+  attached: ->
+    @isHorizontal = @parent().hasClass("horizontal")
+    @prevPane = @prev()
+    @nextPane = @next()
+
+  detached: ->
+
+  handleEvents: ->
+    @on 'dblclick', =>
+      @resizeToFitContent()
+    @on 'mousedown', (e) =>
+      @resizeStarted(e)
+
+  resizeToFitContent: ->
+    # clear flex-grow css style of both pane
+    @prevPane.css('flexGrow', '')
+    @nextPane.css('flexGrow', '')
+
+  resizeStarted: (e)->
+    e.stopPropagation()
+    $(document).on('mousemove', @resizePane)
+    $(document).on('mouseup', @resizeStopped)
+
+  calcRatio: (ratio1, ratio2, total) ->
+    allRatio = ratio1 + ratio2
+    [total * ratio1 / allRatio, total * ratio2 / allRatio]
+
+  getFlexGrow: (element) ->
+    parseFloat element.css('flexGrow')
+
+  setFlexGrow: (prevSize, nextSize) ->
+    flexGrow = @getFlexGrow(@prevPane) + @getFlexGrow(@nextPane)
+    flexGrows = @calcRatio(prevSize, nextSize, flexGrow)
+    @prevPane.css('flexGrow', flexGrows[0].toString())
+    @nextPane.css('flexGrow', flexGrows[1].toString())
+
+  fixInRange: (val, minValue, maxValue) ->
+    Math.min(Math.max(val, minValue), maxValue)
+
+  resizePane: ({pageX, pageY, which}) =>
+    return @resizeStopped() unless which is 1
+
+    if @isHorizontal
+      totalWidth = @prevPane.outerWidth() + @nextPane.outerWidth()
+      #get the left and right width after move the resize view
+      leftWidth = @fixInRange(pageX - @prevPane.offset().left, 0, totalWidth)
+      rightWidth = totalWidth - leftWidth
+      # set the flex grow by the ratio of left width and right width
+      # to change pane width
+      @setFlexGrow(leftWidth, rightWidth)
+    else
+      totalHeight = @prevPane.outerHeight() + @nextPane.outerHeight()
+      topHeight = @fixInRange(pageY - @prevPane.offset().top, 0, totalHeight)
+      bottomHeight = totalHeight - topHeight
+      @setFlexGrow(topHeight, bottomHeight)
+
+  resizeStopped: =>
+    $(document).off('mousemove', @resizePane)
+    $(document).off('mouseup', @resizeStopped)

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -1,6 +1,5 @@
 path = require 'path'
 {$} = require './space-pen-extensions'
-_ = require 'underscore-plus'
 {Disposable} = require 'event-kit'
 ipc = require 'ipc'
 shell = require 'shell'
@@ -134,12 +133,11 @@ class WindowEventHandler
   onDrop: (event) ->
     event.preventDefault()
     event.stopPropagation()
-    pathsToOpen = _.pluck(event.dataTransfer.files, 'path')
-    atom.open({pathsToOpen}) if pathsToOpen.length > 0
 
   onDragOver: (event) ->
     event.preventDefault()
     event.stopPropagation()
+    event.dataTransfer.dropEffect = 'none'
 
   openLink: ({target, currentTarget}) ->
     location = target?.getAttribute('href') or currentTarget?.getAttribute('href')

--- a/static/panes.less
+++ b/static/panes.less
@@ -11,12 +11,26 @@ atom-pane-container {
     display: -webkit-flex;
     -webkit-flex: 1;
     -webkit-flex-direction: column;
+
+    & > div.pane-resize-handle {
+      height: 8px;
+      z-index: 3;
+      cursor: ns-resize;
+      border-bottom: none;
+    }
   }
 
   atom-pane-axis.horizontal {
     display: -webkit-flex;
     -webkit-flex: 1;
     -webkit-flex-direction: row;
+
+    & > div.pane-resize-handle {
+      width: 8px;
+      z-index: 3;
+      cursor: ew-resize;
+      border-right: none;
+    }
   }
 
   atom-pane {


### PR DESCRIPTION
- invalidate document's drop event to prevent the browser's default behavior that open the file URL.
- this commit fix bug #4049. Every pane element will listen `drop` event to make drop action take in this pane view, therefore the drop files will open in the correct split view.
