### PR TITLE
Only use electron version in fingerprint

### DIFF
--- a/script/utils/fingerprint.js
+++ b/script/utils/fingerprint.js
@@ -7,7 +7,11 @@ var fingerprintPath = path.resolve(__dirname, '..', '..', 'node_modules', '.atom
 module.exports = {
   fingerprint: function () {
     var packageJson = fs.readFileSync(path.resolve(__dirname, '..', '..', 'package.json'))
-    var body = packageJson.toString() + process.platform + process.version
+
+    //Include the electron minor version in the fingerprint since that changing requires a re-install
+    var electronVersion = JSON.parse(packageJson).electronVersion.replace(/\.\d+$/, '')
+
+    var body = electronVersion + process.platform + process.version
     return crypto.createHash('sha1').update(body).digest('hex')
   },
 


### PR DESCRIPTION
Previously the CI fingerprint used a SHA-1 of the entire `package.json` contents to determine when to clear the `node_modules` folder.

This would cause lots of clearings of that folder on CI since `master`, `beta`, and `stable` branches all have different `version` values that can change often.

Now only the `electronVersion` value is used in the fingerprint meaning that `node_modules` will only be cleared when the minor version of Electron changes which is why I believe this clearing was originally added before the fingerprint check was incorporated.

/cc @thedaniel @maxbrunsfeld 
