### PR TITLE
Remove window load time console output

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -49,7 +49,6 @@
   function setLoadTime (loadTime) {
     if (global.atom) {
       global.atom.loadTime = loadTime
-      console.log('Window load time: ' + global.atom.getWindowLoadTime() + 'ms')
     }
   }
 


### PR DESCRIPTION
The _"Window load time: ..."_ console message doesn't really provide any tangible benefit, and is generally just annoying as 💩 when running specs.

Additionally, I believe on Windows this is printed in the terminal when Atom is launched via `atom.cmd`.

/cc @atom/feedback @nathansobo @damieng 
