### PR TITLE
return default to default open file behavior

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -111,7 +111,7 @@ module.exports =
       allowPendingPaneItems:
         description: 'Allow items to be previewed without adding them to a pane permanently, such as when single clicking files in the tree view.'
         type: 'boolean'
-        default: true
+        default: false
 
   editor:
     type: 'object'


### PR DESCRIPTION
In stable, click on a file in the tree, Atom opens a new file tab.
In beta, by default, clicking on the file opens over the active tab sometimes.
Switching `allowPendingPaneItems: default: false` returns behavior to expected from v1.5.x.
ref #10762

Not sure if [these lines](https://github.com/atom/atom/blob/ae26e6c8ca284bb2858c65074c8d1d64564d1593/src/workspace.coffee#L417-L418) need to be changed.
