### PR TITLE
Clean up max scroll margin code

### DIFF
--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -1214,7 +1214,7 @@ describe "TextEditorPresenter", ->
 
           # showing
           expectStateUpdate presenter, -> editor.getSelections()[1].clear()
-          expect(stateForCursor(presenter, 1)).toEqual {top: 5, left: 5 * 10, width: 10, height: 10}
+          expect(stateForCursor(presenter, 1)).toEqual {top: 0, left: 5 * 10, width: 10, height: 10}
 
           # hiding
           expectStateUpdate presenter, -> editor.getSelections()[1].setBufferRange([[3, 4], [3, 5]])
@@ -1226,11 +1226,11 @@ describe "TextEditorPresenter", ->
 
           # adding
           expectStateUpdate presenter, -> editor.addCursorAtBufferPosition([4, 4])
-          expect(stateForCursor(presenter, 2)).toEqual {top: 5, left: 4 * 10, width: 10, height: 10}
+          expect(stateForCursor(presenter, 2)).toEqual {top: 0, left: 4 * 10, width: 10, height: 10}
 
           # moving added cursor
           expectStateUpdate presenter, -> editor.getCursors()[2].setBufferPosition([4, 6])
-          expect(stateForCursor(presenter, 2)).toEqual {top: 5, left: 6 * 10, width: 10, height: 10}
+          expect(stateForCursor(presenter, 2)).toEqual {top: 0, left: 6 * 10, width: 10, height: 10}
 
           # destroying
           destroyedCursor = editor.getCursors()[2]

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -177,21 +177,18 @@ class DisplayBuffer extends Model
   # visible - A {Boolean} indicating of the tokenized buffer is shown
   setVisible: (visible) -> @tokenizedBuffer.setVisible(visible)
 
-  getVerticalScrollMargin: -> Math.min(@verticalScrollMargin, (@getHeight() - @getLineHeightInPixels()) / 2)
+  getVerticalScrollMargin: ->
+    maxScrollMargin = Math.floor(((@getHeight() / @getLineHeightInPixels()) - 1) / 2)
+    Math.min(@verticalScrollMargin, maxScrollMargin)
+
   setVerticalScrollMargin: (@verticalScrollMargin) -> @verticalScrollMargin
 
-  getVerticalScrollMarginInPixels: ->
-    scrollMarginInPixels = @getVerticalScrollMargin() * @getLineHeightInPixels()
-    maxScrollMarginInPixels = (@getHeight() - @getLineHeightInPixels()) / 2
-    Math.min(scrollMarginInPixels, maxScrollMarginInPixels)
+  getVerticalScrollMarginInPixels: -> @getVerticalScrollMargin() * @getLineHeightInPixels()
 
-  getHorizontalScrollMargin: -> Math.min(@horizontalScrollMargin, (@getWidth() - @getDefaultCharWidth()) / 2)
+  getHorizontalScrollMargin: -> Math.min(@horizontalScrollMargin, Math.floor(((@getWidth() / @getDefaultCharWidth()) - 1) / 2))
   setHorizontalScrollMargin: (@horizontalScrollMargin) -> @horizontalScrollMargin
 
-  getHorizontalScrollMarginInPixels: ->
-    scrollMarginInPixels = @getHorizontalScrollMargin() * @getDefaultCharWidth()
-    maxScrollMarginInPixels = (@getWidth() - @getDefaultCharWidth()) / 2
-    Math.min(scrollMarginInPixels, maxScrollMarginInPixels)
+  getHorizontalScrollMarginInPixels: -> scrollMarginInPixels = @getHorizontalScrollMargin() * @getDefaultCharWidth()
 
   getHorizontalScrollbarHeight: -> @horizontalScrollbarHeight
   setHorizontalScrollbarHeight: (@horizontalScrollbarHeight) -> @horizontalScrollbarHeight


### PR DESCRIPTION
Previously we were attempting the same computation twice, once incorrectly when returning the scroll margins as integers and then doing the same thing in terms of pixels. This just cleans up the original calculation. It’s _slightly_ different because it takes the floor to continue returning integers, but the behavior is extremely close.
