### PR TITLE
Fix infinite recursion when calling `editor.getLastSelection` from an `onDidAddCursor` event handler

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1191,6 +1191,15 @@ describe "TextEditor", ->
         editor.getLastSelection().destroy()
         expect(editor.getLastSelection().getBufferRange()).toEqual([[0, 0], [0, 0]])
 
+      it "doesn't get stuck in a infinite loop when called from ::onDidAddCursor after the last selection has been destroyed (regression)", ->
+        callCount = 0
+        editor.getLastSelection().destroy()
+        editor.onDidAddCursor (cursor) ->
+          callCount++
+          editor.getLastSelection()
+        expect(editor.getLastSelection().getBufferRange()).toEqual([[0, 0], [0, 0]])
+        expect(callCount).toBe(1)
+
     describe ".getSelections()", ->
       it "creates a new selection at (0, 0) if the last selection has been destroyed", ->
         editor.getLastSelection().destroy()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2284,7 +2284,6 @@ class TextEditor extends Model
     @decorateMarker(marker, type: 'line-number', class: 'cursor-line')
     @decorateMarker(marker, type: 'line-number', class: 'cursor-line-no-selection', onlyHead: true, onlyEmpty: true)
     @decorateMarker(marker, type: 'line', class: 'cursor-line', onlyEmpty: true)
-    @emitter.emit 'did-add-cursor', cursor
     cursor
 
   moveCursors: (fn) ->
@@ -2773,6 +2772,7 @@ class TextEditor extends Model
         if selection.intersectsBufferRange(selectionBufferRange)
           return selection
     else
+      @emitter.emit 'did-add-cursor', cursor
       @emitter.emit 'did-add-selection', selection
       selection
 


### PR DESCRIPTION
Fixes https://github.com/atom/bracket-matcher/issues/271.

When all the selections are destroyed and someone calls `editor.getLastSelection`, Atom ensures there is at least one selection available and, as a result, creates a new one. Due to the way our code was structured, the `onDidAddCursor` event was being fired before the new selection had the chance to be stored in the editor state: as a result, when someone tried to call `editor.getLastSelection` during a "cursor added" event, Atom would retry to create a selection, thus firing again the `onDidAddCursor` event and causing the infinite loop.

This pull request fixes the above problem by emitting the `did-add-cursor` event after the selection has been successfully added to the editor state.

/cc: @atom/maintainers  