### PR TITLE
Increase max listener limit on ipcRenderer

### DIFF
--- a/src/ipc-helpers.js
+++ b/src/ipc-helpers.js
@@ -15,6 +15,7 @@ exports.on = function (emitter, eventName, callback) {
 exports.call = function (channel, ...args) {
   if (!ipcRenderer) {
     ipcRenderer = require('electron').ipcRenderer
+    ipcRenderer.setMaxListeners(20)
   }
 
   var responseChannel = getResponseChannel(channel)


### PR DESCRIPTION
We deliberately assign more than 10 listeners on the method response channel.

This should eliminate `Warning: Possible EventEmitter memory leak detected` spam when running tests.

/cc @BinaryMuse 