### PR TITLE
Updated documentation about keys outside config schema

### DIFF
--- a/src/config.coffee
+++ b/src/config.coffee
@@ -336,6 +336,31 @@ ScopeDescriptor = require './scope-descriptor'
 #     order: 2
 # ```
 #
+# ## Manipulating values outside your configuration schema
+#
+# It is possible to manipulate(`get`, `set`, `observe` etc) values that do not
+# appear in your configuration schema. For example, if the config schema of the
+# package 'some-package' is
+#
+# ```coffee
+# config:
+# someSetting:
+#   type: 'boolean'
+#   default: false
+# ```
+#
+# You can still do the following
+#
+# ```coffee
+# let otherSetting  = atom.config.get('some-package.otherSetting')
+# atom.config.set('some-package.stillAnotherSetting', otherSetting * 5)
+# ```
+#
+# In other words, if a function asks for a `key-path`, that path doesn't have to
+# be described in the config schema for the package or any package. However, as
+# highlighted in the best practices section, you are advised against doing the
+# above.
+#
 # ## Best practices
 #
 # * Don't depend on (or write to) configuration keys outside of your keypath.


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR addresses #13548 and adds documentation to config.coffee about accessing and editing keys that do not appear in the configuration schema of the package and also mentions that it is against best practices to do the same.