### PR TITLE
Fixed atom documentation hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ By participating, you are expected to uphold this code. Please report unacceptab
 
 ## Documentation
 
-If you want to read about using Atom or developing packages in Atom, the [Atom Flight Manual](https://atom.io/docs/latest/) is free and available online, along with ePub, PDF and mobi versions. You can find the source to the manual in [atom/docs](https://github.com/atom/docs).
+If you want to read about using Atom or developing packages in Atom, the [Atom Flight Manual](https://atom.io/docs/latest/) is free and available online, along with ePub, PDF and mobi versions. You can find the source to the manual in the [Atom Documentation](https://github.com/atom/docs).
 
 The [API reference](https://atom.io/docs/api) for developing packages is also documented on Atom.io.
 


### PR DESCRIPTION
Changed the atom/link to Atom Documentation
