### PR TITLE
Set App User Model ID on Win32

### DIFF
--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -23,6 +23,9 @@ start = ->
     squirrelCommand = process.argv[1]
     return if SquirrelUpdate.handleStartupEvent(app, squirrelCommand)
 
+    # NB: This prevents Win10 from showing dupe items in the taskbar
+    app.setAppUserModelId('com.squirrel.atom.atom')
+
   args = parseCommandLine()
 
   addPathToOpen = (event, pathToOpen) ->


### PR DESCRIPTION
This PR set the App User Model ID to match what Squirrel.Windows configures the shortcut to be, which should resolve #7374.

Normally, our App User Model ID is unset, but certain Windows features require an explicit App User Model ID (jump lists and notifications). To solve this Generally™, we rig Squirrel.Windows to configure this in the shortcut, which means that the Browser process will inherit this value.

However, because Chromium forks and the process that actually creates the window isn't the same one, and App User Model IDs don't inherit, our renderer process ends up being the _default_ one (which is effectively the path to the EXE). We fix this in https://github.com/atom/electron/pull/2175, but we still need to tell Electron what the initial name should be. 
