### PR TITLE
Fix behavior of Cursor methods that are aware of word and non-word characters

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -211,6 +211,50 @@ describe "TextEditor", ->
         editor.getLastCursor().destroy()
         expect(editor.getLastCursor().getBufferPosition()).toEqual([0, 0])
 
+    describe ".getCurrentWordBufferRange()", ->
+      cursor = null
+
+      beforeEach ->
+        editor.setText('atom-+electron')
+        atom.config.set 'editor.nonWordCharacters', '-+'
+        cursor = editor.getLastCursor()
+
+      describe "when cursor is between two word characters", ->
+        beforeEach ->
+          editor.setCursorBufferPosition([0, 2]) # at|om-+electron
+
+        describe "when includeNonWordCharacters is false", ->
+          it "returns the word under the cursor, defined with word characters", ->
+            expect(cursor.getCurrentWordBufferRange({"includeNonWordCharacters": false})).toEqual [[0, 0], [0, 4]] # atom
+
+        describe "when includeNonWordCharacters is true", ->
+          it "returns the word under the cursor, defined with word characters", ->
+            expect(cursor.getCurrentWordBufferRange({"includeNonWordCharacters": true})).toEqual [[0, 0], [0, 4]] # atom
+
+      describe "when cursor is between two non-word characters", ->
+        beforeEach ->
+          editor.setCursorBufferPosition([0, 5]) # atom-|+electron
+
+        describe "when includeNonWordCharacters is false", ->
+          it "returns a zero-width range", ->
+            expect(cursor.getCurrentWordBufferRange({"includeNonWordCharacters": false})).toEqual [[0, 5], [0, 5]] # <nothing>
+
+        describe "when includeNonWordCharacters is true", ->
+          it "returns the word under the cursor, defined with non-word characters", ->
+            expect(cursor.getCurrentWordBufferRange({"includeNonWordCharacters": true})).toEqual [[0, 4], [0, 6]] # -+
+
+      describe "when cursor is between a word character and a non-word character", ->
+        beforeEach ->
+          editor.setCursorBufferPosition([0, 6]) # atom-+|electron
+
+        describe "when includeNonWordCharacters is false", ->
+          it "returns the word next to the cursor, defined with word characters", ->
+            expect(cursor.getCurrentWordBufferRange({"includeNonWordCharacters": false})).toEqual [[0, 6], [0, 14]] # electron
+
+        describe "when includeNonWordCharacters is true", ->
+          it "returns the word next to the cursor, defined with word characters", ->
+            expect(cursor.getCurrentWordBufferRange({"includeNonWordCharacters": true})).toEqual [[0, 6], [0, 14]] # electron
+
     describe ".getCursors()", ->
       it "creates a new cursor at (0, 0) if the last cursor has been destroyed", ->
         editor.getLastCursor().destroy()


### PR DESCRIPTION
This is an attempt to close https://github.com/atom/atom/issues/3650 and close https://github.com/atom/atom/issues/6538.

Sorry for the wall of text below, I think it will be helpful in understanding the confusion and figuring out what the expected behavior is. @benogle (since you commented on https://github.com/atom/atom/issues/3650) @maxbrunsfeld @nathansobo -- I'd love to hear your advice here. Also /cc @atom/feedback for extra :eyes:.

My plan is to split the work around this problem into several steps (within this PR):
- [ ] Describe the problem and write specs to help us understand the expected behavior
- [ ] Update the API documentation to explain the behavior of methods and the supported options
- [ ] Fix the incorrect behavior for all affected methods

This text below if about the first task -- describing the problem and adding specs to confirm expected behavior.

https://github.com/atom/atom/issues/3650 and https://github.com/atom/atom/issues/6538 bring up a problem with how `Cursor.getCurrentWordBufferRange` works in some cases. For text like `atom-+electron`, here are results for different positions of the cursor and different values of the `includeNonWordCharacters` option:

| Cursor position | `includeNonWordCharacters = true` | `includeNonWordCharacters = false` |
| --- | --- | --- |
| <code>at&#124;om&#8209;+electron</code> | `atom` | `atom` |
| <code>atom&#8209;&#124;+electron</code> | `-+` | _nothing_ |
| <code>atom&#8209;+&#124;electron</code> | `-+electron` | `electron` |

The problem with the above is the inconsistency of behavior, lack of specs, and unclear documentation:
- When the cursor is between a word character and a non-word character (<code>atom&#8209;+&#124;electron</code>) and `includeNonWordCharacters = true`, then both the word characters and the non word characters are grouped into a single word (`-+electron`), but only those groups next to the cursor (notice that `atom` wasn't grouped into that).
- When the cursor is between two word characters (or two non-word characters) and `includeNonWordCharacters = true`, then only word characters or only non-word characters are grouped into a single word.
- The [documentation](https://github.com/atom/atom/blob/e1fb376a084f463c4f1e641cb89803dc3095f9b2/src/cursor.coffee#L616-L617) for the `includeNonWordCharacters` option is unclear -- it says: "A Boolean indicating whether to include non-word characters in the regex." But it's not clear if that means that the regex then groups both word and non-word characters into a single word, or that the regex groups non-word characters into words, but not together with word characters. The name of the option implies the former, but the behavior _mostly_ implies the latter.
- There are no specs around these methods which would indicate expected behavior, as far as I can tell.

My _guess_ is that the intended meaning of the `includeNonWordCharacters` option is "should non-word characters be grouped together into a word (but never together with word characters)". In other words, the `-+electron` result from table above should not happen since it contains both word and non-word characters, and would be considered a bug. Instead, the result should have been `electron` since that's the word next to the cursor (we favor words consisting of word characters, not words consisting of non-word characters).

Based on this guess -- I added specs in this PR to cover the cases shown in the table, and the only spec which fails is the one for `-+electron`:

```
TextEditor
  cursor
    .getCurrentWordBufferRange()
      when cursor is between a word character and non-word character
        when includeNonWordCharacters is true
          it returns the word next to the cursor, defined with word characters
            Expected { start : { row : 0, column : 4 }, end : { row : 0, column : 14 } } to equal [ [ 0, 6 ], [ 0, 14 ] ].
```

The reason why this problem happens lies in how the `Cursor.getCurrentWordBufferRange` methods works. That method scans to the left and to the right [to find the edge of words](https://github.com/atom/atom/blob/e1fb376a084f463c4f1e641cb89803dc3095f9b2/src/cursor.coffee#L551). However, it doesn't check if the cursor is between a word and a non-word character. That's relevant because if `includeNonWordCharacters` is `true` -- the method will group word and non-word characters together by joining the left and right part together. Some other methods in the `Cursor` class have the same problem (for example, [`getBeginningOfCurrentWordBufferPosition`](https://github.com/atom/atom/blob/e1fb376a084f463c4f1e641cb89803dc3095f9b2/src/cursor.coffee#L476) and [`getEndOfCurrentWordBufferPosition`](https://github.com/atom/atom/blob/e1fb376a084f463c4f1e641cb89803dc3095f9b2/src/cursor.coffee#L506) which `getCurrentWordBufferRange` uses for scanning) -- they don't check if the cursor is between a word and non-word character.

Interestingly, this check is made as a part of one other public method -- in [Selection.selectWord](https://github.com/atom/atom/blob/abf6d40cc4e3462a38fe2ce041d222d369e44147/src/selection.coffee#L315). Notice how this method uses `Cursor.isBetweenWordAndNonWord()` first, and modifies behavior based on that. I believe that logic should be in `Cursor` methods. In other words, `Cursor` methods should check if the cursor is between a word and non-word character and handle the situation when `includeNonWordCharacters` is `true`.

I'm not 100% sure about this, so definitely want to hear if this sounds good to everyone.
