### PR TITLE
Run script/bootstrap from script/build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
   - nvm install $NODE_VERSION
   - nvm use --delete-prefix $NODE_VERSION
   - npm install -g npm
-  - script/bootstrap
   - script/build --create-debian-package --create-rpm-package --compress-artifacts
 
 script: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,6 @@ install:
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - script\bootstrap.cmd
   - script\build.cmd --code-sign --create-windows-installer --compress-artifacts
 
 test: off

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,6 @@ dependencies:
     - npm install -g npm
 
   override:
-    - script/bootstrap
     - script/build --code-sign --compress-artifacts
 
   cache_directories:

--- a/docs/build-instructions/freebsd.md
+++ b/docs/build-instructions/freebsd.md
@@ -15,6 +15,5 @@ FreeBSD -RELEASE 64-bit is the recommended platform.
 ```sh
 git clone https://github.com/atom/atom
 cd atom
-script/bootstrap
 script/build
 ```

--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -19,7 +19,6 @@ For more details, scroll down to find how to setup a specific Linux distro.
 ```sh
 git clone https://github.com/atom/atom.git
 cd atom
-script/bootstrap
 script/build
 ```
 
@@ -39,7 +38,7 @@ To also install the newly built application, use `--create-debian-package` or `-
   sudo apt-get install build-essential git libgnome-keyring-dev fakeroot rpm
   ```
 
-* If `script/bootstrap` exits with an error, you may need to install a newer C++ compiler with C++11:
+* If `script/build` exits with an error, you may need to install a newer C++ compiler with C++11:
 
   ```sh
   sudo add-apt-repository ppa:ubuntu-toolchain-r/test

--- a/docs/build-instructions/macos.md
+++ b/docs/build-instructions/macos.md
@@ -12,7 +12,6 @@
 ```sh
 git clone https://github.com/atom/atom.git
 cd atom
-script/bootstrap
 script/build
 ```
 

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -25,7 +25,6 @@ You can run these commands using Command Prompt, PowerShell or Git Shell via [Gi
 cd C:\
 git clone https://github.com/atom/atom.git
 cd atom
-script\bootstrap
 script\build
 ```
 
@@ -56,10 +55,10 @@ If none of this works, do install Github Desktop and use its Git Shell as it mak
 * `msbuild.exe failed with exit code: 1`
    * Ensure you have Visual C++ support installed. Go into Add/Remove Programs, select Visual Studio and press Modify and then check the Visual C++ box.
 
-* `script\bootstrap` or `script\build` stop with no error or warning shortly after displaying the versions of node, npm and Python
+* `script\build` stop with no error or warning shortly after displaying the versions of node, npm and Python
   * Make sure that the path where you have checked out Atom does not include a space. e.g. use `c:\atom` and not `c:\my stuff\atom`
 
-* `script\bootstrap` or `script\build` outputs only the Node.js and Python versions before returning
+* `script\build` outputs only the Node.js and Python versions before returning
   * Try moving the repository to `C:\atom`. Most likely, the path is too long.
     See [issue #2200](https://github.com/atom/atom/issues/2200).
 
@@ -73,14 +72,14 @@ If none of this works, do install Github Desktop and use its Git Shell as it mak
 * `'node_modules\.bin\npm' is not recognized as an internal or external command, operable program or batch file.`
    * This occurs if the previous build left things in a bad state. Run `script\clean` and then `script\build` again.
 
-* `script\bootstrap` stops at installing runas with `Failed at the runas@x.y.z install script.`
+* `script\build` stops at installing runas with `Failed at the runas@x.y.z install script.`
   * See the next item.
 
 * `error MSB8020: The build tools for Visual Studio 201? (Platform Toolset = 'v1?0') cannot be found.`
-  * Try setting the `GYP_MSVS_VERSION` environment variable to 2013 or 2015 depending on what version of Visual Studio you are running and then `script\clean` followed by `script\bootstrap` (re-open your command prompt or Powershell window if you set it using the GUI)
+  * Try setting the `GYP_MSVS_VERSION` environment variable to 2013 or 2015 depending on what version of Visual Studio you are running and then `script\clean` followed by `script\build` (re-open your command prompt or Powershell window if you set it using the GUI)
 
 * `'node-gyp' is not recognized as an internal or external command, operable program or batch file.`
-  * Try running `npm install -g node-gyp`, and run `script\bootstrap` again.
+  * Try running `npm install -g node-gyp`, and run `script\build` again.
 
 * Other `node-gyp` errors on first build attempt, even though the right Node.js and Python versions are installed.
   * Do try the build command one more time, as experience shows it often works on second try in many of these cases.

--- a/script/build
+++ b/script/build
@@ -42,6 +42,8 @@ process.on('unhandledRejection', function (e) {
   process.exit(1)
 })
 
+require('./bootstrap')
+
 cleanOutputDirectory()
 copyAssets()
 transpileBabelPaths()


### PR DESCRIPTION
This is how things worked previously, and it seems both convenient and low-cost. In the [Scripts To Rule Them All](https://github.com/github/scripts-to-rule-them-all) standard, there are examples of [scripts calling other scripts](https://github.com/github/scripts-to-rule-them-all/blob/master/script/test#L20).

/cc @as-cii @lee-dohm 
