### PR TITLE
Default to using standard GitHub API token during build

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -256,7 +256,7 @@ module.exports = (grunt) ->
       outputDir: 'electron'
       downloadDir: electronDownloadDir
       rebuild: true  # rebuild native modules after electron is updated
-      token: process.env.ATOM_ACCESS_TOKEN
+      token: process.env.ATOM_ACCESS_TOKEN ? 'da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4'
 
     'create-windows-installer':
       installer:


### PR DESCRIPTION
Resolves an issue where the GitHub API is rate-limited during the build when attempting to download Electron.

/cc @kevinsawicki 
