### PR TITLE
Use inline source maps when transpiling coffee-script

### DIFF
--- a/spec/compile-cache-spec.coffee
+++ b/spec/compile-cache-spec.coffee
@@ -17,7 +17,7 @@ describe 'CompileCache', ->
     CompileCache.resetCacheStats()
 
     spyOn(Babel, 'transform').andReturn {code: 'the-babel-code'}
-    spyOn(CoffeeScript, 'compile').andReturn {js: 'the-coffee-code', v3SourceMap: "{}"}
+    spyOn(CoffeeScript, 'compile').andReturn 'the-coffee-code'
     spyOn(TypeScriptSimple::, 'compile').andReturn 'the-typescript-code'
 
   afterEach ->

--- a/src/coffee-script.js
+++ b/src/coffee-script.js
@@ -36,13 +36,10 @@ exports.compile = function (sourceCode, filePath) {
   var output = CoffeeScript.compile(sourceCode, {
     filename: filePath,
     sourceFiles: [filePath],
-    sourceMap: true
+    inlineMap: true
   })
 
-  var js = output.js
-  js += '\n'
-  js += '//# sourceMappingURL=data:application/json;base64,'
-  js += new Buffer(output.v3SourceMap).toString('base64')
-  js += '\n'
-  return js
+  // Strip sourceURL from output so there wouldn't be duplicate entries
+  // in devtools.
+  return output.replace(/\/\/# sourceURL=[^'"\n]+\s*$/, '')
 }

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -74,7 +74,7 @@ function compileFileAtPath (compiler, filePath, extension) {
       cacheStats[extension].hits++
     } else {
       cacheStats[extension].misses++
-      compiledCode = addSourceURL(compiler.compile(sourceCode, filePath), filePath)
+      compiledCode = compiler.compile(sourceCode, filePath)
       writeCachedJavascript(cachePath, compiledCode)
     }
     return compiledCode
@@ -95,13 +95,6 @@ function readCachedJavascript (relativeCachePath) {
 function writeCachedJavascript (relativeCachePath, code) {
   var cachePath = path.join(cacheDirectory, relativeCachePath)
   fs.writeFileSync(cachePath, code, 'utf8')
-}
-
-function addSourceURL (jsCode, filePath) {
-  if (process.platform === 'win32') {
-    filePath = '/' + path.resolve(filePath).replace(/\\/g, '/')
-  }
-  return jsCode + '\n' + '//# sourceURL=' + encodeURI(filePath) + '\n'
 }
 
 var INLINE_SOURCE_MAP_REGEXP = /\/\/[#@]\s*sourceMappingURL=([^'"\n]+)\s*$/mg


### PR DESCRIPTION
Since sourcemaps still refer to `.coffee` files after build, we shouldn't be deleting those from final output directory. Debugging from devtools with latest builds is practically impossible without them.

cc @as-cii 

EDIT -

The approach has changed a bit since the PR was opened. See [the comment below](https://github.com/atom/atom/pull/12713#issuecomment-249570094).
