### PR TITLE
Constrain length of invisible character strings in settings

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -805,7 +805,6 @@ describe "Config", ->
           atom.config.loadUserConfig()
           expect(atom.config.get("foo.bar")).toBe "baz"
 
-
     describe ".observeUserConfig()", ->
       updatedHandler = null
 

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1380,6 +1380,16 @@ describe "Config", ->
           expect(atom.config.set('foo.bar.aString', nope: 'nope')).toBe false
           expect(atom.config.get('foo.bar.aString')).toBe 'ok'
 
+        describe 'when the schema has a "maximumLength" key', ->
+          it "trims the string to be no longer than the specified maximum", ->
+            schema =
+              type: 'string'
+              default: 'ok'
+              maximumLength: 3
+            atom.config.setSchema('foo.bar.aString', schema)
+            atom.config.set('foo.bar.aString', 'abcdefg')
+            expect(atom.config.get('foo.bar.aString')).toBe 'abc'
+
       describe 'when the value has an "object" type', ->
         beforeEach ->
           schema =

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -179,15 +179,19 @@ module.exports =
           eol:
             type: ['boolean', 'string']
             default: '\u00ac'
+            maximumLength: 1
           space:
             type: ['boolean', 'string']
             default: '\u00b7'
+            maximumLength: 1
           tab:
             type: ['boolean', 'string']
             default: '\u00bb'
+            maximumLength: 1
           cr:
             type: ['boolean', 'string']
             default: '\u00a4'
+            maximumLength: 1
       zoomFontWhenCtrlScrolling:
         type: 'boolean'
         default: process.platform isnt 'darwin'

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1060,6 +1060,12 @@ Config.addSchemaEnforcers
         throw new Error("Validation failed at #{keyPath}, #{JSON.stringify(value)} must be a string")
       value
 
+    validateMaximumLength: (keyPath, value, schema) ->
+      if typeof schema.maximumLength is 'number' and value.length > schema.maximumLength
+        value.slice(0, schema.maximumLength)
+      else
+        value
+
   'null':
     # null sort of isnt supported. It will just unset in this case
     coerce: (keyPath, value, schema) ->


### PR DESCRIPTION
We don't currently support invisible character strings that exceed a single character. Previously, rendering went haywire when users specified strings that were longer. This PR disallows that.
