### PR TITLE
Fix destroying a `PanelContainer` containing multiple panels

### DIFF
--- a/spec/panel-container-spec.coffee
+++ b/spec/panel-container-spec.coffee
@@ -5,7 +5,7 @@ describe "PanelContainer", ->
   [container] = []
 
   class TestPanelItem
-    constructior: ->
+    constructor: ->
 
   beforeEach ->
     container = new PanelContainer
@@ -38,6 +38,23 @@ describe "PanelContainer", ->
 
       panel1.destroy()
       expect(removePanelSpy).toHaveBeenCalledWith({panel: panel1, index: 0})
+
+  describe "::destroy()", ->
+    it "destroys the container and all of its panels", ->
+      destroyedPanels = []
+
+      panel1 = new Panel(item: new TestPanelItem())
+      panel1.onDidDestroy -> destroyedPanels.push(panel1)
+      container.addPanel(panel1)
+
+      panel2 = new Panel(item: new TestPanelItem())
+      panel2.onDidDestroy -> destroyedPanels.push(panel2)
+      container.addPanel(panel2)
+
+      container.destroy()
+
+      expect(container.getPanels().length).toBe(0)
+      expect(destroyedPanels).toEqual([panel1, panel2])
 
   describe "panel priority", ->
     describe 'left / top panel container', ->

--- a/src/panel-container.coffee
+++ b/src/panel-container.coffee
@@ -34,7 +34,7 @@ class PanelContainer
 
   isModal: -> @location is 'modal'
 
-  getPanels: -> @panels
+  getPanels: -> @panels.slice()
 
   addPanel: (panel) ->
     @subscriptions.add panel.onDidDestroy(@panelDestroyed.bind(this))


### PR DESCRIPTION
Previously, when calling `destroy` on a `PanelContainer` containing multiple panels, Atom would throw a `Cannot read property 'destroy' of undefined` exception (https://circleci.com/gh/atom/atom/2832). This was due to iterating over the panels while at the same time destroying them, which caused the iterated array to be modified during the loop.

With this commit we slice the array before iterating over it so that destroying a `PanelContainer` doesn't throw exceptions anymore.

/cc: @nathansobo @maxbrunsfeld 