### PR TITLE
Make interactive package tests work with a top-level 'test' directory

### DIFF
--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -1,5 +1,6 @@
 {ipcRenderer} = require 'electron'
 path = require 'path'
+fs = require 'fs-plus'
 {Disposable, CompositeDisposable} = require 'event-kit'
 Grim = require 'grim'
 scrollbarStyle = require 'scrollbar-style'
@@ -122,6 +123,12 @@ class WorkspaceElement extends HTMLElement
       [projectPath] = @project.relativizePath(activePath)
     else
       [projectPath] = @project.getPaths()
-    ipcRenderer.send('run-package-specs', path.join(projectPath, 'spec')) if projectPath
+    if projectPath
+      specPath = path.join(projectPath, 'spec')
+      testPath = path.join(projectPath, 'test')
+      if not fs.existsSync(specPath) and fs.existsSync(testPath)
+        specPath = testPath
+
+      ipcRenderer.send('run-package-specs', specPath)
 
 module.exports = WorkspaceElement = document.registerElement 'atom-workspace', prototype: WorkspaceElement.prototype


### PR DESCRIPTION
I realize this is vain, but I really hate the word "spec" and would like the option to just call them tests. That works fine when specifying paths on the command line, but the interactive runner was defaulting the path to `spec`. This allows `test` instead if no `spec` directory is present.

cc @as-cii @BinaryMuse 
