### PR TITLE
Use an async dialog box

### DIFF
--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -131,7 +131,7 @@ class AtomWindow
         message: 'Editor is not responding'
         detail: 'The editor is not responding. Would you like to force close it or just keep waiting?'
       },
-      callback(response) => @browserWindow.destroy() if response is 0
+      (response) => @browserWindow.destroy() if response is 0
 
     @browserWindow.webContents.on 'crashed', =>
       global.atomApplication.exit(100) if @headless

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -125,12 +125,13 @@ class AtomWindow
     @browserWindow.on 'unresponsive', =>
       return if @isSpec
 
-      chosen = dialog.showMessageBox @browserWindow,
+      dialog.showMessageBox @browserWindow, {
         type: 'warning'
         buttons: ['Close', 'Keep Waiting']
         message: 'Editor is not responding'
         detail: 'The editor is not responding. Would you like to force close it or just keep waiting?'
-      @browserWindow.destroy() if chosen is 0
+      },
+      callback(response) => @browserWindow.destroy() if response is 0
 
     @browserWindow.webContents.on 'crashed', =>
       global.atomApplication.exit(100) if @headless


### PR DESCRIPTION
This way we don't block the main process until the dialog box is closed.  I'm not sure that this actually works - I experienced Atom hanging once with this branch built but didn't receive a dialog.

(See http://electron.atom.io/docs/v0.37.7/api/dialog/#dialogshowmessageboxbrowserwindow-options-callback for the notes about sync/async)

Fixes #11551
