### PR TITLE
Initial paths shouldn't be normalized on save and restore (could contain uris)

### DIFF
--- a/spec/default-directory-provider-spec.coffee
+++ b/spec/default-directory-provider-spec.coffee
@@ -31,6 +31,12 @@ describe "DefaultDirectoryProvider", ->
       directory = provider.directoryForURISync(file)
       expect(directory.getPath()).toEqual tmp
 
+    it "creates a Directory with a path as a uri when passed a uri", ->
+      provider = new DefaultDirectoryProvider()
+      uri = 'remote://server:6792/path/to/a/dir'
+      directory = provider.directoryForURISync(uri)
+      expect(directory.getPath()).toEqual uri
+
   describe ".directoryForURI(uri)", ->
     it "returns a Promise that resolves to a Directory with a path that matches the uri", ->
       provider = new DefaultDirectoryProvider()

--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -227,3 +227,13 @@ describe "Starting Atom", ->
                 [tempDirPath]
                 [otherTempDirPath]
               ].sort()
+
+  describe "opening a remote directory", ->
+    it "opens the parent directory and creates an empty text editor", ->
+      remoteDirectory = 'remote://server:3437/some/directory/path'
+      runAtom [remoteDirectory], {ATOM_HOME: atomHome}, (client) ->
+        client
+          .waitForWindowCount(1, 1000)
+          .waitForExist("atom-workspace", 5000)
+          .treeViewRootDirectories()
+          .then ({value}) -> expect(value).toEqual([remoteDirectory])

--- a/spec/window-spec.coffee
+++ b/spec/window-spec.coffee
@@ -293,3 +293,14 @@ describe "Window", ->
         pathToOpen = __dirname
         atom.getCurrentWindow().send 'message', 'open-locations', [{pathToOpen}]
         expect(atom.workspace.open.callCount).toBe 0
+
+    describe "when the opened path is a uri", ->
+      it "adds it to the project's paths as is", ->
+        pathToOpen = 'remote://server:7644/some/dir/path'
+        atom.getCurrentWindow().send 'message', 'open-locations', [{pathToOpen}]
+
+        waitsFor ->
+          atom.project.getPaths().length is 1
+
+        runs ->
+          expect(atom.project.getPaths()[0]).toBe pathToOpen

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -763,7 +763,8 @@ class Atom extends Model
   # Notify the browser project of the window's current project path
   watchProjectPath: ->
     @disposables.add @project.onDidChangePaths =>
-      @constructor.updateLoadSetting('initialPaths', @project.getPaths())
+      @constructor.updateLoadSetting('initialPaths',
+        @project.getPaths().filter((projectPath) -> fs.existsSync(projectPath)))
 
   exit: (status) ->
     app = remote.require('app')

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -763,8 +763,7 @@ class Atom extends Model
   # Notify the browser project of the window's current project path
   watchProjectPath: ->
     @disposables.add @project.onDidChangePaths =>
-      @constructor.updateLoadSetting('initialPaths',
-        @project.getPaths().filter((projectPath) -> fs.existsSync(projectPath)))
+      @constructor.updateLoadSetting('initialPaths', @project.getPaths())
 
   exit: (status) ->
     app = remote.require('app')

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -522,9 +522,8 @@ class AtomApplication
     new AtomWindow({bootstrapScript, @resourcePath, exitWhenDone, isSpec, specDirectory, devMode})
 
   locationForPathToOpen: (pathToOpen) ->
-    {protocol} = url.parse(pathToOpen)
-    return {pathToOpen} if protocol?
     return {pathToOpen} unless pathToOpen
+    return {pathToOpen} if url.parse(pathToOpen).protocol?
     return {pathToOpen} if fs.existsSync(pathToOpen)
 
     pathToOpen = pathToOpen.replace(/[:\s]+$/, '')

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -369,7 +369,12 @@ class AtomApplication
   #   :windowDimensions - Object with height and width keys.
   #   :window - {AtomWindow} to open file paths in.
   openPaths: ({pathsToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, apiPreviewMode, windowDimensions, profileStartup, window}={}) ->
-    pathsToOpen = (fs.normalize(pathToOpen) for pathToOpen in pathsToOpen)
+    pathsToOpen = pathsToOpen.map (pathToOpen) ->
+      if fs.existsSync(pathToOpen)
+        fs.normalize(pathToOpen)
+      else
+        pathToOpen
+
     locationsToOpen = (@locationForPathToOpen(pathToOpen) for pathToOpen in pathsToOpen)
 
     unless pidToKillWhenClosed or newWindow
@@ -517,6 +522,8 @@ class AtomApplication
     new AtomWindow({bootstrapScript, @resourcePath, exitWhenDone, isSpec, specDirectory, devMode})
 
   locationForPathToOpen: (pathToOpen) ->
+    {protocol} = url.parse(pathToOpen)
+    return {pathToOpen} if protocol?
     return {pathToOpen} unless pathToOpen
     return {pathToOpen} if fs.existsSync(pathToOpen)
 

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -47,7 +47,7 @@ start = ->
     cwd = args.executedFrom?.toString() or process.cwd()
     args.pathsToOpen = args.pathsToOpen.map (pathToOpen) ->
       normalizedPath = fs.normalize(pathToOpen)
-      if url.parse(pathToOpen || '').protocol?
+      if url.parse(pathToOpen).protocol?
         pathToOpen
       else if cwd
         path.resolve(cwd, normalizedPath)

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -5,6 +5,7 @@ app = require 'app'
 fs = require 'fs-plus'
 path = require 'path'
 yargs = require 'yargs'
+url = require 'url'
 nslog = require 'nslog'
 
 console.log = nslog
@@ -45,9 +46,11 @@ start = ->
 
     cwd = args.executedFrom?.toString() or process.cwd()
     args.pathsToOpen = args.pathsToOpen.map (pathToOpen) ->
-      pathToOpen = fs.normalize(pathToOpen)
-      if cwd
-        path.resolve(cwd, pathToOpen)
+      normalizedPath = fs.normalize(pathToOpen)
+      if url.parse(pathToOpen || '').protocol?
+        pathToOpen
+      else if cwd
+        path.resolve(cwd, normalizedPath)
       else
         path.resolve(pathToOpen)
 

--- a/src/default-directory-provider.coffee
+++ b/src/default-directory-provider.coffee
@@ -1,6 +1,7 @@
 {Directory} = require 'pathwatcher'
 fs = require 'fs-plus'
 path = require 'path'
+url = require 'url'
 
 module.exports =
 class DefaultDirectoryProvider
@@ -21,7 +22,13 @@ class DefaultDirectoryProvider
     else
       projectPath
 
-    new Directory(directoryPath)
+    # TODO: Stop normalizing the path in pathwatcher's Directory.
+    directory = new Directory(directoryPath)
+    if (url.parse(directoryPath).protocol)
+      directory.path = directoryPath;
+      if (fs.isCaseInsensitive())
+        directory.lowerCasePath = directoryPath.toLowerCase();
+    directory
 
   # Public: Create a Directory that corresponds to the specified URI.
   #

--- a/src/default-directory-provider.coffee
+++ b/src/default-directory-provider.coffee
@@ -25,9 +25,9 @@ class DefaultDirectoryProvider
     # TODO: Stop normalizing the path in pathwatcher's Directory.
     directory = new Directory(directoryPath)
     if (url.parse(directoryPath).protocol)
-      directory.path = directoryPath;
+      directory.path = directoryPath
       if (fs.isCaseInsensitive())
-        directory.lowerCasePath = directoryPath.toLowerCase();
+        directory.lowerCasePath = directoryPath.toLowerCase()
     directory
 
   # Public: Create a Directory that corresponds to the specified URI.

--- a/src/default-directory-provider.coffee
+++ b/src/default-directory-provider.coffee
@@ -24,9 +24,9 @@ class DefaultDirectoryProvider
 
     # TODO: Stop normalizing the path in pathwatcher's Directory.
     directory = new Directory(directoryPath)
-    if (url.parse(directoryPath).protocol)
+    if url.parse(directoryPath).protocol
       directory.path = directoryPath
-      if (fs.isCaseInsensitive())
+      if fs.isCaseInsensitive()
         directory.lowerCasePath = directoryPath.toLowerCase()
     directory
 

--- a/src/default-directory-provider.coffee
+++ b/src/default-directory-provider.coffee
@@ -15,8 +15,8 @@ class DefaultDirectoryProvider
   # * {Directory} if the given URI is compatible with this provider.
   # * `null` if the given URI is not compatibile with this provider.
   directoryForURISync: (uri) ->
-    normalizedPath = path.normalize(uri);
-    {protocol} = url.parse(uri || '')
+    normalizedPath = path.normalize(uri)
+    {protocol} = url.parse(uri)
     directoryPath = if protocol?
       uri
     else if not fs.isDirectorySync(normalizedPath) and fs.isDirectorySync(path.dirname(normalizedPath))

--- a/src/default-directory-provider.coffee
+++ b/src/default-directory-provider.coffee
@@ -20,7 +20,7 @@ class DefaultDirectoryProvider
     else
       uri
 
-    # TODO: Stop normalizing the path in pathwatcher's Directory.
+    # TODO: Stop normalizing the path in pathwatcher Directory.
     directory = new Directory(directoryPath)
     if url.parse(directoryPath).protocol?
       directory.path = directoryPath

--- a/src/default-directory-provider.coffee
+++ b/src/default-directory-provider.coffee
@@ -15,16 +15,14 @@ class DefaultDirectoryProvider
   # * {Directory} if the given URI is compatible with this provider.
   # * `null` if the given URI is not compatibile with this provider.
   directoryForURISync: (uri) ->
-    projectPath = path.normalize(uri)
-
-    directoryPath = if not fs.isDirectorySync(projectPath) and fs.isDirectorySync(path.dirname(projectPath))
-      path.dirname(projectPath)
+    directoryPath = if not fs.isDirectorySync(uri) and fs.isDirectorySync(path.dirname(uri))
+      path.normalize(path.dirname(uri))
     else
-      projectPath
+      uri
 
     # TODO: Stop normalizing the path in pathwatcher's Directory.
     directory = new Directory(directoryPath)
-    if url.parse(directoryPath).protocol
+    if url.parse(directoryPath).protocol?
       directory.path = directoryPath
       if fs.isCaseInsensitive()
         directory.lowerCasePath = directoryPath.toLowerCase()

--- a/src/default-directory-provider.coffee
+++ b/src/default-directory-provider.coffee
@@ -15,14 +15,18 @@ class DefaultDirectoryProvider
   # * {Directory} if the given URI is compatible with this provider.
   # * `null` if the given URI is not compatibile with this provider.
   directoryForURISync: (uri) ->
-    directoryPath = if not fs.isDirectorySync(uri) and fs.isDirectorySync(path.dirname(uri))
-      path.normalize(path.dirname(uri))
-    else
+    normalizedPath = path.normalize(uri);
+    {protocol} = url.parse(uri || '')
+    directoryPath = if protocol?
       uri
+    else if not fs.isDirectorySync(normalizedPath) and fs.isDirectorySync(path.dirname(normalizedPath))
+      path.dirname(normalizedPath)
+    else
+      normalizedPath
 
-    # TODO: Stop normalizing the path in pathwatcher Directory.
+    # TODO: Stop normalizing the path in pathwatcher's Directory.
     directory = new Directory(directoryPath)
-    if url.parse(directoryPath).protocol?
+    if protocol?
       directory.path = directoryPath
       if fs.isCaseInsensitive()
         directory.lowerCasePath = directoryPath.toLowerCase()

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -23,12 +23,12 @@ class WindowEventHandler
             if pathToOpen? and needsProjectPaths
               if fs.existsSync(pathToOpen)
                 atom.project.addPath(pathToOpen)
+              else if fs.existsSync(path.dirname(pathToOpen))
+                atom.project.addPath(path.dirname(pathToOpen))
               else
-                dirToOpen = path.dirname(pathToOpen)
-                if fs.existsSync(dirToOpen)
-                  atom.project.addPath(dirToOpen)
+                atom.project.addPath(pathToOpen)
 
-            unless fs.isDirectorySync(pathToOpen)
+            if fs.isFileSync(pathToOpen)
               atom.workspace?.open(pathToOpen, {initialLine, initialColumn})
 
           return

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -5,6 +5,7 @@ ipc = require 'ipc'
 shell = require 'shell'
 {Subscriber} = require 'emissary'
 fs = require 'fs-plus'
+url = require 'url'
 
 # Handles low-level events related to the window.
 module.exports =
@@ -28,7 +29,8 @@ class WindowEventHandler
               else
                 atom.project.addPath(pathToOpen)
 
-            if fs.isFileSync(pathToOpen)
+            {protocol} = url.parse(pathToOpen)
+            unless fs.isDirectorySync(pathToOpen) or protocol?
               atom.workspace?.open(pathToOpen, {initialLine, initialColumn})
 
           return


### PR DESCRIPTION
Including url-style paths like `remote://host:port/some/path` in the `initialPaths` causes state loss issues, because the hash creation in: https://github.com/atom/atom/blob/master/src/atom.coffee#L93 creates a key that's different from the key got when restoring the state, because the `initialPaths` are normalized and not existing (see: https://github.com/atom/atom/blob/master/src/browser/atom-application.coffee#L372).

So, when the initialPaths contain a url, the state is never restored

This diff makes sure that project paths and `initialPaths` aren't normalized when not local paths

@bolinfest @maxbrunsfeld @benogle 
