### PR TITLE
Add app name to the Quit menu on macOS

### DIFF
--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -26,7 +26,7 @@
       { label: 'Hide Others', command: 'application:hide-other-applications' }
       { label: 'Show All', command: 'application:unhide-all-applications' }
       { type: 'separator' }
-      { label: 'Quit', command: 'application:quit' }
+      { label: 'Quit Atom', command: 'application:quit' }
     ]
   }
   {


### PR DESCRIPTION
To adhere to the macOS Human Interface Guidelines: https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/OSXHIGuidelines/MenuBarMenus.html