### PR TITLE
:bug: Fix observation of moved items

### DIFF
--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2314,6 +2314,23 @@ i = /test/; #FIXME\
       })
     })
   })
+
+  describe('when an item is moved', () => {
+    it('stores the new location', () => {
+      const ITEM_URI = 'atom://test'
+      const item = {
+        getURI: () => ITEM_URI,
+        getDefaultLocation: jasmine.createSpy().andReturn('left'),
+        getElement: () => document.createElement('div')
+      }
+      const centerPane = workspace.getActivePane()
+      centerPane.addItem(item)
+      const dockPane = atom.workspace.getRightDock().getActivePane()
+      spyOn(workspace.itemLocationStore, 'save')
+      centerPane.moveItemToPane(item, dockPane)
+      expect(workspace.itemLocationStore.save).toHaveBeenCalledWith(ITEM_URI, 'right')
+    })
+  })
 })
 
 const escapeStringRegex = str => str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -296,13 +296,15 @@ module.exports = class Workspace extends Model {
 
   subscribeToMovedItems () {
     for (const paneContainer of this.getPaneContainers()) {
-      paneContainer.onDidAddPaneItem(({item}) => {
-        if (typeof item.getURI === 'function') {
-          const uri = item.getURI()
-          if (uri != null) {
-            this.itemLocationStore.save(item.getURI(), paneContainer.getLocation())
+      paneContainer.observePanes(pane => {
+        pane.onDidAddItem(({item}) => {
+          if (typeof item.getURI === 'function') {
+            const uri = item.getURI()
+            if (uri != null) {
+              this.itemLocationStore.save(item.getURI(), paneContainer.getLocation())
+            }
           }
-        }
+        })
       })
     }
   }


### PR DESCRIPTION
`PaneContainer::onDidAddPaneItem` isn't triggered on moves.