### PR TITLE
Remove non-essential update guard flags from TextEditorPresenter

### DIFF
--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -136,14 +136,6 @@ describe "TextEditorPresenter", ->
         # clearing additional rows won't trigger a state update
         expectNoStateUpdate presenter, -> presenter.clearScreenRowsToMeasure()
 
-        expect(stateFn(presenter).tiles[0]).toBeDefined()
-        expect(stateFn(presenter).tiles[2]).toBeDefined()
-        expect(stateFn(presenter).tiles[4]).toBeDefined()
-        expect(stateFn(presenter).tiles[6]).toBeDefined()
-        expect(stateFn(presenter).tiles[8]).toBeUndefined()
-        expect(stateFn(presenter).tiles[10]).toBeDefined()
-        expect(stateFn(presenter).tiles[12]).toBeDefined()
-
         # when another change triggers a state update we remove useless lines
         expectStateUpdate presenter, -> presenter.setScrollTop(1)
 

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -34,7 +34,6 @@ class TextEditorPresenter
     @observeModel()
     @observeConfig()
     @buildState()
-    @invalidateState()
     @startBlinkingCursors() if @focused
     @startReflowing() if @continuousReflow
     @updating = false
@@ -82,15 +81,10 @@ class TextEditorPresenter
     @updateCommonGutterState()
     @updateReflowState()
 
-    if @shouldUpdateDecorations
-      @fetchDecorations()
-      @updateLineDecorations()
+    @fetchDecorations()
+    @updateLineDecorations()
 
-    if @shouldUpdateLinesState or @shouldUpdateLineNumbersState
-      @updateTilesState()
-      @shouldUpdateLinesState = false
-      @shouldUpdateLineNumbersState = false
-      @shouldUpdateTilesState = true
+    @updateTilesState()
 
     @updating = false
     @state
@@ -104,105 +98,31 @@ class TextEditorPresenter
     @clearPendingScrollPosition()
     @updateRowsPerPage()
 
-    @updateFocusedState() if @shouldUpdateFocusedState
-    @updateHeightState() if @shouldUpdateHeightState
-    @updateVerticalScrollState() if @shouldUpdateVerticalScrollState
-    @updateHorizontalScrollState() if @shouldUpdateHorizontalScrollState
-    @updateScrollbarsState() if @shouldUpdateScrollbarsState
-    @updateHiddenInputState() if @shouldUpdateHiddenInputState
-    @updateContentState() if @shouldUpdateContentState
-    @updateHighlightDecorations() if @shouldUpdateDecorations
-    @updateTilesState() if @shouldUpdateTilesState
-    @updateCursorsState() if @shouldUpdateCursorsState
-    @updateOverlaysState() if @shouldUpdateOverlaysState
-    @updateLineNumberGutterState() if @shouldUpdateLineNumberGutterState
-    @updateGutterOrderState() if @shouldUpdateGutterOrderState
-    @updateCustomGutterDecorationState() if @shouldUpdateCustomGutterDecorationState
+    @updateFocusedState()
+    @updateHeightState()
+    @updateVerticalScrollState()
+    @updateHorizontalScrollState()
+    @updateScrollbarsState()
+    @updateHiddenInputState()
+    @updateContentState()
+    @updateHighlightDecorations()
+    @updateTilesState()
+    @updateCursorsState()
+    @updateOverlaysState()
+    @updateLineNumberGutterState()
+    @updateGutterOrderState()
+    @updateCustomGutterDecorationState()
     @updating = false
 
-    @resetTrackedUpdates()
     @state
 
-  resetTrackedUpdates: ->
-    @shouldUpdateFocusedState = false
-    @shouldUpdateHeightState = false
-    @shouldUpdateVerticalScrollState = false
-    @shouldUpdateHorizontalScrollState = false
-    @shouldUpdateScrollbarsState = false
-    @shouldUpdateHiddenInputState = false
-    @shouldUpdateContentState = false
-    @shouldUpdateDecorations = false
-    @shouldUpdateLinesState = false
-    @shouldUpdateTilesState = false
-    @shouldUpdateCursorsState = false
-    @shouldUpdateOverlaysState = false
-    @shouldUpdateLineNumberGutterState = false
-    @shouldUpdateLineNumbersState = false
-    @shouldUpdateGutterOrderState = false
-    @shouldUpdateCustomGutterDecorationState = false
-
-  invalidateState: ->
-    @shouldUpdateFocusedState = true
-    @shouldUpdateHeightState = true
-    @shouldUpdateVerticalScrollState = true
-    @shouldUpdateHorizontalScrollState = true
-    @shouldUpdateScrollbarsState = true
-    @shouldUpdateHiddenInputState = true
-    @shouldUpdateContentState = true
-    @shouldUpdateDecorations = true
-    @shouldUpdateLinesState = true
-    @shouldUpdateTilesState = true
-    @shouldUpdateCursorsState = true
-    @shouldUpdateOverlaysState = true
-    @shouldUpdateLineNumberGutterState = true
-    @shouldUpdateLineNumbersState = true
-    @shouldUpdateGutterOrderState = true
-    @shouldUpdateCustomGutterDecorationState = true
-
   observeModel: ->
-    @disposables.add @model.onDidChange =>
-      @shouldUpdateHeightState = true
-      @shouldUpdateVerticalScrollState = true
-      @shouldUpdateHorizontalScrollState = true
-      @shouldUpdateScrollbarsState = true
-      @shouldUpdateContentState = true
-      @shouldUpdateDecorations = true
-      @shouldUpdateCursorsState = true
-      @shouldUpdateLinesState = true
-      @shouldUpdateLineNumberGutterState = true
-      @shouldUpdateLineNumbersState = true
-      @shouldUpdateGutterOrderState = true
-      @shouldUpdateCustomGutterDecorationState = true
-      @emitDidUpdateState()
-
-    @disposables.add @model.onDidUpdateDecorations =>
-      @shouldUpdateLinesState = true
-      @shouldUpdateLineNumbersState = true
-      @shouldUpdateDecorations = true
-      @shouldUpdateOverlaysState = true
-      @shouldUpdateCustomGutterDecorationState = true
-      @emitDidUpdateState()
-
+    @disposables.add @model.onDidChange => @emitDidUpdateState()
+    @disposables.add @model.onDidUpdateDecorations => @emitDidUpdateState()
     @disposables.add @model.onDidChangeGrammar(@didChangeGrammar.bind(this))
-    @disposables.add @model.onDidChangePlaceholderText =>
-      @shouldUpdateContentState = true
-      @emitDidUpdateState()
-
-    @disposables.add @model.onDidChangeMini =>
-      @shouldUpdateScrollbarsState = true
-      @shouldUpdateContentState = true
-      @shouldUpdateDecorations = true
-      @shouldUpdateLinesState = true
-      @shouldUpdateLineNumberGutterState = true
-      @shouldUpdateLineNumbersState = true
-      @shouldUpdateGutterOrderState = true
-      @shouldUpdateCustomGutterDecorationState = true
-      @emitDidUpdateState()
-
-    @disposables.add @model.onDidChangeLineNumberGutterVisible =>
-      @shouldUpdateLineNumberGutterState = true
-      @shouldUpdateGutterOrderState = true
-      @emitDidUpdateState()
+    @disposables.add @model.onDidChangePlaceholderText => @emitDidUpdateState()
+    @disposables.add @model.onDidChangeMini => @emitDidUpdateState()
+    @disposables.add @model.onDidChangeLineNumberGutterVisible => @emitDidUpdateState()
 
     @disposables.add @model.onDidAddCursor(@didAddCursor.bind(this))
     @disposables.add @model.onDidRequestAutoscroll(@requestAutoscroll.bind(this))
@@ -227,29 +147,19 @@ class TextEditorPresenter
 
     @configDisposables.add @config.onDidChange 'editor.showIndentGuide', configParams, ({newValue}) =>
       @showIndentGuide = newValue
-      @shouldUpdateContentState = true
 
       @emitDidUpdateState()
     @configDisposables.add @config.onDidChange 'editor.scrollPastEnd', configParams, ({newValue}) =>
       @scrollPastEnd = newValue
-      @shouldUpdateVerticalScrollState = true
-      @shouldUpdateScrollbarsState = true
       @updateScrollHeight()
 
       @emitDidUpdateState()
     @configDisposables.add @config.onDidChange 'editor.showLineNumbers', configParams, ({newValue}) =>
       @showLineNumbers = newValue
-      @shouldUpdateLineNumberGutterState = true
-      @shouldUpdateGutterOrderState = true
-
       @emitDidUpdateState()
 
   didChangeGrammar: ->
     @observeConfig()
-    @shouldUpdateContentState = true
-    @shouldUpdateLineNumberGutterState = true
-    @shouldUpdateGutterOrderState = true
-
     @emitDidUpdateState()
 
   buildState: ->
@@ -381,11 +291,7 @@ class TextEditorPresenter
 
   setScreenRowsToMeasure: (screenRows) ->
     return if not screenRows? or screenRows.length is 0
-
     @screenRowsToMeasure = screenRows
-    @shouldUpdateLinesState = true
-    @shouldUpdateLineNumbersState = true
-    @shouldUpdateDecorations = true
 
   clearScreenRowsToMeasure: ->
     @screenRowsToMeasure = []
@@ -425,8 +331,8 @@ class TextEditorPresenter
       gutterTile.display = "block"
       gutterTile.zIndex = zIndex
 
-      @updateLinesState(tile, rowsWithinTile) if @shouldUpdateLinesState
-      @updateLineNumbersState(gutterTile, rowsWithinTile) if @shouldUpdateLineNumbersState
+      @updateLinesState(tile, rowsWithinTile)
+      @updateLineNumbersState(gutterTile, rowsWithinTile)
 
       visibleTiles[tileStartRow] = true
       zIndex++
@@ -552,23 +458,15 @@ class TextEditorPresenter
   didAddGutter: (gutter) ->
     gutterDisposables = new CompositeDisposable
     gutterDisposables.add gutter.onDidChangeVisible =>
-      @shouldUpdateGutterOrderState = true
-      @shouldUpdateCustomGutterDecorationState = true
-
       @emitDidUpdateState()
     gutterDisposables.add gutter.onDidDestroy =>
       @disposables.remove(gutterDisposables)
       gutterDisposables.dispose()
-      @shouldUpdateGutterOrderState = true
-
       @emitDidUpdateState()
       # It is not necessary to @updateCustomGutterDecorationState here.
       # The destroyed gutter will be removed from the list of gutters in @state,
       # and thus will be removed from the DOM.
     @disposables.add(gutterDisposables)
-    @shouldUpdateGutterOrderState = true
-    @shouldUpdateCustomGutterDecorationState = true
-
     @emitDidUpdateState()
 
   updateGutterOrderState: ->
@@ -861,9 +759,6 @@ class TextEditorPresenter
         @startBlinkingCursors()
       else
         @stopBlinkingCursors(false)
-      @shouldUpdateFocusedState = true
-      @shouldUpdateHiddenInputState = true
-
       @emitDidUpdateState()
 
   setScrollTop: (scrollTop, overrideScroll=true) ->
@@ -871,15 +766,6 @@ class TextEditorPresenter
 
     @pendingScrollLogicalPosition = null if overrideScroll
     @pendingScrollTop = scrollTop
-
-    @shouldUpdateVerticalScrollState = true
-    @shouldUpdateHiddenInputState = true
-    @shouldUpdateDecorations = true
-    @shouldUpdateLinesState = true
-    @shouldUpdateCursorsState = true
-    @shouldUpdateLineNumbersState = true
-    @shouldUpdateCustomGutterDecorationState = true
-    @shouldUpdateOverlaysState = true
 
     @emitDidUpdateState()
 
@@ -901,9 +787,6 @@ class TextEditorPresenter
     @state.content.scrollingVertically = false
     if @mouseWheelScreenRow?
       @mouseWheelScreenRow = null
-      @shouldUpdateLinesState = true
-      @shouldUpdateLineNumbersState = true
-      @shouldUpdateCustomGutterDecorationState = true
 
     @emitDidUpdateState()
 
@@ -912,13 +795,6 @@ class TextEditorPresenter
 
     @pendingScrollLogicalPosition = null if overrideScroll
     @pendingScrollLeft = scrollLeft
-
-    @shouldUpdateHorizontalScrollState = true
-    @shouldUpdateHiddenInputState = true
-    @shouldUpdateCursorsState = true
-    @shouldUpdateOverlaysState = true
-    @shouldUpdateDecorations = true
-    @shouldUpdateLinesState = true
 
     @emitDidUpdateState()
 
@@ -967,43 +843,23 @@ class TextEditorPresenter
     unless @measuredHorizontalScrollbarHeight is horizontalScrollbarHeight
       oldHorizontalScrollbarHeight = @measuredHorizontalScrollbarHeight
       @measuredHorizontalScrollbarHeight = horizontalScrollbarHeight
-      @shouldUpdateScrollbarsState = true
-      @shouldUpdateVerticalScrollState = true
-      @shouldUpdateHorizontalScrollState = true
-      @shouldUpdateCursorsState = true unless oldHorizontalScrollbarHeight?
-
       @emitDidUpdateState()
 
   setVerticalScrollbarWidth: (verticalScrollbarWidth) ->
     unless @measuredVerticalScrollbarWidth is verticalScrollbarWidth
       oldVerticalScrollbarWidth = @measuredVerticalScrollbarWidth
       @measuredVerticalScrollbarWidth = verticalScrollbarWidth
-      @shouldUpdateScrollbarsState = true
-      @shouldUpdateVerticalScrollState = true
-      @shouldUpdateHorizontalScrollState = true
-      @shouldUpdateCursorsState = true unless oldVerticalScrollbarWidth?
-
       @emitDidUpdateState()
 
   setAutoHeight: (autoHeight) ->
     unless @autoHeight is autoHeight
       @autoHeight = autoHeight
-      @shouldUpdateHeightState = true
-
       @emitDidUpdateState()
 
   setExplicitHeight: (explicitHeight) ->
     unless @explicitHeight is explicitHeight
       @explicitHeight = explicitHeight
       @updateHeight()
-      @shouldUpdateVerticalScrollState = true
-      @shouldUpdateScrollbarsState = true
-      @shouldUpdateDecorations = true
-      @shouldUpdateLinesState = true
-      @shouldUpdateCursorsState = true
-      @shouldUpdateLineNumbersState = true
-      @shouldUpdateCustomGutterDecorationState = true
-
       @emitDidUpdateState()
 
   updateHeight: ->
@@ -1022,22 +878,11 @@ class TextEditorPresenter
       @editorWidthInChars = null
       @updateScrollbarDimensions()
       @updateClientWidth()
-      @shouldUpdateVerticalScrollState = true
-      @shouldUpdateHorizontalScrollState = true
-      @shouldUpdateScrollbarsState = true
-      @shouldUpdateContentState = true
-      @shouldUpdateDecorations = true
-      @shouldUpdateLinesState = true
-      @shouldUpdateCursorsState = true unless oldContentFrameWidth?
-
       @emitDidUpdateState()
 
   setBoundingClientRect: (boundingClientRect) ->
     unless @clientRectsEqual(@boundingClientRect, boundingClientRect)
       @boundingClientRect = boundingClientRect
-      @shouldUpdateOverlaysState = true
-      @shouldUpdateContentState = true
-
       @emitDidUpdateState()
 
   clientRectsEqual: (clientRectA, clientRectB) ->
@@ -1051,25 +896,16 @@ class TextEditorPresenter
     if @windowWidth isnt width or @windowHeight isnt height
       @windowWidth = width
       @windowHeight = height
-      @shouldUpdateOverlaysState = true
-
       @emitDidUpdateState()
 
   setBackgroundColor: (backgroundColor) ->
     unless @backgroundColor is backgroundColor
       @backgroundColor = backgroundColor
-      @shouldUpdateContentState = true
-      @shouldUpdateLineNumberGutterState = true
-      @shouldUpdateGutterOrderState = true
-
       @emitDidUpdateState()
 
   setGutterBackgroundColor: (gutterBackgroundColor) ->
     unless @gutterBackgroundColor is gutterBackgroundColor
       @gutterBackgroundColor = gutterBackgroundColor
-      @shouldUpdateLineNumberGutterState = true
-      @shouldUpdateGutterOrderState = true
-
       @emitDidUpdateState()
 
   setGutterWidth: (gutterWidth) ->
@@ -1085,18 +921,6 @@ class TextEditorPresenter
       @lineHeight = lineHeight
       @restoreScrollTopIfNeeded()
       @model.setLineHeightInPixels(lineHeight)
-      @shouldUpdateHeightState = true
-      @shouldUpdateHorizontalScrollState = true
-      @shouldUpdateVerticalScrollState = true
-      @shouldUpdateScrollbarsState = true
-      @shouldUpdateHiddenInputState = true
-      @shouldUpdateDecorations = true
-      @shouldUpdateLinesState = true
-      @shouldUpdateCursorsState = true
-      @shouldUpdateLineNumbersState = true
-      @shouldUpdateCustomGutterDecorationState = true
-      @shouldUpdateOverlaysState = true
-
       @emitDidUpdateState()
 
   setMouseWheelScreenRow: (screenRow) ->
@@ -1115,16 +939,6 @@ class TextEditorPresenter
       @characterWidthsChanged()
 
   characterWidthsChanged: ->
-    @shouldUpdateHorizontalScrollState = true
-    @shouldUpdateVerticalScrollState = true
-    @shouldUpdateScrollbarsState = true
-    @shouldUpdateHiddenInputState = true
-    @shouldUpdateContentState = true
-    @shouldUpdateDecorations = true
-    @shouldUpdateLinesState = true
-    @shouldUpdateCursorsState = true
-    @shouldUpdateOverlaysState = true
-
     @emitDidUpdateState()
 
   hasPixelPositionRequirements: ->
@@ -1365,30 +1179,21 @@ class TextEditorPresenter
       overlayState.itemWidth = itemWidth
       overlayState.itemHeight = itemHeight
       overlayState.contentMargin = contentMargin
-      @shouldUpdateOverlaysState = true
-
       @emitDidUpdateState()
 
   observeCursor: (cursor) ->
     didChangePositionDisposable = cursor.onDidChangePosition =>
-      @shouldUpdateHiddenInputState = true if cursor.isLastCursor()
-      @shouldUpdateCursorsState = true
       @pauseCursorBlinking()
 
       @emitDidUpdateState()
 
     didChangeVisibilityDisposable = cursor.onDidChangeVisibility =>
-      @shouldUpdateCursorsState = true
-
       @emitDidUpdateState()
 
     didDestroyDisposable = cursor.onDidDestroy =>
       @disposables.remove(didChangePositionDisposable)
       @disposables.remove(didChangeVisibilityDisposable)
       @disposables.remove(didDestroyDisposable)
-      @shouldUpdateHiddenInputState = true
-      @shouldUpdateCursorsState = true
-
       @emitDidUpdateState()
 
     @disposables.add(didChangePositionDisposable)
@@ -1397,8 +1202,6 @@ class TextEditorPresenter
 
   didAddCursor: (cursor) ->
     @observeCursor(cursor)
-    @shouldUpdateHiddenInputState = true
-    @shouldUpdateCursorsState = true
     @pauseCursorBlinking()
 
     @emitDidUpdateState()
@@ -1432,17 +1235,6 @@ class TextEditorPresenter
     @pendingScrollLogicalPosition = position
     @pendingScrollTop = null
     @pendingScrollLeft = null
-
-    @shouldUpdateCursorsState = true
-    @shouldUpdateCustomGutterDecorationState = true
-    @shouldUpdateDecorations = true
-    @shouldUpdateHiddenInputState = true
-    @shouldUpdateHorizontalScrollState = true
-    @shouldUpdateLinesState = true
-    @shouldUpdateLineNumbersState = true
-    @shouldUpdateOverlaysState = true
-    @shouldUpdateScrollPosition = true
-    @shouldUpdateVerticalScrollState = true
 
     @emitDidUpdateState()
 

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -135,15 +135,12 @@ class TextEditorPresenter
       @emitDidUpdateState()
 
     @disposables.add @model.onDidChangeGrammar(@didChangeGrammar.bind(this))
-    @disposables.add @model.onDidChangePlaceholderText =>
-      @emitDidUpdateState()
-
+    @disposables.add @model.onDidChangePlaceholderText(@emitDidUpdateState.bind(this))
     @disposables.add @model.onDidChangeMini =>
       @shouldUpdateDecorations = true
       @emitDidUpdateState()
 
-    @disposables.add @model.onDidChangeLineNumberGutterVisible =>
-      @emitDidUpdateState()
+    @disposables.add @model.onDidChangeLineNumberGutterVisible(@emitDidUpdateState.bind(this))
 
     @disposables.add @model.onDidAddCursor(@didAddCursor.bind(this))
     @disposables.add @model.onDidRequestAutoscroll(@requestAutoscroll.bind(this))


### PR DESCRIPTION
The only extremely expensive operation we need to avoid unless it's needed is decoration computation. The rest of these flags don't really warrant the added complexity for the tiny amount of computation they save. Eventually, we'll make the decoration computation so fast so that we can always execute the entire code path whenever we update the editor. This will be easier to reason about both in terms of adding functionality and thinking about performance in a variety of circumstances. Removing the bulk of the flags gets us part of the way there.

/cc @as-cii 
