### PR TITLE
:racehorse: Avoid repeated array allocation in ::getDecorations

### DIFF
--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -886,7 +886,7 @@ class DisplayBuffer extends Model
   getDecorations: (propertyFilter) ->
     allDecorations = []
     for markerId, decorations of @decorationsByMarkerId
-      allDecorations = allDecorations.concat(decorations) if decorations?
+      allDecorations.push(decorations...) if decorations?
     if propertyFilter?
       allDecorations = allDecorations.filter (decoration) ->
         for key, value of propertyFilter


### PR DESCRIPTION
Some good low-hanging :cherries:. Screen updates:

Before:
![before](https://cloud.githubusercontent.com/assets/326587/7524833/9777b4d4-f4b9-11e4-9d8e-cede4539645a.png)
300 ms / 3 fps. Spikes at the bottom are GC.

After:
![after](https://cloud.githubusercontent.com/assets/326587/7524860/ba3ddc64-f4b9-11e4-9c57-39490230d596.png)
20 ms / 50 fps. No GC.
