### PR TITLE
Support Package Sets

### DIFF
--- a/spec/fixtures/packages/package-set-with-main/main-module.coffee
+++ b/spec/fixtures/packages/package-set-with-main/main-module.coffee
@@ -1,0 +1,3 @@
+module.exports =
+activate: ->
+deactivate: ->

--- a/spec/fixtures/packages/package-set-with-main/package.json
+++ b/spec/fixtures/packages/package-set-with-main/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "package-set-with-main",
+  "version": "0.2.0",
+  "type": "package-set",
+  "main": "./main-module",
+  "includedPackages":  {
+    "test-module": ">=0.2.0",
+    "test-module-with-symlink": ">=5.0.0"
+  }
+}

--- a/spec/metadata-helpers-spec.coffee
+++ b/spec/metadata-helpers-spec.coffee
@@ -1,0 +1,96 @@
+{isTheme, isPackageSet, isPackage} = require '../src/metadata-helpers'
+
+describe 'Metadata Helpers', ->
+  [metadata] = []
+  beforeEach ->
+    metadata = null
+
+  describe 'when the metadata is a legacy package', ->
+    beforeEach ->
+      metadata =
+        name: "test-package"
+        version: "1.0.0",
+        description: "Test package."
+
+    it 'classifies the package as a package', ->
+      expect(isPackage(metadata)).toBe(true)
+      expect(isTheme(metadata)).toBe(false)
+      expect(isPackageSet(metadata)).toBe(false)
+
+  describe 'when the metadata is from a current package', ->
+    beforeEach ->
+      metadata =
+        name: "test-package"
+        type: "package"
+        version: "1.0.0",
+        description: "Test package."
+
+    it 'classifies the package as a package', ->
+      expect(isPackage(metadata)).toBe(true)
+      expect(isTheme(metadata)).toBe(false)
+      expect(isPackageSet(metadata)).toBe(false)
+
+  describe 'when the metadata is from a legacy theme', ->
+    beforeEach ->
+      metadata =
+        name: "test-package"
+        theme: true
+        version: "1.0.0",
+        description: "Test package."
+
+    it 'classifies the package as a theme', ->
+      expect(isPackage(metadata)).toBe(false)
+      expect(isTheme(metadata)).toBe(true)
+      expect(isPackageSet(metadata)).toBe(false)
+
+  describe 'when the metadata is from a current ui theme', ->
+    beforeEach ->
+      metadata =
+        name: "test-package"
+        type: "ui-theme"
+        version: "1.0.0",
+        description: "Test package."
+
+    it 'classifies the package as a theme', ->
+      expect(isPackage(metadata)).toBe(false)
+      expect(isTheme(metadata)).toBe(true)
+      expect(isPackageSet(metadata)).toBe(false)
+
+  describe 'when the metadata is from a current syntax theme', ->
+    beforeEach ->
+      metadata =
+        name: "test-package"
+        type: "syntax-theme"
+        version: "1.0.0",
+        description: "Test package."
+
+    it 'classifies the package as a theme', ->
+      expect(isPackage(metadata)).toBe(false)
+      expect(isTheme(metadata)).toBe(true)
+      expect(isPackageSet(metadata)).toBe(false)
+
+  describe 'when the metadata has an unknown package type', ->
+    beforeEach ->
+      metadata =
+        name: "test-package"
+        type: "unknown-type"
+        version: "1.0.0",
+        description: "Test package."
+
+    it 'classifies the package as a package', ->
+      expect(isPackage(metadata)).toBe(true)
+      expect(isTheme(metadata)).toBe(false)
+      expect(isPackageSet(metadata)).toBe(false)
+
+  describe 'when the metadata is from a package set', ->
+    beforeEach ->
+      metadata =
+        name: "test-package"
+        type: "package-set"
+        version: "1.0.0",
+        description: "Test package."
+
+    it 'classifies the package as a package', ->
+      expect(isPackage(metadata)).toBe(false)
+      expect(isTheme(metadata)).toBe(false)
+      expect(isPackageSet(metadata)).toBe(true)

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -780,10 +780,10 @@ describe "PackageManager", ->
       expect(themeActivator).toHaveBeenCalled()
 
       packages = packageActivator.mostRecentCall.args[0]
-      expect(['atom', 'textmate']).toContain(pack.getType()) for pack in packages
+      expect(['package', 'theme']).toContain(pack.type) for pack in packages
 
       themes = themeActivator.mostRecentCall.args[0]
-      expect(['theme']).toContain(theme.getType()) for theme in themes
+      expect(['theme']).toContain(theme.type) for theme in themes
 
     it "calls callbacks registered with ::onDidActivateInitialPackages", ->
       package1 = atom.packages.loadPackage('package-with-main')

--- a/spec/package-spec.coffee
+++ b/spec/package-spec.coffee
@@ -106,6 +106,38 @@ describe "Package", ->
         theme.deactivate()
         expect(spy).toHaveBeenCalled()
 
+  describe "package-set", ->
+    describe "when the metadata specifies a main module path˜", ->
+      it "does not require the module at the specified path and activate it", ->
+        mainModule = require('./fixtures/packages/package-set-with-main/main-module')
+        spyOn(mainModule, 'activate')
+        pack = null
+        waitsForPromise ->
+          atom.packages.activatePackage('package-set-with-main').then (p) -> pack = p
+
+        runs ->
+          expect(mainModule.activate).not.toHaveBeenCalled()
+          expect(pack.mainModule).toBeNull()
+
+      it "deactivates correctly", ->
+        mainModule = require('./fixtures/packages/package-set-with-main/main-module')
+        spyOn(mainModule, 'activate')
+        spyOn(mainModule, 'deactivate')
+        pack = null
+        waitsForPromise ->
+          atom.packages.activatePackage('package-set-with-main').then (p) -> pack = p
+
+        runs ->
+          expect(mainModule.activate).not.toHaveBeenCalled()
+          expect(mainModule.deactivate).not.toHaveBeenCalled()
+          expect(pack.mainModule).toBeNull()
+
+        runs ->
+          atom.packages.deactivatePackage('package-set-with-main')
+          expect(mainModule.activate).not.toHaveBeenCalled()
+          expect(mainModule.deactivate).not.toHaveBeenCalled()
+          expect(pack.mainModule).toBeNull()
+
   describe ".loadMetadata()", ->
     [packagePath, pack, metadata] = []
 

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -802,7 +802,7 @@ class Atom extends Model
   watchThemes: ->
     @themes.onDidChangeActiveThemes =>
       # Only reload stylesheets from non-theme packages
-      for pack in @packages.getActivePackages() when pack.getType() isnt 'theme'
+      for pack in @packages.getActivePackages() when pack.type isnt 'theme'
         pack.reloadStylesheets?()
       return
 

--- a/src/metadata-helpers.coffee
+++ b/src/metadata-helpers.coffee
@@ -1,0 +1,16 @@
+isTheme = (metadata) ->
+  return false unless metadata? and (metadata.theme? or metadata.type?)
+  metadata.theme or metadata.type is 'syntax-theme' or metadata.type is 'ui-theme'
+
+isPackageSet = (metadata) ->
+  metadata?.type is 'package-set'
+
+isPackage = (metadata) ->
+  not (isTheme(metadata) or isPackageSet(metadata))
+
+packageType = (metadata) ->
+  return 'package-type' if isPackageSet(metadata)
+  return 'theme' if isTheme(metadata)
+  'package'
+
+module.exports = {isTheme, isPackageSet, isPackage, packageType}

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -8,7 +8,9 @@ Grim = require 'grim'
 
 ServiceHub = require 'service-hub'
 Package = require './package'
+PackageSet = require './package-set'
 ThemePackage = require './theme-package'
+{isTheme, isPackageSet, isPackage, packageType} = require './metadata-helpers'
 {isDeprecatedPackage, getDeprecatedPackageMetadata} = require './deprecated-packages'
 
 # Extended: Package manager for coordinating the lifecycle of Atom packages.
@@ -43,7 +45,7 @@ class PackageManager
     @serviceHub = new ServiceHub
 
     @packageActivators = []
-    @registerPackageActivator(this, ['atom', 'textmate'])
+    @registerPackageActivator(this, ['package', 'package-set'])
 
   ###
   Section: Event Subscription
@@ -223,9 +225,9 @@ class PackageManager
 
   # Get packages for a certain package type
   #
-  # * `types` an {Array} of {String}s like ['atom', 'textmate'].
+  # * `types` an {Array} of {String}s like ['package', 'package-set', 'theme'].
   getLoadedPackagesForTypes: (types) ->
-    pack for pack in @getLoadedPackages() when pack.getType() in types
+    pack for pack in @getLoadedPackages() when pack.type in types
 
   # Public: Get the loaded {Package} with the given name.
   #
@@ -347,8 +349,10 @@ class PackageManager
           console.warn "Could not load #{metadata.name}@#{metadata.version} because it uses deprecated APIs that have been removed."
           return null
 
-      if metadata.theme
+      if isTheme(metadata)
         pack = new ThemePackage(packagePath, metadata)
+      else if isPackageSet(metadata)
+        pack = new PackageSet(packagePath, metadata)
       else
         pack = new Package(packagePath, metadata)
       pack.load()

--- a/src/package-set.coffee
+++ b/src/package-set.coffee
@@ -1,0 +1,11 @@
+Q = require 'q'
+Package = require './package'
+
+module.exports =
+class PackageSet extends Package
+  load: ->
+    @loadTime = 0
+    this
+
+  activate: ->
+    Promise.resolve()

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -6,6 +6,7 @@ async = require 'async'
 CSON = require 'season'
 fs = require 'fs-plus'
 {Emitter, CompositeDisposable} = require 'event-kit'
+{isTheme, isPackageSet, isPackage, packageType} = require './metadata-helpers'
 Q = require 'q'
 {includeDeprecatedAPIs, deprecate} = require 'grim'
 
@@ -78,6 +79,7 @@ class Package
     @metadata ?= Package.loadMetadata(@path)
     @bundledPackage = Package.isBundledPackagePath(@path)
     @name = @metadata?.name ? path.basename(@path)
+    @type = packageType(metadata)
     ModuleCache.add(@path, @metadata)
     @reset()
 
@@ -104,7 +106,7 @@ class Package
     atom.config.pushAtKeyPath('core.disabledPackages', @name)
 
   isTheme: ->
-    @metadata?.theme?
+    isTheme(@metadata)
 
   measure: (key, fn) ->
     startTime = Date.now()
@@ -112,7 +114,7 @@ class Package
     @[key] = Date.now() - startTime
     value
 
-  getType: -> 'atom'
+  getType: -> @type
 
   getStyleSheetPriority: -> 0
 

--- a/src/theme-package.coffee
+++ b/src/theme-package.coffee
@@ -3,8 +3,6 @@ Package = require './package'
 
 module.exports =
 class ThemePackage extends Package
-  getType: -> 'theme'
-
   getStyleSheetPriority: -> 1
 
   enable: ->


### PR DESCRIPTION
- Ensure that activate and deactivate are no-ops
- Rationalize package type, retain legacy getType
- This should be merged with https://github.com/atom/apm/pull/385
