### PR TITLE
:arrow_up: electron-winstaller

### DIFF
--- a/script/package.json
+++ b/script/package.json
@@ -9,7 +9,7 @@
     "csslint": "1.0.2",
     "donna": "1.0.13",
     "electron-packager": "7.3.0",
-    "electron-winstaller": "2.4.0",
+    "electron-winstaller": "2.5.0",
     "fs-extra": "0.30.0",
     "glob": "7.0.3",
     "joanna": "0.0.6",


### PR DESCRIPTION
Get's us the 1.5 version of Squirrel which includes stub for atom.exe that doesn't move (useful for pinning etc)
