### PR TITLE
Update languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "language-csharp": "0.12.1",
     "language-css": "0.36.2",
     "language-gfm": "0.87.0",
-    "language-git": "0.13.0",
+    "language-git": "0.14.0",
     "language-go": "0.42.0",
     "language-html": "0.44.1",
     "language-hyperlink": "0.16.0",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "language-hyperlink": "0.16.0",
     "language-java": "0.23.0",
     "language-javascript": "0.119.0",
-    "language-json": "0.18.0",
+    "language-json": "0.18.1",
     "language-less": "0.29.3",
     "language-make": "0.22.2",
     "language-mustache": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "language-python": "0.45.0",
     "language-ruby": "0.68.5",
     "language-ruby-on-rails": "0.25.0",
-    "language-sass": "0.54.0",
+    "language-sass": "0.55.0",
     "language-shellscript": "0.22.4",
     "language-source": "0.9.0",
     "language-sql": "0.21.1",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "language-java": "0.23.0",
     "language-javascript": "0.119.0",
     "language-json": "0.18.1",
-    "language-less": "0.29.3",
+    "language-less": "0.29.4",
     "language-make": "0.22.2",
     "language-mustache": "0.13.0",
     "language-objective-c": "0.15.1",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "language-mustache": "0.13.0",
     "language-objective-c": "0.15.1",
     "language-perl": "0.35.0",
-    "language-php": "0.37.0",
+    "language-php": "0.37.1",
     "language-property-list": "0.8.0",
     "language-python": "0.45.0",
     "language-ruby": "0.68.5",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "language-coffee-script": "0.47.0",
     "language-csharp": "0.12.1",
     "language-css": "0.37.0",
-    "language-gfm": "0.87.0",
+    "language-gfm": "0.88.0",
     "language-git": "0.14.0",
     "language-go": "0.42.0",
     "language-html": "0.44.1",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "language-clojure": "0.21.0",
     "language-coffee-script": "0.47.0",
     "language-csharp": "0.12.1",
-    "language-css": "0.36.2",
+    "language-css": "0.37.0",
     "language-gfm": "0.87.0",
     "language-git": "0.14.0",
     "language-go": "0.42.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "language-php": "0.37.1",
     "language-property-list": "0.8.0",
     "language-python": "0.45.0",
-    "language-ruby": "0.68.5",
+    "language-ruby": "0.68.6",
     "language-ruby-on-rails": "0.25.0",
     "language-sass": "0.55.0",
     "language-shellscript": "0.22.4",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "language-sass": "0.55.0",
     "language-shellscript": "0.22.4",
     "language-source": "0.9.0",
-    "language-sql": "0.21.1",
+    "language-sql": "0.22.0",
     "language-text": "0.7.1",
     "language-todo": "0.28.0",
     "language-toml": "0.18.0",


### PR DESCRIPTION
Woo!
- language-css
  - Added pseudo-class support
  - Added inline comments support
  - Added some missing properties
- language-gfm
  - Added `pycon` highlighting
- language-git
  - Added support for `drop` in rebases
- language-json
  - Added `.webmanifest` as a valid file type
- language-less
  - Added `.rc`, `.themerc`, and `.gtkrc` as valid file types
- language-php
  - Added support for the `<=>` operator to fix ligatures
- language-ruby
  - Added support for the `source` keyword
- language-sass
  - Added missing `object-fit` values
  - Added support for new CSS3 colors and deprecated CSS2 system colors
  - Added support for the `picture` element
  - Sass-only: Added support for vendor-prefixed properties
  - Better highlighting for `@mix` and `@namespace`
  - Added support for `@supports` feature queries
  - Fixed `@include` tokenization
- language-sql
  - Removed MySQL comments which also fixed temporary tables being tokenized as comments
  - Added support for `nvarchar`
  - Added `.dsql` as a valid file type
