### PR TITLE
Update languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "language-hyperlink": "0.16.1",
     "language-java": "0.24.0",
     "language-javascript": "0.122.0",
-    "language-json": "0.18.2",
+    "language-json": "0.18.3",
     "language-less": "0.29.6",
     "language-make": "0.22.2",
     "language-mustache": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "language-html": "0.46.1",
     "language-hyperlink": "0.16.1",
     "language-java": "0.24.0",
-    "language-javascript": "0.121.0",
+    "language-javascript": "0.122.0",
     "language-json": "0.18.2",
     "language-less": "0.29.6",
     "language-make": "0.22.2",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "language-clojure": "0.22.0",
     "language-coffee-script": "0.47.3",
     "language-csharp": "0.12.1",
-    "language-css": "0.40.0",
+    "language-css": "0.40.1",
     "language-gfm": "0.88.0",
     "language-git": "0.15.0",
     "language-go": "0.43.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "language-text": "0.7.1",
     "language-todo": "0.29.1",
     "language-toml": "0.18.1",
-    "language-xml": "0.34.11",
+    "language-xml": "0.34.12",
     "language-yaml": "0.27.1"
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "wrap-guide": "0.38.2",
     "language-c": "0.53.2",
     "language-clojure": "0.22.0",
-    "language-coffee-script": "0.47.3",
+    "language-coffee-script": "0.48.0",
     "language-csharp": "0.12.1",
     "language-css": "0.40.1",
     "language-gfm": "0.88.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "whitespace": "0.35.0",
     "wrap-guide": "0.38.2",
     "language-c": "0.54.0",
-    "language-clojure": "0.22.0",
+    "language-clojure": "0.22.1",
     "language-coffee-script": "0.48.0",
     "language-csharp": "0.12.1",
     "language-css": "0.40.1",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "language-gfm": "0.88.0",
     "language-git": "0.15.0",
     "language-go": "0.43.0",
-    "language-html": "0.46.0",
+    "language-html": "0.46.1",
     "language-hyperlink": "0.16.1",
     "language-java": "0.24.0",
     "language-javascript": "0.121.0",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "welcome": "0.35.1",
     "whitespace": "0.35.0",
     "wrap-guide": "0.38.2",
-    "language-c": "0.53.2",
+    "language-c": "0.54.0",
     "language-clojure": "0.22.0",
     "language-coffee-script": "0.48.0",
     "language-csharp": "0.12.1",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "language-php": "0.37.3",
     "language-property-list": "0.8.0",
     "language-python": "0.45.1",
-    "language-ruby": "0.70.1",
+    "language-ruby": "0.70.2",
     "language-ruby-on-rails": "0.25.1",
     "language-sass": "0.57.0",
     "language-shellscript": "0.23.0",


### PR DESCRIPTION
In general, just some minor fixes/modeline support.
- language-javascript, as is now customary, got even more improvements to its JSDoc tokenization.
- language-c can now tokenize operators.

@Alhadis if there's any merged modeline PRs that I forgot to bump the version for, please let me know.  I'll also try to get back to you on the incorrect-file-detection issue shortly.
