### PR TITLE
Lierdakil: Defer Activation Hooks

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -284,6 +284,7 @@ describe "PackageManager", ->
         expect(Package.prototype.requireMainModule.callCount).toBe 0
 
         atom.packages.triggerActivationHook('language-fictitious:grammar-used')
+        atom.packages.triggerDeferredActivationHooks()
 
         waitsForPromise ->
           promise

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -37,6 +37,7 @@ class PackageManager
     @emitter = new Emitter
     @activationHookEmitter = new Emitter
     @packageDirPaths = []
+    @deferredActivationHooks = []
     if configDirPath? and not safeMode
       if @devMode
         @packageDirPaths.push(path.join(configDirPath, "dev", "packages"))
@@ -409,6 +410,8 @@ class PackageManager
       packages = @getLoadedPackagesForTypes(types)
       promises = promises.concat(activator.activatePackages(packages))
     Promise.all(promises).then =>
+      @triggerDeferredActivationHooks()
+      @emit 'activated' if Grim.includeDeprecatedAPIs
       @emitter.emit 'did-activate-initial-packages'
 
   # another type of package manager can handle other package types.
@@ -441,9 +444,16 @@ class PackageManager
     else
       Promise.reject(new Error("Failed to load package '#{name}'"))
 
+  triggerDeferredActivationHooks: ->
+    @activationHookEmitter.emit(hook) for hook in @deferredActivationHooks
+    @deferredActivationHooks = null
+
   triggerActivationHook: (hook) ->
     return new Error("Cannot trigger an empty activation hook") unless hook? and _.isString(hook) and hook.length > 0
-    @activationHookEmitter.emit(hook)
+    if @deferredActivationHooks?
+      @deferredActivationHooks.push hook
+    else
+      @activationHookEmitter.emit(hook)
 
   onDidTriggerActivationHook: (hook, callback) ->
     return unless hook? and _.isString(hook) and hook.length > 0

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -445,6 +445,7 @@ class PackageManager
       Promise.reject(new Error("Failed to load package '#{name}'"))
 
   triggerDeferredActivationHooks: ->
+    return unless @deferredActivationHooks?
     @activationHookEmitter.emit(hook) for hook in @deferredActivationHooks
     @deferredActivationHooks = null
 

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -411,7 +411,6 @@ class PackageManager
       promises = promises.concat(activator.activatePackages(packages))
     Promise.all(promises).then =>
       @triggerDeferredActivationHooks()
-      @emit 'activated' if Grim.includeDeprecatedAPIs
       @emitter.emit 'did-activate-initial-packages'
 
   # another type of package manager can handle other package types.


### PR DESCRIPTION
- Fixes #8692 
- Fixes #8313

This PR fixes merge conflicts for #8692. #8692 fixes a bug with the following scenario:
- Open a file (e.g. `sample.js`)
- Close Atom
- Open Atom (observing that `sample.js` is open)
- A package with an activationHook of `language-javascript:grammar-used` is not activated

LGTM on the original PR.
