### PR TITLE
Style links and code blocks in text-* classes

### DIFF
--- a/static/atom.less
+++ b/static/atom.less
@@ -25,5 +25,6 @@
 @import "text-editor-light";
 @import "select-list";
 @import "syntax";
+@import "text";
 @import "utilities";
 @import "octicons";

--- a/static/text.less
+++ b/static/text.less
@@ -1,0 +1,35 @@
+.text-bits (@type) {
+  @text-color: "text-color-@{type}";
+  @bg-color: "background-color-@{type}";
+
+  code {
+    color: @@text-color;
+    background: fadeout(@@bg-color, 80%);
+  }
+
+  a, a code {
+    color: @@text-color;
+    text-decoration: underline;
+    color: darken(@@text-color, 10%);
+
+    &:hover {
+      color: darken(@@text-color, 15%);
+    }
+  }
+}
+
+.text-info {
+  .text-bits(info);
+}
+
+.text-success {
+  .text-bits(success);
+}
+
+.text-warning {
+  .text-bits(warning);
+}
+
+.text-error {
+  .text-bits(error);
+}


### PR DESCRIPTION
They were unstyled. So this: 

![screen shot 2015-05-28 at 4 10 06 pm](https://cloud.githubusercontent.com/assets/69169/7873204/0fb108d8-0554-11e5-8cd2-743e54f03baa.png)

to this:

![screen shot 2015-05-28 at 4 10 16 pm](https://cloud.githubusercontent.com/assets/69169/7873206/12f27c48-0554-11e5-9425-9bd90ba476bb.png)

Maybe should go in the themes, but I wanted this to be in a central place. What do you think @simurai?
