### PR TITLE
:arrow_up: tree-view@0.181.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "symbols-view": "0.100.0",
     "tabs": "0.82.0",
     "timecop": "0.31.0",
-    "tree-view": "0.181.0",
+    "tree-view": "0.181.1",
     "update-package-dependencies": "0.10.0",
     "welcome": "0.29.0",
     "whitespace": "0.30.0",


### PR DESCRIPTION
Fixes a keybinding conflict with `window:reset-font-size` https://github.com/atom/tree-view/issues/251
