### PR TITLE
update nodejs installation instructions link for Fedora/CentOS/RHEL

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -25,7 +25,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 ### Fedora / CentOS / RHEL
 
 * `sudo dnf --assumeyes install make gcc gcc-c++ glibc-devel git-core libgnome-keyring-devel rpmdevtools`
-* Instructions for [Node.js](https://github.com/nodejs/node-v0.x-archive/wiki/Installing-Node.js-via-package-manager#enterprise-linux-and-fedora).
+* Instructions for [Node.js](https://nodejs.org/en/download/package-manager/#enterprise-linux-and-fedora).
 
 ### Arch
 


### PR DESCRIPTION
In the nodejs installation instructions for Fedora/Centos/RHEL, the old [link](https://github.com/nodejs/node-v0.x-archive/wiki/Installing-Node.js-via-package-manager#enterprise-linux-and-fedora) redirects the user to another [link](https://github.com/nodejs/node/wiki) which is the nodejs wiki, and where there are no installation instructions.
The correct link should be [https://nodejs.org/en/download/package-manager/#enterprise-linux-and-fedora](https://nodejs.org/en/download/package-manager/#enterprise-linux-and-fedora), which contains the most recent instructions to install nodejs.
