### PR TITLE
Eliminate TextEditorComponent's reliance on MutationObserver for detecting changes in visibility, dimensions, and background color

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "color": "^0.7.3",
     "dedent": "^0.6.0",
     "devtron": "1.3.0",
+    "element-resize-detector": "^1.1.10",
     "event-kit": "^2.1.0",
     "find-parent-dir": "^0.3.0",
     "first-mate": "6.1.0",

--- a/script/package.json
+++ b/script/package.json
@@ -6,7 +6,7 @@
     "coffeelint": "1.15.7",
     "colors": "1.1.2",
     "csslint": "1.0.2",
-    "donna": "1.0.13",
+    "donna": "1.0.16",
     "electron-chromedriver": "~1.4",
     "electron-packager": "7.3.0",
     "electron-winstaller": "2.5.1",

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -57,7 +57,6 @@ describe('TextEditorComponent', function () {
     horizontalScrollbarNode = componentNode.querySelector('.horizontal-scrollbar')
 
     component.measureDimensions()
-    advanceClock(atom.views.minimumPollInterval)
     runAnimationFrames(true)
   })
 
@@ -395,9 +394,6 @@ describe('TextEditorComponent', function () {
       }
 
       wrapperNode.style.backgroundColor = 'rgb(255, 0, 0)'
-      // Polling should happen automatically in a mutation observer but its async
-      // and everything is mocked to be sync
-      atom.views.performDocumentPoll()
       runAnimationFrames(true)
 
       expect(linesNode.style.backgroundColor).toBe('rgb(255, 0, 0)')
@@ -985,7 +981,6 @@ describe('TextEditorComponent', function () {
       }
 
       gutterNode.style.backgroundColor = 'rgb(255, 0, 0)'
-      atom.views.performDocumentPoll()
       runAnimationFrames()
 
       expect(lineNumbersNode.style.backgroundColor).toBe('rgb(255, 0, 0)')
@@ -2336,7 +2331,6 @@ describe('TextEditorComponent', function () {
           return window.innerWidth !== innerWidthBefore
         })
 
-        atom.views.performDocumentPoll()
         runAnimationFrames()
 
         expect(overlay.style.left).toBe(window.innerWidth - itemWidth + 'px')
@@ -4284,7 +4278,6 @@ describe('TextEditorComponent', function () {
         componentNode = component.getDomNode()
         expect(componentNode.querySelectorAll('.line').length).toBe(0)
         hiddenParent.style.display = 'block'
-        atom.views.performDocumentPoll()
         expect(componentNode.querySelectorAll('.line').length).toBeGreaterThan(0)
       })
     })
@@ -4391,13 +4384,11 @@ describe('TextEditorComponent', function () {
       expect(parseInt(newHeight)).toBeLessThan(wrapperNode.offsetHeight)
       wrapperNode.style.height = newHeight
       editor.update({autoHeight: false})
-      atom.views.performDocumentPoll()
       runAnimationFrames()
 
       expect(componentNode.querySelectorAll('.line')).toHaveLength(7)
       let gutterWidth = componentNode.querySelector('.gutter').offsetWidth
       componentNode.style.width = gutterWidth + 14 * charWidth + wrapperNode.getVerticalScrollbarWidth() + 'px'
-      atom.views.performDocumentPoll()
       runAnimationFrames()
       expect(componentNode.querySelector('.line').textContent).toBe('var quicksort ')
     })
@@ -4406,7 +4397,6 @@ describe('TextEditorComponent', function () {
       let scrollViewNode = componentNode.querySelector('.scroll-view')
       scrollViewNode.style.paddingLeft = 20 + 'px'
       componentNode.style.width = 30 * charWidth + 'px'
-      atom.views.performDocumentPoll()
       runAnimationFrames()
       expect(component.lineNodeForScreenRow(0).textContent).toBe('var quicksort = ')
     })

--- a/spec/view-registry-spec.coffee
+++ b/spec/view-registry-spec.coffee
@@ -126,8 +126,6 @@ describe "ViewRegistry", ->
       spyOn(window, 'clearInterval').andCallFake(fakeClearInterval)
       events = []
 
-      registry.pollDocument -> events.push('poll')
-      registry.pollAfterNextUpdate()
       registry.updateDocument -> events.push('write 1')
       registry.readDocument ->
         registry.updateDocument -> events.push('write from read 1')
@@ -146,108 +144,20 @@ describe "ViewRegistry", ->
         'write 2'
         'read 1'
         'read 2'
-        'poll'
         'write from read 1'
         'write from read 2'
       ]
-
-    it "pauses DOM polling when reads or writes are pending", ->
-      spyOn(window, 'setInterval').andCallFake(fakeSetInterval)
-      spyOn(window, 'clearInterval').andCallFake(fakeClearInterval)
-      events = []
-
-      registry.pollDocument -> events.push('poll')
-      registry.updateDocument -> events.push('write')
-      registry.readDocument -> events.push('read')
-
-      window.dispatchEvent(new UIEvent('resize'))
-      expect(events).toEqual []
-
-      frameRequests[0]()
-      expect(events).toEqual ['write', 'read', 'poll']
-
-      window.dispatchEvent(new UIEvent('resize'))
-      expect(events).toEqual ['write', 'read', 'poll', 'poll']
-
-    it "polls the document after updating when ::pollAfterNextUpdate() has been called", ->
-      events = []
-      registry.pollDocument -> events.push('poll')
-      registry.updateDocument -> events.push('write')
-      registry.readDocument -> events.push('read')
-      frameRequests.shift()()
-      expect(events).toEqual ['write', 'read']
-
-      events = []
-      registry.pollAfterNextUpdate()
-      registry.updateDocument -> events.push('write')
-      registry.readDocument -> events.push('read')
-      frameRequests.shift()()
-      expect(events).toEqual ['write', 'read', 'poll']
-
-  describe "::pollDocument(fn)", ->
-    [testElement, testStyleSheet, disposable1, disposable2, events] = []
-
-    beforeEach ->
-      testElement = document.createElement('div')
-      testStyleSheet = document.createElement('style')
-      testStyleSheet.textContent = 'body {}'
-      jasmineContent = document.getElementById('jasmine-content')
-      jasmineContent.appendChild(testElement)
-      jasmineContent.appendChild(testStyleSheet)
-
-      events = []
-      disposable1 = registry.pollDocument -> events.push('poll 1')
-      disposable2 = registry.pollDocument -> events.push('poll 2')
-
-    it "calls all registered polling functions after document or stylesheet changes until they are disabled via a returned disposable", ->
-      jasmine.useRealClock()
-      expect(events).toEqual []
-
-      testElement.style.width = '400px'
-
-      waitsFor "events to occur in response to DOM mutation", -> events.length > 0
-
-      runs ->
-        expect(events).toEqual ['poll 1', 'poll 2']
-        events.length = 0
-
-        testStyleSheet.textContent = 'body {color: #333;}'
-
-      waitsFor "events to occur in reponse to style sheet mutation", -> events.length > 0
-
-      runs ->
-        expect(events).toEqual ['poll 1', 'poll 2']
-        events.length = 0
-
-        disposable1.dispose()
-        testElement.style.color = '#fff'
-
-      waitsFor "more events to occur in response to DOM mutation", -> events.length > 0
-
-      runs ->
-        expect(events).toEqual ['poll 2']
-
-    it "calls all registered polling functions when the window resizes", ->
-      expect(events).toEqual []
-
-      window.dispatchEvent(new UIEvent('resize'))
-
-      expect(events).toEqual ['poll 1', 'poll 2']
 
   describe "::getNextUpdatePromise()", ->
     it "returns a promise that resolves at the end of the next update cycle", ->
       updateCalled = false
       readCalled = false
-      pollCalled = false
 
       waitsFor 'getNextUpdatePromise to resolve', (done) ->
         registry.getNextUpdatePromise().then ->
           expect(updateCalled).toBe true
           expect(readCalled).toBe true
-          expect(pollCalled).toBe true
           done()
 
         registry.updateDocument -> updateCalled = true
         registry.readDocument -> readCalled = true
-        registry.pollDocument -> pollCalled = true
-        registry.pollAfterNextUpdate()

--- a/src/line-numbers-tile-component.coffee
+++ b/src/line-numbers-tile-component.coffee
@@ -11,6 +11,7 @@ class LineNumbersTileComponent
     @domNode.style.position = "absolute"
     @domNode.style.display = "block"
     @domNode.style.top = 0 # Cover the space occupied by a dummy lineNumber
+    @domNode.style.backgroundColor = "inherit"
 
   destroy: ->
     @domElementPool.freeElementAndDescendants(@domNode)

--- a/src/lines-component.coffee
+++ b/src/lines-component.coffee
@@ -27,6 +27,7 @@ class LinesComponent extends TiledComponent
     # with other visual elements.
     @tilesNode.style.isolation = "isolate"
     @tilesNode.style.zIndex = 0
+    @tilesNode.style.backgroundColor = "inherit"
     @domNode.appendChild(@tilesNode)
 
     @cursorsComponent = new CursorsComponent

--- a/src/lines-tile-component.js
+++ b/src/lines-tile-component.js
@@ -16,6 +16,7 @@ module.exports = class LinesTileComponent {
     this.domNode = this.domElementPool.buildElement('div')
     this.domNode.style.position = 'absolute'
     this.domNode.style.display = 'block'
+    this.domNode.style.backgroundColor = 'inherit'
     this.highlightsComponent = new HighlightsComponent(this.domElementPool)
     this.domNode.appendChild(this.highlightsComponent.getDomNode())
   }

--- a/src/overlay-manager.coffee
+++ b/src/overlay-manager.coffee
@@ -1,3 +1,5 @@
+elementResizeDetector = require('element-resize-detector')({strategy: 'scroll'})
+
 module.exports =
 class OverlayManager
   constructor: (@presenter, @container, @views) ->
@@ -12,16 +14,13 @@ class OverlayManager
       unless state.content.overlays.hasOwnProperty(id)
         delete @overlaysById[id]
         overlayNode.remove()
+        elementResizeDetector.uninstall(overlayNode)
 
   shouldUpdateOverlay: (decorationId, overlay) ->
     cachedOverlay = @overlaysById[decorationId]
     return true unless cachedOverlay?
     cachedOverlay.pixelPosition?.top isnt overlay.pixelPosition?.top or
       cachedOverlay.pixelPosition?.left isnt overlay.pixelPosition?.left
-
-  measureOverlays: ->
-    for decorationId, {itemView} of @overlaysById
-      @measureOverlay(decorationId, itemView)
 
   measureOverlay: (decorationId, itemView) ->
     contentMargin = parseInt(getComputedStyle(itemView)['margin-left']) ? 0
@@ -33,13 +32,19 @@ class OverlayManager
     unless overlayNode = cachedOverlay?.overlayNode
       overlayNode = document.createElement('atom-overlay')
       overlayNode.classList.add(klass) if klass?
+      elementResizeDetector.listenTo(overlayNode, =>
+        if overlayNode.parentElement?
+          @measureOverlay(decorationId, itemView)
+      )
       @container.appendChild(overlayNode)
       @overlaysById[decorationId] = cachedOverlay = {overlayNode, itemView}
 
     # The same node may be used in more than one overlay. This steals the node
     # back if it has been displayed in another overlay.
-    overlayNode.appendChild(itemView) if overlayNode.childNodes.length is 0
+    overlayNode.appendChild(itemView) unless overlayNode.contains(itemView)
 
     cachedOverlay.pixelPosition = pixelPosition
     overlayNode.style.top = pixelPosition.top + 'px'
     overlayNode.style.left = pixelPosition.left + 'px'
+
+    @measureOverlay(decorationId, itemView)

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -133,6 +133,7 @@ class TextEditorComponent
         @becameVisible()
     )
     @intersectionObserver.observe(@domNode)
+    @becameVisible() if @isVisible()
 
     measureDimensions = @measureDimensions.bind(this)
     elementResizeDetector.listenTo(@domNode, measureDimensions)

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -124,7 +124,7 @@ class TextEditorComponent
     @onVerticalScroll = null
     @onHorizontalScroll = null
 
-    @intersectionObserver.disconnect()
+    @intersectionObserver?.disconnect()
 
   didAttach: ->
     @intersectionObserver = new IntersectionObserver((entries) =>

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -1,8 +1,9 @@
 scrollbarStyle = require 'scrollbar-style'
 {Range, Point} = require 'text-buffer'
-{CompositeDisposable} = require 'event-kit'
+{CompositeDisposable, Disposable} = require 'event-kit'
 {ipcRenderer} = require 'electron'
 Grim = require 'grim'
+elementResizeDetector = require('element-resize-detector')({strategy: 'scroll'})
 
 TextEditorPresenter = require './text-editor-presenter'
 GutterContainerComponent = require './gutter-container-component'
@@ -131,6 +132,10 @@ class TextEditorComponent
         @becameVisible()
     )
     @intersectionObserver.observe(@domNode)
+
+    measureDimensions = @measureDimensions.bind(this)
+    elementResizeDetector.listenTo(@domNode, measureDimensions)
+    @disposables.add(new Disposable => elementResizeDetector.removeListener(@domNode, measureDimensions))
 
   getDomNode: ->
     @domNode
@@ -745,7 +750,6 @@ class TextEditorComponent
     if @isVisible()
       @sampleBackgroundColors()
       @measureWindowSize()
-      @measureDimensions()
       @sampleFontStyling()
       @overlayManager?.measureOverlays()
 

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -139,7 +139,7 @@ class TextEditorComponent
 
     measureWindowSize = @measureWindowSize.bind(this)
     window.addEventListener('resize', measureWindowSize)
-    @disposables.add(new Disposable => window.removeEventListener('resize', measureWindowSize))
+    @disposables.add(new Disposable -> window.removeEventListener('resize', measureWindowSize))
 
   getDomNode: ->
     @domNode

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -106,8 +106,6 @@ class TextEditorComponent
       @disposables.add @themes.onDidChangeActiveThemes @onAllThemesLoaded
     @disposables.add scrollbarStyle.onDidChangePreferredScrollbarStyle @refreshScrollbars
 
-    @disposables.add @views.pollDocument(@pollDOM)
-
     @updateSync()
     @initialized = true
 
@@ -204,7 +202,6 @@ class TextEditorComponent
     @linesComponent.updateSync(@presenter.getPreMeasurementState())
 
   readAfterUpdateSync: =>
-    @overlayManager?.measureOverlays()
     @linesComponent.measureBlockDecorations()
     @offScreenBlockDecorationsComponent.measureBlockDecorations()
 
@@ -750,10 +747,6 @@ class TextEditorComponent
       error.metadata = {@initialized}
 
     @domNode? and (@domNode.offsetHeight > 0 or @domNode.offsetWidth > 0)
-
-  pollDOM: =>
-    if @isVisible()
-      @overlayManager?.measureOverlays()
 
   # Measure explicitly-styled height and width and relay them to the model. If
   # these values aren't explicitly styled, we assume the editor is unconstrained

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -108,7 +108,6 @@ class TextEditorComponent
     @disposables.add @views.pollDocument(@pollDOM)
 
     @updateSync()
-    @checkForVisibilityChange()
     @initialized = true
 
   destroy: ->
@@ -123,6 +122,15 @@ class TextEditorComponent
 
     @onVerticalScroll = null
     @onHorizontalScroll = null
+
+    @intersectionObserver.disconnect()
+
+  didAttach: ->
+    @intersectionObserver = new IntersectionObserver((entries) =>
+      if entries[entries.length - 1].intersectionRatio isnt 0
+        @becameVisible()
+    )
+    @intersectionObserver.observe(@domNode)
 
   getDomNode: ->
     @domNode
@@ -639,9 +647,10 @@ class TextEditorComponent
     @handleStylingChange()
 
   handleStylingChange: =>
-    @sampleFontStyling()
-    @sampleBackgroundColors()
-    @invalidateMeasurements()
+    if @isVisible()
+      @sampleFontStyling()
+      @sampleBackgroundColors()
+      @invalidateMeasurements()
 
   handleDragUntilMouseUp: (dragHandler) ->
     dragging = false
@@ -733,22 +742,12 @@ class TextEditorComponent
     @domNode? and (@domNode.offsetHeight > 0 or @domNode.offsetWidth > 0)
 
   pollDOM: =>
-    unless @checkForVisibilityChange()
+    if @isVisible()
       @sampleBackgroundColors()
       @measureWindowSize()
       @measureDimensions()
       @sampleFontStyling()
       @overlayManager?.measureOverlays()
-
-  checkForVisibilityChange: ->
-    if @isVisible()
-      if @wasVisible
-        false
-      else
-        @becameVisible()
-        @wasVisible = true
-    else
-      @wasVisible = false
 
   # Measure explicitly-styled height and width and relay them to the model. If
   # these values aren't explicitly styled, we assume the editor is unconstrained

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -220,7 +220,6 @@ class TextEditorComponent
     @invalidateMeasurements()
     @measureScrollbars() if @measureScrollbarsWhenShown
     @sampleFontStyling()
-    @sampleBackgroundColors()
     @measureWindowSize()
     @measureDimensions()
     @measureLineHeightAndDefaultCharWidth() if @measureLineHeightAndDefaultCharWidthWhenShown
@@ -661,7 +660,6 @@ class TextEditorComponent
   handleStylingChange: =>
     if @isVisible()
       @sampleFontStyling()
-      @sampleBackgroundColors()
       @invalidateMeasurements()
 
   handleDragUntilMouseUp: (dragHandler) ->
@@ -755,7 +753,6 @@ class TextEditorComponent
 
   pollDOM: =>
     if @isVisible()
-      @sampleBackgroundColors()
       @overlayManager?.measureOverlays()
 
   # Measure explicitly-styled height and width and relay them to the model. If
@@ -821,15 +818,6 @@ class TextEditorComponent
       @clearPoolAfterUpdate = true
       @measureLineHeightAndDefaultCharWidth()
       @invalidateMeasurements()
-
-  sampleBackgroundColors: (suppressUpdate) ->
-    {backgroundColor} = getComputedStyle(@hostElement)
-    @presenter.setBackgroundColor(backgroundColor)
-
-    lineNumberGutter = @gutterContainerComponent?.getLineNumberGutterComponent()
-    if lineNumberGutter
-      gutterBackgroundColor = getComputedStyle(lineNumberGutter.getDomNode()).backgroundColor
-      @presenter.setGutterBackgroundColor(gutterBackgroundColor)
 
   measureLineHeightAndDefaultCharWidth: ->
     if @isVisible()

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -641,11 +641,12 @@ class TextEditorComponent
     return unless @performedInitialMeasurement
     return unless @themes.isInitialLoadComplete()
 
-    # This delay prevents the styling from going haywire when stylesheets are
-    # reloaded in dev mode. It seems like a workaround for a browser bug, but
-    # not totally sure.
-
-    unless @stylingChangeAnimationFrameRequested
+    # Handle styling change synchronously if a global editor property such as
+    # font size might have changed. Otherwise coalesce multiple style sheet changes
+    # into a measurement on the next animation frame to prevent excessive thrashing.
+    if styleElement.getAttribute('source-path') is 'global-text-editor-styles'
+      @handleStylingChange()
+    else if not @stylingChangeAnimationFrameRequested
       @stylingChangeAnimationFrameRequested = true
       requestAnimationFrame =>
         @stylingChangeAnimationFrameRequested = false
@@ -755,7 +756,6 @@ class TextEditorComponent
   pollDOM: =>
     if @isVisible()
       @sampleBackgroundColors()
-      @sampleFontStyling()
       @overlayManager?.measureOverlays()
 
   # Measure explicitly-styled height and width and relay them to the model. If

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -139,6 +139,10 @@ class TextEditorComponent
     elementResizeDetector.listenTo(@domNode, measureDimensions)
     @disposables.add(new Disposable => elementResizeDetector.removeListener(@domNode, measureDimensions))
 
+    measureWindowSize = @measureWindowSize.bind(this)
+    window.addEventListener('resize', measureWindowSize)
+    @disposables.add(new Disposable => window.removeEventListener('resize', measureWindowSize))
+
   getDomNode: ->
     @domNode
 
@@ -751,7 +755,6 @@ class TextEditorComponent
   pollDOM: =>
     if @isVisible()
       @sampleBackgroundColors()
-      @measureWindowSize()
       @sampleFontStyling()
       @overlayManager?.measureOverlays()
 

--- a/src/text-editor-component.coffee
+++ b/src/text-editor-component.coffee
@@ -128,7 +128,8 @@ class TextEditorComponent
 
   didAttach: ->
     @intersectionObserver = new IntersectionObserver((entries) =>
-      if entries[entries.length - 1].intersectionRatio isnt 0
+      {intersectionRect} = entries[entries.length - 1]
+      if intersectionRect.width > 0 or intersectionRect.height > 0
         @becameVisible()
     )
     @intersectionObserver.observe(@domNode)

--- a/src/text-editor-element.coffee
+++ b/src/text-editor-element.coffee
@@ -58,8 +58,8 @@ class TextEditorElement extends HTMLElement
     @buildModel() unless @getModel()?
     @assert(@model.isAlive(), "Attaching a view for a destroyed editor")
     @mountComponent() unless @component?
+    @component.didAttach()
     @listenForComponentEvents()
-    @component.checkForVisibilityChange()
     if @hasFocus()
       @focused()
     @emitter.emit("did-attach")
@@ -94,6 +94,7 @@ class TextEditorElement extends HTMLElement
     @model.setUpdatedSynchronously(@isUpdatedSynchronously())
     @initializeContent()
     @mountComponent()
+    @component.didAttach() if document.contains(this)
     @addGrammarScopeAttribute()
     @addMiniAttribute() if @model.isMini()
     @addEncodingAttribute()

--- a/src/view-registry.coffee
+++ b/src/view-registry.coffee
@@ -49,18 +49,13 @@ module.exports =
 class ViewRegistry
   animationFrameRequest: null
   documentReadInProgress: false
-  performDocumentPollAfterUpdate: false
-  debouncedPerformDocumentPoll: null
-  minimumPollInterval: 200
 
   constructor: (@atomEnvironment) ->
-    @observer = new MutationObserver(@requestDocumentPoll)
     @clear()
 
   clear: ->
     @views = new WeakMap
     @providers = []
-    @debouncedPerformDocumentPoll = _.throttle(@performDocumentPoll, @minimumPollInterval).bind(this)
     @clearDocumentRequests()
 
   # Essential: Add a provider that will be used to construct views in the
@@ -217,16 +212,6 @@ class ViewRegistry
     new Disposable =>
       @documentReaders = @documentReaders.filter (reader) -> reader isnt fn
 
-  pollDocument: (fn) ->
-    @startPollingDocument() if @documentPollers.length is 0
-    @documentPollers.push(fn)
-    new Disposable =>
-      @documentPollers = @documentPollers.filter (poller) -> poller isnt fn
-      @stopPollingDocument() if @documentPollers.length is 0
-
-  pollAfterNextUpdate: ->
-    @performDocumentPollAfterUpdate = true
-
   getNextUpdatePromise: ->
     @nextUpdatePromise ?= new Promise (resolve) =>
       @resolveNextUpdatePromise = resolve
@@ -234,13 +219,11 @@ class ViewRegistry
   clearDocumentRequests: ->
     @documentReaders = []
     @documentWriters = []
-    @documentPollers = []
     @nextUpdatePromise = null
     @resolveNextUpdatePromise = null
     if @animationFrameRequest?
       cancelAnimationFrame(@animationFrameRequest)
       @animationFrameRequest = null
-    @stopPollingDocument()
 
   requestDocumentUpdate: ->
     @animationFrameRequest ?= requestAnimationFrame(@performDocumentUpdate)
@@ -255,29 +238,9 @@ class ViewRegistry
 
     @documentReadInProgress = true
     reader() while reader = @documentReaders.shift()
-    @performDocumentPoll() if @performDocumentPollAfterUpdate
-    @performDocumentPollAfterUpdate = false
     @documentReadInProgress = false
 
     # process updates requested as a result of reads
     writer() while writer = @documentWriters.shift()
 
     resolveNextUpdatePromise?()
-
-  startPollingDocument: ->
-    window.addEventListener('resize', @requestDocumentPoll)
-    @observer.observe(document, {subtree: true, childList: true, attributes: true})
-
-  stopPollingDocument: ->
-    window.removeEventListener('resize', @requestDocumentPoll)
-    @observer.disconnect()
-
-  requestDocumentPoll: =>
-    if @animationFrameRequest?
-      @performDocumentPollAfterUpdate = true
-    else
-      @debouncedPerformDocumentPoll()
-
-  performDocumentPoll: ->
-    poller() for poller in @documentPollers
-    return

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -57,7 +57,6 @@ class WorkspaceElement extends HTMLElement
       }
     """
     @styles.addStyleSheet(styleSheetSource, sourcePath: 'global-text-editor-styles')
-    @views.performDocumentPoll()
 
   initialize: (@model, {@views, @workspace, @project, @config, @styles}) ->
     throw new Error("Must pass a views parameter when initializing WorskpaceElements") unless @views?

--- a/static/text-editor-light.less
+++ b/static/text-editor-light.less
@@ -9,6 +9,7 @@ atom-text-editor {
   .editor--private, .editor-contents--private {
     height: 100%;
     width: 100%;
+    background-color: inherit;
   }
 
   .editor-contents--private {
@@ -19,6 +20,10 @@ atom-text-editor {
     position: relative;
   }
 
+  .gutter-container {
+    background-color: inherit;
+  }
+
   .gutter {
     overflow: hidden;
     z-index: 0;
@@ -26,10 +31,12 @@ atom-text-editor {
     cursor: default;
     min-width: 1em;
     box-sizing: border-box;
+    background-color: inherit;
   }
 
   .line-numbers {
     position: relative;
+    background-color: inherit;
   }
 
   .line-number {
@@ -86,6 +93,7 @@ atom-text-editor {
     flex: 1;
     min-width: 0;
     min-height: 0;
+    background-color: inherit;
   }
 
   .highlight {
@@ -103,6 +111,7 @@ atom-text-editor {
     min-width: 100%;
     position: relative;
     z-index: 1;
+    background-color: inherit;
   }
 
   .line {


### PR DESCRIPTION
With the introduction of Chrome 53 in Electron 1.4, we now have access to a fully functional `IntersectionObserver` API, which can be used to detect when editors change in visibility. This means we can discard the previous `MutationObserver` based polling system, which creates a drag on frame rates in certain circumstances. This impact is hard to quantify because *measuring* the frame rate with mutation observers in place in the current scrolling scheme seems to slow performance dramatically, making this hard to measure. Regardless it's a big simplification to not require full DOM observation.

This PR replaces polling with the following approaches:

* Visibility detection: [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
* Resize detection of editors and overlay decorations: Scroll event hack via the [`element-resize-detector`](https://github.com/wnr/element-resize-detector) library.
* Transferring background to editor tiles: Plain CSS with `background-color: inherit` (now possible with the removal of the shadow DOM)