### PR TITLE
Try to cache *only* node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ script: script/cibuild
 cache:
   directories:
     - node_modules
-    - build/node_modules
-    - apm/node_modules
-    - $HOME/.atom/compile-cache
 
 notifications:
   email:


### PR DESCRIPTION
This pull-request is a test to try out the recently-enabled caching feature in Travis CI.
