### PR TITLE
Add default syntax color variables to syntax-variables

### DIFF
--- a/static/variables/syntax-variables.less
+++ b/static/variables/syntax-variables.less
@@ -28,3 +28,16 @@
 @syntax-color-modified: orange;
 @syntax-color-removed: red;
 @syntax-color-renamed: blue;
+
+// For language entity colors
+@syntax-color-variable: #DF6A73;
+@syntax-color-constant: #DF6A73;
+@syntax-color-property: #DF6A73;
+@syntax-color-value: #D29B67;
+@syntax-color-function: #61AEEF;
+@syntax-color-method: @syntax-color-function;
+@syntax-color-class: #E5C17C;
+@syntax-color-keyword: #555;
+@syntax-color-tag: #555;
+@syntax-color-import: #97C378;
+@syntax-color-snippet: #97C378;


### PR DESCRIPTION
Will be used by syntax themes, and autocomplete
