### PR TITLE
Add ability to see passed specs via tooltips

### DIFF
--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -197,6 +197,21 @@ class AtomReporter
     time = "0#{time}" if time.length < 3
     @time.textContent = "#{time[0...-2]}.#{time[-2..]}s"
 
+  specTitle: (spec) ->
+    parentDescs = []
+    s = spec.suite
+    while s
+      parentDescs.unshift(s.description)
+      s = s.parentSuite
+
+    suiteString = ""
+    indent = ""
+    for desc in parentDescs
+      suiteString += indent + desc + "\n"
+      indent += "  "
+
+    "#{suiteString} #{indent} it #{spec.description}"
+
   addSpecs: (specs) ->
     coreSpecs = 0
     bundledPackageSpecs = 0
@@ -204,6 +219,7 @@ class AtomReporter
     for spec in specs
       symbol = document.createElement('li')
       symbol.setAttribute('id', "spec-summary-#{spec.id}")
+      symbol.setAttribute('title', @specTitle(spec))
       symbol.className = "spec-summary pending"
       switch spec.specType
         when 'core'


### PR DESCRIPTION
This is my first PR against atom, so let me know if I've gotten anything wrong.

It's not currently possible to see what specs pass when you ctrl-alt-cmd-P. You see that some tests pass (via the red and green dots), but you can't see which ones (except by process of deduction by looking at which fail)

This PR adds the description of the spec, as well as all it's parent suites, to a tooltip so you can see what's passing and failing on mouseover.

I couldn't find tests for atom-reporter. Given the simplicity of the change and the overhead of learning how to write tests for this component, it didn't seem worthwhile. If there are already specs for it, please point me to them and I'll be happy to add a quick test.

Before: (no tooltip)
<img width="411" alt="screenshot 2016-08-01 10 24 12" src="https://cloud.githubusercontent.com/assets/181762/17302916/3acf8a1c-57d3-11e6-871f-f85fe21351f0.png">

After: (tooltip, showing suite and test name)
<img width="343" alt="screenshot 2016-08-01 11 23 07" src="https://cloud.githubusercontent.com/assets/181762/17304448/789a2044-57da-11e6-9869-a2fc0830a2d8.png">
