### PR TITLE
Document MenuItem `enabled` and `visible`

### DIFF
--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -86,9 +86,14 @@ class ContextMenuManager
   #   * `label` (Optional) A {String} containing the menu item's label.
   #   * `command` (Optional) A {String} containing the command to invoke on the
   #     target of the right click that invoked the context menu.
+  #   * `enabled` (Optional) A {Boolean} indicating whether the menu item
+  #     should be clickable. Disabled menu items typically appear grayed out.
+  #     Defaults to `true`.
   #   * `submenu` (Optional) An {Array} of additional items.
   #   * `type` (Optional) If you want to create a separator, provide an item
   #      with `type: 'separator'` and no other keys.
+  #   * `visible` (Optional) A {Boolean} indicating whether the menu item
+  #     should appear in the menu. Defaults to `true`.
   #   * `created` (Optional) A {Function} that is called on the item each time a
   #     context menu is created via a right click. You can assign properties to
   #    `this` to dynamically compute the command, label, etc. This method is


### PR DESCRIPTION
The Electron MenuItem[1] `enabled` and `visible` options are exposed to
Atom context menus in menu_helpers.coffee[2] but are not yet documented.
Both options are passed through to Electron.

[1] http://electron.atom.io/docs/v0.31.0/api/menu-item/
[2] https://github.com/atom/atom/blob/v1.0.7/src/menu-helpers.coffee#L49
