### PR TITLE
Upgrade text-buffer to fix serialization incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "space-pen": "3.8.2",
     "stacktrace-parser": "0.1.1",
     "temp": "0.8.1",
-    "text-buffer": "6.7.2",
+    "text-buffer": "6.7.3",
     "theorist": "^1.0.2",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/8849
Fixes https://github.com/atom/atom/issues/8888

In https://github.com/atom/text-buffer/pull/95, I added a field `load` to the `TextBuffer`'s serialization format. I did this because previously, text-buffers would always try to load when deserializing, even if they didn't have a file! Unfortunately, when I did this, I forgot to bump the serialization format. This caused text-buffers to deserialize without loading their underlying file, which caused the above two Atom issues.

In this latest version of `text-buffer`, I remove that `load` field. It was actually somewhat redundant; a better solution is to just avoid loading when buffers don't have a `filePath`.
