### PR TITLE
Support query strings for atom protocol.

### DIFF
--- a/src/browser/atom-protocol-handler.coffee
+++ b/src/browser/atom-protocol-handler.coffee
@@ -32,6 +32,10 @@ class AtomProtocolHandler
     protocol.registerProtocol 'atom', (request) =>
       relativePath = path.normalize(request.url.substr(7))
 
+      qMarkIdx = relativePath.indexOf('?')
+      if qMarkIdx isnt -1
+        relativePath = relativePath.substring(0, qMarkIdx)
+
       if relativePath.indexOf('assets/') is 0
         assetsPath = path.join(process.env.ATOM_HOME, relativePath)
         filePath = assetsPath if fs.statSyncNoException(assetsPath).isFile?()


### PR DESCRIPTION
I created an atom package [disturb-me](https://atom.io/packages/disturb-me) which adds an image randomly moving in the atom window by an `img` tag.
When I specify a gif image located in the package using atom protocol (e.g. `atom://disturb-me/assets/atom/white/atom_die.gif`), the package set the `src` of the `img` tag to it and then the image is shown. But the gif animation is run only when the image is loaded for the first time.
It seems this is because the image was cached. So, to avoid such caching, I want to add a query string with a random value to the url. (e.g. `atom://disturb-me/assets/atom/white/atom_die.gif?time=1441559906660`)
I locally tested the random query method with this change I'm pull-requesting and confirmed the caching issue was solved.
