### PR TITLE
Enable multiple users

### DIFF
--- a/benchmark/browser-process-startup.coffee
+++ b/benchmark/browser-process-startup.coffee
@@ -8,7 +8,7 @@ _ = require 'underscore-plus'
 temp = require 'temp'
 
 directoryToOpen = temp.mkdirSync('browser-process-startup-')
-socketPath = path.join(os.tmpdir(), 'atom.sock')
+socketPath = path.join(os.tmpdir(), "atom_#{process.env['USER']}.sock")
 numberOfRuns = 10
 
 deleteSocketFile = ->

--- a/spec/integration/helpers/start-atom.coffee
+++ b/spec/integration/helpers/start-atom.coffee
@@ -9,7 +9,7 @@ webdriverio = require "../../../build/node_modules/webdriverio"
 AtomPath = remote.process.argv[0]
 AtomLauncherPath = path.join(__dirname, "..", "helpers", "atom-launcher.sh")
 ChromedriverPath = path.resolve(__dirname, '..', '..', '..', 'atom-shell', 'chromedriver', 'chromedriver')
-SocketPath = path.join(temp.mkdirSync("socket-dir"), "atom.sock")
+SocketPath = path.join(temp.mkdirSync("socket-dir"), "atom_#{process.env['USER']}.sock")
 ChromedriverPort = 9515
 
 buildAtomClient = (args, env) ->

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -18,7 +18,7 @@ DefaultSocketPath =
   if process.platform is 'win32'
     '\\\\.\\pipe\\atom-sock'
   else
-    path.join(os.tmpdir(), 'atom.sock')
+    path.join(os.tmpdir(), "atom_#{process.env['USER']}.sock")
 
 # The application's singleton class.
 #

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -18,7 +18,7 @@ DefaultSocketPath =
   if process.platform is 'win32'
     '\\\\.\\pipe\\atom-sock'
   else
-    path.join(os.tmpdir(), "atom_#{process.env['USER']}.sock")
+    path.join(os.tmpdir(), "atom_#{process.env.USER}.sock")
 
 # The application's singleton class.
 #


### PR DESCRIPTION
Currently, it is not possible to use atom for multiple users on the same linux machine. The socket file '/tmp/atom.sock' belongs to the first user that starts atom.
With this small change, a socket file will be created for each user.
