### PR TITLE
Different title for file dialogs and folder dialogs.

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -576,7 +576,7 @@ class AtomApplication
       title: switch type
         when 'file' then 'Open File'
         when 'folder' then 'Open Folder'
-        when 'all' then 'Open'
+        else 'Open'
 
     if process.platform is 'linux'
       if projectPath = @lastFocusedWindow?.projectPath

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -573,7 +573,10 @@ class AtomApplication
 
     openOptions =
       properties: properties.concat(['multiSelections', 'createDirectory'])
-      title: 'Open'
+      title: switch type
+        when 'file' then 'Open File'
+        when 'folder' then 'Open Folder'
+        when 'all' then 'Open'
 
     if process.platform is 'linux'
       if projectPath = @lastFocusedWindow?.projectPath


### PR DESCRIPTION
Fixes #6796
If the dialog opens a file its title is changed to "Open File", and if it opens a directory its title is changed to "Open Folder".
