### PR TITLE
Remove jQuery from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "grim": "1.5.0",
     "jasmine-json": "~0.0",
     "jasmine-tagged": "^1.1.4",
-    "jquery": "2.1.4",
     "key-path-helpers": "^0.4.0",
     "less-cache": "1.1.0",
     "line-top-index": "0.2.0",


### PR DESCRIPTION
### Description of the Change
jQuery was removed from `package.json > dependencies` section

### Why Should This Be In Core?

After a search through this repository I found that jQuery isn't being used anywhere but is still part of `package.json` `dependencies`.

### Benefits

Finally removes jQuery from Atom!

### Possible Drawbacks

There may be something still using jQuery in there, so this needs to pass the CI before actually being done
