### PR TITLE
fix link in ISSUE_TEMPLATE

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,8 +1,8 @@
 ### Prerequisites
 
-* [ ] Can you reproduce the problem in [safe mode](https://atom.io/docs/latest/hacking-atom-debugging#check-if-the-problem-shows-up-in-safe-mode)?
-* [ ] Are you running the [latest version of Atom](https://atom.io/docs/latest/hacking-atom-debugging#update-to-the-latest-version)?
-* [ ] Did you check the [debugging guide](https://atom.io/docs/latest/hacking-atom-debugging)?
+* [ ] Can you reproduce the problem in [safe mode](http://flight-manual.atom.io/hacking-atom/sections/debugging/#check-if-the-problem-shows-up-in-safe-mode)?
+* [ ] Are you running the [latest version of Atom](http://flight-manual.atom.io/hacking-atom/sections/debugging/#update-to-the-latest-version)?
+* [ ] Did you check the [debugging guide](flight-manual.atom.io/hacking-atom/sections/debugging/)?
 * [ ] Did you check the [FAQs on Discuss](https://discuss.atom.io/c/faq)?
 * [ ] Are you reporting to the [correct repository](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#atom-and-packages)?
 * [ ] Did you [perform a cursory search](https://github.com/issues?q=is%3Aissue+user%3Aatom+-repo%3Aatom%2Felectron) to see if your bug or enhancement is already reported?


### PR DESCRIPTION
Some link in issue template were dead (it was linked to the manual main page). This PR fixes that.
