### PR TITLE
Fix scroll width calculation when longest line is folded

### DIFF
--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -498,6 +498,11 @@ describe "TextEditorPresenter", ->
 
           expect(presenter.getState().content.scrollWidth).toBe 10 * editor.getMaxScreenLineLength() + 1
 
+        it "isn't clipped to 0 when the longest line is folded (regression)", ->
+          presenter = buildPresenter(contentFrameWidth: 50, baseCharacterWidth: 10)
+          editor.foldBufferRow(0)
+          expect(presenter.getState().content.scrollWidth).toBe 10 * editor.getMaxScreenLineLength() + 1
+
       describe ".scrollTop", ->
         it "tracks the value of ::scrollTop", ->
           presenter = buildPresenter(scrollTop: 10, lineHeight: 10, explicitHeight: 20)

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -349,15 +349,15 @@ class TextEditorComponent
 
     if Math.abs(wheelDeltaX) > Math.abs(wheelDeltaY)
       # Scrolling horizontally
-      previousScrollLeft = @editor.getScrollLeft()
+      previousScrollLeft = @presenter.getScrollLeft()
       @presenter.setScrollLeft(previousScrollLeft - Math.round(wheelDeltaX * @scrollSensitivity))
-      event.preventDefault() unless previousScrollLeft is @editor.getScrollLeft()
+      event.preventDefault() unless previousScrollLeft is @presenter.getScrollLeft()
     else
       # Scrolling vertically
       @presenter.setMouseWheelScreenRow(@screenRowForNode(event.target))
-      previousScrollTop = @presenter.scrollTop
+      previousScrollTop = @presenter.getScrollTop()
       @presenter.setScrollTop(previousScrollTop - Math.round(wheelDeltaY * @scrollSensitivity))
-      event.preventDefault() unless previousScrollTop is @editor.getScrollTop()
+      event.preventDefault() unless previousScrollTop is @presenter.getScrollTop()
 
   onScrollViewScroll: =>
     if @mounted

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -541,7 +541,8 @@ class TextEditorPresenter
 
     if @baseCharacterWidth?
       oldContentWidth = @contentWidth
-      @contentWidth = @pixelPositionForScreenPosition([@model.getLongestScreenRow(), Infinity]).left
+      clip = @model.tokenizedLineForScreenRow(@model.getLongestScreenRow())?.isSoftWrapped()
+      @contentWidth = @pixelPositionForScreenPosition([@model.getLongestScreenRow(), @model.getMaxScreenLineLength()], clip).left
       @contentWidth += 1 unless @model.isSoftWrapped() # account for cursor width
 
     if @contentHeight isnt oldContentHeight
@@ -691,6 +692,9 @@ class TextEditorPresenter
       @updateCustomGutterDecorationState()
       @updateOverlaysState()
 
+  getScrollTop: ->
+    @scrollTop
+
   didStartScrolling: ->
     if @stoppedScrollingTimeoutId?
       clearTimeout(@stoppedScrollingTimeoutId)
@@ -719,6 +723,9 @@ class TextEditorPresenter
       @updateHiddenInputState()
       @updateCursorsState() unless oldScrollLeft?
       @updateOverlaysState()
+
+  getScrollLeft: ->
+    @scrollLeft
 
   setHorizontalScrollbarHeight: (horizontalScrollbarHeight) ->
     unless @measuredHorizontalScrollbarHeight is horizontalScrollbarHeight


### PR DESCRIPTION
With the presenter we started clipping screen positions prior to translating them to pixel positions. This interacts with the current clipping behavior on folded lines (which should change) where the cursor is always clipped to 0. So when the longest line was also folded we were miscalculating the width. :see_no_evil:!

The removal of clipping also causes us to calculate the width based on the trailing whitespace of soft-wrapped lines, which I actually think is an improvement but it is slightly different.

Fixes #6562
