### PR TITLE
Fix code-signing on CircleCI

### DIFF
--- a/script/lib/code-sign-on-mac.js
+++ b/script/lib/code-sign-on-mac.js
@@ -33,6 +33,18 @@ module.exports = function (packagedAppPath) {
       '-T', '/usr/bin/codesign'
     ])
 
+
+    console.log('Running incantation to suppress dialog when signing on macOS Sierra')
+    try {
+      spawnSync('security', [
+        'set-key-partition-list', '-S', 'apple-tool:,apple:', '-s',
+        '-k', process.env.ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD,
+        process.env.ATOM_MAC_CODE_SIGNING_KEYCHAIN
+      ])
+    } catch (e) {
+      console.log('Incantation failed... maybe this isn\'t Sierra?');
+    }
+
     console.log(`Code-signing application at ${packagedAppPath}`)
     spawnSync('codesign', [
       '--deep', '--force', '--verbose',


### PR DESCRIPTION
We're seeing the following error message in [this failing build](https://circleci.com/gh/atom/atom/2588) on CircleCI:

```
SecKey API returned: -25293, (null)/Users/distiller/atom/out/Atom.app: unknown error -1=ffffffffffffffff
```

Based on [this Stack Overflow article](http://stackoverflow.com/questions/39868578/security-codesign-in-sierra-keychain-ignores-access-control-settings-and-ui-p) it looks like they *may* have upgraded their images to Sierra and are causing this problem.

This PR runs the ✨  command suggested in that article to hopefully fix the issue.