### PR TITLE
Fix config.get for schemas with objects

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1110,6 +1110,24 @@ describe "Config", ->
           nestedObject:
             superNestedInt: 36
 
+        expect(atom.config.get("foo")).toEqual {
+          bar:
+            anInt: 12
+            anObject:
+              nestedInt: 24
+              nestedObject:
+                superNestedInt: 36
+        }
+        atom.config.set("foo.bar.anObject.nestedObject.superNestedInt", 37)
+        expect(atom.config.get("foo")).toEqual {
+          bar:
+            anInt: 12
+            anObject:
+              nestedInt: 24
+              nestedObject:
+                superNestedInt: 37
+        }
+
       it 'can set a non-object schema', ->
         schema =
           type: 'integer'

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -865,7 +865,7 @@ class Config
 
     if value?
       defaultValue = @deepClone(defaultValue)
-      value = _.deepExtends(defaultValue, value) if isPlainObject(value) and isPlainObject(defaultValue)
+      value = _.deepExtend(defaultValue, value) if isPlainObject(value) and isPlainObject(defaultValue)
     else
       value = @deepClone(defaultValue)
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -864,8 +864,8 @@ class Config
       defaultValue = _.valueForKeyPath(@defaultSettings, keyPath)
 
     if value?
-      value = @deepClone(value)
-      _.defaults(value, defaultValue) if isPlainObject(value) and isPlainObject(defaultValue)
+      defaultValue = @deepClone(defaultValue)
+      value = _.deepExtends(defaultValue, value) if isPlainObject(value) and isPlainObject(defaultValue)
     else
       value = @deepClone(defaultValue)
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -864,8 +864,8 @@ class Config
       defaultValue = _.valueForKeyPath(@defaultSettings, keyPath)
 
     if value?
-      defaultValue = @deepClone(defaultValue)
-      value = _.deepExtend(defaultValue, value) if isPlainObject(value) and isPlainObject(defaultValue)
+      value = @deepClone(value)
+      @deepDefaults(value, defaultValue) if isPlainObject(value) and isPlainObject(defaultValue)
     else
       value = @deepClone(defaultValue)
 
@@ -927,6 +927,19 @@ class Config
       _.mapObject object, (key, value) => [key, @deepClone(value)]
     else
       object
+
+  deepDefaults: (target) ->
+    result = target
+    i = 0
+    while ++i < arguments.length
+      object = arguments[i]
+      if isPlainObject(result) and isPlainObject(object)
+        for key in Object.keys(object)
+          result[key] = @deepDefaults(result[key], object[key])
+      else
+        if not result?
+          result = @deepClone(object)
+    result
 
   # `schema` will look something like this
   #


### PR DESCRIPTION
The config.get method does not return the default values for objects with properties in a config schema.
### Example

For example the editor config has:
(excerpt taken from [config-schema.coffee](https://github.com/atom/atom/blob/master/src/config-schema.coffee))

``` coffeescript
...
  backUpBeforeSaving:
    type: 'boolean'
    default: false
    description: 'Ensure file contents aren\'t lost if there is an I/O error during save by making a temporary backup copy.'
  invisibles:
    type: 'object'
    properties:
      eol:
        type: ['boolean', 'string']
        default: '\u00ac'
        maximumLength: 1
      space:
        type: ['boolean', 'string']
        default: '\u00b7'
        maximumLength: 1
      tab:
        type: ['boolean', 'string']
        default: '\u00bb'
        maximumLength: 1
      cr:
        type: ['boolean', 'string']
        default: '\u00a4'
        maximumLength: 1
...
```

A call to `atom.config.get('editor')` returns an object with an 'invisibles' value that is an empty object. We are expecting an object containing the default values for the properties in 'invisibles'. 

This result is caused by `_.defaults()` in `@getRawValue()` not being recursive. The lack of a `_.deepDefaults()` lead me to use a bit of a workaround with `_.deepExtends()`. Now with `_.deepExtends()`, the default values are the base while any new values read from the config.cson overwrite the defaults. This way all default values, even nested ones, appear in the result.
### Side-Effect

A side effect of this issue was that atom/settings-view does not properly present the available configuration options from the config schema. The `appendObject()` method in [settings-view/lib/settings-panel.coffee](https://github.com/atom/settings-view/blob/5a115f9e051da32e7af676daf6076d890d8d5e75/lib/settings-panel.coffee) uses the values provided by `config.get(packageName)`. The lack of keys in the value provided to appendObject would lead to objects in the schema disappearing from the SettingsPanel. With this proposed change, the SettingsPanel now properly displays objects and their properties.

See atom/settings-view#386 and atom/settings-view#518.
