### PR TITLE
Ignore more native source files

### DIFF
--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -124,6 +124,7 @@ module.exports = (grunt) ->
     ignoredPaths.push "#{_.escapeRegExp(path.join('git-utils', 'src') + path.sep)}.*\\.(cc|h)*"
     ignoredPaths.push "#{_.escapeRegExp(path.join('nodegit', 'src') + path.sep)}.*\\.(cc|h)?"
     ignoredPaths.push "#{_.escapeRegExp(path.join('nodegit', 'generate') + path.sep)}.*\\.(cc|h)?"
+    ignoredPaths.push "#{_.escapeRegExp(path.join('nodegit', 'include') + path.sep)}.*\\.(cc|h)?"
     ignoredPaths.push "#{_.escapeRegExp(path.join('keytar', 'src') + path.sep)}.*\\.(cc|h)*"
     ignoredPaths.push "#{_.escapeRegExp(path.join('nslog', 'src') + path.sep)}.*\\.(cc|h)*"
     ignoredPaths.push "#{_.escapeRegExp(path.join('oniguruma', 'src') + path.sep)}.*\\.(cc|h)*"

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -120,6 +120,8 @@ module.exports = (grunt) ->
     # Ignore *.cc and *.h files from native modules
     ignoredPaths.push "#{_.escapeRegExp(path.join('ctags', 'src') + path.sep)}.*\\.(cc|h)*"
     ignoredPaths.push "#{_.escapeRegExp(path.join('git-utils', 'src') + path.sep)}.*\\.(cc|h)*"
+    ignoredPaths.push "#{_.escapeRegExp(path.join('nodegit', 'src') + path.sep)}.*\\.(cc|h)?"
+    ignoredPaths.push "#{_.escapeRegExp(path.join('nodegit', 'generate') + path.sep)}.*\\.(cc|h)?"
     ignoredPaths.push "#{_.escapeRegExp(path.join('keytar', 'src') + path.sep)}.*\\.(cc|h)*"
     ignoredPaths.push "#{_.escapeRegExp(path.join('nslog', 'src') + path.sep)}.*\\.(cc|h)*"
     ignoredPaths.push "#{_.escapeRegExp(path.join('oniguruma', 'src') + path.sep)}.*\\.(cc|h)*"

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -129,6 +129,8 @@ module.exports = (grunt) ->
     ignoredPaths.push "#{_.escapeRegExp(path.join('runas', 'src') + path.sep)}.*\\.(cc|h)*"
     ignoredPaths.push "#{_.escapeRegExp(path.join('scrollbar-style', 'src') + path.sep)}.*\\.(cc|h)*"
     ignoredPaths.push "#{_.escapeRegExp(path.join('spellchecker', 'src') + path.sep)}.*\\.(cc|h)*"
+    ignoredPaths.push "#{_.escapeRegExp(path.join('cached-run-in-this-context', 'src') + path.sep)}.*\\.(cc|h)?"
+    ignoredPaths.push "#{_.escapeRegExp(path.join('marker-index', 'src') + path.sep)}.*\\.(cc|h)?"
     ignoredPaths.push "#{_.escapeRegExp(path.join('keyboard-layout', 'src') + path.sep)}.*\\.(cc|h|mm)*"
 
     # Ignore build files

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -54,6 +54,7 @@ module.exports = (grunt) ->
     # so that it doesn't becomes larger than it needs to be.
     ignoredPaths = [
       path.join('git-utils', 'deps')
+      path.join('nodegit', 'vendor')
       path.join('oniguruma', 'deps')
       path.join('less', 'dist')
       path.join('bootstrap', 'docs')

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -55,6 +55,8 @@ module.exports = (grunt) ->
     ignoredPaths = [
       path.join('git-utils', 'deps')
       path.join('nodegit', 'vendor')
+      path.join('nodegit', 'node_modules', 'node-pre-gyp')
+      path.join('nodegit', 'node_modules', '.bin')
       path.join('oniguruma', 'deps')
       path.join('less', 'dist')
       path.join('bootstrap', 'docs')


### PR DESCRIPTION
Atom maintains a bunch of regexes of things to ignore when bundling the app to prevent bloat.

This pull request adds ignore patterns for the latest native modules added to the build; `nodegit`, `marker-index`, and `cached-run-in-this-context`. These patterns prevent `.c`, `.cc`, and `.h` files from being included in the built app.

This shrinks the `app.asar` overall size from `~151M` to `~105M` and the number of files in the bundle from `~18.5K` to `~14.1K`.  The bulk of the savings was from `nodegit` which was bundling all of the `openssl`, `libssh`, and `libgit2` native source code.

@iolsen and I were pairing today and we noticed this when running the `script/grunt output-build-filetypes` to display what types of files were bundled in the app.

/cc @joshaber @thedaniel :eyes:
