### PR TITLE
Update text-editor.coffee

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -325,7 +325,7 @@ class TextEditor extends Model
   onWillInsertText: (callback) ->
     @emitter.on 'will-insert-text', callback
 
-  # Extended: Calls your `callback` adter text has been inserted.
+  # Extended: Calls your `callback` after text has been inserted.
   #
   # * `callback` {Function}
   #   * `event` event {Object}


### PR DESCRIPTION
Fix a typo in `src/text-editor.coffee` (`adter` => `after`).
