### PR TITLE
Don't prevent renderer-side reloads

### DIFF
--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -146,7 +146,9 @@ class AtomWindow
         when 0 then @browserWindow.destroy()
         when 1 then @browserWindow.restart()
 
-    @browserWindow.webContents.on 'will-navigate', (event) -> event.preventDefault()
+    @browserWindow.webContents.on 'will-navigate', (event, url) =>
+      unless url is @browserWindow.webContents.getUrl()
+        event.preventDefault()
 
     @setupContextMenu()
 


### PR DESCRIPTION
Refs https://github.com/atom/atom/pull/9101

This restores the ability to reload windows using `command-r` in the dev-tools, or anywhere in spec windows. This also works around an electron bug (https://github.com/atom/electron/issues/3114), that causes breakpoints to stop working after a window navigation is cancelled.
