### PR TITLE
Reduce dock initial size lookups

### DIFF
--- a/src/dock.js
+++ b/src/dock.js
@@ -46,6 +46,7 @@ module.exports = class Dock {
     })
 
     this.state = {
+      size: null,
       visible: false,
       shouldAnimate: false
     }


### PR DESCRIPTION
Previously, we would get the initial size every time we didn't have an
explicit one. With this commit, we only get the initial size when we
deserialize and when we go from 0 -> 1 pane items.

Also, if the dock doesn't already have an explicit size, we'll use the
preferred size of the item being dragged when peaking the dock. That
way, dropping it won't cause it to change size.

This kinda-but-not-really fixes #14209. The tree view will still report sizes inconsistently but, since we only ask it once, we won't see the symptom.

cc @ungb @nathansobo