### PR TITLE
⬆ language-c@0.53.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "welcome": "0.35.1",
     "whitespace": "0.33.0",
     "wrap-guide": "0.38.2",
-    "language-c": "0.52.1",
+    "language-c": "0.53.0",
     "language-clojure": "0.21.0",
     "language-coffee-script": "0.47.2",
     "language-csharp": "0.12.1",


### PR DESCRIPTION
Includes proper syntax highlighting for C++11 string literals.

Apologies if you guys prefer to batch the language bumps all at once - just wanted to make sure this didn't slip under the radar.

cc @50Wliu 
