### PR TITLE
Yet another (small) tweak to enable another indentation use case

### DIFF
--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -262,14 +262,15 @@ class LanguageMode
       return currentIndentLevel if precedingRow < 0
 
     desiredIndentLevel = @editor.indentationForBufferRow(precedingRow)
-    return desiredIndentLevel if @buffer.isRowBlank(precedingRow)
 
     unless @editor.isBufferRowCommented(precedingRow)
       precedingLine = @buffer.lineForRow(precedingRow)
       desiredIndentLevel += 1 if increaseIndentRegex?.testSync(precedingLine)
       desiredIndentLevel -= 1 if decreaseNextIndentRegex?.testSync(precedingLine)
 
-    desiredIndentLevel -= 1 if decreaseIndentRegex?.testSync(line)
+    unless @buffer.isRowBlank(precedingRow)
+      desiredIndentLevel -= 1 if decreaseIndentRegex?.testSync(line)
+      
     Math.max(desiredIndentLevel, 0)
 
   # Calculate a minimum indent level for a range of lines excluding empty lines.


### PR DESCRIPTION
By moving down the line that checks if the `precedingRow` is empty, you will still be able to use the `increaseIndentPattern` and `decreaseNextIndentPattern` to influence your indentation.

Now it seems a little weird to me to have a `decreaseNextIndentPattern` match an empty line and by that make the next line decrease it's indent level, but it seems some language packages (tried to) do exactly that before #6808 with the `decreaseIndentPattern`.

While this could have worked for some, IMO it only worked because of the logic error/problem that was changed/fixed in #6808.

So this change enables such a use case again, and even in a much more predicable and exact way. And of course it's also true that if the empty line does _not_ match the `increaseIndentPattern` or `decreaseNextIndentPattern` (which will be the case in most cases) this change will have no effect except for the fact that the also the empty line is now also matched against the regexp's.

As for the tests... I didn't add any new ones for this use case because currently no language package is using this. The issue https://github.com/atom-haskell/language-haskell/issues/40 and some discussion on Gitter lead me to this change/fix as it seems at least the `langange-haskell` package would like to use it. But until (if) they actually do, I cannot write a test for this I think... All existing tests do still pass and I worked with it for a day now and didn't notice any side effects...
