### PR TITLE
Don't open dev tools on uncaught errors in headless tests

### DIFF
--- a/script/test
+++ b/script/test
@@ -41,7 +41,7 @@ function runCoreMainProcessTests (callback) {
   console.log('Executing core main process tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {
     stdio: 'inherit',
-    env: Object.assign({}, process.env, {ATOM_GITHUB_INLINE_GIT_EXEC: 'true'})
+    env: Object.assign({ELECTRON_ENABLE_LOGGING: 1}, process.env, {ATOM_GITHUB_INLINE_GIT_EXEC: 'true'})
   })
   cp.on('error', error => { callback(error) })
   cp.on('close', exitCode => { callback(null, exitCode) })
@@ -55,7 +55,11 @@ function runCoreRenderProcessTests (callback) {
   ]
 
   console.log('Executing core render process tests'.bold.green)
-  const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit'})
+  const cp = childProcess.spawn(
+    executablePath,
+    testArguments,
+    {stdio: 'inherit', env: Object.assign({ELECTRON_ENABLE_LOGGING: 1}, process.env)}
+  )
   cp.on('error', error => { callback(error) })
   cp.on('close', exitCode => { callback(null, exitCode) })
 }
@@ -107,7 +111,11 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
     } else {
       console.log(`Executing ${packageName} tests`.bold.green)
     }
-    const cp = childProcess.spawn(executablePath, testArguments)
+    const cp = childProcess.spawn(
+      executablePath,
+      testArguments,
+      {env: Object.assign({ELECTRON_ENABLE_LOGGING: 1}, process.env)}
+    )
     let stderrOutput = ''
     cp.stderr.on('data', data => stderrOutput += data)
     cp.on('error', error => {

--- a/spec/atom-environment-spec.coffee
+++ b/spec/atom-environment-spec.coffee
@@ -50,10 +50,17 @@ describe "AtomEnvironment", ->
 
   describe "window onerror handler", ->
     devToolsPromise = null
+    originalOpenDevToolsOnError = null
     beforeEach ->
+      originalOpenDevToolsOnError = atom.openDevToolsOnError
+      originalOpenDevToolsOnError = true
       devToolsPromise = Promise.resolve()
       spyOn(atom, 'openDevTools').andReturn(devToolsPromise)
       spyOn(atom, 'executeJavaScriptInDevTools')
+
+    afterEach ->
+      atom.openDevToolsOnError = originalOpenDevToolsOnError
+
 
     it "will open the dev tools when an error is triggered", ->
       try

--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -19,8 +19,9 @@ module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
   applicationDelegate.setWindowDocumentEdited = ->
   window.atom = buildAtomEnvironment({
     applicationDelegate, window, document,
-    configDirPath: process.env.ATOM_HOME
-    enablePersistence: false
+    configDirPath: process.env.ATOM_HOME,
+    enablePersistence: false,
+    openDevToolsOnError: not headless
   })
 
   require './spec-helper'

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -125,8 +125,10 @@ class AtomEnvironment extends Model
 
   # Call .loadOrCreate instead
   constructor: (params={}) ->
-    {@applicationDelegate, @clipboard, @enablePersistence, onlyLoadBaseStyleSheets, @updateProcessEnv} = params
+    {@applicationDelegate, @clipboard, @enablePersistence, onlyLoadBaseStyleSheets} = params
+    {@updateProcessEnv, @openDevToolsOnError} = params
 
+    @openDevToolsOnError ?= true
     @nextProxyRequestId = 0
     @unloaded = false
     @loadTime = null
@@ -779,7 +781,7 @@ class AtomEnvironment extends Model
 
       eventObject = {message, url, line, column, originalError}
 
-      openDevTools = true
+      openDevTools = @openDevToolsOnError
       eventObject.preventDefault = -> openDevTools = false
 
       @emitter.emit 'will-throw-error', eventObject


### PR DESCRIPTION
This is an attempt to debug mysterious failures we're seeing on CI. Our theory is that the dev tools are getting opened due to an uncaught exception and causing subsequent tests to fail.

/cc @as-cii @maxbrunsfeld 