### PR TITLE
Redirect apm scripts to use the actual apm ones

### DIFF
--- a/resources/win/apm.cmd
+++ b/resources/win/apm.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-"%~dp0\..\app\apm\bin\node.exe" "%~dp0\..\app\apm\lib\cli.js" %*
+"%~dp0\..\app\apm\bin\apm.cmd" %*

--- a/resources/win/apm.sh
+++ b/resources/win/apm.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-directory=$(dirname "$0")
-"$directory/../app/apm/bin/node.exe" "$directory/../app/apm/lib/cli.js" "$@"
+"$(dirname "$0")/../app/apm/apm.sh" "$@"


### PR DESCRIPTION
The Windows scripts in atom/apm have been kept considerably more up-to-date than the ones in atom/atom.  This PR updates the apm scripts in atom/atom to call the ones in atom/apm and fixes the issue where `node-gyp` can't be found while `apm install`ing.

There are two alternative solutions:
1. Remove the scripts from this repository and symlink the atom/apm scripts, [as is done for macOS and Linux](https://github.com/atom/atom/blob/beb2b6bbc0c49798ea14ee32803cd880f55a68bf/script/lib/package-application.js#L68)
2. Remove the scripts from this repository and update PATH to include the scripts in atom/apm.
