### PR TITLE
Move browser process requires earlier

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -6,6 +6,8 @@ BrowserWindow = require 'browser-window'
 StorageFolder = require '../storage-folder'
 Menu = require 'menu'
 app = require 'app'
+dialog = require 'dialog'
+shell = require 'shell'
 fs = require 'fs-plus'
 ipc = require 'ipc'
 path = require 'path'
@@ -175,13 +177,13 @@ class AtomApplication
       atomWindow ?= @focusedWindow()
       atomWindow?.browserWindow.inspectElement(x, y)
 
-    @on 'application:open-documentation', -> require('shell').openExternal('https://atom.io/docs/latest/?app')
-    @on 'application:open-discussions', -> require('shell').openExternal('https://discuss.atom.io')
-    @on 'application:open-roadmap', -> require('shell').openExternal('https://atom.io/roadmap?app')
-    @on 'application:open-faq', -> require('shell').openExternal('https://atom.io/faq')
-    @on 'application:open-terms-of-use', -> require('shell').openExternal('https://atom.io/terms')
-    @on 'application:report-issue', -> require('shell').openExternal('https://github.com/atom/atom/blob/master/CONTRIBUTING.md#submitting-issues')
-    @on 'application:search-issues', -> require('shell').openExternal('https://github.com/issues?q=+is%3Aissue+user%3Aatom')
+    @on 'application:open-documentation', -> shell.openExternal('https://atom.io/docs/latest/?app')
+    @on 'application:open-discussions', -> shell.openExternal('https://discuss.atom.io')
+    @on 'application:open-roadmap', -> shell.openExternal('https://atom.io/roadmap?app')
+    @on 'application:open-faq', -> shell.openExternal('https://atom.io/faq')
+    @on 'application:open-terms-of-use', -> shell.openExternal('https://atom.io/terms')
+    @on 'application:report-issue', -> shell.openExternal('https://github.com/atom/atom/blob/master/CONTRIBUTING.md#submitting-issues')
+    @on 'application:search-issues', -> shell.openExternal('https://github.com/issues?q=+is%3Aissue+user%3Aatom')
 
     @on 'application:install-update', =>
       @quitting = true
@@ -582,5 +584,4 @@ class AtomApplication
       if projectPath = @lastFocusedWindow?.projectPath
         openOptions.defaultPath = projectPath
 
-    dialog = require 'dialog'
     dialog.showOpenDialog(parentWindow, openOptions, callback)

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -1,5 +1,6 @@
 BrowserWindow = require 'browser-window'
 app = require 'app'
+dialog = require 'dialog'
 path = require 'path'
 fs = require 'fs'
 url = require 'url'
@@ -125,7 +126,6 @@ class AtomWindow
     @browserWindow.on 'unresponsive', =>
       return if @isSpec
 
-      dialog = require 'dialog'
       chosen = dialog.showMessageBox @browserWindow,
         type: 'warning'
         buttons: ['Close', 'Keep Waiting']
@@ -136,7 +136,6 @@ class AtomWindow
     @browserWindow.webContents.on 'crashed', =>
       global.atomApplication.exit(100) if @exitWhenDone
 
-      dialog = require 'dialog'
       chosen = dialog.showMessageBox @browserWindow,
         type: 'warning'
         buttons: ['Close Window', 'Reload', 'Keep It Open']


### PR DESCRIPTION
This is a stopgap solution to intermittent require errors in the browser process because of an asar/electron bug. This will not be needed once #6877 is merged.

Follow on to https://github.com/atom/atom/pull/7560

Closes #6276
Closes #7591 
Closes https://github.com/atom/tabs/issues/192
Closes https://github.com/atom/tree-view/issues/399
