### PR TITLE
Fixed open empty editor on start bug (issue #10623)

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -689,6 +689,7 @@ class AtomEnvironment extends Model
 
         @menu.update()
 
+        @reopenTabsOnStart()
         @openInitialEmptyEditorIfNecessary()
 
   serialize: (options) ->
@@ -709,9 +710,16 @@ class AtomEnvironment extends Model
     @saveBlobStoreSync()
     @unloaded = true
 
+  #closes all open tabs at startup if the menu option is false
+  #will prompt user to save any unsaved files that are being closed
+  reopenTabsOnStart: ->
+    return unless !@config.get('core.reopenTabsOnStart')
+    panesToRemove.destroyItems() for panesToRemove in @workspace.getPanes()
+
+  #opens a new empty editor on startup if there are no other files open at startup
   openInitialEmptyEditorIfNecessary: ->
     return unless @config.get('core.openEmptyEditorOnStart')
-    if @getLoadSettings().initialPaths?.length is 0 and @workspace.getPaneItems().length is 0
+    if @workspace.getPaneItems().length is 0
       @workspace.open(null)
 
   installUncaughtErrorHandler: ->

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -713,7 +713,7 @@ class AtomEnvironment extends Model
   #closes all open tabs at startup if the menu option is false
   #will prompt user to save any unsaved files that are being closed
   reopenTabsOnStart: ->
-    return unless !@config.get('core.reopenTabsOnStart')
+    return if @config.get('core.reopenTabsOnStart')
     panesToRemove.destroyItems() for panesToRemove in @workspace.getPanes()
 
   #opens a new empty editor on startup if there are no other files open at startup

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -101,7 +101,11 @@ module.exports =
           'windows866'
         ]
       openEmptyEditorOnStart:
-        description: 'Automatically open an empty editor on startup.'
+        description: 'Automatically open a new empty editor on startup, if there are no files open at startup.'
+        type: 'boolean'
+        default: true
+      reopenTabsOnStart:
+        description: 'Automatically reopen files that were open at the time of last closing.'
         type: 'boolean'
         default: true
       automaticallyUpdate:


### PR DESCRIPTION
There seems to be a lot of confusion about the function of the "Open Empty Editor On Start" option in the settings. From what I was able to tell the intent of the option was to open a new blank file for editing if when Atom starts if there are no files open. In my build of the current master branch this option has no effect. I have modified the function according to these assumptions. Because many people expected this option to open Atom with all previously open files closed. With this demand in mind I made a new menu option for this feature. It works by closing all files that were to be reopened upon launching Atom. When Atom is closed is stores even the unsaved buffers, so on launch with this option checked it will still ask the user if they would like to save the file. 
Here is a link to a screen capture to demonstrate the way the bug fix and new feature work: https://youtu.be/JCFOm3LdLoU
