### PR TITLE
Close empty active window when Close command is given

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -1438,11 +1438,11 @@ describe "Workspace", ->
         save = -> atom.workspace.saveActivePaneItem()
         expect(save).toThrow()
 
-  describe "::destroyActivePaneItemOrEmptyPane", ->
+  describe "::closeActivePaneItemOrEmptyPaneOrWindow", ->
     beforeEach ->
       waitsForPromise -> atom.workspace.open()
 
-    it "closes the active pane item until all that remains is a single empty pane", ->
+    it "closes the active pane item, or the active pane if it is empty, or the current window if there is only the empty root pane", ->
       atom.config.set('core.destroyEmptyPanes', false)
 
       pane1 = atom.workspace.getActivePane()
@@ -1450,19 +1450,23 @@ describe "Workspace", ->
 
       expect(atom.workspace.getPanes().length).toBe 2
       expect(pane2.getItems().length).toBe 1
-      atom.workspace.destroyActivePaneItemOrEmptyPane()
+      atom.workspace.closeActivePaneItemOrEmptyPaneOrWindow()
 
       expect(atom.workspace.getPanes().length).toBe 2
       expect(pane2.getItems().length).toBe 0
 
-      atom.workspace.destroyActivePaneItemOrEmptyPane()
+      atom.workspace.closeActivePaneItemOrEmptyPaneOrWindow()
 
       expect(atom.workspace.getPanes().length).toBe 1
       expect(pane1.getItems().length).toBe 1
 
-      atom.workspace.destroyActivePaneItemOrEmptyPane()
+      atom.workspace.closeActivePaneItemOrEmptyPaneOrWindow()
       expect(atom.workspace.getPanes().length).toBe 1
       expect(pane1.getItems().length).toBe 0
 
-      atom.workspace.destroyActivePaneItemOrEmptyPane()
+      atom.workspace.closeActivePaneItemOrEmptyPaneOrWindow()
       expect(atom.workspace.getPanes().length).toBe 1
+
+      spyOn(atom, 'close')
+      atom.workspace.closeActivePaneItemOrEmptyPaneOrWindow()
+      expect(atom.close).toHaveBeenCalled()

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -21,7 +21,6 @@ module.exports =
       followSymlinks:
         type: 'boolean'
         default: true
-        title: 'Follow symlinks'
         description: 'Follow symbolic links when searching files and when opening files with the fuzzy finder.'
       disabledPackages:
         type: 'array'
@@ -54,7 +53,12 @@ module.exports =
       destroyEmptyPanes:
         type: 'boolean'
         default: true
-        description: 'When the last item of a pane is removed, remove that pane as well.'
+        title: 'Remove Empty Panes'
+        description: 'When the last tab of a pane is closed, remove that pane as well.'
+      closeEmptyWindows:
+        type: 'boolean'
+        default: true
+        description: 'When a window with no open tabs or panes is given the \'Close Tab\' command, close that window.'
       fileEncoding:
         description: 'Default character set encoding to use when reading and writing files.'
         type: 'string'

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -55,7 +55,7 @@ module.exports = ({commandRegistry, commandInstaller, config}) ->
     'window:log-deprecation-warnings': -> Grim.logDeprecations()
     'window:toggle-auto-indent': -> config.set("editor.autoIndent", not config.get("editor.autoIndent"))
     'pane:reopen-closed-item': -> @getModel().reopenItem()
-    'core:close': -> @getModel().destroyActivePaneItemOrEmptyPane()
+    'core:close': -> @getModel().closeActivePaneItemOrEmptyPaneOrWindow()
     'core:save': -> @getModel().saveActivePaneItem()
     'core:save-as': -> @getModel().saveActivePaneItemAs()
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -675,9 +675,15 @@ class Workspace extends Model
   destroyActivePane: ->
     @getActivePane()?.destroy()
 
-  # Destroy the active pane item or the active pane if it is empty.
-  destroyActivePaneItemOrEmptyPane: ->
-    if @getActivePaneItem()? then @destroyActivePaneItem() else @destroyActivePane()
+  # Close the active pane item, or the active pane if it is empty,
+  # or the current window if there is only the empty root pane.
+  closeActivePaneItemOrEmptyPaneOrWindow: ->
+    if @getActivePaneItem()?
+      @destroyActivePaneItem()
+    else if @getPanes().length > 1
+      @destroyActivePane()
+    else
+      atom.close()
 
   # Increase the editor font size by 1px.
   increaseFontSize: ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -682,7 +682,7 @@ class Workspace extends Model
       @destroyActivePaneItem()
     else if @getPanes().length > 1
       @destroyActivePane()
-    else
+    else if @config.get('core.closeEmptyWindows')
       atom.close()
 
   # Increase the editor font size by 1px.


### PR DESCRIPTION
On OS X, Command-W is expected to close the current window, unless the current window has tabs (Safari, Chrome, Finder), in which case it will close the current tab, until only one is left, in which case it closes the entire window (and thus also the tab).

Currently in Atom, Command-W will close every pane item in the current pane, then the current pane, and so on until every pane is empty, which makes sense since pane items and panes ~ tabs. However, when only the empty root pane is left, which the user experiences as there being no panes left at all, hitting Command-W will not close the window, but will instead have no effect at all. To actually close the window, one needs to either manually hit the red close button in the upper left corner or the window, choose "Close Window" in the File menu or use the Cmd-Shift-W shortcut, all of which break the OS X UX contract.

With this PR, Command-W will behave exactly as it does right now, with one exception: when only the root pane is left, Command-W closes the entire window.

Hitting Command-W with only one pane item ~ tab open will NOT close the window, which is inconsistent with tabbed web browsing but makes more sense for a text editor.
