### PR TITLE
Remove OS X from Travis Build Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,12 @@ env:
   global:
     - ATOM_ACCESS_TOKEN=da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4
 
-osx_image: xcode7.3
-
 compiler: clang
 
 matrix:
   include:
     - os: linux
       env: NODE_VERSION=4
-    - os: osx
-      env: ATOM_SPECS_TASK=core NODE_VERSION=4
-    - os: osx
-      env: ATOM_SPECS_TASK=packages NODE_VERSION=4
 
 sudo: false
 


### PR DESCRIPTION
We are going to use CircleCI for OS X builds, so this pull-request changes Travis to build Atom only on Linux.
