### PR TITLE
Add lsb_release as Linux dependency

### DIFF
--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,7 @@
 Package: <%= name %>
 Version: <%= version %>
 Depends: git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, python, gvfs-bin, xdg-utils
+Recommends: lsb-release
 Suggests: libgnome-keyring0, gir1.2-gnomekeyring-1.0
 Section: <%= section %>
 Priority: optional

--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -7,6 +7,8 @@ URL:            https://atom.io/
 AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
+Requires: redhat-lsb-core
+
 %description
 <%= description %>
 


### PR DESCRIPTION
Refs https://github.com/atom/notifications/pull/64#issuecomment-103884342

This helps ensure that Linux installs have `lsb_release` installed for more accurate OS reporting in issues.
