### PR TITLE
Fix open dialog default behavior on Linux

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -213,6 +213,14 @@ class AtomEnvironment extends Model
 
     checkPortableHomeWritable()
 
+    setupOpenDefaultPath = ->
+      if process.platform is 'linux'
+        ipc.on 'get-open-default-path', (responseChannel) ->
+          filename = atom.workspace.getActiveTextEditor()?.getDirectoryPath()
+          ipc.send responseChannel, filename
+
+    setupOpenDefaultPath()
+
   setConfigSchema: ->
     @config.setSchema null, {type: 'object', properties: _.clone(require('./config-schema'))}
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -637,7 +637,8 @@ class AtomApplication
         when 'folder' then 'Open Folder'
         else 'Open'
 
-    # On Linux
+    # On Linux get a default directory from the renderer process, based on the
+    # active text editor. Otherwise fall back the the user's home directory.
     if process.platform is 'linux'
       if webContents = @lastFocusedWindow?.browserWindow?.webContents
         responseChannel = 'get-open-default-path-response'


### PR DESCRIPTION
Open dialog now defaults to the same directory as the open file, or the user's home directory if there is no file active (such as when viewing the Settings page). This is the convention for gedit and other text editors on Linux. Because of the render/browser process split, this requires async messages to get the path over. The alternative is passing this data when calling application:open, but this requires more extensive changes.

Note: this change is only for linux but it could easily be expanded to other platforms assuming the dialog module works the same way.

Fixes at least #6762
