### PR TITLE
Add dalek package to let people know when they have built-in packages installed in ~/.atom/packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "bookmarks": "0.44.1",
     "bracket-matcher": "0.85.2",
     "command-palette": "0.40.2",
+    "dalek": "0.2.0",
     "deprecation-cop": "0.56.2",
     "dev-live-reload": "0.47.0",
     "encoding-selector": "0.23.1",


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

The [dalek package](https://github.com/atom/dalek) checks after Atom activates the initial set of packages to see if there are packages that are installed both as built-in packages and as community packages. When people install built-in packages as community packages (often to get "the latest version") because built-in packages are designed to work with a specific version of Atom, strange bugs can happen that are very hard to diagnose. The dalek packages detects this problematic situation and notifies the person running Atom, giving them the information they need to correct the situation.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

* Automatic uninstallation - discounts that there can be valid reasons for this configuration

### Why Should This Be In Core?

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

This functionality is in a package.

### Benefits

<!-- What benefits will be realized by the code change? -->

* Reduced support overhead caused by people being in this situation without knowing it can cause problems

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

* Temporarily increased support overhead caused by people learning that this is a problem

### Applicable Issues

<!-- Enter any applicable Issues here -->

Fixes https://github.com/atom/atom/issues/11090