### PR TITLE
Update select-to-end-of-line behavior

### DIFF
--- a/keymaps/base.cson
+++ b/keymaps/base.cson
@@ -1,6 +1,6 @@
 'atom-text-editor':
   # Platform Bindings
-  # TODO: make home and end select the buffer or screen line? Originally screen
+  # TODO: make home and end select the buffer or screen line? Originally screen. Check atom#2894
   'home': 'editor:move-to-first-character-of-screen-line'
   'end': 'editor:move-to-end-of-screen-line'
   'shift-home': 'editor:select-to-first-character-of-screen-line'

--- a/keymaps/base.cson
+++ b/keymaps/base.cson
@@ -2,8 +2,9 @@
   # Platform Bindings
   'home': 'editor:move-to-first-character-of-screen-line'
   'end': 'editor:move-to-end-of-screen-line'
-  'shift-home': 'editor:select-to-beginning-of-line'
-  'shift-end': 'editor:select-to-end-of-line'
+  # TODO: make the next two function use the full line, instead of screen line?
+  'shift-home': 'editor:select-to-first-character-of-screen-line'
+  'shift-end': 'editor:select-to-end-of-screen-line'
 
 'atom-text-editor:not([mini])':
   # Atom Specific

--- a/keymaps/base.cson
+++ b/keymaps/base.cson
@@ -1,8 +1,8 @@
 'atom-text-editor':
   # Platform Bindings
+  # TODO: make home and end select the buffer or screen line? Originally screen
   'home': 'editor:move-to-first-character-of-screen-line'
   'end': 'editor:move-to-end-of-screen-line'
-  # TODO: make the next two function use the full line, instead of screen line?
   'shift-home': 'editor:select-to-first-character-of-screen-line'
   'shift-end': 'editor:select-to-end-of-screen-line'
 

--- a/keymaps/base.cson
+++ b/keymaps/base.cson
@@ -1,6 +1,6 @@
 'atom-text-editor':
   # Platform Bindings
-  'home': 'editor:move-to-first-character-of-line'
+  'home': 'editor:move-to-first-character-of-screen-line'
   'end': 'editor:move-to-end-of-screen-line'
   # TODO: make the next two function use the full line, instead of screen line?
   'shift-home': 'editor:select-to-first-character-of-screen-line'

--- a/keymaps/base.cson
+++ b/keymaps/base.cson
@@ -2,8 +2,9 @@
   # Platform Bindings
   'home': 'editor:move-to-first-character-of-line'
   'end': 'editor:move-to-end-of-screen-line'
-  'shift-home': 'editor:select-to-first-character-of-line'
-  'shift-end': 'editor:select-to-end-of-line'
+  # TODO: make the next two function use the full line, instead of screen line?
+  'shift-home': 'editor:select-to-first-character-of-screen-line'
+  'shift-end': 'editor:select-to-end-of-screen-line'
 
 'atom-text-editor:not([mini])':
   # Atom Specific

--- a/keymaps/base.cson
+++ b/keymaps/base.cson
@@ -2,9 +2,8 @@
   # Platform Bindings
   'home': 'editor:move-to-first-character-of-screen-line'
   'end': 'editor:move-to-end-of-screen-line'
-  # TODO: make the next two function use the full line, instead of screen line?
-  'shift-home': 'editor:select-to-first-character-of-screen-line'
-  'shift-end': 'editor:select-to-end-of-screen-line'
+  'shift-home': 'editor:select-to-beginning-of-line'
+  'shift-end': 'editor:select-to-end-of-line'
 
 'atom-text-editor:not([mini])':
   # Atom Specific

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -118,27 +118,22 @@
   'cmd-backspace': 'editor:delete-to-beginning-of-line'
   'cmd-shift-backspace': 'editor:delete-to-beginning-of-line'
   'cmd-delete': 'editor:delete-to-end-of-line'
-
+  # TODO: cleanup
   # 'ctrl-A': 'editor:select-to-first-character-of-line'
   'ctrl-A': 'editor:select-to-first-character-of-screen-line'
   # 'ctrl-E': 'editor:select-to-end-of-line'
   'ctrl-E': 'editor:select-to-end-of-screen-line'
-
   'cmd-left': 'editor:move-to-first-character-of-screen-line'
   'cmd-right': 'editor:move-to-end-of-screen-line'
-
   # 'cmd-shift-left': 'editor:select-to-first-character-of-line'
   'cmd-shift-left': 'editor:select-to-first-character-of-screen-line'
   # 'cmd-shift-right': 'editor:select-to-end-of-line'
   'cmd-shift-right': 'editor:select-to-end-of-screen-line'
-
   'alt-backspace': 'editor:delete-to-beginning-of-word'
   'alt-delete': 'editor:delete-to-end-of-word'
-
   'ctrl-a': 'editor:move-to-first-character-of-screen-line'
   # 'ctrl-e': 'editor:move-to-end-of-line'
   'ctrl-e': 'editor:move-to-end-of-screen-line'
-
   'ctrl-k': 'editor:cut-to-end-of-line'
 
 

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -112,21 +112,35 @@
   'alt-shift-left': 'editor:select-to-beginning-of-word'
   'alt-shift-right': 'editor:select-to-end-of-word'
 
+
+
   # Apple Specific
   'cmd-backspace': 'editor:delete-to-beginning-of-line'
   'cmd-shift-backspace': 'editor:delete-to-beginning-of-line'
   'cmd-delete': 'editor:delete-to-end-of-line'
-  'ctrl-A': 'editor:select-to-first-character-of-line'
-  'ctrl-E': 'editor:select-to-end-of-line'
+
+  # 'ctrl-A': 'editor:select-to-first-character-of-line'
+  'ctrl-A': 'editor:select-to-first-character-of-screen-line'
+
+  # 'ctrl-E': 'editor:select-to-end-of-line'
+  'ctrl-E': 'editor:select-to-end-of-screen-line'
   'cmd-left': 'editor:move-to-first-character-of-line'
   'cmd-right': 'editor:move-to-end-of-screen-line'
-  'cmd-shift-left': 'editor:select-to-first-character-of-line'
-  'cmd-shift-right': 'editor:select-to-end-of-line'
+
+  # 'cmd-shift-left': 'editor:select-to-first-character-of-line'
+  'cmd-shift-left': 'editor:select-to-first-character-of-screen-line'
+
+  # 'cmd-shift-right': 'editor:select-to-end-of-line'
+  'cmd-shift-right': 'editor:select-to-end-of-screen-line'
   'alt-backspace': 'editor:delete-to-beginning-of-word'
   'alt-delete': 'editor:delete-to-end-of-word'
   'ctrl-a': 'editor:move-to-first-character-of-line'
-  'ctrl-e': 'editor:move-to-end-of-line'
+
+  # 'ctrl-e': 'editor:move-to-end-of-line'
+  'ctrl-e': 'editor:move-to-end-of-screen-line'
   'ctrl-k': 'editor:cut-to-end-of-line'
+
+
 
   # Atom Specific
   'ctrl-W': 'editor:select-word'

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -121,23 +121,24 @@
 
   # 'ctrl-A': 'editor:select-to-first-character-of-line'
   'ctrl-A': 'editor:select-to-first-character-of-screen-line'
-
   # 'ctrl-E': 'editor:select-to-end-of-line'
   'ctrl-E': 'editor:select-to-end-of-screen-line'
-  'cmd-left': 'editor:move-to-first-character-of-line'
+
+  'cmd-left': 'editor:move-to-first-character-of-screen-line'
   'cmd-right': 'editor:move-to-end-of-screen-line'
 
   # 'cmd-shift-left': 'editor:select-to-first-character-of-line'
   'cmd-shift-left': 'editor:select-to-first-character-of-screen-line'
-
   # 'cmd-shift-right': 'editor:select-to-end-of-line'
   'cmd-shift-right': 'editor:select-to-end-of-screen-line'
+
   'alt-backspace': 'editor:delete-to-beginning-of-word'
   'alt-delete': 'editor:delete-to-end-of-word'
-  'ctrl-a': 'editor:move-to-first-character-of-line'
 
+  'ctrl-a': 'editor:move-to-first-character-of-screen-line'
   # 'ctrl-e': 'editor:move-to-end-of-line'
   'ctrl-e': 'editor:move-to-end-of-screen-line'
+
   'ctrl-k': 'editor:cut-to-end-of-line'
 
 

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -175,7 +175,7 @@
       { label: 'Select to Beginning of Word', command: 'editor:select-to-beginning-of-word' }
       { label: 'Select to Beginning of Line', command: 'editor:select-to-beginning-of-line' }
       { label: 'Select to Beginning of Screen Line', command: 'editor:select-to-beginning-of-screen-line' }
-      { label: 'Select to First Character of Line', command: 'editor:select-to-first-character-of-screen-line' }
+      { label: 'Select to First Character of Screen Line', command: 'editor:select-to-first-character-of-screen-line' }
       { label: 'Select to End of Word', command: 'editor:select-to-end-of-word' }
       { label: 'Select to End of Line', command: 'editor:select-to-end-of-line' }
       { label: 'Select to End of Screen Line', command: 'editor:select-to-end-of-screen-line' }

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -174,9 +174,11 @@
       { label: 'Select Word', command: 'editor:select-word' }
       { label: 'Select to Beginning of Word', command: 'editor:select-to-beginning-of-word' }
       { label: 'Select to Beginning of Line', command: 'editor:select-to-beginning-of-line' }
-      { label: 'Select to First Character of Line', command: 'editor:select-to-first-character-of-line' }
+      { label: 'Select to Beginning of Screen Line', command: 'editor:select-to-beginning-of-screen-line' }
+      { label: 'Select to First Character of Line', command: 'editor:select-to-first-character-of-screen-line' }
       { label: 'Select to End of Word', command: 'editor:select-to-end-of-word' }
       { label: 'Select to End of Line', command: 'editor:select-to-end-of-line' }
+      { label: 'Select to End of Screen Line', command: 'editor:select-to-end-of-screen-line' }
     ]
   }
 

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -175,6 +175,7 @@
       { label: 'Select to Beginning of Word', command: 'editor:select-to-beginning-of-word' }
       { label: 'Select to Beginning of Line', command: 'editor:select-to-beginning-of-line' }
       { label: 'Select to Beginning of Screen Line', command: 'editor:select-to-beginning-of-screen-line' }
+      { label: 'Select to First Character of Line', command: 'editor:select-to-first-character-of-line' }
       { label: 'Select to First Character of Screen Line', command: 'editor:select-to-first-character-of-screen-line' }
       { label: 'Select to End of Word', command: 'editor:select-to-end-of-word' }
       { label: 'Select to End of Line', command: 'editor:select-to-end-of-line' }

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -157,11 +157,12 @@
       { label: 'Select &Word', command: 'editor:select-word' }
       { label: 'Select to Beginning of W&ord', command: 'editor:select-to-beginning-of-word' }
       { label: 'Select to Beginning of L&ine', command: 'editor:select-to-beginning-of-line' }
-      { label: 'Select to Beginning of Screen L&ine', command: 'editor:select-to-beginning-of-screen-line' }
+      { label: 'Select to Beginning of Screen Line', command: 'editor:select-to-beginning-of-screen-line' }
+      { label: 'Select to First Character of Line', command: 'editor:select-to-first-character-of-line' }
       { label: 'Select to First &Character of Screen Line', command: 'editor:select-to-first-character-of-screen-line' }
       { label: 'Select to End of Wor&d', command: 'editor:select-to-end-of-word' }
       { label: 'Select to End of Lin&e', command: 'editor:select-to-end-of-line' }
-      { label: 'Select to End of Screen Lin&e', command: 'editor:select-to-end-of-screen-line' }
+      { label: 'Select to End of Screen Line', command: 'editor:select-to-end-of-screen-line' }
     ]
   }
 

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -157,9 +157,11 @@
       { label: 'Select &Word', command: 'editor:select-word' }
       { label: 'Select to Beginning of W&ord', command: 'editor:select-to-beginning-of-word' }
       { label: 'Select to Beginning of L&ine', command: 'editor:select-to-beginning-of-line' }
-      { label: 'Select to First &Character of Line', command: 'editor:select-to-first-character-of-line' }
+      { label: 'Select to Beginning of Screen L&ine', command: 'editor:select-to-beginning-of-screen-line' }
+      { label: 'Select to First &Character of Line', command: 'editor:select-to-first-character-of-screen-line' }
       { label: 'Select to End of Wor&d', command: 'editor:select-to-end-of-word' }
       { label: 'Select to End of Lin&e', command: 'editor:select-to-end-of-line' }
+      { label: 'Select to End of Screen Lin&e', command: 'editor:select-to-end-of-screen-line' }
     ]
   }
 

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -158,7 +158,7 @@
       { label: 'Select to Beginning of W&ord', command: 'editor:select-to-beginning-of-word' }
       { label: 'Select to Beginning of L&ine', command: 'editor:select-to-beginning-of-line' }
       { label: 'Select to Beginning of Screen L&ine', command: 'editor:select-to-beginning-of-screen-line' }
-      { label: 'Select to First &Character of Line', command: 'editor:select-to-first-character-of-screen-line' }
+      { label: 'Select to First &Character of Screen Line', command: 'editor:select-to-first-character-of-screen-line' }
       { label: 'Select to End of Wor&d', command: 'editor:select-to-end-of-word' }
       { label: 'Select to End of Lin&e', command: 'editor:select-to-end-of-line' }
       { label: 'Select to End of Screen Lin&e', command: 'editor:select-to-end-of-screen-line' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -156,11 +156,12 @@
       { label: 'Select &Word', command: 'editor:select-word' }
       { label: 'Select to Beginning of W&ord', command: 'editor:select-to-beginning-of-word' }
       { label: 'Select to Beginning of L&ine', command: 'editor:select-to-beginning-of-line' }
-      { label: 'Select to Beginning of Screen L&ine', command: 'editor:select-to-beginning-of-screen-line' }
+      { label: 'Select to Beginning of Screen Line', command: 'editor:select-to-beginning-of-screen-line' }
+      { label: 'Select to First Character of Line', command: 'editor:select-to-first-character-of-line' }
       { label: 'Select to First &Character of Line', command: 'editor:select-to-first-character-of-screen-line' }
       { label: 'Select to End of Wor&d', command: 'editor:select-to-end-of-word' }
       { label: 'Select to End of Lin&e', command: 'editor:select-to-end-of-line' }
-      { label: 'Select to End of Screen Lin&e', command: 'editor:select-to-end-of-screen-line' }
+      { label: 'Select to End of Screen Line', command: 'editor:select-to-end-of-screen-line' }
     ]
   }
 

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -156,9 +156,11 @@
       { label: 'Select &Word', command: 'editor:select-word' }
       { label: 'Select to Beginning of W&ord', command: 'editor:select-to-beginning-of-word' }
       { label: 'Select to Beginning of L&ine', command: 'editor:select-to-beginning-of-line' }
-      { label: 'Select to First &Character of Line', command: 'editor:select-to-first-character-of-line' }
+      { label: 'Select to Beginning of Screen L&ine', command: 'editor:select-to-beginning-of-screen-line' }
+      { label: 'Select to First &Character of Line', command: 'editor:select-to-first-character-of-screen-line' }
       { label: 'Select to End of Wor&d', command: 'editor:select-to-end-of-word' }
       { label: 'Select to End of Lin&e', command: 'editor:select-to-end-of-line' }
+      { label: 'Select to End of Screen Lin&e', command: 'editor:select-to-end-of-screen-line' }
     ]
   }
 

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1743,6 +1743,7 @@ describe "TextEditor", ->
           editor.selectWordsContainingCursors()
           expect(editor.getSelectedBufferRange()).toEqual [[0, 4], [0, 13]]
 
+    # TODO: rename to selectToFirstCharacterOfScreenLine
     describe ".selectToFirstCharacterOfLine()", ->
       it "moves to the first character of the current line or the beginning of the line if it's already on the first character", ->
         editor.setCursorScreenPosition [0, 5]

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -302,7 +302,7 @@ class Cursor extends Model
   moveToBottom: ->
     @setBufferPosition(@editor.getEofBufferPosition())
 
-  # Public: Moves the cursor to the beginning of the line.
+  # Public: Moves the cursor to the beginning of the screen line.
   moveToBeginningOfScreenLine: ->
     @setScreenPosition([@getScreenRow(), 0])
 
@@ -330,7 +330,7 @@ class Cursor extends Model
 
     @setBufferPosition([screenLineBufferRange.start.row, targetBufferColumn])
 
-  # Public: Moves the cursor to the end of the line.
+  # Public: Moves the cursor to the end of the screen line.
   moveToEndOfScreenLine: ->
     @setScreenPosition([@getScreenRow(), Infinity])
 

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -310,29 +310,43 @@ class Cursor extends Model
   moveToBeginningOfLine: ->
     @setBufferPosition([@getBufferRow(), 0])
 
-  # Public: Moves the cursor to the beginning of the first character in the
-  # buffer line.
+  # TODO: previous moveToFirstCharacterOfLine function. Clean up
+  # # Public: Moves the cursor to the beginning of the first character in the
+  # # buffer line.
+  # moveToFirstCharacterOfLine: ->
+  #   # screenRow = @getScreenRow()
+  #   bufferRow = @getBufferRow()
+  #   bufferLineStart = @editor.clipBufferPosition([bufferRow, 0], skipSoftWrapIndentation: true)
+  #   bufferLineEnd = [bufferRow, Infinity]
+  #   bufferLineBufferRange = @editor.screenRangeForBufferRange([bufferLineStart, bufferLineEnd])
+  #   #
+  #   firstCharacterColumn = null
+  #   @editor.scanInBufferRange /\S/, bufferLineBufferRange, ({range, stop}) ->
+  #     firstCharacterColumn = range.start.column
+  #     stop()
+  #
+  #   if firstCharacterColumn? and firstCharacterColumn isnt @getBufferColumn()
+  #     targetBufferColumn = firstCharacterColumn
+  #   else
+  #     targetBufferColumn = bufferLineBufferRange.start.column
+  #
+  #   @setBufferPosition([bufferLineBufferRange.start.row, targetBufferColumn])
+
+  # Public: Moves the cursor to the beginning of the first non-whitespace
+  # character in the buffer line.
   moveToFirstCharacterOfLine: ->
-    # screenRow = @getScreenRow()
     bufferRow = @getBufferRow()
-    bufferLineStart = @editor.clipBufferPosition([bufferRow, 0], skipSoftWrapIndentation: true)
-    bufferLineEnd = [bufferRow, Infinity]
-    bufferLineBufferRange = @editor.screenRangeForBufferRange([bufferLineStart, bufferLineEnd])
-    #
-    firstCharacterColumn = null
-    @editor.scanInBufferRange /\S/, bufferLineBufferRange, ({range, stop}) ->
+    bufferColumn = @getBufferColumn()
+    bufferRange = new Range [bufferRow, 0], [bufferRow, bufferColumn]
+    firstCharacterColumn = 0
+    @editor.scanInBufferRange /\S/, bufferRange, ({range, stop}) ->
       firstCharacterColumn = range.start.column
       stop()
 
-    if firstCharacterColumn? and firstCharacterColumn isnt @getBufferColumn()
-      targetBufferColumn = firstCharacterColumn
-    else
-      targetBufferColumn = bufferLineBufferRange.start.column
+    @setBufferPosition([bufferRow, firstCharacterColumn])
 
-    @setBufferPosition([bufferLineBufferRange.start.row, targetBufferColumn])
-
-  # Public: Moves the cursor to the beginning of the first character in the
-  # screen line.
+  # Public: Moves the cursor to the beginning of the first non-whitespace
+  # character in the screen line.
   moveToFirstCharacterOfScreenLine: ->
     screenRow = @getScreenRow()
     screenLineStart = @editor.clipScreenPosition([screenRow, 0], skipSoftWrapIndentation: true)

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -311,8 +311,8 @@ class Cursor extends Model
     @setBufferPosition([@getBufferRow(), 0])
 
   # Public: Moves the cursor to the beginning of the first character in the
-  # line.
-  moveToFirstCharacterOfLine: ->
+  # screen line.
+  moveToFirstCharacterOfScreenLine: ->
     screenRow = @getScreenRow()
     screenLineStart = @editor.clipScreenPosition([screenRow, 0], skipSoftWrapIndentation: true)
     screenLineEnd = [screenRow, Infinity]

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -311,6 +311,27 @@ class Cursor extends Model
     @setBufferPosition([@getBufferRow(), 0])
 
   # Public: Moves the cursor to the beginning of the first character in the
+  # buffer line.
+  moveToFirstCharacterOfLine: ->
+    # screenRow = @getScreenRow()
+    bufferRow = @getBufferRow()
+    bufferLineStart = @editor.clipBufferPosition([bufferRow, 0], skipSoftWrapIndentation: true)
+    bufferLineEnd = [bufferRow, Infinity]
+    bufferLineBufferRange = @editor.screenRangeForBufferRange([bufferLineStart, bufferLineEnd])
+    #
+    firstCharacterColumn = null
+    @editor.scanInBufferRange /\S/, bufferLineBufferRange, ({range, stop}) ->
+      firstCharacterColumn = range.start.column
+      stop()
+
+    if firstCharacterColumn? and firstCharacterColumn isnt @getBufferColumn()
+      targetBufferColumn = firstCharacterColumn
+    else
+      targetBufferColumn = bufferLineBufferRange.start.column
+
+    @setBufferPosition([bufferLineBufferRange.start.row, targetBufferColumn])
+
+  # Public: Moves the cursor to the beginning of the first character in the
   # screen line.
   moveToFirstCharacterOfScreenLine: ->
     screenRow = @getScreenRow()

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -134,7 +134,7 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
 
     # TODO: add select-to-beginning-of-screen-line
     'editor:select-to-beginning-of-line': -> @selectToBeginningOfLine()
-    # TODO: add select-to-first-character-of-screen-line
+    'editor:select-to-first-character-of-screen-line': -> @selectToFirstCharacterOfScreenLine()
     'editor:select-to-end-of-line': -> @selectToEndOfLine()
     'editor:select-to-end-of-screen-line': -> @selectToEndOfScreenLine()
 
@@ -145,7 +145,7 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     'editor:select-to-previous-word-boundary': -> @selectToPreviousWordBoundary()
     'editor:select-to-next-subword-boundary': -> @selectToNextSubwordBoundary()
     'editor:select-to-previous-subword-boundary': -> @selectToPreviousSubwordBoundary()
-    'editor:select-to-first-character-of-line': -> @selectToFirstCharacterOfLine()
+    # 'editor:select-to-first-character-of-line': -> @selectToFirstCharacterOfLine()
     'editor:select-line': -> @selectLinesContainingCursors()
   )
 

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -117,7 +117,7 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     'editor:move-to-beginning-of-line': -> @moveToBeginningOfLine()
     'editor:move-to-end-of-screen-line': -> @moveToEndOfScreenLine()
     'editor:move-to-end-of-line': -> @moveToEndOfLine()
-    'editor:move-to-first-character-of-line': -> @moveToFirstCharacterOfScreenLine()
+    'editor:move-to-first-character-of-screen-line': -> @moveToFirstCharacterOfScreenLine() # TODO: change name to move-to-first-character-of-screen-line?
     'editor:move-to-beginning-of-word': -> @moveToBeginningOfWord()
     'editor:move-to-end-of-word': -> @moveToEndOfWord()
     'editor:move-to-beginning-of-next-word': -> @moveToBeginningOfNextWord()

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -117,7 +117,7 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     'editor:move-to-beginning-of-line': -> @moveToBeginningOfLine()
     'editor:move-to-end-of-screen-line': -> @moveToEndOfScreenLine()
     'editor:move-to-end-of-line': -> @moveToEndOfLine()
-    'editor:move-to-first-character-of-line': -> @moveToFirstCharacterOfLine()
+    'editor:move-to-first-character-of-line': -> @moveToFirstCharacterOfScreenLine()
     'editor:move-to-beginning-of-word': -> @moveToBeginningOfWord()
     'editor:move-to-end-of-word': -> @moveToEndOfWord()
     'editor:move-to-beginning-of-next-word': -> @moveToBeginningOfNextWord()
@@ -132,9 +132,10 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     # 'editor:select-to-end-of-line': -> @selectToEndOfLine()
     # 'editor:select-to-beginning-of-line': -> @selectToBeginningOfLine()
 
-    # TODO: add select-to-beginning-of-screen-line
     'editor:select-to-beginning-of-line': -> @selectToBeginningOfLine()
+    'editor:select-to-beginning-of-screen-line': -> @selectToBeginningOfScreenLine()
     'editor:select-to-first-character-of-screen-line': -> @selectToFirstCharacterOfScreenLine()
+
     'editor:select-to-end-of-line': -> @selectToEndOfLine()
     'editor:select-to-end-of-screen-line': -> @selectToEndOfScreenLine()
 

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -127,8 +127,17 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     'editor:move-to-next-subword-boundary': -> @moveToNextSubwordBoundary()
     'editor:select-to-beginning-of-next-paragraph': -> @selectToBeginningOfNextParagraph()
     'editor:select-to-beginning-of-previous-paragraph': -> @selectToBeginningOfPreviousParagraph()
-    'editor:select-to-end-of-line': -> @selectToEndOfLine()
+
+    # Original
+    # 'editor:select-to-end-of-line': -> @selectToEndOfLine()
+    # 'editor:select-to-beginning-of-line': -> @selectToBeginningOfLine()
+
+    # TODO: add select-to-beginning-of-screen-line
     'editor:select-to-beginning-of-line': -> @selectToBeginningOfLine()
+    # TODO: add select-to-first-character-of-screen-line
+    'editor:select-to-end-of-line': -> @selectToEndOfLine()
+    'editor:select-to-end-of-screen-line': -> @selectToEndOfScreenLine()
+
     'editor:select-to-end-of-word': -> @selectToEndOfWord()
     'editor:select-to-beginning-of-word': -> @selectToBeginningOfWord()
     'editor:select-to-beginning-of-next-word': -> @selectToBeginningOfNextWord()

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -117,7 +117,8 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     'editor:move-to-beginning-of-line': -> @moveToBeginningOfLine()
     'editor:move-to-end-of-screen-line': -> @moveToEndOfScreenLine()
     'editor:move-to-end-of-line': -> @moveToEndOfLine()
-    'editor:move-to-first-character-of-screen-line': -> @moveToFirstCharacterOfScreenLine() # TODO: change name to move-to-first-character-of-screen-line?
+    'editor:move-to-first-character-of-line': -> @moveToFirstCharacterOfLine()
+    'editor:move-to-first-character-of-screen-line': -> @moveToFirstCharacterOfScreenLine()
     'editor:move-to-beginning-of-word': -> @moveToBeginningOfWord()
     'editor:move-to-end-of-word': -> @moveToEndOfWord()
     'editor:move-to-beginning-of-next-word': -> @moveToBeginningOfNextWord()

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -127,7 +127,7 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     'editor:move-to-next-subword-boundary': -> @moveToNextSubwordBoundary()
     'editor:select-to-beginning-of-next-paragraph': -> @selectToBeginningOfNextParagraph()
     'editor:select-to-beginning-of-previous-paragraph': -> @selectToBeginningOfPreviousParagraph()
-
+    # TODO: cleanup
     # Original
     # 'editor:select-to-end-of-line': -> @selectToEndOfLine()
     # 'editor:select-to-beginning-of-line': -> @selectToBeginningOfLine()

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -133,6 +133,7 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     # 'editor:select-to-beginning-of-line': -> @selectToBeginningOfLine()
 
     'editor:select-to-beginning-of-line': -> @selectToBeginningOfLine()
+    'editor:select-to-first-character-of-line': -> @selectToFirstCharacterOfLine()
     'editor:select-to-beginning-of-screen-line': -> @selectToBeginningOfScreenLine()
     'editor:select-to-first-character-of-screen-line': -> @selectToFirstCharacterOfScreenLine()
 
@@ -146,7 +147,6 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     'editor:select-to-previous-word-boundary': -> @selectToPreviousWordBoundary()
     'editor:select-to-next-subword-boundary': -> @selectToNextSubwordBoundary()
     'editor:select-to-previous-subword-boundary': -> @selectToPreviousSubwordBoundary()
-    # 'editor:select-to-first-character-of-line': -> @selectToFirstCharacterOfLine()
     'editor:select-line': -> @selectLinesContainingCursors()
   )
 

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -258,7 +258,7 @@ class Selection extends Model
   # Public: Selects all the text from the current cursor position to the end of
   # the screen line.
   selectToEndOfLine: ->
-    @modifySelection => @cursor.moveToEndOfScreenLine()
+    @modifySelection => @cursor.moveToEndOfLine()
 
   # Public: Selects all the text from the current cursor position to the end of
   # the buffer line.

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -245,25 +245,65 @@ class Selection extends Model
   selectAll: ->
     @setBufferRange(@editor.buffer.getRange(), autoscroll: false)
 
+
+
+
+
+  # Original
+  # # Public: Selects all the text from the current cursor position to the
+  # # beginning of the line.
+  # selectToBeginningOfLine: ->
+  #   @modifySelection => @cursor.moveToBeginningOfLine()
+  #
+  # # Public: Selects all the text from the current cursor position to the first
+  # # character of the line.
+  # selectToFirstCharacterOfLine: ->
+  #   @modifySelection => @cursor.moveToFirstCharacterOfLine()
+  #
+  # # Public: Selects all the text from the current cursor position to the end of
+  # # the screen line.
+  # selectToEndOfLine: ->
+  #   @modifySelection => @cursor.moveToEndOfScreenLine()
+  #
+  # # Public: Selects all the text from the current cursor position to the end of
+  # # the buffer line.
+  # selectToEndOfBufferLine: ->
+  #   @modifySelection => @cursor.moveToEndOfLine()
+
+
+
   # Public: Selects all the text from the current cursor position to the
   # beginning of the line.
   selectToBeginningOfLine: ->
     @modifySelection => @cursor.moveToBeginningOfLine()
 
+  # Public: Selects all the text from the current cursor position to the
+  # beginning of the screen line.
+  selectToBeginningOfScreenLine: ->
+    @modifySelection => @cursor.moveToBeginningOfScreenLine()
+
   # Public: Selects all the text from the current cursor position to the first
-  # character of the line.
-  selectToFirstCharacterOfLine: ->
+  # non-whitespace character of the screen line.
+  # TODO: rename moveToFirstCharacterOfLine to moveToFirstCharacterOfScreenLine?
+  selectToFirstCharacterOfScreenLine: ->
     @modifySelection => @cursor.moveToFirstCharacterOfLine()
 
+
+
   # Public: Selects all the text from the current cursor position to the end of
-  # the screen line.
+  # the line.
   selectToEndOfLine: ->
     @modifySelection => @cursor.moveToEndOfLine()
 
   # Public: Selects all the text from the current cursor position to the end of
-  # the buffer line.
-  selectToEndOfBufferLine: ->
-    @modifySelection => @cursor.moveToEndOfLine()
+  # the screen line.
+  selectToEndOfScreenLine: ->
+    @modifySelection => @cursor.moveToEndOfScreenLine()
+
+
+
+
+
 
   # Public: Selects all the text from the current cursor position to the
   # beginning of the word.

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -270,6 +270,7 @@ class Selection extends Model
   # selectToEndOfBufferLine: ->
   #   @modifySelection => @cursor.moveToEndOfLine()
 
+  # TODO: cleanup
 
 
   # Public: Selects all the text from the current cursor position to the

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -258,7 +258,7 @@ class Selection extends Model
   # # Public: Selects all the text from the current cursor position to the first
   # # character of the line.
   # selectToFirstCharacterOfLine: ->
-  #   @modifySelection => @cursor.moveToFirstCharacterOfLine()
+  #   @modifySelection => @cursor.moveToFirstCharacterOfScreenLine()
   #
   # # Public: Selects all the text from the current cursor position to the end of
   # # the screen line.
@@ -284,9 +284,8 @@ class Selection extends Model
 
   # Public: Selects all the text from the current cursor position to the first
   # non-whitespace character of the screen line.
-  # TODO: rename moveToFirstCharacterOfLine to moveToFirstCharacterOfScreenLine?
   selectToFirstCharacterOfScreenLine: ->
-    @modifySelection => @cursor.moveToFirstCharacterOfLine()
+    @modifySelection => @cursor.moveToFirstCharacterOfScreenLine()
 
 
 
@@ -577,7 +576,7 @@ class Selection extends Model
       # Remove leading whitespace from the line below
       @modifySelection =>
         @cursor.moveRight()
-        @cursor.moveToFirstCharacterOfLine()
+        @cursor.moveToFirstCharacterOfScreenLine()
       @deleteSelectedText()
 
       @cursor.moveLeft() if insertSpace

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -277,6 +277,11 @@ class Selection extends Model
   selectToBeginningOfLine: ->
     @modifySelection => @cursor.moveToBeginningOfLine()
 
+  # Public: Selects all the text from the current cursor position to the first
+  # non-whitespace character of the line.
+  selectToFirstCharacterOfLine: ->
+    @modifySelection => @cursor.moveToFirstCharacterOfLine()
+
   # Public: Selects all the text from the current cursor position to the
   # beginning of the screen line.
   selectToBeginningOfScreenLine: ->

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -270,7 +270,7 @@ class Selection extends Model
   # selectToEndOfBufferLine: ->
   #   @modifySelection => @cursor.moveToEndOfLine()
 
-  # TODO: cleanup
+  # TODO: cleanup, reorder to match other files
 
 
   # Public: Selects all the text from the current cursor position to the

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2368,6 +2368,7 @@ class TextEditor extends Model
   selectAll: ->
     @expandSelectionsForward (selection) -> selection.selectAll()
 
+  # TODO: cleanup
 
 
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2363,6 +2363,11 @@ class TextEditor extends Model
   selectAll: ->
     @expandSelectionsForward (selection) -> selection.selectAll()
 
+
+
+
+
+
   # Essential: Move the cursor of each selection to the beginning of its line
   # while preserving the selection's tail position.
   #
@@ -2370,14 +2375,23 @@ class TextEditor extends Model
   selectToBeginningOfLine: ->
     @expandSelectionsBackward (selection) -> selection.selectToBeginningOfLine()
 
+  # Essential: Move the cursor of each selection to the beginning of its screen line
+  # while preserving the selection's tail position.
+  #
+  # This method may merge selections that end up intesecting.
+  selectToBeginningOfScreenLine: ->
+    @expandSelectionsBackward (selection) -> selection.selectToBeginningOfScreenLine()
+
   # Essential: Move the cursor of each selection to the first non-whitespace
-  # character of its line while preserving the selection's tail position. If the
-  # cursor is already on the first character of the line, move it to the
-  # beginning of the line.
+  # character of its screen line while preserving the selection's tail position. If the
+  # cursor is already on the first character of the screen line, move it to the
+  # beginning of the screen line.
   #
   # This method may merge selections that end up intersecting.
-  selectToFirstCharacterOfLine: ->
-    @expandSelectionsBackward (selection) -> selection.selectToFirstCharacterOfLine()
+  # selectToFirstCharacterOfLine: ->
+  #   @expandSelectionsBackward (selection) -> selection.selectToFirstCharacterOfLine()
+  selectToFirstCharacterOfScreenLine: ->
+    @expandSelectionsBackward (selection) -> selection.selectToFirstCharacterOfScreenLine()
 
   # Essential: Move the cursor of each selection to the end of its line while
   # preserving the selection's tail position.
@@ -2385,6 +2399,18 @@ class TextEditor extends Model
   # This method may merge selections that end up intersecting.
   selectToEndOfLine: ->
     @expandSelectionsForward (selection) -> selection.selectToEndOfLine()
+
+  # Essential: Move the cursor of each selection to the end of its screen line while
+  # preserving the selection's tail position.
+  #
+  # This method may merge selections that end up intersecting.
+  selectToEndOfScreenLine: ->
+    @expandSelectionsForward (selection) -> selection.selectToEndOfScreenLine()
+
+
+
+
+
 
   # Essential: Expand selections to the beginning of their containing word.
   #

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2013,6 +2013,11 @@ class TextEditor extends Model
   moveToBeginningOfLine: ->
     @moveCursors (cursor) -> cursor.moveToBeginningOfLine()
 
+  # Essential: Move every cursor to the first non-whitespace character of its
+  # line.
+  moveToFirstCharacterOfLine: ->
+    @moveCursors (cursor) -> cursor.moveToFirstCharacterOfLine()
+
   # Essential: Move every cursor to the beginning of its line in screen coordinates.
   moveToBeginningOfScreenLine: ->
     @moveCursors (cursor) -> cursor.moveToBeginningOfScreenLine()
@@ -2383,13 +2388,20 @@ class TextEditor extends Model
     @expandSelectionsBackward (selection) -> selection.selectToBeginningOfScreenLine()
 
   # Essential: Move the cursor of each selection to the first non-whitespace
+  # character of its line while preserving the selection's tail position. If the
+  # cursor is already on the first character of the line, move it to the
+  # beginning of the line.
+  #
+  # This method may merge selections that end up intersecting.
+  selectToFirstCharacterOfLine: ->
+    @expandSelectionsBackward (selection) -> selection.selectToFirstCharacterOfLine()
+
+  # Essential: Move the cursor of each selection to the first non-whitespace
   # character of its screen line while preserving the selection's tail position. If the
   # cursor is already on the first character of the screen line, move it to the
   # beginning of the screen line.
   #
   # This method may merge selections that end up intersecting.
-  # selectToFirstCharacterOfLine: ->
-  #   @expandSelectionsBackward (selection) -> selection.selectToFirstCharacterOfLine()
   selectToFirstCharacterOfScreenLine: ->
     @expandSelectionsBackward (selection) -> selection.selectToFirstCharacterOfScreenLine()
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2017,9 +2017,10 @@ class TextEditor extends Model
   moveToBeginningOfScreenLine: ->
     @moveCursors (cursor) -> cursor.moveToBeginningOfScreenLine()
 
-  # Essential: Move every cursor to the first non-whitespace character of its line.
-  moveToFirstCharacterOfLine: ->
-    @moveCursors (cursor) -> cursor.moveToFirstCharacterOfLine()
+  # Essential: Move every cursor to the first non-whitespace character of its
+  # screen line.
+  moveToFirstCharacterOfScreenLine: ->
+    @moveCursors (cursor) -> cursor.moveToFirstCharacterOfScreenLine()
 
   # Essential: Move every cursor to the end of its line in buffer coordinates.
   moveToEndOfLine: ->


### PR DESCRIPTION
Original PR is in atom/atom#12117, but I borked my local repo and started over. Only after I did that did I learn how to fix it :persevere:

Addresses atom#7159, where `editor:select-to-end-of-line` should behave similarly to `editor:move-to-end-of-line`. This PR does the following to make functions behave as expected and provide functions for existing behaviors (all select/move functions do so from the cursor position to the specified position):
- `editor:select-to-beginning-of-line`: **Unchanged,** selects to the beginning of the buffer line
- `editor:select-to-beginning-of-screen-line`: **New,** selects to the beginning of the screen line
- `editor:select-to-end-of-line`: **Changed,** selects to the end of the buffer line, originally selected to the end of the screen line
- `editor:select-to-end-of-screen-line`: **New,** selects to the end of the screen line, original behavior of `editor:select-to-end-of-line`
- `editor:select-to-first-character-of-line`: **Changed,** selects to the first non-whitespace character of the buffer line, originally selected to the first non-whitespace character of the screen line
- `editor:select-to-first-character-of-screen-line`: **New,** selects to the first non-whitespace character of the screen line, same behavior as original `select-to-first-character-of-line`
- `editor:move-to-first-character-of-line`: **Changed,** moves the cursor to the first non-whitespace character of the buffer line, originally moved to the first non-whitespace character of the screen line
- `editor:move-to-first-character-of-screen-line`: **New,** moves the cursor to the first non-whitespace character of the screen line, original behavior of `editor:move-to-first-character-of-line`

@lee-dohm, I expanded your [original checklist](https://github.com/atom/atom/pull/12117#issuecomment-232172717) to include the first-character functions because it followed the same logic as the other function changes. Admittedly, I've never written specs before, but I'm familiar with Jasmine. Any guidance for writing specs for this would be super helpful.
### TODO:
- [ ] Write specs
- [ ] Cleanup, including old commented code and extra space around new code
- [ ] Decide if the `home` and `end` keys should act on the screen or buffer line. Currently it's the screen line
- [ ] Modify new screen line functions in `menus/linux.cson` and `menus/win32.cson` to have shortcuts (at lease I think that's what the ampersand is for on the menu labels. I'm on a Mac :apple:)
- [ ] Edit 2.2 and 2.3 in atom/flight-manual.atom.io to reflect new functions
