### PR TITLE
Add option to make temporary file backups when saving

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "space-pen": "3.8.2",
     "stacktrace-parser": "0.1.1",
     "temp": "0.8.1",
-    "text-buffer": "6.4.0",
+    "text-buffer": "6.5.0",
     "theorist": "^1.0.2",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -173,6 +173,10 @@ module.exports =
         type: 'boolean'
         default: true
         title: 'Confirm Checkout HEAD Revision'
+      backUpBeforeSaving:
+        type: 'boolean'
+        default: false
+        description: 'Ensure file contents aren\'t lost if there is an I/O error during save by making a temporary backup copy.'
       invisibles:
         type: 'object'
         properties:

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -621,14 +621,14 @@ class TextEditor extends Model
   # Essential: Saves the editor's text buffer.
   #
   # See {TextBuffer::save} for more details.
-  save: -> @buffer.save()
+  save: -> @buffer.save(backup: atom.config.get('editor.backUpBeforeSaving'))
 
   # Public: Saves the editor's text buffer as the given path.
   #
   # See {TextBuffer::saveAs} for more details.
   #
   # * `filePath` A {String} path.
-  saveAs: (filePath) -> @buffer.saveAs(filePath)
+  saveAs: (filePath) -> @buffer.saveAs(filePath, backup: atom.config.get('editor.backUpBeforeSaving'))
 
   # Determine whether the user should be prompted to save before closing
   # this editor.


### PR DESCRIPTION
Fixes #3158

@atom/feedback It would be great if you could enable this option once this lands to see if we're encountering unexpected issues with backup files.
