### PR TITLE
Fix random mutation spurious errors

### DIFF
--- a/spec/random-editor-spec.coffee
+++ b/spec/random-editor-spec.coffee
@@ -3,7 +3,7 @@ randomWords = require 'random-words'
 TextBuffer = require 'text-buffer'
 TextEditor = require '../src/text-editor'
 
-describe "TextEditor", ->
+fdescribe "TextEditor", ->
   [editor, tokenizedBuffer, buffer, steps, previousSteps] = []
 
   softWrapColumn = 80
@@ -94,7 +94,7 @@ describe "TextEditor", ->
   softWrapLine = (tokenizedLine) ->
     wrappedLines = []
     while tokenizedLine.text.length > softWrapColumn and wrapScreenColumn = findWrapColumn(tokenizedLine.text)
-      [wrappedLine, tokenizedLine] = tokenizedLine.softWrapAt(wrapScreenColumn)
+      [wrappedLine, tokenizedLine] = tokenizedLine.softWrapAt(wrapScreenColumn, 0)
       wrappedLines.push(wrappedLine)
     wrappedLines.push(tokenizedLine)
     wrappedLines


### PR DESCRIPTION
...which were caused by the recent soft-wrap hanging indent change. The random
mutation editor was not calling `softWrapAt` appropriately. In facts, it was not
passing `hangingIndent` as a parameter, which means it was treated as `null`:
when summed to `totalIndentationSpaces` the result was always `NaN`, thus
exhibiting strange behaviors.

@nathansobo: sorry about this issue :disappointed: I have managed to reproduce it on master as well, though, and I'd say we can safely bring back the reverted branch into master :+1:  

This brings up another important question, which I am not sure I know the answer of: how could we can reduce the coupling between the random text editor and our real production code?
