### PR TITLE
Update selection and cursor state atomically before emitting any events

### DIFF
--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -22,32 +22,6 @@ class Cursor extends Model
 
     @assignId(id)
     @updateVisibility()
-    @marker.onDidChange (e) =>
-      @updateVisibility()
-      {oldHeadScreenPosition, newHeadScreenPosition} = e
-      {oldHeadBufferPosition, newHeadBufferPosition} = e
-      {textChanged} = e
-      return if oldHeadScreenPosition.isEqual(newHeadScreenPosition)
-
-      @goalColumn = null
-
-      movedEvent =
-        oldBufferPosition: oldHeadBufferPosition
-        oldScreenPosition: oldHeadScreenPosition
-        newBufferPosition: newHeadBufferPosition
-        newScreenPosition: newHeadScreenPosition
-        textChanged: textChanged
-        cursor: this
-
-      @emit 'moved', movedEvent if Grim.includeDeprecatedAPIs
-      @emitter.emit 'did-change-position', movedEvent
-      @editor.cursorMoved(movedEvent)
-    @marker.onDidDestroy =>
-      @destroyed = true
-      @editor.removeCursor(this)
-      @emit 'destroyed' if Grim.includeDeprecatedAPIs
-      @emitter.emit 'did-destroy'
-      @emitter.dispose()
 
   destroy: ->
     @marker.destroy()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1761,18 +1761,11 @@ class TextEditor extends Model
     @emitter.emit 'did-add-cursor', cursor
     cursor
 
-  # Remove the given cursor from this editor.
-  removeCursor: (cursor) ->
-    _.remove(@cursors, cursor)
-    @emit 'cursor-removed', cursor if includeDeprecatedAPIs
-    @emitter.emit 'did-remove-cursor', cursor
-
   moveCursors: (fn) ->
     fn(cursor) for cursor in @getCursors()
     @mergeCursors()
 
   cursorMoved: (event) ->
-    @emit 'cursor-moved', event if includeDeprecatedAPIs
     @emitter.emit 'did-change-cursor-position', event
 
   # Merge cursors that have the same screen position
@@ -2259,9 +2252,9 @@ class TextEditor extends Model
 
   # Remove the given selection.
   removeSelection: (selection) ->
+    _.remove(@cursors, selection.cursor)
     _.remove(@selections, selection)
-    atom.assert @selections.length > 0, "Removed last selection"
-    @emit 'selection-removed', selection if includeDeprecatedAPIs
+    @emitter.emit 'did-remove-cursor', selection.cursor
     @emitter.emit 'did-remove-selection', selection
 
   # Reduce one or more selections to a single empty selection based on the most
@@ -2281,7 +2274,6 @@ class TextEditor extends Model
 
   # Called by the selection
   selectionRangeChanged: (event) ->
-    @emit 'selection-screen-range-changed', event if includeDeprecatedAPIs
     @emitter.emit 'did-change-selection-range', event
 
   createLastSelectionIfNeeded: ->


### PR DESCRIPTION
This ensures we correctly restore the last cursor when handling a cursor destruction event. It fixes an exception that occurred when undoing after splitting an editor and supplants #8641.

It also removes some deprecated APIs that were in the path of our changes.
