### PR TITLE
Compare markers instead of ranges in Selection

### DIFF
--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -755,7 +755,7 @@ class Selection extends Model
   #
   # * `otherSelection` A {Selection} to compare against
   compare: (otherSelection) ->
-    @getBufferRange().compare(otherSelection.getBufferRange())
+    @marker.compare(otherSelection.marker)
 
   ###
   Section: Private Utilities


### PR DESCRIPTION
This largely reduces the overhead of converting ranges/points from native to javascript objects.
#### Before

![screen shot 2016-02-17 at 16 26 23](https://cloud.githubusercontent.com/assets/482957/13114303/40bbd43e-d593-11e5-986c-e0251c23093c.png)

_(Total: `~ 1040ms`, benchmarks performed by editing 1500 lines, writing 5 characters)_
#### After

![screen shot 2016-02-17 at 16 22 54](https://cloud.githubusercontent.com/assets/482957/13114297/3b4f1e98-d593-11e5-967f-733af53cff8d.png)

_(Total: `~ 65ms`, 16x speedup :racehorse: :racehorse: :racehorse:)_

Props to @maxbrunsfeld for suggesting this fix! :clap: 

/cc: @atom/core 
