### PR TITLE
Fix Uncaught TypeError: #12528

### DIFF
--- a/src/reopen-project-menu-manager.js
+++ b/src/reopen-project-menu-manager.js
@@ -58,8 +58,8 @@ export default class ReopenProjectMenuManager {
 
     this.app.setJumpList([
       {
-        type:'custom',
-        name:'Recent Projects',
+        type: 'custom',
+        name: 'Recent Projects',
         items: this.projects.map(p => ({
           type: 'task',
           title: ReopenProjectMenuManager.createLabel(p),

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -909,7 +909,7 @@ class TextEditorComponent
 
   screenRowForNode: (node) ->
     while node?
-      if screenRow = node.dataset.screenRow
+      if screenRow = node.dataset?.screenRow
         return parseInt(screenRow)
       node = node.parentElement
     null


### PR DESCRIPTION
Fixes #12528

This uncaught exception occurs during scrolling if the cursor hovers over a block decoration containing a SVG element.
It fails because `scrollevent.target` doesn't have a property `dataset` since it's a path inside the SVG instead of a DIV.

I discovered this bug during redesigning the output area of [Hydrogen](https://github.com/nteract/hydrogen) in https://github.com/nteract/hydrogen/pull/516.

/cc @mangecoeur