### PR TITLE
Fix some of the specs which fail on Linux

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -24,7 +24,7 @@ TextEditorElement = require '../src/text-editor-element'
 TokenizedBuffer = require '../src/tokenized-buffer'
 TextEditorComponent = require '../src/text-editor-component'
 pathwatcher = require 'pathwatcher'
-clipboard = require "../src/native-clipboard"
+clipboard = require "../src/safe-clipboard"
 
 atom.themes.loadBaseStylesheets()
 atom.themes.requireStylesheet '../static/jasmine'

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -24,7 +24,7 @@ TextEditorElement = require '../src/text-editor-element'
 TokenizedBuffer = require '../src/tokenized-buffer'
 TextEditorComponent = require '../src/text-editor-component'
 pathwatcher = require 'pathwatcher'
-clipboard = require 'clipboard'
+clipboard = require "../src/native-clipboard"
 
 atom.themes.loadBaseStylesheets()
 atom.themes.requireStylesheet '../static/jasmine'

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -24,7 +24,7 @@ TextEditorElement = require '../src/text-editor-element'
 TokenizedBuffer = require '../src/tokenized-buffer'
 TextEditorComponent = require '../src/text-editor-component'
 pathwatcher = require 'pathwatcher'
-clipboard = require "../src/safe-clipboard"
+clipboard = require '../src/safe-clipboard'
 
 atom.themes.loadBaseStylesheets()
 atom.themes.requireStylesheet '../static/jasmine'

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -2444,7 +2444,7 @@ describe "TextEditorComponent", ->
         initialLineHeightInPixels = editor.getLineHeightInPixels()
         initialCharWidth = editor.getDefaultCharWidth()
 
-        component.setFontFamily('sans-serif')
+        component.setFontFamily('serif')
         expect(editor.getDefaultCharWidth()).toBe initialCharWidth
 
         wrapperView.show()
@@ -2453,7 +2453,7 @@ describe "TextEditorComponent", ->
       it "does not re-measure character widths until the editor is shown again", ->
         wrapperView.hide()
 
-        component.setFontFamily('sans-serif')
+        component.setFontFamily('serif')
 
         wrapperView.show()
         editor.setCursorBufferPosition([0, Infinity])

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -2816,7 +2816,7 @@ describe "TextEditorComponent", ->
       clipboardWrittenTo = false
       spyOn(require('ipc'), 'send').andCallFake (eventName, selectedText) ->
         if eventName is 'write-text-to-selection-clipboard'
-          require('../src/native-clipboard').writeText(selectedText, 'selection')
+          require('../src/safe-clipboard').writeText(selectedText, 'selection')
           clipboardWrittenTo = true
 
       atom.clipboard.write('')

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -2815,7 +2815,7 @@ describe "TextEditorComponent", ->
       clipboardWrittenTo = false
       spyOn(require('ipc'), 'send').andCallFake (eventName, selectedText) ->
         if eventName is 'write-text-to-selection-clipboard'
-          require('clipboard').writeText(selectedText, 'selection')
+          require('../src/native-clipboard').writeText(selectedText, 'selection')
           clipboardWrittenTo = true
 
       atom.clipboard.write('')

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1340,7 +1340,8 @@ describe "TextEditorComponent", ->
       afterEach ->
         atom.restoreWindowDimensions()
 
-      it "slides horizontally left when near the right edge", ->
+      # This spec should actually run on Linux as well, see TextEditorComponent#measureWindowSize for further information.
+      it "slides horizontally left when near the right edge on #win32 and #darwin", ->
         marker = editor.displayBuffer.markBufferRange([[0, 26], [0, 26]], invalidate: 'never')
         decoration = editor.decorateMarker(marker, {type: 'overlay', item})
         nextAnimationFrame()
@@ -1352,18 +1353,17 @@ describe "TextEditorComponent", ->
         expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
-        if process.platform isnt "linux" # see TextEditorComponent#measureWindowSize
-          editor.insertText('a')
-          nextAnimationFrame()
+        editor.insertText('a')
+        nextAnimationFrame()
 
-          expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
-          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+        expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
+        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
-          editor.insertText('b')
-          nextAnimationFrame()
+        editor.insertText('b')
+        nextAnimationFrame()
 
-          expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
-          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+        expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
+        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
   describe "hidden input field", ->
     it "renders the hidden input field at the position of the last cursor if the cursor is on screen and the editor is focused", ->

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1352,17 +1352,18 @@ describe "TextEditorComponent", ->
         expect(overlay.style.left).toBe position.left + gutterWidth + 'px'
         expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
-        editor.insertText('a')
-        nextAnimationFrame()
+        if process.platform isnt "linux" # see TextEditorComponent#measureWindowSize
+          editor.insertText('a')
+          nextAnimationFrame()
 
-        expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
-        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+          expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
+          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
-        editor.insertText('b')
-        nextAnimationFrame()
+          editor.insertText('b')
+          nextAnimationFrame()
 
-        expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
-        expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
+          expect(overlay.style.left).toBe windowWidth - itemWidth + 'px'
+          expect(overlay.style.top).toBe position.top + editor.getLineHeightInPixels() + 'px'
 
   describe "hidden input field", ->
     it "renders the hidden input field at the position of the last cursor if the cursor is on screen and the editor is focused", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1,4 +1,4 @@
-clipboard = require '../src/native-clipboard'
+clipboard = require '../src/safe-clipboard'
 TextEditor = require '../src/text-editor'
 
 describe "TextEditor", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1,4 +1,4 @@
-clipboard = require 'clipboard'
+clipboard = require '../src/native-clipboard'
 TextEditor = require '../src/text-editor'
 
 describe "TextEditor", ->

--- a/spec/tooltip-manager-spec.coffee
+++ b/spec/tooltip-manager-spec.coffee
@@ -1,8 +1,12 @@
 TooltipManager = require '../src/tooltip-manager'
 {$} = require '../src/space-pen-extensions'
+_ = require "underscore-plus"
 
 describe "TooltipManager", ->
   [manager, element] = []
+
+  ctrlX = _.humanizeKeystroke("ctrl-x")
+  ctrlY = _.humanizeKeystroke("ctrl-y")
 
   beforeEach ->
     manager = new TooltipManager
@@ -35,7 +39,7 @@ describe "TooltipManager", ->
 
           hover element, ->
             tooltipElement = document.body.querySelector(".tooltip")
-            expect(tooltipElement).toHaveText "Title ⌃X ⌃Y"
+            expect(tooltipElement).toHaveText "Title #{ctrlX} #{ctrlY}"
 
       describe "when no title is specified", ->
         it "shows the key binding corresponding to the command alone", ->
@@ -45,7 +49,7 @@ describe "TooltipManager", ->
 
           hover element, ->
             tooltipElement = document.body.querySelector(".tooltip")
-            expect(tooltipElement).toHaveText "⌃X ⌃Y"
+            expect(tooltipElement).toHaveText "#{ctrlX} #{ctrlY}"
 
       describe "when a keyBindingTarget is specified", ->
         it "looks up the key binding relative to the target", ->
@@ -57,7 +61,7 @@ describe "TooltipManager", ->
 
           hover element, ->
             tooltipElement = document.body.querySelector(".tooltip")
-            expect(tooltipElement).toHaveText "⌃X ⌃Y"
+            expect(tooltipElement).toHaveText "#{ctrlX} #{ctrlY}"
 
         it "does not display the keybinding if there is nothing mapped to the specified keyBindingCommand", ->
           manager.add element, title: 'A Title', keyBindingCommand: 'test-command', keyBindingTarget: element

--- a/spec/window-spec.coffee
+++ b/spec/window-spec.coffee
@@ -285,19 +285,35 @@ describe "Window", ->
       it "adds it to the project's paths", ->
         pathToOpen = __filename
         atom.getCurrentWindow().send 'message', 'open-locations', [{pathToOpen}]
-        expect(atom.project.getPaths()[0]).toBe __dirname
+
+        waitsFor ->
+          atom.project.getPaths().length is 1
+
+        runs ->
+          expect(atom.project.getPaths()[0]).toBe __dirname
 
     describe "when the opened path does not exist but its parent directory does", ->
       it "adds the parent directory to the project paths", ->
         pathToOpen = path.join(__dirname, 'this-path-does-not-exist.txt')
         atom.getCurrentWindow().send 'message', 'open-locations', [{pathToOpen}]
-        expect(atom.project.getPaths()[0]).toBe __dirname
+
+        waitsFor ->
+          atom.project.getPaths().length is 1
+
+        runs ->
+          expect(atom.project.getPaths()[0]).toBe __dirname
 
     describe "when the opened path is a file", ->
       it "opens it in the workspace", ->
         pathToOpen = __filename
         atom.getCurrentWindow().send 'message', 'open-locations', [{pathToOpen}]
-        expect(atom.workspace.open.mostRecentCall.args[0]).toBe __filename
+
+        waitsFor ->
+          atom.workspace.open.callCount is 1
+
+        runs ->
+          expect(atom.workspace.open.mostRecentCall.args[0]).toBe __filename
+
 
     describe "when the opened path is a directory", ->
       it "does not open it in the workspace", ->

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -256,7 +256,7 @@ class AtomApplication
 
     clipboard = null
     ipc.on 'write-text-to-selection-clipboard', (event, selectedText) ->
-      clipboard ?= require '../native-clipboard'
+      clipboard ?= require '../safe-clipboard'
       clipboard.writeText(selectedText, 'selection')
 
   # Public: Executes the given command.

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -256,7 +256,7 @@ class AtomApplication
 
     clipboard = null
     ipc.on 'write-text-to-selection-clipboard', (event, selectedText) ->
-      clipboard ?= require 'clipboard'
+      clipboard ?= require '../native-clipboard'
       clipboard.writeText(selectedText, 'selection')
 
   # Public: Executes the given command.

--- a/src/clipboard.coffee
+++ b/src/clipboard.coffee
@@ -1,11 +1,5 @@
 crypto = require 'crypto'
-
-# Using clipboard in renderer process is not safe on Linux.
-clipboard =
-  if process.platform is 'linux'
-    require('remote').require 'clipboard'
-  else
-    require 'clipboard'
+clipboard = require "./native-clipboard"
 
 # Extended: Represents the clipboard used for copying and pasting in Atom.
 #

--- a/src/clipboard.coffee
+++ b/src/clipboard.coffee
@@ -1,5 +1,5 @@
 crypto = require 'crypto'
-clipboard = require "./native-clipboard"
+clipboard = require "./safe-clipboard"
 
 # Extended: Represents the clipboard used for copying and pasting in Atom.
 #

--- a/src/clipboard.coffee
+++ b/src/clipboard.coffee
@@ -1,5 +1,5 @@
 crypto = require 'crypto'
-clipboard = require "./safe-clipboard"
+clipboard = require './safe-clipboard'
 
 # Extended: Represents the clipboard used for copying and pasting in Atom.
 #

--- a/src/native-clipboard.coffee
+++ b/src/native-clipboard.coffee
@@ -1,6 +1,0 @@
-# Using clipboard in renderer process is not safe on Linux.
-module.exports =
-  if process.platform is 'linux'
-    require('remote').require 'clipboard'
-  else
-    require 'clipboard'

--- a/src/native-clipboard.coffee
+++ b/src/native-clipboard.coffee
@@ -1,0 +1,6 @@
+# Using clipboard in renderer process is not safe on Linux.
+module.exports =
+  if process.platform is 'linux'
+    require('remote').require 'clipboard'
+  else
+    require 'clipboard'

--- a/src/safe-clipboard.coffee
+++ b/src/safe-clipboard.coffee
@@ -1,0 +1,6 @@
+# Using clipboard in renderer process is not safe on Linux.
+module.exports =
+  if process.platform is "linux" and process.type is "renderer"
+    require("remote").require("clipboard")
+  else
+    require("clipboard")

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -556,7 +556,7 @@ class TextEditorComponent
 
     pasteSelectionClipboard = (event) =>
       if event?.which is 2 and process.platform is 'linux'
-        if selection = require('clipboard').readText('selection')
+        if selection = require('./native-clipboard').readText('selection')
           @editor.insertText(selection)
 
     window.addEventListener('mousemove', onMouseMove)

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -620,6 +620,10 @@ class TextEditorComponent
 
   measureWindowSize: ->
     return unless @mounted
+
+    # FIXME: on Ubuntu (via xvfb) `window.innerWidth` reports an incorrect value
+    # when window gets resized through `atom.setWindowDimensions({width:
+    # windowWidth, height: windowHeight})`.
     @presenter.setWindowSize(window.innerWidth, window.innerHeight)
 
   sampleFontStyling: =>

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -556,7 +556,7 @@ class TextEditorComponent
 
     pasteSelectionClipboard = (event) =>
       if event?.which is 2 and process.platform is 'linux'
-        if selection = require('./native-clipboard').readText('selection')
+        if selection = require('./safe-clipboard').readText('selection')
           @editor.insertText(selection)
 
     window.addEventListener('mousemove', onMouseMove)


### PR DESCRIPTION
While addressing #6248 I discovered some flaky tests: some of them failed only on Linux, some others failed just because they were executed in a slow machine. In both cases, there wasn't a good reason why they should have failed and, therefore, I decided to fix them :green_heart: 

Please note that, although my ultimate goal is to make every spec bullet-proof, the changes here proposed are deliberately not comprehensive: there are a bunch of other tests which need to be inspected (see #6274) but I think it's better to address each of them incrementally, without creating gargantuan pull requests.

Also, I think this highlights the importance of running specs on every platform: even though all the tests hereby addressed were failing because of a bug in the test itself (and not in our production code), there's a quite high risk of introducing bugs on other platforms without noticing it.

An additional pair of :eyes: is most welcome, especially for some changes (in which I am going to write an additional comment).

Thanks :bow: 

/cc: @maxbrunsfeld @nathansobo @kevinsawicki 
