### PR TITLE
Update language-c, java, javascript, and yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "language-html": "0.40.1",
     "language-hyperlink": "0.14.0",
     "language-java": "0.16.0",
-    "language-javascript": "0.85.0",
+    "language-javascript": "0.86.0",
     "language-json": "0.16.0",
     "language-less": "0.28.2",
     "language-make": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "welcome": "0.29.0",
     "whitespace": "0.30.0",
     "wrap-guide": "0.35.0",
-    "language-c": "0.46.0",
+    "language-c": "0.47.0",
     "language-clojure": "0.16.0",
     "language-coffee-script": "0.41.0",
     "language-csharp": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "language-todo": "0.25.0",
     "language-toml": "0.16.0",
     "language-xml": "0.31.0",
-    "language-yaml": "0.23.0"
+    "language-yaml": "0.24.0"
   },
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "language-go": "0.32.0",
     "language-html": "0.40.1",
     "language-hyperlink": "0.14.0",
-    "language-java": "0.15.0",
+    "language-java": "0.16.0",
     "language-javascript": "0.85.0",
     "language-json": "0.16.0",
     "language-less": "0.28.2",


### PR DESCRIPTION
- language-c updates `this` to be `variable.language.this.c`
- language-java now tokenizes comments in enums and updates `this` to be `variable.language.this.java`
- language-javascript fixes a major regression with const highlighting
- language-yaml fixes more issues with multiline text blocks
