### PR TITLE
:arrow_up: about@1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "one-light-ui": "1.0.3",
     "solarized-dark-syntax": "0.38.1",
     "solarized-light-syntax": "0.22.1",
-    "about": "1.0.1",
+    "about": "1.1.0",
     "archive-view": "0.58.0",
     "autocomplete-atom-api": "0.9.2",
     "autocomplete-css": "0.10.1",


### PR DESCRIPTION
The metrics link in about now opens the metrics package directly in Atom.
