### PR TITLE
Tweak a few Grim.deprecate calls to attribute deprecations to correct packages

### DIFF
--- a/src/package.coffee
+++ b/src/package.coffee
@@ -465,7 +465,7 @@ class Package
           @activationCommands[selector].push(commands...)
 
     if includeDeprecatedAPIs and @metadata.activationEvents?
-      deprecate """
+      deprecate("""
         Use `activationCommands` instead of `activationEvents` in your package.json
         Commands should be grouped by selector as follows:
         ```json
@@ -474,7 +474,7 @@ class Package
             "atom-text-editor": ["foo:quux"]
           }
         ```
-      """
+      """, {packageName: @name})
       if _.isArray(@metadata.activationEvents)
         for eventName in @metadata.activationEvents
           @activationCommands['atom-workspace'] ?= []

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -161,9 +161,9 @@ class Package
       if @mainModule.config? and typeof @mainModule.config is 'object'
         atom.config.setSchema @name, {type: 'object', properties: @mainModule.config}
       else if includeDeprecatedAPIs and @mainModule.configDefaults? and typeof @mainModule.configDefaults is 'object'
-        deprecate """Use a config schema instead. See the configuration section
+        deprecate("""Use a config schema instead. See the configuration section
         of https://atom.io/docs/latest/hacking-atom-package-word-count and
-        https://atom.io/docs/api/latest/Config for more details"""
+        https://atom.io/docs/api/latest/Config for more details""", {packageName: @name})
         atom.config.setDefaults(@name, @mainModule.configDefaults)
       @mainModule.activateConfig?()
     @configActivated = true


### PR DESCRIPTION
See https://github.com/atom/deprecation-cop/issues/36#issuecomment-95621001 (and the following few comments) for motivation.

@maxbrunsfeld @kevinsawicki This fixes the problems reported in https://github.com/atom/atom/issues/6310 and https://github.com/atom/settings-view/issues/476.

`activationEvents` before:

![screen shot 2015-04-23 at 17 08 12](https://cloud.githubusercontent.com/assets/38924/7321801/7f7b4824-eaa4-11e4-9a35-869f69244e34.png)

`activationEvents` after (now reported as a problem on the redacted package):

![screen shot 2015-04-24 at 16 52 00](https://cloud.githubusercontent.com/assets/38924/7321747/56474ab6-eaa4-11e4-8993-012d72895fb4.png)

`configDefaults` before:

![screen shot 2015-04-24 at 17 01 44](https://cloud.githubusercontent.com/assets/38924/7321839/9641003a-eaa4-11e4-8484-86de322d677b.png)

`configDefaults` after (now reported on the closer package):

![screen shot 2015-04-24 at 16 59 50](https://cloud.githubusercontent.com/assets/38924/7321752/5fd36c54-eaa4-11e4-80c5-bc270fe6334f.png)
