### PR TITLE
Batch cursor updates

### DIFF
--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -410,10 +410,7 @@ class TextEditorPresenter
     @updateCursorState(cursor) for cursor in @model.cursors # using property directly to avoid allocation
     return
 
-  updateCursorState: (cursor, destroyOnly = false) ->
-    delete @state.content.cursors[cursor.id]
-
-    return if destroyOnly
+  updateCursorState: (cursor) ->
     return unless @startRow? and @endRow? and @hasPixelRectRequirements() and @baseCharacterWidth?
     return unless cursor.isVisible() and @startRow <= cursor.getScreenRow() < @endRow
 
@@ -1365,20 +1362,20 @@ class TextEditorPresenter
   observeCursor: (cursor) ->
     didChangePositionDisposable = cursor.onDidChangePosition =>
       @shouldUpdateHiddenInputState = true if cursor.isLastCursor()
+      @shouldUpdateCursorsState = true
       @pauseCursorBlinking()
-      @updateCursorState(cursor)
 
       @emitDidUpdateState()
 
     didChangeVisibilityDisposable = cursor.onDidChangeVisibility =>
-      @updateCursorState(cursor)
+      @shouldUpdateCursorsState = true
 
     didDestroyDisposable = cursor.onDidDestroy =>
       @disposables.remove(didChangePositionDisposable)
       @disposables.remove(didChangeVisibilityDisposable)
       @disposables.remove(didDestroyDisposable)
       @shouldUpdateHiddenInputState = true
-      @updateCursorState(cursor, true)
+      @shouldUpdateCursorsState = true
 
       @emitDidUpdateState()
 
@@ -1389,8 +1386,9 @@ class TextEditorPresenter
   didAddCursor: (cursor) ->
     @observeCursor(cursor)
     @shouldUpdateHiddenInputState = true
+    @shouldUpdateCursorsState = true
     @pauseCursorBlinking()
-    @updateCursorState(cursor)
+
     @emitDidUpdateState()
 
   startBlinkingCursors: ->

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -418,8 +418,6 @@ class TextEditorPresenter
     pixelRect.width = @baseCharacterWidth if pixelRect.width is 0
     @state.content.cursors[cursor.id] = pixelRect
 
-    @emitDidUpdateState()
-
   updateOverlaysState: ->
     return unless @hasOverlayPositionRequirements()
 
@@ -1369,6 +1367,8 @@ class TextEditorPresenter
 
     didChangeVisibilityDisposable = cursor.onDidChangeVisibility =>
       @shouldUpdateCursorsState = true
+
+      @emitDidUpdateState()
 
     didDestroyDisposable = cursor.onDidDestroy =>
       @disposables.remove(didChangePositionDisposable)


### PR DESCRIPTION
While working on character measurement, I spotted a couple of _cursor rendering computations_ that were not batched yet.

This PR fixes that, so that when a cursor changes (e.g. gets added, removed, or moves) we wait until the next frame to update it. This is consistent with how we handle other updates in the presenter and should as well yield some speedups when many cursors are added/removed/moved at once.

Any feedback is very welcome and much appreciated! :eyes: :bow: 

/cc: @nathansobo @maxbrunsfeld @atom/feedback 
