### PR TITLE
Add a linux archive to distribute atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ Currently only a 64-bit version is available.
 The Linux version does not currently automatically update so you will need to
 repeat these steps to upgrade to future releases.
 
+### Archive extraction
+
+An archive is available for people who don't want to install `atom` as root.
+
+This version enables you to install multiple Atom versions in parallel. It has been built on Ubuntu 64-bit,
+but should be compatible with other Linux distributions.
+
+1. Install dependencies (on Ubuntu): `sudo apt install git gconf2 gconf-service libgtk2.0-0 libudev1 libgcrypt20
+libnotify4 libxtst6 libnss3 python gvfs-bin xdg-utils libcap2`
+2. Download `atom-amd64.tar.gz` from the [Atom releases page](https://github.com/atom/atom/releases/latest).
+3. Run `tar xf atom-amd64.tar.gz` in the directory where you want to extract the Atom folder.
+4. Launch Atom using the installed `atom` command from the newly extracted directory.
+
+The Linux version does not currently automatically update so you will need to
+repeat these steps to upgrade to future releases.
+
 ## Building
 
 * [Linux](docs/build-instructions/linux.md)

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -285,6 +285,7 @@ module.exports = (grunt) ->
   ciTasks.push('dump-symbols') if process.platform is 'darwin'
   ciTasks.push('set-version', 'check-licenses', 'lint', 'generate-asar')
   ciTasks.push('mkdeb') if process.platform is 'linux'
+  ciTasks.push('mktar') if process.platform is 'linux'
   ciTasks.push('codesign:exe') if process.platform is 'win32' and not process.env.CI
   ciTasks.push('create-windows-installer:installer') if process.platform is 'win32'
   ciTasks.push('test') if process.platform is 'darwin'

--- a/build/tasks/mktar-task.coffee
+++ b/build/tasks/mktar-task.coffee
@@ -1,0 +1,30 @@
+path = require 'path'
+
+module.exports = (grunt) ->
+  {spawn, fillTemplate} = require('./task-helpers')(grunt)
+
+  grunt.registerTask 'mktar', 'Create an archive', ->
+    done = @async()
+
+    appFileName = grunt.config.get('atom.appFileName')
+    buildDir = grunt.config.get('atom.buildDir')
+    shellAppDir = grunt.config.get('atom.shellAppDir')
+    {version, description} = grunt.config.get('atom.metadata')
+
+    if process.arch is 'ia32'
+      arch = 'i386'
+    else if process.arch is 'x64'
+      arch = 'amd64'
+    else
+      return done("Unsupported arch #{process.arch}")
+
+    iconPath = path.join(shellAppDir, 'resources', 'app.asar.unpacked', 'resources', 'atom.png')
+
+    cmd = path.join('script', 'mktar')
+    args = [appFileName, version, arch, iconPath, buildDir]
+    spawn {cmd, args}, (error) ->
+      if error?
+        done(error)
+      else
+        grunt.log.ok "Created " + path.join(buildDir, "#{appFileName}-#{version}-#{arch}.tar.gz")
+        done()

--- a/build/tasks/publish-build-task.coffee
+++ b/build/tasks/publish-build-task.coffee
@@ -85,13 +85,13 @@ getAssets = ->
         arch = 'amd64'
 
       # Check for a Debian build
-      sourcePath = "#{buildDir}/#{appFileName}-#{version}-#{arch}.deb"
+      sourcePath = path.join(buildDir, "#{appFileName}-#{version}-#{arch}.deb")
       assetName = "atom-#{arch}.deb"
 
       # Check for a Fedora build
       unless fs.isFileSync(sourcePath)
         rpmName = fs.readdirSync("#{buildDir}/rpm")[0]
-        sourcePath = "#{buildDir}/rpm/#{rpmName}"
+        sourcePath = path.join(buildDir, "rpm", rpmName)
         if process.arch is 'ia32'
           arch = 'i386'
         else
@@ -99,10 +99,17 @@ getAssets = ->
         assetName = "atom.#{arch}.rpm"
 
       cp sourcePath, path.join(buildDir, assetName)
+      assets = [{assetName, sourcePath}]
 
-      [
-        {assetName, sourcePath}
-      ]
+      # Check for an archive build on a debian build machine.
+      # We could provide a Fedora version if some libraries are not compatible
+      sourcePath = path.join(buildDir, "#{appFileName}-#{version}-#{arch}.tar.gz")
+      if fs.isFileSync(sourcePath)
+        assetName = "atom-#{arch}.tar.gz"
+        cp sourcePath, path.join(buildDir, assetName)
+        assets.push({assetName, sourcePath})
+
+      assets
 
 logError = (message, error, details) ->
   grunt.log.error(message)

--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -74,7 +74,7 @@ If you have problems with permissions don't forget to prefix with `sudo`
 
   To use the newly installed Atom, quit and restart all running Atom instances.
 
-5. *Optionally*, you may generate distributable packages of Atom at `out`. Currently, `.deb` and `.rpm` package types are supported. To create a `.deb` package run:
+5. *Optionally*, you may generate distributable packages of Atom at `out`. Currently, `.deb` and `.rpm` package types are supported, as well as a `tar gz` archive. To create a `.deb` package run:
 
   ```sh
   script/grunt mkdeb
@@ -84,6 +84,12 @@ If you have problems with permissions don't forget to prefix with `sudo`
 
   ```sh
   script/grunt mkrpm
+  ```
+
+  To create a `.tar.gz` package run
+
+  ```sh
+  script/grunt mktar
   ```
 
 ## Advanced Options

--- a/script/mktar
+++ b/script/mktar
@@ -1,0 +1,39 @@
+#!/bin/bash
+# mktar name version arch icon-path build-root-path
+
+set -e
+
+SCRIPT=`readlink -f "$0"`
+ROOT=`readlink -f $(dirname $SCRIPT)/..`
+cd $ROOT
+
+NAME="$1"
+VERSION="$2"
+ARCH="$3"
+ICON_FILE="$4"
+BUILD_ROOT_PATH="$5"
+FILE_MODE=755
+
+TAR_PATH=$BUILD_ROOT_PATH
+ATOM_PATH="$BUILD_ROOT_PATH/Atom"
+
+TARGET_ROOT="`mktemp -d`"
+chmod $FILE_MODE "$TARGET_ROOT"
+NAME_IN_TAR="$NAME-$VERSION-$ARCH"
+TARGET="$TARGET_ROOT/$NAME_IN_TAR"
+
+# Copy executable and resources
+cp -a "$ATOM_PATH" "$TARGET"
+
+# Copy icon file
+cp "$ICON_FILE" "$TARGET/$NAME.png"
+
+# Remove executable bit from .node files
+find "$TARGET" -type f -name "*.node" -exec chmod a-x {} \;
+
+# Create the archive
+pushd "$TARGET_ROOT"
+tar caf "$TAR_PATH/$NAME_IN_TAR.tar.gz" "$NAME_IN_TAR"
+popd
+
+rm -rf "$TARGET_ROOT"


### PR DESCRIPTION
Now that Atom has a relocable/portable config directories and different channels, it makes sense to have a way to distribute an archive on Linux (as suggested on bug #7102) containing latest available code for each channels.

This has two advantages:
- this will enable (in a later step) to enable auto-upgrade to follow multiple channels (optionally in parallel in different directories). We can even think giving a way for people to switch between channels as needed (given the user config stay backward compatible). I'm happy to work on those 2 problematics after/if this PR is merged at some point.
- if all dependencies are installed in the distribution, the atom installation is then just a question of extracting an archive, requiring non root permission contrary to the .deb or .rpm packages.

We can then integrate this archive to be downloaded to some tools like Ubuntu Make (https://github.com/ubuntu/ubuntu-make/issues/6).

We generate a .tar.gz compressed archive (we could switch to a more performant .tar.xz, but the first format is more widespread and usual). I did add the `mktar` to the `CI task` (I saw the rpm wasn't in there, so I guess, it's only running on an Ubuntu machine) and tested it. I did add the task as well to `upload-assets`, but of course, I couldn't test it ;) The changes there are though minimal, but I can modify what's necessary as needed.

As _version_ contains _upstream version + channel name_, I didn't change anything in the naming of the archive publication, and the folder in archive contains thus an uniquely defined build.

Of course, the resulting archive is linked against the libraries available in the builder version. mktar is run where the .deb is built, which is, I guess, the latest ubuntu LTS. I tried the built archive on 14.04 LTS, 15.04, 15.10 and xenial (dev version), and everything is working as expected. If this doesn't work on other distros (which, looking at the deps, seems unlikely and we already only have one deb for debian/ubuntu and one rpm for fedora/opensuse…), we can build multiple archives. But I propose we starts with this one.

I'm happy to do any changes that you feel are necessary!
