### PR TITLE
Codesign atom.exe before building installer

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -237,9 +237,11 @@ module.exports = (grunt) ->
   ciTasks.push('dump-symbols') if process.platform isnt 'win32'
   ciTasks.push('set-version', 'check-licenses', 'lint', 'generate-asar')
   ciTasks.push('mkdeb') if process.platform is 'linux'
+  ciTasks.push('codesign:exe') if process.platform is 'win32' and not process.env.TRAVIS
   ciTasks.push('create-windows-installer:installer') if process.platform is 'win32'
   ciTasks.push('test') if process.platform is 'darwin'
-  ciTasks.push('codesign') unless process.env.TRAVIS
+  ciTasks.push('codesign:installer') if process.platform is 'win32' and not process.env.TRAVIS
+  ciTasks.push('codesign:app') if process.platform is 'darwin' and not process.env.TRAVIS
   ciTasks.push('publish-build') unless process.env.TRAVIS
   grunt.registerTask('ci', ciTasks)
 

--- a/build/tasks/codesign-task.coffee
+++ b/build/tasks/codesign-task.coffee
@@ -4,10 +4,23 @@ fs = require 'fs-plus'
 module.exports = (grunt) ->
   {spawn} = require('./task-helpers')(grunt)
 
-  grunt.registerTask 'codesign', 'Codesign the app', ->
+  grunt.registerTask 'codesign:exe', 'Codesign atom.exe', ->
+    done = @async()
+    spawn {cmd: 'taskkill', args: ['/F', '/IM', 'atom.exe']}, ->
+      cmd = process.env.JANKY_SIGNTOOL ? 'signtool'
+      args = [path.join(grunt.config.get('atom.shellAppDir'), 'atom.exe')]
+      spawn {cmd, args}, (error) -> done(error)
+
+  grunt.registerTask 'codesign:installer', 'Codesign AtomSetup.exe', ->
+    done = @async()
+    cmd = process.env.JANKY_SIGNTOOL ? 'signtool'
+    args = [path.resolve(grunt.config.get('atom.buildDir'), 'installer', 'AtomSetup.exe')]
+    spawn {cmd, args}, (error) -> done(error)
+
+  grunt.registerTask 'codesign:app', 'Codesign Atom.app', ->
     done = @async()
 
-    if process.platform is 'darwin' and process.env.XCODE_KEYCHAIN
+    if process.env.XCODE_KEYCHAIN
       unlockKeychain (error) ->
         if error?
           done(error)
@@ -23,24 +36,6 @@ module.exports = (grunt) ->
     spawn {cmd, args}, (error) -> callback(error)
 
   signApp = (callback) ->
-    switch process.platform
-      when 'darwin'
-        cmd = 'codesign'
-        args = ['--deep', '--force', '--verbose', '--sign', 'Developer ID Application: GitHub', grunt.config.get('atom.shellAppDir')]
-        spawn {cmd, args}, (error) -> callback(error)
-      when 'win32'
-        spawn {cmd: 'taskkill', args: ['/F', '/IM', 'atom.exe']}, ->
-          cmd = process.env.JANKY_SIGNTOOL ? 'signtool'
-          args = [path.join(grunt.config.get('atom.shellAppDir'), 'atom.exe')]
-
-          spawn {cmd, args}, (error) ->
-            return callback(error) if error?
-
-            setupExePath = path.resolve(grunt.config.get('atom.buildDir'), 'installer', 'AtomSetup.exe')
-            if fs.isFileSync(setupExePath)
-              args = [setupExePath]
-              spawn {cmd, args}, (error) -> callback(error)
-            else
-              callback()
-      else
-        callback()
+    cmd = 'codesign'
+    args = ['--deep', '--force', '--verbose', '--sign', 'Developer ID Application: GitHub', grunt.config.get('atom.shellAppDir')]
+    spawn {cmd, args}, (error) -> callback(error)


### PR DESCRIPTION
This breaks apart the `codesign` build task so that `atom.exe` is signed before `AtomSetup.exe` is built and signed.

This should hopefully prevent `atom.exe` from being detected as malware on Windows 10.

Refs #8246
