### PR TITLE
invoke fakeSetInterval callback multiple times if possible

### DIFF
--- a/spec/fake-timer-spec.coffee
+++ b/spec/fake-timer-spec.coffee
@@ -1,0 +1,24 @@
+# spec for fakeSetInterval, converting from @scv119
+
+require "./spec-helper"
+
+describe "test fakeSetInterval", ->
+  it 'triggered in expected order', ->
+    firstExecutedCount = 0
+    secondExecutedCount = 0
+
+    fakeSetInterval ->
+      firstExecutedCount++
+      expect(secondExecutedCount < firstExecutedCount).toBe true
+    , 10
+
+    advanceClock 5
+
+    fakeSetInterval ->
+      secondExecutedCount++
+    , 10
+
+    advanceClock 40
+
+    expect(firstExecutedCount).toBe 4
+    expect(secondExecutedCount).toBe 4


### PR DESCRIPTION
This commit is addressing issue #6627. By recording interval
timer's next invoking time, the callback of `fakeSetInterval`
now will be invoked multiple by `advanceClock()`
