### PR TITLE
Upgrade text-buffer for marker performance improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "space-pen": "3.8.2",
     "stacktrace-parser": "0.1.1",
     "temp": "0.8.1",
-    "text-buffer": "^5.2",
+    "text-buffer": "6.0.0-beta.1",
     "theorist": "^1.0.2",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "space-pen": "3.8.2",
     "stacktrace-parser": "0.1.1",
     "temp": "0.8.1",
-    "text-buffer": "6.0.0-beta.1",
+    "text-buffer": "6.0.0-beta.2",
     "theorist": "^1.0.2",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "space-pen": "3.8.2",
     "stacktrace-parser": "0.1.1",
     "temp": "0.8.1",
-    "text-buffer": "6.0.0-beta.2",
+    "text-buffer": "6.0.0",
     "theorist": "^1.0.2",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6"

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -2266,13 +2266,13 @@ describe "TextEditorComponent", ->
       editor.setText("")
       componentNode.dispatchEvent(buildTextInputEvent(data: 'x', target: inputNode))
 
-      currentTime += 99
+      currentTime += 100
       componentNode.dispatchEvent(buildTextInputEvent(data: 'y', target: inputNode))
 
-      currentTime += 99
+      currentTime += 100
       componentNode.dispatchEvent(new CustomEvent('editor:duplicate-lines', bubbles: true, cancelable: true))
 
-      currentTime += 100
+      currentTime += 101
       componentNode.dispatchEvent(new CustomEvent('editor:duplicate-lines', bubbles: true, cancelable: true))
       expect(editor.getText()).toBe "xy\nxy\nxy"
 

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -359,18 +359,6 @@ class Marker
     @oldTailScreenPosition = newTailScreenPosition
     @wasValid = isValid
 
-  pauseChangeEvents: ->
-    @deferredChangeEvents = []
-
-  resumeChangeEvents: ->
-    if deferredChangeEvents = @deferredChangeEvents
-      @deferredChangeEvents = null
-
-      for event in deferredChangeEvents
-        @emit 'changed', event if Grim.includeDeprecatedAPIs
-        @emitter.emit 'did-change', event
-    return
-
   getPixelRange: ->
     @displayBuffer.pixelRangeForScreenRange(@getScreenRange(), false)
 

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -48,7 +48,6 @@ class Marker
   oldTailBufferPosition: null
   oldTailScreenPosition: null
   wasValid: true
-  deferredChangeEvents: null
 
   ###
   Section: Construction and Destruction
@@ -332,11 +331,11 @@ class Marker
     newTailScreenPosition = @getTailScreenPosition()
     isValid = @isValid()
 
-    return if _.isEqual(isValid, @wasValid) and
-      _.isEqual(newHeadBufferPosition, @oldHeadBufferPosition) and
-      _.isEqual(newHeadScreenPosition, @oldHeadScreenPosition) and
-      _.isEqual(newTailBufferPosition, @oldTailBufferPosition) and
-      _.isEqual(newTailScreenPosition, @oldTailScreenPosition)
+    return if isValid is @wasValid and
+      newHeadBufferPosition.isEqual(@oldHeadBufferPosition) and
+      newHeadScreenPosition.isEqual(@oldHeadScreenPosition) and
+      newTailBufferPosition.isEqual(@oldTailBufferPosition) and
+      newTailScreenPosition.isEqual(@oldTailScreenPosition)
 
     changeEvent = {
       @oldHeadScreenPosition, newHeadScreenPosition,
@@ -347,11 +346,8 @@ class Marker
       isValid
     }
 
-    if @deferredChangeEvents?
-      @deferredChangeEvents.push(changeEvent)
-    else
-      @emit 'changed', changeEvent if Grim.includeDeprecatedAPIs
-      @emitter.emit 'did-change', changeEvent
+    @emit 'changed', changeEvent if Grim.includeDeprecatedAPIs
+    @emitter.emit 'did-change', changeEvent
 
     @oldHeadBufferPosition = newHeadBufferPosition
     @oldHeadScreenPosition = newHeadScreenPosition


### PR DESCRIPTION
See https://github.com/atom/text-buffer/pull/58.

Currently this branch uses a pre-release of text-buffer, `6.0.0-beta.1`, introduced in the above PR.
- [x] Publish the `text-buffer@6.0.0` and switch to using that. 
