### PR TITLE
Fix bad title bar path when viewing files not in a project folder

### DIFF
--- a/spec/workspace-spec.coffee
+++ b/spec/workspace-spec.coffee
@@ -887,7 +887,7 @@ describe "Workspace", ->
   describe "document.title", ->
     describe "when there is no item open", ->
       it "sets the title to 'untitled'", ->
-        expect(document.title).toEqual "untitled"
+        expect(document.title).toMatch ///^untitled///
 
     describe "when the active pane item's path is not inside a project path", ->
       beforeEach ->
@@ -951,7 +951,7 @@ describe "Workspace", ->
         it "updates the title to be untitled", ->
           atom.workspace.getActivePane().destroy()
           expect(atom.workspace.getActivePaneItem()).toBeUndefined()
-          expect(document.title).toEqual "untitled"
+          expect(document.title).toMatch ///^untitled///
 
       describe "when an inactive pane's item changes", ->
         it "does not update the title", ->

--- a/src/workspace.coffee
+++ b/src/workspace.coffee
@@ -182,7 +182,7 @@ class Workspace extends Model
       projectPath = _.find projectPaths, (projectPath) ->
         itemPath is projectPath or itemPath?.startsWith(projectPath + path.sep)
     itemTitle ?= "untitled"
-    projectPath ?= projectPaths[0]
+    projectPath ?= if itemPath then path.dirname(itemPath) else null
     if projectPath?
       projectPath = fs.tildify(projectPath)
 


### PR DESCRIPTION
In cases where the active pane item has a path that is not inside a current project folder, we display the first project folder in the title bar. This can be misleading. For instance, with a project setup like this:

```
project
└ folder1
  └ package.json
└ folder2
  └ package.json
```

If we open `~/random/path/package.json`, the title bar will show `package.json — folder1`, which is incorrect. This made more sense previously, when the project only contained a single folder, but now the behavior seems misleading.

In order to provide the most pertinent information, this PR changes the behavior to the following:

* If the active pane item has a path that is included in a project folder, we show `item title — project folder` (as is the current behavior)
* If the active pane item has a path that is NOT included in a project folder, we show `item title — path to file` (where the path does not include the filename — in the example above, it'd be `~/random/path`)
* If there is no active pane item (i.e., the pane is empty), we simply show `untitled`

Fixes #5058
Fixes #5585
Fixes #10710

/cc @atom/feedback 