### PR TITLE
Add new Grim.deprecate call for context menu CSON format so that it can be correctly attributed to packages

### DIFF
--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -105,9 +105,9 @@ class ContextMenuManager
       # Detect deprecated file path as first argument
       if itemsBySelector? and typeof itemsBySelector isnt 'object'
         Grim.deprecate """
-          ContextMenuManager::add has changed to take a single object as its
+          `ContextMenuManager::add` has changed to take a single object as its
           argument. Please see
-          https://atom.io/docs/api/latest/ContextMenuManager for more info.
+          https://atom.io/docs/api/latest/ContextMenuManager#context-menu-cson-format for more info.
         """
         itemsBySelector = arguments[1]
         devMode = arguments[2]?.devMode
@@ -116,9 +116,9 @@ class ContextMenuManager
       for key, value of itemsBySelector
         unless _.isArray(value)
           Grim.deprecate """
-            ContextMenuManager::add has changed to take a single object as its
+            `ContextMenuManager::add` has changed to take a single object as its
             argument. Please see
-            https://atom.io/docs/api/latest/ContextMenuManager for more info.
+            https://atom.io/docs/api/latest/ContextMenuManager#context-menu-cson-format for more info.
           """
           itemsBySelector = @convertLegacyItemsBySelector(itemsBySelector, devMode)
 

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -191,7 +191,20 @@ class Package
 
     for [menuPath, map] in @menus when map['context-menu']?
       try
-        @activationDisposables.add(atom.contextMenu.add(map['context-menu']))
+        itemsBySelector = map['context-menu']
+
+        if includeDeprecatedAPIs
+          # Detect deprecated format for items object
+          for key, value of itemsBySelector
+            unless _.isArray(value)
+              deprecate("""
+                The context menu CSON format has changed. Please see
+                https://atom.io/docs/api/latest/ContextMenuManager#context-menu-cson-format
+                for more info.
+              """, {packageName: @name})
+              itemsBySelector = atom.contextMenu.convertLegacyItemsBySelector(itemsBySelector)
+
+        @activationDisposables.add(atom.contextMenu.add(itemsBySelector))
       catch error
         if error.code is 'EBADSELECTOR'
           error.message += " in #{menuPath}"


### PR DESCRIPTION
@kevinsawicki @maxbrunsfeld I _think_ this is the last of the fixes for the reports in https://github.com/atom/atom/issues/6310. :sweat_smile: 

Currently, there's no special `Grim.deprecate` call for the old context menu CSON format -- it's being detected [within `ContextMenuManager.add()`](https://github.com/atom/atom/blob/14161a63fe1b56aed834050bd8bb56180e6acfb3/src/context-menu-manager.coffee#L115-L123), which is called from [`Package.activateResources()`](https://github.com/atom/atom/blob/14161a63fe1b56aed834050bd8bb56180e6acfb3/src/package.coffee#L194). So, the `Grim.deprecate` call within `ContextMenuManager.add()` catches both calls to `ContextMenuManager.add()` from packages (adding menu items after activation) and calls to `ContextMenuManager.add()` from Atom when it adds menu items from packages' cson file at activation.

For that reason, the `Grim.deprecate` call in cases when `ContextMenuManager.add()` is called from Atom at package activation is incorrectly attributed to Atom itself. Also, the deprecation text is a bit confusing because it says that `ContextMenuManager.add()` was called, but the package didn't make such a call directly.

This PR adds a new `Grim.deprecate` call to `Package.activateResources()` _before_ `ContextMenuManager.add()` is called. This catches the old-context-menu-CSON-format situation so that it is correctly attributed to packages and a clearer message can be shown. In addition, the conversion from the old format to the new format happens in `Package.activateResources()` as well so that the `Grim.deprecate` call within `ContextMenuManager.add()` isn't triggered in that case. The `Grim.deprecate` call within `ContextMenuManager.add()` wasn't removed because it still needs to catch direct calls to that public method from packages.

Before (call attributed to Atom):

![screen shot 2015-04-26 at 11 08 40](https://cloud.githubusercontent.com/assets/38924/7337875/dcd9a894-ec39-11e4-98e5-ca53684b6ed2.png)

After (call attributed to package + a bit more direct deprecation message)

![screen shot 2015-04-26 at 11 11 41](https://cloud.githubusercontent.com/assets/38924/7337876/e1267b48-ec39-11e4-97e2-c39a08d4ed1f.png)

Does this approach look okay?
