### PR TITLE
Add configuration for probot-stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,24 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+# Starting at two years of no activity
+daysUntilStale: 730
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+daysUntilClose: 30
+# Issues or Pull Requests with these labels will never be considered stale
+exemptLabels:
+  - security
+  - triaged
+# Label to use when marking as stale
+staleLabel: stale
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+closeComment: false
+# Limit to only `issues` or `pulls`
+only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,6 +7,7 @@ daysUntilStale: 730
 daysUntilClose: 30
 # Issues or Pull Requests with these labels will never be considered stale
 exemptLabels:
+  - regression
   - security
   - triaged
 # Label to use when marking as stale


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Add configuration for the [probot-stale integration](https://github.com/probot/stale) to automatically close issues that have not had any recent activity. Currently set to notify issues that haven't had any activity in two years and then close if it still doesn't have activity in an additional 30 days after being notified.

### Alternate Designs

Have been doing this kind of thing manually :cry:

### Why Should This Be In Core?

This is project configuration, not adding anything to the Atom application.

### Benefits

Not having to clean up old issues manually.

### Possible Drawbacks

Might close issues that we still want to remain open but we will be tracking the stale label to ensure that doesn't happen.

### Applicable Issues

N/A
