### PR TITLE
Avoid double transaction when typing

### DIFF
--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -309,8 +309,7 @@ class TextEditorComponent
     selectedLength = inputNode.selectionEnd - inputNode.selectionStart
     @editor.selectLeft() if selectedLength is 1
 
-    insertedRange = @editor.transact atom.config.get('editor.undoGroupingInterval'), =>
-      @editor.insertText(event.data)
+    insertedRange = @editor.insertText(event.data, groupUndo: true)
     inputNode.value = event.data if insertedRange
 
   onVerticalScroll: (scrollTop) =>


### PR DESCRIPTION
The double transaction was just there to set an undo-grouping interval, which can be accomplished another way. This helps performance a little when typing by avoiding duplicate marker snapshots.
