### PR TITLE
Change Help->Documentation url from https to http (Fix #12583)

### DIFF
--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -200,7 +200,7 @@ class AtomApplication
       atomWindow ?= @focusedWindow()
       atomWindow?.browserWindow.inspectElement(x, y)
 
-    @on 'application:open-documentation', -> shell.openExternal('https://flight-manual.atom.io/')
+    @on 'application:open-documentation', -> shell.openExternal('http://flight-manual.atom.io/')
     @on 'application:open-discussions', -> shell.openExternal('https://discuss.atom.io')
     @on 'application:open-faq', -> shell.openExternal('https://atom.io/faq')
     @on 'application:open-terms-of-use', -> shell.openExternal('https://atom.io/terms')


### PR DESCRIPTION
The flight manual page does not have a secure connection, so navigating to the https link in Help->Documentation would result in an error with its security certificate.

Link changed to http but adding https support might be a better idea.
