### PR TITLE
Enable subpixel AA for tabs, status-bar etc.

### DIFF
--- a/static/text-editor-shadow.less
+++ b/static/text-editor-shadow.less
@@ -17,6 +17,7 @@
 
 .gutter {
   overflow: hidden;
+  z-index: 0;
   text-align: right;
   cursor: default;
   min-width: 1em;


### PR DESCRIPTION
### Problem

The GPU layer added to the .gutter .tiles cause the surounding UI to also composite layers, like the tas or the status-bar. This disables subpixel anti-aliasing and text doesn't look that sharp.

Eventhough the `.gutter` has `overflow: hidden`, it seems Chrome still thinks there is a chance of overlapping and thus creates the extra layers.
### Solution

Creating an own stacking context with `z-index` for the `.gutter` seems to fix it.

![z-index](https://cloud.githubusercontent.com/assets/378023/8700714/7bbbe614-2b48-11e5-834b-c4f72630c089.gif)

Fixes #7904
