### PR TITLE
Fixed calling lineTextForBufferRow with unindented lines.

### DIFF
--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -420,7 +420,7 @@ class TokenizedBuffer extends Model
 
       indentLength / @getTabLength()
     else
-      0
+      indentLength = 0
 
   scopeDescriptorForPosition: (position) ->
     {row, column} = @buffer.clipPosition(Point.fromObject(position))


### PR DESCRIPTION
Fixes calling `lineTextForBufferRow()` with unindented rows. Should address #7765
