### PR TITLE
Don't save `null` repositories

### DIFF
--- a/src/project.coffee
+++ b/src/project.coffee
@@ -203,7 +203,7 @@ class Project extends Model
     repo = null
     for provider in @repositoryProviders
       break if repo = provider.repositoryForDirectorySync?(directory)
-    @repositories.push(repo ? null)
+    @repositories.push(repo) if repo
 
     unless options?.emitEvent is false
       @emit "path-changed" if includeDeprecatedAPIs


### PR DESCRIPTION
Putting instances of null in the `@repositories` array can be misleading for packages that want to use `atom.project.getRepositories().length` to know how many repos there actually are instead of how many potential repositories there could be. Right now, I'm filtering the array for non-null values each time I call it.
