### PR TITLE
Update atom.desktop.in

### DIFF
--- a/resources/linux/atom.desktop.in
+++ b/resources/linux/atom.desktop.in
@@ -6,5 +6,5 @@ Exec=<%= installDir %>/share/<%= appFileName %>/atom %F
 Icon=<%= iconPath %>
 Type=Application
 StartupNotify=true
-Categories=GNOME;GTK;Utility;TextEditor;Development;
-MimeType=text/plain;
+Categories=GTK;Utility;TextEditor;Development;
+MimeType=application/javascript;application/json;application/x-httpd-eruby;application/x-httpd-php;application/x-httpd-php3;application/x-httpd-php4;application/x-httpd-php5;application/x-ruby;application/x-bash;application/x-csh;application/x-sh;application/x-zsh;application/x-shellscript;application/x-sql;application/x-tcl;application/xhtml+xml;application/xml;application/xml-dtd;application/xslt+xml;text/coffeescript;text/css;text/html;text/plain;text/xml;text/xml-dtd;text/x-bash;text/x-c++;text/x-c++hdr;text/x-c++src;text/x-c;text/x-chdr;text/x-csh;text/x-csrc;text/x-dsrc;text/x-diff;text/x-go;text/x-java;text/x-java-source;text/x-makefile;text/x-markdown;text/x-objc;text/x-perl;text/x-php;text/x-python;text/x-ruby;text/x-sh;text/x-zsh;text/yaml;inode/directory;


### PR DESCRIPTION
Hi,

In this pull I am editing the `Categories` and `MimeType` fields, for these reasons respectively:
- Deleted the GNOME category as, as that's for GNOME core apps, which Atom is not.
- MimeType should include all default (i.e., with the default bundled packages) supported file types for the editor. Most importantly, it would be delightful if one could open up project folders with Atom using your file manager's context menu. 

Thanks for your time,
Brenton
