### PR TITLE
Upgrade Electron from 1.3.6 to 1.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "1.3.6",
+  "electronVersion": "1.3.9",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "7.1.6",


### PR DESCRIPTION
- Upgrade Node to 6.5.0 - solves mapped drives on Windows resolving to SMB path #13104
- Fix accessibility always enabled on touch screen https://github.com/electron/electron/pull/7611
- Fix window.opener API not behaving as expected