### PR TITLE
Don't soft-wrap on indentation

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -115,6 +115,24 @@ describe "DisplayBuffer", ->
           expect(displayBuffer.tokenizedLineForScreenRow(3).text).toBe '    var pivot = items.shift(), current, left = [], '
           expect(displayBuffer.tokenizedLineForScreenRow(4).text).toBe '    right = [];'
 
+      describe "when the only whitespace characters are at the beginning of the line", ->
+        beforeEach ->
+          displayBuffer.setEditorWidthInChars(10)
+
+        it "wraps the line at the max length when indented with tabs", ->
+          buffer.setTextInRange([[0, 0], [1, 0]], '\t\tabcdefghijklmnopqrstuvwxyz')
+
+          expect(displayBuffer.tokenizedLineForScreenRow(0).text).toBe '    abcdef'
+          expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe '    ghijkl'
+          expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe '    mnopqr'
+
+        it "wraps the line at the max length when indented with spaces", ->
+          buffer.setTextInRange([[0, 0], [1, 0]], '    abcdefghijklmnopqrstuvwxyz')
+
+          expect(displayBuffer.tokenizedLineForScreenRow(0).text).toBe '    abcdef'
+          expect(displayBuffer.tokenizedLineForScreenRow(1).text).toBe '    ghijkl'
+          expect(displayBuffer.tokenizedLineForScreenRow(2).text).toBe '    mnopqr'
+
       describe "when there are hard tabs", ->
         beforeEach ->
           buffer.setText(buffer.getText().replace(new RegExp('  ', 'g'), '\t'))

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1937,14 +1937,14 @@ describe "TextEditorComponent", ->
             gutterNode.dispatchEvent(buildMouseEvent('mousemove', clientCoordinatesForScreenRowInGutter(11), metaKey: true))
             nextAnimationFrame()
             gutterNode.dispatchEvent(buildMouseEvent('mouseup', clientCoordinatesForScreenRowInGutter(11), metaKey: true))
-            expect(editor.getSelectedScreenRanges()).toEqual [[[7, 4], [7, 6]], [[10, 0], [20, 0]]]
+            expect(editor.getSelectedScreenRanges()).toEqual [[[7, 4], [7, 6]], [[10, 0], [19, 0]]]
 
           it "merges overlapping selections", ->
             gutterNode.dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenRowInGutter(17), metaKey: true))
             gutterNode.dispatchEvent(buildMouseEvent('mousemove', clientCoordinatesForScreenRowInGutter(9), metaKey: true))
             nextAnimationFrame()
             gutterNode.dispatchEvent(buildMouseEvent('mouseup', clientCoordinatesForScreenRowInGutter(9), metaKey: true))
-            expect(editor.getSelectedScreenRanges()).toEqual [[[5, 0], [20, 0]]]
+            expect(editor.getSelectedScreenRanges()).toEqual [[[5, 0], [19, 0]]]
 
       describe "when the gutter is shift-clicked and dragged", ->
         describe "when the shift-click is below the existing selection's tail", ->

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -11,6 +11,7 @@ module.exports =
 class TokenizedLine
   endOfLineInvisibles: null
   lineIsWhitespaceOnly: false
+  firstNonWhitespaceIndex: 0
   foldable: false
 
   constructor: ({tokens, @lineEnding, @ruleStack, @startBufferColumn, @fold, @tabLength, @indentLevel, @invisibles}) ->
@@ -162,12 +163,7 @@ class TokenizedLine
     @lineEnding is null
 
   isColumnOutsideIndentation: (column) ->
-    column >= @firstNonWhitespaceIndex and @isColumnOutsideSoftWrapIndentation(column)
-
-  isColumnOutsideSoftWrapIndentation: (column) ->
-    return true if @softWrapIndentationTokens.length == 0
-
-    column > @softWrapIndentationDelta
+    column >= @firstNonWhitespaceIndex
 
   isColumnInsideSoftWrapIndentation: (column) ->
     return false if @softWrapIndentationTokens.length == 0

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -97,6 +97,7 @@ class TokenizedLine
   # Returns a {Number} representing the `line` position where the wrap would take place.
   # Returns `null` if a wrap wouldn't occur.
   findWrapColumn: (maxColumn) ->
+    return unless maxColumn?
     return unless @text.length > maxColumn
 
     if /\s/.test(@text[maxColumn])
@@ -107,7 +108,7 @@ class TokenizedLine
       return @text.length
     else
       # search backward for the start of the word on the boundary
-      for column in [maxColumn..0] when @isColumnOutsideIndentation(column)
+      for column in [maxColumn..@firstNonWhitespaceIndex]
         return column + 1 if /\s/.test(@text[column])
 
       return maxColumn
@@ -161,9 +162,6 @@ class TokenizedLine
 
   isSoftWrapped: ->
     @lineEnding is null
-
-  isColumnOutsideIndentation: (column) ->
-    column >= @firstNonWhitespaceIndex
 
   isColumnInsideSoftWrapIndentation: (column) ->
     return false if @softWrapIndentationTokens.length == 0


### PR DESCRIPTION
Closes #5995 :sparkles: 

As pointed out on the aforementioned issue, Atom behaved unexpectedly while soft-wrapping tab-indented lines. I tracked down the issue to `TokenizedLine#findWrapColumn`: when searching backwards for spaces, in facts, the method didn't skip indentation tokens.

But why this was happening only for tab-indented lines? That's because invisibles were getting replaced with visible characters. However, the replacement for `\t` has a trailing space `»`, whereas the replacement for spaces hasn't.

This PR changes the behavior to always skip indentation tokens while scanning the line backwards for spaces :beetle: :gun: 

![screen shot 2015-03-19 at 12 05 31](https://cloud.githubusercontent.com/assets/482957/6729204/44fb8b72-ce30-11e4-8a1b-4e41d81da2c6.png)

/cc: @izuzak @nathansobo
