### PR TITLE
Remove subpixel-font-scaling option

### DIFF
--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -28,7 +28,6 @@ class AtomWindow
       title: 'Atom'
       'web-preferences':
         'direct-write': true
-        'subpixel-font-scaling': true
 
     if @isSpec
       options['web-preferences']['page-visibility'] = true


### PR DESCRIPTION
This option was removed in Electron v0.33.9, and we're on v0.34.0 now (soon to be v0.34.3).
