### PR TITLE
Tweak how + and - keys are handled when constructing menu keystrokes

### DIFF
--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -163,7 +163,7 @@ class ApplicationMenu
     return null unless firstKeystroke
 
     modifiers = firstKeystroke.split('-')
-    key = modifiers.pop()
+    key = modifiers.pop().toUpperCase().replace('+', 'Plus')
 
     modifiers = modifiers.map (modifier) ->
       modifier.replace(/shift/ig, "Shift")
@@ -171,5 +171,5 @@ class ApplicationMenu
               .replace(/ctrl/ig, "Ctrl")
               .replace(/alt/ig, "Alt")
 
-    keys = modifiers.concat([key.toUpperCase()])
+    keys = modifiers.concat([key])
     keys.join("+")

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -162,7 +162,7 @@ class ApplicationMenu
     firstKeystroke = keystrokesByCommand[command]?[0]
     return null unless firstKeystroke
 
-    modifiers = firstKeystroke.split('-')
+    modifiers = firstKeystroke.split(/-(?=.)/)
     key = modifiers.pop().toUpperCase().replace('+', 'Plus')
 
     modifiers = modifiers.map (modifier) ->


### PR DESCRIPTION
This is an attempt to fix https://github.com/atom/atom/issues/6713 and another problematic case when constructing keystrokes for menus.

The problem in https://github.com/atom/atom/issues/6713 was that the keybinding for `window:increase-font-size` is `cmd-+`, but Electron doesn't accept `+` characters in keystrokes -- [it accepts `Plus`](https://github.com/atom/electron/blob/master/docs/api/accelerator.md#available-key-codes). 29a4ab1 fixes this by detecting `+` keys and switching them with `Plus`. 

![screen shot 2015-05-11 at 14 08 08](https://cloud.githubusercontent.com/assets/38924/7564463/3426c966-f7e7-11e4-819e-fbe6ab41fbc2.png)

Another thing I noticed is that keystrokes are split on `-` (which is the separator Atom uses), which causes problems for keystrokes which use `-` as the key. For example, `window:decrease-font-size` has `cmd--` as one of its keybindings. The reason why this problem doesn't manifest currently is that [`window:decrease-font-size` has two keybindings currently](https://github.com/atom/atom/blob/f1f8c3d0a72de7d20bcde4fd145261c34d3e7462/keymaps/darwin.cson#L79-L80), and the second one is getting picked when constructing the menu (the one which doesn't use `-`):

```
  'cmd--': 'window:decrease-font-size'
  'cmd-_': 'window:decrease-font-size'
```

If you remove that second keybinding, the menu entry for `Decrease font size` will not have a keystroke as well. 71fba99 fixes this by splitting the keystroke on `-`, but only if there's another character after it (so, it doesn't split on trailing `-`).

I tried to figure out how to write tests for this, but failed. :disappointed: @kevinsawicki @maxbrunsfeld if you have some :hourglass: to point me in the right direction -- I'd be happy to add those. 
