### PR TITLE
Add textEditors.getActiveTextEditor() method

### DIFF
--- a/spec/text-editor-registry-spec.js
+++ b/spec/text-editor-registry-spec.js
@@ -91,6 +91,17 @@ describe('TextEditorRegistry', function() {
     });
   });
 
+  describe('.getActiveTextEditor', function () {
+    it('gets the currently focused text editor', function () {
+      const disposable = registry.add(editor)
+      var editorElement = editor.getElement()
+      jasmine.attachToDOM(editorElement)
+      editorElement.focus()
+      expect(registry.getActiveTextEditor()).toBe(editor)
+      disposable.dispose()
+    })
+  })
+  
   describe('.maintainConfig(editor)', function() {
     it('does not update the editor when config settings change for unrelated scope selectors', async function() {
       await atom.packages.activatePackage('language-javascript');

--- a/spec/text-editor-registry-spec.js
+++ b/spec/text-editor-registry-spec.js
@@ -91,17 +91,17 @@ describe('TextEditorRegistry', function() {
     });
   });
 
-  describe('.getActiveTextEditor', function () {
-    it('gets the currently focused text editor', function () {
-      const disposable = registry.add(editor)
-      var editorElement = editor.getElement()
-      jasmine.attachToDOM(editorElement)
-      editorElement.focus()
-      expect(registry.getActiveTextEditor()).toBe(editor)
-      disposable.dispose()
-    })
-  })
-  
+  describe('.getActiveTextEditor', function() {
+    it('gets the currently focused text editor', function() {
+      const disposable = registry.add(editor);
+      var editorElement = editor.getElement();
+      jasmine.attachToDOM(editorElement);
+      editorElement.focus();
+      expect(registry.getActiveTextEditor()).toBe(editor);
+      disposable.dispose();
+    });
+  });
+
   describe('.maintainConfig(editor)', function() {
     it('does not update the editor when config settings change for unrelated scope selectors', async function() {
       await atom.packages.activatePackage('language-javascript');

--- a/src/text-editor-registry.js
+++ b/src/text-editor-registry.js
@@ -115,6 +115,28 @@ module.exports = class TextEditorRegistry {
     return removed;
   }
 
+  // Gets the currently active text editor.
+  //
+  // Returns the currently active text editor, or `null` if there is none.
+  getActiveTextEditor () {
+    for (let ed of this.editors) {
+      // fast path, works as long as there's a shadow DOM inside the text editor
+      if (ed.getElement() == document.activeElement) {
+        return ed
+      } else {
+        let editorElement = ed.getElement()
+        let current = document.activeElement
+        while  (current = current.parentNode) {
+          if (current == editorElement) {
+            return ed
+          }
+        }
+      }
+    }
+    return null
+  }
+
+
   // Invoke the given callback with all the current and future registered
   // `TextEditors`.
   //

--- a/src/text-editor-registry.js
+++ b/src/text-editor-registry.js
@@ -121,21 +121,21 @@ module.exports = class TextEditorRegistry {
   getActiveTextEditor () {
     for (let ed of this.editors) {
       // fast path, works as long as there's a shadow DOM inside the text editor
-      if (ed.getElement() == document.activeElement) {
+      if (ed.getElement() === document.activeElement) {
         return ed
       } else {
         let editorElement = ed.getElement()
         let current = document.activeElement
-        while  (current = current.parentNode) {
-          if (current == editorElement) {
+        while (current) {
+          if (current === editorElement) {
             return ed
           }
+          current = current.parentNode
         }
       }
     }
     return null
   }
-
 
   // Invoke the given callback with all the current and future registered
   // `TextEditors`.

--- a/src/text-editor-registry.js
+++ b/src/text-editor-registry.js
@@ -118,23 +118,23 @@ module.exports = class TextEditorRegistry {
   // Gets the currently active text editor.
   //
   // Returns the currently active text editor, or `null` if there is none.
-  getActiveTextEditor () {
+  getActiveTextEditor() {
     for (let ed of this.editors) {
       // fast path, works as long as there's a shadow DOM inside the text editor
       if (ed.getElement() === document.activeElement) {
-        return ed
+        return ed;
       } else {
-        let editorElement = ed.getElement()
-        let current = document.activeElement
+        let editorElement = ed.getElement();
+        let current = document.activeElement;
         while (current) {
           if (current === editorElement) {
-            return ed
+            return ed;
           }
-          current = current.parentNode
+          current = current.parentNode;
         }
       }
     }
-    return null
+    return null;
   }
 
   // Invoke the given callback with all the current and future registered

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1547,12 +1547,12 @@ module.exports = class Workspace extends Model {
 
   // Essential: Get the active {Pane}'s active item.
   //
-  // Returns an pane item {Object}.
+  // Returns a pane item {Object}.
   getActivePaneItem() {
     return this.getActivePaneContainer().getActivePaneItem();
   }
 
-  // Essential: Get all text editors in the workspace.
+  // Essential: Get all text editors in the workspace, if they are pane items.
   //
   // Returns an {Array} of {TextEditor}s.
   getTextEditors() {


### PR DESCRIPTION
as per #12702. Also clarify (I think) the docs for `workspace.getActiveTextEditor()` etc.

Two caveats:
- I have no idea if the fallback implementation for when there's no shadow DOM anymore actually works.
- No clue if the spec is correct, since I can't run specs locally right now (something about `Failed to execute 'registerElement' on 'Document': Registration failed for type 'atom-styles'. A type with that name is already registered.`).
