### PR TITLE
Prepare 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ Visit [atom.io](https://atom.io) to learn more or visit the [Atom forum](https:/
 Follow [@AtomEditor](https://twitter.com/atomeditor) on Twitter for important
 announcements.
 
-Visit [issue #3684](https://github.com/atom/atom/issues/3684) to learn more
-about the Atom 1.0 roadmap.
-
 ## Documentation
 
 If you want to read about using Atom or developing packages in Atom, the [Atom Flight Manual](https://atom.io/docs/latest/) is free and available online, along with ePub, PDF and mobi versions. You can find the source to the manual in [atom/docs](https://github.com/atom/docs).

--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "1.0.0"
+    "atom-package-manager": "1.0.1"
   }
 }

--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "0.171.0"
+    "atom-package-manager": "1.0.0"
   }
 }

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -95,7 +95,7 @@ module.exports = (grunt) ->
     if process.platform in ['darwin', 'linux']
       options =
         cmd: appPath
-        args: ['--test', "--resource-path=#{resourcePath}", "--spec-directory=#{coreSpecsPath}", '--include-deprecated-apis']
+        args: ['--test', "--resource-path=#{resourcePath}", "--spec-directory=#{coreSpecsPath}"]
         opts:
           env: _.extend({}, process.env,
             ATOM_INTEGRATION_TESTS_ENABLED: true
@@ -104,7 +104,7 @@ module.exports = (grunt) ->
     else if process.platform is 'win32'
       options =
         cmd: process.env.comspec
-        args: ['/c', appPath, '--test', "--resource-path=#{resourcePath}", "--spec-directory=#{coreSpecsPath}", '--log-file=ci.log', '--include-deprecated-apis']
+        args: ['/c', appPath, '--test', "--resource-path=#{resourcePath}", "--spec-directory=#{coreSpecsPath}", '--log-file=ci.log']
         opts:
           env: _.extend({}, process.env,
             ATOM_INTEGRATION_TESTS_ENABLED: true

--- a/exports/atom.coffee
+++ b/exports/atom.coffee
@@ -120,14 +120,6 @@ unless process.env.ATOM_SHELL_INTERNAL_RUN_AS_NODE
       """
       require '../src/select-list-view'
 
-    Object.defineProperty module.exports, 'React', get: ->
-      deprecate "Please require `react-atom-fork` instead: `React = require 'react-atom-fork'`. Add `\"react-atom-fork\": \"^0.11\"` to your package dependencies."
-      require 'react-atom-fork'
-
-    Object.defineProperty module.exports, 'Reactionary', get: ->
-      deprecate "Please require `reactionary-atom-fork` instead: `Reactionary = require 'reactionary-atom-fork'`. Add `\"reactionary-atom-fork\": \"^0.9\"` to your package dependencies."
-      require 'reactionary-atom-fork'
-
 if includeDeprecatedAPIs
   Object.defineProperty module.exports, 'Git', get: ->
     deprecate "Please require `GitRepository` instead of `Git`: `{GitRepository} = require 'atom'`"

--- a/package.json
+++ b/package.json
@@ -51,8 +51,6 @@
     "property-accessors": "^1.1.3",
     "q": "^1.1.2",
     "random-words": "0.0.1",
-    "react-atom-fork": "^0.11.5",
-    "reactionary-atom-fork": "^1.0.0",
     "runas": "2.0.0",
     "scandal": "2.0.3",
     "scoped-property-store": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom",
   "productName": "Atom",
-  "version": "0.212.0",
+  "version": "1.0.0",
   "description": "A hackable text editor for the 21st Century.",
   "main": "./src/browser/main.js",
   "repository": {

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -172,8 +172,6 @@ class AtomApplication
     @on 'application:open-folder', -> @promptForPathToOpen('folder', getLoadSettings())
     @on 'application:open-dev', -> @promptForPathToOpen('all', devMode: true)
     @on 'application:open-safe', -> @promptForPathToOpen('all', safeMode: true)
-    @on 'application:open-with-deprecated-apis', -> @promptForPathToOpen('all', includeDeprecatedAPIs: true)
-    @on 'application:open-dev-with-deprecated-apis', -> @promptForPathToOpen('all', {includeDeprecatedAPIs: true, devMode: true})
     @on 'application:inspect', ({x, y, atomWindow}) ->
       atomWindow ?= @focusedWindow()
       atomWindow?.browserWindow.inspectElement(x, y)

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -18,7 +18,7 @@ class AtomWindow
   isSpec: null
 
   constructor: (settings={}) ->
-    {@resourcePath, pathToOpen, locationsToOpen, @isSpec, @exitWhenDone, @safeMode, @devMode, @includeDeprecatedAPIs} = settings
+    {@resourcePath, pathToOpen, locationsToOpen, @isSpec, @exitWhenDone, @safeMode, @devMode} = settings
     locationsToOpen ?= [{pathToOpen}] if pathToOpen
     locationsToOpen ?= []
 
@@ -47,7 +47,6 @@ class AtomWindow
     loadSettings.resourcePath = @resourcePath
     loadSettings.devMode ?= false
     loadSettings.safeMode ?= false
-    loadSettings.includeDeprecatedAPIs ?= false
 
     # Only send to the first non-spec window created
     if @constructor.includeShellLoadTime and not @isSpec

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -137,7 +137,6 @@ parseCommandLine = ->
   executedFrom = args['executed-from']
   devMode = args['dev']
   safeMode = args['safe']
-  includeDeprecatedAPIs = args['include-deprecated-apis']
   pathsToOpen = args._
   test = args['test']
   specDirectory = args['spec-directory']
@@ -171,7 +170,6 @@ parseCommandLine = ->
   process.env.PATH = args['path-environment'] if args['path-environment']
 
   {resourcePath, pathsToOpen, executedFrom, test, version, pidToKillWhenClosed,
-   devMode, includeDeprecatedAPIs, safeMode, newWindow, specDirectory, logFile,
-   socketPath, profileStartup}
+   devMode, safeMode, newWindow, specDirectory, logFile, socketPath, profileStartup}
 
 start()

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -140,8 +140,6 @@ atom.commands.add 'atom-workspace',
   'application:open-folder': -> ipc.send('command', 'application:open-folder')
   'application:open-dev': -> ipc.send('command', 'application:open-dev')
   'application:open-safe': -> ipc.send('command', 'application:open-safe')
-  'application:open-with-deprecated-apis': -> ipc.send('command', 'application:open-with-deprecated-apis')
-  'application:open-dev-with-deprecated-apis': -> ipc.send('command', 'application:open-dev-with-deprecated-apis')
   'application:add-project-folder': -> atom.addProjectFolder()
   'application:minimize': -> ipc.send('command', 'application:minimize')
   'application:zoom': -> ipc.send('command', 'application:zoom')

--- a/static/index.js
+++ b/static/index.js
@@ -75,7 +75,7 @@ var setupWindow = function(loadSettings) {
   ModuleCache.register(loadSettings);
   ModuleCache.add(loadSettings.resourcePath);
 
-  require('grim').includeDeprecatedAPIs = !!loadSettings.includeDeprecatedAPIs;
+  require('grim').includeDeprecatedAPIs = false;
 
   // Start the crash reporter before anything else.
   require('crash-reporter').start({

--- a/static/index.js
+++ b/static/index.js
@@ -75,7 +75,8 @@ var setupWindow = function(loadSettings) {
   ModuleCache.register(loadSettings);
   ModuleCache.add(loadSettings.resourcePath);
 
-  require('grim').includeDeprecatedAPIs = false;
+  // Only include deprecated APIs when running core spec
+  require('grim').includeDeprecatedAPIs = isRunningCoreSpecs(loadSettings);
 
   // Start the crash reporter before anything else.
   require('crash-reporter').start({
@@ -217,6 +218,14 @@ var setupWindowBackground = function() {
       backgroundStylesheet = null;
     }, 1000);
   }, false);
+}
+
+var isRunningCoreSpecs = function(loadSettings) {
+  return !!(loadSettings &&
+    loadSettings.isSpec &&
+    loadSettings.specDirectory &&
+    loadSettings.resourcePath &&
+    path.dirname(loadSettings.specDirectory) === loadSettings.resourcePath);
 }
 
 parseLoadSettings();


### PR DESCRIPTION
Running task list of cleanup to do before 1.0 ships:
### Things to do before 1.0 ships
- [x] Bump `package.json` version to `1.0.0`
- [x] Remove `--include-deprecated-apis` command line option
- [x] Bump [apm](https://github.com/atom/apm) to 1.0 https://github.com/atom/apm/pull/383
- [x] Upgrade apm package/theme templates to use `^1` `atom` engine field https://github.com/atom/apm/pull/383
- [x] Remove [React forks](https://github.com/atom/atom/blob/master/package.json#L54-L55) from `package.json`
### Things to do after 1.0 ships
- [ ] Update screenshots in docs repo
- [x] Remove `--one` flag from https://github.com/atom/ci files
- [ ] Update `engines` version ranges in `package.json` for bundled packages?
- [ ] Remove or flesh out TODOs in docs

Closes https://github.com/atom/atom/issues/3684
