### PR TITLE
Add --build-dir example in custom installs documentation

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -88,16 +88,16 @@ If you have problems with permissions don't forget to prefix with `sudo`
 
 ## Advanced Options
 
-### Custom install directory
-
-```sh
-sudo script/grunt install --install-dir /install/atom/here
-```
-
 ### Custom build directory
 
 ```sh
 script/build --build-dir /build/atom/here
+```
+
+### Custom install directory
+
+```sh
+sudo script/grunt install --build-dir /build/atom/here --install-dir /install/atom/here
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
If atom was built in a custom directory, a custom install will require the use of `--build-dir`.
