### PR TITLE
Ignore autorun on our buffered process commands. Fixes #10082

### DIFF
--- a/spec/buffered-process-spec.coffee
+++ b/spec/buffered-process-spec.coffee
@@ -88,14 +88,15 @@ describe "BufferedProcess", ->
     describe "when the explorer command is spawned on Windows", ->
       it "doesn't quote arguments of the form /root,C...", ->
         new BufferedProcess({command: 'explorer.exe', args: ['/root,C:\\foo']})
-        expect(ChildProcess.spawn.argsForCall[0][1][2]).toBe '"explorer.exe /root,C:\\foo"'
+        expect(ChildProcess.spawn.argsForCall[0][1][3]).toBe '"explorer.exe /root,C:\\foo"'
 
     it "spawns the command using a cmd.exe wrapper", ->
       new BufferedProcess({command: 'dir'})
       expect(path.basename(ChildProcess.spawn.argsForCall[0][0])).toBe 'cmd.exe'
       expect(ChildProcess.spawn.argsForCall[0][1][0]).toBe '/s'
-      expect(ChildProcess.spawn.argsForCall[0][1][1]).toBe '/c'
-      expect(ChildProcess.spawn.argsForCall[0][1][2]).toBe '"dir"'
+      expect(ChildProcess.spawn.argsForCall[0][1][1]).toBe '/d'
+      expect(ChildProcess.spawn.argsForCall[0][1][2]).toBe '/c'
+      expect(ChildProcess.spawn.argsForCall[0][1][3]).toBe '"dir"'
 
   it "calls the specified stdout, stderr, and exit callbacks", ->
     stdout = ''

--- a/src/buffered-process.coffee
+++ b/src/buffered-process.coffee
@@ -67,7 +67,7 @@ class BufferedProcess
         cmdArgs.unshift("\"#{command}\"")
       else
         cmdArgs.unshift(command)
-      cmdArgs = ['/s', '/c', "\"#{cmdArgs.join(' ')}\""]
+      cmdArgs = ['/s', '/d', '/c', "\"#{cmdArgs.join(' ')}\""]
       cmdOptions = _.clone(options)
       cmdOptions.windowsVerbatimArguments = true
       @spawn(@getCmdPath(), cmdArgs, cmdOptions)


### PR DESCRIPTION
Fixes the problem of apm and atom shell calls via buffered-process being interrupted/confused by autorun entries in the registry by telling our commands to ignore them.
