### PR TITLE
Adding an event for Code-Folding to TextEditor class

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -789,6 +789,15 @@ class TextEditor extends Model
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidRemoveGutter: (callback) ->
     @gutterContainer.onDidRemoveGutter callback
+    
+  # Essential: Calls your `callback` when a {Fold} is toggled in the editor.
+  #
+  # * `callback` {Function}
+  #   * `name` The name of the {Fold} that was toggled.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidToggleFold: (callback) ->
+    @foldContainer.onDidToggleFold callback
 
   # Set the number of characters that can be displayed horizontally in the
   # editor.


### PR DESCRIPTION
### Description of the Change

This few lines of extra code should add the possibility to manage Code-Folding efficiently. At the time, if you want to develope anything around Code-Folding, the only possibility is to permanently check if a row is folded (with the "isFoldedAtBufferRow()" function).

The problem is: every line inside the block i folded, also gets recognized as folded. So I can't check if maybe a sub-block is also folded

### Alternate Designs

Maybe it would be better to use these events:
onDidFolded
onDidUnfolded

### Why Should This Be In Core?

Because Code-Folding is also very important to many developers and is yet not really integrated.

### Benefits

Easier Package-Development with Code-Folding

### Possible Drawbacks

No drawbacks at all

### Applicable Issues

As it only extends the core, there should not be any issues
