### PR TITLE
Fix prepending multiple gutters at once

### DIFF
--- a/spec/gutter-container-component-spec.coffee
+++ b/spec/gutter-container-component-spec.coffee
@@ -139,3 +139,22 @@ describe "GutterContainerComponent", ->
       expect(expectedCustomGutterNode1).toBe atom.views.getView(customGutter1)
       expectedCustomGutterNode3 = gutterContainerComponent.getDomNode().children.item(2)
       expect(expectedCustomGutterNode3).toBe atom.views.getView(customGutter3)
+
+    it "reorders correctly when prepending multiple gutters at once", ->
+      lineNumberGutter = new Gutter(mockGutterContainer, {name: 'line-number'})
+      testState = buildTestState([lineNumberGutter])
+      gutterContainerComponent.updateSync(testState)
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 1
+      expectedCustomGutterNode = gutterContainerComponent.getDomNode().children.item(0)
+      expect(expectedCustomGutterNode).toBe atom.views.getView(lineNumberGutter)
+
+      # Prepend two gutters at once
+      customGutter1 = new Gutter(mockGutterContainer, {name: 'first', priority: -200})
+      customGutter2 = new Gutter(mockGutterContainer, {name: 'second', priority: -100})
+      testState = buildTestState([customGutter1, customGutter2, lineNumberGutter])
+      gutterContainerComponent.updateSync(testState)
+      expect(gutterContainerComponent.getDomNode().children.length).toBe 3
+      expectedCustomGutterNode1 = gutterContainerComponent.getDomNode().children.item(0)
+      expect(expectedCustomGutterNode1).toBe atom.views.getView(customGutter1)
+      expectedCustomGutterNode2 = gutterContainerComponent.getDomNode().children.item(1)
+      expect(expectedCustomGutterNode2).toBe atom.views.getView(customGutter2)

--- a/src/gutter-container-component.coffee
+++ b/src/gutter-container-component.coffee
@@ -103,6 +103,7 @@ class GutterContainerComponent
           @domNode.appendChild(gutterComponent.getDomNode())
         else
           @domNode.insertBefore(gutterComponent.getDomNode(), @domNode.children[indexInOldGutters])
+          indexInOldGutters += 1
 
     # Remove any gutters that were not present in the new gutters state.
     for gutterComponentDescription in @gutterComponents


### PR DESCRIPTION
There's a bug when multiple gutters are prepended at once where their order is not correctly preserved in the dom. The issue is that we do not update indexInOldGutters even though we inserted a dom node in the old gutters dom.

Honestly, I'm unconvinced that this entire logic is correct, but this fixes the use case we have in Nuclide so it's more correct than before :)

Released under CC0