### PR TITLE
Upgrade to Babel 5.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "async": "0.2.6",
     "atom-keymap": "^5.1.6",
     "atom-space-pen-views": "^2.0.4",
-    "babel-core": "^5.6.17",
+    "babel-core": "^5.8.3",
     "bootstrap": "^3.3.4",
     "clear-cut": "^2.0.1",
     "coffee-cash": "0.8.0",


### PR DESCRIPTION
Once https://github.com/babel/babel/issues/2028 is fixed, we can start
picking up new versions of Babel again.

/cc @sebmck
