### PR TITLE
Update some of the out-of-date dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "async": "0.2.6",
     "atom-keymap": "8.1.2",
-    "atom-select-list": "^0.1.0",
+    "atom-select-list": "^0.2.0",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",
     "cached-run-in-this-context": "0.4.1",
@@ -25,7 +25,7 @@
     "clear-cut": "^2.0.2",
     "coffee-script": "1.11.1",
     "color": "^0.7.3",
-    "dedent": "^0.6.0",
+    "dedent": "^0.7.0",
     "devtron": "1.3.0",
     "event-kit": "^2.3.0",
     "find-parent-dir": "^0.3.0",


### PR DESCRIPTION
### Description of the Change
Two outdated packages (dedent and atom-select-list) were upgraded a minor release (from 0.6.0 to 0.7.0 and from 0.1.0 to 0.2.0 respectively)

### Why Should This Be In Core? / Benefits

Tries to decrease the number of outdated dependencies in Atom. 

### Possible Drawbacks

Needs to pass CI to see if there are no regressions

#### ⚠️ NOTE
I will also try to remove the color dependency since it's unused throughout this repository. I want to first see if this commit passes the necessary tests before trying that out 
