### PR TITLE
Remove config option `editor.backUpBeforeSaving`

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -237,10 +237,6 @@ module.exports =
         default: true
         title: 'Confirm Checkout HEAD Revision'
         description: 'Show confirmation dialog when checking out the HEAD revision and discarding changes to current file since last commit.'
-      backUpBeforeSaving:
-        type: 'boolean'
-        default: false
-        description: 'Ensure file contents aren\'t lost if there is an I/O error during save by making a temporary backup copy.'
       invisibles:
         type: 'object'
         description: 'A hash of characters Atom will use to render whitespace characters. Keys are whitespace character types, values are rendered characters (use value false to turn off individual whitespace character types).'

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -757,14 +757,14 @@ class TextEditor extends Model
   # Essential: Saves the editor's text buffer.
   #
   # See {TextBuffer::save} for more details.
-  save: -> @buffer.save(backup: @config.get('editor.backUpBeforeSaving'))
+  save: -> @buffer.save()
 
   # Essential: Saves the editor's text buffer as the given path.
   #
   # See {TextBuffer::saveAs} for more details.
   #
   # * `filePath` A {String} path.
-  saveAs: (filePath) -> @buffer.saveAs(filePath, backup: @config.get('editor.backUpBeforeSaving'))
+  saveAs: (filePath) -> @buffer.saveAs(filePath)
 
   # Determine whether the user should be prompted to save before closing
   # this editor.


### PR DESCRIPTION
After #11828, Atom always creates a backup file in the `~/.atom/recovery` directory, trying to restore it automatically via the main process in case there is a hard crash on the renderer process. This approach should be resilient enough to allow us to delete and stop using the `editor.backUpBeforeSaving` config option.

We can still keep it for a while in text-buffer, in case we need to use it again at some point, but it's probably fine to remove it from there too at some point in the future.

@atom/core: what do you think?
