### PR TITLE
:memo: :fire: broken TextEditorElement link

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -19,9 +19,7 @@ ZERO_WIDTH_NBSP = '\ufeff'
 
 # Essential: This class represents all essential editing state for a single
 # {TextBuffer}, including cursor and selection positions, folds, and soft wraps.
-# If you're manipulating the state of an editor, use this class. If you're
-# interested in the visual appearance of editors, use {TextEditorElement}
-# instead.
+# If you're manipulating the state of an editor, use this class.
 #
 # A single {TextBuffer} can belong to multiple editors. For example, if the
 # same file is open in two different panes, Atom creates a separate editor for


### PR DESCRIPTION
Remove the link to the `TextEditorElement` class since it isn't documented and we don't intend it to be.

Fixes atom/flight-manual.atom.io#128