### PR TITLE
Respect the --resource-path flag

### DIFF
--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -106,14 +106,14 @@ module.exports = function parseCommandLine (processArgs) {
 
   if (args['resource-path']) {
     devMode = true
-    resourcePath = args['resource-path']
+    devResourcePath = args['resource-path']
   }
 
   if (test) {
     devMode = true
   }
 
-  if (devMode && !resourcePath) {
+  if (devMode) {
     resourcePath = devResourcePath
   }
 


### PR DESCRIPTION
There was a bug in `parseCommandLine` that prevented the `--resource-path` flag from being used properly.

🍐 'd with @nathansobo