### PR TITLE
Add `AtomEnvironment.prototype.resolveProxy(url)`

### DIFF
--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -277,3 +277,14 @@ class ApplicationDelegate
 
   emitDidSavePath: (path) ->
     ipcRenderer.sendSync('did-save-path', path)
+
+  resolveProxy: (requestId, url) ->
+    ipcRenderer.send('resolve-proxy', requestId, url)
+
+  onDidResolveProxy: (callback) ->
+    outerCallback = (event, requestId, proxy) ->
+      callback(requestId, proxy)
+
+    ipcRenderer.on('did-resolve-proxy', outerCallback)
+    new Disposable ->
+      ipcRenderer.removeListener('did-resolve-proxy', outerCallback)

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -997,7 +997,7 @@ class AtomEnvironment extends Model
   resolveProxy: (url) ->
     return new Promise (resolve, reject) =>
       requestId = @nextProxyRequestId++
-      disposable = @applicationDelegate.onDidResolveProxy (id, proxy) =>
+      disposable = @applicationDelegate.onDidResolveProxy (id, proxy) ->
         if id is requestId
           disposable.dispose()
           resolve(proxy)

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -133,6 +133,7 @@ class AtomEnvironment extends Model
   constructor: (params={}) ->
     {@blobStore, @applicationDelegate, @window, @document, @clipboard, @configDirPath, @enablePersistence, onlyLoadBaseStyleSheets} = params
 
+    @nextProxyRequestId = 0
     @unloaded = false
     @loadTime = null
     {devMode, safeMode, resourcePath, clearWindowState} = @getLoadSettings()
@@ -992,6 +993,16 @@ class AtomEnvironment extends Model
         @workspace?.open(pathToOpen, {initialLine, initialColumn})
 
     return
+
+  resolveProxy: (url) ->
+    return new Promise (resolve, reject) =>
+      requestId = @nextProxyRequestId++
+      disposable = @applicationDelegate.onDidResolveProxy (id, proxy) =>
+        if id is requestId
+          disposable.dispose()
+          resolve(proxy)
+
+      @applicationDelegate.resolveProxy(requestId, url)
 
 # Preserve this deprecation until 2.0. Sorry. Should have removed Q sooner.
 Promise.prototype.done = (callback) ->

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -283,6 +283,9 @@ class AtomApplication
     @disposable.add ipcHelpers.on ipcMain, 'restart-application', =>
       @restart()
 
+    @disposable.add ipcHelpers.on ipcMain, 'resolve-proxy', (event, requestId, url) ->
+      event.sender.session.resolveProxy url, (proxy) -> event.sender.send('did-resolve-proxy', requestId, proxy)
+
     @disposable.add ipcHelpers.on ipcMain, 'did-change-history-manager', (event) =>
       for atomWindow in @windows
         webContents = atomWindow.browserWindow.webContents


### PR DESCRIPTION
This new private API will allow settings-view to communicate asynchronously with the main process to resolve proxies instead of using `remote` and blocking the renderer process during startup.

/cc: @atom/maintainers 