### PR TITLE
Add descriptions for config settings

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -97,7 +97,7 @@ module.exports =
           'windows866'
         ]
       openEmptyEditorOnStart:
-        description: 'Automatically open an empty editor when on startup.'
+        description: 'Automatically open an empty editor on startup.'
         type: 'boolean'
         default: true
 

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -147,7 +147,6 @@ module.exports =
         type: 'boolean'
         default: true
         description: 'Automatically indent the cursor when inserting a newline.'
-        type: 'boolean'
       autoIndentOnPaste:
         type: 'boolean'
         default: true

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -177,7 +177,7 @@ module.exports =
         type: 'string'
         default: 'auto'
         enum: ['auto', 'soft', 'hard']
-        description: 'Determine character inserted when Tab key is pressed. Possible values: "auto", "soft" and "hard". When set to "soft" or "hard", soft tabs (spaces) or hard tabs (tab characters) are used. When set to "auto", the editor auto-detects the tab type based on the contents of the buffer, or uses the value of the Soft Tabs config setting if auto-detection fails.'
+        description: 'Determine character inserted when Tab key is pressed. Possible values: "auto", "soft" and "hard". When set to "soft" or "hard", soft tabs (spaces) or hard tabs (tab characters) are used. When set to "auto", the editor auto-detects the tab type based on the contents of the buffer (it uses the first leading whitespace on a non-comment line), or uses the value of the Soft Tabs config setting if auto-detection fails.'
       softWrapAtPreferredLineLength:
         type: 'boolean'
         default: false

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -17,7 +17,7 @@ module.exports =
         type: 'boolean'
         default: true
         title: 'Exclude VCS Ignored Paths'
-        description: 'Files and directories ignored by the current project\'s VCS system will be ignored by some packages, such as the fuzzy finder and find and replace. For example, project\'s using Git have these paths defined in the .gitignore file. Individual packages might have additional config settings for ignoring VCS ignored files and folders.'
+        description: 'Files and directories ignored by the current project\'s VCS system will be ignored by some packages, such as the fuzzy finder and find and replace. For example, projects using Git have these paths defined in the .gitignore file. Individual packages might have additional config settings for ignoring VCS ignored files and folders.'
       followSymlinks:
         type: 'boolean'
         default: true
@@ -177,7 +177,7 @@ module.exports =
         type: 'string'
         default: 'auto'
         enum: ['auto', 'soft', 'hard']
-        description: 'Determine character inserted when Tab key is pressed. Possible values: "auto", "soft" and "hard". When set to "soft" or "hard", soft tabs (spaces) or hard tabs (tab characters) are used. When set to "auto", the editor auto-detects the tab type based on the contents of the buffer, or uses the value of the Soft Tabs config setting if auto-dection fails.'
+        description: 'Determine character inserted when Tab key is pressed. Possible values: "auto", "soft" and "hard". When set to "soft" or "hard", soft tabs (spaces) or hard tabs (tab characters) are used. When set to "auto", the editor auto-detects the tab type based on the contents of the buffer, or uses the value of the Soft Tabs config setting if auto-detection fails.'
       softWrapAtPreferredLineLength:
         type: 'boolean'
         default: false

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -12,24 +12,27 @@ module.exports =
         default: [".git", ".hg", ".svn", ".DS_Store", "._*", "Thumbs.db"]
         items:
           type: 'string'
+        description: 'List of string glob patterns. Files and directories matching these patterns will be ignored by some packages, such as the fuzzy finder and tree view. Individual packages might have additional config settings for ignoring names.'
       excludeVcsIgnoredPaths:
         type: 'boolean'
         default: true
         title: 'Exclude VCS Ignored Paths'
+        description: 'Files and directories ignored by the current project\'s VCS system will be ignored by some packages, such as the fuzzy finder and find and replace. For example, project\'s using Git have these paths defined in the .gitignore file. Individual packages might have additional config settings for ignoring VCS ignored files and folders.'
       followSymlinks:
         type: 'boolean'
         default: true
         title: 'Follow symlinks'
-        description: 'Used when searching and when opening files with the fuzzy finder.'
+        description: 'Follow symbolic links when searching files and when opening files with the fuzzy finder.'
       disabledPackages:
         type: 'array'
         default: []
         items:
           type: 'string'
+        description: 'List of names of installed packages which are not loaded at startup.'
       customFileTypes:
         type: 'object'
         default: {}
-        description: 'Associates scope names (e.g. "source.js") with arrays of file extensions and file names (e.g. ["Somefile", ".js2"])'
+        description: 'Associates scope names (e.g. `"source.js"`) with arrays of file extensions and file names (e.g. `["Somefile", ".js2"]`)'
         additionalProperties:
           type: 'array'
           items:
@@ -39,15 +42,19 @@ module.exports =
         default: ['one-dark-ui', 'one-dark-syntax']
         items:
           type: 'string'
+        description: 'Names of UI and syntax themes which will be used when Atom starts.'
       projectHome:
         type: 'string'
         default: path.join(fs.getHomeDirectory(), 'github')
+        description: 'The directory where projects are assumed to be located. Packages created using the Package Generator will be stored here by default.'
       audioBeep:
         type: 'boolean'
         default: true
+        description: 'Trigger the system\'s beep sound when certain actions cannot be executed or there are no results.'
       destroyEmptyPanes:
         type: 'boolean'
         default: true
+        description: 'When the last item of a pane is removed, remove that pane as well.'
       fileEncoding:
         description: 'Default character set encoding to use when reading and writing files.'
         type: 'string'
@@ -90,7 +97,7 @@ module.exports =
           'windows866'
         ]
       openEmptyEditorOnStart:
-        description: 'Automatically opens an empty editor when atom starts.'
+        description: 'Automatically open an empty editor when on startup.'
         type: 'boolean'
         default: true
 
@@ -113,41 +120,52 @@ module.exports =
       fontFamily:
         type: 'string'
         default: ''
+        description: 'The name of the font family used for editor text.'
       fontSize:
         type: 'integer'
         default: 14
         minimum: 1
         maximum: 100
+        description: 'Height in pixels of editor text.'
       lineHeight:
         type: ['string', 'number']
         default: 1.5
+        description: 'Height of editor lines, as a multiplier of font size.'
       showInvisibles:
         type: 'boolean'
         default: false
+        description: 'Render placeholders for invisible characters, such as tabs, spaces and newlines.'
       showIndentGuide:
         type: 'boolean'
         default: false
+        description: 'Show indentation indicators in the editor.'
       showLineNumbers:
         type: 'boolean'
         default: true
+        description: 'Show line numbers in the editor\'s gutter.'
       autoIndent:
         type: 'boolean'
         default: true
-        description: 'Automatically indent the cursor when inserting a newline'
+        description: 'Automatically indent the cursor when inserting a newline.'
+        type: 'boolean'
       autoIndentOnPaste:
         type: 'boolean'
         default: true
+        description: 'Automatically indent pasted text based on the indentation of the previous line.'
       nonWordCharacters:
         type: 'string'
         default: "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-…"
+        description: 'A string of non-word characters to define word boundaries.'
       preferredLineLength:
         type: 'integer'
         default: 80
         minimum: 1
+        description: 'Identifies the length of a line which is used when wrapping text with the `Soft Wrap At Preferred Line Length` setting enabled, in number of characters.'
       tabLength:
         type: 'integer'
         default: 2
         enum: [1, 2, 3, 4, 6, 8]
+        description: 'Number of spaces used to represent a tab.'
       softWrap:
         type: 'boolean'
         default: false
@@ -155,32 +173,36 @@ module.exports =
       softTabs:
         type: 'boolean'
         default: true
+        description: 'If the `Tab Type` config setting is set to "auto" and autodetection of tab type from buffer content fails, then this config setting determines whether a soft tab or a hard tab will be inserted when the Tab key is pressed.'
       tabType:
         type: 'string'
         default: 'auto'
         enum: ['auto', 'soft', 'hard']
-        description: 'Determine character inserted during Tab keypress.'
+        description: 'Determine character inserted when Tab key is pressed. Possible values: "auto", "soft" and "hard". When set to "soft" or "hard", soft tabs (spaces) or hard tabs (tab characters) are used. When set to "auto", the editor auto-detects the tab type based on the contents of the buffer, or uses the value of the Soft Tabs config setting if auto-dection fails.'
       softWrapAtPreferredLineLength:
         type: 'boolean'
         default: false
-        description: 'Will wrap to the number of characters defined by the `Preferred Line Length` setting. This will only take effect when soft wrap is enabled globally or for the current language.'
+        description: 'Instead of wrapping lines to the window\'s width, wrap lines to the number of characters defined by the `Preferred Line Length` setting. This will only take effect when the soft wrap config setting is enabled globally or for the current language.'
       softWrapHangingIndent:
         type: 'integer'
         default: 0
         minimum: 0
+        description: 'When soft wrap is enabled, defines length of additional indentation applied to wrapped lines, in number of characters.'
       scrollSensitivity:
         type: 'integer'
         default: 40
         minimum: 10
         maximum: 200
+        description: 'Determines how fast the editor scrolls when using a mouse or trackpad.'
       scrollPastEnd:
         type: 'boolean'
         default: false
+        description: 'Allow the editor to be scrolled past the end of the last line.'
       undoGroupingInterval:
         type: 'integer'
         default: 300
         minimum: 0
-        description: 'Time interval in milliseconds within which operations will be grouped together in the undo history'
+        description: 'Time interval in milliseconds within which text editing operations will be grouped together in the undo history.'
       useShadowDOM:
         type: 'boolean'
         default: true
@@ -190,33 +212,39 @@ module.exports =
         type: 'boolean'
         default: true
         title: 'Confirm Checkout HEAD Revision'
+        description: 'Show confirmation dialog when checking out the HEAD revision and discarding changes to current file since last commit.'
       backUpBeforeSaving:
         type: 'boolean'
         default: false
         description: 'Ensure file contents aren\'t lost if there is an I/O error during save by making a temporary backup copy.'
       invisibles:
         type: 'object'
+        description: 'A hash of characters Atom will use to render whitespace characters. Keys are whitespace character types, values are rendered characters (use value false to turn off individual whitespace character types).'
         properties:
           eol:
             type: ['boolean', 'string']
             default: '\u00ac'
             maximumLength: 1
+            description: 'Character used to render newline characters (\\n) when the `Show Invisibles` setting is enabled. '
           space:
             type: ['boolean', 'string']
             default: '\u00b7'
             maximumLength: 1
+            description: 'Character used to render leading and trailing space characters when the `Show Invisibles` setting is enabled.'
           tab:
             type: ['boolean', 'string']
             default: '\u00bb'
             maximumLength: 1
+            description: 'Character used to render hard tab characters (\\t) when the `Show Invisibles` setting is enabled.'
           cr:
             type: ['boolean', 'string']
             default: '\u00a4'
             maximumLength: 1
+            description: 'Character used to render carriage return characters (for Microsoft-style line endings) when the `Show Invisibles` setting is enabled.'
       zoomFontWhenCtrlScrolling:
         type: 'boolean'
         default: process.platform isnt 'darwin'
-        description: 'Increase/decrease the editor font size when pressing the Ctrl key and scrolling the mouse up/down.'
+        description: 'Change the editor font size when pressing the Ctrl key and scrolling the mouse up/down.'
 
 if process.platform in ['win32', 'linux']
   module.exports.core.properties.autoHideMenuBar =


### PR DESCRIPTION
This adds descriptions for core and editor config settings. I think this will help users understand the purpose of config settings and use them properly. I've definitely seen confusion about what some settings mean and I've been confused about some as well. Once this is merged, I'll start working on clarifying settings for individual packages.

@atom/feedback I'd love your help in reviewing this and making these descriptions as clear and as helpful as possible. Please let me know if you have any wordsmithing advice. :pray: 

Before:

<img width="884" alt="screen shot 2015-10-09 at 12 58 22" src="https://cloud.githubusercontent.com/assets/38924/10392229/7880098c-6e85-11e5-91e9-a4dbe4fd3715.png">

After

<img width="896" alt="screen shot 2015-10-09 at 12 57 27" src="https://cloud.githubusercontent.com/assets/38924/10392228/787d4c9c-6e85-11e5-946a-7ee4b2d4b70f.png">
