### PR TITLE
Use require to read/parse package.json

### DIFF
--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -276,9 +276,9 @@ class PackageManager
   getPackageDependencies: ->
     unless @packageDependencies?
       try
-        metadataPath = path.join(@resourcePath, 'package.json')
-        {@packageDependencies} = JSON.parse(fs.readFileSync(metadataPath)) ? {}
-      @packageDependencies ?= {}
+        @packageDependencies = require('../package.json')?.packageDependencies ? {}
+      catch error
+        @packageDependencies = {}
 
     @packageDependencies
 

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -276,9 +276,8 @@ class PackageManager
   getPackageDependencies: ->
     unless @packageDependencies?
       try
-        @packageDependencies = require('../package.json')?.packageDependencies ? {}
-      catch error
-        @packageDependencies = {}
+        @packageDependencies = require('../package.json')?.packageDependencies
+      @packageDependencies ?= {}
 
     @packageDependencies
 


### PR DESCRIPTION
This code was really old and an initial oversight, `require` should have been used to read the root `package.json` file like is done in `package.coffee` so that it is cached since it is ~500k.

This shaves 5-10ms off of startup.
