### PR TITLE
Fix bug in focusing full screen Atom from full screen terminal on macOS

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -81,7 +81,7 @@ if [ $OS == 'Mac' ]; then
     "$ATOM_PATH/$ATOM_APP_NAME/Contents/MacOS/Atom" --executed-from="$(pwd)" --pid=$$ "$@"
     exit $?
   else
-    open -a "$ATOM_PATH/$ATOM_APP_NAME" -n --args --executed-from="$(pwd)" --pid=$$ --path-environment="$PATH" "$@"
+    open -a "$ATOM_PATH/$ATOM_APP_NAME" --args --executed-from="$(pwd)" --pid=$$ --path-environment="$PATH" "$@"
   fi
 elif [ $OS == 'Linux' ]; then
   SCRIPT=$(readlink -f "$0")


### PR DESCRIPTION
fix issue #12073, the '-n' option is not needed here. Since with or without this option, atom opens up a directory in new window and a file in a new tab, given that atom is already opened. And removing the '-n' option fix the issue #12073.
