### PR TITLE
Fix multiple indentation on paste

### DIFF
--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -618,7 +618,10 @@ class Selection extends Model
       newLines
 
     initialNewLines = countInitialNewLines(selectionText)
-    startLevel = @editor.indentLevelForLine(@editor.lineTextForBufferRow(start.row + initialNewLines))
+    if initialNewLines > 0
+      startLevel = @editor.indentLevelForLine(@editor.lineTextForBufferRow(start.row + initialNewLines))
+    else
+      startLevel = @editor.indentLevelForLine(precedingText)
 
     if maintainClipboard
       {text: clipboardText, metadata} = @clipboard.readWithMetadata()

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -602,19 +602,23 @@ class Selection extends Model
     {start, end} = @getBufferRange()
     selectionText = @editor.getTextInRange([start, end])
     precedingText = @editor.getTextInRange([[start.row, 0], start])
-    if selectionText.length > 0
-      if selectionText.charAt(0) is '\n'
-        newLineChars = true
-        myCounter = 1
-        while newLineChars and selectionText.length > myCounter
-          if selectionText.charAt(myCounter) is '\n'
-            myCounter++
-          else
-            newLineChars = false
-        startLevel = @editor.indentLevelForLine(@editor.lineTextForBufferRow(start.row + myCounter))
-      else
-        startLevel = @editor.indentLevelForLine(precedingText)
-    else startLevel = 0
+
+    countInitialNewLines = (string) ->
+      newLines = 0
+      counter = 0
+      while counter < string.length
+        if string.charAt(counter) is '\n'
+          counter++
+          newLines++
+        else if counter+1 < string.length and string.substring(counter, counter+2) is "\r\n"
+          counter+=2
+          newLines++
+        else
+          break
+      newLines
+
+    initialNewLines = countInitialNewLines(selectionText)
+    startLevel = @editor.indentLevelForLine(@editor.lineTextForBufferRow(start.row + initialNewLines))
 
     if maintainClipboard
       {text: clipboardText, metadata} = @clipboard.readWithMetadata()

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -602,7 +602,19 @@ class Selection extends Model
     {start, end} = @getBufferRange()
     selectionText = @editor.getTextInRange([start, end])
     precedingText = @editor.getTextInRange([[start.row, 0], start])
-    startLevel = @editor.indentLevelForLine(precedingText)
+    if selectionText.length > 0
+      if selectionText.charAt(0) is '\n'
+        newLineChars = true
+        myCounter = 1
+        while newLineChars and selectionText.length > myCounter
+          if selectionText.charAt(myCounter) is '\n'
+            myCounter++
+          else
+            newLineChars = false
+        startLevel = @editor.indentLevelForLine(@editor.lineTextForBufferRow(start.row + myCounter))
+      else
+        startLevel = @editor.indentLevelForLine(precedingText)
+    else startLevel = 0
 
     if maintainClipboard
       {text: clipboardText, metadata} = @clipboard.readWithMetadata()


### PR DESCRIPTION
This is a copy of #11267 with a small addition to prevent one of the tests failing and only change the behaviour when there's a leading newline. Fixes #9045 #5473.
