### PR TITLE
Remove TextEditor's dependency on ApplicationDelegate

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -81,7 +81,6 @@ class TextEditor extends Model
     state.clipboard = atomEnvironment.clipboard
     state.grammarRegistry = atomEnvironment.grammars
     state.assert = atomEnvironment.assert.bind(atomEnvironment)
-    state.applicationDelegate = atomEnvironment.applicationDelegate
     editor = new this(state)
     if state.registered
       disposable = atomEnvironment.textEditors.add(editor)
@@ -95,7 +94,7 @@ class TextEditor extends Model
       @softTabs, @firstVisibleScreenRow, @firstVisibleScreenColumn, initialLine, initialColumn, tabLength,
       softWrapped, @displayBuffer, @selectionsMarkerLayer, buffer, suppressCursorCreation,
       @mini, @placeholderText, lineNumberGutterVisible, largeFileMode, @config, @clipboard, @grammarRegistry,
-      @assert, @applicationDelegate, grammar, showInvisibles, @autoHeight, @scrollPastEnd
+      @assert, grammar, showInvisibles, @autoHeight, @scrollPastEnd
     } = params
 
     throw new Error("Must pass a config parameter when constructing TextEditors") unless @config?
@@ -510,7 +509,7 @@ class TextEditor extends Model
       @buffer, displayBuffer, selectionsMarkerLayer, @tabLength, softTabs,
       suppressCursorCreation: true, @config,
       @firstVisibleScreenRow, @firstVisibleScreenColumn,
-      @clipboard, @grammarRegistry, @assert, @applicationDelegate
+      @clipboard, @grammarRegistry, @assert
     })
     newEditor
 

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -573,8 +573,7 @@ class Workspace extends Model
   # Returns a {TextEditor}.
   buildTextEditor: (params) ->
     params = _.extend({
-      @config, @clipboard, @grammarRegistry,
-      @assert, @applicationDelegate
+      @config, @clipboard, @grammarRegistry, @assert
     }, params)
     new TextEditor(params)
 


### PR DESCRIPTION
This is step 6 as laid out by @nathansobo in https://github.com/atom/atom/issues/10979.

Remove `TextEditor`s dependency on `ApplicationDelegate`.

(This one was super easy since previous work removed what we needed it for :metal:.)
