### PR TITLE
Use apm from `core.apmPath` config if it exists

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -17,6 +17,20 @@ describe "PackageManager", ->
   beforeEach ->
     workspaceElement = atom.views.getView(atom.workspace)
 
+  describe "::getApmPath()", ->
+    it "returns the path to the apm command", ->
+      apmPath = path.join(process.resourcesPath, "app", "apm", "bin", "apm")
+      if process.platform is 'win32'
+        apmPath += ".cmd"
+      expect(atom.packages.getApmPath()).toBe apmPath
+
+      describe "when the core.apmPath setting is set", ->
+        beforeEach ->
+          atom.config.set("core.apmPath", "/path/to/apm")
+
+        it "returns the value of the core.apmPath config setting", ->
+          expect(atom.packages.getApmPath()).toBe "/path/to/apm"
+
   describe "::loadPackage(name)", ->
     beforeEach ->
       atom.config.set("core.disabledPackages", [])

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -128,8 +128,12 @@ class PackageManager
 
   # Public: Get the path to the apm command.
   #
+  # Uses the value of the `core.apmPath` config setting if it exists.
+  #
   # Return a {String} file path to apm.
   getApmPath: ->
+    configPath = atom.config.get('core.apmPath')
+    return configPath if configPath
     return @apmPath if @apmPath?
 
     commandName = 'apm'


### PR DESCRIPTION
Add the ability to install packages via git urls. See https://github.com/atom/apm/pull/518 and https://github.com/atom/settings-view/pull/743.

Signed-off-by: Michelle Tilley binarymuse@github.com /cc @BinaryMuse 
