### PR TITLE
Fix pane resize cursors on Windows

### DIFF
--- a/static/panes.less
+++ b/static/panes.less
@@ -81,7 +81,7 @@ atom-pane-container {
       }
     }
 
-    atom-pane-axis.vertical {
+    atom-pane-axis.horizontal {
       & > atom-pane-resize-handle {
         cursor: ew-resize;
       }

--- a/static/panes.less
+++ b/static/panes.less
@@ -71,3 +71,20 @@ atom-pane-container {
     }
   }
 }
+
+// Windows doesn't have row- and col-resize cursors
+.platform-win32 {
+  atom-pane-container {
+    atom-pane-axis.vertical {
+      & > atom-pane-resize-handle {
+        cursor: ns-resize;
+      }
+    }
+
+    atom-pane-axis.vertical {
+      & > atom-pane-resize-handle {
+        cursor: ew-resize;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Windows doesn't have `row-resize` or `col-resize` cursors, so this re-adds `ew-resize` and `ns-resize` cursors on the pane resize handle.

Addresses https://github.com/atom/atom/commit/384b88eecf6aae287f9a7a5c79a1f52dd0755494#commitcomment-11715023

Closes https://github.com/atom/atom/pull/7309
