### PR TITLE
Fix source maps for typescript and babel on Windows

### DIFF
--- a/src/babel.js
+++ b/src/babel.js
@@ -49,6 +49,10 @@ exports.compile = function (sourceCode, filePath) {
     Logger.prototype.verbose = noop
   }
 
+  if (process.platform === 'win32') {
+    filePath = 'file:///' + path.resolve(filePath).replace(/\\/g, '/')
+  }
+
   var options = {filename: filePath}
   for (var key in defaultOptions) {
     options[key] = defaultOptions[key]

--- a/src/main-process/main.js
+++ b/src/main-process/main.js
@@ -64,10 +64,6 @@ function start () {
     app.removeListener('open-url', addUrlToOpen)
     const AtomApplication = require(path.join(args.resourcePath, 'src', 'main-process', 'atom-application'))
     AtomApplication.open(args)
-
-    if (!args.test) {
-      console.log(`App load time: ${Date.now() - global.shellStartTime}ms`)
-    }
   })
 }
 

--- a/src/typescript.js
+++ b/src/typescript.js
@@ -37,6 +37,10 @@ exports.compile = function (sourceCode, filePath) {
     TypeScriptSimple = require('typescript-simple').TypeScriptSimple
   }
 
+  if (process.platform === 'win32') {
+    filePath = 'file:///' + path.resolve(filePath).replace(/\\/g, '/')
+  }
+
   var options = _.defaults({filename: filePath}, defaultOptions)
   return new TypeScriptSimple(options, false).compile(sourceCode, filePath)
 }


### PR DESCRIPTION
The source maps for babel and typescript never worked correctly on windows as the path was treated by the Chromium debugger as relative because it was not prefixed with file:///.  This led to a weird issue where the source map was thought to be in a different folder to the generated JS.

This corrects it using the same approach we use for Coffeescript and also removes the 'App load time' which is the last thing spewing onto the command line at start-up now Electron has been upgraded.
