### PR TITLE
Terminate pending state for opened file if pending option is false

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -585,6 +585,22 @@ describe "Workspace", ->
           open = -> workspace.open('file1', workspace.getActivePane())
           expect(open).toThrow()
 
+    describe "when the file is already open in pending state", ->
+      it "should terminate the pending state", ->
+        editor = null
+
+        waitsForPromise ->
+          atom.workspace.open('sample.js', pending: true).then (o) -> editor = o
+          
+        runs ->
+          expect(editor.isPending()).toBe true
+          
+        waitsForPromise ->
+          atom.workspace.open('sample.js').then (o) -> editor = o
+          
+        runs ->
+          expect(editor.isPending()).toBe false
+  
   describe "::reopenItem()", ->
     it "opens the uri associated with the last closed pane that isn't currently open", ->
       pane = workspace.getActivePane()

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -476,7 +476,8 @@ class Workspace extends Model
     activateItem = options.activateItem ? true
 
     if uri?
-      item = pane.itemForURI(uri)
+      if item = pane.itemForURI(uri)
+        item.terminatePendingState?() if item.isPending?() and not options.pending
       item ?= opener(uri, options) for opener in @getOpeners() when not item
 
     try


### PR DESCRIPTION
@joshaber pointed out that opening a file from fuzzy-finder currently does not make a pending pane item permanent. This PR makes it such that if you open a file without the `pending` option and the file is currently opened in pending state, the pending state will be terminated. 

TODO: Merge PRs for find-and-replace and tree-view once this is on stable. I simplified code in these packages by opening items without `pending` option rather than explicitly invoking `terminatePendingState`
