### PR TITLE
Upgrade Bootstrap and fix tooltip arrow positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "atom-keymap": "^5.1.2",
     "atom-space-pen-views": "^2.0.4",
     "babel-core": "^5.1.11",
-    "bootstrap": "git+https://github.com/atom/bootstrap.git#6af81906189f1747fd6c93479e3d998ebe041372",
+    "bootstrap": "^3.3.4",
     "clear-cut": "^2.0.1",
     "coffee-cash": "0.8.0",
     "coffee-script": "1.8.0",

--- a/static/bootstrap-overrides.less
+++ b/static/bootstrap-overrides.less
@@ -26,3 +26,9 @@ body {
   font-family: inherit; // inherit from html
   font-size: inherit; // inherit from html
 }
+
+// Latest Bootstrap specifies the font properties again instead of inheriting
+.tooltip {
+  font-family: @font-family;
+  font-size: @font-size;
+}


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/5009

![screenshot 2015-05-19 10 05 55](https://cloud.githubusercontent.com/assets/823545/7704827/bcca0864-fe0e-11e4-88d5-13c1c6cb24ae.png)

This PR migrates Atom to use the latest source Bootstrap instead of Atom's outdated fork of Bootstrap. There's really no need for Atom's fork anymore because the `viewport` option was added to source Bootstrap awhile ago, and that's all we were using the fork for anyway. [Source Bootstrap fixed the tooltip arrow positioning issue awhile ago too.](https://github.com/twbs/bootstrap/commit/4c9850701069954375b19e19bd1513654130eacf)

_Note: this doesn't mean Atom won't still be moving away from Bootstrap eventually, but Atom does heavily rely on it for such components as tooltips, so upgrading it is still a good idea._

TODO:
- [x] Figure out why bootstrap.less is overriding atom.less for the tooltips' `font-family` (ie. the tooltips are always Helvetica Neue because they're defined to be in bootstrap.less)
- [x] Settings View
  - [x] Fix checkboxes
- [x] Fix padding to left of tabs
- [x] Check Styleguide for other regressions

/cc @atom/feedback @simurai 
