### PR TITLE
quickly hide title-bar by config

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -551,6 +551,9 @@ class AtomEnvironment extends Model
   maximize: ->
     @applicationDelegate.maximizeWindow()
 
+  minimize: ->
+    @applicationDelegate.minimizeWindow()
+    
   # Extended: Returns a {Boolean} that is `true` if the current window is in full screen mode.
   isFullScreen: ->
     @applicationDelegate.isWindowFullScreen()

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -52,7 +52,7 @@ class AtomWindow
     if @shouldHideTitleBar()
       options.frame = false
 
-    if @froceHideTitleBar()
+    if @forceHideTitleBar()
       options.frame = false
 
     @browserWindow = new BrowserWindow(options)
@@ -257,8 +257,8 @@ class AtomWindow
     process.platform is 'darwin' and
     @atomApplication.config.get('core.titleBar') is 'hidden'
 
-  froceHideTitleBar: ->
-    @atomApplication.config.get('core.froceHideTitleBar') is true
+  forceHideTitleBar: ->
+    @atomApplication.config.get('core.forceHideTitleBar') is true
 
   close: -> @browserWindow.close()
 

--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -52,6 +52,9 @@ class AtomWindow
     if @shouldHideTitleBar()
       options.frame = false
 
+    if @froceHideTitleBar()
+      options.frame = false
+
     @browserWindow = new BrowserWindow(options)
     @handleEvents()
 
@@ -253,6 +256,9 @@ class AtomWindow
     not @isSpec and
     process.platform is 'darwin' and
     @atomApplication.config.get('core.titleBar') is 'hidden'
+
+  froceHideTitleBar: ->
+    @atomApplication.config.get('core.froceHideTitleBar') is true
 
   close: -> @browserWindow.close()
 


### PR DESCRIPTION
### Description of the Change

hi
first i add minimize function in `atom-environment.coffee` for use this command: `atom.minimize();`
two add `forceHideTitleBar` config. because designer need hide title-bar for beautiful develop atom.

### Why Should This Be In Core?

better design develop.

### Benefits

quick

### Possible Drawbacks

nothing

### Applicable Issues

nothing

________________________

### my customize [with this changes] demo:

![screenshot 42](https://cloud.githubusercontent.com/assets/8210666/23907919/bc570694-08e7-11e7-8757-24bc660cabb6.png)

[Video demo](http://g1.asset.aparat.com/flv_video_new/2243/536fa42b3fce3ee5d3275c8e09d31dda6726007-720p.apt?direct=1)

sry 4 my bad english
