### PR TITLE
Add docs about passing a function to a tooltip title

### DIFF
--- a/src/tooltip-manager.coffee
+++ b/src/tooltip-manager.coffee
@@ -57,9 +57,10 @@ class TooltipManager
   # Essential: Add a tooltip to the given element.
   #
   # * `target` An `HTMLElement`
-  # * `options` See http://getbootstrap.com/javascript/#tooltips for a full list
-  #   of options. You can also supply the following additional options:
-  #   * `title` {String} Text in the tip.
+  # * `options` See http://getbootstrap.com/javascript/#tooltips-options for a
+  #   full list of options. You can also supply the following additional options:
+  #   * `title` A {String} or {Function} to use for the text in the tip. If
+  #     given a function, `this` will be set to the `target` element.
   #   * `keyBindingCommand` A {String} containing a command name. If you specify
   #     this option and a key binding exists that matches the command, it will
   #     be appended to the title or rendered alone if no title is specified.


### PR DESCRIPTION
This documents the option of passing a function to tooltip's title.

/cc @atom/feedback 
