### PR TITLE
Make LanguageMode::unfoldAll faster

### DIFF
--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -465,8 +465,8 @@ class DisplayBuffer extends Model
 
     folds
 
-  # Returns all the folds that contain the given row range.
-  foldsContainingBufferRowRange: (startRow, endRow) ->
+  # Returns all the folds that intersect the given row range.
+  foldsIntersectingBufferRowRange: (startRow, endRow) ->
     @foldForMarker(marker) for marker in @findFoldMarkers(intersectsRowRange: [startRow, endRow])
 
   # Public: Given a buffer row, this returns folds that include it.

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -465,6 +465,10 @@ class DisplayBuffer extends Model
 
     folds
 
+  # Returns all the folds that contain the given row range.
+  foldsContainingBufferRowRange: (startRow, endRow) ->
+    @foldForMarker(marker) for marker in @findFoldMarkers(intersectsRowRange: [startRow, endRow])
+
   # Public: Given a buffer row, this returns folds that include it.
   #
   #

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -97,8 +97,8 @@ class LanguageMode
 
   # Unfolds all the foldable lines in the buffer.
   unfoldAll: ->
-    for row in [@buffer.getLastRow()..0] by -1
-      fold.destroy() for fold in @editor.displayBuffer.foldsStartingAtBufferRow(row)
+    for fold in @editor.displayBuffer.foldsContainingBufferRowRange(0, @buffer.getLastRow()) by -1
+      fold.destroy()
     return
 
   # Fold all comment and code blocks at a given indentLevel

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -97,7 +97,7 @@ class LanguageMode
 
   # Unfolds all the foldable lines in the buffer.
   unfoldAll: ->
-    for fold in @editor.displayBuffer.foldsContainingBufferRowRange(0, @buffer.getLastRow()) by -1
+    for fold in @editor.displayBuffer.foldsIntersectingBufferRowRange(0, @buffer.getLastRow()) by -1
       fold.destroy()
     return
 


### PR DESCRIPTION
_All the benchmarks were performed by opening `src/text-editor.coffee` on startup_.

In the previous implementation we were constantly querying `TextBuffer` for folds whenever the grammar on `TextEditor` changed:

![screen shot 2015-11-06 at 14 29 22](https://cloud.githubusercontent.com/assets/482957/10998082/d9b7339c-8492-11e5-8f34-014d780743f2.png)

Indeed, when changing the grammar we issue a call to `LanguageMode::unfoldAll` which tries to get a fold for each row in the buffer. 

![screen shot 2015-11-06 at 14 33 40](https://cloud.githubusercontent.com/assets/482957/10998152/6ad7aa82-8493-11e5-9ac7-6674ee1a53f1.png)

This happens also on startup because grammars are loaded after a `TextEditor` instance gets created. Moreover, user's perceived responsiveness gets worse as more files (or larger files) need to be opened/restored because we change the grammar for every instance of `TextEditor` as soon as the packages' grammars are loaded and a new grammar is recognized.
### Solution

With this PR, instead of issuing a `findMarker` call to `TextBuffer` for each buffer row, we just get all the folds intersecting the whole buffer and destroy them in reverse order. This is how the first graph looks like after the improvements:

![screen shot 2015-11-06 at 13 22 04](https://cloud.githubusercontent.com/assets/482957/10998210/d2316e20-8493-11e5-9458-9c58ab169d3c.png)

Calling `::unfoldAll` is almost instantaneous now and for a single ~3000 lines file this saves almost `150ms`. :racehorse: :racehorse: :racehorse: 

In the same code path there's still some work we could do to make loading settings faster, as it would seem like we spend a considerable amount of time in just setting keys/values in `Config` (at least during startup). Nevertheless, this should result in a significant responsiveness increase when users boot up Atom with some open files.

/cc: @nathansobo @atom/feedback 
