### PR TITLE
The ellipsis character is now recognized as punctuation

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -127,7 +127,7 @@ module.exports =
         default: true
       nonWordCharacters:
         type: 'string'
-        default: "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-"
+        default: "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-…"
       preferredLineLength:
         type: 'integer'
         default: 80


### PR DESCRIPTION
It is no longer selected by double-clicking. #7047 
