### PR TITLE
save config.cson in alphabetic order

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -679,6 +679,26 @@ describe "Config", ->
           writtenConfig = CSON.writeFileSync.argsForCall[0][1]
           expect(writtenConfig).toEqual '*': atom.config.settings
 
+        it 'writes properties in alphabetical order', ->
+          atom.config.set('foo', 1)
+          atom.config.set('bar', 2)
+          atom.config.set('baz.foo', 3)
+          atom.config.set('baz.bar', 4)
+
+          CSON.writeFileSync.reset()
+          atom.config.save()
+
+          expect(CSON.writeFileSync.argsForCall[0][0]).toBe atom.config.configFilePath
+          writtenConfig = CSON.writeFileSync.argsForCall[0][1]
+          expect(writtenConfig).toEqual '*': atom.config.settings
+
+          expectedKeys = ['bar', 'baz', 'foo']
+          foundKeys = (key for key of writtenConfig['*'] when key in expectedKeys)
+          expect(foundKeys).toEqual expectedKeys
+          expectedKeys = ['bar', 'foo']
+          foundKeys = (key for key of writtenConfig['*']['baz'] when key in expectedKeys)
+          expect(foundKeys).toEqual expectedKeys
+
       describe "when ~/.atom/config.json doesn't exist", ->
         it "writes any non-default properties to ~/.atom/config.cson", ->
           atom.config.set("a.b.c", 1)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -827,6 +827,7 @@ class Config
 
     allSettings = {'*': @settings}
     allSettings = _.extend allSettings, @scopedSettingsStore.propertiesForSource(@getUserConfigPath())
+    allSettings = sortObject(allSettings)
     try
       CSON.writeFileSync(@configFilePath, allSettings)
     catch error
@@ -1189,6 +1190,13 @@ Config.addSchemaEnforcers
 
 isPlainObject = (value) ->
   _.isObject(value) and not _.isArray(value) and not _.isFunction(value) and not _.isString(value) and not (value instanceof Color)
+
+sortObject = (value) ->
+  return value unless isPlainObject(value)
+  result = {}
+  for key in Object.keys(value).sort()
+    result[key] = sortObject(value[key])
+  result
 
 withoutEmptyObjects = (object) ->
   resultObject = undefined


### PR DESCRIPTION
Currently the `config.cson` is being written in semi-random order (insertion order of the object properties). That makes it pretty difficult so visually find certain options or compare two `config.cson` files from different atom installations. Especially after changing configuration options back and forth the same set of config values results in a very different file.

By ordering the object properties alphabetically the output of that file becomes deterministic. The same configuration results in the same file. And diffing or comparing changes becomes much easier.
- The first commit only contains the new spec (which obviously fails without any other changes):

```
it writes properties in alphabetical order
    Expected [ 'foo', 'bar', 'baz' ] to equal [ 'bar', 'baz', 'foo' ]. (spec/config-spec.coffee:697:29)
    Expected [ 'foo', 'bar' ] to equal [ 'bar', 'foo' ]. (spec/config-spec.coffee:700:29)
```
- The second commit updates the save function to store the data with a deterministic order.
