### PR TITLE
Add top/bottom bars

### DIFF
--- a/spec/workspace-element-spec.coffee
+++ b/spec/workspace-element-spec.coffee
@@ -93,6 +93,28 @@ describe "WorkspaceElement", ->
       atom.workspace.addFooterPanel({item: footerItem})
       expect(footerItem.offsetWidth).toEqual(workspaceElement.offsetWidth)
 
+    it 'shrinks horizontal axis according to header/footer panels height', ->
+      workspaceElement = atom.views.getView(atom.workspace)
+      workspaceElement.style.height = '100px'
+      horizontalAxisElement = workspaceElement.querySelector('atom-workspace-axis.horizontal')
+      jasmine.attachToDOM(workspaceElement)
+
+      originalHorizontalAxisHeight = horizontalAxisElement.offsetHeight
+      expect(workspaceElement.offsetHeight).toBeGreaterThan(0)
+      expect(originalHorizontalAxisHeight).toBeGreaterThan(0)
+
+      headerItem = document.createElement('div')
+      headerItem.style.height = '10px'
+      atom.workspace.addHeaderPanel({item: headerItem})
+      expect(headerItem.offsetHeight).toBeGreaterThan(0)
+
+      footerItem = document.createElement('div')
+      footerItem.style.height = '15px'
+      atom.workspace.addFooterPanel({item: footerItem})
+      expect(footerItem.offsetHeight).toBeGreaterThan(0)
+
+      expect(horizontalAxisElement.offsetHeight).toEqual(originalHorizontalAxisHeight - headerItem.offsetHeight - footerItem.offsetHeight)
+
   describe "the 'window:toggle-invisibles' command", ->
     it "shows/hides invisibles in all open and future editors", ->
       workspaceElement = atom.views.getView(atom.workspace)

--- a/spec/workspace-element-spec.coffee
+++ b/spec/workspace-element-spec.coffee
@@ -80,6 +80,19 @@ describe "WorkspaceElement", ->
       modalContainer = workspaceElement.querySelector('atom-panel-container.modal')
       expect(modalContainer.parentNode).toBe workspaceElement
 
+    it 'stretches header/footer panels to the workspace width', ->
+      workspaceElement = atom.views.getView(atom.workspace)
+      jasmine.attachToDOM(workspaceElement)
+      expect(workspaceElement.offsetWidth).toBeGreaterThan(0)
+
+      headerItem = document.createElement('div')
+      atom.workspace.addHeaderPanel({item: headerItem})
+      expect(headerItem.offsetWidth).toEqual(workspaceElement.offsetWidth)
+
+      footerItem = document.createElement('div')
+      atom.workspace.addFooterPanel({item: footerItem})
+      expect(footerItem.offsetWidth).toEqual(workspaceElement.offsetWidth)
+
   describe "the 'window:toggle-invisibles' command", ->
     it "shows/hides invisibles in all open and future editors", ->
       workspaceElement = atom.views.getView(atom.workspace)

--- a/spec/workspace-element-spec.coffee
+++ b/spec/workspace-element-spec.coffee
@@ -72,6 +72,11 @@ describe "WorkspaceElement", ->
       expect(topContainer.nextSibling).toBe workspaceElement.paneContainer
       expect(bottomContainer.previousSibling).toBe workspaceElement.paneContainer
 
+      topBarContainer = workspaceElement.querySelector('atom-panel-container.top-bar')
+      bottomBarContainer = workspaceElement.querySelector('atom-panel-container.bottom-bar')
+      expect(topBarContainer.nextSibling).toBe workspaceElement.horizontalAxis
+      expect(bottomBarContainer.previousSibling).toBe workspaceElement.horizontalAxis
+
       modalContainer = workspaceElement.querySelector('atom-panel-container.modal')
       expect(modalContainer.parentNode).toBe workspaceElement
 

--- a/spec/workspace-element-spec.coffee
+++ b/spec/workspace-element-spec.coffee
@@ -72,10 +72,10 @@ describe "WorkspaceElement", ->
       expect(topContainer.nextSibling).toBe workspaceElement.paneContainer
       expect(bottomContainer.previousSibling).toBe workspaceElement.paneContainer
 
-      topBarContainer = workspaceElement.querySelector('atom-panel-container.top-bar')
-      bottomBarContainer = workspaceElement.querySelector('atom-panel-container.bottom-bar')
-      expect(topBarContainer.nextSibling).toBe workspaceElement.horizontalAxis
-      expect(bottomBarContainer.previousSibling).toBe workspaceElement.horizontalAxis
+      headerContainer = workspaceElement.querySelector('atom-panel-container.header')
+      footerContainer = workspaceElement.querySelector('atom-panel-container.footer')
+      expect(headerContainer.nextSibling).toBe workspaceElement.horizontalAxis
+      expect(footerContainer.previousSibling).toBe workspaceElement.horizontalAxis
 
       modalContainer = workspaceElement.querySelector('atom-panel-container.modal')
       expect(modalContainer.parentNode).toBe workspaceElement

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -894,33 +894,33 @@ describe "Workspace", ->
         expect(itemView instanceof TestItemElement).toBe(true)
         expect(itemView.getModel()).toBe(model)
 
-    describe '::addTopBarPanel(model)', ->
+    describe '::addHeaderPanel(model)', ->
       it 'adds a panel to the correct panel container', ->
-        expect(atom.workspace.getTopBarPanels().length).toBe(0)
-        atom.workspace.panelContainers.topBar.onDidAddPanel addPanelSpy = jasmine.createSpy()
+        expect(atom.workspace.getHeaderPanels().length).toBe(0)
+        atom.workspace.panelContainers.header.onDidAddPanel addPanelSpy = jasmine.createSpy()
 
         model = new TestItem
-        panel = atom.workspace.addTopBarPanel(item: model)
+        panel = atom.workspace.addHeaderPanel(item: model)
 
         expect(panel).toBeDefined()
         expect(addPanelSpy).toHaveBeenCalledWith({panel, index: 0})
 
-        itemView = atom.views.getView(atom.workspace.getTopBarPanels()[0].getItem())
+        itemView = atom.views.getView(atom.workspace.getHeaderPanels()[0].getItem())
         expect(itemView instanceof TestItemElement).toBe(true)
         expect(itemView.getModel()).toBe(model)
 
-    describe '::addBottomBarPanel(model)', ->
+    describe '::addFooterPanel(model)', ->
       it 'adds a panel to the correct panel container', ->
-        expect(atom.workspace.getBottomBarPanels().length).toBe(0)
-        atom.workspace.panelContainers.bottomBar.onDidAddPanel addPanelSpy = jasmine.createSpy()
+        expect(atom.workspace.getFooterPanels().length).toBe(0)
+        atom.workspace.panelContainers.footer.onDidAddPanel addPanelSpy = jasmine.createSpy()
 
         model = new TestItem
-        panel = atom.workspace.addBottomBarPanel(item: model)
+        panel = atom.workspace.addFooterPanel(item: model)
 
         expect(panel).toBeDefined()
         expect(addPanelSpy).toHaveBeenCalledWith({panel, index: 0})
 
-        itemView = atom.views.getView(atom.workspace.getBottomBarPanels()[0].getItem())
+        itemView = atom.views.getView(atom.workspace.getFooterPanels()[0].getItem())
         expect(itemView instanceof TestItemElement).toBe(true)
         expect(itemView.getModel()).toBe(model)
 

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -894,6 +894,36 @@ describe "Workspace", ->
         expect(itemView instanceof TestItemElement).toBe(true)
         expect(itemView.getModel()).toBe(model)
 
+    describe '::addTopBarPanel(model)', ->
+      it 'adds a panel to the correct panel container', ->
+        expect(atom.workspace.getTopBarPanels().length).toBe(0)
+        atom.workspace.panelContainers.topBar.onDidAddPanel addPanelSpy = jasmine.createSpy()
+
+        model = new TestItem
+        panel = atom.workspace.addTopBarPanel(item: model)
+
+        expect(panel).toBeDefined()
+        expect(addPanelSpy).toHaveBeenCalledWith({panel, index: 0})
+
+        itemView = atom.views.getView(atom.workspace.getTopBarPanels()[0].getItem())
+        expect(itemView instanceof TestItemElement).toBe(true)
+        expect(itemView.getModel()).toBe(model)
+
+    describe '::addBottomBarPanel(model)', ->
+      it 'adds a panel to the correct panel container', ->
+        expect(atom.workspace.getBottomBarPanels().length).toBe(0)
+        atom.workspace.panelContainers.bottomBar.onDidAddPanel addPanelSpy = jasmine.createSpy()
+
+        model = new TestItem
+        panel = atom.workspace.addBottomBarPanel(item: model)
+
+        expect(panel).toBeDefined()
+        expect(addPanelSpy).toHaveBeenCalledWith({panel, index: 0})
+
+        itemView = atom.views.getView(atom.workspace.getBottomBarPanels()[0].getItem())
+        expect(itemView instanceof TestItemElement).toBe(true)
+        expect(itemView.getModel()).toBe(model)
+
     describe '::addModalPanel(model)', ->
       it 'adds a panel to the correct panel container', ->
         expect(atom.workspace.getModalPanels().length).toBe(0)

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -74,8 +74,8 @@ class WorkspaceElement extends HTMLElement
       left: @views.getView(@model.panelContainers.left)
       right: @views.getView(@model.panelContainers.right)
       bottom: @views.getView(@model.panelContainers.bottom)
-      topBar: @views.getView(@model.panelContainers.topBar)
-      bottomBar: @views.getView(@model.panelContainers.bottomBar)
+      header: @views.getView(@model.panelContainers.header)
+      footer: @views.getView(@model.panelContainers.footer)
       modal: @views.getView(@model.panelContainers.modal)
 
     @horizontalAxis.insertBefore(@panelContainers.left, @verticalAxis)
@@ -84,8 +84,8 @@ class WorkspaceElement extends HTMLElement
     @verticalAxis.insertBefore(@panelContainers.top, @paneContainer)
     @verticalAxis.appendChild(@panelContainers.bottom)
 
-    @insertBefore(@panelContainers.topBar, @horizontalAxis)
-    @appendChild(@panelContainers.bottomBar)
+    @insertBefore(@panelContainers.header, @horizontalAxis)
+    @appendChild(@panelContainers.footer)
 
     @appendChild(@panelContainers.modal)
 

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -74,6 +74,8 @@ class WorkspaceElement extends HTMLElement
       left: @views.getView(@model.panelContainers.left)
       right: @views.getView(@model.panelContainers.right)
       bottom: @views.getView(@model.panelContainers.bottom)
+      topBar: @views.getView(@model.panelContainers.topBar)
+      bottomBar: @views.getView(@model.panelContainers.bottomBar)
       modal: @views.getView(@model.panelContainers.modal)
 
     @horizontalAxis.insertBefore(@panelContainers.left, @verticalAxis)
@@ -81,6 +83,9 @@ class WorkspaceElement extends HTMLElement
 
     @verticalAxis.insertBefore(@panelContainers.top, @paneContainer)
     @verticalAxis.appendChild(@panelContainers.bottom)
+
+    @insertBefore(@panelContainers.topBar, @horizontalAxis)
+    @appendChild(@panelContainers.bottomBar)
 
     @appendChild(@panelContainers.modal)
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -47,6 +47,8 @@ class Workspace extends Model
       left: new PanelContainer({location: 'left'})
       right: new PanelContainer({location: 'right'})
       bottom: new PanelContainer({location: 'bottom'})
+      topBar: new PanelContainer({location: 'top-bar'})
+      bottomBar: new PanelContainer({location: 'bottom-bar'})
       modal: new PanelContainer({location: 'modal'})
 
     @subscribeToEvents()
@@ -66,6 +68,8 @@ class Workspace extends Model
       left: new PanelContainer({location: 'left'})
       right: new PanelContainer({location: 'right'})
       bottom: new PanelContainer({location: 'bottom'})
+      topBar: new PanelContainer({location: 'top-bar'})
+      bottomBar: new PanelContainer({location: 'bottom-bar'})
       modal: new PanelContainer({location: 'modal'})
 
     @originalFontSize = null

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -47,8 +47,8 @@ class Workspace extends Model
       left: new PanelContainer({location: 'left'})
       right: new PanelContainer({location: 'right'})
       bottom: new PanelContainer({location: 'bottom'})
-      topBar: new PanelContainer({location: 'top-bar'})
-      bottomBar: new PanelContainer({location: 'bottom-bar'})
+      header: new PanelContainer({location: 'header'})
+      footer: new PanelContainer({location: 'footer'})
       modal: new PanelContainer({location: 'modal'})
 
     @subscribeToEvents()
@@ -68,8 +68,8 @@ class Workspace extends Model
       left: new PanelContainer({location: 'left'})
       right: new PanelContainer({location: 'right'})
       bottom: new PanelContainer({location: 'bottom'})
-      topBar: new PanelContainer({location: 'top-bar'})
-      bottomBar: new PanelContainer({location: 'bottom-bar'})
+      header: new PanelContainer({location: 'header'})
+      footer: new PanelContainer({location: 'footer'})
       modal: new PanelContainer({location: 'modal'})
 
     @originalFontSize = null
@@ -838,11 +838,11 @@ class Workspace extends Model
   addTopPanel: (options) ->
     @addPanel('top', options)
 
-  # Essential: Get an {Array} of all the panel items at the top of the window.
-  getTopBarPanels: ->
-    @getPanels('topBar')
+  # Essential: Get an {Array} of all the panel items in the header.
+  getHeaderPanels: ->
+    @getPanels('header')
 
-  # Essential: Adds a panel item to the top of the window. It will take up full width.
+  # Essential: Adds a panel item to the header.
   #
   # * `options` {Object}
   #   * `item` Your panel content. It can be DOM element, a jQuery element, or
@@ -854,14 +854,14 @@ class Workspace extends Model
   #     forced closer to the edges of the window. (default: 100)
   #
   # Returns a {Panel}
-  addTopBarPanel: (options) ->
-    @addPanel('topBar', options)
+  addHeaderPanel: (options) ->
+    @addPanel('header', options)
 
-  # Essential: Get an {Array} of all the panel items at the bottom of the window.
-  getBottomBarPanels: ->
-    @getPanels('bottomBar')
+  # Essential: Get an {Array} of all the panel items in the footer.
+  getFooterPanels: ->
+    @getPanels('footer')
 
-  # Essential: Adds a panel item to the bottom of the window. It will take up full width.
+  # Essential: Adds a panel item to the footer.
   #
   # * `options` {Object}
   #   * `item` Your panel content. It can be DOM element, a jQuery element, or
@@ -873,8 +873,8 @@ class Workspace extends Model
   #     forced closer to the edges of the window. (default: 100)
   #
   # Returns a {Panel}
-  addBottomBarPanel: (options) ->
-    @addPanel('bottomBar', options)
+  addFooterPanel: (options) ->
+    @addPanel('footer', options)
 
   # Essential: Get an {Array} of all the modal panel items
   getModalPanels: ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -838,6 +838,44 @@ class Workspace extends Model
   addTopPanel: (options) ->
     @addPanel('top', options)
 
+  # Essential: Get an {Array} of all the panel items at the top of the window.
+  getTopBarPanels: ->
+    @getPanels('topBar')
+
+  # Essential: Adds a panel item to the top of the window. It will take up full width.
+  #
+  # * `options` {Object}
+  #   * `item` Your panel content. It can be DOM element, a jQuery element, or
+  #     a model with a view registered via {ViewRegistry::addViewProvider}. We recommend the
+  #     latter. See {ViewRegistry::addViewProvider} for more information.
+  #   * `visible` (optional) {Boolean} false if you want the panel to initially be hidden
+  #     (default: true)
+  #   * `priority` (optional) {Number} Determines stacking order. Lower priority items are
+  #     forced closer to the edges of the window. (default: 100)
+  #
+  # Returns a {Panel}
+  addTopBarPanel: (options) ->
+    @addPanel('topBar', options)
+
+  # Essential: Get an {Array} of all the panel items at the bottom of the window.
+  getBottomBarPanels: ->
+    @getPanels('bottomBar')
+
+  # Essential: Adds a panel item to the bottom of the window. It will take up full width.
+  #
+  # * `options` {Object}
+  #   * `item` Your panel content. It can be DOM element, a jQuery element, or
+  #     a model with a view registered via {ViewRegistry::addViewProvider}. We recommend the
+  #     latter. See {ViewRegistry::addViewProvider} for more information.
+  #   * `visible` (optional) {Boolean} false if you want the panel to initially be hidden
+  #     (default: true)
+  #   * `priority` (optional) {Number} Determines stacking order. Lower priority items are
+  #     forced closer to the edges of the window. (default: 100)
+  #
+  # Returns a {Panel}
+  addBottomBarPanel: (options) ->
+    @addPanel('bottomBar', options)
+
   # Essential: Get an {Array} of all the modal panel items
   getModalPanels: ->
     @getPanels('modal')

--- a/static/panels.less
+++ b/static/panels.less
@@ -61,14 +61,10 @@ atom-panel.bottom {
   flex-direction: column;
 }
 
-atom-panel.left,
-atom-panel.right {
-  flex-direction: row;
-
-  // TODO: Remove in tree-view package
-  .tree-view-resizer {
-    height: initial;
-  }
+// Some packages use `height: 100%` which doesn't play nice with flexbox
+atom-panel-container > atom-panel.left > *,
+atom-panel-container > atom-panel.right > * {
+  height: initial;
 }
 
 // Modal panels

--- a/static/panels.less
+++ b/static/panels.less
@@ -49,16 +49,15 @@ atom-panel-container.right {
   display: flex;
 }
 
-.tool-panel, // deprecated
+.tool-panel, // deprecated: .tool-panel
 atom-panel {
-  display: flex;
   position: relative;
   background-color: @tool-panel-background-color;
 }
 
-atom-panel.top,
-atom-panel.bottom {
-  flex-direction: column;
+atom-panel-container > atom-panel.left,
+atom-panel-container > atom-panel.right {
+  display: flex;
 }
 
 // Some packages use `height: 100%` which doesn't play nice with flexbox

--- a/static/panels.less
+++ b/static/panels.less
@@ -51,6 +51,7 @@ atom-panel-container.right {
 
 .tool-panel, // deprecated: .tool-panel
 atom-panel {
+  display: block;
   position: relative;
   background-color: @tool-panel-background-color;
 }

--- a/static/panels.less
+++ b/static/panels.less
@@ -46,30 +46,29 @@
 
 atom-panel-container.left,
 atom-panel-container.right {
-  display: -webkit-flex;
-  -webkit-flex-direction: row;
-  -webkit-align-items: stretch;
-  height: 100%;
-  atom-panel {
-    height: 100%;
-  }
+  display: flex;
 }
 
+.tool-panel, // deprecated
 atom-panel {
-  display: block;
+  display: flex;
+  position: relative;
+  background-color: @tool-panel-background-color;
 }
 
 atom-panel.top,
-atom-panel.bottom,
-atom-panel.left,
-atom-panel.right {
-  background-color: @tool-panel-background-color;
+atom-panel.bottom {
+  flex-direction: column;
 }
 
-// deprecated
-.tool-panel {
-  position: relative;
-  background-color: @tool-panel-background-color;
+atom-panel.left,
+atom-panel.right {
+  flex-direction: row;
+
+  // TODO: Remove in tree-view package
+  .tree-view-resizer {
+    height: initial;
+  }
 }
 
 // Modal panels
@@ -77,6 +76,7 @@ atom-panel.right {
 .overlay, // deprecated .overlay
 atom-panel.modal {
   position: absolute;
+  display: block;
   left: 50%;
   width: 500px;
   margin-left: -250px;

--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -16,7 +16,8 @@ body {
 }
 
 atom-workspace {
-  display: block;
+  display: flex;
+  flex-direction: column;
   height: 100%;
   overflow: hidden;
   position: relative;
@@ -25,13 +26,13 @@ atom-workspace {
   font-family: @font-family;
 
   atom-workspace-axis.horizontal {
-    display: -webkit-flex;
-    height: 100%;
+    display: flex;
+    flex: 1;
   }
 
   atom-workspace-axis.vertical {
-    display: -webkit-flex;
-    -webkit-flex: 1;
-    -webkit-flex-flow: column;
+    display: flex;
+    flex: 1;
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
This PR adds a top and bottom bar to `atom-workspace`.

``` html
<atom-workspace class="workspace">
  <atom-panel-container class="header"></atom-panel-container><!-- New -->
  <atom-workspace-axis class="horizontal"></atom-workspace-axis>
  <atom-panel-container class="footer"></atom-panel-container><!-- New -->
  <atom-panel-container class="modal"></atom-panel-container>
</atom-workspace>
```

![atom-panels](https://cloud.githubusercontent.com/assets/378023/10159023/c0848db4-66d0-11e5-9cbe-fadbfa2bd110.png)

It allows packages to add `<atom-panel>`s that span across the whole width and not just above/under the editor.

The `status-bar` or `tabs` _could_ go on top and under the tree-view.

![screen shot 2015-10-24 at 3 15 51 pm](https://cloud.githubusercontent.com/assets/378023/10709881/519c7aa8-7a79-11e5-906f-79d4513a1218.png)

![screen shot 2015-10-24 at 3 04 02 pm](https://cloud.githubusercontent.com/assets/378023/10709883/5ce52e1e-7a79-11e5-8467-d69f6fd93144.png)
#### Todo
- [x] Change to flexbox
- [x] Add top/bottom bar elements
- [x] Add API
- [x] Add specs
#### Todo after merging
- [ ] Merge: https://github.com/atom/tree-view/pull/627
#### Packages that break or have issues
- [ ] [nuclide-file-tree](https://atom.io/packages/nuclide) (Scrolling is broken)
- [x] [tool-bar](https://github.com/suda/tool-bar/) (scrolling is broken) -> [PR](https://github.com/suda/tool-bar/pull/111)
- [x] [atom-chat](https://atom.io/packages/atom-chat) (Overflowing content, no scrolling. Fix: Use Flexbox, only scroll `chat-messages`) -> [PR](https://github.com/mertkahyaoglu/atom-chat/pull/7)
- [x] [youtube-pane](https://atom.io/packages/youtube-pane) (footer will cover the youtube panel). -> [PR](https://github.com/alexandruionascu/youtube-pane/pull/3)

Closes #8939
