### PR TITLE
Add config schema for version pinned packages

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -34,6 +34,16 @@ const configSchema = {
 
         description: 'List of names of installed packages which are not loaded at startup.'
       },
+      versionPinnedPackages: {
+        type: 'array',
+        default: [],
+
+        items: {
+          type: 'string'
+        },
+
+        description: 'List of names of installed packages which are not automatically updated.'
+      },
       customFileTypes: {
         type: 'object',
         default: {},


### PR DESCRIPTION
### Description of the Change

Add configuration schema for version pinned packages. See atom/settings-view#950.

### Alternate Designs

See atom/settings-view#950.

### Why Should This Be In Core?

This is where the configuration schema for `core` settings are defined.

### Benefits

See atom/settings-view#950

### Possible Drawbacks

See atom/settings-view#950

### Applicable Issues

* atom/settings-view#950
