### PR TITLE
Throw exception when adding a pane item that has already been destroyed

### DIFF
--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -355,6 +355,7 @@ class Pane extends Model
   # Returns the added item.
   addItem: (item, index=@getActiveItemIndex() + 1) ->
     throw new Error("Pane items must be objects. Attempted to add item #{item}.") unless item? and typeof item is 'object'
+    throw new Error("Adding a pane item with URI '#{item.getURI?()}' that has already been destroyed") if item.isDestroyed?()
 
     return if item in @items
 


### PR DESCRIPTION
Closes atom/bracket-matcher#178

@izuzak: This will help place blame properly when we attempt to add a pane item that reports itself as destroyed.
