### PR TITLE
Allow null TextEditorComponent::domNode during visibility check

### DIFF
--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -34,6 +34,7 @@ class TextEditorComponent
   stylingChangeAnimationFrameRequested: false
   gutterComponent: null
   mounted: true
+  initialized: false
 
   constructor: ({@editor, @hostElement, @rootElement, @stylesElement, @useShadowDOM, tileSize}) ->
     @tileSize = tileSize if tileSize?
@@ -102,6 +103,7 @@ class TextEditorComponent
 
     @updateSync()
     @checkForVisibilityChange()
+    @initialized = true
 
   destroy: ->
     @mounted = false
@@ -558,7 +560,11 @@ class TextEditorComponent
     disposables.add(@editor.onDidDestroy(stopDragging))
 
   isVisible: ->
-    @domNode.offsetHeight > 0 or @domNode.offsetWidth > 0
+    # Investigating an exception that occurs here due to ::domNode being null.
+    atom.assert @domNode?, "TextEditorComponent::domNode was null.", (error) =>
+      error.metadata = {@initialized}
+
+    @domNode? and (@domNode.offsetHeight > 0 or @domNode.offsetWidth > 0)
 
   pollDOM: =>
     unless @checkForVisibilityChange()

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -36,6 +36,12 @@ class TextEditorComponent
   mounted: true
   initialized: false
 
+  Object.defineProperty @prototype, "domNode",
+    get: -> @domNodeValue
+    set: (domNode) ->
+      atom.assert domNode?, "TextEditorComponent::domNode was set to null."
+      @domNodeValue = domNode
+
   constructor: ({@editor, @hostElement, @rootElement, @stylesElement, @useShadowDOM, tileSize}) ->
     @tileSize = tileSize if tileSize?
     @disposables = new CompositeDisposable


### PR DESCRIPTION
...and use `atom.assert` to verify that the constructor was run before the exception.

Ref.: #8762 

/cc: @nathansobo @izuzak 
