### PR TITLE
Safeguard the caching of Babel transpilations by disallowing .babelrc…

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "async": "0.2.6",
     "atom-keymap": "^5.1.8",
     "atom-space-pen-views": "^2.0.4",
-    "babel-core": "^5.8.3",
+    "babel-core": "^5.8.20",
     "bootstrap": "^3.3.4",
     "clear-cut": "^2.0.1",
     "coffee-cash": "0.8.0",

--- a/src/babel.coffee
+++ b/src/babel.coffee
@@ -15,6 +15,18 @@ stats =
   misses: 0
 
 defaultOptions =
+  # Currently, the cache key is a function of:
+  # * The version of Babel used to transpile the .js file.
+  # * The contents of this defaultOptions object.
+  # * The contents of the .js file.
+  # That means that we cannot allow information from an unknown source
+  # to affect the cache key for the output of transpilation, which means
+  # we cannot allow users to override these default options via a .babelrc
+  # file, because the contents of that .babelrc file will not make it into
+  # the cache key. It would be great to support .babelrc files once we
+  # have a way to do so that is safe with respect to caching.
+  breakConfig: true
+
   # The Chrome dev tools will show the original version of the file
   # when the source map is inlined.
   sourceMap: 'inline'


### PR DESCRIPTION
… files.

Also update the version of Babel to pick up a JSON-parsing fix. This was an
issue that was discovered in the course of seeing how reading .babelrc files
would interact badly with Atom's Babel cache.

/cc @sebmck
