### PR TITLE
Add apm.cmd

### DIFF
--- a/resources/win/apm.cmd
+++ b/resources/win/apm.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+"%~dp0\..\app\apm\bin\node.exe" "%~dp0\..\app\apm\lib\cli.js" %*


### PR DESCRIPTION
Allows Windows users who build Atom to conveniently type `apm` in the console just as they would for `atom`.

/cc @raelyard @joefitzgerald @kevinsawicki 
