### PR TITLE
add includeMarkerText param to highlight decorations

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -2040,6 +2040,20 @@ describe('TextEditorComponent', function () {
       expect(regions.length).toBe(2)
     })
 
+    it('renders the marker text in the highlight', async function () {
+      decoration = editor.decorateMarker(marker, {
+        type: 'highlight',
+        'class': 'test-highlight-with-text',
+        includeMarkerText: true
+      })
+      await decorationsUpdatedPromise(editor)
+      await nextViewUpdatePromise()
+      let regions = componentNode.querySelectorAll('.test-highlight-with-text .region')
+      expect(regions.length).toBe(2)
+      expect(regions[0].textContent).toBe('.length <= 1) return items;')
+      expect(regions[1].textContent).toBe('    var pivot =')
+    })
+
     describe('when flashing a decoration via Decoration::flash()', function () {
       let highlightNode
 

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -1843,6 +1843,10 @@ describe "TextEditorPresenter", ->
           marker9 = editor.markBufferRange([[0, 0], [2, 0]], invalidate: 'touch')
           highlight9 = editor.decorateMarker(marker9, type: 'highlight', class: 'h')
 
+          # partially off-screen above, 2 of 3 regions on screen, include marker text
+          marker10 = editor.markBufferRange([[0, 6], [3, 6]])
+          highlight10 = editor.decorateMarker(marker10, type: 'highlight', class: 'c', includeMarkerText: true)
+
           presenter = buildPresenter(explicitHeight: 30, scrollTop: 20, tileSize: 2)
 
           expectUndefinedStateForHighlight(presenter, highlight1)
@@ -1905,6 +1909,14 @@ describe "TextEditorPresenter", ->
           expectUndefinedStateForHighlight(presenter, highlight7)
           expectUndefinedStateForHighlight(presenter, highlight8)
           expectUndefinedStateForHighlight(presenter, highlight9)
+
+          expectValues stateForHighlightInTile(presenter, highlight10, 2), {
+            class: 'c'
+            regions: [
+              {top: 0, left: 0 * 10, right: 0, height: 1 * 10, text: '    if (items.length <= 1) return items;'}
+              {top: 10, left: 0 * 10, width: 6 * 10, height: 1 * 10, text: '    va'}
+            ]
+          }
 
         it "is empty until all of the required measurements are assigned", ->
           editor.setSelectedBufferRanges([

--- a/src/highlights-component.coffee
+++ b/src/highlights-component.coffee
@@ -93,7 +93,8 @@ class HighlightsComponent
           else
             regionNode.style[property] = ''
 
-      regionNode.textContent = newRegionState.text if newHighlightState.includeText
+      if newHighlightState.includeMarkerText
+        regionNode.textContent = newRegionState.text 
 
     return
 

--- a/src/highlights-component.coffee
+++ b/src/highlights-component.coffee
@@ -93,6 +93,8 @@ class HighlightsComponent
           else
             regionNode.style[property] = ''
 
+      regionNode.textContent = newRegionState.text if newHighlightState.includeText
+
     return
 
   flashHighlightNodeIfRequested: (id, newHighlightState) ->

--- a/src/highlights-component.coffee
+++ b/src/highlights-component.coffee
@@ -93,8 +93,7 @@ class HighlightsComponent
           else
             regionNode.style[property] = ''
 
-      if newHighlightState.includeMarkerText
-        regionNode.textContent = newRegionState.text 
+      regionNode.textContent = newRegionState.text if newRegionState.text?
 
     return
 

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -1190,7 +1190,7 @@ class TextEditorPresenter
       highlightState.flashClass = properties.flashClass
       highlightState.flashDuration = properties.flashDuration
       highlightState.class = properties.class
-      highlightState.includeText = properties.includeText
+      highlightState.includeMarkerText = properties.includeMarkerText
       highlightState.deprecatedRegionClass = properties.deprecatedRegionClass
       highlightState.regions = @buildHighlightRegions(rangeWithinTile)
 

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -1190,6 +1190,7 @@ class TextEditorPresenter
       highlightState.flashClass = properties.flashClass
       highlightState.flashDuration = properties.flashDuration
       highlightState.class = properties.class
+      highlightState.includeText = properties.includeText
       highlightState.deprecatedRegionClass = properties.deprecatedRegionClass
       highlightState.regions = @buildHighlightRegions(rangeWithinTile)
 
@@ -1235,6 +1236,7 @@ class TextEditorPresenter
         top: startPixelPosition.top
         height: lineHeightInPixels
         left: startPixelPosition.left
+        text: @model.getTextInRange(@displayLayer.translateScreenRange(screenRange))
 
       if screenRange.end.column is Infinity
         region.right = 0
@@ -1249,6 +1251,7 @@ class TextEditorPresenter
         left: startPixelPosition.left
         height: lineHeightInPixels
         right: 0
+        text: @model.getTextInRange(@displayLayer.translateScreenRange(screenRange))
       )
 
       # Middle rows, extending from left side to right side of screen
@@ -1258,6 +1261,7 @@ class TextEditorPresenter
           height: endPixelPosition.top - startPixelPosition.top - lineHeightInPixels
           left: 0
           right: 0
+          text: @model.getTextInRange(@displayLayer.translateScreenRange(screenRange))
         )
 
       # Last row, extending from left side of screen to selection end
@@ -1266,6 +1270,7 @@ class TextEditorPresenter
           top: endPixelPosition.top
           height: lineHeightInPixels
           left: 0
+          text: @model.getTextInRange(@displayLayer.translateScreenRange(screenRange))
 
         if screenRange.end.column is Infinity
           region.right = 0


### PR DESCRIPTION
When passed in the decoration properties, this flag will render the text of the marker into the highlight's regions. This allow a highlight decoration to have a background color and a contrasting enough color for the text on top of it.

Actually, when using highlight decorations, we can't really use them if we have a background color that may conflict with the foreground color: 

![styles_less_ __users_cedric_development_ruby_leclerc-es-v2](https://cloud.githubusercontent.com/assets/247140/15386192/abdbf8d8-1da6-11e6-8509-2bd86cf380cb.png)

It means than these decorations, while essential in any good text editor, can be only used to outline/underline a marker.

Now, with the `includeMarkerText` flag enabled the following is now possible: 

![json_form_js_coffee_ __users_cedric_development_ruby_leclerc-es-v2](https://cloud.githubusercontent.com/assets/247140/15386270/29eab5a2-1da7-11e6-9b90-09b443d956f5.png)

It's far from an ideal solution, but given than since this problem was first reported (almost two years ago), we still don't have a proper solution for that issue. This one is at least simple, don't cost much performance-wise and can be reverted/changed quite easily as well.
