### PR TITLE
Reintroduce assertion API

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "link": "0.30.0",
     "markdown-preview": "0.150.0",
     "metrics": "0.51.0",
-    "notifications": "0.56.0",
+    "notifications": "0.57.0",
     "open-on-github": "0.37.0",
     "package-generator": "0.39.0",
     "release-notes": "0.53.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "deprecation-cop": "0.53.0",
     "dev-live-reload": "0.46.0",
     "encoding-selector": "0.20.0",
-    "exception-reporting": "0.25.0",
+    "exception-reporting": "0.31.0",
     "find-and-replace": "0.174.1",
     "fuzzy-finder": "0.87.0",
     "git-diff": "0.55.0",

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -86,13 +86,13 @@ describe "the `atom` global", ->
           error = e
           window.onerror.call(window, e.toString(), 'abc', 2, 3, e)
 
-        expect(willThrowSpy).toHaveBeenCalledWith(error)
-
-        # Deprecated event properties
-        expect(error.url).toBe 'abc'
-        expect(error.line).toBe 2
-        expect(error.column).toBe 3
-        expect(error.originalError).toBe error
+        delete willThrowSpy.mostRecentCall.args[0].preventDefault
+        expect(willThrowSpy).toHaveBeenCalledWith
+          message: error.toString()
+          url: 'abc'
+          line: 2
+          column: 3
+          originalError: error
 
       it "will not show the devtools when preventDefault() is called", ->
         willThrowSpy.andCallFake (errorObject) -> errorObject.preventDefault()
@@ -120,27 +120,12 @@ describe "the `atom` global", ->
         catch e
           error = e
           window.onerror.call(window, e.toString(), 'abc', 2, 3, e)
-
-        expect(didThrowSpy).toHaveBeenCalledWith(error)
-
-        # Deprecated event properties
-        expect(error.url).toBe 'abc'
-        expect(error.line).toBe 2
-        expect(error.column).toBe 3
-        expect(error.originalError).toBe error
-
-      it "will not show the devtools when preventDefault() is called", ->
-        didThrowSpy.andCallFake (errorObject) -> errorObject.preventDefault()
-        atom.onDidThrowError(didThrowSpy)
-
-        try
-          a + 1
-        catch e
-          window.onerror.call(window, e.toString(), 'abc', 2, 3, e)
-
-        expect(didThrowSpy).toHaveBeenCalled()
-        expect(atom.openDevTools).not.toHaveBeenCalled()
-        expect(atom.executeJavaScriptInDevTools).not.toHaveBeenCalled()
+        expect(didThrowSpy).toHaveBeenCalledWith
+          message: error.toString()
+          url: 'abc'
+          line: 2
+          column: 3
+          originalError: error
 
   describe ".assert(condition, message, metadata)", ->
     errors = null

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -724,7 +724,7 @@ class Atom extends Model
   assert: (condition, message, metadata) ->
     return true if condition
 
-    error = new Error("Assertion failed: " + message)
+    error = new Error("Assertion failed: #{message}")
     Error.captureStackTrace(error, @assert)
 
     if metadata?

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -292,7 +292,17 @@ class TokenizedBuffer extends Model
   # Returns a {Boolean} indicating whether the given buffer row starts
   # a a foldable row range due to the code's indentation patterns.
   isFoldableCodeAtRow: (row) ->
-    return false if @buffer.isRowBlank(row) or @tokenizedLineForRow(row).isComment()
+    # Investigating an exception that's occurring here due to the line being
+    # undefined. This should paper over the problem but we want to figure out
+    # what is happening:
+    tokenizedLine = @tokenizedLineForRow(row)
+    atom.assert tokenizedLine?, "TokenizedLine is defined", =>
+      metadata:
+        row: row
+        rowCount: @tokenizedLines.length
+    return false unless tokenizedLine?
+
+    return false if @buffer.isRowBlank(row) or tokenizedLine.isComment()
     nextRow = @buffer.nextNonBlankRow(row)
     return false unless nextRow?
 


### PR DESCRIPTION
This was briefly introduced in #7350, but reverted before we went 1.0 to minimize risk. It's the logical next step in attacking our uncaught exceptions.
