### PR TITLE
Default build directory to out/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ debug.log
 docs/output
 docs/includes
 spec/fixtures/evil-files/
+out

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ debug.log
 /tags
 /atom-shell/
 /electron/
+/out/
 docs/output
 docs/includes
 spec/fixtures/evil-files/
-out

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -36,7 +36,7 @@ module.exports = (grunt) ->
   # Options
   installDir = grunt.option('install-dir')
   buildDir = grunt.option('build-dir')
-  buildDir ?= path.join(os.tmpdir(), 'atom-build')
+  buildDir ?= 'out'
   buildDir = path.resolve(buildDir)
 
   channel = grunt.option('channel')

--- a/script/clean
+++ b/script/clean
@@ -21,6 +21,7 @@ var commands = [
   [__dirname, '..', 'apm', 'node_modules'],
   [__dirname, '..', 'atom-shell'],
   [__dirname, '..', 'electron'],
+  [__dirname, '..', 'out'],
   [home, '.atom', '.node-gyp'],
   [home, '.atom', 'storage'],
   [home, '.atom', '.apm'],


### PR DESCRIPTION
I'm struggling to remember why Atom originally built to a temp folder but this pull request changes the default build directory to be inside the repository at `out/` instead of `$TMPDIR/atom-build`.

This should make it easier to access the build once it completes when you are building but not installing since you'll be able to just do `open out/Atom.app` on Mac or `.\out\Atom\atom.exe` on Windows.

The reason I am making this change now is that AppVeyor's artifact upload system requires your artifacts be inside your project folder which got me thinking why Atom didn't follow that pattern like many other projects do like Node, Electron, etc.

/cc @atom/feedback 
