### PR TITLE
Fix activatePackages

### DIFF
--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -419,7 +419,7 @@ class PackageManager
     @config.transact =>
       for pack in packages
         promise = @activatePackage(pack.name)
-        promises.push(promise) unless pack.hasActivationCommands()
+        promises.push(promise) unless pack.activationShouldBeDeferred()
       return
     @observeDisabledPackages()
     @observePackagesWithKeymapsDisabled()


### PR DESCRIPTION
When a package having `activationHooks` exists, `did-activate-initial-packages` is not called.
