### PR TITLE
Measure gutter width rather than calculating the width

### DIFF
--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -32,6 +32,7 @@ describe "TextEditorPresenter", ->
         windowWidth: 500
         windowHeight: 130
         boundingClientRect: {left: 0, top: 0, width: 500, height: 130}
+        gutterWidth: 0
         lineHeight: 10
         baseCharacterWidth: 10
         horizontalScrollbarHeight: 10
@@ -1628,7 +1629,7 @@ describe "TextEditorPresenter", ->
             marker = editor.markBufferPosition([0, 26], invalidate: 'never')
             decoration = editor.decorateMarker(marker, {type: 'overlay', item})
 
-            presenter = buildPresenter({scrollLeft, windowWidth, windowHeight, contentFrameWidth, boundingClientRect})
+            presenter = buildPresenter({scrollLeft, windowWidth, windowHeight, contentFrameWidth, boundingClientRect, gutterWidth})
             expectStateUpdate presenter, ->
               presenter.setOverlayDimensions(decoration.id, itemWidth, itemHeight, contentMargin)
 
@@ -1654,7 +1655,7 @@ describe "TextEditorPresenter", ->
             marker = editor.markBufferPosition([5, 0], invalidate: 'never')
             decoration = editor.decorateMarker(marker, {type: 'overlay', item})
 
-            presenter = buildPresenter({scrollTop, windowWidth, windowHeight, contentFrameWidth, boundingClientRect})
+            presenter = buildPresenter({scrollTop, windowWidth, windowHeight, contentFrameWidth, boundingClientRect, gutterWidth})
             expectStateUpdate presenter, ->
               presenter.setOverlayDimensions(decoration.id, itemWidth, itemHeight, contentMargin)
 
@@ -1682,7 +1683,7 @@ describe "TextEditorPresenter", ->
               marker = cursor.marker
               decoration = editor.decorateMarker(marker, {type: 'overlay', item})
 
-              presenter = buildPresenter({windowWidth, windowHeight, contentFrameWidth, boundingClientRect})
+              presenter = buildPresenter({windowWidth, windowHeight, contentFrameWidth, boundingClientRect, gutterWidth})
               expectStateUpdate presenter, ->
                 presenter.setOverlayDimensions(decoration.id, itemWidth, itemHeight, contentMargin)
 
@@ -1715,7 +1716,7 @@ describe "TextEditorPresenter", ->
               marker = editor.markBufferPosition([1, 0], invalidate: 'never')
               decoration = editor.decorateMarker(marker, {type: 'overlay', item})
 
-              presenter = buildPresenter({windowWidth, windowHeight, contentFrameWidth, boundingClientRect})
+              presenter = buildPresenter({windowWidth, windowHeight, contentFrameWidth, boundingClientRect, gutterWidth})
               expectStateUpdate presenter, ->
                 presenter.setOverlayDimensions(decoration.id, itemWidth, itemHeight, contentMargin)
 
@@ -1736,7 +1737,7 @@ describe "TextEditorPresenter", ->
               marker = editor.markBufferPosition([0, 0], invalidate: 'never')
               decoration = editor.decorateMarker(marker, {type: 'overlay', item})
 
-              presenter = buildPresenter({windowWidth, windowHeight, contentFrameWidth, boundingClientRect})
+              presenter = buildPresenter({windowWidth, windowHeight, contentFrameWidth, boundingClientRect, gutterWidth})
               expectStateUpdate presenter, ->
                 presenter.setOverlayDimensions(decoration.id, itemWidth, itemHeight, contentMargin)
 

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -619,6 +619,7 @@ class TextEditorComponent
     if clientWidth > 0
       @presenter.setContentFrameWidth(clientWidth)
 
+    @presenter.setGutterWidth(@gutterContainerComponent?.getDomNode().offsetWidth ? 0)
     @presenter.setBoundingClientRect(@hostElement.getBoundingClientRect())
 
   measureWindowSize: ->

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -13,7 +13,7 @@ class TextEditorPresenter
   overlayDimensions: {}
 
   constructor: (params) ->
-    {@model, @autoHeight, @explicitHeight, @contentFrameWidth, @scrollTop, @scrollLeft, @boundingClientRect, @windowWidth, @windowHeight} = params
+    {@model, @autoHeight, @explicitHeight, @contentFrameWidth, @scrollTop, @scrollLeft, @boundingClientRect, @windowWidth, @windowHeight, @gutterWidth} = params
     {horizontalScrollbarHeight, verticalScrollbarWidth} = params
     {@lineHeight, @baseCharacterWidth, @lineOverdrawMargin, @backgroundColor, @gutterBackgroundColor} = params
     {@cursorBlinkPeriod, @cursorBlinkResumeDelay, @stoppedScrollingDelay, @focused} = params
@@ -351,10 +351,9 @@ class TextEditorPresenter
       pixelPosition = @pixelPositionForScreenPosition(screenPosition)
 
       {scrollTop, scrollLeft} = @state.content
-      gutterWidth = @boundingClientRect.width - @contentFrameWidth
 
       top = pixelPosition.top + @lineHeight - scrollTop
-      left = pixelPosition.left + gutterWidth - scrollLeft
+      left = pixelPosition.left + @gutterWidth - scrollLeft
 
       if overlayDimensions = @overlayDimensions[decoration.id]
         {itemWidth, itemHeight, contentMargin} = overlayDimensions
@@ -816,6 +815,11 @@ class TextEditorPresenter
       @updateLineNumberGutterState()
       @updateCommonGutterState()
       @updateGutterOrderState()
+
+  setGutterWidth: (gutterWidth) ->
+    if @gutterWidth isnt gutterWidth
+      @gutterWidth = gutterWidth
+      @updateOverlaysState()
 
   setLineHeight: (lineHeight) ->
     unless @lineHeight is lineHeight

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -19,6 +19,7 @@ class TextEditorPresenter
     {@cursorBlinkPeriod, @cursorBlinkResumeDelay, @stoppedScrollingDelay, @focused} = params
     @measuredHorizontalScrollbarHeight = horizontalScrollbarHeight
     @measuredVerticalScrollbarWidth = verticalScrollbarWidth
+    @gutterWidth ?= 0
 
     @disposables = new CompositeDisposable
     @emitter = new Emitter


### PR DESCRIPTION
The minimap inserts itself in the editor shadow DOM, which makes it look like the gutter to the calculation.

Closes https://github.com/atom-community/autocomplete-plus/issues/394
Closes https://github.com/atom-minimap/minimap/issues/317
