### PR TITLE
Revert "Forward compositionstart/end events to KeymapManager to avoid IME issues"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "electronVersion": "1.3.6",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "7.2.0",
+    "atom-keymap": "7.1.4",
     "atom-space-pen-views": "^2.0.0",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -14,8 +14,6 @@ class WindowEventHandler
 
     @addEventListener(@document, 'keyup', @handleDocumentKeyEvent)
     @addEventListener(@document, 'keydown', @handleDocumentKeyEvent)
-    @addEventListener(@document, 'compositionstart', @handleDocumentCompositionStartEvent)
-    @addEventListener(@document, 'compositionend', @handleDocumentCompositionEndEvent)
     @addEventListener(@document, 'drop', @handleDocumentDrop)
     @addEventListener(@document, 'dragover', @handleDocumentDragover)
     @addEventListener(@document, 'contextmenu', @handleDocumentContextmenu)
@@ -77,12 +75,6 @@ class WindowEventHandler
   handleDocumentKeyEvent: (event) =>
     @atomEnvironment.keymaps.handleKeyboardEvent(event)
     event.stopImmediatePropagation()
-
-  handleDocumentCompositionStartEvent: =>
-    @atomEnvironment.keymaps.handleCompositionStart()
-
-  handleDocumentCompositionEndEvent: =>
-    @atomEnvironment.keymaps.handleCompositionEnd()
 
   handleDrop: (event) ->
     event.preventDefault()


### PR DESCRIPTION
Reverts atom/atom#13233

I thought this fixed the problem but it just created a new problem. Was just a *little* too happy with the merge button.