### PR TITLE
Content Security Policy fixes

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src *; img-src data: *; script-src 'self'; style-src 'self' 'unsafe-inline';">
+  <meta http-equiv="Content-Security-Policy" content="default-src *; img-src blob: data: *; script-src 'self'; style-src 'self' 'unsafe-inline'; media-src blob: data: mediastream: *;">
   <script src="index.js"></script>
 </head>
 <body tabindex="-1">


### PR DESCRIPTION
Add blob: protocol to img-src and media-src sources. Add data: and mediastream: protocols to media-src.

These changes are needed to fix video chat in the Floobits Atom plugin (issue https://github.com/Floobits/floobits-atom/issues/114). A CSP directive of `default-src: *` doesn't cover protocols like `blob:`, `data:`, or `mediastream:`, which the Floobits package uses.
