### PR TITLE
Complete documentation for Notification creation

### DIFF
--- a/src/notification-manager.coffee
+++ b/src/notification-manager.coffee
@@ -33,8 +33,18 @@ class NotificationManager
   #
   # * `message` A {String} message
   # * `options` (optional) An options {Object} with the following keys:
-  #    * `detail` (optional) A {String} with additional details about the
-  #      notification.
+  #    * `buttons` (optional) An {Array} of {Object} where each {Object} has the
+  #      following options:
+  #      * `className` (optional) {String} additional class name add to the
+  #        button. It will already receive `btn btn-success`.
+  #      * `onClick` (optional) {Function} callback to call when the button is
+  #        clicked. The context will be set to the {NotificationElement}
+  #        instance.
+  #      * `text` {String} inner text for the button
+  #    * `description` (optional) A {String} that will be rendered as Markdown
+  #      to describe the notification.
+  #    * `detail` (optional) A preformatted {String} that will be rendered as
+  #      plain text with details about the notification.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
   #      notification can be dismissed by the user. Defaults to `false`.
   #    * `icon` (optional) A {String} name of an icon from Octicons to display
@@ -46,8 +56,18 @@ class NotificationManager
   #
   # * `message` A {String} message
   # * `options` (optional) An options {Object} with the following keys:
-  #    * `detail` (optional) A {String} with additional details about the
-  #      notification.
+  #    * `buttons` (optional) An {Array} of {Object} where each {Object} has the
+  #      following options:
+  #      * `className` (optional) {String} additional class name add to the
+  #        button. It will already receive `btn btn-info`.
+  #      * `onClick` (optional) {Function} callback to call when the button is
+  #        clicked. The context will be set to the {NotificationElement}
+  #        instance.
+  #      * `text` {String} inner text for the button
+  #    * `description` (optional) A {String} that will be rendered as Markdown
+  #      to describe the notification.
+  #    * `detail` (optional) A preformatted {String} that will be rendered as
+  #      plain text with details about the notification.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
   #      notification can be dismissed by the user. Defaults to `false`.
   #    * `icon` (optional) A {String} name of an icon from Octicons to display
@@ -59,8 +79,18 @@ class NotificationManager
   #
   # * `message` A {String} message
   # * `options` (optional) An options {Object} with the following keys:
-  #    * `detail` (optional) A {String} with additional details about the
-  #      notification.
+  #    * `buttons` (optional) An {Array} of {Object} where each {Object} has the
+  #      following options:
+  #      * `className` (optional) {String} additional class name add to the
+  #        button. It will already receive `btn btn-warning`.
+  #      * `onClick` (optional) {Function} callback to call when the button is
+  #        clicked. The context will be set to the {NotificationElement}
+  #        instance.
+  #      * `text` {String} inner text for the button
+  #    * `description` (optional) A {String} that will be rendered as Markdown
+  #      to describe the notification.
+  #    * `detail` (optional) A preformatted {String} that will be rendered as
+  #      plain text with details about the notification.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
   #      notification can be dismissed by the user. Defaults to `false`.
   #    * `icon` (optional) A {String} name of an icon from Octicons to display
@@ -72,12 +102,24 @@ class NotificationManager
   #
   # * `message` A {String} message
   # * `options` (optional) An options {Object} with the following keys:
-  #    * `detail` (optional) A {String} with additional details about the
-  #      notification.
+  #    * `buttons` (optional) An {Array} of {Object} where each {Object} has the
+  #      following options:
+  #      * `className` (optional) {String} additional class name add to the
+  #        button. It will already receive `btn btn-error`.
+  #      * `onClick` (optional) {Function} callback to call when the button is
+  #        clicked. The context will be set to the {NotificationElement}
+  #        instance.
+  #      * `text` {String} inner text for the button
+  #    * `description` (optional) A {String} that will be rendered as Markdown
+  #      to describe the notification.
+  #    * `detail` (optional) A preformatted {String} that will be rendered as
+  #      plain text with details about the notification.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
   #      notification can be dismissed by the user. Defaults to `false`.
   #    * `icon` (optional) A {String} name of an icon from Octicons to display
   #      in the notification header. Defaults to `'flame'`.
+  #    * `stack` (optional) A preformatted {String} with stack trace information
+  #      describing the location of the error.
   addError: (message, options) ->
     @addNotification(new Notification('error', message, options))
 
@@ -85,12 +127,24 @@ class NotificationManager
   #
   # * `message` A {String} message
   # * `options` (optional) An options {Object} with the following keys:
-  #    * `detail` (optional) A {String} with additional details about the
-  #      notification.
+  #    * `buttons` (optional) An {Array} of {Object} where each {Object} has the
+  #      following options:
+  #      * `className` (optional) {String} additional class name add to the
+  #        button. It will already receive `btn btn-error`.
+  #      * `onClick` (optional) {Function} callback to call when the button is
+  #        clicked. The context will be set to the {NotificationElement}
+  #        instance.
+  #      * `text` {String} inner text for the button
+  #    * `description` (optional) A {String} that will be rendered as Markdown
+  #      to describe the notification.
+  #    * `detail` (optional) A preformatted {String} that will be rendered as
+  #      plain text with details about the notification.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
   #      notification can be dismissed by the user. Defaults to `false`.
   #    * `icon` (optional) A {String} name of an icon from Octicons to display
   #      in the notification header. Defaults to `'bug'`.
+  #    * `stack` (optional) A preformatted {String} with stack trace information
+  #      describing the location of the error.
   addFatalError: (message, options) ->
     @addNotification(new Notification('fatal', message, options))
 

--- a/src/notification-manager.coffee
+++ b/src/notification-manager.coffee
@@ -42,9 +42,11 @@ class NotificationManager
   #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
   #    * `description` (optional) A Markdown {String} containing a longer
-  #      description about the notification.
-  #    * `detail` (optional) A preformatted {String} that will be rendered as
-  #      plain text with details about the notification.
+  #      description about the notification. By default, this **will not**
+  #      preserve newlines and whitespace when it is rendered.
+  #    * `detail` (optional) A plain-text {String} containing additional details
+  #      about the notification. By default, this **will** preserve newlines
+  #      and whitespace when it is rendered.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
   #      notification can be dismissed by the user. Defaults to `false`.
   #    * `icon` (optional) A {String} name of an icon from Octicons to display
@@ -65,9 +67,11 @@ class NotificationManager
   #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
   #    * `description` (optional) A Markdown {String} containing a longer
-  #      description about the notification.
-  #    * `detail` (optional) A preformatted {String} that will be rendered as
-  #      plain text with details about the notification.
+  #      description about the notification. By default, this **will not**
+  #      preserve newlines and whitespace when it is rendered.
+  #    * `detail` (optional) A plain-text {String} containing additional details
+  #      about the notification. By default, this **will** preserve newlines
+  #      and whitespace when it is rendered.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
   #      notification can be dismissed by the user. Defaults to `false`.
   #    * `icon` (optional) A {String} name of an icon from Octicons to display
@@ -88,9 +92,11 @@ class NotificationManager
   #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
   #    * `description` (optional) A Markdown {String} containing a longer
-  #      description about the notification.
-  #    * `detail` (optional) A preformatted {String} that will be rendered as
-  #      plain text with details about the notification.
+  #      description about the notification. By default, this **will not**
+  #      preserve newlines and whitespace when it is rendered.
+  #    * `detail` (optional) A plain-text {String} containing additional details
+  #      about the notification. By default, this **will** preserve newlines
+  #      and whitespace when it is rendered.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
   #      notification can be dismissed by the user. Defaults to `false`.
   #    * `icon` (optional) A {String} name of an icon from Octicons to display
@@ -111,9 +117,11 @@ class NotificationManager
   #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
   #    * `description` (optional) A Markdown {String} containing a longer
-  #      description about the notification.
-  #    * `detail` (optional) A preformatted {String} that will be rendered as
-  #      plain text with details about the notification.
+  #      description about the notification. By default, this **will not**
+  #      preserve newlines and whitespace when it is rendered.
+  #    * `detail` (optional) A plain-text {String} containing additional details
+  #      about the notification. By default, this **will** preserve newlines
+  #      and whitespace when it is rendered.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
   #      notification can be dismissed by the user. Defaults to `false`.
   #    * `icon` (optional) A {String} name of an icon from Octicons to display
@@ -136,9 +144,11 @@ class NotificationManager
   #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
   #    * `description` (optional) A Markdown {String} containing a longer
-  #      description about the notification.
-  #    * `detail` (optional) A preformatted {String} that will be rendered as
-  #      plain text with details about the notification.
+  #      description about the notification. By default, this **will not**
+  #      preserve newlines and whitespace when it is rendered.
+  #    * `detail` (optional) A plain-text {String} containing additional details
+  #      about the notification. By default, this **will** preserve newlines
+  #      and whitespace when it is rendered.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
   #      notification can be dismissed by the user. Defaults to `false`.
   #    * `icon` (optional) A {String} name of an icon from Octicons to display

--- a/src/notification-manager.coffee
+++ b/src/notification-manager.coffee
@@ -35,14 +35,14 @@ class NotificationManager
   # * `options` (optional) An options {Object} with the following keys:
   #    * `buttons` (optional) An {Array} of {Object} where each {Object} has the
   #      following options:
-  #      * `className` (optional) {String} additional class name add to the
-  #        button. It will already receive `btn btn-success`.
+  #      * `className` (optional) {String} a class name to add to the button's
+  #        default class name (`btn btn-success`).
   #      * `onDidClick` (optional) {Function} callback to call when the button
   #        has been clicked. The context will be set to the
   #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
-  #    * `description` (optional) A {String} that will be rendered as Markdown
-  #      to describe the notification.
+  #    * `description` (optional) A Markdown {String} containing a longer
+  #      description about the notification.
   #    * `detail` (optional) A preformatted {String} that will be rendered as
   #      plain text with details about the notification.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
@@ -58,14 +58,14 @@ class NotificationManager
   # * `options` (optional) An options {Object} with the following keys:
   #    * `buttons` (optional) An {Array} of {Object} where each {Object} has the
   #      following options:
-  #      * `className` (optional) {String} additional class name add to the
-  #        button. It will already receive `btn btn-info`.
+  #      * `className` (optional) {String} a class name to add to the button's
+  #        default class name (`btn btn-info`).
   #      * `onDidClick` (optional) {Function} callback to call when the button
   #        has been clicked. The context will be set to the
   #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
-  #    * `description` (optional) A {String} that will be rendered as Markdown
-  #      to describe the notification.
+  #    * `description` (optional) A Markdown {String} containing a longer
+  #      description about the notification.
   #    * `detail` (optional) A preformatted {String} that will be rendered as
   #      plain text with details about the notification.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
@@ -81,14 +81,14 @@ class NotificationManager
   # * `options` (optional) An options {Object} with the following keys:
   #    * `buttons` (optional) An {Array} of {Object} where each {Object} has the
   #      following options:
-  #      * `className` (optional) {String} additional class name add to the
-  #        button. It will already receive `btn btn-warning`.
+  #      * `className` (optional) {String} a class name to add to the button's
+  #        default class name (`btn btn-warning`).
   #      * `onDidClick` (optional) {Function} callback to call when the button
   #        has been clicked. The context will be set to the
   #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
-  #    * `description` (optional) A {String} that will be rendered as Markdown
-  #      to describe the notification.
+  #    * `description` (optional) A Markdown {String} containing a longer
+  #      description about the notification.
   #    * `detail` (optional) A preformatted {String} that will be rendered as
   #      plain text with details about the notification.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
@@ -104,14 +104,14 @@ class NotificationManager
   # * `options` (optional) An options {Object} with the following keys:
   #    * `buttons` (optional) An {Array} of {Object} where each {Object} has the
   #      following options:
-  #      * `className` (optional) {String} additional class name add to the
-  #        button. It will already receive `btn btn-error`.
+  #      * `className` (optional) {String} a class name to add to the button's
+  #        default class name (`btn btn-error`).
   #      * `onDidClick` (optional) {Function} callback to call when the button
   #        has been clicked. The context will be set to the
   #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
-  #    * `description` (optional) A {String} that will be rendered as Markdown
-  #      to describe the notification.
+  #    * `description` (optional) A Markdown {String} containing a longer
+  #      description about the notification.
   #    * `detail` (optional) A preformatted {String} that will be rendered as
   #      plain text with details about the notification.
   #    * `dismissable` (optional) A {Boolean} indicating whether this
@@ -129,14 +129,14 @@ class NotificationManager
   # * `options` (optional) An options {Object} with the following keys:
   #    * `buttons` (optional) An {Array} of {Object} where each {Object} has the
   #      following options:
-  #      * `className` (optional) {String} additional class name add to the
-  #        button. It will already receive `btn btn-error`.
+  #      * `className` (optional) {String} a class name to add to the button's
+  #        default class name (`btn btn-error`).
   #      * `onDidClick` (optional) {Function} callback to call when the button
   #        has been clicked. The context will be set to the
   #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
-  #    * `description` (optional) A {String} that will be rendered as Markdown
-  #      to describe the notification.
+  #    * `description` (optional) A Markdown {String} containing a longer
+  #      description about the notification.
   #    * `detail` (optional) A preformatted {String} that will be rendered as
   #      plain text with details about the notification.
   #    * `dismissable` (optional) A {Boolean} indicating whether this

--- a/src/notification-manager.coffee
+++ b/src/notification-manager.coffee
@@ -37,9 +37,9 @@ class NotificationManager
   #      following options:
   #      * `className` (optional) {String} additional class name add to the
   #        button. It will already receive `btn btn-success`.
-  #      * `onClick` (optional) {Function} callback to call when the button is
-  #        clicked. The context will be set to the {NotificationElement}
-  #        instance.
+  #      * `onDidClick` (optional) {Function} callback to call when the button
+  #        has been clicked. The context will be set to the
+  #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
   #    * `description` (optional) A {String} that will be rendered as Markdown
   #      to describe the notification.
@@ -60,9 +60,9 @@ class NotificationManager
   #      following options:
   #      * `className` (optional) {String} additional class name add to the
   #        button. It will already receive `btn btn-info`.
-  #      * `onClick` (optional) {Function} callback to call when the button is
-  #        clicked. The context will be set to the {NotificationElement}
-  #        instance.
+  #      * `onDidClick` (optional) {Function} callback to call when the button
+  #        has been clicked. The context will be set to the
+  #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
   #    * `description` (optional) A {String} that will be rendered as Markdown
   #      to describe the notification.
@@ -83,9 +83,9 @@ class NotificationManager
   #      following options:
   #      * `className` (optional) {String} additional class name add to the
   #        button. It will already receive `btn btn-warning`.
-  #      * `onClick` (optional) {Function} callback to call when the button is
-  #        clicked. The context will be set to the {NotificationElement}
-  #        instance.
+  #      * `onDidClick` (optional) {Function} callback to call when the button
+  #        has been clicked. The context will be set to the
+  #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
   #    * `description` (optional) A {String} that will be rendered as Markdown
   #      to describe the notification.
@@ -106,9 +106,9 @@ class NotificationManager
   #      following options:
   #      * `className` (optional) {String} additional class name add to the
   #        button. It will already receive `btn btn-error`.
-  #      * `onClick` (optional) {Function} callback to call when the button is
-  #        clicked. The context will be set to the {NotificationElement}
-  #        instance.
+  #      * `onDidClick` (optional) {Function} callback to call when the button
+  #        has been clicked. The context will be set to the
+  #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
   #    * `description` (optional) A {String} that will be rendered as Markdown
   #      to describe the notification.
@@ -131,9 +131,9 @@ class NotificationManager
   #      following options:
   #      * `className` (optional) {String} additional class name add to the
   #        button. It will already receive `btn btn-error`.
-  #      * `onClick` (optional) {Function} callback to call when the button is
-  #        clicked. The context will be set to the {NotificationElement}
-  #        instance.
+  #      * `onDidClick` (optional) {Function} callback to call when the button
+  #        has been clicked. The context will be set to the
+  #        {NotificationElement} instance.
   #      * `text` {String} inner text for the button
   #    * `description` (optional) A {String} that will be rendered as Markdown
   #      to describe the notification.


### PR DESCRIPTION
Notifications support several options that were yet to be documented:
`buttons`, `description`, and `stack`. Add descriptions for each option
and its defaults (where applicable, e.g. .buttons.className).

`stack` is technically available on all notification types, but it
doesn't make sense to use it on types other than 'error' and 'fatal'.
Therefore it's documented only in those two cases.

The usage and expected display, like preformatted vs. Markdown, taken
from [atom/notifications/lib/notification-element.coffee](https://github.com/atom/notifications/blob/v0.64.1/lib/notification-element.coffee).
