### PR TITLE
Destroy Markers created by DisplayBuffer when buffer is destroyed.

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4044,6 +4044,14 @@ describe "TextEditor", ->
       editor.destroy()
       expect(destroyObserverCalled).toBe true
 
+    it "notifies ::onDidDestroy observers of Markers created for this editor", ->
+      gutterMarker = editor.markBufferPosition([0, 0])
+      onDidDestroyObserver = jasmine.createSpy('onDidDestroy')
+      gutterMarker.onDidDestroy(onDidDestroyObserver)
+
+      editor.destroy()
+      expect(onDidDestroyObserver.callCount).toBe 1
+
   describe ".joinLines()", ->
     describe "when no text is selected", ->
       describe "when the line below isn't empty", ->

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -1174,7 +1174,7 @@ class DisplayBuffer extends Model
 
   destroyed: ->
     fold.destroy() for markerId, fold of @foldsByMarkerId
-    marker.disposables.dispose() for id, marker of @markers
+    marker.destroy() for id, marker of @markers
     @scopedConfigSubscriptions.dispose()
     @disposables.dispose()
     @tokenizedBuffer.destroy()


### PR DESCRIPTION
The implementation of `Marker::destroy()` is:

``` coffee
  destroy: ->
    @bufferMarker.destroy()
    @disposables.dispose()
```

so if `marker.disposables.dispose()` is called instead of `marker.destroy()`, then `marker.bufferMarker.destroy()` does not get called. As best I can tell, `marker.bufferMarker` is a `Marker` returned by a call to `TextBuffer::getMarker(id)` that happens in `DisplayBuffer`.

However, `TextBuffer::getMarker(id)` returns this type of `Marker`:

https://github.com/atom/text-buffer/blob/master/src/marker.coffee

which is distinct from the `Marker` associated with the `DisplayBuffer`:

https://github.com/atom/atom/blob/master/src/marker.coffee

which is a little confusing.

By failing to call `marker.bufferMarker.destroy()`, callbacks registered via `onDidDestroy()` on the `Marker` from the `text-buffer` package will not get called.

Incidentally, there is also this line in the constructor of `Marker`, but that does not seem to help us here:

``` coffee
@disposables.add @bufferMarker.onDidDestroy => @destroyed()
```

I verified that the associated unit test fails without this change and succeeds when the change is added.
