### PR TITLE
Bump versions for packages updated with license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "one-light-ui": "0.8.1",
     "solarized-dark-syntax": "0.35.0",
     "solarized-light-syntax": "0.21.0",
-    "archive-view": "0.56.0",
+    "archive-view": "0.57.0",
     "autocomplete": "0.46.0",
     "autoflow": "0.22.0",
     "autosave": "0.20.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "language-coffee-script": "0.40.0",
     "language-csharp": "0.5.0",
     "language-css": "0.29.0",
-    "language-gfm": "0.72.0",
+    "language-gfm": "0.73.0",
     "language-git": "0.10.0",
     "language-go": "0.26.0",
     "language-html": "0.37.0",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "language-sql": "0.15.0",
     "language-text": "0.6.0",
     "language-todo": "0.20.0",
-    "language-toml": "0.15.0",
+    "language-toml": "0.16.0",
     "language-xml": "0.28.0",
     "language-yaml": "0.22.0"
   },

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "release-notes": "0.52.0",
     "settings-view": "0.198.0",
     "snippets": "0.89.0",
-    "spell-check": "0.56.0",
+    "spell-check": "0.57.0",
     "status-bar": "0.71.0",
     "styleguide": "0.44.0",
     "symbols-view": "0.96.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "solarized-light-syntax": "0.21.0",
     "archive-view": "0.57.0",
     "autocomplete": "0.47.0",
-    "autoflow": "0.22.0",
+    "autoflow": "0.23.0",
     "autosave": "0.20.0",
     "background-tips": "0.24.0",
     "bookmarks": "0.35.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "solarized-dark-syntax": "0.35.0",
     "solarized-light-syntax": "0.21.0",
     "archive-view": "0.57.0",
-    "autocomplete": "0.46.0",
+    "autocomplete": "0.47.0",
     "autoflow": "0.22.0",
     "autosave": "0.20.0",
     "background-tips": "0.24.0",


### PR DESCRIPTION
This bumps the versions of the 6 packages that were missing a `license` filed in their `package.json` per https://github.com/atom/atom/pull/6645#issuecomment-100340178.

:sob: my commit message emoji fails.
