### PR TITLE
Allow workspace item objects to be passed to Workspace.open

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "keybinding-resolver": "0.38.0",
     "line-ending-selector": "0.6.3",
     "link": "0.31.3",
-    "markdown-preview": "0.159.10",
+    "markdown-preview": "0.159.11",
     "metrics": "1.2.2",
     "notifications": "0.67.1",
     "open-on-github": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "status-bar": "1.8.5",
     "styleguide": "0.49.6",
     "symbols-view": "0.115.5",
-    "tabs": "0.105.1",
+    "tabs": "0.105.2",
     "timecop": "0.36.0",
     "tree-view": "0.216.0",
     "update-package-dependencies": "0.11.0",

--- a/spec/pane-spec.coffee
+++ b/spec/pane-spec.coffee
@@ -14,6 +14,7 @@ describe "Pane", ->
     getURI: -> @uri
     getPath: -> @path
     serialize: -> {deserializer: 'Item', @name, @uri}
+    copy: -> new Item(@name, @uri)
     isEqual: (other) -> @name is other?.name
     onDidDestroy: (fn) -> @emitter.on('did-destroy', fn)
     destroy: -> @destroyed = true; @emitter.emit('did-destroy')
@@ -791,6 +792,11 @@ describe "Pane", ->
         it "duplicates the active item", ->
           pane2 = pane1.splitLeft(copyActiveItem: true)
           expect(pane2.getActiveItem()).toEqual pane1.getActiveItem()
+
+        it "does nothing if the active item doesn't implement .copy()", ->
+          item1.copy = null
+          pane2 = pane1.splitLeft(copyActiveItem: true)
+          expect(pane2.getActiveItem()).toBeUndefined()
 
       describe "when the parent is a column", ->
         it "replaces itself with a row and inserts a new pane to the left of itself", ->

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -178,7 +178,7 @@ describe('Workspace', () => {
     })
   })
 
-  describe('::open(uri, options)', () => {
+  describe('::open(itemOrURI, options)', () => {
     let openEvents = null
 
     beforeEach(() => {
@@ -975,48 +975,107 @@ describe('Workspace', () => {
       }
     })
 
-    it('removes matching items from the center', () => {
-      const pane = atom.workspace.getActivePane()
-      pane.addItem(item)
-      atom.workspace.hide(URI)
-      expect(pane.getItems().length).toBe(0)
+    describe('when called with a URI', () => {
+      it('if the item for the given URI is in the center, removes it', () => {
+        const pane = atom.workspace.getActivePane()
+        pane.addItem(item)
+        atom.workspace.hide(URI)
+        expect(pane.getItems().length).toBe(0)
+      })
+
+      it('if the item for the given URI is in a dock, hides the dock', () => {
+        const dock = atom.workspace.getLeftDock()
+        const pane = dock.getActivePane()
+        pane.addItem(item)
+        dock.activate()
+        expect(dock.isOpen()).toBe(true)
+        const itemFound = atom.workspace.hide(URI)
+        expect(itemFound).toBe(true)
+        expect(dock.isOpen()).toBe(false)
+      })
     })
 
-    it('hides the dock when an item matches', () => {
-      const dock = atom.workspace.getLeftDock()
-      const pane = dock.getActivePane()
-      pane.addItem(item)
-      dock.activate()
-      expect(dock.isOpen()).toBe(true)
-      const itemFound = atom.workspace.hide(URI)
-      expect(itemFound).toBe(true)
-      expect(dock.isOpen()).toBe(false)
+    describe('when called with an item', () => {
+      it('if the item is in the center, removes it', () => {
+        const pane = atom.workspace.getActivePane()
+        pane.addItem(item)
+        atom.workspace.hide(item)
+        expect(pane.getItems().length).toBe(0)
+      })
+
+      it('if the item is in a dock, hides the dock', () => {
+        const dock = atom.workspace.getLeftDock()
+        const pane = dock.getActivePane()
+        pane.addItem(item)
+        dock.activate()
+        expect(dock.isOpen()).toBe(true)
+        const itemFound = atom.workspace.hide(item)
+        expect(itemFound).toBe(true)
+        expect(dock.isOpen()).toBe(false)
+      })
     })
   })
 
-  describe('::toggle(uri)', () => {
-    it('shows the item and dock if no item matches', () => {
-      const URI = 'atom://hide-test'
-      workspace.addOpener(uri => {
-        if (uri === URI) {
-          const el = document.createElement('div')
-          return {
-            getDefaultLocation: () => 'left',
-            getTitle: () => 'Item',
-            getElement: () => el,
-            getURI: () => URI
-          }
+  describe('::toggle(itemOrUri)', () => {
+    describe('when the location resolves to a dock', () => {
+      it('adds or shows the item and its dock if it is not currently visible, and otherwise hides the containing dock', async () => {
+        const item1 = {
+          getDefaultLocation () { return 'left' },
+          getElement () { return (this.element = document.createElement('div')) }
         }
+
+        const item2 = {
+          getDefaultLocation () { return 'left' },
+          getElement () { return (this.element = document.createElement('div')) }
+        }
+
+        const dock = workspace.getLeftDock()
+        expect(dock.isOpen()).toBe(false)
+
+        await workspace.toggle(item1)
+        expect(dock.isOpen()).toBe(true)
+        expect(dock.getActivePaneItem()).toBe(item1)
+
+        await workspace.toggle(item2)
+        expect(dock.isOpen()).toBe(true)
+        expect(dock.getActivePaneItem()).toBe(item2)
+
+        await workspace.toggle(item1)
+        expect(dock.isOpen()).toBe(true)
+        expect(dock.getActivePaneItem()).toBe(item1)
+
+        await workspace.toggle(item1)
+        expect(dock.isOpen()).toBe(false)
+        expect(dock.getActivePaneItem()).toBe(item1)
+
+        await workspace.toggle(item2)
+        expect(dock.isOpen()).toBe(true)
+        expect(dock.getActivePaneItem()).toBe(item2)
       })
-      const dock = workspace.getLeftDock()
-      expect(dock.isOpen()).toBe(false)
-      waitsFor(done => {
-        workspace.onDidOpen(({item}) => {
-          expect(item.getURI()).toBe(URI)
-          expect(dock.isOpen()).toBe(true)
-          done()
-        })
-        workspace.toggle(URI)
+    })
+
+    describe('when the location resolves to the center', () => {
+      it('adds or shows the item if it is not currently the active pane item, and otherwise removes the item', async () => {
+        const item1 = {
+          getDefaultLocation () { return 'center' },
+          getElement () { return (this.element = document.createElement('div')) }
+        }
+
+        const item2 = {
+          getDefaultLocation () { return 'center' },
+          getElement () { return (this.element = document.createElement('div')) }
+        }
+
+        expect(workspace.getActivePaneItem()).toBeUndefined()
+        await workspace.toggle(item1)
+        expect(workspace.getActivePaneItem()).toBe(item1)
+        await workspace.toggle(item2)
+        expect(workspace.getActivePaneItem()).toBe(item2)
+        await workspace.toggle(item1)
+        expect(workspace.getActivePaneItem()).toBe(item1)
+        await workspace.toggle(item1)
+        expect(workspace.paneForItem(item1)).toBeUndefined()
+        expect(workspace.getActivePaneItem()).toBe(item2)
       })
     })
   })

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -732,8 +732,7 @@ class Pane extends Model
       false
 
   copyActiveItem: ->
-    if @activeItem?
-      @activeItem.copy?() ? @deserializerManager.deserialize(@activeItem.serialize())
+    @activeItem?.copy?()
 
   ###
   Section: Lifecycle


### PR DESCRIPTION
Currently, in order to add a given item to the workspace, there is some indirection involved. You must add an *opener* function that returns that item based on some URI, and then to call `Workspace.open` with that URI:

```js
const MY_URI = 'my-package://something'

atom.workspace.addOpener((uri) => {
  if (uri === MY_URI) return new MyItem()
})

atom.workspace.open(MY_URI)
```

The URIs are involved because the workspace uses them as a serializable identifier for the items. But often the indirection of the *opener* concept is unnecessary. This PR adds the ability to add a given item directly to the workspace:

```js
atom.workspace.open(myItem)
```

The item can still have a `getURI` method, so the workspace will still be able to identifiy it for purposes like [remembering which Dock you last placed it in](https://github.com/atom/atom/blob/03be10414189b195ce4cbb9f11936cf575b15042/src/workspace.js#L688).

/cc @nathansobo @matthewwithanm