### PR TITLE
Restore correct directory's project state when opening a new file from the CLI

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -228,11 +228,10 @@ describe('AtomApplication', function () {
       // Restore unsaved state when opening a path to a non-existent file in the directory
       const window3 = atomApplication.launch(parseCommandLine([path.join(tempDirPath, 'another-non-existent-file')]))
       await window3.loadedPromise
-      const window3Text = await evalInWebContents(window3.browserWindow.webContents, function (sendBackToMainProcess, nonExistentFilePath) {
-        const pane = atom.workspace.paneForURI(nonExistentFilePath)
-        sendBackToMainProcess(pane.getActiveItem().getText())
-      }, nonExistentFilePath)
-      assert.equal(window3Text, 'Hello World! How are you?')
+      const window3Texts = await evalInWebContents(window3.browserWindow.webContents, function (sendBackToMainProcess, nonExistentFilePath) {
+        sendBackToMainProcess(atom.workspace.getTextEditors().map(editor => editor.getText()))
+      })
+      assert.include(window3Texts, 'Hello World! How are you?')
     })
 
     it('shows all directories in the tree view when multiple directory paths are passed to Atom', async function () {
@@ -503,7 +502,7 @@ describe('AtomApplication', function () {
         function sendBackToMainProcess (result) {
           require('electron').ipcRenderer.send('${channelId}', result)
         }
-        (${source})(sendBackToMainProcess ${args.length > 0 ? ', ': ''} ${args.map(a => JSON.stringify(a)).join(', ')})
+        (${source})(sendBackToMainProcess)
       `)
     })
   }

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -196,9 +196,9 @@ describe('AtomApplication', function () {
     it('persists window state based on the project directories', async function () {
       const tempDirPath = makeTempDir()
       const atomApplication = buildAtomApplication()
-      const newFilePath = path.join(tempDirPath, 'new-file')
+      const nonExistentFilePath = path.join(tempDirPath, 'new-file')
 
-      const window1 = atomApplication.launch(parseCommandLine([newFilePath]))
+      const window1 = atomApplication.launch(parseCommandLine([nonExistentFilePath]))
       await evalInWebContents(window1.browserWindow.webContents, function (sendBackToMainProcess) {
         atom.workspace.observeActivePaneItem(function (textEditor) {
           if (textEditor) {
@@ -225,18 +225,18 @@ describe('AtomApplication', function () {
       window2.close()
       await window2.closedPromise
 
-      // Restore unsaved state when opening a new file in the directory
-      const window3 = atomApplication.launch(parseCommandLine([path.join(tempDirPath, 'another-new-file')]))
-      const window3Text = await evalInWebContents(window3.browserWindow.webContents, function (sendBackToMainProcess, newFilePath) {
+      // Restore unsaved state when opening a path to a non-existent file in the directory
+      const window3 = atomApplication.launch(parseCommandLine([path.join(tempDirPath, 'another-non-existent-file')]))
+      const window3Text = await evalInWebContents(window3.browserWindow.webContents, function (sendBackToMainProcess, nonExistentFilePath) {
         atom.workspace.observeActivePaneItem(function (textEditor) {
           if (textEditor) {
-            const pane = atom.workspace.paneForURI(newFilePath)
+            const pane = atom.workspace.paneForURI(nonExistentFilePath)
             if (pane) {
               sendBackToMainProcess(pane.getActiveItem().getText())
             }
           }
         })
-      }, newFilePath)
+      }, nonExistentFilePath)
       assert.equal(window3Text, 'Hello World! How are you?')
     })
 

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -213,14 +213,12 @@ describe('AtomApplication', function () {
 
       // Restore unsaved state when opening the directory itself
       const window2 = atomApplication.launch(parseCommandLine([tempDirPath]))
+      await window2.loadedPromise
       const window2Text = await evalInWebContents(window2.browserWindow.webContents, function (sendBackToMainProcess) {
-        atom.workspace.observeActivePaneItem(function (textEditor) {
-          if (textEditor) {
-            textEditor.moveToBottom()
-            textEditor.insertText(' How are you?')
-            sendBackToMainProcess(textEditor.getText())
-          }
-        })
+        const textEditor = atom.workspace.getActiveTextEditor()
+        textEditor.moveToBottom()
+        textEditor.insertText(' How are you?')
+        sendBackToMainProcess(textEditor.getText())
       })
       assert.equal(window2Text, 'Hello World! How are you?')
       await window2.saveState()
@@ -229,15 +227,10 @@ describe('AtomApplication', function () {
 
       // Restore unsaved state when opening a path to a non-existent file in the directory
       const window3 = atomApplication.launch(parseCommandLine([path.join(tempDirPath, 'another-non-existent-file')]))
+      await window3.loadedPromise
       const window3Text = await evalInWebContents(window3.browserWindow.webContents, function (sendBackToMainProcess, nonExistentFilePath) {
-        atom.workspace.observeActivePaneItem(function (textEditor) {
-          if (textEditor) {
-            const pane = atom.workspace.paneForURI(nonExistentFilePath)
-            if (pane) {
-              sendBackToMainProcess(pane.getActiveItem().getText())
-            }
-          }
-        })
+        const pane = atom.workspace.paneForURI(nonExistentFilePath)
+        sendBackToMainProcess(pane.getActiveItem().getText())
       }, nonExistentFilePath)
       assert.equal(window3Text, 'Hello World! How are you?')
     })

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -207,6 +207,7 @@ describe('AtomApplication', function () {
           }
         })
       })
+      await window1.saveState()
       window1.close()
       await window1.closedPromise
 
@@ -222,6 +223,7 @@ describe('AtomApplication', function () {
         })
       })
       assert.equal(window2Text, 'Hello World! How are you?')
+      await window2.saveState()
       window2.close()
       await window2.closedPromise
 

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -58,10 +58,15 @@ class AtomWindow
     loadSettings.clearWindowState ?= false
     loadSettings.initialPaths ?=
       for {pathToOpen} in locationsToOpen when pathToOpen
-        if fs.statSyncNoException(pathToOpen).isFile?()
-          path.dirname(pathToOpen)
-        else
+        stat = fs.statSyncNoException(pathToOpen) or null
+        if stat?.isDirectory()
           pathToOpen
+        else
+          parentDirectory = path.dirname(pathToOpen)
+          if stat?.isFile() or fs.existsSync(parentDirectory)
+            parentDirectory
+          else
+            pathToOpen
     loadSettings.initialPaths.sort()
 
     # Only send to the first non-spec window created
@@ -90,7 +95,7 @@ class AtomWindow
 
     hasPathToOpen = not (locationsToOpen.length is 1 and not locationsToOpen[0].pathToOpen?)
     @openLocations(locationsToOpen) if hasPathToOpen and not @isSpecWindow()
-    
+
     @atomApplication.addWindow(this)
 
   hasProjectPath: -> @representedDirectoryPaths.length > 0


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/13729

* [x] Ensure that the correct directory's state is loaded.
* [ ] ~~Remove duplication between `AtomWindow` constructor and `AtomEnvironment.openLocations` method.~~

☝️ We're going to defer this refactor until we take some time to rewrite the main process code.