### PR TITLE
Fix coffelint error causing Travis builds to fail

### DIFF
--- a/src/command-installer.coffee
+++ b/src/command-installer.coffee
@@ -70,7 +70,7 @@ module.exports =
           try
             error = null
             symlinkCommandWithPrivilegeSync(commandPath, destinationPath)
-          catch error
-            undefined
+          catch err
+            error = err
 
         callback?(error)

--- a/src/command-installer.coffee
+++ b/src/command-installer.coffee
@@ -71,5 +71,6 @@ module.exports =
             error = null
             symlinkCommandWithPrivilegeSync(commandPath, destinationPath)
           catch error
+            undefined
 
         callback?(error)

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -933,7 +933,7 @@ class Workspace extends Model
   #
   # Returns a `Promise`.
   replace: (regex, replacementText, filePaths, iterator) ->
-    new Promise (resolve, reject) =>
+    new Promise (resolve, reject) ->
       openPaths = (buffer.getPath() for buffer in atom.project.getBuffers())
       outOfProcessPaths = _.difference(filePaths, openPaths)
 


### PR DESCRIPTION
Currently, running coffeelint produces this error and causes Travis builds to fail:

```
Running "coffeelint:src" (coffeelint) task
src/command-installer.coffee
  ✖  line 73  Line contains inconsistent indentation  Expected 2 got 0
✖ 1 error
Warning: Task "coffeelint:src" failed. Use --force to continue.
Error: Task "coffeelint:src" failed.
```

See clutchski/coffeelint#189 for more information on this problem and suggested approach, and for a different place in Atom where this approach is used see this:

https://github.com/atom/atom/blob/ca39c106d6570b7e46129dd445dde3b9ba84cf9f/src/config.coffee#L984

cc @mnquintana @kevinsawicki for :eyes: and :thought_balloon: in case there's a better way to fix this.
