### PR TITLE
Destroy only containing folds on selection

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1505,9 +1505,12 @@ describe "TextEditor", ->
         editor.setSelectedScreenRanges([[[6, 2], [6, 4]]])
         expect(editor.getSelectedScreenRanges()).toEqual [[[6, 2], [6, 4]]]
 
-      it "merges intersecting selections and unfolds the fold", ->
-        editor.setSelectedScreenRanges([[[2, 2], [3, 3]], [[3, 0], [5, 5]]])
-        expect(editor.getSelectedScreenRanges()).toEqual [[[2, 2], [8, 5]]]
+      it "merges intersecting selections and unfolds the fold which contain them", ->
+        editor.foldBufferRow(0)
+
+        # Use buffer ranges because only the first line is on screen
+        editor.setSelectedBufferRanges([[[2, 2], [3, 3]], [[3, 0], [5, 5]]])
+        expect(editor.getSelectedBufferRanges()).toEqual [[[2, 2], [5, 5]]]
 
       it "recyles existing selection instances", ->
         selection = editor.getLastSelection()

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -100,7 +100,7 @@ class Selection extends Model
     bufferRange = Range.fromObject(bufferRange)
     @needsAutoscroll = options.autoscroll
     options.reversed ?= @isReversed()
-    @editor.destroyFoldsIntersectingBufferRange(bufferRange) unless options.preserveFolds
+    @editor.destroyFoldsContainingBufferRange(bufferRange) unless options.preserveFolds
     @modifySelection =>
       needsFlash = options.flash
       delete options.flash if options.flash?
@@ -251,8 +251,7 @@ class Selection extends Model
 
   # Public: Selects all the text in the buffer.
   selectAll: ->
-    @editor.unfoldAll()
-    @setBufferRange(@editor.buffer.getRange(), autoscroll: false, preserveFolds: true)
+    @setBufferRange(@editor.buffer.getRange(), autoscroll: false)
 
   # Public: Selects all the text from the current cursor position to the
   # beginning of the line.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2241,7 +2241,7 @@ class TextEditor extends Model
   # Returns the new {Selection}.
   addSelection: (marker, options={}) ->
     unless marker.getProperties().preserveFolds
-      @destroyFoldsIntersectingBufferRange(marker.getBufferRange())
+      @destroyFoldsContainingBufferRange(marker.getBufferRange())
     cursor = @addCursor(marker)
     selection = new Selection(_.extend({editor: this, marker, cursor}, options))
     @selections.push(selection)
@@ -2776,11 +2776,14 @@ class TextEditor extends Model
 
   # Remove any {Fold}s found that intersect the given buffer row.
   destroyFoldsIntersectingBufferRange: (bufferRange) ->
-    @unfoldBufferRow(bufferRange.start.row)
-    @unfoldBufferRow(bufferRange.end.row)
+    @destroyFoldsContainingBufferRange(bufferRange)
 
     for row in [bufferRange.end.row..bufferRange.start.row]
       fold.destroy() for fold in @displayBuffer.foldsStartingAtBufferRow(row)
+
+  destroyFoldsContainingBufferRange: (bufferRange) ->
+    @unfoldBufferRow(bufferRange.start.row)
+    @unfoldBufferRow(bufferRange.end.row)
 
   # {Delegates to: DisplayBuffer.largestFoldContainingBufferRow}
   largestFoldContainingBufferRow: (bufferRow) ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2774,13 +2774,14 @@ class TextEditor extends Model
   destroyFoldWithId: (id) ->
     @displayBuffer.destroyFoldWithId(id)
 
-  # Remove any {Fold}s found that intersect the given buffer row.
+  # Remove any {Fold}s found that intersect the given buffer range.
   destroyFoldsIntersectingBufferRange: (bufferRange) ->
     @destroyFoldsContainingBufferRange(bufferRange)
 
     for row in [bufferRange.end.row..bufferRange.start.row]
       fold.destroy() for fold in @displayBuffer.foldsStartingAtBufferRow(row)
 
+  # Remove any {Fold}s found that contain the given buffer range.
   destroyFoldsContainingBufferRange: (bufferRange) ->
     @unfoldBufferRow(bufferRange.start.row)
     @unfoldBufferRow(bufferRange.end.row)


### PR DESCRIPTION
As reported by @nathansobo on #5858:

> I'm fine with leaving the optimization in, although extra bonus :christmas_tree: would be to only destroy folds containing a selection when the selection changes. I don't think selectAll should destroy anything. If you get inspired I would love to remove the optimization combined with that behavior change.

:fire:

Any feedback or suggestion is very welcome, as usual. Thank you! :bow: 

/cc: @izuzak 
