### PR TITLE
Upgrade to Electron 1.3.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "1.3.12",
+  "electronVersion": "1.3.13",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "7.1.13",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "1.3.9",
+  "electronVersion": "1.3.12",
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "7.1.13",


### PR DESCRIPTION
Upgrade to Electron 1.3.13 which includes some important bug fixes and an upstream Chrome patch that (hopefully) addresses the Linux keybinding issues on certain layouts when pressing `Ctrl`.

/cc @as-cii @Ben3eeE the version of Electron with the keybinding fix (1.3.13) is now on this branch if you want to try it out 🐧 