### PR TITLE
Upgrade apm for Windows path length issues

### DIFF
--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "1.0.2"
+    "atom-package-manager": "1.0.4"
   }
 }


### PR DESCRIPTION
CI on Windows is currently failing with:

```
Running "create-windows-installer:installer" (create-windows-installer) task
>> The specified path, file name, or both are too long. The fully qualified file name must be less than 260 characters, and the directory name must be less than 248 characters.
Error: Command failed: The specified path, file name, or both are too long. The fully qualified file name must be less than 260 characters, and the directory name must be less than 248 characters.

  at ChildProcess.exithandler (child_process.js:637:15)
  at ChildProcess.EventEmitter.emit (events.js:98:17)
  at maybeClose (child_process.js:735:16)
  at Process.ChildProcess._handle.onexit (child_process.js:802:5)
```

I believe the paths in the `yargs` dependency of `apm` are causing this.

I'm pinning the `yargs` version for now to see if it resolves this issue.

Closes https://github.com/atom/atom/issues/8528
