### PR TITLE
Updated README: Fedora 22 dnf install requires pathname of package

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ repeat these steps to upgrade to future releases.
 Currently only a 64-bit version is available.
 
 1. Download `atom.x86_64.rpm` from the [Atom releases page](https://github.com/atom/atom/releases/latest).
-2. Run `sudo dnf install atom.x86_64.rpm` on the downloaded package.
+2. Run `sudo dnf install ./atom.x86_64.rpm` on the downloaded package.
 3. Launch Atom using the installed `atom` command.
 
 The Linux version does not currently automatically update so you will need to


### PR DESCRIPTION
For Fedora 22+, `sudo dnf install atom.x86_64.rpm` will not work unless the pathname to the package is mentioned.
