### PR TITLE
There is no ES6 in compile-cache.js

### DIFF
--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -161,8 +161,7 @@ require('source-map-support').install({
 Error.stackTraceLimit = 30
 
 var prepareStackTraceWithSourceMapping = Error.prepareStackTrace
-
-let prepareStackTrace = prepareStackTraceWithSourceMapping
+var prepareStackTrace = prepareStackTraceWithSourceMapping
 
 function prepareStackTraceWithRawStackAssignment (error, frames) {
   if (error.rawStack) { // avoid infinite recursion

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -1,5 +1,10 @@
 'use strict'
 
+// For now, we're not using babel or ES6 features like `let` and `const` in
+// this file, because `apm` requires this file directly in order to pre-warm
+// Atom's compile-cache when installing or updating packages, using an older
+// version of node.js
+
 var path = require('path')
 var fs = require('fs-plus')
 var CSON = null


### PR DESCRIPTION
Fixes https://github.com/atom/apm/issues/476
