### PR TITLE
Fixes search links for GitHub Issues and Pull Requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Before creating bug reports, please check [this list](#before-submitting-a-bug-r
 * **Check the [debugging guide](http://flight-manual.atom.io/hacking-atom/sections/debugging/).** You might be able to find the cause of the problem and fix things yourself. Most importantly, check if you can reproduce the problem [in the latest version of Atom](http://flight-manual.atom.io/hacking-atom/sections/debugging/#update-to-the-latest-version), if the problem happens when you run Atom in [safe mode](http://flight-manual.atom.io/hacking-atom/sections/debugging/#check-if-the-problem-shows-up-in-safe-mode), and if you can get the desired behavior by changing [Atom's or packages' config settings](http://flight-manual.atom.io/hacking-atom/sections/debugging/#check-atom-and-package-settings).
 * **Check the [FAQs on the forum](https://discuss.atom.io/c/faq)** for a list of common questions and problems.
 * **Determine [which repository the problem should be reported in](#atom-and-packages)**.
-* **Perform a [cursory search](https://github.com/issues?q=+is%3Aissue+user%3Aatom)** to see if the problem has already been reported. If it has, add a comment to the existing issue instead of opening a new one.
+* **Perform a [cursory search](https://github.com/search?q=user%3Aatom&type=Issues)** to see if the problem has already been reported. If it has, add a comment to the existing issue instead of opening a new one.
 
 #### How Do I Submit A (Good) Bug Report?
 
@@ -175,7 +175,7 @@ Before creating enhancement suggestions, please check [this list](#before-submit
 * **Check the [debugging guide](http://flight-manual.atom.io/hacking-atom/sections/debugging/)** for tips — you might discover that the enhancement is already available. Most importantly, check if you're using [the latest version of Atom](http://flight-manual.atom.io/hacking-atom/sections/debugging/#update-to-the-latest-version) and if you can get the desired behavior by changing [Atom's or packages' config settings](http://flight-manual.atom.io/hacking-atom/sections/debugging/#check-atom-and-package-settings).
 * **Check if there's already [a package](https://atom.io/packages) which provides that enhancement.**
 * **Determine [which repository the enhancement should be suggested in](#atom-and-packages).**
-* **Perform a [cursory search](https://github.com/issues?q=+is%3Aissue+user%3Aatom)** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+* **Perform a [cursory search](https://github.com/search?q=user%3Aatom&type=Issues)** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 
 #### How Do I Submit A (Good) Enhancement Suggestion?
 
@@ -369,7 +369,7 @@ disablePackage: (name, options, callback) ->
 
 This section lists the labels we use to help us track and manage issues and pull requests. Most labels are used across all Atom repositories, but some are specific to `atom/atom`.
 
-[GitHub search](https://help.github.com/articles/searching-issues/) makes it easy to use labels for finding groups of issues or pull requests you're interested in. For example, you might be interested in [open issues across `atom/atom` and all Atom-owned packages which are labeled as bugs, but still need to be reliably reproduced](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Abug+label%3Aneeds-reproduction) or perhaps [open pull requests in `atom/atom` which haven't been reviewed yet](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+repo%3Aatom%2Fatom+comments%3A0). To help you find issues and pull requests, each label is listed with search links for finding open items with that label in `atom/atom` only and also across all Atom repositories. We  encourage you to read about [other search filters](https://help.github.com/articles/searching-issues/) which will help you write more focused queries.
+[GitHub search](https://help.github.com/articles/searching-issues/) makes it easy to use labels for finding groups of issues or pull requests you're interested in. For example, you might be interested in [open issues across `atom/atom` and all Atom-owned packages which are labeled as bugs, but still need to be reliably reproduced](https://github.com/search?q=user%3Aatom+label%3Abug+label%3Aneeds-reproduction&type=Issues) or perhaps [open pull requests in `atom/atom` which haven't been reviewed yet](https://github.com/atom/atom/pulls?q=is%3Apr%20is%3Aopen%20comments%3A0). To help you find issues and pull requests, each label is listed with search links for finding open items with that label in `atom/atom` only and also across all Atom repositories. We  encourage you to read about [other search filters](https://help.github.com/articles/searching-issues/) which will help you write more focused queries.
 
 The labels are loosely grouped by their purpose, but it's not required that every issue have a label from every group or that an issue can't have more than one label from the same group.
 
@@ -443,94 +443,95 @@ Please open an issue on `atom/atom` if you have suggestions for new labels, and 
 | `requires-changes` | [search][search-atom-repo-label-requires-changes] | [search][search-atom-org-label-requires-changes] | Pull requests which need to be updated based on review comments and then reviewed again. |
 | `needs-testing` | [search][search-atom-repo-label-needs-testing] | [search][search-atom-org-label-needs-testing] | Pull requests which need manual testing. |
 
-[search-atom-repo-label-enhancement]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aenhancement
-[search-atom-org-label-enhancement]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aenhancement
-[search-atom-repo-label-bug]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Abug
-[search-atom-org-label-bug]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Abug
-[search-atom-repo-label-question]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aquestion
-[search-atom-org-label-question]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aquestion
-[search-atom-repo-label-feedback]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Afeedback
-[search-atom-org-label-feedback]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Afeedback
-[search-atom-repo-label-help-wanted]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Ahelp-wanted
-[search-atom-org-label-help-wanted]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Ahelp-wanted
-[search-atom-repo-label-beginner]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Abeginner
-[search-atom-org-label-beginner]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Abeginner
-[search-atom-repo-label-more-information-needed]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Amore-information-needed
-[search-atom-org-label-more-information-needed]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Amore-information-needed
-[search-atom-repo-label-needs-reproduction]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aneeds-reproduction
-[search-atom-org-label-needs-reproduction]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aneeds-reproduction
-[search-atom-repo-label-triage-help-needed]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Atriage-help-needed
-[search-atom-org-label-triage-help-needed]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Atriage-help-needed
-[search-atom-repo-label-windows]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Awindows
-[search-atom-org-label-windows]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Awindows
-[search-atom-repo-label-linux]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Alinux
-[search-atom-org-label-linux]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Alinux
-[search-atom-repo-label-mac]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Amac
-[search-atom-org-label-mac]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Amac
-[search-atom-repo-label-documentation]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Adocumentation
-[search-atom-org-label-documentation]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Adocumentation
-[search-atom-repo-label-performance]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aperformance
-[search-atom-org-label-performance]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aperformance
-[search-atom-repo-label-security]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Asecurity
-[search-atom-org-label-security]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Asecurity
-[search-atom-repo-label-ui]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aui
-[search-atom-org-label-ui]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aui
-[search-atom-repo-label-api]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aapi
-[search-atom-org-label-api]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aapi
-[search-atom-repo-label-crash]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Acrash
-[search-atom-org-label-crash]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Acrash
-[search-atom-repo-label-auto-indent]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aauto-indent
-[search-atom-org-label-auto-indent]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aauto-indent
-[search-atom-repo-label-encoding]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aencoding
-[search-atom-org-label-encoding]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aencoding
-[search-atom-repo-label-network]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Anetwork
-[search-atom-org-label-network]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Anetwork
-[search-atom-repo-label-uncaught-exception]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Auncaught-exception
-[search-atom-org-label-uncaught-exception]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Auncaught-exception
-[search-atom-repo-label-git]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Agit
-[search-atom-org-label-git]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Agit
-[search-atom-repo-label-blocked]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Ablocked
-[search-atom-org-label-blocked]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Ablocked
-[search-atom-repo-label-duplicate]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aduplicate
-[search-atom-org-label-duplicate]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aduplicate
-[search-atom-repo-label-wontfix]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Awontfix
-[search-atom-org-label-wontfix]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Awontfix
-[search-atom-repo-label-invalid]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Ainvalid
-[search-atom-org-label-invalid]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Ainvalid
-[search-atom-repo-label-package-idea]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Apackage-idea
-[search-atom-org-label-package-idea]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Apackage-idea
-[search-atom-repo-label-wrong-repo]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Awrong-repo
-[search-atom-org-label-wrong-repo]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Awrong-repo
-[search-atom-repo-label-editor-rendering]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aeditor-rendering
-[search-atom-org-label-editor-rendering]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aeditor-rendering
-[search-atom-repo-label-build-error]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Abuild-error
-[search-atom-org-label-build-error]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Abuild-error
-[search-atom-repo-label-error-from-pathwatcher]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aerror-from-pathwatcher
-[search-atom-org-label-error-from-pathwatcher]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aerror-from-pathwatcher
-[search-atom-repo-label-error-from-save]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aerror-from-save
-[search-atom-org-label-error-from-save]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aerror-from-save
-[search-atom-repo-label-error-from-open]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aerror-from-open
-[search-atom-org-label-error-from-open]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aerror-from-open
-[search-atom-repo-label-installer]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Ainstaller
-[search-atom-org-label-installer]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Ainstaller
-[search-atom-repo-label-auto-updater]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aauto-updater
-[search-atom-org-label-auto-updater]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aauto-updater
-[search-atom-repo-label-deprecation-help]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Adeprecation-help
-[search-atom-org-label-deprecation-help]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Adeprecation-help
-[search-atom-repo-label-electron]: https://github.com/issues?q=is%3Aissue+repo%3Aatom%2Fatom+is%3Aopen+label%3Aelectron
-[search-atom-org-label-electron]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aelectron
-[search-atom-repo-label-atom]: https://github.com/issues?q=is%3Aopen+is%3Aissue+repo%3Aatom%2Fatom+label%3Aatom
-[search-atom-org-label-atom]: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Aatom+label%3Aatom
-[search-atom-repo-label-work-in-progress]: https://github.com/pulls?q=is%3Aopen+is%3Apr+repo%3Aatom%2Fatom+label%3Awork-in-progress
-[search-atom-org-label-work-in-progress]: https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aatom+label%3Awork-in-progress
-[search-atom-repo-label-needs-review]: https://github.com/pulls?q=is%3Aopen+is%3Apr+repo%3Aatom%2Fatom+label%3Aneeds-review
-[search-atom-org-label-needs-review]: https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aatom+label%3Aneeds-review
-[search-atom-repo-label-under-review]: https://github.com/pulls?q=is%3Aopen+is%3Apr+repo%3Aatom%2Fatom+label%3Aunder-review
-[search-atom-org-label-under-review]: https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aatom+label%3Aunder-review
-[search-atom-repo-label-requires-changes]: https://github.com/pulls?q=is%3Aopen+is%3Apr+repo%3Aatom%2Fatom+label%3Arequires-changes
-[search-atom-org-label-requires-changes]: https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aatom+label%3Arequires-changes
-[search-atom-repo-label-needs-testing]: https://github.com/pulls?q=is%3Aopen+is%3Apr+repo%3Aatom%2Fatom+label%3Aneeds-testing
-[search-atom-org-label-needs-testing]: https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aatom+label%3Aneeds-testing
 
-[beginner]:https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3Abeginner+label%3Ahelp-wanted+user%3Aatom+sort%3Acomments-desc
-[help-wanted]:https://github.com/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted+user%3Aatom+sort%3Acomments-desc
+[search-atom-repo-label-enhancement]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aenhancement
+[search-atom-org-label-enhancement]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aenhancement
+[search-atom-repo-label-bug]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Abug
+[search-atom-org-label-bug]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Abug
+[search-atom-repo-label-question]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aquestion
+[search-atom-org-label-question]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aquestion
+[search-atom-repo-label-feedback]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Afeedback
+[search-atom-org-label-feedback]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Afeedback
+[search-atom-repo-label-help-wanted]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Ahelp-wanted
+[search-atom-org-label-help-wanted]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Ahelp-wanted
+[search-atom-repo-label-beginner]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Abeginner
+[search-atom-org-label-beginner]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Abeginner
+[search-atom-repo-label-more-information-needed]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Amore-information-needed
+[search-atom-org-label-more-information-needed]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Amore-information-needed
+[search-atom-repo-label-needs-reproduction]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aneeds-reproduction
+[search-atom-org-label-needs-reproduction]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aneeds-reproduction
+[search-atom-repo-label-triage-help-needed]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Atriage-help-needed
+[search-atom-org-label-triage-help-needed]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Atriage-help-needed
+[search-atom-repo-label-windows]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Awindows
+[search-atom-org-label-windows]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Awindows
+[search-atom-repo-label-linux]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Alinux
+[search-atom-org-label-linux]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Alinux
+[search-atom-repo-label-mac]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Amac
+[search-atom-org-label-mac]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Amac
+[search-atom-repo-label-documentation]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Adocumentation
+[search-atom-org-label-documentation]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Adocumentation
+[search-atom-repo-label-performance]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aperformance
+[search-atom-org-label-performance]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aperformance
+[search-atom-repo-label-security]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Asecurity
+[search-atom-org-label-security]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Asecurity
+[search-atom-repo-label-ui]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aui
+[search-atom-org-label-ui]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aui
+[search-atom-repo-label-api]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aapi
+[search-atom-org-label-api]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aapi
+[search-atom-repo-label-crash]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Acrash
+[search-atom-org-label-crash]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Acrash
+[search-atom-repo-label-auto-indent]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aauto-indent
+[search-atom-org-label-auto-indent]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aauto-indent
+[search-atom-repo-label-encoding]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aencoding
+[search-atom-org-label-encoding]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aencoding
+[search-atom-repo-label-network]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Anetwork
+[search-atom-org-label-network]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Anetwork
+[search-atom-repo-label-uncaught-exception]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Auncaught-exception
+[search-atom-org-label-uncaught-exception]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Auncaught-exception
+[search-atom-repo-label-git]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Agit
+[search-atom-org-label-git]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Agit
+[search-atom-repo-label-blocked]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Ablocked
+[search-atom-org-label-blocked]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Ablocked
+[search-atom-repo-label-duplicate]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aduplicate
+[search-atom-org-label-duplicate]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aduplicate
+[search-atom-repo-label-wontfix]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Awontfix
+[search-atom-org-label-wontfix]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Awontfix
+[search-atom-repo-label-invalid]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Ainvalid
+[search-atom-org-label-invalid]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Ainvalid
+[search-atom-repo-label-package-idea]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Apackage-idea
+[search-atom-org-label-package-idea]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Apackage-idea
+[search-atom-repo-label-wrong-repo]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Awrong-repo
+[search-atom-org-label-wrong-repo]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Awrong-repo
+[search-atom-repo-label-editor-rendering]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aeditor-rendering
+[search-atom-org-label-editor-rendering]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aeditor-rendering
+[search-atom-repo-label-build-error]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Abuild-error
+[search-atom-org-label-build-error]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Abuild-error
+[search-atom-repo-label-error-from-pathwatcher]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aerror-from-pathwatcher
+[search-atom-org-label-error-from-pathwatcher]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aerror-from-pathwatcher
+[search-atom-repo-label-error-from-save]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aerror-from-save
+[search-atom-org-label-error-from-save]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aerror-from-save
+[search-atom-repo-label-error-from-open]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aerror-from-open
+[search-atom-org-label-error-from-open]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aerror-from-open
+[search-atom-repo-label-installer]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Ainstaller
+[search-atom-org-label-installer]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Ainstaller
+[search-atom-repo-label-auto-updater]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aauto-updater
+[search-atom-org-label-auto-updater]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aauto-updater
+[search-atom-repo-label-deprecation-help]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Adeprecation-help
+[search-atom-org-label-deprecation-help]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Adeprecation-help
+[search-atom-repo-label-electron]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+is%3Aopen+label%3Aelectron
+[search-atom-org-label-electron]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aelectron
+[search-atom-repo-label-atom]: https://github.com/search?state=open&type=Issues&q=repo%3Aatom%2Fatom+label%3Aatom
+[search-atom-org-label-atom]: https://github.com/search?state=open&type=Issues&q=user%3Aatom+label%3Aatom
+[search-atom-repo-label-work-in-progress]: https://github.com/search?q=is%3Aopen+is%3Apr+repo%3Aatom%2Fatom+label%3Awork-in-progress
+[search-atom-org-label-work-in-progress]: https://github.com/search?q=is%3Aopen+is%3Apr+user%3Aatom+label%3Awork-in-progress
+[search-atom-repo-label-needs-review]: https://github.com/search?q=is%3Aopen+is%3Apr+repo%3Aatom%2Fatom+label%3Aneeds-review
+[search-atom-org-label-needs-review]: https://github.com/search?q=is%3Aopen+is%3Apr+user%3Aatom+label%3Aneeds-review
+[search-atom-repo-label-under-review]: https://github.com/search?q=is%3Aopen+is%3Apr+repo%3Aatom%2Fatom+label%3Aunder-review
+[search-atom-org-label-under-review]: https://github.com/search?q=is%3Aopen+is%3Apr+user%3Aatom+label%3Aunder-review
+[search-atom-repo-label-requires-changes]: https://github.com/search?q=is%3Aopen+is%3Apr+repo%3Aatom%2Fatom+label%3Arequires-changes
+[search-atom-org-label-requires-changes]: https://github.com/search?q=is%3Aopen+is%3Apr+user%3Aatom+label%3Arequires-changes
+[search-atom-repo-label-needs-testing]: https://github.com/search?q=is%3Aopen+is%3Apr+repo%3Aatom%2Fatom+label%3Aneeds-testing
+[search-atom-org-label-needs-testing]: https://github.com/search?q=is%3Aopen+is%3Apr+user%3Aatom+label%3Aneeds-testing
+
+[beginner]:https://github.com/search?s=comments&o=desc&q=user%3Aatom+is%3Aopen+label%3Abeginner+label%3Ahelp-wanted
+[help-wanted]:https://github.com/search?s=comments&o=desc&q=user%3Aatom+is%3Aopen+label%3Ahelp-wanted

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -5,7 +5,7 @@
 * [ ] Did you check the [debugging guide](http://flight-manual.atom.io/hacking-atom/sections/debugging/)?
 * [ ] Did you check the [FAQs on Discuss](https://discuss.atom.io/c/faq)?
 * [ ] Are you reporting to the [correct repository](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#atom-and-packages)?
-* [ ] Did you [perform a cursory search](https://github.com/search?q=is%3Aissue+user%3Aatom+-repo%3Aatom%2Felectron) to see if your bug or enhancement is already reported?
+* [ ] Did you [perform a cursory search](https://github.com/issues?q=is%3Aissue+user%3Aatom+-repo%3Aatom%2Felectron) to see if your bug or enhancement is already reported?
 
 For more information on how to write a good [bug report](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#how-do-i-submit-a-good-bug-report) or [enhancement request](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#how-do-i-submit-a-good-enhancement-suggestion), see the `CONTRIBUTING` guide.
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -5,7 +5,7 @@
 * [ ] Did you check the [debugging guide](http://flight-manual.atom.io/hacking-atom/sections/debugging/)?
 * [ ] Did you check the [FAQs on Discuss](https://discuss.atom.io/c/faq)?
 * [ ] Are you reporting to the [correct repository](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#atom-and-packages)?
-* [ ] Did you [perform a cursory search](https://github.com/issues?q=is%3Aissue+user%3Aatom+-repo%3Aatom%2Felectron) to see if your bug or enhancement is already reported?
+* [ ] Did you [perform a cursory search](https://github.com/search?q=is%3Aissue+user%3Aatom+-repo%3Aatom%2Felectron) to see if your bug or enhancement is already reported?
 
 For more information on how to write a good [bug report](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#how-do-i-submit-a-good-bug-report) or [enhancement request](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#how-do-i-submit-a-good-enhancement-suggestion), see the `CONTRIBUTING` guide.
 

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -205,7 +205,7 @@ class AtomApplication
     @on 'application:open-faq', -> shell.openExternal('https://atom.io/faq')
     @on 'application:open-terms-of-use', -> shell.openExternal('https://atom.io/terms')
     @on 'application:report-issue', -> shell.openExternal('https://github.com/atom/atom/blob/master/CONTRIBUTING.md#submitting-issues')
-    @on 'application:search-issues', -> shell.openExternal('https://github.com/issues?q=+is%3Aissue+user%3Aatom')
+    @on 'application:search-issues', -> shell.openExternal('https://github.com/search?q=+is%3Aissue+user%3Aatom')
 
     @on 'application:install-update', =>
       @quitting = true


### PR DESCRIPTION
https://github.com/issues and https://github.com/pulls URLs ~~stopped working in the last couple of days~~ do not work for non-logged-in users.

This changes the URLs used in atom to point to https://github.com/search.

It might not be a problem if most users of atom are already logged in, but would they know that logging in would fix the problem?
