### PR TITLE
Exclude `marker` from deprecated syntax selectors

### DIFF
--- a/src/deprecated-syntax-selectors.js
+++ b/src/deprecated-syntax-selectors.js
@@ -495,7 +495,7 @@ module.exports = new Set([
   'magik', 'mail', 'mailer', 'mailto', 'main', 'makefile', 'makefile2', 'mako',
   'mamba', 'man', 'mantissa', 'manualmelisma', 'map', 'map-library', 'map-name',
   'mapfile', 'mapkey', 'mapping', 'mapping-type', 'maprange', 'marasm',
-  'margin', 'marginpar', 'mark', 'mark-input', 'markdown', 'marker', 'marko',
+  'margin', 'marginpar', 'mark', 'mark-input', 'markdown', 'marko',
   'marko-attribute', 'marko-tag', 'markup', 'markupmode', 'mas2j', 'mask',
   'mason', 'mat', 'mata', 'match', 'match-bind', 'match-branch',
   'match-condition', 'match-definition', 'match-exception', 'match-option',


### PR DESCRIPTION
### Description of the Change

If we get a textmate theme (e.g. https://raw.githubusercontent.com/JetBrains/colorSchemeTool/master/tmThemes/Monokai.tmTheme).

And try to convert it to an atom theme using apm as shown in the docs:
http://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate/

The resulting theme (if we chose it as the current syntax theme on settings) will display a deprecation warning about two class selectors:

> Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:
> 
> atom-text-editor .search-results .marker .region => atom-text-editor .search-results .syntax--marker .region
> atom-text-editor .search-results .marker.current-result .region => atom-text-editor .search-results .syntax--marker.current-result .region
> Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible.

#### Screenshot of the deprecation message
![deprecation-screenshot](https://cloud.githubusercontent.com/assets/2272928/23588842/6b95c996-0191-11e7-8ae4-39089d9dbd91.png)

If we look at the base template theme on apm, it's using the `.marker` selector (https://github.com/atom/apm/blob/master/templates/theme/styles/base.less#L54) and when the shadow rules were removed from apm, `.marker` was not prepended with `.syntax--` (https://github.com/atom/apm/pull/615/files).

So, assuming that apm is actually converting the themes correctly, my guess is that `marker` is not a deprecated selector and should be excluded from the warning messages.

Note: Based this pr on https://github.com/atom/atom/commit/abef1f25f9101183c7b73eaaf22ea872dd815c3a

### Alternate Designs

None.

### Why Should This Be In Core?

All themes that are automatically converted with the official atom "way" (using apm) are currently displaying deprecation warnings and also triggering some unnecessary automatic selector translations.

### Benefits

See previous item.

### Possible Drawbacks

I personally don't know much about the internals of atom. So, the `marked` selector could possibly be deprecated and the solution could lie elsewhere (e.g. on apm).

I also didn't test this fix at all locally (i didn't find instructions on how to run atom from source, etc). Just traced the deprecation warning message on the source code to this line https://github.com/atom/atom/blob/master/src/style-manager.js#L302, which in turn seem to depend on this other one https://github.com/atom/atom/blob/master/src/style-manager.js#L275 and from the deprecation message, the only class on the selector that i found blacklisted was `marker`.

### Applicable Issues

None that i could find both here and on the apm repo.
