### PR TITLE
Command Line Parameter to set Atom to Portable Mode

### DIFF
--- a/spec/atom-portable-spec.coffee
+++ b/spec/atom-portable-spec.coffee
@@ -1,7 +1,6 @@
 path = require "path"
 fs = require 'fs-plus'
 temp = require "temp"
-rimraf = require "rimraf"
 AtomPortable = require "../src/browser/atom-portable"
 
 describe "Set Portable Mode on #win32", ->
@@ -16,8 +15,8 @@ describe "Set Portable Mode on #win32", ->
     if portableAtomHomeNaturallyExists
       fs.renameSync(portableAtomHomeBackupPath, portableAtomHomePath) if not fs.existsSync(portableAtomHomePath)
     else
-      rimraf.sync(portableAtomHomePath) if fs.existsSync(portableAtomHomePath)
-    rimraf.sync(portableAtomHomeBackupPath) if fs.existsSync(portableAtomHomeBackupPath)
+      fs.removeSync(portableAtomHomePath) if fs.existsSync(portableAtomHomePath)
+    fs.removeSync(portableAtomHomeBackupPath) if fs.existsSync(portableAtomHomeBackupPath)
 
   it "creates a portable home directory", ->
     expect(fs.existsSync(portableAtomHomePath)).toBe false
@@ -44,8 +43,8 @@ describe "Check for Portable Mode", ->
         if portableAtomHomeNaturallyExists
           fs.renameSync(portableAtomHomeBackupPath, portableAtomHomePath) if not fs.existsSync(portableAtomHomePath)
         else
-          rimraf.sync(portableAtomHomePath) if fs.existsSync(portableAtomHomePath)
-        rimraf.sync(portableAtomHomeBackupPath) if fs.existsSync(portableAtomHomeBackupPath)
+          fs.removeSync(portableAtomHomePath) if fs.existsSync(portableAtomHomePath)
+        fs.removeSync(portableAtomHomeBackupPath) if fs.existsSync(portableAtomHomeBackupPath)
 
       describe "with .atom directory sibling to exec", ->
         beforeEach ->
@@ -56,7 +55,7 @@ describe "Check for Portable Mode", ->
 
       describe "without .atom directory sibling to exec", ->
         beforeEach ->
-          rimraf.sync(portableAtomHomePath) if fs.existsSync(portableAtomHomePath)
+          fs.removeSync(portableAtomHomePath) if fs.existsSync(portableAtomHomePath)
 
         it "returns false", ->
           expect(AtomPortable.isPortableInstall("win32", environmentAtomHome)).toBe false

--- a/spec/atom-portable-spec.coffee
+++ b/spec/atom-portable-spec.coffee
@@ -19,7 +19,7 @@ describe "Set Portable Mode on #win32", ->
       rimraf.sync(portableAtomHomePath) if fs.existsSync(portableAtomHomePath)
     rimraf.sync(portableAtomHomeBackupPath) if fs.existsSync(portableAtomHomeBackupPath)
 
-  it "creates portable home directory", ->
+  it "creates a portable home directory", ->
     expect(fs.existsSync(portableAtomHomePath)).toBe false
 
     AtomPortable.setPortable(process.env.ATOM_HOME)

--- a/spec/atom-portable-spec.coffee
+++ b/spec/atom-portable-spec.coffee
@@ -20,6 +20,8 @@ describe "Set Portable Mode on #win32", ->
     rimraf.sync(portableAtomHomeBackupPath) if fs.existsSync(portableAtomHomeBackupPath)
 
   it "creates portable home directory", ->
+    expect(fs.existsSync(portableAtomHomePath)).toBe false
+
     AtomPortable.setPortable(process.env.ATOM_HOME)
     expect(fs.existsSync(portableAtomHomePath)).toBe true
 

--- a/spec/atom-portable-spec.coffee
+++ b/spec/atom-portable-spec.coffee
@@ -4,7 +4,7 @@ temp = require "temp"
 rimraf = require "rimraf"
 AtomPortable = require "../src/browser/atom-portable"
 
-describe "Set Portable Mode", ->
+describe "Set Portable Mode on #win32", ->
   portableAtomHomePath = path.join(path.dirname(process.execPath), "..", ".atom")
   portableAtomHomeNaturallyExists = fs.existsSync(portableAtomHomePath)
   portableAtomHomeBackupPath =  "#{portableAtomHomePath}.temp"

--- a/spec/atom-portable-spec.coffee
+++ b/spec/atom-portable-spec.coffee
@@ -5,9 +5,9 @@ rimraf = require "rimraf"
 AtomPortable = require "../src/browser/atom-portable"
 
 describe "Set Portable Mode", ->
-  portableAtomHomePath = path.join(path.dirname(process.execPath), "../.atom").toString()
+  portableAtomHomePath = path.join(path.dirname(process.execPath), "..", ".atom")
   portableAtomHomeNaturallyExists = fs.existsSync(portableAtomHomePath)
-  portableAtomHomeBackupPath = portableAtomHomePath + ".temp"
+  portableAtomHomeBackupPath =  "#{portableAtomHomePath}.temp"
 
   beforeEach ->
     fs.renameSync(portableAtomHomePath, portableAtomHomeBackupPath) if fs.existsSync(portableAtomHomePath)

--- a/spec/atom-portable-spec.coffee
+++ b/spec/atom-portable-spec.coffee
@@ -4,6 +4,25 @@ temp = require "temp"
 rimraf = require "rimraf"
 AtomPortable = require "../src/browser/atom-portable"
 
+describe "Set Portable Mode", ->
+  portableAtomHomePath = path.join(path.dirname(process.execPath), "../.atom").toString()
+  portableAtomHomeNaturallyExists = fs.existsSync(portableAtomHomePath)
+  portableAtomHomeBackupPath = portableAtomHomePath + ".temp"
+
+  beforeEach ->
+    fs.renameSync(portableAtomHomePath, portableAtomHomeBackupPath) if fs.existsSync(portableAtomHomePath)
+
+  afterEach ->
+    if portableAtomHomeNaturallyExists
+      fs.renameSync(portableAtomHomeBackupPath, portableAtomHomePath) if not fs.existsSync(portableAtomHomePath)
+    else
+      rimraf.sync(portableAtomHomePath) if fs.existsSync(portableAtomHomePath)
+    rimraf.sync(portableAtomHomeBackupPath) if fs.existsSync(portableAtomHomeBackupPath)
+
+  it "creates portable home directory", ->
+    AtomPortable.setPortable(process.env.ATOM_HOME)
+    expect(fs.existsSync(portableAtomHomePath)).toBe true
+
 describe "Check for Portable Mode", ->
   describe "Windows", ->
     describe "with ATOM_HOME environment variable", ->

--- a/src/browser/atom-portable.coffee
+++ b/src/browser/atom-portable.coffee
@@ -8,6 +8,9 @@ class AtomPortable
     execDirectoryPath = path.dirname(process.execPath)
     path.join(execDirectoryPath, '..', '.atom')
 
+  @setPortable: (existingAtomHome) ->
+    fs.copySync(existingAtomHome, @getPortableAtomHomePath())
+
   @isPortableInstall: (platform, environmentAtomHome, defaultHome) ->
     return false unless platform is 'win32'
     return false if environmentAtomHome

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -66,7 +66,7 @@ setupAtomHome = ({setPortable}) ->
     try
       AtomPortable.setPortable(atomHome)
     catch error
-      console.log("Failed copying portable directory: '#{atomHome}' to '#{AtomPortable.getPortableAtomHomePath()}'")
+      console.log("Failed copying portable directory '#{atomHome}' to '#{AtomPortable.getPortableAtomHomePath()}'")
       console.log("#{error.message} #{error.stack}")
 
   if AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome)

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -12,14 +12,13 @@ yargs = require 'yargs'
 console.log = require 'nslog'
 
 start = ->
-  setupAtomHome()
+  args = parseCommandLine()
+  setupAtomHome(args)
   setupCompileCache()
   return if handleStartupEventWithSquirrel()
 
   # NB: This prevents Win10 from showing dupe items in the taskbar
   app.setAppUserModelId('com.squirrel.atom.atom')
-
-  args = parseCommandLine()
 
   addPathToOpen = (event, pathToOpen) ->
     event.preventDefault()
@@ -57,7 +56,7 @@ handleStartupEventWithSquirrel = ->
 setupCrashReporter = ->
   crashReporter.start(productName: 'Atom', companyName: 'GitHub')
 
-setupAtomHome = ->
+setupAtomHome = (args) ->
   return if process.env.ATOM_HOME
   atomHome = path.join(app.getHomeDir(), '.atom')
   AtomPortable = require './atom-portable'

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -63,7 +63,10 @@ setupAtomHome = ({setPortable}) ->
   AtomPortable = require './atom-portable'
 
   if setPortable and not AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome)
-    AtomPortable.setPortable(atomHome)
+    try
+      AtomPortable.setPortable(atomHome)
+    catch error
+      console.log("Failed converting portable directory: #{error.message} #{error.stack}")
 
   if AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome)
     atomHome = AtomPortable.getPortableAtomHomePath()

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -113,7 +113,7 @@ parseCommandLine = ->
   options.boolean('profile-startup').describe('profile-startup', 'Create a profile of the startup execution time.')
   options.alias('r', 'resource-path').string('r').describe('r', 'Set the path to the Atom source directory and enable dev-mode.')
   options.boolean('safe').describe('safe', 'Do not load packages from ~/.atom/packages or ~/.atom/dev/packages.')
-  options.boolean('set-portable').describe('set-portable', 'Set portable mode. Copies the ~/.atom folder to be a sibling of the installed Atom location.')
+  options.boolean('portable').describe('portable', 'Set portable mode. Copies the ~/.atom folder to be a sibling of the installed Atom location.')
   options.alias('t', 'test').boolean('t').describe('t', 'Run the specified specs and exit with error code on failures.')
   options.string('timeout').describe('timeout', 'When in test mode, waits until the specified time (in minutes) and kills the process (exit code: 130).')
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')
@@ -143,7 +143,7 @@ parseCommandLine = ->
   profileStartup = args['profile-startup']
   urlsToOpen = []
   devResourcePath = process.env.ATOM_DEV_RESOURCE_PATH ? path.join(app.getHomeDir(), 'github', 'atom')
-  setPortable = args['set-portable']
+  setPortable = args.portable
 
   if args['resource-path']
     devMode = true

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -66,7 +66,7 @@ setupAtomHome = ({setPortable}) ->
     try
       AtomPortable.setPortable(atomHome)
     catch error
-      console.log("Failed converting portable directory: #{error.message} #{error.stack}")
+      console.log("Failed copying portable directory: #{atomHome} to #{AtomPortable.getPortableAtomHomePath()}. #{error.message} #{error.stack}")
 
   if AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome)
     atomHome = AtomPortable.getPortableAtomHomePath()

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -66,7 +66,8 @@ setupAtomHome = ({setPortable}) ->
     try
       AtomPortable.setPortable(atomHome)
     catch error
-      console.log("Failed copying portable directory: #{atomHome} to #{AtomPortable.getPortableAtomHomePath()}. #{error.message} #{error.stack}")
+      console.log("Failed copying portable directory: '#{atomHome}' to '#{AtomPortable.getPortableAtomHomePath()}'")
+      console.log("#{error.message} #{error.stack}")
 
   if AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome)
     atomHome = AtomPortable.getPortableAtomHomePath()

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -113,7 +113,7 @@ parseCommandLine = ->
   options.boolean('profile-startup').describe('profile-startup', 'Create a profile of the startup execution time.')
   options.alias('r', 'resource-path').string('r').describe('r', 'Set the path to the Atom source directory and enable dev-mode.')
   options.boolean('safe').describe('safe', 'Do not load packages from ~/.atom/packages or ~/.atom/dev/packages.')
-  options.boolean('portable').describe('portable', 'Set portable mode. Copies the ~/.atom folder to be a sibling of the installed Atom location if a .atom is not already there.')
+  options.boolean('portable').describe('portable', 'Set portable mode. Copies the ~/.atom folder to be a sibling of the installed Atom location if a .atom folder is not already there.')
   options.alias('t', 'test').boolean('t').describe('t', 'Run the specified specs and exit with error code on failures.')
   options.string('timeout').describe('timeout', 'When in test mode, waits until the specified time (in minutes) and kills the process (exit code: 130).')
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -113,7 +113,7 @@ parseCommandLine = ->
   options.boolean('profile-startup').describe('profile-startup', 'Create a profile of the startup execution time.')
   options.alias('r', 'resource-path').string('r').describe('r', 'Set the path to the Atom source directory and enable dev-mode.')
   options.boolean('safe').describe('safe', 'Do not load packages from ~/.atom/packages or ~/.atom/dev/packages.')
-  options.boolean('portable').describe('portable', 'Set portable mode. Copies the ~/.atom folder to be a sibling of the installed Atom location.')
+  options.boolean('portable').describe('portable', 'Set portable mode. Copies the ~/.atom folder to be a sibling of the installed Atom location if a .atom is not already there.')
   options.alias('t', 'test').boolean('t').describe('t', 'Run the specified specs and exit with error code on failures.')
   options.string('timeout').describe('timeout', 'When in test mode, waits until the specified time (in minutes) and kills the process (exit code: 130).')
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -61,7 +61,9 @@ setupAtomHome = ->
   return if process.env.ATOM_HOME
   atomHome = path.join(app.getHomeDir(), '.atom')
   AtomPortable = require './atom-portable'
-  atomHome = AtomPortable.getPortableAtomHomePath() if AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome)
+
+  AtomPortable.setPortable(atomHome) if not AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome) and args.setPortable
+  atomHome = AtomPortable.getPortableAtomHomePath() if AtomPortable.isPortableInstall process.platform, process.env.ATOM_HOME, atomHome
   try
     atomHome = fs.realpathSync(atomHome)
   process.env.ATOM_HOME = atomHome
@@ -106,6 +108,7 @@ parseCommandLine = ->
   options.string('timeout').describe('timeout', 'When in test mode, waits until the specified time (in minutes) and kills the process (exit code: 130).')
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')
   options.alias('w', 'wait').boolean('w').describe('w', 'Wait for window to be closed before returning.')
+  options.alias('p', 'set-portable').boolean('p').describe('p', 'Set portable mode.')
   options.string('socket-path')
 
   args = options.argv
@@ -131,6 +134,7 @@ parseCommandLine = ->
   profileStartup = args['profile-startup']
   urlsToOpen = []
   devResourcePath = process.env.ATOM_DEV_RESOURCE_PATH ? path.join(app.getHomeDir(), 'github', 'atom')
+  setPortable = args['set-portable']
 
   if args['resource-path']
     devMode = true
@@ -151,6 +155,6 @@ parseCommandLine = ->
 
   {resourcePath, devResourcePath, pathsToOpen, urlsToOpen, executedFrom, test,
    version, pidToKillWhenClosed, devMode, safeMode, newWindow,
-   logFile, socketPath, profileStartup, timeout}
+   logFile, socketPath, profileStartup, timeout, setPortable}
 
 start()

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -56,15 +56,21 @@ handleStartupEventWithSquirrel = ->
 setupCrashReporter = ->
   crashReporter.start(productName: 'Atom', companyName: 'GitHub')
 
-setupAtomHome = (args) ->
+setupAtomHome = ({setPortable}) ->
   return if process.env.ATOM_HOME
+
   atomHome = path.join(app.getHomeDir(), '.atom')
   AtomPortable = require './atom-portable'
 
-  AtomPortable.setPortable(atomHome) if not AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome) and args.setPortable
-  atomHome = AtomPortable.getPortableAtomHomePath() if AtomPortable.isPortableInstall process.platform, process.env.ATOM_HOME, atomHome
+  if setPortable and not AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome)
+    AtomPortable.setPortable(atomHome)
+
+  if AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome)
+    atomHome = AtomPortable.getPortableAtomHomePath()
+
   try
     atomHome = fs.realpathSync(atomHome)
+
   process.env.ATOM_HOME = atomHome
 
 setupCompileCache = ->

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -109,11 +109,11 @@ parseCommandLine = ->
   options.boolean('profile-startup').describe('profile-startup', 'Create a profile of the startup execution time.')
   options.alias('r', 'resource-path').string('r').describe('r', 'Set the path to the Atom source directory and enable dev-mode.')
   options.boolean('safe').describe('safe', 'Do not load packages from ~/.atom/packages or ~/.atom/dev/packages.')
+  options.boolean('set-portable').describe('set-portable', 'Set portable mode. Copies the ~/.atom folder to be a sibling of the installed Atom location.')
   options.alias('t', 'test').boolean('t').describe('t', 'Run the specified specs and exit with error code on failures.')
   options.string('timeout').describe('timeout', 'When in test mode, waits until the specified time (in minutes) and kills the process (exit code: 130).')
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version.')
   options.alias('w', 'wait').boolean('w').describe('w', 'Wait for window to be closed before returning.')
-  options.alias('p', 'set-portable').boolean('p').describe('p', 'Set portable mode.')
   options.string('socket-path')
 
   args = options.argv


### PR DESCRIPTION
I'm porting this from #9229 and retargeting to master.

From @raelyard:

 This is an enhancement to Portable Mode PR #8442 to provide a command line parameter for Atom to automatically set up a Portable Mode directory (a .atom directory as a sibling to the directory containing the Atom executable).

This uses -p and --set-portable
as a straw-man example of what would be the desired parameter.

This copies the .atom home from the default location to the portable location, assuming someone who has been using Atom and wants to go portable would want to take with them what they have already installed/configured.  This may or may not be a good assumption.
