### PR TITLE
Suggest [ci skip] in documentation-only commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,7 @@ Both issue lists are sorted by total number of comments. While not perfect, numb
 * Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
 * Limit the first line to 72 characters or less
 * Reference issues and pull requests liberally
+* When only changing documentation, include `[ci skip]` in the commit description
 * Consider starting the commit message with an applicable emoji:
     * :art: `:art:` when improving the format/structure of the code
     * :racehorse: `:racehorse:` when improving performance


### PR DESCRIPTION
Helps get builds that actually change code started faster.  For example, I'm waiting on Travis to run my Electron PR, and right now it's waiting on 3 documentation-only PRs before it.

If this gets merged I'll also propose the same to atom/electron, since that seems to attract more documentation PRs :).
