### PR TITLE
Suppress TextEditorScrollView scrolled when it shouldn't have warning

### DIFF
--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -420,7 +420,6 @@ class TextEditorComponent
 
   onScrollViewScroll: =>
     if @mounted
-      console.warn "TextEditorScrollView scrolled when it shouldn't have."
       @scrollViewNode.scrollTop = 0
       @scrollViewNode.scrollLeft = 0
 


### PR DESCRIPTION
Per @nathansobo, we’re not sure whether it’s even helpful to know that the text editor has scrolled in this way. It seems to occur often, and I notice it particularly when testing autocomplete-plus providers.

Before:

<img width="753" alt="screen shot 2016-12-09 at 10 09 20 am" src="https://cloud.githubusercontent.com/assets/744740/21031467/c2bc71a8-bdf7-11e6-9c2d-ccdc286091d7.png">

After: 

<img width="799" alt="screen shot 2016-12-09 at 10 10 22 am" src="https://cloud.githubusercontent.com/assets/744740/21031471/cb8ca4ec-bdf7-11e6-9831-2bd43fe0fb41.png">