### PR TITLE
Simplify Environment Patching

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -15,7 +15,7 @@ else
   BETA_VERSION=
 fi
 
-export ATOM_SUPPRESS_ENV_PATCHING=true
+export ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT=true
 
 while getopts ":wtfvh-:" opt; do
   case "$opt" in

--- a/atom.sh
+++ b/atom.sh
@@ -15,6 +15,8 @@ else
   BETA_VERSION=
 fi
 
+export ATOM_SUPPRESS_ENV_PATCHING=true
+
 while getopts ":wtfvh-:" opt; do
   case "$opt" in
     -)

--- a/spec/update-process-env-spec.js
+++ b/spec/update-process-env-spec.js
@@ -96,16 +96,16 @@ describe('updateProcessEnv(launchEnv)', function () {
         ATOM_HOME: '/the/atom/home'
       }
 
-      updateProcessEnv({ATOM_SUPPRESS_ENV_PATCHING: 'true', PWD: '/the/dir'})
+      updateProcessEnv({ATOM_SUPPRESS_ENV_PATCHING: 'true', PWD: '/the/dir', NODE_ENV: 'the-node-env', NODE_PATH: '/the/node/path', ATOM_HOME: '/the/atom/home'})
       expect(process.env).toEqual({
-        PWD: '/the/dir',
         ATOM_SUPPRESS_ENV_PATCHING: 'true',
+        PWD: '/the/dir',
         NODE_ENV: 'the-node-env',
         NODE_PATH: '/the/node/path',
         ATOM_HOME: '/the/atom/home'
       })
 
-      updateProcessEnv({PWD: '/the/dir'})
+      updateProcessEnv({PWD: '/the/dir', NODE_ENV: 'the-node-env', NODE_PATH: '/the/node/path', ATOM_HOME: '/the/atom/home'})
       expect(process.env).toEqual({
         ATOM_SUPPRESS_ENV_PATCHING: 'true',
         PWD: '/the/dir',
@@ -113,6 +113,30 @@ describe('updateProcessEnv(launchEnv)', function () {
         NODE_PATH: '/the/node/path',
         ATOM_HOME: '/the/atom/home'
       })
+    })
+
+    it('allows an existing env variable to be updated', function () {
+      process.env = {
+        WILL_BE_UPDATED: 'old-value',
+        NODE_ENV: 'the-node-env',
+        NODE_PATH: '/the/node/path',
+        ATOM_HOME: '/the/atom/home'
+      }
+
+      updateProcessEnv(process.env)
+      expect(process.env).toEqual(process.env)
+
+      let updatedEnv = {
+        ATOM_SUPPRESS_ENV_PATCHING: 'true',
+        WILL_BE_UPDATED: 'new-value',
+        NODE_ENV: 'the-node-env',
+        NODE_PATH: '/the/node/path',
+        ATOM_HOME: '/the/atom/home',
+        PWD: '/the/dir'
+      }
+
+      updateProcessEnv(updatedEnv)
+      expect(process.env).toEqual(updatedEnv)
     })
   })
 
@@ -203,7 +227,7 @@ describe('updateProcessEnv(launchEnv)', function () {
         expect(shouldGetEnvFromShell({SHELL: '/usr/local/bin/fish'})).toBe(true)
       })
 
-      it('returns false when the shell should not be patched', function () {
+      it('returns false when the environment indicates that Atom was launched from a shell', function () {
         process.platform = 'darwin'
         expect(shouldGetEnvFromShell({ATOM_SUPPRESS_ENV_PATCHING: 'true', SHELL: '/bin/sh'})).toBe(false)
         process.platform = 'linux'

--- a/spec/update-process-env-spec.js
+++ b/spec/update-process-env-spec.js
@@ -32,9 +32,9 @@ describe('updateProcessEnv(launchEnv)', function () {
 
       const initialProcessEnv = process.env
 
-      updateProcessEnv({ATOM_SUPPRESS_ENV_PATCHING: 'true', PWD: '/the/dir', TERM: 'xterm-something', KEY1: 'value1', KEY2: 'value2'})
+      updateProcessEnv({ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true', PWD: '/the/dir', TERM: 'xterm-something', KEY1: 'value1', KEY2: 'value2'})
       expect(process.env).toEqual({
-        ATOM_SUPPRESS_ENV_PATCHING: 'true',
+        ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true',
         PWD: '/the/dir',
         TERM: 'xterm-something',
         KEY1: 'value1',
@@ -60,27 +60,27 @@ describe('updateProcessEnv(launchEnv)', function () {
         ATOM_HOME: '/the/atom/home'
       }
 
-      updateProcessEnv({ATOM_SUPPRESS_ENV_PATCHING: 'true', PWD: '/the/dir'})
+      updateProcessEnv({ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true', PWD: '/the/dir'})
       expect(process.env).toEqual({
         PWD: '/the/dir',
-        ATOM_SUPPRESS_ENV_PATCHING: 'true',
+        ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true',
         NODE_ENV: 'the-node-env',
         NODE_PATH: '/the/node/path',
         ATOM_HOME: '/the/atom/home'
       })
 
-      updateProcessEnv({ATOM_SUPPRESS_ENV_PATCHING: 'true', PWD: '/the/dir', ATOM_HOME: path.join(newAtomHomePath, 'non-existent')})
+      updateProcessEnv({ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true', PWD: '/the/dir', ATOM_HOME: path.join(newAtomHomePath, 'non-existent')})
       expect(process.env).toEqual({
-        ATOM_SUPPRESS_ENV_PATCHING: 'true',
+        ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true',
         PWD: '/the/dir',
         NODE_ENV: 'the-node-env',
         NODE_PATH: '/the/node/path',
         ATOM_HOME: '/the/atom/home'
       })
 
-      updateProcessEnv({ATOM_SUPPRESS_ENV_PATCHING: 'true', PWD: '/the/dir', ATOM_HOME: newAtomHomePath})
+      updateProcessEnv({ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true', PWD: '/the/dir', ATOM_HOME: newAtomHomePath})
       expect(process.env).toEqual({
-        ATOM_SUPPRESS_ENV_PATCHING: 'true',
+        ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true',
         PWD: '/the/dir',
         NODE_ENV: 'the-node-env',
         NODE_PATH: '/the/node/path',
@@ -88,7 +88,7 @@ describe('updateProcessEnv(launchEnv)', function () {
       })
     })
 
-    it('allows ATOM_SUPPRESS_ENV_PATCHING to be preserved if set', function () {
+    it('allows ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT to be preserved if set', function () {
       process.env = {
         WILL_BE_DELETED: 'hi',
         NODE_ENV: 'the-node-env',
@@ -96,9 +96,9 @@ describe('updateProcessEnv(launchEnv)', function () {
         ATOM_HOME: '/the/atom/home'
       }
 
-      updateProcessEnv({ATOM_SUPPRESS_ENV_PATCHING: 'true', PWD: '/the/dir', NODE_ENV: 'the-node-env', NODE_PATH: '/the/node/path', ATOM_HOME: '/the/atom/home'})
+      updateProcessEnv({ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true', PWD: '/the/dir', NODE_ENV: 'the-node-env', NODE_PATH: '/the/node/path', ATOM_HOME: '/the/atom/home'})
       expect(process.env).toEqual({
-        ATOM_SUPPRESS_ENV_PATCHING: 'true',
+        ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true',
         PWD: '/the/dir',
         NODE_ENV: 'the-node-env',
         NODE_PATH: '/the/node/path',
@@ -107,7 +107,7 @@ describe('updateProcessEnv(launchEnv)', function () {
 
       updateProcessEnv({PWD: '/the/dir', NODE_ENV: 'the-node-env', NODE_PATH: '/the/node/path', ATOM_HOME: '/the/atom/home'})
       expect(process.env).toEqual({
-        ATOM_SUPPRESS_ENV_PATCHING: 'true',
+        ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true',
         PWD: '/the/dir',
         NODE_ENV: 'the-node-env',
         NODE_PATH: '/the/node/path',
@@ -127,7 +127,7 @@ describe('updateProcessEnv(launchEnv)', function () {
       expect(process.env).toEqual(process.env)
 
       let updatedEnv = {
-        ATOM_SUPPRESS_ENV_PATCHING: 'true',
+        ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true',
         WILL_BE_UPDATED: 'new-value',
         NODE_ENV: 'the-node-env',
         NODE_PATH: '/the/node/path',
@@ -229,9 +229,9 @@ describe('updateProcessEnv(launchEnv)', function () {
 
       it('returns false when the environment indicates that Atom was launched from a shell', function () {
         process.platform = 'darwin'
-        expect(shouldGetEnvFromShell({ATOM_SUPPRESS_ENV_PATCHING: 'true', SHELL: '/bin/sh'})).toBe(false)
+        expect(shouldGetEnvFromShell({ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true', SHELL: '/bin/sh'})).toBe(false)
         process.platform = 'linux'
-        expect(shouldGetEnvFromShell({ATOM_SUPPRESS_ENV_PATCHING: 'true', SHELL: '/bin/sh'})).toBe(false)
+        expect(shouldGetEnvFromShell({ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true', SHELL: '/bin/sh'})).toBe(false)
       })
 
       it('returns false when the shell is undefined or empty', function () {

--- a/spec/update-process-env-spec.js
+++ b/spec/update-process-env-spec.js
@@ -51,7 +51,7 @@ describe('updateProcessEnv(launchEnv)', function () {
     })
 
     it('allows ATOM_HOME to be overwritten only if the new value is a valid path', function () {
-      newAtomHomePath = temp.mkdirSync('atom-home')
+      let newAtomHomePath = temp.mkdirSync('atom-home')
 
       process.env = {
         WILL_BE_DELETED: 'hi',
@@ -89,8 +89,6 @@ describe('updateProcessEnv(launchEnv)', function () {
     })
 
     it('allows ATOM_SUPPRESS_ENV_PATCHING to be preserved if set', function () {
-      newAtomHomePath = temp.mkdirSync('atom-home')
-
       process.env = {
         WILL_BE_DELETED: 'hi',
         NODE_ENV: 'the-node-env',
@@ -187,8 +185,22 @@ describe('updateProcessEnv(launchEnv)', function () {
       it('indicates when the environment should be fetched from the shell', function () {
         process.platform = 'darwin'
         expect(shouldGetEnvFromShell({SHELL: '/bin/sh'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/usr/local/bin/sh'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/bin/bash'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/usr/local/bin/bash'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/bin/zsh'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/usr/local/bin/zsh'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/bin/fish'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/usr/local/bin/fish'})).toBe(true)
         process.platform = 'linux'
         expect(shouldGetEnvFromShell({SHELL: '/bin/sh'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/usr/local/bin/sh'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/bin/bash'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/usr/local/bin/bash'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/bin/zsh'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/usr/local/bin/zsh'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/bin/fish'})).toBe(true)
+        expect(shouldGetEnvFromShell({SHELL: '/usr/local/bin/fish'})).toBe(true)
       })
 
       it('returns false when the shell should not be patched', function () {

--- a/src/update-process-env.js
+++ b/src/update-process-env.js
@@ -7,7 +7,7 @@ const ENVIRONMENT_VARIABLES_TO_PRESERVE = new Set([
   'NODE_ENV',
   'NODE_PATH',
   'ATOM_HOME',
-  'ATOM_SUPPRESS_ENV_PATCHING'
+  'ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT'
 ])
 
 const PLATFORMS_KNOWN_TO_WORK = new Set([
@@ -51,7 +51,7 @@ function shouldGetEnvFromShell (env) {
     return false
   }
 
-  if (env.ATOM_SUPPRESS_ENV_PATCHING || process.env.ATOM_SUPPRESS_ENV_PATCHING) {
+  if (env.ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT || process.env.ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT) {
     return false
   }
 

--- a/src/update-process-env.js
+++ b/src/update-process-env.js
@@ -31,12 +31,8 @@ function updateProcessEnv (launchEnv) {
     }
 
     for (let key in envToAssign) {
-      if (!ENVIRONMENT_VARIABLES_TO_PRESERVE.has(key)) {
+      if (!ENVIRONMENT_VARIABLES_TO_PRESERVE.has(key) || (!process.env[key] && envToAssign[key])) {
         process.env[key] = envToAssign[key]
-      } else {
-        if (!process.env[key] && envToAssign[key]) {
-          process.env[key] = envToAssign[key]
-        }
       }
     }
 


### PR DESCRIPTION
This PR simplifies the logic used to determine when to patch the environment for users of linux and macOS. Instead of using a whitelist of shells and trying to detect how Atom was launched with environment variable markers, we simply modify `atom.sh` to set a environment variable that is only set when launched from the shell. If this environment variable is not detected, the environment is patched with the environment from a new, interactive, login shell.
- [x] Stop whitelisting shells
- [x] Introduce `ATOM_SUPPRESS_ENV_PATCHING` environment variable, which is only set in `atom.sh`
- [x] Manually test on Ubuntu
- [x] Manually test on macOS

Fixes #11910
Fixes #12535
