### PR TITLE
fix : workspace.open with initial cursor position bug

### DIFF
--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -472,7 +472,7 @@ class Workspace extends Model
           initialLine = options.initialLine
         if Number.isFinite(options.initialColumn)
           initialColumn = options.initialColumn
-        if initialLine > 0 or initialColumn > 0
+        if initialLine > 0 or initialColumn > 0 or options.initialLine? or options.initialColumn?
           item.setCursorBufferPosition?([initialLine, initialColumn])
 
         index = pane.getActiveItemIndex()


### PR DESCRIPTION
## Description

When opening already opened file via `atom.workspace.open(path,{ initialLine: 0,  initialColumn: 0, searchAllPanes: true} )`, cursor position doesn't move to `row : 0, column:0`.

Check below screenshot. 
I run code on console.

``` javascript
var indexPath = "/Users/yomybaby/Documents/AWorkspace/demo-atom-package/app/controllers/index.js"
setInterval(function(){
  atom.workspace.open( indexPath , {initialLine:0, initialColumn:0, searchAllPanes:true});
},1000);
```

![openbug](https://cloud.githubusercontent.com/assets/621215/9134340/31a3663a-3d3e-11e5-8a38-74eb7ab16994.gif)
## Expected result:

Whether or not file is opened already, cursor position has to be [0,0].

Same result of below code

``` javascript
var indexPath = "/Users/yomybaby/Documents/AWorkspace/demo-atom-package/app/controllers/index.js"
setInterval(function(){
  atom.workspace.open( indexPath , {searchAllPanes:true}).then(function(te){
    te.setCursorBufferPosition([0, 0])
  });
},2000);
```

![openexpected](https://cloud.githubusercontent.com/assets/621215/9134344/395fc24c-3d3e-11e5-8e70-22410111b0b2.gif)
