### PR TITLE
Fix toggleLineCommentsInSelection for empty lines

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4335,6 +4335,13 @@ describe "TextEditor", ->
           editor.toggleLineCommentsInSelection()
           expect(buffer.lineForRow(4)).toBe "    while(items.length > 0) {"
 
+      it "does nothing for empty lines and null grammar", ->
+        runs ->
+          editor.setGrammar(atom.grammars.grammarForScopeName('text.plain.null-grammar'))
+          editor.setCursorBufferPosition([10, 0])
+          editor.toggleLineCommentsInSelection()
+          expect(editor.buffer.lineForRow(10)).toBe ""
+
       it "uncomments when the line lacks the trailing whitespace in the comment regex", ->
         editor.setCursorBufferPosition([10, 0])
         editor.toggleLineCommentsInSelection()

--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -27,7 +27,7 @@ class LanguageMode
   toggleLineCommentsForBufferRows: (start, end) ->
     scope = @editor.scopeDescriptorForBufferPosition([start, 0])
     commentStrings = @editor.getCommentStrings(scope)
-    return unless commentStrings?
+    return unless commentStrings?.commentStartString
     {commentStartString, commentEndString} = commentStrings
 
     buffer = @editor.buffer


### PR DESCRIPTION
### Description of the Change

This code:

``` coffee
scope = @editor.scopeDescriptorForBufferPosition([start, 0])
commentStrings = @editor.getCommentStrings(scope)
```

Returns `Object {commentStartString: undefined, commentEndString: undefined}` if the language doesn't have comments. For example with `text.plain.null-grammar`.

Which causes this check in `LanguageMode.toggleLineCommentsForBufferRows`

``` coffee
return unless commentStrings?
```

To not return. Meaning `LanguageMode.toggleLineCommentsForBufferRows` will run even when there is no comment defined for the current language.
Which means that if the line is empty and the language doesn't have a defined comment we print `undefined` in the `TextEditor`.

This PR adds a check to return early if there is no `commentStartString`.
### Alternate Designs

Change the return value to `null` instead of returning an object with `undefined` properties for languages with no defined comments.
### Benefits
1. Fixes bug!
2. Doesn't write `undefined` in the `TextEditor` when trying comment an empty line when the comment is `undefined`!
3. Adds a test to not regress!

### Possible Drawbacks
- We can't add a language that only has a `commentEndString`?

### Applicable Issues

None

/cc: @nathansobo 
