### PR TITLE
[WIP] Fix wrong version on release notes

### DIFF
--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -175,6 +175,8 @@ class ApplicationDelegate
   onUpdateAvailable: (callback) ->
     outerCallback = (message, detail) ->
       if message is 'update-available'
+        {releaseVersion} = detail
+        detail = [releaseVersion]
         callback(detail)
 
     ipc.on('message', outerCallback)


### PR DESCRIPTION
The bug is mixed in that commit : 9e59ab1e45ed4cbb00a6ed0408ce76572d5ab32b

ref:
[atom/src/browser/auto-update-manager.coffee](https://github.com/atom/atom/blob/c90aabed923c49d2b0d5e9d601d806de41b98c6f/src/browser/auto-update-manager.coffee#L65)
f989ed65e1ffd684b338867d964c5de62e83eab3
atom/release-notes#39
#9682
