### PR TITLE
Don't add pane items in built-in resource openers

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -284,13 +284,13 @@ class AtomEnvironment extends Model
     @workspace.addOpener (uri) =>
       switch uri
         when 'atom://.atom/stylesheet'
-          @workspace.open(@styles.getUserStyleSheetPath())
+          @workspace.openTextFile(@styles.getUserStyleSheetPath())
         when 'atom://.atom/keymap'
-          @workspace.open(@keymaps.getUserKeymapPath())
+          @workspace.openTextFile(@keymaps.getUserKeymapPath())
         when 'atom://.atom/config'
-          @workspace.open(@config.getUserConfigPath())
+          @workspace.openTextFile(@config.getUserConfigPath())
         when 'atom://.atom/init-script'
-          @workspace.open(@getUserInitScriptPath())
+          @workspace.openTextFile(@getUserInitScriptPath())
 
   registerDefaultTargetForKeymaps: ->
     @keymaps.defaultTarget = @views.getView(@workspace)


### PR DESCRIPTION
Calling `workspace.open` in an opener doesn't work properly with options like `split: left` because it causes the opened item to be added to the workspace as a side-effect. Since workspace openers are intended to be used during the process of calling `workspace.open`, we need to use `openTextFile`, which just creates an editor but does not attach it to the workspace.