### PR TITLE
Save and restore the environment for windows

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -520,7 +520,10 @@ class AtomApplication
         if loadSettings = window.getLoadSettings()
           env = window.getEnvironment()
           env = process.env unless env?
-          states.push({initialPaths: loadSettings.initialPaths, env: env})
+          if loadSettings.initialPaths.length > 0
+            states.push({initialPaths: loadSettings.initialPaths, env: env})
+          else
+            states.push({initialPaths: loadSettings.initialPaths})
     if states.length > 0 or allowEmpty
       @storageFolder.storeSync('application.json', states)
 

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -511,7 +511,7 @@ class AtomApplication
     for window in @windows
       unless window.isSpec
         if loadSettings = window.getLoadSettings()
-          states.push(initialPaths: loadSettings.initialPaths)
+          states.push({initialPaths: loadSettings.initialPaths, env: process.env})
     if states.length > 0 or allowEmpty
       @storageFolder.storeSync('application.json', states)
 
@@ -525,6 +525,7 @@ class AtomApplication
           urlsToOpen: []
           devMode: @devMode
           safeMode: @safeMode
+          env: state.env
         }))
       true
     else

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -87,6 +87,13 @@ class AtomWindow
       hash = url.parse(@browserWindow.webContents.getURL()).hash.substr(1)
       JSON.parse(decodeURIComponent(hash))
 
+  setEnvironment: (@env) =>
+
+  getEnvironment: =>
+    return @env if @env?.PATH?
+    return @browserWindow.loadSettings.env if @browserWindow?.loadSettings?.env?.PATH?
+    return
+
   hasProjectPath: -> @getLoadSettings().initialPaths?.length > 0
 
   setupContextMenu: ->

--- a/src/environment-helpers.js
+++ b/src/environment-helpers.js
@@ -2,6 +2,7 @@
 
 import {spawnSync} from 'child_process'
 import os from 'os'
+import {ipcRenderer} from 'electron'
 
 // Gets a dump of the user's configured shell environment.
 //
@@ -70,6 +71,7 @@ function needsPatching (options = { platform: process.platform, env: process.env
 function normalize (options = {}) {
   if (options && options.env) {
     process.env = options.env
+    notify()
   }
 
   if (!options.env) {
@@ -87,8 +89,13 @@ function normalize (options = {}) {
     if (shellEnv && shellEnv.PATH) {
       process._originalEnv = process.env
       process.env = shellEnv
+      notify()
     }
   }
+}
+
+function notify () {
+  ipcRenderer.send('environment-updated', process.env)
 }
 
 function replace (env) {
@@ -97,6 +104,7 @@ function replace (env) {
   }
 
   process.env = env
+  notify()
 }
 
 export default { getFromShell, needsPatching, normalize, replace }


### PR DESCRIPTION
This PR more robustly handles the environment in atom-window and the browser window. It:
- Allows an environment to persist when Atom is completely exited and then re-launched, by serializing the environment and restoring it along with the window ("Should process.env be serialized and reused when re-opening an existing project?" from #4126)
- Allows multiple invocations of `FOO=blah atom .` and `FOO=bleh atom .` to result in an updated environment for an existing window ("Should process.env be updated if atom is invoked from the shell for the same directory multiple times?" from #4126)
- Extends #11054
- Partially fixes  #4126

**Note:** This fix is recommended for cherry picking into the beta channel once merged, as it fixes issues present in the 1.7.x beta.

/cc @lee-dohm 
