### PR TITLE
fixing middle mouse button clipboard paste on linux (atom:atom#8648)

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -5019,6 +5019,35 @@ describe('TextEditorComponent', function () {
       expect(atom.clipboard.read()).toBe('sort')
       expect(editor.lineTextForBufferRow(10)).toBe('sort')
     })
+
+    it('pastes the previously selected text at the clicked location, left clicks do not interfere', async function () {
+      let clipboardWrittenTo = false
+      spyOn(require('electron').ipcRenderer, 'send').andCallFake(function (eventName, selectedText) {
+        if (eventName === 'write-text-to-selection-clipboard') {
+          require('../src/safe-clipboard').writeText(selectedText, 'selection')
+          clipboardWrittenTo = true
+        }
+      })
+      atom.clipboard.write('')
+      component.trackSelectionClipboard()
+      editor.setSelectedBufferRange([[1, 6], [1, 10]])
+      advanceClock(0)
+
+      componentNode.querySelector('.scroll-view').dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenPosition([10, 0]), {
+        button: 0
+      }))
+      componentNode.querySelector('.scroll-view').dispatchEvent(buildMouseEvent('mouseup', clientCoordinatesForScreenPosition([10, 0]), {
+        which: 1
+      }))
+      componentNode.querySelector('.scroll-view').dispatchEvent(buildMouseEvent('mousedown', clientCoordinatesForScreenPosition([10, 0]), {
+        button: 1
+      }))
+      componentNode.querySelector('.scroll-view').dispatchEvent(buildMouseEvent('mouseup', clientCoordinatesForScreenPosition([10, 0]), {
+        which: 2
+      }))
+      expect(atom.clipboard.read()).toBe('sort')
+      expect(editor.lineTextForBufferRow(10)).toBe('sort')
+    })
   })
 
   function buildMouseEvent (type, ...propertiesObjects) {


### PR DESCRIPTION
### Description of the Change

The functionality of pasting the clipboard on middle mouse click on Linux has been moved from `onMouseUp` to `onMouseDown`. Now it is consistent with the general behavior on Linux. Also, there was some interplay of this functionality with dragging, which resulted in issue #8648. This is resolved now.

### Alternate Designs

None

### Why Should This Be In Core?

Addresses a bug in Core.

### Benefits

Resolution of issue #8648 and consistency of UI behavior with other Linux applications.

### Possible Drawbacks

None

### Applicable Issues

#8648
