### PR TITLE
Add atom.tooltips.findTooltips(target)

### DIFF
--- a/spec/tooltip-manager-spec.coffee
+++ b/spec/tooltip-manager-spec.coffee
@@ -208,6 +208,6 @@ describe "TooltipManager", ->
         disposable = manager.add element, title: "Title"
         hover element, ->
           expect(document.body.querySelector(".tooltip")).not.toBeNull()
-          manager.findTooltips(element)[0].hide();
+          manager.findTooltips(element)[0].hide()
           expect(document.body.querySelector(".tooltip")).toBeNull()
           disposable.dispose()

--- a/spec/tooltip-manager-spec.coffee
+++ b/spec/tooltip-manager-spec.coffee
@@ -185,8 +185,29 @@ describe "TooltipManager", ->
 
     describe "when the window is resized", ->
       it "hides the tooltips", ->
-        manager.add element, title: "Title"
+        disposable = manager.add element, title: "Title"
         hover element, ->
           expect(document.body.querySelector(".tooltip")).not.toBeNull()
           window.dispatchEvent(new CustomEvent('resize'))
           expect(document.body.querySelector(".tooltip")).toBeNull()
+          disposable.dispose()
+
+    describe "findTooltips", ->
+      it "adds and remove tooltips correctly", ->
+        expect(manager.findTooltips(element).length).toBe(0)
+        disposable1 = manager.add element, title: "elem1"
+        expect(manager.findTooltips(element).length).toBe(1)
+        disposable2 = manager.add element, title: "elem2"
+        expect(manager.findTooltips(element).length).toBe(2)
+        disposable1.dispose()
+        expect(manager.findTooltips(element).length).toBe(1)
+        disposable2.dispose()
+        expect(manager.findTooltips(element).length).toBe(0)
+
+      it "lets us hide tooltips programatically", ->
+        disposable = manager.add element, title: "Title"
+        hover element, ->
+          expect(document.body.querySelector(".tooltip")).not.toBeNull()
+          manager.findTooltips(element)[0].hide();
+          expect(document.body.querySelector(".tooltip")).toBeNull()
+          disposable.dispose()

--- a/src/tooltip-manager.coffee
+++ b/src/tooltip-manager.coffee
@@ -130,7 +130,7 @@ class TooltipManager
 
     tooltip = new Tooltip(target, options, @viewRegistry)
 
-    if !@tooltips.has(target)
+    if not @tooltips.has(target)
       @tooltips.set(target, [])
     @tooltips.get(target).push(tooltip)
 
@@ -148,9 +148,9 @@ class TooltipManager
       if @tooltips.has(target)
         tooltipsForTarget = @tooltips.get(target)
         index = tooltipsForTarget.indexOf(tooltip)
-        if index != -1
+        if index isnt -1
           tooltipsForTarget.splice(index, 1)
-        if tooltipsForTarget.length == 0
+        if tooltipsForTarget.length is 0
           @tooltips.delete(target)
 
     disposable

--- a/src/tooltip-manager.coffee
+++ b/src/tooltip-manager.coffee
@@ -155,6 +155,11 @@ class TooltipManager
 
     disposable
 
+  # Extended: Find the tooltips that have been applied to the given element.
+  #
+  # * `target` The `HTMLElement` to find tooltips on.
+  #
+  # Returns an {Array} of `Tooltip` objects that match the `target`.
   findTooltips: (target) ->
     if @tooltips.has(target)
       @tooltips.get(target).slice()

--- a/src/tooltip-manager.coffee
+++ b/src/tooltip-manager.coffee
@@ -56,6 +56,7 @@ class TooltipManager
     {delay: {show: 1000, hide: 100}}
 
   constructor: ({@keymapManager, @viewRegistry}) ->
+    @tooltips = new Map()
 
   # Essential: Add a tooltip to the given element.
   #
@@ -129,18 +130,36 @@ class TooltipManager
 
     tooltip = new Tooltip(target, options, @viewRegistry)
 
+    if !@tooltips.has(target)
+      @tooltips.set(target, [])
+    @tooltips.get(target).push(tooltip)
+
     hideTooltip = ->
       tooltip.leave(currentTarget: target)
       tooltip.hide()
 
     window.addEventListener('resize', hideTooltip)
 
-    disposable = new Disposable ->
+    disposable = new Disposable =>
       window.removeEventListener('resize', hideTooltip)
       hideTooltip()
       tooltip.destroy()
 
+      if @tooltips.has(target)
+        tooltipsForTarget = @tooltips.get(target)
+        index = tooltipsForTarget.indexOf(tooltip)
+        if index != -1
+          tooltipsForTarget.splice(index, 1)
+        if tooltipsForTarget.length == 0
+          @tooltips.delete(target)
+
     disposable
+
+  findTooltips: (target) ->
+    if @tooltips.has(target)
+      @tooltips.get(target).slice()
+    else
+      []
 
 humanizeKeystrokes = (keystroke) ->
   keystrokes = keystroke.split(' ')


### PR DESCRIPTION
Right now, it is not possible to hide a tooltip programatically. This is useful when we know better than the tooltip implementation that we did an action that should hide it.

After discussing with @lee-dohm, he suggested the findTooltips API that mimicks the KeyMapManager API.

Released under CC0
