### PR TITLE
Mini editor with TextEditor::setMini

### DIFF
--- a/spec/text-editor-element-spec.coffee
+++ b/spec/text-editor-element-spec.coffee
@@ -233,3 +233,13 @@ describe "TextEditorElement", ->
       element = new TextEditorElement
       jasmine.attachToDOM(element)
       expect(element.getDefaultCharacterWidth()).toBeGreaterThan(0)
+
+  describe "on TextEditor::setMini", ->
+    it "changes the element's 'mini' attribute", ->
+      element = new TextEditorElement
+      jasmine.attachToDOM(element)
+      expect(element.hasAttribute('mini')).toBe false
+      element.getModel().setMini(true)
+      expect(element.hasAttribute('mini')).toBe true
+      element.getModel().setMini(false)
+      expect(element.hasAttribute('mini')).toBe false

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -83,11 +83,12 @@ class TextEditorElement extends HTMLElement
     @model = model
     @mountComponent()
     @addGrammarScopeAttribute()
-    @addMiniAttributeIfNeeded()
+    @addMiniAttribute() if @model.isMini()
     @addEncodingAttribute()
     @model.onDidChangeGrammar => @addGrammarScopeAttribute()
     @model.onDidChangeEncoding => @addEncodingAttribute()
     @model.onDidDestroy => @unmountComponent()
+    @model.onDidChangeMini (mini) => if mini then @addMiniAttribute() else @removeMiniAttribute()
     @__spacePenView.setModel(@model) if Grim.includeDeprecatedAPIs
     @model
 
@@ -155,8 +156,11 @@ class TextEditorElement extends HTMLElement
     grammarScope = @model.getGrammar()?.scopeName?.replace(/\./g, ' ')
     @dataset.grammar = grammarScope
 
-  addMiniAttributeIfNeeded: ->
-    @setAttributeNode(document.createAttribute("mini")) if @model.isMini()
+  addMiniAttribute: ->
+    @setAttributeNode(document.createAttribute("mini"))
+
+  removeMiniAttribute: ->
+    @removeAttribute("mini")
 
   addEncodingAttribute: ->
     @dataset.encoding = @model.getEncoding()


### PR DESCRIPTION
`TextEditor` has a function called `setMini` that toggles the mini state of an editor. The problem is that it only "changes" the `TextEditor` itself and `TextEditorPresenter`, but not `TextEditorElement`.
Before fix:
![unfixed-setmini](https://cloud.githubusercontent.com/assets/7817714/8353884/1fbc8b9e-1b43-11e5-965a-8e420f80ab94.png)
After fix:
![fixed-setmini](https://cloud.githubusercontent.com/assets/7817714/8353886/2774bd7a-1b43-11e5-8c85-a38d264e470f.png)
Code:

``` coffeescript
@content: ->
    ...
    @div class:'editor-item', =>
            @subview 'test_data', new TextEditorView({mini:true, placeholderText:'Test Input'})
    ...

toggleMini: ->
    editor = @test_data.getModel()
    editor.setMini(not editor.isMini())
```
