### PR TITLE
Added .apm to .gitignore

### DIFF
--- a/dot-atom/.gitignore
+++ b/dot-atom/.gitignore
@@ -2,5 +2,6 @@ blob-store
 compile-cache
 dev
 storage
+.apm
 .node-gyp
 .npm


### PR DESCRIPTION
Based on comment in dot-atom/.apm/.apmrc, the .apm directory created as part of the default startup is a cache, therefore it shouldn't be included in git.
