### PR TITLE
Update font stack

### DIFF
--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -82,4 +82,4 @@
 
 // Other
 
-@font-family: '.SFNSText-Regular', 'SF UI Text', 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;
+@font-family: 'BlinkMacSystemFont', 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;


### PR DESCRIPTION
Since Chrome 46 supports `BlinkMacSystemFont`, I think we should use it instead of  `.SFNSText-Regular` (also the private font is not working anymore on macOS Sierra).
