### PR TITLE
Add code of conduct to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,9 @@ which are hosted in the [Atom Organization](https://github.com/atom) on GitHub.
 These are just guidelines, not rules, use your best judgment and feel free to
 propose changes to this document in a pull request.
 
+This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
+[code-of-conduct]: http://todogroup.org/opencodeofconduct/#Atom/opensource@github.com
+
 ## Submitting Issues
 
 * You can create an issue [here](https://github.com/atom/atom/issues/new), but

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Visit [atom.io](https://atom.io) to learn more or visit the [Atom forum](https:/
 Follow [@AtomEditor](https://twitter.com/atomeditor) on Twitter for important
 announcements.
 
+This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
+[code-of-conduct]: http://todogroup.org/opencodeofconduct/#Atom/opensource@github.com
+
 ## Documentation
 
 If you want to read about using Atom or developing packages in Atom, the [Atom Flight Manual](https://atom.io/docs/latest/) is free and available online, along with ePub, PDF and mobi versions. You can find the source to the manual in [atom/docs](https://github.com/atom/docs).


### PR DESCRIPTION
I have discussed this with @atom/core and they intend to adopt and uphold this code of conduct. It will apply to all repositories in the [@atom GitHub organization](https://github.com/atom), the [discussion forum](https://discuss.atom.io/), and [chat rooms](http://atom-slack.herokuapp.com/).

A blog post on atom.io will be coming soon about it.
