### PR TITLE
Correctly (un)subscribe to model events on PaneAxisElement attach/detach

### DIFF
--- a/spec/pane-axis-element-spec.coffee
+++ b/spec/pane-axis-element-spec.coffee
@@ -1,0 +1,34 @@
+PaneAxis = require '../src/pane-axis'
+PaneContainer = require '../src/pane-container'
+Pane = require '../src/pane'
+
+buildPane = ->
+  new Pane({
+    applicationDelegate: atom.applicationDelegate,
+    config: atom.config,
+    deserializerManager: atom.deserializers,
+    notificationManager: atom.notifications
+  })
+
+describe "PaneAxisElement", ->
+  it "correctly subscribes and unsubscribes to the underlying model events on attach/detach", ->
+    container = new PaneContainer(config: atom.config, applicationDelegate: atom.applicationDelegate)
+    axis = new PaneAxis
+    axis.setContainer(container)
+    axisElement = atom.views.getView(axis)
+
+    panes = [buildPane(), buildPane(), buildPane()]
+
+    jasmine.attachToDOM(axisElement)
+    axis.addChild(panes[0])
+    expect(axisElement.children[0]).toBe(atom.views.getView(panes[0]))
+
+    axisElement.remove()
+    axis.addChild(panes[1])
+    expect(axisElement.children[2]).toBeUndefined()
+
+    jasmine.attachToDOM(axisElement)
+    expect(axisElement.children[2]).toBe(atom.views.getView(panes[1]))
+
+    axis.addChild(panes[2])
+    expect(axisElement.children[4]).toBe(atom.views.getView(panes[2]))

--- a/spec/pane-container-element-spec.coffee
+++ b/spec/pane-container-element-spec.coffee
@@ -10,7 +10,6 @@ describe "PaneContainerElement", ->
 
       paneAxis = new PaneAxis
       paneAxisElement = new PaneAxisElement().initialize(paneAxis, atom)
-      jasmine.attachToDOM(paneAxisElement)
 
       expect(childTagNames()).toEqual []
 
@@ -42,8 +41,6 @@ describe "PaneContainerElement", ->
         'atom-pane-axis'
       ]
 
-      paneAxisElement.remove()
-
     it "transfers focus to the next pane if a focused pane is removed", ->
       container = new PaneContainer(config: atom.config, confirm: atom.confirm.bind(atom))
       containerElement = atom.views.getView(container)
@@ -63,7 +60,6 @@ describe "PaneContainerElement", ->
     it "builds appropriately-oriented atom-pane-axis elements", ->
       container = new PaneContainer(config: atom.config, confirm: atom.confirm.bind(atom))
       containerElement = atom.views.getView(container)
-      jasmine.attachToDOM(containerElement)
 
       pane1 = container.getActivePane()
       pane2 = pane1.splitRight()
@@ -83,8 +79,6 @@ describe "PaneContainerElement", ->
       expect(verticalPanes.length).toBe 2
       expect(verticalPanes[0]).toBe atom.views.getView(pane2)
       expect(verticalPanes[1]).toBe atom.views.getView(pane3)
-
-      containerElement.remove()
 
   describe "when the resize element is dragged ", ->
     [container, containerElement] = []

--- a/spec/pane-container-element-spec.coffee
+++ b/spec/pane-container-element-spec.coffee
@@ -10,6 +10,7 @@ describe "PaneContainerElement", ->
 
       paneAxis = new PaneAxis
       paneAxisElement = new PaneAxisElement().initialize(paneAxis, atom)
+      jasmine.attachToDOM(paneAxisElement)
 
       expect(childTagNames()).toEqual []
 
@@ -41,6 +42,8 @@ describe "PaneContainerElement", ->
         'atom-pane-axis'
       ]
 
+      paneAxisElement.remove()
+
     it "transfers focus to the next pane if a focused pane is removed", ->
       container = new PaneContainer(config: atom.config, confirm: atom.confirm.bind(atom))
       containerElement = atom.views.getView(container)
@@ -60,6 +63,7 @@ describe "PaneContainerElement", ->
     it "builds appropriately-oriented atom-pane-axis elements", ->
       container = new PaneContainer(config: atom.config, confirm: atom.confirm.bind(atom))
       containerElement = atom.views.getView(container)
+      jasmine.attachToDOM(containerElement)
 
       pane1 = container.getActivePane()
       pane2 = pane1.splitRight()
@@ -79,6 +83,8 @@ describe "PaneContainerElement", ->
       expect(verticalPanes.length).toBe 2
       expect(verticalPanes[0]).toBe atom.views.getView(pane2)
       expect(verticalPanes[1]).toBe atom.views.getView(pane3)
+
+      containerElement.remove()
 
   describe "when the resize element is dragged ", ->
     [container, containerElement] = []

--- a/src/pane-axis-element.coffee
+++ b/src/pane-axis-element.coffee
@@ -3,7 +3,17 @@ PaneResizeHandleElement = require './pane-resize-handle-element'
 
 class PaneAxisElement extends HTMLElement
   attachedCallback: ->
-    @subscriptions = @subscribeToModel()
+    @subscriptions ?= @subscribeToModel()
+    @childAdded({child, index}) for child, index in @model.getChildren()
+
+  detachedCallback: ->
+    @subscriptions.dispose()
+    @subscriptions = null
+    @childRemoved({child}) for child in @model.getChildren()
+
+  initialize: (@model, {@views}) ->
+    throw new Error("Must pass a views parameter when initializing TextEditorElements") unless @views?
+    @subscriptions ?= @subscribeToModel()
     @childAdded({child, index}) for child, index in @model.getChildren()
 
     switch @model.getOrientation()
@@ -11,21 +21,6 @@ class PaneAxisElement extends HTMLElement
         @classList.add('horizontal', 'pane-row')
       when 'vertical'
         @classList.add('vertical', 'pane-column')
-
-  detachedCallback: ->
-    @subscriptions.dispose()
-    @subscriptions = null
-    @childRemoved({child}) for child in @model.getChildren()
-
-    switch @model.getOrientation()
-      when 'horizontal'
-        @classList.remove('horizontal', 'pane-row')
-      when 'vertical'
-        @classList.remove('vertical', 'pane-column')
-
-  initialize: (@model, {@views}) ->
-    throw new Error("Must pass a views parameter when initializing TextEditorElements") unless @views?
-
     this
 
   subscribeToModel: ->

--- a/src/pane-axis-element.coffee
+++ b/src/pane-axis-element.coffee
@@ -3,7 +3,7 @@ PaneResizeHandleElement = require './pane-resize-handle-element'
 
 class PaneAxisElement extends HTMLElement
   attachedCallback: ->
-    @subscriptions ?= @subscribeToModel()
+    @subscriptions = @subscribeToModel()
     @childAdded({child, index}) for child, index in @model.getChildren()
 
     switch @model.getOrientation()


### PR DESCRIPTION
Fixes #10903.

This makes sure that when a `PaneAxisElement` is removed from the DOM and subsequently added back to it (e.g. because of a `PaneContainer` or `PaneAxis`'s `replaceChild` call), its internal state gets reinitialized. The initialization process involves resubscribing to the underlying model, as well as cleaning up / rebuilding children on attach/detach.

/cc: @atom/core 
