### PR TITLE
Fix wrong binding on atom-environment.coffee

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -656,7 +656,7 @@ class AtomEnvironment extends Model
   restoreWindowDimensions: ->
     unless @windowDimensions? and @isValidDimensions(@windowDimensions)
       @windowDimensions = @getDefaultWindowDimensions()
-    @setWindowDimensions(@windowDimensions).then -> @windowDimensions
+    @setWindowDimensions(@windowDimensions).then => @windowDimensions
 
   restoreWindowBackground: ->
     if backgroundColor = window.localStorage.getItem('atom:window-background-color')


### PR DESCRIPTION
Context: I'm trying to run atom in the browser and have strict mode enabled and it threw on this line. We need it to be a fat arrow otherwise it's adding it to the window (or undefined in strict mode).