### PR TITLE
Mark Clipboard::write's metadata argument as optional

### DIFF
--- a/src/clipboard.coffee
+++ b/src/clipboard.coffee
@@ -31,7 +31,7 @@ class Clipboard
   # {::readWithMetadata}.
   #
   # * `text` The {String} to store.
-  # * `metadata` The additional info to associate with the text.
+  # * `metadata` (optional) The additional info to associate with the text.
   write: (text, metadata) ->
     @signatureForMetadata = @md5(text)
     @metadata = metadata


### PR DESCRIPTION
`Clipboard::write()`'s `metadata` argument is optional, but it's currently marked as required - this updates the docs to mark it as optional.

/cc @atom/feedback
