### PR TITLE
Validate atom.notifications input

### DIFF
--- a/spec/notification-spec.coffee
+++ b/spec/notification-spec.coffee
@@ -16,12 +16,6 @@ describe "Notification", ->
     expect(-> new Notification('error', 'message', false)).toThrow()
     expect(-> new Notification('error', 'message', [])).toThrow()
 
-  it "throws an error when created with a non-string detail", ->
-    expect(-> new Notification('error', 'message', detail: 3)).toThrow()
-    expect(-> new Notification('error', 'message', detail: false)).toThrow()
-    expect(-> new Notification('error', 'message', detail: {})).toThrow()
-    expect(-> new Notification('error', 'message', detail: [])).toThrow()
-
   describe "::getTimestamp()", ->
     it "returns a Date object", ->
       notification = new Notification('error', 'message!')

--- a/spec/notification-spec.coffee
+++ b/spec/notification-spec.coffee
@@ -8,16 +8,19 @@ describe "Notification", ->
     expect(-> new Notification('error', 3)).toThrow()
     expect(-> new Notification('error', {})).toThrow()
     expect(-> new Notification('error', false)).toThrow()
+    expect(-> new Notification('error', [])).toThrow()
 
   it "throws an error when created with non-object options", ->
     expect(-> new Notification('error', 'message', 'foo')).toThrow()
     expect(-> new Notification('error', 'message', 3)).toThrow()
     expect(-> new Notification('error', 'message', false)).toThrow()
+    expect(-> new Notification('error', 'message', [])).toThrow()
 
   it "throws an error when created with a non-string detail", ->
     expect(-> new Notification('error', 'message', detail: 3)).toThrow()
     expect(-> new Notification('error', 'message', detail: false)).toThrow()
     expect(-> new Notification('error', 'message', detail: {})).toThrow()
+    expect(-> new Notification('error', 'message', detail: [])).toThrow()
 
   describe "::getTimestamp()", ->
     it "returns a Date object", ->

--- a/spec/notification-spec.coffee
+++ b/spec/notification-spec.coffee
@@ -3,6 +3,22 @@ Notification = require '../src/notification'
 describe "Notification", ->
   [notification] = []
 
+  it "throws an error when created with a non-string message", ->
+    expect(-> new Notification('error', null)).toThrow()
+    expect(-> new Notification('error', 3)).toThrow()
+    expect(-> new Notification('error', {})).toThrow()
+    expect(-> new Notification('error', false)).toThrow()
+
+  it "throws an error when created with non-object options", ->
+    expect(-> new Notification('error', 'message', 'foo')).toThrow()
+    expect(-> new Notification('error', 'message', 3)).toThrow()
+    expect(-> new Notification('error', 'message', false)).toThrow()
+
+  it "throws an error when created with a non-string detail", ->
+    expect(-> new Notification('error', 'message', detail: 3)).toThrow()
+    expect(-> new Notification('error', 'message', detail: false)).toThrow()
+    expect(-> new Notification('error', 'message', detail: {})).toThrow()
+
   describe "::getTimestamp()", ->
     it "returns a Date object", ->
       notification = new Notification('error', 'message!')

--- a/src/notification.coffee
+++ b/src/notification.coffee
@@ -19,9 +19,6 @@ class Notification
     unless _.isObject(@options) and not _.isArray(@options)
       throw new Error("Notification must be created with an options object: #{@options}")
 
-    if @options?.detail? and typeof @options.detail isnt 'string'
-      throw new Error("Notification must be created with string detail: #{@options.detail}")
-
   onDidDismiss: (callback) ->
     @emitter.on 'did-dismiss', callback
 
@@ -38,7 +35,6 @@ class Notification
 
   getTimestamp: -> @timestamp
 
-  # Public: Retrieves the {String} detail.
   getDetail: -> @options.detail
 
   isEqual: (other) ->

--- a/src/notification.coffee
+++ b/src/notification.coffee
@@ -9,6 +9,17 @@ class Notification
     @dismissed = true
     @dismissed = false if @isDismissable()
     @displayed = false
+    @validate()
+
+  validate: ->
+    if typeof @message isnt 'string'
+      throw new Error("Notification must be created with string message: #{@message}")
+
+    if typeof @options isnt 'object'
+      throw new Error("Notification must be created with an options object: #{@options}")
+
+    if @options?.detail? and typeof @options.details isnt 'string'
+      throw new Error("Notification must be created with string detail: #{@options.detail}")
 
   onDidDismiss: (callback) ->
     @emitter.on 'did-dismiss', callback

--- a/src/notification.coffee
+++ b/src/notification.coffee
@@ -1,4 +1,5 @@
 {Emitter} = require 'event-kit'
+_ = require 'underscore-plus'
 
 # Public: A notification to the user containing a message and type.
 module.exports =
@@ -15,7 +16,7 @@ class Notification
     if typeof @message isnt 'string'
       throw new Error("Notification must be created with string message: #{@message}")
 
-    if typeof @options isnt 'object'
+    unless _.isObject(@options) and not _.isArray(@options)
       throw new Error("Notification must be created with an options object: #{@options}")
 
     if @options?.detail? and typeof @options.details isnt 'string'

--- a/src/notification.coffee
+++ b/src/notification.coffee
@@ -37,6 +37,7 @@ class Notification
 
   getTimestamp: -> @timestamp
 
+  # Public: Retrieves the {String} detail.
   getDetail: -> @options.detail
 
   isEqual: (other) ->

--- a/src/notification.coffee
+++ b/src/notification.coffee
@@ -19,7 +19,7 @@ class Notification
     unless _.isObject(@options) and not _.isArray(@options)
       throw new Error("Notification must be created with an options object: #{@options}")
 
-    if @options?.detail? and typeof @options.details isnt 'string'
+    if @options?.detail? and typeof @options.detail isnt 'string'
       throw new Error("Notification must be created with string detail: #{@options.detail}")
 
   onDidDismiss: (callback) ->


### PR DESCRIPTION
Previously the API documented on `atom.notifications` was not validated so you could create a notification with a non-string message, non-object options, or non-string detail. 

This would cause the notifications package to throw errors when it tried to convert a non-string markdown message.

Now it verifies the options on creation and throws error when they are invalid.

Closes https://github.com/atom/notifications/issues/79

/cc @benogle 
