### PR TITLE
Fixing Install issue for linux redhat distro

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -8,7 +8,7 @@ AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
 Requires: lsb-core-noarch
-%if 0%{?fedora} || 0%{?rhel}
+%if 0%{?rhel}%{?fedora}
 Requires: libXScrnSaver
 %else
 Requires: libXss1


### PR DESCRIPTION
### Requirements

Tested on Centos.  the logic before tried to use || for or, but seems to return false for redhat distros, changed statement based on doc here: https://fedoraproject.org/wiki/Packaging:DistTag.  I am new to the build script logic.  @as-cii  @iolsen  can you take a look?  It's working for me on a clean install of centos on VM. 

/cc @philwyett-hemi since I'm modifying the logic that was merged.


### Description of the Change

Change logic in if statement for require for redhat distro.

### Alternate Designs

N/A

### Why Should This Be In Core?

This is currently breaking for Centos and Redhat users.

### Benefits

Fixes issue with installing on centos and redhat.



### Possible Drawbacks

N/A, after the last change this is already broken.

see comments in https://github.com/atom/atom/pull/13421

### Applicable Issues

https://github.com/atom/atom/issues/13417