### PR TITLE
Fix pinch-to-zoom disabling

### DIFF
--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -234,7 +234,7 @@ class ApplicationDelegate
     shell.openExternal(url)
 
   disablePinchToZoom: ->
-    webFrame.setZoomLevelLimits(1, 1)
+    webFrame.setZoomLevelLimits(1, 1.0000000001)
 
   checkForUpdate: ->
     ipcRenderer.send('check-for-update')

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -234,6 +234,9 @@ class ApplicationDelegate
     shell.openExternal(url)
 
   disablePinchToZoom: ->
+    # Setting the same min/max zoom level limit, prevents Chrome to constrain
+    # the zoom level. As a workaround, we use a slightly larger max limit so
+    # that the content cannot be zoomed and the limit is enforced.
     webFrame.setZoomLevelLimits(1, 1.0000000001)
 
   checkForUpdate: ->


### PR DESCRIPTION
Fixes #8850.

There seems to be an issue with how Chromium handles the input data for the `setZoomLevelLimits` API: I suspect there's some kind of guard clause that ignores that function call whenever the `min` and the `max` level limits are the same.

As a stopgap measure, I have changed the max limit to be slightly larger than the minimum so that the configuration gets enforced by Chromium without actually allowing the user to zoom.

/cc: @zcbenz for :eyes: on the electron side.
/cc: @atom/core 
