### PR TITLE
Provide GitRepoAsync.openedPath

### DIFF
--- a/spec/git-repository-async-spec.js
+++ b/spec/git-repository-async-spec.js
@@ -55,6 +55,14 @@ describe('GitRepositoryAsync', () => {
     })
   })
 
+  describe('openedPath', () => {
+    it('is the path passed to .open', () => {
+      const workingDirPath = copyRepository()
+      repo = GitRepositoryAsync.open(workingDirPath)
+      expect(repo.openedPath).toBe(workingDirPath)
+    })
+  })
+
   describe('.getRepo()', () => {
     beforeEach(() => {
       const workingDirectory = copySubmoduleRepository()

--- a/src/git-repository-async.js
+++ b/src/git-repository-async.js
@@ -50,6 +50,10 @@ export default class GitRepositoryAsync {
     return this.repo._refreshingPromise
   }
 
+  get openedPath () {
+    return this.repo.openedPath
+  }
+
   // Public: Destroy this {GitRepositoryAsync} object.
   //
   // This destroys any tasks and subscriptions and releases the underlying


### PR DESCRIPTION
For backward compatibility with GitRepoAsync before moving to ohnogit.
