### PR TITLE
Don't render line-numbers corresponding to lines that need measuring

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "service-hub": "^0.7.0",
     "source-map-support": "^0.3.2",
     "temp": "0.8.1",
-    "text-buffer": "9.0.0",
+    "text-buffer": "9.1.0",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",
     "yargs": "^3.23.0"

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -2805,16 +2805,20 @@ describe "TextEditorPresenter", ->
               editor.setSoftWrapped(true)
               editor.setDefaultCharWidth(1)
               editor.setEditorWidthInChars(51)
-              presenter = buildPresenter(explicitHeight: 25, scrollTop: 30, lineHeight: 10, tileSize: 2)
+              presenter = buildPresenter(explicitHeight: 25, scrollTop: 30, lineHeight: 10, tileSize: 3)
+              presenter.setScreenRowsToMeasure([9, 11])
 
-              expect(lineNumberStateForScreenRow(presenter, 1)).toBeUndefined()
-              expectValues lineNumberStateForScreenRow(presenter, 2), {screenRow: 2, bufferRow: 2, softWrapped: false}
+              expect(lineNumberStateForScreenRow(presenter, 2)).toBeUndefined()
               expectValues lineNumberStateForScreenRow(presenter, 3), {screenRow: 3, bufferRow: 3, softWrapped: false}
               expectValues lineNumberStateForScreenRow(presenter, 4), {screenRow: 4, bufferRow: 3, softWrapped: true}
               expectValues lineNumberStateForScreenRow(presenter, 5), {screenRow: 5, bufferRow: 4, softWrapped: false}
               expectValues lineNumberStateForScreenRow(presenter, 6), {screenRow: 6, bufferRow: 7, softWrapped: false}
               expectValues lineNumberStateForScreenRow(presenter, 7), {screenRow: 7, bufferRow: 8, softWrapped: false}
-              expect(lineNumberStateForScreenRow(presenter, 8)).toBeUndefined()
+              expectValues lineNumberStateForScreenRow(presenter, 8), {screenRow: 8, bufferRow: 8, softWrapped: true}
+              expect(lineNumberStateForScreenRow(presenter, 9)).toBeUndefined()
+              expect(lineNumberStateForScreenRow(presenter, 10)).toBeUndefined()
+              expect(lineNumberStateForScreenRow(presenter, 11)).toBeUndefined()
+              expect(lineNumberStateForScreenRow(presenter, 12)).toBeUndefined()
 
             it "updates when the editor's content changes", ->
               editor.foldBufferRow(4)

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -491,7 +491,7 @@ class TextEditorComponent
     screenPosition = Point.fromObject(screenPosition)
     screenPosition = @editor.clipScreenPosition(screenPosition) if clip
 
-    unless @presenter.isRowVisible(screenPosition.row)
+    unless @presenter.isRowRendered(screenPosition.row)
       @presenter.setScreenRowsToMeasure([screenPosition.row])
 
     unless @linesComponent.lineNodeForScreenRow(screenPosition.row)?
@@ -503,7 +503,7 @@ class TextEditorComponent
 
   screenPositionForPixelPosition: (pixelPosition) ->
     row = @linesYardstick.measuredRowForPixelPosition(pixelPosition)
-    if row? and not @presenter.isRowVisible(row)
+    if row? and not @presenter.isRowRendered(row)
       @presenter.setScreenRowsToMeasure([row])
       @updateSyncPreMeasurement()
 
@@ -513,9 +513,9 @@ class TextEditorComponent
 
   pixelRectForScreenRange: (screenRange) ->
     rowsToMeasure = []
-    unless @presenter.isRowVisible(screenRange.start.row)
+    unless @presenter.isRowRendered(screenRange.start.row)
       rowsToMeasure.push(screenRange.start.row)
-    unless @presenter.isRowVisible(screenRange.end.row)
+    unless @presenter.isRowRendered(screenRange.end.row)
       rowsToMeasure.push(screenRange.end.row)
 
     if rowsToMeasure.length > 0

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -1550,8 +1550,8 @@ class TextEditorPresenter
   getVisibleRowRange: ->
     [@startRow, @endRow]
 
-  isRowVisible: (row) ->
-    @startRow <= row < @endRow
+  isRowRendered: (row) ->
+    @getStartTileRow() <= row < @constrainRow(@getEndTileRow() + @tileSize)
 
   isOpenTagCode: (tagCode) ->
     @displayLayer.isOpenTagCode(tagCode)


### PR DESCRIPTION
~~Depends on atom/text-buffer#156.~~
Fixes #11745.

Rendering line numbers corresponding to lines that need to be measured isn't useful, and it puts unneeded pressure to the DOM. In the process of changing `updateLineNumbersState`, we have also refactored it to stop relying on row ranges being contiguous. This allows that code path to be:
1. Less error-prone, because we were trying to access rows that weren't actually rendered, and thus throwing an exception when measuring non-contiguous screen rows.
2. Tighter, because we can just iterate over each screen row and ask for its soft-wrap descriptor.

/cc: @atom/core 
