### PR TITLE
Add telemetry consent setting

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -112,7 +112,16 @@ module.exports =
         description: 'Allow items to be previewed without adding them to a pane permanently, such as when single clicking files in the tree view.'
         type: 'boolean'
         default: true
-
+      telemetryConsent:
+        description: 'Allow usage statistics and exception reports to be sent to the Atom team to help improve the product.'
+        title: 'Send Telemetry to the Atom Team'
+        type: 'string'
+        default: 'undecided'
+        enum: [
+          {value: 'limited', description: 'Allow limited anonymous usage stats, exception and crash reporting'}
+          {value: 'no', description: 'Do not send any telemetry data'}
+          {value: 'undecided', description: 'Undecided (Atom will ask again next time it is launched)'}
+        ]
   editor:
     type: 'object'
     properties:


### PR DESCRIPTION
New telemetry consent setting that will be used by metrics and exception-reporter to determine whether to collect anonymous usage statistics, exception reports etc.

All parts are required for this to work correctly;
- https://github.com/atom/atom/pull/12281
- https://github.com/atom/metrics/pull/66
- https://github.com/atom/exception-reporting/pull/20
- https://github.com/atom/about/pull/37
- https://github.com/atom/welcome/pull/48
