### PR TITLE
Add 'Show Preferences' command to open Settings

### DIFF
--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -126,6 +126,7 @@ atom.commands.add 'atom-workspace',
   'application:about': -> ipc.send('command', 'application:about')
   'application:run-all-specs': -> ipc.send('command', 'application:run-all-specs')
   'application:run-benchmarks': -> ipc.send('command', 'application:run-benchmarks')
+  'application:show-preferences': -> ipc.send('command', 'application:show-settings')
   'application:show-settings': -> ipc.send('command', 'application:show-settings')
   'application:quit': -> ipc.send('command', 'application:quit')
   'application:hide': -> ipc.send('command', 'application:hide')


### PR DESCRIPTION
We use 'Preferences' as the option within the app menu (e.g. Atom) as is typical in OS X applications. In Chrome and in Atom (and likely elsewhere) we actually call the page you land on 'Settings'. 

This PR adds 'Show Preferences' as an option so that if you happen to search for 'Preferences' rather than 'Settings' you can still make your way to the page. 

<img width='455px' src='https://cloud.githubusercontent.com/assets/1305617/7966759/fea5be40-09da-11e5-814a-25d718aee0b5.png'>

Closes https://github.com/atom/settings-view/issues/80

cc @kevinsawicki 
