### PR TITLE
Don't construct placeholder tokenized lines

### DIFF
--- a/spec/text-editor-registry-spec.js
+++ b/spec/text-editor-registry-spec.js
@@ -198,13 +198,13 @@ describe('TextEditorRegistry', function () {
       registry.maintainConfig(editor2)
       await initialPackageActivation
 
-      expect(editor.getRootScopeDescriptor().getScopesArray()).toEqual(['text.plain'])
+      expect(editor.getRootScopeDescriptor().getScopesArray()).toEqual(['text.plain.null-grammar'])
       expect(editor2.getRootScopeDescriptor().getScopesArray()).toEqual(['source.js'])
 
       expect(editor.getEncoding()).toBe('utf8')
       expect(editor2.getEncoding()).toBe('utf8')
 
-      atom.config.set('core.fileEncoding', 'utf16le', {scopeSelector: '.text.plain'})
+      atom.config.set('core.fileEncoding', 'utf16le', {scopeSelector: '.text.plain.null-grammar'})
       atom.config.set('core.fileEncoding', 'utf16be', {scopeSelector: '.source.js'})
 
       expect(editor.getEncoding()).toBe('utf16le')

--- a/spec/token-iterator-spec.coffee
+++ b/spec/token-iterator-spec.coffee
@@ -29,7 +29,7 @@ describe "TokenIterator", ->
     })
     tokenizedBuffer.setGrammar(grammar)
 
-    tokenIterator = tokenizedBuffer.tokenizedLineForRow(1).getTokenIterator()
+    tokenIterator = tokenizedBuffer.tokenizedLines[1].getTokenIterator()
     tokenIterator.next()
 
     expect(tokenIterator.getBufferStart()).toBe 0

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -2,7 +2,7 @@ TokenizedBuffer = require '../src/tokenized-buffer'
 {Point} = TextBuffer = require 'text-buffer'
 _ = require 'underscore-plus'
 
-fdescribe "TokenizedBuffer", ->
+describe "TokenizedBuffer", ->
   [tokenizedBuffer, buffer] = []
 
   beforeEach ->
@@ -149,8 +149,8 @@ fdescribe "TokenizedBuffer", ->
         it "does not attempt to tokenize the lines in the change, and preserves the existing invalid row", ->
           expect(tokenizedBuffer.firstInvalidRow()).toBe 5
           buffer.setTextInRange([[6, 0], [7, 0]], "\n\n\n")
-          expect(tokenizedBuffer.tokenizedLineForRow(6).ruleStack?).toBeFalsy()
-          expect(tokenizedBuffer.tokenizedLineForRow(7).ruleStack?).toBeFalsy()
+          expect(tokenizedBuffer.tokenizedLineForRow(6)).toBeFalsy()
+          expect(tokenizedBuffer.tokenizedLineForRow(7)).toBeFalsy()
           expect(tokenizedBuffer.firstInvalidRow()).toBe 5
 
     describe "when the buffer is fully tokenized", ->
@@ -252,7 +252,7 @@ fdescribe "TokenizedBuffer", ->
           buffer.insert([0, 0], commentBlock)
           expect(tokenizedBuffer.tokenizedLineForRow(0).ruleStack?).toBeTruthy()
           expect(tokenizedBuffer.tokenizedLineForRow(4).ruleStack?).toBeTruthy()
-          expect(tokenizedBuffer.tokenizedLineForRow(5).ruleStack?).toBeFalsy()
+          expect(tokenizedBuffer.tokenizedLineForRow(5)).toBeFalsy()
 
           advanceClock()
           expect(tokenizedBuffer.tokenizedLineForRow(5).ruleStack?).toBeTruthy()
@@ -585,9 +585,9 @@ fdescribe "TokenizedBuffer", ->
       expect(tokenizeCallback.callCount).toBe 1
       expect(atom.grammars.nullGrammar.tokenizeLine.callCount).toBe 0
 
-      expect(tokenizedBuffer.tokenizedLineForRow(0)).toBe null
-      expect(tokenizedBuffer.tokenizedLineForRow(1)).toBe null
-      expect(tokenizedBuffer.tokenizedLineForRow(2)).toBe null
+      expect(tokenizedBuffer.tokenizedLineForRow(0)).toBeFalsy()
+      expect(tokenizedBuffer.tokenizedLineForRow(1)).toBeFalsy()
+      expect(tokenizedBuffer.tokenizedLineForRow(2)).toBeFalsy()
 
   describe "text decoration layer API", ->
     describe "iterator", ->

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -2,7 +2,7 @@ TokenizedBuffer = require '../src/tokenized-buffer'
 {Point} = TextBuffer = require 'text-buffer'
 _ = require 'underscore-plus'
 
-describe "TokenizedBuffer", ->
+fdescribe "TokenizedBuffer", ->
   [tokenizedBuffer, buffer] = []
 
   beforeEach ->
@@ -90,27 +90,24 @@ describe "TokenizedBuffer", ->
       buffer.release()
 
     describe "on construction", ->
-      it "initially creates un-tokenized screen lines, then tokenizes lines chunk at a time in the background", ->
+      it "tokenizes lines chunk at a time in the background", ->
         line0 = tokenizedBuffer.tokenizedLineForRow(0)
-        expect(line0.tokens).toEqual([value: line0.text, scopes: ['source.js']])
+        expect(line0).toBe(undefined)
 
         line11 = tokenizedBuffer.tokenizedLineForRow(11)
-        expect(line11.tokens).toEqual([value: "  return sort(Array.apply(this, arguments));", scopes: ['source.js']])
-
-        # background tokenization has not begun
-        expect(tokenizedBuffer.tokenizedLineForRow(0).ruleStack).toBeUndefined()
+        expect(line11).toBe(undefined)
 
         # tokenize chunk 1
         advanceClock()
         expect(tokenizedBuffer.tokenizedLineForRow(0).ruleStack?).toBeTruthy()
         expect(tokenizedBuffer.tokenizedLineForRow(4).ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.tokenizedLineForRow(5).ruleStack?).toBeFalsy()
+        expect(tokenizedBuffer.tokenizedLineForRow(5)).toBe(undefined)
 
         # tokenize chunk 2
         advanceClock()
         expect(tokenizedBuffer.tokenizedLineForRow(5).ruleStack?).toBeTruthy()
         expect(tokenizedBuffer.tokenizedLineForRow(9).ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.tokenizedLineForRow(10).ruleStack?).toBeFalsy()
+        expect(tokenizedBuffer.tokenizedLineForRow(10)).toBe(undefined)
 
         # tokenize last chunk
         advanceClock()
@@ -588,12 +585,9 @@ describe "TokenizedBuffer", ->
       expect(tokenizeCallback.callCount).toBe 1
       expect(atom.grammars.nullGrammar.tokenizeLine.callCount).toBe 0
 
-      expect(tokenizedBuffer.tokenizedLineForRow(0).tokens.length).toBe 1
-      expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0].value).toBe 'a'
-      expect(tokenizedBuffer.tokenizedLineForRow(1).tokens.length).toBe 1
-      expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0].value).toBe 'b'
-      expect(tokenizedBuffer.tokenizedLineForRow(2).tokens.length).toBe 1
-      expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0].value).toBe 'c'
+      expect(tokenizedBuffer.tokenizedLineForRow(0)).toBe null
+      expect(tokenizedBuffer.tokenizedLineForRow(1)).toBe null
+      expect(tokenizedBuffer.tokenizedLineForRow(2)).toBe null
 
   describe "text decoration layer API", ->
     describe "iterator", ->

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -33,15 +33,8 @@ describe "TokenizedBuffer", ->
           atom.packages.activatePackage('language-coffee-script')
 
       it "deserializes it searching among the buffers in the current project", ->
-        tokenizedBufferA = new TokenizedBuffer({
-          buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-          assert: atom.assert, tabLength: 2,
-        })
-        tokenizedBufferB = TokenizedBuffer.deserialize(
-          JSON.parse(JSON.stringify(tokenizedBufferA.serialize())),
-          atom
-        )
-
+        tokenizedBufferA = new TokenizedBuffer({buffer, tabLength: 2})
+        tokenizedBufferB = TokenizedBuffer.deserialize(JSON.parse(JSON.stringify(tokenizedBufferA.serialize())), atom)
         expect(tokenizedBufferB.buffer).toBe(tokenizedBufferA.buffer)
 
     describe "when the underlying buffer has no path", ->
@@ -49,25 +42,14 @@ describe "TokenizedBuffer", ->
         buffer = atom.project.bufferForPathSync(null)
 
       it "deserializes it searching among the buffers in the current project", ->
-        tokenizedBufferA = new TokenizedBuffer({
-          buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-          assert: atom.assert, tabLength: 2,
-        })
-        tokenizedBufferB = TokenizedBuffer.deserialize(
-          JSON.parse(JSON.stringify(tokenizedBufferA.serialize())),
-          atom
-        )
-
+        tokenizedBufferA = new TokenizedBuffer({buffer, tabLength: 2})
+        tokenizedBufferB = TokenizedBuffer.deserialize(JSON.parse(JSON.stringify(tokenizedBufferA.serialize())), atom)
         expect(tokenizedBufferB.buffer).toBe(tokenizedBufferA.buffer)
 
   describe "when the buffer is destroyed", ->
     beforeEach ->
       buffer = atom.project.bufferForPathSync('sample.js')
-      tokenizedBuffer = new TokenizedBuffer({
-        buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-        assert: atom.assert, tabLength: 2,
-      })
-      tokenizedBuffer.setGrammar(atom.grammars.grammarForScopeName('source.js'))
+      tokenizedBuffer = new TokenizedBuffer({buffer, grammar: atom.grammars.grammarForScopeName('source.js'), tabLength: 2})
       startTokenizing(tokenizedBuffer)
 
     it "stops tokenization", ->
@@ -79,11 +61,7 @@ describe "TokenizedBuffer", ->
   describe "when the buffer contains soft-tabs", ->
     beforeEach ->
       buffer = atom.project.bufferForPathSync('sample.js')
-      tokenizedBuffer = new TokenizedBuffer({
-        buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-        assert: atom.assert, tabLength: 2,
-      })
-      tokenizedBuffer.setGrammar(atom.grammars.grammarForScopeName('source.js'))
+      tokenizedBuffer = new TokenizedBuffer({buffer, grammar: atom.grammars.grammarForScopeName('source.js'), tabLength: 2})
       startTokenizing(tokenizedBuffer)
 
     afterEach ->
@@ -282,11 +260,7 @@ describe "TokenizedBuffer", ->
 
       runs ->
         buffer = atom.project.bufferForPathSync('sample-with-tabs.coffee')
-        tokenizedBuffer = new TokenizedBuffer({
-          buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-          assert: atom.assert, tabLength: 2,
-        })
-        tokenizedBuffer.setGrammar(atom.grammars.grammarForScopeName('source.coffee'))
+        tokenizedBuffer = new TokenizedBuffer({buffer, grammar: atom.grammars.grammarForScopeName('source.coffee'), tabLength: 2})
         startTokenizing(tokenizedBuffer)
 
     afterEach ->
@@ -350,7 +324,6 @@ describe "TokenizedBuffer", ->
         expect(tokenizedHandler.callCount).toBe(1)
 
     it "retokenizes the buffer", ->
-
       waitsForPromise ->
         atom.packages.activatePackage('language-ruby-on-rails')
 
@@ -360,11 +333,7 @@ describe "TokenizedBuffer", ->
       runs ->
         buffer = atom.project.bufferForPathSync()
         buffer.setText "<div class='name'><%= User.find(2).full_name %></div>"
-        tokenizedBuffer = new TokenizedBuffer({
-          buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-          assert: atom.assert, tabLength: 2,
-        })
-        tokenizedBuffer.setGrammar(atom.grammars.selectGrammar('test.erb'))
+        tokenizedBuffer = new TokenizedBuffer({buffer, grammar: atom.grammars.selectGrammar('test.erb'), tabLength: 2})
         fullyTokenize(tokenizedBuffer)
 
         {tokens} = tokenizedBuffer.tokenizedLines[0]
@@ -385,11 +354,7 @@ describe "TokenizedBuffer", ->
 
     it "returns the correct token (regression)", ->
       buffer = atom.project.bufferForPathSync('sample.js')
-      tokenizedBuffer = new TokenizedBuffer({
-        buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-        assert: atom.assert, tabLength: 2,
-      })
-      tokenizedBuffer.setGrammar(atom.grammars.grammarForScopeName('source.js'))
+      tokenizedBuffer = new TokenizedBuffer({buffer, grammar: atom.grammars.grammarForScopeName('source.js'), tabLength: 2})
       fullyTokenize(tokenizedBuffer)
       expect(tokenizedBuffer.tokenForPosition([1, 0]).scopes).toEqual ["source.js"]
       expect(tokenizedBuffer.tokenForPosition([1, 1]).scopes).toEqual ["source.js"]
@@ -398,11 +363,7 @@ describe "TokenizedBuffer", ->
   describe ".bufferRangeForScopeAtPosition(selector, position)", ->
     beforeEach ->
       buffer = atom.project.bufferForPathSync('sample.js')
-      tokenizedBuffer = new TokenizedBuffer({
-        buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-        assert: atom.assert, tabLength: 2,
-      })
-      tokenizedBuffer.setGrammar(atom.grammars.grammarForScopeName('source.js'))
+      tokenizedBuffer = new TokenizedBuffer({buffer, grammar: atom.grammars.grammarForScopeName('source.js'), tabLength: 2})
       fullyTokenize(tokenizedBuffer)
 
     describe "when the selector does not match the token at the position", ->
@@ -421,11 +382,7 @@ describe "TokenizedBuffer", ->
   describe ".indentLevelForRow(row)", ->
     beforeEach ->
       buffer = atom.project.bufferForPathSync('sample.js')
-      tokenizedBuffer = new TokenizedBuffer({
-        buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-        assert: atom.assert, tabLength: 2,
-      })
-      tokenizedBuffer.setGrammar(atom.grammars.grammarForScopeName('source.js'))
+      tokenizedBuffer = new TokenizedBuffer({buffer, grammar: atom.grammars.grammarForScopeName('source.js'), tabLength: 2})
       fullyTokenize(tokenizedBuffer)
 
     describe "when the line is non-empty", ->
@@ -501,11 +458,7 @@ describe "TokenizedBuffer", ->
       buffer = atom.project.bufferForPathSync('sample.js')
       buffer.insert [10, 0], "  // multi-line\n  // comment\n  // block\n"
       buffer.insert [0, 0], "// multi-line\n// comment\n// block\n"
-      tokenizedBuffer = new TokenizedBuffer({
-        buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-        assert: atom.assert, tabLength: 2,
-      })
-      tokenizedBuffer.setGrammar(atom.grammars.grammarForScopeName('source.js'))
+      tokenizedBuffer = new TokenizedBuffer({buffer, grammar: atom.grammars.grammarForScopeName('source.js'), tabLength: 2})
       fullyTokenize(tokenizedBuffer)
 
     it "includes the first line of multi-line comments", ->
@@ -609,10 +562,7 @@ describe "TokenizedBuffer", ->
       spyOn(NullGrammar, 'tokenizeLine').andCallThrough()
       buffer = atom.project.bufferForPathSync('sample.will-use-the-null-grammar')
       buffer.setText('a\nb\nc')
-      tokenizedBuffer = new TokenizedBuffer({
-        buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-        assert: atom.assert, tabLength: 2
-      })
+      tokenizedBuffer = new TokenizedBuffer({buffer, tabLength: 2})
       tokenizeCallback = jasmine.createSpy('onDidTokenize')
       tokenizedBuffer.onDidTokenize(tokenizeCallback)
 
@@ -633,11 +583,7 @@ describe "TokenizedBuffer", ->
     describe "iterator", ->
       it "iterates over the syntactic scope boundaries", ->
         buffer = new TextBuffer(text: "var foo = 1 /*\nhello*/var bar = 2\n")
-        tokenizedBuffer = new TokenizedBuffer({
-          buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-          assert: atom.assert, tabLength: 2,
-        })
-        tokenizedBuffer.setGrammar(atom.grammars.selectGrammar(".js"))
+        tokenizedBuffer = new TokenizedBuffer({buffer, grammar: atom.grammars.grammarForScopeName("source.js"), tabLength: 2})
         fullyTokenize(tokenizedBuffer)
 
         iterator = tokenizedBuffer.buildIterator()
@@ -689,11 +635,7 @@ describe "TokenizedBuffer", ->
 
         runs ->
           buffer = new TextBuffer(text: "# hello\n# world")
-          tokenizedBuffer = new TokenizedBuffer({
-            buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-            assert: atom.assert, tabLength: 2,
-          })
-          tokenizedBuffer.setGrammar(atom.grammars.selectGrammar(".coffee"))
+          tokenizedBuffer = new TokenizedBuffer({buffer, grammar: atom.grammars.grammarForScopeName("source.coffee"), tabLength: 2})
           fullyTokenize(tokenizedBuffer)
 
           iterator = tokenizedBuffer.buildIterator()
@@ -722,11 +664,7 @@ describe "TokenizedBuffer", ->
         })
 
         buffer = new TextBuffer(text: 'start x\nend x\nx')
-        tokenizedBuffer = new TokenizedBuffer({
-          buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-          assert: atom.assert, tabLength: 2,
-        })
-        tokenizedBuffer.setGrammar(grammar)
+        tokenizedBuffer = new TokenizedBuffer({buffer, grammar, tabLength: 2})
         fullyTokenize(tokenizedBuffer)
 
         iterator = tokenizedBuffer.buildIterator()

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -91,28 +91,28 @@ describe "TokenizedBuffer", ->
 
     describe "on construction", ->
       it "tokenizes lines chunk at a time in the background", ->
-        line0 = tokenizedBuffer.tokenizedLineForRow(0)
+        line0 = tokenizedBuffer.tokenizedLines[0]
         expect(line0).toBe(undefined)
 
-        line11 = tokenizedBuffer.tokenizedLineForRow(11)
+        line11 = tokenizedBuffer.tokenizedLines[11]
         expect(line11).toBe(undefined)
 
         # tokenize chunk 1
         advanceClock()
-        expect(tokenizedBuffer.tokenizedLineForRow(0).ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.tokenizedLineForRow(4).ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.tokenizedLineForRow(5)).toBe(undefined)
+        expect(tokenizedBuffer.tokenizedLines[0].ruleStack?).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLines[4].ruleStack?).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLines[5]).toBe(undefined)
 
         # tokenize chunk 2
         advanceClock()
-        expect(tokenizedBuffer.tokenizedLineForRow(5).ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.tokenizedLineForRow(9).ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.tokenizedLineForRow(10)).toBe(undefined)
+        expect(tokenizedBuffer.tokenizedLines[5].ruleStack?).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLines[9].ruleStack?).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLines[10]).toBe(undefined)
 
         # tokenize last chunk
         advanceClock()
-        expect(tokenizedBuffer.tokenizedLineForRow(10).ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.tokenizedLineForRow(12).ruleStack?).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLines[10].ruleStack?).toBeTruthy()
+        expect(tokenizedBuffer.tokenizedLines[12].ruleStack?).toBeTruthy()
 
     describe "when the buffer is partially tokenized", ->
       beforeEach ->
@@ -149,8 +149,8 @@ describe "TokenizedBuffer", ->
         it "does not attempt to tokenize the lines in the change, and preserves the existing invalid row", ->
           expect(tokenizedBuffer.firstInvalidRow()).toBe 5
           buffer.setTextInRange([[6, 0], [7, 0]], "\n\n\n")
-          expect(tokenizedBuffer.tokenizedLineForRow(6)).toBeFalsy()
-          expect(tokenizedBuffer.tokenizedLineForRow(7)).toBeFalsy()
+          expect(tokenizedBuffer.tokenizedLines[6]).toBeUndefined()
+          expect(tokenizedBuffer.tokenizedLines[7]).toBeUndefined()
           expect(tokenizedBuffer.firstInvalidRow()).toBe 5
 
     describe "when the buffer is fully tokenized", ->
@@ -162,101 +162,101 @@ describe "TokenizedBuffer", ->
           it "updates tokens to reflect the change", ->
             buffer.setTextInRange([[0, 0], [2, 0]], "foo()\n7\n")
 
-            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[1]).toEqual(value: '(', scopes: ['source.js', 'meta.function-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: '7', scopes: ['source.js', 'constant.numeric.decimal.js'])
+            expect(tokenizedBuffer.tokenizedLines[0].tokens[1]).toEqual(value: '(', scopes: ['source.js', 'meta.function-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js'])
+            expect(tokenizedBuffer.tokenizedLines[1].tokens[0]).toEqual(value: '7', scopes: ['source.js', 'constant.numeric.decimal.js'])
             # line 2 is unchanged
-            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[1]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
+            expect(tokenizedBuffer.tokenizedLines[2].tokens[1]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
 
           describe "when the change invalidates the tokenization of subsequent lines", ->
             it "schedules the invalidated lines to be tokenized in the background", ->
               buffer.insert([5, 30], '/* */')
               buffer.insert([2, 0], '/*')
-              expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js']
+              expect(tokenizedBuffer.tokenizedLines[3].tokens[0].scopes).toEqual ['source.js']
 
               advanceClock()
-              expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-              expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-              expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+              expect(tokenizedBuffer.tokenizedLines[3].tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+              expect(tokenizedBuffer.tokenizedLines[4].tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+              expect(tokenizedBuffer.tokenizedLines[5].tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
 
           it "resumes highlighting with the state of the previous line", ->
             buffer.insert([0, 0], '/*')
             buffer.insert([5, 0], '*/')
 
             buffer.insert([1, 0], 'var ')
-            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLines[1].tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
 
         describe "when lines are both updated and removed", ->
           it "updates tokens to reflect the change", ->
             buffer.setTextInRange([[1, 0], [3, 0]], "foo()")
 
             # previous line 0 remains
-            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0]).toEqual(value: 'var', scopes: ['source.js', 'storage.type.var.js'])
+            expect(tokenizedBuffer.tokenizedLines[0].tokens[0]).toEqual(value: 'var', scopes: ['source.js', 'storage.type.var.js'])
 
             # previous line 3 should be combined with input to form line 1
-            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js', 'meta.function-call.js', 'entity.name.function.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[6]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.assignment.js'])
+            expect(tokenizedBuffer.tokenizedLines[1].tokens[0]).toEqual(value: 'foo', scopes: ['source.js', 'meta.function-call.js', 'entity.name.function.js'])
+            expect(tokenizedBuffer.tokenizedLines[1].tokens[6]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.assignment.js'])
 
             # lines below deleted regions should be shifted upward
-            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[1]).toEqual(value: 'while', scopes: ['source.js', 'keyword.control.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[1]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.assignment.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[1]).toEqual(value: '<', scopes: ['source.js', 'keyword.operator.comparison.js'])
+            expect(tokenizedBuffer.tokenizedLines[2].tokens[1]).toEqual(value: 'while', scopes: ['source.js', 'keyword.control.js'])
+            expect(tokenizedBuffer.tokenizedLines[3].tokens[1]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.assignment.js'])
+            expect(tokenizedBuffer.tokenizedLines[4].tokens[1]).toEqual(value: '<', scopes: ['source.js', 'keyword.operator.comparison.js'])
 
         describe "when the change invalidates the tokenization of subsequent lines", ->
           it "schedules the invalidated lines to be tokenized in the background", ->
             buffer.insert([5, 30], '/* */')
             buffer.setTextInRange([[2, 0], [3, 0]], '/*')
-            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js']
+            expect(tokenizedBuffer.tokenizedLines[2].tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
+            expect(tokenizedBuffer.tokenizedLines[3].tokens[0].scopes).toEqual ['source.js']
 
             advanceClock()
-            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLines[3].tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLines[4].tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
 
         describe "when lines are both updated and inserted", ->
           it "updates tokens to reflect the change", ->
             buffer.setTextInRange([[1, 0], [2, 0]], "foo()\nbar()\nbaz()\nquux()")
 
             # previous line 0 remains
-            expect(tokenizedBuffer.tokenizedLineForRow(0).tokens[0]).toEqual( value: 'var', scopes: ['source.js', 'storage.type.var.js'])
+            expect(tokenizedBuffer.tokenizedLines[0].tokens[0]).toEqual( value: 'var', scopes: ['source.js', 'storage.type.var.js'])
 
             # 3 new lines inserted
-            expect(tokenizedBuffer.tokenizedLineForRow(1).tokens[0]).toEqual(value: 'foo', scopes: ['source.js', 'meta.function-call.js', 'entity.name.function.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0]).toEqual(value: 'bar', scopes: ['source.js', 'meta.function-call.js', 'entity.name.function.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0]).toEqual(value: 'baz', scopes: ['source.js', 'meta.function-call.js', 'entity.name.function.js'])
+            expect(tokenizedBuffer.tokenizedLines[1].tokens[0]).toEqual(value: 'foo', scopes: ['source.js', 'meta.function-call.js', 'entity.name.function.js'])
+            expect(tokenizedBuffer.tokenizedLines[2].tokens[0]).toEqual(value: 'bar', scopes: ['source.js', 'meta.function-call.js', 'entity.name.function.js'])
+            expect(tokenizedBuffer.tokenizedLines[3].tokens[0]).toEqual(value: 'baz', scopes: ['source.js', 'meta.function-call.js', 'entity.name.function.js'])
 
             # previous line 2 is joined with quux() on line 4
-            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0]).toEqual(value: 'quux', scopes: ['source.js', 'meta.function-call.js', 'entity.name.function.js'])
-            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[4]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
+            expect(tokenizedBuffer.tokenizedLines[4].tokens[0]).toEqual(value: 'quux', scopes: ['source.js', 'meta.function-call.js', 'entity.name.function.js'])
+            expect(tokenizedBuffer.tokenizedLines[4].tokens[4]).toEqual(value: 'if', scopes: ['source.js', 'keyword.control.js'])
 
             # previous line 3 is pushed down to become line 5
-            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[3]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.assignment.js'])
+            expect(tokenizedBuffer.tokenizedLines[5].tokens[3]).toEqual(value: '=', scopes: ['source.js', 'keyword.operator.assignment.js'])
 
         describe "when the change invalidates the tokenization of subsequent lines", ->
           it "schedules the invalidated lines to be tokenized in the background", ->
             buffer.insert([5, 30], '/* */')
             buffer.insert([2, 0], '/*\nabcde\nabcder')
-            expect(tokenizedBuffer.tokenizedLineForRow(2).tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(3).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(4).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].scopes).toEqual ['source.js']
+            expect(tokenizedBuffer.tokenizedLines[2].tokens[0].scopes).toEqual ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
+            expect(tokenizedBuffer.tokenizedLines[3].tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLines[4].tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLines[5].tokens[0].scopes).toEqual ['source.js']
 
             advanceClock() # tokenize invalidated lines in background
-            expect(tokenizedBuffer.tokenizedLineForRow(5).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(6).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(7).tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
-            expect(tokenizedBuffer.tokenizedLineForRow(8).tokens[0].scopes).not.toBe ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLines[5].tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLines[6].tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLines[7].tokens[0].scopes).toEqual ['source.js', 'comment.block.js']
+            expect(tokenizedBuffer.tokenizedLines[8].tokens[0].scopes).not.toBe ['source.js', 'comment.block.js']
 
       describe "when there is an insertion that is larger than the chunk size", ->
         it "tokenizes the initial chunk synchronously, then tokenizes the remaining lines in the background", ->
           commentBlock = _.multiplyString("// a comment\n", tokenizedBuffer.chunkSize + 2)
           buffer.insert([0, 0], commentBlock)
-          expect(tokenizedBuffer.tokenizedLineForRow(0).ruleStack?).toBeTruthy()
-          expect(tokenizedBuffer.tokenizedLineForRow(4).ruleStack?).toBeTruthy()
-          expect(tokenizedBuffer.tokenizedLineForRow(5)).toBeFalsy()
+          expect(tokenizedBuffer.tokenizedLines[0].ruleStack?).toBeTruthy()
+          expect(tokenizedBuffer.tokenizedLines[4].ruleStack?).toBeTruthy()
+          expect(tokenizedBuffer.tokenizedLines[5]).toBeUndefined()
 
           advanceClock()
-          expect(tokenizedBuffer.tokenizedLineForRow(5).ruleStack?).toBeTruthy()
-          expect(tokenizedBuffer.tokenizedLineForRow(6).ruleStack?).toBeTruthy()
+          expect(tokenizedBuffer.tokenizedLines[5].ruleStack?).toBeTruthy()
+          expect(tokenizedBuffer.tokenizedLines[6].ruleStack?).toBeTruthy()
 
       it "does not break out soft tabs across a scope boundary", ->
         waitsForPromise ->
@@ -366,7 +366,7 @@ describe "TokenizedBuffer", ->
         tokenizedBuffer.setGrammar(atom.grammars.selectGrammar('test.erb'))
         fullyTokenize(tokenizedBuffer)
 
-        {tokens} = tokenizedBuffer.tokenizedLineForRow(0)
+        {tokens} = tokenizedBuffer.tokenizedLines[0]
         expect(tokens[0]).toEqual value: "<div class='name'>", scopes: ["text.html.ruby"]
 
       waitsForPromise ->
@@ -374,7 +374,7 @@ describe "TokenizedBuffer", ->
 
       runs ->
         fullyTokenize(tokenizedBuffer)
-        {tokens} = tokenizedBuffer.tokenizedLineForRow(0)
+        {tokens} = tokenizedBuffer.tokenizedLines[0]
         expect(tokens[0]).toEqual value: '<', scopes: ["text.html.ruby", "meta.tag.block.any.html", "punctuation.definition.tag.begin.html"]
 
   describe ".tokenForPosition(position)", ->
@@ -406,7 +406,7 @@ describe "TokenizedBuffer", ->
 
     describe "when the selector does not match the token at the position", ->
       it "returns a falsy value", ->
-        expect(tokenizedBuffer.bufferRangeForScopeAtPosition('.bogus', [0, 1])).toBeFalsy()
+        expect(tokenizedBuffer.bufferRangeForScopeAtPosition('.bogus', [0, 1])).toBeUndefined()
 
     describe "when the selector matches a single token at the position", ->
       it "returns the range covered by the token", ->
@@ -466,7 +466,7 @@ describe "TokenizedBuffer", ->
 
         buffer.insert([12, 0], '  ')
         expect(tokenizedBuffer.indentLevelForRow(13)).toBe 2
-        expect(tokenizedBuffer.tokenizedLineForRow(14)).not.toBeDefined()
+        expect(tokenizedBuffer.tokenizedLines[14]).not.toBeDefined()
 
       it "updates the indentLevel of empty lines surrounding a change that inserts lines", ->
         buffer.insert([7, 0], '\n\n')
@@ -585,9 +585,9 @@ describe "TokenizedBuffer", ->
       expect(tokenizeCallback.callCount).toBe 1
       expect(atom.grammars.nullGrammar.tokenizeLine.callCount).toBe 0
 
-      expect(tokenizedBuffer.tokenizedLineForRow(0)).toBeFalsy()
-      expect(tokenizedBuffer.tokenizedLineForRow(1)).toBeFalsy()
-      expect(tokenizedBuffer.tokenizedLineForRow(2)).toBeFalsy()
+      expect(tokenizedBuffer.tokenizedLines[0]).toBeUndefined()
+      expect(tokenizedBuffer.tokenizedLines[1]).toBeUndefined()
+      expect(tokenizedBuffer.tokenizedLines[2]).toBeUndefined()
 
   describe "text decoration layer API", ->
     describe "iterator", ->

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -1,3 +1,4 @@
+NullGrammar = require '../src/null-grammar'
 TokenizedBuffer = require '../src/tokenized-buffer'
 {Point} = TextBuffer = require 'text-buffer'
 _ = require 'underscore-plus'
@@ -568,26 +569,29 @@ describe "TokenizedBuffer", ->
       expect(tokenizedBuffer.isFoldableAtRow(8)).toBe false
 
   describe "when the buffer is configured with the null grammar", ->
-    it "uses the placeholder tokens and does not actually tokenize using the grammar", ->
-      spyOn(atom.grammars.nullGrammar, 'tokenizeLine').andCallThrough()
+    it "does not actually tokenize using the grammar", ->
+      spyOn(NullGrammar, 'tokenizeLine').andCallThrough()
       buffer = atom.project.bufferForPathSync('sample.will-use-the-null-grammar')
       buffer.setText('a\nb\nc')
-
       tokenizedBuffer = new TokenizedBuffer({
         buffer, grammarRegistry: atom.grammars, packageManager: atom.packages,
-        assert: atom.assert, tabLength: 2,
+        assert: atom.assert, tabLength: 2
       })
       tokenizeCallback = jasmine.createSpy('onDidTokenize')
       tokenizedBuffer.onDidTokenize(tokenizeCallback)
 
-      fullyTokenize(tokenizedBuffer)
-
-      expect(tokenizeCallback.callCount).toBe 1
-      expect(atom.grammars.nullGrammar.tokenizeLine.callCount).toBe 0
-
       expect(tokenizedBuffer.tokenizedLines[0]).toBeUndefined()
       expect(tokenizedBuffer.tokenizedLines[1]).toBeUndefined()
       expect(tokenizedBuffer.tokenizedLines[2]).toBeUndefined()
+      expect(tokenizeCallback.callCount).toBe(0)
+      expect(NullGrammar.tokenizeLine).not.toHaveBeenCalled()
+
+      fullyTokenize(tokenizedBuffer)
+      expect(tokenizedBuffer.tokenizedLines[0]).toBeUndefined()
+      expect(tokenizedBuffer.tokenizedLines[1]).toBeUndefined()
+      expect(tokenizedBuffer.tokenizedLines[2]).toBeUndefined()
+      expect(tokenizeCallback.callCount).toBe(0)
+      expect(NullGrammar.tokenizeLine).not.toHaveBeenCalled()
 
   describe "text decoration layer API", ->
     describe "iterator", ->

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -93,22 +93,22 @@ describe "TokenizedBuffer", ->
     describe "on construction", ->
       it "tokenizes lines chunk at a time in the background", ->
         line0 = tokenizedBuffer.tokenizedLines[0]
-        expect(line0).toBe(undefined)
+        expect(line0).toBeUndefined()
 
         line11 = tokenizedBuffer.tokenizedLines[11]
-        expect(line11).toBe(undefined)
+        expect(line11).toBeUndefined()
 
         # tokenize chunk 1
         advanceClock()
         expect(tokenizedBuffer.tokenizedLines[0].ruleStack?).toBeTruthy()
         expect(tokenizedBuffer.tokenizedLines[4].ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.tokenizedLines[5]).toBe(undefined)
+        expect(tokenizedBuffer.tokenizedLines[5]).toBeUndefined()
 
         # tokenize chunk 2
         advanceClock()
         expect(tokenizedBuffer.tokenizedLines[5].ruleStack?).toBeTruthy()
         expect(tokenizedBuffer.tokenizedLines[9].ruleStack?).toBeTruthy()
-        expect(tokenizedBuffer.tokenizedLines[10]).toBe(undefined)
+        expect(tokenizedBuffer.tokenizedLines[10]).toBeUndefined()
 
         # tokenize last chunk
         advanceClock()

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -148,19 +148,19 @@ class LanguageMode
     rowRange
 
   rowRangeForCommentAtBufferRow: (bufferRow) ->
-    return unless @editor.tokenizedBuffer.tokenizedLineForRow(bufferRow).isComment()
+    return unless @editor.tokenizedBuffer.tokenizedLines[bufferRow]?.isComment()
 
     startRow = bufferRow
     endRow = bufferRow
 
     if bufferRow > 0
       for currentRow in [bufferRow-1..0] by -1
-        break unless @editor.tokenizedBuffer.tokenizedLineForRow(currentRow).isComment()
+        break unless @editor.tokenizedBuffer.tokenizedLines[currentRow]?.isComment()
         startRow = currentRow
 
     if bufferRow < @buffer.getLastRow()
       for currentRow in [bufferRow+1..@buffer.getLastRow()] by 1
-        break unless @editor.tokenizedBuffer.tokenizedLineForRow(currentRow).isComment()
+        break unless @editor.tokenizedBuffer.tokenizedLines[currentRow]?.isComment()
         endRow = currentRow
 
     return [startRow, endRow] if startRow isnt endRow
@@ -189,7 +189,7 @@ class LanguageMode
   # row is a comment.
   isLineCommentedAtBufferRow: (bufferRow) ->
     return false unless 0 <= bufferRow <= @editor.getLastBufferRow()
-    @editor.tokenizedBuffer.tokenizedLineForRow(bufferRow).isComment()
+    @editor.tokenizedBuffer.tokenizedLines[bufferRow]?.isComment()
 
   # Find a row range for a 'paragraph' around specified bufferRow. A paragraph
   # is a block of text bounded by and empty line or a block of text that is not
@@ -246,10 +246,10 @@ class LanguageMode
     @suggestedIndentForTokenizedLineAtBufferRow(bufferRow, line, tokenizedLine, options)
 
   suggestedIndentForLineAtBufferRow: (bufferRow, line, options) ->
-    if @editor.largeFileMode or @editor.tokenizedBuffer.grammar is NullGrammar
-      tokenizedLine = @editor.tokenizedBuffer.buildPlaceholderTokenizedLineForRowWithText(bufferRow, line)
-    else
-      tokenizedLine = @editor.tokenizedBuffer.buildTokenizedLineForRowWithText(bufferRow, line)
+    tokenizedLine = @editor.tokenizedBuffer.buildTokenizedLineForRowWithText(bufferRow, line)
+    iterator = tokenizedLine.getTokenIterator()
+    iterator.next()
+    scopeDescriptor = new ScopeDescriptor(scopes: iterator.getScopes())
     @suggestedIndentForTokenizedLineAtBufferRow(bufferRow, line, tokenizedLine, options)
 
   suggestedIndentForTokenizedLineAtBufferRow: (bufferRow, line, tokenizedLine, options) ->

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -247,9 +247,6 @@ class LanguageMode
 
   suggestedIndentForLineAtBufferRow: (bufferRow, line, options) ->
     tokenizedLine = @editor.tokenizedBuffer.buildTokenizedLineForRowWithText(bufferRow, line)
-    iterator = tokenizedLine.getTokenIterator()
-    iterator.next()
-    scopeDescriptor = new ScopeDescriptor(scopes: iterator.getScopes())
     @suggestedIndentForTokenizedLineAtBufferRow(bufferRow, line, tokenizedLine, options)
 
   suggestedIndentForTokenizedLineAtBufferRow: (bufferRow, line, tokenizedLine, options) ->

--- a/src/null-grammar.js
+++ b/src/null-grammar.js
@@ -2,7 +2,7 @@
 
 import {Disposable} from 'event-kit'
 
-export default Object.freeze({
+export default {
   name: 'Null Grammar',
   scopeName: 'text.plain.null-grammar',
   scopeForId (id) {
@@ -35,6 +35,6 @@ export default Object.freeze({
   onDidUpdate (callback) {
     return new Disposable(noop)
   }
-})
+}
 
 function noop () {}

--- a/src/null-grammar.js
+++ b/src/null-grammar.js
@@ -4,7 +4,34 @@ import {Disposable} from 'event-kit'
 
 export default Object.freeze({
   name: 'Null Grammar',
-  scopeName: 'text.plain',
+  scopeName: 'text.plain.null-grammar',
+  scopeForId (id) {
+    if (id === -1 || id === -2) {
+      return this.scopeName
+    } else {
+      return null
+    }
+  },
+  startIdForScope (scopeName) {
+    if (scopeName === this.scopeName) {
+      return -1
+    } else {
+      return null
+    }
+  },
+  endIdForScope (scopeName) {
+    if (scopeName === this.scopeName) {
+      return -2
+    } else {
+      return null
+    }
+  },
+  tokenizeLine (text) {
+    return {
+      tags: [this.startIdForScope(this.scopeName), text.length, this.endIdForScope(this.scopeName)],
+      ruleStack: null
+    }
+  },
   onDidUpdate (callback) {
     return new Disposable(noop)
   }

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2868,7 +2868,7 @@ class TextEditor extends Model
   # whitespace.
   usesSoftTabs: ->
     for bufferRow in [0..@buffer.getLastRow()]
-      continue if @tokenizedBuffer.tokenizedLineForRow(bufferRow)?.isComment()
+      continue if @tokenizedBuffer.tokenizedLines[bufferRow]?.isComment()
 
       line = @buffer.lineForRow(bufferRow)
       return true  if line[0] is ' '

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2868,7 +2868,7 @@ class TextEditor extends Model
   # whitespace.
   usesSoftTabs: ->
     for bufferRow in [0..@buffer.getLastRow()]
-      continue if @tokenizedBuffer.tokenizedLineForRow(bufferRow).isComment()
+      continue if @tokenizedBuffer.tokenizedLineForRow(bufferRow)?.isComment()
 
       line = @buffer.lineForRow(bufferRow)
       return true  if line[0] is ' '

--- a/src/tokenized-buffer-iterator.coffee
+++ b/src/tokenized-buffer-iterator.coffee
@@ -13,11 +13,10 @@ class TokenizedBufferIterator
     @tagIndex = null
 
     currentLine = @tokenizedBuffer.tokenizedLineForRow(position.row)
-    @currentLineLength = currentLine.text.length
-    @currentLineOpenTags = currentLine.openScopes
     @currentTags = currentLine.tags
+    @currentLineOpenTags = currentLine.openScopes
+    @currentLineLength = currentLine.text.length
     @containingTags = @currentLineOpenTags.map (id) => @tokenizedBuffer.grammar.scopeForId(id)
-
     currentColumn = 0
 
     for tag, index in @currentTags

--- a/src/tokenized-buffer-iterator.coffee
+++ b/src/tokenized-buffer-iterator.coffee
@@ -1,5 +1,7 @@
 {Point} = require 'text-buffer'
 
+EMPTY = Object.freeze([])
+
 module.exports =
 class TokenizedBufferIterator
   constructor: (@tokenizedBuffer) ->
@@ -12,11 +14,17 @@ class TokenizedBufferIterator
     @closeTags = []
     @tagIndex = null
 
-    currentLine = @tokenizedBuffer.tokenizedLineForRow(position.row)
-    @currentTags = currentLine.tags
-    @currentLineOpenTags = currentLine.openScopes
-    @currentLineLength = currentLine.text.length
-    @containingTags = @currentLineOpenTags.map (id) => @tokenizedBuffer.grammar.scopeForId(id)
+    if currentLine = @tokenizedBuffer.tokenizedLineForRow(position.row)
+      @currentTags = currentLine.tags
+      @currentLineOpenTags = currentLine.openScopes
+      @currentLineLength = currentLine.text.length
+      @containingTags = @currentLineOpenTags.map (id) => @tokenizedBuffer.grammar.scopeForId(id)
+    else
+      @currentTags = EMPTY
+      @currentLineOpenTags = EMPTY
+      @currentLineLength = @tokenizedBuffer.buffer.lineLengthForRow(position.row)
+      @containingTags = []
+
     currentColumn = 0
 
     for tag, index in @currentTags

--- a/src/tokenized-buffer-iterator.coffee
+++ b/src/tokenized-buffer-iterator.coffee
@@ -1,7 +1,5 @@
 {Point} = require 'text-buffer'
 
-EMPTY = Object.freeze([])
-
 module.exports =
 class TokenizedBufferIterator
   constructor: (@tokenizedBuffer) ->
@@ -14,16 +12,11 @@ class TokenizedBufferIterator
     @closeTags = []
     @tagIndex = null
 
-    if currentLine = @tokenizedBuffer.tokenizedLineForRow(position.row)
-      @currentTags = currentLine.tags
-      @currentLineOpenTags = currentLine.openScopes
-      @currentLineLength = currentLine.text.length
-      @containingTags = @currentLineOpenTags.map (id) => @tokenizedBuffer.grammar.scopeForId(id)
-    else
-      @currentTags = EMPTY
-      @currentLineOpenTags = EMPTY
-      @currentLineLength = @tokenizedBuffer.buffer.lineLengthForRow(position.row)
-      @containingTags = []
+    currentLine = @tokenizedBuffer.tokenizedLineForRow(position.row)
+    @currentLineLength = currentLine.text.length
+    @currentLineOpenTags = currentLine.openScopes
+    @currentTags = currentLine.tags
+    @containingTags = @currentLineOpenTags.map (id) => @tokenizedBuffer.grammar.scopeForId(id)
 
     currentColumn = 0
 

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -357,18 +357,16 @@ class TokenizedBuffer extends Model
   scopeDescriptorForPosition: (position) ->
     {row, column} = @buffer.clipPosition(Point.fromObject(position))
 
-    if iterator = @tokenizedLineForRow(row)?.getTokenIterator()
-      while iterator.next()
-        if iterator.getBufferEnd() > column
-          scopes = iterator.getScopes()
-          break
-
-      # rebuild scope of last token if we iterated off the end
-      unless scopes?
+    iterator = @tokenizedLineForRow(row).getTokenIterator()
+    while iterator.next()
+      if iterator.getBufferEnd() > column
         scopes = iterator.getScopes()
-        scopes.push(iterator.getScopeEnds().reverse()...)
-    else
-      scopes = []
+        break
+
+    # rebuild scope of last token if we iterated off the end
+    unless scopes?
+      scopes = iterator.getScopes()
+      scopes.push(iterator.getScopeEnds().reverse()...)
 
     new ScopeDescriptor({scopes})
 

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -269,14 +269,8 @@ class TokenizedBuffer extends Model
       else
         text = @buffer.lineForRow(bufferRow)
         lineEnding = @buffer.lineEndingForRow(bufferRow)
-        tags = [
-          @grammar.startIdForScope(@grammar.scopeName),
-          text.length,
-          @grammar.endIdForScope(@grammar.scopeName)
-        ]
+        tags = [@grammar.startIdForScope(@grammar.scopeName), text.length, @grammar.endIdForScope(@grammar.scopeName)]
         @tokenizedLines[bufferRow] = new TokenizedLine({openScopes: [], text, tags, lineEnding, @tokenIterator})
-    else
-      null
 
   tokenizedLinesForRows: (startRow, endRow) ->
     for row in [startRow..endRow] by 1

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -120,7 +120,7 @@ class TokenizedBuffer extends Model
   tokenizeNextChunk: ->
     # Short circuit null grammar which can just use the placeholder tokens
     if @grammar.name is 'Null Grammar' and @firstInvalidRow()?
-      @tokenizedLines = @buildPlaceholderTokenizedLinesForRows(0, @buffer.getLastRow())
+      @tokenizedLines = new Array(@buffer.getLineCount())
       @invalidRows = []
       @markTokenizationComplete()
       return
@@ -194,7 +194,8 @@ class TokenizedBuffer extends Model
     @updateInvalidRows(start, end, delta)
     previousEndStack = @stackForRow(end) # used in spill detection below
     if @largeFileMode or @grammar.name is 'Null Grammar'
-      newTokenizedLines = @buildPlaceholderTokenizedLinesForRows(start, end + delta)
+      lineCount = ((end + delta) - start) + 1
+      newTokenizedLines = new Array(lineCount)
     else
       newTokenizedLines = @buildTokenizedLinesForRows(start, end + delta, @stackForRow(start - 1), @openScopesForRow(start))
     _.spliceWithArray(@tokenizedLines, start, end - start + 1, newTokenizedLines)
@@ -252,9 +253,6 @@ class TokenizedBuffer extends Model
       @tokenizeInBackground()
 
     tokenizedLines
-
-  buildPlaceholderTokenizedLinesForRows: (startRow, endRow) ->
-    new Array(endRow - startRow + 1)
 
   buildTokenizedLineForRow: (row, ruleStack, openScopes) ->
     @buildTokenizedLineForRowWithText(row, @buffer.lineForRow(row), ruleStack, openScopes)


### PR DESCRIPTION
After merging https://github.com/atom/atom/pull/11414, we changed how we represent syntactic boundaries to use `TokenizedBufferIterator` instead. This approach allows us to not build placeholder lines eagerly whenever there is a buffer change or when instantiating a new `TokenizedBuffer`.

![screen shot 2016-10-14 at 15 34 23](https://cloud.githubusercontent.com/assets/482957/19391120/5f297048-922b-11e6-9de1-3df0ad35bcf4.png)

In reality, we still need to construct `TokenizedLine` instances when `TokenizedBuffer.prototype.tokenizedLineForRow` is called because we want to construct some synthetic null grammar boundaries so that `TokenizedBufferIterator` doesn't iterate till the end of the buffer (regression), and also because other packages are currently relying on that API. In practice this should be pretty cheap, because in the majority of the cases it happens only for lines that are currently on screen.
