### PR TITLE
Clear pending frames on folding specs

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -824,7 +824,8 @@ describe "TextEditorComponent", ->
 
         describe "when the component is destroyed", ->
           it "stops listening for folding events", ->
-            nextAnimationFrame()
+            nextAnimationFrame() unless nextAnimationFrame is noAnimationFrame # clear pending frame request if needed
+
             component.destroy()
 
             lineNumber = component.lineNumberNodeForScreenRow(1)


### PR DESCRIPTION
Fixes #8301.

It seems like, for a time related problem, we're getting intermittent build failures on Travis [for this line](https://github.com/atom/atom/blob/master/spec/text-editor-component-spec.coffee#L827) (which was added as part of #8009).

This PR simply bypasses the `nextAnimationFrame` call when there is no pending frame (as we did for https://github.com/atom/atom/blob/master/spec/text-editor-component-spec.coffee#L852).

/cc: @atom/feedback @thomasjo
