### PR TITLE
Show window sooner

### DIFF
--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -196,6 +196,10 @@ class Atom extends Model
   #
   # Call after this instance has been assigned to the `atom` global.
   initialize: ->
+    dimensions = @restoreWindowDimensions()
+    maximize = dimensions?.maximized and process.platform isnt 'darwin'
+    @displayWindow({maximize})
+
     sourceMapCache = {}
 
     window.onerror = =>
@@ -483,7 +487,10 @@ class Atom extends Model
   # Extended: Set the full screen state of the current window.
   setFullScreen: (fullScreen=false) ->
     ipc.send('call-window-method', 'setFullScreen', fullScreen)
-    if fullScreen then document.body.classList.add("fullscreen") else document.body.classList.remove("fullscreen")
+    if fullScreen
+      document.body.classList.add("fullscreen")
+    else
+      document.body.classList.remove("fullscreen")
 
   # Extended: Toggle the full screen state of the current window.
   toggleFullScreen: ->
@@ -494,8 +501,9 @@ class Atom extends Model
   # This is done in a next tick to prevent a white flicker from occurring
   # if called synchronously.
   displayWindow: ({maximize}={}) ->
+    @show()
+
     setImmediate =>
-      @show()
       @focus()
       @setFullScreen(true) if @workspace.fullScreen
       @maximize() if maximize
@@ -582,7 +590,6 @@ class Atom extends Model
     CommandInstaller.installApmCommand false, (error) ->
       console.warn error.message if error?
 
-    dimensions = @restoreWindowDimensions()
     @loadConfig()
     @keymaps.loadBundledKeymaps()
     @themes.loadBaseStylesheets()
@@ -601,9 +608,6 @@ class Atom extends Model
     @setAutoHideMenuBar(true) if @config.get('core.autoHideMenuBar')
 
     @openInitialEmptyEditorIfNecessary()
-
-    maximize = dimensions?.maximized and process.platform isnt 'darwin'
-    @displayWindow({maximize})
 
   unloadEditorWindow: ->
     return if not @project

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -282,7 +282,9 @@ class Atom extends Model
         deprecate "The atom.syntax global is deprecated. Use atom.grammars instead."
         @grammars
 
-    @disposables.add @packages.onDidActivateInitialPackages => @watchThemes()
+    @disposables.add @packages.onDidActivateInitialPackages =>
+      @watchThemes()
+      @storeWindowBackground()
 
     Project = require './project'
     TextBuffer = require 'text-buffer'
@@ -580,6 +582,11 @@ class Atom extends Model
     dimensions = @getWindowDimensions()
     @state.windowDimensions = dimensions if @isValidDimensions(dimensions)
 
+  storeWindowBackground: ->
+    workspaceElement = @views?.getView(@workspace)
+    backgroundColor = window.getComputedStyle(workspaceElement)['background-color']
+    window.localStorage.setItem('atom:window-background-color', backgroundColor)
+
   # Call this method when establishing a real application window.
   startEditorWindow: ->
     {safeMode} = @getLoadSettings()
@@ -751,7 +758,8 @@ class Atom extends Model
       # Only reload stylesheets from non-theme packages
       for pack in @packages.getActivePackages() when pack.getType() isnt 'theme'
         pack.reloadStylesheets?()
-      null
+      @storeWindowBackground()
+      return
 
   # Notify the browser project of the window's current project path
   watchProjectPath: ->

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -581,6 +581,8 @@ class Atom extends Model
     @state.windowDimensions = dimensions if @isValidDimensions(dimensions)
 
   storeWindowBackground: ->
+    return if @inSpecMode()
+
     workspaceElement = @views?.getView(@workspace)
     backgroundColor = window.getComputedStyle(workspaceElement)['background-color']
     window.localStorage.setItem('atom:window-background-color', backgroundColor)

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -223,7 +223,7 @@ class Atom extends Model
     @disposables?.dispose()
     @disposables = new CompositeDisposable
 
-    @restoreWindow()
+    @displayWindow()
 
     @setBodyPlatformClass()
 
@@ -494,11 +494,11 @@ class Atom extends Model
   toggleFullScreen: ->
     @setFullScreen(not @isFullScreen())
 
-  # Restore the window to its previous dimensions.
+  # Restore the window to its previous dimensions and show it.
   #
   # Also restores the full screen and maximized state on the next tick to
   # prevent resize glitches.
-  restoreWindow: ->
+  displayWindow: ->
     dimensions = @restoreWindowDimensions()
     @show()
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -282,9 +282,7 @@ class Atom extends Model
         deprecate "The atom.syntax global is deprecated. Use atom.grammars instead."
         @grammars
 
-    @disposables.add @packages.onDidActivateInitialPackages =>
-      @watchThemes()
-      @storeWindowBackground()
+    @disposables.add @packages.onDidActivateInitialPackages => @watchThemes()
 
     Project = require './project'
     TextBuffer = require 'text-buffer'
@@ -619,6 +617,7 @@ class Atom extends Model
   unloadEditorWindow: ->
     return if not @project
 
+    @storeWindowBackground()
     @state.grammars = @grammars.serialize()
     @state.project = @project.serialize()
     @state.workspace = @workspace.serialize()
@@ -758,7 +757,6 @@ class Atom extends Model
       # Only reload stylesheets from non-theme packages
       for pack in @packages.getActivePackages() when pack.getType() isnt 'theme'
         pack.reloadStylesheets?()
-      @storeWindowBackground()
       return
 
   # Notify the browser project of the window's current project path

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -223,9 +223,8 @@ class Atom extends Model
     @disposables?.dispose()
     @disposables = new CompositeDisposable
 
-    dimensions = @restoreWindowDimensions()
-    maximize = dimensions?.maximized and process.platform isnt 'darwin'
-    @displayWindow({maximize})
+    @restoreWindow()
+    @show()
 
     @setBodyPlatformClass()
 
@@ -496,16 +495,17 @@ class Atom extends Model
   toggleFullScreen: ->
     @setFullScreen(not @isFullScreen())
 
-  # Schedule the window to be shown and focused on the next tick.
+  # Restore the window to its previous dimensions.
   #
-  # This is done in a next tick to prevent a white flicker from occurring
-  # if called synchronously.
-  displayWindow: ({maximize}={}) ->
-    @show()
+  # Also restores the full screen and maximized state on the next tick to
+  # prevent resize glitches.
+  restoreWindow: ->
+    dimensions = @restoreWindowDimensions()
+    maximize = dimensions?.maximized and process.platform isnt 'darwin'
 
     setImmediate =>
       @focus()
-      @setFullScreen(true) if @workspace.fullScreen
+      @setFullScreen(true) if @workspace?.fullScreen
       @maximize() if maximize
 
   # Get the dimensions of this window.

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -223,7 +223,7 @@ class Atom extends Model
     @disposables?.dispose()
     @disposables = new CompositeDisposable
 
-    @displayWindow()
+    @displayWindow() unless @inSpecMode()
 
     @setBodyPlatformClass()
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -224,7 +224,6 @@ class Atom extends Model
     @disposables = new CompositeDisposable
 
     @restoreWindow()
-    @show()
 
     @setBodyPlatformClass()
 
@@ -501,6 +500,8 @@ class Atom extends Model
   # prevent resize glitches.
   restoreWindow: ->
     dimensions = @restoreWindowDimensions()
+    @show()
+
     maximize = dimensions?.maximized and process.platform isnt 'darwin'
 
     setImmediate =>

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -584,7 +584,7 @@ class Atom extends Model
   storeWindowBackground: ->
     return if @inSpecMode()
 
-    workspaceElement = @views?.getView(@workspace)
+    workspaceElement = @views.getView(@workspace)
     backgroundColor = window.getComputedStyle(workspaceElement)['background-color']
     window.localStorage.setItem('atom:window-background-color', backgroundColor)
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -196,10 +196,6 @@ class Atom extends Model
   #
   # Call after this instance has been assigned to the `atom` global.
   initialize: ->
-    dimensions = @restoreWindowDimensions()
-    maximize = dimensions?.maximized and process.platform isnt 'darwin'
-    @displayWindow({maximize})
-
     sourceMapCache = {}
 
     window.onerror = =>
@@ -226,6 +222,10 @@ class Atom extends Model
 
     @disposables?.dispose()
     @disposables = new CompositeDisposable
+
+    dimensions = @restoreWindowDimensions()
+    maximize = dimensions?.maximized and process.platform isnt 'darwin'
+    @displayWindow({maximize})
 
     @setBodyPlatformClass()
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -502,12 +502,10 @@ class Atom extends Model
     dimensions = @restoreWindowDimensions()
     @show()
 
-    maximize = dimensions?.maximized and process.platform isnt 'darwin'
-
     setImmediate =>
       @focus()
       @setFullScreen(true) if @workspace?.fullScreen
-      @maximize() if maximize
+      @maximize() if dimensions?.maximized and process.platform isnt 'darwin'
 
   # Get the dimensions of this window.
   #

--- a/static/index.html
+++ b/static/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html style="background: #fff">
+<html>
 <head>
   <title></title>
 

--- a/static/index.html
+++ b/static/index.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title></title>
-
   <meta http-equiv="Content-Security-Policy" content="default-src *; script-src 'self'; style-src 'self' 'unsafe-inline';">
 
   <script src="index.js"></script>

--- a/static/index.js
+++ b/static/index.js
@@ -43,6 +43,7 @@ window.onload = function() {
   }
 }
 
+
 var setLoadTime = function(loadTime) {
   if (global.atom) {
     global.atom.loadTime = loadTime;
@@ -162,3 +163,26 @@ var profileStartup = function(cacheDir, loadSettings, initialTime) {
     });
   }
 }
+
+var setupWindowBackground = function() {
+  var backgroundColor = window.localStorage.getItem('atom:window-background-color');
+  if (!backgroundColor) {
+    return;
+  }
+
+  var backgroundStylesheet = document.createElement('style');
+  backgroundStylesheet.type = 'text/css';
+  backgroundStylesheet.innerText = 'html, body { background: ' + backgroundColor + ' }';
+  document.head.appendChild(backgroundStylesheet);
+
+  // Remove once the page loads
+  window.addEventListener("load", function loadWindow() {
+    window.removeEventListener("load", loadWindow, false);
+    setTimeout(function() {
+      backgroundStylesheet.remove();
+      backgroundStylesheet = null;
+    }, 1000);
+  }, false);
+}
+
+setupWindowBackground();

--- a/static/index.js
+++ b/static/index.js
@@ -172,7 +172,7 @@ var setupWindowBackground = function() {
 
   var backgroundStylesheet = document.createElement('style');
   backgroundStylesheet.type = 'text/css';
-  backgroundStylesheet.innerText = 'html, body { background: ' + backgroundColor + ' }';
+  backgroundStylesheet.innerText = 'html, body { background: ' + backgroundColor + '; }';
   document.head.appendChild(backgroundStylesheet);
 
   // Remove once the page loads

--- a/static/index.js
+++ b/static/index.js
@@ -43,7 +43,6 @@ window.onload = function() {
   }
 }
 
-
 var setLoadTime = function(loadTime) {
   if (global.atom) {
     global.atom.loadTime = loadTime;

--- a/static/index.js
+++ b/static/index.js
@@ -174,14 +174,10 @@ var parseLoadSettings = function() {
   } catch (error) {
     loadSettingsError = error;
   }
-
-  if (!loadSettings || typeof loadSettings !== 'object') {
-    loadSettings = {};
-  }
 }
 
 var setupWindowBackground = function() {
-  if (loadSettings.isSpec) {
+  if (loadSettings && loadSettings.isSpec) {
     return;
   }
 

--- a/static/index.js
+++ b/static/index.js
@@ -172,6 +172,7 @@ var parseLoadSettings = function() {
   try {
     loadSettings = JSON.parse(rawLoadSettings);
   } catch (error) {
+    console.error("Failed to parse load settings: " + rawLoadSettings);
     loadSettingsError = error;
   }
 }


### PR DESCRIPTION
This changes Atom to show the editor window as quickly as possibly, before package and theme loading begins.

It stores the background color in local storage to minimize the color changes once the editor loads.
