### PR TITLE
Ignore git repo which has .atomignore file

### DIFF
--- a/src/git-repository-provider.coffee
+++ b/src/git-repository-provider.coffee
@@ -25,7 +25,7 @@ findGitDirectorySync = (directory) ->
   gitDirPath = pathFromGitFile(gitDir.getPath?())
   if gitDirPath
     gitDir = new Directory(directory.resolve(gitDirPath))
-  if gitDir.existsSync?() and isValidGitDirectorySync gitDir
+  if gitDir.existsSync?() and isValidGitDirectorySync(gitDir) and not directory.getFile('.atomignore').existsSync()
     gitDir
   else if directory.isRoot()
     return null


### PR DESCRIPTION
This PR is to make atom ignores git repository which has .atomignore in the working directory.
Atom will consume 90%+ I/O usage and get sick , when open folders which belong to a huge git repository. Maybe we can have chance to ignore huge git repository.

![image](https://cloud.githubusercontent.com/assets/5790649/10685514/ab882270-798d-11e5-8ef2-6e6b618f9957.png)
