### PR TITLE
Register Atom for file associations in Windows

### DIFF
--- a/src/browser/squirrel-update.coffee
+++ b/src/browser/squirrel-update.coffee
@@ -20,6 +20,7 @@ else
 fileKeyPath = 'HKCU\\Software\\Classes\\*\\shell\\Atom'
 directoryKeyPath = 'HKCU\\Software\\Classes\\directory\\shell\\Atom'
 backgroundKeyPath = 'HKCU\\Software\\Classes\\directory\\background\\shell\\Atom'
+applicationsKeyPath = 'HKCU\\Software\\Classes\\Applications\\atom.exe'
 environmentKeyPath = 'HKCU\\Environment'
 
 # Spawn a command and invoke the callback when it completes with an error
@@ -64,6 +65,10 @@ installContextMenu = (callback) ->
     args.push('/f')
     spawnReg(args, callback)
 
+  installFileHandler = (callback) ->
+    args = ["#{applicationsKeyPath}\\shell\\open\\command", '/ve', '/d', "\"#{process.execPath}\" \"%1\""]
+    addToRegistry(args, callback)
+
   installMenu = (keyPath, arg, callback) ->
     args = [keyPath, '/ve', '/d', 'Open with Atom']
     addToRegistry args, ->
@@ -74,7 +79,8 @@ installContextMenu = (callback) ->
 
   installMenu fileKeyPath, '%1', ->
     installMenu directoryKeyPath, '%1', ->
-      installMenu(backgroundKeyPath, '%V', callback)
+      installMenu backgroundKeyPath, '%V', ->
+        installFileHandler(callback)
 
 isAscii = (text) ->
   index = 0
@@ -124,7 +130,8 @@ uninstallContextMenu = (callback) ->
 
   deleteFromRegistry fileKeyPath, ->
     deleteFromRegistry directoryKeyPath, ->
-      deleteFromRegistry(backgroundKeyPath, callback)
+      deleteFromRegistry backgroundKeyPath, ->
+        deleteFromRegistry(applicationsKeyPath, callback)
 
 # Add atom and apm to the PATH
 #


### PR DESCRIPTION
:checkered_flag: Register atom.exe as a file handler for the current user including updating the .exe location on upgrade and removing it on uninstall. 

Addresses #4893 and #6860. Partially addresses #6177 in that we now do the right thing although Cyberduck on Windows still seems to have some issues - I couldn't get Edit With to even work with Notepad although the Open With from the transfer Window now works with Atom.

Tested on Win7/x86 and Win10/x64:
![handlerwin7](https://cloud.githubusercontent.com/assets/118951/13037228/f82a674e-d330-11e5-8021-692c90937dd6.PNG)
![handlerwin10](https://cloud.githubusercontent.com/assets/118951/13037220/e420371a-d330-11e5-9d96-260eb4489dfc.png)
