### PR TITLE
Don't convert paths to real paths when building text buffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "normalize-package-data": "^2.0.0",
     "nslog": "^3",
     "oniguruma": "6.1.0",
-    "pathwatcher": "6.8.0-0",
+    "pathwatcher": "6.8.0",
     "postcss": "5.2.4",
     "postcss-selector-parser": "2.2.1",
     "property-accessors": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "keybinding-resolver": "0.35.0",
     "line-ending-selector": "0.5.1",
     "link": "0.31.2",
-    "markdown-preview": "0.159.1",
+    "markdown-preview": "0.159.2",
     "metrics": "1.1.2",
     "notifications": "0.65.2",
     "open-on-github": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "normalize-package-data": "^2.0.0",
     "nslog": "^3",
     "oniguruma": "6.1.0",
-    "pathwatcher": "^6.7.1",
+    "pathwatcher": "6.8.0-0",
     "postcss": "5.2.4",
     "postcss-selector-parser": "2.2.1",
     "property-accessors": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "symbols-view": "0.114.0",
     "tabs": "0.103.1",
     "timecop": "0.33.2",
-    "tree-view": "0.213.0",
+    "tree-view": "0.213.1",
     "update-package-dependencies": "0.10.0",
     "welcome": "0.35.2",
     "whitespace": "0.36.1",

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -225,11 +225,11 @@ class Project extends Model
       uri
     else
       if fs.isAbsolute(uri)
-        path.normalize(fs.absolute(uri))
+        path.normalize(fs.resolveHome(uri))
 
       # TODO: what should we do here when there are multiple directories?
       else if projectPath = @getPaths()[0]
-        path.normalize(fs.absolute(path.join(projectPath, uri)))
+        path.normalize(fs.resolveHome(path.join(projectPath, uri)))
       else
         undefined
 


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/9879
Refs https://github.com/atom/atom/pull/10856
Refs https://github.com/atom/text-buffer/pull/182
Refs https://github.com/facebook/nuclide/issues/697

/cc @dirk-thomas I have talked to some others on our team, and reconsidered this problem. I feel really bad for the delay in resolving this issue, and all of the work that you've done to propose solutions.

Where we stand right now, we think that the right solution is probably to simply remove the conversion to real paths. There may be some breakage of community packages, but it's hard for me to see how.

Please let me know what you think.

Discussed this with @nathansobo
/cc @noseglid because you maintain `atom-build` and this relates to https://github.com/noseglid/atom-build/issues/245