### PR TITLE
Remove GitRepository git status

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "symbols-view": "0.112.0",
     "tabs": "0.92.0",
     "timecop": "0.33.1",
-    "tree-view": "0.203.2",
+    "tree-view": "0.203.3",
     "update-package-dependencies": "0.10.0",
     "welcome": "0.34.0",
     "whitespace": "0.32.2",

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -136,7 +136,7 @@ class GitRepository
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidDestroy: (callback) ->
-    @emitter.on 'did-destroy', callback
+    @async.onDidDestroy callback
 
   ###
   Section: Event Subscription
@@ -154,7 +154,7 @@ class GitRepository
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidChangeStatus: (callback) ->
-    @emitter.on 'did-change-status', callback
+    @async.onDidChangeStatus callback
 
   # Public: Invoke the given callback when a multiple files' statuses have
   # changed. For example, on window focus, the status of all the paths in the
@@ -165,7 +165,7 @@ class GitRepository
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidChangeStatuses: (callback) ->
-    @emitter.on 'did-change-statuses', callback
+    @async.onDidChangeStatuses callback
 
   ###
   Section: Repository Details

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -470,7 +470,9 @@ class GitRepository
   #
   # Returns a promise that resolves when the repository has been refreshed.
   refreshStatus: ->
-    asyncRefresh = @async.refreshStatus()
+    asyncRefresh = @async.refreshStatus().then =>
+      @branch = @async.branch
+
     syncRefresh = new Promise (resolve, reject) =>
       @handlerPath ?= require.resolve('./repository-status-handler')
 
@@ -487,7 +489,6 @@ class GitRepository
 
         @statuses = statuses
         @upstream = upstream
-        @branch = branch
         @submodules = submodules
 
         for submodulePath, submoduleRepo of @getRepo().submodules

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -347,10 +347,7 @@ class GitRepository
 
     pathStatus = repo.getStatus(repo.relativize(path)) ? 0
     pathStatus = 0 if repo.isStatusIgnored(pathStatus)
-    if pathStatus > 0
-      @statusesByPath[relativePath] = pathStatus
-    else
-      delete @statusesByPath[relativePath]
+    @statusesByPath[relativePath] = pathStatus
 
     if currentPathStatus isnt pathStatus
       @emitter.emit 'did-change-status', {path, pathStatus}

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -1,7 +1,7 @@
 {basename, join} = require 'path'
 
 _ = require 'underscore-plus'
-{Emitter, Disposable, CompositeDisposable} = require 'event-kit'
+{Disposable, CompositeDisposable} = require 'event-kit'
 fs = require 'fs-plus'
 GitRepositoryAsync = require './git-repository-async'
 GitUtils = require 'git-utils'
@@ -69,7 +69,6 @@ class GitRepository
       null
 
   constructor: (path, options={}) ->
-    @emitter = new Emitter
     @subscriptions = new CompositeDisposable
 
     @repo = GitUtils.open(path)
@@ -107,11 +106,6 @@ class GitRepository
   # This destroys any tasks and subscriptions and releases the underlying
   # libgit2 repository handle. This method is idempotent.
   destroy: ->
-    if @emitter?
-      @emitter.emit 'did-destroy'
-      @emitter.dispose()
-      @emitter = null
-
     if @statusTask?
       @statusTask.terminate()
       @statusTask = null
@@ -485,8 +479,5 @@ class GitRepository
           submoduleRepo.upstream = submodules[submodulePath]?.upstream ? {ahead: 0, behind: 0}
 
         resolve()
-
-        unless statusesUnchanged
-          @emitter.emit 'did-change-statuses'
 
     return Promise.all([asyncRefresh, syncRefresh])

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -493,7 +493,7 @@ class GitRepository
   refreshStatus: ->
     asyncRefresh = @async.refreshStatus().then =>
       @statusesByPath = {}
-      @branch = @async.branch
+      @branch = @async?.branch
 
     syncRefresh = new Promise (resolve, reject) =>
       @handlerPath ?= require.resolve('./repository-status-handler')

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -476,18 +476,8 @@ class GitRepository
     syncRefresh = new Promise (resolve, reject) =>
       @handlerPath ?= require.resolve('./repository-status-handler')
 
-      relativeProjectPaths = @project?.getPaths()
-        .map (path) => @relativize(path)
-        .map (path) -> if path.length > 0 then path + '/**' else '*'
-
       @statusTask?.terminate()
-      @statusTask = Task.once @handlerPath, @getPath(), relativeProjectPaths, ({statuses, upstream, branch, submodules}) =>
-        statusesUnchanged = _.isEqual(statuses, @statuses) and
-                            _.isEqual(upstream, @upstream) and
-                            _.isEqual(branch, @branch) and
-                            _.isEqual(submodules, @submodules)
-
-        @statuses = statuses
+      @statusTask = Task.once @handlerPath, @getPath(), ({upstream, submodules}) =>
         @upstream = upstream
         @submodules = submodules
 

--- a/src/repository-status-handler.coffee
+++ b/src/repository-status-handler.coffee
@@ -5,32 +5,15 @@ module.exports = (repoPath, paths = []) ->
   repo = Git.open(repoPath)
 
   upstream = {}
-  statuses = {}
   submodules = {}
-  branch = null
 
   if repo?
-    # Statuses in main repo
-    workingDirectoryPath = repo.getWorkingDirectory()
-    repoStatus = (if paths.length > 0 then repo.getStatusForPaths(paths) else repo.getStatus())
-    for filePath, status of repoStatus
-      statuses[filePath] = status
-
-    # Statuses in submodules
     for submodulePath, submoduleRepo of repo.submodules
       submodules[submodulePath] =
         branch: submoduleRepo.getHead()
         upstream: submoduleRepo.getAheadBehindCount()
 
-      workingDirectoryPath = submoduleRepo.getWorkingDirectory()
-      for filePath, status of submoduleRepo.getStatus()
-        absolutePath = path.join(workingDirectoryPath, filePath)
-        # Make path relative to parent repository
-        relativePath = repo.relativize(absolutePath)
-        statuses[relativePath] = status
-
     upstream = repo.getAheadBehindCount()
-    branch = repo.getHead()
     repo.release()
 
-  {statuses, upstream, branch, submodules}
+  {upstream, submodules}


### PR DESCRIPTION
Partly fixes #11214.

`git status` involves lots of IO (mostly `stat`s). On most file systems, this isn’t a big deal. But on slow file systems (e.g., networked drives), this can be quite costly.

In order to trivially maintain `GitRepository`s API after adding `GitRepositoryAsync`, we simply left it as-is, but that meant we were doing `git status` twice.

This remove’s `GitRepository`s `git status` check by pulling its status information from `GitRepositoryAsync` as much as possible, while still maintaining `GitRepository`s existing API.
