### PR TITLE
Ignore `ref` and `key` props in `TextEditor.prototype.update`

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -353,7 +353,8 @@ class TextEditor extends Model
             cursor.setShowCursorOnSelection(value) for cursor in @getCursors()
 
         else
-          throw new TypeError("Invalid TextEditor parameter: '#{param}'")
+          if param isnt 'ref' and param isnt 'key'
+            throw new TypeError("Invalid TextEditor parameter: '#{param}'")
 
     @displayLayer.reset(displayLayerParams)
 


### PR DESCRIPTION
Instead of throwing an error when supplying `ref` and/or `key`to `TextEditor.prototype.update` we will now simply ignore them. This change is needed because of https://github.com/atom/etch/pull/41 where we decided to pass `key` and `ref` to child components in order to avoid expensive copy operations.

/cc: @nathansobo 