### PR TITLE
Add support for activating and deactivating package-specific keymaps

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -438,6 +438,38 @@ describe "PackageManager", ->
           runs ->
             expect(atom.packages.isPackageActive("package-with-empty-keymap")).toBe true
 
+      describe "when the package's keymaps have been disabled", ->
+        it "does not add the keymaps", ->
+          element1 = $$ -> @div class: 'test-1'
+
+          expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element1[0])).toHaveLength 0
+
+          atom.config.set("core.disabledKeymaps", ["package-with-keymaps-manifest"])
+
+          waitsForPromise ->
+            atom.packages.activatePackage("package-with-keymaps-manifest")
+
+
+          runs ->
+            expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element1[0])).toHaveLength 0
+
+      describe "when the package's keymaps are disabled at activation and re-enabled later", ->
+        it "re-adds the keymaps", ->
+          element1 = $$ -> @div class: 'test-1'
+
+          expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element1[0])).toHaveLength 0
+
+          atom.config.set("core.disabledKeymaps", ["package-with-keymaps-manifest"])
+
+          waitsForPromise ->
+            atom.packages.activatePackage("package-with-keymaps-manifest")
+
+          runs ->
+            atom.config.set("core.disabledKeymaps", [])
+            expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element1[0])[0].command).toBe 'keymap-1'
+
+
+
     describe "menu loading", ->
       beforeEach ->
         atom.contextMenu.definitions = []

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -452,18 +452,17 @@ describe "PackageManager", ->
           runs ->
             expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element1[0])).toHaveLength 0
 
-      describe "when the package's keymaps are disabled at activation and re-enabled later", ->
-        it "re-adds the keymaps", ->
+      describe "when the package's keymaps are disabled and re-enabled after it is activated", ->
+        it "removes and re-adds the keymaps", ->
           element1 = $$ -> @div class: 'test-1'
-
-          expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element1[0])).toHaveLength 0
-
-          atom.config.set("core.disabledKeymaps", ["package-with-keymaps-manifest"])
 
           waitsForPromise ->
             atom.packages.activatePackage("package-with-keymaps-manifest")
 
           runs ->
+            atom.config.set("core.disabledKeymaps", ['package-with-keymaps-manifest'])
+            expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element1[0])).toHaveLength 0
+
             atom.config.set("core.disabledKeymaps", [])
             expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element1[0])[0].command).toBe 'keymap-1'
 

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -449,7 +449,6 @@ describe "PackageManager", ->
           waitsForPromise ->
             atom.packages.activatePackage("package-with-keymaps-manifest")
 
-
           runs ->
             expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element1[0])).toHaveLength 0
 
@@ -467,8 +466,6 @@ describe "PackageManager", ->
           runs ->
             atom.config.set("core.disabledKeymaps", [])
             expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element1[0])[0].command).toBe 'keymap-1'
-
-
 
     describe "menu loading", ->
       beforeEach ->

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -455,6 +455,7 @@ describe "PackageManager", ->
       describe "when the package's keymaps are disabled and re-enabled after it is activated", ->
         it "removes and re-adds the keymaps", ->
           element1 = $$ -> @div class: 'test-1'
+          atom.packages.observeDisabledKeymaps()
 
           waitsForPromise ->
             atom.packages.activatePackage("package-with-keymaps-manifest")

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -201,12 +201,11 @@ class Package
   activateResources: ->
     @activationDisposables = new CompositeDisposable
 
-    @activationDisposables.add atom.config.observe "core.disabledKeymaps", {}, (map) =>
-      value = not _.include(map ? [], @name)
-      if value
-        @activateKeymaps()
-      else if not value
-        @deactivateKeymaps()
+    value = not _.include(atom.config.get("core.disabledKeymaps") ? [], @name)
+    if value
+      @activateKeymaps()
+    else if not value
+      @deactivateKeymaps()
 
     for [menuPath, map] in @menus when map['context-menu']?
       try
@@ -260,7 +259,7 @@ class Package
     for [path, map] in @keymaps
       if map.length > 0
         return true
-        
+
     false
 
   activateServices: ->

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -201,11 +201,11 @@ class Package
   activateResources: ->
     @activationDisposables = new CompositeDisposable
 
-    value = not _.include(atom.config.get("core.disabledKeymaps") ? [], @name)
-    if value
-      @activateKeymaps()
-    else if not value
+    keymapIsDisabled = _.include(atom.config.get("core.disabledKeymaps") ? [], @name)
+    if keymapIsDisabled
       @deactivateKeymaps()
+    else
+      @activateKeymaps()
 
     for [menuPath, map] in @menus when map['context-menu']?
       try
@@ -259,7 +259,6 @@ class Package
     for [path, map] in @keymaps
       if map.length > 0
         return true
-
     false
 
   activateServices: ->

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -200,7 +200,13 @@ class Package
 
   activateResources: ->
     @activationDisposables = new CompositeDisposable
-    @activationDisposables.add(atom.keymaps.add(keymapPath, map)) for [keymapPath, map] in @keymaps
+
+    @activationDisposables.add atom.config.observe "core.disabledKeymaps", {}, (map) =>
+      value = not _.include(map ? [], @name)
+      if value
+        @activateKeymaps()
+      else if not value
+        @deactivateKeymaps()
 
     for [menuPath, map] in @menus when map['context-menu']?
       try
@@ -231,6 +237,31 @@ class Package
 
     settings.activate() for settings in @settings
     @settingsActivated = true
+
+  activateKeymaps: ->
+    return if @keymapActivated
+
+    @keymapDisposables = new CompositeDisposable()
+
+    @keymapDisposables.add(atom.keymaps.add(keymapPath, map)) for [keymapPath, map] in @keymaps
+    atom.menu.update()
+
+    @keymapActivated = true
+
+  deactivateKeymaps: ->
+    return if not @keymapActivated
+
+    @keymapDisposables?.dispose()
+    atom.menu.update()
+
+    @keymapActivated = false
+
+  hasKeymaps: ->
+    for [path, map] in @keymaps
+      if map.length > 0
+        return true
+        
+    false
 
   activateServices: ->
     for name, {versions} of @metadata.providedServices
@@ -399,6 +430,7 @@ class Package
     settings.deactivate() for settings in @settings
     @stylesheetDisposables?.dispose()
     @activationDisposables?.dispose()
+    @keymapDisposables?.dispose()
     @stylesheetsActivated = false
     @grammarsActivated = false
     @settingsActivated = false


### PR DESCRIPTION
Adds support for activating and deactivating the keymaps for individual packages. Currently, there's no good way to quickly disable conflicting keymaps. Adding `unset!` entries for every binding in your own keymap is tedious and error-prone. This adds `Package` support for activating and deactivating keymaps, so you can easily choose which keymaps from which packages are important to you.

See https://github.com/atom/settings-view/pull/610 for UI support.

Related: https://github.com/atom/atom-keymap/issues/82
