### PR TITLE
Remove unused Cursor::getPixelRect function

### DIFF
--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -653,9 +653,6 @@ class Cursor extends Model
     fn()
     @autoscroll() if options.autoscroll ? @isLastCursor()
 
-  getPixelRect: ->
-    @editor.pixelRectForScreenRange(@getScreenRange())
-
   getScreenRange: ->
     {row, column} = @getScreenPosition()
     new Range(new Point(row, column), new Point(row, column + 1))


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Removes a private, unused function that calls a deprecated function.

### Alternate Designs

None.

### Why Should This Be In Core?

This PR removes things and doesn't add anything :)

### Benefits

Code maintenance.

### Possible Drawbacks

Package authors using Cursor::getPixelRect will start receiving errors, but I think that's fine because it was private.

### Applicable Issues

Closes #13541

/cc @maxbrunsfeld