### PR TITLE
Bump symbols-view to v0.103.0

### DIFF
--- a/build/tasks/generate-asar-task.coffee
+++ b/build/tasks/generate-asar-task.coffee
@@ -10,7 +10,7 @@ module.exports = (grunt) ->
 
     unpack = [
       '*.node'
-      '.ctags'
+      'ctags-config'
       'ctags-darwin'
       'ctags-linux'
       'ctags-win32.exe'

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "spell-check": "0.59.0",
     "status-bar": "0.78.0",
     "styleguide": "0.44.0",
-    "symbols-view": "0.101.0",
+    "symbols-view": "0.103.0",
     "tabs": "0.82.0",
     "timecop": "0.31.0",
     "tree-view": "0.184.0",


### PR DESCRIPTION
This PR is necessary as part of the Electron upgrade (https://github.com/atom/atom/pull/7877). A bug was discovered in ASAR that causes hidden files to be ignored. We've worked around that problem by renaming the `.ctags` file in symbols-view to `ctags-config`.
