### PR TITLE
Show a warning prompt when opening files over 20MB

### DIFF
--- a/src/project.coffee
+++ b/src/project.coffee
@@ -329,9 +329,9 @@ class Project extends Model
 
     if fileSize >= 20 * 1048576 # 20MB
       choice = atom.confirm
-        message: 'Atom can have issues with files over 20MB.'
-        detailedMessage: "Do you still want to try to load this?"
-        buttons: ["Open", "Cancel"]
+        message: 'Atom currently freezes during the loading of very large files.'
+        detailedMessage: "Do you still want to load this file?"
+        buttons: ["Proceed", "Cancel"]
       if choice is 1
         error = new Error
         error.code = 'CANCELLED'

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -323,8 +323,22 @@ class Project extends Model
         # allow ENOENT errors to create an editor for paths that dont exist
         throw error unless error.code is 'ENOENT'
 
-    @bufferForPath(filePath).then (buffer) =>
-      @buildEditorForBuffer(buffer, options)
+    absoluteFilePath = @resolvePath(filePath)
+
+    fileSize = fs.getSizeSync(absoluteFilePath)
+
+    if fileSize >= 20 * 1048576 # 20MB
+      choice = atom.confirm
+        message: 'Atom can have issues with files over 20MB.'
+        detailedMessage: "Do you still want to try to load this?"
+        buttons: ["Open", "Cancel"]
+      if choice is 1
+        error = new Error
+        error.code = 'CANCELLED'
+        throw error
+
+    @bufferForPath(absoluteFilePath).then (buffer) =>
+      @buildEditorForBuffer(buffer, _.extend({fileSize}, options))
 
   # Retrieves all the {TextBuffer}s in the project; that is, the
   # buffers for all open files.
@@ -354,8 +368,7 @@ class Project extends Model
   # * `filePath` A {String} representing a path. If `null`, an "Untitled" buffer is created.
   #
   # Returns a promise that resolves to the {TextBuffer}.
-  bufferForPath: (filePath) ->
-    absoluteFilePath = @resolvePath(filePath)
+  bufferForPath: (absoluteFilePath) ->
     existingBuffer = @findBufferForPath(absoluteFilePath) if absoluteFilePath
     Q(existingBuffer ? @buildBuffer(absoluteFilePath))
 
@@ -405,7 +418,7 @@ class Project extends Model
     buffer?.destroy()
 
   buildEditorForBuffer: (buffer, editorOptions) ->
-    largeFileMode = fs.getSizeSync(buffer.getPath()) >= 2 * 1048576 # 2MB
+    largeFileMode = editorOptions.fileSize >= 2 * 1048576 # 2MB
     editor = new TextEditor(_.extend({buffer, largeFileMode, registerEditor: true}, editorOptions))
     editor
 

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -329,7 +329,7 @@ class Project extends Model
 
     if fileSize >= 20 * 1048576 # 20MB
       choice = atom.confirm
-        message: 'Atom currently freezes during the loading of very large files.'
+        message: 'Atom will be unresponsive during the loading of very large files.'
         detailedMessage: "Do you still want to load this file?"
         buttons: ["Proceed", "Cancel"]
       if choice is 1

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -429,15 +429,16 @@ class Workspace extends Model
       item ?= atom.project.open(uri, options)
     catch error
       switch error.code
-        when 'EFILETOOLARGE'
-          atom.notifications.addWarning("#{error.message} Large file support is being tracked at [atom/atom#307](https://github.com/atom/atom/issues/307).")
+        when 'CANCELLED'
+          return Q()
         when 'EACCES'
           atom.notifications.addWarning("Permission denied '#{error.path}'")
+          return Q()
         when 'EPERM', 'EBUSY'
           atom.notifications.addWarning("Unable to open '#{error.path}'", detail: error.message)
+          return Q()
         else
           throw error
-      return Q()
 
     Q(item)
       .then (item) =>


### PR DESCRIPTION
![screenshot 2015-06-08 23 52 18](https://cloud.githubusercontent.com/assets/1789/8046221/79c32c68-0e39-11e5-8ea2-76fc21e68880.png)

I'm now considering chunking the population of the line index on the UI thread to get us a progress bar before 1.0. I want to fix some bugs first, so until then, this will represent a soft limit to keep people from straying into the danger zone with larger files.
