### PR TITLE
Only add absolute paths to project

### DIFF
--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -406,6 +406,15 @@ describe "Project", ->
       expect(atom.project.getPaths()).toEqual([oldPath, newPath])
       expect(onDidChangePathsSpy).toHaveBeenCalled()
 
+    it "doesn't add relative paths", ->
+      onDidChangePathsSpy = jasmine.createSpy('onDidChangePaths spy')
+      atom.project.onDidChangePaths(onDidChangePathsSpy)
+      [oldPath] = atom.project.getPaths()
+
+      atom.project.addPath('a-dir')
+      expect(atom.project.getPaths()).toEqual([oldPath])
+      expect(onDidChangePathsSpy).not.toHaveBeenCalled()
+
   describe ".removePath(path)", ->
     onDidChangePathsSpy = null
 

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -154,8 +154,9 @@ class Project extends Model
 
   # Public: Add a path to the project's list of root paths
   #
-  # * `projectPath` {String} The path to the directory to add.
+  # * `projectPath` {String} The absolute path to the directory to add.
   addPath: (projectPath, options) ->
+    return unless path.isAbsolute(projectPath)
     directory = null
     for provider in @directoryProviders
       break if directory = provider.directoryForURISync?(projectPath)


### PR DESCRIPTION
fixes #9899 - Adding a relative path seems to do ambiguous and incorrect
things. On my system, it attempts to add `/`, on the linked issue it
seems relative to something else. This change rejects relative paths. 

We could try to resolve paths, but relative to what? If there's only one path in the project, we could try relative to that, but if there are multiple, it becomes totally ambiguous.

cc @atom/feedback 
