### PR TITLE
Avoid emitting path change events while destroying the Project

### DIFF
--- a/src/project.coffee
+++ b/src/project.coffee
@@ -21,7 +21,6 @@ class Project extends Model
   constructor: ({@notificationManager, packageManager, config, @applicationDelegate}) ->
     @emitter = new Emitter
     @buffers = []
-    @paths = []
     @rootDirectories = []
     @repositories = []
     @directoryProviders = []
@@ -32,7 +31,9 @@ class Project extends Model
 
   destroyed: ->
     buffer.destroy() for buffer in @buffers
-    @setPaths([])
+    repository?.destroy() for repository in @repositories
+    @rootDirectories = []
+    @repositories = []
 
   reset: (packageManager) ->
     @emitter.dispose()


### PR DESCRIPTION
/cc @ungb 

I believe this resolves the first exception listed in https://github.com/atom/atom/issues/13778#issuecomment-278773192
(`TypeError·Cannot read property 'buildTextEditor' of null`).