### PR TITLE
Throw an error when assertions fail if built from source

### DIFF
--- a/spec/atom-environment-spec.coffee
+++ b/spec/atom-environment-spec.coffee
@@ -126,6 +126,7 @@ describe "AtomEnvironment", ->
 
     beforeEach ->
       errors = []
+      spyOn(atom, 'isReleasedVersion').andReturn(true)
       atom.onDidFailAssertion (error) -> errors.push(error)
 
     describe "if the condition is false", ->
@@ -146,6 +147,11 @@ describe "AtomEnvironment", ->
         it "assigns the metadata on the assertion failure's error object", ->
           atom.assert(false, "a == b", {foo: 'bar'})
           expect(errors[0].metadata).toEqual {foo: 'bar'}
+
+      describe "when Atom has been built from source", ->
+        it "throws an error", ->
+          atom.isReleasedVersion.andReturn(false)
+          expect(-> atom.assert(false, 'testing')).toThrow('Assertion failed: testing')
 
     describe "if the condition is true", ->
       it "does nothing", ->

--- a/spec/dom-element-pool-spec.js
+++ b/spec/dom-element-pool-spec.js
@@ -3,7 +3,10 @@ const DOMElementPool = require ('../src/dom-element-pool')
 describe('DOMElementPool', function () {
   let domElementPool
 
-  beforeEach(() => { domElementPool = new DOMElementPool() })
+  beforeEach(() => {
+    domElementPool = new DOMElementPool()
+    spyOn(atom, 'isReleasedVersion').andReturn(true)
+  })
 
   it('builds DOM nodes, recycling them when they are freed', function () {
     let elements

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -28,7 +28,13 @@ describe "TextEditor", ->
       editor.foldBufferRow(4)
       expect(editor.isFoldedAtBufferRow(4)).toBeTruthy()
 
-      editor2 = TextEditor.deserialize(editor.serialize(), atom)
+      editor2 = TextEditor.deserialize(editor.serialize(), {
+        assert: atom.assert,
+        textEditors: atom.textEditors,
+        project: {
+          bufferForIdSync: (id) -> TextBuffer.deserialize(editor.buffer.serialize())
+        }
+      })
 
       expect(editor2.id).toBe editor.id
       expect(editor2.getBuffer().getPath()).toBe editor.getBuffer().getPath()

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -840,6 +840,8 @@ class AtomEnvironment extends Model
         error.metadata = callbackOrMetadata
 
     @emitter.emit 'did-fail-assertion', error
+    unless @isReleasedVersion()
+      throw error
 
     false
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -387,7 +387,7 @@ class TextEditor extends Model
       softWrapHangingIndentLength: @displayLayer.softWrapHangingIndent
 
       @id, @softTabs, @softWrapped, @softWrapAtPreferredLineLength,
-      @preferredLineLength, @mini, @editorWidthInChars,  @width, @largeFileMode,
+      @preferredLineLength, @mini, @editorWidthInChars, @width, @largeFileMode,
       @registered, @invisibles, @showInvisibles, @showIndentGuide, @autoHeight, @autoWidth
     }
 


### PR DESCRIPTION
This will help us to notice assertions failing during our development.