### PR TITLE
Faster lines joining without soft-wrap

### DIFF
--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -54,6 +54,7 @@ class Cursor extends Model
       @emitter.emit 'did-destroy'
       @emitter.dispose()
     @needsAutoscroll = true
+    @autoscrollEnabled = true
 
   destroy: ->
     @marker.destroy()
@@ -669,7 +670,14 @@ class Cursor extends Model
     {row, column} = @getScreenPosition()
     new Range(new Point(row, column), new Point(row, column + 1))
 
-  autoscroll: (options) ->
+  autoscroll: (options, fn) ->
+    return unless @autoscrollEnabled
+
+    if fn?
+      @autoscrollEnabled = false
+      fn()
+      @autoscrollEnabled = true
+
     @editor.scrollToScreenRange(@getScreenRange(), options)
 
   getBeginningOfNextParagraphBufferPosition: ->

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -673,6 +673,10 @@ class Cursor extends Model
   autoscroll: (options, fn) ->
     return unless @autoscrollEnabled
 
+    if typeof options is "function"
+      fn = options
+      options = fn
+
     if fn?
       @autoscrollEnabled = false
       fn()

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -487,47 +487,48 @@ class Selection extends Model
   #
   # If there selection spans more than one line, all the lines are joined together.
   joinLines: ->
-    selectedRange = @getBufferRange()
-    if selectedRange.isEmpty()
-      return if selectedRange.start.row is @editor.buffer.getLastRow()
-    else
-      joinMarker = @editor.markBufferRange(selectedRange, invalidationStrategy: 'never')
+    @cursor.autoscroll {}, =>
+      selectedRange = @getBufferRange()
+      if selectedRange.isEmpty()
+        return if selectedRange.start.row is @editor.buffer.getLastRow()
+      else
+        joinMarker = @editor.markBufferRange(selectedRange, invalidationStrategy: 'never')
 
-    rowCount = Math.max(1, selectedRange.getRowCount() - 1)
-    for row in [0...rowCount]
-      @cursor.setBufferPosition([selectedRange.start.row])
-      @cursor.moveToEndOfLine()
+      rowCount = Math.max(1, selectedRange.getRowCount() - 1)
+      for row in [0...rowCount]
+        @cursor.setBufferPosition([selectedRange.start.row])
+        @cursor.moveToEndOfLine()
 
-      # Remove trailing whitespace from the current line
-      scanRange = @cursor.getCurrentLineBufferRange()
-      trailingWhitespaceRange = null
-      @editor.scanInBufferRange /[ \t]+$/, scanRange, ({range}) ->
-        trailingWhitespaceRange = range
-      if trailingWhitespaceRange?
-        @setBufferRange(trailingWhitespaceRange)
+        # Remove trailing whitespace from the current line
+        scanRange = @cursor.getCurrentLineBufferRange()
+        trailingWhitespaceRange = null
+        @editor.scanInBufferRange /[ \t]+$/, scanRange, ({range}) ->
+          trailingWhitespaceRange = range
+        if trailingWhitespaceRange?
+          @setBufferRange(trailingWhitespaceRange)
+          @deleteSelectedText()
+
+        currentRow = selectedRange.start.row
+        nextRow = currentRow + 1
+        insertSpace = nextRow <= @editor.buffer.getLastRow() and
+                      @editor.buffer.lineLengthForRow(nextRow) > 0 and
+                      @editor.buffer.lineLengthForRow(currentRow) > 0
+        @insertText(' ') if insertSpace
+
+        @cursor.moveToEndOfLine()
+
+        # Remove leading whitespace from the line below
+        @modifySelection =>
+          @cursor.moveRight()
+          @cursor.moveToFirstCharacterOfLine()
         @deleteSelectedText()
 
-      currentRow = selectedRange.start.row
-      nextRow = currentRow + 1
-      insertSpace = nextRow <= @editor.buffer.getLastRow() and
-                    @editor.buffer.lineLengthForRow(nextRow) > 0 and
-                    @editor.buffer.lineLengthForRow(currentRow) > 0
-      @insertText(' ') if insertSpace
+        @cursor.moveLeft() if insertSpace
 
-      @cursor.moveToEndOfLine()
-
-      # Remove leading whitespace from the line below
-      @modifySelection =>
-        @cursor.moveRight()
-        @cursor.moveToFirstCharacterOfLine()
-      @deleteSelectedText()
-
-      @cursor.moveLeft() if insertSpace
-
-    if joinMarker?
-      newSelectedRange = joinMarker.getBufferRange()
-      @setBufferRange(newSelectedRange)
-      joinMarker.destroy()
+      if joinMarker?
+        newSelectedRange = joinMarker.getBufferRange()
+        @setBufferRange(newSelectedRange)
+        joinMarker.destroy()
 
   # Public: Removes one level of indent from the currently selected rows.
   outdentSelectedRows: ->

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -487,7 +487,7 @@ class Selection extends Model
   #
   # If there selection spans more than one line, all the lines are joined together.
   joinLines: ->
-    @cursor.autoscroll {}, =>
+    @cursor.autoscroll =>
       selectedRange = @getBufferRange()
       if selectedRange.isEmpty()
         return if selectedRange.start.row is @editor.buffer.getLastRow()

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -298,10 +298,7 @@ class TextEditorPresenter
     @state.content.cursors = {}
     @updateCursorState(cursor) for cursor in @model.cursors # using property directly to avoid allocation
 
-  updateCursorState: (cursor, destroyOnly = false) ->
-    delete @state.content.cursors[cursor.id]
-
-    return if destroyOnly
+  updateCursorState: (cursor) ->
     return unless @startRow? and @endRow? and @hasPixelRectRequirements() and @baseCharacterWidth?
     return unless cursor.isVisible() and @startRow <= cursor.getScreenRow() < @endRow
 
@@ -996,17 +993,17 @@ class TextEditorPresenter
     didChangePositionDisposable = cursor.onDidChangePosition =>
       @updateHiddenInputState() if cursor.isLastCursor()
       @pauseCursorBlinking()
-      @updateCursorState(cursor)
+      @updateCursorsState()
 
     didChangeVisibilityDisposable = cursor.onDidChangeVisibility =>
-      @updateCursorState(cursor)
+      @updateCursorsState()
 
     didDestroyDisposable = cursor.onDidDestroy =>
       @disposables.remove(didChangePositionDisposable)
       @disposables.remove(didChangeVisibilityDisposable)
       @disposables.remove(didDestroyDisposable)
       @updateHiddenInputState()
-      @updateCursorState(cursor, true)
+      @updateCursorsState()
 
     @disposables.add(didChangePositionDisposable)
     @disposables.add(didChangeVisibilityDisposable)
@@ -1016,7 +1013,7 @@ class TextEditorPresenter
     @observeCursor(cursor)
     @updateHiddenInputState()
     @pauseCursorBlinking()
-    @updateCursorState(cursor)
+    @updateCursorsState()
 
   startBlinkingCursors: ->
     unless @toggleCursorBlinkHandle

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -416,7 +416,7 @@ class TextEditorPresenter
       @scrollHeight = scrollHeight
       @updateScrollTop()
 
-  updateContentDimensions: ->
+  updateContentDimensions: -> @batch "shouldUpdateContentDimensions", ->
     if @lineHeight?
       oldContentHeight = @contentHeight
       @contentHeight = @lineHeight * @model.getScreenLineCount()

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -70,6 +70,7 @@ class TextEditorPresenter
   getState: ->
     @updating = true
 
+    # Always update these to avoid state corruption
     @updateContentDimensions()
     @updateScrollbarDimensions()
     @updateStartRow()

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -416,7 +416,7 @@ class TextEditorPresenter
       @scrollHeight = scrollHeight
       @updateScrollTop()
 
-  updateContentDimensions: -> @batch "shouldUpdateContentDimensions", ->
+  updateContentDimensions: ->
     if @lineHeight?
       oldContentHeight = @contentHeight
       @contentHeight = @lineHeight * @model.getScreenLineCount()


### PR DESCRIPTION
This partially addresses #5882, read on to understand why it doesn't fully solve it.
### Benchmark

_Benchmark performed using the `test-multiple-lines.js` file found on the aforementioned issue with soft-wrap disabled._
#### Steps
- Select all
- Hit Cmd+J (`core:join-lines`)
#### Before :chart_with_downwards_trend:

![screen shot 2015-03-11 at 11 35 04](https://cloud.githubusercontent.com/assets/482957/6594583/db8b0fbc-c7e2-11e4-8717-4e416c763957.png)
#### After :chart_with_upwards_trend:

![screen shot 2015-03-11 at 11 36 12](https://cloud.githubusercontent.com/assets/482957/6594610/fcec7222-c7e2-11e4-93ed-2311d4cb2d59.png)

On my machine this is almost 3x faster :racehorse: :racehorse: :racehorse: 
### Considerations

Most of the time was spent in autoscrolling (which is something we can do at the end of `joinLines`) and in updating the UI (some operations were not batched). Now time is spent mostly on scanning tokens, which is something that needs to be addressed in another layer (see #979).

![screen shot 2015-03-11 at 11 46 33](https://cloud.githubusercontent.com/assets/482957/6594782/866d817a-c7e4-11e4-9d4c-0a5464c8551f.png)

The situation is dramatically different for soft-wrapped lines. For this particular scenario, in facts, there's a significant amount of throwaway computation involved. When multiple lines are joined together, the operation does not happen atomically but causes `DisplayBuffer` to continuously update the first screen line as more and more lines are joined into the first one. This is quite cheap when soft wrapping is off, but it becomes very expensive when we turn it on:

![screen shot 2015-03-11 at 12 02 40](https://cloud.githubusercontent.com/assets/482957/6595024/8ffc8432-c7e6-11e4-976c-0cf6665e5e90.png)

:fearful:
- One solution could be to make `updateScreenLines` smarter, and reuse previous screen lines as a starting point for updates. However, that would involve a radical change in how we tokenize lines and I feel like this is an improvement that we should make at a lower layer, e.g. while addressing #979 
- Another way to tackle this would be to start batching `DisplayBuffer#handleTokenizedBufferChange` on `TextEditor#transact`. On one hand I find this quite smart, but on the other hand there's a lot of event-handling involved (e.g. markers) and I am afraid this change could break many things. Based on my first trials, I would say it will. @nathansobo: batching, batching everywhere :scream: :smile: 
- Alternatively, all those methods like `Selection#joinLines` could directly operate on the buffer, as if an external program performs the action, and `DisplayBuffer` sees only the final result. This is similar to the solution provided above, but addresses the issue from a different perspective, probably breaking abstraction.

Personally, I feel like the second solution provides quite a lot of benefits without breaking abstractions or changing how we deal with tokenized line. What do you think? 
