### PR TITLE
Update Node versions in the docs

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -7,7 +7,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
   * OS with 64-bit or 32-bit architecture
   * C++ toolchain
   * [Git](http://git-scm.com/)
-  * [node.js](http://nodejs.org/download/) (0.10.x or above)
+  * [Node.js](http://nodejs.org/download/) (0.10.x or above)
   * [npm](https://www.npmjs.com/) v1.4.x or above (automatically bundled with Node.js)
     * `npm -v` to check the version.
     * `npm config set python /usr/bin/python2 -g` to ensure that gyp uses python2.
@@ -17,7 +17,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 ### Ubuntu / Debian
 
 * `sudo apt-get install build-essential git libgnome-keyring-dev fakeroot`
-* Instructions for  [node.js](https://github.com/nodejs/node-v0.x-archive/wiki/Installing-Node.js-via-package-manager#debian-and-ubuntu-based-linux-distributions).
+* Instructions for [Node.js](https://github.com/nodejs/node-v0.x-archive/wiki/Installing-Node.js-via-package-manager#debian-and-ubuntu-based-linux-distributions).
   * Make sure the command `node` is available after Node.js installation (some systems install it as `nodejs`).
   * Use `which node` to check if it is available.
   * Use `sudo update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10` to update it.
@@ -25,7 +25,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 ### Fedora / CentOS / RHEL
 
 * `sudo dnf --assumeyes install make gcc gcc-c++ glibc-devel git-core libgnome-keyring-devel rpmdevtools`
-* Instructions for [node.js](https://github.com/nodejs/node-v0.x-archive/wiki/Installing-Node.js-via-package-manager#enterprise-linux-and-fedora).
+* Instructions for [Node.js](https://github.com/nodejs/node-v0.x-archive/wiki/Installing-Node.js-via-package-manager#enterprise-linux-and-fedora).
 
 ### Arch
 

--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -7,8 +7,8 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
   * OS with 64-bit or 32-bit architecture
   * C++ toolchain
   * [Git](http://git-scm.com/)
-  * [node.js](http://nodejs.org/download/) (0.10.x or 0.12.x) or [io.js](https://iojs.org) (1.x or 2.x)
-  * [npm](https://www.npmjs.com/) v1.4.x (bundled with Node.js)
+  * [node.js](http://nodejs.org/download/) (0.10.x or above)
+  * [npm](https://www.npmjs.com/) v1.4.x or above (automatically bundled with Node.js)
     * `npm -v` to check the version.
     * `npm config set python /usr/bin/python2 -g` to ensure that gyp uses python2.
       * You might need to run this command as `sudo`, depending on how you have set up [npm](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#ubuntu-mint-elementary-os).
@@ -17,7 +17,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 ### Ubuntu / Debian
 
 * `sudo apt-get install build-essential git libgnome-keyring-dev fakeroot`
-* Instructions for  [Node.js](https://github.com/nodejs/node-v0.x-archive/wiki/Installing-Node.js-via-package-manager#debian-and-ubuntu-based-linux-distributions).
+* Instructions for  [node.js](https://github.com/nodejs/node-v0.x-archive/wiki/Installing-Node.js-via-package-manager#debian-and-ubuntu-based-linux-distributions).
   * Make sure the command `node` is available after Node.js installation (some systems install it as `nodejs`).
   * Use `which node` to check if it is available.
   * Use `sudo update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10` to update it.
@@ -25,7 +25,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 ### Fedora / CentOS / RHEL
 
 * `sudo dnf --assumeyes install make gcc gcc-c++ glibc-devel git-core libgnome-keyring-devel rpmdevtools`
-* Instructions for [Node.js](https://github.com/nodejs/node-v0.x-archive/wiki/Installing-Node.js-via-package-manager#enterprise-linux-and-fedora).
+* Instructions for [node.js](https://github.com/nodejs/node-v0.x-archive/wiki/Installing-Node.js-via-package-manager#enterprise-linux-and-fedora).
 
 ### Arch
 

--- a/docs/build-instructions/os-x.md
+++ b/docs/build-instructions/os-x.md
@@ -3,7 +3,7 @@
 ## Requirements
 
   * OS X 10.8 or later
-  * [node.js](http://nodejs.org/download/) (0.10.x or above)
+  * [Node.js](http://nodejs.org/download/) (0.10.x or above)
   * Command Line Tools for [Xcode](https://developer.apple.com/xcode/downloads/) (run `xcode-select --install` to install)
 
 ## Instructions

--- a/docs/build-instructions/os-x.md
+++ b/docs/build-instructions/os-x.md
@@ -3,7 +3,7 @@
 ## Requirements
 
   * OS X 10.8 or later
-  * [node.js](http://nodejs.org/download/) (0.10.x or 0.12.x) or [io.js](https://iojs.org) (1.x or 2.x)
+  * [node.js](http://nodejs.org/download/) (0.10.x or above)
   * Command Line Tools for [Xcode](https://developer.apple.com/xcode/downloads/) (run `xcode-select --install` to install)
 
 ## Instructions

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -5,7 +5,7 @@
 ### On Windows 7
   * [Visual C++ 2010 Express](http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs#DownloadFamilies_4)
   * [Visual Studio 2010 Service Pack 1](http://www.microsoft.com/en-us/download/details.aspx?id=23691)
-  * [node.js](http://nodejs.org/download/) (0.10.x or 0.12.x) or [io.js](https://iojs.org) (1.x or 2.x)
+  * [node.js](http://nodejs.org/download/) (0.10.x or above)
     * For 64-bit builds of node and native modules you **must** have the
     [Windows 7 64-bit SDK](http://www.microsoft.com/en-us/download/details.aspx?id=8279).
     You may also need the [compiler update for the Windows SDK 7.1](http://www.microsoft.com/en-us/download/details.aspx?id=4422)
@@ -20,7 +20,7 @@
   * [Visual Studio Express 2013 or 2015 for Windows Desktop](http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs#DownloadFamilies_2)
     * For VS 2015, be sure to customize the installation to include Visual C++. It's not installed by default.
     * Some have experienced issues with Node locating C++ on VS 2015. If so, try VS 2013.
-  * [node.js](http://nodejs.org/download/) (0.10.x, 0.12.x or 4.x) or [io.js](https://iojs.org) (1.x or 2.x)
+  * [node.js](http://nodejs.org/download/) (0.10.x or above)
   * [Python](https://www.python.org/downloads/) v2.7.x (required by [node-gyp](https://github.com/TooTallNate/node-gyp))
   * [GitHub Desktop](http://desktop.github.com/)
 

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -5,7 +5,7 @@
 ### On Windows 7
   * [Visual C++ 2010 Express](http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs#DownloadFamilies_4)
   * [Visual Studio 2010 Service Pack 1](http://www.microsoft.com/en-us/download/details.aspx?id=23691)
-  * [node.js](http://nodejs.org/download/) (0.10.x or above)
+  * [Node.js](http://nodejs.org/download/) (0.10.x or above)
     * For 64-bit builds of node and native modules you **must** have the
     [Windows 7 64-bit SDK](http://www.microsoft.com/en-us/download/details.aspx?id=8279).
     You may also need the [compiler update for the Windows SDK 7.1](http://www.microsoft.com/en-us/download/details.aspx?id=4422)
@@ -20,7 +20,7 @@
   * [Visual Studio Express 2013 or 2015 for Windows Desktop](http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs#DownloadFamilies_2)
     * For VS 2015, be sure to customize the installation to include Visual C++. It's not installed by default.
     * Some have experienced issues with Node locating C++ on VS 2015. If so, try VS 2013.
-  * [node.js](http://nodejs.org/download/) (0.10.x or above)
+  * [Node.js](http://nodejs.org/download/) (0.10.x or above)
   * [Python](https://www.python.org/downloads/) v2.7.x (required by [node-gyp](https://github.com/TooTallNate/node-gyp))
   * [GitHub Desktop](http://desktop.github.com/)
 


### PR DESCRIPTION
Instead of specifying both node.js and io.js, just say "node.js 0.10.x or above" now that node.js and io.js have merged.
