### PR TITLE
🏇 Improve perf for clicking below buffer of long line to seek cursor

### DIFF
--- a/src/lines-yardstick.coffee
+++ b/src/lines-yardstick.coffee
@@ -36,6 +36,10 @@ class LinesYardstick
     previousColumn = 0
     previousLeft = 0
 
+    if targetLeft is Infinity
+      column = textNodes.reduce(((lineLength, nodeLength) -> lineLength + nodeLength.textContent.length), 0)
+      return Point(row, column)
+
     @tokenIterator.reset(line, false)
     while @tokenIterator.next()
       text = @tokenIterator.getText()


### PR DESCRIPTION
In cases where the last line of a file is very long and the user clicks below that line to seek to the end of the last line, it can take a very long time due to calculating the position of every single column. See #10769 for a test case.

This commit checks the special case of clicking below the buffer and returns the position without going into the whole calculation loop. I'm not super familiar with how the internals of Atom work, and I assumed going through all this calculation to find the very last cursor position was needed due to surrogate pairs or something. But it seems that's not the case as the last column position can be found by just summing the row's textNode lengths, so short circuiting that logic brings a perf win.

This stops freezing for clicking below long lines, but doesn't solve the whole perf problem with seeking long lines. If you were to scroll to the end of a long line and click somewhere close to the end, it will still hang. Perhaps you could calculate the position backwards if the click position is in the latter half of the long line? Either way, that's a discussion for another issue/PR.

As far as tests go, I'm not really sure how you run the line-yardstick specs? Running `script/test` had a lot of failures on master for other specs. I don't think any new specs for line-yardstick is required since it already covers testing clicking below the buffer.

Resolves #10769
