### PR TITLE
Only add local files to the recent documents, not URLs

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -471,6 +471,27 @@ describe "Workspace", ->
           workspace.open("bar://baz").then (item) ->
             expect(item).toEqual {bar: "bar://baz"}
 
+    it "adds the file to the application's recent documents list", ->
+      spyOn(atom.applicationDelegate, 'addRecentDocument')
+
+      waitsForPromise ->
+        workspace.open()
+
+      runs ->
+        expect(atom.applicationDelegate.addRecentDocument).not.toHaveBeenCalled()
+
+      waitsForPromise ->
+        workspace.open('something://a/url')
+
+      runs ->
+        expect(atom.applicationDelegate.addRecentDocument).not.toHaveBeenCalled()
+
+      waitsForPromise ->
+        workspace.open(__filename)
+
+      runs ->
+        expect(atom.applicationDelegate.addRecentDocument).toHaveBeenCalledWith(__filename)
+
     it "notifies ::onDidAddTextEditor observers", ->
       absolutePath = require.resolve('./fixtures/dir/a')
       newEditorHandler = jasmine.createSpy('newEditorHandler')

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -885,8 +885,6 @@ class AtomEnvironment extends Model
         else
           @project.addPath(pathToOpen)
 
-      @applicationDelegate.addRecentDocument(pathToOpen)
-
       unless fs.isDirectorySync(pathToOpen)
         @workspace?.open(pathToOpen, {initialLine, initialColumn})
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -1,4 +1,5 @@
 _ = require 'underscore-plus'
+url = require 'url'
 path = require 'path'
 {join} = path
 {Emitter, Disposable, CompositeDisposable} = require 'event-kit'
@@ -408,6 +409,11 @@ class Workspace extends Model
     searchAllPanes = options.searchAllPanes
     split = options.split
     uri = @project.resolvePath(uri)
+
+    # Avoid adding URLs as recent documents to work-around this Spotlight crash:
+    # https://github.com/atom/atom/issues/10071
+    if uri? and not url.parse(uri).protocol?
+      @applicationDelegate.addRecentDocument(uri)
 
     pane = @paneContainer.paneForURI(uri) if searchAllPanes
     pane ?= switch split


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/10071

Also, add them in `Workspace::open` and not `AtomEnvironment::openLocations`, so that files opened in an existing window will also be added to the list.

/cc @atom/core
