### PR TITLE
Replace `space-pen` with `atom-select-list` in `ReopenProjectListView`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "7.1.13",
-    "atom-space-pen-views": "^2.0.0",
+    "atom-select-list": "0.0.6",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",
     "cached-run-in-this-context": "0.4.1",

--- a/src/reopen-project-list-view.js
+++ b/src/reopen-project-list-view.js
@@ -1,59 +1,71 @@
 /** @babel */
 
-import { SelectListView } from 'atom-space-pen-views'
+import SelectListView from 'atom-select-list'
 
-export default class ReopenProjectListView extends SelectListView {
-  initialize (callback) {
+export default class ReopenProjectListView {
+  constructor (callback) {
     this.callback = callback
-    super.initialize()
-    this.addClass('reopen-project')
-    this.list.addClass('mark-active')
+    this.selectListView = new SelectListView({
+      emptyMessage: 'No projects in history.',
+      itemsClassList: ['mark-active'],
+      items: [],
+      filterKeyForItem: (project) => project.name,
+      elementForItem: (project) => {
+        let element = document.createElement('li')
+        if (project.name === this.currentProjectName) {
+          element.classList.add('active')
+        }
+        element.textContent = project.name
+        return element
+      },
+      didConfirmSelection: (project) => {
+        this.cancel()
+        this.callback(project.value)
+      },
+      didCancelSelection: () => {
+        this.cancel()
+      }
+    })
+    this.selectListView.element.classList.add('reopen-project')
   }
 
-  getFilterKey () {
-    return 'name'
+  get element () {
+    return this.selectListView.element
   }
 
-  destroy () {
+  dispose () {
     this.cancel()
+    return this.selectListView.destroy()
   }
 
-  viewForItem (project) {
-    let element = document.createElement('li')
-    if (project.name === this.currentProjectName) {
-      element.classList.add('active')
-    }
-    element.textContent = project.name
-    return element
-  }
-
-  cancelled () {
+  cancel () {
     if (this.panel != null) {
       this.panel.destroy()
     }
     this.panel = null
     this.currentProjectName = null
-  }
-
-  confirmed (project) {
-    this.cancel()
-    this.callback(project.value)
+    if (this.previouslyFocusedElement) {
+      this.previouslyFocusedElement.focus()
+      this.previouslyFocusedElement = null
+    }
   }
 
   attach () {
-    this.storeFocusedElement()
+    this.previouslyFocusedElement = document.activeElement
     if (this.panel == null) {
       this.panel = atom.workspace.addModalPanel({item: this})
     }
-    this.focusFilterEditor()
+    this.selectListView.focus()
+    this.selectListView.reset()
   }
 
-  toggle () {
+  async toggle () {
     if (this.panel != null) {
       this.cancel()
     } else {
       this.currentProjectName = atom.project != null ? this.makeName(atom.project.getPaths()) : null
-      this.setItems(atom.history.getProjects().map(p => ({ name: this.makeName(p.paths), value: p.paths })))
+      const projects = atom.history.getProjects().map(p => ({ name: this.makeName(p.paths), value: p.paths }))
+      await this.selectListView.update({items: projects})
       this.attach()
     }
   }


### PR DESCRIPTION
This pull request uses atom-select-list as a drop-in replacement for atom-space-pen-views. Feature-wise nothing should change, but this will help remove jQuery from Atom.