### PR TITLE
Perform DOM updates requested from DOM reads in the same frame, after we finish reading

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -2624,7 +2624,7 @@ describe "TextEditorComponent", ->
       expect(componentNode.querySelector('.placeholder-text')).toBeNull()
 
   describe "legacy editor compatibility", ->
-    it "triggers the screen-lines-changed event before the editor:display-update event", ->
+    it "triggers the screen-lines-changed event before the editor:display-updated event", ->
       editor.setSoftWrapped(true)
 
       callingOrder = []
@@ -2633,7 +2633,7 @@ describe "TextEditorComponent", ->
       editor.insertText("HELLO! HELLO!\n HELLO! HELLO! HELLO! HELLO! HELLO! HELLO! HELLO! HELLO! HELLO! HELLO! HELLO! HELLO! HELLO! HELLO! HELLO! HELLO! HELLO! HELLO! ")
       nextAnimationFrame()
 
-      expect(callingOrder).toEqual ['screen-lines-changed', 'editor:display-updated']
+      expect(callingOrder).toEqual ['screen-lines-changed', 'editor:display-updated', 'editor:display-updated']
 
     it "works with the ::setEditorHeightInLines and ::setEditorWidthInChars helpers", ->
       setEditorHeightInLines(wrapperView, 7)


### PR DESCRIPTION
A common pattern is to put something on the DOM, measure it, then update the DOM again based on that measurement. This change ensures that any updates requested as a result of reading from the DOM get scheduled for the end of the current frame. If you want to read _again_ after these follow-on updates, you will need to wait for the next frame. But at least this way we ensure instant feedback with minimal thrashing (1 reflow) when we have no choice but to read the DOM before updating.

/cc @benogle
