### PR TITLE
Print steps time during Grunt tasks and script/bootstrap

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -14,6 +14,8 @@ _ = require 'underscore-plus'
 packageJson = require '../package.json'
 
 module.exports = (grunt) ->
+  require('time-grunt')(grunt)
+
   grunt.loadNpmTasks('grunt-babel')
   grunt.loadNpmTasks('grunt-coffeelint')
   grunt.loadNpmTasks('grunt-lesslint')

--- a/build/package.json
+++ b/build/package.json
@@ -37,6 +37,7 @@
     "runas": "^3.1",
     "tello": "1.0.5",
     "temp": "~0.8.1",
+    "time-grunt": "1.2.2",
     "underscore-plus": "1.x",
     "unzip": "~0.1.9",
     "vm-compatibility-layer": "~0.1.0",

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,8 +5,16 @@ var verifyRequirements = require('./utils/verify-requirements');
 var safeExec = require('./utils/child-process-wrapper.js').safeExec;
 var path = require('path');
 
+var t0, t1
+
 // Executes an array of commands one by one.
 function executeCommands(commands, done, index) {
+  if (index != undefined) {
+    t1 = Date.now()
+    console.log("=> Took " + (t1 - t0) + "ms.");
+    console.log();
+  }
+
   index = (index == undefined ? 0 : index);
   if (index < commands.length) {
     var command = commands[index];
@@ -17,6 +25,7 @@ function executeCommands(commands, done, index) {
       options = command.options;
       command = command.command;
     }
+    t0 = Date.now()
     safeExec(command, options, executeCommands.bind(this, commands, done, index + 1));
   }
   else
@@ -96,7 +105,10 @@ function bootstrap() {
       message: 'Installing apm...',
       options: apmInstallOptions
     },
-    apmPath + ' clean' + apmFlags,
+    {
+      command: apmPath + ' clean' + apmFlags,
+      message: 'Deleting old packages...'
+    },
     moduleInstallCommand,
     dedupeApmCommand + ' ' + packagesToDedupe.join(' '),
   ];


### PR DESCRIPTION
After talking to @maxbrunsfeld about how we may speed up our CI times, we agreed it could have been beneficial to have a better understanding about where the build time gets spent.

As a result, this PR introduces two more pieces of information when building Atom:
1. Package/Modules (un)install times.
2. Grunt tasks times. (these include running specs, linting, transpiling, etc.)

![screen shot 2015-12-19 at 17 52 22](https://cloud.githubusercontent.com/assets/482957/11914198/9ae037c8-a679-11e5-936d-88c6f74fc7cb.png)

![screen shot 2015-12-19 at 17 52 32](https://cloud.githubusercontent.com/assets/482957/11914195/72febdc4-a679-11e5-91ec-f5d93bb741b7.png)

(You can see a more detailed report at https://travis-ci.org/atom/atom/jobs/97848561)

/cc: @maxbrunsfeld @nathansobo @atom/core 
