### PR TITLE
Include minor deprecations in 1.0 API mode

### DIFF
--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1158,6 +1158,7 @@ withoutEmptyObjects = (object) ->
     resultObject = object
   resultObject
 
+# TODO remove in 1.0 API
 Config::unobserve = (keyPath) ->
   Grim.deprecate 'Config::unobserve no longer does anything. Call `.dispose()` on the object returned by Config::observe instead.'
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1158,6 +1158,9 @@ withoutEmptyObjects = (object) ->
     resultObject = object
   resultObject
 
+Config::unobserve = (keyPath) ->
+  Grim.deprecate 'Config::unobserve no longer does anything. Call `.dispose()` on the object returned by Config::observe instead.'
+
 if Grim.includeDeprecatedAPIs
   EmitterMixin = require('emissary').Emitter
   EmitterMixin.includeInto(Config)
@@ -1206,9 +1209,6 @@ if Grim.includeDeprecatedAPIs
   Config::toggle = (keyPath) ->
     Grim.deprecate 'Config::toggle is no longer supported. Please remove from your code.'
     @set(keyPath, not @get(keyPath))
-
-  Config::unobserve = (keyPath) ->
-    Grim.deprecate 'Config::unobserve no longer does anything. Call `.dispose()` on the object returned by Config::observe instead.'
 
   Config::addScopedSettings = (source, selector, value, options) ->
     Grim.deprecate("Use ::set instead")

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -170,7 +170,7 @@ class Package
     if @mainModule?
       if @mainModule.config? and typeof @mainModule.config is 'object'
         atom.config.setSchema @name, {type: 'object', properties: @mainModule.config}
-      else if includeDeprecatedAPIs and @mainModule.configDefaults? and typeof @mainModule.configDefaults is 'object'
+      else if @mainModule.configDefaults? and typeof @mainModule.configDefaults is 'object'
         deprecate("""Use a config schema instead. See the configuration section
         of https://atom.io/docs/latest/hacking-atom-package-word-count and
         https://atom.io/docs/api/latest/Config for more details""", {packageName: @name})

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -277,7 +277,7 @@ class Package
       [stylesheetPath, atom.themes.loadStylesheet(stylesheetPath, true)]
 
   getStylesheetsPath: ->
-    if includeDeprecatedAPIs and fs.isDirectorySync(path.join(@path, 'stylesheets'))
+    if fs.isDirectorySync(path.join(@path, 'stylesheets'))
       deprecate("Store package style sheets in the `styles/` directory instead of `stylesheets/` in the `#{@name}` package", packageName: @name)
       path.join(@path, 'stylesheets')
     else
@@ -353,7 +353,7 @@ class Package
 
     deferred = Q.defer()
 
-    if includeDeprecatedAPIs and fs.isDirectorySync(path.join(@path, 'scoped-properties'))
+    if fs.isDirectorySync(path.join(@path, 'scoped-properties'))
       settingsDirPath = path.join(@path, 'scoped-properties')
       deprecate("Store package settings files in the `settings/` directory instead of `scoped-properties/`", packageName: @name)
     else

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -203,16 +203,15 @@ class Package
       try
         itemsBySelector = map['context-menu']
 
-        if includeDeprecatedAPIs
-          # Detect deprecated format for items object
-          for key, value of itemsBySelector
-            unless _.isArray(value)
-              deprecate("""
-                The context menu CSON format has changed. Please see
-                https://atom.io/docs/api/latest/ContextMenuManager#context-menu-cson-format
-                for more info.
-              """, {packageName: @name})
-              itemsBySelector = atom.contextMenu.convertLegacyItemsBySelector(itemsBySelector)
+        # Detect deprecated format for items object
+        for key, value of itemsBySelector
+          unless _.isArray(value)
+            deprecate("""
+              The context menu CSON format has changed. Please see
+              https://atom.io/docs/api/latest/ContextMenuManager#context-menu-cson-format
+              for more info.
+            """, {packageName: @name})
+            itemsBySelector = atom.contextMenu.convertLegacyItemsBySelector(itemsBySelector)
 
         @activationDisposables.add(atom.contextMenu.add(itemsBySelector))
       catch error

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -489,7 +489,7 @@ class Package
         else if _.isArray(commands)
           @activationCommands[selector].push(commands...)
 
-    if includeDeprecatedAPIs and @metadata.activationEvents?
+    if @metadata.activationEvents?
       deprecate("""
         Use `activationCommands` instead of `activationEvents` in your package.json
         Commands should be grouped by selector as follows:


### PR DESCRIPTION
Keep deprecating but don't remove certain minor deprecations that are easy to keep supporting for a little while longer and don't slow down Atom:
- Loading stylesheets from `stylesheets/` (now `styles/`)
- Loading settings from `scope-properties/` (now `settings/`)
- `activationEvents` in `package.json` (now `activationCommands`)
- `configDefaults` in package main (now `config`)
- `atom.config.unobserve` API (currently a no-op)
- Old `context-menu` format

This is an effort to not break packages that have very minor deprecations.

Refs #6867 
