### PR TITLE
Ensure atom.cmd --wait correctly waits in Windows cmd & powershell

### DIFF
--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -22,30 +22,13 @@ FOR %%a IN (%*) DO (
   )
 )
 
-rem Getting the process ID in cmd of the current cmd process: http://superuser.com/questions/881789/identify-and-kill-batch-script-started-before
-set T=%TEMP%\atomCmdProcessId-%time::=%.tmp
-wmic process where (Name="WMIC.exe" AND CommandLine LIKE "%%%TIME%%%") get ParentProcessId /value | find "ParentProcessId" >%T%
-set /P A=<%T%
-set PID=%A:~16%
-del %T%
-
 IF "%EXPECT_OUTPUT%"=="YES" (
   SET ELECTRON_ENABLE_LOGGING=YES
   IF "%WAIT%"=="YES" (
-    "%~dp0\..\..\atom.exe" --pid=%PID% %*
-    rem If the wait flag is set, don't exit this process until Atom tells it to.
-    goto waitLoop
+    powershell -noexit "%~dp0\..\..\atom.exe" --pid=$pid %* ; wait-event
   ) ELSE (
     "%~dp0\..\..\atom.exe" %*
   )
 ) ELSE (
   "%~dp0\..\app\apm\bin\node.exe" "%~dp0\atom.js" %*
 )
-
-goto end
-
-:waitLoop
-  sleep 1
-  goto waitLoop
-
-:end


### PR DESCRIPTION
Existing solution caused Command Prompt to exit and sleep command is not built in to Windows.

New solution works by spawning powershell child process that passes it's PID to atom and then waits indefinitely. When atom terminates that process the parent process continues.

Tested in Command Prompt and Powershell in Windows 7 32-bit and Windows 10 64-bit.
