### PR TITLE
:arrow_up: coffee-script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chai": "3.5.0",
     "chart.js": "^2.3.0",
     "clear-cut": "^2.0.2",
-    "coffee-script": "1.11.1",
+    "coffee-script": "1.12.7",
     "color": "^0.7.3",
     "dedent": "^0.6.0",
     "devtron": "1.3.0",


### PR DESCRIPTION
Just a friendly reminder to occasionally update coffee-script.

Allows new syntax to be used and also provides better source maps.

After merging, make sure to clear compile-cache for updated source maps to take effect.

Changelogs can be found at http://coffeescript.org/#1.12.0 and then by scrolling up.