### PR TITLE
Fix coffeescript source maps on Windows

### DIFF
--- a/src/coffee-script.js
+++ b/src/coffee-script.js
@@ -29,6 +29,10 @@ exports.compile = function (sourceCode, filePath) {
     Error.prepareStackTrace = previousPrepareStackTrace
   }
 
+  if (process.platform === 'win32') {
+    filePath = 'file:///' + path.resolve(filePath).replace(/\\/g, '/')
+  }
+
   var output = CoffeeScript.compile(sourceCode, {
     filename: filePath,
     sourceFiles: [filePath],


### PR DESCRIPTION
I've done some research of current code and PR #3062 and have found that we not only should convert the slashes in the path, but also prepend `file:///` to it.

After that source maps started to work on Windows for me. Please note that the similar code has been added to [`compile-cache` module](https://github.com/atom/atom/blob/d9410716d2c39fa4d62b2e1ab2fe1251a5805487/src/compile-cache.js#L96) but I'm not sure whether we should/want to generalize and reuse this (because it doesn't prepend `file:///` there and seems to be working fine).

This patch will fix issue #9116.
