### PR TITLE
:arrow_up: babel-core@5.6.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "async": "0.2.6",
     "atom-keymap": "^5.1.6",
     "atom-space-pen-views": "^2.0.4",
-    "babel-core": "^5.1.11",
+    "babel-core": "^5.6.17",
     "bootstrap": "^3.3.4",
     "clear-cut": "^2.0.1",
     "coffee-cash": "0.8.0",


### PR DESCRIPTION
Upgrade Babel to pick up bug fixes and to ensure a version that
has support for transforms such as `es7.classProperties`.

This transform is particularly useful for classes that subclass `React.Component`
as shown in http://babeljs.io/blog/2015/06/07/react-on-es6-plus/#property-initializers.
