### PR TITLE
Let atom-pane-resize-hanle inherit correct height (fix #7446)

### DIFF
--- a/static/panes.less
+++ b/static/panes.less
@@ -10,6 +10,7 @@ atom-pane-container {
   min-width: 0;
 
   atom-pane-axis {
+    position: relative;
     display: flex;
     flex: 1;
     min-width: 0;


### PR DESCRIPTION
This patch fixes `<atom-pane-resize-handle>`(`the handle`) overflow issue introduced in #7446 .

I was thinking of removing `/static/panes.less#L19` 's `z-index: 3`, but it just hide the handle, its height still overflows.

Then I noticed `the handle` uses `height: 100%` to gain height. The overflowed handle, between two `atom-pane-axis.horizontal.pane-row`, should have inherid it's direct parent, but actual it herited a further parent in higher hierachy `atom-pane-axis.horizontal.pane-column`. `atom-pane-axis` does't have a rule let its direct child uses `height: 100%` to gain expected height.

As a result, I set `position: relative` for `atom-pane-axis` to make atom-pane-resize-handle as it's direct child gain correct height.

screenshot with this patch:

![screenshot_20160901_214907](https://cloud.githubusercontent.com/assets/3102803/18170586/62a53916-7091-11e6-8eb5-d43345e5fd2b.png)
