### PR TITLE
Deprecate all on-based event registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "autosave": "0.20.0",
     "background-tips": "0.23.0",
     "bookmarks": "0.35.0",
-    "bracket-matcher": "0.71.0",
+    "bracket-matcher": "0.72.0",
     "command-palette": "0.34.0",
     "deprecation-cop": "0.37.0",
     "dev-live-reload": "0.44.0",

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -96,7 +96,8 @@ class GitRepository
       @subscriptions.add new Disposable(-> window.removeEventListener 'focus', onWindowFocus)
 
     if @project?
-      @subscriptions.add @project.eachBuffer (buffer) => @subscribeToBuffer(buffer)
+      @project.getBuffers().forEach (buffer) => @subscribeToBuffer(buffer)
+      @subscriptions.add @project.onDidAddBuffer (buffer) => @subscribeToBuffer(buffer)
 
   # Public: Destroy this {GitRepository} object.
   #

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -124,6 +124,8 @@ class Marker
         Grim.deprecate("Use Marker::onDidChange instead")
       when 'destroyed'
         Grim.deprecate("Use Marker::onDidDestroy instead")
+      else
+        Grim.deprecate("Marker::on is deprecated. Use documented event subscription methods instead.")
 
     EmitterMixin::on.apply(this, arguments)
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -343,7 +343,7 @@ class Pane extends Model
 
     if typeof item.onDidDestroy is 'function'
       @subscriptions.add item.onDidDestroy => @removeItem(item, true)
-    if typeof item.on is 'function'
+    else if typeof item.on is 'function'
       @subscribe item, 'destroyed', => @removeItem(item, true)
 
     @items.splice(index, 0, item)

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -250,6 +250,10 @@ class Pane extends Model
 
   getPanes: -> [this]
 
+  unsubscribeFromItem: (item) ->
+    @itemSubscriptions.get(item)?.dispose()
+    @itemSubscriptions.delete(item)
+
   ###
   Section: Items
   ###
@@ -372,9 +376,7 @@ class Pane extends Model
 
     if typeof item.on is 'function'
       @unsubscribe item
-
-    @itemSubscriptions.get(item)?.dispose()
-    @itemSubscriptions.delete(item)
+    @unsubscribeFromItem(item)
 
     if item is @activeItem
       if @items.length is 1
@@ -585,10 +587,7 @@ class Pane extends Model
     @container.activateNextPane() if @isActive()
     @emitter.emit 'did-destroy'
     @emitter.dispose()
-    for item in @items.slice()
-      @itemSubscriptions.get(item)?.dispose()
-      @itemSubscriptions.delete(item)
-      item.destroy?()
+    item.destroy?() for item in @items.slice()
     @container?.didDestroyPane(pane: this)
 
   ###

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -118,6 +118,9 @@ class Project extends Model
   onDidChangePaths: (callback) ->
     @emitter.on 'did-change-paths', callback
 
+  onDidAddBuffer: (callback) ->
+    @emitter.on 'did-add-buffer', callback
+
   on: (eventName) ->
     if eventName is 'path-changed'
       Grim.deprecate("Use Project::onDidChangePaths instead")
@@ -436,6 +439,7 @@ class Project extends Model
     @buffers.splice(index, 0, buffer)
     @subscribeToBuffer(buffer)
     @emit 'buffer-created', buffer
+    @emitter.emit 'did-add-buffer', buffer
     buffer
 
   # Removes a {TextBuffer} association from the project.

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -121,6 +121,8 @@ class Project extends Model
   on: (eventName) ->
     if eventName is 'path-changed'
       Grim.deprecate("Use Project::onDidChangePaths instead")
+    else
+      Grim.deprecate("Project::on is deprecated. Use documented event subscription methods instead.")
     super
 
   ###

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -67,6 +67,8 @@ class Selection extends Model
         Grim.deprecate("Use Selection::onDidChangeRange instead. Call ::getScreenRange() yourself in your callback if you need the range.")
       when 'destroyed'
         Grim.deprecate("Use Selection::onDidDestroy instead.")
+      else
+        Grim.deprecate("Selection::on is deprecated. Use documented event subscription methods instead.")
 
     super
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -512,6 +512,9 @@ class TextEditor extends Model
       when 'scroll-left-changed'
         deprecate("Use TextEditor::onDidChangeScrollLeft instead")
 
+      else
+        deprecate("TextEditor::on is deprecated. Use documented event subscription methods instead.")
+
     EmitterMixin::on.apply(this, arguments)
 
   # Retrieves the current {TextBuffer}.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -457,6 +457,10 @@ class TextEditor extends Model
   onDidChangeScrollLeft: (callback) ->
     @emitter.on 'did-change-scroll-left', callback
 
+  # TODO Remove once the tabs package no longer uses .on subscriptions
+  onDidChangeIcon: (callback) ->
+    @emitter.on 'did-change-icon', callback
+
   on: (eventName) ->
     switch eventName
       when 'title-changed'


### PR DESCRIPTION
I noticed bracket matcher was still calling `TextEditor::on` for a `destroyed` event and not getting a deprecation warning for it.
