### PR TITLE
File Open dialog defaults to directory of active editor or project root if no active editor

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -255,9 +255,9 @@ class AtomApplication
     ipcMain.on 'open-command', (event, command, args...) =>
       defaultPath = args[0] if args.length > 0
       switch command
-        when 'application:open' then @promptForPathToOpen('all', getLoadSettings())
+        when 'application:open' then @promptForPathToOpen('all', getLoadSettings(), defaultPath)
         when 'application:open-file' then @promptForPathToOpen('file', getLoadSettings(), defaultPath)
-        when 'application:open-folder' then @promptForPathToOpen('folder', getLoadSettings())
+        when 'application:open-folder' then @promptForPathToOpen('folder', getLoadSettings(), defaultPath)
         else console.log "Invalid open-command received: " + command
 
     ipcMain.on 'window-command', (event, command, args...) ->
@@ -688,7 +688,7 @@ class AtomApplication
         else 'Open'
 
     # File dialog defaults to project directory of currently active editor
-    if path? and type is 'file'
+    if path?
       openOptions.defaultPath = path
 
     dialog.showOpenDialog(parentWindow, openOptions, callback)

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -58,6 +58,7 @@ class AtomApplication
   resourcePath: null
   version: null
   quitting: false
+  lastFilePathOpened: null
 
   exit: (status) -> app.exit(status)
 
@@ -655,6 +656,7 @@ class AtomApplication
   #   :window - An {AtomWindow} to use for opening a selected file path.
   promptForPathToOpen: (type, {devMode, safeMode, window}) ->
     @promptForPath type, (pathsToOpen) =>
+      @lastFilePathOpened = pathsToOpen[0] if pathsToOpen.length > 0
       @openPaths({pathsToOpen, devMode, safeMode, window})
 
   promptForPath: (type, callback) ->
@@ -680,8 +682,8 @@ class AtomApplication
         when 'folder' then 'Open Folder'
         else 'Open'
 
-    if process.platform is 'linux'
-      if projectPath = @lastFocusedWindow?.projectPath
-        openOptions.defaultPath = projectPath
+    # If a file was previously opened, set default path to open there again.
+    if @lastFilePathOpened? and type is 'file'
+      openOptions.defaultPath = @lastFilePathOpened
 
     dialog.showOpenDialog(parentWindow, openOptions, callback)

--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -170,6 +170,8 @@ class AtomApplication
     @on 'application:quit', -> app.quit()
     @on 'application:new-window', -> @openPath(getLoadSettings())
     @on 'application:new-file', -> (@focusedWindow() ? this).openPath()
+    @on 'application:open-dev', -> @promptForPathToOpen('all', devMode: true)
+    @on 'application:open-safe', -> @promptForPathToOpen('all', safeMode: true)
     @on 'application:inspect', ({x, y, atomWindow}) ->
       atomWindow ?= @focusedWindow()
       atomWindow?.browserWindow.inspectElement(x, y)
@@ -251,12 +253,11 @@ class AtomApplication
       @emit(command)
 
     ipcMain.on 'open-command', (event, command, args...) =>
+      defaultPath = args[0] if args.length > 0
       switch command
         when 'application:open' then @promptForPathToOpen('all', getLoadSettings())
-        when 'application:open-file' then @promptForPathToOpen('file', getLoadSettings(), args[0])
+        when 'application:open-file' then @promptForPathToOpen('file', getLoadSettings(), defaultPath)
         when 'application:open-folder' then @promptForPathToOpen('folder', getLoadSettings())
-        when 'application:open-dev' then @promptForPathToOpen('all', devMode: true)
-        when 'application:open-safe' then @promptForPathToOpen('all', safeMode: true)
         else console.log "Invalid open-command received: " + command
 
     ipcMain.on 'window-command', (event, command, args...) ->

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -1,6 +1,7 @@
 {ipcRenderer} = require 'electron'
 
 module.exports = ({commandRegistry, commandInstaller, config, notificationManager}) ->
+
   commandRegistry.add 'atom-workspace',
     'pane:show-next-recently-used-item': -> @getModel().getActivePane().activateNextRecentlyUsedItem()
     'pane:show-previous-recently-used-item': -> @getModel().getActivePane().activatePreviousRecentlyUsedItem()
@@ -31,11 +32,15 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     'application:unhide-all-applications': -> ipcRenderer.send('command', 'application:unhide-all-applications')
     'application:new-window': -> ipcRenderer.send('command', 'application:new-window')
     'application:new-file': -> ipcRenderer.send('command', 'application:new-file')
-    'application:open': -> ipcRenderer.send('open-command', 'application:open')
-    'application:open-file': ->
+    'application:open': -> 
+      defaultPath = atom.workspace.getActiveTextEditor()?.getPath() ? atom.project.getPaths()?[0]
+      ipcRenderer.send('open-command', 'application:open', defaultPath)
+    'application:open-file': -> 
       defaultPath = atom.workspace.getActiveTextEditor()?.getPath() ? atom.project.getPaths()?[0]
       ipcRenderer.send('open-command', 'application:open-file', defaultPath)
-    'application:open-folder': -> ipcRenderer.send('open-command', 'application:open-folder')
+    'application:open-folder': -> 
+      defaultPath = atom.workspace.getActiveTextEditor()?.getPath() ? atom.project.getPaths()?[0]
+      ipcRenderer.send('open-command', 'application:open-folder', defaultPath)
     'application:open-dev': -> ipcRenderer.send('command', 'application:open-dev')
     'application:open-safe': -> ipcRenderer.send('command', 'application:open-safe')
     'application:add-project-folder': -> atom.addProjectFolder()

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -31,11 +31,13 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     'application:unhide-all-applications': -> ipcRenderer.send('command', 'application:unhide-all-applications')
     'application:new-window': -> ipcRenderer.send('command', 'application:new-window')
     'application:new-file': -> ipcRenderer.send('command', 'application:new-file')
-    'application:open': -> ipcRenderer.send('command', 'application:open')
-    'application:open-file': -> ipcRenderer.send('command', 'application:open-file')
-    'application:open-folder': -> ipcRenderer.send('command', 'application:open-folder')
-    'application:open-dev': -> ipcRenderer.send('command', 'application:open-dev')
-    'application:open-safe': -> ipcRenderer.send('command', 'application:open-safe')
+    'application:open': -> ipcRenderer.send('open-command', 'application:open')
+    'application:open-file': ->
+      defaultPath = atom.workspace.getActiveTextEditor()?.getPath() ? atom.project.getPaths()?[0]
+      ipcRenderer.send('open-command', 'application:open-file', defaultPath)
+    'application:open-folder': -> ipcRenderer.send('open-command', 'application:open-folder')
+    'application:open-dev': -> ipcRenderer.send('open-command', 'application:open-dev')
+    'application:open-safe': -> ipcRenderer.send('open-command', 'application:open-safe')
     'application:add-project-folder': -> atom.addProjectFolder()
     'application:minimize': -> ipcRenderer.send('command', 'application:minimize')
     'application:zoom': -> ipcRenderer.send('command', 'application:zoom')

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -36,8 +36,8 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
       defaultPath = atom.workspace.getActiveTextEditor()?.getPath() ? atom.project.getPaths()?[0]
       ipcRenderer.send('open-command', 'application:open-file', defaultPath)
     'application:open-folder': -> ipcRenderer.send('open-command', 'application:open-folder')
-    'application:open-dev': -> ipcRenderer.send('open-command', 'application:open-dev')
-    'application:open-safe': -> ipcRenderer.send('open-command', 'application:open-safe')
+    'application:open-dev': -> ipcRenderer.send('command', 'application:open-dev')
+    'application:open-safe': -> ipcRenderer.send('command', 'application:open-safe')
     'application:add-project-folder': -> atom.addProjectFolder()
     'application:minimize': -> ipcRenderer.send('command', 'application:minimize')
     'application:zoom': -> ipcRenderer.send('command', 'application:zoom')

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -1,7 +1,6 @@
 {ipcRenderer} = require 'electron'
 
 module.exports = ({commandRegistry, commandInstaller, config, notificationManager}) ->
-
   commandRegistry.add 'atom-workspace',
     'pane:show-next-recently-used-item': -> @getModel().getActivePane().activateNextRecentlyUsedItem()
     'pane:show-previous-recently-used-item': -> @getModel().getActivePane().activatePreviousRecentlyUsedItem()
@@ -32,13 +31,13 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     'application:unhide-all-applications': -> ipcRenderer.send('command', 'application:unhide-all-applications')
     'application:new-window': -> ipcRenderer.send('command', 'application:new-window')
     'application:new-file': -> ipcRenderer.send('command', 'application:new-file')
-    'application:open': -> 
+    'application:open': ->
       defaultPath = atom.workspace.getActiveTextEditor()?.getPath() ? atom.project.getPaths()?[0]
       ipcRenderer.send('open-command', 'application:open', defaultPath)
-    'application:open-file': -> 
+    'application:open-file': ->
       defaultPath = atom.workspace.getActiveTextEditor()?.getPath() ? atom.project.getPaths()?[0]
       ipcRenderer.send('open-command', 'application:open-file', defaultPath)
-    'application:open-folder': -> 
+    'application:open-folder': ->
       defaultPath = atom.workspace.getActiveTextEditor()?.getPath() ? atom.project.getPaths()?[0]
       ipcRenderer.send('open-command', 'application:open-folder', defaultPath)
     'application:open-dev': -> ipcRenderer.send('command', 'application:open-dev')


### PR DESCRIPTION
Based on #6762 and suggestion by @lalomartins:

> if this is a huge project, it might be worth it as a temporary fix to open the file chooser in the direction it was last. So, whenever you select a file using the chooser, store the location as state somewhere, then next time start in the same place, if available. It would already be a lot less annoying, I believe, and that's what browsers do with the “save as” dialogue.

Also note that the code this replaces (`openOptions.defaultPath = projectPath`) was completely non-functional. Apparently `AtomWindow.projectPath` was removed a while ago, possibly as a result of #770.
