### PR TITLE
Avoid stack overflow when scrolling with non-integer values

### DIFF
--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -724,7 +724,7 @@ describe "TextEditorPresenter", ->
           expect(presenter.getState().content.scrollWidth).toBe 10 * editor.getMaxScreenLineLength() + 1
 
       describe ".scrollTop", ->
-        it "doesn't get stuck when setting a non-integer position in an event listener", ->
+        it "doesn't get stuck when repeatedly setting the same non-integer position in a scroll event listener", ->
           presenter = buildPresenter(scrollTop: 0, lineHeight: 10, explicitHeight: 20)
           expect(presenter.getState().content.scrollTop).toBe(0)
 
@@ -851,7 +851,7 @@ describe "TextEditorPresenter", ->
           expect(presenter.getState().content.scrollTop).toBe presenter.contentHeight - presenter.clientHeight
 
       describe ".scrollLeft", ->
-        it "doesn't get stuck when setting a non-integer position in an event listener", ->
+        it "doesn't get stuck when repeatedly setting the same non-integer position in a scroll event listener", ->
           presenter = buildPresenter(scrollLeft: 0, lineHeight: 10, baseCharacterWidth: 10, verticalScrollbarWidth: 10, contentFrameWidth: 10)
           expect(presenter.getState().content.scrollLeft).toBe(0)
 

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -724,6 +724,20 @@ describe "TextEditorPresenter", ->
           expect(presenter.getState().content.scrollWidth).toBe 10 * editor.getMaxScreenLineLength() + 1
 
       describe ".scrollTop", ->
+        it "doesn't get stuck when setting a non-integer position in an event listener", ->
+          presenter = buildPresenter(scrollTop: 0, lineHeight: 10, explicitHeight: 20)
+          expect(presenter.getState().content.scrollTop).toBe(0)
+
+          presenter.onDidChangeScrollTop ->
+            presenter.setScrollTop(1.5)
+            presenter.getState() # trigger scroll update
+
+          presenter.setScrollTop(1.5)
+          presenter.getState() # trigger scroll update
+
+          expect(presenter.getScrollTop()).toBe(2)
+          expect(presenter.getRealScrollTop()).toBe(1.5)
+
         it "changes based on the scroll operation that was performed last", ->
           presenter = buildPresenter(scrollTop: 0, lineHeight: 10, explicitHeight: 20)
           expect(presenter.getState().content.scrollTop).toBe(0)
@@ -837,6 +851,20 @@ describe "TextEditorPresenter", ->
           expect(presenter.getState().content.scrollTop).toBe presenter.contentHeight - presenter.clientHeight
 
       describe ".scrollLeft", ->
+        it "doesn't get stuck when setting a non-integer position in an event listener", ->
+          presenter = buildPresenter(scrollLeft: 0, lineHeight: 10, baseCharacterWidth: 10, verticalScrollbarWidth: 10, contentFrameWidth: 10)
+          expect(presenter.getState().content.scrollLeft).toBe(0)
+
+          presenter.onDidChangeScrollLeft ->
+            presenter.setScrollLeft(1.5)
+            presenter.getState() # trigger scroll update
+
+          presenter.setScrollLeft(1.5)
+          presenter.getState() # trigger scroll update
+
+          expect(presenter.getScrollLeft()).toBe(2)
+          expect(presenter.getRealScrollLeft()).toBe(1.5)
+
         it "changes based on the scroll operation that was performed last", ->
           presenter = buildPresenter(scrollLeft: 0, lineHeight: 10, baseCharacterWidth: 10, verticalScrollbarWidth: 10, contentFrameWidth: 10)
           expect(presenter.getState().content.scrollLeft).toBe(0)

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -22,6 +22,8 @@ class TextEditorPresenter
     @gutterWidth ?= 0
     @tileSize ?= 6
 
+    @realScrollTop = @scrollTop
+    @realScrollLeft = @scrollLeft
     @disposables = new CompositeDisposable
     @emitter = new Emitter
     @visibleHighlights = {}
@@ -775,7 +777,7 @@ class TextEditorPresenter
 
   updateScrollTop: (scrollTop) ->
     scrollTop = @constrainScrollTop(scrollTop)
-    if scrollTop isnt @scrollTop and not Number.isNaN(scrollTop)
+    if scrollTop isnt @realScrollTop and not Number.isNaN(scrollTop)
       @realScrollTop = scrollTop
       @scrollTop = Math.round(scrollTop)
       @scrollRow = Math.round(@scrollTop / @lineHeight)
@@ -792,7 +794,7 @@ class TextEditorPresenter
 
   updateScrollLeft: (scrollLeft) ->
     scrollLeft = @constrainScrollLeft(scrollLeft)
-    if scrollLeft isnt @scrollLeft and not Number.isNaN(scrollLeft)
+    if scrollLeft isnt @realScrollLeft and not Number.isNaN(scrollLeft)
       @realScrollLeft = scrollLeft
       @scrollLeft = Math.round(scrollLeft)
       @scrollColumn = Math.round(@scrollLeft / @baseCharacterWidth)


### PR DESCRIPTION
We were mistakenly using the rounded scroll top to guard against such cases. This fixes it by using `@realScrollTop` instead.
