### PR TITLE
Default to auto height being true.

### DIFF
--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -18,6 +18,7 @@ class TextEditorElement extends HTMLElement
   hasTiledRendering: true
   logicalDisplayBuffer: true
   scrollPastEnd: true
+  autoHeight: true
 
   createdCallback: ->
     # Use globals when the following instance variables aren't set.


### PR DESCRIPTION
Otherwise TextEditorElements created through the tag wouldn’t have a
setting and be wrong.

I broke this in https://github.com/atom/atom/pull/10955.
