### PR TITLE
Remove ATOM_ACCESS_TOKEN from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ git:
   depth: 10
 
 env:
-  - NODE_VERSION=0.12
-  - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
+  matrix:
+    - NODE_VERSION=0.12
+
+  global:
+    - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ git:
   depth: 10
 
 env:
-  matrix:
-    - NODE_VERSION=0.12
-
   global:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
+    
+  matrix:
+    - NODE_VERSION=0.12
 
 os:
   - linux


### PR DESCRIPTION
Adding `ATOM_ACCESS_TOKEN` to the environment variables caused Travis to recognize it as another row in the matrix, thus spawning unwanted builds like the ones below (i.e. the failing ones):

![screen shot 2015-04-28 at 09 00 57](https://cloud.githubusercontent.com/assets/482957/7364294/3889a300-ed85-11e4-824f-a06978666f91.png)

This PR fixes it by explicitly specifying `matrix` and `global` into `.travis.yml` (as documented in http://docs.travis-ci.com/user/environment-variables/).

/cc: @thedaniel @kevinsawicki 
