### PR TITLE
Fix inconsistency with pane resize cursors.

### DIFF
--- a/static/panes.less
+++ b/static/panes.less
@@ -25,7 +25,7 @@ atom-pane-container {
       width: 100%;
       height: 8px;
       margin-top: -4px;
-      cursor: ns-resize;
+      cursor: row-resize;
       border-bottom: none;
     }
   }
@@ -37,7 +37,7 @@ atom-pane-container {
       width: 8px;
       height: 100%;
       margin-left: -4px;
-      cursor: ew-resize;
+      cursor: col-resize;
       border-right: none;
     }
   }


### PR DESCRIPTION
Resolves inconsistency as raised by https://github.com/atom/atom/issues/7178 and originally raised by  @trkoch in https://github.com/atom/atom/pull/5902#issuecomment-95063910. Updates the pane resize cursor to leverage col-resize for horizontal and row-resize for vertically split panes.

Cursor Reference: 
https://developer.mozilla.org/en-US/docs/Web/CSS/cursor

Screen Capture showing fix:
![atomresizepanecursorfix](https://cloud.githubusercontent.com/assets/119151/8053335/905e84d0-0e44-11e5-812d-0d26fda05ab5.gif)
