### PR TITLE
Update notification-manager.coffee

### DIFF
--- a/src/notification-manager.coffee
+++ b/src/notification-manager.coffee
@@ -80,7 +80,7 @@ class NotificationManager
 
   # Public: Get all the notifications.
   #
-  # Returns an {Array} of {Notifications}s.
+  # Returns an {Array} of {Notification}s.
   getNotifications: -> @notifications.slice()
 
   ###


### PR DESCRIPTION
Fix a broken link in the docs page for https://atom.io/docs/api/v1.0.10/NotificationManager. The link from `getNotifications` points to a `Notifications` class instead of `Notification`.
