### PR TITLE
Address "node-gyp not found" in Windows build troubleshooting

### DIFF
--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -91,6 +91,9 @@ If none of this works, do install Github Desktop and use its Git Shell as it mak
 * `error MSB8020: The build tools for Visual Studio 201? (Platform Toolset = 'v1?0') cannot be found.`
   * If you're building Atom with Visual Studio 2013 try setting the `GYP_MSVS_VERSION` environment variable to 2013 and then `script/clean` followed by `script/build` (re-open your command prompt or Powershell window if you set it using the GUI)
 
+* `'node-gyp' is not recognized as an internal or external command, operable program or batch file.`
+  * Try running `npm install -g node-gyp`, and run `script/build` again.
+
 * Other `node-gyp` errors on first build attempt, even though the right Node.js and Python versions are installed.
   * Do try the build command one more time, as experience shows it often works on second try in many of these cases.
 


### PR DESCRIPTION
I caught an issue while building Atom on a Windows VM which caused `script/build` to fail. Namely, it seems like `node-gyp` couldn't be found for some reason; installing it manually fixed the problem on my virtual machine, so this pull-request adds `npm install -g node-gyp` as a workaround in the Windows build instructions (under the troubleshooting section).

/cc: @atom/core and @damieng for 👀 
