### PR TITLE
Remove Completions from Settings

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -98,8 +98,6 @@ module.exports =
         type: ['string', 'null']
 
       # These can be used as globals or scoped, thus defaults.
-      completions:
-        type: ['array', 'object']
       fontFamily:
         type: 'string'
         default: ''

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -98,9 +98,6 @@ module.exports =
         type: ['string', 'null']
 
       # These can be used as globals or scoped, thus defaults.
-      completions:
-        type: ['array', 'object']
-        default: []
       fontFamily:
         type: 'string'
         default: ''

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -98,6 +98,8 @@ module.exports =
         type: ['string', 'null']
 
       # These can be used as globals or scoped, thus defaults.
+      completions:
+        type: ['array', 'object']
       fontFamily:
         type: 'string'
         default: ''


### PR DESCRIPTION
We don't really need these here (and it can be confusing) as languages can define them. 

_before_
<img src="https://cloud.githubusercontent.com/assets/1305617/7435334/c9311c84-eff7-11e4-9d58-25447d345b22.png" width="300px">
Closes https://github.com/atom/settings-view/issues/353
