### PR TITLE
Learn configuration of FS paths for which to skip VCS integration.

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -18,6 +18,12 @@ module.exports =
         default: true
         title: 'Exclude VCS Ignored Paths'
         description: 'Files and directories ignored by the current project\'s VCS system will be ignored by some packages, such as the fuzzy finder and find and replace. For example, projects using Git have these paths defined in the .gitignore file. Individual packages might have additional config settings for ignoring VCS ignored files and folders.'
+      skipVcsPaths:
+        type: 'array'
+        default: []
+        items:
+          type: 'string'
+        description: 'List directories under which VCS/Git integration will be skipped.'
       followSymlinks:
         type: 'boolean'
         default: true

--- a/src/git-repository-provider.coffee
+++ b/src/git-repository-provider.coffee
@@ -65,6 +65,14 @@ class GitRepositoryProvider
   # * {GitRepository} if the given directory has a Git repository.
   # * `null` if the given directory does not have a Git repository.
   repositoryForDirectorySync: (directory) ->
+    # Ignore repositories under our configured paths-to-skip, allowing us to
+    # skip the high-I/O git commands on slow network file-systems.
+    skipVcsPaths = @config.get('core.skipVcsPaths')
+    for skipPath in skipVcsPaths
+      skipDirectory = new Directory(skipPath)
+      if skipDirectory.contains(directory.getPath())
+        return null
+
     # Only one GitRepository should be created for each .git folder. Therefore,
     # we must check directory and its parent directories to find the nearest
     # .git folder.


### PR DESCRIPTION
This patch allows users to configure paths such as `/mnt/` or `/Volumes/`
which map to network shares or other targets with slow I/O performance.
By skipping VCS integration on these paths, I/O is significantly reduced at
the cost of not having VCS integration and allowing Atom to at least be usable
as a text-editor when pointed at mounted network shares.

This is a attempt to mitigate some of the effects of #1766. Please consider this
a somewhat naive proposal for a solution that could use some more discussion
around ways to solve #1766. 

Feedback requests:
- Naming of the config variable
- The way this is wired into the git-repository-provider (maybe the `Project` or another location would be better).
- Alternative ways to stop Git integration on a per-project basis.
