### PR TITLE
Handle broken submodules

### DIFF
--- a/src/git-repository-async.js
+++ b/src/git-repository-async.js
@@ -862,10 +862,9 @@ export default class GitRepositoryAsync {
         try {
           await repo.refreshStatus()
         } catch (e) {
-          // If we error trying to refresh, then it probably means the submodule
-          // isn't actually a submodule. Libgit2 will report anything listed in
-          // .gitmodules as a submodule, but that's not necessarily accurate. So
-          // get rid of the submodule entry.
+          // libgit2 will sometimes report submodules that aren't actually valid
+          // (https://github.com/libgit2/libgit2/issues/3580). So check the
+          // validity of the submodules by removing any that fail.
           repo.destroy()
           delete this.submodules[name]
         }

--- a/src/git-repository-async.js
+++ b/src/git-repository-async.js
@@ -37,8 +37,11 @@ export default class GitRepositoryAsync {
     this.emitter = new Emitter()
     this.subscriptions = new CompositeDisposable()
     this.pathStatusCache = {}
-    // NB: This needs to happen before the following .openRepository call.
+
+    // NB: These needs to happen before the following .openRepository call.
     this.openedPath = _path
+    this._openExactPath = options.openExactPath || false
+
     this.repoPromise = this.openRepository()
     this.isCaseInsensitive = fs.isCaseInsensitive()
     this.upstream = {}
@@ -848,7 +851,7 @@ export default class GitRepositoryAsync {
 
       const submodule = await Git.Submodule.lookup(repo, name)
       const absolutePath = path.join(repo.workdir(), submodule.path())
-      const submoduleRepo = GitRepositoryAsync.open(absolutePath)
+      const submoduleRepo = GitRepositoryAsync.open(absolutePath, {openExactPath: true, refreshOnWindowFocus: false})
       this.submodules[name] = submoduleRepo
     }
 
@@ -977,7 +980,11 @@ export default class GitRepositoryAsync {
   //
   // Returns the new {NodeGit.Repository}.
   openRepository () {
-    return Git.Repository.openExt(this.openedPath, 0, '')
+    if (this._openExactPath) {
+      return Git.Repository.open(this.openedPath)
+    } else {
+      return Git.Repository.openExt(this.openedPath, 0, '')
+    }
   }
 
   // Section: Private


### PR DESCRIPTION
Work around https://github.com/libgit2/libgit2/issues/3580.

Otherwise, when we run into one of these phantom submodules we’d:
1. Try to .openExt it.
2. It wouldn’t open the phantom submodule, but instead move up and open the parent repository.
3. Refresh the parent repository thinking it was the submodule.
4. Refresh its submodules.
5. Find the phantom submodule again.
6. Goto (1).
