### PR TITLE
Only use lsb-core instead of full suite of lsb packages

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -7,7 +7,7 @@ URL:            https://atom.io/
 AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
-Requires: lsb
+Requires: lsb-core-noarch
 
 %description
 <%= description %>


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/7096

`lsb` is quite a large package – we should just use what we need (which is `lsb-core`)

Tested on Fedora 21 and OpenSUSE 13.2

/cc @kevinsawicki 
