### PR TITLE
Fix F11 keymaps

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -13,7 +13,7 @@
   'ctrl-alt-o': 'application:add-project-folder'
   'ctrl-shift-pageup': 'pane:move-item-left'
   'ctrl-shift-pagedown': 'pane:move-item-right'
-  'F11': 'window:toggle-full-screen'
+  'f11': 'window:toggle-full-screen'
 
   # Sublime Parity
   'ctrl-,': 'application:show-settings'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -19,7 +19,7 @@
   'ctrl-alt-o': 'application:add-project-folder'
   'ctrl-shift-left': 'pane:move-item-left'
   'ctrl-shift-right': 'pane:move-item-right'
-  'F11': 'window:toggle-full-screen'
+  'f11': 'window:toggle-full-screen'
 
   # Sublime Parity
   'ctrl-,': 'application:show-settings'


### PR DESCRIPTION
Function key keymaps don't work when they feature upperface 'F' characters.
They still tend to work because they typically have an application menu item
which is associated with it and falled back upon. The main difference is that
the originalEvent (KeyboardEvent) is not retained when doing this fallback as
Atom thinks that the menu item was pressed instead of the keymap.

Fixes #10287
