### PR TITLE
update documentation for rowRangeForParagraphAtBufferRow

### DIFF
--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -551,7 +551,7 @@ class Cursor extends Model
 
   # Public: Retrieves the range for the current paragraph.
   #
-  # A paragraph is defined as a block of text surrounded by empty lines.
+  # A paragraph is defined as a block of text surrounded by empty lines or comments.
   #
   # Returns a {Range}.
   getCurrentParagraphBufferRange: ->


### PR DESCRIPTION
The current documentation doesn't make any note about paragraphs being enclosed within comments. This pull request updates that.
