### PR TITLE
Replace `libXScrnSaver` with `libXss.so.1` in RPM package spec

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -7,7 +7,7 @@ URL:            https://atom.io/
 AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
-Requires: lsb-core-noarch, libXScrnSaver
+Requires: lsb-core-noarch, libXss.so.1
 
 %description
 <%= description %>


### PR DESCRIPTION
Closes #13354 

This pull request fixes a regression introduced in #13289 that prevented Atom from installing on openSUSE because of a missing dependency. Replacing `libXScrnSaver` with `libXss.so.1` seems to address the problem, making Atom install as expected on Fedora as well as openSUSE.

@cobexer @Adobe-Android @dominuskernel: can you try building this branch and test that it works as expected on your machine? Thanks!