### PR TITLE
Keymap: toggleLineCommentsInSelection  small improvement

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1343,7 +1343,10 @@ class TextEditor extends Model
   #
   # If the current grammar doesn't support comments, does nothing.
   toggleLineCommentsInSelection: ->
-    @mutateSelectedText (selection) -> selection.toggleLineComments()
+    @mutateSelectedText (selection) ->
+      selection.toggleLineComments()
+    @transact =>
+      @moveDown(1)
 
   # Convert multiple lines to a single line.
   #


### PR DESCRIPTION
Really small UX improvement for toggleLineCommentsInSelection: after commenting/uncommenting text, cursor will move down, so you can continue commenting the following line.

Inspired by PyCharm
