### PR TITLE
Handle more open/save error codes with custom notifications

### DIFF
--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -491,7 +491,7 @@ class Pane extends Model
       try
         item.save?()
       catch error
-        @handleSaveError(error)
+        @handleSaveError(error, item)
       nextAction?()
     else
       @saveItemAs(item, nextAction)
@@ -512,7 +512,7 @@ class Pane extends Model
       try
         item.saveAs(newItemPath)
       catch error
-        @handleSaveError(error)
+        @handleSaveError(error, item)
       nextAction?()
 
   # Public: Save all items.
@@ -676,19 +676,24 @@ class Pane extends Model
       return false unless @promptToSaveItem(item)
     true
 
-  handleSaveError: (error) ->
+  handleSaveError: (error, paneItem) ->
+    itemPath = error.path ? paneItem.getPath?()
+    addWarningWithPath = (message, options) ->
+      message = "#{message} '#{itemPath}'" if itemPath
+      atom.notifications.addWarning(message, options)
+
     if error.code is 'EISDIR' or error.message?.endsWith?('is a directory')
       atom.notifications.addWarning("Unable to save file: #{error.message}")
-    else if error.code is 'EACCES' and error.path?
-      atom.notifications.addWarning("Unable to save file: Permission denied '#{error.path}'")
-    else if error.code in ['EPERM', 'EBUSY', 'UNKNOWN', 'EEXIST'] and error.path?
-      atom.notifications.addWarning("Unable to save file '#{error.path}'", detail: error.message)
-    else if error.code is 'EROFS' and error.path?
-      atom.notifications.addWarning("Unable to save file: Read-only file system '#{error.path}'")
-    else if error.code is 'ENOSPC' and error.path?
-      atom.notifications.addWarning("Unable to save file: No space left on device '#{error.path}'")
-    else if error.code is 'ENXIO' and error.path?
-      atom.notifications.addWarning("Unable to save file: No such device or address '#{error.path}'")
+    else if error.code is 'EACCES'
+      addWarningWithPath('Unable to save file: Permission denied')
+    else if error.code in ['EPERM', 'EBUSY', 'UNKNOWN', 'EEXIST']
+      addWarningWithPath('Unable to save file', detail: error.message)
+    else if error.code is 'EROFS'
+      addWarningWithPath('Unable to save file: Read-only file system')
+    else if error.code is 'ENOSPC'
+      addWarningWithPath('Unable to save file: No space left on device')
+    else if error.code is 'ENXIO'
+      addWarningWithPath('Unable to save file: No such device or address')
     else if errorMatch = /ENOTDIR, not a directory '([^']+)'/.exec(error.message)
       fileName = errorMatch[1]
       atom.notifications.addWarning("Unable to save file: A directory in the path '#{fileName}' could not be written to")

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -694,6 +694,8 @@ class Pane extends Model
       addWarningWithPath('Unable to save file: No space left on device')
     else if error.code is 'ENXIO'
       addWarningWithPath('Unable to save file: No such device or address')
+    else if error.code is 'ENOTSUP'
+      addWarningWithPath('Unable to save file: Operation not supported on socket')
     else if errorMatch = /ENOTDIR, not a directory '([^']+)'/.exec(error.message)
       fileName = errorMatch[1]
       atom.notifications.addWarning("Unable to save file: A directory in the path '#{fileName}' could not be written to")

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -696,6 +696,8 @@ class Pane extends Model
       addWarningWithPath('Unable to save file: No such device or address')
     else if error.code is 'ENOTSUP'
       addWarningWithPath('Unable to save file: Operation not supported on socket')
+    else if error.code is 'EIO'
+      addWarningWithPath('Unable to save file: I/O error writing file')
     else if errorMatch = /ENOTDIR, not a directory '([^']+)'/.exec(error.message)
       fileName = errorMatch[1]
       atom.notifications.addWarning("Unable to save file: A directory in the path '#{fileName}' could not be written to")

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -676,8 +676,8 @@ class Pane extends Model
       return false unless @promptToSaveItem(item)
     true
 
-  handleSaveError: (error, paneItem) ->
-    itemPath = error.path ? paneItem.getPath?()
+  handleSaveError: (error, item) ->
+    itemPath = error.path ? item.getPath?()
     addWarningWithPath = (message, options) ->
       message = "#{message} '#{itemPath}'" if itemPath
       atom.notifications.addWarning(message, options)

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -700,6 +700,8 @@ class Pane extends Model
       addWarningWithPath('Unable to save file: I/O error writing file')
     else if error.code is 'EINTR'
       addWarningWithPath('Unable to save file: Interrupted system call')
+    else if error.code is 'ESPIPE'
+      addWarningWithPath('Unable to save file: Invalid seek')
     else if errorMatch = /ENOTDIR, not a directory '([^']+)'/.exec(error.message)
       fileName = errorMatch[1]
       atom.notifications.addWarning("Unable to save file: A directory in the path '#{fileName}' could not be written to")

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -698,6 +698,8 @@ class Pane extends Model
       addWarningWithPath('Unable to save file: Operation not supported on socket')
     else if error.code is 'EIO'
       addWarningWithPath('Unable to save file: I/O error writing file')
+    else if error.code is 'EINTR'
+      addWarningWithPath('Unable to save file: Interrupted system call')
     else if errorMatch = /ENOTDIR, not a directory '([^']+)'/.exec(error.message)
       fileName = errorMatch[1]
       atom.notifications.addWarning("Unable to save file: A directory in the path '#{fileName}' could not be written to")

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -442,7 +442,7 @@ class Workspace extends Model
         when 'EACCES'
           atom.notifications.addWarning("Permission denied '#{error.path}'")
           return Q()
-        when 'EPERM', 'EBUSY', 'ENXIO'
+        when 'EPERM', 'EBUSY', 'ENXIO', 'EIO'
           atom.notifications.addWarning("Unable to open '#{error.path}'", detail: error.message)
           return Q()
         else

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -442,7 +442,7 @@ class Workspace extends Model
         when 'EACCES'
           atom.notifications.addWarning("Permission denied '#{error.path}'")
           return Q()
-        when 'EPERM', 'EBUSY', 'ENXIO', 'EIO'
+        when 'EPERM', 'EBUSY', 'ENXIO', 'EIO', 'ENOTCONN'
           atom.notifications.addWarning("Unable to open '#{error.path}'", detail: error.message)
           return Q()
         else

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -442,7 +442,7 @@ class Workspace extends Model
         when 'EACCES'
           atom.notifications.addWarning("Permission denied '#{error.path}'")
           return Q()
-        when 'EPERM', 'EBUSY'
+        when 'EPERM', 'EBUSY', 'ENXIO'
           atom.notifications.addWarning("Unable to open '#{error.path}'", detail: error.message)
           return Q()
         else

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -442,7 +442,7 @@ class Workspace extends Model
         when 'EACCES'
           atom.notifications.addWarning("Permission denied '#{error.path}'")
           return Q()
-        when 'EPERM', 'EBUSY', 'ENXIO', 'EIO', 'ENOTCONN'
+        when 'EPERM', 'EBUSY', 'ENXIO', 'EIO', 'ENOTCONN', 'UNKNOWN'
           atom.notifications.addWarning("Unable to open '#{error.path}'", detail: error.message)
           return Q()
         else


### PR DESCRIPTION
Adds several more codes to the handling of read/write errors that have been reported via notifications.
### Open
- [x] `EIO`
- [x] `ENOTCONN`
- [x] `ENXIO`
- [x] `UNKNOWN`
### Save
- [x] `EINTR`
- [x] `EIO`
- [x] `ENOTSUP`
- [x] `ESPIPE`

Refs #2539
Closes #4467
Closes #6348
Closes #6799
Closes #7203
Refs #7649
Closes #7651
Closes #7654
Closes #7780
Closes https://github.com/atom/tree-view/issues/412
