### PR TITLE
Backport Electron stability fixes to 1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "0.34.3",
+  "electronVersion": "0.34.5",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^6.1.1",


### PR DESCRIPTION
This PR will fix #9584 and #9454 on 1.3.3.
