### PR TITLE
Change in-app menu for reporting issues to point to the CONTRIBUTING guide section on submitting issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,14 @@
 
 The following is a set of guidelines for contributing to Atom and its packages,
 which are hosted in the [Atom Organization](https://github.com/atom) on GitHub.
-If you're unsure which package is causing your problem or if you're having an
-issue with Atom core, please open an issue on the [main atom repository](https://github.com/atom/atom/issues).
 These are just guidelines, not rules, use your best judgment and feel free to
 propose changes to this document in a pull request.
 
 ## Submitting Issues
 
+* You can create an issue [here](https://github.com/atom/atom/issues/new), but
+  before doing that please read the notes below on debugging and submitting issues,
+  and include as many details as possible with your report.
 * Check the [debugging guide](https://atom.io/docs/latest/hacking-atom-debugging) for tips
   on debugging. You might be able to find the cause of the problem and fix
   things yourself.
@@ -24,7 +25,8 @@ propose changes to this document in a pull request.
   will be logged. If you can reproduce the error, use this approach to get the
   full stack trace and include it in the issue.
 * On Mac, check Console.app for stack traces to include if reporting a crash.
-* Perform a cursory search to see if a similar issue has already been submitted.
+* Perform a [cursory search](https://github.com/issues?q=+is%3Aissue+user%3Aatom)
+  to see if a similar issue has already been submitted.
 * Please setup a [profile picture](https://help.github.com/articles/how-do-i-set-up-my-profile-picture)
   to make yourself recognizable and so we can all get to know each other better.
 
@@ -37,6 +39,10 @@ many packages and themes that are stored in other repos under the
 [find-and-replace](https://github.com/atom/find-and-replace),
 [language-javascript](https://github.com/atom/language-javascript), and
 [atom-light-ui](https://github.com/atom/atom-light-ui).
+
+If your issue is related to a specific package, open an issue on that package's
+issue tracker. If you're unsure which package is causing your problem or if
+you're having an issue with Atom core, open an issue on this repository.
 
 For more information on how to work with Atom's official packages, see
 [Contributing to Atom Packages](https://github.com/atom/atom/blob/master/docs/contributing-to-packages.md)

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -169,7 +169,7 @@ class AtomApplication
     @on 'application:open-roadmap', -> require('shell').openExternal('https://atom.io/roadmap?app')
     @on 'application:open-faq', -> require('shell').openExternal('https://atom.io/faq')
     @on 'application:open-terms-of-use', -> require('shell').openExternal('https://atom.io/terms')
-    @on 'application:report-issue', -> require('shell').openExternal('https://github.com/atom/atom/issues/new')
+    @on 'application:report-issue', -> require('shell').openExternal('https://github.com/atom/atom/blob/master/CONTRIBUTING.md#submitting-issues')
     @on 'application:search-issues', -> require('shell').openExternal('https://github.com/issues?q=+is%3Aissue+user%3Aatom')
 
     @on 'application:install-update', -> @autoUpdateManager.install()


### PR DESCRIPTION
Currently, clicking the "Report issue" menu option in Atom takes the user to the New Issue form on GitHub for atom/atom. 

![screen shot 2015-04-07 at 13 48 47](https://cloud.githubusercontent.com/assets/38924/7022511/f34967ca-dd2c-11e4-9fc0-96e60bc3769b.png)

I think that's great -- it allows users to quickly report issues. However, it doesn't assist users in creating a good bug report or feature request. We've noticed lots of issues created without even basic information such as Atom version, OS, expected behavior, and screenshots. 

This PR changes the in-app menu option to instead point users to the [CONTRIBUTING guide section on submitting issues](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#submitting-issues). That section explains which information users should include in issues and also points them to the debugging guide. This will introduce an additional step in the process for creating issues, but it will hopefully result in higher quality issues which are easier to triage (and fix). :pray: 

Also, I slightly updated the CONTRIBUTING guide to state this goal more clearly, include a link to the New Issue form in the first bullet, and point to package repositories in the section on submitting issues. The CONTRIBUTING guide will see a lot more updates in the near future, this is just a first step.

cc @atom/core @atom/issue-triage 
