### PR TITLE
Make Alt-F behaviour native on Windows

### DIFF
--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -130,10 +130,12 @@
   'ctrl-k ctrl-8': 'editor:fold-at-indent-level-8'
   'ctrl-k ctrl-9': 'editor:fold-at-indent-level-9'
 
-# allow standard input fields to work correctly
+# allow standard input fields and menu keys to work as expected on Windows
 'body .native-key-bindings':
   'ctrl-z': 'native!'
   'ctrl-Z': 'native!'
   'ctrl-x': 'native!'
   'ctrl-c': 'native!'
   'ctrl-v': 'native!'
+  'alt-f': 'native!'
+


### PR DESCRIPTION
Make Alt-F work natively - to open file menu - as per standard behaviour on Windows platform.

Refer issue #474
