### PR TITLE
:racehorse: Don't tokenize on NullGrammar

### DIFF
--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -138,6 +138,7 @@ class TokenizedBuffer extends Model
 
   tokenizeInBackground: ->
     return if not @visible or @pendingChunk or not @isAlive()
+    return if @grammar is @grammar.registry.nullGrammar
     @pendingChunk = true
     _.defer =>
       @pendingChunk = false


### PR DESCRIPTION
For file format that Atom doesn't recognize as a
programming language, such as log files,
skip Tokenization since no syntax highlighting should be done.
