### PR TITLE
pass through line count options

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "random-words": "0.0.1",
     "resolve": "^1.1.6",
     "runas": "^3.1",
-    "scandal": "^3.0.0",
+    "scandal": "^3.1.0",
     "scoped-property-store": "^0.17.0",
     "scrollbar-style": "^3.2",
     "season": "^6.0.0",

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -1336,7 +1336,9 @@ i = /test/; #FIXME\
       it('calls the callback with all regex results in all files in the project', () => {
         const results = []
         waitsForPromise(() =>
-          atom.workspace.scan(/(a)+/, result => results.push(result))
+          atom.workspace.scan(
+            /(a)+/, {leadingContextLineCount: 1, trailingContextLineCount: 1},
+            result => results.push(result))
         )
 
         runs(() => {
@@ -1349,14 +1351,16 @@ i = /test/; #FIXME\
             lineTextOffset: 0,
             range: [[0, 0], [0, 3]],
             leadingContextLines: [],
-            trailingContextLines: []
+            trailingContextLines: ['cc aa cc']
           })
         })
       })
 
       it('works with with escaped literals (like $ and ^)', () => {
         const results = []
-        waitsForPromise(() => atom.workspace.scan(/\$\w+/, result => results.push(result)))
+        waitsForPromise(() => atom.workspace.scan(
+          /\$\w+/, {leadingContextLineCount: 1, trailingContextLineCount: 1},
+          result => results.push(result)))
 
         runs(() => {
           expect(results.length).toBe(1)
@@ -1368,7 +1372,7 @@ i = /test/; #FIXME\
             lineText: 'dollar$bill',
             lineTextOffset: 0,
             range: [[2, 6], [2, 11]],
-            leadingContextLines: [],
+            leadingContextLines: ['cc aa cc'],
             trailingContextLines: []
           })
         })

--- a/src/default-directory-searcher.coffee
+++ b/src/default-directory-searcher.coffee
@@ -11,13 +11,16 @@ class DirectorySearch
       excludeVcsIgnores: options.excludeVcsIgnores
       globalExclusions: options.exclusions
       follow: options.follow
+    searchOptions =
+      leadingContextLineCount: options.leadingContextLineCount
+      trailingContextLineCount: options.trailingContextLineCount
     @task = new Task(require.resolve('./scan-handler'))
     @task.on 'scan:result-found', options.didMatch
     @task.on 'scan:file-error', options.didError
     @task.on 'scan:paths-searched', options.didSearchPaths
     @promise = new Promise (resolve, reject) =>
       @task.on('task:cancelled', reject)
-      @task.start rootPaths, regex.source, scanHandlerOptions, =>
+      @task.start rootPaths, regex.source, scanHandlerOptions, searchOptions, =>
         @task.terminate()
         resolve()
 

--- a/src/scan-handler.coffee
+++ b/src/scan-handler.coffee
@@ -2,13 +2,13 @@ path = require "path"
 async = require "async"
 {PathSearcher, PathScanner, search} = require 'scandal'
 
-module.exports = (rootPaths, regexSource, options) ->
+module.exports = (rootPaths, regexSource, options, searchOptions={}) ->
   callback = @async()
 
   PATHS_COUNTER_SEARCHED_CHUNK = 50
   pathsSearched = 0
 
-  searcher = new PathSearcher()
+  searcher = new PathSearcher(searchOptions)
 
   searcher.on 'file-error', ({code, path, message}) ->
     emit('scan:file-error', {code, path, message})

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2826,6 +2826,11 @@ class TextEditor extends Model
   # {::backwardsScanInBufferRange} to avoid tripping over your own changes.
   #
   # * `regex` A {RegExp} to search for.
+  # * `options` (optional) {Object}
+  #   * `leadingContextLineCount` {Number} default `0`; The number of lines
+  #      before the matched line to include in the results object.
+  #   * `trailingContextLineCount` {Number} default `0`; The number of lines
+  #      after the matched line to include in the results object.
   # * `iterator` A {Function} that's called on each match
   #   * `object` {Object}
   #     * `match` The current regular expression match.
@@ -2833,7 +2838,12 @@ class TextEditor extends Model
   #     * `range` The {Range} of the match.
   #     * `stop` Call this {Function} to terminate the scan.
   #     * `replace` Call this {Function} with a {String} to replace the match.
-  scan: (regex, iterator) -> @buffer.scan(regex, iterator)
+  scan: (regex, options={}, iterator) ->
+    if _.isFunction(options)
+      iterator = options
+      options = {}
+
+    @buffer.scan(regex, options, iterator)
 
   # Essential: Scan regular expression matches in a given range, calling the given
   # iterator function on each match.

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1202,6 +1202,10 @@ module.exports = class Workspace extends Model {
   //   * `paths` An {Array} of glob patterns to search within.
   //   * `onPathsSearched` (optional) {Function} to be periodically called
   //     with number of paths searched.
+  //   * `leadingContextLineCount` {Number} default `0`; The number of lines
+  //      before the matched line to include in the results object.
+  //   * `trailingContextLineCount` {Number} default `0`; The number of lines
+  //      after the matched line to include in the results object.
   // * `iterator` {Function} callback on each file found.
   //
   // Returns a {Promise} with a `cancel()` method that will cancel all
@@ -1261,6 +1265,8 @@ module.exports = class Workspace extends Model {
         excludeVcsIgnores: this.config.get('core.excludeVcsIgnoredPaths'),
         exclusions: this.config.get('core.ignoredNames'),
         follow: this.config.get('core.followSymlinks'),
+        leadingContextLineCount: options.leadingContextLineCount || 0,
+        trailingContextLineCount: options.trailingContextLineCount || 0,
         didMatch: result => {
           if (!this.project.isPathModified(result.filePath)) {
             return iterator(result)


### PR DESCRIPTION
This is in support of atom/find-and-replace#847.

### Requirements

* atom/find-and-replace#847
* atom/scandal#41
* atom/text-buffer#195

### Description of the Change

Add two additional optional options to `workspace.scan` (namely `lineCountBefore` and `lineCountAfter`) and pass them along to the `scan-handler` and from there to the `PassSearcher`.

### Alternate Designs

I am not aware of an alternative approach.

### Why Should This Be In Core?

Since the modified API for searching is part of the core it needs to be extended to support the use case described in atom/find-and-replace#190. If the `find-and-replace` package could handle this without requiring modifications to the core that would be great but with the current API being provided by the core I don't think this is possible.

### Benefits

It implements the long desired feature described in atom/find-and-replace#190.

### Possible Drawbacks

The additional optional argument shouldn't result in any backward compatibility problem as far as I can tell.

### Applicable Issues / Remaining Todos

* ~~In the current state when the search results list a file which is not opened yet and you click on the result the match is being updated and looses the context information. This is due to the fact that the search is being repeated in the buffer (instead of using `scandal` through the workspace API. In order to address this the `TextBuffer.scan` needs to be extended to support the same new options as in the referenced `scandal` ticket. Therefore I have prefixed the title with `[WIP]` for now.~~ This has been address with the PR to the `text-buffer` package.

* Add test coverage / update existing specs as soon as there is a consensus on the selected approach and the feature works.