### PR TITLE
Reuse Less cache across builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ script: script/cibuild
 cache:
   directories:
     - node_modules
+    - $HOME/.atom/compile-cache
 
 notifications:
   email:

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -122,7 +122,7 @@ module.exports = (grunt) ->
 
   prebuildLessConfig =
     options:
-      cachePath: path.join(homeDir, '.atom', 'compile-cache', 'prebuild-less')
+      cachePath: path.join(homeDir, '.atom', 'compile-cache', 'prebuild-less', require('less-cache/package.json').version)
     src: [
       'static/**/*.less'
     ]

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -121,6 +121,8 @@ module.exports = (grunt) ->
       ext: '.css'
 
   prebuildLessConfig =
+    options:
+      cachePath: path.join(homeDir, '.atom', 'compile-cache', 'prebuild-less')
     src: [
       'static/**/*.less'
     ]

--- a/build/tasks/prebuild-less-task.coffee
+++ b/build/tasks/prebuild-less-task.coffee
@@ -35,39 +35,27 @@ module.exports = (grunt) ->
   grunt.registerMultiTask 'prebuild-less', 'Prebuild cached of compiled Less files', ->
     compileBootstrap()
 
-    prebuiltConfigurations = [
-      ['atom-dark-ui', 'atom-dark-syntax']
-      ['atom-dark-ui', 'atom-light-syntax']
-      ['atom-dark-ui', 'one-dark-syntax']
-      ['atom-dark-ui', 'one-light-syntax']
-      ['atom-dark-ui', 'solarized-dark-syntax']
-      ['atom-dark-ui', 'base16-tomorrow-dark-theme']
-      ['atom-dark-ui', 'base16-tomorrow-light-theme']
-
-      ['atom-light-ui', 'atom-light-syntax']
-      ['atom-light-ui', 'atom-dark-syntax']
-      ['atom-light-ui', 'one-dark-syntax']
-      ['atom-light-ui', 'one-light-syntax']
-      ['atom-light-ui', 'solarized-dark-syntax']
-      ['atom-light-ui', 'base16-tomorrow-dark-theme']
-      ['atom-light-ui', 'base16-tomorrow-light-theme']
-
-      ['one-dark-ui', 'one-dark-syntax']
-      ['one-dark-ui', 'one-light-syntax']
-      ['one-dark-ui', 'atom-dark-syntax']
-      ['one-dark-ui', 'atom-light-syntax']
-      ['one-dark-ui', 'solarized-dark-syntax']
-      ['one-dark-ui', 'base16-tomorrow-dark-theme']
-      ['one-dark-ui', 'base16-tomorrow-light-theme']
-
-      ['one-light-ui', 'one-light-syntax']
-      ['one-light-ui', 'one-dark-syntax']
-      ['one-light-ui', 'atom-light-syntax']
-      ['one-light-ui', 'atom-dark-syntax']
-      ['one-light-ui', 'solarized-dark-syntax']
-      ['one-light-ui', 'base16-tomorrow-dark-theme']
-      ['one-light-ui', 'base16-tomorrow-light-theme']
+    uiThemes = [
+      'atom-dark-ui'
+      'atom-light-ui'
+      'one-dark-ui'
+      'one-light-ui'
     ]
+
+    syntaxThemes = [
+      'atom-dark-syntax'
+      'atom-light-syntax'
+      'one-dark-syntax'
+      'one-light-syntax'
+      'solarized-dark-syntax'
+      'base16-tomorrow-dark-theme'
+      'base16-tomorrow-light-theme'
+    ]
+
+    prebuiltConfigurations = []
+    uiThemes.forEach (uiTheme) ->
+      syntaxThemes.forEach (syntaxTheme) ->
+        prebuiltConfigurations.push([uiTheme, syntaxTheme])
 
     directory = path.join(grunt.config.get('atom.appDir'), 'less-compile-cache')
 

--- a/build/tasks/prebuild-less-task.coffee
+++ b/build/tasks/prebuild-less-task.coffee
@@ -5,6 +5,8 @@ LessCache = require 'less-cache'
 
 module.exports = (grunt) ->
   {rm} = require('./task-helpers')(grunt)
+  cacheMisses = 0
+  cacheHits = 0
 
   compileBootstrap = ->
     appDir = grunt.config.get('atom.appDir')
@@ -19,6 +21,8 @@ module.exports = (grunt) ->
     grunt.file.write(bootstrapCssPath, bootstrapCss)
     rm(bootstrapLessPath)
     rm(path.join(appDir, 'node_modules', 'bootstrap', 'less'))
+    cacheMisses += lessCache.stats.misses
+    cacheHits += lessCache.stats.hits
 
   importFallbackVariables = (lessFilePath) ->
     if lessFilePath.indexOf('static') is 0
@@ -104,3 +108,8 @@ module.exports = (grunt) ->
       for file in themeMains
         grunt.verbose.writeln("File #{file.cyan} created in cache.")
         cssForFile(file)
+
+      cacheMisses += lessCache.stats.misses
+      cacheHits += lessCache.stats.hits
+
+    grunt.log.ok(cacheMisses + ' Less files compiled, ' + cacheHits + ' files reused')

--- a/build/tasks/prebuild-less-task.coffee
+++ b/build/tasks/prebuild-less-task.coffee
@@ -15,6 +15,8 @@ module.exports = (grunt) ->
 
     lessCache = new LessCache
       cacheDir: temp.mkdirSync('atom-less-cache')
+      fallbackDir: grunt.config.get('prebuild-less.options.cachePath')
+      syncCaches: true
       resourcePath: path.resolve('.')
 
     bootstrapCss = lessCache.readFileSync(bootstrapLessPath)
@@ -88,6 +90,8 @@ module.exports = (grunt) ->
       grunt.verbose.writeln("Building Less cache for #{configuration.join(', ').yellow}")
       lessCache = new LessCache
         cacheDir: directory
+        fallbackDir: grunt.config.get('prebuild-less.options.cachePath')
+        syncCaches: true
         resourcePath: path.resolve('.')
         importPaths: importPaths
 
@@ -112,4 +116,4 @@ module.exports = (grunt) ->
       cacheMisses += lessCache.stats.misses
       cacheHits += lessCache.stats.hits
 
-    grunt.log.ok(cacheMisses + ' Less files compiled, ' + cacheHits + ' files reused')
+    grunt.log.ok("#{cacheMisses} files compiled, #{cacheHits} files reused")

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jasmine-tagged": "^1.1.4",
     "jquery": "2.1.4",
     "key-path-helpers": "^0.4.0",
-    "less-cache": "0.22",
+    "less-cache": "0.23",
     "line-top-index": "0.2.0",
     "marked": "^0.3.4",
     "nodegit": "0.9.0",


### PR DESCRIPTION
Previously each build recompiled all `.less` files for all the shipped themes so that the first Atom launch required no Less compiles.

This pull requests adds a cache in `~/.atom/compile-cache/prebuild-less` so that only changed files need to be recompiled across builds.

This should save around 30-60 seconds when no Less changes are made between builds and it will be incremental compiles whenever a file does change.
### Before (first compile)

```
prebuild-less:src    55.1s
```
### After (fully cached)

```
prebuild-less:src    1.5s
```

/cc @iolsen 

Refs https://github.com/atom/less-cache/pull/9
