### PR TITLE
Use screen ranges to select above and below

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1635,6 +1635,19 @@ describe "TextEditor", ->
             [[7, 20], [7, 25]]
           ]
 
+        it "takes atomic tokens into account", ->
+          waitsForPromise ->
+            atom.project.open('sample-with-tabs-and-leading-comment.coffee', autoIndent: false).then (o) -> editor = o
+
+          runs ->
+            editor.setSelectedBufferRange([[2, 1], [2, 3]])
+            editor.addSelectionBelow()
+
+            expect(editor.getSelectedBufferRanges()).toEqual [
+              [[2, 1], [2, 3]]
+              [[3, 1], [3, 2]]
+            ]
+
       describe "when the selection is empty", ->
         it "does not skip soft-wrapped lines shorter than the current column", ->
           editor.setSoftWrapped(true)
@@ -1722,6 +1735,19 @@ describe "TextEditor", ->
             [[7, 20], [7, 25]]
             [[6, 20], [6, 25]]
           ]
+
+        it "takes atomic tokens into account", ->
+          waitsForPromise ->
+            atom.project.open('sample-with-tabs-and-leading-comment.coffee', autoIndent: false).then (o) -> editor = o
+
+          runs ->
+            editor.setSelectedBufferRange([[3, 1], [3, 2]])
+            editor.addSelectionAbove()
+
+            expect(editor.getSelectedBufferRanges()).toEqual [
+              [[3, 1], [3, 2]]
+              [[2, 1], [2, 3]]
+            ]
 
       describe "when the selection is empty", ->
         it "does not skip soft-wrapped lines shorter than the current column", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1456,8 +1456,8 @@ describe "TextEditor", ->
         expect(editor.getSelectedBufferRanges()).toEqual [[[5, 5], [6, 6]]]
 
       it "merges intersecting selections", ->
-        editor.setSelectedBufferRanges([[[2, 2], [3, 3]], [[3, 0], [5, 5]]])
-        expect(editor.getSelectedBufferRanges()).toEqual [[[2, 2], [5, 5]]]
+        editor.setSelectedBufferRanges([[[2, 2], [3, 3]], [[3, 0], [5, 4]]])
+        expect(editor.getSelectedBufferRanges()).toEqual [[[2, 2], [5, 4]]]
 
       it "does not merge non-empty adjacent selections", ->
         editor.setSelectedBufferRanges([[[2, 2], [3, 3]], [[3, 3], [5, 5]]])

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1623,16 +1623,15 @@ describe "TextEditor", ->
             [[6, 22], [6, 28]]
           ]
 
-        it "selects also soft-wrapped lines", ->
+        it "can add selections to soft-wrapped line segments", ->
           editor.setSoftWrapped(true)
-          editor.setDefaultCharWidth(10)
           editor.setEditorWidthInChars(40)
 
-          editor.setSelectedScreenRange([[6, 20], [6, 25]])
+          editor.setSelectedScreenRange([[3, 10], [3, 15]])
           editor.addSelectionBelow()
           expect(editor.getSelectedScreenRanges()).toEqual [
-            [[6, 20], [6, 25]]
-            [[7, 20], [7, 25]]
+            [[3, 10], [3, 15]]
+            [[4, 10], [4, 15]]
           ]
 
         it "takes atomic tokens into account", ->
@@ -1652,25 +1651,24 @@ describe "TextEditor", ->
         describe "when lines are soft-wrapped", ->
           beforeEach ->
             editor.setSoftWrapped(true)
-            editor.setDefaultCharWidth(10)
             editor.setEditorWidthInChars(40)
 
           it "skips soft-wrap indentation tokens", ->
-            editor.setCursorScreenPosition([6, 2])
+            editor.setCursorScreenPosition([3, 0])
             editor.addSelectionBelow()
 
             expect(editor.getSelectedScreenRanges()).toEqual [
-              [[6, 2], [6, 2]]
-              [[7, 6], [7, 6]]
+              [[3, 0], [3, 0]]
+              [[4, 4], [4, 4]]
             ]
 
           it "does not skip them if they're shorter than the current column", ->
-            editor.setCursorScreenPosition([6, 44])
+            editor.setCursorScreenPosition([3, 37])
             editor.addSelectionBelow()
 
             expect(editor.getSelectedScreenRanges()).toEqual [
-              [[6, 44], [6, 44]]
-              [[7, 26], [7, 26]]
+              [[3, 37], [3, 37]]
+              [[4, 26], [4, 26]]
             ]
 
         it "does not skip lines that are shorter than the current column", ->
@@ -1736,16 +1734,15 @@ describe "TextEditor", ->
             [[3, 22], [3, 38]]
           ]
 
-        it "selects also soft-wrapped lines", ->
+        it "can add selections to soft-wrapped line segments", ->
           editor.setSoftWrapped(true)
-          editor.setDefaultCharWidth(10)
           editor.setEditorWidthInChars(40)
 
-          editor.setSelectedScreenRange([[7, 20], [7, 25]])
+          editor.setSelectedScreenRange([[4, 10], [4, 15]])
           editor.addSelectionAbove()
           expect(editor.getSelectedScreenRanges()).toEqual [
-            [[7, 20], [7, 25]]
-            [[6, 20], [6, 25]]
+            [[4, 10], [4, 15]]
+            [[3, 10], [3, 15]]
           ]
 
         it "takes atomic tokens into account", ->
@@ -1765,25 +1762,24 @@ describe "TextEditor", ->
         describe "when lines are soft-wrapped", ->
           beforeEach ->
             editor.setSoftWrapped(true)
-            editor.setDefaultCharWidth(10)
             editor.setEditorWidthInChars(40)
 
           it "skips soft-wrap indentation tokens", ->
-            editor.setCursorScreenPosition([8, 0])
+            editor.setCursorScreenPosition([5, 0])
             editor.addSelectionAbove()
 
             expect(editor.getSelectedScreenRanges()).toEqual [
-              [[8, 0], [8, 0]]
-              [[7, 6], [7, 6]]
+              [[5, 0], [5, 0]]
+              [[4, 4], [4, 4]]
             ]
 
           it "does not skip them if they're shorter than the current column", ->
-            editor.setCursorScreenPosition([6, 44])
+            editor.setCursorScreenPosition([5, 29])
             editor.addSelectionAbove()
 
             expect(editor.getSelectedScreenRanges()).toEqual [
-              [[6, 44], [6, 44]]
-              [[5, 30], [5, 30]]
+              [[5, 29], [5, 29]]
+              [[4, 26], [4, 26]]
             ]
 
         it "does not skip lines that are shorter than the current column", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1649,17 +1649,29 @@ describe "TextEditor", ->
             ]
 
       describe "when the selection is empty", ->
-        it "does not skip soft-wrapped lines shorter than the current column", ->
-          editor.setSoftWrapped(true)
-          editor.setDefaultCharWidth(10)
-          editor.setEditorWidthInChars(40)
+        describe "when lines are soft-wrapped", ->
+          beforeEach ->
+            editor.setSoftWrapped(true)
+            editor.setDefaultCharWidth(10)
+            editor.setEditorWidthInChars(40)
 
-          editor.setCursorScreenPosition([6, 44])
-          editor.addSelectionBelow()
-          expect(editor.getSelectedScreenRanges()).toEqual [
-            [[6, 44], [6, 44]]
-            [[7, 26], [7, 26]]
-          ]
+          it "skips soft-wrap indentation tokens", ->
+            editor.setCursorScreenPosition([6, 2])
+            editor.addSelectionBelow()
+
+            expect(editor.getSelectedScreenRanges()).toEqual [
+              [[6, 2], [6, 2]]
+              [[7, 6], [7, 6]]
+            ]
+
+          it "does not skip them if they're shorter than the current column", ->
+            editor.setCursorScreenPosition([6, 44])
+            editor.addSelectionBelow()
+
+            expect(editor.getSelectedScreenRanges()).toEqual [
+              [[6, 44], [6, 44]]
+              [[7, 26], [7, 26]]
+            ]
 
         it "does not skip lines that are shorter than the current column", ->
           editor.setCursorBufferPosition([3, 36])
@@ -1750,17 +1762,29 @@ describe "TextEditor", ->
             ]
 
       describe "when the selection is empty", ->
-        it "does not skip soft-wrapped lines shorter than the current column", ->
-          editor.setSoftWrapped(true)
-          editor.setDefaultCharWidth(10)
-          editor.setEditorWidthInChars(40)
+        describe "when lines are soft-wrapped", ->
+          beforeEach ->
+            editor.setSoftWrapped(true)
+            editor.setDefaultCharWidth(10)
+            editor.setEditorWidthInChars(40)
 
-          editor.setCursorScreenPosition([6, 44])
-          editor.addSelectionAbove()
-          expect(editor.getSelectedScreenRanges()).toEqual [
-            [[6, 44], [6, 44]]
-            [[5, 30], [5, 30]]
-          ]
+          it "skips soft-wrap indentation tokens", ->
+            editor.setCursorScreenPosition([8, 0])
+            editor.addSelectionAbove()
+
+            expect(editor.getSelectedScreenRanges()).toEqual [
+              [[8, 0], [8, 0]]
+              [[7, 6], [7, 6]]
+            ]
+
+          it "does not skip them if they're shorter than the current column", ->
+            editor.setCursorScreenPosition([6, 44])
+            editor.addSelectionAbove()
+
+            expect(editor.getSelectedScreenRanges()).toEqual [
+              [[6, 44], [6, 44]]
+              [[5, 30], [5, 30]]
+            ]
 
         it "does not skip lines that are shorter than the current column", ->
           editor.setCursorBufferPosition([6, 36])

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1623,7 +1623,31 @@ describe "TextEditor", ->
             [[6, 22], [6, 28]]
           ]
 
+        it "selects also soft-wrapped lines", ->
+          editor.setSoftWrapped(true)
+          editor.setDefaultCharWidth(10)
+          editor.setEditorWidthInChars(40)
+
+          editor.setSelectedScreenRange([[6, 20], [6, 25]])
+          editor.addSelectionBelow()
+          expect(editor.getSelectedScreenRanges()).toEqual [
+            [[6, 20], [6, 25]]
+            [[7, 20], [7, 25]]
+          ]
+
       describe "when the selection is empty", ->
+        it "does not skip soft-wrapped lines shorter than the current column", ->
+          editor.setSoftWrapped(true)
+          editor.setDefaultCharWidth(10)
+          editor.setEditorWidthInChars(40)
+
+          editor.setCursorScreenPosition([6, 44])
+          editor.addSelectionBelow()
+          expect(editor.getSelectedScreenRanges()).toEqual [
+            [[6, 44], [6, 44]]
+            [[7, 26], [7, 26]]
+          ]
+
         it "does not skip lines that are shorter than the current column", ->
           editor.setCursorBufferPosition([3, 36])
           editor.addSelectionBelow()
@@ -1687,7 +1711,31 @@ describe "TextEditor", ->
             [[3, 22], [3, 38]]
           ]
 
+        it "selects also soft-wrapped lines", ->
+          editor.setSoftWrapped(true)
+          editor.setDefaultCharWidth(10)
+          editor.setEditorWidthInChars(40)
+
+          editor.setSelectedScreenRange([[7, 20], [7, 25]])
+          editor.addSelectionAbove()
+          expect(editor.getSelectedScreenRanges()).toEqual [
+            [[7, 20], [7, 25]]
+            [[6, 20], [6, 25]]
+          ]
+
       describe "when the selection is empty", ->
+        it "does not skip soft-wrapped lines shorter than the current column", ->
+          editor.setSoftWrapped(true)
+          editor.setDefaultCharWidth(10)
+          editor.setEditorWidthInChars(40)
+
+          editor.setCursorScreenPosition([6, 44])
+          editor.addSelectionAbove()
+          expect(editor.getSelectedScreenRanges()).toEqual [
+            [[6, 44], [6, 44]]
+            [[5, 30], [5, 30]]
+          ]
+
         it "does not skip lines that are shorter than the current column", ->
           editor.setCursorBufferPosition([6, 36])
           editor.addSelectionAbove()

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1456,8 +1456,8 @@ describe "TextEditor", ->
         expect(editor.getSelectedBufferRanges()).toEqual [[[5, 5], [6, 6]]]
 
       it "merges intersecting selections", ->
-        editor.setSelectedBufferRanges([[[2, 2], [3, 3]], [[3, 0], [5, 4]]])
-        expect(editor.getSelectedBufferRanges()).toEqual [[[2, 2], [5, 4]]]
+        editor.setSelectedBufferRanges([[[2, 2], [3, 3]], [[3, 0], [5, 5]]])
+        expect(editor.getSelectedBufferRanges()).toEqual [[[2, 2], [5, 5]]]
 
       it "does not merge non-empty adjacent selections", ->
         editor.setSelectedBufferRanges([[[2, 2], [3, 3]], [[3, 3], [5, 5]]])

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -859,6 +859,18 @@ class DisplayBuffer extends Model
       column = screenLine.clipScreenColumn(column, options)
     new Point(row, column)
 
+  # Clip the start and end of the given range to valid positions on screen.
+  # See {::clipScreenPosition} for more information.
+  #
+  # * `range` The {Range} to clip.
+  # * `options` (optional) See {::clipScreenPosition} `options`.
+  # Returns a {Range}.
+  clipScreenRange: (range, options) ->
+    start = @clipScreenPosition(range.start, options)
+    end = @clipScreenPosition(range.end, options)
+
+    new Range(start, end)
+
   # Calculates a {Range} representing the start of the {TextBuffer} until the end.
   #
   # Returns a {Range}.

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -183,7 +183,7 @@ class Selection extends Model
 
   # Public: Clears the selection, moving the marker to the head.
   clear: ->
-    @marker.setProperties(goalBufferRange: null)
+    @marker.setProperties(goalBufferRange: null, goalScreenRange: null)
     @marker.clearTail() unless @retainSelection
     @finalize()
 
@@ -657,38 +657,38 @@ class Selection extends Model
 
   # Public: Moves the selection down one row.
   addSelectionBelow: ->
-    range = (@getGoalBufferRange() ? @getBufferRange()).copy()
+    range = (@getGoalScreenRange() ? @getScreenRange()).copy()
     nextRow = range.end.row + 1
 
-    for row in [nextRow..@editor.getLastBufferRow()]
+    for row in [nextRow..@editor.getLastScreenRow()]
       range.start.row = row
       range.end.row = row
-      clippedRange = @editor.clipBufferRange(range)
+      clippedRange = @editor.clipScreenRange(range)
 
       if range.isEmpty()
         continue if range.end.column > 0 and clippedRange.end.column is 0
       else
         continue if clippedRange.isEmpty()
 
-      @editor.addSelectionForBufferRange(range, goalBufferRange: range)
+      @editor.addSelectionForScreenRange(range, goalScreenRange: range)
       break
 
   # Public: Moves the selection up one row.
   addSelectionAbove: ->
-    range = (@getGoalBufferRange() ? @getBufferRange()).copy()
+    range = (@getGoalScreenRange() ? @getScreenRange()).copy()
     previousRow = range.end.row - 1
 
     for row in [previousRow..0]
       range.start.row = row
       range.end.row = row
-      clippedRange = @editor.clipBufferRange(range)
+      clippedRange = @editor.clipScreenRange(range)
 
       if range.isEmpty()
         continue if range.end.column > 0 and clippedRange.end.column is 0
       else
         continue if clippedRange.isEmpty()
 
-      @editor.addSelectionForBufferRange(range, goalBufferRange: range)
+      @editor.addSelectionForScreenRange(range, goalScreenRange: range)
       break
 
   # Public: Combines the given selection into this selection and then destroys
@@ -767,3 +767,7 @@ class Selection extends Model
   getGoalBufferRange: ->
     if goalBufferRange = @marker.getProperties().goalBufferRange
       Range.fromObject(goalBufferRange)
+
+  getGoalScreenRange: ->
+    if goalScreenRange = @marker.getProperties().goalScreenRange
+      Range.fromObject(goalScreenRange)

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -695,7 +695,7 @@ class Selection extends Model
   # the given selection.
   #
   # * `otherSelection` A {Selection} to merge with.
-  # * `options` (optional) {Object} options matching those found in {::setScreenRange}.
+  # * `options` (optional) {Object} options matching those found in {::setBufferRange}.
   merge: (otherSelection, options) ->
     myGoalScreenRange = @getGoalScreenRange()
     otherGoalScreenRange = otherSelection.getGoalScreenRange()
@@ -705,7 +705,7 @@ class Selection extends Model
     else
       options.goalScreenRange = myGoalScreenRange ? otherGoalScreenRange
 
-    @setScreenRange(@getScreenRange().union(otherSelection.getScreenRange()), options)
+    @setBufferRange(@getBufferRange().union(otherSelection.getBufferRange()), options)
     otherSelection.destroy()
 
   ###

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -183,7 +183,7 @@ class Selection extends Model
 
   # Public: Clears the selection, moving the marker to the head.
   clear: ->
-    @marker.setProperties(goalBufferRange: null, goalScreenRange: null)
+    @marker.setProperties(goalScreenRange: null)
     @marker.clearTail() unless @retainSelection
     @finalize()
 
@@ -695,15 +695,17 @@ class Selection extends Model
   # the given selection.
   #
   # * `otherSelection` A {Selection} to merge with.
-  # * `options` (optional) {Object} options matching those found in {::setBufferRange}.
+  # * `options` (optional) {Object} options matching those found in {::setScreenRange}.
   merge: (otherSelection, options) ->
-    myGoalBufferRange = @getGoalBufferRange()
-    otherGoalBufferRange = otherSelection.getGoalBufferRange()
-    if myGoalBufferRange? and otherGoalBufferRange?
-      options.goalBufferRange = myGoalBufferRange.union(otherGoalBufferRange)
+    myGoalScreenRange = @getGoalScreenRange()
+    otherGoalScreenRange = otherSelection.getGoalScreenRange()
+
+    if myGoalScreenRange? and otherGoalScreenRange?
+      options.goalScreenRange = myGoalScreenRange.union(otherGoalScreenRange)
     else
-      options.goalBufferRange = myGoalBufferRange ? otherGoalBufferRange
-    @setBufferRange(@getBufferRange().union(otherSelection.getBufferRange()), options)
+      options.goalScreenRange = myGoalScreenRange ? otherGoalScreenRange
+
+    @setScreenRange(@getScreenRange().union(otherSelection.getScreenRange()), options)
     otherSelection.destroy()
 
   ###
@@ -763,10 +765,6 @@ class Selection extends Model
   # Returns a {Point} representing the new tail position.
   plantTail: ->
     @marker.plantTail()
-
-  getGoalBufferRange: ->
-    if goalBufferRange = @marker.getProperties().goalBufferRange
-      Range.fromObject(goalBufferRange)
 
   getGoalScreenRange: ->
     if goalScreenRange = @marker.getProperties().goalScreenRange

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -663,14 +663,14 @@ class Selection extends Model
     for row in [nextRow..@editor.getLastScreenRow()]
       range.start.row = row
       range.end.row = row
-      clippedRange = @editor.clipScreenRange(range)
+      clippedRange = @editor.clipScreenRange(range, skipSoftWrapIndentation: true)
 
       if range.isEmpty()
         continue if range.end.column > 0 and clippedRange.end.column is 0
       else
         continue if clippedRange.isEmpty()
 
-      @editor.addSelectionForScreenRange(range, goalScreenRange: range)
+      @editor.addSelectionForScreenRange(clippedRange, goalScreenRange: range)
       break
 
   # Public: Moves the selection up one row.
@@ -681,14 +681,14 @@ class Selection extends Model
     for row in [previousRow..0]
       range.start.row = row
       range.end.row = row
-      clippedRange = @editor.clipScreenRange(range)
+      clippedRange = @editor.clipScreenRange(range, skipSoftWrapIndentation: true)
 
       if range.isEmpty()
         continue if range.end.column > 0 and clippedRange.end.column is 0
       else
         continue if clippedRange.isEmpty()
 
-      @editor.addSelectionForScreenRange(range, goalScreenRange: range)
+      @editor.addSelectionForScreenRange(clippedRange, goalScreenRange: range)
       break
 
   # Public: Combines the given selection into this selection and then destroys

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1275,6 +1275,14 @@ class TextEditor extends Model
   # Returns a {Point}.
   clipScreenPosition: (screenPosition, options) -> @displayBuffer.clipScreenPosition(screenPosition, options)
 
+  # Extended: Clip the start and end of the given range to valid positions on screen.
+  # See {::clipScreenPosition} for more information.
+  #
+  # * `range` The {Range} to clip.
+  # * `options` (optional) See {::clipScreenPosition} `options`.
+  # Returns a {Range}.
+  clipScreenRange: (range, options) -> @displayBuffer.clipScreenRange(range, options)
+
   ###
   Section: Decorations
   ###


### PR DESCRIPTION
This fixes #5788 

As reported on the issue, Atom behaved inconsistently while adding selections (above or below) on lines made of tokens with a `screenDelta > bufferDelta` (e.g. tabs). The behavior was not compatible with Sublime Text, too, which handles the scenario like this:
- Selecting above or below works with what's visible on screen (thus, no mismatch between buffer length and screen length)
- Soft-wrapped lines are therefore included while selecting
- When a soft-wrapped line has indentation, skip it and select the first real character

This is the behavior I would expect in Atom as well and, hopefully, this PR includes everything that's needed to achieve it :fire: 

An additional pair of :eyes: is most welcome, but even if code-wise this looks good, I'd prefer to leave this open for a while so that the community has the chance to test-drive it.

Thank you! :bow: 

/cc: @benogle @izuzak @nathansobo @kevinsawicki 
