### PR TITLE
Only trigger branch builds on master and release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 git:
   depth: 10
 
+branches:
+  only:
+  - master
+  - /^[0-9.]+-releases$/
+
 matrix:
   include:
     - os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,11 @@ skip_tags: true
 clone_folder: c:\projects\atom
 clone_depth: 10
 
+branches:
+  only:
+  - master
+  - /^[0-9.]+-releases$/
+
 platform:
   - x64
   - x86

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,10 @@ machine:
     version: 7.3
 
 general:
+  branches:
+    only:
+    - master
+    - /^[0-9.]+-releases$/
   artifacts:
     - out/atom-mac.zip
     - out/atom-mac-symbols.zip

--- a/circle.yml
+++ b/circle.yml
@@ -8,10 +8,6 @@ machine:
     version: 7.3
 
 general:
-  branches:
-    only:
-    - master
-    - /^[0-9.]+-releases$/
   artifacts:
     - out/atom-mac.zip
     - out/atom-mac-symbols.zip


### PR DESCRIPTION
### Description of the Change

Modify the Travis, Circle CI, and AppVeyor build metadata to only create branch builds for `master` and release branches named `x.y-releases`. This should help our build queue situation somewhat.

Note that _pull request_ builds should still be triggered on all three systems.

### Alternate Designs

We could do this by adding logic to the build scripts themselves to detect when they're being executed on a branch build that will also create a PR build, but there's no reason not to use the built-in solutions for this.

AppVeyor and (I believe) Circle both allow you to configure this setting in their own web UIs. I generally prefer to keep build configuration within the repository as much as possible, though, it's less confusing and we can manage it with pull requests (like this one!).

### Why Should This Be In Core?

The core build metadata files are in core :grin:

### Benefits

This will decrease the extraneous builds that are created when maintainers push branches to the atom/atom fork and create pull requests from them, which is [common in our workflow](https://github.com/atom/atom/branches/all). This results in _two_ builds for each push to a feature branch: one from the push to the feature branch and one from the pull request event:

<img width="694" alt="screen shot 2017-04-18 at 12 54 21 pm" src="https://cloud.githubusercontent.com/assets/17565/25142789/2ab061c6-2436-11e7-8ca7-146a88846b10.png">

Running fewer builds will result in less queue pressure and more rapid feedback on changes.

### Possible Drawbacks

Running the tests less often may cause us to miss flaky failures that happen only occasionally. We will also lose the ability to distinguish failures that are present on the branch itself (from the branch build) from those that are caused by the merge into master (from the pull request build).

### Applicable Issues

_N/A_

We've agreed to hold off on changing the build for a day or so to more easily isolate the cause of any problems from #13646.

/cc @damieng @as-cii @maxbrunsfeld @50Wliu 
