### PR TITLE
Add TextEditor.prototype.cursorsForScreenRowRange

### DIFF
--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -432,18 +432,14 @@ class TextEditorPresenter
     return
 
   updateCursorsState: ->
-    @state.content.cursors = {}
-    @updateCursorState(cursor) for cursor in @model.cursors # using property directly to avoid allocation
-    return
-
-  updateCursorState: (cursor) ->
     return unless @startRow? and @endRow? and @hasPixelRectRequirements() and @baseCharacterWidth?
-    screenRange = cursor.getScreenRange()
-    return unless cursor.isVisible() and @startRow <= screenRange.start.row < @endRow
 
-    pixelRect = @pixelRectForScreenRange(screenRange)
-    pixelRect.width = Math.round(@baseCharacterWidth) if pixelRect.width is 0
-    @state.content.cursors[cursor.id] = pixelRect
+    @state.content.cursors = {}
+    for cursor in @model.cursorsForScreenRowRange(@startRow, @endRow - 1) when cursor.isVisible()
+      pixelRect = @pixelRectForScreenRange(cursor.getScreenRange())
+      pixelRect.width = Math.round(@baseCharacterWidth) if pixelRect.width is 0
+      @state.content.cursors[cursor.id] = pixelRect
+    return
 
   updateOverlaysState: ->
     return unless @hasOverlayPositionRequirements()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -109,6 +109,7 @@ class TextEditor extends Model
     @emitter = new Emitter
     @disposables = new CompositeDisposable
     @cursors = []
+    @cursorsByMarkerId = new Map
     @selections = []
 
     buffer ?= new TextBuffer
@@ -1944,10 +1945,18 @@ class TextEditor extends Model
   getCursorsOrderedByBufferPosition: ->
     @getCursors().sort (a, b) -> a.compare(b)
 
+  cursorsForScreenRowRange: (startScreenRow, endScreenRow) ->
+    cursors = []
+    for marker in @selectionsMarkerLayer.findMarkers(intersectsScreenRowRange: [startScreenRow, endScreenRow])
+      if cursor = @cursorsByMarkerId.get(marker.id)
+        cursors.push(cursor)
+    cursors
+
   # Add a cursor based on the given {TextEditorMarker}.
   addCursor: (marker) ->
     cursor = new Cursor(editor: this, marker: marker, config: @config)
     @cursors.push(cursor)
+    @cursorsByMarkerId.set(marker.id, cursor)
     @decorateMarker(marker, type: 'line-number', class: 'cursor-line')
     @decorateMarker(marker, type: 'line-number', class: 'cursor-line-no-selection', onlyHead: true, onlyEmpty: true)
     @decorateMarker(marker, type: 'line', class: 'cursor-line', onlyEmpty: true)
@@ -2446,6 +2455,7 @@ class TextEditor extends Model
   removeSelection: (selection) ->
     _.remove(@cursors, selection.cursor)
     _.remove(@selections, selection)
+    @cursorsByMarkerId.delete(selection.cursor.marker.id)
     @emitter.emit 'did-remove-cursor', selection.cursor
     @emitter.emit 'did-remove-selection', selection
 


### PR DESCRIPTION
With this PR, `TextEditorPresenter` can avoid to scan through all the cursors to understand whether they're visible on screen. This dramatically reduces the calls to `getScreenRange` and, thus, makes `updateCursorsState` faster for scenarios where the number of cursors is elevated (e.g. editing, scrolling through a file, etc.).

Although this code path will partially, and positively, be affected by the in-progress `DisplayLayer` redesign, I believe that reducing the number of cursors we need to iterate is still valuable in terms of performance and reduces the number of `getEnd()` queries we need to perform against `MarkerIndex`.
#### Before

![screen shot 2016-02-16 at 14 44 49](https://cloud.githubusercontent.com/assets/482957/13077922/29de3748-d4bc-11e5-9137-8dfb5d2be0f9.png)

_(Total: `~ 1183ms`, benchmarks performed by editing 3000 lines, writing 5 letters)_
#### After

![screen shot 2016-02-16 at 14 46 45](https://cloud.githubusercontent.com/assets/482957/13077986/9dd66d82-d4bc-11e5-9cb5-9998620adc47.png)

_(Total: `~ 98ms`, 12x faster :racehorse:)_

/cc: @nathansobo @maxbrunsfeld 
