### PR TITLE
:bug: Teach Atom to read .git files

### DIFF
--- a/spec/git-repository-provider-spec.coffee
+++ b/spec/git-repository-provider-spec.coffee
@@ -11,7 +11,7 @@ describe "GitRepositoryProvider", ->
       it "returns a Promise that resolves to a GitRepository", ->
         waitsForPromise ->
           provider = new GitRepositoryProvider atom.project
-          directory = new Directory path.join(__dirname, 'fixtures/git/master.git')
+          directory = new Directory path.join(__dirname, 'fixtures', 'git', 'master.git')
           provider.repositoryForDirectory(directory).then (result) ->
             expect(result).toBeInstanceOf GitRepository
             expect(provider.pathToRepository[result.getPath()]).toBeTruthy()
@@ -24,11 +24,11 @@ describe "GitRepositoryProvider", ->
         secondRepo = null
 
         waitsForPromise ->
-          directory = new Directory path.join(__dirname, 'fixtures/git/master.git')
+          directory = new Directory path.join(__dirname, 'fixtures', 'git', 'master.git')
           provider.repositoryForDirectory(directory).then (result) -> firstRepo = result
 
         waitsForPromise ->
-          directory = new Directory path.join(__dirname, 'fixtures/git/master.git/objects')
+          directory = new Directory path.join(__dirname, 'fixtures', 'git', 'master.git', 'objects')
           provider.repositoryForDirectory(directory).then (result) -> secondRepo = result
 
         runs ->
@@ -60,7 +60,7 @@ describe "GitRepositoryProvider", ->
       it "returns a Promise that resolves to a GitRepository", ->
         waitsForPromise ->
           provider = new GitRepositoryProvider atom.project
-          gitDirPath = path.join(__dirname, 'fixtures/git/master.git')
+          gitDirPath = path.join(__dirname, 'fixtures', 'git', 'master.git')
           workDirPath = temp.mkdirSync('git-workdir')
           fs.writeFileSync(path.join(workDirPath, '.git'), 'gitdir: ' + gitDirPath+'\n')
 

--- a/spec/git-repository-provider-spec.coffee
+++ b/spec/git-repository-provider-spec.coffee
@@ -56,6 +56,21 @@ describe "GitRepositoryProvider", ->
           provider.repositoryForDirectory(directory).then (result) ->
             expect(result).toBe null
 
+    describe "when specified a Directory with a valid gitfile-linked repository", ->
+      it "returns a Promise that resolves to a GitRepository", ->
+        waitsForPromise ->
+          provider = new GitRepositoryProvider atom.project
+          gitDirPath = path.join(__dirname, 'fixtures/git/master.git')
+          workDirPath = temp.mkdirSync('git-workdir')
+          fs.writeFileSync(path.join(workDirPath, '.git'), 'gitdir: ' + gitDirPath+'\n')
+
+          directory = new Directory workDirPath
+          provider.repositoryForDirectory(directory).then (result) ->
+            expect(result).toBeInstanceOf GitRepository
+            expect(provider.pathToRepository[result.getPath()]).toBeTruthy()
+            expect(result.statusTask).toBeTruthy()
+            expect(result.getType()).toBe 'git'
+
     describe "when specified a Directory without existsSync()", ->
       directory = null
       provider = null

--- a/src/git-repository-provider.coffee
+++ b/src/git-repository-provider.coffee
@@ -1,5 +1,16 @@
 fs = require 'fs'
+{Directory} = require 'pathwatcher'
 GitRepository = require './git-repository'
+
+# Returns the .gitdir path in the agnostic Git symlink .git file given, or
+# null if the path is not a valid gitfile.
+#
+# * `gitFile` {String} path of gitfile to parse
+gitFileRegex = RegExp "^gitdir: (.+)"
+pathFromGitFile = (gitFile) ->
+  try
+    gitFileBuff = fs.readFileSync(gitFile, 'utf8')
+    return gitFileBuff?.match(gitFileRegex)[1]
 
 # Checks whether a valid `.git` directory is contained within the given
 # directory or one of its ancestors. If so, a Directory that corresponds to the
@@ -11,6 +22,9 @@ findGitDirectorySync = (directory) ->
   # can return cached values rather than always returning new objects:
   # getParent(), getFile(), getSubdirectory().
   gitDir = directory.getSubdirectory('.git')
+  gitDirPath = pathFromGitFile(gitDir.getPath?())
+  if gitDirPath
+    gitDir = new Directory(directory.resolve(gitDirPath))
   if gitDir.existsSync?() and isValidGitDirectorySync gitDir
     gitDir
   else if directory.isRoot()


### PR DESCRIPTION
This fixes part of #8168.  The git-worktree model still is not supported, but this is because it is so new that libgit2 doesn't know about it yet, either.  But the .git-file feature which is heavily used by submodules works with this fix.
