### PR TITLE
cli: Open stdin as a file when present

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -52,6 +52,12 @@ if [ $EXPECT_OUTPUT ]; then
   export ELECTRON_ENABLE_LOGGING=1
 fi
 
+if [ ! -t 0 ]; then
+  TEMPFILE="$(mktemp)"
+  cat > "$TEMPFILE"
+  set "$TEMPFILE" "$@"
+fi
+
 if [ $OS == 'Mac' ]; then
   if [ -n "$BETA_VERSION" ]; then
     ATOM_APP_NAME="Atom Beta.app"


### PR DESCRIPTION
The [atom cli discards its input from stdin](https://discuss.atom.io/t/it-would-be-nice-to-be-able-to-pipe-standard-out-to-atom-and-have-it-open-in-an-unsaved-document/4781) when other editors would open a new document containing that text.

This change writes input from stdin to a new temporary file and inserts that file as the first argument to the atom executable.
It only does that when stdin is not at tty, i.e. running `git diff | atom` creates and opens a temporary file but running `atom some/file` does not.

Closes https://github.com/atom/atom/issues/1729
## Caveats
- [ ] Errors from `mktemp` are not handled.
- [ ] The call to `mktemp` appears before ensuring that `TMPDIR` is set on line 105.
- [ ] `mktemp` is called without arguments, resulting in a filename like `tmp.XXXXXXXX`.  
  A filename prefix like `atom-stdin` would be nicer but the mktemp commands on [Linux](http://www.unix.com/man-page/linux/1/mktemp/) and [OS X](http://www.unix.com/man-page/osx/1/mktemp/) are sufficiently different to make this more involved. (A call like `mktemp -t atom-stdin` would work on OS X but wouldn't include a random suffix on Linux, if I understand the man page correctly.)
