### PR TITLE
Prevent the resize handle from covering the center

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "autocomplete-atom-api": "0.10.1",
     "autocomplete-css": "0.16.1",
     "autocomplete-html": "0.7.3",
-    "autocomplete-plus": "2.35.2",
+    "autocomplete-plus": "2.35.3",
     "autocomplete-snippets": "1.11.0",
     "autoflow": "0.29.0",
     "autosave": "0.24.2",

--- a/src/dock.js
+++ b/src/dock.js
@@ -205,11 +205,16 @@ module.exports = class Dock {
 
     const shouldBeVisible = state.visible || state.showDropTarget
     const size = Math.max(MINIMUM_SIZE, state.size == null ? this.getInitialSize() : state.size)
+    const resizeHandleSize = this.resizeHandle.getSize()
 
     // We need to change the size of the mask...
-    this.maskElement.style[this.widthOrHeight] = `${shouldBeVisible ? size : this.resizeHandle.getSize()}px`
+    this.maskElement.style[this.widthOrHeight] = `${shouldBeVisible ? size : resizeHandleSize}px`
     // ...but the content needs to maintain a constant size.
     this.wrapperElement.style[this.widthOrHeight] = `${size}px`
+    // ...and the non-absolutely positioned dock element should always be large enough to fit the
+    // resize handle (so the handle doesn't cover the center).
+    const minWidthOrHeight = this.widthOrHeight === 'width' ? 'minWidth' : 'minHeight'
+    this.element.style[minWidthOrHeight] = `${resizeHandleSize}px`
 
     this.resizeHandle.update({dockIsVisible: this.state.visible})
     this.toggleButton.update({

--- a/src/dock.js
+++ b/src/dock.js
@@ -205,16 +205,11 @@ module.exports = class Dock {
 
     const shouldBeVisible = state.visible || state.showDropTarget
     const size = Math.max(MINIMUM_SIZE, state.size == null ? this.getInitialSize() : state.size)
-    const resizeHandleSize = this.resizeHandle.getSize()
 
     // We need to change the size of the mask...
-    this.maskElement.style[this.widthOrHeight] = `${shouldBeVisible ? size : resizeHandleSize}px`
+    this.maskElement.style[this.widthOrHeight] = `${shouldBeVisible ? size : 0}px`
     // ...but the content needs to maintain a constant size.
     this.wrapperElement.style[this.widthOrHeight] = `${size}px`
-    // ...and the non-absolutely positioned dock element should always be large enough to fit the
-    // resize handle (so the handle doesn't cover the center).
-    const minWidthOrHeight = this.widthOrHeight === 'width' ? 'minWidth' : 'minHeight'
-    this.element.style[minWidthOrHeight] = `${resizeHandleSize}px`
 
     this.resizeHandle.update({dockIsVisible: this.state.visible})
     this.toggleButton.update({

--- a/static/panels.less
+++ b/static/panels.less
@@ -7,6 +7,13 @@ atom-panel-container.right {
   display: flex;
 }
 
+atom-panel-container.left {
+  // Align panels to the right of the panel container. The effect of this is
+  // that the left dock's toggle button will appear on the right side of the
+  // empty space when the panel container has a min width in the theme.
+  justify-content: flex-end;
+}
+
 .tool-panel, // deprecated: .tool-panel
 atom-panel {
   display: block;


### PR DESCRIPTION
Currently, the absolutely positioned element is the only thing with a
size. That means that it'll cover the center. With this change, we give
a size to the (relatively-positioned) atom-dock element so that closed
docks take up canvas space instead.

I think @simurai mentioned this problem before but I wasn't following
and then forgot about it. 😖

cc @nathansobo @maxbrunsfeld