### PR TITLE
Don't assign scrollLeft on model on 'scroll-left-changed' events

### DIFF
--- a/src/editor-view.coffee
+++ b/src/editor-view.coffee
@@ -567,7 +567,7 @@ class EditorView extends View
       @scrollTop(scrollTop)
 
     @subscribe @editor, 'scroll-left-changed', (scrollLeft) =>
-      @scrollLeft(scrollLeft)
+      @scrollView.scrollLeft(scrollLeft)
 
     @subscribe @editor, 'soft-wrap-changed', (softWrap) =>
       @setSoftWrap(softWrap)


### PR DESCRIPTION
Fixes #2513

I'm not entirely sure why, but for some reason we're getting into an
feedback cycle when the scrollLeft position changes in certain cases. In
theory, this shouldn't happen because reassigning the same value
shouldn't emit a change event. But since we're about to end-of-life the
jQuery editor, I'd like to try fixing it this way for now.
