### PR TITLE
Export File and Directory through require('atom')

### DIFF
--- a/exports/atom.coffee
+++ b/exports/atom.coffee
@@ -1,5 +1,6 @@
 TextBuffer = require 'text-buffer'
 {Point, Range} = TextBuffer
+{File, Directory} = require 'pathwatcher'
 {Emitter, Disposable, CompositeDisposable} = require 'event-kit'
 {deprecate} = require 'grim'
 
@@ -11,6 +12,8 @@ module.exports =
   TextBuffer: TextBuffer
   Point: Point
   Range: Range
+  File: File
+  Directory: Directory
   Emitter: Emitter
   Disposable: Disposable
   CompositeDisposable: CompositeDisposable


### PR DESCRIPTION
This exports the pathwatcher File and Directory classes through require('atom').

I think this makes sense since those classes are already publicly documented as part of the Atom platform API, but currently there's no way for a package to require and instantiate them. The alternative is to add the pathwatcher module to my own package, but this seems redundant since File and Directory are already documented as part of the Atom platform. Also since pathwatcher is a native package it's even more problematic then it would be with a normal package.
