### PR TITLE
Use system menu font for Atom UI

### DIFF
--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -78,8 +78,3 @@
 @component-border-radius: 2px;
 
 @tab-height: 30px;
-
-
-// Other
-
-@font-family: '.SFNSText-Regular', 'SF UI Text', 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;

--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -78,3 +78,8 @@
 @component-border-radius: 2px;
 
 @tab-height: 30px;
+
+
+// Other
+
+@font-family: '';

--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -8,10 +8,6 @@ html {
   font-size: @font-size;
 }
 
-html when not (@font-family = '') {
-  font-family: @font-family;
-}
-
 html,
 body {
   width: 100%;
@@ -42,6 +38,9 @@ atom-workspace {
   }
 }
 
-atom-workspace when not (@font-family = '') {
-  font-family: @font-family;
+& when not (@font-family = '') {
+  html,
+  atom-workspace {
+    font-family: @font-family;
+  }
 }

--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -22,7 +22,10 @@ atom-workspace {
   position: relative;
   color: @text-color;
   background-color: @app-background-color;
+  font: menu;
   font-family: @font-family;
+  font-size: inherit;
+  line-height: inherit;
 
   atom-workspace-axis.horizontal {
     display: -webkit-flex;

--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -5,8 +5,11 @@
 
 html {
   font: menu;
-  font-family: @font-family;
   font-size: @font-size;
+}
+
+html when not (@font-family = '') {
+  font-family: @font-family;
 }
 
 html,
@@ -24,7 +27,6 @@ atom-workspace {
   color: @text-color;
   background-color: @app-background-color;
   font: menu;
-  font-family: @font-family;
   font-size: inherit;
   line-height: inherit;
 
@@ -38,4 +40,8 @@ atom-workspace {
     -webkit-flex: 1;
     -webkit-flex-flow: column;
   }
+}
+
+atom-workspace when not (@font-family = '') {
+  font-family: @font-family;
 }

--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -4,6 +4,7 @@
 @font-face { .octicon-font(); }
 
 html {
+  font: menu;
   font-family: @font-family;
   font-size: @font-size;
 }


### PR DESCRIPTION
Closes https://github.com/atom/atom/issues/8656

If `@font-family` is undefined by a theme, then Atom will use the OS's default menu font in its place. Theme authors won't have to do anything unless they want their themes to use the OS default font - if that's the case, they need only :fire: their `@font-family` declaration.

This PR is pending changes to the One ~~and Atom~~ themes though for there to actually be an effect. :sweat_smile: 

Possible consequences:
- Anyone using SF UI on anything but El Capitan will be disappointed :disappointed: (since it'll now use the OS default - Helvetica Neue on Yosemite)
- It's possible that some OS font will have weird / unexpected consequences on `line-height` / kerning that we won't necessarily be able to anticipate. If that's the case though, themes can always override the OS default if necessary.

@simurai I was thinking of leaving Atom Dark & Light alone for now, [since they still have some issues with SF UI](https://github.com/atom/atom-dark-ui/pull/48#issuecomment-117368696) - what do you think?

Tested on OS X 10.10.5, Windows 8.1, Fedora 22, and Ubuntu 15.04

/cc @simurai @atom/feedback 
