### PR TITLE
Use %F instead of %U for file variable in desktop file

### DIFF
--- a/resources/linux/atom.desktop.in
+++ b/resources/linux/atom.desktop.in
@@ -2,7 +2,7 @@
 Name=<%= appName %>
 Comment=<%= description %>
 GenericName=Text Editor
-Exec=<%= installDir %>/share/<%= appFileName %>/atom %U
+Exec=<%= installDir %>/share/<%= appFileName %>/atom %F
 Icon=<%= iconPath %>
 Type=Application
 StartupNotify=true


### PR DESCRIPTION
The desktop entry specification states that %U is for URLs and %F is for
files. Since atom doesn't support URLs, we should use %F. Fixes #2320.
