### PR TITLE
Capitalize save in button label so keybindings work

### DIFF
--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -583,7 +583,7 @@ class Pane extends Model
       chosen = @applicationDelegate.confirm
         message: message
         detailedMessage: "Your changes will be lost if you close this item without saving."
-        buttons: [saveButtonText, "Cancel", "Don't save"]
+        buttons: [saveButtonText, "Cancel", "Don't Save"]
       switch chosen
         when 0 then saveFn(item, saveError)
         when 1 then false


### PR DESCRIPTION
Specifying the button label as `Don't Save` instead of `Don't save` allows the keybindings of `cmd-d` and `cmd-delete` to be used on macOS to select this button.

Looks like this might have regressed in https://github.com/atom/atom/commit/4e9048d22de5fce1fb4bce20515fcee96aae786d#diff-1a7d1dda35d8e7ed3ad35b9a9fd2f134L596 and https://github.com/atom/atom/commit/4e9048d22de5fce1fb4bce20515fcee96aae786d#diff-1a7d1dda35d8e7ed3ad35b9a9fd2f134R584

Closes https://github.com/atom/atom/issues/12277

/cc @dgraham 
