### PR TITLE
add new pane switch events for MRU UI

### DIFF
--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -234,6 +234,39 @@ class Pane extends Model
   onDidChangeActiveItem: (callback) ->
     @emitter.on 'did-change-active-item', callback
 
+  # Public: Invoke the given callback when {::activateNextRecentlyUsedItem}
+  # has been called, either initiating or continuing a forward MRU traversal of
+  # pane items.
+  #
+  # * `callback` {Function} to be called with when the active item changes.
+  #   * `nextRecentlyUsedItem` The next MRU item, now being set active
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onChooseNextMRUItem: (callback) ->
+    @emitter.on 'choose-next-mru-item', callback
+
+  # Public: Invoke the given callback when {::activatePreviousRecentlyUsedItem}
+  # has been called, either initiating or continuing a reverse MRU traversal of
+  # pane items.
+  #
+  # * `callback` {Function} to be called with when the active item changes.
+  #   * `previousRecentlyUsedItem` The previous MRU item, now being set active
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onChooseLastMRUItem: (callback) ->
+    @emitter.on 'choose-last-mru-item', callback
+
+  # Public: Invoke the given callback when {::moveActiveItemToTopOfStack}
+  # has been called, terminating an MRU traversal of pane items and moving the
+  # current active item to the top of the stack. Typically bound to a modifier
+  # (e.g. CTRL) key up event.
+  #
+  # * `callback` {Function} to be called with when the MRU traversal is done.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDoneChoosingMRUItem: (callback) ->
+    @emitter.on 'done-choosing-mru-item', callback
+
   # Public: Invoke the given callback with the current and future values of
   # {::getActiveItem}.
   #
@@ -334,6 +367,7 @@ class Pane extends Model
       @itemStackIndex = @itemStack.length if @itemStackIndex is 0
       @itemStackIndex = @itemStackIndex - 1
       nextRecentlyUsedItem = @itemStack[@itemStackIndex]
+      @emitter.emit 'choose-next-mru-item', nextRecentlyUsedItem
       @setActiveItem(nextRecentlyUsedItem, modifyStack: false)
 
   # Makes the previous item in the itemStack active.
@@ -343,12 +377,15 @@ class Pane extends Model
         @itemStackIndex = -1
       @itemStackIndex = @itemStackIndex + 1
       previousRecentlyUsedItem = @itemStack[@itemStackIndex]
+      @emitter.emit 'choose-last-mru-item', previousRecentlyUsedItem
       @setActiveItem(previousRecentlyUsedItem, modifyStack: false)
 
   # Moves the active item to the end of the itemStack once the ctrl key is lifted
   moveActiveItemToTopOfStack: ->
     delete @itemStackIndex
     @addItemToStack(@activeItem)
+    @emitter.emit 'done-choosing-mru-item'
+
 
   # Public: Makes the next item active.
   activateNextItem: ->


### PR DESCRIPTION
New pane events to enable a list view of the MRU tab stack: https://github.com/atom/tabs/pull/388.

Part of the fix for https://github.com/atom/atom/issues/11035.
Requires https://github.com/atom/atom-keymap/pull/156 to work right.
