### PR TITLE
Windows taskbar recent & tasks support

### DIFF
--- a/src/reopen-project-menu-manager.js
+++ b/src/reopen-project-menu-manager.js
@@ -46,6 +46,31 @@ export default class ReopenProjectMenuManager {
     this.projects = this.historyManager.getProjects().slice(0, this.config.get('core.reopenProjectMenuCount'))
     const newMenu = ReopenProjectMenuManager.createProjectsMenu(this.projects)
     this.lastProjectMenu = this.menuManager.add([newMenu])
+    this.updateWindowsJumpList()
+  }
+
+  updateWindowsJumpList () {
+    if (process.platform !== 'win32') return
+
+    if (this.app === undefined) {
+      this.app = require('remote').app
+    }
+
+    this.app.setJumpList([
+      {
+        type:'custom',
+        name:'Recent Projects',
+        items: this.projects.map(p => ({
+          type: 'task',
+          title: ReopenProjectMenuManager.createLabel(p),
+          program: process.execPath,
+          args: p.paths.map(path => `"${path}"`).join(' ') }))
+      },
+      { type: 'recent' },
+      { items: [
+          {type: 'task', title: 'New Window', program: process.execPath, args: '--new-window', description: 'Opens a new Atom window'}
+      ]}
+    ])
   }
 
   dispose () {

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -441,7 +441,7 @@ class Workspace extends Model
 
     # Avoid adding URLs as recent documents to work-around this Spotlight crash:
     # https://github.com/atom/atom/issues/10071
-    if uri? and not url.parse(uri).protocol?
+    if uri? and (not url.parse(uri).protocol? or process.platform is 'win32')
       @applicationDelegate.addRecentDocument(uri)
 
     pane = @paneContainer.paneForURI(uri) if searchAllPanes


### PR DESCRIPTION
The task bar supports a number of cool features in Windows we aren't currently using today.

This PR adds;

- Recently files (opened from Explorer, must be associated, can be pinned)
- Recent projects (same as File > Reopen Project including configurable number of items)
- New Window task (same as File> New Window)

A screenshot is worth n number of words.

![image](https://cloud.githubusercontent.com/assets/118951/20551914/4e1a0630-b0fa-11e6-9207-f9b5203e88be.png)
