### PR TITLE
Add null checks for ShellOption.isRegister/update

### DIFF
--- a/src/main-process/win-shell.coffee
+++ b/src/main-process/win-shell.coffee
@@ -13,7 +13,7 @@ class ShellOption
   isRegistered: (callback) =>
     new Registry({hive: 'HKCU', key: "#{@key}\\#{@parts[0].key}"})
       .get @parts[0].name, (err, val) =>
-        callback(not err? and val.value is @parts[0].value)
+        callback(not err? and val?.value is @parts[0].value)
 
   register: (callback) =>
     doneCount = @parts.length
@@ -31,7 +31,7 @@ class ShellOption
   update: (callback) =>
     new Registry({hive: 'HKCU', key: "#{@key}\\#{@parts[0].key}"})
       .get @parts[0].name, (err, val) =>
-        if err? or not val.value.includes '\\' + exeName
+        if err? or not val?.value.includes '\\' + exeName
           callback(err)
         else
           @register callback


### PR DESCRIPTION
I am getting `Uncaught TypeError: Cannot read property 'value' of null` at the isRegistered function.

see https://github.com/fresc81/node-winreg/blob/master/lib/registry.js#L649

cc @damieng 
