### PR TITLE
Avoid pairing null byte characters

### DIFF
--- a/spec/text-utils-spec.coffee
+++ b/spec/text-utils-spec.coffee
@@ -17,6 +17,9 @@ describe 'text utilities', ->
       expect(textUtils.hasPairedCharacter('\uFE0E\uFE0E')).toBe false
       expect(textUtils.hasPairedCharacter('\u0301\u0301')).toBe false
 
+      expect(textUtils.hasPairedCharacter('\0\u0301')).toBe false
+      expect(textUtils.hasPairedCharacter('\0\uFE0E')).toBe false
+
   describe '.isPairedCharacter(string, index)', ->
     it 'returns true when the index is the start of a high/low surrogate pair, variation sequence, or combined character', ->
       expect(textUtils.isPairedCharacter('a\uD835\uDF97b\uD835\uDF97c', 0)).toBe false
@@ -44,3 +47,6 @@ describe 'text utilities', ->
       expect(textUtils.isPairedCharacter('ae\u0301c', 2)).toBe false
       expect(textUtils.isPairedCharacter('ae\u0301c', 3)).toBe false
       expect(textUtils.isPairedCharacter('ae\u0301c', 4)).toBe false
+
+      expect(textUtils.isPairedCharacter('\0\u0301c', 0)).toBe false
+      expect(textUtils.isPairedCharacter('\0\uFE0E', 0)).toBe false

--- a/src/text-utils.coffee
+++ b/src/text-utils.coffee
@@ -30,6 +30,7 @@ isSurrogatePair = (charCodeA, charCodeB) ->
 #
 # Return a {Boolean}.
 isVariationSequence = (charCodeA, charCodeB) ->
+  return false if charCodeA is 0
   not isVariationSelector(charCodeA) and isVariationSelector(charCodeB)
 
 # Are the given character codes a combined character pair?
@@ -39,6 +40,7 @@ isVariationSequence = (charCodeA, charCodeB) ->
 #
 # Return a {Boolean}.
 isCombinedCharacter = (charCodeA, charCodeB) ->
+  return false if charCodeA is 0
   not isCombiningCharacter(charCodeA) and isCombiningCharacter(charCodeB)
 
 # Is the character at the given index the start of high/low surrogate pair


### PR DESCRIPTION
Fixes #2537.

I am relatively new to this area, so feedback is super appreciated! :bow: 

When a document had null bytes, we were previously detecting whether such bytes were paired with other characters. Thus, if we had a string like the following in the buffer:

```
{someLetter}{nullByte}{variationSelector}
```

`TokenIterator::isPairedCharacter` returned true for `{nullByte}{variationSelector}`.

Although I _suspect_ it would be technically possible for null bytes to be paired with other unicode characters, as soon as we insert a null byte into the DOM it gets ripped off. 

This screwed up our measurement mechanism, which wasn't able to match DOM positions against the model. A solution for this could have been to substitute [this line](https://github.com/atom/atom/blob/master/src/lines-tile-component.coffee#L346) with:

``` coffee
continue if char.indexOf('\0')
```

However, this would skip the whole paired character and it's inconsistent with what gets displayed to the user. This PR changes the behavior of `isPairedCharacter` so that it skips null bytes when detecting pair code points.

/cc: @maxbrunsfeld @nathansobo @atom/feedback for :eyes: 
