### PR TITLE
Add ability to exclude paths when searching files

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -879,7 +879,7 @@ describe "Workspace", ->
             expect(resultPaths.sort()).toEqual([file1, file2].sort())
 
         describe "when an inclusion path starts with either a tilde or exclamation mark", ->
-          it "the path is used as part of the exclusion array, instead of inclusion", ->
+          it "excludes that path", ->
             waitsForPromise ->
               resultPaths = []
               atom.workspace

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -878,6 +878,24 @@ describe "Workspace", ->
           runs ->
             expect(resultPaths.sort()).toEqual([file1, file2].sort())
 
+        describe "when an inclusion path starts with either a tilde or exclamation mark", ->
+          it "the path is used as part of the exclusion array, instead of inclusion", ->
+            waitsForPromise ->
+              resultPaths = []
+              atom.workspace
+                .scan /aaaa/, paths:["dir"], ({filePath}) ->
+                  resultPaths.push(filePath) unless filePath in resultPaths
+                .then ->
+                  expect(resultPaths).equalTo([file1])
+                  
+            waitsForPromise ->
+              resultPaths = []
+              atom.workspace
+                .scan /aaaa/, paths:["!dir"], ({filePath}) ->
+                  resultPaths.push(filePath) unless filePath in resultPaths
+                .then ->
+                  expect(resultPaths).equalTo([])
+
         describe "when an inclusion path starts with the basename of a root directory", ->
           it "interprets the inclusion path as starting from that directory", ->
             waitsForPromise ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -792,10 +792,10 @@ class Workspace extends Model
 
     searchOptions =
       ignoreCase: regex.ignoreCase
-      inclusions: (path for path in options.paths when path[0]!="!" && path[0]!="~")
+      inclusions: (path for path in options.paths when path[0] isnt "!" and path[0] isnt "~")
       includeHidden: true
       excludeVcsIgnores: atom.config.get('core.excludeVcsIgnoredPaths')
-      exclusions: atom.config.get('core.ignoredNames').concat(path.substring(1) for path in options.paths when path[0]=="!" || path[0]=="~")
+      exclusions: atom.config.get('core.ignoredNames').concat(path.substring(1) for path in options.paths when path[0] is "!" or path[0] is "~")
       follow: atom.config.get('core.followSymlinks')
 
     task = Task.once require.resolve('./scan-handler'), atom.project.getPaths(), regex.source, searchOptions, ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -792,10 +792,10 @@ class Workspace extends Model
 
     searchOptions =
       ignoreCase: regex.ignoreCase
-      inclusions: options.paths
+      inclusions: (path for path in options.paths when path[0]!="!" && path[0]!="~")
       includeHidden: true
       excludeVcsIgnores: atom.config.get('core.excludeVcsIgnoredPaths')
-      exclusions: atom.config.get('core.ignoredNames')
+      exclusions: atom.config.get('core.ignoredNames').concat(path.substring(1) for path in options.paths when path[0]=="!" || path[0]=="~")
       follow: atom.config.get('core.followSymlinks')
 
     task = Task.once require.resolve('./scan-handler'), atom.project.getPaths(), regex.source, searchOptions, ->


### PR DESCRIPTION
I started looking into this when a colleague mentioned the lack of exclusion when searching files in Atom. I'm not sure whether or not what I've done is the _correct_ way of doing it, but from what I can see it is working.

Any search paths that a prefixed with either the tilde or exclamation mark character will be excluded from the scan, with the excluded paths as a prefix (although it appears to work using the glob syntax, as well).

Referencing issue atom/find-and-replace#149
