### PR TITLE
:arrow_up: electron v0.37.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "0.36.8",
+  "electronVersion": "0.37.0",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "^6.3.1",


### PR DESCRIPTION
Update electron to the latest upstream. Supersedes PR #10983.
