### PR TITLE
Use the correct Atom executable paths on the beta channel

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -55,8 +55,10 @@ fi
 if [ $OS == 'Mac' ]; then
   if [ -n "$BETA_VERSION" ]; then
     ATOM_APP_NAME="Atom Beta.app"
+    ATOM_EXECUTABLE_NAME="Atom Beta"
   else
     ATOM_APP_NAME="Atom.app"
+    ATOM_EXECUTABLE_NAME="Atom"
   fi
 
   if [ -z "${ATOM_PATH}" ]; then
@@ -78,7 +80,7 @@ if [ $OS == 'Mac' ]; then
   fi
 
   if [ $EXPECT_OUTPUT ]; then
-    "$ATOM_PATH/$ATOM_APP_NAME/Contents/MacOS/Atom" --executed-from="$(pwd)" --pid=$$ "$@"
+    "$ATOM_PATH/$ATOM_APP_NAME/Contents/MacOS/$ATOM_EXECUTABLE_NAME" --executed-from="$(pwd)" --pid=$$ "$@"
     exit $?
   else
     open -a "$ATOM_PATH/$ATOM_APP_NAME" -n --args --executed-from="$(pwd)" --pid=$$ --path-environment="$PATH" "$@"

--- a/src/buffered-node-process.coffee
+++ b/src/buffered-node-process.coffee
@@ -1,4 +1,5 @@
 BufferedProcess = require './buffered-process'
+electron = require 'electron'
 path = require 'path'
 
 # Extended: Like {BufferedProcess}, but accepts a Node script as the command
@@ -36,14 +37,6 @@ class BufferedNodeProcess extends BufferedProcess
   #   * `exit` The callback {Function} which receives a single argument
   #            containing the exit status (optional).
   constructor: ({command, args, options, stdout, stderr, exit}) ->
-    node =
-      if process.platform is 'darwin'
-        # Use a helper to prevent an icon from appearing on the Dock
-        path.resolve(process.resourcesPath, '..', 'Frameworks',
-                     'Atom Helper.app', 'Contents', 'MacOS', 'Atom Helper')
-      else
-        process.execPath
-
     options ?= {}
     options.env ?= Object.create(process.env)
     options.env['ELECTRON_RUN_AS_NODE'] = 1
@@ -53,4 +46,4 @@ class BufferedNodeProcess extends BufferedProcess
     args.unshift(command)
     args.unshift('--no-deprecation')
 
-    super({command: node, args, options, stdout, stderr, exit})
+    super({command: process.execPath, args, options, stdout, stderr, exit})


### PR DESCRIPTION
In #12410 we started using electron-packager which automatically renames Electron executables (e.g. `Electron Helper`, `Contents/MacOS/Electron`) to match the provided app name. This behavior differs from the previous Grunt-based scripts and caused breakage in places where we assumed these executables would always be named `Atom`.
