### PR TITLE
Use the generated snapshot source map in `source-map-support`

### DIFF
--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -58,7 +58,7 @@ module.exports = function (packagedAppPath) {
         relativePath == path.join('..', 'node_modules', 'tmp', 'lib', 'tmp.js')
       )
     }
-  }).then(({snapshotScript, sourceMap}) => {
+  }).then((snapshotScript) => {
     fs.writeFileSync(snapshotScriptPath, snapshotScript)
     process.stdout.write('\n')
 
@@ -72,23 +72,15 @@ module.exports = function (packagedAppPath) {
       [snapshotScriptPath, '--startup_blob', generatedStartupBlobPath]
     )
 
-    let startupBlobDestinationPath, startupBlobSourceMapDestinationPath
+    let startupBlobDestinationPath
     if (process.platform === 'darwin') {
       startupBlobDestinationPath = `${packagedAppPath}/Contents/Frameworks/Electron Framework.framework/Resources/snapshot_blob.bin`
-      startupBlobSourceMapDestinationPath = path.join(packagedAppPath, 'Contents', 'Resources', 'snapshot_sourcemap.json')
-    } else if (process.platform === 'linux') {
-      startupBlobDestinationPath = path.join(packagedAppPath, 'snapshot_blob.bin')
-      startupBlobSourceMapDestinationPath = path.join(packagedAppPath, 'resources', 'snapshot_sourcemap.json')
     } else {
       startupBlobDestinationPath = path.join(packagedAppPath, 'snapshot_blob.bin')
-      startupBlobSourceMapDestinationPath = path.join(packagedAppPath, 'resources', 'snapshot_sourcemap.json')
     }
 
     console.log(`Moving generated startup blob into "${startupBlobDestinationPath}"`)
     fs.unlinkSync(startupBlobDestinationPath)
     fs.renameSync(generatedStartupBlobPath, startupBlobDestinationPath)
-
-    console.log(`Moving generated startup blob sourcemap into "${startupBlobSourceMapDestinationPath}"`)
-    fs.writeFileSync(startupBlobSourceMapDestinationPath, sourceMap)
   })
 }

--- a/script/package.json
+++ b/script/package.json
@@ -8,7 +8,7 @@
     "csslint": "1.0.2",
     "donna": "1.0.13",
     "electron-chromedriver": "~1.3",
-    "electron-link": "0.0.18",
+    "electron-link": "0.0.19",
     "electron-mksnapshot": "~1.3",
     "electron-packager": "7.3.0",
     "electron-winstaller": "2.5.1",

--- a/script/package.json
+++ b/script/package.json
@@ -8,7 +8,7 @@
     "csslint": "1.0.2",
     "donna": "1.0.13",
     "electron-chromedriver": "~1.3",
-    "electron-link": "0.0.19",
+    "electron-link": "0.0.20",
     "electron-mksnapshot": "~1.3",
     "electron-packager": "7.3.0",
     "electron-winstaller": "2.5.1",

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -757,13 +757,10 @@ class AtomEnvironment extends Model
 
       {line, column, source} = mapSourcePosition({source: url, line, column})
 
-      mappedURL = ''
       if url is '<embedded>'
-        mappedURL = source
-      else
-        mappedURL = url
+        url = source
 
-      eventObject = {message, originalUrl: url, url: mappedURL, line, column, originalError}
+      eventObject = {message, url, line, column, originalError}
 
       openDevTools = true
       eventObject.preventDefault = -> openDevTools = false
@@ -773,7 +770,7 @@ class AtomEnvironment extends Model
       if openDevTools
         @openDevTools().then => @executeJavaScriptInDevTools('DevToolsAPI.showPanel("console")')
 
-      @emitter.emit 'did-throw-error', {message, originalURL: url, url: mappedURL, line, column, originalError}
+      @emitter.emit 'did-throw-error', {message, url, line, column, originalError}
 
   uninstallUncaughtErrorHandler: ->
     @window.onerror = @previousWindowErrorHandler

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -755,9 +755,15 @@ class AtomEnvironment extends Model
       @lastUncaughtError = Array::slice.call(arguments)
       [message, url, line, column, originalError] = @lastUncaughtError
 
-      {line, column} = mapSourcePosition({source: url, line, column})
+      {line, column, source} = mapSourcePosition({source: url, line, column})
 
-      eventObject = {message, url, line, column, originalError}
+      mappedURL = ''
+      if url is '<embedded>'
+        mappedURL = source
+      else
+        mappedURL = url
+
+      eventObject = {message, originalUrl: url, url: mappedURL, line, column, originalError}
 
       openDevTools = true
       eventObject.preventDefault = -> openDevTools = false
@@ -767,7 +773,7 @@ class AtomEnvironment extends Model
       if openDevTools
         @openDevTools().then => @executeJavaScriptInDevTools('DevToolsAPI.showPanel("console")')
 
-      @emitter.emit 'did-throw-error', {message, url, line, column, originalError}
+      @emitter.emit 'did-throw-error', {message, originalURL: url, url: mappedURL, line, column, originalError}
 
   uninstallUncaughtErrorHandler: ->
     @window.onerror = @previousWindowErrorHandler

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -113,7 +113,6 @@ function writeCachedJavascript (relativeCachePath, code) {
 }
 
 var INLINE_SOURCE_MAP_REGEXP = /\/\/[#@]\s*sourceMappingURL=([^'"\n]+)\s*$/mg
-let snapshotSourceMap = null
 
 exports.install = function (resourcesPath, nodeRequire) {
   sourceMapSupport.install({
@@ -125,7 +124,7 @@ exports.install = function (resourcesPath, nodeRequire) {
     retrieveSourceMap: function (filePath) {
       if (filePath === '<embedded>') {
         return {
-          map: snapshotResult.sourceMap,
+          map: snapshotResult.sourceMap, // eslint-disable-line no-undef
           url: path.join(resourcesPath, 'app', 'static', 'index.js')
         }
       }

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -113,6 +113,7 @@ function writeCachedJavascript (relativeCachePath, code) {
 }
 
 var INLINE_SOURCE_MAP_REGEXP = /\/\/[#@]\s*sourceMappingURL=([^'"\n]+)\s*$/mg
+let snapshotSourceMap = null
 
 exports.install = function (nodeRequire) {
   sourceMapSupport.install({
@@ -122,6 +123,18 @@ exports.install = function (nodeRequire) {
     // source-map-support module, but we've overridden it to read the javascript
     // code from our cache directory.
     retrieveSourceMap: function (filePath) {
+      if (filePath === '<embedded>') {
+        if (snapshotSourceMap == null) {
+          const snapshotSourceMapContent = fs.readFileSync(path.join(process.resourcesPath, 'snapshot_sourcemap.json'), 'utf8')
+          snapshotSourceMap = JSON.parse(snapshotSourceMapContent)
+        }
+
+        return {
+          map: snapshotSourceMap,
+          url: path.join(process.resourcesPath, 'app', 'static', 'index.js')
+        }
+      }
+
       if (!cacheDirectory || !fs.isFileSync(filePath)) {
         return null
       }

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -115,7 +115,7 @@ function writeCachedJavascript (relativeCachePath, code) {
 var INLINE_SOURCE_MAP_REGEXP = /\/\/[#@]\s*sourceMappingURL=([^'"\n]+)\s*$/mg
 let snapshotSourceMap = null
 
-exports.install = function (nodeRequire) {
+exports.install = function (resourcesPath, nodeRequire) {
   sourceMapSupport.install({
     handleUncaughtExceptions: false,
 
@@ -124,14 +124,9 @@ exports.install = function (nodeRequire) {
     // code from our cache directory.
     retrieveSourceMap: function (filePath) {
       if (filePath === '<embedded>') {
-        if (snapshotSourceMap == null) {
-          const snapshotSourceMapContent = fs.readFileSync(path.join(process.resourcesPath, 'snapshot_sourcemap.json'), 'utf8')
-          snapshotSourceMap = JSON.parse(snapshotSourceMapContent)
-        }
-
         return {
-          map: snapshotSourceMap,
-          url: path.join(process.resourcesPath, 'app', 'static', 'index.js')
+          map: snapshotResult.sourceMap,
+          url: path.join(resourcesPath, 'app', 'static', 'index.js')
         }
       }
 

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -83,5 +83,5 @@ function handleStartupEventWithSquirrel () {
 function setupCompileCache () {
   const CompileCache = require('../compile-cache')
   CompileCache.setAtomHomeDirectory(process.env.ATOM_HOME)
-  CompileCache.install(require)
+  CompileCache.install(process.resourcesPath, require)
 }

--- a/src/task.coffee
+++ b/src/task.coffee
@@ -76,7 +76,7 @@ class Task
 
       CompileCache = #{compileCacheRequire}
       CompileCache.setCacheDirectory('#{compileCachePath}');
-      CompileCache.install(require)
+      CompileCache.install("#{process.resourcesPath}", require)
       #{taskBootstrapRequire}
     """
     bootstrap = bootstrap.replace(/\\/g, "\\\\")

--- a/static/index.js
+++ b/static/index.js
@@ -90,7 +90,7 @@
   function setupWindow () {
     const CompileCache = useSnapshot ? snapshotResult.customRequire('../src/compile-cache.js') : require('../src/compile-cache') // eslint-disable-line no-undef
     CompileCache.setAtomHomeDirectory(process.env.ATOM_HOME)
-    CompileCache.install(require)
+    CompileCache.install(process.resourcesPath, require)
 
     const ModuleCache = useSnapshot ? snapshotResult.customRequire('../src/module-cache.js') : require('../src/module-cache') // eslint-disable-line no-undef
     ModuleCache.register(getWindowLoadSettings())


### PR DESCRIPTION
This will report the correct file and line numbers on stack traces instead of always showing `<embedded>:absoluteLineNumber`. As a result, it will also fix the `notifications` package, which will be able again to identify which package threw an exception and to create an issue on its repository.

/cc: @nathansobo @Ben3eeE 