### PR TITLE
autoindent lines with moveLineUp/moveLineDown

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4145,6 +4145,37 @@ describe "TextEditor", ->
       """
       expect(editor.getSelectedBufferRange()).toEqual [[13, 0], [14, 2]]
 
+  describe ".moveLineUp()", ->
+    it "moves line up", ->
+      editor.setCursorBufferPosition([1, 0])
+      editor.moveLineUp()
+      expect(editor.getTextInBufferRange([[0, 0], [0, 30]])).toBe "  var sort = function(items) {"
+      expect(editor.indentationForBufferRow(0)).toBe 1
+      expect(editor.indentationForBufferRow(1)).toBe 0
+      
+    it "update indentation when config editor.autoIndent is true", ->
+      atom.config.set('editor.autoIndent', true)
+      editor.setCursorBufferPosition([1, 0])
+      editor.moveLineUp()
+      expect(editor.indentationForBufferRow(0)).toBe 0
+      expect(editor.indentationForBufferRow(1)).toBe 0
+      
+  describe ".moveLineDown()", ->
+    it "moves line down", ->
+      editor.setCursorBufferPosition([0, 0])
+      editor.moveLineDown()
+      expect(editor.getTextInBufferRange([[1, 0], [1, 31]])).toBe "var quicksort = function () {"
+      expect(editor.indentationForBufferRow(0)).toBe 1
+      expect(editor.indentationForBufferRow(1)).toBe 0
+         
+    it "update indentation when config editor.autoIndent is true", ->
+      atom.config.set('editor.autoIndent', true)
+      editor.setCursorBufferPosition([0, 0])
+      editor.moveLineDown()
+      expect(editor.indentationForBufferRow(0)).toBe 1
+      expect(editor.indentationForBufferRow(1)).toBe 2
+      
+
   describe ".shouldPromptToSave()", ->
     it "returns false when an edit session's buffer is in use by more than one session", ->
       jasmine.unspy(editor, 'shouldPromptToSave')

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -842,6 +842,7 @@ class TextEditor extends Model
         @foldBufferRow(foldedRow)
 
       @setSelectedBufferRange(selection.translate([-insertDelta]), preserveFolds: true, autoscroll: true)
+      @autoIndentSelectedRows() if @shouldAutoIndent()
 
   # Move lines intersecting the most recent selection down by one row in screen
   # coordinates.
@@ -898,6 +899,7 @@ class TextEditor extends Model
         @foldBufferRow(foldedRow)
 
       @setSelectedBufferRange(selection.translate([insertDelta]), preserveFolds: true, autoscroll: true)
+      @autoIndentSelectedRows() if @shouldAutoIndent()
 
   # Duplicate the most recent cursor's current line.
   duplicateLines: ->


### PR DESCRIPTION
Related to #7546, added the `autoIndentSelection if should autoIndent`. A demo of the change:

![autoindentmoveline](https://cloud.githubusercontent.com/assets/1993929/10412661/8f81b0c2-6f52-11e5-8fe5-45322401d8ea.gif)
