### PR TITLE
Add Remove Trailing Whitespace editor option

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -217,6 +217,10 @@ module.exports =
         type: 'boolean'
         default: process.platform isnt 'darwin'
         description: 'Increase/decrease the editor font size when pressing the Ctrl key and scrolling the mouse up/down.'
+      removeTrailingWhitespace:
+        type: 'boolean'
+        default: 'false'
+        description: 'Remove the trailing whitespace from the previous line on newline.'
 
 if process.platform in ['win32', 'linux']
   module.exports.core.properties.autoHideMenuBar =

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -361,6 +361,8 @@ class Selection extends Model
   #     (for example, when a closing bracket is inserted).
   #   * `normalizeLineEndings` (optional) {Boolean} (default: true)
   #   * `undo` if `skip`, skips the undo stack for this operation.
+  #   * 'removeTrailingWhitespace' if 'true', removes the trailing whitespace
+  #     from the previous line on newline.
   insertText: (text, options={}) ->
     oldBufferRange = @getBufferRange()
     @editor.unfoldBufferRow(oldBufferRange.end.row)
@@ -398,6 +400,8 @@ class Selection extends Model
 
     if options.autoIndentNewline and text is '\n'
       @editor.autoIndentBufferRow(newBufferRange.end.row, preserveLeadingWhitespace: true, skipBlankLines: false)
+      if options.removeTrailingWhitespace and @editor.isBufferRowBlank(newBufferRange.start.row)
+        @editor.setIndentationForBufferRow(newBufferRange.start.row, 0)
     else if options.autoDecreaseIndent and NonWhitespaceRegExp.test(text)
       @editor.autoDecreaseIndentForBufferRow(newBufferRange.start.row)
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -787,6 +787,7 @@ class TextEditor extends Model
 
     options.autoIndentNewline ?= @shouldAutoIndent()
     options.autoDecreaseIndent ?= @shouldAutoIndent()
+    options.removeTrailingWhitespace ?= @shouldRemoveTrailingWhitespace()
     @mutateSelectedText(
       (selection) =>
         range = selection.insertText(text, options)
@@ -2905,6 +2906,9 @@ class TextEditor extends Model
 
   shouldAutoIndentOnPaste: ->
     atom.config.get("editor.autoIndentOnPaste", scope: @getRootScopeDescriptor())
+
+  shouldRemoveTrailingWhitespace: ->
+    atom.config.get("editor.removeTrailingWhitespace", scope: @getRootScopeDescriptor())
 
   ###
   Section: Event Handlers


### PR DESCRIPTION
The editor settings now include an option to remove the trailing whitespace before an inserted newline. This option is disabled by default in order to prevent the sudden change of the editor's indent functionality.

![screen shot 2015-08-25 at 11 50 39 pm](https://cloud.githubusercontent.com/assets/3977054/9487177/229b0e82-4b84-11e5-99a4-7813ad5a7604.png)
### In Action

![remove-trailing-whitespace](https://cloud.githubusercontent.com/assets/3977054/9487486/d3d941ee-4b86-11e5-9e99-be5675a1b0a2.gif)
The boxes signify lines where there was a leftover indent after a newline command. Once enabling remove trailing whitespace, new lines have their indents set to nothing. Lines with anything besides whitespace will not be effected. The newline will continue to have it's indent.
### Note

This should be pretty easy to write a spec for if it is approved as a good change. This closes #7828.
