### PR TITLE
Don't attempt to transpile directories

### DIFF
--- a/script/lib/transpile-babel-paths.js
+++ b/script/lib/transpile-babel-paths.js
@@ -25,13 +25,13 @@ module.exports = function () {
 
 function getPathsToTranspile () {
   let paths = []
-  paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'benchmarks', '**', '*.js')))
-  paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'exports', '**', '*.js')))
-  paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'src', '**', '*.js')))
+  paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'benchmarks', '**', '*.js'), {nodir: true}))
+  paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'exports', '**', '*.js'), {nodir: true}))
+  paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'src', '**', '*.js'), {nodir: true}))
   for (let packageName of Object.keys(CONFIG.appMetadata.packageDependencies)) {
     paths = paths.concat(glob.sync(
       path.join(CONFIG.intermediateAppPath, 'node_modules', packageName, '**', '*.js'),
-      {ignore: path.join(CONFIG.intermediateAppPath, 'node_modules', packageName, 'spec', '**', '*.js')}
+      {ignore: path.join(CONFIG.intermediateAppPath, 'node_modules', packageName, 'spec', '**', '*.js'), nodir: true}
     ))
   }
   return paths

--- a/script/lib/transpile-coffee-script-paths.js
+++ b/script/lib/transpile-coffee-script-paths.js
@@ -16,12 +16,12 @@ module.exports = function () {
 
 function getPathsToTranspile () {
   let paths = []
-  paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'src', '**', '*.coffee')))
-  paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'spec', '*.coffee')))
+  paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'src', '**', '*.coffee'), {nodir: true}))
+  paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'spec', '*.coffee'), {nodir: true}))
   for (let packageName of Object.keys(CONFIG.appMetadata.packageDependencies)) {
     paths = paths.concat(glob.sync(
       path.join(CONFIG.intermediateAppPath, 'node_modules', packageName, '**', '*.coffee'),
-      {ignore: path.join(CONFIG.intermediateAppPath, 'node_modules', packageName, 'spec', '**', '*.coffee')}
+      {ignore: path.join(CONFIG.intermediateAppPath, 'node_modules', packageName, 'spec', '**', '*.coffee'), nodir: true}
     ))
   }
   return paths

--- a/script/lib/transpile-cson-paths.js
+++ b/script/lib/transpile-cson-paths.js
@@ -19,7 +19,7 @@ function getPathsToTranspile () {
   for (let packageName of Object.keys(CONFIG.appMetadata.packageDependencies)) {
     paths = paths.concat(glob.sync(
       path.join(CONFIG.intermediateAppPath, 'node_modules', packageName, '**', '*.cson'),
-      {ignore: path.join(CONFIG.intermediateAppPath, 'node_modules', packageName, 'spec', '**', '*.cson')}
+      {ignore: path.join(CONFIG.intermediateAppPath, 'node_modules', packageName, 'spec', '**', '*.cson'), nodir: true}
     ))
   }
   return paths

--- a/script/lib/transpile-packages-with-custom-transpiler-paths.js
+++ b/script/lib/transpile-packages-with-custom-transpiler-paths.js
@@ -17,7 +17,7 @@ module.exports = function () {
     if (metadata.atomTranspilers) {
       CompileCache.addTranspilerConfigForPath(packagePath, metadata.name, metadata, metadata.atomTranspilers)
       for (let config of metadata.atomTranspilers) {
-        pathsToCompile = pathsToCompile.concat(glob.sync(path.join(packagePath, config.glob)))
+        pathsToCompile = pathsToCompile.concat(glob.sync(path.join(packagePath, config.glob), {nodir: true}))
       }
     }
   }

--- a/script/lib/transpile-peg-js-paths.js
+++ b/script/lib/transpile-peg-js-paths.js
@@ -17,7 +17,7 @@ module.exports = function () {
 function getPathsToTranspile () {
   let paths = []
   for (let packageName of Object.keys(CONFIG.appMetadata.packageDependencies)) {
-    paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'node_modules', packageName, '**', '*.pegjs')))
+    paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'node_modules', packageName, '**', '*.pegjs'), {nodir: true}))
   }
   return paths
 }


### PR DESCRIPTION
Enable option in glob to disable directories from being returned when
finding paths to transpile during compilation

### Description of the Change
Before this PR, building Atom involved transpiling all babel paths, coffeescript files, cson files, etc. by globbing for all paths matching (essentially) `**/*.js`, `**/*.coffee`, etc. Node modules like term.js appear in the directory structure as `node_modules/term.js/<contents>`, which previously caused the folder `node_modules/term.js` to be added to a list of paths to transpile under the assumption that it was a file. This causes an error when [trying to read the folder](https://github.com/atom/atom/blob/master/src/compile-cache.js#L84)) `node_modules/term.js`. This PR fixes that by enabling the `nodir` option, which filters out any directories from being in the results. While I only specifically witnessed this issue in finding javascript files, the bug also exists in the coffeescript, CSON, PEG.js, and custom transpilers if someone names a directory *.coffee, *.cson, or something else expected to be transpiled.

### Alternate Designs
One could check if the path attempting to be transpiled is actually a directory where the error occurs right before transpiling, but glob already checks if the path is a directory.

### Why Should This Be In Core?
Proposed update to building atom

### Benefits
Can include node_modules named like module.js.

### Possible Drawbacks
In the future, if the [transpiler ](https://github.com/atom/atom/blob/master/src/compile-cache.js#L83) (or a custom one) may support directories? In this event, a glob pattern that ends with a `/` still grabs directories (even if `nodir` is enabled).

### Applicable Issues
None