### PR TITLE
Correct semver in spec

### DIFF
--- a/spec/fixtures/packages/package-with-incompatible-native-module/package.json
+++ b/spec/fixtures/packages/package-with-incompatible-native-module/package.json
@@ -1,5 +1,5 @@
 {
   "name": "package-with-incompatible-native-module",
-  "version": "1.0",
+  "version": "1.0.0",
   "main": "./main.js"
 }


### PR DESCRIPTION
This corrects the semver in a spec's `package.json` per https://github.com/atom/atom/pull/6645.
