### PR TITLE
Stop highlighting at the end of the line

### DIFF
--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -20,7 +20,7 @@ class TextEditorPresenter
     @measuredHorizontalScrollbarHeight = horizontalScrollbarHeight
     @measuredVerticalScrollbarWidth = verticalScrollbarWidth
     @gutterWidth ?= 0
-    @tileSize ?= 12
+    @tileSize = 1
 
     @disposables = new CompositeDisposable
     @emitter = new Emitter
@@ -1313,10 +1313,7 @@ class TextEditorPresenter
         height: lineHeightInPixels
         left: startPixelPosition.left
 
-      if screenRange.end.column is Infinity
-        region.right = 0
-      else
-        region.width = endPixelPosition.left - startPixelPosition.left
+      region.width = endPixelPosition.left - startPixelPosition.left
 
       regions.push(region)
     else


### PR DESCRIPTION
Editors like Sublime and Code do not highlight the entire line when doing a multi-line selection, instead they stop after the last character on that line.

I wanted to implement the same thing on Atom. The way I did it is very hacky and not production ready but it gets the job done. Right now, if you highlight 5 lines, the first and last lines are their own "tile" and all the remaining ones are grouped into a single rectangular tile. Since we want to have each line with a different width, I forced the tile size to 1 and removed the logic that makes it expand all the way.

I'd really like this feature to be in atom, let me know how I can refactor the code to make it shippable. Thanks

Different editors (top left: sublime, bottom left: code, top right: atom):
<img width="856" alt="screen shot 2015-09-01 at 12 36 01 pm" src="https://cloud.githubusercontent.com/assets/197597/9636605/35881db4-5151-11e5-9827-b81e784e5e78.png">

Before:
<img width="519" alt="screen shot 2015-09-01 at 5 33 00 pm" src="https://cloud.githubusercontent.com/assets/197597/9636627/4b90e5be-5151-11e5-827f-94e420397f78.png">

After:
<img width="516" alt="screen shot 2015-09-01 at 5 32 29 pm" src="https://cloud.githubusercontent.com/assets/197597/9636630/50dd3ad6-5151-11e5-9584-673bfcca1e01.png">
