### PR TITLE
Remap pane:show-item-9 to activate last pane item

### DIFF
--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -168,6 +168,15 @@ describe "Pane", ->
       pane.activateNextItem()
       expect(pane.getActiveItem()).toBe item1
 
+  describe "::activateLastItem()", ->
+    it "sets the active item to the last item", ->
+      pane = new Pane(paneParams(items: [new Item("A"), new Item("B"), new Item("C")]))
+      [item1, item2, item3] = pane.getItems()
+
+      expect(pane.getActiveItem()).toBe item1
+      pane.activateLastItem()
+      expect(pane.getActiveItem()).toBe item3
+
   describe "::moveItemRight() and ::moveItemLeft()", ->
     it "moves the active item to the right and left, without looping around at either end", ->
       pane = new Pane(paneParams(items: [new Item("A"), new Item("B"), new Item("C")]))

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -312,6 +312,9 @@ class Pane extends Model
     else
       @activateItemAtIndex(@items.length - 1)
 
+  activateLastItem: ->
+    @activateItemAtIndex(@items.length - 1)
+
   # Public: Move the active tab to the right.
   moveItemRight: ->
     index = @getActiveItemIndex()

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -12,7 +12,7 @@ module.exports = ({commandRegistry, commandInstaller, config}) ->
     'pane:show-item-6': -> @getModel().getActivePane().activateItemAtIndex(5)
     'pane:show-item-7': -> @getModel().getActivePane().activateItemAtIndex(6)
     'pane:show-item-8': -> @getModel().getActivePane().activateItemAtIndex(7)
-    'pane:show-item-9': -> @getModel().getActivePane().activateItemAtIndex(8)
+    'pane:show-item-9': -> @getModel().getActivePane().activateLastItem()
     'pane:move-item-right': -> @getModel().getActivePane().moveItemRight()
     'pane:move-item-left': -> @getModel().getActivePane().moveItemLeft()
     'window:increase-font-size': -> @getModel().increaseFontSize()


### PR DESCRIPTION
Activate the last tab on pane on cmd / ctrl + 9 shortcut.

Closes #6609.

Noticed work for this was started on #8557 but never finished. This adds the functionality and accompanying spec.
