### PR TITLE
CSP policy prevents using Polymer in Atom plugins

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src *; img-src blob: data: *; script-src 'self'; style-src 'self' 'unsafe-inline'; media-src blob: data: mediastream: *;">
+  <meta http-equiv="Content-Security-Policy" content="default-src *; img-src blob: data: *; script-src 'self'
+  'unsafe-inline'; style-src 'self' 'unsafe-inline'; media-src blob: data: mediastream: *;">
   <script src="index.js"></script>
 </head>
 <body tabindex="-1">


### PR DESCRIPTION
I'm trying to use [Polymer](https://polymer-project.org) in an Atom plugin, but the CSP policy blocks inline scripts in [HTML imports](http://www.html5rocks.com/en/tutorials/webcomponents/imports/), which is core to how Polymer works. I'm not sure that this actually protects against any actual security boundary in Atom/Electron's security model (which isn't equivalent to the web)
