### PR TITLE
Fix handling of filename:line:column command-line arguments

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -63,7 +63,7 @@ class AtomApplication
   exit: (status) -> app.exit(status)
 
   constructor: (options) ->
-    {@resourcePath, @version, @devMode, @safeMode, @socketPath} = options
+    {@resourcePath, @devResourcePath, @version, @devMode, @safeMode, @socketPath} = options
 
     global.atomApplication = this
 
@@ -160,7 +160,7 @@ class AtomApplication
       devMode: @focusedWindow()?.devMode
       safeMode: @focusedWindow()?.safeMode
 
-    @on 'application:run-all-specs', -> @runSpecs(exitWhenDone: false, resourcePath: global.devResourcePath, safeMode: @focusedWindow()?.safeMode)
+    @on 'application:run-all-specs', -> @runSpecs(exitWhenDone: false, resourcePath: @devResourcePath, safeMode: @focusedWindow()?.safeMode)
     @on 'application:run-benchmarks', -> @runBenchmarks()
     @on 'application:quit', -> app.quit()
     @on 'application:new-window', -> @openPath(_.extend(windowDimensions: @focusedWindow()?.getDimensions(), getLoadSettings()))
@@ -252,7 +252,7 @@ class AtomApplication
       @applicationMenu.update(win, template, keystrokesByCommand)
 
     ipc.on 'run-package-specs', (event, specDirectory) =>
-      @runSpecs({resourcePath: global.devResourcePath, specDirectory: specDirectory, exitWhenDone: false})
+      @runSpecs({resourcePath: @devResourcePath, specDirectory: specDirectory, exitWhenDone: false})
 
     ipc.on 'command', (event, command) =>
       @emit(command)
@@ -398,8 +398,8 @@ class AtomApplication
     else
       if devMode
         try
-          bootstrapScript = require.resolve(path.join(global.devResourcePath, 'src', 'window-bootstrap'))
-          resourcePath = global.devResourcePath
+          bootstrapScript = require.resolve(path.join(@devResourcePath, 'src', 'window-bootstrap'))
+          resourcePath = @devResourcePath
 
       bootstrapScript ?= require.resolve('../window-bootstrap')
       resourcePath ?= @resourcePath
@@ -500,7 +500,7 @@ class AtomApplication
       resourcePath = @resourcePath
 
     try
-      bootstrapScript = require.resolve(path.resolve(global.devResourcePath, 'spec', 'spec-bootstrap'))
+      bootstrapScript = require.resolve(path.resolve(@devResourcePath, 'spec', 'spec-bootstrap'))
     catch error
       bootstrapScript = require.resolve(path.resolve(__dirname, '..', '..', 'spec', 'spec-bootstrap'))
 
@@ -511,7 +511,7 @@ class AtomApplication
 
   runBenchmarks: ({exitWhenDone, specDirectory}={}) ->
     try
-      bootstrapScript = require.resolve(path.resolve(global.devResourcePath, 'benchmark', 'benchmark-bootstrap'))
+      bootstrapScript = require.resolve(path.resolve(@devResourcePath, 'benchmark', 'benchmark-bootstrap'))
     catch error
       bootstrapScript = require.resolve(path.resolve(__dirname, '..', '..', 'benchmark', 'benchmark-bootstrap'))
 

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -5,7 +5,6 @@ app = require 'app'
 fs = require 'fs-plus'
 path = require 'path'
 yargs = require 'yargs'
-url = require 'url'
 console.log = require 'nslog'
 
 start = ->
@@ -31,16 +30,6 @@ start = ->
   app.on 'ready', ->
     app.removeListener 'open-file', addPathToOpen
     app.removeListener 'open-url', addUrlToOpen
-
-    cwd = args.executedFrom?.toString() or process.cwd()
-    args.pathsToOpen = args.pathsToOpen.map (pathToOpen) ->
-      normalizedPath = fs.normalize(pathToOpen)
-      if url.parse(pathToOpen).protocol?
-        pathToOpen
-      else if cwd
-        path.resolve(cwd, normalizedPath)
-      else
-        path.resolve(pathToOpen)
 
     AtomApplication = require path.join(args.resourcePath, 'src', 'browser', 'atom-application')
     AtomApplication.open(args)
@@ -126,7 +115,7 @@ parseCommandLine = ->
     process.stdout.write("#{version}\n")
     process.exit(0)
 
-  executedFrom = args['executed-from']
+  executedFrom = args['executed-from']?.toString() ? process.cwd()
   devMode = args['dev']
   safeMode = args['safe']
   pathsToOpen = args._

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -53,10 +53,6 @@ normalizeDriveLetterName = (filePath) ->
   else
     filePath
 
-global.devResourcePath = normalizeDriveLetterName(
-  process.env.ATOM_DEV_RESOURCE_PATH ? path.join(app.getHomeDir(), 'github', 'atom')
-)
-
 setupUncaughtExceptionHandler = ->
   process.on 'uncaughtException', (error={}) ->
     console.log(error.message) if error.message?
@@ -142,6 +138,7 @@ parseCommandLine = ->
   socketPath = args['socket-path']
   profileStartup = args['profile-startup']
   urlsToOpen = []
+  devResourcePath = process.env.ATOM_DEV_RESOURCE_PATH ? path.join(app.getHomeDir(), 'github', 'atom')
 
   if args['resource-path']
     devMode = true
@@ -157,7 +154,7 @@ parseCommandLine = ->
           resourcePath = packageDirectoryPath if packageManifest.name is 'atom'
 
     if devMode
-      resourcePath ?= global.devResourcePath
+      resourcePath ?= devResourcePath
 
   unless fs.statSyncNoException(resourcePath)
     resourcePath = path.dirname(path.dirname(__dirname))
@@ -167,9 +164,10 @@ parseCommandLine = ->
   process.env.PATH = args['path-environment'] if args['path-environment']
 
   resourcePath = normalizeDriveLetterName(resourcePath)
+  devResourcePath = normalizeDriveLetterName(devResourcePath)
 
-  {resourcePath, pathsToOpen, urlsToOpen, executedFrom, test, version,
-   pidToKillWhenClosed, devMode, safeMode, newWindow, specDirectory, logFile,
-   socketPath, profileStartup}
+  {resourcePath, devResourcePath, pathsToOpen, urlsToOpen, executedFrom, test,
+   version, pidToKillWhenClosed, devMode, safeMode, newWindow, specDirectory,
+   logFile, socketPath, profileStartup}
 
 start()


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/7342

A while ago we added some logic for handling URLs as command-line arguments. This caused problems for our handling of filename arguments with line numbers and column numbers like `file-name.txt:5`, because that argument would parse as a URL.

This also consolidates the logic for handling path arguments, removing it from `main.coffee`.

/cc @mostafaeweda
