### PR TITLE
Don't snapshot minimatch and fix package transpilation registry on win32

### DIFF
--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -46,17 +46,21 @@ module.exports = function (packagedAppPath) {
         relativePath == path.join('..', 'node_modules', 'less', 'lib', 'less', 'fs.js') ||
         relativePath == path.join('..', 'node_modules', 'less', 'lib', 'less-node', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'less', 'node_modules', 'graceful-fs', 'graceful-fs.js') ||
+        relativePath == path.join('..', 'node_modules', 'minimatch', 'minimatch.js') ||
         relativePath == path.join('..', 'node_modules', 'superstring', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'oniguruma', 'lib', 'oniguruma.js') ||
         relativePath == path.join('..', 'node_modules', 'request', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'resolve', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'resolve', 'lib', 'core.js') ||
+        relativePath == path.join('..', 'node_modules', 'scandal', 'node_modules', 'minimatch', 'minimatch.js') ||
         relativePath == path.join('..', 'node_modules', 'settings-view', 'node_modules', 'glob', 'glob.js') ||
+        relativePath == path.join('..', 'node_modules', 'settings-view', 'node_modules', 'minimatch', 'minimatch.js') ||
         relativePath == path.join('..', 'node_modules', 'spellchecker', 'lib', 'spellchecker.js') ||
         relativePath == path.join('..', 'node_modules', 'spelling-manager', 'node_modules', 'natural', 'lib', 'natural', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'tar', 'tar.js') ||
         relativePath == path.join('..', 'node_modules', 'temp', 'lib', 'temp.js') ||
-        relativePath == path.join('..', 'node_modules', 'tmp', 'lib', 'tmp.js')
+        relativePath == path.join('..', 'node_modules', 'tmp', 'lib', 'tmp.js') ||
+        relativePath == path.join('..', 'node_modules', 'tree-view', 'node_modules', 'minimatch', 'minimatch.js')
       )
     }
   }).then((snapshotScript) => {


### PR DESCRIPTION
This module uses Node's `path` for determinining which path separator to use on the current platform. On browsers (and every other environment that does not support `require`, such as v8 snapshots) it falls back to always using a forward slash.

As a result, `PackageTranspilationRegistry` (and potentially other bundled packages that depend on `minimatch`) couldn't match glob expressions against any given path on Windows, thus causing the custom transpiler code to not work properly.

/cc: @BinaryMuse @smashwilson 