### PR TITLE
Tokenize visible buffer chunk immediately

### DIFF
--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -154,6 +154,7 @@ class TokenizedBuffer extends Model
     @emitter.emit 'did-change', event
 
   setVisible: (@visible) ->
+    @tokenizeNextChunk()
     @tokenizeInBackground() if @visible
 
   getTabLength: ->


### PR DESCRIPTION
When opening a new file, there is currently a flash of unstyled content ("FOUC") between the point where the file is first rendered and when syntax highlights are rendered. This gap can be hundreds of milliseconds, and the flash can be jarring.

To resolve this, I propose paying some tokenizing costs up front so that the first rendering of the file is already highlighted. Tokenize the first chunk, then defer the rest.

This means implicitly adding 20ms or so to the initial render pass, but there is no longer a jarring style change.

Test Plan:

Open JS files of varying sizes. Verify that the initial render of the file is already highlighted, with no flash.
