### PR TITLE
Cleanup activationHookSubscriptions when deactivating package

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -431,6 +431,27 @@ describe "PackageManager", ->
         runs ->
           expect(Package.prototype.requireMainModule.callCount).toBe 1
 
+      it "does not double register activation hooks when deactivating and reactivating", ->
+        expect(mainModule.activate.callCount).toBe 0
+        atom.packages.triggerActivationHook('language-fictitious:grammar-used')
+        atom.packages.triggerDeferredActivationHooks()
+
+        waitsForPromise ->
+          promise
+
+        runs ->
+          expect(mainModule.activate.callCount).toBe 1
+          atom.packages.deactivatePackage('package-with-activation-hooks')
+          promise = atom.packages.activatePackage('package-with-activation-hooks')
+          atom.packages.triggerActivationHook('language-fictitious:grammar-used')
+          atom.packages.triggerDeferredActivationHooks()
+
+        waitsForPromise ->
+          promise
+
+        runs ->
+          expect(mainModule.activate.callCount).toBe 2
+
       it "activates the package immediately when activationHooks is empty", ->
         mainModule = require './fixtures/packages/package-with-empty-activation-hooks/index'
         spyOn(mainModule, 'activate').andCallThrough()

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -388,6 +388,7 @@ class Package
     @activationPromise = null
     @resolveActivationPromise = null
     @activationCommandSubscriptions?.dispose()
+    @activationHookSubscriptions?.dispose()
     @configSchemaRegisteredOnActivate = false
     @deactivateResources()
     @deactivateKeymaps()


### PR DESCRIPTION
Without this fix, the included test would fail with:

```
$ ./out/Atom.app/Contents/MacOS/Atom --test --resource-path="$(pwd)" -- spec/package-manager-spec.coffee
(electron) submitURL is now a required option to crashReporter.start
Error Downloading Update: Could not get code signature for running application
---------------------------------.F.---------------------------------------

PackageManager
  ::activatePackage(id)
    when the package metadata includes `activationHooks`
      it does not double register activation hooks when deactivating and reactivating
        Expected 2 to be 1.
          at .<anonymous> (/Users/asuarez/src/atom/atom/spec/package-manager-spec.coffee:444:49)
        Expected 3 to be 2.
          at .<anonymous> (/Users/asuarez/src/atom/atom/spec/package-manager-spec.coffee:455:49)
```

cc: @hansonw 
