### PR TITLE
Remove hard coded restrictions to enable more correct indentions

### DIFF
--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -311,7 +311,7 @@ class LanguageMode
 
     desiredIndentLevel = @editor.indentationForBufferRow(precedingRow)
     desiredIndentLevel -= 1 unless increaseIndentRegex.testSync(precedingLine)
-    if desiredIndentLevel >= 0 and desiredIndentLevel < currentIndentLevel
+    if desiredIndentLevel >= 0
       @editor.setIndentationForBufferRow(bufferRow, desiredIndentLevel)
 
   getRegexForProperty: (scopeDescriptor, property) ->

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -389,8 +389,6 @@ class Selection extends Model
     if options.autoIndentNewline and text is '\n'
       currentIndentation = @editor.indentationForBufferRow(newBufferRange.start.row)
       @editor.autoIndentBufferRow(newBufferRange.end.row, preserveLeadingWhitespace: true, skipBlankLines: false)
-      if @editor.indentationForBufferRow(newBufferRange.end.row) < currentIndentation
-        @editor.setIndentationForBufferRow(newBufferRange.end.row, currentIndentation)
     else if options.autoDecreaseIndent and NonWhitespaceRegExp.test(text)
       @editor.autoDecreaseIndentForBufferRow(newBufferRange.start.row)
 


### PR DESCRIPTION
Currently these hard coded restrictions prevent some very valid use cases (will add a before and after screencasts at the bottom) and limit the possibilities to implement correct indentation. As far as I’ve tested with it, I did not
find any negative and/or unexpected behaviour with the restrictions removed, but of course I did not test with all possible languages Atom supports.

If it turns out there is a language that does have negative effects from this change, I would argue that the correct place to fix that is in the specific language package by altering the increaseIndentPattern and/or (more likely) the decreaseIndentPattern, instead of relying on these hard coded restrictions.

Before:
![before](https://cloud.githubusercontent.com/assets/4171547/7628544/db28e958-fa24-11e4-9599-126bd61ef749.gif)
As you can see here the bracket isn't indented correctly when moving it to the next line. The decreaseIndentPattern is correct as it does increase when removing and typing in the bracket again on the same line.

After:
![after](https://cloud.githubusercontent.com/assets/4171547/7628620/df8dfb5e-fa25-11e4-9056-b58b4aee31fa.gif)
After removing the hard coded restrictions, the bracket is indented as expected.
