### PR TITLE
Add `saveFocusedPaneItem()` and call it in "core:save" command

### DIFF
--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -1872,6 +1872,38 @@ i = /test/; #FIXME\
     })
   })
 
+  describe('::saveFocusedPaneItem', () => {
+    let editor, workspaceElement
+
+    beforeEach(() => {
+      workspaceElement = atom.views.getView(atom.workspace)
+      document.body.appendChild(workspaceElement)
+      waitsForPromise(() => atom.workspace.open('a').then(o => { editor = o }))
+    })
+
+    afterEach(() => {
+      workspaceElement.remove()
+    })
+
+    it("calls the focused item's save method", () => {
+      spyOn(editor, 'save')
+      editor.getElement().focus()
+      atom.workspace.saveFocusedPaneItem()
+      expect(editor.save).toHaveBeenCalled()
+    })
+
+    it("doesn't save the active editor if it's not focused", () => {
+      spyOn(editor, 'save')
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+      expect(document.activeElement).toBe(input)
+      atom.workspace.saveFocusedPaneItem()
+      expect(editor.save).not.toHaveBeenCalled()
+      input.remove()
+    })
+  })
+
   describe('::saveActivePaneItem()', () => {
     let editor = null
     beforeEach(() =>

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -77,8 +77,8 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
       'window:toggle-auto-indent': -> config.set("editor.autoIndent", not config.get("editor.autoIndent"))
       'pane:reopen-closed-item': -> @getModel().reopenItem()
       'core:close': -> @getModel().closeActivePaneItemOrEmptyPaneOrWindow()
-      'core:save': -> @getModel().saveActivePaneItem()
-      'core:save-as': -> @getModel().saveActivePaneItemAs()
+      'core:save': -> @getModel().saveFocusedPaneItem()
+      'core:save-as': -> @getModel().saveFocusedPaneItemAs()
     },
     false
   )

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -10,6 +10,7 @@ const DefaultDirectorySearcher = require('./default-directory-searcher')
 const Model = require('./model')
 const TextEditor = require('./text-editor')
 const PaneContainer = require('./pane-container')
+const Pane = require('./pane')
 const Panel = require('./panel')
 const PanelContainer = require('./panel-container')
 const Task = require('./task')
@@ -863,7 +864,7 @@ module.exports = class Workspace extends Model {
   // {::saveActivePaneItemAs} # will be called instead. This method does nothing
   // if the active item does not implement a `.save` method.
   saveActivePaneItem () {
-    return this.getActivePane().saveActiveItem()
+    this.getActivePane().saveActiveItem()
   }
 
   // Prompt the user for a path and save the active pane item to it.
@@ -872,7 +873,43 @@ module.exports = class Workspace extends Model {
   // `.saveAs` on the item with the selected path. This method does nothing if
   // the active item does not implement a `.saveAs` method.
   saveActivePaneItemAs () {
-    return this.getActivePane().saveActiveItemAs()
+    this.getActivePane().saveActiveItemAs()
+  }
+
+  getFocusedPane () {
+    let el = document.activeElement
+    while (el != null) {
+      if (typeof el.getModel === 'function') {
+        const model = el.getModel()
+        if (model instanceof Pane) return model
+      }
+      el = el.parentElement
+    }
+  }
+
+  // Save the currently focused pane item.
+  //
+  // If the focused pane item currently has a URI according to the item's
+  // `.getURI` method, calls `.save` on the item. Otherwise
+  // {::saveFocusedPaneItemAs} will be called instead. This method does nothing
+  // if the focused item does not implement a `.save` method.
+  saveFocusedPaneItem () {
+    const pane = this.getFocusedPane()
+    if (pane) {
+      pane.saveActiveItem()
+    }
+  }
+
+  // Prompt the user for a path and save the focused pane item to it.
+  //
+  // Opens a native dialog where the user selects a path on disk, then calls
+  // `.saveAs` on the item with the selected path. This method does nothing if
+  // the focused item does not implement a `.saveAs` method.
+  saveFocusedPaneItemAs () {
+    const pane = this.getFocusedPane()
+    if (pane) {
+      pane.saveActiveItemAs()
+    }
   }
 
   // Destroy (close) the active pane item.


### PR DESCRIPTION
### Description of the Change

Add methods that chose what to save based on focus (instead of the active pane). This behavior change means that pane items in docks (#13977) will be savable too.

### Alternate Designs

The alternate we considered was having a single method which attempted to use the focused pane and then fell back to the active one, however this one was chosen because it's more predictable (i.e. doesn't depend on a state the user may not understand intuitively).

### Benefits

Editors in docks can be saved!

### Possible Drawbacks

Some may be relying on the current behavior, and use the command when an editor isn't active.

cc @nathansobo @maxbrunsfeld 