### PR TITLE
Upgrade Squirrel for Windows

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -23,7 +23,7 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks('grunt-contrib-less')
   grunt.loadNpmTasks('grunt-shell')
   grunt.loadNpmTasks('grunt-download-atom-shell')
-  grunt.loadNpmTasks('grunt-atom-shell-installer')
+  grunt.loadNpmTasks('grunt-electron-installer')
   grunt.loadNpmTasks('grunt-peg')
   grunt.loadTasks('tasks')
 

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -212,7 +212,7 @@ module.exports = (grunt) ->
       token: process.env.ATOM_ACCESS_TOKEN
 
     'create-windows-installer':
-      config:
+      installer:
         appDirectory: shellAppDir
         outputDirectory: path.join(buildDir, 'installer')
         authors: 'GitHub Inc.'
@@ -237,7 +237,7 @@ module.exports = (grunt) ->
   ciTasks.push('dump-symbols') if process.platform isnt 'win32'
   ciTasks.push('set-version', 'check-licenses', 'lint', 'generate-asar')
   ciTasks.push('mkdeb') if process.platform is 'linux'
-  ciTasks.push('create-windows-installer') if process.platform is 'win32'
+  ciTasks.push('create-windows-installer:installer') if process.platform is 'win32'
   ciTasks.push('test') if process.platform is 'darwin'
   ciTasks.push('codesign') unless process.env.TRAVIS
   ciTasks.push('publish-build') unless process.env.TRAVIS

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -212,13 +212,14 @@ module.exports = (grunt) ->
       token: process.env.ATOM_ACCESS_TOKEN
 
     'create-windows-installer':
-      appDirectory: shellAppDir
-      outputDirectory: path.join(buildDir, 'installer')
-      authors: 'GitHub Inc.'
-      loadingGif: path.resolve(__dirname, '..', 'resources', 'win', 'loading.gif')
-      iconUrl: 'https://raw.githubusercontent.com/atom/atom/master/resources/win/atom.ico'
-      setupIcon: path.resolve(__dirname, '..', 'resources', 'win', 'atom.ico')
-      remoteReleases: 'https://atom.io/api/updates'
+      config:
+        appDirectory: shellAppDir
+        outputDirectory: path.join(buildDir, 'installer')
+        authors: 'GitHub Inc.'
+        loadingGif: path.resolve(__dirname, '..', 'resources', 'win', 'loading.gif')
+        iconUrl: 'https://raw.githubusercontent.com/atom/atom/master/resources/win/atom.ico'
+        setupIcon: path.resolve(__dirname, '..', 'resources', 'win', 'atom.ico')
+        remoteReleases: 'https://atom.io/api/updates'
 
     shell:
       'kill-atom':

--- a/build/package.json
+++ b/build/package.json
@@ -13,7 +13,7 @@
     "fs-plus": "2.x",
     "github-releases": "~0.2.0",
     "grunt": "~0.4.1",
-    "grunt-atom-shell-installer": "^0.29.0",
+    "grunt-electron-installer": "^0.36.0",
     "grunt-cli": "~0.1.9",
     "grunt-coffeelint": "git+https://github.com/atom/grunt-coffeelint.git#cfb99aa99811d52687969532bd5a98011ed95bfe",
     "grunt-contrib-coffee": "~0.12.0",


### PR DESCRIPTION
Long time coming, upgrades to Squirrel for Windows 0.99.3 via upgrading the grunt plugin for creating electron installers.
