### PR TITLE
macOS: Let atom.sh find itself when run from an .app

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -55,7 +55,12 @@ if [ $EXPECT_OUTPUT ]; then
 fi
 
 if [ $OS == 'Mac' ]; then
-  ATOM_APP="$(dirname "$(dirname "$(dirname "$(dirname "$(readlink "$0")")")")")"
+  if [ -L "$0" ]; then
+    SCRIPT="$(readlink "$0")"
+  else
+    SCRIPT="$0"
+  fi
+  ATOM_APP="$(dirname "$(dirname "$(dirname "$(dirname "$SCRIPT")")")")"
   if [ "$ATOM_APP" == . ]; then
     unset ATOM_APP
   else

--- a/atom.sh
+++ b/atom.sh
@@ -55,11 +55,17 @@ if [ $EXPECT_OUTPUT ]; then
 fi
 
 if [ $OS == 'Mac' ]; then
+  ATOM_APP="$(dirname "$(dirname "$(dirname "$(dirname "$(readlink "$0")")")")")"
+  if [ "$ATOM_APP" == . ]; then
+    unset ATOM_APP
+  else
+    ATOM_PATH="$(dirname "$ATOM_APP")"
+    ATOM_APP_NAME="$(basename "$ATOM_APP")"
+  fi
+
   if [ -n "$BETA_VERSION" ]; then
-    ATOM_APP_NAME="Atom Beta.app"
     ATOM_EXECUTABLE_NAME="Atom Beta"
   else
-    ATOM_APP_NAME="Atom.app"
     ATOM_EXECUTABLE_NAME="Atom"
   fi
 


### PR DESCRIPTION
**Problem** This patch is needed because `node-gyp` doesn't work with a space in `Atom Beta.app` -> renamed to `Atom-Beta.app`. This error occurs:

```
Cannot locate Atom.app, it is usually located in /Applications. Set the ATOM_PATH environment variable to the directory containing Atom.app.
```

**Use case** Developers/others want to multiple versions of Atom side-by-side.

**Solution** When launched from a Mac .app, a valid, symlinked `atom.sh` -> `atom`/`atom-beta` will always be contained in it's .app. This also works when a different `atom-something` symlink points to another atom.sh in an .app.
