### PR TITLE
🎉

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,12 @@ install:
   - nvm install $NODE_VERSION
   - nvm use --delete-prefix $NODE_VERSION
   - npm install -g npm
-  - script/build --create-debian-package --create-rpm-package --compress-artifacts
+  - script/build
 
 script:
   - script/lint
   - script/test
+  - cat /tmp/disposable.log
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,11 @@ install:
   - nvm install $NODE_VERSION
   - nvm use --delete-prefix $NODE_VERSION
   - npm install -g npm
-  - script/build
+  - script/build --create-debian-package --create-rpm-package --compress-artifacts
 
 script:
   - script/lint
   - script/test
-  - cat /tmp/disposable.log
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "exception-reporting": "0.41.4",
     "find-and-replace": "0.208.1",
     "fuzzy-finder": "1.5.6",
-    "github": "0.0.2",
+    "github": "0.0.4",
     "git-diff": "1.3.6",
     "go-to-line": "0.32.1",
     "grammar-selector": "0.49.4",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "exception-reporting": "0.41.4",
     "find-and-replace": "0.208.1",
     "fuzzy-finder": "1.5.6",
-    "github": "0.0.1",
+    "github": "0.0.2",
     "git-diff": "1.3.6",
     "go-to-line": "0.32.1",
     "grammar-selector": "0.49.4",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "timecop": "0.36.0",
     "tree-view": "0.217.0-7",
     "update-package-dependencies": "0.11.0",
-    "welcome": "0.36.2",
+    "welcome": "0.36.3",
     "whitespace": "0.36.2",
     "wrap-guide": "0.40.2",
     "language-c": "0.58.0",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "exception-reporting": "0.41.4",
     "find-and-replace": "0.208.1",
     "fuzzy-finder": "1.5.6",
+    "github": "0.0.1",
     "git-diff": "1.3.6",
     "go-to-line": "0.32.1",
     "grammar-selector": "0.49.4",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "exception-reporting": "0.41.4",
     "find-and-replace": "0.208.1",
     "fuzzy-finder": "1.5.6",
-    "github": "0.0.5",
+    "github": "0.0.6",
     "git-diff": "1.3.6",
     "go-to-line": "0.32.1",
     "grammar-selector": "0.49.4",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "exception-reporting": "0.41.4",
     "find-and-replace": "0.208.1",
     "fuzzy-finder": "1.5.6",
-    "github": "0.0.4",
+    "github": "0.0.5",
     "git-diff": "1.3.6",
     "go-to-line": "0.32.1",
     "grammar-selector": "0.49.4",

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,7 +6,7 @@ const cleanDependencies = require('./lib/clean-dependencies')
 const deleteMsbuildFromPath = require('./lib/delete-msbuild-from-path')
 const dependenciesFingerprint = require('./lib/dependencies-fingerprint')
 const installApm = require('./lib/install-apm')
-const installAtomDependencies = require('./lib/install-atom-dependencies')
+const runApmInstall = require('./lib/run-apm-install')
 const installScriptDependencies = require('./lib/install-script-dependencies')
 const verifyMachineRequirements = require('./lib/verify-machine-requirements')
 
@@ -25,6 +25,6 @@ if (process.platform === 'win32') deleteMsbuildFromPath()
 
 installScriptDependencies()
 installApm()
-installAtomDependencies()
+runApmInstall(CONFIG.repositoryRootPath)
 
 dependenciesFingerprint.write()

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,6 +2,7 @@
 
 'use strict'
 
+const CONFIG = require('./config')
 const cleanDependencies = require('./lib/clean-dependencies')
 const deleteMsbuildFromPath = require('./lib/delete-msbuild-from-path')
 const dependenciesFingerprint = require('./lib/dependencies-fingerprint')

--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -43,6 +43,9 @@ module.exports = function (packagedAppPath) {
         relativePath == path.join('..', 'node_modules', 'glob', 'glob.js') ||
         relativePath == path.join('..', 'node_modules', 'graceful-fs', 'graceful-fs.js') ||
         relativePath == path.join('..', 'node_modules', 'htmlparser2', 'lib', 'index.js') ||
+        relativePath == path.join('..', 'node_modules', 'markdown-preview', 'node_modules', 'htmlparser2', 'lib', 'index.js') ||
+        relativePath == path.join('..', 'node_modules', 'roaster', 'node_modules', 'htmlparser2', 'lib', 'index.js') ||
+        relativePath == path.join('..', 'node_modules', 'task-lists', 'node_modules', 'htmlparser2', 'lib', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'iconv-lite', 'encodings', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'less', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'less', 'lib', 'less', 'fs.js') ||

--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -27,6 +27,7 @@ module.exports = function (packagedAppPath) {
         modulePath.endsWith('.node') ||
         coreModules.has(modulePath) ||
         (relativePath.startsWith(path.join('..', 'src')) && relativePath.endsWith('-element.js')) ||
+        relativePath.startsWith(path.join('..', 'node_modules', 'dugite')) ||
         relativePath == path.join('..', 'exports', 'atom.js') ||
         relativePath == path.join('..', 'src', 'electron-shims.js') ||
         relativePath == path.join('..', 'src', 'safe-clipboard.js') ||
@@ -37,6 +38,7 @@ module.exports = function (packagedAppPath) {
         relativePath == path.join('..', 'node_modules', 'cson-parser', 'node_modules', 'coffee-script', 'lib', 'coffee-script', 'register.js') ||
         relativePath == path.join('..', 'node_modules', 'decompress-zip', 'lib', 'decompress-zip.js') ||
         relativePath == path.join('..', 'node_modules', 'debug', 'node.js') ||
+        relativePath == path.join('..', 'node_modules', 'fs-extra', 'lib', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'git-utils', 'lib', 'git.js') ||
         relativePath == path.join('..', 'node_modules', 'glob', 'glob.js') ||
         relativePath == path.join('..', 'node_modules', 'graceful-fs', 'graceful-fs.js') ||
@@ -47,6 +49,8 @@ module.exports = function (packagedAppPath) {
         relativePath == path.join('..', 'node_modules', 'less', 'lib', 'less-node', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'less', 'node_modules', 'graceful-fs', 'graceful-fs.js') ||
         relativePath == path.join('..', 'node_modules', 'minimatch', 'minimatch.js') ||
+        relativePath == path.join('..', 'node_modules', 'node-fetch', 'lib', 'fetch-error.js') ||
+        relativePath == path.join('..', 'node_modules', 'nsfw', 'node_modules', 'fs-extra', 'lib', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'superstring', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'oniguruma', 'src', 'oniguruma.js') ||
         relativePath == path.join('..', 'node_modules', 'request', 'index.js') ||

--- a/script/lib/run-apm-install.js
+++ b/script/lib/run-apm-install.js
@@ -1,11 +1,9 @@
-'use strict'
-
 const childProcess = require('child_process')
 const path = require('path')
 
 const CONFIG = require('../config')
 
-module.exports = function () {
+module.exports = function (packagePath) {
   const installEnv = Object.assign({}, process.env)
   // Set resource path so that apm can load metadata related to Atom.
   installEnv.ATOM_RESOURCE_PATH = CONFIG.repositoryRootPath
@@ -15,6 +13,6 @@ module.exports = function () {
   childProcess.execFileSync(
     CONFIG.getApmBinPath(),
     ['--loglevel=error', 'install'],
-    {env: installEnv, cwd: CONFIG.repositoryRootPath, stdio: 'inherit'}
+    {env: installEnv, cwd: packagePath, stdio: 'inherit'}
   )
 }

--- a/script/lib/run-apm-install.js
+++ b/script/lib/run-apm-install.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const childProcess = require('child_process')
 const path = require('path')
 

--- a/script/test
+++ b/script/test
@@ -41,6 +41,7 @@ function runCoreMainProcessTests (callback) {
   console.log('Executing core main process tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {
     stdio: 'inherit',
+    env: Object.assign({}, process.env, {ATOM_GITHUB_INLINE_GIT_EXEC: 'true'})
   })
   cp.on('error', error => { callback(error) })
   cp.on('close', exitCode => { callback(null, exitCode) })

--- a/script/test
+++ b/script/test
@@ -88,8 +88,20 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
     ]
 
     const pkgJsonPath = path.join(repositoryPackagePath, 'package.json')
+    const nodeModulesPath = path.join(repositoryPackagePath, 'node_modules')
+    const nodeModulesBackupPath = path.join(repositoryPackagePath, 'node_modules.bak')
+    let finalize = () => null
     if (require(pkgJsonPath).atomTestRunner) {
       console.log(`Installing test runner dependencies for ${packageName}`.bold.green)
+      if (fs.existsSync(nodeModulesPath)) {
+        fs.copySync(nodeModulesPath, nodeModulesBackupPath)
+        finalize = () => {
+          fs.removeSync(nodeModulesPath)
+          fs.renameSync(nodeModulesBackupPath, nodeModulesPath)
+        }
+      } else {
+        finalize = () => fs.removeSync(nodeModulesPath)
+      }
       runApmInstall(repositoryPackagePath)
       console.log(`Executing ${packageName} tests`.green)
     } else {
@@ -98,12 +110,16 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
     const cp = childProcess.spawn(executablePath, testArguments)
     let stderrOutput = ''
     cp.stderr.on('data', data => stderrOutput += data)
-    cp.on('error', error => { callback(error) })
+    cp.on('error', error => {
+      finalize()
+      callback(error)
+    })
     cp.on('close', exitCode => {
       if (exitCode !== 0) {
         console.log(`Package tests failed for ${packageName}:`.red)
         console.log(stderrOutput)
       }
+      finalize()
       callback(null, exitCode)
     })
   })

--- a/script/test
+++ b/script/test
@@ -6,11 +6,12 @@ require('colors')
 const assert = require('assert')
 const async = require('async')
 const childProcess = require('child_process')
-const fs = require('fs')
+const fs = require('fs-extra')
 const glob = require('glob')
 const path = require('path')
 
 const CONFIG = require('./config')
+const runApmInstall = require('./lib/run-apm-install')
 
 const resourcePath = CONFIG.repositoryRootPath
 let executablePath
@@ -62,19 +63,29 @@ function runCoreRenderProcessTests (callback) {
 // Build an array of functions, each running tests for a different bundled package
 const packageTestSuites = []
 for (let packageName in CONFIG.appMetadata.packageDependencies) {
-  const packagePath = path.join(CONFIG.repositoryRootPath, 'node_modules', packageName)
-  const packageSpecDirPath = ['spec', 'test']
-    .map(folder => path.join(packagePath, folder))
-    .find(fullPath => fs.existsSync(fullPath))
-  if (!packageSpecDirPath) continue
+  const repositoryPackagePath = path.join(CONFIG.repositoryRootPath, 'node_modules', packageName)
+  const intermediatePackagePath = path.join(CONFIG.intermediateAppPath, 'node_modules', packageName)
+  const testSubdir = ['spec', 'test'].find(subdir => fs.existsSync(path.join(intermediatePackagePath, subdir)))
+
+  if (!testSubdir) {
+    console.log(`Skipping test for ${packageName} because no test folder was found`.bold.yellow)
+    continue
+  }
+
+  const sourceTestFolder = path.join(repositoryPackagePath, testSubdir)
+  const targetTestFolder = path.join(intermediatePackagePath, testSubdir)
 
   packageTestSuites.push(function (callback) {
     const testArguments = [
       '--resource-path', resourcePath,
-      '--test', packageSpecDirPath
+      '--test', targetTestFolder
     ]
 
-    console.log(`Executing ${packageName} tests`.bold.green)
+    fs.removeSync(targetTestFolder)
+    fs.copySync(sourceTestFolder, targetTestFolder)
+    console.log(`Installing dependencies for ${packageName}`.bold.green)
+    runApmInstall(intermediatePackagePath)
+    console.log(`Executing ${packageName} tests`.green)
     const cp = childProcess.spawn(executablePath, testArguments)
     let stderrOutput = ''
     cp.stderr.on('data', data => stderrOutput += data)

--- a/script/test
+++ b/script/test
@@ -63,6 +63,11 @@ function runCoreRenderProcessTests (callback) {
 // Build an array of functions, each running tests for a different bundled package
 const packageTestSuites = []
 for (let packageName in CONFIG.appMetadata.packageDependencies) {
+  if (process.env.ATOM_PACKAGES_TO_TEST) {
+    const packagesToTest = process.env.ATOM_PACKAGES_TO_TEST.split(',').map(pkg => pkg.trim())
+    if (!packagesToTest.includes(packageName)) continue
+  }
+
   const repositoryPackagePath = path.join(CONFIG.repositoryRootPath, 'node_modules', packageName)
   const testSubdir = ['spec', 'test'].find(subdir => fs.existsSync(path.join(repositoryPackagePath, subdir)))
 

--- a/script/test
+++ b/script/test
@@ -41,7 +41,6 @@ function runCoreMainProcessTests (callback) {
   console.log('Executing core main process tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {
     stdio: 'inherit',
-    env: Object.assign({}, process.env, {ATOM_GITHUB_INLINE_GIT_EXEC: 'true'})
   })
   cp.on('error', error => { callback(error) })
   cp.on('close', exitCode => { callback(null, exitCode) })

--- a/script/test
+++ b/script/test
@@ -83,9 +83,14 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
 
     fs.removeSync(targetTestFolder)
     fs.copySync(sourceTestFolder, targetTestFolder)
-    console.log(`Installing dependencies for ${packageName}`.bold.green)
-    runApmInstall(intermediatePackagePath)
-    console.log(`Executing ${packageName} tests`.green)
+    const pkgJsonPath = path.join(intermediatePackagePath, 'package.json')
+    if (require(pkgJsonPath).atomTestRunner) {
+      console.log(`Installing dependencies for ${packageName}`.bold.green)
+      runApmInstall(intermediatePackagePath)
+      console.log(`Executing ${packageName} tests`.green)
+    } else {
+      console.log(`Executing ${packageName} tests`.bold.green)
+    }
     const cp = childProcess.spawn(executablePath, testArguments)
     let stderrOutput = ''
     cp.stderr.on('data', data => stderrOutput += data)

--- a/script/test
+++ b/script/test
@@ -38,7 +38,10 @@ function runCoreMainProcessTests (callback) {
   ]
 
   console.log('Executing core main process tests'.bold.green)
-  const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit'})
+  const cp = childProcess.spawn(executablePath, testArguments, {
+    stdio: 'inherit',
+    env: Object.assign({}, process.env, {ATOM_GITHUB_INLINE_GIT_EXEC: 'true'})
+  })
   cp.on('error', error => { callback(error) })
   cp.on('close', exitCode => { callback(null, exitCode) })
 }

--- a/script/test
+++ b/script/test
@@ -59,8 +59,11 @@ function runCoreRenderProcessTests (callback) {
 // Build an array of functions, each running tests for a different bundled package
 const packageTestSuites = []
 for (let packageName in CONFIG.appMetadata.packageDependencies) {
-  const packageSpecDirPath = path.join(CONFIG.repositoryRootPath, 'node_modules', packageName, 'spec')
-  if (!fs.existsSync(packageSpecDirPath)) continue
+  const packagePath = path.join(CONFIG.repositoryRootPath, 'node_modules', packageName)
+  const packageSpecDirPath = ['spec', 'test']
+    .map(folder => path.join(packagePath, folder))
+    .find(fullPath => fs.existsSync(fullPath))
+  if (!packageSpecDirPath) continue
 
   packageTestSuites.push(function (callback) {
     const testArguments = [

--- a/script/test
+++ b/script/test
@@ -64,29 +64,28 @@ function runCoreRenderProcessTests (callback) {
 const packageTestSuites = []
 for (let packageName in CONFIG.appMetadata.packageDependencies) {
   const repositoryPackagePath = path.join(CONFIG.repositoryRootPath, 'node_modules', packageName)
-  const intermediatePackagePath = path.join(CONFIG.intermediateAppPath, 'node_modules', packageName)
-  const testSubdir = ['spec', 'test'].find(subdir => fs.existsSync(path.join(intermediatePackagePath, subdir)))
+  const testSubdir = ['spec', 'test'].find(subdir => fs.existsSync(path.join(repositoryPackagePath, subdir)))
 
   if (!testSubdir) {
-    console.log(`Skipping test for ${packageName} because no test folder was found`.bold.yellow)
+    packageTestSuites.push(function (callback) {
+      console.log(`Skipping tests for ${packageName} because no test folder was found`.bold.yellow)
+      callback(null, 0)
+    })
     continue
   }
 
-  const sourceTestFolder = path.join(repositoryPackagePath, testSubdir)
-  const targetTestFolder = path.join(intermediatePackagePath, testSubdir)
+  const testFolder = path.join(repositoryPackagePath, testSubdir)
 
   packageTestSuites.push(function (callback) {
     const testArguments = [
       '--resource-path', resourcePath,
-      '--test', targetTestFolder
+      '--test', testFolder
     ]
 
-    fs.removeSync(targetTestFolder)
-    fs.copySync(sourceTestFolder, targetTestFolder)
-    const pkgJsonPath = path.join(intermediatePackagePath, 'package.json')
+    const pkgJsonPath = path.join(repositoryPackagePath, 'package.json')
     if (require(pkgJsonPath).atomTestRunner) {
-      console.log(`Installing dependencies for ${packageName}`.bold.green)
-      runApmInstall(intermediatePackagePath)
+      console.log(`Installing test runner dependencies for ${packageName}`.bold.green)
+      runApmInstall(repositoryPackagePath)
       console.log(`Executing ${packageName} tests`.green)
     } else {
       console.log(`Executing ${packageName} tests`.bold.green)

--- a/src/initialize-application-window.coffee
+++ b/src/initialize-application-window.coffee
@@ -29,6 +29,7 @@ if global.isGeneratingSnapshot
   require('dalek')
   require('find-and-replace')
   require('fuzzy-finder')
+  require('github')
   require('git-diff')
   require('go-to-line')
   require('grammar-selector')


### PR DESCRIPTION
itshappening.gif

---

For posterity: In addition to some more exciting changes ✨, this PR makes some changes to the way we run tests. In particular, if a core package has an `atomTestRunner` entry in it's `package.json`, we now perform the following operations:

1. Copy the package's `node_modules` to `node_modules.bak`
2. Run `apm install` inside the package folder to install all its devDependencies
3. Run the tests as usual
4. Remove the new `node_modules` folder and rename `node_modules.bak` to `node_modules`

This ensures that all test dependencies get installed, while also ensuring that we don't corrupt CI's `node_modules` cache.