### PR TITLE
Document build flags

### DIFF
--- a/docs/build-instructions/freebsd.md
+++ b/docs/build-instructions/freebsd.md
@@ -19,4 +19,18 @@ FreeBSD -RELEASE 64-bit is the recommended platform.
   sudo script/grunt install # Installs command to /usr/local/bin/atom
   ```
 
+## Advanced Options
+
+### Custom install directory
+
+```sh
+sudo script/grunt install --install-dir /install/atom/here
+```
+
+### Custom build directory
+
+```sh
+script/build --build-dir /build/atom/here
+```
+
 ## Troubleshooting

--- a/docs/build-instructions/os-x.md
+++ b/docs/build-instructions/os-x.md
@@ -14,6 +14,11 @@
   script/build # Creates application at /Applications/Atom.app
   ```
 
+### `script/build` Options
+  * `--install-dir` - Creates the final built application in this directory.
+  * `--build-dir` - Build the application in this directory.
+  * `--verbose` - Verbose mode. A lot more information output.
+
 ## Troubleshooting
 
 ### OSX build error reports in atom/atom

--- a/docs/build-instructions/os-x.md
+++ b/docs/build-instructions/os-x.md
@@ -15,7 +15,7 @@
   ```
 
 ### `script/build` Options
-  * `--install-dir` - Creates the final built application in this directory.
+  * `--install-dir` - The full path to the final built application (must include `.app` in the path), e.g. `script/build --install-dir full/path/to/Atom.app`
   * `--build-dir` - Build the application in this directory.
   * `--verbose` - Verbose mode. A lot more information output.
 

--- a/docs/build-instructions/os-x.md
+++ b/docs/build-instructions/os-x.md
@@ -15,7 +15,7 @@
   ```
 
 ### `script/build` Options
-  * `--install-dir` - The full path to the final built application (must include `.app` in the path), e.g. `script/build --install-dir full/path/to/Atom.app`
+  * `--install-dir` - The full path to the final built application (must include `.app` in the path), e.g. `script/build --install-dir /Users/username/full/path/to/Atom.app`
   * `--build-dir` - Build the application in this directory.
   * `--verbose` - Verbose mode. A lot more information output.
 

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -33,6 +33,11 @@ cd atom
 script/build # Creates application in the `Program Files` directory
 ```
 
+### `script/build` Options
+  * `--install-dir` - Creates the final built application in this directory.
+  * `--build-dir` - Build the application in this directory.
+  * `--verbose` - Verbose mode. A lot more information output.
+
 ## Why do I have to use GitHub for Windows?
 
 You don't. You can use your existing Git! GitHub for Windows's Git Shell is just


### PR DESCRIPTION
Refs https://discuss.atom.io/t/install-atom-as-standard-user-on-os-x/17142/2?u=mnquintana

`script/build`'s option flags are currently undocumented for every platform but Linux – this documents it for other platforms.

/cc @atom/feedback 
