### PR TITLE
Extend ViewRegistry with support for objects with an element property

### DIFF
--- a/spec/view-registry-spec.coffee
+++ b/spec/view-registry-spec.coffee
@@ -26,6 +26,14 @@ describe "ViewRegistry", ->
         expect(node.textContent).toBe "Hello"
         expect(node.spacePenView).toBe view
 
+    describe "when passed an object with an element property", ->
+      it "returns the element property if it's an instance of HTMLElement", ->
+        class TestComponent
+          constructor: -> @element = document.createElement('div')
+
+        component = new TestComponent
+        expect(registry.getView(component)).toBe component.element
+
     describe "when passed a model object", ->
       describe "when a view provider is registered matching the object's constructor", ->
         it "constructs a view element and assigns the model on it", ->

--- a/src/view-registry.coffee
+++ b/src/view-registry.coffee
@@ -138,6 +138,8 @@ class ViewRegistry
   createView: (object) ->
     if object instanceof HTMLElement
       object
+    else if object?.element instanceof HTMLElement
+      object.element
     else if object?.jquery
       object[0]
     else if provider = @findProvider(object)


### PR DESCRIPTION
By adding this extension to `ViewRegistry::getView` we're paving the way for [Etch](https://github.com/nathansobo/etch)-like view frameworks which promotes the usage of plain objects and classes with an `element` property which is an instance of `HTMLElement`.

/cc @nathansobo @maxbrunsfeld 
