### PR TITLE
Add a note how to hide the wrap-guide

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -197,7 +197,7 @@ module.exports =
       softWrapAtPreferredLineLength:
         type: 'boolean'
         default: false
-        description: 'Instead of wrapping lines to the window\'s width, wrap lines to the number of characters defined by the `Preferred Line Length` setting. This will only take effect when the soft wrap config setting is enabled globally or for the current language.'
+        description: 'Instead of wrapping lines to the window\'s width, wrap lines to the number of characters defined by the `Preferred Line Length` setting. This will only take effect when the soft wrap config setting is enabled globally or for the current language. Note: I you like to hide the wrap guide (the vertical line) you can disable the `wrap-guide` package.'
       softWrapHangingIndent:
         type: 'integer'
         default: 0

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -197,7 +197,7 @@ module.exports =
       softWrapAtPreferredLineLength:
         type: 'boolean'
         default: false
-        description: 'Instead of wrapping lines to the window\'s width, wrap lines to the number of characters defined by the `Preferred Line Length` setting. This will only take effect when the soft wrap config setting is enabled globally or for the current language. Note: If you like to hide the wrap guide (the vertical line) you can disable the `wrap-guide` package.'
+        description: 'Instead of wrapping lines to the window\'s width, wrap lines to the number of characters defined by the `Preferred Line Length` setting. This will only take effect when the soft wrap config setting is enabled globally or for the current language. **Note:** If you want to hide the wrap guide (the vertical line) you can disable the `wrap-guide` package.'
       softWrapHangingIndent:
         type: 'integer'
         default: 0

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -197,7 +197,7 @@ module.exports =
       softWrapAtPreferredLineLength:
         type: 'boolean'
         default: false
-        description: 'Instead of wrapping lines to the window\'s width, wrap lines to the number of characters defined by the `Preferred Line Length` setting. This will only take effect when the soft wrap config setting is enabled globally or for the current language. Note: I you like to hide the wrap guide (the vertical line) you can disable the `wrap-guide` package.'
+        description: 'Instead of wrapping lines to the window\'s width, wrap lines to the number of characters defined by the `Preferred Line Length` setting. This will only take effect when the soft wrap config setting is enabled globally or for the current language. Note: If you like to hide the wrap guide (the vertical line) you can disable the `wrap-guide` package.'
       softWrapHangingIndent:
         type: 'integer'
         default: 0


### PR DESCRIPTION
Ideally this would be an option in the settings, but maybe a note will already help too.

![screen shot 2016-05-21 at 10 27 45 am](https://cloud.githubusercontent.com/assets/378023/15445687/e7b6288a-1f3e-11e6-9657-9555752c92de.png)

Refs: https://github.com/atom/settings-view/issues/790 + https://github.com/atom/atom/issues/11782. There are many more issues and discussions about this, but these are just the recent two.
