### PR TITLE
[WIP] Extract registry functions from squirrel-update

### DIFF
--- a/spec/spawner-spec.coffee
+++ b/spec/spawner-spec.coffee
@@ -1,0 +1,25 @@
+ChildProcess = require 'child_process'
+Spawner = require '../src/browser/spawner'
+
+describe "Spawner", ->
+  beforeEach ->
+    # Prevent any commands from actually running and affecting the host
+    originalSpawn = ChildProcess.spawn
+
+    spyOn(ChildProcess, 'spawn').andCallFake (command, args) ->
+      # Just spawn something that won't actually modify the host
+      if process.platform is 'win32'
+        originalSpawn('dir')
+      else
+        originalSpawn('ls')
+
+  it "ignores errors by spawned process", ->
+    jasmine.unspy(ChildProcess, 'spawn')
+    spyOn(ChildProcess, 'spawn').andCallFake -> throw new Error("EBUSY")
+
+    someCallback = jasmine.createSpy('someCallback')
+
+    expect(Spawner.spawn('some-command', 'some-args', someCallback)).toBe undefined
+
+    waitsFor ->
+      someCallback.callCount is 1

--- a/spec/squirrel-update-spec.coffee
+++ b/spec/squirrel-update-spec.coffee
@@ -15,7 +15,7 @@ describe "Windows squirrel updates", ->
 
     # Prevent any commands from actually running and affecting the host
     originalSpawn = Spawner.spawn
-    spyOn(Spawner, 'spawn').andCallFake (command, args) ->
+    spyOn(Spawner, 'spawn').andCallFake (command, args, callback) ->
       if path.basename(command) is 'Update.exe' and args?[0] is '--createShortcut'
         fs.writeFileSync(path.join(tempHomeDirectory, 'Desktop', 'Atom.lnk'), '')
 
@@ -25,15 +25,8 @@ describe "Windows squirrel updates", ->
       else
         originalSpawn('ls')
 
-  it "ignores errors spawning Squirrel", ->
-    jasmine.unspy(Spawner, 'spawn')
-    spyOn(Spawner, 'spawn').andCallFake -> throw new Error("EBUSY")
-
-    app = quit: jasmine.createSpy('quit')
-    expect(SquirrelUpdate.handleStartupEvent(app, '--squirrel-install')).toBe true
-
-    waitsFor ->
-      app.quit.callCount is 1
+      # Finally, run following callback
+      callback?
 
   it "quits the app on all squirrel events", ->
     app = quit: jasmine.createSpy('quit')

--- a/spec/squirrel-update-spec.coffee
+++ b/spec/squirrel-update-spec.coffee
@@ -1,8 +1,8 @@
-ChildProcess = require 'child_process'
 {EventEmitter} = require 'events'
 fs = require 'fs-plus'
 path = require 'path'
 temp = require 'temp'
+Spawner = require '../src/browser/spawner'
 SquirrelUpdate = require '../src/browser/squirrel-update'
 
 describe "Windows squirrel updates", ->
@@ -14,8 +14,8 @@ describe "Windows squirrel updates", ->
     spyOn(fs, 'getHomeDirectory').andReturn(tempHomeDirectory)
 
     # Prevent any commands from actually running and affecting the host
-    originalSpawn = ChildProcess.spawn
-    spyOn(ChildProcess, 'spawn').andCallFake (command, args) ->
+    originalSpawn = Spawner.spawn
+    spyOn(Spawner, 'spawn').andCallFake (command, args) ->
       if path.basename(command) is 'Update.exe' and args?[0] is '--createShortcut'
         fs.writeFileSync(path.join(tempHomeDirectory, 'Desktop', 'Atom.lnk'), '')
 
@@ -26,8 +26,8 @@ describe "Windows squirrel updates", ->
         originalSpawn('ls')
 
   it "ignores errors spawning Squirrel", ->
-    jasmine.unspy(ChildProcess, 'spawn')
-    spyOn(ChildProcess, 'spawn').andCallFake -> throw new Error("EBUSY")
+    jasmine.unspy(Spawner, 'spawn')
+    spyOn(Spawner, 'spawn').andCallFake -> throw new Error("EBUSY")
 
     app = quit: jasmine.createSpy('quit')
     expect(SquirrelUpdate.handleStartupEvent(app, '--squirrel-install')).toBe true
@@ -98,7 +98,7 @@ describe "Windows squirrel updates", ->
       SquirrelUpdate.restartAtom(app)
       expect(app.quit.callCount).toBe 1
 
-      expect(ChildProcess.spawn.callCount).toBe 0
+      expect(Spawner.spawn.callCount).toBe 0
       app.emit('will-quit')
-      expect(ChildProcess.spawn.callCount).toBe 1
-      expect(path.basename(ChildProcess.spawn.argsForCall[0][0])).toBe 'atom.cmd'
+      expect(Spawner.spawn.callCount).toBe 1
+      expect(path.basename(Spawner.spawn.argsForCall[0][0])).toBe 'atom.cmd'

--- a/src/browser/spawner.coffee
+++ b/src/browser/spawner.coffee
@@ -1,0 +1,23 @@
+ChildProcess = require 'child_process'
+
+# Spawn a command and invoke the callback when it completes with an error
+# and the output from standard out.
+exports.spawn = (command, args, callback) ->
+  stdout = ''
+
+  try
+    spawnedProcess = ChildProcess.spawn(command, args)
+  catch error
+    # Spawn can throw an error
+    process.nextTick -> callback?(error, stdout)
+    return
+
+  spawnedProcess.stdout.on 'data', (data) -> stdout += data
+
+  error = null
+  spawnedProcess.on 'error', (processError) -> error ?= processError
+  spawnedProcess.on 'close', (code, signal) ->
+    error ?= new Error("Command failed: #{signal ? code}") if code isnt 0
+    error?.code ?= code
+    error?.stdout ?= stdout
+    callback?(error, stdout)

--- a/src/browser/win-registry.coffee
+++ b/src/browser/win-registry.coffee
@@ -1,0 +1,88 @@
+Spawner = require './spawner'
+
+# Registry keys used for context menu
+fileKeyPath = 'HKCU\\Software\\Classes\\*\\shell\\Atom'
+directoryKeyPath = 'HKCU\\Software\\Classes\\directory\\shell\\Atom'
+backgroundKeyPath = 'HKCU\\Software\\Classes\\directory\\background\\shell\\Atom'
+
+# Registry keys used for environment variables
+environmentKeyPath = 'HKCU\\Environment'
+
+if process.env.SystemRoot
+  system32Path = path.join(process.env.SystemRoot, 'System32')
+  regPath = path.join(system32Path, 'reg.exe')
+else
+  regPath = 'reg.exe'
+
+# Spawn reg.exe and callback when it completes
+spawnReg = (args, callback) ->
+  Spawner.spawn(regPath, args, callback)
+
+isAscii = (text) ->
+  index = 0
+  while index < text.length
+    return false if text.charCodeAt(index) > 127
+    index++
+  true
+
+# Install the Open with Atom explorer context menu items via the registry.
+exports.installContextMenu = (callback) ->
+  addToRegistry = (args, callback) ->
+    args.unshift('add')
+    args.push('/f')
+    spawnReg(args, callback)
+
+  installMenu = (keyPath, arg, callback) ->
+    args = [keyPath, '/ve', '/d', 'Open with Atom']
+    addToRegistry args, ->
+      args = [keyPath, '/v', 'Icon', '/d', process.execPath]
+      addToRegistry args, ->
+        args = ["#{keyPath}\\command", '/ve', '/d', "#{process.execPath} \"#{arg}\""]
+        addToRegistry(args, callback)
+
+  installMenu fileKeyPath, '%1', ->
+    installMenu directoryKeyPath, '%1', ->
+      installMenu(backgroundKeyPath, '%V', callback)
+
+# Uninstall the Open with Atom explorer context menu items via the registry.
+exports.uninstallContextMenu = (callback) ->
+  deleteFromRegistry = (keyPath, callback) ->
+    spawnReg(['delete', keyPath, '/f'], callback)
+
+  deleteFromRegistry fileKeyPath, ->
+    deleteFromRegistry directoryKeyPath, ->
+      deleteFromRegistry(backgroundKeyPath, callback)
+
+# Get the user's PATH environment variable registry value.
+exports.getPath = (callback) ->
+  spawnReg ['query', environmentKeyPath, '/v', 'Path'], (error, stdout) ->
+    if error?
+      if error.code is 1
+        # FIXME Don't overwrite path when reading value is disabled
+        # https://github.com/atom/atom/issues/5092
+        if stdout.indexOf('ERROR: Registry editing has been disabled by your administrator.') isnt -1
+          return callback(error)
+
+        # The query failed so the Path does not exist yet in the registry
+        return callback(null, '')
+      else
+        return callback(error)
+
+    # Registry query output is in the form:
+    #
+    # HKEY_CURRENT_USER\Environment
+    #     Path    REG_SZ    C:\a\folder\on\the\path;C\another\folder
+    #
+
+    lines = stdout.split(/[\r\n]+/).filter (line) -> line
+    segments = lines[lines.length - 1]?.split('    ')
+    if segments[1] is 'Path' and segments.length >= 3
+      pathEnv = segments?[3..].join('    ')
+      if isAscii(pathEnv)
+        callback(null, pathEnv)
+      else
+        # FIXME Don't corrupt non-ASCII PATH values
+        # https://github.com/atom/atom/issues/5063
+        callback(new Error('PATH contains non-ASCII values'))
+    else
+      callback(new Error('Registry query for PATH failed'))

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -223,3 +223,9 @@ if process.platform in ['win32', 'linux']
     type: 'boolean'
     default: false
     description: 'Automatically hide the menu bar and toggle it by pressing Alt. This is only supported on Windows & Linux.'
+
+if process.platform in ['win32']
+  module.exports.core.properties.showAtomInShellContextMenu =
+    type: 'boolean'
+    default: true
+    description: 'Show Atom in Explorer context menu when right-clicking on files and folders. This is only supported on Windows.'


### PR DESCRIPTION
This is a work-in-progress. When running _apm test_ (apart from a load of messages coming from other unrelated files) in the end it reports 3 failures, all related to _squirrel-update-spec.coffee_:

```
Windows squirrel updates
  it ignores errors spawning Squirrel
    Error: EBUSY
      at Object.<anonymous> (/my/path/atom/spec/squirrel-update-spec.coffee:30:54)
      at spawnUpdate (/my/path/atom/src/browser/squirrel-update.coffee:25:11)
      at createShortcuts (/my/path/atom/src/browser/squirrel-update.coffee:90:3)
      at Object.exports.handleStartupEvent (/my/path/atom/src/browser/squirrel-update.coffee:131:7)
      at [object Object].<anonymous> (/my/path/atom/spec/squirrel-update-spec.coffee:33:27)
  it quits the app on all squirrel events
    timeout: timed out after 5000 msec waiting for something to happen
  it keeps the desktop shortcut deleted on updates if it was previously deleted after install
    timeout: timed out after 5000 msec waiting for something to happen

Finished in 288.948 seconds
1838 tests, 6583 assertions, 3 failures, 0 skipped
```

I'd just like to stress that at the moment we're running this on a Mac, so not sure if those tests strictly depend on platform. Of course we'll move on a Win machine as soon as we grab one, next week probably. 
