### PR TITLE
Use CommandRegistry to listen for native-key-bindings

### DIFF
--- a/spec/window-event-handler-spec.coffee
+++ b/spec/window-event-handler-spec.coffee
@@ -200,3 +200,34 @@ describe "WindowEventHandler", ->
 
       expect(dispatchedCommands.length).toBe 1
       expect(dispatchedCommands[0].type).toBe 'foo-command'
+
+  describe "native key bindings", ->
+    it "correctly dispatches them to active elements with the '.native-key-bindings' class", ->
+      webContentsSpy = jasmine.createSpyObj("webContents", ["copy", "paste"])
+      spyOn(atom.applicationDelegate, "getCurrentWindow").andReturn({
+        webContents: webContentsSpy
+      })
+
+      nativeKeyBindingsInput = document.createElement("input")
+      nativeKeyBindingsInput.classList.add("native-key-bindings")
+      jasmine.attachToDOM(nativeKeyBindingsInput)
+      nativeKeyBindingsInput.focus()
+
+      atom.dispatchApplicationMenuCommand("core:copy")
+      atom.dispatchApplicationMenuCommand("core:paste")
+
+      expect(webContentsSpy.copy).toHaveBeenCalled()
+      expect(webContentsSpy.paste).toHaveBeenCalled()
+
+      webContentsSpy.copy.reset()
+      webContentsSpy.paste.reset()
+
+      normalInput = document.createElement("input")
+      jasmine.attachToDOM(normalInput)
+      normalInput.focus()
+
+      atom.dispatchApplicationMenuCommand("core:copy")
+      atom.dispatchApplicationMenuCommand("core:paste")
+
+      expect(webContentsSpy.copy).not.toHaveBeenCalled()
+      expect(webContentsSpy.paste).not.toHaveBeenCalled()

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -42,9 +42,8 @@ class WindowEventHandler
   # `.native-key-bindings` class.
   handleNativeKeybindings: ->
     bindCommandToAction = (command, action) =>
-      @addEventListener @document, command, (event) =>
-        if event.target.webkitMatchesSelector('.native-key-bindings')
-          @applicationDelegate.getCurrentWindow().webContents[action]()
+      @subscriptions.add @atomEnvironment.commands.add '.native-key-bindings', command, (event) =>
+        @applicationDelegate.getCurrentWindow().webContents[action]()
 
     bindCommandToAction('core:copy', 'copy')
     bindCommandToAction('core:paste', 'paste')


### PR DESCRIPTION
Fixes #9548.

Before this PR, we were using `addEventListener` to listen for commands on elements with the `.native-key-bindings` class. The only way a command (i.e. not a standard event) can be triggered on an HTML element, however, is through `atom-keymap`, but that doesn't happen whenever a native keymap is fully matched.

In the old jQuery days, whenever adding an event listener on the document, we also called `atom.commands.add`, thus allowing to listen on the document and still being notified for events dispatched manually from `CommandRegistry`. After dropping it, though, we didn't update the `handleNativeKeybindings` code path to use `CommandRegistry`, thus not hitting that code path anymore when e.g. copy-pasting because those kinds of event are _synthesized_ (and not triggered on the DOM) whenever a command from `ApplicationMenu` or `ContextMenu` is dispatched.

It would be awesome if anyone could verify that the above rationale is sound, 'cause I'm relatively new to this area of the codebase. :smile_cat: 

/cc: @nathansobo @atom/feedback 
