### PR TITLE
Activate packages immediately if hook had already been triggered

### DIFF
--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -443,11 +443,9 @@ describe "PackageManager", ->
         spyOn(mainModule, 'activate').andCallThrough()
         spyOn(Package.prototype, 'requireMainModule').andCallThrough()
 
-        promise = atom.packages.activatePackage('package-with-activation-hooks')
-
       it "defers requiring/activating the main module until an triggering of an activation hook occurs", ->
+        promise = atom.packages.activatePackage('package-with-activation-hooks')
         expect(Package.prototype.requireMainModule.callCount).toBe 0
-
         atom.packages.triggerActivationHook('language-fictitious:grammar-used')
         atom.packages.triggerDeferredActivationHooks()
 
@@ -458,6 +456,7 @@ describe "PackageManager", ->
           expect(Package.prototype.requireMainModule.callCount).toBe 1
 
       it "does not double register activation hooks when deactivating and reactivating", ->
+        promise = atom.packages.activatePackage('package-with-activation-hooks')
         expect(mainModule.activate.callCount).toBe 0
         atom.packages.triggerActivationHook('language-fictitious:grammar-used')
         atom.packages.triggerDeferredActivationHooks()
@@ -490,6 +489,16 @@ describe "PackageManager", ->
 
         runs ->
           expect(mainModule.activate.callCount).toBe 1
+          expect(Package.prototype.requireMainModule.callCount).toBe 1
+
+      it "activates the package immediately if the activation hook had already been triggered", ->
+        atom.packages.triggerActivationHook('language-fictitious:grammar-used')
+        atom.packages.triggerDeferredActivationHooks()
+
+        waitsForPromise ->
+          atom.packages.activatePackage('package-with-activation-hooks')
+
+        runs ->
           expect(Package.prototype.requireMainModule.callCount).toBe 1
 
     describe "when the package has no main module", ->

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -494,6 +494,7 @@ describe "PackageManager", ->
       it "activates the package immediately if the activation hook had already been triggered", ->
         atom.packages.triggerActivationHook('language-fictitious:grammar-used')
         atom.packages.triggerDeferredActivationHooks()
+        expect(Package.prototype.requireMainModule.callCount).toBe 0
 
         waitsForPromise ->
           atom.packages.activatePackage('package-with-activation-hooks')

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -162,6 +162,8 @@ class Package
         @mainModule.activate?(@packageManager.getPackageState(@name) ? {})
         @mainActivated = true
         @activateServices()
+      @activationCommandSubscriptions?.dispose()
+      @activationHookSubscriptions?.dispose()
     catch error
       @handleError("Failed to activate the #{@name} package", error)
 


### PR DESCRIPTION
Refs: https://github.com/atom/atom/pull/13200#issuecomment-264423190

This pull request fixes a subtle bug that prevented hooks from being triggered on packages that were activated *after* Atom's initialization. In particular, when installing or disabling/enabling a package that relied on the `core:loaded-shell-environment` hook, such package would never activate because the hook had already been triggered.

This problem was not specific to `core:loaded-shell-environment`: in facts, the `grammar-used` hook was affected by it as well, although it was less evident because a `grammar-used` hook is emitted every time a new file is opened, rather than just once as it happens for `core:loaded-shell-environment`.

With this pull request, when a package is activated (either after installing it or after re-enabling it) we will re-trigger all the activation hooks that have been triggered until that moment. In addition, after a package has been successfully activated, we will stop listening to further activation (hooks and commands) events for that specific package.

/cc: @atom/maintainers @joefitzgerald 