### PR TITLE
Remove TextEditor's dependency on PackageManager

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -1617,17 +1617,21 @@ describe "Workspace", ->
       runs ->
         expect(pane.getPendingItem()).toBeFalsy()
 
-  escapeStringRegex = (str) ->
-    str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
-
   describe "grammar activation", ->
-    it "activates grammars", ->
+    beforeEach ->
+      waitsForPromise ->
+        atom.packages.activatePackage('language-javascript')
+
+    it "notifies the workspace of which grammar is used", ->
       editor = null
 
-      atom.workspace.handleGrammarUsed = jasmine.createSpy()
+      grammarUsed = jasmine.createSpy()
+      atom.workspace.handleGrammarUsed = grammarUsed
 
       waitsForPromise -> atom.workspace.open('sample-with-comments.js').then (o) -> editor = o
+      waitsFor -> grammarUsed.callCount is 1
       runs ->
-        atom.grammars.setGrammarOverrideForPath(editor.getPath(), 'source.coffee')
-        editor.reloadGrammar()
-      waitsFor -> atom.workspace.handleGrammarUsed.callCount is 1
+        expect(grammarUsed.argsForCall[0][0].name).toBe 'JavaScript'
+
+  escapeStringRegex = (str) ->
+    str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -1619,3 +1619,15 @@ describe "Workspace", ->
 
   escapeStringRegex = (str) ->
     str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+
+  describe "grammar activation", ->
+    it "activates grammars", ->
+      editor = null
+
+      atom.workspace.handleGrammarUsed = jasmine.createSpy()
+
+      waitsForPromise -> atom.workspace.open('sample-with-comments.js').then (o) -> editor = o
+      runs ->
+        atom.grammars.setGrammarOverrideForPath(editor.getPath(), 'source.coffee')
+        editor.reloadGrammar()
+      waitsFor -> atom.workspace.handleGrammarUsed.callCount is 1

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -136,9 +136,6 @@ class DisplayBuffer extends Model
   onDidChangeGrammar: (callback) ->
     @tokenizedBuffer.onDidChangeGrammar(callback)
 
-  onDidUseGrammar: (callback) ->
-    @tokenizedBuffer.onDidUseGrammar(callback)
-
   onDidTokenize: (callback) ->
     @tokenizedBuffer.onDidTokenize(callback)
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -136,6 +136,9 @@ class DisplayBuffer extends Model
   onDidChangeGrammar: (callback) ->
     @tokenizedBuffer.onDidChangeGrammar(callback)
 
+  onDidUseGrammar: (callback) ->
+    @tokenizedBuffer.onDidUseGrammar(callback)
+
   onDidTokenize: (callback) ->
     @tokenizedBuffer.onDidTokenize(callback)
 

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -35,7 +35,6 @@ class DisplayBuffer extends Model
     state.config = atomEnvironment.config
     state.assert = atomEnvironment.assert
     state.grammarRegistry = atomEnvironment.grammars
-    state.packageManager = atomEnvironment.packages
     new this(state)
 
   constructor: (params={}) ->
@@ -43,7 +42,7 @@ class DisplayBuffer extends Model
 
     {
       tabLength, @editorWidthInChars, @tokenizedBuffer, @foldsMarkerLayer, buffer,
-      ignoreInvisibles, @largeFileMode, @config, @assert, @grammarRegistry, @packageManager
+      ignoreInvisibles, @largeFileMode, @config, @assert, @grammarRegistry
     } = params
 
     @emitter = new Emitter
@@ -51,7 +50,7 @@ class DisplayBuffer extends Model
 
     @tokenizedBuffer ?= new TokenizedBuffer({
       tabLength, buffer, ignoreInvisibles, @largeFileMode, @config,
-      @grammarRegistry, @packageManager, @assert
+      @grammarRegistry, @assert
     })
     @buffer = @tokenizedBuffer.buffer
     @charWidthsByScope = {}
@@ -122,7 +121,7 @@ class DisplayBuffer extends Model
     foldsMarkerLayer = @foldsMarkerLayer.copy()
     new DisplayBuffer({
       @buffer, tabLength: @getTabLength(), @largeFileMode, @config, @assert,
-      @grammarRegistry, @packageManager, foldsMarkerLayer
+      @grammarRegistry, foldsMarkerLayer
     })
 
   updateAllScreenLines: ->

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -137,6 +137,9 @@ class DisplayBuffer extends Model
   onDidChangeGrammar: (callback) ->
     @tokenizedBuffer.onDidChangeGrammar(callback)
 
+  onDidUseGrammar: (callback) ->
+    @tokenizedBuffer.onDidUseGrammar(callback)
+
   onDidTokenize: (callback) ->
     @tokenizedBuffer.onDidTokenize(callback)
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -323,9 +323,6 @@ class TextEditor extends Model
   onDidChangeGrammar: (callback) ->
     @emitter.on 'did-change-grammar', callback
 
-  onDidUseGrammar: (callback) ->
-    @displayBuffer.onDidUseGrammar(callback)
-
   # Extended: Calls your `callback` when the result of {::isModified} changes.
   #
   # * `callback` {Function}

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -323,6 +323,9 @@ class TextEditor extends Model
   onDidChangeGrammar: (callback) ->
     @emitter.on 'did-change-grammar', callback
 
+  onDidUseGrammar: (callback) ->
+    @displayBuffer.onDidUseGrammar(callback)
+
   # Extended: Calls your `callback` when the result of {::isModified} changes.
   #
   # * `callback` {Function}

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -79,7 +79,6 @@ class TextEditor extends Model
     state.displayBuffer = displayBuffer
     state.selectionsMarkerLayer = displayBuffer.getMarkerLayer(state.selectionsMarkerLayerId)
     state.config = atomEnvironment.config
-    state.packageManager = atomEnvironment.packages
     state.clipboard = atomEnvironment.clipboard
     state.viewRegistry = atomEnvironment.views
     state.grammarRegistry = atomEnvironment.grammars
@@ -99,12 +98,11 @@ class TextEditor extends Model
       @softTabs, @firstVisibleScreenRow, @firstVisibleScreenColumn, initialLine, initialColumn, tabLength,
       softWrapped, @displayBuffer, @selectionsMarkerLayer, buffer, suppressCursorCreation,
       @mini, @placeholderText, lineNumberGutterVisible, largeFileMode, @config,
-      @packageManager, @clipboard, @viewRegistry, @grammarRegistry,
+      @clipboard, @viewRegistry, @grammarRegistry,
       @project, @assert, @applicationDelegate, grammar, showInvisibles, @autoHeight, @scrollPastEnd
     } = params
 
     throw new Error("Must pass a config parameter when constructing TextEditors") unless @config?
-    throw new Error("Must pass a packageManager parameter when constructing TextEditors") unless @packageManager?
     throw new Error("Must pass a clipboard parameter when constructing TextEditors") unless @clipboard?
     throw new Error("Must pass a viewRegistry parameter when constructing TextEditors") unless @viewRegistry?
     throw new Error("Must pass a grammarRegistry parameter when constructing TextEditors") unless @grammarRegistry?
@@ -127,7 +125,7 @@ class TextEditor extends Model
     buffer ?= new TextBuffer
     @displayBuffer ?= new DisplayBuffer({
       buffer, tabLength, softWrapped, ignoreInvisibles: @mini or not showInvisibles, largeFileMode,
-      @config, @assert, @grammarRegistry, @packageManager
+      @config, @assert, @grammarRegistry
     })
     @buffer = @displayBuffer.buffer
     @selectionsMarkerLayer ?= @addMarkerLayer(maintainHistory: true)
@@ -521,7 +519,7 @@ class TextEditor extends Model
     softTabs = @getSoftTabs()
     newEditor = new TextEditor({
       @buffer, displayBuffer, selectionsMarkerLayer, @tabLength, softTabs,
-      suppressCursorCreation: true, @config, @packageManager,
+      suppressCursorCreation: true, @config,
       @firstVisibleScreenRow, @firstVisibleScreenColumn,
       @clipboard, @viewRegistry, @grammarRegistry, @project, @assert, @applicationDelegate
     })

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -325,6 +325,9 @@ class TextEditor extends Model
   onDidChangeGrammar: (callback) ->
     @emitter.on 'did-change-grammar', callback
 
+  onDidUseGrammar: (callback) ->
+    @displayBuffer.onDidUseGrammar(callback)
+
   # Extended: Calls your `callback` when the result of {::isModified} changes.
   #
   # * `callback` {Function}

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -129,7 +129,7 @@ class TokenizedBuffer extends Model
     @emitter.emit 'did-change-grammar', grammar
 
     # Delay this to the next tick to ensure whoever created the buffer has the
-    # change to listen for this event before we send it.
+    # chance to listen for this event before we send it.
     process.nextTick =>
       @emitter.emit 'did-use-grammar', grammar
 

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -29,14 +29,13 @@ class TokenizedBuffer extends Model
       state.buffer = atomEnvironment.project.bufferForPathSync(state.bufferPath)
     state.config = atomEnvironment.config
     state.grammarRegistry = atomEnvironment.grammars
-    state.packageManager = atomEnvironment.packages
     state.assert = atomEnvironment.assert
     new this(state)
 
   constructor: (params) ->
     {
       @buffer, @tabLength, @ignoreInvisibles, @largeFileMode, @config,
-      @grammarRegistry, @packageManager, @assert, grammarScopeName
+      @grammarRegistry, @assert, grammarScopeName
     } = params
 
     @emitter = new Emitter

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -128,14 +128,6 @@ class TokenizedBuffer extends Model
 
     @emitter.emit 'did-change-grammar', grammar
 
-    # Delay this to the next tick to ensure whoever created the buffer has the
-    # chance to listen for this event before we send it.
-    process.nextTick =>
-      @emitter.emit 'did-use-grammar', grammar
-
-  onDidUseGrammar: (callback) ->
-    @emitter.on 'did-use-grammar', callback
-
   getGrammarSelectionContent: ->
     @buffer.getTextInRange([[0, 0], [10, 0]])
 

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -125,11 +125,7 @@ class TokenizedBuffer extends Model
     @disposables.add(@configSubscriptions)
 
     @retokenizeLines()
-    @emitter.emit 'did-use-grammar', grammar
     @emitter.emit 'did-change-grammar', grammar
-
-  onDidUseGrammar: (callback) ->
-    @emitter.on 'did-use-grammar', callback
 
   getGrammarSelectionContent: ->
     @buffer.getTextInRange([[0, 0], [10, 0]])

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -125,8 +125,13 @@ class TokenizedBuffer extends Model
     @disposables.add(@configSubscriptions)
 
     @retokenizeLines()
-    @emitter.emit 'did-use-grammar', grammar
+
     @emitter.emit 'did-change-grammar', grammar
+
+    # Delay this to the next tick to ensure whoever created the buffer has the
+    # change to listen for this event before we send it.
+    process.nextTick =>
+      @emitter.emit 'did-use-grammar', grammar
 
   onDidUseGrammar: (callback) ->
     @emitter.on 'did-use-grammar', callback

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -125,7 +125,11 @@ class TokenizedBuffer extends Model
     @disposables.add(@configSubscriptions)
 
     @retokenizeLines()
+    @emitter.emit 'did-use-grammar', grammar
     @emitter.emit 'did-change-grammar', grammar
+
+  onDidUseGrammar: (callback) ->
+    @emitter.on 'did-use-grammar', callback
 
   getGrammarSelectionContent: ->
     @buffer.getTextInRange([[0, 0], [10, 0]])

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -126,8 +126,11 @@ class TokenizedBuffer extends Model
     @disposables.add(@configSubscriptions)
 
     @retokenizeLines()
-    @packageManager.triggerActivationHook("#{grammar.packageName}:grammar-used")
+    @emitter.emit 'did-use-grammar', grammar
     @emitter.emit 'did-change-grammar', grammar
+
+  onDidUseGrammar: (callback) ->
+    @emitter.on 'did-use-grammar', callback
 
   getGrammarSelectionContent: ->
     @buffer.getTextInRange([[0, 0], [10, 0]])

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -550,7 +550,7 @@ class Workspace extends Model
     @project.bufferForPath(filePath, options).then (buffer) =>
       editor = @buildTextEditor(_.extend({buffer, largeFileMode}, options))
       disposable = atom.textEditors.add(editor)
-      grammarSubscription = editor.onDidUseGrammar(@activateGrammar.bind(this))
+      grammarSubscription = editor.onDidChangeGrammar(@activateGrammar.bind(this))
       editor.onDidDestroy ->
         grammarSubscription.dispose()
         disposable.dispose()

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -550,7 +550,7 @@ class Workspace extends Model
     @project.bufferForPath(filePath, options).then (buffer) =>
       editor = @buildTextEditor(_.extend({buffer, largeFileMode}, options))
       disposable = atom.textEditors.add(editor)
-      grammarSubscription = editor.onDidUseGrammar(@handleGrammarUsed.bind(this))
+      grammarSubscription = editor.observeGrammar(@handleGrammarUsed.bind(this))
       editor.onDidDestroy ->
         grammarSubscription.dispose()
         disposable.dispose()

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -557,6 +557,8 @@ class Workspace extends Model
       editor
 
   handleGrammarUsed: (grammar) ->
+    return unless grammar?
+
     @packageManager.triggerActivationHook("#{grammar.packageName}:grammar-used")
 
   # Public: Returns a {Boolean} that is `true` if `object` is a `TextEditor`.

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -570,8 +570,8 @@ class Workspace extends Model
   # Returns a {TextEditor}.
   buildTextEditor: (params) ->
     params = _.extend({
-      @config, @packageManager, @clipboard, @viewRegistry,
-      @grammarRegistry, @project, @assert, @applicationDelegate
+      @config, @clipboard, @viewRegistry, @grammarRegistry,
+      @project, @assert, @applicationDelegate
     }, params)
     new TextEditor(params)
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -550,7 +550,7 @@ class Workspace extends Model
     @project.bufferForPath(filePath, options).then (buffer) =>
       editor = @buildTextEditor(_.extend({buffer, largeFileMode}, options))
       disposable = atom.textEditors.add(editor)
-      grammarSubscription = editor.onDidChangeGrammar(@activateGrammar.bind(this))
+      grammarSubscription = editor.onDidUseGrammar(@activateGrammar.bind(this))
       editor.onDidDestroy ->
         grammarSubscription.dispose()
         disposable.dispose()

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -550,8 +550,14 @@ class Workspace extends Model
     @project.bufferForPath(filePath, options).then (buffer) =>
       editor = @buildTextEditor(_.extend({buffer, largeFileMode}, options))
       disposable = atom.textEditors.add(editor)
-      editor.onDidDestroy -> disposable.dispose()
+      grammarSubscription = editor.onDidUseGrammar(@handleDidUseGrammar.bind(this))
+      editor.onDidDestroy ->
+        grammarSubscription.dispose()
+        disposable.dispose()
       editor
+
+  handleDidUseGrammar: (grammar) ->
+    @packageManager.triggerActivationHook("#{grammar.packageName}:grammar-used")
 
   # Public: Returns a {Boolean} that is `true` if `object` is a `TextEditor`.
   #

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -550,13 +550,13 @@ class Workspace extends Model
     @project.bufferForPath(filePath, options).then (buffer) =>
       editor = @buildTextEditor(_.extend({buffer, largeFileMode}, options))
       disposable = atom.textEditors.add(editor)
-      grammarSubscription = editor.onDidUseGrammar(@handleDidUseGrammar.bind(this))
+      grammarSubscription = editor.onDidUseGrammar(@activateGrammar.bind(this))
       editor.onDidDestroy ->
         grammarSubscription.dispose()
         disposable.dispose()
       editor
 
-  handleDidUseGrammar: (grammar) ->
+  activateGrammar: (grammar) ->
     @packageManager.triggerActivationHook("#{grammar.packageName}:grammar-used")
 
   # Public: Returns a {Boolean} that is `true` if `object` is a `TextEditor`.

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -550,13 +550,13 @@ class Workspace extends Model
     @project.bufferForPath(filePath, options).then (buffer) =>
       editor = @buildTextEditor(_.extend({buffer, largeFileMode}, options))
       disposable = atom.textEditors.add(editor)
-      grammarSubscription = editor.onDidUseGrammar(@activateGrammar.bind(this))
+      grammarSubscription = editor.onDidUseGrammar(@handleGrammarUsed.bind(this))
       editor.onDidDestroy ->
         grammarSubscription.dispose()
         disposable.dispose()
       editor
 
-  activateGrammar: (grammar) ->
+  handleGrammarUsed: (grammar) ->
     @packageManager.triggerActivationHook("#{grammar.packageName}:grammar-used")
 
   # Public: Returns a {Boolean} that is `true` if `object` is a `TextEditor`.


### PR DESCRIPTION
This is step 2 as laid out by @nathansobo in https://github.com/atom/atom/issues/10979.

Remove `TextEditor`s dependency on `PackageManager`.
