### PR TITLE
Don't show restore dialog for non-editor dock items

### DIFF
--- a/spec/atom-environment-spec.coffee
+++ b/spec/atom-environment-spec.coffee
@@ -392,6 +392,17 @@ describe "AtomEnvironment", ->
         expect(atom.workspace.open.callCount).toBe(1)
         expect(atom.workspace.open).toHaveBeenCalledWith(__filename)
 
+      describe "when a dock has a non-text editor", ->
+        it "doesn't prompt the user to restore state", ->
+          dock = atom.workspace.getLeftDock()
+          dock.getActivePane().addItem
+            getTitle: -> 'title'
+            element: document.createElement 'div'
+          state = Symbol()
+          spyOn(atom, 'confirm')
+          atom.attemptRestoreProjectStateForPaths(state, [__dirname], [__filename])
+          expect(atom.confirm).not.toHaveBeenCalled()
+
     describe "when the window is dirty", ->
       editor = null
 
@@ -399,6 +410,17 @@ describe "AtomEnvironment", ->
         waitsForPromise -> atom.workspace.open().then (e) ->
           editor = e
           editor.setText('new editor')
+
+      describe "when a dock has a modified editor", ->
+        it "prompts the user to restore the state", ->
+          dock = atom.workspace.getLeftDock()
+          dock.getActivePane().addItem editor
+          spyOn(atom, "confirm").andReturn(1)
+          spyOn(atom.project, 'addPath')
+          spyOn(atom.workspace, 'open')
+          state = Symbol()
+          atom.attemptRestoreProjectStateForPaths(state, [__dirname], [__filename])
+          expect(atom.confirm).toHaveBeenCalled()
 
       it "prompts the user to restore the state in a new window, discarding it and adding folder to current window", ->
         spyOn(atom, "confirm").andReturn(1)

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -901,13 +901,17 @@ class AtomEnvironment extends Model
         @project.addPath(folder) for folder in projectPaths
 
   attemptRestoreProjectStateForPaths: (state, projectPaths, filesToOpen = []) ->
-    paneItemIsEmptyUnnamedTextEditor = (item) ->
-      return false unless item instanceof TextEditor
-      return false if item.getPath() or item.isModified()
+    center = @workspace.getCenter()
+    windowIsUnused = =>
+      for container in @workspace.getPaneContainers()
+        for item in container.getPaneItems()
+          if item instanceof TextEditor
+            return false if item.getPath() or item.isModified()
+          else
+            return false if container is center
       true
 
-    windowIsUnused = @workspace.getPaneItems().every(paneItemIsEmptyUnnamedTextEditor)
-    if windowIsUnused
+    if windowIsUnused()
       @restoreStateIntoThisEnvironment(state)
       Promise.all (@workspace.open(file) for file in filesToOpen)
     else


### PR DESCRIPTION
The Nuclide file tree was causing this dialog to be shown every time.
With this commit, we exclude non-editor dock items from the "dirty"
check.

cc @BinaryMuse @maxbrunsfeld