### PR TITLE
Add description text to the File Encoding list

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -222,7 +222,7 @@ const configSchema = {
           },
           {
             value: 'windows1258',
-            description: 'Vietnamese (Windows 1254)'
+            description: 'Vietnamese (Windows 1258)'
           },
           {
             value: 'iso88591',

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -85,76 +85,48 @@ const configSchema = {
         default: 'utf8',
         enum: [
           {
-            value: 'utf8',
-            description: 'UTF-8'
-          },
-          {
-            value: 'utf16le',
-            description: 'UTF-16 LE'
-          },
-          {
-            value: 'utf16be',
-            description: 'UTF-16 BE'
-          },
-          {
-            value: 'windows1252',
-            description: 'Western (Windows 1252)'
-          },
-          {
-            value: 'iso88591',
-            description: 'Western (ISO 8859-1)'
-          },
-          {
-            value: 'iso88593',
-            description: 'Western (ISO 8859-3)'
-          },
-          {
-            value: 'iso885915',
-            description: 'Western (ISO 8859-15)'
-          },
-          {
-            value: 'macroman',
-            description: 'Western (Mac Roman)'
-          },
-          {
-            value: 'cp437',
-            description: 'DOS (CP 437)'
-          },
-          {
-            value: 'cp850',
-            description: 'DOS (CP 850)'
+            value: 'iso88596',
+            description: 'Arabic (ISO 8859-6)'
           },
           {
             value: 'windows1256',
             description: 'Arabic (Windows 1256)'
           },
           {
-            value: 'iso88596',
-            description: 'Arabic (ISO 8859-6)'
+            value: 'iso88594',
+            description: 'Baltic (ISO 8859-4)'
           },
           {
             value: 'windows1257',
             description: 'Baltic (Windows 1257)'
           },
           {
-            value: 'iso88594',
-            description: 'Baltic (ISO 8859-4)'
-          },
-          {
             value: 'iso885914',
             description: 'Celtic (ISO 8859-14)'
-          },
-          {
-            value: 'windows1250',
-            description: 'Central European (Windows 1250)'
           },
           {
             value: 'iso88592',
             description: 'Central European (ISO 8859-2)'
           },
           {
-            value: 'windows1251',
-            description: 'Cyrillic (Windows 1251)'
+            value: 'windows1250',
+            description: 'Central European (Windows 1250)'
+          },
+          {
+            value: 'gb18030',
+            description: 'Chinese (GB18030)'
+          },
+          {
+            value: 'gbk',
+            description: 'Chinese (GBK)'
+          },
+          {
+            value: 'cp950',
+            description: 'Traditional Chinese (Big5)'
+          },
+          {
+            value: 'big5hkscs',
+            description: 'Traditional Chinese (Big5-HKSCS)'
           },
           {
             value: 'cp866',
@@ -173,64 +145,36 @@ const configSchema = {
             description: 'Cyrillic (KOI8-U)'
           },
           {
-            value: 'iso885913',
-            description: 'Estonian (ISO 8859-13)'
+            value: 'windows1251',
+            description: 'Cyrillic (Windows 1251)'
           },
           {
-            value: 'windows1253',
-            description: 'Greek (Windows 1253)'
+            value: 'cp437',
+            description: 'DOS (CP 437)'
+          },
+          {
+            value: 'cp850',
+            description: 'DOS (CP 850)'
+          },
+          {
+            value: 'iso885913',
+            description: 'Estonian (ISO 8859-13)'
           },
           {
             value: 'iso88597',
             description: 'Greek (ISO 8859-7)'
           },
           {
-            value: 'windows1255',
-            description: 'Hebrew (Windows 1255)'
+            value: 'windows1253',
+            description: 'Greek (Windows 1253)'
           },
           {
             value: 'iso88598',
             description: 'Hebrew (ISO 8859-8)'
           },
           {
-            value: 'iso885910',
-            description: 'Nordic (ISO 8859-10)'
-          },
-          {
-            value: 'iso885916',
-            description: 'Romanian (ISO 8859-16)'
-          },
-          {
-            value: 'windows1254',
-            description: 'Turkish (Windows 1254)'
-          },
-          {
-            value: 'iso88599',
-            description: 'Turkish (ISO 8859-9)'
-          },
-          {
-            value: 'windows1258',
-            description: 'Vietnamese (Windows 1254)'
-          },
-          {
-            value: 'gbk',
-            description: 'Chinese (GBK)'
-          },
-          {
-            value: 'gb18030',
-            description: 'Chinese (GB18030)'
-          },
-          {
-            value: 'cp950',
-            description: 'Traditional Chinese (Big5)'
-          },
-          {
-            value: 'big5hkscs',
-            description: 'Traditional Chinese (Big5-HKSCS)'
-          },
-          {
-            value: 'shiftjis',
-            description: 'Japanese (Shift JIS)'
+            value: 'windows1255',
+            description: 'Hebrew (Windows 1255)'
           },
           {
             value: 'cp932',
@@ -241,8 +185,64 @@ const configSchema = {
             description: 'Japanese (EUC-JP)'
           },
           {
+            value: 'shiftjis',
+            description: 'Japanese (Shift JIS)'
+          },
+          {
             value: 'euckr',
             description: 'Korean (EUC-KR)'
+          },
+          {
+            value: 'iso885910',
+            description: 'Nordic (ISO 8859-10)'
+          },
+          {
+            value: 'iso885916',
+            description: 'Romanian (ISO 8859-16)'
+          },
+          {
+            value: 'iso88599',
+            description: 'Turkish (ISO 8859-9)'
+          },
+          {
+            value: 'windows1254',
+            description: 'Turkish (Windows 1254)'
+          },
+          {
+            value: 'utf8',
+            description: 'Unicode (UTF-8)'
+          },
+          {
+            value: 'utf16le',
+            description: 'Unicode (UTF-16 LE)'
+          },
+          {
+            value: 'utf16be',
+            description: 'Unicode (UTF-16 BE)'
+          },
+          {
+            value: 'windows1258',
+            description: 'Vietnamese (Windows 1254)'
+          },
+          {
+            value: 'iso88591',
+            description: 'Western (ISO 8859-1)'
+          },
+          {
+            value: 'iso88593',
+            description: 'Western (ISO 8859-3)'
+          },
+          {
+            value: 'iso885915',
+            description: 'Western (ISO 8859-15)'
+          },
+          {
+            value: 'macroman',
+            description: 'Western (Mac Roman)'
+          },
+          {
+            value: 'windows1252',
+            description: 'Western (Windows 1252)'
           }
         ]
       },

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -84,42 +84,166 @@ const configSchema = {
         type: 'string',
         default: 'utf8',
         enum: [
-          'cp437',
-          'cp850',
-          'cp866',
-          'eucjp',
-          'euckr',
-          'gbk',
-          'iso88591',
-          'iso885910',
-          'iso885913',
-          'iso885914',
-          'iso885915',
-          'iso885916',
-          'iso88592',
-          'iso88593',
-          'iso88594',
-          'iso88595',
-          'iso88596',
-          'iso88597',
-          'iso88597',
-          'iso88598',
-          'koi8r',
-          'koi8u',
-          'macroman',
-          'shiftjis',
-          'utf16be',
-          'utf16le',
-          'utf8',
-          'windows1250',
-          'windows1251',
-          'windows1252',
-          'windows1253',
-          'windows1254',
-          'windows1255',
-          'windows1256',
-          'windows1257',
-          'windows1258'
+          {
+            value: 'utf8',
+            description: 'UTF-8'
+          },
+          {
+            value: 'utf16le',
+            description: 'UTF-16 LE'
+          },
+          {
+            value: 'utf16be',
+            description: 'UTF-16 BE'
+          },
+          {
+            value: 'windows1252',
+            description: 'Western (Windows 1252)'
+          },
+          {
+            value: 'iso88591',
+            description: 'Western (ISO 8859-1)'
+          },
+          {
+            value: 'iso88593',
+            description: 'Western (ISO 8859-3)'
+          },
+          {
+            value: 'iso885915',
+            description: 'Western (ISO 8859-15)'
+          },
+          {
+            value: 'macroman',
+            description: 'Western (Mac Roman)'
+          },
+          {
+            value: 'cp437',
+            description: 'DOS (CP 437)'
+          },
+          {
+            value: 'cp850',
+            description: 'DOS (CP 850)'
+          },
+          {
+            value: 'windows1256',
+            description: 'Arabic (Windows 1256)'
+          },
+          {
+            value: 'iso88596',
+            description: 'Arabic (ISO 8859-6)'
+          },
+          {
+            value: 'windows1257',
+            description: 'Baltic (Windows 1257)'
+          },
+          {
+            value: 'iso88594',
+            description: 'Baltic (ISO 8859-4)'
+          },
+          {
+            value: 'iso885914',
+            description: 'Celtic (ISO 8859-14)'
+          },
+          {
+            value: 'windows1250',
+            description: 'Central European (Windows 1250)'
+          },
+          {
+            value: 'iso88592',
+            description: 'Central European (ISO 8859-2)'
+          },
+          {
+            value: 'windows1251',
+            description: 'Cyrillic (Windows 1251)'
+          },
+          {
+            value: 'cp866',
+            description: 'Cyrillic (CP 866)'
+          },
+          {
+            value: 'iso88595',
+            description: 'Cyrillic (ISO 8859-5)'
+          },
+          {
+            value: 'koi8r',
+            description: 'Cyrillic (KOI8-R)'
+          },
+          {
+            value: 'koi8u',
+            description: 'Cyrillic (KOI8-U)'
+          },
+          {
+            value: 'iso885913',
+            description: 'Estonian (ISO 8859-13)'
+          },
+          {
+            value: 'windows1253',
+            description: 'Greek (Windows 1253)'
+          },
+          {
+            value: 'iso88597',
+            description: 'Greek (ISO 8859-7)'
+          },
+          {
+            value: 'windows1255',
+            description: 'Hebrew (Windows 1255)'
+          },
+          {
+            value: 'iso88598',
+            description: 'Hebrew (ISO 8859-8)'
+          },
+          {
+            value: 'iso885910',
+            description: 'Nordic (ISO 8859-10)'
+          },
+          {
+            value: 'iso885916',
+            description: 'Romanian (ISO 8859-16)'
+          },
+          {
+            value: 'windows1254',
+            description: 'Turkish (Windows 1254)'
+          },
+          {
+            value: 'iso88599',
+            description: 'Turkish (ISO 8859-9)'
+          },
+          {
+            value: 'windows1258',
+            description: 'Vietnamese (Windows 1254)'
+          },
+          {
+            value: 'gbk',
+            description: 'Chinese (GBK)'
+          },
+          {
+            value: 'gb18030',
+            description: 'Chinese (GB18030)'
+          },
+          {
+            value: 'cp950',
+            description: 'Traditional Chinese (Big5)'
+          },
+          {
+            value: 'big5hkscs',
+            description: 'Traditional Chinese (Big5-HKSCS)'
+          },
+          {
+            value: 'shiftjis',
+            description: 'Japanese (Shift JIS)'
+          },
+          {
+            value: 'cp932',
+            description: 'Japanese (CP 932)'
+          },
+          {
+            value: 'eucjp',
+            description: 'Japanese (EUC-JP)'
+          },
+          {
+            value: 'euckr',
+            description: 'Korean (EUC-KR)'
+          }
         ]
       },
       openEmptyEditorOnStart: {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I updated the list of text encodings that appear in the Settings configuration menu to properly reflect the code pages supported by [encoding-selector](https://github.com/atom/encoding-selector), as well as present descriptive text for the selection menu.

In the process, I removed what appeared to be a duplicate entry ('iso88597').

### Alternate Designs

None considered. I based the syntax on the code below it (the Telemetry selection options).

### Why Should This Be In Core?

It's a more user-friendly presentation of the list of supported code pages.

### Benefits

Users may more easily recognize the available text encodings that Atom supports from the Settings configuration page. 

### Possible Drawbacks

The code may break the functionality of the menu, because I'm not aware of how the menus are constructed, to be honest. I presume a more experienced coder can figure this out.

I just thought this could be an improvement to the menu. 😃 

### Applicable Issues

None cited.