### PR TITLE
Show stdout in addition to stderr in script/test

### DIFF
--- a/script/test
+++ b/script/test
@@ -110,6 +110,7 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
     const cp = childProcess.spawn(executablePath, testArguments)
     let stderrOutput = ''
     cp.stderr.on('data', data => stderrOutput += data)
+    cp.stdout.on('data', data => stderrOutput += data)
     cp.on('error', error => {
       finalize()
       callback(error)


### PR DESCRIPTION
Some test runners output on stdout instead of stderr. This changes `script/test` so that if tests fail, output from stdout will also be shown.