### PR TITLE
Remove extra function wrapper in deprecated Decoration::update method

### DIFF
--- a/src/decoration.coffee
+++ b/src/decoration.coffee
@@ -201,6 +201,6 @@ if Grim.includeDeprecatedAPIs
     Grim.deprecate 'Use Decoration::getProperties instead'
     @getProperties()
 
-  Decoration::update = -> (newProperties) ->
+  Decoration::update = (newProperties) ->
     Grim.deprecate 'Use Decoration::setProperties instead'
     @setProperties(newProperties)


### PR DESCRIPTION
While I was [updating](https://github.com/atom/decoration-example/pull/1) decoration-example to 1.0 APIs, I noticed that this `Decoration::update` call was not triggering a deprecation warning and might be wrong (because it will return a function which would need to be called again). I think the extra function wrapper is not needed so this removes it.

After removing it, the deprecation is correctly reported in Deprecation cop when calling `Decoration::update`.

![screen shot 2015-05-12 at 12 58 43](https://cloud.githubusercontent.com/assets/38924/7585823/a6584108-f8a6-11e4-9047-707ba1e50f07.png)
