### PR TITLE
Clear the require cache for a package files and dependencies

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -225,6 +225,20 @@ describe "PackageManager", ->
         atom.packages.unloadPackage(pack.name)
         expect(atom.packages.isPackageLoaded(pack.name)).toBeFalsy()
 
+      it "clears the require cache entries for all the package files and dependencies", ->
+        pathsForPackage = (pack) ->
+          Object.keys(require.cache).filter (p) ->
+            p.indexOf(pack.path + path.sep) is 0
+
+        pack = atom.packages.loadPackage('package-with-main')
+        require.cache[path.join(pack.path, 'main-module.coffee')] = {}
+        require.cache[path.join(pack.path + '-other', 'main.coffee')] = {}
+
+        expect(pathsForPackage(pack).length > 0).toBeTruthy()
+        atom.packages.unloadPackage(pack.name)
+        expect(pathsForPackage(pack).length > 0).toBeFalsy()
+        expect(require.cache[path.join(pack.path + '-other', 'main.coffee')]).not.toBeUndefined()
+
     it "invokes ::onDidUnloadPackage listeners with the unloaded package", ->
       atom.packages.loadPackage('package-with-main')
       unloadedPackage = null

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -403,6 +403,9 @@ class PackageManager
 
     if pack = @getLoadedPackage(name)
       delete @loadedPackages[pack.name]
+      Object.keys(require.cache)
+      .filter (p) -> p.indexOf(pack.path + path.sep) is 0
+      .forEach (p) -> delete require.cache[p]
       @emitter.emit 'did-unload-package', pack
     else
       throw new Error("No loaded package for name '#{name}'")


### PR DESCRIPTION
This is an attempt to fix the issues after a package update by clearing the `require.cache` object of all the paths related to the package.
