### PR TITLE
Use core:cancel command to dissmiss notifications

### DIFF
--- a/src/notification-manager.coffee
+++ b/src/notification-manager.coffee
@@ -8,6 +8,10 @@ class NotificationManager
   constructor: ->
     @notifications = []
     @emitter = new Emitter
+    
+    atom.commands.add 'atom-workspace', 'core:cancel', ->
+      @getNotifications.forEach (notification) ->
+        notification.dismiss()
 
   ###
   Section: Events


### PR DESCRIPTION
Listen to `core:cancel` on `atom-workspace`. When triggered dismiss notifications.
