### PR TITLE
Fix bug w/ markers mutated inside of change listeners

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1085,6 +1085,21 @@ describe "DisplayBuffer", ->
         expect(changeHandler).toHaveBeenCalled()
         expect(markerChangedHandler).toHaveBeenCalled()
 
+      it "emits the correct events when markers are mutated inside event listeners", ->
+        marker.onDidChange ->
+          if marker.getHeadScreenPosition().isEqual([5, 9])
+            marker.setHeadScreenPosition([5, 8])
+
+        marker.setHeadScreenPosition([5, 9])
+
+        headChanges = for [event] in markerChangedHandler.argsForCall
+          {old: event.oldHeadScreenPosition, new: event.newHeadScreenPosition}
+
+        expect(headChanges).toEqual [
+          {old: [5, 10], new: [5, 9]}
+          {old: [5, 9], new: [5, 8]}
+        ]
+
     describe "::findMarkers(attributes)", ->
       it "allows the startBufferRow and endBufferRow to be specified", ->
         marker1 = displayBuffer.markBufferRange([[0, 0], [3, 0]], class: 'a')

--- a/src/marker.coffee
+++ b/src/marker.coffee
@@ -346,14 +346,14 @@ class Marker
       isValid
     }
 
-    @emit 'changed', changeEvent if Grim.includeDeprecatedAPIs
-    @emitter.emit 'did-change', changeEvent
-
     @oldHeadBufferPosition = newHeadBufferPosition
     @oldHeadScreenPosition = newHeadScreenPosition
     @oldTailBufferPosition = newTailBufferPosition
     @oldTailScreenPosition = newTailScreenPosition
     @wasValid = isValid
+
+    @emit 'changed', changeEvent if Grim.includeDeprecatedAPIs
+    @emitter.emit 'did-change', changeEvent
 
   getPixelRange: ->
     @displayBuffer.pixelRangeForScreenRange(@getScreenRange(), false)


### PR DESCRIPTION
The vim-mode package [moves cursors](https://github.com/atom/vim-mode/blob/208b36df89c62ef2657f04fc21055334374d8dbc/lib/vim-state.coffee#L32) inside of marker change handlers. Currently, this causes incorrect marker change events to be emitted. This fixes that.
