### PR TITLE
Don't throw an error when $ATOM_HOME does not exist

### DIFF
--- a/src/main-process/main.js
+++ b/src/main-process/main.js
@@ -113,9 +113,11 @@ function setupAtomHome ({setPortable}) {
 
   try {
     atomHome = fs.realpathSync(atomHome)
-  } finally {
-    process.env.ATOM_HOME = atomHome
+  } catch (e) {
+    // Don't throw an error if atomHome doesn't exist.
   }
+
+  process.env.ATOM_HOME = atomHome
 }
 
 function setupCompileCache () {


### PR DESCRIPTION
This was introduced in #12246 as a result of the `.coffee` -> `.js` conversion of `main-process/main.js`. An exception we were suppressing in Coffeescript via its `try` (without `catch`, which means is implicit) is now being thrown again, causing Atom to not start when the `$ATOM_HOME` folder doesn't exist.

Fixes #12283.

/cc: @atom/core 
