### PR TITLE
Pass the menu item when executing menu command

### DIFF
--- a/src/main-process/application-menu.coffee
+++ b/src/main-process/application-menu.coffee
@@ -142,7 +142,7 @@ class ApplicationMenu
       item.metadata ?= {}
       if item.command
         item.accelerator = @acceleratorForCommand(item.command, keystrokesByCommand)
-        item.click = -> global.atomApplication.sendCommand(item.command)
+        item.click = -> global.atomApplication.sendCommand(item.command, item)
         item.metadata.windowSpecific = true unless /^application:/.test(item.command)
       @translateTemplate(item.submenu, keystrokesByCommand) if item.submenu
     template


### PR DESCRIPTION
Pass the menu item when executing menu command so that we could know exactly which menu item triggers the event by interrogating event.detail property.

E.g., Inside a package

``` js
this.subscriptions = new CompositeDisposable();
this.subscriptions.add(atom.commands.add("atom-workspace", {
  "some-command": (evt) => {
    console.log(evt.detail);  // detail should be menu item
  }
});
```
