### PR TITLE
Load large files with fewer features but much better performance

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -66,6 +66,25 @@ describe "TextEditor", ->
 
       expect(editor.tokenizedLineForScreenRow(0).invisibles.eol).toBe '?'
 
+  describe "when the editor is constructed with the largeFileMode option set to true", ->
+    it "loads the editor but doesn't tokenize", ->
+      editor = null
+
+      waitsForPromise ->
+        atom.workspace.open('sample.js', largeFileMode: true).then (o) -> editor = o
+
+      runs ->
+        buffer = editor.getBuffer()
+        expect(editor.tokenizedLineForScreenRow(0).text).toBe buffer.lineForRow(0)
+        expect(editor.tokenizedLineForScreenRow(0).tokens.length).toBe 1
+        expect(editor.tokenizedLineForScreenRow(1).tokens.length).toBe 2 # soft tab
+        expect(editor.tokenizedLineForScreenRow(12).text).toBe buffer.lineForRow(12)
+        expect(editor.tokenizedLineForScreenRow(0).tokens.length).toBe 1
+        expect(editor.getCursorScreenPosition()).toEqual [0, 0]
+        editor.insertText('hey"')
+        expect(editor.tokenizedLineForScreenRow(0).tokens.length).toBe 1
+        expect(editor.tokenizedLineForScreenRow(1).tokens.length).toBe 2 # sof tab
+
   describe "when the editor is constructed with an initialLine option", ->
     it "positions the cursor on the specified line", ->
       editor = null

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -272,20 +272,6 @@ describe "Workspace", ->
       beforeEach ->
         atom.notifications.onDidAddNotification notificationSpy = jasmine.createSpy()
 
-      describe "when a large file is opened", ->
-        beforeEach ->
-          spyOn(fs, 'getSizeSync').andReturn 2 * 1048577 # 2MB
-
-        it "creates a notification", ->
-          waitsForPromise ->
-            workspace.open('file1')
-
-          runs ->
-            expect(notificationSpy).toHaveBeenCalled()
-            notification = notificationSpy.mostRecentCall.args[0]
-            expect(notification.getType()).toBe 'warning'
-            expect(notification.getMessage()).toContain '< 2MB'
-
       describe "when a file does not exist", ->
         it "creates an empty buffer for the specified path", ->
           waitsForPromise ->

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -224,6 +224,17 @@ describe "Workspace", ->
               expect(workspace.paneContainer.root.children[0]).toBe pane1
               expect(workspace.paneContainer.root.children[1]).toBe pane4
 
+    describe "when the file is large (over 2mb)", ->
+      it "opens the editor with largeFileMode: true", ->
+        spyOn(fs, 'getSizeSync').andReturn 2 * 1048577 # 2MB
+
+        editor = null
+        waitsForPromise ->
+          workspace.open('sample.js').then (e) -> editor = e
+
+        runs ->
+          expect(editor.displayBuffer.largeFileMode).toBe true
+
     describe "when passed a path that matches a custom opener", ->
       it "returns the resource returned by the custom opener", ->
         fooOpener = (pathToOpen, options) -> {foo: pathToOpen, options} if pathToOpen?.match(/\.foo/)

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -483,11 +483,11 @@ class DisplayBuffer extends Model
   # Returns {TokenizedLine}
   tokenizedLineForScreenRow: (screenRow) ->
     if @largeFileMode
-      line = @tokenizedBuffer.tokenizedLineForRow(screenRow)
-      if line.text.length > @maxLineLength
-        @maxLineLength = line.text.length
-        @longestScreenRow = screenRow
-      line
+      if line = @tokenizedBuffer.tokenizedLineForRow(screenRow)
+        if line.text.length > @maxLineLength
+          @maxLineLength = line.text.length
+          @longestScreenRow = screenRow
+        line
     else
       @screenLines[screenRow]
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -532,10 +532,11 @@ class DisplayBuffer extends Model
   #
   # Returns the new {Fold}.
   createFold: (startRow, endRow) ->
-    foldMarker =
-      @findFoldMarker({startRow, endRow}) ?
-        @buffer.markRange([[startRow, 0], [endRow, Infinity]], @getFoldMarkerAttributes())
-    @foldForMarker(foldMarker)
+    unless @largeFileMode
+      foldMarker =
+        @findFoldMarker({startRow, endRow}) ?
+          @buffer.markRange([[startRow, 0], [endRow, Infinity]], @getFoldMarkerAttributes())
+      @foldForMarker(foldMarker)
 
   isFoldedAtBufferRow: (bufferRow) ->
     @largestFoldContainingBufferRow(bufferRow)?

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -445,7 +445,10 @@ class DisplayBuffer extends Model
       @isSoftWrapped()
 
   isSoftWrapped: ->
-    @softWrapped ? @configSettings.softWrap ? false
+    if @largeFileMode
+      false
+    else
+      @softWrapped ? @configSettings.softWrap ? false
 
   # Set the number of characters that fit horizontally in the editor.
   #

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -89,13 +89,14 @@ class DisplayBuffer extends Model
     scrollTop: @scrollTop
     scrollLeft: @scrollLeft
     tokenizedBuffer: @tokenizedBuffer.serialize()
+    largeFileMode: @largeFileMode
 
   deserializeParams: (params) ->
     params.tokenizedBuffer = TokenizedBuffer.deserialize(params.tokenizedBuffer)
     params
 
   copy: ->
-    newDisplayBuffer = new DisplayBuffer({@buffer, tabLength: @getTabLength()})
+    newDisplayBuffer = new DisplayBuffer({@buffer, tabLength: @getTabLength(), @largeFileMode})
     newDisplayBuffer.setScrollTop(@getScrollTop())
     newDisplayBuffer.setScrollLeft(@getScrollLeft())
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -479,7 +479,11 @@ class DisplayBuffer extends Model
   # Returns {TokenizedLine}
   tokenizedLineForScreenRow: (screenRow) ->
     if @largeFileMode
-      @tokenizedBuffer.tokenizedLineForRow(screenRow)
+      line = @tokenizedBuffer.tokenizedLineForRow(screenRow)
+      if line.text.length > @maxLineLength
+        @maxLineLength = line.text.length
+        @longestScreenRow = screenRow
+      line
     else
       @screenLines[screenRow]
 
@@ -760,19 +764,13 @@ class DisplayBuffer extends Model
   #
   # Returns a {Number}.
   getMaxLineLength: ->
-    if @largeFileMode
-      100
-    else
-      @maxLineLength
+    @maxLineLength
 
   # Gets the row number of the longest screen line.
   #
   # Return a {}
   getLongestScreenRow: ->
-    if @largeFileMode
-      0
-    else
-      @longestScreenRow
+    @longestScreenRow
 
   # Given a buffer position, this converts it into a screen position.
   #

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -376,11 +376,6 @@ class Project extends Model
   #
   # Returns a promise that resolves to the {TextBuffer}.
   buildBuffer: (absoluteFilePath) ->
-    if fs.getSizeSync(absoluteFilePath) >= 2 * 1048576 # 2MB
-      error = new Error("Atom can only handle files < 2MB for now.")
-      error.code = 'EFILETOOLARGE'
-      throw error
-
     buffer = new TextBuffer({filePath: absoluteFilePath})
     @addBuffer(buffer)
     buffer.load()
@@ -410,7 +405,8 @@ class Project extends Model
     buffer?.destroy()
 
   buildEditorForBuffer: (buffer, editorOptions) ->
-    editor = new TextEditor(_.extend({buffer, registerEditor: true}, editorOptions))
+    largeFileMode = fs.getSizeSync(buffer.getPath()) >= 2 * 1048576 # 2MB
+    editor = new TextEditor(_.extend({buffer, largeFileMode, registerEditor: true}, editorOptions))
     editor
 
   eachBuffer: (args...) ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -75,7 +75,7 @@ class TextEditor extends Model
     'autoDecreaseIndentForBufferRow', 'toggleLineCommentForBufferRow', 'toggleLineCommentsForBufferRows',
     toProperty: 'languageMode'
 
-  constructor: ({@softTabs, initialLine, initialColumn, tabLength, softWrapped, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini, @placeholderText, lineNumberGutterVisible}={}) ->
+  constructor: ({@softTabs, initialLine, initialColumn, tabLength, softWrapped, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini, @placeholderText, lineNumberGutterVisible, largeFileMode}={}) ->
     super
 
     @emitter = new Emitter
@@ -84,7 +84,7 @@ class TextEditor extends Model
     @selections = []
 
     buffer ?= new TextBuffer
-    @displayBuffer ?= new DisplayBuffer({buffer, tabLength, softWrapped, ignoreInvisibles: @mini})
+    @displayBuffer ?= new DisplayBuffer({buffer, tabLength, softWrapped, ignoreInvisibles: @mini, largeFileMode})
     @buffer = @displayBuffer.buffer
     @softTabs = @usesSoftTabs() ? @softTabs ? atom.config.get('editor.softTabs') ? true
 

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -263,6 +263,8 @@ class TokenizedBuffer extends Model
     row - increment
 
   updateFoldableStatus: (startRow, endRow) ->
+    return [startRow, endRow] if @largeFileMode
+
     scanStartRow = @buffer.previousNonBlankRow(startRow) ? startRow
     scanStartRow-- while scanStartRow > 0 and @tokenizedLineForRow(scanStartRow).isComment()
     scanEndRow = @buffer.nextNonBlankRow(endRow) ? endRow
@@ -278,7 +280,10 @@ class TokenizedBuffer extends Model
     [startRow, endRow]
 
   isFoldableAtRow: (row) ->
-    @isFoldableCodeAtRow(row) or @isFoldableCommentAtRow(row)
+    if @largeFileMode
+      false
+    else
+      @isFoldableCodeAtRow(row) or @isFoldableCommentAtRow(row)
 
   # Returns a {Boolean} indicating whether the given buffer row starts
   # a a foldable row range due to the code's indentation patterns.

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -44,6 +44,7 @@ class TokenizedBuffer extends Model
     bufferPath: @buffer.getPath()
     tabLength: @tabLength
     ignoreInvisibles: @ignoreInvisibles
+    largeFileMode: @largeFileMode
 
   deserializeParams: (params) ->
     params.buffer = atom.project.bufferForPathSync(params.bufferPath)

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -67,7 +67,7 @@ class TokenizedBuffer extends Model
     if grammar.injectionSelector?
       @retokenizeLines() if @hasTokenForSelector(grammar.injectionSelector)
     else
-      newScore = grammar.getScore(@buffer.getPath(), @buffer.getText())
+      newScore = grammar.getScore(@buffer.getPath(), @getGrammarSelectionContent())
       @setGrammar(grammar, newScore) if newScore > @currentGrammarScore
 
   setGrammar: (grammar, score) ->
@@ -75,7 +75,7 @@ class TokenizedBuffer extends Model
 
     @grammar = grammar
     @rootScopeDescriptor = new ScopeDescriptor(scopes: [@grammar.scopeName])
-    @currentGrammarScore = score ? grammar.getScore(@buffer.getPath(), @buffer.getText())
+    @currentGrammarScore = score ? grammar.getScore(@buffer.getPath(), @getGrammarSelectionContent())
 
     @grammarUpdateDisposable?.dispose()
     @grammarUpdateDisposable = @grammar.onDidUpdate => @retokenizeLines()
@@ -106,8 +106,11 @@ class TokenizedBuffer extends Model
     @emit 'grammar-changed', grammar if Grim.includeDeprecatedAPIs
     @emitter.emit 'did-change-grammar', grammar
 
+  getGrammarSelectionContent: ->
+    @buffer.getTextInRange([[0, 0], [10, 0]])
+
   reloadGrammar: ->
-    if grammar = atom.grammars.selectGrammar(@buffer.getPath(), @buffer.getText())
+    if grammar = atom.grammars.selectGrammar(@buffer.getPath(), @getGrammarSelectionContent())
       @setGrammar(grammar)
     else
       throw new Error("No grammar found for path: #{path}")


### PR DESCRIPTION
Pictured below is Atom opening an 18.5 MB file (repeated copies of jQuery):

![large-file](https://cloud.githubusercontent.com/assets/1789/8014574/45c5fa94-0bd2-11e5-88b2-98601aac5bda.gif)
### Less Is More

The lion's share of overhead when working with text files goes to supporting the following features:
- Soft wrap
- Folds
- Syntax analysis

As files get larger, this overhead becomes more problematic. Yes, we can reduce this overhead and plan to do so, but it's also true that these features are less likely to be critical when editing really huge files. So this PR disables them for files above 2MB.

In return we can do the following:
- Compute placeholder `TokenizedLine`s on demand instead of up-front. This skips all of the processing I was trying to perform in the background on #7060, which can now be closed. It also avoids the memory hit of storing horizontal spatial metadata for any lines we haven't yet viewed. I'm leaving lines cached once we compute them once to avoid creating the same line over and over again. We could potentially use an LRU ("least recently used") cache eviction strategy if we want to cap consumed memory, but I'm not sure it's worth prioritizing.
- Delegate straight through to `TokenizedBuffer` from `DisplayBuffer` rather than storing a second copy of lines, since there are no folds and soft wraps. This isn't a huge win but it does avoid an extra potentially huge array of references.
- Not block the UI thread as we perform the initial tokenization. This is really long overdue to be backgrounded, but this is a good stopgap.
### Metrics

Now that we've cleared a huge bottleneck, new bottlenecks are revealing themselves in the initial load of a large file. At least on an SSD, I/O really isn't high on the list yet. Here's a flame graph for loading that 18.5 MB file:

<img width="1318" alt="screenshot_2015-06-05_22_11_18" src="https://cloud.githubusercontent.com/assets/1789/8014847/6b37b540-0bd4-11e5-94f9-0d91da9083e6.png">

There's plenty of low hanging :apple: in here. I've highlighted a few things that stood out to me.

@maxbrunsfeld: `TextBuffer` might be a good first candidate for `Patch` after all, at least in terms of getting that data structure optimized for insertion. `SpanSkipList` insertion is by far the biggest remaining cost.

From a memory perspective, the `SpanSkipList` is also our biggest offender when `TokenizedLine`s are out of the way:

![screenshot 2015-06-05 22 10 07](https://cloud.githubusercontent.com/assets/1789/8014925/f7aff92e-0bd4-11e5-8777-73d92bdfe6ad.png)
### Closing Thoughts

I still want to push the efficiency of the structures that support Atom's full feature set, and we have a bunch of ideas for how to do so. But in the meantime, this is a much better compromise than an error message.
