### PR TITLE
Fix a regression in hovered dock tracking

### DIFF
--- a/src/dock.js
+++ b/src/dock.js
@@ -118,7 +118,9 @@ module.exports = class Dock {
   // Extended: Toggle the dock's visiblity without changing the {Workspace}'s
   // active pane container.
   toggle () {
-    this.setState({visible: !this.state.visible})
+    const state = {visible: !this.state.visible}
+    if (!state.visible) state.hovered = false
+    this.setState(state)
   }
 
   // Extended: Check if the dock is visible.
@@ -293,7 +295,7 @@ module.exports = class Dock {
   // Determine whether the cursor is within the dock hover area. This isn't as simple as just using
   // mouseenter/leave because we want to be a little more forgiving. For example, if the cursor is
   // over the footer, we want to show the bottom dock's toggle button.
-  pointWithinHoverArea (point, includeButtonWidth) {
+  pointWithinHoverArea (point, includeButtonWidth = this.state.hovered) {
     const dockBounds = this.innerElement.getBoundingClientRect()
     // Copy the bounds object since we can't mutate it.
     const bounds = {

--- a/src/workspace-element.js
+++ b/src/workspace-element.js
@@ -182,20 +182,16 @@ class WorkspaceElement extends HTMLElement {
   }
 
   updateHoveredDock (mousePosition) {
-    // See if we've left the currently hovered dock's area.
-    if (this.model.hoveredDock) {
-      const hideToggleButton = !this.model.hoveredDock.pointWithinHoverArea(mousePosition, true)
-      if (hideToggleButton) {
-        this.model.setHoveredDock(null)
-      }
-    }
-    // See if we've moved over a dock.
-    if (this.model.hoveredDock == null) {
-      const hoveredDock = _.values(this.model.docks).find(
-        dock => dock.pointWithinHoverArea(mousePosition, false)
-      )
-      if (hoveredDock != null) {
-        this.model.setHoveredDock(hoveredDock)
+    this.model.hoveredDock = null
+    for (let location in this.model.paneContainers) {
+      if (location !== 'center') {
+        const dock = this.model.paneContainers[location]
+        if (!this.model.hoveredDock && dock.pointWithinHoverArea(mousePosition)) {
+          this.model.hoveredDock = dock
+          dock.setHovered(true)
+        } else {
+          dock.setHovered(false)
+        }
       }
     }
     this.checkCleanupDockHoverEvents()

--- a/src/workspace-element.js
+++ b/src/workspace-element.js
@@ -182,12 +182,12 @@ class WorkspaceElement extends HTMLElement {
   }
 
   updateHoveredDock (mousePosition) {
-    this.model.hoveredDock = null
+    this.hoveredDock = null
     for (let location in this.model.paneContainers) {
       if (location !== 'center') {
         const dock = this.model.paneContainers[location]
-        if (!this.model.hoveredDock && dock.pointWithinHoverArea(mousePosition)) {
-          this.model.hoveredDock = dock
+        if (!this.hoveredDock && dock.pointWithinHoverArea(mousePosition)) {
+          this.hoveredDock = dock
           dock.setHovered(true)
         } else {
           dock.setHovered(false)
@@ -198,7 +198,7 @@ class WorkspaceElement extends HTMLElement {
   }
 
   checkCleanupDockHoverEvents () {
-    if (this.cursorInCenter && !this.model.hoveredDock) {
+    if (this.cursorInCenter && !this.hoveredDock) {
       window.removeEventListener('mousemove', this.handleEdgesMouseMove)
       window.removeEventListener('dragend', this.handleDockDragEnd)
     }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -328,13 +328,6 @@ module.exports = class Workspace extends Model {
     this.getCenter().activate()
   }
 
-  setHoveredDock (hoveredDock) {
-    this.hoveredDock = hoveredDock
-    _.values(this.paneContainers).forEach(dock => {
-      dock.setHovered(dock === hoveredDock)
-    })
-  }
-
   setDraggingItem (draggingItem) {
     _.values(this.paneContainers).forEach(dock => {
       dock.setDraggingItem(draggingItem)

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -54,7 +54,6 @@ module.exports = class Workspace extends Model {
     this.deserializerManager = params.deserializerManager
     this.textEditorRegistry = params.textEditorRegistry
     this.styleManager = params.styleManager
-    this.hoveredDock = null
     this.draggingItem = false
     this.itemLocationStore = new StateStore('AtomPreviousItemLocations', 1)
 


### PR DESCRIPTION
This fixes a regression introduced in #14143 and backfills some tests for the dock toggle buttons.

This also fixes a minor bug where, after clicking the dock toggle button to hide the dock, the button would remain visible until the next mouse movement.

/cc @nathansobo @matthewwithanm