### PR TITLE
Let packages define deserializers & view providers as main module methods

### DIFF
--- a/spec/fixtures/packages/package-with-deserializers/deserializer-1.js
+++ b/spec/fixtures/packages/package-with-deserializers/deserializer-1.js
@@ -1,6 +1,0 @@
-module.exports = function (state) {
-  return {
-    wasDeserializedBy: 'Deserializer1',
-    state: state
-  }
-}

--- a/spec/fixtures/packages/package-with-deserializers/deserializer-2.js
+++ b/spec/fixtures/packages/package-with-deserializers/deserializer-2.js
@@ -1,6 +1,0 @@
-module.exports = function (state) {
-  return {
-    wasDeserializedBy: 'Deserializer2',
-    state: state
-  }
-}

--- a/spec/fixtures/packages/package-with-deserializers/index.js
+++ b/spec/fixtures/packages/package-with-deserializers/index.js
@@ -1,3 +1,17 @@
 module.exports = {
-  activate: function() {}
+  activate () {},
+
+  deserializeMethod1 (state) {
+    return {
+      wasDeserializedBy: 'deserializeMethod1',
+      state: state
+    }
+  },
+
+  deserializeMethod2 (state) {
+    return {
+      wasDeserializedBy: 'deserializeMethod2',
+      state: state
+    }
+  }
 }

--- a/spec/fixtures/packages/package-with-deserializers/package.json
+++ b/spec/fixtures/packages/package-with-deserializers/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "./index",
   "deserializers": {
-    "Deserializer1": "./deserializer-1.js",
-    "Deserializer2": "./deserializer-2.js"
+    "Deserializer1": "deserializeMethod1",
+    "Deserializer2": "deserializeMethod2"
   }
 }

--- a/spec/fixtures/packages/package-with-view-providers/deserializer.js
+++ b/spec/fixtures/packages/package-with-view-providers/deserializer.js
@@ -1,3 +1,0 @@
-module.exports = function (state) {
-  return {state: state}
-}

--- a/spec/fixtures/packages/package-with-view-providers/index.js
+++ b/spec/fixtures/packages/package-with-view-providers/index.js
@@ -1,3 +1,25 @@
+'use strict'
+
 module.exports = {
-  activate: function() {}
+  activate () {},
+
+  theDeserializerMethod (state) {
+    return {state: state}
+  },
+
+  viewProviderMethod1 (model) {
+    if (model.worksWithViewProvider1) {
+      let element = document.createElement('div')
+      element.dataset['createdBy'] = 'view-provider-1'
+      return element
+    }
+  },
+
+  viewProviderMethod2 (model) {
+    if (model.worksWithViewProvider2) {
+      let element = document.createElement('div')
+      element.dataset['createdBy'] = 'view-provider-2'
+      return element
+    }
+  }
 }

--- a/spec/fixtures/packages/package-with-view-providers/package.json
+++ b/spec/fixtures/packages/package-with-view-providers/package.json
@@ -3,10 +3,10 @@
   "main": "./index",
   "version": "1.0.0",
   "deserializers": {
-    "DeserializerFromPackageWithViewProviders": "./deserializer"
+    "DeserializerFromPackageWithViewProviders": "theDeserializerMethod"
   },
   "viewProviders": [
-    "./view-provider-1",
-    "./view-provider-2"
+    "viewProviderMethod1",
+    "viewProviderMethod2"
   ]
 }

--- a/spec/fixtures/packages/package-with-view-providers/view-provider-1.js
+++ b/spec/fixtures/packages/package-with-view-providers/view-provider-1.js
@@ -1,9 +1,0 @@
-'use strict'
-
-module.exports = function (model) {
-  if (model.worksWithViewProvider1) {
-    let element = document.createElement('div')
-    element.dataset['createdBy'] = 'view-provider-1'
-    return element
-  }
-}

--- a/spec/fixtures/packages/package-with-view-providers/view-provider-2.js
+++ b/spec/fixtures/packages/package-with-view-providers/view-provider-2.js
@@ -1,9 +1,0 @@
-'use strict'
-
-module.exports = function (model) {
-  if (model.worksWithViewProvider2) {
-    let element = document.createElement('div')
-    element.dataset['createdBy'] = 'view-provider-2'
-    return element
-  }
-}

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -88,17 +88,15 @@ describe "PackageManager", ->
 
       state1 = {deserializer: 'Deserializer1', a: 'b'}
       expect(atom.deserializers.deserialize(state1)).toEqual {
-        wasDeserializedBy: 'Deserializer1'
+        wasDeserializedBy: 'deserializeMethod1'
         state: state1
       }
 
       state2 = {deserializer: 'Deserializer2', c: 'd'}
       expect(atom.deserializers.deserialize(state2)).toEqual {
-        wasDeserializedBy: 'Deserializer2'
+        wasDeserializedBy: 'deserializeMethod2'
         state: state2
       }
-
-      expect(pack.mainModule).toBeNull()
 
     describe "when there are view providers specified in the package's package.json", ->
       model1 = {worksWithViewProvider1: true}

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -291,9 +291,9 @@ class Package
 
   registerViewProviders: ->
     if @metadata.viewProviders? and not @registeredViewProviders
+      @requireMainModule()
       @metadata.viewProviders.forEach (methodName) =>
         @viewRegistry.addViewProvider (model) =>
-          @requireMainModule()
           @mainModule[methodName](model)
       @registeredViewProviders = true
 

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -84,7 +84,7 @@ class Package
         @loadKeymaps()
         @loadMenus()
         @loadStylesheets()
-        @loadDeserializers()
+        @registerDeserializerMethods()
         @configSchemaRegisteredOnLoad = @registerConfigSchemaFromMetadata()
         @settingsPromise = @loadSettings()
         if @shouldRequireMainModuleOnLoad() and not @mainModule?
@@ -277,24 +277,24 @@ class Package
     @stylesheets = @getStylesheetPaths().map (stylesheetPath) =>
       [stylesheetPath, @themeManager.loadStylesheet(stylesheetPath, true)]
 
-  loadDeserializers: ->
+  registerDeserializerMethods: ->
     if @metadata.deserializers?
-      for name, implementationPath of @metadata.deserializers
-        do =>
-          deserializePath = path.join(@path, implementationPath)
-          deserializeFunction = null
-          atom.deserializers.add
-            name: name,
-            deserialize: =>
-              @registerViewProviders()
-              deserializeFunction ?= require(deserializePath)
-              deserializeFunction.apply(this, arguments)
+      Object.keys(@metadata.deserializers).forEach (deserializerName) =>
+        methodName = @metadata.deserializers[deserializerName]
+        atom.deserializers.add
+          name: deserializerName,
+          deserialize: (state, atomEnvironment) =>
+            @registerViewProviders()
+            @requireMainModule()
+            @mainModule[methodName](state, atomEnvironment)
       return
 
   registerViewProviders: ->
     if @metadata.viewProviders? and not @registeredViewProviders
-      for implementationPath in @metadata.viewProviders
-        @viewRegistry.addViewProvider(require(path.join(@path, implementationPath)))
+      @metadata.viewProviders.forEach (methodName) =>
+        @viewRegistry.addViewProvider (model) =>
+          @requireMainModule()
+          @mainModule[methodName](model)
       @registeredViewProviders = true
 
   getStylesheetsPath: ->


### PR DESCRIPTION
This makes some further changes to the new `package.json`-based deserializer and view-provider APIs introduced in https://github.com/atom/atom/pull/9687. After updating some packages (see https://github.com/atom/atom/issues/9974) to use these new fields, I realized that it was somewhat awkward to specify deserializers and view providers in separate files from the packages's main module. I think it is better if these fields work similarly to `consumedServices` and `providedServices`, by specifying names of methods on the package's main module.
#### Example

`package.json`

``` json
{
  "name": "my-package",
  "main": "index",
  "deserializers": {
    "MyObject": "deserializeMyObject"
  },
  "viewProviders": [
    "buildMyObjectView"
  ]
}
```

`index.js`

``` js
const MyObject = require('./my-object')

module.exports = {
  activate () {
    // ...
  },

  deserializeMyObject (state) {
    return new MyObject(state)
  },

  buildMyObjectView (model) {
    if (model instanceof MyObject) {
      return new MyObjectView
    }
  }
}
```
#### Advantages
- This approach is more consistent with `consumedServices` and `providedServices`, which seem to be working well for a variety of use cases.
- Many packages currently maintain singleton instances of some view or model object, and keep a reference to it in their main module. This makes it easier for view providers and deserializers to create or update that singleton instance. The alternative would be for the instance to be stored as a global variable in the deserializer file, or in some third file that is required by both the main module and the deserializer.
- Similarly, this allows the deserializer to interact with any of the package's consumed or provided services with less boilerplate.
- Overall, I like the idea of the package's main module being the only file that needs global state, and all other files in the package exporting classes or functions.
#### Drawbacks
- The main module will be required earlier now, for packages that either 1) have view providers, or 2) have deserializers that are needed immediately. But _some_ code file would have to be required under these conditions regardless, so I think as long as the main module defers its requires effectively, it shouldn't make any difference in terms of load time.

/cc @atom/core
