### PR TITLE
workaround: do not paste if stopped dragging

### DIFF
--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -650,7 +650,8 @@ class TextEditorComponent
         stopDragging()
         @editor.finalizeSelections()
         @editor.mergeIntersectingSelections()
-      pasteSelectionClipboard(event)
+      else
+        pasteSelectionClipboard(event)
 
     stopDragging = ->
       dragging = false


### PR DESCRIPTION
I'm not sure if this is the correct solution and if it has any side effects. I suspect that the mouse button 2 action on linux can be detected as a mini-drag, causing onMouseUp to be invoked twice. 

Issue: https://github.com/atom/atom/issues/8648#issuecomment-200905442
