### PR TITLE
Add initialize() hook to packages

### DIFF
--- a/spec/fixtures/packages/package-with-deserializers/index.js
+++ b/spec/fixtures/packages/package-with-deserializers/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  initialize() {},
   activate () {},
 
   deserializeMethod1 (state) {

--- a/spec/package-spec.coffee
+++ b/spec/package-spec.coffee
@@ -205,3 +205,26 @@ describe "Package", ->
 
     it "uses the package name defined in package.json", ->
       expect(metadata.name).toBe 'package-with-a-totally-different-name'
+
+  describe "the initialize() hook", ->
+    it "gets called when the package is activated", ->
+      packagePath = atom.project.getDirectories()[0].resolve('packages/package-with-deserializers')
+      pack = buildPackage(packagePath)
+      pack.requireMainModule()
+      mainModule = pack.mainModule
+      spyOn(mainModule, 'initialize')
+      expect(mainModule.initialize).not.toHaveBeenCalled()
+      pack.activate()
+      expect(mainModule.initialize).toHaveBeenCalled()
+      expect(mainModule.initialize.callCount).toBe(1)
+
+    it "gets called when a deserializer is used", ->
+      packagePath = atom.project.getDirectories()[0].resolve('packages/package-with-deserializers')
+      pack = buildPackage(packagePath)
+      pack.requireMainModule()
+      mainModule = pack.mainModule
+      spyOn(mainModule, 'initialize')
+      pack.load()
+      expect(mainModule.initialize).not.toHaveBeenCalled()
+      atom.deserializers.deserialize({deserializer: 'Deserializer1', a: 'b'})
+      expect(mainModule.initialize).toHaveBeenCalled()


### PR DESCRIPTION
This adds a new hook, `initialize()` to packages. This is meant to be called before any interaction with the package. Like `activate()`, it's passed the serialized state from the previous session. Unlike `activate()`, it's called _before_ deserialization, enabling item deserialization that's dependent on serialized package state.

It might be a little weird that a function called "initialize" can be called multiple times…open to bikeshedding the name!