### PR TITLE
Guard against missing stdout/stderr on Task

### DIFF
--- a/spec/task-spec.coffee
+++ b/spec/task-spec.coffee
@@ -71,6 +71,17 @@ describe "Task", ->
     expect(stdout.listeners('data').length).toBe 0
     expect(stderr.listeners('data').length).toBe 0
 
+    task = new Task(require.resolve('./fixtures/task-spec-handler'))
+    task.start()
+
+    # Sometimes process don't have stdout/stderr
+    task.childProcess.stdout = null
+    task.childProcess.stderr = null
+
+    task.terminate()
+
+    expect(-> task.terminate()).not.toThrow()
+
   describe "::cancel()", ->
     it "dispatches 'task:cancelled' when invoked on an active task", ->
       task = new Task(require.resolve('./fixtures/task-spec-handler'))

--- a/spec/task-spec.coffee
+++ b/spec/task-spec.coffee
@@ -71,15 +71,16 @@ describe "Task", ->
     expect(stdout.listeners('data').length).toBe 0
     expect(stderr.listeners('data').length).toBe 0
 
+  it "does not throw an error for forked processes missing stdout/stderr", ->
+    spyOn(require('child_process'), 'fork').andCallFake ->
+      Events = require 'events'
+      fakeProcess = new Events()
+      fakeProcess.send = ->
+      fakeProcess.kill = ->
+      fakeProcess
+
     task = new Task(require.resolve('./fixtures/task-spec-handler'))
-    task.start()
-
-    # Sometimes process don't have stdout/stderr
-    task.childProcess.stdout = null
-    task.childProcess.stderr = null
-
-    task.terminate()
-
+    expect(-> task.start()).not.toThrow()
     expect(-> task.terminate()).not.toThrow()
 
   describe "::cancel()", ->

--- a/src/task.coffee
+++ b/src/task.coffee
@@ -1,5 +1,5 @@
 _ = require 'underscore-plus'
-{fork} = require 'child_process'
+ChildProcess = require 'child_process'
 {Emitter} = require 'emissary'
 Grim = require 'grim'
 
@@ -83,7 +83,7 @@ class Task
     taskPath = taskPath.replace(/\\/g, "\\\\")
 
     env = _.extend({}, process.env, {taskPath, userAgent: navigator.userAgent})
-    @childProcess = fork '--eval', [bootstrap], {env, silent: true}
+    @childProcess = ChildProcess.fork '--eval', [bootstrap], {env, silent: true}
 
     @on "task:log", -> console.log(arguments...)
     @on "task:warn", -> console.warn(arguments...)
@@ -102,10 +102,13 @@ class Task
       @emit(event, args...) if @childProcess?
 
     # Catch the errors that happened before task-bootstrap.
-    @childProcess.stdout.removeAllListeners()
-    @childProcess.stdout.on 'data', (data) -> console.log data.toString()
-    @childProcess.stderr.removeAllListeners()
-    @childProcess.stderr.on 'data', (data) -> console.error data.toString()
+    if @childProcess.stdout?
+      @childProcess.stdout.removeAllListeners()
+      @childProcess.stdout.on 'data', (data) -> console.log data.toString()
+
+    if @childProcess.stderr?
+      @childProcess.stderr.removeAllListeners()
+      @childProcess.stderr.on 'data', (data) -> console.error data.toString()
 
   # Public: Starts the task.
   #
@@ -153,8 +156,8 @@ class Task
     return false unless @childProcess?
 
     @childProcess.removeAllListeners()
-    @childProcess.stdout.removeAllListeners()
-    @childProcess.stderr.removeAllListeners()
+    @childProcess.stdout?.removeAllListeners()
+    @childProcess.stderr?.removeAllListeners()
     @childProcess.kill()
     @childProcess = null
 


### PR DESCRIPTION
These appear to not always be there depending on the forked process.

Closes #7459
