### PR TITLE
Support `editor.tabType`

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3833,6 +3833,23 @@ describe "TextEditor", ->
             atom.config.set('editor.tabType', 'auto')
             expect(editor.getSoftTabs()).toBe false
 
+    describe "when the grammar changes", ->
+      coffeeEditor = null
+      beforeEach ->
+        atom.config.set('editor.tabType', 'hard', scopeSelector: '.source.js')
+        atom.config.set('editor.tabType', 'soft', scopeSelector: '.source.coffee')
+
+        waitsForPromise ->
+          Promise.all [
+            atom.packages.activatePackage('language-coffee-script')
+            atom.project.open('coffee.coffee', autoIndent: false).then (o) -> coffeeEditor = o
+          ]
+
+      it "updates based on the value chosen", ->
+        expect(editor.getSoftTabs()).toBe false
+        editor.setGrammar(coffeeEditor.getGrammar())
+        expect(editor.getSoftTabs()).toBe true
+
   describe '.getTabLength()', ->
     describe 'when scoped settings are used', ->
       coffeeEditor = null

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3822,6 +3822,8 @@ describe "TextEditor", ->
             expect(editor.getSoftTabs()).toBe false
             atom.config.set('editor.tabType', 'auto')
             expect(editor.getSoftTabs()).toBe true
+            atom.config.set('editor.tabType', 'hard', scopeSelector: '.source.js')
+            expect(editor.getSoftTabs()).toBe false
 
         waitsForPromise ->
           atom.workspace.open('sample-with-tabs.coffee').then (editor) ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3810,6 +3810,27 @@ describe "TextEditor", ->
         runs ->
           expect(editor.softTabs).toBe true
 
+    describe "when editor.tabType changes", ->
+      beforeEach ->
+        atom.config.set('editor.tabType', 'auto')
+
+      it "updates based on the value chosen", ->
+        waitsForPromise ->
+          atom.workspace.open('sample.js').then (editor) ->
+            expect(editor.getSoftTabs()).toBe true
+            atom.config.set('editor.tabType', 'hard')
+            expect(editor.getSoftTabs()).toBe false
+            atom.config.set('editor.tabType', 'auto')
+            expect(editor.getSoftTabs()).toBe true
+
+        waitsForPromise ->
+          atom.workspace.open('sample-with-tabs.coffee').then (editor) ->
+            expect(editor.getSoftTabs()).toBe false
+            atom.config.set('editor.tabType', 'soft')
+            expect(editor.getSoftTabs()).toBe true
+            atom.config.set('editor.tabType', 'auto')
+            expect(editor.getSoftTabs()).toBe false
+
   describe '.getTabLength()', ->
     describe 'when scoped settings are used', ->
       coffeeEditor = null

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3694,6 +3694,38 @@ describe "TextEditor", ->
         atom.workspace.open(null, softTabs: false).then (editor) ->
           expect(editor.getSoftTabs()).toBeFalsy()
 
+    afterEach ->
+      atom.packages.deactivatePackages()
+      atom.packages.unloadPackages()
+
+    it "resets the tab style when tokenization is complete", ->
+      editor.destroy()
+
+      waitsForPromise ->
+        atom.project.open('sample-with-tabs-and-leading-comment.coffee').then (o) -> editor = o
+
+      runs ->
+        expect(editor.softTabs).toBe true
+
+      waitsForPromise ->
+        atom.packages.activatePackage('language-coffee-script')
+
+      runs ->
+        expect(editor.softTabs).toBe false
+
+    it "uses hard tabs in Makefile files", ->
+      # FIXME remove once this is handled by a scoped setting in the
+      # language-make package
+
+      waitsForPromise ->
+        atom.packages.activatePackage('language-make')
+
+      waitsForPromise ->
+        atom.project.open('Makefile').then (o) -> editor = o
+
+      runs ->
+        expect(editor.softTabs).toBe false
+
   describe '.getTabLength()', ->
     describe 'when scoped settings are used', ->
       coffeeEditor = null
@@ -3922,39 +3954,6 @@ describe "TextEditor", ->
         coffeeEditor.setCursorBufferPosition([1, 18])
         coffeeEditor.insertText("\n")
         expect(coffeeEditor.lineTextForBufferRow(2)).toBe ""
-
-  describe "soft and hard tabs", ->
-    afterEach ->
-      atom.packages.deactivatePackages()
-      atom.packages.unloadPackages()
-
-    it "resets the tab style when tokenization is complete", ->
-      editor.destroy()
-
-      waitsForPromise ->
-        atom.project.open('sample-with-tabs-and-leading-comment.coffee').then (o) -> editor = o
-
-      runs ->
-        expect(editor.softTabs).toBe true
-
-      waitsForPromise ->
-        atom.packages.activatePackage('language-coffee-script')
-
-      runs ->
-        expect(editor.softTabs).toBe false
-
-    it "uses hard tabs in Makefile files", ->
-      # FIXME remove once this is handled by a scoped setting in the
-      # language-make package
-
-      waitsForPromise ->
-        atom.packages.activatePackage('language-make')
-
-      waitsForPromise ->
-        atom.project.open('Makefile').then (o) -> editor = o
-
-      runs ->
-        expect(editor.softTabs).toBe false
 
   describe ".destroy()", ->
     it "destroys all markers associated with the edit session", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3840,14 +3840,11 @@ describe "TextEditor", ->
         atom.config.set('editor.tabType', 'soft', scopeSelector: '.source.coffee')
 
         waitsForPromise ->
-          Promise.all [
-            atom.packages.activatePackage('language-coffee-script')
-            atom.project.open('coffee.coffee', autoIndent: false).then (o) -> coffeeEditor = o
-          ]
+          atom.packages.activatePackage('language-coffee-script')
 
       it "updates based on the value chosen", ->
         expect(editor.getSoftTabs()).toBe false
-        editor.setGrammar(coffeeEditor.getGrammar())
+        editor.setGrammar(atom.grammars.grammarForScopeName('source.coffee'))
         expect(editor.getSoftTabs()).toBe true
 
   describe '.getTabLength()', ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3737,6 +3737,79 @@ describe "TextEditor", ->
         runs ->
           expect(editor.softTabs).toBe false
 
+    describe "when editor.tabType is 'hard'", ->
+      beforeEach ->
+        atom.config.set('editor.tabType', 'hard')
+
+      it "always chooses hard tabs and setSoftTabs() overrides the setting", ->
+        waitsForPromise ->
+          atom.workspace.open('sample.js').then (editor) ->
+            expect(editor.getSoftTabs()).toBe false
+            editor.setSoftTabs(true)
+            expect(editor.getSoftTabs()).toBe true
+
+        waitsForPromise ->
+          atom.workspace.open('sample-with-tabs.coffee').then (editor) ->
+            expect(editor.getSoftTabs()).toBe false
+            editor.setSoftTabs(true)
+            expect(editor.getSoftTabs()).toBe true
+
+        waitsForPromise ->
+          atom.workspace.open('sample-with-tabs-and-initial-comment.js').then (editor) ->
+            expect(editor.getSoftTabs()).toBe false
+            editor.setSoftTabs(true)
+            expect(editor.getSoftTabs()).toBe true
+
+        waitsForPromise ->
+          atom.workspace.open(null).then (editor) ->
+            expect(editor.getSoftTabs()).toBe false
+            editor.setSoftTabs(true)
+            expect(editor.getSoftTabs()).toBe true
+
+    describe "when editor.tabType is 'soft'", ->
+      beforeEach ->
+        atom.config.set('editor.tabType', 'soft')
+
+      it "always chooses soft tabs and setSoftTabs() overrides the setting", ->
+        waitsForPromise ->
+          atom.workspace.open('sample.js').then (editor) ->
+            expect(editor.getSoftTabs()).toBe true
+            editor.setSoftTabs(false)
+            expect(editor.getSoftTabs()).toBe false
+
+        waitsForPromise ->
+          atom.workspace.open('sample-with-tabs.coffee').then (editor) ->
+            expect(editor.getSoftTabs()).toBe true
+            editor.setSoftTabs(false)
+            expect(editor.getSoftTabs()).toBe false
+
+        waitsForPromise ->
+          atom.workspace.open('sample-with-tabs-and-initial-comment.js').then (editor) ->
+            expect(editor.getSoftTabs()).toBe true
+            editor.setSoftTabs(false)
+            expect(editor.getSoftTabs()).toBe false
+
+        waitsForPromise ->
+          atom.workspace.open(null).then (editor) ->
+            expect(editor.getSoftTabs()).toBe true
+            editor.setSoftTabs(false)
+            expect(editor.getSoftTabs()).toBe false
+
+      it "keeps the tabType when tokenization is complete", ->
+        editor.destroy()
+
+        waitsForPromise ->
+          atom.project.open('sample-with-tabs-and-leading-comment.coffee').then (o) -> editor = o
+
+        runs ->
+          expect(editor.softTabs).toBe true
+
+        waitsForPromise ->
+          atom.packages.activatePackage('language-coffee-script')
+
+        runs ->
+          expect(editor.softTabs).toBe true
+
   describe '.getTabLength()', ->
     describe 'when scoped settings are used', ->
       coffeeEditor = null

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -143,6 +143,10 @@ module.exports =
       softTabs:
         type: 'boolean'
         default: true
+      tabType:
+        type: 'string'
+        default: 'auto'
+        enum: ['auto', 'soft', 'hard']
       softWrapAtPreferredLineLength:
         type: 'boolean'
         default: false

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -147,6 +147,7 @@ module.exports =
         type: 'string'
         default: 'auto'
         enum: ['auto', 'soft', 'hard']
+        description: 'Determine character inserted during Tab keypress.'
       softWrapAtPreferredLineLength:
         type: 'boolean'
         default: false

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -87,9 +87,6 @@ class TextEditor extends Model
     @displayBuffer ?= new DisplayBuffer({buffer, tabLength, softWrapped, ignoreInvisibles: @mini, largeFileMode})
     @buffer = @displayBuffer.buffer
 
-    @disposables.add atom.config.observe 'editor.tabType', scope: @getRootScopeDescriptor(), =>
-      @softTabs = @shouldUseSoftTabs(defaultValue: @softTabs)
-
     for marker in @findMarkers(@getSelectionMarkerAttributes())
       marker.setProperties(preserveFolds: true)
       @addSelection(marker)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2376,7 +2376,7 @@ class TextEditor extends Model
   usesSoftTabs: ->
     # FIXME Remove once this can be specified as a scoped setting in the
     # language-make package
-    return false if @getGrammar().scopeName is 'source.makefile'
+    return false if @getGrammar()?.scopeName is 'source.makefile'
 
     for bufferRow in [0..@buffer.getLastRow()]
       continue if @displayBuffer.tokenizedBuffer.tokenizedLineForRow(bufferRow).isComment()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -75,7 +75,7 @@ class TextEditor extends Model
     'autoDecreaseIndentForBufferRow', 'toggleLineCommentForBufferRow', 'toggleLineCommentsForBufferRows',
     toProperty: 'languageMode'
 
-  constructor: ({softTabs, initialLine, initialColumn, tabLength, softWrapped, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini, @placeholderText, lineNumberGutterVisible, largeFileMode}={}) ->
+  constructor: ({@softTabs, initialLine, initialColumn, tabLength, softWrapped, @displayBuffer, buffer, registerEditor, suppressCursorCreation, @mini, @placeholderText, lineNumberGutterVisible, largeFileMode}={}) ->
     super
 
     @emitter = new Emitter
@@ -86,7 +86,9 @@ class TextEditor extends Model
     buffer ?= new TextBuffer
     @displayBuffer ?= new DisplayBuffer({buffer, tabLength, softWrapped, ignoreInvisibles: @mini, largeFileMode})
     @buffer = @displayBuffer.buffer
-    @softTabs = @shouldUseSoftTabs(defaultValue: softTabs)
+
+    @disposables.add atom.config.observe 'editor.tabType', scope: @getRootScopeDescriptor(), =>
+      @softTabs = @shouldUseSoftTabs(defaultValue: @softTabs)
 
     for marker in @findMarkers(@getSelectionMarkerAttributes())
       marker.setProperties(preserveFolds: true)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -94,6 +94,7 @@ class TextEditor extends Model
       marker.setProperties(preserveFolds: true)
       @addSelection(marker)
 
+    @subscribeToTabTypeConfig()
     @subscribeToBuffer()
     @subscribeToDisplayBuffer()
 
@@ -178,9 +179,15 @@ class TextEditor extends Model
       @subscribe @displayBuffer.onDidAddDecoration (decoration) => @emit 'decoration-added', decoration
       @subscribe @displayBuffer.onDidRemoveDecoration (decoration) => @emit 'decoration-removed', decoration
 
+  subscribeToTabTypeConfig: ->
+    @tabTypeSubscription?.dispose()
+    @tabTypeSubscription = atom.config.observe 'editor.tabType', scope: @getRootScopeDescriptor(), =>
+      @softTabs = @shouldUseSoftTabs(defaultValue: @softTabs)
+
   destroyed: ->
     @unsubscribe() if includeDeprecatedAPIs
     @disposables.dispose()
+    @tabTypeSubscription.dispose()
     selection.destroy() for selection in @getSelections()
     @buffer.release()
     @displayBuffer.destroy()
@@ -2895,6 +2902,7 @@ class TextEditor extends Model
 
   handleGrammarChange: ->
     @unfoldAll()
+    @subscribeToTabTypeConfig()
     @emitter.emit 'did-change-grammar', @getGrammar()
 
   handleMarkerCreated: (marker) =>


### PR DESCRIPTION
This does the simplest thing possible. When `editor.tabType` is set to `auto`, it does what it did before. When it is set to `hard` or `soft`, it uses those values all the time unless `setSoftTabs()` is explicitly called. The API is unchanged. Specs have been consolidated a bit as there were a couple places where the tab stuff was being tested.

Eventually (another PR), I'd like to change the name of `editor.softTabs` setting to `editor.defaultTabType` or something more clear. 

Closes https://github.com/atom/atom/pull/8186 @Abdillah, I've used a couple of your commits.
Closes https://github.com/atom/atom/issues/3719
