### PR TITLE
Bug in moving selected lines down

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -849,7 +849,7 @@ class TextEditor extends Model
     selection = @getSelectedBufferRange()
     lastRow = @buffer.getLastRow()
     return if selection.end.row is lastRow
-    return if selection.end.row is lastRow - 1 and @buffer.getLastLine() is ''
+    return if selection.end.row is lastRow - 1 and @buffer.getLastLine() is '' and selection.end.column isnt 0
 
     @transact =>
       foldedRows = []


### PR DESCRIPTION
There was a bug in moving lines down. 
The bug can be reproduced in the following steps:
- Make a text file with last line blank
- Select the entire row of third last line
- Try moving down. It won't move

![output](https://cloud.githubusercontent.com/assets/10784031/10346678/f98a38b0-6d4d-11e5-817b-91391134443b.gif)
