### PR TITLE
Skip linting fixtures

### DIFF
--- a/.coffeelintignore
+++ b/.coffeelintignore
@@ -1,0 +1,1 @@
+spec/fixtures


### PR DESCRIPTION
Refs #6898, https://github.com/atom/atom/issues/5982, and https://github.com/atom/atom/pull/6230#discussion_r27896062

This adds a `.coffeelintignore` file to ensure that no one accidentally lints the `spec/fixtures` directory, lest we break the universe.
