### PR TITLE
Hotfix: Use bundled Node when running `apm rebuild` from within Atom

### DIFF
--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "1.0.4"
+    "atom-package-manager": "1.0.5"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/8837
