### PR TITLE
Preserve cursor position after editor:delete-line

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4763,6 +4763,11 @@ describe "TextEditor", ->
       expect(buffer.getLineCount()).toBe(1)
       expect(buffer.getText()).toBe('')
 
+    it "does not change cursor position after deletion", ->
+      initPos = editor.getLastCursor().getScreenPosition()
+      editor.deleteLine()
+      expect(editor.getLastCursor()).toBe(initPos)
+
     describe "when soft wrap is enabled", ->
       it "deletes the entire line that the cursor is on", ->
         editor.setSoftWrapped(true)

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -485,6 +485,7 @@ class Selection extends Model
   # is empty unless the selection spans multiple lines in which case all lines
   # are removed.
   deleteLine: ->
+    initPos = @cursor.getScreenPosition()
     if @isEmpty()
       start = @cursor.getScreenRow()
       range = @editor.bufferRowsForScreenRows(start, start + 1)
@@ -499,6 +500,7 @@ class Selection extends Model
       if end isnt @editor.buffer.getLastRow() and range.end.column is 0
         end--
       @editor.buffer.deleteRows(start, end)
+    @cursor.setScreenPosition(initPos)
 
   # Public: Joins the current line with the one below it. Lines will
   # be separated by a single space.


### PR DESCRIPTION
Hello! This is my first time contributing to atom, this PR fixes issue #12744 .

Resulting Behavior
![fixed](https://cloud.githubusercontent.com/assets/7445868/19396189/5510af92-9274-11e6-8251-cb30b7edf06e.gif)
