### PR TITLE
Always strip git+ prefix and .git suffix from package repository URLs

### DIFF
--- a/spec/fixtures/packages/package-with-prefixed-and-suffixed-repo-url/package.json
+++ b/spec/fixtures/packages/package-with-prefixed-and-suffixed-repo-url/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "package-with-a-git-prefixed-git-repo-url",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/example/repo.git"
+  },
+  "_id": "this is here to simulate the URL being already normalized by npm. we still need to stript git+ from the beginning and .git from the end."
+}

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -55,11 +55,16 @@ describe "PackageManager", ->
     it "normalizes short repository urls in package.json", ->
       {metadata} = atom.packages.loadPackage("package-with-short-url-package-json")
       expect(metadata.repository.type).toBe "git"
-      expect(metadata.repository.url).toBe "https://github.com/example/repo.git"
+      expect(metadata.repository.url).toBe "https://github.com/example/repo"
 
       {metadata} = atom.packages.loadPackage("package-with-invalid-url-package-json")
       expect(metadata.repository.type).toBe "git"
       expect(metadata.repository.url).toBe "foo"
+
+    it "trims git+ from the beginning and .git from the end of repository URLs, even if npm already normalized them ", ->
+      {metadata} = atom.packages.loadPackage("package-with-prefixed-and-suffixed-repo-url")
+      expect(metadata.repository.type).toBe "git"
+      expect(metadata.repository.url).toBe "https://github.com/example/repo"
 
     it "returns null if the package is not found in any package directory", ->
       spyOn(console, 'warn')

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -541,11 +541,12 @@ class PackageManager
     unless typeof metadata.name is 'string' and metadata.name.length > 0
       metadata.name = packageName
 
+    if metadata.repository?.type is 'git' and typeof metadata.repository.url is 'string'
+      metadata.repository.url = metadata.repository.url.replace(/(^git\+)|(\.git$)/g, '')
+
     metadata
 
   normalizePackageMetadata: (metadata) ->
     unless metadata?._id
       normalizePackageData ?= require 'normalize-package-data'
       normalizePackageData(metadata)
-      if metadata.repository?.type is 'git' and typeof metadata.repository.url is 'string'
-        metadata.repository.url = metadata.repository.url.replace(/^git\+/, '')


### PR DESCRIPTION
Fixes https://github.com/atom/deprecation-cop/issues/66

Previously, a guard based on the presence of the `_id` field (which is inserted by npm during installation) prevented a regex replacement of the git+ prefix on URLs. Now we always do this. Since the .git suffix also causes problems and we’re removing that in packages, I now remove that as well.

The result should be that deprecation cop doesn't need to perform its own normalization. This was the intended original behavior but the `_id` guard broke it.
