### PR TITLE
Relativize spec paths more when reporting

### DIFF
--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -1,4 +1,5 @@
 path = require 'path'
+process = require 'process'
 _ = require 'underscore-plus'
 grim = require 'grim'
 marked = require 'marked'
@@ -20,12 +21,15 @@ formatStackTrace = (spec, message='', stackTrace) ->
   lines.shift() if message.trim() is errorMatch?[1]?.trim()
 
   for line, index in lines
-    # Remove prefix of lines matching: at [object Object].<anonymous> (path:1:2)
-    prefixMatch = line.match(/at \[object Object\]\.<anonymous> \(([^)]+)\)/)
+    # Remove prefix of lines matching: at .<anonymous> (path:1:2)
+    prefixMatch = line.match(/at \.<anonymous> \(([^)]+)\)/)
     line = "at #{prefixMatch[1]}" if prefixMatch
 
     # Relativize locations to spec directory
-    lines[index] = line.replace("at #{spec.specDirectory}#{path.sep}", 'at ')
+    if process.platform is 'win32'
+      line = line.replace('file:///', '').replace(///#{path.posix.sep}///g, path.win32.sep)
+    line = line.replace("at #{spec.specDirectory}#{path.sep}", 'at ')
+    lines[index] = line.replace("(#{spec.specDirectory}#{path.sep}", '(') # at step (path:1:2)
 
   lines = lines.map (line) -> line.trim()
   lines.join('\n').trim()


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

First, here's a before/after comparison on Windows:

|Before|After|
|-------|-----|
|![specs-before](https://cloud.githubusercontent.com/assets/2766036/22984731/500a632e-f374-11e6-9dbc-86dbaa8bf82e.png "Before")|![specs-after](https://cloud.githubusercontent.com/assets/2766036/22984485/7bf7cef0-f373-11e6-9c74-70926ed40f59.PNG "After")|

Much nicer.

Changes include:
* Updating to the new `.<anonymous>` syntax
* Stripping away `file:///` identifiers on Windows paths and converting the rest of the path to use Windows path separators (in order for it to get relativized correctly)
* Relativizing paths in parentheses

### Alternate Designs

Instead of relativizing the path twice, depending on if its in parentheses or not, a more general `line.replace(///#{_.escapeRegExp(spec.specDirectory}#{_.escapeRegExp(path.sep}///, '')` could be used.  I am unsure if that would potentially relativize more than we wanted.

### Why Should This Be In Core?

Because it fixes already-implemented code in core.

### Benefits

See before/after picture above.

### Possible Drawbacks

I don't foresee any.

### Applicable Issues

None.

/cc @damieng for the Windows portions.