### PR TITLE
Avoid leaking DOM objects

### DIFF
--- a/src/scrollbar-component.coffee
+++ b/src/scrollbar-component.coffee
@@ -12,6 +12,9 @@ class ScrollbarComponent
 
     @domNode.addEventListener 'scroll', @onScrollCallback
 
+  destroy: ->
+    @onScroll = null
+
   getDomNode: ->
     @domNode
 

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -119,6 +119,14 @@ class TextEditorComponent
     @gutterContainerComponent?.destroy()
     @domElementPool.clear()
 
+    @verticalScrollbarComponent.destroy()
+    @horizontalScrollbarComponent.destroy()
+
+    @verticalScrollbarComponent = null
+    @horizontalScrollbarComponent = null
+    @onVerticalScroll = null
+    @onHorizontalScroll = null
+
   getDomNode: ->
     @domNode
 

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -563,7 +563,7 @@ class TextEditorComponent
     @sampleBackgroundColors()
     @remeasureCharacterWidths()
 
-  handleDragUntilMouseUp: (dragHandler) =>
+  handleDragUntilMouseUp: (dragHandler) ->
     dragging = false
     lastMousePosition = {}
     animationLoop = =>

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -122,8 +122,6 @@ class TextEditorComponent
     @verticalScrollbarComponent.destroy()
     @horizontalScrollbarComponent.destroy()
 
-    @verticalScrollbarComponent = null
-    @horizontalScrollbarComponent = null
     @onVerticalScroll = null
     @onHorizontalScroll = null
 

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -129,7 +129,7 @@ class TextEditorPresenter
       @shouldUpdateCustomGutterDecorationState = true
       @emitDidUpdateState()
 
-    @model.onDidUpdateMarkers =>
+    @disposables.add @model.onDidUpdateMarkers =>
       @shouldUpdateLinesState = true
       @shouldUpdateLineNumbersState = true
       @shouldUpdateDecorations = true


### PR DESCRIPTION
With this PR we make sure to clear out all the references that caused `TextEditorComponent`s to be retained (e.g. closures, etc.). Below you can have a look at how the heap looked like after scrolling for a while on multiple editors and then closing them.

![screen shot 2015-10-07 at 11 09 04](https://cloud.githubusercontent.com/assets/482957/10333455/62597a46-6ce4-11e5-9b86-fefc036d4e29.png)

![screen shot 2015-10-07 at 11 16 35](https://cloud.githubusercontent.com/assets/482957/10333550/f726adc4-6ce4-11e5-9a44-dd4a5fdc73ed.png)

As you can see, a lot of elements were leaking because they were still retained by `TextEditorComponent`.

This is how the heap looks after the changes in this PR:

![screen shot 2015-10-07 at 11 09 11](https://cloud.githubusercontent.com/assets/482957/10333477/88224b18-6ce4-11e5-83ff-313df800aa74.png)

:non-potable_water: :non-potable_water: :non-potable_water:

/cc: @nathansobo @atom/feedback for :eyes: 
