### PR TITLE
Allow overlay decorations to break out of the editor; bound overlays to window

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -370,7 +370,7 @@ window.setEditorWidthInChars = (editorView, widthInChars, charWidth=editorView.c
 
 window.setEditorHeightInLines = (editorView, heightInLines, lineHeight=editorView.lineHeight) ->
   editorView.height(editorView.getEditor().getLineHeightInPixels() * heightInLines)
-  editorView.component?.measureHeightAndWidth()
+  editorView.component?.measureDimensions()
 
 $.fn.resultOfTrigger = (type) ->
   event = $.Event(type)

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1384,7 +1384,7 @@ describe "TextEditorComponent", ->
       afterEach ->
         atom.restoreWindowDimensions()
 
-      it "slides horizontally when near the right edge", ->
+      it "slides horizontally left when near the right edge", ->
         marker = editor.displayBuffer.markBufferRange([[0, 26], [0, 26]], invalidate: 'never')
         decoration = editor.decorateMarker(marker, {type: 'overlay', item})
         nextAnimationFrame()
@@ -1407,9 +1407,6 @@ describe "TextEditorComponent", ->
         expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
-      it "slides horizontally right when near the left edge with margin", ->
-        # TODO:
-
       it "flips vertically when near the bottom edge", ->
         marker = editor.displayBuffer.markBufferRange([[4, 0], [4, 0]], invalidate: 'never')
         decoration = editor.decorateMarker(marker, {type: 'overlay', item})
@@ -1428,6 +1425,39 @@ describe "TextEditorComponent", ->
 
         expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
         expect(overlay.style.top).toBe position.top - itemHeight + 'px'
+
+      describe "when the overlay item has a margin", ->
+        itemMargin = null
+        beforeEach ->
+          itemWidth = 12 * editor.getDefaultCharWidth()
+          itemMargin = gutterWidth + 2 * editor.getDefaultCharWidth()
+          item.style.width = itemWidth + 'px'
+          item.style['margin-left'] = "-#{itemMargin}px"
+
+        it "slides horizontally right when near the left edge with margin", ->
+          editor.setCursorBufferPosition([0, 3])
+          cursor = editor.getLastCursor()
+          marker = cursor.marker
+          decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+          nextAnimationFrame()
+
+          position = wrapperNode.pixelPositionForBufferPosition([0, 3])
+
+          overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
+          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
+          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+          cursor.moveLeft()
+          nextAnimationFrame()
+
+          expect(overlay.style.left).toBe itemMargin + 'px'
+          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+          cursor.moveLeft()
+          nextAnimationFrame()
+
+          expect(overlay.style.left).toBe itemMargin + 'px'
+          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
       describe "when the editor is very small", ->
         beforeEach ->

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -2234,6 +2234,7 @@ describe "TextEditorComponent", ->
       expect(editor.lineTextForBufferRow(0)).toBe 'üvar quicksort = function () {'
 
     it "does not handle input events when input is disabled", ->
+      nextAnimationFrame = noAnimationFrame # This spec is flaky on the build machine, so this.
       component.setInputEnabled(false)
       componentNode.dispatchEvent(buildTextInputEvent(data: 'x', target: inputNode))
       expect(nextAnimationFrame).toBe noAnimationFrame

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1308,6 +1308,7 @@ describe "TextEditorComponent", ->
         marker = editor.getLastCursor().getMarker()
         decoration = editor.decorateMarker(marker, {type: 'overlay', item})
         nextAnimationFrame()
+        nextAnimationFrame()
 
         position = wrapperNode.pixelPositionForBufferPosition([2, 5])
 
@@ -1329,6 +1330,7 @@ describe "TextEditorComponent", ->
         marker = editor.displayBuffer.markBufferRange([[2, 5], [2, 10]], invalidate: 'never')
         decoration = editor.decorateMarker(marker, {type: 'overlay', item})
         nextAnimationFrame()
+        nextAnimationFrame()
 
         position = wrapperNode.pixelPositionForBufferPosition([2, 10])
 
@@ -1340,6 +1342,7 @@ describe "TextEditorComponent", ->
         marker = editor.displayBuffer.markBufferRange([[2, 5], [2, 10]], invalidate: 'never', reversed: true)
         decoration = editor.decorateMarker(marker, {type: 'overlay', item})
         nextAnimationFrame()
+        nextAnimationFrame()
 
         position = wrapperNode.pixelPositionForBufferPosition([2, 5])
 
@@ -1350,6 +1353,7 @@ describe "TextEditorComponent", ->
       it "renders at the tail of the marker when the 'position' option is 'tail'", ->
         marker = editor.displayBuffer.markBufferRange([[2, 5], [2, 10]], invalidate: 'never')
         decoration = editor.decorateMarker(marker, {type: 'overlay', position: 'tail', item})
+        nextAnimationFrame()
         nextAnimationFrame()
 
         position = wrapperNode.pixelPositionForBufferPosition([2, 5])
@@ -1388,6 +1392,7 @@ describe "TextEditorComponent", ->
         marker = editor.displayBuffer.markBufferRange([[0, 26], [0, 26]], invalidate: 'never')
         decoration = editor.decorateMarker(marker, {type: 'overlay', item})
         nextAnimationFrame()
+        nextAnimationFrame()
 
         position = wrapperNode.pixelPositionForBufferPosition([0, 26])
 
@@ -1410,6 +1415,7 @@ describe "TextEditorComponent", ->
       it "flips vertically when near the bottom edge", ->
         marker = editor.displayBuffer.markBufferRange([[4, 0], [4, 0]], invalidate: 'never')
         decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+        nextAnimationFrame()
         nextAnimationFrame()
 
         position = wrapperNode.pixelPositionForBufferPosition([4, 0])
@@ -1439,6 +1445,7 @@ describe "TextEditorComponent", ->
           cursor = editor.getLastCursor()
           marker = cursor.marker
           decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+          nextAnimationFrame()
           nextAnimationFrame()
 
           position = wrapperNode.pixelPositionForBufferPosition([0, 3])
@@ -1475,6 +1482,7 @@ describe "TextEditorComponent", ->
           marker = editor.displayBuffer.markBufferRange([[0, 2], [0, 2]], invalidate: 'never')
           decoration = editor.decorateMarker(marker, {type: 'overlay', item})
           nextAnimationFrame()
+          nextAnimationFrame()
 
           position = wrapperNode.pixelPositionForBufferPosition([0, 2])
 
@@ -1493,6 +1501,7 @@ describe "TextEditorComponent", ->
         it "does not flip vertically and force the overlay to have a negative top", ->
           marker = editor.displayBuffer.markBufferRange([[1, 0], [1, 0]], invalidate: 'never')
           decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+          nextAnimationFrame()
           nextAnimationFrame()
 
           position = wrapperNode.pixelPositionForBufferPosition([1, 0])
@@ -1517,6 +1526,7 @@ describe "TextEditorComponent", ->
           marker = editor.displayBuffer.markBufferRange([[1, 29], [1, 29]], invalidate: 'never')
           decoration = editor.decorateMarker(marker, {type: 'overlay', item})
           nextAnimationFrame()
+          nextAnimationFrame()
 
           position = wrapperNode.pixelPositionForBufferPosition([1, 29])
 
@@ -1537,6 +1547,7 @@ describe "TextEditorComponent", ->
 
           marker = editor.displayBuffer.markBufferRange([[6, 0], [6, 0]], invalidate: 'never')
           decoration = editor.decorateMarker(marker, {type: 'overlay', item})
+          nextAnimationFrame()
           nextAnimationFrame()
 
           position = wrapperNode.pixelPositionForBufferPosition([6, 0])

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -50,7 +50,7 @@ describe "TextEditorComponent", ->
       verticalScrollbarNode = componentNode.querySelector('.vertical-scrollbar')
       horizontalScrollbarNode = componentNode.querySelector('.horizontal-scrollbar')
 
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
   afterEach ->
@@ -70,7 +70,7 @@ describe "TextEditorComponent", ->
   describe "line rendering", ->
     it "renders the currently-visible lines plus the overdraw margin", ->
       wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       linesNode = componentNode.querySelector('.lines')
@@ -113,7 +113,7 @@ describe "TextEditorComponent", ->
 
     it "updates the lines when lines are inserted or removed above the rendered row range", ->
       wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
       verticalScrollbarNode.scrollTop = 5 * lineHeightInPixels
       verticalScrollbarNode.dispatchEvent(new UIEvent('scroll'))
@@ -163,7 +163,7 @@ describe "TextEditorComponent", ->
     it "renders the .lines div at the full height of the editor if there aren't enough lines to scroll vertically", ->
       editor.setText('')
       wrapperNode.style.height = '300px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       linesNode = componentNode.querySelector('.lines')
@@ -175,7 +175,7 @@ describe "TextEditorComponent", ->
       lineNodes = componentNode.querySelectorAll('.line')
 
       componentNode.style.width = gutterWidth + (30 * charWidth) + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
       expect(editor.getScrollWidth()).toBeGreaterThan scrollViewNode.offsetWidth
 
@@ -187,7 +187,7 @@ describe "TextEditorComponent", ->
         expect(lineNode.style.width).toBe editor.getScrollWidth() + 'px'
 
       componentNode.style.width = gutterWidth + editor.getScrollWidth() + 100 + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
       scrollViewWidth = scrollViewNode.offsetWidth
 
@@ -339,7 +339,7 @@ describe "TextEditorComponent", ->
           editor.setSoftWrapped(true)
           nextAnimationFrame()
           componentNode.style.width = 16 * charWidth + editor.getVerticalScrollbarWidth() + 'px'
-          component.measureHeightAndWidth()
+          component.measureDimensions()
           nextAnimationFrame()
 
         it "doesn't show end of line invisibles at the end of wrapped lines", ->
@@ -480,7 +480,7 @@ describe "TextEditorComponent", ->
   describe "gutter rendering", ->
     it "renders the currently-visible line numbers", ->
       wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       expect(componentNode.querySelectorAll('.line-number').length).toBe 6 + 2 + 1 # line overdraw margin below + dummy line number
@@ -524,7 +524,7 @@ describe "TextEditorComponent", ->
       editor.setSoftWrapped(true)
       wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
       wrapperNode.style.width = 30 * charWidth + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       expect(componentNode.querySelectorAll('.line-number').length).toBe 6 + lineOverdrawMargin + 1 # 1 dummy line componentNode
@@ -562,7 +562,7 @@ describe "TextEditorComponent", ->
 
     it "renders the .line-numbers div at the full height of the editor even if it's taller than its content", ->
       wrapperNode.style.height = componentNode.offsetHeight + 100 + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
       expect(componentNode.querySelector('.line-numbers').offsetHeight).toBe componentNode.offsetHeight
 
@@ -653,7 +653,7 @@ describe "TextEditorComponent", ->
             editor.setSoftWrapped(true)
             nextAnimationFrame()
             componentNode.style.width = 16 * charWidth + editor.getVerticalScrollbarWidth() + 'px'
-            component.measureHeightAndWidth()
+            component.measureDimensions()
             nextAnimationFrame()
 
           it "doesn't add the foldable class for soft-wrapped lines", ->
@@ -697,7 +697,7 @@ describe "TextEditorComponent", ->
 
       wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
       wrapperNode.style.width = 20 * lineHeightInPixels + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       cursorNodes = componentNode.querySelectorAll('.cursor')
@@ -992,7 +992,7 @@ describe "TextEditorComponent", ->
 
       # Shrink editor vertically
       wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       # Add decorations that are out of range
@@ -1016,7 +1016,7 @@ describe "TextEditorComponent", ->
       editor.setText("a line that wraps, ok")
       editor.setSoftWrapped(true)
       componentNode.style.width = 16 * charWidth + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       marker.destroy()
@@ -1132,7 +1132,7 @@ describe "TextEditorComponent", ->
 
     it "does not render highlights for off-screen lines until they come on-screen", ->
       wrapperNode.style.height = 2.5 * lineHeightInPixels + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       marker = editor.displayBuffer.markBufferRange([[9, 2], [9, 4]], invalidate: 'inside')
@@ -1279,10 +1279,13 @@ describe "TextEditorComponent", ->
         expect(componentNode.querySelector('.new-test-highlight')).toBeTruthy()
 
   describe "overlay decoration rendering", ->
-    [item] = []
+    [item, gutterWidth] = []
     beforeEach ->
       item = document.createElement('div')
       item.classList.add 'overlay-test'
+      item.style.background = 'red'
+
+      gutterWidth = componentNode.querySelector('.gutter').offsetWidth
 
     describe "when the marker is empty", ->
       it "renders an overlay decoration when added and removes the overlay when the decoration is destroyed", ->
@@ -1309,7 +1312,7 @@ describe "TextEditorComponent", ->
         position = wrapperNode.pixelPositionForBufferPosition([2, 5])
 
         overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
         editor.moveRight()
@@ -1318,7 +1321,7 @@ describe "TextEditorComponent", ->
 
         position = wrapperNode.pixelPositionForBufferPosition([2, 7])
 
-        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
     describe "when the marker is not empty", ->
@@ -1330,7 +1333,7 @@ describe "TextEditorComponent", ->
         position = wrapperNode.pixelPositionForBufferPosition([2, 10])
 
         overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
       it "renders at the head of the marker when the marker is reversed", ->
@@ -1341,7 +1344,7 @@ describe "TextEditorComponent", ->
         position = wrapperNode.pixelPositionForBufferPosition([2, 5])
 
         overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
       it "renders at the tail of the marker when the 'position' option is 'tail'", ->
@@ -1352,18 +1355,19 @@ describe "TextEditorComponent", ->
         position = wrapperNode.pixelPositionForBufferPosition([2, 5])
 
         overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
     describe "positioning the overlay when near the edge of the editor", ->
-      [itemWidth, itemHeight] = []
+      [itemWidth, itemHeight, windowWidth, windowHeight] = []
       beforeEach ->
+        atom.storeWindowDimensions()
+
         itemWidth = 4 * editor.getDefaultCharWidth()
         itemHeight = 4 * editor.getLineHeightInPixels()
 
-        gutterWidth = componentNode.querySelector('.gutter').offsetWidth
         windowWidth = gutterWidth + 30 * editor.getDefaultCharWidth()
-        windowHeight = 9 * editor.getLineHeightInPixels()
+        windowHeight = 10 * editor.getLineHeightInPixels()
 
         item.style.width = itemWidth + 'px'
         item.style.height = itemHeight + 'px'
@@ -1371,10 +1375,16 @@ describe "TextEditorComponent", ->
         wrapperNode.style.width = windowWidth + 'px'
         wrapperNode.style.height = windowHeight + 'px'
 
-        component.measureHeightAndWidth()
+        atom.setWindowDimensions({width: windowWidth, height: windowHeight})
+
+        component.measureDimensions()
+        component.measureWindowSize()
         nextAnimationFrame()
 
-      it "flips horizontally when near the right edge", ->
+      afterEach ->
+        atom.restoreWindowDimensions()
+
+      it "slides horizontally when near the right edge", ->
         marker = editor.displayBuffer.markBufferRange([[0, 26], [0, 26]], invalidate: 'never')
         decoration = editor.decorateMarker(marker, {type: 'overlay', item})
         nextAnimationFrame()
@@ -1382,16 +1392,23 @@ describe "TextEditorComponent", ->
         position = wrapperNode.pixelPositionForBufferPosition([0, 26])
 
         overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
         editor.insertText('a')
         nextAnimationFrame()
 
-        position = wrapperNode.pixelPositionForBufferPosition([0, 27])
-
-        expect(overlay.style.left).toBe position.left - itemWidth + 'px'
+        expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+        editor.insertText('b')
+        nextAnimationFrame()
+
+        expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
+        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+
+      it "slides horizontally right when near the left edge with margin", ->
+        # TODO:
 
       it "flips vertically when near the bottom edge", ->
         marker = editor.displayBuffer.markBufferRange([[4, 0], [4, 0]], invalidate: 'never')
@@ -1401,7 +1418,7 @@ describe "TextEditorComponent", ->
         position = wrapperNode.pixelPositionForBufferPosition([4, 0])
 
         overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
         editor.insertNewline()
@@ -1409,7 +1426,7 @@ describe "TextEditorComponent", ->
 
         position = wrapperNode.pixelPositionForBufferPosition([5, 0])
 
-        expect(overlay.style.left).toBe position.left + 'px'
+        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
         expect(overlay.style.top).toBe position.top - itemHeight + 'px'
 
       describe "when the editor is very small", ->
@@ -1421,7 +1438,7 @@ describe "TextEditorComponent", ->
           wrapperNode.style.width = windowWidth + 'px'
           wrapperNode.style.height = windowHeight + 'px'
 
-          component.measureHeightAndWidth()
+          component.measureDimensions()
           nextAnimationFrame()
 
         it "does not flip horizontally and force the overlay to have a negative left", ->
@@ -1432,7 +1449,7 @@ describe "TextEditorComponent", ->
           position = wrapperNode.pixelPositionForBufferPosition([0, 2])
 
           overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-          expect(overlay.style.left).toBe position.left + 'px'
+          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
           expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
           editor.insertText('a')
@@ -1440,7 +1457,7 @@ describe "TextEditorComponent", ->
 
           position = wrapperNode.pixelPositionForBufferPosition([0, 3])
 
-          expect(overlay.style.left).toBe position.left + 'px'
+          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
           expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
         it "does not flip vertically and force the overlay to have a negative top", ->
@@ -1451,7 +1468,7 @@ describe "TextEditorComponent", ->
           position = wrapperNode.pixelPositionForBufferPosition([1, 0])
 
           overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-          expect(overlay.style.left).toBe position.left + 'px'
+          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
           expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
           editor.insertNewline()
@@ -1459,33 +1476,35 @@ describe "TextEditorComponent", ->
 
           position = wrapperNode.pixelPositionForBufferPosition([2, 0])
 
-          expect(overlay.style.left).toBe position.left + 'px'
+          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
           expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
 
       describe "when editor scroll position is not 0", ->
         it "flips horizontally when near the right edge", ->
-          editor.setScrollLeft(2 * editor.getDefaultCharWidth())
-          marker = editor.displayBuffer.markBufferRange([[0, 28], [0, 28]], invalidate: 'never')
+          scrollLeft = 3 * editor.getDefaultCharWidth()
+          editor.setScrollLeft(scrollLeft)
+          editor.setCursorBufferPosition([1, 20])
+          marker = editor.displayBuffer.markBufferRange([[1, 29], [1, 29]], invalidate: 'never')
           decoration = editor.decorateMarker(marker, {type: 'overlay', item})
           nextAnimationFrame()
 
-          position = wrapperNode.pixelPositionForBufferPosition([0, 28])
+          position = wrapperNode.pixelPositionForBufferPosition([1, 29])
 
           overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-          expect(overlay.style.left).toBe position.left + 'px'
+          expect(overlay.style.left).toBe position.left + gutterWidth - scrollLeft + 'px'
           expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
           editor.insertText('a')
           nextAnimationFrame()
 
-          position = wrapperNode.pixelPositionForBufferPosition([0, 29])
-
-          expect(overlay.style.left).toBe position.left - itemWidth + 'px'
+          expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
           expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
         it "flips vertically when near the bottom edge", ->
-          editor.setScrollTop(2 * editor.getLineHeightInPixels())
+          scrollTop = 2 * editor.getLineHeightInPixels()
+          editor.setScrollTop(scrollTop)
+          editor.setCursorBufferPosition([5, 0])
+
           marker = editor.displayBuffer.markBufferRange([[6, 0], [6, 0]], invalidate: 'never')
           decoration = editor.decorateMarker(marker, {type: 'overlay', item})
           nextAnimationFrame()
@@ -1493,16 +1512,16 @@ describe "TextEditorComponent", ->
           position = wrapperNode.pixelPositionForBufferPosition([6, 0])
 
           overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-          expect(overlay.style.left).toBe position.left + 'px'
-          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
+          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() - scrollTop + 'px'
 
           editor.insertNewline()
           nextAnimationFrame()
 
           position = wrapperNode.pixelPositionForBufferPosition([7, 0])
 
-          expect(overlay.style.left).toBe position.left + 'px'
-          expect(overlay.style.top).toBe position.top - itemHeight + 'px'
+          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
+          expect(overlay.style.top).toBe position.top - itemHeight - scrollTop + 'px'
 
   describe "hidden input field", ->
     it "renders the hidden input field at the position of the last cursor if the cursor is on screen and the editor is focused", ->
@@ -1512,7 +1531,7 @@ describe "TextEditorComponent", ->
       inputNode = componentNode.querySelector('.hidden-input')
       wrapperNode.style.height = 5 * lineHeightInPixels + 'px'
       wrapperNode.style.width = 10 * charWidth + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       expect(editor.getCursorScreenPosition()).toEqual [0, 0]
@@ -1566,7 +1585,7 @@ describe "TextEditorComponent", ->
         height = 4.5 * lineHeightInPixels
         wrapperNode.style.height = height + 'px'
         wrapperNode.style.width = 10 * charWidth + 'px'
-        component.measureHeightAndWidth()
+        component.measureDimensions()
         nextAnimationFrame()
 
         coordinates = clientCoordinatesForScreenPosition([0, 2])
@@ -1580,7 +1599,7 @@ describe "TextEditorComponent", ->
         it "moves the cursor to the nearest screen position", ->
           wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
           wrapperNode.style.width = 10 * charWidth + 'px'
-          component.measureHeightAndWidth()
+          component.measureDimensions()
           editor.setScrollTop(3.5 * lineHeightInPixels)
           editor.setScrollLeft(2 * charWidth)
           nextAnimationFrame()
@@ -1863,7 +1882,7 @@ describe "TextEditorComponent", ->
         editor.setSoftWrapped(true)
         nextAnimationFrame()
         componentNode.style.width = 21 * charWidth + editor.getVerticalScrollbarWidth() + 'px'
-        component.measureHeightAndWidth()
+        component.measureDimensions()
         nextAnimationFrame()
 
       describe "when the gutter is clicked", ->
@@ -2029,7 +2048,7 @@ describe "TextEditorComponent", ->
   describe "scrolling", ->
     it "updates the vertical scrollbar when the scrollTop is changed in the model", ->
       wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       expect(verticalScrollbarNode.scrollTop).toBe 0
@@ -2040,7 +2059,7 @@ describe "TextEditorComponent", ->
 
     it "updates the horizontal scrollbar and the x transform of the lines based on the scrollLeft of the model", ->
       componentNode.style.width = 30 * charWidth + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       linesNode = componentNode.querySelector('.lines')
@@ -2054,7 +2073,7 @@ describe "TextEditorComponent", ->
 
     it "updates the scrollLeft of the model when the scrollLeft of the horizontal scrollbar changes", ->
       componentNode.style.width = 30 * charWidth + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       expect(editor.getScrollLeft()).toBe 0
@@ -2067,7 +2086,7 @@ describe "TextEditorComponent", ->
     it "does not obscure the last line with the horizontal scrollbar", ->
       wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
       wrapperNode.style.width = 10 * charWidth + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       editor.setScrollBottom(editor.getScrollHeight())
       nextAnimationFrame()
       lastLineNode = component.lineNodeForScreenRow(editor.getLastScreenRow())
@@ -2077,7 +2096,7 @@ describe "TextEditorComponent", ->
 
       # Scroll so there's no space below the last line when the horizontal scrollbar disappears
       wrapperNode.style.width = 100 * charWidth + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
       bottomOfLastLine = lastLineNode.getBoundingClientRect().bottom
       bottomOfEditor = componentNode.getBoundingClientRect().bottom
@@ -2086,7 +2105,7 @@ describe "TextEditorComponent", ->
     it "does not obscure the last character of the longest line with the vertical scrollbar", ->
       wrapperNode.style.height = 7 * lineHeightInPixels + 'px'
       wrapperNode.style.width = 10 * charWidth + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       editor.setScrollLeft(Infinity)
       nextAnimationFrame()
 
@@ -2100,21 +2119,21 @@ describe "TextEditorComponent", ->
 
       wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
       wrapperNode.style.width = '1000px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       expect(verticalScrollbarNode.style.display).toBe ''
       expect(horizontalScrollbarNode.style.display).toBe 'none'
 
       componentNode.style.width = 10 * charWidth + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       expect(verticalScrollbarNode.style.display).toBe ''
       expect(horizontalScrollbarNode.style.display).toBe ''
 
       wrapperNode.style.height = 20 * lineHeightInPixels + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       expect(verticalScrollbarNode.style.display).toBe 'none'
@@ -2123,7 +2142,7 @@ describe "TextEditorComponent", ->
     it "makes the dummy scrollbar divs only as tall/wide as the actual scrollbars", ->
       wrapperNode.style.height = 4 * lineHeightInPixels + 'px'
       wrapperNode.style.width = 10 * charWidth + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       atom.styles.addStyleSheet """
@@ -2152,21 +2171,21 @@ describe "TextEditorComponent", ->
 
       wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
       wrapperNode.style.width = '1000px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
       expect(verticalScrollbarNode.style.bottom).toBe '0px'
       expect(horizontalScrollbarNode.style.right).toBe verticalScrollbarNode.offsetWidth + 'px'
       expect(scrollbarCornerNode.style.display).toBe 'none'
 
       componentNode.style.width = 10 * charWidth + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
       expect(verticalScrollbarNode.style.bottom).toBe horizontalScrollbarNode.offsetHeight + 'px'
       expect(horizontalScrollbarNode.style.right).toBe verticalScrollbarNode.offsetWidth + 'px'
       expect(scrollbarCornerNode.style.display).toBe ''
 
       wrapperNode.style.height = 20 * lineHeightInPixels + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
       expect(verticalScrollbarNode.style.bottom).toBe horizontalScrollbarNode.offsetHeight + 'px'
       expect(horizontalScrollbarNode.style.right).toBe '0px'
@@ -2175,7 +2194,7 @@ describe "TextEditorComponent", ->
     it "accounts for the width of the gutter in the scrollWidth of the horizontal scrollbar", ->
       gutterNode = componentNode.querySelector('.gutter')
       componentNode.style.width = 10 * charWidth + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       expect(horizontalScrollbarNode.scrollWidth).toBe editor.getScrollWidth()
@@ -2189,7 +2208,7 @@ describe "TextEditorComponent", ->
       beforeEach ->
         wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
         wrapperNode.style.width = 20 * charWidth + 'px'
-        component.measureHeightAndWidth()
+        component.measureDimensions()
         nextAnimationFrame()
 
       it "updates the scrollLeft or scrollTop on mousewheel events depending on which delta is greater (x or y)", ->
@@ -2233,7 +2252,7 @@ describe "TextEditorComponent", ->
       it "keeps the line on the DOM if it is scrolled off-screen", ->
         wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
         wrapperNode.style.width = 20 * charWidth + 'px'
-        component.measureHeightAndWidth()
+        component.measureDimensions()
 
         lineNode = componentNode.querySelector('.line')
         wheelEvent = new WheelEvent('mousewheel', wheelDeltaX: 0, wheelDeltaY: -500)
@@ -2246,7 +2265,7 @@ describe "TextEditorComponent", ->
       it "does not set the mouseWheelScreenRow if scrolling horizontally", ->
         wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
         wrapperNode.style.width = 20 * charWidth + 'px'
-        component.measureHeightAndWidth()
+        component.measureDimensions()
 
         lineNode = componentNode.querySelector('.line')
         wheelEvent = new WheelEvent('mousewheel', wheelDeltaX: 10, wheelDeltaY: 0)
@@ -2289,7 +2308,7 @@ describe "TextEditorComponent", ->
       it "keeps the line number on the DOM if it is scrolled off-screen", ->
         wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
         wrapperNode.style.width = 20 * charWidth + 'px'
-        component.measureHeightAndWidth()
+        component.measureDimensions()
 
         lineNumberNode = componentNode.querySelectorAll('.line-number')[1]
         wheelEvent = new WheelEvent('mousewheel', wheelDeltaX: 0, wheelDeltaY: -500)
@@ -2304,7 +2323,7 @@ describe "TextEditorComponent", ->
 
       wrapperNode.style.height = 4.5 * lineHeightInPixels + 'px'
       wrapperNode.style.width = 20 * charWidth + 'px'
-      component.measureHeightAndWidth()
+      component.measureDimensions()
       nextAnimationFrame()
 
       # try to scroll past the top, which is impossible
@@ -2700,7 +2719,7 @@ describe "TextEditorComponent", ->
     describe "when the wrapper view has an explicit height", ->
       it "does not assign a height on the component node", ->
         wrapperNode.style.height = '200px'
-        component.measureHeightAndWidth()
+        component.measureDimensions()
         nextAnimationFrame()
         expect(componentNode.style.height).toBe ''
 

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1284,7 +1284,6 @@ describe "TextEditorComponent", ->
       item = document.createElement('div')
       item.classList.add 'overlay-test'
       item.style.background = 'red'
-
       gutterWidth = componentNode.querySelector('.gutter').offsetWidth
 
     describe "when the marker is empty", ->
@@ -1301,29 +1300,6 @@ describe "TextEditorComponent", ->
 
         overlay = component.getTopmostDOMNode().querySelector('atom-overlay .overlay-test')
         expect(overlay).toBe null
-
-      it "renders in the correct position on initial display and when the marker moves", ->
-        editor.setCursorBufferPosition([2, 5])
-
-        marker = editor.getLastCursor().getMarker()
-        decoration = editor.decorateMarker(marker, {type: 'overlay', item})
-        nextAnimationFrame()
-        nextAnimationFrame()
-
-        position = wrapperNode.pixelPositionForBufferPosition([2, 5])
-
-        overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
-        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
-        editor.moveRight()
-        editor.moveRight()
-        nextAnimationFrame()
-
-        position = wrapperNode.pixelPositionForBufferPosition([2, 7])
-
-        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
-        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
     describe "when the marker is not empty", ->
       it "renders at the head of the marker by default", ->
@@ -1387,14 +1363,6 @@ describe "TextEditorComponent", ->
 
         expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-        editor.insertNewline()
-        nextAnimationFrame()
-
-        position = wrapperNode.pixelPositionForBufferPosition([5, 0])
-
-        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
-        expect(overlay.style.top).toBe position.top - itemHeight + 'px'
-
 
   describe "hidden input field", ->
     it "renders the hidden input field at the position of the last cursor if the cursor is on screen and the editor is focused", ->

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1338,30 +1338,6 @@ describe "TextEditorComponent", ->
         expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
-      it "renders at the head of the marker when the marker is reversed", ->
-        marker = editor.displayBuffer.markBufferRange([[2, 5], [2, 10]], invalidate: 'never', reversed: true)
-        decoration = editor.decorateMarker(marker, {type: 'overlay', item})
-        nextAnimationFrame()
-        nextAnimationFrame()
-
-        position = wrapperNode.pixelPositionForBufferPosition([2, 5])
-
-        overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
-        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
-      it "renders at the tail of the marker when the 'position' option is 'tail'", ->
-        marker = editor.displayBuffer.markBufferRange([[2, 5], [2, 10]], invalidate: 'never')
-        decoration = editor.decorateMarker(marker, {type: 'overlay', position: 'tail', item})
-        nextAnimationFrame()
-        nextAnimationFrame()
-
-        position = wrapperNode.pixelPositionForBufferPosition([2, 5])
-
-        overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
-        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
     describe "positioning the overlay when near the edge of the editor", ->
       [itemWidth, itemHeight, windowWidth, windowHeight] = []
       beforeEach ->
@@ -1411,19 +1387,6 @@ describe "TextEditorComponent", ->
 
         expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
-      it "flips vertically when near the bottom edge", ->
-        marker = editor.displayBuffer.markBufferRange([[4, 0], [4, 0]], invalidate: 'never')
-        decoration = editor.decorateMarker(marker, {type: 'overlay', item})
-        nextAnimationFrame()
-        nextAnimationFrame()
-
-        position = wrapperNode.pixelPositionForBufferPosition([4, 0])
-
-        overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-        expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
-        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
         editor.insertNewline()
         nextAnimationFrame()
 
@@ -1432,137 +1395,6 @@ describe "TextEditorComponent", ->
         expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
         expect(overlay.style.top).toBe position.top - itemHeight + 'px'
 
-      describe "when the overlay item has a margin", ->
-        itemMargin = null
-        beforeEach ->
-          itemWidth = 12 * editor.getDefaultCharWidth()
-          itemMargin = gutterWidth + 2 * editor.getDefaultCharWidth()
-          item.style.width = itemWidth + 'px'
-          item.style['margin-left'] = "-#{itemMargin}px"
-
-        it "slides horizontally right when near the left edge with margin", ->
-          editor.setCursorBufferPosition([0, 3])
-          cursor = editor.getLastCursor()
-          marker = cursor.marker
-          decoration = editor.decorateMarker(marker, {type: 'overlay', item})
-          nextAnimationFrame()
-          nextAnimationFrame()
-
-          position = wrapperNode.pixelPositionForBufferPosition([0, 3])
-
-          overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
-          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
-          cursor.moveLeft()
-          nextAnimationFrame()
-
-          expect(overlay.style.left).toBe itemMargin + 'px'
-          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
-          cursor.moveLeft()
-          nextAnimationFrame()
-
-          expect(overlay.style.left).toBe itemMargin + 'px'
-          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
-      describe "when the editor is very small", ->
-        beforeEach ->
-          gutterWidth = componentNode.querySelector('.gutter').offsetWidth
-          windowWidth = gutterWidth + 6 * editor.getDefaultCharWidth()
-          windowHeight = 6 * editor.getLineHeightInPixels()
-
-          wrapperNode.style.width = windowWidth + 'px'
-          wrapperNode.style.height = windowHeight + 'px'
-
-          component.measureDimensions()
-          nextAnimationFrame()
-
-        it "does not flip horizontally and force the overlay to have a negative left", ->
-          marker = editor.displayBuffer.markBufferRange([[0, 2], [0, 2]], invalidate: 'never')
-          decoration = editor.decorateMarker(marker, {type: 'overlay', item})
-          nextAnimationFrame()
-          nextAnimationFrame()
-
-          position = wrapperNode.pixelPositionForBufferPosition([0, 2])
-
-          overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
-          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
-          editor.insertText('a')
-          nextAnimationFrame()
-
-          position = wrapperNode.pixelPositionForBufferPosition([0, 3])
-
-          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
-          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
-        it "does not flip vertically and force the overlay to have a negative top", ->
-          marker = editor.displayBuffer.markBufferRange([[1, 0], [1, 0]], invalidate: 'never')
-          decoration = editor.decorateMarker(marker, {type: 'overlay', item})
-          nextAnimationFrame()
-          nextAnimationFrame()
-
-          position = wrapperNode.pixelPositionForBufferPosition([1, 0])
-
-          overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
-          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
-          editor.insertNewline()
-          nextAnimationFrame()
-
-          position = wrapperNode.pixelPositionForBufferPosition([2, 0])
-
-          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
-          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
-      describe "when editor scroll position is not 0", ->
-        it "flips horizontally when near the right edge", ->
-          scrollLeft = 3 * editor.getDefaultCharWidth()
-          editor.setScrollLeft(scrollLeft)
-          editor.setCursorBufferPosition([1, 20])
-          marker = editor.displayBuffer.markBufferRange([[1, 29], [1, 29]], invalidate: 'never')
-          decoration = editor.decorateMarker(marker, {type: 'overlay', item})
-          nextAnimationFrame()
-          nextAnimationFrame()
-
-          position = wrapperNode.pixelPositionForBufferPosition([1, 29])
-
-          overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-          expect(overlay.style.left).toBe position.left + gutterWidth - scrollLeft + 'px'
-          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
-          editor.insertText('a')
-          nextAnimationFrame()
-
-          expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
-          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
-
-        it "flips vertically when near the bottom edge", ->
-          scrollTop = 2 * editor.getLineHeightInPixels()
-          editor.setScrollTop(scrollTop)
-          editor.setCursorBufferPosition([5, 0])
-
-          marker = editor.displayBuffer.markBufferRange([[6, 0], [6, 0]], invalidate: 'never')
-          decoration = editor.decorateMarker(marker, {type: 'overlay', item})
-          nextAnimationFrame()
-          nextAnimationFrame()
-
-          position = wrapperNode.pixelPositionForBufferPosition([6, 0])
-
-          overlay = component.getTopmostDOMNode().querySelector('atom-overlay')
-          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
-          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() - scrollTop + 'px'
-
-          editor.insertNewline()
-          nextAnimationFrame()
-
-          position = wrapperNode.pixelPositionForBufferPosition([7, 0])
-
-          expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
-          expect(overlay.style.top).toBe position.top - itemHeight - scrollTop + 'px'
 
   describe "hidden input field", ->
     it "renders the hidden input field at the position of the last cursor if the cursor is on screen and the editor is focused", ->

--- a/spec/view-registry-spec.coffee
+++ b/spec/view-registry-spec.coffee
@@ -137,6 +137,21 @@ describe "ViewRegistry", ->
       advanceClock(registry.documentPollingInterval)
       expect(events).toEqual ['write', 'read', 'poll', 'poll']
 
+    it "polls the document after updating when ::pollAfterNextUpdate() has been called", ->
+      events = []
+      registry.pollDocument -> events.push('poll')
+      registry.updateDocument -> events.push('write')
+      registry.readDocument -> events.push('read')
+      frameRequests.shift()()
+      expect(events).toEqual ['write', 'read']
+
+      events = []
+      registry.pollAfterNextUpdate()
+      registry.updateDocument -> events.push('write')
+      registry.readDocument -> events.push('read')
+      frameRequests.shift()()
+      expect(events).toEqual ['write', 'read', 'poll']
+
   describe "::pollDocument(fn)", ->
     it "calls all registered reader functions on an interval until they are disabled via a returned disposable", ->
       spyOn(window, 'setInterval').andCallFake(fakeSetInterval)

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -4,7 +4,6 @@ _ = require 'underscore-plus'
 
 CursorsComponent = require './cursors-component'
 HighlightsComponent = require './highlights-component'
-OverlayManager = require './overlay-manager'
 
 DummyLineNode = $$(-> @div className: 'line', style: 'position: absolute; visibility: hidden;', => @span 'x')[0]
 AcceptFilter = {acceptNode: -> NodeFilter.FILTER_ACCEPT}
@@ -40,13 +39,6 @@ class LinesComponent
       insertionPoint.setAttribute('select', '.overlayer')
       @domNode.appendChild(insertionPoint)
 
-      insertionPoint = document.createElement('content')
-      insertionPoint.setAttribute('select', 'atom-overlay')
-      @overlayManager = new OverlayManager(@presenter, @hostElement)
-      @domNode.appendChild(insertionPoint)
-    else
-      @overlayManager = new OverlayManager(@presenter, @domNode)
-
   updateSync: (state) ->
     @newState = state.content
     @oldState ?= {lines: {}}
@@ -81,8 +73,6 @@ class LinesComponent
 
     @cursorsComponent.updateSync(state)
     @highlightsComponent.updateSync(state)
-
-    @overlayManager?.render(state)
 
     @oldState.indentGuidesVisible = @newState.indentGuidesVisible
     @oldState.scrollWidth = @newState.scrollWidth

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -4,99 +4,38 @@ class OverlayManager
     @overlaysById = {}
 
   render: (state) ->
-    editorDimensionsHaveChanged = !@editorDimensionsAreEqual(state)
-
     for decorationId, overlay of state.content.overlays
-      overlayHasChanged = not @overlayStateIsEqual(decorationId, overlay)
-      if editorDimensionsHaveChanged or overlayHasChanged
+      if @shouldUpdateOverlay(decorationId, overlay)
         @renderOverlay(state, decorationId, overlay)
-        @cacheOverlayState(decorationId, overlay)
 
     for id, {overlayNode} of @overlaysById
       unless state.content.overlays.hasOwnProperty(id)
         delete @overlaysById[id]
         overlayNode.remove()
 
-    @cacheEditorDimensions(state)
-
-  overlayStateIsEqual: (decorationId, overlay) ->
-    return false unless @overlaysById[decorationId]?
-    @overlaysById[decorationId].itemWidth is overlay.itemWidth and
-      @overlaysById[decorationId].itemHeight is overlay.itemHeight and
-      @overlaysById[decorationId].contentMargin is overlay.contentMargin and
-      @overlaysById[decorationId].pixelPosition?.top is overlay.pixelPosition?.top and
-      @overlaysById[decorationId].pixelPosition?.left is overlay.pixelPosition?.left
-
-  cacheOverlayState: (decorationId, overlay) ->
-    return unless @overlaysById[decorationId]?
-    @overlaysById[decorationId].itemWidth = overlay.itemWidth
-    @overlaysById[decorationId].itemHeight = overlay.itemHeight
-    @overlaysById[decorationId].contentMargin = overlay.contentMargin
-    @overlaysById[decorationId].pixelPosition = overlay.pixelPosition
-
-  cacheEditorDimensions: (state) ->
-    @cachedEditorDimensions =
-      lineHeight: @presenter.lineHeight
-      contentFrameWidth: @presenter.contentFrameWidth
-      editorTop: @presenter.boundingClientRect?.top
-      editorLeft: @presenter.boundingClientRect?.left
-      editorWidth: @presenter.boundingClientRect?.width
-      windowWidth: @presenter.windowWidth
-      windowHeight: @presenter.windowHeight
-      scrollTop: state.content.scrollTop
-      scrollLeft: state.content.scrollLeft
-
-  editorDimensionsAreEqual: (state) ->
-    return false unless @cachedEditorDimensions?
-    @cachedEditorDimensions.lineHeight is @presenter.lineHeight and
-      @cachedEditorDimensions.contentFrameWidth is @presenter.contentFrameWidth and
-      @cachedEditorDimensions.editorTop is @presenter.boundingClientRect?.top and
-      @cachedEditorDimensions.editorLeft is @presenter.boundingClientRect?.left and
-      @cachedEditorDimensions.editorWidth is @presenter.boundingClientRect?.width and
-      @cachedEditorDimensions.windowWidth is @presenter.windowWidth and
-      @cachedEditorDimensions.windowHeight is @presenter.windowHeight and
-      @cachedEditorDimensions.scrollTop is state.content.scrollTop and
-      @cachedEditorDimensions.scrollLeft is state.content.scrollLeft
+  shouldUpdateOverlay: (decorationId, overlay) ->
+    cachedOverlay = @overlaysById[decorationId]
+    return true unless cachedOverlay?
+    cachedOverlay.pixelPosition?.top isnt overlay.pixelPosition?.top or
+      cachedOverlay.pixelPosition?.left isnt overlay.pixelPosition?.left
 
   measureOverlays: ->
-    for decorationId, {item} of @overlaysById
-      @measureOverlay(decorationId, item)
+    for decorationId, {itemView} of @overlaysById
+      @measureOverlay(decorationId, itemView)
 
-  measureOverlay: (decorationId, item) ->
-    contentMargin = parseInt(getComputedStyle(item)['margin-left']) ? 0
-    @presenter.setOverlayDimensions(decorationId, item.offsetWidth, item.offsetHeight, contentMargin)
+  measureOverlay: (decorationId, itemView) ->
+    contentMargin = parseInt(getComputedStyle(itemView)['margin-left']) ? 0
+    @presenter.setOverlayDimensions(decorationId, itemView.offsetWidth, itemView.offsetHeight, contentMargin)
 
   renderOverlay: (state, decorationId, {item, pixelPosition}) ->
-    item = atom.views.getView(item)
-    overlay = @overlaysById[decorationId]
-    unless overlayNode = overlay?.overlayNode
+    itemView = atom.views.getView(item)
+    cachedOverlay = @overlaysById[decorationId]
+    unless overlayNode = cachedOverlay?.overlayNode
       overlayNode = document.createElement('atom-overlay')
-      overlayNode.appendChild(item)
+      overlayNode.appendChild(itemView)
       @container.appendChild(overlayNode)
-      @overlaysById[decorationId] = overlay = {overlayNode, item}
+      @overlaysById[decorationId] = cachedOverlay = {overlayNode, itemView}
 
-    overlayDimensions = @presenter.getOverlayDimensions(decorationId)
-    unless overlayDimensions?.itemWidth?
-      @measureOverlay(decorationId, item)
-      overlayDimensions = @presenter.getOverlayDimensions(decorationId)
-
-    {itemWidth, itemHeight, contentMargin} = overlayDimensions
-    {scrollTop, scrollLeft} = state.content
-
-    editorBounds = @presenter.boundingClientRect
-    gutterWidth = editorBounds.width - @presenter.contentFrameWidth
-
-    left = pixelPosition.left - scrollLeft + gutterWidth
-    top = pixelPosition.top + @presenter.lineHeight - scrollTop
-
-    rightDiff = left + editorBounds.left + itemWidth + contentMargin - @presenter.windowWidth
-    left -= rightDiff if rightDiff > 0
-
-    leftDiff = left + editorBounds.left + contentMargin
-    left -= leftDiff if leftDiff < 0
-
-    if top + editorBounds.top + itemHeight > @presenter.windowHeight
-      top -= itemHeight + @presenter.lineHeight
-
-    overlayNode.style.top = top + 'px'
-    overlayNode.style.left = left + 'px'
+    cachedOverlay.pixelPosition = pixelPosition
+    overlayNode.style.top = pixelPosition.top + 'px'
+    overlayNode.style.left = pixelPosition.left + 'px'

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -1,30 +1,86 @@
 module.exports =
 class OverlayManager
   constructor: (@presenter, @container) ->
-    @overlayNodesById = {}
+    @overlaysById = {}
 
   render: (state) ->
-    for decorationId, {pixelPosition, item} of state.content.overlays
-      @renderOverlay(state, decorationId, item, pixelPosition)
+    editorDimensionsHaveChanged = !@editorDimensionsAreEqual(state)
 
-    for id, overlayNode of @overlayNodesById
+    for decorationId, overlay of state.content.overlays
+      overlayHasChanged = not @overlayStateIsEqual(decorationId, overlay)
+      if editorDimensionsHaveChanged or overlayHasChanged
+        @renderOverlay(state, decorationId, overlay)
+        @cacheOverlayState(decorationId, overlay)
+
+    for id, {overlayNode} of @overlaysById
       unless state.content.overlays.hasOwnProperty(id)
-        delete @overlayNodesById[id]
+        delete @overlaysById[id]
         overlayNode.remove()
 
-    return
+    @cacheEditorDimensions(state)
 
-  renderOverlay: (state, decorationId, item, pixelPosition) ->
+  overlayStateIsEqual: (decorationId, overlay) ->
+    return false unless @overlaysById[decorationId]?
+    @overlaysById[decorationId].itemWidth is overlay.itemWidth and
+      @overlaysById[decorationId].itemHeight is overlay.itemHeight and
+      @overlaysById[decorationId].contentMargin is overlay.contentMargin and
+      @overlaysById[decorationId].pixelPosition?.top is overlay.pixelPosition?.top and
+      @overlaysById[decorationId].pixelPosition?.left is overlay.pixelPosition?.left
+
+  cacheOverlayState: (decorationId, overlay) ->
+    return unless @overlaysById[decorationId]?
+    @overlaysById[decorationId].itemWidth = overlay.itemWidth
+    @overlaysById[decorationId].itemHeight = overlay.itemHeight
+    @overlaysById[decorationId].contentMargin = overlay.contentMargin
+    @overlaysById[decorationId].pixelPosition = overlay.pixelPosition
+
+  cacheEditorDimensions: (state) ->
+    @cachedEditorDimensions =
+      lineHeight: @presenter.lineHeight
+      contentFrameWidth: @presenter.contentFrameWidth
+      editorTop: @presenter.boundingClientRect?.top
+      editorLeft: @presenter.boundingClientRect?.left
+      editorWidth: @presenter.boundingClientRect?.width
+      windowWidth: @presenter.windowWidth
+      windowHeight: @presenter.windowHeight
+      scrollTop: state.content.scrollTop
+      scrollLeft: state.content.scrollLeft
+
+  editorDimensionsAreEqual: (state) ->
+    return false unless @cachedEditorDimensions?
+    @cachedEditorDimensions.lineHeight is @presenter.lineHeight and
+      @cachedEditorDimensions.contentFrameWidth is @presenter.contentFrameWidth and
+      @cachedEditorDimensions.editorTop is @presenter.boundingClientRect?.top and
+      @cachedEditorDimensions.editorLeft is @presenter.boundingClientRect?.left and
+      @cachedEditorDimensions.editorWidth is @presenter.boundingClientRect?.width and
+      @cachedEditorDimensions.windowWidth is @presenter.windowWidth and
+      @cachedEditorDimensions.windowHeight is @presenter.windowHeight and
+      @cachedEditorDimensions.scrollTop is state.content.scrollTop and
+      @cachedEditorDimensions.scrollLeft is state.content.scrollLeft
+
+  measureOverlays: ->
+    for decorationId, {item} of @overlaysById
+      @measureOverlay(decorationId, item)
+
+  measureOverlay: (decorationId, item) ->
+    contentMargin = parseInt(getComputedStyle(item)['margin-left']) ? 0
+    @presenter.setOverlayDimensions(decorationId, item.offsetWidth, item.offsetHeight, contentMargin)
+
+  renderOverlay: (state, decorationId, {item, pixelPosition}) ->
     item = atom.views.getView(item)
-    unless overlayNode = @overlayNodesById[decorationId]
-      overlayNode = @overlayNodesById[decorationId] = document.createElement('atom-overlay')
+    overlay = @overlaysById[decorationId]
+    unless overlayNode = overlay?.overlayNode
+      overlayNode = document.createElement('atom-overlay')
       overlayNode.appendChild(item)
       @container.appendChild(overlayNode)
+      @overlaysById[decorationId] = overlay = {overlayNode, item}
 
-    itemWidth = item.offsetWidth
-    itemHeight = item.offsetHeight
-    contentMargin = parseInt(getComputedStyle(item)['margin-left']) ? 0
+    overlayDimensions = @presenter.getOverlayDimensions(decorationId)
+    unless overlayDimensions?.itemWidth?
+      @measureOverlay(decorationId, item)
+      overlayDimensions = @presenter.getOverlayDimensions(decorationId)
 
+    {itemWidth, itemHeight, contentMargin} = overlayDimensions
     {scrollTop, scrollLeft} = state.content
 
     editorBounds = @presenter.boundingClientRect

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -32,9 +32,12 @@ class OverlayManager
     cachedOverlay = @overlaysById[decorationId]
     unless overlayNode = cachedOverlay?.overlayNode
       overlayNode = document.createElement('atom-overlay')
-      overlayNode.appendChild(itemView)
       @container.appendChild(overlayNode)
       @overlaysById[decorationId] = cachedOverlay = {overlayNode, itemView}
+
+    # The same node may be used in more than one overlay. This steals the node
+    # back if it has been displayed in another overlay.
+    overlayNode.appendChild(itemView) if overlayNode.childNodes.length == 0
 
     cachedOverlay.pixelPosition = pixelPosition
     overlayNode.style.top = pixelPosition.top + 'px'

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -23,16 +23,23 @@ class OverlayManager
 
     itemWidth = item.offsetWidth
     itemHeight = item.offsetHeight
-
+    contentMargin = parseInt(getComputedStyle(item)['margin-left']) ? 0
 
     {scrollTop, scrollLeft} = state.content
 
-    left = pixelPosition.left
-    if left + itemWidth - scrollLeft > @presenter.contentFrameWidth and left - itemWidth >= scrollLeft
-      left -= itemWidth
+    editorBounds = @presenter.boundingClientRect
+    gutterWidth = editorBounds.width - @presenter.contentFrameWidth
 
-    top = pixelPosition.top + @presenter.lineHeight
-    if top + itemHeight - scrollTop > @presenter.height and top - itemHeight - @presenter.lineHeight >= scrollTop
+    left = pixelPosition.left - scrollLeft + gutterWidth
+    top = pixelPosition.top + @presenter.lineHeight - scrollTop
+
+    rightDiff = left + editorBounds.left + itemWidth + contentMargin - @presenter.windowWidth
+    left -= rightDiff if rightDiff > 0
+
+    leftDiff = left + editorBounds.left + contentMargin
+    left -= leftDiff if leftDiff < 0
+
+    if top + editorBounds.top + itemHeight > @presenter.windowHeight
       top -= itemHeight + @presenter.lineHeight
 
     overlayNode.style.top = top + 'px'

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -158,6 +158,7 @@ class TextEditorComponent
 
   readAfterUpdateSync: =>
     @linesComponent.measureCharactersInNewLines() if @isVisible() and not @newState.content.scrollingVertically
+    @overlayManager?.measureOverlays()
 
   mountGutterComponent: ->
     @gutterComponent = new GutterComponent({@editor, onMouseDown: @onGutterMouseDown})
@@ -189,6 +190,8 @@ class TextEditorComponent
     else unless @updateRequested
       @updateRequested = true
       atom.views.updateDocument =>
+        @editor.horribleUpdateMethod?()
+        @editor.horribleUpdateMethod = null
         @updateRequested = false
         @updateSync() if @editor.isAlive()
       atom.views.readDocument(@readAfterUpdateSync)
@@ -568,6 +571,7 @@ class TextEditorComponent
       @sampleBackgroundColors()
       @measureDimensions()
       @sampleFontStyling()
+      @overlayManager?.measureOverlays()
 
   checkForVisibilityChange: ->
     if @isVisible()
@@ -617,11 +621,7 @@ class TextEditorComponent
 
   measureWindowSize: ->
     return unless @mounted
-
-    width = window.innerWidth
-    height = window.innerHeight
-
-    @presenter.setWindowSize(width, height)
+    @presenter.setWindowSize(window.innerWidth, window.innerHeight)
 
   sampleFontStyling: =>
     oldFontSize = @fontSize

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -168,7 +168,8 @@ class TextEditorComponent
     @measureScrollbars() if @measureScrollbarsWhenShown
     @sampleFontStyling()
     @sampleBackgroundColors()
-    @measureHeightAndWidth()
+    @measureWindowSize()
+    @measureDimensions()
     @measureLineHeightAndDefaultCharWidth() if @measureLineHeightAndDefaultCharWidthWhenShown
     @remeasureCharacterWidths() if @remeasureCharacterWidthsWhenShown
     @editor.setVisible(true)
@@ -565,7 +566,7 @@ class TextEditorComponent
   pollDOM: =>
     unless @checkForVisibilityChange()
       @sampleBackgroundColors()
-      @measureHeightAndWidth()
+      @measureDimensions()
       @sampleFontStyling()
 
   checkForVisibilityChange: ->
@@ -584,13 +585,14 @@ class TextEditorComponent
     @heightAndWidthMeasurementRequested = true
     requestAnimationFrame =>
       @heightAndWidthMeasurementRequested = false
-      @measureHeightAndWidth()
+      @measureDimensions()
+      @measureWindowSize()
 
   # Measure explicitly-styled height and width and relay them to the model. If
   # these values aren't explicitly styled, we assume the editor is unconstrained
   # and use the scrollHeight / scrollWidth as its height and width in
   # calculations.
-  measureHeightAndWidth: ->
+  measureDimensions: ->
     return unless @mounted
 
     {position} = getComputedStyle(@hostElement)
@@ -610,6 +612,16 @@ class TextEditorComponent
     clientWidth -= paddingLeft
     if clientWidth > 0
       @presenter.setContentFrameWidth(clientWidth)
+
+    @presenter.setBoundingClientRect(@hostElement.getBoundingClientRect())
+
+  measureWindowSize: ->
+    return unless @mounted
+
+    width = window.innerWidth
+    height = window.innerHeight
+
+    @presenter.setWindowSize(width, height)
 
   sampleFontStyling: =>
     oldFontSize = @fontSize

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -190,8 +190,6 @@ class TextEditorComponent
     else unless @updateRequested
       @updateRequested = true
       atom.views.updateDocument =>
-        @editor.horribleUpdateMethod?()
-        @editor.horribleUpdateMethod = null
         @updateRequested = false
         @updateSync() if @editor.isAlive()
       atom.views.readDocument(@readAfterUpdateSync)

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -11,6 +11,7 @@ InputComponent = require './input-component'
 LinesComponent = require './lines-component'
 ScrollbarComponent = require './scrollbar-component'
 ScrollbarCornerComponent = require './scrollbar-corner-component'
+OverlayManager = require './overlay-manager'
 
 module.exports =
 class TextEditorComponent
@@ -56,8 +57,14 @@ class TextEditorComponent
     @domNode = document.createElement('div')
     if @useShadowDOM
       @domNode.classList.add('editor-contents--private')
+
+      insertionPoint = document.createElement('content')
+      insertionPoint.setAttribute('select', 'atom-overlay')
+      @domNode.appendChild(insertionPoint)
+      @overlayManager = new OverlayManager(@presenter, @hostElement)
     else
       @domNode.classList.add('editor-contents')
+      @overlayManager = new OverlayManager(@presenter, @domNode)
 
     @scrollViewNode = document.createElement('div')
     @scrollViewNode.classList.add('scroll-view')
@@ -139,6 +146,8 @@ class TextEditorComponent
     @horizontalScrollbarComponent.updateSync(@newState)
     @verticalScrollbarComponent.updateSync(@newState)
     @scrollbarCornerComponent.updateSync(@newState)
+
+    @overlayManager?.render(@newState)
 
     if @editor.isAlive()
       @updateParentViewFocusedClassIfNeeded()

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -657,6 +657,24 @@ class TextEditorPresenter
       @updateLinesState()
       @updateCursorsState() unless oldContentFrameWidth?
 
+  setBoundingClientRect: (boundingClientRect) ->
+    unless @clientRectsEqual(@boundingClientRect, boundingClientRect)
+      @boundingClientRect = boundingClientRect
+      @updateOverlaysState()
+
+  clientRectsEqual: (clientRectA, clientRectB) ->
+    clientRectA? and clientRectB? and
+      clientRectA.top is clientRectB.top and
+      clientRectA.left is clientRectB.left and
+      clientRectA.width is clientRectB.width and
+      clientRectA.height is clientRectB.height
+
+  setWindowSize: (width, height) ->
+    if @windowWidth isnt width or @windowHeight isnt height
+      @windowWidth = width
+      @windowHeight = height
+      @updateOverlaysState()
+
   setBackgroundColor: (backgroundColor) ->
     unless @backgroundColor is backgroundColor
       @backgroundColor = backgroundColor

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -1053,9 +1053,6 @@ class TextEditorPresenter
       overlayState.contentMargin = contentMargin
       @updateOverlaysState()
 
-  getOverlayDimensions: (decorationId) ->
-    @overlayDimensions[decorationId]
-
   observeCursor: (cursor) ->
     didChangePositionDisposable = cursor.onDidChangePosition =>
       @updateHiddenInputState() if cursor.isLastCursor()

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -333,8 +333,8 @@ class TextEditorPresenter
       {scrollTop, scrollLeft} = @state.content
       gutterWidth = @boundingClientRect.width - @contentFrameWidth
 
-      left = pixelPosition.left - scrollLeft + gutterWidth
       top = pixelPosition.top + @lineHeight - scrollTop
+      left = pixelPosition.left + gutterWidth - scrollLeft
 
       if overlayDimensions = @overlayDimensions[decoration.id]
         {itemWidth, itemHeight, contentMargin} = overlayDimensions
@@ -345,7 +345,7 @@ class TextEditorPresenter
         leftDiff = left + @boundingClientRect.left + contentMargin
         left -= leftDiff if leftDiff < 0
 
-        if top + @boundingClientRect.top + itemHeight > @windowHeight
+        if top + @boundingClientRect.top + itemHeight > @windowHeight and top - (itemHeight + @lineHeight) >= 0
           top -= itemHeight + @lineHeight
 
       pixelPosition.top = top

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -1012,6 +1012,20 @@ class TextEditorPresenter
 
       regions
 
+  setOverlayDimensions: (decorationId, itemWidth, itemHeight, contentMargin) ->
+    if overlayState = @state.content.overlays[decorationId]
+      dimensionsAreEqual = overlayState.itemWidth is itemWidth and
+        overlayState.itemHeight is itemHeight and
+        overlayState.contentMargin is contentMargin
+      unless dimensionsAreEqual
+        overlayState.itemWidth = itemWidth
+        overlayState.itemHeight = itemHeight
+        overlayState.contentMargin = contentMargin
+        @updateOverlaysState()
+
+  getOverlayDimensions: (decorationId) ->
+    @state.content.overlays[decorationId]
+
   observeCursor: (cursor) ->
     didChangePositionDisposable = cursor.onDidChangePosition =>
       @updateHiddenInputState() if cursor.isLastCursor()

--- a/src/view-registry.coffee
+++ b/src/view-registry.coffee
@@ -178,6 +178,9 @@ class ViewRegistry
       @documentPollers = @documentPollers.filter (poller) -> poller isnt fn
       @stopPollingDocument() if @documentPollers.length is 0
 
+  pollAfterNextUpdate: ->
+    @performDocumentPollAfterUpdate = true
+
   clearDocumentRequests: ->
     @documentReaders = []
     @documentWriters = []
@@ -194,6 +197,7 @@ class ViewRegistry
     writer() while writer = @documentWriters.shift()
     reader() while reader = @documentReaders.shift()
     @performDocumentPoll() if @performDocumentPollAfterUpdate
+    @performDocumentPollAfterUpdate = false
 
   startPollingDocument: ->
     @pollIntervalHandle = window.setInterval(@performDocumentPoll, @documentPollingInterval)
@@ -205,6 +209,5 @@ class ViewRegistry
     if @documentUpdateRequested
       @performDocumentPollAfterUpdate = true
     else
-      @performDocumentPollAfterUpdate = false
       poller() for poller in @documentPollers
       return

--- a/static/panes.less
+++ b/static/panes.less
@@ -24,7 +24,7 @@ atom-pane-container {
     display: -webkit-flex;
     -webkit-flex: 1;
     -webkit-flex-direction: column;
-    overflow: hidden;
+    overflow: visible;
 
     .item-views {
       -webkit-flex: 1;

--- a/static/text-editor-shadow.less
+++ b/static/text-editor-shadow.less
@@ -9,7 +9,6 @@
 
 .editor-contents--private {
   width: 100%;
-  overflow: hidden;
   cursor: text;
   display: -webkit-flex;
   -webkit-user-select: none;


### PR DESCRIPTION
Here is an overlay outside the editor bounds with a `-250px` `left-margin`:

![screen shot 2015-03-31 at 7 13 04 pm](https://cloud.githubusercontent.com/assets/69169/6933331/7e001cfe-d7da-11e4-9b83-4b810b9894fb.png)

Here is autocomplete using the new overlay. Note how it is up against the window, and it is shifted horizontally and flipped vertically to keep within the window.

![autocomplete-recompute-better](https://cloud.githubusercontent.com/assets/69169/6933332/8b437e92-d7da-11e4-8e81-8485c5cc1968.gif)
### Notes
- The overlay parent is the `atom-text-editor`. The editor and containing pane are now both `overflow: visible`. This allows the pane item the flexibility to have things jump out if necessary.
- When bumping up against the left or right edge of the window, the overlay will _shift_ horizontally, not flip. This always keeps it in the window frame. Shifting felt more natural than flipping.
- When bumping up against the bottom edge of the window, the overlay will flip. It will not necessarily be always visible in the window frame (due to scrolling), but does its best with the flip.
- A `left-margin` is supported on the overlay. It will take the margin into account when doing the window bounds-checking. Note the blue box in the first image has a `-250px` left margin.
- In the future, it would be nice to allow configuration of the shift or flip, or bounds checking at all, but for right now, keeping it simple.
### TODO
- [x] Make it work
- [x] Clean up the overlay caching :art:
- [x] Move specs to the presenter
- [x] All specs passing

cc @nathansobo @bolinfest 
