### PR TITLE
Upgrade Electron To 0.34.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "0.34.0",
+  "electronVersion": "0.34.3",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^6.1.0",


### PR DESCRIPTION
- Fixes Windows Overflow On `process.exit` (Causing apm To Always Fail) https://github.com/atom/electron/releases/tag/v0.34.3
- Fixes Excessive Console Logging On Windows: https://github.com/atom/atom/issues/8957 / https://github.com/atom/electron/releases/tag/v0.34.1
