### PR TITLE
More reliable way of stopping Babel stderr output on Windows

### DIFF
--- a/spec/babel-spec.coffee
+++ b/spec/babel-spec.coffee
@@ -36,15 +36,6 @@ describe "Babel transpiler support", ->
       transpiled = require('./fixtures/babel/babel-double-quotes.js')
       expect(transpiled(3)).toBe 4
 
-  describe 'when a .js file starts with /* @flow */', ->
-    it "transpiles it using babel", ->
-      transpiled = require('./fixtures/babel/flow-comment.js')
-      expect(transpiled(3)).toBe 4
-
-  describe "when a .js file does not start with 'use babel';", ->
-    it "does not transpile it using babel", ->
-      expect(-> require('./fixtures/babel/invalid.js')).toThrow()
-
     it "does not try to log to stdout or stderr while parsing the file", ->
       spyOn(process.stderr, 'write')
       spyOn(process.stdout, 'write')
@@ -53,3 +44,12 @@ describe "Babel transpiler support", ->
 
       expect(process.stdout.write).not.toHaveBeenCalled()
       expect(process.stderr.write).not.toHaveBeenCalled()
+
+  describe 'when a .js file starts with /* @flow */', ->
+    it "transpiles it using babel", ->
+      transpiled = require('./fixtures/babel/flow-comment.js')
+      expect(transpiled(3)).toBe 4
+
+  describe "when a .js file does not start with 'use babel';", ->
+    it "does not transpile it using babel", ->
+      expect(-> require('./fixtures/babel/invalid.js')).toThrow()

--- a/src/babel.js
+++ b/src/babel.js
@@ -44,11 +44,7 @@ exports.getCachePath = function (sourceCode) {
 exports.compile = function (sourceCode, filePath) {
   if (!babel) {
     babel = require('babel-core')
-    var Logger = require('babel-core/lib/transformation/file/logger')
-    var noop = function () {}
-    Logger.prototype.debug = noop
-    Logger.prototype.verbose = noop
-
+    require('debug').log = () => { } // Stop Babel logging to stdout/stderr (would error when no console attached)
     options = {ast: false, babelrc: false}
     for (var key in defaultOptions) {
       if (key === 'plugins') {


### PR DESCRIPTION
The debug module used by babel tends to throw stuff onto stderr and stdout when it feels like it.

This is a problem on Windows when Atom is launched from the UI and it doesn't have these attached - writing to them causes errors.

We previously had another fix in but it was quite dependent on the internals of Babel and broke. Hopefully this one lasts longer.