### PR TITLE
Workspace.open() support for splitting up/down 

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -225,6 +225,40 @@ describe "Workspace", ->
               expect(workspace.paneContainer.root.children[0]).toBe pane1
               expect(workspace.paneContainer.root.children[1]).toBe pane4
 
+      describe "when the 'split' option is 'up'", ->
+        it "opens the new item in the upmost pane of the current pane axis", ->
+          editor = null
+          pane1 = workspace.getActivePane()
+          pane2 = pane1.splitDown()
+          pane2.activate()
+          expect(workspace.getActivePane()).toBe pane2
+          pane3 = null
+
+          waitsForPromise ->
+            workspace.open('a', split: 'up').then (o) -> editor = o
+
+          runs ->
+            pane3 = workspace.getPanes().filter((p) ->
+              p isnt pane1)[1]
+            expect(workspace.getActivePane()).toBe pane1
+
+        describe "when the 'split' option is 'down'", ->
+          it "opens the new item in the downmost pane of the current pane axis", ->
+            editor = null
+            pane1 = workspace.getActivePane()
+            pane2 = pane1.splitDown()
+            pane1.activate()
+            expect(workspace.getActivePane()).toBe pane1
+            pane3 = null
+
+            waitsForPromise ->
+              workspace.open('a', split: 'down').then (o) -> editor = o
+
+            runs ->
+              pane3 = workspace.getPanes().filter((p) ->
+                p isnt pane1)[0]
+              expect(workspace.getActivePane()).toBe pane2
+
     describe "when the file is over 2MB", ->
       it "opens the editor with largeFileMode: true", ->
         spyOn(fs, 'getSizeSync').andReturn 2 * 1048577 # 2MB

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -680,6 +680,25 @@ class Pane extends Model
     else
       @splitRight()
 
+  # If the parent is a vertical axis, returns either first child if `up` or last child if `down` if the
+  # child is a pane; otherwise returns a new pane created by splitting this pane according to the `direction` given
+  #
+  # * `direction` {String} of either `up` or `down` to indicate which direction to split the pane
+  findOrCreateFurthestVerticalSibling: (direction) ->
+    @splitDirection = switch direction
+      when 'up' then @splitUp
+      when 'down' then @splitDown
+    if @parent.orientation is 'vertical'
+      farthestSibling = switch direction
+        when 'up' then @parent.children[0]
+        when 'down'then last(@parent.children)
+      if farthestSibling instanceof PaneAxis
+        @splitDirection()
+      else
+        farthestSibling
+    else
+      @splitDirection()
+
   close: ->
     @destroy() if @confirmClose()
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -366,9 +366,10 @@ class Workspace extends Model
   #     initially. Defaults to `0`.
   #   * `initialColumn` A {Number} indicating which column to move the cursor to
   #     initially. Defaults to `0`.
-  #   * `split` Either 'left' or 'right'. If 'left', the item will be opened in
-  #     leftmost pane of the current active pane's row. If 'right', the
-  #     item will be opened in the rightmost pane of the current active pane's row.
+  #   * `split` Either 'left', 'right', 'up', or 'down'. If 'left', the item will be opened in leftmost pane of the
+  #     current active pane's row. If 'right', the item will be opened in the rightmost pane of the current active
+  #     pane's row. If 'up', the item will be opened in the upmost pane or a new pane created Split Up.
+  #     If 'down', the item will be oppened in the downmost pane or a new pane created Split Down.
   #   * `activatePane` A {Boolean} indicating whether to call {Pane::activate} on
   #     containing pane. Defaults to `true`.
   #   * `searchAllPanes` A {Boolean}. If `true`, the workspace will attempt to
@@ -388,6 +389,10 @@ class Workspace extends Model
         @getActivePane().findLeftmostSibling()
       when 'right'
         @getActivePane().findOrCreateRightmostSibling()
+      when 'down'
+        @getActivePane().findOrCreateFurthestVerticalSibling('down')
+      when 'up'
+        @getActivePane().findOrCreateFurthestVerticalSibling('up')
       else
         @getActivePane()
 


### PR DESCRIPTION
Closes https://github.com/atom/atom/issues/7059
Related to https://github.com/atom/markdown-preview/issues/99

Add ability to call `atom.workspace.open()` with `up` / `down` split properties.
