### PR TITLE
Fixed the indentation logic

### DIFF
--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -252,6 +252,9 @@ class LanguageMode
     decreaseThisIndentRegex = @decreaseThisIndentRegexForScopeDescriptor(scopeDescriptor)
     decreaseIndentRegex = @decreaseIndentRegexForScopeDescriptor(scopeDescriptor)
 
+    if not decreaseThisIndentRegex
+      decreaseThisIndentRegex = decreaseIndentRegex
+
     if options?.skipBlankLines ? true
       precedingRow = @buffer.previousNonBlankRow(bufferRow)
       return 0 unless precedingRow?

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -243,13 +243,14 @@ class LanguageMode
     @suggestedIndentForTokenizedLineAtBufferRow(bufferRow, line, tokenizedLine, options)
 
   suggestedIndentForTokenizedLineAtBufferRow: (bufferRow, line, tokenizedLine, options) ->
+    # console.log tokenizedLine
     iterator = tokenizedLine.getTokenIterator()
     iterator.next()
     scopeDescriptor = new ScopeDescriptor(scopes: iterator.getScopes())
 
     increaseIndentRegex = @increaseIndentRegexForScopeDescriptor(scopeDescriptor)
+    decreaseThisIndentRegex = @decreaseThisIndentRegexForScopeDescriptor(scopeDescriptor)
     decreaseIndentRegex = @decreaseIndentRegexForScopeDescriptor(scopeDescriptor)
-    decreaseNextIndentRegex = @decreaseNextIndentRegexForScopeDescriptor(scopeDescriptor)
 
     if options?.skipBlankLines ? true
       precedingRow = @buffer.previousNonBlankRow(bufferRow)
@@ -263,12 +264,29 @@ class LanguageMode
 
     unless @editor.isBufferRowCommented(precedingRow)
       precedingLine = @buffer.lineForRow(precedingRow)
-      desiredIndentLevel += 1 if increaseIndentRegex?.testSync(precedingLine)
-      desiredIndentLevel -= 1 if decreaseNextIndentRegex?.testSync(precedingLine)
+      tokenizedPrecedingLine =
+        @editor.displayBuffer.tokenizedBuffer
+        .buildTokenizedLineForRowWithText(precedingRow, precedingLine)
+
+      # console.log "preceding", tokenizedPrecedingLine
+
+      # desiredIndentLevel += 1 if increaseIndentRegex?.testSync(precedingLine)
+      if increaseIndentRegex
+        desiredIndentLevel += @countRegex(increaseIndentRegex, precedingLine, tokenizedPrecedingLine)
+      # desiredIndentLevel -= 1 if decreaseIndentRegex?.testSync(precedingLine)
+      if decreaseIndentRegex
+        desiredIndentLevel -= @countRegex(decreaseIndentRegex, precedingLine, tokenizedPrecedingLine)
+      # we need to add back one if we already closed one scope on the previous line itself
+      if decreaseThisIndentRegex and @countRegex(decreaseThisIndentRegex, precedingLine, tokenizedPrecedingLine)
+        desiredIndentLevel += 1
 
     unless @buffer.isRowBlank(precedingRow)
-      desiredIndentLevel -= 1 if decreaseIndentRegex?.testSync(line)
+      # desiredIndentLevel -= 1 if decreaseThisIndentRegex?.testSync(line)
+      if decreaseThisIndentRegex and @countRegex(decreaseThisIndentRegex, line, tokenizedLine)
+        desiredIndentLevel -= 1
+      # desiredIndentLevel -= @countRegex(decreaseThisIndentRegex, line) if decreaseThisIndentRegex
 
+    # console.log("suggestedIndentForTokenizedLineAtBufferRow: rtv", desiredIndentLevel)
     Math.max(desiredIndentLevel, 0)
 
   # Calculate a minimum indent level for a range of lines excluding empty lines.
@@ -298,15 +316,30 @@ class LanguageMode
     indentLevel = @suggestedIndentForBufferRow(bufferRow, options)
     @editor.setIndentationForBufferRow(bufferRow, indentLevel, options)
 
+
+  # Count the number of occurence of regex in string, given its tokenized
+  # version, and ignoring any occurence that start inside a quoted string
+  countRegex: (regex, string, tokenized) ->
+    count = 0
+    m = regex.searchSync(string)
+    while (m)
+      quoted = false
+      if scopes = tokenized.tokenAtBufferColumn(m[0].start)?.scopes
+        quoted = scope for scope in scopes when scope.match '^string.quoted'
+      # console.log quoted
+      count += 1 unless quoted
+      m = regex.searchSync(string, m[0].start + 1)
+    count
+
   # Given a buffer row, this decreases the indentation.
   #
   # bufferRow - The row {Number}
   autoDecreaseIndentForBufferRow: (bufferRow) ->
     scopeDescriptor = @editor.scopeDescriptorForBufferPosition([bufferRow, 0])
-    return unless decreaseIndentRegex = @decreaseIndentRegexForScopeDescriptor(scopeDescriptor)
+    return unless decreaseThisIndentRegex = @decreaseThisIndentRegexForScopeDescriptor(scopeDescriptor)
 
     line = @buffer.lineForRow(bufferRow)
-    return unless decreaseIndentRegex.testSync(line)
+    return unless decreaseThisIndentRegex.testSync(line)
 
     currentIndentLevel = @editor.indentationForBufferRow(bufferRow)
     return if currentIndentLevel is 0
@@ -320,9 +353,11 @@ class LanguageMode
     if increaseIndentRegex = @increaseIndentRegexForScopeDescriptor(scopeDescriptor)
       desiredIndentLevel -= 1 unless increaseIndentRegex.testSync(precedingLine)
 
-    if decreaseNextIndentRegex = @decreaseNextIndentRegexForScopeDescriptor(scopeDescriptor)
-      desiredIndentLevel -= 1 if decreaseNextIndentRegex.testSync(precedingLine)
+    if decreaseIndentRegex = @decreaseIndentRegexForScopeDescriptor(scopeDescriptor)
+      desiredIndentLevel -= 1 if decreaseIndentRegex.testSync(precedingLine)
+      # desiredIndentLevel -= @countRegex(decreaseIndentRegex, precedingLine)
 
+    # console.log("autoDecreaseThisIndentForBufferRow: desiredIndentLevel", desiredIndentLevel)
     if desiredIndentLevel >= 0 and desiredIndentLevel < currentIndentLevel
       @editor.setIndentationForBufferRow(bufferRow, desiredIndentLevel)
 
@@ -330,14 +365,21 @@ class LanguageMode
     if pattern = @config.get(property, scope: scopeDescriptor)
       new OnigRegExp(pattern)
 
+  # when the previous line matches this pattern than increase indentation of the
+  # current line
   increaseIndentRegexForScopeDescriptor: (scopeDescriptor) ->
     @getRegexForProperty(scopeDescriptor, 'editor.increaseIndentPattern')
 
+  # when the *current* line matches this pattern than decrease indentation of
+  # the current line (this, e.g., puts closing brackets with nothing before them
+  # at the level of the opening statement, as in the KR style for C)
+  decreaseThisIndentRegexForScopeDescriptor: (scopeDescriptor) ->
+    @getRegexForProperty(scopeDescriptor, 'editor.decreaseThisIndentPattern')
+
+  # when the previous line matches this pattern than decrease indentation of the
+  # current line
   decreaseIndentRegexForScopeDescriptor: (scopeDescriptor) ->
     @getRegexForProperty(scopeDescriptor, 'editor.decreaseIndentPattern')
-
-  decreaseNextIndentRegexForScopeDescriptor: (scopeDescriptor) ->
-    @getRegexForProperty(scopeDescriptor, 'editor.decreaseNextIndentPattern')
 
   foldEndRegexForScopeDescriptor: (scopeDescriptor) ->
     @getRegexForProperty(scopeDescriptor, 'editor.foldEndPattern')


### PR DESCRIPTION
Previously the logic lacked handling of multiple matches of the
increase/decrease regexs, so things like the following javascript
would not be handled correctly (the last line would be indented).

``` js
if (test) {
  foo({a:1
  })};
var t = "this should be at indentation 0";
```

Fixed that.

Also revisited the logic regarding decreaseIndent and
decreaseNextIndent. It did not seem very logical that decreaseIndent
did _not_ correspond to increaseIndent: decreaseIndent regarded the
current line whereas increaseIndent regarded the next line (just like
decreaseNextIndent). For that reason I renamed decreaseIndent to
decreaseThisIndent and decreaseNextIndent to decreaseIndent. This way
we also avoid a whole lot of issues related to the concept of
decreaseNextIndent, because most of the language packages I looked at
have not yet adopted it but the semantics of decreaseIndent had
changed. So now the semantics of decreaseIndent is back to what it was
and decreaseThisIndent is the new concept.

Also now using the tokenized line to determine whether a in-/decrease
pattern appears within a quoted string (and ignoring it in that case),
rather than requiring regexes for checking whether or not the
occurrence is within a quoted string or not -- the examples I saw for
that were wrong, too (e.g., things like `/} [^"] /` are non-sense,
because things like `} var x = "hey"` are perfectly fine). One really
needs to reason about balanced quotation to get it right, and the
tokenizer already does that for us, so let's use it rather than
reinventing the wheel. The decrease/increase regexes can now be much
simpler in the language packages.
