### PR TITLE
Added keymap to insert current date

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -31,6 +31,7 @@
   'cmd-alt-ctrl-p': 'window:run-package-specs'
   'ctrl-shift-left': 'pane:move-item-left'
   'ctrl-shift-right': 'pane:move-item-right'
+  'ctrl-alt-d': 'editor:insert-date'
 
   # Sublime Parity
   'cmd-,': 'application:show-settings'

--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -16,6 +16,7 @@
   'f11': 'window:toggle-full-screen'
   'alt-shift-left': 'editor:move-selection-left'
   'alt-shift-right': 'editor:move-selection-right'
+  'ctrl-alt-d': 'editor:insert-date'
 
   # Sublime Parity
   'ctrl-,': 'application:show-settings'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -22,6 +22,7 @@
   'f11': 'window:toggle-full-screen'
   'alt-shift-left': 'editor:move-selection-left'
   'alt-shift-right': 'editor:move-selection-right'
+  'ctrl-alt-d': 'editor:insert-date'
 
   # Sublime Parity
   'ctrl-,': 'application:show-settings'

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -140,6 +140,7 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
     'editor:select-to-previous-subword-boundary': -> @selectToPreviousSubwordBoundary()
     'editor:select-to-first-character-of-line': -> @selectToFirstCharacterOfLine()
     'editor:select-line': -> @selectLinesContainingCursors()
+    'editor:insert-date': ->  @getModel().insertText(new Date().toLocaleString())
   )
 
   commandRegistry.add 'atom-text-editor', stopEventPropagationAndGroupUndo(config,


### PR DESCRIPTION
This feature allows the user to quickly add the current date to the editor buffer by pressing 'ctrl-alt-d' :
![1](https://cloud.githubusercontent.com/assets/9059178/21296303/b86d39c4-c560-11e6-82d6-81f80366a345.PNG)
