### PR TITLE
Parallelize Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ git:
 env:
   global:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
+    - NODE_VERSION=0.12
 
   matrix:
-    - NODE_VERSION=0.12
     - ATOM_SPECS_TASK=packages
     - ATOM_SPECS_TASK=core
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,18 @@ git:
 env:
   global:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
-    - NODE_VERSION=0.12
 
-  matrix:
+  env:
+    - NODE_VERSION=0.12
     - ATOM_SPECS_TASK=packages
     - ATOM_SPECS_TASK=core
+
+  matrix:
+    exclude:
+      - os: linux
+        env: ATOM_SPECS_TASK=core
+      - os: linux
+        env: ATOM_SPECS_TASK=packages
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ git:
 env:
   global:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
-    
+
   matrix:
     - NODE_VERSION=0.12
+    - ATOM_SPECS_TASK=packages
+    - ATOM_SPECS_TASK=core
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ env:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
     - NODE_VERSION=0.12
 
-  matrix:
-    - ATOM_SPECS_TASK=packages
-    - ATOM_SPECS_TASK=core
-
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,9 @@ matrix:
       env: ATOM_SPECS_TASK=core
     - os: osx
       env: ATOM_SPECS_TASK=packages
-  exclude:
-    - os: osx
 
 os:
   - linux
-  - osx
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,18 @@ git:
 env:
   global:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
-
-  env:
     - NODE_VERSION=0.12
+
+  matrix:
     - ATOM_SPECS_TASK=packages
     - ATOM_SPECS_TASK=core
 
-  matrix:
-    exclude:
-      - os: linux
-        env: ATOM_SPECS_TASK=core
-      - os: linux
-        env: ATOM_SPECS_TASK=packages
+matrix:
+  exclude:
+    - os: linux
+      env: ATOM_SPECS_TASK=core
+    - os: linux
+      env: ATOM_SPECS_TASK=packages
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ git:
 env:
   global:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
-    - NODE_VERSION=0.12
 
   matrix:
+    - NODE_VERSION=0.12
     - ATOM_SPECS_TASK=packages
     - ATOM_SPECS_TASK=core
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,12 @@ env:
 
 matrix:
   include:
-    - os: linux
     - os: osx
       env: ATOM_SPECS_TASK=core
     - os: osx
       env: ATOM_SPECS_TASK=packages
+  exclude:
+    - os: osx
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,11 @@ env:
     - ATOM_SPECS_TASK=core
 
 matrix:
-  exclude:
+  include:
     - os: linux
+    - os: osx
       env: ATOM_SPECS_TASK=core
-    - os: linux
+    - os: osx
       env: ATOM_SPECS_TASK=packages
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,11 @@ env:
 
 matrix:
   include:
+    - os: linux
     - os: osx
       env: ATOM_SPECS_TASK=core
     - os: osx
       env: ATOM_SPECS_TASK=packages
-
-os:
-  - linux
 
 sudo: false
 

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -158,4 +158,4 @@ module.exports = (grunt) ->
       if process.platform is 'win32' and process.env.JANKY_SHA1
         done()
       else
-        done(not coreSpecFailed and failedPackages.length is 0)
+        done(not coreSpecFailed and failedPackages?.length is 0)

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -131,7 +131,7 @@ module.exports = (grunt) ->
       else
         async.parallel
 
-    specs =
+    runSpecs =
       if process.env.ATOM_SPECS_TASK is 'packages'
         [runPackageSpecs]
       else if process.env.ATOM_SPECS_TASK is 'core'
@@ -139,7 +139,7 @@ module.exports = (grunt) ->
       else
         [runCoreSpecs, runPackageSpecs]
 
-    method specs, (error, results) ->
+    method runSpecs, (error, results) ->
       [coreSpecFailed, failedPackages] = results
       elapsedTime = Math.round((Date.now() - startTime) / 100) / 10
       grunt.log.ok("Total spec time: #{elapsedTime}s using #{concurrency} cores")

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -131,7 +131,7 @@ module.exports = (grunt) ->
       else
         async.parallel
 
-    runSpecs =
+    specs =
       if process.env.ATOM_SPECS_TASK is 'packages'
         [runPackageSpecs]
       else if process.env.ATOM_SPECS_TASK is 'core'
@@ -139,7 +139,7 @@ module.exports = (grunt) ->
       else
         [runCoreSpecs, runPackageSpecs]
 
-    method runSpecs, (error, results) ->
+    method specs, (error, results) ->
       [coreSpecFailed, failedPackages] = results
       elapsedTime = Math.round((Date.now() - startTime) / 100) / 10
       grunt.log.ok("Total spec time: #{elapsedTime}s using #{concurrency} cores")

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -140,6 +140,9 @@ module.exports = (grunt) ->
         [runCoreSpecs, runPackageSpecs]
 
     method specs, (error, results) ->
+      failedPackages = []
+      coreSpecFailed = []
+
       if process.env.ATOM_SPECS_TASK is 'packages'
         [failedPackages] = results
       else if process.env.ATOM_SPECS_TASK is 'core'
@@ -150,12 +153,12 @@ module.exports = (grunt) ->
       console.log results
       elapsedTime = Math.round((Date.now() - startTime) / 100) / 10
       grunt.log.ok("Total spec time: #{elapsedTime}s using #{concurrency} cores")
-      failures = failedPackages ? []
-      failures.push "atom core" if coreSpecFailed
+      failures = failedPackages
+      failures.push "atom core" if coreSpecFailed.length > 0
 
       grunt.log.error("[Error]".red + " #{failures.join(', ')} spec(s) failed") if failures.length > 0
 
       if process.platform is 'win32' and process.env.JANKY_SHA1
         done()
       else
-        done(not coreSpecFailed and failedPackages?.length is 0)
+        done(not coreSpecFailed and failedPackages.length is 0)

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -141,7 +141,7 @@ module.exports = (grunt) ->
 
     method specs, (error, results) ->
       failedPackages = []
-      coreSpecFailed = []
+      coreSpecFailed = null
 
       if process.env.ATOM_SPECS_TASK is 'packages'
         [failedPackages] = results
@@ -154,7 +154,7 @@ module.exports = (grunt) ->
       elapsedTime = Math.round((Date.now() - startTime) / 100) / 10
       grunt.log.ok("Total spec time: #{elapsedTime}s using #{concurrency} cores")
       failures = failedPackages
-      failures.push "atom core" if coreSpecFailed.length > 0
+      failures.push "atom core" if coreSpecFailed
 
       grunt.log.error("[Error]".red + " #{failures.join(', ')} spec(s) failed") if failures.length > 0
 

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -131,7 +131,15 @@ module.exports = (grunt) ->
       else
         async.parallel
 
-    method [runCoreSpecs, runPackageSpecs], (error, results) ->
+    specs =
+      if process.env.ATOM_SPECS_TASK is 'packages'
+        [runPackageSpecs]
+      else if process.env.ATOM_SPECS_TASK is 'core'
+        [runCoreSpecs]
+      else
+        [runCoreSpecs, runPackageSpecs]
+
+    method specs, (error, results) ->
       [coreSpecFailed, failedPackages] = results
       elapsedTime = Math.round((Date.now() - startTime) / 100) / 10
       grunt.log.ok("Total spec time: #{elapsedTime}s using #{concurrency} cores")

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -150,7 +150,6 @@ module.exports = (grunt) ->
       else
         [coreSpecFailed, failedPackages] = results
 
-      console.log results
       elapsedTime = Math.round((Date.now() - startTime) / 100) / 10
       grunt.log.ok("Total spec time: #{elapsedTime}s using #{concurrency} cores")
       failures = failedPackages

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -140,10 +140,17 @@ module.exports = (grunt) ->
         [runCoreSpecs, runPackageSpecs]
 
     method specs, (error, results) ->
-      [coreSpecFailed, failedPackages] = results
+      if process.env.ATOM_SPECS_TASK is 'packages'
+        [failedPackages] = results
+      else if process.env.ATOM_SPECS_TASK is 'core'
+        [coreSpecFailed] = results
+      else
+        [coreSpecFailed, failedPackages] = results
+
+      console.log results
       elapsedTime = Math.round((Date.now() - startTime) / 100) / 10
       grunt.log.ok("Total spec time: #{elapsedTime}s using #{concurrency} cores")
-      failures = failedPackages
+      failures = failedPackages ? []
       failures.push "atom core" if coreSpecFailed
 
       grunt.log.error("[Error]".red + " #{failures.join(', ')} spec(s) failed") if failures.length > 0


### PR DESCRIPTION
This PR parallelizes the Travis build so that core specs and package specs can be run concurrently, significantly cutting down on build time.

| Before | After |
| --- | --- |
| [~27 min](https://travis-ci.org/atom/atom/builds/68887449) | [~22 min](https://travis-ci.org/atom/atom/builds/68996020) |

~22 minutes is still a pretty long time, so there's still some work to be done here. :wink: 

Possible next steps:
- Set up custom caching for packages on S3
  - If we manage to fix the issue below, then we might be able to use [the custom caching scheme built into Travis.](http://docs.travis-ci.com/user/caching/#Arbitrary-directories) (It's only supported for the container-based infrastructure on Linux.) Although, to do this, I think we'd have to add an option to `apm install` to only install if the package isn't already installed.
- Fix flaky specs so they can be run on Travis' (much faster and more stable) Linux infrastructure instead of the Mac infrastructure (was discussing this with @as-cii at CodeConf – this is probably the trickiest of the two)

/cc @as-cii @atom/feedback 
