### PR TITLE
Add text color to atom-workspace

### DIFF
--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -20,6 +20,7 @@ atom-workspace {
   height: 100%;
   overflow: hidden;
   position: relative;
+  color: @text-color;
   background-color: @app-background-color;
   font-family: @font-family;
 


### PR DESCRIPTION
Currently the `atom-workspace` background-color uses `@app-background-color`, but text color isn't defined and falls back to Bootstrap's default color of `#333`. This can make text hard to read with dark themes.

This PR adds `color: @text-color;` which should match the background.
