### PR TITLE
Adds feature: Restore column position after editor:delete-line

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4717,6 +4717,39 @@ describe "TextEditor", ->
       expect(buffer.lineForRow(0)).toBe(line2)
       expect(buffer.getLineCount()).toBe(count - 2)
 
+    it "restores cursor position for multiple cursors", ->
+      line = Array(9).join('0123456789')
+      editor.setText([1..5].map(-> line).join('\n'))
+      editor.setCursorScreenPosition([0, 5])
+      editor.addCursorAtScreenPosition([2, 8])
+      editor.deleteLine()
+      expect(editor.getCursors().length).toBe 2
+      [cursor1, cursor2] = editor.getCursors()
+      pos = cursor1.getScreenPosition()
+      expect(pos.row).toBe(0)
+      expect(pos.column).toBe(5)
+      pos = cursor2.getScreenPosition()
+      expect(pos.row).toBe(1)
+      expect(pos.column).toBe(8)
+
+    it "restores cursor position for multiple selections", ->
+      line = Array(9).join('0123456789')
+      editor.setText([1..5].map(-> line).join('\n'))
+      editor.setCursorScreenPosition([0, 5])
+      editor.setSelectedBufferRanges([
+        [[0, 5], [0, 8]],
+        [[2, 4], [2, 15]]
+      ])
+      editor.deleteLine()
+      expect(editor.getCursors().length).toBe 2
+      [cursor1, cursor2] = editor.getCursors()
+      pos = cursor1.getScreenPosition()
+      expect(pos.row).toBe(0)
+      expect(pos.column).toBe(5)
+      pos = cursor2.getScreenPosition()
+      expect(pos.row).toBe(1)
+      expect(pos.column).toBe(4)
+
     it "deletes a line only once when multiple selections are on the same line", ->
       line1 = buffer.lineForRow(1)
       count = buffer.getLineCount()

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -487,6 +487,7 @@ class Selection extends Model
   deleteLine: ->
     if @isEmpty()
       start = @cursor.getScreenRow()
+      startColumn = @cursor.getScreenColumn()
       range = @editor.bufferRowsForScreenRows(start, start + 1)
       if range[1] > range[0]
         @editor.buffer.deleteRows(range[0], range[1] - 1)
@@ -496,9 +497,11 @@ class Selection extends Model
       range = @getBufferRange()
       start = range.start.row
       end = range.end.row
+      startColumn = range.start.column
       if end isnt @editor.buffer.getLastRow() and range.end.column is 0
         end--
       @editor.buffer.deleteRows(start, end)
+    @cursor.setScreenPosition({row: @cursor.getScreenRow(), column: startColumn})
 
   # Public: Joins the current line with the one below it. Lines will
   # be separated by a single space.


### PR DESCRIPTION
Closes Issue #12744 

New behaviour can be seen from this screen cast

![screen cast](https://cloud.githubusercontent.com/assets/2497481/18846601/581b4bd6-8444-11e6-9b03-23ada04530af.gif)
