### PR TITLE
Correct path separator in Windows Build instructions

### DIFF
--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -33,7 +33,7 @@ cd atom
 script/build # Creates application in the `Program Files` directory
 ```
 
-### `script/build` Options
+### `script\build` Options
   * `--install-dir` - Creates the final built application in this directory.
   * `--build-dir` - Build the application in this directory.
   * `--verbose` - Verbose mode. A lot more information output.
@@ -58,7 +58,7 @@ If none of this works, do install Github for Windows and use its Git shell. Make
   available on your Path.
 
 
-* `script/build` outputs only the Node and Python versions before returning
+* `script\build` outputs only the Node and Python versions before returning
 
   * Try moving the repository to `C:\atom`. Most likely, the path is too long.
     See [issue #2200](https://github.com/atom/atom/issues/2200).
@@ -71,14 +71,14 @@ If none of this works, do install Github for Windows and use its Git shell. Make
     * https://github.com/TooTallNate/node-gyp/issues/297
     * https://code.google.com/p/gyp/issues/detail?id=393
 
-* `script/build` stops at installing runas with 'Failed at the runas@0.5.4 install script.'
+* `script\build` stops at installing runas with 'Failed at the runas@0.5.4 install script.'
 
   See the next item.
 
 * `error MSB8020: The build tools for Visual Studio 2010 (Platform Toolset = 'v100') cannot be found.`
 
   * If you're building atom with Visual Studio 2013 try executing the following
-    command in your Git shell and then re-run `script/build`:
+    command in your Git shell and then re-run `script\build`:
 
     ```
     $env:GYP_MSVS_VERSION=2013


### PR DESCRIPTION
Just a little oversight.
