### PR TITLE
Pin escope to ~3.3.0 to prevent 3.4.0 use

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -11,6 +11,7 @@
     "aws-sdk": "^2.2.18",
     "babel-eslint": "^5.0.0-beta6",
     "donna": "^1.0.13",
+    "escope": "~3.3.0",
     "formidable": "~1.0.14",
     "fs-plus": "2.x",
     "github-releases": "~0.3.1",


### PR DESCRIPTION
See https://github.com/estools/escope/issues/99 for more details

Seeing CI failures like this currently:

```
Running "standard:src" (standard) task
TypeError: Cannot read property 'visitClass' of undefined
  at monkeypatch (C:\projects\atom\build\node_modules\babel-eslint\index.js:220:40)
  at Object.exports.parse (C:\projects\atom\build\node_modules\babel-eslint\index.js:362:5)
  at parse (C:\projects\atom\build\node_modules\standard\node_modules\standard-engine\node_modules\eslint\lib\eslint.js:528:27)
  at EventEmitter.module.exports.api.verify (C:\projects\atom\build\node_modules\standard\node_modules\standard-engine\node_modules\eslint\lib\eslint.js:652:19)
  at processText (C:\projects\atom\build\node_modules\standard\node_modules\standard-engine\node_modules\eslint\lib\cli-engine.js:225:27)
  at processFile (C:\projects\atom\build\node_modules\standard\node_modules\standard-engine\node_modules\eslint\lib\cli-engine.js:262:18)
  at executeOnFile (C:\projects\atom\build\node_modules\standard\node_modules\standard-engine\node_modules\eslint\lib\cli-engine.js:609:23)
  at Array.forEach (native)
  at CLIEngine.executeOnFiles (C:\projects\atom\build\node_modules\standard\node_modules\standard-engine\node_modules\eslint\lib\cli-engine.js:632:56)
  at C:\projects\atom\build\node_modules\standard\node_modules\standard-engine\index.js:105:56
  at zalgoSafe (C:\projects\atom\build\node_modules\standard\node_modules\standard-engine\node_modules\dezalgo\dezalgo.js:20:10)
  at C:\projects\atom\build\node_modules\standard\node_modules\standard-engine\node_modules\deglob\index.js:64:12
  at end (C:\projects\atom\build\node_modules\standard\node_modules\standard-engine\node_modules\deglob\node_modules\run-parallel\index.js:16:15)
  at done (C:\projects\atom\build\node_modules\standard\node_modules\standard-engine\node_modules\deglob\node_modules\run-parallel\index.js:20:10)
  at each (C:\projects\atom\build\node_modules\standard\node_modules\standard-engine\node_modules\deglob\node_modules\run-parallel\index.js:26:7)
  at f (C:\projects\atom\build\node_modules\glob\node_modules\once\once.js:17:25)
  at Glob.<anonymous> (C:\projects\atom\build\node_modules\glob\glob.js:133:7)
  at Glob.emit (events.js:95:17)
  at Glob._finish (C:\projects\atom\build\node_modules\glob\glob.js:172:8)
  at done (C:\projects\atom\build\node_modules\glob\glob.js:159:12)
  at Glob._processSimple2 (C:\projects\atom\build\node_modules\glob\glob.js:670:3)
  at C:\projects\atom\build\node_modules\glob\glob.js:640:10
  at Glob._stat2 (C:\projects\atom\build\node_modules\glob\glob.js:751:10)
  at lstatcb_ (C:\projects\atom\build\node_modules\glob\glob.js:728:12)
  at RES (C:\projects\atom\build\node_modules\glob\node_modules\inflight\inflight.js:23:14)
  at f (C:\projects\atom\build\node_modules\glob\node_modules\once\once.js:17:25)
  at Object.oncomplete (fs.js:108:15)
```
