### PR TITLE
Use ELECTRON_ENABLE_LOGGING instead of console.log shims

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -50,6 +50,10 @@ if [ $REDIRECT_STDERR ]; then
   exec 2> /dev/null
 fi
 
+if [ $EXPECT_OUTPUT ]; then
+  export ELECTRON_ENABLE_LOGGING=1
+fi
+
 if [ $OS == 'Mac' ]; then
   if [ -n "$BETA_VERSION" ]; then
     ATOM_APP_NAME="Atom Beta.app"

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -16,6 +16,7 @@ FOR %%a IN (%*) DO (
 )
 
 IF "%EXPECT_OUTPUT%"=="YES" (
+  SET ELECTRON_ENABLE_LOGGING=YES
   "%~dp0\..\..\atom.exe" %*
 ) ELSE (
   "%~dp0\..\app\apm\bin\node.exe" "%~dp0\atom.js" %*

--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -18,6 +18,7 @@ done
 directory=$(dirname "$0")
 
 if [ $EXPECT_OUTPUT ]; then
+  export ELECTRON_ENABLE_LOGGING=1
   "$directory/../../atom.exe" "$@"
 else
   "$directory/../app/apm/bin/node.exe" "$directory/atom.js" "$@"

--- a/src/initialize-test-window.coffee
+++ b/src/initialize-test-window.coffee
@@ -21,16 +21,7 @@ module.exports = ({blobStore}) ->
 
     {testRunnerPath, legacyTestRunnerPath, headless, logFile, testPaths} = getWindowLoadSettings()
 
-    if headless
-      # Override logging in headless mode so it goes to the console, regardless
-      # of the --enable-logging flag to Electron.
-      console.log = (args...) ->
-        ipc.send 'write-to-stdout', args.join(' ') + '\n'
-      console.warn = (args...) ->
-        ipc.send 'write-to-stderr', args.join(' ') + '\n'
-      console.error = (args...) ->
-        ipc.send 'write-to-stderr', args.join(' ') + '\n'
-    else
+    unless headless
       # Show window synchronously so a focusout doesn't fire on input elements
       # that are focused in the very first spec run.
       remote.getCurrentWindow().show()


### PR DESCRIPTION
This PR attempts to leverage the `ELECTRON_ENABLE_LOGGING` environment variable flag added to Electron in v0.34.1. Setting the environment variable enables `console.log` support in Electron, just as the `--enable-logging` application argument does.

I haven't tested my changes on Windows yet, so it'd be brilliant if someone (@50Wliu perhaps?) could quickly check if they work. Otherwise I'll boot up one of my Windows VMs later and give it a whirl.

Note that I tried setting this in various places in code, but it seemed that wasn't early enough in the application lifecycle, hence why I ended up setting the environment variable in the shell scripts. Also note that I'm setting the variable whenever `EXPECT_OUTPUT` is set which I feel is appropriate, but if someone disagrees, I can easily change it so that it's only set in the case of launching Atom in test mode.

/cc @atom/feedback 
