### PR TITLE
Move "Fold all" menu entry to above the "Unfold all" entry

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -108,9 +108,9 @@
         submenu: [
           { label: 'Fold', command: 'editor:fold-current-row' }
           { label: 'Unfold', command: 'editor:unfold-current-row' }
+          { label: 'Fold All', command: 'editor:fold-all' }
           { label: 'Unfold All', command: 'editor:unfold-all' }
           { type: 'separator' }
-          { label: 'Fold All', command: 'editor:fold-all' }
           { label: 'Fold Level 1', command: 'editor:fold-at-indent-level-1' }
           { label: 'Fold Level 2', command: 'editor:fold-at-indent-level-2' }
           { label: 'Fold Level 3', command: 'editor:fold-at-indent-level-3' }

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -81,9 +81,9 @@
         submenu: [
           { label: '&Fold', command: 'editor:fold-current-row' }
           { label: '&Unfold', command: 'editor:unfold-current-row' }
+          { label: 'Fol&d All', command: 'editor:fold-all' }
           { label: 'Unfold &All', command: 'editor:unfold-all' }
           { type: 'separator' }
-          { label: 'Fol&d All', command: 'editor:fold-all' }
           { label: 'Fold Level 1', command: 'editor:fold-at-indent-level-1' }
           { label: 'Fold Level 2', command: 'editor:fold-at-indent-level-2' }
           { label: 'Fold Level 3', command: 'editor:fold-at-indent-level-3' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -89,9 +89,9 @@
         submenu: [
           { label: '&Fold', command: 'editor:fold-current-row' }
           { label: '&Unfold', command: 'editor:unfold-current-row' }
+          { label: 'Fol&d All', command: 'editor:fold-all' }
           { label: 'Unfold &All', command: 'editor:unfold-all' }
           { type: 'separator' }
-          { label: 'Fol&d All', command: 'editor:fold-all' }
           { label: 'Fold Level 1', command: 'editor:fold-at-indent-level-1' }
           { label: 'Fold Level 2', command: 'editor:fold-at-indent-level-2' }
           { label: 'Fold Level 3', command: 'editor:fold-at-indent-level-3' }


### PR DESCRIPTION
Move "Fold all" to above the "Unfold all" and separator. 
Fixes #13262