### PR TITLE
Use application-level events to control updates in the browser process

### DIFF
--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -245,10 +245,10 @@ class ApplicationDelegate
     webFrame.setZoomLevelLimits(1, 1)
 
   checkForUpdate: ->
-    ipcRenderer.send('check-for-update')
+    ipcRenderer.send('command', 'application:check-for-update')
 
   restartAndInstallUpdate: ->
-    ipcRenderer.send('install-update')
+    ipcRenderer.send('command', 'application:install-update')
 
   getAutoUpdateManagerState: ->
     ipcRenderer.sendSync('get-auto-update-manager-state')

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -310,9 +310,6 @@ class AtomApplication
     ipcMain.on 'execute-javascript-in-dev-tools', (event, code) ->
       event.sender.devToolsWebContents?.executeJavaScript(code)
 
-    ipcMain.on 'check-for-update', =>
-      @autoUpdateManager.check()
-
     ipcMain.on 'get-auto-update-manager-state', (event) =>
       event.returnValue = @autoUpdateManager.getState()
 


### PR DESCRIPTION
Fixes https://github.com/atom/about/issues/21.

Back in #10675 we [introduced a listener for checking updates](https://github.com/atom/atom/blob/f884c987e29acef83a40164b681950a7fd8bf047/src/browser/atom-application.coffee#L307-L308) in the browser process without, however, adding the restart/install updates counterpart. However, we already expose both commands under application-level events (`application:check-for-update`, `application:install-update`), so this PR changes `ApplicationDelegate` to use those instead (and removing the unnecessary additional listener).

/cc: @amytruong @atom/core 
