### PR TITLE
`updateContentDimensions` when model changes

### DIFF
--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -153,7 +153,6 @@ describe "TextEditorPresenter", ->
         expect(stateFn(presenter).tiles[8]).toBeDefined()
         expect(stateFn(presenter).tiles[10]).toBeUndefined()
 
-
       it "updates when ::lineHeight changes", ->
         presenter = buildPresenter(explicitHeight: 6, scrollTop: 0, lineHeight: 1, tileSize: 2)
 
@@ -660,6 +659,16 @@ describe "TextEditorPresenter", ->
           expect(presenter.getState().content.scrollTop).toBe 10
           expectStateUpdate presenter, -> presenter.setScrollTop(50)
           expect(presenter.getState().content.scrollTop).toBe 50
+
+        it "scrolls down automatically when the model is changed", ->
+          presenter = buildPresenter(scrollTop: 0, lineHeight: 10, explicitHeight: 20)
+
+          editor.setText("")
+          editor.insertNewline()
+          expect(presenter.getState().content.scrollTop).toBe(0)
+
+          editor.insertNewline()
+          expect(presenter.getState().content.scrollTop).toBe(10)
 
         it "never exceeds the computed scroll height minus the computed client height", ->
           presenter = buildPresenter(scrollTop: 10, lineHeight: 10, explicitHeight: 50, horizontalScrollbarHeight: 10)

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -112,6 +112,8 @@ class TextEditorPresenter
 
   observeModel: ->
     @disposables.add @model.onDidChange =>
+      @updateContentDimensions()
+
       @shouldUpdateHeightState = true
       @shouldUpdateVerticalScrollState = true
       @shouldUpdateHorizontalScrollState = true


### PR DESCRIPTION
In #7733 we have removed a couple of update statements that were no longer needed. Unfortunately, we didn’t catch a :bug: that caused the editor not to scroll automatically when the model changed.

This PR fixes it and also adds a spec to prevent this to happen in the future. The :beetle: was caused by the following scenario:
1. A new line was inserted at the end of the buffer, causing the content height to be bigger;
2. The model triggered a `setScrollTop` on `TextEditorPresenter` with the correct value;
3. `TextEditorPresenter::setScrollTop` didn’t know about the change in the model yet and tried to constrain `@scrollTop` using a bad value (i.e. the content height before the change) as the upper bound;
4. :bug: 

/cc: @maxbrunsfeld @nathansobo 
