### PR TITLE
NodeJS-devel is required on OpenSUSE

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -38,7 +38,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 
 ### openSUSE
 
-* `sudo zypper install nodejs make gcc gcc-c++ glibc-devel git-core libgnome-keyring-devel rpmdevtools`
+* `sudo zypper install nodejs nodejs-devel make gcc gcc-c++ glibc-devel git-core libgnome-keyring-devel rpmdevtools`
 
 ## Instructions
 


### PR DESCRIPTION
Otherwise this error happens:

```
tobia@tobia-pc:~/Downloads/atom> git fethc -p
git: 'fethc' is not a git command. See 'git --help'.

Did you mean this?
    fetch
tobia@tobia-pc:~/Downloads/atom> git fetch -p
tobia@tobia-pc:~/Downloads/atom> ./script/build 
Node: v0.10.31
npm: v1.4.23
Installing build modules...
gyp: /usr/share/node/common.gypi not found (cwd: /home/tobia/Downloads/atom/build/node_modules/runas) while reading includes of binding.gyp while trying to load binding.gyp
gyp ERR! configure error 
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/usr/lib64/node_modules/npm/node_modules/node-gyp/lib/configure.js:338:16)
gyp ERR! stack     at ChildProcess.emit (events.js:98:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:810:12)
gyp ERR! System Linux 3.16.7-21-desktop
gyp ERR! command "node" "/usr/lib64/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/tobia/Downloads/atom/build/node_modules/runas
gyp ERR! node -v v0.10.31
gyp ERR! node-gyp -v v1.0.1
gyp ERR! not ok 
npm ERR! runas@2.0.0 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the runas@2.0.0 install script.
npm ERR! This is most likely a problem with the runas package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-gyp rebuild
npm ERR! You can get their info via:
npm ERR!     npm owner ls runas
npm ERR! There is likely additional logging output above.

npm ERR! System Linux 3.16.7-21-desktop
npm ERR! command "/usr/bin/node" "/usr/bin/npm" "--userconfig=/home/tobia/Downloads/atom/build/.npmrc" "install" "--loglevel" "error"
npm ERR! cwd /home/tobia/Downloads/atom/build
npm ERR! node -v v0.10.31
npm ERR! npm -v 1.4.23
npm ERR! code ELIFECYCLE
gyp: /usr/share/node/common.gypi not found (cwd: /home/tobia/Downloads/atom/build/node_modules/grunt-atom-shell-installer/node_modules/asar/node_modules/chromium-pickle) while reading includes of binding.gyp while trying to load binding.gyp
gyp ERR! configure error 
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/usr/lib64/node_modules/npm/node_modules/node-gyp/lib/configure.js:338:16)
gyp ERR! stack     at ChildProcess.emit (events.js:98:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:810:12)
gyp ERR! System Linux 3.16.7-21-desktop
gyp ERR! command "node" "/usr/lib64/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/tobia/Downloads/atom/build/node_modules/grunt-atom-shell-installer/node_modules/asar/node_modules/chromium-pickle
gyp ERR! node -v v0.10.31
gyp ERR! node-gyp -v v1.0.1
gyp ERR! not ok 
gyp: /usr/share/node/common.gypi not found (cwd: /home/tobia/Downloads/atom/build/node_modules/minidump) while reading includes of binding.gyp while trying to load binding.gyp
gyp ERR! configure error 
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/usr/lib64/node_modules/npm/node_modules/node-gyp/lib/configure.js:338:16)
gyp ERR! stack     at ChildProcess.emit (events.js:98:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:810:12)
gyp ERR! System Linux 3.16.7-21-desktop
gyp ERR! command "node" "/usr/lib64/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/tobia/Downloads/atom/build/node_modules/minidump
gyp ERR! node -v v0.10.31
gyp ERR! node-gyp -v v1.0.1
gyp ERR! not ok 
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /home/tobia/Downloads/atom/build/npm-debug.log
npm ERR! not ok code 0
```
