### PR TITLE
Bump version of minidump@0.9

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -26,7 +26,7 @@
     "grunt-shell": "~0.3.1",
     "harmony-collections": "~0.3.8",
     "legal-eagle": "~0.10.0",
-    "minidump": "~0.8",
+    "minidump": "~0.9",
     "npm": "2.5.1",
     "rcedit": "~0.3.0",
     "request": "~2.27.0",


### PR DESCRIPTION
This updates the version of `minidump` to `0.9` which includes a fix for building on ARM machines.
 :computer: :muscle: :sparkles: 

:link: https://github.com/atom/node-minidump/issues/5
