### PR TITLE
Add styleguide for specs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ For more information on how to work with Atom's official packages, see
   [JavaScript](https://github.com/styleguide/javascript),
   and [CSS](https://github.com/styleguide/css) styleguides.
 * Include thoughtfully-worded, well-structured
-  [Jasmine](http://jasmine.github.io/) specs in the `./spec` folder. Run them using `apm test`.
+  [Jasmine](http://jasmine.github.io/) specs in the `./spec` folder. Run them using `apm test`. See the [Specs Styleguide](#specs-styleguide) below.
 * Document new code based on the
   [Documentation Styleguide](#documentation-styleguide)
 * End files with a newline.
@@ -107,6 +107,24 @@ For more information on how to work with Atom's official packages, see
 * Use `slice()` to copy an array
 * Add an explicit `return` when your function ends with a `for`/`while` loop and
   you don't want it to return a collected array.
+
+## Specs Styleguide
+
+- Include thoughtfully-worded, well-structured
+  [Jasmine](http://jasmine.github.io/) specs in the `./spec` folder.
+- treat `describe` as a noun or situation.
+- trea `it` as a statement about state or how an operation changes state.
+
+### Example
+
+```coffee
+describe 'a dog'
+ it 'barks'
+ # spec here
+ describe 'when the dog is happy'
+  it 'wags its tail'
+  # spec here
+```
 
 ## Documentation Styleguide
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,11 +118,11 @@ For more information on how to work with Atom's official packages, see
 ### Example
 
 ```coffee
-describe 'a dog'
- it 'barks'
+describe 'a dog', ->
+ it 'barks', ->
  # spec here
- describe 'when the dog is happy'
-  it 'wags its tail'
+ describe 'when the dog is happy', ->
+  it 'wags its tail', ->
   # spec here
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ For more information on how to work with Atom's official packages, see
 - Include thoughtfully-worded, well-structured
   [Jasmine](http://jasmine.github.io/) specs in the `./spec` folder.
 - treat `describe` as a noun or situation.
-- trea `it` as a statement about state or how an operation changes state.
+- treat `it` as a statement about state or how an operation changes state.
 
 ### Example
 


### PR DESCRIPTION
A wee PR here to add a section on spec writing. Coming from a suggestion from @nathansobo [here](https://github.com/atom/markdown-preview/pull/220#issuecomment-84234793).

Nathan, I tweaked the orginal dog scenario to be a happier one :dog: :grinning: 

[r E n D e R e D](https://github.com/atom/atom/blob/0f43b246b4ef5c1759c81440e8b0b2abbf9230d3/CONTRIBUTING.md)
