### PR TITLE
Favor installed packages when breaking grammar score ties

### DIFF
--- a/spec/fixtures/packages/package-with-rb-filetype/grammars/rb.cson
+++ b/spec/fixtures/packages/package-with-rb-filetype/grammars/rb.cson
@@ -1,0 +1,11 @@
+'name': 'Test Ruby'
+'scopeName': 'test.rb'
+'fileTypes': [
+  'rb'
+]
+'patterns': [
+  {
+    'match': 'ruby'
+    'name': 'meta.class.ruby'
+  }
+]

--- a/spec/fixtures/packages/package-with-rb-filetype/package.json
+++ b/spec/fixtures/packages/package-with-rb-filetype/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-with-rb-filetype",
+  "version": "1.0.0"
+}

--- a/spec/grammars-spec.coffee
+++ b/spec/grammars-spec.coffee
@@ -25,9 +25,9 @@ describe "the `grammars` global", ->
       filePath = '/foo/bar/file.js'
       expect(atom.grammars.selectGrammar(filePath).name).not.toBe 'Ruby'
       atom.grammars.setGrammarOverrideForPath(filePath, 'source.ruby')
-      syntax2 = atom.deserializers.deserialize(atom.grammars.serialize())
-      syntax2.addGrammar(grammar) for grammar in atom.grammars.grammars when grammar isnt atom.grammars.nullGrammar
-      expect(syntax2.selectGrammar(filePath).name).toBe 'Ruby'
+      grammars2 = atom.deserializers.deserialize(atom.grammars.serialize())
+      grammars2.addGrammar(grammar) for grammar in atom.grammars.grammars when grammar isnt atom.grammars.nullGrammar
+      expect(grammars2.selectGrammar(filePath).name).toBe 'Ruby'
 
   describe ".selectGrammar(filePath)", ->
     it "can use the filePath to load the correct grammar based on the grammar's filetype", ->

--- a/spec/grammars-spec.coffee
+++ b/spec/grammars-spec.coffee
@@ -95,14 +95,14 @@ describe "the `grammars` global", ->
         expect(atom.grammars.selectGrammar('more.test', '')).toBe grammar2
 
     it "favors non-bundled packages when breaking scoring ties", ->
-        waitsForPromise ->
-          atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'packages', 'package-with-rb-filetype'))
+      waitsForPromise ->
+        atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'packages', 'package-with-rb-filetype'))
 
-        runs ->
-          atom.grammars.grammarForScopeName('source.ruby').bundledPackage = true
-          atom.grammars.grammarForScopeName('test.rb').bundledPackage = false
+      runs ->
+        atom.grammars.grammarForScopeName('source.ruby').bundledPackage = true
+        atom.grammars.grammarForScopeName('test.rb').bundledPackage = false
 
-          expect(atom.grammars.selectGrammar('test.rb').scopeName).toBe 'test.rb'
+        expect(atom.grammars.selectGrammar('test.rb').scopeName).toBe 'test.rb'
 
     describe "when there is no file path", ->
       it "does not throw an exception (regression)", ->

--- a/spec/grammars-spec.coffee
+++ b/spec/grammars-spec.coffee
@@ -94,6 +94,16 @@ describe "the `grammars` global", ->
         grammar2 = atom.grammars.loadGrammarSync(grammarPath2)
         expect(atom.grammars.selectGrammar('more.test', '')).toBe grammar2
 
+    it "favors non-bundled packages when breaking scoring ties", ->
+        waitsForPromise ->
+          atom.packages.activatePackage(path.join(__dirname, 'fixtures', 'packages', 'package-with-rb-filetype'))
+
+        runs ->
+          atom.grammars.grammarForScopeName('source.ruby').bundledPackage = true
+          atom.grammars.grammarForScopeName('test.rb').bundledPackage = false
+
+          expect(atom.grammars.selectGrammar('test.rb').scopeName).toBe 'test.rb'
+
     describe "when there is no file path", ->
       it "does not throw an exception (regression)", ->
         expect(-> atom.grammars.selectGrammar(null, '#!/usr/bin/ruby')).not.toThrow()

--- a/spec/grammars-spec.coffee
+++ b/spec/grammars-spec.coffee
@@ -2,7 +2,7 @@ path = require 'path'
 fs = require 'fs-plus'
 temp = require 'temp'
 
-describe "the `syntax` global", ->
+describe "the `grammars` global", ->
   beforeEach ->
     waitsForPromise ->
       atom.packages.activatePackage('language-text')

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -40,10 +40,10 @@ class GrammarRegistry extends FirstMate.GrammarRegistry
     highestScore = -Infinity
     for grammar in @grammars
       score = grammar.getScore(filePath, fileContents)
-      if score > highestScore
+      if score > highestScore or not bestMatch?
         bestMatch = grammar
-      else if score is highestScore
-        bestMatch = grammar if bestMatch.bundledPackage and not grammar.bundledPackage
+      else if score is highestScore and bestMatch?.bundledPackage
+        bestMatch = grammar unless grammar.bundledPackage
     bestMatch
 
   clearObservers: ->

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -42,6 +42,7 @@ class GrammarRegistry extends FirstMate.GrammarRegistry
       score = grammar.getScore(filePath, fileContents)
       if score > highestScore or not bestMatch?
         bestMatch = grammar
+        highestScore = score
       else if score is highestScore and bestMatch?.bundledPackage
         bestMatch = grammar unless grammar.bundledPackage
     bestMatch

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -35,7 +35,16 @@ class GrammarRegistry extends FirstMate.GrammarRegistry
   # * `fileContents` A {String} of text for the file path.
   #
   # Returns a {Grammar}, never null.
-  selectGrammar: (filePath, fileContents) -> super
+  selectGrammar: (filePath, fileContents) ->
+    bestMatch = null
+    highestScore = -Infinity
+    for grammar in @grammars
+      score = grammar.getScore(filePath, fileContents)
+      if score > highestScore
+        bestMatch = grammar
+      else if score is highestScore
+        bestMatch = grammar if bestMatch.bundledPackage and not grammar.bundledPackage
+    bestMatch
 
   clearObservers: ->
     @off() if includeDeprecatedAPIs

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -303,6 +303,7 @@ class Package
       try
         grammar = atom.grammars.readGrammarSync(grammarPath)
         grammar.packageName = @name
+        grammar.bundledPackage = @bundledPackage
         @grammars.push(grammar)
         grammar.activate()
       catch error
@@ -322,6 +323,7 @@ class Package
           atom.notifications.addFatalError("Failed to load a #{@name} package grammar", {stack, detail, dismissable: true})
         else
           grammar.packageName = @name
+          grammar.bundledPackage = @bundledPackage
           @grammars.push(grammar)
           grammar.activate() if @grammarsActivated
         callback()


### PR DESCRIPTION
If two grammars are both registered for the same file type, use the one from the non-bundled package.

This allows bundled grammars to be easily overridden by installed packages.

This takes away the stress from adding/removing more file types to core grammars in fear that they will break installed packages.

Basically installed packages will always win.

Refs https://github.com/atom/language-python/pull/61
Refs https://github.com/atom/language-php/pull/50
Refs https://github.com/atom/language-xml/issues/23

/cc @atom/feedback 
/cc @lee-dohm @thomasjo
