### PR TITLE
replace _.extend in favor of Object.assign

### DIFF
--- a/src/browser/atom-application.coffee
+++ b/src/browser/atom-application.coffee
@@ -25,7 +25,7 @@ LocationSuffixRegExp = /(:\d+)(:\d+)?$/
 #
 module.exports =
 class AtomApplication
-  _.extend @prototype, EventEmitter.prototype
+  Object.assign @prototype, EventEmitter.prototype
 
   # Public: The entry point into the Atom application.
   @open: (options) ->
@@ -528,7 +528,7 @@ class AtomApplication
     restorePreviousState = @config.get('core.restorePreviousWindowsOnStart') ? true
     if restorePreviousState and (states = @storageFolder.load('application.json'))?.length > 0
       for state in states
-        @openWithOptions(_.extend(options, {
+        @openWithOptions(Object.assign(options, {
           initialPaths: state.initialPaths
           pathsToOpen: state.initialPaths.filter (directoryPath) -> fs.isDirectorySync(directoryPath)
           urlsToOpen: []

--- a/src/browser/atom-window.coffee
+++ b/src/browser/atom-window.coffee
@@ -2,12 +2,11 @@
 path = require 'path'
 fs = require 'fs'
 url = require 'url'
-_ = require 'underscore-plus'
 {EventEmitter} = require 'events'
 
 module.exports =
 class AtomWindow
-  _.extend @prototype, EventEmitter.prototype
+  Object.assign @prototype, EventEmitter.prototype
 
   @iconPath: path.resolve(__dirname, '..', '..', 'resources', 'atom.png')
   @includeShellLoadTime: true
@@ -40,7 +39,7 @@ class AtomWindow
 
     @handleEvents()
 
-    loadSettings = _.extend({}, settings)
+    loadSettings = Object.assign({}, settings)
     loadSettings.appVersion = app.getVersion()
     loadSettings.resourcePath = @resourcePath
     loadSettings.devMode ?= false

--- a/src/browser/auto-update-manager.coffee
+++ b/src/browser/auto-update-manager.coffee
@@ -1,5 +1,4 @@
 autoUpdater = null
-_ = require 'underscore-plus'
 {EventEmitter} = require 'events'
 path = require 'path'
 
@@ -13,7 +12,7 @@ ErrorState = 'error'
 
 module.exports =
 class AutoUpdateManager
-  _.extend @prototype, EventEmitter.prototype
+  Object.assign @prototype, EventEmitter.prototype
 
   constructor: (@version, @testMode, resourcePath, @config) ->
     @state = IdleState

--- a/src/browser/auto-updater-win32.coffee
+++ b/src/browser/auto-updater-win32.coffee
@@ -1,9 +1,8 @@
 {EventEmitter} = require 'events'
-_ = require 'underscore-plus'
 SquirrelUpdate = require './squirrel-update'
 
 class AutoUpdater
-  _.extend @prototype, EventEmitter.prototype
+  Object.assign @prototype, EventEmitter.prototype
 
   setFeedURL: (@updateUrl) ->
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -785,7 +785,7 @@ class Config
         properties[key] ?= {}
         rootSchema = properties[key]
 
-    _.extend rootSchema, schema
+    Object.assign rootSchema, schema
     @setDefaults(keyPath, @extractDefaultsFromSchema(schema))
     @setScopedDefaultsFromSchema(keyPath, schema)
     @resetSettingsForSchemaChange()
@@ -870,7 +870,7 @@ class Config
     return if @shouldNotAccessFileSystem()
 
     allSettings = {'*': @settings}
-    allSettings = _.extend allSettings, @scopedSettingsStore.propertiesForSource(@getUserConfigPath())
+    allSettings = Object.assign allSettings, @scopedSettingsStore.propertiesForSource(@getUserConfigPath())
     allSettings = sortObject(allSettings)
     try
       CSON.writeFileSync(@configFilePath, allSettings)

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -537,8 +537,8 @@ class Cursor extends Model
   #   * `wordRegex` A {RegExp} indicating what constitutes a "word"
   #     (default: {::wordRegExp}).
   getCurrentWordBufferRange: (options={}) ->
-    startOptions = _.extend(_.clone(options), allowPrevious: false)
-    endOptions = _.extend(_.clone(options), allowNext: false)
+    startOptions = Object.assign(_.clone(options), allowPrevious: false)
+    endOptions = Object.assign(_.clone(options), allowNext: false)
     new Range(@getBeginningOfCurrentWordBufferPosition(startOptions), @getEndOfCurrentWordBufferPosition(endOptions))
 
   # Public: Returns the buffer Range for the current line.

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -318,7 +318,7 @@ class GitRepository
   getDirectoryStatus: (directoryPath)  ->
     directoryPath = "#{@relativize(directoryPath)}/"
     directoryStatus = 0
-    for path, status of _.extend({}, @async.getCachedPathStatuses(), @statusesByPath)
+    for path, status of Object.assign({}, @async.getCachedPathStatuses(), @statusesByPath)
       directoryStatus |= status if path.indexOf(directoryPath) is 0
     directoryStatus
 

--- a/src/scan-handler.coffee
+++ b/src/scan-handler.coffee
@@ -1,4 +1,3 @@
-_ = require "underscore-plus"
 path = require "path"
 async = require "async"
 {PathSearcher, PathScanner, search} = require 'scandal'
@@ -26,7 +25,7 @@ module.exports = (rootPaths, regexSource, options) ->
   async.each(
     rootPaths,
     (rootPath, next) ->
-      options2 = _.extend {}, options,
+      options2 = Object.assign {}, options,
         inclusions: processPaths(rootPath, options.inclusions)
         globalExclusions: processPaths(rootPath, options.globalExclusions)
 

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -1,5 +1,5 @@
 {Point, Range} = require 'text-buffer'
-{pick} = _ = require 'underscore-plus'
+{pick} = require 'underscore-plus'
 {Emitter} = require 'event-kit'
 Model = require './model'
 
@@ -738,7 +738,7 @@ class Selection extends Model
     else
       options.goalScreenRange = myGoalScreenRange ? otherGoalScreenRange
 
-    @setBufferRange(@getBufferRange().union(otherSelection.getBufferRange()), _.extend(autoscroll: false, options))
+    @setBufferRange(@getBufferRange().union(otherSelection.getBufferRange()), Object.assign(autoscroll: false, options))
     otherSelection.destroy()
 
   ###

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2595,7 +2595,7 @@ class TextEditor extends Model
   # Returns the new {Selection}.
   addSelection: (marker, options={}) ->
     cursor = @addCursor(marker)
-    selection = new Selection(_.extend({editor: this, marker, cursor, @clipboard}, options))
+    selection = new Selection(Object.assign({editor: this, marker, cursor, @clipboard}, options))
     @selections.push(selection)
     selectionBufferRange = selection.getBufferRange()
     @mergeIntersectingSelections(preserveFolds: options.preserveFolds)

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -549,7 +549,7 @@ class Workspace extends Model
         throw error
 
     @project.bufferForPath(filePath, options).then (buffer) =>
-      editor = @buildTextEditor(_.extend({buffer, largeFileMode}, options))
+      editor = @buildTextEditor(Object.assign({buffer, largeFileMode}, options))
       disposable = atom.textEditors.add(editor)
       grammarSubscription = editor.observeGrammar(@handleGrammarUsed.bind(this))
       editor.onDidDestroy ->
@@ -572,7 +572,7 @@ class Workspace extends Model
   #
   # Returns a {TextEditor}.
   buildTextEditor: (params) ->
-    params = _.extend({
+    params = Object.assign({
       @config, @clipboard, @grammarRegistry, @assert
     }, params)
     new TextEditor(params)


### PR DESCRIPTION
Since Chromium 45 supports native `Object.assign` for merging objects. Let's get rid `extends` from `underscore` in favor of native method.
