### PR TITLE
Make Error.prepareStackTrace read-only (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "fstream": "0.1.24",
     "fuzzaldrin": "^2.1",
     "git-utils": "^4",
-    "grim": "1.4.2",
+    "grim": "1.5.0",
     "jasmine-json": "~0.0",
     "jasmine-tagged": "^1.1.4",
     "jquery": "^2.1.1",

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -158,6 +158,27 @@ require('source-map-support').install({
   }
 })
 
+var sourceMapPrepareStackTrace = Error.prepareStackTrace
+var prepareStackTrace = sourceMapPrepareStackTrace
+
+// Prevent coffee-script from reassigning Error.prepareStackTrace
+Object.defineProperty(Error, 'prepareStackTrace', {
+  get: function () { return prepareStackTrace },
+  set: function (newValue) {}
+})
+
+// Enable Grim to access the raw stack without reassigning Error.prepareStackTrace
+Error.prototype.getRawStack = function () {
+  prepareStackTrace = getRawStack
+  var result = this.stack
+  prepareStackTrace = sourceMapPrepareStackTrace
+  return result
+}
+
+function getRawStack (error, stack) {
+  return stack
+}
+
 Object.keys(COMPILERS).forEach(function (extension) {
   var compiler = COMPILERS[extension]
 

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -168,14 +168,14 @@ Object.defineProperty(Error, 'prepareStackTrace', {
 })
 
 // Enable Grim to access the raw stack without reassigning Error.prepareStackTrace
-Error.prototype.getRawStack = function () {
+Error.prototype.getRawStack = function () { // eslint-disable-line no-extend-native
   prepareStackTrace = getRawStack
   var result = this.stack
   prepareStackTrace = sourceMapPrepareStackTrace
   return result
 }
 
-function getRawStack (error, stack) {
+function getRawStack (_, stack) {
   return stack
 }
 


### PR DESCRIPTION
Stack traces were incorrect for babel-compiled JS files again, because the require order had changed such that coffee-script once again clobbered our Error.prepareStackTrace. We've made that property read-only again, but this time, we've provided a way for Grim to access an Error's raw stack trace array.
