### PR TITLE
Add libXScrnSaver dependency to the RPM package spec

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -7,7 +7,7 @@ URL:            https://atom.io/
 AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
-Requires: lsb-core-noarch
+Requires: lsb-core-noarch, libXScrnSaver
 
 %description
 <%= description %>


### PR DESCRIPTION
Fixes #13176.

/cc: @atom/maintainers 