### PR TITLE
This fixes ability to override default git provider

### DIFF
--- a/src/project.coffee
+++ b/src/project.coffee
@@ -289,7 +289,7 @@ class Project extends Model
       '^0.1.0',
       (provider) =>
         @repositoryProviders.unshift(provider)
-        @setPaths(@getPaths()) if null in @repositories
+        @setPaths(@getPaths())
         new Disposable =>
           @repositoryProviders.splice(@repositoryProviders.indexOf(provider), 1)
     )


### PR DESCRIPTION
Let's say, we have default git provider and packages for hg and git.
First of all, setPaths is being called earlier then consumer, that
means that default git provider will already be there.
Second, we are checking for @repositories.length when adding new
provider, but if default git provider is already there, we're in
trouble, because another git provider simply won't be initialized.
Third, if we'll leave that condition there and fix something else,
again, after consuming hg, we'll have setPaths called with default
git adapter :( This kinda complicates stuff on first load / plugin
enable-disable on fly, but I don't feel that this is a big issue.
