### PR TITLE
Use package-specific transpilation options during tests

### DIFF
--- a/src/initialize-test-window.coffee
+++ b/src/initialize-test-window.coffee
@@ -19,6 +19,7 @@ module.exports = ({blobStore}) ->
     path = require 'path'
     {ipcRenderer} = require 'electron'
     {getWindowLoadSettings} = require './window-load-settings-helpers'
+    CompileCache = require './compile-cache'
     AtomEnvironment = require '../src/atom-environment'
     ApplicationDelegate = require '../src/application-delegate'
     Clipboard = require '../src/clipboard'
@@ -57,6 +58,13 @@ module.exports = ({blobStore}) ->
     exportsPath = path.join(getWindowLoadSettings().resourcePath, 'exports')
     require('module').globalPaths.push(exportsPath)
     process.env.NODE_PATH = exportsPath # Set NODE_PATH env variable since tasks may need it.
+
+    # Set up optional transpilation for packages under test if any
+    FindParentDir = require 'find-parent-dir'
+    if packageRoot = FindParentDir.sync(testPaths[0], 'package.json')
+      packageMetadata = require(path.join(packageRoot, 'package.json'))
+      if packageMetadata.atomTranspilers
+        CompileCache.addTranspilerConfigForPath(packageRoot, packageMetadata.name, packageMetadata, packageMetadata.atomTranspilers)
 
     document.title = "Spec Suite"
 

--- a/src/native-compile-cache.js
+++ b/src/native-compile-cache.js
@@ -74,7 +74,13 @@ class NativeCompileCache {
           self.cacheStore.delete(cacheKey)
         }
       } else {
-        let compilationResult = cachedVm.runInThisContext(wrapper, filename)
+        let compilationResult
+        try {
+          compilationResult = cachedVm.runInThisContext(wrapper, filename)
+        } catch (err) {
+          console.error(`Error running script ${filename}`)
+          throw err
+        }
         if (compilationResult.cacheBuffer) {
           self.cacheStore.set(cacheKey, invalidationKey, compilationResult.cacheBuffer)
         }


### PR DESCRIPTION
Turns out that packages were not transpiled using the transpiler under `atomTranspilers` during tests due to the way the test window is initialized. This fixes that issue.

/cc @atom/core 