### PR TITLE
Change hard coded restrictions to enable more correct indentions

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "language-css": "0.32.0",
     "language-gfm": "0.78.0",
     "language-git": "0.10.0",
-    "language-go": "0.27.0",
+    "language-go": "0.28.0",
     "language-html": "0.40.0",
     "language-hyperlink": "0.14.0",
     "language-java": "0.15.0",

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -246,8 +246,12 @@ class LanguageMode
     iterator.next()
     scopeDescriptor = new ScopeDescriptor(scopes: iterator.getScopes())
 
+    increaseIndentRegex = @increaseIndentRegexForScopeDescriptor(scopeDescriptor)
+    decreaseIndentRegex = @decreaseIndentRegexForScopeDescriptor(scopeDescriptor)
+    decreaseNextIndentRegex = @decreaseNextIndentRegexForScopeDescriptor(scopeDescriptor)
+
     currentIndentLevel = @editor.indentationForBufferRow(bufferRow)
-    return currentIndentLevel unless increaseIndentRegex = @increaseIndentRegexForScopeDescriptor(scopeDescriptor)
+    return currentIndentLevel unless increaseIndentRegex
 
     if options?.skipBlankLines ? true
       precedingRow = @buffer.previousNonBlankRow(bufferRow)
@@ -256,13 +260,17 @@ class LanguageMode
       precedingRow = bufferRow - 1
       return currentIndentLevel if precedingRow < 0
 
-    precedingLine = @buffer.lineForRow(precedingRow)
     desiredIndentLevel = @editor.indentationForBufferRow(precedingRow)
-    desiredIndentLevel += 1 if increaseIndentRegex.testSync(precedingLine) and not @editor.isBufferRowCommented(precedingRow)
+    return desiredIndentLevel if @buffer.isRowBlank(precedingRow)
 
-    return desiredIndentLevel unless decreaseIndentRegex = @decreaseIndentRegexForScopeDescriptor(scopeDescriptor)
-    line = @buffer.lineForRow(bufferRow)
-    desiredIndentLevel -= 1 if decreaseIndentRegex.testSync(line)
+    unless @editor.isBufferRowCommented(precedingRow)
+      precedingLine = @buffer.lineForRow(precedingRow)
+      desiredIndentLevel += 1 if increaseIndentRegex?.testSync(precedingLine)
+      desiredIndentLevel -= 1 if decreaseNextIndentRegex?.testSync(precedingLine)
+
+    unless @editor.isBufferRowCommented(bufferRow)
+      bufferLine = @buffer.lineForRow(bufferRow)
+      desiredIndentLevel -= 1 if decreaseIndentRegex?.testSync(bufferLine)
 
     Math.max(desiredIndentLevel, 0)
 
@@ -298,21 +306,26 @@ class LanguageMode
   # bufferRow - The row {Number}
   autoDecreaseIndentForBufferRow: (bufferRow) ->
     scopeDescriptor = @editor.scopeDescriptorForBufferPosition([bufferRow, 0])
-    increaseIndentRegex = @increaseIndentRegexForScopeDescriptor(scopeDescriptor)
-    decreaseIndentRegex = @decreaseIndentRegexForScopeDescriptor(scopeDescriptor)
-    return unless increaseIndentRegex and decreaseIndentRegex
+    return unless decreaseIndentRegex = @decreaseIndentRegexForScopeDescriptor(scopeDescriptor)
 
     line = @buffer.lineForRow(bufferRow)
     return unless decreaseIndentRegex.testSync(line)
 
     currentIndentLevel = @editor.indentationForBufferRow(bufferRow)
     return if currentIndentLevel is 0
+
     precedingRow = @buffer.previousNonBlankRow(bufferRow)
     return unless precedingRow?
-    precedingLine = @buffer.lineForRow(precedingRow)
 
+    precedingLine = @buffer.lineForRow(precedingRow)
     desiredIndentLevel = @editor.indentationForBufferRow(precedingRow)
-    desiredIndentLevel -= 1 unless increaseIndentRegex.testSync(precedingLine)
+
+    if increaseIndentRegex = @increaseIndentRegexForScopeDescriptor(scopeDescriptor)
+      desiredIndentLevel -= 1 unless increaseIndentRegex.testSync(precedingLine)
+
+    if decreaseNextIndentRegex = @decreaseNextIndentRegexForScopeDescriptor(scopeDescriptor)
+      desiredIndentLevel -= 1 if decreaseNextIndentRegex.testSync(precedingLine)
+
     if desiredIndentLevel >= 0 and desiredIndentLevel < currentIndentLevel
       @editor.setIndentationForBufferRow(bufferRow, desiredIndentLevel)
 
@@ -325,6 +338,9 @@ class LanguageMode
 
   decreaseIndentRegexForScopeDescriptor: (scopeDescriptor) ->
     @getRegexForProperty(scopeDescriptor, 'editor.decreaseIndentPattern')
+
+  decreaseNextIndentRegexForScopeDescriptor: (scopeDescriptor) ->
+    @getRegexForProperty(scopeDescriptor, 'editor.decreaseNextIndentPattern')
 
   foldEndRegexForScopeDescriptor: (scopeDescriptor) ->
     @getRegexForProperty(scopeDescriptor, 'editor.foldEndPattern')

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -395,10 +395,7 @@ class Selection extends Model
       @editor.setIndentationForBufferRow(oldBufferRange.start.row, desiredIndentLevel)
 
     if options.autoIndentNewline and text is '\n'
-      currentIndentation = @editor.indentationForBufferRow(newBufferRange.start.row)
       @editor.autoIndentBufferRow(newBufferRange.end.row, preserveLeadingWhitespace: true, skipBlankLines: false)
-      if @editor.indentationForBufferRow(newBufferRange.end.row) < currentIndentation
-        @editor.setIndentationForBufferRow(newBufferRange.end.row, currentIndentation)
     else if options.autoDecreaseIndent and NonWhitespaceRegExp.test(text)
       @editor.autoDecreaseIndentForBufferRow(newBufferRange.start.row)
 


### PR DESCRIPTION
Currently the hard coded restrictions prevent some very valid use cases (will add a before and after screencasts at the bottom) and limit the possibilities to implement correct indentation.

Before:
![before](https://cloud.githubusercontent.com/assets/4171547/7628544/db28e958-fa24-11e4-9599-126bd61ef749.gif)
As you can see here the bracket isn't indented correctly when moving it to the next line. The decreaseIndentPattern is correct as it does increase when removing and typing in the bracket again on the same line.

After:
![after](https://cloud.githubusercontent.com/assets/4171547/7628620/df8dfb5e-fa25-11e4-9056-b58b4aee31fa.gif)
After removing the hard coded restrictions, the bracket is indented as expected.
