### PR TITLE
Handle weird scope sequences without throwing exceptions

### DIFF
--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -394,20 +394,21 @@ class TokenizedBuffer extends Model
       if (tag % 2) is -1
         scopes.push(tag)
       else
-        expectedScope = tag + 1
-        poppedScope = scopes.pop()
-        unless poppedScope is expectedScope
-          error = new Error("Encountered an invalid scope end id. Popped #{poppedScope}, expected to pop #{expectedScope}.")
-          error.metadata = {
-            grammarScopeName: @grammar.scopeName
-          }
-          path = require 'path'
-          error.privateMetadataDescription = "The contents of `#{path.basename(@buffer.getPath())}`"
-          error.privateMetadata = {
-            filePath: @buffer.getPath()
-            fileContents: @buffer.getText()
-          }
-          throw error
+        matchingStartTag = tag + 1
+        loop
+          break if scopes.pop() is matchingStartTag
+          if scopes.length is 0
+            atom.assert false, "Encountered an unmatched scope end tag.", (error) =>
+              error.metadata = {
+                grammarScopeName: @grammar.scopeName
+                unmatchedEndTag: @grammar.scopeForId(tag)
+              }
+              path = require 'path'
+              error.privateMetadataDescription = "The contents of `#{path.basename(@buffer.getPath())}`"
+              error.privateMetadata = {
+                filePath: @buffer.getPath()
+                fileContents: @buffer.getText()
+              }
     scopes
 
   indentLevelForRow: (bufferRow) ->


### PR DESCRIPTION
Fixes #7923 
Fixes #7910
Fixes #7853
Fixes #7582 
Fixes #7198
Fixes #7063

If we encounter a scope end tag, we'll just keep popping scopes until we find the matching scope start tag. I'm not totally sure why we're getting unmatched starts, but I don't think it's a catastrophic enough situation to warrant throwing this exception anymore.
