### PR TITLE
Fix Arch build instructions again

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -31,7 +31,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 
 * To automatically build Atom from source, install the atom-editor package from the [Arch User Repository (AUR)](https://wiki.archlinux.org/index.php/Arch_User_Repository)
 * Alternatively run
-  * `sudo pacman -S gconf base-devel git nodejs npm libgnome-keyring python2`
+  * `sudo pacman -S --needed gconf base-devel git nodejs npm libgnome-keyring python2`
   * `export PYTHON=/usr/bin/python2` before building Atom.
 
 ### Slackware

--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -29,8 +29,10 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 
 ### Arch
 
-* `sudo pacman -S gconf base-devel git nodejs npm libgnome-keyring python2`
-* `export PYTHON=/usr/bin/python2` before building Atom.
+* To automatically build Atom from source, install the atom-editor package from the [Arch User Repository (AUR)](https://wiki.archlinux.org/index.php/Arch_User_Repository)
+* Alternatively run
+  * `sudo pacman -S gconf base-devel git nodejs npm libgnome-keyring python2`
+  * `export PYTHON=/usr/bin/python2` before building Atom.
 
 ### Slackware
 

--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -29,10 +29,8 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 
 ### Arch
 
-* To automatically build Atom from source, install the atom-editor package from the [Arch User Repository (AUR)](https://wiki.archlinux.org/index.php/Arch_User_Repository)
-* Alternatively run
-  * `sudo pacman -S --needed gconf base-devel git nodejs npm libgnome-keyring python2`
-  * `export PYTHON=/usr/bin/python2` before building Atom.
+* `sudo pacman -S --needed gconf base-devel git nodejs npm libgnome-keyring python2`
+* `export PYTHON=/usr/bin/python2` before building Atom.
 
 ### Slackware
 

--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -29,7 +29,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 
 ### Arch
 
-* `sudo pacman -S gconf base-devel git nodejs libgnome-keyring python2`
+* `sudo pacman -S gconf base-devel git nodejs npm libgnome-keyring python2`
 * `export PYTHON=/usr/bin/python2` before building Atom.
 
 ### Slackware


### PR DESCRIPTION
npm is missing from the current instructions. Also, I added a note about the AUR as an alternative for building from source on Arch.  

This addresses issues raised by @Narrat in #7426 and @fusion809 in #7511.
