### PR TITLE
:bug: Fix apm shell script reference in Windows

### DIFF
--- a/resources/win/apm.sh
+++ b/resources/win/apm.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-"$(dirname "$0")/../app/apm/apm.sh" "$@"
+"$(dirname "$0")/../app/apm/bin/apm" "$@"


### PR DESCRIPTION

### Requirements

* [&check;] Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* [&cross;] All new code requires tests to ensure against regressions (It's not new.)

### Description of the Change

Change the Windows apm CLI shell reference to the correct path.

### Applicable Issues

Fixes #13874.
