### PR TITLE
:arrow_up: deprecation-cop@0.54.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "bookmarks": "0.35.0",
     "bracket-matcher": "0.76.0",
     "command-palette": "0.36.0",
-    "deprecation-cop": "0.53.1",
+    "deprecation-cop": "0.54.0",
     "dev-live-reload": "0.46.0",
     "encoding-selector": "0.21.0",
     "exception-reporting": "0.36.0",


### PR DESCRIPTION
This now hides deprecation-cop's status bar view unless the window is in dev mode. https://github.com/atom/deprecation-cop/pull/64
