### PR TITLE
Fix overflowing of the tabs

### DIFF
--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -38,5 +38,6 @@ atom-workspace {
     display: flex;
     flex: 1;
     flex-direction: column;
+    min-width: 0;
   }
 }


### PR DESCRIPTION
This is a follow up for #11866.

In this case when there are too many tabs, they start to push `atom-workspace-axis.vertical` beyond the window width.

![image](https://cloud.githubusercontent.com/assets/490562/15840511/54e98534-2c9e-11e6-84cd-90067c05aebd.png)

Fixes https://github.com/atom/one-dark-ui/issues/138
