### PR TITLE
penguin: Respect DISPLAY env variable in Unix like environments

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -269,6 +269,25 @@ describe('AtomApplication', function () {
       await conditionPromise(async () => (await getTreeViewRootDirectories(reusedWindow)).length > 0)
     })
 
+    it('opens a new window with no project paths to open directories but with different DISPLAYs', async function () {
+      originalGetUnixDisplay = AtomApplication.getUnixDisplay;
+      mockUnixDisplay(':0')
+      const tempDirPath = makeTempDir()
+      const atomApplication = buildAtomApplication()
+      const window1 = atomApplication.launch(parseCommandLine([]))
+      await focusWindow(window1)
+
+      mockUnixDisplay(':1')
+      const window2 = atomApplication.launch(parseCommandLine([tempDirPath]))
+      await focusWindow(window2)
+
+      // don't need the display mock anymore so reset sooner than later
+      AtomApplication.getUnixDisplay = originalGetUnixDisplay;
+
+      assert.notEqual(window1, window2)
+      await conditionPromise(async () => (await getTreeViewRootDirectories(reusedWindow)).length > 0)
+    })
+
     it('opens a new window with a single untitled buffer when launched with no path, even if windows already exist', async function () {
       const atomApplication = buildAtomApplication()
       const window1 = atomApplication.launch(parseCommandLine([]))
@@ -486,6 +505,12 @@ describe('AtomApplication', function () {
     }
     electron.app.hasQuitted = function () {
       return quitted
+    }
+  }
+
+  function mockUnixDisplay (display) {
+    AtomApplication.getUnixDisplay = function () {
+      return display
     }
   }
 

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -37,7 +37,10 @@ class AtomApplication
         userNameSafe = new Buffer(process.env.USERNAME).toString('base64')
         options.socketPath = "\\\\.\\pipe\\atom-#{options.version}-#{userNameSafe}-#{process.arch}-sock"
       else
-        options.socketPath = path.join(os.tmpdir(), "atom-#{options.version}-#{process.env.USER}.sock")
+        socketName = "atom-#{options.version}-#{process.env.USER}"
+        if process.env.DISPLAY?
+          socketName += "-#{process.env.DISPLAY}"
+        options.socketPath = path.join(os.tmpdir(), "#{socketName}.sock")
 
     # FIXME: Sometimes when socketPath doesn't exist, net.connect would strangely
     # take a few seconds to trigger 'error' event, it could be a bug of node

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -38,8 +38,9 @@ class AtomApplication
         options.socketPath = "\\\\.\\pipe\\atom-#{options.version}-#{userNameSafe}-#{process.arch}-sock"
       else
         socketName = "atom-#{options.version}-#{process.env.USER}"
-        if process.env.DISPLAY?
-          socketName += "-#{process.env.DISPLAY}"
+        unixDisplay = AtomApplication.getUnixDisplay()
+        if unixDisplay?
+          socketName += "-#{unixDisplay}"
         options.socketPath = path.join(os.tmpdir(), "#{socketName}.sock")
 
     # FIXME: Sometimes when socketPath doesn't exist, net.connect would strangely
@@ -56,6 +57,10 @@ class AtomApplication
         app.quit()
 
     client.on 'error', -> new AtomApplication(options).initialize(options)
+
+  # Private: make changing displays mockable without changing the actual env
+  # var which would cause the app to fail to load
+  @getUnixDisplay: -> process.env.DISPLAY
 
   windows: null
   applicationMenu: null


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

Please advise on a test I can write. I have not been able to successfully compile HEAD so I'm not sure if I can test or if this code is complete. It is a small patch so feel free to just fork it. Note that I did manually test the concept by using the --socket-path option on startup and writing the socket path in the same way that it would be constructed in this code.

### Description of the Change

Atom connects to a socket to determine if it is already running
and if it should launch a new window in the same process.
This socket is named with the user's name but ignores the user's
display. If a user has multiple displays, such as running a
remote display server, Atom will pop up the new window on the display
that it was first started on.

This patch adds the display name to the socket name if it exists
in the env. Because a separate socket is being opened Atom does
the correct thing and launches on the display it was started on.

### Alternate Designs

No alternatives. On linux it should be using D-Bus to avoid these lifecycle/session issues but this is good enough with the benefit that it will work across different Unix like envs.

### Why Should This Be In Core?

Atom windows should open up on the display they are started on.

### Benefits

Users who remote into a different display (such as I have to do for work) will be able to start Atom without first stopping Atom processes running on a different display.

### Possible Drawbacks

None. This is proper behavior. Applications should always respect the environment they are started in.

### Applicable Issues

