### PR TITLE
Remove hardcoded Makefile tab behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "language-javascript": "0.96.0",
     "language-json": "0.16.0",
     "language-less": "0.28.2",
-    "language-make": "0.17.0",
+    "language-make": "0.18.0",
     "language-mustache": "0.12.0",
     "language-objective-c": "0.15.0",
     "language-perl": "0.29.0",

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3684,19 +3684,6 @@ describe "TextEditor", ->
         runs ->
           expect(editor.softTabs).toBe false
 
-      it "uses hard tabs in Makefile files", ->
-        # FIXME remove once this is handled by a scoped setting in the
-        # language-make package
-
-        waitsForPromise ->
-          atom.packages.activatePackage('language-make')
-
-        waitsForPromise ->
-          atom.project.open('Makefile').then (o) -> editor = o
-
-        runs ->
-          expect(editor.softTabs).toBe false
-
     describe "when editor.tabType is 'hard'", ->
       beforeEach ->
         atom.config.set('editor.tabType', 'hard')

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2344,10 +2344,6 @@ class TextEditor extends Model
   # Returns a {Boolean} or undefined if no non-comment lines had leading
   # whitespace.
   usesSoftTabs: ->
-    # FIXME Remove once this can be specified as a scoped setting in the
-    # language-make package
-    return false if @getGrammar()?.scopeName is 'source.makefile'
-
     for bufferRow in [0..@buffer.getLastRow()]
       continue if @displayBuffer.tokenizedBuffer.tokenizedLineForRow(bufferRow).isComment()
 


### PR DESCRIPTION
With the merge of atom/language-make#23, this hardcoded behavior is no longer needed and is set in the Make package itself.

Refs atom/language-make#21.

/cc @benogle 
