### PR TITLE
Allow a paragraph to start with a line of whitespace

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1096,6 +1096,16 @@ describe "TextEditor", ->
         editor.moveToBeginningOfNextParagraph()
         expect(editor.getCursorBufferPosition()).toEqual [0, 0]
 
+      it "moves the cursor to the next paragraph when it starts with a whitespace line", ->
+        editor.setText('abcd\n\n  \nefgh\n')
+
+        editor.setCursorBufferPosition [0, 0]
+        editor.moveToBeginningOfNextParagraph()
+        expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+
+        editor.moveToBeginningOfNextParagraph()
+        expect(editor.getCursorBufferPosition()).toEqual [4, 0]
+
     describe ".moveToBeginningOfPreviousParagraph()", ->
       it "moves the cursor before the first line of the previous paragraph", ->
         editor.setCursorBufferPosition [10, 0]

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -3,7 +3,7 @@
 _ = require 'underscore-plus'
 Model = require './model'
 
-EmptyLineRegExp = /(\r\n[\t ]*\r\n)|(\n[\t ]*\n)/g
+EmptyLineRegExp = /(\r\n[\t]*\r\n)|(\n[\t]*\n)/g
 
 # Extended: The `Cursor` class represents the little blinking line identifying
 # where text can be inserted.


### PR DESCRIPTION
A paragraph should be able to start with a line containing only spaces.
This was the behavior prior to fe5b1b70e8b0b85a3d7fa2a06fee625aca3e70ca

This change in behavior is causing a unit test to fail in the atom/vim-mode project.
