### PR TITLE
Limit line decoration update to visible row range

### DIFF
--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -1141,7 +1141,9 @@ class TextEditorPresenter
       @lineNumberDecorationsByScreenRow[screenRow] ?= {}
       @lineNumberDecorationsByScreenRow[screenRow][decorationId] = properties
     else
-      for row in [screenRange.start.row..screenRange.end.row] by 1
+      startRow = Math.max(screenRange.start.row, @getStartTileRow())
+      endRow = Math.min(screenRange.end.row, @getEndTileRow() + @tileSize)
+      for row in [startRow..endRow] by 1
         continue if properties.onlyHead and row isnt headScreenPosition.row
         continue if omitLastRow and row is screenRange.end.row
 


### PR DESCRIPTION
Previously, if we had selections exceeding the visible range we still add line decorations to the cache for every row in the selection, including rows that were off screen and not rendered. This resulted in massive slowdowns when rendering with a large selection.

Here's some profiles showing me scrolling a 250,000-line file with a single selection spanning the entire file.

Before this change, 500ms frames and terribleness:

![screen shot 2016-12-21 at 6 27 25 pm](https://cloud.githubusercontent.com/assets/1789/21412186/8b7dac08-c7ab-11e6-9f60-5f3150ec155b.png)

After this change, the line decorations don't appear in the profile, frames down to ~10ms.

![screen shot 2016-12-21 at 6 28 43 pm](https://cloud.githubusercontent.com/assets/1789/21412208/c3c8208e-c7ab-11e6-91e3-3c95aaf82159.png)

/cc @maxbrunsfeld 