### PR TITLE
WIP: Use default cursor instead of pointer

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -203,6 +203,30 @@ module.exports = (grunt) ->
       src: [
         'static/**/*.less'
       ]
+      options:
+        csslint:
+          'adjoining-classes': false
+          'duplicate-background-images': false
+          'box-model': false
+          'box-sizing': false
+          'bulletproof-font-face': false
+          'compatible-vendor-prefixes': false
+          'display-property-grouping': false
+          'fallback-colors': false
+          'floats': false
+          'font-sizes': false
+          'gradients': false
+          'ids': false
+          'important': false
+          'known-properties': false
+          'outline-none': false
+          'overqualified-elements': false
+          'qualified-headings': false
+          'regex-selectors': false
+          'unique-headings': false
+          'universal-selector': false
+          'vendor-prefix': false
+
 
     'download-atom-shell':
       version: packageJson.atomShellVersion

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -119,6 +119,29 @@ module.exports = (grunt) ->
       dest: appDir
       ext: '.js'
 
+  csslintConfig =
+    'adjoining-classes': false
+    'duplicate-background-images': false
+    'box-model': false
+    'box-sizing': false
+    'bulletproof-font-face': false
+    'compatible-vendor-prefixes': false
+    'display-property-grouping': false
+    'fallback-colors': false
+    'floats': false
+    'font-sizes': false
+    'gradients': false
+    'ids': false
+    'important': false
+    'known-properties': false
+    'outline-none': false
+    'overqualified-elements': false
+    'qualified-headings': false
+    'regex-selectors': false
+    'unique-headings': false
+    'universal-selector': false
+    'vendor-prefix': false
+
   for child in fs.readdirSync('node_modules') when child isnt '.bin'
     directory = path.join('node_modules', child)
     metadataPath = path.join(directory, 'package.json')
@@ -175,26 +198,7 @@ module.exports = (grunt) ->
       ]
 
     csslint:
-      options:
-        'adjoining-classes': false
-        'duplicate-background-images': false
-        'box-model': false
-        'box-sizing': false
-        'bulletproof-font-face': false
-        'compatible-vendor-prefixes': false
-        'display-property-grouping': false
-        'fallback-colors': false
-        'font-sizes': false
-        'gradients': false
-        'ids': false
-        'important': false
-        'known-properties': false
-        'outline-none': false
-        'overqualified-elements': false
-        'qualified-headings': false
-        'unique-headings': false
-        'universal-selector': false
-        'vendor-prefix': false
+      options: csslintConfig
       src: [
         'static/**/*.css'
       ]
@@ -204,29 +208,7 @@ module.exports = (grunt) ->
         'static/**/*.less'
       ]
       options:
-        csslint:
-          'adjoining-classes': false
-          'duplicate-background-images': false
-          'box-model': false
-          'box-sizing': false
-          'bulletproof-font-face': false
-          'compatible-vendor-prefixes': false
-          'display-property-grouping': false
-          'fallback-colors': false
-          'floats': false
-          'font-sizes': false
-          'gradients': false
-          'ids': false
-          'important': false
-          'known-properties': false
-          'outline-none': false
-          'overqualified-elements': false
-          'qualified-headings': false
-          'regex-selectors': false
-          'unique-headings': false
-          'universal-selector': false
-          'vendor-prefix': false
-
+        csslint: csslintConfig
 
     'download-atom-shell':
       version: packageJson.atomShellVersion

--- a/build/package.json
+++ b/build/package.json
@@ -21,7 +21,7 @@
     "grunt-contrib-less": "~0.8.0",
     "grunt-cson": "0.14.0",
     "grunt-download-atom-shell": "~0.14.0",
-    "grunt-lesslint": "0.17.0",
+    "grunt-lesslint": "~1.1.14",
     "grunt-peg": "~1.1.0",
     "grunt-shell": "~0.3.1",
     "harmony-collections": "~0.3.8",

--- a/static/bootstrap-overrides.less
+++ b/static/bootstrap-overrides.less
@@ -39,3 +39,7 @@ kbd {
   background-color: none;
   box-shadow: none;
 }
+
+.btn {
+  cursor: default;
+}

--- a/static/bootstrap-overrides.less
+++ b/static/bootstrap-overrides.less
@@ -40,6 +40,6 @@ kbd {
   box-shadow: none;
 }
 
-.btn {
+button, .btn {
   cursor: default;
 }

--- a/static/bootstrap-overrides.less
+++ b/static/bootstrap-overrides.less
@@ -40,6 +40,9 @@ kbd {
   box-shadow: none;
 }
 
-button, .btn, .radio label, .checkbox label {
+button,
+.btn,
+.radio label,
+.checkbox label {
   cursor: default;
 }

--- a/static/bootstrap-overrides.less
+++ b/static/bootstrap-overrides.less
@@ -40,6 +40,6 @@ kbd {
   box-shadow: none;
 }
 
-button, .btn {
+button, .btn, .radio label, .checkbox label {
   cursor: default;
 }

--- a/static/links.less
+++ b/static/links.less
@@ -7,8 +7,12 @@ a {
     text-decoration: underline;
   }
 
-  &.link-external,
   &[href^="http"] {
     cursor: pointer;
   }
+}
+
+// For non anchor elements that open external links
+.link-external {
+  cursor: pointer;
 }

--- a/static/links.less
+++ b/static/links.less
@@ -7,7 +7,8 @@ a {
     text-decoration: underline;
   }
 
-  &[href^="http"], .link-external {
+  & .link-external,
+  &[href^="http"] {
     cursor: pointer;
   }
 }

--- a/static/links.less
+++ b/static/links.less
@@ -7,7 +7,8 @@ a {
     text-decoration: underline;
   }
 
-  &[href^="http"] {
+  &[href^="http"],
+  & * {
     cursor: pointer;
   }
 }

--- a/static/links.less
+++ b/static/links.less
@@ -1,10 +1,13 @@
 @import "ui-variables";
 
 a {
-  cursor: pointer;
   color: @text-color-highlight;
   &:hover {
     color: @text-color-highlight;
     text-decoration: underline;
+  }
+
+  &[href^="http"], .link-external {
+    cursor: pointer;
   }
 }

--- a/static/links.less
+++ b/static/links.less
@@ -7,7 +7,7 @@ a {
     text-decoration: underline;
   }
 
-  & .link-external,
+  &.link-external,
   &[href^="http"] {
     cursor: pointer;
   }

--- a/static/links.less
+++ b/static/links.less
@@ -13,7 +13,38 @@ a {
   }
 }
 
-// For non anchor elements that open external links
+// For any elements that open external links
 .link-external {
   cursor: pointer;
+}
+
+// For any textual elements that are not styled like buttons but open something
+// "internally" in Atom
+.link-internal {
+  cursor: default !important;
+  text-decoration: none;
+  color: @text-color-info;
+  // transition: padding 0.5s;
+
+  &:active,
+  &:hover,
+  &:focus {
+    border-radius: 2px;
+    text-decoration: none;
+    // padding: 1px;
+  }
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: contrast(@text-color-info, darken(@text-color-info, 26%), lighten(@text-color-info, 26%), 43%);
+  }
+
+  &:hover, &:focus {
+    background-color: @text-color-info;
+  }
+
+  &:active {
+    background-color: lighten(@text-color-info, 4%);
+  }
 }

--- a/static/links.less
+++ b/static/links.less
@@ -13,9 +13,9 @@ a {
   }
 }
 
-// For any elements that open external links
+// For any non-button elements that open external links
 .link-external {
-  cursor: pointer;
+  cursor: pointer !important;
 }
 
 // For any textual elements that are not styled like buttons but open something
@@ -24,14 +24,12 @@ a {
   cursor: default !important;
   text-decoration: none;
   color: @text-color-info;
-  // transition: padding 0.5s;
 
   &:active,
   &:hover,
   &:focus {
     border-radius: 2px;
     text-decoration: none;
-    // padding: 1px;
   }
 
   &:hover,

--- a/static/links.less
+++ b/static/links.less
@@ -39,10 +39,10 @@ a {
   }
 
   &:hover, &:focus {
-    background-color: @text-color-info;
+    background-color: @background-color-selected;
   }
 
   &:active {
-    background-color: lighten(@text-color-info, 4%);
+    background-color: lighten(@background-color-selected, 4%);
   }
 }

--- a/static/text.less
+++ b/static/text.less
@@ -37,3 +37,8 @@
 .text-error {
   .text-bits(error);
 }
+
+.text-selectable {
+  -webkit-user-select: text;
+  cursor: text;
+}

--- a/static/text.less
+++ b/static/text.less
@@ -38,7 +38,7 @@
   .text-bits(error);
 }
 
-.text-selectable {
+.text-selectable, .text-selectable * {
   -webkit-user-select: text;
-  cursor: text;
+  cursor: auto;
 }

--- a/static/text.less
+++ b/static/text.less
@@ -38,7 +38,7 @@
   .text-bits(error);
 }
 
-.text-selectable, .text-selectable * {
+.text-selectable, .text-selectable *, p {
   -webkit-user-select: text;
   cursor: auto;
 }

--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -3,6 +3,10 @@
 
 @font-face { .octicon-font(); }
 
+* {
+  cursor: default;
+}
+
 html {
   font-family: @font-family;
   font-size: @font-size;


### PR DESCRIPTION
Refs https://github.com/atom/settings-view/issues/531

This implements something @simurai and I have been throwing around for awhile now – it removes all Atom core usage of `cursor: pointer` in favor of `cursor: default`. As @jerone put it in https://github.com/atom/settings-view/issues/531:

> Showing the cursor as a "hand" when hovering over things in the UI is a very "web" oriented convention.

This will go a long way, I think, toward making Atom feel less like a """website""" running in a semi-headless Chrome, and far more like a native app with a custom UI. :smile: 

_Note: This won't affect the styling of any components that explicitly declare another `cursor` type._

> But how will I know I can click on a thing? How will I know if a thing can be interacted with?

Here's how various OSes and desktop shells handle this:
- **OS X**: Occasionally a hover state, often a thing that looks like a button, but usually no way of knowing other than by clicking on it.
- **Windows**: Hover states.
- **GNOME 3**: Hover states.
- **Ubuntu Unity**: Hover states.

I think the safest bet here is to give actionable elements appropriate hover states as a replacement for `cursor: pointer`.

Although this is quite a sweeping change, it doesn't _entirely_ do away with `cursor: pointer` – the pointer should still be used when an element actually is an external link (whether it's an `a` element or not). Ideally this will be combined with https://github.com/atom/status-bar/issues/89 eventually.

TODO:
- [x] What do we do about actionable text? Right now it'll have a standard link-like underline hover state, but without `cursor: pointer`.
- [x] ~~We could be more extreme and add an `!important` flag to really discourage use of `cursor: pointer` – thoughts?~~
- [ ] Ensure that no other Bootstrap classes need overrides
- [ ] Add `.link-external` class example to styleguide
- [ ] Add `.link-internal` class example to styleguide
- [ ] Add `.text-selectable` class example to styleguide
- [x] Remove all remaining uses of `cursor: pointer` from settings-view (https://github.com/atom/settings-view/pull/575)
- [ ] Ensure that all actionable status bar tiles have hover states
  - [ ] Update status bar tile hover states to look less like links (background highlight maybe?)
- [ ] Communicate this change well so package authors can adapt if need be
  - [ ] Also encourage package authors to use `cursor: default` + hover state for actionable elements in their packages over `cursor: pointer`

/cc @atom/feedback 
