### PR TITLE
Register all editors added to the workspace

### DIFF
--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -165,7 +165,10 @@ class Workspace extends Model
     @onDidAddPaneItem ({item, pane, index}) =>
       if item instanceof TextEditor
         grammarSubscription = item.observeGrammar(@handleGrammarUsed.bind(this))
-        item.onDidDestroy -> grammarSubscription.dispose()
+        editorRegistrySubscription = atom.textEditors.add(item)
+        item.onDidDestroy ->
+          grammarSubscription.dispose()
+          editorRegistrySubscription.dispose()
         @emitter.emit 'did-add-text-editor', {textEditor: item, pane, index}
 
   # Updates the application's title and proxy icon based on whichever file is
@@ -556,10 +559,7 @@ class Workspace extends Model
         throw error
 
     @project.bufferForPath(filePath, options).then (buffer) =>
-      editor = @buildTextEditor(Object.assign({buffer, largeFileMode}, options))
-      disposable = atom.textEditors.add(editor)
-      editor.onDidDestroy -> disposable.dispose()
-      editor
+      @buildTextEditor(Object.assign({buffer, largeFileMode}, options))
 
   handleGrammarUsed: (grammar) ->
     return unless grammar?


### PR DESCRIPTION
This replicates a bugfix that landed on master in via https://github.com/atom/atom/pull/12125, into the `1.10-releases` branch.

Refs https://github.com/atom/autocomplete-plus/issues/752

We need this before we can do another railcar release.
