### PR TITLE
Avoid infinite recursion in Error.prepareStackTrace

### DIFF
--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -163,8 +163,12 @@ var prepareStackTraceWithSourceMapping = Error.prepareStackTrace
 let prepareStackTrace = prepareStackTraceWithSourceMapping
 
 function prepareStackTraceWithRawStackAssignment (error, frames) {
-  error.rawStack = frames
-  return prepareStackTrace(error, frames)
+  if (error.rawStack) { // avoid infinite recursion
+    return prepareStackTraceWithSourceMapping(error, frames)
+  } else {
+    error.rawStack = frames
+    return prepareStackTrace(error, frames)
+  }
 }
 
 Object.defineProperty(Error, 'prepareStackTrace', {


### PR DESCRIPTION
Refs #9660

Previously, prepareStackTraceWithStackAssignment could end up calling itself when third-party code assigned Error.prepareStackTrace back to its original value. Now, we short-circuit this process if the rawStack property has already been assigned.

:pear:d on this with @maxbrunsfeld.
