### PR TITLE
Ensure that win_delay_load_hook.cc is included in the bundled app

### DIFF
--- a/script/lib/include-path-in-packaged-app.js
+++ b/script/lib/include-path-in-packaged-app.js
@@ -3,8 +3,8 @@
 const path = require('path')
 const CONFIG = require('../config')
 
-module.exports = function (path) {
-  return !EXCLUDED_PATHS_REGEXP.test(path)
+module.exports = function (filePath) {
+  return !EXCLUDED_PATHS_REGEXP.test(filePath) || INCLUDED_PATHS_REGEXP.test(filePath)
 }
 
 const EXCLUDE_REGEXPS_SOURCES = [
@@ -82,6 +82,10 @@ if (process.platform === 'darwin') {
 
 const EXCLUDED_PATHS_REGEXP = new RegExp(
   EXCLUDE_REGEXPS_SOURCES.map(path => `(${path})`).join('|')
+)
+
+const INCLUDED_PATHS_REGEXP = new RegExp(
+  escapeRegExp(path.join('node_modules', 'node-gyp', 'src', 'win_delay_load_hook.cc'))
 )
 
 function escapeRegExp (string) {


### PR DESCRIPTION
### Description of the Change

The file `src/win_delay_load_hook.cc` is required for node_gyp to build native dependencies on Windows. This overrides the exclusion of `*.cc` and `*.h` sources from the packaged app for this specific, odd case, allowing native dependency builds to succeed again.

### Alternate Designs

I tried to find a way to modify the existing regexp to prevent `EXCLUDED_PATHS_REGEXP` from matching this file, but unfortunately JavaScript doesn't support negative lookbehind and I was concerned about the risk of an explosion in computational complexity with the workarounds.

I also considered splitting the `*.(cc|h)` exclusion rule into more specific exclusion rules, but there are too many of each that we _do_ want to exclude (all of the others; currently about 375 *.cc and 1000 *.h files). That would also cause a maintenance issue when adding any new dependencies with native components in the future.

### Why Should This Be In Core?

That's where the build scripts are :wink:

### Benefits

Attempting to build native dependencies on Windows machines fails with an error containing the following:

```
c1xx : fatal error C1083: Cannot open source file: 'C:\Users\foo\AppData\Local\Atom x64\app-dev\resources\app\apm\node_modules\node-gyp\src\win_delay_load_hook.cc': No such file or directory [C:\Users\foo\Documents\GitHub\xyz\node_modules\keytar\build\keytar.vcxproj]
```

These builds now succeed.

### Possible Drawbacks

Juggling multiple inclusion and exclusion patterns with precedence can quickly gets confusing (see: .gitignore files).

### Applicable Issues

My previous attempt to fix this was in atom/apm#716, merged in atom/atom#14331.
