### PR TITLE
Backport identical tab names fix

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -168,7 +168,7 @@ describe "TextEditor", ->
         buffer.setPath(undefined)
         expect(editor.getLongTitle()).toBe 'untitled'
 
-      it "returns <parent-directory>/<filename> when opened files has identical file names", ->
+      it "returns '<filename> — <parent-directory>' when opened files have identical file names", ->
         editor1 = null
         editor2 = null
         waitsForPromise ->
@@ -177,10 +177,10 @@ describe "TextEditor", ->
             atom.workspace.open(path.join('sample-theme-2', 'readme')).then (o) ->
               editor2 = o
         runs ->
-          expect(editor1.getLongTitle()).toBe 'sample-theme-1/readme'
-          expect(editor2.getLongTitle()).toBe 'sample-theme-2/readme'
+          expect(editor1.getLongTitle()).toBe "readme \u2014 sample-theme-1"
+          expect(editor2.getLongTitle()).toBe "readme \u2014 sample-theme-2"
 
-      it "or returns <parent-directory>/.../<filename> when opened files has identical file names", ->
+      it "returns '<filename> — <parent-directories>' when opened files have identical file and dir names", ->
         editor1 = null
         editor2 = null
         waitsForPromise ->
@@ -189,9 +189,20 @@ describe "TextEditor", ->
             atom.workspace.open(path.join('sample-theme-2', 'src', 'js', 'main.js')).then (o) ->
               editor2 = o
         runs ->
-          expect(editor1.getLongTitle()).toBe 'sample-theme-1/.../main.js'
-          expect(editor2.getLongTitle()).toBe 'sample-theme-2/.../main.js'
+          expect(editor1.getLongTitle()).toBe "main.js \u2014 sample-theme-1/src/js"
+          expect(editor2.getLongTitle()).toBe "main.js \u2014 sample-theme-2/src/js"
 
+      it "returns '<filename> — <parent-directories>' when opened files have identical file and same parent dir name", ->
+        editor1 = null
+        editor2 = null
+        waitsForPromise ->
+          atom.workspace.open(path.join('sample-theme-2', 'src', 'js', 'main.js')).then (o) ->
+            editor1 = o
+            atom.workspace.open(path.join('sample-theme-2', 'src', 'js', 'plugin', 'main.js')).then (o) ->
+              editor2 = o
+        runs ->
+          expect(editor1.getLongTitle()).toBe "main.js \u2014 js"
+          expect(editor2.getLongTitle()).toBe "main.js \u2014 js/plugin"
 
     it "notifies ::onDidChangeTitle observers when the underlying buffer path changes", ->
       observed = []

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -76,7 +76,7 @@ describe "Workspace", ->
           expect(editor4.getCursorScreenPosition()).toEqual [2, 4]
 
           expect(atom.workspace.getActiveTextEditor().getPath()).toBe editor3.getPath()
-          expect(document.title).toBe "#{path.basename(editor3.getPath())} - #{atom.project.getPaths()[0]} - Atom"
+          expect(document.title).toBe "#{path.basename(editor3.getLongTitle())} - #{atom.project.getPaths()[0]} - Atom"
 
     describe "where there are no open panes or editors", ->
       it "constructs the view with no open editors", ->
@@ -776,8 +776,8 @@ describe "Workspace", ->
           applicationDelegate: atom.applicationDelegate, assert: atom.assert.bind(atom)
         })
         workspace2.deserialize(atom.workspace.serialize(), atom.deserializers)
-        item = atom.workspace.getActivePaneItem()
-        expect(document.title).toBe "#{item.getTitle()} - #{atom.project.getPaths()[0]} - Atom"
+        item = workspace2.getActivePaneItem()
+        expect(document.title).toBe "#{item.getLongTitle()} - #{atom.project.getPaths()[0]} - Atom"
         workspace2.destroy()
 
   describe "document edited status", ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -155,7 +155,7 @@ class Workspace extends Model
     projectPaths = @project.getPaths() ? []
     if item = @getActivePaneItem()
       itemPath = item.getPath?()
-      itemTitle = item.getTitle?()
+      itemTitle = item.getLongTitle?() ? item.getTitle?()
       projectPath = _.find projectPaths, (projectPath) ->
         itemPath is projectPath or itemPath?.startsWith(projectPath + path.sep)
     itemTitle ?= "untitled"


### PR DESCRIPTION
Fixes Atom hanging indefinitely upon encountering two identical filenames located in different directories in 1.3.x.

(Is cherry-picking the correct way to do this?  It feels really weird creating a PR that uses someone else's commits)
