### PR TITLE
BufferedProcess: search only new data for new lines rather than entire buffer

### DIFF
--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -111,11 +111,12 @@ class BufferedProcess
 
     stream.on 'data', (data) =>
       return if @killed
+      bufferedLength = buffered.length
       buffered += data
-      lastNewlineIndex = buffered.lastIndexOf('\n')
+      lastNewlineIndex = data.lastIndexOf('\n')
       if lastNewlineIndex isnt -1
-        onLines(buffered.substring(0, lastNewlineIndex + 1))
-        buffered = buffered.substring(lastNewlineIndex + 1)
+        onLines(buffered.substring(0, lastNewlineIndex + bufferedLength + 1))
+        buffered = buffered.substring(lastNewlineIndex + bufferedLength + 1)
 
     stream.on 'close', =>
       return if @killed


### PR DESCRIPTION
I've noticed for some time that viewing installed packages inside of settings-view was very slow. I did a little research on it, and reported the issue on the settings-view repo here atom/settings-view#734. It seems the issue is due to BufferedProcess trying to find new lines on the entire stream buffer, including data that it's already searched for new lines on. 

This PR fixes that by only searching the new data from the stream. Viewing installed packages is now significantly faster. I've attached a before and after screenshot of the CPU profile when opening settings-view and then going to the Packages tab.
### Before

![screen shot 2016-02-22 at 3 24 51 pm](https://cloud.githubusercontent.com/assets/1184341/13231590/917f5312-d978-11e5-9488-eb51ea4f459b.png)
### After:

![screen shot 2016-02-22 at 3 25 30 pm](https://cloud.githubusercontent.com/assets/1184341/13231594/955bcad8-d978-11e5-8b24-fbf5b4169ef3.png)
