### PR TITLE
Added an option to disable keymaps for packages.

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -357,6 +357,26 @@ describe "PackageManager", ->
             expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-n', target: element1[0])[0].command).toBe 'keymap-2'
             expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-y', target: element3[0])).toHaveLength 0
 
+      describe "when the package is listed in the config 'core.packagesWithKeymapsDisabled'", ->
+        it "doesn't load the keymaps", ->
+          atom.config.set("config.packagesWithKeymapsDisabled", ["package-with-keymaps"])
+
+          element1 = $$ -> @div class: 'test-1'
+          element2 = $$ -> @div class: 'test-2'
+          element3 = $$ -> @div class: 'test-3'
+
+          expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element1[0])).toHaveLength 0
+          expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element2[0])).toHaveLength 0
+          expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element3[0])).toHaveLength 0
+
+          waitsForPromise ->
+            atom.packages.activatePackage("package-with-keymaps")
+
+          runs ->
+            expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element1[0])).toHaveLength 0
+            expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element2[0])).toHaveLength 0
+            expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element3[0])).toHaveLength 0
+
       describe "when the keymap file is empty", ->
         it "does not throw an error on activation", ->
           waitsForPromise ->

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -26,6 +26,13 @@ module.exports =
         default: []
         items:
           type: 'string'
+      packagesWithKeymapsDisabled:
+        type: 'array'
+        default: []
+        title: "Disable Keymaps for Packages"
+        description: "Used to disable keymaps for individual packages."
+        items:
+          type: 'string'
       themes:
         type: 'array'
         default: ['one-dark-ui', 'one-dark-syntax']

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -222,7 +222,9 @@ class Package
     return
 
   loadKeymaps: ->
-    if @bundledPackage and packagesCache[@name]?
+    if _.contains(atom.config.get("core.packagesWithKeymapsDisabled") ? [], @name)
+      @keymaps = []
+    else if @bundledPackage and packagesCache[@name]?
       @keymaps = (["#{atom.packages.resourcePath}#{path.sep}#{keymapPath}", keymapObject] for keymapPath, keymapObject of packagesCache[@name].keymaps)
     else
       @keymaps = @getKeymapPaths().map (keymapPath) -> [keymapPath, CSON.readFileSync(keymapPath) ? {}]


### PR DESCRIPTION
Introduces a config entry called packagesWithKeymapsDisabled that allows users to disable specific packages' keymaps.

![atom-disable-keymaps-for-packages](https://cloud.githubusercontent.com/assets/547186/6989279/685b23f0-da62-11e4-8038-6e74e4299f2c.gif)
