### PR TITLE
Destroy a TextEditor's Gutters when it is destroyed

### DIFF
--- a/spec/gutter-container-spec.coffee
+++ b/spec/gutter-container-spec.coffee
@@ -50,3 +50,13 @@ describe 'GutterContainer', ->
       otherGutterContainer = new GutterContainer fakeOtherTextEditor
       gutter = new Gutter 'gutter-name', otherGutterContainer
       expect(gutterContainer.removeGutter.bind(null, gutter)).toThrow()
+
+  describe '::destroy', ->
+    it 'clears its array of gutters and destroys custom gutters', ->
+      newGutter = gutterContainer.addGutter {'test-gutter', priority: 1}
+      newGutterSpy = jasmine.createSpy()
+      newGutter.onDidDestroy(newGutterSpy)
+
+      gutterContainer.destroy()
+      expect(newGutterSpy).toHaveBeenCalled()
+      expect(gutterContainer.getGutters()).toEqual []

--- a/src/gutter-container.coffee
+++ b/src/gutter-container.coffee
@@ -13,7 +13,12 @@ class GutterContainer
     @emitter = new Emitter
 
   destroy: ->
-    @gutters = null
+    # Create a copy, because `Gutter::destroy` removes the gutter from
+    # GutterContainer's @gutters.
+    guttersToDestroy = @gutters.slice(0)
+    for gutter in guttersToDestroy
+      gutter.destroy() if gutter.name isnt 'line-number'
+    @gutters = []
     @emitter.dispose()
 
   # Creates and returns a {Gutter}.


### PR DESCRIPTION
It seems expected for custom `Gutter`s to be destroyed when its `TextEditor` is destroyed.
We decided that the `line-numbers` Gutter could not be deliberately `destroy`-ed, which is why there is a special case for it. 

The change in this PR also prevents an exception that would be thrown if you call `Gutter::destroy` after the TextEditor has been destroyed:
- `TextEditor::destroyed` calls `GutterContainer::destroy`
- ... which used to set the GutterContainer's `@gutters = null`.
- Then if you call `Gutter::destroy`, it calls `GutterContainer::removeGutter`
- ... which attempts to call `@gutters.indexOf`. But `@gutters` would be `null`, not an Array.
