### PR TITLE
Install only the 64 bit version of libXss.so.1

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -7,7 +7,7 @@ URL:            https://atom.io/
 AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
-Requires: lsb-core-noarch, libXss.so.1
+Requires: lsb-core-noarch, libXss.so.1()(64bit)
 
 %description
 <%= description %>


### PR DESCRIPTION
Fixes #13417.

Considering that the .rpm package we release is for `x86_64` architectures, there should be no need to install i686 dependencies. With this pull request we are installing `libXss.so.1()(64bit)` instead of the more generic `libXss.so.1` to prevent extra dependencies from being installed on users' systems.

This works egregiously on Fedora, but it would be great to confirm it runs flawlessly on all Linux distros that support the .rpm packaging system. @ungb: can you help me with that, please? 🙇 