### PR TITLE
Add package name metadata for load errors

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -38,6 +38,7 @@ describe "PackageManager", ->
       expect(-> pack.reloadStylesheets()).not.toThrow()
       expect(addErrorHandler.callCount).toBe 2
       expect(addErrorHandler.argsForCall[1][0].message).toContain("Failed to reload the package-with-invalid-styles package stylesheets")
+      expect(addErrorHandler.argsForCall[1][0].options.packageName).toEqual "package-with-invalid-styles"
 
     it "returns null if the package has an invalid package.json", ->
       addErrorHandler = jasmine.createSpy()
@@ -45,6 +46,7 @@ describe "PackageManager", ->
       expect(atom.packages.loadPackage("package-with-broken-package-json")).toBeNull()
       expect(addErrorHandler.callCount).toBe 1
       expect(addErrorHandler.argsForCall[0][0].message).toContain("Failed to load the package-with-broken-package-json package")
+      expect(addErrorHandler.argsForCall[0][0].options.packageName).toEqual "package-with-broken-package-json"
 
     it "normalizes short repository urls in package.json", ->
       {metadata} = atom.packages.loadPackage("package-with-short-url-package-json")
@@ -230,6 +232,7 @@ describe "PackageManager", ->
           expect(-> atom.packages.activatePackage('package-with-invalid-activation-commands')).not.toThrow()
           expect(addErrorHandler.callCount).toBe 1
           expect(addErrorHandler.argsForCall[0][0].message).toContain("Failed to activate the package-with-invalid-activation-commands package")
+          expect(addErrorHandler.argsForCall[0][0].options.packageName).toEqual "package-with-invalid-activation-commands"
 
         it "adds a notification when the context menu is invalid", ->
           addErrorHandler = jasmine.createSpy()
@@ -237,6 +240,7 @@ describe "PackageManager", ->
           expect(-> atom.packages.activatePackage('package-with-invalid-context-menu')).not.toThrow()
           expect(addErrorHandler.callCount).toBe 1
           expect(addErrorHandler.argsForCall[0][0].message).toContain("Failed to activate the package-with-invalid-context-menu package")
+          expect(addErrorHandler.argsForCall[0][0].options.packageName).toEqual "package-with-invalid-context-menu"
 
         it "adds a notification when the grammar is invalid", ->
           addErrorHandler = jasmine.createSpy()
@@ -250,6 +254,7 @@ describe "PackageManager", ->
           runs ->
             expect(addErrorHandler.callCount).toBe 1
             expect(addErrorHandler.argsForCall[0][0].message).toContain("Failed to load a package-with-invalid-grammar package grammar")
+            expect(addErrorHandler.argsForCall[0][0].options.packageName).toEqual "package-with-invalid-grammar"
 
         it "adds a notification when the settings are invalid", ->
           addErrorHandler = jasmine.createSpy()
@@ -263,6 +268,7 @@ describe "PackageManager", ->
           runs ->
             expect(addErrorHandler.callCount).toBe 1
             expect(addErrorHandler.argsForCall[0][0].message).toContain("Failed to load the package-with-invalid-settings package settings")
+            expect(addErrorHandler.argsForCall[0][0].options.packageName).toEqual "package-with-invalid-settings"
 
     describe "when the package metadata includes `activationHooks`", ->
       [mainModule, promise] = []
@@ -351,6 +357,7 @@ describe "PackageManager", ->
         expect(-> atom.packages.activatePackage("package-that-throws-an-exception")).not.toThrow()
         expect(addErrorHandler.callCount).toBe 1
         expect(addErrorHandler.argsForCall[0][0].message).toContain("Failed to load the package-that-throws-an-exception package")
+        expect(addErrorHandler.argsForCall[0][0].options.packageName).toEqual "package-that-throws-an-exception"
 
     describe "when the package is not found", ->
       it "rejects the promise", ->

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -467,7 +467,7 @@ class PackageManager
     detail = "#{error.message} in #{metadataPath}"
     stack = "#{error.stack}\n  at #{metadataPath}:1:1"
     message = "Failed to load the #{path.basename(packagePath)} package"
-    @notificationManager.addError(message, {stack, detail, dismissable: true})
+    @notificationManager.addError(message, {stack, detail, packageName: path.basename(packagePath), dismissable: true})
 
   uninstallDirectory: (directory) ->
     symlinkPromise = new Promise (resolve) ->

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -317,7 +317,7 @@ class Package
         if error?
           detail = "#{error.message} in #{settingsPath}"
           stack = "#{error.stack}\n  at #{settingsPath}:1:1"
-          @notificationManager.addFatalError("Failed to load the #{@name} package settings", {stack, detail, dismissable: true})
+          @notificationManager.addFatalError("Failed to load the #{@name} package settings", {stack, detail, packageName: @name, dismissable: true})
         else
           @settings.push(settings)
           settings.activate() if @settingsActivated

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -293,7 +293,7 @@ class Package
         if error?
           detail = "#{error.message} in #{grammarPath}"
           stack = "#{error.stack}\n  at #{grammarPath}:1:1"
-          @notificationManager.addFatalError("Failed to load a #{@name} package grammar", {stack, detail, dismissable: true})
+          @notificationManager.addFatalError("Failed to load a #{@name} package grammar", {stack, detail, packageName: @name, dismissable: true})
         else
           grammar.packageName = @name
           grammar.bundledPackage = @bundledPackage
@@ -634,4 +634,4 @@ class Package
       detail = error.message
       stack = error.stack ? error
 
-    @notificationManager.addFatalError(message, {stack, detail, dismissable: true})
+    @notificationManager.addFatalError(message, {stack, detail, packageName: @name, dismissable: true})


### PR DESCRIPTION
Fatal notifications created during package load/activation/etc. now contain additional package name metadata for use in the Notifications package.

Required for atom/notifications#100.

/cc @kevinsawicki @benogle 
