### PR TITLE
Ignore errors when loading an invalid blob store

### DIFF
--- a/src/file-system-blob-store.js
+++ b/src/file-system-blob-store.js
@@ -12,12 +12,16 @@ class FileSystemBlobStore {
   }
 
   constructor (directory) {
-    this.inMemoryBlobs = new Map()
-    this.invalidationKeys = {}
     this.blobFilename = path.join(directory, 'BLOB')
     this.blobMapFilename = path.join(directory, 'MAP')
     this.invalidationKeysFilename = path.join(directory, 'INVKEYS')
     this.lockFilename = path.join(directory, 'LOCK')
+    this.reset()
+  }
+
+  reset () {
+    this.inMemoryBlobs = new Map()
+    this.invalidationKeys = {}
     this.storedBlob = new Buffer(0)
     this.storedBlobMap = {}
   }
@@ -32,9 +36,14 @@ class FileSystemBlobStore {
     if (!fs.existsSync(this.invalidationKeysFilename)) {
       return
     }
-    this.storedBlob = fs.readFileSync(this.blobFilename)
-    this.storedBlobMap = JSON.parse(fs.readFileSync(this.blobMapFilename))
-    this.invalidationKeys = JSON.parse(fs.readFileSync(this.invalidationKeysFilename))
+
+    try {
+      this.storedBlob = fs.readFileSync(this.blobFilename)
+      this.storedBlobMap = JSON.parse(fs.readFileSync(this.blobMapFilename))
+      this.invalidationKeys = JSON.parse(fs.readFileSync(this.invalidationKeysFilename))
+    } catch (e) {
+      this.reset()
+    }
   }
 
   save () {


### PR DESCRIPTION
Fixes #10047.
Fixes #10015.

Although I am not able to reproduce the problem reported in the above issues, with this PR we're introducing a more flexible way of loading the blob store, which now doesn't crash Atom if any of the files is corrupted.

This seems like a reasonable default to have and, in the meantime, we can keep an eye on what triggers this particular edge case. I don't think it's a race condition caused by Atom, as we're already using a lock file to prevent such scenarios, but I could be overlooking something here.

/cc: @maxbrunsfeld @nathansobo @atom/feedback 
