### PR TITLE
Ignore NaN coordinates passed to workspace.open

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -135,6 +135,30 @@ describe "TextEditor", ->
         expect(editor.getLastCursor().getBufferPosition().row).toEqual 0
         expect(editor.getLastCursor().getBufferPosition().column).toEqual 7
 
+  it "ignores non-numeric initialLine and initialColumn options", ->
+    [editor1, editor2, editor3] = []
+
+    waitsForPromise ->
+      atom.workspace.open('sample.less', initialColumn: 8, initialLine: NaN).then (o) -> editor1 = o
+
+    runs ->
+      expect(editor1.getLastCursor().getBufferPosition().row).toEqual 0
+      expect(editor1.getLastCursor().getBufferPosition().column).toEqual 8
+
+    waitsForPromise ->
+      atom.workspace.open('sample.less', initialColumn: NaN, initialLine: 3).then (o) -> editor2 = o
+
+    runs ->
+      expect(editor2.getLastCursor().getBufferPosition().row).toEqual 3
+      expect(editor2.getLastCursor().getBufferPosition().column).toEqual 0
+
+    waitsForPromise ->
+      atom.workspace.open('sample.less', initialColumn: NaN, initialLine: NaN).then (o) -> editor3 = o
+
+    runs ->
+      expect(editor3.getLastCursor().getBufferPosition().row).toEqual 3
+      expect(editor3.getLastCursor().getBufferPosition().column).toEqual 0
+
   describe ".copy()", ->
     it "returns a different edit session with the same initial state", ->
       editor.setSelectedBufferRange([[1, 2], [3, 4]])

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -456,8 +456,15 @@ class Workspace extends Model
         @itemOpened(item)
         pane.activateItem(item)
         pane.activate() if activatePane
-        if options.initialLine? or options.initialColumn?
-          item.setCursorBufferPosition?([options.initialLine, options.initialColumn])
+
+        initialLine = initialColumn = 0
+        if Number.isFinite(options.initialLine)
+          initialLine = options.initialLine
+        if Number.isFinite(options.initialColumn)
+          initialColumn = options.initialColumn
+        if initialLine > 0 or initialColumn > 0
+          item.setCursorBufferPosition?([initialLine, initialColumn])
+
         index = pane.getActiveItemIndex()
         @emit "uri-opened" if includeDeprecatedAPIs
         @emitter.emit 'did-open', {uri, pane, item, index}


### PR DESCRIPTION
Generally, I want an exception to be thrown when packages try to put markers at invalid positions: it's a problem in the package. But in the case of calling `Workspace::open` with an `initialLine` or `initialColumn`, the stack trace doesn't include the package, because the method is async. It also seems like it's not a big deal to ignore these parameters if they're something that's not a number, like `NaN`.

Fixes https://github.com/atom/atom/issues/7398
Fixes https://github.com/atom/atom/issues/7672
