### PR TITLE
Require package's main module in legacy activateConfig method

### DIFF
--- a/src/package.coffee
+++ b/src/package.coffee
@@ -158,7 +158,9 @@ class Package
     false
 
   # TODO: Remove. Settings view calls this method currently.
-  activateConfig: -> @registerConfigSchemaFromMainModule()
+  activateConfig: ->
+    @requireMainModule()
+    @registerConfigSchemaFromMainModule()
 
   activateStylesheets: ->
     return if @stylesheetsActivated


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/10426

I haven't added tests for this because I want to remove this method somewhat soon (once https://github.com/atom/atom/issues/9974 is finished and we deprecate specifying config schemas in package's main modules).
