### PR TITLE
Add remove cursor when there are multiple cursors and cmd clicking on it

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1578,19 +1578,19 @@ describe "TextEditorComponent", ->
 
         describe "when there are multiple cursors, and one of the cursor's screen position is the same as the mouse click screen position", ->
           it "removes a cursor at the mouse screen position", ->
-            editor.setCursorScreenPosition([3,4])
-            editor.addCursorAtScreenPosition([5,2])
+            editor.setCursorScreenPosition([3, 4])
+            editor.addCursorAtScreenPosition([5, 2])
             editor.addCursorAtScreenPosition([7, 5])
-            linesNode.dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenPosition([3,4]), metaKey: true))
+            linesNode.dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenPosition([3, 4]), metaKey: true))
             nextAnimationFrame()
-            expect(editor.getSelectedScreenRanges()).toEqual [[[5,2], [5,2]], [[7,5], [7,5]]]
+            expect(editor.getSelectedScreenRanges()).toEqual [[[5, 2], [5, 2]], [[7, 5], [7, 5]]]
 
         describe "when there is a single cursor and the click occurs at the cursor's screen position", ->
           it "neither adds a new cursor nor removes the current cursor", ->
             editor.setCursorScreenPosition([3, 4])
-            linesNode.dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenPosition([3,4]), metaKey: true))
+            linesNode.dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenPosition([3, 4]), metaKey: true))
             nextAnimationFrame()
-            expect(editor.getSelectedScreenRanges()).toEqual [[[3,4], [3,4]]]
+            expect(editor.getSelectedScreenRanges()).toEqual [[[3, 4], [3, 4]]]
 
     describe "when a non-folded line is double-clicked", ->
       describe "when no modifier keys are held down", ->

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1569,11 +1569,28 @@ describe "TextEditorComponent", ->
           expect(editor.getSelectedScreenRange()).toEqual [[3, 4], [5, 6]]
 
       describe "when the command key is held down", ->
-        it "adds a cursor at the nearest screen position", ->
-          editor.setCursorScreenPosition([3, 4])
-          linesNode.dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenPosition([5, 6]), metaKey: true))
-          nextAnimationFrame()
-          expect(editor.getSelectedScreenRanges()).toEqual [[[3, 4], [3, 4]], [[5, 6], [5, 6]]]
+        describe "the current cursor position and screen position do not match", ->
+          it "adds a cursor at the nearest screen position", ->
+            editor.setCursorScreenPosition([3, 4])
+            linesNode.dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenPosition([5, 6]), metaKey: true))
+            nextAnimationFrame()
+            expect(editor.getSelectedScreenRanges()).toEqual [[[3, 4], [3, 4]], [[5, 6], [5, 6]]]
+
+        describe "when there are multiple cursors, and one of the cursor's screen position is the same as the mouse click screen position", ->
+          it "removes a cursor at the mouse screen position", ->
+            editor.setCursorScreenPosition([3,4])
+            editor.addCursorAtScreenPosition([5,2])
+            editor.addCursorAtScreenPosition([7, 5])
+            linesNode.dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenPosition([3,4]), metaKey: true))
+            nextAnimationFrame()
+            expect(editor.getSelectedScreenRanges()).toEqual [[[5,2], [5,2]], [[7,5], [7,5]]]
+
+        describe "when there is a single cursor and the click occurs at the cursor's screen position", ->
+          it "neither adds a new cursor nor removes the current cursor", ->
+            editor.setCursorScreenPosition([3, 4])
+            linesNode.dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenPosition([3,4]), metaKey: true))
+            nextAnimationFrame()
+            expect(editor.getSelectedScreenRanges()).toEqual [[[3,4], [3,4]]]
 
     describe "when a non-folded line is double-clicked", ->
       describe "when no modifier keys are held down", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -916,6 +916,12 @@ describe "TextEditor", ->
         editor.setCursorBufferPosition([3, 1])
         expect(editor.getCurrentParagraphBufferRange()).toBeUndefined()
 
+    describe "getCursorAtScreenPosition(screenPosition)", ->
+      it "returns the cursor at the given screenPosition", ->
+        cursor1 = editor.addCursorAtScreenPosition([0, 2])
+        cursor2 = editor.getCursorAtScreenPosition(cursor1.getScreenPosition())
+        expect(cursor2.marker).toBe cursor1.marker
+
     describe "::getCursorScreenPositions()", ->
       it "returns the cursor positions in the order they were added", ->
         editor.foldBufferRow(4)

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -920,7 +920,7 @@ describe "TextEditor", ->
       it "returns the cursor at the given screenPosition", ->
         cursor1 = editor.addCursorAtScreenPosition([0, 2])
         cursor2 = editor.getCursorAtScreenPosition(cursor1.getScreenPosition())
-        expect(cursor2.marker).toBe cursor1.marker
+        expect(cursor2).toBe cursor1
 
     describe "::getCursorScreenPositions()", ->
       it "returns the cursor positions in the order they were added", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -941,7 +941,7 @@ describe "TextEditor", ->
         it "returns the existing cursor", ->
           cursor1 = editor.addCursorAtScreenPosition([0, 2])
           cursor2 = editor.addCursorAtScreenPosition([0, 2])
-          expect(cursor2.marker).toBe cursor1.marker
+          expect(cursor2).toBe cursor1
 
     describe "addCursorAtBufferPosition(bufferPosition)", ->
       describe "when a cursor already exists at the position", ->

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -392,7 +392,11 @@ class TextEditorComponent
         if shiftKey
           @editor.selectToScreenPosition(screenPosition)
         else if metaKey or (ctrlKey and process.platform isnt 'darwin')
-          @editor.addCursorAtScreenPosition(screenPosition)
+          cursorAtScreenPosition = @editor.getCursorAtScreenPosition(screenPosition)
+          if cursorAtScreenPosition and @editor.hasMultipleCursors()
+            cursorAtScreenPosition.destroy()
+          else
+            @editor.addCursorAtScreenPosition(screenPosition)
         else
           @editor.setCursorScreenPosition(screenPosition)
       when 2

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1563,7 +1563,7 @@ class TextEditor extends Model
 
   # Essential: Get a {Cursor} at given screen coordinates {Point}
   #
-  #* `position` A {Point}
+  # * `position` A {Point} or {Array} of `[row, column]`
   #
   # Returns the first matched {Cursor} or undefined
   getCursorAtScreenPosition: (position) ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1561,6 +1561,17 @@ class TextEditor extends Model
   setCursorBufferPosition: (position, options) ->
     @moveCursors (cursor) -> cursor.setBufferPosition(position, options)
 
+  # Essential: Get a {Cursor} at given screen coordinates {Point}
+  #
+  #* `position` A {Point}
+  #
+  # Returns the first matched {Cursor} or undefined
+  getCursorAtScreenPosition: (position) ->
+    cursorsAtPoint = @cursors.filter (cursor) ->
+      cursorPosition = cursor.getScreenPosition()
+      cursorPosition.row is position.row and cursorPosition.column is position.column
+    if cursorsAtPoint.length > 0 then cursorsAtPoint[0] else undefined
+
   # Essential: Get the position of the most recently added cursor in screen
   # coordinates.
   #

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1567,10 +1567,9 @@ class TextEditor extends Model
   #
   # Returns the first matched {Cursor} or undefined
   getCursorAtScreenPosition: (position) ->
-    cursorsAtPoint = @cursors.filter (cursor) ->
-      cursorPosition = cursor.getScreenPosition()
-      cursorPosition.row is position.row and cursorPosition.column is position.column
-    if cursorsAtPoint.length > 0 then cursorsAtPoint[0] else undefined
+    for cursor in @cursors
+      return cursor if cursor.getScreenPosition().isEqual(position)
+    undefined
 
   # Essential: Get the position of the most recently added cursor in screen
   # coordinates.


### PR DESCRIPTION
Closes https://github.com/atom/atom/issues/6909

![deselect](https://cloud.githubusercontent.com/assets/5764316/8105547/6d6a5a9c-103a-11e5-80d1-3fe6b7ad1e7d.gif)

 `Cmd / Ctrl-Click` -ing on a cursor when there are multiple cursors will remove that cursor. 

If there is only the one cursor and it is `Cmd / Ctrl-Click`-ed, nothing will happen. 
