### PR TITLE
Add methods for checking if initial packages have been loaded/activated

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -31,6 +31,19 @@ describe "PackageManager", ->
         it "returns the value of the core.apmPath config setting", ->
           expect(atom.packages.getApmPath()).toBe "/path/to/apm"
 
+  describe "::loadPackages()", ->
+    beforeEach ->
+      spyOn(atom.packages, 'loadPackage')
+
+    afterEach ->
+      atom.packages.deactivatePackages()
+      atom.packages.unloadPackages()
+
+    it "sets hasLoadedInitialPackages", ->
+      expect(atom.packages.hasLoadedInitialPackages()).toBe false
+      atom.packages.loadPackages()
+      expect(atom.packages.hasLoadedInitialPackages()).toBe true
+
   describe "::loadPackage(name)", ->
     beforeEach ->
       atom.config.set("core.disabledPackages", [])
@@ -1021,6 +1034,12 @@ describe "PackageManager", ->
       atom.packages.unloadPackages()
 
       jasmine.restoreDeprecationsSnapshot()
+
+    it "sets hasActivatedInitialPackages", ->
+      spyOn(atom.packages, 'activatePackages')
+      expect(atom.packages.hasActivatedInitialPackages()).toBe false
+      waitsForPromise -> atom.packages.activate()
+      runs -> expect(atom.packages.hasActivatedInitialPackages()).toBe true
 
     it "activates all the packages, and none of the themes", ->
       packageActivator = spyOn(atom.packages, 'activatePackages')

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -45,6 +45,8 @@ class PackageManager
       @packageDirPaths.push(path.join(configDirPath, "packages"))
 
     @packagesCache = require('../package.json')?._atomPackages ? {}
+    @initialPackagesLoaded = false
+    @initialPackagesActivated = false
     @loadedPackages = {}
     @activePackages = {}
     @activatingPackages = {}
@@ -241,6 +243,9 @@ class PackageManager
   isPackageActive: (name) ->
     @getActivePackage(name)?
 
+  # Public: Returns a {Boolean} indicating whether package activation has occurred.
+  hasActivatedInitialPackages: -> @initialPackagesActivated
+
   ###
   Section: Accessing loaded packages
   ###
@@ -270,6 +275,9 @@ class PackageManager
   # Returns a {Boolean}.
   isPackageLoaded: (name) ->
     @getLoadedPackage(name)?
+
+  # Public: Returns a {Boolean} indicating whether package loading has occurred.
+  hasLoadedInitialPackages: -> @initialPackagesLoaded
 
   ###
   Section: Accessing available packages
@@ -364,6 +372,7 @@ class PackageManager
     @config.transact =>
       @loadPackage(packagePath) for packagePath in packagePaths
       return
+    @initialPackagesLoaded = true
     @emitter.emit 'did-load-initial-packages'
 
   loadPackage: (nameOrPath) ->
@@ -426,6 +435,7 @@ class PackageManager
       promises = promises.concat(activator.activatePackages(packages))
     Promise.all(promises).then =>
       @triggerDeferredActivationHooks()
+      @initialPackagesActivated = true
       @emitter.emit 'did-activate-initial-packages'
 
   # another type of package manager can handle other package types.


### PR DESCRIPTION
This will allow packages to observe the state without having to worry
about subscribing to the events after they've already fired.

Originally suggested in #10839
