### PR TITLE
Fix: Scroll line vertically to the center if opened with initialRow

### DIFF
--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -651,7 +651,8 @@ class Cursor extends Model
   changePosition: (options, fn) ->
     @clearSelection(autoscroll: false)
     fn()
-    @autoscroll() if options.autoscroll ? @isLastCursor()
+    if options.autoscroll ? @isLastCursor()
+      @autoscroll(center: ( options.autoscrollCenter or false ))
 
   getPixelRect: ->
     @editor.pixelRectForScreenRange(@getScreenRange())

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -531,7 +531,7 @@ class Workspace extends Model
         unless Number.isNaN(options.initialColumn)
           initialColumn = options.initialColumn
         if initialLine >= 0 or initialColumn >= 0
-          item.setCursorBufferPosition?([initialLine, initialColumn])
+          item.setCursorBufferPosition?([initialLine, initialColumn], autoscrollCenter: true)
 
         index = pane.getActiveItemIndex()
         @emitter.emit 'did-open', {uri, pane, item, index}


### PR DESCRIPTION
Fixes issue #12253 

Added `center: true` for autoscroll to get this behaviour.

Also, regarding the specs, I couldn't find any existing behaviour tests that can distinguish between `center: true` and `center: false` for `autoscroll`. The current `initialLine` tests are [here](https://github.com/atom/atom/blob/706eea2f4298e990a81d117414c766be53146251/spec/workspace-spec.coffee#L385) and the `autoscroll tests` are [here](https://github.com/atom/atom/blob/706eea2f4298e990a81d117414c766be53146251/spec/text-editor-component-spec.js#L4814) (These just check if there is a certain amount of scroll amount from top and not whether the actual location of the cursor is in the center of the displayed screen )

Will add specs if someone can suggest how to proceed.
