### PR TITLE
Only build pushes to master on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 git:
   depth: 10
 
+branches:
+  only:
+    - master
+
 env:
   global:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4


### PR DESCRIPTION
This PR adds some Travis config to only trigger builds for pushes to `master`, instead of building pushes for every branch in the repo. This should help keep our jobs queue from being flooded - it should cut down our number of build jobs from 6 to 3. However, this does preserve triggering builds for PRs.

I think we should probably add this config to every repo in the Atom org.

/cc @as-cii @atom/feedback 
