### PR TITLE
Cause an assertion failure if defaultMarkerLayer is destroyed early

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -192,6 +192,9 @@ class TextEditor extends Model
 
     @displayLayer.setTextDecorationLayer(@tokenizedBuffer)
     @defaultMarkerLayer = @displayLayer.addMarkerLayer()
+    @disposables.add(@defaultMarkerLayer.onDidDestroy =>
+      @assert(false, "defaultMarkerLayer destroyed at an unexpected time")
+    )
     @selectionsMarkerLayer ?= @addMarkerLayer(maintainHistory: true, persistent: true)
     @selectionsMarkerLayer.trackDestructionInOnDidCreateMarkerCallbacks = true
 


### PR DESCRIPTION
This is to investigate a case where the default marker layer of the editor is destroyed without the editor itself or its buffer being destroyed, which is causing `Cannot decorate a destroyed marker` exceptions.