### PR TITLE
Fix Long tab lengths fail, and default back to 4 Issue #9147 

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -163,7 +163,8 @@ module.exports =
       tabLength:
         type: 'integer'
         default: 2
-        enum: [1, 2, 3, 4, 6, 8]
+        minimum: 1
+        maximum: 100
         description: 'Number of spaces used to represent a tab.'
       softWrap:
         type: 'boolean'


### PR DESCRIPTION
Implement fix for issue #9147. Valid tab lengths are any number between 1 and 100.

![tablength](https://cloud.githubusercontent.com/assets/5561632/11309131/e5904ab6-8f76-11e5-8fc9-7ca744aa7a98.png)
