### PR TITLE
Use lsb virtual package instead of hard require

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -7,7 +7,7 @@ URL:            https://atom.io/
 AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
-Requires: redhat-lsb-core
+Requires: lsb
 
 %description
 <%= description %>


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/6983
Refs https://github.com/atom/atom/pull/6888

I'm not 100% sure, but I think this should fix https://github.com/atom/atom/issues/6983 – rather than requiring the exact package name (which may be repo-specific) this requires the virtual package name `lsb`, which should cover all possible `lsb` packages for distros. 

I've tested this on Fedora 21, but don't have a VM set up for any other RPM-based distros. If anyone does, I'd very much appreciate trying to install `lsb` with your package manager and reporting your results here. Thanks!

/cc @kevinsawicki @mingjunyang
