### PR TITLE
Change Document Polling from Time Interval to Event 

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -280,6 +280,7 @@ describe "TextEditorComponent", ->
         expect(tileNode.style.backgroundColor).toBe(backgroundColor)
 
       wrapperNode.style.backgroundColor = 'rgb(255, 0, 0)'
+      atom.views.performDocumentPoll()
 
       advanceClock(atom.views.documentPollingInterval)
       nextAnimationFrame()
@@ -701,7 +702,8 @@ describe "TextEditorComponent", ->
 
       # favor gutter color if it's assigned
       gutterNode.style.backgroundColor = 'rgb(255, 0, 0)'
-      advanceClock(atom.views.documentPollingInterval)
+      atom.views.performDocumentPoll()
+
       nextAnimationFrame()
       expect(lineNumbersNode.style.backgroundColor).toBe 'rgb(255, 0, 0)'
       for tileNode in lineNumbersNode.querySelectorAll(".tile")
@@ -800,6 +802,7 @@ describe "TextEditorComponent", ->
 
         describe "when the component is destroyed", ->
           it "stops listening for folding events", ->
+            nextAnimationFrame()
             component.destroy()
 
             lineNumber = component.lineNumberNodeForScreenRow(1)
@@ -824,6 +827,8 @@ describe "TextEditorComponent", ->
           expect(lineNumberHasClass(1, 'folded')).toBe false
 
         it "does not fold when the line number componentNode is clicked", ->
+          nextAnimationFrame() # clear pending frame request
+
           lineNumber = component.lineNumberNodeForScreenRow(1)
           lineNumber.dispatchEvent(buildClickEvent(lineNumber))
           expect(nextAnimationFrame).toBe noAnimationFrame
@@ -2600,7 +2605,7 @@ describe "TextEditorComponent", ->
         expect(componentNode.querySelectorAll('.line').length).toBe 0
 
         hiddenParent.style.display = 'block'
-        advanceClock(atom.views.documentPollingInterval)
+        atom.views.performDocumentPoll()
 
         expect(componentNode.querySelectorAll('.line').length).toBeGreaterThan 0
 
@@ -2710,13 +2715,13 @@ describe "TextEditorComponent", ->
       expect(parseInt(newHeight)).toBeLessThan wrapperNode.offsetHeight
       wrapperNode.style.height = newHeight
 
-      advanceClock(atom.views.documentPollingInterval)
+      atom.views.performDocumentPoll()
       nextAnimationFrame()
       expect(componentNode.querySelectorAll('.line')).toHaveLength(6)
 
       gutterWidth = componentNode.querySelector('.gutter').offsetWidth
       componentNode.style.width = gutterWidth + 14 * charWidth + editor.getVerticalScrollbarWidth() + 'px'
-      advanceClock(atom.views.documentPollingInterval)
+      atom.views.performDocumentPoll()
       nextAnimationFrame()
       expect(componentNode.querySelector('.line').textContent).toBe "var quicksort "
 
@@ -2725,7 +2730,7 @@ describe "TextEditorComponent", ->
       scrollViewNode.style.paddingLeft = 20 + 'px'
       componentNode.style.width = 30 * charWidth + 'px'
 
-      advanceClock(atom.views.documentPollingInterval)
+      atom.views.performDocumentPoll()
       nextAnimationFrame()
 
       expect(component.lineNodeForScreenRow(0).textContent).toBe "var quicksort = "

--- a/spec/view-registry-spec.coffee
+++ b/spec/view-registry-spec.coffee
@@ -7,6 +7,9 @@ describe "ViewRegistry", ->
   beforeEach ->
     registry = new ViewRegistry
 
+  afterEach ->
+    registry.clearDocumentRequests()
+
   describe "::getView(object)", ->
     describe "when passed a DOM node", ->
       it "returns the given DOM node", ->

--- a/spec/view-registry-spec.coffee
+++ b/spec/view-registry-spec.coffee
@@ -1,7 +1,7 @@
 ViewRegistry = require '../src/view-registry'
 {View} = require '../src/space-pen-extensions'
 
-describe "ViewRegistry", ->
+fdescribe "ViewRegistry", ->
   registry = null
 
   beforeEach ->
@@ -161,13 +161,13 @@ describe "ViewRegistry", ->
       registry.updateDocument -> events.push('write')
       registry.readDocument -> events.push('read')
 
-      advanceClock(registry.documentPollingInterval)
+      window.dispatchEvent(new UIEvent('resize'))
       expect(events).toEqual []
 
       frameRequests[0]()
       expect(events).toEqual ['write', 'read', 'poll']
 
-      advanceClock(registry.documentPollingInterval)
+      window.dispatchEvent(new UIEvent('resize'))
       expect(events).toEqual ['write', 'read', 'poll', 'poll']
 
     it "polls the document after updating when ::pollAfterNextUpdate() has been called", ->

--- a/spec/view-registry-spec.coffee
+++ b/spec/view-registry-spec.coffee
@@ -186,7 +186,9 @@ describe "ViewRegistry", ->
       expect(events).toEqual ['write', 'read', 'poll']
 
   describe "::pollDocument(fn)", ->
-    it "calls all registered polling functions after document or stylesheet changes until they are disabled via a returned disposable", ->
+    [testElement, testStyleSheet, disposable1, disposable2, events] = []
+
+    beforeEach ->
       testElement = document.createElement('div')
       testStyleSheet = document.createElement('style')
       testStyleSheet.textContent = 'body {}'
@@ -198,6 +200,7 @@ describe "ViewRegistry", ->
       disposable1 = registry.pollDocument -> events.push('poll 1')
       disposable2 = registry.pollDocument -> events.push('poll 2')
 
+    it "calls all registered polling functions after document or stylesheet changes until they are disabled via a returned disposable", ->
       expect(events).toEqual []
 
       testElement.style.height = '400px'
@@ -223,3 +226,10 @@ describe "ViewRegistry", ->
 
       runs ->
         expect(events).toEqual ['poll 2']
+
+    it "calls all registered polling functions when the window resizes", ->
+      expect(events).toEqual []
+
+      window.dispatchEvent(new UIEvent('resize'))
+
+      expect(events).toEqual ['poll 1', 'poll 2']

--- a/spec/view-registry-spec.coffee
+++ b/spec/view-registry-spec.coffee
@@ -191,8 +191,6 @@ describe "ViewRegistry", ->
       jasmineContent.appendChild(testElement)
       jasmineContent.appendChild(testStyleSheet)
 
-      spyOn(window, 'setInterval').andCallFake(fakeSetInterval)
-
       events = []
       disposable1 = registry.pollDocument -> events.push('poll 1')
       disposable2 = registry.pollDocument -> events.push('poll 2')

--- a/spec/view-registry-spec.coffee
+++ b/spec/view-registry-spec.coffee
@@ -201,9 +201,10 @@ describe "ViewRegistry", ->
       disposable2 = registry.pollDocument -> events.push('poll 2')
 
     it "calls all registered polling functions after document or stylesheet changes until they are disabled via a returned disposable", ->
+      jasmine.useRealClock()
       expect(events).toEqual []
 
-      testElement.style.height = '400px'
+      testElement.style.width = '400px'
 
       waitsFor "events to occur in response to DOM mutation", -> events.length > 0
 
@@ -213,7 +214,7 @@ describe "ViewRegistry", ->
 
         testStyleSheet.textContent = 'body {color: #333;}'
 
-      waitsFor "events to occur in reponse to style mutation", -> events.length > 0
+      waitsFor "events to occur in reponse to style sheet mutation", -> events.length > 0
 
       runs ->
         expect(events).toEqual ['poll 1', 'poll 2']

--- a/spec/view-registry-spec.coffee
+++ b/spec/view-registry-spec.coffee
@@ -1,7 +1,7 @@
 ViewRegistry = require '../src/view-registry'
 {View} = require '../src/space-pen-extensions'
 
-fdescribe "ViewRegistry", ->
+describe "ViewRegistry", ->
   registry = null
 
   beforeEach ->

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -107,7 +107,6 @@ class TextEditorComponent
     @disposables.dispose()
     @presenter.destroy()
     @gutterContainerComponent?.destroy()
-    window.removeEventListener 'resize', @requestHeightAndWidthMeasurement
 
   getDomNode: ->
     @domNode
@@ -224,7 +223,6 @@ class TextEditorComponent
     @domNode.addEventListener 'textInput', @onTextInput
     @scrollViewNode.addEventListener 'mousedown', @onMouseDown
     @scrollViewNode.addEventListener 'scroll', @onScrollViewScroll
-    window.addEventListener 'resize', @requestHeightAndWidthMeasurement
 
     @listenForIMEEvents()
     @trackSelectionClipboard() if process.platform is 'linux'
@@ -588,15 +586,6 @@ class TextEditorComponent
         @wasVisible = true
     else
       @wasVisible = false
-
-  requestHeightAndWidthMeasurement: =>
-    return if @heightAndWidthMeasurementRequested
-
-    @heightAndWidthMeasurementRequested = true
-    requestAnimationFrame =>
-      @heightAndWidthMeasurementRequested = false
-      @measureDimensions()
-      @measureWindowSize()
 
   # Measure explicitly-styled height and width and relay them to the model. If
   # these values aren't explicitly styled, we assume the editor is unconstrained

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -1386,12 +1386,15 @@ class TextEditorPresenter
     @emitDidUpdateState()
 
   startBlinkingCursors: ->
-    unless @toggleCursorBlinkHandle
+    unless @isCursorBlinking()
       @state.content.cursorsVisible = true
       @toggleCursorBlinkHandle = setInterval(@toggleCursorBlink.bind(this), @getCursorBlinkPeriod() / 2)
 
+  isCursorBlinking: ->
+    @toggleCursorBlinkHandle?
+
   stopBlinkingCursors: (visible) ->
-    if @toggleCursorBlinkHandle
+    if @isCursorBlinking()
       @state.content.cursorsVisible = visible
       clearInterval(@toggleCursorBlinkHandle)
       @toggleCursorBlinkHandle = null
@@ -1401,7 +1404,8 @@ class TextEditorPresenter
     @emitDidUpdateState()
 
   pauseCursorBlinking: ->
-    @stopBlinkingCursors(true)
-    @startBlinkingCursorsAfterDelay ?= _.debounce(@startBlinkingCursors, @getCursorBlinkResumeDelay())
-    @startBlinkingCursorsAfterDelay()
-    @emitDidUpdateState()
+    if @isCursorBlinking()
+      @stopBlinkingCursors(true)
+      @startBlinkingCursorsAfterDelay ?= _.debounce(@startBlinkingCursors, @getCursorBlinkResumeDelay())
+      @startBlinkingCursorsAfterDelay()
+      @emitDidUpdateState()

--- a/src/view-registry.coffee
+++ b/src/view-registry.coffee
@@ -55,6 +55,8 @@ class ViewRegistry
     @documentReaders = []
     @documentPollers = []
 
+    @observer = new MutationObserver(@performDocumentPoll)
+
   # Essential: Add a provider that will be used to construct views in the
   # workspace's view layer based on model objects in its model layer.
   #
@@ -208,10 +210,10 @@ class ViewRegistry
     writer() while writer = @documentWriters.shift()
 
   startPollingDocument: ->
-    @pollIntervalHandle = window.setInterval(@performDocumentPoll, @documentPollingInterval)
+    @observer.observe(document, {subtree: true, childList: true, attributes: true})
 
   stopPollingDocument: ->
-    window.clearInterval(@pollIntervalHandle)
+    @observer.disconnect()
 
   performDocumentPoll: =>
     if @documentUpdateRequested

--- a/src/view-registry.coffee
+++ b/src/view-registry.coffee
@@ -42,11 +42,9 @@ Grim = require 'grim'
 # ```
 module.exports =
 class ViewRegistry
-  documentPollingInterval: 200
   documentUpdateRequested: false
   documentReadInProgress: false
   performDocumentPollAfterUpdate: false
-  pollIntervalHandle: null
 
   constructor: ->
     @views = new WeakMap

--- a/src/view-registry.coffee
+++ b/src/view-registry.coffee
@@ -210,9 +210,11 @@ class ViewRegistry
     writer() while writer = @documentWriters.shift()
 
   startPollingDocument: ->
+    window.addEventListener('resize', @performDocumentPoll)
     @observer.observe(document, {subtree: true, childList: true, attributes: true})
 
   stopPollingDocument: ->
+    window.removeEventListener('resize', @performDocumentPoll)
     @observer.disconnect()
 
   performDocumentPoll: =>


### PR DESCRIPTION
:pear: ing with @nathansobo 

Previously document polling happened through timed intervals causing continued use of CPU when the editor was unfocused. 

This PR changes the polling to occur when the DOM is mutated or the window is resized (since that doesn't fall under a DOM mutation). Additionally it changes the way Atom updates the CSS so that it occurs as a mutation and the event is captured. Furthermore! It prevents the cursor from ever starting to blink if it wasn't blinking already which can be caused, for instance, when content is changed in the Settings View.

We've added test coverage but are still testing this branch out to be sure we've:
- covered all the DOM changing scenarios
- not added additional CPU usage when editor _is_ active

cc @atom/feedback, try out this branch too if ya can :+1: 

Fixes https://github.com/atom/atom/issues/4019
Quality Initiative https://github.com/atom/atom/issues/7995
