### PR TITLE
Add opened files and folders to recently opened list

### DIFF
--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -168,6 +168,8 @@ class AtomWindow
     if @loaded
       @focus()
       @sendMessage 'open-locations', locationsToOpen
+      for location in locationsToOpen
+        app.addRecentDocument(location.pathToOpen)
     else
       @browserWindow.once 'window:loaded', => @openLocations(locationsToOpen)
 


### PR DESCRIPTION
This pull request adds the recent files list to the Atom dock icon's menu on Mac OS.

![screen shot 2015-05-13 at 9 37 23 pm](https://cloud.githubusercontent.com/assets/742678/7626165/7d4f455a-f9b8-11e4-90c2-2b3ab95e7f00.png)

Electron's API supposedly also supports Windows, so theoretically this patch should also work on that platform, but I'm not able to test it.

No change will be visible on Linux.

Unfortunately I attempted to add a Clear Recent Documents dock menu item using the Electron API, but I wasn't able to make that work. Maybe someone else has some guidance on that or can implement it themselves.
