### PR TITLE
Remove keyPath as a possible return value on the event object for onDidChange in config.coffee

### DIFF
--- a/src/config.coffee
+++ b/src/config.coffee
@@ -422,7 +422,6 @@ class Config
   #   * `event` {Object}
   #     * `newValue` the new value of the key
   #     * `oldValue` the prior value of the key.
-  #     * `keyPath` the keyPath of the changed key
   #
   # Returns a {Disposable} with the following keys on which you can call
   # `.dispose()` to unsubscribe.


### PR DESCRIPTION
Updated the documentation for onDidChange in config.coffee. The value is never returned on the object so the documentation was updated to reflect that. Should close https://github.com/atom/atom/issues/7918
