### PR TITLE
Add section on feature suggestions to CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ These are just guidelines, not rules, use your best judgment and feel free to pr
 
 [How Can I Contribute?](#how-can-i-contribute)
   * [Reporting Bugs](#reporting-bugs)
-  * [Suggesting Features](#suggesting-features)
+  * [Suggesting Enhancements](#suggesting-enhancements)
   * [Your First Code Contribution](#your-first-code-contribution)
   * [Pull Requests](#pull-requests)
 
@@ -158,38 +158,38 @@ Include details about your configuration and environment:
     * Problem can be reliably reproduced, doesn't happen randomly: [Yes/No]
     * Problem happens with all files and projects, not only some files or projects: [Yes/No]
 
-### Suggesting Features
+### Suggesting Enhancements
 
-This section guides you through submitting a feature suggestion for Atom. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+This section guides you through submitting an enhancement suggestion for Atom, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
-Before creating feature suggestions, please check [this list](#before-submitting-a-feature-suggestion) as you might find out that you don't need to create one. When you are creating a feature suggestion, please [include as many details as possible](#how-do-i-submit-a-good-feature-suggestion). If you'd like, you can use [this template](#template-for-submitting-feature-suggestions) to structure the information.
+Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion) as you might find out that you don't need to create one. When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion). If you'd like, you can use [this template](#template-for-submitting-enhancement-suggestions) to structure the information.
 
-#### Before Submitting A Feature Suggestion
+#### Before Submitting An Enhancement Suggestion
 
-* **Check the [debugging guide](https://atom.io/docs/latest/hacking-atom-debugging)** for tips — you might discover that the feature is already available. Most importantly, check if you're using [the latest version of Atom](https://atom.io/docs/latest/hacking-atom-debugging#update-to-the-latest-version) and if you can get the desired behavior by changing [Atom's or packages' config settings](https://atom.io/docs/latest/hacking-atom-debugging#check-atom-and-package-settings).
-* **Check if there's already [a package](https://atom.io/packages) which provides that feature.**
-* **Determine [which repository the feature should be suggested in](#atom-and-packages).**
-* **Perform a [cursory search](https://github.com/issues?q=+is%3Aissue+user%3Aatom)** to see if the feature has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+* **Check the [debugging guide](https://atom.io/docs/latest/hacking-atom-debugging)** for tips — you might discover that the enhancement is already available. Most importantly, check if you're using [the latest version of Atom](https://atom.io/docs/latest/hacking-atom-debugging#update-to-the-latest-version) and if you can get the desired behavior by changing [Atom's or packages' config settings](https://atom.io/docs/latest/hacking-atom-debugging#check-atom-and-package-settings).
+* **Check if there's already [a package](https://atom.io/packages) which provides that enhancement.**
+* **Determine [which repository the enhancement should be suggested in](#atom-and-packages).**
+* **Perform a [cursory search](https://github.com/issues?q=+is%3Aissue+user%3Aatom)** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 
-#### How Do I Submit A (Good) Feature Suggestion?
+#### How Do I Submit A (Good) Enhancement Suggestion?
 
-Feature suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you've determined [which repository](#atom-and-packages) your feature suggestions is related to, create an issue on that repository and provide the following information:
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you've determined [which repository](#atom-and-packages) your enhancement suggestions is related to, create an issue on that repository and provide the following information:
 
 * **Use a clear and descriptive title** for the issue to identify the suggestion.
-* **Provide a step-by-step description of the suggested feature** in as many details as possible.
+* **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
 * **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 * **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
 * **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of Atom which the suggestion is related to. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on OSX and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
-* **Explain why this feature would be useful** to most Atom users and isn't something that can or should be implemented as a [community package](#atom-and-packages).
-* **List some other text editors or applications where this feature exists.**
+* **Explain why this enhancement would be useful** to most Atom users and isn't something that can or should be implemented as a [community package](#atom-and-packages).
+* **List some other text editors or applications where this enhancement exists.**
 * **Specify which version of Atom you're using.** You can get the exact version by running `atom -v` in your terminal, or by starting Atom and running the `Application: About` command from the [Command Palette](https://github.com/atom/command-palette).
 * **Specify the name and version of the OS you're using.**
 
-#### Template For Submitting Feature Suggestions
+#### Template For Submitting Enhancement Suggestions
 
     [Short description of suggestion]
 
-    **Steps which explain the feature**
+    **Steps which explain the enhancement**
 
     1. [First Step]
     2. [Second Step]
@@ -199,15 +199,15 @@ Feature suggestions are tracked as [GitHub issues](https://guides.github.com/fea
 
     [Describe current and suggested behavior here]
 
-    **Why would the feature be useful to most users**
+    **Why would the enhancement be useful to most users**
 
-    [Explain why the feature would be useful to most users]
+    [Explain why the enhancement would be useful to most users]
 
-    [List some other text editors or applications where this feature exists]
+    [List some other text editors or applications where this enhancement exists]
 
     **Screenshots and GIFs**
 
-    ![Screenshots and GIFs which demonstrate the steps or part of Atom the feature suggestion is related to](url)
+    ![Screenshots and GIFs which demonstrate the steps or part of Atom the enhancement suggestion is related to](url)
 
     **Atom Version:** [Enter Atom version here]
     **OS and Version:** [Enter OS name and version here]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ These are just guidelines, not rules, use your best judgment and feel free to pr
 
 [How Can I Contribute?](#how-can-i-contribute)
   * [Reporting Bugs](#reporting-bugs)
+  * [Suggesting Features](#suggesting-features)
   * [Your First Code Contribution](#your-first-code-contribution)
   * [Pull Requests](#pull-requests)
 
@@ -156,6 +157,60 @@ Include details about your configuration and environment:
     * Problem started happening recently, didn't happen in an older version of Atom: [Yes/No]
     * Problem can be reliably reproduced, doesn't happen randomly: [Yes/No]
     * Problem happens with all files and projects, not only some files or projects: [Yes/No]
+
+### Suggesting Features
+
+This section guides you through submitting a feature suggestion for Atom. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+
+Before creating feature suggestions, please check [this list](#before-submitting-a-feature-suggestion) as you might find out that you don't need to create one. When you are creating a feature suggestion, please [include as many details as possible](#how-do-i-submit-a-good-feature-suggestion). If you'd like, you can use [this template](#template-for-submitting-feature-suggestions) to structure the information.
+
+#### Before Submitting A Feature Suggestion
+
+* **Check the [debugging guide](https://atom.io/docs/latest/hacking-atom-debugging)** for tips — you might discover that the feature is already available. Most importantly, check if you're using [the latest version of Atom](https://atom.io/docs/latest/hacking-atom-debugging#update-to-the-latest-version) and if you can get the desired behavior by changing [Atom's or packages' config settings](https://atom.io/docs/latest/hacking-atom-debugging#check-atom-and-package-settings).
+* **Check if there's already [a package](https://atom.io/packages) which provides that feature.**
+* **Determine [which repository the feature should be suggested in](#atom-and-packages).**
+* **Perform a [cursory search](https://github.com/issues?q=+is%3Aissue+user%3Aatom)** to see if the feature has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+
+#### How Do I Submit A (Good) Feature Suggestion?
+
+Feature suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you've determined [which repository](#atom-and-packages) your feature suggestions is related to, create an issue on that repository and provide the following information:
+
+* **Use a clear and descriptive title** for the issue to identify the suggestion.
+* **Provide a step-by-step description of the suggested feature** in as many details as possible.
+* **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
+* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of Atom which the suggestion is related to. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on OSX and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+* **Explain why this feature would be useful** to most Atom users and isn't something that can or should be implemented as a [community package](#atom-and-packages).
+* **List some other text editors or applications where this feature exists.**
+* **Specify which version of Atom you're using.** You can get the exact version by running `atom -v` in your terminal, or by starting Atom and running the `Application: About` command from the [Command Palette](https://github.com/atom/command-palette).
+* **Specify the name and version of the OS you're using.**
+
+#### Template For Submitting Feature Suggestions
+
+    [Short description of suggestion]
+
+    **Steps which explain the feature**
+
+    1. [First Step]
+    2. [Second Step]
+    3. [Other Steps...]
+
+    **Current and suggested behavior**
+
+    [Describe current and suggested behavior here]
+
+    **Why would the feature be useful to most users**
+
+    [Explain why the feature would be useful to most users]
+
+    [List some other text editors or applications where this feature exists]
+
+    **Screenshots and GIFs**
+
+    ![Screenshots and GIFs which demonstrate the steps or part of Atom the feature suggestion is related to](url)
+
+    **Atom Version:** [Enter Atom version here]
+    **OS and Version:** [Enter OS name and version here]
 
 ### Your First Code Contribution
 


### PR DESCRIPTION
Similar to https://github.com/atom/atom/pull/9333 which added a section on reporting bugs, this adds a section on suggesting features.

@atom/feedback @atom/issue-triage As always, I'd appreciate your feedback. If you can think of anything else that might be helpful here -- please let me know. :koala: 
