### PR TITLE
Improve the "Save As" file path

### DIFF
--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -662,13 +662,13 @@ class Pane extends Model
           @handleSaveError(error, item)
 
   getDefaultSaveAsPath: (item) =>
-    itemPath = item.getPath();
+    itemPath = item.getPath()
     if itemPath
       return itemPath
 
     return unless @getActiveEditor()?
 
-    firstRowTrimmed = @getActiveEditor().getTextInRange([[0, 0],[0, 50]])
+    firstRowTrimmed = @getActiveEditor().getTextInRange([[0, 0], [0, 50]])
 
     return path.join getWindowLoadSettings().initialPaths[0], firstRowTrimmed
 

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -3,7 +3,10 @@ Grim = require 'grim'
 {CompositeDisposable, Emitter} = require 'event-kit'
 Model = require './model'
 PaneAxis = require './pane-axis'
+path = require 'path'
 TextEditor = require './text-editor'
+{getWindowLoadSettings} = require './window-load-settings-helpers'
+
 
 # Extended: A container for presenting content in the center of the workspace.
 # Panes can contain multiple items, one of which is *active* at a given time.
@@ -646,7 +649,7 @@ class Pane extends Model
     return unless item?.saveAs?
 
     saveOptions = item.getSaveDialogOptions?() ? {}
-    saveOptions.defaultPath ?= item.getPath()
+    saveOptions.defaultPath ?= @getDefaultSaveAsPath(item)
     newItemPath = @applicationDelegate.showSaveDialog(saveOptions)
     if newItemPath
       try
@@ -657,6 +660,17 @@ class Pane extends Model
           nextAction(error)
         else
           @handleSaveError(error, item)
+
+  getDefaultSaveAsPath: (item) =>
+    itemPath = item.getPath();
+    if itemPath
+      return itemPath
+
+    return unless @getActiveEditor()?
+
+    firstRowTrimmed = @getActiveEditor().getTextInRange([[0, 0],[0, 50]])
+
+    return path.join getWindowLoadSettings().initialPaths[0], firstRowTrimmed
 
   # Public: Save all items.
   saveItems: ->


### PR DESCRIPTION
Currently in Atom when you do a "Save As" (or save a new file) it will have a default name of "Untitled".

Sublime had a feature that would take the first 50 characters of your file and make that the default file name when using "Save As".  I loved this feature because when I was creating new files I would tend to start them with something that could be a useful file name.

This is still a work in progress, but I wanted to get the conversation started.

I am trying to find if there is a good way to do some kind of a hook so that the default "Save As" file name could be configured via a package.

I don't think it is possible right now but I might have missed something.  This is my first stab at implementing a feature in Atom. Any help would be appreciated.

Here is an example:

![](https://media.giphy.com/media/3o7TKsxO1p8iWGeJws/giphy.gif)
