### PR TITLE
Update subword regex

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4522,6 +4522,17 @@ describe "TextEditor", ->
       expect(cursor1.getBufferPosition()).toEqual([0, 3])
       expect(cursor2.getBufferPosition()).toEqual([1, 6])
 
+  it "works with non-English characters", ->
+    editor.setText("supåTøåst \n")
+    editor.setCursorBufferPosition([0, 9])
+    editor.moveToPreviousSubwordBoundary()
+    expect(editor.getCursorBufferPosition()).toEqual([0, 4])
+
+    editor.setText("supaÖast \n")
+    editor.setCursorBufferPosition([0, 8])
+    editor.moveToPreviousSubwordBoundary()
+    expect(editor.getCursorBufferPosition()).toEqual([0, 4])
+
   describe ".moveToNextSubwordBoundary", ->
     it "does not move the cursor when there is no next subword boundary", ->
       editor.setText('')
@@ -4599,6 +4610,17 @@ describe "TextEditor", ->
       editor.moveToNextSubwordBoundary()
       expect(cursor1.getBufferPosition()).toEqual([0, 3])
       expect(cursor2.getBufferPosition()).toEqual([1, 6])
+
+  it "works with non-English characters", ->
+    editor.setText("supåTøåst \n")
+    editor.setCursorBufferPosition([0, 0])
+    editor.moveToNextSubwordBoundary()
+    expect(editor.getCursorBufferPosition()).toEqual([0, 4])
+
+    editor.setText("supaÖast \n")
+    editor.setCursorBufferPosition([0, 0])
+    editor.moveToNextSubwordBoundary()
+    expect(editor.getCursorBufferPosition()).toEqual([0, 4])
 
   describe ".selectToPreviousSubwordBoundary", ->
     it "selects subwords", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4450,13 +4450,16 @@ describe "TextEditor", ->
       expect(editor.getCursorBufferPosition()).toEqual([0, 0])
 
     it "stops at word and underscore boundaries", ->
-      editor.setText("_word \n")
-      editor.setCursorBufferPosition([0, 6])
+      editor.setText("sub_word \n")
+      editor.setCursorBufferPosition([0, 9])
       editor.moveToPreviousSubwordBoundary()
-      expect(editor.getCursorBufferPosition()).toEqual([0, 5])
+      expect(editor.getCursorBufferPosition()).toEqual([0, 8])
 
       editor.moveToPreviousSubwordBoundary()
-      expect(editor.getCursorBufferPosition()).toEqual([0, 1])
+      expect(editor.getCursorBufferPosition()).toEqual([0, 4])
+
+      editor.moveToPreviousSubwordBoundary()
+      expect(editor.getCursorBufferPosition()).toEqual([0, 0])
 
       editor.setText(" word\n")
       editor.setCursorBufferPosition([0, 3])
@@ -4526,13 +4529,16 @@ describe "TextEditor", ->
       expect(editor.getCursorBufferPosition()).toEqual([0, 0])
 
     it "stops at word and underscore boundaries", ->
-      editor.setText(" word_ \n")
+      editor.setText(" sub_word \n")
       editor.setCursorBufferPosition([0, 0])
       editor.moveToNextSubwordBoundary()
       expect(editor.getCursorBufferPosition()).toEqual([0, 1])
 
       editor.moveToNextSubwordBoundary()
-      expect(editor.getCursorBufferPosition()).toEqual([0, 5])
+      expect(editor.getCursorBufferPosition()).toEqual([0, 4])
+
+      editor.moveToNextSubwordBoundary()
+      expect(editor.getCursorBufferPosition()).toEqual([0, 9])
 
       editor.setText("word \n")
       editor.setCursorBufferPosition([0, 0])

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -657,11 +657,13 @@ class Cursor extends Model
   # Returns a {RegExp}.
   subwordRegExp: (options={}) ->
     nonWordCharacters = atom.config.get('editor.nonWordCharacters', scope: @getScopeDescriptor())
-    snakeCamelSegment = "[A-Z]?[a-z]+"
+    lowercaseLetters = 'a-z\\u00DF-\\u00F6\\u00F8-\\u00FF'
+    uppercaseLetters = 'A-Z\\u00C0-\\u00D6\\u00D8-\\u00DE'
+    snakeCamelSegment = "[#{uppercaseLetters}]?[#{lowercaseLetters}]+"
     segments = [
       "^[\t ]+",
       "[\t ]+$",
-      "[A-Z]+(?![a-z])",
+      "[#{uppercaseLetters}]+(?![#{lowercaseLetters}])",
       "\\d+"
     ]
     if options.backwards

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -657,18 +657,20 @@ class Cursor extends Model
   # Returns a {RegExp}.
   subwordRegExp: (options={}) ->
     nonWordCharacters = atom.config.get('editor.nonWordCharacters', scope: @getScopeDescriptor())
+    snakeCamelSegment = "[A-Z]?[a-z]+"
     segments = [
       "^[\t ]+",
       "[\t ]+$",
-      "[A-Z]?[a-z]+",
       "[A-Z]+(?![a-z])",
-      "\\d+",
-      "_+"
+      "\\d+"
     ]
     if options.backwards
+      segments.push("#{snakeCamelSegment}_*")
       segments.push("[#{_.escapeRegExp(nonWordCharacters)}]+\\s*")
     else
+      segments.push("_*#{snakeCamelSegment}")
       segments.push("\\s*[#{_.escapeRegExp(nonWordCharacters)}]+")
+    segments.push("_+")
     new RegExp(segments.join("|"), "g")
 
   ###


### PR DESCRIPTION
Fixes #7656 #7658

I added underscore to the snake case/camel case regex segments so that we can skip over it when moving right and left.  In addition, I added non-English letters to the subword regex for better compatibility.

Sorry about combining these into one PR, but I thought it would save time and hassle.
