### PR TITLE
Add Node 4 to Travis Build Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ branches:
     - master
 
 env:
+  - NODE_VERSION=0.12
+  - NODE_VERSION=4
+
   global:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
-    - NODE_VERSION=0.12
 
 compiler: clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ branches:
     - master
 
 env:
-  - NODE_VERSION=0.12
-  - NODE_VERSION=4
-
+  matrix:
+    - NODE_VERSION=0.12
+    - NODE_VERSION=4
   global:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,7 @@ matrix:
     - os: linux
       env: NODE_VERSION=4
     - os: osx
-      env: ATOM_SPECS_TASK=core NODE_VERSION=4
-    - os: osx
       env: ATOM_SPECS_TASK=core NODE_VERSION=0.12
-    - os: osx
-      env: ATOM_SPECS_TASK=packages NODE_VERSION=4
     - os: osx
       env: ATOM_SPECS_TASK=packages NODE_VERSION=0.12
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-os:
-  - linux
-  - osx
-
 git:
   depth: 10
 
@@ -10,9 +6,6 @@ branches:
     - master
 
 env:
-  matrix:
-    - NODE_VERSION=0.12
-    - NODE_VERSION=4
   global:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
 
@@ -20,12 +13,18 @@ compiler: clang
 
 matrix:
   include:
+    - os: linux
+      env: NODE_VERSION=0.12
+    - os: linux
+      env: NODE_VERSION=4
     - os: osx
-      env:
-        - ATOM_SPECS_TASK=core
+      env: ATOM_SPECS_TASK=core NODE_VERSION=4
     - os: osx
-      env:
-        - ATOM_SPECS_TASK=packages
+      env: ATOM_SPECS_TASK=core NODE_VERSION=0.12
+    - os: osx
+      env: ATOM_SPECS_TASK=packages NODE_VERSION=4
+    - os: osx
+      env: ATOM_SPECS_TASK=packages NODE_VERSION=0.12
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ branches:
     - master
 
 env:
+  matrix:
+    - NODE_VERSION=0.12
+    - NODE_VERSION=4
   global:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
-    - NODE_VERSION=4
 
 compiler: clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,9 @@ branches:
     - master
 
 env:
-  matrix:
-    - NODE_VERSION=0.12
-    - NODE_VERSION=4
   global:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
+    - NODE_VERSION=4
 
 compiler: clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - linux
+  - osx
+
 git:
   depth: 10
 
@@ -16,11 +20,12 @@ compiler: clang
 
 matrix:
   include:
-    - os: linux
     - os: osx
-      env: ATOM_SPECS_TASK=core
+      env:
+        - ATOM_SPECS_TASK=core
     - os: osx
-      env: ATOM_SPECS_TASK=packages
+      env:
+        - ATOM_SPECS_TASK=packages
 
 sudo: false
 

--- a/build/package.json
+++ b/build/package.json
@@ -33,7 +33,7 @@
     "rcedit": "~0.3.0",
     "request": "~2.27.0",
     "rimraf": "~2.2.2",
-    "runas": "^2",
+    "runas": "^3",
     "tello": "1.0.5",
     "temp": "~0.8.1",
     "underscore-plus": "1.x",

--- a/build/package.json
+++ b/build/package.json
@@ -33,7 +33,7 @@
     "rcedit": "~0.3.0",
     "request": "~2.27.0",
     "rimraf": "~2.2.2",
-    "runas": "^3",
+    "runas": "^3.1",
     "tello": "1.0.5",
     "temp": "~0.8.1",
     "underscore-plus": "1.x",


### PR DESCRIPTION
Closes #8923.

This is a continuation of #8923 that will allow us to test whether node 4 works correctly with our dependencies.

This will increase a bit the Travis backlog but this is only temporary, as we should be able to keep only the latest node version after we merge #8779.

/cc: @atom/feedback @mnquintana 
