### PR TITLE
Move package load/activation times into package metadata

### DIFF
--- a/src/package.coffee
+++ b/src/package.coffee
@@ -73,7 +73,7 @@ class Package
   measure: (key, fn) ->
     startTime = Date.now()
     value = fn()
-    @[key] = Date.now() - startTime
+    @metadata[key] = Date.now() - startTime
     value
 
   getType: -> 'atom'


### PR DESCRIPTION
This would be helpful for atom/settings-view#893.  Everything except `loadTime` and `activationTime` are available in the package's metadata, which is pretty much what the Settings View exclusively deals with.  This would prevent an extra call to `atom.packages.getLoadedPackage(name)` when we already have the rest of the package data available.  Unsure if this is a breaking change/if any packages are relying on this (why?).