### PR TITLE
load initialPaths for first new-window event

### DIFF
--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -127,7 +127,7 @@ class AtomApplication
         app.quit()
         return
     @windows.splice(@windows.indexOf(window), 1)
-    @saveState(true) unless window.isSpec
+    @saveState(false) unless window.isSpec
 
   # Public: Adds the {AtomWindow} to the global window list.
   addWindow: (window) ->
@@ -190,7 +190,15 @@ class AtomApplication
       safeMode: @focusedWindow()?.safeMode
 
     @on 'application:quit', -> app.quit()
-    @on 'application:new-window', -> @openPath(getLoadSettings())
+    @on 'application:new-window', ->
+      loadSettings = getLoadSettings()
+      if @windows.length is 0
+        restorePreviousState = @config.get('core.restorePreviousWindowsOnStart') ? true
+        if restorePreviousState and (states = @storageFolder.load('application.json'))?.length > 0
+          loadSettings.pathsToOpen = states[0].initialPaths.filter (directoryPath) -> fs.isDirectorySync(directoryPath)
+        @openPaths(loadSettings)
+      else
+        @openPath(loadSettings)
     @on 'application:new-file', -> (@focusedWindow() ? this).openPath()
     @on 'application:open-dev', -> @promptForPathToOpen('all', devMode: true)
     @on 'application:open-safe', -> @promptForPathToOpen('all', safeMode: true)


### PR DESCRIPTION
Fix bug https://github.com/atom/atom/issues/11361

1、On macOS,  the sate is not saved when the last window is removed because the progress is running, so "removeWindow" function must be updated to :

> `@saveState(false) unless window.isSpec`

2、We must load paths from '.atom/storage/application.json' for the first window  when the application is running and no window, especially on macOS
