### PR TITLE
Fix some issues with auto-indent

### DIFF
--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -101,6 +101,18 @@ describe "LanguageMode", ->
         expect(languageMode.suggestedIndentForBufferRow(0)).toBe 0
         expect(languageMode.suggestedIndentForBufferRow(1)).toBe 1
         expect(languageMode.suggestedIndentForBufferRow(2)).toBe 2
+        expect(languageMode.suggestedIndentForBufferRow(5)).toBe 3
+        expect(languageMode.suggestedIndentForBufferRow(7)).toBe 2
+        expect(languageMode.suggestedIndentForBufferRow(9)).toBe 1
+        expect(languageMode.suggestedIndentForBufferRow(11)).toBe 1
+
+      it "does not take invisibles into account", ->
+        atom.config.set('editor.showInvisibles', true)
+        expect(languageMode.suggestedIndentForBufferRow(0)).toBe 0
+        expect(languageMode.suggestedIndentForBufferRow(1)).toBe 1
+        expect(languageMode.suggestedIndentForBufferRow(2)).toBe 2
+        expect(languageMode.suggestedIndentForBufferRow(5)).toBe 3
+        expect(languageMode.suggestedIndentForBufferRow(7)).toBe 2
         expect(languageMode.suggestedIndentForBufferRow(9)).toBe 1
         expect(languageMode.suggestedIndentForBufferRow(11)).toBe 1
 

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -261,7 +261,8 @@ class LanguageMode
     desiredIndentLevel += 1 if increaseIndentRegex.testSync(precedingLine) and not @editor.isBufferRowCommented(precedingRow)
 
     return desiredIndentLevel unless decreaseIndentRegex = @decreaseIndentRegexForScopeDescriptor(scopeDescriptor)
-    desiredIndentLevel -= 1 if decreaseIndentRegex.testSync(tokenizedLine.text)
+    line = @buffer.lineForRow(bufferRow)
+    desiredIndentLevel -= 1 if decreaseIndentRegex.testSync(line)
 
     Math.max(desiredIndentLevel, 0)
 

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -366,7 +366,7 @@ class Selection extends Model
       indentAdjustment = @editor.indentLevelForLine(precedingText) - options.indentBasis
       @adjustIndent(remainingLines, indentAdjustment)
 
-    if options.autoIndent and not NonWhitespaceRegExp.test(precedingText)
+    if options.autoIndent and not NonWhitespaceRegExp.test(precedingText) and remainingLines.length > 0
       autoIndentFirstLine = true
       firstLine = precedingText + firstInsertedLine
       desiredIndentLevel = @editor.languageMode.suggestedIndentForLineAtBufferRow(oldBufferRange.start.row, firstLine)


### PR DESCRIPTION
Previously, when pasting text with the `Auto Indent on Paste` setting enabled, the indentation of the affected lines would always be adjusted afterwards based on the language's 'suggested indentation'. This would sometimes have the effect of undoing the paste!

Now, this adjustment is _only_ performed if the pasted text spans more than one line. I believe this matches the behavior of TextMate, which I find to be very intuitive.

Also, while fixing this, I noticed an unrelated bug where the `decreaseIndentPattern` would sometimes incorrectly fail to match, because it was being tested against the version of the text with invisible characters substituted. For example, when invisibles are enabled, leading spaces are displayed as `•`. The regex was being tested against the displayed string instead of the buffer's actual contents. This would cause [language-html's](https://github.com/atom/language-html/blob/94e850dc4ab848baac1f413e4cb864864e1c24f8/settings/language-html.cson#L14) and [language-javascript's](https://github.com/atom/language-javascript/blob/601cb6cb8f80e03e7eaa5695515d6366fb2b6d18/settings/language-javascript.cson#L11) decrease-indent-patterns to fail to match.

Fixes https://github.com/atom/atom/issues/7317
