### PR TITLE
Adding 'Run Benchmark' menu item for win32 and linux platform

### DIFF
--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -137,6 +137,7 @@
           { label: 'Open In &Dev Mode…', command: 'application:open-dev' }
           { label: '&Reload Window', command: 'window:reload' }
           { label: 'Run Package &Specs', command: 'window:run-package-specs' }
+          { label: 'Run &Benchmarks', command: 'window:run-benchmarks' }
           { label: 'Toggle Developer &Tools', command: 'window:toggle-dev-tools' }
         ]
       }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -136,6 +136,7 @@
           { label: 'Open In &Dev Mode…', command: 'application:open-dev' }
           { label: '&Reload Window', command: 'window:reload' }
           { label: 'Run Package &Specs', command: 'window:run-package-specs' }
+          { label: 'Run &Benchmarks', command: 'window:run-benchmarks' }
           { label: 'Toggle Developer &Tools', command: 'window:toggle-dev-tools' }
         ]
       }


### PR DESCRIPTION
### Description of the Change

By latest comment in #12984 from @as-cii 
adding 'Run Benchmark' menu item for win32 and linux platform.
would be an enhancement.

Also use letter `B` as hotkey hint.

### Benefits

we can run benchmark via menu in win32 and linux platform.

### Applicable Issues

enhancement of #12984