### PR TITLE
Documentation: workspace.open( ) with no URI

### DIFF
--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -371,8 +371,8 @@ class Workspace extends Model
   Section: Opening
   ###
 
-  # Essential: Open a given URI in Atom asynchronously. 
-  # If no URI is given, or URI does not resolve to an existing file, 
+  # Essential: Opens the given URI in Atom asynchronously, if it's not already open. 
+  # If no URI is given, or the URI is the path of a file that does not exist,
   # a new empty text edtior is created.
   # 
   # * `uri` (optional) A {String} containing a URI. 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -371,9 +371,11 @@ class Workspace extends Model
   Section: Opening
   ###
 
-  # Essential: Open a given a URI in Atom asynchronously.
-  #
-  # * `uri` A {String} containing a URI.
+  # Essential: Open a given URI in Atom asynchronously. 
+  # If no URI is given, or URI does not resolve to an existing file, 
+  # a new empty text edtior is created.
+  # 
+  # * `uri` (optional) A {String} containing a URI. 
   # * `options` (optional) {Object}
   #   * `initialLine` A {Number} indicating which row to move the cursor to
   #     initially. Defaults to `0`.


### PR DESCRIPTION
I just learned that [calling open on workspace](https://discuss.atom.io/t/how-can-we-help-you-write-packages/4268/67) without specifying an uri is the way to go for getting a new tab with a new document. 

I can't find anything about this in either the docs or the [api documentation.](https://atom.io/docs/api/v0.187.0/Workspace#instance-open)

Should `uri` be marked optional, like the `options` params? And should it be added a line stating that no uri opens a blank editor?

(and there's an extra `a` in the title..)
