### PR TITLE
San Francisco font on El Capitan Beta

### DIFF
--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -82,4 +82,4 @@
 
 // Other
 
-@font-family: 'SF UI Text', 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;
+@font-family: '.SFNSText-Regular', 'SF UI Text', 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;


### PR DESCRIPTION
This PR adds support for the bundled system font (San Francisco) that ships in El Capitan **Beta**.

The font stack will be:
1. `.SFNSText-Regular`: San Francisco on OS X El Capitan **Beta**.
2. `SF UI Text`: San Francisco on OS X when the downloaded version is installed.
3. `Lucida Grande`: <= OS X Yosemite.
4. `Segoe UI`: Windows
5. `Ubuntu`: Linux (Ubuntu)
6. `Cantarell, sans-serif`: Fallback

Closes #8594

**Note**: Most themes will override the `@font-family` variable, but still good to add as "default".
