### PR TITLE
Compute a state key even if there are no project folders

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -880,7 +880,8 @@ class AtomEnvironment extends Model
       sha1 = crypto.createHash('sha1').update(paths.slice().sort().join("\n")).digest('hex')
       "editor-#{sha1}"
     else
-      null
+      # Represents an empty editor (no project folders)
+      "editor-<empty>"
 
   getConfigDirPath: ->
     @configDirPath ?= process.env.ATOM_HOME


### PR DESCRIPTION
This allows for state to be saved without a project folder added.

Would fix #10474 

---

I can add a spec for this if this something we want.
