### PR TITLE
Add coffeelint config files to ignored build paths

### DIFF
--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -103,6 +103,8 @@ module.exports = (grunt) ->
       '.lintignore'
       '.eslintrc'
       '.jshintignore'
+      'coffeelint.json'
+      '.coffeelintignore'
       '.gitattributes'
       '.gitkeep'
     ]


### PR DESCRIPTION
This adds `.coffeelintignore` and `coffeelint.json` to the list of ignored paths so we don't ship with them.

Refs https://github.com/atom/atom/issues/5982

/cc @kevinsawicki 
