### PR TITLE
Defer activation hooks (#8313)

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -278,6 +278,7 @@ describe "PackageManager", ->
         expect(Package.prototype.requireMainModule.callCount).toBe 0
 
         atom.packages.triggerActivationHook('language-fictitious:grammar-used')
+        atom.packages.triggerDeferredActivationHooks()
 
         waitsForPromise ->
           promise

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -417,6 +417,7 @@ class PackageManager
       Promise.reject(new Error("Failed to load package '#{name}'"))
 
   triggerDeferredActivationHooks: ->
+    return unless @deferredActivationHooks?
     @activationHookEmitter.emit(hook) for hook in @deferredActivationHooks
     @deferredActivationHooks = null
 

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -385,7 +385,6 @@ class PackageManager
       promises = promises.concat(activator.activatePackages(packages))
     Promise.all(promises).then =>
       @triggerDeferredActivationHooks()
-      @emit 'activated' if Grim.includeDeprecatedAPIs
       @emitter.emit 'did-activate-initial-packages'
 
   # another type of package manager can handle other package types.

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -30,6 +30,7 @@ class PackageManager
     @emitter = new Emitter
     @activationHookEmitter = new Emitter
     @packageDirPaths = []
+    @deferredActivationHooks = []
     unless safeMode
       if @devMode
         @packageDirPaths.push(path.join(configDirPath, "dev", "packages"))
@@ -383,6 +384,8 @@ class PackageManager
       packages = @getLoadedPackagesForTypes(types)
       promises = promises.concat(activator.activatePackages(packages))
     Promise.all(promises).then =>
+      @triggerDeferredActivationHooks()
+      @emit 'activated' if Grim.includeDeprecatedAPIs
       @emitter.emit 'did-activate-initial-packages'
 
   # another type of package manager can handle other package types.
@@ -395,7 +398,7 @@ class PackageManager
     atom.config.transact =>
       for pack in packages
         promise = @activatePackage(pack.name)
-        promises.push(promise) unless pack.hasActivationCommands()
+        promises.push(promise) unless pack.activationShouldBeDeferred()
       return
     @observeDisabledPackages()
     @observePackagesWithKeymapsDisabled()
@@ -413,9 +416,16 @@ class PackageManager
     else
       Promise.reject(new Error("Failed to load package '#{name}'"))
 
+  triggerDeferredActivationHooks: ->
+    @activationHookEmitter.emit(hook) for hook in @deferredActivationHooks
+    @deferredActivationHooks = null
+
   triggerActivationHook: (hook) ->
     return new Error("Cannot trigger an empty activation hook") unless hook? and _.isString(hook) and hook.length > 0
-    @activationHookEmitter.emit(hook)
+    if @deferredActivationHooks?
+      @deferredActivationHooks.push hook
+    else
+      @activationHookEmitter.emit(hook)
 
   onDidTriggerActivationHook: (hook, callback) ->
     return unless hook? and _.isString(hook) and hook.length > 0


### PR DESCRIPTION
This is a first attempt at solving #8313. Actually triggering activation hooks is deferred until all packages that could be activated, are.

Note that there was a little oversight at line 409/411, due to which `did-activate-initial-packages` was emitted late if there were packages with activation hooks, I had to fix that as well.

Not entirely sure on how should I go about adding specs for this. Any advice is welcome.
