### PR TITLE
Allow pasting white space when `autoIndentOnPaste` is enabled

### DIFF
--- a/spec/selection-spec.coffee
+++ b/spec/selection-spec.coffee
@@ -83,3 +83,11 @@ describe "Selection", ->
       selection.setBufferRange([[2, 0], [2, 10]])
       selection.destroy()
       expect(selection.marker.isDestroyed()).toBeTruthy()
+
+  describe ".insertText(text, options)", ->
+    it "allows pasting white space only lines when autoIndent is enabled", ->
+      selection.setBufferRange [[0, 0], [0, 0]]
+      selection.insertText("    \n    \n\n", autoIndent: true)
+      expect(buffer.lineForRow(0)).toBe "    "
+      expect(buffer.lineForRow(1)).toBe "    "
+      expect(buffer.lineForRow(2)).toBe ""

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -378,7 +378,7 @@ class Selection extends Model
       indentAdjustment = @editor.indentLevelForLine(precedingText) - options.indentBasis
       @adjustIndent(remainingLines, indentAdjustment)
 
-    if options.autoIndent and not NonWhitespaceRegExp.test(precedingText) and remainingLines.length > 0
+    if options.autoIndent and NonWhitespaceRegExp.test(text) and not NonWhitespaceRegExp.test(precedingText) and remainingLines.length > 0
       autoIndentFirstLine = true
       firstLine = precedingText + firstInsertedLine
       desiredIndentLevel = @editor.languageMode.suggestedIndentForLineAtBufferRow(oldBufferRange.start.row, firstLine)


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/5891
