### PR TITLE
Fix SyntaxError while building v1.16.0 release on Ubuntu 17.04 i686

### DIFF
--- a/script/lib/code-sign-on-mac.js
+++ b/script/lib/code-sign-on-mac.js
@@ -10,7 +10,7 @@ module.exports = function (packagedAppPath) {
     return
   }
 
-  let certPath = process.env.ATOM_MAC_CODE_SIGNING_CERT_PATH;
+  var certPath = process.env.ATOM_MAC_CODE_SIGNING_CERT_PATH;
   if (!certPath) {
     certPath = path.join(os.tmpdir(), 'mac.p12')
     downloadFileFromGithub(process.env.ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL, certPath)


### PR DESCRIPTION
 Fix **SyntaxError** while building v1.16.0 release on Ubuntu 17.04 i686 with `./script/build --create-debian-package`

```
~/atom/script/lib/code-sign-on-mac.js:13
  let certPath = process.env.ATOM_MAC_CODE_SIGNING_CERT_PATH;
    ^^^

    SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

Thank's to @yvan-sraka for it's helpful debug!