### PR TITLE
Update nodegit to 0.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "less-cache": "0.23",
     "line-top-index": "0.2.0",
     "marked": "^0.3.4",
-    "nodegit": "0.12.1",
+    "nodegit": "0.12.2",
     "normalize-package-data": "^2.0.0",
     "nslog": "^3",
     "oniguruma": "^5",


### PR DESCRIPTION
This should add support for 32-bit Linux systems (nodegit 0.12.2 now has prebuilt binaries for it)

(I don't have a 32-bit Linux system with me right now to test this, unfortunately, but I know that the 32-bit binary exists, as I was able to manually download it and make sure it was a 32-bit binary)

Related: #10819
