### PR TITLE
Fixed positioning for overlay

### DIFF
--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -459,19 +459,21 @@ class TextEditorPresenter
 
       pixelPosition = @pixelPositionForScreenPosition(screenPosition)
 
-      top = pixelPosition.top + @lineHeight
-      left = pixelPosition.left + @gutterWidth
+      # Fixed positioning.
+      top = @boundingClientRect.top + pixelPosition.top + @lineHeight
+      left = @boundingClientRect.left + pixelPosition.left + @gutterWidth
 
       if overlayDimensions = @overlayDimensions[decoration.id]
         {itemWidth, itemHeight, contentMargin} = overlayDimensions
 
-        rightDiff = left + @boundingClientRect.left + itemWidth + contentMargin - @windowWidth
+        rightDiff = left + itemWidth + contentMargin - @windowWidth
         left -= rightDiff if rightDiff > 0
 
-        leftDiff = left + @boundingClientRect.left + contentMargin
+        leftDiff = left + contentMargin
         left -= leftDiff if leftDiff < 0
 
-        if top + @boundingClientRect.top + itemHeight > @windowHeight and top - (itemHeight + @lineHeight) >= 0
+        if top + itemHeight > @windowHeight and
+           top - (itemHeight + @lineHeight) >= 0
           top -= itemHeight + @lineHeight
 
       pixelPosition.top = top

--- a/static/text-editor-light.less
+++ b/static/text-editor-light.less
@@ -15,7 +15,7 @@ atom-text-editor[mini] {
 }
 
 atom-overlay {
-  position: absolute;
+  position: fixed;
   display: block;
   z-index: 4;
 }


### PR DESCRIPTION
This PR changes the positioning of the overlay from absolute to fixed.
This ensures that no overflow will be triggered in surrounding elements, which is important especially for mini TextEditors.
cc @nathansobo 
