### PR TITLE
Reset font size to window's starting font size

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -425,6 +425,19 @@ describe "Workspace", ->
       expect(atom.config.get('editor.fontSize')).toBe 1
       workspace.decreaseFontSize()
       expect(atom.config.get('editor.fontSize')).toBe 1
+  describe "::resetFontSize()", ->
+    it "resets the font size to the window's starting font size", ->
+      originalFontSize = 6
+
+      atom.config.set('editor.fontSize', originalFontSize)
+      workspace.increaseFontSize()
+      expect(atom.config.get('editor.fontSize')).toBe originalFontSize + 1
+      workspace.resetFontSize()
+      expect(atom.config.get('editor.fontSize')).toBe originalFontSize
+      workspace.decreaseFontSize()
+      expect(atom.config.get('editor.fontSize')).toBe originalFontSize - 1
+      workspace.resetFontSize()
+      expect(atom.config.get('editor.fontSize')).toBe originalFontSize
 
   describe "::openLicense()", ->
     it "opens the license as plain-text in a buffer", ->

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -425,6 +425,7 @@ describe "Workspace", ->
       expect(atom.config.get('editor.fontSize')).toBe 1
       workspace.decreaseFontSize()
       expect(atom.config.get('editor.fontSize')).toBe 1
+
   describe "::resetFontSize()", ->
     it "resets the font size to the window's starting font size", ->
       originalFontSize = 6
@@ -436,6 +437,13 @@ describe "Workspace", ->
       expect(atom.config.get('editor.fontSize')).toBe originalFontSize
       workspace.decreaseFontSize()
       expect(atom.config.get('editor.fontSize')).toBe originalFontSize - 1
+      workspace.resetFontSize()
+      expect(atom.config.get('editor.fontSize')).toBe originalFontSize
+
+    it "does nothing if the font size has not been changed", ->
+      originalFontSize = 6
+
+      atom.config.set('editor.fontSize', originalFontSize)
       workspace.resetFontSize()
       expect(atom.config.get('editor.fontSize')).toBe originalFontSize
 

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -430,7 +430,6 @@ describe "Workspace", ->
     it "resets the font size to the window's starting font size", ->
       originalFontSize = atom.config.get('editor.fontSize')
 
-      atom.config.set('editor.fontSize', originalFontSize)
       workspace.increaseFontSize()
       expect(atom.config.get('editor.fontSize')).toBe originalFontSize + 1
       workspace.resetFontSize()
@@ -443,7 +442,6 @@ describe "Workspace", ->
     it "does nothing if the font size has not been changed", ->
       originalFontSize = atom.config.get('editor.fontSize')
 
-      atom.config.set('editor.fontSize', originalFontSize)
       workspace.resetFontSize()
       expect(atom.config.get('editor.fontSize')).toBe originalFontSize
 

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -428,7 +428,7 @@ describe "Workspace", ->
 
   describe "::resetFontSize()", ->
     it "resets the font size to the window's starting font size", ->
-      originalFontSize = 6
+      originalFontSize = atom.config.get('editor.fontSize')
 
       atom.config.set('editor.fontSize', originalFontSize)
       workspace.increaseFontSize()
@@ -441,9 +441,19 @@ describe "Workspace", ->
       expect(atom.config.get('editor.fontSize')).toBe originalFontSize
 
     it "does nothing if the font size has not been changed", ->
-      originalFontSize = 6
+      originalFontSize = atom.config.get('editor.fontSize')
 
       atom.config.set('editor.fontSize', originalFontSize)
+      workspace.resetFontSize()
+      expect(atom.config.get('editor.fontSize')).toBe originalFontSize
+
+    it "resets the font size when the editor's font size changes", ->
+      originalFontSize = atom.config.get('editor.fontSize')
+
+      atom.config.set('editor.fontSize', originalFontSize + 1)
+      workspace.resetFontSize()
+      expect(atom.config.get('editor.fontSize')).toBe originalFontSize
+      atom.config.set('editor.fontSize', originalFontSize - 1)
       workspace.resetFontSize()
       expect(atom.config.get('editor.fontSize')).toBe originalFontSize
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -612,16 +612,18 @@ class Workspace extends Model
 
   # Increase the editor font size by 1px.
   increaseFontSize: ->
+    @originalFontSize ?= atom.config.get("editor.fontSize")
     atom.config.set("editor.fontSize", atom.config.get("editor.fontSize") + 1)
 
   # Decrease the editor font size by 1px.
   decreaseFontSize: ->
+    @originalFontSize ?= atom.config.get("editor.fontSize")
     fontSize = atom.config.get("editor.fontSize")
     atom.config.set("editor.fontSize", fontSize - 1) if fontSize > 1
 
-  # Restore to a default editor font size.
+  # Restore to the window's original editor font size.
   resetFontSize: ->
-    atom.config.unset("editor.fontSize")
+    atom.config.set("editor.fontSize", @originalFontSize)
 
   # Removes the item's uri from the list of potential items to reopen.
   itemOpened: (item) ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -75,6 +75,8 @@ class Workspace extends Model
     atom.views.addViewProvider Panel, (model) ->
       new PanelElement().initialize(model)
 
+    @subscribeToFontSize()
+
   # Called by the Serializable mixin during deserialization
   deserializeParams: (params) ->
     for packageName in params.packagesWithActiveGrammars ? []
@@ -612,12 +614,10 @@ class Workspace extends Model
 
   # Increase the editor font size by 1px.
   increaseFontSize: ->
-    @originalFontSize ?= atom.config.get("editor.fontSize")
     atom.config.set("editor.fontSize", atom.config.get("editor.fontSize") + 1)
 
   # Decrease the editor font size by 1px.
   decreaseFontSize: ->
-    @originalFontSize ?= atom.config.get("editor.fontSize")
     fontSize = atom.config.get("editor.fontSize")
     atom.config.set("editor.fontSize", fontSize - 1) if fontSize > 1
 
@@ -625,6 +625,10 @@ class Workspace extends Model
   resetFontSize: ->
     if @originalFontSize
       atom.config.set("editor.fontSize", @originalFontSize)
+
+  subscribeToFontSize: ->
+    atom.config.onDidChange 'editor.fontSize', ({newValue, oldValue}) =>
+      @originalFontSize ?= oldValue
 
   # Removes the item's uri from the list of potential items to reopen.
   itemOpened: (item) ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -627,7 +627,7 @@ class Workspace extends Model
       atom.config.set("editor.fontSize", @originalFontSize)
 
   subscribeToFontSize: ->
-    atom.config.onDidChange 'editor.fontSize', ({newValue, oldValue}) =>
+    atom.config.onDidChange 'editor.fontSize', ({oldValue}) =>
       @originalFontSize ?= oldValue
 
   # Removes the item's uri from the list of potential items to reopen.

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -623,7 +623,8 @@ class Workspace extends Model
 
   # Restore to the window's original editor font size.
   resetFontSize: ->
-    atom.config.set("editor.fontSize", @originalFontSize)
+    if @originalFontSize
+      atom.config.set("editor.fontSize", @originalFontSize)
 
   # Removes the item's uri from the list of potential items to reopen.
   itemOpened: (item) ->


### PR DESCRIPTION
This changes `workspace::resetFontSize`'s behavior from restoring Atom's default font size to restoring the window's starting font size. 

This is, I think, far more useful behavior than restoring Atom's default font size, which you can do by just emptying the Font Size input in Settings View. If you've ever had to change the font size to make code more readable to others temporarily (ie. a presentation or a talk), having a command to return to what you had configured originally is a godsend. (I've found myself in that situation quite often.)

Please try this branch out and let me know what you think! :wink:

/cc @atom/feedback 
