### PR TITLE
Fix updating

### DIFF
--- a/resources/mac/atom-Info.plist
+++ b/resources/mac/atom-Info.plist
@@ -38,6 +38,17 @@
 	<string>speakeasy.pem</string>
 	<key>SUScheduledCheckInterval</key>
 	<string>3600</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>github-cloud.s3.amazonaws.com</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/resources/mac/helper-Info.plist
+++ b/resources/mac/helper-Info.plist
@@ -28,5 +28,16 @@
 	<string>1</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>github-cloud.s3.amazonaws.com</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Give github-cloud.s3.amazonaws.com a pass. Fixes #9658.

We’ll use an exception for now until we can get an updated certificate in place.

After this lands I’ll cherry-pick it to `beta`.
