### PR TITLE
Specs: test reliability & auto temp clean-up

### DIFF
--- a/spec/atom-environment-spec.coffee
+++ b/spec/atom-environment-spec.coffee
@@ -1,10 +1,13 @@
 _ = require 'underscore-plus'
 path = require 'path'
-temp = require 'temp'
+temp = require('temp').track()
 AtomEnvironment = require '../src/atom-environment'
 StorageFolder = require '../src/storage-folder'
 
 describe "AtomEnvironment", ->
+  afterEach ->
+    temp.cleanupSync()
+
   describe 'window sizing methods', ->
     describe '::getPosition and ::setPosition', ->
       originalPosition = null
@@ -324,7 +327,7 @@ describe "AtomEnvironment", ->
 
   describe "::unloadEditorWindow()", ->
     it "saves the BlobStore so it can be loaded after reload", ->
-      configDirPath = temp.mkdirSync()
+      configDirPath = temp.mkdirSync('atom-spec-environment')
       fakeBlobStore = jasmine.createSpyObj("blob store", ["save"])
       atomEnvironment = new AtomEnvironment({applicationDelegate: atom.applicationDelegate, enablePersistence: true, configDirPath, blobStore: fakeBlobStore, window, document})
 
@@ -336,7 +339,7 @@ describe "AtomEnvironment", ->
 
   describe "::destroy()", ->
     it "does not throw exceptions when unsubscribing from ipc events (regression)", ->
-      configDirPath = temp.mkdirSync()
+      configDirPath = temp.mkdirSync('atom-spec-environment')
       fakeDocument = {
         addEventListener: ->
         removeEventListener: ->

--- a/spec/babel-spec.coffee
+++ b/spec/babel-spec.coffee
@@ -19,6 +19,7 @@ describe "Babel transpiler support", ->
 
   afterEach ->
     CompileCache.setCacheDirectory(originalCacheDir)
+    temp.cleanupSync()
 
   describe 'when a .js file starts with /** @babel */;', ->
     it "transpiles it using babel", ->

--- a/spec/command-installer-spec.coffee
+++ b/spec/command-installer-spec.coffee
@@ -1,6 +1,6 @@
 path = require 'path'
 fs = require 'fs-plus'
-temp = require 'temp'
+temp = require('temp').track()
 CommandInstaller = require '../src/command-installer'
 
 describe "CommandInstaller on #darwin", ->
@@ -19,6 +19,9 @@ describe "CommandInstaller on #darwin", ->
 
     spyOn(CommandInstaller::, 'getResourcesDirectory').andReturn(resourcesPath)
     spyOn(CommandInstaller::, 'getInstallDirectory').andReturn(installationPath)
+
+  afterEach ->
+    temp.cleanupSync()
 
   it "shows an error dialog when installing commands interactively fails", ->
     appDelegate = jasmine.createSpyObj("appDelegate", ["confirm"])

--- a/spec/compile-cache-spec.coffee
+++ b/spec/compile-cache-spec.coffee
@@ -21,8 +21,8 @@ describe 'CompileCache', ->
     spyOn(TypeScriptSimple::, 'compile').andReturn 'the-typescript-code'
 
   afterEach ->
-    CSON.setCacheDir(CompileCache.getCacheDirectory())
     CompileCache.setAtomHomeDirectory(process.env.ATOM_HOME)
+    CSON.setCacheDir(CompileCache.getCacheDirectory())
     temp.cleanupSync()
 
   describe 'addPathToCache(filePath, atomHome)', ->

--- a/spec/compile-cache-spec.coffee
+++ b/spec/compile-cache-spec.coffee
@@ -23,6 +23,7 @@ describe 'CompileCache', ->
   afterEach ->
     CSON.setCacheDir(CompileCache.getCacheDirectory())
     CompileCache.setAtomHomeDirectory(process.env.ATOM_HOME)
+    temp.cleanupSync()
 
   describe 'addPathToCache(filePath, atomHome)', ->
     describe 'when the given file is plain javascript', ->
@@ -81,6 +82,7 @@ describe 'CompileCache', ->
 
       error = new Error("Oops")
       expect(error.stack).toBe 'a-stack-trace'
+      console.log('stack ' + error.getRawStack())
       expect(Array.isArray(error.getRawStack())).toBe true
 
       waits(1)

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1,5 +1,5 @@
 path = require 'path'
-temp = require 'temp'
+temp = require('temp').track()
 CSON = require 'season'
 fs = require 'fs-plus'
 
@@ -9,13 +9,14 @@ describe "Config", ->
   beforeEach ->
     spyOn(atom.config, "load")
     spyOn(atom.config, "save")
-    dotAtomPath = temp.path('dot-atom-dir')
+    dotAtomPath = temp.path('atom-spec-config')
     atom.config.configDirPath = dotAtomPath
     atom.config.enablePersistence = true
     atom.config.configFilePath = path.join(atom.config.configDirPath, "atom.config.cson")
 
   afterEach ->
     atom.config.enablePersistence = false
+    fs.removeSync(dotAtomPath)
 
   describe ".get(keyPath, {scope, sources, excludeSources})", ->
     it "allows a key path's value to be read", ->
@@ -486,8 +487,8 @@ describe "Config", ->
       observeHandler.reset() # clear the initial call
       atom.config.set('foo.bar.baz', "value 2")
       expect(observeHandler).toHaveBeenCalledWith("value 2")
-      observeHandler.reset()
 
+      observeHandler.reset()
       atom.config.set('foo.bar.baz', "value 1")
       expect(observeHandler).toHaveBeenCalledWith("value 1")
       advanceClock(100) # complete pending save that was requested in ::set

--- a/spec/default-directory-provider-spec.coffee
+++ b/spec/default-directory-provider-spec.coffee
@@ -1,20 +1,26 @@
 DefaultDirectoryProvider = require '../src/default-directory-provider'
 path = require 'path'
 fs = require 'fs-plus'
-temp = require 'temp'
+temp = require('temp').track()
 
 describe "DefaultDirectoryProvider", ->
+  tmp = null
+
+  beforeEach ->
+    tmp = temp.mkdirSync('atom-spec-default-dir-provider')
+
+  afterEach ->
+    temp.cleanupSync()
+
   describe ".directoryForURISync(uri)", ->
     it "returns a Directory with a path that matches the uri", ->
       provider = new DefaultDirectoryProvider()
-      tmp = temp.mkdirSync()
 
       directory = provider.directoryForURISync(tmp)
       expect(directory.getPath()).toEqual tmp
 
     it "normalizes its input before creating a Directory for it", ->
       provider = new DefaultDirectoryProvider()
-      tmp = temp.mkdirSync()
       nonNormalizedPath = tmp + path.sep +  ".." + path.sep + path.basename(tmp)
       expect(tmp.includes("..")).toBe false
       expect(nonNormalizedPath.includes("..")).toBe true
@@ -24,7 +30,6 @@ describe "DefaultDirectoryProvider", ->
 
     it "creates a Directory for its parent dir when passed a file", ->
       provider = new DefaultDirectoryProvider()
-      tmp = temp.mkdirSync()
       file = path.join(tmp, "example.txt")
       fs.writeFileSync(file, "data")
 
@@ -40,7 +45,6 @@ describe "DefaultDirectoryProvider", ->
   describe ".directoryForURI(uri)", ->
     it "returns a Promise that resolves to a Directory with a path that matches the uri", ->
       provider = new DefaultDirectoryProvider()
-      tmp = temp.mkdirSync()
 
       waitsForPromise ->
         provider.directoryForURI(tmp).then (directory) ->

--- a/spec/file-system-blob-store-spec.coffee
+++ b/spec/file-system-blob-store-spec.coffee
@@ -1,4 +1,4 @@
-temp = require 'temp'
+temp = require('temp').track()
 path = require 'path'
 fs = require 'fs-plus'
 FileSystemBlobStore = require '../src/file-system-blob-store'
@@ -7,8 +7,11 @@ describe "FileSystemBlobStore", ->
   [storageDirectory, blobStore] = []
 
   beforeEach ->
-    storageDirectory = temp.path()
+    storageDirectory = temp.path('atom-spec-filesystemblobstore')
     blobStore = FileSystemBlobStore.load(storageDirectory)
+
+  afterEach ->
+    fs.removeSync(storageDirectory)
 
   it "is empty when the file doesn't exist", ->
     expect(blobStore.get("foo", "invalidation-key-1")).toBeUndefined()

--- a/spec/git-repository-provider-spec.coffee
+++ b/spec/git-repository-provider-spec.coffee
@@ -1,6 +1,6 @@
 path = require 'path'
 fs = require 'fs-plus'
-temp = require 'temp'
+temp = require('temp').track()
 {Directory} = require 'pathwatcher'
 GitRepository = require '../src/git-repository'
 GitRepositoryProvider = require '../src/git-repository-provider'
@@ -10,6 +10,9 @@ describe "GitRepositoryProvider", ->
 
   beforeEach ->
     provider = new GitRepositoryProvider(atom.project, atom.config, atom.confirm)
+
+  afterEach ->
+    temp.cleanupSync()
 
   describe ".repositoryForDirectory(directory)", ->
     describe "when specified a Directory with a Git repository", ->

--- a/spec/git-repository-spec.coffee
+++ b/spec/git-repository-spec.coffee
@@ -1,11 +1,11 @@
-temp = require 'temp'
+temp = require('temp').track()
 GitRepository = require '../src/git-repository'
 fs = require 'fs-plus'
 path = require 'path'
 Project = require '../src/project'
 
 copyRepository = ->
-  workingDirPath = temp.mkdirSync('atom-working-dir')
+  workingDirPath = temp.mkdirSync('atom-spec-git')
   fs.copySync(path.join(__dirname, 'fixtures', 'git', 'working-dir'), workingDirPath)
   fs.renameSync(path.join(workingDirPath, 'git.git'), path.join(workingDirPath, '.git'))
   workingDirPath
@@ -19,6 +19,8 @@ describe "GitRepository", ->
 
   afterEach ->
     repo.destroy() if repo?.repo?
+    try
+      temp.cleanupSync() # These tests sometimes lag at shutting down resources
 
   describe "@open(path)", ->
     it "returns null when no repository is found", ->

--- a/spec/grammars-spec.coffee
+++ b/spec/grammars-spec.coffee
@@ -1,6 +1,6 @@
 path = require 'path'
 fs = require 'fs-plus'
-temp = require 'temp'
+temp = require('temp').track()
 GrammarRegistry = require '../src/grammar-registry'
 Grim = require 'grim'
 
@@ -24,6 +24,7 @@ describe "the `grammars` global", ->
   afterEach ->
     atom.packages.deactivatePackages()
     atom.packages.unloadPackages()
+    temp.cleanupSync()
 
   describe ".selectGrammar(filePath)", ->
     it "always returns a grammar", ->
@@ -96,6 +97,7 @@ describe "the `grammars` global", ->
         )
         grammar1 = atom.grammars.loadGrammarSync(grammarPath1)
         expect(atom.grammars.selectGrammar('more.test', '')).toBe grammar1
+        fs.removeSync(grammarPath1)
 
         grammarPath2 = temp.path(suffix: '.json')
         fs.writeFileSync grammarPath2, JSON.stringify(
@@ -105,6 +107,7 @@ describe "the `grammars` global", ->
         )
         grammar2 = atom.grammars.loadGrammarSync(grammarPath2)
         expect(atom.grammars.selectGrammar('more.test', '')).toBe grammar2
+        fs.removeSync(grammarPath2)
 
     it "favors non-bundled packages when breaking scoring ties", ->
       waitsForPromise ->

--- a/spec/integration/helpers/start-atom.coffee
+++ b/spec/integration/helpers/start-atom.coffee
@@ -16,7 +16,7 @@ ChromedriverPort = 9515
 ChromedriverURLBase = "/wd/hub"
 ChromedriverStatusURL = "http://localhost:#{ChromedriverPort}#{ChromedriverURLBase}/status"
 
-userDataDir = temp.mkdirSync('atom-user-data-dir')
+userDataDir = null
 
 chromeDriverUp = (done) ->
   checkStatus = ->
@@ -38,6 +38,7 @@ chromeDriverDown = (done) ->
   setTimeout(checkStatus, 100)
 
 buildAtomClient = (args, env) ->
+  userDataDir = temp.mkdirSync('atom-user-data-dir')
   client = webdriverio.remote(
     host: 'localhost'
     port: ChromedriverPort

--- a/spec/main-process/file-recovery-service.test.js
+++ b/spec/main-process/file-recovery-service.test.js
@@ -2,17 +2,21 @@
 
 import {dialog} from 'electron'
 import FileRecoveryService from '../../src/main-process/file-recovery-service'
-import temp from 'temp'
 import fs from 'fs-plus'
 import sinon from 'sinon'
 import {escapeRegExp} from 'underscore-plus'
+const temp = require('temp').track()
 
 describe("FileRecoveryService", () => {
   let recoveryService, recoveryDirectory
 
   beforeEach(() => {
-    recoveryDirectory = temp.mkdirSync()
+    recoveryDirectory = temp.mkdirSync('atom-spec-file-recovery')
     recoveryService = new FileRecoveryService(recoveryDirectory)
+  })
+
+  afterEach(() => {
+    temp.cleanupSync()
   })
 
   describe("when no crash happens during a save", () => {
@@ -28,6 +32,8 @@ describe("FileRecoveryService", () => {
       recoveryService.didSavePath(mockWindow, filePath)
       assert.equal(fs.listTreeSync(recoveryDirectory).length, 0)
       assert.equal(fs.readFileSync(filePath, 'utf8'), "changed")
+
+      fs.removeSync(filePath)
     })
 
     it("creates only one recovery file when many windows attempt to save the same file, deleting it when the last one finishes saving it", () => {
@@ -48,6 +54,8 @@ describe("FileRecoveryService", () => {
       recoveryService.didSavePath(anotherMockWindow, filePath)
       assert.equal(fs.listTreeSync(recoveryDirectory).length, 0)
       assert.equal(fs.readFileSync(filePath, 'utf8'), "changed")
+
+      fs.removeSync(filePath)
     })
   })
 
@@ -64,6 +72,8 @@ describe("FileRecoveryService", () => {
       recoveryService.didCrashWindow(mockWindow)
       assert.equal(fs.listTreeSync(recoveryDirectory).length, 0)
       assert.equal(fs.readFileSync(filePath, 'utf8'), "some content")
+
+      fs.removeSync(filePath)
     })
 
     it("restores the created recovery file when many windows attempt to save the same file and one of them crashes", () => {
@@ -94,6 +104,8 @@ describe("FileRecoveryService", () => {
       recoveryService.didCrashWindow(anotherMockWindow)
       assert.equal(fs.readFileSync(filePath, 'utf8'), "D")
       assert.equal(fs.listTreeSync(recoveryDirectory).length, 0)
+
+      fs.removeSync(filePath)
     })
 
     it("emits a warning when a file can't be recovered", sinon.test(function () {
@@ -113,6 +125,8 @@ describe("FileRecoveryService", () => {
       assert.equal(logs.length, 1)
       assert.match(logs[0], new RegExp(escapeRegExp(filePath)))
       assert.match(logs[0], new RegExp(escapeRegExp(recoveryFiles[0])))
+
+      fs.removeSync(filePath)
     }))
   })
 

--- a/spec/module-cache-spec.coffee
+++ b/spec/module-cache-spec.coffee
@@ -1,12 +1,15 @@
 path = require 'path'
 Module = require 'module'
 fs = require 'fs-plus'
-temp = require 'temp'
+temp = require('temp').track()
 ModuleCache = require '../src/module-cache'
 
 describe 'ModuleCache', ->
   beforeEach ->
     spyOn(Module, '_findPath').andCallThrough()
+
+  afterEach ->
+    temp.cleanupSync()
 
   it 'resolves Electron module paths without hitting the filesystem', ->
     builtins = ModuleCache.cache.builtins

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -1,6 +1,6 @@
 path = require 'path'
 Package = require '../src/package'
-temp = require 'temp'
+temp = require('temp').track()
 fs = require 'fs-plus'
 {Disposable} = require 'atom'
 {buildKeydownEvent} = require '../src/keymap-extensions'
@@ -16,6 +16,9 @@ describe "PackageManager", ->
 
   beforeEach ->
     workspaceElement = atom.views.getView(atom.workspace)
+
+  afterEach ->
+    temp.cleanupSync()
 
   describe "::getApmPath()", ->
     it "returns the path to the apm command", ->
@@ -643,7 +646,7 @@ describe "PackageManager", ->
         [element, events, userKeymapPath] = []
 
         beforeEach ->
-          userKeymapPath = path.join(temp.path(), "user-keymaps.cson")
+          userKeymapPath = path.join(temp.mkdirSync(), "user-keymaps.cson")
           spyOn(atom.keymaps, "getUserKeymapPath").andReturn(userKeymapPath)
 
           element = createTestElement('test-1')
@@ -659,6 +662,8 @@ describe "PackageManager", ->
           # Avoid leaking user keymap subscription
           atom.keymaps.watchSubscriptions[userKeymapPath].dispose()
           delete atom.keymaps.watchSubscriptions[userKeymapPath]
+
+          temp.cleanupSync()
 
         it "doesn't override user-defined keymaps", ->
           fs.writeFileSync userKeymapPath, """

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -1,4 +1,4 @@
-temp = require 'temp'
+temp = require('temp').track()
 Project = require '../src/project'
 fs = require 'fs-plus'
 path = require 'path'
@@ -11,6 +11,9 @@ describe "Project", ->
 
     # Wait for project's service consumers to be asynchronously added
     waits(1)
+
+  afterEach ->
+    temp.cleanupSync()
 
   describe "serialization", ->
     deserializedProject = null
@@ -51,7 +54,7 @@ describe "Project", ->
 
 
     it "does not deserialize buffers when their path is a directory that exists", ->
-      pathToOpen = path.join(temp.mkdirSync(), 'file.txt')
+      pathToOpen = path.join(temp.mkdirSync('atom-spec-project'), 'file.txt')
 
       waitsForPromise ->
         atom.workspace.open(pathToOpen)
@@ -65,7 +68,7 @@ describe "Project", ->
 
     it "does not deserialize buffers when their path is inaccessible", ->
       return if process.platform is 'win32' # chmod not supported on win32
-      pathToOpen = path.join(temp.mkdirSync(), 'file.txt')
+      pathToOpen = path.join(temp.mkdirSync('atom-spec-project'), 'file.txt')
       fs.writeFileSync(pathToOpen, '')
 
       waitsForPromise ->

--- a/spec/squirrel-update-spec.coffee
+++ b/spec/squirrel-update-spec.coffee
@@ -1,7 +1,7 @@
 {EventEmitter} = require 'events'
 fs = require 'fs-plus'
 path = require 'path'
-temp = require 'temp'
+temp = require('temp').track()
 SquirrelUpdate = require '../src/main-process/squirrel-update'
 Spawner = require '../src/main-process/spawner'
 WinShell = require '../src/main-process/win-shell'
@@ -35,6 +35,9 @@ describe "Windows Squirrel Update", ->
     WinShell.fileContextMenu = new FakeShellOption()
     WinShell.folderContextMenu = new FakeShellOption()
     WinShell.folderBackgroundContextMenu = new FakeShellOption()
+
+  afterEach ->
+    temp.cleanupSync()
 
   it "quits the app on all squirrel events", ->
     app = quit: jasmine.createSpy('quit')

--- a/spec/style-manager-spec.js
+++ b/spec/style-manager-spec.js
@@ -1,4 +1,4 @@
-const temp = require('temp')
+const temp = require('temp').track()
 const StyleManager = require('../src/style-manager')
 
 describe('StyleManager', () => {
@@ -12,6 +12,10 @@ describe('StyleManager', () => {
     styleManager.onDidAddStyleElement((event) => { addEvents.push(event) })
     styleManager.onDidRemoveStyleElement((event) => { removeEvents.push(event) })
     styleManager.onDidUpdateStyleElement((event) => { updateEvents.push(event) })
+  })
+
+  afterEach(() => {
+    temp.cleanupSync()
   })
 
   describe('::addStyleSheet(source, params)', () => {

--- a/spec/theme-manager-spec.coffee
+++ b/spec/theme-manager-spec.coffee
@@ -1,6 +1,6 @@
 path = require 'path'
 fs = require 'fs-plus'
-temp = require 'temp'
+temp = require('temp').track()
 
 describe "atom.themes", ->
   beforeEach ->
@@ -8,6 +8,7 @@ describe "atom.themes", ->
 
   afterEach ->
     atom.themes.deactivateThemes()
+    temp.cleanupSync()
 
   describe "theme getters and setters", ->
     beforeEach ->

--- a/spec/update-process-env-spec.js
+++ b/spec/update-process-env-spec.js
@@ -3,12 +3,12 @@
 
 import {it, fit, ffit, fffit, beforeEach, afterEach} from './async-spec-helpers'
 import path from 'path'
-import temp from 'temp'
 import childProcess from 'child_process'
 import {updateProcessEnv, shouldGetEnvFromShell} from '../src/update-process-env'
 import dedent from 'dedent'
 import {EventEmitter} from 'events'
 import mockSpawn from 'mock-spawn'
+const temp = require('temp').track()
 
 describe('updateProcessEnv(launchEnv)', function () {
   let originalProcessEnv, originalProcessPlatform, originalSpawn, spawn
@@ -28,6 +28,7 @@ describe('updateProcessEnv(launchEnv)', function () {
     }
     process.env = originalProcessEnv
     process.platform = originalProcessPlatform
+    temp.cleanupSync()
   })
 
   describe('when the launch environment appears to come from a shell', function () {

--- a/spec/workspace-element-spec.coffee
+++ b/spec/workspace-element-spec.coffee
@@ -4,6 +4,9 @@ temp = require('temp').track()
 {Disposable} = require 'event-kit'
 
 describe "WorkspaceElement", ->
+  afterEach ->
+    temp.cleanupSync()
+
   describe "when the workspace element is focused", ->
     it "transfers focus to the active pane", ->
       workspaceElement = atom.views.getView(atom.workspace)

--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -1,5 +1,5 @@
 path = require 'path'
-temp = require 'temp'
+temp = require('temp').track()
 TextEditor = require '../src/text-editor'
 Workspace = require '../src/workspace'
 Project = require '../src/project'
@@ -18,6 +18,9 @@ describe "Workspace", ->
     setDocumentEdited = spyOn(atom.applicationDelegate, 'setWindowDocumentEdited')
     atom.project.setPaths([atom.project.getDirectories()[0]?.resolve('dir')])
     waits(1)
+
+  afterEach ->
+    temp.cleanupSync()
 
   describe "serialization", ->
     simulateReload = ->
@@ -1226,7 +1229,7 @@ describe "Workspace", ->
           expect(matches.length).toBe 1
 
       it "includes files and folders that begin with a '.'", ->
-        projectPath = temp.mkdirSync()
+        projectPath = temp.mkdirSync('atom-spec-workspace')
         filePath = path.join(projectPath, '.text')
         fs.writeFileSync(filePath, 'match this')
         atom.project.setPaths([projectPath])


### PR DESCRIPTION
This started-off as trying to figure out why a few tests fail under Windows and indeed should fix a couple of them.

In doing so I decided to make the tests clean up after themselves so that;

- I could see what was going on
- Any resource leaks/locks would show up (there is at least 1 in libgit2/git-utils)
- I didn't have to keep deleting %TEMP% (not automatic on Windows)
- I could now run the specs against a small RAM disk instead (down from 4 minutes to 2)