### PR TITLE
Add support for jasmine 2.0

### DIFF
--- a/benchmark/benchmark-bootstrap.coffee
+++ b/benchmark/benchmark-bootstrap.coffee
@@ -9,4 +9,4 @@ window.atom = atom
 atom.openDevTools()
 
 document.title = "Benchmark Suite"
-runSpecSuite('../benchmark/benchmark-suite', atom.getLoadSettings().logFile)
+runSpecSuite('../benchmark/benchmark-suite', atom.getLoadSettings().logFile, false)

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -19,7 +19,6 @@
 
   # Atom Specific
   'cmd-O': 'application:open-dev'
-  'cmd-alt-ctrl-s': 'application:run-all-specs'
   'enter': 'core:confirm'
   'escape': 'core:cancel'
   'up': 'core:move-up'

--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -9,7 +9,6 @@
   'ctrl-alt-r': 'window:reload'
   'ctrl-shift-i': 'window:toggle-dev-tools'
   'ctrl-alt-p': 'window:run-package-specs'
-  'ctrl-alt-s': 'application:run-all-specs'
   'ctrl-alt-o': 'application:open-dev'
   'ctrl-shift-o': 'application:open-folder'
   'ctrl-shift-pageup': 'pane:move-item-left'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -13,7 +13,6 @@
   'ctrl-alt-r': 'window:reload'
   'ctrl-alt-i': 'window:toggle-dev-tools'
   'ctrl-alt-p': 'window:run-package-specs'
-  'ctrl-alt-s': 'application:run-all-specs'
   'ctrl-alt-o': 'application:open-dev'
   'ctrl-shift-o': 'application:open-folder'
   'ctrl-shift-left': 'pane:move-item-left'

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -161,7 +161,6 @@
         label: 'Developer'
         submenu: [
           { label: 'Open In Dev Mode...', command: 'application:open-dev' }
-          { label: 'Run Atom Specs', command: 'application:run-all-specs' }
           { label: 'Run Package Specs', command: 'window:run-package-specs' }
           { label: 'Toggle Developer Tools', command: 'window:toggle-dev-tools' }
         ]

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -99,7 +99,6 @@
         label: 'Developer'
         submenu: [
           { label: 'Open In &Dev Mode...', command: 'application:open-dev' }
-          { label: 'Run &Atom Specs', command: 'application:run-all-specs' }
           { label: 'Run Package &Specs', command: 'window:run-package-specs' }
           { label: 'Toggle Developer &Tools', command: 'window:toggle-dev-tools' }
         ]

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -117,7 +117,6 @@
         label: 'Developer'
         submenu: [
           { label: 'Open In &Dev Mode...', command: 'application:open-dev' }
-          { label: 'Run &Atom Specs', command: 'application:run-all-specs' }
           { label: 'Run Package &Specs', command: 'window:run-package-specs' }
           { label: 'Toggle Developer &Tools', command: 'window:toggle-dev-tools' }
         ]

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "grim": "1.2",
     "jasmine-json": "~0.0",
     "jasmine-tagged": "^1.1.4",
+    "jasmine-core": "^2.2.0",
     "jquery": "^2.1.1",
     "less-cache": "0.22",
     "marked": "^0.3",

--- a/spec/jasmine-helper.coffee
+++ b/spec/jasmine-helper.coffee
@@ -1,8 +1,6 @@
 fs = require 'fs'
 
 module.exports.runSpecSuite = (specSuite, logFile, logErrors=true) ->
-  {$, $$} = require '../src/space-pen-extensions'
-
   window[key] = value for key, value of require '../vendor/jasmine'
 
   {TerminalReporter} = require 'jasmine-tagged'
@@ -40,7 +38,9 @@ module.exports.runSpecSuite = (specSuite, logFile, logErrors=true) ->
   jasmineEnv.addReporter(timeReporter)
   jasmineEnv.setIncludedTags([process.platform])
 
-  $('body').append $$ -> @div id: 'jasmine-content'
+  jasmineContent = document.createElement("div")
+  jasmineContent.id = "jasmine-content"
+  document.body.appendChild(jasmineContent)
 
   jasmineEnv.execute()
 

--- a/spec/jasmine-helper.coffee
+++ b/spec/jasmine-helper.coffee
@@ -1,9 +1,42 @@
 fs = require 'fs'
 
+module.exports.runSpecSuiteV2 = (specSuite, logFile) ->
+  jasmineRequire = require("jasmine-core")
+  window.jasmine = jasmineRequire.core(jasmineRequire)
+  jasmineInterface = jasmineRequire.interface(jasmine, jasmine.getEnv())
+  window[key] = value for key, value of jasmineInterface
+
+  atom.initialize()
+  atom.themes.loadBaseStylesheets()
+  atom.themes.requireStylesheet '../static/jasmine'
+
+  if atom.getLoadSettings().exitWhenDone
+    ConsoleReporter = require("jasmine-core/lib/console/console").ConsoleReporter()
+    reporter = new ConsoleReporter(
+      print: (content) -> process.stdout.write(content)
+      onComplete: (passed) ->
+        atom.exit(if passed then 0 else 1)
+    )
+  else
+    AtomReporter = require './atom-reporter'
+    reporter = new AtomReporter()
+
+  require specSuite
+
+  jasmineEnv = jasmine.getEnv()
+  jasmineEnv.addReporter(reporter)
+
+  jasmineContent = document.createElement("div")
+  jasmineContent.id = "jasmine-content"
+  document.body.appendChild(jasmineContent)
+
+  jasmineEnv.execute()
+
 module.exports.runSpecSuite = (specSuite, logFile, logErrors=true) ->
   window[key] = value for key, value of require '../vendor/jasmine'
 
   {TerminalReporter} = require 'jasmine-tagged'
+  require './spec-helper'
 
   disableFocusMethods() if process.env.JANKY_SHA1
 

--- a/spec/jasmine-helper.coffee
+++ b/spec/jasmine-helper.coffee
@@ -1,42 +1,19 @@
 fs = require 'fs'
 
-module.exports.runSpecSuiteV2 = (specSuite, logFile) ->
-  jasmineRequire = require("jasmine-core")
-  window.jasmine = jasmineRequire.core(jasmineRequire)
-  jasmineInterface = jasmineRequire.interface(jasmine, jasmine.getEnv())
-  window[key] = value for key, value of jasmineInterface
-
-  atom.initialize()
-  atom.themes.loadBaseStylesheets()
-  atom.themes.requireStylesheet '../static/jasmine'
-
-  if atom.getLoadSettings().exitWhenDone
-    ConsoleReporter = require("jasmine-core/lib/console/console").ConsoleReporter()
-    reporter = new ConsoleReporter(
-      print: (content) -> process.stdout.write(content)
-      onComplete: (passed) ->
-        atom.exit(if passed then 0 else 1)
-    )
+module.exports.runSpecSuite = (specSuite, logFile, useJasmineV2) ->
+  if useJasmineV2
+    jasmineRequire = require("jasmine-core")
+    window.jasmine = jasmineRequire.core(jasmineRequire)
+    jasmineInterface = jasmineRequire.interface(jasmine, jasmine.getEnv())
+    window[key] = value for key, value of jasmineInterface
+    atom.initialize()
+    atom.themes.loadBaseStylesheets()
+    atom.themes.requireStylesheet '../static/jasmine'
   else
-    AtomReporter = require './atom-reporter'
-    reporter = new AtomReporter()
-
-  require specSuite
-
-  jasmineEnv = jasmine.getEnv()
-  jasmineEnv.addReporter(reporter)
-
-  jasmineContent = document.createElement("div")
-  jasmineContent.id = "jasmine-content"
-  document.body.appendChild(jasmineContent)
-
-  jasmineEnv.execute()
-
-module.exports.runSpecSuite = (specSuite, logFile, logErrors=true) ->
-  window[key] = value for key, value of require '../vendor/jasmine'
+    window[key] = value for key, value of require '../vendor/jasmine' 
+    require "./spec-helper"
 
   {TerminalReporter} = require 'jasmine-tagged'
-  require './spec-helper'
 
   disableFocusMethods() if process.env.JANKY_SHA1
 

--- a/spec/spec-bootstrap.coffee
+++ b/spec/spec-bootstrap.coffee
@@ -8,8 +8,11 @@ atom.getCurrentWindow().show() unless atom.getLoadSettings().exitWhenDone
 
 try
   document.title = "Spec Suite"
-  {runSpecSuite} = require './jasmine-helper'
-  runSpecSuite('./spec-suite', atom.getLoadSettings().logFile)
+  {runSpecSuite, runSpecSuiteV2} = require './jasmine-helper'
+  if atom.getLoadSettings().useJasmine2
+    runSpecSuiteV2('./spec-suite', atom.getLoadSettings().logFile)
+  else
+    runSpecSuite('./spec-suite', atom.getLoadSettings().logFile)
 catch error
   if atom?.getLoadSettings().exitWhenDone
     console.error(error.stack ? error)

--- a/spec/spec-bootstrap.coffee
+++ b/spec/spec-bootstrap.coffee
@@ -1,27 +1,15 @@
-# Start the crash reporter before anything else.
-require('crash-reporter').start(productName: 'Atom', companyName: 'GitHub')
+require '../src/window'
+Atom = require '../src/atom'
+window.atom = Atom.loadOrCreate('spec')
 
-path = require 'path'
+# Show window synchronously so a focusout doesn't fire on input elements
+# that are focused in the very first spec run.
+atom.getCurrentWindow().show() unless atom.getLoadSettings().exitWhenDone
 
 try
-  require '../src/window'
-  Atom = require '../src/atom'
-  window.atom = Atom.loadOrCreate('spec')
-
-  # Show window synchronously so a focusout doesn't fire on input elements
-  # that are focused in the very first spec run.
-  atom.getCurrentWindow().show() unless atom.getLoadSettings().exitWhenDone
-
-  {runSpecSuite} = require './jasmine-helper'
-
-  # Add 'exports' to module search path.
-  exportsPath = path.join(atom.getLoadSettings().resourcePath, 'exports')
-  require('module').globalPaths.push(exportsPath)
-  # Still set NODE_PATH since tasks may need it.
-  process.env.NODE_PATH = exportsPath
-
   document.title = "Spec Suite"
-  runSpecSuite './spec-suite', atom.getLoadSettings().logFile
+  {runSpecSuite} = require './jasmine-helper'
+  runSpecSuite('./spec-suite', atom.getLoadSettings().logFile)
 catch error
   if atom?.getLoadSettings().exitWhenDone
     console.error(error.stack ? error)

--- a/spec/spec-bootstrap.coffee
+++ b/spec/spec-bootstrap.coffee
@@ -8,11 +8,8 @@ atom.getCurrentWindow().show() unless atom.getLoadSettings().exitWhenDone
 
 try
   document.title = "Spec Suite"
-  {runSpecSuite, runSpecSuiteV2} = require './jasmine-helper'
-  if atom.getLoadSettings().useJasmine2
-    runSpecSuiteV2('./spec-suite', atom.getLoadSettings().logFile)
-  else
-    runSpecSuite('./spec-suite', atom.getLoadSettings().logFile)
+  {runSpecSuite} = require './jasmine-helper'
+  runSpecSuite('./spec-suite', atom.getLoadSettings().logFile, atom.getLoadSettings().useJasmine2)
 catch error
   if atom?.getLoadSettings().exitWhenDone
     console.error(error.stack ? error)

--- a/spec/spec-suite.coffee
+++ b/spec/spec-suite.coffee
@@ -1,55 +1,5 @@
-_ = require 'underscore-plus'
 fs = require 'fs-plus'
-path = require 'path'
-require './spec-helper'
+specDirectory = atom.getLoadSettings().specDirectory
 
-requireSpecs = (specDirectory, specType) ->
-  for specFilePath in fs.listTreeSync(specDirectory) when /-spec\.(coffee|js)$/.test specFilePath
-    require specFilePath
-
-    # Set spec directory on spec for setting up the project in spec-helper
-    setSpecDirectory(specDirectory)
-
-setSpecField = (name, value) ->
-  specs = jasmine.getEnv().currentRunner().specs()
-  return if specs.length is 0
-  for index in [specs.length-1..0]
-    break if specs[index][name]?
-    specs[index][name] = value
-
-setSpecType = (specType) ->
-  setSpecField('specType', specType)
-
-setSpecDirectory = (specDirectory) ->
-  setSpecField('specDirectory', specDirectory)
-
-runAllSpecs = ->
-  {resourcePath} = atom.getLoadSettings()
-
-  requireSpecs(path.join(resourcePath, 'spec'))
-  setSpecType('core')
-
-  fixturesPackagesPath = path.join(__dirname, 'fixtures', 'packages')
-  packagePaths = atom.packages.getAvailablePackageNames().map (packageName) ->
-    atom.packages.resolvePackagePath(packageName)
-  packagePaths = _.groupBy packagePaths, (packagePath) ->
-    if packagePath.indexOf("#{fixturesPackagesPath}#{path.sep}") is 0
-      'fixtures'
-    else if packagePath.indexOf("#{resourcePath}#{path.sep}") is 0
-      'bundled'
-    else
-      'user'
-
-  # Run bundled package specs
-  requireSpecs(path.join(packagePath, 'spec')) for packagePath in packagePaths.bundled ? []
-  setSpecType('bundled')
-
-  # Run user package specs
-  requireSpecs(path.join(packagePath, 'spec')) for packagePath in packagePaths.user ? []
-  setSpecType('user')
-
-if specDirectory = atom.getLoadSettings().specDirectory
-  requireSpecs(specDirectory)
-  setSpecType('user')
-else
-  runAllSpecs()
+for specFilePath in fs.listTreeSync(specDirectory)
+  require(specFilePath) if /-spec\.(coffee|js)$/.test(specFilePath)

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -459,7 +459,9 @@ class AtomApplication
     safeMode ?= false
 
     packageMetadata = JSON.parse(fs.readFileSync(path.join(specDirectory, "..", "package.json"), 'utf8'))
-    useJasmine2 = packageMetadata['use-jasmine-2']
+    if jasmineEngineVersion = packageMetadata.engines?['atom-jasmine']
+      semver = require 'semver'
+      useJasmine2 = semver.satisfies('2.2.0', jasmineEngineVersion)
 
     new AtomWindow({bootstrapScript, resourcePath, exitWhenDone, isSpec, devMode, specDirectory, logFile, safeMode, useJasmine2})
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -147,7 +147,6 @@ class AtomApplication
       devMode: @focusedWindow()?.devMode
       safeMode: @focusedWindow()?.safeMode
 
-    @on 'application:run-all-specs', -> @runSpecs(exitWhenDone: false, resourcePath: global.devResourcePath, safeMode: @focusedWindow()?.safeMode)
     @on 'application:run-benchmarks', -> @runBenchmarks()
     @on 'application:quit', -> app.quit()
     @on 'application:new-window', -> @openPath(_.extend(windowDimensions: @focusedWindow()?.getDimensions(), getLoadSettings()))
@@ -234,7 +233,7 @@ class AtomApplication
       @applicationMenu.update(win, template, keystrokesByCommand)
 
     ipc.on 'run-package-specs', (event, specDirectory) =>
-      @runSpecs({resourcePath: global.devResourcePath, specDirectory: specDirectory, exitWhenDone: false})
+      @runSpecs({resourcePath: global.devResourcePath, specDirectory, exitWhenDone: false})
 
     ipc.on 'command', (event, command) =>
       @emit(command)
@@ -458,7 +457,11 @@ class AtomApplication
     isSpec = true
     devMode = true
     safeMode ?= false
-    new AtomWindow({bootstrapScript, resourcePath, exitWhenDone, isSpec, devMode, specDirectory, logFile, safeMode})
+
+    packageMetadata = JSON.parse(fs.readFileSync(path.join(specDirectory, "..", "package.json"), 'utf8'))
+    useJasmine2 = packageMetadata['use-jasmine-2']
+
+    new AtomWindow({bootstrapScript, resourcePath, exitWhenDone, isSpec, devMode, specDirectory, logFile, safeMode, useJasmine2})
 
   runBenchmarks: ({exitWhenDone, specDirectory}={}) ->
     try

--- a/src/window-bootstrap.coffee
+++ b/src/window-bootstrap.coffee
@@ -1,8 +1,7 @@
-# Like sands through the hourglass, so are the days of our lives.
 require './window'
-
 Atom = require './atom'
 window.atom = Atom.loadOrCreate('editor')
+
 atom.initialize()
 atom.startEditorWindow()
 

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -113,15 +113,17 @@ class WorkspaceElement extends HTMLElement
   focusPaneViewOnRight: -> @paneContainer.focusPaneViewOnRight()
 
   runPackageSpecs: ->
-    [projectPath] = atom.project.getPaths()
-    ipc.send('run-package-specs', path.join(projectPath, 'spec')) if projectPath
+    if activePath = @getModel().getActivePaneItem()?.getPath?()
+      [projectPath] = atom.project.relativizePath(activePath)
+    projectPath ?= atom.project.getPaths()[0]
+    if projectPath
+      ipc.send('run-package-specs', path.join(projectPath, 'spec'))
 
 atom.commands.add 'atom-workspace',
   'window:increase-font-size': -> @getModel().increaseFontSize()
   'window:decrease-font-size': -> @getModel().decreaseFontSize()
   'window:reset-font-size': -> @getModel().resetFontSize()
   'application:about': -> ipc.send('command', 'application:about')
-  'application:run-all-specs': -> ipc.send('command', 'application:run-all-specs')
   'application:run-benchmarks': -> ipc.send('command', 'application:run-benchmarks')
   'application:show-settings': -> ipc.send('command', 'application:show-settings')
   'application:quit': -> ipc.send('command', 'application:quit')


### PR DESCRIPTION
#### Motivation

Currently, any npm modules we work on (e.g. `text-document`) need to use jasmine 1.3 so we can run specs in Atom, which is really useful for debugging. Without Atom's monkey-patched `waitsFor`, Jasmine 1.3 is basically unusable for testing async code (it only supports polling, no callbacks). Rather than have `text-document` and other libraries vendor atom/atom's customized version of jasmine 1.3, we should just use jasmine 2.
#### Changes

This allows packages and npm-modules to opt-in to using Jasmine-2.0 for the `application:run-package-specs` command in Atom. Packages opt in by adding `atom-jasmine: "^2.0.0"` to the `engines` object in their `package.json`.

Currently, when using Jasmine 2, `spec-helper` is not loaded. I think it would be nice to eventually stop using the miscellaneous global functions defined in that file. Some of them (e.g. the non-standard `jasmine.advanceClock`) duplicate functionality that is built into jasmine.

I am thinking that some community members might be interested in upgrading individual package's test suites to use Jasmine-2.0. We could make `good-first` issues for doing that in various packages.
- [x] Make the `AtomReporter` support the jasmine 2 reporter API
- [x] Make sure `fit`, `fdescribe` et al work w/ jasmine 2
- [x] Make sure `apm test` works w/ jasmine 2
#### Questions
- [ ] This PR also removes the `application:run-all-specs` command. It doesn't seem like that command is used anymore, and it would have been difficult to preserve it while adding support for Jasmine-2.0 in the 
  AtomReporter. Also, it would be very difficult to support that command's functionality if individual packages started to migrate to Jasmine-2.0.
- [ ] Is the `engines.atom-jasmine` the right way to do this?

/cc @atom/core @atom/non-github-maintainers I'm not sure if it's overly aggressive to get rid of `run-all-specs` command. What do you think?

Refs #5393.
