### PR TITLE
Add OS X dock menu with 'New Window' option

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -82,6 +82,7 @@ class AtomApplication
     @listenForArgumentsFromNewProcess()
     @setupJavaScriptArguments()
     @handleEvents()
+    @setupDockMenu()
     @storageFolder = new StorageFolder(process.env.ATOM_HOME)
 
     if options.pathsToOpen?.length > 0 or options.urlsToOpen?.length > 0 or options.test
@@ -279,6 +280,13 @@ class AtomApplication
 
     ipc.on 'write-to-stderr', (event, output) ->
       process.stderr.write(output)
+
+  setupDockMenu: ->
+    if process.platform is 'darwin'
+      dockMenu = Menu.buildFromTemplate [
+        {label: 'New Window',  click: => @emit('application:new-window')}
+      ]
+      app.dock.setMenu dockMenu
 
   # Public: Executes the given command.
   #


### PR DESCRIPTION
I was getting annoyed by Atom missing this common OS X feature. 

It's especially useful when you have multiple spaces (desktops) with Atom already active on a different one than you are on currently. Currently, getting a new Atom window in this space takes 5 steps:
1. Click the dock icon, which would move you to the other space where Atom was already active
2. Choose "New Window" in the File menu (or use the Command+Shift+N shortcut)
3. Toggle Mission Control by hitting F3 or swiping up with the configured number of fingers
4. Drag the Atom window from the current space to the one where you wanted it
5. Switch back to the space you were on originally

Now, it only takes 2:
1. Right-click the Atom icon
2. Choose "New Window"

<img width="213" alt="screen shot 2015-11-15 at 19 52 36" src="https://cloud.githubusercontent.com/assets/159434/11170443/bfa18400-8bd4-11e5-8c1e-ac2c09c293b0.png">
