### PR TITLE
Add pane:close to atom-pane context menu

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -225,5 +225,6 @@
     {label: 'Split Down', command: 'pane:split-down'}
     {label: 'Split Left', command: 'pane:split-left'}
     {label: 'Split Right', command: 'pane:split-right'}
+    {label: 'Close Pane', command: 'pane:close'}
     {type: 'separator'}
   ]

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -217,6 +217,7 @@
     {label: 'Split Down', command: 'pane:split-down'}
     {label: 'Split Left', command: 'pane:split-left'}
     {label: 'Split Right', command: 'pane:split-right'}
+    {label: 'Close Pane', command: 'pane:close'}
     {type: 'separator'}
   ]
   'atom-pane': [

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -174,6 +174,7 @@
     {label: 'Split Down', command: 'pane:split-down'}
     {label: 'Split Left', command: 'pane:split-left'}
     {label: 'Split Right', command: 'pane:split-right'}
+    {label: 'Close Pane', command: 'pane:close'}
     {type: 'separator'}
   ]
   'atom-pane': [
@@ -182,5 +183,6 @@
     {label: 'Split Down', command: 'pane:split-down'}
     {label: 'Split Left', command: 'pane:split-left'}
     {label: 'Split Right', command: 'pane:split-right'}
+    {label: 'Close Pane', command: 'pane:close'}
     {type: 'separator'}
   ]

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -196,6 +196,7 @@
     {label: 'Split Down', command: 'pane:split-down'}
     {label: 'Split Left', command: 'pane:split-left'}
     {label: 'Split Right', command: 'pane:split-right'}
+    {label: 'Close Pane', command: 'pane:close'}
     {type: 'separator'}
   ]
   'atom-pane': [
@@ -204,5 +205,6 @@
     {label: 'Split Down', command: 'pane:split-down'}
     {label: 'Split Left', command: 'pane:split-left'}
     {label: 'Split Right', command: 'pane:split-right'}
+    {label: 'Close Pane', command: 'pane:close'}
     {type: 'separator'}
   ]


### PR DESCRIPTION
I've found myself wanting to do this quite frequently – this PR adds "Close Pane" to `atom-pane`'s context menu, allowing you to close the active pane from the context menu just like you can do with the "Split" pane commands.
