### PR TITLE
Position lines without absolute coordinates

### DIFF
--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -850,7 +850,6 @@ describe "TextEditorPresenter", ->
               firstNonWhitespaceIndex: line3.firstNonWhitespaceIndex
               firstTrailingWhitespaceIndex: line3.firstTrailingWhitespaceIndex
               invisibles: line3.invisibles
-              top: 0
             }
 
             line4 = editor.tokenizedLineForScreenRow(4)
@@ -862,7 +861,6 @@ describe "TextEditorPresenter", ->
               firstNonWhitespaceIndex: line4.firstNonWhitespaceIndex
               firstTrailingWhitespaceIndex: line4.firstTrailingWhitespaceIndex
               invisibles: line4.invisibles
-              top: 1
             }
 
             line5 = editor.tokenizedLineForScreenRow(5)
@@ -874,7 +872,6 @@ describe "TextEditorPresenter", ->
               firstNonWhitespaceIndex: line5.firstNonWhitespaceIndex
               firstTrailingWhitespaceIndex: line5.firstTrailingWhitespaceIndex
               invisibles: line5.invisibles
-              top: 2
             }
 
             line6 = editor.tokenizedLineForScreenRow(6)
@@ -886,7 +883,6 @@ describe "TextEditorPresenter", ->
               firstNonWhitespaceIndex: line6.firstNonWhitespaceIndex
               firstTrailingWhitespaceIndex: line6.firstTrailingWhitespaceIndex
               invisibles: line6.invisibles
-              top: 0
             }
 
             line7 = editor.tokenizedLineForScreenRow(7)
@@ -898,7 +894,6 @@ describe "TextEditorPresenter", ->
               firstNonWhitespaceIndex: line7.firstNonWhitespaceIndex
               firstTrailingWhitespaceIndex: line7.firstTrailingWhitespaceIndex
               invisibles: line7.invisibles
-              top: 1
             }
 
             line8 = editor.tokenizedLineForScreenRow(8)
@@ -910,7 +905,6 @@ describe "TextEditorPresenter", ->
               firstNonWhitespaceIndex: line8.firstNonWhitespaceIndex
               firstTrailingWhitespaceIndex: line8.firstTrailingWhitespaceIndex
               invisibles: line8.invisibles
-              top: 2
             }
 
             expect(lineStateForScreenRow(presenter, 9)).toBeUndefined()

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -368,7 +368,6 @@ class TextEditorPresenter
       if tileState.lines.hasOwnProperty(line.id)
         lineState = tileState.lines[line.id]
         lineState.screenRow = row
-        lineState.top = (row - startRow) * @lineHeight
         lineState.decorationClasses = @lineDecorationClassesForRow(row)
       else
         tileState.lines[line.id] =
@@ -385,7 +384,6 @@ class TextEditorPresenter
           indentLevel: line.indentLevel
           tabLength: line.tabLength
           fold: line.fold
-          top: (row - startRow) * @lineHeight
           decorationClasses: @lineDecorationClassesForRow(row)
       row++
 

--- a/src/tile-component.coffee
+++ b/src/tile-component.coffee
@@ -105,9 +105,26 @@ class TileComponent
     for id, i in newLineIds
       lineNode = newLineNodes[i]
       @lineNodesByLineId[id] = lineNode
-      @domNode.appendChild(lineNode)
-
+      @insertLineNode(id, lineNode)
     return
+
+  insertLineNode: (id, lineNode) ->
+    [dummyNode, domChildren...] = @domNode.children
+
+    screenRowToInsert = parseInt(lineNode.dataset.screenRow)
+    previousScreenRow = -Infinity
+
+    for currentNode in domChildren
+      currentScreenRow = parseInt(currentNode.dataset.screenRow)
+
+      if previousScreenRow < screenRowToInsert < currentScreenRow
+        @domNode.insertBefore(lineNode, currentNode)
+        inserted = true
+        break
+
+      previousScreenRow = currentNode.dataset.screenRow
+
+    @domNode.appendChild(lineNode) unless inserted?
 
   buildLineHTML: (id) ->
     {width} = @newState
@@ -119,7 +136,7 @@ class TileComponent
         classes += decorationClass + ' '
     classes += 'line'
 
-    lineHTML = "<div class=\"#{classes}\" style=\"position: absolute; top: #{top}px; width: #{width}px;\" data-screen-row=\"#{screenRow}\">"
+    lineHTML = "<div class=\"#{classes}\" style=\"width: #{width}px;\" data-screen-row=\"#{screenRow}\">"
 
     if text is ""
       lineHTML += @buildEmptyLineInnerHTML(id)
@@ -296,10 +313,6 @@ class TileComponent
           lineNode.classList.add(decorationClass)
 
     oldLineState.decorationClasses = newLineState.decorationClasses
-
-    if newLineState.top isnt oldLineState.top
-      lineNode.style.top = newLineState.top + 'px'
-      oldLineState.top = newLineState.top
 
     if newLineState.screenRow isnt oldLineState.screenRow
       lineNode.dataset.screenRow = newLineState.screenRow

--- a/src/tile-component.coffee
+++ b/src/tile-component.coffee
@@ -113,18 +113,19 @@ class TileComponent
 
     screenRowToInsert = parseInt(lineNode.dataset.screenRow)
     previousScreenRow = -Infinity
+    hasInsertedNode = false
 
     for currentNode in domChildren
       currentScreenRow = parseInt(currentNode.dataset.screenRow)
 
       if previousScreenRow < screenRowToInsert < currentScreenRow
         @domNode.insertBefore(lineNode, currentNode)
-        inserted = true
+        hasInsertedNode = true
         break
 
       previousScreenRow = currentScreenRow
 
-    @domNode.appendChild(lineNode) unless inserted?
+    @domNode.appendChild(lineNode) unless hasInsertedNode
 
   buildLineHTML: (id) ->
     {width} = @newState

--- a/src/tile-component.coffee
+++ b/src/tile-component.coffee
@@ -122,7 +122,7 @@ class TileComponent
         inserted = true
         break
 
-      previousScreenRow = currentNode.dataset.screenRow
+      previousScreenRow = currentScreenRow
 
     @domNode.appendChild(lineNode) unless inserted?
 


### PR DESCRIPTION
At CodeConf, we had a quick chat with a Chromium team member about how we could improve the rendering layer in Atom.

It turned out that Chromium is heavily optimized for non-absolutely positioned elements and, as a result, we may want to avoid using them for our lines nodes.

The main change we had to make in this PR was to ensure that lines were correctly sorted when inserting them in the DOM, so that the browser could properly figure out how to lay things out. I ended up employing a naive insertion sort algorithm which, although not super efficient, does its job and is pretty fast anyway given the small amount of lines.

Using the timeline, however, I couldn’t notice any major speedup:

| Before | After |
| --- | --- |
| ![screen shot 2015-06-30 at 15 31 12](https://cloud.githubusercontent.com/assets/482957/8432661/ae9c3c22-1f41-11e5-91e0-ac53c7c76541.png) | ![screen shot 2015-06-30 at 15 30 20](https://cloud.githubusercontent.com/assets/482957/8432659/ac801940-1f41-11e5-9bc5-a41517a9071a.png) |

It is subtle, but I can kinda feel it is a bit faster, hence it is likely that the Chrome timeline is not the right tool for the job and `about:traces` could tell a different story. 

@nathansobo: what’s your take on this? Should we go for this route? My opinion is that we may just continue using the absolute coordinates mechanism, as the benefits of this approach do not seem to be extremely evident. 

Thanks! :bow: 
