### PR TITLE
Fix for #10474

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -5173,11 +5173,15 @@ describe "TextEditor", ->
       expect(editor.getSelectedBufferRange()).toEqual [[13, 0], [14, 2]]
 
   describe ".shouldPromptToSave()", ->
-    it "returns false when an edit session's buffer is in use by more than one session", ->
+    it "returns true when buffer changed", ->
       jasmine.unspy(editor, 'shouldPromptToSave')
       expect(editor.shouldPromptToSave()).toBeFalsy()
       buffer.setText('changed')
       expect(editor.shouldPromptToSave()).toBeTruthy()
+
+    it "returns false when an edit session's buffer is in use by more than one session", ->
+      jasmine.unspy(editor, 'shouldPromptToSave')
+      buffer.setText('changed')
 
       editor2 = null
       waitsForPromise ->
@@ -5188,6 +5192,16 @@ describe "TextEditor", ->
         expect(editor.shouldPromptToSave()).toBeFalsy()
         editor2.destroy()
         expect(editor.shouldPromptToSave()).toBeTruthy()
+
+    it "returns false when close of a window requested and edit session opened inside project", ->
+      jasmine.unspy(editor, 'shouldPromptToSave')
+      buffer.setText('changed')
+      expect(editor.shouldPromptToSave(windowCloseRequested: true, projectHasPaths: true)).toBeFalsy()
+
+    it "returns true when close of a window requested and edit session opened without project", ->
+      jasmine.unspy(editor, 'shouldPromptToSave')
+      buffer.setText('changed')
+      expect(editor.shouldPromptToSave(windowCloseRequested: true, projectHasPaths: false)).toBeTruthy()
 
   describe "when the editor contains surrogate pair characters", ->
     it "correctly backspaces over them", ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -879,7 +879,7 @@ class TextEditor extends Model
   # Determine whether the user should be prompted to save before closing
   # this editor.
   shouldPromptToSave: ({windowCloseRequested, projectHasPaths}={}) ->
-    if windowCloseRequested && projectHasPaths
+    if windowCloseRequested and projectHasPaths
       false
     else
       @isModified() and not @buffer.hasMultipleEditors()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -878,8 +878,8 @@ class TextEditor extends Model
 
   # Determine whether the user should be prompted to save before closing
   # this editor.
-  shouldPromptToSave: ({windowCloseRequested}={}) ->
-    if windowCloseRequested
+  shouldPromptToSave: ({windowCloseRequested, projectHasPaths}={}) ->
+    if windowCloseRequested && projectHasPaths
       false
     else
       @isModified() and not @buffer.hasMultipleEditors()

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -148,7 +148,8 @@ class WindowEventHandler
     @document.body.classList.remove("fullscreen")
 
   handleWindowBeforeunload: (event) =>
-    confirmed = @atomEnvironment.workspace?.confirmClose(windowCloseRequested: true)
+    projectHasPaths = @atomEnvironment.project.getPaths().length > 0
+    confirmed = @atomEnvironment.workspace?.confirmClose(windowCloseRequested: true, projectHasPaths: projectHasPaths)
     if confirmed and not @reloadRequested and not @atomEnvironment.inSpecMode() and @atomEnvironment.getCurrentWindow().isWebViewFocused()
       @atomEnvironment.hide()
     @reloadRequested = false


### PR DESCRIPTION
If Atom opened with folder e.g. `atom ./` it will save all buffers to workspace tied to this folder.
But if atom opened without folder e.g. `atom` it will prompt if you wan to save all unsaved buffers.
### Testcase
1. Open Atom (without params)
2. Type some text in untitled buffer
3. Quit Atom (Cmd + Q)

Expected behaviour:
1. Shows Prompt whether you want to save or not
2. Depending on user choice close Atom or not 

Current behaviour
1. Close Atom. All text in unsaved buffer is lost
