### PR TITLE
:memo: fix pane flex scale doc

### DIFF
--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -84,7 +84,8 @@ class Pane extends Model
 
   # Public: Invoke the given callback when the pane resize
   #
-  # the callback will be invoked when pane's flexScale property changes
+  # The callback will be invoked when pane's flexScale property changes.
+  # Use {::getFlexScale} to get the current value.
   #
   # * `callback` {Function} to be called when the pane is resized
   #
@@ -92,11 +93,13 @@ class Pane extends Model
   onDidChangeFlexScale: (callback) ->
     @emitter.on 'did-change-flex-scale', callback
 
-  # Public: Invoke the given callback with all current and future items.
+  # Public: Invoke the given callback with the current and future values of
+  # {::getFlexScale}.
   #
-  # * `callback` {Function} to be called with current and future items.
-  #   * `item` An item that is present in {::getItems} at the time of
-  #     subscription or that is added at some later time.
+  # * `callback` {Function} to be called with the current and future values of
+  #   the {::getFlexScale} property.
+  #   * `flexScale` {Number} representing the panes `flex-grow`; ability for a
+  #     flex item to grow if necessary.
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   observeFlexScale: (callback) ->


### PR DESCRIPTION
Fixes #8401.

Might consider making `::getFlexScale` and `::setFlexScale` public, as they are pretty essential for controlling / registering the pane’s size from a package.
