### PR TITLE
Fire event before a pane is destroyed.

### DIFF
--- a/spec/pane-container-spec.coffee
+++ b/spec/pane-container-spec.coffee
@@ -161,6 +161,27 @@ describe "PaneContainer", ->
 
       expect(events).toEqual [{pane: pane2}, {pane: pane3}]
 
+  describe "::onWillDestroyPane(callback)", ->
+    it "invokes the given callback before panes or their items are destroyed", ->
+      class TestItem
+        constructor: -> @_isDestroyed = false
+        destroy: -> @_isDestroyed = true
+        isDestroyed: -> @_isDestroyed
+
+      container = new PaneContainer
+      events = []
+      container.onWillDestroyPane (event) ->
+        itemsDestroyed = (item.isDestroyed() for item in event.pane.getItems())
+        events.push([event, itemsDestroyed: itemsDestroyed])
+
+      pane1 = container.getActivePane()
+      pane2 = pane1.splitRight()
+      pane2.addItem(new TestItem)
+
+      pane2.destroy()
+
+      expect(events).toEqual [[{pane: pane2}, itemsDestroyed: [false]]]
+
   describe "::onDidDestroyPane(callback)", ->
     it "invokes the given callback when panes are destroyed", ->
       container = new PaneContainer

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -680,6 +680,13 @@ describe "Pane", ->
       pane1.addItems([new Item("A"), new Item("B")])
       pane2 = pane1.splitRight()
 
+    it "invokes ::onWillDestroy observers before destroying items", ->
+      itemsDestroyed = null
+      pane1.onWillDestroy ->
+        itemsDestroyed = (item.isDestroyed() for item in pane1.getItems())
+      pane1.destroy()
+      expect(itemsDestroyed).toEqual([false, false])
+
     it "destroys the pane's destroyable items", ->
       [item1, item2] = pane1.getItems()
       pane1.destroy()

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -62,6 +62,9 @@ class PaneContainer extends Model
   onDidDestroyPane: (fn) ->
     @emitter.on 'did-destroy-pane', fn
 
+  onWillDestroyPane: (fn) ->
+    @emitter.on 'will-destroy-pane', fn
+
   onDidChangeActivePane: (fn) ->
     @emitter.on 'did-change-active-pane', fn
 
@@ -177,6 +180,9 @@ class PaneContainer extends Model
 
   didAddPane: (event) ->
     @emitter.emit 'did-add-pane', event
+
+  willDestroyPane: (event) ->
+    @emitter.emit 'will-destroy-pane', event
 
   didDestroyPane: (event) ->
     @emitter.emit 'did-destroy-pane', event

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -109,6 +109,14 @@ class Pane extends Model
   onDidActivate: (callback) ->
     @emitter.on 'did-activate', callback
 
+  # Public: Invoke the given callback before the pane is destroyed.
+  #
+  # * `callback` {Function} to be called before the pane is destroyed.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onWillDestroy: (callback) ->
+    @emitter.on 'will-destroy', callback
+
   # Public: Invoke the given callback when the pane is destroyed.
   #
   # * `callback` {Function} to be called when the pane is destroyed.
@@ -573,6 +581,8 @@ class Pane extends Model
     if @container?.isAlive() and @container.getPanes().length is 1
       @destroyItems()
     else
+      @emitter.emit 'will-destroy'
+      @container?.willDestroyPane(pane: this)
       super
 
   # Called by model superclass.

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -251,6 +251,16 @@ class Workspace extends Model
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidAddPane: (callback) -> @paneContainer.onDidAddPane(callback)
 
+  # Extended: Invoke the given callback before a pane is destroyed in the
+  # workspace.
+  #
+  # * `callback` {Function} to be called before panes are destroyed.
+  #   * `event` {Object} with the following keys:
+  #     * `pane` The pane to be destroyed.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onWillDestroyPane: (callback) -> @paneContainer.onWillDestroyPane(callback)
+
   # Extended: Invoke the given callback when a pane is destroyed in the
   # workspace.
   #


### PR DESCRIPTION
Rationale: I don't like losing my tabs when I close a pane (or accidentally close the wrong pane), so want to be able to move them into another pane just before the pane is destroyed.

This adds both `pane.onWillDestroy -> ...` and `workspace.onWillDestoryPane (pane) -> ...`, analogous to the pane item callbacks.
