### PR TITLE
Stop babel from logging to stderr during compilation

### DIFF
--- a/spec/babel-spec.coffee
+++ b/spec/babel-spec.coffee
@@ -1,3 +1,8 @@
+# Users may have this environment variable set. Currently, it causes babel to
+# log to stderr, which causes errors on Windows.
+# See https://github.com/atom/electron/issues/2033
+process.env.DEBUG='*'
+
 path = require('path')
 temp = require('temp').track()
 CompileCache = require('../src/compile-cache')
@@ -34,3 +39,12 @@ describe "Babel transpiler support", ->
   describe "when a .js file does not start with 'use babel';", ->
     it "does not transpile it using babel", ->
       expect(-> require('./fixtures/babel/invalid.js')).toThrow()
+
+    it "does not try to log to stdout or stderr while parsing the file", ->
+      spyOn(process.stderr, 'write')
+      spyOn(process.stdout, 'write')
+
+      transpiled = require('./fixtures/babel/babel-double-quotes.js')
+
+      expect(process.stdout.write).not.toHaveBeenCalled()
+      expect(process.stderr.write).not.toHaveBeenCalled()

--- a/spec/babel-spec.coffee
+++ b/spec/babel-spec.coffee
@@ -1,4 +1,21 @@
+path = require('path')
+temp = require('temp').track()
+CompileCache = require('../src/compile-cache')
+
 describe "Babel transpiler support", ->
+  originalCacheDir = null
+
+  beforeEach ->
+    originalCacheDir = CompileCache.getCacheDirectory()
+    CompileCache.setCacheDirectory(temp.mkdirSync('compile-cache'))
+    for cacheKey in Object.keys(require.cache)
+      if cacheKey.startsWith(path.join(__dirname, 'fixtures', 'babel'))
+        console.log('deleting', cacheKey)
+        delete require.cache[cacheKey]
+
+  afterEach ->
+    CompileCache.setCacheDirectory(originalCacheDir)
+
   describe 'when a .js file starts with /** @babel */;', ->
     it "transpiles it using babel", ->
       transpiled = require('./fixtures/babel/babel-comment.js')

--- a/src/babel.js
+++ b/src/babel.js
@@ -42,6 +42,10 @@ exports.getCachePath = function (sourceCode) {
 exports.compile = function (sourceCode, filePath) {
   if (!babel) {
     babel = require('babel-core')
+    var Logger = require('babel-core/lib/transformation/file/logger')
+    var noop = function () {}
+    Logger.prototype.debug = noop
+    Logger.prototype.verbose = noop
   }
 
   var options = {filename: filePath}


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/10056
Refs https://github.com/atom-minimap/minimap/issues/426

This stops babel from logging to stderr in the case where the user has the `DEBUG` environment variable set to `*` or `babel`. Babel doesn't have an API (except for the env var) for disabling this logging, so I've monkey-patched its `Logger` class, and created a feature request for adding a programmatic API: https://phabricator.babeljs.io/T6955.
