### PR TITLE
:racehorse: Avoid setting hidden input value on textInput

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -3767,11 +3767,12 @@ describe('TextEditorComponent', function () {
       expect(editor.lineTextForBufferRow(0)).toBe('xyvar quicksort = function () {')
     })
 
-    it('replaces the last character if the length of the input\'s value does not increase, as occurs with the accented character menu', async function () {
+    it('replaces the last character if the textInput event is followed by one or more additional keydown events, which occurs when the accented character menu is shown', async function () {
       componentNode.dispatchEvent(buildTextInputEvent({
         data: 'u',
         target: inputNode
       }))
+      componentNode.dispatchEvent(new KeyboardEvent('keydown'))
       await nextViewUpdatePromise()
 
       expect(editor.lineTextForBufferRow(0)).toBe('uvar quicksort = function () {')

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -3745,6 +3745,21 @@ describe('TextEditorComponent', function () {
       return event
     }
 
+    function buildKeydownEvent ({keyCode, target}) {
+      let event = new KeyboardEvent('keydown')
+      Object.defineProperty(event, 'keyCode', {
+        get: function () {
+          return keyCode
+        }
+      })
+      Object.defineProperty(event, 'target', {
+        get: function () {
+          return target
+        }
+      })
+      return event
+    }
+
     let inputNode
 
     beforeEach(function () {
@@ -3767,12 +3782,12 @@ describe('TextEditorComponent', function () {
       expect(editor.lineTextForBufferRow(0)).toBe('xyvar quicksort = function () {')
     })
 
-    it('replaces the last character if the textInput event is followed by one or more additional keydown events, which occurs when the accented character menu is shown', async function () {
-      componentNode.dispatchEvent(buildTextInputEvent({
-        data: 'u',
-        target: inputNode
-      }))
-      componentNode.dispatchEvent(new KeyboardEvent('keydown'))
+    it('replaces the last character if a keypress event is bracketed by keydown events with matching keyCodes, which occurs when the accented character menu is shown', async function () {
+      componentNode.dispatchEvent(buildKeydownEvent({keyCode: 85, target: inputNode}))
+      componentNode.dispatchEvent(buildTextInputEvent({data: 'u', target: inputNode}))
+      componentNode.dispatchEvent(new KeyboardEvent('keypress'))
+      componentNode.dispatchEvent(buildKeydownEvent({keyCode: 85, target: inputNode}))
+      componentNode.dispatchEvent(new KeyboardEvent('keyup'))
       await nextViewUpdatePromise()
 
       expect(editor.lineTextForBufferRow(0)).toBe('uvar quicksort = function () {')

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -263,7 +263,7 @@ class TextEditorComponent
     # before observing any keyup event, we observe events in the following
     # sequence:
     #
-    # keydown(keyCode: X), keypress, keydown(codeCode: X)
+    # keydown(keyCode: X), keypress, keydown(keyCode: X)
     #
     # The keyCode X must be the same in the keydown events that bracket the
     # keypress, meaning we're *holding* the _same_ key we intially pressed.


### PR DESCRIPTION
Atom currently sets the `value` of the input on every `textInput` event, in an effort to appropriately handle changes made via the OSX diacritic menu (for accents, umlauts, etc).

The drawback of this is approach is that updating the value of the input will trigger layout and a subsequent layer tree update.

To resolve this, here is my proposal:
- Track a flag for `keypress` events. When the diacritic menu is used, there are two `textInput` events, with no `keypress` in between. Therefore, when no `keypress` has occurred just prior to a `textInput`, the editor model can select the previous character to be replaced by the new accented character.
- Track a flag for `compositionstart` events. When a user is in IME mode, the diacritic menu cannot be used, so the editor can skip the backward selection.

Test Plan:

Tested in a plaintext file.
- Type Latin characters, verify proper character insertion.
- Press and hold <kbd>a</kbd>. Diacritic menu appears. Select an option using the keyboard or mouse. Verify that the `a` is replaced by an accented `a`, with no extra characters.
- Type test strings in Katakana, 2-Set Korean, Telex (Vietnamese), Simplified Pinyin. Verify that characters are inserted correctly while composing, and after committing strings.

cc @ssorallen @nathansobo 
