### PR TITLE
Do not run the for/of transform in Babel.

### DIFF
--- a/src/babel.coffee
+++ b/src/babel.coffee
@@ -25,6 +25,7 @@ defaultOptions =
   # I think this can include es6.arrowFunctions, es6.classes, and
   # possibly others, but I want to be conservative.
   blacklist: [
+    'es6.forOf'
     'useStrict'
   ]
 


### PR DESCRIPTION
Because the target environment in Atom supports for/of natively,
do not transpile for/of using Babel. Without this change, the following code:

``` js
var arr = ['foo', 'bar', 'baz'];
for (var item of arr) console.log(item);
```

would be unnecessarily be transpiled to:

``` js
var arr = ['foo', 'bar', 'baz'];
var _iteratorNormalCompletion = true;
var _didIteratorError = false;
var _iteratorError = undefined;

try {
  for (var _iterator = arr[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
    var item = _step.value;
    console.log(item);
  }
} catch (err) {
  _didIteratorError = true;
  _iteratorError = err;
} finally {
  try {
    if (!_iteratorNormalCompletion && _iterator['return']) {
      _iterator['return']();
    }
  } finally {
    if (_didIteratorError) {
      throw _iteratorError;
    }
  }
}
```
