### PR TITLE
Update nodegit

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "less-cache": "0.23",
     "line-top-index": "0.2.0",
     "marked": "^0.3.4",
-    "nodegit": "0.12.0",
+    "nodegit": "0.12.1",
     "normalize-package-data": "^2.0.0",
     "nslog": "^3",
     "oniguruma": "^5",


### PR DESCRIPTION
Fixes build on Windows machines that don’t have bash. Somehow this apparently worked on our CI machines already.
