### PR TITLE
Don't cascade on reload

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -11,7 +11,7 @@ Model = require './model'
 WindowEventHandler = require './window-event-handler'
 StylesElement = require './styles-element'
 StorageFolder = require './storage-folder'
-{getWindowLoadSettings} = require './window-load-settings-helpers'
+{getWindowLoadSettings, setWindowLoadSettings} = require './window-load-settings-helpers'
 registerDefaultCommands = require './register-default-commands'
 
 DeserializerManager = require './deserializer-manager'
@@ -492,6 +492,8 @@ class AtomEnvironment extends Model
 
   # Extended: Reload the current window.
   reload: ->
+    @saveWindowDimensions()
+
     @applicationDelegate.restartWindow()
 
   # Extended: Returns a {Boolean} that is `true` if the current window is maximized.
@@ -779,6 +781,11 @@ class AtomEnvironment extends Model
     return unless @enablePersistence
 
     @blobStore.save()
+
+  saveWindowDimensions: ->
+    loadSettings = getWindowLoadSettings()
+    loadSettings['windowDimensions'] = @getWindowDimensions()
+    setWindowLoadSettings(loadSettings)
 
   saveStateSync: ->
     return unless @enablePersistence

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -606,7 +606,7 @@ class AtomEnvironment extends Model
     # The first time the window's loaded we want to use the default dimensions.
     # But after that, e.g., when the window's been reloaded, we want to use the
     # dimensions we've saved for it.
-    if !@isFirstLoad()
+    if not @isFirstLoad()
       dimensions = @state.windowDimensions
 
     unless @isValidDimensions(dimensions)

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -384,6 +384,8 @@ class AtomEnvironment extends Model
   inSpecMode: ->
     @specMode ?= @getLoadSettings().isSpec
 
+  # Returns a {Boolean} indicating whether this the first time the window's been
+  # loaded.
   isFirstLoad: ->
     @firstLoad ?= @getLoadSettings().firstLoad
 

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -49,6 +49,7 @@ class AtomWindow
     loadSettings.devMode ?= false
     loadSettings.safeMode ?= false
     loadSettings.atomHome = process.env.ATOM_HOME
+    loadSettings.firstLoad = true
 
     # Only send to the first non-spec window created
     if @constructor.includeShellLoadTime and not @isSpec

--- a/src/initialize-application-window.coffee
+++ b/src/initialize-application-window.coffee
@@ -23,6 +23,7 @@ module.exports = ({blobStore}) ->
     enablePersistence: true
   })
 
+  atom.loadStateSync()
   atom.displayWindow()
   atom.startEditorWindow()
 


### PR DESCRIPTION
Fixes #10648.

So this fix is a little fussy.
1. Ideally we’d simply update the window load settings with the window dimensions before we reload, so that the reloaded window has the same dimensions.
2. **But** any changes we make to the window load settings in our `beforeunload` handler aren’t reflected in the reload. (I suspect Chromium’s grabbing the location for reload before calling the handler?)
3. So the next best thing: we detect a reload before `beforeunload` is called and update the window load settings there. This worked for _most_ reloads but I wasn’t able to find a hook for reloads triggered by cmd-r with the dev tools focused. That inconsistency would have been super annoying, to me at least.
4. So instead we track whether this is the first time the window’s been loaded. If it is, we use the default dimensions. If it isn’t, we use the dimensions we’re already saving in state.

@atom/core I’m curious if I’ve totally overcomplicated this or missed anything obvious.
