### PR TITLE
Remove `height: 100%` from atom-text-editor elements

### DIFF
--- a/static/text-editor-light.less
+++ b/static/text-editor-light.less
@@ -5,7 +5,6 @@
 atom-text-editor {
   display: block;
   font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-  height: 100%;
 }
 
 atom-text-editor[mini] {


### PR DESCRIPTION
Originally, editors with autoHeight set to false had an inline style of 100%. We attempted to retain this behavior while allowing CSS to change the height by applying this styling via a global CSS rule instead: unfortunately, however, this applies to non autoHeight editors as well because due to our deprecated autoHeight detection routine, the height of these editors must be assigned on an internal element and therefore does not override the 100% styling from the stylesheet.
