### PR TITLE
Disable soft wrap on mini editors

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -5961,7 +5961,7 @@ describe "TextEditor", ->
       expect(editor.getGrammar().name).toBe 'CoffeeScript'
 
   describe "softWrapAtPreferredLineLength", ->
-    it "soft wraps the editor at the preferred line length unless the editor is narrower", ->
+    it "soft wraps the editor at the preferred line length unless the editor is narrower or the editor is mini", ->
       editor.update({
         editorWidthInChars: 30
         softWrapped: true
@@ -5973,6 +5973,9 @@ describe "TextEditor", ->
 
       editor.update({editorWidthInChars: 10})
       expect(editor.lineTextForScreenRow(0)).toBe 'var '
+
+      editor.update({mini: true})
+      expect(editor.lineTextForScreenRow(0)).toBe 'var quicksort = function () {'
 
   describe "softWrapHangingIndentLength", ->
     it "controls how much extra indentation is applied to soft-wrapped lines", ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -285,6 +285,7 @@ class TextEditor extends Model
             @mini = value
             @emitter.emit 'did-change-mini', value
             displayLayerParams.invisibles = @getInvisibles()
+            displayLayerParams.softWrapColumn = @getSoftWrapColumn()
             displayLayerParams.showIndentGuides = @doesShowIndentGuide()
 
         when 'placeholderText'
@@ -2958,7 +2959,7 @@ class TextEditor extends Model
 
   # Essential: Gets the column at which column will soft wrap
   getSoftWrapColumn: ->
-    if @isSoftWrapped()
+    if @isSoftWrapped() and not @mini
       if @softWrapAtPreferredLineLength
         Math.min(@getEditorWidthInChars(), @preferredLineLength)
       else

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -169,8 +169,8 @@ class TextEditor extends Model
     unless @displayLayer?
       displayLayerParams = {
         invisibles: @getInvisibles(),
-        softWrapColumn: not @isMini() and @getSoftWrapColumn(),
-        showIndentGuides: not @isMini() and @doesShowIndentGuide(),
+        softWrapColumn: @getSoftWrapColumn(),
+        showIndentGuides: @doesShowIndentGuide(),
         atomicSoftTabs: params.atomicSoftTabs ? true,
         tabLength: tabLength,
         ratioForCharacter: @ratioForCharacter.bind(this),

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -169,7 +169,7 @@ class TextEditor extends Model
     unless @displayLayer?
       displayLayerParams = {
         invisibles: @getInvisibles(),
-        softWrapColumn: @getSoftWrapColumn(),
+        softWrapColumn: not @isMini() and @getSoftWrapColumn(),
         showIndentGuides: not @isMini() and @doesShowIndentGuide(),
         atomicSoftTabs: params.atomicSoftTabs ? true,
         tabLength: tabLength,


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Don't soft wrap mini editors.  It seems like this isn't really useful for mini editors.

### Alternate Designs

There could be a separate programmatic toggle for mini editors that also looks at the global setting.

### Why Should This Be In Core?

Because mini editors already live in core!

### Benefits

No more "why can't I scroll right when I type something really long?"

### Possible Drawbacks

Some mini editors may be relying on this, though I think that would be bad practice considering it's a user setting.

### Applicable Issues

Fixes atom/tree-view#473

/cc @simurai