### PR TITLE
Act on active center items only when saving and closing

### DIFF
--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2486,7 +2486,7 @@ i = /test/; #FIXME\
       waitsForPromise(() => atom.workspace.open())
     })
 
-    it('closes the active pane item, or the active pane if it is empty, or the current window if there is only the empty root pane', async () => {
+    it('closes the active center pane item, or the active center pane if it is empty, or the current window if there is only the empty root pane in the center', async () => {
       atom.config.set('core.destroyEmptyPanes', false)
 
       const pane1 = atom.workspace.getActivePane()
@@ -2509,6 +2509,7 @@ i = /test/; #FIXME\
       expect(pane1.getItems().length).toBe(0)
       expect(atom.workspace.getCenter().getPanes().length).toBe(1)
 
+      // The dock items should not be closed
       await atom.workspace.open({
         getTitle: () => 'Permanent Dock Item',
         element: document.createElement('div'),
@@ -2522,13 +2523,6 @@ i = /test/; #FIXME\
       })
 
       expect(atom.workspace.getLeftDock().getPaneItems().length).toBe(2)
-      atom.workspace.closeActivePaneItemOrEmptyPaneOrWindow()
-      expect(atom.workspace.getLeftDock().getPaneItems().length).toBe(1)
-      atom.workspace.closeActivePaneItemOrEmptyPaneOrWindow()
-      expect(atom.workspace.getLeftDock().getPaneItems().length).toBe(1)
-      expect(atom.close).not.toHaveBeenCalled()
-
-      atom.workspace.getCenter().activate()
       atom.workspace.closeActivePaneItemOrEmptyPaneOrWindow()
       expect(atom.close).toHaveBeenCalled()
     })

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1307,7 +1307,7 @@ module.exports = class Workspace extends Model {
   // {::saveActivePaneItemAs} # will be called instead. This method does nothing
   // if the active item does not implement a `.save` method.
   saveActivePaneItem () {
-    this.getActivePane().saveActiveItem()
+    this.getCenter().getActivePane().saveActiveItem()
   }
 
   // Prompt the user for a path and save the active pane item to it.
@@ -1316,7 +1316,7 @@ module.exports = class Workspace extends Model {
   // `.saveAs` on the item with the selected path. This method does nothing if
   // the active item does not implement a `.saveAs` method.
   saveActivePaneItemAs () {
-    this.getActivePane().saveActiveItemAs()
+    this.getCenter().getActivePane().saveActiveItemAs()
   }
 
   // Destroy (close) the active pane item.
@@ -1419,13 +1419,13 @@ module.exports = class Workspace extends Model {
     }
   }
 
-  // Close the active pane item, or the active pane if it is empty,
-  // or the current window if there is only the empty root pane.
+  // Close the active center pane item, or the active center pane if it is
+  // empty, or the current window if there is only the empty root pane.
   closeActivePaneItemOrEmptyPaneOrWindow () {
-    if (this.getActivePaneItem() != null) {
-      this.destroyActivePaneItem()
+    if (this.getCenter().getActivePaneItem() != null) {
+      this.getCenter().getActivePane().destroyActiveItem()
     } else if (this.getCenter().getPanes().length > 1) {
-      this.destroyActivePane()
+      this.getCenter().destroyActivePane()
     } else if (this.config.get('core.closeEmptyWindows')) {
       atom.close()
     }


### PR DESCRIPTION
This PR changes the behavior of the save and close commands to only act on the active item in the *center* of the workspace, rather than including items in docks.

This *could* be slightly confusing in some cases, such as if a user drags an editor or other save-able/closeable item into a dock, but ultimately treating dock items the same as center items for saving and closing has proven to be more confusing than helpful.

/cc @matthewwithanm @BinaryMuse @smashwilson @lee-dohm 