### PR TITLE
Add preview pane item support.

### DIFF
--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -430,7 +430,7 @@ class Workspace extends Model
       options.activatePane = options.changeFocus
       delete options.changeFocus
 
-    {initialLine, initialColumn} = options
+    {initialLine, initialColumn, preview} = options
     activatePane = options.activatePane ? true
 
     uri = atom.project.resolvePath(uri)
@@ -438,8 +438,12 @@ class Workspace extends Model
     if uri
       item ?= opener(uri, options) for opener in @getOpeners() when !item
     item ?= atom.project.openSync(uri, {initialLine, initialColumn})
-
-    @getActivePane().activateItem(item)
+    
+    if options.preview
+      @getActivePane().activatePreviewItem(item)
+    else 
+      @getActivePane().activateItem(item)
+      
     @itemOpened(item)
     @getActivePane().activate() if activatePane
     item
@@ -477,7 +481,10 @@ class Workspace extends Model
           pane = new Pane(items: [item])
           @paneContainer.root = pane
         @itemOpened(item)
-        pane.activateItem(item)
+        if options.preview
+          pane.activatePreviewItem(item)
+        else 
+          pane.activateItem(item)
         pane.activate() if activatePane
         if options.initialLine? or options.initialColumn?
           item.setCursorBufferPosition?([options.initialLine, options.initialColumn])


### PR DESCRIPTION
To make previewable pane items part of the atom core as discussed in #3683 and https://github.com/atom/tree-view/issues/3, I added this pull request to help speed up the process.

I added a `previewItem` property similar to the `activePane` property, which allows for simple implementation in the tree-view and tabs packages.

I know this is not a high priority for atom right now, but if this is helpful I can add specs and post my tree-view and tabs implementation as well?

Suggestions are very welcome! :smiley: 
