### PR TITLE
Fix misattributed package load/activate notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "scandal": "2.0.3",
     "scoped-property-store": "^0.17.0",
     "scrollbar-style": "^3.1",
-    "season": "^5.1.4",
+    "season": "^5.3",
     "semver": "^4.3.3",
     "serializable": "^1",
     "service-hub": "^0.5.0",


### PR DESCRIPTION
There were cases where the error thrown loading/activating a package was not properly attributed to the package because of the stack trace.
- [x] Add path information to CSON errors https://github.com/atom/season/pull/15

Fixes https://github.com/atom/atom/issues/6227
### Before

![screen shot 2015-06-10 at 3 01 35 pm](https://cloud.githubusercontent.com/assets/671378/8095274/aa90660a-0f81-11e5-8631-d1aebd7e3b91.png)
### After

![screen shot 2015-06-10 at 3 01 47 pm](https://cloud.githubusercontent.com/assets/671378/8095271/a864ab16-0f81-11e5-9fba-b40d6a45c133.png)
