### PR TITLE
Add atom.restartApplication

### DIFF
--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -58,8 +58,7 @@ class ApplicationDelegate
     ipcRenderer.send("call-window-method", "reload")
 
   restartApplication: ->
-    remote.app.relaunch({args: []})
-    remote.app.quit()
+    ipcRenderer.send("restart-application")
 
   minimizeWindow: ->
     ipcRenderer.send("call-window-method", "minimize")

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -57,6 +57,10 @@ class ApplicationDelegate
   reloadWindow: ->
     ipcRenderer.send("call-window-method", "reload")
 
+  restartApplication: ->
+    remote.app.relaunch({args: []})
+    remote.app.quit()
+
   minimizeWindow: ->
     ipcRenderer.send("call-window-method", "minimize")
 

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -545,6 +545,10 @@ class AtomEnvironment extends Model
   reload: ->
     @applicationDelegate.reloadWindow()
 
+  # Extended: Relaunch the entire application.
+  restartApplication: ->
+    @applicationDelegate.restartApplication()
+
   # Extended: Returns a {Boolean} that is `true` if the current window is maximized.
   isMaximized: ->
     @applicationDelegate.isWindowMaximized()

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -734,10 +734,9 @@ class AtomApplication
   promptForRelaunch: ->
     chosen = dialog.showMessageBox BrowserWindow.getFocusedWindow(),
       type: 'warning'
-      title: 'Relaunch required'
-      message: "You will need to relaunch Atom for this change to take effect."
-      buttons: ['Quit Atom', 'Cancel']
+      title: 'Restart required'
+      message: "You will need to restart Atom for this change to take effect."
+      buttons: ['Restart Atom', 'Cancel']
     if chosen is 0
-      # once we're using electron v.1.2.2
-      # app.relaunch()
+      app.relaunch({args: []})
       app.quit()

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -83,7 +83,7 @@ class AtomApplication
   initialize: (options) ->
     global.atomApplication = this
 
-    @config.onDidChange 'core.useCustomTitleBar', @promptForRelaunch
+    @config.onDidChange 'core.useCustomTitleBar', @promptForRestart
 
     @autoUpdateManager = new AutoUpdateManager(@version, options.test, @resourcePath, @config)
     @applicationMenu = new ApplicationMenu(@version, @autoUpdateManager)
@@ -734,7 +734,7 @@ class AtomApplication
 
     dialog.showOpenDialog(parentWindow, openOptions, callback)
 
-  promptForRelaunch: ->
+  promptForRestart: ->
     chosen = dialog.showMessageBox BrowserWindow.getFocusedWindow(),
       type: 'warning'
       title: 'Restart required'


### PR DESCRIPTION
This uses the new Electron `app.relaunch` API and will be used to restart Atom after updating packages or when changing the `useCustomTitleBar` option. Restart is actually performed in the main process in `AtomApplication.restart`, and we preserve various command line flags from the previous instance based on the state of the application.
