### PR TITLE
Cache other node_modules folders on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ script: script/cibuild
 cache:
   directories:
     - node_modules
+    - build/node_modules
+    - apm/node_modules
     - $HOME/.atom/compile-cache
 
 notifications:


### PR DESCRIPTION
This pull request adds `apm/node_modules` and `build/node_modules` to the Travis cache to hopefully speed on bootstrap time on the Linux builds there.
