### PR TITLE
Don't pack spellchecker into asar archive

### DIFF
--- a/build/tasks/generate-asar-task.coffee
+++ b/build/tasks/generate-asar-task.coffee
@@ -14,6 +14,7 @@ module.exports = (grunt) ->
       'ctags-darwin'
       'ctags-linux'
       'ctags-win32.exe'
+      '**/node_modules/spellchecker/**'
     ]
     unpack = "{#{unpack.join(',')}}"
 

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "release-notes": "0.52.0",
     "settings-view": "0.198.0",
     "snippets": "0.89.0",
-    "spell-check": "0.56.0",
+    "spell-check": "0.57.0",
     "status-bar": "0.71.0",
     "styleguide": "0.44.0",
     "symbols-view": "0.96.0",


### PR DESCRIPTION
The hunspell dictionaries need to be unpacked so lets just unpack the entire `spellchecker` module since it is small and used out of process anyway.

Closes #6621
Closes atom/spell-check#57
