### PR TITLE
Build appropriate 32/64-bit version on Linux

### DIFF
--- a/script/lib/package-application.js
+++ b/script/lib/package-application.js
@@ -18,7 +18,12 @@ module.exports = function () {
     'app-bundle-id': 'com.github.atom',
     'app-copyright': `Copyright © 2014-${(new Date()).getFullYear()} GitHub, Inc. All rights reserved.`,
     'app-version': CONFIG.appMetadata.version,
-    'arch': process.platform === 'win32' ? 'ia32' : 'x64',
+    'arch': (() => {
+      if (process.platform === 'linux') {
+        return process.arch
+      } else {
+        return process.platform === 'win32' ? 'ia32' : 'x64'
+      }})(),
     'asar': {unpack: buildAsarUnpackGlobExpression()},
     'build-version': CONFIG.appMetadata.version,
     'download': {cache: CONFIG.electronDownloadPath},


### PR DESCRIPTION
I don't know if the fixation of the architecture on non linux platforms makes any sense (line 25). Maybe simply 'arch': process.arch is the right way to go. Can't test it on my linux machine.

Fixes #12972
