### PR TITLE
Save state of open windows more frequently

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -99,7 +99,11 @@ class AtomApplication
   # Public: Removes the {AtomWindow} from the global window list.
   removeWindow: (window) ->
     @windows.splice @windows.indexOf(window), 1
-    @applicationMenu?.enableWindowSpecificItems(false) if @windows.length is 0
+    if @windows.length is 0
+      @applicationMenu?.enableWindowSpecificItems(false)
+      if process.platform in ['win32', 'linux']
+        app.quit()
+        return
     @saveState()
 
   # Public: Adds the {AtomWindow} to the global window list.
@@ -200,9 +204,6 @@ class AtomApplication
     @openPathOnEvent('application:open-your-snippets', 'atom://.atom/snippets')
     @openPathOnEvent('application:open-your-stylesheet', 'atom://.atom/stylesheet')
     @openPathOnEvent('application:open-license', path.join(process.resourcesPath, 'LICENSE.md'))
-
-    app.on 'window-all-closed', ->
-      app.quit() if process.platform in ['win32', 'linux']
 
     app.on 'will-quit', =>
       @killAllProcesses()

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -213,7 +213,7 @@ class AtomApplication
       @deleteSocketFile()
 
     app.on 'will-exit', =>
-      @saveState()
+      @saveState() unless @windows.every (window) -> window.isSpec
       @killAllProcesses()
       @deleteSocketFile()
 
@@ -426,8 +426,8 @@ class AtomApplication
   saveState: ->
     states = []
     for window in @windows
-      if loadSettings = window.getLoadSettings()
-        unless loadSettings.isSpec
+      unless window.isSpec
+        if loadSettings = window.getLoadSettings()
           states.push(initialPaths: loadSettings.initialPaths)
     @storageFolder.store('application.json', states)
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -213,6 +213,7 @@ class AtomApplication
       @deleteSocketFile()
 
     app.on 'will-exit', =>
+      @saveState()
       @killAllProcesses()
       @deleteSocketFile()
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -115,10 +115,13 @@ class AtomApplication
 
     unless window.isSpec
       focusHandler = => @lastFocusedWindow = window
+      blurHandler = => @saveState()
       window.browserWindow.on 'focus', focusHandler
+      window.browserWindow.on 'blur', blurHandler
       window.browserWindow.once 'closed', =>
         @lastFocusedWindow = null if window is @lastFocusedWindow
         window.browserWindow.removeListener 'focus', focusHandler
+        window.browserWindow.removeListener 'blur', blurHandler
       window.browserWindow.webContents.once 'did-finish-load', => @saveState()
 
   # Creates server to listen for additional atom application launches.

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -104,7 +104,7 @@ class AtomApplication
       if process.platform in ['win32', 'linux']
         app.quit()
         return
-    @saveState()
+    @saveState() unless window.isSpec
 
   # Public: Adds the {AtomWindow} to the global window list.
   addWindow: (window) ->

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -100,6 +100,7 @@ class AtomApplication
   removeWindow: (window) ->
     @windows.splice @windows.indexOf(window), 1
     @applicationMenu?.enableWindowSpecificItems(false) if @windows.length is 0
+    @saveState()
 
   # Public: Adds the {AtomWindow} to the global window list.
   addWindow: (window) ->
@@ -114,6 +115,7 @@ class AtomApplication
       window.browserWindow.once 'closed', =>
         @lastFocusedWindow = null if window is @lastFocusedWindow
         window.browserWindow.removeListener 'focus', focusHandler
+      window.browserWindow.webContents.once 'did-finish-load', => @saveState()
 
   # Creates server to listen for additional atom application launches.
   #
@@ -201,9 +203,6 @@ class AtomApplication
 
     app.on 'window-all-closed', ->
       app.quit() if process.platform in ['win32', 'linux']
-
-    app.on 'before-quit', =>
-      @saveState()
 
     app.on 'will-quit', =>
       @killAllProcesses()


### PR DESCRIPTION
We now save the open windows whenever:
- A new window is opened
- A window loses focus
- A window is closed (unless it's the last window open on linux or windows)
- `atom.exit()` is called

Refs #6466
