### PR TITLE
Avoid incorrect character replacement when initially typing in text-editor

### DIFF
--- a/src/input-component.coffee
+++ b/src/input-component.coffee
@@ -3,6 +3,7 @@ class InputComponent
   constructor: ->
     @domNode = document.createElement('input')
     @domNode.classList.add('hidden-input')
+    @domNode.setAttribute('tabindex', -1)
     @domNode.setAttribute('data-react-skip-selection-restoration', true)
     @domNode.style['-webkit-transform'] = 'translateZ(0)'
     @domNode.addEventListener 'paste', (event) -> event.preventDefault()


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/8785

It seems that chrome now automatically selects all text in an input element
when its containing shadow root gains focus, as if it had been reached by
typing tab. Setting the input's tabindex to -1 prevents this behavior.
