### PR TITLE
Fix searching explicitly in directories that contain dots

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "q": "^1.1.2",
     "random-words": "0.0.1",
     "runas": "2.0.0",
-    "scandal": "2.1.1",
+    "scandal": "2.1.2",
     "scoped-property-store": "^0.17.0",
     "scrollbar-style": "^3.1",
     "season": "^5.3",


### PR DESCRIPTION
Scandal now stats path patterns that do not contain any `*` chars to better determine if a pattern is a file or directory. So the case of "Search in directory" when the directory contains dots will now work.

![screen shot 2015-08-04 at 5 41 58 pm](https://cloud.githubusercontent.com/assets/69169/9075915/22084ff8-3ad0-11e5-8b06-85edff9994e1.png)

Closes https://github.com/atom/atom/issues/6134
Closes https://github.com/atom/find-and-replace/issues/388
Closes https://github.com/atom/find-and-replace/issues/309

@jugglingnutcase feel free to try out this branch to see if it fixes your problem. You will need to `script/bootstrap` after pulling down this branch to get the new scandal version. 
