### PR TITLE
Require `TextEditorElement` eagerly

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -196,6 +196,11 @@ class AtomEnvironment extends Model
       @applicationDelegate.didChangeHistoryManager() unless e.reloaded
 
   initialize: (params={}) ->
+    # This will force TextEditorElement to register the custom element, so that
+    # using `document.createElement('atom-text-editor')` works if it's called
+    # before opening a buffer.
+    require './text-editor-element'
+
     {@window, @document, @blobStore, @configDirPath, onlyLoadBaseStyleSheets} = params
     {devMode, safeMode, resourcePath, clearWindowState} = @getLoadSettings()
 


### PR DESCRIPTION
Fixes #14193.

With snapshots, all the forbidden modules are required lazily. In the case of `TextEditorElement` this can be problematic because users might create editors via `document.createElement('atom-text-editor')` before we have the chance to register the custom element.

With this pull request we will eagerly require `src/text-editor-element.coffee`, thus forcing `TextEditorElement` to register the HTML custom element when Atom is loaded and fixing the aforementioned issue.

/cc: @atom/maintainers 