### PR TITLE
Signing key changes for Windows

### DIFF
--- a/script/lib/create-windows-installer.js
+++ b/script/lib/create-windows-installer.js
@@ -28,19 +28,19 @@ module.exports = function (packagedAppPath, codeSign) {
   }
 
   const certPath = path.join(os.tmpdir(), 'win.p12')
-  const signing = codeSign && process.env.WIN_P12KEY_URL
+  const signing = codeSign && process.env.ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL
 
   if (signing) {
-    downloadFileFromGithub(process.env.WIN_P12KEY_URL, certPath)
+    downloadFileFromGithub(process.env.ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL, certPath)
     var signParams = []
     signParams.push(`/f ${certPath}`) // Signing cert file
-    signParams.push(`/p ${process.env.WIN_P12KEY_PASSWORD}`) // Signing cert password
+    signParams.push(`/p ${process.env.ATOM_WIN_CODE_SIGNING_CERT_PASSWORD}`) // Signing cert password
     signParams.push('/fd sha256') // File digest algorithm
     signParams.push('/tr http://timestamp.digicert.com') // Time stamp server
     signParams.push('/td sha256') // Times stamp algorithm
     options.signWithParams = signParams.join(' ')
   } else {
-    console.log('Skipping code-signing. Specify the --code-sign option and provide a WIN_P12KEY_URL environment variable to perform code-signing'.gray)
+    console.log('Skipping code-signing. Specify the --code-sign option and provide a ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL environment variable to perform code-signing'.gray)
   }
 
   const cleanUp = function () {


### PR DESCRIPTION
Our new signing key is not yet widely used and is triggering SmartSafe warnings.

We move the new key to new environment variables that match the Mac naming so that master/dev builds continue to be signed with the new key.

The old key is now back on the original environment variables so stable and beta will continue to be signed by the old key for a while.