### PR TITLE
Add asar support in Atom

### DIFF
--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "0.157.0"
+    "atom-package-manager": "0.158.0"
   }
 }

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -223,7 +223,7 @@ module.exports = (grunt) ->
 
   ciTasks = ['output-disk-space', 'download-atom-shell', 'download-atom-shell-chromedriver', 'build']
   ciTasks.push('dump-symbols') if process.platform isnt 'win32'
-  ciTasks.push('set-version', 'check-licenses', 'lint')
+  ciTasks.push('set-version', 'check-licenses', 'lint', 'generate-asar')
   ciTasks.push('mkdeb') if process.platform is 'linux'
   ciTasks.push('create-windows-installer') if process.platform is 'win32'
   ciTasks.push('test') if process.platform is 'darwin'
@@ -231,6 +231,6 @@ module.exports = (grunt) ->
   ciTasks.push('publish-build')
   grunt.registerTask('ci', ciTasks)
 
-  defaultTasks = ['download-atom-shell', 'download-atom-shell-chromedriver', 'build', 'set-version']
+  defaultTasks = ['download-atom-shell', 'download-atom-shell-chromedriver', 'build', 'set-version', 'generate-asar']
   defaultTasks.push 'install' unless process.platform is 'linux'
   grunt.registerTask('default', defaultTasks)

--- a/build/package.json
+++ b/build/package.json
@@ -13,7 +13,7 @@
     "fs-plus": "2.x",
     "github-releases": "~0.2.0",
     "grunt": "~0.4.1",
-    "grunt-atom-shell-installer": "^0.28.0",
+    "grunt-atom-shell-installer": "^0.29.0",
     "grunt-cli": "~0.1.9",
     "grunt-coffeelint": "git+https://github.com/atom/grunt-coffeelint.git#cfb99aa99811d52687969532bd5a98011ed95bfe",
     "grunt-contrib-coffee": "~0.12.0",

--- a/build/package.json
+++ b/build/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
+    "asar": "^0.4.0",
     "async": "~0.2.9",
     "donna": "1.0.10",
     "formidable": "~1.0.14",

--- a/build/package.json
+++ b/build/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "asar": "^0.4.0",
+    "asar": "^0.4.4",
     "async": "~0.2.9",
     "donna": "1.0.10",
     "formidable": "~1.0.14",

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -65,6 +65,7 @@ module.exports = (grunt) ->
       path.join('jasmine-node', 'node_modules', 'gaze')
       path.join('jasmine-node', 'spec')
       path.join('node_modules', 'nan')
+      path.join('node_modules', 'native-mate')
       path.join('build', 'binding.Makefile')
       path.join('build', 'config.gypi')
       path.join('build', 'gyp-mac-tool')

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -22,7 +22,7 @@ module.exports = (grunt) ->
     mkdir appDir
 
     if process.platform isnt 'win32'
-      cp 'atom.sh', path.join(appDir, 'atom.sh')
+      cp 'atom.sh', path.resolve(appDir, '..', 'atom.sh')
 
     cp 'package.json', path.join(appDir, 'package.json')
 
@@ -147,9 +147,9 @@ module.exports = (grunt) ->
     cp 'src', path.join(appDir, 'src'), filter: /.+\.(cson|coffee)$/
     cp 'static', path.join(appDir, 'static')
 
-    cp path.join('apm', 'node_modules', 'atom-package-manager'), path.join(appDir, 'apm'), filter: filterNodeModule
+    cp path.join('apm', 'node_modules', 'atom-package-manager'), path.resolve(appDir, '..', 'apm'), filter: filterNodeModule
     if process.platform isnt 'win32'
-      fs.symlinkSync(path.join('..', '..', 'bin', 'apm'), path.join(appDir, 'apm', 'node_modules', '.bin', 'apm'))
+      fs.symlinkSync(path.join('..', '..', 'bin', 'apm'), path.resolve(appDir, '..', 'apm', 'node_modules', '.bin', 'apm'))
 
     if process.platform is 'darwin'
       grunt.file.recurse path.join('resources', 'mac'), (sourcePath, rootDirectory, subDirectory='', filename) ->

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -22,7 +22,7 @@ module.exports = (grunt) ->
     mkdir appDir
 
     if process.platform isnt 'win32'
-      cp 'atom.sh', path.resolve(appDir, '..', 'atom.sh')
+      cp 'atom.sh', path.resolve(appDir, '..', 'new-app', 'atom.sh')
 
     cp 'package.json', path.join(appDir, 'package.json')
 
@@ -147,9 +147,9 @@ module.exports = (grunt) ->
     cp 'src', path.join(appDir, 'src'), filter: /.+\.(cson|coffee)$/
     cp 'static', path.join(appDir, 'static')
 
-    cp path.join('apm', 'node_modules', 'atom-package-manager'), path.resolve(appDir, '..', 'apm'), filter: filterNodeModule
+    cp path.join('apm', 'node_modules', 'atom-package-manager'), path.resolve(appDir, '..', 'new-app', 'apm'), filter: filterNodeModule
     if process.platform isnt 'win32'
-      fs.symlinkSync(path.join('..', '..', 'bin', 'apm'), path.resolve(appDir, '..', 'apm', 'node_modules', '.bin', 'apm'))
+      fs.symlinkSync(path.join('..', '..', 'bin', 'apm'), path.resolve(appDir, '..', 'new-app', 'apm', 'node_modules', '.bin', 'apm'))
 
     if process.platform is 'darwin'
       grunt.file.recurse path.join('resources', 'mac'), (sourcePath, rootDirectory, subDirectory='', filename) ->

--- a/build/tasks/generate-asar-task.coffee
+++ b/build/tasks/generate-asar-task.coffee
@@ -3,7 +3,7 @@ fs = require 'fs'
 path = require 'path'
 
 module.exports = (grunt) ->
-  {rm} = require('./task-helpers')(grunt)
+  {cp, rm} = require('./task-helpers')(grunt)
 
   grunt.registerTask 'generate-asar', 'Generate asar archive for the app', ->
     done = @async()
@@ -15,5 +15,7 @@ module.exports = (grunt) ->
 
     asar.createPackageWithOptions appDir, path.resolve(appDir, '..', 'app.asar'), {unpack: '*.node'}, (err) ->
       return done(err) if err?
+
       rm appDir
+      fs.renameSync path.resolve(appDir, '..', 'new-app'), appDir
       done()

--- a/build/tasks/generate-asar-task.coffee
+++ b/build/tasks/generate-asar-task.coffee
@@ -10,10 +10,10 @@ module.exports = (grunt) ->
 
     unpack = [
       '*.node'
+      '*.ctags'
       'ctags-darwin'
       'ctags-linux'
       'ctags-win32.exe'
-      '\\.ctags'
     ]
     unpack = "{#{unpack.join(',')}}"
 

--- a/build/tasks/generate-asar-task.coffee
+++ b/build/tasks/generate-asar-task.coffee
@@ -18,4 +18,9 @@ module.exports = (grunt) ->
 
       rm appDir
       fs.renameSync path.resolve(appDir, '..', 'new-app'), appDir
+
+      ctagsFolder = path.join("#{appDir}.asar.unpacked", 'node_modules', 'symbols-view', 'vendor')
+      for ctagsFile in fs.readdirSync(ctagsFolder)
+        fs.chmodSync(path.join(ctagsFolder, ctagsFile), "755")
+
       done()

--- a/build/tasks/generate-asar-task.coffee
+++ b/build/tasks/generate-asar-task.coffee
@@ -13,7 +13,7 @@ module.exports = (grunt) ->
       grunt.log.error 'The app has to be built before generating asar archive.'
       return done(false)
 
-    asar.createPackageWithOptions appDir, path.resolve(appDir, '..', 'app.asar'), {unpack: '*.node'}, (err) ->
+    asar.createPackageWithOptions appDir, path.resolve(appDir, '..', 'app.asar'), {unpack: '{*.node,ctags-darwin,ctags-linux,ctags-win32.exe}'}, (err) ->
       return done(err) if err?
 
       rm appDir

--- a/build/tasks/generate-asar-task.coffee
+++ b/build/tasks/generate-asar-task.coffee
@@ -10,7 +10,7 @@ module.exports = (grunt) ->
 
     unpack = [
       '*.node'
-      '*.ctags'
+      '.ctags'
       'ctags-darwin'
       'ctags-linux'
       'ctags-win32.exe'

--- a/build/tasks/generate-asar-task.coffee
+++ b/build/tasks/generate-asar-task.coffee
@@ -1,0 +1,19 @@
+asar = require 'asar'
+fs = require 'fs'
+path = require 'path'
+
+module.exports = (grunt) ->
+  {rm} = require('./task-helpers')(grunt)
+
+  grunt.registerTask 'generate-asar', 'Generate asar archive for the app', ->
+    done = @async()
+
+    appDir = grunt.config.get('atom.appDir')
+    unless fs.existsSync(appDir)
+      grunt.log.error 'The app has to be built before generating asar archive.'
+      return done(false)
+
+    asar.createPackageWithOptions appDir, path.resolve(appDir, '..', 'app.asar'), {unpack: '*.node'}, (err) ->
+      return done(err) if err?
+      rm appDir
+      done()

--- a/build/tasks/generate-asar-task.coffee
+++ b/build/tasks/generate-asar-task.coffee
@@ -8,12 +8,21 @@ module.exports = (grunt) ->
   grunt.registerTask 'generate-asar', 'Generate asar archive for the app', ->
     done = @async()
 
+    unpack = [
+      '*.node'
+      'ctags-darwin'
+      'ctags-linux'
+      'ctags-win32.exe'
+      '\\.ctags'
+    ]
+    unpack = "{#{unpack.join(',')}}"
+
     appDir = grunt.config.get('atom.appDir')
     unless fs.existsSync(appDir)
       grunt.log.error 'The app has to be built before generating asar archive.'
       return done(false)
 
-    asar.createPackageWithOptions appDir, path.resolve(appDir, '..', 'app.asar'), {unpack: '{*.node,ctags-darwin,ctags-linux,ctags-win32.exe,\\.ctags}'}, (err) ->
+    asar.createPackageWithOptions appDir, path.resolve(appDir, '..', 'app.asar'), {unpack}, (err) ->
       return done(err) if err?
 
       rm appDir

--- a/build/tasks/generate-asar-task.coffee
+++ b/build/tasks/generate-asar-task.coffee
@@ -13,7 +13,7 @@ module.exports = (grunt) ->
       grunt.log.error 'The app has to be built before generating asar archive.'
       return done(false)
 
-    asar.createPackageWithOptions appDir, path.resolve(appDir, '..', 'app.asar'), {unpack: '{*.node,ctags-darwin,ctags-linux,ctags-win32.exe}'}, (err) ->
+    asar.createPackageWithOptions appDir, path.resolve(appDir, '..', 'app.asar'), {unpack: '{*.node,ctags-darwin,ctags-linux,ctags-win32.exe,\\.ctags}'}, (err) ->
       return done(err) if err?
 
       rm appDir

--- a/build/tasks/generate-license-task.coffee
+++ b/build/tasks/generate-license-task.coffee
@@ -17,7 +17,7 @@ module.exports = (grunt) ->
 
       licenseText = getLicenseText(dependencyLicenses)
       if mode is 'save'
-        targetPath = path.join(grunt.config.get('atom.appDir'), 'LICENSE.md')
+        targetPath = path.resolve(grunt.config.get('atom.appDir'), '..', 'LICENSE.md')
         fs.writeFileSync(targetPath, licenseText)
       else
         console.log licenseText

--- a/script/mkdeb
+++ b/script/mkdeb
@@ -33,7 +33,7 @@ cp "$ICON_FILE" "$TARGET/usr/share/pixmaps"
 
 # Copy generated LICENSE.md to /usr/share/doc/atom/copyright
 mkdir -m $FILE_MODE -p "$TARGET/usr/share/doc/atom"
-cp "$TARGET/usr/share/atom/resources/app/LICENSE.md" "$TARGET/usr/share/doc/atom/copyright"
+cp "$TARGET/usr/share/atom/resources/LICENSE.md" "$TARGET/usr/share/doc/atom/copyright"
 
 # Add lintian overrides
 mkdir -m $FILE_MODE -p "$TARGET/usr/share/lintian/overrides"

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -215,7 +215,7 @@ class Atom extends Model
 
       if openDevTools
         @openDevTools()
-        @executeJavaScriptInDevTools('InspectorFrontendAPI.showConsole()')
+        @executeJavaScriptInDevTools('DevToolsAPI.showConsole()')
 
       @emit 'uncaught-error', arguments... if includeDeprecatedAPIs
       @emitter.emit 'did-throw-error', {message, url, line, column, originalError}
@@ -577,9 +577,9 @@ class Atom extends Model
     {resourcePath, safeMode} = @getLoadSettings()
 
     CommandInstaller = require './command-installer'
-    CommandInstaller.installAtomCommand resourcePath, false, (error) ->
+    CommandInstaller.installAtomCommand false, (error) ->
       console.warn error.message if error?
-    CommandInstaller.installApmCommand resourcePath, false, (error) ->
+    CommandInstaller.installApmCommand false, (error) ->
       console.warn error.message if error?
 
     dimensions = @restoreWindowDimensions()

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -574,7 +574,7 @@ class Atom extends Model
 
   # Call this method when establishing a real application window.
   startEditorWindow: ->
-    {resourcePath, safeMode} = @getLoadSettings()
+    {safeMode} = @getLoadSettings()
 
     CommandInstaller = require './command-installer'
     CommandInstaller.installAtomCommand false, (error) ->

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -196,7 +196,7 @@ class AtomApplication
     @openPathOnEvent('application:open-your-keymap', 'atom://.atom/keymap')
     @openPathOnEvent('application:open-your-snippets', 'atom://.atom/snippets')
     @openPathOnEvent('application:open-your-stylesheet', 'atom://.atom/stylesheet')
-    @openPathOnEvent('application:open-license', path.join(@resourcePath, 'LICENSE.md'))
+    @openPathOnEvent('application:open-license', path.join(process.resourcesPath, 'LICENSE.md'))
 
     app.on 'window-all-closed', ->
       app.quit() if process.platform in ['win32', 'linux']

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -142,7 +142,7 @@ addCommandsToPath = (callback) ->
     atomShCommand = "#!/bin/sh\r\n\"$0/../#{relativeAtomShPath.replace(/\\/g, '/')}\" \"$@\""
 
     apmCommandPath = path.join(binFolder, 'apm.cmd')
-    relativeApmPath = path.relative(binFolder, path.join(process.resourcesPath, 'app', 'apm', 'bin', 'apm.cmd'))
+    relativeApmPath = path.relative(binFolder, path.join(process.resourcesPath, 'apm', 'bin', 'apm.cmd'))
     apmCommand = "@echo off\r\n\"%~dp0\\#{relativeApmPath}\" %*"
 
     apmShCommandPath = path.join(binFolder, 'apm')

--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -142,7 +142,7 @@ addCommandsToPath = (callback) ->
     atomShCommand = "#!/bin/sh\r\n\"$0/../#{relativeAtomShPath.replace(/\\/g, '/')}\" \"$@\""
 
     apmCommandPath = path.join(binFolder, 'apm.cmd')
-    relativeApmPath = path.relative(binFolder, path.join(process.resourcesPath, 'apm', 'bin', 'apm.cmd'))
+    relativeApmPath = path.relative(binFolder, path.join(process.resourcesPath, 'app', 'apm', 'bin', 'apm.cmd'))
     apmCommand = "@echo off\r\n\"%~dp0\\#{relativeApmPath}\" %*"
 
     apmShCommandPath = path.join(binFolder, 'apm')

--- a/src/command-installer.coffee
+++ b/src/command-installer.coffee
@@ -36,12 +36,11 @@ module.exports =
         message: "Failed to install shell commands"
         detailedMessage: error.message
 
-    resourcePath = atom.getLoadSettings().resourcePath
-    @installAtomCommand resourcePath, true, (error) =>
+    @installAtomCommand true, (error) =>
       if error?
         showErrorDialog(error)
       else
-        @installApmCommand resourcePath, true, (error) ->
+        @installApmCommand true, (error) ->
           if error?
             showErrorDialog(error)
           else
@@ -49,12 +48,12 @@ module.exports =
               message: "Commands installed."
               detailedMessage: "The shell commands `atom` and `apm` are installed."
 
-  installAtomCommand: (resourcePath, askForPrivilege, callback) ->
-    commandPath = path.join(resourcePath, 'atom.sh')
+  installAtomCommand: (askForPrivilege, callback) ->
+    commandPath = path.join(process.resourcesPath, 'atom.sh')
     @createSymlink commandPath, askForPrivilege, callback
 
-  installApmCommand: (resourcePath, askForPrivilege, callback) ->
-    commandPath = path.join(resourcePath, 'apm', 'node_modules', '.bin', 'apm')
+  installApmCommand: (askForPrivilege, callback) ->
+    commandPath = path.join(process.resourcesPath, 'apm', 'node_modules', '.bin', 'apm')
     @createSymlink commandPath, askForPrivilege, callback
 
   createSymlink: (commandPath, askForPrivilege, callback) ->

--- a/src/command-installer.coffee
+++ b/src/command-installer.coffee
@@ -49,11 +49,11 @@ module.exports =
               detailedMessage: "The shell commands `atom` and `apm` are installed."
 
   installAtomCommand: (askForPrivilege, callback) ->
-    commandPath = path.join(process.resourcesPath, 'atom.sh')
+    commandPath = path.join(process.resourcesPath, 'app', 'atom.sh')
     @createSymlink commandPath, askForPrivilege, callback
 
   installApmCommand: (askForPrivilege, callback) ->
-    commandPath = path.join(process.resourcesPath, 'apm', 'node_modules', '.bin', 'apm')
+    commandPath = path.join(process.resourcesPath, 'app', 'apm', 'node_modules', '.bin', 'apm')
     @createSymlink commandPath, askForPrivilege, callback
 
   createSymlink: (commandPath, askForPrivilege, callback) ->

--- a/src/command-installer.coffee
+++ b/src/command-installer.coffee
@@ -1,6 +1,4 @@
 path = require 'path'
-_ = require 'underscore-plus'
-async = require 'async'
 fs = require 'fs-plus'
 runas = null # defer until used
 

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -111,7 +111,7 @@ class PackageManager
 
     commandName = 'apm'
     commandName += '.cmd' if process.platform is 'win32'
-    apmRoot = path.join(process.resourcesPath, 'apm')
+    apmRoot = path.join(process.resourcesPath, 'app', 'apm')
     @apmPath = path.join(apmRoot, 'bin', commandName)
     unless fs.isFileSync(@apmPath)
       @apmPath = path.join(apmRoot, 'node_modules', 'atom-package-manager', 'bin', commandName)

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -111,7 +111,7 @@ class PackageManager
 
     commandName = 'apm'
     commandName += '.cmd' if process.platform is 'win32'
-    apmRoot = path.resolve(__dirname, '..', 'apm')
+    apmRoot = path.join(process.resourcesPath, 'apm')
     @apmPath = path.join(apmRoot, 'bin', commandName)
     unless fs.isFileSync(@apmPath)
       @apmPath = path.join(apmRoot, 'node_modules', 'atom-package-manager', 'bin', commandName)

--- a/src/task.coffee
+++ b/src/task.coffee
@@ -83,7 +83,7 @@ class Task
     taskPath = taskPath.replace(/\\/g, "\\\\")
 
     env = _.extend({}, process.env, {taskPath, userAgent: navigator.userAgent})
-    @childProcess = fork '--eval', [bootstrap], {env, cwd: __dirname}
+    @childProcess = fork '--eval', [bootstrap], {env, silent: true}
 
     @on "task:log", -> console.log(arguments...)
     @on "task:warn", -> console.warn(arguments...)
@@ -100,6 +100,11 @@ class Task
     @childProcess.removeAllListeners()
     @childProcess.on 'message', ({event, args}) =>
       @emit(event, args...) if @childProcess?
+    # Catch the errors that happened before task-bootstrap.
+    @childProcess.stdout.on 'data', (data) ->
+      console.log data.toString()
+    @childProcess.stderr.on 'data', (data) ->
+      console.error data.toString()
 
   # Public: Starts the task.
   #


### PR DESCRIPTION
Reverts atom/atom#6242 and brings back #5382 
### Packages To Test

These packages use a buffered process which might have issues inside an `.asar` archive.
- [x] Symbols View
- [x] Notifications
- [x] Package Generator
- [x] Settings View
- [x] Tree View
- [x] Update Package Dependencies
- [x] `apm` populating the compile cache on package install
### Platforms To Test
- [x] Windows
  - Verify atom and apm commands work with installer
  - Verify no long paths
- [x] Mac
  - Verify atom and apm commands install from system menu
- [x] Linux
  - Verify atom and apm commands work from native package installation
### Results
- Startup appears 100-200ms faster on my Windows 8.1 VM running inside Parallels
- Windows installer appears to be much snappier
