### PR TITLE
DisplayBuffer::decorateMarker leak subscriptions

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1229,6 +1229,11 @@ describe "DisplayBuffer", ->
       decoration.destroy()
       expect(displayBuffer.decorationForId(decoration.id)).not.toBeDefined()
 
+    it "does not leak disposables", ->
+      disposablesSize = displayBuffer.disposables.disposables.size
+      decoration.destroy()
+      expect(displayBuffer.disposables.disposables.size).toBe(disposablesSize - 1)
+
     describe "when a decoration is updated via Decoration::update()", ->
       it "emits an 'updated' event containing the new and old params", ->
         decoration.onDidChangeProperties updatedSpy = jasmine.createSpy()

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -974,7 +974,10 @@ class DisplayBuffer extends Model
   decorateMarker: (marker, decorationParams) ->
     marker = @getMarker(marker.id)
     decoration = new Decoration(marker, this, decorationParams)
-    @disposables.add decoration.onDidDestroy => @removeDecoration(decoration)
+    decorationDestroyedDisposable = decoration.onDidDestroy =>
+      @removeDecoration(decoration)
+      @disposables.remove(decorationDestroyedDisposable)
+    @disposables.add(decorationDestroyedDisposable)
     @decorationsByMarkerId[marker.id] ?= []
     @decorationsByMarkerId[marker.id].push(decoration)
     @overlayDecorationsById[decoration.id] = decoration if decoration.isType('overlay')


### PR DESCRIPTION
decoration listener is not destroyed.

**Active Packages**
- bracket-matcher

[![Gyazo](http://i.gyazo.com/b61da2fc549debdaf6ece5779ab17a30.gif)](http://gyazo.com/b61da2fc549debdaf6ece5779ab17a30)
