### PR TITLE
Log message about --one being removed

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -11,14 +11,14 @@ else
   exit 1
 fi
 
-while getopts ":wtfvh1-:" opt; do
+while getopts ":wtfvh-:" opt; do
   case "$opt" in
     -)
       case "${OPTARG}" in
         wait)
           WAIT=1
           ;;
-        help|version|one)
+        help|version)
           REDIRECT_STDERR=1
           EXPECT_OUTPUT=1
           ;;
@@ -30,7 +30,7 @@ while getopts ":wtfvh1-:" opt; do
     w)
       WAIT=1
       ;;
-    h|v|1)
+    h|v)
       REDIRECT_STDERR=1
       EXPECT_OUTPUT=1
       ;;

--- a/atom.sh
+++ b/atom.sh
@@ -11,14 +11,14 @@ else
   exit 1
 fi
 
-while getopts ":wtfvh-:" opt; do
+while getopts ":wtfvh1-:" opt; do
   case "$opt" in
     -)
       case "${OPTARG}" in
         wait)
           WAIT=1
           ;;
-        help|version)
+        help|version|one)
           REDIRECT_STDERR=1
           EXPECT_OUTPUT=1
           ;;
@@ -30,7 +30,7 @@ while getopts ":wtfvh-:" opt; do
     w)
       WAIT=1
       ;;
-    h|v)
+    h|v|1)
       REDIRECT_STDERR=1
       EXPECT_OUTPUT=1
       ;;

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -121,7 +121,15 @@ parseCommandLine = ->
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')
   options.alias('w', 'wait').boolean('w').describe('w', 'Wait for window to be closed before returning.')
   options.string('socket-path')
+  options.alias('1', 'one').boolean('one') # Deprecated 1.0 API preview flag
   args = options.argv
+
+  if args.one
+    process.stdout.write """
+      The -1/--one option has been removed. Atom now defaults to launching with
+      the 1.0 API. Use --include-deprecated-apis to run Atom with deprecated APIs.
+
+    """
 
   if args.help
     process.stdout.write(options.help())

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -121,7 +121,7 @@ parseCommandLine = ->
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')
   options.alias('w', 'wait').boolean('w').describe('w', 'Wait for window to be closed before returning.')
   options.string('socket-path')
-  options.alias('1', 'one').boolean('one') # Deprecated 1.0 API preview flag
+  options.alias('1', 'one').boolean('1') # Deprecated 1.0 API preview flag
   args = options.argv
 
   if args.one

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -123,7 +123,7 @@ parseCommandLine = ->
   options.string('socket-path')
 
   # Deprecated 1.0 API preview flag
-  options.alias('1', 'one').boolean('1').describe('1', 'The option is no longer supported. Atom now defaults to launching with the 1.0 API. Use --include-deprecated-apis to run Atom with deprecated APIs.')
+  options.alias('1', 'one').boolean('1').describe('1', 'This option is no longer supported. Atom now defaults to launching with the 1.0 API. Use --include-deprecated-apis to run Atom with deprecated APIs.')
 
   args = options.argv
 

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -107,7 +107,7 @@ parseCommandLine = ->
       ATOM_HOME               The root path for all configuration files and folders.
                               Defaults to `~/.atom`.
   """
-  options.boolean('include-deprecated-apis').describe('include-deprecated-apis', 'Include deprecated APIs')
+  options.boolean('include-deprecated-apis').describe('include-deprecated-apis', 'Include deprecated APIs.')
   options.alias('d', 'dev').boolean('d').describe('d', 'Run in development mode.')
   options.alias('f', 'foreground').boolean('f').describe('f', 'Keep the browser process in the foreground.')
   options.alias('h', 'help').boolean('h').describe('h', 'Print this usage message.')
@@ -121,15 +121,11 @@ parseCommandLine = ->
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')
   options.alias('w', 'wait').boolean('w').describe('w', 'Wait for window to be closed before returning.')
   options.string('socket-path')
-  options.alias('1', 'one').boolean('1') # Deprecated 1.0 API preview flag
+
+  # Deprecated 1.0 API preview flag
+  options.alias('1', 'one').boolean('1').describe('1', 'The option is no longer supported. Atom now defaults to launching with the 1.0 API. Use --include-deprecated-apis to run Atom with deprecated APIs.')
+
   args = options.argv
-
-  if args.one
-    process.stdout.write """
-      The -1/--one option has been removed. Atom now defaults to launching with
-      the 1.0 API. Use --include-deprecated-apis to run Atom with deprecated APIs.
-
-    """
 
   if args.help
     process.stdout.write(options.help())


### PR DESCRIPTION
`-1`/`--one` has been removed so add a warning about it, see #7055 for more details

This ensure people that aliased `atom --one` to `atom` don't have breakage where the path after the `--one` argument isn't treated as a path to open.
