### PR TITLE
Update CSS languages, autocomplete-css

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "language-python": "0.45.2",
     "language-ruby": "0.70.5",
     "language-ruby-on-rails": "0.25.2",
-    "language-sass": "0.58.0",
+    "language-sass": "0.59.0",
     "language-shellscript": "0.25.0",
     "language-source": "0.9.0",
     "language-sql": "0.25.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "language-java": "0.27.0",
     "language-javascript": "0.126.1",
     "language-json": "0.19.0",
-    "language-less": "0.31.0",
+    "language-less": "0.32.0",
     "language-make": "0.22.3",
     "language-mustache": "0.13.1",
     "language-objective-c": "0.15.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "about": "1.7.5",
     "archive-view": "0.63.1",
     "autocomplete-atom-api": "0.10.1",
-    "autocomplete-css": "0.15.2",
+    "autocomplete-css": "0.16.0",
     "autocomplete-html": "0.7.3",
     "autocomplete-plus": "2.35.0",
     "autocomplete-snippets": "1.11.0",


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

language-less and language-sass now use the property names and values in language-css to keep the languages more in sync.  Credit goes to @Alhadis.  Some issues with Sass have been fixed as well (most notably: Sass's custom property-list syntax is now tokenized properly).
autocomplete-css now has considerably better descriptions on a good portion of the property names.

### Alternate Designs

None.

### Why Should This Be In Core?

Core packages.

### Benefits

It should be easier to propagate property name and value changes across the three CSS languages now.  No more wacky autocomplete descriptions (or at least, a lot less).

### Possible Drawbacks

There may be some Sass (not SCSS) regressions.

### Applicable Issues

None.

Will merge when green.