### PR TITLE
Add pane increase/decrease size commands

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -182,8 +182,8 @@
   'cmd-k cmd-9': 'editor:fold-at-indent-level-9'
 
 'atom-workspace atom-pane':
-  'cmd-alt-=': 'pane:enlarge'
-  'cmd-alt--': 'pane:shrink'
+  'cmd-alt-=': 'pane:increase-size'
+  'cmd-alt--': 'pane:decrease-size'
 
 # allow standard input fields to work correctly
 'body .native-key-bindings':

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -181,6 +181,10 @@
   'cmd-k cmd-8': 'editor:fold-at-indent-level-8'
   'cmd-k cmd-9': 'editor:fold-at-indent-level-9'
 
+'atom-workspace atom-pane':
+  'cmd-alt-=': 'pane:enlarge'
+  'cmd-alt--': 'pane:shrink'
+
 # allow standard input fields to work correctly
 'body .native-key-bindings':
   'cmd-z': 'native!'

--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -143,6 +143,10 @@
   'ctrl-k ctrl-8': 'editor:fold-at-indent-level-8'
   'ctrl-k ctrl-9': 'editor:fold-at-indent-level-9'
 
+'atom-workspace atom-pane':
+  'ctrl-alt-=': 'pane:enlarge'
+  'ctrl-alt--': 'pane:shrink'
+  
 # allow standard input fields to work correctly
 'body .native-key-bindings':
   'ctrl-z': 'native!'

--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -144,9 +144,9 @@
   'ctrl-k ctrl-9': 'editor:fold-at-indent-level-9'
 
 'atom-workspace atom-pane':
-  'ctrl-alt-=': 'pane:enlarge'
-  'ctrl-alt--': 'pane:shrink'
-  
+  'ctrl-alt-=': 'pane:increase-size'
+  'ctrl-alt--': 'pane:decrease-size'
+
 # allow standard input fields to work correctly
 'body .native-key-bindings':
   'ctrl-z': 'native!'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -147,6 +147,10 @@
   'ctrl-k ctrl-8': 'editor:fold-at-indent-level-8'
   'ctrl-k ctrl-9': 'editor:fold-at-indent-level-9'
 
+'atom-workspace atom-pane':
+  'ctrl-alt-=': 'pane:enlarge'
+  'ctrl-alt--': 'pane:shrink'
+
 # allow standard input fields to work correctly
 'body .native-key-bindings':
   'ctrl-z': 'native!'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -148,8 +148,8 @@
   'ctrl-k ctrl-9': 'editor:fold-at-indent-level-9'
 
 'atom-workspace atom-pane':
-  'ctrl-alt-=': 'pane:enlarge'
-  'ctrl-alt--': 'pane:shrink'
+  'ctrl-alt-=': 'pane:increase-size'
+  'ctrl-alt--': 'pane:decrease-size'
 
 # allow standard input fields to work correctly
 'body .native-key-bindings':

--- a/spec/pane-container-element-spec.coffee
+++ b/spec/pane-container-element-spec.coffee
@@ -160,3 +160,37 @@ describe "PaneContainerElement", ->
       element = getResizeElement(0)
       element.remove()
       expect(-> element.resizeToFitContent()).not.toThrow()
+
+  describe "pane resizing", ->
+    [leftPane, rightPane] = []
+
+    beforeEach ->
+      container = new PaneContainer
+      leftPane = container.getActivePane()
+      rightPane = leftPane.splitRight()
+
+    describe "when pane:increase-size is triggered", ->
+      it "increases the size of the pane", ->
+        expect(leftPane.getFlexScale()).toBe 1
+        expect(rightPane.getFlexScale()).toBe 1
+
+        atom.commands.dispatch(atom.views.getView(leftPane), 'pane:increase-size')
+        expect(leftPane.getFlexScale()).toBe 1.1
+        expect(rightPane.getFlexScale()).toBe 1
+
+        atom.commands.dispatch(atom.views.getView(rightPane), 'pane:increase-size')
+        expect(leftPane.getFlexScale()).toBe 1.1
+        expect(rightPane.getFlexScale()).toBe 1.1
+
+    describe "when pane:decrease-size is triggered", ->
+      it "decreases the size of the pane", ->
+        expect(leftPane.getFlexScale()).toBe 1
+        expect(rightPane.getFlexScale()).toBe 1
+
+        atom.commands.dispatch(atom.views.getView(leftPane), 'pane:decrease-size')
+        expect(leftPane.getFlexScale()).toBe 1/1.1
+        expect(rightPane.getFlexScale()).toBe 1
+
+        atom.commands.dispatch(atom.views.getView(rightPane), 'pane:decrease-size')
+        expect(leftPane.getFlexScale()).toBe 1/1.1
+        expect(rightPane.getFlexScale()).toBe 1/1.1

--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -158,5 +158,7 @@ atom.commands.add 'atom-pane',
   'pane:split-down': -> @getModel().splitDown(copyActiveItem: true)
   'pane:close': -> @getModel().close()
   'pane:close-other-items': -> @getModel().destroyInactiveItems()
+  'pane:enlarge': -> @getModel().setFlexScale(@getModel().getFlexScale() * 1.1)
+  'pane:shrink': -> @getModel().setFlexScale(@getModel().getFlexScale() / 1.1)
 
 module.exports = PaneElement = document.registerElement 'atom-pane', prototype: PaneElement.prototype

--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -158,7 +158,7 @@ atom.commands.add 'atom-pane',
   'pane:split-down': -> @getModel().splitDown(copyActiveItem: true)
   'pane:close': -> @getModel().close()
   'pane:close-other-items': -> @getModel().destroyInactiveItems()
-  'pane:enlarge': -> @getModel().setFlexScale(@getModel().getFlexScale() * 1.1)
-  'pane:shrink': -> @getModel().setFlexScale(@getModel().getFlexScale() / 1.1)
+  'pane:increase-size': -> @getModel().setFlexScale(@getModel().getFlexScale() * 1.1)
+  'pane:decrease-size': -> @getModel().setFlexScale(@getModel().getFlexScale() / 1.1)
 
 module.exports = PaneElement = document.registerElement 'atom-pane', prototype: PaneElement.prototype

--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -158,7 +158,7 @@ atom.commands.add 'atom-pane',
   'pane:split-down': -> @getModel().splitDown(copyActiveItem: true)
   'pane:close': -> @getModel().close()
   'pane:close-other-items': -> @getModel().destroyInactiveItems()
-  'pane:increase-size': -> @getModel().setFlexScale(@getModel().getFlexScale() * 1.1)
-  'pane:decrease-size': -> @getModel().setFlexScale(@getModel().getFlexScale() / 1.1)
+  'pane:increase-size': -> @getModel().increaseSize()
+  'pane:decrease-size': -> @getModel().decreaseSize()
 
 module.exports = PaneElement = document.registerElement 'atom-pane', prototype: PaneElement.prototype

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -73,6 +73,11 @@ class Pane extends Model
     @flexScale
 
   getFlexScale: -> @flexScale
+
+  increaseSize: -> @setFlexScale(@getFlexScale() * 1.1)
+
+  decreaseSize: -> @setFlexScale(@getFlexScale() / 1.1)
+
   ###
   Section: Event Subscription
   ###


### PR DESCRIPTION
Adds two new pane commands, `pane:increase-size` and `pane:decrease-size` with some default keybindings on all platforms.

Continuation of #7354

Closes https://github.com/atom/atom/issues/7332
