### PR TITLE
Update languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "language-todo": "0.29.1",
     "language-toml": "0.18.1",
     "language-xml": "0.34.13",
-    "language-yaml": "0.27.1"
+    "language-yaml": "0.27.2"
   },
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "language-sass": "0.57.1",
     "language-shellscript": "0.24.0",
     "language-source": "0.9.0",
-    "language-sql": "0.25.1",
+    "language-sql": "0.25.2",
     "language-text": "0.7.1",
     "language-todo": "0.29.1",
     "language-toml": "0.18.1",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "language-html": "0.47.1",
     "language-hyperlink": "0.16.1",
     "language-java": "0.25.0",
-    "language-javascript": "0.124.0",
+    "language-javascript": "0.125.0",
     "language-json": "0.18.3",
     "language-less": "0.30.0",
     "language-make": "0.22.3",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "language-go": "0.43.0",
     "language-html": "0.47.1",
     "language-hyperlink": "0.16.1",
-    "language-java": "0.24.0",
+    "language-java": "0.25.0",
     "language-javascript": "0.124.0",
     "language-json": "0.18.3",
     "language-less": "0.30.0",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "language-php": "0.37.3",
     "language-property-list": "0.9.0",
     "language-python": "0.45.1",
-    "language-ruby": "0.70.3",
+    "language-ruby": "0.70.4",
     "language-ruby-on-rails": "0.25.1",
     "language-sass": "0.57.1",
     "language-shellscript": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "welcome": "0.35.2",
     "whitespace": "0.36.0",
     "wrap-guide": "0.39.0",
-    "language-c": "0.54.0",
+    "language-c": "0.54.1",
     "language-clojure": "0.22.1",
     "language-coffee-script": "0.48.2",
     "language-csharp": "0.13.0",


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* language-c
  * Fixes an issue where lines were merged even if they weren't supposed to
  * Improves ternary expression highlighting
  * Minor code cleanup
* language-java
  * Large rewrite to how `new` is matched and tokenized
  * Fixes static initialization blocks not being recognized
* language-javascript
  * Ligature support for `!!`
  * Fixes highlighting for multiline imports
  * Unsurprisingly, more JSDoc improvements and fixes
* language-ruby
  * Remove `*.erb` files from the recognized filetypes
* language-sql
  * Add `timestamptz` as a recognized keyword
* language-yaml
  * Add `.yml.erb` and `.yaml.erb` to the recognized filetypes

### Alternate Designs

N/A

### Why Should This Be In Core?

N/A

### Benefits

See above.

### Possible Drawbacks

Possible regressions are always a possibility.  Things to look out for this time include Java tokenization regressions (especially around lines containing `new` and `static`).

### Applicable Issues

N/A

Coming up: more language-java and language-c bugfixes, as well as a giant overhaul of language-css.