### PR TITLE
Report core deprecations in specs

### DIFF
--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -221,7 +221,7 @@ describe "Project", ->
     beforeEach ->
       absolutePath = require.resolve('./fixtures/dir/a')
       newBufferHandler = jasmine.createSpy('newBufferHandler')
-      atom.project.on 'buffer-created', newBufferHandler
+      atom.project.onDidAddBuffer(newBufferHandler)
 
     describe "when given an absolute path that isn't currently open", ->
       it "returns a new edit session for the given path and emits 'buffer-created'", ->

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -502,7 +502,11 @@ describe "Project", ->
 
   describe ".eachBuffer(callback)", ->
     beforeEach ->
+      jasmine.snapshotDeprecations()
       atom.project.bufferForPathSync('a')
+
+    afterEach ->
+      jasmine.restoreDeprecationsSnapshot()
 
     it "invokes the callback for existing buffer", ->
       count = 0

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -72,7 +72,6 @@ if specDirectory
 isCoreSpec = specDirectory == fs.realpathSync(__dirname)
 
 beforeEach ->
-  Grim.clearDeprecations() if isCoreSpec
   $.fx.off = true
   documentTitle = null
   projectPath = specProjectPath ? path.join(@specDirectory, 'fixtures')

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -728,7 +728,7 @@ describe "TextEditorComponent", ->
       expect(cursorNodes[0].style['-webkit-transform']).toBe "translate(#{10 * charWidth}px, #{4 * lineHeightInPixels}px)"
       expect(cursorNodes[1].style['-webkit-transform']).toBe "translate(#{11 * charWidth}px, #{8 * lineHeightInPixels}px)"
 
-      wrapperView.on 'cursor:moved', cursorMovedListener = jasmine.createSpy('cursorMovedListener')
+      editor.onDidChangeCursorPosition cursorMovedListener = jasmine.createSpy('cursorMovedListener')
       cursor3.setScreenPosition([4, 11], autoscroll: false)
       nextAnimationFrame()
       expect(cursorNodes[0].style['-webkit-transform']).toBe "translate(#{11 * charWidth}px, #{4 * lineHeightInPixels}px)"


### PR DESCRIPTION
Core spec deprecations are clear on before each run meaning they aren't reported to the build output and the build doesn't fail when they are hit.

This pull request is an attempt to rid the core specs of deprecated calls and fail the build going forward whenever deprecations are hit in core specs.
