### PR TITLE
Fix uses of `call-window-method` IPC channel in specs

### DIFF
--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -3,6 +3,7 @@ _ = require 'underscore-plus'
 grim = require 'grim'
 marked = require 'marked'
 listen = require '../src/delegated-listener'
+ipcHelpers = require '../src/ipc-helpers'
 
 formatStackTrace = (spec, message='', stackTrace) ->
   return stackTrace unless stackTrace
@@ -173,7 +174,7 @@ class AtomReporter
     listen document, 'click', '.stack-trace', (event) ->
       event.currentTarget.classList.toggle('expanded')
 
-    @reloadButton.addEventListener('click', -> require('electron').ipcRenderer.send('call-window-method', 'reload'))
+    @reloadButton.addEventListener('click', -> ipcHelpers.call('window-method', 'reload'))
 
   updateSpecCounts: ->
     if @skippedCount

--- a/src/initialize-test-window.coffee
+++ b/src/initialize-test-window.coffee
@@ -1,3 +1,5 @@
+ipcHelpers = require './ipc-helpers'
+
 cloneObject = (object) ->
   clone = {}
   clone[key] = value for key, value of object
@@ -31,19 +33,19 @@ module.exports = ({blobStore}) ->
     handleKeydown = (event) ->
       # Reload: cmd-r / ctrl-r
       if (event.metaKey or event.ctrlKey) and event.keyCode is 82
-        ipcRenderer.send('call-window-method', 'reload')
+        ipcHelpers.call('window-method', 'reload')
 
       # Toggle Dev Tools: cmd-alt-i / ctrl-alt-i
       if (event.metaKey or event.ctrlKey) and event.altKey and event.keyCode is 73
-        ipcRenderer.send('call-window-method', 'toggleDevTools')
+        ipcHelpers.call('window-method', 'toggleDevTools')
 
       # Close: cmd-w / ctrl-w
       if (event.metaKey or event.ctrlKey) and event.keyCode is 87
-        ipcRenderer.send('call-window-method', 'close')
+        ipcHelpers.call('window-method', 'close')
 
       # Copy: cmd-c / ctrl-c
       if (event.metaKey or event.ctrlKey) and event.keyCode is 67
-        ipcRenderer.send('call-window-method', 'copy')
+        ipcHelpers.call('window-method', 'copy')
 
     window.addEventListener('keydown', handleKeydown, true)
 


### PR DESCRIPTION
Refs https://github.com/atom/atom/pull/12759

In that PR, we broke the ability to toggle the dev tools and reload spec windows.
