### PR TITLE
Text height should be in Points, not Pixels

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -199,7 +199,7 @@ const configSchema = {
         default: 14,
         minimum: 1,
         maximum: 100,
-        description: 'Height in pixels of editor text.'
+        description: 'Height in points of editor text.'
       },
       lineHeight: {
         type: ['string', 'number'],


### PR DESCRIPTION
This is confusing for users of High-DPI screens