### PR TITLE
Optimize menu sorting

### DIFF
--- a/src/menu-helpers.coffee
+++ b/src/menu-helpers.coffee
@@ -32,21 +32,18 @@ unmerge = (menu, item) ->
 
 findMatchingItemIndex = (menu, {type, label, submenu}) ->
   return -1 if type is 'separator'
+  normalizedLabel = normalizeLabel(label)
   for item, index in menu
-    if normalizeLabel(item.label) is normalizeLabel(label) and item.submenu? is submenu?
+    if item.normalizedLabel is normalizedLabel and item.submenu? is submenu?
       return index
   -1
 
 normalizeLabel = (label) ->
   return undefined unless label?
-
-  if process.platform is 'darwin'
-    label
-  else
-    label.replace(/\&/g, '')
+  label.replace(/&(?!&)/g, '') # Remove accelerators (& followed by anything not an &)
 
 cloneMenuItem = (item) ->
-  item = _.pick(item, 'type', 'label', 'enabled', 'visible', 'command', 'submenu', 'commandDetail', 'role')
+  item = _.pick(item, 'type', 'label', 'enabled', 'visible', 'command', 'submenu', 'commandDetail', 'role', 'normalizedLabel')
   if item.submenu?
     item.submenu = item.submenu.map (submenuItem) -> cloneMenuItem(submenuItem)
   item

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -88,6 +88,11 @@ class MenuManager
   # added menu items.
   add: (items) ->
     items = _.deepClone(items)
+
+    # Cache normalized labels for sorting
+    for item in items
+      item.normalizedLabel = MenuHelpers.normalizeLabel(item.label)
+
     @merge(@template, item) for item in items
     @update()
     new Disposable => @remove(items)
@@ -190,12 +195,12 @@ class MenuManager
       []
 
   sortPackagesMenu: ->
-    packagesMenu = _.find @template, ({label}) -> MenuHelpers.normalizeLabel(label) is 'Packages'
+    packagesMenu = _.find @template, ({label}) -> label.normalizedLabel is 'Packages'
     return unless packagesMenu?.submenu?
 
     packagesMenu.submenu.sort (item1, item2) ->
-      if item1.label and item2.label
-        MenuHelpers.normalizeLabel(item1.label).localeCompare(MenuHelpers.normalizeLabel(item2.label))
+      if item1.normalizedLabel and item2.normalizedLabel
+        item1.normalizedLabel.localeCompare(item2.normalizedLabel)
       else
         0
     @update()


### PR DESCRIPTION
This prevents the normalize function being called over and over again during sorting of menu items by caching it on its own reusable property (normalizedLabel)
