### PR TITLE
Scroll to cursor on unfold all

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2936,6 +2936,7 @@ class TextEditor extends Model
   # Extended: Unfold all existing folds.
   unfoldAll: ->
     @languageMode.unfoldAll()
+    @scrollToCursorPosition()
 
   # Extended: Fold all foldable lines at the given indent level.
   #


### PR DESCRIPTION
In **`text-editor.coffee`**, call `scrollToCursorPosition` on the `unfoldAll` handler.

![atom-unfold-all-fixed](https://cloud.githubusercontent.com/assets/1685621/13551477/0c1789d2-e31a-11e5-9798-d37a6031d09e.gif)

---

Fixes #11066.
