### PR TITLE
Renaming Linux sections; adding SUSE section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The `.zip` version will not automatically update.
 Using [chocolatey](https://chocolatey.org/)? Run `cinst Atom` to install
 the latest version of Atom.
 
-### Debian Linux (Ubuntu)
+### Debian / Ubuntu / Linux Mint / derivatives thereof
 
 Currently only a 64-bit version is available.
 
@@ -54,7 +54,7 @@ Currently only a 64-bit version is available.
 The Linux version does not currently automatically update so you will need to
 repeat these steps to upgrade to future releases.
 
-### Red Hat Linux (Fedora 21 and under, CentOS, Red Hat)
+### CentOS / Fedora &leq;21 / Red Hat Enterprise Linux / derivatives thereof
 
 Currently only a 64-bit version is available.
 
@@ -65,7 +65,7 @@ Currently only a 64-bit version is available.
 The Linux version does not currently automatically update so you will need to
 repeat these steps to upgrade to future releases.
 
-### Fedora 22+
+### Fedora &geq;22 / derivatives thereof
 
 Currently only a 64-bit version is available.
 
@@ -75,6 +75,14 @@ Currently only a 64-bit version is available.
 
 The Linux version does not currently automatically update so you will need to
 repeat these steps to upgrade to future releases.
+
+### openSUSE / SUSE Linux Enterprise Server / derivatives thereof
+
+Currently only a 64-bit version is officially available. 
+
+1. Download `atom.x86_64.rpm` from the [Atom releases page](https://github.com/atom/atom/releases/latest).
+2. Run `sudo zypper in atom.x86_64.rpm` on the downloaded package. 
+3. Launch Atom using the installed `atom` command. 
 
 ### Archive extraction
 


### PR DESCRIPTION
Hi,

In this pull request I added a SUSE section, I also improved the accuracy of the Linux section titles (as these instructions should work on derivative distributions too), specifically:
- Debian Linux (Ubuntu) &rarr; Debian / Ubuntu / Linux Mint / derivatives thereof
- Red Hat Linux (Fedora) &rarr; CentOS / Fedora / Red Hat Enterprise Linux / derivatives thereof

Thanks for your time,
Brenton
