### PR TITLE
Add and improve core.*OnStart setting descriptions

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -122,7 +122,12 @@ const configSchema = {
         ]
       },
       openEmptyEditorOnStart: {
-        description: 'When checked opens an untitled editor on _File > New Window_; otherwise no buffer is opened.',
+        description: 'When checked opens an untitled editor when loading a blank environment (such as with _File > New Window_ or when "Restore Previous Windows On Start" is unchecked); otherwise no buffer is opened when loading a blank environment. This setting has no effect when restoring a previous state.',
+        type: 'boolean',
+        default: true
+      },
+      restorePreviousWindowsOnStart: {
+        description: 'When checked restores the last state of all Atom windows when started from the icon or `atom` by itself from the command line; otherwise a blank environment is loaded.',
         type: 'boolean',
         default: true
       },

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -122,7 +122,7 @@ const configSchema = {
         ]
       },
       openEmptyEditorOnStart: {
-        description: 'When checked opens an untitled editor when loading a blank environment (such as with _File > New Window_ or when "Restore Previous Windows On Start" is unchecked); otherwise no buffer is opened when loading a blank environment. This setting has no effect when restoring a previous state.',
+        description: 'When checked opens an untitled editor when loading a blank environment (such as with _File > New Window_ or when "Restore Previous Windows On Start" is unchecked); otherwise no editor is opened when loading a blank environment. This setting has no effect when restoring a previous state.',
         type: 'boolean',
         default: true
       },

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -122,7 +122,7 @@ const configSchema = {
         ]
       },
       openEmptyEditorOnStart: {
-        description: 'Automatically open an empty editor on startup.',
+        description: 'When checked opens an untitled editor on _File > New Window_; otherwise no buffer is opened.',
         type: 'boolean',
         default: true
       },


### PR DESCRIPTION
### Description of the Change

The current description of the `core.openEmptyEditorOnStart` is misleading which has caused a lot of confusion around what this option is supposed to do or not do. Many people change this setting expecting some behavior difference when they start Atom the next time only to find out that it doesn't do anything from what they can tell. This is because Atom's default behavior in the absence of other instructions is to restore the state from the last time Atom was open, completely ignoring this setting.

There is [a way to configure Atom to not restore the last state](https://github.com/atom/atom/pull/11324). The configuration setting was never exposed in the config schema though so people had to dig through the code or search through Issues and PRs to discover that it was an option. This change adds the `core.restorePreviousWindowsOnStart` setting to the schema so that is no longer necessary.

### Alternate Designs

A more [comprehensive overhaul of Atom's launch story](https://github.com/atom/atom/issues/10517) whether in one large change or multiple small ones is something that is being looked at but won't realistically solve this confusion in the near term.

### Why Should This Be In Core?

This isn't new functionality.

### Benefits

A more clear understanding of what these settings do and do not.

### Possible Drawbacks

If not adding the `core.restorePreviousWindowsOnStart` setting to the config schema was intentional, this has the obvious drawback that it is now showing up in the Settings View.

### Applicable Issues

* Applies to #10517
* Fixes #10623
