### PR TITLE
Minimize synchronous I/O during startup

### DIFF
--- a/spec/history-manager-spec.js
+++ b/spec/history-manager-spec.js
@@ -30,7 +30,7 @@ describe("HistoryManager", () => {
       return projectDisposable
     })
 
-    historyManager = new HistoryManager({stateStore, project, commands: commandRegistry})
+    historyManager = new HistoryManager({stateStore, localStorage: window.localStorage, project, commands: commandRegistry})
     await historyManager.loadState()
   })
 
@@ -75,7 +75,7 @@ describe("HistoryManager", () => {
 
       it("saves the state", async () => {
         await historyManager.clearProjects()
-        const historyManager2 = new HistoryManager({stateStore, project, commands: commandRegistry})
+        const historyManager2 = new HistoryManager({stateStore, localStorage: window.localStorage, project, commands: commandRegistry})
         await historyManager2.loadState()
         expect(historyManager.getProjects().length).toBe(0)
       })
@@ -186,7 +186,7 @@ describe("HistoryManager", () => {
     it("saves the state", async () => {
       await historyManager.addProject(["/save/state"])
       await historyManager.saveState()
-      const historyManager2 = new HistoryManager({stateStore, project, commands: commandRegistry})
+      const historyManager2 = new HistoryManager({stateStore, localStorage: window.localStorage, project, commands: commandRegistry})
       await historyManager2.loadState()
       expect(historyManager2.getProjects()[0].paths).toEqual(['/save/state'])
     })

--- a/spec/history-manager-spec.js
+++ b/spec/history-manager-spec.js
@@ -4,27 +4,24 @@ import {it, fit, ffit, fffit, beforeEach, afterEach} from './async-spec-helpers'
 import {Emitter, Disposable, CompositeDisposable} from 'event-kit'
 
 import {HistoryManager, HistoryProject} from '../src/history-manager'
+import StateStore from '../src/state-store'
 
 describe("HistoryManager", () => {
-  let historyManager, commandRegistry, project, localStorage, stateStore
+  let historyManager, commandRegistry, project, stateStore
   let commandDisposable, projectDisposable
 
-  beforeEach(() => {
+  beforeEach(async () => {
     commandDisposable = jasmine.createSpyObj('Disposable', ['dispose'])
     commandRegistry = jasmine.createSpyObj('CommandRegistry', ['add'])
     commandRegistry.add.andReturn(commandDisposable)
 
-    localStorage = jasmine.createSpyObj('LocalStorage', ['getItem', 'setItem'])
-    localStorage.items = {
-      history: JSON.stringify({
-        projects: [
-          { paths: ['/1', 'c:\\2'], lastOpened: new Date(2016, 9, 17, 17, 16, 23) },
-          { paths: ['/test'], lastOpened: new Date(2016, 9, 17, 11, 12, 13) }
-        ]
-      })
-    }
-    localStorage.getItem.andCallFake((key) => localStorage.items[key])
-    localStorage.setItem.andCallFake((key, value) => localStorage.items[key] = value)
+    stateStore = new StateStore('history-manager-test', 1)
+    await stateStore.save('history-manager', {
+      projects: [
+        {paths: ['/1', 'c:\\2'], lastOpened: new Date(2016, 9, 17, 17, 16, 23)},
+        {paths: ['/test'], lastOpened: new Date(2016, 9, 17, 11, 12, 13)}
+      ]
+    })
 
     projectDisposable = jasmine.createSpyObj('Disposable', ['dispose'])
     project = jasmine.createSpyObj('Project', ['onDidChangePaths'])
@@ -33,7 +30,12 @@ describe("HistoryManager", () => {
       return projectDisposable
     })
 
-    historyManager = new HistoryManager({project, commands:commandRegistry, localStorage})
+    historyManager = new HistoryManager({stateStore, project, commands: commandRegistry})
+    await historyManager.loadState()
+  })
+
+  afterEach(async () => {
+    await stateStore.clear()
   })
 
   describe("constructor", () => {
@@ -65,31 +67,26 @@ describe("HistoryManager", () => {
     })
 
     describe("clearProjects", () => {
-      it("clears the list of projects", () => {
+      it("clears the list of projects", async () => {
         expect(historyManager.getProjects().length).not.toBe(0)
-        historyManager.clearProjects()
+        await historyManager.clearProjects()
         expect(historyManager.getProjects().length).toBe(0)
       })
 
-      it("saves the state", () => {
-        expect(localStorage.setItem).not.toHaveBeenCalled()
-        historyManager.clearProjects()
-        expect(localStorage.setItem).toHaveBeenCalled()
-        expect(localStorage.setItem.calls[0].args[0]).toBe('history')
+      it("saves the state", async () => {
+        await historyManager.clearProjects()
+        const historyManager2 = new HistoryManager({stateStore, project, commands: commandRegistry})
+        await historyManager2.loadState()
         expect(historyManager.getProjects().length).toBe(0)
       })
 
-      it("fires the onDidChangeProjects event", () => {
-        expect(localStorage.setItem).not.toHaveBeenCalled()
-        historyManager.clearProjects()
-        expect(localStorage.setItem).toHaveBeenCalled()
-        expect(localStorage.setItem.calls[0].args[0]).toBe('history')
+      it("fires the onDidChangeProjects event", async () => {
+        const didChangeSpy = jasmine.createSpy()
+        historyManager.onDidChangeProjects(didChangeSpy)
+        await historyManager.clearProjects()
         expect(historyManager.getProjects().length).toBe(0)
+        expect(didChangeSpy).toHaveBeenCalled()
       })
-    })
-
-    it("loads state", () => {
-      expect(localStorage.getItem).toHaveBeenCalledWith('history')
     })
 
     it("listens to project.onDidChangePaths adding a new project", () => {
@@ -112,61 +109,61 @@ describe("HistoryManager", () => {
   })
 
   describe("loadState", () => {
-    it("defaults to an empty array if no state", () => {
-      localStorage.items.history = null
-      historyManager.loadState()
+    it("defaults to an empty array if no state", async () => {
+      await stateStore.clear()
+      await historyManager.loadState()
       expect(historyManager.getProjects()).toEqual([])
     })
 
-    it("defaults to an empty array if no projects", () => {
-      localStorage.items.history = JSON.stringify('')
-      historyManager.loadState()
+    it("defaults to an empty array if no projects", async () => {
+      await stateStore.save('history-manager', {})
+      await historyManager.loadState()
       expect(historyManager.getProjects()).toEqual([])
     })
   })
 
   describe("addProject", () => {
-    it("adds a new project to the end", () => {
+    it("adds a new project to the end", async () => {
       const date = new Date(2010, 10, 9, 8, 7, 6)
-      historyManager.addProject(['/a/b'], date)
+      await historyManager.addProject(['/a/b'], date)
       const projects = historyManager.getProjects()
       expect(projects.length).toBe(3)
       expect(projects[2].paths).toEqual(['/a/b'])
       expect(projects[2].lastOpened).toBe(date)
     })
 
-    it("adds a new project to the start", () => {
+    it("adds a new project to the start", async () => {
       const date = new Date()
-      historyManager.addProject(['/so/new'], date)
+      await historyManager.addProject(['/so/new'], date)
       const projects = historyManager.getProjects()
       expect(projects.length).toBe(3)
       expect(projects[0].paths).toEqual(['/so/new'])
       expect(projects[0].lastOpened).toBe(date)
     })
 
-    it("updates an existing project and moves it to the start", () => {
+    it("updates an existing project and moves it to the start", async () => {
       const date = new Date()
-      historyManager.addProject(['/test'], date)
+      await historyManager.addProject(['/test'], date)
       const projects = historyManager.getProjects()
       expect(projects.length).toBe(2)
       expect(projects[0].paths).toEqual(['/test'])
       expect(projects[0].lastOpened).toBe(date)
     })
 
-    it("fires the onDidChangeProjects event when adding a project", () => {
+    it("fires the onDidChangeProjects event when adding a project", async () => {
       const didChangeSpy = jasmine.createSpy()
       const beforeCount = historyManager.getProjects().length
       historyManager.onDidChangeProjects(didChangeSpy)
-      historyManager.addProject(['/test-new'], new Date())
+      await historyManager.addProject(['/test-new'], new Date())
       expect(didChangeSpy).toHaveBeenCalled()
       expect(historyManager.getProjects().length).toBe(beforeCount + 1)
     })
 
-    it("fires the onDidChangeProjects event when updating a project", () => {
+    it("fires the onDidChangeProjects event when updating a project", async () => {
       const didChangeSpy = jasmine.createSpy()
       const beforeCount = historyManager.getProjects().length
       historyManager.onDidChangeProjects(didChangeSpy)
-      historyManager.addProject(['/test'], new Date())
+      await historyManager.addProject(['/test'], new Date())
       expect(didChangeSpy).toHaveBeenCalled()
       expect(historyManager.getProjects().length).toBe(beforeCount)
     })
@@ -186,14 +183,12 @@ describe("HistoryManager", () => {
   })
 
   describe("saveState" ,() => {
-    it("saves the state", () => {
-      historyManager.addProject(["/save/state"])
-      historyManager.saveState()
-      expect(localStorage.setItem).toHaveBeenCalled()
-      expect(localStorage.setItem.calls[0].args[0]).toBe('history')
-      expect(localStorage.items['history']).toContain('/save/state')
-      historyManager.loadState()
-      expect(historyManager.getProjects()[0].paths).toEqual(['/save/state'])
+    it("saves the state", async () => {
+      await historyManager.addProject(["/save/state"])
+      await historyManager.saveState()
+      const historyManager2 = new HistoryManager({stateStore, project, commands: commandRegistry})
+      await historyManager2.loadState()
+      expect(historyManager2.getProjects()[0].paths).toEqual(['/save/state'])
     })
   })
 })

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -1,5 +1,5 @@
 _ = require 'underscore-plus'
-{screen, ipcRenderer, remote, shell, webFrame} = require 'electron'
+{ipcRenderer, remote, shell} = require 'electron'
 ipcHelpers = require './ipc-helpers'
 {Disposable} = require 'event-kit'
 getWindowLoadSettings = require './get-window-load-settings'
@@ -253,20 +253,6 @@ class ApplicationDelegate
 
   openExternal: (url) ->
     shell.openExternal(url)
-
-  disableZoom: ->
-    outerCallback = ->
-      webFrame.setZoomLevelLimits(1, 1)
-
-    outerCallback()
-    # Set the limits every time a display is added or removed, otherwise the
-    # configuration gets reset to the default, which allows zooming the
-    # webframe.
-    screen.on('display-added', outerCallback)
-    screen.on('display-removed', outerCallback)
-    new Disposable ->
-      screen.removeListener('display-added', outerCallback)
-      screen.removeListener('display-removed', outerCallback)
 
   checkForUpdate: ->
     ipcRenderer.send('command', 'application:check-for-update')

--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -80,6 +80,12 @@ class ApplicationDelegate
   setWindowFullScreen: (fullScreen=false) ->
     ipcHelpers.call('window-method', 'setFullScreen', fullScreen)
 
+  onDidEnterFullScreen: (callback) ->
+    ipcHelpers.on(ipcRenderer, 'did-enter-full-screen', callback)
+
+  onDidLeaveFullScreen: (callback) ->
+    ipcHelpers.on(ipcRenderer, 'did-leave-full-screen', callback)
+
   openWindowDevTools: ->
     # Defer DevTools interaction to the next tick, because using them during
     # event handling causes some wrong input events to be triggered on

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -229,7 +229,7 @@ class AtomEnvironment extends Model
 
     @observeAutoHideMenuBar()
 
-    @history = new HistoryManager({@project, @commands, @stateStore})
+    @history = new HistoryManager({@project, @commands, @stateStore, localStorage: window.localStorage})
     # Keep instances of HistoryManager in sync
     @disposables.add @history.onDidChangeProjects (e) =>
       @applicationDelegate.didChangeHistoryManager() unless e.reloaded

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -215,8 +215,6 @@ class AtomEnvironment extends Model
     @stylesElement = @styles.buildStylesElement()
     @document.head.appendChild(@stylesElement)
 
-    @disposables.add(@applicationDelegate.disableZoom())
-
     @keymaps.subscribeToFileReadFailure()
     @keymaps.loadBundledKeymaps()
 

--- a/src/get-window-load-settings.js
+++ b/src/get-window-load-settings.js
@@ -4,7 +4,7 @@ let windowLoadSettings = null
 
 module.exports = () => {
   if (!windowLoadSettings) {
-    windowLoadSettings = remote.getCurrentWindow().loadSettings
+    windowLoadSettings = JSON.parse(remote.getCurrentWindow().loadSettingsJSON)
   }
   return windowLoadSettings
 }

--- a/src/history-manager.js
+++ b/src/history-manager.js
@@ -133,32 +133,3 @@ export class HistoryProject {
   set lastOpened (lastOpened) { this._lastOpened = lastOpened }
   get lastOpened () { return this._lastOpened }
 }
-
-class HistoryImporter {
-  static async getStateStoreCursor () {
-    const db = await atom.stateStore.dbPromise
-    const store = db.transaction(['states']).objectStore('states')
-    return store.openCursor()
-  }
-
-  static async getAllProjects (stateStore) {
-    const request = await HistoryImporter.getStateStoreCursor()
-    return new Promise((resolve, reject) => {
-      const rows = []
-      request.onerror = reject
-      request.onsuccess = event => {
-        const cursor = event.target.result
-        if (cursor) {
-          let project = cursor.value.value.project
-          let storedAt = cursor.value.storedAt
-          if (project && project.paths && storedAt) {
-            rows.push(new HistoryProject(project.paths, new Date(Date.parse(storedAt))))
-          }
-          cursor.continue()
-        } else {
-          resolve(rows)
-        }
-      }
-    })
-  }
-}

--- a/src/history-manager.js
+++ b/src/history-manager.js
@@ -8,8 +8,9 @@ import {Emitter, CompositeDisposable} from 'event-kit'
 //
 // The project history is used to enable the 'Reopen Project' menu.
 export class HistoryManager {
-  constructor ({stateStore, project, commands}) {
+  constructor ({stateStore, localStorage, project, commands}) {
     this.stateStore = stateStore
+    this.localStorage = localStorage
     this.emitter = new Emitter()
     this.projects = []
     this.disposables = new CompositeDisposable()
@@ -93,7 +94,11 @@ export class HistoryManager {
   }
 
   async loadState () {
-    const history = await this.stateStore.load('history-manager')
+    let history = await this.stateStore.load('history-manager')
+    if (!history) {
+      history = JSON.parse(this.localStorage.getItem('history'))
+    }
+
     if (history && history.projects) {
       this.projects = history.projects.filter(p => Array.isArray(p.paths) && p.paths.length > 0).map(p => new HistoryProject(p.paths, new Date(p.lastOpened)))
       this.didChangeProjects({reloaded: true})

--- a/src/history-manager.js
+++ b/src/history-manager.js
@@ -1,6 +1,6 @@
 /** @babel */
 
-import {Emitter} from 'event-kit'
+import {Emitter, CompositeDisposable} from 'event-kit'
 
 // Extended: History manager for remembering which projects have been opened.
 //
@@ -8,12 +8,17 @@ import {Emitter} from 'event-kit'
 //
 // The project history is used to enable the 'Reopen Project' menu.
 export class HistoryManager {
-  constructor ({project, commands, localStorage}) {
-    this.localStorage = localStorage
-    commands.add('atom-workspace', {'application:clear-project-history': this.clearProjects.bind(this)})
+  constructor ({stateStore, project, commands}) {
+    this.stateStore = stateStore
     this.emitter = new Emitter()
-    this.loadState()
-    project.onDidChangePaths((projectPaths) => this.addProject(projectPaths))
+    this.projects = []
+    this.disposables = new CompositeDisposable()
+    this.disposables.add(commands.add('atom-workspace', {'application:clear-project-history': this.clearProjects.bind(this)}))
+    this.disposables.add(project.onDidChangePaths((projectPaths) => this.addProject(projectPaths)))
+  }
+
+  destroy () {
+    this.disposables.dispose()
   }
 
   // Public: Obtain a list of previously opened projects.
@@ -27,9 +32,12 @@ export class HistoryManager {
   //
   // Note: This is not a privacy function - other traces will still exist,
   // e.g. window state.
-  clearProjects () {
+  //
+  // Return a {Promise} that resolves when the history has been successfully
+  // cleared.
+  async clearProjects () {
     this.projects = []
-    this.saveState()
+    await this.saveState()
     this.didChangeProjects()
   }
 
@@ -46,7 +54,7 @@ export class HistoryManager {
     this.emitter.emit('did-change-projects', args || { reloaded: false })
   }
 
-  addProject (paths, lastOpened) {
+  async addProject (paths, lastOpened) {
     if (paths.length === 0) return
 
     let project = this.getProject(paths)
@@ -57,11 +65,11 @@ export class HistoryManager {
     project.lastOpened = lastOpened || new Date()
     this.projects.sort((a, b) => b.lastOpened - a.lastOpened)
 
-    this.saveState()
+    await this.saveState()
     this.didChangeProjects()
   }
 
-  removeProject (paths) {
+  async removeProject (paths) {
     if (paths.length === 0) return
 
     let project = this.getProject(paths)
@@ -70,7 +78,7 @@ export class HistoryManager {
     let index = this.projects.indexOf(project)
     this.projects.splice(index, 1)
 
-    this.saveState()
+    await this.saveState()
     this.didChangeProjects()
   }
 
@@ -84,31 +92,25 @@ export class HistoryManager {
     return null
   }
 
-  loadState () {
-    const state = JSON.parse(this.localStorage.getItem('history'))
-    if (state && state.projects) {
-      this.projects = state.projects.filter(p => Array.isArray(p.paths) && p.paths.length > 0).map(p => new HistoryProject(p.paths, new Date(p.lastOpened)))
-      this.didChangeProjects({ reloaded: true })
+  async loadState () {
+    const history = await this.stateStore.load('history-manager')
+    if (history && history.projects) {
+      this.projects = history.projects.filter(p => Array.isArray(p.paths) && p.paths.length > 0).map(p => new HistoryProject(p.paths, new Date(p.lastOpened)))
+      this.didChangeProjects({reloaded: true})
     } else {
       this.projects = []
     }
   }
 
-  saveState () {
-    const state = JSON.stringify({
-      projects: this.projects.map(p => ({
-        paths: p.paths, lastOpened: p.lastOpened
-      }))
-    })
-    this.localStorage.setItem('history', state)
+  async saveState () {
+    const projects = this.projects.map(p => ({paths: p.paths, lastOpened: p.lastOpened}))
+    await this.stateStore.save('history-manager', {projects})
   }
 
   async importProjectHistory () {
     for (let project of await HistoryImporter.getAllProjects()) {
-      this.addProject(project.paths, project.lastOpened)
+      await this.addProject(project.paths, project.lastOpened)
     }
-    this.saveState()
-    this.didChangeProjects()
   }
 }
 

--- a/src/history-manager.js
+++ b/src/history-manager.js
@@ -111,12 +111,6 @@ export class HistoryManager {
     const projects = this.projects.map(p => ({paths: p.paths, lastOpened: p.lastOpened}))
     await this.stateStore.save('history-manager', {projects})
   }
-
-  async importProjectHistory () {
-    for (let project of await HistoryImporter.getAllProjects()) {
-      await this.addProject(project.paths, project.lastOpened)
-    }
-  }
 }
 
 function arrayEquivalent (a, b) {

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -101,6 +101,7 @@ class AtomWindow
 
     hasPathToOpen = not (locationsToOpen.length is 1 and not locationsToOpen[0].pathToOpen?)
     @openLocations(locationsToOpen) if hasPathToOpen and not @isSpecWindow()
+    @disableZoom()
 
     @atomApplication.addWindow(this)
 
@@ -303,3 +304,6 @@ class AtomWindow
     @atomApplication.saveState()
 
   copy: -> @browserWindow.copy()
+
+  disableZoom: ->
+    @browserWindow.webContents.setZoomLevelLimits(1, 1)

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -83,7 +83,7 @@ class AtomWindow
     @representedDirectoryPaths = loadSettings.initialPaths
     @env = loadSettings.env if loadSettings.env?
 
-    @browserWindow.loadSettings = loadSettings
+    @browserWindow.loadSettingsJSON = JSON.stringify(loadSettings)
 
     @browserWindow.on 'window:loaded', =>
       @emit 'window:loaded'

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -89,6 +89,12 @@ class AtomWindow
       @emit 'window:loaded'
       @resolveLoadedPromise()
 
+    @browserWindow.on 'enter-full-screen', =>
+      @browserWindow.webContents.send('did-enter-full-screen')
+
+    @browserWindow.on 'leave-full-screen', =>
+      @browserWindow.webContents.send('did-leave-full-screen')
+
     @browserWindow.loadURL url.format
       protocol: 'file'
       pathname: "#{@resourcePath}/static/index.html"

--- a/src/reopen-project-menu-manager.js
+++ b/src/reopen-project-menu-manager.js
@@ -58,7 +58,7 @@ export default class ReopenProjectMenuManager {
   // Windows users can right-click Atom taskbar and remove project from the jump list.
   // We have to honor that or the group stops working. As we only get a partial list
   // each time we remove them from history entirely.
-  applyWindowsJumpListRemovals () {
+  async applyWindowsJumpListRemovals () {
     if (process.platform !== 'win32') return
     if (this.app === undefined) {
       this.app = require('remote').app
@@ -68,7 +68,7 @@ export default class ReopenProjectMenuManager {
     if (removed.length === 0) return
     for (let project of this.historyManager.getProjects()) {
       if (removed.includes(ReopenProjectMenuManager.taskDescription(project.paths))) {
-        this.historyManager.removeProject(project.paths)
+        await this.historyManager.removeProject(project.paths)
       }
     }
   }

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -20,14 +20,8 @@ class WindowEventHandler
     @subscriptions.add listen(@document, 'click', 'a', @handleLinkClick)
     @subscriptions.add listen(@document, 'submit', 'form', @handleFormSubmit)
 
-    browserWindow = @applicationDelegate.getCurrentWindow()
-    browserWindow.on 'enter-full-screen', @handleEnterFullScreen
-    @subscriptions.add new Disposable =>
-      browserWindow.removeListener('enter-full-screen', @handleEnterFullScreen)
-
-    browserWindow.on 'leave-full-screen', @handleLeaveFullScreen
-    @subscriptions.add new Disposable =>
-      browserWindow.removeListener('leave-full-screen', @handleLeaveFullScreen)
+    @subscriptions.add(@applicationDelegate.onDidEnterFullScreen(@handleEnterFullScreen))
+    @subscriptions.add(@applicationDelegate.onDidLeaveFullScreen(@handleLeaveFullScreen))
 
     @subscriptions.add @atomEnvironment.commands.add @window,
       'window:toggle-full-screen': @handleWindowToggleFullScreen


### PR DESCRIPTION
When Atom boots up it is extremely crucial to perform as little synchronous operations as possible in order to minimize startup time. This pull request does so by:

1. Exposing load settings to `BrowserWindow`s as JSON.

    When accessing objects in the main process via the `remote` module, Electron returns proxy objects that are references to the original ones. This means that trying to access a remote object's property or function results in a synchronous message exchange with the main process. <br>

    In Atom core we frequently access the load settings coming from the main process, especially during startup. This caused a lot of synchronous I/O which was blocking the renderer process for several milliseconds.
  
    With this pull request, instead of exposing load settings as a JavaScript object, we serialize them to JSON in the main process and parse them back to a JavaScript object in the renderer processes. This allows us to get a full copy of the object locally and pay for I/O only once when retrieving load settings from the main process for the first time.

2. Disabling zoom in the main process rather than in the renderer process.

    With this pull request we will register the `display-added` and `display-removed` events only once in the main process in order to disable zoom (see
    #11345) directly instead of unnecessarily paying for I/O in the renderer process during startup.

3. Registering enter/leave fullscreen events in the main process rather than in the renderer process.

    This will still notify render processes when such events are triggered without, however, incurring the additional cost of synchronously retrieving a `BrowserWindow` (and its properties) via `remote` during startup.

4. Replacing `localStorage` with `StateStore` in `HistoryManager`.

    Instead of using `localStorage` to store and retrieve the project history, with this pull request we will use `StateStore` so that we can retrieve state asynchronously without blocking Atom during startup. @damieng: I think this slightly changes the public `clearProjects` API by making it asynchronous. Considering the recent introduction of the API and its low adoption (I couldn't find anyone using it in packages), I believe this might be negligible; if you have any concern about it, though, please don't hesitate to raise them up.

These improvements are particularly evident during the construction of an `AtomEnvironment` instance. This is how a typical chart of that code path looks like today on master:

![screen shot 2017-03-07 at 11 10 00](https://cloud.githubusercontent.com/assets/482957/23651715/ae6bb898-0326-11e7-9059-22eb4bdd7f9a.png)

After removing all the synchronous I/O, the same code path looks like the following:

![screen shot 2017-03-07 at 11 05 29](https://cloud.githubusercontent.com/assets/482957/23651745/c4b1626a-0326-11e7-990e-cb9962520920.png)

On average, with these changes we save `~ 40ms` for the construction of `AtomEnvironment`. Moreover, the experience should be snappier across all the code paths because we won't pay any additional cost to retrieve load settings and to save project history state anymore. 

The next step will involve building an `AtomEnvironment` instance right inside the snapshot (as opposed to doing so at runtime) and thus potentially save 80-90% of the remaining `~ 80ms` observed after the changes introduced by this pull request.

/cc: @atom/maintainers 