### PR TITLE
Only perform a single marker query for folds when updating screen lines

### DIFF
--- a/src/fold.coffee
+++ b/src/fold.coffee
@@ -13,7 +13,6 @@ class Fold
   constructor: (@displayBuffer, @marker) ->
     @id = @marker.id
     @displayBuffer.foldsByMarkerId[@marker.id] = this
-    @updateDisplayBuffer()
     @marker.onDidDestroy => @destroyed()
     @marker.onDidChange ({isValid}) => @destroy() unless isValid
 


### PR DESCRIPTION
This saves over 50ms to initialize the DisplayBuffer when opening `text-editor.coffee`. The savings increase as files get larger.
