### PR TITLE
Faster state serialization

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -813,12 +813,17 @@ class AtomEnvironment extends Model
 
   saveState: ->
     return Promise.resolve() unless @enablePersistence
-    state = @serialize()
 
-    if storageKey = @getStateKey(@project?.getPaths())
-      @stateStore.save(storageKey, state)
-    else
-      @applicationDelegate.setTemporaryWindowState(state)
+    new Promise (resolve, reject) =>
+      window.requestIdleCallback =>
+        state = @serialize()
+        savePromise =
+          if storageKey = @getStateKey(@project?.getPaths())
+            @stateStore.save(storageKey, state)
+          else
+            @applicationDelegate.setTemporaryWindowState(state)
+        savePromise.catch(reject).then(resolve)
+
 
   loadState: ->
     if @enablePersistence

--- a/src/state-store.js
+++ b/src/state-store.js
@@ -24,16 +24,18 @@ class StateStore {
   }
 
   save (key, value) {
-    return this.dbPromise.then(db => {
-      if (!db) return
+    return new Promise((resolve, reject) => {
+      window.requestIdleCallback(deadline => {
+        this.dbPromise.then(db => {
+          if (db == null) resolve()
 
-      return new Promise((resolve, reject) => {
-        var request = db.transaction(['states'], 'readwrite')
-          .objectStore('states')
-          .put({value: value, storedAt: new Date().toString()}, key)
+          var request = db.transaction(['states'], 'readwrite')
+            .objectStore('states')
+            .put({value: value, storedAt: new Date().toString()}, key)
 
-        request.onsuccess = resolve
-        request.onerror = reject
+          request.onsuccess = resolve
+          request.onerror = reject
+        })
       })
     })
   }

--- a/src/state-store.js
+++ b/src/state-store.js
@@ -24,18 +24,19 @@ class StateStore {
   }
 
   save (key, value) {
+    // Serialize values using JSON.stringify, as it seems way faster than IndexedDB structured clone.
+    // (Ref.: https://bugs.chromium.org/p/chromium/issues/detail?id=536620)
+    let jsonValue = JSON.stringify(value)
     return new Promise((resolve, reject) => {
-      window.requestIdleCallback(deadline => {
-        this.dbPromise.then(db => {
-          if (db == null) resolve()
+      this.dbPromise.then(db => {
+        if (db == null) resolve()
 
-          var request = db.transaction(['states'], 'readwrite')
-            .objectStore('states')
-            .put({value: value, storedAt: new Date().toString()}, key)
+        var request = db.transaction(['states'], 'readwrite')
+          .objectStore('states')
+          .put({value: jsonValue, storedAt: new Date().toString(), isJSON: true}, key)
 
-          request.onsuccess = resolve
-          request.onerror = reject
-        })
+        request.onsuccess = resolve
+        request.onerror = reject
       })
     })
   }
@@ -51,7 +52,12 @@ class StateStore {
 
         request.onsuccess = (event) => {
           let result = event.target.result
-          resolve(result ? result.value : null)
+          if (result) {
+            // TODO: remove this when state will be serialized only via JSON.
+            resolve(result.isJSON ? JSON.parse(result.value) : result.value)
+          } else {
+            resolve(null)
+          }
         }
 
         request.onerror = (event) => reject(event)


### PR DESCRIPTION
Last week we discovered with @kuychaco that serializing state is taxing on Atom's responsiveness, because serialization happens on the main thread. As per https://bugs.chromium.org/p/chromium/issues/detail?id=536620, we discovered that structured clone isn't very performant and therefore we started researching a different approach that could perform better.

Below you can take a look at a profile of `saveState` and `IndexedDb.put()`:

![before](https://cloud.githubusercontent.com/assets/482957/13218622/135896a4-d96b-11e5-84b1-57eef4b94b74.png)

**Total:** `~ 116ms` for inserting 11 characters on 200 cursors.

We decided to attack the problem in two ways:
1. Use `JSON.stringify` instead of structured clone to store state in IndexedDb.
2. Defer work until a `requestIdleCallback` is dispatched. This allows to avoid blocking the main thread if some important operation is being performed.

For the same scenario, this is how this PR performs:

![after](https://cloud.githubusercontent.com/assets/482957/13218818/3aeeae00-d96c-11e5-8112-9812b6fd0195.png)

**Total:** `~ 40ms`, `~ 3x` faster. :racehorse:
#### Serializing History

Another problem we noticed is that the more edits get performed on a certain buffer the slower serializing its history becomes. This makes sense, especially in the context of large multi-cursor operations, where a single checkpoint in history could contain lots of changes. 

![history](https://cloud.githubusercontent.com/assets/482957/13219700/fa7c2220-d971-11e5-91c9-ca34289e5e19.png)

**Total:** `~ 130ms`, for inserting 5 characters on 1500 cursors.

This is an issue we still have to solve, but here's a list of potential solutions:
1. Remove history serialization altogether. I didn't expect history to be remembered across sessions and I believe this is not a "loss of work" scenario, although it's admittedly a nice feature. Sublime Text doesn't preserve history after closing the window, but you might argue that our users are already familiar with this behavior.
2. Add an option to preserve history. The default would be false, and users can decide to opt-in if they want to keep the original behavior.
3. Incrementally serialize history's state. This might be a nice improvement for long-running editor sessions, because we just have to serialize new changes as they come in, avoiding the repeated work of serializing the same state over and over and spreading the cost over a large timespan. This won't help the multi-cursor scenario, though, where a huge amount of changes could be collected over a short amount of time, and hence slow down the UI.
4. Serialize state across multiple `requestIdleCallback`s. This is a nice idea in theory because it allows to split the cost of serialization in `50ms` chunks, thus not blocking the main thread at all. In practice, however, it might be difficult to both keep track of changes and serialize stuff in parallel: for example, what happens if, while serializing state, an edit occurred?
5. After :ship:ping web workers, move this work off the main thread. I think @nathansobo brought up this idea in the past, but basically we could have a separate `TextBuffer` instance working on another thread; as changes come in, we `postMessage` to the worker thread and we let it deal with all the serialization stuff. This somewhat depends on structured clone being fast, though, because otherwise sending message to the worker thread would let the main thread pay roughly the same cost of serialization.

I believe 2) could actually be fine because it would allows us to keep this code path fast without sacrificing simpleness.
#### Conclusion

I think it might okay to :ship: and experiment with this even if we do not solve the problem illustrated above. If serialization is still a bottleneck after test-driving this, we definitely need to back the feature out and address the problem from another, more performant perspective.

What do you think?

/cc: @atom/core 
