### PR TITLE
Pane shouldn't steal focus from its children

### DIFF
--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -67,7 +67,7 @@ class PaneElement extends HTMLElement
 
   activated: ->
     @isActivating = true
-    @focus()
+    @focus() unless @hasFocus() # Don't steal focus from children.
     @isActivating = false
 
   activeStatusChanged: (active) ->


### PR DESCRIPTION
This was removed in #14175 in order to solve #14173 (editors not being
focused when clicking tabs). However, it means that the pane steals
focus from its children. The solution is to add the guard back and to
solve #14173 in another way: by delaying the activation of the item
(see atom/tabs#439).