### PR TITLE
Normalize short urls for repositories in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "fuzzaldrin": "^2.1",
     "git-utils": "^3.0.0",
     "grim": "1.4.0",
+    "hosted-git-info": "^2.1.2",
     "jasmine-json": "~0.0",
     "jasmine-tagged": "^1.1.4",
     "jquery": "^2.1.1",

--- a/spec/fixtures/packages/package-with-short-url-package-json/package.json
+++ b/spec/fixtures/packages/package-with-short-url-package-json/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-with-short-url-package-json",
+  "repository": "example/repo"
+}

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -41,6 +41,11 @@ describe "PackageManager", ->
       expect(addErrorHandler.callCount).toBe 1
       expect(addErrorHandler.argsForCall[0][0].message).toContain("Failed to load the package-with-broken-package-json package")
 
+    it "normalizes short repository urls in package.json", ->
+      {metadata} = atom.packages.loadPackage("package-with-short-url-package-json")
+      expect(metadata.repository.type).toBe "git"
+      expect(metadata.repository.url).toBe "https://github.com/example/repo.git"
+
     it "returns null if the package is not found in any package directory", ->
       spyOn(console, 'warn')
       expect(atom.packages.loadPackage("this-package-cannot-be-found")).toBeNull()

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -36,8 +36,6 @@ class Package
       info = hostedGitInfo.fromUrl(repoUrl)
       if info.getDefaultRepresentation() is 'shortcut'
         metadata.repository.url = info.https().replace(/^git\+/, '')
-      else
-        metadata.repository.url = info.toString()
 
   @loadMetadata: (packagePath, ignoreErrors=false) ->
     packageName = path.basename(packagePath)


### PR DESCRIPTION
This adds a dependency and replicates the way npm handles 'shortcut' repository urls in package.json, turning them into urls. 

Closes atom/settings-view#387
