### PR TITLE
Handle thrown spawn errors

### DIFF
--- a/spec/buffered-process-spec.coffee
+++ b/spec/buffered-process-spec.coffee
@@ -96,3 +96,21 @@ describe "BufferedProcess", ->
       expect(ChildProcess.spawn.argsForCall[0][1][0]).toBe '/s'
       expect(ChildProcess.spawn.argsForCall[0][1][1]).toBe '/c'
       expect(ChildProcess.spawn.argsForCall[0][1][2]).toBe '"dir"'
+
+  it "calls the specified stdout, stderr, and exit callbacks ", ->
+    stdout = ''
+    stderr = ''
+    exitCallback = jasmine.createSpy('exit callback')
+    process = new BufferedProcess
+      command: atom.packages.getApmPath()
+      args: ['-h']
+      options: {}
+      stdout: (lines) -> stdout += lines
+      stderr: (lines) -> stderr += lines
+      exit: exitCallback
+
+    waitsFor -> exitCallback.callCount is 1
+
+    runs ->
+      expect(stderr).toContain 'apm - Atom Package Manager'
+      expect(stdout).toEqual ''

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -187,10 +187,10 @@ class BufferedProcess
 
   spawn: (command, args, options) ->
     try
-      process = ChildProcess.spawn(command, args, options)
+      spawned = ChildProcess.spawn(command, args, options)
     catch spawnError
       process.nextTick => @handleError(spawnError)
-    process
+    spawned
 
   handleEvents: (stdout, stderr, exit) ->
     stdoutClosed = true

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -164,6 +164,8 @@ class BufferedProcess
   # This is required since killing the cmd.exe does not terminate child
   # processes.
   killOnWindows: ->
+    return unless @process?
+
     parentPid = @process.pid
     cmd = 'wmic'
     args = [

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -69,9 +69,9 @@ class BufferedProcess
       cmdArgs = ['/s', '/c', "\"#{cmdArgs.join(' ')}\""]
       cmdOptions = _.clone(options)
       cmdOptions.windowsVerbatimArguments = true
-      @process = ChildProcess.spawn(@getCmdPath(), cmdArgs, cmdOptions)
+      @process = @spawn(@getCmdPath(), cmdArgs, cmdOptions)
     else
-      @process = ChildProcess.spawn(command, args, options)
+      @process = @spawn(command, args, options)
     @killed = false
 
     stdoutClosed = true
@@ -212,6 +212,13 @@ class BufferedProcess
       @killProcess()
 
     undefined
+
+  spawn: (command, args, options) ->
+    try
+      process = ChildProcess.spawn(command, args, options)
+    catch spawnError
+      process.nextTick => @handleError(spawnError)
+    process
 
   handleError: (error) ->
     handled = false

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -102,17 +102,7 @@ class BufferedProcess
         processExited = true
         triggerExitCallback()
 
-    @process.on 'error', (error) =>
-      handled = false
-      handle = -> handled = true
-
-      @emitter.emit 'will-throw-error', {error, handle}
-
-      if error.code is 'ENOENT' and error.syscall.indexOf('spawn') is 0
-        error = new Error("Failed to spawn command `#{command}`. Make sure `#{command}` is installed and on your PATH", error.path)
-        error.name = 'BufferedProcessError'
-
-      throw error unless handled
+    @process.on 'error', (error) => @handleError(error)
 
   ###
   Section: Event Subscription
@@ -222,3 +212,15 @@ class BufferedProcess
       @killProcess()
 
     undefined
+
+  handleError: (error) ->
+    handled = false
+    handle = -> handled = true
+
+    @emitter.emit 'will-throw-error', {error, handle}
+
+    if error.code is 'ENOENT' and error.syscall.indexOf('spawn') is 0
+      error = new Error("Failed to spawn command `#{command}`. Make sure `#{command}` is installed and on your PATH", error.path)
+      error.name = 'BufferedProcessError'
+
+    throw error unless handled

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -48,6 +48,7 @@ class BufferedProcess
   constructor: ({command, args, options, stdout, stderr, exit}={}) ->
     @emitter = new Emitter
     options ?= {}
+    @command = command
     # Related to joyent/node#2318
     if process.platform is 'win32'
       # Quote all arguments and escapes inner quotes
@@ -232,7 +233,7 @@ class BufferedProcess
     @emitter.emit 'will-throw-error', {error, handle}
 
     if error.code is 'ENOENT' and error.syscall.indexOf('spawn') is 0
-      error = new Error("Failed to spawn command `#{command}`. Make sure `#{command}` is installed and on your PATH", error.path)
+      error = new Error("Failed to spawn command `#{@command}`. Make sure `#{@command}` is installed and on your PATH", error.path)
       error.name = 'BufferedProcessError'
 
     throw error unless handled

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -139,7 +139,12 @@ class BufferedProcess
       'processid'
     ]
 
-    wmicProcess = ChildProcess.spawn(cmd, args)
+    try
+      wmicProcess = ChildProcess.spawn(cmd, args)
+    catch spawnError
+      @killProcess()
+      return
+
     wmicProcess.on 'error', -> # ignore errors
     output = ''
     wmicProcess.stdout.on 'data', (data) -> output += data

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -74,7 +74,7 @@ class BufferedProcess
       @spawn(command, args, options)
 
     @killed = false
-    @handleEvents(stdout, stderr, exit) if @process?
+    @handleEvents(stdout, stderr, exit)
 
   ###
   Section: Event Subscription
@@ -192,6 +192,8 @@ class BufferedProcess
       process.nextTick => @handleError(spawnError)
 
   handleEvents: (stdout, stderr, exit) ->
+    return unless @process?
+
     stdoutClosed = true
     stderrClosed = true
     processExited = true

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -74,7 +74,7 @@ class BufferedProcess
       @process = @spawn(command, args, options)
 
     @killed = false
-    @handeEvents(stdout, stderr, exit) if @process?
+    @handleEvents(stdout, stderr, exit) if @process?
 
   ###
   Section: Event Subscription

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -69,9 +69,9 @@ class BufferedProcess
       cmdArgs = ['/s', '/c', "\"#{cmdArgs.join(' ')}\""]
       cmdOptions = _.clone(options)
       cmdOptions.windowsVerbatimArguments = true
-      @process = @spawn(@getCmdPath(), cmdArgs, cmdOptions)
+      @spawn(@getCmdPath(), cmdArgs, cmdOptions)
     else
-      @process = @spawn(command, args, options)
+      @spawn(command, args, options)
 
     @killed = false
     @handleEvents(stdout, stderr, exit) if @process?
@@ -187,10 +187,9 @@ class BufferedProcess
 
   spawn: (command, args, options) ->
     try
-      spawned = ChildProcess.spawn(command, args, options)
+      @process = ChildProcess.spawn(command, args, options)
     catch spawnError
       process.nextTick => @handleError(spawnError)
-    spawned
 
   handleEvents: (stdout, stderr, exit) ->
     stdoutClosed = true


### PR DESCRIPTION
Calling `child_process.spawn` can [throw](https://github.com/iojs/io.js/blob/391cae3595e5b426be50cf26a2ae02c346c2a63f/lib/child_process.js#L1093) a runtime error distinct from the `error` events that are emitted on the returned process object.

This pull request catches these exceptions and sends them down the `BufferedProcess::onWillThrowError` path on a `process.nextTick` callback so that emitted errors and spawn errors can be handled consistently.

Without this you would need to wrap `new BufferedProcess` calls in a `try`/`catch` block which isn't very intuitive given that `error` events are emitted in most cases.

Fixes #5560
Fixes #6556

/cc @benogle 
