### PR TITLE
More consistency checks for DisplayBuffer and TokenizedBuffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "space-pen": "3.8.2",
     "stacktrace-parser": "0.1.1",
     "temp": "0.8.1",
-    "text-buffer": "6.3.8",
+    "text-buffer": "6.3.9",
     "theorist": "^1.0.2",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -23,6 +23,7 @@ class DisplayBuffer extends Model
   verticalScrollMargin: 2
   horizontalScrollMargin: 6
   scopedCharacterWidthsChangeCount: 0
+  changeCount: 0
 
   constructor: ({tabLength, @editorWidthInChars, @tokenizedBuffer, buffer, ignoreInvisibles, @largeFileMode}={}) ->
     super
@@ -800,6 +801,11 @@ class DisplayBuffer extends Model
           foldCount: @findFoldMarkers().length
           lastBufferRow: @buffer.getLastRow()
           lastScreenRow: @getLastRow()
+          bufferRow: row
+          screenRow: screenRow
+          displayBufferChangeCount: @changeCount
+          tokenizedBufferChangeCount: @tokenizedBuffer.changeCount
+          bufferChangeCount: @buffer.changeCount
 
       maxBufferColumn = screenLine.getMaxBufferColumn()
       if screenLine.isSoftWrapped() and column > maxBufferColumn
@@ -898,6 +904,9 @@ class DisplayBuffer extends Model
         screenColumn: column
         maxScreenRow: @getLastRow()
         screenLinesDefined: @screenLines.map (sl) -> sl?
+        displayBufferChangeCount: @changeCount
+        tokenizedBufferChangeCount: @tokenizedBuffer.changeCount
+        bufferChangeCount: @buffer.changeCount
       }
       throw error
 
@@ -1179,6 +1188,7 @@ class DisplayBuffer extends Model
     @tokenizedBuffer.rootScopeDescriptor
 
   handleTokenizedBufferChange: (tokenizedBufferChange) =>
+    @changeCount = @tokenizedBuffer.changeCount
     {start, end, delta, bufferChange} = tokenizedBufferChange
     @updateScreenLines(start, end + 1, delta, refreshMarkers: false)
     @setScrollTop(Math.min(@getScrollTop(), @getMaxScrollTop())) if delta < 0

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -1194,6 +1194,9 @@ class DisplayBuffer extends Model
     screenDelta = screenLines.length - (endScreenRow - startScreenRow)
 
     _.spliceWithArray(@screenLines, startScreenRow, endScreenRow - startScreenRow, screenLines, 10000)
+
+    @checkScreenLinesInvariant()
+
     @rowMap.spliceRegions(startBufferRow, endBufferRow - startBufferRow, regions)
     @findMaxLineLength(startScreenRow, endScreenRow, screenLines, screenDelta)
 
@@ -1312,6 +1315,20 @@ class DisplayBuffer extends Model
       @overlayDecorationsById[decoration.id] = decoration
     else
       delete @overlayDecorationsById[decoration.id]
+
+  checkScreenLinesInvariant: ->
+    return if @isSoftWrapped()
+    return if _.size(@foldsByMarkerId) > 0
+
+    screenLinesCount = @screenLines.length
+    tokenizedLinesCount = @tokenizedBuffer.getLineCount()
+    bufferLinesCount = @buffer.getLineCount()
+
+    atom.assert screenLinesCount is tokenizedLinesCount, "Display buffer line count out of sync with tokenized buffer", (error) ->
+      error.metadata = {screenLinesCount, tokenizedLinesCount, bufferLinesCount}
+
+    atom.assert screenLinesCount is bufferLinesCount, "Display buffer line count out of sync with buffer", (error) ->
+      error.metadata = {screenLinesCount, tokenizedLinesCount, bufferLinesCount}
 
 if Grim.includeDeprecatedAPIs
   DisplayBuffer.properties

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -23,6 +23,7 @@ class TokenizedBuffer extends Model
   invalidRows: null
   visible: false
   configSettings: null
+  changeCount: 0
 
   constructor: ({@buffer, @tabLength, @ignoreInvisibles, @largeFileMode}) ->
     @emitter = new Emitter
@@ -229,6 +230,8 @@ class TokenizedBuffer extends Model
         row + delta
 
   handleBufferChange: (e) ->
+    @changeCount = @buffer.changeCount
+
     {oldRange, newRange} = e
     start = oldRange.start.row
     end = oldRange.end.row
@@ -296,10 +299,12 @@ class TokenizedBuffer extends Model
     # undefined. This should paper over the problem but we want to figure out
     # what is happening:
     tokenizedLine = @tokenizedLineForRow(row)
-    atom.assert tokenizedLine?, "TokenizedLine is defined", (error) =>
+    atom.assert tokenizedLine?, "TokenizedLine is undefined", (error) =>
       error.metadata = {
         row: row
         rowCount: @tokenizedLines.length
+        tokenizedBufferChangeCount: @changeCount
+        bufferChangeCount: @buffer.changeCount
       }
 
     return false unless tokenizedLine?


### PR DESCRIPTION
I'm trying to hunt down these uncaught exceptions that seem to derive from corrupted states. This PR seasons in some additional checks to help us track where things go wrong.
- An assertion whenever we update screen lines that the count matches the buffer if there are no folds or soft wraps. This should help us see the moment this goes wrong if it does.
- The inclusion of change counts in exception metadata. Every time the buffer changes, we'll increment a count. When the tokenized buffer and display buffer process these changes, we'll assign their change counts to match. If these numbers ever differ, it means we haven't processed a change between two layers.
