### PR TITLE
Remove the buildTextEditor binding in workspace

### DIFF
--- a/src/workspace.js
+++ b/src/workspace.js
@@ -57,12 +57,6 @@ module.exports = class Workspace extends Model {
     this.defaultDirectorySearcher = new DefaultDirectorySearcher()
     this.consumeServices(this.packageManager)
 
-    // One cannot simply .bind here since it could be used as a component with
-    // Etch, in which case it'd be `new`d. And when it's `new`d, `this` is always
-    // the newly created object.
-    const realThis = this
-    this.buildTextEditor = (params) => Workspace.prototype.buildTextEditor.call(realThis, params)
-
     this.panelContainers = {
       top: new PanelContainer({location: 'top'}),
       left: new PanelContainer({location: 'left'}),


### PR DESCRIPTION
The comment was actually no longer accurate since arrow functions aren't newable. After doing an audit, @maxbrunsfeld determined that it could just be removed.