### PR TITLE
Improve package association with uncaught errors

### DIFF
--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "0.147.0"
+    "atom-package-manager": "0.149.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "link": "0.30.0",
     "markdown-preview": "0.144.0",
     "metrics": "0.45.0",
-    "notifications": "0.34.0",
+    "notifications": "0.35.0",
     "open-on-github": "0.34.0",
     "package-generator": "0.38.0",
     "release-notes": "0.52.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "link": "0.30.0",
     "markdown-preview": "0.144.0",
     "metrics": "0.45.0",
-    "notifications": "0.33.0",
+    "notifications": "0.34.0",
     "open-on-github": "0.34.0",
     "package-generator": "0.38.0",
     "release-notes": "0.52.0",

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -572,12 +572,12 @@ class Package
         SyntaxError: #{error.message}
           at #{location}
       """
-    else if error.type and error.filename and error.column? and error.line?
+    else if error.less and error.filename and error.column? and error.line?
       # Less errors
       location = "#{error.filename}:#{error.line}:#{error.column}"
       detail = "#{error.message} in #{location}"
       stack = """
-        Error: #{error.message}
+        LessError: #{error.message}
           at #{location}
       """
     else

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -572,6 +572,14 @@ class Package
         SyntaxError: #{error.message}
           at #{location}
       """
+    else if error.type and error.filename and error.column? and error.line?
+      # Less errors
+      location = "#{error.filename}:#{error.line}:#{error.column}"
+      detail = "#{error.message} in #{location}"
+      stack = """
+        Error: #{error.message}
+          at #{location}
+      """
     else
       detail = error.message
       stack = error.stack ? error

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -319,6 +319,9 @@ class ThemeManager
         @lessCache.read(lessStylesheetPath)
     catch error
       if error.line?
+        # Adjust line numbers for import fallbacks
+        error.line -= 2 if importFallbackVariables
+
         message = "Error compiling Less stylesheet: `#{lessStylesheetPath}`"
         detail = """
           Line number: #{error.line}

--- a/src/theme-manager.coffee
+++ b/src/theme-manager.coffee
@@ -318,6 +318,7 @@ class ThemeManager
       else
         @lessCache.read(lessStylesheetPath)
     catch error
+      error.less = true
       if error.line?
         # Adjust line numbers for import fallbacks
         error.line -= 2 if importFallbackVariables


### PR DESCRIPTION
Tweaks notifications to prompt to open issues on the package instead of core when an error is thrown loading a package or is thrown from an unloaded package.

Closes atom/notifications#48
