### PR TITLE
Allow code signing cert to be specified at a local path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ git:
 matrix:
   include:
     - os: linux
-      env: NODE_VERSION=4.4.7 DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1
+      env: NODE_VERSION=6.9.4 DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1
 
 sudo: false
 

--- a/circle.yml
+++ b/circle.yml
@@ -16,8 +16,8 @@ general:
 dependencies:
   pre:
     - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash
-    - nvm install 4.4.7
-    - nvm use 4.4.7
+    - nvm install 6.9.4
+    - nvm use 6.9.4
     - npm install -g npm
 
   override:

--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -7,7 +7,7 @@ Ubuntu LTS 12.04 64-bit is the recommended platform.
 * OS with 64-bit or 32-bit architecture
 * C++11 toolchain
 * Git
-* Node.js 4.4.x or later (we recommend installing it via [nvm](https://github.com/creationix/nvm))
+* Node.js 6.x (we recommend installing it via [nvm](https://github.com/creationix/nvm))
 * npm 3.10.x or later (run `npm install -g npm`)
 * Ensure node-gyp uses python2 (run `npm config set python /usr/bin/python2 -g`, use `sudo` if you didn't install node via nvm)
 * Development headers for [GNOME Keyring](https://wiki.gnome.org/Projects/GnomeKeyring).

--- a/docs/build-instructions/macOS.md
+++ b/docs/build-instructions/macOS.md
@@ -3,7 +3,7 @@
 ## Requirements
 
   * macOS 10.8 or later
-  * Node.js 4.4.x or later (we recommend installing it via [nvm](https://github.com/creationix/nvm))
+  * Node.js 6.x (we recommend installing it via [nvm](https://github.com/creationix/nvm))
   * npm 3.10.x or later (run `npm install -g npm`)
   * Command Line Tools for [Xcode](https://developer.apple.com/xcode/downloads/) (run `xcode-select --install` to install)
 

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-* Node.js 4.4.x or later (the architecture of node available to the build system will determine whether you build 32-bit or 64-bit Atom)
+* Node.js 6.x (the architecture of node available to the build system will determine whether you build 32-bit or 64-bit Atom)
 * Python v2.7.x
   * The python.exe must be available at `%SystemDrive%\Python27\python.exe`. If it is installed elsewhere create a symbolic link to the directory containing the python.exe using: `mklink /d %SystemDrive%\Python27 D:\elsewhere\Python27`
 * 7zip (7z.exe available from the command line) - for creating distribution zip files

--- a/script/lib/code-sign-on-mac.js
+++ b/script/lib/code-sign-on-mac.js
@@ -5,15 +5,17 @@ const path = require('path')
 const spawnSync = require('./spawn-sync')
 
 module.exports = function (packagedAppPath) {
-  if (!process.env.ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL) {
+  if (!process.env.ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL && !process.env.ATOM_MAC_CODE_SIGNING_CERT_PATH) {
     console.log('Skipping code signing because the ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL environment variable is not defined'.gray)
     return
   }
 
-  try {
-    const certPath = path.join(os.tmpdir(), 'mac.p12')
+  let certPath = process.env.ATOM_MAC_CODE_SIGNING_CERT_PATH;
+  if (!certPath) {
+    certPath = path.join(os.tmpdir(), 'mac.p12')
     downloadFileFromGithub(process.env.ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL, certPath)
-
+  }
+  try {
     console.log(`Unlocking keychain ${process.env.ATOM_MAC_CODE_SIGNING_KEYCHAIN}`)
     const unlockArgs = ['unlock-keychain']
     // For signing on local workstations, password could be entered interactively
@@ -38,7 +40,9 @@ module.exports = function (packagedAppPath) {
       '--sign', 'Developer ID Application: GitHub', packagedAppPath
     ], {stdio: 'inherit'})
   } finally {
-    console.log(`Deleting certificate at ${certPath}`)
-    fs.removeSync(certPath)
+    if (!process.env.ATOM_MAC_CODE_SIGNING_CERT_PATH) {
+      console.log(`Deleting certificate at ${certPath}`)
+      fs.removeSync(certPath)
+    }
   }
 }

--- a/script/lib/create-windows-installer.js
+++ b/script/lib/create-windows-installer.js
@@ -23,7 +23,7 @@ module.exports = function (packagedAppPath, codeSign) {
   }
 
   const signing = codeSign && (process.env.ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL || process.env.ATOM_WIN_CODE_SIGNING_CERT_PATH)
-  let certPath = ATOM_WIN_CODE_SIGNING_CERT_PATH;
+  let certPath = process.env.ATOM_WIN_CODE_SIGNING_CERT_PATH;
 
   if (signing) {
     if (!certPath) {

--- a/script/lib/create-windows-installer.js
+++ b/script/lib/create-windows-installer.js
@@ -24,12 +24,13 @@ module.exports = function (packagedAppPath, codeSign) {
 
   const signing = codeSign && (process.env.ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL || process.env.ATOM_WIN_CODE_SIGNING_CERT_PATH)
   let certPath = ATOM_WIN_CODE_SIGNING_CERT_PATH;
-  if (!certPath) {
-    certPath = path.join(os.tmpdir(), 'win.p12')
-    downloadFileFromGithub(process.env.ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL, certPath)
-  }
 
   if (signing) {
+    if (!certPath) {
+      certPath = path.join(os.tmpdir(), 'win.p12')
+      downloadFileFromGithub(process.env.ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL, certPath)
+    }
+
     var signParams = []
     signParams.push(`/f ${certPath}`) // Signing cert file
     signParams.push(`/p ${process.env.ATOM_WIN_CODE_SIGNING_CERT_PASSWORD}`) // Signing cert password

--- a/script/lib/create-windows-installer.js
+++ b/script/lib/create-windows-installer.js
@@ -22,11 +22,14 @@ module.exports = function (packagedAppPath, codeSign) {
     setupIcon: path.join(CONFIG.repositoryRootPath, 'resources', 'app-icons', CONFIG.channel, 'atom.ico')
   }
 
-  const certPath = path.join(os.tmpdir(), 'win.p12')
-  const signing = codeSign && process.env.ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL
+  const signing = codeSign && (process.env.ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL || process.env.ATOM_WIN_CODE_SIGNING_CERT_PATH)
+  let certPath = ATOM_WIN_CODE_SIGNING_CERT_PATH;
+  if (!certPath) {
+    certPath = path.join(os.tmpdir(), 'win.p12')
+    downloadFileFromGithub(process.env.ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL, certPath)
+  }
 
   if (signing) {
-    downloadFileFromGithub(process.env.ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL, certPath)
     var signParams = []
     signParams.push(`/f ${certPath}`) // Signing cert file
     signParams.push(`/p ${process.env.ATOM_WIN_CODE_SIGNING_CERT_PASSWORD}`) // Signing cert password
@@ -39,7 +42,7 @@ module.exports = function (packagedAppPath, codeSign) {
   }
 
   const cleanUp = function () {
-    if (fs.existsSync(certPath)) {
+    if (fs.existsSync(certPath) && !process.env.ATOM_WIN_CODE_SIGNING_CERT_PATH) {
       console.log(`Deleting certificate at ${certPath}`)
       fs.removeSync(certPath)
     }


### PR DESCRIPTION
This allows code signing certificates to be specified via `ATOM_MAC_CODE_SIGNING_CERT_PATH` and `ATOM_WIN_CODE_SIGNING_CERT_PATH` on macOS and Windows, respectively. In that case, we don't try to download the certificate, and we also don't delete the certificate after signing is complete.

This also fixes an issue where `certPath` wasn't in scope for the `finally` block in the macOS case.

/cc @as-cii @damieng 