### PR TITLE
Use bash highlighting instead of bat

### DIFF
--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -24,14 +24,14 @@
 
 ## Instructions
 
-  ```bat
-  # Use the `Git Shell` app which was installed by GitHub for Windows. Also Make
-  # sure you have logged into the GitHub for Windows GUI App.
-  cd C:\
-  git clone https://github.com/atom/atom/
-  cd atom
-  script/build # Creates application in the `Program Files` directory
-  ```
+```bash
+# Use the `Git Shell` program which was installed by GitHub for Windows.
+# Also make sure that you are logged into GitHub for Windows.
+cd C:\
+git clone https://github.com/atom/atom/
+cd atom
+script/build # Creates application in the `Program Files` directory
+```
 
 ## Why do I have to use GitHub for Windows?
 


### PR DESCRIPTION
Last I checked, Git Shell uses bash-like syntax, not bat.  This fixes comments not being recognized and instead being parsed (such as the `for` receiving special highlighting).
Also some wording changes (and remove some indentation that's not needed).
