### PR TITLE
Properly restore focus to center when hiding dock via toggle

### DIFF
--- a/spec/dock-spec.js
+++ b/spec/dock-spec.js
@@ -25,6 +25,12 @@ describe('Dock', () => {
 
       dock.hide()
       expect(document.activeElement).toBe(atom.workspace.getCenter().getActivePane().getElement())
+
+      dock.activate()
+      expect(document.activeElement).toBe(dock.getActivePane().getElement())
+
+      dock.toggle()
+      expect(document.activeElement).toBe(atom.workspace.getCenter().getActivePane().getElement())
     })
   })
 

--- a/src/dock.js
+++ b/src/dock.js
@@ -112,7 +112,6 @@ module.exports = class Dock {
   // was previously focused.
   hide () {
     this.setState({visible: false})
-    this.didHide()
   }
 
   // Extended: Toggle the dock's visiblity without changing the {Workspace}'s
@@ -133,12 +132,14 @@ module.exports = class Dock {
   setState (newState) {
     const prevState = this.state
     const nextState = Object.assign({}, prevState, newState)
+    let didHide = false
 
     // Update the `shouldAnimate` state. This needs to be written to the DOM before updating the
     // class that changes the animated property. Normally we'd have to defer the class change a
     // frame to ensure the property is animated (or not) appropriately, however we luck out in this
     // case because the drag start always happens before the item is dragged into the toggle button.
     if (nextState.visible !== prevState.visible) {
+      didHide = !nextState.visible
       // Never animate toggling visiblity...
       nextState.shouldAnimate = false
     } else if (!nextState.visible && nextState.draggingItem && !prevState.draggingItem) {
@@ -148,6 +149,7 @@ module.exports = class Dock {
 
     this.state = nextState
     this.render(this.state)
+    if (didHide) this.didHide()
   }
 
   render (state) {


### PR DESCRIPTION
Previously, we were only restoring focus to the active center pane when hiding a dock via the *hide* method. Since `toggle` calls `setState` directly, we weren't notifying the workspace and restoring focus when hiding the dock via `toggle`. This PR fixes that.

@maxbrunsfeld we should cherry-pick this to 1.17-releases before publishing today.