### PR TITLE
Don't remeasure the first character of a line

### DIFF
--- a/src/lines-yardstick.coffee
+++ b/src/lines-yardstick.coffee
@@ -91,34 +91,34 @@ class LinesYardstick
     lineNode = @lineNodesProvider.lineNodeForScreenRow(row)
     lineId = @lineNodesProvider.lineIdForScreenRow(row)
 
-    return 0 unless lineNode?
-
-    if cachedPosition = @leftPixelPositionCache[lineId]?[column]
-      return cachedPosition
-
-    textNodes = @lineNodesProvider.textNodesForScreenRow(row)
-    textNodeStartColumn = 0
-
-    for textNode in textNodes
-      textNodeEndColumn = textNodeStartColumn + textNode.textContent.length
-      if textNodeEndColumn > column
-        indexInTextNode = column - textNodeStartColumn
-        break
+    if lineNode?
+      if @leftPixelPositionCache[lineId]?[column]?
+        @leftPixelPositionCache[lineId][column]
       else
-        textNodeStartColumn = textNodeEndColumn
+        textNodes = @lineNodesProvider.textNodesForScreenRow(row)
+        textNodeStartColumn = 0
+        for textNode in textNodes
+          textNodeEndColumn = textNodeStartColumn + textNode.textContent.length
+          if textNodeEndColumn > column
+            indexInTextNode = column - textNodeStartColumn
+            break
+          else
+            textNodeStartColumn = textNodeEndColumn
 
-    if textNode?
-      indexInTextNode ?= textNode.textContent.length
-      lineOffset = lineNode.getBoundingClientRect().left
-      if indexInTextNode is 0
-        leftPixelPosition = @clientRectForRange(textNode, 0, 1).left
-      else
-        leftPixelPosition = @clientRectForRange(textNode, 0, indexInTextNode).right
-      leftPixelPosition -= lineOffset
+        if textNode?
+          indexInTextNode ?= textNode.textContent.length
+          lineOffset = lineNode.getBoundingClientRect().left
+          if indexInTextNode is 0
+            leftPixelPosition = @clientRectForRange(textNode, 0, 1).left
+          else
+            leftPixelPosition = @clientRectForRange(textNode, 0, indexInTextNode).right
+          leftPixelPosition -= lineOffset
 
-      @leftPixelPositionCache[lineId] ?= {}
-      @leftPixelPositionCache[lineId][column] = leftPixelPosition
-      leftPixelPosition
+          @leftPixelPositionCache[lineId] ?= {}
+          @leftPixelPositionCache[lineId][column] = leftPixelPosition
+          leftPixelPosition
+        else
+          0
     else
       0
 

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -195,6 +195,9 @@ class TextEditorComponent
 
   becameVisible: ->
     @updatesPaused = true
+    if @invalidateMeasurementsWhenVisible
+      @invalidateMeasurements()
+      @invalidateMeasurementsWhenVisible = false
     @measureScrollbars() if @measureScrollbarsWhenShown
     @sampleFontStyling()
     @sampleBackgroundColors()
@@ -934,8 +937,11 @@ class TextEditorComponent
     @invalidateMeasurements()
 
   invalidateMeasurements: ->
-    @linesYardstick.invalidateCache()
-    @presenter.measurementsChanged()
+    if @isVisible()
+      @linesYardstick.invalidateCache()
+      @presenter.measurementsChanged()
+    else
+      @invalidateMeasurementsWhenVisible = true
 
   screenPositionForMouseEvent: (event, linesClientRect) ->
     pixelPosition = @pixelPositionForMouseEvent(event, linesClientRect)


### PR DESCRIPTION
Previously we were ignoring the measurement cache for characters located at `left: 0px` because `0` is evaluated as falsy in Javascript, causing those character to be constantly re-measured.

This pull-request fixes it so that we explicitly check for null values when consulting the cache. It's pretty minor, but should save some CPU cycles when rendering an editor.

/cc: @atom/core 
