### PR TITLE
🎨 Remove duplicate "Note:"

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -271,4 +271,4 @@ if process.platform is 'darwin'
   module.exports.core.properties.useCustomTitleBar =
     type: 'boolean'
     default: false
-    description: 'Use custom, theme-aware title-bar.<br />Note: Note: This currently does not include a proxy icon.<br />This setting will require a relaunch of Atom to take effect.'
+    description: 'Use custom, theme-aware title bar.<br>Note: This currently does not include a proxy icon.<br>This setting will require a relaunch of Atom to take effect.'


### PR DESCRIPTION
Just a small touchup - I noticed that there was a duplicate "Note:" in the custom title bar settings. I also took the opportunity to use HTML5s preferred `<br>` rather than `<br />`, and changed "title-bar" to "title bar" for consistency.
