### PR TITLE
Item provides save panel options

### DIFF
--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -3,7 +3,7 @@ Pane = require '../src/pane'
 PaneAxis = require '../src/pane-axis'
 PaneContainer = require '../src/pane-container'
 
-fdescribe "Pane", ->
+describe "Pane", ->
   deserializerDisposable = null
 
   class Item extends Model

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -3,7 +3,7 @@ Pane = require '../src/pane'
 PaneAxis = require '../src/pane-axis'
 PaneContainer = require '../src/pane-container'
 
-describe "Pane", ->
+fdescribe "Pane", ->
   deserializerDisposable = null
 
   class Item extends Model
@@ -414,7 +414,7 @@ describe "Pane", ->
         pane.getActiveItem().path = __filename
         pane.getActiveItem().saveAs = jasmine.createSpy("saveAs")
         pane.saveActiveItemAs()
-        expect(atom.showSaveDialogSync).toHaveBeenCalledWith(__filename)
+        expect(atom.showSaveDialogSync).toHaveBeenCalledWith(defaultPath: __filename)
         expect(pane.getActiveItem().saveAs).toHaveBeenCalledWith('/selected/path')
 
     describe "when the current item does not have a saveAs method", ->

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -783,11 +783,12 @@ class Atom extends Model
   showSaveDialog: (callback) ->
     callback(showSaveDialogSync())
 
-  showSaveDialogSync: (defaultPath) ->
-    defaultPath ?= @project?.getPaths()[0]
+  showSaveDialogSync: (options={}) ->
     currentWindow = @getCurrentWindow()
     dialog = remote.require('dialog')
-    dialog.showSaveDialog currentWindow, {title: 'Save File', defaultPath}
+    options.title ?= 'Save File'
+    options.defaultPath ?= @project?.getPaths()[0]
+    dialog.showSaveDialog currentWindow, options
 
   saveSync: ->
     if storageKey = @constructor.getStateKey(@project?.getPaths(), @mode)

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -786,6 +786,8 @@ class Atom extends Model
   showSaveDialogSync: (options={}) ->
     if _.isString(options)
       options = defaultPath: options
+    else
+      options = _.clone(options)
     currentWindow = @getCurrentWindow()
     dialog = remote.require('dialog')
     options.title ?= 'Save File'

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -784,6 +784,8 @@ class Atom extends Model
     callback(showSaveDialogSync())
 
   showSaveDialogSync: (options={}) ->
+    if _.isString(options)
+      options = defaultPath: options
     currentWindow = @getCurrentWindow()
     dialog = remote.require('dialog')
     options.title ?= 'Save File'

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -492,7 +492,7 @@ class Pane extends Model
   saveItemAs: (item, nextAction) ->
     return unless item?.saveAs?
 
-    saveOptions = item.getSaveOptions?() or {}
+    saveOptions = item.getSaveDialogOptions?() ? {}
     saveOptions.defaultPath ?= item.getPath()
     newItemPath = atom.showSaveDialogSync(saveOptions)
     if newItemPath

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -492,8 +492,9 @@ class Pane extends Model
   saveItemAs: (item, nextAction) ->
     return unless item?.saveAs?
 
-    itemPath = item.getPath?()
-    newItemPath = atom.showSaveDialogSync(itemPath)
+    saveOptions = item.getSaveOptions?() or {}
+    saveOptions.defaultPath ?= item.getPath()
+    newItemPath = atom.showSaveDialogSync(saveOptions)
     if newItemPath
       try
         item.saveAs(newItemPath)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -593,6 +593,16 @@ class TextEditor extends Model
   # Essential: Returns the {String} path of this editor's text buffer.
   getPath: -> @buffer.getPath()
 
+  # Private: Return [save options](http://electron.atom.io/docs/v0.27.0/api/di
+  # alog/#dialog.showsavedialog(%5Bbrowserwindow%5D,-%5Boptions%5D,-%5Bcallbac
+  # k%5D)) to be used when displaying the save dialog.
+  #
+  # Default empty options are returned now. In the future this would be the
+  # place to start implementing things like: https://discuss.atom.io/t
+  # /request-saving- file-with-correct-extension/17521
+  getSaveDialogOptions: ->
+    {}
+
   # Extended: Returns the {String} character set encoding of this editor's text
   # buffer.
   getEncoding: -> @buffer.getEncoding()


### PR DESCRIPTION
This changes the pane.saveItemAs logic to look for a getSaveOptions method and if present those options will be passed into the save dialogue. This add flexibility, giving items more control over how the save dialog works. I need it so that I can include filter types in the save dialogue. But I expect there will be other uses cases going forward.
