### PR TITLE
Build rpm package on Fedora 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,9 @@ RUN yum install -y \
     glibc-devel \
     git-core \
     libgnome-keyring-devel \
-    rpmdevtools
-
-# Install node
-RUN curl -sL https://rpm.nodesource.com/setup | bash -
-RUN yum install -y nodejs
+    rpmdevtools \
+    nodejs \
+    npm
 
 ADD . /atom
 WORKDIR /atom

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # DESCRIPTION:    Image to build Atom and create a .rpm file
 
 # Base docker image
-FROM fedora:20
+FROM fedora:21
 
 # Install dependencies
 RUN yum install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN yum install -y \
     nodejs \
     npm
 
-RUN npm install -g npm@1.4.28
+RUN npm install -g npm@1.4.28 --loglevel error
 
 ADD . /atom
 WORKDIR /atom

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,7 @@ RUN yum install -y \
     nodejs \
     npm
 
+RUN npm install -g npm@1.4.28
+
 ADD . /atom
 WORKDIR /atom

--- a/script/utils/verify-requirements.js
+++ b/script/utils/verify-requirements.js
@@ -56,7 +56,7 @@ function verifyNpm(cb) {
     var versionArray = npmVersion.split('.');
     var npmMajorVersion = +versionArray[0] || 0;
     var npmMinorVersion = +versionArray[1] || 0;
-    if (npmMajorVersion === 1 && npmMinorVersion < 4)
+    if (npmMajorVersion === 1 && npmMinorVersion < 4 && !process.env.JANKY_SHA1)
       cb("npm v1.4+ is required to build Atom. Version " + npmVersion + " was detected");
     else
       cb(null, "npm: v" + npmVersion);

--- a/script/utils/verify-requirements.js
+++ b/script/utils/verify-requirements.js
@@ -56,8 +56,8 @@ function verifyNpm(cb) {
     var versionArray = npmVersion.split('.');
     var npmMajorVersion = +versionArray[0] || 0;
     var npmMinorVersion = +versionArray[1] || 0;
-    if (npmMajorVersion === 1 && npmMinorVersion < 4 && !process.env.JANKY_SHA1)
-      cb("npm v1.4+ is required to build Atom. Version " + npmVersion + " was detected");
+    if (npmMajorVersion === 1 && npmMinorVersion < 4)
+      cb("npm v1.4+ is required to build Atom. Version " + npmVersion + " was detected.");
     else
       cb(null, "npm: v" + npmVersion);
   });

--- a/script/utils/verify-requirements.js
+++ b/script/utils/verify-requirements.js
@@ -57,7 +57,7 @@ function verifyNpm(cb) {
     var npmMajorVersion = +versionArray[0] || 0;
     var npmMinorVersion = +versionArray[1] || 0;
     if (npmMajorVersion === 1 && npmMinorVersion < 4)
-      cb("npm v1.4+ is required to build Atom.");
+      cb("npm v1.4+ is required to build Atom. Version " + npmVersion + " was detected");
     else
       cb(null, "npm: v" + npmVersion);
   });


### PR DESCRIPTION
The rpm CI builds were failing after a recent upgrade to a new Fedora 20 container.

Fedora 21 came out last December so lets starts building on that.
