### PR TITLE
Forward compositionstart/end events to KeymapManager to avoid IME issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "electronVersion": "1.3.6",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "7.1.4",
+    "atom-keymap": "7.2.0",
     "atom-space-pen-views": "^2.0.0",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -14,6 +14,8 @@ class WindowEventHandler
 
     @addEventListener(@document, 'keyup', @handleDocumentKeyEvent)
     @addEventListener(@document, 'keydown', @handleDocumentKeyEvent)
+    @addEventListener(@document, 'compositionstart', @handleDocumentCompositionStartEvent)
+    @addEventListener(@document, 'compositionend', @handleDocumentCompositionEndEvent)
     @addEventListener(@document, 'drop', @handleDocumentDrop)
     @addEventListener(@document, 'dragover', @handleDocumentDragover)
     @addEventListener(@document, 'contextmenu', @handleDocumentContextmenu)
@@ -75,6 +77,12 @@ class WindowEventHandler
   handleDocumentKeyEvent: (event) =>
     @atomEnvironment.keymaps.handleKeyboardEvent(event)
     event.stopImmediatePropagation()
+
+  handleDocumentCompositionStartEvent: =>
+    @atomEnvironment.keymaps.handleCompositionStart()
+
+  handleDocumentCompositionEndEvent: =>
+    @atomEnvironment.keymaps.handleCompositionEnd()
 
   handleDrop: (event) ->
     event.preventDefault()


### PR DESCRIPTION
This PR upgrades `atom-keymap` to `7.2.0`, which adds an API for reporting IME composition start and end events. When composition is in progress, all bindings and keystroke replays are suppressed to prevent interference with the IME API.

@ungb It would be great if you could test this out with various languages that require IME such as Japanese and Simplified Chinese. One thing to watch for is multi-keystroke bindings containing single keystrokes that partially match before the IME opens up... for example, `vim-mode-plus` defines `j k` to exit insert mode, but `j i` pops up the IME menu in Japanese text entry. We need to make sure Japanese IME still works.

I'm going to need to do some weird gymnastics to hotfix this to beta with this change so that IME users have a usable Atom build. I don't want to pull in the changes associated with keyup events though, so I may need to use a weird semver suffix to make it work.