### PR TITLE
metrics removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "keybinding-resolver": "0.33.0",
     "link": "0.30.0",
     "markdown-preview": "0.150.0",
-    "metrics": "0.51.0",
     "notifications": "0.57.0",
     "open-on-github": "0.37.0",
     "package-generator": "0.40.0",


### PR DESCRIPTION
Metrics. A package that reports usage information to Google Analytics. A hackable text editor for the 21st century should be free as in freedom.
