### PR TITLE
Adjust icon size for small buttons

### DIFF
--- a/static/buttons.less
+++ b/static/buttons.less
@@ -32,7 +32,7 @@
   height: auto;
   line-height: 1.3em;
   &.icon:before {
-    font-size: 12px;
+    font-size: @font-size - 2px;
   }
 }
 .btn.btn-sm,
@@ -41,7 +41,7 @@
   height: auto;
   line-height: 1.3em;
   &.icon:before {
-    font-size: 14px;
+    font-size: @font-size + 1px;
   }
 }
 .btn.btn-lg,
@@ -50,6 +50,9 @@
   padding: @component-padding - 2px  @component-padding + 2px;
   height: auto;
   line-height: 1.3em;
+  &.icon:before {
+    font-size: @font-size + 6px;
+  }
 }
 
 .btn-group > .btn {

--- a/static/buttons.less
+++ b/static/buttons.less
@@ -31,12 +31,18 @@
   font-size: @font-size - 2px;
   height: auto;
   line-height: 1.3em;
+  &.icon:before {
+    font-size: 12px;
+  }
 }
 .btn.btn-sm,
 .btn-group-sm > .btn {
   padding: @component-padding/4 @component-padding/2;
   height: auto;
   line-height: 1.3em;
+  &.icon:before {
+    font-size: 14px;
+  }
 }
 .btn.btn-lg,
 .btn-group-lg > .btn {
@@ -61,6 +67,18 @@
   border-right: none;
   border-top-right-radius: @component-border-radius;
   border-bottom-right-radius: @component-border-radius;
+}
+
+// Icon buttons
+.btn.icon {
+  &:before {
+    width: initial;
+    height: initial;
+    margin-right: .3125em;
+  }
+  &:empty:before {
+    margin-right: 0;
+  }
 }
 
 .btn-toolbar {


### PR DESCRIPTION
This PR makes the icons in small and extra small buttons a bit smaller too. Fixes #8412

Before:

![screen shot 2015-11-07 at 9 52 47 pm](https://cloud.githubusercontent.com/assets/378023/11015248/f0e8f7e6-8599-11e5-823b-c1175377df8d.png)

After:

![screen shot 2015-11-07 at 9 50 42 pm](https://cloud.githubusercontent.com/assets/378023/11015249/f817b6d8-8599-11e5-92e4-3061734e3fef.png)

Screenshots are with core styles only (no theme).
