### PR TITLE
Clarify that config files require unique keys

### DIFF
--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -2,7 +2,8 @@
 #
 # Atom keymaps work similarly to style sheets. Just as style sheets use
 # selectors to apply styles to elements, Atom keymaps use selectors to associate
-# keystrokes with events in specific contexts.
+# keystrokes with events in specific contexts. (Unlike style sheets however,
+# each selector can only be declared once.)
 #
 # You can create a new keybinding in this file by typing "key" and then hitting
 # tab.

--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -2,8 +2,8 @@
 #
 # Atom keymaps work similarly to style sheets. Just as style sheets use
 # selectors to apply styles to elements, Atom keymaps use selectors to associate
-# keystrokes with events in specific contexts. (Unlike style sheets however,
-# each selector can only be declared once.)
+# keystrokes with events in specific contexts. Unlike style sheets however,
+# each selector can only be declared once.
 #
 # You can create a new keybinding in this file by typing "key" and then hitting
 # tab.

--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -22,5 +22,6 @@
 # * https://atom.io/docs/latest/behind-atom-keymaps-in-depth
 #
 # This file uses CoffeeScript Object Notation (CSON).
-# If you are unfamiliar with CSON, you can read more about it here:
-# https://github.com/bevry/cson#what-is-cson
+# If you are unfamiliar with CSON, you can read more about it in the 
+# Atom Flight Manual:
+# https://atom.io/docs/latest/using-atom-basic-customization#cson

--- a/dot-atom/snippets.cson
+++ b/dot-atom/snippets.cson
@@ -13,6 +13,8 @@
 #     'prefix': 'log'
 #     'body': 'console.log $1'
 #
+# Each scope can only be declared once.
+#
 # This file uses CoffeeScript Object Notation (CSON).
 # If you are unfamiliar with CSON, you can read more about it here:
 # https://github.com/bevry/cson#what-is-cson

--- a/dot-atom/snippets.cson
+++ b/dot-atom/snippets.cson
@@ -13,7 +13,7 @@
 #     'prefix': 'log'
 #     'body': 'console.log $1'
 #
-# Each scope can only be declared once.
+# Each scope (e.g. '.source.coffee' above) can only be declared once.
 #
 # This file uses CoffeeScript Object Notation (CSON).
 # If you are unfamiliar with CSON, you can read more about it here:

--- a/dot-atom/snippets.cson
+++ b/dot-atom/snippets.cson
@@ -16,5 +16,6 @@
 # Each scope (e.g. '.source.coffee' above) can only be declared once.
 #
 # This file uses CoffeeScript Object Notation (CSON).
-# If you are unfamiliar with CSON, you can read more about it here:
-# https://github.com/bevry/cson#what-is-cson
+# If you are unfamiliar with CSON, you can read more about it in the
+# Atom Flight Manual:
+# https://atom.io/docs/latest/using-atom-basic-customization#cson


### PR DESCRIPTION
From https://github.com/atom/atom/issues/7552#issuecomment-116735581

A lot of people try to use the config files as they would a stylesheet, trying to override keybindings for instance by repeating the same selector multiple times in the file, which causes issues because CSON keys must be unique. This makes it a bit more explicit that keys need to be unique.
