### PR TITLE
Call `openDevTools` on `WebContents` rather than on `BrowserWindow`

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -116,14 +116,12 @@
       })
     }
 
-    var currentWindow = require('electron').remote.getCurrentWindow()
-    if (currentWindow.devToolsWebContents) {
+    const webContents = require('electron').remote.getCurrentWindow().webContents
+    if (webContents.devToolsWebContents) {
       profile()
     } else {
-      currentWindow.openDevTools()
-      currentWindow.once('devtools-opened', function () {
-        setTimeout(profile, 1000)
-      })
+      webContents.once('devtools-opened', () => { setTimeout(profile, 1000) })
+      webContents.openDevTools()
     }
   }
 


### PR DESCRIPTION
Fixes #13171.

This probably broke after upgrading electron but, since it's a code path we rarely touch, it went unnoticed.

/cc: @atom/maintainers 