### PR TITLE
Delete partially off-screen markers which are empty

### DIFF
--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -1327,6 +1327,10 @@ describe "TextEditorPresenter", ->
           marker8 = editor.markBufferRange([[2, 2], [2, 2]])
           highlight8 = editor.decorateMarker(marker8, type: 'highlight', class: 'h')
 
+          # partially off-screen above, empty
+          marker9 = editor.markBufferRange([[0, 0], [2, 0]], invalidate: 'touch')
+          highlight9 = editor.decorateMarker(marker9, type: 'highlight', class: 'h')
+
           presenter = buildPresenter(explicitHeight: 30, scrollTop: 20, tileSize: 2)
 
           expectUndefinedStateForHighlight(presenter, highlight1)
@@ -1388,6 +1392,7 @@ describe "TextEditorPresenter", ->
 
           expectUndefinedStateForHighlight(presenter, highlight7)
           expectUndefinedStateForHighlight(presenter, highlight8)
+          expectUndefinedStateForHighlight(presenter, highlight9)
 
         it "is empty until all of the required measurements are assigned", ->
           editor.setSelectedBufferRanges([

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -1253,13 +1253,6 @@ class TextEditorPresenter
     range = marker.getScreenRange()
 
     if decoration.isDestroyed() or not marker.isValid() or range.isEmpty() or not range.intersectsRowRange(@startRow, @endRow - 1)
-      tileStartRow = @tileForRow(range.start.row)
-      tileEndRow = @tileForRow(range.end.row)
-
-      for tile in [tileStartRow..tileEndRow] by @tileSize
-        delete @state.content.tiles[tile]?.highlights[decoration.id]
-
-      @emitDidUpdateState()
       return
 
     if range.start.row < @startRow
@@ -1269,11 +1262,7 @@ class TextEditorPresenter
       range.end.row = @endRow
       range.end.column = 0
 
-    if range.isEmpty()
-      tileState = @state.content.tiles[@tileForRow(range.start.row)]
-      delete tileState.highlights[decoration.id]
-      @emitDidUpdateState()
-      return
+    return if range.isEmpty()
 
     flash = decoration.consumeNextFlash()
 
@@ -1306,8 +1295,6 @@ class TextEditorPresenter
 
       @visibleHighlights[tileStartRow] ?= {}
       @visibleHighlights[tileStartRow][decoration.id] = true
-
-    @emitDidUpdateState()
 
     true
 


### PR DESCRIPTION
- :fire: Delete old code which was written to support some non-batched
  methods in a previous version;
- :white_check_mark: Cover “partially off-screen markers which are
  empty” scenario, since that [code path](https://github.com/atom/atom/blob/f830623512fe69c287f17fd5e02b9ad9dca401ad/src/text-editor-presenter.coffee#L1274) was not being hit by `TextEditorPresenter` specs;

Fixes #7183

/cc: @izuzak @nathansobo @maxbrunsfeld 
