### PR TITLE
Add TextEditors to the registry only when opting in

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -83,8 +83,9 @@ class TextEditor extends Model
     state.assert = atomEnvironment.assert.bind(atomEnvironment)
     state.applicationDelegate = atomEnvironment.applicationDelegate
     editor = new this(state)
-    disposable = atomEnvironment.textEditors.add(editor)
-    editor.onDidDestroy -> disposable.dispose()
+    if state.registered
+      disposable = atomEnvironment.textEditors.add(editor)
+      editor.onDidDestroy -> disposable.dispose()
     editor
 
   constructor: (params={}) ->
@@ -155,6 +156,7 @@ class TextEditor extends Model
     firstVisibleScreenColumn: @getFirstVisibleScreenColumn()
     displayBuffer: @displayBuffer.serialize()
     selectionsMarkerLayerId: @selectionsMarkerLayer.id
+    registered: atom.textEditors.editors.has this
 
   subscribeToBuffer: ->
     @buffer.retain()

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -542,7 +542,10 @@ class Workspace extends Model
         throw error
 
     @project.bufferForPath(filePath, options).then (buffer) =>
-      @buildTextEditor(_.extend({buffer, largeFileMode}, options))
+      editor = @buildTextEditor(_.extend({buffer, largeFileMode}, options))
+      disposable = atom.textEditors.add(editor)
+      editor.onDidDestroy -> disposable.dispose()
+      editor
 
   # Public: Returns a {Boolean} that is `true` if `object` is a `TextEditor`.
   #
@@ -558,10 +561,7 @@ class Workspace extends Model
       @config, @notificationManager, @packageManager, @clipboard, @viewRegistry,
       @grammarRegistry, @project, @assert, @applicationDelegate
     }, params)
-    editor = new TextEditor(params)
-    disposable = atom.textEditors.add(editor)
-    editor.onDidDestroy -> disposable.dispose()
-    editor
+    new TextEditor(params)
 
   # Public: Asynchronously reopens the last-closed item's URI if it hasn't already been
   # reopened.


### PR DESCRIPTION
This PR makes it so `TextEditors` are added to the registry only when they explicitly opt in.
This was mentioned in atom/atom#10851 (where I forgot to include it) to avoid leaking memory due to package authors not calling `destroy`.

/cc @nathansobo 
