### PR TITLE
Upload assets to pre & production releases from beta & stable branches

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -11,7 +11,7 @@
     "donna": "1.0.10",
     "formidable": "~1.0.14",
     "fs-plus": "2.x",
-    "github-releases": "~0.2.0",
+    "github-releases": "~0.3.0",
     "glob": "^5.0.14",
     "grunt": "~0.4.1",
     "grunt-babel": "^5.0.1",

--- a/build/package.json
+++ b/build/package.json
@@ -22,7 +22,7 @@
     "grunt-contrib-less": "~0.8.0",
     "grunt-cson": "0.15.0",
     "grunt-download-electron": "^2.1.1",
-    "grunt-electron-installer": "1.0.0",
+    "grunt-electron-installer": "1.0.3-0",
     "grunt-lesslint": "0.17.0",
     "grunt-peg": "~1.1.0",
     "grunt-shell": "~0.3.1",

--- a/build/tasks/mkrpm-task.coffee
+++ b/build/tasks/mkrpm-task.coffee
@@ -24,6 +24,12 @@ module.exports = (grunt) ->
       return done("Unsupported arch #{process.arch}")
 
     {name, version, description} = grunt.file.readJSON('package.json')
+
+    # RPM versions can't have dashes in them.
+    # * http://www.rpm.org/max-rpm/ch-rpm-file-format.html
+    # * https://github.com/mojombo/semver/issues/145
+    version = version.replace(/-beta$/, "~beta")
+
     buildDir = grunt.config.get('atom.buildDir')
 
     rpmDir = path.join(buildDir, 'rpm')

--- a/build/tasks/set-version-task.coffee
+++ b/build/tasks/set-version-task.coffee
@@ -5,7 +5,7 @@ module.exports = (grunt) ->
   {spawn} = require('./task-helpers')(grunt)
 
   getVersion = (callback) ->
-    onBuildMachine = process.env.JANKY_SHA1 and process.env.JANKY_BRANCH is 'master'
+    onBuildMachine = process.env.JANKY_SHA1 and process.env.JANKY_BRANCH in ['stable', 'beta']
     inRepository = fs.existsSync(path.resolve(__dirname, '..', '..', '.git'))
     {version} = require(path.join(grunt.config.get('atom.appDir'), 'package.json'))
     if onBuildMachine or not inRepository

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom",
   "productName": "Atom",
-  "version": "1.0.12",
+  "version": "1.0.12-beta",
   "description": "A hackable text editor for the 21st Century.",
   "main": "./src/browser/main.js",
   "repository": {


### PR DESCRIPTION
Previously, CI would upload assets when building the `master` branch. Now, it uploads assets to a pre-release when building the `beta` branch, and to a normal release when building the `stable` branch.
- [x] Update build scripts to create and upload assets to pre and production releases from the `beta` and `stable` branches, respectively.
- [x] Create a `beta` branch off of this branch. Verify that after CI runs, a draft pre-release is created and populated with assets.
- [x] Create a `stable` branch off of this branch. Verify that after CI runs, the draft normal release is populated with assets.
- [x] Add `-beta` to Atom's version number on the `beta` branch.
