### PR TITLE
Add the -a, --add CLI option

### DIFF
--- a/spec/atom-environment-spec.coffee
+++ b/spec/atom-environment-spec.coffee
@@ -275,6 +275,14 @@ describe "AtomEnvironment", ->
         atom.openLocations([{pathToOpen}])
         expect(atom.project.getPaths()[0]).toBe __dirname
 
+      describe "then a second path is opened with forceAddToWindow", ->
+        it "adds the second path to the project's paths", ->
+          firstPathToOpen = __dirname
+          secondPathToOpen = path.resolve(__dirname, './fixtures')
+          atom.openLocations([{pathToOpen: firstPathToOpen}])
+          atom.openLocations([{pathToOpen: secondPathToOpen, forceAddToWindow: true}])
+          expect(atom.project.getPaths()).toEqual([firstPathToOpen, secondPathToOpen])
+
     describe "when the opened path does not exist but its parent directory does", ->
       it "adds the parent directory to the project paths", ->
         pathToOpen = path.join(__dirname, 'this-path-does-not-exist.txt')

--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -123,6 +123,34 @@ describe "Starting Atom", ->
           .waitForPaneItemCount(0, 1000)
           .treeViewRootDirectories()
           .then ({value}) -> expect(value).toEqual([otherTempDirPath])
+    describe "when using the -a, --add option", ->
+      it "reuses that window and add the folder to project paths", ->
+        fourthTempDir = temp.mkdirSync("a-fourth-dir")
+        fourthTempFilePath = path.join(fourthTempDir, "a-file")
+        fs.writeFileSync(fourthTempFilePath, "4 - This file was already here.")
+
+        fifthTempDir = temp.mkdirSync("a-fifth-dir")
+        fifthTempFilePath = path.join(fifthTempDir, "a-file")
+        fs.writeFileSync(fifthTempFilePath, "5 - This file was already here.")
+
+        runAtom [path.join(tempDirPath, "new-file")], {ATOM_HOME: atomHome}, (client) ->
+          client
+            .waitForPaneItemCount(1, 5000)
+
+            # Opening another file reuses the same window and add parent dir to
+            # project paths.
+            .startAnotherAtom(['-a', fourthTempFilePath], ATOM_HOME: atomHome)
+            .waitForPaneItemCount(2, 5000)
+            .waitForWindowCount(1, 1000)
+            .treeViewRootDirectories()
+            .then ({value}) -> expect(value).toEqual([tempDirPath, fourthTempDir])
+            .execute -> atom.workspace.getActiveTextEditor().getText()
+            .then ({value: text}) -> expect(text).toBe "4 - This file was already here."
+
+            # Opening another directory resuses the same window and add the folder to project paths.
+            .startAnotherAtom(['--add', fifthTempDir], ATOM_HOME: atomHome)
+            .treeViewRootDirectories()
+            .then ({value}) -> expect(value).toEqual([tempDirPath, fourthTempDir, fifthTempDir])
 
     it "opens the new window offset from the other window", ->
       runAtom [path.join(tempDirPath, "new-file")], {ATOM_HOME: atomHome}, (client) ->

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -897,8 +897,8 @@ class AtomEnvironment extends Model
   openLocations: (locations) ->
     needsProjectPaths = @project?.getPaths().length is 0
 
-    for {pathToOpen, initialLine, initialColumn} in locations
-      if pathToOpen? and needsProjectPaths
+    for {pathToOpen, initialLine, initialColumn, forceAddToWindow} in locations
+      if pathToOpen? and (needsProjectPaths or forceAddToWindow)
         if fs.existsSync(pathToOpen)
           @project.addPath(pathToOpen)
         else if fs.existsSync(path.dirname(pathToOpen))

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -85,16 +85,16 @@ class AtomApplication
     else
       @loadState(options) or @openPath(options)
 
-  openWithOptions: ({pathsToOpen, executedFrom, urlsToOpen, test, pidToKillWhenClosed, devMode, safeMode, newWindow, logFile, profileStartup, timeout, clearWindowState}) ->
+  openWithOptions: ({pathsToOpen, executedFrom, urlsToOpen, test, pidToKillWhenClosed, devMode, safeMode, newWindow, logFile, profileStartup, timeout, clearWindowState, addToLastWindow}) ->
     if test
       @runTests({headless: true, devMode, @resourcePath, executedFrom, pathsToOpen, logFile, timeout})
     else if pathsToOpen.length > 0
-      @openPaths({pathsToOpen, executedFrom, pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, clearWindowState})
+      @openPaths({pathsToOpen, executedFrom, pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, clearWindowState, addToLastWindow})
     else if urlsToOpen.length > 0
       @openUrl({urlToOpen, devMode, safeMode}) for urlToOpen in urlsToOpen
     else
       # Always open a editor window if this is the first instance of Atom.
-      @openPath({pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, clearWindowState})
+      @openPath({pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, clearWindowState, addToLastWindow})
 
   # Public: Removes the {AtomWindow} from the global window list.
   removeWindow: (window) ->
@@ -409,8 +409,9 @@ class AtomApplication
   #   :safeMode - Boolean to control the opened window's safe mode.
   #   :profileStartup - Boolean to control creating a profile of the startup time.
   #   :window - {AtomWindow} to open file paths in.
-  openPath: ({pathToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, window, clearWindowState} = {}) ->
-    @openPaths({pathsToOpen: [pathToOpen], pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, window, clearWindowState})
+  #   :addToLastWindow - Boolean of whether this should be opened in last focused window.
+  openPath: ({pathToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, window, clearWindowState, addToLastWindow} = {}) ->
+    @openPaths({pathsToOpen: [pathToOpen], pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, window, clearWindowState, addToLastWindow})
 
   # Public: Opens multiple paths, in existing windows if possible.
   #
@@ -422,11 +423,12 @@ class AtomApplication
   #   :safeMode - Boolean to control the opened window's safe mode.
   #   :windowDimensions - Object with height and width keys.
   #   :window - {AtomWindow} to open file paths in.
-  openPaths: ({pathsToOpen, executedFrom, pidToKillWhenClosed, newWindow, devMode, safeMode, windowDimensions, profileStartup, window, clearWindowState}={}) ->
+  #   :addToLastWindow - Boolean of whether this should be opened in last focused window.
+  openPaths: ({pathsToOpen, executedFrom, pidToKillWhenClosed, newWindow, devMode, safeMode, windowDimensions, profileStartup, window, clearWindowState, addToLastWindow}={}) ->
     devMode = Boolean(devMode)
     safeMode = Boolean(safeMode)
     clearWindowState = Boolean(clearWindowState)
-    locationsToOpen = (@locationForPathToOpen(pathToOpen, executedFrom) for pathToOpen in pathsToOpen)
+    locationsToOpen = (@locationForPathToOpen(pathToOpen, executedFrom, addToLastWindow) for pathToOpen in pathsToOpen)
     pathsToOpen = (locationToOpen.pathToOpen for locationToOpen in locationsToOpen)
 
     unless pidToKillWhenClosed or newWindow
@@ -435,6 +437,7 @@ class AtomApplication
       unless existingWindow?
         if currentWindow = window ? @lastFocusedWindow
           existingWindow = currentWindow if (
+            addToLastWindow or
             currentWindow.devMode is devMode and
             (
               stats.every((stat) -> stat.isFile?()) or
@@ -603,7 +606,7 @@ class AtomApplication
     catch error
       require.resolve(path.resolve(__dirname, '..', '..', 'spec', 'jasmine-test-runner'))
 
-  locationForPathToOpen: (pathToOpen, executedFrom='') ->
+  locationForPathToOpen: (pathToOpen, executedFrom='', forceAddToWindow) ->
     return {pathToOpen} unless pathToOpen
 
     pathToOpen = pathToOpen.replace(/[:\s]+$/, '')
@@ -619,7 +622,7 @@ class AtomApplication
     unless url.parse(pathToOpen).protocol?
       pathToOpen = path.resolve(executedFrom, fs.normalize(pathToOpen))
 
-    {pathToOpen, initialLine, initialColumn}
+    {pathToOpen, initialLine, initialColumn, forceAddToWindow}
 
   # Opens a native dialog to prompt the user for a path.
   #

--- a/src/browser/main.coffee
+++ b/src/browser/main.coffee
@@ -132,6 +132,7 @@ parseCommandLine = ->
   options.string('timeout').describe('timeout', 'When in test mode, waits until the specified time (in minutes) and kills the process (exit code: 130).')
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version information.')
   options.alias('w', 'wait').boolean('w').describe('w', 'Wait for window to be closed before returning.')
+  options.alias('a', 'add').boolean('a').describe('add', 'Open path as a new project in last used window.')
   options.string('socket-path')
   options.string('user-data-dir')
   options.boolean('clear-window-state').describe('clear-window-state', 'Delete all Atom environment state.')
@@ -146,6 +147,7 @@ parseCommandLine = ->
     writeFullVersion()
     process.exit(0)
 
+  addToLastWindow = args['add']
   executedFrom = args['executed-from']?.toString() ? process.cwd()
   devMode = args['dev']
   safeMode = args['safe']
@@ -183,6 +185,6 @@ parseCommandLine = ->
   {resourcePath, devResourcePath, pathsToOpen, urlsToOpen, executedFrom, test,
    version, pidToKillWhenClosed, devMode, safeMode, newWindow,
    logFile, socketPath, userDataDir, profileStartup, timeout, setPortable,
-   clearWindowState}
+   clearWindowState, addToLastWindow}
 
 start()


### PR DESCRIPTION
This commit adds the `-a, --add` option to the CLI which allows users to add paths to the last focused window (similar to Sublime), like shown here:

![add-option](https://cloud.githubusercontent.com/assets/228886/13084046/9380e642-d4cf-11e5-902a-cd1e126685fd.gif)

This allows you to open many projects in the same Atom window (but not necessarily at the same time) without the hassle of clicking through the menus (right click > Add Project Folder > find my way to the folder...) but doing it from the CLI instead.

This comes with:
- a single additional test, I'm not sure if adding more is necessary
- documented CLI usage (automated)

I'm not sure if that feature needs to be documented elsewhere, if it does I'd be happy to do it.
