### PR TITLE
Use React with addons

### DIFF
--- a/exports/atom.coffee
+++ b/exports/atom.coffee
@@ -122,7 +122,7 @@ unless process.env.ATOM_SHELL_INTERNAL_RUN_AS_NODE
 
     Object.defineProperty module.exports, 'React', get: ->
       deprecate "Please require `react-atom-fork` instead: `React = require 'react-atom-fork'`. Add `\"react-atom-fork\": \"^0.11\"` to your package dependencies."
-      require 'react-atom-fork'
+      require 'react-atom-fork/addons'
 
     Object.defineProperty module.exports, 'Reactionary', get: ->
       deprecate "Please require `reactionary-atom-fork` instead: `Reactionary = require 'reactionary-atom-fork'`. Add `\"reactionary-atom-fork\": \"^0.9\"` to your package dependencies."


### PR DESCRIPTION
This makes [React addons](https://facebook.github.io/react/docs/addons.html) available on `atom.React.addons`.

Without this change, developers using `React.addons` either need to pull in a completely different React build that includes addons (bad), or use addons from another react module (also bad, because the module may have diverged from `atom.React`).
