### PR TITLE
Enable deprecations in all windows

### DIFF
--- a/spec/jasmine-helper.coffee
+++ b/spec/jasmine-helper.coffee
@@ -27,8 +27,15 @@ module.exports.runSpecSuite = (specSuite, logFile, logErrors=true) ->
         fs.closeSync(logStream) if logStream?
         if process.env.JANKY_SHA1
           grim = require 'grim'
-          grim.logDeprecations() if grim.getDeprecationsLength() > 0
-        atom.exit(runner.results().failedCount > 0 ? 1 : 0)
+
+          if grim.getDeprecationsLength() > 0
+            grim.logDeprecations()
+            return atom.exit(1) if runner.results().failedCount is 0
+
+        if runner.results().failedCount > 0
+          atom.exit(1)
+        else
+          atom.exit(0)
   else
     AtomReporter = require './atom-reporter'
     reporter = new AtomReporter()

--- a/spec/jasmine-helper.coffee
+++ b/spec/jasmine-helper.coffee
@@ -30,7 +30,7 @@ module.exports.runSpecSuite = (specSuite, logFile, logErrors=true) ->
 
           if grim.getDeprecationsLength() > 0
             grim.logDeprecations()
-            return atom.exit(1) if runner.results().failedCount is 0
+            return atom.exit(1)
 
         if runner.results().failedCount > 0
           atom.exit(1)

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -207,12 +207,6 @@ class Atom extends Model
   #
   # Call after this instance has been assigned to the `atom` global.
   initialize: ->
-    # Disable deprecations unless in dev mode or spec mode so that regular
-    # editor performance isn't impacted by generating stack traces for
-    # deprecated calls.
-    unless @inDevMode() or @inSpecMode()
-      require('grim').deprecate = ->
-
     sourceMapCache = {}
 
     window.onerror = =>


### PR DESCRIPTION
Previously deprecations were only shown in dev and test windows.

Removing this check enables it for all windows.
