### PR TITLE
Add note about Xcode on El Captain

### DIFF
--- a/docs/build-instructions/os-x.md
+++ b/docs/build-instructions/os-x.md
@@ -8,7 +8,7 @@
 
 ## Instructions
 
- **El Captain**: Install XCode from App Store and then open it before running build script.
+ **El Captain**: Install Xcode from App Store and then open it before running build script.
 
   ```sh
   git clone https://github.com/atom/atom.git

--- a/docs/build-instructions/os-x.md
+++ b/docs/build-instructions/os-x.md
@@ -8,6 +8,8 @@
 
 ## Instructions
 
+ **El Captain**: Install XCode from App Store and then open it before running build script.
+
   ```sh
   git clone https://github.com/atom/atom.git
   cd atom


### PR DESCRIPTION
I have just built atom on my mac for the first time. I took me about 2 hours to do it successfully, because installing XCode with App Store **then** opening it was not so obvious. This PR adds a note about it before the little code snippet.
