### PR TITLE
Reset the package's local storage setting if loading cannot be deferred

### DIFF
--- a/src/package.js
+++ b/src/package.js
@@ -917,6 +917,10 @@ module.exports = class Package {
             this.getCanDeferMainModuleRequireStorageKey(),
             'true'
           );
+        } else {
+          localStorage.removeItem(
+            this.getCanDeferMainModuleRequireStorageKey()
+          );
         }
         return this.mainModule;
       }


### PR DESCRIPTION
Hi there, it’s been a while since I last got some time to work on Atom.

So this PR attempt to fix an annoying issue I struggled with for months now, without being able to figure when it came from, but I finally found an explanation. I initially reported it in #9677, but without any clue as to why it was not working properly the issue was closed expected.

So now, let’s enter the main topic. 

Let’s say we create a new package, we’re running it in dev mode, and for the moment there’s no deserializers or registered views for that package. 

When requiring the main module, we will end up passing in [this branch](https://github.com/atom/atom/blob/master/src/package.coffee#L442-L444) that will set the `getCanDeferMainModuleRequireStorageKey()` flag to `true`.

Now if we start adding deserializers into our package, since the flag is never turned off, the package main module loading will always be deferred on activation as [this condition will always be true](https://github.com/atom/atom/blob/master/src/package.coffee#L102), resulting in error if the there’s serialized pane items that need to be deserialized. 

Of course, as these settings are scoped using the package version, this is generally not an issue with published packages. If serializers or views are added between two versions the local storage keys will be different  and the previous value will be ignored.

However, this issue is making developing a package that have serializers seriously complicated as there’s no longer a way to test them in dev mode once we entered that state (unless knowing that this local storage setting must be removed).

A simple solution here is to simply remove the local storage item if we find that the package now has deserializers or registered views that it didn’t have before.
