### PR TITLE
Add language-nlf to deprecated packages

### DIFF
--- a/script/deprecated-packages.json
+++ b/script/deprecated-packages.json
@@ -866,6 +866,10 @@
     "hasDeprecations": true,
     "latestHasDeprecations": true
   },
+  "language-nlf": {
+    "hasAlternative": true,
+    "alternative": "language-nsis"
+  },
   "language-rspec": {
     "version": "<=0.2.1",
     "hasDeprecations": true,


### PR DESCRIPTION
All features of `language-nlf` have been merged into `language-nsis`. The former will no longer be updated.
