### PR TITLE
Hotfix: Preserve all event properties when dispatching commands

### DIFF
--- a/spec/command-registry-spec.coffee
+++ b/spec/command-registry-spec.coffee
@@ -115,6 +115,15 @@ describe "CommandRegistry", ->
       grandchild.dispatchEvent(dispatchedEvent)
       expect(dispatchedEvent.abortKeyBinding).toHaveBeenCalled()
 
+    it "copies non-standard properties from the original event to the synthetic event", ->
+      syntheticEvent = null
+      registry.add '.child', 'command', (event) -> syntheticEvent = event
+
+      dispatchedEvent = new CustomEvent('command', bubbles: true)
+      dispatchedEvent.nonStandardProperty = 'testing'
+      grandchild.dispatchEvent(dispatchedEvent)
+      expect(syntheticEvent.nonStandardProperty).toBe 'testing'
+
     it "allows listeners to be removed via a disposable returned by ::add", ->
       calls = []
 

--- a/src/command-registry.coffee
+++ b/src/command-registry.coffee
@@ -227,6 +227,9 @@ class CommandRegistry
     Object.defineProperty dispatchedEvent, 'abortKeyBinding', value: ->
       event.abortKeyBinding?()
 
+    for key in Object.keys(event)
+      dispatchedEvent[key] = event[key]
+
     @emitter.emit 'will-dispatch', dispatchedEvent
 
     loop


### PR DESCRIPTION
Fixes https://github.com/atom/vim-mode/issues/863
Fixes https://github.com/atom/atom/issues/8845

/cc @bhuga
