### PR TITLE
Update specs for language-javascript changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "language-html": "0.43.0",
     "language-hyperlink": "0.15.0",
     "language-java": "0.17.0",
-    "language-javascript": "0.103.0",
+    "language-javascript": "0.104.0",
     "language-json": "0.17.2",
     "language-less": "0.29.0",
     "language-make": "0.21.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "language-gfm": "0.81.0",
     "language-git": "0.10.0",
     "language-go": "0.40.0",
-    "language-html": "0.43.0",
+    "language-html": "0.43.1",
     "language-hyperlink": "0.15.0",
     "language-java": "0.17.0",
     "language-javascript": "0.104.0",

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -484,7 +484,7 @@ describe('TextEditorComponent', function () {
       it('displays newlines as their own token outside of the other tokens\' scopeDescriptor', async function () {
         editor.setText('let\n')
         await nextViewUpdatePromise()
-        expect(component.lineNodeForScreenRow(0).innerHTML).toBe('<span class="source js"><span class="storage modifier js">let</span></span><span class="invisible-character">' + invisibles.eol + '</span>')
+        expect(component.lineNodeForScreenRow(0).innerHTML).toBe('<span class="source js"><span class="storage type var js">let</span></span><span class="invisible-character">' + invisibles.eol + '</span>')
       })
 
       it('displays trailing carriage returns using a visible, non-empty value', async function () {

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -611,7 +611,7 @@ describe "TextEditorPresenter", ->
             expect(presenter.getState().hiddenInput.width).toBe 15
 
             expectStateUpdate presenter, ->
-              presenter.getLinesYardstick().setScopedCharacterWidth(['source.js', 'storage.modifier.js'], 'r', 20)
+              presenter.getLinesYardstick().setScopedCharacterWidth(['source.js', 'storage.type.var.js'], 'r', 20)
               presenter.characterWidthsChanged()
             expect(presenter.getState().hiddenInput.width).toBe 20
 

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -1449,12 +1449,12 @@ describe "TextEditorPresenter", ->
             presenter = buildPresenter(explicitHeight: 20)
 
             expectStateUpdate presenter, ->
-              presenter.getLinesYardstick().setScopedCharacterWidth(['source.js', 'storage.modifier.js'], 'v', 20)
+              presenter.getLinesYardstick().setScopedCharacterWidth(['source.js', 'storage.type.var.js'], 'v', 20)
               presenter.characterWidthsChanged()
             expect(stateForCursor(presenter, 0)).toEqual {top: 1 * 10, left: (3 * 10) + 20, width: 10, height: 10}
 
             expectStateUpdate presenter, ->
-              presenter.getLinesYardstick().setScopedCharacterWidth(['source.js', 'storage.modifier.js'], 'r', 20)
+              presenter.getLinesYardstick().setScopedCharacterWidth(['source.js', 'storage.type.var.js'], 'r', 20)
               presenter.characterWidthsChanged()
             expect(stateForCursor(presenter, 0)).toEqual {top: 1 * 10, left: (3 * 10) + 20, width: 20, height: 10}
 

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -5337,7 +5337,7 @@ describe "TextEditor", ->
 
         tokens = atom.grammars.decodeTokens(line, tags)
         expect(tokens[0].value).toBe "var"
-        expect(tokens[0].scopes).toEqual ["source.js", "storage.modifier.js"]
+        expect(tokens[0].scopes).toEqual ["source.js", "storage.type.var.js"]
 
         expect(tokens[6].value).toBe "http://github.com"
         expect(tokens[6].scopes).toEqual ["source.js", "comment.line.double-slash.js", "markup.underline.link.http.hyperlink"]

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -198,7 +198,7 @@ describe "TokenizedBuffer", ->
             buffer.setTextInRange([[1, 0], [3, 0]], "foo()")
 
             # previous line 0 remains
-            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0]).toEqual(value: 'var', scopes: ['source.js', 'storage.modifier.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0]).toEqual(value: 'var', scopes: ['source.js', 'storage.type.var.js'])
 
             # previous line 3 should be combined with input to form line 1
             expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js', 'meta.function-call.js', 'entity.name.function.js'])
@@ -242,7 +242,7 @@ describe "TokenizedBuffer", ->
             buffer.setTextInRange([[1, 0], [2, 0]], "foo()\nbar()\nbaz()\nquux()")
 
             # previous line 0 remains
-            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0]).toEqual( value: 'var', scopes: ['source.js', 'storage.modifier.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0]).toEqual( value: 'var', scopes: ['source.js', 'storage.type.var.js'])
 
             # 3 new lines inserted
             expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js', 'meta.function-call.js', 'entity.name.function.js'])
@@ -582,7 +582,7 @@ describe "TokenizedBuffer", ->
       fullyTokenize(tokenizedBuffer)
       expect(tokenizedBuffer.tokenForPosition([1, 0]).scopes).toEqual ["source.js"]
       expect(tokenizedBuffer.tokenForPosition([1, 1]).scopes).toEqual ["source.js"]
-      expect(tokenizedBuffer.tokenForPosition([1, 2]).scopes).toEqual ["source.js", "storage.modifier.js"]
+      expect(tokenizedBuffer.tokenForPosition([1, 2]).scopes).toEqual ["source.js", "storage.type.var.js"]
 
   describe ".bufferRangeForScopeAtPosition(selector, position)", ->
     beforeEach ->
@@ -599,8 +599,8 @@ describe "TokenizedBuffer", ->
 
     describe "when the selector matches a single token at the position", ->
       it "returns the range covered by the token", ->
-        expect(tokenizedBuffer.bufferRangeForScopeAtPosition('.storage.modifier.js', [0, 1])).toEqual [[0, 0], [0, 3]]
-        expect(tokenizedBuffer.bufferRangeForScopeAtPosition('.storage.modifier.js', [0, 3])).toEqual [[0, 0], [0, 3]]
+        expect(tokenizedBuffer.bufferRangeForScopeAtPosition('.storage.type.var.js', [0, 1])).toEqual [[0, 0], [0, 3]]
+        expect(tokenizedBuffer.bufferRangeForScopeAtPosition('.storage.type.var.js', [0, 3])).toEqual [[0, 0], [0, 3]]
 
     describe "when the selector matches a run of multiple tokens at the position", ->
       it "returns the range covered by all contigous tokens (within a single line)", ->


### PR DESCRIPTION
`let` and `var` are now tokenized as `storage.type.var.js` instead of `storage.modifier.js`.
# TODO:
- [x] Get core specs to pass
- [x] Update language-html (atom/language-html#97)
- [x] Get package specs to pass

Refs atom/language-javascript#277

Closes #8556
