### PR TITLE
Fix config.set scope selector example

### DIFF
--- a/src/config.coffee
+++ b/src/config.coffee
@@ -561,7 +561,7 @@ class Config
   # atom.config.get('editor.tabLength', scope: ['source.js']) # => 4
   #
   # # Set ruby to 2
-  # atom.config.set('editor.tabLength', 2, scopeSelector: 'source.ruby') # => true
+  # atom.config.set('editor.tabLength', 2, scopeSelector: '.source.ruby') # => true
   #
   # # Notice it's only set to 2 in the case of ruby
   # atom.config.get('editor.tabLength') # => 4


### PR DESCRIPTION
It seems that the `config.get` and `config.set` APIs are not fully compatible. The `set` API takes a scope selector which must be prefixed with a `.`, while the `get` API takes a scope descriptor which doesn't need to have a `.` (it's first converted into a ScopeDescriptor and then then that object prepends a `.` if it's missing, as far as I can tell). Would be nice if they were compatible in this way, but for now -- I think fixing the example would be :sparkles:.

cc @maxbrunsfeld for :eyes: since Git blame says you were polishing these examples in the past. 
