### PR TITLE
Add atom.project.observeBuffers

### DIFF
--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -518,6 +518,54 @@ describe "Project", ->
       atom.project.removePath(ftpURI)
       expect(atom.project.getPaths()).toEqual []
 
+  describe ".onDidAddBuffer()", ->
+    it "invokes the callback with added text buffers", ->
+      buffers = []
+      added = []
+
+      waitsForPromise ->
+        atom.project.buildBuffer(require.resolve('./fixtures/dir/a'))
+          .then (o) -> buffers.push(o)
+
+      runs ->
+        expect(buffers.length).toBe 1
+        atom.project.onDidAddBuffer (buffer) -> added.push(buffer)
+
+      waitsForPromise ->
+        atom.project.buildBuffer(require.resolve('./fixtures/dir/b'))
+          .then (o) -> buffers.push(o)
+
+      runs ->
+        expect(buffers.length).toBe 2
+        expect(added).toEqual [buffers[1]]
+
+  describe ".observeBuffers()", ->
+    it "invokes the observer with current and future text buffers", ->
+      buffers = []
+      observed = []
+
+      waitsForPromise ->
+        atom.project.buildBuffer(require.resolve('./fixtures/dir/a'))
+          .then (o) -> buffers.push(o)
+
+      waitsForPromise ->
+        atom.project.buildBuffer(require.resolve('./fixtures/dir/b'))
+          .then (o) -> buffers.push(o)
+
+      runs ->
+        expect(buffers.length).toBe 2
+        atom.project.observeBuffers (buffer) -> observed.push(buffer)
+        expect(observed).toEqual buffers
+
+      waitsForPromise ->
+        atom.project.buildBuffer(require.resolve('./fixtures/dir/b'))
+          .then (o) -> buffers.push(o)
+
+      runs ->
+        expect(observed.length).toBe 3
+        expect(buffers.length).toBe 3
+        expect(observed).toEqual buffers
+
   describe ".relativize(path)", ->
     it "returns the path, relative to whichever root directory it is inside of", ->
       atom.project.addPath(temp.mkdirSync("another-path"))

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -89,8 +89,26 @@ class Project extends Model
   onDidChangePaths: (callback) ->
     @emitter.on 'did-change-paths', callback
 
+  # Public: Invoke the given callback when a text buffer is added to the
+  # project.
+  #
+  # * `callback` {Function} to be called when a text buffer is added.
+  #   * `buffer` A {TextBuffer} item.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidAddBuffer: (callback) ->
     @emitter.on 'did-add-buffer', callback
+
+  # Public: Invoke the given callback with all current and future text
+  # buffers in the project.
+  #
+  # * `callback` {Function} to be called with current and future text buffers.
+  #   * `buffer` A {TextBuffer} item.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  observeBuffers: (callback) ->
+    callback(buffer) for buffer in @getBuffers()
+    @onDidAddBuffer callback
 
   ###
   Section: Accessing the git repository


### PR DESCRIPTION
This makes `onDidAddBuffer` symmetrical with other `onDidAddX` methods and their `observeXs`. It also documents `onDidAddBuffer` and adds tests for it.

Released under CC0.
