### PR TITLE
Modify selection to stop highlight at new-line (instead of continuing to end-of-screen)

### DIFF
--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -18,7 +18,7 @@ class TextEditorPresenter
     {@contentFrameWidth} = params
 
     @gutterWidth = 0
-    @tileSize ?= 6
+    @tileSize ?= 1
     @realScrollTop = @scrollTop
     @realScrollLeft = @scrollLeft
     @disposables = new CompositeDisposable
@@ -1228,51 +1228,17 @@ class TextEditorPresenter
     spannedRows = screenRange.end.row - screenRange.start.row + 1
 
     regions = []
+    region =
+      top: startPixelPosition.top
+      height: lineHeightInPixels
+      left: startPixelPosition.left
 
-    if spannedRows is 1
-      region =
-        top: startPixelPosition.top
-        height: lineHeightInPixels
-        left: startPixelPosition.left
+    region.width = endPixelPosition.left - startPixelPosition.left
+    if screenRange.end.column is Infinity
+      # Select the new line character
+      region.width += @baseCharacterWidth
 
-      if screenRange.end.column is Infinity
-        region.right = 0
-      else
-        region.width = endPixelPosition.left - startPixelPosition.left
-
-      regions.push(region)
-    else
-      # First row, extending from selection start to the right side of screen
-      regions.push(
-        top: startPixelPosition.top
-        left: startPixelPosition.left
-        height: lineHeightInPixels
-        right: 0
-      )
-
-      # Middle rows, extending from left side to right side of screen
-      if spannedRows > 2
-        regions.push(
-          top: startPixelPosition.top + lineHeightInPixels
-          height: endPixelPosition.top - startPixelPosition.top - lineHeightInPixels
-          left: 0
-          right: 0
-        )
-
-      # Last row, extending from left side of screen to selection end
-      if screenRange.end.column > 0
-        region =
-          top: endPixelPosition.top
-          height: lineHeightInPixels
-          left: 0
-
-        if screenRange.end.column is Infinity
-          region.right = 0
-        else
-          region.width = endPixelPosition.left
-
-        regions.push(region)
-
+    regions.push(region)
     regions
 
   setOverlayDimensions: (decorationId, itemWidth, itemHeight, contentMargin) ->


### PR DESCRIPTION
Continued work by @vjeux from https://github.com/atom/atom/pull/8640

It's mostly the same as what @vjeux had but I further extend the selection to select the new line (as it does in sublime and vs code).

---

Some general direction on how to go from there and I don't mind going through the specs and adjusting.

Now.. I'm not sure how to get the rounded corners that VS Code and Sublime have on the selection. I tried playing with border-radius and it sort of works but we need these triangles to fill in the bottom-right border radius (but only if the line is shorter than the line under it). An idea I had is we could perhaps switch to constructing a single SVG Path that is filled for selection. Perhaps @simurai knows a creative method to make it work in CSS. If there is a reasonable method to do this with CSS; the rounded selection could be left up to a theme to implement (and leave corner with pointy corner selection).

---

A question before I delve too much deeper. Is this something that would be accepted if we figure out a good solution? @nathansobo @benogle 
