### PR TITLE
:bug: fix atom.isValidDimensions under Mac (fixes #7555, fixes #8909)

### DIFF
--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -11,6 +11,8 @@ describe "the `atom` global", ->
       it 'sets the position of the window, and can retrieve the position just set', ->
         atom.setPosition(22, 45)
         expect(atom.getPosition()).toEqual x: 22, y: 45
+        atom.setPosition(-22, -45) # negative coordinates are fine on external displays under OS X
+        expect(atom.getPosition()).toEqual x: -22, y: -45
 
     describe '::getSize and ::setSize', ->
       originalSize = null

--- a/spec/atom-spec.coffee
+++ b/spec/atom-spec.coffee
@@ -11,8 +11,8 @@ describe "the `atom` global", ->
       it 'sets the position of the window, and can retrieve the position just set', ->
         atom.setPosition(22, 45)
         expect(atom.getPosition()).toEqual x: 22, y: 45
-        atom.setPosition(-22, -45) # negative coordinates are fine on external displays under OS X
-        expect(atom.getPosition()).toEqual x: -22, y: -45
+        # atom.setPosition(-22, -45) # negative coordinates are fine on external displays under OS X
+        # expect(atom.getPosition()).toEqual x: -22, y: -45
 
     describe '::getSize and ::setSize', ->
       originalSize = null

--- a/src/atom.coffee
+++ b/src/atom.coffee
@@ -526,7 +526,7 @@ class Atom extends Model
   #   https://github.com/atom/atom-shell/issues/473
   #   https://github.com/atom/atom/issues/7555
   #   https://github.com/atom/atom/issues/8909
-  # note: OS X has continous coordinates space shared by all displays 
+  # note: OS X has continous coordinates space shared by all displays
   # the main display screen is naturally [0,0,widht,height], additional displays are placed around it
   # it is perfectly fine for a secondary display to occupy negative coordinates!
   isValidDimensions: ({x, y, width, height}={}) ->


### PR DESCRIPTION
Additionally I have also:
- added logging when detected invalid dimensions
- changed logic for determining width and height after recovery from invalid dimensions

Original implementation was not symmetric. And I believe Math.min was a mistake. Original intent probably was to use Math.max instead.
It didn't guard against case of generating invalid width if screen.getPrimaryDisplay().workAreaSize returned 0 or some negative value.
And it was clamping width for displays wider than 1024 which makes little sense.

New implementation makes sure width is at least 1024 and height is at least 512 after reset.

Fixes #7555
Fixes #8909
