### PR TITLE
Remove deferred browser process requires

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -273,9 +273,8 @@ class AtomApplication
     ipc.on 'cancel-window-close', =>
       @quitting = false
 
-    clipboard = null
+    clipboard = require '../safe-clipboard'
     ipc.on 'write-text-to-selection-clipboard', (event, selectedText) ->
-      clipboard ?= require '../safe-clipboard'
       clipboard.writeText(selectedText, 'selection')
 
   # Public: Executes the given command.

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -93,10 +93,9 @@ class AtomWindow
   hasProjectPath: -> @getLoadSettings().initialPaths?.length > 0
 
   setupContextMenu: ->
-    ContextMenu = null
+    ContextMenu = require './context-menu'
 
     @browserWindow.on 'context-menu', (menuTemplate) =>
-      ContextMenu ?= require './context-menu'
       new ContextMenu(menuTemplate, this)
 
   containsPaths: (paths) ->


### PR DESCRIPTION
This is a temporary fix for #6548 until #6877 is merged.

Basically just do the requires up front instead of deferred so this asar bug isn't hit.

This should have an incredibly minimal negative impact to startup time since these deferred requires are incredibly small and asar is now used so it is only two extra file reads at startup.

Closes #6548 
