### PR TITLE
Allow custom directory search providers to also override replace

### DIFF
--- a/spec/default-directory-searcher-spec.coffee
+++ b/spec/default-directory-searcher-spec.coffee
@@ -1,6 +1,8 @@
 DefaultDirectorySearcher = require '../src/default-directory-searcher'
 Task = require '../src/task'
+fs = require 'fs-plus'
 path = require 'path'
+temp = require('temp').track()
 
 describe "DefaultDirectorySearcher", ->
   [searcher, dirPath] = []
@@ -26,3 +28,19 @@ describe "DefaultDirectorySearcher", ->
 
     runs ->
       expect(Task::terminate).toHaveBeenCalled()
+
+  it "is able to replace files", ->
+    tempDir = temp.mkdirSync('dir')
+    tempFile = path.join(tempDir, 'test_file')
+    fs.writeFileSync(tempFile, 'aaa')
+
+    results = []
+    waitsForPromise ->
+      searcher.replace [tempFile], /a/, 'b', (result) ->
+        results.push(result)
+
+    runs ->
+      expect(results).toEqual [
+        {filePath: tempFile, replacements: 3},
+      ]
+      expect(fs.readFileSync(tempFile, 'utf8')).toBe 'bbb'

--- a/src/default-directory-searcher.coffee
+++ b/src/default-directory-searcher.coffee
@@ -92,3 +92,25 @@ class DefaultDirectorySearcher
         isCancelled = true
         directorySearch.cancel()
     }
+
+  # Performs a replace across all the specified files.
+  #
+  # * `filePaths` An {Array} of file path strings to run the replace on.
+  # * `regex` A {RegExp} to search with.
+  # * `replacementText` {String} to replace all matches of regex with.
+  # * `iterator` A {Function} callback on each file with replacements:
+  #   * `options` {Object} with keys:
+  #     * `filePath` {String} a path with replacements
+  #     * `replacements` {Number} the count of replacements performed
+  #
+  # Returns a {Promise}.
+  replace: (filePaths, regex, replacementText, iterator) ->
+    new Promise (resolve, reject) ->
+      flags = 'g'
+      flags += 'i' if regex.ignoreCase
+
+      task = Task.once require.resolve('./replace-handler'),
+        filePaths, regex.source, flags, replacementText, resolve
+
+      task.on 'replace:path-replaced', iterator
+      task.on 'replace:file-error', (error) -> iterator(null, error)


### PR DESCRIPTION
This change allows providers of `atom.directory-searcher` to provide a custom `replace` method to override the default `scandal`-based replacement logic, and moves the existing replacement logic into the default `DirectorySearch` provider.

For example, in Nuclide, we provide a custom directory searcher to enable searching remote files. However, remote file replacement is naturally still broken.

As a temporary workaround we ended up monkey-patching `atom.workspace.replace` (cc @zertosh): https://github.com/facebook/nuclide/blob/master/pkg/nuclide-remote-projects/lib/patchAtomWorkspaceReplace.js#L41

This will allow us to remove the hack and add the necessary code to our custom remote directory search provider instead.

Released under CC0.