### PR TITLE
Remove redundant calls to buffer-to-screen conversion methods

### DIFF
--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -416,9 +416,10 @@ class TextEditorPresenter
 
   updateCursorState: (cursor) ->
     return unless @startRow? and @endRow? and @hasPixelRectRequirements() and @baseCharacterWidth?
-    return unless cursor.isVisible() and @startRow <= cursor.getScreenRow() < @endRow
+    screenRange = cursor.getScreenRange()
+    return unless cursor.isVisible() and @startRow <= screenRange.start.row < @endRow
 
-    pixelRect = @pixelRectForScreenRange(cursor.getScreenRange())
+    pixelRect = @pixelRectForScreenRange(screenRange)
     pixelRect.width = @baseCharacterWidth if pixelRect.width is 0
     @state.content.cursors[cursor.id] = pixelRect
 
@@ -1166,7 +1167,7 @@ class TextEditorPresenter
         if decoration.isType('line') or decoration.isType('gutter')
           @addToLineDecorationCaches(decoration, range)
         else if decoration.isType('highlight')
-          @updateHighlightState(decoration)
+          @updateHighlightState(decoration, range)
 
     for tileId, tileState of @state.content.tiles
       for id, highlight of tileState.highlights
@@ -1237,12 +1238,11 @@ class TextEditorPresenter
 
     intersectingRange
 
-  updateHighlightState: (decoration) ->
+  updateHighlightState: (decoration, range) ->
     return unless @startRow? and @endRow? and @lineHeight? and @hasPixelPositionRequirements()
 
     properties = decoration.getProperties()
     marker = decoration.getMarker()
-    range = marker.getScreenRange()
 
     if decoration.isDestroyed() or not marker.isValid() or range.isEmpty() or not range.intersectsRowRange(@startRow, @endRow - 1)
       return


### PR DESCRIPTION
Some methods in `TextEditorPresenter` were calling buffer-to-screen conversion methods more than once, causing unnecessary slowdowns when many cursors/decorations were in place.

Before:

![screen shot 2015-08-27 at 11 36 19](https://cloud.githubusercontent.com/assets/482957/9517510/cd605688-4cb0-11e5-9b34-0bd1f5d9921e.png)

After:

![screen shot 2015-08-27 at 11 36 04](https://cloud.githubusercontent.com/assets/482957/9517511/cff9de46-4cb0-11e5-8d6a-6e711cd23cfa.png)

_(benchmarks executed on a file with ~ 3k rows full of cursors and decorations)_

 :racehorse: 

Ideally, we shouldn't need to be conservative about such kinds of calls but that would require to address the problem from a totally different perspective and, on the other hand, this is a fairly quick win we can take advantage of in the meantime.

/cc: @maxbrunsfeld @nathansobo @atom/feedback 
