### PR TITLE
Fix deprecations reporting

### DIFF
--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -5,6 +5,13 @@ temp = require('temp').track()
 _ = require 'underscore-plus'
 async = require 'async'
 
+# TODO: This should really be parallel on every platform, however:
+# - On Windows, our fixtures step on each others toes.
+if process.platform is 'win32'
+  concurrency = 1
+else
+  concurrency = 2
+
 module.exports = (grunt) ->
   {isAtomPackage, spawn} = require('./task-helpers')(grunt)
 
@@ -12,7 +19,13 @@ module.exports = (grunt) ->
 
   getAppPath = ->
     contentsDir = grunt.config.get('atom.contentsDir')
-    path.join(contentsDir, 'MacOS', 'Atom')
+    switch process.platform
+      when 'darwin'
+        path.join(contentsDir, 'MacOS', 'Atom')
+      when 'linux'
+        path.join(contentsDir, 'atom')
+      when 'win32'
+        path.join(contentsDir, 'atom.exe')
 
   runPackageSpecs = (callback) ->
     failedPackages = []
@@ -20,16 +33,32 @@ module.exports = (grunt) ->
     resourcePath = process.cwd()
     appPath = getAppPath()
 
+    # Ensure application is executable on Linux
+    fs.chmodSync(appPath, '755') if process.platform is 'linux'
+
     packageSpecQueue = async.queue (packagePath, callback) ->
-      options =
-        cmd: appPath
-        args: ['--test', "--resource-path=#{resourcePath}", path.join(packagePath, 'spec')]
-        opts:
-          cwd: packagePath
-          env: _.extend({}, process.env, ELECTRON_ENABLE_LOGGING: true, ATOM_PATH: rootDir)
+      if process.platform in ['darwin', 'linux']
+        options =
+          cmd: appPath
+          args: ['--test', "--resource-path=#{resourcePath}", path.join(packagePath, 'spec')]
+          opts:
+            cwd: packagePath
+            env: _.extend({}, process.env, ELECTRON_ENABLE_LOGGING: true, ATOM_PATH: rootDir)
+      else if process.platform is 'win32'
+        options =
+          cmd: process.env.comspec
+          args: ['/c', appPath, '--test', "--resource-path=#{resourcePath}", "--log-file=ci.log", path.join(packagePath, 'spec')]
+          opts:
+            cwd: packagePath
+            env: _.extend({}, process.env, ELECTRON_ENABLE_LOGGING: true, ATOM_PATH: rootDir)
 
       grunt.log.ok "Launching #{path.basename(packagePath)} specs."
-      spawn options, (error) ->
+      spawn options, (error, results, code) ->
+        if process.platform is 'win32'
+          if error
+            process.stderr.write(fs.readFileSync(path.join(packagePath, 'ci.log')))
+          fs.unlinkSync(path.join(packagePath, 'ci.log'))
+
         failedPackages.push path.basename(packagePath) if error
         callback()
 
@@ -40,7 +69,7 @@ module.exports = (grunt) ->
       continue unless isAtomPackage(packagePath)
       packageSpecQueue.push(packagePath)
 
-    packageSpecQueue.concurrency = 1
+    packageSpecQueue.concurrency = Math.max(1, concurrency - 1)
     packageSpecQueue.drain = -> callback(null, failedPackages)
 
   runCoreSpecs = (callback) ->
@@ -48,20 +77,41 @@ module.exports = (grunt) ->
     resourcePath = process.cwd()
     coreSpecsPath = path.resolve('spec')
 
-    options =
-      cmd: appPath
-      args: ['--test', "--resource-path=#{resourcePath}", coreSpecsPath, "--user-data-dir=#{temp.mkdirSync('atom-user-data-dir')}"]
-      opts:
-        env: _.extend({}, process.env, {ATOM_INTEGRATION_TESTS_ENABLED: true, ELECTRON_ENABLE_LOGGING: true})
-        stdio: 'inherit'
+    if process.platform in ['darwin', 'linux']
+      options =
+        cmd: appPath
+        args: ['--test', "--resource-path=#{resourcePath}", coreSpecsPath, "--user-data-dir=#{temp.mkdirSync('atom-user-data-dir')}"]
+        opts:
+          env: _.extend({}, process.env, {ELECTRON_ENABLE_LOGGING: true, ATOM_INTEGRATION_TESTS_ENABLED: true})
+          stdio: 'inherit'
+
+    else if process.platform is 'win32'
+      options =
+        cmd: process.env.comspec
+        args: ['/c', appPath, '--test', "--resource-path=#{resourcePath}", '--log-file=ci.log', coreSpecsPath]
+        opts:
+          env: _.extend({}, process.env, {ELECTRON_ENABLE_LOGGING: true, ATOM_INTEGRATION_TESTS_ENABLED: true})
+          stdio: 'inherit'
 
     grunt.log.ok "Launching core specs."
-    spawn options, (error, results) ->
+    spawn options, (error, results, code) ->
+      if process.platform is 'win32'
+        process.stderr.write(fs.readFileSync('ci.log')) if error
+        fs.unlinkSync('ci.log')
+      else
+        # TODO: Restore concurrency on Windows
+        packageSpecQueue?.concurrency = concurrency
+
       callback(null, error)
 
   grunt.registerTask 'run-specs', 'Run the specs', ->
     done = @async()
     startTime = Date.now()
+    method =
+      if concurrency is 1
+        async.series
+      else
+        async.parallel
 
     specs =
       if process.env.ATOM_SPECS_TASK is 'packages'
@@ -71,7 +121,7 @@ module.exports = (grunt) ->
       else
         [runCoreSpecs, runPackageSpecs]
 
-    async.series specs, (error, results) ->
+    method specs, (error, results) ->
       failedPackages = []
       coreSpecFailed = null
 
@@ -83,10 +133,13 @@ module.exports = (grunt) ->
         [coreSpecFailed, failedPackages] = results
 
       elapsedTime = Math.round((Date.now() - startTime) / 100) / 10
-      grunt.log.ok("Total spec time: #{elapsedTime}s")
+      grunt.log.ok("Total spec time: #{elapsedTime}s using #{concurrency} cores")
       failures = failedPackages
       failures.push "atom core" if coreSpecFailed
 
       grunt.log.error("[Error]".red + " #{failures.join(', ')} spec(s) failed") if failures.length > 0
 
-      done(not coreSpecFailed and failedPackages.length is 0)
+      if process.platform is 'win32' and process.env.JANKY_SHA1
+        done()
+      else
+        done(not coreSpecFailed and failedPackages.length is 0)

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -5,40 +5,14 @@ temp = require('temp').track()
 _ = require 'underscore-plus'
 async = require 'async'
 
-# TODO: This should really be parallel on every platform, however:
-# - On Windows, our fixtures step on each others toes.
-if process.platform is 'win32'
-  concurrency = 1
-else
-  concurrency = 2
-
 module.exports = (grunt) ->
   {isAtomPackage, spawn} = require('./task-helpers')(grunt)
 
   packageSpecQueue = null
 
-  logDeprecations = (label, {stderr}={}) ->
-    stderr ?= ''
-    deprecatedStart = stderr.indexOf('Calls to deprecated functions')
-    return if deprecatedStart is -1
-
-    grunt.log.error(label)
-    stderr = stderr.substring(deprecatedStart)
-    stderr = stderr.replace(/^\s*\[[^\]]+\]\s+/gm, '')
-    stderr = stderr.replace(/source: .*$/gm, '')
-    stderr = stderr.replace(/^"/gm, '')
-    stderr = stderr.replace(/",\s*$/gm, '')
-    grunt.log.error(stderr)
-
   getAppPath = ->
     contentsDir = grunt.config.get('atom.contentsDir')
-    switch process.platform
-      when 'darwin'
-        path.join(contentsDir, 'MacOS', 'Atom')
-      when 'linux'
-        path.join(contentsDir, 'atom')
-      when 'win32'
-        path.join(contentsDir, 'atom.exe')
+    path.join(contentsDir, 'MacOS', 'Atom')
 
   runPackageSpecs = (callback) ->
     failedPackages = []
@@ -46,34 +20,17 @@ module.exports = (grunt) ->
     resourcePath = process.cwd()
     appPath = getAppPath()
 
-    # Ensure application is executable on Linux
-    fs.chmodSync(appPath, '755') if process.platform is 'linux'
-
     packageSpecQueue = async.queue (packagePath, callback) ->
-      if process.platform in ['darwin', 'linux']
-        options =
-          cmd: appPath
-          args: ['--test', "--resource-path=#{resourcePath}", path.join(packagePath, 'spec')]
-          opts:
-            cwd: packagePath
-            env: _.extend({}, process.env, ATOM_PATH: rootDir)
-      else if process.platform is 'win32'
-        options =
-          cmd: process.env.comspec
-          args: ['/c', appPath, '--test', "--resource-path=#{resourcePath}", "--log-file=ci.log", path.join(packagePath, 'spec')]
-          opts:
-            cwd: packagePath
-            env: _.extend({}, process.env, ATOM_PATH: rootDir)
+      options =
+        cmd: appPath
+        args: ['--test', "--resource-path=#{resourcePath}", path.join(packagePath, 'spec')]
+        opts:
+          cwd: packagePath
+          env: _.extend({}, process.env, ELECTRON_ENABLE_LOGGING: true, ATOM_PATH: rootDir)
 
       grunt.log.ok "Launching #{path.basename(packagePath)} specs."
-      spawn options, (error, results, code) ->
-        if process.platform is 'win32'
-          if error
-            process.stderr.write(fs.readFileSync(path.join(packagePath, 'ci.log')))
-          fs.unlinkSync(path.join(packagePath, 'ci.log'))
-
+      spawn options, (error) ->
         failedPackages.push path.basename(packagePath) if error
-        logDeprecations("#{path.basename(packagePath)} Specs", results)
         callback()
 
     modulesDirectory = path.resolve('node_modules')
@@ -83,71 +40,38 @@ module.exports = (grunt) ->
       continue unless isAtomPackage(packagePath)
       packageSpecQueue.push(packagePath)
 
-    packageSpecQueue.concurrency = Math.max(1, concurrency - 1)
+    packageSpecQueue.concurrency = 1
     packageSpecQueue.drain = -> callback(null, failedPackages)
 
-  runCoreSpecs = (callback, logOutput = false) ->
+  runCoreSpecs = (callback) ->
     appPath = getAppPath()
     resourcePath = process.cwd()
     coreSpecsPath = path.resolve('spec')
 
-    if process.platform in ['darwin', 'linux']
-      options =
-        cmd: appPath
-        args: ['--test', "--resource-path=#{resourcePath}", coreSpecsPath, "--user-data-dir=#{temp.mkdirSync('atom-user-data-dir')}"]
-        opts:
-          env: _.extend({}, process.env,
-            ATOM_INTEGRATION_TESTS_ENABLED: true
-          )
-
-    else if process.platform is 'win32'
-      options =
-        cmd: process.env.comspec
-        args: ['/c', appPath, '--test', "--resource-path=#{resourcePath}", '--log-file=ci.log', coreSpecsPath]
-        opts:
-          env: _.extend({}, process.env,
-            ATOM_INTEGRATION_TESTS_ENABLED: true
-          )
-
-    if logOutput
-      options.opts.stdio = 'inherit'
+    options =
+      cmd: appPath
+      args: ['--test', "--resource-path=#{resourcePath}", coreSpecsPath, "--user-data-dir=#{temp.mkdirSync('atom-user-data-dir')}"]
+      opts:
+        env: _.extend({}, process.env, {ATOM_INTEGRATION_TESTS_ENABLED: true, ELECTRON_ENABLE_LOGGING: true})
+        stdio: 'inherit'
 
     grunt.log.ok "Launching core specs."
-    spawn options, (error, results, code) ->
-      if process.platform is 'win32'
-        process.stderr.write(fs.readFileSync('ci.log')) if error
-        fs.unlinkSync('ci.log')
-      else
-        # TODO: Restore concurrency on Windows
-        packageSpecQueue?.concurrency = concurrency
-        logDeprecations('Core Specs', results)
-
+    spawn options, (error, results) ->
       callback(null, error)
 
   grunt.registerTask 'run-specs', 'Run the specs', ->
     done = @async()
     startTime = Date.now()
-    method =
-      if concurrency is 1
-        async.series
-      else
-        async.parallel
-
-    # If we're just running the core specs then we won't have any output to
-    # indicate the tests actually *are* running. This upsets Travis:
-    # https://github.com/atom/atom/issues/10837. So pass the test output
-    # through.
-    runCoreSpecsWithLogging = (callback) -> runCoreSpecs(callback, true)
 
     specs =
       if process.env.ATOM_SPECS_TASK is 'packages'
         [runPackageSpecs]
       else if process.env.ATOM_SPECS_TASK is 'core'
-        [runCoreSpecsWithLogging]
+        [runCoreSpecs]
       else
         [runCoreSpecs, runPackageSpecs]
 
-    method specs, (error, results) ->
+    async.series specs, (error, results) ->
       failedPackages = []
       coreSpecFailed = null
 
@@ -159,13 +83,10 @@ module.exports = (grunt) ->
         [coreSpecFailed, failedPackages] = results
 
       elapsedTime = Math.round((Date.now() - startTime) / 100) / 10
-      grunt.log.ok("Total spec time: #{elapsedTime}s using #{concurrency} cores")
+      grunt.log.ok("Total spec time: #{elapsedTime}s")
       failures = failedPackages
       failures.push "atom core" if coreSpecFailed
 
       grunt.log.error("[Error]".red + " #{failures.join(', ')} spec(s) failed") if failures.length > 0
 
-      if process.platform is 'win32' and process.env.JANKY_SHA1
-        done()
-      else
-        done(not coreSpecFailed and failedPackages.length is 0)
+      done(not coreSpecFailed and failedPackages.length is 0)

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -18,7 +18,6 @@ module.exports = (grunt) ->
   packageSpecQueue = null
 
   logDeprecations = (label, {stderr}={}) ->
-    return unless process.env.JANKY_SHA1 or process.env.CI
     stderr ?= ''
     deprecatedStart = stderr.indexOf('Calls to deprecated functions')
     return if deprecatedStart is -1

--- a/spec/fake-spec.coffee
+++ b/spec/fake-spec.coffee
@@ -1,0 +1,3 @@
+fdescribe "remove this", ->
+  it "remove me", ->
+    require("grim").deprecate("foo")

--- a/spec/fake-spec.coffee
+++ b/spec/fake-spec.coffee
@@ -1,3 +1,0 @@
-fdescribe "remove this", ->
-  it "remove me", ->
-    require("grim").deprecate("foo")

--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -1,3 +1,4 @@
+Grim = require 'grim'
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
 path = require 'path'
@@ -96,13 +97,10 @@ buildTerminalReporter = (logFile, resolveWithExitCode) ->
       log(str)
     onComplete: (runner) ->
       fs.closeSync(logStream) if logStream?
-      if process.env.JANKY_SHA1 or process.env.CI
-        grim = require 'grim'
-
-        if grim.getDeprecationsLength() > 0
-          grim.logDeprecations()
-          resolveWithExitCode(1)
-          return
+      if Grim.getDeprecationsLength() > 0
+        Grim.logDeprecations()
+        resolveWithExitCode(1)
+        return
 
       if runner.results().failedCount > 0
         resolveWithExitCode(1)

--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -25,7 +25,7 @@ module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
   })
 
   require './spec-helper'
-  # disableFocusMethods() if process.env.JANKY_SHA1 or process.env.CI
+  disableFocusMethods() if process.env.JANKY_SHA1 or process.env.CI
   requireSpecs(testPath) for testPath in testPaths
 
   setSpecType('user')

--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -25,7 +25,7 @@ module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
   })
 
   require './spec-helper'
-  disableFocusMethods() if process.env.JANKY_SHA1 or process.env.CI
+  # disableFocusMethods() if process.env.JANKY_SHA1 or process.env.CI
   requireSpecs(testPath) for testPath in testPaths
 
   setSpecType('user')


### PR DESCRIPTION
Previously builds that contained deprecations were failing without logging out the reason. I tracked down the issue to `ELECTRON_ENABLE_LOGGING`, which was preventing deprecations from being logged out. This is how this PR changes the `run-specs` task to handle this scenario correctly:
1. :bug: Use `ELECTRON_ENABLE_LOGGING=true`. This allows us to capture the output of calls to `console.warn` and `console.log`, which are useful to log out Grim deprecations.
2. :fire: Remove calls to `logDeprecations`. This method used to format the output captured in `stderr` to strip out "[Console]" noise from deprecations. This code path was not running anymore because we started using `stdio: 'inherit'` in #10838 for core specs, which prevents stderr output to be captured. I feel like it's okay to remove it, as the output is already readable as it is.

You can see a sample of a new build here: https://travis-ci.org/atom/atom/jobs/123049543#L254-L257.
