### PR TITLE
Attempt fixing exception when trying to use portable electronUserData

### DIFF
--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -24,7 +24,7 @@ module.exports = function start (resourcePath, startTime) {
 
   const args = parseCommandLine(process.argv.slice(1))
   atomPaths.setAtomHome(app.getPath('home'))
-  atomPaths.setUserData()
+  atomPaths.setUserData(app)
   setupCompileCache()
 
   if (handleStartupEventWithSquirrel()) {


### PR DESCRIPTION
### Description of the Change

Whoops:

```
Cannot read property 'setPath' of undefined
TypeError: Cannot read property 'setPath' of undefined
    at Object.setUserData (C:\Users\Segev\Atom\Atom x64\resources\app.asar\src\atom-paths.js:53:12)
    at start (C:\Users\Segev\Atom\Atom x64\resources\app.asar\src\main-process\start.js:27:13)
    at Object.<anonymous> (C:\Users\Segev\Atom\Atom x64\resources\app.asar\src\main-process\main.js:36:1)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Object.<anonymous> (C:\Users\Segev\Atom\Atom x64\resources\electron.asar\browser\init.js:166:8)
    at Module._compile (module.js:556:32)
```

I didn't test this, submitted directly from GitHub

### Why Should This Be In Core? & Benefits

It should fix the ability to use a portable electronUserData directory.