### PR TITLE
Fix the atom:// URL handler for real (with tests this time)

### DIFF
--- a/spec/fixtures/packages/package-with-url-main/index.js
+++ b/spec/fixtures/packages/package-with-url-main/index.js
@@ -1,0 +1,4 @@
+module.exports = function initialize() {
+  global.reachedUrlMain = true;
+  return Promise.resolve();
+};

--- a/spec/fixtures/packages/package-with-url-main/package.json
+++ b/spec/fixtures/packages/package-with-url-main/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "package-with-url-main",
+  "version": "1.0.0",
+  "urlMain": "./index.js"
+}

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -437,6 +437,27 @@ describe('AtomApplication', function () {
         assert.deepEqual(await getTreeViewRootDirectories(window2), [dirB])
       })
     })
+
+    describe('when opening atom:// URLs', function () {
+      it('loads the urlMain file in a new window', async function () {
+        const packagePath = path.join(__dirname, '..', 'fixtures', 'packages', 'package-with-url-main')
+        const packagesDirPath = path.join(process.env.ATOM_HOME, 'packages')
+        fs.mkdirSync(packagesDirPath)
+        fs.symlinkSync(packagePath, path.join(packagesDirPath, 'package-with-url-main'), 'junction')
+
+        const atomApplication = buildAtomApplication()
+        const launchOptions = parseCommandLine([])
+        launchOptions.urlsToOpen = ['atom://package-with-url-main/test']
+        let windows = atomApplication.launch(launchOptions)
+        await windows[0].loadedPromise
+
+        let reached = await evalInWebContents(windows[0].browserWindow.webContents, function (sendBackToMainProcess) {
+          sendBackToMainProcess(global.reachedUrlMain)
+        })
+        assert.equal(reached, true);
+        windows[0].close();
+      })
+    })
   })
 
   describe('before quitting', function () {

--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -644,7 +644,7 @@ class AtomApplication
   openUrl: ({urlToOpen, devMode, safeMode, env}) ->
     unless @packages?
       PackageManager = require '../package-manager'
-      @packages = new PackageManager()
+      @packages = new PackageManager({})
       @packages.initialize
         configDirPath: process.env.ATOM_HOME
         devMode: devMode


### PR DESCRIPTION
I messed up the fix in https://github.com/atom/atom/pull/14320 (not sure how I got that to work), since `PackageManager` requires an object in the constructor.
This also adds some real tests so it doesn't break again.

Released under CC0.