### PR TITLE
Add restorePreviousWindowsOnStart setting

### DIFF
--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -269,11 +269,6 @@ describe "Starting Atom", ->
               ].sort()
 
     it "doesn't reopen any previously opened windows if restorePreviousWindowsOnStart is disabled", ->
-      configPath = path.join(atomHome, 'config.cson')
-      config = CSON.readFileSync(configPath)
-      config['*'].core = {restorePreviousWindowsOnStart: false}
-      CSON.writeFileSync(configPath, config)
-
       runAtom [tempDirPath], {ATOM_HOME: atomHome}, (client) ->
         client
           .waitForExist("atom-workspace")
@@ -281,6 +276,11 @@ describe "Starting Atom", ->
             @startAnotherAtom([otherTempDirPath], ATOM_HOME: atomHome)
           , 5000)
           .waitForExist("atom-workspace")
+
+      configPath = path.join(atomHome, 'config.cson')
+      config = CSON.readFileSync(configPath)
+      config['*'].core = {restorePreviousWindowsOnStart: false}
+      CSON.writeFileSync(configPath, config)
 
       runAtom [], {ATOM_HOME: atomHome}, (client) ->
         windowProjectPaths = []

--- a/spec/integration/startup-spec.coffee
+++ b/spec/integration/startup-spec.coffee
@@ -268,6 +268,36 @@ describe "Starting Atom", ->
                 [otherTempDirPath]
               ].sort()
 
+    it "doesn't reopen any previously opened windows if restorePreviousWindowsOnStart is disabled", ->
+      configPath = path.join(atomHome, 'config.cson')
+      config = CSON.readFileSync(configPath)
+      config['*'].core = {restorePreviousWindowsOnStart: false}
+      CSON.writeFileSync(configPath, config)
+
+      runAtom [tempDirPath], {ATOM_HOME: atomHome}, (client) ->
+        client
+          .waitForExist("atom-workspace")
+          .waitForNewWindow(->
+            @startAnotherAtom([otherTempDirPath], ATOM_HOME: atomHome)
+          , 5000)
+          .waitForExist("atom-workspace")
+
+      runAtom [], {ATOM_HOME: atomHome}, (client) ->
+        windowProjectPaths = []
+
+        client
+          .waitForWindowCount(1, 10000)
+          .then ({value: windowHandles}) ->
+            @window(windowHandles[0])
+            .waitForExist("atom-workspace")
+            .treeViewRootDirectories()
+            .then ({value: directories}) -> windowProjectPaths.push(directories)
+
+            .call ->
+              expect(windowProjectPaths).toEqual [
+                []
+              ]
+
   describe "opening a remote directory", ->
     it "opens the parent directory and creates an empty text editor", ->
       remoteDirectory = 'remote://server:3437/some/directory/path'

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -506,18 +506,17 @@ class AtomApplication
 
   saveState: (allowEmpty=false) ->
     return if @quitting
-    restorePreviousState = @config.get('core.restorePreviousWindowsOnStart') ? true
     states = []
-    if restorePreviousState
-      for window in @windows
-        unless window.isSpec
-          if loadSettings = window.getLoadSettings()
-            states.push(initialPaths: loadSettings.initialPaths)
-    if states.length > 0 or allowEmpty or not restorePreviousState
+    for window in @windows
+      unless window.isSpec
+        if loadSettings = window.getLoadSettings()
+          states.push(initialPaths: loadSettings.initialPaths)
+    if states.length > 0 or allowEmpty
       @storageFolder.storeSync('application.json', states)
 
   loadState: (options) ->
-    if (states = @storageFolder.load('application.json'))?.length > 0
+    restorePreviousState = @config.get('core.restorePreviousWindowsOnStart') ? true
+    if (states = @storageFolder.load('application.json'))?.length > 0 and restorePreviousState
       for state in states
         @openWithOptions(_.extend(options, {
           initialPaths: state.initialPaths

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -516,7 +516,7 @@ class AtomApplication
 
   loadState: (options) ->
     restorePreviousState = @config.get('core.restorePreviousWindowsOnStart') ? true
-    if (states = @storageFolder.load('application.json'))?.length > 0 and restorePreviousState
+    if restorePreviousState and (states = @storageFolder.load('application.json'))?.length > 0
       for state in states
         @openWithOptions(_.extend(options, {
           initialPaths: state.initialPaths

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -3,6 +3,7 @@ ApplicationMenu = require './application-menu'
 AtomProtocolHandler = require './atom-protocol-handler'
 AutoUpdateManager = require './auto-update-manager'
 StorageFolder = require '../storage-folder'
+Config = require '../config'
 ipcHelpers = require '../ipc-helpers'
 {BrowserWindow, Menu, app, dialog, ipcMain, shell} = require 'electron'
 fs = require 'fs-plus'
@@ -70,7 +71,11 @@ class AtomApplication
     @pidsToOpenWindows = {}
     @windows = []
 
-    @autoUpdateManager = new AutoUpdateManager(@version, options.test, @resourcePath)
+    @config = new Config({configDirPath: process.env.ATOM_HOME, @resourcePath, enablePersistence: true})
+    @config.setSchema null, {type: 'object', properties: _.clone(require('../config-schema'))}
+    @config.load()
+
+    @autoUpdateManager = new AutoUpdateManager(@version, options.test, @resourcePath, @config)
     @applicationMenu = new ApplicationMenu(@version, @autoUpdateManager)
     @atomProtocolHandler = new AtomProtocolHandler(@resourcePath, @safeMode)
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -506,12 +506,14 @@ class AtomApplication
 
   saveState: (allowEmpty=false) ->
     return if @quitting
+    restorePreviousState = @config.get('core.restorePreviousWindowsOnStart') ? true
     states = []
-    for window in @windows
-      unless window.isSpec
-        if loadSettings = window.getLoadSettings()
-          states.push(initialPaths: loadSettings.initialPaths)
-    if states.length > 0 or allowEmpty
+    if restorePreviousState
+      for window in @windows
+        unless window.isSpec
+          if loadSettings = window.getLoadSettings()
+            states.push(initialPaths: loadSettings.initialPaths)
+    if states.length > 0 or allowEmpty or not restorePreviousState
       @storageFolder.storeSync('application.json', states)
 
   loadState: (options) ->

--- a/src/browser/auto-update-manager.coffee
+++ b/src/browser/auto-update-manager.coffee
@@ -1,6 +1,5 @@
 autoUpdater = null
 _ = require 'underscore-plus'
-Config = require '../config'
 {EventEmitter} = require 'events'
 path = require 'path'
 
@@ -16,13 +15,10 @@ module.exports =
 class AutoUpdateManager
   _.extend @prototype, EventEmitter.prototype
 
-  constructor: (@version, @testMode, resourcePath) ->
+  constructor: (@version, @testMode, resourcePath, @config) ->
     @state = IdleState
     @iconPath = path.resolve(__dirname, '..', '..', 'resources', 'atom.png')
     @feedUrl = "https://atom.io/api/updates?version=#{@version}"
-    @config = new Config({configDirPath: process.env.ATOM_HOME, resourcePath, enablePersistence: true})
-    @config.setSchema null, {type: 'object', properties: _.clone(require('../config-schema'))}
-    @config.load()
     process.nextTick => @setupAutoUpdater()
 
   setupAutoUpdater: ->


### PR DESCRIPTION
Supersedes and closes #9042.

This PR adds a couple of small changes to the above PR, so that:
- :racehorse: Atom opens slightly faster when `restorePreviousWindowsOnStart` is `false`;
- :white_check_mark: Specs ensure that such config parameter gets checked on start, rather than on exit;

Many thanks to @jordanbtucker for providing the original implementation and moving this forward! :sparkles: 

/cc: @atom/core 
