### PR TITLE
Correctly terminate scopes that end at the beginning of a line

### DIFF
--- a/spec/token-iterator-spec.coffee
+++ b/spec/token-iterator-spec.coffee
@@ -1,0 +1,35 @@
+TextBuffer = require 'text-buffer'
+TokenizedBuffer = require '../src/tokenized-buffer'
+
+describe "TokenIterator", ->
+  it "correctly terminates scopes at the beginning of the line (regression)", ->
+    grammar = atom.grammars.createGrammar('test', {
+      'scopeName': 'text.broken'
+      'name': 'Broken grammar'
+      'patterns': [
+        {
+          'begin': 'start'
+          'end': '(?=end)'
+          'name': 'blue.broken'
+        }
+        {
+          'match': '.'
+          'name': 'yellow.broken'
+        }
+      ]
+    })
+
+    buffer = new TextBuffer(text: """
+      start x
+      end x
+      x
+    """)
+    tokenizedBuffer = new TokenizedBuffer({buffer})
+    tokenizedBuffer.setGrammar(grammar)
+
+    tokenIterator = tokenizedBuffer.tokenizedLineForRow(1).getTokenIterator()
+    tokenIterator.next()
+
+    expect(tokenIterator.getBufferStart()).toBe 0
+    expect(tokenIterator.getScopeEnds()).toEqual []
+    expect(tokenIterator.getScopeStarts()).toEqual ['text.broken', 'yellow.broken']

--- a/src/token-iterator.coffee
+++ b/src/token-iterator.coffee
@@ -36,7 +36,7 @@ class TokenIterator
           if @scopeStarts[@scopeStarts.length - 1] is scopeName
             @scopeStarts.pop()
           else
-            @scopeEnds.push()
+            @scopeEnds.push(scopeName)
           @scopes.pop()
         else
           scope = atom.grammars.scopeForId(tag)

--- a/src/token-iterator.coffee
+++ b/src/token-iterator.coffee
@@ -32,7 +32,14 @@ class TokenIterator
       tag = tags[@index]
       if tag < 0
         if tag % 2 is 0
-          @scopeEnds.push(atom.grammars.scopeForId(tag + 1))
+          scopeName = atom.grammars.scopeForId(tag + 1)
+          if @scopeEnds.length is 0
+            @scopeEnds.push(scopeName)
+          else
+            startsTop = this.scopeStarts.pop()
+            if startsTop isnt scopeName
+              @scopeStarts.push(startsTop)
+              @scopeEnds.push(scopeName)
           @scopes.pop()
         else
           scope = atom.grammars.scopeForId(tag)

--- a/src/token-iterator.coffee
+++ b/src/token-iterator.coffee
@@ -33,7 +33,7 @@ class TokenIterator
       if tag < 0
         if tag % 2 is 0
           scopeName = atom.grammars.scopeForId(tag + 1)
-          if @scopeEnds.length is 0
+          if @scopeStarts.length is 0
             @scopeEnds.push(scopeName)
           else
             startsTop = this.scopeStarts.pop()

--- a/src/token-iterator.coffee
+++ b/src/token-iterator.coffee
@@ -33,13 +33,10 @@ class TokenIterator
       if tag < 0
         if tag % 2 is 0
           scopeName = atom.grammars.scopeForId(tag + 1)
-          if @scopeStarts.length is 0
-            @scopeEnds.push(scopeName)
+          if @scopeStarts[@scopeStarts.length - 1] is scopeName
+            @scopeStarts.pop()
           else
-            startsTop = this.scopeStarts.pop()
-            if startsTop isnt scopeName
-              @scopeStarts.push(startsTop)
-              @scopeEnds.push(scopeName)
+            @scopeEnds.push()
           @scopes.pop()
         else
           scope = atom.grammars.scopeForId(tag)

--- a/src/token-iterator.coffee
+++ b/src/token-iterator.coffee
@@ -31,15 +31,14 @@ class TokenIterator
     while @index < tags.length
       tag = tags[@index]
       if tag < 0
+        scope = atom.grammars.scopeForId(tag)
         if tag % 2 is 0
-          scopeName = atom.grammars.scopeForId(tag + 1)
-          if @scopeStarts[@scopeStarts.length - 1] is scopeName
+          if @scopeStarts[@scopeStarts.length - 1] is scope
             @scopeStarts.pop()
           else
-            @scopeEnds.push(scopeName)
+            @scopeEnds.push(scope)
           @scopes.pop()
         else
-          scope = atom.grammars.scopeForId(tag)
           @scopeStarts.push(scope)
           @scopes.push(scope)
         @index++


### PR DESCRIPTION
Closes #8703
Fixes #8701

Major props to @Ingramz for discovering this obscure bug in `TokenIterator`. This PR adds a test and adjusts the implementation slightly, while incorporating his original commits. Thanks so much for your contribution :metal:.
