### PR TITLE
Fix potential null reference callback invokation in script/clean

### DIFF
--- a/script/utils/child-process-wrapper.js
+++ b/script/utils/child-process-wrapper.js
@@ -17,7 +17,7 @@ exports.safeExec = function(command, options, callback) {
   var child = childProcess.exec(command, options, function(error, stdout, stderr) {
     if (error)
       process.exit(error.code || 1);
-    else
+    else if (callback)
       callback(null);
   });
   child.stderr.pipe(process.stderr);


### PR DESCRIPTION
A bug was introduced in https://github.com/atom/atom/commit/76f9f43e6aec3d53b1b23b893648eac238090a60, which boiled down to not checking whether the (seemingly) optional callback in `ChildProcess.safeExec` is defined before invokation.

I wasn't sure whether we wanted to add a condition on the `else` statement, or set `callback` to a noop function. I opted for the formed, but I'm open to suggestions.

/cc @thedaniel @abe33 @damieng 

---

Fixes #11328 
