### PR TITLE
Fixes #11848 Moving line up without line ending

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -2693,6 +2693,22 @@ describe "TextEditor", ->
             expect(editor.isFoldedAtBufferRow(6)).toBeFalsy()
             expect(editor.lineTextForBufferRow(6)).toBe "    if (items.length <= 1) return items;"
 
+        describe "when the last line of selection does not end with a valid line ending", ->
+          it "appends line ending to last line and moves the lines spanned by the selection to the preceeding row", ->
+            expect(editor.lineTextForBufferRow(9)).toBe "  };"
+            expect(editor.lineTextForBufferRow(10)).toBe ""
+            expect(editor.lineTextForBufferRow(11)).toBe "  return sort(Array.apply(this, arguments));"
+            expect(editor.lineTextForBufferRow(12)).toBe "};"
+
+            editor.setSelectedBufferRange([[10, 0], [12, 2]])
+            editor.moveLineUp()
+
+            expect(editor.getSelectedBufferRange()).toEqual [[9, 0], [11, 2]]
+            expect(editor.lineTextForBufferRow(9)).toBe ""
+            expect(editor.lineTextForBufferRow(10)).toBe "  return sort(Array.apply(this, arguments));"
+            expect(editor.lineTextForBufferRow(11)).toBe "};"
+            expect(editor.lineTextForBufferRow(12)).toBe "  };"
+
       describe "when there are multiple selections", ->
         describe "when all the selections span different lines", ->
           describe "when there is no folds", ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1132,7 +1132,7 @@ class TextEditor extends Model
 
         # Delete lines spanned by selection and insert them on the preceding buffer row
         lines = @buffer.getTextInRange(linesRange)
-        lines += @buffer.lineEndingForRow(linesRange.end.row - 1) unless lines[lines.length - 1] is '\n'
+        lines += @buffer.lineEndingForRow(linesRange.end.row - 2) unless lines[lines.length - 1] is '\n'
         @buffer.delete(linesRange)
         @buffer.insert([precedingRow, 0], lines)
 


### PR DESCRIPTION
## Bug

Fixes the bug described in issue #11848

![move-line-up-bug](https://cloud.githubusercontent.com/assets/5964236/19289643/31871060-9068-11e6-89ad-055e0d2bb5d5.gif)
## Fix

From what I explored it looks like a previous dev has tried to fix this bug. Although because rows are 0 indexed, to select the penultimate row for the range it requires using `-2`. 

I wonder whether it's worth rewriting the line:

``` coffeescript
lines += '\n' unless lines[lines.length - 1] is '\n'
```

I've attempted to add a valid test. Suggestions to improve or better represent the test welcome 😸 

![move-line-up-fix](https://cloud.githubusercontent.com/assets/5964236/19289650/3aee8e58-9068-11e6-8fc9-9066c1306ebb.gif)
