### PR TITLE
Bind ctrl-up/down to just move up or down by default

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -23,6 +23,8 @@
   'escape': 'core:cancel'
   'up': 'core:move-up'
   'down': 'core:move-down'
+  'ctrl-up': 'core:move-up'
+  'ctrl-down': 'core:move-down'
   'left': 'core:move-left'
   'right': 'core:move-right'
   'ctrl-alt-cmd-l': 'window:reload'

--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -51,6 +51,8 @@
   'ctrl-shift-tab': 'pane:show-previous-item'
   'ctrl-pageup': 'pane:show-previous-item'
   'ctrl-pagedown': 'pane:show-next-item'
+  'ctrl-up': 'core:move-up'
+  'ctrl-down': 'core:move-down'
   'ctrl-shift-up': 'core:move-up'
   'ctrl-shift-down': 'core:move-down'
   'ctrl-=': 'window:increase-font-size'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -8,6 +8,8 @@
   'escape': 'core:cancel'
   'up': 'core:move-up'
   'down': 'core:move-down'
+  'ctrl-up': 'core:move-up'
+  'ctrl-down': 'core:move-down'
   'left': 'core:move-left'
   'right': 'core:move-right'
   'ctrl-alt-r': 'window:reload'


### PR DESCRIPTION
Fixes #6949

This prevents insertion of weird characters when ctrl-up/down are pressed.
