### PR TITLE
Handle double-click on custom title bar

### DIFF
--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -136,8 +136,8 @@ class ApplicationDelegate
   getPrimaryDisplayWorkAreaSize: ->
     remote.screen.getPrimaryDisplay().workAreaSize
 
-  getAppleActionOnDoubleClick: ->
-    remote.systemPreferences.getUserDefault("AppleActionOnDoubleClick", "string")
+  getUserDefault: (key, type) ->
+    remote.systemPreferences.getUserDefault(key, type)
 
   confirm: ({message, detailedMessage, buttons}) ->
     buttons ?= {}

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -1,5 +1,5 @@
 _ = require 'underscore-plus'
-{screen, ipcRenderer, remote, shell, webFrame} = require 'electron'
+{screen, ipcRenderer, remote, shell, systemPreferences, webFrame} = require 'electron'
 ipcHelpers = require './ipc-helpers'
 {Disposable} = require 'event-kit'
 {getWindowLoadSettings, setWindowLoadSettings} = require './window-load-settings-helpers'
@@ -57,11 +57,17 @@ class ApplicationDelegate
   reloadWindow: ->
     ipcRenderer.send("call-window-method", "reload")
 
+  minimizeWindow: ->
+    ipcRenderer.send("call-window-method", "minimize")
+
   isWindowMaximized: ->
     remote.getCurrentWindow().isMaximized()
 
   maximizeWindow: ->
     ipcRenderer.send("call-window-method", "maximize")
+
+  unmaximizeWindow: ->
+    ipcRenderer.send("call-window-method", "unmaximize")
 
   isWindowFullScreen: ->
     remote.getCurrentWindow().isFullScreen()
@@ -129,6 +135,9 @@ class ApplicationDelegate
 
   getPrimaryDisplayWorkAreaSize: ->
     remote.screen.getPrimaryDisplay().workAreaSize
+
+  getAppleActionOnDoubleClick: ->
+    remote.systemPreferences.getUserDefault("AppleActionOnDoubleClick", "string")
 
   confirm: ({message, detailedMessage, buttons}) ->
     buttons ?= {}

--- a/src/title-bar.coffee
+++ b/src/title-bar.coffee
@@ -17,7 +17,8 @@ class TitleBar
     @updateWindowSheetOffset()
 
   dblclickHandler: =>
-    switch @applicationDelegate.getAppleActionOnDoubleClick()
+    # User preference deciding which action to take on a title bar double-click
+    switch @applicationDelegate.getUserDefault('AppleActionOnDoubleClick', 'string')
       when 'Minimize'
         @applicationDelegate.minimizeWindow()
       when 'Maximize'

--- a/src/title-bar.coffee
+++ b/src/title-bar.coffee
@@ -8,11 +8,23 @@ class TitleBar
     @titleElement.classList.add('title')
     @element.appendChild(@titleElement)
 
+    @element.addEventListener 'dblclick', @dblclickHandler
+
     @workspace.onDidChangeActivePaneItem => @updateTitle()
     @themes.onDidChangeActiveThemes => @updateWindowSheetOffset()
 
     @updateTitle()
     @updateWindowSheetOffset()
+
+  dblclickHandler: =>
+    switch @applicationDelegate.getAppleActionOnDoubleClick()
+      when 'Minimize'
+        @applicationDelegate.minimizeWindow()
+      when 'Maximize'
+        if @applicationDelegate.isWindowMaximized()
+          @applicationDelegate.unmaximizeWindow()
+        else
+          @applicationDelegate.maximizeWindow()
 
   updateTitle: ->
     @titleElement.textContent = document.title


### PR DESCRIPTION
Unlike the native version, the custom title bar implemented in #11790 doesn't respond to double-clicks. This pull request implements the double-click behaviour in a manner that is consistent with the native title bar.

This is my first contribution to Atom, and the first time I've written CoffeeScript. I'd be grateful for feedback if there's something I ought to have done differently.

In case this pull request should include a test, I would appreciate some help in putting it together 🙂
