### PR TITLE
Run main process tests on CircleCI, Travis and AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ git:
 matrix:
   include:
     - os: linux
-      env: NODE_VERSION=4.4.7 CC=clang CXX=clang++ npm_config_clang=1
+      env: NODE_VERSION=4.4.7 DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1
 
 sudo: false
+
+before_install:
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 
 install:
   - git clone https://github.com/creationix/nvm.git /tmp/.nvm
@@ -16,7 +19,7 @@ install:
   - npm install -g npm
   - script/build --create-debian-package --create-rpm-package --compress-artifacts
 
-script: true
+script: script/test
 
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,9 @@ build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
   - script\build.cmd --code-sign --create-windows-installer --compress-artifacts
 
-test: off
+test_script:
+  - script\test.cmd
+
 deploy: off
 artifacts:
   - path: out\AtomSetup.exe

--- a/script/test
+++ b/script/test
@@ -22,6 +22,12 @@ if (process.platform === 'darwin') {
   const executablePaths = glob.sync(path.join(CONFIG.buildOutputPath, '**', 'atom'))
   assert(executablePaths.length === 1, `More than one application to run tests against was found. ${executablePaths.join(',')}`)
   executablePath = executablePaths[0]
+} else if (process.platform === 'win32') {
+  const executablePaths = glob.sync(path.join(CONFIG.buildOutputPath, '**', 'atom.exe'))
+  assert(executablePaths.length === 1, `More than one application to run tests against was found. ${executablePaths.join(',')}`)
+  executablePath = executablePaths[0]
+} else {
+  throw new Error('Running tests on this platform is not supported.')
 }
 
 function runCoreMainProcessTests (callback) {

--- a/script/test
+++ b/script/test
@@ -3,17 +3,26 @@
 'use strict'
 
 require('colors')
+const assert = require('assert')
 const async = require('async')
 const childProcess = require('child_process')
 const fs = require('fs')
+const glob = require('glob')
 const path = require('path')
 
 const CONFIG = require('./config')
 
-const appName = CONFIG.channel === 'beta' ? 'Atom Beta' : 'Atom'
-const packagedAppPath = path.resolve(__dirname, '..', 'out', `${appName}.app`)
-const executablePath = path.join(packagedAppPath, 'Contents', 'MacOS', appName)
 const resourcePath = CONFIG.repositoryRootPath
+let executablePath
+if (process.platform === 'darwin') {
+  const executablePaths = glob.sync(path.join(CONFIG.buildOutputPath, '*.app'))
+  assert(executablePaths.length === 1, `More than one application to run tests against was found. ${executablePaths.join(',')}`)
+  executablePath = path.join(executablePaths[0], 'Contents', 'MacOS', path.basename(executablePaths[0], '.app'))
+} else if (process.platform === 'linux') {
+  const executablePaths = glob.sync(path.join(CONFIG.buildOutputPath, '**', 'atom'))
+  assert(executablePaths.length === 1, `More than one application to run tests against was found. ${executablePaths.join(',')}`)
+  executablePath = executablePaths[0]
+}
 
 function runCoreMainProcessTests (callback) {
   const testPath = path.join(CONFIG.repositoryRootPath, 'spec', 'main-process')
@@ -68,7 +77,12 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
   })
 }
 
-const testSuitesToRun = [runCoreMainProcessTests, runCoreRenderProcessTests].concat(packageTestSuites)
+let testSuitesToRun
+if (process.platform === 'darwin') {
+  testSuitesToRun = [runCoreMainProcessTests, runCoreRenderProcessTests].concat(packageTestSuites)
+} else {
+  testSuitesToRun = [runCoreMainProcessTests]
+}
 
 async.series(testSuitesToRun, function (err, exitCodes) {
   if (err) {

--- a/script/test.cmd
+++ b/script/test.cmd
@@ -1,0 +1,5 @@
+@IF EXIST "%~dp0\node.exe" (
+  "%~dp0\node.exe"  "%~dp0\test" %*
+) ELSE (
+  node  "%~dp0\test" %*
+)

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -14,7 +14,7 @@ const ATOM_RESOURCE_PATH = path.resolve(__dirname, '..', '..')
 describe('AtomApplication', function () {
   this.timeout(60 * 1000)
 
-  let originalPlatform, originalAppQuit, originalAtomHome, atomApplicationsToDestroy
+  let originalAppQuit, originalAtomHome, atomApplicationsToDestroy
 
   beforeEach(function () {
     originalAppQuit = electron.app.quit
@@ -371,41 +371,25 @@ describe('AtomApplication', function () {
     })
 
     describe('when closing the last window', function () {
-      describe('on win32', function () {
+      if (process.platform === 'linux' || process.platform === 'win32') {
         it('quits the application', async function () {
           const atomApplication = buildAtomApplication()
-          Object.defineProperty(process, 'platform', {get: () => 'win32'})
           const window = atomApplication.launch(parseCommandLine([path.join(makeTempDir("a"), 'file-a')]))
           await focusWindow(window)
           window.close()
           await window.closedPromise
           assert(electron.app.hasQuitted())
         })
-      })
-
-      describe('on linux', function () {
-        it('quits the application', async function () {
-          const atomApplication = buildAtomApplication()
-          Object.defineProperty(process, 'platform', {get: () => 'linux'})
-          const window = atomApplication.launch(parseCommandLine([path.join(makeTempDir("a"), 'file-a')]))
-          await focusWindow(window)
-          window.close()
-          await window.closedPromise
-          assert(electron.app.hasQuitted())
-        })
-      })
-
-      describe('on darwin', function () {
+      } else if (process.platform === 'darwin') {
         it('leaves the application open', async function () {
           const atomApplication = buildAtomApplication()
-          Object.defineProperty(process, 'platform', {get: () => 'darwin'})
           const window = atomApplication.launch(parseCommandLine([path.join(makeTempDir("a"), 'file-a')]))
           await focusWindow(window)
           window.close()
           await window.closedPromise
           assert(!electron.app.hasQuitted())
         })
-      })
+      }
     })
   })
 

--- a/spec/main-process/file-recovery-service.test.js
+++ b/spec/main-process/file-recovery-service.test.js
@@ -5,6 +5,7 @@ import FileRecoveryService from '../../src/main-process/file-recovery-service'
 import temp from 'temp'
 import fs from 'fs-plus'
 import sinon from 'sinon'
+import {escapeRegExp} from 'underscore-plus'
 
 describe("FileRecoveryService", () => {
   let recoveryService, recoveryDirectory
@@ -110,8 +111,8 @@ describe("FileRecoveryService", () => {
       let recoveryFiles = fs.listTreeSync(recoveryDirectory)
       assert.equal(recoveryFiles.length, 1)
       assert.equal(logs.length, 1)
-      assert.match(logs[0], new RegExp(filePath))
-      assert.match(logs[0], new RegExp(recoveryFiles[0]))
+      assert.match(logs[0], new RegExp(escapeRegExp(filePath)))
+      assert.match(logs[0], new RegExp(escapeRegExp(recoveryFiles[0])))
     }))
   })
 


### PR DESCRIPTION
Previously we used to run tests only on CircleCI which, despite providing a pretty extensive coverage for macOS, is insufficient to understand whether something has regressed on other platforms. The ideal solution to this problem would be to run tests on every operating system: our renderer test suite, however, is particularly flaky on Linux and Windows as, with time, it has evolved without multi-platform compatibility in mind.

This pull-request is a first step towards such solution: instead of using Travis and AppVeyor as build-only providers, we will now run main process tests on them. These kind of tests are more coarse-grained than the renderer process ones, but they provide quick feedback and should act as good smoke tests for when we release new versions. We could have used `chromedriver` as well, but it seems like it's quite flaky on both Windows and Linux, so I have put that on hold for the time being (in a later pull-request, it might be interesting to change our current `smoke-spec` to use [electron/spectron](https://github.com/electron/spectron) instead and see if that changes anything).

/cc: @atom/core 
