### PR TITLE
Revert ":arrow_up: apm@1.9.3"

### DIFF
--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "1.9.3"
+    "atom-package-manager": "1.9.2"
   }
 }


### PR DESCRIPTION
This reverts commit 3b204d404f4cb6216bedc0afa9c4035f8245e4a8.

It seems to be causing build failures on Travis and our internal CI.
