### PR TITLE
Add 'New View For File' to file menu

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -35,6 +35,7 @@
       { label: 'New File', command: 'application:new-file' }
       { label: 'Open…', command: 'application:open' }
       { label: 'Add Project Folder…', command: 'application:add-project-folder' }
+      { label: 'New View For File', command: 'application:new-view-for-file'}
       { label: 'Reopen Last Item', command: 'pane:reopen-closed-item' }
       { type: 'separator' }
       { label: 'Save', command: 'core:save' }

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -7,6 +7,7 @@
       { label: '&Open File…', command: 'application:open-file' }
       { label: 'Open Folder…', command: 'application:open-folder' }
       { label: 'Add Project Folder…', command: 'application:add-project-folder' }
+      { label: 'New View For File', command: 'application:new-view-for-file'}
       { label: 'Reopen Last &Item', command: 'pane:reopen-closed-item' }
       { type: 'separator' }
       { label: '&Save', command: 'core:save' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -7,6 +7,7 @@
       { label: '&Open File…', command: 'application:open-file' }
       { label: 'Open Folder…', command: 'application:open-folder' }
       { label: 'Add Project Folder…', command: 'application:add-project-folder' }
+      { label: 'New View For File', command: 'application:new-view-for-file'}
       { label: 'Reopen Last &Item', command: 'pane:reopen-closed-item' }
       { type: 'separator' }
       { label: 'Se&ttings', command: 'application:show-settings' }

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -127,6 +127,7 @@ atom.commands.add 'atom-workspace',
   'application:unhide-all-applications': -> ipc.send('command', 'application:unhide-all-applications')
   'application:new-window': -> ipc.send('command', 'application:new-window')
   'application:new-file': -> ipc.send('command', 'application:new-file')
+  'application:new-view-for-file': -> @getModel().newViewForActiveTextEditor()
   'application:open': -> ipc.send('command', 'application:open')
   'application:open-file': -> ipc.send('command', 'application:open-file')
   'application:open-folder': -> ipc.send('command', 'application:open-folder')

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -566,6 +566,19 @@ class Workspace extends Model
   confirmClose: (options) ->
     @paneContainer.confirmClose(options)
 
+  # Create a duplicate view of the active pane item if it is an {TextEditor}.
+  #
+  # Adds a copy of the active item to the active pane if the item is an
+  # {TextEditor}, then sets the copy as the active item. Returns the new
+  # {TextEditor} or 'undefined' if the current active item is not an
+  # {TextEditor}.
+  newViewForActiveTextEditor: ->
+    newItem = @getActiveTextEditor()?.copy()
+    if newItem
+      @getActivePane().addItem(newItem)
+      @getActivePane().setActiveItem(newItem)
+    newItem
+
   # Save the active pane item.
   #
   # If the active pane item currently has a URI according to the item's


### PR DESCRIPTION
New option in the file menu to create a new tab for the current active pane item. Only works if the active item is a TextEditor object. The new item is then set as the active item. newViewForActiveTextEditor() returns the new TextEditor or 'undefined' if the active pane item is not a TextEditor. This closes atom/atom#8409.
### Preview

![new-view-for-file](https://cloud.githubusercontent.com/assets/3977054/9483900/03921fbe-4b5a-11e5-8028-36abe230691e.gif)
### Note

No spec for this yet, because I am not sure which spec this should belong to. Might want to change the command name from `application:new-view-for-file` to something else. I was not sure if it should be 'application' or 'pane' in the command.
