### PR TITLE
Add support for keybindings with keyup keystrokes

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "grammar-selector": "0.48.1",
     "image-view": "0.56.0",
     "incompatible-packages": "0.25.1",
-    "keybinding-resolver": "0.33.0",
+    "keybinding-resolver": "0.34.0",
     "line-ending-selector": "0.3.1",
     "link": "0.31.0",
     "markdown-preview": "0.157.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "electronVersion": "0.36.7",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "^6.2.0",
+    "atom-keymap": "^6.3.1",
     "babel-core": "^5.8.21",
     "bootstrap": "^3.3.4",
     "cached-run-in-this-context": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "grammar-selector": "0.48.1",
     "image-view": "0.56.0",
     "incompatible-packages": "0.25.1",
-    "keybinding-resolver": "0.34.0",
+    "keybinding-resolver": "0.35.0",
     "line-ending-selector": "0.3.1",
     "link": "0.31.0",
     "markdown-preview": "0.157.3",

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -15,7 +15,8 @@ class WindowEventHandler
     @addEventListener(@window, 'focus', @handleWindowFocus)
     @addEventListener(@window, 'blur', @handleWindowBlur)
 
-    @addEventListener(@document, 'keydown', @handleDocumentKeydown)
+    @addEventListener(@document, 'keyup', @handleDocumentKeyEvent)
+    @addEventListener(@document, 'keydown', @handleDocumentKeyEvent)
     @addEventListener(@document, 'drop', @handleDocumentDrop)
     @addEventListener(@document, 'dragover', @handleDocumentDragover)
     @addEventListener(@document, 'contextmenu', @handleDocumentContextmenu)
@@ -66,7 +67,7 @@ class WindowEventHandler
     target.addEventListener(eventName, handler)
     @subscriptions.add(new Disposable(-> target.removeEventListener(eventName, handler)))
 
-  handleDocumentKeydown: (event) =>
+  handleDocumentKeyEvent: (event) =>
     @atomEnvironment.keymaps.handleKeyboardEvent(event)
     event.stopImmediatePropagation()
 


### PR DESCRIPTION
The main utility is to unblock MRU tabs: https://github.com/atom/atom/pull/10737, but there should be some interesting features unlocked by this change.

Effectively, this adds new syntax for dispatching commands on keyup events. It looks like this:

``` coffee
'atom-workspace':
  'ctrl-y ^ctrl': 'core:do-stuff'
```

Which means, user presses `ctrl-y`, then lifts `ctrl` to fire the `core:do-stuff` command. If any other keybinding is used instead of a `ctrl` keyup after the `ctrl-y`, the command will not be dispatched.

For more info see the PRs on atom-keymaps
- [Add handlers for keyup events](https://github.com/atom/atom-keymap/issues/113)
- [Run exact matches when the remainder of the partially matched commands are only keyup events](https://github.com/atom/atom-keymap/issues/115)

cc @natalieogle
