### PR TITLE
Allow A Window's Environment To Reflect The Most Recent atom Invocation

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -466,6 +466,7 @@ class AtomApplication
         openedWindow.restore()
       else
         openedWindow.focus()
+      openedWindow.replaceEnvironment(env)
     else
       if devMode
         try

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -68,6 +68,7 @@ class AtomWindow
       @loaded = true
 
     @setLoadSettings(loadSettings)
+    @env = loadSettings.env if loadSettings.env?
     @browserWindow.focusOnWebView() if @isSpec
     @browserWindow.temporaryState = {windowDimensions} if windowDimensions?
 
@@ -168,6 +169,9 @@ class AtomWindow
       @sendMessage 'open-locations', locationsToOpen
     else
       @browserWindow.once 'window:loaded', => @openLocations(locationsToOpen)
+
+  replaceEnvironment: (env) ->
+    @browserWindow.webContents.send 'environment', env
 
   sendMessage: (message, detail) ->
     @browserWindow.webContents.send 'message', message, detail

--- a/src/environment-helpers.js
+++ b/src/environment-helpers.js
@@ -91,4 +91,12 @@ function normalize (options = {}) {
   }
 }
 
-export default { getFromShell, needsPatching, normalize }
+function replace (env) {
+  if (!env || !env.PATH) {
+    return
+  }
+
+  process.env = env
+}
+
+export default { getFromShell, needsPatching, normalize, replace }

--- a/src/initialize-application-window.coffee
+++ b/src/initialize-application-window.coffee
@@ -4,11 +4,12 @@ module.exports = ({blobStore}) ->
   path = require 'path'
   require './window'
   {getWindowLoadSettings} = require './window-load-settings-helpers'
-
+  {ipcRenderer} = require 'electron'
   {resourcePath, isSpec, devMode, env} = getWindowLoadSettings()
 
   # Set baseline environment
   environmentHelpers.normalize({env: env})
+  env = process.env
 
   # Add application-specific exports to module search path.
   exportsPath = path.join(resourcePath, 'exports')
@@ -25,7 +26,7 @@ module.exports = ({blobStore}) ->
     applicationDelegate: new ApplicationDelegate,
     configDirPath: process.env.ATOM_HOME
     enablePersistence: true
-    env: env
+    env: process.env
   })
 
   atom.startEditorWindow().then ->
@@ -35,3 +36,6 @@ module.exports = ({blobStore}) ->
       window.removeEventListener('focus', windowFocused)
       setTimeout (-> document.querySelector('atom-workspace').focus()), 0
     window.addEventListener('focus', windowFocused)
+    ipcRenderer.on('environment', (event, env) ->
+      environmentHelpers.replace(env)
+    )


### PR DESCRIPTION
This PR splits out portions of #11337, to address:
- Allows multiple invocations of `FOO=blah atom .` and `FOO=bleh atom .` to result in an updated environment for an existing window ("Should `process.env` be updated if atom is invoked from the shell for the same directory multiple times?" from #4126)

/cc @lee-dohm 
