### PR TITLE
Refactor `state.gutters` in TextEditorPresenter; pass minimal state to gutter components

### DIFF
--- a/spec/custom-gutter-component-spec.coffee
+++ b/spec/custom-gutter-component-spec.coffee
@@ -30,15 +30,12 @@ describe "CustomGutterComponent", ->
 
     buildTestState = (customDecorations) ->
       mockTestState =
-        gutters:
+        content: if customDecorations then customDecorations else {}
+        styles:
           scrollHeight: 100
           scrollTop: 10
           backgroundColor: 'black'
-          sortedDescriptions: [{gutter, visible: true}]
-          customDecorations: customDecorations
-        lineNumberGutter:
-          maxLineNumberDigits: 10
-          lineNumbers: {}
+
       mockTestState
 
     it "sets the custom-decoration wrapper's scrollHeight, scrollTop, and background color", ->
@@ -53,7 +50,7 @@ describe "CustomGutterComponent", ->
       expect(decorationsWrapperNode.style.backgroundColor).not.toBe ''
 
     it "creates a new DOM node for a new decoration and adds it to the gutter at the right place", ->
-      customDecorations = 'test-gutter':
+      customDecorations =
         'decoration-id-1':
           top: 0
           height: 10
@@ -75,7 +72,7 @@ describe "CustomGutterComponent", ->
       expect(decorationItem).toBe decorationItem1
 
     it "updates the existing DOM node for a decoration that existed but has new properties", ->
-      initialCustomDecorations = 'test-gutter':
+      initialCustomDecorations =
         'decoration-id-1':
           top: 0
           height: 10
@@ -86,7 +83,7 @@ describe "CustomGutterComponent", ->
 
       # Change the dimensions and item, remove the class.
       decorationItem2 = document.createElement('div')
-      changedCustomDecorations = 'test-gutter':
+      changedCustomDecorations =
         'decoration-id-1':
           top: 10
           height: 20
@@ -103,7 +100,7 @@ describe "CustomGutterComponent", ->
       expect(decorationItem).toBe decorationItem2
 
       # Remove the item, add a class.
-      changedCustomDecorations = 'test-gutter':
+      changedCustomDecorations =
         'decoration-id-1':
           top: 10
           height: 20
@@ -118,7 +115,7 @@ describe "CustomGutterComponent", ->
       expect(changedDecorationNode.children.length).toBe 0
 
     it "removes any decorations that existed previously but aren't in the latest update", ->
-      customDecorations = 'test-gutter':
+      customDecorations =
         'decoration-id-1':
           top: 0
           height: 10
@@ -127,6 +124,6 @@ describe "CustomGutterComponent", ->
       decorationsWrapperNode = gutterComponent.getDomNode().children.item(0)
       expect(decorationsWrapperNode.children.length).toBe 1
 
-      emptyCustomDecorations = 'test-gutter': {}
+      emptyCustomDecorations = {}
       gutterComponent.updateSync(buildTestState(emptyCustomDecorations))
       expect(decorationsWrapperNode.children.length).toBe 0

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -1772,15 +1772,22 @@ describe "TextEditorPresenter", ->
                 pixelPosition: {top: 10, left: 0}
               }
 
-    describe ".lineNumberGutter", ->
+    # TODO jssln Move this under '.gutters'
+    describe "when the gutter is the line-number gutter", ->
+      getLineNumberGutterState = (presenter) ->
+        gutterDescriptions = presenter.getState().gutters
+        for description in gutterDescriptions
+          gutter = description.gutter
+          return description if gutter.name is 'line-number'
+
       describe ".maxLineNumberDigits", ->
         it "is set to the number of digits used by the greatest line number", ->
           presenter = buildPresenter()
           expect(editor.getLastBufferRow()).toBe 12
-          expect(presenter.getState().gutters.lineNumberGutter.maxLineNumberDigits).toBe 2
+          expect(getLineNumberGutterState(presenter).content.maxLineNumberDigits).toBe 2
 
           editor.setText("1\n2\n3")
-          expect(presenter.getState().gutters.lineNumberGutter.maxLineNumberDigits).toBe 1
+          expect(getLineNumberGutterState(presenter).content.maxLineNumberDigits).toBe 1
 
       describe ".lineNumbers", ->
         lineNumberStateForScreenRow = (presenter, screenRow) ->
@@ -1792,7 +1799,7 @@ describe "TextEditorPresenter", ->
           else
             key = bufferRow
 
-          presenter.getState().gutters.lineNumberGutter.lineNumbers[key]
+          getLineNumberGutterState(presenter).content.lineNumbers[key]
 
         it "contains states for line numbers that are visible on screen, plus and minus the overdraw margin", ->
           editor.foldBufferRow(4)
@@ -2025,13 +2032,14 @@ describe "TextEditorPresenter", ->
             presenter = buildPresenter()
             marker = editor.markBufferRange([[0, 0], [0, 0]])
             decoration = editor.decorateMarker(marker, type: 'line-number', class: 'a')
-            expect(lineNumberStateForScreenRow(presenter, 0).decorationClasses).toBeNull()
+            # A mini editor will have no gutters.
+            expect(getLineNumberGutterState(presenter)).toBeUndefined()
 
             expectStateUpdate presenter, -> editor.setMini(false)
             expect(lineNumberStateForScreenRow(presenter, 0).decorationClasses).toEqual ['cursor-line', 'cursor-line-no-selection', 'a']
 
             expectStateUpdate presenter, -> editor.setMini(true)
-            expect(lineNumberStateForScreenRow(presenter, 0).decorationClasses).toBeNull()
+            expect(getLineNumberGutterState(presenter)).toBeUndefined()
 
           it "only applies line-number decorations to screen rows that are spanned by their marker when lines are soft-wrapped", ->
             editor.setText("a line that wraps, ok")

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -2156,7 +2156,7 @@ describe "TextEditorPresenter", ->
           gutter = description.gutter
           return description if gutter.name is gutterName
 
-      describe "the array itself", ->
+      describe "the array itself, an array of gutter descriptions", ->
         it "updates when gutters are added to the editor model, and keeps the gutters sorted by priority", ->
           presenter = buildPresenter()
           gutter1 = editor.addGutter({name: 'test-gutter-1', priority: -100, visible: true})
@@ -2180,8 +2180,238 @@ describe "TextEditorPresenter", ->
           gutter.destroy()
           expect(getStateForGutterWithName(presenter, 'test-gutter')).toBeUndefined()
 
-      describe "when gutter description corresponds to a custom gutter", ->
-        # TODO
+      describe "for a gutter description that corresponds to a custom gutter", ->
+        describe ".content", ->
+          getContentForGutterWithName = (presenter, gutterName) ->
+            fullState = getStateForGutterWithName(presenter, gutterName)
+            return fullState.content if fullState
+
+          [presenter, gutter, decorationItem, decorationParams] = []
+          [marker1, decoration1, marker2, decoration2, marker3, decoration3] = []
+
+          # Set the scrollTop to 0 to show the very top of the file.
+          # Set the explicitHeight to make 10 lines visible.
+          scrollTop = 0
+          lineHeight = 10
+          explicitHeight = lineHeight * 10
+          lineOverdrawMargin = 1
+
+          beforeEach ->
+            # At the beginning of each test, decoration1 and decoration2 are in visible range,
+            # but not decoration3.
+            presenter = buildPresenter({explicitHeight, scrollTop, lineHeight, lineOverdrawMargin})
+            gutter = editor.addGutter({name: 'test-gutter', visible: true})
+            decorationItem = document.createElement('div')
+            decorationItem.class = 'decoration-item'
+            decorationParams =
+              type: 'gutter'
+              gutterName: 'test-gutter'
+              class: 'test-class'
+              item: decorationItem
+            marker1 = editor.markBufferRange([[0,0],[1,0]])
+            decoration1 = editor.decorateMarker(marker1, decorationParams)
+            marker2 = editor.markBufferRange([[9,0],[12,0]])
+            decoration2 = editor.decorateMarker(marker2, decorationParams)
+            marker3 = editor.markBufferRange([[13,0],[14,0]])
+            decoration3 = editor.decorateMarker(marker3, decorationParams)
+
+            # Clear any batched state updates.
+            presenter.getState()
+
+          it "contains all decorations within the visible buffer range", ->
+            decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+            expect(decorationState[decoration1.id].top).toBe lineHeight * marker1.getScreenRange().start.row
+            expect(decorationState[decoration1.id].height).toBe lineHeight * marker1.getScreenRange().getRowCount()
+            expect(decorationState[decoration1.id].item).toBe decorationItem
+            expect(decorationState[decoration1.id].class).toBe 'test-class'
+
+            expect(decorationState[decoration2.id].top).toBe lineHeight * marker2.getScreenRange().start.row
+            expect(decorationState[decoration2.id].height).toBe lineHeight * marker2.getScreenRange().getRowCount()
+            expect(decorationState[decoration2.id].item).toBe decorationItem
+            expect(decorationState[decoration2.id].class).toBe 'test-class'
+
+            expect(decorationState[decoration3.id]).toBeUndefined()
+
+          it "updates when ::scrollTop changes", ->
+            # This update will scroll decoration1 out of view, and decoration3 into view.
+            expectStateUpdate presenter, -> presenter.setScrollTop(scrollTop + lineHeight * 5)
+
+            decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+            expect(decorationState[decoration1.id]).toBeUndefined()
+            expect(decorationState[decoration2.id].top).toBeDefined()
+            expect(decorationState[decoration3.id].top).toBeDefined()
+
+          it "updates when ::explicitHeight changes", ->
+            # This update will make all three decorations visible.
+            expectStateUpdate presenter, -> presenter.setExplicitHeight(explicitHeight + lineHeight * 5)
+
+            decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+            expect(decorationState[decoration1.id].top).toBeDefined()
+            expect(decorationState[decoration2.id].top).toBeDefined()
+            expect(decorationState[decoration3.id].top).toBeDefined()
+
+          it "updates when ::lineHeight changes", ->
+            # This update will make all three decorations visible.
+            expectStateUpdate presenter, -> presenter.setLineHeight(Math.ceil(1.0 * explicitHeight / marker3.getBufferRange().end.row))
+
+            decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+            expect(decorationState[decoration1.id].top).toBeDefined()
+            expect(decorationState[decoration2.id].top).toBeDefined()
+            expect(decorationState[decoration3.id].top).toBeDefined()
+
+          it "updates when the editor's content changes", ->
+            # This update will add enough lines to push decoration2 out of view.
+            expectStateUpdate presenter, -> editor.setTextInBufferRange([[8,0],[9,0]],'\n\n\n\n\n')
+
+            decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+            expect(decorationState[decoration1.id].top).toBeDefined()
+            expect(decorationState[decoration2.id]).toBeUndefined()
+            expect(decorationState[decoration3.id]).toBeUndefined()
+
+          it "updates when a decoration's marker is modified", ->
+            # This update will move decoration1 out of view.
+            expectStateUpdate presenter, ->
+              newRange = new Range([13,0],[14,0])
+              marker1.setBufferRange(newRange)
+
+            decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+            expect(decorationState[decoration1.id]).toBeUndefined()
+            expect(decorationState[decoration2.id].top).toBeDefined()
+            expect(decorationState[decoration3.id]).toBeUndefined()
+
+          describe "when a decoration's properties are modified", ->
+            it "updates the item applied to the decoration, if the decoration item is changed", ->
+              # This changes the decoration class. The visibility of the decoration should not be affected.
+              newItem = document.createElement('div')
+              newItem.class = 'new-decoration-item'
+              newDecorationParams =
+                type: 'gutter'
+                gutterName: 'test-gutter'
+                class: 'test-class'
+                item: newItem
+              expectStateUpdate presenter, -> decoration1.setProperties(newDecorationParams)
+
+              decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+              expect(decorationState[decoration1.id].item).toBe newItem
+              expect(decorationState[decoration2.id].item).toBe decorationItem
+              expect(decorationState[decoration3.id]).toBeUndefined()
+
+            it "updates the class applied to the decoration, if the decoration class is changed", ->
+              # This changes the decoration item. The visibility of the decoration should not be affected.
+              newDecorationParams =
+                type: 'gutter'
+                gutterName: 'test-gutter'
+                class: 'new-test-class'
+                item: decorationItem
+              expectStateUpdate presenter, -> decoration1.setProperties(newDecorationParams)
+
+              decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+              expect(decorationState[decoration1.id].class).toBe 'new-test-class'
+              expect(decorationState[decoration2.id].class).toBe 'test-class'
+              expect(decorationState[decoration3.id]).toBeUndefined()
+
+            it "updates the type of the decoration, if the decoration type is changed", ->
+              # This changes the type of the decoration. This should remove the decoration from the gutter.
+              newDecorationParams =
+                type: 'line'
+                gutterName: 'test-gutter' # This is an invalid/meaningless option here, but it shouldn't matter.
+                class: 'test-class'
+                item: decorationItem
+              expectStateUpdate presenter, -> decoration1.setProperties(newDecorationParams)
+
+              decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+              expect(decorationState[decoration1.id]).toBeUndefined()
+              expect(decorationState[decoration2.id].top).toBeDefined()
+              expect(decorationState[decoration3.id]).toBeUndefined()
+
+            it "updates the gutter the decoration targets, if the decoration gutterName is changed", ->
+              # This changes which gutter this decoration applies to. Since this gutter does not exist,
+              # the decoration should not appear in the customDecorations state.
+              newDecorationParams =
+                type: 'gutter'
+                gutterName: 'test-gutter-2'
+                class: 'new-test-class'
+                item: decorationItem
+              expectStateUpdate presenter, -> decoration1.setProperties(newDecorationParams)
+
+              decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+              expect(decorationState[decoration1.id]).toBeUndefined()
+              expect(decorationState[decoration2.id].top).toBeDefined()
+              expect(decorationState[decoration3.id]).toBeUndefined()
+
+              # After adding the targeted gutter, the decoration will appear in the state for that gutter,
+              # since it should be visible.
+              expectStateUpdate presenter, -> editor.addGutter({name: 'test-gutter-2'})
+              newGutterDecorationState = getContentForGutterWithName(presenter, 'test-gutter-2')
+              expect(newGutterDecorationState[decoration1.id].top).toBeDefined()
+              expect(newGutterDecorationState[decoration2.id]).toBeUndefined()
+              expect(newGutterDecorationState[decoration3.id]).toBeUndefined()
+              oldGutterDecorationState = getContentForGutterWithName(presenter, 'test-gutter')
+              expect(oldGutterDecorationState[decoration1.id]).toBeUndefined()
+              expect(oldGutterDecorationState[decoration2.id].top).toBeDefined()
+              expect(oldGutterDecorationState[decoration3.id]).toBeUndefined()
+
+          it "updates when the editor's mini state changes, and is cleared when the editor is mini", ->
+            expectStateUpdate presenter, -> editor.setMini(true)
+            decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+            expect(decorationState).toBeUndefined()
+
+            # The decorations should return to the original state.
+            expectStateUpdate presenter, -> editor.setMini(false)
+            decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+            expect(decorationState[decoration1.id].top).toBeDefined()
+            expect(decorationState[decoration2.id].top).toBeDefined()
+            expect(decorationState[decoration3.id]).toBeUndefined()
+
+          it "updates when a gutter's visibility changes, and is cleared when the gutter is not visible", ->
+            expectStateUpdate presenter, -> gutter.hide()
+            decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+            expect(decorationState[decoration1.id]).toBeUndefined()
+            expect(decorationState[decoration2.id]).toBeUndefined()
+            expect(decorationState[decoration3.id]).toBeUndefined()
+
+            # The decorations should return to the original state.
+            expectStateUpdate presenter, -> gutter.show()
+            decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+            expect(decorationState[decoration1.id].top).toBeDefined()
+            expect(decorationState[decoration2.id].top).toBeDefined()
+            expect(decorationState[decoration3.id]).toBeUndefined()
+
+          it "updates when a gutter is added to the editor", ->
+            decorationParams =
+              type: 'gutter'
+              gutterName: 'test-gutter-2'
+              class: 'test-class'
+            marker4 = editor.markBufferRange([[0,0],[1,0]])
+            decoration4 = editor.decorateMarker(marker4, decorationParams)
+            expectStateUpdate presenter, -> editor.addGutter({name: 'test-gutter-2'})
+
+            decorationState = getContentForGutterWithName(presenter, 'test-gutter-2')
+            expect(decorationState[decoration1.id]).toBeUndefined()
+            expect(decorationState[decoration2.id]).toBeUndefined()
+            expect(decorationState[decoration3.id]).toBeUndefined()
+            expect(decorationState[decoration4.id].top).toBeDefined()
+
+          it "updates when editor lines are folded", ->
+            oldDimensionsForDecoration1 =
+              top: lineHeight * marker1.getScreenRange().start.row
+              height: lineHeight * marker1.getScreenRange().getRowCount()
+            oldDimensionsForDecoration2 =
+              top: lineHeight * marker2.getScreenRange().start.row
+              height: lineHeight * marker2.getScreenRange().getRowCount()
+
+            # Based on the contents of sample.js, this should affect all but the top
+            # part of decoration1.
+            expectStateUpdate presenter, -> editor.foldBufferRow(0)
+
+            decorationState = getContentForGutterWithName(presenter, 'test-gutter')
+            expect(decorationState[decoration1.id].top).toBe oldDimensionsForDecoration1.top
+            expect(decorationState[decoration1.id].height).not.toBe oldDimensionsForDecoration1.height
+            # Due to the issue described here: https://github.com/atom/atom/issues/6454, decoration2
+            # will be bumped up to the row that was folded and still made visible, instead of being
+            # entirely collapsed. (The same thing will happen to decoration3.)
+            expect(decorationState[decoration2.id].top).not.toBe oldDimensionsForDecoration2.top
+            expect(decorationState[decoration2.id].height).not.toBe oldDimensionsForDecoration2.height
 
       describe "regardless of what kind of gutter a gutter description corresponds to", ->
         [customGutter] = []
@@ -2309,238 +2539,6 @@ describe "TextEditorPresenter", ->
             expectStateUpdate presenter, -> presenter.setBackgroundColor("rgba(0, 0, 255, 0)")
             expect(getStylesForGutterWithName(presenter, 'line-number').backgroundColor).toBe "rgba(0, 0, 255, 0)"
             expect(getStylesForGutterWithName(presenter, 'test-gutter').backgroundColor).toBe "rgba(0, 0, 255, 0)"
-
-      # TODO
-      describe ".customDecorations", ->
-        [presenter, gutter, decorationItem, decorationParams] = []
-        [marker1, decoration1, marker2, decoration2, marker3, decoration3] = []
-
-        # Set the scrollTop to 0 to show the very top of the file.
-        # Set the explicitHeight to make 10 lines visible.
-        scrollTop = 0
-        lineHeight = 10
-        explicitHeight = lineHeight * 10
-        lineOverdrawMargin = 1
-
-        decorationStateForGutterName = (presenter, gutterName) ->
-          presenter.getState().gutters.customDecorations[gutterName]
-
-        beforeEach ->
-          # At the beginning of each test, decoration1 and decoration2 are in visible range,
-          # but not decoration3.
-          presenter = buildPresenter({explicitHeight, scrollTop, lineHeight, lineOverdrawMargin})
-          gutter = editor.addGutter({name: 'test-gutter', visible: true})
-          decorationItem = document.createElement('div')
-          decorationItem.class = 'decoration-item'
-          decorationParams =
-            type: 'gutter'
-            gutterName: 'test-gutter'
-            class: 'test-class'
-            item: decorationItem
-          marker1 = editor.markBufferRange([[0,0],[1,0]])
-          decoration1 = editor.decorateMarker(marker1, decorationParams)
-          marker2 = editor.markBufferRange([[9,0],[12,0]])
-          decoration2 = editor.decorateMarker(marker2, decorationParams)
-          marker3 = editor.markBufferRange([[13,0],[14,0]])
-          decoration3 = editor.decorateMarker(marker3, decorationParams)
-
-          # Clear any batched state updates.
-          presenter.getState()
-
-        it "contains all decorations within the visible buffer range", ->
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-          expect(decorationState[decoration1.id].top).toBe lineHeight * marker1.getScreenRange().start.row
-          expect(decorationState[decoration1.id].height).toBe lineHeight * marker1.getScreenRange().getRowCount()
-          expect(decorationState[decoration1.id].item).toBe decorationItem
-          expect(decorationState[decoration1.id].class).toBe 'test-class'
-
-          expect(decorationState[decoration2.id].top).toBe lineHeight * marker2.getScreenRange().start.row
-          expect(decorationState[decoration2.id].height).toBe lineHeight * marker2.getScreenRange().getRowCount()
-          expect(decorationState[decoration2.id].item).toBe decorationItem
-          expect(decorationState[decoration2.id].class).toBe 'test-class'
-
-          expect(decorationState[decoration3.id]).toBeUndefined()
-
-        it "updates when ::scrollTop changes", ->
-          # This update will scroll decoration1 out of view, and decoration3 into view.
-          expectStateUpdate presenter, -> presenter.setScrollTop(scrollTop + lineHeight * 5)
-
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-          expect(decorationState[decoration1.id]).toBeUndefined()
-          expect(decorationState[decoration2.id].top).toBeDefined()
-          expect(decorationState[decoration3.id].top).toBeDefined()
-
-        it "updates when ::explicitHeight changes", ->
-          # This update will make all three decorations visible.
-          expectStateUpdate presenter, -> presenter.setExplicitHeight(explicitHeight + lineHeight * 5)
-
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-          expect(decorationState[decoration1.id].top).toBeDefined()
-          expect(decorationState[decoration2.id].top).toBeDefined()
-          expect(decorationState[decoration3.id].top).toBeDefined()
-
-        it "updates when ::lineHeight changes", ->
-          # This update will make all three decorations visible.
-          expectStateUpdate presenter, -> presenter.setLineHeight(Math.ceil(1.0 * explicitHeight / marker3.getBufferRange().end.row))
-
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-          expect(decorationState[decoration1.id].top).toBeDefined()
-          expect(decorationState[decoration2.id].top).toBeDefined()
-          expect(decorationState[decoration3.id].top).toBeDefined()
-
-        it "updates when the editor's content changes", ->
-          # This update will add enough lines to push decoration2 out of view.
-          expectStateUpdate presenter, -> editor.setTextInBufferRange([[8,0],[9,0]],'\n\n\n\n\n')
-
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-          expect(decorationState[decoration1.id].top).toBeDefined()
-          expect(decorationState[decoration2.id]).toBeUndefined()
-          expect(decorationState[decoration3.id]).toBeUndefined()
-
-        it "updates when a decoration's marker is modified", ->
-          # This update will move decoration1 out of view.
-          expectStateUpdate presenter, ->
-            newRange = new Range([13,0],[14,0])
-            marker1.setBufferRange(newRange)
-
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-          expect(decorationState[decoration1.id]).toBeUndefined()
-          expect(decorationState[decoration2.id].top).toBeDefined()
-          expect(decorationState[decoration3.id]).toBeUndefined()
-
-        describe "when a decoration's properties are modified", ->
-          it "updates the item applied to the decoration, if the decoration item is changed", ->
-            # This changes the decoration class. The visibility of the decoration should not be affected.
-            newItem = document.createElement('div')
-            newItem.class = 'new-decoration-item'
-            newDecorationParams =
-              type: 'gutter'
-              gutterName: 'test-gutter'
-              class: 'test-class'
-              item: newItem
-            expectStateUpdate presenter, -> decoration1.setProperties(newDecorationParams)
-
-            decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-            expect(decorationState[decoration1.id].item).toBe newItem
-            expect(decorationState[decoration2.id].item).toBe decorationItem
-            expect(decorationState[decoration3.id]).toBeUndefined()
-
-          it "updates the class applied to the decoration, if the decoration class is changed", ->
-            # This changes the decoration item. The visibility of the decoration should not be affected.
-            newDecorationParams =
-              type: 'gutter'
-              gutterName: 'test-gutter'
-              class: 'new-test-class'
-              item: decorationItem
-            expectStateUpdate presenter, -> decoration1.setProperties(newDecorationParams)
-
-            decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-            expect(decorationState[decoration1.id].class).toBe 'new-test-class'
-            expect(decorationState[decoration2.id].class).toBe 'test-class'
-            expect(decorationState[decoration3.id]).toBeUndefined()
-
-          it "updates the type of the decoration, if the decoration type is changed", ->
-            # This changes the type of the decoration. This should remove the decoration from the gutter.
-            newDecorationParams =
-              type: 'line'
-              gutterName: 'test-gutter' # This is an invalid/meaningless option here, but it shouldn't matter.
-              class: 'test-class'
-              item: decorationItem
-            expectStateUpdate presenter, -> decoration1.setProperties(newDecorationParams)
-
-            decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-            expect(decorationState[decoration1.id]).toBeUndefined()
-            expect(decorationState[decoration2.id].top).toBeDefined()
-            expect(decorationState[decoration3.id]).toBeUndefined()
-
-          it "updates the gutter the decoration targets, if the decoration gutterName is changed", ->
-            # This changes which gutter this decoration applies to. Since this gutter does not exist,
-            # the decoration should not appear in the customDecorations state.
-            newDecorationParams =
-              type: 'gutter'
-              gutterName: 'test-gutter-2'
-              class: 'new-test-class'
-              item: decorationItem
-            expectStateUpdate presenter, -> decoration1.setProperties(newDecorationParams)
-
-            decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-            expect(decorationState[decoration1.id]).toBeUndefined()
-            expect(decorationState[decoration2.id].top).toBeDefined()
-            expect(decorationState[decoration3.id]).toBeUndefined()
-
-            # After adding the targeted gutter, the decoration will appear in the state for that gutter,
-            # since it should be visible.
-            expectStateUpdate presenter, -> editor.addGutter({name: 'test-gutter-2'})
-            newGutterDecorationState = decorationStateForGutterName(presenter, 'test-gutter-2')
-            expect(newGutterDecorationState[decoration1.id].top).toBeDefined()
-            expect(newGutterDecorationState[decoration2.id]).toBeUndefined()
-            expect(newGutterDecorationState[decoration3.id]).toBeUndefined()
-            oldGutterDecorationState = decorationStateForGutterName(presenter, 'test-gutter')
-            expect(oldGutterDecorationState[decoration1.id]).toBeUndefined()
-            expect(oldGutterDecorationState[decoration2.id].top).toBeDefined()
-            expect(oldGutterDecorationState[decoration3.id]).toBeUndefined()
-
-        it "updates when the editor's mini state changes, and is cleared when the editor is mini", ->
-          expectStateUpdate presenter, -> editor.setMini(true)
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-          expect(decorationState).toBeUndefined()
-
-          # The decorations should return to the original state.
-          expectStateUpdate presenter, -> editor.setMini(false)
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-          expect(decorationState[decoration1.id].top).toBeDefined()
-          expect(decorationState[decoration2.id].top).toBeDefined()
-          expect(decorationState[decoration3.id]).toBeUndefined()
-
-        it "updates when a gutter's visibility changes, and is cleared when the gutter is not visible", ->
-          expectStateUpdate presenter, -> gutter.hide()
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-          expect(decorationState[decoration1.id]).toBeUndefined()
-          expect(decorationState[decoration2.id]).toBeUndefined()
-          expect(decorationState[decoration3.id]).toBeUndefined()
-
-          # The decorations should return to the original state.
-          expectStateUpdate presenter, -> gutter.show()
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-          expect(decorationState[decoration1.id].top).toBeDefined()
-          expect(decorationState[decoration2.id].top).toBeDefined()
-          expect(decorationState[decoration3.id]).toBeUndefined()
-
-        it "updates when a gutter is added to the editor", ->
-          decorationParams =
-            type: 'gutter'
-            gutterName: 'test-gutter-2'
-            class: 'test-class'
-          marker4 = editor.markBufferRange([[0,0],[1,0]])
-          decoration4 = editor.decorateMarker(marker4, decorationParams)
-          expectStateUpdate presenter, -> editor.addGutter({name: 'test-gutter-2'})
-
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter-2')
-          expect(decorationState[decoration1.id]).toBeUndefined()
-          expect(decorationState[decoration2.id]).toBeUndefined()
-          expect(decorationState[decoration3.id]).toBeUndefined()
-          expect(decorationState[decoration4.id].top).toBeDefined()
-
-        it "updates when editor lines are folded", ->
-          oldDimensionsForDecoration1 =
-            top: lineHeight * marker1.getScreenRange().start.row
-            height: lineHeight * marker1.getScreenRange().getRowCount()
-          oldDimensionsForDecoration2 =
-            top: lineHeight * marker2.getScreenRange().start.row
-            height: lineHeight * marker2.getScreenRange().getRowCount()
-
-          # Based on the contents of sample.js, this should affect all but the top
-          # part of decoration1.
-          expectStateUpdate presenter, -> editor.foldBufferRow(0)
-
-          decorationState = decorationStateForGutterName(presenter, 'test-gutter')
-          expect(decorationState[decoration1.id].top).toBe oldDimensionsForDecoration1.top
-          expect(decorationState[decoration1.id].height).not.toBe oldDimensionsForDecoration1.height
-          # Due to the issue described here: https://github.com/atom/atom/issues/6454, decoration2
-          # will be bumped up to the row that was folded and still made visible, instead of being
-          # entirely collapsed. (The same thing will happen to decoration3.)
-          expect(decorationState[decoration2.id].top).not.toBe oldDimensionsForDecoration2.top
-          expect(decorationState[decoration2.id].height).not.toBe oldDimensionsForDecoration2.height
 
   # disabled until we fix an issue with display buffer markers not updating when
   # they are moved on screen but not in the buffer

--- a/src/custom-gutter-component.coffee
+++ b/src/custom-gutter-component.coffee
@@ -29,13 +29,14 @@ class CustomGutterComponent
       @domNode.style.removeProperty('display')
       @visible = true
 
+  # `state` is a subset of the TextEditorPresenter state that is specific
+  # to this line number gutter.
   updateSync: (state) ->
     @oldDimensionsAndBackgroundState ?= {}
-    newDimensionsAndBackgroundState = state.gutters
-    setDimensionsAndBackground(@oldDimensionsAndBackgroundState, newDimensionsAndBackgroundState, @decorationsNode)
+    setDimensionsAndBackground(@oldDimensionsAndBackgroundState, state.styles, @decorationsNode)
 
     @oldDecorationPositionState ?= {}
-    decorationState = state.gutters.customDecorations[@gutter.name]
+    decorationState = state.content
 
     updatedDecorationIds = new Set
     for decorationId, decorationInfo of decorationState

--- a/src/gutter-container-component.coffee
+++ b/src/gutter-container-component.coffee
@@ -27,7 +27,7 @@ class GutterContainerComponent
   updateSync: (state) ->
     # The GutterContainerComponent expects the gutters to be sorted in the order
     # they should appear.
-    newState = state.gutters.sortedDescriptions
+    newState = state.gutters
 
     newGutterComponents = []
     newGutterComponentsByGutterName = {}

--- a/src/gutter-container-component.coffee
+++ b/src/gutter-container-component.coffee
@@ -1,3 +1,4 @@
+_ = require 'underscore-plus'
 CustomGutterComponent = require './custom-gutter-component'
 LineNumberGutterComponent = require './line-number-gutter-component'
 
@@ -30,7 +31,7 @@ class GutterContainerComponent
 
     newGutterComponents = []
     newGutterComponentsByGutterName = {}
-    for {gutter, visible} in newState
+    for {gutter, visible, styles, content} in newState
       gutterComponent = @gutterComponentsByGutterName[gutter.name]
       if not gutterComponent
         if gutter.name is 'line-number'
@@ -39,7 +40,15 @@ class GutterContainerComponent
         else
           gutterComponent = new CustomGutterComponent({gutter})
       if visible then gutterComponent.showNode() else gutterComponent.hideNode()
-      gutterComponent.updateSync(state)
+      if gutter.name is 'line-number'
+        # Pass the gutter only the state that it needs.
+        # For ease of use in the gutter component, set the shared 'styles' as a
+        # field under the 'content'.
+        gutterSubstate = _.clone(content)
+        gutterSubstate.styles = styles
+        gutterComponent.updateSync(gutterSubstate)
+      else
+        gutterComponent.updateSync(state)
       newGutterComponents.push({
         name: gutter.name,
         component: gutterComponent,

--- a/src/gutter-container-component.coffee
+++ b/src/gutter-container-component.coffee
@@ -39,16 +39,20 @@ class GutterContainerComponent
           @lineNumberGutterComponent = gutterComponent
         else
           gutterComponent = new CustomGutterComponent({gutter})
+
       if visible then gutterComponent.showNode() else gutterComponent.hideNode()
+      # Pass the gutter only the state that it needs.
       if gutter.name is 'line-number'
-        # Pass the gutter only the state that it needs.
-        # For ease of use in the gutter component, set the shared 'styles' as a
-        # field under the 'content'.
+        # For ease of use in the line number gutter component, set the shared
+        # 'styles' as a field under the 'content'.
         gutterSubstate = _.clone(content)
         gutterSubstate.styles = styles
-        gutterComponent.updateSync(gutterSubstate)
       else
-        gutterComponent.updateSync(state)
+        # Custom gutter 'content' is keyed on gutter name, so we cannot set
+        # 'styles' as a subfield directly under it.
+        gutterSubstate = {content, styles}
+      gutterComponent.updateSync(gutterSubstate)
+
       newGutterComponents.push({
         name: gutter.name,
         component: gutterComponent,

--- a/src/line-number-gutter-component.coffee
+++ b/src/line-number-gutter-component.coffee
@@ -31,19 +31,25 @@ class LineNumberGutterComponent
       @domNode.style.removeProperty('display')
       @visible = true
 
+  # `state` is a subset of the TextEditorPresenter state that is specific
+  # to this line number gutter.
   updateSync: (state) ->
-    @newState = state.gutters.lineNumberGutter
-    @oldState ?= {lineNumbers: {}}
+    @newState = state
+    @oldState ?=
+      lineNumbers: {}
+      styles: {}
 
     @appendDummyLineNumber() unless @dummyLineNumberNode?
 
-    newDimensionsAndBackgroundState = state.gutters
-    setDimensionsAndBackground(@oldState, newDimensionsAndBackgroundState, @lineNumbersNode)
+    setDimensionsAndBackground(@oldState.styles, @newState.styles, @lineNumbersNode)
 
     if @newState.maxLineNumberDigits isnt @oldState.maxLineNumberDigits
       @updateDummyLineNumber()
       node.remove() for id, node of @lineNumberNodesById
-      @oldState = {maxLineNumberDigits: @newState.maxLineNumberDigits, lineNumbers: {}}
+      @oldState =
+        maxLineNumberDigits: @newState.maxLineNumberDigits
+        lineNumbers: {}
+        styles: {}
       @lineNumberNodesById = {}
 
     @updateLineNumbers()

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -70,7 +70,7 @@ class TextEditorComponent
     @scrollViewNode.classList.add('scroll-view')
     @domNode.appendChild(@scrollViewNode)
 
-    @mountGutterContainerComponent() if @presenter.getState().gutters.sortedDescriptions.length
+    @mountGutterContainerComponent() if @presenter.getState().gutters.length
 
     @hiddenInputComponent = new InputComponent
     @scrollViewNode.appendChild(@hiddenInputComponent.getDomNode())
@@ -137,7 +137,7 @@ class TextEditorComponent
         else
           @domNode.style.height = ''
 
-    if @newState.gutters.sortedDescriptions.length
+    if @newState.gutters.length
       @mountGutterContainerComponent() unless @gutterContainerComponent?
       @gutterContainerComponent.updateSync(@newState)
     else

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -481,12 +481,12 @@ class TextEditorPresenter
     for gutter in @model.getGutters()
       gutterName = gutter.name
       gutterDecorations = @customGutterDecorations[gutterName]
-      if not gutterDecorations
-        @customGutterDecorations[gutterName] = {}
-      else
+      if gutterDecorations
         # Clear the gutter decorations; they are rebuilt.
         # We clear instead of reassigning to preserve the reference.
         @clearDecorationsForCustomGutterName(gutterName)
+      else
+        @customGutterDecorations[gutterName] = {}
       return if not @gutterIsVisible(gutter)
 
       relevantDecorations = @customGutterDecorationsInRange(gutterName, @startRow, @endRow - 1)

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -473,12 +473,20 @@ class TextEditorPresenter
   updateCustomGutterDecorationState: ->
     return unless @startRow? and @endRow? and @lineHeight?
 
-    @customGutterDecorations = {}
-    return if @model.isMini()
+    if @model.isMini()
+      # Mini editors have no gutter decorations.
+      # We clear instead of reassigning to preserve the reference.
+      @clearAllCustomGutterDecorations()
 
     for gutter in @model.getGutters()
       gutterName = gutter.name
-      @customGutterDecorations[gutterName] = {}
+      gutterDecorations = @customGutterDecorations[gutterName]
+      if not gutterDecorations
+        @customGutterDecorations[gutterName] = {}
+      else
+        # Clear the gutter decorations; they are rebuilt.
+        # We clear instead of reassigning to preserve the reference.
+        @clearDecorationsForCustomGutterName(gutterName)
       return if not @gutterIsVisible(gutter)
 
       relevantDecorations = @customGutterDecorationsInRange(gutterName, @startRow, @endRow - 1)
@@ -489,6 +497,18 @@ class TextEditorPresenter
           height: @lineHeight * decorationRange.getRowCount()
           item: decoration.getProperties().item
           class: decoration.getProperties().class
+
+  clearAllCustomGutterDecorations: ->
+    allGutterNames = Object.keys(@customGutterDecorations)
+    for gutterName in allGutterNames
+      @clearDecorationsForCustomGutterName(gutterName)
+
+  clearDecorationsForCustomGutterName: (gutterName) ->
+    gutterDecorations = @customGutterDecorations[gutterName]
+    if gutterDecorations
+      allDecorationIds = Object.keys(gutterDecorations)
+      for decorationId in allDecorationIds
+        delete gutterDecorations[decorationId]
 
   gutterIsVisible: (gutterModel) ->
     isVisible = gutterModel.isVisible()

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -216,6 +216,8 @@ class TextEditorPresenter
     # Shared state that is copied into ``@state.gutters`.
     @sharedGutterStyles = {}
     @customGutterDecorations = {}
+    @lineNumberGutter =
+      lineNumbers: {}
 
     @updateState()
 
@@ -416,7 +418,7 @@ class TextEditorPresenter
     return
 
   updateLineNumberGutterState: ->
-    @state.gutters.lineNumberGutter.maxLineNumberDigits = @model.getLineCount().toString().length
+    @lineNumberGutter.maxLineNumberDigits = @model.getLineCount().toString().length
 
   updateCommonGutterState: ->
     @sharedGutterStyles.backgroundColor = if @gutterBackgroundColor isnt "rgba(0, 0, 0, 0)"
@@ -459,6 +461,7 @@ class TextEditorPresenter
         styles: @sharedGutterStyles
       })
     @state.gutters.customDecorations = @customGutterDecorations # TODO jssln Remove
+    @state.gutters.lineNumberGutter = @lineNumberGutter # TODO jssln Remove
 
   # Updates the decoration state for the gutter with the given gutterName.
   # @customGutterDecorations is an {Object}, with the form:
@@ -546,7 +549,7 @@ class TextEditorPresenter
         decorationClasses = @lineNumberDecorationClassesForRow(screenRow)
         foldable = @model.isFoldableAtScreenRow(screenRow)
 
-        @state.gutters.lineNumberGutter.lineNumbers[id] = {screenRow, bufferRow, softWrapped, top, decorationClasses, foldable}
+        @lineNumberGutter.lineNumbers[id] = {screenRow, bufferRow, softWrapped, top, decorationClasses, foldable}
         visibleLineNumberIds[id] = true
 
     if @mouseWheelScreenRow?
@@ -556,8 +559,8 @@ class TextEditorPresenter
       id += '-' + wrapCount if wrapCount > 0
       visibleLineNumberIds[id] = true
 
-    for id of @state.gutters.lineNumberGutter.lineNumbers
-      delete @state.gutters.lineNumberGutter.lineNumbers[id] unless visibleLineNumberIds[id]
+    for id of @lineNumberGutter.lineNumbers
+      delete @lineNumberGutter.lineNumbers[id] unless visibleLineNumberIds[id]
 
     return
 

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -215,6 +215,7 @@ class TextEditorPresenter
           lineNumbers: {}
     # Shared state that is copied into ``@state.gutters`.
     @sharedGutterStyles = {}
+    @customGutterDecorations = {}
 
     @updateState()
 
@@ -457,9 +458,10 @@ class TextEditorPresenter
         visible: isVisible,
         styles: @sharedGutterStyles
       })
+    @state.gutters.customDecorations = @customGutterDecorations # TODO jssln Remove
 
   # Updates the decoration state for the gutter with the given gutterName.
-  # @state.gutters.customDecorations is an {Object}, with the form:
+  # @customGutterDecorations is an {Object}, with the form:
   #   * gutterName : {
   #     decoration.id : {
   #       top: # of pixels from top
@@ -471,18 +473,18 @@ class TextEditorPresenter
   updateCustomGutterDecorationState: ->
     return unless @startRow? and @endRow? and @lineHeight?
 
-    @state.gutters.customDecorations = {}
+    @customGutterDecorations = {}
     return if @model.isMini()
 
     for gutter in @model.getGutters()
       gutterName = gutter.name
-      @state.gutters.customDecorations[gutterName] = {}
+      @customGutterDecorations[gutterName] = {}
       return if not @gutterIsVisible(gutter)
 
       relevantDecorations = @customGutterDecorationsInRange(gutterName, @startRow, @endRow - 1)
       relevantDecorations.forEach (decoration) =>
         decorationRange = decoration.getMarker().getScreenRange()
-        @state.gutters.customDecorations[gutterName][decoration.id] =
+        @customGutterDecorations[gutterName][decoration.id] =
           top: @lineHeight * decorationRange.start.row
           height: @lineHeight * decorationRange.getRowCount()
           item: decoration.getProperties().item

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -208,8 +208,7 @@ class TextEditorPresenter
         lines: {}
         highlights: {}
         overlays: {}
-      gutters:
-        sortedDescriptions: []
+      gutters: []
     # Shared state that is copied into ``@state.gutters`.
     @sharedGutterStyles = {}
     @customGutterDecorations = {}
@@ -444,7 +443,7 @@ class TextEditorPresenter
     @emitDidUpdateState()
 
   updateGutterOrderState: ->
-    @state.gutters.sortedDescriptions = []
+    @state.gutters = []
     if @model.isMini()
       return
     for gutter in @model.getGutters()
@@ -454,7 +453,7 @@ class TextEditorPresenter
       else
         @customGutterDecorations[gutter.name] ?= {}
         content = @customGutterDecorations[gutter.name]
-      @state.gutters.sortedDescriptions.push({
+      @state.gutters.push({
         gutter,
         visible: isVisible,
         styles: @sharedGutterStyles,

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -210,9 +210,6 @@ class TextEditorPresenter
         overlays: {}
       gutters:
         sortedDescriptions: []
-        customDecorations: {}
-        lineNumberGutter:
-          lineNumbers: {}
     # Shared state that is copied into ``@state.gutters`.
     @sharedGutterStyles = {}
     @customGutterDecorations = {}
@@ -257,12 +254,10 @@ class TextEditorPresenter
 
   updateVerticalScrollState: ->
     @state.content.scrollHeight = @scrollHeight
-    @state.gutters.scrollHeight = @scrollHeight # TODO jssln Remove
     @sharedGutterStyles.scrollHeight = @scrollHeight
     @state.verticalScrollbar.scrollHeight = @scrollHeight
 
     @state.content.scrollTop = @scrollTop
-    @state.gutters.scrollTop = @scrollTop # TODO jssln Remove
     @sharedGutterStyles.scrollTop = @scrollTop
     @state.verticalScrollbar.scrollTop = @scrollTop
 
@@ -425,7 +420,6 @@ class TextEditorPresenter
       @gutterBackgroundColor
     else
       @backgroundColor
-    @state.gutters.backgroundColor = @sharedGutterStyles.backgroundColor # TODO jssln Remove
 
   didAddGutter: (gutter) ->
     gutterDisposables = new CompositeDisposable
@@ -466,8 +460,6 @@ class TextEditorPresenter
         styles: @sharedGutterStyles,
         content,
       })
-    @state.gutters.customDecorations = @customGutterDecorations # TODO jssln Remove
-    @state.gutters.lineNumberGutter = @lineNumberGutter # TODO jssln Remove
 
   # Updates the decoration state for the gutter with the given gutterName.
   # @customGutterDecorations is an {Object}, with the form:

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -455,10 +455,16 @@ class TextEditorPresenter
       return
     for gutter in @model.getGutters()
       isVisible = @gutterIsVisible(gutter)
+      if gutter.name is 'line-number'
+        content = @lineNumberGutter
+      else
+        @customGutterDecorations[gutter.name] ?= {}
+        content = @customGutterDecorations[gutter.name]
       @state.gutters.sortedDescriptions.push({
         gutter,
         visible: isVisible,
-        styles: @sharedGutterStyles
+        styles: @sharedGutterStyles,
+        content,
       })
     @state.gutters.customDecorations = @customGutterDecorations # TODO jssln Remove
     @state.gutters.lineNumberGutter = @lineNumberGutter # TODO jssln Remove

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -213,6 +213,9 @@ class TextEditorPresenter
         customDecorations: {}
         lineNumberGutter:
           lineNumbers: {}
+    # Shared state that is copied into ``@state.gutters`.
+    @sharedGutterStyles = {}
+
     @updateState()
 
   updateState: ->
@@ -251,11 +254,13 @@ class TextEditorPresenter
 
   updateVerticalScrollState: ->
     @state.content.scrollHeight = @scrollHeight
-    @state.gutters.scrollHeight = @scrollHeight
+    @state.gutters.scrollHeight = @scrollHeight # TODO jssln Remove
+    @sharedGutterStyles.scrollHeight = @scrollHeight
     @state.verticalScrollbar.scrollHeight = @scrollHeight
 
     @state.content.scrollTop = @scrollTop
-    @state.gutters.scrollTop = @scrollTop
+    @state.gutters.scrollTop = @scrollTop # TODO jssln Remove
+    @sharedGutterStyles.scrollTop = @scrollTop
     @state.verticalScrollbar.scrollTop = @scrollTop
 
   updateHorizontalScrollState: ->
@@ -413,10 +418,11 @@ class TextEditorPresenter
     @state.gutters.lineNumberGutter.maxLineNumberDigits = @model.getLineCount().toString().length
 
   updateCommonGutterState: ->
-    @state.gutters.backgroundColor = if @gutterBackgroundColor isnt "rgba(0, 0, 0, 0)"
+    @sharedGutterStyles.backgroundColor = if @gutterBackgroundColor isnt "rgba(0, 0, 0, 0)"
       @gutterBackgroundColor
     else
       @backgroundColor
+    @state.gutters.backgroundColor = @sharedGutterStyles.backgroundColor # TODO jssln Remove
 
   didAddGutter: (gutter) ->
     gutterDisposables = new CompositeDisposable
@@ -446,7 +452,11 @@ class TextEditorPresenter
       return
     for gutter in @model.getGutters()
       isVisible = @gutterIsVisible(gutter)
-      @state.gutters.sortedDescriptions.push({gutter, visible: isVisible})
+      @state.gutters.sortedDescriptions.push({
+        gutter,
+        visible: isVisible,
+        styles: @sharedGutterStyles
+      })
 
   # Updates the decoration state for the gutter with the given gutterName.
   # @state.gutters.customDecorations is an {Object}, with the form:


### PR DESCRIPTION
This is the first part in a series of follow-ups to polish off https://github.com/atom/atom/pull/5217.

This PR does the following:
- Changes `@state.gutters` in TextEditorPresenter to be an Array of Objects of the form:
  - gutter: Gutter model object
  - visible: boolean, whether the gutter is visible
  - content: either what used to be @state.gutters.lineNumberGutter or @state.gutters.customDecorations[gutterName], depending on the gutter
  - styles: an Object with fields: scrollHeight, scrollTop, backgroundColor
- Changes the `state` that is passed to each gutter component's `::updateSync` to only contain the state that it needs.
