### PR TITLE
🐛 Fix $NODE_PATH being unset when using -a to add project

### DIFF
--- a/src/initialize-application-window.coffee
+++ b/src/initialize-application-window.coffee
@@ -11,11 +11,6 @@ module.exports = ({blobStore}) ->
   environmentHelpers.normalize({env: env})
   env = process.env
 
-  # Add application-specific exports to module search path.
-  exportsPath = path.join(resourcePath, 'exports')
-  require('module').globalPaths.push(exportsPath)
-  process.env.NODE_PATH = exportsPath
-
   # Make React faster
   process.env.NODE_ENV ?= 'production' unless devMode
 

--- a/src/main-process/main.coffee
+++ b/src/main-process/main.coffee
@@ -14,8 +14,9 @@ console.log = require 'nslog'
 
 start = ->
   args = parseCommandLine()
-  args.env = process.env
+  args.env = Object.assign({}, process.env)
   setupAtomHome(args)
+  setupNodePath(args)
   setupCompileCache()
   if handleStartupEventWithSquirrel()
     return
@@ -69,7 +70,7 @@ handleStartupEventWithSquirrel = ->
 setupCrashReporter = ->
   crashReporter.start(productName: 'Atom', companyName: 'GitHub', submitURL: 'http://54.249.141.255:1127/post')
 
-setupAtomHome = ({setPortable}) ->
+setupAtomHome = ({env, setPortable}) ->
   return if process.env.ATOM_HOME
 
   atomHome = path.join(app.getPath('home'), '.atom')
@@ -88,7 +89,12 @@ setupAtomHome = ({setPortable}) ->
   try
     atomHome = fs.realpathSync(atomHome)
 
-  process.env.ATOM_HOME = atomHome
+  process.env.ATOM_HOME = env.ATOM_HOME = atomHome
+
+setupNodePath = ({env, resourcePath}) ->
+  # Add application-specific exports to module search path.
+  exportsPath = path.join(resourcePath, 'exports')
+  env.NODE_PATH = exportsPath
 
 setupCompileCache = ->
   compileCache = require('../compile-cache')


### PR DESCRIPTION
When the -a flag is used, atom replaces env of the existing window. Since this existing window doesn't rerun `init-application-window.coffee`, the $NODE_PATH env variable becomes unset. This commit moves setting $NODE_PATH earlier in the window creation process so that it gets set regardless. This fixes the [issue](https://github.com/atom/fuzzy-finder/issues/205) where fuzzy-finder's indexing task cannot find the 'atom' module because the $NODE_PATH becomes unset.
