### PR TITLE
Add Workspace.setActivePaneItem API

### DIFF
--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -611,6 +611,13 @@ class Workspace extends Model
   getActivePaneItem: ->
     @paneContainer.getActivePaneItem()
 
+  # Essential: Activates the pane containing `item` and activates `item`.
+  #
+  # * `item` Pane item to set as active.
+  setActivePaneItem: (item) ->
+    pane = @paneContainer.paneForItem(item)
+    pane?.activateItem(item)
+
   # Essential: Get all text editors in the workspace.
   #
   # Returns an {Array} of {TextEditor}s.


### PR DESCRIPTION
Applies to https://github.com/atom/atom/issues/5344

This is the missing API piece that will allow anyone to create packages for any tab order they wish to have: left-to-right, MRU, LRU, or something we haven't thought of yet.

Tests still needed.
