### PR TITLE
Pin the Babel dependency to a specific version number.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "async": "0.2.6",
     "atom-keymap": "^5.1.4",
     "atom-space-pen-views": "^2.0.4",
-    "babel-core": "^5.1.11",
+    "babel-core": "5.4.7",
     "bootstrap": "^3.3.4",
     "clear-cut": "^2.0.1",
     "coffee-cash": "0.8.0",


### PR DESCRIPTION
Third-party Atom packages may want to use the exact same version of Babel
that Atom uses to transpile Babel files automatically. Specifying the version
as a range makes this hard to do.
