### PR TITLE
Fixes to Windows command-line handling

### DIFF
--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -2,6 +2,7 @@
 
 SET EXPECT_OUTPUT=
 SET WAIT=
+SET PSARGS=%*
 
 FOR %%a IN (%*) DO (
   IF /I "%%a"=="-f"           SET EXPECT_OUTPUT=YES
@@ -25,7 +26,7 @@ FOR %%a IN (%*) DO (
 IF "%EXPECT_OUTPUT%"=="YES" (
   SET ELECTRON_ENABLE_LOGGING=YES
   IF "%WAIT%"=="YES" (
-    powershell -noexit "%~dp0\..\..\atom.exe" --pid=$pid %* ; wait-event
+    powershell -noexit "Start-Process -FilePath \"%~dp0\..\..\atom.exe\" -ArgumentList \"--pid=$pid $env:PSARGS\" ; wait-event"
   ) ELSE (
     "%~dp0\..\..\atom.exe" %*
   )

--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
-$(dirname "$0")/atom.cmd "$@"
+pushd $(dirname "$0") > /dev/null
+ATOMCMD=""$(pwd -W)"/atom.cmd"
+popd > /dev/null
+cmd.exe //c "$ATOMCMD" "$@"


### PR DESCRIPTION
Fixes:
- `Atom .` opens wrong folder from Bash #11454
- Atom fails to launch from Bash when install dir contains space #11492
- Atom fails to open in older versions of Bash #11164
