### PR TITLE
Document all options for creating Notifications

### DIFF
--- a/src/notification-manager.coffee
+++ b/src/notification-manager.coffee
@@ -29,40 +29,65 @@ class NotificationManager
   # Public: Add a success notification.
   #
   # * `message` A {String} message
-  # * `options` An options {Object} with optional keys such as:
-  #    * `detail` A {String} with additional details about the notification
+  # * `options` (optional) An options {Object} with the following keys:
+  #    * `detail` (optional) A {String} with additional details about the
+  #      notification.
+  #    * `dismissable` (optional) A {Boolean} indicating whether this
+  #      notification can be dismissed by the user. Defaults to `false`.
+  #    * `icon` (optional) A {String} name of an icon from Octicons to display
+  #      in the notification header. Defaults to `'check'`.
   addSuccess: (message, options) ->
     @addNotification(new Notification('success', message, options))
 
   # Public: Add an informational notification.
   #
   # * `message` A {String} message
-  # * `options` An options {Object} with optional keys such as:
-  #    * `detail` A {String} with additional details about the notification
+  # * `options` (optional) An options {Object} with the following keys:
+  #    * `detail` (optional) A {String} with additional details about the
+  #      notification.
+  #    * `dismissable` (optional) A {Boolean} indicating whether this
+  #      notification can be dismissed by the user. Defaults to `false`.
+  #    * `icon` (optional) A {String} name of an icon from Octicons to display
+  #      in the notification header. Defaults to `'info'`.
   addInfo: (message, options) ->
     @addNotification(new Notification('info', message, options))
 
   # Public: Add a warning notification.
   #
   # * `message` A {String} message
-  # * `options` An options {Object} with optional keys such as:
-  #    * `detail` A {String} with additional details about the notification
+  # * `options` (optional) An options {Object} with the following keys:
+  #    * `detail` (optional) A {String} with additional details about the
+  #      notification.
+  #    * `dismissable` (optional) A {Boolean} indicating whether this
+  #      notification can be dismissed by the user. Defaults to `false`.
+  #    * `icon` (optional) A {String} name of an icon from Octicons to display
+  #      in the notification header. Defaults to `'alert'`.
   addWarning: (message, options) ->
     @addNotification(new Notification('warning', message, options))
 
   # Public: Add an error notification.
   #
   # * `message` A {String} message
-  # * `options` An options {Object} with optional keys such as:
-  #    * `detail` A {String} with additional details about the notification
+  # * `options` (optional) An options {Object} with the following keys:
+  #    * `detail` (optional) A {String} with additional details about the
+  #      notification.
+  #    * `dismissable` (optional) A {Boolean} indicating whether this
+  #      notification can be dismissed by the user. Defaults to `false`.
+  #    * `icon` (optional) A {String} name of an icon from Octicons to display
+  #      in the notification header. Defaults to `'flame'`.
   addError: (message, options) ->
     @addNotification(new Notification('error', message, options))
 
   # Public: Add a fatal error notification.
   #
   # * `message` A {String} message
-  # * `options` An options {Object} with optional keys such as:
-  #    * `detail` A {String} with additional details about the notification
+  # * `options` (optional) An options {Object} with the following keys:
+  #    * `detail` (optional) A {String} with additional details about the
+  #      notification.
+  #    * `dismissable` (optional) A {Boolean} indicating whether this
+  #      notification can be dismissed by the user. Defaults to `false`.
+  #    * `icon` (optional) A {String} name of an icon from Octicons to display
+  #      in the notification header. Defaults to `'bug'`.
   addFatalError: (message, options) ->
     @addNotification(new Notification('fatal', message, options))
 


### PR DESCRIPTION
- The defaults for the 'icon' values come from [Notification::getIcon][0].
- `dismissable` defaults to `!!options.dismissable`, which equates to `false` for `undefined`.

[0]:
https://github.com/atom/atom/blob/v1.0.7/src/notification.coffee#L79
