### PR TITLE
Update linux.md

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -30,7 +30,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 ### Arch
 
 * `sudo pacman -S gconf base-devel git nodejs libgnome-keyring python2`
-* `export PYTHON=/usr/bin/python2` before building Atom.
+* `export python=/usr/bin/python2` before building Atom.
 
 ### Slackware
 


### PR DESCRIPTION
For Arch, `export PYTHON=/usr/bin/python2` should correct for `export python=/usr/bin/python2`
