### PR TITLE
Avoid redundant decoration state updates in presenter

### DIFF
--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -1134,8 +1134,6 @@ class TextEditorPresenter
         @shouldUpdateLineNumbersState = true
       else if decoration.isType('gutter')
         @shouldUpdateCustomGutterDecorationState = true
-    if decoration.isType('highlight')
-      @updateHighlightState(decoration)
     if decoration.isType('overlay')
       @shouldUpdateOverlaysState = true
 
@@ -1145,14 +1143,14 @@ class TextEditorPresenter
     @observeDecoration(decoration)
 
     if decoration.isType('line') or decoration.isType('gutter')
-      @addToLineDecorationCaches(decoration, decoration.getMarker().getScreenRange())
+      @shouldUpdateDecorations = true
       @shouldUpdateTilesState = true if decoration.isType('line')
       if decoration.isType('line-number')
         @shouldUpdateLineNumbersState = true
       else if decoration.isType('gutter')
         @shouldUpdateCustomGutterDecorationState = true
     else if decoration.isType('highlight')
-      @updateHighlightState(decoration)
+      @shouldUpdateDecorations = true
     else if decoration.isType('overlay')
       @shouldUpdateOverlaysState = true
 
@@ -1357,7 +1355,6 @@ class TextEditorPresenter
     @shouldUpdateHiddenInputState = true
     @pauseCursorBlinking()
     @updateCursorState(cursor)
-
     @emitDidUpdateState()
 
   startBlinkingCursors: ->


### PR DESCRIPTION
In #7023, when we switched to a fully batched system of computing decoration states, I neglected to remove a couple of unnecessary incremental decoration state updates. They are now gone.

This exposes another performance benefit of the batched system: large find-and-replace searches are now much faster because we avoid thousands of unnecessary presenter state updates as highlights are created.

A search in an 8800-line file with 20k results now takes about **2.7 seconds** on my machine, whereas before it took **4 seconds**.

/cc @nathansobo
