### PR TITLE
Open file in pending state on single click

### DIFF
--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -18,6 +18,8 @@ describe "Pane", ->
     onDidDestroy: (fn) -> @emitter.on('did-destroy', fn)
     destroy: -> @destroyed = true; @emitter.emit('did-destroy')
     isDestroyed: -> @destroyed
+    isPending: -> @pending
+    pending: false
 
   beforeEach ->
     confirm = spyOn(atom.applicationDelegate, 'confirm')
@@ -152,6 +154,26 @@ describe "Pane", ->
       pane.onDidChangeActiveItem (item) -> observed.push(item)
       pane.activateItem(pane.itemAtIndex(1))
       expect(observed).toEqual [pane.itemAtIndex(1)]
+
+    it "replaces pending items", ->
+      itemC = new Item("C")
+      itemD = new Item("D")
+      itemC.pending = true
+      itemD.pending = true
+
+      expect(itemC.isPending()).toBe true
+      pane.activateItem(itemC)
+      expect(pane.getItems().length).toBe 3
+      expect(pane.getActiveItem()).toBe pane.itemAtIndex(1)
+
+      expect(itemD.isPending()).toBe true
+      pane.activateItem(itemD)
+      expect(pane.getItems().length).toBe 3
+      expect(pane.getActiveItem()).toBe pane.itemAtIndex(1)
+
+      pane.activateItem(pane.itemAtIndex(2))
+      expect(pane.getItems().length).toBe 2
+      expect(pane.getActiveItem()).toBe pane.itemAtIndex(1)
 
   describe "::activateNextItem() and ::activatePreviousItem()", ->
     it "sets the active item to the next/previous item, looping around at either end", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -5821,3 +5821,11 @@ describe "TextEditor", ->
       editor1.terminatePendingState()
       expect(editor1.isPending()).toBe false
       expect(events).toEqual [editor1]
+
+    it "should terminate pending state when buffer is changed", ->
+      events = []
+      editor1.onDidTerminatePendingState (event) -> events.push(event)
+      expect(editor1.isPending()).toBe true
+      editor1.insertText('I\'ll be back!')
+      expect(editor1.isPending()).toBe false
+      expect(events).toEqual [editor1]

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -5815,7 +5815,7 @@ describe "TextEditor", ->
       expect(editor1.isPending()).toBe true
       expect(editor.isPending()).toBe false # By default pending status is false
 
-    it "invokes ::onDidTerminatePendingState observers if pending status is removed", ->
+    it "invokes ::onDidTerminatePendingState observers if pending status is terminated", ->
       events = []
       editor1.onDidTerminatePendingState (event) -> events.push(event)
       editor1.terminatePendingState()

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -5827,5 +5827,6 @@ describe "TextEditor", ->
       editor1.onDidTerminatePendingState (event) -> events.push(event)
       expect(editor1.isPending()).toBe true
       editor1.insertText('I\'ll be back!')
+      advanceClock(500)
       expect(editor1.isPending()).toBe false
       expect(events).toEqual [editor1]

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -5804,3 +5804,20 @@ describe "TextEditor", ->
           screenRange: marker1.getRange(),
           rangeIsReversed: false
         }
+
+  describe "pending state", ->
+    editor1 = null
+    beforeEach ->
+      waitsForPromise ->
+        atom.workspace.open('sample.txt', pending: true).then (o) -> editor1 = o
+
+    it "should open file in pending state if 'pending' option is true", ->
+      expect(editor1.isPending()).toBe true
+      expect(editor.isPending()).toBe false # By default pending status is false
+
+    it "invokes ::onDidTerminatePendingState observers if pending status is removed", ->
+      events = []
+      editor1.onDidTerminatePendingState (event) -> events.push(event)
+      editor1.terminatePendingState()
+      expect(editor1.isPending()).toBe false
+      expect(events).toEqual [editor1]

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -345,7 +345,7 @@ class Pane extends Model
     if item?
       if @activeItem?.isPending?()
         index = @getActiveItemIndex()
-        @destroyActiveItem()
+        @destroyActiveItem() unless item is @activeItem
       else
         index = @getActiveItemIndex() + 1
       @addItem(item, index, false)
@@ -580,7 +580,6 @@ class Pane extends Model
   # Public: Makes this pane the *active* pane, causing it to gain focus.
   activate: ->
     throw new Error("Pane has been destroyed") if @isDestroyed()
-
     @container?.setActivePane(this)
     @emitter.emit 'did-activate'
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -343,7 +343,7 @@ class Pane extends Model
   # the pane's view.
   activateItem: (item) ->
     if item?
-      if @activeItem?.isPending()
+      if @activeItem?.isPending?()
         index = @getActiveItemIndex()
         @destroyActiveItem()
       else

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -337,7 +337,8 @@ class Pane extends Model
   #
   # * `index` {Number}
   activateItemAtIndex: (index) ->
-    @activateItem(@itemAtIndex(index))
+    item = @itemAtIndex(index) or @getActiveItem()
+    @setActiveItem(item)
 
   # Public: Make the given item *active*, causing it to be displayed by
   # the pane's view.
@@ -370,7 +371,7 @@ class Pane extends Model
 
     @items.splice(index, 0, item)
     @emitter.emit 'did-add-item', {item, index, moved}
-    @setActiveItem(item) unless @getActiveItem()
+    @setActiveItem(item) unless @getActiveItem()?
     item
 
   # Public: Add the given items to the pane.

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -337,7 +337,7 @@ class Pane extends Model
   #
   # * `index` {Number}
   activateItemAtIndex: (index) ->
-    @setActiveItem(@itemAtIndex(index))
+    @activateItem(@itemAtIndex(index))
 
   # Public: Make the given item *active*, causing it to be displayed by
   # the pane's view.
@@ -349,6 +349,7 @@ class Pane extends Model
       else
         index = @getActiveItemIndex() + 1
       @addItem(item, index, false)
+      @setActiveItem(item)
 
   # Public: Add the given item to the pane.
   #
@@ -362,16 +363,14 @@ class Pane extends Model
     throw new Error("Pane items must be objects. Attempted to add item #{item}.") unless item? and typeof item is 'object'
     throw new Error("Adding a pane item with URI '#{item.getURI?()}' that has already been destroyed") if item.isDestroyed?()
 
-    if item in @items
-      @setActiveItem(item)
-      return
+    return if item in @items
 
     if typeof item.onDidDestroy is 'function'
       @itemSubscriptions.set item, item.onDidDestroy => @removeItem(item, false)
 
     @items.splice(index, 0, item)
     @emitter.emit 'did-add-item', {item, index, moved}
-    @setActiveItem(item)
+    @setActiveItem(item) unless @getActiveItem()
     item
 
   # Public: Add the given items to the pane.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -164,7 +164,7 @@ class TextEditor extends Model
     @disposables.add @buffer.onDidDestroy => @destroy()
     if @pending
       @disposables.add @buffer.onDidChangeModified =>
-        @confirmPendingState() if @buffer.isModified()
+        @terminatePendingState() if @buffer.isModified()
 
     @preserveCursorPositionOnBufferReload()
 
@@ -573,10 +573,10 @@ class TextEditor extends Model
   getEditorWidthInChars: ->
     @displayBuffer.getEditorWidthInChars()
 
-  onDidConfirmPendingState: (callback) ->
+  onDidTerminatePendingState: (callback) ->
     @emitter.on 'did-confirm-pending-state', callback
 
-  confirmPendingState: ->
+  terminatePendingState: ->
     @pending = false
     @emitter.emit 'did-confirm-pending-state', this
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -95,7 +95,6 @@ class TextEditor extends Model
       @project, @assert, @applicationDelegate, @pending
     } = params
 
-
     throw new Error("Must pass a config parameter when constructing TextEditors") unless @config?
     throw new Error("Must pass a notificationManager parameter when constructing TextEditors") unless @notificationManager?
     throw new Error("Must pass a packageManager parameter when constructing TextEditors") unless @packageManager?

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -574,11 +574,11 @@ class TextEditor extends Model
     @displayBuffer.getEditorWidthInChars()
 
   onDidTerminatePendingState: (callback) ->
-    @emitter.on 'did-confirm-pending-state', callback
+    @emitter.on 'did-terminate-pending-state', callback
 
   terminatePendingState: ->
     @pending = false
-    @emitter.emit 'did-confirm-pending-state', this
+    @emitter.emit 'did-terminate-pending-state', this
 
   ###
   Section: File Details


### PR DESCRIPTION
Addresses issue #9165 

Single-clicking on a file in tree-view or on a search result from find-in-project opens a 'pending tab'. 

See corresponding pull requests for tree-view and tabs packages:
- [tree-view #682](https://github.com/atom/tree-view/pull/682)
- [tabs #246](https://github.com/atom/tabs/pull/246)
- [find-and-replace #644](https://github.com/atom/find-and-replace/pull/644)
