### PR TITLE
Fix typo in error message.

### DIFF
--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -92,7 +92,7 @@ class TextEditorElement extends HTMLElement
       @emitter.emit("did-change-scroll-left", arguments...)
 
   initialize: (model, {@views, @config, @themes, @workspace, @assert, @styles, @grammars}, @autoHeight = true, @scrollPastEnd = true) ->
-    throw new Error("Must pass a config parameter when initializing TextEditorElements") unless @views?
+    throw new Error("Must pass a views parameter when initializing TextEditorElements") unless @views?
     throw new Error("Must pass a config parameter when initializing TextEditorElements") unless @config?
     throw new Error("Must pass a themes parameter when initializing TextEditorElements") unless @themes?
     throw new Error("Must pass a workspace parameter when initializing TextEditorElements") unless @workspace?


### PR DESCRIPTION
I was just reading the source code and noticed this minor cut-and-paste error in the error message.
