### PR TITLE
upgrades yargs dependency to ^3.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "theorist": "^1.0.2",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",
-    "yargs": "3.19.0"
+    "yargs": "^3.23.0"
   },
   "packageDependencies": {
     "atom-dark-syntax": "0.27.0",


### PR DESCRIPTION
`yargs@3.23.0` eliminates the dependency on spawn-sync, to prevent regressions like we had last week yargs now has:

windows testing via AppVeyor: https://ci.appveyor.com/project/bcoe/yargs

_and_

OSX testing via Travis: https://travis-ci.org/bcoe/yargs
