### PR TITLE
Cache regexes in LanguageMode.prototype.getRegexForProperty

### DIFF
--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -10,6 +10,7 @@ class LanguageMode
   # editor - The {TextEditor} to associate with
   constructor: (@editor, @config) ->
     {@buffer} = @editor
+    @regexesByPattern = {}
 
   destroy: ->
 
@@ -328,7 +329,8 @@ class LanguageMode
 
   getRegexForProperty: (scopeDescriptor, property) ->
     if pattern = @config.get(property, scope: scopeDescriptor)
-      new OnigRegExp(pattern)
+      @regexesByPattern[pattern] ?= new OnigRegExp(pattern)
+      @regexesByPattern[pattern]
 
   increaseIndentRegexForScopeDescriptor: (scopeDescriptor) ->
     @getRegexForProperty(scopeDescriptor, 'editor.increaseIndentPattern')


### PR DESCRIPTION
This adds a simple layer of caching into `LanguageMode.prototype.getRegexForProperty` to avoid allocating `OnigRegExp` objects when e.g. calling `autoDecreaseIndentForBufferRow` (which is called for each line when performing a multi-cursor edit).
#### Before

![screen shot 2016-02-18 at 14 31 43](https://cloud.githubusercontent.com/assets/482957/13144733/a71cfc62-d64c-11e5-8bf6-aa67be04f6d4.png)

_(Total: `~ 293ms`, benchmark performed by editing 1500 lines, writing 5 characters)_
#### After

![screen shot 2016-02-18 at 14 29 03](https://cloud.githubusercontent.com/assets/482957/13144735/aae39284-d64c-11e5-9fcd-c2a74b571b92.png)

_(Total: `~ 135ms`, ~ 2x speedup :racehorse:)_

For the same edit, the method now takes `~ 135ms` to execute, but most of that time (`> 80ms`) is spent in getting the scope descriptor for a certain buffer position. That should get better with @nathansobo's improvements at the `DisplayLayer`, making `autoDecreaseIndentForBufferRow` a pretty cheap function call.

/cc: @atom/core 
