### PR TITLE
Always favor more recently added inline listeners

### DIFF
--- a/spec/command-registry-spec.coffee
+++ b/spec/command-registry-spec.coffee
@@ -74,6 +74,13 @@ describe "CommandRegistry", ->
       grandchild.dispatchEvent(new CustomEvent('command', bubbles: true))
       expect(calls).toEqual ['.foo.bar', '.bar', '.foo']
 
+    it "orders inline listeners by reverse registration order", ->
+      calls = []
+      registry.add child, 'command', -> calls.push('child1')
+      registry.add child, 'command', -> calls.push('child2')
+      child.dispatchEvent(new CustomEvent('command', bubbles: true))
+      expect(calls).toEqual ['child2', 'child1']
+
     it "stops bubbling through ancestors when .stopPropagation() is called on the event", ->
       calls = []
 

--- a/src/command-registry.coffee
+++ b/src/command-registry.coffee
@@ -244,11 +244,14 @@ class CommandRegistry
           (@selectorBasedListenersByCommandName[event.type] ? [])
             .filter (listener) -> currentTarget.webkitMatchesSelector(listener.selector)
             .sort (a, b) -> a.compare(b)
-        listeners = listeners.concat(selectorBasedListeners)
+        listeners = selectorBasedListeners.concat(listeners)
 
       matched = true if listeners.length > 0
 
-      for listener in listeners
+      # Call inline listeners first in reverse registration order,
+      # and selector-based listeners by specificity and reverse
+      # registration order.
+      for listener in listeners by -1
         break if immediatePropagationStopped
         listener.callback.call(currentTarget, dispatchedEvent)
 
@@ -271,8 +274,8 @@ class SelectorBasedListener
     @sequenceNumber = SequenceCount++
 
   compare: (other) ->
-    other.specificity - @specificity  or
-      other.sequenceNumber - @sequenceNumber
+    @specificity - other.specificity or
+      @sequenceNumber - other.sequenceNumber
 
 class InlineListener
   constructor: (@callback) ->


### PR DESCRIPTION
This allows newer listeners to be prioritized based on when they are added.
This is useful as more recent contexts often have to be resolved first.

For example, when `core:move-down` is called in a `find-and-replace` editor, it will go through its history.
But when an autocompletion listener is added later, it should move through the possible autocompletions.

I am curious how this use case is handled in for plain DOM listeners, as they will always be called [in the order of their registration](https://www.w3.org/TR/uievents/#event-flow). It seems possible that listeners can be backed up, and restored after the context is resolved. I'm not very experienced in front-end development though, do you guys have insight?

cc @nathansobo 
