### PR TITLE
Disable throttling in test windows via WebAudio hack

### DIFF
--- a/src/initialize-test-window.coffee
+++ b/src/initialize-test-window.coffee
@@ -57,6 +57,12 @@ module.exports = ({blobStore}) ->
 
     document.title = "Spec Suite"
 
+    # Avoid throttling of test window by playing silence
+    context = new AudioContext()
+    source = context.createBufferSource()
+    source.connect(context.destination)
+    source.start(0)
+
     testRunner = require(testRunnerPath)
     legacyTestRunner = require(legacyTestRunnerPath)
     buildDefaultApplicationDelegate = -> new ApplicationDelegate()


### PR DESCRIPTION
Throttling in test windows is annoying when tests run interactively, and _seems_ to cause issues with animation frames not firing even in headless tests, though it’s difficult to fully confirm since this issue is intermittent.

Refs atom/electron#3225
/cc @zcbenz 
