### PR TITLE
Throw an exception when adding a non-object pane item

### DIFF
--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -108,6 +108,12 @@ describe "Pane", ->
       pane2 = pane1.splitRight()
       expect(-> pane2.addItem(item)).toThrow()
 
+    it "throws an exception if the item isn't an object", ->
+      pane = new Pane(items: [])
+      expect(-> pane.addItem(null)).toThrow()
+      expect(-> pane.addItem('foo')).toThrow()
+      expect(-> pane.addItem(1)).toThrow()
+
   describe "::activateItem(item)", ->
     pane = null
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -336,6 +336,8 @@ class Pane extends Model
   #
   # Returns the added item.
   addItem: (item, index=@getActiveItemIndex() + 1) ->
+    throw new Error("Pane items must be objects. Attempted to add item #{item}.") unless item? and typeof item is 'object'
+
     return if item in @items
 
     if typeof item.onDidDestroy is 'function'


### PR DESCRIPTION
Closes #5978

We end up attempting to retrieve a view for pane items from a WeakMap, which can only use objects as keys. Throwing an exception earlier helps to clarify to package authors that this won't work.
