### PR TITLE
Only remove node_modules on ci if changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,13 @@ install:
 
 script: script/cibuild
 
+cache:
+  directories:
+    - $HOME/.atom/.apm
+    - $HOME/.atom/.node-gyp/.atom
+    - $HOME/.atom/.npm
+    - node_modules
+
 notifications:
   email:
     on_success: never

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -284,6 +284,7 @@ module.exports = (grunt) ->
   ciTasks.push('download-electron')
   ciTasks.push('download-electron-chromedriver')
   ciTasks.push('build')
+  ciTasks.push('fingerprint')
   ciTasks.push('dump-symbols') if process.platform isnt 'win32'
   ciTasks.push('set-version', 'check-licenses', 'lint', 'generate-asar')
   ciTasks.push('mkdeb') if process.platform is 'linux'

--- a/build/tasks/fingerprint-task.js
+++ b/build/tasks/fingerprint-task.js
@@ -1,0 +1,7 @@
+var fingerprint = require('../../script/utils/fingerprint')
+
+module.exports = function (grunt) {
+  grunt.registerTask('fingerprint', 'Fingerpint the node_modules folder for caching on CI', function () {
+    fingerprint.writeFingerprint()
+  })
+}

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 var cp = require('./utils/child-process-wrapper.js');
+var crypto = require('crypto')
 var fs = require('fs');
 var path = require('path');
 
 process.chdir(path.dirname(__dirname));
 
 var homeDir = process.platform == 'win32' ? process.env.USERPROFILE : process.env.HOME;
+var fingerprintPath = path.resolve(__dirname, '..', '.atom-ci-fingerprint')
 
 function loadEnvironmentVariables(filePath) {
   try {
@@ -42,6 +44,12 @@ function setEnvironmentVariables() {
 }
 
 function removeNodeModules() {
+  var fingerprint = generateModuleFingerprint()
+  if (fs.existsSync(fingerprintPath) && fs.readFileSync(fingerprintPath).toString() === fingerprint) {
+    console.log('node_modules matches current fingerprint ' + fingerprint + ' - not removing')
+    return
+  }
+
   var fsPlus;
   try {
     fsPlus = require('fs-plus');
@@ -55,6 +63,17 @@ function removeNodeModules() {
     console.error(error.message);
     process.exit(1);
   }
+}
+
+function generateModuleFingerprint () {
+  var packageJson = fs.readFileSync(path.resolve(__dirname, '..', 'package.json'))
+  var body = packageJson.toString() + process.platform
+  return crypto.createHash('sha1').update(body).digest('hex')
+}
+
+function fingerprintNodeModules (callback) {
+  fs.writeFileSync(fingerprintPath, generateModuleFingerprint())
+  callback(null, fingerprintPath)
 }
 
 function removeTempFolders() {
@@ -98,7 +117,7 @@ cp.safeExec.bind(global, 'npm install npm --loglevel error', {cwd: path.resolve(
     var async = require('async');
     var gruntPath = path.join('build', 'node_modules', '.bin', 'grunt') + (process.platform === 'win32' ? '.cmd' : '');
     var tasks = [
-      cp.safeExec.bind(global, 'git clean -dff'),
+      cp.safeExec.bind(global, 'git clean -dff -e node_modules -e .atom-ci-fingerprint'), // If we left them behind in removeNodeModules() they are OK to use
       cp.safeExec.bind(global, gruntPath + ' ci --gruntfile build/Gruntfile.coffee --stack --no-color'),
     ]
     async.series(tasks, function(error) {

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 var cp = require('./utils/child-process-wrapper.js');
 var crypto = require('crypto')
+var fingerprint = require('./utils/fingerprint')
 var fs = require('fs');
 var path = require('path');
 
 process.chdir(path.dirname(__dirname));
 
 var homeDir = process.platform == 'win32' ? process.env.USERPROFILE : process.env.HOME;
-var fingerprintPath = path.resolve(__dirname, '..', '.atom-ci-fingerprint')
 
 function loadEnvironmentVariables(filePath) {
   try {
@@ -44,9 +44,8 @@ function setEnvironmentVariables() {
 }
 
 function removeNodeModules() {
-  var fingerprint = generateModuleFingerprint()
-  if (fs.existsSync(fingerprintPath) && fs.readFileSync(fingerprintPath).toString() === fingerprint) {
-    console.log('node_modules matches current fingerprint ' + fingerprint + ' - not removing')
+  if (fingerprint.fingerprintMatches()) {
+    console.log('node_modules matches current fingerprint ' + fingerprint.fingerprint() + ' - not removing')
     return
   }
 
@@ -63,17 +62,6 @@ function removeNodeModules() {
     console.error(error.message);
     process.exit(1);
   }
-}
-
-function generateModuleFingerprint () {
-  var packageJson = fs.readFileSync(path.resolve(__dirname, '..', 'package.json'))
-  var body = packageJson.toString() + process.platform
-  return crypto.createHash('sha1').update(body).digest('hex')
-}
-
-function fingerprintNodeModules (callback) {
-  fs.writeFileSync(fingerprintPath, generateModuleFingerprint())
-  callback(null, fingerprintPath)
 }
 
 function removeTempFolders() {
@@ -117,8 +105,8 @@ cp.safeExec.bind(global, 'npm install npm --loglevel error', {cwd: path.resolve(
     var async = require('async');
     var gruntPath = path.join('build', 'node_modules', '.bin', 'grunt') + (process.platform === 'win32' ? '.cmd' : '');
     var tasks = [
-      cp.safeExec.bind(global, 'git clean -dff -e node_modules -e .atom-ci-fingerprint'), // If we left them behind in removeNodeModules() they are OK to use
-      cp.safeExec.bind(global, gruntPath + ' ci --gruntfile build/Gruntfile.coffee --stack --no-color'),
+      cp.safeExec.bind(global, 'git clean -dff -e node_modules'), // If we left them behind in removeNodeModules() they are OK to use
+      cp.safeExec.bind(global, gruntPath + ' ci --gruntfile build/Gruntfile.coffee --stack --no-color')
     ]
     async.series(tasks, function(error) {
       process.exit(error ? 1 : 0);

--- a/script/utils/fingerprint.js
+++ b/script/utils/fingerprint.js
@@ -7,7 +7,7 @@ var fingerprintPath = path.resolve(__dirname, '..', '..', 'node_modules', '.atom
 module.exports = {
   fingerprint: function () {
     var packageJson = fs.readFileSync(path.resolve(__dirname, '..', '..', 'package.json'))
-    var body = packageJson.toString() + process.platform
+    var body = packageJson.toString() + process.platform + process.version
     return crypto.createHash('sha1').update(body).digest('hex')
   },
 

--- a/script/utils/fingerprint.js
+++ b/script/utils/fingerprint.js
@@ -15,7 +15,7 @@ module.exports = {
     var fingerprint = this.fingerprint()
     fs.writeFileSync(fingerprintPath, fingerprint)
     console.log('Wrote ci fingerprint:', fingerprintPath, fingerprint)
-  }
+  },
 
   readFingerprint: function() {
     if (fs.existsSync(fingerprintPath)) {
@@ -23,7 +23,7 @@ module.exports = {
     } else {
       return null
     }
-  }
+  },
 
   fingerprintMatches: function () {
     return this.readFingerprint() && this.readFingerprint() === this.fingerprint()

--- a/script/utils/fingerprint.js
+++ b/script/utils/fingerprint.js
@@ -1,0 +1,31 @@
+var crypto = require('crypto')
+var fs = require('fs')
+var path = require('path')
+
+var fingerprintPath = path.resolve(__dirname, '..', '..', 'node_modules', '.atom-ci-fingerprint')
+
+module.exports = {
+  fingerprint: function () {
+    var packageJson = fs.readFileSync(path.resolve(__dirname, '..', '..', 'package.json'))
+    var body = packageJson.toString() + process.platform
+    return crypto.createHash('sha1').update(body).digest('hex')
+  },
+
+  writeFingerprint: function () {
+    var fingerprint = this.fingerprint()
+    fs.writeFileSync(fingerprintPath, fingerprint)
+    console.log('Wrote ci fingerprint:', fingerprintPath, fingerprint)
+  }
+
+  readFingerprint: function() {
+    if (fs.existsSync(fingerprintPath)) {
+      return fs.readFileSync(fingerprintPath).toString()
+    } else {
+      return null
+    }
+  }
+
+  fingerprintMatches: function () {
+    return this.readFingerprint() && this.readFingerprint() === this.fingerprint()
+  }
+}


### PR DESCRIPTION
_This is just a spike, the hash probably needs more stuff in it (node version, etc), just curious how it will interact with Travis_

Just opening this PR to kick off a couple Travis builds as it's the simplest way to test this change. Basically, are now using their container infrastructure which allows caching, but `script/cibuild` manually removes `node_modules` before running anyway. This just writes a sha into node_modules based on package.json and process.platform that prevents us from wiping it out of the build succeeds & the deps didn't change.
