### PR TITLE
Move Bootstrap into Core

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -235,8 +235,10 @@ module.exports = (grunt) ->
         'outline-none': false
         'overqualified-elements': false
         'qualified-headings': false
+        'regex-selectors': false
         'unique-headings': false
         'universal-selector': false
+        'unqualified-attributes': false
         'vendor-prefix': false
       src: [
         'static/**/*.css'

--- a/static/alerts.less
+++ b/static/alerts.less
@@ -1,0 +1,114 @@
+@import "variables/variables";
+@import "ui-variables";
+
+//
+// Alerts
+// --------------------------------------------------
+
+//## Define alert colors, border radius, and padding.
+
+@alert-padding:               15px;
+@alert-border-radius:         @border-radius-base;
+@alert-link-font-weight:      bold;
+
+@alert-success-bg:            @state-success-bg;
+@alert-success-text:          @state-success-text;
+@alert-success-border:        @state-success-border;
+
+@alert-info-bg:               @state-info-bg;
+@alert-info-text:             @state-info-text;
+@alert-info-border:           @state-info-border;
+
+@alert-warning-bg:            @state-warning-bg;
+@alert-warning-text:          @state-warning-text;
+@alert-warning-border:        @state-warning-border;
+
+@alert-danger-bg:             @state-danger-bg;
+@alert-danger-text:           @state-danger-text;
+@alert-danger-border:         @state-danger-border;
+
+
+//## variant mixin
+
+.alert-variant(@background; @border; @text-color) {
+  background-color: @background;
+  border-color: @border;
+  color: @text-color;
+
+  hr {
+    border-top-color: darken(@border, 5%);
+  }
+  .alert-link {
+    color: darken(@text-color, 10%);
+  }
+}
+
+
+// Base styles
+// -------------------------
+
+.alert {
+  padding: @alert-padding;
+  margin-bottom: @line-height-computed;
+  border: 1px solid transparent;
+  border-radius: @alert-border-radius;
+
+  // Headings for larger alerts
+  h4 {
+    margin-top: 0;
+    // Specified for the h4 to prevent conflicts of changing @headings-color
+    color: inherit;
+  }
+
+  // Provide class for links that match alerts
+  .alert-link {
+    font-weight: @alert-link-font-weight;
+  }
+
+  // Improve alignment and spacing of inner content
+  > p,
+  > ul {
+    margin-bottom: 0;
+  }
+
+  > p + p {
+    margin-top: 5px;
+  }
+}
+
+// Dismissible alerts
+//
+// Expand the right padding and account for the close button's positioning.
+
+.alert-dismissable, // The misspelled .alert-dismissable was deprecated in 3.2.0.
+.alert-dismissible {
+  padding-right: (@alert-padding + 20);
+
+  // Adjust close link position
+  .close {
+    position: relative;
+    top: -2px;
+    right: -21px;
+    color: inherit;
+  }
+}
+
+// Alternate styles
+//
+// Generate contextual modifier classes for colorizing the alert.
+
+.alert-success {
+  .alert-variant(@alert-success-bg; @alert-success-border; @alert-success-text);
+}
+
+.alert-info {
+  .alert-variant(@alert-info-bg; @alert-info-border; @alert-info-text);
+}
+
+.alert-warning {
+  .alert-variant(@alert-warning-bg; @alert-warning-border; @alert-warning-text);
+}
+
+.alert-danger {
+  .alert-variant(@alert-danger-bg; @alert-danger-border; @alert-danger-text);
+}

--- a/static/atom.less
+++ b/static/atom.less
@@ -14,6 +14,7 @@
 @import "badges";
 @import "button-groups";
 @import "buttons";
+@import "code";
 @import "icons";
 @import "links";
 @import "panes";

--- a/static/atom.less
+++ b/static/atom.less
@@ -9,6 +9,9 @@
 @import "octicon-utf-codes";
 @import "octicon-mixins";
 
+// Reset
+@import "normalize";
+
 @import "workspace-view";
 @import "bootstrap-overrides";
 @import "badges";

--- a/static/atom.less
+++ b/static/atom.less
@@ -13,7 +13,6 @@
 @import "normalize";
 @import "scaffolding";
 
-
 // Components
 @import "alerts";
 @import "badges";
@@ -21,6 +20,7 @@
 @import "buttons";
 @import "code";
 @import "cursors";
+@import "forms.less";
 @import "icons";
 @import "links";
 @import "lists";

--- a/static/atom.less
+++ b/static/atom.less
@@ -13,8 +13,9 @@
 @import "normalize";
 @import "scaffolding";
 
-// Components
 
+// Components
+@import "alerts";
 @import "badges";
 @import "button-groups";
 @import "buttons";

--- a/static/atom.less
+++ b/static/atom.less
@@ -35,6 +35,7 @@
 @import "select-list";
 @import "syntax";
 @import "text-editor-light";
+@import "tables";
 @import "text";
 @import "tooltip";
 @import "workspace-view";

--- a/static/atom.less
+++ b/static/atom.less
@@ -9,32 +9,34 @@
 @import "octicon-utf-codes";
 @import "octicon-mixins";
 
-// Reset
+// Normalize + scaffolding
 @import "normalize";
 @import "scaffolding";
 
-@import "workspace-view";
+// Components
+
 @import "badges";
 @import "button-groups";
 @import "buttons";
 @import "code";
+@import "cursors";
 @import "icons";
 @import "links";
-@import "panes";
-@import "panels";
-@import "sections";
 @import "lists";
-@import "popover-list";
-@import "messages";
 @import "markdown";
+@import "messages";
 @import "navs";
-@import "text-editor-light";
+@import "octicons";
+@import "panels";
+@import "panes";
+@import "popover-list";
+@import "sections";
 @import "select-list";
 @import "syntax";
+@import "text-editor-light";
 @import "text";
 @import "tooltip";
-@import "octicons";
-@import "cursors";
+@import "workspace-view";
 
 // Utilities
 @import "utilities";

--- a/static/atom.less
+++ b/static/atom.less
@@ -33,6 +33,8 @@
 @import "syntax";
 @import "text";
 @import "tooltip";
-@import "utilities";
 @import "octicons";
 @import "cursors";
+
+// Utilities
+@import "utilities";

--- a/static/atom.less
+++ b/static/atom.less
@@ -12,6 +12,7 @@
 @import "workspace-view";
 @import "bootstrap-overrides";
 @import "badges";
+@import "button-groups";
 @import "buttons";
 @import "icons";
 @import "links";

--- a/static/atom.less
+++ b/static/atom.less
@@ -26,6 +26,7 @@
 @import "select-list";
 @import "syntax";
 @import "text";
+@import "tooltip";
 @import "utilities";
 @import "octicons";
 @import "cursors";

--- a/static/atom.less
+++ b/static/atom.less
@@ -14,7 +14,6 @@
 @import "scaffolding";
 
 @import "workspace-view";
-@import "bootstrap-overrides";
 @import "badges";
 @import "button-groups";
 @import "buttons";

--- a/static/atom.less
+++ b/static/atom.less
@@ -24,6 +24,7 @@
 @import "popover-list";
 @import "messages";
 @import "markdown";
+@import "navs";
 @import "text-editor-light";
 @import "select-list";
 @import "syntax";

--- a/static/atom.less
+++ b/static/atom.less
@@ -11,6 +11,7 @@
 
 // Reset
 @import "normalize";
+@import "scaffolding";
 
 @import "workspace-view";
 @import "bootstrap-overrides";

--- a/static/bootstrap-overrides.less
+++ b/static/bootstrap-overrides.less
@@ -1,1 +1,0 @@
-@import "ui-variables";

--- a/static/bootstrap-overrides.less
+++ b/static/bootstrap-overrides.less
@@ -13,15 +13,6 @@
   }
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-family: inherit; // inherit from themes
-}
-
 body {
   font-family: inherit; // inherit from html
   font-size: inherit; // inherit from html

--- a/static/bootstrap-overrides.less
+++ b/static/bootstrap-overrides.less
@@ -17,10 +17,3 @@ body {
   font-family: inherit; // inherit from html
   font-size: inherit; // inherit from html
 }
-
-// disable some <kbd> styling, will be styled in themes
-kbd {
-  color: inherit;
-  background-color: none;
-  box-shadow: none;
-}

--- a/static/bootstrap-overrides.less
+++ b/static/bootstrap-overrides.less
@@ -1,18 +1,5 @@
 @import "ui-variables";
 
-.nav {
-  > li > a {
-    border-radius: @component-border-radius;
-  }
-  > li > a:hover {
-    background-color: @background-color-highlight;
-  }
-
-  &.nav-pills > li.active > a {
-    background-color: @background-color-selected;
-  }
-}
-
 body {
   font-family: inherit; // inherit from html
   font-size: inherit; // inherit from html

--- a/static/bootstrap-overrides.less
+++ b/static/bootstrap-overrides.less
@@ -27,12 +27,6 @@ body {
   font-size: inherit; // inherit from html
 }
 
-// Latest Bootstrap specifies the font properties again instead of inheriting
-.tooltip {
-  font-family: @font-family;
-  font-size: @font-size;
-}
-
 // disable some <kbd> styling, will be styled in themes
 kbd {
   color: inherit;

--- a/static/bootstrap-overrides.less
+++ b/static/bootstrap-overrides.less
@@ -1,6 +1,1 @@
 @import "ui-variables";
-
-body {
-  font-family: inherit; // inherit from html
-  font-size: inherit; // inherit from html
-}

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -3,7 +3,6 @@
 @import "../node_modules/bootstrap/less/mixins.less";
 
 // Core CSS
-@import "../node_modules/bootstrap/less/scaffolding.less";
 @import "../node_modules/bootstrap/less/type.less";
 @import "../node_modules/bootstrap/less/grid.less";
 @import "../node_modules/bootstrap/less/tables.less";

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -12,7 +12,6 @@
 @import "../node_modules/bootstrap/less/grid.less";
 @import "../node_modules/bootstrap/less/tables.less";
 @import "../node_modules/bootstrap/less/forms.less";
-@import "../node_modules/bootstrap/less/buttons.less";
 
 // Components
 @import "../node_modules/bootstrap/less/button-groups.less";

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -14,6 +14,3 @@
 @import "../node_modules/bootstrap/less/alerts.less";
 @import "../node_modules/bootstrap/less/thumbnails.less";
 @import "../node_modules/bootstrap/less/close.less";
-
-// Utility classes
-@import "../node_modules/bootstrap/less/utilities.less";

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -18,7 +18,6 @@
 @import "../node_modules/bootstrap/less/navs.less";
 @import "../node_modules/bootstrap/less/labels.less";
 @import "../node_modules/bootstrap/less/alerts.less";
-@import "../node_modules/bootstrap/less/list-group.less";
 @import "../node_modules/bootstrap/less/thumbnails.less";
 @import "../node_modules/bootstrap/less/close.less";
 

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -5,7 +5,6 @@
 // Core CSS
 @import "../node_modules/bootstrap/less/type.less";
 @import "../node_modules/bootstrap/less/grid.less";
-@import "../node_modules/bootstrap/less/tables.less";
 @import "../node_modules/bootstrap/less/forms.less";
 
 // Components

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -2,9 +2,6 @@
 @import "../node_modules/bootstrap/less/variables.less";
 @import "../node_modules/bootstrap/less/mixins.less";
 
-// Reset
-@import "../node_modules/bootstrap/less/normalize.less";
-
 // Core CSS
 @import "../node_modules/bootstrap/less/scaffolding.less";
 @import "../node_modules/bootstrap/less/type.less";

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -9,7 +9,6 @@
 
 // Core CSS
 // @import "../node_modules/bootstrap/less/grid.less";
-// @import "../node_modules/bootstrap/less/forms.less";
 
 // Components
 // @import "../node_modules/bootstrap/less/input-groups.less";

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -1,13 +1,18 @@
+/* Most of the Bootstrap styles are now in Core (atom.less) */
+/* TODO: Remove this file if nothing burned down */
+
+// Below the removed styles
+
 // Core variables and mixins
-@import "../node_modules/bootstrap/less/variables.less";
-@import "../node_modules/bootstrap/less/mixins.less";
+// @import "../node_modules/bootstrap/less/variables.less";
+// @import "../node_modules/bootstrap/less/mixins.less";
 
 // Core CSS
-@import "../node_modules/bootstrap/less/grid.less";
-@import "../node_modules/bootstrap/less/forms.less";
+// @import "../node_modules/bootstrap/less/grid.less";
+// @import "../node_modules/bootstrap/less/forms.less";
 
 // Components
-@import "../node_modules/bootstrap/less/input-groups.less";
-@import "../node_modules/bootstrap/less/labels.less";
-@import "../node_modules/bootstrap/less/thumbnails.less";
-@import "../node_modules/bootstrap/less/close.less";
+// @import "../node_modules/bootstrap/less/input-groups.less";
+// @import "../node_modules/bootstrap/less/labels.less";
+// @import "../node_modules/bootstrap/less/thumbnails.less";
+// @import "../node_modules/bootstrap/less/close.less";

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -24,8 +24,5 @@
 @import "../node_modules/bootstrap/less/thumbnails.less";
 @import "../node_modules/bootstrap/less/close.less";
 
-// Components w/ JavaScript
-@import "../node_modules/bootstrap/less/tooltip.less";
-
 // Utility classes
 @import "../node_modules/bootstrap/less/utilities.less";

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -3,7 +3,6 @@
 @import "../node_modules/bootstrap/less/mixins.less";
 
 // Core CSS
-@import "../node_modules/bootstrap/less/type.less";
 @import "../node_modules/bootstrap/less/grid.less";
 @import "../node_modules/bootstrap/less/forms.less";
 

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -14,7 +14,6 @@
 @import "../node_modules/bootstrap/less/forms.less";
 
 // Components
-@import "../node_modules/bootstrap/less/button-groups.less";
 @import "../node_modules/bootstrap/less/input-groups.less";
 @import "../node_modules/bootstrap/less/navs.less";
 @import "../node_modules/bootstrap/less/labels.less";

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -14,7 +14,6 @@
 
 // Components
 @import "../node_modules/bootstrap/less/input-groups.less";
-@import "../node_modules/bootstrap/less/navs.less";
 @import "../node_modules/bootstrap/less/labels.less";
 @import "../node_modules/bootstrap/less/alerts.less";
 @import "../node_modules/bootstrap/less/thumbnails.less";

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -11,6 +11,5 @@
 // Components
 @import "../node_modules/bootstrap/less/input-groups.less";
 @import "../node_modules/bootstrap/less/labels.less";
-@import "../node_modules/bootstrap/less/alerts.less";
 @import "../node_modules/bootstrap/less/thumbnails.less";
 @import "../node_modules/bootstrap/less/close.less";

--- a/static/bootstrap.less
+++ b/static/bootstrap.less
@@ -8,7 +8,6 @@
 // Core CSS
 @import "../node_modules/bootstrap/less/scaffolding.less";
 @import "../node_modules/bootstrap/less/type.less";
-@import "../node_modules/bootstrap/less/code.less";
 @import "../node_modules/bootstrap/less/grid.less";
 @import "../node_modules/bootstrap/less/tables.less";
 @import "../node_modules/bootstrap/less/forms.less";

--- a/static/button-groups.less
+++ b/static/button-groups.less
@@ -1,0 +1,265 @@
+//
+// Button groups
+// --------------------------------------------------
+
+// Make the div behave like a button
+.btn-group,
+.btn-group-vertical {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle; // match .btn alignment given font-size hack above
+  > .btn {
+    position: relative;
+    float: left;
+    // Bring the "active" button to the front
+    &:hover,
+    &:focus,
+    &:active,
+    &.active {
+      z-index: 2;
+    }
+  }
+}
+
+
+// Borders
+// ---------------------------------------------------------
+
+.btn-group > .btn {
+  border-left: 1px solid @button-border-color;
+  border-right: 1px solid @button-border-color;
+}
+.btn-group > .btn:first-child {
+  border-left: none;
+  border-top-left-radius: @component-border-radius;
+  border-bottom-left-radius: @component-border-radius;
+}
+.btn-group > .btn:last-child,
+.btn-group > .btn.selected:last-child,
+.btn-group > .dropdown-toggle {
+  border-right: none;
+  border-top-right-radius: @component-border-radius;
+  border-bottom-right-radius: @component-border-radius;
+}
+
+// Prevent double borders when buttons are next to each other
+.btn-group {
+  .btn + .btn,
+  .btn + .btn-group,
+  .btn-group + .btn,
+  .btn-group + .btn-group {
+    margin-left: -1px;
+  }
+}
+
+// Optional: Group multiple button groups together for a toolbar
+.btn-toolbar {
+  margin-left: -5px; // Offset the first child's margin
+  &:extend(.clearfix all);
+
+  .btn,
+  .btn-group,
+  .input-group {
+    float: left;
+  }
+  > .btn,
+  > .btn-group,
+  > .input-group {
+    margin-left: 5px;
+  }
+}
+
+.btn-group > .btn:not(:first-child):not(:last-child):not(.dropdown-toggle) {
+  border-radius: 0;
+}
+
+// Set corners individual because sometimes a single button can be in a .btn-group and we need :first-child and :last-child to both match
+.btn-group > .btn:first-child {
+  margin-left: 0;
+  &:not(:last-child):not(.dropdown-toggle) {
+    .border-right-radius(0);
+  }
+}
+// Need .dropdown-toggle since :last-child doesn't apply given a .dropdown-menu immediately after it
+.btn-group > .btn:last-child:not(:first-child),
+.btn-group > .dropdown-toggle:not(:first-child) {
+  .border-left-radius(0);
+}
+
+// Custom edits for including btn-groups within btn-groups (useful for including dropdown buttons within a btn-group)
+.btn-group > .btn-group {
+  float: left;
+}
+.btn-group > .btn-group:not(:first-child):not(:last-child) > .btn {
+  border-radius: 0;
+}
+.btn-group > .btn-group:first-child:not(:last-child) {
+  > .btn:last-child,
+  > .dropdown-toggle {
+    .border-right-radius(0);
+  }
+}
+.btn-group > .btn-group:last-child:not(:first-child) > .btn:first-child {
+  .border-left-radius(0);
+}
+
+// On active and open, don't show outline
+.btn-group .dropdown-toggle:active,
+.btn-group.open .dropdown-toggle {
+  outline: 0;
+}
+
+
+// Sizing
+//
+// Remix the default button sizing classes into new ones for easier manipulation.
+
+.btn-group-xs > .btn { &:extend(.btn-xs); }
+.btn-group-sm > .btn { &:extend(.btn-sm); }
+.btn-group-lg > .btn { &:extend(.btn-lg); }
+
+
+// Split button dropdowns
+// ----------------------
+
+// Give the line between buttons some depth
+.btn-group > .btn + .dropdown-toggle {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+.btn-group > .btn-lg + .dropdown-toggle {
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+// The clickable button for toggling the menu
+// Remove the gradient and set the same inset shadow as the :active state
+.btn-group.open .dropdown-toggle {
+  box-shadow: inset 0 3px 5px rgba(0,0,0,.125);
+
+  // Show no shadow for `.btn-link` since it has no other button styles.
+  &.btn-link {
+    box-shadow: none;
+  }
+}
+
+
+// Reposition the caret
+.btn .caret {
+  margin-left: 0;
+}
+// Carets in other button sizes
+.btn-lg .caret {
+  border-width: @caret-width-large @caret-width-large 0;
+  border-bottom-width: 0;
+}
+// Upside down carets for .dropup
+.dropup .btn-lg .caret {
+  border-width: 0 @caret-width-large @caret-width-large;
+}
+
+
+// Vertical button groups
+// ----------------------
+
+.btn-group-vertical {
+  > .btn,
+  > .btn-group,
+  > .btn-group > .btn {
+    display: block;
+    float: none;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  // Clear floats so dropdown menus can be properly placed
+  > .btn-group {
+    &:extend(.clearfix all);
+    > .btn {
+      float: none;
+    }
+  }
+
+  > .btn + .btn,
+  > .btn + .btn-group,
+  > .btn-group + .btn,
+  > .btn-group + .btn-group {
+    margin-top: -1px;
+    margin-left: 0;
+  }
+}
+
+.btn-group-vertical > .btn {
+  &:not(:first-child):not(:last-child) {
+    border-radius: 0;
+  }
+  &:first-child:not(:last-child) {
+    .border-top-radius(@btn-border-radius-base);
+    .border-bottom-radius(0);
+  }
+  &:last-child:not(:first-child) {
+    .border-top-radius(0);
+    .border-bottom-radius(@btn-border-radius-base);
+  }
+}
+.btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn {
+  border-radius: 0;
+}
+.btn-group-vertical > .btn-group:first-child:not(:last-child) {
+  > .btn:last-child,
+  > .dropdown-toggle {
+    .border-bottom-radius(0);
+  }
+}
+.btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn:first-child {
+  .border-top-radius(0);
+}
+
+
+// Justified button groups
+// ----------------------
+
+.btn-group-justified {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: separate;
+  > .btn,
+  > .btn-group {
+    float: none;
+    display: table-cell;
+    width: 1%;
+  }
+  > .btn-group .btn {
+    width: 100%;
+  }
+
+  > .btn-group .dropdown-menu {
+    left: auto;
+  }
+}
+
+
+// Checkbox and radio options
+//
+// In order to support the browser's form validation feedback, powered by the
+// `required` attribute, we have to "hide" the inputs via `clip`. We cannot use
+// `display: none;` or `visibility: hidden;` as that also hides the popover.
+// Simply visually hiding the inputs via `opacity` would leave them clickable in
+// certain cases which is prevented by using `clip` and `pointer-events`.
+// This way, we ensure a DOM element is visible to position the popover from.
+//
+// See https://github.com/twbs/bootstrap/pull/12794 and
+// https://github.com/twbs/bootstrap/pull/14559 for more information.
+
+[data-toggle="buttons"] {
+  > .btn,
+  > .btn-group > .btn {
+    input[type="radio"],
+    input[type="checkbox"] {
+      position: absolute;
+      clip: rect(0,0,0,0);
+      pointer-events: none;
+    }
+  }
+}

--- a/static/button-groups.less
+++ b/static/button-groups.less
@@ -1,3 +1,7 @@
+@import "variables/variables";
+@import "ui-variables";
+@import "mixins/mixins";
+
 //
 // Button groups
 // --------------------------------------------------

--- a/static/buttons.less
+++ b/static/buttons.less
@@ -2,113 +2,38 @@
 @import "ui-variables";
 @import "mixins/mixins";
 
-
 //
 // Buttons
 // --------------------------------------------------
 
 
-@btn-font-weight:                normal;
+// Button variables
+// --------------------------------------------------
 
-@btn-default-color:              #333;
-@btn-default-bg:                 #fff;
-@btn-default-border:             #ccc;
+@btn-default-color:              @text-color;
+@btn-default-bg:                 @button-background-color;
 
 @btn-primary-color:              #fff;
-@btn-primary-bg:                 @brand-primary;
-@btn-primary-border:             darken(@btn-primary-bg, 5%);
+@btn-primary-bg:                 @background-color-info;
 
 @btn-success-color:              #fff;
-@btn-success-bg:                 @brand-success;
-@btn-success-border:             darken(@btn-success-bg, 5%);
+@btn-success-bg:                 @background-color-success;
 
 @btn-info-color:                 #fff;
-@btn-info-bg:                    @brand-info;
-@btn-info-border:                darken(@btn-info-bg, 5%);
+@btn-info-bg:                    @background-color-info;
 
 @btn-warning-color:              #fff;
-@btn-warning-bg:                 @brand-warning;
-@btn-warning-border:             darken(@btn-warning-bg, 5%);
+@btn-warning-bg:                 @background-color-warning;
 
-@btn-danger-color:               #fff;
-@btn-danger-bg:                  @brand-danger;
-@btn-danger-border:              darken(@btn-danger-bg, 5%);
+@btn-error-color:               #fff;
+@btn-error-bg:                  @background-color-error;
 
-@btn-link-disabled-color:        @gray-light;
+@btn-link-disabled-color:        @text-color-subtle;
 
 // Allows for customizing button radius independently from global border radius
 @btn-border-radius-base:         @component-border-radius;
 @btn-border-radius-large:        @component-border-radius * 2;
 @btn-border-radius-small:        @component-border-radius / 2;
-
-
-
-// Button variants
-//
-// Easily pump out default styles, as well as :hover, :focus, :active,
-// and disabled options for all buttons
-
-.button-variant(@color; @background; @border) {
-  color: @color;
-  background-color: @background;
-  border-color: @border;
-
-  &:focus,
-  &.focus {
-    color: @color;
-    background-color: darken(@background, 10%);
-        border-color: darken(@border, 25%);
-  }
-  &:hover {
-    color: @color;
-    background-color: darken(@background, 10%);
-        border-color: darken(@border, 12%);
-  }
-  &:active,
-  &.active,
-  .open > .dropdown-toggle& {
-    color: @color;
-    background-color: darken(@background, 10%);
-        border-color: darken(@border, 12%);
-
-    &:hover,
-    &:focus,
-    &.focus {
-      color: @color;
-      background-color: darken(@background, 17%);
-          border-color: darken(@border, 25%);
-    }
-  }
-  &:active,
-  &.active,
-  .open > .dropdown-toggle& {
-    background-image: none;
-  }
-  &.disabled,
-  &[disabled],
-  fieldset[disabled] & {
-    &:hover,
-    &:focus,
-    &.focus {
-      background-color: @background;
-          border-color: @border;
-    }
-  }
-
-  .badge {
-    color: @background;
-    background-color: @color;
-  }
-}
-
-// Button sizes
-.button-size(@padding-vertical; @padding-horizontal; @font-size; @line-height; @border-radius) {
-  padding: @padding-vertical @padding-horizontal;
-  font-size: @font-size;
-  line-height: @line-height;
-  border-radius: @border-radius;
-}
-
 
 
 // Base styles
@@ -117,16 +42,20 @@
 .btn {
   display: inline-block;
   margin-bottom: 0; // For input.btn
-  font-weight: @btn-font-weight;
+  height: @component-line-height + 2px;
+  padding: 0 @component-padding;
+  font-size: @font-size;
+  font-weight: normal;
+  line-height: @component-line-height;
   text-align: center;
   vertical-align: middle;
-  touch-action: manipulation;
-  cursor: pointer;
-  background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
-  border: 1px solid transparent;
+  border: none;
+  border-radius: @component-border-radius;
+  background-color: @btn-default-bg;
   white-space: nowrap;
+  cursor: pointer;
+  z-index: 0;
   -webkit-user-select: none;
-  .button-size(@padding-base-vertical; @padding-base-horizontal; @font-size-base; @line-height-base; @btn-border-radius-base);
 
   &,
   &:active,
@@ -142,6 +71,7 @@
   &.focus {
     color: @btn-default-color;
     text-decoration: none;
+    background-color: @button-background-color-hover;
   }
 
   &:active,
@@ -149,6 +79,13 @@
     outline: 0;
     background-image: none;
     box-shadow: inset 0 3px 5px rgba(0,0,0,.125);
+  }
+
+  &.selected,
+  &.selected:hover {
+    // we want the selected button to behave like the :hover button; it's on top of the other buttons.
+    z-index: 1;
+    background-color: @button-background-color-selected;
   }
 
   &.disabled,
@@ -168,143 +105,82 @@
 }
 
 
-// Alternate buttons
+// Button variants
 // --------------------------------------------------
 
-.btn-default {
-  .button-variant(@btn-default-color; @btn-default-bg; @btn-default-border);
-}
-.btn-primary {
-  .button-variant(@btn-primary-color; @btn-primary-bg; @btn-primary-border);
-}
-// Success appears as green
-.btn-success {
-  .button-variant(@btn-success-color; @btn-success-bg; @btn-success-border);
-}
-// Info appears as blue-green
-.btn-info {
-  .button-variant(@btn-info-color; @btn-info-bg; @btn-info-border);
-}
-// Warning appears as orange
-.btn-warning {
-  .button-variant(@btn-warning-color; @btn-warning-bg; @btn-warning-border);
-}
-// Danger and error appear as red
-.btn-danger {
-  .button-variant(@btn-danger-color; @btn-danger-bg; @btn-danger-border);
-}
+.button-variant(@color; @background;) {
+  color: @color;
+  background-color: @background;
 
-
-// Link buttons
-// -------------------------
-
-// Make a button look and behave like a link
-.btn-link {
-  color: @link-color;
-  font-weight: normal;
-  border-radius: 0;
-
-  &,
-  &:active,
-  &.active,
-  &[disabled],
-  fieldset[disabled] & {
-    background-color: transparent;
-    box-shadow: none;
-  }
-  &,
-  &:hover,
   &:focus,
-  &:active {
-    border-color: transparent;
+  &.focus {
+    color: @color;
+    background-color: darken(@background, 10%);
   }
-  &:hover,
-  &:focus {
-    color: @link-hover-color;
-    text-decoration: @link-hover-decoration;
-    background-color: transparent;
+  &:hover {
+    color: @color;
+    background-color: darken(@background, 10%);
   }
+  &:active,
+  &.active {
+    color: @color;
+    background-color: darken(@background, 10%);
+
+    &:hover,
+    &:focus,
+    &.focus {
+      color: @color;
+      background-color: darken(@background, 17%);
+    }
+  }
+  &.selected,
+  &.selected:hover {
+    // we want the selected button to behave like the :hover button; it's on top of the other buttons.
+    z-index: 1;
+    background-color: darken(@background, 10%);
+  }
+
+  &.disabled,
   &[disabled],
   fieldset[disabled] & {
     &:hover,
-    &:focus {
-      color: @btn-link-disabled-color;
-      text-decoration: none;
+    &:focus,
+    &.focus {
+      background-color: @background;
     }
   }
+
+  .badge {
+    color: @background;
+    background-color: @color;
+  }
+}
+
+.btn-primary {
+  .button-variant(@btn-primary-color; @btn-primary-bg;);
+}
+// Success appears as green
+.btn-success {
+  .button-variant(@btn-success-color; @btn-success-bg;);
+}
+// Info appears as blue-green
+.btn-info {
+  .button-variant(@btn-info-color; @btn-info-bg;);
+}
+// Warning appears as orange
+.btn-warning {
+  .button-variant(@btn-warning-color; @btn-warning-bg;);
+}
+// Danger and error appear as red
+.btn-error {
+  .button-variant(@btn-error-color; @btn-error-bg;);
 }
 
 
 // Button Sizes
 // --------------------------------------------------
 
-.btn-lg {
-  // line-height: ensure even-numbered height of button next to large input
-  .button-size(@padding-large-vertical; @padding-large-horizontal; @font-size-large; @line-height-large; @btn-border-radius-large);
-}
-.btn-sm {
-  // line-height: ensure proper height of button next to small input
-  .button-size(@padding-small-vertical; @padding-small-horizontal; @font-size-small; @line-height-small; @btn-border-radius-small);
-}
-.btn-xs {
-  .button-size(@padding-xs-vertical; @padding-xs-horizontal; @font-size-small; @line-height-small; @btn-border-radius-small);
-}
-
-
-// Block button
-// --------------------------------------------------
-
-.btn-block {
-  display: block;
-  width: 100%;
-}
-
-// Vertically space out multiple block buttons
-.btn-block + .btn-block {
-  margin-top: 5px;
-}
-
-// Specificity overrides
-input[type="submit"],
-input[type="reset"],
-input[type="button"] {
-  &.btn-block {
-    width: 100%;
-  }
-}
-
-
-
-
-// Atom overrides --------------------------------------------------------------------
-// ------------------------------------------------------------------------------------
-
-.btn {
-  color: @text-color;
-  border-radius: @component-border-radius;
-  border: none;
-  text-shadow: none;
-
-  height: @component-line-height + 2px;
-  line-height: @component-line-height;
-
-  padding: 0 @component-padding;
-  font-size: @font-size;
-  z-index: 0;
-
-  background-color: @button-background-color;
-  &:hover {
-    background-color: @button-background-color-hover;
-  }
-  &.selected,
-  &.selected:hover {
-    // we want the selected button to behave like the :hover button; it's on top of the other buttons.
-    z-index: 1;
-    background-color: @button-background-color-selected;
-  }
-}
-
-.btn.btn-xs,
+.btn-xs,
 .btn-group-xs > .btn {
   padding: @component-padding/4 @component-padding/2;
   font-size: @font-size - 2px;
@@ -314,7 +190,7 @@ input[type="button"] {
     font-size: @font-size - 2px;
   }
 }
-.btn.btn-sm,
+.btn-sm,
 .btn-group-sm > .btn {
   padding: @component-padding/4 @component-padding/2;
   height: auto;
@@ -323,7 +199,7 @@ input[type="button"] {
     font-size: @font-size + 1px;
   }
 }
-.btn.btn-lg,
+.btn-lg,
 .btn-group-lg > .btn {
   font-size: @font-size + 2px;
   padding: @component-padding - 2px  @component-padding + 2px;
@@ -351,7 +227,66 @@ input[type="button"] {
   border-bottom-right-radius: @component-border-radius;
 }
 
+
+// Link button
+// -------------------------
+
+// Make a button look and behave like a link
+.btn-link {
+  color: @link-color;
+  font-weight: normal;
+  border-radius: 0;
+  &,
+  &:active,
+  &.active,
+  &[disabled],
+  fieldset[disabled] & {
+    background-color: transparent;
+    box-shadow: none;
+  }
+  &:hover,
+  &:focus {
+    color: @link-hover-color;
+    text-decoration: @link-hover-decoration;
+    background-color: transparent;
+  }
+  &[disabled],
+  fieldset[disabled] & {
+    &:hover,
+    &:focus {
+      color: @btn-link-disabled-color;
+      text-decoration: none;
+    }
+  }
+}
+
+
+// Block button
+// --------------------------------------------------
+
+.btn-block {
+  display: block;
+  width: 100%;
+}
+
+// Vertically space out multiple block buttons
+.btn-block + .btn-block {
+  margin-top: 5px;
+}
+
+// Specificity overrides
+input[type="submit"],
+input[type="reset"],
+input[type="button"] {
+  &.btn-block {
+    width: 100%;
+  }
+}
+
+
 // Icon buttons
+// --------------------------------------------------
+
 .btn.icon {
   &:before {
     width: initial;
@@ -363,8 +298,14 @@ input[type="button"] {
   }
 }
 
+
+// Button Toolbar
+// --------------------------------------------------
+
 .btn-toolbar {
-  > .btn-group + .btn-group, > .btn-group + .btn, > .btn + .btn {
+  > .btn-group + .btn-group,
+  > .btn-group + .btn,
+  > .btn + .btn {
     float: none;
     display: inline-block;
     margin-left: 0;

--- a/static/buttons.less
+++ b/static/buttons.less
@@ -7,35 +7,6 @@
 // --------------------------------------------------
 
 
-// Button variables
-// --------------------------------------------------
-
-@btn-default-color:              @text-color;
-@btn-default-bg:                 @button-background-color;
-
-@btn-primary-color:              #fff;
-@btn-primary-bg:                 @background-color-info;
-
-@btn-success-color:              #fff;
-@btn-success-bg:                 @background-color-success;
-
-@btn-info-color:                 #fff;
-@btn-info-bg:                    @background-color-info;
-
-@btn-warning-color:              #fff;
-@btn-warning-bg:                 @background-color-warning;
-
-@btn-error-color:               #fff;
-@btn-error-bg:                  @background-color-error;
-
-@btn-link-disabled-color:        @text-color-subtle;
-
-// Allows for customizing button radius independently from global border radius
-@btn-border-radius-base:         @component-border-radius;
-@btn-border-radius-large:        @component-border-radius * 2;
-@btn-border-radius-small:        @component-border-radius / 2;
-
-
 // Base styles
 // --------------------------------------------------
 

--- a/static/buttons.less
+++ b/static/buttons.less
@@ -210,23 +210,6 @@
   }
 }
 
-.btn-group > .btn {
-  border-left: 1px solid @button-border-color;
-  border-right: 1px solid @button-border-color;
-}
-.btn-group > .btn:first-child {
-  border-left: none;
-  border-top-left-radius: @component-border-radius;
-  border-bottom-left-radius: @component-border-radius;
-}
-.btn-group > .btn:last-child,
-.btn-group > .btn.selected:last-child,
-.btn-group > .dropdown-toggle {
-  border-right: none;
-  border-top-right-radius: @component-border-radius;
-  border-bottom-right-radius: @component-border-radius;
-}
-
 
 // Link button
 // -------------------------

--- a/static/buttons.less
+++ b/static/buttons.less
@@ -1,4 +1,283 @@
+@import "variables/variables";
 @import "ui-variables";
+@import "mixins/mixins";
+
+
+//
+// Buttons
+// --------------------------------------------------
+
+
+@btn-font-weight:                normal;
+
+@btn-default-color:              #333;
+@btn-default-bg:                 #fff;
+@btn-default-border:             #ccc;
+
+@btn-primary-color:              #fff;
+@btn-primary-bg:                 @brand-primary;
+@btn-primary-border:             darken(@btn-primary-bg, 5%);
+
+@btn-success-color:              #fff;
+@btn-success-bg:                 @brand-success;
+@btn-success-border:             darken(@btn-success-bg, 5%);
+
+@btn-info-color:                 #fff;
+@btn-info-bg:                    @brand-info;
+@btn-info-border:                darken(@btn-info-bg, 5%);
+
+@btn-warning-color:              #fff;
+@btn-warning-bg:                 @brand-warning;
+@btn-warning-border:             darken(@btn-warning-bg, 5%);
+
+@btn-danger-color:               #fff;
+@btn-danger-bg:                  @brand-danger;
+@btn-danger-border:              darken(@btn-danger-bg, 5%);
+
+@btn-link-disabled-color:        @gray-light;
+
+// Allows for customizing button radius independently from global border radius
+@btn-border-radius-base:         @component-border-radius;
+@btn-border-radius-large:        @component-border-radius * 2;
+@btn-border-radius-small:        @component-border-radius / 2;
+
+
+
+// Button variants
+//
+// Easily pump out default styles, as well as :hover, :focus, :active,
+// and disabled options for all buttons
+
+.button-variant(@color; @background; @border) {
+  color: @color;
+  background-color: @background;
+  border-color: @border;
+
+  &:focus,
+  &.focus {
+    color: @color;
+    background-color: darken(@background, 10%);
+        border-color: darken(@border, 25%);
+  }
+  &:hover {
+    color: @color;
+    background-color: darken(@background, 10%);
+        border-color: darken(@border, 12%);
+  }
+  &:active,
+  &.active,
+  .open > .dropdown-toggle& {
+    color: @color;
+    background-color: darken(@background, 10%);
+        border-color: darken(@border, 12%);
+
+    &:hover,
+    &:focus,
+    &.focus {
+      color: @color;
+      background-color: darken(@background, 17%);
+          border-color: darken(@border, 25%);
+    }
+  }
+  &:active,
+  &.active,
+  .open > .dropdown-toggle& {
+    background-image: none;
+  }
+  &.disabled,
+  &[disabled],
+  fieldset[disabled] & {
+    &:hover,
+    &:focus,
+    &.focus {
+      background-color: @background;
+          border-color: @border;
+    }
+  }
+
+  .badge {
+    color: @background;
+    background-color: @color;
+  }
+}
+
+// Button sizes
+.button-size(@padding-vertical; @padding-horizontal; @font-size; @line-height; @border-radius) {
+  padding: @padding-vertical @padding-horizontal;
+  font-size: @font-size;
+  line-height: @line-height;
+  border-radius: @border-radius;
+}
+
+
+
+// Base styles
+// --------------------------------------------------
+
+.btn {
+  display: inline-block;
+  margin-bottom: 0; // For input.btn
+  font-weight: @btn-font-weight;
+  text-align: center;
+  vertical-align: middle;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
+  border: 1px solid transparent;
+  white-space: nowrap;
+  -webkit-user-select: none;
+  .button-size(@padding-base-vertical; @padding-base-horizontal; @font-size-base; @line-height-base; @btn-border-radius-base);
+
+  &,
+  &:active,
+  &.active {
+    &:focus,
+    &.focus {
+      .tab-focus();
+    }
+  }
+
+  &:hover,
+  &:focus,
+  &.focus {
+    color: @btn-default-color;
+    text-decoration: none;
+  }
+
+  &:active,
+  &.active {
+    outline: 0;
+    background-image: none;
+    box-shadow: inset 0 3px 5px rgba(0,0,0,.125);
+  }
+
+  &.disabled,
+  &[disabled],
+  fieldset[disabled] & {
+    cursor: @cursor-disabled;
+    opacity: .65;
+    box-shadow: none;
+  }
+
+  a& {
+    &.disabled,
+    fieldset[disabled] & {
+      pointer-events: none; // Future-proof disabling of clicks on `<a>` elements
+    }
+  }
+}
+
+
+// Alternate buttons
+// --------------------------------------------------
+
+.btn-default {
+  .button-variant(@btn-default-color; @btn-default-bg; @btn-default-border);
+}
+.btn-primary {
+  .button-variant(@btn-primary-color; @btn-primary-bg; @btn-primary-border);
+}
+// Success appears as green
+.btn-success {
+  .button-variant(@btn-success-color; @btn-success-bg; @btn-success-border);
+}
+// Info appears as blue-green
+.btn-info {
+  .button-variant(@btn-info-color; @btn-info-bg; @btn-info-border);
+}
+// Warning appears as orange
+.btn-warning {
+  .button-variant(@btn-warning-color; @btn-warning-bg; @btn-warning-border);
+}
+// Danger and error appear as red
+.btn-danger {
+  .button-variant(@btn-danger-color; @btn-danger-bg; @btn-danger-border);
+}
+
+
+// Link buttons
+// -------------------------
+
+// Make a button look and behave like a link
+.btn-link {
+  color: @link-color;
+  font-weight: normal;
+  border-radius: 0;
+
+  &,
+  &:active,
+  &.active,
+  &[disabled],
+  fieldset[disabled] & {
+    background-color: transparent;
+    box-shadow: none;
+  }
+  &,
+  &:hover,
+  &:focus,
+  &:active {
+    border-color: transparent;
+  }
+  &:hover,
+  &:focus {
+    color: @link-hover-color;
+    text-decoration: @link-hover-decoration;
+    background-color: transparent;
+  }
+  &[disabled],
+  fieldset[disabled] & {
+    &:hover,
+    &:focus {
+      color: @btn-link-disabled-color;
+      text-decoration: none;
+    }
+  }
+}
+
+
+// Button Sizes
+// --------------------------------------------------
+
+.btn-lg {
+  // line-height: ensure even-numbered height of button next to large input
+  .button-size(@padding-large-vertical; @padding-large-horizontal; @font-size-large; @line-height-large; @btn-border-radius-large);
+}
+.btn-sm {
+  // line-height: ensure proper height of button next to small input
+  .button-size(@padding-small-vertical; @padding-small-horizontal; @font-size-small; @line-height-small; @btn-border-radius-small);
+}
+.btn-xs {
+  .button-size(@padding-xs-vertical; @padding-xs-horizontal; @font-size-small; @line-height-small; @btn-border-radius-small);
+}
+
+
+// Block button
+// --------------------------------------------------
+
+.btn-block {
+  display: block;
+  width: 100%;
+}
+
+// Vertically space out multiple block buttons
+.btn-block + .btn-block {
+  margin-top: 5px;
+}
+
+// Specificity overrides
+input[type="submit"],
+input[type="reset"],
+input[type="button"] {
+  &.btn-block {
+    width: 100%;
+  }
+}
+
+
+
+
+// Atom overrides --------------------------------------------------------------------
+// ------------------------------------------------------------------------------------
 
 .btn {
   color: @text-color;

--- a/static/code.less
+++ b/static/code.less
@@ -1,0 +1,74 @@
+//
+// Code (inline and block)
+// --------------------------------------------------
+
+@code-color: @text-color-highlight;
+@code-bg: @background-color-highlight;
+
+@pre-color:                   @code-color;
+@pre-bg:                      @code-bg;
+@pre-border-color:            @base-border-color;
+@pre-scrollable-max-height:   340px;
+
+// Inline and block code styles
+code,
+kbd,
+pre,
+samp {
+  font-family: @font-family-monospace;
+}
+
+// Inline code
+code {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: @code-color;
+  background-color: @code-bg;
+  border-radius: @border-radius-base;
+}
+
+// User input typically entered via keyboard
+kbd {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: @code-color;
+  background-color: @code-bg;
+  border-radius: @border-radius-small;
+
+  kbd {
+    padding: 0;
+    font-size: 100%;
+    font-weight: bold;
+  }
+}
+
+// Blocks of code
+pre {
+  display: block;
+  padding: ((@line-height-computed - 1) / 2);
+  margin: 0 0 (@line-height-computed / 2);
+  font-size: (@font-size-base - 1); // 14px to 13px
+  line-height: @line-height-base;
+  word-break: break-all;
+  word-wrap: break-word;
+  color: @pre-color;
+  background-color: @pre-bg;
+  border: 1px solid @pre-border-color;
+  border-radius: @border-radius-base;
+
+  // Account for some code outputs that place code tags in pre tags
+  code {
+    padding: 0;
+    font-size: inherit;
+    color: inherit;
+    white-space: pre-wrap;
+    background-color: transparent;
+    border-radius: 0;
+  }
+}
+
+// Enable scrollable blocks of code
+.pre-scrollable {
+  max-height: @pre-scrollable-max-height;
+  overflow-y: scroll;
+}

--- a/static/code.less
+++ b/static/code.less
@@ -1,3 +1,6 @@
+@import "variables/variables";
+@import "ui-variables";
+
 //
 // Code (inline and block)
 // --------------------------------------------------

--- a/static/forms.less
+++ b/static/forms.less
@@ -1,0 +1,767 @@
+@import "variables/variables";
+@import "ui-variables";
+@import "mixins/mixins";
+
+//
+// Forms
+// --------------------------------------------------
+
+//** `<input>` background color
+@input-bg:                       #fff;
+//** `<input disabled>` background color
+@input-bg-disabled:              @gray-lighter;
+
+//** Text color for `<input>`s
+@input-color:                    @gray;
+//** `<input>` border color
+@input-border:                   #ccc;
+
+// TODO: Rename `@input-border-radius` to `@input-border-radius-base` in v4
+//** Default `.form-control` border radius
+// This has no effect on `<select>`s in some browsers, due to the limited stylability of `<select>`s in CSS.
+@input-border-radius:            @border-radius-base;
+//** Large `.form-control` border radius
+@input-border-radius-large:      @border-radius-large;
+//** Small `.form-control` border radius
+@input-border-radius-small:      @border-radius-small;
+
+//** Border color for inputs on focus
+@input-border-focus:             #66afe9;
+
+//** Placeholder text color
+@input-color-placeholder:        #999;
+
+//** Default `.form-control` height
+@input-height-base:              (@line-height-computed + (@padding-base-vertical * 2) + 2);
+//** Large `.form-control` height
+@input-height-large:             (ceil(@font-size-large * @line-height-large) + (@padding-large-vertical * 2) + 2);
+//** Small `.form-control` height
+@input-height-small:             (floor(@font-size-small * @line-height-small) + (@padding-small-vertical * 2) + 2);
+
+//** `.form-group` margin
+@form-group-margin-bottom:       15px;
+
+@legend-color:                   @gray-dark;
+@legend-border-color:            #e5e5e5;
+
+//** Background color for textual input addons
+@input-group-addon-bg:           @gray-lighter;
+//** Border color for textual input addons
+@input-group-addon-border-color: @input-border;
+
+//** Disabled cursor for form controls and buttons.
+@cursor-disabled:                not-allowed;
+
+//** Padding between columns. Gets divided in half for the left and right.
+@grid-gutter-width:         30px;
+
+
+// Form validation states
+//
+// Used in forms.less to generate the form validation CSS for warnings, errors,
+// and successes.
+
+.form-control-validation(@text-color: #555; @border-color: #ccc; @background-color: #f5f5f5) {
+  // Color the label and help text
+  .help-block,
+  .control-label,
+  .radio,
+  .checkbox,
+  .radio-inline,
+  .checkbox-inline,
+  &.radio label,
+  &.checkbox label,
+  &.radio-inline label,
+  &.checkbox-inline label  {
+    color: @text-color;
+  }
+  // Set the border and box shadow on specific inputs to match
+  .form-control {
+    border-color: @border-color;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075); // Redeclare so transitions work
+    &:focus {
+      border-color: darken(@border-color, 10%);
+      box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 6px lighten(@border-color, 20%);
+    }
+  }
+  // Set validation states also for addons
+  .input-group-addon {
+    color: @text-color;
+    border-color: @border-color;
+    background-color: @background-color;
+  }
+  // Optional feedback icon
+  .form-control-feedback {
+    color: @text-color;
+  }
+}
+
+
+// Form control focus state
+//
+// Generate a customized focus state and for any input with the specified color,
+// which defaults to the `@input-border-focus` variable.
+//
+// We highly encourage you to not customize the default value, but instead use
+// this to tweak colors on an as-needed basis. This aesthetic change is based on
+// WebKit's default styles, but applicable to a wider range of browsers. Its
+// usability and accessibility should be taken into account with any change.
+//
+// Example usage: change the default blue border and shadow to white for better
+// contrast against a dark gray background.
+.form-control-focus(@color: @input-border-focus) {
+  @color-rgba: rgba(red(@color), green(@color), blue(@color), .6);
+  &:focus {
+    border-color: @color;
+    outline: 0;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px @color-rgba;
+  }
+}
+
+// Form control sizing
+//
+// Relative text size, padding, and border-radii changes for form controls. For
+// horizontal sizing, wrap controls in the predefined grid classes. `<select>`
+// element gets special love because it's special, and that's a fact!
+.input-size(@input-height; @padding-vertical; @padding-horizontal; @font-size; @line-height; @border-radius) {
+  height: @input-height;
+  padding: @padding-vertical @padding-horizontal;
+  font-size: @font-size;
+  line-height: @line-height;
+  border-radius: @border-radius;
+
+  select& {
+    height: @input-height;
+    line-height: @input-height;
+  }
+
+  textarea&,
+  select[multiple]& {
+    height: auto;
+  }
+}
+
+// Placeholder text
+.placeholder(@color: @input-color-placeholder) {
+  &::-webkit-input-placeholder  { color: @color; } // Safari and Chrome
+}
+
+// Creates a wrapper for a series of columns
+.make-row(@gutter: @grid-gutter-width) {
+  margin-left:  ceil((@gutter / -2));
+  margin-right: floor((@gutter / -2));
+  &:extend(.clearfix all);
+}
+
+
+// -----------------------------------------------------
+
+
+// Normalize non-controls
+//
+// Restyle and baseline non-control form elements.
+
+fieldset {
+  padding: 0;
+  margin: 0;
+  border: 0;
+  // Chrome and Firefox set a `min-width: min-content;` on fieldsets,
+  // so we reset that to ensure it behaves more like a standard block element.
+  // See https://github.com/twbs/bootstrap/issues/12359.
+  min-width: 0;
+}
+
+legend {
+  display: block;
+  width: 100%;
+  padding: 0;
+  margin-bottom: @line-height-computed;
+  font-size: (@font-size-base * 1.5);
+  line-height: inherit;
+  color: @legend-color;
+  border: 0;
+  border-bottom: 1px solid @legend-border-color;
+}
+
+label {
+  display: inline-block;
+  max-width: 100%; // Force IE8 to wrap long content (see https://github.com/twbs/bootstrap/issues/13141)
+  margin-bottom: 5px;
+  font-weight: bold;
+}
+
+
+// Normalize form controls
+//
+// While most of our form styles require extra classes, some basic normalization
+// is required to ensure optimum display with or without those classes to better
+// address browser inconsistencies.
+
+// Override content-box in Normalize (* isn't specific enough)
+input[type="search"] {
+  box-sizing: border-box;
+}
+
+// Position radios and checkboxes better
+input[type="radio"],
+input[type="checkbox"] {
+  margin: 4px 0 0;
+  margin-top: 1px \9; // IE8-9
+  line-height: normal;
+}
+
+input[type="file"] {
+  display: block;
+}
+
+// Make range inputs behave like textual form controls
+input[type="range"] {
+  display: block;
+  width: 100%;
+}
+
+// Make multiple select elements height not fixed
+select[multiple],
+select[size] {
+  height: auto;
+}
+
+// Focus for file, radio, and checkbox
+input[type="file"]:focus,
+input[type="radio"]:focus,
+input[type="checkbox"]:focus {
+  .tab-focus();
+}
+
+// Adjust output element
+output {
+  display: block;
+  padding-top: (@padding-base-vertical + 1);
+  font-size: @font-size-base;
+  line-height: @line-height-base;
+  color: @input-color;
+}
+
+
+// Common form controls
+//
+// Shared size and type resets for form controls. Apply `.form-control` to any
+// of the following form controls:
+//
+// select
+// textarea
+// input[type="text"]
+// input[type="password"]
+// input[type="datetime"]
+// input[type="datetime-local"]
+// input[type="date"]
+// input[type="month"]
+// input[type="time"]
+// input[type="week"]
+// input[type="number"]
+// input[type="email"]
+// input[type="url"]
+// input[type="search"]
+// input[type="tel"]
+// input[type="color"]
+
+.form-control {
+  display: block;
+  width: 100%;
+  height: @input-height-base; // Make inputs at least the height of their button counterpart (base line-height + padding + border)
+  padding: @padding-base-vertical @padding-base-horizontal;
+  font-size: @font-size-base;
+  line-height: @line-height-base;
+  color: @input-color;
+  background-color: @input-bg;
+  background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
+  border: 1px solid @input-border;
+  border-radius: @input-border-radius; // Note: This has no effect on <select>s in some browsers, due to the limited stylability of <select>s in CSS.
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+
+  // Customize the `:focus` state to imitate native WebKit styles.
+  .form-control-focus();
+
+  // Placeholder
+  .placeholder();
+
+  // Unstyle the caret on `<select>`s in IE10+.
+  &::-ms-expand {
+    border: 0;
+    background-color: transparent;
+  }
+
+  // Disabled and read-only inputs
+  //
+  // HTML5 says that controls under a fieldset > legend:first-child won't be
+  // disabled if the fieldset is disabled. Due to implementation difficulty, we
+  // don't honor that edge case; we style them as disabled anyway.
+  &[disabled],
+  &[readonly],
+  fieldset[disabled] & {
+    background-color: @input-bg-disabled;
+    opacity: 1; // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655
+  }
+
+  &[disabled],
+  fieldset[disabled] & {
+    cursor: @cursor-disabled;
+  }
+
+  // Reset height for `textarea`s
+  textarea& {
+    height: auto;
+  }
+}
+
+
+// Search inputs in iOS
+//
+// This overrides the extra rounded corners on search inputs in iOS so that our
+// `.form-control` class can properly style them. Note that this cannot simply
+// be added to `.form-control` as it's not specific enough. For details, see
+// https://github.com/twbs/bootstrap/issues/11586.
+
+input[type="search"] {
+  -webkit-appearance: none;
+}
+
+
+// Special styles for iOS temporal inputs
+//
+// In Mobile Safari, setting `display: block` on temporal inputs causes the
+// text within the input to become vertically misaligned. As a workaround, we
+// set a pixel line-height that matches the given height of the input, but only
+// for Safari. See https://bugs.webkit.org/show_bug.cgi?id=139848
+//
+// Note that as of 8.3, iOS doesn't support `datetime` or `week`.
+
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  input[type="date"],
+  input[type="time"],
+  input[type="datetime-local"],
+  input[type="month"] {
+    &.form-control {
+      line-height: @input-height-base;
+    }
+
+    &.input-sm,
+    .input-group-sm & {
+      line-height: @input-height-small;
+    }
+
+    &.input-lg,
+    .input-group-lg & {
+      line-height: @input-height-large;
+    }
+  }
+}
+
+
+// Form groups
+//
+// Designed to help with the organization and spacing of vertical forms. For
+// horizontal forms, use the predefined grid classes.
+
+.form-group {
+  margin-bottom: @form-group-margin-bottom;
+}
+
+
+// Checkboxes and radios
+//
+// Indent the labels to position radios/checkboxes as hanging controls.
+
+.radio,
+.checkbox {
+  position: relative;
+  display: block;
+  margin-top: 10px;
+  margin-bottom: 10px;
+
+  label {
+    min-height: @line-height-computed; // Ensure the input doesn't jump when there is no text
+    padding-left: 20px;
+    margin-bottom: 0;
+    font-weight: normal;
+    cursor: pointer;
+  }
+}
+.radio input[type="radio"],
+.radio-inline input[type="radio"],
+.checkbox input[type="checkbox"],
+.checkbox-inline input[type="checkbox"] {
+  position: absolute;
+  margin-left: -20px;
+  margin-top: 4px \9;
+}
+
+.radio + .radio,
+.checkbox + .checkbox {
+  margin-top: -5px; // Move up sibling radios or checkboxes for tighter spacing
+}
+
+// Radios and checkboxes on same line
+.radio-inline,
+.checkbox-inline {
+  position: relative;
+  display: inline-block;
+  padding-left: 20px;
+  margin-bottom: 0;
+  vertical-align: middle;
+  font-weight: normal;
+  cursor: pointer;
+}
+.radio-inline + .radio-inline,
+.checkbox-inline + .checkbox-inline {
+  margin-top: 0;
+  margin-left: 10px; // space out consecutive inline controls
+}
+
+// Apply same disabled cursor tweak as for inputs
+// Some special care is needed because <label>s don't inherit their parent's `cursor`.
+//
+// Note: Neither radios nor checkboxes can be readonly.
+input[type="radio"],
+input[type="checkbox"] {
+  &[disabled],
+  &.disabled,
+  fieldset[disabled] & {
+    cursor: @cursor-disabled;
+  }
+}
+// These classes are used directly on <label>s
+.radio-inline,
+.checkbox-inline {
+  &.disabled,
+  fieldset[disabled] & {
+    cursor: @cursor-disabled;
+  }
+}
+// These classes are used on elements with <label> descendants
+.radio,
+.checkbox {
+  &.disabled,
+  fieldset[disabled] & {
+    label {
+      cursor: @cursor-disabled;
+    }
+  }
+}
+
+
+// Static form control text
+//
+// Apply class to a `p` element to make any string of text align with labels in
+// a horizontal form layout.
+
+.form-control-static {
+  // Size it appropriately next to real form controls
+  padding-top: (@padding-base-vertical + 1);
+  padding-bottom: (@padding-base-vertical + 1);
+  // Remove default margin from `p`
+  margin-bottom: 0;
+  min-height: (@line-height-computed + @font-size-base);
+
+  &.input-lg,
+  &.input-sm {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+
+// Form control sizing
+//
+// Build on `.form-control` with modifier classes to decrease or increase the
+// height and font-size of form controls.
+//
+// The `.form-group-* form-control` variations are sadly duplicated to avoid the
+// issue documented in https://github.com/twbs/bootstrap/issues/15074.
+
+.input-sm {
+  .input-size(@input-height-small; @padding-small-vertical; @padding-small-horizontal; @font-size-small; @line-height-small; @input-border-radius-small);
+}
+.form-group-sm {
+  .form-control {
+    height: @input-height-small;
+    padding: @padding-small-vertical @padding-small-horizontal;
+    font-size: @font-size-small;
+    line-height: @line-height-small;
+    border-radius: @input-border-radius-small;
+  }
+  select.form-control {
+    height: @input-height-small;
+    line-height: @input-height-small;
+  }
+  textarea.form-control,
+  select[multiple].form-control {
+    height: auto;
+  }
+  .form-control-static {
+    height: @input-height-small;
+    min-height: (@line-height-computed + @font-size-small);
+    padding: (@padding-small-vertical + 1) @padding-small-horizontal;
+    font-size: @font-size-small;
+    line-height: @line-height-small;
+  }
+}
+
+.input-lg {
+  .input-size(@input-height-large; @padding-large-vertical; @padding-large-horizontal; @font-size-large; @line-height-large; @input-border-radius-large);
+}
+.form-group-lg {
+  .form-control {
+    height: @input-height-large;
+    padding: @padding-large-vertical @padding-large-horizontal;
+    font-size: @font-size-large;
+    line-height: @line-height-large;
+    border-radius: @input-border-radius-large;
+  }
+  select.form-control {
+    height: @input-height-large;
+    line-height: @input-height-large;
+  }
+  textarea.form-control,
+  select[multiple].form-control {
+    height: auto;
+  }
+  .form-control-static {
+    height: @input-height-large;
+    min-height: (@line-height-computed + @font-size-large);
+    padding: (@padding-large-vertical + 1) @padding-large-horizontal;
+    font-size: @font-size-large;
+    line-height: @line-height-large;
+  }
+}
+
+
+// Form control feedback states
+//
+// Apply contextual and semantic states to individual form controls.
+
+.has-feedback {
+  // Enable absolute positioning
+  position: relative;
+
+  // Ensure icons don't overlap text
+  .form-control {
+    padding-right: (@input-height-base * 1.25);
+  }
+}
+// Feedback icon (requires .glyphicon classes)
+.form-control-feedback {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2; // Ensure icon is above input groups
+  display: block;
+  width: @input-height-base;
+  height: @input-height-base;
+  line-height: @input-height-base;
+  text-align: center;
+  pointer-events: none;
+}
+.input-lg + .form-control-feedback,
+.input-group-lg + .form-control-feedback,
+.form-group-lg .form-control + .form-control-feedback {
+  width: @input-height-large;
+  height: @input-height-large;
+  line-height: @input-height-large;
+}
+.input-sm + .form-control-feedback,
+.input-group-sm + .form-control-feedback,
+.form-group-sm .form-control + .form-control-feedback {
+  width: @input-height-small;
+  height: @input-height-small;
+  line-height: @input-height-small;
+}
+
+// Feedback states
+.has-success {
+  .form-control-validation(@state-success-text; @state-success-text; @state-success-bg);
+}
+.has-warning {
+  .form-control-validation(@state-warning-text; @state-warning-text; @state-warning-bg);
+}
+.has-error {
+  .form-control-validation(@state-danger-text; @state-danger-text; @state-danger-bg);
+}
+
+// Reposition feedback icon if input has visible label above
+.has-feedback label {
+
+  & ~ .form-control-feedback {
+    top: (@line-height-computed + 5); // Height of the `label` and its margin
+  }
+  &.sr-only ~ .form-control-feedback {
+    top: 0;
+  }
+}
+
+
+// Help text
+//
+// Apply to any element you wish to create light text for placement immediately
+// below a form control. Use for general help, formatting, or instructional text.
+
+.help-block {
+  display: block; // account for any element using help-block
+  margin-top: 5px;
+  margin-bottom: 10px;
+  color: lighten(@text-color, 25%); // lighten the text some for contrast
+}
+
+
+// Inline forms
+//
+// Make forms appear inline(-block) by adding the `.form-inline` class. Inline
+// forms begin stacked on extra small (mobile) devices and then go inline when
+// viewports reach <768px.
+//
+// Requires wrapping inputs and labels with `.form-group` for proper display of
+// default HTML form controls and our custom form controls (e.g., input groups).
+//
+// Heads up! This is mixin-ed into `.navbar-form` in navbars.less.
+
+.form-inline {
+
+  // Kick in the inline
+  @media (min-width: @screen-sm-min) {
+    // Inline-block all the things for "inline"
+    .form-group {
+      display: inline-block;
+      margin-bottom: 0;
+      vertical-align: middle;
+    }
+
+    // In navbar-form, allow folks to *not* use `.form-group`
+    .form-control {
+      display: inline-block;
+      width: auto; // Prevent labels from stacking above inputs in `.form-group`
+      vertical-align: middle;
+    }
+
+    // Make static controls behave like regular ones
+    .form-control-static {
+      display: inline-block;
+    }
+
+    .input-group {
+      display: inline-table;
+      vertical-align: middle;
+
+      .input-group-addon,
+      .input-group-btn,
+      .form-control {
+        width: auto;
+      }
+    }
+
+    // Input groups need that 100% width though
+    .input-group > .form-control {
+      width: 100%;
+    }
+
+    .control-label {
+      margin-bottom: 0;
+      vertical-align: middle;
+    }
+
+    // Remove default margin on radios/checkboxes that were used for stacking, and
+    // then undo the floating of radios and checkboxes to match.
+    .radio,
+    .checkbox {
+      display: inline-block;
+      margin-top: 0;
+      margin-bottom: 0;
+      vertical-align: middle;
+
+      label {
+        padding-left: 0;
+      }
+    }
+    .radio input[type="radio"],
+    .checkbox input[type="checkbox"] {
+      position: relative;
+      margin-left: 0;
+    }
+
+    // Re-override the feedback icon.
+    .has-feedback .form-control-feedback {
+      top: 0;
+    }
+  }
+}
+
+
+// Horizontal forms
+//
+// Horizontal forms are built on grid classes and allow you to create forms with
+// labels on the left and inputs on the right.
+
+.form-horizontal {
+
+  // Consistent vertical alignment of radios and checkboxes
+  //
+  // Labels also get some reset styles, but that is scoped to a media query below.
+  .radio,
+  .checkbox,
+  .radio-inline,
+  .checkbox-inline {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-top: (@padding-base-vertical + 1); // Default padding plus a border
+  }
+  // Account for padding we're adding to ensure the alignment and of help text
+  // and other content below items
+  .radio,
+  .checkbox {
+    min-height: (@line-height-computed + (@padding-base-vertical + 1));
+  }
+
+  // Make form groups behave like rows
+  .form-group {
+    .make-row();
+  }
+
+  // Reset spacing and right align labels, but scope to media queries so that
+  // labels on narrow viewports stack the same as a default form example.
+  @media (min-width: @screen-sm-min) {
+    .control-label {
+      text-align: right;
+      margin-bottom: 0;
+      padding-top: (@padding-base-vertical + 1); // Default padding plus a border
+    }
+  }
+
+  // Validation states
+  //
+  // Reposition the icon because it's now within a grid column and columns have
+  // `position: relative;` on them. Also accounts for the grid gutter padding.
+  .has-feedback .form-control-feedback {
+    right: floor((@grid-gutter-width / 2));
+  }
+
+  // Form group sizes
+  //
+  // Quick utility class for applying `.input-lg` and `.input-sm` styles to the
+  // inputs and labels within a `.form-group`.
+  .form-group-lg {
+    @media (min-width: @screen-sm-min) {
+      .control-label {
+        padding-top: (@padding-large-vertical + 1);
+        font-size: @font-size-large;
+      }
+    }
+  }
+  .form-group-sm {
+    @media (min-width: @screen-sm-min) {
+      .control-label {
+        padding-top: (@padding-small-vertical + 1);
+        font-size: @font-size-small;
+      }
+    }
+  }
+}

--- a/static/icons.less
+++ b/static/icons.less
@@ -4,8 +4,7 @@
   margin-right: @component-icon-padding;
 }
 
-a.icon,
-button.icon {
+a.icon {
   text-decoration: none;
   color: @text-color;
   &:hover{

--- a/static/lists.less
+++ b/static/lists.less
@@ -1,4 +1,7 @@
+@import "variables/variables";
 @import "ui-variables";
+@import "mixins/mixins";
+
 @import "octicon-mixins";
 
 

--- a/static/lists.less
+++ b/static/lists.less
@@ -1,7 +1,165 @@
 @import "ui-variables";
 @import "octicon-mixins";
 
+
+
+//
+// List groups
+// --------------------------------------------------
+
+// Mixins
+
+.list-group-item-variant(@state; @background; @color) {
+  .list-group-item-@{state} {
+    color: @color;
+    background-color: @background;
+
+    a&,
+    button& {
+      color: @color;
+
+      .list-group-item-heading {
+        color: inherit;
+      }
+
+      &:hover,
+      &:focus {
+        color: @color;
+        background-color: darken(@background, 5%);
+      }
+      &.active,
+      &.active:hover,
+      &.active:focus {
+        color: #fff;
+        background-color: @color;
+        border-color: @color;
+      }
+    }
+  }
+}
+
+
+
+// Individual list items
+//
+// Use on `li`s or `div`s within the `.list-group` parent.
+
+.list-group-item {
+  position: relative;
+  display: block;
+  padding: 10px 15px;
+  // Place the border on the list items and negative margin up for better styling
+  margin-bottom: -1px;
+  background-color: @list-group-bg;
+  border: 1px solid @list-group-border;
+
+  // Round the first and last items
+  &:first-child {
+    .border-top-radius(@list-group-border-radius);
+  }
+  &:last-child {
+    margin-bottom: 0;
+    .border-bottom-radius(@list-group-border-radius);
+  }
+}
+
+
+// Interactive list items
+//
+// Use anchor or button elements instead of `li`s or `div`s to create interactive items.
+// Includes an extra `.active` modifier class for showing selected items.
+
+a.list-group-item,
+button.list-group-item {
+  color: @list-group-link-color;
+
+  .list-group-item-heading {
+    color: @list-group-link-heading-color;
+  }
+
+  // Hover state
+  &:hover,
+  &:focus {
+    text-decoration: none;
+    color: @list-group-link-hover-color;
+    background-color: @list-group-hover-bg;
+  }
+}
+
+button.list-group-item {
+  width: 100%;
+  text-align: left;
+}
+
+.list-group-item {
+  // Disabled state
+  &.disabled,
+  &.disabled:hover,
+  &.disabled:focus {
+    background-color: @list-group-disabled-bg;
+    color: @list-group-disabled-color;
+    cursor: @cursor-disabled;
+
+    // Force color to inherit for custom content
+    .list-group-item-heading {
+      color: inherit;
+    }
+    .list-group-item-text {
+      color: @list-group-disabled-text-color;
+    }
+  }
+
+  // Active class on item itself, not parent
+  &.active,
+  &.active:hover,
+  &.active:focus {
+    z-index: 2; // Place active items above their siblings for proper border styling
+    color: @list-group-active-color;
+    background-color: @list-group-active-bg;
+    border-color: @list-group-active-border;
+
+    // Force color to inherit for custom content
+    .list-group-item-heading,
+    .list-group-item-heading > small,
+    .list-group-item-heading > .small {
+      color: inherit;
+    }
+    .list-group-item-text {
+      color: @list-group-active-text-color;
+    }
+  }
+}
+
+
+// Contextual variants
+//
+// Add modifier classes to change text and background color on individual items.
+// Organizationally, this must come after the `:hover` states.
+
+.list-group-item-variant(success; @state-success-bg; @state-success-text);
+.list-group-item-variant(info; @state-info-bg; @state-info-text);
+.list-group-item-variant(warning; @state-warning-bg; @state-warning-text);
+.list-group-item-variant(danger; @state-danger-bg; @state-danger-text);
+
+
+// Custom content options
+//
+// Extra classes for creating well-formatted content within `.list-group-item`s.
+
+.list-group-item-heading {
+  margin-top: 0;
+  margin-bottom: 5px;
+}
+.list-group-item-text {
+  margin-bottom: 0;
+  line-height: 1.3;
+}
+
+
+
 // This is a bootstrap override
+// ---------------------------------------------
+
 .list-group,
 .list-group .list-group-item {
   background-color: transparent;

--- a/static/mixins/mixins.less
+++ b/static/mixins/mixins.less
@@ -2,14 +2,16 @@
 // Core mixins
 // ----------------------------------------
 
+// Focus
+//
 .tab-focus() {
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
 
 
-// Border-radius ----------------------------
-
+// Border-radius
+//
 .border-top-radius(@radius) {
   border-top-right-radius: @radius;
    border-top-left-radius: @radius;
@@ -25,4 +27,13 @@
 .border-left-radius(@radius) {
   border-bottom-left-radius: @radius;
      border-top-left-radius: @radius;
+}
+
+// Responsive image
+//
+// Keep images from scaling beyond the width of their parents.
+.img-responsive(@display: block) {
+  display: @display;
+  max-width: 100%; // Part 1: Set a maximum relative to the parent
+  height: auto; // Part 2: Scale the height according to the width, otherwise you get stretching
 }

--- a/static/mixins/mixins.less
+++ b/static/mixins/mixins.less
@@ -37,3 +37,50 @@
   max-width: 100%; // Part 1: Set a maximum relative to the parent
   height: auto; // Part 2: Scale the height according to the width, otherwise you get stretching
 }
+
+
+// Clearfix
+//
+// For modern browsers
+// 1. The space content is one way to avoid an Opera bug when the
+//    contenteditable attribute is included anywhere else in the document.
+//    Otherwise it causes space to appear at the top and bottom of elements
+//    that are clearfixed.
+// 2. The use of `table` rather than `block` is only necessary if using
+//    `:before` to contain the top-margins of child elements.
+//
+// Source: http://nicolasgallagher.com/micro-clearfix-hack/
+
+.clearfix() {
+  &:before,
+  &:after {
+    content: " "; // 1
+    display: table; // 2
+  }
+  &:after {
+    clear: both;
+  }
+}
+
+
+// CSS image replacement
+//
+// Heads up! v3 launched with only `.hide-text()`, but per our pattern for
+// mixins being reused as classes with the same name, this doesn't hold up. As
+// of v3.0.1 we have added `.text-hide()` and deprecated `.hide-text()`.
+//
+// Source: https://github.com/h5bp/html5-boilerplate/commit/aa0396eae757
+
+// Deprecated as of v3.0.1 (has been removed in v4)
+.hide-text() {
+  font: ~"0/0" a;
+  color: transparent;
+  text-shadow: none;
+  background-color: transparent;
+  border: 0;
+}
+
+// New mixin to use as of v3.0.1
+.text-hide() {
+  .hide-text();
+}

--- a/static/mixins/mixins.less
+++ b/static/mixins/mixins.less
@@ -1,0 +1,8 @@
+
+// Core mixins
+// ----------------------------------------
+
+.tab-focus() {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}

--- a/static/mixins/mixins.less
+++ b/static/mixins/mixins.less
@@ -84,3 +84,13 @@
 .text-hide() {
   .hide-text();
 }
+
+
+// Text overflow
+// Requires inline-block or block for proper styling
+
+.text-overflow() {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/static/mixins/mixins.less
+++ b/static/mixins/mixins.less
@@ -6,3 +6,23 @@
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
+
+
+// Border-radius ----------------------------
+
+.border-top-radius(@radius) {
+  border-top-right-radius: @radius;
+   border-top-left-radius: @radius;
+}
+.border-right-radius(@radius) {
+  border-bottom-right-radius: @radius;
+     border-top-right-radius: @radius;
+}
+.border-bottom-radius(@radius) {
+  border-bottom-right-radius: @radius;
+   border-bottom-left-radius: @radius;
+}
+.border-left-radius(@radius) {
+  border-bottom-left-radius: @radius;
+     border-top-left-radius: @radius;
+}

--- a/static/navs.less
+++ b/static/navs.less
@@ -1,3 +1,7 @@
+@import "variables/variables";
+@import "ui-variables";
+@import "mixins/mixins";
+
 //
 // Navs
 // --------------------------------------------------

--- a/static/navs.less
+++ b/static/navs.less
@@ -1,0 +1,275 @@
+//
+// Navs
+// --------------------------------------------------
+
+//=== Shared nav styles
+@nav-link-padding:                          10px 15px;
+@nav-link-hover-bg:                         @gray-lighter;
+
+@nav-disabled-link-color:                   @gray-light;
+@nav-disabled-link-hover-color:             @gray-light;
+
+//== Tabs
+@nav-tabs-border-color:                     #ddd;
+
+@nav-tabs-link-hover-border-color:          @gray-lighter;
+
+@nav-tabs-active-link-hover-bg:             @body-bg;
+@nav-tabs-active-link-hover-color:          @gray;
+@nav-tabs-active-link-hover-border-color:   #ddd;
+
+@nav-tabs-justified-link-border-color:            #ddd;
+@nav-tabs-justified-active-link-border-color:     @body-bg;
+
+//== Pills
+@nav-pills-border-radius:                   @border-radius-base;
+@nav-pills-active-link-hover-bg:            @component-active-bg;
+@nav-pills-active-link-hover-color:         @component-active-color;
+
+
+.nav-divider(@color: #e5e5e5) {
+  height: 1px;
+  margin: ((@line-height-computed / 2) - 1) 0;
+  overflow: hidden;
+  background-color: @color;
+}
+
+
+// Base class
+// --------------------------------------------------
+
+.nav {
+  margin-bottom: 0;
+  padding-left: 0; // Override default ul/ol
+  list-style: none;
+  &:extend(.clearfix all);
+
+  > li {
+    position: relative;
+    display: block;
+
+    > a {
+      position: relative;
+      display: block;
+      padding: @nav-link-padding;
+      border-radius: @component-border-radius;
+      &:hover,
+      &:focus {
+        text-decoration: none;
+        background-color: @background-color-highlight;
+      }
+    }
+
+    // Disabled state sets text to gray and nukes hover/tab effects
+    &.disabled > a {
+      color: @nav-disabled-link-color;
+
+      &:hover,
+      &:focus {
+        color: @nav-disabled-link-hover-color;
+        text-decoration: none;
+        background-color: transparent;
+        cursor: @cursor-disabled;
+      }
+    }
+  }
+
+  // Open dropdowns
+  .open > a {
+    &,
+    &:hover,
+    &:focus {
+      background-color: @nav-link-hover-bg;
+      border-color: @link-color;
+    }
+  }
+
+  // Nav dividers (deprecated with v3.0.1)
+  //
+  // This should have been removed in v3 with the dropping of `.nav-list`, but
+  // we missed it. We don't currently support this anywhere, but in the interest
+  // of maintaining backward compatibility in case you use it, it's deprecated.
+  .nav-divider {
+    .nav-divider();
+  }
+
+  // Prevent IE8 from misplacing imgs
+  //
+  // See https://github.com/h5bp/html5-boilerplate/issues/984#issuecomment-3985989
+  > li > a > img {
+    max-width: none;
+  }
+}
+
+
+// Tabs
+// -------------------------
+
+// Give the tabs something to sit on
+.nav-tabs {
+  border-bottom: 1px solid @nav-tabs-border-color;
+  > li {
+    float: left;
+    // Make the list-items overlay the bottom border
+    margin-bottom: -1px;
+
+    // Actual tabs (as links)
+    > a {
+      margin-right: 2px;
+      line-height: @line-height-base;
+      border: 1px solid transparent;
+      border-radius: @border-radius-base @border-radius-base 0 0;
+      &:hover {
+        border-color: @nav-tabs-link-hover-border-color @nav-tabs-link-hover-border-color @nav-tabs-border-color;
+      }
+    }
+
+    // Active state, and its :hover to override normal :hover
+    &.active > a {
+      &,
+      &:hover,
+      &:focus {
+        color: @nav-tabs-active-link-hover-color;
+        background-color: @nav-tabs-active-link-hover-bg;
+        border: 1px solid @nav-tabs-active-link-hover-border-color;
+        border-bottom-color: transparent;
+        cursor: default;
+      }
+    }
+  }
+  // pulling this in mainly for less shorthand
+  &.nav-justified {
+    .nav-justified();
+    .nav-tabs-justified();
+  }
+}
+
+
+// Pills
+// -------------------------
+.nav-pills {
+  > li {
+    float: left;
+
+    // Links rendered as pills
+    > a {
+      border-radius: @nav-pills-border-radius;
+    }
+    + li {
+      margin-left: 2px;
+    }
+
+    // Active state
+    &.active > a {
+      &,
+      &:hover,
+      &:focus {
+        color: @nav-pills-active-link-hover-color;
+        background-color: @background-color-selected;
+      }
+    }
+  }
+}
+
+
+// Stacked pills
+.nav-stacked {
+  > li {
+    float: none;
+    + li {
+      margin-top: 2px;
+      margin-left: 0; // no need for this gap between nav items
+    }
+  }
+}
+
+
+// Nav variations
+// --------------------------------------------------
+
+// Justified nav links
+// -------------------------
+
+.nav-justified {
+  width: 100%;
+
+  > li {
+    float: none;
+    > a {
+      text-align: center;
+      margin-bottom: 5px;
+    }
+  }
+
+  > .dropdown .dropdown-menu {
+    top: auto;
+    left: auto;
+  }
+
+  @media (min-width: @screen-sm-min) {
+    > li {
+      display: table-cell;
+      width: 1%;
+      > a {
+        margin-bottom: 0;
+      }
+    }
+  }
+}
+
+// Move borders to anchors instead of bottom of list
+//
+// Mixin for adding on top the shared `.nav-justified` styles for our tabs
+.nav-tabs-justified {
+  border-bottom: 0;
+
+  > li > a {
+    // Override margin from .nav-tabs
+    margin-right: 0;
+    border-radius: @border-radius-base;
+  }
+
+  > .active > a,
+  > .active > a:hover,
+  > .active > a:focus {
+    border: 1px solid @nav-tabs-justified-link-border-color;
+  }
+
+  @media (min-width: @screen-sm-min) {
+    > li > a {
+      border-bottom: 1px solid @nav-tabs-justified-link-border-color;
+      border-radius: @border-radius-base @border-radius-base 0 0;
+    }
+    > .active > a,
+    > .active > a:hover,
+    > .active > a:focus {
+      border-bottom-color: @nav-tabs-justified-active-link-border-color;
+    }
+  }
+}
+
+
+// Tabbable tabs
+// -------------------------
+
+// Hide tabbable panes to start, show them when `.active`
+.tab-content {
+  > .tab-pane {
+    display: none;
+  }
+  > .active {
+    display: block;
+  }
+}
+
+
+// Dropdowns
+// -------------------------
+
+// Specific dropdowns
+.nav-tabs .dropdown-menu {
+  // make dropdown border overlap tab border
+  margin-top: -1px;
+  // Remove the top rounded corners here since there is a hard edge above the menu
+  .border-top-radius(0);
+}

--- a/static/normalize.less
+++ b/static/normalize.less
@@ -1,0 +1,424 @@
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+
+//
+// 1. Set default font family to sans-serif.
+// 2. Prevent iOS and IE text size adjust after device orientation change,
+//    without disabling user zoom.
+//
+
+html {
+  font-family: sans-serif; // 1
+  -ms-text-size-adjust: 100%; // 2
+  -webkit-text-size-adjust: 100%; // 2
+}
+
+//
+// Remove default margin.
+//
+
+body {
+  margin: 0;
+}
+
+// HTML5 display definitions
+// ==========================================================================
+
+//
+// Correct `block` display not defined for any HTML5 element in IE 8/9.
+// Correct `block` display not defined for `details` or `summary` in IE 10/11
+// and Firefox.
+// Correct `block` display not defined for `main` in IE 11.
+//
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+
+//
+// 1. Correct `inline-block` display not defined in IE 8/9.
+// 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+//
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; // 1
+  vertical-align: baseline; // 2
+}
+
+//
+// Prevent modern browsers from displaying `audio` without controls.
+// Remove excess height in iOS 5 devices.
+//
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+//
+// Address `[hidden]` styling not present in IE 8/9/10.
+// Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
+//
+
+[hidden],
+template {
+  display: none;
+}
+
+// Links
+// ==========================================================================
+
+//
+// Remove the gray background color from active links in IE 10.
+//
+
+a {
+  background-color: transparent;
+}
+
+//
+// Improve readability of focused elements when they are also in an
+// active/hover state.
+//
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+// Text-level semantics
+// ==========================================================================
+
+//
+// Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+//
+
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+//
+// Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+//
+
+b,
+strong {
+  font-weight: bold;
+}
+
+//
+// Address styling not present in Safari and Chrome.
+//
+
+dfn {
+  font-style: italic;
+}
+
+//
+// Address variable `h1` font-size and margin within `section` and `article`
+// contexts in Firefox 4+, Safari, and Chrome.
+//
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+//
+// Address styling not present in IE 8/9.
+//
+
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+//
+// Address inconsistent and variable font size in all browsers.
+//
+
+small {
+  font-size: 80%;
+}
+
+//
+// Prevent `sub` and `sup` affecting `line-height` in all browsers.
+//
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+// Embedded content
+// ==========================================================================
+
+//
+// Remove border when inside `a` element in IE 8/9/10.
+//
+
+img {
+  border: 0;
+}
+
+//
+// Correct overflow not hidden in IE 9/10/11.
+//
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+// Grouping content
+// ==========================================================================
+
+//
+// Address margin not present in IE 8/9 and Safari.
+//
+
+figure {
+  margin: 1em 40px;
+}
+
+//
+// Address differences between Firefox and other browsers.
+//
+
+hr {
+  box-sizing: content-box;
+  height: 0;
+}
+
+//
+// Contain overflow in all browsers.
+//
+
+pre {
+  overflow: auto;
+}
+
+//
+// Address odd `em`-unit font size rendering in all browsers.
+//
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+// Forms
+// ==========================================================================
+
+//
+// Known limitation: by default, Chrome and Safari on OS X allow very limited
+// styling of `select`, unless a `border` property is set.
+//
+
+//
+// 1. Correct color not being inherited.
+//    Known issue: affects color of disabled elements.
+// 2. Correct font properties not being inherited.
+// 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+//
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit; // 1
+  font: inherit; // 2
+  margin: 0; // 3
+}
+
+//
+// Address `overflow` set to `hidden` in IE 8/9/10/11.
+//
+
+button {
+  overflow: visible;
+}
+
+//
+// Address inconsistent `text-transform` inheritance for `button` and `select`.
+// All other form control elements do not inherit `text-transform` values.
+// Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+// Correct `select` style inheritance in Firefox.
+//
+
+button,
+select {
+  text-transform: none;
+}
+
+//
+// 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+//    and `video` controls.
+// 2. Correct inability to style clickable `input` types in iOS.
+// 3. Improve usability and consistency of cursor style between image-type
+//    `input` and others.
+//
+
+button,
+html input[type="button"], // 1
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; // 2
+  cursor: pointer; // 3
+}
+
+//
+// Re-set default cursor for disabled elements.
+//
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+//
+// Remove inner padding and border in Firefox 4+.
+//
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+//
+// Address Firefox 4+ setting `line-height` on `input` using `!important` in
+// the UA stylesheet.
+//
+
+input {
+  line-height: normal;
+}
+
+//
+// It's recommended that you don't attempt to style these elements.
+// Firefox's implementation doesn't respect box-sizing, padding, or width.
+//
+// 1. Address box sizing set to `content-box` in IE 8/9/10.
+// 2. Remove excess padding in IE 8/9/10.
+//
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; // 1
+  padding: 0; // 2
+}
+
+//
+// Fix the cursor style for Chrome's increment/decrement buttons. For certain
+// `font-size` values of the `input`, it causes the cursor style of the
+// decrement button to change from `default` to `text`.
+//
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+//
+// 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+// 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+//
+
+input[type="search"] {
+  -webkit-appearance: textfield; // 1
+  box-sizing: content-box; //2
+}
+
+//
+// Remove inner padding and search cancel button in Safari and Chrome on OS X.
+// Safari (but not Chrome) clips the cancel button when the search input has
+// padding (and `textfield` appearance).
+//
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+//
+// Define consistent border, margin, and padding.
+//
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+//
+// 1. Correct `color` not being inherited in IE 8/9/10/11.
+// 2. Remove padding so people aren't caught out if they zero out fieldsets.
+//
+
+legend {
+  border: 0; // 1
+  padding: 0; // 2
+}
+
+//
+// Remove default vertical scrollbar in IE 8/9/10/11.
+//
+
+textarea {
+  overflow: auto;
+}
+
+//
+// Don't inherit the `font-weight` (applied by a rule above).
+// NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+//
+
+optgroup {
+  font-weight: bold;
+}
+
+// Tables
+// ==========================================================================
+
+//
+// Remove most spacing between table cells.
+//
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}

--- a/static/normalize.less
+++ b/static/normalize.less
@@ -1,16 +1,5 @@
 /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
-
-//
-// 1. Set default font family to sans-serif.
-// 2. Prevent iOS and IE text size adjust after device orientation change,
-//    without disabling user zoom.
-//
-
-html {
-  font-family: sans-serif; // 1
-  -ms-text-size-adjust: 100%; // 2
-  -webkit-text-size-adjust: 100%; // 2
-}
+// Modified to Chrome only.
 
 //
 // Remove default margin.
@@ -24,71 +13,26 @@ body {
 // ==========================================================================
 
 //
-// Correct `block` display not defined for any HTML5 element in IE 8/9.
-// Correct `block` display not defined for `details` or `summary` in IE 10/11
-// and Firefox.
-// Correct `block` display not defined for `main` in IE 11.
-//
-
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-main,
-menu,
-nav,
-section,
-summary {
-  display: block;
-}
-
-//
-// 1. Correct `inline-block` display not defined in IE 8/9.
-// 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+// 1. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
 //
 
 audio,
 canvas,
 progress,
 video {
-  display: inline-block; // 1
-  vertical-align: baseline; // 2
+  vertical-align: baseline; // 1
 }
 
 //
 // Prevent modern browsers from displaying `audio` without controls.
-// Remove excess height in iOS 5 devices.
 //
 
 audio:not([controls]) {
-  display: none;
-  height: 0;
-}
-
-//
-// Address `[hidden]` styling not present in IE 8/9/10.
-// Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
-//
-
-[hidden],
-template {
   display: none;
 }
 
 // Links
 // ==========================================================================
-
-//
-// Remove the gray background color from active links in IE 10.
-//
-
-a {
-  background-color: transparent;
-}
 
 //
 // Improve readability of focused elements when they are also in an
@@ -139,15 +83,6 @@ h1 {
 }
 
 //
-// Address styling not present in IE 8/9.
-//
-
-mark {
-  background: #ff0;
-  color: #000;
-}
-
-//
 // Address inconsistent and variable font size in all browsers.
 //
 
@@ -175,35 +110,8 @@ sub {
   bottom: -0.25em;
 }
 
-// Embedded content
-// ==========================================================================
-
-//
-// Remove border when inside `a` element in IE 8/9/10.
-//
-
-img {
-  border: 0;
-}
-
-//
-// Correct overflow not hidden in IE 9/10/11.
-//
-
-svg:not(:root) {
-  overflow: hidden;
-}
-
 // Grouping content
 // ==========================================================================
-
-//
-// Address margin not present in IE 8/9 and Safari.
-//
-
-figure {
-  margin: 1em 40px;
-}
 
 //
 // Address differences between Firefox and other browsers.
@@ -260,18 +168,8 @@ textarea {
 }
 
 //
-// Address `overflow` set to `hidden` in IE 8/9/10/11.
-//
-
-button {
-  overflow: visible;
-}
-
-//
 // Address inconsistent `text-transform` inheritance for `button` and `select`.
 // All other form control elements do not inherit `text-transform` values.
-// Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
-// Correct `select` style inheritance in Firefox.
 //
 
 button,
@@ -280,19 +178,14 @@ select {
 }
 
 //
-// 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
-//    and `video` controls.
-// 2. Correct inability to style clickable `input` types in iOS.
-// 3. Improve usability and consistency of cursor style between image-type
+// 1. Improve usability and consistency of cursor style between image-type
 //    `input` and others.
 //
 
 button,
-html input[type="button"], // 1
 input[type="reset"],
 input[type="submit"] {
-  -webkit-appearance: button; // 2
-  cursor: pointer; // 3
+  cursor: pointer; // 1
 }
 
 //
@@ -302,39 +195,6 @@ input[type="submit"] {
 button[disabled],
 html input[disabled] {
   cursor: default;
-}
-
-//
-// Remove inner padding and border in Firefox 4+.
-//
-
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-  border: 0;
-  padding: 0;
-}
-
-//
-// Address Firefox 4+ setting `line-height` on `input` using `!important` in
-// the UA stylesheet.
-//
-
-input {
-  line-height: normal;
-}
-
-//
-// It's recommended that you don't attempt to style these elements.
-// Firefox's implementation doesn't respect box-sizing, padding, or width.
-//
-// 1. Address box sizing set to `content-box` in IE 8/9/10.
-// 2. Remove excess padding in IE 8/9/10.
-//
-
-input[type="checkbox"],
-input[type="radio"] {
-  box-sizing: border-box; // 1
-  padding: 0; // 2
 }
 
 //
@@ -374,27 +234,17 @@ input[type="search"]::-webkit-search-decoration {
 //
 
 fieldset {
-  border: 1px solid #c0c0c0;
+  border: 1px solid;
   margin: 0 2px;
   padding: 0.35em 0.625em 0.75em;
 }
 
 //
-// 1. Correct `color` not being inherited in IE 8/9/10/11.
-// 2. Remove padding so people aren't caught out if they zero out fieldsets.
+// 1. Remove padding so people aren't caught out if they zero out fieldsets.
 //
 
 legend {
-  border: 0; // 1
-  padding: 0; // 2
-}
-
-//
-// Remove default vertical scrollbar in IE 8/9/10/11.
-//
-
-textarea {
-  overflow: auto;
+  padding: 0; // 1
 }
 
 //

--- a/static/scaffolding.less
+++ b/static/scaffolding.less
@@ -1,0 +1,163 @@
+//
+// Scaffolding
+// --------------------------------------------------
+
+// Octicon font
+
+@font-face { .octicon-font(); }
+
+
+// Reset the box-sizing
+
+*,
+*:before,
+*:after {
+  box-sizing: border-box;
+}
+
+
+// HTML + body
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+html {
+  font-family: @font-family;
+  font-size: @font-size;
+  line-height: @line-height-base;
+  color: @text-color;
+  background-color: @app-background-color;
+}
+
+
+// Reset fonts for relevant elements
+input,
+button,
+select,
+textarea {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+
+// Links
+
+a {
+  color: @link-color;
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    color: @link-hover-color;
+    text-decoration: @link-hover-decoration;
+  }
+
+  &:focus {
+    .tab-focus();
+  }
+}
+
+
+// Figures
+//
+// We reset this here because previously Normalize had no `figure` margins. This
+// ensures we don't break anyone's use of the element.
+
+figure {
+  margin: 0;
+}
+
+
+// Images
+
+img {
+  vertical-align: middle;
+}
+
+// Responsive images (ensure images don't scale beyond their parents)
+.img-responsive {
+  .img-responsive();
+}
+
+// Rounded corners
+.img-rounded {
+  border-radius: @border-radius-large;
+}
+
+// Image thumbnails
+//
+// Heads up! This is mixin-ed into thumbnails.less for `.thumbnail`.
+.img-thumbnail {
+  padding: @thumbnail-padding;
+  line-height: @line-height-base;
+  background-color: @thumbnail-bg;
+  border: 1px solid @thumbnail-border;
+  border-radius: @thumbnail-border-radius;
+  transition: all .2s ease-in-out;
+
+  // Keep them at most 100% wide
+  .img-responsive(inline-block);
+}
+
+// Perfect circle
+.img-circle {
+  border-radius: 50%; // set radius in percents
+}
+
+
+// Horizontal rules
+
+hr {
+  margin-top:    @line-height-computed;
+  margin-bottom: @line-height-computed;
+  border: 0;
+  border-top: 1px solid @hr-border;
+}
+
+
+// Only display content to screen readers
+//
+// See: http://a11yproject.com/posts/how-to-hide-content/
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  border: 0;
+}
+
+// Use in conjunction with .sr-only to only display content when it's focused.
+// Useful for "Skip to main content" links; see http://www.w3.org/TR/2013/NOTE-WCAG20-TECHS-20130905/G1
+// Credit: HTML5 Boilerplate
+
+.sr-only-focusable {
+  &:active,
+  &:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+  }
+}
+
+
+// iOS "clickable elements" fix for role="button"
+//
+// Fixes "clickability" issue (and more generally, the firing of events such as focus as well)
+// for traditionally non-focusable elements with role="button"
+// see https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile
+
+[role="button"] {
+  cursor: pointer;
+}

--- a/static/scaffolding.less
+++ b/static/scaffolding.less
@@ -1,3 +1,9 @@
+@import "variables/variables";
+@import "ui-variables";
+@import "mixins/mixins";
+
+@import "octicon-mixins";
+
 //
 // Scaffolding
 // --------------------------------------------------

--- a/static/tables.less
+++ b/static/tables.less
@@ -1,0 +1,289 @@
+@import "variables/variables";
+@import "ui-variables";
+
+//
+// Tables
+// --------------------------------------------------
+
+//## Customizes the `.table` component with basic values, each used across all table variations.
+
+//** Padding for `<th>`s and `<td>`s.
+@table-cell-padding:            8px;
+//** Padding for cells in `.table-condensed`.
+@table-condensed-cell-padding:  5px;
+
+//** Default background color used for all tables.
+@table-bg:                      transparent;
+//** Background color used for `.table-striped`.
+@table-bg-accent:               #f9f9f9;
+//** Background color used for `.table-hover`.
+@table-bg-hover:                #f5f5f5;
+@table-bg-active:               @table-bg-hover;
+
+//** Border color for table and cell borders.
+@table-border-color:            #ddd;
+
+
+
+// Variant mixin
+
+.table-row-variant(@state; @background) {
+  // Exact selectors below required to override `.table-striped` and prevent
+  // inheritance to nested tables.
+  .table > thead > tr,
+  .table > tbody > tr,
+  .table > tfoot > tr {
+    > td.@{state},
+    > th.@{state},
+    &.@{state} > td,
+    &.@{state} > th {
+      background-color: @background;
+    }
+  }
+
+  // Hover states for `.table-hover`
+  // Note: this is not available for cells or rows within `thead` or `tfoot`.
+  .table-hover > tbody > tr {
+    > td.@{state}:hover,
+    > th.@{state}:hover,
+    &.@{state}:hover > td,
+    &:hover > .@{state},
+    &.@{state}:hover > th {
+      background-color: darken(@background, 5%);
+    }
+  }
+}
+
+
+
+// Global overrides
+
+table {
+  background-color: @table-bg;
+}
+caption {
+  padding-top: @table-cell-padding;
+  padding-bottom: @table-cell-padding;
+  color: @text-muted;
+  text-align: left;
+}
+th {
+  text-align: left;
+}
+
+
+// Baseline styles
+
+.table {
+  width: 100%;
+  max-width: 100%;
+  margin-bottom: @line-height-computed;
+  // Cells
+  > thead,
+  > tbody,
+  > tfoot {
+    > tr {
+      > th,
+      > td {
+        padding: @table-cell-padding;
+        line-height: @line-height-base;
+        vertical-align: top;
+        border-top: 1px solid @table-border-color;
+      }
+    }
+  }
+  // Bottom align for column headings
+  > thead > tr > th {
+    vertical-align: bottom;
+    border-bottom: 2px solid @table-border-color;
+  }
+  // Remove top border from thead by default
+  > caption + thead,
+  > colgroup + thead,
+  > thead:first-child {
+    > tr:first-child {
+      > th,
+      > td {
+        border-top: 0;
+      }
+    }
+  }
+  // Account for multiple tbody instances
+  > tbody + tbody {
+    border-top: 2px solid @table-border-color;
+  }
+
+  // Nesting
+  .table {
+    background-color: @body-bg;
+  }
+}
+
+
+// Condensed table w/ half padding
+
+.table-condensed {
+  > thead,
+  > tbody,
+  > tfoot {
+    > tr {
+      > th,
+      > td {
+        padding: @table-condensed-cell-padding;
+      }
+    }
+  }
+}
+
+
+// Bordered version
+//
+// Add borders all around the table and between all the columns.
+
+.table-bordered {
+  border: 1px solid @table-border-color;
+  > thead,
+  > tbody,
+  > tfoot {
+    > tr {
+      > th,
+      > td {
+        border: 1px solid @table-border-color;
+      }
+    }
+  }
+  > thead > tr {
+    > th,
+    > td {
+      border-bottom-width: 2px;
+    }
+  }
+}
+
+
+// Zebra-striping
+//
+// Default zebra-stripe styles (alternating gray and transparent backgrounds)
+
+.table-striped {
+  > tbody > tr:nth-of-type(odd) {
+    background-color: @table-bg-accent;
+  }
+}
+
+
+// Hover effect
+//
+// Placed here since it has to come after the potential zebra striping
+
+.table-hover {
+  > tbody > tr:hover {
+    background-color: @table-bg-hover;
+  }
+}
+
+
+// Table cell sizing
+//
+// Reset default table behavior
+
+table col[class*="col-"] {
+  position: static; // Prevent border hiding in Firefox and IE9-11 (see https://github.com/twbs/bootstrap/issues/11623)
+  float: none;
+  display: table-column;
+}
+table {
+  td,
+  th {
+    &[class*="col-"] {
+      position: static; // Prevent border hiding in Firefox and IE9-11 (see https://github.com/twbs/bootstrap/issues/11623)
+      float: none;
+      display: table-cell;
+    }
+  }
+}
+
+
+// Table backgrounds
+//
+// Exact selectors below required to override `.table-striped` and prevent
+// inheritance to nested tables.
+
+// Generate the contextual variants
+.table-row-variant(active; @table-bg-active);
+.table-row-variant(success; @state-success-bg);
+.table-row-variant(info; @state-info-bg);
+.table-row-variant(warning; @state-warning-bg);
+.table-row-variant(danger; @state-danger-bg);
+
+
+// Responsive tables
+//
+// Wrap your tables in `.table-responsive` and we'll make them mobile friendly
+// by enabling horizontal scrolling. Only applies <768px. Everything above that
+// will display normally.
+
+.table-responsive {
+  overflow-x: auto;
+  min-height: 0.01%; // Workaround for IE9 bug (see https://github.com/twbs/bootstrap/issues/14837)
+
+  @media screen and (max-width: @screen-xs-max) {
+    width: 100%;
+    margin-bottom: (@line-height-computed * 0.75);
+    overflow-y: hidden;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+    border: 1px solid @table-border-color;
+
+    // Tighten up spacing
+    > .table {
+      margin-bottom: 0;
+
+      // Ensure the content doesn't wrap
+      > thead,
+      > tbody,
+      > tfoot {
+        > tr {
+          > th,
+          > td {
+            white-space: nowrap;
+          }
+        }
+      }
+    }
+
+    // Special overrides for the bordered tables
+    > .table-bordered {
+      border: 0;
+
+      // Nuke the appropriate borders so that the parent can handle them
+      > thead,
+      > tbody,
+      > tfoot {
+        > tr {
+          > th:first-child,
+          > td:first-child {
+            border-left: 0;
+          }
+          > th:last-child,
+          > td:last-child {
+            border-right: 0;
+          }
+        }
+      }
+
+      // Only nuke the last row's bottom-border in `tbody` and `tfoot` since
+      // chances are there will be only one `tr` in a `thead` and that would
+      // remove the border altogether.
+      > tbody,
+      > tfoot {
+        > tr:last-child {
+          > th,
+          > td {
+            border-bottom: 0;
+          }
+        }
+      }
+
+    }
+  }
+}

--- a/static/text.less
+++ b/static/text.less
@@ -1,11 +1,38 @@
+@import "variables/variables";
 @import "ui-variables";
+@import "mixins/mixins";
 
-.text-bits (@type) {
+//
+// Typography
+// --------------------------------------------------
+
+@font-size-h1:            floor((@font-size-base * 2.6)); // ~36px
+@font-size-h2:            floor((@font-size-base * 2.15)); // ~30px
+@font-size-h3:            ceil((@font-size-base * 1.7)); // ~24px
+@font-size-h4:            ceil((@font-size-base * 1.25)); // ~18px
+@font-size-h5:            @font-size-base;
+@font-size-h6:            ceil((@font-size-base * 0.85)); // ~12px
+
+@headings-font-family:    inherit;
+@headings-font-weight:    500;
+@headings-line-height:    1.1;
+@headings-color:          inherit;
+
+// Mixins
+// -------------------------
+
+.text-variant(@type) {
   @text-color-name: "text-color-@{type}";
   @bg-color-name: "background-color-@{type}";
 
   @text-color: @@text-color-name;
   @bg-color: @@bg-color-name;
+
+  color: @text-color;
+  a&:hover,
+  a&:focus {
+    color: darken(@text-color, 10%);
+  }
 
   code {
     color: @text-color;
@@ -22,27 +49,307 @@
   }
 }
 
-.text-info {
-  .text-bits(info);
+.bg-variant(@color) {
+  background-color: @color;
+  a&:hover,
+  a&:focus {
+    background-color: darken(@color, 10%);
+  }
 }
 
+// Headings
+// -------------------------
+
+h1, h2, h3, h4, h5, h6,
+.h1, .h2, .h3, .h4, .h5, .h6 {
+  font-family: @headings-font-family;
+  font-weight: @headings-font-weight;
+  line-height: @headings-line-height;
+  color: @headings-color;
+
+  small,
+  .small {
+    font-weight: normal;
+    line-height: 1;
+    color: @headings-small-color;
+  }
+}
+
+h1, .h1,
+h2, .h2,
+h3, .h3 {
+  margin-top: @line-height-computed;
+  margin-bottom: (@line-height-computed / 2);
+
+  small,
+  .small {
+    font-size: 65%;
+  }
+}
+h4, .h4,
+h5, .h5,
+h6, .h6 {
+  margin-top: (@line-height-computed / 2);
+  margin-bottom: (@line-height-computed / 2);
+
+  small,
+  .small {
+    font-size: 75%;
+  }
+}
+
+h1, .h1 { font-size: @font-size-h1; }
+h2, .h2 { font-size: @font-size-h2; }
+h3, .h3 { font-size: @font-size-h3; }
+h4, .h4 { font-size: @font-size-h4; }
+h5, .h5 { font-size: @font-size-h5; }
+h6, .h6 { font-size: @font-size-h6; }
+
+
+// Body text
+// -------------------------
+
+p {
+  margin: 0 0 (@line-height-computed / 2);
+}
+
+.lead {
+  margin-bottom: @line-height-computed;
+  font-size: floor((@font-size-base * 1.15));
+  font-weight: 300;
+  line-height: 1.4;
+
+  @media (min-width: @screen-sm-min) {
+    font-size: (@font-size-base * 1.5);
+  }
+}
+
+
+// Emphasis & misc
+// -------------------------
+
+// Ex: (12px small font / 14px base font) * 100% = about 85%
+small,
+.small {
+  font-size: floor((100% * @font-size-small / @font-size-base));
+}
+
+mark,
+.mark {
+  background-color: @state-warning-bg;
+  padding: .2em;
+}
+
+// Alignment
+.text-left           { text-align: left; }
+.text-right          { text-align: right; }
+.text-center         { text-align: center; }
+.text-justify        { text-align: justify; }
+.text-nowrap         { white-space: nowrap; }
+
+// Transformation
+.text-lowercase      { text-transform: lowercase; }
+.text-uppercase      { text-transform: uppercase; }
+.text-capitalize     { text-transform: capitalize; }
+
+// Contextual colors
+.text-muted {
+  color: @text-muted;
+}
+.text-info,
+.text-primary {
+  .text-variant(info);
+}
 .text-success {
-  .text-bits(success);
+  .text-variant(success);
 }
-
 .text-warning {
-  .text-bits(warning);
+  .text-variant(warning);
+}
+.text-error,
+.text-danger {
+  .text-variant(error);
 }
 
-.text-error {
-  .text-bits(error);
+// Contextual backgrounds
+// For now we'll leave these alongside the text classes until v4 when we can
+// safely shift things around (per SemVer rules).
+.bg-primary {
+  // Given the contrast here, this is the only class to have its color inverted
+  // automatically.
+  color: #fff;
+  .bg-variant(@brand-primary);
+}
+.bg-success {
+  .bg-variant(@state-success-bg);
+}
+.bg-info {
+  .bg-variant(@state-info-bg);
+}
+.bg-warning {
+  .bg-variant(@state-warning-bg);
+}
+.bg-danger {
+  .bg-variant(@state-danger-bg);
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-family: inherit; // inherit from themes
+
+// Page header
+// -------------------------
+
+.page-header {
+  padding-bottom: ((@line-height-computed / 2) - 1);
+  margin: (@line-height-computed * 2) 0 @line-height-computed;
+  border-bottom: 1px solid @page-header-border-color;
+}
+
+
+// Lists
+// -------------------------
+
+// Unordered and Ordered lists
+ul,
+ol {
+  margin-top: 0;
+  margin-bottom: (@line-height-computed / 2);
+  ul,
+  ol {
+    margin-bottom: 0;
+  }
+}
+
+// List options
+
+// Unstyled keeps list items block level, just removes default browser padding and list-style
+.list-unstyled {
+  padding-left: 0;
+  list-style: none;
+}
+
+// Inline turns list items into inline-block
+.list-inline {
+  .list-unstyled();
+  margin-left: -5px;
+
+  > li {
+    display: inline-block;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+}
+
+// Description Lists
+dl {
+  margin-top: 0; // Remove browser default
+  margin-bottom: @line-height-computed;
+}
+dt,
+dd {
+  line-height: @line-height-base;
+}
+dt {
+  font-weight: bold;
+}
+dd {
+  margin-left: 0; // Undo browser default
+}
+
+// Horizontal description lists
+//
+// Defaults to being stacked without any of the below styles applied, until the
+// grid breakpoint is reached (default of ~768px).
+
+.dl-horizontal {
+  dd {
+    &:extend(.clearfix all); // Clear the floated `dt` if an empty `dd` is present
+  }
+
+  @media (min-width: @screen-sm-min) {
+    dt {
+      float: left;
+      width: 160px;
+      clear: left;
+      text-align: right;
+      .text-overflow();
+    }
+    dd {
+      margin-left: 180px;
+    }
+  }
+}
+
+
+// Misc
+// -------------------------
+
+// Abbreviations and acronyms
+abbr[title],
+// Add data-* attribute to help out our tooltip plugin, per https://github.com/twbs/bootstrap/issues/5257
+abbr[data-original-title] {
+  cursor: help;
+  border-bottom: 1px dotted @abbr-border-color;
+}
+.initialism {
+  font-size: 90%;
+  .text-uppercase();
+}
+
+// Blockquotes
+blockquote {
+  padding: (@line-height-computed / 2) @line-height-computed;
+  margin: 0 0 @line-height-computed;
+  font-size: @blockquote-font-size;
+  border-left: 5px solid @blockquote-border-color;
+
+  p,
+  ul,
+  ol {
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  // Note: Deprecated small and .small as of v3.1.0
+  // Context: https://github.com/twbs/bootstrap/issues/11660
+  footer,
+  small,
+  .small {
+    display: block;
+    font-size: 80%; // back to default font-size
+    line-height: @line-height-base;
+    color: @blockquote-small-color;
+
+    &:before {
+      content: '\2014 \00A0'; // em dash, nbsp
+    }
+  }
+}
+
+// Opposite alignment of blockquote
+//
+// Heads up: `blockquote.pull-right` has been deprecated as of v3.1.0.
+.blockquote-reverse,
+blockquote.pull-right {
+  padding-right: 15px;
+  padding-left: 0;
+  border-right: 5px solid @blockquote-border-color;
+  border-left: 0;
+  text-align: right;
+
+  // Account for citation
+  footer,
+  small,
+  .small {
+    &:before { content: ''; }
+    &:after {
+      content: '\00A0 \2014'; // nbsp, em dash
+    }
+  }
+}
+
+// Addresses
+address {
+  margin-bottom: @line-height-computed;
+  font-style: normal;
+  line-height: @line-height-base;
 }

--- a/static/text.less
+++ b/static/text.less
@@ -37,3 +37,12 @@
 .text-error {
   .text-bits(error);
 }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: inherit; // inherit from themes
+}

--- a/static/tooltip.less
+++ b/static/tooltip.less
@@ -1,0 +1,112 @@
+@import "ui-variables";
+
+//
+// Tooltips
+// --------------------------------------------------
+
+@tooltip-max-width:           200px; //** Tooltip max width
+@tooltip-color:               #fff; //** Tooltip text color
+@tooltip-bg:                  @background-color-info; //** Tooltip background color
+@tooltip-opacity:             .9;
+@tooltip-arrow-width:         5px; //** Tooltip arrow width
+@tooltip-arrow-color:         @tooltip-bg; //** Tooltip arrow color
+@tooltip-zindex:              1070;
+
+
+// Base class
+.tooltip {
+  // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
+  // So reset our font and text properties to avoid inheriting weird values.
+  all: initial;
+
+  position: absolute;
+  z-index: @tooltip-zindex;
+  display: block;
+  font-family: @font-family;
+  font-size: @font-size;
+  opacity: 0;
+
+  &.in     { opacity: @tooltip-opacity; }
+  &.top    { margin-top:  -3px; padding: @tooltip-arrow-width 0; }
+  &.right  { margin-left:  3px; padding: 0 @tooltip-arrow-width; }
+  &.bottom { margin-top:   3px; padding: @tooltip-arrow-width 0; }
+  &.left   { margin-left: -3px; padding: 0 @tooltip-arrow-width; }
+}
+
+// Wrapper for the tooltip content
+.tooltip-inner {
+  max-width: @tooltip-max-width;
+  padding: 3px 8px;
+  color: @tooltip-color;
+  text-align: center;
+  background-color: @tooltip-bg;
+  border-radius: @component-border-radius;
+}
+
+// Arrows
+.tooltip-arrow {
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+}
+// Note: Deprecated .top-left, .top-right, .bottom-left, and .bottom-right as of v3.3.1
+.tooltip {
+  &.top .tooltip-arrow {
+    bottom: 0;
+    left: 50%;
+    margin-left: -@tooltip-arrow-width;
+    border-width: @tooltip-arrow-width @tooltip-arrow-width 0;
+    border-top-color: @tooltip-arrow-color;
+  }
+  &.top-left .tooltip-arrow {
+    bottom: 0;
+    right: @tooltip-arrow-width;
+    margin-bottom: -@tooltip-arrow-width;
+    border-width: @tooltip-arrow-width @tooltip-arrow-width 0;
+    border-top-color: @tooltip-arrow-color;
+  }
+  &.top-right .tooltip-arrow {
+    bottom: 0;
+    left: @tooltip-arrow-width;
+    margin-bottom: -@tooltip-arrow-width;
+    border-width: @tooltip-arrow-width @tooltip-arrow-width 0;
+    border-top-color: @tooltip-arrow-color;
+  }
+  &.right .tooltip-arrow {
+    top: 50%;
+    left: 0;
+    margin-top: -@tooltip-arrow-width;
+    border-width: @tooltip-arrow-width @tooltip-arrow-width @tooltip-arrow-width 0;
+    border-right-color: @tooltip-arrow-color;
+  }
+  &.left .tooltip-arrow {
+    top: 50%;
+    right: 0;
+    margin-top: -@tooltip-arrow-width;
+    border-width: @tooltip-arrow-width 0 @tooltip-arrow-width @tooltip-arrow-width;
+    border-left-color: @tooltip-arrow-color;
+  }
+  &.bottom .tooltip-arrow {
+    top: 0;
+    left: 50%;
+    margin-left: -@tooltip-arrow-width;
+    border-width: 0 @tooltip-arrow-width @tooltip-arrow-width;
+    border-bottom-color: @tooltip-arrow-color;
+  }
+  &.bottom-left .tooltip-arrow {
+    top: 0;
+    right: @tooltip-arrow-width;
+    margin-top: -@tooltip-arrow-width;
+    border-width: 0 @tooltip-arrow-width @tooltip-arrow-width;
+    border-bottom-color: @tooltip-arrow-color;
+  }
+  &.bottom-right .tooltip-arrow {
+    top: 0;
+    left: @tooltip-arrow-width;
+    margin-top: -@tooltip-arrow-width;
+    border-width: 0 @tooltip-arrow-width @tooltip-arrow-width;
+    border-bottom-color: @tooltip-arrow-color;
+  }
+}

--- a/static/utilities.less
+++ b/static/utilities.less
@@ -1,4 +1,5 @@
 @import "ui-variables";
+@import "mixins/mixins";
 
 :focus {
   outline: none;
@@ -14,6 +15,12 @@
 }
 
 // Blocks
+
+.center-block {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
 
 // Must be div.block so as not to affect syntax highlighting.
 ul.block,
@@ -47,9 +54,14 @@ div > .inline-block-tight:last-child {
   vertical-align: top;
 }
 
+// Floats
+// -------------------------
+
 // Use left margin when it's in a float: right element.
 // Sets the margin correctly when inline blocks are hidden and shown.
 .pull-right {
+  float: right !important;
+
   .inline-block {
     margin-right: 0;
     margin-left: @component-padding;
@@ -63,4 +75,47 @@ div > .inline-block-tight:last-child {
   > .inline-block-tight:first-child {
     margin-left: 0;
   }
+}
+
+.pull-left {
+  float: left !important;
+}
+
+.clearfix {
+  .clearfix();
+}
+
+
+// Toggling content
+// -------------------------
+
+// Note: Deprecated .hide in favor of .hidden or .sr-only (as appropriate) in v3.0.1
+.hide {
+  display: none !important;
+}
+.show {
+  display: block !important;
+}
+.invisible {
+  visibility: hidden;
+}
+.text-hide {
+  .text-hide();
+}
+
+
+// Hide from screenreaders and browsers
+//
+// Credit: HTML5 Boilerplate
+
+.hidden {
+  display: none !important;
+}
+
+
+// For Affix plugin
+// -------------------------
+
+.affix {
+  position: fixed;
 }

--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -17,7 +17,7 @@
 @background-color-success: #17ca65;
 @background-color-warning: #ff4800;
 @background-color-error: #c00;
-@background-color-highlight: rgba(255, 255, 255, 0.10);
+@background-color-highlight: hsla(0,0%,0%,.1);
 @background-color-selected: @background-color-highlight;
 
 @app-background-color: #fff;

--- a/static/variables/variables.less
+++ b/static/variables/variables.less
@@ -137,15 +137,19 @@
 //
 @state-success-text:             #3c763d;
 @state-success-bg:               #dff0d8;
+@state-success-border:           darken(spin(@state-success-bg, -10), 5%);
 
 @state-info-text:                #31708f;
 @state-info-bg:                  #d9edf7;
+@state-info-border:              darken(spin(@state-info-bg, -10), 7%);
 
 @state-warning-text:             #8a6d3b;
 @state-warning-bg:               #fcf8e3;
+@state-warning-border:           darken(spin(@state-warning-bg, -10), 5%);
 
 @state-danger-text:              #a94442;
 @state-danger-bg:                #f2dede;
+@state-danger-border:            darken(spin(@state-danger-bg, -10), 5%);
 
 
 // == List group

--- a/static/variables/variables.less
+++ b/static/variables/variables.less
@@ -1,0 +1,871 @@
+//
+// Core Variables (Forked from Bootstrap 3.3.6)
+// Don't use these variables in packages/themes.
+// Only use the public ui-variables.less + syntax-variables.less
+// --------------------------------------------------
+
+
+//== Colors
+//
+//## Gray and brand colors for use across Bootstrap.
+
+@gray-base:              #000;
+@gray-darker:            lighten(@gray-base, 13.5%); // #222
+@gray-dark:              lighten(@gray-base, 20%);   // #333
+@gray:                   lighten(@gray-base, 33.5%); // #555
+@gray-light:             lighten(@gray-base, 46.7%); // #777
+@gray-lighter:           lighten(@gray-base, 93.5%); // #eee
+
+@brand-primary:         darken(#428bca, 6.5%); // #337ab7
+@brand-success:         #5cb85c;
+@brand-info:            #5bc0de;
+@brand-warning:         #f0ad4e;
+@brand-danger:          #d9534f;
+
+
+// //== Scaffolding
+// //
+// //## Settings for some of the most global styles.
+//
+// //** Background color for `<body>`.
+// @body-bg:               #fff;
+// //** Global text color on `<body>`.
+// @text-color:            @gray-dark;
+
+//** Global textual link color.
+@link-color:            @brand-primary;
+//** Link hover color set via `darken()` function.
+@link-hover-color:      darken(@link-color, 15%);
+//** Link hover decoration.
+@link-hover-decoration: underline;
+
+
+//== Typography
+//
+//## Font, line-height, and color for body text, headings, and more.
+
+// @font-family-sans-serif:  "Helvetica Neue", Helvetica, Arial, sans-serif;
+// @font-family-serif:       Georgia, "Times New Roman", Times, serif;
+// //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
+// @font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
+// @font-family-base:        @font-family-sans-serif;
+//
+@font-size-base:          14px;
+@font-size-large:         ceil((@font-size-base * 1.25)); // ~18px
+@font-size-small:         ceil((@font-size-base * 0.85)); // ~12px
+
+// @font-size-h1:            floor((@font-size-base * 2.6)); // ~36px
+// @font-size-h2:            floor((@font-size-base * 2.15)); // ~30px
+// @font-size-h3:            ceil((@font-size-base * 1.7)); // ~24px
+// @font-size-h4:            ceil((@font-size-base * 1.25)); // ~18px
+// @font-size-h5:            @font-size-base;
+// @font-size-h6:            ceil((@font-size-base * 0.85)); // ~12px
+//
+// //** Unit-less `line-height` for use in components like buttons.
+@line-height-base:        1.428571429; // 20/14
+// //** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
+// @line-height-computed:    floor((@font-size-base * @line-height-base)); // ~20px
+//
+// //** By default, this inherits from the `<body>`.
+// @headings-font-family:    inherit;
+// @headings-font-weight:    500;
+// @headings-line-height:    1.1;
+// @headings-color:          inherit;
+//
+//
+// //== Iconography
+// //
+// //## Specify custom location and filename of the included Glyphicons icon font. Useful for those including Bootstrap via Bower.
+//
+// //** Load fonts from this directory.
+// @icon-font-path:          "../fonts/";
+// //** File name for all font files.
+// @icon-font-name:          "glyphicons-halflings-regular";
+// //** Element ID within SVG icon file.
+// @icon-font-svg-id:        "glyphicons_halflingsregular";
+//
+//
+//== Components
+//
+//## Define common padding and border radius sizes and more. Values based on 14px text and 1.428 line-height (~20px to start).
+
+@padding-base-vertical:     6px;
+@padding-base-horizontal:   12px;
+
+@padding-large-vertical:    10px;
+@padding-large-horizontal:  16px;
+
+@padding-small-vertical:    5px;
+@padding-small-horizontal:  10px;
+
+@padding-xs-vertical:       1px;
+@padding-xs-horizontal:     5px;
+
+@line-height-large:         1.3333333; // extra decimals for Win 8.1 Chrome
+@line-height-small:         1.5;
+//
+// @border-radius-base:        4px;
+// @border-radius-large:       6px;
+// @border-radius-small:       3px;
+//
+// //** Global color for active items (e.g., navs or dropdowns).
+// @component-active-color:    #fff;
+// //** Global background color for active items (e.g., navs or dropdowns).
+// @component-active-bg:       @brand-primary;
+//
+// //** Width of the `border` for generating carets that indicator dropdowns.
+// @caret-width-base:          4px;
+// //** Carets increase slightly in size for larger components.
+// @caret-width-large:         5px;
+//
+//
+// //== Tables
+// //
+// //## Customizes the `.table` component with basic values, each used across all table variations.
+//
+// //** Padding for `<th>`s and `<td>`s.
+// @table-cell-padding:            8px;
+// //** Padding for cells in `.table-condensed`.
+// @table-condensed-cell-padding:  5px;
+//
+// //** Default background color used for all tables.
+// @table-bg:                      transparent;
+// //** Background color used for `.table-striped`.
+// @table-bg-accent:               #f9f9f9;
+// //** Background color used for `.table-hover`.
+// @table-bg-hover:                #f5f5f5;
+// @table-bg-active:               @table-bg-hover;
+//
+// //** Border color for table and cell borders.
+// @table-border-color:            #ddd;
+//
+//
+// //== Buttons
+// //
+// //## For each of Bootstrap's buttons, define text, background and border color.
+//
+// @btn-font-weight:                normal;
+//
+// @btn-default-color:              #333;
+// @btn-default-bg:                 #fff;
+// @btn-default-border:             #ccc;
+//
+// @btn-primary-color:              #fff;
+// @btn-primary-bg:                 @brand-primary;
+// @btn-primary-border:             darken(@btn-primary-bg, 5%);
+//
+// @btn-success-color:              #fff;
+// @btn-success-bg:                 @brand-success;
+// @btn-success-border:             darken(@btn-success-bg, 5%);
+//
+// @btn-info-color:                 #fff;
+// @btn-info-bg:                    @brand-info;
+// @btn-info-border:                darken(@btn-info-bg, 5%);
+//
+// @btn-warning-color:              #fff;
+// @btn-warning-bg:                 @brand-warning;
+// @btn-warning-border:             darken(@btn-warning-bg, 5%);
+//
+// @btn-danger-color:               #fff;
+// @btn-danger-bg:                  @brand-danger;
+// @btn-danger-border:              darken(@btn-danger-bg, 5%);
+//
+// @btn-link-disabled-color:        @gray-light;
+//
+// // Allows for customizing button radius independently from global border radius
+// @btn-border-radius-base:         @border-radius-base;
+// @btn-border-radius-large:        @border-radius-large;
+// @btn-border-radius-small:        @border-radius-small;
+//
+//
+// //== Forms
+// //
+// //##
+//
+// //** `<input>` background color
+// @input-bg:                       #fff;
+// //** `<input disabled>` background color
+// @input-bg-disabled:              @gray-lighter;
+//
+// //** Text color for `<input>`s
+// @input-color:                    @gray;
+// //** `<input>` border color
+// @input-border:                   #ccc;
+//
+// // TODO: Rename `@input-border-radius` to `@input-border-radius-base` in v4
+// //** Default `.form-control` border radius
+// // This has no effect on `<select>`s in some browsers, due to the limited stylability of `<select>`s in CSS.
+// @input-border-radius:            @border-radius-base;
+// //** Large `.form-control` border radius
+// @input-border-radius-large:      @border-radius-large;
+// //** Small `.form-control` border radius
+// @input-border-radius-small:      @border-radius-small;
+//
+// //** Border color for inputs on focus
+// @input-border-focus:             #66afe9;
+//
+// //** Placeholder text color
+// @input-color-placeholder:        #999;
+//
+// //** Default `.form-control` height
+// @input-height-base:              (@line-height-computed + (@padding-base-vertical * 2) + 2);
+// //** Large `.form-control` height
+// @input-height-large:             (ceil(@font-size-large * @line-height-large) + (@padding-large-vertical * 2) + 2);
+// //** Small `.form-control` height
+// @input-height-small:             (floor(@font-size-small * @line-height-small) + (@padding-small-vertical * 2) + 2);
+//
+// //** `.form-group` margin
+// @form-group-margin-bottom:       15px;
+//
+// @legend-color:                   @gray-dark;
+// @legend-border-color:            #e5e5e5;
+//
+// //** Background color for textual input addons
+// @input-group-addon-bg:           @gray-lighter;
+// //** Border color for textual input addons
+// @input-group-addon-border-color: @input-border;
+
+//** Disabled cursor for form controls and buttons.
+@cursor-disabled:                not-allowed;
+
+
+// //== Dropdowns
+// //
+// //## Dropdown menu container and contents.
+//
+// //** Background for the dropdown menu.
+// @dropdown-bg:                    #fff;
+// //** Dropdown menu `border-color`.
+// @dropdown-border:                rgba(0,0,0,.15);
+// //** Dropdown menu `border-color` **for IE8**.
+// @dropdown-fallback-border:       #ccc;
+// //** Divider color for between dropdown items.
+// @dropdown-divider-bg:            #e5e5e5;
+//
+// //** Dropdown link text color.
+// @dropdown-link-color:            @gray-dark;
+// //** Hover color for dropdown links.
+// @dropdown-link-hover-color:      darken(@gray-dark, 5%);
+// //** Hover background for dropdown links.
+// @dropdown-link-hover-bg:         #f5f5f5;
+//
+// //** Active dropdown menu item text color.
+// @dropdown-link-active-color:     @component-active-color;
+// //** Active dropdown menu item background color.
+// @dropdown-link-active-bg:        @component-active-bg;
+//
+// //** Disabled dropdown menu item background color.
+// @dropdown-link-disabled-color:   @gray-light;
+//
+// //** Text color for headers within dropdown menus.
+// @dropdown-header-color:          @gray-light;
+//
+// //** Deprecated `@dropdown-caret-color` as of v3.1.0
+// @dropdown-caret-color:           #000;
+//
+//
+// //-- Z-index master list
+// //
+// // Warning: Avoid customizing these values. They're used for a bird's eye view
+// // of components dependent on the z-axis and are designed to all work together.
+// //
+// // Note: These variables are not generated into the Customizer.
+//
+// @zindex-navbar:            1000;
+// @zindex-dropdown:          1000;
+// @zindex-popover:           1060;
+// @zindex-tooltip:           1070;
+// @zindex-navbar-fixed:      1030;
+// @zindex-modal-background:  1040;
+// @zindex-modal:             1050;
+//
+//
+// //== Media queries breakpoints
+// //
+// //## Define the breakpoints at which your layout will change, adapting to different screen sizes.
+//
+// // Extra small screen / phone
+// //** Deprecated `@screen-xs` as of v3.0.1
+// @screen-xs:                  480px;
+// //** Deprecated `@screen-xs-min` as of v3.2.0
+// @screen-xs-min:              @screen-xs;
+// //** Deprecated `@screen-phone` as of v3.0.1
+// @screen-phone:               @screen-xs-min;
+//
+// // Small screen / tablet
+// //** Deprecated `@screen-sm` as of v3.0.1
+// @screen-sm:                  768px;
+// @screen-sm-min:              @screen-sm;
+// //** Deprecated `@screen-tablet` as of v3.0.1
+// @screen-tablet:              @screen-sm-min;
+//
+// // Medium screen / desktop
+// //** Deprecated `@screen-md` as of v3.0.1
+// @screen-md:                  992px;
+// @screen-md-min:              @screen-md;
+// //** Deprecated `@screen-desktop` as of v3.0.1
+// @screen-desktop:             @screen-md-min;
+//
+// // Large screen / wide desktop
+// //** Deprecated `@screen-lg` as of v3.0.1
+// @screen-lg:                  1200px;
+// @screen-lg-min:              @screen-lg;
+// //** Deprecated `@screen-lg-desktop` as of v3.0.1
+// @screen-lg-desktop:          @screen-lg-min;
+//
+// // So media queries don't overlap when required, provide a maximum
+// @screen-xs-max:              (@screen-sm-min - 1);
+// @screen-sm-max:              (@screen-md-min - 1);
+// @screen-md-max:              (@screen-lg-min - 1);
+//
+//
+// //== Grid system
+// //
+// //## Define your custom responsive grid.
+//
+// //** Number of columns in the grid.
+// @grid-columns:              12;
+// //** Padding between columns. Gets divided in half for the left and right.
+// @grid-gutter-width:         30px;
+// // Navbar collapse
+// //** Point at which the navbar becomes uncollapsed.
+// @grid-float-breakpoint:     @screen-sm-min;
+// //** Point at which the navbar begins collapsing.
+// @grid-float-breakpoint-max: (@grid-float-breakpoint - 1);
+//
+//
+// //== Container sizes
+// //
+// //## Define the maximum width of `.container` for different screen sizes.
+//
+// // Small screen / tablet
+// @container-tablet:             (720px + @grid-gutter-width);
+// //** For `@screen-sm-min` and up.
+// @container-sm:                 @container-tablet;
+//
+// // Medium screen / desktop
+// @container-desktop:            (940px + @grid-gutter-width);
+// //** For `@screen-md-min` and up.
+// @container-md:                 @container-desktop;
+//
+// // Large screen / wide desktop
+// @container-large-desktop:      (1140px + @grid-gutter-width);
+// //** For `@screen-lg-min` and up.
+// @container-lg:                 @container-large-desktop;
+//
+//
+// //== Navbar
+// //
+// //##
+//
+// // Basics of a navbar
+// @navbar-height:                    50px;
+// @navbar-margin-bottom:             @line-height-computed;
+// @navbar-border-radius:             @border-radius-base;
+// @navbar-padding-horizontal:        floor((@grid-gutter-width / 2));
+// @navbar-padding-vertical:          ((@navbar-height - @line-height-computed) / 2);
+// @navbar-collapse-max-height:       340px;
+//
+// @navbar-default-color:             #777;
+// @navbar-default-bg:                #f8f8f8;
+// @navbar-default-border:            darken(@navbar-default-bg, 6.5%);
+//
+// // Navbar links
+// @navbar-default-link-color:                #777;
+// @navbar-default-link-hover-color:          #333;
+// @navbar-default-link-hover-bg:             transparent;
+// @navbar-default-link-active-color:         #555;
+// @navbar-default-link-active-bg:            darken(@navbar-default-bg, 6.5%);
+// @navbar-default-link-disabled-color:       #ccc;
+// @navbar-default-link-disabled-bg:          transparent;
+//
+// // Navbar brand label
+// @navbar-default-brand-color:               @navbar-default-link-color;
+// @navbar-default-brand-hover-color:         darken(@navbar-default-brand-color, 10%);
+// @navbar-default-brand-hover-bg:            transparent;
+//
+// // Navbar toggle
+// @navbar-default-toggle-hover-bg:           #ddd;
+// @navbar-default-toggle-icon-bar-bg:        #888;
+// @navbar-default-toggle-border-color:       #ddd;
+//
+//
+// //=== Inverted navbar
+// // Reset inverted navbar basics
+// @navbar-inverse-color:                      lighten(@gray-light, 15%);
+// @navbar-inverse-bg:                         #222;
+// @navbar-inverse-border:                     darken(@navbar-inverse-bg, 10%);
+//
+// // Inverted navbar links
+// @navbar-inverse-link-color:                 lighten(@gray-light, 15%);
+// @navbar-inverse-link-hover-color:           #fff;
+// @navbar-inverse-link-hover-bg:              transparent;
+// @navbar-inverse-link-active-color:          @navbar-inverse-link-hover-color;
+// @navbar-inverse-link-active-bg:             darken(@navbar-inverse-bg, 10%);
+// @navbar-inverse-link-disabled-color:        #444;
+// @navbar-inverse-link-disabled-bg:           transparent;
+//
+// // Inverted navbar brand label
+// @navbar-inverse-brand-color:                @navbar-inverse-link-color;
+// @navbar-inverse-brand-hover-color:          #fff;
+// @navbar-inverse-brand-hover-bg:             transparent;
+//
+// // Inverted navbar toggle
+// @navbar-inverse-toggle-hover-bg:            #333;
+// @navbar-inverse-toggle-icon-bar-bg:         #fff;
+// @navbar-inverse-toggle-border-color:        #333;
+//
+//
+// //== Navs
+// //
+// //##
+//
+// //=== Shared nav styles
+// @nav-link-padding:                          10px 15px;
+// @nav-link-hover-bg:                         @gray-lighter;
+//
+// @nav-disabled-link-color:                   @gray-light;
+// @nav-disabled-link-hover-color:             @gray-light;
+//
+// //== Tabs
+// @nav-tabs-border-color:                     #ddd;
+//
+// @nav-tabs-link-hover-border-color:          @gray-lighter;
+//
+// @nav-tabs-active-link-hover-bg:             @body-bg;
+// @nav-tabs-active-link-hover-color:          @gray;
+// @nav-tabs-active-link-hover-border-color:   #ddd;
+//
+// @nav-tabs-justified-link-border-color:            #ddd;
+// @nav-tabs-justified-active-link-border-color:     @body-bg;
+//
+// //== Pills
+// @nav-pills-border-radius:                   @border-radius-base;
+// @nav-pills-active-link-hover-bg:            @component-active-bg;
+// @nav-pills-active-link-hover-color:         @component-active-color;
+//
+//
+// //== Pagination
+// //
+// //##
+//
+// @pagination-color:                     @link-color;
+// @pagination-bg:                        #fff;
+// @pagination-border:                    #ddd;
+//
+// @pagination-hover-color:               @link-hover-color;
+// @pagination-hover-bg:                  @gray-lighter;
+// @pagination-hover-border:              #ddd;
+//
+// @pagination-active-color:              #fff;
+// @pagination-active-bg:                 @brand-primary;
+// @pagination-active-border:             @brand-primary;
+//
+// @pagination-disabled-color:            @gray-light;
+// @pagination-disabled-bg:               #fff;
+// @pagination-disabled-border:           #ddd;
+//
+//
+// //== Pager
+// //
+// //##
+//
+// @pager-bg:                             @pagination-bg;
+// @pager-border:                         @pagination-border;
+// @pager-border-radius:                  15px;
+//
+// @pager-hover-bg:                       @pagination-hover-bg;
+//
+// @pager-active-bg:                      @pagination-active-bg;
+// @pager-active-color:                   @pagination-active-color;
+//
+// @pager-disabled-color:                 @pagination-disabled-color;
+//
+//
+// //== Jumbotron
+// //
+// //##
+//
+// @jumbotron-padding:              30px;
+// @jumbotron-color:                inherit;
+// @jumbotron-bg:                   @gray-lighter;
+// @jumbotron-heading-color:        inherit;
+// @jumbotron-font-size:            ceil((@font-size-base * 1.5));
+// @jumbotron-heading-font-size:    ceil((@font-size-base * 4.5));
+//
+//
+// //== Form states and alerts
+// //
+// //## Define colors for form feedback states and, by default, alerts.
+//
+// @state-success-text:             #3c763d;
+// @state-success-bg:               #dff0d8;
+// @state-success-border:           darken(spin(@state-success-bg, -10), 5%);
+//
+// @state-info-text:                #31708f;
+// @state-info-bg:                  #d9edf7;
+// @state-info-border:              darken(spin(@state-info-bg, -10), 7%);
+//
+// @state-warning-text:             #8a6d3b;
+// @state-warning-bg:               #fcf8e3;
+// @state-warning-border:           darken(spin(@state-warning-bg, -10), 5%);
+//
+// @state-danger-text:              #a94442;
+// @state-danger-bg:                #f2dede;
+// @state-danger-border:            darken(spin(@state-danger-bg, -10), 5%);
+//
+//
+// //== Tooltips
+// //
+// //##
+//
+// //** Tooltip max width
+// @tooltip-max-width:           200px;
+// //** Tooltip text color
+// @tooltip-color:               #fff;
+// //** Tooltip background color
+// @tooltip-bg:                  #000;
+// @tooltip-opacity:             .9;
+//
+// //** Tooltip arrow width
+// @tooltip-arrow-width:         5px;
+// //** Tooltip arrow color
+// @tooltip-arrow-color:         @tooltip-bg;
+//
+//
+// //== Popovers
+// //
+// //##
+//
+// //** Popover body background color
+// @popover-bg:                          #fff;
+// //** Popover maximum width
+// @popover-max-width:                   276px;
+// //** Popover border color
+// @popover-border-color:                rgba(0,0,0,.2);
+// //** Popover fallback border color
+// @popover-fallback-border-color:       #ccc;
+//
+// //** Popover title background color
+// @popover-title-bg:                    darken(@popover-bg, 3%);
+//
+// //** Popover arrow width
+// @popover-arrow-width:                 10px;
+// //** Popover arrow color
+// @popover-arrow-color:                 @popover-bg;
+//
+// //** Popover outer arrow width
+// @popover-arrow-outer-width:           (@popover-arrow-width + 1);
+// //** Popover outer arrow color
+// @popover-arrow-outer-color:           fadein(@popover-border-color, 5%);
+// //** Popover outer arrow fallback color
+// @popover-arrow-outer-fallback-color:  darken(@popover-fallback-border-color, 20%);
+//
+//
+// //== Labels
+// //
+// //##
+//
+// //** Default label background color
+// @label-default-bg:            @gray-light;
+// //** Primary label background color
+// @label-primary-bg:            @brand-primary;
+// //** Success label background color
+// @label-success-bg:            @brand-success;
+// //** Info label background color
+// @label-info-bg:               @brand-info;
+// //** Warning label background color
+// @label-warning-bg:            @brand-warning;
+// //** Danger label background color
+// @label-danger-bg:             @brand-danger;
+//
+// //** Default label text color
+// @label-color:                 #fff;
+// //** Default text color of a linked label
+// @label-link-hover-color:      #fff;
+//
+//
+// //== Modals
+// //
+// //##
+//
+// //** Padding applied to the modal body
+// @modal-inner-padding:         15px;
+//
+// //** Padding applied to the modal title
+// @modal-title-padding:         15px;
+// //** Modal title line-height
+// @modal-title-line-height:     @line-height-base;
+//
+// //** Background color of modal content area
+// @modal-content-bg:                             #fff;
+// //** Modal content border color
+// @modal-content-border-color:                   rgba(0,0,0,.2);
+// //** Modal content border color **for IE8**
+// @modal-content-fallback-border-color:          #999;
+//
+// //** Modal backdrop background color
+// @modal-backdrop-bg:           #000;
+// //** Modal backdrop opacity
+// @modal-backdrop-opacity:      .5;
+// //** Modal header border color
+// @modal-header-border-color:   #e5e5e5;
+// //** Modal footer border color
+// @modal-footer-border-color:   @modal-header-border-color;
+//
+// @modal-lg:                    900px;
+// @modal-md:                    600px;
+// @modal-sm:                    300px;
+//
+//
+// //== Alerts
+// //
+// //## Define alert colors, border radius, and padding.
+//
+// @alert-padding:               15px;
+// @alert-border-radius:         @border-radius-base;
+// @alert-link-font-weight:      bold;
+//
+// @alert-success-bg:            @state-success-bg;
+// @alert-success-text:          @state-success-text;
+// @alert-success-border:        @state-success-border;
+//
+// @alert-info-bg:               @state-info-bg;
+// @alert-info-text:             @state-info-text;
+// @alert-info-border:           @state-info-border;
+//
+// @alert-warning-bg:            @state-warning-bg;
+// @alert-warning-text:          @state-warning-text;
+// @alert-warning-border:        @state-warning-border;
+//
+// @alert-danger-bg:             @state-danger-bg;
+// @alert-danger-text:           @state-danger-text;
+// @alert-danger-border:         @state-danger-border;
+//
+//
+// //== Progress bars
+// //
+// //##
+//
+// //** Background color of the whole progress component
+// @progress-bg:                 #f5f5f5;
+// //** Progress bar text color
+// @progress-bar-color:          #fff;
+// //** Variable for setting rounded corners on progress bar.
+// @progress-border-radius:      @border-radius-base;
+//
+// //** Default progress bar color
+// @progress-bar-bg:             @brand-primary;
+// //** Success progress bar color
+// @progress-bar-success-bg:     @brand-success;
+// //** Warning progress bar color
+// @progress-bar-warning-bg:     @brand-warning;
+// //** Danger progress bar color
+// @progress-bar-danger-bg:      @brand-danger;
+// //** Info progress bar color
+// @progress-bar-info-bg:        @brand-info;
+//
+//
+// //== List group
+// //
+// //##
+//
+// //** Background color on `.list-group-item`
+// @list-group-bg:                 #fff;
+// //** `.list-group-item` border color
+// @list-group-border:             #ddd;
+// //** List group border radius
+// @list-group-border-radius:      @border-radius-base;
+//
+// //** Background color of single list items on hover
+// @list-group-hover-bg:           #f5f5f5;
+// //** Text color of active list items
+// @list-group-active-color:       @component-active-color;
+// //** Background color of active list items
+// @list-group-active-bg:          @component-active-bg;
+// //** Border color of active list elements
+// @list-group-active-border:      @list-group-active-bg;
+// //** Text color for content within active list items
+// @list-group-active-text-color:  lighten(@list-group-active-bg, 40%);
+//
+// //** Text color of disabled list items
+// @list-group-disabled-color:      @gray-light;
+// //** Background color of disabled list items
+// @list-group-disabled-bg:         @gray-lighter;
+// //** Text color for content within disabled list items
+// @list-group-disabled-text-color: @list-group-disabled-color;
+//
+// @list-group-link-color:         #555;
+// @list-group-link-hover-color:   @list-group-link-color;
+// @list-group-link-heading-color: #333;
+//
+//
+// //== Panels
+// //
+// //##
+//
+// @panel-bg:                    #fff;
+// @panel-body-padding:          15px;
+// @panel-heading-padding:       10px 15px;
+// @panel-footer-padding:        @panel-heading-padding;
+// @panel-border-radius:         @border-radius-base;
+//
+// //** Border color for elements within panels
+// @panel-inner-border:          #ddd;
+// @panel-footer-bg:             #f5f5f5;
+//
+// @panel-default-text:          @gray-dark;
+// @panel-default-border:        #ddd;
+// @panel-default-heading-bg:    #f5f5f5;
+//
+// @panel-primary-text:          #fff;
+// @panel-primary-border:        @brand-primary;
+// @panel-primary-heading-bg:    @brand-primary;
+//
+// @panel-success-text:          @state-success-text;
+// @panel-success-border:        @state-success-border;
+// @panel-success-heading-bg:    @state-success-bg;
+//
+// @panel-info-text:             @state-info-text;
+// @panel-info-border:           @state-info-border;
+// @panel-info-heading-bg:       @state-info-bg;
+//
+// @panel-warning-text:          @state-warning-text;
+// @panel-warning-border:        @state-warning-border;
+// @panel-warning-heading-bg:    @state-warning-bg;
+//
+// @panel-danger-text:           @state-danger-text;
+// @panel-danger-border:         @state-danger-border;
+// @panel-danger-heading-bg:     @state-danger-bg;
+//
+//
+// //== Thumbnails
+// //
+// //##
+//
+// //** Padding around the thumbnail image
+// @thumbnail-padding:           4px;
+// //** Thumbnail background color
+// @thumbnail-bg:                @body-bg;
+// //** Thumbnail border color
+// @thumbnail-border:            #ddd;
+// //** Thumbnail border radius
+// @thumbnail-border-radius:     @border-radius-base;
+//
+// //** Custom text color for thumbnail captions
+// @thumbnail-caption-color:     @text-color;
+// //** Padding around the thumbnail caption
+// @thumbnail-caption-padding:   9px;
+//
+//
+// //== Wells
+// //
+// //##
+//
+// @well-bg:                     #f5f5f5;
+// @well-border:                 darken(@well-bg, 7%);
+//
+//
+// //== Badges
+// //
+// //##
+//
+// @badge-color:                 #fff;
+// //** Linked badge text color on hover
+// @badge-link-hover-color:      #fff;
+// @badge-bg:                    @gray-light;
+//
+// //** Badge text color in active nav link
+// @badge-active-color:          @link-color;
+// //** Badge background color in active nav link
+// @badge-active-bg:             #fff;
+//
+// @badge-font-weight:           bold;
+// @badge-line-height:           1;
+// @badge-border-radius:         10px;
+//
+//
+// //== Breadcrumbs
+// //
+// //##
+//
+// @breadcrumb-padding-vertical:   8px;
+// @breadcrumb-padding-horizontal: 15px;
+// //** Breadcrumb background color
+// @breadcrumb-bg:                 #f5f5f5;
+// //** Breadcrumb text color
+// @breadcrumb-color:              #ccc;
+// //** Text color of current page in the breadcrumb
+// @breadcrumb-active-color:       @gray-light;
+// //** Textual separator for between breadcrumb elements
+// @breadcrumb-separator:          "/";
+//
+//
+// //== Carousel
+// //
+// //##
+//
+// @carousel-text-shadow:                        0 1px 2px rgba(0,0,0,.6);
+//
+// @carousel-control-color:                      #fff;
+// @carousel-control-width:                      15%;
+// @carousel-control-opacity:                    .5;
+// @carousel-control-font-size:                  20px;
+//
+// @carousel-indicator-active-bg:                #fff;
+// @carousel-indicator-border-color:             #fff;
+//
+// @carousel-caption-color:                      #fff;
+//
+//
+// //== Close
+// //
+// //##
+//
+// @close-font-weight:           bold;
+// @close-color:                 #000;
+// @close-text-shadow:           0 1px 0 #fff;
+//
+//
+// //== Code
+// //
+// //##
+//
+// @code-color:                  #c7254e;
+// @code-bg:                     #f9f2f4;
+//
+// @kbd-color:                   #fff;
+// @kbd-bg:                      #333;
+//
+// @pre-bg:                      #f5f5f5;
+// @pre-color:                   @gray-dark;
+// @pre-border-color:            #ccc;
+// @pre-scrollable-max-height:   340px;
+//
+//
+// //== Type
+// //
+// //##
+//
+// //** Horizontal offset for forms and lists.
+// @component-offset-horizontal: 180px;
+// //** Text muted color
+// @text-muted:                  @gray-light;
+// //** Abbreviations and acronyms border color
+// @abbr-border-color:           @gray-light;
+// //** Headings small color
+// @headings-small-color:        @gray-light;
+// //** Blockquote small color
+// @blockquote-small-color:      @gray-light;
+// //** Blockquote font size
+// @blockquote-font-size:        (@font-size-base * 1.25);
+// //** Blockquote border color
+// @blockquote-border-color:     @gray-lighter;
+// //** Page header border color
+// @page-header-border-color:    @gray-lighter;
+// //** Width of horizontal description list titles
+// @dl-horizontal-offset:        @component-offset-horizontal;
+// //** Point at which .dl-horizontal becomes horizontal
+// @dl-horizontal-breakpoint:    @grid-float-breakpoint;
+// //** Horizontal line color.
+// @hr-border:                   @gray-lighter;

--- a/static/variables/variables.less
+++ b/static/variables/variables.less
@@ -47,7 +47,7 @@
 // @font-family-sans-serif:  "Helvetica Neue", Helvetica, Arial, sans-serif;
 // @font-family-serif:       Georgia, "Times New Roman", Times, serif;
 // //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
-// @font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
+@font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
 // @font-family-base:        @font-family-sans-serif;
 //
 @font-size-base:          14px;
@@ -60,12 +60,12 @@
 // @font-size-h4:            ceil((@font-size-base * 1.25)); // ~18px
 // @font-size-h5:            @font-size-base;
 // @font-size-h6:            ceil((@font-size-base * 0.85)); // ~12px
-//
-// //** Unit-less `line-height` for use in components like buttons.
+
+//** Unit-less `line-height` for use in components like buttons.
 @line-height-base:        1.428571429; // 20/14
-// //** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
-// @line-height-computed:    floor((@font-size-base * @line-height-base)); // ~20px
-//
+//** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
+@line-height-computed:    floor((@font-size-base * @line-height-base)); // ~20px
+
 // //** By default, this inherits from the `<body>`.
 // @headings-font-family:    inherit;
 // @headings-font-weight:    500;

--- a/static/variables/variables.less
+++ b/static/variables/variables.less
@@ -46,47 +46,19 @@
 //
 //## Font, line-height, and color for body text, headings, and more.
 
-// @font-family-sans-serif:  "Helvetica Neue", Helvetica, Arial, sans-serif;
-// @font-family-serif:       Georgia, "Times New Roman", Times, serif;
-// //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
+//** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
 @font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
-// @font-family-base:        @font-family-sans-serif;
-//
+
 @font-size-base:          14px;
 @font-size-large:         ceil((@font-size-base * 1.25)); // ~18px
 @font-size-small:         ceil((@font-size-base * 0.85)); // ~12px
-
-// @font-size-h1:            floor((@font-size-base * 2.6)); // ~36px
-// @font-size-h2:            floor((@font-size-base * 2.15)); // ~30px
-// @font-size-h3:            ceil((@font-size-base * 1.7)); // ~24px
-// @font-size-h4:            ceil((@font-size-base * 1.25)); // ~18px
-// @font-size-h5:            @font-size-base;
-// @font-size-h6:            ceil((@font-size-base * 0.85)); // ~12px
 
 //** Unit-less `line-height` for use in components like buttons.
 @line-height-base:        1.428571429; // 20/14
 //** Computed "line-height" (`font-size` * `line-height`) for use with `margin`, `padding`, etc.
 @line-height-computed:    floor((@font-size-base * @line-height-base)); // ~20px
 
-// //** By default, this inherits from the `<body>`.
-// @headings-font-family:    inherit;
-// @headings-font-weight:    500;
-// @headings-line-height:    1.1;
-// @headings-color:          inherit;
-//
-//
-// //== Iconography
-// //
-// //## Specify custom location and filename of the included Glyphicons icon font. Useful for those including Bootstrap via Bower.
-//
-// //** Load fonts from this directory.
-// @icon-font-path:          "../fonts/";
-// //** File name for all font files.
-// @icon-font-name:          "glyphicons-halflings-regular";
-// //** Element ID within SVG icon file.
-// @icon-font-svg-id:        "glyphicons_halflingsregular";
-//
-//
+
 //== Components
 //
 //## Define common padding and border radius sizes and more. Values based on 14px text and 1.428 line-height (~20px to start).
@@ -116,30 +88,9 @@
 @component-active-bg:       @brand-primary;
 
 //** Width of the `border` for generating carets that indicator dropdowns.
-// @caret-width-base:          4px;
+@caret-width-base:          4px;
 //** Carets increase slightly in size for larger components.
 @caret-width-large:         5px;
-
-//
-// //== Tables
-// //
-// //## Customizes the `.table` component with basic values, each used across all table variations.
-//
-// //** Padding for `<th>`s and `<td>`s.
-// @table-cell-padding:            8px;
-// //** Padding for cells in `.table-condensed`.
-// @table-condensed-cell-padding:  5px;
-//
-// //** Default background color used for all tables.
-// @table-bg:                      transparent;
-// //** Background color used for `.table-striped`.
-// @table-bg-accent:               #f9f9f9;
-// //** Background color used for `.table-hover`.
-// @table-bg-hover:                #f5f5f5;
-// @table-bg-active:               @table-bg-hover;
-//
-// //** Border color for table and cell borders.
-// @table-border-color:            #ddd;
 
 
 //== Buttons
@@ -172,492 +123,32 @@
 @btn-border-radius-small:        @component-border-radius / 2;
 
 
-// //== Forms
-// //
-// //##
-//
-// //** `<input>` background color
-// @input-bg:                       #fff;
-// //** `<input disabled>` background color
-// @input-bg-disabled:              @gray-lighter;
-//
-// //** Text color for `<input>`s
-// @input-color:                    @gray;
-// //** `<input>` border color
-// @input-border:                   #ccc;
-//
-// // TODO: Rename `@input-border-radius` to `@input-border-radius-base` in v4
-// //** Default `.form-control` border radius
-// // This has no effect on `<select>`s in some browsers, due to the limited stylability of `<select>`s in CSS.
-// @input-border-radius:            @border-radius-base;
-// //** Large `.form-control` border radius
-// @input-border-radius-large:      @border-radius-large;
-// //** Small `.form-control` border radius
-// @input-border-radius-small:      @border-radius-small;
-//
-// //** Border color for inputs on focus
-// @input-border-focus:             #66afe9;
-//
-// //** Placeholder text color
-// @input-color-placeholder:        #999;
-//
-// //** Default `.form-control` height
-// @input-height-base:              (@line-height-computed + (@padding-base-vertical * 2) + 2);
-// //** Large `.form-control` height
-// @input-height-large:             (ceil(@font-size-large * @line-height-large) + (@padding-large-vertical * 2) + 2);
-// //** Small `.form-control` height
-// @input-height-small:             (floor(@font-size-small * @line-height-small) + (@padding-small-vertical * 2) + 2);
-//
-// //** `.form-group` margin
-// @form-group-margin-bottom:       15px;
-//
-// @legend-color:                   @gray-dark;
-// @legend-border-color:            #e5e5e5;
-//
-// //** Background color for textual input addons
-// @input-group-addon-bg:           @gray-lighter;
-// //** Border color for textual input addons
-// @input-group-addon-border-color: @input-border;
 
-//** Disabled cursor for form controls and buttons.
-@cursor-disabled:                not-allowed;
-
-
-// //== Dropdowns
-// //
-// //## Dropdown menu container and contents.
+//== Media queries breakpoints
 //
-// //** Background for the dropdown menu.
-// @dropdown-bg:                    #fff;
-// //** Dropdown menu `border-color`.
-// @dropdown-border:                rgba(0,0,0,.15);
-// //** Dropdown menu `border-color` **for IE8**.
-// @dropdown-fallback-border:       #ccc;
-// //** Divider color for between dropdown items.
-// @dropdown-divider-bg:            #e5e5e5;
-//
-// //** Dropdown link text color.
-// @dropdown-link-color:            @gray-dark;
-// //** Hover color for dropdown links.
-// @dropdown-link-hover-color:      darken(@gray-dark, 5%);
-// //** Hover background for dropdown links.
-// @dropdown-link-hover-bg:         #f5f5f5;
-//
-// //** Active dropdown menu item text color.
-// @dropdown-link-active-color:     @component-active-color;
-// //** Active dropdown menu item background color.
-// @dropdown-link-active-bg:        @component-active-bg;
-//
-// //** Disabled dropdown menu item background color.
-// @dropdown-link-disabled-color:   @gray-light;
-//
-// //** Text color for headers within dropdown menus.
-// @dropdown-header-color:          @gray-light;
-//
-// //** Deprecated `@dropdown-caret-color` as of v3.1.0
-// @dropdown-caret-color:           #000;
-//
-//
-// //-- Z-index master list
-// //
-// // Warning: Avoid customizing these values. They're used for a bird's eye view
-// // of components dependent on the z-axis and are designed to all work together.
-// //
-// // Note: These variables are not generated into the Customizer.
-//
-// @zindex-navbar:            1000;
-// @zindex-dropdown:          1000;
-// @zindex-popover:           1060;
-// @zindex-tooltip:           1070;
-// @zindex-navbar-fixed:      1030;
-// @zindex-modal-background:  1040;
-// @zindex-modal:             1050;
-//
-//
-// //== Media queries breakpoints
-// //
-// //## Define the breakpoints at which your layout will change, adapting to different screen sizes.
-//
-// // Extra small screen / phone
-// //** Deprecated `@screen-xs` as of v3.0.1
-// @screen-xs:                  480px;
-// //** Deprecated `@screen-xs-min` as of v3.2.0
-// @screen-xs-min:              @screen-xs;
-// //** Deprecated `@screen-phone` as of v3.0.1
-// @screen-phone:               @screen-xs-min;
+//## Define the breakpoints at which your layout will change, adapting to different screen sizes
 
 // Small screen / tablet
 //** Deprecated `@screen-sm` as of v3.0.1
 @screen-sm:                  768px;
 @screen-sm-min:              @screen-sm;
-// //** Deprecated `@screen-tablet` as of v3.0.1
-// @screen-tablet:              @screen-sm-min;
-//
-// // Medium screen / desktop
-// //** Deprecated `@screen-md` as of v3.0.1
-// @screen-md:                  992px;
-// @screen-md-min:              @screen-md;
-// //** Deprecated `@screen-desktop` as of v3.0.1
-// @screen-desktop:             @screen-md-min;
-//
-// // Large screen / wide desktop
-// //** Deprecated `@screen-lg` as of v3.0.1
-// @screen-lg:                  1200px;
-// @screen-lg-min:              @screen-lg;
-// //** Deprecated `@screen-lg-desktop` as of v3.0.1
-// @screen-lg-desktop:          @screen-lg-min;
-//
-// // So media queries don't overlap when required, provide a maximum
-// @screen-xs-max:              (@screen-sm-min - 1);
-// @screen-sm-max:              (@screen-md-min - 1);
-// @screen-md-max:              (@screen-lg-min - 1);
-//
-//
-// //== Grid system
-// //
-// //## Define your custom responsive grid.
-//
-// //** Number of columns in the grid.
-// @grid-columns:              12;
-// //** Padding between columns. Gets divided in half for the left and right.
-// @grid-gutter-width:         30px;
-// // Navbar collapse
-// //** Point at which the navbar becomes uncollapsed.
-// @grid-float-breakpoint:     @screen-sm-min;
-// //** Point at which the navbar begins collapsing.
-// @grid-float-breakpoint-max: (@grid-float-breakpoint - 1);
-//
-//
-// //== Container sizes
-// //
-// //## Define the maximum width of `.container` for different screen sizes.
-//
-// // Small screen / tablet
-// @container-tablet:             (720px + @grid-gutter-width);
-// //** For `@screen-sm-min` and up.
-// @container-sm:                 @container-tablet;
-//
-// // Medium screen / desktop
-// @container-desktop:            (940px + @grid-gutter-width);
-// //** For `@screen-md-min` and up.
-// @container-md:                 @container-desktop;
-//
-// // Large screen / wide desktop
-// @container-large-desktop:      (1140px + @grid-gutter-width);
-// //** For `@screen-lg-min` and up.
-// @container-lg:                 @container-large-desktop;
-//
-//
-// //== Navbar
-// //
-// //##
-//
-// // Basics of a navbar
-// @navbar-height:                    50px;
-// @navbar-margin-bottom:             @line-height-computed;
-// @navbar-border-radius:             @border-radius-base;
-// @navbar-padding-horizontal:        floor((@grid-gutter-width / 2));
-// @navbar-padding-vertical:          ((@navbar-height - @line-height-computed) / 2);
-// @navbar-collapse-max-height:       340px;
-//
-// @navbar-default-color:             #777;
-// @navbar-default-bg:                #f8f8f8;
-// @navbar-default-border:            darken(@navbar-default-bg, 6.5%);
-//
-// // Navbar links
-// @navbar-default-link-color:                #777;
-// @navbar-default-link-hover-color:          #333;
-// @navbar-default-link-hover-bg:             transparent;
-// @navbar-default-link-active-color:         #555;
-// @navbar-default-link-active-bg:            darken(@navbar-default-bg, 6.5%);
-// @navbar-default-link-disabled-color:       #ccc;
-// @navbar-default-link-disabled-bg:          transparent;
-//
-// // Navbar brand label
-// @navbar-default-brand-color:               @navbar-default-link-color;
-// @navbar-default-brand-hover-color:         darken(@navbar-default-brand-color, 10%);
-// @navbar-default-brand-hover-bg:            transparent;
-//
-// // Navbar toggle
-// @navbar-default-toggle-hover-bg:           #ddd;
-// @navbar-default-toggle-icon-bar-bg:        #888;
-// @navbar-default-toggle-border-color:       #ddd;
-//
-//
-// //=== Inverted navbar
-// // Reset inverted navbar basics
-// @navbar-inverse-color:                      lighten(@gray-light, 15%);
-// @navbar-inverse-bg:                         #222;
-// @navbar-inverse-border:                     darken(@navbar-inverse-bg, 10%);
-//
-// // Inverted navbar links
-// @navbar-inverse-link-color:                 lighten(@gray-light, 15%);
-// @navbar-inverse-link-hover-color:           #fff;
-// @navbar-inverse-link-hover-bg:              transparent;
-// @navbar-inverse-link-active-color:          @navbar-inverse-link-hover-color;
-// @navbar-inverse-link-active-bg:             darken(@navbar-inverse-bg, 10%);
-// @navbar-inverse-link-disabled-color:        #444;
-// @navbar-inverse-link-disabled-bg:           transparent;
-//
-// // Inverted navbar brand label
-// @navbar-inverse-brand-color:                @navbar-inverse-link-color;
-// @navbar-inverse-brand-hover-color:          #fff;
-// @navbar-inverse-brand-hover-bg:             transparent;
-//
-// // Inverted navbar toggle
-// @navbar-inverse-toggle-hover-bg:            #333;
-// @navbar-inverse-toggle-icon-bar-bg:         #fff;
-// @navbar-inverse-toggle-border-color:        #333;
-//
-//
-// //== Navs
-// //
-// //##
-//
-// //=== Shared nav styles
-// @nav-link-padding:                          10px 15px;
-// @nav-link-hover-bg:                         @gray-lighter;
-//
-// @nav-disabled-link-color:                   @gray-light;
-// @nav-disabled-link-hover-color:             @gray-light;
-//
-// //== Tabs
-// @nav-tabs-border-color:                     #ddd;
-//
-// @nav-tabs-link-hover-border-color:          @gray-lighter;
-//
-// @nav-tabs-active-link-hover-bg:             @body-bg;
-// @nav-tabs-active-link-hover-color:          @gray;
-// @nav-tabs-active-link-hover-border-color:   #ddd;
-//
-// @nav-tabs-justified-link-border-color:            #ddd;
-// @nav-tabs-justified-active-link-border-color:     @body-bg;
-//
-// //== Pills
-// @nav-pills-border-radius:                   @border-radius-base;
-// @nav-pills-active-link-hover-bg:            @component-active-bg;
-// @nav-pills-active-link-hover-color:         @component-active-color;
-//
-//
-// //== Pagination
-// //
-// //##
-//
-// @pagination-color:                     @link-color;
-// @pagination-bg:                        #fff;
-// @pagination-border:                    #ddd;
-//
-// @pagination-hover-color:               @link-hover-color;
-// @pagination-hover-bg:                  @gray-lighter;
-// @pagination-hover-border:              #ddd;
-//
-// @pagination-active-color:              #fff;
-// @pagination-active-bg:                 @brand-primary;
-// @pagination-active-border:             @brand-primary;
-//
-// @pagination-disabled-color:            @gray-light;
-// @pagination-disabled-bg:               #fff;
-// @pagination-disabled-border:           #ddd;
-//
-//
-// //== Pager
-// //
-// //##
-//
-// @pager-bg:                             @pagination-bg;
-// @pager-border:                         @pagination-border;
-// @pager-border-radius:                  15px;
-//
-// @pager-hover-bg:                       @pagination-hover-bg;
-//
-// @pager-active-bg:                      @pagination-active-bg;
-// @pager-active-color:                   @pagination-active-color;
-//
-// @pager-disabled-color:                 @pagination-disabled-color;
-//
-//
-// //== Jumbotron
-// //
-// //##
-//
-// @jumbotron-padding:              30px;
-// @jumbotron-color:                inherit;
-// @jumbotron-bg:                   @gray-lighter;
-// @jumbotron-heading-color:        inherit;
-// @jumbotron-font-size:            ceil((@font-size-base * 1.5));
-// @jumbotron-heading-font-size:    ceil((@font-size-base * 4.5));
-//
-//
+
+
 // //== Form states and alerts
 // //
 // //## Define colors for form feedback states and, by default, alerts.
 //
 @state-success-text:             #3c763d;
 @state-success-bg:               #dff0d8;
-// @state-success-border:           darken(spin(@state-success-bg, -10), 5%);
 
 @state-info-text:                #31708f;
 @state-info-bg:                  #d9edf7;
-// @state-info-border:              darken(spin(@state-info-bg, -10), 7%);
 
 @state-warning-text:             #8a6d3b;
 @state-warning-bg:               #fcf8e3;
-// @state-warning-border:           darken(spin(@state-warning-bg, -10), 5%);
 
 @state-danger-text:              #a94442;
 @state-danger-bg:                #f2dede;
-// @state-danger-border:            darken(spin(@state-danger-bg, -10), 5%);
-//
-//
-// //== Tooltips
-// //
-// //##
-//
-// //** Tooltip max width
-// @tooltip-max-width:           200px;
-// //** Tooltip text color
-// @tooltip-color:               #fff;
-// //** Tooltip background color
-// @tooltip-bg:                  #000;
-// @tooltip-opacity:             .9;
-//
-// //** Tooltip arrow width
-// @tooltip-arrow-width:         5px;
-// //** Tooltip arrow color
-// @tooltip-arrow-color:         @tooltip-bg;
-//
-//
-// //== Popovers
-// //
-// //##
-//
-// //** Popover body background color
-// @popover-bg:                          #fff;
-// //** Popover maximum width
-// @popover-max-width:                   276px;
-// //** Popover border color
-// @popover-border-color:                rgba(0,0,0,.2);
-// //** Popover fallback border color
-// @popover-fallback-border-color:       #ccc;
-//
-// //** Popover title background color
-// @popover-title-bg:                    darken(@popover-bg, 3%);
-//
-// //** Popover arrow width
-// @popover-arrow-width:                 10px;
-// //** Popover arrow color
-// @popover-arrow-color:                 @popover-bg;
-//
-// //** Popover outer arrow width
-// @popover-arrow-outer-width:           (@popover-arrow-width + 1);
-// //** Popover outer arrow color
-// @popover-arrow-outer-color:           fadein(@popover-border-color, 5%);
-// //** Popover outer arrow fallback color
-// @popover-arrow-outer-fallback-color:  darken(@popover-fallback-border-color, 20%);
-//
-//
-// //== Labels
-// //
-// //##
-//
-// //** Default label background color
-// @label-default-bg:            @gray-light;
-// //** Primary label background color
-// @label-primary-bg:            @brand-primary;
-// //** Success label background color
-// @label-success-bg:            @brand-success;
-// //** Info label background color
-// @label-info-bg:               @brand-info;
-// //** Warning label background color
-// @label-warning-bg:            @brand-warning;
-// //** Danger label background color
-// @label-danger-bg:             @brand-danger;
-//
-// //** Default label text color
-// @label-color:                 #fff;
-// //** Default text color of a linked label
-// @label-link-hover-color:      #fff;
-//
-//
-// //== Modals
-// //
-// //##
-//
-// //** Padding applied to the modal body
-// @modal-inner-padding:         15px;
-//
-// //** Padding applied to the modal title
-// @modal-title-padding:         15px;
-// //** Modal title line-height
-// @modal-title-line-height:     @line-height-base;
-//
-// //** Background color of modal content area
-// @modal-content-bg:                             #fff;
-// //** Modal content border color
-// @modal-content-border-color:                   rgba(0,0,0,.2);
-// //** Modal content border color **for IE8**
-// @modal-content-fallback-border-color:          #999;
-//
-// //** Modal backdrop background color
-// @modal-backdrop-bg:           #000;
-// //** Modal backdrop opacity
-// @modal-backdrop-opacity:      .5;
-// //** Modal header border color
-// @modal-header-border-color:   #e5e5e5;
-// //** Modal footer border color
-// @modal-footer-border-color:   @modal-header-border-color;
-//
-// @modal-lg:                    900px;
-// @modal-md:                    600px;
-// @modal-sm:                    300px;
-//
-//
-// //== Alerts
-// //
-// //## Define alert colors, border radius, and padding.
-//
-// @alert-padding:               15px;
-// @alert-border-radius:         @border-radius-base;
-// @alert-link-font-weight:      bold;
-//
-// @alert-success-bg:            @state-success-bg;
-// @alert-success-text:          @state-success-text;
-// @alert-success-border:        @state-success-border;
-//
-// @alert-info-bg:               @state-info-bg;
-// @alert-info-text:             @state-info-text;
-// @alert-info-border:           @state-info-border;
-//
-// @alert-warning-bg:            @state-warning-bg;
-// @alert-warning-text:          @state-warning-text;
-// @alert-warning-border:        @state-warning-border;
-//
-// @alert-danger-bg:             @state-danger-bg;
-// @alert-danger-text:           @state-danger-text;
-// @alert-danger-border:         @state-danger-border;
-//
-//
-// //== Progress bars
-// //
-// //##
-//
-// //** Background color of the whole progress component
-// @progress-bg:                 #f5f5f5;
-// //** Progress bar text color
-// @progress-bar-color:          #fff;
-// //** Variable for setting rounded corners on progress bar.
-// @progress-border-radius:      @border-radius-base;
-//
-// //** Default progress bar color
-// @progress-bar-bg:             @brand-primary;
-// //** Success progress bar color
-// @progress-bar-success-bg:     @brand-success;
-// //** Warning progress bar color
-// @progress-bar-warning-bg:     @brand-warning;
-// //** Danger progress bar color
-// @progress-bar-danger-bg:      @brand-danger;
-// //** Info progress bar color
-// @progress-bar-info-bg:        @brand-info;
 
 
 // == List group
@@ -694,45 +185,6 @@
 @list-group-link-heading-color: #333;
 
 
-// //== Panels
-// //
-// //##
-//
-// @panel-bg:                    #fff;
-// @panel-body-padding:          15px;
-// @panel-heading-padding:       10px 15px;
-// @panel-footer-padding:        @panel-heading-padding;
-// @panel-border-radius:         @border-radius-base;
-//
-// //** Border color for elements within panels
-// @panel-inner-border:          #ddd;
-// @panel-footer-bg:             #f5f5f5;
-//
-// @panel-default-text:          @gray-dark;
-// @panel-default-border:        #ddd;
-// @panel-default-heading-bg:    #f5f5f5;
-//
-// @panel-primary-text:          #fff;
-// @panel-primary-border:        @brand-primary;
-// @panel-primary-heading-bg:    @brand-primary;
-//
-// @panel-success-text:          @state-success-text;
-// @panel-success-border:        @state-success-border;
-// @panel-success-heading-bg:    @state-success-bg;
-//
-// @panel-info-text:             @state-info-text;
-// @panel-info-border:           @state-info-border;
-// @panel-info-heading-bg:       @state-info-bg;
-//
-// @panel-warning-text:          @state-warning-text;
-// @panel-warning-border:        @state-warning-border;
-// @panel-warning-heading-bg:    @state-warning-bg;
-//
-// @panel-danger-text:           @state-danger-text;
-// @panel-danger-border:         @state-danger-border;
-// @panel-danger-heading-bg:     @state-danger-bg;
-//
-//
 //== Thumbnails
 //
 //##
@@ -746,120 +198,11 @@
 //** Thumbnail border radius
 @thumbnail-border-radius:     @border-radius-base;
 
-// //** Custom text color for thumbnail captions
-// @thumbnail-caption-color:     @text-color;
-// //** Padding around the thumbnail caption
-// @thumbnail-caption-padding:   9px;
+
+//== Misc
 //
-//
-// //== Wells
-// //
-// //##
-//
-// @well-bg:                     #f5f5f5;
-// @well-border:                 darken(@well-bg, 7%);
-//
-//
-// //== Badges
-// //
-// //##
-//
-// @badge-color:                 #fff;
-// //** Linked badge text color on hover
-// @badge-link-hover-color:      #fff;
-// @badge-bg:                    @gray-light;
-//
-// //** Badge text color in active nav link
-// @badge-active-color:          @link-color;
-// //** Badge background color in active nav link
-// @badge-active-bg:             #fff;
-//
-// @badge-font-weight:           bold;
-// @badge-line-height:           1;
-// @badge-border-radius:         10px;
-//
-//
-// //== Breadcrumbs
-// //
-// //##
-//
-// @breadcrumb-padding-vertical:   8px;
-// @breadcrumb-padding-horizontal: 15px;
-// //** Breadcrumb background color
-// @breadcrumb-bg:                 #f5f5f5;
-// //** Breadcrumb text color
-// @breadcrumb-color:              #ccc;
-// //** Text color of current page in the breadcrumb
-// @breadcrumb-active-color:       @gray-light;
-// //** Textual separator for between breadcrumb elements
-// @breadcrumb-separator:          "/";
-//
-//
-// //== Carousel
-// //
-// //##
-//
-// @carousel-text-shadow:                        0 1px 2px rgba(0,0,0,.6);
-//
-// @carousel-control-color:                      #fff;
-// @carousel-control-width:                      15%;
-// @carousel-control-opacity:                    .5;
-// @carousel-control-font-size:                  20px;
-//
-// @carousel-indicator-active-bg:                #fff;
-// @carousel-indicator-border-color:             #fff;
-//
-// @carousel-caption-color:                      #fff;
-//
-//
-// //== Close
-// //
-// //##
-//
-// @close-font-weight:           bold;
-// @close-color:                 #000;
-// @close-text-shadow:           0 1px 0 #fff;
-//
-//
-// //== Code
-// //
-// //##
-//
-// @code-color:                  #c7254e;
-// @code-bg:                     #f9f2f4;
-//
-// @kbd-color:                   #fff;
-// @kbd-bg:                      #333;
-//
-// @pre-bg:                      #f5f5f5;
-// @pre-color:                   @gray-dark;
-// @pre-border-color:            #ccc;
-// @pre-scrollable-max-height:   340px;
-//
-//
-// //== Type
-// //
-// //##
-//
-// //** Horizontal offset for forms and lists.
-// @component-offset-horizontal: 180px;
-// //** Text muted color
-// @text-muted:                  @gray-light;
-// //** Abbreviations and acronyms border color
-// @abbr-border-color:           @gray-light;
-// //** Headings small color
-// @headings-small-color:        @gray-light;
-// //** Blockquote small color
-// @blockquote-small-color:      @gray-light;
-// //** Blockquote font size
-// @blockquote-font-size:        (@font-size-base * 1.25);
-// //** Blockquote border color
-// @blockquote-border-color:     @gray-lighter;
-// //** Page header border color
-// @page-header-border-color:    @gray-lighter;
-// //** Width of horizontal description list titles
-// @dl-horizontal-offset:        @component-offset-horizontal;
-// //** Point at which .dl-horizontal becomes horizontal
-// @dl-horizontal-breakpoint:    @grid-float-breakpoint;
-//** Horizontal line color.
-@hr-border:                   @gray-lighter;
+//##
+
+//** Disabled cursor for form controls and buttons.
+@cursor-disabled: not-allowed;
+@hr-border:       @gray-lighter;

--- a/static/variables/variables.less
+++ b/static/variables/variables.less
@@ -18,11 +18,11 @@
 @gray-light:             lighten(@gray-base, 46.7%); // #777
 @gray-lighter:           lighten(@gray-base, 93.5%); // #eee
 
-@brand-primary:         darken(#428bca, 6.5%); // #337ab7
-@brand-success:         #5cb85c;
-@brand-info:            #5bc0de;
-@brand-warning:         #f0ad4e;
-@brand-danger:          #d9534f;
+@brand-primary:         @text-color-info;
+@brand-info:            @text-color-info;
+@brand-success:         @text-color-success;
+@brand-warning:         @text-color-warning;
+@brand-danger:          @text-color-error;
 
 
 //== Scaffolding
@@ -30,10 +30,7 @@
 //## Settings for some of the most global styles.
 
 //** Background color for `<body>`.
-@body-bg:               #fff;
-//** Global text color on `<body>`.
-@text-color:            @gray-dark;
-
+@body-bg:               @app-background-color;
 //** Global textual link color.
 @link-color:            @brand-primary;
 //** Link hover color set via `darken()` function.
@@ -49,7 +46,7 @@
 //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
 @font-family-monospace:   Menlo, Monaco, Consolas, "Courier New", monospace;
 
-@font-size-base:          14px;
+@font-size-base:          @font-size;
 @font-size-large:         ceil((@font-size-base * 1.25)); // ~18px
 @font-size-small:         ceil((@font-size-base * 0.85)); // ~12px
 

--- a/static/variables/variables.less
+++ b/static/variables/variables.less
@@ -739,19 +739,19 @@
 // @panel-danger-heading-bg:     @state-danger-bg;
 //
 //
-// //== Thumbnails
-// //
-// //##
+//== Thumbnails
 //
-// //** Padding around the thumbnail image
-// @thumbnail-padding:           4px;
-// //** Thumbnail background color
-// @thumbnail-bg:                @body-bg;
-// //** Thumbnail border color
-// @thumbnail-border:            #ddd;
-// //** Thumbnail border radius
-// @thumbnail-border-radius:     @border-radius-base;
-//
+//##
+
+//** Padding around the thumbnail image
+@thumbnail-padding:           4px;
+//** Thumbnail background color
+@thumbnail-bg:                @body-bg;
+//** Thumbnail border color
+@thumbnail-border:            #ddd;
+//** Thumbnail border radius
+@thumbnail-border-radius:     @border-radius-base;
+
 // //** Custom text color for thumbnail captions
 // @thumbnail-caption-color:     @text-color;
 // //** Padding around the thumbnail caption
@@ -867,5 +867,5 @@
 // @dl-horizontal-offset:        @component-offset-horizontal;
 // //** Point at which .dl-horizontal becomes horizontal
 // @dl-horizontal-breakpoint:    @grid-float-breakpoint;
-// //** Horizontal line color.
-// @hr-border:                   @gray-lighter;
+//** Horizontal line color.
+@hr-border:                   @gray-lighter;

--- a/static/variables/variables.less
+++ b/static/variables/variables.less
@@ -112,12 +112,12 @@
 // @component-active-color:    #fff;
 // //** Global background color for active items (e.g., navs or dropdowns).
 // @component-active-bg:       @brand-primary;
-//
-// //** Width of the `border` for generating carets that indicator dropdowns.
+
+//** Width of the `border` for generating carets that indicator dropdowns.
 // @caret-width-base:          4px;
-// //** Carets increase slightly in size for larger components.
-// @caret-width-large:         5px;
-//
+//** Carets increase slightly in size for larger components.
+@caret-width-large:         5px;
+
 //
 // //== Tables
 // //

--- a/static/variables/variables.less
+++ b/static/variables/variables.less
@@ -103,15 +103,15 @@
 
 @line-height-large:         1.3333333; // extra decimals for Win 8.1 Chrome
 @line-height-small:         1.5;
-//
-// @border-radius-base:        4px;
-// @border-radius-large:       6px;
-// @border-radius-small:       3px;
-//
-// //** Global color for active items (e.g., navs or dropdowns).
-// @component-active-color:    #fff;
-// //** Global background color for active items (e.g., navs or dropdowns).
-// @component-active-bg:       @brand-primary;
+
+@border-radius-base:        4px;
+@border-radius-large:       6px;
+@border-radius-small:       3px;
+
+//** Global color for active items (e.g., navs or dropdowns).
+@component-active-color:    #fff;
+//** Global background color for active items (e.g., navs or dropdowns).
+@component-active-bg:       @brand-primary;
 
 //** Width of the `border` for generating carets that indicator dropdowns.
 // @caret-width-base:          4px;
@@ -498,20 +498,20 @@
 // //
 // //## Define colors for form feedback states and, by default, alerts.
 //
-// @state-success-text:             #3c763d;
-// @state-success-bg:               #dff0d8;
+@state-success-text:             #3c763d;
+@state-success-bg:               #dff0d8;
 // @state-success-border:           darken(spin(@state-success-bg, -10), 5%);
-//
-// @state-info-text:                #31708f;
-// @state-info-bg:                  #d9edf7;
+
+@state-info-text:                #31708f;
+@state-info-bg:                  #d9edf7;
 // @state-info-border:              darken(spin(@state-info-bg, -10), 7%);
-//
-// @state-warning-text:             #8a6d3b;
-// @state-warning-bg:               #fcf8e3;
+
+@state-warning-text:             #8a6d3b;
+@state-warning-bg:               #fcf8e3;
 // @state-warning-border:           darken(spin(@state-warning-bg, -10), 5%);
-//
-// @state-danger-text:              #a94442;
-// @state-danger-bg:                #f2dede;
+
+@state-danger-text:              #a94442;
+@state-danger-bg:                #f2dede;
 // @state-danger-border:            darken(spin(@state-danger-bg, -10), 5%);
 //
 //
@@ -664,42 +664,42 @@
 // @progress-bar-danger-bg:      @brand-danger;
 // //** Info progress bar color
 // @progress-bar-info-bg:        @brand-info;
+
+
+// == List group
 //
-//
-// //== List group
-// //
-// //##
-//
-// //** Background color on `.list-group-item`
-// @list-group-bg:                 #fff;
-// //** `.list-group-item` border color
-// @list-group-border:             #ddd;
-// //** List group border radius
-// @list-group-border-radius:      @border-radius-base;
-//
-// //** Background color of single list items on hover
-// @list-group-hover-bg:           #f5f5f5;
-// //** Text color of active list items
-// @list-group-active-color:       @component-active-color;
-// //** Background color of active list items
-// @list-group-active-bg:          @component-active-bg;
-// //** Border color of active list elements
-// @list-group-active-border:      @list-group-active-bg;
-// //** Text color for content within active list items
-// @list-group-active-text-color:  lighten(@list-group-active-bg, 40%);
-//
-// //** Text color of disabled list items
-// @list-group-disabled-color:      @gray-light;
-// //** Background color of disabled list items
-// @list-group-disabled-bg:         @gray-lighter;
-// //** Text color for content within disabled list items
-// @list-group-disabled-text-color: @list-group-disabled-color;
-//
-// @list-group-link-color:         #555;
-// @list-group-link-hover-color:   @list-group-link-color;
-// @list-group-link-heading-color: #333;
-//
-//
+// ##
+
+//** Background color on `.list-group-item`
+@list-group-bg:                 #fff;
+//** `.list-group-item` border color
+@list-group-border:             #ddd;
+//** List group border radius
+@list-group-border-radius:      @border-radius-base;
+
+//** Background color of single list items on hover
+@list-group-hover-bg:           #f5f5f5;
+//** Text color of active list items
+@list-group-active-color:       @component-active-color;
+//** Background color of active list items
+@list-group-active-bg:          @component-active-bg;
+//** Border color of active list elements
+@list-group-active-border:      @list-group-active-bg;
+//** Text color for content within active list items
+@list-group-active-text-color:  lighten(@list-group-active-bg, 40%);
+
+//** Text color of disabled list items
+@list-group-disabled-color:      @gray-light;
+//** Background color of disabled list items
+@list-group-disabled-bg:         @gray-lighter;
+//** Text color for content within disabled list items
+@list-group-disabled-text-color: @list-group-disabled-color;
+
+@list-group-link-color:         #555;
+@list-group-link-hover-color:   @list-group-link-color;
+@list-group-link-heading-color: #333;
+
+
 // //== Panels
 // //
 // //##

--- a/static/variables/variables.less
+++ b/static/variables/variables.less
@@ -125,11 +125,10 @@
 //
 //## Define the breakpoints at which your layout will change, adapting to different screen sizes
 
-// Small screen / tablet
-//** Deprecated `@screen-sm` as of v3.0.1
 @screen-sm:                  768px;
 @screen-sm-min:              @screen-sm;
 
+@screen-xs-max:              (@screen-sm-min - 1);
 
 // //== Form states and alerts
 // //
@@ -200,10 +199,33 @@
 @thumbnail-border-radius:     @border-radius-base;
 
 
+//== Type
+//
+//##
+
+//** Horizontal offset for forms and lists.
+@component-offset-horizontal: 180px;
+//** Text muted color
+@text-muted:                  @gray-light;
+//** Abbreviations and acronyms border color
+@abbr-border-color:           @gray-light;
+//** Headings small color
+@headings-small-color:        @gray-light;
+//** Blockquote small color
+@blockquote-small-color:      @gray-light;
+//** Blockquote font size
+@blockquote-font-size:        (@font-size-base * 1.25);
+//** Blockquote border color
+@blockquote-border-color:     @gray-lighter;
+//** Page header border color
+@page-header-border-color:    @gray-lighter;
+//** Horizontal line color.
+@hr-border:                   @gray-lighter;
+
+
 //== Misc
 //
 //##
 
 //** Disabled cursor for form controls and buttons.
 @cursor-disabled: not-allowed;
-@hr-border:       @gray-lighter;

--- a/static/variables/variables.less
+++ b/static/variables/variables.less
@@ -23,14 +23,14 @@
 @brand-danger:          #d9534f;
 
 
-// //== Scaffolding
-// //
-// //## Settings for some of the most global styles.
+//== Scaffolding
 //
-// //** Background color for `<body>`.
-// @body-bg:               #fff;
-// //** Global text color on `<body>`.
-// @text-color:            @gray-dark;
+//## Settings for some of the most global styles.
+
+//** Background color for `<body>`.
+@body-bg:               #fff;
+//** Global text color on `<body>`.
+@text-color:            @gray-dark;
 
 //** Global textual link color.
 @link-color:            @brand-primary;
@@ -291,11 +291,11 @@
 // @screen-xs-min:              @screen-xs;
 // //** Deprecated `@screen-phone` as of v3.0.1
 // @screen-phone:               @screen-xs-min;
-//
-// // Small screen / tablet
-// //** Deprecated `@screen-sm` as of v3.0.1
-// @screen-sm:                  768px;
-// @screen-sm-min:              @screen-sm;
+
+// Small screen / tablet
+//** Deprecated `@screen-sm` as of v3.0.1
+@screen-sm:                  768px;
+@screen-sm-min:              @screen-sm;
 // //** Deprecated `@screen-tablet` as of v3.0.1
 // @screen-tablet:              @screen-sm-min;
 //

--- a/static/variables/variables.less
+++ b/static/variables/variables.less
@@ -1,3 +1,5 @@
+@import "ui-variables";
+
 //
 // Core Variables (Forked from Bootstrap 3.3.6)
 // Don't use these variables in packages/themes.
@@ -138,46 +140,38 @@
 //
 // //** Border color for table and cell borders.
 // @table-border-color:            #ddd;
+
+
+//== Buttons
 //
-//
-// //== Buttons
-// //
-// //## For each of Bootstrap's buttons, define text, background and border color.
-//
-// @btn-font-weight:                normal;
-//
-// @btn-default-color:              #333;
-// @btn-default-bg:                 #fff;
-// @btn-default-border:             #ccc;
-//
-// @btn-primary-color:              #fff;
-// @btn-primary-bg:                 @brand-primary;
-// @btn-primary-border:             darken(@btn-primary-bg, 5%);
-//
-// @btn-success-color:              #fff;
-// @btn-success-bg:                 @brand-success;
-// @btn-success-border:             darken(@btn-success-bg, 5%);
-//
-// @btn-info-color:                 #fff;
-// @btn-info-bg:                    @brand-info;
-// @btn-info-border:                darken(@btn-info-bg, 5%);
-//
-// @btn-warning-color:              #fff;
-// @btn-warning-bg:                 @brand-warning;
-// @btn-warning-border:             darken(@btn-warning-bg, 5%);
-//
-// @btn-danger-color:               #fff;
-// @btn-danger-bg:                  @brand-danger;
-// @btn-danger-border:              darken(@btn-danger-bg, 5%);
-//
-// @btn-link-disabled-color:        @gray-light;
-//
-// // Allows for customizing button radius independently from global border radius
-// @btn-border-radius-base:         @border-radius-base;
-// @btn-border-radius-large:        @border-radius-large;
-// @btn-border-radius-small:        @border-radius-small;
-//
-//
+//## For each of Bootstrap's buttons, define text, background and border color.
+
+@btn-default-color:              @text-color;
+@btn-default-bg:                 @button-background-color;
+
+@btn-primary-color:              #fff;
+@btn-primary-bg:                 @background-color-info;
+
+@btn-success-color:              #fff;
+@btn-success-bg:                 @background-color-success;
+
+@btn-info-color:                 #fff;
+@btn-info-bg:                    @background-color-info;
+
+@btn-warning-color:              #fff;
+@btn-warning-bg:                 @background-color-warning;
+
+@btn-error-color:               #fff;
+@btn-error-bg:                  @background-color-error;
+
+@btn-link-disabled-color:        @text-color-subtle;
+
+// Allows for customizing button radius independently from global border radius
+@btn-border-radius-base:         @component-border-radius;
+@btn-border-radius-large:        @component-border-radius * 2;
+@btn-border-radius-small:        @component-border-radius / 2;
+
+
 // //== Forms
 // //
 // //##

--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -1,20 +1,6 @@
 @import "ui-variables";
 @import "octicon-mixins";
 
-@font-face { .octicon-font(); }
-
-html {
-  font-family: @font-family;
-  font-size: @font-size;
-}
-
-html,
-body {
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-}
-
 atom-workspace {
   display: flex;
   flex-direction: column;
@@ -28,7 +14,7 @@ atom-workspace {
   atom-workspace-axis {
     position: relative;
   }
-  
+
   atom-workspace-axis.horizontal {
     display: flex;
     flex: 1;

--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -1,5 +1,4 @@
 @import "ui-variables";
-@import "octicon-mixins";
 
 atom-workspace {
   display: flex;


### PR DESCRIPTION
⚠️  This is in parallel to #11858 + 11875. Don't merge all PRs, only pick one. ⚠️ 

This moves most of the Bootstrap styles into Core. The styles are based on Bootstrap `3.3.6`. It probably will be the last Bootstrap version that supports Less.

Refs: #6351, #8237 
### Moved + merged into Core
- [x] Tooltips
- [x] Buttons + Button Groups
- [x] Lists
- [x] Code
- [x] Nav
- [x] Scaffolding
- [x] Utilities
- [x] Alerts
- [x] Tables
- [x] Forms
- [x] Type
- [x] Normalize
- [x] Clean up some un-used styles. Like IE hacks etc.
### Removed
- 🔥  grid
- 🔥  input-groups
- 🔥  labels
- 🔥  thumbnails
- 🔥  close
## Risks

Since some styles got removed, there is a chance that something might look unstyled or off. Packages bundled with Atom should be fine, but it's hard to predict if community packages rely on any of the removed styles.

/cc @atom/design @atom/feedback 
