### PR TITLE
Suppress line measurement exceptions and gather data to solve them

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "deprecation-cop": "0.53.0",
     "dev-live-reload": "0.46.0",
     "encoding-selector": "0.21.0",
-    "exception-reporting": "0.34.0",
+    "exception-reporting": "0.35.0",
     "find-and-replace": "0.174.2",
     "fuzzy-finder": "0.87.0",
     "git-diff": "0.55.0",

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -127,7 +127,7 @@ describe "the `atom` global", ->
           column: 3
           originalError: error
 
-  describe ".assert(condition, message, metadata)", ->
+  describe ".assert(condition, message, callback)", ->
     errors = null
 
     beforeEach ->
@@ -142,17 +142,11 @@ describe "the `atom` global", ->
         expect(errors[0].message).toBe "Assertion failed: a == b"
         expect(errors[0].stack).toContain('atom-spec')
 
-      describe "if metadata is an object", ->
-        it "assigns the object on the error as `metadata`", ->
-          metadata = {foo: 'bar'}
-          atom.assert(false, "a == b", metadata)
-          expect(errors[0].metadata).toBe metadata
-
-      describe "if metadata is a function", ->
-        it "assigns the function's return value on the error as `metadata`", ->
-          metadata = {foo: 'bar'}
-          atom.assert(false, "a == b", -> metadata)
-          expect(errors[0].metadata).toBe metadata
+      describe "if passed a callback function", ->
+        it "calls the callback with the assertion failure's error object", ->
+          error = null
+          atom.assert(false, "a == b", (e) -> error = e)
+          expect(error).toBe errors[0]
 
     describe "if the condition is true", ->
       it "does nothing", ->

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -721,17 +721,12 @@ class Atom extends Model
   Section: Private
   ###
 
-  assert: (condition, message, metadata) ->
+  assert: (condition, message, callback) ->
     return true if condition
 
     error = new Error("Assertion failed: #{message}")
     Error.captureStackTrace(error, @assert)
-
-    if metadata?
-      if typeof metadata is 'function'
-        error.metadata = metadata()
-      else
-        error.metadata = metadata
+    callback?(error)
 
     @emitter.emit 'did-fail-assertion', error
 

--- a/src/lines-tile-component.coffee
+++ b/src/lines-tile-component.coffee
@@ -346,17 +346,44 @@ class LinesTileComponent
             rangeForMeasurement ?= document.createRange()
             iterator =  document.createNodeIterator(lineNode, NodeFilter.SHOW_TEXT, AcceptFilter)
             textNode = iterator.nextNode()
+            textNodeLength = textNode.length
             textNodeIndex = 0
             nextTextNodeIndex = textNode.textContent.length
 
           while nextTextNodeIndex <= charIndex
             textNode = iterator.nextNode()
+            textNodeLength = textNode.length
             textNodeIndex = nextTextNodeIndex
             nextTextNodeIndex = textNodeIndex + textNode.textContent.length
 
           i = charIndex - textNodeIndex
           rangeForMeasurement.setStart(textNode, i)
-          rangeForMeasurement.setEnd(textNode, i + charLength)
+
+          if i + charLength <= textNodeLength
+            rangeForMeasurement.setEnd(textNode, i + charLength)
+          else
+            rangeForMeasurement.setEnd(textNode, textNodeLength)
+            atom.assert false, "Expected index to be less than the length of text node while measuring", (error) =>
+              editor = @presenter.model
+              screenRow = tokenizedLine.screenRow
+              bufferRow = editor.bufferRowForScreenRow(screenRow)
+
+              error.metadata = {
+                grammarScopeName: editor.getGrammar().scopeName
+                screenRow: screenRow
+                bufferRow: bufferRow
+                softWrapped: editor.isSoftWrapped()
+                softTabs: editor.getSoftTabs()
+                i: i
+                charLength: charLength
+                textNodeLength: textNode.length
+              }
+              error.privateMetadataDescription = "The contents of line #{bufferRow + 1}."
+              error.privateMetadata = {
+                lineText: editor.lineTextForBufferRow(bufferRow)
+              }
+              error.privateMetadataRequestName = "measured-line-text"
+
           charWidth = rangeForMeasurement.getBoundingClientRect().width
           @presenter.setScopedCharacterWidth(scopes, char, charWidth)
 

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -296,10 +296,12 @@ class TokenizedBuffer extends Model
     # undefined. This should paper over the problem but we want to figure out
     # what is happening:
     tokenizedLine = @tokenizedLineForRow(row)
-    atom.assert tokenizedLine?, "TokenizedLine is defined", =>
-      metadata:
+    atom.assert tokenizedLine?, "TokenizedLine is defined", (error) =>
+      error.metadata = {
         row: row
         rowCount: @tokenizedLines.length
+      }
+
     return false unless tokenizedLine?
 
     return false if @buffer.isRowBlank(row) or tokenizedLine.isComment()


### PR DESCRIPTION
This code recovers gracefully from situations where we try to measure off the end of a text node. Since this situation is unexpected, when it happens, we ask the user (only once) for the text of the line where it's happening. Hopefully we can use this information to get a better understanding of why this is happening.
