### PR TITLE
replace OSX window title bar with custom title-bar

### DIFF
--- a/spec/title-bar-element-spec.coffee
+++ b/spec/title-bar-element-spec.coffee
@@ -15,5 +15,4 @@ describe "TitleBarElement", ->
     document.title = 'new-title'
     element.updateTitle()
 
-    console.log element.querySelector('.title').textContent
     expect(element.querySelector('.title').textContent).toBe 'new-title'

--- a/spec/title-bar-element-spec.coffee
+++ b/spec/title-bar-element-spec.coffee
@@ -1,0 +1,19 @@
+TitleBar = require '../src/title-bar'
+TitleBarElement = require '../src/title-bar-element'
+
+describe "TitleBarElement", ->
+  beforeEach ->
+    atom.views.addViewProvider TitleBar, (model, env) ->
+      new TitleBarElement().initialize(model, env)
+
+  it 'updates the title based on document.title', ->
+    titleBar = new TitleBar({item: new TitleBarElement})
+    element = atom.views.getView(titleBar)
+
+    expect(element.querySelector('.title').textContent).toBe document.title
+
+    document.title = 'new-title'
+    element.updateTitle()
+
+    console.log element.querySelector('.title').textContent
+    expect(element.querySelector('.title').textContent).toBe 'new-title'

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -684,7 +684,7 @@ class AtomEnvironment extends Model
         @deserialize(state) if state?
         @deserializeTimings.atom = Date.now() - startTime
 
-        @document.body.appendChild(@views.getView(@titleBar)) if @titleBar
+        @workspace.addHeaderPanel({item: @views.getView(@titleBar)}) if @titleBar
         @document.body.appendChild(@views.getView(@workspace))
         @backgroundStylesheet?.remove()
 

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -196,13 +196,15 @@ class AtomEnvironment extends Model
       notificationManager: @notifications, @applicationDelegate, @clipboard, viewRegistry: @views, assert: @assert.bind(this)
     })
 
-    @titleBar = new TitleBar() if process.platform is 'darwin'
     @themes.workspace = @workspace
 
     @textEditors = new TextEditorRegistry
     @autoUpdater = new AutoUpdateManager({@applicationDelegate})
 
     @config.load()
+
+    # This needs to happen after config.load()
+    @titleBar = new TitleBar() if process.platform is 'darwin' and @config.get('core.useCustomTitleBar')
 
     @themes.loadBaseStylesheets()
     @initialStyleElements = @styles.getSnapshot()

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -31,6 +31,7 @@ ContextMenuManager = require './context-menu-manager'
 CommandInstaller = require './command-installer'
 Clipboard = require './clipboard'
 Project = require './project'
+TitleBar = require './title-bar'
 Workspace = require './workspace'
 PanelContainer = require './panel-container'
 Panel = require './panel'
@@ -44,6 +45,7 @@ Gutter = require './gutter'
 TextEditorRegistry = require './text-editor-registry'
 AutoUpdateManager = require './auto-update-manager'
 
+TitleBarElement = require './title-bar-element'
 WorkspaceElement = require './workspace-element'
 PanelContainerElement = require './panel-container-element'
 PanelElement = require './panel-element'
@@ -193,6 +195,8 @@ class AtomEnvironment extends Model
       @config, @project, packageManager: @packages, grammarRegistry: @grammars, deserializerManager: @deserializers,
       notificationManager: @notifications, @applicationDelegate, @clipboard, viewRegistry: @views, assert: @assert.bind(this)
     })
+
+    @titleBar = new TitleBar() if process.platform is 'darwin'
     @themes.workspace = @workspace
 
     @textEditors = new TextEditorRegistry
@@ -259,6 +263,8 @@ class AtomEnvironment extends Model
     registerDefaultCommands({commandRegistry: @commands, @config, @commandInstaller, notificationManager: @notifications, @project, @clipboard})
 
   registerDefaultViewProviders: ->
+    @views.addViewProvider TitleBar, (model, env) ->
+      new TitleBarElement().initialize(model, env)
     @views.addViewProvider Workspace, (model, env) ->
       new WorkspaceElement().initialize(model, env)
     @views.addViewProvider PanelContainer, (model, env) ->
@@ -678,6 +684,7 @@ class AtomEnvironment extends Model
         @deserialize(state) if state?
         @deserializeTimings.atom = Date.now() - startTime
 
+        @document.body.appendChild(@views.getView(@titleBar)) if @titleBar
         @document.body.appendChild(@views.getView(@workspace))
         @backgroundStylesheet?.remove()
 

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -557,10 +557,6 @@ class AtomEnvironment extends Model
   # Extended: Set the full screen state of the current window.
   setFullScreen: (fullScreen=false) ->
     @applicationDelegate.setWindowFullScreen(fullScreen)
-    if fullScreen
-      @document.body.classList.add("fullscreen")
-    else
-      @document.body.classList.remove("fullscreen")
 
   # Extended: Toggle the full screen state of the current window.
   toggleFullScreen: ->

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -271,4 +271,4 @@ if process.platform is 'darwin'
   module.exports.core.properties.useCustomTitleBar =
     type: 'boolean'
     default: false
-    description: 'Use custom, theme-aware title-bar.<br />Note: This currently does not include a file icon or title context menu.<br />This setting will require a relaunch of Atom to take effect.'
+    description: 'Use custom, theme-aware title-bar.<br />Note: Note: This currently does not include a proxy icon.<br />This setting will require a relaunch of Atom to take effect.'

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -266,3 +266,9 @@ if process.platform in ['win32', 'linux']
     type: 'boolean'
     default: false
     description: 'Automatically hide the menu bar and toggle it by pressing Alt. This is only supported on Windows & Linux.'
+
+if process.platform is 'darwin'
+  module.exports.core.properties.useCustomTitleBar =
+    type: 'boolean'
+    default: false
+    description: 'Use custom, theme-aware title-bar.<br />Note: This currently does not include a file icon or title context menu.<br />This setting will require a relaunch of Atom to take effect.'

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -76,6 +76,8 @@ class AtomApplication
     @config.setSchema null, {type: 'object', properties: _.clone(require('../config-schema'))}
     @config.load()
 
+    @config.onDidChange 'core.useCustomTitleBar', @promptForRelaunch
+
     @autoUpdateManager = new AutoUpdateManager(@version, options.test, @resourcePath, @config)
     @applicationMenu = new ApplicationMenu(@version, @autoUpdateManager)
     @atomProtocolHandler = new AtomProtocolHandler(@resourcePath, @safeMode)
@@ -86,6 +88,7 @@ class AtomApplication
     @handleEvents()
     @setupDockMenu()
     @storageFolder = new StorageFolder(process.env.ATOM_HOME)
+
 
     if options.pathsToOpen?.length > 0 or options.urlsToOpen?.length > 0 or options.test
       @openWithOptions(options)
@@ -706,3 +709,16 @@ class AtomApplication
       openOptions.defaultPath = path
 
     dialog.showOpenDialog(parentWindow, openOptions, callback)
+
+  promptForRelaunch: ->
+    chosen = dialog.showMessageBox BrowserWindow.getFocusedWindow(),
+      type: 'warning'
+      title: 'Relaunch required'
+      message: "To apply this setting, you'll need to relaunch Atom."
+      detail: ''
+      buttons: ['Relaunch Atom', 'Cancel']
+    if chosen is 0
+      # once we're using electron v.1.2.2
+      # app.relaunch()
+      app.quit()
+

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -714,9 +714,8 @@ class AtomApplication
     chosen = dialog.showMessageBox BrowserWindow.getFocusedWindow(),
       type: 'warning'
       title: 'Relaunch required'
-      message: "To apply this setting, you'll need to relaunch Atom."
-      detail: ''
-      buttons: ['Relaunch Atom', 'Cancel']
+      message: "You will need to relaunch Atom for this change to take effect."
+      buttons: ['Quit Atom', 'Cancel']
     if chosen is 0
       # once we're using electron v.1.2.2
       # app.relaunch()

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -40,13 +40,13 @@ class AtomWindow
     if process.platform is 'linux'
       options.icon = @constructor.iconPath
 
-    if process.platform is 'darwin' and global.atomApplication.config.get('core.useCustomTitleBar')
+    if @applyTitleBarSetting()
       options.titleBarStyle = 'hidden'
 
     @browserWindow = new BrowserWindow options
     global.atomApplication.addWindow(this)
 
-    if process.platform is 'darwin' and global.atomApplication.config.get('core.useCustomTitleBar')
+    if @applyTitleBarSetting()
       @browserWindow.setSheetOffset(23)
 
     @handleEvents()
@@ -204,6 +204,11 @@ class AtomWindow
     [x, y] = @browserWindow.getPosition()
     [width, height] = @browserWindow.getSize()
     {x, y, width, height}
+
+  applyTitleBarSetting: ->
+    not @isSpec and
+    process.platform is 'darwin' and
+    global.atomApplication.config.get('core.useCustomTitleBar')
 
   close: -> @browserWindow.close()
 

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -23,7 +23,6 @@ class AtomWindow
     options =
       show: false
       title: 'Atom'
-      titleBarStyle: 'hidden'
       # Add an opaque backgroundColor (instead of keeping the default
       # transparent one) to prevent subpixel anti-aliasing from being disabled.
       # We believe this is a regression introduced with Electron 0.37.3, and
@@ -40,6 +39,9 @@ class AtomWindow
     # taskbar's icon. See https://github.com/atom/atom/issues/4811 for more.
     if process.platform is 'linux'
       options.icon = @constructor.iconPath
+
+    if process.platform is 'darwin'
+      options.titleBarStyle = 'hidden'
 
     @browserWindow = new BrowserWindow options
     global.atomApplication.addWindow(this)

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -40,7 +40,7 @@ class AtomWindow
     if process.platform is 'linux'
       options.icon = @constructor.iconPath
 
-    if process.platform is 'darwin'
+    if process.platform is 'darwin' and global.atomApplication.config.get('core.useCustomTitleBar')
       options.titleBarStyle = 'hidden'
 
     @browserWindow = new BrowserWindow options

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -46,6 +46,9 @@ class AtomWindow
     @browserWindow = new BrowserWindow options
     global.atomApplication.addWindow(this)
 
+    if process.platform is 'darwin' and global.atomApplication.config.get('core.useCustomTitleBar')
+      @browserWindow.setSheetOffset(23)
+
     @handleEvents()
 
     loadSettings = Object.assign({}, settings)

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -46,9 +46,6 @@ class AtomWindow
     @browserWindow = new BrowserWindow options
     global.atomApplication.addWindow(this)
 
-    if @applyTitleBarSetting()
-      @browserWindow.setSheetOffset(23)
-
     @handleEvents()
 
     loadSettings = Object.assign({}, settings)

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -23,6 +23,7 @@ class AtomWindow
     options =
       show: false
       title: 'Atom'
+      titleBarStyle: 'hidden'
       # Add an opaque backgroundColor (instead of keeping the default
       # transparent one) to prevent subpixel anti-aliasing from being disabled.
       # We believe this is a regression introduced with Electron 0.37.3, and

--- a/src/title-bar-element.coffee
+++ b/src/title-bar-element.coffee
@@ -1,0 +1,30 @@
+
+module.exports =
+class TitleBarElement extends HTMLElement
+  initialize: (@model, {@views, @workspace, @project, @config, @styles}) ->
+
+    @classList.add('title-bar')
+
+    @titleElement = document.createElement('div')
+    @titleElement.classList.add('title')
+    @titleElement.textContent = document.title
+    @appendChild @titleElement
+
+    @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem (activeItem) =>
+      @subscribeToActiveTextEditor()
+
+    return this
+
+  subscribeToActiveTextEditor: ->
+    @cursorSubscription?.dispose()
+    @cursorSubscription = @getActiveTextEditor()?.onDidChangeTitle =>
+      @updateTitle()
+    @updateTitle()
+
+  updateTitle: ->
+    @titleElement.textContent = document.title
+
+  getActiveTextEditor: ->
+    atom.workspace.getActiveTextEditor()
+
+module.exports = TitleBarElement = document.registerElement 'atom-title-bar', prototype: TitleBarElement.prototype

--- a/src/title-bar-element.coffee
+++ b/src/title-bar-element.coffee
@@ -1,7 +1,7 @@
 
 module.exports =
 class TitleBarElement extends HTMLElement
-  initialize: (@model, {@views, @workspace, @project, @config, @styles}) ->
+  initialize: (@model, {@workspace, @themes, @applicationDelegate}) ->
 
     @classList.add('title-bar')
 
@@ -11,12 +11,15 @@ class TitleBarElement extends HTMLElement
     @appendChild @titleElement
 
     @workspace.onDidChangeActivePaneItem => @updateTitle()
+    @themes.onDidChangeActiveThemes => @setSheetOffset()
 
     @updateTitle()
-
     return this
 
-  updateTitle: =>
+  setSheetOffset: ->
+    @applicationDelegate.getCurrentWindow().setSheetOffset(@offsetHeight)
+
+  updateTitle: ->
     @titleElement.textContent = document.title
 
 module.exports = TitleBarElement = document.registerElement 'atom-title-bar', prototype: TitleBarElement.prototype

--- a/src/title-bar-element.coffee
+++ b/src/title-bar-element.coffee
@@ -10,21 +10,13 @@ class TitleBarElement extends HTMLElement
     @titleElement.textContent = document.title
     @appendChild @titleElement
 
-    @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem (activeItem) =>
-      @subscribeToActiveTextEditor()
+    @workspace.onDidChangeActivePaneItem => @updateTitle()
+
+    @updateTitle()
 
     return this
 
-  subscribeToActiveTextEditor: ->
-    @cursorSubscription?.dispose()
-    @cursorSubscription = @getActiveTextEditor()?.onDidChangeTitle =>
-      @updateTitle()
-    @updateTitle()
-
-  updateTitle: ->
+  updateTitle: =>
     @titleElement.textContent = document.title
-
-  getActiveTextEditor: ->
-    atom.workspace.getActiveTextEditor()
 
 module.exports = TitleBarElement = document.registerElement 'atom-title-bar', prototype: TitleBarElement.prototype

--- a/src/title-bar.coffee
+++ b/src/title-bar.coffee
@@ -1,0 +1,6 @@
+Model = require './model'
+
+module.exports =
+class TitleBar extends Model
+  constructor: (params) ->
+    super

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -23,6 +23,10 @@ class WindowEventHandler
     @subscriptions.add listen(@document, 'click', 'a', @handleLinkClick)
     @subscriptions.add listen(@document, 'submit', 'form', @handleFormSubmit)
 
+    browserWindow = @applicationDelegate.getCurrentWindow()
+    browserWindow.on 'enter-full-screen', @handleEnterFullScreen
+    browserWindow.on 'leave-full-screen', @handleLeaveFullScreen
+
     @subscriptions.add @atomEnvironment.commands.add @window,
       'window:toggle-full-screen': @handleWindowToggleFullScreen
       'window:close': @handleWindowClose
@@ -135,6 +139,12 @@ class WindowEventHandler
   handleWindowBlur: =>
     @document.body.classList.add('is-blurred')
     @atomEnvironment.storeWindowDimensions()
+
+  handleEnterFullScreen: =>
+    @document.body.classList.add("fullscreen")
+
+  handleLeaveFullScreen: =>
+    @document.body.classList.remove("fullscreen")
 
   handleWindowBeforeunload: =>
     confirmed = @atomEnvironment.workspace?.confirmClose(windowCloseRequested: true)

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -24,8 +24,8 @@ class WindowEventHandler
     @subscriptions.add listen(@document, 'submit', 'form', @handleFormSubmit)
 
     browserWindow = @applicationDelegate.getCurrentWindow()
-    browserWindow.on 'enter-full-screen', @handleEnterFullScreen
-    browserWindow.on 'leave-full-screen', @handleLeaveFullScreen
+    browserWindow.on? 'enter-full-screen', @handleEnterFullScreen
+    browserWindow.on? 'leave-full-screen', @handleLeaveFullScreen
 
     @subscriptions.add @atomEnvironment.commands.add @window,
       'window:toggle-full-screen': @handleWindowToggleFullScreen

--- a/static/atom.less
+++ b/static/atom.less
@@ -17,11 +17,6 @@
 
 // Core components
 @import "cursors";
-@import "bootstrap-overrides";
-@import "badges";
-@import "buttons";
-@import "icons";
-@import "links";
 @import "panels";
 @import "panes";
 @import "syntax";

--- a/static/atom.less
+++ b/static/atom.less
@@ -17,10 +17,16 @@
 
 // Core components
 @import "cursors";
+@import "bootstrap-overrides";
+@import "badges";
+@import "buttons";
+@import "icons";
+@import "links";
 @import "panels";
 @import "panes";
 @import "syntax";
 @import "text-editor-light";
+@import "title-bar";
 @import "workspace-view";
 
 // Atom UI library

--- a/static/title-bar.less
+++ b/static/title-bar.less
@@ -23,7 +23,6 @@
     text-overflow: ellipsis;
   }
 
-
   background-image: linear-gradient(@title-bar-gradient-focused);
   border-bottom: 1px solid @title-bar-border-color-focused;
 
@@ -31,24 +30,5 @@
     color: @title-bar-text-blurred;
     background-image: linear-gradient(@title-bar-gradient-blurred);
     border-bottom-color: @title-bar-border-color-blurred;
-  }
-
-  [title-bar-style="combined"] & {
-    display: none;
-    position: absolute;
-  }
-}
-
-[title-bar-style="combined"] .tab-bar {
-  height: 37px;
-  padding-left: 80px;
-  background-image: linear-gradient(@title-bar-gradient-focused);
-
-  .tab {
-    top: 7px;
-    border-radius: 3px 3px 0 0 !important;
-    &:after {
-      border-radius: 3px 3px 0 0 !important;
-  }
   }
 }

--- a/static/title-bar.less
+++ b/static/title-bar.less
@@ -23,6 +23,7 @@
     text-overflow: ellipsis;
   }
 
+  box-shadow: 0 1px 0 @title-bar-highlight inset;
   background-image: linear-gradient(@title-bar-gradient-focused);
   border-bottom: 1px solid @title-bar-border-color-focused;
 

--- a/static/title-bar.less
+++ b/static/title-bar.less
@@ -1,4 +1,8 @@
-@import "./variables/ui-variables";
+@import "ui-variables";
+
+@title-bar-text-size: 13px;
+@title-bar-background-color: @base-background-color;
+@title-bar-border-color: @base-border-color;
 
 .title-bar {
   height: 23px;
@@ -8,12 +12,11 @@
   align-items: center;
   justify-content: center;
 
-  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue";
   font-size: @title-bar-text-size;
-  color: @title-bar-text-focused;
   -webkit-user-select: none;
+  -webkit-app-region: drag;
 
-  padding: 0 10px 0 70px;
+  padding: 0 70px;
   overflow: hidden;
 
   .title {
@@ -23,13 +26,10 @@
     text-overflow: ellipsis;
   }
 
-  box-shadow: 0 1px 0 @title-bar-highlight inset;
-  background-image: linear-gradient(@title-bar-gradient-focused);
-  border-bottom: 1px solid @title-bar-border-color-focused;
+  background-color: @title-bar-background-color;
+  border-bottom: 1px solid @title-bar-border-color;
 
   .is-blurred & {
-    color: @title-bar-text-blurred;
-    background-image: linear-gradient(@title-bar-gradient-blurred);
-    border-bottom-color: @title-bar-border-color-blurred;
+    color: @text-color-subtle;
   }
 }

--- a/static/title-bar.less
+++ b/static/title-bar.less
@@ -1,15 +1,17 @@
 @import "ui-variables";
 
 @title-bar-text-size: 13px;
+@title-bar-height: 23px;
 @title-bar-background-color: @base-background-color;
 @title-bar-border-color: @base-border-color;
 
 body.fullscreen .title-bar {
-  display: none;
+  margin-top: -@title-bar-height;
 }
 
 .title-bar {
-  height: 23px;
+  height: @title-bar-height;
+  transition: margin-top 200ms ease-out 700ms;
 
   flex-shrink: 0;
   display: flex;

--- a/static/title-bar.less
+++ b/static/title-bar.less
@@ -4,6 +4,10 @@
 @title-bar-background-color: @base-background-color;
 @title-bar-border-color: @base-border-color;
 
+body.fullscreen .title-bar {
+  display: none;
+}
+
 .title-bar {
   height: 23px;
 

--- a/static/title-bar.less
+++ b/static/title-bar.less
@@ -11,7 +11,7 @@ body.fullscreen .title-bar {
 
 .title-bar {
   height: @title-bar-height;
-  transition: margin-top 200ms ease-out 700ms;
+  transition: margin-top 160ms;
 
   flex-shrink: 0;
   display: flex;

--- a/static/title-bar.less
+++ b/static/title-bar.less
@@ -1,0 +1,54 @@
+@import "./variables/ui-variables";
+
+.title-bar {
+  height: 23px;
+
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue";
+  font-size: @title-bar-text-size;
+  color: @title-bar-text-focused;
+  -webkit-user-select: none;
+
+  padding: 0 10px 0 70px;
+  overflow: hidden;
+
+  .title {
+    flex: 0 1 auto;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+
+  background-image: linear-gradient(@title-bar-gradient-focused);
+  border-bottom: 1px solid @title-bar-border-color-focused;
+
+  .is-blurred & {
+    color: @title-bar-text-blurred;
+    background-image: linear-gradient(@title-bar-gradient-blurred);
+    border-bottom-color: @title-bar-border-color-blurred;
+  }
+
+  [title-bar-style="combined"] & {
+    display: none;
+    position: absolute;
+  }
+}
+
+[title-bar-style="combined"] .tab-bar {
+  height: 37px;
+  padding-left: 80px;
+  background-image: linear-gradient(@title-bar-gradient-focused);
+
+  .tab {
+    top: 7px;
+    border-radius: 3px 3px 0 0 !important;
+    &:after {
+      border-radius: 3px 3px 0 0 !important;
+  }
+  }
+}

--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -82,14 +82,15 @@
 // TitleBar
 
 @title-bar-text-size: 13px;
+@title-bar-highlight: lighten(@base-background-color, 10%);
 
-@title-bar-gradient-focused: #ededed 0, #ededed 1px, #e7e7e7 2px, #d1d1d1 100%;
-@title-bar-text-focused: #4d4d4d;
-@title-bar-border-color-focused: #afafaf;
+@title-bar-gradient-focused: lighten(@base-background-color, 5%), @base-background-color;
+@title-bar-text-focused: @text-color;
+@title-bar-border-color-focused: @base-border-color;
 
-@title-bar-gradient-blurred: #fafafa 0px, #f6f6f6 2px, #f6f6f6 100%;
-@title-bar-text-blurred: #d3d3d3;
-@title-bar-border-color-blurred: #d1d1d1;
+@title-bar-gradient-blurred: @title-bar-gradient-focused;
+@title-bar-text-blurred: @title-bar-text-focused;
+@title-bar-border-color-blurred: @base-border-color;
 
 
 // Other

--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -79,6 +79,18 @@
 
 @tab-height: 30px;
 
+// TitleBar
+
+@title-bar-text-size: 13px;
+
+@title-bar-gradient-focused: #ededed 0, #ededed 1px, #e7e7e7 2px, #d1d1d1 100%;
+@title-bar-text-focused: #4d4d4d;
+@title-bar-border-color-focused: #afafaf;
+
+@title-bar-gradient-blurred: #fafafa 0px, #f6f6f6 2px, #f6f6f6 100%;
+@title-bar-text-blurred: #d3d3d3;
+@title-bar-border-color-blurred: #d1d1d1;
+
 
 // Other
 

--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -79,20 +79,6 @@
 
 @tab-height: 30px;
 
-// TitleBar
-
-@title-bar-text-size: 13px;
-@title-bar-highlight: lighten(@base-background-color, 10%);
-
-@title-bar-gradient-focused: lighten(@base-background-color, 5%), @base-background-color;
-@title-bar-text-focused: @text-color;
-@title-bar-border-color-focused: @base-border-color;
-
-@title-bar-gradient-blurred: @title-bar-gradient-focused;
-@title-bar-text-blurred: @title-bar-text-focused;
-@title-bar-border-color-blurred: @base-border-color;
-
-
 // Other
 
 @font-family: 'BlinkMacSystemFont', 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;

--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -1,9 +1,26 @@
 @import "ui-variables";
+@import "octicon-mixins";
+
+@font-face { .octicon-font(); }
+
+html {
+  font-family: @font-family;
+  font-size: @font-size;
+}
+
+html,
+body {
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
 
 atom-workspace {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  flex-grow: 1;
   overflow: hidden;
   position: relative;
   color: @text-color;

--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -10,17 +10,15 @@ html {
 
 html,
 body {
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
-  display: flex;
-  flex-direction: column;
 }
 
 atom-workspace {
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
+  height: 100%;
   overflow: hidden;
   position: relative;
   color: @text-color;

--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -1,19 +1,4 @@
 @import "ui-variables";
-@import "octicon-mixins";
-
-@font-face { .octicon-font(); }
-
-html {
-  font-family: @font-family;
-  font-size: @font-size;
-}
-
-html,
-body {
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-}
 
 atom-workspace {
   display: flex;


### PR DESCRIPTION
This pull request is intended to naively implement a custom titlebar on OSX.

I've included fallback styling to match El Capitan's titlebars, which is probably not necessary as I modified the four included themes to provide their own titlebar styling. I'll create PRs for these in their respective repositories if this PR gets considered.

I'd like to hear your thoughts on the implementation, I just banged on the code until it worked 😁 

This is what it looks like by default: 
![image](https://cloud.githubusercontent.com/assets/170500/15407444/211946aa-1e0b-11e6-871b-4f332cbab894.png)

This is the titlebar provided by one-dark-ui, with the oceanic-next syntax
![image](https://cloud.githubusercontent.com/assets/170500/15407534/ad8b0c4a-1e0b-11e6-842e-de6df82d5e15.png)

This is one-light-ui, with the atom-light syntax
![image](https://cloud.githubusercontent.com/assets/170500/15407555/c5222ba4-1e0b-11e6-9aeb-2f7693e20a2d.png)

Things left to do:
- [x] ✅ specs

This is a partial continuation of https://github.com/atom/atom/pull/10208 albeit without the combined title-bar-and-tabs functionality, for which this would be the groundwork. (As requested in https://github.com/atom/atom/issues/4599 for example.)
