### PR TITLE
Add eol to word regex

### DIFF
--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -641,6 +641,8 @@ class Cursor extends Model
   # * `options` (optional) {Object} with the following keys:
   #   * `includeNonWordCharacters` A {Boolean} indicating whether to include
   #     non-word characters in the regex. (default: true)
+  #   * `includeEol` A {Boolean} indicating whether to include the end of the
+  #     line in the regex. (default: false)
   #
   # Returns a {RegExp}.
   wordRegExp: (options={}) ->

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -643,13 +643,16 @@ class Cursor extends Model
   #     non-word characters in the regex. (default: true)
   #
   # Returns a {RegExp}.
-  wordRegExp: ({includeNonWordCharacters}={}) ->
-    includeNonWordCharacters ?= true
+  wordRegExp: (options={}) ->
+    options.includeNonWordCharacters ?= true
+    options.includeEol ?= false
     nonWordCharacters = atom.config.get('editor.nonWordCharacters', scope: @getScopeDescriptor())
     segments = ["^[\t ]*$"]
     segments.push("[^\\s#{_.escapeRegExp(nonWordCharacters)}]+")
-    if includeNonWordCharacters
+    if options.includeNonWordCharacters
       segments.push("[#{_.escapeRegExp(nonWordCharacters)}]+")
+    if options.includeEol
+      segments.push("$")
     new RegExp(segments.join("|"), "g")
 
   # Public: Get the RegExp used by the cursor to determine what a "subword" is.


### PR DESCRIPTION
I added the EOL symbol as an option for the word regex.  This will be used in atom/vim-mode#581.  Let me know if tests should be added.
