### PR TITLE
Bump git-utils take 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "fs-plus": "^2.8.0",
     "fstream": "0.1.24",
     "fuzzaldrin": "^2.1",
-    "git-utils": "^4",
+    "git-utils": "^4.0.7",
     "grim": "1.5.0",
     "jasmine-json": "~0.0",
     "jasmine-tagged": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "normalize-package-data": "^2.0.0",
     "nslog": "^3",
     "oniguruma": "^5",
-    "pathwatcher": "^6.2",
+    "pathwatcher": "~6.2",
     "property-accessors": "^1.1.3",
     "random-words": "0.0.1",
     "resolve": "^1.1.6",


### PR DESCRIPTION
Fixes #9339.

A diff of the libgit2 changes: https://github.com/libgit2/libgit2/compare/21e7015ca3425e396c2b7cc03ac67e297a646c91...db1edf91e9ba9e82e6534c445008703766b5a6da
