### PR TITLE
Fix 64-bit Windows builds

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -90,7 +90,8 @@ function bootstrap() {
   var electronVersion = require('../package.json').electronVersion;
   moduleInstallEnv.npm_config_target = electronVersion;
 
-  // Atom on Windows is always 32-bit currently.
+  // Force 32-bit modules on Windows.
+  // /cc https://github.com/atom/atom/issues/10450
   if (process.platform === 'win32') {
     moduleInstallEnv.npm_config_target_arch = 'ia32';
   }

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -89,6 +89,11 @@ function bootstrap() {
   // proper binaries.
   var electronVersion = require('../package.json').electronVersion;
   moduleInstallEnv.npm_config_target = electronVersion;
+
+  // Atom on Windows is always 32-bit currently.
+  if (process.platform === 'win32') {
+    moduleInstallEnv.npm_config_target_arch = 'ia32';
+  }
   var moduleInstallOptions = {env: moduleInstallEnv};
 
   if (process.argv.indexOf('--no-quiet') === -1) {

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -107,7 +107,7 @@ function bootstrap() {
 
   // apm ships with 32-bit node so make sure its native modules are compiled
   // for a 32-bit target architecture
-  if (process.platform === 'win32')
+  if (process.env.JANKY_SHA1 && process.platform === 'win32')
     apmInstallCommand += ' --arch=ia32';
 
   var commands = [


### PR DESCRIPTION
Fixes #10450.

It turned out to be a combination of a couple things: I accidentally broke it in the async-git branch, but we were also missing one 32-bit override.
