### PR TITLE
Use persistence stateKey directly rather than initialPaths

### DIFF
--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -121,6 +121,11 @@ class ApplicationDelegate
     loadSettings['initialPaths'] = paths
     setWindowLoadSettings(loadSettings)
 
+  setRepresentedStateKey: (stateKey) ->
+    loadSettings = getWindowLoadSettings()
+    loadSettings['stateKey'] = stateKey
+    setWindowLoadSettings(loadSettings)
+
   setAutoHideWindowMenuBar: (autoHide) ->
     ipcRenderer.send("call-window-method", "setAutoHideMenuBar", autoHide)
 

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -811,6 +811,7 @@ class AtomEnvironment extends Model
   watchProjectPath: ->
     @disposables.add @project.onDidChangePaths =>
       @applicationDelegate.setRepresentedDirectoryPaths(@project.getPaths())
+      @applicationDelegate.setRepresentedStateKey(@getStateKey(@project.getPaths()))
 
   setDocumentEdited: (edited) ->
     @applicationDelegate.setWindowDocumentEdited?(edited)
@@ -848,7 +849,9 @@ class AtomEnvironment extends Model
 
   loadState: ->
     if @enablePersistence
-      if stateKey = @getStateKey(@getLoadSettings().initialPaths)
+      stateKey = @getLoadSettings().stateKey
+      stateKey ?= @getStateKey(@getLoadSettings().initialPaths) # backwards compability
+      if stateKey
         @stateStore.load(stateKey)
       else
         @applicationDelegate.getTemporaryWindowState()

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -677,6 +677,8 @@ class AtomEnvironment extends Model
         @backgroundStylesheet?.remove()
 
         @watchProjectPath()
+        # Ensure initialPaths is up to date
+        @applicationDelegate.setRepresentedDirectoryPaths(@project.getPaths())
 
         @packages.activate()
         @keymaps.loadUserKeymap()

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -504,7 +504,7 @@ class AtomApplication
     for window in @windows
       unless window.isSpec
         if loadSettings = window.getLoadSettings()
-          states.push(stateKey: loadSettings.stateKey)
+          states.push(stateKey: loadSettings.stateKey, initialPaths: loadSettings.initialPaths)
     if states.length > 0 or allowEmpty
       @storageFolder.storeSync('application.json', states)
 


### PR DESCRIPTION
Saves and restores application state using the stateKey rather than initialPaths themselves. This avoids having Atom "open" these initialPaths, instead using the deserialized project to restore these paths.

Replaces #10628, see #11023

spec/integration/startup-spec.coffee should have a spec for this, but I couldn't get the tests to run.
