### PR TITLE
Roll back multi-cursor undo fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "space-pen": "3.8.2",
     "stacktrace-parser": "0.1.1",
     "temp": "0.8.1",
-    "text-buffer": "6.7.0",
+    "text-buffer": "6.6.1",
     "theorist": "^1.0.2",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",

--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1025,7 +1025,7 @@ describe "DisplayBuffer", ->
         markerChangedHandler.reset()
         marker2ChangedHandler.reset()
 
-        marker3 = displayBuffer.markBufferRange([[8, 1], [8, 2]])
+        marker3 = displayBuffer.markBufferRange([[8, 1], [8, 2]], maintainHistory: true)
         marker3.onDidChange marker3ChangedHandler = jasmine.createSpy("marker3ChangedHandler")
 
         onDisplayBufferChange = ->
@@ -1038,6 +1038,10 @@ describe "DisplayBuffer", ->
           expect(marker.getScreenRange()).toEqual [[5, 4], [5, 10]]
           expect(marker.getHeadScreenPosition()).toEqual [5, 10]
           expect(marker.getTailScreenPosition()).toEqual [5, 4]
+
+          # but marker snapshots are not restored until the end of the undo.
+          expect(marker2.isValid()).toBeFalsy()
+          expect(marker3.isValid()).toBeFalsy()
 
         buffer.undo()
         expect(changeHandler).toHaveBeenCalled()
@@ -1074,6 +1078,8 @@ describe "DisplayBuffer", ->
         expect(markerChangedHandler).toHaveBeenCalled()
         expect(marker2ChangedHandler).toHaveBeenCalled()
         expect(marker3ChangedHandler).toHaveBeenCalled()
+        expect(marker2.isValid()).toBeFalsy()
+        expect(marker3.isValid()).toBeTruthy()
 
       it "updates the position of markers before emitting change events that aren't caused by a buffer change", ->
         displayBuffer.onDidChange changeHandler = jasmine.createSpy("changeHandler").andCallFake ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3436,63 +3436,6 @@ describe "TextEditor", ->
         expect(buffer.lineForRow(0)).not.toContain "foo"
         expect(buffer.lineForRow(0)).toContain "fovar"
 
-      it "restores cursors and selections to their states before and after undone and redone changes", ->
-        editor.setSelectedBufferRanges([
-          [[0, 0], [0, 0]],
-          [[1, 0], [1, 3]],
-        ])
-        editor.insertText("abc")
-
-        expect(editor.getSelectedBufferRanges()).toEqual [
-          [[0, 3], [0, 3]],
-          [[1, 3], [1, 3]]
-        ]
-
-        editor.setCursorBufferPosition([0, 0])
-        editor.setSelectedBufferRanges([
-          [[2, 0], [2, 0]],
-          [[3, 0], [3, 0]],
-          [[4, 0], [4, 3]],
-        ])
-        editor.insertText("def")
-
-        expect(editor.getSelectedBufferRanges()).toEqual [
-          [[2, 3], [2, 3]],
-          [[3, 3], [3, 3]]
-          [[4, 3], [4, 3]]
-        ]
-
-        editor.setCursorBufferPosition([0, 0])
-        editor.undo()
-
-        expect(editor.getSelectedBufferRanges()).toEqual [
-          [[2, 0], [2, 0]],
-          [[3, 0], [3, 0]],
-          [[4, 0], [4, 3]],
-        ]
-
-        editor.undo()
-
-        expect(editor.getSelectedBufferRanges()).toEqual [
-          [[0, 0], [0, 0]],
-          [[1, 0], [1, 3]]
-        ]
-
-        editor.redo()
-
-        expect(editor.getSelectedBufferRanges()).toEqual [
-          [[0, 3], [0, 3]],
-          [[1, 3], [1, 3]]
-        ]
-
-        editor.redo()
-
-        expect(editor.getSelectedBufferRanges()).toEqual [
-          [[2, 3], [2, 3]],
-          [[3, 3], [3, 3]]
-          [[4, 3], [4, 3]]
-        ]
-
       it "restores the selected ranges after undo and redo", ->
         editor.setSelectedBufferRanges([[[1, 6], [1, 10]], [[1, 22], [1, 27]]])
         editor.delete()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1106,12 +1106,12 @@ class TextEditor extends Model
 
   # Essential: Undo the last change.
   undo: ->
-    @avoidMergingSelections => @buffer.undo()
+    @buffer.undo()
     @getLastSelection().autoscroll()
 
   # Essential: Redo the last change.
   redo: ->
-    @avoidMergingSelections => @buffer.redo()
+    @buffer.redo(this)
     @getLastSelection().autoscroll()
 
   # Extended: Batch multiple operations as a single undo/redo step.
@@ -2205,9 +2205,6 @@ class TextEditor extends Model
       screenRange = currentSelection.getScreenRange()
 
       previousSelection.intersectsScreenRowRange(screenRange.start.row, screenRange.end.row)
-
-  avoidMergingSelections: (args...) ->
-    @mergeSelections args..., -> false
 
   mergeSelections: (args...) ->
     mergePredicate = args.pop()


### PR DESCRIPTION
Refs #8506

This is causing issues when undoing after splitting the editors. This is because the cursor of the second editor isn't visible in the snapshots prior to undo and is getting destroyed, leaving us with zero cursors. We're going to need to re-release once this is merged.
