### PR TITLE
Remove TextEditor's dependency on NotificationManager

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1189,14 +1189,10 @@ describe "TextEditor", ->
           cursor2 = editor.addCursorAtBufferPosition([1, 4])
           expect(cursor2.marker).toBe cursor1.marker
 
-    describe '.logCursorScope()', ->
-      beforeEach ->
-        spyOn(atom.notifications, 'addInfo')
-
-      it 'opens a notification', ->
-        editor.logCursorScope()
-
-        expect(atom.notifications.addInfo).toHaveBeenCalled()
+    describe '.getCursorScope()', ->
+      it 'returns the current scope', ->
+        descriptor = editor.getCursorScope()
+        expect(descriptor.scopes).toContain ('source.js')
 
   describe "selection", ->
     selection = null

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1192,7 +1192,7 @@ describe "TextEditor", ->
     describe '.getCursorScope()', ->
       it 'returns the current scope', ->
         descriptor = editor.getCursorScope()
-        expect(descriptor.scopes).toContain ('source.js')
+        expect(descriptor.scopes).toContain('source.js')
 
   describe "selection", ->
     selection = null

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -255,7 +255,7 @@ class AtomEnvironment extends Model
     @deserializers.add(TextBuffer)
 
   registerDefaultCommands: ->
-    registerDefaultCommands({commandRegistry: @commands, @config, @commandInstaller})
+    registerDefaultCommands({commandRegistry: @commands, @config, @commandInstaller, notificationManager: @notifications})
 
   registerDefaultViewProviders: ->
     @views.addViewProvider Workspace, (model, env) ->

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -1,6 +1,6 @@
 {ipcRenderer} = require 'electron'
 
-module.exports = ({commandRegistry, commandInstaller, config}) ->
+module.exports = ({commandRegistry, commandInstaller, config, notificationManager}) ->
   commandRegistry.add 'atom-workspace',
     'pane:show-next-recently-used-item': -> @getModel().getActivePane().activateNextRecentlyUsedItem()
     'pane:show-previous-recently-used-item': -> @getModel().getActivePane().activatePreviousRecentlyUsedItem()
@@ -187,7 +187,7 @@ module.exports = ({commandRegistry, commandInstaller, config}) ->
     'editor:fold-at-indent-level-7': -> @foldAllAtIndentLevel(6)
     'editor:fold-at-indent-level-8': -> @foldAllAtIndentLevel(7)
     'editor:fold-at-indent-level-9': -> @foldAllAtIndentLevel(8)
-    'editor:log-cursor-scope': -> @logCursorScope()
+    'editor:log-cursor-scope': -> showCursorScope(@getCursorScope(), notificationManager)
     'editor:copy-path': -> @copyPathToClipboard(false)
     'editor:copy-project-path': -> @copyPathToClipboard(true)
     'editor:toggle-indent-guide': -> config.set('editor.showIndentGuide', not config.get('editor.showIndentGuide'))
@@ -232,3 +232,10 @@ stopEventPropagationAndGroupUndo = (config, commandListeners) ->
         model.transact config.get('editor.undoGroupingInterval'), ->
           commandListener.call(model, event)
   newCommandListeners
+
+showCursorScope = (descriptor, notificationManager) ->
+  list = descriptor.scopes.toString().split(',')
+  list = list.map (item) -> "* #{item}"
+  content = "Scopes at Cursor\n#{list.join('\n')}"
+
+  notificationManager.addInfo(content, dismissable: true)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -79,7 +79,6 @@ class TextEditor extends Model
     state.displayBuffer = displayBuffer
     state.selectionsMarkerLayer = displayBuffer.getMarkerLayer(state.selectionsMarkerLayerId)
     state.config = atomEnvironment.config
-    state.notificationManager = atomEnvironment.notifications
     state.packageManager = atomEnvironment.packages
     state.clipboard = atomEnvironment.clipboard
     state.viewRegistry = atomEnvironment.views
@@ -100,12 +99,11 @@ class TextEditor extends Model
       @softTabs, @firstVisibleScreenRow, @firstVisibleScreenColumn, initialLine, initialColumn, tabLength,
       softWrapped, @displayBuffer, @selectionsMarkerLayer, buffer, suppressCursorCreation,
       @mini, @placeholderText, lineNumberGutterVisible, largeFileMode, @config,
-      @notificationManager, @packageManager, @clipboard, @viewRegistry, @grammarRegistry,
+      @packageManager, @clipboard, @viewRegistry, @grammarRegistry,
       @project, @assert, @applicationDelegate, grammar, showInvisibles, @autoHeight, @scrollPastEnd
     } = params
 
     throw new Error("Must pass a config parameter when constructing TextEditors") unless @config?
-    throw new Error("Must pass a notificationManager parameter when constructing TextEditors") unless @notificationManager?
     throw new Error("Must pass a packageManager parameter when constructing TextEditors") unless @packageManager?
     throw new Error("Must pass a clipboard parameter when constructing TextEditors") unless @clipboard?
     throw new Error("Must pass a viewRegistry parameter when constructing TextEditors") unless @viewRegistry?
@@ -520,7 +518,7 @@ class TextEditor extends Model
     softTabs = @getSoftTabs()
     newEditor = new TextEditor({
       @buffer, displayBuffer, selectionsMarkerLayer, @tabLength, softTabs,
-      suppressCursorCreation: true, @config, @notificationManager, @packageManager,
+      suppressCursorCreation: true, @config, @packageManager,
       @firstVisibleScreenRow, @firstVisibleScreenColumn,
       @clipboard, @viewRegistry, @grammarRegistry, @project, @assert, @applicationDelegate
     })
@@ -2827,13 +2825,9 @@ class TextEditor extends Model
       @commentScopeSelector ?= new TextMateScopeSelector('comment.*')
       @commentScopeSelector.matches(@scopeDescriptorForBufferPosition([bufferRow, match.index]).scopes)
 
-  logCursorScope: ->
-    scopeDescriptor = @getLastCursor().getScopeDescriptor()
-    list = scopeDescriptor.scopes.toString().split(',')
-    list = list.map (item) -> "* #{item}"
-    content = "Scopes at Cursor\n#{list.join('\n')}"
-
-    @notificationManager.addInfo(content, dismissable: true)
+  # Get the scope descriptor at the cursor.
+  getCursorScope: ->
+    @getLastCursor().getScopeDescriptor()
 
   # {Delegates to: DisplayBuffer.tokenForBufferPosition}
   tokenForBufferPosition: (bufferPosition) -> @displayBuffer.tokenForBufferPosition(bufferPosition)

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -564,7 +564,7 @@ class Workspace extends Model
   # Returns a {TextEditor}.
   buildTextEditor: (params) ->
     params = _.extend({
-      @config, @notificationManager, @packageManager, @clipboard, @viewRegistry,
+      @config, @packageManager, @clipboard, @viewRegistry,
       @grammarRegistry, @project, @assert, @applicationDelegate
     }, params)
     new TextEditor(params)


### PR DESCRIPTION
This is step 1 as laid out by @nathansobo in https://github.com/atom/atom/issues/10979.

Remove `TextEditor`s dependency on `NotificationManager`.
