### PR TITLE
Improve Windows build instructions

### DIFF
--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -2,40 +2,36 @@
 
 ## Requirements
 
-### On Windows 7
-  * [Visual C++ 2010 Express](http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs#DownloadFamilies_4)
-  * [Visual Studio 2010 Service Pack 1](http://www.microsoft.com/en-us/download/details.aspx?id=23691)
-  * [Node.js](http://nodejs.org/download/) (0.10.x or above)
-    * For 64-bit builds of node and native modules you **must** have the
-    [Windows 7 64-bit SDK](http://www.microsoft.com/en-us/download/details.aspx?id=8279).
-    You may also need the [compiler update for the Windows SDK 7.1](http://www.microsoft.com/en-us/download/details.aspx?id=4422)
-  * [Python](https://www.python.org/downloads/) v2.7.
+### General
+  * [Node.js](http://nodejs.org/en/download/) (0.10.x or above)
+  * [Python](https://www.python.org/downloads/) v2.7.x
     * The python.exe must be available at `%SystemDrive%\Python27\python.exe`.
       If it is installed elsewhere, you can create a symbolic link to the
       directory containing the python.exe using:
       `mklink /d %SystemDrive%\Python27 D:\elsewhere\Python27`
   * [GitHub Desktop](http://desktop.github.com/)
 
+### On Windows 7
+  * [Visual C++ 2010 Express](http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs#DownloadFamilies_4)
+  * [Visual Studio 2010 Service Pack 1](http://www.microsoft.com/en-us/download/details.aspx?id=23691)
+  * [Windows 7 64-bit SDK](http://www.microsoft.com/en-us/download/details.aspx?id=8279) for 64-bit builds of Node and native modules
+    * You may also need the [compiler update for the Windows SDK 7.1](http://www.microsoft.com/en-us/download/details.aspx?id=4422)
+
 ### On Windows 8 or 10
   * [Visual Studio Express 2013 or 2015 for Windows Desktop](http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs#DownloadFamilies_2)
-    * For VS 2015, be sure to customize the installation to include Visual C++. It's not installed by default.
-    * Some have experienced issues with Node locating C++ on VS 2015. If so, try VS 2013.
-  * [Node.js](http://nodejs.org/download/) (0.10.x or above)
-  * [Python](https://www.python.org/downloads/) v2.7.x (required by [node-gyp](https://github.com/TooTallNate/node-gyp))
-  * [GitHub Desktop](http://desktop.github.com/)
+    * To ensure that node-gyp knows what version of Visual Studio is installed, set the `GYP_MSVS_VERSION` environment variable to the Visual Studio version (e.g. `2013` or `2015`)
 
 ## Instructions
 
 ```bash
-# Use the `Git Shell` program which was installed by GitHub Desktop.
-# Also make sure that you are logged into GitHub Desktop.
+# Use the `Git Shell` program which was installed by GitHub Desktop and make sure that you are logged into Github Desktop
 cd C:\
 git clone https://github.com/atom/atom/
 cd atom
 script/build # Creates application in the `Program Files` directory
 ```
-Note: If you use cmd or Powershell instead of the Git shell, use a backslash instead: i.e. `script\build`.
-We will assume the git shell for these instructions.
+Note: If you use cmd or Powershell instead of Git Shell, use a backslash instead: i.e. `script\build`.
+These instructions will assume the use of Git Shell.
 
 ### `script/build` Options
   * `--install-dir` - Creates the final built application in this directory.
@@ -73,19 +69,19 @@ If none of this works, do install Github Desktop and use its Git shell. Makes li
     * https://github.com/TooTallNate/node-gyp/issues/297
     * https://code.google.com/p/gyp/issues/detail?id=393
 
-* `script/build` stops at installing runas with 'Failed at the runas@x.y.z install script.'
+* `script/build` stops at installing runas with `Failed at the runas@x.y.z install script.`
 
-  See the next item.
+  * See the next item.
 
 * `error MSB8020: The build tools for Visual Studio 2010 (Platform Toolset = 'v100') cannot be found.`
 
-  * If you're building atom with Visual Studio 2013 try executing the following
-    command in your Git shell and then re-run `script/build`:
+  * If you're building Atom with Visual Studio 2013 or above make sure the `GYP_MSVS_VERSION` environment variable is set, and then re-run `script/build`:
 
+    ```bash
+    $env:GYP_MSVS_VERSION=2013 # 2015 if using Visual Studio 2015, and so on
+    script/build
     ```
-    $env:GYP_MSVS_VERSION=2013
-    ```
-  * If you are using Visual Studio 2013 and the build fails with some other error message this environment variable might still be required.
+  * If you are using Visual Studio 2013 or above and the build fails with some other error message this environment variable might still be required.
 
 * Other `node-gyp` errors on first build attempt, even though the right node and python versions are installed.
   * Do try the build command one more time, as experience shows it often works on second try in many of these cases.
@@ -93,5 +89,4 @@ If none of this works, do install Github Desktop and use its Git shell. Makes li
 
 ### Windows build error reports in atom/atom
 * If all fails, use [this search](https://github.com/atom/atom/search?q=label%3Abuild-error+label%3Awindows&type=Issues) to get a list of reports about build errors on Windows, and see if yours has already been reported.
-
-* If it hasn't, please open a new issue with your Windows version 32/64bit and a print/screenshot of your build output, incl. the node and python versions.
+    * If it hasn't, please open a new issue with your Windows version, architecture (x32 or x64), and a screenshot of your build output, including the Node and Python versions.

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -74,7 +74,7 @@ If none of this works, do install Github Desktop and use its Git shell. Makes li
   * If you're building Atom with Visual Studio 2013 or above make sure the `GYP_MSVS_VERSION` environment variable is set, and then re-run `script/build`:
 
     ```bash
-    GYP_MSVS_VERSION=2013 # 2015 if using Visual Studio 2015, and so on
+    $env:GYP_MSVS_VERSION='2013' # '2015' if using Visual Studio 2015, and so on
     script/build
     ```
   * If you are using Visual Studio 2013 or above and the build fails with some other error message this environment variable might still be required.

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 ### General
-  * [Node.js](http://nodejs.org/en/download/) (0.10.x or above)
+  * [Node.js](http://nodejs.org/en/download/) v4.x
   * [Python](https://www.python.org/downloads/) v2.7.x
     * The python.exe must be available at `%SystemDrive%\Python27\python.exe`.
       If it is installed elsewhere, you can create a symbolic link to the
@@ -12,10 +12,7 @@
   * [GitHub Desktop](http://desktop.github.com/)
 
 ### On Windows 7
-  * [Visual C++ 2010 Express](http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs#DownloadFamilies_4)
-  * [Visual Studio 2010 Service Pack 1](http://www.microsoft.com/en-us/download/details.aspx?id=23691)
-  * [Windows 7 64-bit SDK](http://www.microsoft.com/en-us/download/details.aspx?id=8279) for 64-bit builds of Node and native modules
-    * You may also need the [compiler update for the Windows SDK 7.1](http://www.microsoft.com/en-us/download/details.aspx?id=4422)
+  * [Visual Studio 2013 Update 5](http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs#DownloadFamilies_4)
 
 ### On Windows 8 or 10
   * [Visual Studio Express 2013 or 2015 for Windows Desktop](http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs#DownloadFamilies_2)
@@ -24,7 +21,7 @@
 ## Instructions
 
 ```bash
-# Use the `Git Shell` program which was installed by GitHub Desktop and make sure that you are logged into Github Desktop
+# Use the Git Shell program which was installed by GitHub Desktop
 cd C:\
 git clone https://github.com/atom/atom/
 cd atom
@@ -47,7 +44,6 @@ Note that you may have to open your command window as administrator. For powersh
 
 If none of this works, do install Github Desktop and use its Git shell. Makes life easier.
 
-
 ## Troubleshooting
 
 ### Common Errors
@@ -63,7 +59,7 @@ If none of this works, do install Github Desktop and use its Git shell. Makes li
 
 * `error MSB4025: The project file could not be loaded. Invalid character in the given encoding.`
 
-  * These can occur because your home directory (`%USERPROFILE%`) has non-ASCII
+  * This can occur because your home directory (`%USERPROFILE%`) has non-ASCII
     characters in it. This is a bug in [gyp](https://code.google.com/p/gyp/)
     which is used to build native node modules and there is no known workaround.
     * https://github.com/TooTallNate/node-gyp/issues/297
@@ -78,7 +74,7 @@ If none of this works, do install Github Desktop and use its Git shell. Makes li
   * If you're building Atom with Visual Studio 2013 or above make sure the `GYP_MSVS_VERSION` environment variable is set, and then re-run `script/build`:
 
     ```bash
-    $env:GYP_MSVS_VERSION=2013 # 2015 if using Visual Studio 2015, and so on
+    GYP_MSVS_VERSION=2013 # 2015 if using Visual Studio 2015, and so on
     script/build
     ```
   * If you are using Visual Studio 2013 or above and the build fails with some other error message this environment variable might still be required.
@@ -86,7 +82,6 @@ If none of this works, do install Github Desktop and use its Git shell. Makes li
 * Other `node-gyp` errors on first build attempt, even though the right node and python versions are installed.
   * Do try the build command one more time, as experience shows it often works on second try in many of these cases.
 
-
 ### Windows build error reports in atom/atom
 * If all fails, use [this search](https://github.com/atom/atom/search?q=label%3Abuild-error+label%3Awindows&type=Issues) to get a list of reports about build errors on Windows, and see if yours has already been reported.
-    * If it hasn't, please open a new issue with your Windows version, architecture (x32 or x64), and a screenshot of your build output, including the Node and Python versions.
+    * If it hasn't, please open a new issue with your Windows version, architecture (x86 or amd64), and a screenshot of your build output, including the Node and Python versions.


### PR DESCRIPTION
Based on my experience with getting Atom to build on Windows, I decided to try to refresh the Windows docs.

Changes:
- Node.js download link changed from http://nodejs.org/download/ to http://nodejs.org/en/download/.  The new link is an actual webpage, not just a list of files :P
- Restructured the requirements section
- Added explicit note about `GYP_MSVS_VERSION` (this was the cause of all my troubles :cry:)
- Included VS 2015 in the troubleshooting section
- Other minor grammatical changes

/cc @paulcbetts @raelyard @atom/feedback for review
