### PR TITLE
Properly restore initialPaths so project paths are not loaded as files

### DIFF
--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -19,7 +19,7 @@ class AtomWindow
   isSpec: null
 
   constructor: (settings={}) ->
-    {@resourcePath, pathToOpen, locationsToOpen, @isSpec, @headless, @safeMode, @devMode} = settings
+    {@resourcePath, initialPaths, pathToOpen, locationsToOpen, @isSpec, @headless, @safeMode, @devMode} = settings
     locationsToOpen ?= [{pathToOpen}] if pathToOpen
     locationsToOpen ?= []
 
@@ -49,20 +49,13 @@ class AtomWindow
     loadSettings.devMode ?= false
     loadSettings.safeMode ?= false
     loadSettings.atomHome = process.env.ATOM_HOME
+    loadSettings.initialPaths ?= []
+    loadSettings.initialPaths.sort()
 
     # Only send to the first non-spec window created
     if @constructor.includeShellLoadTime and not @isSpec
       @constructor.includeShellLoadTime = false
       loadSettings.shellLoadTime ?= Date.now() - global.shellStartTime
-
-    loadSettings.initialPaths =
-      for {pathToOpen} in locationsToOpen when pathToOpen
-        if fs.statSyncNoException(pathToOpen).isFile?()
-          path.dirname(pathToOpen)
-        else
-          pathToOpen
-
-    loadSettings.initialPaths.sort()
 
     @browserWindow.loadSettings = loadSettings
     @browserWindow.once 'window:loaded', =>


### PR DESCRIPTION
If project folders no longer exist or are not mounted, then Atom would open them as buffers, which are empty because the corresponding file did not exist (and if it did, it would be a directory, which would make little sense). This threads the right state through the startup sequence so that `initialPaths`, which actually are project roots, are restored correctly.
