### PR TITLE
[WIP] Skip CI build entirely when code did not change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ debug.log
 docs/output
 docs/includes
 spec/fixtures/evil-files/
+
+.ci-cache-previous.txt
+.ci-cache-this.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - nvm install $NODE_VERSION
   - nvm use $NODE_VERSION
 
-script: script/cibuild
+script: script/cibuild-when-code-changed
 
 notifications:
   email:

--- a/script/cibuild-when-code-changed
+++ b/script/cibuild-when-code-changed
@@ -2,9 +2,11 @@
 
 COFFEE=./node_modules/.bin/coffee
 UGLIFY=./node_modules/.bin/uglifyjs
+BABEL=./node_modules/.bin/babel
 
 # Was unsure where to place these since putting them in build/ is too late.
 npm install coffee-script@1.8.0
+npm install babel-cli@6.2.0
 npm install uglify-js@2.6.1
 
 # Find the two commits to compare against: [START ... END]
@@ -41,7 +43,16 @@ echo "DID_CODE_CHANGE: END_COMMIT=${END_COMMIT}"
 # No need to check out since the END_COMMIT is already checked out
 # git checkout -q ${END_COMMIT}
 
-cat $(find ./src -name "*.coffee") | ${COFFEE} --compile --stdio | ${UGLIFY} --beautify > .ci-cache-this.txt
+# Files that go into the blob:
+#
+# 1. Compile & Minify CoffeeScript files
+# 2. Transpile JavaScript files
+# 3. Concat JSON/CSON files
+# 4. Concat spec tests and fixtures
+cat $(find ./ -name "*.coffee" | grep -v "spec") | ${COFFEE} --compile --stdio | ${UGLIFY} --beautify > .ci-cache-this.txt
+find ./src -name "*.js" | xargs ${BABEL} >> .ci-cache-this.txt
+cat $(find ./ -name "*.?son" | grep -v "node_modules") >> .ci-cache-this.txt
+cat $(find ./spec -type f) >> .ci-cache-this.txt
 
 
 echo "DID_CODE_CHANGE: Building slug for the previous commit (to compare against)"
@@ -50,7 +61,10 @@ echo "DID_CODE_CHANGE: START_COMMIT=${START_COMMIT}"
 # Check out the version *just before* the testing range
 git checkout -q ${START_COMMIT}
 
-cat $(find ./src -name "*.coffee") | ${COFFEE} --compile --stdio | ${UGLIFY} --beautify > .ci-cache-previous.txt
+cat $(find ./ -name "*.coffee" | grep -v "spec") | ${COFFEE} --compile --stdio | ${UGLIFY} --beautify > .ci-cache-previous.txt
+find ./src -name "*.js" | xargs ${BABEL} >> .ci-cache-previous.txt
+cat $(find ./ -name "*.?son" | grep -v "node_modules") >> .ci-cache-previous.txt
+cat $(find ./spec -type f) >> .ci-cache-previous.txt
 
 
 echo "DID_CODE_CHANGE: Comparing slugs"

--- a/script/cibuild-when-code-changed
+++ b/script/cibuild-when-code-changed
@@ -1,0 +1,43 @@
+COFFEE=./node_modules/.bin/coffee
+UGLIFY=./node_modules/.bin/uglifyjs
+
+# Was unsure where to place these since putting them in build/ is too late.
+npm install coffee-script@1.8.0
+npm install uglify-js@2.6.1
+
+# Find the two commits to compare against: [START-1 ... END]
+if [ -z ${TRAVIS_COMMIT} ]
+then
+  START_COMMIT=$(git rev-parse HEAD)
+  END_COMMIT=$(git rev-parse HEAD)
+
+# If this is the first commit on a branch then TRAVIS_COMMIT_RANGE is empty
+# so just use the current commit
+elif [ -z ${TRAVIS_COMMIT_RANGE} ]
+then
+  START_COMMIT=${TRAVIS_COMMIT}
+  END_COMMIT=${TRAVIS_COMMIT}
+else
+  START_COMMIT=$(echo ${TRAVIS_COMMIT_RANGE} | sed 's/\([a-z0-9]*\).*/\1/')
+  END_COMMIT=${TRAVIS_COMMIT}
+fi
+
+# Check out the version *just before* the testing range
+git checkout $(git rev-parse ${START_COMMIT}^1)
+
+cat $(find ./src -name "*.coffee") | ${COFFEE} --compile --stdio | ${UGLIFY} --beautify > .ci-cache-previous.txt
+
+
+git checkout ${END_COMMIT}
+
+cat $(find ./src -name "*.coffee") | ${COFFEE} --compile --stdio | ${UGLIFY} --beautify > .ci-cache-this.txt
+
+diff ./.ci-cache-previous.txt ./.ci-cache-this.txt > /dev/null
+
+if [ $? -eq 0 ]
+then
+  echo "Just a documentation change. No need to run tests"
+else
+  echo "Code changed. Running tests"
+  script/cibuild
+fi

--- a/script/cibuild-when-code-changed
+++ b/script/cibuild-when-code-changed
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 COFFEE=./node_modules/.bin/coffee
 UGLIFY=./node_modules/.bin/uglifyjs
 
@@ -5,39 +7,59 @@ UGLIFY=./node_modules/.bin/uglifyjs
 npm install coffee-script@1.8.0
 npm install uglify-js@2.6.1
 
-# Find the two commits to compare against: [START-1 ... END]
-if [ -z ${TRAVIS_COMMIT} ]
-then
-  START_COMMIT=$(git rev-parse HEAD)
-  END_COMMIT=$(git rev-parse HEAD)
+# Find the two commits to compare against: [START ... END]
+END_COMMIT=$(git rev-parse HEAD)
 
-# If this is the first commit on a branch then TRAVIS_COMMIT_RANGE is empty
-# so just use the current commit
-elif [ -z ${TRAVIS_COMMIT_RANGE} ]
+# Find the commit to start from
+if [ "${TRAVIS_PULL_REQUEST}" != "false" ]
 then
-  START_COMMIT=${TRAVIS_COMMIT}
-  END_COMMIT=${TRAVIS_COMMIT}
+  # Testing a whole Pull Request.
+  # This means the current commit is a new one with the branch merged into the PR destination.
+  # What Travis did:
+  # 1. `git fetch origin +refs/pull/[PR_NUMBER]/merge:`
+  # 2. `git checkout -qf FETCH_HEAD`
+  echo "DID_CODE_CHANGE: CASE 1: This is the continuous-integration/travis-ci/pr case"
+  START_COMMIT=$(git rev-parse HEAD^1)
+
+elif [ -n "${TRAVIS_COMMIT_RANGE}" ]
+then
+  # Multiple commits occurred between the last Travis test
+  echo "DID_CODE_CHANGE: CASE 2: This is a continuous-integration/travis-ci/push case"
+  # What Travis did: `git checkout -qf [SHA]`
+  START_COMMIT=$(echo ${TRAVIS_COMMIT_RANGE} | sed 's/\([a-z0-9\^]*\).*/\1/')
+
 else
-  START_COMMIT=$(echo ${TRAVIS_COMMIT_RANGE} | sed 's/\([a-z0-9]*\).*/\1/')
-  END_COMMIT=${TRAVIS_COMMIT}
+  # No commit range specified. This is 1 commit on a new branch
+  # What Travis did: `git checkout -qf [SHA]`
+  echo "DID_CODE_CHANGE: CASE 3: This is the other continuous-integration/travis-ci/push case"
+  START_COMMIT=$(git rev-parse HEAD^1)
 fi
 
+echo "DID_CODE_CHANGE: Building slug for this commit"
+echo "DID_CODE_CHANGE: END_COMMIT=${END_COMMIT}"
+
+# No need to check out since the END_COMMIT is already checked out
+# git checkout -q ${END_COMMIT}
+
+cat $(find ./src -name "*.coffee") | ${COFFEE} --compile --stdio | ${UGLIFY} --beautify > .ci-cache-this.txt
+
+
+echo "DID_CODE_CHANGE: Building slug for the previous commit (to compare against)"
+echo "DID_CODE_CHANGE: START_COMMIT=${START_COMMIT}"
+
 # Check out the version *just before* the testing range
-git checkout $(git rev-parse ${START_COMMIT}^1)
+git checkout -q ${START_COMMIT}
 
 cat $(find ./src -name "*.coffee") | ${COFFEE} --compile --stdio | ${UGLIFY} --beautify > .ci-cache-previous.txt
 
 
-git checkout ${END_COMMIT}
-
-cat $(find ./src -name "*.coffee") | ${COFFEE} --compile --stdio | ${UGLIFY} --beautify > .ci-cache-this.txt
-
+echo "DID_CODE_CHANGE: Comparing slugs"
 diff ./.ci-cache-previous.txt ./.ci-cache-this.txt > /dev/null
 
 if [ $? -eq 0 ]
 then
-  echo "Just a documentation change. No need to run tests"
+  echo "DID_CODE_CHANGE: Just a documentation change. No need to run tests"
 else
-  echo "Code changed. Running tests"
+  echo "DID_CODE_CHANGE: Yes, code changed. Running tests"
   script/cibuild
 fi


### PR DESCRIPTION
This checks if the code changed by building a glob of all the minified code (& JSON files) in this repo and compares it to a generated glob of the previous commit.

Comments, local variable renames, and lint fixes should not start an entire build. But changing package versions should.

Hopefully Travis won't :sweat: over this PR too much :smile: 

**Side note:** I was not sure where to install `uglify` since it seems `build/package.json` is too late.

You can test it out locally:
1. check out this branch
2. make a code change or add a comment and commit
3. run `script/cibuild-when-code-changed`
4. See if it says "Just a documentation change. No need to run tests!"

If this approach seems promising I can get the rest of the "kinks" out:
- [ ] switch to using `node` instead of shell scripts
- [x] include JSON/CSON/scripts/spec tests in the glob
- [x] build babel files
- [ ] generate a checksum instead of using `diff`
# Console Output

```
$ script/cibuild-when-code-changed
DID_CODE_CHANGE: CASE 1: This is the continuous-integration/travis-ci/pr case
DID_CODE_CHANGE: Building slug for this commit
DID_CODE_CHANGE: END_COMMIT=c1002e587ead0c237feb75963c0427c765c3a1e7
DID_CODE_CHANGE: Building slug for the previous commit (to compare against)
DID_CODE_CHANGE: START_COMMIT=cad74060855aa37c5de528d6f03761ac74170103
DID_CODE_CHANGE: Comparing slugs
DID_CODE_CHANGE: Just a documentation change. No need to run tests
The command "script/cibuild-when-code-changed" exited with 0.
```
