### PR TITLE
Return decorations for markers from *all* marker layers from decorationsForScreenRowRange

### DIFF
--- a/spec/decoration-manager-spec.coffee
+++ b/spec/decoration-manager-spec.coffee
@@ -51,7 +51,7 @@ describe "DecorationManager", ->
       layer1Marker.destroy()
       expect(->
         decorationManager.decorateMarker(layer1Marker, {type: 'overlay', item: document.createElement('div')})
-      ).toThrow("Cannot decorate a destroyed layer1Marker")
+      ).toThrow("Cannot decorate a destroyed marker")
       expect(decorationManager.getOverlayDecorations()).toEqual []
 
     it "does not allow destroyed marker layers to be decorated", ->

--- a/spec/decoration-manager-spec.coffee
+++ b/spec/decoration-manager-spec.coffee
@@ -1,14 +1,14 @@
 DecorationManager = require '../src/decoration-manager'
 
 describe "DecorationManager", ->
-  [decorationManager, buffer, defaultMarkerLayer, displayLayer, otherMarkerLayer] = []
+  [decorationManager, buffer, displayLayer, markerLayer1, markerLayer2] = []
 
   beforeEach ->
     buffer = atom.project.bufferForPathSync('sample.js')
     displayLayer = buffer.addDisplayLayer()
-    defaultMarkerLayer = displayLayer.addMarkerLayer()
-    otherMarkerLayer = displayLayer.addMarkerLayer()
-    decorationManager = new DecorationManager(displayLayer, defaultMarkerLayer)
+    markerLayer1 = displayLayer.addMarkerLayer()
+    markerLayer2 = displayLayer.addMarkerLayer()
+    decorationManager = new DecorationManager(displayLayer)
 
     waitsForPromise ->
       atom.packages.activatePackage('language-javascript')
@@ -18,40 +18,40 @@ describe "DecorationManager", ->
     buffer.release()
 
   describe "decorations", ->
-    [marker, layerMarker, decoration, layerMarkerDecoration, decorationProperties] = []
+    [layer1Marker, layer2Marker, layer1MarkerDecoration, layer2MarkerDecoration, decorationProperties] = []
     beforeEach ->
-      marker = defaultMarkerLayer.markBufferRange([[2, 13], [3, 15]])
+      layer1Marker = markerLayer1.markBufferRange([[2, 13], [3, 15]])
       decorationProperties = {type: 'line-number', class: 'one'}
-      decoration = decorationManager.decorateMarker(marker, decorationProperties)
-      layerMarker = otherMarkerLayer.markBufferRange([[2, 13], [3, 15]])
-      layerMarkerDecoration = decorationManager.decorateMarker(layerMarker, decorationProperties)
+      layer1MarkerDecoration = decorationManager.decorateMarker(layer1Marker, decorationProperties)
+      layer2Marker = markerLayer2.markBufferRange([[2, 13], [3, 15]])
+      layer2MarkerDecoration = decorationManager.decorateMarker(layer2Marker, decorationProperties)
 
     it "can add decorations associated with markers and remove them", ->
-      expect(decoration).toBeDefined()
-      expect(decoration.getProperties()).toBe decorationProperties
-      expect(decorationManager.decorationForId(decoration.id)).toBe decoration
+      expect(layer1MarkerDecoration).toBeDefined()
+      expect(layer1MarkerDecoration.getProperties()).toBe decorationProperties
+      expect(decorationManager.decorationForId(layer1MarkerDecoration.id)).toBe layer1MarkerDecoration
       expect(decorationManager.decorationsForScreenRowRange(2, 3)).toEqual {
-        "#{marker.id}": [decoration],
-        "#{layerMarker.id}": [layerMarkerDecoration]
+        "#{layer1Marker.id}": [layer1MarkerDecoration],
+        "#{layer2Marker.id}": [layer2MarkerDecoration]
       }
 
-      decoration.destroy()
-      expect(decorationManager.decorationsForScreenRowRange(2, 3)[marker.id]).not.toBeDefined()
-      expect(decorationManager.decorationForId(decoration.id)).not.toBeDefined()
-      layerMarkerDecoration.destroy()
-      expect(decorationManager.decorationsForScreenRowRange(2, 3)[layerMarker.id]).not.toBeDefined()
-      expect(decorationManager.decorationForId(layerMarkerDecoration.id)).not.toBeDefined()
+      layer1MarkerDecoration.destroy()
+      expect(decorationManager.decorationsForScreenRowRange(2, 3)[layer1Marker.id]).not.toBeDefined()
+      expect(decorationManager.decorationForId(layer1MarkerDecoration.id)).not.toBeDefined()
+      layer2MarkerDecoration.destroy()
+      expect(decorationManager.decorationsForScreenRowRange(2, 3)[layer2Marker.id]).not.toBeDefined()
+      expect(decorationManager.decorationForId(layer2MarkerDecoration.id)).not.toBeDefined()
 
     it "will not fail if the decoration is removed twice", ->
-      decoration.destroy()
-      decoration.destroy()
-      expect(decorationManager.decorationForId(decoration.id)).not.toBeDefined()
+      layer1MarkerDecoration.destroy()
+      layer1MarkerDecoration.destroy()
+      expect(decorationManager.decorationForId(layer1MarkerDecoration.id)).not.toBeDefined()
 
     it "does not allow destroyed markers to be decorated", ->
-      marker.destroy()
+      layer1Marker.destroy()
       expect(->
-        decorationManager.decorateMarker(marker, {type: 'overlay', item: document.createElement('div')})
-      ).toThrow("Cannot decorate a destroyed marker")
+        decorationManager.decorateMarker(layer1Marker, {type: 'overlay', item: document.createElement('div')})
+      ).toThrow("Cannot decorate a destroyed layer1Marker")
       expect(decorationManager.getOverlayDecorations()).toEqual []
 
     it "does not allow destroyed marker layers to be decorated", ->
@@ -63,8 +63,8 @@ describe "DecorationManager", ->
 
     describe "when a decoration is updated via Decoration::update()", ->
       it "emits an 'updated' event containing the new and old params", ->
-        decoration.onDidChangeProperties updatedSpy = jasmine.createSpy()
-        decoration.setProperties type: 'line-number', class: 'two'
+        layer1MarkerDecoration.onDidChangeProperties updatedSpy = jasmine.createSpy()
+        layer1MarkerDecoration.setProperties type: 'line-number', class: 'two'
 
         {oldProperties, newProperties} = updatedSpy.mostRecentCall.args[0]
         expect(oldProperties).toEqual decorationProperties
@@ -72,29 +72,29 @@ describe "DecorationManager", ->
 
     describe "::getDecorations(properties)", ->
       it "returns decorations matching the given optional properties", ->
-        expect(decorationManager.getDecorations()).toEqual [decoration, layerMarkerDecoration]
+        expect(decorationManager.getDecorations()).toEqual [layer1MarkerDecoration, layer2MarkerDecoration]
         expect(decorationManager.getDecorations(class: 'two').length).toEqual 0
         expect(decorationManager.getDecorations(class: 'one').length).toEqual 2
 
   describe "::decorateMarker", ->
     describe "when decorating gutters", ->
-      [marker] = []
+      [layer1Marker] = []
 
       beforeEach ->
-        marker = defaultMarkerLayer.markBufferRange([[1, 0], [1, 0]])
+        layer1Marker = markerLayer1.markBufferRange([[1, 0], [1, 0]])
 
       it "creates a decoration that is both of 'line-number' and 'gutter' type when called with the 'line-number' type", ->
         decorationProperties = {type: 'line-number', class: 'one'}
-        decoration = decorationManager.decorateMarker(marker, decorationProperties)
-        expect(decoration.isType('line-number')).toBe true
-        expect(decoration.isType('gutter')).toBe true
-        expect(decoration.getProperties().gutterName).toBe 'line-number'
-        expect(decoration.getProperties().class).toBe 'one'
+        layer1MarkerDecoration = decorationManager.decorateMarker(layer1Marker, decorationProperties)
+        expect(layer1MarkerDecoration.isType('line-number')).toBe true
+        expect(layer1MarkerDecoration.isType('gutter')).toBe true
+        expect(layer1MarkerDecoration.getProperties().gutterName).toBe 'line-number'
+        expect(layer1MarkerDecoration.getProperties().class).toBe 'one'
 
       it "creates a decoration that is only of 'gutter' type if called with the 'gutter' type and a 'gutterName'", ->
         decorationProperties = {type: 'gutter', gutterName: 'test-gutter', class: 'one'}
-        decoration = decorationManager.decorateMarker(marker, decorationProperties)
-        expect(decoration.isType('gutter')).toBe true
-        expect(decoration.isType('line-number')).toBe false
-        expect(decoration.getProperties().gutterName).toBe 'test-gutter'
-        expect(decoration.getProperties().class).toBe 'one'
+        layer1MarkerDecoration = decorationManager.decorateMarker(layer1Marker, decorationProperties)
+        expect(layer1MarkerDecoration.isType('gutter')).toBe true
+        expect(layer1MarkerDecoration.isType('line-number')).toBe false
+        expect(layer1MarkerDecoration.getProperties().gutterName).toBe 'test-gutter'
+        expect(layer1MarkerDecoration.getProperties().class).toBe 'one'

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1747,11 +1747,13 @@ describe('TextEditorComponent', function () {
   })
 
   describe('block decorations rendering', function () {
+    let markerLayer
+
     function createBlockDecorationBeforeScreenRow(screenRow, {className}) {
       let item = document.createElement("div")
       item.className = className || ""
       let blockDecoration = editor.decorateMarker(
-        editor.markScreenPosition([screenRow, 0], {invalidate: "never"}),
+        markerLayer.markScreenPosition([screenRow, 0], {invalidate: "never"}),
         {type: "block", item: item, position: "before"}
       )
       return [item, blockDecoration]
@@ -1761,13 +1763,14 @@ describe('TextEditorComponent', function () {
       let item = document.createElement("div")
       item.className = className || ""
       let blockDecoration = editor.decorateMarker(
-        editor.markScreenPosition([screenRow, 0], {invalidate: "never"}),
+        markerLayer.markScreenPosition([screenRow, 0], {invalidate: "never"}),
         {type: "block", item: item, position: "after"}
       )
       return [item, blockDecoration]
     }
 
     beforeEach(function () {
+      markerLayer = editor.addMarkerLayer()
       wrapperNode.style.height = 5 * lineHeightInPixels + 'px'
       editor.update({autoHeight: false})
       component.measureDimensions()

--- a/src/decoration-manager.coffee
+++ b/src/decoration-manager.coffee
@@ -8,7 +8,7 @@ class DecorationManager extends Model
   didUpdateDecorationsEventScheduled: false
   updatedSynchronously: false
 
-  constructor: (@displayLayer, @defaultMarkerLayer) ->
+  constructor: (@displayLayer) ->
     super
 
     @emitter = new Emitter

--- a/src/decoration-manager.coffee
+++ b/src/decoration-manager.coffee
@@ -71,9 +71,11 @@ class DecorationManager extends Model
 
   decorationsForScreenRowRange: (startScreenRow, endScreenRow) ->
     decorationsByMarkerId = {}
-    for marker in @defaultMarkerLayer.findMarkers(intersectsScreenRowRange: [startScreenRow, endScreenRow])
-      if decorations = @decorationsByMarkerId[marker.id]
-        decorationsByMarkerId[marker.id] = decorations
+    for layerId of @decorationCountsByLayerId
+      layer = @displayLayer.getMarkerLayer(layerId)
+      for marker in layer.findMarkers(intersectsScreenRowRange: [startScreenRow, endScreenRow])
+        if decorations = @decorationsByMarkerId[marker.id]
+          decorationsByMarkerId[marker.id] = decorations
     decorationsByMarkerId
 
   decorationsStateForScreenRowRange: (startScreenRow, endScreenRow) ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -193,7 +193,7 @@ class TextEditor extends Model
     @defaultMarkerLayer = @displayLayer.addMarkerLayer()
     @selectionsMarkerLayer ?= @addMarkerLayer(maintainHistory: true, persistent: true)
 
-    @decorationManager = new DecorationManager(@displayLayer, @defaultMarkerLayer)
+    @decorationManager = new DecorationManager(@displayLayer)
     @decorateMarkerLayer(@displayLayer.foldsMarkerLayer, {type: 'line-number', class: 'folded'})
 
     for marker in @selectionsMarkerLayer.getMarkers()


### PR DESCRIPTION
Previously, TextEditor.decorationsForScreenRowRange only returned decorations for markers on the default layer. This was inconsistent with other methods and was also making it impossible to add block decorations for markers on non-default marker layers.

🍐 'd with @as-cii 

/cc @smashwilson 