### PR TITLE
Update reference to deprecated method Project::getRepo

### DIFF
--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -10,8 +10,8 @@ Task = require './task'
 # Extended: Represents the underlying git operations performed by Atom.
 #
 # This class shouldn't be instantiated directly but instead by accessing the
-# `atom.project` global and calling `getRepo()`. Note that this will only be
-# available when the project is backed by a Git repository.
+# `atom.project` global and calling `getRepositories()`. Note that this will
+# only be available when the project is backed by a Git repository.
 #
 # This class handles submodules automatically by taking a `path` argument to many
 # of the methods.  This `path` argument will determine which underlying
@@ -20,7 +20,7 @@ Task = require './task'
 # For a repository with submodules this would have the following outcome:
 #
 # ```coffee
-# repo = atom.project.getRepo()
+# repo = atom.project.getRepositories()[0]
 # repo.getShortHead() # 'master'
 # repo.getShortHead('vendor/path/to/a/submodule') # 'dead1234'
 # ```
@@ -30,7 +30,7 @@ Task = require './task'
 # ### Logging the URL of the origin remote
 #
 # ```coffee
-# git = atom.project.getRepo()
+# git = atom.project.getRepositories()[0]
 # console.log git.getOriginURL()
 # ```
 #


### PR DESCRIPTION
GitRepository class documentation references deprecated method `Project::getRepo`. This resolves that by instead using the replacement `Project::getRepositories`.

Although, it seems as if that will be removed in v2.0, so perhaps we should update this to instead using the async `Project::getDirectories` method, coupled with `Project::repositoryForDirectory`?

/cc @atom/feedback

---

Fixes #8971
