### PR TITLE
Fix highlight movement when horizontally scrolling

### DIFF
--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -2028,6 +2028,27 @@ describe "TextEditorPresenter", ->
 
           expect(stateForHighlightInTile(presenter, highlight, 0)).toBeUndefined()
 
+        it "handles highlights that extend to the left of the visible area (regression)", ->
+          editor.setSelectedBufferRanges([
+            [[0, 2], [1, 4]],
+          ])
+
+          presenter = buildPresenter(explicitHeight: 20, scrollLeft: 0, tileSize: 2)
+          expectValues stateForSelectionInTile(presenter, 0, 0), {
+            regions: [
+              {top: 0 * 10, height: 10, left: 2 * 10, right: 0 * 10},
+              {top: 1 * 10, height: 10, left: 0 * 10, width: 4 * 10}
+            ]
+          }
+
+          presenter = buildPresenter(explicitHeight: 20, scrollLeft: 20, tileSize: 2)
+          expectValues stateForSelectionInTile(presenter, 0, 0), {
+            regions: [
+              {top: 0 * 10, height: 10, left: 2 * 10, right: 0 * 10},
+              {top: 1 * 10, height: 10, left: 0 * 10, width: 4 * 10}
+            ]
+          }
+
         it "updates when ::scrollTop changes", ->
           editor.setSelectedBufferRanges([
             [[6, 2], [6, 4]],

--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -1001,8 +1001,7 @@ class TextEditorPresenter
     @lineHeight? and @baseCharacterWidth?
 
   pixelPositionForScreenPosition: (screenPosition) ->
-    position =
-      @linesYardstick.pixelPositionForScreenPosition(screenPosition)
+    position = @linesYardstick.pixelPositionForScreenPosition(screenPosition)
     position.top -= @getScrollTop()
     position.left -= @getScrollLeft()
 
@@ -1225,13 +1224,14 @@ class TextEditorPresenter
       screenRange.end.column = 0
 
   repositionRegionWithinTile: (region, tileStartRow) ->
-    region.top  += @scrollTop - @lineTopIndex.pixelPositionBeforeBlocksForRow(tileStartRow)
-    region.left += @scrollLeft
+    region.top += @scrollTop - @lineTopIndex.pixelPositionBeforeBlocksForRow(tileStartRow)
 
   buildHighlightRegions: (screenRange) ->
     lineHeightInPixels = @lineHeight
     startPixelPosition = @pixelPositionForScreenPosition(screenRange.start)
     endPixelPosition = @pixelPositionForScreenPosition(screenRange.end)
+    startPixelPosition.left += @scrollLeft
+    endPixelPosition.left += @scrollLeft
     spannedRows = screenRange.end.row - screenRange.start.row + 1
 
     regions = []


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/13349
Fixes https://github.com/atom/atom/issues/12612

The `TextEditorPresenter` was highlight regions' `left` positions to reflect its current `scrollLeft` value, but it was not adjusting their `width` properties properly in some cases.

🎩 @kevinsawicki for pointing this out