### PR TITLE
Guard against null tab length value

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,9 +7,6 @@ machine:
   xcode:
     version: 7.3
 
-  post:
-    - osascript -e 'tell application "System Events" to keystroke "x"' # clear screen saver
-
 general:
   artifacts:
     - out/atom-mac.zip
@@ -36,6 +33,7 @@ dependencies:
 test:
   override:
     - script/lint
+    - osascript -e 'tell application "System Events" to keystroke "x"' # clear screen saver
     - caffeinate -s script/test # Run with caffeinate to prevent screen saver
 
 experimental:

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4878,6 +4878,11 @@ describe "TextEditor", ->
       editor.setTabLength(6)
       expect(changeHandler).not.toHaveBeenCalled()
 
+    it 'does not change its tab length when the given tab length is null', ->
+      editor.setTabLength(4)
+      editor.setTabLength(null)
+      expect(editor.getTabLength()).toBe(4)
+
   describe ".indentLevelForLine(line)", ->
     it "returns the indent level when the line has only leading whitespace", ->
       expect(editor.indentLevelForLine("    hello")).toBe(2)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -241,7 +241,7 @@ class TextEditor extends Model
             displayLayerParams.atomicSoftTabs = value
 
         when 'tabLength'
-          if value isnt @tokenizedBuffer.getTabLength()
+          if value? and value isnt @tokenizedBuffer.getTabLength()
             @tokenizedBuffer.setTabLength(value)
             displayLayerParams.tabLength = value
 


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/12575

🍐 'd with @as-cii 
