### PR TITLE
Fix #9806 small issue in scrollbar component

### DIFF
--- a/src/scrollbar-component.coffee
+++ b/src/scrollbar-component.coffee
@@ -24,11 +24,14 @@ class ScrollbarComponent
     switch @orientation
       when 'vertical'
         @newState = state.verticalScrollbar
+        @updateVisible()
         @updateVertical()
       when 'horizontal'
         @newState = state.horizontalScrollbar
+        @updateVisible()
         @updateHorizontal()
 
+  updateVisible: ->
     if @newState.visible isnt @oldState.visible
       if @newState.visible
         @domNode.style.display = ''


### PR DESCRIPTION
This fix the issue #9806 [Small issue with scroll position]. Since the scrollTop is always 0 when the element is `display: none`, we need to update the visibility of the element before we update the scrollTop.
