### PR TITLE
Copy apm.cmd to the build directory when building

### DIFF
--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -178,6 +178,7 @@ module.exports = (grunt) ->
       cp path.join('resources', 'win', 'atom.cmd'), path.join(shellAppDir, 'resources', 'cli', 'atom.cmd')
       cp path.join('resources', 'win', 'atom.sh'), path.join(shellAppDir, 'resources', 'cli', 'atom.sh')
       cp path.join('resources', 'win', 'atom.js'), path.join(shellAppDir, 'resources', 'cli', 'atom.js')
+      cp path.join('resources', 'win', 'apm.cmd'), path.join(shellAppDir, 'resources', 'cli', 'apm.cmd')
       cp path.join('resources', 'win', 'apm.sh'), path.join(shellAppDir, 'resources', 'cli', 'apm.sh')
 
     if process.platform is 'linux'


### PR DESCRIPTION
In #9585 I added `apm.cmd`, but forgot to copy it over when building...:weary:.

Thanks to @PaulAik for asking why `apm.cmd` wasn't available!
