### PR TITLE
Add TextEditor::{onWill,onDid}MutateSelectedText

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2984,6 +2984,22 @@ describe "TextEditor", ->
           expect(willInsertSpy).toHaveBeenCalled()
           expect(didInsertSpy).not.toHaveBeenCalled()
 
+      describe "when there are ::onWillMutateSelectedText and ::onDidMutateSelectedText observers", ->
+        it "notifies the observers just once before and after mutating the selections", ->
+          events = []
+
+          editor.onWillMutateSelectedText -> events.push("will-mutate")
+          editor.onDidMutateSelectedText -> events.push("did-mutate")
+
+          editor.setSelectedBufferRanges([
+            [[0, 0], [0, 0]]
+            [[1, 0], [1, 0]]
+            [[4, 0], [4, 0]]
+          ])
+          editor.insertText("hey")
+
+          expect(events).toEqual(["will-mutate", "did-mutate"])
+
       describe "when the undo option is set to 'skip'", ->
         beforeEach ->
           editor.setSelectedBufferRange([[1, 2], [1, 2]])
@@ -3336,6 +3352,22 @@ describe "TextEditor", ->
           editor.setSelectedBufferRanges([[[0, 4], [0, 13]], [[0, 16], [0, 24]]])
           editor.backspace()
           expect(editor.lineTextForBufferRow(0)).toBe 'var  =  () {'
+
+      describe "when there are ::onWillMutateSelectedText and ::onDidMutateSelectedText observers", ->
+        it "notifies the observers just once before and after mutating the selections", ->
+          events = []
+
+          editor.onWillMutateSelectedText -> events.push("will-mutate")
+          editor.onDidMutateSelectedText -> events.push("did-mutate")
+
+          editor.setSelectedBufferRanges([
+            [[0, 0], [0, 0]]
+            [[1, 0], [1, 0]]
+            [[4, 0], [4, 0]]
+          ])
+          editor.backspace()
+
+          expect(events).toEqual(["will-mutate", "did-mutate"])
 
     describe ".deleteToPreviousWordBoundary()", ->
       describe "when no text is selected", ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -341,6 +341,12 @@ class TextEditor extends Model
   onDidInsertText: (callback) ->
     @emitter.on 'did-insert-text', callback
 
+  onWillMutateSelectedText: (callback) ->
+    @emitter.on 'will-mutate-selected-text', callback
+
+  onDidMutateSelectedText: (callback) ->
+    @emitter.on 'did-mutate-selected-text', callback
+
   # Essential: Invoke the given callback after the buffer is saved to disk.
   #
   # * `callback` {Function} to be called after the buffer is saved.
@@ -883,9 +889,11 @@ class TextEditor extends Model
   #      argument will be a {Selection} and the second argument will be the
   #      {Number} index of that selection.
   mutateSelectedText: (fn, groupingInterval=0) ->
+    @emitter.emit 'will-mutate-selected-text'
     @mergeIntersectingSelections =>
       @transact groupingInterval, =>
         fn(selection, index) for selection, index in @getSelectionsOrderedByBufferPosition()
+    @emitter.emit 'did-mutate-selected-text'
 
   # Move lines intersecting the most recent selection or multiple selections
   # up by one row in screen coordinates.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -890,10 +890,11 @@ class TextEditor extends Model
   #      {Number} index of that selection.
   mutateSelectedText: (fn, groupingInterval=0) ->
     @emitter.emit 'will-mutate-selected-text'
-    @mergeIntersectingSelections =>
+    result = @mergeIntersectingSelections =>
       @transact groupingInterval, =>
         fn(selection, index) for selection, index in @getSelectionsOrderedByBufferPosition()
     @emitter.emit 'did-mutate-selected-text'
+    result
 
   # Move lines intersecting the most recent selection or multiple selections
   # up by one row in screen coordinates.


### PR DESCRIPTION
Before this PR, we could catch edits to the buffer (or the editor) only on a per-change basis (e.g. `onDidChange` or `onDidInsertText`), thus preventing packages to schedule work at the beginning or at the end of a multi-cursor change.

This PR adds `onWillMutateSelectedText` and `onDidMutateSelectedText` on `TextEditor`, which will respectively trigger at the beginning and at the end of a `mutateSelectedText` operation.

@nathansobo @maxbrunsfeld @kuychaco: although similar, these new APIs serve a different purpose than the `TextBuffer.prototype.setTextsInBufferRanges` API (and the possible associated events) we have talked about, as they're meant to catch only user-triggered changes to the editor and they're much higher level, as they won't provide information about the changes (adding such information would indeed be tricky, as selections could do an arbitrary number of changes to the underlying buffer, and it would require a much more invasive refactoring).

On the other hand, adding these is super cheap and provides an entry point for coarse-grained batching operations. What do you think? I am planning to use them in autocomplete-plus (a PR is on the way to that repo which will show how it'd work).
