### PR TITLE
Change default path when opening files

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -637,8 +637,8 @@ class AtomApplication
         when 'folder' then 'Open Folder'
         else 'Open'
 
-    if process.platform is 'linux'
-      if projectPath = @lastFocusedWindow?.projectPath
-        openOptions.defaultPath = projectPath
+    # Attempt to set the default path on all platforms.
+    if projectPath = @getModel().getActivePane().getActiveItem().path
+      openOptions.defaultPath = projectPath
 
     dialog.showOpenDialog(parentWindow, openOptions, callback)


### PR DESCRIPTION
This is an attempt to use the active pane and active item to determine the default path when opening a file (on all platforms).

Note: Not tested yet. See #6762 for the discussion around this bug/feature.
