### PR TITLE
Recreate Repository if the same project is added after being removed

### DIFF
--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -363,6 +363,24 @@ describe "Project", ->
           # Verify that the result is cached.
           expect(atom.project.repositoryForDirectory(directory)).toBe(promise)
 
+    it "creates a new repository if a previous one with the same directory had been destroyed", ->
+      repository = null
+      directory = new Directory(path.join(__dirname, '..'))
+
+      waitsForPromise ->
+        atom.project.repositoryForDirectory(directory).then (repo) -> repository = repo
+
+      runs ->
+        expect(repository.isDestroyed()).toBe(false)
+        repository.destroy()
+        expect(repository.isDestroyed()).toBe(true)
+
+      waitsForPromise ->
+        atom.project.repositoryForDirectory(directory).then (repo) -> repository = repo
+
+      runs ->
+        expect(repository.isDestroyed()).toBe(false)
+
   describe ".setPaths(paths)", ->
     describe "when path is a file", ->
       it "sets its path to the files parent directory and updates the root directory", ->

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -130,6 +130,10 @@ class GitRepository
       @async.destroy()
       @async = null
 
+  # Public: Returns a {Boolean} indicating if this repository has been destroyed.
+  isDestroyed: ->
+    not @repo?
+
   # Public: Invoke the given callback when this GitRepository's destroy() method
   # is invoked.
   #

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -129,6 +129,7 @@ class Project extends Model
         # registered in the future that could supply a Repository for the
         # directory.
         @repositoryPromisesByPath.delete(pathForDirectory) unless repo?
+        repo?.onDidDestroy?(=> @repositoryPromisesByPath.delete(pathForDirectory))
         repo
       @repositoryPromisesByPath.set(pathForDirectory, promise)
     promise


### PR DESCRIPTION
Previously promises resolving to destroyed repositories remained in our cache after removing a project folder. This caused subsequent calls to `repositoryForDirectory` to return the previous instance of the `GitRepository`, even after adding the working directory back to the project.

/cc: @atom/core 
