### PR TITLE
Recalculate Tooltip positions when their contents change

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -1,3 +1,5 @@
+/* global MutationObserver */
+
 'use strict'
 
 const EventKit = require('event-kit')
@@ -46,7 +48,7 @@ Tooltip.prototype.init = function (element, options) {
   this.element = element
   this.options = this.getOptions(options)
   this.disposables = new EventKit.CompositeDisposable()
-  this.mutationObserver = new MutationObserver(this.handleMutations.bind(this));
+  this.mutationObserver = new MutationObserver(this.handleMutations.bind(this))
 
   if (this.options.viewport) {
     if (typeof this.options.viewport === 'function') {
@@ -104,21 +106,21 @@ Tooltip.prototype.init = function (element, options) {
     : this.fixTitle()
 }
 
-Tooltip.prototype.startObservingMutations = function() {
+Tooltip.prototype.startObservingMutations = function () {
   this.mutationObserver.observe(this.getTooltipElement(), {
     attributes: true, childList: true, characterData: true, subtree: true
   })
 }
 
-Tooltip.prototype.stopObservingMutations = function() {
-  this.mutationObserver.disconnect();
+Tooltip.prototype.stopObservingMutations = function () {
+  this.mutationObserver.disconnect()
 }
 
-Tooltip.prototype.handleMutations = function(mutations) {
-  this.stopObservingMutations();
-  requestAnimationFrame(function() {
-    this.recalculatePosition();
-    this.startObservingMutations();
+Tooltip.prototype.handleMutations = function (mutations) {
+  this.stopObservingMutations()
+  window.requestAnimationFrame(function () {
+    this.recalculatePosition()
+    this.startObservingMutations()
   }.bind(this))
 }
 
@@ -221,7 +223,7 @@ Tooltip.prototype.show = function () {
     }
 
     var tip = this.getTooltipElement()
-    this.startObservingMutations();
+    this.startObservingMutations()
     var tipId = this.getUID('tooltip')
 
     this.setContent()
@@ -360,7 +362,7 @@ Tooltip.prototype.hide = function (callback) {
   }
 
   this.tip && this.tip.classList.remove('in')
-  this.stopObservingMutations();
+  this.stopObservingMutations()
 
   if (this.hoverState !== 'in') this.tip && this.tip.remove()
 
@@ -503,11 +505,12 @@ Tooltip.prototype.getDelegateComponent = function (element) {
   return component
 }
 
-Tooltip.prototype.recalculatePosition = function() {
-  var tip = this.getTooltipElement();
-  var placement = typeof this.options.placement == 'function' ?
-    this.options.placement.call(this, tip, this.element) :
-    this.options.placement
+Tooltip.prototype.recalculatePosition = function () {
+  var tip = this.getTooltipElement()
+
+  var placement = typeof this.options.placement === 'function'
+    ? this.options.placement.call(this, tip, this.element)
+    : this.options.placement
 
   var autoToken = /\s?auto?\s?/i
   var autoPlace = autoToken.test(placement)
@@ -515,19 +518,19 @@ Tooltip.prototype.recalculatePosition = function() {
 
   tip.classList.add(placement)
 
-  var pos          = this.element.getBoundingClientRect()
-  var actualWidth  = tip.offsetWidth
+  var pos = this.element.getBoundingClientRect()
+  var actualWidth = tip.offsetWidth
   var actualHeight = tip.offsetHeight
 
   if (autoPlace) {
     var orgPlacement = placement
     var viewportDim = this.viewport.getBoundingClientRect()
 
-    placement = placement == 'bottom' && pos.bottom + actualHeight > viewportDim.bottom ? 'top'    :
-                placement == 'top'    && pos.top    - actualHeight < viewportDim.top    ? 'bottom' :
-                placement == 'right'  && pos.right  + actualWidth  > viewportDim.width  ? 'left'   :
-                placement == 'left'   && pos.left   - actualWidth  < viewportDim.left   ? 'right'  :
-                placement
+    placement = placement === 'bottom' && pos.bottom + actualHeight > viewportDim.bottom ? 'top'
+              : placement === 'top' && pos.top - actualHeight < viewportDim.top ? 'bottom'
+              : placement === 'right' && pos.right + actualWidth > viewportDim.width ? 'left'
+              : placement === 'left' && pos.left - actualWidth < viewportDim.left ? 'right'
+              : placement
 
     tip.classList.remove(orgPlacement)
     tip.classList.add(placement)

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -482,6 +482,40 @@ Tooltip.prototype.getDelegateComponent = function (element) {
   return component
 }
 
+Tooltip.prototype.recalculatePosition = function() {
+  var tip = this.getTooltipElement();
+  var placement = typeof this.options.placement == 'function' ?
+    this.options.placement.call(this, tip, this.element) :
+    this.options.placement
+
+  var autoToken = /\s?auto?\s?/i
+  var autoPlace = autoToken.test(placement)
+  if (autoPlace) placement = placement.replace(autoToken, '') || 'top'
+
+  tip.classList.add(placement)
+
+  var pos          = this.element.getBoundingClientRect()
+  var actualWidth  = tip.offsetWidth
+  var actualHeight = tip.offsetHeight
+
+  if (autoPlace) {
+    var orgPlacement = placement
+    var viewportDim = this.viewport.getBoundingClientRect()
+
+    placement = placement == 'bottom' && pos.bottom + actualHeight > viewportDim.bottom ? 'top'    :
+                placement == 'top'    && pos.top    - actualHeight < viewportDim.top    ? 'bottom' :
+                placement == 'right'  && pos.right  + actualWidth  > viewportDim.width  ? 'left'   :
+                placement == 'left'   && pos.left   - actualWidth  < viewportDim.left   ? 'right'  :
+                placement
+
+    tip.classList.remove(orgPlacement)
+    tip.classList.add(placement)
+  }
+
+  var calculatedOffset = this.getCalculatedOffset(placement, pos, actualWidth, actualHeight)
+  this.applyPlacement(calculatedOffset, placement)
+}
+
 function extend () {
   var args = Array.prototype.slice.apply(arguments)
   var target = args.shift()

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -116,9 +116,9 @@ Tooltip.prototype.stopObservingMutations = function () {
   this.mutationObserver.disconnect()
 }
 
-Tooltip.prototype.handleMutations = function (mutations) {
-  this.stopObservingMutations()
+Tooltip.prototype.handleMutations = function () {
   window.requestAnimationFrame(function () {
+    this.stopObservingMutations()
     this.recalculatePosition()
     this.startObservingMutations()
   }.bind(this))


### PR DESCRIPTION
### Description of the Change

This PR implements `Tooltip#recalculatePosition` which resets the Tooltip's position based on its current size. It also adds a `MutationObserver` that watches for the tooltip to change and calls the aforementioned method on the next animation frame when it does.

### Alternate Designs

`ResizeObserver` is not available until Electron 1.6 (with a flag), so a `MutationObserver` covers the majority of the important use cases until then.

I originally implemented this so the resizing operation took place in an `atom.views.pollDocument` call, but this made the tooltip feel very jerky, so I put it in an rAF instead. Happy to hear other 💭 s.

/cc @nathansobo 