### PR TITLE
Fix indentation when pasting lines

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2262,7 +2262,7 @@ describe "TextEditor", ->
             expect(editor.indentationForBufferRow(2)).toBe 0
             expect(editor.indentationForBufferRow(3)).toBe 1
 
-      describe "when a newline is appended on a line that matches the decreaseNextIndentRegex", ->
+      describe "when a newline is appended on a line that matches the decreaseNextIndentPattern", ->
         it "indents the new line to the correct level when editor.autoIndent is true", ->
           waitsForPromise ->
             atom.packages.activatePackage('language-go')
@@ -3012,7 +3012,19 @@ describe "TextEditor", ->
               expect(editor.lineTextForBufferRow(7)).toBe("\t\t\t * indent")
               expect(editor.lineTextForBufferRow(8)).toBe("\t\t\t **/")
 
-          describe "when pasting a single line of text", ->
+          describe "when pasting line(s) above a line that matches the decreaseIndentPattern", ->
+            it "auto-indents based on the pasted line(s) only", ->
+              atom.clipboard.write("a(x);\n  b(x);\n    c(x);\n", indentBasis: 0)
+              editor.setCursorBufferPosition([7, 0])
+              editor.pasteText()
+
+              expect(editor.lineTextForBufferRow(7)).toBe "      a(x);"
+              expect(editor.lineTextForBufferRow(8)).toBe "        b(x);"
+              expect(editor.lineTextForBufferRow(9)).toBe "          c(x);"
+              expect(editor.lineTextForBufferRow(10)).toBe "    }"
+
+
+          describe "when pasting a line of text without line ending", ->
             it "does not auto-indent the text", ->
               atom.clipboard.write("a(x);", indentBasis: 0)
               editor.setCursorBufferPosition([5, 0])

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3023,7 +3023,6 @@ describe "TextEditor", ->
               expect(editor.lineTextForBufferRow(9)).toBe "          c(x);"
               expect(editor.lineTextForBufferRow(10)).toBe "    }"
 
-
           describe "when pasting a line of text without line ending", ->
             it "does not auto-indent the text", ->
               atom.clipboard.write("a(x);", indentBasis: 0)

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -234,14 +234,15 @@ class LanguageMode
   #
   # Returns a {Number}.
   suggestedIndentForBufferRow: (bufferRow, options) ->
+    line = @buffer.lineForRow(bufferRow)
     tokenizedLine = @editor.displayBuffer.tokenizedBuffer.tokenizedLineForRow(bufferRow)
-    @suggestedIndentForTokenizedLineAtBufferRow(bufferRow, tokenizedLine, options)
+    @suggestedIndentForTokenizedLineAtBufferRow(bufferRow, line, tokenizedLine, options)
 
   suggestedIndentForLineAtBufferRow: (bufferRow, line, options) ->
     tokenizedLine = @editor.displayBuffer.tokenizedBuffer.buildTokenizedLineForRowWithText(bufferRow, line)
-    @suggestedIndentForTokenizedLineAtBufferRow(bufferRow, tokenizedLine, options)
+    @suggestedIndentForTokenizedLineAtBufferRow(bufferRow, line, tokenizedLine, options)
 
-  suggestedIndentForTokenizedLineAtBufferRow: (bufferRow, tokenizedLine, options) ->
+  suggestedIndentForTokenizedLineAtBufferRow: (bufferRow, line, tokenizedLine, options={}) ->
     iterator = tokenizedLine.getTokenIterator()
     iterator.next()
     scopeDescriptor = new ScopeDescriptor(scopes: iterator.getScopes())
@@ -253,7 +254,7 @@ class LanguageMode
     currentIndentLevel = @editor.indentationForBufferRow(bufferRow)
     return currentIndentLevel unless increaseIndentRegex
 
-    if options?.skipBlankLines ? true
+    if options.skipBlankLines ? true
       precedingRow = @buffer.previousNonBlankRow(bufferRow)
       return 0 unless precedingRow?
     else
@@ -268,10 +269,7 @@ class LanguageMode
       desiredIndentLevel += 1 if increaseIndentRegex?.testSync(precedingLine)
       desiredIndentLevel -= 1 if decreaseNextIndentRegex?.testSync(precedingLine)
 
-    unless @editor.isBufferRowCommented(bufferRow)
-      bufferLine = @buffer.lineForRow(bufferRow)
-      desiredIndentLevel -= 1 if decreaseIndentRegex?.testSync(bufferLine)
-
+    desiredIndentLevel -= 1 if decreaseIndentRegex?.testSync(line)
     Math.max(desiredIndentLevel, 0)
 
   # Calculate a minimum indent level for a range of lines excluding empty lines.

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -242,7 +242,7 @@ class LanguageMode
     tokenizedLine = @editor.displayBuffer.tokenizedBuffer.buildTokenizedLineForRowWithText(bufferRow, line)
     @suggestedIndentForTokenizedLineAtBufferRow(bufferRow, line, tokenizedLine, options)
 
-  suggestedIndentForTokenizedLineAtBufferRow: (bufferRow, line, tokenizedLine, options={}) ->
+  suggestedIndentForTokenizedLineAtBufferRow: (bufferRow, line, tokenizedLine, options) ->
     iterator = tokenizedLine.getTokenIterator()
     iterator.next()
     scopeDescriptor = new ScopeDescriptor(scopes: iterator.getScopes())
@@ -254,7 +254,7 @@ class LanguageMode
     currentIndentLevel = @editor.indentationForBufferRow(bufferRow)
     return currentIndentLevel unless increaseIndentRegex
 
-    if options.skipBlankLines ? true
+    if options?.skipBlankLines ? true
       precedingRow = @buffer.previousNonBlankRow(bufferRow)
       return 0 unless precedingRow?
     else


### PR DESCRIPTION
The fix to ignore invisibles (64dfda572dd3db46ff841db9659f413a5f9b3b21) introduces a new bug when pasting lines from the clipboard:

![before](https://cloud.githubusercontent.com/assets/4171547/8640040/70538f4e-28ea-11e5-97ab-d39416dcf8fa.gif)

As the commit takes the content of `@buffer.lineFromRow(bufferRow)` to test against the `decreaseIndentRegex`, it will actually test the content of the row the cursor is on instead of the content that is being pasted. And this (of course) could cause unexpected indentations...

In turn the same goes for checking if the `bufferRow` is a commented line, so this check is removed again.

After this commit pasting above a line matching the `decreaseIndentRegex` works as expected again:

![after](https://cloud.githubusercontent.com/assets/4171547/8640053/139c7a8a-28eb-11e5-9f18-4329950dfc22.gif)
