### PR TITLE
fix spec toShow()

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -205,7 +205,8 @@ addCustomMatchers = (spec) ->
       element = @actual
       element = element.get(0) if element.jquery
       @message = -> return "Expected element '#{element}' or its descendants #{toOrNotTo} show."
-      element.style.display in ['block', 'inline-block', 'static', 'fixed']
+      computedStyle = getComputedStyle(element)
+      computedStyle.display isnt 'none' and computedStyle.visibility is 'visible' and not element.hidden
 
     toEqualPath: (expected) ->
       actualPath = path.normalize(@actual)


### PR DESCRIPTION
This patch fixes toShow for correct matching not hidden element.

Previos realization has some problems:

1) `element.style.display` is '' (empty string) if property setted via not inline style. We should use `getComputedStyle` for correct detecting css rules instead of style property.
2) Checked only `block` and `inline-block`. What's about `table`, `inline`, `flex`, etc? It's enough just check for not `none`
3) Ignored `style.visibility` and `hidden` property
