### PR TITLE
Revert "Use /usr/bin/env bash in hashbang"

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 if [ "$(uname)" == 'Darwin' ]; then
   OS='Mac'


### PR DESCRIPTION
Reverts atom/atom#6735

Alas, I'd hoped this would be a drop-in replacement, but it breaks installations with malformed `PATH`s.

Fixes https://github.com/atom/atom/issues/6985
