### PR TITLE
Fixed missing icon when building from source

### DIFF
--- a/build/tasks/generate-asar-task.coffee
+++ b/build/tasks/generate-asar-task.coffee
@@ -15,6 +15,7 @@ module.exports = (grunt) ->
       'ctags-linux'
       'ctags-win32.exe'
       '**/node_modules/spellchecker/**'
+      'atom.png'
     ]
     unpack = "{#{unpack.join(',')}}"
 

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -46,7 +46,7 @@ module.exports = (grunt) ->
         desktopInstallFile = path.join(installDir, 'share', 'applications', 'atom.desktop')
 
         {description} = grunt.file.readJSON('package.json')
-        iconName = path.join(shareDir, 'resources', 'app', 'resources', 'atom.png')
+        iconName = path.join(shareDir, 'resources', 'app.asar.unpacked', 'resources', 'atom.png')
         executable = path.join(shareDir, 'atom')
         template = _.template(String(fs.readFileSync(desktopFile)))
         filled = template({description, iconName, executable})


### PR DESCRIPTION
When building from source there is a problem with the `atom.desktop`. The icon that it points to doesn't exit.
I added `atom.png` to get unpacked from app.asar and changed `atom.desktop` to point to and fixed the problem
