### PR TITLE
Remove event listeners from orphaned gutters

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -743,6 +743,16 @@ describe "TextEditorComponent", ->
         beforeEach ->
           gutterNode = componentNode.querySelector('.gutter')
 
+        describe "when the component is destroyed", ->
+          it "stops listening for folding events", ->
+            component.destroy()
+
+            lineNumber = component.lineNumberNodeForScreenRow(1)
+            target = lineNumber.querySelector('.icon-right')
+            target.dispatchEvent(buildClickEvent(target))
+
+            expect(nextAnimationFrame).toBe(noAnimationFrame)
+
         it "folds and unfolds the block represented by the fold indicator when clicked", ->
           expect(lineNumberHasClass(1, 'folded')).toBe false
 
@@ -1726,6 +1736,14 @@ describe "TextEditorComponent", ->
 
     beforeEach ->
       gutterNode = componentNode.querySelector('.gutter')
+
+    describe "when the component is destroyed", ->
+      it "stops listening for selection events", ->
+        component.destroy()
+
+        gutterNode.dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenRowInGutter(1)))
+
+        expect(editor.getSelectedScreenRange()).toEqual [[0, 0], [0, 0]]
 
     describe "when the gutter is clicked", ->
       it "selects the clicked row", ->

--- a/src/gutter-container-component.coffee
+++ b/src/gutter-container-component.coffee
@@ -16,7 +16,12 @@ class GutterContainerComponent
 
     @domNode = document.createElement('div')
     @domNode.classList.add('gutter-container')
-    @domNode.style.display = 'flex';
+    @domNode.style.display = 'flex'
+
+  destroy: ->
+    for {name, component} in @gutterComponents
+      component.destroy?()
+    return
 
   getDomNode: ->
     @domNode

--- a/src/line-number-gutter-component.coffee
+++ b/src/line-number-gutter-component.coffee
@@ -18,6 +18,10 @@ class LineNumberGutterComponent
     @domNode.addEventListener 'click', @onClick
     @domNode.addEventListener 'mousedown', @onMouseDown
 
+  destroy: ->
+    @domNode.removeEventListener 'click', @onClick
+    @domNode.removeEventListener 'mousedown', @onMouseDown
+
   getDomNode: ->
     @domNode
 

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -106,6 +106,7 @@ class TextEditorComponent
     @mounted = false
     @disposables.dispose()
     @presenter.destroy()
+    @gutterContainerComponent?.destroy()
     window.removeEventListener 'resize', @requestHeightAndWidthMeasurement
 
   getDomNode: ->


### PR DESCRIPTION
Fixes #7337.

We caught another :bug: related to #7320. Basically, when multiple `TextEditorComponent`s were created for the same instance of `TextEditor`, we weren’t removing some event listeners from the recycled gutter DOM node which, in turn, had multiple handlers listening and acting when a certain event was fired (e.g. `onMouseDown` and `onMouseClick`).

@maxbrunsfeld: could you give this a shot and look out for the bug you reported? I am quite confident this is going to fix it but I’d like to have your feedback as well. :bow: 

I think this is likely to be the last fix for all the so-called “global state” issues that we have encountered over the last days. However, I won’t feel very confident about changing these areas of the code without introducing new :beetle:s. I like @jssln's proposal :bulb: of having a `1:1` correspondence between `TextEditorComponent` and `TextEditor` and I think we have two ways of handling it:
1. When panes are split, always create a new instance of `TextEditor`.
2. When `TextEditorElement` is detached, avoid creating a new instance of `TextEditorComponent` and simply use the previous one.

@nathansobo: this PR can be merged without addressing the above proposal, but I am curious about your :thought_balloon: on this. My two cents are that we should go for 2), as it’s kinda pointless to always create new instances as proposed in 1). I am sure, though, that there are good reasons for that behavior to exist  and it’d be great if you could share your thoughts about them.

Thanks everyone! :bow: 
