### PR TITLE
Use previous definition of scope selector match to fix API breakage

### DIFF
--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -572,7 +572,7 @@ describe "TokenizedBuffer", ->
 
     describe "when the selector matches a run of multiple tokens at the position", ->
       it "returns the range covered by all contigous tokens (within a single line)", ->
-        expect(tokenizedBuffer.bufferRangeForScopeAtPosition('.meta.function', [1, 18])).toEqual [[1, 6], [1, 28]]
+        expect(tokenizedBuffer.bufferRangeForScopeAtPosition('.function', [1, 18])).toEqual [[1, 6], [1, 28]]
 
   describe "when the editor.tabLength config value changes", ->
     it "updates the tab length of the tokenized lines", ->


### PR DESCRIPTION
I switched to first-mate Selector because I didn’t want to replicate the poorly-defined Token::matchesScopeSelector method now that tokens are not stored on lines. However, the first-mate semantics are stricter and that broke the API. Perhaps using selector-kit here would be better, but I just wanted to put back exactly to how it was for now.

@kevinsawicki we need to merge this and release ASAP to fix railroad diagrams and probably some other packages. Sorry about this everybody.

/cc @ypresto
