### PR TITLE
Compile native modules on Travis using clang-3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 git:
   depth: 10
 
-compiler: clang
-
 matrix:
   include:
     - os: linux
-      env: NODE_VERSION=4.4.7 CXX=g++-5
+      env: NODE_VERSION=4.4.7 CC=clang CXX=clang++ npm_config_clang=1
 
 sudo: false
 
@@ -41,14 +39,10 @@ addons:
       - out/atom-amd64.tar.gz
     target_paths: travis-artifacts/$TRAVIS_BUILD_ID
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
     packages:
     - build-essential
+    - clang-3.3
     - fakeroot
-    - gcc-multilib
-    - gcc-5
-    - g++-5
     - git
     - libgnome-keyring-dev
     - rpm


### PR DESCRIPTION
Fixes #12587.

All the native modules we ship with Atom are compiled by dynamically linking the libstdc++ library. Using gcc (and g++) > 4.6 to compile them, however, requires a newer version of that library, which is not installed by default on Ubuntu Precise (Travis' default image) and thus causes all the third-party packages built via Travis to fail when using Atom 1.11-beta.

By using clang-3.3 we can keep backwards compatibility with previous versions of libstdc++ and still be able to compile C++11 code (which is mandatory for Node >= 4).
