### PR TITLE
Use spawn instead of execFile and clean up running processes on process exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "marked": "^0.3.6",
     "minimatch": "^3.0.3",
     "mocha": "2.5.1",
+    "mock-spawn": "^0.2.6",
     "normalize-package-data": "^2.0.0",
     "nslog": "^3",
     "oniguruma": "6.1.0",

--- a/spec/update-process-env-spec.js
+++ b/spec/update-process-env-spec.js
@@ -4,7 +4,7 @@
 import {it, fit, ffit, fffit, beforeEach, afterEach} from './async-spec-helpers'
 import path from 'path'
 import temp from 'temp'
-import child_process from 'child_process'
+import childProcess from 'child_process'
 import {updateProcessEnv, shouldGetEnvFromShell} from '../src/update-process-env'
 import dedent from 'dedent'
 import {EventEmitter} from 'events'
@@ -14,9 +14,9 @@ describe('updateProcessEnv(launchEnv)', function () {
   let originalProcessEnv, originalProcessPlatform, originalSpawn, spawn
 
   beforeEach(function () {
-    originalSpawn = child_process.spawn
+    originalSpawn = childProcess.spawn
     spawn = mockSpawn()
-    child_process.spawn = spawn
+    childProcess.spawn = spawn
     originalProcessEnv = process.env
     originalProcessPlatform = process.platform
     process.env = {}
@@ -24,7 +24,7 @@ describe('updateProcessEnv(launchEnv)', function () {
 
   afterEach(function () {
     if (originalSpawn) {
-      child_process.spawn = originalSpawn
+      childProcess.spawn = originalSpawn
     }
     process.env = originalProcessEnv
     process.platform = originalProcessPlatform
@@ -201,11 +201,11 @@ describe('updateProcessEnv(launchEnv)', function () {
     describe('on windows', function () {
       it('does not update process.env', async function () {
         process.platform = 'win32'
-        spyOn(child_process, 'spawn')
+        spyOn(childProcess, 'spawn')
         process.env = {FOO: 'bar'}
 
         await updateProcessEnv(process.env)
-        expect(child_process.spawn).not.toHaveBeenCalled()
+        expect(childProcess.spawn).not.toHaveBeenCalled()
         expect(process.env).toEqual({FOO: 'bar'})
       })
     })

--- a/spec/update-process-env-spec.js
+++ b/spec/update-process-env-spec.js
@@ -205,7 +205,7 @@ describe('updateProcessEnv(launchEnv)', function () {
         process.env = {FOO: 'bar'}
 
         await updateProcessEnv(process.env)
-        expect(child_process.execFile).not.toHaveBeenCalled()
+        expect(child_process.spawn).not.toHaveBeenCalled()
         expect(process.env).toEqual({FOO: 'bar'})
       })
     })

--- a/spec/update-process-env-spec.js
+++ b/spec/update-process-env-spec.js
@@ -7,17 +7,25 @@ import temp from 'temp'
 import child_process from 'child_process'
 import {updateProcessEnv, shouldGetEnvFromShell} from '../src/update-process-env'
 import dedent from 'dedent'
+import {EventEmitter} from 'events'
+import mockSpawn from 'mock-spawn'
 
 describe('updateProcessEnv(launchEnv)', function () {
-  let originalProcessEnv, originalProcessPlatform
+  let originalProcessEnv, originalProcessPlatform, originalSpawn, spawn
 
   beforeEach(function () {
+    originalSpawn = child_process.spawn
+    spawn = mockSpawn()
+    child_process.spawn = spawn
     originalProcessEnv = process.env
     originalProcessPlatform = process.platform
     process.env = {}
   })
 
   afterEach(function () {
+    if (originalSpawn) {
+      child_process.spawn = originalSpawn
+    }
     process.env = originalProcessEnv
     process.platform = originalProcessPlatform
   })
@@ -146,21 +154,15 @@ describe('updateProcessEnv(launchEnv)', function () {
       it('updates process.env to match the environment in the user\'s login shell', async function () {
         process.platform = 'darwin'
         process.env.SHELL = '/my/custom/bash'
-
-        spyOn(child_process, 'execFile').andCallFake((cmd, args, opts, callback) => {
-          expect(cmd).toBe('/my/custom/bash')
-          callback(
-            null,
-            dedent`
-              FOO=BAR=BAZ=QUUX
-              TERM=xterm-something
-              PATH=/usr/bin:/bin:/usr/sbin:/sbin:/crazy/path
-            `
-          )
-        })
-
+        spawn.setDefault(spawn.simple(0, dedent`
+          FOO=BAR=BAZ=QUUX
+          TERM=xterm-something
+          PATH=/usr/bin:/bin:/usr/sbin:/sbin:/crazy/path
+        `))
         await updateProcessEnv(process.env)
-
+        expect(spawn.calls.length).toBe(1)
+        expect(spawn.calls[0].command).toBe('/my/custom/bash')
+        expect(spawn.calls[0].args).toEqual(['-ilc', 'command env'])
         expect(process.env).toEqual({
           FOO: 'BAR=BAZ=QUUX',
           TERM: 'xterm-something',
@@ -176,21 +178,15 @@ describe('updateProcessEnv(launchEnv)', function () {
       it('updates process.env to match the environment in the user\'s login shell', async function () {
         process.platform = 'linux'
         process.env.SHELL = '/my/custom/bash'
-
-        spyOn(child_process, 'execFile').andCallFake((cmd, args, opts, callback) => {
-          expect(cmd).toBe('/my/custom/bash')
-          callback(
-            null,
-            dedent`
-              FOO=BAR=BAZ=QUUX
-              TERM=xterm-something
-              PATH=/usr/bin:/bin:/usr/sbin:/sbin:/crazy/path
-            `
-          )
-        })
-
+        spawn.setDefault(spawn.simple(0, dedent`
+          FOO=BAR=BAZ=QUUX
+          TERM=xterm-something
+          PATH=/usr/bin:/bin:/usr/sbin:/sbin:/crazy/path
+        `))
         await updateProcessEnv(process.env)
-
+        expect(spawn.calls.length).toBe(1)
+        expect(spawn.calls[0].command).toBe('/my/custom/bash')
+        expect(spawn.calls[0].args).toEqual(['-ilc', 'command env'])
         expect(process.env).toEqual({
           FOO: 'BAR=BAZ=QUUX',
           TERM: 'xterm-something',
@@ -205,7 +201,7 @@ describe('updateProcessEnv(launchEnv)', function () {
     describe('on windows', function () {
       it('does not update process.env', async function () {
         process.platform = 'win32'
-        spyOn(child_process, 'execFile')
+        spyOn(child_process, 'spawn')
         process.env = {FOO: 'bar'}
 
         await updateProcessEnv(process.env)

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -509,7 +509,7 @@ class AtomApplication
   openPaths: ({initialPaths, pathsToOpen, executedFrom, pidToKillWhenClosed, newWindow, devMode, safeMode, windowDimensions, profileStartup, window, clearWindowState, addToLastWindow, env}={}) ->
     if not pathsToOpen? or pathsToOpen.length is 0
       return
-
+    env = process.env unless env?
     devMode = Boolean(devMode)
     safeMode = Boolean(safeMode)
     clearWindowState = Boolean(clearWindowState)

--- a/src/update-process-env.js
+++ b/src/update-process-env.js
@@ -1,7 +1,7 @@
 /** @babel */
 
 import fs from 'fs'
-import childProcess from 'child_process'
+import child_process from 'child_process'
 
 const ENVIRONMENT_VARIABLES_TO_PRESERVE = new Set([
   'NODE_ENV',
@@ -64,31 +64,31 @@ async function getEnvFromShell (env) {
   }
 
   let {stdout, error} = await new Promise((resolve) => {
-    let cp
+    let childProcess
     let error
     let stdout = ''
     const killer = () => {
-      if (cp) {
-        cp.kill()
+      if (childProcess) {
+        childProcess.kill()
       }
     }
     process.once('exit', killer)
 
-    cp = childProcess.spawn(env.SHELL, ['-ilc', 'command env'], {encoding: 'utf8', timeout: 5000, detached: true, stdio: ['ignore', 'pipe', process.stderr]})
+    childProcess = child_process.spawn(env.SHELL, ['-ilc', 'command env'], {encoding: 'utf8', timeout: 5000, detached: true, stdio: ['ignore', 'pipe', process.stderr]})
 
     const buffers = []
-    cp.on('error', (e) => {
+    childProcess.on('error', (e) => {
       error = e
     })
-    cp.stdout.on('data', (data) => {
+    childProcess.stdout.on('data', (data) => {
       buffers.push(data)
     })
-    cp.on('close', (code, signal) => {
+    childProcess.on('close', (code, signal) => {
       process.removeListener('exit', killer)
       if (buffers.length) {
         stdout = Buffer.concat(buffers).toString('utf8')
       }
-            
+
       resolve({stdout, error})
     })
   })

--- a/src/update-process-env.js
+++ b/src/update-process-env.js
@@ -101,18 +101,20 @@ async function getEnvFromShell (env) {
     console.log(error)
   }
 
-  if (stdout && stdout.trim() !== '') {
-    let result = {}
-    for (let line of stdout.split('\n')) {
-      if (line.includes('=')) {
-        let components = line.split('=')
-        let key = components.shift()
-        let value = components.join('=')
-        result[key] = value
-      }
-    }
-    return result
+  if (!stdout || stdout.trim() === '') {
+    return null
   }
+
+  let result = {}
+  for (let line of stdout.split('\n')) {
+    if (line.includes('=')) {
+      let components = line.split('=')
+      let key = components.shift()
+      let value = components.join('=')
+      result[key] = value
+    }
+  }
+  return result
 }
 
 export default { updateProcessEnv, shouldGetEnvFromShell }

--- a/src/update-process-env.js
+++ b/src/update-process-env.js
@@ -1,7 +1,7 @@
 /** @babel */
 
 import fs from 'fs'
-import child_process from 'child_process'
+import childProcess from 'child_process'
 
 const ENVIRONMENT_VARIABLES_TO_PRESERVE = new Set([
   'NODE_ENV',
@@ -23,7 +23,7 @@ async function updateProcessEnv (launchEnv) {
     } else if (launchEnv.PWD) {
       envToAssign = launchEnv
     }
-  }  
+  }
 
   if (envToAssign) {
     for (let key in process.env) {
@@ -64,15 +64,15 @@ async function getEnvFromShell (env) {
   let {stdout, error} = await new Promise((resolve) => {
     let error
     let stdout = ''
-    const childProcess = child_process.spawn(env.SHELL, ['-ilc', 'command env'], {encoding: 'utf8', stdio: ['ignore', 'pipe', process.stderr]})
+    const child = childProcess.spawn(env.SHELL, ['-ilc', 'command env'], {encoding: 'utf8', stdio: ['ignore', 'pipe', process.stderr]})
     const buffers = []
-    childProcess.on('error', (e) => {
+    child.on('error', (e) => {
       error = e
     })
-    childProcess.stdout.on('data', (data) => {
+    child.stdout.on('data', (data) => {
       buffers.push(data)
     })
-    childProcess.on('close', (code, signal) => {
+    child.on('close', (code, signal) => {
       if (buffers.length) {
         stdout = Buffer.concat(buffers).toString('utf8')
       }


### PR DESCRIPTION
Fixes #13084

* Listen for the `exit` event on `process`, and kill the child process
* Unregister the event handler once the child process exits
* Switch to use `child_process.spawn` instead of `child_process.execFile` to avoid 100% CPU utilization on linux
* Ensure the environment is always set in `openPaths`