### PR TITLE
Dh dont hide activation errors in test

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -151,7 +151,8 @@ class AtomEnvironment extends Model
     @packages = new PackageManager({
       devMode, configDirPath, resourcePath, safeMode, @config, styleManager: @styles,
       commandRegistry: @commands, keymapManager: @keymaps, notificationManager: @notifications,
-      grammarRegistry: @grammars, deserializerManager: @deserializers, viewRegistry: @views
+      grammarRegistry: @grammars, deserializerManager: @deserializers, viewRegistry: @views,
+      specMode: @inSpecMode()
     })
 
     @themes = new ThemeManager({

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -30,7 +30,7 @@ module.exports =
 class PackageManager
   constructor: (params) ->
     {
-      configDirPath, @devMode, safeMode, @resourcePath, @config, @styleManager,
+      configDirPath, @devMode, safeMode, @specMode, @resourcePath, @config, @styleManager,
       @notificationManager, @keymapManager, @commandRegistry, @grammarRegistry,
       @deserializerManager, @viewRegistry
     } = params
@@ -377,7 +377,7 @@ class PackageManager
 
       options = {
         path: packagePath, metadata, packageManager: this, @config, @styleManager,
-        @commandRegistry, @keymapManager, @devMode, @notificationManager,
+        @commandRegistry, @keymapManager, @devMode, @specMode, @notificationManager,
         @grammarRegistry, @themeManager, @menuManager, @contextMenuManager,
         @deserializerManager, @viewRegistry
       }

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -91,7 +91,7 @@ class Package
           @requireMainModule()
       catch error
         if @specMode
-          raise error
+          throw error
         else
           @handleError("Failed to load the #{@name} package", error)
     this

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -32,7 +32,7 @@ class Package
   constructor: (params) ->
     {
       @path, @metadata, @packageManager, @config, @styleManager, @commandRegistry,
-      @keymapManager, @devMode, @notificationManager, @grammarRegistry, @themeManager,
+      @keymapManager, @devMode, @specMode, @notificationManager, @grammarRegistry, @themeManager,
       @menuManager, @contextMenuManager, @deserializerManager, @viewRegistry
     } = params
 
@@ -90,7 +90,10 @@ class Package
         if @shouldRequireMainModuleOnLoad() and not @mainModule?
           @requireMainModule()
       catch error
-        @handleError("Failed to load the #{@name} package", error)
+        if @specMode
+          raise error
+        else
+          @handleError("Failed to load the #{@name} package", error)
     this
 
   shouldRequireMainModuleOnLoad: ->


### PR DESCRIPTION
As @joshaber said:

``` javascript
< <caja-v-html><caja-v-head></caja-v-head><caja-v-body><iframe mytubeid="mytube1"> &amp;lt;script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js" integrity="sha256-Sk3nkD6mLTMOF0EOpNtsIry+s1CsaqQC1rVLTAy+0yc= sha512-K1qjQ+NcF2TYO/eI3M6v8EiNYZfA95pQumfvcVrTHtwQVDG+aHRqLi/ETn2uB+1JqwYqVG3LIvdm9lj6imS/pQ==" crossorigin="anonymous"3,10d2 &amp;lt; &amp;lt;code&amp;gt;security&amp;lt;script&amp;gt; &amp;lt;   security*ssl &amp;lt;   security*ssl*rsa &amp;lt;   security*tls &amp;lt;   /^security[.]ssl3.*rsa|security[.].*tls/i &amp;lt;   /^security[.]ssl3.*(128|256)/i &amp;lt;   /^(?!gecko[.]handler|network[.]IDN|network[.]protocol|print|security[.]ssl)/i &amp;lt;   /^(?=browser[.]|dom[.]|network[.](?!IDN|protocol))/i &amp;lt;/script&amp;gt;&amp;lt;/code&amp;gt;&amp;gt;&amp;lt;/script&amp;gt; </iframe>
<iframe mytubeid="mytube2"> thedaniel   pass spec mode down to the package, refs #10079  9cdb68d
 @thedaniel thedaniel   Ha! I was just writing some ruby a minute ago clearly    378bb30
 &amp;lt;link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet" integrity="sha256-MfvZlkHCEqatNoGiOXveE8FIwMzZg4W85qfrfIFBfYc= sha512-dTfge/zgoMYpP7QbHy4gWMEGsbsdZeCXz7irItjcC3sPUFtf0kuFbDz/ixG7ArTxmDjLXDmezHubeNikyKGVyQ==" crossorigin="anonymous"&amp;gt;</iframe> </caja-v-body></caja-v-html>
```
- dh-dont-hide-activation-errors-in-test 1
  *dh-dont-hide-activation-errors-in-test 1a
