### PR TITLE
Bump packages for telemetry consent changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "one-light-syntax": "1.3.0",
     "solarized-dark-syntax": "1.0.2",
     "solarized-light-syntax": "1.0.2",
-    "about": "1.6.0",
+    "about": "1.7.0",
     "archive-view": "0.61.1",
     "autocomplete-atom-api": "0.10.0",
     "autocomplete-css": "0.11.2",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "timecop": "0.33.2",
     "tree-view": "0.209.0",
     "update-package-dependencies": "0.10.0",
-    "welcome": "0.34.0",
+    "welcome": "0.35.0",
     "whitespace": "0.33.0",
     "wrap-guide": "0.38.2",
     "language-c": "0.52.1",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "line-ending-selector": "0.5.0",
     "link": "0.31.1",
     "markdown-preview": "0.158.0",
-    "metrics": "0.53.1",
+    "metrics": "1.0.0",
     "notifications": "0.65.1",
     "open-on-github": "1.2.0",
     "package-generator": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "deprecation-cop": "0.54.1",
     "dev-live-reload": "0.47.0",
     "encoding-selector": "0.22.0",
-    "exception-reporting": "0.39.0",
+    "exception-reporting": "0.40.0",
     "find-and-replace": "0.201.1",
     "fuzzy-finder": "1.4.0",
     "git-diff": "1.1.0",


### PR DESCRIPTION
Continuation of:
- https://github.com/atom/atom/pull/12281
- https://github.com/atom/metrics/pull/66
- https://github.com/atom/exception-reporting/pull/20
- https://github.com/atom/about/pull/37
- https://github.com/atom/welcome/pull/48

This PR bumps all the packages that were changed as part of the new telemetry consent stuff, so all those changes will be in `master` 😄 

👀 @damieng 
