### PR TITLE
:bug: fix rowRangeForParagraphAtBufferRow using \S

### DIFF
--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -124,6 +124,11 @@ describe "LanguageMode", ->
               // lines
               var sort = function(items) {};
               // comment line after fn
+
+              var nosort = function(items) {
+                  return item;
+              }
+
             };
           '''
 
@@ -143,6 +148,9 @@ describe "LanguageMode", ->
 
           range = languageMode.rowRangeForParagraphAtBufferRow(15)
           expect(range).toEqual [[15,0], [15,26]]
+
+          range = languageMode.rowRangeForParagraphAtBufferRow(18)
+          expect(range).toEqual [[17,0], [19,1]]
 
   describe "coffeescript", ->
     beforeEach ->

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -199,7 +199,7 @@ class LanguageMode
   # Right now, a paragraph is a block of text bounded by and empty line or a
   # block of text that is not the same type (comments next to source code).
   rowRangeForParagraphAtBufferRow: (bufferRow) ->
-    return unless /\w/.test(@editor.lineTextForBufferRow(bufferRow))
+    return unless /\S/.test(@editor.lineTextForBufferRow(bufferRow))
 
     if @isLineCommentedAtBufferRow(bufferRow)
       isOriginalRowComment = true
@@ -212,14 +212,14 @@ class LanguageMode
     startRow = bufferRow
     while startRow > firstRow
       break if @isLineCommentedAtBufferRow(startRow - 1) != isOriginalRowComment
-      break unless /\w/.test(@editor.lineTextForBufferRow(startRow - 1))
+      break unless /\S/.test(@editor.lineTextForBufferRow(startRow - 1))
       startRow--
 
     endRow = bufferRow
     lastRow = @editor.getLastBufferRow()
     while endRow < lastRow
       break if @isLineCommentedAtBufferRow(endRow + 1) != isOriginalRowComment
-      break unless /\w/.test(@editor.lineTextForBufferRow(endRow + 1))
+      break unless /\S/.test(@editor.lineTextForBufferRow(endRow + 1))
       endRow++
 
     new Range([startRow, 0], [endRow, @editor.lineTextForBufferRow(endRow).length])


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/5963 , seems there shoud be using `\S`. 
But I'm not be able to run the test locally, please review
