### PR TITLE
Fix uncaught exception when open file dialog is cancelled

### DIFF
--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -445,6 +445,9 @@ class AtomApplication
   #   :window - {AtomWindow} to open file paths in.
   #   :addToLastWindow - Boolean of whether this should be opened in last focused window.
   openPaths: ({initialPaths, pathsToOpen, executedFrom, pidToKillWhenClosed, newWindow, devMode, safeMode, windowDimensions, profileStartup, window, clearWindowState, addToLastWindow, env}={}) ->
+    if not pathsToOpen? or pathsToOpen.length == 0
+      return
+
     devMode = Boolean(devMode)
     safeMode = Boolean(safeMode)
     clearWindowState = Boolean(clearWindowState)

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -445,7 +445,7 @@ class AtomApplication
   #   :window - {AtomWindow} to open file paths in.
   #   :addToLastWindow - Boolean of whether this should be opened in last focused window.
   openPaths: ({initialPaths, pathsToOpen, executedFrom, pidToKillWhenClosed, newWindow, devMode, safeMode, windowDimensions, profileStartup, window, clearWindowState, addToLastWindow, env}={}) ->
-    if not pathsToOpen? or pathsToOpen.length == 0
+    if not pathsToOpen? or pathsToOpen.length is 0
       return
 
     devMode = Boolean(devMode)


### PR DESCRIPTION
Fixes an uncaught exception when the open files dialog is cancelled. The `openPaths` function just needs to check to ensure `initialPaths` isn't null or empty when called (issues #10315 and #10308).

Should probably add a spec for this?
