### PR TITLE
Allow a BufferedProcess to be manually started

### DIFF
--- a/spec/buffered-process-spec.coffee
+++ b/spec/buffered-process-spec.coffee
@@ -67,6 +67,29 @@ describe "BufferedProcess", ->
           expect(window.onerror.mostRecentCall.args[0]).toContain 'Failed to spawn command `bad-command-nope2`'
           expect(window.onerror.mostRecentCall.args[4].name).toBe 'BufferedProcessError'
 
+  describe "when autoStart is false", ->
+    it "doesnt start unless start method is called", ->
+      stdout = ''
+      stderr = ''
+      exitCallback = jasmine.createSpy('exit callback')
+      apmProcess = new BufferedProcess
+        autoStart: false
+        command: atom.packages.getApmPath()
+        args: ['-h']
+        options: {}
+        stdout: (lines) -> stdout += lines
+        stderr: (lines) -> stderr += lines
+        exit: exitCallback
+
+      expect(apmProcess.started).not.toBe(true)
+      apmProcess.start()
+      expect(apmProcess.started).toBe(true)
+
+      waitsFor -> exitCallback.callCount is 1
+      runs ->
+        expect(stderr).toContain 'apm - Atom Package Manager'
+        expect(stdout).toEqual ''
+
   it "calls the specified stdout, stderr, and exit callbacks", ->
     stdout = ''
     stderr = ''

--- a/src/buffered-process.js
+++ b/src/buffered-process.js
@@ -46,18 +46,34 @@ export default class BufferedProcess {
   //   * `exit` {Function} (optional) The callback which receives a single
   //     argument containing the exit status.
   //     * `code` {Number}
-  constructor ({command, args, options = {}, stdout, stderr, exit} = {}) {
+  //   * `autoStart` {Boolean} (optional) Whether the command will automatically start
+  //     when this BufferedProcess is created. Defaults to true.  When set to false you
+  //     must call the `start` method to start the process.
+  constructor ({command, args, options = {}, stdout, stderr, exit, autoStart = true} = {}) {
     this.emitter = new Emitter()
     this.command = command
-    // Related to joyent/node#2318
-    if (process.platform === 'win32' && options.shell === undefined) {
-      this.spawnWithEscapedWindowsArgs(command, args, options)
-    } else {
-      this.spawn(command, args, options)
+    this.args = args
+    this.options = options
+    this.stdout = stdout
+    this.stderr = stderr
+    this.exit = exit
+    if (autoStart === true) {
+      this.start()
     }
-
     this.killed = false
-    this.handleEvents(stdout, stderr, exit)
+  }
+
+  start() {
+    if (this.started === true) return
+
+    this.started = true
+    // Related to joyent/node#2318
+    if (process.platform === 'win32' && this.options.shell === undefined) {
+      this.spawnWithEscapedWindowsArgs(this.command, this.args, this.options)
+    } else {
+      this.spawn(this.command, this.args, this.options)
+    }
+    this.handleEvents(this.stdout, this.stderr, this.exit)
   }
 
   // Windows has a bunch of special rules that node still doesn't take care of for you


### PR DESCRIPTION
This is required so that settings-view can successfully set the proxy servers for apm - it's an async call that can't stop returning the bufferedProcess object to callers.