### PR TITLE
Disable zoom only after the window has finished loading

### DIFF
--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -86,6 +86,7 @@ class AtomWindow
     @browserWindow.loadSettingsJSON = JSON.stringify(loadSettings)
 
     @browserWindow.on 'window:loaded', =>
+      @disableZoom()
       @emit 'window:loaded'
       @resolveLoadedPromise()
 
@@ -110,7 +111,6 @@ class AtomWindow
 
     hasPathToOpen = not (locationsToOpen.length is 1 and not locationsToOpen[0].pathToOpen?)
     @openLocations(locationsToOpen) if hasPathToOpen and not @isSpecWindow()
-    @disableZoom()
 
     @atomApplication.addWindow(this)
 


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/14252.

Previously, we were disabling the zoom functionality right when creating an `AtomWindow` instance, which doesn't work possibly due to `webContents` not being ready yet.

With this pull request we will disable zooming in/out only after receiving the `window:loaded` event from the renderer process.

/cc: @ungb @iolsen 

 