### PR TITLE
Fix toggle-line-comments bug in LanguageMode

### DIFF
--- a/src/language-mode.coffee
+++ b/src/language-mode.coffee
@@ -55,7 +55,7 @@ class LanguageMode
           indentLength = buffer.lineForRow(start).match(/^\s*/)?[0].length ? 0
           buffer.insert([start, indentLength], commentStartString)
           buffer.insert([end, buffer.lineLengthForRow(end)], commentEndString)
-    else
+    else if commentStartString
       allBlank = true
       allBlankOrCommented = true
 


### PR DESCRIPTION
This will fix a bug when executing `editor:toggle-line-comments` in a file with a grammar without comments (or without a `commentStartString`), for example plain text.

Before this update i got this exception:
```
TypeError: Cannot read property 'split' of undefined
    at Function.module.exports.Range.fromText (/usr/lib/atom/node_modules/text-buffer/lib/range.js:47:19)
    at TextBuffer.module.exports.TextBuffer.setTextInRange (/usr/lib/atom/node_modules/text-buffer/lib/text-buffer.js:608:24)
    at TextBuffer.module.exports.TextBuffer.insert (/usr/lib/atom/node_modules/text-buffer/lib/text-buffer.js:627:19)
    at LanguageMode.module.exports.LanguageMode.toggleLineCommentsForBufferRows (/usr/lib/atom/src/language-mode.js:98:22)
    at TextEditor.module.exports.TextEditor.toggleLineCommentsForBufferRows (/usr/lib/atom/src/text-editor.js:3570:32)
    at Selection.module.exports.Selection.toggleLineComments (/usr/lib/atom/src/selection.js:684:67)
    at /usr/lib/atom/src/text-editor.js:1405:26
    at /usr/lib/atom/src/text-editor.js:1107:28
    at TextBuffer.module.exports.TextBuffer.transact (/usr/lib/atom/node_modules/text-buffer/lib/text-buffer.js:866:18)
    at TextEditor.module.exports.TextEditor.transact (/usr/lib/atom/src/text-editor.js:1524:26)
    at /usr/lib/atom/src/text-editor.js:1101:24
    at TextEditor.module.exports.TextEditor.mergeSelections (/usr/lib/atom/src/text-editor.js:2498:43)
    at TextEditor.module.exports.TextEditor.mergeIntersectingSelections (/usr/lib/atom/src/text-editor.js:2464:35)
    at TextEditor.module.exports.TextEditor.mutateSelectedText (/usr/lib/atom/src/text-editor.js:1099:19)
    at TextEditor.module.exports.TextEditor.toggleLineCommentsInSelection (/usr/lib/atom/src/text-editor.js:1404:19)
    at TextEditor.editor:toggle-line-comments (/usr/lib/atom/src/register-default-commands.js:612:21)
    at /usr/lib/atom/src/register-default-commands.js:663:34
    at TextBuffer.module.exports.TextBuffer.transact (/usr/lib/atom/node_modules/text-buffer/lib/text-buffer.js:866:18)
    at TextEditor.module.exports.TextEditor.transact (/usr/lib/atom/src/text-editor.js:1524:26)
    at atom-text-editor.newCommandListeners.(anonymous function) (/usr/lib/atom/src/register-default-commands.js:662:22)
    at CommandRegistry.module.exports.CommandRegistry.handleCommandEvent (/usr/lib/atom/src/command-registry.js:259:29)
    at /usr/lib/atom/src/command-registry.js:3:59
    at KeymapManager.module.exports.KeymapManager.dispatchCommandEvent (/usr/lib/atom/node_modules/atom-keymap/lib/keymap-manager.js:587:16)
    at KeymapManager.module.exports.KeymapManager.handleKeyboardEvent (/usr/lib/atom/node_modules/atom-keymap/lib/keymap-manager.js:382:22)
    at WindowEventHandler.module.exports.WindowEventHandler.handleDocumentKeyEvent (/usr/lib/atom/src/window-event-handler.js:106:36)
    at HTMLDocument.<anonymous> (/usr/lib/atom/src/window-event-handler.js:3:59)
```

Atom linked the exception with the issue #6831, but I don't think this issue is related.