### PR TITLE
Default maintainHistory marker option to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "space-pen": "3.8.2",
     "stacktrace-parser": "0.1.1",
     "temp": "0.8.1",
-    "text-buffer": "6.3.11",
+    "text-buffer": "6.4.0-0",
     "theorist": "^1.0.2",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -854,7 +854,7 @@ describe "DisplayBuffer", ->
       [markerChangedHandler, marker] = []
 
       beforeEach ->
-        marker = displayBuffer.markScreenRange([[5, 4], [5, 10]])
+        marker = displayBuffer.markScreenRange([[5, 4], [5, 10]], maintainHistory: true)
         marker.onDidChange markerChangedHandler = jasmine.createSpy("markerChangedHandler")
 
       it "triggers the 'changed' event whenever the markers head's screen position changes in the buffer or on screen", ->
@@ -991,7 +991,7 @@ describe "DisplayBuffer", ->
         expect(markerChangedHandler).not.toHaveBeenCalled()
 
       it "updates markers before emitting buffer change events, but does not notify their observers until the change event", ->
-        marker2 = displayBuffer.markBufferRange([[8, 1], [8, 1]])
+        marker2 = displayBuffer.markBufferRange([[8, 1], [8, 1]], maintainHistory: true)
         marker2.onDidChange marker2ChangedHandler = jasmine.createSpy("marker2ChangedHandler")
         displayBuffer.onDidChange changeHandler = jasmine.createSpy("changeHandler").andCallFake -> onDisplayBufferChange()
 
@@ -1018,7 +1018,7 @@ describe "DisplayBuffer", ->
         markerChangedHandler.reset()
         marker2ChangedHandler.reset()
 
-        marker3 = displayBuffer.markBufferRange([[8, 1], [8, 2]])
+        marker3 = displayBuffer.markBufferRange([[8, 1], [8, 2]], maintainHistory: true)
         marker3.onDidChange marker3ChangedHandler = jasmine.createSpy("marker3ChangedHandler")
 
         onDisplayBufferChange = ->

--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1147,7 +1147,7 @@ describe "TextEditorComponent", ->
     [marker, decoration, decorationParams] = []
 
     beforeEach ->
-      marker = editor.displayBuffer.markBufferRange([[2, 13], [3, 15]], invalidate: 'inside')
+      marker = editor.displayBuffer.markBufferRange([[2, 13], [3, 15]], invalidate: 'inside', maintainHistory: true)
       decorationParams = {type: ['line-number', 'line'], class: 'a'}
       decoration = editor.decorateMarker(marker, decorationParams)
       nextAnimationFrame()
@@ -1291,7 +1291,7 @@ describe "TextEditorComponent", ->
     [marker, decoration, decorationParams, scrollViewClientLeft] = []
     beforeEach ->
       scrollViewClientLeft = componentNode.querySelector('.scroll-view').getBoundingClientRect().left
-      marker = editor.displayBuffer.markBufferRange([[2, 13], [3, 15]], invalidate: 'inside')
+      marker = editor.displayBuffer.markBufferRange([[2, 13], [3, 15]], invalidate: 'inside', maintainHistory: true)
       decorationParams = {type: 'highlight', class: 'test-highlight'}
       decoration = editor.decorateMarker(marker, decorationParams)
       nextAnimationFrame()

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -940,10 +940,10 @@ describe "TextEditorPresenter", ->
 
           describe ".decorationClasses", ->
             it "adds decoration classes to the relevant line state objects, both initially and when decorations change", ->
-              marker1 = editor.markBufferRange([[4, 0], [6, 2]], invalidate: 'touch')
+              marker1 = editor.markBufferRange([[4, 0], [6, 2]], invalidate: 'touch', maintainHistory: true)
               decoration1 = editor.decorateMarker(marker1, type: 'line', class: 'a')
               presenter = buildPresenter()
-              marker2 = editor.markBufferRange([[4, 0], [6, 2]], invalidate: 'touch')
+              marker2 = editor.markBufferRange([[4, 0], [6, 2]], invalidate: 'touch', maintainHistory: true)
               decoration2 = editor.decorateMarker(marker2, type: 'line', class: 'b')
 
               expect(lineStateForScreenRow(presenter, 3).decorationClasses).toBeNull()
@@ -1637,7 +1637,7 @@ describe "TextEditorPresenter", ->
           presenter.getState().content.overlays[decoration.id]
 
         it "contains state for overlay decorations both initially and when their markers move", ->
-          marker = editor.markBufferPosition([2, 13], invalidate: 'touch')
+          marker = editor.markBufferPosition([2, 13], invalidate: 'touch', maintainHistory: true)
           decoration = editor.decorateMarker(marker, {type: 'overlay', item})
           presenter = buildPresenter(explicitHeight: 30, scrollTop: 20)
 
@@ -2093,10 +2093,10 @@ describe "TextEditorPresenter", ->
 
             describe ".decorationClasses", ->
               it "adds decoration classes to the relevant line number state objects, both initially and when decorations change", ->
-                marker1 = editor.markBufferRange([[4, 0], [6, 2]], invalidate: 'touch')
+                marker1 = editor.markBufferRange([[4, 0], [6, 2]], invalidate: 'touch', maintainHistory: true)
                 decoration1 = editor.decorateMarker(marker1, type: 'line-number', class: 'a')
                 presenter = buildPresenter()
-                marker2 = editor.markBufferRange([[4, 0], [6, 2]], invalidate: 'touch')
+                marker2 = editor.markBufferRange([[4, 0], [6, 2]], invalidate: 'touch', maintainHistory: true)
                 decoration2 = editor.decorateMarker(marker2, type: 'line-number', class: 'b')
 
                 expect(lineNumberStateForScreenRow(presenter, 3).decorationClasses).toBeNull()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1415,11 +1415,17 @@ class TextEditor extends Model
   # * `range` A {Range} or range-compatible {Array}
   # * `properties` A hash of key-value pairs to associate with the marker. There
   #   are also reserved property names that have marker-specific meaning.
-  #   * `reversed` (optional) Creates the marker in a reversed orientation. (default: false)
-  #   * `persistent` (optional) Whether to include this marker when serializing the buffer. (default: true)
-  #   * `invalidate` (optional) Determines the rules by which changes to the
-  #     buffer *invalidate* the marker. (default: 'overlap') It can be any of
-  #     the following strategies, in order of fragility
+  #   * `maintainHistory` (optional) {Boolean} Whether to store this marker's
+  #     range before and after each change in the undo history. This allows the
+  #     marker's position to be restored more accurately for certain undo/redo
+  #     operations, but uses more time and memory. (default: false)
+  #   * `reversed` (optional) {Boolean} Creates the marker in a reversed
+  #     orientation. (default: false)
+  #   * `persistent` (optional) {Boolean} Whether to include this marker when
+  #     serializing the buffer. (default: true)
+  #   * `invalidate` (optional) {String} Determines the rules by which changes
+  #     to the buffer *invalidate* the marker. (default: 'overlap') It can be
+  #     any of the following strategies, in order of fragility:
   #     * __never__: The marker is never marked as invalid. This is a good choice for
   #       markers representing selections in an editor.
   #     * __surround__: The marker is invalidated by changes that completely surround it.
@@ -1444,11 +1450,17 @@ class TextEditor extends Model
   # * `range` A {Range} or range-compatible {Array}
   # * `properties` A hash of key-value pairs to associate with the marker. There
   #   are also reserved property names that have marker-specific meaning.
-  #   * `reversed` (optional) Creates the marker in a reversed orientation. (default: false)
-  #   * `persistent` (optional) Whether to include this marker when serializing the buffer. (default: true)
-  #   * `invalidate` (optional) Determines the rules by which changes to the
-  #     buffer *invalidate* the marker. (default: 'overlap') It can be any of
-  #     the following strategies, in order of fragility
+  #   * `maintainHistory` (optional) {Boolean} Whether to store this marker's
+  #     range before and after each change in the undo history. This allows the
+  #     marker's position to be restored more accurately for certain undo/redo
+  #     operations, but uses more time and memory. (default: false)
+  #   * `reversed` (optional) {Boolean} Creates the marker in a reversed
+  #     orientation. (default: false)
+  #   * `persistent` (optional) {Boolean} Whether to include this marker when
+  #     serializing the buffer. (default: true)
+  #   * `invalidate` (optional) {String} Determines the rules by which changes
+  #     to the buffer *invalidate* the marker. (default: 'overlap') It can be
+  #     any of the following strategies, in order of fragility:
   #     * __never__: The marker is never marked as invalid. This is a good choice for
   #       markers representing selections in an editor.
   #     * __surround__: The marker is invalidated by changes that completely surround it.
@@ -2907,7 +2919,7 @@ class TextEditor extends Model
     @displayBuffer.pixelPositionForScreenPosition(screenPosition)
 
   getSelectionMarkerAttributes: ->
-    type: 'selection', editorId: @id, invalidate: 'never'
+    {type: 'selection', editorId: @id, invalidate: 'never', maintainHistory: true}
 
   getVerticalScrollMargin: -> @displayBuffer.getVerticalScrollMargin()
   setVerticalScrollMargin: (verticalScrollMargin) -> @displayBuffer.setVerticalScrollMargin(verticalScrollMargin)


### PR DESCRIPTION
This is a change I've been meaning to make for a while. I made `find-and-replace` and `spell-check` explicitly opt out of marker snapshotting, but in other situations where there are lots of markers (e.g. the linter w/ lots of errors, a big file w/ lots of folds) the marker snapshotting causes noticeable lag.
#### Before

In a 2000-line file w/ 150 folds, `MarkerStore::createSnapshot` takes a long time before and after each change. This character insertion **took 15 ms**.

![screen shot 2015-07-21 at 2 43 16 pm](https://cloud.githubusercontent.com/assets/326587/8813331/7fdf8034-2fb7-11e5-977e-00bd087a21de.png)
#### After

Now that part of the flame graph is gone, because folds aren't snapshotted. Folds shouldn't be snapshotted, because they are destroyed if touched by a change anyway. The same character insertion **took 4 ms**.

![screen shot 2015-07-21 at 2 43 33 pm](https://cloud.githubusercontent.com/assets/326587/8813377/efa24f96-2fb7-11e5-9704-fa86a21b4abf.png)
