### PR TITLE
Only disable a package if it isn't already disabled

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -1026,6 +1026,16 @@ describe "PackageManager", ->
         expect(atom.packages.enablePackage("this-doesnt-exist")).toBeNull()
         expect(console.warn.callCount).toBe 1
 
+      fit "does not disable an already disabled package", ->
+        packageName = 'package-with-main'
+        atom.config.pushAtKeyPath('core.disabledPackages', packageName)
+        atom.packages.observeDisabledPackages()
+        expect(atom.config.get('core.disabledPackages')).toContain packageName
+
+        atom.packages.disablePackage(packageName)
+        packagesDisabled = atom.config.get('core.disabledPackages').filter((pack) -> pack is packageName)
+        expect(packagesDisabled.length).toEqual 1
+
     describe "with themes", ->
       didChangeActiveThemesHandler = null
 

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -1026,7 +1026,7 @@ describe "PackageManager", ->
         expect(atom.packages.enablePackage("this-doesnt-exist")).toBeNull()
         expect(console.warn.callCount).toBe 1
 
-      fit "does not disable an already disabled package", ->
+      it "does not disable an already disabled package", ->
         packageName = 'package-with-main'
         atom.config.pushAtKeyPath('core.disabledPackages', packageName)
         atom.packages.observeDisabledPackages()

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -199,7 +199,10 @@ class PackageManager
   # Returns the {Package} that was disabled or null if it isn't loaded.
   disablePackage: (name) ->
     pack = @loadPackage(name)
-    pack?.disable()
+
+    unless @isPackageDisabled(name)
+      pack?.disable()
+
     pack
 
   # Public: Is the package with the given name disabled?


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/10358

I wasn't sure if this check was better suited for `Package` or `PackageManager`, but I think it's more within the scope of `PackageManager` to manage the state of the `core.disabledPackages` keypath. Let me know if you think I should move it though!

/cc @atom/feedback 
