### PR TITLE
Transpile exports/**/*.js when running script/build

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -84,7 +84,6 @@ module.exports = (grunt) ->
         'src/**/*.coffee'
         'spec/*.coffee'
         '!spec/*-spec.coffee'
-        'exports/**/*.coffee'
         'static/**/*.coffee'
       ]
       dest: appDir
@@ -139,6 +138,13 @@ module.exports = (grunt) ->
       ext: '.js'
 
   for jsFile in glob.sync("src/**/*.js")
+    if usesBabel(jsFile)
+      babelConfig.dist.files.push({
+        src: [jsFile]
+        dest: path.join(appDir, jsFile)
+      })
+
+  for jsFile in glob.sync("exports/**/*.js")
     if usesBabel(jsFile)
       babelConfig.dist.files.push({
         src: [jsFile]
@@ -204,7 +210,6 @@ module.exports = (grunt) ->
         configFile: 'coffeelint.json'
       src: [
         'dot-atom/**/*.coffee'
-        'exports/**/*.coffee'
         'src/**/*.coffee'
       ]
       build: [
@@ -217,6 +222,7 @@ module.exports = (grunt) ->
 
     standard:
       src: [
+        'exports/**/*.js'
         'src/**/*.js'
         'static/*.js'
       ]


### PR DESCRIPTION
This fixes a regression introduced in #12350 that was preventing Atom from starting after running `script/build`. Specifically, we were still transpiling coffee script files located in the `exports` directory, ignoring all the javascript assets inside of it, thereby causing the output application to not contain the Atom exports file and to throw an exception on startup. To fix this, we have replaced coffee script transpilation with babel transpilation for `export/**/*.js` files.

/cc: @maxbrunsfeld @mnquintana @CraZySacX
