### PR TITLE
Fix static .less prebuilt cache

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -92,6 +92,7 @@ module.exports = (grunt) ->
   prebuildLessConfig =
     src: [
       'static/**/*.less'
+      'node_modules/atom-space-pen-views/stylesheets/**/*.less'
     ]
 
   csonConfig =

--- a/build/tasks/prebuild-less-task.coffee
+++ b/build/tasks/prebuild-less-task.coffee
@@ -21,7 +21,12 @@ module.exports = (grunt) ->
     rm(path.join(appDir, 'node_modules', 'bootstrap', 'less'))
 
   importFallbackVariables = (lessFilePath) ->
-    lessFilePath.indexOf('static') isnt 0
+    if lessFilePath.indexOf('static') is 0
+      false
+    else if lessFilePath.indexOf('atom-space-pen-views') isnt -1
+      false
+    else
+      true
 
   grunt.registerMultiTask 'prebuild-less', 'Prebuild cached of compiled Less files', ->
     compileBootstrap()

--- a/build/tasks/prebuild-less-task.coffee
+++ b/build/tasks/prebuild-less-task.coffee
@@ -20,6 +20,9 @@ module.exports = (grunt) ->
     rm(bootstrapLessPath)
     rm(path.join(appDir, 'node_modules', 'bootstrap', 'less'))
 
+  importFallbackVariables = (lessFilePath) ->
+    lessFilePath.indexOf('static') isnt 0
+
   grunt.registerMultiTask 'prebuild-less', 'Prebuild cached of compiled Less files', ->
     compileBootstrap()
 
@@ -82,12 +85,14 @@ module.exports = (grunt) ->
         importPaths: importPaths
 
       cssForFile = (file) ->
-        baseVarImports = """
-        @import "variables/ui-variables";
-        @import "variables/syntax-variables";
-        """
         less = fs.readFileSync(file, 'utf8')
-        lessCache.cssForFile(file, [baseVarImports, less].join('\n'))
+        if importFallbackVariables(file)
+          baseVarImports = """
+          @import "variables/ui-variables";
+          @import "variables/syntax-variables";
+          """
+          less = [baseVarImports, less].join('\n')
+        lessCache.cssForFile(file, less)
 
       for file in @filesSrc
         grunt.verbose.writeln("File #{file.cyan} created in cache.")


### PR DESCRIPTION
There was a regression at some point where the files under `static/` were not properly prebuilt into the Less cache causing them to be recompiled on the fly during runtime.

This would slow down the very first launch of Atom on a machine before `~/.atom/compile-cache` would be populated.

It would also slow down the first launch after an update whenever a stylesheet under `static/` had been changed.

This saves ~500ms off of the very first Atom launch on a machine by not having to compile the following Less files on the fly:
- `static/atom.less`
- `static/text-editor-shadow.less`
- `node_modules/atom-space-pen-views/stylesheets/select-list.less`

You can see this slow down by deleting `~/.atom/compile-cache/less` and then restarting Atom with `--safe`.
