### PR TITLE
upgrade packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "stacktrace-parser": "0.1.3",
     "temp": "0.8.3",
     "text-buffer": "7.1.2",
-    "typescript-simple": "1.0.0",
+    "typescript-simple": "2.0.0",
     "underscore-plus": "^1.6.6",
     "yargs": "^3.23.0"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "scrollbar-style": "^3.2",
     "season": "^5.3",
     "semver": "^5.0.3",
-    "service-hub": "^0.6.2",
+    "service-hub": "^0.7.0",
     "source-map-support": "^0.3.2",
     "stacktrace-parser": "0.1.3",
     "temp": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "event-kit": "^1.3.0",
     "first-mate": "^5.0.0",
     "fs-plus": "^2.8.0",
-    "fstream": "0.1.24",
+    "fstream": "1.0.8",
     "fuzzaldrin": "^2.1",
     "git-utils": "^4",
     "grim": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "service-hub": "^0.6.2",
     "source-map-support": "^0.3.2",
     "stacktrace-parser": "0.1.3",
-    "temp": "0.8.1",
+    "temp": "0.8.3",
     "text-buffer": "7.1.2",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "scoped-property-store": "^0.17.0",
     "scrollbar-style": "^3.2",
     "season": "^5.3",
-    "semver": "^4.3.3",
+    "semver": "^5.0.3",
     "service-hub": "^0.6.2",
     "source-map-support": "^0.3.2",
     "stacktrace-parser": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bootstrap": "^3.3.4",
     "clear-cut": "^2.0.1",
     "coffee-script": "1.8.0",
-    "color": "^0.7.3",
+    "color": "^0.10.1",
     "event-kit": "^1.3.0",
     "first-mate": "^5.0.0",
     "fs-plus": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "semver": "^4.3.3",
     "service-hub": "^0.6.2",
     "source-map-support": "^0.3.2",
-    "stacktrace-parser": "0.1.1",
+    "stacktrace-parser": "0.1.3",
     "temp": "0.8.1",
     "text-buffer": "7.1.2",
     "typescript-simple": "1.0.0",


### PR DESCRIPTION
| package | current | upgraded | status | age |
| :-: | :-: | :-: | :-: | :-: |
| async | 0.2.6 |  | :arrow_left: | 31 months :heavy_exclamation_mark: |
| coffee-script | 1.8.0 |  | :arrow_left: | 13 months |
| color | ^0.7.3 | ^10.0.1 | :arrow_up: | 12 months |
| fstream | 0.1.24 | 1.0.8 | :arrow_up: | 26 months :heavy_exclamation_mark: |
| semver | ^4.3.3 | ^5.0.3 | :arrow_up: | 4 months |
| service-hub | ^0.6.2 | ^0.7.0 | :arrow_up: | 3 months |
| stacktrace-parser | 0.1.1 | 1.1.3 | :arrow_up: | 20 months :heavy_exclamation_mark: |
| temp | 0.8.1 | 0.8.3 | :arrow_up: | 14 months |
| typescript-simple | 1.0.0 | 2.0.0 | :arrow_up: | 7 months |
