### PR TITLE
:arrow_up: marked@0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jasmine-tagged": "^1.1.4",
     "jquery": "^2.1.1",
     "less-cache": "0.22",
-    "marked": "^0.3.3",
+    "marked": "^0.3.4",
     "mixto": "^1",
     "normalize-package-data": "^2.0.0",
     "nslog": "^2.0.0",


### PR DESCRIPTION
`marked` 0.3.4 was just released, which resolves a [security vulnerability](https://nodesecurity.io/advisories/marked_redos). Although 0.3.4 was already satisfying the semver version range, this bumps the minimum version to be more explicit (and hopefully make [David](https://david-dm.org/atom/atom)'s `insecure` status go away :stuck_out_tongue_closed_eyes:)
