### PR TITLE
Register text decoration layer when initializing TokenizedBuffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "sinon": "1.17.4",
     "source-map-support": "^0.3.2",
     "temp": "0.8.1",
-    "text-buffer": "9.2.7",
+    "text-buffer": "9.2.9",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",
     "winreg": "^1.2.1",

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -46,7 +46,7 @@ class TokenizedBuffer extends Model
     @disposables.add @grammarRegistry.onDidAddGrammar(@grammarAddedOrUpdated)
     @disposables.add @grammarRegistry.onDidUpdateGrammar(@grammarAddedOrUpdated)
 
-    @disposables.add @buffer.preemptDidChange (e) => @handleBufferChange(e)
+    @disposables.add @buffer.registerTextDecorationLayer(this)
     @disposables.add @buffer.onDidChangePath (@bufferPath) => @reloadGrammar()
 
     if grammar = @grammarRegistry.grammarForScopeName(grammarScopeName)
@@ -241,7 +241,7 @@ class TokenizedBuffer extends Model
       else if row > end
         row + delta
 
-  handleBufferChange: (e) ->
+  bufferDidChange: (e) ->
     if @lastBufferChangeEventId?
       @assert(
         @lastBufferChangeEventId is e.eventId - 1,

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -88,9 +88,6 @@ class TokenizedBuffer extends Model
   onDidChangeGrammar: (callback) ->
     @emitter.on 'did-change-grammar', callback
 
-  onDidChange: (callback) ->
-    @emitter.on 'did-change', callback
-
   onDidTokenize: (callback) ->
     @emitter.on 'did-tokenize', callback
 
@@ -151,8 +148,6 @@ class TokenizedBuffer extends Model
     @invalidRows = []
     @invalidateRow(0)
     @fullyTokenized = false
-    event = {start: 0, end: lastRow, delta: 0}
-    @emitter.emit 'did-change', event
 
   setVisible: (@visible) ->
     @tokenizeInBackground() if @visible
@@ -204,8 +199,6 @@ class TokenizedBuffer extends Model
       @validateRow(endRow)
       @invalidateRow(endRow + 1) unless filledRegion
 
-      event = {start: startRow, end: endRow, delta: 0}
-      @emitter.emit 'did-change', event
       @emitter.emit 'did-invalidate-range', Range(Point(startRow, 0), Point(endRow + 1, 0))
 
     if @firstInvalidRow()?
@@ -273,9 +266,6 @@ class TokenizedBuffer extends Model
       @invalidateRow(end + delta + 1)
 
     @invalidatedRange = Range(start, end)
-
-    event = {start, end, delta, bufferChange: e}
-    @emitter.emit 'did-change', event
 
   isFoldableAtRow: (row) ->
     if @largeFileMode


### PR DESCRIPTION
Depends on atom/text-buffer#170.
Fixes #12085.

/cc: @nathansobo 
