### PR TITLE
:memo: Fix linking the decorateMarker

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1551,7 +1551,7 @@ class TextEditor extends Model
   #
   # * `markerLayer` A {TextEditorMarkerLayer} or {MarkerLayer} to decorate.
   # * `decorationParams` The same parameters that are passed to
-  #   {decorateMarker}, except the `type` cannot be `overlay` or `gutter`.
+  #   {TextEditor::decorateMarker}, except the `type` cannot be `overlay` or `gutter`.
   #
   # This API is experimental and subject to change on any release.
   #


### PR DESCRIPTION
Error happens at this place in the docs
https://atom.io/docs/api/v1.6.2/TextEditor#instance-decorateMarkerLayer
