### PR TITLE
asar optimizations

### DIFF
--- a/src/package.coffee
+++ b/src/package.coffee
@@ -305,8 +305,11 @@ class Package
 
     deferred = Q.defer()
     grammarsDirPath = path.join(@path, 'grammars')
-    fs.list grammarsDirPath, ['json', 'cson'], (error, grammarPaths=[]) ->
-      async.each grammarPaths, loadGrammar, -> deferred.resolve()
+    fs.exists grammarsDirPath, (grammarsDirExists) ->
+      return deferred.resolve() unless grammarsDirExists
+
+      fs.list grammarsDirPath, ['json', 'cson'], (error, grammarPaths=[]) ->
+        async.each grammarPaths, loadGrammar, ->
     deferred.promise
 
   loadSettings: ->
@@ -331,8 +334,11 @@ class Package
     else
       settingsDirPath = path.join(@path, 'settings')
 
-    fs.list settingsDirPath, ['json', 'cson'], (error, settingsPaths=[]) ->
-      async.each settingsPaths, loadSettingsFile, -> deferred.resolve()
+    fs.exists settingsDirPath, (settingsDirExists) ->
+      return deferred.resolve() unless settingsDirExists
+
+      fs.list settingsDirPath, ['json', 'cson'], (error, settingsPaths=[]) ->
+        async.each settingsPaths, loadSettingsFile, -> deferred.resolve()
     deferred.promise
 
   serialize: ->

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -309,7 +309,7 @@ class Package
       return deferred.resolve() unless grammarsDirExists
 
       fs.list grammarsDirPath, ['json', 'cson'], (error, grammarPaths=[]) ->
-        async.each grammarPaths, loadGrammar, ->
+        async.each grammarPaths, loadGrammar, -> deferred.resolve()
     deferred.promise
 
   loadSettings: ->


### PR DESCRIPTION
While profiling startup I noticed that https://github.com/atom/atom-shell/blob/29338e2fa488c87a02a466d28b7f78ff9fc86903/atom/common/lib/asar.coffee#L56 was showing up in the profile a lot.

This fixes that by verifying that the `grammars` and `settings` folders exists before reading them.
