### PR TITLE
Allow specifying installation directory

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -29,7 +29,7 @@ To also install the newly built application, use `--create-debian-package` or `-
 * `--compress-artifacts`: zips the generated application as `out/atom-{arch}.tar.gz`.
 * `--create-debian-package`: creates a .deb package as `out/atom-{arch}.deb`
 * `--create-rpm-package`: creates a .rpm package as `out/atom-{arch}.rpm`
-* `--install`: installs the application in `/usr/local/`.
+* `--install[=dir]`: installs the application in `${dir}`; `${dir}` defaults to `/usr/local`.
 
 ### Ubuntu / Debian
 

--- a/docs/build-instructions/macOS.md
+++ b/docs/build-instructions/macOS.md
@@ -21,7 +21,7 @@ To also install the newly built application, use `script/build --install`.
 
 * `--code-sign`: signs the application with the GitHub certificate specified in `$ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL`.
 * `--compress-artifacts`: zips the generated application as `out/atom-mac.zip`.
-* `--install`: installs the application at `/Applications/Atom.app` for dev and stable versions or at `/Applications/Atom-Beta.app` for beta versions.
+* `--install[=dir]`: installs the application at `${dir}/Atom.app` for dev and stable versions or at `${dir}/Atom-Beta.app` for beta versions; `${dir}` defaults to `/Applications`.
 
 ## Troubleshooting
 

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -35,7 +35,7 @@ To also install the newly built application, use `script\build --create-windows-
 * `--code-sign`: signs the application with the GitHub certificate specified in `$WIN_P12KEY_URL`.
 * `--compress-artifacts`: zips the generated application as `out\atom-windows.zip` (requires [7-Zip](http://www.7-zip.org)).
 * `--create-windows-installer`: creates an `.msi`, an `.exe` and two `.nupkg` packages in the `out` directory.
-* `--install`: installs the application in `%LOCALAPPDATA%\Atom\app-dev\`.
+* `--install[=dir]`: installs the application in `${dir}\Atom\app-dev`; `${dir}` defaults to `%LOCALAPPDATA%`.
 
 ### Running tests
 

--- a/script/build
+++ b/script/build
@@ -20,6 +20,7 @@ const argv = yargs
   .describe('create-rpm-package', 'Create .rpm package (Linux only)')
   .describe('compress-artifacts', 'Compress Atom binaries (and symbols on macOS)')
   .describe('install', 'Install Atom')
+  .string('install')
   .wrap(yargs.terminalWidth())
   .argv
 
@@ -99,8 +100,8 @@ dumpSymbols()
       console.log('Skipping artifacts compression. Specify the --compress-artifacts option to compress Atom binaries (and symbols on macOS)'.gray)
     }
 
-    if (argv.install) {
-      installApplication(packagedAppPath)
+    if (argv.install != null) {
+      installApplication(packagedAppPath, argv.install)
     } else {
       console.log('Skipping installation. Specify the --install option to install Atom'.gray)
     }

--- a/script/lib/handle-tilde.js
+++ b/script/lib/handle-tilde.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const os = require('os')
+const passwdUser = require('passwd-user')
+const path = require('path')
+
+module.exports = function (aPath) {
+  if (!aPath.startsWith('~')) {
+    return aPath
+  }
+
+  const sepIndex = aPath.indexOf(path.sep)
+  const user = (sepIndex < 0) ? aPath.substring(1) : aPath.substring(1, sepIndex)
+  const rest = (sepIndex < 0) ? '' : aPath.substring(sepIndex)
+  const home = (user === '') ? os.homedir() : (() => {
+    const passwd = passwdUser.sync(user);
+    if (passwd === undefined) {
+      throw new Error(`Failed to expand the tilde in ${aPath} - user "${user}" does not exist`)
+    }
+    return passwd.homedir
+  })()
+
+  return `${home}${rest}`
+}

--- a/script/lib/install-application.js
+++ b/script/lib/install-application.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const fs = require('fs-extra')
+const handleTilde = require('./handle-tilde')
 const path = require('path')
 const runas = require('runas')
 const template = require('lodash.template')
@@ -10,7 +11,7 @@ const CONFIG = require('../config')
 module.exports = function (packagedAppPath, installDir) {
   const packagedAppFileName = path.basename(packagedAppPath)
   if (process.platform === 'darwin') {
-    const installPrefix = installDir !== '' ? installDir : path.join(path.sep, 'Applications')
+    const installPrefix = installDir !== '' ? handleTilde(installDir) : path.join(path.sep, 'Applications')
     const installationDirPath = path.join(installPrefix, packagedAppFileName)
     if (fs.existsSync(installationDirPath)) {
       console.log(`Removing previously installed "${packagedAppFileName}" at "${installationDirPath}"`)
@@ -41,7 +42,7 @@ module.exports = function (packagedAppPath, installDir) {
     const apmExecutableName = CONFIG.channel === 'beta' ? 'apm-beta' : 'apm'
     const appName = CONFIG.channel === 'beta' ? 'Atom Beta' : 'Atom'
     const appDescription = CONFIG.appMetadata.description
-    const prefixDirPath = installDir !== '' ? installDir : path.join('/usr', 'local')
+    const prefixDirPath = installDir !== '' ? handleTilde(installDir) : path.join('/usr', 'local')
     const shareDirPath = path.join(prefixDirPath, 'share')
     const installationDirPath = path.join(shareDirPath, atomExecutableName)
     const applicationsDirPath = path.join(shareDirPath, 'applications')

--- a/script/package.json
+++ b/script/package.json
@@ -23,6 +23,7 @@
     "mkdirp": "0.5.1",
     "normalize-package-data": "2.3.5",
     "npm": "3.10.5",
+    "passwd-user": "2.1.0",
     "pegjs": "0.9.0",
     "runas": "3.1.1",
     "season": "5.3.0",


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Currently the `--install` flag of the `./script/build` is a boolean flag that either installs atom to some predefined location or skips it. This PR extends the flag so it can accept a value telling the script where to install atom. Passing just `--install` will behave as it used to so far, so it will install atom to `/usr/local` on linux and other default locations on darwin and windows. Same with not passing the flag - atom won't be installed. But passing `--install=/opt/atom` will install atom under the given location.

The documentation is updated accordingly.

### Alternate Designs

I haven't considered other designs, extending the `--install` flag looked natural to me.

### Why Should This Be In Core?

It's a part of the builder script, so it can't be a package.

### Benefits

One can install the code in the location of choice. (Like for flatpaks, we want to install atom under `/app`).

### Possible Drawbacks

It's backward compatible, so not sure if there are drawbacks.

### Applicable Issues

Didn't file any.
