### PR TITLE
Mark notifications public

### DIFF
--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -151,7 +151,7 @@ class Atom extends Model
   # Public: A {TooltipManager} instance
   tooltips: null
 
-  # Experimental: A {NotificationManager} instance
+  # Public: A {NotificationManager} instance
   notifications: null
 
   # Public: A {Project} instance

--- a/src/notification-manager.coffee
+++ b/src/notification-manager.coffee
@@ -78,7 +78,10 @@ class NotificationManager
   Section: Getting Notifications
   ###
 
-  getNotifications: -> @notifications
+  # Public: Get all the notifications.
+  #
+  # Returns an {Array} of {Notifications}s.
+  getNotifications: -> @notifications.slice()
 
   ###
   Section: Managing Notifications

--- a/src/notification-manager.coffee
+++ b/src/notification-manager.coffee
@@ -1,8 +1,8 @@
 {Emitter, Disposable} = require 'event-kit'
 Notification = require '../src/notification'
 
-# Experimental: Allows messaging the user. This will likely change, dont use
-# quite yet!
+# Public: A notification manager used to create {Notification}s to be shown
+# to the user.
 module.exports =
 class NotificationManager
   constructor: ->
@@ -13,6 +13,12 @@ class NotificationManager
   Section: Events
   ###
 
+  # Public: Invoke the given callback after a notification has been added.
+  #
+  # * `callback` {Function} to be called after the notification is added.
+  #   * `notification` The {Notification} that was added.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidAddNotification: (callback) ->
     @emitter.on 'did-add-notification', callback
 
@@ -20,18 +26,43 @@ class NotificationManager
   Section: Adding Notifications
   ###
 
+  # Public: Add a success notification.
+  #
+  # * `message` A {String} message
+  # * `options` An options {Object} with optional keys such as:
+  #    * `detail` A {String} with additional details about the notification
   addSuccess: (message, options) ->
     @addNotification(new Notification('success', message, options))
 
+  # Public: Add an informational notification.
+  #
+  # * `message` A {String} message
+  # * `options` An options {Object} with optional keys such as:
+  #    * `detail` A {String} with additional details about the notification
   addInfo: (message, options) ->
     @addNotification(new Notification('info', message, options))
 
+  # Public: Add a warning notification.
+  #
+  # * `message` A {String} message
+  # * `options` An options {Object} with optional keys such as:
+  #    * `detail` A {String} with additional details about the notification
   addWarning: (message, options) ->
     @addNotification(new Notification('warning', message, options))
 
+  # Public: Add an error notification.
+  #
+  # * `message` A {String} message
+  # * `options` An options {Object} with optional keys such as:
+  #    * `detail` A {String} with additional details about the notification
   addError: (message, options) ->
     @addNotification(new Notification('error', message, options))
 
+  # Public: Add a fatal error notification.
+  #
+  # * `message` A {String} message
+  # * `options` An options {Object} with optional keys such as:
+  #    * `detail` A {String} with additional details about the notification
   addFatalError: (message, options) ->
     @addNotification(new Notification('fatal', message, options))
 

--- a/src/notification.coffee
+++ b/src/notification.coffee
@@ -18,10 +18,10 @@ class Notification
 
   getOptions: -> @options
 
-  # Public: Retrieves the {String} notification type.
+  # Public: Retrieves the {String} type.
   getType: -> @type
 
-  # Public: Retrieves the {String} notification message.
+  # Public: Retrieves the {String} message.
   getMessage: -> @message
 
   getTimestamp: -> @timestamp

--- a/src/notification.coffee
+++ b/src/notification.coffee
@@ -1,6 +1,6 @@
 {Emitter} = require 'event-kit'
 
-# Experimental: This will likely change, do not use.
+# Public: A notification to the user containing a message and type.
 module.exports =
 class Notification
   constructor: (@type, @message, @options={}) ->
@@ -18,8 +18,10 @@ class Notification
 
   getOptions: -> @options
 
+  # Public: Retrieves the {String} notification type.
   getType: -> @type
 
+  # Public: Retrieves the {String} notification message.
   getMessage: -> @message
 
   getTimestamp: -> @timestamp


### PR DESCRIPTION
Put `atom.notifications` in the public API.

Mark `NotificationManager` and `Notification` as public as well and expose a minimal API.

Closes #5870
