### PR TITLE
Remove x64 delta workaround code in create-windows-installer

### DIFF
--- a/script/lib/create-windows-installer.js
+++ b/script/lib/create-windows-installer.js
@@ -22,11 +22,6 @@ module.exports = function (packagedAppPath, codeSign) {
     setupIcon: path.join(CONFIG.repositoryRootPath, 'resources', 'app-icons', CONFIG.channel, 'atom.ico')
   }
 
-  // Remove this once an x64 version is published or atom.io is returning blank instead of 404 for RELEASES-X64
-  if (process.arch === 'x64') {
-    options.remoteReleases = null
-  }
-
   const certPath = path.join(os.tmpdir(), 'win.p12')
   const signing = codeSign && process.env.ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL
 


### PR DESCRIPTION
Now that x64 Windows is published we can let the installer create deltas!