### PR TITLE
Handle native cut command in render process too

### DIFF
--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -127,6 +127,7 @@ class WindowEventHandler
     bindCommandToAction('core:undo', 'undo:')
     bindCommandToAction('core:redo', 'redo:')
     bindCommandToAction('core:select-all', 'selectAll:')
+    bindCommandToAction('core:cut', 'cut:')
 
   onKeydown: (event) ->
     atom.keymaps.handleKeyboardEvent(event)


### PR DESCRIPTION
I imagine the cut command was missed when this was originally done in https://github.com/atom/atom/commit/bb1bcc233ae37f6e72f3172db30908885c768919 ?

I verified it working manually by [re-building atom](https://github.com/atom/atom#building) and adding an input element with the `native-key-bindings` class through the developer console, e.g.

``` js
i=document.createElement('input'); i.classList.add('native-key-bindings'); i.type="text"; i.tabIndex="-1"; document.body.appendChild(i); i.style.position="absolute"; i.style.zIndex=3; i.style.bottom=0; i.style.border="5px solid red"; i;
```

and verifying that the cut now works with this change.
