### PR TITLE
Assign `Package.prototype.mainModulePath` eagerly for preloaded packages

### DIFF
--- a/src/package.coffee
+++ b/src/package.coffee
@@ -102,6 +102,10 @@ class Package
       @path = path.join(@packageManager.resourcePath, @path)
       @loadStylesheets()
 
+      # Unfortunately some packages are accessing `@mainModulePath`, so we need
+      # to compute that variable eagerly also for preloaded packages.
+      @getMainModulePath()
+
   load: ->
     @measure 'loadTime', =>
       try


### PR DESCRIPTION
Many packages currently use this instance variable instead of calling `Package.prototype.getMainModulePath`. With this pull request we will eagerly compute such variable for preloaded packages too and therefore prevent third party packages that rely on this implementation detail from breaking.

/cc: @Ben3eeE who noticed this. Can you confirm this fixes the issue you experienced? Thanks!