### PR TITLE
Guard against not loaded packages when updating disabled keymaps

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -433,6 +433,13 @@ describe "PackageManager", ->
           runs ->
             expect(atom.keymaps.findKeyBindings(keystrokes: 'ctrl-z', target: element1)).toHaveLength 0
 
+      describe "when setting core.packagesWithKeymapsDisabled", ->
+        it "ignores package names in the array that aren't loaded", ->
+          atom.packages.observePackagesWithKeymapsDisabled()
+
+          expect(-> atom.config.set("core.packagesWithKeymapsDisabled", ["package-does-not-exist"])).not.toThrow()
+          expect(-> atom.config.set("core.packagesWithKeymapsDisabled", [])).not.toThrow()
+
       describe "when the package's keymaps are disabled and re-enabled after it is activated", ->
         it "removes and re-adds the keymaps", ->
           element1 = createTestElement('test-1')

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -336,8 +336,10 @@ class PackageManager
       keymapsToEnable = _.difference(oldValue, newValue)
       keymapsToDisable = _.difference(newValue, oldValue)
 
-      @getLoadedPackage(packageName).deactivateKeymaps() for packageName in keymapsToDisable when not @isPackageDisabled(packageName)
-      @getLoadedPackage(packageName).activateKeymaps() for packageName in keymapsToEnable when not @isPackageDisabled(packageName)
+      for packageName in keymapsToDisable when not @isPackageDisabled(packageName)
+        @getLoadedPackage(packageName)?.deactivateKeymaps()
+      for packageName in keymapsToEnable when not @isPackageDisabled(packageName)
+        @getLoadedPackage(packageName)?.activateKeymaps()
       null
 
   loadPackages: ->


### PR DESCRIPTION
Previously an uncaught exception was thrown if `core.packagesWithKeymapsDisabled` was set to an array that included a package name that wasn't loaded, such as a package that was uninstalled.

Closes atom/settings-view#695
