### PR TITLE
Allow 0 to be passed as initialLine when opening files via command line

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -518,11 +518,11 @@ class AtomApplication
 
     [fileToOpen, initialLine, initialColumn] = path.basename(pathToOpen).split(':')
     return {pathToOpen} unless initialLine
-    return {pathToOpen} unless parseInt(initialLine) > 0
+    return {pathToOpen} unless parseInt(initialLine) >= 0
 
     # Convert line numbers to a base of 0
-    initialLine -= 1 if initialLine
-    initialColumn -= 1 if initialColumn
+    initialLine = Math.max(0, initialLine - 1) if initialLine
+    initialColumn = Math.max(0, initialColumn - 1) if initialColumn
     pathToOpen = path.join(path.dirname(pathToOpen), fileToOpen)
     {pathToOpen, initialLine, initialColumn}
 


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/1743 which was reopened due to this observation:

> This doesn't quite work yet. When opening a file to line 0, Atom will just try to open a file called "filename.txt:0" rather than just defaulting to the top of the file.

I think it's worth supporting this edge case where we'd normally expect the user to specify "1" as the initial line, not "0".

cc @kevinsawicki 
