### PR TITLE
:arrow_up: babel-core@5.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "async": "0.2.6",
     "atom-keymap": "^5.1.2",
     "atom-space-pen-views": "^2.0.4",
-    "babel-core": "^4.0.2",
+    "babel-core": "^5.1.11",
     "bootstrap": "git+https://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",
     "clear-cut": "^2.0.1",
     "coffee-cash": "0.8.0",

--- a/src/babel.coffee
+++ b/src/babel.coffee
@@ -28,10 +28,6 @@ defaultOptions =
     'useStrict'
   ]
 
-  # Includes support for es7 features listed at:
-  # http://babeljs.io/docs/usage/transformers/#es7-experimental-.
-  experimental: true
-
   optional: [
     # Target a version of the regenerator runtime that
     # supports yield so the transpiled code is cleaner/smaller.
@@ -42,6 +38,11 @@ defaultOptions =
     # JSX transformer produces pre-v0.12 code.
     'reactCompat'
   ]
+
+  # Includes support for es7 features listed at:
+  # http://babeljs.io/docs/usage/experimental/.
+  stage: 0
+
 
 ###
 shasum - Hash with an update() method.


### PR DESCRIPTION
Bump babel-core from 4.0.2 to 5.1.11.

Note that this is a major version bump, so `babel.coffee` also had to be updated to reflect the minor API changes.

Notable new features from the [changelog](https://github.com/babel/babel/blob/master/CHANGELOG.md) since 4.0.2:
- Add [trailing function comma proposal](https://github.com/jeffmo/es-trailing-function-commas).
- Decorators based on [@wycat's stage 1 proposal](https://github.com/wycats).

There is a number of bug fixes and performance improvements, as well.

One new error that users are likely to run into is this one in subclass constructors that reference `this` but not `super`:

```
'this' is not allowed before super()
```

As best I can tell, this was a recent-ish update to the ES6 constructor semantics spec that Babel is now enforcing: https://gist.github.com/allenwb/53927e46b31564168a1d. /cc @sebmck
