### PR TITLE
Upgrade to pathwatcher 4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "bracket-matcher": "0.72.0",
     "command-palette": "0.34.0",
     "deprecation-cop": "0.37.0",
-    "dev-live-reload": "0.44.0",
+    "dev-live-reload": "0.45.0",
     "encoding-selector": "0.19.0",
     "exception-reporting": "0.24.0",
     "feedback": "0.34.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "one-light-ui": "0.4.0",
     "solarized-dark-syntax": "0.32.0",
     "solarized-light-syntax": "0.19.0",
-    "archive-view": "0.52.0",
+    "archive-view": "0.53.0",
     "autocomplete": "0.44.0",
     "autoflow": "0.22.0",
     "autosave": "0.20.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "atomShellVersion": "0.21.3",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "^3.1.5",
+    "atom-keymap": "^4",
     "atom-space-pen-views": "^2.0.4",
     "babel-core": "^4.0.2",
     "bootstrap": "git+https://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nslog": "^2.0.0",
     "oniguruma": "^4.0.0",
     "optimist": "0.4.0",
-    "pathwatcher": "^3.3.3",
+    "pathwatcher": "^4.2",
     "property-accessors": "^1.1.3",
     "q": "^1.1.2",
     "random-words": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nslog": "^2.0.0",
     "oniguruma": "^4.0.0",
     "optimist": "0.4.0",
-    "pathwatcher": "^4.3",
+    "pathwatcher": "^4.3.1",
     "property-accessors": "^1.1.3",
     "q": "^1.1.2",
     "random-words": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "symbols-view": "0.91.0",
     "tabs": "0.67.0",
     "timecop": "0.31.0",
-    "tree-view": "0.167.0",
+    "tree-view": "0.168.0",
     "update-package-dependencies": "0.9.0",
     "welcome": "0.25.0",
     "whitespace": "0.29.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "incompatible-packages": "0.24.0",
     "keybinding-resolver": "0.29.0",
     "link": "0.30.0",
-    "markdown-preview": "0.142.0",
+    "markdown-preview": "0.143.0",
     "metrics": "0.45.0",
     "notifications": "0.33.0",
     "open-on-github": "0.34.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nslog": "^2.0.0",
     "oniguruma": "^4.0.0",
     "optimist": "0.4.0",
-    "pathwatcher": "^4.2",
+    "pathwatcher": "^4.3",
     "property-accessors": "^1.1.3",
     "q": "^1.1.2",
     "random-words": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "git-diff": "0.54.0",
     "go-to-line": "0.30.0",
     "grammar-selector": "0.46.0",
-    "image-view": "0.51.0",
+    "image-view": "0.52.0",
     "incompatible-packages": "0.24.0",
     "keybinding-resolver": "0.29.0",
     "link": "0.30.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "spell-check": "0.55.0",
     "status-bar": "0.63.0",
     "styleguide": "0.44.0",
-    "symbols-view": "0.90.0",
+    "symbols-view": "0.91.0",
     "tabs": "0.67.0",
     "timecop": "0.31.0",
     "tree-view": "0.167.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "package-generator": "0.38.0",
     "release-notes": "0.52.0",
     "settings-view": "0.184.0",
-    "snippets": "0.82.0",
+    "snippets": "0.83.0",
     "spell-check": "0.55.0",
     "status-bar": "0.63.0",
     "styleguide": "0.44.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "space-pen": "3.8.2",
     "stacktrace-parser": "0.1.1",
     "temp": "0.8.1",
-    "text-buffer": "^4.1.5",
+    "text-buffer": "^5",
     "theorist": "^1.0.2",
     "underscore-plus": "^1.6.6"
   },


### PR DESCRIPTION
Upgrade core, core libraries, and core packages to use pathwatcher 4.x which had some breaking changes from 3.x such as a `Sync` suffix to methods on `File`.

Closes #5706 
