### PR TITLE
Move Pane::addItem 'pending' option to options object

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "status-bar": "0.83.0",
     "styleguide": "0.45.1",
     "symbols-view": "0.110.1",
-    "tabs": "0.91.2",
+    "tabs": "0.91.3",
     "timecop": "0.33.0",
     "tree-view": "0.201.5",
     "update-package-dependencies": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "status-bar": "0.83.0",
     "styleguide": "0.45.1",
     "symbols-view": "0.110.1",
-    "tabs": "0.91.1",
+    "tabs": "0.91.2",
     "timecop": "0.33.0",
     "tree-view": "0.201.5",
     "update-package-dependencies": "0.10.0",

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -680,6 +680,23 @@ describe "Pane", ->
           expect(pane2.isDestroyed()).toBe true
           expect(item4.isDestroyed()).toBe false
 
+    describe "when the item being moved is pending", ->
+      it "is made permanent in the new pane", ->
+        item6 = new Item("F")
+        pane1.addItem(item6, pending: true)
+        expect(pane1.getPendingItem()).toEqual item6
+        pane1.moveItemToPane(item6, pane2, 0)
+        expect(pane2.getPendingItem()).not.toEqual item6
+
+    describe "when the target pane has a pending item", ->
+      it "does not destroy the pending item", ->
+        item6 = new Item("F")
+        pane1.addItem(item6, pending: true)
+        expect(pane1.getPendingItem()).toEqual item6
+        pane2.moveItemToPane(item5, pane1, 0)
+        expect(pane1.getPendingItem()).toEqual item6
+
+
   describe "split methods", ->
     [pane1, item1, container] = []
 

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -1,5 +1,6 @@
 {extend} = require 'underscore-plus'
 {Emitter} = require 'event-kit'
+Grim = require 'grim'
 Pane = require '../src/pane'
 PaneAxis = require '../src/pane-axis'
 PaneContainer = require '../src/pane-container'
@@ -164,21 +165,24 @@ describe "Pane", ->
       runs ->
         expect(eventOrder).toEqual ["add", "remove"]
 
-    it "supports the older public API of ::addItem(item, index, moved)", ->
-      pane = new Pane(paneParams(items: []))
-      itemA = new Item("A")
-      itemB = new Item("B")
-      itemC = new Item("C")
-      pane.addItem(itemA, undefined, false, false)
-      pane.addItem(itemB, undefined, false, true)
-      pane.addItem(itemC, undefined, false, false)
-      expect(itemB.isDestroyed()).toBe true
+    describe "when using the old API of ::addItem(item, index)", ->
+      beforeEach ->
+        spyOn Grim, "deprecate"
 
-    it "shows a deprecation warning when passing a number", ->
-      spyOn Grim, "deprecate"
-      pane = new Pane(paneParams(items: []))
-      pane.addItem(new Item(), 2)
-      expect(Grim.deprecate).toHaveBeenCalledWith "Pane::addItem(item, 2) is deprecated in favor of Pane::addItem(item, {index: 2})"
+      it "supports the older public API", ->
+        pane = new Pane(paneParams(items: []))
+        itemA = new Item("A")
+        itemB = new Item("B")
+        itemC = new Item("C")
+        pane.addItem(itemA, 0)
+        pane.addItem(itemB, 0)
+        pane.addItem(itemC, 0)
+        expect(pane.getItems()).toEqual [itemC, itemB, itemA]
+
+      it "shows a deprecation warning", ->
+        pane = new Pane(paneParams(items: []))
+        pane.addItem(new Item(), 2)
+        expect(Grim.deprecate).toHaveBeenCalledWith "Pane::addItem(item, 2) is deprecated in favor of Pane::addItem(item, {index: 2})"
 
   describe "::activateItem(item)", ->
     pane = null

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -92,7 +92,7 @@ describe "Pane", ->
       pane = new Pane(paneParams(items: [new Item("A"), new Item("B")]))
       [item1, item2] = pane.getItems()
       item3 = new Item("C")
-      pane.addItem(item3, 1)
+      pane.addItem(item3, index: 1)
       expect(pane.getItems()).toEqual [item1, item3, item2]
 
     it "adds the item after the active item if no index is provided", ->
@@ -115,7 +115,7 @@ describe "Pane", ->
       pane.onDidAddItem (event) -> events.push(event)
 
       item = new Item("C")
-      pane.addItem(item, 1)
+      pane.addItem(item, index: 1)
       expect(events).toEqual [{item, index: 1, moved: false}]
 
     it "throws an exception if the item is already present on a pane", ->
@@ -137,9 +137,9 @@ describe "Pane", ->
       itemA = new Item("A")
       itemB = new Item("B")
       itemC = new Item("C")
-      pane.addItem(itemA, undefined, pending: false)
-      pane.addItem(itemB, undefined, pending: true)
-      pane.addItem(itemC, undefined, pending: false)
+      pane.addItem(itemA, pending: false)
+      pane.addItem(itemB, pending: true)
+      pane.addItem(itemC, pending: false)
       expect(itemB.isDestroyed()).toBe true
 
     it "adds the new item before destroying any existing pending item", ->
@@ -148,7 +148,7 @@ describe "Pane", ->
       pane = new Pane(paneParams(items: []))
       itemA = new Item("A")
       itemB = new Item("B")
-      pane.addItem(itemA, undefined, pending: true)
+      pane.addItem(itemA, pending: true)
 
       pane.onDidAddItem ({item}) ->
         eventOrder.push("add") if item is itemB
@@ -163,6 +163,16 @@ describe "Pane", ->
 
       runs ->
         expect(eventOrder).toEqual ["add", "remove"]
+
+    it "supports the older public API of ::addItem(item, index, moved)", ->
+      pane = new Pane(paneParams(items: []))
+      itemA = new Item("A")
+      itemB = new Item("B")
+      itemC = new Item("C")
+      pane.addItem(itemA, undefined, false, false)
+      pane.addItem(itemB, undefined, false, true)
+      pane.addItem(itemC, undefined, false, false)
+      expect(itemB.isDestroyed()).toBe true
 
   describe "::activateItem(item)", ->
     pane = null

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -174,6 +174,12 @@ describe "Pane", ->
       pane.addItem(itemC, undefined, false, false)
       expect(itemB.isDestroyed()).toBe true
 
+    it "shows a deprecation warning when passing a number", ->
+      spyOn Grim, "deprecate"
+      pane = new Pane(paneParams(items: []))
+      pane.addItem(new Item(), 2)
+      expect(Grim.deprecate).toHaveBeenCalledWith "Pane::addItem(item, 2) is deprecated in favor of Pane::addItem(item, {index: 2})"
+
   describe "::activateItem(item)", ->
     pane = null
 

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -137,9 +137,9 @@ describe "Pane", ->
       itemA = new Item("A")
       itemB = new Item("B")
       itemC = new Item("C")
-      pane.addItem(itemA, undefined, false, false)
-      pane.addItem(itemB, undefined, false, true)
-      pane.addItem(itemC, undefined, false, false)
+      pane.addItem(itemA, undefined, pending: false)
+      pane.addItem(itemB, undefined, pending: true)
+      pane.addItem(itemC, undefined, pending: false)
       expect(itemB.isDestroyed()).toBe true
 
     it "adds the new item before destroying any existing pending item", ->
@@ -148,7 +148,7 @@ describe "Pane", ->
       pane = new Pane(paneParams(items: []))
       itemA = new Item("A")
       itemB = new Item("B")
-      pane.addItem(itemA, undefined, false, true)
+      pane.addItem(itemA, undefined, pending: true)
 
       pane.onDidAddItem ({item}) ->
         eventOrder.push("add") if item is itemB
@@ -196,15 +196,15 @@ describe "Pane", ->
         itemD = new Item("D")
 
       it "replaces the active item if it is pending", ->
-        pane.activateItem(itemC, true)
+        pane.activateItem(itemC, pending: true)
         expect(pane.getItems().map (item) -> item.name).toEqual ['A', 'C', 'B']
-        pane.activateItem(itemD, true)
+        pane.activateItem(itemD, pending: true)
         expect(pane.getItems().map (item) -> item.name).toEqual ['A', 'D', 'B']
 
       it "adds the item after the active item if it is not pending", ->
-        pane.activateItem(itemC, true)
+        pane.activateItem(itemC, pending: true)
         pane.activateItemAtIndex(2)
-        pane.activateItem(itemD, true)
+        pane.activateItem(itemD, pending: true)
         expect(pane.getItems().map (item) -> item.name).toEqual ['A', 'B', 'D']
 
   describe "::setPendingItem", ->

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -404,7 +404,7 @@ class Pane extends Model
     @setPendingItem(item) if pending
 
     @emitter.emit 'did-add-item', {item, index, moved}
-    @destroyItem(lastPendingItem) if lastPendingItem?
+    @destroyItem(lastPendingItem) if lastPendingItem? and not moved
     @setActiveItem(item) unless @getActiveItem()?
     item
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -348,16 +348,17 @@ class Pane extends Model
   # Public: Make the given item *active*, causing it to be displayed by
   # the pane's view.
   #
-  # * `pending` (optional) {Boolean} indicating that the item should be added
-  #   in a pending state if it does not yet exist in the pane. Existing pending
-  #   items in a pane are replaced with new pending items when they are opened.
-  activateItem: (item, pending=false) ->
+  # * `options` (optional) {Object}
+  #   * `pending` (optional) {Boolean} indicating that the item should be added
+  #     in a pending state if it does not yet exist in the pane. Existing pending
+  #     items in a pane are replaced with new pending items when they are opened.
+  activateItem: (item, options={}) ->
     if item?
       if @getPendingItem() is @activeItem
         index = @getActiveItemIndex()
       else
         index = @getActiveItemIndex() + 1
-      @addItem(item, index, false, pending)
+      @addItem(item, index, options)
       @setActiveItem(item)
 
   # Public: Add the given item to the pane.
@@ -366,12 +367,16 @@ class Pane extends Model
   #   view.
   # * `index` (optional) {Number} indicating the index at which to add the item.
   #   If omitted, the item is added after the current active item.
-  # * `pending` (optional) {Boolean} indicating that the item should be
-  #   added in a pending state. Existing pending items in a pane are replaced with
-  #   new pending items when they are opened.
+  # * `options` (optional) {Object}
+  #   * `pending` (optional) {Boolean} indicating that the item should be
+  #     added in a pending state. Existing pending items in a pane are replaced with
+  #     new pending items when they are opened.
   #
   # Returns the added item.
-  addItem: (item, index=@getActiveItemIndex() + 1, moved=false, pending=false) ->
+  addItem: (item, index=@getActiveItemIndex() + 1, options={}) ->
+    pending = options.pending ? false
+    moved = options.moved ? false
+
     throw new Error("Pane items must be objects. Attempted to add item #{item}.") unless item? and typeof item is 'object'
     throw new Error("Adding a pane item with URI '#{item.getURI?()}' that has already been destroyed") if item.isDestroyed?()
 
@@ -463,7 +468,7 @@ class Pane extends Model
   #   given pane.
   moveItemToPane: (item, pane, index) ->
     @removeItem(item, true)
-    pane.addItem(item, index, true)
+    pane.addItem(item, index, {moved: true})
 
   # Public: Destroy the active item and activate the next item.
   destroyActiveItem: ->

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -1,4 +1,3 @@
-_ = require 'underscore-plus'
 Grim = require 'grim'
 {find, compact, extend, last} = require 'underscore-plus'
 {CompositeDisposable, Emitter} = require 'event-kit'
@@ -360,7 +359,7 @@ class Pane extends Model
         index = @getActiveItemIndex()
       else
         index = @getActiveItemIndex() + 1
-      @addItem(item, _.extend({index: index}, options))
+      @addItem(item, extend({}, options, {index: index}))
       @setActiveItem(item)
 
   # Public: Add the given item to the pane.
@@ -375,23 +374,12 @@ class Pane extends Model
   #     new pending items when they are opened.
   #
   # Returns the added item.
-  # addItem: (item, index=@getActiveItemIndex() + 1, moved=false, pending=false) ->
-  addItem: (item, options, args...) ->
+  addItem: (item, options={}) ->
     # Backward compat with old API:
-    #   addItem(item, index=@getActiveItemIndex() + 1, moved=false, pending=false)
-    unless options? and typeof options is "object"
-      if typeof options is "number"
-        Grim.deprecate("Pane::addItem(item, #{options}) is deprecated in favor of Pane::addItem(item, {index: #{options}})")
-
-      options =
-        index: options
-        moved: false
-        pending: false
-
-      if args.length > 0
-        [moved, pending] = args
-        options.moved = moved
-        options.pending = pending
+    #   addItem(item, index=@getActiveItemIndex() + 1)
+    if typeof options is "number"
+      Grim.deprecate("Pane::addItem(item, #{options}) is deprecated in favor of Pane::addItem(item, {index: #{options}})")
+      options = index: options
 
     index = options.index ? @getActiveItemIndex() + 1
     moved = options.moved ? false

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -1,4 +1,5 @@
 _ = require 'underscore-plus'
+Grim = require 'grim'
 {find, compact, extend, last} = require 'underscore-plus'
 {CompositeDisposable, Emitter} = require 'event-kit'
 Model = require './model'
@@ -374,10 +375,14 @@ class Pane extends Model
   #     new pending items when they are opened.
   #
   # Returns the added item.
+  # addItem: (item, index=@getActiveItemIndex() + 1, moved=false, pending=false) ->
   addItem: (item, options, args...) ->
     # Backward compat with old API:
     #   addItem(item, index=@getActiveItemIndex() + 1, moved=false, pending=false)
     unless options? and typeof options is "object"
+      if typeof options is "number"
+        Grim.deprecate("Pane::addItem(item, #{options}) is deprecated in favor of Pane::addItem(item, {index: #{options}})")
+
       options =
         index: options
         moved: false

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -503,7 +503,7 @@ class Workspace extends Model
         return item if pane.isDestroyed()
 
         @itemOpened(item)
-        pane.activateItem(item, options.pending) if activateItem
+        pane.activateItem(item, {pending: options.pending}) if activateItem
         pane.activate() if activatePane
 
         initialLine = initialColumn = 0


### PR DESCRIPTION
The API for adding pending pane items is pretty verbose; combined with ddb08d0c46ccf6408c5e7618fedd6cfc93bbad50, the argument list to `Pane::addItem` was getting pretty long, and it's easy to imagine it getting longer. This collapses things into an options object.

/cc @nathansobo re: the commit above; since the part of the API that changed was never publicly documented I assume it's fine to change for 1.6.

/cc @kuychaco the pending-ness :crown: 
