### PR TITLE
Don't install devtron when toggling DevTools

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -790,7 +790,6 @@ class AtomEnvironment extends Model
   # Returns a {Promise} that resolves when the DevTools have been opened or
   # closed.
   toggleDevTools: ->
-    require("devtron").install()
     @applicationDelegate.toggleWindowDevTools()
 
   # Extended: Execute code in dev tools.


### PR DESCRIPTION
Refs: #11750

Instead of automatically installing devtron after toggling the developer tools, we just bundle it in Atom and let people install it manually when they need to debug the application by executing the following snippet in the console:

```
require('devtron').install()
```

/cc: @lee-dohm 
