### PR TITLE
:bug: Put a limit of 100 on max font size

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -108,6 +108,7 @@ module.exports =
         type: 'integer'
         default: 16
         minimum: 1
+        maximum: 100
       lineHeight:
         type: ['string', 'number']
         default: 1.3


### PR DESCRIPTION
This will prevent Atom from crashing, but still allow folks who need large
font sizes for visual impairments to have them.

Fix #4880
