### PR TITLE
Focus pane items async, improve tab responsiveness

### DIFF
--- a/spec/pane-element-spec.coffee
+++ b/spec/pane-element-spec.coffee
@@ -58,8 +58,16 @@ describe "PaneElement", ->
       jasmine.attachToDOM(paneElement)
       paneElement.focus()
 
+      pane.activateItem(item1)
+      # Advance the clock to trigger the pane element's debounced active item
+      # change event handler.
+      advanceClock(51)
+
       expect(document.activeElement).toBe item1
       pane.activateItem(item2)
+      # Advance the clock to trigger the pane element's debounced active item
+      # change event handler.
+      advanceClock(51)
       expect(document.activeElement).toBe item2
 
     describe "if the active item is a model object", ->

--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -1,11 +1,14 @@
-path = require 'path'
 {CompositeDisposable} = require 'event-kit'
+
+{debounce} = require 'underscore-plus'
+path = require 'path'
 
 class PaneElement extends HTMLElement
   attached: false
 
   createdCallback: ->
     @attached = false
+    @hadFocusLocked = false
     @subscriptions = new CompositeDisposable
     @inlineDisplayStyles = new WeakMap
 
@@ -58,6 +61,9 @@ class PaneElement extends HTMLElement
     @subscriptions.add @model.onDidActivate(@activated.bind(this))
     @subscriptions.add @model.observeActive(@activeStatusChanged.bind(this))
     @subscriptions.add @model.observeActiveItem(@activeItemChanged.bind(this))
+    @subscriptions.add @model.observeActiveItem(
+      debounce(@activeItemStoppedChanging.bind(this), 50)
+    )
     @subscriptions.add @model.onDidRemoveItem(@itemRemoved.bind(this))
     @subscriptions.add @model.onDidDestroy(@paneDestroyed.bind(this))
     @subscriptions.add @model.observeFlexScale(@flexScaleChanged.bind(this))
@@ -80,7 +86,12 @@ class PaneElement extends HTMLElement
 
     return unless item?
 
-    hasFocus = @hasFocus()
+    # Track the focus state (in `@hadFocus`) of the active item if there's not
+    # already a pending focus state change (locked by `@hadFocusLocked`).
+    unless @hadFocusLocked
+      @hadFocus = @hasFocus()
+      @hadFocusLocked = true
+
     itemView = @views.getView(item)
 
     if itemPath = item.getPath?()
@@ -96,7 +107,18 @@ class PaneElement extends HTMLElement
       else
         @hideItemView(child)
 
-    itemView.focus() if hasFocus
+  activeItemStoppedChanging: (item) ->
+    # This function consumes any pending focus state change (captured in
+    # `@hadFocus`). Reset the lock (`@hadFocusLocked`) so the next item change
+    # can again set the focus.
+    @hadFocusLocked = false
+
+    return unless item?
+
+    if @hadFocus
+      itemView = @views.getView(item)
+      itemView.focus()
+      @hadFocus = false
 
   showItemView: (itemView) ->
     inlineDisplayStyle = @inlineDisplayStyles.get(itemView)


### PR DESCRIPTION
The native `focus` call is the bulk of the time spent in response to
an active item change event. By debouncing the event and always focusing
asynchronously (async is the default for `debounce` callbacks), tab
changing is more responsive because the 'tabs' package typically updates
its UI only after the native `focus` call completes.

For the crazy perf test of pressing and holding next/previous tab
(ctrl-tab on OS X), many unnecessary `focus` calls are avoided because
of debouncing.
