### PR TITLE
Stringify/parse temporary window state to avoid nulling out references

### DIFF
--- a/spec/application-delegate-spec.js
+++ b/spec/application-delegate-spec.js
@@ -1,0 +1,19 @@
+/** @babel */
+
+import {it, fit, ffit, fffit, beforeEach, afterEach} from './async-spec-helpers'
+import ApplicationDelegate from '../src/application-delegate'
+
+describe('ApplicationDelegate', function () {
+  describe('set/getTemporaryWindowState', function () {
+    it('can serialize object trees containing redundant child object references', async function () {
+      const applicationDelegate = new ApplicationDelegate()
+      const childObject = {c: 1}
+      const sentObject = {a: childObject, b: childObject}
+
+      await applicationDelegate.setTemporaryWindowState(sentObject)
+      const receivedObject = await applicationDelegate.getTemporaryWindowState()
+
+      expect(receivedObject).toEqual(sentObject)
+    })
+  })
+})

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -23,10 +23,10 @@ class ApplicationDelegate
     ipcRenderer.send("call-window-method", "close")
 
   getTemporaryWindowState: ->
-    ipcHelpers.call('get-temporary-window-state')
+    ipcHelpers.call('get-temporary-window-state').then (stateJSON) -> JSON.parse(stateJSON)
 
   setTemporaryWindowState: (state) ->
-    ipcHelpers.call('set-temporary-window-state', state)
+    ipcHelpers.call('set-temporary-window-state', JSON.stringify(state))
 
   getWindowSize: ->
     [width, height] = remote.getCurrentWindow().getSize()


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/12280

If the object passed via IPC contains any keys of the same reference, all but one of these keys will be nulled out. Converting to/from a string avoids this problem.

@atom/electron-maintainers is it expected that objects passed over IPC would have fields nulled out if they point to the same object?
