### PR TITLE
store disabled packages in deterministic order

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1104,6 +1104,17 @@ describe "Config", ->
         expect(atom.config.get("foo.bar.baz")).toEqual ["a", "b"]
         expect(observeHandler).toHaveBeenCalledWith atom.config.get("foo.bar.baz")
 
+    describe ".insertInOrderAtKeyPath(keyPath, value)", ->
+      it "insert the given value to the array in alphabetic order at the key path and updates observers", ->
+        atom.config.set("foo.bar.baz", ["b"])
+        observeHandler = jasmine.createSpy "observeHandler"
+        atom.config.observe "foo.bar.baz", observeHandler
+        observeHandler.reset()
+
+        expect(atom.config.insertInOrderAtKeyPath("foo.bar.baz", "a")).toBe true
+        expect(atom.config.get("foo.bar.baz")).toEqual ["a", "b"]
+        expect(observeHandler).toHaveBeenCalledWith atom.config.get("foo.bar.baz")
+
     describe ".unshiftAtKeyPath(keyPath, value)", ->
       it "unshifts the given value to the array at the key path and updates observers", ->
         atom.config.set("foo.bar.baz", ["b"])

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -757,6 +757,12 @@ class Config
     @set(keyPath, arrayValue)
     result
 
+  insertInOrderAtKeyPath: (keyPath, value) ->
+    arrayValue = @get(keyPath) ? []
+    arrayValue.push(value)
+    arrayValue.sort()
+    @set(keyPath, arrayValue)
+
   unshiftAtKeyPath: (keyPath, value) ->
     arrayValue = @get(keyPath) ? []
     result = arrayValue.unshift(value)

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -63,7 +63,7 @@ class Package
     @config.removeAtKeyPath('core.disabledPackages', @name)
 
   disable: ->
-    @config.pushAtKeyPath('core.disabledPackages', @name)
+    @config.insertInOrderAtKeyPath('core.disabledPackages', @name)
 
   isTheme: ->
     @metadata?.theme?


### PR DESCRIPTION
Follow up of #9948. Storing the list of disabled package names in a deterministic order.
