### PR TITLE
Fix Arch Linux package names

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -59,7 +59,7 @@ To also install the newly built application, use `--create-debian-package` or `-
 
 ### Arch
 
-* `sudo pacman -S --needed gconf base-devel git nodejs npm libgnome-keyring python2 libX11-devel libxkbfile-devel`
+* `sudo pacman -S --needed gconf base-devel git nodejs npm libgnome-keyring python2 libx11 libxkbfile`
 * `export PYTHON=/usr/bin/python2` before building Atom.
 
 ### Slackware


### PR DESCRIPTION
Arch Linux does not have `devel` packages. The include files and the libraries
are usually built in the main packages. There is neither `libX11-devel`, nor
`libxkbfile-devel`. They should be changed to `libx11` and `libxkbfile`.

### Description of the Change

This is a documentation fix.

### Alternate Designs

No alternatives.

### Why Should This Be In Core?

Otherwise people using Arch Linux will be confused.

### Benefits

More friendly to contributors using Arch Linux.

### Possible Drawbacks

None.

### Applicable Issues

None.