### PR TITLE
Add "Yes for All" and "No for All" buttons to prompts from pane:close

### DIFF
--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -704,6 +704,42 @@ describe "Pane", ->
       expect(item1.save).not.toHaveBeenCalled()
       expect(pane.isDestroyed()).toBe false
 
+    it "stops prompting to save if no for all is selected", ->
+      pane = new Pane(paneParams(items: [new Item("A"), new Item("B")]))
+      [item1, item2] = pane.getItems()
+      item1.shouldPromptToSave = -> true
+      item2.shouldPromptToSave = -> true
+      item1.getURI = -> "test/path"
+      item2.getURI = -> "test/path2"
+      item1.save = jasmine.createSpy("save")
+      item2.save = jasmine.createSpy("save")
+
+      confirm.andReturn(3)
+      pane.close()
+
+      expect(confirm).toHaveBeenCalled()
+      expect(item1.save).not.toHaveBeenCalled()
+      expect(item2.save).not.toHaveBeenCalled()
+      expect(pane.isDestroyed()).toBe true
+
+    it "prompts to save for all unsaved files when yes for all is selected", ->
+      pane = new Pane(paneParams(items: [new Item("A"), new Item("B")]))
+      [item1, item2] = pane.getItems()
+      item1.shouldPromptToSave = -> true
+      item2.shouldPromptToSave = -> true
+      item1.getURI = -> "test/path"
+      item2.getURI = -> "test/path2"
+      item1.save = jasmine.createSpy("save")
+      item2.save = jasmine.createSpy("save")
+
+      confirm.andReturn(4)
+      pane.close()
+
+      expect(confirm).toHaveBeenCalled()
+      expect(item1.save).toHaveBeenCalled()
+      expect(item2.save).toHaveBeenCalled()
+      expect(pane.isDestroyed()).toBe true
+
   describe "::destroy()", ->
     [container, pane1, pane2] = []
 

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -137,7 +137,7 @@ class PaneContainer extends Model
 
     for pane in @getPanes()
       for item in pane.getItems()
-        unless pane.promptToSaveItem(item, options)
+        unless pane.promptToSaveItem(item, options) is 0
           allSaved = false
           break
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -722,7 +722,7 @@ class Pane extends Model
     promptToSave = true
     for item in items
       if promptToSave is true
-        promptToSave = @promptToSaveItem(item, {} ,(items.length > 1))
+        promptToSave = @promptToSaveItem(item, {}, (items.length > 1))
         if promptToSave is 2
           @saveItem(item)
       else if promptToSave is false


### PR DESCRIPTION
When using the _pane:close_ command, if there're more than one unsaved items open in the pane, the save prompt will now display two additional buttons as seen in the GIF below:

![newbehavior](https://cloud.githubusercontent.com/assets/9729792/11762937/65e86b6a-a0ef-11e5-8174-53c158f8bff6.gif)

This also fixes an issue where using pane:close when only one pane exists makes atom prompt to save an unsaved item twice, as you can see below. The issue was verified on Windows, Mac and Linux.

<img src="https://i.gyazo.com/0694bf20634c29959f4abcd2806c0f1a.gif" >

 This was due to @promptToSaveItem being called twice in different methods in the case of there only being one pane. 

Also, thank you to @joaomnb for contributing to this new functionality. 
