### PR TITLE
Changed "git-core" package to "git-all" to support "git submodule" co…

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -51,11 +51,11 @@ To also install the newly built application, use `--create-debian-package` or `-
 
 ### Fedora
 
-* `sudo dnf install make gcc gcc-c++ glibc-devel git-core libgnome-keyring-devel rpmdevtools libX11-devel libxkbfile-devel`
+* `sudo dnf install make gcc gcc-c++ glibc-devel git-all libgnome-keyring-devel rpmdevtools libX11-devel libxkbfile-devel`
 
 ### RHEL / CentOS
 
-* `sudo yum install make gcc gcc-c++ glibc-devel git-core libgnome-keyring-devel rpmdevtools libX11-devel libxkbfile-devel`
+* `sudo yum install make gcc gcc-c++ glibc-devel git-all libgnome-keyring-devel rpmdevtools libX11-devel libxkbfile-devel`
 
 ### Arch
 


### PR DESCRIPTION
### Requirements

In Fedora, RHEL and CentOS git-core package doesn't support "git submodule" command, so the build script break, I changed to "git-all" to enable it.

### Description of the Change

Simple change "git-core" package to "git-all" in Fedora, RHEL and CentOS

### Alternate Designs

Nothing

### Why Should This Be In Core?

To enable others users to build Atom

### Benefits

Correct the build script in Fedora, RHEL and CentOS

### Possible Drawbacks

More dependencies installed

### Applicable Issues

Can't build Atom since the "git-core" package haven't the "submodule" command
