### PR TITLE
Adjust `DisplayBuffer#getVisibleRowRange` logic

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1253,17 +1253,17 @@ describe "DisplayBuffer", ->
       displayBuffer.setLineHeightInPixels(10)
       displayBuffer.setHeight(100)
 
-    it "returns a closed interval of visible rows", ->
+    it "returns the first and the last visible rows", ->
       displayBuffer.setScrollTop(0)
 
       expect(displayBuffer.getVisibleRowRange()).toEqual [0, 9]
 
-    it "includes partially visible rows in the interval", ->
+    it "includes partially visible rows in the range", ->
       displayBuffer.setScrollTop(5)
 
       expect(displayBuffer.getVisibleRowRange()).toEqual [0, 10]
 
-    it "returns an empty interval when lineHeight is 0", ->
+    it "returns an empty range when lineHeight is 0", ->
       displayBuffer.setLineHeightInPixels(0)
 
       expect(displayBuffer.getVisibleRowRange()).toEqual [0, 0]

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1247,3 +1247,22 @@ describe "DisplayBuffer", ->
 
       expect(displayBuffer.getScrollWidth()).toBe 10 * 63 + operatorWidth * 2 + cursorWidth
       expect(changedSpy.callCount).toBe 1
+
+  describe "::getVisibleRowRange()", ->
+    beforeEach ->
+      displayBuffer.setLineHeightInPixels(10)
+      displayBuffer.setHeight(100)
+
+    it "returns a closed interval of visible rows", ->
+      displayBuffer.setScrollTop(0)
+
+      expect(displayBuffer.getVisibleRowRange()).toEqual [0, 9]
+
+    it "includes partially visible rows in the interval", ->
+      displayBuffer.setScrollTop(5)
+      expect(displayBuffer.getVisibleRowRange()).toEqual [0, 10]
+
+    it "returns an empty interval when lineHeight is 0", ->
+      displayBuffer.setLineHeightInPixels(0)
+
+      expect(displayBuffer.getVisibleRowRange()).toEqual [0, 0]

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1260,6 +1260,7 @@ describe "DisplayBuffer", ->
 
     it "includes partially visible rows in the interval", ->
       displayBuffer.setScrollTop(5)
+
       expect(displayBuffer.getVisibleRowRange()).toEqual [0, 10]
 
     it "returns an empty interval when lineHeight is 0", ->

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1267,3 +1267,8 @@ describe "DisplayBuffer", ->
       displayBuffer.setLineHeightInPixels(0)
 
       expect(displayBuffer.getVisibleRowRange()).toEqual [0, 0]
+
+    it "ends at last buffer row even if there's more space available", ->
+      displayBuffer.setScrollTop(60)
+
+      expect(displayBuffer.getVisibleRowRange()).toEqual [6, 13]

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -348,12 +348,13 @@ class DisplayBuffer extends Model
   getScrollWidth: ->
     @scrollWidth
 
+  # Returns an {Array} of two numbers representing a closed interval of visible rows.
   getVisibleRowRange: ->
     return [0, 0] unless @getLineHeightInPixels() > 0
 
-    heightInLines = Math.ceil(@getHeight() / @getLineHeightInPixels()) + 1
     startRow = Math.floor(@getScrollTop() / @getLineHeightInPixels())
-    endRow = Math.min(@getLineCount(), startRow + heightInLines)
+    endRow = Math.ceil((@getScrollTop() + @getHeight()) / @getLineHeightInPixels()) - 1
+    endRow = Math.min(@getLineCount(), endRow)
 
     [startRow, endRow]
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -348,7 +348,7 @@ class DisplayBuffer extends Model
   getScrollWidth: ->
     @scrollWidth
 
-  # Returns an {Array} of two numbers representing a closed interval of visible rows.
+  # Returns an {Array} of two numbers representing the first and the last visible rows.
   getVisibleRowRange: ->
     return [0, 0] unless @getLineHeightInPixels() > 0
 


### PR DESCRIPTION
Supersedes and closes #4597

Thanks to @izuzak, @neojski and @nathansobo for reporting the issue, providing an alternative algorithm and bringing the issue forward: you are great guys! :clap: 

As usual, an additional pair of :eyes: is most welcome :bow: 
