### PR TITLE
Improve performance of opening files

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -36,23 +36,21 @@ describe "TextEditor", ->
 
     it "preserves the invisibles setting", ->
       atom.config.set('editor.showInvisibles', true)
-      previousInvisibles = editor.displayBuffer.invisibles
+      previousInvisibles = editor.tokenizedLineForScreenRow(0).invisibles
 
       editor2 = editor.testSerialization()
 
-      expect(editor2.displayBuffer.invisibles).toEqual previousInvisibles
-      expect(editor2.displayBuffer.tokenizedBuffer.invisibles).toEqual previousInvisibles
+      expect(previousInvisibles).toBeDefined()
+      expect(editor2.displayBuffer.tokenizedLineForScreenRow(0).invisibles).toEqual previousInvisibles
 
     it "updates invisibles if the settings have changed between serialization and deserialization", ->
       atom.config.set('editor.showInvisibles', true)
-      previousInvisibles = editor.displayBuffer.invisibles
 
       state = editor.serialize()
       atom.config.set('editor.invisibles', eol: '?')
       editor2 = TextEditor.deserialize(state)
 
-      expect(editor2.displayBuffer.invisibles.eol).toBe '?'
-      expect(editor2.displayBuffer.tokenizedBuffer.invisibles.eol).toBe '?'
+      expect(editor.tokenizedLineForScreenRow(0).invisibles.eol).toBe '?'
 
   describe "when the editor is constructed with an initialLine option", ->
     it "positions the cursor on the specified line", ->

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -611,7 +611,8 @@ describe "TokenizedBuffer", ->
       tokenizedBuffer = new TokenizedBuffer({buffer})
       fullyTokenize(tokenizedBuffer)
 
-      tokenizedBuffer.setInvisibles(space: 'S', tab: 'T')
+      atom.config.set("editor.showInvisibles", true)
+      atom.config.set("editor.invisibles", space: 'S', tab: 'T')
       fullyTokenize(tokenizedBuffer)
 
       expect(tokenizedBuffer.tokenizedLineForRow(0).text).toBe "SST Sa line with tabsTand T spacesSTS"
@@ -623,7 +624,7 @@ describe "TokenizedBuffer", ->
       tokenizedBuffer = new TokenizedBuffer({buffer})
 
       atom.config.set('editor.showInvisibles', true)
-      tokenizedBuffer.setInvisibles(cr: 'R', eol: 'N')
+      atom.config.set("editor.invisibles", cr: 'R', eol: 'N')
       fullyTokenize(tokenizedBuffer)
 
       expect(tokenizedBuffer.tokenizedLineForRow(0).endOfLineInvisibles).toEqual ['R', 'N']
@@ -634,7 +635,7 @@ describe "TokenizedBuffer", ->
       expect(left.endOfLineInvisibles).toBe null
       expect(right.endOfLineInvisibles).toEqual ['R', 'N']
 
-      tokenizedBuffer.setInvisibles(cr: 'R', eol: false)
+      atom.config.set("editor.invisibles", cr: 'R', eol: false)
       expect(tokenizedBuffer.tokenizedLineForRow(0).endOfLineInvisibles).toEqual ['R']
       expect(tokenizedBuffer.tokenizedLineForRow(1).endOfLineInvisibles).toEqual []
 
@@ -688,7 +689,8 @@ describe "TokenizedBuffer", ->
     it "sets leading and trailing whitespace correctly on a line with invisible characters that is copied", ->
       buffer.setText("  \t a line with tabs\tand \tspaces \t ")
 
-      tokenizedBuffer.setInvisibles(space: 'S', tab: 'T')
+      atom.config.set("editor.showInvisibles", true)
+      atom.config.set("editor.invisibles", space: 'S', tab: 'T')
       fullyTokenize(tokenizedBuffer)
 
       line = tokenizedBuffer.tokenizedLineForRow(0).copy()
@@ -696,7 +698,8 @@ describe "TokenizedBuffer", ->
       expect(line.tokens[line.tokens.length - 1].firstTrailingWhitespaceIndex).toBe 0
 
     it "sets the ::firstNonWhitespaceIndex and ::firstTrailingWhitespaceIndex correctly when tokens are split for soft-wrapping", ->
-      tokenizedBuffer.setInvisibles(space: 'S')
+      atom.config.set("editor.showInvisibles", true)
+      atom.config.set("editor.invisibles", space: 'S')
       buffer.setText(" token ")
       fullyTokenize(tokenizedBuffer)
       token = tokenizedBuffer.tokenizedLines[0].tokens[0]

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -42,6 +42,7 @@ class DisplayBuffer extends Model
     @disposables.add @buffer.onDidUpdateMarkers @handleBufferMarkersUpdated
     @disposables.add @buffer.onDidCreateMarker @handleBufferMarkerCreated
     @updateAllScreenLines()
+    @foldMarkerAttributes = Object.freeze({class: 'fold', displayBufferId: @id})
     @createFoldForMarker(marker) for marker in @buffer.findMarkers(@getFoldMarkerAttributes())
 
   subscribeToScopedConfigSettings: =>
@@ -1075,8 +1076,11 @@ class DisplayBuffer extends Model
   findFoldMarkers: (attributes) ->
     @buffer.findMarkers(@getFoldMarkerAttributes(attributes))
 
-  getFoldMarkerAttributes: (attributes={}) ->
-    _.extend(attributes, class: 'fold', displayBufferId: @id)
+  getFoldMarkerAttributes: (attributes) ->
+    if attributes
+      _.extend(attributes, @foldMarkerAttributes)
+    else
+      @foldMarkerAttributes
 
   pauseMarkerChangeEvents: ->
     marker.pauseChangeEvents() for marker in @getMarkers()

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -24,13 +24,13 @@ class DisplayBuffer extends Model
   horizontalScrollMargin: 6
   scopedCharacterWidthsChangeCount: 0
 
-  constructor: ({tabLength, @editorWidthInChars, @tokenizedBuffer, buffer, @invisibles}={}) ->
+  constructor: ({tabLength, @editorWidthInChars, @tokenizedBuffer, buffer, ignoreInvisibles}={}) ->
     super
 
     @emitter = new Emitter
     @disposables = new CompositeDisposable
 
-    @tokenizedBuffer ?= new TokenizedBuffer({tabLength, buffer, @invisibles})
+    @tokenizedBuffer ?= new TokenizedBuffer({tabLength, buffer, ignoreInvisibles})
     @buffer = @tokenizedBuffer.buffer
     @charWidthsByScope = {}
     @markers = {}
@@ -87,14 +87,13 @@ class DisplayBuffer extends Model
     scrollTop: @scrollTop
     scrollLeft: @scrollLeft
     tokenizedBuffer: @tokenizedBuffer.serialize()
-    invisibles: _.clone(@invisibles)
 
   deserializeParams: (params) ->
     params.tokenizedBuffer = TokenizedBuffer.deserialize(params.tokenizedBuffer)
     params
 
   copy: ->
-    newDisplayBuffer = new DisplayBuffer({@buffer, tabLength: @getTabLength(), @invisibles})
+    newDisplayBuffer = new DisplayBuffer({@buffer, tabLength: @getTabLength()})
     newDisplayBuffer.setScrollTop(@getScrollTop())
     newDisplayBuffer.setScrollLeft(@getScrollLeft())
 
@@ -429,8 +428,8 @@ class DisplayBuffer extends Model
   setTabLength: (tabLength) ->
     @tokenizedBuffer.setTabLength(tabLength)
 
-  setInvisibles: (@invisibles) ->
-    @tokenizedBuffer.setInvisibles(@invisibles)
+  setIgnoreInvisibles: (ignoreInvisibles) ->
+    @tokenizedBuffer.setIgnoreInvisibles(ignoreInvisibles)
 
   setSoftWrapped: (softWrapped) ->
     if softWrapped isnt @softWrapped

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -84,11 +84,9 @@ class TextEditor extends Model
     @selections = []
 
     buffer ?= new TextBuffer
-    @displayBuffer ?= new DisplayBuffer({buffer, tabLength, softWrapped})
+    @displayBuffer ?= new DisplayBuffer({buffer, tabLength, softWrapped, ignoreInvisibles: @mini})
     @buffer = @displayBuffer.buffer
     @softTabs = @usesSoftTabs() ? @softTabs ? atom.config.get('editor.softTabs') ? true
-
-    @updateInvisibles()
 
     for marker in @findMarkers(@getSelectionMarkerAttributes())
       marker.setProperties(preserveFolds: true)
@@ -170,21 +168,9 @@ class TextEditor extends Model
       @subscribe @displayBuffer.onDidAddDecoration (decoration) => @emit 'decoration-added', decoration
       @subscribe @displayBuffer.onDidRemoveDecoration (decoration) => @emit 'decoration-removed', decoration
 
-    @subscribeToScopedConfigSettings()
-
-  subscribeToScopedConfigSettings: ->
-    @scopedConfigSubscriptions?.dispose()
-    @scopedConfigSubscriptions = subscriptions = new CompositeDisposable
-
-    scopeDescriptor = @getRootScopeDescriptor()
-
-    subscriptions.add atom.config.onDidChange 'editor.showInvisibles', scope: scopeDescriptor, => @updateInvisibles()
-    subscriptions.add atom.config.onDidChange 'editor.invisibles', scope: scopeDescriptor, => @updateInvisibles()
-
   destroyed: ->
     @unsubscribe() if includeDeprecatedAPIs
     @disposables.dispose()
-    @scopedConfigSubscriptions.dispose()
     selection.destroy() for selection in @getSelections()
     @buffer.release()
     @displayBuffer.destroy()
@@ -488,7 +474,7 @@ class TextEditor extends Model
   setMini: (mini) ->
     if mini isnt @mini
       @mini = mini
-      @updateInvisibles()
+      @displayBuffer.setIgnoreInvisibles(@mini)
       @emitter.emit 'did-change-mini', @mini
     @mini
 
@@ -2779,15 +2765,6 @@ class TextEditor extends Model
   shouldAutoIndentOnPaste: ->
     atom.config.get("editor.autoIndentOnPaste", scope: @getRootScopeDescriptor())
 
-  shouldShowInvisibles: ->
-    not @mini and atom.config.get('editor.showInvisibles', scope: @getRootScopeDescriptor())
-
-  updateInvisibles: ->
-    if @shouldShowInvisibles()
-      @displayBuffer.setInvisibles(atom.config.get('editor.invisibles', scope: @getRootScopeDescriptor()))
-    else
-      @displayBuffer.setInvisibles(null)
-
   ###
   Section: Event Handlers
   ###
@@ -2796,8 +2773,6 @@ class TextEditor extends Model
     @softTabs = @usesSoftTabs() ? @softTabs
 
   handleGrammarChange: ->
-    @updateInvisibles()
-    @subscribeToScopedConfigSettings()
     @unfoldAll()
     @emit 'grammar-changed' if includeDeprecatedAPIs
     @emitter.emit 'did-change-grammar', @getGrammar()

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -90,14 +90,11 @@ class TokenizedBuffer extends Model
     @configSubscriptions.add atom.config.onDidChange 'editor.tabLength', scopeOptions, ({newValue}) =>
       @configSettings.tabLength = newValue
       @retokenizeLines()
-    @configSubscriptions.add atom.config.onDidChange 'editor.invisibles', scopeOptions, ({newValue}) =>
-      oldInvisibles = @getInvisiblesToShow()
-      @configSettings.invisibles = newValue
-      @retokenizeLines() unless _.isEqual(@getInvisiblesToShow(), oldInvisibles)
-    @configSubscriptions.add atom.config.onDidChange 'editor.showInvisibles', scopeOptions, ({newValue}) =>
-      oldInvisibles = @getInvisiblesToShow()
-      @configSettings.showInvisibles = newValue
-      @retokenizeLines() unless _.isEqual(@getInvisiblesToShow(), oldInvisibles)
+    ['invisibles', 'showInvisibles'].forEach (key) =>
+      @configSubscriptions.add atom.config.onDidChange "editor.#{key}", scopeOptions, ({newValue}) =>
+        oldInvisibles = @getInvisiblesToShow()
+        @configSettings[key] = newValue
+        @retokenizeLines() unless _.isEqual(@getInvisiblesToShow(), oldInvisibles)
     @disposables.add(@configSubscriptions)
 
     @retokenizeLines()


### PR DESCRIPTION
Currently, opening large files takes a long time. Most of the time is spent tokenizing the lines and computing the screen lines (accounting for soft-wraps, etc). Because of a small logic error, this was all happening _twice_, every time we opened a file.

These flame graphs are for opening an example 2.3MB javascript file (jQuery 2.0.3, concatenated 10 times).
### Before

Opening the file took about **8.2 seconds**. The span of time between the two red arrows is unnecessary work.

![screen shot 2015-05-13 at 8 18 58 pm](https://cloud.githubusercontent.com/assets/326587/7625546/dd157690-f9ad-11e4-8025-481e19c33bc1.png)
### After

No more duplicated work. Opening the file took about **3.2 seconds**.

![screen shot 2015-05-13 at 8 17 45 pm](https://cloud.githubusercontent.com/assets/326587/7625548/e51e262a-f9ad-11e4-995f-8c0236b4dce7.png)
