### PR TITLE
Remove debugger statement

### DIFF
--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -255,7 +255,6 @@ class TokenizedBuffer extends Model
     new TokenizedLine({openScopes, text, tags, ruleStack, lineEnding, @tokenIterator})
 
   tokenizedLineForRow: (bufferRow) ->
-    debugger
     if 0 <= bufferRow <= @buffer.getLastRow()
       if tokenizedLine = @tokenizedLines[bufferRow]
         tokenizedLine


### PR DESCRIPTION
Looks like a `debugger` statement slipped in to master as part of cc6e127e.

Fixes #14244.