### PR TITLE
Catch read errors during deserialization

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1,3 +1,6 @@
+fs = require 'fs-plus'
+path = require 'path'
+temp = require 'temp'
 clipboard = require '../src/safe-clipboard'
 TextEditor = require '../src/text-editor'
 
@@ -19,6 +22,17 @@ describe "TextEditor", ->
       atom.packages.activatePackage('language-javascript')
 
   describe "when the editor is deserialized", ->
+    it "returns undefined when the path cannot be read", ->
+      pathToOpen = path.join(temp.mkdirSync(), 'file.txt')
+      editor1 = null
+
+      waitsForPromise ->
+        atom.project.open(pathToOpen).then (o) -> editor1 = o
+
+      runs ->
+        fs.mkdirSync(pathToOpen)
+        expect(editor1.testSerialization()).toBeUndefined()
+
     it "restores selections and folds based on markers in the buffer", ->
       editor.setSelectedBufferRange([[1, 2], [3, 4]])
       editor.addSelectionForBufferRange([[5, 6], [7, 5]], reversed: true)

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -16,6 +16,19 @@ describe "Workspace", ->
     atom.project.setPaths([atom.project.getDirectories()[0]?.resolve('dir')])
     atom.workspace = workspace = new Workspace
 
+  describe "serialization", ->
+    it "does not deserialize text editors for files that can't be read", ->
+      pathToOpen = path.join(temp.mkdirSync(), 'file.txt')
+
+      waitsForPromise ->
+        workspace.open(pathToOpen)
+
+      runs ->
+        expect(workspace.getPaneItems().length).toBe 1
+        fs.mkdirSync(pathToOpen)
+        deserializedWorkspace = atom.workspace.testSerialization()
+        expect(deserializedWorkspace.getPaneItems().length).toBe 0
+
   describe "::open(uri, options)", ->
     openEvents = null
 

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -16,19 +16,6 @@ describe "Workspace", ->
     atom.project.setPaths([atom.project.getDirectories()[0]?.resolve('dir')])
     atom.workspace = workspace = new Workspace
 
-  describe "serialization", ->
-    it "does not deserialize text editors for files that can't be read", ->
-      pathToOpen = path.join(temp.mkdirSync(), 'file.txt')
-
-      waitsForPromise ->
-        workspace.open(pathToOpen)
-
-      runs ->
-        expect(workspace.getPaneItems().length).toBe 1
-        fs.mkdirSync(pathToOpen)
-        deserializedWorkspace = atom.workspace.testSerialization()
-        expect(deserializedWorkspace.getPaneItems().length).toBe 0
-
   describe "::open(uri, options)", ->
     openEvents = null
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -128,7 +128,15 @@ class TextEditor extends Model
     displayBuffer: @displayBuffer.serialize()
 
   deserializeParams: (params) ->
-    params.displayBuffer = DisplayBuffer.deserialize(params.displayBuffer)
+    try
+      displayBuffer = DisplayBuffer.deserialize(params.displayBuffer)
+    catch error
+      if error.syscall is 'read'
+        return # Error reading the file, don't deserialize an editor for it
+      else
+        throw error
+
+    params.displayBuffer = displayBuffer
     params.registerEditor = true
     params
 


### PR DESCRIPTION
Prevents Atom from failing to open because of a read error with a serialized editor.

Closes #6955
