### PR TITLE
Fix node env

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -4,7 +4,6 @@ path = require 'path'
 
 _ = require 'underscore-plus'
 {deprecate} = require 'grim'
-environmentHelpers = require('./environment-helpers')
 {CompositeDisposable, Disposable, Emitter} = require 'event-kit'
 fs = require 'fs-plus'
 {mapSourcePosition} = require 'source-map-support'
@@ -128,7 +127,6 @@ class AtomEnvironment extends Model
 
   # Call .loadOrCreate instead
   constructor: (params={}) ->
-    environmentHelpers.normalize(params)
     {@blobStore, @applicationDelegate, @window, @document, configDirPath, @enablePersistence, onlyLoadBaseStyleSheets} = params
 
     @unloaded = false

--- a/src/initialize-application-window.coffee
+++ b/src/initialize-application-window.coffee
@@ -1,10 +1,14 @@
 # Like sands through the hourglass, so are the days of our lives.
 module.exports = ({blobStore}) ->
+  environmentHelpers = require('./environment-helpers')
   path = require 'path'
   require './window'
   {getWindowLoadSettings} = require './window-load-settings-helpers'
 
   {resourcePath, isSpec, devMode, env} = getWindowLoadSettings()
+
+  # Set baseline environment
+  environmentHelpers.normalize({env: env})
 
   # Add application-specific exports to module search path.
   exportsPath = path.join(resourcePath, 'exports')


### PR DESCRIPTION
https://github.com/atom/atom/pull/11054 wasn't preserving the `NODE_PATH` environment variable when the `process.env` was changed. This caused at least one problem: fuzzy-finder could no longer index files. This fix preserves all `NODE_` environment variables from the original environment, no matter what other changes are made.

/cc @joefitzgerald @nathansobo 
