### PR TITLE
Don't bundle specs and fixtures

### DIFF
--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -143,7 +143,7 @@ module.exports = (grunt) ->
     for directory in packageDirectories
       cp directory, path.join(appDir, directory), filter: filterPackage
 
-    cp 'spec', path.join(appDir, 'spec')
+    cp 'spec', path.join(appDir, 'spec'), filter: /fixtures|integration|.+-spec\.coffee/
     cp 'src', path.join(appDir, 'src'), filter: /.+\.(cson|coffee)$/
     cp 'static', path.join(appDir, 'static')
 


### PR DESCRIPTION
This keeps the spec runner and helpers but not the specs themselves and not the fixtures.

This shaves ~225 files from the app bundle and 1.8M of size.

The spec runner should still run the same for packages and projects with a `spec/` folder.

This only impacts the ability to Atom's specs directly without cloning the repo first.

The remaining spec files shipped are:
- app/spec/atom-reporter.coffee
- app/spec/jasmine-helper.coffee
- app/spec/spec-bootstrap.coffee
- app/spec/spec-helper-platform.coffee
- app/spec/spec-helper.coffee
- app/spec/spec-suite.coffee
- app/spec/time-reporter.coffee

/cc @maxbrunsfeld 
