### PR TITLE
Fixed selection.copy, which caused bugs in selection.insertText when pasting

### DIFF
--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -608,19 +608,23 @@ class Selection extends Model
     {start, end} = @getBufferRange()
     selectionText = @editor.getTextInRange([start, end])
     precedingText = @editor.getTextInRange([[start.row, 0], start])
-    if selectionText.length > 0
-      if selectionText.charAt(0) is '\n'
-        newLineChars = true
-        myCounter = 1
-        while newLineChars and selectionText.length > myCounter
-          if selectionText.charAt(myCounter) is '\n'
-            myCounter++
-          else
-            newLineChars = false
-        startLevel = @editor.indentLevelForLine(@editor.lineTextForBufferRow(start.row + myCounter))
-      else
-        startLevel = @editor.indentLevelForLine(precedingText)
-    else startLevel = 0
+
+    countInitialNewLines = (string) ->
+      newLines = 0
+      counter = 0
+      while counter < string.length
+        if string.charAt(counter) is '\n'
+          counter++
+          newLines++
+        else if counter+1 < string.length and string.substring(counter, counter+2) is "\r\n"
+          counter+=2
+          newLines++
+        else
+          break
+      newLines
+
+    initialNewLines = countInitialNewLines(selectionText)
+    startLevel = @editor.indentLevelForLine(@editor.lineTextForBufferRow(start.row + initialNewLines))
 
     if maintainClipboard
       {text: clipboardText, metadata} = @clipboard.readWithMetadata()

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -608,7 +608,19 @@ class Selection extends Model
     {start, end} = @getBufferRange()
     selectionText = @editor.getTextInRange([start, end])
     precedingText = @editor.getTextInRange([[start.row, 0], start])
-    startLevel = @editor.indentLevelForLine(precedingText)
+    if selectionText.length > 0
+      if selectionText.charAt(0) is '\n'
+        newLineChars = true
+        myCounter = 1
+        while newLineChars and selectionText.length > myCounter
+          if selectionText.charAt(myCounter) is '\n'
+            myCounter++
+          else
+            newLineChars = false
+        startLevel = @editor.indentLevelForLine(@editor.lineTextForBufferRow(start.row + myCounter))
+      else
+        startLevel = @editor.indentLevelForLine(precedingText)
+    else startLevel = 0
 
     if maintainClipboard
       {text: clipboardText, metadata} = @clipboard.readWithMetadata()


### PR DESCRIPTION
Referenced Issues: [1](https://github.com/atom/atom/issues/9045) [2](https://github.com/atom/atom/issues/5473) [3](https://github.com/atom/atom/issues/4461) 

In the specific case where you copy text beginning with a newline, the metadata field 'indentBasis' can be improperly stored, which doesn't create any issues until you try to paste somewhere else and the 'autoIndentOnPaste'  setting is on. It uses that incorrect indentBasis which results in incorrect indentation.
### evidence for the bug

1) Take a build of atom besides this one, and make a new file. add the following text:

```
one
  two
```

2) Add `\n\ttwo` to your clipboard by clicking and dragging from the right of 'two' until the right on 'one'. It's important that you capture that newline character.

3) With your cursor to the right of 'two', press cmd+v or ctrl+v depending on your OS. You should have had  the twos at the same indentation level, but instead the second two will be indented twice.

4) If you're not convinced yet, you can try this again with the first 'two' indented twice, and you'll see the second one indented four times.
### What Happens

copy() takes the indent level of the first selected line and stores that as the indentBasis. The user will want an indentBasis of 1, but get an indentBasis of 0 because \n is technically on the previous line.
### Why this matters

When people copy/paste large bodies of text, they will often drag their cursor up and to the right of whatever they're copying, which will give them that initial newline character. Knowing to avoid this is a workaround people shouldn't have to consider when they're focused on writing whatever they're writing.
