### PR TITLE
🐛 fix #12187

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -631,6 +631,16 @@ describe "TextEditor", ->
           cursor = editor.getLastCursor()
           expect(cursor.getScreenPosition()).toEqual [1, 0]
 
+      describe "when soft wrap is on and line is indented", ->
+        it "moves cursor to the beginning screen line excluding indentation", ->
+          editor.setSoftWrapped(true)
+          editor.setEditorWidthInChars(10)
+          editor.setIndentationForBufferRow(editor.bufferRowForScreenRow(1), 1)
+          editor.setCursorScreenPosition([1, 4])
+          editor.moveToBeginningOfScreenLine()
+          cursor = editor.getLastCursor()
+          expect(cursor.getScreenPosition()).toEqual [1, 2]
+
       describe "when soft wrap is off", ->
         it "moves cursor to the beginning of the line", ->
           editor.setCursorScreenPosition [0, 5]

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -304,7 +304,23 @@ class Cursor extends Model
 
   # Public: Moves the cursor to the beginning of the line.
   moveToBeginningOfScreenLine: ->
-    @setScreenPosition([@getScreenRow(), 0])
+    screenRow = @getScreenRow()
+
+    # check if screenRow is soft-wrapped
+    lineIterator = @editor.displayLayer.spatialLineIterator
+    lineIterator.seekToScreenRow(screenRow)
+    softWrapped = lineIterator.isSoftWrappedAtStart()
+
+    if softWrapped
+      # get text content of screen line
+      lineText = @editor.screenLineForScreenRow(screenRow).lineText
+      # get number of spaces at start in internal representation (not the same as indent level)
+      match = lineText.match(/^\s+/g)
+      spaces = if match then match[0].length else 0
+
+      @setScreenPosition([screenRow, spaces])
+    else
+      @setScreenPosition([screenRow, 0])
 
   # Public: Moves the cursor to the beginning of the buffer line.
   moveToBeginningOfLine: ->


### PR DESCRIPTION
This fixes issue #12187 with the command `editor:move-to-beginning-of-screen-line` when used on indented soft-wrapped lines. I've testing it with soft-wrapping on and off, with no indentation, one level of indentation, and multiple levels of indentation, and it seems to give the expected behavior.
