### PR TITLE
Fix process leak

### DIFF
--- a/spec/default-directory-searcher-spec.coffee
+++ b/spec/default-directory-searcher-spec.coffee
@@ -1,7 +1,6 @@
 DefaultDirectorySearcher = require "../src/default-directory-searcher"
+Task = require "../src/task"
 path = require "path"
-fs = require 'fs-plus'
-temp = require "temp"
 
 describe "DefaultDirectorySearcher", ->
   [searcher, dirPath] = []
@@ -21,10 +20,9 @@ describe "DefaultDirectorySearcher", ->
       didError: ->
       didSearchPaths: ->
     searchPromise = searcher.search([{getPath: -> dirPath}], /abcdefg/, options)
-    spyOn(searchPromise.directorySearch.task, 'terminate').andCallThrough()
+    spyOn(Task::, 'terminate').andCallThrough()
 
     waitsForPromise -> searchPromise
 
     runs ->
-      expect(searchPromise.directorySearch.task.terminate).toHaveBeenCalled()
-      expect(searchPromise.directorySearch.task.childProcess).toBe null
+      expect(Task::terminate).toHaveBeenCalled()

--- a/spec/default-directory-searcher-spec.coffee
+++ b/spec/default-directory-searcher-spec.coffee
@@ -11,7 +11,6 @@ describe "DefaultDirectorySearcher", ->
     searcher = new DefaultDirectorySearcher
 
   it "terminates the task after running a search", ->
-    console.log searcher
     options =
       ignoreCase: false
       includeHidden: false

--- a/spec/default-directory-searcher-spec.coffee
+++ b/spec/default-directory-searcher-spec.coffee
@@ -1,0 +1,31 @@
+DefaultDirectorySearcher = require "../src/default-directory-searcher"
+path = require "path"
+fs = require 'fs-plus'
+temp = require "temp"
+
+describe "DefaultDirectorySearcher", ->
+  [searcher, dirPath] = []
+
+  beforeEach ->
+    dirPath = path.resolve(__dirname, 'fixtures', 'dir')
+    searcher = new DefaultDirectorySearcher
+
+  it "terminates the task after running a search", ->
+    console.log searcher
+    options =
+      ignoreCase: false
+      includeHidden: false
+      excludeVcsIgnores: true
+      inclusions: []
+      globalExclusions: ['a-dir']
+      didMatch: ->
+      didError: ->
+      didSearchPaths: ->
+    searchPromise = searcher.search([{getPath: -> dirPath}], /abcdefg/, options)
+    spyOn(searchPromise.directorySearch.task, 'terminate').andCallThrough()
+
+    waitsForPromise -> searchPromise
+
+    runs ->
+      expect(searchPromise.directorySearch.task.terminate).toHaveBeenCalled()
+      expect(searchPromise.directorySearch.task.childProcess).toBe null

--- a/src/default-directory-searcher.coffee
+++ b/src/default-directory-searcher.coffee
@@ -18,7 +18,9 @@ class DirectorySearch
     @task.on 'scan:paths-searched', options.didSearchPaths
     @promise = new Promise (resolve, reject) =>
       @task.on('task:cancelled', reject)
-      @task.start(rootPaths, regex.source, scanHandlerOptions, resolve)
+      @task.start rootPaths, regex.source, scanHandlerOptions, =>
+        @task.terminate()
+        resolve()
 
   # Public: Implementation of `then()` to satisfy the *thenable* contract.
   # This makes it possible to use a `DirectorySearch` with `Promise.all()`.
@@ -89,6 +91,8 @@ class DefaultDirectorySearcher
           reject()
     return {
       then: promise.then.bind(promise)
+      catch: promise.catch.bind(promise)
+      directorySearch: directorySearch
       cancel: ->
         isCancelled = true
         directorySearch.cancel()

--- a/src/default-directory-searcher.coffee
+++ b/src/default-directory-searcher.coffee
@@ -92,7 +92,6 @@ class DefaultDirectorySearcher
     return {
       then: promise.then.bind(promise)
       catch: promise.catch.bind(promise)
-      directorySearch: directorySearch
       cancel: ->
         isCancelled = true
         directorySearch.cancel()


### PR DESCRIPTION
The process for each project search would stick around:

![screen shot 2015-07-28 at 2 11 12 pm](https://cloud.githubusercontent.com/assets/69169/8947369/07e0ad04-354f-11e5-9529-e3db0eadf779.png)

Closes https://github.com/atom/find-and-replace/issues/459
