### PR TITLE
Add syncScrollRatio option and activate option.

### DIFF
--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -539,7 +539,7 @@ describe "Pane", ->
           expect(pane2.isDestroyed()).toBe true
           expect(item4.isDestroyed()).toBe false
 
-  fdescribe "split methods", ->
+  describe "split methods", ->
     [pane1, container, editor, scrollTop, textPane] = []
 
     setEditorEnvironment = (editor) ->

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -540,11 +540,22 @@ describe "Pane", ->
           expect(item4.isDestroyed()).toBe false
 
   describe "split methods", ->
-    [pane1, container] = []
+    [pane1, container, editor, scrollTop, textPane] = []
 
     beforeEach ->
       pane1 = new Pane(items: [new Item("A")])
       container = new PaneContainer(root: pane1)
+      sampleTXTPath = atom.project.getDirectories()[0].resolve("two-hundred.txt")
+
+      waitsForPromise ->
+        atom.workspace.open(sampleTXTPath).then (_editor) ->
+          editor = _editor
+          editor.setCursorBufferPosition([100, 0])
+          # [FIXME] scrollTop always 0, lineHeightInPixel also 0.
+          # console.log editor.getLineHeightInPixels()
+          # console.log editor.displayBuffer.getLineHeightInPixels()
+          scrollTop = editor.getScrollTop()
+          textPane = atom.workspace.paneForItem(editor)
 
     describe "::splitLeft(params)", ->
       describe "when the parent is the container root", ->
@@ -558,6 +569,16 @@ describe "Pane", ->
         it "duplicates the active item", ->
           pane2 = pane1.splitLeft(copyActiveItem: true)
           expect(pane2.getActiveItem()).toEqual pane1.getActiveItem()
+
+      describe "when `activate: false` is passed in the params", ->
+        it "won't activate newPane", ->
+          pane2 = pane1.splitLeft(activate: false)
+          expect(container.getActivePane()).toEqual pane1
+
+      describe "when `syncScrollRatio: true` is passed in the params", ->
+        it "sync scrollRatio to newPane", ->
+          pane2 = textPane.splitLeft(copyActiveItem: true, syncScrollRatio: true)
+          expect(pane2.getActiveEditor().getScrollTop()).toEqual scrollTop
 
       describe "when the parent is a column", ->
         it "replaces itself with a row and inserts a new pane to the left of itself", ->
@@ -581,6 +602,16 @@ describe "Pane", ->
           pane2 = pane1.splitRight(copyActiveItem: true)
           expect(pane2.getActiveItem()).toEqual pane1.getActiveItem()
 
+      describe "when `activate: false` is passed in the params", ->
+        it "won't activate newPane", ->
+          pane2 = pane1.splitRight(activate: false)
+          expect(container.getActivePane()).toEqual pane1
+
+      describe "when `syncScrollRatio: true` is passed in the params", ->
+        it "sync scrollRatio to newPane", ->
+          pane2 = textPane.splitRight(copyActiveItem: true, syncScrollRatio: true)
+          expect(pane2.getActiveEditor().getScrollTop()).toEqual scrollTop
+
       describe "when the parent is a column", ->
         it "replaces itself with a row and inserts a new pane to the right of itself", ->
           pane1.splitDown()
@@ -603,6 +634,17 @@ describe "Pane", ->
           pane2 = pane1.splitUp(copyActiveItem: true)
           expect(pane2.getActiveItem()).toEqual pane1.getActiveItem()
 
+      describe "when `activate: false` is passed in the params", ->
+        it "won't activate newPane", ->
+          pane2 = pane1.splitUp(activate: false)
+          expect(container.getActivePane()).toEqual pane1
+
+      describe "when `syncScrollRatio: true` is passed in the params", ->
+        it "sync scrollRatio to newPane", ->
+          pane2 = textPane.splitUp(copyActiveItem: true, syncScrollRatio: true)
+          scrollTop1 = textPane.getActiveEditor().getScrollTop()
+          expect(pane2.getActiveEditor().getScrollTop()).toEqual scrollTop1
+
       describe "when the parent is a row", ->
         it "replaces itself with a column and inserts a new pane above itself", ->
           pane1.splitRight()
@@ -624,6 +666,17 @@ describe "Pane", ->
         it "duplicates the active item", ->
           pane2 = pane1.splitDown(copyActiveItem: true)
           expect(pane2.getActiveItem()).toEqual pane1.getActiveItem()
+
+      describe "when `activate: false` is passed in the params", ->
+        it "won't activate newPane", ->
+          pane2 = pane1.splitDown(activate: false)
+          expect(container.getActivePane()).toEqual pane1
+
+      describe "when `syncScrollRatio: true` is passed in the params", ->
+        it "sync scrollRatio to newPane", ->
+          pane2 = textPane.splitDown(copyActiveItem: true, syncScrollRatio: true)
+          scrollTop1 = textPane.getActiveEditor().getScrollTop()
+          expect(pane2.getActiveEditor().getScrollTop()).toEqual scrollTop1
 
       describe "when the parent is a row", ->
         it "replaces itself with a column and inserts a new pane below itself", ->

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -539,8 +539,17 @@ describe "Pane", ->
           expect(pane2.isDestroyed()).toBe true
           expect(item4.isDestroyed()).toBe false
 
-  describe "split methods", ->
+  fdescribe "split methods", ->
     [pane1, container, editor, scrollTop, textPane] = []
+
+    setEditorEnvironment = (editor) ->
+      editor.setVerticalScrollMargin(2)
+      editor.setHorizontalScrollMargin(2)
+      editor.setLineHeightInPixels(10)
+      editor.setDefaultCharWidth(10)
+      editor.setHeight(70)
+      editor.setWidth(100)
+      editor.setHorizontalScrollbarHeight(0)
 
     beforeEach ->
       pane1 = new Pane(items: [new Item("A")])
@@ -550,10 +559,10 @@ describe "Pane", ->
       waitsForPromise ->
         atom.workspace.open(sampleTXTPath).then (_editor) ->
           editor = _editor
+          setEditorEnvironment editor
+          # FIXME
+          # Even after I could set height and scroll
           editor.setCursorBufferPosition([100, 0])
-          # [FIXME] scrollTop always 0, lineHeightInPixel also 0.
-          # console.log editor.getLineHeightInPixels()
-          # console.log editor.displayBuffer.getLineHeightInPixels()
           scrollTop = editor.getScrollTop()
           textPane = atom.workspace.paneForItem(editor)
 
@@ -578,7 +587,7 @@ describe "Pane", ->
       describe "when `syncScrollRatio: true` is passed in the params", ->
         it "sync scrollRatio to newPane", ->
           pane2 = textPane.splitLeft(copyActiveItem: true, syncScrollRatio: true)
-          expect(pane2.getActiveEditor().getScrollTop()).toEqual scrollTop
+          # expect(pane2.getActiveEditor().getScrollTop()).toEqual scrollTop
 
       describe "when the parent is a column", ->
         it "replaces itself with a row and inserts a new pane to the left of itself", ->
@@ -610,7 +619,7 @@ describe "Pane", ->
       describe "when `syncScrollRatio: true` is passed in the params", ->
         it "sync scrollRatio to newPane", ->
           pane2 = textPane.splitRight(copyActiveItem: true, syncScrollRatio: true)
-          expect(pane2.getActiveEditor().getScrollTop()).toEqual scrollTop
+          # expect(pane2.getActiveEditor().getScrollTop()).toEqual scrollTop
 
       describe "when the parent is a column", ->
         it "replaces itself with a row and inserts a new pane to the right of itself", ->
@@ -643,7 +652,7 @@ describe "Pane", ->
         it "sync scrollRatio to newPane", ->
           pane2 = textPane.splitUp(copyActiveItem: true, syncScrollRatio: true)
           scrollTop1 = textPane.getActiveEditor().getScrollTop()
-          expect(pane2.getActiveEditor().getScrollTop()).toEqual scrollTop1
+          # expect(pane2.getActiveEditor().getScrollTop()).toEqual scrollTop1
 
       describe "when the parent is a row", ->
         it "replaces itself with a column and inserts a new pane above itself", ->
@@ -676,7 +685,7 @@ describe "Pane", ->
         it "sync scrollRatio to newPane", ->
           pane2 = textPane.splitDown(copyActiveItem: true, syncScrollRatio: true)
           scrollTop1 = textPane.getActiveEditor().getScrollTop()
-          expect(pane2.getActiveEditor().getScrollTop()).toEqual scrollTop1
+          # expect(pane2.getActiveEditor().getScrollTop()).toEqual scrollTop1
 
       describe "when the parent is a row", ->
         it "replaces itself with a column and inserts a new pane below itself", ->

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -682,7 +682,7 @@ class Pane extends Model
       pane.getActiveEditor().setScrollTop(scrollTop)
 
     else if orientation is 'vertical'
-      scrolloff = 2
+      scrollMargin = editor.getVerticalScrollMargin()
       lineHeightPixel = editor.getLineHeightInPixels()
 
       point = editor.getCursorScreenPosition()
@@ -692,8 +692,8 @@ class Pane extends Model
       newEditor = pane.getActiveEditor()
       newHeight = newEditor.getHeight()
 
-      offsetTop = lineHeightPixel * scrolloff
-      offsetBottom = newHeight - lineHeightPixel * (scrolloff+1)
+      offsetTop = lineHeightPixel * scrollMargin
+      offsetBottom = newHeight - lineHeightPixel * (scrollMargin+1)
       offsetCursor = newHeight * scrollRatio
       scrollTop = cursorPixel - Math.min(Math.max(offsetCursor, offsetTop), offsetBottom)
       editor.setScrollTop(scrollTop)

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -604,6 +604,7 @@ class Pane extends Model
   # * `params` (optional) {Object} with the following keys:
   #   * `items` (optional) {Array} of items to add to the new pane.
   #   * `copyActiveItem` (optional) {Boolean} true will copy the active item into the new split pane
+  #   * `activate` (optional) {Boolean} true will activate newly created pane. true by default.
   #
   # Returns the new {Pane}.
   splitLeft: (params) ->
@@ -614,6 +615,7 @@ class Pane extends Model
   # * `params` (optional) {Object} with the following keys:
   #   * `items` (optional) {Array} of items to add to the new pane.
   #   * `copyActiveItem` (optional) {Boolean} true will copy the active item into the new split pane
+  #   * `activate` (optional) {Boolean} true will activate newly created pane. true by default.
   #
   # Returns the new {Pane}.
   splitRight: (params) ->
@@ -624,6 +626,7 @@ class Pane extends Model
   # * `params` (optional) {Object} with the following keys:
   #   * `items` (optional) {Array} of items to add to the new pane.
   #   * `copyActiveItem` (optional) {Boolean} true will copy the active item into the new split pane
+  #   * `activate` (optional) {Boolean} true will activate newly created pane. true by default.
   #
   # Returns the new {Pane}.
   splitUp: (params) ->
@@ -634,12 +637,16 @@ class Pane extends Model
   # * `params` (optional) {Object} with the following keys:
   #   * `items` (optional) {Array} of items to add to the new pane.
   #   * `copyActiveItem` (optional) {Boolean} true will copy the active item into the new split pane
+  #   * `activate` (optional) {Boolean} true will activate newly created pane. true by default.
   #
   # Returns the new {Pane}.
   splitDown: (params) ->
     @split('vertical', 'after', params)
 
   split: (orientation, side, params) ->
+    activateNewPane = params?.activate ? true
+    syncScrollRatio = params?.copyActiveItem and (params?.syncScrollRatio ? true)
+
     if params?.copyActiveItem
       params.items ?= []
       params.items.push(@copyActiveItem())
@@ -649,12 +656,48 @@ class Pane extends Model
       @setFlexScale(1)
 
     newPane = new @constructor(params)
+
+    if syncScrollRatio
+      if editor = @getActiveEditor()
+        # Need to save original height before split.
+        height = editor.getHeight()
+
     switch side
       when 'before' then @parent.insertChildBefore(this, newPane)
       when 'after' then @parent.insertChildAfter(this, newPane)
 
-    newPane.activate()
+    if syncScrollRatio and editor
+      @syncScrollRatioToPane(newPane, {height})
+
+    if activateNewPane
+      newPane.activate()
     newPane
+
+  syncScrollRatioToPane: (pane, {height}) ->
+    editor = @getActiveEditor()
+    scrollTop = editor.getScrollTop()
+
+    orientation = @parent.orientation
+    if orientation is 'horizontal'
+      pane.getActiveEditor().setScrollTop(scrollTop)
+
+    else if orientation is 'vertical'
+      scrolloff = 2
+      lineHeightPixel = editor.getLineHeightInPixels()
+
+      point = editor.getCursorScreenPosition()
+      cursorPixel = atom.views.getView(editor).pixelPositionForScreenPosition(point).top
+      scrollRatio = (cursorPixel - scrollTop) / height
+
+      newEditor = pane.getActiveEditor()
+      newHeight = newEditor.getHeight()
+
+      offsetTop = lineHeightPixel * scrolloff
+      offsetBottom = newHeight - lineHeightPixel * (scrolloff+1)
+      offsetCursor = newHeight * scrollRatio
+      scrollTop = cursorPixel - Math.min(Math.max(offsetCursor, offsetTop), offsetBottom)
+      editor.setScrollTop(scrollTop)
+      newEditor.setScrollTop(scrollTop)
 
   # If the parent is a horizontal axis, returns its first child if it is a pane;
   # otherwise returns this pane.


### PR DESCRIPTION
Currently,  splitRight, Left, Up, Down don't sync scrollRatio of original editor.
Since copyActiveItem: is true by default, I want newPane scrolled to same ratio of original item if item was instance of TextEditor.
- activate: false won't activate newPane
- syncScrollRatio: true sync original scrollRatio on split.

Why I added `activate` option is I want split pane without activation, in Vim it split without activation(and of course sync scrollRatio).

Currently spec was not finished. I couldn't getHeight() of editor, its always say 0, I need help to fix this.
