### PR TITLE
Always return an empty array in TokenizedBuffer.getInvalidatedRanges

### DIFF
--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -49,10 +49,7 @@ class TokenizedBuffer extends Model
     new TokenizedBufferIterator(this)
 
   getInvalidatedRanges: ->
-    if @invalidatedRange?
-      [@invalidatedRange]
-    else
-      []
+    []
 
   onDidInvalidateRange: (fn) ->
     @emitter.on 'did-invalidate-range', fn
@@ -206,8 +203,6 @@ class TokenizedBuffer extends Model
     newEndStack = @stackForRow(end + delta)
     if newEndStack and not _.isEqual(newEndStack, previousEndStack)
       @invalidateRow(end + delta + 1)
-
-    @invalidatedRange = Range(start, end)
 
   isFoldableAtRow: (row) ->
     if @largeFileMode


### PR DESCRIPTION
Previously, we were always mistakenly returning `[(0, 0), (0, 0)]`, thus causing the first line of a file to be constantly invalidated. This caused also a performance regression for long lines with lots of highlight decorations at row 0, because any change in the buffer at other rows caused that line to be re-rendered and, therefore, re-measured as well. This was a contributing factor in the performance problem mentioned on #12662.

Since `TokenizedBuffer` never synchronously invalidates beyond the extent of the spatial change we can simply return an empty array instead.
