### PR TITLE
Move view registration for Pane & Gutter related views earlier

### DIFF
--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -265,6 +265,7 @@ class Atom extends Model
     @notifications = new NotificationManager
     @commands = new CommandRegistry
     @views = new ViewRegistry
+    @registerViewProviders()
     @packages = new PackageManager({devMode, configDirPath, resourcePath, safeMode})
     @styles = new StyleManager
     document.head.appendChild(new StylesElement)
@@ -290,6 +291,30 @@ class Atom extends Model
     TextEditor = require './text-editor'
 
     @windowEventHandler = new WindowEventHandler
+
+  # Register the core views as early as possible in case they are needed for
+  # package deserialization.
+  registerViewProviders: ->
+    Gutter = require './gutter'
+    Pane = require './pane'
+    PaneElement = require './pane-element'
+    PaneContainer = require './pane-container'
+    PaneContainerElement = require './pane-container-element'
+    PaneAxis = require './pane-axis'
+    PaneAxisElement = require './pane-axis-element'
+    TextEditor = require './text-editor'
+    TextEditorElement = require './text-editor-element'
+    {createGutterView} = require './gutter-component-helpers'
+
+    atom.views.addViewProvider PaneContainer, (model) ->
+      new PaneContainerElement().initialize(model)
+    atom.views.addViewProvider PaneAxis, (model) ->
+      new PaneAxisElement().initialize(model)
+    atom.views.addViewProvider Pane, (model) ->
+      new PaneElement().initialize(model)
+    atom.views.addViewProvider TextEditor, (model) ->
+      new TextEditorElement().initialize(model)
+    atom.views.addViewProvider(Gutter, createGutterView)
 
   ###
   Section: Event Subscription

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -2,16 +2,8 @@
 Grim = require 'grim'
 {Emitter, CompositeDisposable} = require 'event-kit'
 Serializable = require 'serializable'
-{createGutterView} = require './gutter-component-helpers'
 Gutter = require './gutter'
 Model = require './model'
-Pane = require './pane'
-PaneElement = require './pane-element'
-PaneContainerElement = require './pane-container-element'
-PaneAxisElement = require './pane-axis-element'
-PaneAxis = require './pane-axis'
-TextEditor = require './text-editor'
-TextEditorElement = require './text-editor-element'
 ItemRegistry = require './item-registry'
 
 module.exports =
@@ -33,7 +25,6 @@ class PaneContainer extends Model
     @subscriptions = new CompositeDisposable
 
     @itemRegistry = new ItemRegistry
-    @registerViewProviders()
 
     @setRoot(params?.root ? new Pane)
     @setActivePane(@getPanes()[0]) unless @getActivePane()
@@ -52,17 +43,6 @@ class PaneContainer extends Model
   serializeParams: (params) ->
     root: @root?.serialize()
     activePaneId: @activePane.id
-
-  registerViewProviders: ->
-    atom.views.addViewProvider PaneContainer, (model) ->
-      new PaneContainerElement().initialize(model)
-    atom.views.addViewProvider PaneAxis, (model) ->
-      new PaneAxisElement().initialize(model)
-    atom.views.addViewProvider Pane, (model) ->
-      new PaneElement().initialize(model)
-    atom.views.addViewProvider TextEditor, (model) ->
-      new TextEditorElement().initialize(model)
-    atom.views.addViewProvider(Gutter, createGutterView)
 
   onDidChangeRoot: (fn) ->
     @emitter.on 'did-change-root', fn

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -4,6 +4,7 @@ Grim = require 'grim'
 Serializable = require 'serializable'
 Gutter = require './gutter'
 Model = require './model'
+Pane = require './pane'
 ItemRegistry = require './item-registry'
 
 module.exports =


### PR DESCRIPTION
Registering them in pane-container led to packages deserializing before e.g. Gutter was available.
