### PR TITLE
Use internal scroll assignment methods when committing logical positions

### DIFF
--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -625,23 +625,6 @@ describe "TextEditorPresenter", ->
           expect(getState(presenter).hiddenInput.width).toBe 2
 
     describe ".content", ->
-      describe ".scrollingVertically", ->
-        it "is true for ::stoppedScrollingDelay milliseconds following a changes to ::scrollTop", ->
-          presenter = buildPresenter(scrollTop: 10, stoppedScrollingDelay: 200, explicitHeight: 100)
-          expect(getState(presenter).content.scrollingVertically).toBe true
-          advanceClock(300)
-          expect(getState(presenter).content.scrollingVertically).toBe false
-          expectStateUpdate presenter, -> presenter.setScrollTop(0)
-          expect(getState(presenter).content.scrollingVertically).toBe true
-          advanceClock(100)
-          expect(getState(presenter).content.scrollingVertically).toBe true
-          presenter.setScrollTop(10)
-          getState(presenter) # commits scroll position
-          advanceClock(100)
-          expect(getState(presenter).content.scrollingVertically).toBe true
-          expectStateUpdate presenter, -> advanceClock(100)
-          expect(getState(presenter).content.scrollingVertically).toBe false
-
       describe ".maxHeight", ->
         it "changes based on boundingClientRect", ->
           presenter = buildPresenter(scrollTop: 0, lineHeight: 10)

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -866,10 +866,10 @@ class TextEditorPresenter
 
       @emitDidUpdateState()
 
-  setScrollTop: (scrollTop, overrideScroll=true) ->
+  setScrollTop: (scrollTop) ->
     return unless scrollTop?
 
-    @pendingScrollLogicalPosition = null if overrideScroll
+    @pendingScrollLogicalPosition = null
     @pendingScrollTop = scrollTop
 
     @shouldUpdateVerticalScrollState = true
@@ -894,11 +894,8 @@ class TextEditorPresenter
       clearTimeout(@stoppedScrollingTimeoutId)
       @stoppedScrollingTimeoutId = null
     @stoppedScrollingTimeoutId = setTimeout(@didStopScrolling.bind(this), @stoppedScrollingDelay)
-    @state.content.scrollingVertically = true
-    @emitDidUpdateState()
 
   didStopScrolling: ->
-    @state.content.scrollingVertically = false
     if @mouseWheelScreenRow?
       @mouseWheelScreenRow = null
       @shouldUpdateLinesState = true
@@ -907,10 +904,10 @@ class TextEditorPresenter
 
     @emitDidUpdateState()
 
-  setScrollLeft: (scrollLeft, overrideScroll=true) ->
+  setScrollLeft: (scrollLeft) ->
     return unless scrollLeft?
 
-    @pendingScrollLogicalPosition = null if overrideScroll
+    @pendingScrollLogicalPosition = null
     @pendingScrollLeft = scrollLeft
 
     @shouldUpdateHorizontalScrollState = true
@@ -941,13 +938,13 @@ class TextEditorPresenter
       @contentFrameWidth - @verticalScrollbarWidth
 
   getScrollBottom: -> @getScrollTop() + @getClientHeight()
-  setScrollBottom: (scrollBottom, overrideScroll) ->
-    @setScrollTop(scrollBottom - @getClientHeight(), overrideScroll)
+  setScrollBottom: (scrollBottom) ->
+    @setScrollTop(scrollBottom - @getClientHeight())
     @getScrollBottom()
 
   getScrollRight: -> @getScrollLeft() + @getClientWidth()
-  setScrollRight: (scrollRight, overrideScroll) ->
-    @setScrollLeft(scrollRight - @getClientWidth(), overrideScroll)
+  setScrollRight: (scrollRight) ->
+    @setScrollLeft(scrollRight - @getClientWidth())
     @getScrollRight()
 
   getScrollHeight: ->
@@ -1482,14 +1479,14 @@ class TextEditorPresenter
 
     if options?.reversed ? true
       if desiredScrollBottom > @getScrollBottom()
-        @setScrollBottom(desiredScrollBottom, false)
+        @updateScrollTop(desiredScrollBottom - @getClientHeight())
       if desiredScrollTop < @getScrollTop()
-        @setScrollTop(desiredScrollTop, false)
+        @updateScrollTop(desiredScrollTop)
     else
       if desiredScrollTop < @getScrollTop()
-        @setScrollTop(desiredScrollTop, false)
+        @updateScrollTop(desiredScrollTop)
       if desiredScrollBottom > @getScrollBottom()
-        @setScrollBottom(desiredScrollBottom, false)
+        @updateScrollTop(desiredScrollBottom - @getClientHeight())
 
   commitPendingLogicalScrollLeftPosition: ->
     return unless @pendingScrollLogicalPosition?
@@ -1509,14 +1506,14 @@ class TextEditorPresenter
 
     if options?.reversed ? true
       if desiredScrollRight > @getScrollRight()
-        @setScrollRight(desiredScrollRight, false)
+        @updateScrollLeft(desiredScrollRight - @getClientWidth())
       if desiredScrollLeft < @getScrollLeft()
-        @setScrollLeft(desiredScrollLeft, false)
+        @updateScrollLeft(desiredScrollLeft)
     else
       if desiredScrollLeft < @getScrollLeft()
-        @setScrollLeft(desiredScrollLeft, false)
+        @updateScrollLeft(desiredScrollLeft)
       if desiredScrollRight > @getScrollRight()
-        @setScrollRight(desiredScrollRight, false)
+        @updateScrollLeft(desiredScrollRight - @getClientWidth())
 
   commitPendingScrollLeftPosition: ->
     if @pendingScrollLeft?


### PR DESCRIPTION
This prevents an additional pending scroll top/left assignment and cuts directly to adjusting the positions, saving us an update cycle. It prevents the only major case of emitting an update event during state computation.

@as-cii Am I missing anything here?
