### PR TITLE
Avoid saving state when closing windows due to auto-update

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -105,7 +105,7 @@ class AtomApplication
         app.quit()
         return
     @windows.splice(@windows.indexOf(window), 1)
-    @saveState() unless window.isSpec or @quitting
+    @saveState() unless window.isSpec
 
   # Public: Adds the {AtomWindow} to the global window list.
   addWindow: (window) ->
@@ -273,6 +273,9 @@ class AtomApplication
       @promptForPath "folder", (selectedPaths) ->
         event.sender.send(responseChannel, selectedPaths)
 
+    ipc.on 'cancel-window-close', =>
+      @quitting = false
+
     clipboard = null
     ipc.on 'write-text-to-selection-clipboard', (event, selectedText) ->
       clipboard ?= require '../safe-clipboard'
@@ -437,6 +440,7 @@ class AtomApplication
     delete @pidsToOpenWindows[pid]
 
   saveState: ->
+    return if @quitting
     states = []
     for window in @windows
       unless window.isSpec

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -186,7 +186,10 @@ class AtomApplication
     @on 'application:report-issue', -> require('shell').openExternal('https://github.com/atom/atom/blob/master/CONTRIBUTING.md#submitting-issues')
     @on 'application:search-issues', -> require('shell').openExternal('https://github.com/issues?q=+is%3Aissue+user%3Aatom')
 
-    @on 'application:install-update', => @autoUpdateManager.install()
+    @on 'application:install-update', =>
+      @quitting = true
+      @autoUpdateManager.install()
+
     @on 'application:check-for-update', => @autoUpdateManager.check()
 
     if process.platform is 'darwin'

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -64,7 +64,10 @@ class WindowEventHandler
 
       atom.storeDefaultWindowDimensions()
       atom.storeWindowDimensions()
-      atom.unloadEditorWindow() if confirmed
+      if confirmed
+        atom.unloadEditorWindow()
+      else
+        ipc.send('cancel-window-close')
 
       confirmed
 


### PR DESCRIPTION
This also fixes some cases where the window state would incorrectly be saved in the middle of exiting.
- [x] Avoid incorrectly saving state as windows are closed while restarting to install an update.
- [x] Make sure that `quitting` state doesn't incorrectly persist if quit is cancelled due to unsaved buffers.

Fixes #7156
Fixes #7214
