### PR TITLE
Revert "Flush DOM before displaying context menu"

### DIFF
--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -4,7 +4,6 @@ fs = require 'fs-plus'
 {calculateSpecificity, validateSelector} = require 'clear-cut'
 {Disposable} = require 'event-kit'
 {remote} = require 'electron'
-ipcHelpers = require './ipc-helpers'
 MenuHelpers = require './menu-helpers'
 
 platformContextMenu = require('../package.json')?._atomMenu?['context-menu']
@@ -201,8 +200,7 @@ class ContextMenuManager
     menuTemplate = @templateForEvent(event)
 
     return unless menuTemplate?.length > 0
-
-    ipcHelpers.call('window-method', 'openContextMenu', menuTemplate)
+    remote.getCurrentWindow().emit('context-menu', menuTemplate)
     return
 
   clear: ->

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -3,7 +3,6 @@ path = require 'path'
 fs = require 'fs'
 url = require 'url'
 {EventEmitter} = require 'events'
-ContextMenu = require './context-menu'
 
 module.exports =
 class AtomWindow
@@ -101,8 +100,11 @@ class AtomWindow
 
   hasProjectPath: -> @getLoadSettings().initialPaths?.length > 0
 
-  openContextMenu: (menuTemplate) ->
-    new ContextMenu(menuTemplate, this)
+  setupContextMenu: ->
+    ContextMenu = require './context-menu'
+
+    @browserWindow.on 'context-menu', (menuTemplate) =>
+      new ContextMenu(menuTemplate, this)
 
   containsPaths: (paths) ->
     for pathToCheck in paths
@@ -163,6 +165,8 @@ class AtomWindow
     @browserWindow.webContents.on 'will-navigate', (event, url) =>
       unless url is @browserWindow.webContents.getURL()
         event.preventDefault()
+
+    @setupContextMenu()
 
     if @isSpec
       # Spec window's web view should always have focus


### PR DESCRIPTION
Reverts atom/atom#13266 as it doesn't address #2991.

/cc: @vjeux 