### PR TITLE
New default editor font

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -108,7 +108,7 @@ module.exports =
         maximum: 100
       lineHeight:
         type: ['string', 'number']
-        default: 1.44
+        default: 1.5
       showInvisibles:
         type: 'boolean'
         default: false

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -108,7 +108,7 @@ module.exports =
         maximum: 100
       lineHeight:
         type: ['string', 'number']
-        default: 1.4
+        default: 1.44
       showInvisibles:
         type: 'boolean'
         default: false

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -103,12 +103,12 @@ module.exports =
         default: ''
       fontSize:
         type: 'integer'
-        default: 16
+        default: 14
         minimum: 1
         maximum: 100
       lineHeight:
         type: ['string', 'number']
-        default: 1.3
+        default: 1.4
       showInvisibles:
         type: 'boolean'
         default: false

--- a/static/text-editor-light.less
+++ b/static/text-editor-light.less
@@ -4,8 +4,7 @@
 
 atom-text-editor {
   display: block;
-  font-family: Inconsolata, Monaco, Consolas, 'DejaVu Sans Mono', monospace;
-  line-height: 1.3;
+  font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
 }
 
 atom-text-editor[mini] {


### PR DESCRIPTION
This PR replaces the current default font for the editor. Fixes #7220

**Before**: The default is `Inconsolata`, but only if it's installed. If not, the fallback font is `Monaco`. The problem is that Inconsolata is quite smaller than other fonts, making it look bigger when changing the font in the settings. Or it's already too big when Inconsolata isn't installed. It's also a problem in mini editors.

**After**: New default is `Menlo`.
- Much closer to other fonts.
- Already comes preinstalled with OS X from Snow Leopard or newer.
- Is also the default in other editors/applications, like Xcode.

![default-font](https://cloud.githubusercontent.com/assets/378023/8155190/b9f42d94-137c-11e5-8bf0-714972431662.gif)

Text in mini editors in some/most themes will look bigger. But they already do that, if Inconsolata isn't installed or if a user changes the font in the settings. So with this change, themes hopefully make the `@input-font-size` a bit smaller and then it would be more consistent with other fonts.

![screen shot 2015-06-15 at 4 16 11 pm](https://cloud.githubusercontent.com/assets/378023/8155386/b3b808ae-137e-11e5-8327-51b88e79c72c.png)
### Possible alternatives
1. `Monaco`. It's the current fallback font if Inconsolata is not installed.
   - Pro: Less people would be affected by this change.
   - Con: Monaco doesn't have _italic_ and _bold_ version, which some themes use. Also in MD files. Menlo is newer and arguably more legible.
2. Bundle a new default font (see: #4201).
   - Pro: Could be any font, not just a system font. Would be consistent across all platforms.
   - Con: Even more users would be affected (also Win+Linux). Staying close to the platform might be a good idea because people are already used to that font from other editors/applications. Like Xcode uses Menlo and Visual Studio uses Consolas, in Atom it would be the same.
### Who is affected?
- Users that haven't changed the Font Family in the settings and have Inconsolata installed or are on OS X.
- Users that haven't changed the Font Size in the settings.
- Users that haven't changed the Line Height in the settings.
### I prefer the old default

For users that prefer the old default, it can be changed back in the settings to:
- Font Family: `Inconsolata, Monaco, Consolas, 'DejaVu Sans Mono', monospace`
- Font Size: `16`
- Line Height: `1.3`
