### PR TITLE
Add a rootDirectories filtering option to atom.workspace.scan().

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -2,6 +2,7 @@ path = require 'path'
 temp = require 'temp'
 Workspace = require '../src/workspace'
 Pane = require '../src/pane'
+{Directory} = require 'pathwatcher'
 {View} = require '../src/space-pen-extensions'
 platform = require './spec-helper-platform'
 _ = require 'underscore-plus'
@@ -906,6 +907,16 @@ describe "Workspace", ->
 
           runs ->
             expect(resultPaths.sort()).toEqual([file1, file2].sort())
+
+        it "respects the rootDirectories filter option", ->
+          resultPaths = []
+          options =
+            rootDirectories: [new Directory(dir1)]
+          waitsForPromise ->
+            atom.workspace.scan /aaaa/, options, ({filePath}) ->
+              resultPaths.push(filePath)
+          runs ->
+            expect(resultPaths).toEqual([file1])
 
         describe "when an inclusion path starts with the basename of a root directory", ->
           it "interprets the inclusion path as starting from that directory", ->


### PR DESCRIPTION
By default, `atom.workspace.scan()` scans everything in `atom.project.getDirectories()`.
This introduces the option to restrict `scan()` to a specific set of `Directory` objects.

This will be useful for excluding special root `Directory` objects (such as those created
via a custom `DirectoryProvider`) from calls to `scan()`, if appropriate.

Because I was in the neighborhood, I also made some small documentation fixes:
- Documented the previously undocumented `onPathsSearched` option.
- Clarified that the returned `Promise` has a `cancel()` method.
