### PR TITLE
Load large files in background

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -40,6 +40,14 @@ describe "DisplayBuffer", ->
       displayBuffer2.unfoldBufferRow(3)
       expect(displayBuffer2.isFoldedAtBufferRow(3)).not.toBe displayBuffer.isFoldedAtBufferRow(3)
 
+  describe "when the constructed with largeFileMode: true", ->
+    it "invokes onDidLoad listeners once the file is fully loaded", ->
+      displayBuffer = new DisplayBuffer({buffer, tabLength, largeFileMode: true})
+      waitsFor "display buffer to load", (done) -> displayBuffer.onDidLoad(done)
+      runs ->
+        expect(displayBuffer.tokenizedLineForScreenRow(0).text).toBe buffer.lineForRow(0)
+        expect(displayBuffer.tokenizedLineForScreenRow(12).text).toBe buffer.lineForRow(12)
+
   describe "when the buffer changes", ->
     it "renders line numbers correctly", ->
       originalLineCount = displayBuffer.getLineCount()

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -41,12 +41,29 @@ describe "DisplayBuffer", ->
       expect(displayBuffer2.isFoldedAtBufferRow(3)).not.toBe displayBuffer.isFoldedAtBufferRow(3)
 
   describe "when the constructed with largeFileMode: true", ->
-    it "invokes onDidLoad listeners once the file is fully loaded", ->
+    it "reports the progress of the load", ->
       displayBuffer = new DisplayBuffer({buffer, tabLength, largeFileMode: true})
-      waitsFor "display buffer to load", (done) -> displayBuffer.onDidLoad(done)
+      expect(displayBuffer.getLoadProgress()).toBe 0
+
+      waitsFor "display buffer to load", (done) ->
+        displayBuffer.onDidChangeLoadProgress (progress) ->
+          done() if progress is 1
+
       runs ->
+        expect(displayBuffer.getLoadProgress()).toBe 1
         expect(displayBuffer.tokenizedLineForScreenRow(0).text).toBe buffer.lineForRow(0)
         expect(displayBuffer.tokenizedLineForScreenRow(12).text).toBe buffer.lineForRow(12)
+
+        reportedProgress = null
+        displayBuffer.onDidChangeLoadProgress (progress) -> reportedProgress = progress
+        displayBuffer.setTabLength(6)
+
+        expect(reportedProgress).toBe 0
+        expect(displayBuffer.getLoadProgress()).toBe 0
+
+      waitsFor "display buffer to reload", (done) ->
+        displayBuffer.onDidChangeLoadProgress (progress) ->
+          done() if progress is 1
 
   describe "when the buffer changes", ->
     it "renders line numbers correctly", ->

--- a/spec/fixtures/task-spec-handler.coffee
+++ b/spec/fixtures/task-spec-handler.coffee
@@ -1,3 +1,4 @@
 module.exports = ->
   emit("some-event", 1, 2, 3)
+  @emit("some-other-event", 4, 5, 6)
   'hello'

--- a/spec/task-spec.coffee
+++ b/spec/task-spec.coffee
@@ -25,13 +25,17 @@ describe "Task", ->
   it "calls listeners registered with ::on when events are emitted in the task", ->
     task = new Task(require.resolve('./fixtures/task-spec-handler'))
 
-    eventSpy = jasmine.createSpy('eventSpy')
-    task.on("some-event", eventSpy)
+    events = []
+    task.on "some-event", (args...) -> events.push(["some-event", args...])
+    task.on "some-other-event", (args...) -> events.push(["some-other-event", args...])
 
     waitsFor (done) -> task.start(done)
 
     runs ->
-      expect(eventSpy).toHaveBeenCalledWith(1, 2, 3)
+      expect(events).toEqual [
+        ["some-event", 1, 2, 3]
+        ["some-other-event", 4, 5, 6]
+      ]
 
   it "unregisters listeners when the Disposable returned by ::on is disposed", ->
     task = new Task(require.resolve('./fixtures/task-spec-handler'))

--- a/spec/text-editor-loader-spec.coffee
+++ b/spec/text-editor-loader-spec.coffee
@@ -1,0 +1,14 @@
+describe "TextEditorLoader", ->
+  it "replaces itself with the editor being loaded once loading is complete", ->
+    loader = null
+    atom.project.largeFileThreshhold = 0
+    waitsForPromise -> atom.workspace.open('sample.js').then (l) -> loader = l
+
+    runs ->
+      expect(atom.workspace.getActivePaneItem()).toBe(loader)
+
+    waitsFor "text editor to load", (done) ->
+      loader.editor.onDidLoad(done)
+
+    runs ->
+      expect(atom.workspace.getActivePane().getItems()).toEqual [loader.editor]

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -66,6 +66,22 @@ describe "TextEditor", ->
 
       expect(editor.tokenizedLineForScreenRow(0).invisibles.eol).toBe '?'
 
+  describe "when the editor is constructed in large file mode", ->
+    it "defers final construction until the file is loaded", ->
+      [buffer, editor] = []
+
+      waitsForPromise ->
+        atom.project.bufferForPath('sample.js').then (b) ->
+          buffer = b
+          editor = new TextEditor({buffer, largeFileMode: true})
+
+      waitsFor "editor to finish loading", (done) ->
+        editor.onDidLoad(done)
+
+      runs ->
+        expect(editor.tokenizedLineForScreenRow(0).text).toBe buffer.lineForRow(0)
+        expect(editor.tokenizedLineForScreenRow(12).text).toBe buffer.lineForRow(12)
+
   describe "when the editor is constructed with an initialLine option", ->
     it "positions the cursor on the specified line", ->
       editor = null

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -76,7 +76,7 @@ describe "TextEditor", ->
           editor = new TextEditor({buffer, largeFileMode: true})
 
       waitsFor "editor to finish loading", (done) ->
-        editor.onDidLoad(done)
+        editor.onDidChangeLoadProgress (progress) -> done() if progress is 1
 
       runs ->
         expect(editor.tokenizedLineForScreenRow(0).text).toBe buffer.lineForRow(0)

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -26,8 +26,8 @@ describe "TokenizedBuffer", ->
     advanceClock() while tokenizedBuffer.firstInvalidRow()?
     changeHandler?.reset()
 
-  describe "when constructed with the 'loadAsync' option set to true", ->
-    it "streams the initial placeholder lines from a background task and reports on progress", ->
+  describe "when constructed with largeFileMode: true", ->
+    it "constructs the initial placeholder lines in a background process", ->
       TokenizedBuffer::chunkSize = 2
       buffer = atom.project.bufferForPathSync('sample.js')
       syncTokenizedBuffer = new TokenizedBuffer({buffer})

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -28,16 +28,25 @@ describe "TokenizedBuffer", ->
 
   describe "when constructed with largeFileMode: true", ->
     it "constructs the initial placeholder lines in a background process", ->
-      TokenizedBuffer::chunkSize = 2
+      TokenizedBuffer::initialLinesChunkSize = 2
       buffer = atom.project.bufferForPathSync('sample.js')
       syncTokenizedBuffer = new TokenizedBuffer({buffer})
       syncTokenizedBuffer.setGrammar(atom.grammars.nullGrammar)
       asyncTokenizedBuffer = new TokenizedBuffer({buffer, largeFileMode: true})
 
+      expect(asyncTokenizedBuffer.getLoadProgress()).toBe 0
+
+      progressCount = 0
+      asyncTokenizedBuffer.onDidChangeLoadProgress (progress) ->
+        expect(asyncTokenizedBuffer.getLoadProgress()).toBe progress
+        expect(progress).toBeGreaterThan 0
+        progressCount++
+
       waitsFor 'load to complete', (done) ->
         asyncTokenizedBuffer.onDidLoad(done)
 
       runs ->
+        expect(progressCount).toBe 5
         expectSameLineStates(
           asyncTokenizedBuffer.tokenizedLines,
           syncTokenizedBuffer.tokenizedLines

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -31,7 +31,6 @@ describe "TokenizedBuffer", ->
       TokenizedBuffer::initialLinesChunkSize = 2
       buffer = atom.project.bufferForPathSync('sample.js')
       syncTokenizedBuffer = new TokenizedBuffer({buffer})
-      syncTokenizedBuffer.setGrammar(atom.grammars.nullGrammar)
       asyncTokenizedBuffer = new TokenizedBuffer({buffer, largeFileMode: true})
 
       expect(asyncTokenizedBuffer.getLoadProgress()).toBe 0

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -42,7 +42,8 @@ describe "TokenizedBuffer", ->
         progressCount++
 
       waitsFor 'load to complete', (done) ->
-        asyncTokenizedBuffer.onDidLoad(done)
+        asyncTokenizedBuffer.onDidChangeLoadProgress (progress) ->
+          done() if progress is 1
 
       runs ->
         expect(asyncTokenizedBuffer.getLoadProgress()).toBe 1

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -122,6 +122,9 @@ class DisplayBuffer extends Model
   onDidLoad: (callback) ->
     @tokenizedBuffer.onDidLoad(callback)
 
+  onDidChangeLoadProgress: (callback) ->
+    @tokenizedBuffer.onDidChangeLoadProgress(callback)
+
   getLoadProgress: ->
     @tokenizedBuffer.getLoadProgress()
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -122,6 +122,9 @@ class DisplayBuffer extends Model
   onDidLoad: (callback) ->
     @tokenizedBuffer.onDidLoad(callback)
 
+  getLoadProgress: ->
+    @tokenizedBuffer.getLoadProgress()
+
   onDidTokenize: (callback) ->
     @tokenizedBuffer.onDidTokenize(callback)
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -24,13 +24,13 @@ class DisplayBuffer extends Model
   horizontalScrollMargin: 6
   scopedCharacterWidthsChangeCount: 0
 
-  constructor: ({tabLength, @editorWidthInChars, @tokenizedBuffer, buffer, ignoreInvisibles, @largeFileMode}={}) ->
+  constructor: ({tabLength, @editorWidthInChars, @tokenizedBuffer, buffer, ignoreInvisibles, largeFileMode}={}) ->
     super
 
     @emitter = new Emitter
     @disposables = new CompositeDisposable
 
-    @tokenizedBuffer ?= new TokenizedBuffer({tabLength, buffer, ignoreInvisibles, @largeFileMode})
+    @tokenizedBuffer ?= new TokenizedBuffer({tabLength, buffer, ignoreInvisibles, largeFileMode})
     @buffer = @tokenizedBuffer.buffer
     @charWidthsByScope = {}
     @markers = {}
@@ -41,12 +41,11 @@ class DisplayBuffer extends Model
     @disposables.add @tokenizedBuffer.onDidChange @handleTokenizedBufferChange
     @disposables.add @buffer.onDidCreateMarker @handleBufferMarkerCreated
     @foldMarkerAttributes = Object.freeze({class: 'fold', displayBufferId: @id})
-    if @largeFileMode
-      @tokenizedBuffer.onDidLoad(=> @finalizeConstruction())
-    else
-      @finalizeConstruction()
 
-  finalizeConstruction: ->
+    @tokenizedBuffer.onDidChangeLoadProgress (loadProgress) => @tokenizedBufferDidLoad() if loadProgress is 1
+    @tokenizedBufferDidLoad() if @tokenizedBuffer.getLoadProgress() is 1
+
+  tokenizedBufferDidLoad: ->
     folds = (new Fold(this, marker) for marker in @buffer.findMarkers(@getFoldMarkerAttributes()))
     @updateAllScreenLines()
     @decorateFold(fold) for fold in folds
@@ -118,9 +117,6 @@ class DisplayBuffer extends Model
 
   onDidChangeGrammar: (callback) ->
     @tokenizedBuffer.onDidChangeGrammar(callback)
-
-  onDidLoad: (callback) ->
-    @tokenizedBuffer.onDidLoad(callback)
 
   onDidChangeLoadProgress: (callback) ->
     @tokenizedBuffer.onDidChangeLoadProgress(callback)

--- a/src/initial-tokenized-lines-task.coffee
+++ b/src/initial-tokenized-lines-task.coffee
@@ -1,0 +1,31 @@
+fs = require 'fs'
+TextBuffer = require 'text-buffer'
+TokenizedLine = require './tokenized-line'
+
+module.exports = ({filePath, tabLength, invisibles, rootScopeId}) ->
+  done = @async()
+
+  buffer = new TextBuffer({filePath})
+  buffer.load().then =>
+    lines = []
+    openScopes = [rootScopeId]
+    indentLevel = 0
+    lastLineEmpty = false
+
+    for row in [0..buffer.getLastRow()] by 1
+      text = buffer.lineForRow(row)
+      tags = [text.length]
+      lineEnding = buffer.lineEndingForRow(row)
+      line = new TokenizedLine({openScopes, text, tags, tabLength, indentLevel, invisibles, lineEnding})
+
+      newIndentLevel = Math.ceil(line.indentLevel)
+      if lastLineEmpty and newIndentLevel > indentLevel
+        for previousLine in lines by -1
+          break unless previousLine.text.length is 0
+          previousLine.indentLevel = newIndentLevel
+
+      indentLevel = newIndentLevel
+      lastLineEmpty = line.text.length is 0
+      lines.push(line)
+
+    done(lines)

--- a/src/initial-tokenized-lines-task.coffee
+++ b/src/initial-tokenized-lines-task.coffee
@@ -12,7 +12,8 @@ module.exports = ({filePath, tabLength, invisibles, rootScopeId, chunkSize}) ->
     indentLevel = 0
     lastLineEmpty = false
 
-    for row in [0..buffer.getLastRow()] by 1
+    rowCount = buffer.getLastRow()
+    for row in [0..rowCount] by 1
       text = buffer.lineForRow(row)
       tags = [text.length]
       lineEnding = buffer.lineEndingForRow(row)
@@ -29,8 +30,8 @@ module.exports = ({filePath, tabLength, invisibles, rootScopeId, chunkSize}) ->
 
       currentChunk.push(line)
       if currentChunk.length > chunkSize and not lastLineEmpty
-        @emit 'chunk', currentChunk
+        @emit 'progress', {lines: currentChunk, progress: row / rowCount}
         currentChunk.length = 0
 
-    @emit 'chunk', currentChunk
+    @emit 'progress', {lines: currentChunk, progress: 1}
     done()

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -12,6 +12,8 @@ PaneAxisElement = require './pane-axis-element'
 PaneAxis = require './pane-axis'
 TextEditor = require './text-editor'
 TextEditorElement = require './text-editor-element'
+TextEditorLoader = require './text-editor-loader'
+TextEditorLoaderElement = require './text-editor-loader-element'
 ItemRegistry = require './item-registry'
 
 module.exports =
@@ -63,6 +65,8 @@ class PaneContainer extends Model
     atom.views.addViewProvider TextEditor, (model) ->
       new TextEditorElement().initialize(model)
     atom.views.addViewProvider(Gutter, createGutterView)
+    atom.views.addViewProvider TextEditorLoader, (model) ->
+      new TextEditorLoaderElement().initialize(model)
 
   onDidChangeRoot: (fn) ->
     @emitter.on 'did-change-root', fn

--- a/src/special-token-symbols.coffee
+++ b/src/special-token-symbols.coffee
@@ -1,6 +1,6 @@
 module.exports = {
-  SoftTab: Symbol('SoftTab')
-  HardTab: Symbol('HardTab')
-  PairedCharacter: Symbol('PairedCharacter')
-  SoftWrapIndent: Symbol('SoftWrapIndent')
+  SoftTab: 0
+  HardTab: 1
+  PairedCharacter: 2
+  SoftWrapIndent: 3
 }

--- a/src/task-bootstrap.coffee
+++ b/src/task-bootstrap.coffee
@@ -38,7 +38,7 @@ handleEvents = ->
       isAsync = true
       (result) ->
         emit('task:completed', result)
-    result = handler.bind({async})(args...)
+    result = handler.bind({async, emit})(args...)
     emit('task:completed', result) unless isAsync
 
 setupDeprecations = ->

--- a/src/text-editor-loader-element.coffee
+++ b/src/text-editor-loader-element.coffee
@@ -1,11 +1,9 @@
 class TextEditorLoaderElement extends HTMLElement
   createdCallback: ->
-    progressBar = document.createElement('div')
-    progressBar.classList.add('progress-bar')
-    @progressIndicator = document.createElement('div')
-    @progressIndicator.classList.add('progress-indicator')
-    progressBar.appendChild(@progressIndicator)
-    @appendChild(progressBar)
+    @progressElement = document.createElement('progress')
+    @progressElement.setAttribute('max', 100)
+    @progressElement.setAttribute('value', 0)
+    @appendChild(@progressElement)
 
   attachedCallback: ->
     @initialize(@model) if @model?
@@ -19,7 +17,7 @@ class TextEditorLoaderElement extends HTMLElement
     this
 
   updateProgress: (progress) ->
-    @progressIndicator.style.width = "#{Math.round(progress * 100)}%"
+    @progressElement.setAttribute('value', Math.round(progress * 100))
 
 module.exports = TextEditorLoaderElement = document.registerElement 'atom-text-editor-loader',
   prototype: TextEditorLoaderElement.prototype

--- a/src/text-editor-loader-element.coffee
+++ b/src/text-editor-loader-element.coffee
@@ -1,0 +1,25 @@
+class TextEditorLoaderElement extends HTMLElement
+  createdCallback: ->
+    progressBar = document.createElement('div')
+    progressBar.classList.add('progress-bar')
+    @progressIndicator = document.createElement('div')
+    @progressIndicator.classList.add('progress-indicator')
+    progressBar.appendChild(@progressIndicator)
+    @appendChild(progressBar)
+
+  attachedCallback: ->
+    @initialize(@model) if @model?
+
+  detachedCallback: ->
+    @modelSubscription.dispose()
+
+  initialize: (@model) ->
+    @updateProgress(@model.getLoadProgress())
+    @modelSubscription = @model.onDidChangeLoadProgress(@updateProgress.bind(this))
+    this
+
+  updateProgress: (progress) ->
+    @progressIndicator.style.width = "#{Math.round(progress * 100)}%"
+
+module.exports = TextEditorLoaderElement = document.registerElement 'atom-text-editor-loader',
+  prototype: TextEditorLoaderElement.prototype

--- a/src/text-editor-loader.coffee
+++ b/src/text-editor-loader.coffee
@@ -14,7 +14,8 @@ class TextEditorLoader
   getTitle: ->
     @editor.getTitle()
 
-atom.views.addViewProvider TextEditorLoader, (loader) ->
-  node = document.createElement("div")
-  node.textContent = "Loading #{loader.getTitle()}..."
-  node
+  getLoadProgress: ->
+    @editor.getLoadProgress()
+
+  onDidChangeLoadProgress: (callback) ->
+    @editor.onDidChangeLoadProgress(callback)

--- a/src/text-editor-loader.coffee
+++ b/src/text-editor-loader.coffee
@@ -1,0 +1,20 @@
+module.exports =
+class TextEditorLoader
+  constructor: (@editor) ->
+    @loadDisposable = @editor.onDidLoad => @finishLoading()
+
+  finishLoading: ->
+    @loadDisposable.dispose()
+
+    pane = atom.workspace.paneForItem(this)
+    myIndex = pane.getItems().indexOf(this)
+    pane.addItem(@editor, myIndex + 1)
+    pane.destroyItem(this)
+
+  getTitle: ->
+    @editor.getTitle()
+
+atom.views.addViewProvider TextEditorLoader, (loader) ->
+  node = document.createElement("div")
+  node.textContent = "Loading #{loader.getTitle()}..."
+  node

--- a/src/text-editor-loader.coffee
+++ b/src/text-editor-loader.coffee
@@ -1,7 +1,8 @@
 module.exports =
 class TextEditorLoader
   constructor: (@editor) ->
-    @loadDisposable = @editor.onDidLoad => @finishLoading()
+    @loadDisposable = @editor.onDidChangeLoadProgress (progress) =>
+      @finishLoading() if progress is 1
 
   finishLoading: ->
     @loadDisposable.dispose()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -87,8 +87,6 @@ class TextEditor extends Model
 
     buffer ?= new TextBuffer
 
-    @largeFileMode ?= buffer?.getLineCount() > 10000
-
     @displayBuffer ?= new DisplayBuffer({buffer, tabLength, softWrapped, ignoreInvisibles: @mini, @largeFileMode})
     @buffer = @displayBuffer.buffer
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -469,12 +469,15 @@ class TextEditor extends Model
   onDidChangeScrollLeft: (callback) ->
     @emitter.on 'did-change-scroll-left', callback
 
-  onDidLoad: (callback) ->
-    @displayBuffer.onDidLoad(callback)
-
   # TODO Remove once the tabs package no longer uses .on subscriptions
   onDidChangeIcon: (callback) ->
     @emitter.on 'did-change-icon', callback
+
+  onDidLoad: (callback) ->
+    @displayBuffer.onDidLoad(callback)
+
+  getLoadProgress: ->
+    @displayBuffer.getLoadProgress()
 
   # Public: Retrieves the current {TextBuffer}.
   getBuffer: -> @buffer

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -476,6 +476,9 @@ class TextEditor extends Model
   onDidLoad: (callback) ->
     @displayBuffer.onDidLoad(callback)
 
+  onDidChangeLoadProgress: (callback) ->
+    @displayBuffer.onDidChangeLoadProgress(callback)
+
   getLoadProgress: ->
     @displayBuffer.getLoadProgress()
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -76,8 +76,8 @@ class TextEditor extends Model
     toProperty: 'languageMode'
 
   constructor: (params={}) ->
-    {@softTabs, tabLength, softWrapped, @displayBuffer, buffer} = params
-    {@mini, @placeholderText, @largeFileMode} = params
+    {softTabs, tabLength, softWrapped, @displayBuffer, buffer} = params
+    {@mini, @placeholderText, largeFileMode, lineNumberGutterVisible} = params
     super
 
     @emitter = new Emitter
@@ -86,49 +86,37 @@ class TextEditor extends Model
     @selections = []
 
     buffer ?= new TextBuffer
-
-    @displayBuffer ?= new DisplayBuffer({buffer, tabLength, softWrapped, ignoreInvisibles: @mini, @largeFileMode})
+    @displayBuffer ?= new DisplayBuffer({buffer, tabLength, softWrapped, ignoreInvisibles: @mini, largeFileMode})
     @buffer = @displayBuffer.buffer
-
-    if @largeFileMode
-      @displayBuffer.onDidLoad(=> @finalizeConstruction(params))
-    else
-      @finalizeConstruction(params)
-
-  finalizeConstruction: (params) ->
-    {initialLine, initialColumn, registerEditor, suppressCursorCreation, lineNumberGutterVisible} = params
-
-    @softTabs = @usesSoftTabs() ? @softTabs ? atom.config.get('editor.softTabs') ? true
-
-    for marker in @findMarkers(@getSelectionMarkerAttributes())
-      marker.setProperties(preserveFolds: true)
-      @addSelection(marker)
-
-    @subscribeToBuffer()
-    @subscribeToDisplayBuffer()
-
-    if @getCursors().length is 0 and not suppressCursorCreation
-      initialLine = Math.max(parseInt(initialLine) or 0, 0)
-      initialColumn = Math.max(parseInt(initialColumn) or 0, 0)
-      @addCursorAtBufferPosition([initialLine, initialColumn])
-
     @languageMode = new LanguageMode(this)
-
-    @setEncoding(atom.config.get('core.fileEncoding', scope: @getRootScopeDescriptor()))
-
-    @disposables.add @displayBuffer.onDidChangeScrollTop (scrollTop) =>
-      @emit 'scroll-top-changed', scrollTop if includeDeprecatedAPIs
-      @emitter.emit 'did-change-scroll-top', scrollTop
-
-    @disposables.add @displayBuffer.onDidChangeScrollLeft (scrollLeft) =>
-      @emit 'scroll-left-changed', scrollLeft if includeDeprecatedAPIs
-      @emitter.emit 'did-change-scroll-left', scrollLeft
-
     @gutterContainer = new GutterContainer(this)
     @lineNumberGutter = @gutterContainer.addGutter
       name: 'line-number'
       priority: 0
       visible: lineNumberGutterVisible
+
+    @subscribeToBuffer()
+    @subscribeToDisplayBuffer()
+
+    @setEncoding(atom.config.get('core.fileEncoding', scope: @getRootScopeDescriptor()))
+
+    @displayBuffer.onDidChangeLoadProgress (loadProgress) =>
+      @finalizeConstruction(params) if loadProgress is 1
+    @finalizeConstruction(params) if @displayBuffer.getLoadProgress() is 1
+
+  finalizeConstruction: (params) ->
+    {softTabs, registerEditor, initialLine, initialColumn, suppressCursorCreation} = params
+
+    @softTabs = @usesSoftTabs() ? softTabs ? atom.config.get('editor.softTabs') ? true
+
+    for marker in @findMarkers(@getSelectionMarkerAttributes())
+      marker.setProperties(preserveFolds: true)
+      @addSelection(marker)
+
+    if @getCursors().length is 0 and not suppressCursorCreation
+      initialLine = Math.max(parseInt(initialLine) or 0, 0)
+      initialColumn = Math.max(parseInt(initialColumn) or 0, 0)
+      @addCursorAtBufferPosition([initialLine, initialColumn])
 
     atom.workspace?.editorAdded(this) if registerEditor
 
@@ -181,6 +169,12 @@ class TextEditor extends Model
     @disposables.add @displayBuffer.onDidChange (e) =>
       @emit 'screen-lines-changed', e if includeDeprecatedAPIs
       @emitter.emit 'did-change', e
+    @disposables.add @displayBuffer.onDidChangeScrollTop (scrollTop) =>
+      @emit 'scroll-top-changed', scrollTop if includeDeprecatedAPIs
+      @emitter.emit 'did-change-scroll-top', scrollTop
+    @disposables.add @displayBuffer.onDidChangeScrollLeft (scrollLeft) =>
+      @emit 'scroll-left-changed', scrollLeft if includeDeprecatedAPIs
+      @emitter.emit 'did-change-scroll-left', scrollLeft
 
     # TODO: remove these when we remove the deprecations. Though, no one is likely using them
     if includeDeprecatedAPIs
@@ -472,9 +466,6 @@ class TextEditor extends Model
   # TODO Remove once the tabs package no longer uses .on subscriptions
   onDidChangeIcon: (callback) ->
     @emitter.on 'did-change-icon', callback
-
-  onDidLoad: (callback) ->
-    @displayBuffer.onDidLoad(callback)
 
   onDidChangeLoadProgress: (callback) ->
     @displayBuffer.onDidChangeLoadProgress(callback)

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -293,9 +293,9 @@ class TokenizedBuffer extends Model
       @tokenizedLineForRow(row).isComment() and
       @tokenizedLineForRow(nextRow).isComment()
 
-  buildTokenizedLinesForRows: (startRow, endRow, startingStack, startingopenScopes) ->
+  buildTokenizedLinesForRows: (startRow, endRow, startingStack, startingOpenScopes) ->
     ruleStack = startingStack
-    openScopes = startingopenScopes
+    openScopes = startingOpenScopes
     stopTokenizingAt = startRow + @chunkSize
     tokenizedLines = for row in [startRow..endRow]
       if (ruleStack or row is 0) and row < stopTokenizingAt

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -25,7 +25,7 @@ class TokenizedBuffer extends Model
   invalidRows: null
   visible: false
   configSettings: null
-  loadProgress: 0
+  loadProgress: 1
 
   constructor: ({@buffer, @tabLength, @ignoreInvisibles, @largeFileMode}) ->
     @emitter = new Emitter
@@ -165,6 +165,8 @@ class TokenizedBuffer extends Model
 
   buildInitialLinesInBackground: ->
     @loadProgress = 0
+    @emitter.emit 'did-change-load-progress', 0
+
     @tokenizedLines = []
 
     taskPath = require.resolve('./initial-tokenized-lines-task')

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -42,10 +42,11 @@ class TokenizedLine
 
     @specialTokens = {}
     {@openScopes, @text, @tags, @lineEnding, @ruleStack, @tokenIterator} = properties
-    {@startBufferColumn, @fold, @tabLength, @indentLevel, @invisibles} = properties
+    {@startBufferColumn, @fold, @tabLength, indentLevel, @invisibles} = properties
 
     @startBufferColumn ?= 0
     @bufferDelta = @text.length
+    @indentLevel = indentLevel if @bufferDelta is 0
 
     @transformContent()
     @buildEndOfLineInvisibles() if @invisibles? and @lineEnding?
@@ -170,7 +171,9 @@ class TokenizedLine
     else
       @text = text
 
+    @indentLevel = (firstNonWhitespaceColumn / @tabLength) if @bufferDelta > 0
     @firstNonWhitespaceIndex = firstNonWhitespaceColumn
+
     if lastNonWhitespaceColumn?
       if lastNonWhitespaceColumn + 1 < @text.length
         @firstTrailingWhitespaceIndex = lastNonWhitespaceColumn + 1

--- a/static/text-editor-light.less
+++ b/static/text-editor-light.less
@@ -233,18 +233,10 @@ atom-text-editor-loader {
   bottom: 0;
   left: 0;
 
-  .progress-bar {
+  progress {
     position: absolute;
     top: 50%;
+    width: 80%;
     left: 10%;
-    right: 10%;
-    height: 2px;
-    margin-top: -1px;
-  }
-
-  .progress-indicator {
-    position: absolute;
-    height: 100%;
-    background: @syntax-cursor-color;
   }
 }

--- a/static/text-editor-light.less
+++ b/static/text-editor-light.less
@@ -225,3 +225,26 @@ atom-text-editor {
     right: 0;
   }
 }
+
+atom-text-editor-loader {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+
+  .progress-bar {
+    position: absolute;
+    top: 50%;
+    left: 10%;
+    right: 10%;
+    height: 2px;
+    margin-top: -1px;
+  }
+
+  .progress-indicator {
+    position: absolute;
+    height: 100%;
+    background: @syntax-cursor-color;
+  }
+}


### PR DESCRIPTION
:rotating_light: Work In Progress :rotating_light:

Loading a 3.7MB file created by concatenating jQuery to itself multiple times:

![async-load](https://cloud.githubusercontent.com/assets/1789/7931652/b7a75e18-0912-11e5-884c-cb314ae6b089.gif)

Constructing the initial set of `TokenizedLine`s hangs the UI thread for large files. This PR performs this work in a background task for files above a certain size to avoid the pause, indicating progress with a progress bar. To integrate smoothly with existing packages, we open a `TextEditorLoader` item to display progress until the editor is fully loaded, then replace it with the editor afterward. This ensures that no packages attempt to interact with an editor in a partially loaded state.
## Remaining Issues
### Can't change grammars

We currently use tokenized lines to store horizontal spatial information such as hard tabs, paired unicode characters, soft-wrap indents, etc. This is in addition to their primary purpose of representing syntactic scopes. This entanglement makes it awkward to change the grammar once the file is loaded, because doing so replaces all the tokenized lines with the same placeholder lines we're constructing in the background to clear all the styling, then starts tokenizing again from the beginning. However, this takes a lot of time for a large file. Once the editor is loaded, I don't want to put it back in "background loading" mode because that implies a lot of complexity. Ideally I'd like to store the horizontal spatial information outside of the tokenized lines, so styling could be cleared without throwing away all this computation.
### Can't change tab length, invisibles, etc

Again, these require recomputing the tokenized lines from scratch. Invisibles can be dealt with by separating them out into a second rendering phase once our position calculation is more decoupled from the content of the model. Tab lengths are not so easy. We may be able to use our existing metadata about tab locations to update the lengths more efficiently in a synchronous way (without having to scan every token). Or we may want to just disable the ability to change it over a certain size. Or we may need to bite the bullet and figure out how to put the editor back in "background loading" mode after all. I'd like to put that off though.
### Long pauses before / after progress bar

The initial pause is due to loading the entire buffer in the background task before beginning processing. I just did this as a first pass implementation and will fix it before merging this. The second pause is autocomplete-plus populating its symbol table. We may want to disable it for now for files above a certain size, then work on optimizing this.
## Tasks
- [x] Display progress bar for loading in background
- [ ] Disallow operations that require recomputation of tokenized lines
- [ ] Optimize background task by computing results in a streaming fashion
- [ ] Do something about autocomplete plus

I may want to push tokenization to a background task in a different PR. That would allow us to at least select an initial grammar for large files instead of the null grammar as is currently the case on this PR. But I think loading huge files without highlighting is enough of an improvement to do that in a second pass.
