### PR TITLE
Run package specs from the active item's project folder

### DIFF
--- a/spec/workspace-element-spec.coffee
+++ b/spec/workspace-element-spec.coffee
@@ -1,0 +1,44 @@
+ipc = require 'ipc'
+path = require 'path'
+temp = require('temp').track()
+
+describe "WorkspaceElement", ->
+  workspaceElement = null
+
+  beforeEach ->
+    workspaceElement = atom.views.getView(atom.workspace)
+
+  describe "the 'window:run-package-specs' command", ->
+    it "runs the package specs for the active item's project path, or the first project path", ->
+      spyOn(ipc, 'send')
+
+      # No project paths. Don't try to run specs.
+      atom.commands.dispatch(workspaceElement, "window:run-package-specs")
+      expect(ipc.send).not.toHaveBeenCalledWith("run-package-specs")
+
+      projectPaths = [temp.mkdirSync("dir1-"), temp.mkdirSync("dir2-")]
+      atom.project.setPaths(projectPaths)
+
+      # No active item. Use first project directory.
+      atom.commands.dispatch(workspaceElement, "window:run-package-specs")
+      expect(ipc.send).toHaveBeenCalledWith("run-package-specs", path.join(projectPaths[0], "spec"))
+      ipc.send.reset()
+
+      # Active item doesn't implement ::getPath(). Use first project directory.
+      item = document.createElement("div")
+      atom.workspace.getActivePane().activateItem(item)
+      atom.commands.dispatch(workspaceElement, "window:run-package-specs")
+      expect(ipc.send).toHaveBeenCalledWith("run-package-specs", path.join(projectPaths[0], "spec"))
+      ipc.send.reset()
+
+      # Active item has no path. Use first project directory.
+      item.getPath = -> null
+      atom.commands.dispatch(workspaceElement, "window:run-package-specs")
+      expect(ipc.send).toHaveBeenCalledWith("run-package-specs", path.join(projectPaths[0], "spec"))
+      ipc.send.reset()
+
+      # Active item has path. Use project path for item path.
+      item.getPath = -> path.join(projectPaths[1], "a-file.txt")
+      atom.commands.dispatch(workspaceElement, "window:run-package-specs")
+      expect(ipc.send).toHaveBeenCalledWith("run-package-specs", path.join(projectPaths[1], "spec"))
+      ipc.send.reset()

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -113,7 +113,10 @@ class WorkspaceElement extends HTMLElement
   focusPaneViewOnRight: -> @paneContainer.focusPaneViewOnRight()
 
   runPackageSpecs: ->
-    [projectPath] = atom.project.getPaths()
+    if activePath = atom.workspace.getActivePaneItem()?.getPath?()
+      [projectPath] = atom.project.relativizePath(activePath)
+    else
+      [projectPath] = atom.project.getPaths()
     ipc.send('run-package-specs', path.join(projectPath, 'spec')) if projectPath
 
 atom.commands.add 'atom-workspace',


### PR DESCRIPTION
I was editing `find-and-replace` and `atom` in the same window, and it was annoying not being able to run specs for both projects. Now it tries to run the package specs for the active pane item. If there's no active pane item or it doesn't have a path, it uses the first project directory like it did before.
