### PR TITLE
Fallback to ~/.atom/storage when no state is found in IndexedDb

### DIFF
--- a/spec/atom-environment-spec.coffee
+++ b/spec/atom-environment-spec.coffee
@@ -173,7 +173,7 @@ describe "AtomEnvironment", ->
       waitsForPromise ->
         atom.saveState().then ->
           atom.loadState().then (state) ->
-            expect(state).toBeNull()
+            expect(state).toBeFalsy()
 
       waitsForPromise ->
         loadSettings.initialPaths = [dir2, dir1]
@@ -188,15 +188,14 @@ describe "AtomEnvironment", ->
       loadSettings = _.extend(atom.getLoadSettings(), {initialPaths: [temp.mkdirSync("project-directory")]})
       spyOn(atom, 'getLoadSettings').andReturn(loadSettings)
       spyOn(atom, 'serialize').andReturn(serializedState)
-      spyOn(atom, 'getConfigDirPath').andReturn(temp.mkdirSync("config-directory"))
+      spyOn(atom, 'getStorageFolder').andReturn(new StorageFolder(temp.mkdirSync("config-directory")))
       atom.project.setPaths(atom.getLoadSettings().initialPaths)
 
       waitsForPromise ->
         atom.stateStore.connect()
 
       runs ->
-        storageFolder = new StorageFolder(atom.getConfigDirPath())
-        storageFolder.storeSync(atom.getStateKey(loadSettings.initialPaths), storageFolderState)
+        atom.getStorageFolder().storeSync(atom.getStateKey(loadSettings.initialPaths), storageFolderState)
 
       waitsForPromise ->
         atom.loadState().then (state) -> expect(state).toEqual(storageFolderState)

--- a/spec/atom-environment-spec.coffee
+++ b/spec/atom-environment-spec.coffee
@@ -4,6 +4,7 @@ temp = require 'temp'
 Package = require '../src/package'
 ThemeManager = require '../src/theme-manager'
 AtomEnvironment = require '../src/atom-environment'
+StorageFolder = require '../src/storage-folder'
 
 describe "AtomEnvironment", ->
   describe 'window sizing methods', ->
@@ -178,6 +179,33 @@ describe "AtomEnvironment", ->
         loadSettings.initialPaths = [dir2, dir1]
         atom.loadState().then (state) ->
           expect(state).toEqual({stuff: 'cool'})
+
+    it "loads state from the storage folder when it can't be found in atom.stateStore", ->
+      jasmine.useRealClock()
+
+      storageFolderState = {foo: 1, bar: 2}
+      serializedState = {someState: 42}
+      loadSettings = _.extend(atom.getLoadSettings(), {initialPaths: [temp.mkdirSync("project-directory")]})
+      spyOn(atom, 'getLoadSettings').andReturn(loadSettings)
+      spyOn(atom, 'serialize').andReturn(serializedState)
+      spyOn(atom, 'getConfigDirPath').andReturn(temp.mkdirSync("config-directory"))
+      atom.project.setPaths(atom.getLoadSettings().initialPaths)
+
+      waitsForPromise ->
+        atom.stateStore.connect()
+
+      runs ->
+        storageFolder = new StorageFolder(atom.getConfigDirPath())
+        storageFolder.storeSync(atom.getStateKey(loadSettings.initialPaths), storageFolderState)
+
+      waitsForPromise ->
+        atom.loadState().then (state) -> expect(state).toEqual(storageFolderState)
+
+      waitsForPromise ->
+        atom.saveState()
+
+      waitsForPromise ->
+        atom.loadState().then (state) -> expect(state).toEqual(serializedState)
 
     it "saves state on keydown, mousedown, and when the editor window unloads", ->
       spyOn(atom, 'saveState')

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -128,7 +128,7 @@ class AtomEnvironment extends Model
 
   # Call .loadOrCreate instead
   constructor: (params={}) ->
-    {@blobStore, @applicationDelegate, @window, @document, configDirPath, @enablePersistence, onlyLoadBaseStyleSheets} = params
+    {@blobStore, @applicationDelegate, @window, @document, @configDirPath, @enablePersistence, onlyLoadBaseStyleSheets} = params
 
     @unloaded = false
     @loadTime = null
@@ -148,10 +148,10 @@ class AtomEnvironment extends Model
 
     @notifications = new NotificationManager
 
-    @config = new Config({configDirPath, resourcePath, notificationManager: @notifications, @enablePersistence})
+    @config = new Config({@configDirPath, resourcePath, notificationManager: @notifications, @enablePersistence})
     @setConfigSchema()
 
-    @keymaps = new KeymapManager({configDirPath, resourcePath, notificationManager: @notifications})
+    @keymaps = new KeymapManager({@configDirPath, resourcePath, notificationManager: @notifications})
 
     @tooltips = new TooltipManager(keymapManager: @keymaps)
 
@@ -160,16 +160,16 @@ class AtomEnvironment extends Model
 
     @grammars = new GrammarRegistry({@config})
 
-    @styles = new StyleManager({configDirPath})
+    @styles = new StyleManager({@configDirPath})
 
     @packages = new PackageManager({
-      devMode, configDirPath, resourcePath, safeMode, @config, styleManager: @styles,
+      devMode, @configDirPath, resourcePath, safeMode, @config, styleManager: @styles,
       commandRegistry: @commands, keymapManager: @keymaps, notificationManager: @notifications,
       grammarRegistry: @grammars, deserializerManager: @deserializers, viewRegistry: @views
     })
 
     @themes = new ThemeManager({
-      packageManager: @packages, configDirPath, resourcePath, safeMode, @config,
+      packageManager: @packages, @configDirPath, resourcePath, safeMode, @config,
       styleManager: @styles, notificationManager: @notifications, viewRegistry: @views
     })
 

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -139,7 +139,9 @@ class AtomEnvironment extends Model
 
     @stateStore = new StateStore('AtomEnvironments', 1)
 
-    @stateStore.clear() if clearWindowState
+    if clearWindowState
+      @getStorageFolder().clear()
+      @stateStore.clear()
 
     @deserializers = new DeserializerManager(this)
     @deserializeTimings = {}

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -11,6 +11,7 @@ Model = require './model'
 WindowEventHandler = require './window-event-handler'
 StylesElement = require './styles-element'
 StateStore = require './state-store'
+StorageFolder = require './storage-folder'
 {getWindowLoadSettings, setWindowLoadSettings} = require './window-load-settings-helpers'
 registerDefaultCommands = require './register-default-commands'
 
@@ -853,7 +854,12 @@ class AtomEnvironment extends Model
   loadState: ->
     if @enablePersistence
       if stateKey = @getStateKey(@getLoadSettings().initialPaths)
-        @stateStore.load(stateKey)
+        @stateStore.load(stateKey).then (state) =>
+          if state
+            state
+          else
+            # TODO: remove this when every user has migrated to the IndexedDb state store.
+            @getStorageFolder().load(stateKey)
       else
         @applicationDelegate.getTemporaryWindowState()
     else
@@ -881,6 +887,9 @@ class AtomEnvironment extends Model
       "editor-#{sha1}"
     else
       null
+
+  getStorageFolder: ->
+    @storageFolder ?= new StorageFolder(@getConfigDirPath())
 
   getConfigDirPath: ->
     @configDirPath ?= process.env.ATOM_HOME

--- a/src/storage-folder.coffee
+++ b/src/storage-folder.coffee
@@ -12,7 +12,7 @@ class StorageFolder
     try
       fs.removeSync(@path)
     catch error
-      console.warn "Error deleting #{statePath}", error.stack, error
+      console.warn "Error deleting #{@path}", error.stack, error
 
   storeSync: (name, object) ->
     return unless @path?

--- a/src/storage-folder.coffee
+++ b/src/storage-folder.coffee
@@ -6,6 +6,14 @@ class StorageFolder
   constructor: (containingPath) ->
     @path = path.join(containingPath, "storage") if containingPath?
 
+  clear: ->
+    return unless @path?
+
+    try
+      fs.removeSync(@path)
+    catch error
+      console.warn "Error deleting #{statePath}", error.stack, error
+
   storeSync: (name, object) ->
     return unless @path?
 


### PR DESCRIPTION
This PR addresses the concerns raised by @jeancroy  in https://github.com/atom/atom/pull/10605#issuecomment-199603786 by falling back to reading state from the storage folder when we can't find one under IndexedDb.

Moreover, this introduces a `clear()` method on `StorageFolder` that deletes the storage folder whenever the user supplies the `--clear-window-state` argument (so that no state can be loaded in both IndexedDb and `~/.atom/storage`).

/cc: @nathansobo @kuychaco @iolsen 
