### PR TITLE
Add did-load-user-keymap event

### DIFF
--- a/spec/keymap-extensions-spec.coffee
+++ b/spec/keymap-extensions-spec.coffee
@@ -1,0 +1,23 @@
+path = require 'path'
+temp = require('temp').track()
+CSON = require 'season'
+fs = require 'fs-plus'
+
+describe "keymap-extensions", ->
+
+  beforeEach ->
+    atom.keymaps.configDirPath = temp.path('atom-spec-keymap-ext')
+    fs.writeFileSync(atom.keymaps.getUserKeymapPath(), '#')
+    @userKeymapLoaded = ->
+    atom.keymaps.onDidLoadUserKeymap => @userKeymapLoaded()
+
+  afterEach ->
+    fs.removeSync(atom.keymaps.configDirPath)
+    atom.keymaps.destroy()
+
+  describe "did-load-user-keymap", ->
+
+    it  "fires when user keymap is loaded", ->
+      spyOn(this, 'userKeymapLoaded')
+      atom.keymaps.loadUserKeymap()
+      expect(@userKeymapLoaded).toHaveBeenCalled()

--- a/src/keymap-extensions.coffee
+++ b/src/keymap-extensions.coffee
@@ -35,10 +35,8 @@ KeymapManager::loadUserKeymap = ->
   return unless fs.isFileSync(userKeymapPath)
 
   try
-    errorLoading = false
     @loadKeymap(userKeymapPath, watch: true, suppressErrors: true, priority: 100)
   catch error
-    errorLoading = true
     if error.message.indexOf('Unable to watch path') > -1
       message = """
         Unable to watch path: `#{path.basename(userKeymapPath)}`. Make sure you
@@ -54,7 +52,7 @@ KeymapManager::loadUserKeymap = ->
       stack = error.stack
       @notificationManager.addFatalError(error.message, {detail, stack, dismissable: true})
 
-  @emitter.emit 'did-load-user-keymap' unless errorLoading
+  @emitter.emit 'did-load-user-keymap'
 
 
 KeymapManager::subscribeToFileReadFailure = ->


### PR DESCRIPTION
### Description of the Change

This change adds an event that fires after the user keymap has successfully loaded. It should be broadly useful in packages but is specifically being added in service of the MRU tab setting as described below.

### Applicable Issues

This is necessary for adding an [MRU tab traversal setting](https://github.com/atom/atom/issues/11035) in a way that won't alter behavior for users who have already modified their keymaps to turn it off. At package init time the user keymap has not yet loaded so it's not possible to check for them.
