### PR TITLE
Don’t break out soft tabs that are interrupted by a scope boundary

### DIFF
--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -322,6 +322,22 @@ describe "TokenizedBuffer", ->
         expect(tokens[2].value).toBe " \u030b"
         expect(tokens[2].hasLeadingWhitespace()).toBe false
 
+      it "does not break out soft tabs across a scope boundary", ->
+        waitsForPromise ->
+          atom.packages.activatePackage('language-gfm')
+
+        runs ->
+          tokenizedBuffer.setTabLength(4)
+          tokenizedBuffer.setGrammar(atom.grammars.selectGrammar('.md'))
+          buffer.setText('    <![]()\n    ')
+          fullyTokenize(tokenizedBuffer)
+
+          length = 0
+          for tag in tokenizedBuffer.tokenizedLines[1].tags
+            length += tag if tag > 0
+
+          expect(length).toBe 4
+
   describe "when the buffer contains hard-tabs", ->
     beforeEach ->
       waitsForPromise ->

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -102,10 +102,11 @@ class TokenizedLine
           substringEnd += 1
         else
           if (screenColumn + 1) % @tabLength is 0
-            @specialTokens[tokenIndex] = SoftTab
             suffix = @tags[tokenIndex] - @tabLength
-            @tags.splice(tokenIndex, 1, @tabLength)
-            @tags.splice(tokenIndex + 1, 0, suffix) if suffix > 0
+            if suffix >= 0
+              @specialTokens[tokenIndex] = SoftTab
+              @tags.splice(tokenIndex, 1, @tabLength)
+              @tags.splice(tokenIndex + 1, 0, suffix) if suffix > 0
 
           if @invisibles?.space
             if substringEnd > substringStart


### PR DESCRIPTION
Fixes #7160
