### PR TITLE
prevent use of socket in apm test

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -65,6 +65,8 @@ class AtomApplication
   constructor: (options) ->
     {@resourcePath, @devResourcePath, @version, @devMode, @safeMode, @socketPath} = options
 
+    @socketPath = null if options.test
+
     global.atomApplication = this
 
     @pidsToOpenWindows = {}
@@ -130,6 +132,7 @@ class AtomApplication
   # the other launches will just pass their information to this server and then
   # close immediately.
   listenForArgumentsFromNewProcess: ->
+    return unless @socketPath?
     @deleteSocketFile()
     server = net.createServer (connection) =>
       connection.on 'data', (data) =>
@@ -139,7 +142,7 @@ class AtomApplication
     server.on 'error', (error) -> console.error 'Application server failed', error
 
   deleteSocketFile: ->
-    return if process.platform is 'win32'
+    return if process.platform is 'win32' or not @socketPath?
 
     if fs.existsSync(@socketPath)
       try


### PR DESCRIPTION
When I run `apm test` while having another Atom window open (on a mac, if that matters), the new Atom instance screws with the socket file: it deletes the original socket on start [here](https://github.com/atom/atom/blob/5e5139b753b9c24b2671064f3b1eceabb31112d9/src/browser/atom-application.coffee#L136), creates its own and deletes that on exit.

That means that after `apm test`, `atom .` no longer opens in the original (still running) window.

Even worse, during `apm test`, `atom .` will open a window in the instance running the tests, which then happily dies (taking the new window with it) when the specs are done.

Comments on the PR welcome.
