### PR TITLE
Bump markdown-preview@v0.158.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "keybinding-resolver": "0.35.0",
     "line-ending-selector": "0.3.1",
     "link": "0.31.0",
-    "markdown-preview": "0.157.3",
+    "markdown-preview": "0.158.0",
     "metrics": "0.53.1",
     "notifications": "0.62.4",
     "open-on-github": "1.0.0",


### PR DESCRIPTION
This PR adds [Use GitHub style when "Save as HTML"](https://github.com/atom/markdown-preview/pull/335), but CI failed. Due to the "language-javascript-was-updated-but-markdown-preview-didn't-receive-the-changes-yet" failures, see https://github.com/atom/markdown-preview/pull/335#issuecomment-195120014.

Not sure if this will cause a build error in atom/atom too, hence this PR.
