### PR TITLE
Explicitly guard against decorating destroyed markers

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -1253,6 +1253,13 @@ describe "DisplayBuffer", ->
       decoration.destroy()
       expect(displayBuffer.decorationForId(decoration.id)).not.toBeDefined()
 
+    it "does not allow destroyed markers to be decorated", ->
+      marker.destroy()
+      expect(->
+        displayBuffer.decorateMarker(marker, {type: 'overlay', item: document.createElement('div')})
+      ).toThrow("Cannot decorate a destroyed marker")
+      expect(displayBuffer.getOverlayDecorations()).toEqual []
+
     describe "when a decoration is updated via Decoration::update()", ->
       it "emits an 'updated' event containing the new and old params", ->
         decoration.onDidChangeProperties updatedSpy = jasmine.createSpy()

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -812,6 +812,7 @@ class DisplayBuffer extends Model
     decorationsState
 
   decorateMarker: (marker, decorationParams) ->
+    throw new Error("Cannot decorate a destroyed marker") if marker.isDestroyed()
     marker = @getMarkerLayer(marker.layer.id).getMarker(marker.id)
     decoration = new Decoration(marker, this, decorationParams)
     @decorationsByMarkerId[marker.id] ?= []


### PR DESCRIPTION
Fixes #10014

/cc @steelbrain - It looks like the linter is passing markers that have been destroyed to `TextEditor::decorateMarker`. We had a hard time reproducing it, so I can't give you precise steps. It seems to happen when editing after closing split panes. When I reproduced it, I was undoing and redoing repeatedly, but I'm not sure if that's related.
