### PR TITLE
:racehorse: wrap loop of config.setDefaults() in transact()

### DIFF
--- a/src/config.coffee
+++ b/src/config.coffee
@@ -958,9 +958,10 @@ class Config
   setDefaults: (keyPath, defaults) ->
     if defaults? and isPlainObject(defaults)
       keys = splitKeyPath(keyPath)
-      for key, childValue of defaults
-        continue unless defaults.hasOwnProperty(key)
-        @setDefaults(keys.concat([key]).join('.'), childValue)
+      @transact =>
+        for key, childValue of defaults
+          continue unless defaults.hasOwnProperty(key)
+          @setDefaults(keys.concat([key]).join('.'), childValue)
     else
       try
         defaults = @makeValueConformToSchema(keyPath, defaults)


### PR DESCRIPTION
When config.setDefaults() is called "did-change" event emitted per one config key.
This hits performance when package has large set of default configs (like [atom-beautify](https://github.com/Glavin001/atom-beautify/issues/679).

Without transact: 

<img width="637" alt="2016-03-20 1 29 10" src="https://cloud.githubusercontent.com/assets/400558/13903054/ab40c602-eeac-11e5-807b-953c18cbdded.png">

With transact:

<img width="641" alt="2016-03-20 14 47 49" src="https://cloud.githubusercontent.com/assets/400558/13903071/1def58bc-eead-11e5-8cd7-5394d0ee017a.png">

Thanks!
