### PR TITLE
Bump up markdown-preview@0.144.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "incompatible-packages": "0.24.0",
     "keybinding-resolver": "0.29.0",
     "link": "0.30.0",
-    "markdown-preview": "0.143.0",
+    "markdown-preview": "0.144.0",
     "metrics": "0.45.0",
     "notifications": "0.33.0",
     "open-on-github": "0.34.0",


### PR DESCRIPTION
This updates to the latest version of `markdown-preview` which no longer has a cursor for each text block :1234: 
