### PR TITLE
Defer keydown event to refresh screen while fast key typing

### DIFF
--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -130,7 +130,7 @@ class WindowEventHandler
     bindCommandToAction('core:select-all', 'selectAll:')
 
   onKeydown: (event) ->
-    atom.keymaps.handleKeyboardEvent(event)
+    _.defer -> atom.keymaps.handleKeyboardEvent(event)
     event.stopImmediatePropagation()
 
   onDrop: (event) ->


### PR DESCRIPTION
I feel atom is very laggy while typing fast or key repeat (than vim :) ).
Especially lag on repeating j/k caret move is huge, freezes for seconds.

With time profiler, I found continuous keydown events block main thread for >10sec (!).

![2015-03-22 21 03 57](https://cloud.githubusercontent.com/assets/400558/6769259/482ce42c-d0d7-11e4-8915-66825d458791.png)

![2015-03-22 21 05 36](https://cloud.githubusercontent.com/assets/400558/6769260/49c7114a-d0d7-11e4-9495-2faeb35e8170.png)

This happens even if vim-mode is disabled.

It is significant because I use [Karabiner](https://pqrs.org/osx/karabiner/index.html.en) to make key repeat even faster than maximum speed of OS X preferences.

This PR increases rendering rate by deferring keydown event handling until next setTimeout dispatch.
This enables to refresh screen before handling next key event.
Lag on fast typing in insert mode is reduced too.

Left: before, right: after!

![atom-key-typing-speed-720p](https://cloud.githubusercontent.com/assets/400558/6769489/08a94b06-d0e1-11e4-9918-09a3fcf02103.gif)

(I'm wondering that there is so much idle time after releasing key and before main thread is released. See below.)

![2015-03-22 21 08 37](https://cloud.githubusercontent.com/assets/400558/6769269/d6cf159c-d0d7-11e4-91d6-4fa546bc26b9.png)
