### PR TITLE
Introduce CircleCI for macOS builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Atom](https://cloud.githubusercontent.com/assets/72919/2874231/3af1db48-d3dd-11e3-98dc-6066f8bc766f.png)
 
-[![macOS Build Status](https://travis-ci.org/atom/atom.svg?branch=master)](https://travis-ci.org/atom/atom) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/1tkktwh654w07eim?svg=true)](https://ci.appveyor.com/project/Atom/atom)
+[![macOS Build Status](https://circleci.com/gh/atom/atom.svg?style=svg)](https://circleci.com/gh/atom/atom) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/1tkktwh654w07eim?svg=true)](https://ci.appveyor.com/project/Atom/atom)
 [![Dependency Status](https://david-dm.org/atom/atom.svg)](https://david-dm.org/atom/atom)
 [![Join the Atom Community on Slack](http://atom-slack.herokuapp.com/badge.svg)](http://atom-slack.herokuapp.com/)
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ machine:
   environment:
     XCODE_SCHEME: test
     XCODE_WORKSPACE: test
+    XCODE_PROJECT: test
 
   xcode:
     version: 7.3

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,6 @@ dependencies:
     - apm/node_modules
     - build/node_modules
     - node_modules
-    - electron
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,12 @@ dependencies:
   override:
     - script/bootstrap
 
+  cache_directories:
+    - apm/node_modules
+    - build/node_modules
+    - node_modules
+    - electron
+
 test:
   override:
     - script/grunt ci

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
 
 general:
   artifacts:
-    - out/Atom.app
+    - out/Atom.zip
 
 dependencies:
   pre:
@@ -33,3 +33,6 @@ dependencies:
 test:
   override:
     - script/grunt ci
+
+  post:
+    - zip -r out/Atom.zip out/Atom.app

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,10 @@ machine:
   xcode:
     version: 7.3
 
+general:
+  artifacts:
+    - out/Atom.app
+
 dependencies:
   pre:
     - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 machine:
   environment:
     XCODE_SCHEME: test
+    XCODE_WORKSPACE: test
 
   xcode:
     version: 7.3

--- a/circle.yml
+++ b/circle.yml
@@ -7,11 +7,6 @@ machine:
   xcode:
     version: 7.3
 
-general:
-  branches:
-    only:
-      - as-circle-ci
-
 dependencies:
   pre:
     - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,16 @@
+machine:
+  node:
+    version: 4.4.7
+
 general:
   branches:
     only:
-      - io-circle-ci
+      - as-circle-ci
+
+dependencies:
+  override:
+    - script/bootstrap
+
+test:
+  override:
+    - script/grunt ci

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,7 @@
 machine:
+  xcode:
+    version: 7.3
+
   node:
     version: 4.4.7
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,15 +7,17 @@ machine:
   xcode:
     version: 7.3
 
-  node:
-    version: 4.4.7
-
 general:
   branches:
     only:
       - as-circle-ci
 
 dependencies:
+  pre:
+    - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash
+    - nvm install 4.4.7
+    - nvm use 4.4.7
+
   override:
     - script/bootstrap
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,7 @@
 machine:
+  environment:
+    XCODE_SCHEME: test
+
   xcode:
     version: 7.3
 

--- a/circle.yml
+++ b/circle.yml
@@ -18,9 +18,13 @@ dependencies:
     - nvm install 4.4.7
     - nvm use 4.4.7
     - npm install -g npm
+    - script/fingerprint-clean
 
   override:
     - script/bootstrap
+
+  post:
+    - script/fingerprint-write
 
   cache_directories:
     - apm/node_modules

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ dependencies:
     - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash
     - nvm install 4.4.7
     - nvm use 4.4.7
+    - npm install -g npm
 
   override:
     - script/bootstrap

--- a/script/fingerprint-clean
+++ b/script/fingerprint-clean
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 var fingerprint = require('./utils/fingerprint')
+var fs = require('fs')
+var path = require('path')
+
+if (!fs.existsSync(path.resolve(__dirname, '..', 'node_modules', '.atom-ci-fingerprint'))) {
+  return
+}
 
 if (fingerprint.fingerprintMatches()) {
   console.log('node_modules matches current fingerprint ' + fingerprint.fingerprint() + ' - not removing')

--- a/script/fingerprint-clean
+++ b/script/fingerprint-clean
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+var fingerprint = require('./utils/fingerprint')
+
+if (fingerprint.fingerprintMatches()) {
+  console.log('node_modules matches current fingerprint ' + fingerprint.fingerprint() + ' - not removing')
+  return
+}
+
+var fsPlus
+try {
+  fsPlus = require('fs-plus')
+} catch (error) {
+  console.log(error.message)
+  return
+}
+
+try {
+  fsPlus.removeSync(path.resolve(__dirname, '..', 'node_modules'))
+  fsPlus.removeSync(path.resolve(__dirname, '..', 'apm', 'node_modules'))
+} catch (error) {
+  console.error(error.message)
+  process.exit(1)
+}

--- a/script/fingerprint-write
+++ b/script/fingerprint-write
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('./utils/fingerprint').writeFingerprint()


### PR DESCRIPTION
Depends on #11897. This is the [actual diff](https://github.com/atom/atom/compare/mkt-use-apm-with-npm3-and-node-4...as-circle-ci).

This pull-request tries to supplant Travis and replace it with CircleCI. After trying it out for a while, the build process seems more reliable and faster as well. Moreover, if CircleCI enables parallelism for macOS containers in the future, we could be able to speed up our test suite very easily.

Right now the build fails because of some flaky tests that are not related to CircleCI at all (i.e. Janky and Travis fail too for the same specs), but overall I think we might be able to 🚢 this and let it run alongside Travis for a while so that we can assess how well it performs. If after the test-drive everything looks good, we can :fire: Travis and use CircleCI only.

This is the plan we're on right now:

![screen shot 2016-07-20 at 20 47 37](https://cloud.githubusercontent.com/assets/482957/17016782/e2e37304-4f30-11e6-9976-e367fb17b27f.png)

After the experimentation phase, I believe we should switch initially to **Startup** and consider **Growth** too if we run out of minutes.

/cc: @nathansobo @iolsen @atom/core 
