### PR TITLE
Add Pane::onWillRemoveItem event.

### DIFF
--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -209,6 +209,12 @@ describe "Pane", ->
       expect(item2.isDestroyed()).toBe true
       expect(events).toEqual [{item: item2, index: 1}]
 
+    it "invokes ::onWillRemoveItem() observers", ->
+      events = []
+      pane.onWillRemoveItem (event) -> events.push(event)
+      pane.destroyItem(item2)
+      expect(events).toEqual [{item: item2, index: 1, destroyed: true}]
+
     it "invokes ::onDidRemoveItem() observers", ->
       events = []
       pane.onDidRemoveItem (event) -> events.push(event)
@@ -495,6 +501,13 @@ describe "Pane", ->
       pane1.moveItemToPane(item2, pane2, 1)
       expect(pane1.getItems()).toEqual [item1, item3]
       expect(pane2.getItems()).toEqual [item4, item2, item5]
+
+    it "invokes ::onWillRemoveItem() observers", ->
+      events = []
+      pane1.onWillRemoveItem (event) -> events.push(event)
+      pane1.moveItemToPane(item2, pane2, 1)
+
+      expect(events).toEqual [{item: item2, index: 1, destroyed: false}]
 
     it "invokes ::onDidRemoveItem() observers", ->
       events = []

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -163,6 +163,15 @@ class Pane extends Model
   onDidRemoveItem: (callback) ->
     @emitter.on 'did-remove-item', callback
 
+  # Public: Invoke the given callback before an item is removed from the pane.
+  #
+  # * `callback` {Function} to be called with when items are removed.
+  #   * `event` {Object} with the following keys:
+  #     * `item` The pane item to be removed.
+  #     * `index` {Number} indicating where the item is located.
+  onWillRemoveItem: (callback) ->
+    @emitter.on 'will-remove-item', callback
+
   # Public: Invoke the given callback when an item is moved within the pane.
   #
   # * `callback` {Function} to be called with when items are moved.
@@ -357,6 +366,8 @@ class Pane extends Model
   removeItem: (item, destroyed=false) ->
     index = @items.indexOf(item)
     return if index is -1
+
+    @emitter.emit 'will-remove-item', {item, index, destroyed}
 
     if Grim.includeDeprecatedAPIs and typeof item.on is 'function'
       @unsubscribe item


### PR DESCRIPTION
Hi,

I'd love to have this here `will-remove-item` event on Pane. The motivation is for oggy/tab-switcher#11, where I want to determine in a `did-change-active-item` hook if an item is being activated because the user clicked the tab, or if it's just because the active item was removed and this was next to it (which I could do by setting a flag between `will-remove-item` and `did-remove-item`).

There are probably many possible solutions here, but this seemed the most generic. WDYT?
