### PR TITLE
Disable telemetry on AtomApplication tests and smoke tests

### DIFF
--- a/spec/integration/fixtures/atom-home/config.cson
+++ b/spec/integration/fixtures/atom-home/config.cson
@@ -1,5 +1,0 @@
-"*":
-  welcome:
-    showOnStartup: false
-  "exception-reporting":
-    userId: "7c0a3c52-795c-5e20-5323-64efcf91f212"

--- a/spec/integration/smoke-spec.coffee
+++ b/spec/integration/smoke-spec.coffee
@@ -1,5 +1,6 @@
 fs = require 'fs-plus'
 path = require 'path'
+season = require 'season'
 temp = require('temp').track()
 runAtom = require './helpers/start-atom'
 
@@ -8,7 +9,12 @@ describe "Smoke Test", ->
 
   beforeEach ->
     jasmine.useRealClock()
-    fs.writeFileSync(path.join(atomHome, 'config.cson'), fs.readFileSync(path.join(__dirname, 'fixtures', 'atom-home', 'config.cson')))
+    season.writeFileSync(path.join(atomHome, 'config.cson'), {
+      '*': {
+        welcome: {showOnStartup: false},
+        core: {telemetryConsent: 'no'}
+      }
+    })
 
   it "can open a file in Atom and perform basic operations on it", ->
     tempDirPath = temp.mkdirSync("empty-dir")

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -22,7 +22,10 @@ describe('AtomApplication', function () {
     // Symlinking the compile cache into the temporary home dir makes the windows load much faster
     fs.symlinkSync(path.join(originalAtomHome, 'compile-cache'), path.join(process.env.ATOM_HOME, 'compile-cache'))
     season.writeFileSync(path.join(process.env.ATOM_HOME, 'config.cson'), {
-      '*': {welcome: {showOnStartup: false}}
+      '*': {
+        welcome: {showOnStartup: false},
+        core: {telemetryConsent: 'no'}
+      }
     })
     atomApplicationsToDestroy = []
   })


### PR DESCRIPTION
Unless a choice has been made by the user, the telemetry consent tab always shows up as the first one when opening Atom, thus breaking some of the assumptions we make in main process tests. This caused our test suite to be ❌, even if behavior-wise everything was okay.

With this pull-request we disable the telemetry tab in main process and smoke tests, so that the build is 💚 again.

/cc: @atom/core 
