### PR TITLE
add pane resize keyboard commands

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -173,6 +173,10 @@
   'cmd-k cmd-8': 'editor:fold-at-indent-level-8'
   'cmd-k cmd-9': 'editor:fold-at-indent-level-9'
 
+'atom-workspace atom-pane':
+  'cmd-alt-=': 'pane:enlarge'
+  'cmd-alt--': 'pane:shrink'
+
 # allow standard input fields to work correctly
 'body .native-key-bindings':
   'cmd-z': 'native!'

--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -135,6 +135,10 @@
   'ctrl-k ctrl-8': 'editor:fold-at-indent-level-8'
   'ctrl-k ctrl-9': 'editor:fold-at-indent-level-9'
 
+'atom-workspace atom-pane':
+  'ctrl-alt-=': 'pane:enlarge'
+  'ctrl-alt--': 'pane:shrink'
+  
 # allow standard input fields to work correctly
 'body .native-key-bindings':
   'ctrl-z': 'native!'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -139,6 +139,10 @@
   'ctrl-k ctrl-8': 'editor:fold-at-indent-level-8'
   'ctrl-k ctrl-9': 'editor:fold-at-indent-level-9'
 
+'atom-workspace atom-pane':
+  'ctrl-alt-=': 'pane:enlarge'
+  'ctrl-alt--': 'pane:shrink'
+
 # allow standard input fields to work correctly
 'body .native-key-bindings':
   'ctrl-z': 'native!'

--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -156,5 +156,7 @@ atom.commands.add 'atom-pane',
   'pane:split-down': -> @getModel().splitDown(copyActiveItem: true)
   'pane:close': -> @getModel().close()
   'pane:close-other-items': -> @getModel().destroyInactiveItems()
+  'pane:enlarge': -> @getModel().setFlexScale(@getModel().getFlexScale() * 1.1)
+  'pane:shrink': -> @getModel().setFlexScale(@getModel().getFlexScale() / 1.1)
 
 module.exports = PaneElement = document.registerElement 'atom-pane', prototype: PaneElement.prototype


### PR DESCRIPTION
This PR add commands `pane:shrink` and `pane:enlarge` to make it enable resize the panes with keyboard.

The following is the keymap binding:

| Command name | Default key binding | Comment |
| --- | :-: | --- |
| `pane:enlarge` | `cmd-alt-=` | enlarge the current pane by 10% |
| `panes:shrink` | `cmd-alt--` | shrink the current pane by 10% |

Closes https://github.com/atom/atom/issues/7332
