### PR TITLE
Update language-javascript, python, and go

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "language-perl": "0.28.0",
     "language-php": "0.27.0",
     "language-property-list": "0.8.0",
-    "language-python": "0.37.0",
+    "language-python": "0.38.0",
     "language-ruby": "0.56.0",
     "language-ruby-on-rails": "0.22.0",
     "language-sass": "0.39.1",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "language-css": "0.32.1",
     "language-gfm": "0.79.0",
     "language-git": "0.10.0",
-    "language-go": "0.30.0",
+    "language-go": "0.31.0",
     "language-html": "0.40.0",
     "language-hyperlink": "0.14.0",
     "language-java": "0.15.0",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "language-html": "0.40.0",
     "language-hyperlink": "0.14.0",
     "language-java": "0.15.0",
-    "language-javascript": "0.81.0",
+    "language-javascript": "0.82.0",
     "language-json": "0.15.0",
     "language-less": "0.28.1",
     "language-make": "0.14.0",


### PR DESCRIPTION
- Javascript 0.82.0 now tokenizes the `$` in  `$something` as an instance constructor and also fixes tokenization when destructuring in `const` assignments (`const [first, second, ...rest] = array);`)
- Python 0.38.0 correctly tokenizes `self.something` now
- Go 0.31.0 adds the `fmt printf` snippet for debugging
