### PR TITLE
Do not create an AutoUpdateManager when in test mode.

### DIFF
--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -9,11 +9,10 @@ _ = require 'underscore-plus'
 # and maintain the state of all menu items.
 module.exports =
 class ApplicationMenu
-  constructor: (@version) ->
+  constructor: (@version, @autoUpdateManager) ->
     @windowTemplates = new WeakMap()
     @setActiveTemplate(@getDefaultTemplate())
-    global.atomApplication.autoUpdateManager.on 'state-changed', (state) =>
-      @showUpdateMenuItem(state)
+    @autoUpdateManager?.on 'state-changed', (state) => @showUpdateMenuItem(state)
 
   # Public: Updates the entire menu with the given keybindings.
   #
@@ -33,7 +32,7 @@ class ApplicationMenu
       @menu = Menu.buildFromTemplate(_.deepClone(template))
       Menu.setApplicationMenu(@menu)
 
-    @showUpdateMenuItem(global.atomApplication.autoUpdateManager.getState())
+    @showUpdateMenuItem(@autoUpdateManager.getState()) if @autoUpdateManager?
 
   # Register a BrowserWindow with this application menu.
   addWindow: (window) ->

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -32,7 +32,7 @@ class ApplicationMenu
       @menu = Menu.buildFromTemplate(_.deepClone(template))
       Menu.setApplicationMenu(@menu)
 
-    @showUpdateMenuItem(@autoUpdateManager.getState()) if @autoUpdateManager?
+    @showUpdateMenuItem(@autoUpdateManager?.getState())
 
   # Register a BrowserWindow with this application menu.
   addWindow: (window) ->

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -12,7 +12,7 @@ class ApplicationMenu
   constructor: (@version, @autoUpdateManager) ->
     @windowTemplates = new WeakMap()
     @setActiveTemplate(@getDefaultTemplate())
-    @autoUpdateManager?.on 'state-changed', (state) => @showUpdateMenuItem(state)
+    @autoUpdateManager.on 'state-changed', (state) => @showUpdateMenuItem(state)
 
   # Public: Updates the entire menu with the given keybindings.
   #
@@ -32,7 +32,7 @@ class ApplicationMenu
       @menu = Menu.buildFromTemplate(_.deepClone(template))
       Menu.setApplicationMenu(@menu)
 
-    @showUpdateMenuItem(@autoUpdateManager?.getState())
+    @showUpdateMenuItem(@autoUpdateManager.getState())
 
   # Register a BrowserWindow with this application menu.
   addWindow: (window) ->

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -73,6 +73,7 @@ class AtomApplication
     unless options.test
       AutoUpdateManager = require './auto-update-manager'
       @autoUpdateManager = new AutoUpdateManager(@version)
+
     @applicationMenu = new ApplicationMenu(@version)
     @atomProtocolHandler = new AtomProtocolHandler(@resourcePath, @safeMode)
 
@@ -111,7 +112,8 @@ class AtomApplication
   addWindow: (window) ->
     @windows.push window
     @applicationMenu?.addWindow(window.browserWindow)
-    if @autoUpdateManager
+
+    if @autoUpdateManager?
       window.once 'window:loaded', =>
         @autoUpdateManager.emitUpdateAvailableEvent(window)
 
@@ -187,8 +189,9 @@ class AtomApplication
     @on 'application:report-issue', -> require('shell').openExternal('https://github.com/atom/atom/blob/master/CONTRIBUTING.md#submitting-issues')
     @on 'application:search-issues', -> require('shell').openExternal('https://github.com/issues?q=+is%3Aissue+user%3Aatom')
 
-    @on 'application:install-update', -> @autoUpdateManager?.install()
-    @on 'application:check-for-update', => @autoUpdateManager?.check()
+    if @autoUpdateManager?
+      @on 'application:install-update', => @autoUpdateManager.install()
+      @on 'application:check-for-update', => @autoUpdateManager.check()
 
     if process.platform is 'darwin'
       @on 'application:about', -> Menu.sendActionToFirstResponder('orderFrontStandardAboutPanel:')

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -110,7 +110,6 @@ class AtomApplication
   addWindow: (window) ->
     @windows.push window
     @applicationMenu?.addWindow(window.browserWindow)
-
     window.once 'window:loaded', =>
       @autoUpdateManager.emitUpdateAvailableEvent(window)
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -74,7 +74,7 @@ class AtomApplication
       AutoUpdateManager = require './auto-update-manager'
       @autoUpdateManager = new AutoUpdateManager(@version)
 
-    @applicationMenu = new ApplicationMenu(@version)
+    @applicationMenu = new ApplicationMenu(@version, @autoUpdateManager)
     @atomProtocolHandler = new AtomProtocolHandler(@resourcePath, @safeMode)
 
     @listenForArgumentsFromNewProcess()

--- a/src/browser/auto-update-manager.coffee
+++ b/src/browser/auto-update-manager.coffee
@@ -15,7 +15,7 @@ module.exports =
 class AutoUpdateManager
   _.extend @prototype, EventEmitter.prototype
 
-  constructor: (@version) ->
+  constructor: (@version, @testMode) ->
     @state = IdleState
     if process.platform is 'win32'
       # Squirrel for Windows can't handle query params
@@ -80,7 +80,7 @@ class AutoUpdateManager
       autoUpdater.once 'update-not-available', @onUpdateNotAvailable
       autoUpdater.once 'error', @onUpdateError
 
-    autoUpdater.checkForUpdates()
+    autoUpdater.checkForUpdates() unless @testMode
 
   install: ->
     autoUpdater.quitAndInstall()

--- a/src/browser/auto-update-manager.coffee
+++ b/src/browser/auto-update-manager.coffee
@@ -83,7 +83,7 @@ class AutoUpdateManager
     autoUpdater.checkForUpdates() unless @testMode
 
   install: ->
-    autoUpdater.quitAndInstall()
+    autoUpdater.quitAndInstall() unless @testMode
 
   onUpdateNotAvailable: =>
     autoUpdater.removeListener 'error', @onUpdateError


### PR DESCRIPTION
Tests should be 100% reproducible, but `AutoUpdateManager` introduces unpredictable behavior, so it should not be installed when Atom is launched via `apm test`.
