### PR TITLE
Refactor pending state to live in pane instead of items

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -55,16 +55,6 @@ describe "TextEditor", ->
 
       expect(editor.tokenizedLineForScreenRow(0).invisibles.eol).toBe '?'
 
-    it "restores pending tabs in pending state", ->
-      expect(editor.isPending()).toBe false
-      editor2 = TextEditor.deserialize(editor.serialize(), atom)
-      expect(editor2.isPending()).toBe false
-
-      pendingEditor = atom.workspace.buildTextEditor(pending: true)
-      expect(pendingEditor.isPending()).toBe true
-      editor3 = TextEditor.deserialize(pendingEditor.serialize(), atom)
-      expect(editor3.isPending()).toBe true
-
   describe "when the editor is constructed with the largeFileMode option set to true", ->
     it "loads the editor but doesn't tokenize", ->
       editor = null
@@ -5827,53 +5817,3 @@ describe "TextEditor", ->
           screenRange: marker1.getRange(),
           rangeIsReversed: false
         }
-
-  describe "pending state", ->
-    editor1 = null
-    eventCount = null
-
-    beforeEach ->
-      waitsForPromise ->
-        atom.workspace.open('sample.txt', pending: true).then (o) -> editor1 = o
-
-      runs ->
-        eventCount = 0
-        editor1.onDidTerminatePendingState -> eventCount++
-
-    it "does not open file in pending state by default", ->
-      expect(editor.isPending()).toBe false
-
-    it "opens file in pending state if 'pending' option is true", ->
-      expect(editor1.isPending()).toBe true
-
-    it "terminates pending state if ::terminatePendingState is invoked", ->
-      editor1.terminatePendingState()
-
-      expect(editor1.isPending()).toBe false
-      expect(eventCount).toBe 1
-
-    it "terminates pending state when buffer is changed", ->
-      editor1.insertText('I\'ll be back!')
-      advanceClock(editor1.getBuffer().stoppedChangingDelay)
-
-      expect(editor1.isPending()).toBe false
-      expect(eventCount).toBe 1
-
-    it "only calls terminate handler once when text is modified twice", ->
-      editor1.insertText('Some text')
-      advanceClock(editor1.getBuffer().stoppedChangingDelay)
-
-      editor1.save()
-
-      editor1.insertText('More text')
-      advanceClock(editor1.getBuffer().stoppedChangingDelay)
-
-      expect(editor1.isPending()).toBe false
-      expect(eventCount).toBe 1
-
-    it "only calls terminate handler once when terminatePendingState is called twice", ->
-      editor1.terminatePendingState()
-      editor1.terminatePendingState()
-
-      expect(editor1.isPending()).toBe false
-      expect(eventCount).toBe 1

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -588,19 +588,22 @@ describe "Workspace", ->
     describe "when the file is already open in pending state", ->
       it "should terminate the pending state", ->
         editor = null
+        pane = null
 
         waitsForPromise ->
-          atom.workspace.open('sample.js', pending: true).then (o) -> editor = o
-          
+          atom.workspace.open('sample.js', pending: true).then (o) ->
+            editor = o
+            pane = atom.workspace.getActivePane()
+
         runs ->
-          expect(editor.isPending()).toBe true
-          
+          expect(pane.getPendingItem()).toEqual editor
+
         waitsForPromise ->
-          atom.workspace.open('sample.js').then (o) -> editor = o
-          
+          atom.workspace.open('sample.js')
+
         runs ->
-          expect(editor.isPending()).toBe false
-  
+          expect(pane.getPendingItem()).toBeNull()
+
   describe "::reopenItem()", ->
     it "opens the uri associated with the last closed pane that isn't currently open", ->
       pane = workspace.getActivePane()
@@ -1551,11 +1554,12 @@ describe "Workspace", ->
 
   describe "when the core.allowPendingPaneItems option is falsey", ->
     it "does not open item with `pending: true` option as pending", ->
-      editor = null
+      pane = null
       atom.config.set('core.allowPendingPaneItems', false)
 
       waitsForPromise ->
-        atom.workspace.open('sample.js', pending: true).then (o) -> editor = o
+        atom.workspace.open('sample.js', pending: true).then ->
+          pane = atom.workspace.getActivePane()
 
       runs ->
-        expect(editor.isPending()).toBeFalsy()
+        expect(pane.getPendingItem()).toBeFalsy()

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -353,7 +353,7 @@ class Pane extends Model
   #   items in a pane are replaced with new pending items when they are opened.
   activateItem: (item, pending=false) ->
     if item?
-      if @isItemPending(@activeItem)
+      if @getPendingItem() is @activeItem
         index = @getActiveItemIndex()
       else
         index = @getActiveItemIndex() + 1

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -426,7 +426,7 @@ class Pane extends Model
     index = @items.indexOf(item)
     return if index is -1
 
-    @pendingItem = null if @isItemPending(item)
+    @pendingItem = null if @getPendingItem() is item
 
     @emitter.emit 'will-remove-item', {item, index, destroyed: not moved, moved}
     @unsubscribeFromItem(item)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -164,7 +164,7 @@ class TextEditor extends Model
       @emitter.emit 'did-change-encoding', @getEncoding()
     @disposables.add @buffer.onDidDestroy => @destroy()
     @disposables.add @buffer.onDidChangeModified =>
-      @terminatePendingState() if @buffer.isModified()
+      @terminatePendingState() if not @hasTerminatedPendingState and @buffer.isModified()
 
     @preserveCursorPositionOnBufferReload()
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -165,10 +165,12 @@ class TextEditor extends Model
       @emitter.emit 'did-change-encoding', @getEncoding()
     @disposables.add @buffer.onDidDestroy => @destroy()
     @disposables.add @buffer.onDidChangeModified =>
-      atom.workspace.setItemNotPending(this) if not @bufferHasChanged and @buffer.isModified()
-      @bufferHasChanged = true
+      @emitter.emit 'did-terminate-pending-state'
 
     @preserveCursorPositionOnBufferReload()
+
+  onDidTerminatePendingState: (callback) ->
+    @emitter.on 'did-terminate-pending-state', callback
 
   subscribeToDisplayBuffer: ->
     @disposables.add @selectionsMarkerLayer.onDidCreateMarker @addSelection.bind(this)

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -515,12 +515,6 @@ class Workspace extends Model
         @emitter.emit 'did-open', {uri, pane, item, index}
         item
 
-  setItemNotPending: (item) =>
-    for pane in @getPanes()
-      if item is pane.getPendingItem()
-        pane.setPendingItem(null)
-        break
-
   openTextFile: (uri, options) ->
     filePath = @project.resolvePath(uri)
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -477,7 +477,7 @@ class Workspace extends Model
 
     if uri?
       if item = pane.itemForURI(uri)
-        item.terminatePendingState?() if item.isPending?() and not options.pending
+        pane.setPendingItem(null) if not options.pending
       item ?= opener(uri, options) for opener in @getOpeners() when not item
 
     try
@@ -500,7 +500,7 @@ class Workspace extends Model
         return item if pane.isDestroyed()
 
         @itemOpened(item)
-        pane.activateItem(item) if activateItem
+        pane.activateItem(item, options.pending) if activateItem
         pane.activate() if activatePane
 
         initialLine = initialColumn = 0
@@ -514,6 +514,12 @@ class Workspace extends Model
         index = pane.getActiveItemIndex()
         @emitter.emit 'did-open', {uri, pane, item, index}
         item
+
+  setItemNotPending: (item) =>
+    for pane in @getPanes()
+      if item is pane.getPendingItem()
+        pane.setPendingItem(null)
+        break
 
   openTextFile: (uri, options) ->
     filePath = @project.resolvePath(uri)

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -403,6 +403,9 @@ class Workspace extends Model
   #     containing pane. Defaults to `true`.
   #   * `activateItem` A {Boolean} indicating whether to call {Pane::activateItem}
   #     on containing pane. Defaults to `true`.
+  #   * `pending` A {Boolean} indicating whether or not the item should be opened
+  #     in a pending state. Existing pending items in a pane are replaced with
+  #     new pending items when they are opened.
   #   * `searchAllPanes` A {Boolean}. If `true`, the workspace will attempt to
   #     activate an existing item for the given URI on any pane.
   #     If `false`, only the active pane will be searched for
@@ -477,7 +480,7 @@ class Workspace extends Model
 
     if uri?
       if item = pane.itemForURI(uri)
-        pane.setPendingItem(null) if not options.pending
+        pane.clearPendingItem() if not options.pending and pane.getPendingItem() is item
       item ?= opener(uri, options) for opener in @getOpeners() when not item
 
     try


### PR DESCRIPTION
- ~~New public API `workspace.setItemNotPending` that
  packages can use to set an item to set an item to not pending
  (e.g. when the user interacts with the item)~~
- Pending state for newly opened items with `{pending: true}`
  is now tracked by `Pane` instead of the item, and packages like
  `tabs` that query this information now get it from the Pane.

See corresponding changes:
- https://github.com/atom/tabs/pull/268
- https://github.com/atom/tree-view/pull/741
