### PR TITLE
Add --no-auto-update while run `scripts/build` to disable autoupdate

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -36,6 +36,7 @@ module.exports = (grunt) ->
   buildDir = grunt.option('build-dir') ? path.join(tmpDir, 'atom-build')
   buildDir = path.resolve(buildDir)
   installDir = grunt.option('install-dir')
+  disableAutoUpdate = grunt.option('no-auto-update') ? false
 
   channel = grunt.option('channel')
   channel ?= process.env.JANKY_BRANCH if process.env.JANKY_BRANCH in ['stable', 'beta']
@@ -155,7 +156,7 @@ module.exports = (grunt) ->
   grunt.initConfig
     pkg: grunt.file.readJSON('package.json')
 
-    atom: {appDir, appName, symbolsDir, buildDir, contentsDir, installDir, shellAppDir, channel}
+    atom: {appDir, appName, symbolsDir, buildDir, contentsDir, installDir, shellAppDir, channel, disableAutoUpdate}
 
     docsOutputDir: 'docs/output'
 

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -190,4 +190,5 @@ module.exports = (grunt) ->
     dependencies = ['compile', 'generate-license:save', 'generate-module-cache', 'compile-packages-slug']
     dependencies.push('copy-info-plist') if process.platform is 'darwin'
     dependencies.push('set-exe-icon') if process.platform is 'win32'
+    dependencies.push('disable-autoupdate') if grunt.config.get('atom.disableAutoUpdate')
     grunt.task.run(dependencies...)

--- a/build/tasks/disable-autoupdate-task.coffee
+++ b/build/tasks/disable-autoupdate-task.coffee
@@ -1,0 +1,12 @@
+fs = require 'fs'
+path = require 'path'
+
+module.exports = (grunt) ->
+
+  grunt.registerTask 'disable-autoupdate', 'Set up disableAutoUpdate field in package.json file', ->
+    appDir = fs.realpathSync(grunt.config.get('atom.appDir'))
+
+    metadata = grunt.file.readJSON(path.join(appDir, 'package.json'))
+    metadata._disableAutoUpdate = grunt.config.get('atom.disableAutoUpdate')
+
+    grunt.file.write(path.join(appDir, 'package.json'), JSON.stringify(metadata))

--- a/src/browser/application-menu.coffee
+++ b/src/browser/application-menu.coffee
@@ -103,6 +103,8 @@ class ApplicationMenu
     downloadingUpdateItem.visible = false
     installUpdateItem.visible = false
 
+    return if @autoUpdateManager.isDisabled()
+
     switch state
       when 'idle', 'error', 'no-update-available'
         checkForUpdateItem.visible = true
@@ -117,16 +119,19 @@ class ApplicationMenu
   #
   # Returns an Array of menu item Objects.
   getDefaultTemplate: ->
-    [
+    template = [
       label: "Atom"
       submenu: [
-          {label: "Check for Update", metadata: {autoUpdate: true}}
           {label: 'Reload', accelerator: 'Command+R', click: => @focusedWindow()?.reload()}
           {label: 'Close Window', accelerator: 'Command+Shift+W', click: => @focusedWindow()?.close()}
           {label: 'Toggle Dev Tools', accelerator: 'Command+Alt+I', click: => @focusedWindow()?.toggleDevTools()}
           {label: 'Quit', accelerator: 'Command+Q', click: -> app.quit()}
       ]
     ]
+
+    # Add `Check for Update` button if autoUpdateManager is enabled.
+    template[0].submenu.unshift({label: "Check for Update", metadata: {autoUpdate: true}}) unless @autoUpdateManager.isDisabled()
+    template
 
   focusedWindow: ->
     _.find global.atomApplication.windows, (atomWindow) -> atomWindow.isFocused()

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -72,7 +72,8 @@ class AtomApplication
     @pidsToOpenWindows = {}
     @windows = []
 
-    @autoUpdateManager = new AutoUpdateManager(@version, options.test)
+    disableAutoUpdate = require(path.join(@resourcePath, 'package.json'))._disableAutoUpdate ? false
+    @autoUpdateManager = new AutoUpdateManager(@version, options.test, disableAutoUpdate)
     @applicationMenu = new ApplicationMenu(@version, @autoUpdateManager)
     @atomProtocolHandler = new AtomProtocolHandler(@resourcePath, @safeMode)
 


### PR DESCRIPTION
Add `--no-auto-update` to script/build as an option to disable Atom autoupdate.

This PR create a new grunt task that set `_enableAutoUpdate` to Atom's package.json while building. And in AutoupdateManager, it loads package.json and check if `_enableAutoupdate` is set.

I verified that `script/build --no-auto-update` will set `"_enableAutoUpdate" : false` in Atom's package.json whereas `script/build` will  set `"_enableAutoUpdate" : true`. 

However, it seems that the build generated by `script/build` won't trigger autoupdate even if I made the the version to be `1.0.9` instead of `1.0.9-somehash`.

Any thought on how to verify the autoupdate feature using `script/build`?

cc @bolinfest  @maxbrunsfeld  @kevinsawicki 
