### PR TITLE
Introduce follow through behavior for tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "one-light-syntax": "1.6.0",
     "solarized-dark-syntax": "1.1.1",
     "solarized-light-syntax": "1.1.1",
-    "about": "1.7.0",
+    "about": "1.7.1",
     "archive-view": "0.62.0",
     "autocomplete-atom-api": "0.10.0",
     "autocomplete-css": "0.14.1",

--- a/spec/tooltip-manager-spec.coffee
+++ b/spec/tooltip-manager-spec.coffee
@@ -1,3 +1,4 @@
+{CompositeDisposable} = require 'atom'
 TooltipManager = require '../src/tooltip-manager'
 Tooltip = require '../src/tooltip'
 _ = require 'underscore-plus'
@@ -39,6 +40,32 @@ describe "TooltipManager", ->
         manager.add element, title: "Title"
         hover element, ->
           expect(document.body.querySelector(".tooltip")).toHaveText("Title")
+
+      it "displays tooltips immediately when hovering over new elements once a tooltip has been displayed once", ->
+        disposables = new CompositeDisposable
+        element1 = createElement('foo')
+        disposables.add(manager.add element1, title: 'Title')
+        element2 = createElement('bar')
+        disposables.add(manager.add element2, title: 'Title')
+        element3 = createElement('baz')
+        disposables.add(manager.add element3, title: 'Title')
+
+        hover element1, ->
+        expect(document.body.querySelector(".tooltip")).toBeNull()
+
+        mouseEnter(element2)
+        expect(document.body.querySelector(".tooltip")).not.toBeNull()
+        mouseLeave(element2)
+        advanceClock(manager.hoverDefaults.delay.hide)
+        expect(document.body.querySelector(".tooltip")).toBeNull()
+
+        advanceClock(Tooltip.FOLLOW_THROUGH_DURATION)
+        mouseEnter(element3)
+        expect(document.body.querySelector(".tooltip")).toBeNull()
+        advanceClock(manager.hoverDefaults.delay.show)
+        expect(document.body.querySelector(".tooltip")).not.toBeNull()
+
+        disposables.dispose()
 
     describe "when the trigger is 'manual'", ->
       it "creates a tooltip immediately and only hides it on dispose", ->
@@ -163,26 +190,3 @@ describe "TooltipManager", ->
           expect(document.body.querySelector(".tooltip")).not.toBeNull()
           window.dispatchEvent(new CustomEvent('resize'))
           expect(document.body.querySelector(".tooltip")).toBeNull()
-
-    it "works with follow-through", ->
-      element1 = createElement('foo')
-      manager.add element1, title: 'Title'
-      element2 = createElement('bar')
-      manager.add element2, title: 'Title'
-      element3 = createElement('baz')
-      manager.add element3, title: 'Title'
-
-      hover element1, ->
-      expect(document.body.querySelector(".tooltip")).toBeNull()
-
-      mouseEnter(element2)
-      expect(document.body.querySelector(".tooltip")).not.toBeNull()
-      mouseLeave(element2)
-      advanceClock(manager.hoverDefaults.delay.hide)
-      expect(document.body.querySelector(".tooltip")).toBeNull()
-
-      advanceClock(Tooltip.FOLLOW_THROUGH_DURATION)
-      mouseEnter(element3)
-      expect(document.body.querySelector(".tooltip")).toBeNull()
-      advanceClock(manager.hoverDefaults.delay.show)
-      expect(document.body.querySelector(".tooltip")).not.toBeNull()

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -7,6 +7,8 @@ const listen = require('./delegated-listener')
 // This tooltip class is derived from Bootstrap 3, but modified to not require
 // jQuery, which is an expensive dependency we want to eliminate.
 
+var followThroughTimer = null
+
 var Tooltip = function (element, options, viewRegistry) {
   this.options = null
   this.enabled = null
@@ -21,7 +23,7 @@ var Tooltip = function (element, options, viewRegistry) {
 
 Tooltip.VERSION = '3.3.5'
 
-Tooltip.TRANSITION_DURATION = 150
+Tooltip.FOLLOW_THROUGH_DURATION = 300
 
 Tooltip.DEFAULTS = {
   animation: true,
@@ -151,7 +153,11 @@ Tooltip.prototype.enter = function (event) {
 
   this.hoverState = 'in'
 
-  if (!this.options.delay || !this.options.delay.show) return this.show()
+  if (!this.options.delay ||
+      !this.options.delay.show ||
+      followThroughTimer) {
+    return this.show()
+  }
 
   this.timeout = setTimeout(function () {
     if (this.hoverState === 'in') this.show()
@@ -342,6 +348,14 @@ Tooltip.prototype.hide = function (callback) {
   callback && callback()
 
   this.hoverState = null
+
+  clearTimeout(followThroughTimer)
+  followThroughTimer = setTimeout(
+    function () {
+      followThroughTimer = null
+    },
+    Tooltip.FOLLOW_THROUGH_DURATION
+  )
 
   return this
 }


### PR DESCRIPTION
Inside of Nuclide, we have multiple places where we have multiple icons close together that have a tooltip: the left toolbar, the bottom status bar, the debugger icons...

The current behavior is very frustrating as you've got to wait for the delay on every single one of them. But, we have a clear signal that the user wants a tooltip when s/he waits the time to see it and it's likely that moving the mouse over the next item quickly means that s/he wants to see it as well.

This pull request introduces the concept of follow through: if you have seen a tooltip, you're going to instantly see tooltip on the next element you mouse over within a short timer (300ms right now).

Test Plan:
Video before:
![](http://g.recordit.co/7PCg0hjohP.gif)

Video after:
![](http://g.recordit.co/9OnZCvy9oI.gif)

Released under CC0
