### PR TITLE
Packages preloading

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "grammar-selector": "0.49.4",
     "image-view": "0.61.2",
     "incompatible-packages": "0.27.2",
-    "keybinding-resolver": "0.37.0",
+    "keybinding-resolver": "0.38.0",
     "line-ending-selector": "0.6.3",
     "link": "0.31.3",
     "markdown-preview": "0.159.10",

--- a/script/lib/generate-metadata.js
+++ b/script/lib/generate-metadata.js
@@ -48,7 +48,7 @@ function buildBundledPackagesMetadata () {
       }
     }
 
-    const packageNewMetadata = {metadata: packageMetadata, keymaps: {}, menus: {}, grammarPaths: []}
+    const packageNewMetadata = {metadata: packageMetadata, keymaps: {}, menus: {}, grammarPaths: [], settings: {}}
 
     packageNewMetadata.rootDirPath = path.relative(CONFIG.intermediateAppPath, packagePath)
 
@@ -83,6 +83,12 @@ function buildBundledPackagesMetadata () {
     for (let packageGrammarPath of fs.listSync(packageGrammarsPath, ['json', 'cson'])) {
       const relativePath = path.relative(CONFIG.intermediateAppPath, packageGrammarPath)
       packageNewMetadata.grammarPaths.push(relativePath)
+    }
+
+    const packageSettingsPath = path.join(packagePath, 'settings')
+    for (let packageSettingPath of fs.listSync(packageSettingsPath, ['json', 'cson'])) {
+      const relativePath = path.relative(CONFIG.intermediateAppPath, packageSettingPath)
+      packageNewMetadata.settings[relativePath] = CSON.readFileSync(packageSettingPath)
     }
 
     const packageStyleSheetsPath = path.join(packagePath, 'styles')

--- a/script/lib/generate-metadata.js
+++ b/script/lib/generate-metadata.js
@@ -114,7 +114,7 @@ function buildBundledPackagesMetadata () {
     }
 
     packageNewMetadata.styleSheetPaths =
-      styleSheets.map(styleSheetPath => path.relative(CONFIG.intermediateAppPath, styleSheetPath))
+      styleSheets.map(styleSheetPath => path.relative(packagePath, styleSheetPath))
 
     packages[packageMetadata.name] = packageNewMetadata
     if (packageModuleCache.extensions) {

--- a/script/lib/generate-metadata.js
+++ b/script/lib/generate-metadata.js
@@ -48,7 +48,7 @@ function buildBundledPackagesMetadata () {
       }
     }
 
-    const packageNewMetadata = {metadata: packageMetadata, keymaps: {}, menus: {}}
+    const packageNewMetadata = {metadata: packageMetadata, keymaps: {}, menus: {}, grammarPaths: []}
 
     packageNewMetadata.rootDirPath = path.relative(CONFIG.intermediateAppPath, packagePath)
 
@@ -79,6 +79,12 @@ function buildBundledPackagesMetadata () {
       }
     }
 
+    const packageGrammarsPath = path.join(packagePath, 'grammars')
+    for (let packageGrammarPath of fs.listSync(packageGrammarsPath, ['json', 'cson'])) {
+      const relativePath = path.relative(CONFIG.intermediateAppPath, packageGrammarPath)
+      packageNewMetadata.grammarPaths.push(relativePath)
+    }
+
     const packageStyleSheetsPath = path.join(packagePath, 'styles')
     let styleSheets = null
     if (packageMetadata.mainStyleSheet) {
@@ -97,7 +103,7 @@ function buildBundledPackagesMetadata () {
     }
 
     packageNewMetadata.styleSheetPaths =
-      styleSheets.map(styleSheetPath => path.relative(packagePath, styleSheetPath))
+      styleSheets.map(styleSheetPath => path.relative(CONFIG.intermediateAppPath, styleSheetPath))
 
     packages[packageMetadata.name] = packageNewMetadata
     if (packageModuleCache.extensions) {

--- a/script/lib/generate-metadata.js
+++ b/script/lib/generate-metadata.js
@@ -55,6 +55,11 @@ function buildBundledPackagesMetadata () {
     if (packageMetadata.main) {
       const mainPath = require.resolve(path.resolve(packagePath, packageMetadata.main))
       packageNewMetadata.main = path.relative(path.join(CONFIG.intermediateAppPath, 'static'), mainPath)
+      // Convert backward slashes to forward slashes in order to allow package
+      // main modules to be required from the snapshot. This is because we use
+      // forward slashes to cache the sources in the snapshot, so we need to use
+      // them here as well.
+      packageNewMetadata.main = packageNewMetadata.main.replace(/\\/g, '/')
     }
 
     const packageKeymapsPath = path.join(packagePath, 'keymaps')

--- a/script/lib/generate-metadata.js
+++ b/script/lib/generate-metadata.js
@@ -49,9 +49,12 @@ function buildBundledPackagesMetadata () {
     }
 
     const packageNewMetadata = {metadata: packageMetadata, keymaps: {}, menus: {}}
+
+    packageNewMetadata.rootDirPath = path.relative(CONFIG.intermediateAppPath, packagePath)
+
     if (packageMetadata.main) {
       const mainPath = require.resolve(path.resolve(packagePath, packageMetadata.main))
-      packageNewMetadata.main = path.relative(CONFIG.intermediateAppPath, mainPath)
+      packageNewMetadata.main = path.relative(path.join(CONFIG.intermediateAppPath, 'static'), mainPath)
     }
 
     const packageKeymapsPath = path.join(packagePath, 'keymaps')

--- a/script/package.json
+++ b/script/package.json
@@ -9,7 +9,7 @@
     "csslint": "1.0.2",
     "donna": "1.0.13",
     "electron-chromedriver": "~1.3",
-    "electron-link": "0.0.20",
+    "electron-link": "0.0.21",
     "electron-mksnapshot": "~1.3",
     "electron-packager": "7.3.0",
     "electron-winstaller": "2.5.1",

--- a/spec/package-manager-spec.coffee
+++ b/spec/package-manager-spec.coffee
@@ -36,7 +36,7 @@ describe "PackageManager", ->
 
   describe "::loadPackages()", ->
     beforeEach ->
-      spyOn(atom.packages, 'loadPackage')
+      spyOn(atom.packages, 'loadAvailablePackage')
 
     afterEach ->
       atom.packages.deactivatePackages()

--- a/spec/package-spec.coffee
+++ b/spec/package-spec.coffee
@@ -11,8 +11,7 @@ describe "Package", ->
       keymapManager: atom.keymaps, commandRegistry: atom.command,
       grammarRegistry: atom.grammars, themeManager: atom.themes,
       menuManager: atom.menu, contextMenuManager: atom.contextMenu,
-      deserializerManager: atom.deserializers, viewRegistry: atom.views,
-      devMode: false
+      deserializerManager: atom.deserializers, viewRegistry: atom.views
     )
 
   buildPackage = (packagePath) -> build(Package, packagePath)
@@ -21,7 +20,11 @@ describe "Package", ->
 
   describe "when the package contains incompatible native modules", ->
     beforeEach ->
+      atom.packages.devMode = false
       mockLocalStorage()
+
+    afterEach ->
+      atom.packages.devMode = true
 
     it "does not activate it", ->
       packagePath = atom.project.getDirectories()[0].resolve('packages/package-with-incompatible-native-module')
@@ -64,7 +67,11 @@ describe "Package", ->
 
   describe "::rebuild()", ->
     beforeEach ->
+      atom.packages.devMode = false
       mockLocalStorage()
+
+    afterEach ->
+      atom.packages.devMode = true
 
     it "returns a promise resolving to the results of `apm rebuild`", ->
       packagePath = atom.project.getDirectories()[0]?.resolve('packages/package-with-index')

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -259,6 +259,9 @@ class AtomEnvironment extends Model
     @history.initialize(@window.localStorage)
     @disposables.add @applicationDelegate.onDidChangeHistoryManager(=> @history.loadState())
 
+  preloadPackages: ->
+    @packages.preloadPackages()
+
   attachSaveStateListeners: ->
     saveState = _.debounce((=>
       window.requestIdleCallback => @saveState({isUnloading: false}) unless @unloaded

--- a/src/initialize-application-window.coffee
+++ b/src/initialize-application-window.coffee
@@ -58,11 +58,13 @@ require('wrap-guide')
 clipboard = new Clipboard
 TextEditor.setClipboard(clipboard)
 
-window.atom = new AtomEnvironment({
+global.atom = new AtomEnvironment({
   clipboard,
   applicationDelegate: new ApplicationDelegate,
   enablePersistence: true
 })
+
+global.atom.preloadPackages()
 
 # Like sands through the hourglass, so are the days of our lives.
 module.exports = ({blobStore}) ->
@@ -82,13 +84,13 @@ module.exports = ({blobStore}) ->
   # Make React faster
   process.env.NODE_ENV ?= 'production' unless devMode
 
-  window.atom.initialize({
+  global.atom.initialize({
     window, document, blobStore,
     configDirPath: process.env.ATOM_HOME,
     env: process.env
   })
 
-  window.atom.startEditorWindow().then ->
+  global.atom.startEditorWindow().then ->
     # Workaround for focus getting cleared upon window creation
     windowFocused = ->
       window.removeEventListener('focus', windowFocused)

--- a/src/keymap-extensions.coffee
+++ b/src/keymap-extensions.coffee
@@ -17,7 +17,7 @@ KeymapManager::canLoadBundledKeymapsFromMemory = ->
 KeymapManager::loadBundledKeymaps = ->
   if bundledKeymaps?
     for keymapName, keymap of bundledKeymaps
-      keymapPath = "core/#{keymapName}"
+      keymapPath = "core:#{keymapName}"
       @add(keymapPath, keymap, 0, @devMode ? false)
   else
     keymapsPath = path.join(@resourcePath, 'keymaps')

--- a/src/menu-manager.coffee
+++ b/src/menu-manager.coffee
@@ -94,7 +94,7 @@ class MenuManager
   add: (items) ->
     items = _.deepClone(items)
     @merge(@template, item) for item in items
-    @update() if @initialized
+    @update()
     new Disposable => @remove(items)
 
   remove: (items) ->
@@ -147,6 +147,8 @@ class MenuManager
 
   # Public: Refreshes the currently visible menu.
   update: ->
+    return unless @initialized
+
     clearImmediate(@pendingUpdateOperation) if @pendingUpdateOperation?
 
     @pendingUpdateOperation = setImmediate =>

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -294,7 +294,7 @@ class PackageManager
 
   # Public: Returns an {Array} of {String}s of all the available package names.
   getAvailablePackageNames: ->
-    @getAvailablePackages().sort((a) -> a.name)
+    @getAvailablePackages().map((a) -> a.name)
 
   # Public: Returns an {Array} of {String}s of all the available package metadata.
   getAvailablePackageMetadata: ->

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -390,7 +390,7 @@ class PackageManager
       options = {
         path: pack.rootDirPath, name: packageName, preloadedPackage: true,
         bundledPackage: true, metadata, packageManager: this, @config,
-        @styleManager, @commandRegistry, @keymapManager, @devMode,
+        @styleManager, @commandRegistry, @keymapManager,
         @notificationManager, @grammarRegistry, @themeManager, @menuManager,
         @contextMenuManager, @deserializerManager, @viewRegistry
       }
@@ -454,7 +454,7 @@ class PackageManager
       options = {
         path: availablePackage.path, name: availablePackage.name, metadata,
         bundledPackage: availablePackage.isBundled, packageManager: this,
-        @config, @styleManager, @commandRegistry, @keymapManager, @devMode,
+        @config, @styleManager, @commandRegistry, @keymapManager,
         @notificationManager, @grammarRegistry, @themeManager, @menuManager,
         @contextMenuManager, @deserializerManager, @viewRegistry
       }

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -410,7 +410,11 @@ class PackageManager
     disabledPackageNames = new Set(@config.get('core.disabledPackages'))
     @config.transact =>
       for pack in @getAvailablePackages()
-        unless disabledPackageNames.has(pack.name)
+        if disabledPackageNames.has(pack.name)
+          if preloadedPackage = @preloadedPackages[pack.name]
+            preloadedPackage.deactivate()
+            delete preloadedPackage[pack.name]
+        else
           @loadAvailablePackage(pack)
       return
     @initialPackagesLoaded = true

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -388,11 +388,11 @@ class PackageManager
         metadata.repository.url = metadata.repository.url.replace(/(^git\+)|(\.git$)/g, '')
 
       options = {
-        path: pack.rootDirPath, name: packageName, bundledPackage: true, metadata,
-        packageManager: this, @config, @styleManager, @commandRegistry,
-        @keymapManager, @devMode, @notificationManager, @grammarRegistry,
-        @themeManager, @menuManager, @contextMenuManager, @deserializerManager,
-        @viewRegistry
+        path: pack.rootDirPath, name: packageName, preloadedPackage: true,
+        bundledPackage: true, metadata, packageManager: this, @config,
+        @styleManager, @commandRegistry, @keymapManager, @devMode,
+        @notificationManager, @grammarRegistry, @themeManager, @menuManager,
+        @contextMenuManager, @deserializerManager, @viewRegistry
       }
       if metadata.theme
         pack = new ThemePackage(options)

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -433,13 +433,20 @@ class PackageManager
       null
 
   loadAvailablePackage: (availablePackage) ->
-    if preloadedPackage = @preloadedPackages[availablePackage.name]
-      preloadedPackage.finishLoading()
-      @loadedPackages[availablePackage.name] = preloadedPackage
-      preloadedPackage
-    else if loadedPackage = @getLoadedPackage(availablePackage.name)
+    loadedPackage = @getLoadedPackage(availablePackage.name)
+    if loadedPackage?
       loadedPackage
     else
+      preloadedPackage = @preloadedPackages[availablePackage.name]
+      if preloadedPackage?
+        if availablePackage.isBundled
+          preloadedPackage.finishLoading()
+          @loadedPackages[availablePackage.name] = preloadedPackage
+          return preloadedPackage
+        else
+          preloadedPackage.deactivate()
+          delete preloadedPackage[availablePackage.name]
+
       try
         metadata = @loadPackageMetadata(availablePackage) ? {}
       catch error

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -100,6 +100,7 @@ class Package
 
   finishLoading: ->
     @measure 'loadTime', =>
+      @path = path.join(@packageManager.resourcePath, @path)
       @loadStylesheets()
 
   load: ->
@@ -337,22 +338,14 @@ class Package
     return
 
   getKeymapPaths: ->
-    if @bundledPackage and not @packageManager.devMode
-      keymapsDirPath = path.join(@packageManager.resourcePath, 'keymaps')
-    else
-      keymapsDirPath = path.join(@path, 'keymaps')
-
+    keymapsDirPath = path.join(@path, 'keymaps')
     if @metadata.keymaps
       @metadata.keymaps.map (name) -> fs.resolve(keymapsDirPath, name, ['json', 'cson', ''])
     else
       fs.listSync(keymapsDirPath, ['cson', 'json'])
 
   getMenuPaths: ->
-    if @bundledPackage and not @packageManager.devMode
-      menusDirPath = path.join(@packageManager.resourcePath, 'menus')
-    else
-      menusDirPath = path.join(@path, 'menus')
-
+    menusDirPath = path.join(@path, 'menus')
     if @metadata.menus
       @metadata.menus.map (name) -> fs.resolve(menusDirPath, name, ['json', 'cson', ''])
     else
@@ -394,15 +387,12 @@ class Package
       @registeredViewProviders = true
 
   getStylesheetsPath: ->
-    if @bundledPackage and not @packageManager.devMode
-      path.join(@packageManager.resourcePath, 'styles')
-    else
-      path.join(@path, 'styles')
+    path.join(@path, 'styles')
 
   getStylesheetPaths: ->
-    if @bundledPackage and not @packageManager.devMode and @packageManager.packagesCache[@name]?.styleSheetPaths?
+    if @bundledPackage and @packageManager.packagesCache[@name]?.styleSheetPaths?
       styleSheetPaths = @packageManager.packagesCache[@name].styleSheetPaths
-      styleSheetPaths.map (styleSheetPath) => path.resolve(@packageManager.resourcePath, styleSheetPath)
+      styleSheetPaths.map (styleSheetPath) => path.join(@path, styleSheetPath)
     else
       stylesheetDirPath = @getStylesheetsPath()
       if @metadata.mainStyleSheet
@@ -611,10 +601,7 @@ class Package
             @activationCommandSubscriptions.add @commandRegistry.add selector, command, ->
           catch error
             if error.code is 'EBADSELECTOR'
-              if @bundledPackage and not @packageManager.devMode
-                metadataPath = path.resolve(@packageManager.resourcePath, @path, 'package.json')
-              else
-                metadataPath = path.join(@path, 'package.json')
+              metadataPath = path.join(@path, 'package.json')
               error.message += " in #{metadataPath}"
               error.stack += "\n  at #{metadataPath}:1:1"
             throw error
@@ -685,10 +672,7 @@ class Package
     if @metadata._atomModuleCache?
       relativeNativeModuleBindingPaths = @metadata._atomModuleCache.extensions?['.node'] ? []
       for relativeNativeModuleBindingPath in relativeNativeModuleBindingPaths
-        if @bundledPackage and not @packageManager.devMode
-          nativeModulePath = path.resolve(@packageManager.resourcePath, @path, relativeNativeModuleBindingPath, '..', '..', '..')
-        else
-          nativeModulePath = path.join(@path, relativeNativeModuleBindingPath, '..', '..', '..')
+        nativeModulePath = path.join(@path, relativeNativeModuleBindingPath, '..', '..', '..')
         nativeModulePaths.push(nativeModulePath)
       return nativeModulePaths
 
@@ -699,11 +683,7 @@ class Package
           traversePath(path.join(modulePath, 'node_modules'))
       return
 
-    if @bundledPackage and not @packageManager.devMode
-      traversePath(path.resolve(@packageManager.resourcePath, @path, 'node_modules'))
-    else
-      traversePath(path.join(@path, 'node_modules'))
-
+    traversePath(path.join(@path, 'node_modules'))
     nativeModulePaths
 
   ###

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -33,15 +33,15 @@ class Package
 
   constructor: (params) ->
     {
-      @path, @metadata, @packageManager, @config, @styleManager, @commandRegistry,
+      @path, @metadata, @bundledPackage, @packageManager, @config, @styleManager, @commandRegistry,
       @keymapManager, @devMode, @notificationManager, @grammarRegistry, @themeManager,
       @menuManager, @contextMenuManager, @deserializerManager, @viewRegistry
     } = params
 
     @emitter = new Emitter
     @metadata ?= @packageManager.loadPackageMetadata(@path)
-    @bundledPackage = @packageManager.isBundledPackagePath(@path)
-    @name = @metadata?.name ? path.basename(@path)
+    @bundledPackage ?= @packageManager.isBundledPackagePath(@path)
+    @name = @metadata?.name ? params.name ? path.basename(@path)
     unless @bundledPackage
       ModuleCache.add(@path, @metadata)
     @reset()

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -325,14 +325,14 @@ class Package
 
   loadKeymaps: ->
     if @bundledPackage and @packageManager.packagesCache[@name]?
-      @keymaps = (["core/#{keymapPath}", keymapObject] for keymapPath, keymapObject of @packageManager.packagesCache[@name].keymaps)
+      @keymaps = (["core:#{keymapPath}", keymapObject] for keymapPath, keymapObject of @packageManager.packagesCache[@name].keymaps)
     else
       @keymaps = @getKeymapPaths().map (keymapPath) -> [keymapPath, CSON.readFileSync(keymapPath, allowDuplicateKeys: false) ? {}]
     return
 
   loadMenus: ->
     if @bundledPackage and @packageManager.packagesCache[@name]?
-      @menus = (["core/#{menuPath}", menuObject] for menuPath, menuObject of @packageManager.packagesCache[@name].menus)
+      @menus = (["core:#{menuPath}", menuObject] for menuPath, menuObject of @packageManager.packagesCache[@name].menus)
     else
       @menus = @getMenuPaths().map (menuPath) -> [menuPath, CSON.readFileSync(menuPath) ? {}]
     return
@@ -476,7 +476,7 @@ class Package
     new Promise (resolve) =>
       if @preloadedPackage
         for settingsPath, scopedProperties of @packageManager.packagesCache[@name].settings
-          settings = new ScopedProperties("core/#{settingsPath}", scopedProperties ? {}, @config)
+          settings = new ScopedProperties("core:#{settingsPath}", scopedProperties ? {}, @config)
           @settings.push(settings)
           settings.activate() if @settingsActivated
         resolve()

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -407,13 +407,13 @@ class Package
   loadGrammarsSync: ->
     return if @grammarsLoaded
 
-    if @bundledPackage and not @packageManager.devMode
+    if @preloadedPackage
       grammarPaths = @packageManager.packagesCache[@name].grammarPaths
     else
       grammarPaths = fs.listSync(path.join(@path, 'grammars'), ['json', 'cson'])
 
     for grammarPath in grammarPaths
-      if @bundledPackage and not @packageManager.devMode
+      if @preloadedPackage
         grammarPath = path.resolve(@packageManager.resourcePath, grammarPath)
 
       try
@@ -432,7 +432,7 @@ class Package
     return Promise.resolve() if @grammarsLoaded
 
     loadGrammar = (grammarPath, callback) =>
-      if @bundledPackage and not @packageManager.devMode
+      if @preloadedPackage
         grammarPath = path.resolve(@packageManager.resourcePath, grammarPath)
 
       @grammarRegistry.readGrammar grammarPath, (error, grammar) =>
@@ -448,7 +448,7 @@ class Package
         callback()
 
     new Promise (resolve) =>
-      if @bundledPackage and not @packageManager.devMode
+      if @preloadedPackage
         grammarPaths = @packageManager.packagesCache[@name].grammarPaths
         async.each grammarPaths, loadGrammar, -> resolve()
       else
@@ -474,7 +474,7 @@ class Package
         callback()
 
     new Promise (resolve) =>
-      if @bundledPackage and not @packageManager.devMode
+      if @preloadedPackage
         for settingsPath, scopedProperties of @packageManager.packagesCache[@name].settings
           settings = new ScopedProperties("core/#{settingsPath}", scopedProperties ? {}, @config)
           @settings.push(settings)
@@ -699,8 +699,8 @@ class Package
   isCompatible: ->
     return @compatible if @compatible?
 
-    if @bundledPackage and not @packageManager.devMode
-      # Bundled packages are always considered compatible
+    if @preloadedPackage
+      # Preloaded packages are always considered compatible
       @compatible = true
     else if @getMainModulePath()
       @incompatibleModules = @getIncompatibleNativeModules()

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -34,7 +34,7 @@ class Package
   constructor: (params) ->
     {
       @path, @metadata, @bundledPackage, @preloadedPackage, @packageManager, @config, @styleManager, @commandRegistry,
-      @keymapManager, @devMode, @notificationManager, @grammarRegistry, @themeManager,
+      @keymapManager, @notificationManager, @grammarRegistry, @themeManager,
       @menuManager, @contextMenuManager, @deserializerManager, @viewRegistry
     } = params
 
@@ -719,7 +719,7 @@ class Package
   isCompatible: ->
     return @compatible if @compatible?
 
-    if @bundledPackage and not @devMode
+    if @bundledPackage and not @packageManager.devMode
       # Bundled packages are always considered compatible
       @compatible = true
     else if @getMainModulePath()
@@ -780,7 +780,7 @@ class Package
   # This information is cached in local storage on a per package/version basis
   # to minimize the impact on startup time.
   getIncompatibleNativeModules: ->
-    unless @devMode
+    unless @packageManager.devMode
       try
         if arrayAsString = global.localStorage.getItem(@getIncompatibleNativeModulesStorageKey())
           return JSON.parse(arrayAsString)

--- a/src/theme-package.coffee
+++ b/src/theme-package.coffee
@@ -1,3 +1,4 @@
+path = require 'path'
 Package = require './package'
 
 module.exports =
@@ -17,7 +18,7 @@ class ThemePackage extends Package
     @configSchemaRegisteredOnLoad = @registerConfigSchemaFromMetadata()
 
   finishLoading: ->
-
+    @path = path.join(@packageManager.resourcePath, @path)
 
   load: ->
     @loadTime = 0

--- a/src/theme-package.coffee
+++ b/src/theme-package.coffee
@@ -12,6 +12,13 @@ class ThemePackage extends Package
   disable: ->
     @config.removeAtKeyPath('core.themes', @name)
 
+  preload: ->
+    @loadTime = 0
+    @configSchemaRegisteredOnLoad = @registerConfigSchemaFromMetadata()
+
+  finishLoading: ->
+
+
   load: ->
     @loadTime = 0
     @configSchemaRegisteredOnLoad = @registerConfigSchemaFromMetadata()


### PR DESCRIPTION
This pull request aims at reducing bundled packages loading and activation time even further by preloading them. During the snapshot phase, in fact, Atom will now scan all the core packages and load their main module, keymaps, menus, and settings. Later, at runtime, it will finish loading those packages by compiling their style sheets, calling `activate` on them, etc.

In addition, this pull request improves the way packages are resolved and, as a result, minimizes the I/O cost associated to it. Previously, in fact, because of the way the code was structured, we would get the list of package directories and constantly issue a `resolvePackagePath` for each of them. This, in turn, would unnecessarily verify again that each path was a directory, thus querying the file system and blocking the main thread. After these changes, we will perform that I/O just once and return a javascript object which contains all the information needed to load the associated package without extra cost.

On master, this is how loading and activating packages looks like:

![screen shot 2017-03-28 at 12 10 41](https://cloud.githubusercontent.com/assets/482957/24405701/1c772f16-13c6-11e7-9748-e5fe694c922c.png)

![screen shot 2017-03-28 at 12 09 41](https://cloud.githubusercontent.com/assets/482957/24405711/2586fa96-13c6-11e7-9ed9-d1c07a17cbb5.png)

This is how the same scenario looks like after the changes contained in this pull request:

![screen shot 2017-03-28 at 12 05 44](https://cloud.githubusercontent.com/assets/482957/24405970/fabc0576-13c6-11e7-8c27-d3b07eb1c58a.png)

![screen shot 2017-03-28 at 12 07 39](https://cloud.githubusercontent.com/assets/482957/24405975/fed3ee6c-13c6-11e7-824d-17f959ccc376.png)

You can notice how startup got `~ 90ms` faster, and packages loading alone became almost instantaneous. I am expecting this to be even more noticeable on machines that have slow hard drives, where the cost of I/O is much more dramatic.

This marks the end of the first round of performance improvements that can be achieved thanks to snapshots; there are still many things we can improve both in the renderer process and in the browser process, especially related to the scheduling of the tasks that currently happen as part of startup. I believe Atom could be a lot smarter about that, but I am going to illustrate what and how we could make it so in a separate issue (that is going to supplant the now outdated #13253).

/cc: @atom/maintainers 