### PR TITLE
Update coffee-script to 1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cached-run-in-this-context": "0.4.1",
     "chai": "3.5.0",
     "clear-cut": "^2.0.1",
-    "coffee-script": "1.8.0",
+    "coffee-script": "1.11.0",
     "color": "^0.7.3",
     "dedent": "^0.6.0",
     "devtron": "1.1.0",

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -847,7 +847,7 @@ class AtomEnvironment extends Model
       @project.addPath(selectedPath) for selectedPath in selectedPaths
 
   showSaveDialog: (callback) ->
-    callback(showSaveDialogSync())
+    callback(@showSaveDialogSync())
 
   showSaveDialogSync: (options={}) ->
     @applicationDelegate.showSaveDialog(options)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2824,7 +2824,7 @@ class TextEditor extends Model
   # Essential: Enable or disable soft tabs for this editor.
   #
   # * `softTabs` A {Boolean}
-  setSoftTabs: (@softTabs) -> @update({softTabs})
+  setSoftTabs: (@softTabs) -> @update({@softTabs})
 
   # Returns a {Boolean} indicating whether atomic soft tabs are enabled for this editor.
   hasAtomicSoftTabs: -> @displayLayer.atomicSoftTabs


### PR DESCRIPTION
With help from @50Wliu in #12189 we've managed to get Atom's CoffeeScript files (also in bundled packages) forward-compatible with [CoffeeScript >=1.9.0](http://coffeescript.org/#1.9.0):

> Changed strategy for the generation of internal compiler variable names. Note that this means that <code>@example</code> function parameters are no longer available as naked <code>example</code> variables within the function body.

This has only one major drawback - community packages which still use the old style need to be updated in a similar fashion, so before making a major release, we should give enough time for package developers to ensure their packages work with the new version. Most of the time it is fixable by adding a `@` in front of the parameter variable name. Inevitably this will also introduce issues like "the new version broke package xyz".

<details> 
  <summary>

If you are a package developer, use coffeelint already and want a somewhat convenient way to check your coffeescript project for that specific error, expand me.</summary>


For Atom packages I used [coffeescope2](https://github.com/za-creature/coffeescope) with following configuration (add into `coffeelint.json`).

``` json
  "check_scope": {
    "module": "coffeescope2",
    "level": "warn",
    "environments": ["es5", "es6", "browser", "node", "jasmine"],
    "globals": {
      "atom": true,
      "afterEach": true,
      "beforeEach": true,
      "describe": true,
      "fdescribe": true,
      "xdescribe": true,
      "expect": true,
      "it": true,
      "fit": true,
      "xit": true,
      "jasmine": true,
      "runs": true,
      "spyOn": true,
      "waitsFor": true,
      "waitsForPromise": true,
      "indexedDB": true
    },
    "overwrite": false,
    "shadow": false,
    "shadow_builtins": false,
    "shadow_exceptions": ["err", "next"],
    "undefined": true,
    "hoist_local": true,
    "hoist_parent": true,
    "unused_variables": false,
    "unused_arguments": false,
    "unused_classes": true
  }
```

Then run:

```
npm install
npm install coffeescope2
node_modules/.bin/coffeelint .
```

![screen shot 2016-09-26 at 18 23 37](https://cloud.githubusercontent.com/assets/1017132/18840213/77bda71e-8416-11e6-8a5b-f43e6e1c3cac.png)

Undefined identifier is potentially the problematic spot you will want to fix. In my case the following change was enough: https://github.com/atom/open-on-github/commit/1f19165cadec324a6f300e371ebfe3b72898e1fd

After that it is up to you whether you want to keep using coffeescope2 or not, but it should help avoiding the most common issue that comes with this CoffeeScript update. Using coffeescope2 after this procedure is completely optional.

**One extra note as I see people copying this configuration to their projects. Some of very useful functionality of coffeescope2 has been disabled in this configuration, so that we could focus on fixing the current issue. You are missing out on quite a bit (namely detection of unused variables, variable overwriting and shadowing), you might want to take a look at it by enabling the flags in configuration.**
</details>
Closes #9739
