### PR TITLE
Enable "Downloading Update" context menu entry

### DIFF
--- a/src/browser/auto-updater-win32.coffee
+++ b/src/browser/auto-updater-win32.coffee
@@ -14,8 +14,6 @@ class AutoUpdater
       require('auto-updater').quitAndInstall()
 
   downloadUpdate: (callback) ->
-    @emit 'update-available'
-
     SquirrelUpdate.spawn ['--download', @updateUrl], (error, stdout) ->
       return callback(error) if error?
 
@@ -52,6 +50,8 @@ class AutoUpdater
       unless update?
         @emit 'update-not-available'
         return
+
+      @emit 'update-available'
 
       @installUpdate (error) =>
         if error?

--- a/src/browser/auto-updater-win32.coffee
+++ b/src/browser/auto-updater-win32.coffee
@@ -14,6 +14,8 @@ class AutoUpdater
       require('auto-updater').quitAndInstall()
 
   downloadUpdate: (callback) ->
+    @emit 'update-available'
+
     SquirrelUpdate.spawn ['--download', @updateUrl], (error, stdout) ->
       return callback(error) if error?
 
@@ -56,7 +58,6 @@ class AutoUpdater
           @emit 'update-not-available'
           return
 
-        @emit 'update-available'
         @emit 'update-downloaded', {}, update.releaseNotes, update.version, new Date(), 'https://atom.io', => @quitAndInstall()
 
 module.exports = new AutoUpdater()


### PR DESCRIPTION
Previously `update-downloaded` would get emitted right after `update-available` which would suppress the "Downloading Update" menu entry.

I'm not too literate at Coffeescript so hopefully I put `@emit update-available` where it actually belongs :P.

Fixes #7128.
