### PR TITLE
Tildify path in title bar

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -81,7 +81,7 @@ describe "Workspace", ->
           expect(untitledEditor.getText()).toBe("An untitled editor.")
 
           expect(atom.workspace.getActiveTextEditor().getPath()).toBe editor3.getPath()
-          pathEscaped = escapeStringRegex(atom.project.getPaths()[0])
+          pathEscaped = fs.tildify(escapeStringRegex(atom.project.getPaths()[0]))
           expect(document.title).toMatch ///^#{path.basename(editor3.getLongTitle())}\ \u2014\ #{pathEscaped}///
 
     describe "where there are no open panes or editors", ->
@@ -894,28 +894,28 @@ describe "Workspace", ->
       describe "when there is an active pane item", ->
         it "sets the title to the pane item's title plus the project path", ->
           item = atom.workspace.getActivePaneItem()
-          pathEscaped = escapeStringRegex(atom.project.getPaths()[0])
+          pathEscaped = fs.tildify(escapeStringRegex(atom.project.getPaths()[0]))
           expect(document.title).toMatch ///^#{item.getTitle()}\ \u2014\ #{pathEscaped}///
 
       describe "when the title of the active pane item changes", ->
         it "updates the window title based on the item's new title", ->
           editor = atom.workspace.getActivePaneItem()
           editor.buffer.setPath(path.join(temp.dir, 'hi'))
-          pathEscaped = escapeStringRegex(atom.project.getPaths()[0])
+          pathEscaped = fs.tildify(escapeStringRegex(atom.project.getPaths()[0]))
           expect(document.title).toMatch ///^#{editor.getTitle()}\ \u2014\ #{pathEscaped}///
 
       describe "when the active pane's item changes", ->
         it "updates the title to the new item's title plus the project path", ->
           atom.workspace.getActivePane().activateNextItem()
           item = atom.workspace.getActivePaneItem()
-          pathEscaped = escapeStringRegex(atom.project.getPaths()[0])
+          pathEscaped = fs.tildify(escapeStringRegex(atom.project.getPaths()[0]))
           expect(document.title).toMatch ///^#{item.getTitle()}\ \u2014\ #{pathEscaped}///
 
       describe "when the last pane item is removed", ->
         it "updates the title to contain the project's path", ->
           atom.workspace.getActivePane().destroy()
           expect(atom.workspace.getActivePaneItem()).toBeUndefined()
-          pathEscaped = escapeStringRegex(atom.project.getPaths()[0])
+          pathEscaped = fs.tildify(escapeStringRegex(atom.project.getPaths()[0]))
           expect(document.title).toMatch ///^#{pathEscaped}///
 
       describe "when an inactive pane's item changes", ->
@@ -941,7 +941,7 @@ describe "Workspace", ->
         })
         workspace2.deserialize(atom.workspace.serialize(), atom.deserializers)
         item = workspace2.getActivePaneItem()
-        pathEscaped = escapeStringRegex(atom.project.getPaths()[0])
+        pathEscaped = fs.tildify(escapeStringRegex(atom.project.getPaths()[0]))
         expect(document.title).toMatch ///^#{item.getLongTitle()}\ \u2014\ #{pathEscaped}///
         workspace2.destroy()
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore-plus'
 path = require 'path'
+fs = require 'fs-plus'
 Grim = require 'grim'
 {CompositeDisposable, Emitter} = require 'event-kit'
 {Point, Range} = TextBuffer = require 'text-buffer'
@@ -803,12 +804,13 @@ class TextEditor extends Model
       allPathSegments = []
       for textEditor in atom.workspace.getTextEditors() when textEditor isnt this
         if textEditor.getFileName() is fileName
-          allPathSegments.push(textEditor.getDirectoryPath().split(path.sep))
+          directoryPath = fs.tildify(textEditor.getDirectoryPath())
+          allPathSegments.push(directoryPath.split(path.sep))
 
       if allPathSegments.length is 0
         return fileName
 
-      ourPathSegments = @getDirectoryPath().split(path.sep)
+      ourPathSegments = fs.tildify(@getDirectoryPath()).split(path.sep)
       allPathSegments.push ourPathSegments
 
       loop

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -185,6 +185,8 @@ class Workspace extends Model
         itemPath is projectPath or itemPath?.startsWith(projectPath + path.sep)
     itemTitle ?= "untitled"
     projectPath ?= projectPaths[0]
+    if projectPath?
+      projectPath = fs.tildify(projectPath)
 
     titleParts = []
     if item? and projectPath?


### PR DESCRIPTION
This was originally brought up in #12573 (Sorry, I force pushed and couldn't reopen this PR).

It will shorten the directory path displayed in the title bar
PR:
<img width="270" alt="bildschirmfoto 2016-09-01 um 02 14 06" src="https://cloud.githubusercontent.com/assets/13285808/18151613/bc5bb666-6ff0-11e6-9bd1-f5ebece7a21f.png">
Master:
<img width="398" alt="bildschirmfoto 2016-09-01 um 02 23 43" src="https://cloud.githubusercontent.com/assets/13285808/18151614/bc5bd3ee-6ff0-11e6-935d-fc1e24d66cb7.png">

@iolsen thanks for merging https://github.com/atom/fs-plus/pull/32.
