### PR TITLE
Per-package transpilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "less-cache": "0.23",
     "line-top-index": "0.2.0",
     "marked": "^0.3.6",
+    "minimatch": "^3.0.3",
     "mocha": "2.5.1",
     "normalize-package-data": "^2.0.0",
     "nslog": "^3",

--- a/spec/package-transpilation-registry-spec.js
+++ b/spec/package-transpilation-registry-spec.js
@@ -77,13 +77,6 @@ describe("PackageTranspilationRegistry", () => {
       jsSpec._transpilerSource = "js-transpiler-source"
       coffeeSpec._transpilerSource = "coffee-transpiler-source"
 
-      const oldFsRealpathSync = fs.realpathSync.bind(fs)
-      spyOn(fs, 'realpathSync').andCallFake(thePath => {
-        if (thePath === '/path/to') return thePath
-        if (thePath === '/path/other') return thePath
-        return oldFsRealpathSync(thePath)
-      })
-
       spyOn(registry, "getTranspiler").andCallFake(spec => {
         if (spec.transpiler === './transpiler-js') return jsTranspiler
         if (spec.transpiler === './transpiler-coffee') return coffeeTranspiler

--- a/spec/package-transpilation-registry-spec.js
+++ b/spec/package-transpilation-registry-spec.js
@@ -55,7 +55,7 @@ describe("PackageTranspilationRegistry", () => {
 
     let jsTranspiler = {
       transpile: (sourceCode, filePath, options) => {
-        return sourceCode + "-transpiler-js"
+        return {code: sourceCode + "-transpiler-js"}
       },
 
       getCacheKeyData: (sourceCode, filePath, options) => {
@@ -65,7 +65,7 @@ describe("PackageTranspilationRegistry", () => {
 
     let coffeeTranspiler = {
       transpile: (sourceCode, filePath, options) => {
-        return sourceCode + "-transpiler-coffee"
+        return {code: sourceCode + "-transpiler-coffee"}
       },
 
       getCacheKeyData: (sourceCode, filePath, options) => {

--- a/spec/package-transpilation-registry-spec.js
+++ b/spec/package-transpilation-registry-spec.js
@@ -98,7 +98,7 @@ describe("PackageTranspilationRegistry", () => {
         throw new Error('bad transpiler path ' + spec.transpiler)
       })
 
-      registry.addTranspilerConfigForPath('/path/to', [
+      registry.addTranspilerConfigForPath('/path/to', 'my-package', [
         jsSpec, coffeeSpec, omgSpec
       ])
     })

--- a/spec/package-transpilation-registry-spec.js
+++ b/spec/package-transpilation-registry-spec.js
@@ -1,0 +1,128 @@
+/** @babel */
+import fs from 'fs'
+import path from 'path'
+
+import {it, fit, ffit, fffit, beforeEach, afterEach} from './async-spec-helpers'
+
+import PackageTranspilationRegistry from '../src/package-transpilation-registry'
+
+let originalCompiler = {
+  getCachePath: (sourceCode, filePath) => {
+    return "orig-cache-path"
+  },
+
+  compile: (sourceCode, filePath) => {
+    return sourceCode + "-original-compiler"
+  },
+
+  shouldCompile: (sourceCode, filePath) => {
+    return path.extname(filePath) === '.js'
+  }
+}
+
+describe("PackageTranspilationRegistry", () => {
+  let registry
+  let wrappedCompiler
+
+  beforeEach(() => {
+    registry = new PackageTranspilationRegistry()
+    wrappedCompiler = registry.wrapTranspiler(originalCompiler)
+  })
+
+  it('falls through to the original compiler by default', () => {
+    spyOn(originalCompiler, 'getCachePath')
+    spyOn(originalCompiler, 'compile')
+    spyOn(originalCompiler, 'shouldCompile')
+
+    wrappedCompiler.getCachePath('source', '/path/to/file.js')
+    wrappedCompiler.compile('source', '/path/to/filejs')
+    wrappedCompiler.shouldCompile('source', '/path/to/file.js')
+
+    expect(originalCompiler.getCachePath).toHaveBeenCalled()
+    expect(originalCompiler.compile).toHaveBeenCalled()
+    expect(originalCompiler.shouldCompile).toHaveBeenCalled()
+  })
+
+  describe('when a file is contained in a path that has custom transpilation', () => {
+    let hitPath = '/path/to/lib/file.js'
+    let hitPathCoffee = '/path/to/file2.coffee'
+    let missPath = '/path/other/file3.js'
+    let hitPathMissSubdir = '/path/to/file4.js'
+    let hitPathMissExt = '/path/to/file5.ts'
+
+    let jsSpec = { glob: "lib/**/*.js", transpiler: './transpiler-js', options: { type: 'js' } }
+    let coffeeSpec = { glob: "*.coffee", transpiler: './transpiler-coffee', options: { type: 'coffee' } }
+
+    let jsTranspiler = {
+      transpile: (sourceCode, filePath, options) => {
+        return sourceCode + "-transpiler-js"
+      },
+
+      getCacheKeyData: (sourceCode, filePath, options) => {
+        return 'js-transpiler-cache-data'
+      }
+    }
+
+    let coffeeTranspiler = {
+      transpile: (sourceCode, filePath, options) => {
+        return sourceCode + "-transpiler-coffee"
+      },
+
+      getCacheKeyData: (sourceCode, filePath, options) => {
+        return 'coffee-transpiler-cache-data'
+      }
+    }
+
+    beforeEach(() => {
+      jsSpec._transpilerSource = "js-transpiler-source"
+      coffeeSpec._transpilerSource = "coffee-transpiler-source"
+
+      const oldFsRealpathSync = fs.realpathSync.bind(fs)
+      spyOn(fs, 'realpathSync').andCallFake(thePath => {
+        if (thePath === '/path/to') return thePath
+        if (thePath === '/path/other') return thePath
+        return oldFsRealpathSync(thePath)
+      })
+
+      spyOn(registry, "getTranspiler").andCallFake(spec => {
+        if (spec.transpiler === './transpiler-js') return jsTranspiler
+        if (spec.transpiler === './transpiler-coffee') return coffeeTranspiler
+        throw new Error('bad transpiler path ' + spec.transpiler)
+      })
+
+      registry.addTranspilerConfigForPath('/path/to', [
+        jsSpec, coffeeSpec
+      ])
+    })
+
+    it('always returns true from shouldCompile for a file in that dir that match a glob', () => {
+      spyOn(originalCompiler, 'shouldCompile').andReturn(false)
+      expect(wrappedCompiler.shouldCompile('source', hitPath)).toBe(true)
+      expect(wrappedCompiler.shouldCompile('source', hitPathCoffee)).toBe(true)
+      expect(wrappedCompiler.shouldCompile('source', hitPathMissExt)).toBe(false)
+      expect(wrappedCompiler.shouldCompile('source', hitPathMissSubdir)).toBe(false)
+      expect(wrappedCompiler.shouldCompile('source', missPath)).toBe(false)
+    })
+
+    it('calls getCacheKeyData on the transpiler to get additional cache key data', () => {
+      spyOn(registry, "getTranspilerPath").andReturn("./transpiler-js")
+      spyOn(jsTranspiler, 'getCacheKeyData').andCallThrough()
+
+      wrappedCompiler.getCachePath('source', missPath, jsSpec)
+      expect(jsTranspiler.getCacheKeyData).not.toHaveBeenCalled()
+      wrappedCompiler.getCachePath('source', hitPath, jsSpec)
+      expect(jsTranspiler.getCacheKeyData).toHaveBeenCalled()
+    })
+
+    it('compiles files matching a glob with the associated transpiler, and the old one otherwise', () => {
+      spyOn(jsTranspiler, "transpile").andCallThrough()
+      spyOn(coffeeTranspiler, "transpile").andCallThrough()
+
+      expect(wrappedCompiler.compile('source', hitPath)).toEqual('source-transpiler-js')
+      expect(wrappedCompiler.compile('source', hitPathCoffee)).toEqual('source-transpiler-coffee')
+      expect(wrappedCompiler.compile('source', missPath)).toEqual('source-original-compiler')
+      expect(wrappedCompiler.compile('source', hitPathMissExt)).toEqual('source-original-compiler')
+      expect(wrappedCompiler.compile('source', hitPathMissSubdir)).toEqual('source-original-compiler')
+    })
+  })
+})

--- a/spec/package-transpilation-registry-spec.js
+++ b/spec/package-transpilation-registry-spec.js
@@ -6,7 +6,7 @@ import {it, fit, ffit, fffit, beforeEach, afterEach} from './async-spec-helpers'
 
 import PackageTranspilationRegistry from '../src/package-transpilation-registry'
 
-let originalCompiler = {
+const originalCompiler = {
   getCachePath: (sourceCode, filePath) => {
     return "orig-cache-path"
   },
@@ -44,19 +44,19 @@ describe("PackageTranspilationRegistry", () => {
   })
 
   describe('when a file is contained in a path that has custom transpilation', () => {
-    let hitPath = '/path/to/lib/file.js'
-    let hitPathCoffee = '/path/to/file2.coffee'
-    let missPath = '/path/other/file3.js'
-    let hitPathMissSubdir = '/path/to/file4.js'
-    let hitPathMissExt = '/path/to/file5.ts'
-    let nodeModulesFolder = '/path/to/lib/node_modules/file6.js'
-    let hitNonStandardExt = '/path/to/file7.omgwhatisthis'
+    const hitPath = '/path/to/lib/file.js'
+    const hitPathCoffee = '/path/to/file2.coffee'
+    const missPath = '/path/other/file3.js'
+    const hitPathMissSubdir = '/path/to/file4.js'
+    const hitPathMissExt = '/path/to/file5.ts'
+    const nodeModulesFolder = '/path/to/lib/node_modules/file6.js'
+    const hitNonStandardExt = '/path/to/file7.omgwhatisthis'
 
-    let jsSpec = { glob: "lib/**/*.js", transpiler: './transpiler-js', options: { type: 'js' } }
-    let coffeeSpec = { glob: "*.coffee", transpiler: './transpiler-coffee', options: { type: 'coffee' } }
-    let omgSpec = { glob: "*.omgwhatisthis", transpiler: './transpiler-omg', options: { type: 'omg' } }
+    const jsSpec = { glob: "lib/**/*.js", transpiler: './transpiler-js', options: { type: 'js' } }
+    const coffeeSpec = { glob: "*.coffee", transpiler: './transpiler-coffee', options: { type: 'coffee' } }
+    const omgSpec = { glob: "*.omgwhatisthis", transpiler: './transpiler-omg', options: { type: 'omg' } }
 
-    let jsTranspiler = {
+    const jsTranspiler = {
       transpile: (sourceCode, filePath, options) => {
         return {code: sourceCode + "-transpiler-js"}
       },
@@ -66,7 +66,7 @@ describe("PackageTranspilationRegistry", () => {
       }
     }
 
-    let coffeeTranspiler = {
+    const coffeeTranspiler = {
       transpile: (sourceCode, filePath, options) => {
         return {code: sourceCode + "-transpiler-coffee"}
       },
@@ -76,7 +76,7 @@ describe("PackageTranspilationRegistry", () => {
       }
     }
 
-    let omgTranspiler = {
+    const omgTranspiler = {
       transpile: (sourceCode, filePath, options) => {
         return {code: sourceCode + "-transpiler-omg"}
       },

--- a/spec/package-transpilation-registry-spec.js
+++ b/spec/package-transpilation-registry-spec.js
@@ -49,6 +49,7 @@ describe("PackageTranspilationRegistry", () => {
     let missPath = '/path/other/file3.js'
     let hitPathMissSubdir = '/path/to/file4.js'
     let hitPathMissExt = '/path/to/file5.ts'
+    let nodeModulesFolder = '/path/to/lib/node_modules/file6.js'
 
     let jsSpec = { glob: "lib/**/*.js", transpiler: './transpiler-js', options: { type: 'js' } }
     let coffeeSpec = { glob: "*.coffee", transpiler: './transpiler-coffee', options: { type: 'coffee' } }
@@ -95,6 +96,7 @@ describe("PackageTranspilationRegistry", () => {
       expect(wrappedCompiler.shouldCompile('source', hitPathMissExt)).toBe(false)
       expect(wrappedCompiler.shouldCompile('source', hitPathMissSubdir)).toBe(false)
       expect(wrappedCompiler.shouldCompile('source', missPath)).toBe(false)
+      expect(wrappedCompiler.shouldCompile('source', nodeModulesFolder)).toBe(false)
     })
 
     it('calls getCacheKeyData on the transpiler to get additional cache key data', () => {
@@ -116,6 +118,7 @@ describe("PackageTranspilationRegistry", () => {
       expect(wrappedCompiler.compile('source', missPath)).toEqual('source-original-compiler')
       expect(wrappedCompiler.compile('source', hitPathMissExt)).toEqual('source-original-compiler')
       expect(wrappedCompiler.compile('source', hitPathMissSubdir)).toEqual('source-original-compiler')
+      expect(wrappedCompiler.compile('source', nodeModulesFolder)).toEqual('source-original-compiler')
     })
   })
 })

--- a/spec/package-transpilation-registry-spec.js
+++ b/spec/package-transpilation-registry-spec.js
@@ -127,10 +127,15 @@ describe("PackageTranspilationRegistry", () => {
     it('compiles files matching a glob with the associated transpiler, and the old one otherwise', () => {
       spyOn(jsTranspiler, "transpile").andCallThrough()
       spyOn(coffeeTranspiler, "transpile").andCallThrough()
+      spyOn(omgTranspiler, "transpile").andCallThrough()
 
       expect(wrappedCompiler.compile('source', hitPath)).toEqual('source-transpiler-js')
+      expect(jsTranspiler.transpile).toHaveBeenCalledWith('source', hitPath, jsSpec.options)
       expect(wrappedCompiler.compile('source', hitPathCoffee)).toEqual('source-transpiler-coffee')
+      expect(coffeeTranspiler.transpile).toHaveBeenCalledWith('source', hitPathCoffee, coffeeSpec.options)
       expect(wrappedCompiler.compile('source', hitNonStandardExt)).toEqual('source-transpiler-omg')
+      expect(omgTranspiler.transpile).toHaveBeenCalledWith('source', hitNonStandardExt, omgSpec.options)
+
       expect(wrappedCompiler.compile('source', missPath)).toEqual('source-original-compiler')
       expect(wrappedCompiler.compile('source', hitPathMissExt)).toEqual('source-original-compiler')
       expect(wrappedCompiler.compile('source', hitPathMissSubdir)).toEqual('source-original-compiler')

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -20,10 +20,12 @@ var COMPILERS = {
 }
 
 exports.addTranspilerConfigForPath = function (packagePath, config) {
+  packagePath = fs.realpathSync(packagePath)
   packageTranspilationRegistry.addTranspilerConfigForPath(packagePath, config)
 }
 
 exports.removeTranspilerConfigForPath = function (packagePath) {
+  packagePath = fs.realpathSync(packagePath)
   packageTranspilationRegistry.removeTranspilerConfigForPath(packagePath)
 }
 

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -19,9 +19,9 @@ var COMPILERS = {
   '.coffee': packageTranspilationRegistry.wrapTranspiler(require('./coffee-script'))
 }
 
-exports.addTranspilerConfigForPath = function (packagePath, config) {
+exports.addTranspilerConfigForPath = function (packagePath, packageName, config) {
   packagePath = fs.realpathSync(packagePath)
-  packageTranspilationRegistry.addTranspilerConfigForPath(packagePath, config)
+  packageTranspilationRegistry.addTranspilerConfigForPath(packagePath, packageName, config)
 }
 
 exports.removeTranspilerConfigForPath = function (packagePath) {

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -7,12 +7,24 @@
 
 var path = require('path')
 var fs = require('fs-plus')
+
+var PackageTranspilationRegistry = require('./package-transpilation-registry')
 var CSON = null
 
+var packageTranspilationRegistry = new PackageTranspilationRegistry()
+
 var COMPILERS = {
-  '.js': require('./babel'),
-  '.ts': require('./typescript'),
-  '.coffee': require('./coffee-script')
+  '.js': packageTranspilationRegistry.wrapTranspiler(require('./babel')),
+  '.ts': packageTranspilationRegistry.wrapTranspiler(require('./typescript')),
+  '.coffee': packageTranspilationRegistry.wrapTranspiler(require('./coffee-script'))
+}
+
+exports.addTranspilerConfigForPath = function (packagePath, config) {
+  packageTranspilationRegistry.addTranspilerConfigForPath(packagePath, config)
+}
+
+exports.removeTranspilerConfigForPath = function (packagePath) {
+  packageTranspilationRegistry.removeTranspilerConfigForPath(packagePath)
 }
 
 var cacheStats = {}

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -10,7 +10,6 @@ function PackageTranspilationRegistry () {
   this.configByPackagePath = {}
   this.specByFilePath = {}
   this.transpilerPaths = {}
-  this.transpilerHashes = {}
 }
 
 Object.assign(PackageTranspilationRegistry.prototype, {

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -128,7 +128,7 @@ Object.assign(PackageTranspilationRegistry.prototype, {
       }
     } else {
       var err = new Error("Could not resolve transpiler '" + spec.transpiler + "' from '" + spec._config.path + "'")
-      console.error(err)
+      throw err
     }
   },
 

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -13,10 +13,11 @@ function PackageTranspilationRegistry () {
 }
 
 Object.assign(PackageTranspilationRegistry.prototype, {
-  addTranspilerConfigForPath: function (packagePath, config) {
+  addTranspilerConfigForPath: function (packagePath, packageName, config) {
     this.configByPackagePath[packagePath] = {
-      specs: config,
-      path: packagePath
+      name: packageName,
+      path: packagePath,
+      specs: config
     }
   },
 
@@ -116,7 +117,7 @@ Object.assign(PackageTranspilationRegistry.prototype, {
       hash.update(additionalCacheData, 'utf8')
     }
 
-    return path.join('package-transpile', hash.digest('hex'))
+    return path.join('package-transpile', spec._config.name, hash.digest('hex'))
   },
 
   transpileWithPackageTranspiler: function (sourceCode, filePath, spec) {

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -1,59 +1,63 @@
-var crypto = require('crypto')
-var fs = require('fs')
-var path = require('path')
+"use strict"
+// This file is required by compile-cache, which is required directly from
+// apm, so it can only use the subset of newer JavaScript features that apm's
+// version of Node supports. Strict mode is required for block scoped declarations.
 
-var minimatch = require('minimatch')
+const crypto = require('crypto')
+const fs = require('fs')
+const path = require('path')
 
-var Resolve = null
+const minimatch = require('minimatch')
 
-function PackageTranspilationRegistry () {
-  this.configByPackagePath = {}
-  this.specByFilePath = {}
-  this.transpilerPaths = {}
-}
+let Resolve = null
 
-Object.assign(PackageTranspilationRegistry.prototype, {
-  addTranspilerConfigForPath: function (packagePath, packageName, config) {
+class PackageTranspilationRegistry {
+  constructor () {
+    this.configByPackagePath = {}
+    this.specByFilePath = {}
+    this.transpilerPaths = {}
+  }
+
+  addTranspilerConfigForPath (packagePath, packageName, config) {
     this.configByPackagePath[packagePath] = {
       name: packageName,
       path: packagePath,
       specs: config
     }
-  },
+  }
 
-  removeTranspilerConfigForPath: function (packagePath) {
+  removeTranspilerConfigForPath (packagePath) {
     delete this.configByPackagePath[packagePath]
-  },
+  }
 
   // Wraps the transpiler in an object with the same interface
   // that falls back to the original transpiler implementation if and
   // only if a package hasn't registered its desire to transpile its own source.
-  wrapTranspiler: function (transpiler) {
-    var self = this
+  wrapTranspiler (transpiler) {
     return {
-      getCachePath: function (sourceCode, filePath) {
-        var spec = self.getPackageTranspilerSpecForFilePath(filePath)
+      getCachePath: (sourceCode, filePath) => {
+        const spec = this.getPackageTranspilerSpecForFilePath(filePath)
         if (spec) {
-          return self.getCachePath(sourceCode, filePath, spec)
+          return this.getCachePath(sourceCode, filePath, spec)
         }
 
         return transpiler.getCachePath(sourceCode, filePath)
       },
 
-      compile: function (sourceCode, filePath) {
-        var spec = self.getPackageTranspilerSpecForFilePath(filePath)
+      compile: (sourceCode, filePath) => {
+        const spec = this.getPackageTranspilerSpecForFilePath(filePath)
         if (spec) {
-          return self.transpileWithPackageTranspiler(sourceCode, filePath, spec)
+          return this.transpileWithPackageTranspiler(sourceCode, filePath, spec)
         }
 
         return transpiler.compile(sourceCode, filePath)
       },
 
-      shouldCompile: function (sourceCode, filePath) {
-        if (self.transpilerPaths[filePath]) {
+      shouldCompile: (sourceCode, filePath) => {
+        if (this.transpilerPaths[filePath]) {
           return false
         }
-        var spec = self.getPackageTranspilerSpecForFilePath(filePath)
+        const spec = this.getPackageTranspilerSpecForFilePath(filePath)
         if (spec) {
           return true
         }
@@ -61,9 +65,9 @@ Object.assign(PackageTranspilationRegistry.prototype, {
         return transpiler.shouldCompile(sourceCode, filePath)
       }
     }
-  },
+  }
 
-  getPackageTranspilerSpecForFilePath: function (filePath) {
+  getPackageTranspilerSpecForFilePath (filePath) {
     if (this.specByFilePath[filePath] !== undefined) return this.specByFilePath[filePath]
 
     // ignore node_modules
@@ -71,18 +75,17 @@ Object.assign(PackageTranspilationRegistry.prototype, {
       return false
     }
 
-    var config = null
-    var spec = null
-    var thisPath = filePath
-    var lastPath = null
+    let thisPath = filePath
+    let lastPath = null
     // Iterate parents from the file path to the root, checking at each level
     // to see if a package manages transpilation for that directory.
     // This means searching for a config for `/path/to/file/here.js` only
     // only iterates four times, even if there are hundreds of configs registered.
     while (thisPath !== lastPath) { // until we reach the root
-      if (config = this.configByPackagePath[thisPath]) { // eslint-disable-line no-cond-assign
-        for (var i = 0; i < config.specs.length; i++) {
-          spec = config.specs[i]
+      let config = this.configByPackagePath[thisPath]
+      if (config) {
+        for (let i = 0; i < config.specs.length; i++) {
+          const spec = config.specs[i]
           if (minimatch(filePath, path.join(config.path, spec.glob))) {
             spec._config = config
             this.specByFilePath[filePath] = spec
@@ -97,34 +100,33 @@ Object.assign(PackageTranspilationRegistry.prototype, {
 
     this.specByFilePath[filePath] = null
     return null
-  },
+  }
 
-  getCachePath: function (sourceCode, filePath, spec) {
-    var transpilerPath = this.getTranspilerPath(spec)
-    var transpilerSource = spec._transpilerSource || fs.readFileSync(transpilerPath, 'utf8')
+  getCachePath (sourceCode, filePath, spec) {
+    const transpilerPath = this.getTranspilerPath(spec)
+    const transpilerSource = spec._transpilerSource || fs.readFileSync(transpilerPath, 'utf8')
     spec._transpilerSource = transpilerSource
-    var transpiler = this.getTranspiler(spec)
+    const transpiler = this.getTranspiler(spec)
 
-    var hash = crypto
+    let hash = crypto
       .createHash('sha1')
       .update(JSON.stringify(spec.options || {}))
       .update(transpilerSource, 'utf8')
       .update(sourceCode, 'utf8')
 
-    var additionalCacheData
     if (transpiler && transpiler.getCacheKeyData) {
-      additionalCacheData = transpiler.getCacheKeyData(sourceCode, filePath, spec.options)
+      const additionalCacheData = transpiler.getCacheKeyData(sourceCode, filePath, spec.options)
       hash.update(additionalCacheData, 'utf8')
     }
 
     return path.join('package-transpile', spec._config.name, hash.digest('hex'))
-  },
+  }
 
-  transpileWithPackageTranspiler: function (sourceCode, filePath, spec) {
-    var transpiler = this.getTranspiler(spec)
+  transpileWithPackageTranspiler (sourceCode, filePath, spec) {
+    const transpiler = this.getTranspiler(spec)
 
     if (transpiler) {
-      var result = transpiler.transpile(sourceCode, filePath, spec.options || {})
+      const result = transpiler.transpile(sourceCode, filePath, spec.options || {})
       if (result === undefined || (result && result.code === undefined)) {
         return sourceCode
       } else if (result.code) {
@@ -133,27 +135,27 @@ Object.assign(PackageTranspilationRegistry.prototype, {
         throw new Error('Could not find a property `.code` on the transpilation results of ' + filePath)
       }
     } else {
-      var err = new Error("Could not resolve transpiler '" + spec.transpiler + "' from '" + spec._config.path + "'")
+      const err = new Error("Could not resolve transpiler '" + spec.transpiler + "' from '" + spec._config.path + "'")
       throw err
     }
-  },
+  }
 
-  getTranspilerPath: function (spec) {
+  getTranspilerPath (spec) {
     Resolve = Resolve || require('resolve')
     return Resolve.sync(spec.transpiler, {
       basedir: spec._config.path,
       extensions: Object.keys(require.extensions)
     })
-  },
+  }
 
-  getTranspiler: function (spec) {
-    var transpilerPath = this.getTranspilerPath(spec)
+  getTranspiler (spec) {
+    const transpilerPath = this.getTranspilerPath(spec)
     if (transpilerPath) {
-      var transpiler = require(transpilerPath)
+      const transpiler = require(transpilerPath)
       this.transpilerPaths[transpilerPath] = true
       return transpiler
     }
   }
-})
+}
 
 module.exports = PackageTranspilationRegistry

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -129,7 +129,7 @@ Object.assign(PackageTranspilationRegistry.prototype, {
       } else if (result.code) {
         return result.code.toString()
       } else {
-        throw new Error("Could not find a property `.code` on the transpilation results of " + filePath)
+        throw new Error('Could not find a property `.code` on the transpilation results of ' + filePath)
       }
     } else {
       var err = new Error("Could not resolve transpiler '" + spec.transpiler + "' from '" + spec._config.path + "'")

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -76,7 +76,7 @@ Object.assign(PackageTranspilationRegistry.prototype, {
     // This means searching for a config for `/path/to/file/here.js` only
     // only iterates four times, even if there are hundreds of configs registered.
     while (thisPath !== lastPath) { // until we reach the root
-      if (config = this.configByPackagePath[thisPath]) {
+      if (config = this.configByPackagePath[thisPath]) { // // eslint-disable-line no-cond-assign
         for (var i = 0; i < config.specs.length; i++) {
           spec = config.specs[i]
           if (minimatch(filePath, path.join(config.path, spec.glob))) {
@@ -100,7 +100,7 @@ Object.assign(PackageTranspilationRegistry.prototype, {
     var transpilerSource = spec._transpilerSource || fs.readFileSync(transpilerPath, 'utf8')
     spec._transpilerSource = transpilerSource
     return path.join(
-      "package-transpile",
+      'package-transpile',
       crypto
         .createHash('sha1')
         .update(JSON.stringify(spec.options || {}))
@@ -127,7 +127,7 @@ Object.assign(PackageTranspilationRegistry.prototype, {
         return result
       }
     } else {
-      var err = new Error("Could not resolve transpiler '" + spec.transpiler + "' from '" + config.path + "'")
+      var err = new Error("Could not resolve transpiler '" + spec.transpiler + "' from '" + spec._config.path + "'")
       console.error(err)
     }
   }

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -14,7 +14,6 @@ function PackageTranspilationRegistry () {
 
 Object.assign(PackageTranspilationRegistry.prototype, {
   addTranspilerConfigForPath: function (packagePath, config) {
-    packagePath = fs.realpathSync(packagePath)
     this.configByPackagePath[packagePath] = {
       specs: config,
       path: packagePath
@@ -22,7 +21,6 @@ Object.assign(PackageTranspilationRegistry.prototype, {
   },
 
   removeTranspilerConfigForPath: function (packagePath) {
-    packagePath = fs.realpathSync(packagePath)
     delete this.configByPackagePath[packagePath]
   },
 

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -124,7 +124,7 @@ Object.assign(PackageTranspilationRegistry.prototype, {
       if (result === undefined) {
         return sourceCode
       } else {
-        return result
+        return result.toString()
       }
     } else {
       var err = new Error("Could not resolve transpiler '" + spec.transpiler + "' from '" + spec._config.path + "'")

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -1,0 +1,122 @@
+var crypto = require('crypto')
+var fs = require('fs')
+var path = require('path')
+
+var Resolve = null
+
+function PackageTranspilationRegistry () {
+  this.configByPackagePath = {}
+  this.configByFilePath = {}
+  this.transpilerPaths = {}
+  this.transpilerHashes = {}
+}
+
+PackageTranspilationRegistry.prototype.addTranspilerConfigForPath = function (packagePath, config) {
+  packagePath = fs.realpathSync(packagePath)
+  this.configByPackagePath[packagePath] = Object.assign({}, config, {
+    path: packagePath
+  })
+}
+
+PackageTranspilationRegistry.prototype.removeTranspilerConfigForPath = function (packagePath) {
+  packagePath = fs.realpathSync(packagePath)
+  delete this.configByPackagePath[path]
+}
+
+// Wraps the transpiler in an object with the same interface
+// that falls back to the original transpiler implementation if and
+// only if a package hasn't registered its desire to transpile its own source.
+PackageTranspilationRegistry.prototype.wrapTranspiler = function (transpiler) {
+  var self = this
+  return {
+    getCachePath: function (sourceCode, filePath) {
+      var config = self.getPackageTranspilerConfigForFilePath(filePath)
+      if (config) {
+        return self.getCachePath(sourceCode, filePath, config)
+      }
+
+      return transpiler.getCachePath(sourceCode, filePath)
+    },
+
+    compile: function (sourceCode, filePath) {
+      var config = self.getPackageTranspilerConfigForFilePath(filePath)
+      if (config) {
+        return self.transpileWithPackageTranspiler(sourceCode, filePath, config)
+      }
+
+      return transpiler.compile(sourceCode, filePath)
+    },
+
+    shouldCompile: function (sourceCode, filePath) {
+      if (self.transpilerPaths[filePath]) {
+        return false
+      }
+      var config = self.getPackageTranspilerConfigForFilePath(filePath)
+      if (config) {
+        return true
+      }
+
+      return transpiler.shouldCompile(sourceCode, filePath)
+    }
+  }
+}
+
+PackageTranspilationRegistry.prototype.getPackageTranspilerConfigForFilePath = function (filePath) {
+  if (this.configByFilePath[filePath] !== undefined) return this.configByFilePath[filePath]
+
+  var config = null
+  var thisPath = filePath
+  var lastPath = null
+  // Iterate parents from the file path to the root, checking at each level
+  // to see if a package manages transpilation for that directory.
+  // This means searching for a config for `/path/to/file/here.js` only
+  // only iterates four times, even if there are hundreds of configs registered.
+  while (thisPath !== lastPath) { // until we reach the root
+    if (config = this.configByPackagePath[thisPath]) {
+      this.configByFilePath[filePath] = config
+      return config
+    }
+
+    lastPath = thisPath
+    thisPath = path.resolve(thisPath, '..')
+  }
+
+  this.configByFilePath[filePath] = null
+  return null
+}
+
+PackageTranspilationRegistry.prototype.getCachePath = function (sourceCode, filePath, config) {
+  var transpilerPath = path.join(config.path, config.transpiler)
+  var transpilerSource = config._transpilerSource || fs.readFileSync(transpilerPath, 'utf8')
+  config._transpilerSource = transpilerSource
+  return path.join(
+    "package-transpile",
+    crypto
+      .createHash('sha1')
+      .update(transpilerSource, 'utf8')
+      .update(sourceCode, 'utf8')
+      .digest('hex')
+  )
+}
+
+PackageTranspilationRegistry.prototype.transpileWithPackageTranspiler = function (sourceCode, filePath) {
+  var config = this.configByFilePath[filePath]
+
+  Resolve = Resolve || require('resolve')
+  var transpilerPath = Resolve.sync(config.transpiler, {basedir: config.path, extensions: Object.keys(require.extensions)})
+  if (transpilerPath) {
+    this.transpilerPaths[transpilerPath] = true
+    var transpiler = require(transpilerPath)
+    var result = transpiler.compile(sourceCode, filePath)
+    if (result === undefined) {
+      return sourceCode
+    } else {
+      return result
+    }
+  } else {
+    var err = new Error("Could not find transpiler '" + config.transpiler + "' from '" + config.path + "'")
+    console.error(err)
+  }
+}
+
+module.exports = PackageTranspilationRegistry

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -120,7 +120,7 @@ Object.assign(PackageTranspilationRegistry.prototype, {
     var transpiler = this.getTranspiler(spec)
 
     if (transpiler) {
-      var result = transpiler.compile(sourceCode, filePath, spec.options || {})
+      var result = transpiler.transpile(sourceCode, filePath, spec.options || {})
       if (result === undefined) {
         return sourceCode
       } else {

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -2,121 +2,141 @@ var crypto = require('crypto')
 var fs = require('fs')
 var path = require('path')
 
+var minimatch = require('minimatch')
+
 var Resolve = null
 
 function PackageTranspilationRegistry () {
   this.configByPackagePath = {}
-  this.configByFilePath = {}
+  this.specByFilePath = {}
   this.transpilerPaths = {}
   this.transpilerHashes = {}
 }
 
-PackageTranspilationRegistry.prototype.addTranspilerConfigForPath = function (packagePath, config) {
-  packagePath = fs.realpathSync(packagePath)
-  this.configByPackagePath[packagePath] = Object.assign({}, config, {
-    path: packagePath
-  })
-}
-
-PackageTranspilationRegistry.prototype.removeTranspilerConfigForPath = function (packagePath) {
-  packagePath = fs.realpathSync(packagePath)
-  delete this.configByPackagePath[path]
-}
-
-// Wraps the transpiler in an object with the same interface
-// that falls back to the original transpiler implementation if and
-// only if a package hasn't registered its desire to transpile its own source.
-PackageTranspilationRegistry.prototype.wrapTranspiler = function (transpiler) {
-  var self = this
-  return {
-    getCachePath: function (sourceCode, filePath) {
-      var config = self.getPackageTranspilerConfigForFilePath(filePath)
-      if (config) {
-        return self.getCachePath(sourceCode, filePath, config)
-      }
-
-      return transpiler.getCachePath(sourceCode, filePath)
-    },
-
-    compile: function (sourceCode, filePath) {
-      var config = self.getPackageTranspilerConfigForFilePath(filePath)
-      if (config) {
-        return self.transpileWithPackageTranspiler(sourceCode, filePath, config)
-      }
-
-      return transpiler.compile(sourceCode, filePath)
-    },
-
-    shouldCompile: function (sourceCode, filePath) {
-      if (self.transpilerPaths[filePath]) {
-        return false
-      }
-      var config = self.getPackageTranspilerConfigForFilePath(filePath)
-      if (config) {
-        return true
-      }
-
-      return transpiler.shouldCompile(sourceCode, filePath)
+Object.assign(PackageTranspilationRegistry.prototype, {
+  addTranspilerConfigForPath: function (packagePath, config) {
+    packagePath = fs.realpathSync(packagePath)
+    this.configByPackagePath[packagePath] = {
+      specs: config,
+      path: packagePath
     }
-  }
-}
+    console.debug(">> adding", this.configByPackagePath[packagePath])
+  },
 
-PackageTranspilationRegistry.prototype.getPackageTranspilerConfigForFilePath = function (filePath) {
-  if (this.configByFilePath[filePath] !== undefined) return this.configByFilePath[filePath]
+  removeTranspilerConfigForPath: function (packagePath) {
+    packagePath = fs.realpathSync(packagePath)
+    delete this.configByPackagePath[packagePath]
+  },
 
-  var config = null
-  var thisPath = filePath
-  var lastPath = null
-  // Iterate parents from the file path to the root, checking at each level
-  // to see if a package manages transpilation for that directory.
-  // This means searching for a config for `/path/to/file/here.js` only
-  // only iterates four times, even if there are hundreds of configs registered.
-  while (thisPath !== lastPath) { // until we reach the root
-    if (config = this.configByPackagePath[thisPath]) {
-      this.configByFilePath[filePath] = config
-      return config
+  // Wraps the transpiler in an object with the same interface
+  // that falls back to the original transpiler implementation if and
+  // only if a package hasn't registered its desire to transpile its own source.
+  wrapTranspiler: function (transpiler) {
+    var self = this
+    return {
+      getCachePath: function (sourceCode, filePath) {
+        var spec = self.getPackageTranspilerSpecForFilePath(filePath)
+        if (spec) {
+          return self.getCachePath(sourceCode, filePath, spec)
+        }
+
+        return transpiler.getCachePath(sourceCode, filePath)
+      },
+
+      compile: function (sourceCode, filePath) {
+        var spec = self.getPackageTranspilerSpecForFilePath(filePath)
+        if (spec) {
+          return self.transpileWithPackageTranspiler(sourceCode, filePath, spec)
+        }
+
+        return transpiler.compile(sourceCode, filePath)
+      },
+
+      shouldCompile: function (sourceCode, filePath) {
+        if (self.transpilerPaths[filePath]) {
+          return false
+        }
+        var spec = self.getPackageTranspilerSpecForFilePath(filePath)
+        if (spec) {
+          return true
+        }
+
+        return transpiler.shouldCompile(sourceCode, filePath)
+      }
+    }
+  },
+
+  getPackageTranspilerSpecForFilePath: function (filePath) {
+    if (this.specByFilePath[filePath] !== undefined) return this.specByFilePath[filePath]
+
+    var config = null
+    var spec = null
+    var thisPath = filePath
+    var lastPath = null
+    // Iterate parents from the file path to the root, checking at each level
+    // to see if a package manages transpilation for that directory.
+    // This means searching for a config for `/path/to/file/here.js` only
+    // only iterates four times, even if there are hundreds of configs registered.
+    while (thisPath !== lastPath) { // until we reach the root
+      if (config = this.configByPackagePath[thisPath]) {
+        console.log('got one')
+        for (var i = 0; i < config.specs.length; i++) {
+          spec = config.specs[i]
+          console.log("checking", filePath, "against", path.join(config.path, spec.glob))
+          if (minimatch(filePath, path.join(config.path, spec.glob))) {
+            spec._config = config
+            this.specByFilePath[filePath] = spec
+            return spec
+          }
+        }
+      }
+
+      lastPath = thisPath
+      thisPath = path.resolve(thisPath, '..')
     }
 
-    lastPath = thisPath
-    thisPath = path.resolve(thisPath, '..')
-  }
+    this.specByFilePath[filePath] = null
+    return null
+  },
 
-  this.configByFilePath[filePath] = null
-  return null
-}
+  getCachePath: function (sourceCode, filePath, spec) {
+    var transpilerPath = path.join(spec._config.path, spec.transpiler)
+    var transpilerSource = spec._transpilerSource || fs.readFileSync(transpilerPath, 'utf8')
+    spec._transpilerSource = transpilerSource
+    return path.join(
+      "package-transpile",
+      crypto
+        .createHash('sha1')
+        .update(JSON.stringify(spec.options || {}))
+        .update(transpilerSource, 'utf8')
+        .update(sourceCode, 'utf8')
+        .digest('hex')
+    )
+  },
 
-PackageTranspilationRegistry.prototype.getCachePath = function (sourceCode, filePath, config) {
-  var transpilerPath = path.join(config.path, config.transpiler)
-  var transpilerSource = config._transpilerSource || fs.readFileSync(transpilerPath, 'utf8')
-  config._transpilerSource = transpilerSource
-  return path.join(
-    "package-transpile",
-    crypto
-      .createHash('sha1')
-      .update(transpilerSource, 'utf8')
-      .update(sourceCode, 'utf8')
-      .digest('hex')
-  )
-}
+  transpileWithPackageTranspiler: function (sourceCode, filePath, spec) {
+    var spec = this.specByFilePath[filePath]
 
-PackageTranspilationRegistry.prototype.transpileWithPackageTranspiler = function (sourceCode, filePath) {
-  var config = this.configByFilePath[filePath]
+    Resolve = Resolve || require('resolve')
+    var transpilerPath = Resolve.sync(spec.transpiler, {
+      basedir: spec._config.path,
+      extensions: Object.keys(require.extensions)
+    })
 
-  Resolve = Resolve || require('resolve')
-  var transpilerPath = Resolve.sync(config.transpiler, {basedir: config.path, extensions: Object.keys(require.extensions)})
-  if (transpilerPath) {
-    this.transpilerPaths[transpilerPath] = true
-    var transpiler = require(transpilerPath)
-    var result = transpiler.compile(sourceCode, filePath, config.options || {})
-    if (result === undefined) {
-      return sourceCode
+    if (transpilerPath) {
+      this.transpilerPaths[transpilerPath] = true
+      var transpiler = require(transpilerPath)
+      var result = transpiler.compile(sourceCode, filePath, spec.options || {})
+      if (result === undefined) {
+        return sourceCode
+      } else {
+        return result
+      }
     } else {
-      return result
+      var err = new Error("Could not resolve transpiler '" + spec.transpiler + "' from '" + config.path + "'")
+      console.error(err)
     }
-  } else {
-    var err = new Error("Could not find transpiler '" + config.transpiler + "' from '" + config.path + "'")
-    console.error(err)
   }
-}
+})
 
 module.exports = PackageTranspilationRegistry

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -111,8 +111,6 @@ Object.assign(PackageTranspilationRegistry.prototype, {
   },
 
   transpileWithPackageTranspiler: function (sourceCode, filePath, spec) {
-    var spec = this.specByFilePath[filePath]
-
     Resolve = Resolve || require('resolve')
     var transpilerPath = Resolve.sync(spec.transpiler, {
       basedir: spec._config.path,

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -19,7 +19,6 @@ Object.assign(PackageTranspilationRegistry.prototype, {
       specs: config,
       path: packagePath
     }
-    console.debug(">> adding", this.configByPackagePath[packagePath])
   },
 
   removeTranspilerConfigForPath: function (packagePath) {
@@ -78,10 +77,8 @@ Object.assign(PackageTranspilationRegistry.prototype, {
     // only iterates four times, even if there are hundreds of configs registered.
     while (thisPath !== lastPath) { // until we reach the root
       if (config = this.configByPackagePath[thisPath]) {
-        console.log('got one')
         for (var i = 0; i < config.specs.length; i++) {
           spec = config.specs[i]
-          console.log("checking", filePath, "against", path.join(config.path, spec.glob))
           if (minimatch(filePath, path.join(config.path, spec.glob))) {
             spec._config = config
             this.specByFilePath[filePath] = spec

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -107,7 +107,7 @@ PackageTranspilationRegistry.prototype.transpileWithPackageTranspiler = function
   if (transpilerPath) {
     this.transpilerPaths[transpilerPath] = true
     var transpiler = require(transpilerPath)
-    var result = transpiler.compile(sourceCode, filePath)
+    var result = transpiler.compile(sourceCode, filePath, config.options || {})
     if (result === undefined) {
       return sourceCode
     } else {

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -1,4 +1,4 @@
-"use strict"
+'use strict'
 // This file is required by compile-cache, which is required directly from
 // apm, so it can only use the subset of newer JavaScript features that apm's
 // version of Node supports. Strict mode is required for block scoped declarations.

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -119,10 +119,12 @@ Object.assign(PackageTranspilationRegistry.prototype, {
 
     if (transpiler) {
       var result = transpiler.transpile(sourceCode, filePath, spec.options || {})
-      if (result === undefined) {
+      if (result === undefined || (result && result.code === undefined)) {
         return sourceCode
+      } else if (result.code) {
+        return result.code.toString()
       } else {
-        return result.toString()
+        throw new Error("Could not find a property `.code` on the transpilation results of " + filePath)
       }
     } else {
       var err = new Error("Could not resolve transpiler '" + spec.transpiler + "' from '" + spec._config.path + "'")

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -76,7 +76,7 @@ Object.assign(PackageTranspilationRegistry.prototype, {
     // This means searching for a config for `/path/to/file/here.js` only
     // only iterates four times, even if there are hundreds of configs registered.
     while (thisPath !== lastPath) { // until we reach the root
-      if (config = this.configByPackagePath[thisPath]) { // // eslint-disable-line no-cond-assign
+      if (config = this.configByPackagePath[thisPath]) { // eslint-disable-line no-cond-assign
         for (var i = 0; i < config.specs.length; i++) {
           spec = config.specs[i]
           if (minimatch(filePath, path.join(config.path, spec.glob))) {

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -65,6 +65,11 @@ Object.assign(PackageTranspilationRegistry.prototype, {
   getPackageTranspilerSpecForFilePath: function (filePath) {
     if (this.specByFilePath[filePath] !== undefined) return this.specByFilePath[filePath]
 
+    // ignore node_modules
+    if (filePath.indexOf(path.sep + 'node_modules' + path.sep) > -1) {
+      return false
+    }
+
     var config = null
     var spec = null
     var thisPath = filePath

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -254,7 +254,7 @@ class Package
 
   registerTranspilerConfig: ->
     if @metadata.atomTranspilers
-      CompileCache.addTranspilerConfigForPath(@path, @metadata.atomTranspilers)
+      CompileCache.addTranspilerConfigForPath(@path, @name, @metadata.atomTranspilers)
 
   unregisterTranspilerConfig: ->
     if @metadata.atomTranspilers

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -254,13 +254,11 @@ class Package
 
   registerTranspilerConfig: ->
     if @metadata.atomTranspilers
-      for transpiler in @metadata.atomTranspilers
-        CompileCache.addTranspilerConfigForPath(@path, transpiler)
+      CompileCache.addTranspilerConfigForPath(@path, @metadata.atomTranspilers)
 
   unregisterTranspilerConfig: ->
     if @metadata.atomTranspilers
-      for transpiler in @metadata.atomTranspilers
-        CompileCache.removeTranspilerConfigForPath(@path)
+      CompileCache.removeTranspilerConfigForPath(@path)
 
   loadKeymaps: ->
     if @bundledPackage and @packageManager.packagesCache[@name]?

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -6,6 +6,7 @@ CSON = require 'season'
 fs = require 'fs-plus'
 {Emitter, CompositeDisposable} = require 'event-kit'
 
+CompileCache = require './compile-cache'
 ModuleCache = require './module-cache'
 ScopedProperties = require './scoped-properties'
 BufferedProcess = require './buffered-process'
@@ -86,6 +87,7 @@ class Package
         @loadStylesheets()
         @registerDeserializerMethods()
         @activateCoreStartupServices()
+        @registerTranspilerConfig()
         @configSchemaRegisteredOnLoad = @registerConfigSchemaFromMetadata()
         @settingsPromise = @loadSettings()
         if @shouldRequireMainModuleOnLoad() and not @mainModule?
@@ -93,6 +95,9 @@ class Package
       catch error
         @handleError("Failed to load the #{@name} package", error)
     this
+
+  unload: ->
+    @unregisterTranspilerConfig()
 
   shouldRequireMainModuleOnLoad: ->
     not (
@@ -246,6 +251,16 @@ class Package
         if typeof @mainModule[methodName] is 'function'
           @activationDisposables.add @packageManager.serviceHub.consume(name, version, @mainModule[methodName].bind(@mainModule))
     return
+
+  registerTranspilerConfig: ->
+    if @metadata.atomTranspilers
+      for transpiler in @metadata.atomTranspilers
+        CompileCache.addTranspilerConfigForPath(@path, transpiler)
+
+  unregisterTranspilerConfig: ->
+    if @metadata.atomTranspilers
+      for transpiler in @metadata.atomTranspilers
+        CompileCache.removeTranspilerConfigForPath(@path)
 
   loadKeymaps: ->
     if @bundledPackage and @packageManager.packagesCache[@name]?


### PR DESCRIPTION
This is a ~~WIP and (thus far) rough~~ implementation of per-package transpilation pipelines mentioned in #13087. It allows packages to opt in to fully managing their own transpilation steps, bypassing the built-in Atom transpilation entirely. Here's roughly how it works:
1. A package declares a property in its `package.json` called `atomTranspilers`. This is an array of objects, with each object specifying `glob`, `transpiler`, and optionally `options`.
2. When a package is loaded, if `atomTranspilers` exists in its metadata, we notify the `CompileCache` that it wants to do its own compilation.
3. A new class called `PackageTranspilationRegistry` wraps all the `CompileCache` compilers with a new object of the same interface that falls back to the original compiler if a package hasn't opted in to its own transpilation, but bypasses it completely otherwise.
4. If a package is doing it's own compilation, then for each file that matches the `glob` specified, the associated `transpiler` is required, and the exported value should be an object with a function called `compile` that takes three arguments: `sourceCode`, `filePath`, and `options` (where `options` comes from the package's `package.json`). It should return a string or Buffer with the transpiled source, or `undefined` to indicate that it doesn't want to transpile that file. Note that returning `undefined` doesn't fall back to the legacy, core behavior — packages which opt in to this mechanism are _fully_ responsible for _all_ their transpilation.

Also worth noting is that the transpiler file cannot be transpiled itself; its source must run in a vanilla Atom environment (which is admittedly pretty capable these days :).

One question I have is how to handle the caching. For example, I currently have `getCachePath` set to

``` javascript
return path.join(
  "package-transpile",
  crypto
    .createHash('sha1')
    .update(transpilerSource, 'utf8')
    .update(sourceCode, 'utf8')
    .digest('hex')
  )
```

but in many cases it's possible that neither the file's source nor the transpiler's source has changed, but the output of transpilation would be different (e.g. when editing a `.babelrc` file). Perhaps we should allow the package author to also specify a cache key for the file?

/cc @nathansobo @atom/core for early 💭 
