### PR TITLE
Portable: Uses "userdata" folder if exists inside the application path

### DIFF
--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -69,7 +69,9 @@ setupCrashReporter = ->
 setupAtomHome = ->
   return if process.env.ATOM_HOME
 
-  atomHome = path.join(app.getHomeDir(), '.atom')
+  atomHome = path.join(path.dirname(process.execPath), '.atom')
+  if not fs.existsSync(atomHome)
+    atomHome = path.join(app.getHomeDir(), '.atom')
   try
     atomHome = fs.realpathSync(atomHome)
   process.env.ATOM_HOME = atomHome

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -69,7 +69,7 @@ setupCrashReporter = ->
 setupAtomHome = ->
   return if process.env.ATOM_HOME
 
-  atomHome = path.join(path.dirname(process.execPath), '.atom')
+  atomHome = path.join(path.dirname(process.execPath), 'userdata')
   if not fs.existsSync(atomHome)
     atomHome = path.join(app.getHomeDir(), '.atom')
   try


### PR DESCRIPTION
I like portable apps, but I don't wanna create an env. variable in every computer I plug my USB drive. So I did this to solve my (or everyone's?) problem.
