### PR TITLE
Call debounced cursor blink resume callback any time the cursor moves

### DIFF
--- a/src/text-editor-presenter.coffee
+++ b/src/text-editor-presenter.coffee
@@ -1412,11 +1412,10 @@ class TextEditorPresenter
     @emitDidUpdateState()
 
   pauseCursorBlinking: ->
-    if @isCursorBlinking()
-      @stopBlinkingCursors(true)
-      @startBlinkingCursorsAfterDelay ?= _.debounce(@startBlinkingCursors, @getCursorBlinkResumeDelay())
-      @startBlinkingCursorsAfterDelay()
-      @emitDidUpdateState()
+    @stopBlinkingCursors(true)
+    @startBlinkingCursorsAfterDelay ?= _.debounce(@startBlinkingCursors, @getCursorBlinkResumeDelay())
+    @startBlinkingCursorsAfterDelay()
+    @emitDidUpdateState()
 
   requestAutoscroll: (position) ->
     @pendingScrollLogicalPosition = position


### PR DESCRIPTION
Previously, we were only calling the debounced resume callback when the cursor was already blinking, but this meant we didn't renew the debounce window. This in turn meant we attempted to start blinking the cursor again every 100ms regardless of cursor interactions, which was consuming an extra frame and causing cursor movement to not feel smooth.