### PR TITLE
Set initialLoadComplete to true only in test mode

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -117,7 +117,7 @@ class AtomEnvironment extends Model
 
   # Call .loadOrCreate instead
   constructor: (params={}) ->
-    {@blobStore, @applicationDelegate, @window, @document, configDirPath, @enablePersistence} = params
+    {@blobStore, @applicationDelegate, @window, @document, configDirPath, @enablePersistence, loadBaseStylesheetsOnly} = params
 
     @state = {version: @constructor.version}
 
@@ -183,7 +183,7 @@ class AtomEnvironment extends Model
 
     @themes.loadBaseStylesheets()
     @initialStyleElements = @styles.getSnapshot()
-    @themes.initialLoadComplete = true
+    @themes.initialLoadComplete = true if loadBaseStylesheetsOnly
     @setBodyPlatformClass()
 
     @stylesElement = @styles.buildStylesElement()

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -117,7 +117,7 @@ class AtomEnvironment extends Model
 
   # Call .loadOrCreate instead
   constructor: (params={}) ->
-    {@blobStore, @applicationDelegate, @window, @document, configDirPath, @enablePersistence, loadBaseStylesheetsOnly} = params
+    {@blobStore, @applicationDelegate, @window, @document, configDirPath, @enablePersistence, onlyLoadBaseStyleSheets} = params
 
     @state = {version: @constructor.version}
 
@@ -183,7 +183,7 @@ class AtomEnvironment extends Model
 
     @themes.loadBaseStylesheets()
     @initialStyleElements = @styles.getSnapshot()
-    @themes.initialLoadComplete = true if loadBaseStylesheetsOnly
+    @themes.initialLoadComplete = true if onlyLoadBaseStyleSheets
     @setBodyPlatformClass()
 
     @stylesElement = @styles.buildStylesElement()

--- a/src/initialize-test-window.coffee
+++ b/src/initialize-test-window.coffee
@@ -70,7 +70,7 @@ module.exports = ({blobStore}) ->
     buildAtomEnvironment = (params) ->
       params = cloneObject(params)
       params.blobStore = blobStore unless params.hasOwnProperty("blobStore")
-      params.loadBaseStylesheetsOnly = true unless params.hasOwnProperty("loadBaseStylesheetsOnly")
+      params.onlyLoadBaseStyleSheets = true unless params.hasOwnProperty("onlyLoadBaseStyleSheets")
       new AtomEnvironment(params)
 
     promise = testRunner({

--- a/src/initialize-test-window.coffee
+++ b/src/initialize-test-window.coffee
@@ -70,6 +70,7 @@ module.exports = ({blobStore}) ->
     buildAtomEnvironment = (params) ->
       params = cloneObject(params)
       params.blobStore = blobStore unless params.hasOwnProperty("blobStore")
+      params.loadBaseStylesheetsOnly = true unless params.hasOwnProperty("loadBaseStylesheetsOnly")
       new AtomEnvironment(params)
 
     promise = testRunner({


### PR DESCRIPTION
Fixes #9189 

After the changes in #8968, `ThemeManager::isInitialLoadComplete` [was always being set to true](https://github.com/atom/atom/blob/master/src/atom-environment.coffee#L185-L186), whereas in the past we used to set it only after all the theme packages had been activated.

How does this relate to scrollbars? When restoring the previous state we attach the workspace along with the needed `TextEditorElement`s. When `TextEditorComponent` gets instantiated, it uses `isInitialLoadComplete` to decide whether it should listen to `ThemeManager::onDidChangeActiveThemes`, which is what triggers `::refreshScrollbars` after e.g. `one-dark-ui` loads.

Since `::isInitialLoadComplete` was true before the themes had the chance to actually being loaded, we weren't refreshing scrollbars at all, thus not allowing webkit to apply the needed stylesheets (when we refresh the scrollbars we explicitly trigger a reflow to let Chrome handle stylesheets correctly).

This PR changes the existing behavior so that we mark the initial theme load as complete only in test mode (through a configurable option).

/cc: @nathansobo @atom/feedback 
