### PR TITLE
Allow to run script/build --install on all platforms

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -29,6 +29,7 @@ To also install the newly built application, use `--create-debian-package` or `-
 * `--compress-artifacts`: zips the generated application as `out/atom-{arch}.tar.gz`.
 * `--create-debian-package`: creates a .deb package as `out/atom-{arch}.deb`
 * `--create-rpm-package`: creates a .rpm package as `out/atom-{arch}.rpm`
+* `--install`: installs the application in `/usr/local/`.
 
 ### Ubuntu / Debian
 

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -34,6 +34,7 @@ To also install the newly built application, use `script\build --create-windows-
 * `--code-sign`: signs the application with the GitHub certificate specified in `$WIN_P12KEY_URL`.
 * `--compress-artifacts`: zips the generated application as `out/atom-windows.zip` (requires 7-zip).
 * `--create-windows-installer`: creates an `.msi`, an `.exe` and a `.nupkg` installer in the `out/` directory.
+* `--install`: installs the application in `C:\Users\<user name>\AppData\Local\`.
 
 ## Do I have to use GitHub Desktop?
 

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -34,7 +34,7 @@ To also install the newly built application, use `script\build --create-windows-
 * `--code-sign`: signs the application with the GitHub certificate specified in `$WIN_P12KEY_URL`.
 * `--compress-artifacts`: zips the generated application as `out/atom-windows.zip` (requires 7-zip).
 * `--create-windows-installer`: creates an `.msi`, an `.exe` and a `.nupkg` installer in the `out/` directory.
-* `--install`: installs the application in `C:\Users\<user name>\AppData\Local\`.
+* `--install`: installs the application in `%LOCALAPPDATA%\Atom\app-dev\`.
 
 ## Do I have to use GitHub Desktop?
 

--- a/resources/linux/atom.desktop.in
+++ b/resources/linux/atom.desktop.in
@@ -3,7 +3,7 @@ Name=<%= appName %>
 Comment=<%= description %>
 GenericName=Text Editor
 Exec=<%= installDir %>/share/<%= appFileName %>/atom %F
-Icon=<%= iconName %>
+Icon=<%= iconPath %>
 Type=Application
 StartupNotify=true
 Categories=GNOME;GTK;Utility;TextEditor;Development;

--- a/script/copy-folder.cmd
+++ b/script/copy-folder.cmd
@@ -1,0 +1,18 @@
+@echo off
+
+set USAGE=Usage: %0 source destination
+
+if [%1] == [] (
+  echo %USAGE%
+  exit 1
+)
+if [%2] == [] (
+  echo %USAGE%
+  exit 2
+)
+
+:: rm -rf %2
+if exist %2 rmdir %2 /s /q
+
+:: cp -rf %1 %2
+(robocopy %1 %2 /e) ^& IF %ERRORLEVEL% LEQ 1 exit 0

--- a/script/lib/clean-caches.js
+++ b/script/lib/clean-caches.js
@@ -8,7 +8,7 @@ const CONFIG = require('../config')
 
 module.exports = function () {
   const cachePaths = [
-    path.join(CONFIG.repositoryRootPath, 'cache'),
+    path.join(CONFIG.repositoryRootPath, 'electron'),
     path.join(CONFIG.homeDirPath, '.atom', '.node-gyp'),
     path.join(CONFIG.homeDirPath, '.atom', 'storage'),
     path.join(CONFIG.homeDirPath, '.atom', '.apm'),

--- a/script/lib/create-debian-package.js
+++ b/script/lib/create-debian-package.js
@@ -84,7 +84,7 @@ module.exports = function (packagedAppPath) {
   const desktopEntryTemplate = fs.readFileSync(path.join(CONFIG.repositoryRootPath, 'resources', 'linux', 'atom.desktop.in'))
   const desktopEntryContents = template(desktopEntryTemplate)({
     appName: appName, appFileName: atomExecutableName, description: appDescription,
-    installDir: '/usr', iconName: atomExecutableName
+    installDir: '/usr', iconPath: atomExecutableName
   })
   fs.writeFileSync(path.join(debianPackageApplicationsDirPath, `${atomExecutableName}.desktop`), desktopEntryContents)
 

--- a/script/lib/create-rpm-package.js
+++ b/script/lib/create-rpm-package.js
@@ -60,7 +60,7 @@ module.exports = function (packagedAppPath) {
   const desktopEntryTemplate = fs.readFileSync(path.join(CONFIG.repositoryRootPath, 'resources', 'linux', 'atom.desktop.in'))
   const desktopEntryContents = template(desktopEntryTemplate)({
     appName: appName, appFileName: atomExecutableName, description: appDescription,
-    installDir: '/usr', iconName: atomExecutableName
+    installDir: '/usr', iconPath: atomExecutableName
   })
   fs.writeFileSync(path.join(rpmPackageBuildDirPath, `${atomExecutableName}.desktop`), desktopEntryContents)
 

--- a/script/lib/install-application.js
+++ b/script/lib/install-application.js
@@ -2,18 +2,91 @@
 
 const fs = require('fs-extra')
 const path = require('path')
+const runas = require('runas')
+const template = require('lodash.template')
+
+const CONFIG = require('../config')
 
 module.exports = function (packagedAppPath) {
+  const packagedAppFileName = path.basename(packagedAppPath)
   if (process.platform === 'darwin') {
-    const packagedAppPathFileName = path.basename(packagedAppPath)
-    const installationDirPath = path.join(path.sep, 'Applications', packagedAppPathFileName)
+    const installationDirPath = path.join(path.sep, 'Applications', packagedAppFileName)
     if (fs.existsSync(installationDirPath)) {
-      console.log(`Removing previously installed ${packagedAppPathFileName} at ${installationDirPath}`)
+      console.log(`Removing previously installed "${packagedAppFileName}" at "${installationDirPath}"`)
       fs.removeSync(installationDirPath)
     }
-    console.log(`Installing ${packagedAppPath} at ${installationDirPath}`)
+    console.log(`Installing "${packagedAppPath}" at "${installationDirPath}"`)
     fs.copySync(packagedAppPath, installationDirPath)
+  } else if (process.platform === 'win32') {
+    const installationDirPath = path.join(process.env.LOCALAPPDATA, packagedAppFileName, 'app-dev')
+    try {
+      if (fs.existsSync(installationDirPath)) {
+        console.log(`Removing previously installed "${packagedAppFileName}" at "${installationDirPath}"`)
+        fs.removeSync(installationDirPath)
+      }
+      console.log(`Installing "${packagedAppPath}" at "${installationDirPath}"`)
+      fs.copySync(packagedAppPath, installationDirPath)
+    } catch (e) {
+      console.log(`Administrator elevation required to install into "${installationDirPath}"`)
+      const copyScriptPath = path.join(CONFIG.repositoryRootPath, 'script', 'copy-folder.cmd')
+      const exitCode = runas('cmd', ['/c', copyScriptPath, packagedAppPath, installationDirPath], {admin: true})
+      if (exitCode !== 0) {
+        throw new Error(`Installation failed. "${copyScriptPath}" exited with status: ${exitCode}`)
+      }
+    }
   } else {
-    throw new Error("Not implemented yet.")
+    const atomExecutableName = CONFIG.channel === 'beta' ? 'atom-beta' : 'atom'
+    const apmExecutableName = CONFIG.channel === 'beta' ? 'apm-beta' : 'apm'
+    const appName = CONFIG.channel === 'beta' ? 'Atom Beta' : 'Atom'
+    const appDescription = CONFIG.appMetadata.description
+    const userLocalDirPath = path.join('/usr', 'local')
+    const shareDirPath = path.join(userLocalDirPath, 'share')
+    const installationDirPath = path.join(shareDirPath, atomExecutableName)
+    const applicationsDirPath = path.join(shareDirPath, 'applications')
+    const desktopEntryPath = path.join(applicationsDirPath, `${atomExecutableName}.desktop`)
+    const binDirPath = path.join(userLocalDirPath, 'bin')
+    const atomBinDestinationPath = path.join(binDirPath, atomExecutableName)
+    const apmBinDestinationPath = path.join(binDirPath, apmExecutableName)
+
+    fs.mkdirpSync(applicationsDirPath)
+    fs.mkdirpSync(binDirPath)
+
+    if (fs.existsSync(installationDirPath)) {
+      console.log(`Removing previously installed "${packagedAppFileName}" at "${installationDirPath}"`)
+      fs.removeSync(installationDirPath)
+    }
+    console.log(`Installing "${packagedAppFileName}" at "${installationDirPath}"`)
+    fs.copySync(packagedAppPath, installationDirPath)
+
+    if (fs.existsSync(desktopEntryPath)) {
+      console.log(`Removing existing desktop entry file at "${desktopEntryPath}"`)
+      fs.removeSync(desktopEntryPath)
+    }
+    console.log(`Writing desktop entry file at "${desktopEntryPath}"`)
+    const iconPath = path.join(CONFIG.repositoryRootPath, 'resources', 'app-icons', CONFIG.channel, 'png', '1024.png')
+    const desktopEntryTemplate = fs.readFileSync(path.join(CONFIG.repositoryRootPath, 'resources', 'linux', 'atom.desktop.in'))
+    const desktopEntryContents = template(desktopEntryTemplate)({
+      appName, appFileName: atomExecutableName, description: appDescription,
+      installDir: '/usr', iconPath
+    })
+    fs.writeFileSync(desktopEntryPath, desktopEntryContents)
+
+    if (fs.existsSync(atomBinDestinationPath)) {
+      console.log(`Removing existing executable at "${atomBinDestinationPath}"`)
+      fs.removeSync(atomBinDestinationPath)
+    }
+    console.log(`Copying atom.sh to "${atomBinDestinationPath}"`)
+    fs.copySync(path.join(CONFIG.repositoryRootPath, 'atom.sh'), atomBinDestinationPath)
+
+    try {
+      fs.lstatSync(apmBinDestinationPath)
+      console.log(`Removing existing executable at "${apmBinDestinationPath}"`)
+      fs.removeSync(apmBinDestinationPath)
+    } catch (e) { }
+    console.log(`Symlinking apm to "${apmBinDestinationPath}"`)
+    fs.symlinkSync(path.join('..', 'share', atomExecutableName, 'resources', 'app', 'apm', 'node_modules', '.bin', 'apm'), apmBinDestinationPath)
+
+    console.log(`Changing permissions to 755 for "${installationDirPath}"`)
+    fs.chmodSync(installationDirPath, '755')
   }
 }

--- a/script/lib/kill-running-atom-instances.js
+++ b/script/lib/kill-running-atom-instances.js
@@ -1,4 +1,4 @@
-const spawnSync = require('./spawn-sync')
+const childProcess = require('child_process')
 
 const CONFIG = require('../config.js')
 

--- a/script/package.json
+++ b/script/package.json
@@ -21,6 +21,7 @@
     "normalize-package-data": "2.3.5",
     "npm": "3.10.5",
     "pegjs": "0.9.0",
+    "runas": "3.1.1",
     "season": "5.3.0",
     "semver": "5.3.0",
     "standard": "6.0.0",


### PR DESCRIPTION
Fixes #12549.

This pull-request adds the ability to run `script/build --install` also on Linux (installing Atom in `/usr/local`) and on Windows (installing Atom in `C:\Users\<user name>\AppData\Local\`).

/cc: @nathansobo
