### PR TITLE
Add TextEditorElement::isCursorOnScreen()

### DIFF
--- a/spec/text-editor-element-spec.coffee
+++ b/spec/text-editor-element-spec.coffee
@@ -234,7 +234,7 @@ describe "TextEditorElement", ->
       jasmine.attachToDOM(element)
       expect(element.getDefaultCharacterWidth()).toBeGreaterThan(0)
 
-  fdescribe "::isCursorOnScreen", ->
+  describe "::isCursorOnScreen", ->
     [element, model] = []
 
     beforeEach ->

--- a/spec/text-editor-element-spec.coffee
+++ b/spec/text-editor-element-spec.coffee
@@ -233,3 +233,23 @@ describe "TextEditorElement", ->
       element = new TextEditorElement
       jasmine.attachToDOM(element)
       expect(element.getDefaultCharacterWidth()).toBeGreaterThan(0)
+
+  fdescribe "::isCursorOnScreen", ->
+    [element, model] = []
+
+    beforeEach ->
+      atom.project.setPaths([atom.project.getDirectories()[0]?.resolve('.')])
+
+      waitsForPromise ->
+        atom.workspace.open('two-hundred.txt').then (o) -> model = o
+
+    it "returns true if the cursor is visible on the screen", ->
+      element = atom.views.getView(model)
+      expect(model.getCursorScreenPosition()).toEqual [0, 0]
+      expect(element.isCursorOnScreen()).toBe true
+
+    it "returns false if the cursor is not visible on the screen", ->
+      element = atom.views.getView(model)
+      expect(model.getCursorBufferPosition()).toEqual [0, 0]
+      model.setCursorBufferPosition([element.getLastVisibleScreenRow() + 1, 0], autoscroll: false)
+      expect(element.isCursorOnScreen()).toBe false

--- a/spec/text-editor-element-spec.coffee
+++ b/spec/text-editor-element-spec.coffee
@@ -234,7 +234,7 @@ describe "TextEditorElement", ->
       jasmine.attachToDOM(element)
       expect(element.getDefaultCharacterWidth()).toBeGreaterThan(0)
 
-  describe "::isCursorOnScreen", ->
+  fdescribe "::isCursorOnScreen", ->
     [element, model] = []
 
     beforeEach ->
@@ -253,3 +253,13 @@ describe "TextEditorElement", ->
       expect(model.getCursorBufferPosition()).toEqual [0, 0]
       model.setCursorBufferPosition([element.getLastVisibleScreenRow() + 1, 0], autoscroll: false)
       expect(element.isCursorOnScreen()).toBe false
+
+    describe "when options.axis is horizontal", ->
+      it "returns false if the cursor is not horizontally visible on the screen", ->
+        element = atom.views.getView(model)
+        expect(model.getCursorBufferPosition()).toEqual [0, 0]
+        lastVisiblePixelPosition = {top: 0, left: model.getScrollWidth()}
+        lastVisibleColumn = model.screenPositionForPixelPosition(lastVisiblePixelPosition).column
+        model.setCursorBufferPosition([4, lastVisibleColumn + 1], autoscroll: false)
+        expect(model.getCursorBufferPosition()).toEqual [4, lastVisibleColumn + 1]
+        expect(element.isCursorOnScreen(model.getLastCursor(), axis: 'horizontal')).toBe false

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -597,14 +597,6 @@ class Cursor extends Model
   updateVisibility: ->
     @setVisible(@marker.getBufferRange().isEmpty())
 
-  # Public: Returns whether the cursor is visible in the current viewport.
-  isVisibleOnScreen: ->
-    @editorElement ?= atom.views.getView @editor
-    firstRow = @editorElement.getFirstVisibleScreenRow()
-    lastRow = @editorElement.getLastVisibleScreenRow()
-    cursorRow = @editor.getCursorBufferPosition().row
-    firstRow <= cursorRow <= lastRow
-
   ###
   Section: Comparing to another cursor
   ###

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -597,6 +597,14 @@ class Cursor extends Model
   updateVisibility: ->
     @setVisible(@marker.getBufferRange().isEmpty())
 
+  # Public: Returns whether the cursor is visible in the current viewport.
+  isVisibleOnScreen: ->
+    @editorElement ?= atom.views.getView @editor
+    firstRow = @editorElement.getFirstVisibleScreenRow()
+    lastRow = @editorElement.getLastVisibleScreenRow()
+    cursorRow = @editor.getCursorBufferPosition().row
+    firstRow <= cursorRow <= lastRow
+
   ###
   Section: Comparing to another cursor
   ###

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -205,6 +205,17 @@ class TextEditorElement extends HTMLElement
   getLastVisibleScreenRow: ->
     @getModel().getLastVisibleScreenRow(true)
 
+  # Extended: Returns whether the cursor is visible in the current viewport.
+  #
+  # * `cursor` (optional) A [Cursor] object. (default: {TextEditor::getLastCursor()})
+  #
+  # Returns a {Boolean}.
+  isCursorOnScreen: (cursor=@getModel().getLastCursor()) ->
+    firstRow = @getFirstVisibleScreenRow()
+    lastRow = @getLastVisibleScreenRow()
+    cursorRow = cursor.getScreenRow()
+    firstRow <= cursorRow <= lastRow
+
   # Extended: call the given `callback` when the editor is attached to the DOM.
   #
   # * `callback` {Function}

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -226,8 +226,8 @@ class TextEditorElement extends HTMLElement
     if options.axis is 'horizontal' or not options.axis?
       cursorPixelPositionLeft = @pixelPositionForScreenPosition(cursor.getScreenPosition()).left
       scrollLeft = @getModel().getScrollLeft()
-      scrollWidth = @getModel().getScrollWidth()
-      isHorizontallyOnScreen = scrollLeft <= cursorPixelPositionLeft <= scrollWidth
+      clientWidth = @component.presenter.getClientWidth()
+      isHorizontallyOnScreen = scrollLeft <= cursorPixelPositionLeft <= clientWidth
       return isHorizontallyOnScreen if options.axis is 'horizontal'
 
     isVerticallyOnScreen and isHorizontallyOnScreen

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -208,13 +208,29 @@ class TextEditorElement extends HTMLElement
   # Extended: Returns whether the cursor is visible in the current viewport.
   #
   # * `cursor` (optional) A [Cursor] object. (default: {TextEditor::getLastCursor()})
+  # * `options` (optional) {Object} with key:
+  #   * `axis` If `'vertical'`, returns whether `cursor` is vertically visible
+  #     on the screen; if `horizontal`, returns whether `cursor` is horizontally
+  #     visible on the screen. If not specified, returns whether `cursor` is both
+  #     vertically *and* horizontally visible on the screen.
   #
   # Returns a {Boolean}.
-  isCursorOnScreen: (cursor=@getModel().getLastCursor()) ->
-    firstRow = @getFirstVisibleScreenRow()
-    lastRow = @getLastVisibleScreenRow()
-    cursorRow = cursor.getScreenRow()
-    firstRow <= cursorRow <= lastRow
+  isCursorOnScreen: (cursor=@getModel().getLastCursor(), options={}) ->
+    if options.axis is 'vertical' or not options.axis?
+      firstRow = @getFirstVisibleScreenRow()
+      lastRow = @getLastVisibleScreenRow()
+      cursorRow = cursor.getScreenRow()
+      isVerticallyOnScreen = firstRow <= cursorRow <= lastRow
+      return isVerticallyOnScreen if options.axis is 'vertical'
+
+    if options.axis is 'horizontal' or not options.axis?
+      cursorPixelPositionLeft = @pixelPositionForScreenPosition(cursor.getScreenPosition()).left
+      scrollLeft = @getModel().getScrollLeft()
+      scrollWidth = @getModel().getScrollWidth()
+      isHorizontallyOnScreen = scrollLeft <= cursorPixelPositionLeft <= scrollWidth
+      return isHorizontallyOnScreen if options.axis is 'horizontal'
+
+    isVerticallyOnScreen and isHorizontallyOnScreen
 
   # Extended: call the given `callback` when the editor is attached to the DOM.
   #

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -639,6 +639,9 @@ class TextEditorPresenter
       @updateScrollWidth()
       @updateScrollLeft()
 
+  getClientWidth: ->
+    @clientWidth
+
   updateScrollTop: ->
     scrollTop = @constrainScrollTop(@scrollTop)
     unless @scrollTop is scrollTop


### PR DESCRIPTION
This adds the method `::isCursorOnScreen()` to `TextEditorElement`, which makes it a lot easier to determine whether or not a cursor is visible on screen without having to do the rows comparison yourself. This is especially handy for testing, but could certainly have other uses for package authors.

/cc @atom/feedback @nathansobo
