### PR TITLE
Improve support for international keyboards

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "electronVersion": "1.3.5",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "6.3.3-beta1",
+    "atom-keymap": "6.3.3",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",
     "cached-run-in-this-context": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "electronVersion": "1.3.5",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "6.3.2",
+    "atom-keymap": "6.3.3-beta1",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",
     "cached-run-in-this-context": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "electronVersion": "1.3.5",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "6.3.3",
+    "atom-keymap": "6.3.4",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",
     "cached-run-in-this-context": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "electronVersion": "1.3.5",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "6.3.4",
+    "atom-keymap": "6.3.5",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",
     "cached-run-in-this-context": "0.4.1",

--- a/spec/menu-manager-spec.coffee
+++ b/spec/menu-manager-spec.coffee
@@ -53,6 +53,9 @@ describe "MenuManager", ->
       expect(menu.template[originalItemCount]).toEqual {label: "A", submenu: [{label: "B", command: "b"}]}
 
   describe "::update()", ->
+    originalPlatform = process.platform
+    afterEach -> Object.defineProperty process, 'platform', value: originalPlatform
+
     it "sends the current menu template and associated key bindings to the browser process", ->
       spyOn(menu, 'sendToBrowserProcess')
       menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
@@ -74,6 +77,47 @@ describe "MenuManager", ->
       waits 50
 
       runs -> expect(menu.sendToBrowserProcess.argsForCall[0][1]['b']).toBeUndefined()
+
+    it "omits key bindings that could conflict with AltGraph characters on macOS", ->
+      spyOn(menu, 'sendToBrowserProcess')
+      menu.add [{label: "A", submenu: [
+        {label: "B", command: "b"},
+        {label: "C", command: "c"}
+        {label: "D", command: "d"}
+      ]}]
+
+      atom.keymaps.add 'test', 'atom-workspace':
+        'alt-b': 'b'
+        'alt-shift-C': 'c'
+        'alt-cmd-d': 'd'
+
+      waits 50
+
+      runs ->
+        expect(menu.sendToBrowserProcess.argsForCall[0][1]['b']).toBeUndefined()
+        expect(menu.sendToBrowserProcess.argsForCall[0][1]['c']).toBeUndefined()
+        expect(menu.sendToBrowserProcess.argsForCall[0][1]['d']).toEqual(['alt-cmd-d'])
+
+    it "omits key bindings that could conflict with AltGraph characters on Windows", ->
+      Object.defineProperty process, 'platform', value: 'win32'
+      spyOn(menu, 'sendToBrowserProcess')
+      menu.add [{label: "A", submenu: [
+        {label: "B", command: "b"},
+        {label: "C", command: "c"}
+        {label: "D", command: "d"}
+      ]}]
+
+      atom.keymaps.add 'test', 'atom-workspace':
+        'ctrl-alt-b': 'b'
+        'ctrl-alt-shift-C': 'c'
+        'ctrl-alt-cmd-d': 'd'
+
+      waits 50
+
+      runs ->
+        expect(menu.sendToBrowserProcess.argsForCall[0][1]['b']).toBeUndefined()
+        expect(menu.sendToBrowserProcess.argsForCall[0][1]['c']).toBeUndefined()
+        expect(menu.sendToBrowserProcess.argsForCall[0][1]['d']).toEqual(['ctrl-alt-cmd-d'])
 
   it "updates the application menu when a keymap is reloaded", ->
     spyOn(menu, 'update')

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -144,16 +144,15 @@ class MenuManager
   update: ->
     clearImmediate(@pendingUpdateOperation) if @pendingUpdateOperation?
     @pendingUpdateOperation = setImmediate =>
-      includedBindings = []
-      unsetKeystrokes = new Set
-
-      for binding in @keymapManager.getKeyBindings() when @includeSelector(binding.selector)
-        includedBindings.push(binding)
-        if binding.command is 'unset!'
-          unsetKeystrokes.add(binding.keystrokes)
+      includedBindings = @keymapManager.getKeyBindings().filter (binding) =>
+        return false unless @includeSelector(binding.selector)
+        return false if binding.command is 'unset!'
+        return false if process.platform is 'darwin' and /^alt-(shift-)?.$/.test(binding.keystrokes)
+        return false if process.platform is 'win32' and /^ctrl-alt-(shift-)?.$/.test(binding.keystrokes)
+        true
 
       keystrokesByCommand = {}
-      for binding in includedBindings when not unsetKeystrokes.has(binding.keystrokes)
+      for binding in includedBindings
         keystrokesByCommand[binding.command] ?= []
         keystrokesByCommand[binding.command].unshift binding.keystrokes
 


### PR DESCRIPTION
Closes https://github.com/atom/atom-keymap/issues/35
Closes https://github.com/atom/atom-keymap/issues/34

This PR includes a new version of `atom-keymap` with changes described in https://github.com/atom/atom-keymap/pull/144.

The basic idea is that we will never shadow the ability to type an ASCII character with any key binding. Most of this logic is handled in `atom-keymap` and is describe in the above PR.

In addition to the keymap changes, we are forced to omit keyboard shortcuts for application menu items if there's a possibility they could interfere with typing `AltGraph`-modified characters on international layouts. This means that `alt-` bindings on Mac and `ctrl-alt-` bindings on Windows won't show up in the menu, but the bindings will still work so long as they don't conflict.

I'd appreciate it if international users could give this a try by downloading binaries from the build provider for their platform. You can find links to builds of this PR in the build status section at the bottom of this page, then navigate to the "artifacts" section:
- For Windows, go to AppVeyor artifiacts
- For Mac, go to Circle artifacts
- For Linux, go to Travis, where you can find the S3 download URLs in the build log
