### PR TITLE
Remove unwanted loop returns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,9 @@ For more information on how to work with Atom's official packages, see
   should be lower-case:
   * `getURI` instead of `getUri`
   * `uriToOpen` instead of `URIToOpen`
+* Use `slice()` to copy an array
+* Add an explicit `return` when your function ends with a `for`/`while` loop and
+  you don't want it to return a collected array.
 
 ## Documentation Styleguide
 

--- a/build/tasks/output-for-loop-returns.coffee
+++ b/build/tasks/output-for-loop-returns.coffee
@@ -12,7 +12,7 @@ module.exports = (grunt) ->
       js = grunt.file.read(jsPath)
       method = null
       for line, index in js.split('\n')
-        [match, className, methodName] = /^\s*([a-zA-Z]+)\.prototype\.([a-zA-Z]+)\s*=\s*function\(/.exec(line) ? []
+        [match, className, methodName] = /^\s*([a-zA-Z]+)\.(?:prototype\.)?([a-zA-Z]+)\s*=\s*function\(/.exec(line) ? []
         if className and methodName
           method = "#{className}::#{methodName}"
         else

--- a/build/tasks/output-for-loop-returns.coffee
+++ b/build/tasks/output-for-loop-returns.coffee
@@ -1,0 +1,22 @@
+path = require 'path'
+
+module.exports = (grunt) ->
+  grunt.registerTask 'output-for-loop-returns', 'Log methods that end with a for loop', ->
+    appDir = grunt.config.get('atom.appDir')
+
+    jsPaths = []
+    grunt.file.recurse path.join(appDir, 'src'), (absolutePath, rootPath, relativePath, fileName) ->
+      jsPaths.push(absolutePath) if path.extname(fileName) is '.js'
+
+    jsPaths.forEach (jsPath) ->
+      js = grunt.file.read(jsPath)
+      method = null
+      for line, index in js.split('\n')
+        [match, className, methodName] = /^\s*([a-zA-Z]+)\.prototype\.([a-zA-Z]+)\s*=\s*function\(/.exec(line) ? []
+        if className and methodName
+          method = "#{className}::#{methodName}"
+        else
+          [match, ctorName] = /^\s*function\s+([a-zA-Z]+)\(/.exec(line) ? []
+
+        if /^\s*return\s+_results;\s*$/.test(line)
+          console.log(method ? "#{path.basename(jsPath)}:#{index}")

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -825,6 +825,7 @@ class Atom extends Model
         delete window[key]
       else
         window[key] = value
+    return
 
   onUpdateAvailable: (callback) ->
     @emitter.on 'update-available', callback

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -82,7 +82,8 @@ class ApplicationMenu
   #          window specific items.
   enableWindowSpecificItems: (enable) ->
     for item in @flattenMenuItems(@menu)
-      item.enabled = enable if item.metadata?['windowSpecific']
+      item.enabled = enable if item.metadata?.windowSpecific
+    return
 
   # Replaces VERSION with the current version.
   substituteVersion: (template) ->
@@ -145,7 +146,7 @@ class ApplicationMenu
       if item.command
         item.accelerator = @acceleratorForCommand(item.command, keystrokesByCommand)
         item.click = -> global.atomApplication.sendCommand(item.command)
-        item.metadata['windowSpecific'] = true unless /^application:/.test(item.command)
+        item.metadata.windowSpecific = true unless /^application:/.test(item.command)
       @translateTemplate(item.submenu, keystrokesByCommand) if item.submenu
     template
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -388,11 +388,13 @@ class AtomApplication
   # Kill all processes associated with opened windows.
   killAllProcesses: ->
     @killProcess(pid) for pid of @pidsToOpenWindows
+    return
 
   # Kill process associated with the given opened window.
   killProcessForWindow: (openedWindow) ->
     for pid, trackedWindow of @pidsToOpenWindows
       @killProcess(pid) if trackedWindow is openedWindow
+    return
 
   # Kill the process with the given pid.
   killProcess: (pid) ->

--- a/src/browser/auto-update-manager.coffee
+++ b/src/browser/auto-update-manager.coffee
@@ -65,6 +65,7 @@ class AutoUpdateManager
     return unless @releaseVersion?
     for atomWindow in windows
       atomWindow.sendMessage('update-available', {@releaseVersion})
+    return
 
   setState: (state) ->
     return if @state is state

--- a/src/command-registry.coffee
+++ b/src/command-registry.coffee
@@ -50,6 +50,7 @@ class CommandRegistry
   destroy: ->
     for commandName of @registeredCommands
       window.removeEventListener(commandName, @handleCommandEvent, true)
+    return
 
   # Public: Add one or more command listeners associated with a selector.
   #
@@ -187,6 +188,7 @@ class CommandRegistry
     @selectorBasedListenersByCommandName = {}
     for commandName, listeners of snapshot
       @selectorBasedListenersByCommandName[commandName] = listeners.slice()
+    return
 
   handleCommandEvent: (originalEvent) =>
     propagationStopped = false

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -301,6 +301,7 @@ class Config
     for typeName, functions of filters
       for name, enforcerFunction of functions
         @addSchemaEnforcer(typeName, enforcerFunction)
+    return
 
   @executeSchemaEnforcers: (keyPath, value, schema) ->
     error = null
@@ -898,6 +899,7 @@ class Config
     @transact =>
       @settings = {}
       @set(key, value, save: false) for key, value of newSettings
+      return
 
   getRawValue: (keyPath, options) ->
     unless options?.excludeSources?.indexOf(@getUserConfigPath()) >= 0
@@ -958,6 +960,7 @@ class Config
         @setRawDefault(keyPath, defaults)
       catch e
         console.warn("'#{keyPath}' could not set the default. Attempted default: #{JSON.stringify(defaults)}; Schema: #{JSON.stringify(@getSchema(keyPath))}")
+    return
 
   deepClone: (object) ->
     if object instanceof Color

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -132,6 +132,7 @@ class ContextMenuManager
     new Disposable =>
       for itemSet in addedItemSets
         @itemSets.splice(@itemSets.indexOf(itemSet), 1)
+      return
 
   templateForElement: (target) ->
     @templateForEvent({target})

--- a/src/cursors-component.coffee
+++ b/src/cursors-component.coffee
@@ -35,6 +35,8 @@ class CursorsComponent
         @domNode.appendChild(cursorNode)
       @updateCursorNode(id, cursorState)
 
+    return
+
   updateCursorNode: (id, newCursorState) ->
     cursorNode = @cursorNodesById[id]
     oldCursorState = (@oldState.cursors[id] ?= {})

--- a/src/custom-event-mixin.coffee
+++ b/src/custom-event-mixin.coffee
@@ -7,9 +7,11 @@ CustomEventMixin =
     for name, listeners in @customEventListeners
       for listener in listeners
         @getDOMNode().removeEventListener(name, listener)
+    return
 
   addCustomEventListeners: (customEventListeners) ->
     for name, listener of customEventListeners
       @customEventListeners[name] ?= []
       @customEventListeners[name].push(listener)
       @getDOMNode().addEventListener(name, listener)
+    return

--- a/src/deserializer-manager.coffee
+++ b/src/deserializer-manager.coffee
@@ -35,10 +35,12 @@ class DeserializerManager
     @deserializers[deserializer.name] = deserializer for deserializer in deserializers
     new Disposable =>
       delete @deserializers[deserializer.name] for deserializer in deserializers
+      return
 
   remove: (classes...) ->
     Grim.deprecate("Call .dispose() on the Disposable return from ::add instead")
     delete @deserializers[name] for {name} in classes
+    return
 
   # Public: Deserialize the state and params.
   #

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -538,6 +538,7 @@ class DisplayBuffer extends Model
   # bufferRow - The buffer row {Number} to check against
   unfoldBufferRow: (bufferRow) ->
     fold.destroy() for fold in @foldsContainingBufferRow(bufferRow)
+    return
 
   # Given a buffer row, this returns the largest fold that starts there.
   #
@@ -1082,6 +1083,7 @@ class DisplayBuffer extends Model
 
   pauseMarkerChangeEvents: ->
     marker.pauseChangeEvents() for marker in @getMarkers()
+    return
 
   resumeMarkerChangeEvents: ->
     marker.resumeChangeEvents() for marker in @getMarkers()
@@ -1091,6 +1093,7 @@ class DisplayBuffer extends Model
   refreshMarkerScreenPositions: ->
     for marker in @getMarkers()
       marker.notifyObservers(textChanged: false)
+    return
 
   destroyed: ->
     marker.unsubscribe() for id, marker of @markers
@@ -1102,6 +1105,7 @@ class DisplayBuffer extends Model
     for row in [start..end]
       line = @tokenizedLineForScreenRow(row).text
       console.log row, @bufferRowForScreenRow(row), line, line.length
+    return
 
   getRootScopeDescriptor: ->
     @tokenizedBuffer.rootScopeDescriptor

--- a/src/gutter-component.coffee
+++ b/src/gutter-component.coffee
@@ -84,6 +84,8 @@ class GutterComponent
         delete @lineNumberNodesById[id]
         delete @oldState.lineNumbers[id]
 
+    return
+
   buildLineNumberHTML: (lineNumberState) ->
     {screenRow, bufferRow, softWrapped, top, decorationClasses} = lineNumberState
     if screenRow?

--- a/src/highlights-component.coffee
+++ b/src/highlights-component.coffee
@@ -39,6 +39,8 @@ class HighlightsComponent
         @domNode.appendChild(highlightNode)
       @updateHighlightNode(id, highlightState)
 
+    return
+
   updateHighlightNode: (id, newHighlightState) ->
     highlightNode = @highlightNodesById[id]
     oldHighlightState = (@oldState[id] ?= {regions: [], flashCount: 0})
@@ -91,6 +93,8 @@ class HighlightsComponent
             regionNode.style[property] = newRegionState[property] + 'px'
           else
             regionNode.style[property] = ''
+
+    return
 
   flashHighlightNodeIfRequested: (id, newHighlightState) ->
     oldHighlightState = @oldState[id]

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -104,11 +104,13 @@ class LanguageMode
       [startRow, endRow] = @rowRangeForFoldAtBufferRow(currentRow) ? []
       continue unless startRow?
       @editor.createFold(startRow, endRow)
+    return
 
   # Unfolds all the foldable lines in the buffer.
   unfoldAll: ->
     for row in [@buffer.getLastRow()..0]
       fold.destroy() for fold in @editor.displayBuffer.foldsStartingAtBufferRow(row)
+    return
 
   # Fold all comment and code blocks at a given indentLevel
   #
@@ -122,6 +124,7 @@ class LanguageMode
       # assumption: startRow will always be the min indent level for the entire range
       if @editor.indentationForBufferRow(startRow) == indentLevel
         @editor.createFold(startRow, endRow)
+    return
 
   # Given a buffer row, creates a fold at it.
   #
@@ -276,6 +279,7 @@ class LanguageMode
   # endRow - The row {Number} to end at
   autoIndentBufferRows: (startRow, endRow) ->
     @autoIndentBufferRow(row) for row in [startRow..endRow]
+    return
 
   # Given a buffer row, this indents it.
   #

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -89,6 +89,7 @@ class LinesComponent
 
   removeLineNodes: ->
     @removeLineNode(id) for id of @oldState.lines
+    return
 
   removeLineNode: (id) ->
     @lineNodesByLineId[id].remove()
@@ -125,6 +126,8 @@ class LinesComponent
       lineNode = newLineNodes[i]
       @lineNodesByLineId[id] = lineNode
       @domNode.appendChild(lineNode)
+
+    return
 
   buildLineHTML: (id) ->
     {scrollWidth} = @newState

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -396,6 +396,7 @@ class Marker
       for event in deferredChangeEvents
         @emit 'changed', event
         @emitter.emit 'did-change', event
+    return
 
   getPixelRange: ->
     @displayBuffer.pixelRangeForScreenRange(@getScreenRange(), false)

--- a/src/menu-helpers.coffee
+++ b/src/menu-helpers.coffee
@@ -17,6 +17,8 @@ merge = (menu, item, itemSpecificity=Infinity) ->
   else unless item.type is 'separator' and _.last(menu)?.type is 'separator'
     menu.push(item)
 
+  return
+
 unmerge = (menu, item) ->
   matchingItemIndex = findMatchingItemIndex(menu, item)
   matchingItem = menu[matchingItemIndex] unless matchingItemIndex is - 1

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -394,6 +394,7 @@ class PackageManager
       for pack in packages
         promise = @activatePackage(pack.name)
         promises.push(promise) unless pack.hasActivationCommands()
+      return
     @observeDisabledPackages()
     promises
 
@@ -413,6 +414,7 @@ class PackageManager
   deactivatePackages: ->
     atom.config.transact =>
       @deactivatePackage(pack.name) for pack in @getLoadedPackages()
+      return
     @unobserveDisabledPackages()
 
   # Deactivate the package with the given name

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -449,6 +449,7 @@ class Package
                 @activateNow()
                 break
               currentTarget = currentTarget.parentElement
+            return
     return
 
   getActivationCommands: ->

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -238,12 +238,14 @@ class Package
       @keymaps = (["#{atom.packages.resourcePath}#{path.sep}#{keymapPath}", keymapObject] for keymapPath, keymapObject of packagesCache[@name].keymaps)
     else
       @keymaps = @getKeymapPaths().map (keymapPath) -> [keymapPath, CSON.readFileSync(keymapPath) ? {}]
+    return
 
   loadMenus: ->
     if @bundledPackage and packagesCache[@name]?
       @menus = (["#{atom.packages.resourcePath}#{path.sep}#{menuPath}", menuObject] for menuPath, menuObject of packagesCache[@name].menus)
     else
       @menus = @getMenuPaths().map (menuPath) -> [menuPath, CSON.readFileSync(menuPath) ? {}]
+    return
 
   getKeymapPaths: ->
     keymapsDirPath = path.join(@path, 'keymaps')
@@ -447,6 +449,7 @@ class Package
                 @activateNow()
                 break
               currentTarget = currentTarget.parentElement
+    return
 
   getActivationCommands: ->
     return @activationCommands if @activationCommands?
@@ -505,6 +508,7 @@ class Package
         for modulePath in fs.listSync(nodeModulesPath)
           nativeModulePaths.push(modulePath) if @isNativeModule(modulePath)
           traversePath(path.join(modulePath, 'node_modules'))
+      return
 
     traversePath(path.join(@path, 'node_modules'))
     nativeModulePaths

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -151,6 +151,7 @@ class PaneContainer extends Model
 
   saveAll: ->
     pane.saveItems() for pane in @getPanes()
+    return
 
   confirmClose: (options) ->
     allSaved = true
@@ -186,6 +187,7 @@ class PaneContainer extends Model
 
   destroyEmptyPanes: ->
     pane.destroy() for pane in @getPanes() when pane.items.length is 0
+    return
 
   willDestroyPaneItem: (event) ->
     @emitter.emit 'will-destroy-pane-item', event

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -440,10 +440,12 @@ class Pane extends Model
   # Public: Destroy all items.
   destroyItems: ->
     @destroyItem(item) for item in @getItems()
+    return
 
   # Public: Destroy all items except for the active item.
   destroyInactiveItems: ->
     @destroyItem(item) for item in @getItems() when item isnt @activeItem
+    return
 
   promptToSaveItem: (item, options={}) ->
     return true unless item.shouldPromptToSave?(options)
@@ -518,6 +520,7 @@ class Pane extends Model
   # Public: Save all items.
   saveItems: ->
     @saveItem(item) for item in @getItems()
+    return
 
   # Public: Return the first item that matches the given URI or undefined if
   # none exists.

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -83,6 +83,7 @@ class Project extends Model
 
   destroyUnretainedBuffers: ->
     buffer.destroy() for buffer in @getBuffers() when not buffer.isRetained()
+    return
 
   ###
   Section: Serialization

--- a/src/row-map.coffee
+++ b/src/row-map.coffee
@@ -112,6 +112,7 @@ class RowMap
           @regions.splice index - 1, 2,
             bufferRows: leftRegion.bufferRows + rightRegion.bufferRows
             screenRows: leftRegion.screenRows + rightRegion.screenRows
+    return
 
   # Public: Returns an array of strings describing the map's regions.
   inspect: ->

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -538,6 +538,7 @@ class Selection extends Model
     for row in [start..end]
       if matchLength = buffer.lineForRow(row).match(leadingTabRegex)?[0].length
         buffer.delete [[row, 0], [row, matchLength]]
+    return
 
   # Public: Sets the indentation level of all selected rows to values suggested
   # by the relevant grammars.
@@ -620,6 +621,7 @@ class Selection extends Model
         currentIndentLevel = @editor.indentLevelForLine(lines[i])
         indentLevel = Math.max(0, currentIndentLevel + indentAdjustment)
         lines[i] = line.replace(/^[\t ]+/, @editor.buildIndentString(indentLevel))
+    return
 
   # Indent the current line(s).
   #
@@ -651,6 +653,7 @@ class Selection extends Model
     [start, end] = @getBufferRowRange()
     for row in [start..end]
       @editor.buffer.insert([row, 0], @editor.getTabText()) unless @editor.buffer.lineLengthForRow(row) == 0
+    return
 
   ###
   Section: Managing multiple selections
@@ -674,6 +677,8 @@ class Selection extends Model
       @editor.addSelectionForScreenRange(clippedRange, goalScreenRange: range)
       break
 
+    return
+
   # Public: Moves the selection up one row.
   addSelectionAbove: ->
     range = (@getGoalScreenRange() ? @getScreenRange()).copy()
@@ -691,6 +696,8 @@ class Selection extends Model
 
       @editor.addSelectionForScreenRange(clippedRange, goalScreenRange: range)
       break
+
+    return
 
   # Public: Combines the given selection into this selection and then destroys
   # the given selection.

--- a/src/style-manager.coffee
+++ b/src/style-manager.coffee
@@ -152,6 +152,8 @@ class StyleManager
     for styleElement in styleElementsToRestore
       @addStyleElement(styleElement) unless styleElement in existingStyleElements
 
+    return
+
   ###
   Section: Paths
   ###

--- a/src/styles-element.coffee
+++ b/src/styles-element.coffee
@@ -46,6 +46,7 @@ class StylesElement extends HTMLElement
     @styleElementRemoved(child) for child in Array::slice.call(@children)
     @context = @getAttribute('context')
     @styleElementAdded(styleElement) for styleElement in atom.styles.getStyleElements()
+    return
 
   styleElementAdded: (styleElement) ->
     return unless @styleElementMatchesContext(styleElement)

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -124,6 +124,7 @@ class TextEditorPresenter
     @disposables.add @model.onDidChangeScrollLeft(@setScrollLeft.bind(this))
     @observeDecoration(decoration) for decoration in @model.getDecorations()
     @observeCursor(cursor) for cursor in @model.getCursors()
+    return
 
   observeConfig: ->
     configParams = {scope: @model.getRootScopeDescriptor()}
@@ -273,6 +274,7 @@ class TextEditorPresenter
     for id, line of @state.content.lines
       unless visibleLineIds.hasOwnProperty(id)
         delete @state.content.lines[id]
+    return
 
   updateLineState: (row, line) ->
     lineState = @state.content.lines[line.id]
@@ -296,6 +298,7 @@ class TextEditorPresenter
   updateCursorsState: -> @batch "shouldUpdateCursorsState", ->
     @state.content.cursors = {}
     @updateCursorState(cursor) for cursor in @model.cursors # using property directly to avoid allocation
+    return
 
   updateCursorState: (cursor, destroyOnly = false) ->
     delete @state.content.cursors[cursor.id]
@@ -330,6 +333,8 @@ class TextEditorPresenter
 
     for id of @state.content.overlays
       delete @state.content.overlays[id] unless visibleDecorationIds[id]
+
+    return
 
   updateGutterState: -> @batch "shouldUpdateGutterState", ->
     @state.gutter.visible = not @model.isMini() and (@model.isGutterVisible() ? true) and @showLineNumbers
@@ -381,6 +386,8 @@ class TextEditorPresenter
 
     for id of @state.gutter.lineNumbers
       delete @state.gutter.lineNumbers[id] unless visibleLineNumberIds[id]
+
+    return
 
   updateStartRow: ->
     return unless @scrollTop? and @lineHeight?
@@ -873,11 +880,13 @@ class TextEditorPresenter
       unless visibleHighlights[id]
         delete @state.content.highlights[id]
 
+    return
 
   removeFromLineDecorationCaches: (decoration, range) ->
     for row in [range.start.row..range.end.row] by 1
       delete @lineDecorationsByScreenRow[row]?[decoration.id]
       delete @lineNumberDecorationsByScreenRow[row]?[decoration.id]
+    return
 
   addToLineDecorationCaches: (decoration, range) ->
     marker = decoration.getMarker()
@@ -902,6 +911,8 @@ class TextEditorPresenter
       if decoration.isType('line-number')
         @lineNumberDecorationsByScreenRow[row] ?= {}
         @lineNumberDecorationsByScreenRow[row][decoration.id] = decoration
+
+    return
 
   updateHighlightState: (decoration) ->
     return unless @startRow? and @endRow? and @lineHeight? and @hasPixelPositionRequirements()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -844,7 +844,6 @@ class TextEditor extends Model
     @mergeIntersectingSelections =>
       @transact =>
         fn(selection, index) for selection, index in @getSelections()
-        return
 
   # Move lines intersection the most recent selection up by one row in screen
   # coordinates.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -842,7 +842,9 @@ class TextEditor extends Model
   #      {Number} index of that selection.
   mutateSelectedText: (fn) ->
     @mergeIntersectingSelections =>
-      @transact => fn(selection, index) for selection, index in @getSelections()
+      @transact =>
+        fn(selection, index) for selection, index in @getSelections()
+        return
 
   # Move lines intersection the most recent selection up by one row in screen
   # coordinates.
@@ -978,6 +980,7 @@ class TextEditor extends Model
         selection.setBufferRange(selectedBufferRange.translate([delta, 0]))
         for [foldStartRow, foldEndRow] in foldedRowRanges
           @createFold(foldStartRow + delta, foldEndRow + delta)
+      return
 
   # Deprecated: Use {::duplicateLines} instead.
   duplicateLine: ->
@@ -1013,6 +1016,7 @@ class TextEditor extends Model
         while ++row < end.row
           @addSelectionForBufferRange([[row, 0], [row, Infinity]])
         @addSelectionForBufferRange([[end.row, 0], [end.row, end.column]]) unless end.column is 0
+      return
 
   # Extended: For each selection, transpose the selected text.
   #
@@ -1779,7 +1783,7 @@ class TextEditor extends Model
 
   # Extended: Get an Array of all {Cursor}s.
   getCursors: ->
-    cursor for cursor in @cursors
+    @cursors.slice()
 
   # Extended: Get all {Cursors}s, ordered by their position in the buffer
   # instead of the order in which they were added.
@@ -1822,6 +1826,7 @@ class TextEditor extends Model
         cursor.destroy()
       else
         positions[position] = true
+    return
 
   preserveCursorPositionOnBufferReload: ->
     cursorPosition = null
@@ -1886,6 +1891,7 @@ class TextEditor extends Model
           selections[i].setBufferRange(bufferRange, options)
         else
           @addSelectionForBufferRange(bufferRange, options)
+      return
 
   # Essential: Get the {Range} of the most recently added selection in screen
   # coordinates.
@@ -1932,6 +1938,7 @@ class TextEditor extends Model
           selections[i].setScreenRange(screenRange, options)
         else
           @addSelectionForScreenRange(screenRange, options)
+      return
 
   # Essential: Add a selection for the given range in buffer coordinates.
   #
@@ -2159,7 +2166,7 @@ class TextEditor extends Model
   #
   # Returns: An {Array} of {Selection}s.
   getSelections: ->
-    selection for selection in @selections
+    @selections.slice()
 
   # Extended: Get all {Selection}s, ordered by their position in the buffer
   # instead of the order in which they were added.
@@ -2206,15 +2213,18 @@ class TextEditor extends Model
   expandSelectionsForward: (fn) ->
     @mergeIntersectingSelections =>
       fn(selection) for selection in @getSelections()
+      return
 
   # Calls the given function with each selection, then merges selections in the
   # reversed orientation
   expandSelectionsBackward: (fn) ->
     @mergeIntersectingSelections reversed: true, =>
       fn(selection) for selection in @getSelections()
+      return
 
   finalizeSelections: ->
     selection.finalize() for selection in @getSelections()
+    return
 
   selectionsForScreenRows: (startRow, endRow) ->
     @getSelections().filter (selection) -> selection.intersectsScreenRowRange(startRow, endRow)
@@ -2620,6 +2630,7 @@ class TextEditor extends Model
       else
         selection.copy(maintainClipboard, false)
       maintainClipboard = true
+    return
 
   # Essential: For each selection, cut the selected text.
   cutSelectedText: ->
@@ -2714,6 +2725,7 @@ class TextEditor extends Model
   # Extended: For each selection, fold the rows it intersects.
   foldSelectedLines: ->
     selection.fold() for selection in @getSelections()
+    return
 
   # Extended: Fold all foldable lines.
   foldAll: ->
@@ -2795,6 +2807,8 @@ class TextEditor extends Model
 
     for row in [bufferRange.end.row..bufferRange.start.row]
       fold.destroy() for fold in @displayBuffer.foldsStartingAtBufferRow(row)
+
+    return
 
   # Remove any {Fold}s found that contain the given buffer range.
   destroyFoldsContainingBufferRange: (bufferRange) ->

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -197,6 +197,7 @@ class TokenizedBuffer extends Model
 
   validateRow: (row) ->
     @invalidRows.shift() while @invalidRows[0] <= row
+    return
 
   invalidateRow: (row) ->
     @invalidRows.push(row)
@@ -468,3 +469,4 @@ class TokenizedBuffer extends Model
     for row in [start..end]
       line = @tokenizedLineForRow(row).text
       console.log row, line, line.length
+    return

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -222,6 +222,7 @@ class TokenizedLine
       if @lineEnding? and (index + token.value.length > firstTrailingWhitespaceIndex)
         token.firstTrailingWhitespaceIndex = Math.max(0, firstTrailingWhitespaceIndex - index)
       index += token.value.length
+    return
 
   substituteInvisibleCharacters: ->
     invisibles = @invisibles
@@ -308,6 +309,8 @@ class TokenizedLine
     # Push onto common prefix until scopeStack equals desiredScopeDescriptor
     for j in [i...desiredScopeDescriptor.length]
       scopeStack.push(new Scope(desiredScopeDescriptor[j]))
+
+    return
 
 class Scope
   constructor: (@scope) ->

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -32,6 +32,8 @@ class WindowEventHandler
             unless fs.isDirectorySync(pathToOpen)
               atom.workspace?.open(pathToOpen, {initialLine, initialColumn})
 
+          return
+
         when 'update-available'
           atom.updateAvailable(detail)
 
@@ -156,6 +158,7 @@ class WindowEventHandler
       continue unless tabIndex >= 0
 
       callback(element, tabIndex)
+    return
 
   focusNext: =>
     focusedTabIndex = parseInt($(':focus').attr('tabindex')) or -Infinity

--- a/src/workspace-view.coffee
+++ b/src/workspace-view.coffee
@@ -222,7 +222,6 @@ class WorkspaceView extends View
     for editorElement in @panes.element.querySelectorAll('atom-pane > .item-views > atom-text-editor')
       $(editorElement).view()
 
-
   ###
   Section: Deprecated
   ###

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -110,6 +110,7 @@ class Workspace extends Model
       packageNames.push(packageName)
       for scopeName in includedGrammarScopes ? []
         addGrammar(atom.grammars.grammarForScopeName(scopeName))
+      return
 
     editors = @getTextEditors()
     addGrammar(editor.getGrammar()) for editor in editors


### PR DESCRIPTION
Profiling some of the lower level libraries in the past has shown GC pauses and slow downs when methods accidentally build-up and return an array accidentally when the function ends with a `for` or `while` loop.

This cleans up a bunch of areas in core that were doing this involuntarily as well as adds a grunt task to lint for them in the future.

This also updates array copies to consistently use `slice` instead of `for` which is significantly faster, https://jsperf.com/slice-vs-loop-return/2

I don't have any metrics on before/after speedups but it does reduce the total JS size of the `src` folder by ~225 lines.

This also prevents some public APIs from returning arrays accidentally when they should have been returning `undefined`.
