### PR TITLE
Only dump symbols on Mac OS X CI

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -295,7 +295,7 @@ module.exports = (grunt) ->
   ciTasks.push('download-electron-chromedriver')
   ciTasks.push('build')
   ciTasks.push('fingerprint')
-  ciTasks.push('dump-symbols') if process.platform isnt 'win32'
+  ciTasks.push('dump-symbols') if process.platform is 'darwin'
   ciTasks.push('set-version', 'check-licenses', 'lint', 'generate-asar')
   ciTasks.push('mkdeb') if process.platform is 'linux'
   ciTasks.push('codesign:exe') if process.platform is 'win32' and not process.env.CI


### PR DESCRIPTION
The symbols are only published for the Mac version so only generate them on Mac.
