### PR TITLE
Use lazy loaded snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "open-on-github": "0.40.0",
     "package-generator": "0.41.0",
     "release-notes": "0.53.0",
-    "settings-view": "0.231.0",
+    "settings-view": "0.232.0",
     "snippets": "1.0.1",
     "spell-check": "0.63.0",
     "status-bar": "0.80.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "package-generator": "0.41.0",
     "release-notes": "0.53.0",
     "settings-view": "0.231.0",
-    "snippets": "0.101.1",
+    "snippets": "1.0.1",
     "spell-check": "0.63.0",
     "status-bar": "0.80.0",
     "styleguide": "0.45.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "autocomplete-css": "0.11.0",
     "autocomplete-html": "0.7.2",
     "autocomplete-plus": "2.23.0",
-    "autocomplete-snippets": "1.7.1",
+    "autocomplete-snippets": "1.8.0",
     "autoflow": "0.26.0",
     "autosave": "0.23.0",
     "background-tips": "0.26.0",


### PR DESCRIPTION
Ref.: https://github.com/atom/snippets/pull/182
Ref.: https://github.com/atom/settings-view/pull/694
Ref.: https://github.com/atom/autocomplete-snippets/pull/60

This PR just bumps snippets, settings-view and autocomplete-snippets, in order to give the snippets lazy load approach a spin on Travis. I am going to :ship: this as soon as the build gets :green_heart:.

/cc: @atom/feedback @nathansobo 
