### PR TITLE
Temporarily disable deserializers & viewProviders metadata fields

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -83,75 +83,6 @@ describe "PackageManager", ->
 
       expect(loadedPackage.name).toBe "package-with-main"
 
-    it "registers any deserializers specified in the package's package.json", ->
-      pack = atom.packages.loadPackage("package-with-deserializers")
-
-      state1 = {deserializer: 'Deserializer1', a: 'b'}
-      expect(atom.deserializers.deserialize(state1)).toEqual {
-        wasDeserializedBy: 'Deserializer1'
-        state: state1
-      }
-
-      state2 = {deserializer: 'Deserializer2', c: 'd'}
-      expect(atom.deserializers.deserialize(state2)).toEqual {
-        wasDeserializedBy: 'Deserializer2'
-        state: state2
-      }
-
-      expect(pack.mainModule).toBeNull()
-
-    describe "when there are view providers specified in the package's package.json", ->
-      model1 = {worksWithViewProvider1: true}
-      model2 = {worksWithViewProvider2: true}
-
-      afterEach ->
-        atom.packages.deactivatePackage('package-with-view-providers')
-        atom.packages.unloadPackage('package-with-view-providers')
-
-      it "does not load the view providers immediately", ->
-        pack = atom.packages.loadPackage("package-with-view-providers")
-        expect(pack.mainModule).toBeNull()
-
-        expect(-> atom.views.getView(model1)).toThrow()
-        expect(-> atom.views.getView(model2)).toThrow()
-
-      it "registers the view providers when the package is activated", ->
-        pack = atom.packages.loadPackage("package-with-view-providers")
-
-        waitsForPromise ->
-          atom.packages.activatePackage("package-with-view-providers").then ->
-            element1 = atom.views.getView(model1)
-            expect(element1 instanceof HTMLDivElement).toBe true
-            expect(element1.dataset.createdBy).toBe 'view-provider-1'
-
-            element2 = atom.views.getView(model2)
-            expect(element2 instanceof HTMLDivElement).toBe true
-            expect(element2.dataset.createdBy).toBe 'view-provider-2'
-
-      it "registers the view providers when any of the package's deserializers are used", ->
-        pack = atom.packages.loadPackage("package-with-view-providers")
-
-        spyOn(atom.views, 'addViewProvider').andCallThrough()
-        atom.deserializers.deserialize({
-          deserializer: 'DeserializerFromPackageWithViewProviders',
-          a: 'b'
-        })
-        expect(atom.views.addViewProvider.callCount).toBe 2
-
-        atom.deserializers.deserialize({
-          deserializer: 'DeserializerFromPackageWithViewProviders',
-          a: 'b'
-        })
-        expect(atom.views.addViewProvider.callCount).toBe 2
-
-        element1 = atom.views.getView(model1)
-        expect(element1 instanceof HTMLDivElement).toBe true
-        expect(element1.dataset.createdBy).toBe 'view-provider-1'
-
-        element2 = atom.views.getView(model2)
-        expect(element2 instanceof HTMLDivElement).toBe true
-        expect(element2.dataset.createdBy).toBe 'view-provider-2'
-
     it "registers the config schema in the package's metadata, if present", ->
       pack = atom.packages.loadPackage("package-with-json-config-schema")
       expect(atom.config.getSchema('package-with-json-config-schema')).toEqual {
@@ -179,15 +110,6 @@ describe "PackageManager", ->
     describe "when a package does not have deserializers, view providers or a config schema in its package.json", ->
       beforeEach ->
         mockLocalStorage()
-
-      it "defers loading the package's main module if the package previously used no Atom APIs when its main module was required", ->
-        pack1 = atom.packages.loadPackage('package-with-main')
-        expect(pack1.mainModule).toBeDefined()
-
-        atom.packages.unloadPackage('package-with-main')
-
-        pack2 = atom.packages.loadPackage('package-with-main')
-        expect(pack2.mainModule).toBeNull()
 
       it "does not defer loading the package's main module if the package previously used Atom APIs when its main module was required", ->
         pack1 = atom.packages.loadPackage('package-with-eval-time-api-calls')

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -84,7 +84,6 @@ class Package
         @loadKeymaps()
         @loadMenus()
         @loadStylesheets()
-        @loadDeserializers()
         @configSchemaRegisteredOnLoad = @registerConfigSchemaFromMetadata()
         @settingsPromise = @loadSettings()
         if @shouldRequireMainModuleOnLoad() and not @mainModule?
@@ -94,13 +93,7 @@ class Package
     this
 
   shouldRequireMainModuleOnLoad: ->
-    not (
-      @metadata.deserializers? or
-      @metadata.viewProviders? or
-      @metadata.configSchema? or
-      @activationShouldBeDeferred() or
-      localStorage.getItem(@getCanDeferMainModuleRequireStorageKey()) is 'true'
-    )
+    not @activationShouldBeDeferred()
 
   reset: ->
     @stylesheets = []
@@ -131,7 +124,6 @@ class Package
     try
       @requireMainModule() unless @mainModule?
       @configSchemaRegisteredOnActivate = @registerConfigSchemaFromMainModule()
-      @registerViewProviders()
       @activateStylesheets()
       if @mainModule? and not @mainActivated
         @mainModule.activateConfig?()


### PR DESCRIPTION
See https://github.com/atom/atom/pull/10764

After merging the above PR in master, I'd like to avoid waiting for v1.7.0 to be released before I can merge PRs that update packages to use the new deserializer and view-provider APIs. I can change the packages in a backwards-compatible way, but I need to temporarily remove the logic that I added in https://github.com/atom/atom/pull/9687 for handling the slightly-different API that I had introduced previously.

This should be pretty risk-free, since it just removes calls to some methods that I recently added. Once it goes :green_heart:, my intent is to merge it directly into stable and publish a new patch release, just to unblock continuing efforts to use the improved APIs.

/cc @nathansobo
