### PR TITLE
Use `border-box` to prevent losing subpixel AA

### DIFF
--- a/src/highlights-component.coffee
+++ b/src/highlights-component.coffee
@@ -76,6 +76,10 @@ class HighlightsComponent
       unless oldHighlightState.regions[i]?
         oldHighlightState.regions[i] = {}
         regionNode = document.createElement('div')
+        # This prevents highlights at the tiles boundaries to be hidden by the
+        # subsequent tile. When this happens, subpixel anti-aliasing gets
+        # disabled.
+        regionNode.style.boxSizing = "border-box"
         regionNode.classList.add('region')
         regionNode.classList.add(newHighlightState.deprecatedRegionClass) if newHighlightState.deprecatedRegionClass?
         @regionNodesByHighlightId[id][i] = regionNode


### PR DESCRIPTION
When highlights are positioned outside the line box, they could get hidden by a subsequent tile (because of its opaque background). As a result, subpixel anti-aliasing gets disabled by Chrome.

Using `border-box` as the default `box-sizing` allows highlights to always fit within the line. This won’t cover cases where a style like `margin` is applied (causing the highlight to go outside its boundaries), but I am not sure we should consider such scenarios given that highlights should be positioned right inside lines.

Fixes #7382
Fixes #7316
Fixes #7772

@karai17 @w1res @burodepeper: it would be great if you guys could try this branch out to see if it actually fixes the issues you reported. If you don’t know how to build this branch, you can also put the following snippet in your personal stylesheet:

``` less
atom-text-editor::shadow .region {
  box-sizing: border-box;
}
```

Thank you! :pray: 

/cc: @nathansobo @atom/feedback for additional :eyes: 
