### PR TITLE
Registry for TextEditors

### DIFF
--- a/spec/text-editor-registry-spec.coffee
+++ b/spec/text-editor-registry-spec.coffee
@@ -1,0 +1,38 @@
+TextEditorRegistry = require '../src/text-editor-registry'
+
+describe "TextEditorRegistry", ->
+  [registry, editor] = []
+
+  beforeEach ->
+    registry = new TextEditorRegistry
+
+  describe "when a TextEditor is added", ->
+    it "gets added to the list of registered editors", ->
+      editor = {}
+      registry.add(editor)
+      expect(registry.editors.size).toBe 1
+      expect(registry.editors.has(editor)).toBe(true)
+
+    it "returns a Disposable that can unregister the editor", ->
+      editor = {}
+      disposable = registry.add(editor)
+      expect(registry.editors.size).toBe 1
+      disposable.dispose()
+      expect(registry.editors.size).toBe 0
+
+  describe "when the registry is observed", ->
+    it "calls the callback for current and future editors until unsubscribed", ->
+      [editor1, editor2, editor3] = [{}, {}, {}]
+
+      registry.add(editor1)
+      subscription = registry.observe spy = jasmine.createSpy()
+      expect(spy.calls.length).toBe 1
+
+      registry.add(editor2)
+      expect(spy.calls.length).toBe 2
+      expect(spy.argsForCall[0][0]).toBe editor1
+      expect(spy.argsForCall[1][0]).toBe editor2
+
+      subscription.dispose()
+      registry.add(editor3)
+      expect(spy.calls.length).toBe 2

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -40,6 +40,7 @@ Project = require './project'
 TextEditor = require './text-editor'
 TextBuffer = require 'text-buffer'
 Gutter = require './gutter'
+TextEditorRegistry = require './text-editor-registry'
 
 WorkspaceElement = require './workspace-element'
 PanelContainerElement = require './panel-container-element'
@@ -110,6 +111,9 @@ class AtomEnvironment extends Model
 
   # Public: A {Workspace} instance
   workspace: null
+
+  # Public: A {TextEditorRegistry} instance
+  textEditors: null
 
   saveStateDebounceInterval: 1000
 
@@ -182,6 +186,8 @@ class AtomEnvironment extends Model
       notificationManager: @notifications, @applicationDelegate, @clipboard, viewRegistry: @views, assert: @assert.bind(this)
     })
     @themes.workspace = @workspace
+
+    @textEditors = new TextEditorRegistry
 
     @config.load()
 

--- a/src/text-editor-registry.coffee
+++ b/src/text-editor-registry.coffee
@@ -1,0 +1,33 @@
+{Emitter, Disposable} = require 'event-kit'
+
+# This global registry tracks registered `TextEditors`.
+#
+# Packages that provide extra functionality to `TextEditors`, such as
+# autocompletion, can observe this registry to find applicable editors.
+module.exports =
+class TextEditorRegistry
+  constructor: ->
+    @editors = new Set
+    @emitter = new Emitter
+
+  # Register a `TextEditor`.
+  #
+  # * `editor` The editor to register.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to remove the
+  # added editor. To avoid any memory leaks this should be called when the
+  # editor is destroyed.
+  add: (editor) ->
+    @editors.add(editor)
+    @emitter.emit 'did-add-editor', editor
+    new Disposable => @editors.delete(editor)
+
+  # Invoke the given callback with all the current and future registered
+  # `TextEditors`.
+  #
+  # * `callback` {Function} to be called with current and future text editors.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  observe: (callback) ->
+    @editors.forEach (editor) -> callback(editor)
+    @emitter.on 'did-add-editor', callback

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -82,7 +82,10 @@ class TextEditor extends Model
     state.project = atomEnvironment.project
     state.assert = atomEnvironment.assert.bind(atomEnvironment)
     state.applicationDelegate = atomEnvironment.applicationDelegate
-    new this(state)
+    editor = new this(state)
+    disposable = atomEnvironment.textEditors.add(editor)
+    editor.onDidDestroy -> disposable.dispose()
+    editor
 
   constructor: (params={}) ->
     super

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -558,7 +558,10 @@ class Workspace extends Model
       @config, @notificationManager, @packageManager, @clipboard, @viewRegistry,
       @grammarRegistry, @project, @assert, @applicationDelegate
     }, params)
-    new TextEditor(params)
+    editor = new TextEditor(params)
+    disposable = atom.textEditors.add(editor)
+    editor.onDidDestroy -> disposable.dispose()
+    editor
 
   # Public: Asynchronously reopens the last-closed item's URI if it hasn't already been
   # reopened.


### PR DESCRIPTION
Currently, only `TextEditors` that are items of `Panes` are observable.
From the model point-of-view, the `TextEditors` are linked to the workspace through the `PaneContainer` and `Panes`.

There are other `TextEditors` that are of interest though.
For example, the editor in `find-and-replace` might want autocomplete functionality (atom/autocomplete-plus#383).

With this change, any editor created through `workspace.buildTextEditor` can be observed, which seemed the cleanest way to observe `TextEditors` across a varied use in the model.

Note: the tests seem to succeed locally, let me know if they are failing due to flakiness or if I am doing something wrong.
