### PR TITLE
Autoscroll correctly when dragging gutter selections

### DIFF
--- a/spec/text-editor-component-spec.coffee
+++ b/spec/text-editor-component-spec.coffee
@@ -1953,6 +1953,32 @@ describe "TextEditorComponent", ->
           gutterNode.dispatchEvent(buildMouseEvent('mouseup', clientCoordinatesForScreenRowInGutter(2)))
           expect(editor.getSelectedScreenRange()).toEqual [[2, 0], [7, 0]]
 
+      it "orients the selection appropriately when the mouse moves above or below the initially-clicked row", ->
+        gutterNode.dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenRowInGutter(4)))
+        gutterNode.dispatchEvent(buildMouseEvent('mousemove', clientCoordinatesForScreenRowInGutter(2)))
+        nextAnimationFrame()
+        expect(editor.getLastSelection().isReversed()).toBe true
+        gutterNode.dispatchEvent(buildMouseEvent('mousemove', clientCoordinatesForScreenRowInGutter(6)))
+        nextAnimationFrame()
+        expect(editor.getLastSelection().isReversed()).toBe false
+
+      it "autoscrolls to the cursor position, but not the entire selected range", ->
+        wrapperNode.style.height = 6 * lineHeightInPixels + 'px'
+        component.measureDimensions()
+
+        expect(editor.getScrollTop()).toBe 0
+
+        gutterNode.dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenRowInGutter(2)))
+        gutterNode.dispatchEvent(buildMouseEvent('mousemove', clientCoordinatesForScreenRowInGutter(6)))
+        nextAnimationFrame()
+
+        expect(editor.getScrollTop()).toBeGreaterThan 0
+        maxScrollTop = editor.getScrollTop()
+
+        gutterNode.dispatchEvent(buildMouseEvent('mousemove', clientCoordinatesForScreenRowInGutter(5)))
+        nextAnimationFrame()
+        expect(editor.getScrollTop()).toBe maxScrollTop
+
     describe "when the gutter is meta-clicked and dragged", ->
       beforeEach ->
         editor.setSelectedScreenRange([[3, 0], [3, 2]])

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -428,9 +428,10 @@ class TextEditorComponent
       dragRow = screenPosition.row
       dragBufferRow = @editor.bufferRowForScreenRow(dragRow)
       if dragBufferRow < clickedBufferRow # dragging up
-        @editor.setSelectedBufferRange([[dragBufferRow, 0], [clickedBufferRow + 1, 0]], preserveFolds: true)
+        @editor.setSelectedBufferRange([[dragBufferRow, 0], [clickedBufferRow + 1, 0]], reversed: true, preserveFolds: true, autoscroll: false)
       else
-        @editor.setSelectedBufferRange([[clickedBufferRow, 0], [dragBufferRow + 1, 0]], preserveFolds: true)
+        @editor.setSelectedBufferRange([[clickedBufferRow, 0], [dragBufferRow + 1, 0]], reversed: false, preserveFolds: true, autoscroll: false)
+      @editor.getLastCursor().autoscroll()
 
   onGutterMetaClick: (event) =>
     clickedRow = @screenPositionForMouseEvent(event).row


### PR DESCRIPTION
Fixes #2696
- Explicitly assign the orientation of the selection when it crosses the initially clicked row.
- Autoscroll to the cursor, not the entire selection.
