### PR TITLE
Use ctrl-shift-f5 to reload on Win/Linux

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -6,7 +6,7 @@
   'down': 'core:move-down'
   'left': 'core:move-left'
   'right': 'core:move-right'
-  'ctrl-shift-r': 'window:reload'
+  'ctrl-shift-f5': 'window:reload'
   'ctrl-shift-i': 'window:toggle-dev-tools'
   'ctrl-shift-y': 'window:run-package-specs'
   'ctrl-shift-o': 'application:open-folder'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -12,7 +12,7 @@
   'ctrl-down': 'core:move-down'
   'left': 'core:move-left'
   'right': 'core:move-right'
-  'ctrl-shift-r': 'window:reload'
+  'ctrl-shift-f5': 'window:reload'
   'ctrl-shift-i': 'window:toggle-dev-tools'
   'ctrl-shift-y': 'window:run-package-specs'
   'ctrl-shift-o': 'application:open-folder'


### PR DESCRIPTION
This rebinds `windows:reload` command to <kbd>ctrl</kbd><kbd>shift</kbd><kbd>f5</kbd> on Windows and Linux to avoid conflicts with SymbolView package. 

Fixes #13267