### PR TITLE
Skip linting for benchmark fixtures

### DIFF
--- a/.coffeelintignore
+++ b/.coffeelintignore
@@ -1,1 +1,2 @@
 spec/fixtures
+benchmark/fixtures


### PR DESCRIPTION
We shouldn't accidentally lint benchmark fixtures either.
