### PR TITLE
Lint for even more style errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,9 @@ For more information on how to work with Atom's official packages, see
 
 * Set parameter defaults without spaces around the equal sign
     * `clear = (count=1) ->` instead of `clear = (count = 1) ->`
+* Use spaces around operators
+    * `count + 1` instead of `count+1`
+* Use spaces after commas (unless separated by newlines)
 * Use parentheses if it improves code clarity.
 * Prefer alphabetic keywords to symbolic keywords:
     * `a is b` instead of `a == b`
@@ -113,6 +116,8 @@ For more information on how to work with Atom's official packages, see
 * Use `slice()` to copy an array
 * Add an explicit `return` when your function ends with a `for`/`while` loop and
   you don't want it to return a collected array.
+* Use `this` instead of a standalone `@`
+  * `return this` instead of `return @`
 
 ## Specs Styleguide
 

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -31,7 +31,7 @@ module.exports = (grunt) ->
       binDir = path.join(installDir, 'bin')
       shareDir = path.join(installDir, 'share', 'atom')
 
-      iconName = path.join(shareDir,'resources', 'app', 'resources', 'atom.png')
+      iconName = path.join(shareDir, 'resources', 'app', 'resources', 'atom.png')
 
       mkdir binDir
       cp 'atom.sh', path.join(binDir, 'atom')

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -33,9 +33,5 @@
   },
   "no_stand_alone_at": {
     "level": "error"
-  },
-  "newlines_after_classes": {
-    "value": 2,
-    "level": "error"
   }
 }

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -27,5 +27,17 @@
   "braces_spacing": {
     "spaces": 0,
     "level": "error"
+  },
+  "space_operators": {
+    "level": "error"
+  },
+  "spacing_after_comma": {
+    "level": "error"
+  },
+  "no_stand_alone_at": {
+    "level": "error"
+  },
+  "newlines_after_classes": {
+    "level": "error"
   }
 }

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -35,6 +35,7 @@
     "level": "error"
   },
   "newlines_after_classes": {
+    "value": 2,
     "level": "error"
   }
 }

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -28,9 +28,6 @@
     "spaces": 0,
     "level": "error"
   },
-  "space_operators": {
-    "level": "error"
-  },
   "spacing_after_comma": {
     "level": "error"
   },

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -44,7 +44,7 @@ describe "DisplayBuffer", ->
     it "renders line numbers correctly", ->
       originalLineCount = displayBuffer.getLineCount()
       oneHundredLines = [0..100].join("\n")
-      buffer.insert([0,0], oneHundredLines)
+      buffer.insert([0, 0], oneHundredLines)
       expect(displayBuffer.getLineCount()).toBe 100 + originalLineCount
 
     it "reassigns the scrollTop if it exceeds the max possible value after lines are removed", ->
@@ -382,10 +382,10 @@ describe "DisplayBuffer", ->
 
       describe "when creating a fold where one already exists", ->
         it "returns existing fold and does't create new fold", ->
-          fold = displayBuffer.createFold(0,10)
+          fold = displayBuffer.createFold(0, 10)
           expect(displayBuffer.findMarkers(class: 'fold').length).toBe 1
 
-          newFold = displayBuffer.createFold(0,10)
+          newFold = displayBuffer.createFold(0, 10)
           expect(newFold).toBe fold
           expect(displayBuffer.findMarkers(class: 'fold').length).toBe 1
 

--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -134,23 +134,23 @@ describe "LanguageMode", ->
 
         it "will limit paragraph range to comments", ->
           range = languageMode.rowRangeForParagraphAtBufferRow(0)
-          expect(range).toEqual [[0,0], [0,29]]
+          expect(range).toEqual [[0, 0], [0, 29]]
 
           range = languageMode.rowRangeForParagraphAtBufferRow(10)
-          expect(range).toEqual [[10,0], [10,14]]
+          expect(range).toEqual [[10, 0], [10, 14]]
           range = languageMode.rowRangeForParagraphAtBufferRow(11)
           expect(range).toBeFalsy()
           range = languageMode.rowRangeForParagraphAtBufferRow(12)
-          expect(range).toEqual [[12,0], [13,10]]
+          expect(range).toEqual [[12, 0], [13, 10]]
 
           range = languageMode.rowRangeForParagraphAtBufferRow(14)
-          expect(range).toEqual [[14,0], [14,32]]
+          expect(range).toEqual [[14, 0], [14, 32]]
 
           range = languageMode.rowRangeForParagraphAtBufferRow(15)
-          expect(range).toEqual [[15,0], [15,26]]
+          expect(range).toEqual [[15, 0], [15, 26]]
 
           range = languageMode.rowRangeForParagraphAtBufferRow(18)
-          expect(range).toEqual [[17,0], [19,3]]
+          expect(range).toEqual [[17, 0], [19, 3]]
 
   describe "coffeescript", ->
     beforeEach ->
@@ -305,9 +305,9 @@ describe "LanguageMode", ->
       atom.packages.unloadPackages()
 
     it "maintains cursor buffer position when a folding/unfolding", ->
-      editor.setCursorBufferPosition([5,5])
+      editor.setCursorBufferPosition([5, 5])
       languageMode.foldAll()
-      expect(editor.getCursorBufferPosition()).toEqual([5,5])
+      expect(editor.getCursorBufferPosition()).toEqual([5, 5])
 
     describe ".unfoldAll()", ->
       it "unfolds every folded line", ->
@@ -359,7 +359,7 @@ describe "LanguageMode", ->
 
       describe "when the bufferRow is in a multi-line comment", ->
         it "searches upward and downward for surrounding comment lines and folds them as a single fold", ->
-          buffer.insert([1,0], "  //this is a comment\n  // and\n  //more docs\n\n//second comment")
+          buffer.insert([1, 0], "  //this is a comment\n  // and\n  //more docs\n\n//second comment")
           languageMode.foldBufferRow(1)
           fold = editor.tokenizedLineForScreenRow(1).fold
           expect(fold.getStartRow()).toBe 1
@@ -367,7 +367,7 @@ describe "LanguageMode", ->
 
       describe "when the bufferRow is a single-line comment", ->
         it "searches upward for the first row that begins a syntatic region containing the folded row (and folds it)", ->
-          buffer.insert([1,0], "  //this is a single line comment\n")
+          buffer.insert([1, 0], "  //this is a single line comment\n")
           languageMode.foldBufferRow(1)
           fold = editor.tokenizedLineForScreenRow(0).fold
           expect(fold.getStartRow()).toBe 0

--- a/spec/selection-spec.coffee
+++ b/spec/selection-spec.coffee
@@ -14,18 +14,18 @@ describe "Selection", ->
   describe ".deleteSelectedText()", ->
     describe "when nothing is selected", ->
       it "deletes nothing", ->
-        selection.setBufferRange [[0,3], [0,3]]
+        selection.setBufferRange [[0, 3], [0, 3]]
         selection.deleteSelectedText()
         expect(buffer.lineForRow(0)).toBe "var quicksort = function () {"
 
     describe "when one line is selected", ->
       it "deletes selected text and clears the selection", ->
-        selection.setBufferRange [[0,4], [0,14]]
+        selection.setBufferRange [[0, 4], [0, 14]]
         selection.deleteSelectedText()
         expect(buffer.lineForRow(0)).toBe "var = function () {"
 
         endOfLine = buffer.lineForRow(0).length
-        selection.setBufferRange [[0,0], [0, endOfLine]]
+        selection.setBufferRange [[0, 0], [0, endOfLine]]
         selection.deleteSelectedText()
         expect(buffer.lineForRow(0)).toBe ""
 
@@ -33,15 +33,15 @@ describe "Selection", ->
 
     describe "when multiple lines are selected", ->
       it "deletes selected text and clears the selection", ->
-        selection.setBufferRange [[0,1], [2,39]]
+        selection.setBufferRange [[0, 1], [2, 39]]
         selection.deleteSelectedText()
         expect(buffer.lineForRow(0)).toBe "v;"
         expect(selection.isEmpty()).toBeTruthy()
 
     describe "when the cursor precedes the tail", ->
       it "deletes selected text and clears the selection", ->
-        selection.cursor.setScreenPosition [0,13]
-        selection.selectToScreenPosition [0,4]
+        selection.cursor.setScreenPosition [0, 13]
+        selection.selectToScreenPosition [0, 4]
 
         selection.delete()
         expect(buffer.lineForRow(0)).toBe "var  = function () {"

--- a/spec/text-editor-element-spec.coffee
+++ b/spec/text-editor-element-spec.coffee
@@ -83,7 +83,7 @@ describe "TextEditorElement", ->
       editor = new TextEditor
       editor.setText('1\n2\n3')
       editor.addGutter({name: 'test-gutter'})
-      marker = editor.markBufferRange([[0,0],[2,0]])
+      marker = editor.markBufferRange([[0, 0], [2, 0]])
       editor.decorateMarker(marker, {type: 'gutter', gutterName: 'test-gutter'})
       element = atom.views.getView(editor)
 

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -2227,11 +2227,11 @@ describe "TextEditorPresenter", ->
               gutterName: 'test-gutter'
               class: 'test-class'
               item: decorationItem
-            marker1 = editor.markBufferRange([[0,0],[1,0]])
+            marker1 = editor.markBufferRange([[0, 0], [1, 0]])
             decoration1 = editor.decorateMarker(marker1, decorationParams)
-            marker2 = editor.markBufferRange([[9,0],[12,0]])
+            marker2 = editor.markBufferRange([[9, 0], [12, 0]])
             decoration2 = editor.decorateMarker(marker2, decorationParams)
-            marker3 = editor.markBufferRange([[13,0],[14,0]])
+            marker3 = editor.markBufferRange([[13, 0], [14, 0]])
             decoration3 = editor.decorateMarker(marker3, decorationParams)
 
             # Clear any batched state updates.
@@ -2280,7 +2280,7 @@ describe "TextEditorPresenter", ->
 
           it "updates when the editor's content changes", ->
             # This update will add enough lines to push decoration2 out of view.
-            expectStateUpdate presenter, -> editor.setTextInBufferRange([[8,0],[9,0]],'\n\n\n\n\n')
+            expectStateUpdate presenter, -> editor.setTextInBufferRange([[8, 0], [9, 0]], '\n\n\n\n\n')
 
             decorationState = getContentForGutterWithName(presenter, 'test-gutter')
             expect(decorationState[decoration1.id].top).toBeDefined()
@@ -2290,7 +2290,7 @@ describe "TextEditorPresenter", ->
           it "updates when a decoration's marker is modified", ->
             # This update will move decoration1 out of view.
             expectStateUpdate presenter, ->
-              newRange = new Range([13,0],[14,0])
+              newRange = new Range([13, 0], [14, 0])
               marker1.setBufferRange(newRange)
 
             decorationState = getContentForGutterWithName(presenter, 'test-gutter')
@@ -2401,7 +2401,7 @@ describe "TextEditorPresenter", ->
               type: 'gutter'
               gutterName: 'test-gutter-2'
               class: 'test-class'
-            marker4 = editor.markBufferRange([[0,0],[1,0]])
+            marker4 = editor.markBufferRange([[0, 0], [1, 0]])
             decoration4 = editor.decorateMarker(marker4, decorationParams)
             expectStateUpdate presenter, -> editor.addGutter({name: 'test-gutter-2'})
 

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -553,7 +553,7 @@ describe "TextEditor", ->
 
       describe "when there is a selection", ->
         beforeEach ->
-          editor.setSelectedBufferRange([[5, 22],[5, 27]])
+          editor.setSelectedBufferRange([[5, 22], [5, 27]])
 
         it "moves to the left of the selection", ->
           cursor = editor.getLastCursor()
@@ -570,12 +570,12 @@ describe "TextEditor", ->
 
         editor.moveRight()
         expect(editor.getCursors()).toEqual [cursor1]
-        expect(cursor1.getBufferPosition()).toEqual [12,2]
+        expect(cursor1.getBufferPosition()).toEqual [12, 2]
 
     describe ".moveToTop()", ->
       it "moves the cursor to the top of the buffer", ->
-        editor.setCursorScreenPosition [11,1]
-        editor.addCursorAtScreenPosition [12,0]
+        editor.setCursorScreenPosition [11, 1]
+        editor.addCursorAtScreenPosition [12, 0]
         editor.moveToTop()
         expect(editor.getCursors().length).toBe 1
         expect(editor.getCursorBufferPosition()).toEqual [0, 0]
@@ -651,58 +651,58 @@ describe "TextEditor", ->
         it "moves to the first character of the current screen line or the beginning of the screen line if it's already on the first character", ->
           editor.setSoftWrapped(true)
           editor.setEditorWidthInChars(10)
-          editor.setCursorScreenPosition [2,5]
-          editor.addCursorAtScreenPosition [8,7]
+          editor.setCursorScreenPosition [2, 5]
+          editor.addCursorAtScreenPosition [8, 7]
 
           editor.moveToFirstCharacterOfLine()
           [cursor1, cursor2] = editor.getCursors()
-          expect(cursor1.getScreenPosition()).toEqual [2,0]
-          expect(cursor2.getScreenPosition()).toEqual [8,2]
+          expect(cursor1.getScreenPosition()).toEqual [2, 0]
+          expect(cursor2.getScreenPosition()).toEqual [8, 2]
 
           editor.moveToFirstCharacterOfLine()
-          expect(cursor1.getScreenPosition()).toEqual [2,0]
-          expect(cursor2.getScreenPosition()).toEqual [8,2]
+          expect(cursor1.getScreenPosition()).toEqual [2, 0]
+          expect(cursor2.getScreenPosition()).toEqual [8, 2]
 
       describe "when soft wrap is off", ->
         it "moves to the first character of the current line or the beginning of the line if it's already on the first character", ->
-          editor.setCursorScreenPosition [0,5]
-          editor.addCursorAtScreenPosition [1,7]
+          editor.setCursorScreenPosition [0, 5]
+          editor.addCursorAtScreenPosition [1, 7]
 
           editor.moveToFirstCharacterOfLine()
           [cursor1, cursor2] = editor.getCursors()
-          expect(cursor1.getBufferPosition()).toEqual [0,0]
-          expect(cursor2.getBufferPosition()).toEqual [1,2]
+          expect(cursor1.getBufferPosition()).toEqual [0, 0]
+          expect(cursor2.getBufferPosition()).toEqual [1, 2]
 
           editor.moveToFirstCharacterOfLine()
-          expect(cursor1.getBufferPosition()).toEqual [0,0]
-          expect(cursor2.getBufferPosition()).toEqual [1,0]
+          expect(cursor1.getBufferPosition()).toEqual [0, 0]
+          expect(cursor2.getBufferPosition()).toEqual [1, 0]
 
         it "moves to the beginning of the line if it only contains whitespace ", ->
           editor.setText("first\n    \nthird")
-          editor.setCursorScreenPosition [1,2]
+          editor.setCursorScreenPosition [1, 2]
           editor.moveToFirstCharacterOfLine()
           cursor = editor.getLastCursor()
-          expect(cursor.getBufferPosition()).toEqual [1,0]
+          expect(cursor.getBufferPosition()).toEqual [1, 0]
 
         describe "when invisible characters are enabled with soft tabs", ->
           it "moves to the first character of the current line without being confused by the invisible characters", ->
             atom.config.set('editor.showInvisibles', true)
-            editor.setCursorScreenPosition [1,7]
+            editor.setCursorScreenPosition [1, 7]
             editor.moveToFirstCharacterOfLine()
-            expect(editor.getCursorBufferPosition()).toEqual [1,2]
+            expect(editor.getCursorBufferPosition()).toEqual [1, 2]
             editor.moveToFirstCharacterOfLine()
-            expect(editor.getCursorBufferPosition()).toEqual [1,0]
+            expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
         describe "when invisible characters are enabled with hard tabs", ->
           it "moves to the first character of the current line without being confused by the invisible characters", ->
             atom.config.set('editor.showInvisibles', true)
             buffer.setTextInRange([[1, 0], [1, Infinity]], '\t\t\ta', normalizeLineEndings: false)
 
-            editor.setCursorScreenPosition [1,7]
+            editor.setCursorScreenPosition [1, 7]
             editor.moveToFirstCharacterOfLine()
-            expect(editor.getCursorBufferPosition()).toEqual [1,3]
+            expect(editor.getCursorBufferPosition()).toEqual [1, 3]
             editor.moveToFirstCharacterOfLine()
-            expect(editor.getCursorBufferPosition()).toEqual [1,0]
+            expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
     describe ".moveToBeginningOfWord()", ->
       it "moves the cursor to the beginning of the word", ->
@@ -792,9 +792,9 @@ describe "TextEditor", ->
 
     describe ".moveToBeginningOfNextWord()", ->
       it "moves the cursor before the first character of the next word", ->
-        editor.setCursorBufferPosition [0,6]
-        editor.addCursorAtBufferPosition [1,11]
-        editor.addCursorAtBufferPosition [2,0]
+        editor.setCursorBufferPosition [0, 6]
+        editor.addCursorAtBufferPosition [1, 11]
+        editor.addCursorAtBufferPosition [2, 0]
         [cursor1, cursor2, cursor3] = editor.getCursors()
 
         editor.moveToBeginningOfNextWord()
@@ -805,7 +805,7 @@ describe "TextEditor", ->
 
         # When the cursor is on whitespace
         editor.setText("ab cde- ")
-        editor.setCursorBufferPosition [0,2]
+        editor.setCursorBufferPosition [0, 2]
         cursor = editor.getLastCursor()
         editor.moveToBeginningOfNextWord()
 
@@ -900,15 +900,15 @@ describe "TextEditor", ->
     describe "addCursorAtScreenPosition(screenPosition)", ->
       describe "when a cursor already exists at the position", ->
         it "returns the existing cursor", ->
-          cursor1 = editor.addCursorAtScreenPosition([0,2])
-          cursor2 = editor.addCursorAtScreenPosition([0,2])
+          cursor1 = editor.addCursorAtScreenPosition([0, 2])
+          cursor2 = editor.addCursorAtScreenPosition([0, 2])
           expect(cursor2.marker).toBe cursor1.marker
 
     describe "addCursorAtBufferPosition(bufferPosition)", ->
       describe "when a cursor already exists at the position", ->
         it "returns the existing cursor", ->
-          cursor1 = editor.addCursorAtBufferPosition([1,4])
-          cursor2 = editor.addCursorAtBufferPosition([1,4])
+          cursor1 = editor.addCursorAtBufferPosition([1, 4])
+          cursor2 = editor.addCursorAtBufferPosition([1, 4])
           expect(cursor2.marker).toBe cursor1.marker
 
     describe "autoscroll", ->
@@ -1056,28 +1056,28 @@ describe "TextEditor", ->
 
     describe ".selectUp/Down/Left/Right()", ->
       it "expands each selection to its cursor's new location", ->
-        editor.setSelectedBufferRanges([[[0,9], [0,13]], [[3,16], [3,21]]])
+        editor.setSelectedBufferRanges([[[0, 9], [0, 13]], [[3, 16], [3, 21]]])
         [selection1, selection2] = editor.getSelections()
 
         editor.selectRight()
-        expect(selection1.getBufferRange()).toEqual [[0,9], [0,14]]
-        expect(selection2.getBufferRange()).toEqual [[3,16], [3,22]]
+        expect(selection1.getBufferRange()).toEqual [[0, 9], [0, 14]]
+        expect(selection2.getBufferRange()).toEqual [[3, 16], [3, 22]]
 
         editor.selectLeft()
         editor.selectLeft()
-        expect(selection1.getBufferRange()).toEqual [[0,9], [0,12]]
-        expect(selection2.getBufferRange()).toEqual [[3,16], [3,20]]
+        expect(selection1.getBufferRange()).toEqual [[0, 9], [0, 12]]
+        expect(selection2.getBufferRange()).toEqual [[3, 16], [3, 20]]
 
         editor.selectDown()
-        expect(selection1.getBufferRange()).toEqual [[0,9], [1,12]]
-        expect(selection2.getBufferRange()).toEqual [[3,16], [4,20]]
+        expect(selection1.getBufferRange()).toEqual [[0, 9], [1, 12]]
+        expect(selection2.getBufferRange()).toEqual [[3, 16], [4, 20]]
 
         editor.selectUp()
-        expect(selection1.getBufferRange()).toEqual [[0,9], [0,12]]
-        expect(selection2.getBufferRange()).toEqual [[3,16], [3,20]]
+        expect(selection1.getBufferRange()).toEqual [[0, 9], [0, 12]]
+        expect(selection2.getBufferRange()).toEqual [[3, 16], [3, 20]]
 
       it "merges selections when they intersect when moving down", ->
-        editor.setSelectedBufferRanges([[[0,9], [0,13]], [[1,10], [1,20]], [[2,15], [3,25]]])
+        editor.setSelectedBufferRanges([[[0, 9], [0, 13]], [[1, 10], [1, 20]], [[2, 15], [3, 25]]])
         [selection1, selection2, selection3] = editor.getSelections()
 
         editor.selectDown()
@@ -1086,7 +1086,7 @@ describe "TextEditor", ->
         expect(selection1.isReversed()).toBeFalsy()
 
       it "merges selections when they intersect when moving up", ->
-        editor.setSelectedBufferRanges([[[0,9], [0,13]], [[1,10], [1,20]]], reversed: true)
+        editor.setSelectedBufferRanges([[[0, 9], [0, 13]], [[1, 10], [1, 20]]], reversed: true)
         [selection1, selection2] = editor.getSelections()
 
         editor.selectUp()
@@ -1096,7 +1096,7 @@ describe "TextEditor", ->
         expect(selection1.isReversed()).toBeTruthy()
 
       it "merges selections when they intersect when moving left", ->
-        editor.setSelectedBufferRanges([[[0,9], [0,13]], [[0,13], [1,20]]], reversed: true)
+        editor.setSelectedBufferRanges([[[0, 9], [0, 13]], [[0, 13], [1, 20]]], reversed: true)
         [selection1, selection2] = editor.getSelections()
 
         editor.selectLeft()
@@ -1105,7 +1105,7 @@ describe "TextEditor", ->
         expect(selection1.isReversed()).toBeTruthy()
 
       it "merges selections when they intersect when moving right", ->
-        editor.setSelectedBufferRanges([[[0,9], [0,14]], [[0,14], [1,20]]])
+        editor.setSelectedBufferRanges([[[0, 9], [0, 14]], [[0, 14], [1, 20]]])
         [selection1, selection2] = editor.getSelections()
 
         editor.selectRight()
@@ -1115,24 +1115,24 @@ describe "TextEditor", ->
 
       describe "when counts are passed into the selection functions", ->
         it "expands each selection to its cursor's new location", ->
-          editor.setSelectedBufferRanges([[[0,9], [0,13]], [[3,16], [3,21]]])
+          editor.setSelectedBufferRanges([[[0, 9], [0, 13]], [[3, 16], [3, 21]]])
           [selection1, selection2] = editor.getSelections()
 
           editor.selectRight(2)
-          expect(selection1.getBufferRange()).toEqual [[0,9], [0,15]]
-          expect(selection2.getBufferRange()).toEqual [[3,16], [3,23]]
+          expect(selection1.getBufferRange()).toEqual [[0, 9], [0, 15]]
+          expect(selection2.getBufferRange()).toEqual [[3, 16], [3, 23]]
 
           editor.selectLeft(3)
-          expect(selection1.getBufferRange()).toEqual [[0,9], [0,12]]
-          expect(selection2.getBufferRange()).toEqual [[3,16], [3,20]]
+          expect(selection1.getBufferRange()).toEqual [[0, 9], [0, 12]]
+          expect(selection2.getBufferRange()).toEqual [[3, 16], [3, 20]]
 
           editor.selectDown(3)
-          expect(selection1.getBufferRange()).toEqual [[0,9], [3,12]]
-          expect(selection2.getBufferRange()).toEqual [[3,16], [6,20]]
+          expect(selection1.getBufferRange()).toEqual [[0, 9], [3, 12]]
+          expect(selection2.getBufferRange()).toEqual [[3, 16], [6, 20]]
 
           editor.selectUp(2)
-          expect(selection1.getBufferRange()).toEqual [[0,9], [1,12]]
-          expect(selection2.getBufferRange()).toEqual [[3,16], [4,20]]
+          expect(selection1.getBufferRange()).toEqual [[0, 9], [1, 12]]
+          expect(selection2.getBufferRange()).toEqual [[3, 16], [4, 20]]
 
     describe ".selectToBufferPosition(bufferPosition)", ->
       it "expands the last selection to the given position", ->
@@ -1205,22 +1205,22 @@ describe "TextEditor", ->
 
     describe ".selectToTop()", ->
       it "selects text from cusor position to the top of the buffer", ->
-        editor.setCursorScreenPosition [11,2]
-        editor.addCursorAtScreenPosition [10,0]
+        editor.setCursorScreenPosition [11, 2]
+        editor.addCursorAtScreenPosition [10, 0]
         editor.selectToTop()
         expect(editor.getCursors().length).toBe 1
-        expect(editor.getCursorBufferPosition()).toEqual [0,0]
-        expect(editor.getLastSelection().getBufferRange()).toEqual [[0,0], [11,2]]
+        expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+        expect(editor.getLastSelection().getBufferRange()).toEqual [[0, 0], [11, 2]]
         expect(editor.getLastSelection().isReversed()).toBeTruthy()
 
     describe ".selectToBottom()", ->
       it "selects text from cusor position to the bottom of the buffer", ->
-        editor.setCursorScreenPosition [10,0]
-        editor.addCursorAtScreenPosition [9,3]
+        editor.setCursorScreenPosition [10, 0]
+        editor.addCursorAtScreenPosition [9, 3]
         editor.selectToBottom()
         expect(editor.getCursors().length).toBe 1
-        expect(editor.getCursorBufferPosition()).toEqual [12,2]
-        expect(editor.getLastSelection().getBufferRange()).toEqual [[9,3], [12,2]]
+        expect(editor.getCursorBufferPosition()).toEqual [12, 2]
+        expect(editor.getLastSelection().getBufferRange()).toEqual [[9, 3], [12, 2]]
         expect(editor.getLastSelection().isReversed()).toBeFalsy()
 
     describe ".selectAll()", ->
@@ -1230,57 +1230,57 @@ describe "TextEditor", ->
 
     describe ".selectToBeginningOfLine()", ->
       it "selects text from cusor position to beginning of line", ->
-        editor.setCursorScreenPosition [12,2]
-        editor.addCursorAtScreenPosition [11,3]
+        editor.setCursorScreenPosition [12, 2]
+        editor.addCursorAtScreenPosition [11, 3]
 
         editor.selectToBeginningOfLine()
 
         expect(editor.getCursors().length).toBe 2
         [cursor1, cursor2] = editor.getCursors()
-        expect(cursor1.getBufferPosition()).toEqual [12,0]
-        expect(cursor2.getBufferPosition()).toEqual [11,0]
+        expect(cursor1.getBufferPosition()).toEqual [12, 0]
+        expect(cursor2.getBufferPosition()).toEqual [11, 0]
 
         expect(editor.getSelections().length).toBe 2
         [selection1, selection2] = editor.getSelections()
-        expect(selection1.getBufferRange()).toEqual [[12,0], [12,2]]
+        expect(selection1.getBufferRange()).toEqual [[12, 0], [12, 2]]
         expect(selection1.isReversed()).toBeTruthy()
-        expect(selection2.getBufferRange()).toEqual [[11,0], [11,3]]
+        expect(selection2.getBufferRange()).toEqual [[11, 0], [11, 3]]
         expect(selection2.isReversed()).toBeTruthy()
 
     describe ".selectToEndOfLine()", ->
       it "selects text from cusor position to end of line", ->
-        editor.setCursorScreenPosition [12,0]
-        editor.addCursorAtScreenPosition [11,3]
+        editor.setCursorScreenPosition [12, 0]
+        editor.addCursorAtScreenPosition [11, 3]
 
         editor.selectToEndOfLine()
 
         expect(editor.getCursors().length).toBe 2
         [cursor1, cursor2] = editor.getCursors()
-        expect(cursor1.getBufferPosition()).toEqual [12,2]
-        expect(cursor2.getBufferPosition()).toEqual [11,44]
+        expect(cursor1.getBufferPosition()).toEqual [12, 2]
+        expect(cursor2.getBufferPosition()).toEqual [11, 44]
 
         expect(editor.getSelections().length).toBe 2
         [selection1, selection2] = editor.getSelections()
-        expect(selection1.getBufferRange()).toEqual [[12,0], [12,2]]
+        expect(selection1.getBufferRange()).toEqual [[12, 0], [12, 2]]
         expect(selection1.isReversed()).toBeFalsy()
-        expect(selection2.getBufferRange()).toEqual [[11,3], [11,44]]
+        expect(selection2.getBufferRange()).toEqual [[11, 3], [11, 44]]
         expect(selection2.isReversed()).toBeFalsy()
 
     describe ".selectLinesContainingCursors()", ->
       it "selects the entire line (including newlines) at given row", ->
         editor.setCursorScreenPosition([1, 2])
         editor.selectLinesContainingCursors()
-        expect(editor.getSelectedBufferRange()).toEqual [[1,0], [2,0]]
+        expect(editor.getSelectedBufferRange()).toEqual [[1, 0], [2, 0]]
         expect(editor.getSelectedText()).toBe "  var sort = function(items) {\n"
 
         editor.setCursorScreenPosition([12, 2])
         editor.selectLinesContainingCursors()
-        expect(editor.getSelectedBufferRange()).toEqual [[12,0], [12,2]]
+        expect(editor.getSelectedBufferRange()).toEqual [[12, 0], [12, 2]]
 
         editor.setCursorBufferPosition([0, 2])
         editor.selectLinesContainingCursors()
         editor.selectLinesContainingCursors()
-        expect(editor.getSelectedBufferRange()).toEqual [[0,0], [2,0]]
+        expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [2, 0]]
 
       it "autoscrolls to the selection", ->
         editor.setLineHeightInPixels(10)
@@ -1298,59 +1298,59 @@ describe "TextEditor", ->
 
     describe ".selectToBeginningOfWord()", ->
       it "selects text from cusor position to beginning of word", ->
-        editor.setCursorScreenPosition [0,13]
-        editor.addCursorAtScreenPosition [3,49]
+        editor.setCursorScreenPosition [0, 13]
+        editor.addCursorAtScreenPosition [3, 49]
 
         editor.selectToBeginningOfWord()
 
         expect(editor.getCursors().length).toBe 2
         [cursor1, cursor2] = editor.getCursors()
-        expect(cursor1.getBufferPosition()).toEqual [0,4]
-        expect(cursor2.getBufferPosition()).toEqual [3,47]
+        expect(cursor1.getBufferPosition()).toEqual [0, 4]
+        expect(cursor2.getBufferPosition()).toEqual [3, 47]
 
         expect(editor.getSelections().length).toBe 2
         [selection1, selection2] = editor.getSelections()
-        expect(selection1.getBufferRange()).toEqual [[0,4], [0,13]]
+        expect(selection1.getBufferRange()).toEqual [[0, 4], [0, 13]]
         expect(selection1.isReversed()).toBeTruthy()
-        expect(selection2.getBufferRange()).toEqual [[3,47], [3,49]]
+        expect(selection2.getBufferRange()).toEqual [[3, 47], [3, 49]]
         expect(selection2.isReversed()).toBeTruthy()
 
     describe ".selectToEndOfWord()", ->
       it "selects text from cusor position to end of word", ->
-        editor.setCursorScreenPosition [0,4]
-        editor.addCursorAtScreenPosition [3,48]
+        editor.setCursorScreenPosition [0, 4]
+        editor.addCursorAtScreenPosition [3, 48]
 
         editor.selectToEndOfWord()
 
         expect(editor.getCursors().length).toBe 2
         [cursor1, cursor2] = editor.getCursors()
-        expect(cursor1.getBufferPosition()).toEqual [0,13]
-        expect(cursor2.getBufferPosition()).toEqual [3,50]
+        expect(cursor1.getBufferPosition()).toEqual [0, 13]
+        expect(cursor2.getBufferPosition()).toEqual [3, 50]
 
         expect(editor.getSelections().length).toBe 2
         [selection1, selection2] = editor.getSelections()
-        expect(selection1.getBufferRange()).toEqual [[0,4], [0,13]]
+        expect(selection1.getBufferRange()).toEqual [[0, 4], [0, 13]]
         expect(selection1.isReversed()).toBeFalsy()
-        expect(selection2.getBufferRange()).toEqual [[3,48], [3,50]]
+        expect(selection2.getBufferRange()).toEqual [[3, 48], [3, 50]]
         expect(selection2.isReversed()).toBeFalsy()
 
     describe ".selectToBeginningOfNextWord()", ->
       it "selects text from cusor position to beginning of next word", ->
-        editor.setCursorScreenPosition [0,4]
-        editor.addCursorAtScreenPosition [3,48]
+        editor.setCursorScreenPosition [0, 4]
+        editor.addCursorAtScreenPosition [3, 48]
 
         editor.selectToBeginningOfNextWord()
 
         expect(editor.getCursors().length).toBe 2
         [cursor1, cursor2] = editor.getCursors()
-        expect(cursor1.getBufferPosition()).toEqual [0,14]
-        expect(cursor2.getBufferPosition()).toEqual [3,51]
+        expect(cursor1.getBufferPosition()).toEqual [0, 14]
+        expect(cursor2.getBufferPosition()).toEqual [3, 51]
 
         expect(editor.getSelections().length).toBe 2
         [selection1, selection2] = editor.getSelections()
-        expect(selection1.getBufferRange()).toEqual [[0,4], [0,14]]
+        expect(selection1.getBufferRange()).toEqual [[0, 4], [0, 14]]
         expect(selection1.isReversed()).toBeFalsy()
-        expect(selection2.getBufferRange()).toEqual [[3,48], [3,51]]
+        expect(selection2.getBufferRange()).toEqual [[3, 48], [3, 51]]
         expect(selection2.isReversed()).toBeFalsy()
 
     describe ".selectToPreviousWordBoundary()", ->
@@ -1364,13 +1364,13 @@ describe "TextEditor", ->
 
         expect(editor.getSelections().length).toBe 4
         [selection1, selection2, selection3, selection4] = editor.getSelections()
-        expect(selection1.getBufferRange()).toEqual [[0,8], [0,4]]
+        expect(selection1.getBufferRange()).toEqual [[0, 8], [0, 4]]
         expect(selection1.isReversed()).toBeTruthy()
-        expect(selection2.getBufferRange()).toEqual [[2,0], [1,30]]
+        expect(selection2.getBufferRange()).toEqual [[2, 0], [1, 30]]
         expect(selection2.isReversed()).toBeTruthy()
-        expect(selection3.getBufferRange()).toEqual [[3,4], [3,0]]
+        expect(selection3.getBufferRange()).toEqual [[3, 4], [3, 0]]
         expect(selection3.isReversed()).toBeTruthy()
-        expect(selection4.getBufferRange()).toEqual [[3,14], [3,13]]
+        expect(selection4.getBufferRange()).toEqual [[3, 14], [3, 13]]
         expect(selection4.isReversed()).toBeTruthy()
 
     describe ".selectToNextWordBoundary()", ->
@@ -1384,13 +1384,13 @@ describe "TextEditor", ->
 
         expect(editor.getSelections().length).toBe 4
         [selection1, selection2, selection3, selection4] = editor.getSelections()
-        expect(selection1.getBufferRange()).toEqual [[0,8], [0,13]]
+        expect(selection1.getBufferRange()).toEqual [[0, 8], [0, 13]]
         expect(selection1.isReversed()).toBeFalsy()
-        expect(selection2.getBufferRange()).toEqual [[2,40], [3,0]]
+        expect(selection2.getBufferRange()).toEqual [[2, 40], [3, 0]]
         expect(selection2.isReversed()).toBeFalsy()
-        expect(selection3.getBufferRange()).toEqual [[4,0], [4,4]]
+        expect(selection3.getBufferRange()).toEqual [[4, 0], [4, 4]]
         expect(selection3.isReversed()).toBeFalsy()
-        expect(selection4.getBufferRange()).toEqual [[3,30], [3,31]]
+        expect(selection4.getBufferRange()).toEqual [[3, 30], [3, 31]]
         expect(selection4.isReversed()).toBeFalsy()
 
     describe ".selectWordsContainingCursors()", ->
@@ -1452,27 +1452,27 @@ describe "TextEditor", ->
 
     describe ".selectToFirstCharacterOfLine()", ->
       it "moves to the first character of the current line or the beginning of the line if it's already on the first character", ->
-        editor.setCursorScreenPosition [0,5]
-        editor.addCursorAtScreenPosition [1,7]
+        editor.setCursorScreenPosition [0, 5]
+        editor.addCursorAtScreenPosition [1, 7]
 
         editor.selectToFirstCharacterOfLine()
 
         [cursor1, cursor2] = editor.getCursors()
-        expect(cursor1.getBufferPosition()).toEqual [0,0]
-        expect(cursor2.getBufferPosition()).toEqual [1,2]
+        expect(cursor1.getBufferPosition()).toEqual [0, 0]
+        expect(cursor2.getBufferPosition()).toEqual [1, 2]
 
         expect(editor.getSelections().length).toBe 2
         [selection1, selection2] = editor.getSelections()
-        expect(selection1.getBufferRange()).toEqual [[0,0], [0,5]]
+        expect(selection1.getBufferRange()).toEqual [[0, 0], [0, 5]]
         expect(selection1.isReversed()).toBeTruthy()
-        expect(selection2.getBufferRange()).toEqual [[1,2], [1,7]]
+        expect(selection2.getBufferRange()).toEqual [[1, 2], [1, 7]]
         expect(selection2.isReversed()).toBeTruthy()
 
         editor.selectToFirstCharacterOfLine()
         [selection1, selection2] = editor.getSelections()
-        expect(selection1.getBufferRange()).toEqual [[0,0], [0,5]]
+        expect(selection1.getBufferRange()).toEqual [[0, 0], [0, 5]]
         expect(selection1.isReversed()).toBeTruthy()
-        expect(selection2.getBufferRange()).toEqual [[1,0], [1,7]]
+        expect(selection2.getBufferRange()).toEqual [[1, 0], [1, 7]]
         expect(selection2.isReversed()).toBeTruthy()
 
     describe ".setSelectedBufferRanges(ranges)", ->
@@ -1501,7 +1501,7 @@ describe "TextEditor", ->
 
       describe "when the 'preserveFolds' option is false (the default)", ->
         it "removes folds that contain the selections", ->
-          editor.setSelectedBufferRange([[0,0], [0,0]])
+          editor.setSelectedBufferRange([[0, 0], [0, 0]])
           editor.createFold(1, 4)
           editor.createFold(2, 3)
           editor.createFold(6, 8)
@@ -1515,7 +1515,7 @@ describe "TextEditor", ->
 
       describe "when the 'preserveFolds' option is true", ->
         it "does not remove folds that contain the selections", ->
-          editor.setSelectedBufferRange([[0,0], [0,0]])
+          editor.setSelectedBufferRange([[0, 0], [0, 0]])
           editor.createFold(1, 4)
           editor.createFold(6, 8)
           editor.setSelectedBufferRanges([[[2, 2], [3, 3]], [[6, 0], [6, 1]]], preserveFolds: true)
@@ -1965,7 +1965,7 @@ describe "TextEditor", ->
       describe "when there are multiple non-empty selections", ->
         describe "when the selections are on the same line", ->
           it "replaces each selection range with the inserted characters", ->
-            editor.setSelectedBufferRanges([[[0,4], [0,13]], [[0,22], [0,24]]])
+            editor.setSelectedBufferRanges([[[0, 4], [0, 13]], [[0, 22], [0, 24]]])
             editor.insertText("x")
 
             [cursor1, cursor2] = editor.getCursors()
@@ -1995,8 +1995,8 @@ describe "TextEditor", ->
 
       describe "when there is a selection that ends on a folded line", ->
         it "destroys the selection", ->
-          editor.createFold(2,4)
-          editor.setSelectedBufferRange([[1,0], [2,0]])
+          editor.createFold(2, 4)
+          editor.setSelectedBufferRange([[1, 0], [2, 0]])
           editor.insertText('holy cow')
           expect(editor.tokenizedLineForScreenRow(2).fold).toBeUndefined()
 
@@ -2117,17 +2117,17 @@ describe "TextEditor", ->
             expect(editor.lineTextForBufferRow(9)).toBe "    }"
 
             [cursor1, cursor2] = editor.getCursors()
-            expect(cursor1.getBufferPosition()).toEqual [4,0]
-            expect(cursor2.getBufferPosition()).toEqual [8,0]
+            expect(cursor1.getBufferPosition()).toEqual [4, 0]
+            expect(cursor2.getBufferPosition()).toEqual [8, 0]
 
     describe ".insertNewlineBelow()", ->
       describe "when the operation is undone", ->
         it "places the cursor back at the previous location", ->
-          editor.setCursorBufferPosition([0,2])
+          editor.setCursorBufferPosition([0, 2])
           editor.insertNewlineBelow()
-          expect(editor.getCursorBufferPosition()).toEqual [1,0]
+          expect(editor.getCursorBufferPosition()).toEqual [1, 0]
           editor.undo()
-          expect(editor.getCursorBufferPosition()).toEqual [0,2]
+          expect(editor.getCursorBufferPosition()).toEqual [0, 2]
 
       it "inserts a newline below the cursor's current line, autoindents it, and moves the cursor to the end of the line", ->
         atom.config.set("editor.autoIndent", true)
@@ -2141,48 +2141,48 @@ describe "TextEditor", ->
         it "inserts a newline on the first line and moves the cursor to the first line", ->
           editor.setCursorBufferPosition([0])
           editor.insertNewlineAbove()
-          expect(editor.getCursorBufferPosition()).toEqual [0,0]
+          expect(editor.getCursorBufferPosition()).toEqual [0, 0]
           expect(editor.lineTextForBufferRow(0)).toBe ''
           expect(editor.lineTextForBufferRow(1)).toBe 'var quicksort = function () {'
           expect(editor.buffer.getLineCount()).toBe 14
 
       describe "when the cursor is not on the first line", ->
         it "inserts a newline above the current line and moves the cursor to the inserted line", ->
-          editor.setCursorBufferPosition([3,4])
+          editor.setCursorBufferPosition([3, 4])
           editor.insertNewlineAbove()
-          expect(editor.getCursorBufferPosition()).toEqual [3,0]
+          expect(editor.getCursorBufferPosition()).toEqual [3, 0]
           expect(editor.lineTextForBufferRow(3)).toBe ''
           expect(editor.lineTextForBufferRow(4)).toBe '    var pivot = items.shift(), current, left = [], right = [];'
           expect(editor.buffer.getLineCount()).toBe 14
 
           editor.undo()
-          expect(editor.getCursorBufferPosition()).toEqual [3,4]
+          expect(editor.getCursorBufferPosition()).toEqual [3, 4]
 
       it "indents the new line to the correct level when editor.autoIndent is true", ->
         atom.config.set('editor.autoIndent', true)
 
         editor.setText('  var test')
-        editor.setCursorBufferPosition([0,2])
+        editor.setCursorBufferPosition([0, 2])
         editor.insertNewlineAbove()
 
-        expect(editor.getCursorBufferPosition()).toEqual [0,2]
+        expect(editor.getCursorBufferPosition()).toEqual [0, 2]
         expect(editor.lineTextForBufferRow(0)).toBe '  '
         expect(editor.lineTextForBufferRow(1)).toBe '  var test'
 
         editor.setText('\n  var test')
-        editor.setCursorBufferPosition([1,2])
+        editor.setCursorBufferPosition([1, 2])
         editor.insertNewlineAbove()
 
-        expect(editor.getCursorBufferPosition()).toEqual [1,2]
+        expect(editor.getCursorBufferPosition()).toEqual [1, 2]
         expect(editor.lineTextForBufferRow(0)).toBe ''
         expect(editor.lineTextForBufferRow(1)).toBe '  '
         expect(editor.lineTextForBufferRow(2)).toBe '  var test'
 
         editor.setText('function() {\n}')
-        editor.setCursorBufferPosition([1,1])
+        editor.setCursorBufferPosition([1, 1])
         editor.insertNewlineAbove()
 
-        expect(editor.getCursorBufferPosition()).toEqual [1,2]
+        expect(editor.getCursorBufferPosition()).toEqual [1, 2]
         expect(editor.lineTextForBufferRow(0)).toBe 'function() {'
         expect(editor.lineTextForBufferRow(1)).toBe '  '
         expect(editor.lineTextForBufferRow(2)).toBe '}'
@@ -2190,7 +2190,7 @@ describe "TextEditor", ->
     describe "when a new line is appended before a closing tag (e.g. by pressing enter before a selection)", ->
       it "moves the line down and keeps the indentation level the same when editor.autoIndent is true", ->
         atom.config.set('editor.autoIndent', true)
-        editor.setCursorBufferPosition([9,2])
+        editor.setCursorBufferPosition([9, 2])
         editor.insertNewline()
         expect(editor.lineTextForBufferRow(10)).toBe '  };'
 
@@ -2240,9 +2240,9 @@ describe "TextEditor", ->
 
         describe "when the cursor is on the first column of a line below a fold", ->
           it "deletes the folded lines", ->
-            editor.setCursorScreenPosition([4,0])
+            editor.setCursorScreenPosition([4, 0])
             editor.foldCurrentRow()
-            editor.setCursorScreenPosition([5,0])
+            editor.setCursorScreenPosition([5, 0])
             editor.backspace()
 
             expect(buffer.lineForRow(4)).toBe "    return sort(left).concat(pivot).concat(sort(right));"
@@ -2250,9 +2250,9 @@ describe "TextEditor", ->
 
         describe "when the cursor is in the middle of a line below a fold", ->
           it "backspaces as normal", ->
-            editor.setCursorScreenPosition([4,0])
+            editor.setCursorScreenPosition([4, 0])
             editor.foldCurrentRow()
-            editor.setCursorScreenPosition([5,5])
+            editor.setCursorScreenPosition([5, 5])
             editor.backspace()
 
             expect(buffer.lineForRow(7)).toBe "    }"
@@ -2317,18 +2317,18 @@ describe "TextEditor", ->
               expect(editor.lineTextForBufferRow(5)).toBe "    }"
 
               [cursor1, cursor2] = editor.getCursors()
-              expect(cursor1.getBufferPosition()).toEqual [2,40]
-              expect(cursor2.getBufferPosition()).toEqual [4,30]
+              expect(cursor1.getBufferPosition()).toEqual [2, 40]
+              expect(cursor2.getBufferPosition()).toEqual [4, 30]
 
       describe "when there is a single selection", ->
         it "deletes the selection, but not the character before it", ->
-          editor.setSelectedBufferRange([[0,5], [0,9]])
+          editor.setSelectedBufferRange([[0, 5], [0, 9]])
           editor.backspace()
           expect(editor.buffer.lineForRow(0)).toBe 'var qsort = function () {'
 
         describe "when the selection ends on a folded line", ->
           it "preserves the fold", ->
-            editor.setSelectedBufferRange([[3,0], [4,0]])
+            editor.setSelectedBufferRange([[3, 0], [4, 0]])
             editor.foldBufferRow(4)
             editor.backspace()
 
@@ -2337,7 +2337,7 @@ describe "TextEditor", ->
 
       describe "when there are multiple selections", ->
         it "removes all selected text", ->
-          editor.setSelectedBufferRanges([[[0,4], [0,13]], [[0,16], [0,24]]])
+          editor.setSelectedBufferRanges([[[0, 4], [0, 13]], [[0, 16], [0, 24]]])
           editor.backspace()
           expect(editor.lineTextForBufferRow(0)).toBe 'var  =  () {'
 
@@ -2533,8 +2533,8 @@ describe "TextEditor", ->
         describe "when the cursor is on a folded line", ->
           it "removes the lines contained by the fold", ->
             editor.setSelectedBufferRange([[2, 0], [2, 0]])
-            editor.createFold(2,4)
-            editor.createFold(2,6)
+            editor.createFold(2, 4)
+            editor.createFold(2, 6)
             oldLine7 = buffer.lineForRow(7)
             oldLine8 = buffer.lineForRow(8)
 
@@ -2589,8 +2589,8 @@ describe "TextEditor", ->
               expect(editor.lineTextForBufferRow(0)).toBe "var quicksort = function () {  var sort = function(items) {    if (items.length <= 1) return items;"
 
               [cursor1, cursor2] = editor.getCursors()
-              expect(cursor1.getBufferPosition()).toEqual [0,29]
-              expect(cursor2.getBufferPosition()).toEqual [0,59]
+              expect(cursor1.getBufferPosition()).toEqual [0, 29]
+              expect(cursor2.getBufferPosition()).toEqual [0, 59]
 
       describe "when there is a single selection", ->
         it "deletes the selection, but not the character following it", ->
@@ -2603,7 +2603,7 @@ describe "TextEditor", ->
       describe "when there are multiple selections", ->
         describe "when selections are on the same line", ->
           it "removes all selected text", ->
-            editor.setSelectedBufferRanges([[[0,4], [0,13]], [[0,16], [0,24]]])
+            editor.setSelectedBufferRanges([[[0, 4], [0, 13]], [[0, 16], [0, 24]]])
             editor.delete()
             expect(editor.lineTextForBufferRow(0)).toBe 'var  =  () {'
 
@@ -2781,9 +2781,9 @@ describe "TextEditor", ->
         describe "when many selections get added in shuffle order", ->
           it "cuts them in order", ->
             editor.setSelectedBufferRanges([
-              [[2,8], [2, 13]]
-              [[0,4], [0,13]],
-              [[1,6], [1, 10]],
+              [[2, 8], [2, 13]]
+              [[0, 4], [0, 13]],
+              [[1, 6], [1, 10]],
             ])
             editor.cutSelectedText()
             expect(atom.clipboard.read()).toEqual """
@@ -2813,7 +2813,7 @@ describe "TextEditor", ->
 
           describe "when text is selected", ->
             it "only cuts the selected text, not to the end of the line", ->
-              editor.setSelectedBufferRanges([[[2,20], [2, 30]], [[3, 20], [3, 20]]])
+              editor.setSelectedBufferRanges([[[2, 20], [2, 30]], [[3, 20], [3, 20]]])
 
               editor.cutToEndOfLine()
 
@@ -2823,7 +2823,7 @@ describe "TextEditor", ->
 
       describe ".copySelectedText()", ->
         it "copies selected text onto the clipboard", ->
-          editor.setSelectedBufferRanges([[[0,4], [0,13]], [[1,6], [1, 10]], [[2,8], [2, 13]]])
+          editor.setSelectedBufferRanges([[[0, 4], [0, 13]], [[1, 6], [1, 10]], [[2, 8], [2, 13]]])
 
           editor.copySelectedText()
           expect(buffer.lineForRow(0)).toBe "var quicksort = function () {"
@@ -2857,9 +2857,9 @@ describe "TextEditor", ->
         describe "when many selections get added in shuffle order", ->
           it "copies them in order", ->
             editor.setSelectedBufferRanges([
-              [[2,8], [2, 13]]
-              [[0,4], [0,13]],
-              [[1,6], [1, 10]],
+              [[2, 8], [2, 13]]
+              [[0, 4], [0, 13]],
+              [[1, 6], [1, 10]],
             ])
             editor.copySelectedText()
             expect(atom.clipboard.read()).toEqual """
@@ -2876,7 +2876,7 @@ describe "TextEditor", ->
           textEditor.insertText(text)
           numberOfNewlines = text.match(/\n/g)?.length
           endColumn = text.match(/[^\n]*$/)[0]?.length
-          textEditor.getLastSelection().setBufferRange([[0,startColumn], [numberOfNewlines,endColumn]])
+          textEditor.getLastSelection().setBufferRange([[0, startColumn], [numberOfNewlines, endColumn]])
           textEditor.cutSelectedText()
 
         it "pastes text into the buffer", ->
@@ -3020,7 +3020,7 @@ describe "TextEditor", ->
       describe "when nothing is selected", ->
         describe "when softTabs is enabled", ->
           it "indents line and retains selection", ->
-            editor.setSelectedBufferRange([[0,3], [0,3]])
+            editor.setSelectedBufferRange([[0, 3], [0, 3]])
             editor.indentSelectedRows()
             expect(buffer.lineForRow(0)).toBe "  var quicksort = function () {"
             expect(editor.getSelectedBufferRange()).toEqual [[0, 3 + editor.getTabLength()], [0, 3 + editor.getTabLength()]]
@@ -3029,7 +3029,7 @@ describe "TextEditor", ->
           it "indents line and retains selection", ->
             convertToHardTabs(buffer)
             editor.setSoftTabs(false)
-            editor.setSelectedBufferRange([[0,3], [0,3]])
+            editor.setSelectedBufferRange([[0, 3], [0, 3]])
             editor.indentSelectedRows()
             expect(buffer.lineForRow(0)).toBe "\tvar quicksort = function () {"
             expect(editor.getSelectedBufferRange()).toEqual [[0, 3 + 1], [0, 3 + 1]]
@@ -3037,7 +3037,7 @@ describe "TextEditor", ->
       describe "when one line is selected", ->
         describe "when softTabs is enabled", ->
           it "indents line and retains selection", ->
-            editor.setSelectedBufferRange([[0,4], [0,14]])
+            editor.setSelectedBufferRange([[0, 4], [0, 14]])
             editor.indentSelectedRows()
             expect(buffer.lineForRow(0)).toBe "#{editor.getTabText()}var quicksort = function () {"
             expect(editor.getSelectedBufferRange()).toEqual [[0, 4 + editor.getTabLength()], [0, 14 + editor.getTabLength()]]
@@ -3046,7 +3046,7 @@ describe "TextEditor", ->
           it "indents line and retains selection", ->
             convertToHardTabs(buffer)
             editor.setSoftTabs(false)
-            editor.setSelectedBufferRange([[0,4], [0,14]])
+            editor.setSelectedBufferRange([[0, 4], [0, 14]])
             editor.indentSelectedRows()
             expect(buffer.lineForRow(0)).toBe "\tvar quicksort = function () {"
             expect(editor.getSelectedBufferRange()).toEqual [[0, 4 + 1], [0, 14 + 1]]
@@ -3054,7 +3054,7 @@ describe "TextEditor", ->
       describe "when multiple lines are selected", ->
         describe "when softTabs is enabled", ->
           it "indents selected lines (that are not empty) and retains selection", ->
-            editor.setSelectedBufferRange([[9,1], [11,15]])
+            editor.setSelectedBufferRange([[9, 1], [11, 15]])
             editor.indentSelectedRows()
             expect(buffer.lineForRow(9)).toBe "    };"
             expect(buffer.lineForRow(10)).toBe ""
@@ -3062,7 +3062,7 @@ describe "TextEditor", ->
             expect(editor.getSelectedBufferRange()).toEqual [[9, 1 + editor.getTabLength()], [11, 15 + editor.getTabLength()]]
 
           it "does not indent the last row if the selection ends at column 0", ->
-            editor.setSelectedBufferRange([[9,1], [11,0]])
+            editor.setSelectedBufferRange([[9, 1], [11, 0]])
             editor.indentSelectedRows()
             expect(buffer.lineForRow(9)).toBe "    };"
             expect(buffer.lineForRow(10)).toBe ""
@@ -3073,7 +3073,7 @@ describe "TextEditor", ->
           it "indents selected lines (that are not empty) and retains selection", ->
             convertToHardTabs(buffer)
             editor.setSoftTabs(false)
-            editor.setSelectedBufferRange([[9,1], [11,15]])
+            editor.setSelectedBufferRange([[9, 1], [11, 15]])
             editor.indentSelectedRows()
             expect(buffer.lineForRow(9)).toBe "\t\t};"
             expect(buffer.lineForRow(10)).toBe ""
@@ -3083,7 +3083,7 @@ describe "TextEditor", ->
     describe ".outdentSelectedRows()", ->
       describe "when nothing is selected", ->
         it "outdents line and retains selection", ->
-          editor.setSelectedBufferRange([[1,3], [1,3]])
+          editor.setSelectedBufferRange([[1, 3], [1, 3]])
           editor.outdentSelectedRows()
           expect(buffer.lineForRow(1)).toBe "var sort = function(items) {"
           expect(editor.getSelectedBufferRange()).toEqual [[1, 3 - editor.getTabLength()], [1, 3 - editor.getTabLength()]]
@@ -3120,14 +3120,14 @@ describe "TextEditor", ->
 
       describe "when one line is selected", ->
         it "outdents line and retains editor", ->
-          editor.setSelectedBufferRange([[1,4], [1,14]])
+          editor.setSelectedBufferRange([[1, 4], [1, 14]])
           editor.outdentSelectedRows()
           expect(buffer.lineForRow(1)).toBe "var sort = function(items) {"
           expect(editor.getSelectedBufferRange()).toEqual [[1, 4 - editor.getTabLength()], [1, 14 - editor.getTabLength()]]
 
       describe "when multiple lines are selected", ->
         it "outdents selected lines and retains editor", ->
-          editor.setSelectedBufferRange([[0,1], [3,15]])
+          editor.setSelectedBufferRange([[0, 1], [3, 15]])
           editor.outdentSelectedRows()
           expect(buffer.lineForRow(0)).toBe "var quicksort = function () {"
           expect(buffer.lineForRow(1)).toBe "var sort = function(items) {"
@@ -3136,7 +3136,7 @@ describe "TextEditor", ->
           expect(editor.getSelectedBufferRange()).toEqual [[0, 1], [3, 15 - editor.getTabLength()]]
 
         it "does not outdent the last line of the selection if it ends at column 0", ->
-          editor.setSelectedBufferRange([[0,1], [3,0]])
+          editor.setSelectedBufferRange([[0, 1], [3, 0]])
           editor.outdentSelectedRows()
           expect(buffer.lineForRow(0)).toBe "var quicksort = function () {"
           expect(buffer.lineForRow(1)).toBe "var sort = function(items) {"
@@ -3149,7 +3149,7 @@ describe "TextEditor", ->
       it "auto-indents the selection", ->
         editor.setCursorBufferPosition([2, 0])
         editor.insertText("function() {\ninside=true\n}\n  i=1\n")
-        editor.getLastSelection().setBufferRange([[2,0], [6,0]])
+        editor.getLastSelection().setBufferRange([[2, 0], [6, 0]])
         editor.autoIndentSelectedRows()
 
         expect(editor.lineTextForBufferRow(2)).toBe "    function() {"
@@ -3385,8 +3385,8 @@ describe "TextEditor", ->
 
         expect(editor.getCursors().length).toBe 2
         expect(editor.getCursors()).toEqual [cursor1, cursor3]
-        expect(cursor1.getBufferPosition()).toEqual [0,0]
-        expect(cursor3.getBufferPosition()).toEqual [1,2]
+        expect(cursor1.getBufferPosition()).toEqual [0, 0]
+        expect(cursor3.getBufferPosition()).toEqual [1, 2]
 
   describe 'reading text', ->
     it '.lineTextForScreenRow(row)', ->
@@ -3544,7 +3544,7 @@ describe "TextEditor", ->
     describe "when there is a selection", ->
       it "upper cases the current selection", ->
         editor.buffer.setText("abc")
-        editor.setSelectedBufferRange([[0,0], [0,2]])
+        editor.setSelectedBufferRange([[0, 0], [0, 2]])
         editor.upperCase()
         expect(editor.lineTextForBufferRow(0)).toBe 'ABc'
         expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [0, 2]]
@@ -3561,7 +3561,7 @@ describe "TextEditor", ->
     describe "when there is a selection", ->
       it "lower cases the current selection", ->
         editor.buffer.setText("ABC")
-        editor.setSelectedBufferRange([[0,0], [0,2]])
+        editor.setSelectedBufferRange([[0, 0], [0, 2]])
         editor.lowerCase()
         expect(editor.lineTextForBufferRow(0)).toBe 'abC'
         expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [0, 2]]
@@ -3652,7 +3652,7 @@ describe "TextEditor", ->
     it "preserves the current cursor position", ->
       editor.setCursorScreenPosition([0, 1])
       editor.buffer.reload()
-      expect(editor.getCursorScreenPosition()).toEqual [0,1]
+      expect(editor.getCursorScreenPosition()).toEqual [0, 1]
 
   describe "when a better-matched grammar is added to syntax", ->
     it "switches to the better-matched grammar and re-tokenizes the buffer", ->
@@ -4235,28 +4235,28 @@ describe "TextEditor", ->
 
       editor.selectPageDown()
       expect(editor.getScrollTop()).toBe 30
-      expect(editor.getSelectedBufferRanges()).toEqual [[[0,0], [5,0]]]
+      expect(editor.getSelectedBufferRanges()).toEqual [[[0, 0], [5, 0]]]
 
       editor.selectPageDown()
       expect(editor.getScrollTop()).toBe 80
-      expect(editor.getSelectedBufferRanges()).toEqual [[[0,0], [10,0]]]
+      expect(editor.getSelectedBufferRanges()).toEqual [[[0, 0], [10, 0]]]
 
       editor.selectPageDown()
       expect(editor.getScrollTop()).toBe 80
-      expect(editor.getSelectedBufferRanges()).toEqual [[[0,0], [12,2]]]
+      expect(editor.getSelectedBufferRanges()).toEqual [[[0, 0], [12, 2]]]
 
       editor.moveToBottom()
       editor.selectPageUp()
       expect(editor.getScrollTop()).toBe 50
-      expect(editor.getSelectedBufferRanges()).toEqual [[[7,0], [12,2]]]
+      expect(editor.getSelectedBufferRanges()).toEqual [[[7, 0], [12, 2]]]
 
       editor.selectPageUp()
       expect(editor.getScrollTop()).toBe 0
-      expect(editor.getSelectedBufferRanges()).toEqual [[[2,0], [12,2]]]
+      expect(editor.getSelectedBufferRanges()).toEqual [[[2, 0], [12, 2]]]
 
       editor.selectPageUp()
       expect(editor.getScrollTop()).toBe 0
-      expect(editor.getSelectedBufferRanges()).toEqual [[[0,0], [12,2]]]
+      expect(editor.getSelectedBufferRanges()).toEqual [[[0, 0], [12, 2]]]
 
   describe '.get/setPlaceholderText()', ->
     it 'can be created with placeholderText', ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -227,7 +227,7 @@ describe "TextEditor", ->
     describe "when the cursor moves", ->
       it "clears a goal column established by vertical movement", ->
         editor.setText('b')
-        editor.setCursorBufferPosition([0,0])
+        editor.setCursorBufferPosition([0, 0])
         editor.insertNewline()
         editor.moveUp()
         editor.insertText('a')
@@ -262,7 +262,7 @@ describe "TextEditor", ->
         expect(editor.getCursorScreenPosition().column).not.toBe 6
 
         # clear the goal column by explicitly setting the cursor position
-        editor.setCursorScreenPosition([4,6])
+        editor.setCursorScreenPosition([4, 6])
         expect(editor.getCursorScreenPosition().column).toBe 6
 
         editor.moveDown()
@@ -317,7 +317,7 @@ describe "TextEditor", ->
 
       describe "when there is a selection", ->
         beforeEach ->
-          editor.setSelectedBufferRange([[4, 9],[5, 10]])
+          editor.setSelectedBufferRange([[4, 9], [5, 10]])
 
         it "moves above the selection", ->
           cursor = editor.getLastCursor()
@@ -330,7 +330,7 @@ describe "TextEditor", ->
 
         editor.moveUp()
         expect(editor.getCursors()).toEqual [cursor1]
-        expect(cursor1.getBufferPosition()).toEqual [0,0]
+        expect(cursor1.getBufferPosition()).toEqual [0, 0]
 
       describe "when the cursor was moved down from the beginning of an indented soft-wrapped line", ->
         it "moves to the beginning of the previous line", ->
@@ -396,7 +396,7 @@ describe "TextEditor", ->
 
       describe "when there is a selection", ->
         beforeEach ->
-          editor.setSelectedBufferRange([[4, 9],[5, 10]])
+          editor.setSelectedBufferRange([[4, 9], [5, 10]])
 
         it "moves below the selection", ->
           cursor = editor.getLastCursor()
@@ -410,7 +410,7 @@ describe "TextEditor", ->
 
         editor.moveDown()
         expect(editor.getCursors()).toEqual [cursor1]
-        expect(cursor1.getBufferPosition()).toEqual [12,2]
+        expect(cursor1.getBufferPosition()).toEqual [12, 2]
 
     describe ".moveLeft()", ->
       it "moves the cursor by one column to the left", ->
@@ -481,7 +481,7 @@ describe "TextEditor", ->
 
       describe "when there is a selection", ->
         beforeEach ->
-          editor.setSelectedBufferRange([[5, 22],[5, 27]])
+          editor.setSelectedBufferRange([[5, 22], [5, 27]])
 
         it "moves to the left of the selection", ->
           cursor = editor.getLastCursor()
@@ -498,7 +498,7 @@ describe "TextEditor", ->
         [cursor1, cursor2] = editor.getCursors()
         editor.moveLeft()
         expect(editor.getCursors()).toEqual [cursor1]
-        expect(cursor1.getBufferPosition()).toEqual [0,0]
+        expect(cursor1.getBufferPosition()).toEqual [0, 0]
 
     describe ".moveRight()", ->
       it "moves the cursor by one column to the right", ->
@@ -578,15 +578,15 @@ describe "TextEditor", ->
         editor.addCursorAtScreenPosition [12,0]
         editor.moveToTop()
         expect(editor.getCursors().length).toBe 1
-        expect(editor.getCursorBufferPosition()).toEqual [0,0]
+        expect(editor.getCursorBufferPosition()).toEqual [0, 0]
 
     describe ".moveToBottom()", ->
       it "moves the cusor to the bottom of the buffer", ->
-        editor.setCursorScreenPosition [0,0]
-        editor.addCursorAtScreenPosition [1,0]
+        editor.setCursorScreenPosition [0, 0]
+        editor.addCursorAtScreenPosition [1, 0]
         editor.moveToBottom()
         expect(editor.getCursors().length).toBe 1
-        expect(editor.getCursorBufferPosition()).toEqual [12,2]
+        expect(editor.getCursorBufferPosition()).toEqual [12, 2]
 
     describe ".moveToBeginningOfScreenLine()", ->
       describe "when soft wrap is on", ->
@@ -599,14 +599,14 @@ describe "TextEditor", ->
           expect(cursor.getScreenPosition()).toEqual [1, 0]
 
       describe "when soft wrap is off", ->
-        it "moves cursor to the beginning of then line", ->
-          editor.setCursorScreenPosition [0,5]
-          editor.addCursorAtScreenPosition [1,7]
+        it "moves cursor to the beginning of the line", ->
+          editor.setCursorScreenPosition [0, 5]
+          editor.addCursorAtScreenPosition [1, 7]
           editor.moveToBeginningOfScreenLine()
           expect(editor.getCursors().length).toBe 2
           [cursor1, cursor2] = editor.getCursors()
-          expect(cursor1.getBufferPosition()).toEqual [0,0]
-          expect(cursor2.getBufferPosition()).toEqual [1,0]
+          expect(cursor1.getBufferPosition()).toEqual [0, 0]
+          expect(cursor2.getBufferPosition()).toEqual [1, 0]
 
     describe ".moveToEndOfScreenLine()", ->
       describe "when soft wrap is on", ->
@@ -620,13 +620,13 @@ describe "TextEditor", ->
 
       describe "when soft wrap is off", ->
         it "moves cursor to the end of line", ->
-          editor.setCursorScreenPosition [0,0]
-          editor.addCursorAtScreenPosition [1,0]
+          editor.setCursorScreenPosition [0, 0]
+          editor.addCursorAtScreenPosition [1, 0]
           editor.moveToEndOfScreenLine()
           expect(editor.getCursors().length).toBe 2
           [cursor1, cursor2] = editor.getCursors()
-          expect(cursor1.getBufferPosition()).toEqual [0,29]
-          expect(cursor2.getBufferPosition()).toEqual [1,30]
+          expect(cursor1.getBufferPosition()).toEqual [0, 29]
+          expect(cursor2.getBufferPosition()).toEqual [1, 30]
 
     describe ".moveToBeginningOfLine()", ->
       it "moves cursor to the beginning of the buffer line", ->

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -287,7 +287,7 @@ describe "TokenizedBuffer", ->
       describe "when there is an insertion that is larger than the chunk size", ->
         it "tokenizes the initial chunk synchronously, then tokenizes the remaining lines in the background", ->
           commentBlock = _.multiplyString("// a comment\n", tokenizedBuffer.chunkSize + 2)
-          buffer.insert([0,0], commentBlock)
+          buffer.insert([0, 0], commentBlock)
           expect(tokenizedBuffer.tokenizedLineForRow(0).ruleStack?).toBeTruthy()
           expect(tokenizedBuffer.tokenizedLineForRow(4).ruleStack?).toBeTruthy()
           expect(tokenizedBuffer.tokenizedLineForRow(5).ruleStack?).toBeFalsy()
@@ -541,7 +541,7 @@ describe "TokenizedBuffer", ->
       runs ->
         fullyTokenize(tokenizedBuffer)
         {tokens} = tokenizedBuffer.tokenizedLineForRow(0)
-        expect(tokens[0]).toEqual value: '<', scopes: ["text.html.ruby","meta.tag.block.any.html","punctuation.definition.tag.begin.html"]
+        expect(tokens[0]).toEqual value: '<', scopes: ["text.html.ruby", "meta.tag.block.any.html", "punctuation.definition.tag.begin.html"]
 
   describe ".tokenForPosition(position)", ->
     afterEach ->
@@ -552,9 +552,9 @@ describe "TokenizedBuffer", ->
       buffer = atom.project.bufferForPathSync('sample.js')
       tokenizedBuffer = new TokenizedBuffer({buffer})
       fullyTokenize(tokenizedBuffer)
-      expect(tokenizedBuffer.tokenForPosition([1,0]).scopes).toEqual ["source.js"]
-      expect(tokenizedBuffer.tokenForPosition([1,1]).scopes).toEqual ["source.js"]
-      expect(tokenizedBuffer.tokenForPosition([1,2]).scopes).toEqual ["source.js", "storage.modifier.js"]
+      expect(tokenizedBuffer.tokenForPosition([1, 0]).scopes).toEqual ["source.js"]
+      expect(tokenizedBuffer.tokenForPosition([1, 1]).scopes).toEqual ["source.js"]
+      expect(tokenizedBuffer.tokenForPosition([1, 2]).scopes).toEqual ["source.js", "storage.modifier.js"]
 
   describe ".bufferRangeForScopeAtPosition(selector, position)", ->
     beforeEach ->
@@ -580,20 +580,20 @@ describe "TokenizedBuffer", ->
       buffer.setText('\ttest')
       tokenizedBuffer = new TokenizedBuffer({buffer})
       fullyTokenize(tokenizedBuffer)
-      expect(tokenizedBuffer.tokenForPosition([0,0]).value).toBe '  '
+      expect(tokenizedBuffer.tokenForPosition([0, 0]).value).toBe '  '
       atom.config.set('editor.tabLength', 6)
-      expect(tokenizedBuffer.tokenForPosition([0,0]).value).toBe '      '
+      expect(tokenizedBuffer.tokenForPosition([0, 0]).value).toBe '      '
 
     it "does not allow the tab length to be less than 1", ->
       buffer = atom.project.bufferForPathSync('sample.js')
       buffer.setText('\ttest')
       tokenizedBuffer = new TokenizedBuffer({buffer})
       fullyTokenize(tokenizedBuffer)
-      expect(tokenizedBuffer.tokenForPosition([0,0]).value).toBe '  '
+      expect(tokenizedBuffer.tokenForPosition([0, 0]).value).toBe '  '
       atom.config.set('editor.tabLength', 1)
-      expect(tokenizedBuffer.tokenForPosition([0,0]).value).toBe ' '
+      expect(tokenizedBuffer.tokenForPosition([0, 0]).value).toBe ' '
       atom.config.set('editor.tabLength', 0)
-      expect(tokenizedBuffer.tokenForPosition([0,0]).value).toBe ' '
+      expect(tokenizedBuffer.tokenForPosition([0, 0]).value).toBe ' '
 
   describe "when the invisibles value changes", ->
     beforeEach ->

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -1027,7 +1027,7 @@ describe "Workspace", ->
           atom.project.open('sample.js').then (o) -> editor = o
 
         runs ->
-          editor.buffer.setTextInRange([[0,0],[0,0]], 'omg')
+          editor.buffer.setTextInRange([[0, 0], [0, 0]], 'omg')
           expect(editor.isModified()).toBeTruthy()
 
         waitsForPromise ->

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -174,7 +174,7 @@ class AtomApplication
     @on 'application:open-safe', -> @promptForPathToOpen('all', safeMode: true)
     @on 'application:open-api-preview', -> @promptForPathToOpen('all', apiPreviewMode: true)
     @on 'application:open-dev-api-preview', -> @promptForPathToOpen('all', {apiPreviewMode: true, devMode: true})
-    @on 'application:inspect', ({x,y, atomWindow}) ->
+    @on 'application:inspect', ({x, y, atomWindow}) ->
       atomWindow ?= @focusedWindow()
       atomWindow?.browserWindow.inspectElement(x, y)
 

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -333,7 +333,7 @@ class Cursor extends Model
 
   # Public: Moves the cursor to the top of the buffer.
   moveToTop: ->
-    @setBufferPosition([0,0])
+    @setBufferPosition([0, 0])
 
   # Public: Moves the cursor to the bottom of the buffer.
   moveToBottom: ->
@@ -673,9 +673,9 @@ class Cursor extends Model
     start = @getBufferPosition()
 
     {row, column} = start
-    scanRange = [[row-1, column], [0,0]]
+    scanRange = [[row-1, column], [0, 0]]
     position = new Point(0, 0)
-    zero = new Point(0,0)
+    zero = new Point(0, 0)
     @editor.backwardsScanInBufferRange /^\n*$/g, scanRange, ({range, stop}) ->
       unless range.start.isEqual(zero)
         position = range.start

--- a/src/text-editor-view.coffee
+++ b/src/text-editor-view.coffee
@@ -120,14 +120,14 @@ class TextEditorView extends View
 
   getEditor: -> @model
 
-  Object.defineProperty @::, 'lineHeight', get: -> @model.getLineHeightInPixels()
-  Object.defineProperty @::, 'charWidth', get: -> @model.getDefaultCharWidth()
-  Object.defineProperty @::, 'firstRenderedScreenRow', get: -> @component.getRenderedRowRange()[0]
-  Object.defineProperty @::, 'lastRenderedScreenRow', get: -> @component.getRenderedRowRange()[1]
-  Object.defineProperty @::, 'active', get: -> @is(@getPaneView()?.activeView)
-  Object.defineProperty @::, 'isFocused', get: -> document.activeElement is @element or document.activeElement is @element.component?.hiddenInputComponent?.getDomNode()
-  Object.defineProperty @::, 'mini', get: -> @model?.isMini()
-  Object.defineProperty @::, 'component', get: -> @element?.component
+  Object.defineProperty @prototype, 'lineHeight', get: -> @model.getLineHeightInPixels()
+  Object.defineProperty @prototype, 'charWidth', get: -> @model.getDefaultCharWidth()
+  Object.defineProperty @prototype, 'firstRenderedScreenRow', get: -> @component.getRenderedRowRange()[0]
+  Object.defineProperty @prototype, 'lastRenderedScreenRow', get: -> @component.getRenderedRowRange()[1]
+  Object.defineProperty @prototype, 'active', get: -> @is(@getPaneView()?.activeView)
+  Object.defineProperty @prototype, 'isFocused', get: -> document.activeElement is @element or document.activeElement is @element.component?.hiddenInputComponent?.getDomNode()
+  Object.defineProperty @prototype, 'mini', get: -> @model?.isMini()
+  Object.defineProperty @prototype, 'component', get: -> @element?.component
 
   afterAttach: (onDom) ->
     return unless onDom


### PR DESCRIPTION
The sequel to https://github.com/atom/atom/pull/6230

I'm sure making the package linting job harder for myself :stuck_out_tongue_closed_eyes:, but I figured I should do this now before I add linting support to any more packages – this updates coffeelint.json to lint for more code style errors.

Let me know if these changes seem reasonable!

/cc @atom/feedback 
