### PR TITLE
Setting for settings-view to apply Chromium proxies to apm via env vars

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -142,6 +142,11 @@ const configSchema = {
         type: 'boolean',
         default: true
       },
+      useProxySettingsWhenCallingApm: {
+        description: 'Use detected proxy settings when calling the `apm` command-line tool.',
+        type: 'boolean',
+        default: true
+      },
       allowPendingPaneItems: {
         description: 'Allow items to be previewed without adding them to a pane permanently, such as when single clicking files in the tree view.',
         type: 'boolean',


### PR DESCRIPTION
The on/off setting for automatic apm proxies, see https://github.com/atom/settings-view/pull/898 for more details.