### PR TITLE
Fix app not quitting on win32 and linux when closing the last window

### DIFF
--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -122,12 +122,12 @@ class AtomApplication
 
   # Public: Removes the {AtomWindow} from the global window list.
   removeWindow: (window) ->
-    if @windows.length is 1
+    @windows.splice(@windows.indexOf(window), 1)
+    if @windows.length is 0
       @applicationMenu?.enableWindowSpecificItems(false)
       if process.platform in ['win32', 'linux']
         app.quit()
         return
-    @windows.splice(@windows.indexOf(window), 1)
     @saveState(true) unless window.isSpec
 
   # Public: Adds the {AtomWindow} to the global window list.


### PR DESCRIPTION
This regression was caused by a nuance in the way we maintain state in `AtomApplication` for open windows. Specifically, when closing the last window on Windows and Linux, we were explicitly calling `app.quit` _before_ removing such window from the list of open ones. In turn, this caused the new `before-quit` behavior introduced in #12619 to work improperly because it made the application wait on saving the state of a stale window before exiting.

With this pull-request we are fixing that by making sure the stale window is removed before calling `app.quit` in `removeWindow`.

/cc: @atom/core @damieng 
