### PR TITLE
Upgrade Electron to v1.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "1.3.5",
+  "electronVersion": "1.3.6",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "6.3.2",


### PR DESCRIPTION
This might need some manual testing. Judging by the [changelog](https://github.com/electron/electron/releases/tag/v1.3.6) I don't expect this to cause any issues, but it doesn't hurt to be extra careful.

/cc @atom/feedback 
