### PR TITLE
Re-enable tree-view and tabs when sublime-tabs is installed but not loaded

### DIFF
--- a/spec/fixtures/packages/sublime-tabs/package.json
+++ b/spec/fixtures/packages/sublime-tabs/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "sublime-tabs",
+  "version": "1.0.0"
+}

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -877,3 +877,22 @@ describe "PackageManager", ->
       runs ->
         expect(fs.isDirectorySync(autocompleteCSSPath)).toBe false
         expect(fs.isSymbolicLinkSync(autocompletePlusPath)).toBe true
+
+  describe "when the deprecated sublime-tabs package is installed", ->
+    it "enables the tree-view and tabs package", ->
+      atom.config.pushAtKeyPath('core.disabledPackages', 'tree-view')
+      atom.config.pushAtKeyPath('core.disabledPackages', 'tabs')
+
+      spyOn(atom.packages, 'getAvailablePackagePaths').andReturn [
+        path.join(__dirname, 'fixtures', 'packages', 'sublime-tabs')
+        path.resolve(__dirname, '..', 'node_modules', 'tree-view')
+        path.resolve(__dirname, '..', 'node_modules', 'tabs')
+      ]
+      atom.packages.loadPackages()
+
+      waitsFor ->
+        not atom.packages.isPackageDisabled('tree-view') and not atom.packages.isPackageDisabled('tabs')
+
+      runs ->
+        expect(atom.packages.isPackageLoaded('tree-view')).toBe true
+        expect(atom.packages.isPackageLoaded('tabs')).toBe true

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -879,6 +879,16 @@ describe "PackageManager", ->
         expect(fs.isSymbolicLinkSync(autocompletePlusPath)).toBe true
 
   describe "when the deprecated sublime-tabs package is installed", ->
+    grim = require 'grim'
+    includeDeprecatedAPIs = null
+
+    beforeEach ->
+      {includeDeprecatedAPIs} = grim
+      grim.includeDeprecatedAPIs = false
+
+    afterEach ->
+      grim.includeDeprecatedAPIs = includeDeprecatedAPIs
+
     it "enables the tree-view and tabs package", ->
       atom.config.pushAtKeyPath('core.disabledPackages', 'tree-view')
       atom.config.pushAtKeyPath('core.disabledPackages', 'tabs')

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -451,6 +451,7 @@ class PackageManager
 
   # TODO: remove this after a few versions
   migrateSublimeTabsSettings: (packagePaths) ->
+    return if Grim.includeDeprecatedAPIs
     for packagePath in packagePaths when path.basename(packagePath) is 'sublime-tabs'
       atom.config.removeAtKeyPath('core.disabledPackages', 'tree-view')
       atom.config.removeAtKeyPath('core.disabledPackages', 'tabs')

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -314,6 +314,10 @@ class PackageManager
     @uninstallAutocompletePlus()
 
     packagePaths = @getAvailablePackagePaths()
+
+    # TODO: remove after a few atom versions.
+    @migrateSublimeTabsSettings(packagePaths)
+
     packagePaths = packagePaths.filter (packagePath) => not @isPackageDisabled(path.basename(packagePath))
     packagePaths = _.uniq packagePaths, (packagePath) -> path.basename(packagePath)
     @loadPackage(packagePath) for packagePath in packagePaths
@@ -443,6 +447,13 @@ class PackageManager
       ]
       for dirToRemove in dirsToRemove
         @uninstallDirectory(dirToRemove)
+    return
+
+  # TODO: remove this after a few versions
+  migrateSublimeTabsSettings: (packagePaths) ->
+    for packagePath in packagePaths when path.basename(packagePath) is 'sublime-tabs'
+      atom.config.removeAtKeyPath('core.disabledPackages', 'tree-view')
+      atom.config.removeAtKeyPath('core.disabledPackages', 'tabs')
     return
 
   uninstallDirectory: (directory) ->


### PR DESCRIPTION
The sublime-tabs package disables the tree-view and tabs packages so re-enable them when sublime-tabs is installed but not loaded because it is deprecated.

Refs https://github.com/atom/tree-view/issues/467
Refs https://github.com/atom/tabs/issues/162
