### PR TITLE
Codesign Update.exe before building installer

### DIFF
--- a/build/tasks/codesign-task.coffee
+++ b/build/tasks/codesign-task.coffee
@@ -3,12 +3,16 @@ path = require 'path'
 module.exports = (grunt) ->
   {spawn} = require('./task-helpers')(grunt)
 
-  grunt.registerTask 'codesign:exe', 'Codesign atom.exe', ->
+  grunt.registerTask 'codesign:exe', 'Codesign atom.exe and Update.exe', ->
     done = @async()
     spawn {cmd: 'taskkill', args: ['/F', '/IM', 'atom.exe']}, ->
       cmd = process.env.JANKY_SIGNTOOL ? 'signtool'
-      args = [path.join(grunt.config.get('atom.shellAppDir'), 'atom.exe')]
-      spawn {cmd, args}, (error) -> done(error)
+
+      spawn {cmd, args: [atomExePath]}, (error) ->
+        return done(error) if error
+
+        updateExePath = path.resolve(__dirname, '..', 'node_modules', 'grunt-electron-installer' 'vendor', 'Update.exe')
+        spawn {cmd, args: [updateExePath]}, (error) -> done(error)
 
   grunt.registerTask 'codesign:installer', 'Codesign AtomSetup.exe', ->
     done = @async()

--- a/build/tasks/codesign-task.coffee
+++ b/build/tasks/codesign-task.coffee
@@ -11,7 +11,7 @@ module.exports = (grunt) ->
       spawn {cmd, args: [atomExePath]}, (error) ->
         return done(error) if error?
 
-        updateExePath = path.resolve(__dirname, '..', 'node_modules', 'grunt-electron-installer' 'vendor', 'Update.exe')
+        updateExePath = path.resolve(__dirname, '..', 'node_modules', 'grunt-electron-installer', 'vendor', 'Update.exe')
         spawn {cmd, args: [updateExePath]}, (error) -> done(error)
 
   grunt.registerTask 'codesign:installer', 'Codesign AtomSetup.exe', ->

--- a/build/tasks/codesign-task.coffee
+++ b/build/tasks/codesign-task.coffee
@@ -9,7 +9,7 @@ module.exports = (grunt) ->
       cmd = process.env.JANKY_SIGNTOOL ? 'signtool'
 
       spawn {cmd, args: [atomExePath]}, (error) ->
-        return done(error) if error
+        return done(error) if error?
 
         updateExePath = path.resolve(__dirname, '..', 'node_modules', 'grunt-electron-installer' 'vendor', 'Update.exe')
         spawn {cmd, args: [updateExePath]}, (error) -> done(error)

--- a/build/tasks/codesign-task.coffee
+++ b/build/tasks/codesign-task.coffee
@@ -7,7 +7,7 @@ module.exports = (grunt) ->
     done = @async()
     spawn {cmd: 'taskkill', args: ['/F', '/IM', 'atom.exe']}, ->
       cmd = process.env.JANKY_SIGNTOOL ? 'signtool'
-
+      atomExePath = path.join(grunt.config.get('atom.shellAppDir'), 'atom.exe')
       spawn {cmd, args: [atomExePath]}, (error) ->
         return done(error) if error?
 

--- a/build/tasks/codesign-task.coffee
+++ b/build/tasks/codesign-task.coffee
@@ -17,8 +17,8 @@ module.exports = (grunt) ->
   grunt.registerTask 'codesign:installer', 'Codesign AtomSetup.exe', ->
     done = @async()
     cmd = process.env.JANKY_SIGNTOOL ? 'signtool'
-    args = [path.resolve(grunt.config.get('atom.buildDir'), 'installer', 'AtomSetup.exe')]
-    spawn {cmd, args}, (error) -> done(error)
+    atomSetupExePath = path.resolve(grunt.config.get('atom.buildDir'), 'installer', 'AtomSetup.exe')
+    spawn {cmd, args: [atomSetupExePath]}, (error) -> done(error)
 
   grunt.registerTask 'codesign:app', 'Codesign Atom.app', ->
     done = @async()


### PR DESCRIPTION
Follow on to #8254, sign `Update.exe` as well before building the installer.

Refs #8246 
