### PR TITLE
Add menu roles

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -19,7 +19,7 @@
       { type: 'separator' }
       { label: 'Install Shell Commands', command: 'window:install-shell-commands' }
       { type: 'separator' }
-      { label: 'Services', submenu: [] }
+      { label: 'Services', role: 'services', submenu: [] }
       { type: 'separator' }
       { label: 'Hide Atom', command: 'application:hide' }
       { label: 'Hide Others', command: 'application:hide-other-applications' }
@@ -184,16 +184,18 @@
 
   {
     label: 'Window'
+    role: 'window'
     submenu: [
       { label: 'Minimize', command: 'application:minimize' }
       { label: 'Zoom', command: 'application:zoom' }
       { type: 'separator' }
-      { label: 'Bring All to Front', command: 'application:bring-all-windows-to-front' }
+      { label: 'Bring All to Front', command: 'application:bring-all-windows-to-front'}
     ]
   }
 
   {
     label: 'Help'
+    role: 'help'
     submenu: [
       { label: 'Terms of Use', command: 'application:open-terms-of-use' }
       { label: 'Documentation', command: 'application:open-documentation' }

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -189,7 +189,7 @@
       { label: 'Minimize', command: 'application:minimize' }
       { label: 'Zoom', command: 'application:zoom' }
       { type: 'separator' }
-      { label: 'Bring All to Front', command: 'application:bring-all-windows-to-front'}
+      { label: 'Bring All to Front', command: 'application:bring-all-windows-to-front' }
     ]
   }
 

--- a/src/menu-helpers.coffee
+++ b/src/menu-helpers.coffee
@@ -46,7 +46,7 @@ normalizeLabel = (label) ->
     label.replace(/\&/g, '')
 
 cloneMenuItem = (item) ->
-  item = _.pick(item, 'type', 'label', 'enabled', 'visible', 'command', 'submenu', 'commandDetail')
+  item = _.pick(item, 'type', 'label', 'enabled', 'visible', 'command', 'submenu', 'commandDetail', 'role')
   if item.submenu?
     item.submenu = item.submenu.map (submenuItem) -> cloneMenuItem(submenuItem)
   item


### PR DESCRIPTION
This adds roles to the `Services`, `Window`, and `Help` menus to re-enable them after a recent Electron upgrade.

Closes #3204
Closes #9408
