### PR TITLE
Add zero to hexadecimal numbers below F (16)

### DIFF
--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1621,6 +1621,16 @@ describe "Config", ->
           expect(color.toHexString()).toBe '#ff0000'
           expect(color.toRGBAString()).toBe 'rgba(255, 0, 0, 1)'
 
+          color.red = 11
+          color.green = 11
+          color.blue = 124
+          color.alpha = 1
+          atom.config.set('foo.bar.aColor', color)
+
+          color = atom.config.get('foo.bar.aColor')
+          expect(color.toHexString()).toBe '#0b0b7c'
+          expect(color.toRGBAString()).toBe 'rgba(11, 11, 124, 1)'
+
         it 'coerces various types to a color object', ->
           atom.config.set('foo.bar.aColor', 'red')
           expect(atom.config.get('foo.bar.aColor')).toEqual {red: 255, green: 0, blue: 0, alpha: 1}

--- a/src/color.coffee
+++ b/src/color.coffee
@@ -85,5 +85,5 @@ parseAlpha = (alpha) ->
 
 numberToHexString = (number) ->
   hex = number.toString(16)
-  hex = "0#{hex}" if number < 10
+  hex = "0#{hex}" if number < 16
   hex


### PR DESCRIPTION
Should fix https://github.com/atom/settings-view/issues/712

The `numberToHexString` method incorrectly only put a 0 for numbers below 10 instead of 16, outputting `A` instead of `0A` for 11, for example. I've added a test at the only place that uses `toHexString` that fails on the current master branch. I'm not sure if it's in the right place, please let me know if I should move it/create seperate test cases.
