### PR TITLE
Adds support for variable-width terminals

### DIFF
--- a/script/build
+++ b/script/build
@@ -10,7 +10,8 @@ require('./bootstrap')
 require('coffee-script/register')
 require('colors')
 
-const argv = require('yargs')
+const yargs = require('yargs')
+const argv = yargs
   .usage('Usage: $0 [options]')
   .help('help')
   .describe('code-sign',  'Code-sign executables (macOS and Windows only)')
@@ -19,6 +20,7 @@ const argv = require('yargs')
   .describe('create-rpm-package', 'Create .rpm package (Linux only)')
   .describe('compress-artifacts', 'Compress Atom binaries (and symbols on macOS)')
   .describe('install', 'Install Atom')
+  .wrap(yargs.terminalWidth())
   .argv
 
 const cleanOutputDirectory = require('./lib/clean-output-directory')

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -7,7 +7,7 @@ const path = require('path')
 const fs = require('fs-plus')
 
 module.exports = function parseCommandLine (processArgs) {
-  const options = yargs(processArgs).wrap(100)
+  const options = yargs(processArgs).wrap(yargs(processArgs).terminalWidth())
   const version = app.getVersion()
   options.usage(
     dedent`Atom Editor v${version}

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -7,7 +7,7 @@ const path = require('path')
 const fs = require('fs-plus')
 
 module.exports = function parseCommandLine (processArgs) {
-  const options = yargs(processArgs).wrap(yargs(processArgs).terminalWidth())
+  const options = yargs(processArgs).wrap(yargs.terminalWidth())
   const version = app.getVersion()
   options.usage(
     dedent`Atom Editor v${version}


### PR DESCRIPTION
This uses the `yargs.terminalWidth()` to set the width for `atom` and `./script/build`. Fixes #12719
# Screenshots

80 characters:

![image](https://cloud.githubusercontent.com/assets/253202/18886657/cac5e072-84be-11e6-8166-76ff9ed30e20.png)

130 characters:

![image](https://cloud.githubusercontent.com/assets/253202/18886676/daeeb82a-84be-11e6-95b2-acb510a76545.png)
