### PR TITLE
Don't include destroyed panes in result of PaneContainer.getPanes() after PaneContainer is destroyed

### DIFF
--- a/spec/pane-container-spec.coffee
+++ b/spec/pane-container-spec.coffee
@@ -255,7 +255,9 @@ describe "PaneContainer", ->
     it "invokes the given callback when panes are destroyed", ->
       container = new PaneContainer(params)
       events = []
-      container.onDidDestroyPane (event) -> events.push(event)
+      container.onDidDestroyPane (event) ->
+        expect(event.pane in container.getPanes()).toBe false
+        events.push(event)
 
       pane1 = container.getActivePane()
       pane2 = pane1.splitRight()
@@ -265,6 +267,21 @@ describe "PaneContainer", ->
       pane3.destroy()
 
       expect(events).toEqual [{pane: pane2}, {pane: pane3}]
+
+    it "invokes the given callback when the container is destroyed", ->
+      container = new PaneContainer(params)
+      events = []
+      container.onDidDestroyPane (event) ->
+        expect(event.pane in container.getPanes()).toBe false
+        events.push(event)
+
+      pane1 = container.getActivePane()
+      pane2 = pane1.splitRight()
+      pane3 = pane2.splitDown()
+
+      container.destroy()
+
+      expect(events).toEqual [{pane: pane1}, {pane: pane2}, {pane: pane3}]
 
   describe "::onWillDestroyPaneItem() and ::onDidDestroyPaneItem", ->
     it "invokes the given callbacks when an item will be destroyed on any pane", ->

--- a/src/pane-container.coffee
+++ b/src/pane-container.coffee
@@ -102,7 +102,10 @@ class PaneContainer extends Model
     @setRoot(newChild)
 
   getPanes: ->
-    @getRoot().getPanes()
+    if @alive
+      @getRoot().getPanes()
+    else
+      []
 
   getPaneItems: ->
     @getRoot().getItems()
@@ -195,7 +198,7 @@ class PaneContainer extends Model
   # Called by Model superclass when destroyed
   destroyed: ->
     @cancelStoppedChangingActivePaneItemTimeout()
-    pane.destroy() for pane in @getPanes()
+    pane.destroy() for pane in @getRoot().getPanes()
     @subscriptions.dispose()
     @emitter.dispose()
 


### PR DESCRIPTION
This is a failing test to illustrate a bug in `getPanes()`. I'm not sure what the right fix for this is 😞

Here's the problem as I understand it now: when you call `PaneContainer::destroy()`, it destroys all of its Panes. Each Pane will notify its PaneAxis, which will then remove the Pane from its list of children. This all works as long as the container's root is a PaneAxis, however, when you go from 2 to 1 Panes, the PaneAxis will reparent the last Pane making it the container's root. From that point on, `PaneContainer::getPanes()` will delegate to [the (destroyed) Pane](https://github.com/atom/atom/blob/v1.11.0-beta5/src/pane.coffee), which returns a list that includes itself.

My gut says that the right way to address this is to never have a Pane be the root (e.g. always contain it in a PaneAxis) but I don't really know.
