### PR TITLE
Fixes #14102 to use ATOM_HOME if present.

### DIFF
--- a/script/config.js
+++ b/script/config.js
@@ -15,7 +15,7 @@ const intermediateAppPath = path.join(buildOutputPath, 'app')
 const symbolsPath = path.join(buildOutputPath, 'symbols')
 const electronDownloadPath = path.join(repositoryRootPath, 'electron')
 const homeDirPath = process.env.HOME || process.env.USERPROFILE
-const atomHomeDirPath = path.join(homeDirPath, '.atom')
+const atomHomeDirPath = process.env.ATOM_HOME || path.join(homeDirPath, '.atom')
 
 const appMetadata = require(path.join(repositoryRootPath, 'package.json'))
 const apmMetadata = require(path.join(apmRootPath, 'package.json'))

--- a/script/lib/clean-caches.js
+++ b/script/lib/clean-caches.js
@@ -9,13 +9,13 @@ const CONFIG = require('../config')
 module.exports = function () {
   const cachePaths = [
     path.join(CONFIG.repositoryRootPath, 'electron'),
-    path.join(CONFIG.homeDirPath, '.atom', '.node-gyp'),
-    path.join(CONFIG.homeDirPath, '.atom', 'storage'),
-    path.join(CONFIG.homeDirPath, '.atom', '.apm'),
-    path.join(CONFIG.homeDirPath, '.atom', '.npm'),
-    path.join(CONFIG.homeDirPath, '.atom', 'compile-cache'),
-    path.join(CONFIG.homeDirPath, '.atom', 'atom-shell'),
-    path.join(CONFIG.homeDirPath, '.atom', 'electron'),
+    path.join(CONFIG.atomHomeDirPath, '.node-gyp'),
+    path.join(CONFIG.atomHomeDirPath, 'storage'),
+    path.join(CONFIG.atomHomeDirPath, '.apm'),
+    path.join(CONFIG.atomHomeDirPath, '.npm'),
+    path.join(CONFIG.atomHomeDirPath, 'compile-cache'),
+    path.join(CONFIG.atomHomeDirPath, 'atom-shell'),
+    path.join(CONFIG.atomHomeDirPath, 'electron'),
     path.join(os.tmpdir(), 'atom-build'),
     path.join(os.tmpdir(), 'atom-cached-atom-shells')
   ]


### PR DESCRIPTION
To test:

`$ ATOM_HOME=<some dir> ./scripts/build`

Check that outputs exist in that dir

`$ATOM_HOME=<some dir> ./scripts/clean`

Check that dir cleaned.

Repeat with no `ATOM_HOME` to check default home dir works