### PR TITLE
Remove babel compatibility option for legacy React versions

### DIFF
--- a/src/babel.coffee
+++ b/src/babel.coffee
@@ -32,11 +32,6 @@ defaultOptions =
     # Target a version of the regenerator runtime that
     # supports yield so the transpiled code is cleaner/smaller.
     'asyncToGenerator'
-
-    # Because Atom is currently packaged with a fork of React v0.11,
-    # it makes sense to use the reactCompat transform so the React
-    # JSX transformer produces pre-v0.12 code.
-    'reactCompat'
   ]
 
   # Includes support for es7 features listed at:


### PR DESCRIPTION
This change depends on https://github.com/atom/react/pull/2.

After updating https://www.npmjs.com/package/react-atom-fork to v0.13.2 per the above PR, we need to remove the compatibility transform.
