### PR TITLE
:bug: make atom protocol urls more robust

### DIFF
--- a/spec/atom-protocol-handler-spec.coffee
+++ b/spec/atom-protocol-handler-spec.coffee
@@ -1,15 +1,23 @@
 {$} = require '../src/space-pen-extensions'
 
+fetch = (url, callback) ->
+  $.ajax
+    url: url
+    success: callback
+    # In old versions of jQuery, ajax calls to custom protocol would always
+    # be treated as error eventhough the browser thinks it's a success
+    # request.
+    error: callback
+  
+
 describe '"atom" protocol URL', ->
   it 'sends the file relative in the package as response', ->
-    called = false
-    callback = -> called = true
-    $.ajax
-      url: 'atom://async/package.json'
-      success: callback
-      # In old versions of jQuery, ajax calls to custom protocol would always
-      # be treated as error eventhough the browser thinks it's a success
-      # request.
-      error: callback
+    called = 0
+    callback = -> called += 1
+    fetch('atom://async/package.json', callback)
+    fetch('atom://async/package.json#some-hash', callback)
+    fetch('atom://async/package.json?some&params=value', callback)
+    fetch('atom://async/package.json?', callback) # test edge-case
+    fetch('atom://async/package.json#', callback) # test edge-case
 
-    waitsFor 'request to be done', -> called is true
+    waitsFor 'request to be done', -> called is 5

--- a/src/browser/atom-protocol-handler.coffee
+++ b/src/browser/atom-protocol-handler.coffee
@@ -30,7 +30,7 @@ class AtomProtocolHandler
   # Creates the 'atom' custom protocol handler.
   registerAtomProtocol: ->
     protocol.registerProtocol 'atom', (request) =>
-      relativePath = path.normalize(request.url.substr(7))
+      relativePath = path.normalize(request.url.substr(7).split(/[\?\#]/)[0])
 
       if relativePath.indexOf('assets/') is 0
         assetsPath = path.join(process.env.ATOM_HOME, relativePath)


### PR DESCRIPTION
I wanted to bundle some fonts to my package as described here: https://atom.io/docs/v0.186.0/creating-a-package#bundle-external-resources.

It didn't work and after diving into Atom's sources I realised that the problem is translation of urls to file-system paths. In my case urls contained extra url parameters, e.g. `atom://plastic-clojurescript/fonts/eot/hack-regularoblique-webfont.eot?v=2.010`

I have modified the code to strip parts after question mark or hash from urls. That was a quick fix.

Possible future improvement could be using some robust library for proper url parsing.
