### PR TITLE
Ignore trailing colons and whitespace when opening files from command line

### DIFF
--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -41,6 +41,22 @@ describe "Starting Atom", ->
           .then ({value}) -> expect(value).toBe "Hello!"
           .dispatchCommand("editor:delete-line")
 
+    it "removes all trailing whitespace and colons from the specified path", ->
+      runAtom [path.join(tempDirPath, "new-file:  ")], {ATOM_HOME: atomHome}, (client) ->
+        client
+          .waitForWindowCount(1, 1000)
+          .waitForExist("atom-workspace", 5000)
+          .waitForPaneItemCount(1, 1000)
+
+          .treeViewRootDirectories()
+          .then ({value}) -> expect(value).toEqual([tempDirPath])
+
+          .waitForExist("atom-text-editor", 5000)
+          .then (exists) -> expect(exists).toBe true
+          .click("atom-text-editor")
+          .execute -> atom.workspace.getActiveTextEditor().getPath()
+          .then ({value}) -> expect(value).toBe path.join(tempDirPath, "new-file")
+
   describe "when there is already a window open", ->
     it "reuses that window when opening files, but not when opening directories", ->
       tempFilePath = path.join(temp.mkdirSync("a-third-dir"), "a-file")

--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -41,7 +41,7 @@ describe "Starting Atom", ->
           .then ({value}) -> expect(value).toBe "Hello!"
           .dispatchCommand("editor:delete-line")
 
-    it "opens the parent directory and creates an empty text editor", ->
+    it "opens the file to the specified line number", ->
       filePath = path.join(fs.realpathSync(tempDirPath), "new-file")
       fs.writeFileSync filePath, """
         1
@@ -65,6 +65,31 @@ describe "Starting Atom", ->
           .then ({value}) ->
             expect(value.row).toBe 2
             expect(value.column).toBe 0
+
+    it "opens the file to the specified line number and column number", ->
+      filePath = path.join(fs.realpathSync(tempDirPath), "new-file")
+      fs.writeFileSync filePath, """
+        1
+        2
+        3
+        4
+      """
+
+      runAtom ["#{filePath}:2:2"], {ATOM_HOME: atomHome}, (client) ->
+        client
+          .waitForWindowCount(1, 1000)
+          .waitForExist("atom-workspace", 5000)
+          .waitForPaneItemCount(1, 1000)
+          .waitForExist("atom-text-editor", 5000)
+          .then (exists) -> expect(exists).toBe true
+
+          .execute -> atom.workspace.getActiveTextEditor().getPath()
+          .then ({value}) -> expect(value).toBe filePath
+
+          .execute -> atom.workspace.getActiveTextEditor().getCursorBufferPosition()
+          .then ({value}) ->
+            expect(value.row).toBe 1
+            expect(value.column).toBe 1
 
     it "removes all trailing whitespace and colons from the specified path", ->
       filePath = path.join(tempDirPath, "new-file")

--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -1,10 +1,10 @@
 # These tests are excluded by default. To run them from the command line:
 #
 # ATOM_INTEGRATION_TESTS_ENABLED=true apm test
-# return unless process.env.ATOM_INTEGRATION_TESTS_ENABLED
+return unless process.env.ATOM_INTEGRATION_TESTS_ENABLED
 # Integration tests require a fast machine and, for now, we cannot afford to
 # run them on Travis.
-# return if process.env.TRAVIS
+return if process.env.TRAVIS
 
 fs = require "fs"
 path = require "path"

--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -9,7 +9,7 @@ return if process.env.TRAVIS
 fs = require "fs"
 path = require "path"
 temp = require("temp").track()
-runAtom = require("./helpers/start-atom")
+runAtom = require "./helpers/start-atom"
 
 describe "Starting Atom", ->
   [tempDirPath, otherTempDirPath, atomHome] = []

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -517,6 +517,8 @@ class AtomApplication
     return {pathToOpen} unless pathToOpen
     return {pathToOpen} if fs.existsSync(pathToOpen)
 
+    pathToOpen = pathToOpen.replace(/[:\s]+$/, '')
+
     [fileToOpen, initialLine, initialColumn] = path.basename(pathToOpen).split(':')
     return {pathToOpen} unless initialLine
     return {pathToOpen} unless parseInt(initialLine) >= 0


### PR DESCRIPTION
This is the little brother of https://github.com/atom/atom/pull/6640 and together they should fix https://github.com/atom/atom/issues/6654. :family: :facepunch: 

cc @kevinsawicki for :eyes: 
