### PR TITLE
🏇 Improve perf for clicking on long buffer rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "async": "0.2.6",
     "atom-keymap": "6.3.2",
     "babel-core": "^5.8.21",
-    "binary-search-with-index": "^1.3.0",
     "bootstrap": "^3.3.4",
     "cached-run-in-this-context": "0.4.1",
     "clear-cut": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "async": "0.2.6",
     "atom-keymap": "6.3.2",
     "babel-core": "^5.8.21",
+    "binary-search-with-index": "^1.3.0",
     "bootstrap": "^3.3.4",
     "cached-run-in-this-context": "0.4.1",
     "clear-cut": "^2.0.1",


### PR DESCRIPTION
As discussed in https://github.com/atom/atom/pull/11539#issuecomment-213368868 by @as-cii, this PR reimplements the `screenPositionforPixelPosition` method in `lines-yardstick.coffee` to use two binary searches to find the position in order to minimize the number of `getBoundingClientRect` calls. The first stage performs a binary search on the text nodes of a row to find the node containing the pixelPosition. The second stage performs a binary search within the text node to find the character that contains the pixelPosition. This improves responsiveness when clicking near the end of a very long line of text.

~~This adds a dependency on [`binary-search-with-index`](https://www.npmjs.com/package/binary-search-with-index), which is my fork of [`binary-search`](https://www.npmjs.com/package/binary-search). This fork passes the index to the comparator which is needed in the `characterComparator`, and also relicenses the package to MIT. The original package was CC0-1.0 and waived all copyrights, so this should be okay.~~

**Update**: The original package accepted my PR, so the only thing preventing us from using it is that its `CC0-1.0` license doesn't pass the [`legal-eagle`](https://github.com/atom/legal-eagle) check. Might be a better idea to patch `legal-eagle` to accept `CC0-1.0` since it does accept public domain.

Resolves #10769
