### PR TITLE
Add top/bottom split options when opening uri in a workspace

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -281,6 +281,90 @@ describe "Workspace", ->
               expect(workspace.paneContainer.root.children[0]).toBe pane1
               expect(workspace.paneContainer.root.children[1]).toBe pane4
 
+      describe "when the 'split' option is 'up'", ->
+        it "opens the editor in the topmost pane of the current pane axis", ->
+          pane1 = workspace.getActivePane()
+          pane2 = pane1.splitDown()
+          expect(workspace.getActivePane()).toBe pane2
+
+          editor = null
+          waitsForPromise ->
+            workspace.open('a', split: 'up').then (o) -> editor = o
+
+          runs ->
+            expect(workspace.getActivePane()).toBe pane1
+            expect(pane1.items).toEqual [editor]
+            expect(pane2.items).toEqual []
+
+          # Focus bottom pane and reopen the file on the top
+          waitsForPromise ->
+            pane2.focus()
+            workspace.open('a', split: 'up').then (o) -> editor = o
+
+          runs ->
+            expect(workspace.getActivePane()).toBe pane1
+            expect(pane1.items).toEqual [editor]
+            expect(pane2.items).toEqual []
+
+      describe "when a pane axis is the topmost sibling of the current pane", ->
+        it "opens the new item in the current pane", ->
+          editor = null
+          pane1 = workspace.getActivePane()
+          pane2 = pane1.splitUp()
+          pane3 = pane2.splitRight()
+          pane1.activate()
+          expect(workspace.getActivePane()).toBe pane1
+
+          waitsForPromise ->
+            workspace.open('a', split: 'up').then (o) -> editor = o
+
+          runs ->
+            expect(workspace.getActivePane()).toBe pane1
+            expect(pane1.items).toEqual [editor]
+
+      describe "when the 'split' option is 'down'", ->
+        it "opens the editor in the bottommost pane of the current pane axis", ->
+          editor = null
+          pane1 = workspace.getActivePane()
+          pane2 = null
+          waitsForPromise ->
+            workspace.open('a', split: 'down').then (o) -> editor = o
+
+          runs ->
+            pane2 = workspace.getPanes().filter((p) -> p isnt pane1)[0]
+            expect(workspace.getActivePane()).toBe pane2
+            expect(pane1.items).toEqual []
+            expect(pane2.items).toEqual [editor]
+
+          # Focus bottom pane and reopen the file on the right
+          waitsForPromise ->
+            pane1.focus()
+            workspace.open('a', split: 'down').then (o) -> editor = o
+
+          runs ->
+            expect(workspace.getActivePane()).toBe pane2
+            expect(pane1.items).toEqual []
+            expect(pane2.items).toEqual [editor]
+
+        describe "when a pane axis is the bottommost sibling of the current pane", ->
+          it "opens the new item in a new pane split to the bottom of the current pane", ->
+            editor = null
+            pane1 = workspace.getActivePane()
+            pane2 = pane1.splitDown()
+            pane1.activate()
+            expect(workspace.getActivePane()).toBe pane1
+            pane4 = null
+
+            waitsForPromise ->
+              workspace.open('a', split: 'down').then (o) -> editor = o
+
+            runs ->
+              pane4 = workspace.getPanes().filter((p) -> p isnt pane1)[0]
+              expect(workspace.getActivePane()).toBe pane4
+              expect(pane4.items).toEqual [editor]
+              expect(workspace.paneContainer.root.children[0]).toBe pane1
+              expect(workspace.paneContainer.root.children[1]).toBe pane2
+
     describe "when an initialLine and initialColumn are specified", ->
       it "moves the cursor to the indicated location", ->
         waitsForPromise ->

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -678,6 +678,30 @@ class Pane extends Model
     else
       @splitRight()
 
+  # If the parent is a vertical axis, returns its first child if it is a pane;
+  # otherwise returns this pane.
+  findTopmostSibling: ->
+    if @parent.orientation is 'vertical'
+      [topmostSibling] = @parent.children
+      if topmostSibling instanceof PaneAxis
+        this
+      else
+        topmostSibling
+    else
+      this
+
+  # If the parent is a vertical axis, returns its last child if it is a pane;
+  # otherwise returns a new pane created by splitting this pane bottomward.
+  findOrCreateBottommostSibling: ->
+    if @parent.orientation is 'vertical'
+      bottommostSibling = last(@parent.children)
+      if bottommostSibling instanceof PaneAxis
+        @splitRight()
+      else
+        bottommostSibling
+    else
+      @splitDown()
+
   close: ->
     @destroy() if @confirmClose()
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -361,9 +361,11 @@ class Workspace extends Model
   #     initially. Defaults to `0`.
   #   * `initialColumn` A {Number} indicating which column to move the cursor to
   #     initially. Defaults to `0`.
-  #   * `split` Either 'left' or 'right'. If 'left', the item will be opened in
-  #     leftmost pane of the current active pane's row. If 'right', the
-  #     item will be opened in the rightmost pane of the current active pane's row.
+  #   * `split` Either 'left', 'right', 'top' or 'bottom'.
+  #     If 'left', the item will be opened in leftmost pane of the current active pane's row.
+  #     If 'right', the item will be opened in the rightmost pane of the current active pane's row.
+  #     If 'up', the item will be opened in topmost pane of the current active pane's row.
+  #     If 'down', the item will be opened in the bottommost pane of the current active pane's row.
   #   * `activatePane` A {Boolean} indicating whether to call {Pane::activate} on
   #     containing pane. Defaults to `true`.
   #   * `searchAllPanes` A {Boolean}. If `true`, the workspace will attempt to
@@ -383,6 +385,10 @@ class Workspace extends Model
         @getActivePane().findLeftmostSibling()
       when 'right'
         @getActivePane().findOrCreateRightmostSibling()
+      when 'up'
+        @getActivePane().findTopmostSibling()
+      when 'down'
+        @getActivePane().findOrCreateBottommostSibling()
       else
         @getActivePane()
 


### PR DESCRIPTION
Exactly the same behaviour as left/right for top/bottom.

FYI, I need this to update the [find-and-replace](https://github.com/atom/find-and-replace) package with an option to open Find results on the bottom. For now, the package allows to open Find results only on the right.

Now : 

![capture d ecran 2015-09-24 a 10 27 07](https://cloud.githubusercontent.com/assets/216385/10068890/81d1a970-62a8-11e5-9906-cec69f10143d.png)

With the bottom option : 

![capture d ecran 2015-09-24 a 10 27 36](https://cloud.githubusercontent.com/assets/216385/10068891/8a845da6-62a8-11e5-9797-d9a7d8d5f676.png)
