### PR TITLE
Interact with DevTools asynchronously

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "line-ending-selector": "0.3.0",
     "link": "0.31.0",
     "markdown-preview": "0.156.2",
-    "metrics": "0.53.0",
+    "metrics": "0.53.1",
     "notifications": "0.62.1",
     "open-on-github": "0.40.0",
     "package-generator": "0.41.0",

--- a/spec/atom-environment-spec.coffee
+++ b/spec/atom-environment-spec.coffee
@@ -45,9 +45,11 @@ describe "AtomEnvironment", ->
       expect(atom.config.get('editor.showInvisibles')).toBe false
 
   describe "window onerror handler", ->
+    devToolsPromise = null
     beforeEach ->
-      spyOn atom, 'openDevTools'
-      spyOn atom, 'executeJavaScriptInDevTools'
+      devToolsPromise = Promise.resolve()
+      spyOn(atom, 'openDevTools').andReturn(devToolsPromise)
+      spyOn(atom, 'executeJavaScriptInDevTools')
 
     it "will open the dev tools when an error is triggered", ->
       try
@@ -55,8 +57,10 @@ describe "AtomEnvironment", ->
       catch e
         window.onerror.call(window, e.toString(), 'abc', 2, 3, e)
 
-      expect(atom.openDevTools).toHaveBeenCalled()
-      expect(atom.executeJavaScriptInDevTools).toHaveBeenCalled()
+      waitsForPromise -> devToolsPromise
+      runs ->
+        expect(atom.openDevTools).toHaveBeenCalled()
+        expect(atom.executeJavaScriptInDevTools).toHaveBeenCalled()
 
     describe "::onWillThrowError", ->
       willThrowSpy = null

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -73,19 +73,8 @@ class ApplicationDelegate
         remote.getCurrentWindow().once("devtools-opened", -> resolve())
         ipc.send("call-window-method", "openDevTools")
 
-  closeWindowDevTools: ->
-    unless remote.getCurrentWindow().isDevToolsOpened()
-      Promise.resolve()
-    else
-      new Promise (resolve) ->
-        remote.getCurrentWindow().once("devtools-closed", -> resolve())
-        ipc.send("call-window-method", "closeDevTools")
-
   toggleWindowDevTools: ->
-    if remote.getCurrentWindow().isDevToolsOpened()
-      @closeWindowDevTools()
-    else
-      @openWindowDevTools()
+    ipc.send("call-window-method", "toggleDevTools")
 
   executeJavaScriptInWindowDevTools: (code) ->
     ipc.send("call-window-method", "executeJavaScriptInDevTools", code)

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -67,6 +67,9 @@ class ApplicationDelegate
 
   openWindowDevTools: ->
     new Promise (resolve) ->
+      # Defer DevTools interaction to the next tick, because using them during
+      # event handling causes some wrong input events to be triggered on
+      # `TextEditorComponent` (Ref.: https://github.com/atom/atom/issues/9697).
       process.nextTick ->
         if remote.getCurrentWindow().isDevToolsOpened()
           resolve()
@@ -76,6 +79,9 @@ class ApplicationDelegate
 
   closeWindowDevTools: ->
     new Promise (resolve) ->
+      # Defer DevTools interaction to the next tick, because using them during
+      # event handling causes some wrong input events to be triggered on
+      # `TextEditorComponent` (Ref.: https://github.com/atom/atom/issues/9697).
       process.nextTick ->
         unless remote.getCurrentWindow().isDevToolsOpened()
           resolve()
@@ -85,6 +91,9 @@ class ApplicationDelegate
 
   toggleWindowDevTools: ->
     new Promise (resolve) =>
+      # Defer DevTools interaction to the next tick, because using them during
+      # event handling causes some wrong input events to be triggered on
+      # `TextEditorComponent` (Ref.: https://github.com/atom/atom/issues/9697).
       process.nextTick =>
         if remote.getCurrentWindow().isDevToolsOpened()
           @closeWindowDevTools().then(resolve)

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -66,10 +66,26 @@ class ApplicationDelegate
     ipc.send("call-window-method", "setFullScreen", fullScreen)
 
   openWindowDevTools: ->
-    ipc.send("call-window-method", "openDevTools")
+    if remote.getCurrentWindow().isDevToolsOpened()
+      Promise.resolve()
+    else
+      new Promise (resolve) ->
+        remote.getCurrentWindow().once("devtools-opened", -> resolve())
+        ipc.send("call-window-method", "openDevTools")
+
+  closeWindowDevTools: ->
+    unless remote.getCurrentWindow().isDevToolsOpened()
+      Promise.resolve()
+    else
+      new Promise (resolve) ->
+        remote.getCurrentWindow().once("devtools-closed", -> resolve())
+        ipc.send("call-window-method", "closeDevTools")
 
   toggleWindowDevTools: ->
-    ipc.send("call-window-method", "toggleDevTools")
+    if remote.getCurrentWindow().isDevToolsOpened()
+      @closeWindowDevTools()
+    else
+      @openWindowDevTools()
 
   executeJavaScriptInWindowDevTools: (code) ->
     ipc.send("call-window-method", "executeJavaScriptInDevTools", code)

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -66,13 +66,13 @@ class ApplicationDelegate
     ipc.send("call-window-method", "setFullScreen", fullScreen)
 
   openWindowDevTools: ->
-    remote.getCurrentWindow().openDevTools()
+    ipc.send("call-window-method", "openDevTools")
 
   toggleWindowDevTools: ->
-    remote.getCurrentWindow().toggleDevTools()
+    ipc.send("call-window-method", "toggleDevTools")
 
   executeJavaScriptInWindowDevTools: (code) ->
-    remote.getCurrentWindow().executeJavaScriptInDevTools(code)
+    ipc.send("call-window-method", "executeJavaScriptInDevTools", code)
 
   setWindowDocumentEdited: (edited) ->
     ipc.send("call-window-method", "setDocumentEdited", edited)

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -670,8 +670,7 @@ class AtomEnvironment extends Model
       @emitter.emit 'will-throw-error', eventObject
 
       if openDevTools
-        @openDevTools()
-        @executeJavaScriptInDevTools('DevToolsAPI.showConsole()')
+        @openDevTools().then => @executeJavaScriptInDevTools('DevToolsAPI.showConsole()')
 
       @emitter.emit 'did-throw-error', {message, url, line, column, originalError}
 
@@ -721,10 +720,15 @@ class AtomEnvironment extends Model
   ###
 
   # Extended: Open the dev tools for the current window.
+  #
+  # Returns a {Promise} that resolves when the DevTools have been opened.
   openDevTools: ->
     @applicationDelegate.openWindowDevTools()
 
   # Extended: Toggle the visibility of the dev tools for the current window.
+  #
+  # Returns a {Promise} that resolves when the DevTools have been opened or
+  # closed.
   toggleDevTools: ->
     @applicationDelegate.toggleWindowDevTools()
 

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -726,9 +726,6 @@ class AtomEnvironment extends Model
     @applicationDelegate.openWindowDevTools()
 
   # Extended: Toggle the visibility of the dev tools for the current window.
-  #
-  # Returns a {Promise} that resolves when the DevTools have been opened or
-  # closed.
   toggleDevTools: ->
     @applicationDelegate.toggleWindowDevTools()
 

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -726,6 +726,9 @@ class AtomEnvironment extends Model
     @applicationDelegate.openWindowDevTools()
 
   # Extended: Toggle the visibility of the dev tools for the current window.
+  #
+  # Returns a {Promise} that resolves when the DevTools have been opened or
+  # closed.
   toggleDevTools: ->
     @applicationDelegate.toggleWindowDevTools()
 


### PR DESCRIPTION
Fixes #9697.

The above issue can be consistently reproduced by switching to Dvorak and trying to open the DevTools through `Cmd-Alt-I` (which, if you have a Qwerty keyboard, is `Cmd-Alt-G`). This doesn't happen on most Qwerty keyboards and, quite oddly, I tracked down the problem to be related to DevTools being opened or closed. Indeed, if we try to replace `ApplicationDelegate::toggleWindowDevTools` with a simple log statement this problem doesn't seem to be reproducible. The reason why only certain keyboard layouts trigger this particular behavior is obscure to me at the moment, but somehow I believe this has to do with the DevTools appearing and disappearing, thereby confusing Chromium's input events. (@zcbenz: maybe you have some ideas on what's triggering this behavior?)

I think this wasn't caused by a recent Electron upgrade, but rather to the way we have changed Atom DevTools interaction: in the past, this was asynchronous but it got changed to be sync during the `AtomEnvironment` refactoring. I switched back to using an asynchronous approach, so that our keybinding/commands event handlers have the chance to fully execute without waiting for DevTools to be opened/closed.

I _think_ we were using a sync version because [these lines of code](https://github.com/atom/atom/blob/master/src/atom-environment.coffee#L672-L674) need to be executed in succession, so that the javascript code can be run when DevTools are already open. It turns out that, before these changes, the console wasn't getting shown if DevTools were closed because we still have to wait until the `devtools-opened` event gets triggered. This PR fixes also this problem by implementing a Promise-based API on top of Electron DevTools API.

/cc: @nathansobo @atom/feedback
