### PR TITLE
Compute content width when the longest row is the first one

### DIFF
--- a/spec/fake-lines-yardstick.coffee
+++ b/spec/fake-lines-yardstick.coffee
@@ -7,6 +7,7 @@ class FakeLinesYardstick
 
   prepareScreenRowsForMeasurement: ->
     @presenter.getPreMeasurementState()
+    @screenRows = new Set(@presenter.getScreenRows())
 
   getScopedCharacterWidth: (scopeNames, char) ->
     @getScopedCharacterWidths(scopeNames)[char]
@@ -33,6 +34,8 @@ class FakeLinesYardstick
     top = targetRow * @model.getLineHeightInPixels()
     left = 0
     column = 0
+
+    return {top, left: 0} unless @screenRows.has(screenPosition.row)
 
     iterator = @model.tokenizedLineForScreenRow(targetRow).getTokenIterator()
     while iterator.next()

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -694,6 +694,20 @@ describe "TextEditorPresenter", ->
           presenter = buildPresenter(explicitHeight: 100, contentFrameWidth: 10 * maxLineLength + 20, baseCharacterWidth: 10, verticalScrollbarWidth: 10)
           expect(presenter.getState().content.scrollWidth).toBe 10 * maxLineLength + 20 - 10 # subtract vertical scrollbar width
 
+        describe "when the longest screen row is the first one and it's hidden", ->
+          it "doesn't compute an invalid value (regression)", ->
+            presenter = buildPresenter(tileSize: 2, contentFrameWidth: 10, explicitHeight: 20)
+            editor.setText """
+            a very long long long long long long line
+            b
+            c
+            d
+            e
+            """
+
+            expectStateUpdate presenter, -> presenter.setScrollTop(40)
+            expect(presenter.getState().content.scrollWidth).toBe 10 * editor.getMaxScreenLineLength() + 1
+
         it "updates when the ::contentFrameWidth changes", ->
           maxLineLength = editor.getMaxScreenLineLength()
           presenter = buildPresenter(contentFrameWidth: 50, baseCharacterWidth: 10)

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -377,7 +377,8 @@ class TextEditorPresenter
     endRow = @constrainRow(@getEndTileRow() + @tileSize)
 
     screenRows = [startRow...endRow]
-    if longestScreenRow = @model.getLongestScreenRow()
+    longestScreenRow = @model.getLongestScreenRow()
+    if longestScreenRow?
       screenRows.push(longestScreenRow)
     if @screenRowsToMeasure?
       screenRows.push(@screenRowsToMeasure...)


### PR DESCRIPTION
Fixes #9649

There was a subtle problem with an `if` statement that went overlooked when implementing the new measurement strategy which caused the first screen row to be ignored when computing content width if that row was both hidden and the longest one.

This PR fixes it and adds a spec to prevent this from happening in the future.

/cc: @abe33 @nathansobo 
