### PR TITLE
[WIP] add project.resolveNonRealpath to return non-realpath compared to project.resolvePath

### DIFF
--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -106,7 +106,7 @@ describe "Project", ->
 
       runs ->
         editor.saveAs(tempFile)
-        expect(atom.project.getPaths()[0]).toBe path.dirname(tempFile)
+        expect(atom.project.getPaths()[0]).toBe path.dirname(atom.project.normalizeRealpath(tempFile))
 
   describe "before and after saving a buffer", ->
     [buffer] = []


### PR DESCRIPTION
This PR is trying to address #9879.

~~The first commit simply changes the semantic of `project.resolvePath()` to return a non-realpath. Since this might break the callers expectation I will try to keep the semantic of existing API on-top as outlined in https://github.com/atom/atom/issues/9879#issuecomment-162253183 as necessary.~~ See newer comment for current behavior.
