### PR TITLE
Use app 'activate' event instead of defunct 'activate-with-no-open-windows'

### DIFF
--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -250,9 +250,10 @@ class AtomApplication
       event.preventDefault()
       @openUrl({urlToOpen, @devMode, @safeMode})
 
-    @disposable.add ipcHelpers.on app, 'activate-with-no-open-windows', (event) =>
-      event?.preventDefault()
-      @emit('application:new-window')
+    @disposable.add ipcHelpers.on app, 'activate', (event, hasVisibleWindows) =>
+      unless hasVisibleWindows
+        event?.preventDefault()
+        @emit('application:new-window')
 
     @disposable.add ipcHelpers.on ipcMain, 'restart-application', =>
       @restart()


### PR DESCRIPTION
This restores the ability to open a Window by single-clicking the dock icon on macOS.

🍐 ed with @maxbrunsfeld 

Closes https://github.com/atom/atom/issues/12728
