### PR TITLE
Update linux.md

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -31,6 +31,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 
 * `sudo pacman -S gconf base-devel git nodejs libgnome-keyring python2`
 * `export python=/usr/bin/python2` before building Atom.
+* if you have both python2 and python3, it would be best to `ln -s /usr/bin/python2 /usr/bin/python`
 
 ### Slackware
 


### PR DESCRIPTION
Some one have both python2 and python3 in archlinux will have some problem, there python will links to python3, so they should `ln -s /usr/bin/python2 /usr/bin/python` before building atom.
