### PR TITLE
Add Project::createFile and ::createDirectory

### DIFF
--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -498,6 +498,13 @@ describe "Project", ->
       runs ->
         expect(fs.readFileSync(filePath, 'utf8')).toBe ''
 
+    it "calls callbacks registered with ::onDidCreateFile", ->
+      waitsFor 'onDidCreateFile event', 100, (done) ->
+        atom.project.createFile(filePath)
+        atom.project.onDidCreateFile (file) ->
+          expect(file.getPath()).toBe filePath
+          done()
+
     describe "when the file already exists", ->
       it "rejects with an error", ->
         fs.writeFileSync(filePath, '')
@@ -542,6 +549,13 @@ describe "Project", ->
 
       runs ->
         expect(fs.existsSync(dirPath)).toBe true
+
+    it "calls callbacks registered with ::onDidCreateDirectory", ->
+      waitsFor 'onDidCreateDirectory event', 100, (done) ->
+        atom.project.createDirectory(dirPath)
+        atom.project.onDidCreateDirectory (dir) ->
+          expect(dir.getPath()).toBe dirPath
+          done()
 
     describe "when the directory already exists", ->
       it "rejects with an error", ->

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -93,6 +93,12 @@ class Project extends Model
   onDidAddBuffer: (callback) ->
     @emitter.on 'did-add-buffer', callback
 
+  onDidCreateFile: (callback) ->
+    @emitter.on 'did-create-file', callback
+
+  onDidCreateDirectory: (callback) ->
+    @emitter.on 'did-create-directory', callback
+
   ###
   Section: Accessing the git repository
   ###

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -93,9 +93,22 @@ class Project extends Model
   onDidAddBuffer: (callback) ->
     @emitter.on 'did-add-buffer', callback
 
+  # Public: Invoke the given callback when a file is created via `createFile`.
+  #
+  # * `callback` {Function} to be called after a file is created.
+  #    * `file` The {File} that was created.
+  #
+  # Returns a {Disposable} on which `.dispose` can be called to unsubscribe.
   onDidCreateFile: (callback) ->
     @emitter.on 'did-create-file', callback
 
+  # Public: Invoke the given callback when a directory is created via
+  # `createDirectory`.
+  #
+  # * `callback` {Function} to be called after a directory is created.
+  #    * `directory` The {Directory} that was created.
+  #
+  # Returns a {Disposable} on which `.dispose` can be called to unsubscribe.
   onDidCreateDirectory: (callback) ->
     @emitter.on 'did-create-directory', callback
 
@@ -207,6 +220,13 @@ class Project extends Model
     else
       false
 
+  # Public: create a new file.
+  #
+  # * `path` {String} The path to the file to create.
+  #
+  # Returns a {Promise} that resolves to a {File} object if the file is
+  # successfully created or rejects with an error object if the file cannot
+  # be created.
   createFile: (path) ->
     new Promise (resolve, reject) =>
       fs.exists path, (exists) =>
@@ -220,6 +240,13 @@ class Project extends Model
           @emitter.emit 'did-create-file', file
           resolve(file)
 
+  # Public: create a new directory.
+  #
+  # * `path` {String} The path to the directory to create.
+  #
+  # Returns a {Promise} that resolves to a {Directory} object if the directory
+  # is successfully created or rejects with an error object if the directory
+  # cannot be created.
   createDirectory: (path) ->
     new Promise (resolve, reject) =>
       fs.exists path, (exists) =>

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -208,12 +208,24 @@ class Project extends Model
           return reject(new Error("'#{path}' already exists."))
 
         fs.writeFile path, '', (err) =>
-          if err
-            return reject(err)
+          return reject(err) if err?
 
           file = new File(path)
           @emitter.emit 'did-create-file', file
           resolve(file)
+
+  createDirectory: (path) ->
+    new Promise (resolve, reject) =>
+      fs.exists path, (exists) =>
+        if exists
+          return reject(new Error("'#{path}' already exists."))
+
+        fs.makeTree path, (err) =>
+          return reject(err) if err?
+
+          dir = new Directory(path)
+          @emitter.emit 'did-create-directory', dir
+          resolve(dir)
 
   # Public: Get an {Array} of {Directory}s associated with this project.
   getDirectories: ->

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -4,6 +4,7 @@ url = require 'url'
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
 {Emitter, Disposable} = require 'event-kit'
+{File, Directory} = require 'pathwatcher'
 TextBuffer = require 'text-buffer'
 
 DefaultDirectoryProvider = require './default-directory-provider'
@@ -199,6 +200,20 @@ class Project extends Model
       true
     else
       false
+
+  createFile: (path) ->
+    new Promise (resolve, reject) =>
+      fs.exists path, (exists) =>
+        if exists
+          return reject(new Error("'#{path}' already exists."))
+
+        fs.writeFile path, '', (err) =>
+          if err
+            return reject(err)
+
+          file = new File(path)
+          @emitter.emit 'did-create-file', file
+          resolve(file)
 
   # Public: Get an {Array} of {Directory}s associated with this project.
   getDirectories: ->


### PR DESCRIPTION
This PR implements four new methods on `Project` to create files, create directories, and watch for the creation of both:
- `Project::createFile(path)`
- `Project::createDirectory(path)`
- `Project::onDidCreateFile(callback)`
- `Project::onDidCreateDirectory(callback)`

Currently packages (like `tree-view`) manually call out to the filesystem APIs to create files, and other packages aren't notified of such changes. This leads to bugs like https://github.com/atom/fuzzy-finder/issues/175. By centralizing file and directory creation and adding notification hooks, packages can be notified any time a `Project`'s file structure changes.

/cc @nathansobo @atom/core 
