### PR TITLE
Fix application:open-license command

### DIFF
--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -377,7 +377,7 @@ class Workspace extends Model
 
   # Open Atom's license in the active pane.
   openLicense: ->
-    @open(join(atom.getLoadSettings().resourcePath, 'LICENSE.md'))
+    @open(path.join(process.resourcesPath, 'LICENSE.md'))
 
   # Synchronously open the given URI in the active pane. **Only use this method
   # in specs. Calling this in production code will block the UI thread and


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/6918

The issue here was that `atom.getLoadSettings().resourcePath` was returning the path to `app.asar`, but the LICENSE.md currently doesn't get placed inside `app.asar` – it lives directly inside the resources directory. This gets around that by using `process.resourcesPath` like https://github.com/atom/atom/blob/master/src/browser/atom-application.coffee#L210, but this probably isn't the best approach since `process.resourcePath` won't change if you launched Atom normally but have a dev mode window active.
- Should we generate LICENSE.md inside `app.asar`?

/cc @atom/feedback @kevinsawicki 
