### PR TITLE
Switch to Contributor Covenant from Open Code of Conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ which are hosted in the [Atom Organization](https://github.com/atom) on GitHub.
 These are just guidelines, not rules, use your best judgment and feel free to
 propose changes to this document in a pull request.
 
-This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
-[code-of-conduct]: http://todogroup.org/opencodeofconduct/#Atom/opensource@github.com
+This project adheres to the [Contributor Covenant 1.2](http://contributor-covenant.org/version/1/2/0).
+By participating, you are expected to uphold this code. Please report unacceptable behavior to atom@github.com.
 
 ## Submitting Issues
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Visit [atom.io](https://atom.io) to learn more or visit the [Atom forum](https:/
 Follow [@AtomEditor](https://twitter.com/atomeditor) on Twitter for important
 announcements.
 
-This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
-[code-of-conduct]: http://todogroup.org/opencodeofconduct/#Atom/opensource@github.com
+This project adheres to the [Contributor Covenant 1.2](http://contributor-covenant.org/version/1/2/0).
+By participating, you are expected to uphold this code. Please report unacceptable behavior to atom@github.com.
 
 ## Documentation
 


### PR DESCRIPTION
Switch to the [Contributor Covenant](http://contributor-covenant.org/version/1/2/0/) from the [Open Code of Conduct](http://todogroup.org/opencodeofconduct).

See https://github.com/todogroup/opencodeofconduct/issues/84 for more details.

See [here](http://contributor-covenant.org/#who) for other projects using the Contributor Covenant.

/cc @atom/feedback 

Closes #8206 
