### PR TITLE
Add link to article on glob patterns

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -12,7 +12,7 @@ module.exports =
         default: [".git", ".hg", ".svn", ".DS_Store", "._*", "Thumbs.db"]
         items:
           type: 'string'
-        description: 'List of string glob patterns. Files and directories matching these patterns will be ignored by some packages, such as the fuzzy finder and tree view. Individual packages might have additional config settings for ignoring names.'
+        description: 'List of [glob patterns](https://en.wikipedia.org/wiki/Glob_%28programming%29). Files and directories matching these patterns will be ignored by some packages, such as the fuzzy finder and tree view. Individual packages might have additional config settings for ignoring names.'
       excludeVcsIgnoredPaths:
         type: 'boolean'
         default: true


### PR DESCRIPTION
Ultimately we should add some stuff to the Flight Manual about file globs in various places in Atom. I just wanted to get something in place for now because of:

https://discuss.atom.io/t/tree-view-not-ignoring-ignored-names-names/25258
