### PR TITLE
:memo: Suggest branch name section in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,26 @@ For more information on how to work with Atom's official packages, see
 * Using a plain `return` when returning explicitly at the end of a function.
     * Not `return null`, `return undefined`, `null`, or `undefined`
 
+### Branch
+
+* Branch name is desired to follow those style-guides:
+  * Begin with your Github Username
+  * Include Topic Categories
+  * Include simple descriptive name for your branch
+  * Username and Topic Categories are separated with `/`
+  * Topic Categories and Branch Name are separated with `_`
+  * Each name is concatenated with `-`
+
+#### Example
+
+```text
+// General
+[Github Username]/topic-categories_simple-descriptive-name-of-your-branch
+
+// Example
+KENJU/documentation_suggestion-for-branch-name-in-contributing
+```
+
 ## Git Commit Messages
 
 * Use the present tense ("Add feature" not "Added feature")


### PR DESCRIPTION
# What
- Suggestion for writing `branch-name` section in `CONTRIBUTING.md`
- What I wrote is just for the first draft, and should be reviewed and improved
# Why
- With the more contributor is getting joined with this community, there are a bunch of branch name
  without any under coherence
# How
- I strongly believe that beginning with Github Username is easy to find and at the same time recognizable
- As for the latter part (topic categories and branch name style), I would like to hear more contributor's opinions
