### PR TITLE
Specify class attributes directly for overlay nodes

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1475,6 +1475,17 @@ describe "TextEditorComponent", ->
         overlay = component.getTopmostDOMNode().querySelector('atom-overlay .overlay-test')
         expect(overlay).toBe null
 
+      it "renders the overlay element with the CSS class specified by the decoration", ->
+        marker = editor.displayBuffer.markBufferRange([[2, 13], [2, 13]], invalidate: 'never')
+        decoration = editor.decorateMarker(marker, {type: 'overlay', class: 'my-overlay', item})
+        nextAnimationFrame()
+
+        overlay = component.getTopmostDOMNode().querySelector('atom-overlay.my-overlay')
+        expect(overlay).not.toBe null
+
+        child = overlay.querySelector('.overlay-test')
+        expect(child).toBe item
+
     describe "when the marker is not empty", ->
       it "renders at the head of the marker by default", ->
         marker = editor.displayBuffer.markBufferRange([[2, 5], [2, 10]], invalidate: 'never')

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -27,11 +27,12 @@ class OverlayManager
     contentMargin = parseInt(getComputedStyle(itemView)['margin-left']) ? 0
     @presenter.setOverlayDimensions(decorationId, itemView.offsetWidth, itemView.offsetHeight, contentMargin)
 
-  renderOverlay: (state, decorationId, {item, pixelPosition}) ->
+  renderOverlay: (state, decorationId, {item, pixelPosition, class: klass}) ->
     itemView = atom.views.getView(item)
     cachedOverlay = @overlaysById[decorationId]
     unless overlayNode = cachedOverlay?.overlayNode
       overlayNode = document.createElement('atom-overlay')
+      overlayNode.classList.add(klass) if klass?
       @container.appendChild(overlayNode)
       @overlaysById[decorationId] = cachedOverlay = {overlayNode, itemView}
 

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -424,7 +424,7 @@ class TextEditorPresenter
     for decoration in @model.getOverlayDecorations()
       continue unless decoration.getMarker().isValid()
 
-      {item, position} = decoration.getProperties()
+      {item, position, class: klass} = decoration.getProperties()
       if position is 'tail'
         screenPosition = decoration.getMarker().getTailScreenPosition()
       else
@@ -450,8 +450,9 @@ class TextEditorPresenter
       pixelPosition.top = top
       pixelPosition.left = left
 
-      @state.content.overlays[decoration.id] ?= {item}
-      @state.content.overlays[decoration.id].pixelPosition = pixelPosition
+      overlayState = @state.content.overlays[decoration.id] ?= {item}
+      overlayState.pixelPosition = pixelPosition
+      overlayState.class = klass if klass?
       visibleDecorationIds[decoration.id] = true
 
     for id of @state.content.overlays

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1316,7 +1316,7 @@ class TextEditor extends Model
   #       head or tail of the given marker, depending on the `position`
   #       property.
   #   * `class` This CSS class will be applied to the decorated line number,
-  #     line, or highlight.
+  #     line, highlight, or overlay.
   #   * `onlyHead` (optional) If `true`, the decoration will only be applied to
   #     the head of the marker. Only applicable to the `line` and `gutter`
   #     types.


### PR DESCRIPTION
Specifying a `.class` parameter when creating an overlay decoration now applies that CSS class to the created `atom-overlay` element:

``` coffee
decoration = editor.decorateMarker(marker, {type: 'overlay', item: element, class: 'my-overlay'})
```

Usually, this isn't necessary, because you can apply styles to the item's view instead. I hit a problem with that when I tried to apply positioning styles to the item, though, because the overlay element's absolute positioning interfered with the positioning I was trying to apply. I've had [a workaround](https://github.com/smashwilson/merge-conflicts/blob/1088c7fbcf32924998ff6c88c41f088bf0da37c9/lib/view/covering-view.coffee#L23) in place for a while, but being able to apply styles to the overlay element itself would make it a bit more graceful, I think. It would also make overlay parameters a bit more consistent with those accepted by the other decorations.
