### PR TITLE
:memo: Mark Package class as Extended, so that it appears in the docs.

### DIFF
--- a/src/package.coffee
+++ b/src/package.coffee
@@ -14,7 +14,7 @@ ScopedProperties = require './scoped-properties'
 
 packagesCache = require('../package.json')?._atomPackages ? {}
 
-# Loads and activates a package's main module and resources such as
+# Extended: Loads and activates a package's main module and resources such as
 # stylesheets, keymaps, grammar, editor properties, and menus.
 module.exports =
 class Package


### PR DESCRIPTION
Several functions on the [PackageManager docs page](https://atom.io/docs/api/v1.0.2/PackageManager) return objects of type `Package`. The docs link to the address https://atom.io/docs/api/v1.0.2/Package, which does not exist as `Package` is not marked as an extended class (thus no docs page is generated for it). This PR makes `Package` an extended class so that the docs links are no longer broken.
