### PR TITLE
Add ContextMenuManager.remove

### DIFF
--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -169,6 +169,7 @@ class ContextMenuManager
         if not keepNextItemIfSeparator or index is menu.length - 1
           menu.splice(index, 1)
         else
+          keepNextItemIfSeparator = false
           index++
       else
         keepNextItemIfSeparator = true

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -126,6 +126,7 @@ class ContextMenuManager
 
   templateForEvent: (event) ->
     template = []
+    removeItems = []
     currentTarget = event.target
 
     while currentTarget?
@@ -142,7 +143,6 @@ class ContextMenuManager
       for item in currentTargetItems
         MenuHelpers.merge(template, item, false)
 
-      currentTargetRemoveItems = []
       matchingRemoveItemSets =
         @removeItemSets.filter (itemSet) -> currentTarget.webkitMatchesSelector(itemSet.selector)
 
@@ -150,15 +150,15 @@ class ContextMenuManager
         for item in itemSet.items
           itemForEvent = @cloneItemForEvent(item, event)
           if itemForEvent
-            MenuHelpers.merge(currentTargetRemoveItems, itemForEvent, itemSet.specificity)
-
-      for item in currentTargetRemoveItems
-        MenuHelpers.unmerge(template, item, false)
+            MenuHelpers.merge(removeItems, itemForEvent, itemSet.specificity)
 
       currentTarget = currentTarget.parentElement
 
+    for item in removeItems
+      MenuHelpers.unmerge(template, item, false)
+      
     @pruneRedundantSeparators(template)
-
+    
     template
 
   pruneRedundantSeparators: (menu) ->

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -236,17 +236,16 @@ class ContextMenuManager
   # To remove a context menu, pass a selector matching the elements to which you
   # want the menu to apply as the top level key, followed by a menu descriptor.
   # The invocation below removes a global 'Help' context menu item and a 'History'
-  # submenu on the editor supporting undo/redo. This is just for example
-  # purposes and not the way the menu is actually configured in Atom by default.
+  # submenu on the editor supporting undo/redo.
   #
   # ```coffee
   # atom.contextMenu.remove {
-  #   'atom-workspace': [{label: 'Help', command: 'application:open-documentation'}]
+  #   'atom-workspace': [{label: 'Help'}]
   #   'atom-text-editor': [{
   #     label: 'History',
   #     submenu: [
-  #       {label: 'Undo', command:'core:undo'}
-  #       {label: 'Redo', command:'core:redo'}
+  #       {label: 'Undo'}
+  #       {label: 'Redo'}
   #     ]
   #   }]
   # }
@@ -257,29 +256,10 @@ class ContextMenuManager
   # * `itemsBySelector` An {Object} whose keys are CSS selectors and whose
   #   values are {Array}s of item {Object}s containing the following keys:
   #   * `label` (optional) A {String} containing the menu item's label.
-  #   * `command` (optional) A {String} containing the command to invoke on the
-  #     target of the right click that invoked the context menu.
-  #   * `enabled` (optional) A {Boolean} indicating whether the menu item
-  #     should be clickable. Disabled menu items typically appear grayed out.
-  #     Defaults to `true`.
-  #   * `submenu` (optional) An {Array} of additional items.
-  #   * `type` (optional) If you want to create a separator, provide an item
-  #      with `type: 'separator'` and no other keys.
-  #   * `visible` (optional) A {Boolean} indicating whether the menu item
-  #     should appear in the menu. Defaults to `true`.
-  #   * `created` (optional) A {Function} that is called on the item each time a
-  #     context menu is created via a right click. You can assign properties to
-  #    `this` to dynamically compute the command, label, etc. This method is
-  #    actually called on a clone of the original item template to prevent state
-  #    from leaking across context menu deployments. Called with the following
-  #    argument:
-  #     * `event` The click event that deployed the context menu.
-  #   * `shouldDisplay` (optional) A {Function} that is called to determine
-  #     whether to display this item on a given context menu deployment. Called
-  #     with the following argument:
-  #     * `event` The click event that deployed the context menu.
+  #   * `submenu` (optional) An {Array} of items to be removed from the submenu.
+  #     The top level menu item is removed only if all submenu items are removed.
   #
-  # Returns a {Disposable} on which `.dispose()` can be called to remove the
+  # Returns a {Disposable} on which `.dispose()` can be called to re-add the
   # removed menu items.
   remove: (itemsBySelector) ->
     removedItemSets = []

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -142,6 +142,19 @@ class ContextMenuManager
       for item in currentTargetItems
         MenuHelpers.merge(template, item, false)
 
+      currentTargetRemoveItems = []
+      matchingRemoveItemSets =
+        @removeItemSets.filter (itemSet) -> currentTarget.webkitMatchesSelector(itemSet.selector)
+
+      for itemSet in matchingRemoveItemSets
+        for item in itemSet.items
+          itemForEvent = @cloneItemForEvent(item, event)
+          if itemForEvent
+            MenuHelpers.merge(currentTargetRemoveItems, itemForEvent, itemSet.specificity)
+
+      for item in currentTargetRemoveItems
+        MenuHelpers.unmerge(template, item, false)
+
       currentTarget = currentTarget.parentElement
 
     @pruneRedundantSeparators(template)
@@ -206,6 +219,7 @@ class ContextMenuManager
   clear: ->
     @activeElement = null
     @itemSets = []
+    @removeItemSets = []
     @add 'atom-workspace': [{
       label: 'Inspect Element'
       command: 'application:inspect'
@@ -214,6 +228,72 @@ class ContextMenuManager
         {pageX, pageY} = event
         @commandDetail = {x: pageX, y: pageY}
     }]
+
+  # Public: Remove context menu items scoped by CSS selectors.
+  #
+  # ## Examples
+  #
+  # To remove a context menu, pass a selector matching the elements to which you
+  # want the menu to apply as the top level key, followed by a menu descriptor.
+  # The invocation below removes a global 'Help' context menu item and a 'History'
+  # submenu on the editor supporting undo/redo. This is just for example
+  # purposes and not the way the menu is actually configured in Atom by default.
+  #
+  # ```coffee
+  # atom.contextMenu.remove {
+  #   'atom-workspace': [{label: 'Help', command: 'application:open-documentation'}]
+  #   'atom-text-editor': [{
+  #     label: 'History',
+  #     submenu: [
+  #       {label: 'Undo', command:'core:undo'}
+  #       {label: 'Redo', command:'core:redo'}
+  #     ]
+  #   }]
+  # }
+  # ```
+  #
+  # ## Arguments
+  #
+  # * `itemsBySelector` An {Object} whose keys are CSS selectors and whose
+  #   values are {Array}s of item {Object}s containing the following keys:
+  #   * `label` (optional) A {String} containing the menu item's label.
+  #   * `command` (optional) A {String} containing the command to invoke on the
+  #     target of the right click that invoked the context menu.
+  #   * `enabled` (optional) A {Boolean} indicating whether the menu item
+  #     should be clickable. Disabled menu items typically appear grayed out.
+  #     Defaults to `true`.
+  #   * `submenu` (optional) An {Array} of additional items.
+  #   * `type` (optional) If you want to create a separator, provide an item
+  #      with `type: 'separator'` and no other keys.
+  #   * `visible` (optional) A {Boolean} indicating whether the menu item
+  #     should appear in the menu. Defaults to `true`.
+  #   * `created` (optional) A {Function} that is called on the item each time a
+  #     context menu is created via a right click. You can assign properties to
+  #    `this` to dynamically compute the command, label, etc. This method is
+  #    actually called on a clone of the original item template to prevent state
+  #    from leaking across context menu deployments. Called with the following
+  #    argument:
+  #     * `event` The click event that deployed the context menu.
+  #   * `shouldDisplay` (optional) A {Function} that is called to determine
+  #     whether to display this item on a given context menu deployment. Called
+  #     with the following argument:
+  #     * `event` The click event that deployed the context menu.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to remove the
+  # removed menu items.
+  remove: (itemsBySelector) ->
+    removedItemSets = []
+
+    for selector, items of itemsBySelector
+      validateSelector(selector)
+      itemSet = new ContextMenuItemSet(selector, items)
+      removedItemSets.push(itemSet)
+      @removeItemSets.push(itemSet)
+
+    new Disposable =>
+      for itemSet in removedItemSets
+        @removeItemSets.splice(@removeItemSets.indexOf(itemSet), 1)
+      return
 
 class ContextMenuItemSet
   constructor: (@selector, @items) ->


### PR DESCRIPTION
### Description of the Change

This will add a `remove` method to `atom.contextMenu` to counter the `add` method

With this method one will be able to remove items from the context menu by specifying a selector(s) and label(s)

### Why Should This Be In Core?

Because the only alternative is to override a global object `atom.contextMenu`

### Benefits

This will finally give the ability to remove items that clutter the context menus from packages.
Similar to the benefits of disabling keybindings that packages automatically add

### Possible Drawbacks

None that I can think of.

### Applicable Issues

#9429
#7739