### PR TITLE
Fix New File with no open windows

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -370,7 +370,7 @@ class AtomApplication
   #   :safeMode - Boolean to control the opened window's safe mode.
   #   :profileStartup - Boolean to control creating a profile of the startup time.
   #   :window - {AtomWindow} to open file paths in.
-  openPath: ({pathToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, window}) ->
+  openPath: ({pathToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, window} = {}) ->
     @openPaths({pathsToOpen: [pathToOpen], pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, window})
 
   # Public: Opens multiple paths, in existing windows if possible.

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -229,7 +229,7 @@ class AtomApplication
       @openUrl({urlToOpen, @devMode, @safeMode})
 
     app.on 'activate-with-no-open-windows', (event) =>
-      event.preventDefault()
+      event?.preventDefault()
       @emit('application:new-window')
 
     # A request from the associated render process to open a new render process.


### PR DESCRIPTION
Fixes #7171 and #7428.

It'd fail previously with:

```
TypeError: Cannot read property 'pathToOpen' of undefined
```

/cc @atom/feedback
