### PR TITLE
Fix path on macOS link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ In this directory you can only find very specific build and API level documentat
 
 Instructions for building Atom on various platforms from source.
 
-* [macOS](./build-instructions/macos.md)
+* [macOS](./build-instructions/macOS.md)
 * [Windows](./build-instructions/windows.md)
 * [Linux](./build-instructions/linux.md)
 * [FreeBSD](./build-instructions/freebsd.md)


### PR DESCRIPTION
### Requirements
No requirements

### Description of the Change
Link on this README.md is broken (people from MacOS can't get this link from current version of README.md

### Alternate Designs

May be remove links from readme.md and put link to "docs"

### Why Should This Be In Core?

Same as Description of the Change

### Benefits

Clean README always better (any wrong text in README make bad view of code/repository)

### Possible Drawbacks

Don't understand

### Applicable Issues

Don't understand
