### PR TITLE
Add assertion mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "link": "0.30.0",
     "markdown-preview": "0.150.0",
     "metrics": "0.51.0",
-    "notifications": "0.56.0",
+    "notifications": "0.57.0",
     "open-on-github": "0.37.0",
     "package-generator": "0.39.0",
     "release-notes": "0.53.0",

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -142,6 +142,37 @@ describe "the `atom` global", ->
         expect(atom.openDevTools).not.toHaveBeenCalled()
         expect(atom.executeJavaScriptInDevTools).not.toHaveBeenCalled()
 
+  describe ".assert(condition, message, metadata)", ->
+    errors = null
+
+    beforeEach ->
+      errors = []
+      atom.onDidFailAssertion (error) -> errors.push(error)
+
+    describe "if the condition is false", ->
+      it "notifies onDidFailAssertion handlers with an error object based on the call site of the assertion", ->
+        atom.assert(false, "a == b")
+        expect(errors.length).toBe 1
+        expect(errors[0].message).toBe "Assertion failed: a == b"
+        expect(errors[0].stack).toContain('atom-spec')
+
+      describe "if metadata is an object", ->
+        it "assigns the object on the error as `metadata`", ->
+          metadata = {foo: 'bar'}
+          atom.assert(false, "a == b", metadata)
+          expect(errors[0].metadata).toBe metadata
+
+      describe "if metadata is a function", ->
+        it "assigns the function's return value on the error as `metadata`", ->
+          metadata = {foo: 'bar'}
+          atom.assert(false, "a == b", -> metadata)
+          expect(errors[0].metadata).toBe metadata
+
+    describe "if the condition is true", ->
+      it "does nothing", ->
+        atom.assert(true, "a == b")
+        expect(errors).toEqual []
+
   describe "saving and loading", ->
     afterEach -> atom.mode = "spec"
 

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -151,7 +151,8 @@ describe "the `atom` global", ->
 
     describe "if the condition is false", ->
       it "notifies onDidFailAssertion handlers with an error object based on the call site of the assertion", ->
-        atom.assert(false, "a == b")
+        result = atom.assert(false, "a == b")
+        expect(result).toBe false
         expect(errors.length).toBe 1
         expect(errors[0].message).toBe "Assertion failed: a == b"
         expect(errors[0].stack).toContain('atom-spec')
@@ -170,7 +171,8 @@ describe "the `atom` global", ->
 
     describe "if the condition is true", ->
       it "does nothing", ->
-        atom.assert(true, "a == b")
+        result = atom.assert(true, "a == b")
+        expect(result).toBe true
         expect(errors).toEqual []
 
   describe "saving and loading", ->

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -86,13 +86,13 @@ describe "the `atom` global", ->
           error = e
           window.onerror.call(window, e.toString(), 'abc', 2, 3, e)
 
-        delete willThrowSpy.mostRecentCall.args[0].preventDefault
-        expect(willThrowSpy).toHaveBeenCalledWith
-          message: error.toString()
-          url: 'abc'
-          line: 2
-          column: 3
-          originalError: error
+        expect(willThrowSpy).toHaveBeenCalledWith(error)
+
+        # Deprecated event properties
+        expect(error.url).toBe 'abc'
+        expect(error.line).toBe 2
+        expect(error.column).toBe 3
+        expect(error.originalError).toBe error
 
       it "will not show the devtools when preventDefault() is called", ->
         willThrowSpy.andCallFake (errorObject) -> errorObject.preventDefault()
@@ -120,12 +120,27 @@ describe "the `atom` global", ->
         catch e
           error = e
           window.onerror.call(window, e.toString(), 'abc', 2, 3, e)
-        expect(didThrowSpy).toHaveBeenCalledWith
-          message: error.toString()
-          url: 'abc'
-          line: 2
-          column: 3
-          originalError: error
+
+        expect(didThrowSpy).toHaveBeenCalledWith(error)
+
+        # Deprecated event properties
+        expect(error.url).toBe 'abc'
+        expect(error.line).toBe 2
+        expect(error.column).toBe 3
+        expect(error.originalError).toBe error
+
+      it "will not show the devtools when preventDefault() is called", ->
+        didThrowSpy.andCallFake (errorObject) -> errorObject.preventDefault()
+        atom.onDidThrowError(didThrowSpy)
+
+        try
+          a + 1
+        catch e
+          window.onerror.call(window, e.toString(), 'abc', 2, 3, e)
+
+        expect(didThrowSpy).toHaveBeenCalled()
+        expect(atom.openDevTools).not.toHaveBeenCalled()
+        expect(atom.executeJavaScriptInDevTools).not.toHaveBeenCalled()
 
   describe "saving and loading", ->
     afterEach -> atom.mode = "spec"

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -329,6 +329,9 @@ class Atom extends Model
   onDidThrowError: (callback) ->
     @emitter.on 'did-throw-error', callback
 
+  onDidFailAssertion: (callback) ->
+    @emitter.on 'did-fail-assertion', callback
+
   ###
   Section: Atom Details
   ###
@@ -710,6 +713,20 @@ class Atom extends Model
   ###
   Section: Private
   ###
+
+  assert: (condition, message, metadata) ->
+    return if condition
+
+    error = new Error("Assertion failed: " + message)
+    Error.captureStackTrace(error, @assert)
+
+    if metadata?
+      if typeof metadata is 'function'
+        error.metadata = metadata()
+      else
+        error.metadata = metadata
+
+    @emitter.emit 'did-fail-assertion', error
 
   deserializeProject: ->
     Project = require './project'

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -198,27 +198,28 @@ class Atom extends Model
   initialize: ->
     sourceMapCache = {}
 
-    window.onerror = =>
-      @lastUncaughtError = Array::slice.call(arguments)
-      [message, url, line, column, originalError] = @lastUncaughtError
+    window.onerror = (message, url, line, column, error) =>
+      @lastUncaughtError = error
 
-      convertedLine = convertLine(url, line, column, sourceMapCache)
-      {line, column} = convertedLine if convertedLine?
-      originalError.stack = convertStackTrace(originalError.stack, sourceMapCache) if originalError
-
-      eventObject = {message, url, line, column, originalError}
+      # TODO: These should be deprecated for 2.0 once we transition the
+      # exception-reporting package to the new API.
+      error.url = url
+      error.line = line
+      error.column = column
+      error.originalError = error
 
       openDevTools = true
-      eventObject.preventDefault = -> openDevTools = false
+      error.preventDefault = -> openDevTools = false
 
-      @emitter.emit 'will-throw-error', eventObject
+      # TODO: Deprecate onWillThrowError once we transition the notifications
+      # package to use onDidThrowError instead.
+      @emitter.emit 'will-throw-error', error
+      @emit 'uncaught-error', arguments... if includeDeprecatedAPIs
+      @emitter.emit 'did-throw-error', error
 
       if openDevTools
         @openDevTools()
         @executeJavaScriptInDevTools('DevToolsAPI.showConsole()')
-
-      @emit 'uncaught-error', arguments... if includeDeprecatedAPIs
-      @emitter.emit 'did-throw-error', {message, url, line, column, originalError}
 
     @disposables?.dispose()
     @disposables = new CompositeDisposable
@@ -321,13 +322,8 @@ class Atom extends Model
 
   # Extended: Invoke the given callback whenever there is an unhandled error.
   #
-  # * `callback` {Function} to be called whenever there is an unhandled error
-  #   * `event` {Object}
-  #     * `originalError` {Object} the original error object
-  #     * `message` {String} the original error object
-  #     * `url` {String} Url to the file where the error originated.
-  #     * `line` {Number}
-  #     * `column` {Number}
+  # * `callback` {Function} to be called whenever there is an unhandled error.
+  #   * `error` The unhandled {Error} object.
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidThrowError: (callback) ->

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -715,7 +715,7 @@ class Atom extends Model
   ###
 
   assert: (condition, message, metadata) ->
-    return if condition
+    return true if condition
 
     error = new Error("Assertion failed: " + message)
     Error.captureStackTrace(error, @assert)
@@ -727,6 +727,8 @@ class Atom extends Model
         error.metadata = metadata
 
     @emitter.emit 'did-fail-assertion', error
+
+    false
 
   deserializeProject: ->
     Project = require './project'

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -203,6 +203,7 @@ class Atom extends Model
 
       # TODO: These should be deprecated for 2.0 once we transition the
       # exception-reporting package to the new API.
+      error ?= {}
       error.url = url
       error.line = line
       error.column = column

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -204,6 +204,7 @@ class Atom extends Model
       # TODO: These should be deprecated for 2.0 once we transition the
       # exception-reporting package to the new API.
       error ?= {}
+      error.message ?= message
       error.url = url
       error.line = line
       error.column = column

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -292,7 +292,17 @@ class TokenizedBuffer extends Model
   # Returns a {Boolean} indicating whether the given buffer row starts
   # a a foldable row range due to the code's indentation patterns.
   isFoldableCodeAtRow: (row) ->
-    return false if @buffer.isRowBlank(row) or @tokenizedLineForRow(row).isComment()
+    # Investigating an exception that's occurring here due to the line being
+    # undefined. This should paper over the problem but we want to figure out
+    # what is happening:
+    tokenizedLine = @tokenizedLineForRow(row)
+    atom.assert tokenizedLine?, "TokenizedLine is defined", =>
+      metadata:
+        row: row
+        rowCount: @tokenizedLines.length
+    return false unless tokenizedLine?
+
+    return false if @buffer.isRowBlank(row) or tokenizedLine.isComment()
     nextRow = @buffer.nextNonBlankRow(row)
     return false unless nextRow?
 


### PR DESCRIPTION
There are a few hard-to-reproduce uncaught exceptions lurking in Atom that are giving a subset of our users a hard time. Until now, in order to solve these kinds of mysteries, our only option other than raw luck with reproduction steps or a brilliant stroke of insight was to be more aggressive about throwing exceptions when getting into an invalid state. But, of course, we're extremely reluctant to do that because who wants to introduce an even greater chance of throwing an exception?!

This PR enables a better approach by adding a new tool to our box: `atom.assert`. This global method takes a condition, a description message, and an optional metadata callback as follows:

``` coffee
atom.assert a is b, "a is b", -> {a, b}
```

Now, whenever we have uncaught exceptions, our goal should be as follows:
- If appropriate, do something to suppress the exception. This may lead to other, weirder errors, but we also may survive without the user ever noticing. This is obviously an extremely short-term strategy, and it will need to be applied judiciously.
- Start forming hypotheses and seasoning in efficient-to-run assertions that can investigate how and where things might be going wrong. This will enable us to start chasing errors to their source as we put out releases.

An example of this approach is included in this PR, referencing #5905.

@atom/feedback Once we start doing this, it could be fairly important to know if an assertion has failed when someone is reporting a bug. We'll be reporting assertion failures to bugsnag and logging them to the console. Do we want some other indicator? My main thing is that we need to be able to insert assertions without interrupting a user's flow.

It's also worth noting that this changes the API of `atom.onDidThrowError` to yield the entire `Error` object to subscribers. It's made backward-compatible by adding the old event properties to the error object. I found no packages that use this method, so it should be pretty safe to change this.
