### PR TITLE
Disable zoom every time a display gets added or removed

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -208,7 +208,7 @@ class AtomEnvironment extends Model
     @stylesElement = @styles.buildStylesElement()
     @document.head.appendChild(@stylesElement)
 
-    @applicationDelegate.disablePinchToZoom()
+    @disposables.add(@applicationDelegate.disableZoom())
 
     @keymaps.subscribeToFileReadFailure()
     @keymaps.loadBundledKeymaps()


### PR DESCRIPTION
Fixes #8850. This continues the investigation started on #11326 and attempts to fix it using a different approach.

It turns out that the issue with pinch-to-zoom occurs only under certain circumstances; on my MacBook, it happens only whenever I do the following:
1. Start Atom with my MacBook closed and my external monitor on;
2. Open my Macbook, so that both displays are on;
3. Try to pinch the tree-view;
4. :boom: 

_(The above never happens if my MacBook is open when Atom is launched)_

As soon as a new display gets added or removed, in facts, the zoom level limit of the web frame is reset to the default and hence the page becomes zoomable again. This doesn't happen when changing the display's metrics (e.g. screen resolution), so I assume it must be something related to adding/removing displays. I have verified this arises also when enabling/disabling mirroring, which is considered by OS X as adding/removing one display.

Electron provides two events which allow us to detect when a display gets added or removed, so that we can reset the zoom level limits to `(1, 1)` every time this happens. I suspect this is what is happening in #8850, and this PR should fix it once for all.

/cc: @joshaber @nathansobo @mnquintana @atom/feedback for extra :eyes: :eyes: :eyes:.
