### PR TITLE
Always invalidate yardstick measurements when the editor becomes visible

### DIFF
--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -195,9 +195,10 @@ class TextEditorComponent
 
   becameVisible: ->
     @updatesPaused = true
-    if @invalidateMeasurementsWhenVisible
-      @invalidateMeasurements()
-      @invalidateMeasurementsWhenVisible = false
+    # Always invalidate LinesYardstick measurements when the editor becomes
+    # visible again, because content might have been reflowed and measurements
+    # could be outdated.
+    @invalidateMeasurements()
     @measureScrollbars() if @measureScrollbarsWhenShown
     @sampleFontStyling()
     @sampleBackgroundColors()
@@ -937,11 +938,8 @@ class TextEditorComponent
     @invalidateMeasurements()
 
   invalidateMeasurements: ->
-    if @isVisible()
-      @linesYardstick.invalidateCache()
-      @presenter.measurementsChanged()
-    else
-      @invalidateMeasurementsWhenVisible = true
+    @linesYardstick.invalidateCache()
+    @presenter.measurementsChanged()
 
   screenPositionForMouseEvent: (event, linesClientRect) ->
     pixelPosition = @pixelPositionForMouseEvent(event, linesClientRect)


### PR DESCRIPTION
...because content could get reflowed and previous measurements might become inaccurate. Typically, this could occur when measuring while the editor is hidden: in that case, the yardstick would always report `0px` and save that position into the cache. Then, when the editor becomes visible again, the wrong `0px` value would be returned, thus causing cursors etc. to be displayed incorrectly.

This was being shadowed by a 🐛 in our measurements cache, but after fixing it in #12730 it started becoming more evident.

/cc: @atom/core 
