### PR TITLE
Replace language-python with MagicPython

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
     "language-perl": "0.37.0",
     "language-php": "0.37.4",
     "language-property-list": "0.9.0",
-    "language-python": "0.45.2",
     "language-ruby": "0.70.5",
     "language-ruby-on-rails": "0.25.2",
     "language-sass": "0.57.1",
@@ -172,7 +171,8 @@
     "language-todo": "0.29.1",
     "language-toml": "0.18.1",
     "language-xml": "0.34.16",
-    "language-yaml": "0.28.0"
+    "language-yaml": "0.28.0",
+    "MagicPython": "1.0.7"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
This is a follow up to the discussion in https://github.com/atom/language-python/issues/109. Both @50Wliu and @iolsen indicated that they are willing to replace `language-python` with **[MagicPython](https://github.com/magicstack/magicpython)**.

### Why Should This Be In Core?

Atom ships with `language-python` syntax highlighter, which was backported from TextMate. It has a lot of unresolved bugs and lacks many features, such as:

* Does not highlight [f-strings](https://github.com/atom/language-python/issues/185), [`yield from`](https://github.com/atom/language-python/issues/119), [fails](https://github.com/atom/language-python/issues/150) to highlight `r` string literals properly, [etc](https://github.com/atom/language-python/issues);

* Does not highlight docstrings as a separate class of strings;

* [Breaks](https://github.com/atom/language-python/issues/68) on complex function parameters and return annotations;

* We've paid special attention to little details, such as highlighting `&&` as an invalid operator (makes switching between Python & JavaScript coding easier), properly highlighting improper syntax in decorators and many other features that make it easier to write Python code.

* MagicPython properly highlights all Python 3 builtins, magic methods, syntax features, string format qualifiers.

* We have a huge number of [tests](https://github.com/MagicStack/MagicPython/tree/master/test). This makes it easy for us to test new features and bug fixes and make releases with confidence.

In addition to the above: 

* GitHub.com [uses](https://github.com/github/linguist/blob/733ef6319378ab8c76dc72681bf2f435083dbcae/grammars.yml#L56) MagicPython to highlight Python source code.

* VSCode now [ships](https://github.com/Microsoft/vscode/tree/master/extensions/python/syntaxes) with MagicPython.

* MagicPython is already used by more than [69k](https://atom.io/packages/magicpython) Atom users, and [360k](https://marketplace.visualstudio.com/items?itemName=magicstack.MagicPython) VSCode users (360k manual installs, bundled MagicPython isn't included in this statistic).

At this point, we believe that integrating MagicPython to Atom is easier, than trying to fix `language-python`.

### Possible Drawbacks

The only possible drawback is that MagicPython does not highlight SQL syntax in Python string literals. `language-python` detects when a string starts with `SELECT`, `INSERT`, `UPDATE`, or `WITH` and delegates highlighting to an SQL syntax.

Due to some limitations of TextMate syntax format, this feature can cause highlighting bugs, such as: https://github.com/atom/language-python/issues/174#issuecomment-266842718 and https://github.com/atom/language-python/issues/143.

Another question is why we need to treat SQL specially. There are many other declarative languages (HTML, templates, etc) that people use in Python strings. 

We think that Python syntax highlighter should only highlight Python language, and highlighting of other languages within Python source code should be delegated to plugins.

### Integration

We've made some changes in MagicPython 1.0.7 specifically for Atom integration:

* backported `python-console` and `python-traceback` syntaxes;

* added generation of Jasmine spec files to make MagicPython testable under Atom, see [test/atom-spec](https://github.com/MagicStack/MagicPython/tree/master/test/atom-spec) directory.

One thing that this PR does not cover is update of `atom/docs/build-instructions/build-status.md` file. If Atom team approves this PR, we probably need to start testing MagicPython on Atom's TravisCI instance.