### PR TITLE
Added docs for `PackageManager::activatePackage` and `PackageManager::deactivatePackage`

### DIFF
--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -373,6 +373,10 @@ class PackageManager
     else
       throw new Error("No loaded package for name '#{name}'")
 
+  ###
+  Section: Activating and deactivating packages
+  ###
+
   # Activate all the packages that should be activated.
   activate: ->
     promises = []
@@ -398,7 +402,13 @@ class PackageManager
     @observeDisabledPackages()
     promises
 
-  # Activate a single package by name
+  # Public: Activate a single package by name.
+  #
+  # * `name` - The {String} package name.
+  #
+  # Returns a `Promise` that completes when the package is activated. Note
+  # that, for packages that have activation commands, this promise will not
+  # resolve until at least one of those commands has been broadcast.
   activatePackage: (name) ->
     if pack = @getActivePackage(name)
       Q(pack)
@@ -425,7 +435,9 @@ class PackageManager
       return
     @unobserveDisabledPackages()
 
-  # Deactivate the package with the given name
+  # Public: Deactivate the package with the given name.
+  #
+  # * `name` - The {String} package name.
   deactivatePackage: (name) ->
     pack = @getLoadedPackage(name)
     if @isPackageActive(name)

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -406,9 +406,10 @@ class PackageManager
   #
   # * `name` - The {String} package name.
   #
-  # Returns a `Promise` that completes when the package is activated. Note
-  # that, for packages that have activation commands, this promise will not
-  # resolve until at least one of those commands has been broadcast.
+  # Returns a `Promise` that resolves to a {Package} object when the package
+  # is activated. Note that, for packages that have activation commands, this
+  # promise will not resolve until at least one of those commands has been
+  # broadcast.
   activatePackage: (name) ->
     if pack = @getActivePackage(name)
       Q(pack)


### PR DESCRIPTION
:memo: I noticed that the `PackageManager::activatePackage` function is used frequently in specs for packages (ex: [1](https://github.com/lee-dohm/indentation-indicator/blob/master/spec/indentation-indicator-spec.coffee#L12) [2](https://github.com/atom/tree-view/blob/17fb96308437ac63d2cb16da9d787cd20740a418/spec/tree-view-spec.coffee#L30) [3](https://github.com/atom/find-and-replace/blob/8e357b79e590ddc8b952aa78f77dbb3200a38967/spec/select-next-spec.coffee#L18)), however is undocumented in the [API docs](https://atom.io/docs/api/v1.0.2/PackageManager).

This PR adds a new section `Activating and deactivating packages` to the `PackageManager` docs, with documentation for the `activatePackage` and `deactivatePackage` functions.
