### PR TITLE
Focus application on all code paths that open windows in main process

### DIFF
--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -109,6 +109,8 @@ class AtomApplication
       @loadState(options) or @openPath(options)
 
   openWithOptions: ({initialPaths, pathsToOpen, executedFrom, urlsToOpen, test, pidToKillWhenClosed, devMode, safeMode, newWindow, logFile, profileStartup, timeout, clearWindowState, addToLastWindow, env}) ->
+    app.focus()
+
     if test
       @runTests({headless: true, devMode, @resourcePath, executedFrom, pathsToOpen, logFile, timeout, env})
     else if pathsToOpen.length > 0


### PR DESCRIPTION
I think this should take the application out of “app nap” on macOS, leading to better responsiveness when opening paths from the CLI. Based on my research this morning I'm fairly optimistic that this might be all that is required to solve our issues with intermittent slowness when opening from the command line on macOS.

/cc @maxbrunsfeld @as-cii @damieng 
