### PR TITLE
Emit will-insert-text event when pasting

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2925,6 +2925,17 @@ describe "TextEditor", ->
           expect(editor.lineTextForBufferRow(0)).toBe "var first = function () {"
           expect(editor.lineTextForBufferRow(1)).toBe "  var first = function(items) {"
 
+        it "notifies ::onWillInsertText observers", ->
+          insertedStrings = []
+          editor.onWillInsertText ({text, cancel}) ->
+            insertedStrings.push(text)
+            cancel()
+
+          atom.clipboard.write("hello")
+          editor.pasteText()
+
+          expect(insertedStrings).toEqual ["hello"]
+
         describe "when `autoIndentOnPaste` is true", ->
           beforeEach ->
             atom.config.set("editor.autoIndentOnPaste", true)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -772,31 +772,24 @@ class TextEditor extends Model
   # Returns a {Range} when the text has been inserted
   # Returns a {Boolean} false when the text has not been inserted
   insertText: (text, options={}) ->
-    willInsert = true
-    cancel = -> willInsert = false
-    willInsertEvent = {cancel, text}
-    @emit('will-insert-text', willInsertEvent) if includeDeprecatedAPIs
-    @emitter.emit 'will-insert-text', willInsertEvent
+    return false unless @emitWillInsertTextEvent(text)
 
     groupingInterval = if options.groupUndo
       atom.config.get('editor.undoGroupingInterval')
     else
       0
 
-    if willInsert
-      options.autoIndentNewline ?= @shouldAutoIndent()
-      options.autoDecreaseIndent ?= @shouldAutoIndent()
-      @mutateSelectedText(
-        (selection) =>
-          range = selection.insertText(text, options)
-          didInsertEvent = {text, range}
-          @emit('did-insert-text', didInsertEvent) if includeDeprecatedAPIs
-          @emitter.emit 'did-insert-text', didInsertEvent
-          range
-        , groupingInterval
-      )
-    else
-      false
+    options.autoIndentNewline ?= @shouldAutoIndent()
+    options.autoDecreaseIndent ?= @shouldAutoIndent()
+    @mutateSelectedText(
+      (selection) =>
+        range = selection.insertText(text, options)
+        didInsertEvent = {text, range}
+        @emit('did-insert-text', didInsertEvent) if includeDeprecatedAPIs
+        @emitter.emit 'did-insert-text', didInsertEvent
+        range
+      , groupingInterval
+    )
 
   # Essential: For each selection, replace the selected text with a newline.
   insertNewline: ->
@@ -2602,6 +2595,8 @@ class TextEditor extends Model
   # * `options` (optional) See {Selection::insertText}.
   pasteText: (options={}) ->
     {text: clipboardText, metadata} = atom.clipboard.readWithMetadata()
+    return false unless @emitWillInsertTextEvent(clipboardText)
+
     metadata ?= {}
     options.autoIndent = @shouldAutoIndentOnPaste()
 
@@ -2976,6 +2971,14 @@ class TextEditor extends Model
     "<TextEditor #{@id}>"
 
   logScreenLines: (start, end) -> @displayBuffer.logLines(start, end)
+
+  emitWillInsertTextEvent: (text) ->
+    result = true
+    cancel = -> result = false
+    willInsertEvent = {cancel, text}
+    @emit('will-insert-text', willInsertEvent) if includeDeprecatedAPIs
+    @emitter.emit 'will-insert-text', willInsertEvent
+    result
 
 if includeDeprecatedAPIs
   TextEditor.delegatesProperties '$lineHeightInPixels', '$defaultCharWidth', '$height', '$width',


### PR DESCRIPTION
Packages like `go-to-line` [use the `::onWillInsertText` event](https://github.com/atom/go-to-line/blob/70428c943c4e1c5c2675d90e418bdcf2fd62833b/lib/go-to-line-view.coffee#L24) to stop invalid text from being inserted into a text-editor. Previously, this event was not emitted when pasting. This allowed invalid data to enter the editor in the `go-to-line` dialog.

Fixes atom/go-to-line#22
