### PR TITLE
Update language-javascript to 0.84.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "language-html": "0.40.0",
     "language-hyperlink": "0.14.0",
     "language-java": "0.15.0",
-    "language-javascript": "0.82.0",
+    "language-javascript": "0.84.0",
     "language-json": "0.15.0",
     "language-less": "0.28.1",
     "language-make": "0.14.0",


### PR DESCRIPTION
0.83.0 fixes an issue with regex highlighting after a `const` declaration.
0.84.0 fixes the `setInterval` and `setTimeout` snippets not being properly escaped.
