### PR TITLE
Add ::scan tests to ignore files when a directory filter is given

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -1151,7 +1151,7 @@ describe "Workspace", ->
           atom.config.set('core.excludeVcsIgnoredPaths', true)
           resultHandler = jasmine.createSpy("result found")
           waitsForPromise ->
-            atom.workspace.scan /match/, paths:["subdir#{path.sep}"], (results) ->
+            atom.workspace.scan /match/, paths: ["subdir#{path.sep}"], (results) ->
               resultHandler()
 
           runs ->
@@ -1213,7 +1213,7 @@ describe "Workspace", ->
 
         resultHandler = jasmine.createSpy("result found")
         waitsForPromise ->
-          atom.workspace.scan /bbb/, paths:["a-dir#{path.sep}"], (results) ->
+          atom.workspace.scan /bbb/, paths: ["a-dir#{path.sep}"], (results) ->
             resultHandler()
 
         runs ->

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -1129,6 +1129,8 @@ describe "Workspace", ->
             fs.rename(path.join(projectPath, 'git.git'), path.join(projectPath, '.git'))
             ignoredPath = path.join(projectPath, 'ignored.txt')
             fs.writeFileSync(ignoredPath, 'this match should not be included')
+            ignoredSubPath = path.join(projectPath, 'subdir', 'ignored.txt')
+            fs.writeFileSync(ignoredSubPath, 'this subdir match should not be included')
 
         afterEach ->
           fs.removeSync(projectPath) if fs.existsSync(projectPath)
@@ -1139,6 +1141,17 @@ describe "Workspace", ->
           resultHandler = jasmine.createSpy("result found")
           waitsForPromise ->
             atom.workspace.scan /match/, (results) ->
+              resultHandler()
+
+          runs ->
+            expect(resultHandler).not.toHaveBeenCalled()
+
+        xit "excludes ignored files when a directory filter is specified", ->
+          atom.project.setPaths([projectPath])
+          atom.config.set('core.excludeVcsIgnoredPaths', true)
+          resultHandler = jasmine.createSpy("result found")
+          waitsForPromise ->
+            atom.workspace.scan /match/, paths:["subdir#{path.sep}"], (results) ->
               resultHandler()
 
           runs ->
@@ -1188,6 +1201,19 @@ describe "Workspace", ->
         resultHandler = jasmine.createSpy("result found")
         waitsForPromise ->
           atom.workspace.scan /dollar/, (results) ->
+            resultHandler()
+
+        runs ->
+          expect(resultHandler).not.toHaveBeenCalled()
+
+      xit "excludes values in core.ignoredNames when a directory filter is specified", ->
+        ignoredNames = atom.config.get("core.ignoredNames")
+        ignoredNames.push("oh-git")
+        atom.config.set("core.ignoredNames", ignoredNames)
+
+        resultHandler = jasmine.createSpy("result found")
+        waitsForPromise ->
+          atom.workspace.scan /bbb/, paths:["a-dir#{path.sep}"], (results) ->
             resultHandler()
 
         runs ->


### PR DESCRIPTION
These tests are currently failing.
Highlights the bug noted in atom/find-and-replace#621 and atom/atom#12389
