### PR TITLE
Bump status-bar@0.66.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "settings-view": "0.186.0",
     "snippets": "0.86.0",
     "spell-check": "0.55.0",
-    "status-bar": "0.64.0",
+    "status-bar": "0.66.0",
     "styleguide": "0.44.0",
     "symbols-view": "0.93.0",
     "tabs": "0.67.0",


### PR DESCRIPTION
Use the latest version of `status-bar` which moves to the deprecation call for the `legacyProvideStatusBar` to the returned methods. https://github.com/atom/status-bar/pull/65

:green_apple: :green_apple: :green_apple: :green_apple: :green_apple: 
