### PR TITLE
Update language-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "keybinding-resolver": "0.33.0",
     "line-ending-selector": "0.3.0",
     "link": "0.31.0",
-    "markdown-preview": "0.156.0",
+    "markdown-preview": "0.156.1",
     "metrics": "0.53.0",
     "notifications": "0.61.0",
     "open-on-github": "0.39.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "language-html": "0.42.0",
     "language-hyperlink": "0.15.0",
     "language-java": "0.16.1",
-    "language-javascript": "0.99.0",
+    "language-javascript": "0.100.0",
     "language-json": "0.17.1",
     "language-less": "0.28.3",
     "language-make": "0.19.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "language-html": "0.42.0",
     "language-hyperlink": "0.15.0",
     "language-java": "0.16.1",
-    "language-javascript": "0.98.0",
+    "language-javascript": "0.99.0",
     "language-json": "0.17.1",
     "language-less": "0.28.3",
     "language-make": "0.19.0",

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -202,12 +202,12 @@ describe "TokenizedBuffer", ->
 
             # previous line 3 should be combined with input to form line 1
             expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[6]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[6]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.assignment.js'])
 
             # lines below deleted regions should be shifted upward
             expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[2]).toEqual(value: 'while', scopes: ['source.js', 'keyword.control.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[4]).toEqual(value: '<', scopes: ['source.js', 'keyword.operator.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.assignment.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[4]).toEqual(value: '<', scopes: ['source.js', 'keyword.operator.comparison.js'])
 
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]
@@ -254,7 +254,7 @@ describe "TokenizedBuffer", ->
             expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[4]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
 
             # previous line 3 is pushed down to become line 5
-            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[4]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.assignment.js'])
 
             expect(changeHandler).toHaveBeenCalled()
             [event] = changeHandler.argsForCall[0]


### PR DESCRIPTION
0.99.0 contains large changes to how operators are tokenized, so I'm pretty sure it's going to break language-html and/or core specs.  Creating a PR to be on the safe side.

TODO:
- [x] Fix core specs
- [x] Fix markdown-preview specs
