### PR TITLE
Ensure binary compatibility checks with/without the module cache are consistent

### DIFF
--- a/src/package.coffee
+++ b/src/package.coffee
@@ -658,10 +658,13 @@ class Package
 
     @activationHooks = _.uniq(@activationHooks)
 
+  getNativeBindingDirectory: (modulePath) ->
+    path.join(modulePath, 'build', 'Release')
+
   # Does the given module path contain native code?
   isNativeModule: (modulePath) ->
     try
-      fs.listSync(path.join(modulePath, 'build', 'Release'), ['.node']).length > 0
+      fs.listSync(@getNativeBindingDirectory(modulePath), ['.node']).length > 0
     catch error
       false
 
@@ -676,8 +679,10 @@ class Package
     if @metadata._atomModuleCache?
       relativeNativeModuleBindingPaths = @metadata._atomModuleCache.extensions?['.node'] ? []
       for relativeNativeModuleBindingPath in relativeNativeModuleBindingPaths
-        nativeModulePath = path.join(@path, relativeNativeModuleBindingPath, '..', '..', '..')
-        nativeModulePaths.push(nativeModulePath)
+        relativeNativeModulePath = path.join(relativeNativeModuleBindingPath, '..', '..', '..')
+        if path.dirname(relativeNativeModuleBindingPath) is @getNativeBindingDirectory(relativeNativeModulePath)
+          nativeModulePath = path.join(@path, relativeNativeModulePath)
+          nativeModulePaths.push(nativeModulePath)
       return nativeModulePaths
 
     traversePath = (nodeModulesPath) =>


### PR DESCRIPTION
The binary compatibility check normally only looks at `.node` files inside `build/Release`. However, the check with the cached `_atomModuleCache` looks at _all_ `.node` files no matter where they are.

This can cause all sorts of issues depending on where the `.node` files are. Since `_atomModuleCache` blindly indexes all files in the package, this can false-alarm on incompatible binaries even if they're never required.