### PR TITLE
Update language-javascript to 0.85.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "language-html": "0.40.0",
     "language-hyperlink": "0.14.0",
     "language-java": "0.15.0",
-    "language-javascript": "0.84.0",
+    "language-javascript": "0.85.0",
     "language-json": "0.15.0",
     "language-less": "0.28.1",
     "language-make": "0.14.0",


### PR DESCRIPTION
Fixes an issue where strings would be incorrectly highlighted in the following scenario:

``` js
write("){");
```

(Also, sorry for the many JS PRs lately - maybe I should try bumping the version less often :P)
