### PR TITLE
Add showCursorOnSelection config

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1347,7 +1347,19 @@ describe('TextEditorComponent', function () {
       expect(cursorsNode.classList.contains('blink-off')).toBe(true)
     })
 
-    it('does not render cursors that are associated with non-empty selections', function () {
+    it('renders cursors that are associated with empty selections', function () {
+      editor.update({showCursorOnSelection: true})
+      editor.setSelectedScreenRange([[0, 4], [4, 6]])
+      editor.addCursorAtScreenPosition([6, 8])
+      runAnimationFrames()
+      let cursorNodes = componentNode.querySelectorAll('.cursor')
+      expect(cursorNodes.length).toBe(2)
+      expect(cursorNodes[0].style['-webkit-transform']).toBe('translate(' + (Math.round(6 * charWidth)) + 'px, ' + (4 * lineHeightInPixels) + 'px)')
+      expect(cursorNodes[1].style['-webkit-transform']).toBe('translate(' + (Math.round(8 * charWidth)) + 'px, ' + (6 * lineHeightInPixels) + 'px)')
+    })
+
+    it('does not render cursors that are associated with non-empty selections when showCursorOnSelection is false', function () {
+      editor.update({showCursorOnSelection: false})
       editor.setSelectedScreenRange([[0, 4], [4, 6]])
       editor.addCursorAtScreenPosition([6, 8])
       runAnimationFrames()

--- a/spec/text-editor-presenter-spec.coffee
+++ b/spec/text-editor-presenter-spec.coffee
@@ -1583,6 +1583,7 @@ describe "TextEditorPresenter", ->
           getState(presenter).content.cursors[presenter.model.getCursors()[cursorIndex].id]
 
         it "contains pixelRects for empty selections that are visible on screen", ->
+          editor.update({showCursorOnSelection: false})
           editor.setSelectedBufferRanges([
             [[1, 2], [1, 2]],
             [[2, 4], [2, 4]],
@@ -1627,6 +1628,7 @@ describe "TextEditorPresenter", ->
           expect(getState(presenter).content.cursors).not.toEqual({})
 
         it "updates when block decorations change", ->
+          editor.update({showCursorOnSelection: false})
           editor.setSelectedBufferRanges([
             [[1, 2], [1, 2]],
             [[2, 4], [2, 4]],
@@ -1704,6 +1706,7 @@ describe "TextEditorPresenter", ->
           expect(stateForCursor(presenter, 0)).toEqual {top: 20, left: 10 * 22, width: 10, height: 10}
 
         it "updates when ::explicitHeight changes", ->
+          editor.update({showCursorOnSelection: false})
           editor.setSelectedBufferRanges([
             [[1, 2], [1, 2]],
             [[2, 4], [2, 4]],
@@ -1757,6 +1760,7 @@ describe "TextEditorPresenter", ->
             expect(stateForCursor(presenter, 0)).toEqual {top: 1 * 10, left: (3 * 10) + 20, width: 20, height: 10}
 
         it "updates when cursors are added, moved, hidden, shown, or destroyed", ->
+          editor.update({showCursorOnSelection: false})
           editor.setSelectedBufferRanges([
             [[1, 2], [1, 2]],
             [[3, 4], [3, 5]]

--- a/spec/text-editor-registry-spec.js
+++ b/spec/text-editor-registry-spec.js
@@ -436,6 +436,19 @@ describe('TextEditorRegistry', function () {
       expect(editor.hasAtomicSoftTabs()).toBe(true)
     })
 
+    it('enables or disables cursor on selection visibility based on the config', async function () {
+      editor.update({showCursorOnSelection: true})
+      expect(editor.getShowCursorOnSelection()).toBe(true)
+
+      atom.config.set('editor.showCursorOnSelection', false)
+      registry.maintainConfig(editor)
+      await initialPackageActivation
+      expect(editor.getShowCursorOnSelection()).toBe(false)
+
+      atom.config.set('editor.showCursorOnSelection', true)
+      expect(editor.getShowCursorOnSelection()).toBe(true)
+    })
+
     it('enables or disables line numbers based on the config', async function () {
       editor.update({showLineNumbers: true})
       expect(editor.showLineNumbers).toBe(true)

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -217,6 +217,11 @@ const configSchema = {
         default: 1.5,
         description: 'Height of editor lines, as a multiplier of font size.'
       },
+      showCursorOnSelection: {
+        type: 'boolean',
+        'default': true,
+        description: 'Show cursor while there is a selection.'
+      },
       showInvisibles: {
         type: 'boolean',
         default: false,

--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -12,14 +12,17 @@ EmptyLineRegExp = /(\r\n[\t ]*\r\n)|(\n[\t ]*\n)/g
 # of a {DisplayMarker}.
 module.exports =
 class Cursor extends Model
+  showCursorOnSelection: null
   screenPosition: null
   bufferPosition: null
   goalColumn: null
   visible: true
 
   # Instantiated by a {TextEditor}
-  constructor: ({@editor, @marker, id}) ->
+  constructor: ({@editor, @marker, @showCursorOnSelection, id}) ->
     @emitter = new Emitter
+
+    @showCursorOnSelection ?= true
 
     @assignId(id)
     @updateVisibility()
@@ -575,7 +578,10 @@ class Cursor extends Model
   isVisible: -> @visible
 
   updateVisibility: ->
-    @setVisible(@marker.getBufferRange().isEmpty())
+    if @showCursorOnSelection
+      @setVisible(true)
+    else
+      @setVisible(@marker.getBufferRange().isEmpty())
 
   ###
   Section: Comparing to another cursor
@@ -644,6 +650,11 @@ class Cursor extends Model
   ###
   Section: Private
   ###
+
+  setShowCursorOnSelection: (value) ->
+    if value isnt @showCursorOnSelection
+      @showCursorOnSelection = value
+      @updateVisibility()
 
   getNonWordCharacters: ->
     @editor.getNonWordCharacters(@getScopeDescriptor().getScopesArray())

--- a/src/text-editor-registry.js
+++ b/src/text-editor-registry.js
@@ -11,6 +11,7 @@ const EDITOR_PARAMS_BY_SETTING_KEY = [
   ['editor.showInvisibles', 'showInvisibles'],
   ['editor.tabLength', 'tabLength'],
   ['editor.invisibles', 'invisibles'],
+  ['editor.showCursorOnSelection', 'showCursorOnSelection'],
   ['editor.showIndentGuide', 'showIndentGuide'],
   ['editor.showLineNumbers', 'showLineNumbers'],
   ['editor.softWrap', 'softWrapped'],

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -67,6 +67,7 @@ class TextEditor extends Model
   buffer: null
   languageMode: null
   cursors: null
+  showCursorOnSelection: null
   selections: null
   suppressSelectionMerging: false
   selectionFlashDuration: 500
@@ -133,7 +134,8 @@ class TextEditor extends Model
       @mini, @placeholderText, lineNumberGutterVisible, @largeFileMode,
       @assert, grammar, @showInvisibles, @autoHeight, @autoWidth, @scrollPastEnd, @editorWidthInChars,
       @tokenizedBuffer, @displayLayer, @invisibles, @showIndentGuide,
-      @softWrapped, @softWrapAtPreferredLineLength, @preferredLineLength
+      @softWrapped, @softWrapAtPreferredLineLength, @preferredLineLength,
+      @showCursorOnSelection
     } = params
 
     @assert ?= (condition) -> condition
@@ -153,6 +155,7 @@ class TextEditor extends Model
     tabLength ?= 2
     @autoIndent ?= true
     @autoIndentOnPaste ?= true
+    @showCursorOnSelection ?= true
     @undoGroupingInterval ?= 300
     @nonWordCharacters ?= "/\\()\"':,.;<>~!@#$%^&*|+=[]{}`?-…"
     @softWrapped ?= false
@@ -342,6 +345,12 @@ class TextEditor extends Model
           if value isnt @autoWidth
             @autoWidth = value
             @presenter?.didChangeAutoWidth()
+
+        when 'showCursorOnSelection'
+          if value isnt @showCursorOnSelection
+            @showCursorOnSelection = value
+            cursor.setShowCursorOnSelection(value) for cursor in @getCursors()
+
         else
           throw new TypeError("Invalid TextEditor parameter: '#{param}'")
 
@@ -722,7 +731,7 @@ class TextEditor extends Model
       tabLength: @tokenizedBuffer.getTabLength(),
       @firstVisibleScreenRow, @firstVisibleScreenColumn,
       @assert, displayLayer, grammar: @getGrammar(),
-      @autoWidth, @autoHeight
+      @autoWidth, @autoHeight, @showCursorOnSelection
     })
 
   # Controls visibility based on the given {Boolean}.
@@ -2269,7 +2278,7 @@ class TextEditor extends Model
 
   # Add a cursor based on the given {DisplayMarker}.
   addCursor: (marker) ->
-    cursor = new Cursor(editor: this, marker: marker)
+    cursor = new Cursor(editor: this, marker: marker, showCursorOnSelection: @showCursorOnSelection)
     @cursors.push(cursor)
     @cursorsByMarkerId.set(marker.id, cursor)
     @decorateMarker(marker, type: 'line-number', class: 'cursor-line')
@@ -3465,6 +3474,11 @@ class TextEditor extends Model
   #
   # Returns a positive {Number}.
   getScrollSensitivity: -> @scrollSensitivity
+
+  # Experimental: Does this editor show cursors while there is a selection?
+  #
+  # Returns a positive {Boolean}.
+  getShowCursorOnSelection: -> @showCursorOnSelection
 
   # Experimental: Are line numbers enabled for this editor?
   #


### PR DESCRIPTION
### Description of the Change

Adds a new config `editor.showCursorOnSelection`, enabled by default (changing the current default behavior), that makes it so that the cursor is always blinking even when you have a selection(s).

### Why Should This Be In Core?

It's pretty tied to the internals of `Cursor` and `TextEditor`.

### Benefits

Brings Atom in line with the behavior of Sublime (and others).

This is super useful for when you do `cmd+d` (`find-and-replace:select-next`) and you can't find where your cursor went.

### Possible Drawbacks

The current behavior is to hide the cursor when there's a selection. Since we're changing the default, that's sure to upset someone. However, since it is configurable, those that don't like it can easily revert to the old behavior.