### PR TITLE
:apple: Menus: replace three period with ellipsis

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -10,7 +10,7 @@
       { label: 'Checking for Update', enabled: false, visible: false}
       { label: 'Downloading Update', enabled: false, visible: false}
       { type: 'separator' }
-      { label: 'Preferences...', command: 'application:show-settings' }
+      { label: 'Preferences…', command: 'application:show-settings' }
       { label: 'Open Your Config', command: 'application:open-your-config' }
       { label: 'Open Your Init Script', command: 'application:open-your-init-script' }
       { label: 'Open Your Keymap', command: 'application:open-your-keymap' }
@@ -33,12 +33,12 @@
     submenu: [
       { label: 'New Window', command: 'application:new-window' }
       { label: 'New File', command: 'application:new-file' }
-      { label: 'Open...', command: 'application:open' }
-      { label: 'Add Project Folder...', command: 'application:add-project-folder' }
+      { label: 'Open…', command: 'application:open' }
+      { label: 'Add Project Folder…', command: 'application:add-project-folder' }
       { label: 'Reopen Last Item', command: 'pane:reopen-closed-item' }
       { type: 'separator' }
       { label: 'Save', command: 'core:save' }
-      { label: 'Save As...', command: 'core:save-as' }
+      { label: 'Save As…', command: 'core:save-as' }
       { label: 'Save All', command: 'window:save-all' }
       { type: 'separator' }
       { label: 'Close Tab', command: 'core:close' }
@@ -163,7 +163,7 @@
       {
         label: 'Developer'
         submenu: [
-          { label: 'Open In Dev Mode...', command: 'application:open-dev' }
+          { label: 'Open In Dev Mode…', command: 'application:open-dev' }
           { label: 'Run Atom Specs', command: 'application:run-all-specs' }
           { label: 'Run Package Specs', command: 'window:run-package-specs' }
           { label: 'Toggle Developer Tools', command: 'window:toggle-dev-tools' }

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -4,13 +4,13 @@
     submenu: [
       { label: 'New &Window', command: 'application:new-window' }
       { label: '&New File', command: 'application:new-file' }
-      { label: '&Open File...', command: 'application:open-file' }
-      { label: 'Open Folder...', command: 'application:open-folder' }
-      { label: 'Add Project Folder...', command: 'application:add-project-folder' }
+      { label: '&Open File…', command: 'application:open-file' }
+      { label: 'Open Folder…', command: 'application:open-folder' }
+      { label: 'Add Project Folder…', command: 'application:add-project-folder' }
       { label: 'Reopen Last &Item', command: 'pane:reopen-closed-item' }
       { type: 'separator' }
       { label: '&Save', command: 'core:save' }
-      { label: 'Save &As...', command: 'core:save-as' }
+      { label: 'Save &As…', command: 'core:save-as' }
       { label: 'Save A&ll', command: 'window:save-all' }
       { type: 'separator' }
       { label: '&Close Tab', command: 'core:close' }
@@ -120,7 +120,7 @@
       {
         label: 'Developer'
         submenu: [
-          { label: 'Open In &Dev Mode...', command: 'application:open-dev' }
+          { label: 'Open In &Dev Mode…', command: 'application:open-dev' }
           { label: 'Run &Atom Specs', command: 'application:run-all-specs' }
           { label: 'Run Package &Specs', command: 'window:run-package-specs' }
           { label: 'Toggle Developer &Tools', command: 'window:toggle-dev-tools' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -4,9 +4,9 @@
     submenu: [
       { label: 'New &Window', command: 'application:new-window' }
       { label: '&New File', command: 'application:new-file' }
-      { label: '&Open File...', command: 'application:open-file' }
-      { label: 'Open Folder...', command: 'application:open-folder' }
-      { label: 'Add Project Folder...', command: 'application:add-project-folder' }
+      { label: '&Open File…', command: 'application:open-file' }
+      { label: 'Open Folder…', command: 'application:open-folder' }
+      { label: 'Add Project Folder…', command: 'application:add-project-folder' }
       { label: 'Reopen Last &Item', command: 'pane:reopen-closed-item' }
       { type: 'separator' }
       { label: 'Se&ttings', command: 'application:show-settings' }
@@ -17,7 +17,7 @@
       { label: 'Open Your Stylesheet', command: 'application:open-your-stylesheet' }
       { type: 'separator' }
       { label: '&Save', command: 'core:save' }
-      { label: 'Save &As...', command: 'core:save-as' }
+      { label: 'Save &As…', command: 'core:save-as' }
       { label: 'Save A&ll', command: 'window:save-all' }
       { type: 'separator' }
       { label: '&Close Tab', command: 'core:close' }
@@ -119,7 +119,7 @@
       {
         label: 'Developer'
         submenu: [
-          { label: 'Open In &Dev Mode...', command: 'application:open-dev' }
+          { label: 'Open In &Dev Mode…', command: 'application:open-dev' }
           { label: 'Run &Atom Specs', command: 'application:run-all-specs' }
           { label: 'Run Package &Specs', command: 'window:run-package-specs' }
           { label: 'Toggle Developer &Tools', command: 'window:toggle-dev-tools' }


### PR DESCRIPTION
From:
[OS X Human Interface Guidelines -Terminology and Wording](https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/TerminologyWording.html#//apple_ref/doc/uid/20000957-CH15-SW3)

> IMPORTANT
> 
> Be sure to create the ellipsis character using the key combination Option-; (Option-semicolon). This ensures that an assistive app can provide the correct interpretation of the character to a disabled user. If you use three period characters to simulate an ellipsis, many assistive apps will be unable to make sense of them. Also, three period characters and an ellipsis don't look the same because the periods are spaced differently than the points of an ellipsis.
