### PR TITLE
Add popover panel API

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -645,6 +645,21 @@ describe "Workspace", ->
         expect(itemView instanceof TestItemElement).toBe(true)
         expect(itemView.getModel()).toBe(model)
 
+    describe '::addPopoverPanel(model)', ->
+      it 'adds a panel to the correct panel container', ->
+        expect(atom.workspace.getPopoverPanels().length).toBe(0)
+        atom.workspace.panelContainers.popover.onDidAddPanel addPanelSpy = jasmine.createSpy()
+
+        model = new TestItem
+        panel = atom.workspace.addPopoverPanel(item: model)
+
+        expect(panel).toBeDefined()
+        expect(addPanelSpy).toHaveBeenCalledWith({panel, index: 0})
+
+        itemView = atom.views.getView(atom.workspace.getPopoverPanels()[0].getItem())
+        expect(itemView instanceof TestItemElement).toBe(true)
+        expect(itemView.getModel()).toBe(model)
+
     describe '::addModalPanel(model)', ->
       it 'adds a panel to the correct panel container', ->
         expect(atom.workspace.getModalPanels().length).toBe(0)

--- a/spec/workspace-view-spec.coffee
+++ b/spec/workspace-view-spec.coffee
@@ -292,5 +292,8 @@ describe "WorkspaceView", ->
       expect(topContainer.nextSibling).toBe workspaceElement.paneContainer
       expect(bottomContainer.previousSibling).toBe workspaceElement.paneContainer
 
+      popoverContainer = workspaceElement.querySelector('atom-panel-container.popover')
+      expect(popoverContainer.parentNode).toBe workspaceElement
+
       modalContainer = workspaceElement.querySelector('atom-panel-container.modal')
       expect(modalContainer.parentNode).toBe workspaceElement

--- a/src/panel-element.coffee
+++ b/src/panel-element.coffee
@@ -23,6 +23,7 @@ class PanelElement extends HTMLElement
   attachedCallback: ->
     callAttachHooks(@getItemView()) # for backward compatibility with SpacePen views
     @visibleChanged(@getModel().isVisible())
+    @positionPopover()
 
   visibleChanged: (visible) ->
     if visible
@@ -30,8 +31,141 @@ class PanelElement extends HTMLElement
     else
       @style.display = 'none'
 
+  positionPopover: ->
+    unless target = @model.target
+      return
+
+    viewport = @model.viewport
+    placement = @model.placement.split ' '
+    panelRect = @getBoundingClientRect()
+    panelRect = # mutable
+      top: panelRect.top
+      bottom: panelRect.bottom
+      left: panelRect.left
+      right: panelRect.right
+      width: panelRect.width
+      height: panelRect.height
+
+    # Target can be a DOM element, a function that returns a rect, or a rect.
+    # If they target is dynamic then the popover is continuously positioned in
+    # a requestAnimationFrame loop until it's hidden.
+    if targetRect = target.getBoundingClientRect?()
+      schedulePositionPopovers()
+    else if targetRect ?= target?()
+      schedulePositionPopovers()
+    else
+      targetRect = target
+
+    # Target can be a DOM element, a function that returns a rect, or a rect.
+    # If they viewport is dynamic then the popover is continuously positioned
+    # in a requestAnimationFrame loop until it's hidden.
+    if viewportRect = viewport?.getBoundingClientRect?()
+      schedulePositionPopovers()
+    else if viewportRect ?= viewport?()
+      schedulePositionPopovers()
+    else
+      viewportRect = viewport
+
+    placePrimary = placement[0]
+    placeSecondary = placement[1]
+    constraintedPlacePrimary = placePrimary
+
+    # Initial positioning and report when out of viewport
+    out = @positionPopoverRect panelRect, targetRect, placePrimary, placeSecondary, viewportRect
+
+    # Flip placement and reposition panel rect if out of viewport
+    if out.top and constraintedPlacePrimary is 'top'
+      constraintedPlacePrimary = 'bottom'
+    else if out.bottom and constraintedPlacePrimary is 'bottom'
+      constraintedPlacePrimary = 'top'
+    else if out.left and constraintedPlacePrimary is 'left'
+      constraintedPlacePrimary = 'right'
+    else if out.right and constraintedPlacePrimary is 'right'
+      constraintedPlacePrimary = 'left'
+
+    unless placePrimary is constraintedPlacePrimary
+      out = @positionPopoverRect panelRect, targetRect, constraintedPlacePrimary, placeSecondary, viewportRect
+
+    # Constrain panel rect to viewport
+    if out.top
+      panelRect.top = viewportRect.top
+    else if out.bottom
+      panelRect.top = viewportRect.bottom - panelRect.height
+    else if out.left
+      panelRect.left = viewportRect.left
+    else if out.right
+      panelRect.left = viewportRect.right - panelRect.width
+
+    # Update panel top, left style if changed
+    unless @cachedTop is panelRect.top and @cachedLeft is panelRect.left
+      unless @_arrowDIV
+        @_arrowDIV = document.createElement 'div'
+        @_arrowDIV.classList.add 'arrow'
+        @insertBefore @_arrowDIV, @firstChild
+
+      @setAttribute 'data-arrow', constraintedPlacePrimary
+      @style.top = panelRect.top + 'px'
+      @style.left = panelRect.left + 'px'
+      @cachedTop = panelRect.top
+      @cachedLeft = panelRect.left
+
+  positionPopoverRect: (panelRect, targetRect, placePrimary, placeSecondary, viewportRect) ->
+    switch placePrimary
+      when 'top'
+        panelRect.top = targetRect.top - panelRect.height
+      when 'bottom'
+        panelRect.top = targetRect.bottom
+      when 'left'
+        panelRect.left = targetRect.left - panelRect.width
+      when 'right'
+        panelRect.left = targetRect.right
+
+    switch placeSecondary
+      when 'left'
+        panelRect.left = targetRect.left
+      when 'center'
+        panelRect.left = targetRect.left - ((panelRect.width - targetRect.width) / 2.0)
+      when 'right'
+        panelRect.left = targetRect.right - panelRect.width
+      when 'top'
+        panelRect.top = targetRect.top
+      when 'middle'
+        panelRect.top = targetRect.top - ((panelRect.height - targetRect.height) / 2.0)
+      when 'bottom'
+        panelRect.top = targetRect.bottom - panelRect.height
+
+    panelRect.bottom = panelRect.top + panelRect.height
+    panelRect.right = panelRect.left + panelRect.width
+    out = {}
+
+    if viewportRect
+      if panelRect.top < viewportRect.top
+        out['top'] = true
+      if panelRect.bottom > viewportRect.bottom
+        out['bottom'] = true
+      if panelRect.left < viewportRect.left
+        out['left'] = true
+      if panelRect.right > viewportRect.right
+        out['right'] = true
+
+    out
+
   destroyed: ->
     @subscriptions.dispose()
     @parentNode?.removeChild(this)
+
+
+# Popover positioning is performed in a `requestAnimationFrame` loop when
+# either of `target` or `viewport` are dynamic (ie functions or elements)
+positionPopoversFrameID = null
+schedulePositionPopovers = ->
+  unless positionPopoversFrameID
+    positionPopoversFrameID = window.requestAnimationFrame positionPopovers
+
+positionPopovers = ->
+  positionPopoversFrameID = null
+  for panel in atom.workspace.getPopoverPanels()
+    if panel.isVisible()
+      atom.views.getView(panel).positionPopover()
 
 module.exports = PanelElement = document.registerElement 'atom-panel', prototype: PanelElement.prototype

--- a/src/panel.coffee
+++ b/src/panel.coffee
@@ -14,10 +14,11 @@ class Panel
   Section: Construction and Destruction
   ###
 
-  constructor: ({@item, @visible, @priority, @className}={}) ->
+  constructor: ({@item, @visible, @priority, @className, @target, @viewport, @placement}={}) ->
     @emitter = new Emitter
     @visible ?= true
     @priority ?= 100
+    @placement ?= 'top center'
 
   # Public: Destroy and remove this panel from the UI.
   destroy: ->

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -72,6 +72,7 @@ class WorkspaceElement extends HTMLElement
       left: atom.views.getView(@model.panelContainers.left)
       right: atom.views.getView(@model.panelContainers.right)
       bottom: atom.views.getView(@model.panelContainers.bottom)
+      popover: atom.views.getView(@model.panelContainers.popover)
       modal: atom.views.getView(@model.panelContainers.modal)
 
     @horizontalAxis.insertBefore(@panelContainers.left, @verticalAxis)
@@ -80,6 +81,7 @@ class WorkspaceElement extends HTMLElement
     @verticalAxis.insertBefore(@panelContainers.top, @paneContainer)
     @verticalAxis.appendChild(@panelContainers.bottom)
 
+    @appendChild(@panelContainers.popover)
     @appendChild(@panelContainers.modal)
 
     @__spacePenView.setModel(@model) if Grim.includeDeprecatedAPIs

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -51,6 +51,7 @@ class Workspace extends Model
       left: new PanelContainer({location: 'left'})
       right: new PanelContainer({location: 'right'})
       bottom: new PanelContainer({location: 'bottom'})
+      popover: new PanelContainer({location: 'popover'})
       modal: new PanelContainer({location: 'modal'})
 
     @subscribeToActiveItem()
@@ -734,6 +735,24 @@ class Workspace extends Model
   # Returns a {Panel}
   addTopPanel: (options) ->
     @addPanel('top', options)
+
+  # Essential: Get an {Array} of all the popover panel items
+  getPopoverPanels: ->
+    @getPanels('popover')
+
+  # Essential: Adds a panel item as a popover.
+  #
+  # * `options` {Object}
+  #   * `item` Your panel content. It can be DOM element, a jQuery element, or
+  #     a model with a view registered via {ViewRegistry::addViewProvider}. We recommend the
+  #     latter. See {ViewRegistry::addViewProvider} for more information.
+  #   * `visible` (optional) {Boolean} false if you want the panel to initially be hidden
+  #     (default: true)
+  #   * `priority` (optional) {Number} Determines stacking order. (default: 100)
+  #
+  # Returns a {Panel}
+  addPopoverPanel: (options={}) ->
+    @addPanel('popover', options)
 
   # Essential: Get an {Array} of all the modal panel items
   getModalPanels: ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -744,11 +744,17 @@ class Workspace extends Model
   #
   # * `options` {Object}
   #   * `item` Your panel content. It can be DOM element, a jQuery element, or
-  #     a model with a view registered via {ViewRegistry::addViewProvider}. We recommend the
-  #     latter. See {ViewRegistry::addViewProvider} for more information.
-  #   * `visible` (optional) {Boolean} false if you want the panel to initially be hidden
-  #     (default: true)
-  #   * `priority` (optional) {Number} Determines stacking order. (default: 100)
+  #     `a model with a view registered via {ViewRegistry::addViewProvider}.
+  #     `We recommend the latter. See {ViewRegistry::addViewProvider} for more
+  #     `information.
+  #   * `target` {Element} or {Function} or {Rect} Target rectangle around
+  #     `which popover is placed.
+  #   * `viewport` (optional) {Element} or {Function} or {Rect} Keeps the
+  #     `popover within the viewport rectangle. (default: null)
+  #   * `placement` (optional) {String} How to position the popover. (default:
+  #     `"top center")
+  #   * `visible` (optional) {Boolean} false if you want the panel to
+  #     `initially be hidden (default: true)
   #
   # Returns a {Panel}
   addPopoverPanel: (options={}) ->

--- a/static/panels.less
+++ b/static/panels.less
@@ -72,6 +72,17 @@ atom-panel.right {
   background-color: @tool-panel-background-color;
 }
 
+// Popover panels
+
+atom-panel-container.popover {
+  position: absolute;
+  top: 0;
+  z-index: 5000;
+  > atom-panel {
+    position: absolute;
+  }
+}
+
 // Modal panels
 
 .overlay, // deprecated .overlay


### PR DESCRIPTION
Currently Atom has panel layers for top/left/right/bottom and modal. I think it would also be useful to have a 'popover' panel layer. This would be an absolutely positioned layer above all other window content (except modal panel layer). Panels are absolute positioned within it. Benefits include:
1. A standard place (using existing panel API) for inserting overlay elements. Now it seems the common practice is for packages to insert popover UI arbitrarily into the DOM.
2. Support more use cases then TextEditor 'overlay' decorations, because the popover panel layer would allow popovers anywhere in the Atom window, not just within a text editor. This layer might also be a place to solve https://github.com/atom/atom/issues/5469.
3. Optionally implement popover layout logic once instead of having each package implement it badly once. Popover layout logic is somewhat complex since generally popovers want to be positioned relative to an existing element while also not being clipped by screen edges.

This pull request is a minimal start. It defines the popover layer and API for adding panels. But it doesn't perform any positioning logic. Assuming people like this idea I would also like to add positioning options and logic with the basic goal being:
1. Uses should be able to position panel at arbitrary position on screen
2. Or users should be able to position panel relative to an existing element on screen similar to Cocoa's [NSPopover](https://developer.apple.com/library/mac/documentation/AppKit/Reference/NSPopover_Class/index.html#//apple_ref/occ/instm/NSPopover/showRelativeToRect:ofView:preferredEdge:).

Thoughts?
