### PR TITLE
Normalize disk drive letter in path on Windows

### DIFF
--- a/spec/default-directory-provider-spec.coffee
+++ b/spec/default-directory-provider-spec.coffee
@@ -28,6 +28,15 @@ describe "DefaultDirectoryProvider", ->
       directory = provider.directoryForURISync(nonNormalizedPath)
       expect(directory.getPath()).toEqual tmp
 
+    it "normalizes disk drive letter in path on #win32", ->
+      provider = new DefaultDirectoryProvider()
+      nonNormalizedPath = tmp[0].toLowerCase()+tmp.slice(1)
+      expect(tmp).not.toMatch /^[a-z]:/
+      expect(nonNormalizedPath).toMatch /^[a-z]:/
+
+      directory = provider.directoryForURISync(nonNormalizedPath)
+      expect(directory.getPath()).toEqual tmp
+
     it "creates a Directory for its parent dir when passed a file", ->
       provider = new DefaultDirectoryProvider()
       file = path.join(tmp, "example.txt")

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -614,3 +614,7 @@ describe "Project", ->
 
       randomPath = path.join("some", "random", "path")
       expect(atom.project.contains(randomPath)).toBe false
+
+  describe ".resolvePath(uri)", ->
+    it "normalizes disk drive letter in passed path on #win32", ->
+      expect(atom.project.resolvePath("d:\\file.txt")).toEqual "D:\\file.txt"

--- a/src/default-directory-provider.coffee
+++ b/src/default-directory-provider.coffee
@@ -15,7 +15,7 @@ class DefaultDirectoryProvider
   # * {Directory} if the given URI is compatible with this provider.
   # * `null` if the given URI is not compatibile with this provider.
   directoryForURISync: (uri) ->
-    normalizedPath = path.normalize(uri)
+    normalizedPath = @normalizePath(uri)
     {host} = url.parse(uri)
     directoryPath = if host
       uri
@@ -42,3 +42,17 @@ class DefaultDirectoryProvider
   # * `null` if the given URI is not compatibile with this provider.
   directoryForURI: (uri) ->
     Promise.resolve(@directoryForURISync(uri))
+
+  # Public: Normalizes path.
+  #
+  # * `uri` {String} The path that should be normalized.
+  #
+  # Returns a {String} with normalized path.
+  normalizePath: (uri) ->
+    # Normalize disk drive letter on Windows to avoid opening two buffers for the same file
+    pathWithNormalizedDiskDriveLetter =
+      if process.platform is 'win32' and matchData = uri.match(/^([a-z]):/)
+        "#{matchData[1].toUpperCase()}#{uri.slice(1)}"
+      else
+        uri
+    path.normalize(pathWithNormalizedDiskDriveLetter)

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -205,7 +205,7 @@ class Project extends Model
   removePath: (projectPath) ->
     # The projectPath may be a URI, in which case it should not be normalized.
     unless projectPath in @getPaths()
-      projectPath = path.normalize(projectPath)
+      projectPath = @defaultDirectoryProvider.normalizePath(projectPath)
 
     indexToRemove = null
     for directory, i in @rootDirectories
@@ -233,11 +233,10 @@ class Project extends Model
       uri
     else
       if fs.isAbsolute(uri)
-        path.normalize(fs.resolveHome(uri))
-
+        @defaultDirectoryProvider.normalizePath(fs.resolveHome(uri))
       # TODO: what should we do here when there are multiple directories?
       else if projectPath = @getPaths()[0]
-        path.normalize(fs.resolveHome(path.join(projectPath, uri)))
+        @defaultDirectoryProvider.normalizePath(fs.resolveHome(path.join(projectPath, uri)))
       else
         undefined
 


### PR DESCRIPTION
### Description of the Change

Currently atom creates two buffers for the same file if passed paths use difference case for disk drive letter, e.g. `d:\file.txt` and `D:\file.txt`

This change ensures that the absolute path always has disk drive letter in uppercase. 

### Alternate Designs

The other place where this fix could be applied is [findBufferForPath](https://github.com/atom/atom/blob/master/src/project.coffee#L331) function. However the used function [resolvePath](https://github.com/atom/atom/blob/master/src/project.coffee#L229) already has some path normalization code, so I think this is the best fit.

Actually Windows interpreters `file.txt` and `File.txt` as the same file. Maybe it makes sense to extend this patch and make Atom to do the same on this operation system, but I'm not sure because it can be file system specific. Any suggestions are welcome!

### Why Should This Be In Core?

I believe the current behavior of the editor is wrong for Windows users, so it makes no sense to create a plugin to fix that.

### Benefits

The main benefit I would like to get is the ability to click on parsed backtrace in my terminal emulation app (ConEmu). Right now it works, but atom opens second buffer for the same file because it doesn't normalize disk drive letter.

### Possible Drawbacks

The possible drawback is some broken tests, but I've checked that and it seems everything works.

### Applicable Issues

Here is the related issue #8221. It's not exactly about my problem, but it's very near.