### PR TITLE
Display `.indent-guide`s inline

### DIFF
--- a/static/text-editor-shadow.less
+++ b/static/text-editor-shadow.less
@@ -129,7 +129,6 @@
 }
 
 .indent-guide {
-  display: inline-block;
   box-shadow: inset 1px 0;
 }
 


### PR DESCRIPTION
This is part of our ongoing effort to cut down rendering times.

Apparently, our indent-guides have a modest impact on Layout. Currently, they are styled with `display: inline-block` so that they have the same height of line nodes. This produces the effect of a contiguous vertical line:

![screen shot 2015-09-07 at 14 21 42](https://cloud.githubusercontent.com/assets/482957/9716625/e2fdfa22-556b-11e5-93cf-7401d0a130fc.png)

My assumption is that, when rendering text runs, Chrome has to take a slightly different route to lay out inline blocks, thereby slowing down reflows.

As a result, if we use `display: inline` for indent guides as well, **Layout** decreases from `3.2ms – 3.5ms` to `2.0ms – 2.5ms` for a full reflow. This, however, has the consequence of showing indent guides as the following:

![screen shot 2015-09-07 at 14 25 59](https://cloud.githubusercontent.com/assets/482957/9716677/630db856-556c-11e5-9dc6-ab0363208af5.png)

I have worked with @simurai to find a performant replacement which didn't alter the UI, but we had no luck in our investigation. We might probably render indent guides _outside_ the line, but I am not sure it's really worth it, especially since users may be okay with the slowdown and still keep the contiguous line effect with a simple change in their stylesheet:

``` less
atom-text-editor::shadow .indent-guide {
  display: inline-block;
}
```

What do you think? :thought_balloon:

Thanks!

/cc: @nathansobo @atom/feedback 
