### PR TITLE
Fix removeListener calls

### DIFF
--- a/spec/atom-environment-spec.coffee
+++ b/spec/atom-environment-spec.coffee
@@ -249,6 +249,20 @@ describe "AtomEnvironment", ->
 
         expect(buffer.getSubscriptionCount()).toBe 0
 
+    it "does not throw exceptions when unsubscribing from ipc events (regression)", ->
+      configDirPath = temp.mkdirSync()
+      fakeDocument = {
+        addEventListener: ->
+        removeEventListener: ->
+        head: document.createElement('head')
+        body: document.createElement('body')
+      }
+      atomEnvironment = new AtomEnvironment({applicationDelegate: atom.applicationDelegate, window, document: fakeDocument})
+      spyOn(atomEnvironment.packages, 'getAvailablePackagePaths').andReturn []
+      atomEnvironment.startEditorWindow()
+      atomEnvironment.unloadEditorWindow()
+      atomEnvironment.destroy()
+
   describe "::openLocations(locations) (called via IPC from browser process)", ->
     beforeEach ->
       spyOn(atom.workspace, 'open')

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -138,7 +138,7 @@ class ApplicationDelegate
 
     ipc.on('message', outerCallback)
     new Disposable ->
-      ipc.removeEventListener('message', outerCallback)
+      ipc.removeListener('message', outerCallback)
 
   onUpdateAvailable: (callback) ->
     outerCallback = (message, detail) ->
@@ -147,17 +147,17 @@ class ApplicationDelegate
 
     ipc.on('message', outerCallback)
     new Disposable ->
-      ipc.removeEventListener('message', outerCallback)
+      ipc.removeListener('message', outerCallback)
 
   onApplicationMenuCommand: (callback) ->
     ipc.on('command', callback)
     new Disposable ->
-      ipc.removeEventListener('command', callback)
+      ipc.removeListener('command', callback)
 
   onContextMenuCommand: (callback) ->
     ipc.on('context-command', callback)
     new Disposable ->
-      ipc.removeEventListener('context-command', callback)
+      ipc.removeListener('context-command', callback)
 
   didCancelWindowUnload: ->
     ipc.send('did-cancel-window-unload')


### PR DESCRIPTION
These are throwing exceptions when we destroy the global environment. We're getting away with it because we've already serialized state, but it's still not good.
