### PR TITLE
On Circle, clear screensaver right before running tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,9 +7,6 @@ machine:
   xcode:
     version: 7.3
 
-  post:
-    - osascript -e 'tell application "System Events" to keystroke "x"' # clear screen saver
-
 general:
   artifacts:
     - out/atom-mac.zip
@@ -36,6 +33,7 @@ dependencies:
 test:
   override:
     - script/lint
+    - osascript -e 'tell application "System Events" to keystroke "x"' # clear screen saver
     - caffeinate -s script/test # Run with caffeinate to prevent screen saver
 
 experimental:


### PR DESCRIPTION
We're seeing some Circle builds time out, and we think it may be because after sending the keystroke, enough time is elapsing during our tests that the screensaver is _still_ starting.

Example: https://circleci.com/gh/atom/atom/1287
