### PR TITLE
Don't store default locations

### DIFF
--- a/spec/state-store-spec.js
+++ b/spec/state-store-spec.js
@@ -7,12 +7,21 @@ describe("StateStore", () => {
   let databaseName = `test-database-${Date.now()}`
   let version = 1
 
-  it("can save and load states", () => {
+  it("can save, load, and delete states", () => {
     const store = new StateStore(databaseName, version)
     return store.save('key', {foo:'bar'})
       .then(() => store.load('key'))
       .then((state) => {
         expect(state).toEqual({foo:'bar'})
+      })
+      .then(() => store.delete('key'))
+      .then(() => store.load('key'))
+      .then((value) => {
+        expect(value).toBeNull()
+      })
+      .then(() => store.count())
+      .then((count) => {
+        expect(count).toBe(0)
       })
   })
 

--- a/src/state-store.js
+++ b/src/state-store.js
@@ -77,6 +77,21 @@ class StateStore {
     })
   }
 
+  delete (key) {
+    return new Promise((resolve, reject) => {
+      this.dbPromise.then((db) => {
+        if (db == null) return resolve()
+
+        var request = db.transaction(['states'], 'readwrite')
+          .objectStore('states')
+          .delete(key)
+
+        request.onsuccess = resolve
+        request.onerror = reject
+      })
+    })
+  }
+
   clear () {
     return this.dbPromise.then((db) => {
       if (!db) return

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -301,7 +301,17 @@ module.exports = class Workspace extends Model {
           if (typeof item.getURI === 'function') {
             const uri = item.getURI()
             if (uri != null) {
-              this.itemLocationStore.save(item.getURI(), paneContainer.getLocation())
+              const location = paneContainer.getLocation()
+              let defaultLocation
+              if (typeof item.getDefaultLocation === 'function') {
+                defaultLocation = item.getDefaultLocation()
+              }
+              defaultLocation = defaultLocation || 'center'
+              if (location === defaultLocation) {
+                this.itemLocationStore.delete(item.getURI())
+              } else {
+                this.itemLocationStore.save(item.getURI(), location)
+              }
             }
           }
         })


### PR DESCRIPTION
### Description of the Change

Previously, when an item was moved, we would store the location in a StateStore. This updates that code to only store non-default values.

### Benefits

This reduces the noise in the DB and might be clearer for devs experimenting with default locations.