### PR TITLE
Show folded marker in the first screen row of a soft-wrapped buffer row

### DIFF
--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -3069,15 +3069,28 @@ describe "TextEditorPresenter", ->
                   expect(lineNumberStateForScreenRow(presenter, 0).decorationClasses).toContain 'a'
                   expect(lineNumberStateForScreenRow(presenter, 1).decorationClasses).toContain 'a'
 
-              it "applies the 'folded' decoration only to the initial screen row of a soft-wrapped buffer row", ->
-                editor.setSoftWrapped(true)
-                editor.setDefaultCharWidth(1)
-                editor.setEditorWidthInChars(15)
-                editor.foldBufferRange([[0, 20], [0, 22]])
-                presenter = buildPresenter(explicitHeight: 35, scrollTop: 0, tileSize: 2)
+              describe "when a fold spans a single soft-wrapped buffer row", ->
+                it "applies the 'folded' decoration only to its initial screen row", ->
+                  editor.setSoftWrapped(true)
+                  editor.setDefaultCharWidth(1)
+                  editor.setEditorWidthInChars(20)
+                  editor.foldBufferRange([[0, 20], [0, 22]])
+                  editor.foldBufferRange([[0, 10], [0, 14]])
+                  presenter = buildPresenter(explicitHeight: 35, scrollTop: 0, tileSize: 2)
 
-                expect(lineNumberStateForScreenRow(presenter, 0).decorationClasses).toContain 'folded'
-                expect(lineNumberStateForScreenRow(presenter, 1).decorationClasses).toBeNull()
+                  expect(lineNumberStateForScreenRow(presenter, 0).decorationClasses).toContain('folded')
+                  expect(lineNumberStateForScreenRow(presenter, 1).decorationClasses).toBeNull()
+
+              describe "when a fold is at the end of a soft-wrapped buffer row", ->
+                it "applies the 'folded' decoration only to its initial screen row", ->
+                  editor.setSoftWrapped(true)
+                  editor.setDefaultCharWidth(1)
+                  editor.setEditorWidthInChars(25)
+                  editor.foldBufferRow(1)
+                  presenter = buildPresenter(explicitHeight: 35, scrollTop: 0, tileSize: 2)
+
+                  expect(lineNumberStateForScreenRow(presenter, 2).decorationClasses).toContain('folded')
+                  expect(lineNumberStateForScreenRow(presenter, 3).decorationClasses).toBeNull()
 
             describe ".foldable", ->
               it "marks line numbers at the start of a foldable region as foldable", ->

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -1153,13 +1153,11 @@ class TextEditorPresenter
 
     if rangeIsReversed
       headScreenPosition = screenRange.start
-      headBufferPosition = bufferRange.start
     else
       headScreenPosition = screenRange.end
-      headBufferPosition = bufferRange.end
 
     if properties.class is 'folded' and Decoration.isType(properties, 'line-number')
-      screenRow = @model.screenRowForBufferRow(headBufferPosition.row)
+      screenRow = @model.screenRowForBufferRow(bufferRange.start.row)
       @lineNumberDecorationsByScreenRow[screenRow] ?= {}
       @lineNumberDecorationsByScreenRow[screenRow][decorationId] = properties
     else


### PR DESCRIPTION
This fixes a problem (introduced in #11414) in the rendering of the gutter "folded" icon when a line is soft wrapped. In particular, such icon was being shown on the last screen row of the wrapped buffer row rather than on the first one. 

**Before:**
![before](https://cloud.githubusercontent.com/assets/482957/15285778/a6f1edc2-1b59-11e6-92ae-5e13e7ce0939.gif)

**After:**
![after](https://cloud.githubusercontent.com/assets/482957/15285788/b568977a-1b59-11e6-9e63-f7cf9d0f264d.gif)

/cc: @atom/core 
