### PR TITLE
Changes ATOM_HOME on Windows to be APPDATA.

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -76,13 +76,13 @@ var setupCoffeeCache = function(cacheDir) {
 
 var setupAtomHome = function() {
   if (!process.env.ATOM_HOME) {
-    var home;
+    var atomHome;
     if (process.platform === 'win32') {
-      home = process.env.USERPROFILE;
-    } else {
-      home = process.env.HOME;
+      atomHome = path.join(process.env.APPDATA, 'atom');
     }
-    var atomHome = path.join(home, '.atom');
+    else {
+      atomHome = path.join(process.env.HOME, '.atom');
+    }
     try {
       atomHome = fs.realpathSync(atomHome);
     } catch (error) {


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/6345.

This doesn't address the migration issue where a user may be upgrading from a previous version of ATOM and have files currently stored in `~/.atom`.  How this is resolved is a much bigger design decision than I am qualified to make so I will leave it up to the Atom maintainers.

My 2 cents is that migration occurs on first-run after an upgrade.  It is unclear to me if Atom has mechanisms in place to make this easy or not.  Alternatively, every run of atom could check to see if there are files in the old location and if so, migrate them.
