### PR TITLE
Note where GitRepositoryAsync deviates from its synchronous predecessor

### DIFF
--- a/src/git-repository-async.js
+++ b/src/git-repository-async.js
@@ -442,9 +442,6 @@ export default class GitRepositoryAsync {
   // Returns a {Promise} which resolves to a {Boolean} that's true if the `path`
   // is ignored.
   isPathIgnored (_path) {
-    // NB: We're matching the behavior of `GitRepository` here.
-    if (!_path) return Promise.resolve(false)
-
     return this.getRepo()
       .then(repo => {
         const relativePath = this.relativize(_path, repo.workdir())
@@ -521,10 +518,6 @@ export default class GitRepositoryAsync {
   // Returns a {Promise} which resolves to a status {Number} or null if the
   // path is not in the cache.
   getCachedPathStatus (_path) {
-    // NB: I don't love this, but we're matching the behavior of
-    // `GitRepository` here for API compatibility.
-    if (!_path) return null
-
     return this.relativizeToWorkingDirectory(_path)
       .then(relativePath => this.pathStatusCache[relativePath])
   }

--- a/src/git-repository-async.js
+++ b/src/git-repository-async.js
@@ -660,6 +660,11 @@ export default class GitRepositoryAsync {
         }
         return this._diffBlobToBuffer(blob, text, options)
       })
+      .catch(e => {
+        // NB: I don't love this, but we're matching the behavior of
+        // `GitRepository` here for API compatibility.
+        return {}
+      })
   }
 
   // Checking Out

--- a/src/git-repository-async.js
+++ b/src/git-repository-async.js
@@ -15,6 +15,12 @@ const submoduleMode = 57344 // TODO: compose this from libgit2 constants
 // Just using this for _.isEqual and _.object, we should impl our own here
 import _ from 'underscore-plus'
 
+// For the most part, this class behaves the same as `GitRepository`, with a few
+// notable differences:
+//   * Errors are generally propagated out to the caller instead of being
+//     swallowed within `GitRepositoryAsync`.
+//   * Methods accepting a path shouldn't be given a null path, unless it is
+//     specifically allowed as noted in the method's documentation.
 export default class GitRepositoryAsync {
   static open (path, options = {}) {
     // QUESTION: Should this wrap Git.Repository and reject with a nicer message?

--- a/src/git-repository-async.js
+++ b/src/git-repository-async.js
@@ -660,11 +660,6 @@ export default class GitRepositoryAsync {
         }
         return this._diffBlobToBuffer(blob, text, options)
       })
-      .catch(e => {
-        // NB: I don't love this, but we're matching the behavior of
-        // `GitRepository` here for API compatibility.
-        return {}
-      })
   }
 
   // Checking Out

--- a/src/git-repository-async.js
+++ b/src/git-repository-async.js
@@ -442,6 +442,9 @@ export default class GitRepositoryAsync {
   // Returns a {Promise} which resolves to a {Boolean} that's true if the `path`
   // is ignored.
   isPathIgnored (_path) {
+    // NB: We're matching the behavior of `GitRepository` here.
+    if (!_path) return Promise.resolve(false)
+
     return this.getRepo()
       .then(repo => {
         const relativePath = this.relativize(_path, repo.workdir())
@@ -518,6 +521,10 @@ export default class GitRepositoryAsync {
   // Returns a {Promise} which resolves to a status {Number} or null if the
   // path is not in the cache.
   getCachedPathStatus (_path) {
+    // NB: I don't love this, but we're matching the behavior of
+    // `GitRepository` here for API compatibility.
+    if (!_path) return null
+
     return this.relativizeToWorkingDirectory(_path)
       .then(relativePath => this.pathStatusCache[relativePath])
   }


### PR DESCRIPTION
Documents changes wrt https://github.com/atom/git-diff/issues/93 and https://github.com/atom/git-diff/issues/94.
