### PR TITLE
Clean up npm temp folders on CI

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -69,7 +69,7 @@ function removeTempFolders() {
     });
 
     if (deletedFolders > 0)
-      console.log("Deleted " + deletedFolder + " npm folders from temp directory");
+      console.log("Deleted " + deletedFolders + " npm folders from temp directory");
   } catch (error) {
     console.error(error.message);
     process.exit(1);

--- a/script/cibuild
+++ b/script/cibuild
@@ -46,8 +46,39 @@ function removeNodeModules() {
   }
 }
 
+function removeTempFolders() {
+  var fsPlus;
+  try {
+    fsPlus = require('fs-plus');
+  } catch (error) {
+    return;
+  }
+
+  var temp = require('os').tmpdir();
+  if (!fsPlus.isDirectorySync(temp))
+    return;
+
+  var deletedFolders = 0;
+
+  try {
+    fsPlus.readdirSync(temp).filter(function(folderName) {
+      return folderName.indexOf('npm-') === 0;
+    }).forEach(function(folderName) {
+      fsPlus.removeSync(path.join(temp, folderName));
+      deletedFolders++;
+    });
+
+    if (deletedFolders > 0)
+      console.log("Deleted " + deletedFolder + " npm folders from temp directory");
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
 readEnvironmentVariables();
 removeNodeModules();
+removeTempFolders();
 cp.safeExec.bind(global, 'npm install npm --loglevel error', {cwd: path.resolve(__dirname, '..', 'build')}, function() {
   cp.safeExec.bind(global, 'node script/bootstrap', function(error) {
     if (error)


### PR DESCRIPTION
Folders of the style `npm-10200-49dae08c` are filling up our CI machines so delete them all each time a CI build runs since they are leftovers from previous builds and are never reused or needed again.
