### PR TITLE
Fixes #11190

### DIFF
--- a/src/environment-helpers.js
+++ b/src/environment-helpers.js
@@ -58,7 +58,7 @@ function getFromShell () {
 function needsPatching (options = { platform: process.platform, env: process.env }) {
   if (options.platform === 'darwin' && !options.env.PWD) {
     let shell = getUserShell()
-    if (shell.endsWith('csh') || shell.endsWith('tcsh')) {
+    if (shell.endsWith('csh') || shell.endsWith('tcsh') || shell.endsWith('fish')) {
       return false
     }
     return true


### PR DESCRIPTION
This is the error thrown when starting Atom from Spotlight on Mac or by double clicking on the App and the default shell is `fish-shell`.
I attach a Snapshot of the error, that doesn't happen anymore after the fix.
![screen shot 2016-04-14 at 16 19 48](https://cloud.githubusercontent.com/assets/533153/14531454/ab89a0ec-025d-11e6-92ca-010838d0f97b.png)
