### PR TITLE
Upgrade atom-keymap to fix issues with multiple layouts on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "electronVersion": "1.3.13",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "7.1.16",
+    "atom-keymap": "7.1.17",
     "atom-select-list": "0.0.6",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "electronVersion": "1.3.13",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "7.1.17",
+    "atom-keymap": "7.1.18",
     "atom-select-list": "0.0.6",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "electronVersion": "1.3.13",
   "dependencies": {
     "async": "0.2.6",
-    "atom-keymap": "7.1.15",
+    "atom-keymap": "7.1.16",
     "atom-select-list": "0.0.6",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",


### PR DESCRIPTION
@Ben3eeE, @ungb: @as-cii and I are hoping that this version of `atom-keymap` fixes https://github.com/atom/atom/issues/13131 by improving our detection of the native keyboard layout on Gnome systems. Could you two give this a spin on Gnome and see if we're right about that? You should be able to download the builds associated with this branch.

I've decided to hold off on removing the fallback code via https://github.com/atom/atom-keymap/pull/201 in the name of introducing less change. I think if we can reliably detect the layout, that code should be okay to run.

PS: If we're still failing to match any other bundled keystrokes, it might be worth creating an issue summarizing the platform, layout, and keystroke combinations that are still problematic.