### PR TITLE
Inline core menus/keymaps into app package.json

### DIFF
--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -63,7 +63,7 @@ module.exports = (grunt) ->
 
     metadata = grunt.file.readJSON(path.join(appDir, 'package.json'))
     metadata._atomPackages = packages
-    metadata._menu = getMenu(appDir)
-    metadata._keymaps = getKeymaps(appDir)
+    metadata._atomMenu = getMenu(appDir)
+    metadata._atomKeymaps = getKeymaps(appDir)
 
     grunt.file.write(path.join(appDir, 'package.json'), JSON.stringify(metadata))

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -18,7 +18,7 @@ module.exports = (grunt) ->
   getKeymaps = (appDir) ->
     keymapsPath = path.join(appDir, 'keymaps')
     keymaps = {}
-    for keymapPath in fs.listSync(keymapsPath, ['.cson', '.json'])
+    for keymapPath in fs.listSync(keymapsPath, ['.json'])
       name = path.basename(keymapPath, path.extname(keymapPath))
       continue unless OtherPlatforms.indexOf(name) is -1
 

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -6,6 +6,13 @@ _ = require 'underscore-plus'
 module.exports = (grunt) ->
   {spawn, rm} = require('./task-helpers')(grunt)
 
+  getMenu = (appDir) ->
+    menusPath = path.join(appDir, 'menus')
+    menuPath = path.join(menusPath, process.platform)
+    menu = CSON.readFileSync(menuPath) if fs.isFileSync(menuPath)
+    rm menusPath
+    menu ? {}
+
   grunt.registerTask 'compile-packages-slug', 'Add bundled package metadata information to the main package.json file', ->
     appDir = fs.realpathSync(grunt.config.get('atom.appDir'))
 
@@ -50,5 +57,6 @@ module.exports = (grunt) ->
 
     metadata = grunt.file.readJSON(path.join(appDir, 'package.json'))
     metadata._atomPackages = packages
+    metadata._menu = getMenu(appDir)
 
     grunt.file.write(path.join(appDir, 'package.json'), JSON.stringify(metadata))

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -13,6 +13,12 @@ module.exports = (grunt) ->
     rm menusPath
     menu ? {}
 
+  getKeymaps = (appDir) ->
+    keymapsPath = path.join(appDir, 'keymaps')
+    keymaps = fs.listSync(keymapsPath, ['.cson', '.json']).map (keymapPath) -> CSON.readFileSync(keymapPath)
+    rm keymapsPath
+    keymaps ? []
+
   grunt.registerTask 'compile-packages-slug', 'Add bundled package metadata information to the main package.json file', ->
     appDir = fs.realpathSync(grunt.config.get('atom.appDir'))
 
@@ -58,5 +64,6 @@ module.exports = (grunt) ->
     metadata = grunt.file.readJSON(path.join(appDir, 'package.json'))
     metadata._atomPackages = packages
     metadata._menu = getMenu(appDir)
+    metadata._keymaps = getKeymaps(appDir)
 
     grunt.file.write(path.join(appDir, 'package.json'), JSON.stringify(metadata))

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -13,7 +13,7 @@ module.exports = (grunt) ->
     menuPath = path.join(menusPath, "#{process.platform}.json")
     menu = CSON.readFileSync(menuPath) if fs.isFileSync(menuPath)
     rm menusPath
-    menu ? {}
+    menu
 
   getKeymaps = (appDir) ->
     keymapsPath = path.join(appDir, 'keymaps')

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -3,6 +3,8 @@ CSON = require 'season'
 fs = require 'fs-plus'
 _ = require 'underscore-plus'
 
+OtherPlatforms = ['darwin', 'freebsd', 'linux', 'sunos', 'win32'].filter (platform) -> platform isnt process.platform
+
 module.exports = (grunt) ->
   {spawn, rm} = require('./task-helpers')(grunt)
 
@@ -15,7 +17,13 @@ module.exports = (grunt) ->
 
   getKeymaps = (appDir) ->
     keymapsPath = path.join(appDir, 'keymaps')
-    keymaps = fs.listSync(keymapsPath, ['.cson', '.json']).map (keymapPath) -> CSON.readFileSync(keymapPath)
+    keymaps = {}
+    for keymapPath in fs.listSync(keymapsPath, ['.cson', '.json'])
+      name = path.basename(keymapPath, path.extname(keymapPath))
+      continue unless OtherPlatforms.indexOf(name) is -1
+
+      keymap = CSON.readFileSync(keymapPath)
+      keymaps[path.basename(keymapPath)] = keymap
     rm keymapsPath
     keymaps
 

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -17,7 +17,7 @@ module.exports = (grunt) ->
     keymapsPath = path.join(appDir, 'keymaps')
     keymaps = fs.listSync(keymapsPath, ['.cson', '.json']).map (keymapPath) -> CSON.readFileSync(keymapPath)
     rm keymapsPath
-    keymaps ? []
+    keymaps
 
   grunt.registerTask 'compile-packages-slug', 'Add bundled package metadata information to the main package.json file', ->
     appDir = fs.realpathSync(grunt.config.get('atom.appDir'))

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -10,7 +10,7 @@ module.exports = (grunt) ->
 
   getMenu = (appDir) ->
     menusPath = path.join(appDir, 'menus')
-    menuPath = path.join(menusPath, "#{process.platform}.cson")
+    menuPath = path.join(menusPath, "#{process.platform}.json")
     menu = CSON.readFileSync(menuPath) if fs.isFileSync(menuPath)
     rm menusPath
     menu ? {}

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -8,7 +8,7 @@ module.exports = (grunt) ->
 
   getMenu = (appDir) ->
     menusPath = path.join(appDir, 'menus')
-    menuPath = path.join(menusPath, process.platform)
+    menuPath = path.join(menusPath, "#{process.platform}.cson")
     menu = CSON.readFileSync(menuPath) if fs.isFileSync(menuPath)
     rm menusPath
     menu ? {}

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -8,11 +8,7 @@ Grim = require 'grim'
 MenuHelpers = require './menu-helpers'
 {validateSelector} = require './selector-validator'
 
-try
-  platformContextMenu = require('../package.json')?._atomMenu?['context-menu']
-catch error
-  platformContextMenu = null
-
+platformContextMenu = require('../package.json')?._atomMenu?['context-menu']
 SpecificityCache = {}
 
 # Extended: Provides a registry for commands that you'd like to appear in the

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -8,6 +8,11 @@ Grim = require 'grim'
 MenuHelpers = require './menu-helpers'
 {validateSelector} = require './selector-validator'
 
+try
+  platformContextMenu = require('../package.json')?._atomMenu?['context-menu']
+catch error
+  platformContextMenu = null
+
 SpecificityCache = {}
 
 # Extended: Provides a registry for commands that you'd like to appear in the
@@ -49,10 +54,13 @@ class ContextMenuManager
     atom.keymaps.onDidLoadBundledKeymaps => @loadPlatformItems()
 
   loadPlatformItems: ->
-    menusDirPath = path.join(@resourcePath, 'menus')
-    platformMenuPath = fs.resolve(menusDirPath, process.platform, ['cson', 'json'])
-    map = CSON.readFileSync(platformMenuPath)
-    atom.contextMenu.add(map['context-menu'])
+    if platformContextMenu?
+      @add(platformContextMenu)
+    else
+      menusDirPath = path.join(@resourcePath, 'menus')
+      platformMenuPath = fs.resolve(menusDirPath, process.platform, ['cson', 'json'])
+      map = CSON.readFileSync(platformMenuPath)
+      @add(map['context-menu'])
 
   # Public: Add context menu items scoped by CSS selectors.
   #

--- a/src/keymap-extensions.coffee
+++ b/src/keymap-extensions.coffee
@@ -5,10 +5,7 @@ CSON = require 'season'
 {jQuery} = require 'space-pen'
 Grim = require 'grim'
 
-try
-  bundledKeymaps = require('../package.json')?._atomKeymaps
-catch error
-  bundledKeymaps = null
+bundledKeymaps = require('../package.json')?._atomKeymaps
 
 KeymapManager::onDidLoadBundledKeymaps = (callback) ->
   @emitter.on 'did-load-bundled-keymaps', callback

--- a/src/keymap-extensions.coffee
+++ b/src/keymap-extensions.coffee
@@ -63,7 +63,7 @@ KeymapManager::subscribeToFileReadFailure = ->
     else
       error.message
 
-    atom.notifications.addError(message, {detail: detail, dismissable: true})
+    atom.notifications.addError(message, {detail, dismissable: true})
 
 # This enables command handlers registered via jQuery to call
 # `.abortKeyBinding()` on the `jQuery.Event` object passed to the handler.

--- a/src/keymap-extensions.coffee
+++ b/src/keymap-extensions.coffee
@@ -5,11 +5,23 @@ CSON = require 'season'
 {jQuery} = require 'space-pen'
 Grim = require 'grim'
 
+try
+  bundledKeymaps = require('../package.json')?._atomKeymaps
+catch error
+  bundledKeymaps = null
+
 KeymapManager::onDidLoadBundledKeymaps = (callback) ->
   @emitter.on 'did-load-bundled-keymaps', callback
 
 KeymapManager::loadBundledKeymaps = ->
-  @loadKeymap(path.join(@resourcePath, 'keymaps'))
+  keymapsPath = path.join(@resourcePath, 'keymaps')
+  if bundledKeymaps?
+    for keymapName, keymap of bundledKeymaps
+      keymapPath = path.join(keymapsPath, keymapName)
+      @add(keymapPath, keymap)
+  else
+    @loadKeymap(keymapsPath)
+
   @emit 'bundled-keymaps-loaded' if Grim.includeDeprecatedAPIs
   @emitter.emit 'did-load-bundled-keymaps'
 

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -8,6 +8,11 @@ fs = require 'fs-plus'
 
 MenuHelpers = require './menu-helpers'
 
+try
+  platformMenu = require('../package.json')?._atomMenu
+catch error
+  platformMenu = null
+
 # Extended: Provides a registry for menu items that you'd like to appear in the
 # application menu.
 #
@@ -144,10 +149,13 @@ class MenuManager
       @sendToBrowserProcess(@template, keystrokesByCommand)
 
   loadPlatformItems: ->
-    menusDirPath = path.join(@resourcePath, 'menus')
-    platformMenuPath = fs.resolve(menusDirPath, process.platform, ['cson', 'json'])
-    {menu} = CSON.readFileSync(platformMenuPath)
-    @add(menu)
+    if platformMenuPath
+      @add(menu)
+    else
+      menusDirPath = path.join(@resourcePath, 'menus')
+      platformMenuPath = fs.resolve(menusDirPath, process.platform, ['cson', 'json'])
+      {menu} = CSON.readFileSync(platformMenuPath)
+      @add(menu)
 
   # Merges an item in a submenu aware way such that new items are always
   # appended to the bottom of existing menus where possible.

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -149,8 +149,8 @@ class MenuManager
       @sendToBrowserProcess(@template, keystrokesByCommand)
 
   loadPlatformItems: ->
-    if platformMenuPath
-      @add(menu)
+    if platformMenu?
+      @add(platformMenu)
     else
       menusDirPath = path.join(@resourcePath, 'menus')
       platformMenuPath = fs.resolve(menusDirPath, process.platform, ['cson', 'json'])

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -8,10 +8,7 @@ fs = require 'fs-plus'
 
 MenuHelpers = require './menu-helpers'
 
-try
-  platformMenu = require('../package.json')?._atomMenu?.menu
-catch error
-  platformMenu = null
+platformMenu = require('../package.json')?._atomMenu?.menu
 
 # Extended: Provides a registry for menu items that you'd like to appear in the
 # application menu.

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -9,7 +9,7 @@ fs = require 'fs-plus'
 MenuHelpers = require './menu-helpers'
 
 try
-  platformMenu = require('../package.json')?._atomMenu
+  platformMenu = require('../package.json')?._atomMenu?.menu
 catch error
   platformMenu = null
 

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -11,10 +11,7 @@ Q = require 'q'
 ModuleCache = require './module-cache'
 ScopedProperties = require './scoped-properties'
 
-try
-  packagesCache = require('../package.json')?._atomPackages ? {}
-catch error
-  packagesCache = {}
+packagesCache = require('../package.json')?._atomPackages ? {}
 
 # Loads and activates a package's main module and resources such as
 # stylesheets, keymaps, grammar, editor properties, and menus.


### PR DESCRIPTION
We've inlined the bundled package metadata, keymaps, and menus for awhile but neglected the core keymaps and menus.

This pull request inlines all the files in the `keymaps/` and `menus/` folders into the main app's `package.json` file so ~5 fewer JSON files are read and parsed at startup.

I noticed this when I saw `atom.menus.loadPlatformItems` show up in the startup profile since it does a resolve, read, and parse that is directly mirrored in `atom.contextMenu.loadPlatformItems` as well.
