### PR TITLE
Install dev dependencies when transpiling

### DIFF
--- a/script/lib/backup-node-modules.js
+++ b/script/lib/backup-node-modules.js
@@ -1,0 +1,20 @@
+const fs = require('fs-extra')
+const path = require('path')
+
+module.exports = function(packagePath) {
+  const nodeModulesPath = path.join(packagePath, 'node_modules')
+  const nodeModulesBackupPath = path.join(packagePath, 'node_modules.bak')
+  if (fs.existsSync(nodeModulesBackupPath)) {
+    throw new Error("Cannot back up " + nodeModulesPath + "; " + nodeModulesBackupPath + " already exists")
+  }
+
+  fs.copySync(nodeModulesPath, nodeModulesBackupPath)
+
+  return function restoreNodeModules() {
+    if (!fs.existsSync(nodeModulesBackupPath)) {
+      throw new Error("Cannot restore " + nodeModulesPath + "; " + nodeModulesBackupPath + " does not exist")
+    }
+    fs.removeSync(nodeModulesPath)
+    fs.renameSync(nodeModulesBackupPath, nodeModulesPath)
+  }
+}

--- a/script/lib/transpile-packages-with-custom-transpiler-paths.js
+++ b/script/lib/transpile-packages-with-custom-transpiler-paths.js
@@ -6,6 +6,7 @@ const glob = require('glob')
 const path = require('path')
 
 const CONFIG = require('../config')
+const backupNodeModules = require('./backup-node-modules')
 const runApmInstall = require('./run-apm-install')
 
 require('colors')
@@ -19,9 +20,7 @@ module.exports = function () {
     const metadata = require(metadataPath)
     if (metadata.atomTranspilers) {
       console.log(' transpiling for package '.cyan + packageName.cyan)
-      const nodeModulesPath = path.join(packagePath, 'node_modules')
-      const nodeModulesBackupPath = path.join(packagePath, 'node_modules.bak')
-      fs.copySync(nodeModulesPath, nodeModulesBackupPath)
+      const restoreNodeModules = backupNodeModules(packagePath)
       runApmInstall(packagePath)
 
       CompileCache.addTranspilerConfigForPath(packagePath, metadata.name, metadata, metadata.atomTranspilers)
@@ -30,8 +29,7 @@ module.exports = function () {
         pathsToCompile.forEach(transpilePath)
       }
 
-      fs.removeSync(nodeModulesPath)
-      fs.renameSync(nodeModulesBackupPath, nodeModulesPath)
+      restoreNodeModules()
     }
   }
 }

--- a/script/lib/transpile-packages-with-custom-transpiler-paths.js
+++ b/script/lib/transpile-packages-with-custom-transpiler-paths.js
@@ -1,29 +1,38 @@
 'use strict'
 
 const CompileCache = require('../../src/compile-cache')
-const fs = require('fs')
+const fs = require('fs-extra')
 const glob = require('glob')
 const path = require('path')
 
 const CONFIG = require('../config')
+const runApmInstall = require('./run-apm-install')
+
+require('colors')
+
 
 module.exports = function () {
   console.log(`Transpiling packages with custom transpiler configurations in ${CONFIG.intermediateAppPath}`)
-  let pathsToCompile = []
   for (let packageName of Object.keys(CONFIG.appMetadata.packageDependencies)) {
     const packagePath = path.join(CONFIG.intermediateAppPath, 'node_modules', packageName)
     const metadataPath = path.join(packagePath, 'package.json')
     const metadata = require(metadataPath)
     if (metadata.atomTranspilers) {
+      console.log(' transpiling for package '.cyan + packageName.cyan)
+      const nodeModulesPath = path.join(packagePath, 'node_modules')
+      const nodeModulesBackupPath = path.join(packagePath, 'node_modules.bak')
+      fs.copySync(nodeModulesPath, nodeModulesBackupPath)
+      runApmInstall(packagePath)
+
       CompileCache.addTranspilerConfigForPath(packagePath, metadata.name, metadata, metadata.atomTranspilers)
       for (let config of metadata.atomTranspilers) {
-        pathsToCompile = pathsToCompile.concat(glob.sync(path.join(packagePath, config.glob), {nodir: true}))
+        const pathsToCompile = glob.sync(path.join(packagePath, config.glob), {nodir: true})
+        pathsToCompile.forEach(transpilePath)
       }
-    }
-  }
 
-  for (let path of pathsToCompile) {
-    transpilePath(path)
+      fs.removeSync(nodeModulesPath)
+      fs.renameSync(nodeModulesBackupPath, nodeModulesPath)
+    }
   }
 }
 

--- a/script/test
+++ b/script/test
@@ -11,6 +11,7 @@ const glob = require('glob')
 const path = require('path')
 
 const CONFIG = require('./config')
+const backupNodeModules = require('./lib/backup-node-modules')
 const runApmInstall = require('./lib/run-apm-install')
 
 const resourcePath = CONFIG.repositoryRootPath
@@ -94,11 +95,7 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
     if (require(pkgJsonPath).atomTestRunner) {
       console.log(`Installing test runner dependencies for ${packageName}`.bold.green)
       if (fs.existsSync(nodeModulesPath)) {
-        fs.copySync(nodeModulesPath, nodeModulesBackupPath)
-        finalize = () => {
-          fs.removeSync(nodeModulesPath)
-          fs.renameSync(nodeModulesBackupPath, nodeModulesPath)
-        }
+        finalize = backupNodeModules(repositoryPackagePath)
       } else {
         finalize = () => fs.removeSync(nodeModulesPath)
       }


### PR DESCRIPTION
This is to allow us to move babel and other dependencies used only during transpiling to dev dependencies so that we can reduce the size of our build artifacts. 

Ref https://github.com/atom/github/issues/638