### PR TITLE
Fix Regression In #12317 For zsh and Patch Environment On OSX For Users Of fish

### DIFF
--- a/spec/update-process-env-spec.js
+++ b/spec/update-process-env-spec.js
@@ -2,7 +2,7 @@
 /* eslint-env jasmine */
 
 import child_process from 'child_process'
-import {updateProcessEnv, shellShouldBePatched} from '../src/update-process-env'
+import {updateProcessEnv, envShouldBePatched} from '../src/update-process-env'
 import dedent from 'dedent'
 
 describe('updateProcessEnv(launchEnv)', function () {
@@ -86,38 +86,30 @@ describe('updateProcessEnv(launchEnv)', function () {
     })
 
     describe('shells on osx', function () {
-      it('shellShouldBePatched() returns the shell when the shell should be patched', function () {
+      it('envShouldBePatched() returns the shell when the shell should be patched', function () {
         process.platform = 'darwin'
-        let shellsToTest = new Set([
-          '/bin/sh',
-          '/usr/local/bin/sh',
-          '/bin/bash',
-          '/usr/local/bin/bash',
-          '/bin/zsh',
-          '/usr/local/bin/zsh',
-          '/bin/fish',
-          '/usr/local/bin/fish'
-        ])
-        for (let shell of shellsToTest) {
-          process.env.SHELL = shell
-          expect(shellShouldBePatched()).toBe(shell)
-        }
+        expect(envShouldBePatched('/bin/sh')).toBe(true)
+        expect(envShouldBePatched('/usr/local/bin/sh')).toBe(true)
+        expect(envShouldBePatched('/bin/bash')).toBe(true)
+        expect(envShouldBePatched('/usr/local/bin/bash')).toBe(true)
+        expect(envShouldBePatched('/bin/zsh')).toBe(true)
+        expect(envShouldBePatched('/usr/local/bin/zsh')).toBe(true)
+        expect(envShouldBePatched('/bin/fish')).toBe(true)
+        expect(envShouldBePatched('/usr/local/bin/fish')).toBe(true)
       })
 
-      it('shellShouldBePatched() returns false when the shell should not be patched', function () {
+      it('envShouldBePatched() returns false when the shell should not be patched', function () {
         process.platform = 'darwin'
-        let shellsToTest = new Set([
-          '/bin/unsupported',
-          '/bin/shh',
-          '/bin/tcsh',
-          '/usr/csh'
-        ])
-        for (let shell of shellsToTest) {
-          process.env.SHELL = shell
-          let result = shellShouldBePatched()
-          console.log(result)
-          expect(result).toBe(false)
-        }
+        expect(envShouldBePatched('/bin/unsupported')).toBe(false)
+        expect(envShouldBePatched('/bin/shh')).toBe(false)
+        expect(envShouldBePatched('/bin/tcsh')).toBe(false)
+        expect(envShouldBePatched('/usr/csh')).toBe(false)
+      })
+
+      it('envShouldBePatched() returns false when the shell is undefined or empty', function () {
+        process.platform = 'darwin'
+        expect(envShouldBePatched(undefined)).toBe(false)
+        expect(envShouldBePatched('')).toBe(false)
       })
     })
   })

--- a/spec/update-process-env-spec.js
+++ b/spec/update-process-env-spec.js
@@ -85,8 +85,8 @@ describe('updateProcessEnv(launchEnv)', function () {
       })
     })
 
-    describe('shells on osx', function () {
-      it('shouldGetEnvFromShell() returns the shell when the shell should be patched', function () {
+    describe('shouldGetEnvFromShell()', function () {
+      it('returns the shell when the shell should be patched', function () {
         process.platform = 'darwin'
         expect(shouldGetEnvFromShell('/bin/sh')).toBe(true)
         expect(shouldGetEnvFromShell('/usr/local/bin/sh')).toBe(true)
@@ -98,7 +98,7 @@ describe('updateProcessEnv(launchEnv)', function () {
         expect(shouldGetEnvFromShell('/usr/local/bin/fish')).toBe(true)
       })
 
-      it('shouldGetEnvFromShell() returns false when the shell should not be patched', function () {
+      it('returns false when the shell should not be patched', function () {
         process.platform = 'darwin'
         expect(shouldGetEnvFromShell('/bin/unsupported')).toBe(false)
         expect(shouldGetEnvFromShell('/bin/shh')).toBe(false)
@@ -106,7 +106,7 @@ describe('updateProcessEnv(launchEnv)', function () {
         expect(shouldGetEnvFromShell('/usr/csh')).toBe(false)
       })
 
-      it('shouldGetEnvFromShell() returns false when the shell is undefined or empty', function () {
+      it('returns false when the shell is undefined or empty', function () {
         process.platform = 'darwin'
         expect(shouldGetEnvFromShell(undefined)).toBe(false)
         expect(shouldGetEnvFromShell('')).toBe(false)

--- a/spec/update-process-env-spec.js
+++ b/spec/update-process-env-spec.js
@@ -2,7 +2,7 @@
 /* eslint-env jasmine */
 
 import child_process from 'child_process'
-import {updateProcessEnv, envShouldBePatched} from '../src/update-process-env'
+import {updateProcessEnv, shouldGetEnvFromShell} from '../src/update-process-env'
 import dedent from 'dedent'
 
 describe('updateProcessEnv(launchEnv)', function () {
@@ -86,30 +86,30 @@ describe('updateProcessEnv(launchEnv)', function () {
     })
 
     describe('shells on osx', function () {
-      it('envShouldBePatched() returns the shell when the shell should be patched', function () {
+      it('shouldGetEnvFromShell() returns the shell when the shell should be patched', function () {
         process.platform = 'darwin'
-        expect(envShouldBePatched('/bin/sh')).toBe(true)
-        expect(envShouldBePatched('/usr/local/bin/sh')).toBe(true)
-        expect(envShouldBePatched('/bin/bash')).toBe(true)
-        expect(envShouldBePatched('/usr/local/bin/bash')).toBe(true)
-        expect(envShouldBePatched('/bin/zsh')).toBe(true)
-        expect(envShouldBePatched('/usr/local/bin/zsh')).toBe(true)
-        expect(envShouldBePatched('/bin/fish')).toBe(true)
-        expect(envShouldBePatched('/usr/local/bin/fish')).toBe(true)
+        expect(shouldGetEnvFromShell('/bin/sh')).toBe(true)
+        expect(shouldGetEnvFromShell('/usr/local/bin/sh')).toBe(true)
+        expect(shouldGetEnvFromShell('/bin/bash')).toBe(true)
+        expect(shouldGetEnvFromShell('/usr/local/bin/bash')).toBe(true)
+        expect(shouldGetEnvFromShell('/bin/zsh')).toBe(true)
+        expect(shouldGetEnvFromShell('/usr/local/bin/zsh')).toBe(true)
+        expect(shouldGetEnvFromShell('/bin/fish')).toBe(true)
+        expect(shouldGetEnvFromShell('/usr/local/bin/fish')).toBe(true)
       })
 
-      it('envShouldBePatched() returns false when the shell should not be patched', function () {
+      it('shouldGetEnvFromShell() returns false when the shell should not be patched', function () {
         process.platform = 'darwin'
-        expect(envShouldBePatched('/bin/unsupported')).toBe(false)
-        expect(envShouldBePatched('/bin/shh')).toBe(false)
-        expect(envShouldBePatched('/bin/tcsh')).toBe(false)
-        expect(envShouldBePatched('/usr/csh')).toBe(false)
+        expect(shouldGetEnvFromShell('/bin/unsupported')).toBe(false)
+        expect(shouldGetEnvFromShell('/bin/shh')).toBe(false)
+        expect(shouldGetEnvFromShell('/bin/tcsh')).toBe(false)
+        expect(shouldGetEnvFromShell('/usr/csh')).toBe(false)
       })
 
-      it('envShouldBePatched() returns false when the shell is undefined or empty', function () {
+      it('shouldGetEnvFromShell() returns false when the shell is undefined or empty', function () {
         process.platform = 'darwin'
-        expect(envShouldBePatched(undefined)).toBe(false)
-        expect(envShouldBePatched('')).toBe(false)
+        expect(shouldGetEnvFromShell(undefined)).toBe(false)
+        expect(shouldGetEnvFromShell('')).toBe(false)
       })
     })
   })

--- a/spec/update-process-env-spec.js
+++ b/spec/update-process-env-spec.js
@@ -2,7 +2,7 @@
 /* eslint-env jasmine */
 
 import child_process from 'child_process'
-import updateProcessEnv from '../src/update-process-env'
+import {updateProcessEnv, shellShouldBePatched} from '../src/update-process-env'
 import dedent from 'dedent'
 
 describe('updateProcessEnv(launchEnv)', function () {
@@ -82,6 +82,42 @@ describe('updateProcessEnv(launchEnv)', function () {
         updateProcessEnv(process.env)
         expect(child_process.spawnSync).not.toHaveBeenCalled()
         expect(process.env).toEqual({FOO: 'bar'})
+      })
+    })
+
+    describe('shells on osx', function () {
+      it('shellShouldBePatched() returns the shell when the shell should be patched', function () {
+        process.platform = 'darwin'
+        let shellsToTest = new Set([
+          '/bin/sh',
+          '/usr/local/bin/sh',
+          '/bin/bash',
+          '/usr/local/bin/bash',
+          '/bin/zsh',
+          '/usr/local/bin/zsh',
+          '/bin/fish',
+          '/usr/local/bin/fish'
+        ])
+        for (let shell of shellsToTest) {
+          process.env.SHELL = shell
+          expect(shellShouldBePatched()).toBe(shell)
+        }
+      })
+
+      it('shellShouldBePatched() returns false when the shell should not be patched', function () {
+        process.platform = 'darwin'
+        let shellsToTest = new Set([
+          '/bin/unsupported',
+          '/bin/shh',
+          '/bin/tcsh',
+          '/usr/csh'
+        ])
+        for (let shell of shellsToTest) {
+          process.env.SHELL = shell
+          let result = shellShouldBePatched()
+          console.log(result)
+          expect(result).toBe(false)
+        }
       })
     })
   })

--- a/src/initialize-application-window.coffee
+++ b/src/initialize-application-window.coffee
@@ -1,6 +1,6 @@
 # Like sands through the hourglass, so are the days of our lives.
 module.exports = ({blobStore}) ->
-  updateProcessEnv = require('./update-process-env')
+  {updateProcessEnv} = require('./update-process-env')
   path = require 'path'
   require './window'
   {getWindowLoadSettings} = require './window-load-settings-helpers'

--- a/src/update-process-env.js
+++ b/src/update-process-env.js
@@ -40,7 +40,7 @@ function updateProcessEnv (launchEnv) {
   }
 }
 
-function envShouldBePatched (shell) {
+function shouldGetEnvFromShell (shell) {
   if (!shell || shell.trim() === '') {
     return false
   }
@@ -55,7 +55,7 @@ function envShouldBePatched (shell) {
 
 function getEnvFromShell () {
   let shell = process.env.SHELL
-  if (!envShouldBePatched(shell)) {
+  if (!shouldGetEnvFromShell(shell)) {
     return
   }
 
@@ -74,4 +74,4 @@ function getEnvFromShell () {
   }
 }
 
-export default { updateProcessEnv, envShouldBePatched }
+export default { updateProcessEnv, shouldGetEnvFromShell }


### PR DESCRIPTION
In Atom 1.7 and 1.8, the environment would be patched for users of the zsh shell on OS X, who launched Atom from the Dock / Finder / Spotlight. A whitelist of shells was established in #12317, which is extended here to include zsh and fish.

Tested with built-in zsh, homebrew installed zsh, and homebrew installed fish.
