### PR TITLE
Clear out apm folder in cibuild

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -62,6 +62,7 @@ function removeNodeModules() {
 
   try {
     fsPlus.removeSync(path.resolve(__dirname, '..', 'node_modules'));
+    fsPlus.removeSync(path.resolve(__dirname, '..', 'apm', 'node_modules'));
   } catch (error) {
     console.error(error.message);
     process.exit(1);


### PR DESCRIPTION
Previously, the atom master build was failing because the `apm/node_modules` folder was somehow getting into an invalid state. Probably related to https://github.com/atom/atom/pull/12170.
