### PR TITLE
Pop scope from the top of scopeStarts directly

### DIFF
--- a/src/token-iterator.coffee
+++ b/src/token-iterator.coffee
@@ -32,7 +32,14 @@ class TokenIterator
       tag = tags[@index]
       if tag < 0
         if tag % 2 is 0
-          @scopeEnds.push(atom.grammars.scopeForId(tag + 1))
+          scopeName = atom.grammars.scopeForId(tag + 1)
+          if @scopeEnds.length is 0
+            @scopeEnds.push(scopeName)
+          else
+            startsTop = this.scopeStarts.pop()
+            if startsTop isnt scopeName
+              @scopeStarts.push(startsTop)
+              @scopeEnds.push(scopeName)
           @scopes.pop()
         else
           scope = atom.grammars.scopeForId(tag)

--- a/src/token-iterator.coffee
+++ b/src/token-iterator.coffee
@@ -33,7 +33,7 @@ class TokenIterator
       if tag < 0
         if tag % 2 is 0
           scopeName = atom.grammars.scopeForId(tag + 1)
-          if @scopeEnds.length is 0
+          if @scopeStarts.length is 0
             @scopeEnds.push(scopeName)
           else
             startsTop = this.scopeStarts.pop()


### PR DESCRIPTION
Fixes #8701  

If scopeStarts contains the end element we encounter from tags, we should pop it directly from scopeStarts instead of pushing it to scopeEnds. If the top element wasn't the same (or it didn't exist), we add scopeStarts element back and push the tag to scopeEnds just like we used to.

Also I am interested in knowing if there is a safe way to peek the top of stack without popping.
