### PR TITLE
Run Atom from Windows Subsystem for Linux

### DIFF
--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -4,9 +4,15 @@ if command -v "cygpath" > /dev/null; then
   # We have cygpath to do the conversion
   ATOMCMD=$(cygpath "$(dirname "$0")/atom.cmd" -a -w)
 else
-  # We don't have cygpath so try pwd -W
   pushd "$(dirname "$0")" > /dev/null
-  ATOMCMD="$(pwd -W)/atom.cmd"
+  if [ "grep -q Microsoft /proc/sys/kernel/osrelease" ]; then
+    # We are in Windows Subsystem for Linux, map /mnt/drive
+    ATOMCMD="$(echo $PWD | sed 's/\/mnt\/\([a-z]*\)\(.*\)/\1:\2/')/atom.cmd"
+    ATOMCMD="${ATOMCMD////\\}"
+  else
+    # We don't have cygpath or WSL so try pwd -W
+    ATOMCMD="$(pwd -W)/atom.cmd"
+  fi
   popd > /dev/null
 fi
 if [ "$(uname -o)" == "Msys" ]; then

--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -5,7 +5,7 @@ if command -v "cygpath" > /dev/null; then
   ATOMCMD=$(cygpath "$(dirname "$0")/atom.cmd" -a -w)
 else
   pushd "$(dirname "$0")" > /dev/null
-  if [ "grep -q Microsoft /proc/sys/kernel/osrelease" ]; then
+  if [[ $(uname -r) == *-Microsoft ]]; then
     # We are in Windows Subsystem for Linux, map /mnt/drive
     ATOMCMD="$(echo $PWD | sed 's/\/mnt\/\([a-z]*\)\(.*\)/\1:\2/')/atom.cmd"
     ATOMCMD="${ATOMCMD////\\}"


### PR DESCRIPTION
Correctly launch the Windows native version of Atom from the Windows Subsystem for Linux (WSL)

Fixes #14258 along with https://github.com/atom/apm/pull/714 for APM