### PR TITLE
Make atom.sh work in Cygwin

### DIFF
--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -38,7 +38,8 @@ if [ $EXPECT_OUTPUT ]; then
   export ELECTRON_ENABLE_LOGGING=1
   "$directory/../../atom.exe" --executed-from="$(pwd)" --pid=$PID "$@"
 else
-  "$directory/../app/apm/bin/node.exe" "$directory/atom.js" "$@"
+  cd "$directory"
+  "$directory/../app/apm/bin/node.exe" "atom.js" "$@"
 fi
 
 # If the wait flag is set, don't exit this process until Atom tells it to.


### PR DESCRIPTION
Node cannot figure out to resolve atom.js while running though cygwin:

```
$ atom --wait .
module.js:340
    throw err;
          ^
Error: Cannot find module 'C:\cygdrive\c...'
```

But if we change current working directory to `$directory` then node will be able to resolve atom.js
