### PR TITLE
Makes script/build experience better for Windows users.

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -57,7 +57,7 @@ module.exports = (grunt) ->
     homeDir = process.env.USERPROFILE
     contentsDir = shellAppDir
     appDir = path.join(shellAppDir, 'resources', 'app')
-    installDir ?= path.join(process.env.ProgramFiles, appName)
+    installDir ?= path.join(process.env.LOCALAPPDATA, appName, 'app-dev')
     killCommand = 'taskkill /F /IM atom.exe'
   else if process.platform is 'darwin'
     homeDir = process.env.HOME

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -16,10 +16,22 @@ module.exports = (grunt) ->
     {description} = grunt.config.get('atom.metadata')
 
     if process.platform is 'win32'
-      runas ?= require 'runas'
-      copyFolder = path.resolve 'script', 'copy-folder.cmd'
-      if runas('cmd', ['/c', copyFolder, shellAppDir, installDir], admin: true) isnt 0
-        grunt.log.error("Failed to copy #{shellAppDir} to #{installDir}")
+      done = @async()
+      fs.access(installDir, fs.W_OK, (err) ->
+        adminRequired = true if err
+        if adminRequired
+          grunt.log.ok("User does not have write access to #{installDir}, elevating to admin")
+        runas ?= require 'runas'
+        copyFolder = path.resolve 'script', 'copy-folder.cmd'
+
+        if runas('cmd', ['/c', copyFolder, shellAppDir, installDir], admin: adminRequired) isnt 0
+          grunt.log.error("Failed to copy #{shellAppDir} to #{installDir}")
+        else
+          grunt.log.ok("Installed into #{installDir}")
+
+        done()
+      )
+
     else if process.platform is 'darwin'
       rm installDir
       mkdir path.dirname(installDir)

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -34,7 +34,7 @@ git clone https://github.com/atom/atom/
 cd atom
 script/build
 ```
-This will create the Atom application in the `out\Atom` folder as well as copy it to a folder named `Atom` within `Program Files`.
+This will create the Atom application in the `out\Atom` folder as well as copy it to a subfolder of your user profile (e.g. `c:\Users\Bob`) called `AppData\Local\atom\app-dev`.
 
 ### `script/build` Options
   * `--install-dir` - Creates the final built application in this directory. Example (trailing slash is optional):


### PR DESCRIPTION
This does two things:
1. Changes the default install folder to better match atomsetup.exe location, e.g. `c:\users\bob\appdata\local\atom\app-dev\` instead of `c:\program files\atom`
2. Only requests Admin rights if it can't write to the target instead of always prompting UAC
