### PR TITLE
build: [ci skip] add lint npm script

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -45,5 +45,8 @@
     "unzip": "~0.1.9",
     "vm-compatibility-layer": "~0.1.0",
     "webdriverio": "^2.4.5"
+  },
+  "scripts": {
+    "lint": "grunt --gruntfile Gruntfile.coffee lint"
   }
 }

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
   "private": true,
   "scripts": {
     "preinstall": "node -e 'process.exit(0)'",
+    "lint": "cd build && npm run lint",
     "test": "node script/test"
   },
   "standard": {


### PR DESCRIPTION
Aim: to be able to invoke only linting from command line, as opposed to the whole (long) build process. With this, one can call `npm run lint` from project root directory.
