### PR TITLE
Revert "Fix inconsistency with pane resize cursors."

### DIFF
--- a/static/panes.less
+++ b/static/panes.less
@@ -25,7 +25,7 @@ atom-pane-container {
       width: 100%;
       height: 8px;
       margin-top: -4px;
-      cursor: row-resize;
+      cursor: ns-resize;
       border-bottom: none;
     }
   }
@@ -37,7 +37,7 @@ atom-pane-container {
       width: 8px;
       height: 100%;
       margin-left: -4px;
-      cursor: col-resize;
+      cursor: ew-resize;
       border-right: none;
     }
   }


### PR DESCRIPTION
Reverts atom/atom#7179 

Tree view uses `ew-resize` as shown here : https://github.com/atom/tree-view/blob/f0530bca9217ef6c2bb9fc63d815c9d153d2c898/styles/tree-view.less#L58

`row-resize` and `col-resize` don't work on windows (for whatever reason). 

Screenshots : https://github.com/atom/atom/pull/7179#commitcomment-11715003 
