### PR TITLE
Use unique text editor title in window and tab titles	

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -168,7 +168,7 @@ describe "TextEditor", ->
         buffer.setPath(undefined)
         expect(editor.getLongTitle()).toBe 'untitled'
 
-      it "returns <parent-directory>/<filename> when opened files has identical file names", ->
+      it "returns '<filename> — <parent-directory>' when opened files have identical file names", ->
         editor1 = null
         editor2 = null
         waitsForPromise ->
@@ -177,10 +177,10 @@ describe "TextEditor", ->
             atom.workspace.open(path.join('sample-theme-2', 'readme')).then (o) ->
               editor2 = o
         runs ->
-          expect(editor1.getLongTitle()).toBe 'sample-theme-1/readme'
-          expect(editor2.getLongTitle()).toBe 'sample-theme-2/readme'
+          expect(editor1.getLongTitle()).toBe "readme \u2014 sample-theme-1"
+          expect(editor2.getLongTitle()).toBe "readme \u2014 sample-theme-2"
 
-      it "or returns <parent-directory>/.../<filename> when opened files has identical file names", ->
+      it "returns '<filename> — <parent-directories>' when opened files have identical file and dir names", ->
         editor1 = null
         editor2 = null
         waitsForPromise ->
@@ -189,9 +189,20 @@ describe "TextEditor", ->
             atom.workspace.open(path.join('sample-theme-2', 'src', 'js', 'main.js')).then (o) ->
               editor2 = o
         runs ->
-          expect(editor1.getLongTitle()).toBe 'sample-theme-1/.../main.js'
-          expect(editor2.getLongTitle()).toBe 'sample-theme-2/.../main.js'
+          expect(editor1.getLongTitle()).toBe "main.js \u2014 sample-theme-1/src/js"
+          expect(editor2.getLongTitle()).toBe "main.js \u2014 sample-theme-2/src/js"
 
+      it "returns '<filename> — <parent-directories>' when opened files have identical file and same parent dir name", ->
+        editor1 = null
+        editor2 = null
+        waitsForPromise ->
+          atom.workspace.open(path.join('sample-theme-2', 'src', 'js', 'main.js')).then (o) ->
+            editor1 = o
+            atom.workspace.open(path.join('sample-theme-2', 'src', 'js', 'plugin', 'main.js')).then (o) ->
+              editor2 = o
+        runs ->
+          expect(editor1.getLongTitle()).toBe "main.js \u2014 js"
+          expect(editor2.getLongTitle()).toBe "main.js \u2014 js/plugin"
 
     it "notifies ::onDidChangeTitle observers when the underlying buffer path changes", ->
       observed = []

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -76,7 +76,7 @@ describe "Workspace", ->
           expect(editor4.getCursorScreenPosition()).toEqual [2, 4]
 
           expect(atom.workspace.getActiveTextEditor().getPath()).toBe editor3.getPath()
-          expect(document.title).toBe "#{path.basename(editor3.getPath())} - #{atom.project.getPaths()[0]} - Atom"
+          expect(document.title).toBe "#{path.basename(editor3.getLongTitle())} - #{atom.project.getPaths()[0]} - Atom"
 
     describe "where there are no open panes or editors", ->
       it "constructs the view with no open editors", ->
@@ -776,8 +776,8 @@ describe "Workspace", ->
           applicationDelegate: atom.applicationDelegate, assert: atom.assert.bind(atom)
         })
         workspace2.deserialize(atom.workspace.serialize(), atom.deserializers)
-        item = atom.workspace.getActivePaneItem()
-        expect(document.title).toBe "#{item.getTitle()} - #{atom.project.getPaths()[0]} - Atom"
+        item = workspace2.getActivePaneItem()
+        expect(document.title).toBe "#{item.getLongTitle()} - #{atom.project.getPaths()[0]} - Atom"
         workspace2.destroy()
 
   describe "document edited status", ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -155,7 +155,7 @@ class Workspace extends Model
     projectPaths = @project.getPaths() ? []
     if item = @getActivePaneItem()
       itemPath = item.getPath?()
-      itemTitle = item.getTitle?()
+      itemTitle = item.getLongTitle?() ? item.getTitle?()
       projectPath = _.find projectPaths, (projectPath) ->
         itemPath is projectPath or itemPath?.startsWith(projectPath + path.sep)
     itemTitle ?= "untitled"


### PR DESCRIPTION
I have two files, `app/services/notes/create_service.rb` and `app/services/issues/create_service.rb`.

Right now it's impossible to find which is which using either the window or tab title:

<img width="851" alt="screen shot 2015-11-16 at 20 16 02" src="https://cloud.githubusercontent.com/assets/159434/11192012/ec039e28-8c9e-11e5-88e3-c9064d4bc078.png">

<img width="844" alt="screen shot 2015-11-16 at 20 16 10" src="https://cloud.githubusercontent.com/assets/159434/11192011/ebfe696c-8c9e-11e5-9da7-abb5c79f27c5.png">

With these changes, it is:

<img width="870" alt="screen shot 2015-11-16 at 20 18 28" src="https://cloud.githubusercontent.com/assets/159434/11192086/449feaa0-8c9f-11e5-8606-958d0bc146a4.png">
<img width="872" alt="screen shot 2015-11-16 at 20 18 36" src="https://cloud.githubusercontent.com/assets/159434/11192085/449c3860-8c9f-11e5-9562-44e944995b82.png">

Both now use `<item>::getLongTitle` which delegates to `TextEditor::getUniqueTitle` in the case of `TextEditor` items.

Besides this, `TextEditor::getUniqueTitle` was modified to match Sublime Text's behavior, where `features/index.html`, `features/main/index.html` and `contact/index.html` will show as `index.html — features`, `index.html — features/main` and `index.html — contact` rather than `features/index.html — features`, `features/.../index.html` and `features/index.html`. With the original implementation, the difference between the first two would still be difficult to spot, and the actual filename could be pushed out of the tab if the directory names were especially long.

PS. I used em-dashes rather than 'normal' dashes since this was developed in conjunction with #9620.
