### PR TITLE
(WIP) Move all logic related to preview tabs into core

### DIFF
--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -3,6 +3,7 @@
 Pane = require '../src/pane'
 PaneAxis = require '../src/pane-axis'
 PaneContainer = require '../src/pane-container'
+TextEditor = require '../src/text-editor'
 
 describe "Pane", ->
   [confirm, showSaveDialog, deserializerDisposable] = []
@@ -153,7 +154,7 @@ describe "Pane", ->
       pane.activateItem(pane.itemAtIndex(1))
       expect(observed).toEqual [pane.itemAtIndex(1)]
 
-    describe "when the `pending` option is true", ->
+    fdescribe "when the `pending` option is true", ->
       it "reports the new active item as pending", ->
         item = new Item("C")
         pane.activateItem(item, pending: true)
@@ -191,7 +192,7 @@ describe "Pane", ->
         expect(pane.getActiveItemIndex()).toBe 1
         expect(pane.isActiveItemPending()).toBe false
 
-    describe "when pending item is re-activated", ->
+    fdescribe "when pending item is re-activated", ->
       it "invokes ::onDidConfirmPendingItem() observers if `pending` is not true", ->
         itemC = new Item("C")
         events = []
@@ -215,6 +216,26 @@ describe "Pane", ->
         expect(pane.getActiveItemIndex()).toBe 1
         expect(events).toEqual []
         expect(pane.isActiveItemPending()).toBe true
+
+    fdescribe "when pending item's buffer content is changed", ->
+      it "invokes ::onDidConfirmPendingItem() observers", ->
+        itemC = new Item("C")
+        events = []
+        pane.onDidConfirmPendingItem (event) -> events.push(event)
+        pane.activateItem(itemC, pending: true)
+        console.log 'active item', pane.getActiveItem()
+        console.log '####', pane.getActiveItem() instanceof TextEditor
+        expect(itemC in pane.getItems()).toBe true
+        expect(pane.getActiveItem()).toBe itemC
+        expect(pane.getActiveItemIndex()).toBe 1
+        expect(events).toEqual [{item: itemC, index: 1}]
+        expect(pane.isActiveItemPending()).toBe false
+
+
+    fdescribe "when pending item is saved or destroyed", ->
+      it "invokes ::onDidConfirmPendingItem() observers", ->
+        # handle saved
+        # handle destroyed
 
   describe "::activateNextItem() and ::activatePreviousItem()", ->
     it "sets the active item to the next/previous item, looping around at either end", ->

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -199,8 +199,11 @@ describe "Pane", ->
         pane.onDidConfirmPendingItem (event) -> events.push(event)
         pane.activateItem(itemC, pending: true)
         pane.activateItem(itemC)
+        expect(itemC in pane.getItems()).toBe true
+        expect(pane.getActiveItem()).toBe itemC
+        expect(pane.getActiveItemIndex()).toBe 1
         expect(events).toEqual [{item: itemC, index: 1}]
-
+        expect(pane.isActiveItemPending()).toBe false
 
   describe "::activateNextItem() and ::activatePreviousItem()", ->
     it "sets the active item to the next/previous item, looping around at either end", ->

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -191,8 +191,8 @@ describe "Pane", ->
         expect(pane.getActiveItemIndex()).toBe 1
         expect(pane.isActiveItemPending()).toBe false
 
-    describe "when pending item is re-activated without `pending: true`", ->
-      it "invokes ::onDidConfirmPendingItem() observers", ->
+    describe "when pending item is re-activated", ->
+      it "invokes ::onDidConfirmPendingItem() observers if `pending` is not true", ->
         itemC = new Item("C")
         events = []
         pane.onDidConfirmPendingItem (event) -> events.push(event)
@@ -203,6 +203,18 @@ describe "Pane", ->
         expect(pane.getActiveItemIndex()).toBe 1
         expect(events).toEqual [{item: itemC, index: 1}]
         expect(pane.isActiveItemPending()).toBe false
+
+      it "does not invoke ::onDidConfirmPendingItem() observers if `pending` is true", ->
+        itemD = new Item("D")
+        events = []
+        pane.onDidConfirmPendingItem (event) -> events.push(event)
+        pane.activateItem(itemD, pending: true)
+        pane.activateItem(itemD, pending: true)
+        expect(itemD in pane.getItems()).toBe true
+        expect(pane.getActiveItem()).toBe itemD
+        expect(pane.getActiveItemIndex()).toBe 1
+        expect(events).toEqual []
+        expect(pane.isActiveItemPending()).toBe true
 
   describe "::activateNextItem() and ::activatePreviousItem()", ->
     it "sets the active item to the next/previous item, looping around at either end", ->

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -180,7 +180,6 @@ describe "Pane", ->
 
         pane.activateItem(itemD, pending: true)
 
-        expect(itemC in pane.getItems()).toBe false
         expect(pane.getActiveItem()).toBe itemD
         expect(pane.getActiveItemIndex()).toBe 1
         expect(pane.isActiveItemPending()).toBe true

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -130,7 +130,7 @@ describe "Pane", ->
       expect(-> pane.addItem('foo')).toThrow()
       expect(-> pane.addItem(1)).toThrow()
 
-  describe "::activateItem(item)", ->
+  describe "::activateItem(item, options)", ->
     pane = null
 
     beforeEach ->
@@ -152,6 +152,31 @@ describe "Pane", ->
       pane.onDidChangeActiveItem (item) -> observed.push(item)
       pane.activateItem(pane.itemAtIndex(1))
       expect(observed).toEqual [pane.itemAtIndex(1)]
+
+    describe "when the `pending` option is true", ->
+      it "reports the new active item as pending", ->
+        item = new Item("C")
+        pane.activateItem(item, pending: true)
+        expect(item in pane.getItems()).toBe true
+        expect(pane.getActiveItem()).toBe item
+        expect(pane.isActiveItemPending()).toBe true
+
+      it "replaces an existing pending item", ->
+        itemC = new Item("C")
+        itemD = new Item("D")
+        pane.activateItem(itemC, pending: true)
+
+        expect(itemC in pane.getItems()).toBe true
+        expect(pane.getActiveItem()).toBe itemC
+        expect(pane.getActiveItemIndex()).toBe 1
+        expect(pane.isActiveItemPending()).toBe true
+
+        pane.activateItem(itemD, pending: true)
+
+        expect(itemC in pane.getItems()).toBe false
+        expect(pane.getActiveItem()).toBe itemD
+        expect(pane.getActiveItemIndex()).toBe 1
+        expect(pane.isActiveItemPending()).toBe true
 
   describe "::activateNextItem() and ::activatePreviousItem()", ->
     it "sets the active item to the next/previous item, looping around at either end", ->

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -178,12 +178,29 @@ describe "Pane", ->
         expect(pane.getActiveItemIndex()).toBe 1
         expect(pane.isActiveItemPending()).toBe true
 
+        pane.activateItem(itemD, pending: true)
+
+        expect(itemC in pane.getItems()).toBe false
+        expect(pane.getActiveItem()).toBe itemD
+        expect(pane.getActiveItemIndex()).toBe 1
+        expect(pane.isActiveItemPending()).toBe true
+
         pane.activateItem(itemB)
 
         expect(itemD in pane.getItems()).toBe false
         expect(pane.getActiveItem()).toBe itemB
         expect(pane.getActiveItemIndex()).toBe 1
         expect(pane.isActiveItemPending()).toBe false
+
+    describe "when pending item is re-activated without `pending: true`", ->
+      it "invokes ::onDidConfirmPendingItem() observers", ->
+        itemC = new Item("C")
+        events = []
+        pane.onDidConfirmPendingItem (event) -> events.push(event)
+        pane.activateItem(itemC, pending: true)
+        pane.activateItem(itemC)
+        expect(events).toEqual [{item: itemC, index: 1}]
+
 
   describe "::activateNextItem() and ::activatePreviousItem()", ->
     it "sets the active item to the next/previous item, looping around at either end", ->

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -3,7 +3,6 @@
 Pane = require '../src/pane'
 PaneAxis = require '../src/pane-axis'
 PaneContainer = require '../src/pane-container'
-TextEditor = require '../src/text-editor'
 
 describe "Pane", ->
   [confirm, showSaveDialog, deserializerDisposable] = []

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -131,10 +131,10 @@ describe "Pane", ->
       expect(-> pane.addItem(1)).toThrow()
 
   describe "::activateItem(item, options)", ->
-    pane = null
+    [pane, itemB] = []
 
     beforeEach ->
-      pane = new Pane(paneParams(items: [new Item("A"), new Item("B")]))
+      pane = new Pane(paneParams(items: [new Item("A"), itemB = new Item("B")]))
 
     it "changes the active item to the current item", ->
       expect(pane.getActiveItem()).toBe pane.itemAtIndex(0)
@@ -161,7 +161,7 @@ describe "Pane", ->
         expect(pane.getActiveItem()).toBe item
         expect(pane.isActiveItemPending()).toBe true
 
-      it "replaces an existing pending item", ->
+      it "replaces the item when new items are activated", ->
         itemC = new Item("C")
         itemD = new Item("D")
         pane.activateItem(itemC, pending: true)
@@ -177,6 +177,13 @@ describe "Pane", ->
         expect(pane.getActiveItem()).toBe itemD
         expect(pane.getActiveItemIndex()).toBe 1
         expect(pane.isActiveItemPending()).toBe true
+
+        pane.activateItem(itemB)
+
+        expect(itemD in pane.getItems()).toBe false
+        expect(pane.getActiveItem()).toBe itemB
+        expect(pane.getActiveItemIndex()).toBe 1
+        expect(pane.isActiveItemPending()).toBe false
 
   describe "::activateNextItem() and ::activatePreviousItem()", ->
     it "sets the active item to the next/previous item, looping around at either end", ->

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -381,6 +381,32 @@ describe "Workspace", ->
               expect(workspace.paneContainer.root.children[0]).toBe pane1
               expect(workspace.paneContainer.root.children[1]).toBe pane2
 
+    describe "when the 'pending' option is true", ->
+      it "opens the new item in the existing pane with pending status", ->
+        editor = null
+        pane = workspace.getActivePane()
+
+        waitsForPromise ->
+          workspace.open('a', pending: true).then (o) -> editor = o
+
+        runs ->
+          expect(workspace.getActivePane()).toBe pane
+          expect(pane.items).toEqual [editor]
+          expect(pane.isActiveItemPending()).toBe true
+
+    describe "when the 'pending' option is NOT true", ->
+      it "opens the new item in the existing pane WITHOUT pending status", ->
+        editor = null
+        pane = workspace.getActivePane()
+
+        waitsForPromise ->
+          workspace.open('a').then (o) -> editor = o
+
+        runs ->
+          expect(workspace.getActivePane()).toBe pane
+          expect(pane.items).toEqual [editor]
+          expect(pane.isActiveItemPending()).toBe false
+
     describe "when an initialLine and initialColumn are specified", ->
       it "moves the cursor to the indicated location", ->
         waitsForPromise ->

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -355,7 +355,7 @@ class Pane extends Model
       @addItem(item, index, false)
       @setActiveItem(item)
       if options?.pending
-        @activeItemPending = true
+        @activatePendingItem(item, index)
         @watchPendingItem()
 
   watchPendingItem: () ->
@@ -372,6 +372,13 @@ class Pane extends Model
   confirmPendingItem: (item, index) ->
     @activeItemPending = false
     @emitter.emit 'did-confirm-pending-item', {item, index}
+
+  onDidActivatePendingItem: (callback) ->
+    @emitter.on 'did-activate-pending-item', callback
+
+  activatePendingItem: (item, index) ->
+    @activeItemPending = true
+    @emitter.emit 'did-activate-pending-item',{item, index}
 
   # Public: Add the given item to the pane.
   #

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -346,7 +346,6 @@ class Pane extends Model
     if item?
       if @activeItemPending
         index = @getActiveItemIndex()
-        @activeItemPending = false
         if @getActiveItem() is item
           @confirmPendingItem(item, index) unless options?.pending
         else
@@ -363,6 +362,7 @@ class Pane extends Model
     @emitter.on 'did-confirm-pending-item', callback
 
   confirmPendingItem: (item, index) ->
+    @activeItemPending = false
     @emitter.emit 'did-confirm-pending-item', {item, index}
 
   # Public: Add the given item to the pane.
@@ -442,6 +442,7 @@ class Pane extends Model
 
   # Public: Destroy the active item and activate the next item.
   destroyActiveItem: ->
+    @activeItemPending = false if @activeItemPending
     @destroyItem(@activeItem)
     false
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -348,7 +348,7 @@ class Pane extends Model
         index = @getActiveItemIndex()
         @activeItemPending = false
         if @getActiveItem() is item
-          @confirmPendingItem(item, index)
+          @confirmPendingItem(item, index) unless options?.pending
         else
           @destroyActiveItem()
       else

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -356,9 +356,13 @@ class Pane extends Model
       @setActiveItem(item)
       if options?.pending
         @activeItemPending = true
-        if typeof item.onDidChangeModified is 'function'
-          @itemSubscriptions.set item, item.onDidChangeModified =>
-            @confirmPendingItem(item, index) if item.isModified()
+        @watchPendingItem()
+
+  watchPendingItem: () ->
+    if @activeItemPending and editor = @getActiveEditor()
+      if typeof editor.onDidChangeModified is 'function'
+        @itemSubscriptions.set editor, editor.onDidChangeModified =>
+          @confirmPendingItem(editor, @getActiveItemIndex()) if editor.isModified()
 
   isActiveItemPending: -> @activeItemPending
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -347,6 +347,7 @@ class Pane extends Model
       if @activeItemPending
         index = @getActiveItemIndex()
         @activeItemPending = false
+        @confirmPendingItem(item, index) if @getActiveItem() is item
         @destroyActiveItem()
       else
         index = @getActiveItemIndex() + 1
@@ -356,7 +357,11 @@ class Pane extends Model
 
   isActiveItemPending: -> @activeItemPending
 
-  onDidConfirmPendingItem: ->
+  onDidConfirmPendingItem: (callback) ->
+    @emitter.on 'did-confirm-pending-item', callback
+
+  confirmPendingItem: (item, index) ->
+    @emitter.emit 'did-confirm-pending-item', {item, index}
 
   # Public: Add the given item to the pane.
   #
@@ -368,7 +373,7 @@ class Pane extends Model
   # Returns the added item.
   addItem: (item, index=@getActiveItemIndex() + 1, moved=false) ->
     throw new Error("Pane items must be objects. Attempted to add item #{item}.") unless item? and typeof item is 'object'
-    throw new Error("Adding a pane item with URI '#{item.getURI?()}' that has already been destroyed") if item.isDestroyed?()
+    # throw new Error("Adding a pane item with URI '#{item.getURI?()}' that has already been destroyed") if item.isDestroyed?()
 
     return if item in @items
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -347,8 +347,10 @@ class Pane extends Model
       if @activeItemPending
         index = @getActiveItemIndex()
         @activeItemPending = false
-        @confirmPendingItem(item, index) if @getActiveItem() is item
-        @destroyActiveItem()
+        if @getActiveItem() is item
+          @confirmPendingItem(item, index)
+        else
+          @destroyActiveItem()
       else
         index = @getActiveItemIndex() + 1
       @addItem(item, index, false)
@@ -373,7 +375,7 @@ class Pane extends Model
   # Returns the added item.
   addItem: (item, index=@getActiveItemIndex() + 1, moved=false) ->
     throw new Error("Pane items must be objects. Attempted to add item #{item}.") unless item? and typeof item is 'object'
-    # throw new Error("Adding a pane item with URI '#{item.getURI?()}' that has already been destroyed") if item.isDestroyed?()
+    throw new Error("Adding a pane item with URI '#{item.getURI?()}' that has already been destroyed") if item.isDestroyed?()
 
     return if item in @items
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -354,7 +354,11 @@ class Pane extends Model
         index = @getActiveItemIndex() + 1
       @addItem(item, index, false)
       @setActiveItem(item)
-      @activeItemPending = true if options?.pending
+      if options?.pending
+        @activeItemPending = true
+        if typeof item.onDidChangeModified is 'function'
+          @itemSubscriptions.set item, item.onDidChangeModified =>
+            @confirmPendingItem(item, index) if item.isModified()
 
   isActiveItemPending: -> @activeItemPending
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -39,6 +39,7 @@ class Pane extends Model
     @emitter = new Emitter
     @itemSubscriptions = new WeakMap
     @items = []
+    @activeItemPending = false
 
     @addItems(compact(params?.items ? []))
     @setActiveItem(@items[0]) unless @getActiveItem()?
@@ -341,10 +342,21 @@ class Pane extends Model
 
   # Public: Make the given item *active*, causing it to be displayed by
   # the pane's view.
-  activateItem: (item) ->
+  activateItem: (item, options) ->
     if item?
-      @addItem(item, @getActiveItemIndex() + 1, false)
+      if @activeItemPending
+        index = @getActiveItemIndex()
+        @activeItemPending = false
+        @destroyActiveItem()
+      else
+        index = @getActiveItemIndex() + 1
+      @addItem(item, index, false)
       @setActiveItem(item)
+      @activeItemPending = true if options?.pending
+
+  isActiveItemPending: -> @activeItemPending
+
+  onDidConfirmPendingItem: ->
 
   # Public: Add the given item to the pane.
   #

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -446,6 +446,7 @@ class Workspace extends Model
     {initialLine, initialColumn} = options
     activatePane = options.activatePane ? true
     activateItem = options.activateItem ? true
+    pending = options.pending ? null
 
     uri = @project.resolvePath(uri)
     item = @getActivePane().itemForURI(uri)
@@ -453,7 +454,7 @@ class Workspace extends Model
       item ?= opener(uri, options) for opener in @getOpeners() when not item
     item ?= @project.openSync(uri, {initialLine, initialColumn})
 
-    @getActivePane().activateItem(item) if activateItem
+    @getActivePane().activateItem(item, {pending}) if activateItem
     @itemOpened(item)
     @getActivePane().activate() if activatePane
     item
@@ -461,6 +462,7 @@ class Workspace extends Model
   openURIInPane: (uri, pane, options={}) ->
     activatePane = options.activatePane ? true
     activateItem = options.activateItem ? true
+    pending = options.pending ? null
 
     if uri?
       item = pane.itemForURI(uri)
@@ -484,7 +486,7 @@ class Workspace extends Model
     Promise.resolve(item)
       .then (item) =>
         @itemOpened(item)
-        pane.activateItem(item) if activateItem
+        pane.activateItem(item, {pending}) if activateItem
         pane.activate() if activatePane
 
         initialLine = initialColumn = 0

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -446,7 +446,7 @@ class Workspace extends Model
     {initialLine, initialColumn} = options
     activatePane = options.activatePane ? true
     activateItem = options.activateItem ? true
-    pending = options.pending ? null
+    pending = options.pending ? false
 
     uri = @project.resolvePath(uri)
     item = @getActivePane().itemForURI(uri)
@@ -462,7 +462,7 @@ class Workspace extends Model
   openURIInPane: (uri, pane, options={}) ->
     activatePane = options.activatePane ? true
     activateItem = options.activateItem ? true
-    pending = options.pending ? null
+    pending = options.pending ? false
 
     if uri?
       item = pane.itemForURI(uri)


### PR DESCRIPTION
Work in progress, just starting a conversation here. 

See corresponding pull requests for tree-view and tabs packages:
- [tree-view #681](https://github.com/atom/tree-view/pull/681)
- [tabs #244](https://github.com/atom/tabs/pull/244)

Still need to write more tests and clean out tabs package to remove unnecessary code. 

Also, considering refactoring to move pending item logic to the Text Editor. This seems to be the better approach and can be found here #10178.

![ku-pending-pane-items](https://cloud.githubusercontent.com/assets/7910250/11986220/f75f2bac-a981-11e5-843e-5ea03253764a.gif)
