### PR TITLE
Prioritize first line matches over bundled/non bundled cirteria in grammar scoring

### DIFF
--- a/spec/fixtures/packages/package-with-rb-filetype/grammars/rb.cson
+++ b/spec/fixtures/packages/package-with-rb-filetype/grammars/rb.cson
@@ -1,5 +1,6 @@
 'name': 'Test Ruby'
 'scopeName': 'test.rb'
+'firstLineMatch': '^\\#!.*(?:\\s|\\/)(?:testruby)(?:$|\\s)'
 'fileTypes': [
   'rb'
 ]

--- a/spec/grammars-spec.coffee
+++ b/spec/grammars-spec.coffee
@@ -120,6 +120,8 @@ describe "the `grammars` global", ->
         atom.grammars.grammarForScopeName('source.ruby').bundledPackage = true
         atom.grammars.grammarForScopeName('test.rb').bundledPackage = false
 
+        expect(atom.grammars.selectGrammar('test.rb', '#!/usr/bin/env ruby').scopeName).toBe 'source.ruby'
+        expect(atom.grammars.selectGrammar('test.rb', '#!/usr/bin/env testruby').scopeName).toBe 'test.rb'
         expect(atom.grammars.selectGrammar('test.rb').scopeName).toBe 'test.rb'
 
     describe "when there is no file path", ->

--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -58,10 +58,10 @@ class GrammarRegistry extends FirstMate.GrammarRegistry {
 
     let score = this.getGrammarPathScore(grammar, filePath)
     if ((score > 0) && !grammar.bundledPackage) {
-      score += 0.25
+      score += 0.125
     }
     if (this.grammarMatchesContents(grammar, contents)) {
-      score += 0.125
+      score += 0.25
     }
     return score
   }


### PR DESCRIPTION
When detecting grammar to use, the grammar scoring system's bundled/not bundled criteria should be lower priority than first line match. This would enable the use case where user installed grammar intentionally hands over the victory to bundled grammar based on first line match. If the two grammars were equal in terms of first line match, they would be still judged by bundled/non bundled, thus not breaking old intended behavior.

Cases where grammar relied on being a non bundled package, we'll have to at least copy the firstLineMatch of the bundled grammar or have a better one if the bundled package had one. This will be useful in the future nonetheless.

For more details, see https://github.com/atom/first-mate/issues/85