### PR TITLE
Precompile bootstrap

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -92,7 +92,6 @@ module.exports = (grunt) ->
   prebuildLessConfig =
     src: [
       'static/**/*.less'
-      'node_modules/bootstrap/less/bootstrap.less'
     ]
 
   csonConfig =

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -49,6 +49,8 @@ module.exports = (grunt) ->
       path.join('oniguruma', 'deps')
       path.join('less', 'dist')
       path.join('bootstrap', 'docs')
+      path.join('bootstrap', 'dist')
+      path.join('bootstrap', 'fonts')
       path.join('bootstrap', '_config.yml')
       path.join('bootstrap', '_includes')
       path.join('bootstrap', '_layouts')

--- a/build/tasks/prebuild-less-task.coffee
+++ b/build/tasks/prebuild-less-task.coffee
@@ -75,7 +75,7 @@ module.exports = (grunt) ->
         themeMains.push(mainPath) if grunt.file.isFile(mainPath)
         importPaths.unshift(stylesheetsDir) if grunt.file.isDir(stylesheetsDir)
 
-      grunt.verbose.writeln("Building LESS cache for #{configuration.join(', ').yellow}")
+      grunt.verbose.writeln("Building Less cache for #{configuration.join(', ').yellow}")
       lessCache = new LessCache
         cacheDir: directory
         resourcePath: path.resolve('.')

--- a/build/tasks/prebuild-less-task.coffee
+++ b/build/tasks/prebuild-less-task.coffee
@@ -20,7 +20,7 @@ module.exports = (grunt) ->
     rm(bootstrapLessPath)
     rm(path.join(appDir, 'node_modules', 'bootstrap', 'less'))
 
-  grunt.registerMultiTask 'prebuild-less', 'Prebuild cached of compiled LESS files', ->
+  grunt.registerMultiTask 'prebuild-less', 'Prebuild cached of compiled Less files', ->
     compileBootstrap()
 
     prebuiltConfigurations = [

--- a/build/tasks/prebuild-less-task.coffee
+++ b/build/tasks/prebuild-less-task.coffee
@@ -21,6 +21,8 @@ module.exports = (grunt) ->
     rm(path.join(appDir, 'node_modules', 'bootstrap', 'less'))
 
   grunt.registerMultiTask 'prebuild-less', 'Prebuild cached of compiled LESS files', ->
+    compileBootstrap()
+
     prebuiltConfigurations = [
       ['atom-dark-ui', 'atom-dark-syntax']
       ['atom-dark-ui', 'atom-light-syntax']
@@ -94,5 +96,3 @@ module.exports = (grunt) ->
       for file in themeMains
         grunt.verbose.writeln("File #{file.cyan} created in cache.")
         cssForFile(file)
-
-    compileBootstrap()

--- a/build/tasks/prebuild-less-task.coffee
+++ b/build/tasks/prebuild-less-task.coffee
@@ -18,6 +18,7 @@ module.exports = (grunt) ->
     bootstrapCss = lessCache.readFileSync(bootstrapLessPath)
     grunt.file.write(bootstrapCssPath, bootstrapCss)
     rm(bootstrapLessPath)
+    rm(path.join(appDir, 'node_modules', 'bootstrap', 'less'))
 
   grunt.registerMultiTask 'prebuild-less', 'Prebuild cached of compiled LESS files', ->
     prebuiltConfigurations = [

--- a/build/tasks/prebuild-less-task.coffee
+++ b/build/tasks/prebuild-less-task.coffee
@@ -1,9 +1,24 @@
 path = require 'path'
 fs = require 'fs'
-
+temp = require('temp').track()
 LessCache = require 'less-cache'
 
 module.exports = (grunt) ->
+  {rm} = require('./task-helpers')(grunt)
+
+  compileBootstrap = ->
+    appDir = grunt.config.get('atom.appDir')
+    bootstrapLessPath = path.join(appDir, 'static', 'bootstrap.less')
+    bootstrapCssPath = path.join(appDir, 'static', 'bootstrap.css')
+
+    lessCache = new LessCache
+      cacheDir: temp.mkdirSync('atom-less-cache')
+      resourcePath: path.resolve('.')
+
+    bootstrapCss = lessCache.readFileSync(bootstrapLessPath)
+    grunt.file.write(bootstrapCssPath, bootstrapCss)
+    rm(bootstrapLessPath)
+
   grunt.registerMultiTask 'prebuild-less', 'Prebuild cached of compiled LESS files', ->
     prebuiltConfigurations = [
       ['atom-dark-ui', 'atom-dark-syntax']
@@ -78,3 +93,5 @@ module.exports = (grunt) ->
       for file in themeMains
         grunt.verbose.writeln("File #{file.cyan} created in cache.")
         cssForFile(file)
+
+    compileBootstrap()


### PR DESCRIPTION
Precompile the `static/bootstrap.less` file and ship a `static/bootstrap.css` instead.

This shaves ~10ms off of startup since the less import cache checks aren't run and the file system is only hit once for the `.css` file instead of 10 times for all the bootstrap imports.
