### PR TITLE
Disable autosubmit of crash reporter

### DIFF
--- a/src/crash-reporter-start.coffee
+++ b/src/crash-reporter-start.coffee
@@ -4,6 +4,6 @@ module.exports = (extra) ->
   crashReporter.start({
     productName: 'Atom',
     companyName: 'GitHub',
-    submitURL: 'http://54.249.141.255:1127/post'
+    autoSubmit: false,
     extra: extra
   })


### PR DESCRIPTION
Disabling the crash reporter's autosubmit and removing the current endpoint as it is down.
