### PR TITLE
Guard against non-string messages in Pane.handleSaveError

### DIFF
--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -677,7 +677,7 @@ class Pane extends Model
     true
 
   handleSaveError: (error) ->
-    if error.code is 'EISDIR' or error.message?.endsWith('is a directory')
+    if error.code is 'EISDIR' or error.message?.endsWith?('is a directory')
       atom.notifications.addWarning("Unable to save file: #{error.message}")
     else if error.code is 'EACCES' and error.path?
       atom.notifications.addWarning("Unable to save file: Permission denied '#{error.path}'")


### PR DESCRIPTION
See https://github.com/atom/atom/pull/7717#issuecomment-119280666 for context. 

cc @kevinsawicki :zap: for catching that case as well
