### PR TITLE
Delegate TextEditor.getMarkerCount to default marker layer.

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1852,7 +1852,7 @@ class TextEditor extends Model
   #
   # Returns a {Number}.
   getMarkerCount: ->
-    @buffer.getMarkerCount()
+    @defaultMarkerLayer.getMarkerCount()
 
   destroyMarker: (id) ->
     @getMarker(id)?.destroy()


### PR DESCRIPTION
Looks like this should follow the other marker methods in delegating to the default marker layer rather than the buffer directly.
