### PR TITLE
Generate AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,21 @@ install:
   - nvm use --delete-prefix $NODE_VERSION
   - npm install -g npm
   - script/build --create-debian-package --create-rpm-package --compress-artifacts
+  - find /tmp/atom-*/
+  - cd /tmp/atom-*/
+  - wget -c https://github.com/probonopd/AppImageKit/releases/download/continuous/AppRun-x86_64 -O AppRun
+  - chmod a+x ./AppRun
+  - cp usr/share/applications/atom.desktop .
+  - cp usr/share/pixmaps/atom.png .
+  - cd -
+  - wget -c "https://github.com/probonopd/AppImageKit/releases/download/8/appimagetool-x86_64.AppImage" 
+  - chmod a+x appimagetool*.AppImage
+  - ./appimagetool*.AppImage --appimage-extract
+  - export VERSION=git.$(git rev-parse --short HEAD)
+  - ./squashfs-root/AppRun /tmp/atom-*/
+  - curl --upload-file ./Atom-*.AppImage https://transfer.sh/Atom-$VERSION-x86_64.AppImage # DELETE THIS LINE
+  - mv Atom-*.AppImage out/
+  - ls -lh
 
 script:
   - script/lint
@@ -42,6 +57,7 @@ addons:
       - out/atom-amd64.deb
       - out/atom.x86_64.rpm
       - out/atom-amd64.tar.gz
+      - out/Atom-*.AppImage
     target_paths: travis-artifacts/$TRAVIS_BUILD_ID
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - script/build --create-debian-package --create-rpm-package --compress-artifacts
   - find /tmp/atom-*/
   - cd /tmp/atom-*/
-  - wget -c https://github.com/probonopd/AppImageKit/releases/download/continuous/AppRun-x86_64 -O AppRun
+  - wget -c https://github.com/probonopd/AppImageKit/releases/download/8/AppRun-x86_64 -O AppRun
   - chmod a+x ./AppRun
   - cp usr/share/applications/atom.desktop .
   - cp usr/share/pixmaps/atom.png .


### PR DESCRIPTION
### Requirements

* Linux 64-bit machine

### Description of the Change

This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build. __Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. In this case, delete [this line](https://github.com/atom/atom/pull/13921/files#diff-354f30a63fb0907d4ad57269548329e3R33) from the `.travis.yml` file.

### Alternate Designs

* Flatpak: Requires the setup of Flatpak and a runtime first, need to use the command line. Does not work out-of-the-box on most distributions but Fedora. Does not run on Live CDs.
* Snap: Canonical centric solution, Requires the setup of Snap and a runtime first, does not work out-of-the-box on most distributions but Ubuntu.

### Why Should This Be In Core?

Linux should be a first-class desktop for Atom, and using Atom on Linux should be as easy as on Windows and macOS.

### Benefits

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Just one format for all major distributions
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

### Possible Drawbacks

None. Providing an AppImage could be done in addition to providing other types of Linux packages and/or bundles.

### Applicable Issues

* https://github.com/atom/atom/issues/13118: Feature request: Provide an AppImage for Atom Stable and Atom Beta releases
* https://github.com/atom/atom/issues/4980: Add portable version for Linux
* https://github.com/atom/atom/issues/11000: Building Atom Beta releases so they can be installed simultaneously, on the same machine, to stable releases
* https://github.com/atom/atom/issues/4330: Installing atom without sudo privileges
* https://github.com/atom/atom/issues/2956: Add Linux software repositories for app update support 
* https://github.com/atom/atom/issues/11837: Flatpak release support
* https://github.com/atom/atom/issues/13298: Please provide a snap package