### PR TITLE
Enhancement: More detailed snippets file

### DIFF
--- a/dot-atom/snippets.cson
+++ b/dot-atom/snippets.cson
@@ -15,6 +15,16 @@
 #
 # Each scope (e.g. '.source.coffee' above) can only be declared once.
 #
+# An example of using each scope with multiple snippets:
+#
+# '.text.html.basic':
+#   'Stylesheet':
+#     'prefix': 'stylesheet'
+#     'body': '<link rel="stylesheet" type="text/css" href="style.css" />'
+#   'Viewport Meta':
+#     'prefix': 'viewport'
+#     'body': '<meta name="viewport" content="width=device-width, initial-scale=1.0" />'
+#
 # This file uses CoffeeScript Object Notation (CSON).
 # If you are unfamiliar with CSON, you can read more about it in the
 # Atom Flight Manual:


### PR DESCRIPTION
### Description of the Change

A simple change to the description of the Atom snippets file to make it clearer and more detailed for users adding multiple snippets with the same source (e.g. source.coffee). 
The 'snip' shortcut automatically adds the 'source' field to the snippets template, making it seem like it needs to be included for every snippet.

### Alternate Designs

None.

### Why Should This Be In Core?

I found the instructions a lot less clear when starting out with Atom for the first time and using snippets. It was only after some trial and error and searching through the docs that I found the reason for the confusion was having multiple sources to each snippet. I feel this will make it a lit clearer.

### Benefits

Clearer understanding for new users who aren't familiar with Atom. Easier first time setup, not requiring a visit to the documentation to get up and running.

### Possible Drawbacks

None that come to mind.

### Applicable Issues

None.