### PR TITLE
Use latest npm in build

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -27,7 +27,7 @@
     "harmony-collections": "~0.3.8",
     "legal-eagle": "~0.10.0",
     "minidump": "~0.9",
-    "npm": "2.5.1",
+    "npm": "2.11.2",
     "rcedit": "~0.3.0",
     "request": "~2.27.0",
     "rimraf": "~2.2.2",

--- a/build/package.json
+++ b/build/package.json
@@ -27,7 +27,7 @@
     "harmony-collections": "~0.3.8",
     "legal-eagle": "~0.10.0",
     "minidump": "~0.9",
-    "npm": "2.11.2",
+    "npm": "2.13.3",
     "rcedit": "~0.3.0",
     "request": "~2.27.0",
     "rimraf": "~2.2.2",


### PR DESCRIPTION
This bumps npm to the latest version (2.11.2) - part of [an effort to update dependencies.](https://david-dm.org/atom/atom) Let's see if this goes green! :traffic_light: 

Fixes https://github.com/atom/atom/issues/8045
