### PR TITLE
Fix increasing/decreasing font size via ctrl-mousewheel

### DIFF
--- a/spec/workspace-element-spec.coffee
+++ b/spec/workspace-element-spec.coffee
@@ -74,14 +74,14 @@ describe "WorkspaceElement", ->
       atom.config.set('editor.fontSize', 12)
 
       # Zoom out
-      editorElement.dispatchEvent(new WheelEvent('mousewheel', {
+      editorElement.querySelector('span').dispatchEvent(new WheelEvent('mousewheel', {
         wheelDeltaY: -10,
         ctrlKey: true
       }))
       expect(atom.config.get('editor.fontSize')).toBe(11)
 
       # Zoom in
-      editorElement.dispatchEvent(new WheelEvent('mousewheel', {
+      editorElement.querySelector('span').dispatchEvent(new WheelEvent('mousewheel', {
         wheelDeltaY: 10,
         ctrlKey: true
       }))
@@ -95,13 +95,13 @@ describe "WorkspaceElement", ->
       expect(atom.config.get('editor.fontSize')).toBe(12)
 
       # No ctrl key
-      workspaceElement.dispatchEvent(new WheelEvent('mousewheel', {
+      editorElement.querySelector('span').dispatchEvent(new WheelEvent('mousewheel', {
         wheelDeltaY: 10,
       }))
       expect(atom.config.get('editor.fontSize')).toBe(12)
 
       atom.config.set('editor.zoomFontWhenCtrlScrolling', false)
-      editorElement.dispatchEvent(new WheelEvent('mousewheel', {
+      editorElement.querySelector('span').dispatchEvent(new WheelEvent('mousewheel', {
         wheelDeltaY: 10,
         ctrlKey: true
       }))

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -102,7 +102,7 @@ class WorkspaceElement extends HTMLElement
   getModel: -> @model
 
   handleMousewheel: (event) ->
-    if event.ctrlKey and @config.get('editor.zoomFontWhenCtrlScrolling') and event.target.matches('atom-text-editor')
+    if event.ctrlKey and @config.get('editor.zoomFontWhenCtrlScrolling') and event.target.closest('atom-text-editor')?
       if event.wheelDeltaY > 0
         @model.increaseFontSize()
       else if event.wheelDeltaY < 0


### PR DESCRIPTION
Fixes #13625.

This regression was introduced with the removal of the shadow DOM from `<atom-text-editor>` elements. Previously we were relying on Chrome always reporting `<atom-text-editor>` as the mousewheel `event.target`. As a result, removing the shadow boundary caused the mousewheel event to be potentially dispatched from anywhere inside the editor element, making our previous logic for handling ctrl-mousewheel invalid.

This pull request fixes it by recognizing mousewheel events that are dispatched from within an editor.

/cc: @atom/core