### PR TITLE
Fix Javascript-related specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "keybinding-resolver": "0.33.0",
     "line-ending-selector": "0.3.0",
     "link": "0.31.0",
-    "markdown-preview": "0.157.1",
+    "markdown-preview": "0.157.2",
     "metrics": "0.53.1",
     "notifications": "0.62.1",
     "open-on-github": "0.41.0",

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -235,7 +235,7 @@ describe "TokenizedBuffer", ->
             buffer.setTextInRange([[0, 0], [2, 0]], "foo()\n7\n")
 
             expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[1]).toEqual(value: '(', scopes: ['source.js', 'meta.function-call.js', 'punctuation.definition.arguments.begin.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: '7', scopes: ['source.js', 'constant.numeric.js'])
+            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: '7', scopes: ['source.js', 'constant.numeric.decimal.js'])
             # line 2 is unchanged
             expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[2]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
 


### PR DESCRIPTION
These specs broke yesterday after Atom was updated to use `language-javascript@0.109.0`.  That version provided further control over numbers by splitting hex/octal/decimal numbers into different tokens.  Normal numbers are now `constant.numeric.decimal` instead of `constant.numeric`.

Will merge once specs are green.
