### PR TITLE
Save initial paths immediately on change

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -58,21 +58,18 @@ describe('AtomApplication', function () {
       await focusWindow(window)
 
       const addProjectPathFn = function (dir) {
-        return 'function (sendBackToMainProcess) { atom.project.addPath("' + dir + '"); sendBackToMainProcess(null); }'
+        return 'function (sendBackToMainProcess) { atom.project.addPath(' + JSON.stringify(dir) + '); sendBackToMainProcess(null); }'
       }
       const removeProjectPathFn = function (dir) {
-        return 'function (sendBackToMainProcess) { atom.project.removePath("' + dir + '"); sendBackToMainProcess(null); }'
+        return 'function (sendBackToMainProcess) { atom.project.removePath(' + JSON.stringify(dir) + '); sendBackToMainProcess(null); }'
       }
 
       atomApplication.saveState = mockSaveState
       await evalInWebContents(window.browserWindow.webContents, addProjectPathFn(dirA))
-      await conditionPromise(() => cnt === 1)
       assert.equal(cnt, 1)
       await evalInWebContents(window.browserWindow.webContents, addProjectPathFn(dirB))
-      await conditionPromise(() => cnt === 2)
       assert.equal(cnt, 2)
       await evalInWebContents(window.browserWindow.webContents, removeProjectPathFn(dirA))
-      await conditionPromise(() => cnt === 3)
       assert.equal(cnt, 3)
     })
   })

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -66,10 +66,13 @@ describe('AtomApplication', function () {
 
       atomApplication.saveState = mockSaveState
       await evalInWebContents(window.browserWindow.webContents, addProjectPathFn(dirA))
+      await conditionPromise(() => cnt === 1)
       assert.equal(cnt, 1)
       await evalInWebContents(window.browserWindow.webContents, addProjectPathFn(dirB))
+      await conditionPromise(() => cnt === 2)
       assert.equal(cnt, 2)
       await evalInWebContents(window.browserWindow.webContents, removeProjectPathFn(dirA))
+      await conditionPromise(() => cnt === 3)
       assert.equal(cnt, 3)
     })
   })

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -59,6 +59,8 @@ describe('AtomApplication', function () {
 
       await evalInWebContents(window.browserWindow.webContents, addProjectPathFn(dirA))
 
+      assert( fs.existsSync(path.join(process.env.ATOM_HOME, 'storage', 'application.json')), 'ATOM_HOME/storage/application.json not exists' )
+
       const appState1 = JSON.parse(fs.readFileSync(path.join(process.env.ATOM_HOME, 'storage', 'application.json'), 'utf8'))
       assert.deepEqual(appState1[0].initialPaths, [dirA])
       

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -41,6 +41,39 @@ describe('AtomApplication', function () {
     electron.app.quit = originalAppQuit
   })
 
+  describe('project paths', function () {
+    it('sync application state on changes', async function () {
+      const dirA = makeTempDir()
+      const dirB = makeTempDir()
+      const atomApplication = buildAtomApplication()
+
+      const window = atomApplication.launch(parseCommandLine([]))
+      await focusWindow(window)
+
+      const addProjectPathFn = function (dir) {
+        return 'function (sendBackToMainProcess) { atom.project.addPath("' + dir + '"); sendBackToMainProcess(null); }'
+      }
+      const removeProjectPathFn = function (dir) {
+        return 'function (sendBackToMainProcess) { atom.project.removePath("' + dir + '"); sendBackToMainProcess(null); }'
+      }
+
+      await evalInWebContents(window.browserWindow.webContents, addProjectPathFn(dirA))
+
+      const appState1 = JSON.parse(fs.readFileSync(path.join(process.env.ATOM_HOME, 'storage', 'application.json'), 'utf8'))
+      assert.deepEqual(appState1[0].initialPaths, [dirA])
+      
+      await evalInWebContents(window.browserWindow.webContents, addProjectPathFn(dirB))
+
+      const appState2 = JSON.parse(fs.readFileSync(path.join(process.env.ATOM_HOME, 'storage', 'application.json'), 'utf8'))
+      assert.deepEqual(appState2[0].initialPaths, [dirA, dirB])
+      
+      await evalInWebContents(window.browserWindow.webContents, removeProjectPathFn(dirA))
+      
+      const appState3 = JSON.parse(fs.readFileSync(path.join(process.env.ATOM_HOME, 'storage', 'application.json'), 'utf8'))
+      assert.deepEqual(appState3[0].initialPaths, [dirB])
+    })
+  })
+
   describe('launch', function () {
     it('can open to a specific line number of a file', async function () {
       const filePath = path.join(makeTempDir(), 'new-file')

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -45,6 +45,7 @@ describe('AtomApplication', function () {
     it('sync application state on changes', async function () {
       const dirA = makeTempDir()
       const dirB = makeTempDir()
+      const storageFilePath = path.join(process.env.ATOM_HOME, 'storage', 'application.json')
       const atomApplication = buildAtomApplication()
 
       const window = atomApplication.launch(parseCommandLine([]))
@@ -59,19 +60,19 @@ describe('AtomApplication', function () {
 
       await evalInWebContents(window.browserWindow.webContents, addProjectPathFn(dirA))
 
-      assert( fs.existsSync(path.join(process.env.ATOM_HOME, 'storage', 'application.json')), 'ATOM_HOME/storage/application.json not exists' )
+      assert( fs.existsSync(storageFilePath), 'ATOM_HOME/storage/application.json not exists' )
 
-      const appState1 = JSON.parse(fs.readFileSync(path.join(process.env.ATOM_HOME, 'storage', 'application.json'), 'utf8'))
+      const appState1 = JSON.parse(fs.readFileSync(storageFilePath, 'utf8'))
       assert.deepEqual(appState1[0].initialPaths, [dirA])
       
       await evalInWebContents(window.browserWindow.webContents, addProjectPathFn(dirB))
 
-      const appState2 = JSON.parse(fs.readFileSync(path.join(process.env.ATOM_HOME, 'storage', 'application.json'), 'utf8'))
+      const appState2 = JSON.parse(fs.readFileSync(storageFilePath, 'utf8'))
       assert.deepEqual(appState2[0].initialPaths, [dirA, dirB])
       
       await evalInWebContents(window.browserWindow.webContents, removeProjectPathFn(dirA))
 
-      const appState3 = JSON.parse(fs.readFileSync(path.join(process.env.ATOM_HOME, 'storage', 'application.json'), 'utf8'))
+      const appState3 = JSON.parse(fs.readFileSync(storageFilePath, 'utf8'))
       assert.deepEqual(appState3[0].initialPaths, [dirB])      
     })
   })

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -126,7 +126,7 @@ class ApplicationDelegate
     loadSettings = getWindowLoadSettings()
     loadSettings['initialPaths'] = paths
     setWindowLoadSettings(loadSettings)
-    ipcRenderer.send("did-save-state")
+    ipcRenderer.send("did-change-paths")
 
 
   setAutoHideWindowMenuBar: (autoHide) ->

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -128,7 +128,6 @@ class ApplicationDelegate
     setWindowLoadSettings(loadSettings)
     ipcRenderer.send("did-change-paths")
 
-
   setAutoHideWindowMenuBar: (autoHide) ->
     ipcRenderer.send("call-window-method", "setAutoHideMenuBar", autoHide)
 

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -126,6 +126,8 @@ class ApplicationDelegate
     loadSettings = getWindowLoadSettings()
     loadSettings['initialPaths'] = paths
     setWindowLoadSettings(loadSettings)
+    ipcRenderer.send("did-save-state")
+
 
   setAutoHideWindowMenuBar: (autoHide) ->
     ipcRenderer.send("call-window-method", "setAutoHideMenuBar", autoHide)

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -351,7 +351,7 @@ class AtomApplication
       @fileRecoveryService.didSavePath(@windowForEvent(event), path)
       event.returnValue = true
 
-    @disposable.add ipcHelpers.on ipcMain, 'did-save-state', =>
+    @disposable.add ipcHelpers.on ipcMain, 'did-change-paths', =>
       @saveState(false)
 
   setupDockMenu: ->

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -351,6 +351,9 @@ class AtomApplication
       @fileRecoveryService.didSavePath(@windowForEvent(event), path)
       event.returnValue = true
 
+    @disposable.add ipcHelpers.on ipcMain, 'did-save-state', =>
+      @saveState(false)
+
   setupDockMenu: ->
     if process.platform is 'darwin'
       dockMenu = Menu.buildFromTemplate [


### PR DESCRIPTION
This is #12545 (send event to save state after 'Add Project Folder' or 'Remove Projec') + tests. Does it appropriate for merge now?

Copy of the description from #12545:

Fixes #12495

When we add or remove project folder, the window's current project path will be changed, then "initialPaths" will be reloaded, it is the best time to save state

/cc @maxbrunsfeld @lee-dohm 