### PR TITLE
Copy selection command to only write to clipboard if text selected

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2994,6 +2994,31 @@ describe "TextEditor", ->
               sort
               items
             """
+      describe ".copyOnlySelectedText()", ->
+        it "copies selected text onto the clipboard", ->
+          editor.setSelectedBufferRanges([[[0, 4], [0, 13]], [[1, 6], [1, 10]], [[2, 8], [2, 13]]])
+
+          editor.copyOnlySelectedText()
+          expect(buffer.lineForRow(0)).toBe "var quicksort = function () {"
+          expect(buffer.lineForRow(1)).toBe "  var sort = function(items) {"
+          expect(buffer.lineForRow(2)).toBe "    if (items.length <= 1) return items;"
+          expect(clipboard.readText()).toBe 'quicksort\nsort\nitems'
+          expect(atom.clipboard.read()).toEqual """
+            quicksort
+            sort
+            items
+          """
+
+        describe "when no text is selected", ->
+          it "copies the line on which the cursor is at the begginning of the line", ->
+            editor.setCursorBufferPosition([1, 0])
+            editor.copyOnlySelectedText()
+            expect(atom.clipboard.read()).toEqual "  var sort = function(items) {\n"
+
+          it "does not copy anything if the cursor is not at the beginning of the line", ->
+            editor.setCursorBufferPosition([1, 5])
+            editor.copyOnlySelectedText()
+            expect(atom.clipboard.read()).toEqual "initial clipboard content"
 
       describe ".pasteText()", ->
         copyText = (text, {startColumn, textEditor}={}) ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3010,12 +3010,7 @@ describe "TextEditor", ->
           """
 
         describe "when no text is selected", ->
-          it "copies the line on which the cursor is at the begginning of the line", ->
-            editor.setCursorBufferPosition([1, 0])
-            editor.copyOnlySelectedText()
-            expect(atom.clipboard.read()).toEqual "  var sort = function(items) {\n"
-
-          it "does not copy anything if the cursor is not at the beginning of the line", ->
+          it "does not copy anything", ->
             editor.setCursorBufferPosition([1, 5])
             editor.copyOnlySelectedText()
             expect(atom.clipboard.read()).toEqual "initial clipboard content"

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2994,6 +2994,7 @@ describe "TextEditor", ->
               sort
               items
             """
+
       describe ".copyOnlySelectedText()", ->
         describe "when thee are multiple selections", ->
           it "copies selected text onto the clipboard", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2995,19 +2995,20 @@ describe "TextEditor", ->
               items
             """
       describe ".copyOnlySelectedText()", ->
-        it "copies selected text onto the clipboard", ->
-          editor.setSelectedBufferRanges([[[0, 4], [0, 13]], [[1, 6], [1, 10]], [[2, 8], [2, 13]]])
+        describe "when thee are multiple selections", ->
+          it "copies selected text onto the clipboard", ->
+            editor.setSelectedBufferRanges([[[0, 4], [0, 13]], [[1, 6], [1, 10]], [[2, 8], [2, 13]]])
 
-          editor.copyOnlySelectedText()
-          expect(buffer.lineForRow(0)).toBe "var quicksort = function () {"
-          expect(buffer.lineForRow(1)).toBe "  var sort = function(items) {"
-          expect(buffer.lineForRow(2)).toBe "    if (items.length <= 1) return items;"
-          expect(clipboard.readText()).toBe 'quicksort\nsort\nitems'
-          expect(atom.clipboard.read()).toEqual """
-            quicksort
-            sort
-            items
-          """
+            editor.copyOnlySelectedText()
+            expect(buffer.lineForRow(0)).toBe "var quicksort = function () {"
+            expect(buffer.lineForRow(1)).toBe "  var sort = function(items) {"
+            expect(buffer.lineForRow(2)).toBe "    if (items.length <= 1) return items;"
+            expect(clipboard.readText()).toBe 'quicksort\nsort\nitems'
+            expect(atom.clipboard.read()).toEqual """
+              quicksort
+              sort
+              items
+            """
 
         describe "when no text is selected", ->
           it "does not copy anything", ->

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -302,6 +302,7 @@ atom.commands.add 'atom-text-editor', stopEventPropagationAndGroupUndo(
   'editor:transpose': -> @transpose()
   'editor:upper-case': -> @upperCase()
   'editor:lower-case': -> @lowerCase()
+  'editor:copy-selection': -> @copyOnlySelectedText()
 )
 
 atom.commands.add 'atom-text-editor:not([mini])', stopEventPropagation(

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2594,7 +2594,7 @@ class TextEditor extends Model
     for selection in @getSelectionsOrderedByBufferPosition()
       if not selection.isEmpty()
         selection.copy(maintainClipboard, true)
-      maintainClipboard = true
+        maintainClipboard = true
     return
 
   # Essential: For each selection, cut the selected text.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2587,7 +2587,6 @@ class TextEditor extends Model
       maintainClipboard = true
     return
 
-
   # Private: For each selection, only copy highlighted text.
   copyOnlySelectedText: ->
     maintainClipboard = false

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2588,7 +2588,7 @@ class TextEditor extends Model
     return
 
 
-  # Essential: For each selection, only copy hightlighted text. Line is coptied if no selected text and cursor is at the beginning of the line
+  # Private: For each selection, only copy highlighted text.
   copyOnlySelectedText: ->
     maintainClipboard = false
     for selection in @getSelectionsOrderedByBufferPosition()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2594,8 +2594,6 @@ class TextEditor extends Model
     for selection in @getSelectionsOrderedByBufferPosition()
       if not selection.isEmpty()
         selection.copy(maintainClipboard, true)
-      else if selection.isEmpty() and selection.cursor.isAtBeginningOfLine()
-        @copySelectedText()
       maintainClipboard = true
     return
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2587,6 +2587,18 @@ class TextEditor extends Model
       maintainClipboard = true
     return
 
+
+  # Essential: For each selection, only copy hightlighted text. Line is coptied if no selected text and cursor is at the beginning of the line
+  copyOnlySelectedText: ->
+    maintainClipboard = false
+    for selection in @getSelectionsOrderedByBufferPosition()
+      if not selection.isEmpty()
+        selection.copy(maintainClipboard, true)
+      else if selection.isEmpty() and selection.cursor.isAtBeginningOfLine()
+        @copySelectedText()
+      maintainClipboard = true
+    return
+
   # Essential: For each selection, cut the selected text.
   cutSelectedText: ->
     maintainClipboard = false


### PR DESCRIPTION
Closes https://github.com/atom/atom/issues/7103

Add a new command, `editor:copy-selection`, that writes to the clipboard only if the user has selected text 
