### PR TITLE
Re-prioritize @windowForPaths and currentWindow

### DIFF
--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -545,16 +545,15 @@ class AtomApplication
     unless pidToKillWhenClosed or newWindow
       existingWindow = @windowForPaths(pathsToOpen, devMode)
       stats = (fs.statSyncNoException(pathToOpen) for pathToOpen in pathsToOpen)
-      unless existingWindow?
-        if currentWindow = window ? @lastFocusedWindow
-          existingWindow = currentWindow if (
-            addToLastWindow or
-            currentWindow.devMode is devMode and
-            (
-              stats.every((stat) -> stat.isFile?()) or
-              stats.some((stat) -> stat.isDirectory?() and not currentWindow.hasProjectPath())
-            )
+      if currentWindow = window ? @lastFocusedWindow
+        existingWindow = currentWindow if (
+          addToLastWindow or
+          currentWindow.devMode is devMode and
+          (
+            stats.every((stat) -> stat.isFile?()) or
+            stats.some((stat) -> stat.isDirectory?() and not currentWindow.hasProjectPath())
           )
+        )
 
     if existingWindow?
       openedWindow = existingWindow


### PR DESCRIPTION
### Description of the Change

Currently, @windowForPaths() being non-null inhibits addToLastWindow, thus rendering the -a switch at least partially useless on ArchLinux with XFCE/Gnome desktop. The patch restores its claimed ability to open documents in an Atom window the user was last working with.
The fix leaves existingWindow equal to @windowForPaths() only if there are no windows more suitable to become an existingWindow.

### Alternate Designs

No alternate designs were considered, as the one in this PR is the least invasive. Here\`s the only place in the whole Atom codebase where addToLastWindow value is actually used.

### Why Should This Be In Core?

This is a bugfix.

### Benefits

Restoration of documented functionality.

### Possible Drawbacks

Calling currentWindow.hasProjectPath(), isFile?() and isDirectory?() for all opened entries even if @windowForPaths() is non-null.

### Applicable Issues

https://stackoverflow.com/questions/43526384