### PR TITLE
Introduce Config::transactAsync

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -589,6 +589,49 @@ describe "Config", ->
       atom.config.transact ->
       expect(changeSpy).not.toHaveBeenCalled()
 
+  describe ".transactAsync(callback)", ->
+    changeSpy = null
+
+    beforeEach ->
+      changeSpy = jasmine.createSpy('onDidChange callback')
+      atom.config.onDidChange("foo.bar.baz", changeSpy)
+
+    it "allows only one change event for the duration of the given promise if it gets resolved", ->
+      waitsForPromise ->
+        atom.config.transactAsync ->
+          atom.config.set("foo.bar.baz", 1)
+          atom.config.set("foo.bar.baz", 2)
+          atom.config.set("foo.bar.baz", 3)
+          Promise.resolve()
+
+      runs ->
+        expect(changeSpy.callCount).toBe(1)
+        expect(changeSpy.argsForCall[0][0]).toEqual(newValue: 3, oldValue: undefined)
+
+    it "allows only one change event for the duration of the given promise if it gets rejected", ->
+      waitsForPromise shouldReject: true, ->
+        atom.config.transactAsync ->
+          atom.config.set("foo.bar.baz", 1)
+          atom.config.set("foo.bar.baz", 2)
+          atom.config.set("foo.bar.baz", 3)
+          Promise.reject()
+
+      runs ->
+        expect(changeSpy.callCount).toBe(1)
+        expect(changeSpy.argsForCall[0][0]).toEqual(newValue: 3, oldValue: undefined)
+
+    it "allows only one change event even when the given callback throws", ->
+      waitsForPromise shouldReject: true, ->
+        atom.config.transactAsync ->
+          atom.config.set("foo.bar.baz", 1)
+          atom.config.set("foo.bar.baz", 2)
+          atom.config.set("foo.bar.baz", 3)
+          throw new Error("Oops!")
+
+      runs ->
+        expect(changeSpy.callCount).toBe(1)
+        expect(changeSpy.argsForCall[0][0]).toEqual(newValue: 3, oldValue: undefined)
+
   describe ".getSources()", ->
     it "returns an array of all of the config's source names", ->
       expect(atom.config.getSources()).toEqual([])

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -597,38 +597,48 @@ describe "Config", ->
       atom.config.onDidChange("foo.bar.baz", changeSpy)
 
     it "allows only one change event for the duration of the given promise if it gets resolved", ->
-      waitsForPromise ->
-        atom.config.transactAsync ->
-          atom.config.set("foo.bar.baz", 1)
-          atom.config.set("foo.bar.baz", 2)
-          atom.config.set("foo.bar.baz", 3)
-          Promise.resolve()
+      promiseResult = null
+      transactionPromise = atom.config.transactAsync ->
+        atom.config.set("foo.bar.baz", 1)
+        atom.config.set("foo.bar.baz", 2)
+        atom.config.set("foo.bar.baz", 3)
+        Promise.resolve("a result")
+
+      waitsForPromise -> transactionPromise.then (r) -> promiseResult = r
 
       runs ->
+        expect(promiseResult).toBe("a result")
         expect(changeSpy.callCount).toBe(1)
         expect(changeSpy.argsForCall[0][0]).toEqual(newValue: 3, oldValue: undefined)
 
     it "allows only one change event for the duration of the given promise if it gets rejected", ->
-      waitsForPromise shouldReject: true, ->
-        atom.config.transactAsync ->
-          atom.config.set("foo.bar.baz", 1)
-          atom.config.set("foo.bar.baz", 2)
-          atom.config.set("foo.bar.baz", 3)
-          Promise.reject()
+      promiseError = null
+      transactionPromise = atom.config.transactAsync ->
+        atom.config.set("foo.bar.baz", 1)
+        atom.config.set("foo.bar.baz", 2)
+        atom.config.set("foo.bar.baz", 3)
+        Promise.reject("an error")
+
+      waitsForPromise -> transactionPromise.catch (e) -> promiseError = e
 
       runs ->
+        expect(promiseError).toBe("an error")
         expect(changeSpy.callCount).toBe(1)
         expect(changeSpy.argsForCall[0][0]).toEqual(newValue: 3, oldValue: undefined)
 
     it "allows only one change event even when the given callback throws", ->
-      waitsForPromise shouldReject: true, ->
-        atom.config.transactAsync ->
-          atom.config.set("foo.bar.baz", 1)
-          atom.config.set("foo.bar.baz", 2)
-          atom.config.set("foo.bar.baz", 3)
-          throw new Error("Oops!")
+      error = new Error("Oops!")
+      promiseError = null
+      transactionPromise = atom.config.transactAsync ->
+        atom.config.set("foo.bar.baz", 1)
+        atom.config.set("foo.bar.baz", 2)
+        atom.config.set("foo.bar.baz", 3)
+        throw error
+
+      waitsForPromise -> transactionPromise.catch (e) -> promiseError = e
 
       runs ->
+        expect(promiseError).toBe(error)
         expect(changeSpy.callCount).toBe(1)
         expect(changeSpy.argsForCall[0][0]).toEqual(newValue: 3, oldValue: undefined)
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -687,7 +687,7 @@ class Config
   #
   # Returns a {Promise} that is either resolved or rejected according to the
   # `{Promise}` returned by `callback`. If `callback` throws an error, a
-  # rejected {Promise} will be returned.
+  # rejected {Promise} will be returned instead.
   transactAsync: (callback) ->
     @beginTransaction()
     endTransaction = (resolveOrReject) => (args...) =>

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -677,10 +677,14 @@ class Config
     finally
       @endTransaction()
 
-  # Extended: Suppress calls to handler functions registered with
-  # {::onDidChange} and {::observe} for the duration of the {Promise} returned
-  # by `callback`. After the {Promise} is either resolved or rejected, handlers
-  # will be called once if the value for their key-path has changed.
+  ###
+  Section: Internal methods used by core
+  ###
+
+  # Private: Suppress calls to handler functions registered with {::onDidChange}
+  # and {::observe} for the duration of the {Promise} returned by `callback`.
+  # After the {Promise} is either resolved or rejected, handlers will be called
+  # once if the value for their key-path has changed.
   #
   # * `callback` {Function} that returns a {Promise}, which will be executed
   #   while suppressing calls to handlers.
@@ -707,10 +711,6 @@ class Config
   endTransaction: ->
     @transactDepth--
     @emitChangeEvent()
-
-  ###
-  Section: Internal methods used by core
-  ###
 
   pushAtKeyPath: (keyPath, value) ->
     arrayValue = @get(keyPath) ? []

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -690,11 +690,10 @@ class Config
   # rejected {Promise} will be returned instead.
   transactAsync: (callback) ->
     @beginTransaction()
-    endTransaction = (resolveOrReject) => (args...) =>
-      @endTransaction()
-      resolveOrReject(args...)
-
     try
+      endTransaction = (fn) => (args...) =>
+        @endTransaction()
+        fn(args...)
       result = callback()
       new Promise (resolve, reject) =>
         result

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -696,9 +696,7 @@ class Config
         fn(args...)
       result = callback()
       new Promise (resolve, reject) =>
-        result
-          .then(endTransaction(resolve))
-          .catch(endTransaction(reject))
+        result.then(endTransaction(resolve)).catch(endTransaction(reject))
     catch error
       @endTransaction()
       Promise.reject(error)

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -418,13 +418,11 @@ class PackageManager
 
   activatePackages: (packages) ->
     promises = []
-    @config.beginTransaction()
-    for pack in packages
-      promise = @activatePackage(pack.name)
-      promises.push(promise) unless pack.activationShouldBeDeferred()
-    Promise.all(promises)
-      .then(=> @config.endTransaction())
-      .catch(=> @config.endTransaction())
+    @config.transactAsync =>
+      for pack in packages
+        promise = @activatePackage(pack.name)
+        promises.push(promise) unless pack.activationShouldBeDeferred()
+      Promise.all(promises)
     @observeDisabledPackages()
     @observePackagesWithKeymapsDisabled()
     promises


### PR DESCRIPTION
Refs: #9508 

This method is supposed to wrap asynchronous code within a `Config` transaction. It accepts a `callback` which must return a `Promise`: when this resolves or gets rejected (or the `callback` throws an error) we complete the transaction.

I am not super happy with the name I've chosen for this API, as it would have probably been better to follow Node's conventions (i.e. rename `::transact` to `::transactSync` and name the new one `::transact`): unfortunately that method name was already taken and it's part of the public API.

Another thought was to include this feature right inside the existing `::transact` method: although possible, the resulting method would need to conform to two different contracts based on the return type of `callback`, which feels somewhat misleading for clients. In the end having a separate method felt somewhat cleaner.

Feedback super welcome! :bow:  

/cc: @nathansobo @joshaber @atom/feedback 
