### PR TITLE
Fix Windows context menu shortcut

### DIFF
--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -67,9 +67,9 @@ installContextMenu = (callback) ->
   installMenu = (keyPath, arg, callback) ->
     args = [keyPath, '/ve', '/d', 'Open with Atom']
     addToRegistry args, ->
-      args = [keyPath, '/v', 'Icon', '/d', process.execPath]
+      args = [keyPath, '/v', 'Icon', '/d', "\"#{process.execPath}\""]
       addToRegistry args, ->
-        args = ["#{keyPath}\\command", '/ve', '/d', "#{process.execPath} \"#{arg}\""]
+        args = ["#{keyPath}\\command", '/ve', '/d', "\"#{process.execPath}\" \"#{arg}\""]
         addToRegistry(args, callback)
 
   installMenu fileKeyPath, '%1', ->


### PR DESCRIPTION
Fix the bug where Open With Atom on Windows machines will fail for paths containing spaces. Wraps quotes around the path to the Atom executable in the reg key string. This fixes #8658.
