### PR TITLE
Multiple fixes for RPM and in docs RPM distros.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Atom is only available for 64-bit Linux systems.
 The Linux version does not currently automatically update so you will need to
 repeat these steps to upgrade to future releases.
 
-### Red Hat Linux (Fedora 21 and under, CentOS, Red Hat)
+### Red Hat Enterprise Linux (RHEL) / CentOS
 
 Atom is only available for 64-bit Linux systems.
 
@@ -64,12 +64,12 @@ Atom is only available for 64-bit Linux systems.
 The Linux version does not currently automatically update so you will need to
 repeat these steps to upgrade to future releases.
 
-### Fedora 22+
+### Fedora
 
 Atom is only available for 64-bit Linux systems.
 
 1. Download `atom.x86_64.rpm` from the [Atom releases page](https://github.com/atom/atom/releases/latest).
-2. Run `sudo dnf install ./atom.x86_64.rpm` on the downloaded package.
+2. Run `sudo dnf install atom.x86_64.rpm` on the downloaded package.
 3. Launch Atom using the installed `atom` command.
 
 The Linux version does not currently automatically update so you will need to

--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -49,9 +49,13 @@ To also install the newly built application, use `--create-debian-package` or `-
   sudo update-alternatives --config gcc # choose gcc-5 from the list
   ```
 
-### Fedora / CentOS / RHEL
+### Fedora
 
-* `sudo dnf --assumeyes install make gcc gcc-c++ glibc-devel git-core libgnome-keyring-devel rpmdevtools libX11-devel libxkbfile-devel`
+* `sudo dnf install make gcc gcc-c++ glibc-devel git-core libgnome-keyring-devel rpmdevtools libX11-devel libxkbfile-devel`
+
+### RHEL / CentOS
+
+* `sudo yum install make gcc gcc-c++ glibc-devel git-core libgnome-keyring-devel rpmdevtools libX11-devel libxkbfile-devel`
 
 ### Arch
 

--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -7,7 +7,12 @@ URL:            https://atom.io/
 AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
-Requires: lsb-core-noarch, libXss.so.1
+Requires: lsb-core-noarch
+%if 0%{?fedora} || 0%{?rhel}
+Requires: libXScrnSaver
+%else
+Requires: libXss1
+%endif
 
 %description
 <%= description %>


### PR DESCRIPTION
* Correct requires for libXss across Fedora/RedHat (and derivatives) and SUSE.
* Split instructions for Fedora and RHEL etc. i.e. yum and dnf.
* Never use --assumeyes or -y installing packages. atom 1.12.7 shows if
  this had been done by end users it would have caused them great issue.
* Fedora 22 is End Of Life (EOL), so no instructions needed.