### PR TITLE
Avoid creating empty buffers for deleted previous project paths

### DIFF
--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -21,6 +21,14 @@ describe "Project", ->
     afterEach ->
       deserializedProject?.destroy()
 
+    it "does not deserialize paths to non directories", ->
+      deserializedProject = new Project({notificationManager: atom.notifications, packageManager: atom.packages, confirm: atom.confirm})
+      state = atom.project.serialize()
+      state.paths.push('/directory/that/does/not/exist')
+      state.paths.push(path.join(__dirname, 'fixtures', 'sample.js'))
+      deserializedProject.deserialize(state, atom.deserializers)
+      expect(deserializedProject.getPaths()).toEqual(atom.project.getPaths())
+
     it "does not include unretained buffers in the serialized state", ->
       waitsForPromise ->
         atom.project.bufferForPath('a')

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -676,7 +676,7 @@ class AtomEnvironment extends Model
         @document.body.appendChild(@views.getView(@workspace))
         @backgroundStylesheet?.remove()
 
-        @watchProjectPath()
+        @watchProjectPaths()
 
         @packages.activate()
         @keymaps.loadUserKeymap()
@@ -808,7 +808,7 @@ class AtomEnvironment extends Model
     @themes.load()
 
   # Notify the browser project of the window's current project path
-  watchProjectPath: ->
+  watchProjectPaths: ->
     @disposables.add @project.onDidChangePaths =>
       @applicationDelegate.setRepresentedDirectoryPaths(@project.getPaths())
 

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -809,6 +809,7 @@ class AtomEnvironment extends Model
 
   # Notify the browser project of the window's current project path
   watchProjectPaths: ->
+    @applicationDelegate.setRepresentedDirectoryPaths(@project.getPaths())
     @disposables.add @project.onDidChangePaths =>
       @applicationDelegate.setRepresentedDirectoryPaths(@project.getPaths())
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -85,7 +85,7 @@ class AtomApplication
     else
       @loadState(options) or @openPath(options)
 
-  openWithOptions: ({pathsToOpen, executedFrom, urlsToOpen, test, pidToKillWhenClosed, devMode, safeMode, newWindow, logFile, profileStartup, timeout, clearWindowState, addToLastWindow}) ->
+  openWithOptions: ({initialPaths, pathsToOpen, executedFrom, urlsToOpen, test, pidToKillWhenClosed, devMode, safeMode, newWindow, logFile, profileStartup, timeout, clearWindowState, addToLastWindow}) ->
     if test
       @runTests({headless: true, devMode, @resourcePath, executedFrom, pathsToOpen, logFile, timeout})
     else if pathsToOpen.length > 0
@@ -94,7 +94,7 @@ class AtomApplication
       @openUrl({urlToOpen, devMode, safeMode}) for urlToOpen in urlsToOpen
     else
       # Always open a editor window if this is the first instance of Atom.
-      @openPath({pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, clearWindowState, addToLastWindow})
+      @openPath({initialPaths, pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, clearWindowState, addToLastWindow})
 
   # Public: Removes the {AtomWindow} from the global window list.
   removeWindow: (window) ->
@@ -418,8 +418,8 @@ class AtomApplication
   #   :profileStartup - Boolean to control creating a profile of the startup time.
   #   :window - {AtomWindow} to open file paths in.
   #   :addToLastWindow - Boolean of whether this should be opened in last focused window.
-  openPath: ({pathToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, window, clearWindowState, addToLastWindow} = {}) ->
-    @openPaths({pathsToOpen: [pathToOpen], pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, window, clearWindowState, addToLastWindow})
+  openPath: ({initialPaths, pathToOpen, pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, window, clearWindowState, addToLastWindow} = {}) ->
+    @openPaths({initialPaths, pathsToOpen: [pathToOpen], pidToKillWhenClosed, newWindow, devMode, safeMode, profileStartup, window, clearWindowState, addToLastWindow})
 
   # Public: Opens multiple paths, in existing windows if possible.
   #
@@ -432,7 +432,7 @@ class AtomApplication
   #   :windowDimensions - Object with height and width keys.
   #   :window - {AtomWindow} to open file paths in.
   #   :addToLastWindow - Boolean of whether this should be opened in last focused window.
-  openPaths: ({pathsToOpen, executedFrom, pidToKillWhenClosed, newWindow, devMode, safeMode, windowDimensions, profileStartup, window, clearWindowState, addToLastWindow}={}) ->
+  openPaths: ({initialPaths, pathsToOpen, executedFrom, pidToKillWhenClosed, newWindow, devMode, safeMode, windowDimensions, profileStartup, window, clearWindowState, addToLastWindow}={}) ->
     devMode = Boolean(devMode)
     safeMode = Boolean(safeMode)
     clearWindowState = Boolean(clearWindowState)
@@ -469,7 +469,7 @@ class AtomApplication
       windowInitializationScript ?= require.resolve('../initialize-application-window')
       resourcePath ?= @resourcePath
       windowDimensions ?= @getDimensionsForNewWindow()
-      openedWindow = new AtomWindow({locationsToOpen, windowInitializationScript, resourcePath, devMode, safeMode, windowDimensions, profileStartup, clearWindowState})
+      openedWindow = new AtomWindow({initialPaths, locationsToOpen, windowInitializationScript, resourcePath, devMode, safeMode, windowDimensions, profileStartup, clearWindowState})
 
     if pidToKillWhenClosed?
       @pidsToOpenWindows[pidToKillWhenClosed] = openedWindow
@@ -512,7 +512,8 @@ class AtomApplication
     if (states = @storageFolder.load('application.json'))?.length > 0
       for state in states
         @openWithOptions(_.extend(options, {
-          pathsToOpen: state.initialPaths
+          initialPaths: state.initialPaths
+          pathsToOpen: []
           urlsToOpen: []
           devMode: @devMode
           safeMode: @safeMode

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -47,20 +47,20 @@ class AtomWindow
     loadSettings.safeMode ?= false
     loadSettings.atomHome = process.env.ATOM_HOME
     loadSettings.clearWindowState ?= false
+    loadSettings.initialPaths ?=
+      for {pathToOpen} in locationsToOpen when pathToOpen
+        if fs.statSyncNoException(pathToOpen).isFile?()
+          path.dirname(pathToOpen)
+        else
+          pathToOpen
+    loadSettings.initialPaths.sort()
 
     # Only send to the first non-spec window created
     if @constructor.includeShellLoadTime and not @isSpec
       @constructor.includeShellLoadTime = false
       loadSettings.shellLoadTime ?= Date.now() - global.shellStartTime
 
-    loadSettings.initialPaths =
-      for {pathToOpen} in locationsToOpen when pathToOpen
-        if fs.statSyncNoException(pathToOpen).isFile?()
-          path.dirname(pathToOpen)
-        else
-          pathToOpen
 
-    loadSettings.initialPaths.sort()
 
     @browserWindow.once 'window:loaded', =>
       @emit 'window:loaded'

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -56,6 +56,7 @@ class Project extends Model
 
   deserialize: (state, deserializerManager) ->
     state.paths = [state.path] if state.path? # backward compatibility
+    state.paths = state.paths.filter (directoryPath) -> fs.isDirectorySync(directoryPath)
 
     @buffers = _.compact state.buffers.map (bufferState) ->
       # Check that buffer's file path is accessible


### PR DESCRIPTION
Closes #10628 

To test this:
- Open Atom with 2 directories.
- Delete one of the directories and reload Atom.
- Atom should be opened with only one directory.
