### PR TITLE
Markdown for numbered list in Issues Template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -22,8 +22,8 @@ Do you want to ask a question? Are you looking for support? The Atom message boa
 ### Steps to Reproduce
 
 1. [First Step]
-2. [Second Step]
-3. [and so on...]
+1. [Second Step]
+1. [and so on...]
 
 **Expected behavior:** [What you expect to happen]
 


### PR DESCRIPTION
### Description of the Change

I changed the Github Issues Template so that the numbered list uses repeating `1.` instead of incrementing numeric values.

### Alternate Designs

The current numbering scheme could still be used, but ... see *Benefits* for why I prefer not.

### Why Should This Be In Core?

This is the code repo that this specific Issues Template is used for.

### Benefits

I found that it is much easier to edit a numbered list in any Markdown document that uses repeating numbering instead of incremental numbers that represent the actual numbering that is rendered. It is much easier to add and remove any list element if repeated numbering is used. I only have to focus on the element's content and not the position that it appears in the list. Otherwise, I would have to also manually edit the numbers for any element that appears after the added/removed element. The numbering applied in the raw Markdown is ignored by the HTML renderer anyway, since it will be converted to HTML `<ol><li>`.

### Possible Drawbacks

The repeated numbering may be confusing for those less familiar with Markdown than if reading the raw Markdown code with incremental numbering. However, I would argue that the learning curve to understand how repeated numbering will be rendered is quite minimal. Markdown has become a universal documentation standard in the software world anyways.

### Applicable Issues

None that I am aware of.

### Other Notes

PRs similar to this one could potentially be applied to other projects under the **Atom** organization, such as [settings-view](https://github.com/atom/settings-view/blob/master/ISSUE_TEMPLATE.md) and [tree-view](https://github.com/atom/tree-view/blob/master/ISSUE_TEMPLATE.md).
