### PR TITLE
Updating requires for linux to support 32bit build

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -7,7 +7,11 @@ URL:            https://atom.io/
 AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
+%ifarch i386 i486 i586 i686
+Requires: lsb-core-noarch, libXss.so.1
+%else
 Requires: lsb-core-noarch, libXss.so.1()(64bit)
+%endif
 
 %description
 <%= description %>


### PR DESCRIPTION

### Description of the Change
Added logic from @progkix to support builds for 32bit linux.

### Alternate Designs

N/A
### Why Should This Be In Core?

Build scripts are in core.

### Benefits

allows people to build on 32bit linux.

### Possible Drawbacks

None so far. Will test this change before merging
### Applicable Issues

https://github.com/atom/atom/issues/13788#issuecomment-279019713
/cc @progkix