### PR TITLE
Improve font stack

### DIFF
--- a/static/text-editor-light.less
+++ b/static/text-editor-light.less
@@ -4,7 +4,7 @@
 
 atom-text-editor {
   display: block;
-  font-family: Inconsolata, Monaco, Consolas, 'DejaVu Sans Mono', 'Courier New', Courier;
+  font-family: Inconsolata, Monaco, Consolas, 'DejaVu Sans Mono', monospace;
   line-height: 1.3;
 }
 

--- a/static/text-editor-light.less
+++ b/static/text-editor-light.less
@@ -4,7 +4,7 @@
 
 atom-text-editor {
   display: block;
-  font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier;
+  font-family: Inconsolata, Monaco, Consolas, 'DejaVu Sans Mono', 'Courier New', Courier;
   line-height: 1.3;
 }
 


### PR DESCRIPTION
This PR adds `DejaVu Sans Mono` to the Atom font stack. It should fix font issues on Linux. See #4201

The default fonts will be:
- `Inconsolata` on all platforms, but must be manually installed by the user. Otherwise..
- `Monaco` on OS X
- `Consolas` on Windows
- `DejaVu Sans Mono` on most Linux distros. Thx @fvsch.
#### Unpleasant surprises

This change should only affect users on Linux that have not defined a custom font in the settings. But arguably that will be a pleasant surprise.
