### PR TITLE
Add workspace element command for 'add root folder'

### DIFF
--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -180,3 +180,19 @@ describe "the `atom` global", ->
       it "does not open an empty buffer", ->
         atom.openInitialEmptyEditorIfNecessary()
         expect(atom.workspace.open).not.toHaveBeenCalled()
+
+  describe "adding a root folder", ->
+    it "adds a second path to the project", ->
+      initialPaths = atom.project.getPaths()
+      tempDirectory = temp.mkdirSync("a-new-directory")
+      spyOn(atom, "pickFolder").andCallFake (callback) ->
+        callback([tempDirectory])
+      atom.addRootFolder()
+      expect(atom.project.getPaths()).toEqual(initialPaths.concat([tempDirectory]))
+
+    it "does nothing if the user dismisses the file picker", ->
+      initialPaths = atom.project.getPaths()
+      tempDirectory = temp.mkdirSync("a-new-directory")
+      spyOn(atom, "pickFolder").andCallFake (callback) -> callback(null)
+      atom.addRootFolder()
+      expect(atom.project.getPaths()).toEqual(initialPaths)

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -412,10 +412,11 @@ class Atom extends Model
   open: (options) ->
     ipc.send('open', options)
 
-  # Extended: Show the native dialog to prompt the user to select a folder.
+  # Extended: Prompt the user to select one or more folders.
   #
-  # * `callback` A {Function} to call once the user has selected a folder.
-  #   * `path` {String} the path to the folder the user selected.
+  # * `callback` A {Function} to call once the user has confirmed the selection.
+  #   * `paths` An {Array} of {String} paths that the user selected, or `null`
+  #     if the user dismissed the dialog.
   pickFolder: (callback) ->
     responseChannel = "atom-pick-folder-response"
     ipc.on responseChannel, (path) ->
@@ -772,6 +773,10 @@ class Atom extends Model
 
   setRepresentedFilename: (filename) ->
     ipc.send('call-window-method', 'setRepresentedFilename', filename)
+
+  addRootFolder: ->
+    @pickFolder (selectedPaths = []) =>
+      @project.addPath(selectedPath) for selectedPath in selectedPaths
 
   showSaveDialog: (callback) ->
     callback(showSaveDialogSync())

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -138,6 +138,7 @@ atom.commands.add 'atom-workspace',
   'application:open-safe': -> ipc.send('command', 'application:open-safe')
   'application:open-api-preview': -> ipc.send('command', 'application:open-api-preview')
   'application:open-dev-api-preview': -> ipc.send('command', 'application:open-dev-api-preview')
+  'application:add-root-folder': -> atom.addRootFolder()
   'application:minimize': -> ipc.send('command', 'application:minimize')
   'application:zoom': -> ipc.send('command', 'application:zoom')
   'application:bring-all-windows-to-front': -> ipc.send('command', 'application:bring-all-windows-to-front')


### PR DESCRIPTION
I think this will make it easier for people to add root folders. Now they can trigger the command (`Application: Add Root Folder`) anywhere within the workpace, not just on the tree view. This doesn't add any key-binding to the command.
