### PR TITLE
Do not bundle package specs

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -69,6 +69,8 @@ module.exports = (grunt) ->
       expand: true
       src: [
         'src/**/*.coffee'
+        'spec/*.coffee'
+        '!spec/*-spec.coffee'
         'exports/**/*.coffee'
         'static/**/*.coffee'
       ]

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -128,7 +128,7 @@ module.exports = (grunt) ->
       lessConfig.glob_to_multiple.src.push("#{directory}/**/*.less")
       prebuildLessConfig.src.push("#{directory}/**/*.less") unless theme
       csonConfig.glob_to_multiple.src.push("#{directory}/**/*.cson")
-      pegConfig.glob_to_multiple.src.push("#{directory}/**/*.pegjs")
+      pegConfig.glob_to_multiple.src.push("#{directory}/lib/*.pegjs")
 
   grunt.initConfig
     pkg: grunt.file.readJSON('package.json')

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -125,9 +125,13 @@ module.exports = (grunt) ->
     {engines, theme} = grunt.file.readJSON(metadataPath)
     if engines?.atom?
       coffeeConfig.glob_to_multiple.src.push("#{directory}/**/*.coffee")
+      coffeeConfig.glob_to_multiple.src.push("!#{directory}/spec/**/*.coffee")
+
       lessConfig.glob_to_multiple.src.push("#{directory}/**/*.less")
       prebuildLessConfig.src.push("#{directory}/**/*.less") unless theme
+
       csonConfig.glob_to_multiple.src.push("#{directory}/**/*.cson")
+
       pegConfig.glob_to_multiple.src.push("#{directory}/lib/*.pegjs")
 
   grunt.initConfig

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -128,9 +128,11 @@ module.exports = (grunt) ->
       coffeeConfig.glob_to_multiple.src.push("!#{directory}/spec/**/*.coffee")
 
       lessConfig.glob_to_multiple.src.push("#{directory}/**/*.less")
+      lessConfig.glob_to_multiple.src.push("!#{directory}/spec/**/*.less")
       prebuildLessConfig.src.push("#{directory}/**/*.less") unless theme
 
       csonConfig.glob_to_multiple.src.push("#{directory}/**/*.cson")
+      csonConfig.glob_to_multiple.src.push("!#{directory}/spec/**/*.cson")
 
       pegConfig.glob_to_multiple.src.push("#{directory}/lib/*.pegjs")
 

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -129,7 +129,10 @@ module.exports = (grunt) ->
 
       lessConfig.glob_to_multiple.src.push("#{directory}/**/*.less")
       lessConfig.glob_to_multiple.src.push("!#{directory}/spec/**/*.less")
-      prebuildLessConfig.src.push("#{directory}/**/*.less") unless theme
+
+      unless theme
+        prebuildLessConfig.src.push("#{directory}/**/*.less")
+        prebuildLessConfig.src.push("!#{directory}/spec/**/*.less")
 
       csonConfig.glob_to_multiple.src.push("#{directory}/**/*.cson")
       csonConfig.glob_to_multiple.src.push("!#{directory}/spec/**/*.cson")

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -63,6 +63,8 @@ module.exports = (grunt) ->
       path.join('npm', 'node_modules', '.bin', 'clear')
       path.join('npm', 'node_modules', '.bin', 'starwars')
       path.join('pegjs', 'examples')
+      path.join('get-parameter-names', 'node_modules', 'testla')
+      path.join('get-parameter-names', '.bin', 'testla')
       path.join('jasmine-reporters', 'ext')
       path.join('jasmine-node', 'node_modules', 'gaze')
       path.join('jasmine-node', 'spec')

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -26,6 +26,7 @@ module.exports = (grunt) ->
 
     cp 'package.json', path.join(appDir, 'package.json')
 
+    packageNames = []
     packageDirectories = []
     nonPackageDirectories = [
       'benchmark'
@@ -39,6 +40,7 @@ module.exports = (grunt) ->
       directory = path.join('node_modules', child)
       if isAtomPackage(directory)
         packageDirectories.push(directory)
+        packageNames.push(child)
       else
         nonPackageDirectories.push(directory)
 
@@ -92,6 +94,9 @@ module.exports = (grunt) ->
       '.pairs'
       '.travis.yml'
     ]
+
+    packageNames.forEach (packageName) -> ignoredPaths.push(path.join(packageName, 'spec'))
+
     ignoredPaths = ignoredPaths.map (ignoredPath) -> _.escapeRegExp(ignoredPath)
 
     # Add .* to avoid matching hunspell_dictionaries.

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -87,6 +87,10 @@ module.exports = (grunt) ->
       path.join('snippets', 'node_modules', 'pegjs')
       path.join('snippets', 'node_modules', '.bin', 'pegjs')
 
+      # These aren't needed since WeakMap is built-in
+      path.join('emissary', 'node_modules', 'es6-weak-map')
+      path.join('property-accessors', 'node_modules', 'es6-weak-map')
+
       '.DS_Store'
       '.jshintrc'
       '.npmignore'

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -98,6 +98,7 @@ module.exports = (grunt) ->
       '.lint'
       '.lintignore'
       '.eslintrc'
+      '.jshintignore'
     ]
 
     packageNames.forEach (packageName) -> ignoredPaths.push(path.join(packageName, 'spec'))

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -93,6 +93,7 @@ module.exports = (grunt) ->
       '.pairs'
       '.travis.yml'
       'appveyor.yml'
+      '.idea'
     ]
 
     packageNames.forEach (packageName) -> ignoredPaths.push(path.join(packageName, 'spec'))

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -126,7 +126,7 @@ module.exports = (grunt) ->
       ignoredPaths.push path.join('spellchecker', 'vendor', 'hunspell_dictionaries')
     ignoredPaths = ignoredPaths.map (ignoredPath) -> "(#{ignoredPath})"
 
-    testFolderPattern = new RegExp("#{_.escapeRegExp(path.sep)}te?sts?#{_.escapeRegExp(path.sep)}")
+    testFolderPattern = new RegExp("#{_.escapeRegExp(path.sep)}_*te?sts?_*#{_.escapeRegExp(path.sep)}")
     exampleFolderPattern = new RegExp("#{_.escapeRegExp(path.sep)}examples?#{_.escapeRegExp(path.sep)}")
     benchmarkFolderPattern = new RegExp("#{_.escapeRegExp(path.sep)}benchmarks?#{_.escapeRegExp(path.sep)}")
 

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -64,7 +64,7 @@ module.exports = (grunt) ->
       path.join('npm', 'node_modules', '.bin', 'starwars')
       path.join('pegjs', 'examples')
       path.join('get-parameter-names', 'node_modules', 'testla')
-      path.join('get-parameter-names', '.bin', 'testla')
+      path.join('get-parameter-names', 'node_modules', '.bin', 'testla')
       path.join('jasmine-reporters', 'ext')
       path.join('jasmine-node', 'node_modules', 'gaze')
       path.join('jasmine-node', 'spec')

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -162,7 +162,6 @@ module.exports = (grunt) ->
     for directory in packageDirectories
       cp directory, path.join(appDir, directory), filter: filterPackage
 
-    cp 'spec', path.join(appDir, 'spec'), filter: /fixtures|integration|.+-spec\.coffee/
     cp 'src', path.join(appDir, 'src'), filter: /.+\.(cson|coffee)$/
     cp 'static', path.join(appDir, 'static')
 

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -99,6 +99,8 @@ module.exports = (grunt) ->
       '.lintignore'
       '.eslintrc'
       '.jshintignore'
+      '.gitattributes'
+      '.gitkeep'
     ]
 
     packageNames.forEach (packageName) -> ignoredPaths.push(path.join(packageName, 'spec'))

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -81,9 +81,6 @@ module.exports = (grunt) ->
       path.join('resources', 'win')
 
       # These are only require in dev mode when the grammar isn't precompiled
-      path.join('atom-keymap', 'node_modules', 'loophole')
-      path.join('atom-keymap', 'node_modules', 'pegjs')
-      path.join('atom-keymap', 'node_modules', '.bin', 'pegjs')
       path.join('snippets', 'node_modules', 'loophole')
       path.join('snippets', 'node_modules', 'pegjs')
       path.join('snippets', 'node_modules', '.bin', 'pegjs')

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -125,6 +125,7 @@ module.exports = (grunt) ->
     ignoredPaths.push "#{_.escapeRegExp(path.join('runas', 'src') + path.sep)}.*\\.(cc|h)*"
     ignoredPaths.push "#{_.escapeRegExp(path.join('scrollbar-style', 'src') + path.sep)}.*\\.(cc|h)*"
     ignoredPaths.push "#{_.escapeRegExp(path.join('spellchecker', 'src') + path.sep)}.*\\.(cc|h)*"
+    ignoredPaths.push "#{_.escapeRegExp(path.join('keyboard-layout', 'src') + path.sep)}.*\\.(cc|h|mm)*"
 
     # Ignore build files
     ignoredPaths.push "#{_.escapeRegExp(path.sep)}binding\\.gyp$"

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -92,6 +92,7 @@ module.exports = (grunt) ->
       '.npmignore'
       '.pairs'
       '.travis.yml'
+      'appveyor.yml'
     ]
 
     packageNames.forEach (packageName) -> ignoredPaths.push(path.join(packageName, 'spec'))

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -94,6 +94,10 @@ module.exports = (grunt) ->
       '.travis.yml'
       'appveyor.yml'
       '.idea'
+      '.editorconfig'
+      '.lint'
+      '.lintignore'
+      '.eslintrc'
     ]
 
     packageNames.forEach (packageName) -> ignoredPaths.push(path.join(packageName, 'spec'))

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -54,15 +54,19 @@ module.exports = (grunt) ->
         mainPath = require.resolve(path.resolve(moduleDirectory, metadata.main))
         pack.main = path.relative(appDir, mainPath)
 
-      for keymapPath in fs.listSync(path.join(moduleDirectory, 'keymaps'), ['.cson', '.json'])
+      keymapsPath = path.join(moduleDirectory, 'keymaps')
+      for keymapPath in fs.listSync(keymapsPath, ['.cson', '.json'])
         relativePath = path.relative(appDir, keymapPath)
         pack.keymaps[relativePath] = CSON.readFileSync(keymapPath)
         rm keymapPath
+      rm keymapsPath if fs.listSync(keymapsPath).length is 0
 
-      for menuPath in fs.listSync(path.join(moduleDirectory, 'menus'), ['.cson', '.json'])
+      menusPath = path.join(moduleDirectory, 'menus')
+      for menuPath in fs.listSync(menusPath, ['.cson', '.json'])
         relativePath = path.relative(appDir, menuPath)
         pack.menus[relativePath] = CSON.readFileSync(menuPath)
         rm menuPath
+      rm menusPath if fs.listSync(menusPath).length is 0
 
       packages[metadata.name] = pack
 

--- a/build/tasks/output-build-filetypes.coffee
+++ b/build/tasks/output-build-filetypes.coffee
@@ -28,7 +28,7 @@ module.exports = (grunt) ->
 
     if extension = grunt.option('extension')
       types[extension]?.sort().forEach (filePath) ->
-        console.log filePath
+        grunt.log.error filePath
     else
-      extensions.forEach (extension) ->
+      extensions[0...25].forEach (extension) ->
         grunt.log.error "#{extension}: #{types[extension].length}"

--- a/build/tasks/output-build-filetypes.coffee
+++ b/build/tasks/output-build-filetypes.coffee
@@ -8,8 +8,8 @@ module.exports = (grunt) ->
     types = {}
     registerFile = (filePath) ->
       extension = path.extname(filePath) or path.basename(filePath)
-      types[extension] ?= 0
-      types[extension]++
+      types[extension] ?= []
+      types[extension].push(filePath)
 
       if extension is '.asar'
         asar.listPackage(filePath).forEach (archivePath) ->
@@ -20,11 +20,15 @@ module.exports = (grunt) ->
     grunt.file.recurse shellAppDir, (absolutePath, rootPath, relativePath, fileName) -> registerFile(absolutePath)
 
     extensions = Object.keys(types).sort (extension1, extension2) ->
-      diff = types[extension2] - types[extension1]
+      diff = types[extension2].length - types[extension1].length
       if diff is 0
         extension1.toLowerCase().localeCompare(extension2.toLowerCase())
       else
         diff
 
-    extensions.forEach (extension) ->
-      grunt.log.error "#{extension}: #{types[extension]}"
+    if extension = grunt.option('extension')
+      types[extension]?.sort().forEach (filePath) ->
+        console.log filePath
+    else
+      extensions.forEach (extension) ->
+        grunt.log.error "#{extension}: #{types[extension].length}"


### PR DESCRIPTION
#6395 removed core specs and fixtures and this PR removes package specs and fixtures from the bundle to reduce the size.

It also removes a bunch of other unneeded files from the app bundle that I noticed while auditing.

This removes around **~2,500** unneeded files from the app which shrinks `app.asar` by 3MB.
