### PR TITLE
Don't erase NODE_ENV from environment.

### DIFF
--- a/src/environment-helpers.js
+++ b/src/environment-helpers.js
@@ -72,7 +72,10 @@ function needsPatching (options = { platform: process.platform, env: process.env
 // underlying functionality.
 function clone (to, from) {
   for (var key in to) {
-    delete to[key]
+    // Don't erase NODE_ENV. Fixes #12024
+    if (key !== 'NODE_ENV') {
+      delete to[key]
+    }
   }
 
   Object.assign(to, from)


### PR DESCRIPTION
Atom sets NODE_ENV to 'production' earlier, but some code paths can cause it to be un-set. This degrades performance and sometimes crashes React. Fixes #12024.

I've tested this on Linux and macOS, but not Windows.
