### PR TITLE
use electron instead of atom-shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ node_modules
 npm-debug.log
 debug.log
 /tags
-/atom-shell/
+/electron/
 docs/output
 docs/includes
 spec/fixtures/evil-files/

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -22,7 +22,7 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks('grunt-contrib-coffee')
   grunt.loadNpmTasks('grunt-contrib-less')
   grunt.loadNpmTasks('grunt-shell')
-  grunt.loadNpmTasks('grunt-download-atom-shell')
+  grunt.loadNpmTasks('grunt-download-electron')
   grunt.loadNpmTasks('grunt-atom-shell-installer')
   grunt.loadNpmTasks('grunt-peg')
   grunt.loadTasks('tasks')
@@ -42,7 +42,7 @@ module.exports = (grunt) ->
   installDir = grunt.option('install-dir')
 
   home = if process.platform is 'win32' then process.env.USERPROFILE else process.env.HOME
-  atomShellDownloadDir = path.join(home, '.atom', 'atom-shell')
+  electronDownloadDir = path.join(home, '.atom', 'electron')
 
   symbolsDir = path.join(buildDir, 'Atom.breakpad.syms')
   shellAppDir = path.join(buildDir, appName)
@@ -193,10 +193,10 @@ module.exports = (grunt) ->
         'static/**/*.less'
       ]
 
-    'download-atom-shell':
-      version: packageJson.atomShellVersion
-      outputDir: 'atom-shell'
-      downloadDir: atomShellDownloadDir
+    'download-electron':
+      version: packageJson.electronVersion
+      outputDir: 'electron'
+      downloadDir: electronDownloadDir
       rebuild: true  # rebuild native modules after atom-shell is updated
       token: process.env.ATOM_ACCESS_TOKEN
 
@@ -221,7 +221,7 @@ module.exports = (grunt) ->
   grunt.registerTask('lint', ['coffeelint', 'csslint', 'lesslint'])
   grunt.registerTask('test', ['shell:kill-atom', 'run-specs'])
 
-  ciTasks = ['output-disk-space', 'download-atom-shell', 'download-atom-shell-chromedriver', 'build']
+  ciTasks = ['output-disk-space', 'download-electron', 'download-electron-chromedriver', 'build']
   ciTasks.push('dump-symbols') if process.platform isnt 'win32'
   ciTasks.push('set-version', 'check-licenses', 'lint', 'generate-asar')
   ciTasks.push('mkdeb') if process.platform is 'linux'
@@ -231,6 +231,6 @@ module.exports = (grunt) ->
   ciTasks.push('publish-build') unless process.env.TRAVIS
   grunt.registerTask('ci', ciTasks)
 
-  defaultTasks = ['download-atom-shell', 'download-atom-shell-chromedriver', 'build', 'set-version', 'generate-asar']
+  defaultTasks = ['download-electron', 'download-electron-chromedriver', 'build', 'set-version', 'generate-asar']
   defaultTasks.push 'install' unless process.platform is 'linux'
   grunt.registerTask('default', defaultTasks)

--- a/build/package.json
+++ b/build/package.json
@@ -20,7 +20,7 @@
     "grunt-contrib-csslint": "~0.1.2",
     "grunt-contrib-less": "~0.8.0",
     "grunt-cson": "0.14.0",
-    "grunt-download-atom-shell": "~0.12.0",
+    "grunt-download-electron": "~1.0.1",
     "grunt-lesslint": "0.13.0",
     "grunt-peg": "~1.1.0",
     "grunt-shell": "~0.3.1",

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -9,15 +9,15 @@ module.exports = (grunt) ->
     shellAppDir = grunt.config.get('atom.shellAppDir')
     buildDir = grunt.config.get('atom.buildDir')
     appDir = grunt.config.get('atom.appDir')
-
+    console.log shellAppDir, buildDir, appDir
     rm shellAppDir
     rm path.join(buildDir, 'installer')
     mkdir path.dirname(buildDir)
 
     if process.platform is 'darwin'
-      cp 'atom-shell/Atom.app', shellAppDir, filter: /default_app/
+      cp 'electron/Atom.app', shellAppDir, filter: /default_app/
     else
-      cp 'atom-shell', shellAppDir, filter: /default_app/
+      cp 'electron', shellAppDir, filter: /default_app/
 
     mkdir appDir
 

--- a/build/tasks/clean-task.coffee
+++ b/build/tasks/clean-task.coffee
@@ -10,8 +10,8 @@ module.exports = (grunt) ->
     rm grunt.config.get('atom.buildDir')
     rm require('../src/coffee-cache').cacheDir
     rm require('../src/less-compile-cache').cacheDir
-    rm path.join(tmpdir, 'atom-cached-atom-shells')
-    rm 'atom-shell'
+    rm path.join(tmpdir, 'atom-cached-electrons')
+    rm 'electron'
 
   grunt.registerTask 'clean', 'Delete all the build files', ->
     homeDir = process.env[if process.platform is 'win32' then 'USERPROFILE' else 'HOME']

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "url": "http://github.com/atom/atom/raw/master/LICENSE.md"
     }
   ],
-  "atomShellVersion": "0.22.3",
+  "electronVersion": "0.24.0",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^5.1.2",

--- a/script/clean
+++ b/script/clean
@@ -19,15 +19,15 @@ var commands = [
   [__dirname, '..', 'node_modules'],
   [__dirname, '..', 'build', 'node_modules'],
   [__dirname, '..', 'apm', 'node_modules'],
-  [__dirname, '..', 'atom-shell'],
+  [__dirname, '..', 'electron'],
   [home, '.atom', '.node-gyp'],
   [home, '.atom', 'storage'],
   [home, '.atom', '.apm'],
   [home, '.atom', '.npm'],
   [home, '.atom', 'compile-cache'],
-  [home, '.atom', 'atom-shell'],
+  [home, '.atom', 'electron'],
   [tmpdir, 'atom-build'],
-  [tmpdir, 'atom-cached-atom-shells'],
+  [tmpdir, 'atom-cached-electrons'],
 ];
 var run = function() {
   var next = commands.shift();

--- a/spec/integration/helpers/start-atom.coffee
+++ b/spec/integration/helpers/start-atom.coffee
@@ -9,7 +9,7 @@ webdriverio = require "../../../build/node_modules/webdriverio"
 
 AtomPath = remote.process.argv[0]
 AtomLauncherPath = path.join(__dirname, "..", "helpers", "atom-launcher.sh")
-ChromedriverPath = path.resolve(__dirname, '..', '..', '..', 'atom-shell', 'chromedriver', 'chromedriver')
+ChromedriverPath = path.resolve(__dirname, '..', '..', '..', 'electron', 'chromedriver', 'chromedriver')
 SocketPath = path.join(temp.mkdirSync("socket-dir"), "atom-#{process.env.USER}.sock")
 ChromedriverPort = 9515
 ChromedriverURLBase = "/wd/hub"


### PR DESCRIPTION
The one thing I can't understand is why the built app is called Electron.app instead of Atom.app. Help?
