### PR TITLE
Fix for broken link in the contributing document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,7 +233,7 @@ If you want to read about using Atom or developing packages in Atom, the [Atom F
 
 * Include screenshots and animated GIFs in your pull request whenever possible.
 * Follow the [CoffeeScript](#coffeescript-styleguide),
-  [JavaScript](https://github.com/styleguide/javascript),
+  [JavaScript](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#javascript-styleguide),
   and [CSS](https://github.com/styleguide/css) styleguides.
 * Include thoughtfully-worded, well-structured
   [Jasmine](http://jasmine.github.io/) specs in the `./spec` folder. Run them using `apm test`. See the [Specs Styleguide](#specs-styleguide) below.


### PR DESCRIPTION
I was checking out the contributing document and noticed the JS style guide link is dead. I figured the second best thing would be the JS styleguide in the document itself?
