### PR TITLE
Don't test CSON.readFileSync behavior twice (here and in atom/season)

### DIFF
--- a/spec/compile-cache-spec.coffee
+++ b/spec/compile-cache-spec.coffee
@@ -4,7 +4,6 @@ Babel = require 'babel-core'
 CoffeeScript = require 'coffee-script'
 {TypeScriptSimple} = require 'typescript-simple'
 CSON = require 'season'
-CSONParser = require 'season/node_modules/cson-parser'
 CompileCache = require '../src/compile-cache'
 
 describe 'CompileCache', ->
@@ -20,7 +19,6 @@ describe 'CompileCache', ->
     spyOn(Babel, 'transform').andReturn {code: 'the-babel-code'}
     spyOn(CoffeeScript, 'compile').andReturn {js: 'the-coffee-code', v3SourceMap: "{}"}
     spyOn(TypeScriptSimple::, 'compile').andReturn 'the-typescript-code'
-    spyOn(CSONParser, 'parse').andReturn {the: 'cson-data'}
 
   afterEach ->
     CSON.setCacheDir(CompileCache.getCacheDirectory())
@@ -64,11 +62,18 @@ describe 'CompileCache', ->
 
     describe 'when the given file is CSON', ->
       it 'compiles the file to JSON and caches it', ->
-        CompileCache.addPathToCache(path.join(fixtures, 'cson.cson'), atomHome)
-        expect(CSONParser.parse.callCount).toBe 1
+        spyOn(CSON, 'setCacheDir').andCallThrough()
+        spyOn(CSON, 'readFileSync').andCallThrough()
 
         CompileCache.addPathToCache(path.join(fixtures, 'cson.cson'), atomHome)
-        expect(CSONParser.parse.callCount).toBe 1
+        expect(CSON.readFileSync).toHaveBeenCalledWith(path.join(fixtures, 'cson.cson'))
+        expect(CSON.setCacheDir).toHaveBeenCalledWith(path.join(atomHome, '/compile-cache'))
+
+        CSON.readFileSync.reset()
+        CSON.setCacheDir.reset()
+        CompileCache.addPathToCache(path.join(fixtures, 'cson.cson'), atomHome)
+        expect(CSON.readFileSync).toHaveBeenCalledWith(path.join(fixtures, 'cson.cson'))
+        expect(CSON.setCacheDir).not.toHaveBeenCalled()
 
   describe 'overriding Error.prepareStackTrace', ->
     it 'removes the override on the next tick, and always assigns the raw stack', ->


### PR DESCRIPTION
Our build is failing on Janky with the following exception:

```
[26891:0615/122703:INFO:CONSOLE(87)] "Error: Cannot find module 'season/node_modules/cson-parser'
  at Module._resolveFilename (module.js:339:15)
  at Function.Module._resolveFilename (/private/var/lib/jenkins/workspace/atom/src/module-cache.coffee:273:20)
  at Function.Module._load (module.js:290:25)
  at Module.require (module.js:367:17)
  at require (/private/var/lib/jenkins/workspace/atom/src/native-compile-cache.js:50:27)
  at Object.<anonymous> (/private/var/lib/jenkins/workspace/atom/spec/compile-cache-spec.coffee:7:14)
  at Object.<anonymous> (/private/var/lib/jenkins/workspace/atom/spec/compile-cache-spec.coffee:1:1)
```

Which points at a problem with requiring a module's internal submodule in `compile-cache-spec.coffee`. Instead of relying on a `season` internal module, with this pull-request we simply verify that the CSON module gets called appropriately and avoid testing its caching/parsing behavior again in Atom (i.e. it's already tested in https://github.com/atom/season/blob/master/spec/cson-spec.coffee#L207).

I am not clear on why Janky cannot find that internal module (maybe npm got updated there and the module is now flattened?), but it felt reasonable to avoid this anti-pattern in the spec so that we can make it more bulletproof independently of which npm version our CI is running.

/cc: @atom/core
