### PR TITLE
Following replaceSelectedText(), update the selected text range accordingly.

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4868,8 +4868,8 @@ describe "TextEditor", ->
         editor.replaceSelectedText {}, -> '123'
         expect(buffer.lineForRow(0)).toBe '123var quicksort = function () {'
 
-        editor.replaceSelectedText {selectWordIfEmpty: true}, -> 'var'
         editor.setCursorBufferPosition([0])
+        editor.replaceSelectedText {selectWordIfEmpty: true}, -> 'var'
         expect(buffer.lineForRow(0)).toBe 'var quicksort = function () {'
 
         editor.setCursorBufferPosition([10])
@@ -4881,6 +4881,12 @@ describe "TextEditor", ->
         editor.setSelectedBufferRange([[0, 1], [0, 3]])
         editor.replaceSelectedText {}, -> 'ia'
         expect(buffer.lineForRow(0)).toBe 'via quicksort = function () {'
+
+      it "replaces the selected text and selects the replacement text", ->
+        editor.setSelectedBufferRange([[0, 4], [0, 9]])
+        editor.replaceSelectedText {}, -> 'whatnot'
+        expect(buffer.lineForRow(0)).toBe 'var whatnotsort = function () {'
+        expect(editor.getSelectedBufferRange()).toEqual [[0, 4], [0, 11]]
 
   describe ".transpose()", ->
     it "swaps two characters", ->
@@ -4902,7 +4908,7 @@ describe "TextEditor", ->
         editor.setCursorScreenPosition([0, 1])
         editor.upperCase()
         expect(editor.lineTextForBufferRow(0)).toBe 'ABC'
-        expect(editor.getSelectedBufferRange()).toEqual [[0, 1], [0, 1]]
+        expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [0, 3]]
 
     describe "when there is a selection", ->
       it "upper cases the current selection", ->
@@ -4919,7 +4925,7 @@ describe "TextEditor", ->
         editor.setCursorScreenPosition([0, 1])
         editor.lowerCase()
         expect(editor.lineTextForBufferRow(0)).toBe 'abc'
-        expect(editor.getSelectedBufferRange()).toEqual [[0, 1], [0, 1]]
+        expect(editor.getSelectedBufferRange()).toEqual [[0, 0], [0, 3]]
 
     describe "when there is a selection", ->
       it "lower cases the current selection", ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1328,12 +1328,12 @@ class TextEditor extends Model
   replaceSelectedText: (options={}, fn) ->
     {selectWordIfEmpty} = options
     @mutateSelectedText (selection) ->
-      range = selection.getBufferRange()
+      selection.getBufferRange()
       if selectWordIfEmpty and selection.isEmpty()
         selection.selectWord()
       text = selection.getText()
       selection.deleteSelectedText()
-      selection.insertText(fn(text))
+      range = selection.insertText(fn(text))
       selection.setBufferRange(range)
 
   # Split multi-line selections into one selection per line.


### PR DESCRIPTION
Following a call to `replaceSelectedText()`, the previous selected text range is not necessarily still relevant as that text has been replaced. The newly inserted text can possibly have a totally different range. Use the range of the newly inserted text as the final selection range.
