### PR TITLE
Fix emoji rendering on OSX

### DIFF
--- a/spec/workspace-element-spec.coffee
+++ b/spec/workspace-element-spec.coffee
@@ -47,9 +47,14 @@ describe "WorkspaceElement", ->
 
     it "updates the font-family based on the 'editor.fontFamily' config value", ->
       initialCharWidth = editor.getDefaultCharWidth()
-      expect(getComputedStyle(editorElement).fontFamily).toBe atom.config.get('editor.fontFamily') + ", 'Apple Color Emoji'"
+      fontFamily = atom.config.get('editor.fontFamily')
+      fontFamily += ", 'Apple Color Emoji'" if process.platform is 'darwin'
+      expect(getComputedStyle(editorElement).fontFamily).toBe fontFamily
+
       atom.config.set('editor.fontFamily', 'sans-serif')
-      expect(getComputedStyle(editorElement).fontFamily).toBe atom.config.get('editor.fontFamily') + ", 'Apple Color Emoji'"
+      fontFamily = atom.config.get('editor.fontFamily')
+      fontFamily += ", 'Apple Color Emoji'" if process.platform is 'darwin'
+      expect(getComputedStyle(editorElement).fontFamily).toBe fontFamily
       expect(editor.getDefaultCharWidth()).not.toBe initialCharWidth
 
     it "updates the line-height based on the 'editor.lineHeight' config value", ->

--- a/spec/workspace-element-spec.coffee
+++ b/spec/workspace-element-spec.coffee
@@ -47,9 +47,9 @@ describe "WorkspaceElement", ->
 
     it "updates the font-family based on the 'editor.fontFamily' config value", ->
       initialCharWidth = editor.getDefaultCharWidth()
-      expect(getComputedStyle(editorElement).fontFamily).toBe atom.config.get('editor.fontFamily')
+      expect(getComputedStyle(editorElement).fontFamily).toBe atom.config.get('editor.fontFamily') + ", 'Apple Color Emoji'"
       atom.config.set('editor.fontFamily', 'sans-serif')
-      expect(getComputedStyle(editorElement).fontFamily).toBe atom.config.get('editor.fontFamily')
+      expect(getComputedStyle(editorElement).fontFamily).toBe atom.config.get('editor.fontFamily') + ", 'Apple Color Emoji'"
       expect(editor.getDefaultCharWidth()).not.toBe initialCharWidth
 
     it "updates the line-height based on the 'editor.lineHeight' config value", ->

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -44,10 +44,15 @@ class WorkspaceElement extends HTMLElement
     @subscriptions.add @config.onDidChange 'editor.lineHeight', @updateGlobalTextEditorStyleSheet.bind(this)
 
   updateGlobalTextEditorStyleSheet: ->
+    fontFamily = @config.get('editor.fontFamily')
+    # TODO: There is a bug in how some emojis (e.g. ❤️) are rendered on OSX.
+    # This workaround should be removed once we update to Chromium 51, where the
+    # problem was fixed.
+    fontFamily += ', "Apple Color Emoji"' if process.platform is 'darwin'
     styleSheetSource = """
       atom-text-editor {
         font-size: #{@config.get('editor.fontSize')}px;
-        font-family: #{@config.get('editor.fontFamily')};
+        font-family: #{fontFamily};
         line-height: #{@config.get('editor.lineHeight')};
       }
     """


### PR DESCRIPTION
Fixes #10403.

On OS X, we noticed that some emojis were not being displayed correctly. This is a problem with the rendering mechanism that Chromium uses and is present in Chrome 50 as well:

![screen shot 2016-03-31 at 11 26 59](https://cloud.githubusercontent.com/assets/482957/14171984/2f63fc88-f736-11e5-895d-f48cca510511.png)

However, it seems like it has been fixed on Chrome 51 Canary, where the test above works perfectly:

![screen shot 2016-03-31 at 11 26 34](https://cloud.githubusercontent.com/assets/482957/14172028/598ebfe8-f736-11e5-892d-e8068e1b7641.png)
### A workaround

Even with Chrome 50, however, I noticed that GitHub.com was rendering emojis correctly without using PNGs:

![screen shot 2016-03-31 at 11 48 34](https://cloud.githubusercontent.com/assets/482957/14172067/88db969a-f736-11e5-851c-151763d630cd.png)

It seems, in fact, that adding the "Apple Color Emoji" font to the list of font families allows Chrome to pick up the right glyph to render instead of the ugly box:

![screen shot 2016-03-31 at 11 31 04](https://cloud.githubusercontent.com/assets/482957/14172145/deb5f330-f736-11e5-808e-0bd574c4722a.png)

![screen shot 2016-03-31 at 11 31 09](https://cloud.githubusercontent.com/assets/482957/14172149/e1ae8958-f736-11e5-9f7f-2297f8df8090.png)

As expected, removing it, causes the box to appear (again, this works fine in Chrome Canary 51):

![screen shot 2016-03-31 at 11 30 31](https://cloud.githubusercontent.com/assets/482957/14172172/f9bd9836-f736-11e5-8c18-d55545381742.png)
![screen shot 2016-03-31 at 11 30 24](https://cloud.githubusercontent.com/assets/482957/14172173/fc8e0082-f736-11e5-9b1f-f8493d3734f1.png)

This is the exact workaround I have employed in Atom as well; indeed, we should be able to remove it  as soon as Chrome 51 gets released and Electron is updated.

/cc: @atom/core 
