### PR TITLE
Stop polling document when clearing document requests

### DIFF
--- a/src/view-registry.coffee
+++ b/src/view-registry.coffee
@@ -186,6 +186,7 @@ class ViewRegistry
     @documentWriters = []
     @documentPollers = []
     @documentUpdateRequested = false
+    @stopPollingDocument()
 
   requestDocumentUpdate: ->
     unless @documentUpdateRequested


### PR DESCRIPTION
Fixes #6274 :tada: :tada: :tada:

First of all, you can reproduce some of the failures mentioned in the previous issue by simply checking out **master** and focusing on a `SelectListView` spec and a failing spec on `TextEditorComponent`, e.g.:

``` diff
diff --git a/spec/select-list-view-spec.coffee b/spec/select-list-view-spec.coffee
index e22b24f..106661f 100644
--- a/spec/select-list-view-spec.coffee
+++ b/spec/select-list-view-spec.coffee
@@ -23,7 +23,7 @@ describe "SelectListView", ->
     {list, filterEditorView} = selectList

   describe "when an array is assigned", ->
-    it "populates the list with up to maxItems items, based on the liForElement function", ->
+    fit "populates the list with up to maxItems items, based on the liForElement function", ->
       expect(list.find('li').length).toBe selectList.maxItems
       expect(list.find('li:eq(0)')).toHaveText 'Alpha'
       expect(list.find('li:eq(0)')).toHaveClass 'A'
diff --git a/spec/text-editor-component-spec.coffee b/spec/text-editor-component-spec.coffee
index 769ce42..b518c0b 100644
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -198,7 +198,7 @@ describe "TextEditorComponent", ->
       atom.config.set("editor.showInvisibles", false)
       expect(component.lineNodeForScreenRow(10).textContent).toBe nbsp

-    it "gives the lines div the same background color as the editor to improve GPU performance", ->
+    fit "gives the lines div the same background color as the editor to improve GPU performance", ->
       linesNode = componentNode.querySelector('.lines')
       backgroundColor = getComputedStyle(wrapperNode).backgroundColor
       expect(linesNode.style.backgroundColor).toBe backgroundColor
```

To be fair, this doesn't always cause the specs to fail: in 90% of the cases, though, it does on my machine so I assume it does on yours as well. Running the command below will help if you still cannot reproduce the error:

``` bash
$ sudo nice -n -20 stress --io 8 --cpu 8
```

Back to the randomly failing tests! :fire: 
### Why did they fail, then?

Our `spec-helper` is supposed to clear all the state from previous tests during `beforeEach` and `afterEach`: in practice, however, it doesn't do so for `setInterval` and `clearInterval`. The specs which use those two methods, either directly or indirectly, need to make sure to clean the state themselves or even mock those functions if they need them to write a particular expectation.

Specifically, the root of the failures resided in a dirty `ViewRegistry` which contained an active `setInterval` function instantiated by the previous SUT (e.g. `SelectListView` uses a `TextEditorView`, which in turn uses a `TextEditorComponent`, which in turn uses a `ViewRegistry` via `@pollDocument`) and which were being triggered during `TextEditorComponent` tests. The reason why they presented to ourselves in a randomized fashion, was because the _unmocked_ `setInterval` method was used during `SelectListView` specs and the system triggered the timeout independently from our `advanceClock`.
### A solution

My first reaction was to always mock `setInterval` and `clearInterval`, as `TextEditorComponent` does, in our `spec-helper`, but then I noticed this in `text-editor-presenter-spec.coffee`:

``` coffee
# These *should* be mocked in the spec helper, but changing that now would break packages :-(
spyOn(window, "setInterval").andCallFake window.fakeSetInterval
spyOn(window, "clearInterval").andCallFake window.fakeClearInterval
```
- A quick workaround could be to mock such methods only while running core tests. The question is: do we have a way to recognize when we're in such environment?
- An alternative could be to mock those two methods in `select-list-view-spec`, but we wouldn't use them at all for our test assertions and I'd love not to bother with this stuff every time we deal with a SUT which uses those methods internally (also because we may not be aware of that).

That said, I have decided to put a `@stopPollingDocument` right inside `ViewRegistry#clearDocumentRequests` which, to be fair, seems a quite reasonable tradeoff to me. This seems to have fixed those spurious errors once for all (https://travis-ci.org/atom/atom/jobs/58576153) and I cannot reproduce them locally anymore :tada: 

I'd :heart: to hear your feedback on this :bow: 

/cc: @kevinsawicki @maxbrunsfeld 
