### PR TITLE
Prevent builds on Node 7+ until they're fixed

### DIFF
--- a/script/lib/verify-machine-requirements.js
+++ b/script/lib/verify-machine-requirements.js
@@ -17,7 +17,7 @@ module.exports = function () {
 function verifyNode () {
   const fullVersion = process.versions.node
   const majorVersion = fullVersion.split('.')[0]
-  if (majorVersion >= 4) {
+  if (majorVersion >= 4 && majorVersion < 7) {
     console.log(`Node:\tv${fullVersion}`)
   } else if (majorVersion >= 7) {
     throw new Error(`Atom does not build properly on node v7+. node v${fullVersion} is installed.`)

--- a/script/lib/verify-machine-requirements.js
+++ b/script/lib/verify-machine-requirements.js
@@ -19,6 +19,8 @@ function verifyNode () {
   const majorVersion = fullVersion.split('.')[0]
   if (majorVersion >= 4) {
     console.log(`Node:\tv${fullVersion}`)
+  } else if (majorVersion >= 7) {
+    throw new Error(`Atom does not build properly on node v7+. node v${fullVersion} is installed.`)
   } else {
     throw new Error(`node v4+ is required to build Atom. node v${fullVersion} is installed.`)
   }


### PR DESCRIPTION
I ran into strange problems with builds not working when I accidentally upgraded my environment to Node v7. I believe @damieng got bitten by this too. I figured I would save us and others the trouble :grinning: