### PR TITLE
Create new stacking context for tiles

### DIFF
--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -14,6 +14,9 @@ class LinesComponent extends TiledComponent
     @domNode = document.createElement('div')
     @domNode.classList.add('lines')
     @tilesNode = document.createElement("div")
+    # Create a new stacking context, so that tiles z-index does not interfere
+    # with other visual elements.
+    @tilesNode.style.isolation = "isolate"
     @tilesNode.style.zIndex = 0
     @domNode.appendChild(@tilesNode)
 


### PR DESCRIPTION
Refs: #8098

To create a new stacking context we need to isolate the container div (https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Understanding_z_index/The_stacking_context).

This fixes a visual glitch on the wrap-guide whenever there are more than 5 tiles (i.e. the wrap guide gets hidden). I am sorry for not catching this early, but apparently I overlooked it while testing #8098.

/cc: @nathansobo 
