### PR TITLE
Copy empty .lproj dirs to fix `navigator.language` on OS X

### DIFF
--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -19,6 +19,18 @@ module.exports = (grunt) ->
       fs.renameSync path.join(shellAppDir, 'Contents', 'MacOS', 'Electron'), path.join(shellAppDir, 'Contents', 'MacOS', 'Atom')
       fs.renameSync path.join(shellAppDir, 'Contents', 'Frameworks', 'Electron Helper.app'), path.join(shellAppDir, 'Contents', 'Frameworks', 'Atom Helper.app')
       fs.renameSync path.join(shellAppDir, 'Contents', 'Frameworks', 'Atom Helper.app', 'Contents', 'MacOS', 'Electron Helper'), path.join(shellAppDir, 'Contents', 'Frameworks', 'Atom Helper.app', 'Contents', 'MacOS', 'Atom Helper')
+
+      # Create locale directories that were skipped because they were empty.
+      # Otherwise, `navigator.language` always returns `English`.
+      resourcesDir = 'electron/Electron.app/Contents/Resources'
+      filenames = fs.readdirSync(resourcesDir)
+      for filename in filenames
+        continue unless fs.statSync(path.join(resourcesDir, filename)).isDirectory()
+        continue unless path.extname(filename) is '.lproj'
+        destination = path.join(shellAppDir, 'Contents', 'Resources', filename)
+        continue if fs.existsSync(destination)
+        grunt.file.mkdir(destination)
+
     else
       cp 'electron', shellAppDir, filter: /default_app/
 


### PR DESCRIPTION
(Related: https://github.com/atom/electron/issues/2484)

In Atom 1.3.1, navigator.language is always set to "English" on Mac OS X, even if the user is using another language. This is particularly troublesome because English isn't even an appropriate value for that field. (It should be something like `en-US`). This PR is a copy of a change we made to nylas/N1 to fix this issue. It turns out the empty `.lproj` directories inside Electron must be copied for language detection to work in Chromium.
