### PR TITLE
Improve “Editor is not responding” dialogue

### DIFF
--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -145,9 +145,10 @@ class AtomWindow
 
       chosen = dialog.showMessageBox @browserWindow,
         type: 'warning'
-        buttons: ['Close', 'Keep Waiting']
+        buttons: ['Keep Waiting', 'Force Close']
         message: 'Editor is not responding'
         detail: 'The editor is not responding. Would you like to force close it or just keep waiting?'
+        cancelId: 0 # Keep Waiting
       @browserWindow.destroy() if chosen is 0
 
     @browserWindow.webContents.on 'crashed', =>


### PR DESCRIPTION
When the “Editor is not responding” dialogue appears and user tries to dismiss it using <kbd>Escape</kbd> key, the Atom window is closed instead. This behaviour is counter-intuitive because closing a dialogue should never result in a destructive action.
