### PR TITLE
Export ::isTextEditor function

### DIFF
--- a/exports/atom.coffee
+++ b/exports/atom.coffee
@@ -35,7 +35,6 @@ unless process.env.ATOM_SHELL_INTERNAL_RUN_AS_NODE
         The `TextEditor` constructor is no longer public.
 
         To construct a text editor, use `atom.workspace.buildTextEditor()`.
-        To check if an object is a text editor, look for for the existence of
-        a public method that you're using (e.g. `::getText`).
+        To check if an object is a text editor, use `atom.workspace.isTextEditor(object)`.
       """
       TextEditor

--- a/exports/atom.coffee
+++ b/exports/atom.coffee
@@ -23,15 +23,10 @@ module.exports =
 unless process.env.ATOM_SHELL_INTERNAL_RUN_AS_NODE
   module.exports.Task = require '../src/task'
 
-  InternalTextEditor = require('../src/text-editor')
-
-  module.exports.isTextEditor = (object) ->
-    object instanceof InternalTextEditor
-
   TextEditor = (params) ->
     atom.workspace.buildTextEditor(params)
 
-  TextEditor.prototype = InternalTextEditor.prototype
+  TextEditor.prototype = require('../src/text-editor').prototype
 
   Object.defineProperty module.exports, 'TextEditor',
     enumerable: true
@@ -40,7 +35,7 @@ unless process.env.ATOM_SHELL_INTERNAL_RUN_AS_NODE
         The `TextEditor` constructor is no longer public.
 
         To construct a text editor, use `atom.workspace.buildTextEditor()`.
-        To check if an object is a text editor, use the `isTextEditor`
-        function in the `atom` exports. (e.g. `{isTextEditor} = require('atom'))`
+        To check if an object is a text editor, look for for the existence of
+        a public method that you're using (e.g. `::getText`).
       """
       TextEditor

--- a/exports/atom.coffee
+++ b/exports/atom.coffee
@@ -23,10 +23,15 @@ module.exports =
 unless process.env.ATOM_SHELL_INTERNAL_RUN_AS_NODE
   module.exports.Task = require '../src/task'
 
+  InternalTextEditor = require('../src/text-editor')
+
+  module.exports.isTextEditor = (object) ->
+    object instanceof InternalTextEditor
+
   TextEditor = (params) ->
     atom.workspace.buildTextEditor(params)
 
-  TextEditor.prototype = require('../src/text-editor').prototype
+  TextEditor.prototype = InternalTextEditor.prototype
 
   Object.defineProperty module.exports, 'TextEditor',
     enumerable: true

--- a/exports/atom.coffee
+++ b/exports/atom.coffee
@@ -40,7 +40,7 @@ unless process.env.ATOM_SHELL_INTERNAL_RUN_AS_NODE
         The `TextEditor` constructor is no longer public.
 
         To construct a text editor, use `atom.workspace.buildTextEditor()`.
-        To check if an object is a text editor, look for for the existence of
-        a public method that you're using (e.g. `::getText`).
+        To check if an object is a text editor, use the `isTextEditor`
+        function in the `atom` exports. (e.g. `{isTextEditor} = require('atom'))`
       """
       TextEditor

--- a/spec/atom-exports-spec.coffee
+++ b/spec/atom-exports-spec.coffee
@@ -1,0 +1,7 @@
+{isTextEditor} = require 'atom'
+
+describe "atom exports", ->
+  describe "::isTextEditor(obj)", ->
+    it "returns true when the passed object is an instance of `TextEditor`", ->
+      expect(isTextEditor(atom.workspace.buildTextEditor())).toBe(true)
+      expect(isTextEditor({getText: ->})).toBe(false)

--- a/spec/atom-exports-spec.coffee
+++ b/spec/atom-exports-spec.coffee
@@ -5,3 +5,5 @@ describe "atom exports", ->
     it "returns true when the passed object is an instance of `TextEditor`", ->
       expect(isTextEditor(atom.workspace.buildTextEditor())).toBe(true)
       expect(isTextEditor({getText: ->})).toBe(false)
+      expect(isTextEditor(null)).toBe(false)
+      expect(isTextEditor(undefined)).toBe(false)

--- a/spec/atom-exports-spec.coffee
+++ b/spec/atom-exports-spec.coffee
@@ -1,9 +1,0 @@
-{isTextEditor} = require 'atom'
-
-describe "atom exports", ->
-  describe "::isTextEditor(obj)", ->
-    it "returns true when the passed object is an instance of `TextEditor`", ->
-      expect(isTextEditor(atom.workspace.buildTextEditor())).toBe(true)
-      expect(isTextEditor({getText: ->})).toBe(false)
-      expect(isTextEditor(null)).toBe(false)
-      expect(isTextEditor(undefined)).toBe(false)

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -658,6 +658,13 @@ describe "Workspace", ->
       waitsForPromise -> workspace.openLicense()
       runs -> expect(workspace.getActivePaneItem().getText()).toMatch /Copyright/
 
+  describe "::isTextEditor(obj)", ->
+    it "returns true when the passed object is an instance of `TextEditor`", ->
+      expect(workspace.isTextEditor(atom.workspace.buildTextEditor())).toBe(true)
+      expect(workspace.isTextEditor({getText: ->})).toBe(false)
+      expect(workspace.isTextEditor(null)).toBe(false)
+      expect(workspace.isTextEditor(undefined)).toBe(false)
+
   describe "::observeTextEditors()", ->
     it "invokes the observer with current and future text editors", ->
       observed = []

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -518,6 +518,12 @@ class Workspace extends Model
     @project.bufferForPath(filePath, options).then (buffer) =>
       @buildTextEditor(_.extend({buffer, largeFileMode}, options))
 
+  # Public: Returns a {Boolean} that is `true` if `object` is a `TextEditor`.
+  #
+  # * `object` An {Object} you want to perform the check against.
+  isTextEditor: (object) ->
+    object instanceof TextEditor
+
   # Extended: Create a new text editor.
   #
   # Returns a {TextEditor}.


### PR DESCRIPTION
To understand if an object was a `TextEditor`, we previously suggested users to check for the existence of some of its methods. It turns out that this approach could lead to issues like https://github.com/atom/autocomplete-plus/issues/614, caused by checking for the wrong methods.

The alternative approach herein proposed tries to solve this problem by exporting an `::isTextEditor` function in `exports/atom.coffee`. This allows us to not export the internal `TextEditor` constructor while still letting user to understand whether a given object is a `TextEditor` or not.

I am going to open a PR that makes use of this new function in `autocomplete-plus`, where the problem first appeared, and search for other spots where we could use it.

/cc: @nathansobo @maxbrunsfeld  
