### PR TITLE
Handle auto-updater errors

### DIFF
--- a/spec/auto-update-manager-spec.js
+++ b/spec/auto-update-manager-spec.js
@@ -64,6 +64,16 @@ describe('AutoUpdateManager (renderer)', () => {
     })
   })
 
+  describe('::onUpdateError', () => {
+    it('subscribes to "update-error" event', () => {
+      const spy = jasmine.createSpy('spy')
+      autoUpdateManager.onUpdateError(spy)
+      electronAutoUpdater.emit('error', {}, 'an error')
+      waitsFor(() => spy.callCount === 1)
+      runs(() => expect(spy).toHaveBeenCalledWith('an error'))
+    })
+  })
+
   describe('::platformSupportsUpdates', () => {
     let state, releaseChannel
     it('returns true on OS X and Windows when in stable', () => {

--- a/spec/auto-update-manager-spec.js
+++ b/spec/auto-update-manager-spec.js
@@ -68,8 +68,9 @@ describe('AutoUpdateManager (renderer)', () => {
     it('subscribes to "update-error" event', () => {
       const spy = jasmine.createSpy('spy')
       autoUpdateManager.onUpdateError(spy)
-      electronAutoUpdater.emit('error', {}, 'an error')
+      electronAutoUpdater.emit('error', {}, 'an error message')
       waitsFor(() => spy.callCount === 1)
+      runs(() => expect(autoUpdateManager.getErrorMessage()).toBe('an error message'))
     })
   })
 

--- a/spec/auto-update-manager-spec.js
+++ b/spec/auto-update-manager-spec.js
@@ -70,7 +70,6 @@ describe('AutoUpdateManager (renderer)', () => {
       autoUpdateManager.onUpdateError(spy)
       electronAutoUpdater.emit('error', {}, 'an error')
       waitsFor(() => spy.callCount === 1)
-      runs(() => expect(spy).toHaveBeenCalledWith('an error'))
     })
   })
 

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -211,6 +211,14 @@ class ApplicationDelegate
     new Disposable ->
       ipcRenderer.removeListener('message', outerCallback)
 
+  onUpdateError: (callback) ->
+    outerCallback = (event, message, detail) ->
+      callback(detail) if message is 'update-error'
+
+    ipcRenderer.on('message', outerCallback)
+    new Disposable ->
+      ipcRenderer.removeListener('message', outerCallback)
+
   onApplicationMenuCommand: (callback) ->
     outerCallback = (event, args...) ->
       callback(args...)

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -252,3 +252,6 @@ class ApplicationDelegate
 
   getAutoUpdateManagerState: ->
     ipcRenderer.sendSync('get-auto-update-manager-state')
+
+  getAutoUpdateManagerErrorMessage: ->
+    ipcRenderer.sendSync('get-auto-update-manager-error')

--- a/src/auto-update-manager.js
+++ b/src/auto-update-manager.js
@@ -22,6 +22,7 @@ export default class AutoUpdateManager {
         this.emitter.emit('update-not-available')
       }),
       applicationDelegate.onUpdateError((message) => {
+        console.error(message)
         this.emitter.emit('update-error', message)
       })
     )

--- a/src/auto-update-manager.js
+++ b/src/auto-update-manager.js
@@ -21,9 +21,8 @@ export default class AutoUpdateManager {
       applicationDelegate.onUpdateNotAvailable(() => {
         this.emitter.emit('update-not-available')
       }),
-      applicationDelegate.onUpdateError((message) => {
-        console.error(message)
-        this.emitter.emit('update-error', message)
+      applicationDelegate.onUpdateError(() => {
+        this.emitter.emit('update-error')
       })
     )
   }
@@ -43,6 +42,10 @@ export default class AutoUpdateManager {
 
   getState () {
     return this.applicationDelegate.getAutoUpdateManagerState()
+  }
+
+  getErrorMessage () {
+    return this.applicationDelegate.getAutoUpdateManagerErrorMessage()
   }
 
   platformSupportsUpdates () {

--- a/src/auto-update-manager.js
+++ b/src/auto-update-manager.js
@@ -20,6 +20,9 @@ export default class AutoUpdateManager {
       }),
       applicationDelegate.onUpdateNotAvailable(() => {
         this.emitter.emit('update-not-available')
+      }),
+      applicationDelegate.onUpdateError((message) => {
+        this.emitter.emit('update-error', message)
       })
     )
   }
@@ -65,6 +68,10 @@ export default class AutoUpdateManager {
 
   onUpdateNotAvailable (callback) {
     return this.emitter.on('update-not-available', callback)
+  }
+
+  onUpdateError (callback) {
+    return this.emitter.on('update-error', callback)
   }
 
   getPlatform () {

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -311,6 +311,9 @@ class AtomApplication
     ipcMain.on 'get-auto-update-manager-state', (event) =>
       event.returnValue = @autoUpdateManager.getState()
 
+    ipcMain.on 'get-auto-update-manager-error', (event) =>
+      event.returnValue = @autoUpdateManager.getErrorMessage()
+
     ipcMain.on 'execute-javascript-in-dev-tools', (event, code) ->
       event.sender.devToolsWebContents?.executeJavaScript(code)
 

--- a/src/browser/auto-update-manager.coffee
+++ b/src/browser/auto-update-manager.coffee
@@ -32,8 +32,8 @@ class AutoUpdateManager
       {autoUpdater} = require 'electron'
 
     autoUpdater.on 'error', (event, message) =>
-      @setState(ErrorState)
-      @emitWindowEvent('update-error', message)
+      @setState(ErrorState, message)
+      @emitWindowEvent('update-error')
       console.error "Error Downloading Update: #{message}"
 
     autoUpdater.setFeedURL @feedUrl
@@ -83,13 +83,17 @@ class AutoUpdateManager
       atomWindow.sendMessage(eventName, payload)
     return
 
-  setState: (state) ->
+  setState: (state, errorMessage) ->
     return if @state is state
     @state = state
+    @errorMessage = errorMessage
     @emit 'state-changed', @state
 
   getState: ->
     @state
+
+  getErrorMessage: ->
+    @errorMessage
 
   scheduleUpdateCheck: ->
     # Only schedule update check periodically if running in release version and

--- a/src/browser/auto-update-manager.coffee
+++ b/src/browser/auto-update-manager.coffee
@@ -33,6 +33,7 @@ class AutoUpdateManager
 
     autoUpdater.on 'error', (event, message) =>
       @setState(ErrorState)
+      @emitWindowEvent('update-error', message)
       console.error "Error Downloading Update: #{message}"
 
     autoUpdater.setFeedURL @feedUrl


### PR DESCRIPTION
This PR propagates the auto-update errors to the renderer process so that we can handle the error state in the about package and show an appropriate error label.

/cc: @thedaniel @joshaber @atom/core 
