### PR TITLE
Add Devtron to the Developer Tools window

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clear-cut": "^2.0.1",
     "coffee-script": "1.8.0",
     "color": "^0.7.3",
+    "devtron": "1.1.0",
     "event-kit": "^1.5.0",
     "find-parent-dir": "^0.3.0",
     "first-mate": "^5.1.1",

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -790,6 +790,7 @@ class AtomEnvironment extends Model
   # Returns a {Promise} that resolves when the DevTools have been opened or
   # closed.
   toggleDevTools: ->
+    require("devtron").install()
     @applicationDelegate.toggleWindowDevTools()
 
   # Extended: Execute code in dev tools.


### PR DESCRIPTION
I decided to be conservative here and:
1. Pin to a specific version of Devtron
2. Only load Devtron when the Developer Tools are first opened

[More information on Devtron.](http://electron.atom.io/devtron/)
