### PR TITLE
Bump tabs@0.72.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "status-bar": "0.74.0",
     "styleguide": "0.44.0",
     "symbols-view": "0.97.0",
-    "tabs": "0.71.0",
+    "tabs": "0.72.0",
     "timecop": "0.31.0",
     "tree-view": "0.171.0",
     "update-package-dependencies": "0.10.0",


### PR DESCRIPTION
This ensures that preview tabs work for all files, not just files that open `TextEditor`s.
