### PR TITLE
Check if error message exists before using it in Pane.handleSaveError

### DIFF
--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -677,7 +677,7 @@ class Pane extends Model
     true
 
   handleSaveError: (error) ->
-    if error.code is 'EISDIR' or error.message.endsWith('is a directory')
+    if error.code is 'EISDIR' or error.message?.endsWith('is a directory')
       atom.notifications.addWarning("Unable to save file: #{error.message}")
     else if error.code is 'EACCES' and error.path?
       atom.notifications.addWarning("Unable to save file: Permission denied '#{error.path}'")


### PR DESCRIPTION
This should fix https://github.com/atom/atom/issues/7714, though I'm not really sure when an error won't have a message defined (other than manually setting it to undefined, which a package could do I guess?). 

cc @kevinsawicki for :thought_balloon: :eyes: 
