### PR TITLE
Add command for cutting text to the end of the cursor's buffer line

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2899,6 +2899,35 @@ describe "TextEditor", ->
               expect(buffer.lineForRow(3)).toBe '    var pivot = item'
               expect(atom.clipboard.read()).toBe ' <= 1) ret\ns.shift(), current, left = [], right = [];'
 
+      describe ".cutToEndOfBufferLine()", ->
+        describe "when soft wrap is on", ->
+          it "cuts up to the end of the buffer line", ->
+            editor.setSoftWrapped(true)
+            editor.setEditorWidthInChars(10)
+            editor.setCursorScreenPosition([2, 2])
+            editor.cutToEndOfBufferLine()
+            expect(editor.tokenizedLineForScreenRow(2).text).toBe '= '
+
+        describe "when soft wrap is off", ->
+          describe "when nothing is selected", ->
+            it "cuts up to the end of the buffer line", ->
+              editor.setCursorBufferPosition([2, 20])
+              editor.addCursorAtBufferPosition([3, 20])
+              editor.cutToEndOfBufferLine()
+              expect(buffer.lineForRow(2)).toBe '    if (items.length'
+              expect(buffer.lineForRow(3)).toBe '    var pivot = item'
+              expect(atom.clipboard.read()).toBe ' <= 1) return items;\ns.shift(), current, left = [], right = [];'
+
+          describe "when text is selected", ->
+            it "only cuts the selected text, not to the end of the buffer line", ->
+              editor.setSelectedBufferRanges([[[2, 20], [2, 30]], [[3, 20], [3, 20]]])
+
+              editor.cutToEndOfBufferLine()
+
+              expect(buffer.lineForRow(2)).toBe '    if (items.lengthurn items;'
+              expect(buffer.lineForRow(3)).toBe '    var pivot = item'
+              expect(atom.clipboard.read()).toBe ' <= 1) ret\ns.shift(), current, left = [], right = [];'
+
       describe ".copySelectedText()", ->
         it "copies selected text onto the clipboard", ->
           editor.setSelectedBufferRanges([[[0, 4], [0, 13]], [[1, 6], [1, 10]], [[2, 8], [2, 13]]])

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2900,33 +2900,30 @@ describe "TextEditor", ->
               expect(atom.clipboard.read()).toBe ' <= 1) ret\ns.shift(), current, left = [], right = [];'
 
       describe ".cutToEndOfBufferLine()", ->
-        describe "when soft wrap is on", ->
+        beforeEach ->
+          editor.setSoftWrapped(true)
+          editor.setEditorWidthInChars(10)
+
+        describe "when nothing is selected", ->
           it "cuts up to the end of the buffer line", ->
-            editor.setSoftWrapped(true)
-            editor.setEditorWidthInChars(10)
-            editor.setCursorScreenPosition([2, 2])
+            editor.setCursorBufferPosition([2, 20])
+            editor.addCursorAtBufferPosition([3, 20])
+
             editor.cutToEndOfBufferLine()
-            expect(editor.tokenizedLineForScreenRow(2).text).toBe '= '
 
-        describe "when soft wrap is off", ->
-          describe "when nothing is selected", ->
-            it "cuts up to the end of the buffer line", ->
-              editor.setCursorBufferPosition([2, 20])
-              editor.addCursorAtBufferPosition([3, 20])
-              editor.cutToEndOfBufferLine()
-              expect(buffer.lineForRow(2)).toBe '    if (items.length'
-              expect(buffer.lineForRow(3)).toBe '    var pivot = item'
-              expect(atom.clipboard.read()).toBe ' <= 1) return items;\ns.shift(), current, left = [], right = [];'
+            expect(buffer.lineForRow(2)).toBe '    if (items.length'
+            expect(buffer.lineForRow(3)).toBe '    var pivot = item'
+            expect(atom.clipboard.read()).toBe ' <= 1) return items;\ns.shift(), current, left = [], right = [];'
 
-          describe "when text is selected", ->
-            it "only cuts the selected text, not to the end of the buffer line", ->
-              editor.setSelectedBufferRanges([[[2, 20], [2, 30]], [[3, 20], [3, 20]]])
+        describe "when text is selected", ->
+          it "only cuts the selected text, not to the end of the buffer line", ->
+            editor.setSelectedBufferRanges([[[2, 20], [2, 30]], [[3, 20], [3, 20]]])
 
-              editor.cutToEndOfBufferLine()
+            editor.cutToEndOfBufferLine()
 
-              expect(buffer.lineForRow(2)).toBe '    if (items.lengthurn items;'
-              expect(buffer.lineForRow(3)).toBe '    var pivot = item'
-              expect(atom.clipboard.read()).toBe ' <= 1) ret\ns.shift(), current, left = [], right = [];'
+            expect(buffer.lineForRow(2)).toBe '    if (items.lengthurn items;'
+            expect(buffer.lineForRow(3)).toBe '    var pivot = item'
+            expect(atom.clipboard.read()).toBe ' <= 1) ret\ns.shift(), current, left = [], right = [];'
 
       describe ".copySelectedText()", ->
         it "copies selected text onto the clipboard", ->

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -257,9 +257,14 @@ class Selection extends Model
     @modifySelection => @cursor.moveToFirstCharacterOfLine()
 
   # Public: Selects all the text from the current cursor position to the end of
-  # the line.
+  # the screen line.
   selectToEndOfLine: ->
     @modifySelection => @cursor.moveToEndOfScreenLine()
+
+  # Public: Selects all the text from the current cursor position to the end of
+  # the buffer line.
+  selectToEndOfBufferLine: ->
+    @modifySelection => @cursor.moveToEndOfLine()
 
   # Public: Selects all the text from the current cursor position to the
   # beginning of the word.
@@ -572,9 +577,14 @@ class Selection extends Model
   toggleLineComments: ->
     @editor.toggleLineCommentsForBufferRows(@getBufferRowRange()...)
 
-  # Public: Cuts the selection until the end of the line.
+  # Public: Cuts the selection until the end of the screen line.
   cutToEndOfLine: (maintainClipboard) ->
     @selectToEndOfLine() if @isEmpty()
+    @cut(maintainClipboard)
+
+  # Public: Cuts the selection until the end of the buffer line.
+  cutToEndOfBufferLine: (maintainClipboard) ->
+    @selectToEndOfBufferLine() if @isEmpty()
     @cut(maintainClipboard)
 
   # Public: Copies the selection to the clipboard and then deletes it.

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -299,6 +299,7 @@ atom.commands.add 'atom-text-editor', stopEventPropagationAndGroupUndo(
   'editor:delete-to-end-of-subword': -> @deleteToEndOfSubword()
   'editor:delete-line': -> @deleteLine()
   'editor:cut-to-end-of-line': -> @cutToEndOfLine()
+  'editor:cut-to-end-of-buffer-line': -> @cutToEndOfBufferLine()
   'editor:transpose': -> @transpose()
   'editor:upper-case': -> @upperCase()
   'editor:lower-case': -> @lowerCase()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2664,12 +2664,21 @@ class TextEditor extends Model
       @emitter.emit 'did-insert-text', didInsertEvent
 
   # Essential: For each selection, if the selection is empty, cut all characters
-  # of the containing line following the cursor. Otherwise cut the selected
+  # of the containing screen line following the cursor. Otherwise cut the selected
   # text.
   cutToEndOfLine: ->
     maintainClipboard = false
     @mutateSelectedText (selection) ->
       selection.cutToEndOfLine(maintainClipboard)
+      maintainClipboard = true
+
+  # Essential: For each selection, if the selection is empty, cut all characters
+  # of the containing buffer line following the cursor. Otherwise cut the
+  # selected text.
+  cutToEndOfBufferLine: ->
+    maintainClipboard = false
+    @mutateSelectedText (selection) ->
+      selection.cutToEndOfBufferLine(maintainClipboard)
       maintainClipboard = true
 
   ###


### PR DESCRIPTION
This is an attempt to close https://github.com/atom/atom/issues/2607. 

Currently, the `TextEditor.cutToEndOfLine` method and associated `editor:cut-to-end-of-line` command cut text from the cursor to the end of the cursor's _screen_ line. For some users, this is not the expected behavior when the cursor is in a soft wrapped line -- for those users, a more intuitive behavior would be to cut to the end of the cursor's _buffer_ line.

This PR adds a new method and command which cuts text to the end of the buffer line. Users can add a new keybinding for that or change the existing keybinding for `editor:cut-to-end-of-line` to point to the new command.

Notes:
- I decided not to change the current method `TextEditor.cutToEndOfLine` so that it cuts to the end of the buffer line because that would be considered a breaking change for that API. Still, if we consider this to be a bug in that API method, I'd be happy to change that method instead.
- I decided not to change the current command `editor:cut-to-end-of-line` so that it cuts to the end of the buffer line because that would might surprise users who are relying the current behavior. Also, `editor:select-to-end-of-line` select to the end of the screen line as well, not buffer line, so it made sense to keep these in sync (selecting and cutting to end of line should work with the same line concept so that it's not surprising for users). 
- I decided not to add a new keybinding for this command because it seemed a bit strange to have keybinding for both `editor:cut-to-end-of-line` and `editor:cut-to-end-of-buffer-line`. Normally, users wouldn't use both, they'd use one or the other. 
- I decided not to change the existing keybinding for `editor:cut-to-end-of-line` so that it calls `editor:cut-to-end-of-buffer-line` just so it doesn't surprise users who are used to the existing behavior.

I'm not 100% sure in any of those decisions above. I opened this PR to have a discussion about them -- happy to make changes if anyone feels differently.

cc @thedaniel since you opened that issue https://github.com/atom/atom/issues/2607 and @nathansobo @maxbrunsfeld for :thought_balloon: and :eyes:
