### PR TITLE
Remove macOS emoji workaround

### DIFF
--- a/spec/workspace-element-spec.coffee
+++ b/spec/workspace-element-spec.coffee
@@ -54,12 +54,10 @@ describe "WorkspaceElement", ->
     it "updates the font-family based on the 'editor.fontFamily' config value", ->
       initialCharWidth = editor.getDefaultCharWidth()
       fontFamily = atom.config.get('editor.fontFamily')
-      fontFamily += ', "Apple Color Emoji"' if process.platform is 'darwin'
       expect(getComputedStyle(editorElement).fontFamily).toBe fontFamily
 
       atom.config.set('editor.fontFamily', 'sans-serif')
       fontFamily = atom.config.get('editor.fontFamily')
-      fontFamily += ', "Apple Color Emoji"' if process.platform is 'darwin'
       expect(getComputedStyle(editorElement).fontFamily).toBe fontFamily
       expect(editor.getDefaultCharWidth()).not.toBe initialCharWidth
 

--- a/src/workspace-element.coffee
+++ b/src/workspace-element.coffee
@@ -44,15 +44,10 @@ class WorkspaceElement extends HTMLElement
     @subscriptions.add @config.onDidChange 'editor.lineHeight', @updateGlobalTextEditorStyleSheet.bind(this)
 
   updateGlobalTextEditorStyleSheet: ->
-    fontFamily = @config.get('editor.fontFamily')
-    # TODO: There is a bug in how some emojis (e.g. ❤️) are rendered on macOS.
-    # This workaround should be removed once we update to Chromium 51, where the
-    # problem was fixed.
-    fontFamily += ', "Apple Color Emoji"' if process.platform is 'darwin'
     styleSheetSource = """
       atom-text-editor {
         font-size: #{@config.get('editor.fontSize')}px;
-        font-family: #{fontFamily};
+        font-family: #{@config.get('editor.fontFamily')};
         line-height: #{@config.get('editor.lineHeight')};
       }
     """


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

As noted in the comment, this workaround should have been removed once we upgraded to Chromium 51+.  We are now on Chromium 53, so this should be safe to remove.

### Alternate Designs

None.

### Why Should This Be In Core?

N/A

### Benefits

Maintenance

### Possible Drawbacks

None.

### Applicable Issues

None.