### PR TITLE
Load packages before deserializing workspace

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -612,7 +612,7 @@ class AtomEnvironment extends Model
     @registerDefaultTargetForKeymaps()
 
     @packages.loadPackages()
-
+    @loadStateSync()
     @document.body.appendChild(@views.getView(@workspace))
 
     @watchProjectPath()

--- a/src/initialize-application-window.coffee
+++ b/src/initialize-application-window.coffee
@@ -24,7 +24,6 @@ window.atom = new AtomEnvironment({
 })
 
 atom.displayWindow()
-atom.loadStateSync()
 atom.startEditorWindow()
 
 # Workaround for focus getting cleared upon window creation


### PR DESCRIPTION
Fixes #9600

This ensures that package-defined deserializers work. Tried to test it, but our global environment is still a pretty tangled mess and the tests ended up feeling like they had negative value. We really need to refactor at this layer.
