### PR TITLE
Upgrade service hub again

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "bookmarks": "0.35.0",
     "bracket-matcher": "0.76.0",
     "command-palette": "0.36.0",
-    "deprecation-cop": "0.53.0",
+    "deprecation-cop": "0.53.1",
     "dev-live-reload": "0.46.0",
     "encoding-selector": "0.21.0",
     "exception-reporting": "0.36.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "go-to-line": "0.30.0",
     "grammar-selector": "0.47.0",
     "image-view": "0.54.0",
-    "incompatible-packages": "0.24.0",
+    "incompatible-packages": "0.24.1",
     "keybinding-resolver": "0.33.0",
     "link": "0.30.0",
     "markdown-preview": "0.150.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "season": "^5.3",
     "semver": "^4.3.3",
     "serializable": "^1",
-    "service-hub": "0.5.0",
+    "service-hub": "^0.6.2",
     "space-pen": "3.8.2",
     "stacktrace-parser": "0.1.1",
     "temp": "0.8.1",

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -106,8 +106,8 @@ describe "Project", ->
       atom.packages.serviceHub.provide(
         "atom.repository-provider", "0.1.0", repositoryProvider)
 
-      expect(atom.project.repositoryProviders.length).toBe 2
-      expect(atom.project.getRepositories()).toEqual [dummyRepository]
+      waitsFor -> atom.project.repositoryProviders.length is 2
+      runs -> expect(atom.project.getRepositories()).toEqual [dummyRepository]
 
     it "does not update @repositories if every path has a Repository", ->
       repositories = atom.project.getRepositories()

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -15,6 +15,7 @@ describe "Workspace", ->
   beforeEach ->
     atom.project.setPaths([atom.project.getDirectories()[0]?.resolve('dir')])
     atom.workspace = workspace = new Workspace
+    waits(1)
 
   describe "::open(uri, options)", ->
     openEvents = null


### PR DESCRIPTION
The new service-hub (0.6.2) has fewer changes than when I first tried to upgrade (0.6.0).
