### PR TITLE
:bug: `BufferedProcess.kill` now fully kills any child-process-eption that happens

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "oniguruma": "^5",
     "pathwatcher": "^6.2",
     "property-accessors": "^1.1.3",
+    "ps-tree": "^1.0.1",
     "random-words": "0.0.1",
     "runas": "^3.1",
     "scandal": "^2.2",


### PR DESCRIPTION
closes #7252
- fixes :bug: where child processes spawned by spawned child processes on *nix systems were not getting killed correctly
