### PR TITLE
Add Workspace.paneContainerForItem method

### DIFF
--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -984,6 +984,29 @@ describe('Workspace', () => {
     })
   })
 
+  describe('finding items in the workspace', () => {
+    it('can identify the pane and pane container for a given item or URI', () => {
+      const uri = 'atom://test-pane-for-item'
+      const item = {
+        element: document.createElement('div'),
+        getURI () { return uri }
+      }
+
+      atom.workspace.getActivePane().activateItem(item)
+      expect(atom.workspace.paneForItem(item)).toBe(atom.workspace.getCenter().getActivePane())
+      expect(atom.workspace.paneContainerForItem(item)).toBe(atom.workspace.getCenter())
+      expect(atom.workspace.paneForURI(uri)).toBe(atom.workspace.getCenter().getActivePane())
+      expect(atom.workspace.paneContainerForURI(uri)).toBe(atom.workspace.getCenter())
+
+      atom.workspace.getActivePane().destroyActiveItem()
+      atom.workspace.getLeftDock().getActivePane().activateItem(item)
+      expect(atom.workspace.paneForItem(item)).toBe(atom.workspace.getLeftDock().getActivePane())
+      expect(atom.workspace.paneContainerForItem(item)).toBe(atom.workspace.getLeftDock())
+      expect(atom.workspace.paneForURI(uri)).toBe(atom.workspace.getLeftDock().getActivePane())
+      expect(atom.workspace.paneContainerForURI(uri)).toBe(atom.workspace.getLeftDock())
+    })
+  })
+
   describe('::hide(uri)', () => {
     let item
     const URI = 'atom://hide-test'

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1373,6 +1373,16 @@ module.exports = class Workspace extends Model {
     return this.getPaneContainers().find(container => container.paneForURI(uri))
   }
 
+  // Extended: Get the first pane container that contains the given item.
+  //
+  // * `item` the Item that the returned pane container must contain.
+  //
+  // Returns a {Dock}, the {WorkspaceCenter}, or `undefined` if no item exists
+  // with the given URI.
+  paneContainerForItem (uri) {
+    return this.getPaneContainers().find(container => container.paneForItem(uri))
+  }
+
   // Extended: Get the first {Pane} that contains an item with the given URI.
   //
   // * `uri` {String} uri
@@ -1389,7 +1399,7 @@ module.exports = class Workspace extends Model {
 
   // Extended: Get the {Pane} containing the given item.
   //
-  // * `item` Item the returned pane contains.
+  // * `item` the Item that the returned pane must contain.
   //
   // Returns a {Pane} or `undefined` if no pane exists for the given item.
   paneForItem (item) {


### PR DESCRIPTION
The methods `paneForItem`, `paneForURI`, and `paneContainerForURI` already exist, so it seems reasonable to add `paneContainerForItem` as well. I've also backfilled some tests for these simple methods.