### PR TITLE
Handle native chromium undo, redo, cut, copy, paste, selectAll on all platforms

### DIFF
--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -114,23 +114,23 @@ class WindowEventHandler
 
     @handleNativeKeybindings()
 
-  # Wire commands that should be handled by the native menu
-  # for elements with the `.native-key-bindings` class.
+  # Wire commands that should be handled by Chromium for elements with the
+  # `.native-key-bindings` class.
   handleNativeKeybindings: ->
     menu = null
     bindCommandToAction = (command, action) =>
       @subscribe $(document), command, (event) ->
         if event.target.webkitMatchesSelector('.native-key-bindings')
-          menu ?= require('remote').require('menu')
-          menu.sendActionToFirstResponder(action)
+          webContents = require('remote').getCurrentWindow().webContents
+          webContents[action]()
         true
 
-    bindCommandToAction('core:copy', 'copy:')
-    bindCommandToAction('core:paste', 'paste:')
-    bindCommandToAction('core:undo', 'undo:')
-    bindCommandToAction('core:redo', 'redo:')
-    bindCommandToAction('core:select-all', 'selectAll:')
-    bindCommandToAction('core:cut', 'cut:')
+    bindCommandToAction('core:copy', 'copy')
+    bindCommandToAction('core:paste', 'paste')
+    bindCommandToAction('core:undo', 'undo')
+    bindCommandToAction('core:redo', 'redo')
+    bindCommandToAction('core:select-all', 'selectAll')
+    bindCommandToAction('core:cut', 'cut')
 
   onKeydown: (event) ->
     atom.keymaps.handleKeyboardEvent(event)


### PR DESCRIPTION
Our current approach relies on `menu.sendActionToFirstResponder`, which is only defined on OS X. It would be good to actually make this work elsewhere, but this will at least prevent the exception for the undefined method.

Closes #6587
