### PR TITLE
Fixes documentation for TextEditor::indentationForBufferRow()

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2930,9 +2930,9 @@ class TextEditor extends Model
   Section: Indentation
   ###
 
-  # Essential: Get the indentation level of the given a buffer row.
+  # Essential: Get the indentation level of the given buffer row.
   #
-  # Returns how deeply the given row is indented based on the soft tabs and
+  # Determines how deeply the given row is indented based on the soft tabs and
   # tab length settings of this editor. Note that if soft tabs are enabled and
   # the tab length is 2, a row with 4 leading spaces would have an indentation
   # level of 2.

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2973,7 +2973,7 @@ class TextEditor extends Model
 
   # Extended: Get the indentation level of the given line of text.
   #
-  # Returns how deeply the given line is indented based on the soft tabs and
+  # Determines how deeply the given line is indented based on the soft tabs and
   # tab length settings of this editor. Note that if soft tabs are enabled and
   # the tab length is 2, a row with 4 leading spaces would have an indentation
   # level of 2.


### PR DESCRIPTION
fixes #12820. 

The problem was that lines beginning with `Returns` are [special in atomdoc](https://github.com/atom/atomdoc/blob/f2917a6433b72f8fafb89f5fcff7060a450fa661/src/parser.coffee#L10)  so I replaced it with `Determines`.
# New atom-api.json

``` json
{
  "name": "indentationForBufferRow",
  "sectionName": "Indentation",
  "srcUrl": "https://github.com/atom/atom/blob/v1.12.0-dev/src/text-editor.coffee#L2943",
  "visibility": "Essential",
  "summary": "Get the indentation level of the given buffer row.",
  "description": "Get the indentation level of the given buffer row.\n\nDetermines how deeply the given row is indented based on the soft tabs and\ntab length settings of this editor. Note that if soft tabs are enabled and\nthe tab length is 2, a row with 4 leading spaces would have an indentation\nlevel of 2.",
  "arguments": [
    {
      "name": "bufferRow",
      "description": "A {Number} indicating the buffer row.",
      "type": "Number",
      "isOptional": false
    }
  ],
  "returnValues": [
    {
      "type": "Number",
      "description": "Returns a {Number}."
    }
  ]
}
```
