### PR TITLE
More accurate block decoration measurements

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1840,17 +1840,22 @@ describe('TextEditorComponent', function () {
       expect(component.lineNodeForScreenRow(2).dataset.screenRow).toBe("2")
     })
 
-    it('measures block decorations taking into account both top and bottom margins', async function () {
+    it('measures block decorations taking into account both top and bottom margins of the element and its children', async function () {
       let [item, blockDecoration] = createBlockDecorationBeforeScreenRow(0, {className: "decoration-1"})
+      let child = document.createElement("div")
+      child.style.height = "7px"
+      child.style.width = "30px"
+      child.style.marginBottom = "20px"
+      item.appendChild(child)
       atom.styles.addStyleSheet(
-        'atom-text-editor .decoration-1 { width: 30px; height: 30px; margin-top: 10px; margin-bottom: 5px; }',
+        'atom-text-editor .decoration-1 { width: 30px; margin-top: 10px; }',
          {context: 'atom-text-editor'}
       )
 
       await nextAnimationFramePromise() // causes the DOM to update and to retrieve new styles
       await nextAnimationFramePromise() // applies the changes
 
-      expect(component.tileNodesForLines()[0].style.height).toBe(TILE_SIZE * editor.getLineHeightInPixels() + 30 + 10 + 5 + "px")
+      expect(component.tileNodesForLines()[0].style.height).toBe(TILE_SIZE * editor.getLineHeightInPixels() + 10 + 7 + 20 + "px")
       expect(component.tileNodesForLines()[0].style.webkitTransform).toBe("translate3d(0px, 0px, 0px)")
       expect(component.tileNodesForLines()[1].style.height).toBe(TILE_SIZE * editor.getLineHeightInPixels() + "px")
       expect(component.tileNodesForLines()[1].style.webkitTransform).toBe(`translate3d(0px, ${component.tileNodesForLines()[0].offsetHeight}px, 0px)`)

--- a/src/block-decorations-component.coffee
+++ b/src/block-decorations-component.coffee
@@ -26,7 +26,10 @@ class BlockDecorationsComponent
 
     for id, blockDecorationState of @oldState.blockDecorations
       unless @newState.blockDecorations.hasOwnProperty(id)
-        @blockDecorationNodesById[id].remove()
+        blockDecorationNode = @blockDecorationNodesById[id]
+        blockDecorationNode.previousSibling.remove()
+        blockDecorationNode.nextSibling.remove()
+        blockDecorationNode.remove()
         delete @blockDecorationNodesById[id]
         delete @oldState.blockDecorations[id]
 
@@ -41,19 +44,27 @@ class BlockDecorationsComponent
     for decorationId, blockDecorationNode of @blockDecorationNodesById
       style = getComputedStyle(blockDecorationNode)
       decoration = @newState.blockDecorations[decorationId].decoration
-      marginBottom = parseInt(style.marginBottom) ? 0
-      marginTop = parseInt(style.marginTop) ? 0
-      @presenter.setBlockDecorationDimensions(
-        decoration,
-        blockDecorationNode.offsetWidth,
-        blockDecorationNode.offsetHeight + marginTop + marginBottom
-      )
+      topRuler = blockDecorationNode.previousSibling
+      bottomRuler = blockDecorationNode.nextSibling
+
+      width = blockDecorationNode.offsetWidth
+      height = bottomRuler.offsetTop - topRuler.offsetTop
+      @presenter.setBlockDecorationDimensions(decoration, width, height)
 
   createAndAppendBlockDecorationNode: (id) ->
     blockDecorationState = @newState.blockDecorations[id]
+    blockDecorationClass = "atom--block-decoration-#{id}"
+    topRuler = document.createElement("div")
     blockDecorationNode = @views.getView(blockDecorationState.decoration.getProperties().item)
-    blockDecorationNode.id = "atom--block-decoration-#{id}"
+    bottomRuler = document.createElement("div")
+    topRuler.classList.add(blockDecorationClass)
+    blockDecorationNode.classList.add(blockDecorationClass)
+    bottomRuler.classList.add(blockDecorationClass)
+
+    @container.appendChild(topRuler)
     @container.appendChild(blockDecorationNode)
+    @container.appendChild(bottomRuler)
+
     @blockDecorationNodesById[id] = blockDecorationNode
     @updateBlockDecorationNode(id)
 

--- a/src/block-decorations-component.coffee
+++ b/src/block-decorations-component.coffee
@@ -69,15 +69,13 @@ class BlockDecorationsComponent
     @updateBlockDecorationNode(id)
 
   updateBlockDecorationNode: (id) ->
-    newBlockDecorationState = @newState.blockDecorations[id]
-    oldBlockDecorationState = @oldState.blockDecorations[id]
     blockDecorationNode = @blockDecorationNodesById[id]
 
-    if newBlockDecorationState.isVisible
+    if @newState.blockDecorations[id].isVisible
+      blockDecorationNode.previousSibling.classList.remove("atom--invisible-block-decoration")
       blockDecorationNode.classList.remove("atom--invisible-block-decoration")
+      blockDecorationNode.nextSibling.classList.remove("atom--invisible-block-decoration")
     else
+      blockDecorationNode.previousSibling.classList.add("atom--invisible-block-decoration")
       blockDecorationNode.classList.add("atom--invisible-block-decoration")
-
-    if oldBlockDecorationState.screenRow isnt newBlockDecorationState.screenRow
-      blockDecorationNode.dataset.screenRow = newBlockDecorationState.screenRow
-      oldBlockDecorationState.screenRow = newBlockDecorationState.screenRow
+      blockDecorationNode.nextSibling.classList.add("atom--invisible-block-decoration")

--- a/src/block-decorations-component.coffee
+++ b/src/block-decorations-component.coffee
@@ -69,9 +69,11 @@ class BlockDecorationsComponent
     @updateBlockDecorationNode(id)
 
   updateBlockDecorationNode: (id) ->
+    newBlockDecorationState = @newState.blockDecorations[id]
+    oldBlockDecorationState = @oldState.blockDecorations[id]
     blockDecorationNode = @blockDecorationNodesById[id]
 
-    if @newState.blockDecorations[id].isVisible
+    if newBlockDecorationState.isVisible
       blockDecorationNode.previousSibling.classList.remove("atom--invisible-block-decoration")
       blockDecorationNode.classList.remove("atom--invisible-block-decoration")
       blockDecorationNode.nextSibling.classList.remove("atom--invisible-block-decoration")
@@ -79,3 +81,7 @@ class BlockDecorationsComponent
       blockDecorationNode.previousSibling.classList.add("atom--invisible-block-decoration")
       blockDecorationNode.classList.add("atom--invisible-block-decoration")
       blockDecorationNode.nextSibling.classList.add("atom--invisible-block-decoration")
+
+    if oldBlockDecorationState.screenRow isnt newBlockDecorationState.screenRow
+      blockDecorationNode.dataset.screenRow = newBlockDecorationState.screenRow
+      oldBlockDecorationState.screenRow = newBlockDecorationState.screenRow

--- a/src/lines-tile-component.coffee
+++ b/src/lines-tile-component.coffee
@@ -149,7 +149,7 @@ class LinesTileComponent
     if newLineState.screenRow isnt oldLineState.screenRow
       insertionPoint.dataset.screenRow = newLineState.screenRow
 
-    precedingBlockDecorationsSelector = newLineState.precedingBlockDecorations.map((d) -> "#atom--block-decoration-#{d.id}").join(',')
+    precedingBlockDecorationsSelector = newLineState.precedingBlockDecorations.map((d) -> ".atom--block-decoration-#{d.id}").join(',')
 
     if precedingBlockDecorationsSelector isnt oldLineState.precedingBlockDecorationsSelector
       insertionPoint.setAttribute("select", precedingBlockDecorationsSelector)
@@ -180,7 +180,7 @@ class LinesTileComponent
     if newLineState.screenRow isnt oldLineState.screenRow
       insertionPoint.dataset.screenRow = newLineState.screenRow
 
-    followingBlockDecorationsSelector = newLineState.followingBlockDecorations.map((d) -> "#atom--block-decoration-#{d.id}").join(',')
+    followingBlockDecorationsSelector = newLineState.followingBlockDecorations.map((d) -> ".atom--block-decoration-#{d.id}").join(',')
 
     if followingBlockDecorationsSelector isnt oldLineState.followingBlockDecorationsSelector
       insertionPoint.setAttribute("select", followingBlockDecorationsSelector)


### PR DESCRIPTION
Fixes #11228.

Using `offsetHeight + marginTop + marginBottom` for any given block decoration item isn't appropriate, because it doesn't take into account the decoration's children and how they affect the surrounding content spatially.

With this PR, we are adding an element before and one after every block decoration, and use them as rulers that help us computing the appropriate height. Although it introduces two extra elements for each decoration, it shouldn't be a huge deal since those elements are supposedly pretty straightforward to lay out for Chrome.

/cc: @thedaniel @nathansobo 
