### PR TITLE
Throw exceptions when decorating destroyed marker layers

### DIFF
--- a/spec/decoration-manager-spec.coffee
+++ b/spec/decoration-manager-spec.coffee
@@ -1,7 +1,7 @@
 DecorationManager = require '../src/decoration-manager'
 
 describe "DecorationManager", ->
-  [decorationManager, buffer, defaultMarkerLayer] = []
+  [decorationManager, buffer, defaultMarkerLayer, displayLayer] = []
 
   beforeEach ->
     buffer = atom.project.bufferForPathSync('sample.js')
@@ -44,6 +44,13 @@ describe "DecorationManager", ->
         decorationManager.decorateMarker(marker, {type: 'overlay', item: document.createElement('div')})
       ).toThrow("Cannot decorate a destroyed marker")
       expect(decorationManager.getOverlayDecorations()).toEqual []
+
+    it "does not allow destroyed marker layers to be decorated", ->
+      layer = displayLayer.addMarkerLayer()
+      layer.destroy()
+      expect(->
+        decorationManager.decorateMarkerLayer(layer, {type: 'highlight'})
+      ).toThrow("Cannot decorate a destroyed marker layer")
 
     describe "when a decoration is updated via Decoration::update()", ->
       it "emits an 'updated' event containing the new and old params", ->

--- a/src/decoration-manager.coffee
+++ b/src/decoration-manager.coffee
@@ -117,6 +117,7 @@ class DecorationManager extends Model
     decoration
 
   decorateMarkerLayer: (markerLayer, decorationParams) ->
+    throw new Error("Cannot decorate a destroyed marker layer") if markerLayer.isDestroyed()
     decoration = new LayerDecoration(markerLayer, this, decorationParams)
     @layerDecorationsByMarkerLayerId[markerLayer.id] ?= []
     @layerDecorationsByMarkerLayerId[markerLayer.id].push(decoration)


### PR DESCRIPTION
We're seeing exceptions like the following:

```
TypeError Cannot read property 'findMarkers' of undefined 
    /app.asar/src/decoration-manager.js:151:20 module.exports.DecorationManager.decorationsStateForScreenRowRange
    /app.asar/src/text-editor.js:1698:37 module.exports.TextEditor.decorationsStateForScreenRowRange
    /app.asar/src/text-editor-presenter.js:1381:44 module.exports.TextEditorPresenter.fetchDecorations
    /app.asar/src/text-editor-presenter.js:125:14 module.exports.TextEditorPresenter.getPreMeasurementState
    /app.asar/src/text-editor-component.js:264:60 module.exports.TextEditorComponent.updateSyncPreMeasurement
    /app.asar/src/text-editor-component.js:196:12 module.exports.TextEditorComponent.updateSync
    /app.asar/src/text-editor-component.js:303:21 module.exports.TextEditorComponent.becameVisible
    /app.asar/src/text-editor-component.js:994:16 module.exports.TextEditorComponent.checkForVisibilityChange
    /app.asar/src/text-editor-component.js:980:17 module.exports.TextEditorComponent.pollDOM
    /app.asar/src/text-editor-component.js:3:59 none
    /app.asar/src/view-registry.js:263:9 module.exports.ViewRegistry.performDocumentPoll
    /app.asar/src/view-registry.js:226:14 module.exports.ViewRegistry.performDocumentUpdate
    /app.asar/src/view-registry.js:3:59 none
```

One way these could occur is if a package attempts to decorate an already destroyed marker layer. If that happened, we would previously silently allow the decoration to be created and then end up querying the editor's display layer for the destroyed layer's id, getting an undefined result.

/cc @maxbrunsfeld 