### PR TITLE
Add margin left to icons

### DIFF
--- a/static/lists.less
+++ b/static/lists.less
@@ -43,6 +43,7 @@
   }
 
   .icon::before {
+    margin-left: 1px;
     margin-right: @component-icon-padding;
     position: relative;
     top: 1px;


### PR DESCRIPTION
I'm using Kubuntu 15.04 and Atom 1.0.11
I just added one line `margin-left: 1px` because when I use atom with half screen I can see the icons cutted.

![Screenshot](http://i.imgur.com/DOgHHjA.png)
![Margin](http://i.imgur.com/Ql1XzA5.png)
