### PR TITLE
Automatically resize command-palette for small screens

### DIFF
--- a/src/panel-element.coffee
+++ b/src/panel-element.coffee
@@ -13,7 +13,22 @@ class PanelElement extends HTMLElement
     @classList.add(@model.getClassName().split(' ')...) if @model.getClassName()?
     @subscriptions.add @model.onDidChangeVisible(@visibleChanged.bind(this))
     @subscriptions.add @model.onDidDestroy(@destroyed.bind(this))
+    @subscriptions.add window.onresize = @updateModalSize
     this
+  
+  updateModalSize:=>
+    modalPanels = atom.views.getView(atom.workspace).panelContainers.modal.children
+    screenWidth = atom.getSize().width
+    fontSize = atom.config.get('editor.fontSize')
+    screenEM = screenWidth/fontSize
+    for a in modalPanels
+      if screenEM < 50
+        a.style.width = "#{screenEM}em"
+        marginLeftNew = screenEM/2
+        a.style.marginLeft = "-#{marginLeftNew}em"
+      else
+        a.style.width = "50em"
+        a.style.marginLeft = "-25em"
 
   getModel: ->
     @model ?= new Panel

--- a/src/panel-element.coffee
+++ b/src/panel-element.coffee
@@ -16,7 +16,7 @@ class PanelElement extends HTMLElement
     @subscriptions.add window.onresize = @updateModalSize
     this
   
-  updateModalSize:=>
+  updateModalSize: ->
     modalPanels = atom.views.getView(atom.workspace).panelContainers.modal.children
     screenWidth = atom.getSize().width
     fontSize = atom.config.get('editor.fontSize')


### PR DESCRIPTION
Fixes #10603 

Now command palette is automatically resized when global window size is very small. 
