### PR TITLE
Exclude beginner issues from help wanted issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -533,4 +533,4 @@ Please open an issue on `atom/atom` if you have suggestions for new labels, and 
 [search-atom-org-label-needs-testing]: https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aatom+label%3Aneeds-testing
 
 [beginner]:https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3Abeginner+label%3Ahelp-wanted+user%3Aatom+sort%3Acomments-desc
-[help-wanted]:https://github.com/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted+user%3Aatom+sort%3Acomments-desc
+[help-wanted]:https://github.com/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted+user%3Aatom+sort%3Acomments-desc+-label%3Abeginner


### PR DESCRIPTION
Looking at https://github.com/atom/atom/blob/master/CONTRIBUTING.md#your-first-code-contribution I suggest the following changes:
1. Exclude beginner label from the help wanted search link. Help wanted without beginner currently is supposed to be more involved issues and we want to search for these exclusively.
2. Sort by reactions rather than comments. We don't want to encourage +1 comments.

Currently fixes 1. I am unsure how to fix 2 since we would have to search by multiple reactions combined.

/cc: @lee-dohm @iolsen 
