### PR TITLE
Add cross-platform "About Atom" view

### DIFF
--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -181,6 +181,8 @@
       { label: 'Report Issue', command: 'application:report-issue' }
       { label: 'Search Issues', command: 'application:search-issues' }
       { type: 'separator' }
+      { label: 'About Atom', command: 'application:about' }
+      { type: 'separator' }
     ]
   }
 ]

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -184,6 +184,8 @@
       { label: 'Report Issue', command: 'application:report-issue' }
       { label: 'Search Issues', command: 'application:search-issues' }
       { type: 'separator' }
+      { label: 'About Atom', command: 'application:about' }
+      { type: 'separator' }
     ]
   }
 ]

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "one-light-ui": "1.0.2",
     "solarized-dark-syntax": "0.38.1",
     "solarized-light-syntax": "0.22.1",
-    "about": "0.1.0",
+    "about": "1.0.1",
     "archive-view": "0.58.0",
     "autocomplete-atom-api": "0.9.2",
     "autocomplete-css": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "one-light-ui": "1.0.2",
     "solarized-dark-syntax": "0.38.1",
     "solarized-light-syntax": "0.22.1",
+    "about": "0.1.0",
     "archive-view": "0.58.0",
     "autocomplete-atom-api": "0.9.2",
     "autocomplete-css": "0.9.0",

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -192,7 +192,6 @@ class AtomApplication
     @on 'application:check-for-update', => @autoUpdateManager.check()
 
     if process.platform is 'darwin'
-      @on 'application:about', -> Menu.sendActionToFirstResponder('orderFrontStandardAboutPanel:')
       @on 'application:bring-all-windows-to-front', -> Menu.sendActionToFirstResponder('arrangeInFront:')
       @on 'application:hide', -> Menu.sendActionToFirstResponder('hide:')
       @on 'application:hide-other-applications', -> Menu.sendActionToFirstResponder('hideOtherApplications:')
@@ -203,6 +202,7 @@ class AtomApplication
       @on 'application:minimize', -> @focusedWindow()?.minimize()
       @on 'application:zoom', -> @focusedWindow()?.maximize()
 
+    @openPathOnEvent('application:about', 'atom://about')
     @openPathOnEvent('application:show-settings', 'atom://config')
     @openPathOnEvent('application:open-your-config', 'atom://.atom/config')
     @openPathOnEvent('application:open-your-init-script', 'atom://.atom/init-script')


### PR DESCRIPTION
Closes https://github.com/atom/atom/issues/3377
Closes https://github.com/atom/about/issues/2

This PR adds a new package - [`about`](https://github.com/mnquintana/atom-about) - dedicated to viewing information about your Atom installation within Atom, across all platforms.

![About screenshot](https://raw.githubusercontent.com/mnquintana/atom-about/master/resources/about-atom.png)

_Note: The color on the Atom logo is the hover state._

Right now it doesn't do a whole lot (you can copy the version number though), but I have several enhancements planned right now (showing all Atom org contributors, checking for updates, checking if latest commit if using built Atom, installed packages, etc), but that should make it a bit easier to review. I plan on continuing to maintain this package if it gets merged (along with the core team and the rest of the maintainers and anyone else who wants to pitch in :smile:).

If the team decides to go forward with this, then we should:
- [x] Transfer repo to Atom org
- [x] Transfer atom.io ownership to atom
- [x] Remove Command Palette entry for About: About Atom

Let me know what you think!

/cc @simurai @atom/feedback 
