### PR TITLE
Upgrade to Electron 0.30.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "0.30.6",
+  "electronVersion": "0.30.7",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^5.1.10",


### PR DESCRIPTION
Upgrades Electron to prevent a file handle leak on Windows and an uncaught exception when reading an invalid path in the `.asar` archives.

Refs https://github.com/atom/electron/issues/2871
Closes https://github.com/atom/atom/issues/8834
Closes https://github.com/atom/atom/issues/8882
Closes https://github.com/atom/tree-view/issues/580
Closes https://github.com/atom/settings-view/issues/653
