### PR TITLE
Add option for closing deleted file tabs

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -68,6 +68,12 @@ const configSchema = {
         default: true,
         description: 'Trigger the system\'s beep sound when certain actions cannot be executed or there are no results.'
       },
+      closeDeletedFileTabs: {
+        type: 'boolean',
+        default: false,
+        title: 'Close Deleted File Tabs',
+        description: 'Close corresponding editors when a file is deleted outside Atom.'
+      },
       destroyEmptyPanes: {
         type: 'boolean',
         default: true,

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -360,9 +360,13 @@ class Project extends Model
     else
       @buildBuffer(absoluteFilePath)
 
+  shouldDestroyBufferOnFileDelete: ->
+    atom.config.get('core.closeDeletedFileTabs')
+
   # Still needed when deserializing a tokenized buffer
   buildBufferSync: (absoluteFilePath) ->
     buffer = new TextBuffer({filePath: absoluteFilePath})
+    buffer.setConfigCallbacks(@shouldDestroyBufferOnFileDelete) if buffer.setConfigCallbacks?
     @addBuffer(buffer)
     buffer.loadSync()
     buffer
@@ -375,6 +379,7 @@ class Project extends Model
   # Returns a {Promise} that resolves to the {TextBuffer}.
   buildBuffer: (absoluteFilePath) ->
     buffer = new TextBuffer({filePath: absoluteFilePath})
+    buffer.setConfigCallbacks(@shouldDestroyBufferOnFileDelete) if buffer.setConfigCallbacks?
     @addBuffer(buffer)
     buffer.load()
       .then((buffer) -> buffer)

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -62,6 +62,9 @@ class Project extends Model
           fs.closeSync(fs.openSync(bufferState.filePath, 'r'))
         catch error
           return unless error.code is 'ENOENT'
+      unless bufferState.shouldDestroyOnFileDelete?
+        bufferState.shouldDestroyOnFileDelete =
+          -> atom.config.get('core.closeDeletedFileTabs')
       TextBuffer.deserialize(bufferState)
 
     @subscribeToBuffer(buffer) for buffer in @buffers
@@ -365,8 +368,9 @@ class Project extends Model
 
   # Still needed when deserializing a tokenized buffer
   buildBufferSync: (absoluteFilePath) ->
-    buffer = new TextBuffer({filePath: absoluteFilePath})
-    buffer.setConfigCallbacks(@shouldDestroyBufferOnFileDelete) if buffer.setConfigCallbacks?
+    buffer = new TextBuffer({
+      filePath: absoluteFilePath
+      shouldDestroyOnFileDelete: @shouldDestroyBufferOnFileDelete})
     @addBuffer(buffer)
     buffer.loadSync()
     buffer
@@ -378,8 +382,9 @@ class Project extends Model
   #
   # Returns a {Promise} that resolves to the {TextBuffer}.
   buildBuffer: (absoluteFilePath) ->
-    buffer = new TextBuffer({filePath: absoluteFilePath})
-    buffer.setConfigCallbacks(@shouldDestroyBufferOnFileDelete) if buffer.setConfigCallbacks?
+    buffer = new TextBuffer({
+      filePath: absoluteFilePath
+      shouldDestroyOnFileDelete: @shouldDestroyBufferOnFileDelete})
     @addBuffer(buffer)
     buffer.load()
       .then((buffer) -> buffer)

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -107,8 +107,10 @@ class TextEditorElement extends HTMLElement
     @model ? @buildModel()
 
   buildModel: ->
+    newBuffer = new TextBuffer(@textContent)
+    newBuffer.setConfigCallbacks(-> atom.config.get('core.closeDeletedFileTabs')) if newBuffer.setConfigCallbacks?
     @setModel(@workspace.buildTextEditor(
-      buffer: new TextBuffer(@textContent)
+      buffer: newBuffer
       softWrapped: false
       tabLength: 2
       softTabs: true

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -107,10 +107,11 @@ class TextEditorElement extends HTMLElement
     @model ? @buildModel()
 
   buildModel: ->
-    newBuffer = new TextBuffer(@textContent)
-    newBuffer.setConfigCallbacks(-> atom.config.get('core.closeDeletedFileTabs')) if newBuffer.setConfigCallbacks?
     @setModel(@workspace.buildTextEditor(
-      buffer: newBuffer
+      buffer: new TextBuffer({
+        text: @textContent
+        shouldDestroyOnFileDelete:
+          -> atom.config.get('core.closeDeletedFileTabs')})
       softWrapped: false
       tabLength: 2
       softTabs: true

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -159,8 +159,8 @@ class TextEditor extends Model
     @softWrapAtPreferredLineLength ?= false
     @preferredLineLength ?= 80
 
-    @buffer ?= new TextBuffer
-    @buffer.setConfigCallbacks(-> atom.config.get('core.closeDeletedFileTabs')) if @buffer.setConfigCallbacks?
+    @buffer ?= new TextBuffer({shouldDestroyOnFileDelete: ->
+      atom.config.get('core.closeDeletedFileTabs')})
     @tokenizedBuffer ?= new TokenizedBuffer({
       grammar, tabLength, @buffer, @largeFileMode, @assert
     })

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -160,6 +160,7 @@ class TextEditor extends Model
     @preferredLineLength ?= 80
 
     @buffer ?= new TextBuffer
+    @buffer.setConfigCallbacks(-> atom.config.get('core.closeDeletedFileTabs')) if @buffer.setConfigCallbacks?
     @tokenizedBuffer ?= new TokenizedBuffer({
       grammar, tabLength, @buffer, @largeFileMode, @assert
     })


### PR DESCRIPTION
Adds a core option for keeping open editors whose underlying files are deleted outside Atom.

![screen shot 2017-01-18 at 4 40 27 pm](https://cloud.githubusercontent.com/assets/553742/22088980/e1f25d3e-dd9c-11e6-81de-53846a511971.png)

To be merged in tandem with atom/text-buffer#178 (which will include tests for this option) and atom/tree-view#1026 in order to close atom/tabs#306.

Note that the default will change to keep these tabs open, as that's the conservative behavior with respect to potentially losing data.