### PR TITLE
Wrong location for apm

### DIFF
--- a/resources/win/apm.sh
+++ b/resources/win/apm.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-"$(dirname "$0")/../app/apm/apm.sh" "$@"
+"$(dirname "$0")/../app/apm/bin/apm" "$@"


### PR DESCRIPTION
It seems this was set to the wrong location for apm.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
Change the path to apm in apm.sh

### Alternate Designs
None

### Why Should This Be In Core?
Because apm does not work if the path is wrong.

### Benefits
APM will work.

### Possible Drawbacks
None

### Applicable Issues
None