### PR TITLE
Make an option to always restore the last session

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "key-path-helpers": "^0.4.0",
     "less-cache": "0.23",
     "line-top-index": "0.2.0",
-    "lodash.clonedeep": "*",
     "marked": "^0.3.6",
     "minimatch": "^3.0.3",
     "mocha": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "key-path-helpers": "^0.4.0",
     "less-cache": "0.23",
     "line-top-index": "0.2.0",
+    "lodash.clonedeep": "*",
     "marked": "^0.3.6",
     "minimatch": "^3.0.3",
     "mocha": "2.5.1",

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -372,7 +372,7 @@ describe('AtomApplication', function () {
       assert.deepEqual(await getTreeViewRootDirectories(app2Window2), [tempDirPath2])
     })
 
-    it('does not reopen any previously opened windows when launched with no path and `core.restorePreviousWindowsOnStart` is false', async function () {
+    it('does not reopen any previously opened windows when launched with no path and `core.restorePreviousWindowsOnStart` is no', async function () {
       const atomApplication1 = buildAtomApplication()
       const app1Window1 = atomApplication1.launch(parseCommandLine([makeTempDir()]))
       await focusWindow(app1Window1)
@@ -382,7 +382,7 @@ describe('AtomApplication', function () {
       const configPath = path.join(process.env.ATOM_HOME, 'config.cson')
       const config = season.readFileSync(configPath)
       if (!config['*'].core) config['*'].core = {}
-      config['*'].core.restorePreviousWindowsOnStart = false
+      config['*'].core.restorePreviousWindowsOnStart = 'no'
       season.writeFileSync(configPath, config)
 
       const atomApplication2 = buildAtomApplication()

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -258,14 +258,10 @@ const configSchema = {
         default: true
       },
       restorePreviousWindowsOnStart: {
-        description: 'When checked restores the last state of all Atom windows when started from the icon or `atom` by itself from the command line; otherwise a blank environment is loaded.',
-        type: 'boolean',
-        default: true
-      },
-      restorePreviousWindowsOnStartAlways: {
-        description: 'When checked *ALWAYS* restores the last state of all Atom windows.',
-        type: 'boolean',
-        default: false
+        type: 'string',
+        enum: ['no', 'yes', 'always'],
+        default: 'yes',
+        description: "When selected 'no', a blank environment is loaded. When selected 'yes' and Atom is started from the icon or `atom` by itself from the command line, restores the last state of all Atom windows; otherwise a blank environment is loaded. When selected 'always', restores the last state of all Atom windows always, no matter how Atom is started."
       },
       reopenProjectMenuCount: {
         description: 'How many recent projects to show in the Reopen Project menu.',

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -262,6 +262,11 @@ const configSchema = {
         type: 'boolean',
         default: true
       },
+      restorePreviousWindowsOnStartAlways: {
+        description: 'When checked *ALWAYS* restores the last state of all Atom windows.',
+        type: 'boolean',
+        default: false
+      },
       reopenProjectMenuCount: {
         description: 'How many recent projects to show in the Reopen Project menu.',
         type: 'integer',

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -112,7 +112,7 @@ class AtomApplication
   launch: (options) ->
     if options.pathsToOpen?.length > 0 or options.urlsToOpen?.length > 0 or options.test or options.benchmark or options.benchmarkTest
       if @config.get('core.restorePreviousWindowsOnStart') is 'always'
-        @loadState(clone(options))
+        @loadState(_.cloneDeep(options))
       @openWithOptions(options)
     else
       @loadState(options) or @openPath(options)
@@ -814,10 +814,3 @@ class AtomApplication
       args.push("--resource-path=#{@resourcePath}")
     app.relaunch({args})
     app.quit()
-
-  clone = (obj) ->
-    return obj if obj is null or typeof (obj) isnt "object"
-    temp = new obj.constructor()
-    for key of obj
-      temp[key] = clone(obj[key])
-    temp

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -15,7 +15,6 @@ net = require 'net'
 url = require 'url'
 {EventEmitter} = require 'events'
 _ = require 'underscore-plus'
-cloneDeep = require 'lodash.clonedeep'
 FindParentDir = null
 Resolve = null
 
@@ -113,7 +112,7 @@ class AtomApplication
   launch: (options) ->
     if options.pathsToOpen?.length > 0 or options.urlsToOpen?.length > 0 or options.test or options.benchmark or options.benchmarkTest
       if @config.get('core.restorePreviousWindowsOnStart') is 'always'
-        @loadState(cloneDeep(options))
+        @loadState(_.deepClone(options))
       @openWithOptions(options)
     else
       @loadState(options) or @openPath(options)

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -111,7 +111,7 @@ class AtomApplication
 
   launch: (options) ->
     if options.pathsToOpen?.length > 0 or options.urlsToOpen?.length > 0 or options.test or options.benchmark or options.benchmarkTest
-      if @config.get('core.restorePreviousWindowsOnStartAlways')
+      if @config.get('core.restorePreviousWindowsOnStart') is 'always'
         @loadState(clone(options))
       @openWithOptions(options)
     else
@@ -601,7 +601,7 @@ class AtomApplication
       @storageFolder.storeSync('application.json', states)
 
   loadState: (options) ->
-    if (@config.get('core.restorePreviousWindowsOnStartAlways') or @config.get('core.restorePreviousWindowsOnStart')) and (states = @storageFolder.load('application.json'))?.length > 0
+    if (@config.get('core.restorePreviousWindowsOnStart') in ['yes', 'always']) and (states = @storageFolder.load('application.json'))?.length > 0
       for state in states
         @openWithOptions(Object.assign(options, {
           initialPaths: state.initialPaths

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -15,6 +15,7 @@ net = require 'net'
 url = require 'url'
 {EventEmitter} = require 'events'
 _ = require 'underscore-plus'
+cloneDeep = require 'lodash.clonedeep'
 FindParentDir = null
 Resolve = null
 
@@ -112,7 +113,7 @@ class AtomApplication
   launch: (options) ->
     if options.pathsToOpen?.length > 0 or options.urlsToOpen?.length > 0 or options.test or options.benchmark or options.benchmarkTest
       if @config.get('core.restorePreviousWindowsOnStart') is 'always'
-        @loadState(_.cloneDeep(options))
+        @loadState(cloneDeep(options))
       @openWithOptions(options)
     else
       @loadState(options) or @openPath(options)


### PR DESCRIPTION
Make an option to *always* restore the last session, no matter how Atom is invoked (#9643).

### Description of the Change

`src/config-schema.js`: the change adds the option to the Settings window.

`src/main-process/atom-application.coffee`:
- line 114: load previous session if the option is turned on;
- line 563: IMO it's a bug, here the newly created window is activated, but `@lastFocusedWindow` is not updated, so on the second invocation at the same moment in time there'll be no lastFocusedWindow and a second (new) window would be created (at line 542/544 -> 550/552).
- line 604: if any of the options is checked, restore the last session (applicable when starting atom without arguments)
- line 817: a function to duplicate an object, taken from: https://coffeescript-cookbook.github.io/chapters/classes_and_objects/cloning

### Alternate Designs

TL;DR: none, see the issue #9643 for an extended discussion.


### Why Should This Be In Core?

This is a standard behavior for most of modern multi-tab apps today, i.e. the ability to restore the last session after crash or normal exit, no matter how the app is invoked for the first time since the last session (i.e. with or without path parameters).


### Benefits

See the previous point.


### Possible Drawbacks

None as this is an option turned off by default, so it won't affect anyone if not explicitly terned on by the user.


### Applicable Issues

So far no issues were discovered.


### Other

script/test: 23 passing (2m), i.e. no errors when the option is turned off (the default behavior)
Jasmine specs in the ./spec folder are not provided

![atom_settings](https://cloud.githubusercontent.com/assets/22968420/23647967/5a4bb3fa-02f7-11e7-999a-6a513a885bd8.png)
