### PR TITLE
Ensure a dialog is not opened when webContents crash in headless mode

### DIFF
--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -150,7 +150,10 @@ class AtomWindow
       @browserWindow.destroy() if chosen is 0
 
     @browserWindow.webContents.on 'crashed', =>
-      @atomApplication.exit(100) if @headless
+      if @headless
+        console.log "Renderer process crashed, exiting"
+        @atomApplication.exit(100)
+        return
 
       @fileRecoveryService.didCrashWindow(this)
       chosen = dialog.showMessageBox @browserWindow,


### PR DESCRIPTION
When the renderer process crashes in headless mode, we open a dialog even though we have `@atomApplication.exit(100) if @headless` at the top of the handler. `exit` appears to not be as synchronous as the Electron docs say it is. :) This results in a confusing error:

```
2017-01-12 14:25:12.092 Atom[95390:27209761] TypeError: Error processing argument at index 9, conversion failure from #<BrowserWindow>
    at TypeError (native)
    at Object.showMessageBox (/Applications/Atom.app/Contents/Resources/electron.asar/browser/api/dialog.js:184:20)
    at WebContents.<anonymous> (/Users/mtilley/github/atom/src/main-process/atom-window.coffee:156:23)
    at emitOne (events.js:96:13)
    at WebContents.emit (events.js:188:7)
```

In this PR, we simply log a message and return early from the event handler to avoid the extraneous message.

/cc @atom/core