### PR TITLE
Fix Windows installer path update woes

### DIFF
--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -58,7 +58,12 @@ spawnReg = (args, callback) ->
 spawnPowershell = (args, callback) ->
   # set encoding and execute the command, capture the output, and return it via .NET's console in order to have consistent UTF-8 encoding
   # http://stackoverflow.com/questions/22349139/utf-8-output-from-powershell
-  args[0] = "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8\r\n$output=#{args[0]}\r\n[Console]::WriteLine($output)"
+  # to address https://github.com/atom/atom/issues/5063
+  args[0] = """
+    [Console]::OutputEncoding=[System.Text.Encoding]::UTF8
+    $output=#{args[0]}
+    [Console]::WriteLine($output)
+  """
   args.unshift('-command')
   args.unshift('RemoteSigned')
   args.unshift('-ExecutionPolicy')


### PR DESCRIPTION
#5092 and #7757 were worked around with not updating the path if registry tools access disabled in the Windows Group Policy
#5063 was worked around with not updating the path if the path contains characters outside the ASCII range

This addresses both of these with fixes that correctly update the user path under these conditions with the deleting or corruption of the user path resulting from these issues.
