### PR TITLE
Add --profile-startup option

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -85,15 +85,16 @@ class AtomApplication
     else
       @loadState() or @openPath(options)
 
-  openWithOptions: ({pathsToOpen, urlsToOpen, test, pidToKillWhenClosed, devMode, safeMode, apiPreviewMode, newWindow, specDirectory, logFile}) ->
+  openWithOptions: ({pathsToOpen, urlsToOpen, test, pidToKillWhenClosed, devMode, safeMode, apiPreviewMode, newWindow, specDirectory, logFile, profileStartup}) ->
     if test
       @runSpecs({exitWhenDone: true, @resourcePath, specDirectory, logFile})
     else if pathsToOpen.length > 0
-      @openPaths({pathsToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, apiPreviewMode})
+      @openPaths({pathsToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, apiPreviewMode, profileStartup})
     else if urlsToOpen.length > 0
       @openUrl({urlToOpen, devMode, safeMode, apiPreviewMode}) for urlToOpen in urlsToOpen
     else
-      @openPath({pidToKillWhenClosed, newWindow, devMode, safeMode, apiPreviewMode}) # Always open a editor window if this is the first instance of Atom.
+      # Always open a editor window if this is the first instance of Atom.
+      @openPath({pidToKillWhenClosed, newWindow, devMode, safeMode, apiPreviewMode, profileStartup})
 
   # Public: Removes the {AtomWindow} from the global window list.
   removeWindow: (window) ->
@@ -343,9 +344,10 @@ class AtomApplication
   #   :devMode - Boolean to control the opened window's dev mode.
   #   :safeMode - Boolean to control the opened window's safe mode.
   #   :apiPreviewMode - Boolean to control the opened window's 1.0 API preview mode.
+  #   :profileStartup - Boolean to control creating a profile of the startup time.
   #   :window - {AtomWindow} to open file paths in.
-  openPath: ({pathToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, apiPreviewMode, window}) ->
-    @openPaths({pathsToOpen: [pathToOpen], pidToKillWhenClosed, newWindow, devMode, safeMode, apiPreviewMode, window})
+  openPath: ({pathToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, apiPreviewMode, profileStartup, window}) ->
+    @openPaths({pathsToOpen: [pathToOpen], pidToKillWhenClosed, newWindow, devMode, safeMode, apiPreviewMode, profileStartup, window})
 
   # Public: Opens multiple paths, in existing windows if possible.
   #
@@ -358,7 +360,7 @@ class AtomApplication
   #   :apiPreviewMode - Boolean to control the opened window's 1.0 API preview mode.
   #   :windowDimensions - Object with height and width keys.
   #   :window - {AtomWindow} to open file paths in.
-  openPaths: ({pathsToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, apiPreviewMode, windowDimensions, window}={}) ->
+  openPaths: ({pathsToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, apiPreviewMode, windowDimensions, profileStartup, window}={}) ->
     pathsToOpen = (fs.normalize(pathToOpen) for pathToOpen in pathsToOpen)
     locationsToOpen = (@locationForPathToOpen(pathToOpen) for pathToOpen in pathsToOpen)
 
@@ -388,7 +390,7 @@ class AtomApplication
 
       bootstrapScript ?= require.resolve('../window-bootstrap')
       resourcePath ?= @resourcePath
-      openedWindow = new AtomWindow({locationsToOpen, bootstrapScript, resourcePath, devMode, safeMode, apiPreviewMode, windowDimensions})
+      openedWindow = new AtomWindow({locationsToOpen, bootstrapScript, resourcePath, devMode, safeMode, apiPreviewMode, windowDimensions, profileStartup})
 
     if pidToKillWhenClosed?
       @pidsToOpenWindows[pidToKillWhenClosed] = openedWindow

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -110,6 +110,7 @@ parseCommandLine = ->
   options.alias('h', 'help').boolean('h').describe('h', 'Print this usage message.')
   options.alias('l', 'log-file').string('l').describe('l', 'Log all output to file.')
   options.alias('n', 'new-window').boolean('n').describe('n', 'Open a new window.')
+  options.boolean('profile-startup').describe('profile-startup', 'Create a profile of startup execution time.')
   options.alias('r', 'resource-path').string('r').describe('r', 'Set the path to the Atom source directory and enable dev-mode.')
   options.alias('s', 'spec-directory').string('s').describe('s', 'Set the directory from which to run package specs (default: Atom\'s spec directory).')
   options.boolean('safe').describe('safe', 'Do not load packages from ~/.atom/packages or ~/.atom/dev/packages.')
@@ -139,6 +140,7 @@ parseCommandLine = ->
   pidToKillWhenClosed = args['pid'] if args['wait']
   logFile = args['log-file']
   socketPath = args['socket-path']
+  profileStartup = args['profile-startup']
 
   if args['resource-path']
     devMode = true
@@ -165,6 +167,6 @@ parseCommandLine = ->
 
   {resourcePath, pathsToOpen, executedFrom, test, version, pidToKillWhenClosed,
    devMode, apiPreviewMode, safeMode, newWindow, specDirectory, logFile,
-   socketPath}
+   socketPath, profileStartup}
 
 start()

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -110,7 +110,7 @@ parseCommandLine = ->
   options.alias('h', 'help').boolean('h').describe('h', 'Print this usage message.')
   options.alias('l', 'log-file').string('l').describe('l', 'Log all output to file.')
   options.alias('n', 'new-window').boolean('n').describe('n', 'Open a new window.')
-  options.boolean('profile-startup').describe('profile-startup', 'Create a profile of startup execution time.')
+  options.boolean('profile-startup').describe('profile-startup', 'Create a profile of the startup execution time.')
   options.alias('r', 'resource-path').string('r').describe('r', 'Set the path to the Atom source directory and enable dev-mode.')
   options.alias('s', 'spec-directory').string('s').describe('s', 'Set the directory from which to run package specs (default: Atom\'s spec directory).')
   options.boolean('safe').describe('safe', 'Do not load packages from ~/.atom/packages or ~/.atom/dev/packages.')

--- a/static/index.js
+++ b/static/index.js
@@ -146,7 +146,7 @@ var profileStartup = function(cacheDir, loadSettings) {
         handleSetupError(error);
       } finally {
         console.profileEnd('startup');
-        console.log("Switch to the Profiles tab to view the startup profile")
+        console.log("Switch to the Profiles tab to view the created startup profile")
       }
     }, 100);
   });

--- a/static/index.js
+++ b/static/index.js
@@ -135,19 +135,25 @@ var setupVmCompatibility = function() {
 }
 
 var profileStartup = function(cacheDir, loadSettings) {
+  var profile = function() {
+    console.profile('startup');
+    try {
+      setupWindow(cacheDir, loadSettings);
+    } catch (error) {
+      handleSetupError(error);
+    } finally {
+      console.profileEnd('startup');
+      console.log("Switch to the Profiles tab to view the created startup profile")
+    }
+  };
+
   var currentWindow = require('remote').getCurrentWindow();
-  currentWindow.openDevTools();
-  currentWindow.once('devtools-opened', function() {
-    setTimeout(function() {
-      console.profile('startup');
-      try {
-        setupWindow(cacheDir, loadSettings);
-      } catch (error) {
-        handleSetupError(error);
-      } finally {
-        console.profileEnd('startup');
-        console.log("Switch to the Profiles tab to view the created startup profile")
-      }
-    }, 100);
-  });
+  if (currentWindow.devToolsWebContents) {
+    profile();
+  } else {
+    currentWindow.openDevTools();
+    currentWindow.once('devtools-opened', function() {
+      setTimeout(profile, 100);
+    });
+  }
 }


### PR DESCRIPTION
This pull request adds the `--profile-startup` command line option that will profile render process for the created window.

The goal here is to make it easy to see why an Atom window might be loading slowly.

It covers the time between the `window.onload` handler firing and the completion of the bootstrap script. So it will include deserialization, all requires, package loading, theme loading, etc.

``` sh
atom --profile-startup
```

![screen shot 2015-04-27 at 6 17 00 pm](https://cloud.githubusercontent.com/assets/671378/7361208/aab03f38-ed09-11e4-8e1d-7eb248f74995.png)
