### PR TITLE
Add instructions to install Atom on Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ Currently only a 64-bit version is available.
 The Linux version does not currently automatically update so you will need to
 repeat these steps to upgrade to future releases.
 
+### Arch Linux
+
+Both 32-bit and 64-bit versions are available.
+
+1. Run `sudo pacman -S atom` to install from the [official repositories](https://www.archlinux.org/packages/?q=atom).
+2. Launch Atom using the installed `atom` command.
+
 ### Archive extraction
 
 An archive is available for people who don't want to install `atom` as root.


### PR DESCRIPTION
The Atom package is available on Arch Linux in the official repositories for both [32-bit](https://www.archlinux.org/packages/community/i686/atom/) and [64-bit](https://www.archlinux.org/packages/community/x86_64/atom/).
