### PR TITLE
send event to save state after 'Add Project Folder' or 'Remove Projec…

### DIFF
--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -126,7 +126,7 @@ class ApplicationDelegate
     loadSettings = getWindowLoadSettings()
     loadSettings['initialPaths'] = paths
     setWindowLoadSettings(loadSettings)
-    ipcRenderer.send("did-save-state")
+    ipcRenderer.send("did-change-paths")
 
 
   setAutoHideWindowMenuBar: (autoHide) ->

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -128,7 +128,6 @@ class ApplicationDelegate
     setWindowLoadSettings(loadSettings)
     ipcRenderer.send("did-change-paths")
 
-
   setAutoHideWindowMenuBar: (autoHide) ->
     ipcRenderer.send("call-window-method", "setAutoHideMenuBar", autoHide)
 

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -126,6 +126,8 @@ class ApplicationDelegate
     loadSettings = getWindowLoadSettings()
     loadSettings['initialPaths'] = paths
     setWindowLoadSettings(loadSettings)
+    ipcRenderer.send("did-save-state")
+
 
   setAutoHideWindowMenuBar: (autoHide) ->
     ipcRenderer.send("call-window-method", "setAutoHideMenuBar", autoHide)

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -351,7 +351,7 @@ class AtomApplication
       @fileRecoveryService.didSavePath(@windowForEvent(event), path)
       event.returnValue = true
 
-    @disposable.add ipcHelpers.on ipcMain, 'did-save-state', =>
+    @disposable.add ipcHelpers.on ipcMain, 'did-change-paths', =>
       @saveState(false)
 
   setupDockMenu: ->

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -351,6 +351,9 @@ class AtomApplication
       @fileRecoveryService.didSavePath(@windowForEvent(event), path)
       event.returnValue = true
 
+    @disposable.add ipcHelpers.on ipcMain, 'did-save-state', =>
+      @saveState(false)
+
   setupDockMenu: ->
     if process.platform is 'darwin'
       dockMenu = Menu.buildFromTemplate [


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/12495

When we add or remove project folder,  the window's current project path will be changed, then "initialPaths" will be reloaded, it is the best time to save state

/cc @maxbrunsfeld @lee-dohm 
