### PR TITLE
Modified keymap 'ctrl-q' to save files before quiting

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -1,6 +1,6 @@
 'body':
   # Apple specific
-  'cmd-q': 'application:quit'
+  'cmd-q': 'application:safeQuit'
   'cmd-h': 'application:hide'
   'cmd-alt-h': 'application:hide-other-applications'
   'cmd-m': 'application:minimize'

--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -22,7 +22,7 @@
   'ctrl-N': 'application:new-window'
   'ctrl-W': 'window:close'
   'ctrl-o': 'application:open-file'
-  'ctrl-q': 'application:quit'
+  'ctrl-q': 'application:safeQuit'
   'ctrl-T': 'pane:reopen-closed-item'
   'ctrl-n': 'application:new-file'
   'ctrl-s': 'core:save'

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -26,6 +26,7 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     'application:show-preferences': -> ipcRenderer.send('command', 'application:show-settings')
     'application:show-settings': -> ipcRenderer.send('command', 'application:show-settings')
     'application:quit': -> ipcRenderer.send('command', 'application:quit')
+    'application:safeQuit': -> safeQuit(ipcRenderer)
     'application:hide': -> ipcRenderer.send('command', 'application:hide')
     'application:hide-other-applications': -> ipcRenderer.send('command', 'application:hide-other-applications')
     'application:install-update': -> ipcRenderer.send('command', 'application:install-update')
@@ -252,3 +253,8 @@ copyPathToClipboard = (editor, project, clipboard, relative) ->
   if filePath = editor.getPath()
     filePath = project.relativize(filePath) if relative
     clipboard.write(filePath)
+
+safeQuit = (ipcRenderer) ->
+  model = @getModel()
+  model.saveAll()
+  ipcRenderer.send('command', 'application:quit')


### PR DESCRIPTION
This discussion (https://discuss.atom.io/t/quit-confirmation/5572) and the issue #6082 discusses how useful would be having a warning message before quitting because, sometimes when multiple buffers and multiple windows are opened, user wants to close current buffer in current window by pressing Ctrl+W. Unfortunately, they inadvertently pressed Ctrl+Q and everything disappears. If it's a completely new file on a new window, all the written code is lost.
Atom's community manager opposed this warning message, he said:
>I philosophically disagree with quit confirmations because I believe that quit confirmations are solving a real problem with red tape. The real problem is "I don't want to lose data accidentally".

So I decide a different approach, changing the keymap 'ctrl-q', to first save all documents and only after it would quit the program.

Hope you find this useful and that I'm using the proper channel.