### PR TITLE
Remove an unnecessary call to then().

### DIFF
--- a/src/git-repository-async.js
+++ b/src/git-repository-async.js
@@ -158,8 +158,7 @@ export default class GitRepositoryAsync {
 
     if (!this.projectAtRoot) {
       this.projectAtRoot = this.getRepo()
-        .then(repo => this.project.relativize(repo.workdir()))
-        .then(relativePath => relativePath === '')
+        .then(repo => this.project.relativize(repo.workdir()) === '')
     }
 
     return this.projectAtRoot


### PR DESCRIPTION
I see that this file has a little use of async/await and many uses of `then()`.
Things would be much less verbose and much more linear if async/await were used throughout.
Would Atom be open to a PR that changes this?

For bonus points, we could also replace `'use babel'` with `/* @flow */` at the top of the file :)
