### PR TITLE
Issue #8038: add ellipses to "Downloading Update" message

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -8,7 +8,7 @@
       { label: 'Restart and Install Update', command: 'application:install-update', visible: false}
       { label: 'Check for Update', command: 'application:check-for-update', visible: false}
       { label: 'Checking for Update', enabled: false, visible: false}
-      { label: 'Downloading Update', enabled: false, visible: false}
+      { label: 'Downloading Update ...', enabled: false, visible: false}
       { type: 'separator' }
       { label: 'Preferences…', command: 'application:show-settings' }
       { label: 'Open Your Config', command: 'application:open-your-config' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -174,7 +174,7 @@
       { label: 'Restart and Install Update', command: 'application:install-update', visible: false}
       { label: 'Check for Update', command: 'application:check-for-update', visible: false}
       { label: 'Checking for Update', enabled: false, visible: false}
-      { label: 'Downloading Update', enabled: false, visible: false}
+      { label: 'Downloading Update ...', enabled: false, visible: false}
       { type: 'separator' }
       { label: '&Documentation', command: 'application:open-documentation' }
       { label: 'Roadmap', command: 'application:open-roadmap' }


### PR DESCRIPTION
Partially fix to address the lack of download progress by adding ellipses to the "Downlading Update" message.

Solution suggested by @Ivoz in https://github.com/atom/atom/issues/8038#issuecomment-127039291.
