### PR TITLE
Add `Repository::getType()`.

### DIFF
--- a/spec/git-repository-provider-spec.coffee
+++ b/spec/git-repository-provider-spec.coffee
@@ -16,6 +16,7 @@ describe "GitRepositoryProvider", ->
             expect(result).toBeInstanceOf GitRepository
             expect(provider.pathToRepository[result.getPath()]).toBeTruthy()
             expect(result.statusTask).toBeTruthy()
+            expect(result.getType()).toBe 'git'
 
       it "returns the same GitRepository for different Directory objects in the same repo", ->
         provider = new GitRepositoryProvider atom.project

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -169,6 +169,12 @@ class GitRepository
   Section: Repository Details
   ###
 
+  # Public: A {String} indicating the type of version control system used by
+  # this repository.
+  #
+  # Returns `"git"`.
+  getType: -> 'git'
+
   # Public: Returns the {String} path of the repository.
   getPath: ->
     @path ?= fs.absolute(@getRepo().getPath())


### PR DESCRIPTION
For `GitRepository`, this will return `"git"`.
