### PR TITLE
Remove leftover update statements

### DIFF
--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -897,6 +897,7 @@ class TextEditorPresenter
       oldContentFrameWidth = @contentFrameWidth
       @contentFrameWidth = contentFrameWidth
       @model.setWidth(contentFrameWidth)
+      @updateScrollbarDimensions()
       @updateClientWidth()
       @shouldUpdateVerticalScrollState = true
       @shouldUpdateHorizontalScrollState = true

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -71,6 +71,7 @@ class TextEditorPresenter
     @updateScrollbarDimensions()
     @updateStartRow()
     @updateEndRow()
+    @updateCommonGutterState()
 
     @updateFocusedState() if @shouldUpdateFocusedState
     @updateHeightState() if @shouldUpdateHeightState
@@ -111,8 +112,6 @@ class TextEditorPresenter
 
   observeModel: ->
     @disposables.add @model.onDidChange =>
-      @updateContentDimensions()
-      @updateEndRow()
       @shouldUpdateHeightState = true
       @shouldUpdateVerticalScrollState = true
       @shouldUpdateHorizontalScrollState = true
@@ -149,14 +148,11 @@ class TextEditorPresenter
       @shouldUpdateLineNumbersState = true
       @shouldUpdateGutterOrderState = true
       @shouldUpdateCustomGutterDecorationState = true
-      @updateScrollbarDimensions()
-      @updateCommonGutterState()
       @emitDidUpdateState()
 
     @disposables.add @model.onDidChangeLineNumberGutterVisible =>
       @shouldUpdateLineNumberGutterState = true
       @shouldUpdateGutterOrderState = true
-      @updateCommonGutterState()
       @emitDidUpdateState()
 
     @disposables.add @model.onDidAddDecoration(@didAddDecoration.bind(this))
@@ -198,7 +194,6 @@ class TextEditorPresenter
       @showLineNumbers = newValue
       @shouldUpdateLineNumberGutterState = true
       @shouldUpdateGutterOrderState = true
-      @updateCommonGutterState()
 
       @emitDidUpdateState()
 
@@ -207,7 +202,6 @@ class TextEditorPresenter
     @shouldUpdateContentState = true
     @shouldUpdateLineNumberGutterState = true
     @shouldUpdateGutterOrderState = true
-    @updateCommonGutterState()
 
     @emitDidUpdateState()
 
@@ -792,8 +786,6 @@ class TextEditorPresenter
     unless @scrollTop is scrollTop or Number.isNaN(scrollTop)
       @scrollTop = scrollTop
       @model.setScrollTop(scrollTop)
-      @updateStartRow()
-      @updateEndRow()
       @didStartScrolling()
       @shouldUpdateVerticalScrollState = true
       @shouldUpdateHiddenInputState = true
@@ -850,7 +842,6 @@ class TextEditorPresenter
       oldHorizontalScrollbarHeight = @measuredHorizontalScrollbarHeight
       @measuredHorizontalScrollbarHeight = horizontalScrollbarHeight
       @model.setHorizontalScrollbarHeight(horizontalScrollbarHeight)
-      @updateScrollbarDimensions()
       @shouldUpdateScrollbarsState = true
       @shouldUpdateVerticalScrollState = true
       @shouldUpdateHorizontalScrollState = true
@@ -863,7 +854,6 @@ class TextEditorPresenter
       oldVerticalScrollbarWidth = @measuredVerticalScrollbarWidth
       @measuredVerticalScrollbarWidth = verticalScrollbarWidth
       @model.setVerticalScrollbarWidth(verticalScrollbarWidth)
-      @updateScrollbarDimensions()
       @shouldUpdateScrollbarsState = true
       @shouldUpdateVerticalScrollState = true
       @shouldUpdateHorizontalScrollState = true
@@ -907,7 +897,6 @@ class TextEditorPresenter
       oldContentFrameWidth = @contentFrameWidth
       @contentFrameWidth = contentFrameWidth
       @model.setWidth(contentFrameWidth)
-      @updateScrollbarDimensions()
       @updateClientWidth()
       @shouldUpdateVerticalScrollState = true
       @shouldUpdateHorizontalScrollState = true
@@ -946,7 +935,6 @@ class TextEditorPresenter
       @backgroundColor = backgroundColor
       @shouldUpdateContentState = true
       @shouldUpdateLineNumberGutterState = true
-      @updateCommonGutterState()
       @shouldUpdateGutterOrderState = true
 
       @emitDidUpdateState()
@@ -955,7 +943,6 @@ class TextEditorPresenter
     unless @gutterBackgroundColor is gutterBackgroundColor
       @gutterBackgroundColor = gutterBackgroundColor
       @shouldUpdateLineNumberGutterState = true
-      @updateCommonGutterState()
       @shouldUpdateGutterOrderState = true
 
       @emitDidUpdateState()
@@ -969,11 +956,6 @@ class TextEditorPresenter
     unless @lineHeight is lineHeight
       @lineHeight = lineHeight
       @model.setLineHeightInPixels(lineHeight)
-      @updateContentDimensions()
-      @updateScrollHeight()
-      @updateHeight()
-      @updateStartRow()
-      @updateEndRow()
       @shouldUpdateHeightState = true
       @shouldUpdateHorizontalScrollState = true
       @shouldUpdateVerticalScrollState = true
@@ -1024,8 +1006,6 @@ class TextEditorPresenter
     @characterWidthsChanged() unless @batchingCharacterMeasurement
 
   characterWidthsChanged: ->
-    @updateContentDimensions()
-
     @shouldUpdateHorizontalScrollState = true
     @shouldUpdateVerticalScrollState = true
     @shouldUpdateScrollbarsState = true


### PR DESCRIPTION
This PR gets rid of a couple of `update` statements in `TextEditorPresenter` that were getting executed when some event was triggered. They are unnecessary because they’ll get executed anyway as soon as `getState` is called.

Although this is pretty straightforward, another pair of :eyes: is most welcome. Thanks! :bow: 

/cc: @nathansobo @atom/feedback 
