### PR TITLE
Don't wait for spec windows to save state

### DIFF
--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -178,6 +178,9 @@ class AtomWindow
     @unloading = false
 
   saveState: ->
+    if @isSpecWindow()
+      return Promise.resolve()
+
     @lastSaveStatePromise = new Promise (resolve) =>
       callback = (event) =>
         if BrowserWindow.fromWebContents(event.sender) is @browserWindow


### PR DESCRIPTION
Since spec windows don't register handlers for the IPC messages requested window state to be saved, the promise never resolves and the close button needs to be clicked twice. To avoid this, we'll just resolve the promise immediately in a spec window so we can proceed to close it.

Closes #12664
