### PR TITLE
[build instructions] Only checkout stable releases

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -55,7 +55,7 @@ If you have problems with permissions don't forget to prefix with `sudo`
 
   ```sh
   git fetch -p
-  git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
+  git checkout $(git tag --sort="version:refname" | grep -v -E "alpha|beta" | tail -n 1)
   ```
 
 3. Build Atom:


### PR DESCRIPTION
The previous command checked out a alpha or beta release, as this is the latest release nearly all the time.  With this commit checkouts are limited to tags containing neither `alpha` nor `beta`.
