### PR TITLE
Avoid errors deserializing 1.17 workspace state in prior Atom versions

### DIFF
--- a/src/workspace.js
+++ b/src/workspace.js
@@ -193,6 +193,9 @@ module.exports = class Workspace extends Model {
       deserializer: 'Workspace',
       packagesWithActiveGrammars: this.getPackageNamesWithActiveGrammars(),
       destroyedItemURIs: this.destroyedItemURIs.slice(),
+      // Ensure deserializing 1.17 state with pre 1.17 Atom does not error
+      // TODO: Remove after 1.17 has been on stable for a while
+      paneContainer: {version: 2},
       paneContainers: {
         center: this.paneContainers.center.serialize(),
         left: this.paneContainers.left.serialize(),


### PR DESCRIPTION
We're seeing errors that break window startup when deserializing 1.17 workspace state in prior Atom versions. Since users switch back and forth between beta and stable, this could cause unnecessary confusion. Here we don't provide full compatibility when downgrading, but we at least avoid errors so the window starts up gracefully. Unfortunately, we'll need to cherry-pick this to 1.17-releases.

/cc @maxbrunsfeld 