### PR TITLE
SelectLine : When multiple lines selected, complete both first and last line

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1299,6 +1299,13 @@ describe "TextEditor", ->
         editor.selectLinesContainingCursors()
         expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [2, 0]]
 
+      describe "when selection span multiple row", ->
+        it "complete selection to contain the entire first and last line", ->
+          selection = editor.getLastSelection()
+          selection.setBufferRange [[1, 10], [3, 20]]
+          editor.selectLinesContainingCursors()
+          expect(editor.getSelectedBufferRange()).toEqual [[1, 0], [4, 0]]
+
       it "autoscrolls to the selection", ->
         editor.setLineHeightInPixels(10)
         editor.setDefaultCharWidth(10)

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -324,9 +324,18 @@ class Selection extends Model
   #
   # * `row` The line {Number} to select (default: the row of the cursor).
   selectLine: (row, options) ->
-    row ?= @cursor.getBufferPosition().row
-    range = @editor.bufferRangeForBufferRow(row, includeNewline: true)
-    @setBufferRange(@getBufferRange().union(range), options)
+
+    if row?
+      range = @editor.bufferRangeForBufferRow(row, includeNewline: true)
+      @setBufferRange(@getBufferRange().union(range), options)
+
+    else
+      rowStart = @marker.getStartBufferPosition().row
+      rangeStart = @editor.bufferRangeForBufferRow(rowStart, includeNewline: true)
+      rowEnd = @marker.getEndBufferPosition().row
+      rangeEnd = @editor.bufferRangeForBufferRow(rowEnd, includeNewline: true)
+      @setBufferRange(@getBufferRange().union(rangeStart).union(rangeEnd), options)
+
     @linewise = true
     @wordwise = false
     @initialScreenRange = @getScreenRange()


### PR DESCRIPTION
Possible fix for https://github.com/atom/atom/issues/3624.

Problem is that line completion was triggered only on cursor line.
Other editor like sublime will complete the missing selection both before the start and after the end of a multi-lines selection.
## Before

![before](https://cloud.githubusercontent.com/assets/12763666/9647785/8e44bfe0-51ae-11e5-8fed-4267d8107c03.gif)
## After

![after](https://cloud.githubusercontent.com/assets/12763666/9647786/939f7f2a-51ae-11e5-903a-fa0f8c7d8032.gif)
