### PR TITLE
Fix flexbox issues after upgrading to Electron v0.37.8

### DIFF
--- a/spec/pane-element-spec.coffee
+++ b/spec/pane-element-spec.coffee
@@ -1,12 +1,13 @@
 PaneContainer = require '../src/pane-container'
 
 describe "PaneElement", ->
-  [paneElement, container, pane] = []
+  [paneElement, container, containerElement, pane] = []
 
   beforeEach ->
     spyOn(atom.applicationDelegate, "open")
 
     container = new PaneContainer(config: atom.config, confirm: atom.confirm.bind(atom))
+    containerElement = atom.views.getView(container)
     pane = container.getActivePane()
     paneElement = atom.views.getView(pane)
 
@@ -195,3 +196,18 @@ describe "PaneElement", ->
         event = buildDragEvent("drop", [])
         paneElement.dispatchEvent(event)
         expect(atom.applicationDelegate.open).not.toHaveBeenCalled()
+
+  describe "resize", ->
+    it "shrinks independently of its contents' width", ->
+      jasmine.attachToDOM(containerElement)
+      item = document.createElement('div')
+      item.style.width = "2000px"
+      item.style.height = "30px"
+      paneElement.insertBefore(item, paneElement.children[0])
+
+      paneElement.style.flexGrow = 0.1
+      expect(paneElement.getBoundingClientRect().width).toBeGreaterThan(0)
+      expect(paneElement.getBoundingClientRect().width).toBeLessThan(item.getBoundingClientRect().width)
+
+      paneElement.style.flexGrow = 0
+      expect(paneElement.getBoundingClientRect().width).toBe(0)

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -64,10 +64,6 @@ class LinesComponent extends TiledComponent
         @domNode.appendChild(@placeholderTextDiv)
       @oldState.placeholderText = @newState.placeholderText
 
-    if @newState.width isnt @oldState.width
-      @domNode.style.width = @newState.width + 'px'
-      @oldState.width = @newState.width
-
     @cursorsComponent.updateSync(state)
 
   buildComponentForTile: (id) -> new LinesTileComponent({id, @presenter, @domElementPool, @assert, @grammars})

--- a/static/panes.less
+++ b/static/panes.less
@@ -48,6 +48,7 @@ atom-pane-container {
     -webkit-flex: 1;
     -webkit-flex-direction: column;
     overflow: visible;
+    min-width: 0;
 
     .item-views {
       -webkit-flex: 1;


### PR DESCRIPTION
1) Fixes atom/find-and-replace#732.
2) Fixes an issue with resizing atom panes when one or more panes had many open tabs.

After [upgrading to Electron v0.37.8](https://github.com/atom/atom/pull/11474), we have noticed a couple of regressions when resizing some of Atom's UI elements. In particular, it seems like some of the flexbox rules for laying content out have changed since v0.36.12, and this causes elements like `atom-pane` or find-and-replace input boxes, to not shrink correctly when they are resized.

This pull-request fixes 1) by removing the explicit width on `atom-text-editor`'s `.lines` element (setting it should be unnecessary after #6733), which sometimes caused `atom-text-editor`'s width to determine the width of its parent, and 2) by allowing `atom-pane`s to be shrunk indefinitely, as it was before the Electron bump.
