### PR TITLE
Add `atom.whenShellEnvironmentLoaded()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "color": "^0.7.3",
     "dedent": "^0.6.0",
     "devtron": "1.3.0",
-    "event-kit": "^2.1.0",
+    "event-kit": "^2.3.0",
     "find-parent-dir": "^0.3.0",
     "first-mate": "7.0.2",
     "fs-plus": "^3.0.0",

--- a/spec/atom-environment-spec.coffee
+++ b/spec/atom-environment-spec.coffee
@@ -458,6 +458,39 @@ describe "AtomEnvironment", ->
       atomEnvironment.unloadEditorWindow()
       atomEnvironment.destroy()
 
+  describe "::whenShellEnvironmentLoaded()", ->
+    [atomEnvironment, envLoaded, spy] = []
+
+    beforeEach ->
+      resolve = null
+      promise = new Promise (r) -> resolve = r
+      envLoaded = ->
+        resolve()
+        waitsForPromise -> promise
+      atomEnvironment = new AtomEnvironment
+        applicationDelegate: atom.applicationDelegate
+        updateProcessEnv: -> promise
+      atomEnvironment.initialize({window, document})
+      spyOn(atomEnvironment.packages, 'getAvailablePackagePaths').andReturn []
+      spyOn(atomEnvironment, 'displayWindow').andReturn Promise.resolve()
+      spy = jasmine.createSpy()
+      atomEnvironment.startEditorWindow()
+
+    afterEach ->
+      atomEnvironment.unloadEditorWindow()
+      atomEnvironment.destroy()
+
+    it "is triggered once the shell environment is loaded", ->
+      atomEnvironment.whenShellEnvironmentLoaded spy
+      envLoaded()
+      runs -> expect(spy).toHaveBeenCalled()
+
+    it "triggers the callback immediately if the shell environment is already loaded", ->
+      envLoaded()
+      runs ->
+        atomEnvironment.whenShellEnvironmentLoaded spy
+        expect(spy).toHaveBeenCalled()
+
   describe "::openLocations(locations) (called via IPC from browser process)", ->
     beforeEach ->
       spyOn(atom.workspace, 'open')


### PR DESCRIPTION
This provides a way to be notified when the shell environment has loaded—even if it's already happened. (This implements the proposal from #14155.)

cc @nathansobo @maxbrunsfeld