### PR TITLE
Allow build script to specify install prefix.

### DIFF
--- a/script/build
+++ b/script/build
@@ -42,6 +42,7 @@ const transpileBabelPaths = require('./lib/transpile-babel-paths')
 const transpileCoffeeScriptPaths = require('./lib/transpile-coffee-script-paths')
 const transpileCsonPaths = require('./lib/transpile-cson-paths')
 const transpilePegJsPaths = require('./lib/transpile-peg-js-paths')
+const path = require('path')
 
 process.on('unhandledRejection', function (e) {
   console.error(e.stack || e)
@@ -98,7 +99,8 @@ dumpSymbols()
     }
 
     if (argv.install) {
-      installApplication(packagedAppPath)
+      if (argv.install === true) argv.install = path.join('/usr', 'local')
+      installApplication(packagedAppPath, path.resolve(argv.install))
     } else {
       console.log('Skipping installation. Specify the --install option to install Atom'.gray)
     }

--- a/script/lib/install-application.js
+++ b/script/lib/install-application.js
@@ -7,7 +7,7 @@ const template = require('lodash.template')
 
 const CONFIG = require('../config')
 
-module.exports = function (packagedAppPath) {
+module.exports = function (packagedAppPath, prefix) {
   const packagedAppFileName = path.basename(packagedAppPath)
   if (process.platform === 'darwin') {
     const installationDirPath = path.join(path.sep, 'Applications', packagedAppFileName)
@@ -39,7 +39,7 @@ module.exports = function (packagedAppPath) {
     const apmExecutableName = CONFIG.channel === 'beta' ? 'apm-beta' : 'apm'
     const appName = CONFIG.channel === 'beta' ? 'Atom Beta' : 'Atom'
     const appDescription = CONFIG.appMetadata.description
-    const userLocalDirPath = path.join('/usr', 'local')
+    const userLocalDirPath = prefix
     const shareDirPath = path.join(userLocalDirPath, 'share')
     const installationDirPath = path.join(shareDirPath, atomExecutableName)
     const applicationsDirPath = path.join(shareDirPath, 'applications')
@@ -67,7 +67,7 @@ module.exports = function (packagedAppPath) {
     const desktopEntryTemplate = fs.readFileSync(path.join(CONFIG.repositoryRootPath, 'resources', 'linux', 'atom.desktop.in'))
     const desktopEntryContents = template(desktopEntryTemplate)({
       appName, appFileName: atomExecutableName, description: appDescription,
-      installDir: '/usr', iconPath
+      installDir: userLocalDirPath, iconPath
     })
     fs.writeFileSync(desktopEntryPath, desktopEntryContents)
 


### PR DESCRIPTION
This change is a _work in progess_.

Used twice successfully with v1.12.6 and v1.12.7, linux only.

Sparked from #13240 & #13389.