### PR TITLE
Make main-process/main.js as minimal as possible

### DIFF
--- a/src/main-process/main.js
+++ b/src/main-process/main.js
@@ -1,115 +1,36 @@
-global.shellStartTime = Date.now()
+const startTime = Date.now()
 
-process.on('uncaughtException', function (error = {}) {
-  if (error.message != null) {
-    console.log(error.message)
-  }
-
-  if (error.stack != null) {
-    console.log(error.stack)
-  }
-})
-
-const {app} = require('electron')
-const fs = require('fs-plus')
+const electron = require('electron')
+const fs = require('fs')
 const path = require('path')
-const temp = require('temp')
-const parseCommandLine = require('./parse-command-line')
-const startCrashReporter = require('../crash-reporter-start')
-const previousConsoleLog = console.log
-console.log = require('nslog')
+const yargs = require('yargs')
 
-function start () {
-  const args = parseCommandLine(process.argv.slice(1))
-  setupAtomHome(args)
-  setupCompileCache()
+const args =
+  yargs(process.argv)
+    .alias('d', 'dev')
+    .alias('t', 'test')
+    .argv
 
-  if (handleStartupEventWithSquirrel()) {
-    return
-  } else if (args.test && args.mainProcess) {
-    app.setPath('userData', temp.mkdirSync('atom-user-data-dir-for-main-process-tests'))
-    console.log = previousConsoleLog
-    app.on('ready', function () {
-      const testRunner = require(path.join(args.resourcePath, 'spec/main-process/mocha-test-runner'))
-      testRunner(args.pathsToOpen)
-    })
-    return
-  }
+let resourcePath
 
-  // NB: This prevents Win10 from showing dupe items in the taskbar
-  app.setAppUserModelId('com.squirrel.atom.atom')
+if (args.resourcePath) {
+  resourcePath = args.resourcePath
+} else {
+  const stableResourcePath = path.dirname(path.dirname(__dirname))
+  const defaultRepositoryPath = path.join(electron.app.getPath('home'), 'github', 'atom')
 
-  function addPathToOpen (event, pathToOpen) {
-    event.preventDefault()
-    args.pathsToOpen.push(pathToOpen)
-  }
-
-  function addUrlToOpen (event, urlToOpen) {
-    event.preventDefault()
-    args.urlsToOpen.push(urlToOpen)
-  }
-
-  app.on('open-file', addPathToOpen)
-  app.on('open-url', addUrlToOpen)
-  app.on('will-finish-launching', startCrashReporter)
-
-  if (args.userDataDir != null) {
-    app.setPath('userData', args.userDataDir)
-  } else if (args.test) {
-    app.setPath('userData', temp.mkdirSync('atom-test-data'))
-  }
-
-  app.on('ready', function () {
-    app.removeListener('open-file', addPathToOpen)
-    app.removeListener('open-url', addUrlToOpen)
-    const AtomApplication = require(path.join(args.resourcePath, 'src', 'main-process', 'atom-application'))
-    AtomApplication.open(args)
-  })
-}
-
-function handleStartupEventWithSquirrel () {
-  if (process.platform !== 'win32') {
-    return false
-  }
-
-  const SquirrelUpdate = require('./squirrel-update')
-  const squirrelCommand = process.argv[1]
-  return SquirrelUpdate.handleStartupEvent(app, squirrelCommand)
-}
-
-function setupAtomHome ({setPortable}) {
-  if (process.env.ATOM_HOME) {
-    return
-  }
-
-  let atomHome = path.join(app.getPath('home'), '.atom')
-  const AtomPortable = require('./atom-portable')
-
-  if (setPortable && !AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome)) {
-    try {
-      AtomPortable.setPortable(atomHome)
-    } catch (error) {
-      console.log(`Failed copying portable directory '${atomHome}' to '${AtomPortable.getPortableAtomHomePath()}'`)
-      console.log(`${error.message} ${error.stack}`)
+  if (args.dev || args.test) {
+    if (process.env.ATOM_DEV_RESOURCE_PATH) {
+      resourcePath = process.env.ATOM_DEV_RESOURCE_PATH
+    } else if (fs.statSyncNoException(defaultRepositoryPath)) {
+      resourcePath = defaultRepositoryPath
+    } else {
+      resourcePath = stableResourcePath
     }
+  } else {
+    resourcePath = stableResourcePath
   }
-
-  if (AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome)) {
-    atomHome = AtomPortable.getPortableAtomHomePath()
-  }
-
-  try {
-    atomHome = fs.realpathSync(atomHome)
-  } catch (e) {
-    // Don't throw an error if atomHome doesn't exist.
-  }
-
-  process.env.ATOM_HOME = atomHome
 }
 
-function setupCompileCache () {
-  const CompileCache = require('../compile-cache')
-  CompileCache.setAtomHomeDirectory(process.env.ATOM_HOME)
-}
-
-start()
+const start = require(path.join(resourcePath, 'src', 'main-process', 'start'))
+start(resourcePath, startTime)

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -1,0 +1,115 @@
+const {app} = require('electron')
+const fs = require('fs-plus')
+const nslog = require('nslog')
+const path = require('path')
+const temp = require('temp')
+const parseCommandLine = require('./parse-command-line')
+const startCrashReporter = require('../crash-reporter-start')
+
+module.exports = function start (resourcePath, startTime) {
+  global.shellStartTime = startTime
+
+  process.on('uncaughtException', function (error = {}) {
+    if (error.message != null) {
+      console.log(error.message)
+    }
+
+    if (error.stack != null) {
+      console.log(error.stack)
+    }
+  })
+
+  const previousConsoleLog = console.log
+  console.log = nslog
+
+  const args = parseCommandLine(process.argv.slice(1))
+  setupAtomHome(args)
+  setupCompileCache()
+
+  if (handleStartupEventWithSquirrel()) {
+    return
+  } else if (args.test && args.mainProcess) {
+    app.setPath('userData', temp.mkdirSync('atom-user-data-dir-for-main-process-tests'))
+    console.log = previousConsoleLog
+    app.on('ready', function () {
+      const testRunner = require(path.join(args.resourcePath, 'spec/main-process/mocha-test-runner'))
+      testRunner(args.pathsToOpen)
+    })
+    return
+  }
+
+  // NB: This prevents Win10 from showing dupe items in the taskbar
+  app.setAppUserModelId('com.squirrel.atom.atom')
+
+  function addPathToOpen (event, pathToOpen) {
+    event.preventDefault()
+    args.pathsToOpen.push(pathToOpen)
+  }
+
+  function addUrlToOpen (event, urlToOpen) {
+    event.preventDefault()
+    args.urlsToOpen.push(urlToOpen)
+  }
+
+  app.on('open-file', addPathToOpen)
+  app.on('open-url', addUrlToOpen)
+  app.on('will-finish-launching', startCrashReporter)
+
+  if (args.userDataDir != null) {
+    app.setPath('userData', args.userDataDir)
+  } else if (args.test) {
+    app.setPath('userData', temp.mkdirSync('atom-test-data'))
+  }
+
+  app.on('ready', function () {
+    app.removeListener('open-file', addPathToOpen)
+    app.removeListener('open-url', addUrlToOpen)
+    const AtomApplication = require(path.join(args.resourcePath, 'src', 'main-process', 'atom-application'))
+    AtomApplication.open(args)
+  })
+}
+
+function handleStartupEventWithSquirrel () {
+  if (process.platform !== 'win32') {
+    return false
+  }
+
+  const SquirrelUpdate = require('./squirrel-update')
+  const squirrelCommand = process.argv[1]
+  return SquirrelUpdate.handleStartupEvent(app, squirrelCommand)
+}
+
+function setupAtomHome ({setPortable}) {
+  if (process.env.ATOM_HOME) {
+    return
+  }
+
+  let atomHome = path.join(app.getPath('home'), '.atom')
+  const AtomPortable = require('./atom-portable')
+
+  if (setPortable && !AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome)) {
+    try {
+      AtomPortable.setPortable(atomHome)
+    } catch (error) {
+      console.log(`Failed copying portable directory '${atomHome}' to '${AtomPortable.getPortableAtomHomePath()}'`)
+      console.log(`${error.message} ${error.stack}`)
+    }
+  }
+
+  if (AtomPortable.isPortableInstall(process.platform, process.env.ATOM_HOME, atomHome)) {
+    atomHome = AtomPortable.getPortableAtomHomePath()
+  }
+
+  try {
+    atomHome = fs.realpathSync(atomHome)
+  } catch (e) {
+    // Don't throw an error if atomHome doesn't exist.
+  }
+
+  process.env.ATOM_HOME = atomHome
+}
+
+function setupCompileCache () {
+  const CompileCache = require('../compile-cache')
+  CompileCache.setAtomHomeDirectory(process.env.ATOM_HOME)
+}


### PR DESCRIPTION
In order to test changes to main.js, we need to rebuild the application. For this reason, it makes sense to do as little work as possible here. In this PR, we change main to just determine the resourcePath, then use that path to require a start function which can be iterated on in dev mode.

This PR is a prerequisite to much larger changes we plan to make to the main process code. It will make these changes much easier to test as we develop them.

:pear:ed with @maxbrunsfeld 
