### PR TITLE
Fix a inconsistent getLineCount() use

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -3215,7 +3215,7 @@ class TextEditor extends Model
   # top of the visible area.
   setFirstVisibleScreenRow: (screenRow, fromView) ->
     unless fromView
-      maxScreenRow = @getLineCount() - 1
+      maxScreenRow = @getScreenLineCount() - 1
       unless @config.get('editor.scrollPastEnd')
         height = @displayBuffer.getHeight()
         lineHeightInPixels = @displayBuffer.getLineHeightInPixels()
@@ -3233,7 +3233,7 @@ class TextEditor extends Model
     height = @displayBuffer.getHeight()
     lineHeightInPixels = @displayBuffer.getLineHeightInPixels()
     if height? and lineHeightInPixels?
-      Math.min(@firstVisibleScreenRow + Math.floor(height / lineHeightInPixels), @getLineCount() - 1)
+      Math.min(@firstVisibleScreenRow + Math.floor(height / lineHeightInPixels), @getScreenLineCount() - 1)
     else
       null
 


### PR DESCRIPTION
This PR refer to [vim-mode-issue 961](https://github.com/atom/vim-mode/issues/961) and [vim-mode-PR 970](https://github.com/atom/vim-mode/pull/970).

To explain the problem more details, I uploaded a video file.
[video reproduce the problem](https://youtu.be/cu8EDDZt_aU)

Thank you.
