### PR TITLE
Throw error for commands registered with non-function callbacks

### DIFF
--- a/spec/command-registry-spec.coffee
+++ b/spec/command-registry-spec.coffee
@@ -158,11 +158,22 @@ describe "CommandRegistry", ->
         addError = error
       expect(addError.message).toContain(badSelector)
 
-    it "throws an error when called with an non-function callback", ->
+    it "throws an error when called with a non-function callback and selector target", ->
       badCallback = null
       addError = null
+
       try
         registry.add '.selector', 'foo:bar', badCallback
+      catch error
+        addError = error
+      expect(addError.message).toContain("Can't register a command with non-function callback.")
+
+    it "throws an error when called with an non-function callback and object target", ->
+      badCallback = null
+      addError = null
+
+      try
+        registry.add document.body, 'foo:bar', badCallback
       catch error
         addError = error
       expect(addError.message).toContain("Can't register a command with non-function callback.")

--- a/spec/command-registry-spec.coffee
+++ b/spec/command-registry-spec.coffee
@@ -158,6 +158,15 @@ describe "CommandRegistry", ->
         addError = error
       expect(addError.message).toContain(badSelector)
 
+    it "throws an error when called with an non-function callback", ->
+      badCallback = null
+      addError = null
+      try
+        registry.add '.selector', 'foo:bar', badCallback
+      catch error
+        addError = error
+      expect(addError.message).toContain("Can't register a command with non-function callback.")
+
   describe "::findCommands({target})", ->
     it "returns commands that can be invoked on the target or its ancestors", ->
       registry.add '.parent', 'namespace:command-1', ->

--- a/src/command-registry.coffee
+++ b/src/command-registry.coffee
@@ -93,6 +93,9 @@ class CommandRegistry
       return disposable
 
     if typeof target is 'string'
+      if typeof callback isnt 'function'
+        throw new Error("Can't register a command with non-function callback.")
+
       validateSelector(target)
       @addSelectorBasedListener(target, commandName, callback)
     else

--- a/src/command-registry.coffee
+++ b/src/command-registry.coffee
@@ -92,10 +92,10 @@ class CommandRegistry
         disposable.add @add(target, commandName, callback)
       return disposable
 
-    if typeof target is 'string'
-      if typeof callback isnt 'function'
-        throw new Error("Can't register a command with non-function callback.")
+    if typeof callback isnt 'function'
+      throw new Error("Can't register a command with non-function callback.")
 
+    if typeof target is 'string'
       validateSelector(target)
       @addSelectorBasedListener(target, commandName, callback)
     else


### PR DESCRIPTION
This fixes https://github.com/atom/command-palette/issues/42 using the approach suggested in https://github.com/atom/command-palette/issues/42#issuecomment-104730041.

Without the fix, the test added in 6521c86 expectedly fails with:

```
CommandRegistry
  ::add(selector, commandName, callback)
    it throws an error when called with an non-function callback
      TypeError: Cannot read property 'message' of null (spec/command-registry-spec.coffee:168:22)
```

With the fix added in d477377, the tests pass again.

cc @nathansobo @kevinsawicki for :eyes: 
