### PR TITLE
Add david-dm dependency status badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Atom](https://cloud.githubusercontent.com/assets/72919/2874231/3af1db48-d3dd-11e3-98dc-6066f8bc766f.png)
 
 [![Build Status](https://travis-ci.org/atom/atom.svg?branch=master)](https://travis-ci.org/atom/atom)
+[![Dependency Status](https://david-dm.org/atom/atom.svg)](https://david-dm.org/atom/atom)
 
 Atom is a hackable text editor for the 21st century, built on [Electron](https://github.com/atom/electron), and based on everything we love about our favorite editors. We designed it to be deeply customizable, but still approachable using the default configuration.
 


### PR DESCRIPTION
This adds a dependency status badge (from https://david-dm.org) to the Readme to make it a bit easier to keep track of dependency up-to-date-ness. Unfortunately, this only works for dependencies in `atom/atom/package.json` and not `atom/atom/build/package.json` (they don't support subdirectories... yet). This should make it a bit easier to keep track of dependency versions and see when we're out of date.

Eventually I'd like to add this to all package Readmes too, but that will come with @atom/issue-triage's big rewrites.
