### PR TITLE
Remove --harmony JavaScript flag

### DIFF
--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -93,7 +93,6 @@ class AtomApplication
     @atomProtocolHandler = new AtomProtocolHandler(@resourcePath, @safeMode)
 
     @listenForArgumentsFromNewProcess()
-    @setupJavaScriptArguments()
     @setupDockMenu()
 
     @launch(options)
@@ -200,10 +199,6 @@ class AtomApplication
         # check and the call to unlink sync. This occurred occasionally on CI
         # which is why this check is here.
         throw error unless error.code is 'ENOENT'
-
-  # Configures required javascript environment flags.
-  setupJavaScriptArguments: ->
-    app.commandLine.appendSwitch 'js-flags', '--harmony'
 
   # Registers basic application commands, non-idempotent.
   handleEvents: ->


### PR DESCRIPTION
### Description of the Change

Because the newer versions of Chromium (v52 in Atom v1.12.0-beta4) we're using in the current versions of Atom support all of the critical pieces of ES6, the `--harmony` flag is no longer necessary. Since the `--harmony` flag was the only flag set in that function, I also removed the `setupJavascriptArguments` function and the one call to the function.
### Alternate Designs

v1.4.x of Electron, which is based on Chromium v53, doesn't suffer from the bug that the `--harmony` flag exposes. Our [Electron v1.4 update PR](https://github.com/atom/atom/pull/12696) is still not quite ready to merge, so we decided to just remove the flag.
### Benefits

People won't experience random crashes when executing async code in Atom v1.12.x and above.
### Possible Drawbacks

There may be some packages that rely on features provided by `--harmony` that aren't available in the vanilla JavaScript support in Chromium or less likely aren't available in Atom's Babel support.
### Applicable Issues

Fixes #13073 
