### PR TITLE
Fix release channel detection on Travis

### DIFF
--- a/script/config.js
+++ b/script/config.js
@@ -30,21 +30,13 @@ module.exports = {
 }
 
 function getChannel () {
-  if (appMetadata.version.match(/dev/) || isBuildingPR()) {
+  if (appMetadata.version.match(/dev/)) {
     return 'dev'
   } else if (appMetadata.version.match(/beta/)) {
     return 'beta'
   } else {
     return 'stable'
   }
-}
-
-function isBuildingPR () {
-  return (
-    process.env.APPVEYOR_PULL_REQUEST_NUMBER ||
-    process.env.TRAVIS_PULL_REQUEST ||
-    process.env.CI_PULL_REQUEST
-  )
 }
 
 function getApmBinPath () {


### PR DESCRIPTION
Fixes #12571 

In the previous build scripts, we were considering all the builds triggered by a pull-request to be part of the dev channel. We adopted the same heuristic for the new build scripts, but didn't notice that Travis always sets the `TRAVIS_PULL_REQUEST` variable to "false" (which causes the `process.env.TRAVIS_PULL_REQUEST` expression to be evaluated as truthy).

In the past, this wasn't a problem because we were building artifacts via Janky, but after switching to Travis this makes it generate the wrong assets on stable and beta.

To fix this, it seems reasonable to remove the conditional that checks if we are building a pull-request: in the past this could have been problematic because assets could be uploaded inadvertently to S3 or GitHub, but this should be safe now that we rely on the release publisher to perform that task.

/cc: @nathansobo @joefitzgerald 
