### PR TITLE
Wait for windows' state to be saved before closing the app or any window

### DIFF
--- a/spec/atom-environment-spec.coffee
+++ b/spec/atom-environment-spec.coffee
@@ -228,7 +228,7 @@ describe "AtomEnvironment", ->
       expect(atom.saveState).toHaveBeenCalledWith({isUnloading: false})
       expect(atom.saveState).not.toHaveBeenCalledWith({isUnloading: true})
 
-    it "saves state immediately when unloading the editor window, ignoring pending and successive mousedown/keydown events", ->
+    it "ignores mousedown/keydown events happening after calling unloadEditorWindow", ->
       spyOn(atom, 'saveState')
       idleCallbacks = []
       spyOn(window, 'requestIdleCallback').andCallFake (callback) -> idleCallbacks.push(callback)
@@ -236,15 +236,12 @@ describe "AtomEnvironment", ->
       mousedown = new MouseEvent('mousedown')
       atom.document.dispatchEvent(mousedown)
       atom.unloadEditorWindow()
-      expect(atom.saveState).toHaveBeenCalledWith({isUnloading: true})
-      expect(atom.saveState).not.toHaveBeenCalledWith({isUnloading: false})
+      expect(atom.saveState).not.toHaveBeenCalled()
 
-      atom.saveState.reset()
       advanceClock atom.saveStateDebounceInterval
       idleCallbacks.shift()()
       expect(atom.saveState).not.toHaveBeenCalled()
 
-      atom.saveState.reset()
       mousedown = new MouseEvent('mousedown')
       atom.document.dispatchEvent(mousedown)
       advanceClock atom.saveStateDebounceInterval

--- a/spec/integration/helpers/start-atom.coffee
+++ b/spec/integration/helpers/start-atom.coffee
@@ -125,11 +125,6 @@ buildAtomClient = (args, env) ->
       @execute "atom.commands.dispatch(document.activeElement, '#{command}')"
       .call(done)
 
-    .addCommand "simulateQuit", (done) ->
-      @execute -> atom.unloadEditorWindow()
-      .execute -> require("electron").remote.app.emit("before-quit")
-      .call(done)
-
 module.exports = (args, env, fn) ->
   [chromedriver, chromedriverLogs, chromedriverExit] = []
 
@@ -154,9 +149,7 @@ module.exports = (args, env, fn) ->
 
   waitsFor("tests to run", (done) ->
     finish = once ->
-      client
-        .simulateQuit()
-        .end()
+      client.end()
         .then(-> chromedriver.kill())
         .then(chromedriverExit.then(
           (errorCode) ->

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -244,7 +244,7 @@ class ApplicationDelegate
     new Disposable ->
       ipcRenderer.removeListener('context-command', outerCallback)
 
-  onSaveWindowState: (callback) ->
+  onSaveWindowStateRequest: (callback) ->
     outerCallback = (event, message) ->
       callback(event)
 

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -244,6 +244,17 @@ class ApplicationDelegate
     new Disposable ->
       ipcRenderer.removeListener('context-command', outerCallback)
 
+  onSaveWindowState: (callback) ->
+    outerCallback = (event, message) ->
+      callback(event)
+
+    ipcRenderer.on('save-window-state', outerCallback)
+    new Disposable ->
+      ipcRenderer.removeListener('save-window-state', outerCallback)
+
+  didSaveWindowState: ->
+    ipcRenderer.send('did-save-window-state')
+
   didCancelWindowUnload: ->
     ipcRenderer.send('did-cancel-window-unload')
 

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -674,7 +674,7 @@ class AtomEnvironment extends Model
         @disposables.add(@applicationDelegate.onDidOpenLocations(@openLocations.bind(this)))
         @disposables.add(@applicationDelegate.onApplicationMenuCommand(@dispatchApplicationMenuCommand.bind(this)))
         @disposables.add(@applicationDelegate.onContextMenuCommand(@dispatchContextMenuCommand.bind(this)))
-        @disposables.add @applicationDelegate.onSaveWindowState =>
+        @disposables.add @applicationDelegate.onSaveWindowStateRequest =>
           callback = => @applicationDelegate.didSaveWindowState()
           @saveState({isUnloading: true}).catch(callback).then(callback)
 

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -178,13 +178,14 @@ class AtomWindow
     @unloading = false
 
   saveState: ->
-    new Promise (resolve) =>
+    @lastSaveStatePromise = new Promise (resolve) =>
       callback = (event) =>
         if BrowserWindow.fromWebContents(event.sender) is @browserWindow
           ipcMain.removeListener('did-save-window-state', callback)
           resolve()
       ipcMain.on('did-save-window-state', callback)
       @browserWindow.webContents.send('save-window-state')
+    @lastSaveStatePromise
 
   openPath: (pathToOpen, initialLine, initialColumn) ->
     @openLocations([{pathToOpen, initialLine, initialColumn}])


### PR DESCRIPTION
This fixes a test failure on #12300 where the new Electron version prevents state from being serialized.

Previously, we used to save the window's state in the renderer process `beforeunload` event handler: because of the synchronous nature of event handlers and the asynchronous design of IndexedDB, this could potentially not save anything if windows close fast enough to prevent IndexedDB from committing the pending transaction containing the state. (Ref.: https://mzl.la/2bXCXDn)

With this commit, we will intercept the `before-quit` events on `electron.app` and the `close` event on `BrowserWindow` (which will fire respectively before quitting the application and before closing a
window), and prevent them from performing the default action. We will then ask each renderer process to save its state and, finally, close the window and/or the app when the IndexedDB transaction completes.

/cc: @atom/core @thomasjo 
