### PR TITLE
Fix #4300 by preventing 'will-navigate' event from firing

### DIFF
--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -142,6 +142,8 @@ class AtomWindow
         when 0 then @browserWindow.destroy()
         when 1 then @browserWindow.restart()
 
+    @browserWindow.webContents.on 'will-navigate', (event) -> event.preventDefault()
+
     @setupContextMenu()
 
     if @isSpec


### PR DESCRIPTION
According to https://github.com/atom/atom/issues/4300#issuecomment-139103318 preventing the `will-navigate` event from firing/propagating will resolve the file dragging and dropping problem reported in #4300.

I've been unable to reproduce the problem on OS X, so I'm unsure if this actually fixes it or not. Will test on a VM in the morning (UTC) unless someone can verify that this fixes the problem.

In addition I wasn't sure whether we wanted to add the event subscription in `atom-window.coffee` or `atom-application.coffee`. 

/cc @atom/feedback 

---

Fixes #4300 (**unverified**)
