### PR TITLE
WIP: Fix Issues With atom.cmd On Beta Channel

### DIFF
--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -35,8 +35,7 @@ IF "%EXPECT_OUTPUT%"=="YES" (
     "%~dp0\..\..\atom.exe" --pid=%PID% %*
     rem If the wait flag is set, don't exit this process until Atom tells it to.
     goto waitLoop
-  )
-  ELSE (
+  ) ELSE (
     "%~dp0\..\..\atom.exe" %*
   )
 ) ELSE (

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -24,10 +24,10 @@ FOR %%a IN (%*) DO (
 
 rem Getting the process ID in cmd of the current cmd process: http://superuser.com/questions/881789/identify-and-kill-batch-script-started-before
 set T=%TEMP%\atomCmdProcessId-%time::=%.tmp
-wmic process where (Name="WMIC.exe" AND CommandLine LIKE "%%%TIME%%%") get ParentProcessId /value | find "ParentProcessId" >%T%
-set /P A=<%T%
+wmic process where (Name="WMIC.exe" AND CommandLine LIKE "%%%TIME%%%") get ParentProcessId /value | find "ParentProcessId" >"%T%"
+set /P A=<"%T%"
 set PID=%A:~16%
-del %T%
+del "%T%"
 
 IF "%EXPECT_OUTPUT%"=="YES" (
   SET ELECTRON_ENABLE_LOGGING=YES
@@ -45,7 +45,7 @@ IF "%EXPECT_OUTPUT%"=="YES" (
 goto end
 
 :waitLoop
-  sleep 1
+  timeout 1 > nul
   goto waitLoop
 
 :end

--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -38,7 +38,7 @@ if [ $EXPECT_OUTPUT ]; then
   export ELECTRON_ENABLE_LOGGING=1
   "$directory/../../atom.exe" --executed-from="$(pwd)" --pid=$PID "$@"
 else
-  "$directory/../app/apm/bin/node.exe" "$directory/atom.js" "$@"
+  "$directory/../app/apm/bin/node.exe" "$directory/atom.js" --pid=$PID "$@"
 fi
 
 # If the wait flag is set, don't exit this process until Atom tells it to.


### PR DESCRIPTION
This PR:
- [x] Fixes a syntax error regarding `ELSE`
- [x] Fixes an issue associated with a space being a component of the path to atom.cmd or atom.exe
- [ ] Ensures that --wait exits correctly when used
## 
- Fixes #10934 

/cc @raelyard 
