### PR TITLE
Upgrade autocomplete-plus to use new text-buffer API

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "service-hub": "^0.7.0",
     "source-map-support": "^0.3.2",
     "temp": "0.8.1",
-    "text-buffer": "8.2.1",
+    "text-buffer": "8.3.0",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",
     "yargs": "^3.23.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "autocomplete-atom-api": "0.10.0",
     "autocomplete-css": "0.11.0",
     "autocomplete-html": "0.7.2",
-    "autocomplete-plus": "2.25.0",
+    "autocomplete-plus": "2.27.1",
     "autocomplete-snippets": "1.10.0",
     "autoflow": "0.27.0",
     "autosave": "0.23.1",


### PR DESCRIPTION
Refs: https://github.com/atom/autocomplete-plus/pull/659

What's missing:
- [x] `apm publish -t v2.27.1` for autocomplete-plus (it's currently failing with `Application Error`)

@maxbrunsfeld: I noticed you published a new version of autocomplete-plus but didn't upgrade it on atom/atom. The new version I plan to publish will include your changes: are you okay with this? Is there anything you were waiting for before updating ac+?
