### PR TITLE
Add activationHooks + Trigger `{grammar-package-name}:grammar-used` Hook When A text-editor-element's Grammar Is Set

### DIFF
--- a/spec/fixtures/packages/package-with-activation-hooks/index.coffee
+++ b/spec/fixtures/packages/package-with-activation-hooks/index.coffee
@@ -1,0 +1,5 @@
+module.exports =
+  activateCallCount: 0
+
+  activate: ->
+    @activateCallCount++

--- a/spec/fixtures/packages/package-with-activation-hooks/package.cson
+++ b/spec/fixtures/packages/package-with-activation-hooks/package.cson
@@ -1,0 +1,5 @@
+{
+  "name": "package-with-activation-hooks",
+  "version": "0.1.0",
+  "activationHooks": ['language-fictitious:grammar-used']
+}

--- a/spec/fixtures/packages/package-with-empty-activation-hooks/index.coffee
+++ b/spec/fixtures/packages/package-with-empty-activation-hooks/index.coffee
@@ -1,0 +1,1 @@
+module.exports = activate: ->

--- a/spec/fixtures/packages/package-with-empty-activation-hooks/package.json
+++ b/spec/fixtures/packages/package-with-empty-activation-hooks/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "package-with-empty-activation-hooks",
+  "version": "0.1.0",
+  "activationHooks": []
+}

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -895,3 +895,57 @@ describe "TokenizedBuffer", ->
       expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0].value).toBe 'b'
       expect(tokenizedBuffer.tokenizedLineForRow(2).tokens.length).toBe 1
       expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0].value).toBe 'c'
+
+  describe 'when a file is opened', ->
+    [registration, editor, called] = []
+    beforeEach ->
+      runs ->
+        called = false
+        registration = atom.packages.onDidTriggerActivationHook('language-javascript:grammar-used', -> called = true)
+
+      waitsForPromise ->
+        atom.project.open('sample.js', autoIndent: false).then (o) ->
+          editor = o
+
+      waitsForPromise ->
+        atom.packages.activatePackage('language-javascript')
+
+    afterEach: ->
+      registration?.dispose?()
+      atom.packages.deactivatePackages()
+      atom.packages.unloadPackages()
+
+    it 'triggers the grammar-used hook', ->
+      waitsFor ->
+        called is true
+
+      runs ->
+        expect(called).toBe true
+
+    describe 'when changing the grammar of an open file', ->
+      [coffeeRegistration, coffeeCalled] = []
+
+      beforeEach ->
+        coffeeCalled = false
+        coffeeRegistration = atom.packages.onDidTriggerActivationHook('language-coffee-script:grammar-used', -> coffeeCalled = true)
+
+        waitsForPromise ->
+          atom.packages.activatePackage('language-coffee-script')
+
+      afterEach ->
+        coffeeRegistration?.dispose()
+
+      it 'triggers the grammar-used hook', ->
+        waitsFor ->
+          called is true
+
+        runs ->
+          expect(called).toBe true
+          expect(coffeeCalled).toBe false
+          editor.setGrammar(atom.grammars.selectGrammar('.coffee'))
+
+        waitsFor ->
+          coffeeCalled is true
+
+        runs ->
+          expect(coffeeCalled).toBe true

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -30,7 +30,7 @@ module.exports =
 class PackageManager
   constructor: ({configDirPath, @devMode, safeMode, @resourcePath}) ->
     @emitter = new Emitter
-    @hooks = new Emitter
+    @activationHookEmitter = new Emitter
     @packageDirPaths = []
     unless safeMode
       if @devMode
@@ -412,11 +412,11 @@ class PackageManager
 
   triggerActivationHook: (hook) ->
     return new Error("Cannot trigger an empty activation hook") unless hook? and _.isString(hook) and hook.length > 0
-    @hooks.emit(hook)
+    @activationHookEmitter.emit(hook)
 
   onDidTriggerActivationHook: (hook, callback) ->
     return unless hook? and _.isString(hook) and hook.length > 0
-    @hooks.on(hook, callback)
+    @activationHookEmitter.on(hook, callback)
 
   # Deactivate all packages
   deactivatePackages: ->

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -30,6 +30,7 @@ module.exports =
 class PackageManager
   constructor: ({configDirPath, @devMode, safeMode, @resourcePath}) ->
     @emitter = new Emitter
+    @hooks = new Emitter
     @packageDirPaths = []
     unless safeMode
       if @devMode
@@ -408,6 +409,14 @@ class PackageManager
         pack
     else
       Q.reject(new Error("Failed to load package '#{name}'"))
+
+  triggerActivationHook: (hook) ->
+    return new Error("Cannot trigger an empty activation hook") unless hook? and _.isString(hook) and hook.length > 0
+    @hooks.emit(hook)
+
+  onDidTriggerActivationHook: (hook, callback) ->
+    return unless hook? and _.isString(hook) and hook.length > 0
+    @hooks.on(hook, callback)
 
   # Deactivate all packages
   deactivatePackages: ->

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -154,8 +154,7 @@ class TextEditorElement extends HTMLElement
     @component.focused() if event.relatedTarget is this
 
   addGrammarScopeAttribute: ->
-    grammarScope = @model.getGrammar()?.scopeName?.replace(/\./g, ' ')
-    @dataset.grammar = grammarScope
+    @dataset.grammar = @model.getGrammar()?.scopeName?.replace(/\./g, ' ')
 
   addMiniAttribute: ->
     @setAttributeNode(document.createAttribute("mini"))

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2861,7 +2861,6 @@ class TextEditor extends Model
 
   handleGrammarChange: ->
     @unfoldAll()
-    @emit 'grammar-changed' if includeDeprecatedAPIs
     @emitter.emit 'did-change-grammar', @getGrammar()
 
   handleMarkerCreated: (marker) =>

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -71,7 +71,7 @@ class TokenizedBuffer extends Model
       @setGrammar(grammar, newScore) if newScore > @currentGrammarScore
 
   setGrammar: (grammar, score) ->
-    return if grammar is @grammar
+    return unless grammar? and grammar isnt @grammar
 
     @grammar = grammar
     @rootScopeDescriptor = new ScopeDescriptor(scopes: [@grammar.scopeName])
@@ -102,8 +102,7 @@ class TokenizedBuffer extends Model
     @disposables.add(@configSubscriptions)
 
     @retokenizeLines()
-
-    @emit 'grammar-changed', grammar if Grim.includeDeprecatedAPIs
+    atom.packages.triggerActivationHook("#{grammar.packageName}:grammar-used")
     @emitter.emit 'did-change-grammar', grammar
 
   getGrammarSelectionContent: ->


### PR DESCRIPTION
This PR:
- Adds `activationHooks` to package.json
- Triggers the `{grammar-package-name}:grammar-used` hook when a text-editor-element's grammar is set

This allows package authors to defer package activation for language-specific packages until the first use of the grammar(s) their package serves. It also leaves open the possibility to trigger other activation hooks in the future with minimal code.
- Fixes #6629

/cc @kevinsawicki
