### PR TITLE
Bump deprecation-cop@0.38.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "bookmarks": "0.35.0",
     "bracket-matcher": "0.73.0",
     "command-palette": "0.34.0",
-    "deprecation-cop": "0.37.0",
+    "deprecation-cop": "0.38.0",
     "dev-live-reload": "0.45.0",
     "encoding-selector": "0.19.0",
     "exception-reporting": "0.24.0",


### PR DESCRIPTION
Use the latest version of `deprecation-cop` which uses the latest version of the `status-bar` Service API. :cat2: 
