### PR TITLE
:bug: Wait for connection end to get completed data;

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -138,7 +138,11 @@ class AtomApplication
     return unless @socketPath?
     @deleteSocketFile()
     server = net.createServer (connection) =>
-      connection.on 'data', (data) =>
+      data = ''
+      connection.on 'data', (chunk) ->
+        data = data + chunk
+
+      connection.on 'end', =>
         options = JSON.parse(data)
         @openWithOptions(options)
 


### PR DESCRIPTION
When env contains lots of data,eg: custom `LS_COLORS` or a very long long `PATH`, the connection will receive data multiple times in chunk, need to wait for its end to get completed data
