### PR TITLE
Make it easier to define user key bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "electronVersion": "1.3.6",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "6.3.5",
+    "atom-keymap": "7.0.0",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",
     "cached-run-in-this-context": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "electronVersion": "1.3.6",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "7.0.0",
+    "atom-keymap": "7.0.1",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",
     "cached-run-in-this-context": "0.4.1",
@@ -52,7 +52,7 @@
     "scandal": "^2.2.1",
     "scoped-property-store": "^0.17.0",
     "scrollbar-style": "^3.2",
-    "season": "^5.4",
+    "season": "^5.4.1",
     "semver": "^4.3.3",
     "service-hub": "^0.7.2",
     "sinon": "1.17.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "scandal": "^2.2.1",
     "scoped-property-store": "^0.17.0",
     "scrollbar-style": "^3.2",
-    "season": "^5.3",
+    "season": "^5.4",
     "semver": "^4.3.3",
     "service-hub": "^0.7.2",
     "sinon": "1.17.4",

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -251,7 +251,7 @@ class Package
     if @bundledPackage and @packageManager.packagesCache[@name]?
       @keymaps = (["#{@packageManager.resourcePath}#{path.sep}#{keymapPath}", keymapObject] for keymapPath, keymapObject of @packageManager.packagesCache[@name].keymaps)
     else
-      @keymaps = @getKeymapPaths().map (keymapPath) -> [keymapPath, CSON.readFileSync(keymapPath) ? {}]
+      @keymaps = @getKeymapPaths().map (keymapPath) -> [keymapPath, CSON.readFileSync(keymapPath, allowDuplicateKeys: false) ? {}]
     return
 
   loadMenus: ->


### PR DESCRIPTION
1. User key bindings now take precedence over package key bindings regardless of their selector specificity.
2. We now throw errors if key binding files contain duplicate keys. This was an easy error to make because it's easy to think of these CSON files as working like style sheets, rather than JSON objects.

Closes https://github.com/atom/atom-keymap/issues/110

🍐  w/ @nathansobo 
