### PR TITLE
Use em-dash in window title and exclude app name on OS X

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -76,7 +76,7 @@ describe "Workspace", ->
           expect(editor4.getCursorScreenPosition()).toEqual [2, 4]
 
           expect(atom.workspace.getActiveTextEditor().getPath()).toBe editor3.getPath()
-          expect(document.title).toBe "#{path.basename(editor3.getLongTitle())} - #{atom.project.getPaths()[0]} - Atom"
+          expect(document.title).toMatch ///^#{path.basename(editor3.getLongTitle())}\ \u2014\ #{atom.project.getPaths()[0]}///
 
     describe "where there are no open panes or editors", ->
       it "constructs the view with no open editors", ->
@@ -732,7 +732,7 @@ describe "Workspace", ->
     describe "when the project has no path", ->
       it "sets the title to 'untitled'", ->
         atom.project.setPaths([])
-        expect(document.title).toBe 'untitled - Atom'
+        expect(document.title).toMatch ///^untitled///
 
     describe "when the project has a path", ->
       beforeEach ->
@@ -742,25 +742,25 @@ describe "Workspace", ->
       describe "when there is an active pane item", ->
         it "sets the title to the pane item's title plus the project path", ->
           item = atom.workspace.getActivePaneItem()
-          expect(document.title).toBe "#{item.getTitle()} - #{atom.project.getPaths()[0]} - Atom"
+          expect(document.title).toMatch ///^#{item.getTitle()}\ \u2014\ #{atom.project.getPaths()[0]}///
 
       describe "when the title of the active pane item changes", ->
         it "updates the window title based on the item's new title", ->
           editor = atom.workspace.getActivePaneItem()
           editor.buffer.setPath(path.join(temp.dir, 'hi'))
-          expect(document.title).toBe "#{editor.getTitle()} - #{atom.project.getPaths()[0]} - Atom"
+          expect(document.title).toMatch ///^#{editor.getTitle()}\ \u2014\ #{atom.project.getPaths()[0]}///
 
       describe "when the active pane's item changes", ->
         it "updates the title to the new item's title plus the project path", ->
           atom.workspace.getActivePane().activateNextItem()
           item = atom.workspace.getActivePaneItem()
-          expect(document.title).toBe "#{item.getTitle()} - #{atom.project.getPaths()[0]} - Atom"
+          expect(document.title).toMatch ///^#{item.getTitle()}\ \u2014\ #{atom.project.getPaths()[0]}///
 
       describe "when the last pane item is removed", ->
         it "updates the title to contain the project's path", ->
           atom.workspace.getActivePane().destroy()
           expect(atom.workspace.getActivePaneItem()).toBeUndefined()
-          expect(document.title).toBe "#{atom.project.getPaths()[0]} - Atom"
+          expect(document.title).toMatch ///^#{atom.project.getPaths()[0]}///
 
       describe "when an inactive pane's item changes", ->
         it "does not update the title", ->
@@ -784,7 +784,7 @@ describe "Workspace", ->
         })
         workspace2.deserialize(atom.workspace.serialize(), atom.deserializers)
         item = workspace2.getActivePaneItem()
-        expect(document.title).toBe "#{item.getLongTitle()} - #{atom.project.getPaths()[0]} - Atom"
+        expect(document.title).toMatch ///^#{item.getLongTitle()}\ \u2014\ #{atom.project.getPaths()[0]}///
         workspace2.destroy()
 
   describe "document edited status", ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -161,15 +161,22 @@ class Workspace extends Model
     itemTitle ?= "untitled"
     projectPath ?= projectPaths[0]
 
+    titleParts = []
     if item? and projectPath?
-      document.title = "#{itemTitle} - #{projectPath} - #{appName}"
-      @applicationDelegate.setRepresentedFilename(itemPath ? projectPath)
+      titleParts.push itemTitle, projectPath
+      representedPath = itemPath ? projectPath
     else if projectPath?
-      document.title = "#{projectPath} - #{appName}"
-      @applicationDelegate.setRepresentedFilename(projectPath)
+      titleParts.push projectPath
+      representedPath = projectPath
     else
-      document.title = "#{itemTitle} - #{appName}"
-      @applicationDelegate.setRepresentedFilename("")
+      titleParts.push itemTitle
+      representedPath = ""
+
+    unless process.platform is 'darwin'
+      titleParts.push appName
+
+    document.title = titleParts.join(" \u2014 ")
+    @applicationDelegate.setRepresentedFilename(representedPath)
 
   # On OS X, fades the application window's proxy icon when the current file
   # has been modified.


### PR DESCRIPTION
On OS X, the convention is to use the em-dash as the segment separator in window titles, and to not include the app name: (The two items at the top are window titles)
<img src="https://cloud.githubusercontent.com/assets/639601/5069962/6032658a-6e9c-11e4-9953-aa84006bdfff.png" width="341">
## OLD

<img width="488" alt="screen shot 2015-11-16 at 12 02 36" src="https://cloud.githubusercontent.com/assets/159434/11180302/f37325d8-8c59-11e5-9435-355aecac706d.png">
<img width="573" alt="screen shot 2015-11-16 at 12 03 00" src="https://cloud.githubusercontent.com/assets/159434/11180313/0ac7f024-8c5a-11e5-80b8-d0ae731cb78a.png">
## NEW

<img width="492" alt="screen shot 2015-11-16 at 11 57 31" src="https://cloud.githubusercontent.com/assets/159434/11180252/983be42a-8c59-11e5-8515-ed43ff71e4ba.png">
<img width="540" alt="screen shot 2015-11-16 at 11 57 59" src="https://cloud.githubusercontent.com/assets/159434/11180251/98387c22-8c59-11e5-9d71-556d733b8136.png">
