### PR TITLE
Include relatedTarget when dispatching blur events from editor elements

### DIFF
--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -141,7 +141,7 @@ class TextEditorElement extends HTMLElement
 
   inputNodeBlurred: (event) ->
     if event.relatedTarget isnt this
-      @dispatchEvent(new FocusEvent('blur', bubbles: false))
+      @dispatchEvent(new FocusEvent('blur', relatedTarget: event.relatedTarget, bubbles: false))
 
   addGrammarScopeAttribute: ->
     @dataset.grammar = @model.getGrammar()?.scopeName?.replace(/\./g, ' ')


### PR DESCRIPTION
Refs: #13254 

~~In atom-space-pen-views, on require, we call `atom.themes.requireStylesheet` to include a default style sheet for the select list. Now that we are planning to replace all usages of space pen with a more modern alternative (https://github.com/atom/atom-select-list), I believe a better design can be achieved by including a default style sheet in Atom core instead of relying on a require-time call to the `ThemeManager`.~~

This pull request introduces a `relatedTarget` option in the synthesized blur event of `TextEditorElement` to make it easier for users of this API to know the value of `document.activeElement` after the event dispatch. We will use this in atom-select-list to [determine if the user has clicked outside the select list](https://github.com/atom/atom-select-list/blob/fa20fdc7d0763a02aa2f1e2385f8f61e0063eb65/src/select-list-view.js#L35-L41) and, if so, trigger a `didCancelSelection` event.

/cc: @atom/maintainers 