### PR TITLE
Update github-releases to 0.3.2

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -14,7 +14,7 @@
     "escope": "~3.3.0",
     "formidable": "~1.0.14",
     "fs-plus": "2.x",
-    "github-releases": "~0.3.1",
+    "github-releases": "~0.3.2",
     "glob": "^5.0.14",
     "grunt": "~0.4.1",
     "grunt-babel": "^5.0.1",


### PR DESCRIPTION
The update to 0.3.1 to 0.3.2 contains two changes:
- Fixes an issue where we were using an outdated version of `prettyjson` that wanted a Node version lower than or equal to 0.11.0, and so would print a warning during every `script/build`
- Fixes an issue where using a proxy would fail to download the Github release ~~(should fix #11525)~~
