### PR TITLE
remove atomShellVersion

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "atomShellVersion": "0.22.3",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^5.1.10",


### PR DESCRIPTION
Remove "atomShellVersion" in package.json.

Whats about "ElectronVersion"?
