### PR TITLE
Don't use theorist when in 1.0 API preview mode

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "async": "~0.2.9",
-    "donna": "1.0.9",
+    "donna": "1.0.10",
     "formidable": "~1.0.14",
     "fs-plus": "2.x",
     "github-releases": "~0.2.0",

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -252,10 +252,10 @@ class DisplayBuffer extends Model
   getScrollTop: -> @scrollTop
   setScrollTop: (scrollTop) ->
     scrollTop = Math.round(Math.max(0, Math.min(@getMaxScrollTop(), scrollTop)))
-    return if scrollTop is @scrollTop
-
-    @scrollTop = scrollTop
-    @emitter.emit 'did-change-scroll-top', @scrollTop
+    unless scrollTop is @scrollTop
+      @scrollTop = scrollTop
+      @emitter.emit 'did-change-scroll-top', @scrollTop
+    @scrollTop
 
   getMaxScrollTop: ->
     @getScrollHeight() - @getClientHeight()
@@ -268,10 +268,10 @@ class DisplayBuffer extends Model
   getScrollLeft: -> @scrollLeft
   setScrollLeft: (scrollLeft) ->
     scrollLeft = Math.round(Math.max(0, Math.min(@getScrollWidth() - @getClientWidth(), scrollLeft)))
-    return if scrollLeft is @scrollLeft
-
-    @scrollLeft = scrollLeft
-    @emitter.emit 'did-change-scroll-left', @scrollLeft
+    unless scrollLeft is @scrollLeft
+      @scrollLeft = scrollLeft
+      @emitter.emit 'did-change-scroll-left', @scrollLeft
+    @scrollLeft
 
   getMaxScrollLeft: ->
     @getScrollWidth() - @getClientWidth()

--- a/src/pane-axis.coffee
+++ b/src/pane-axis.coffee
@@ -1,7 +1,7 @@
-{Model} = require 'theorist'
 {Emitter, CompositeDisposable} = require 'event-kit'
 {flatten} = require 'underscore-plus'
 Serializable = require 'serializable'
+Model = require './model'
 
 module.exports =
 class PaneAxis extends Model

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -24,6 +24,9 @@ class PaneContainer extends Model
   constructor: (params) ->
     super
 
+    unless Grim.includeDeprecatedAPIs
+      @activePane = params?.activePane
+
     @emitter = new Emitter
     @subscriptions = new CompositeDisposable
 
@@ -238,6 +241,5 @@ if Grim.includeDeprecatedAPIs
     @$activePane
       .switch((activePane) -> activePane?.$activeItem)
       .distinctUntilChanged()
-
 else
   PaneContainer::activePane = null

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -1,7 +1,8 @@
 {find, flatten} = require 'underscore-plus'
-{Model} = require 'theorist'
+Grim = require 'grim'
 {Emitter, CompositeDisposable} = require 'event-kit'
 Serializable = require 'serializable'
+Model = require './model'
 Pane = require './pane'
 PaneElement = require './pane-element'
 PaneContainerElement = require './pane-container-element'
@@ -18,15 +19,7 @@ class PaneContainer extends Model
 
   @version: 1
 
-  @properties
-    activePane: null
-
   root: null
-
-  @behavior 'activePaneItem', ->
-    @$activePane
-      .switch((activePane) -> activePane?.$activeItem)
-      .distinctUntilChanged()
 
   constructor: (params) ->
     super
@@ -236,3 +229,15 @@ class PaneContainer extends Model
 
   removedPaneItem: (item) ->
     @itemRegistry.removeItem(item)
+
+if Grim.includeDeprecatedAPIs
+  PaneContainer.properties
+    activePane: null
+
+  PaneContainer.behavior 'activePaneItem', ->
+    @$activePane
+      .switch((activePane) -> activePane?.$activeItem)
+      .distinctUntilChanged()
+
+else
+  PaneContainer::activePane = null

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -241,5 +241,3 @@ if Grim.includeDeprecatedAPIs
     @$activePane
       .switch((activePane) -> activePane?.$activeItem)
       .distinctUntilChanged()
-else
-  PaneContainer::activePane = null

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -15,22 +15,12 @@ class Pane extends Model
   atom.deserializers.add(this)
   Serializable.includeInto(this)
 
-  @properties
-    container: undefined
-    activeItem: undefined
-    focused: false
-
-  # Public: Only one pane is considered *active* at a time. A pane is activated
-  # when it is focused, and when focus returns to the pane container after
-  # moving to another element such as a panel, it returns to the active pane.
-  @behavior 'active', ->
-    @$container
-      .switch((container) -> container?.$activePane)
-      .map((activePane) => activePane is this)
-      .distinctUntilChanged()
-
   constructor: (params) ->
     super
+
+    unless Grim.includeDeprecatedAPIs
+      @container = params?.container
+      @activeItem = params?.activeItem
 
     @emitter = new Emitter
     @itemSubscriptions = new WeakMap
@@ -313,7 +303,8 @@ class Pane extends Model
 
     if typeof item.onDidDestroy is 'function'
       @itemSubscriptions.set item, item.onDidDestroy => @removeItem(item, true)
-    else if typeof item.on is 'function'
+    else if Grim.includeDeprecations and typeof item.on is 'function'
+      deprecate 'If you would like your pane item to support removal when destroyed behavior, please implement a ::onDidDestroy() method. ::on methods for items are no longer supported. If not, ignore this message.'
       @subscribe item, 'destroyed', => @removeItem(item, true)
 
     @items.splice(index, 0, item)
@@ -340,7 +331,7 @@ class Pane extends Model
     index = @items.indexOf(item)
     return if index is -1
 
-    if typeof item.on is 'function'
+    if Grim.includeDeprecations and typeof item.on is 'function'
       @unsubscribe item
     @unsubscribeFromItem(item)
 
@@ -661,6 +652,17 @@ class Pane extends Model
       throw error
 
 if Grim.includeDeprecatedAPIs
+  Pane.properties
+    container: undefined
+    activeItem: undefined
+    focused: false
+
+  Pane.behavior 'active', ->
+    @$container
+      .switch((container) -> container?.$activePane)
+      .map((activePane) => activePane is this)
+      .distinctUntilChanged()
+
   Pane::on = (eventName) ->
     switch eventName
       when 'activated'
@@ -701,3 +703,7 @@ if Grim.includeDeprecatedAPIs
   Pane::activateItemForUri = (uri) ->
     Grim.deprecate("Use `::activateItemForURI` instead.")
     @activateItemForURI(uri)
+else
+  Pane::container = undefined
+  Pane::activeItem = undefined
+  Pane::focused = undefined

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -303,8 +303,8 @@ class Pane extends Model
 
     if typeof item.onDidDestroy is 'function'
       @itemSubscriptions.set item, item.onDidDestroy => @removeItem(item, true)
-    else if Grim.includeDeprecations and typeof item.on is 'function'
-      deprecate 'If you would like your pane item to support removal when destroyed behavior, please implement a ::onDidDestroy() method. ::on methods for items are no longer supported. If not, ignore this message.'
+    else if Grim.includeDeprecatedAPIs and typeof item.on is 'function'
+      Grim.deprecate 'If you would like your pane item to support removal when destroyed behavior, please implement a ::onDidDestroy() method. ::on methods for items are no longer supported. If not, ignore this message.'
       @subscribe item, 'destroyed', => @removeItem(item, true)
 
     @items.splice(index, 0, item)
@@ -331,7 +331,7 @@ class Pane extends Model
     index = @items.indexOf(item)
     return if index is -1
 
-    if Grim.includeDeprecations and typeof item.on is 'function'
+    if Grim.includeDeprecatedAPIs and typeof item.on is 'function'
       @unsubscribe item
     @unsubscribeFromItem(item)
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -304,7 +304,6 @@ class Pane extends Model
     if typeof item.onDidDestroy is 'function'
       @itemSubscriptions.set item, item.onDidDestroy => @removeItem(item, true)
     else if Grim.includeDeprecatedAPIs and typeof item.on is 'function'
-      Grim.deprecate 'If you would like your pane item to support removal when destroyed behavior, please implement a ::onDidDestroy() method. ::on methods for items are no longer supported. If not, ignore this message.'
       @subscribe item, 'destroyed', => @removeItem(item, true)
 
     @items.splice(index, 0, item)

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -49,7 +49,7 @@ class Pane extends Model
     params.activeItem = find params.items, (item) ->
       if typeof item.getURI is 'function'
         itemURI = item.getURI()
-      else if typeof item.getUri is 'function'
+      else if Grim.includeDeprecatedAPIs and typeof item.getUri is 'function'
         itemURI = item.getUri()
 
       itemURI is activeItemURI

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -1,8 +1,8 @@
 {find, compact, extend, last} = require 'underscore-plus'
-{Model} = require 'theorist'
 {Emitter} = require 'event-kit'
 Serializable = require 'serializable'
 Grim = require 'grim'
+Model = require './model'
 PaneAxis = require './pane-axis'
 TextEditor = require './text-editor'
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -74,10 +74,6 @@ class TextEditor extends Model
     'autoDecreaseIndentForBufferRow', 'toggleLineCommentForBufferRow', 'toggleLineCommentsForBufferRows',
     toProperty: 'languageMode'
 
-  @delegatesProperties '$lineHeightInPixels', '$defaultCharWidth', '$height', '$width',
-    '$verticalScrollbarWidth', '$horizontalScrollbarHeight', '$scrollTop', '$scrollLeft',
-    toProperty: 'displayBuffer'
-
   constructor: ({@softTabs, initialLine, initialColumn, tabLength, softWrapped, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini, @placeholderText, @gutterVisible}) ->
     super
 
@@ -108,10 +104,10 @@ class TextEditor extends Model
 
     @setEncoding(atom.config.get('core.fileEncoding', scope: @getRootScopeDescriptor()))
 
-    @subscribe @$scrollTop, (scrollTop) =>
+    @subscribe @displayBuffer.$scrollTop, (scrollTop) =>
       @emit 'scroll-top-changed', scrollTop if includeDeprecatedAPIs
       @emitter.emit 'did-change-scroll-top', scrollTop
-    @subscribe @$scrollLeft, (scrollLeft) =>
+    @subscribe @displayBuffer.$scrollLeft, (scrollLeft) =>
       @emit 'scroll-left-changed', scrollLeft if includeDeprecatedAPIs
       @emitter.emit 'did-change-scroll-left', scrollLeft
 
@@ -2837,6 +2833,10 @@ class TextEditor extends Model
   logScreenLines: (start, end) -> @displayBuffer.logLines(start, end)
 
 if includeDeprecatedAPIs
+  TextEditor.delegatesProperties '$lineHeightInPixels', '$defaultCharWidth', '$height', '$width',
+    '$verticalScrollbarWidth', '$horizontalScrollbarHeight', '$scrollTop', '$scrollLeft',
+    toProperty: 'displayBuffer'
+
   TextEditor::getViewClass = ->
     require './text-editor-view'
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -78,6 +78,7 @@ class TextEditor extends Model
     super
 
     @emitter = new Emitter
+    @disposables = new CompositeDisposable
     @cursors = []
     @selections = []
 
@@ -104,10 +105,11 @@ class TextEditor extends Model
 
     @setEncoding(atom.config.get('core.fileEncoding', scope: @getRootScopeDescriptor()))
 
-    @subscribe @displayBuffer.$scrollTop, (scrollTop) =>
+    @disposables.add @displayBuffer.onDidChangeScrollTop (scrollTop) =>
       @emit 'scroll-top-changed', scrollTop if includeDeprecatedAPIs
       @emitter.emit 'did-change-scroll-top', scrollTop
-    @subscribe @displayBuffer.$scrollLeft, (scrollLeft) =>
+
+    @disposables.add @displayBuffer.onDidChangeScrollLeft (scrollLeft) =>
       @emit 'scroll-left-changed', scrollLeft if includeDeprecatedAPIs
       @emitter.emit 'did-change-scroll-left', scrollLeft
 
@@ -173,6 +175,7 @@ class TextEditor extends Model
 
   destroyed: ->
     @unsubscribe()
+    @disposables.dispose()
     @scopedConfigSubscriptions.dispose()
     selection.destroy() for selection in @getSelections()
     @buffer.release()

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -1,8 +1,8 @@
 _ = require 'underscore-plus'
-{Model} = require 'theorist'
 {CompositeDisposable, Emitter} = require 'event-kit'
 {Point, Range} = require 'text-buffer'
 Serializable = require 'serializable'
+Model = require './model'
 TokenizedLine = require './tokenized-line'
 Token = require './token'
 ScopeDescriptor = require './scope-descriptor'
@@ -12,11 +12,10 @@ module.exports =
 class TokenizedBuffer extends Model
   Serializable.includeInto(this)
 
-  @property 'tabLength'
-
   grammar: null
   currentGrammarScore: null
   buffer: null
+  tabLength: null
   tokenizedLines: null
   chunkSize: 50
   invalidRows: null

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -2,7 +2,6 @@
 _ = require 'underscore-plus'
 path = require 'path'
 {join} = path
-{Model} = require 'theorist'
 Q = require 'q'
 Serializable = require 'serializable'
 {Emitter, Disposable, CompositeDisposable} = require 'event-kit'

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -9,6 +9,7 @@ Serializable = require 'serializable'
 Grim = require 'grim'
 fs = require 'fs-plus'
 StackTraceParser = require 'stacktrace-parser'
+Model = require './model'
 TextEditor = require './text-editor'
 PaneContainer = require './pane-container'
 Pane = require './pane'
@@ -33,13 +34,13 @@ class Workspace extends Model
   atom.deserializers.add(this)
   Serializable.includeInto(this)
 
-  @properties
-    paneContainer: null
-    fullScreen: false
-    destroyedItemURIs: -> []
-
   constructor: (params) ->
     super
+
+    unless Grim.includeDeprecatedAPIs
+      @paneContainer = params?.paneContainer
+      @fullScreen = params?.fullScreen ? false
+      @destroyedItemURIs = params?.destroyedItemURIs ? []
 
     @emitter = new Emitter
     @openers = []
@@ -892,6 +893,11 @@ class Workspace extends Model
     deferred.promise
 
 if includeDeprecatedAPIs
+  Workspace.properties
+    paneContainer: null
+    fullScreen: false
+    destroyedItemURIs: -> []
+
   Object.defineProperty Workspace::, 'activePaneItem',
     get: ->
       Grim.deprecate "Use ::getActivePaneItem() instead of the ::activePaneItem property"


### PR DESCRIPTION
This migrates the classes that `extend Model` to use a new simpler version that has incrementing `id` support built-in but doesn't pull in the full models from the theorist library.

This ensures model elements such as `TextEditor` won't have emissary mixins included when in 1.0 API preview model.

This is a follow-on pull request to #6103 
