### PR TITLE
Show Cursor When Selecting - Add setting to show cursor when selecting

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1272,6 +1272,18 @@ describe('TextEditorComponent', function () {
       expect(cursorNodes[0].style['-webkit-transform']).toBe('translate(' + (Math.round(8 * charWidth)) + 'px, ' + (6 * lineHeightInPixels) + 'px)')
     })
 
+    it('does render cursors that are associated with non-empty selections when editor.showCursorWhenSelecting is true', async function () {
+      atom.config.set('editor.showCursorWhenSelecting', true)
+      editor.setSelectedScreenRange([[0, 4], [4, 6]])
+      editor.addCursorAtScreenPosition([6, 8])
+      await nextViewUpdatePromise()
+      let cursorNodes = componentNode.querySelectorAll('.cursor')
+      expect(cursorNodes.length).toBe(2)
+      expect(cursorNodes[0].style['-webkit-transform']).toBe('translate(' + (Math.round(6 * charWidth)) + 'px, ' + (4 * lineHeightInPixels) + 'px)')
+      expect(cursorNodes[1].style['-webkit-transform']).toBe('translate(' + (Math.round(8 * charWidth)) + 'px, ' + (6 * lineHeightInPixels) + 'px)')
+      atom.config.unset('editor.showCursorWhenSelecting')
+    })
+
     it('updates cursor positions when the line height changes', async function () {
       editor.setCursorBufferPosition([1, 10])
       component.setLineHeight(2)

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -575,7 +575,9 @@ class Cursor extends Model
   isVisible: -> @visible
 
   updateVisibility: ->
-    @setVisible(@marker.getBufferRange().isEmpty())
+    scope = @getScopeDescriptor()
+    showCursorWhenSelecting = @config.get('editor.showCursorWhenSelecting', {scope})
+    @setVisible(showCursorWhenSelecting or @marker.getBufferRange().isEmpty())
 
   ###
   Section: Comparing to another cursor


### PR DESCRIPTION
Redo #11085  commits with passing tests.

![screenshot from 2016-04-02 14-49-29](https://cloud.githubusercontent.com/assets/2925395/14228684/35b992f2-f8e2-11e5-9bef-280edce6dcc8.png)

Use the option `editor.showCursorWhenSelecting`
