### PR TITLE
Update build to pre-compile packages with per-package transpilation configs

### DIFF
--- a/script/build
+++ b/script/build
@@ -43,7 +43,7 @@ const transpileBabelPaths = require('./lib/transpile-babel-paths')
 const transpileCoffeeScriptPaths = require('./lib/transpile-coffee-script-paths')
 const transpileCsonPaths = require('./lib/transpile-cson-paths')
 const transpilePegJsPaths = require('./lib/transpile-peg-js-paths')
-const transpilePerPackageTranspilationPaths = require('./lib/transpile-per-package-transpilation-paths')
+const transpilePackagesWithCustomTranspilerPaths = require('./lib/transpile-packages-with-custom-transpiler-paths.js')
 
 process.on('unhandledRejection', function (e) {
   console.error(e.stack || e)
@@ -53,7 +53,7 @@ process.on('unhandledRejection', function (e) {
 checkChromedriverVersion()
 cleanOutputDirectory()
 copyAssets()
-transpilePerPackageTranspilationPaths()
+transpilePackagesWithCustomTranspilerPaths()
 transpileBabelPaths()
 transpileCoffeeScriptPaths()
 transpileCsonPaths()

--- a/script/build
+++ b/script/build
@@ -43,6 +43,7 @@ const transpileBabelPaths = require('./lib/transpile-babel-paths')
 const transpileCoffeeScriptPaths = require('./lib/transpile-coffee-script-paths')
 const transpileCsonPaths = require('./lib/transpile-cson-paths')
 const transpilePegJsPaths = require('./lib/transpile-peg-js-paths')
+const transpilePerPackageTranspilationPaths = require('./lib/transpile-per-package-transpilation-paths')
 
 process.on('unhandledRejection', function (e) {
   console.error(e.stack || e)
@@ -52,6 +53,7 @@ process.on('unhandledRejection', function (e) {
 checkChromedriverVersion()
 cleanOutputDirectory()
 copyAssets()
+transpilePerPackageTranspilationPaths()
 transpileBabelPaths()
 transpileCoffeeScriptPaths()
 transpileCsonPaths()

--- a/script/lib/transpile-packages-with-custom-transpiler-paths.js
+++ b/script/lib/transpile-packages-with-custom-transpiler-paths.js
@@ -8,7 +8,7 @@ const path = require('path')
 const CONFIG = require('../config')
 
 module.exports = function () {
-  console.log(`Transpiling per-package transpilation paths in ${CONFIG.intermediateAppPath}`)
+  console.log(`Transpiling packages with custom transpiler configurations in ${CONFIG.intermediateAppPath}`)
   let pathsToCompile = []
   for (let packageName of Object.keys(CONFIG.appMetadata.packageDependencies)) {
     const packagePath = path.join(CONFIG.intermediateAppPath, 'node_modules', packageName)

--- a/script/lib/transpile-per-package-transpilation-paths.js
+++ b/script/lib/transpile-per-package-transpilation-paths.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const CompileCache = require('../../src/compile-cache')
+const fs = require('fs')
+const glob = require('glob')
+const path = require('path')
+
+const CONFIG = require('../config')
+
+module.exports = function () {
+  console.log(`Transpiling per-package transpilation paths in ${CONFIG.intermediateAppPath}`)
+  let pathsToCompile = []
+  for (let packageName of Object.keys(CONFIG.appMetadata.packageDependencies)) {
+    const packagePath = path.join(CONFIG.intermediateAppPath, 'node_modules', packageName)
+    const metadataPath = path.join(packagePath, 'package.json')
+    const metadata = require(metadataPath)
+    if (metadata.atomTranspilers) {
+      CompileCache.addTranspilerConfigForPath(packagePath, metadata.name, metadata, metadata.atomTranspilers)
+      for (let config of metadata.atomTranspilers) {
+        pathsToCompile = pathsToCompile.concat(glob.sync(path.join(packagePath, config.glob)))
+      }
+    }
+  }
+
+  for (let path of pathsToCompile) {
+    transpilePath(path)
+  }
+}
+
+function transpilePath (path) {
+  fs.writeFileSync(path, CompileCache.addPathToCache(path, CONFIG.atomHomeDirPath))
+}

--- a/spec/package-transpilation-registry-spec.js
+++ b/spec/package-transpilation-registry-spec.js
@@ -143,5 +143,19 @@ describe("PackageTranspilationRegistry", () => {
       expect(wrappedCompiler.compile('source', hitPathMissSubdir)).toEqual('source-original-compiler')
       expect(wrappedCompiler.compile('source', nodeModulesFolder)).toEqual('source-original-compiler')
     })
+
+    describe('when the packages root path contains node_modules', () =>{
+      beforeEach(() => {
+        registry.addTranspilerConfigForPath(path.join('/path/with/node_modules/in/root'), 'my-other-package', { some: 'metadata' }, [
+          jsSpec
+        ])
+      })
+
+      it('returns appropriate values from shouldCompile', () => {
+        spyOn(originalCompiler, 'shouldCompile').andReturn(false)
+        expect(wrappedCompiler.shouldCompile('source', '/path/with/node_modules/in/root/lib/test.js')).toBe(true)
+        expect(wrappedCompiler.shouldCompile('source', '/path/with/node_modules/in/root/lib/node_modules/test.js')).toBe(false)
+      })
+    })
   })
 })

--- a/src/package-transpilation-registry.js
+++ b/src/package-transpilation-registry.js
@@ -71,11 +71,6 @@ class PackageTranspilationRegistry {
   getPackageTranspilerSpecForFilePath (filePath) {
     if (this.specByFilePath[filePath] !== undefined) return this.specByFilePath[filePath]
 
-    // ignore node_modules
-    if (filePath.indexOf(path.sep + 'node_modules' + path.sep) > -1) {
-      return false
-    }
-
     let thisPath = filePath
     let lastPath = null
     // Iterate parents from the file path to the root, checking at each level
@@ -85,6 +80,10 @@ class PackageTranspilationRegistry {
     while (thisPath !== lastPath) { // until we reach the root
       let config = this.configByPackagePath[thisPath]
       if (config) {
+        const relativePath = path.relative(thisPath, filePath)
+        if (relativePath.startsWith(`node_modules${path.sep}`) || relativePath.indexOf(`${path.sep}node_modules${path.sep}`) > -1) {
+          return false
+        }
         for (let i = 0; i < config.specs.length; i++) {
           const spec = config.specs[i]
           if (minimatch(filePath, path.join(config.path, spec.glob))) {

--- a/src/package.coffee
+++ b/src/package.coffee
@@ -86,7 +86,6 @@ class Package
     @loadMenus()
     @registerDeserializerMethods()
     @activateCoreStartupServices()
-    @registerTranspilerConfig()
     @configSchemaRegisteredOnLoad = @registerConfigSchemaFromMetadata()
     @requireMainModule()
     @settingsPromise = @loadSettings()


### PR DESCRIPTION
This allows us to bundle packages with per-package transpilation setups as allowed in #13101. It's very similar to the existing built-in Babel pre-transpilation, but looks in `package.json` for the `atomTranspilers` configuration and adds the appropriate `CompileCache` setup *before* we begin to transpile *any* paths.

/cc @kuychaco @as-cii 