### PR TITLE
Always mutate selections in order

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2730,6 +2730,20 @@ describe "TextEditor", ->
 
             """
 
+        describe "when many selections get added in shuffle order", ->
+          it "cuts them in order", ->
+            editor.setSelectedBufferRanges([
+              [[2,8], [2, 13]]
+              [[0,4], [0,13]],
+              [[1,6], [1, 10]],
+            ])
+            editor.cutSelectedText()
+            expect(atom.clipboard.read()).toEqual """
+              quicksort
+              sort
+              items
+            """
+
       describe ".cutToEndOfLine()", ->
         describe "when soft wrap is on", ->
           it "cuts up to the end of the line", ->
@@ -2900,8 +2914,12 @@ describe "TextEditor", ->
             editor.setSelectedBufferRanges([[[0, 4], [0, 13]], [[1, 6], [1, 10]]])
             editor.copySelectedText()
 
-          it "pastes each selection separately into the buffer", ->
-            editor.copySelectedText()
+          it "pastes each selection in order separately into the buffer", ->
+            editor.setSelectedBufferRanges([
+              [[1, 6], [1, 10]]
+              [[0, 4], [0, 13]],
+            ])
+
             editor.moveRight()
             editor.insertText("_")
             editor.pasteText()

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2792,6 +2792,20 @@ describe "TextEditor", ->
               [[5, 8], [5, 8]]
             ])
 
+        describe "when many selections get added in shuffle order", ->
+          it "copies them in order", ->
+            editor.setSelectedBufferRanges([
+              [[2,8], [2, 13]]
+              [[0,4], [0,13]],
+              [[1,6], [1, 10]],
+            ])
+            editor.copySelectedText()
+            expect(atom.clipboard.read()).toEqual """
+              quicksort
+              sort
+              items
+            """
+
       describe ".pasteText()", ->
         copyText = (text, {startColumn, textEditor}={}) ->
           startColumn ?= 0

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2621,7 +2621,7 @@ class TextEditor extends Model
   # Essential: For each selection, copy the selected text.
   copySelectedText: ->
     maintainClipboard = false
-    for selection in @getSelections()
+    for selection in @getSelectionsOrderedByBufferPosition()
       if selection.isEmpty()
         previousRange = selection.getBufferRange()
         selection.selectLine()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -843,7 +843,7 @@ class TextEditor extends Model
   mutateSelectedText: (fn) ->
     @mergeIntersectingSelections =>
       @transact =>
-        fn(selection, index) for selection, index in @getSelections()
+        fn(selection, index) for selection, index in @getSelectionsOrderedByBufferPosition()
 
   # Move lines intersection the most recent selection up by one row in screen
   # coordinates.


### PR DESCRIPTION
Closes #6190 

When copying, cutting, pasting and mutating selections in general, we were accessing selections as they were added to the editor. This caused unexpected behaviors, especially when dealing with multi-line selections.

With this pull-request we now compute all the aforementioned operations ordering the selections first. This is also consistent with how Sublime Text works :sparkles:

/cc: @nathansobo 
