### PR TITLE
Allow different versions of Atom to run simultaneously on Win32

### DIFF
--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -32,7 +32,7 @@ class AtomApplication
   @open: (options) ->
     unless options.socketPath?
       if process.platform is 'win32'
-        options.socketPath = '\\\\.\\pipe\\atom-sock'
+        options.socketPath = "\\\\.\\pipe\\atom-#{options.version}-sock"
       else
         options.socketPath = path.join(os.tmpdir(), "atom-#{options.version}-#{process.env.USER}.sock")
 


### PR DESCRIPTION
Allow side-by-side versions to run rather than whichever version of Atom was launched first ends up opening all subsequent requests.
