### PR TITLE
6075 focus tab on save prompt

### DIFF
--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -579,6 +579,8 @@ class Pane extends Model
     else
       return true
 
+    # @setActiveItem(item)
+
     saveDialog = (saveButtonText, saveFn, message) =>
       chosen = @applicationDelegate.confirm
         message: message
@@ -587,12 +589,15 @@ class Pane extends Model
       switch chosen
         when 0 then saveFn(item, saveError)
         when 1 then false
-        when 2 then true
+        when 2
+          @activateNextRecentlyUsedItem()
+          true
 
     saveError = (error) =>
       if error
         saveDialog("Save as", @saveItemAs, "'#{item.getTitle?() ? uri}' could not be saved.\nError: #{@getMessageForErrorCode(error.code)}")
       else
+        @activateNextRecentlyUsedItem()
         true
 
     saveDialog("Save", @saveItem, "'#{item.getTitle?() ? uri}' has changes, do you want to save them?")


### PR DESCRIPTION
This PR is replacement for https://github.com/atom/atom/pull/6075. But this is not Production Ready yet. Created it to discuss.

Closes https://github.com/atom/atom/issues/6070
Closes https://github.com/atom/atom/pull/6075
Depends on https://github.com/atom/tabs/pull/386
### Testcase
1. Open Atom (without params)
2. Type some text in untitled buffer
3. Create new buffer (Cmd+N)
4. Close first buffer without switching to it

Expected behaviour:
1. Switch to first tab
2. Shows Prompt whether you want to save or not

Current behaviour
1. Shows Prompt whether you want to save or not
### Technical details

<img width="1181" alt="graph3" src="https://cloud.githubusercontent.com/assets/179534/19308223/38631c20-9087-11e6-84ab-232190497414.png">

As of now all actions after click on close icon happens synchronously - control not returned to browser, so it has no ability to do paint. Solution make reflow actions in asynchronous way so browser would be able to do paints.

As example we can do something like (`tab-bar-view.coffee`):

``` coffeescript
 onClick: (event) ->
    return unless matches(event.target, ".tab .close-icon")

    tab = closest(event.target, '.tab')
    @setActiveTab(tab) if tab.item.isModified?()
    setImmediate => @pane.destroyItem(tab.item)
    false
```

which will allow browser to do paints

<img width="565" alt="graph4" src="https://cloud.githubusercontent.com/assets/179534/19308847/5d07b204-908a-11e6-9180-a9867802df63.png">
