### PR TITLE
Use dirname of $0

### DIFF
--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -16,7 +16,7 @@ while getopts ":fhtvw-:" opt; do
 done
 
 if [ $EXPECT_OUTPUT ]; then
-  "$0/../../../atom.exe" "$@"
+  "$(dirname $0)/../../atom.exe" "$@"
 else
-  "$0/../../app/apm/bin/node.exe" "$0/../atom.js" "$@"
+  "$(dirname $0)/../app/apm/bin/node.exe" "$0/../atom.js" "$@"
 fi


### PR DESCRIPTION
This fixes

```
/c/Users/jhasse/AppData/Local/atom/bin/../app-0.198.0/resources/cli/atom.sh: Zeile 21: /c/Users/jhasse/AppData/Local/atom/bin/../app-0.198.0/resources/cli/atom.sh/../../app/apm/bin/node.exe: No such file or directory
```

On Windows 7 using MSYS 2.
