### PR TITLE
Don't load settings from disk when a save has been requested

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -854,7 +854,7 @@ describe "Config", ->
             expect(atom.config.get('foo.bar')).toBe 'baz'
             expect(atom.config.get('foo.baz')).toBe 'ok'
 
-        describe 'when the default value is a complex value', ->
+        describe "when the default value is a complex value", ->
           beforeEach ->
             atom.config.setSchema 'foo.bar',
               type: 'array'
@@ -877,7 +877,7 @@ describe "Config", ->
               expect(atom.config.get('foo.bar')).toEqual ['baz', 'ok']
               expect(atom.config.get('foo.baz')).toBe 'another'
 
-        describe 'when scoped settings are used', ->
+        describe "when scoped settings are used", ->
           it "fires a change event for scoped settings that are removed", ->
             scopedSpy = jasmine.createSpy()
             atom.config.onDidChange('foo.scoped', scope: ['.source.ruby'], scopedSpy)


### PR DESCRIPTION
Fixes #5771

When we change config values rapidly, we end up detecting our own changes to the user config file, causing a load to be requested. If we have made changes to the config since the last write that haven't yet been saved, our changes end up getting clobbered when the stale values are loaded. My simple solution is to just never load values from disk when there are unsaved changes pending.

This is actually a pretty nuanced problem to get right in the general case, and reminds me of the kinds of problems databases deal with. The sync API backed by async persistence is especially tricky. But I think for our limited case, it should be fine to suppress loading config for a brief window when we're about to write to it again.

/cc @maxbrunsfeld since this interacts with your original improvements to make config reads and writes asynchronous.
