### PR TITLE
Remap ctrl-alt keys on Linux to avoid i8n keyboard glyphs

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -6,11 +6,11 @@
   'down': 'core:move-down'
   'left': 'core:move-left'
   'right': 'core:move-right'
-  'ctrl-alt-r': 'window:reload'
+  'ctrl-shift-r': 'window:reload'
   'ctrl-shift-i': 'window:toggle-dev-tools'
-  'ctrl-alt-p': 'window:run-package-specs'
+  'ctrl-shift-y': 'window:run-package-specs'
   'ctrl-shift-o': 'application:open-folder'
-  'ctrl-alt-o': 'application:add-project-folder'
+  'ctrl-shift-a': 'application:add-project-folder'
   'ctrl-shift-pageup': 'pane:move-item-left'
   'ctrl-shift-pagedown': 'pane:move-item-right'
   'f11': 'window:toggle-full-screen'
@@ -70,12 +70,12 @@
   'ctrl-k left': 'pane:split-left-and-copy-active-item' # Atom Specific
   'ctrl-k right': 'pane:split-right-and-copy-active-item' # Atom Specific
   'ctrl-k ctrl-w': 'pane:close' # Atom Specific
-  'ctrl-k alt-ctrl-w': 'pane:close-other-items' # Atom Specific
+  'ctrl-k ctrl-alt-w': 'pane:close-other-items' # Atom Specific
   'ctrl-k ctrl-p': 'window:focus-previous-pane'
   'ctrl-k ctrl-n': 'window:focus-next-pane'
-  'ctrl-k ctrl-up':    'window:focus-pane-above'
-  'ctrl-k ctrl-down':  'window:focus-pane-below'
-  'ctrl-k ctrl-left':  'window:focus-pane-on-left'
+  'ctrl-k ctrl-up': 'window:focus-pane-above'
+  'ctrl-k ctrl-down': 'window:focus-pane-below'
+  'ctrl-k ctrl-left': 'window:focus-pane-on-left'
   'ctrl-k ctrl-right': 'window:focus-pane-on-right'
   'alt-1': 'pane:show-item-1'
   'alt-2': 'pane:show-item-2'
@@ -108,16 +108,15 @@
 
   # Sublime Parity
   'ctrl-a': 'core:select-all'
-  'ctrl-alt-shift-p': 'editor:log-cursor-scope'
   'ctrl-k ctrl-u': 'editor:upper-case'
   'ctrl-k ctrl-l': 'editor:lower-case'
   'ctrl-l': 'editor:select-line'
 
 'atom-workspace atom-text-editor:not([mini])':
   # Atom specific
-  'alt-ctrl-z': 'editor:checkout-head-revision'
+  'ctrl-alt-shift-z': 'editor:checkout-head-revision'
   'ctrl-<': 'editor:scroll-to-cursor'
-  'alt-ctrl-f': 'editor:fold-selection'
+  'ctrl-alt-shift-[': 'editor:fold-selection'
 
   # Sublime Parity
   'ctrl-enter': 'editor:newline-below'

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "autocomplete-html": "0.7.2",
     "autocomplete-plus": "2.34.0",
     "autocomplete-snippets": "1.11.0",
-    "autoflow": "0.28.0",
+    "autoflow": "0.29.0",
     "autosave": "0.23.2",
     "background-tips": "0.26.1",
     "bookmarks": "0.43.2",


### PR DESCRIPTION
Matches the work done on Windows in 13e501b12e562f308c935f896a59c21bc282620d and 47ee7c6665b6ff99d730d5294b4b853c0f170ca0