### PR TITLE
Fix visible screen row line count checks.

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -3183,7 +3183,7 @@ class TextEditor extends Model
   # top of the visible area.
   setFirstVisibleScreenRow: (screenRow, fromView) ->
     unless fromView
-      maxScreenRow = @getLineCount() - 1
+      maxScreenRow = @getScreenLineCount() - 1
       unless @config.get('editor.scrollPastEnd')
         height = @displayBuffer.getHeight()
         lineHeightInPixels = @displayBuffer.getLineHeightInPixels()
@@ -3201,7 +3201,7 @@ class TextEditor extends Model
     height = @displayBuffer.getHeight()
     lineHeightInPixels = @displayBuffer.getLineHeightInPixels()
     if height? and lineHeightInPixels?
-      Math.min(@firstVisibleScreenRow + Math.floor(height / lineHeightInPixels), @getLineCount() - 1)
+      Math.min(@firstVisibleScreenRow + Math.floor(height / lineHeightInPixels), @getScreenLineCount() - 1)
     else
       null
 


### PR DESCRIPTION
Visible screen row calculations should use getScreenLineCount so that correct values are found when text is wrapped or folded.
