### PR TITLE
Restore ability to cancel the closing of a window from save dialog

### DIFF
--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -16,9 +16,10 @@ class WindowEventHandler
     @on(ipc, 'command', @handleIPCCommand)
     @on(ipc, 'context-command', @handleIPCContextCommand)
 
+    @previousOnbeforeunloadHandler = window.onbeforeunload
+    window.onbeforeunload = @handleWindowBeforeunload
     @addEventListener(window, 'focus', @handleWindowFocus)
     @addEventListener(window, 'blur', @handleWindowBlur)
-    @addEventListener(window, 'beforeunload', @handleWindowBeforeunload)
     @addEventListener(window, 'unload', @handleWindowUnload)
 
     @addEventListener(document, 'keydown', @handleDocumentKeydown)
@@ -60,6 +61,7 @@ class WindowEventHandler
     bindCommandToAction('core:cut', 'cut')
 
   unsubscribe: ->
+    window.onbeforeunload = @previousOnbeforeunloadHandler
     @subscriptions.dispose()
 
   on: (target, eventName, handler) ->


### PR DESCRIPTION
We need to assign `onbeforeunload` rather than listening to `beforeunload` via `addEventListener` (which I guess jQuery was doing under the hood). This enables us to return `false` from the handler to cancel the closing of the window. See https://github.com/atom/electron/issues/2481#issuecomment-134467494.

Fixes #8947
