### PR TITLE
Upgrade to Electron 0.34.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "0.34.3",
+  "electronVersion": "0.34.4",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^6.1.1",


### PR DESCRIPTION
This should fix https://github.com/atom/atom/issues/9454 by rounding down any device scale factor between 1.0 and 1.3.

Could any Linux user build this locally to check if this solves the problem? 

/cc: @atom/feedback @dappiu @martinb3 @NikoUY @anywhim @fiws
