### PR TITLE
:bug: Make "Open Empty Editor on Start" config effective

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -231,6 +231,10 @@ class AtomEnvironment extends Model
       ipcRenderer.send('check-portable-home-writable', responseChannel)
 
     checkPortableHomeWritable()
+    
+    @config.onDidChange 'core.openEmptyEditorOnStart', ({newValue}) =>
+      ipcRenderer.send('config-initial-empty-editor', newValue)
+    ipcRenderer.send('config-initial-empty-editor', @config.get('core.openEmptyEditorOnStart') ? false)
 
   attachSaveStateListeners: ->
     saveState = => @saveState({isUnloading: false}) unless @unloaded
@@ -867,6 +871,8 @@ class AtomEnvironment extends Model
 
     @setFullScreen(state.fullScreen)
 
+    return if @config.get('core.openEmptyEditorOnStart')
+    
     @packages.packageStates = state.packageStates ? {}
 
     startTime = Date.now()

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -57,6 +57,7 @@ class AtomApplication
   resourcePath: null
   version: null
   quitting: false
+  initialEmptyEditor: false
 
   exit: (status) -> app.exit(status)
 
@@ -314,6 +315,10 @@ class AtomApplication
     ipcMain.on 'execute-javascript-in-dev-tools', (event, code) ->
       event.sender.devToolsWebContents?.executeJavaScript(code)
 
+    ipcMain.on 'config-initial-empty-editor', (event, newValue) =>
+      @initialEmptyEditor = newValue
+      @saveState(true)
+      
   setupDockMenu: ->
     if process.platform is 'darwin'
       dockMenu = Menu.buildFromTemplate [
@@ -502,10 +507,11 @@ class AtomApplication
   saveState: (allowEmpty=false) ->
     return if @quitting
     states = []
-    for window in @windows
-      unless window.isSpec
-        if loadSettings = window.getLoadSettings()
-          states.push(initialPaths: loadSettings.initialPaths)
+    unless @initialEmptyEditor
+      for window in @windows
+        unless window.isSpec
+          if loadSettings = window.getLoadSettings()
+            states.push(initialPaths: loadSettings.initialPaths)
     if states.length > 0 or allowEmpty
       @storageFolder.storeSync('application.json', states)
 


### PR DESCRIPTION
As reported on issue #10623, this config isn't effective or at least doesn't work as it sounds it should. This is due to the state persistence feature, which is unaware of this setting, restoring the editor to its last state on every startup. I agree with @ExClouds (the guy who opened the issue), when he says

> i expect the editor to open blank.. No open tabs, no open projects..

My strategy was to prevent state saving/loading when the setting is on. This is my first contribution to atom and I'm not that familiar with the code. I did what I thought would be the least intrusive changes.
