### PR TITLE
Add `rpm --rebuilddb` to prevent 'Rpmdb checksum' error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM nodesource/fedora21:4.2.6
 
 # Install dependencies
-RUN yum install -y \
+RUN rpm --rebuilddb && yum install -y \
     make \
     gcc \
     gcc-c++ \


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I fixed Dockerfile to rebuild RPM DB to prevent checksum error described in #14224 .

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
* Change the base docker image.
* Force to ignore checksum errors.

### Why Should This Be In Core?

This Dockerfile is used to test core with Copr. (#10945)

### Benefits

CIs and Developers can build atom using Docker.

### Possible Drawbacks

(If present) Current CI settings which depends on this Dockerfile may be affected.

### Applicable Issues

#14224