### PR TITLE
Fix install on a symlinked $INSTALL_DIR/bin

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -86,8 +86,8 @@ if [ $OS == 'Mac' ]; then
     open -a "$ATOM_PATH/$ATOM_APP_NAME" -n --args --executed-from="$(pwd)" --pid=$$ --path-environment="$PATH" "$@"
   fi
 elif [ $OS == 'Linux' ]; then
-  SCRIPT=$(readlink -f "$0")
-  USR_DIRECTORY=$(readlink -f $(dirname $SCRIPT)/..)
+  BIN_DIRECTORY=$(cd $(dirname "$0") >& /dev/null ; pwd -L)
+  USR_DIRECTORY=$(dirname "$BIN_DIRECTORY")
 
   if [ -n "$BETA_VERSION" ]; then
     ATOM_PATH="$USR_DIRECTORY/share/atom-beta/atom"

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -50,7 +50,7 @@ module.exports = (grunt) ->
 
       rm(path.join(binDir, apmFileName))
       fs.symlinkSync(
-        path.join('..', 'share', appFileName, 'resources', 'app', 'apm', 'node_modules', '.bin', 'apm'),
+        path.join(shareDir, 'resources', 'app', 'apm', 'node_modules', '.bin', 'apm'),
         path.join(binDir, apmFileName)
       )
 


### PR DESCRIPTION
The installation script `script/grub install --install-dir $INSTALL_DIR`
is broken on linux machines if `$INSTALL_DIR/bin` happens to be a
symlinked folder.

This PR fixes the installation task `build/tasks/install-task.coffee`
and the launching script `atom.sh` to allow for symlinked folders.
