### PR TITLE
Fix height when splitting panes

### DIFF
--- a/static/panes.less
+++ b/static/panes.less
@@ -8,12 +8,14 @@ atom-pane-container {
   display: flex;
   flex: 1;
   min-width: 0;
+  min-height: 0;
 
   atom-pane-axis {
     position: relative;
     display: flex;
     flex: 1;
     min-width: 0;
+    min-height: 0;
 
     & > atom-pane-resize-handle {
       position: absolute;
@@ -52,12 +54,13 @@ atom-pane-container {
     flex-direction: column;
     overflow: visible;
     min-width: 0;
+    min-height: 0;
 
     .item-views {
       flex: 1;
       display: flex;
-      min-height: 0;
       min-width: 0;
+      min-height: 0;
       position: relative;
 
       .pane-item {

--- a/static/text-editor-light.less
+++ b/static/text-editor-light.less
@@ -98,6 +98,7 @@ atom-text-editor {
     overflow: hidden;
     flex: 1;
     min-width: 0;
+    min-height: 0;
   }
 
   .highlight {

--- a/static/text-editor-shadow.less
+++ b/static/text-editor-shadow.less
@@ -81,6 +81,7 @@
   overflow: hidden;
   flex: 1;
   min-width: 0;
+  min-height: 0;
 }
 
 .highlight {

--- a/static/workspace-view.less
+++ b/static/workspace-view.less
@@ -18,6 +18,7 @@ atom-workspace {
     display: flex;
     flex: 1;
     min-width: 0;
+    min-height: 0;
   }
 
   atom-workspace-axis.vertical {
@@ -25,5 +26,6 @@ atom-workspace {
     flex: 1;
     flex-direction: column;
     min-width: 0;
+    min-height: 0;
   }
 }


### PR DESCRIPTION
When splitting a pane **down**, the height isn't evenly split in half, just after resizing the tree-view. Or when some other style is changed in DevTools.. maybe if the change triggers a reflow?

![split](https://cloud.githubusercontent.com/assets/378023/18302313/2d086ea6-7512-11e6-9ded-24679c9cde6a.gif)

> Using `1.11.0-dev-eff5fa6` on macOS.

Adding `min-height: 0;` seems to work. This is probably related to #11866. Or some rendering bug. This PR adds `min-height: 0;` everywhere we already added `min-width: 0;`.
