### PR TITLE
Unbreak URL handlers in Atom 1.17-beta

### DIFF
--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -642,7 +642,8 @@ class AtomApplication
   openUrl: ({urlToOpen, devMode, safeMode, env}) ->
     unless @packages?
       PackageManager = require '../package-manager'
-      @packages = new PackageManager
+      @packages = new PackageManager()
+      @packages.initialize
         configDirPath: process.env.ATOM_HOME
         devMode: devMode
         resourcePath: @resourcePath


### PR DESCRIPTION
This fixes a regression caused by https://github.com/atom/atom/commit/c4d0944c0da51e0a2d88273ff58a47c469d07be8.

The `urlOpen` function in AtomApplication is still constructing the `PackageManager` in the old way, but we need to use `initialize` now. (Let me know if there is a better way to do this now that we have snapshots!)

Released under CC0.