### PR TITLE
Prioritize file type matching over first line matching in grammar scoring system

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "language-make": "0.20.0",
     "language-mustache": "0.13.0",
     "language-objective-c": "0.15.0",
-    "language-perl": "0.30.0",
+    "language-perl": "0.31.0",
     "language-php": "0.34.0",
     "language-property-list": "0.8.0",
     "language-python": "0.41.0",

--- a/spec/grammars-spec.coffee
+++ b/spec/grammars-spec.coffee
@@ -142,9 +142,13 @@ describe "the `grammars` global", ->
         expect(atom.grammars.selectGrammar('Rakefile', '').scopeName).toBe 'source.coffee'
         expect(atom.grammars.selectGrammar('Cakefile', '').scopeName).toBe 'source.ruby'
 
-      it "favors grammars with matching first-line-regexps even if custom file types match the file", ->
+      it "favors user-defined file types over grammars with matching first-line-regexps", ->
         atom.config.set('core.customFileTypes', 'source.ruby': ['bootstrap'])
-        expect(atom.grammars.selectGrammar('bootstrap', '#!/usr/bin/env node').scopeName).toBe 'source.js'
+        expect(atom.grammars.selectGrammar('bootstrap', '#!/usr/bin/env node').scopeName).toBe 'source.ruby'
+
+  describe "when there is a grammar with a first line pattern, the file type of the file is known, but from a different grammar", ->
+    it "favors file type over the matching pattern", ->
+      expect(atom.grammars.selectGrammar('foo.rb', '#!/usr/bin/env node').scopeName).toBe 'source.ruby'
 
   describe ".removeGrammar(grammar)", ->
     it "removes the grammar, so it won't be returned by selectGrammar", ->

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -46,7 +46,7 @@ class GrammarRegistry extends FirstMate.GrammarRegistry
     contents = fs.readFileSync(filePath, 'utf8') if not contents? and fs.isFileSync(filePath)
 
     score = @getGrammarPathScore(grammar, filePath)
-    if not grammar.bundledPackage
+    if score > 0 and not grammar.bundledPackage
       score += 0.25
     if @grammarMatchesContents(grammar, contents)
       score += 0.125

--- a/src/grammar-registry.coffee
+++ b/src/grammar-registry.coffee
@@ -36,21 +36,21 @@ class GrammarRegistry extends FirstMate.GrammarRegistry
       if score > highestScore or not bestMatch?
         bestMatch = grammar
         highestScore = score
-      else if score is highestScore and bestMatch?.bundledPackage
-        bestMatch = grammar unless grammar.bundledPackage
     bestMatch
 
   # Extended: Returns a {Number} representing how well the grammar matches the
   # `filePath` and `contents`.
   getGrammarScore: (grammar, filePath, contents) ->
+    return Infinity if @grammarOverrideForPath(filePath) is grammar.scopeName
+
     contents = fs.readFileSync(filePath, 'utf8') if not contents? and fs.isFileSync(filePath)
 
-    if @grammarOverrideForPath(filePath) is grammar.scopeName
-      2 + (filePath?.length ? 0)
-    else if @grammarMatchesContents(grammar, contents)
-      1 + (filePath?.length ? 0)
-    else
-      @getGrammarPathScore(grammar, filePath)
+    score = @getGrammarPathScore(grammar, filePath)
+    if not grammar.bundledPackage
+      score += 0.25
+    if @grammarMatchesContents(grammar, contents)
+      score += 0.125
+    score
 
   getGrammarPathScore: (grammar, filePath) ->
     return -1 unless filePath

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -419,7 +419,7 @@ class PackageManager
     @config.transact =>
       for pack in packages
         promise = @activatePackage(pack.name)
-        promises.push(promise) unless pack.hasActivationCommands()
+        promises.push(promise) unless pack.activationShouldBeDeferred()
       return
     @observeDisabledPackages()
     @observePackagesWithKeymapsDisabled()


### PR DESCRIPTION
Fixes atom/atom#2734

This is a pull request version of https://github.com/atom/atom/issues/2734#issuecomment-155230824 in order to work together on solving the currently unfair grammar scoring system. The main problem with the current system is that it gives a higher score to HTML grammar for any file that begins with HTML doctype, but the file might be using PHP or some other (templating) language that utilizes HTML syntax (with a different file type, eg `php`).

@nathansobo suggested adding an option to fall back to using the old system in case the new one breaks something, but I am not sure how to do that exactly. Also another question would be whether this transition period is needed at all, because all it "breaks" right now is grammar selection for files, for which there is a known file type, but the first line is matched from some other grammar. A fix for that case would be just adding the file type via user configuration, to override the known type from the other language.
