### PR TITLE
Change editor:duplicate-lines to only duplicate once per line

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -1279,6 +1279,7 @@ class TextEditor extends Model
   # Duplicate the most recent cursor's current line.
   duplicateLines: ->
     @transact =>
+      @processedRanges = {}
       for selection in @getSelectionsOrderedByBufferPosition().reverse()
         selectedBufferRange = selection.getBufferRange()
         if selection.isEmpty()
@@ -1287,13 +1288,18 @@ class TextEditor extends Model
 
         [startRow, endRow] = selection.getBufferRowRange()
         endRow++
+  
+        # If we already processed a selection in the current line, don't reinsert the line again.
+        @rangeKey = "#{startRow}, #{endRow}"
+        if @processedRanges[@rangeKey] is undefined
+          intersectingFolds = @displayLayer.foldsIntersectingBufferRange([[startRow, 0], [endRow, 0]])
+          rangeToDuplicate = [[startRow, 0], [endRow, 0]]
+          textToDuplicate = @getTextInBufferRange(rangeToDuplicate)
+          textToDuplicate = '\n' + textToDuplicate if endRow > @getLastBufferRow()
+          @buffer.insert([endRow, 0], textToDuplicate)
+          @processedRanges[@rangeKey] = 1
 
-        intersectingFolds = @displayLayer.foldsIntersectingBufferRange([[startRow, 0], [endRow, 0]])
-        rangeToDuplicate = [[startRow, 0], [endRow, 0]]
-        textToDuplicate = @getTextInBufferRange(rangeToDuplicate)
-        textToDuplicate = '\n' + textToDuplicate if endRow > @getLastBufferRow()
-        @buffer.insert([endRow, 0], textToDuplicate)
-
+        # Whether or not we skipped duplicating the line, make sure the new line has the right selection.
         delta = endRow - startRow
         selection.setBufferRange(selectedBufferRange.translate([delta, 0]))
         for fold in intersectingFolds


### PR DESCRIPTION
Adds a fix to only duplicate a line once, no matter how many selections exist on the same line. The selections are set correctly on the duplicated line.
![anim](https://cloud.githubusercontent.com/assets/416212/19617150/e1b120bc-97dd-11e6-8a75-3ba4d4c7fc2e.gif)

Fixes https://github.com/atom/atom/issues/12927