### PR TITLE
Fix TextEditorPresenter spec timeout.

### DIFF
--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -20,7 +20,6 @@ describe "TextEditorPresenter", ->
 
       buffer = new TextBuffer(filePath: require.resolve('./fixtures/sample.js'))
       editor = atom.workspace.buildTextEditor({buffer})
-      editor.setUpdatedSynchronously(true)
       waitsForPromise -> buffer.load()
 
     afterEach ->

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -91,7 +91,7 @@ describe "TextEditorPresenter", ->
     expectNoStateUpdate = (presenter, fn) -> expectStateUpdatedToBe(false, presenter, fn)
 
     waitsForStateToUpdate = (presenter, fn) ->
-      waitsFor "presenter state to update", 1000, (done) ->
+      waitsFor "presenter state to update", 2000, (done) ->
         fn?()
         disposable = presenter.onDidUpdateState ->
           disposable.dispose()

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -92,14 +92,14 @@ describe "TextEditorPresenter", ->
     expectNoStateUpdate = (presenter, fn) -> expectStateUpdatedToBe(false, presenter, fn)
 
     waitsForStateToUpdate2 = (presenter, fn) ->
-      waitsFor "presenter state to update", 5000, (done) ->
+      waitsFor "presenter state to update", 1000, (done) ->
         disposable = presenter.onDidUpdateState ->
           disposable.dispose()
           process.nextTick(done)
         fn?()
 
     waitsForStateToUpdate = (presenter, fn) ->
-      waitsFor "presenter state to update", 5000, (done) ->
+      waitsFor "presenter state to update", 1000, (done) ->
         fn?()
         disposable = presenter.onDidUpdateState ->
           disposable.dispose()

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -91,7 +91,7 @@ describe "TextEditorPresenter", ->
     expectNoStateUpdate = (presenter, fn) -> expectStateUpdatedToBe(false, presenter, fn)
 
     waitsForStateToUpdate = (presenter, fn) ->
-      waitsFor "presenter state to update", 2000, (done) ->
+      waitsFor "presenter state to update", 5000, (done) ->
         fn?()
         disposable = presenter.onDidUpdateState ->
           disposable.dispose()

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -20,6 +20,7 @@ describe "TextEditorPresenter", ->
 
       buffer = new TextBuffer(filePath: require.resolve('./fixtures/sample.js'))
       editor = atom.workspace.buildTextEditor({buffer})
+      editor.setUpdatedSynchronously(true)
       waitsForPromise -> buffer.load()
 
     afterEach ->

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -2979,7 +2979,6 @@ describe "TextEditorPresenter", ->
               presenter.setBlockDecorationDimensions(blockDecoration4, 0, 35)
               presenter.setBlockDecorationDimensions(blockDecoration4, 0, 40)
               presenter.setBlockDecorationDimensions(blockDecoration5, 0, 50)
-              presenter.setBlockDecorationDimensions(blockDecoration6, 0, 60)
 
               waitsForStateToUpdate presenter, -> presenter.setBlockDecorationDimensions(blockDecoration6, 0, 60)
               runs ->

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -90,6 +90,15 @@ describe "TextEditorPresenter", ->
 
     expectNoStateUpdate = (presenter, fn) -> expectStateUpdatedToBe(false, presenter, fn)
 
+    waitsForStateToUpdate2 = (presenter, fn) ->
+      didUpdate = false
+      disposable = presenter.onDidUpdateState ->
+        disposable.dispose()
+        didUpdate = true
+      fn?()
+      waitsFor "presenter state to update", 5000, (done) ->
+        didUpdate
+
     waitsForStateToUpdate = (presenter, fn) ->
       waitsFor "presenter state to update", 5000, (done) ->
         fn?()
@@ -1680,7 +1689,7 @@ describe "TextEditorPresenter", ->
           blockDecoration1 = addBlockDecorationBeforeScreenRow(0)
           blockDecoration2 = addBlockDecorationBeforeScreenRow(1)
 
-          waitsForStateToUpdate presenter, ->
+          waitsForStateToUpdate2 presenter, ->
             presenter.setBlockDecorationDimensions(blockDecoration1, 0, 30)
             presenter.setBlockDecorationDimensions(blockDecoration2, 0, 10)
 
@@ -1691,7 +1700,7 @@ describe "TextEditorPresenter", ->
             expect(stateForCursor(presenter, 3)).toBeUndefined()
             expect(stateForCursor(presenter, 4)).toBeUndefined()
 
-          waitsForStateToUpdate presenter, ->
+          waitsForStateToUpdate2 presenter, ->
             blockDecoration2.destroy()
             editor.setCursorBufferPosition([0, 0])
             editor.insertNewline()

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -91,13 +91,11 @@ describe "TextEditorPresenter", ->
     expectNoStateUpdate = (presenter, fn) -> expectStateUpdatedToBe(false, presenter, fn)
 
     waitsForStateToUpdate2 = (presenter, fn) ->
-      didUpdate = false
-      disposable = presenter.onDidUpdateState ->
-        disposable.dispose()
-        didUpdate = true
-      fn?()
       waitsFor "presenter state to update", 5000, (done) ->
-        didUpdate
+        disposable = presenter.onDidUpdateState ->
+          disposable.dispose()
+          process.nextTick(done)
+        fn?()
 
     waitsForStateToUpdate = (presenter, fn) ->
       waitsFor "presenter state to update", 5000, (done) ->

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -3467,9 +3467,9 @@ describe "TextEditorPresenter", ->
               gutterName: 'test-gutter-2'
               class: 'test-class'
             marker4 = editor.markBufferRange([[0, 0], [1, 0]])
-            decoration4 = editor.decorateMarker(marker4, decorationParams)
+            decoration4 = null
 
-            waitsForStateToUpdate presenter
+            waitsForStateToUpdate2 presenter, -> decoration4 = editor.decorateMarker(marker4, decorationParams)
 
             runs ->
               expectStateUpdate presenter, -> editor.addGutter({name: 'test-gutter-2'})


### PR DESCRIPTION
Fixes #10435.

I haven’t been able to reproduce this locally yet, but let’s see if it’s as easy as giving it a longer timeout.
