### PR TITLE
Introduce atom.directory-searcher service v0.1.0.

### DIFF
--- a/spec/task-spec.coffee
+++ b/spec/task-spec.coffee
@@ -70,3 +70,29 @@ describe "Task", ->
     task.terminate()
     expect(stdout.listeners('data').length).toBe 0
     expect(stderr.listeners('data').length).toBe 0
+
+  describe "::cancel()", ->
+    it "dispatches 'task:cancelled' when invoked on an active task", ->
+      task = new Task(require.resolve('./fixtures/task-spec-handler'))
+      cancelledEventSpy = jasmine.createSpy('eventSpy')
+      task.on('task:cancelled', cancelledEventSpy)
+      completedEventSpy = jasmine.createSpy('eventSpy')
+      task.on('task:completed', completedEventSpy)
+
+      expect(task.cancel()).toBe(true)
+      expect(cancelledEventSpy).toHaveBeenCalled()
+      expect(completedEventSpy).not.toHaveBeenCalled()
+
+    it "does not dispatch 'task:cancelled' when invoked on an inactive task", ->
+      handlerResult = null
+      task = Task.once require.resolve('./fixtures/task-spec-handler'), (result) ->
+        handlerResult = result
+
+      waitsFor ->
+        handlerResult?
+
+      runs ->
+        cancelledEventSpy = jasmine.createSpy('eventSpy')
+        task.on('task:cancelled', cancelledEventSpy)
+        expect(task.cancel()).toBe(false)
+        expect(cancelledEventSpy).not.toHaveBeenCalled()

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -1,6 +1,5 @@
 path = require 'path'
 temp = require 'temp'
-{Disposable} = require 'event-kit'
 Workspace = require '../src/workspace'
 Pane = require '../src/pane'
 {View} = require '../src/space-pen-extensions'

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -978,7 +978,8 @@ describe "Workspace", ->
               ]
             onFakeSearchCreated = (fakeSearch) ->
               fakeSearch.options.didMatch(searchResult)
-              fakeSearch.options.didSearchPaths(numPathsToPretendToSearchInCustomDirectorySearcher)
+              directory1 = atom.project.getDirectories()[atom.project.getPaths().indexOf(dir1)]
+              fakeSearch.options.didSearchPaths(directory1, numPathsToPretendToSearchInCustomDirectorySearcher)
               fakeSearch.hoistedResolve()
 
             resultPaths = []

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -1014,12 +1014,12 @@ describe "Workspace", ->
             cancelableSearch = atom.workspace.scan /aaaa/, ->
             fakeSearch.hoistedReject()
 
-            resultOfPromiseSearch = null
+            didReject = false
             waitsForPromise ->
-              cancelableSearch.then (promiseResult) -> resultOfPromiseSearch = promiseResult
+              cancelableSearch.catch -> didReject = true
 
             runs ->
-              expect(resultOfPromiseSearch).toBe('cancelled')
+              expect(didReject).toBe(true)
 
   describe "::replace(regex, replacementText, paths, iterator)", ->
     [filePath, commentFilePath, sampleContent, sampleCommentContent] = []

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -945,7 +945,7 @@ describe "Workspace", ->
             numPathsSearchedInDir2 = 1
             numPathsToPretendToSearchInCustomDirectorySearcher = 10
             class CustomDirectorySearch
-              constructor: () ->
+              constructor: ->
                 @promise = Promise.resolve()
               then: (args...) ->
                 @promise.then.apply(@promise, args)
@@ -997,7 +997,7 @@ describe "Workspace", ->
           it "can be cancelled by cancelling one of the DirectorySearchers", ->
             customDirectorySearcherPromiseInstance = null
             class CustomDirectorySearchToCancel
-              constructor: () ->
+              constructor: ->
                 # Note that hoisting reject in this way is generally frowned upon.
                 @promise = new Promise (resolve, reject) =>
                   @hoistedReject = reject

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -957,8 +957,8 @@ describe "Workspace", ->
                       range: [[0, 0], [0, 5]],
                     },
                   ]
-                delegate.onDidMatch(searchResult1)
-                delegate.onDidSearchPaths(numPathsToPretendToSearchInCustomDirectorySearcher)
+                delegate.didMatch(searchResult1)
+                delegate.didSearchPaths(numPathsToPretendToSearchInCustomDirectorySearcher)
               then: (args...) ->
                 @promise.then.apply(@promise, args)
               cancel: ->

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -952,7 +952,9 @@ describe "Workspace", ->
                 onFakeSearchCreated?(this)
             then: (args...) ->
               @promise.then.apply(@promise, args)
-            cancel: -> @cancelled = true
+            cancel: ->
+              @cancelled = true
+              @hoistedReject()
 
           beforeEach ->
             fakeSearch = null
@@ -978,8 +980,7 @@ describe "Workspace", ->
               ]
             onFakeSearchCreated = (fakeSearch) ->
               fakeSearch.options.didMatch(searchResult)
-              directory1 = atom.project.getDirectories()[atom.project.getPaths().indexOf(dir1)]
-              fakeSearch.options.didSearchPaths(directory1, numPathsToPretendToSearchInCustomDirectorySearcher)
+              fakeSearch.options.didSearchPaths(numPathsToPretendToSearchInCustomDirectorySearcher)
               fakeSearch.hoistedResolve()
 
             resultPaths = []

--- a/src/default-directory-searcher.coffee
+++ b/src/default-directory-searcher.coffee
@@ -1,0 +1,61 @@
+Task = require './task'
+
+# Default provider for the `atom.directory-searcher` service.
+module.exports =
+class DefaultDirectorySearcher
+  # Public: Determines whether this object supports search for a `Directory`.
+  #
+  # * `directory` {Directory} whose search needs might be supported by this object.
+  #
+  # Returns a `boolean` indicating whether this object can search this `Directory`.
+  canSearchDirectory: (directory) -> true
+
+  # Public: Performs a text search for files in the specified `Directory`, subject to the
+  # specified parameters.
+  #
+  # Results are streamed back to the caller via `recordSearchResult()` and `recordSearchError()`.
+  #
+  # * `directory` {Directory} that has been accepted by this provider's `canSearchDirectory()`
+  # predicate.
+  # * `regexSource` {String} regex to search with. Produced via `RegExp::source`.
+  # (Note this reflects the "Use Regex" option exposed via the ProjectFindView UI.)
+  # * `onSearchResult` {Function} Should be called with each matching search result.
+  #   * `searchResult` {Object} with the following keys:
+  #     * `filePath` {String} absolute path to the matching file.
+  #     * `matches` {Array} with object elements with the following keys:
+  #       * `lineText` {String} The full text of the matching line (without a line terminator character).
+  #       * `lineTextOffset` {Number} (This always seems to be 0?)
+  #       * `matchText` {String} The text that matched the `regex` used for the search.
+  #       * `range` {Range} Identifies the matching region in the file. (Likely as an array of numeric arrays.)
+  # * `onSearchError` {Function} Should be called to report a search error.
+  # * `onPathsSearched` {Function} callback that should be invoked periodically with the number of
+  # paths searched.
+  # * `options` {Object} with the following properties:
+  #   * `ignoreCase` {boolean}
+  #   * `inclusions` {Array} of glob patterns (as strings) to search within. Note that this
+  #   array may be empty, indicating that all files should be searched.
+  #
+  #   Each item in the array is a file/directory pattern, e.g., `src` to search in the "src"
+  #   directory or `*.js` to search all JavaScript files. In practice, this often comes from the
+  #   comma-delimited list of patterns in the bottom text input of the ProjectFindView dialog.
+  #   * `ignoreHidden` {boolean}
+  #   * `excludeVcsIgnores` {boolean}
+  #   * `exclusions` {Array} similar to inclusions
+  #   * `follow` {boolean} whether symlinks should be followed
+  #
+  # Returns a `Promise` that includes a `cancel()` method. If invoked before the `Proimse` is
+  # determined, it will reject the `Promise`.
+  search: (directory, regexSource, onSearchResult, onSearchError, onPathsSearched, options) ->
+    task = null
+    rootPaths = [directory.getPath()]
+    promise = new Promise (resolve, reject) ->
+      task = Task.once require.resolve('./scan-handler'), rootPaths, regexSource, options, resolve
+      task.on 'task:cancelled', reject
+    promise.cancel = ->
+      task.cancel()
+
+    task.on 'scan:result-found', onSearchResult
+    task.on 'scan:file-error', onSearchError
+    task.on 'scan:paths-searched', onPathsSearched
+
+    promise

--- a/src/default-directory-searcher.coffee
+++ b/src/default-directory-searcher.coffee
@@ -36,9 +36,9 @@ class DirectorySearch
       @task.on('task:cancelled', reject)
       emitter.once id, =>
         @task.start(rootPaths, options.regexSource, options, resolve)
-    @task.on 'scan:result-found', delegate.onDidMatch
-    @task.on 'scan:file-error', delegate.onDidError
-    @task.on 'scan:paths-searched', delegate.onDidSearchPaths
+    @task.on 'scan:result-found', delegate.didMatch
+    @task.on 'scan:file-error', delegate.didError
+    @task.on 'scan:paths-searched', delegate.didSearchPaths
 
   # Public: Implementation of `then()` to satisfy the *thenable* contract.
   # This makes it possible to use a `DirectorySearch` with `Promise.all()`.
@@ -72,7 +72,7 @@ class DefaultDirectorySearcher
   # * `directory` {Directory} that has been accepted by this provider's `canSearchDirectory()`
   # predicate.
   # * `delegate` {Object} with the following properties:
-  #   * `onDidMatch` {Function} call with a search result structured as follows:
+  #   * `didMatch` {Function} call with a search result structured as follows:
   #     * `searchResult` {Object} with the following keys:
   #       * `filePath` {String} absolute path to the matching file.
   #       * `matches` {Array} with object elements with the following keys:
@@ -80,8 +80,8 @@ class DefaultDirectorySearcher
   #         * `lineTextOffset` {Number} (This always seems to be 0?)
   #         * `matchText` {String} The text that matched the `regex` used for the search.
   #         * `range` {Range} Identifies the matching region in the file. (Likely as an array of numeric arrays.)
-  #   * `onDidError` {Function} call with an Error if there is a problem during the search.
-  #   * `onDidSearchPaths` {Function} periodically call with the number of paths searched thus far.
+  #   * `didError` {Function} call with an Error if there is a problem during the search.
+  #   * `didSearchPaths` {Function} periodically call with the number of paths searched thus far.
   # * `options` {Object} with the following properties:
   #   * `regexSource` {String} regex to search with. Produced via `RegExp::source`.
   #   * `ignoreCase` {boolean} reflects whether the regex should be run with the `i` option.

--- a/src/default-directory-searcher.coffee
+++ b/src/default-directory-searcher.coffee
@@ -76,7 +76,7 @@ class DefaultDirectorySearcher
   #   * `follow` {boolean} whether symlinks should be followed.
   #
   # Returns a *thenable* `DirectorySearch` that includes a `cancel()` method. If `cancel()` is
-  # invoked before the `DirectorySearch` is determined, it will reject the `DirectorySearch`.
+  # invoked before the `DirectorySearch` is determined, it will resolve the `DirectorySearch`.
   search: (directories, regex, options) ->
     rootPaths = directories.map (directory) -> directory.getPath()
     isCancelled = false

--- a/src/default-directory-searcher.coffee
+++ b/src/default-directory-searcher.coffee
@@ -8,9 +8,7 @@ class DirectorySearch
     @task = new Task(require.resolve('./scan-handler'))
     rootPaths = [directory.getPath()]
     @promise = new Promise (resolve, reject) =>
-      myResolve = (arg) ->
-        resolve(arg)
-      @task.start(rootPaths, options.regexSource, options, myResolve)
+      @task.start(rootPaths, options.regexSource, options, resolve)
       @task.on('task:cancelled', reject)
 
   # Public:

--- a/src/default-directory-searcher.coffee
+++ b/src/default-directory-searcher.coffee
@@ -1,32 +1,73 @@
+{EventEmitter} = require 'events'
 Task = require './task'
 
-# Public:
+# Maintain a queue of ids of searches to run. When a search is complete, the active
+# search is cleared and the next search (if any) in the queue is notified to run.
+# This ensures there is at most one scan-handler task running at a time.
+searchQueue = []
+nextId = 1
+activeSearchId = 0
+emitter = new EventEmitter
+
+onSearchFinished = () ->
+  activeSearchId = null
+  runNextSearch()
+
+runNextSearch = () ->
+  unless activeSearchId
+    activeSearchId = searchQueue.shift()
+    emitter.emit(activeSearchId, null) if activeSearchId
+
+enqueue = (id) ->
+  searchQueue.push(id)
+  runNextSearch()
+
+
+# Public: Searches local files for lines matching a specified regex.
+#
 # Implements thenable so it can be used with `Promise.all()`.
 class DirectorySearch
-  # Public:
-  constructor: (directory, options) ->
+  # Public: Creates a new DirectorySearch that will not start running until the
+  # `emitter` that is private to this file emits an event with the specified `id`.
+  constructor: (directory, options, id) ->
     @task = new Task(require.resolve('./scan-handler'))
     rootPaths = [directory.getPath()]
     @promise = new Promise (resolve, reject) =>
-      @task.start(rootPaths, options.regexSource, options, resolve)
       @task.on('task:cancelled', reject)
+      emitter.once id, =>
+        @task.start(rootPaths, options.regexSource, options, resolve)
 
-  # Public:
+  # Public: Implementation of `then()` to satisfy the *thenable* contract.
+  # This makes it possible to use a `DirectorySearch` with `Promise.all()`.
+  #
   # Returns `Promise`.
   then: (args...) ->
     @promise.then.apply(@promise, args)
 
-  # Public:
+  # Public: Get notified when a search result is found.
+  #
+  # * `callback` {Function} called with a search result structured as follows:
+  #   * `searchResult` {Object} with the following keys:
+  #     * `filePath` {String} absolute path to the matching file.
+  #     * `matches` {Array} with object elements with the following keys:
+  #       * `lineText` {String} The full text of the matching line (without a line terminator character).
+  #       * `lineTextOffset` {Number} (This always seems to be 0?)
+  #       * `matchText` {String} The text that matched the `regex` used for the search.
+  #       * `range` {Range} Identifies the matching region in the file. (Likely as an array of numeric arrays.)
+  #
   # Returns `Disposable`.
   onDidMatch: (callback) ->
     @task.on 'scan:result-found', callback
 
-  # Public:
+  # Public: Get notified about any search errors.
+  #
+  # * `callback` {Function} called with an Error if there is a problem during the search.
+  #
   # Returns `Disposable`.
   onDidError: (callback) ->
     @task.on 'scan:file-error', callback
 
-  # Public:
+  # Public: Get notified with the number of paths searched thus far.
   #
   # * `callback` {Function} called with the number of paths searched thus far.
   #
@@ -34,10 +75,11 @@ class DirectorySearch
   onDidSearchPaths: (callback) ->
     @task.on 'scan:paths-searched', callback
 
-  # Public:
+  # Public: Cancels the search.
   cancel: ->
     # This will cause @promise to reject.
     @task.cancel()
+    null
 
 
 # Default provider for the `atom.directory-searcher` service.
@@ -53,37 +95,31 @@ class DefaultDirectorySearcher
   # Public: Performs a text search for files in the specified `Directory`, subject to the
   # specified parameters.
   #
-  # Results are streamed back to the caller via `recordSearchResult()` and `recordSearchError()`.
+  # Results are streamed back to the caller by adding callbacks to the `DirectorySearch` returned by
+  # this method.
   #
   # * `directory` {Directory} that has been accepted by this provider's `canSearchDirectory()`
   # predicate.
-  # (Note this reflects the "Use Regex" option exposed via the ProjectFindView UI.)
-  # * `onSearchResult` {Function} Should be called with each matching search result.
-  #   * `searchResult` {Object} with the following keys:
-  #     * `filePath` {String} absolute path to the matching file.
-  #     * `matches` {Array} with object elements with the following keys:
-  #       * `lineText` {String} The full text of the matching line (without a line terminator character).
-  #       * `lineTextOffset` {Number} (This always seems to be 0?)
-  #       * `matchText` {String} The text that matched the `regex` used for the search.
-  #       * `range` {Range} Identifies the matching region in the file. (Likely as an array of numeric arrays.)
-  # * `onSearchError` {Function} Should be called to report a search error.
-  # * `onPathsSearched` {Function} callback that should be invoked periodically with the number of
-  # paths searched.
   # * `options` {Object} with the following properties:
   #   * `regexSource` {String} regex to search with. Produced via `RegExp::source`.
-  #   * `ignoreCase` {boolean}
+  #   * `ignoreCase` {boolean} reflects whether the regex should be run with the `i` option.
   #   * `inclusions` {Array} of glob patterns (as strings) to search within. Note that this
   #   array may be empty, indicating that all files should be searched.
   #
   #   Each item in the array is a file/directory pattern, e.g., `src` to search in the "src"
   #   directory or `*.js` to search all JavaScript files. In practice, this often comes from the
   #   comma-delimited list of patterns in the bottom text input of the ProjectFindView dialog.
-  #   * `ignoreHidden` {boolean}
-  #   * `excludeVcsIgnores` {boolean}
+  #   * `ignoreHidden` {boolean} whether to ignore hidden files.
+  #   * `excludeVcsIgnores` {boolean} whether to exclude VCS ignored paths.
   #   * `exclusions` {Array} similar to inclusions
-  #   * `follow` {boolean} whether symlinks should be followed
+  #   * `follow` {boolean} whether symlinks should be followed.
   #
-  # Returns a `DirectorySearch` that includes a `cancel()` method. If invoked before the `Proimse` is
-  # determined, it will reject the `Promise`.
+  # Returns a *thenable* `DirectorySearch` that includes a `cancel()` method. If `cancel()` is
+  # invoked before the `DirectorySearch` is determined, it will reject the `DirectorySearch`.
   search: (directory, options) ->
-    new DirectorySearch(directory, options)
+    id = nextId
+    nextId += 1
+    directorySearch = new DirectorySearch(directory, options, id)
+    directorySearch.then(onSearchFinished, onSearchFinished)
+    enqueue(id)
+    directorySearch

--- a/src/default-directory-searcher.coffee
+++ b/src/default-directory-searcher.coffee
@@ -9,11 +9,11 @@ nextId = 1
 activeSearchId = 0
 emitter = new EventEmitter
 
-onSearchFinished = () ->
+onSearchFinished = ->
   activeSearchId = null
   runNextSearch()
 
-runNextSearch = () ->
+runNextSearch = ->
   unless activeSearchId
     activeSearchId = searchQueue.shift()
     emitter.emit(activeSearchId, null) if activeSearchId

--- a/src/task.coffee
+++ b/src/task.coffee
@@ -150,7 +150,7 @@ class Task
   #
   # No more events are emitted once this method is called.
   terminate: ->
-    return unless @childProcess?
+    return false unless @childProcess?
 
     @childProcess.removeAllListeners()
     @childProcess.stdout.removeAllListeners()
@@ -158,4 +158,10 @@ class Task
     @childProcess.kill()
     @childProcess = null
 
-    undefined
+    true
+
+  cancel: ->
+    didForcefullyTerminate = @terminate()
+    if didForcefullyTerminate
+      @emit('task:cancelled')
+    didForcefullyTerminate

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -52,8 +52,6 @@ class Workspace extends Model
     atom.packages.serviceHub.consume(
       'atom.directory-searcher',
       '^0.1.0',
-      # New providers are added to the front of @directorySearchers because
-      # DefaultDirectorySearcher is a catch-all that will always claim to search a Directory.
       (provider) => @directorySearchers.unshift(provider))
 
     @panelContainers =

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -803,7 +803,8 @@ class Workspace extends Model
   #   * `onPathsSearched` (optional) {Function}
   # * `iterator` {Function} callback on each file found
   #
-  # Returns a `Promise`.
+  # Returns a *thenable* object with a `cancel()` method that will cancel all
+  # of the underlying searches that were started as part of this scan.
   scan: (regex, options={}, iterator) ->
     if _.isFunction(options)
       iterator = options

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -874,15 +874,18 @@ class Workspace extends Model
     # with the existing behavior, instead of cancel() rejecting the promise, it should
     # resolve it with the special value 'cancelled'. At least the built-in find-and-replace
     # package relies on this behavior.
+    isCancelled = false
     cancellablePromise = new Promise (resolve, reject) ->
       onSuccess = ->
         resolve(null)
-        return
       onFailure = ->
-        resolve('cancelled')
-        return
+        if isCancelled
+          resolve('cancelled')
+        else
+          reject()
       searchPromise.then(onSuccess, onFailure)
     cancellablePromise.cancel = ->
+      isCancelled = true
       # Note that cancelling all (or actually, any) of the members of allSearches
       # will cause searchPromise to reject, which will cause cancellablePromise to resolve
       # in the desired way.

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -855,7 +855,7 @@ class Workspace extends Model
       onPathsSearched = ->
 
     # Kick off all of the searches and unify them into one Promise.
-    allSearchPromises = []
+    allSearches = []
     disposables = new CompositeDisposable
     for entry in searchersAndDirectories
       {searcher, directory} = entry
@@ -864,8 +864,8 @@ class Workspace extends Model
       disposables.add(directorySearcher.onDidError(onSearchError))
       recordNumberOfPathsSearched = onPathsSearched.bind(undefined, directory)
       disposables.add(directorySearcher.onDidSearchPaths(recordNumberOfPathsSearched))
-      allSearchPromises.push(directorySearcher)
-    searchPromise = Promise.all(allSearchPromises)
+      allSearches.push(directorySearcher)
+    searchPromise = Promise.all(allSearches)
 
     # Make sure to clean up the disposables once the searchPromise is determined.
     disposeAll = (args...) ->
@@ -887,15 +887,15 @@ class Workspace extends Model
       onSuccess = ->
         resolve(null)
         return
-      onFailure	= ->
+      onFailure = ->
         resolve('cancelled')
         return
       searchPromise.then(onSuccess, onFailure)
     cancellablePromise.cancel = ->
-      # Note that cancelling all (or actually, any) of the members of allSearchPromises
+      # Note that cancelling all (or actually, any) of the members of allSearches
       # will cause searchPromise to reject, which will cause cancellablePromise to resolve
       # in the desired way.
-      promise.cancel() for promise in allSearchPromises
+      promise.cancel() for promise in allSearches
 
     # Although this method claims to return a `Promise`, the `ResultsPaneView.onSearch()`
     # method in the find-and-replace package expects the object returned by this method to have a

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -802,7 +802,7 @@ class Workspace extends Model
   #   * `onPathsSearched` (optional) {Function}
   # * `iterator` {Function} callback on each file found
   #
-  # Returns a *thenable* object with a `cancel()` method that will cancel all
+  # Returns a `Promise` with a `cancel()` method that will cancel all
   # of the underlying searches that were started as part of this scan.
   scan: (regex, options={}, iterator) ->
     if _.isFunction(options)

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -853,7 +853,7 @@ class Workspace extends Model
         didError: (error) ->
           iterator(null, error)
         didSearchPaths: onPathsSearched.bind(undefined, directory)
-      directorySearcher = searcher.search(directory, regex, searchOptions)
+      directorySearcher = searcher.search([directory], regex, searchOptions)
       allSearches.push(directorySearcher)
     searchPromise = Promise.all(allSearches)
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -830,12 +830,12 @@ class Workspace extends Model
       # replace the entry in the map and update the total.
       onPathsSearchedOption = options.onPathsSearched
       totalNumberOfPathsSearched = 0
-      numberOfPathsSearchedForDirectory = new Map()
+      numberOfPathsSearchedForSearcher = new Map()
       onPathsSearched = (searcher, numberOfPathsSearched) ->
-        oldValue = numberOfPathsSearchedForDirectory.get(searcher)
+        oldValue = numberOfPathsSearchedForSearcher.get(searcher)
         if oldValue
           totalNumberOfPathsSearched -= oldValue
-        numberOfPathsSearchedForDirectory.set(searcher, numberOfPathsSearched)
+        numberOfPathsSearchedForSearcher.set(searcher, numberOfPathsSearched)
         totalNumberOfPathsSearched += numberOfPathsSearched
         onPathsSearchedOption(totalNumberOfPathsSearched)
     else

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -833,9 +833,9 @@ class Workspace extends Model
 
     # Now that we are sure every Directory has a searcher, construct the search options.
     delegateProto = {
-      onDidMatch: (result) ->
+      didMatch: (result) ->
         iterator(result) unless atom.project.isPathModified(result.filePath)
-      onDidError: (error) ->
+      didError: (error) ->
         iterator(null, error)
     }
 
@@ -862,7 +862,7 @@ class Workspace extends Model
       {searcher, directory} = entry
       recordNumberOfPathsSearched = onPathsSearched.bind(undefined, directory)
       delegate = Object.create(delegateProto, {
-        onDidSearchPaths: {
+        didSearchPaths: {
           value: recordNumberOfPathsSearched,
         }
       })


### PR DESCRIPTION
The contract for a provider for the `atom.directory-searcher` service
is defined by the spec of the `DefaultDirectorySearcher`.

This modifies `Workspace::scan()` to use the appropriate `DirectorySearcher`
for each member of `atom.project.getDirectories()` when scanning the workspace
for files that match the specified regex.
