### PR TITLE
Default `core.followSymlinks` to true

### DIFF
--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -55,7 +55,7 @@ describe "the `atom` global", ->
   describe "loading default config", ->
     it 'loads the default core config', ->
       expect(atom.config.get('core.excludeVcsIgnoredPaths')).toBe true
-      expect(atom.config.get('core.followSymlinks')).toBe false
+      expect(atom.config.get('core.followSymlinks')).toBe true
       expect(atom.config.get('editor.showInvisibles')).toBe false
 
   describe "window onerror handler", ->

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -18,7 +18,7 @@ module.exports =
         title: 'Exclude VCS Ignored Paths'
       followSymlinks:
         type: 'boolean'
-        default: false
+        default: true
         title: 'Follow symlinks'
         description: 'Used when searching and when opening files with the fuzzy finder.'
       disabledPackages:


### PR DESCRIPTION
Now that https://github.com/atom/scandal/pull/21 is merged and there are no more duplicates when searching symlinked files, this should default to true. 
