### PR TITLE
Implement Paste without formatting/indentation

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -51,6 +51,7 @@
   'cmd-x': 'core:cut'
   'cmd-c': 'core:copy'
   'cmd-v': 'core:paste'
+  'cmd-shift-v': 'core:paste-verbatim'
   'shift-up': 'core:select-up'
   'shift-down': 'core:select-down'
   'shift-left': 'core:select-left'

--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -35,6 +35,7 @@
   'ctrl-x': 'core:cut'
   'ctrl-c': 'core:copy'
   'ctrl-v': 'core:paste'
+  'ctrl-shift-v': 'core:paste-verbatim'
   'ctrl-insert': 'core:copy'
   'shift-insert': 'core:paste'
   'shift-up': 'core:select-up'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -43,6 +43,7 @@
   'ctrl-x': 'core:cut'
   'ctrl-c': 'core:copy'
   'ctrl-v': 'core:paste'
+  'ctrl-shift-v': 'core:paste-verbatim'
   'shift-up': 'core:select-up'
   'shift-down': 'core:select-down'
   'shift-left': 'core:select-left'

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -65,6 +65,7 @@
       { label: 'Copy', command: 'core:copy' }
       { label: 'Copy Path', command: 'editor:copy-path' }
       { label: 'Paste', command: 'core:paste' }
+      { label: 'Paste without formatting', command: 'core:paste-verbatim' }
       { label: 'Select All', command: 'core:select-all' }
       { type: 'separator' }
       { label: 'Toggle Comments', command: 'editor:toggle-line-comments' }

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -38,6 +38,7 @@
       { label: 'C&opy', command: 'core:copy' }
       { label: 'Copy Pat&h', command: 'editor:copy-path' }
       { label: '&Paste', command: 'core:paste' }
+      { label: 'Paste without formatting', command: 'core:paste-verbatim' }
       { label: 'Select &All', command: 'core:select-all' }
       { type: 'separator' }
       { label: '&Toggle Comments', command: 'editor:toggle-line-comments' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -46,6 +46,7 @@
       { label: '&Copy', command: 'core:copy' }
       { label: 'Copy Pat&h', command: 'editor:copy-path' }
       { label: '&Paste', command: 'core:paste' }
+      { label: 'Paste without formatting', command: 'core:paste-verbatim' }
       { label: 'Select &All', command: 'core:select-all' }
       { type: 'separator' }
       { label: '&Toggle Comments', command: 'editor:toggle-line-comments' }

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4043,13 +4043,13 @@ describe "TextEditor", ->
           it "does not override autoIndent option", ->
             atom.clipboard.write('first')
 
-            editor.mutateSelectedText (selection, index) =>
+            editor.mutateSelectedText (selection, index) ->
               spyOn(selection, 'insertText')
 
             editor.pasteText autoIndent: false
 
-            editor.mutateSelectedText (selection, index) =>
-              expect(selection.insertText).toHaveBeenCalledWith('first', autoIndent: false);
+            editor.mutateSelectedText (selection, index) ->
+              expect(selection.insertText).toHaveBeenCalledWith('first', autoIndent: false)
 
 
           describe "when pasting multiple lines before any non-whitespace characters", ->
@@ -4124,13 +4124,13 @@ describe "TextEditor", ->
           it "does not override autoIndent option", ->
             atom.clipboard.write('first')
 
-            editor.mutateSelectedText (selection, index) =>
+            editor.mutateSelectedText (selection, index) ->
               spyOn(selection, 'insertText')
 
             editor.pasteText autoIndent: true
 
-            editor.mutateSelectedText (selection, index) =>
-              expect(selection.insertText).toHaveBeenCalledWith('first', autoIndent: true);
+            editor.mutateSelectedText (selection, index) ->
+              expect(selection.insertText).toHaveBeenCalledWith('first', autoIndent: true)
 
           describe "when the cursor is indented further than the original copied text", ->
             it "increases the indentation of the copied lines to match", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4040,6 +4040,18 @@ describe "TextEditor", ->
           beforeEach ->
             editor.update({autoIndentOnPaste: true})
 
+          it "does not override autoIndent option", ->
+            atom.clipboard.write('first')
+
+            editor.mutateSelectedText (selection, index) =>
+              spyOn(selection, 'insertText')
+
+            editor.pasteText autoIndent: false
+
+            editor.mutateSelectedText (selection, index) =>
+              expect(selection.insertText).toHaveBeenCalledWith('first', autoIndent: false);
+
+
           describe "when pasting multiple lines before any non-whitespace characters", ->
             it "auto-indents the lines spanned by the pasted text, based on the first pasted line", ->
               atom.clipboard.write("a(x);\n  b(x);\n    c(x);\n", indentBasis: 0)
@@ -4108,6 +4120,17 @@ describe "TextEditor", ->
         describe "when `autoIndentOnPaste` is false", ->
           beforeEach ->
             editor.update({autoIndentOnPaste: false})
+
+          it "does not override autoIndent option", ->
+            atom.clipboard.write('first')
+
+            editor.mutateSelectedText (selection, index) =>
+              spyOn(selection, 'insertText')
+
+            editor.pasteText autoIndent: true
+
+            editor.mutateSelectedText (selection, index) =>
+              expect(selection.insertText).toHaveBeenCalledWith('first', autoIndent: true);
 
           describe "when the cursor is indented further than the original copied text", ->
             it "increases the indentation of the copied lines to match", ->

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -174,6 +174,7 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
         'core:cut': -> @cutSelectedText()
         'core:copy': -> @copySelectedText()
         'core:paste': -> @pasteText()
+        'core:paste-verbatim': -> @pasteText autoIndent: false
         'editor:delete-to-previous-word-boundary': -> @deleteToPreviousWordBoundary()
         'editor:delete-to-next-word-boundary': -> @deleteToNextWordBoundary()
         'editor:delete-to-beginning-of-word': -> @deleteToBeginningOfWord()

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -174,7 +174,7 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
         'core:cut': -> @cutSelectedText()
         'core:copy': -> @copySelectedText()
         'core:paste': -> @pasteText()
-        'core:paste-verbatim': -> @pasteText autoIndent: false
+        'core:paste-verbatim': -> @pasteText(autoIndent: false)
         'editor:delete-to-previous-word-boundary': -> @deleteToPreviousWordBoundary()
         'editor:delete-to-next-word-boundary': -> @deleteToNextWordBoundary()
         'editor:delete-to-beginning-of-word': -> @deleteToBeginningOfWord()

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -3188,7 +3188,7 @@ class TextEditor extends Model
     return false unless @emitWillInsertTextEvent(clipboardText)
 
     metadata ?= {}
-    options.autoIndent = @shouldAutoIndentOnPaste()
+    options.autoIndent = @shouldAutoIndentOnPaste() unless options.autoIndent?
 
     @mutateSelectedText (selection, index) =>
       if metadata.selections?.length is @getSelections().length


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR implements Paste without formatting/indentation as described in https://github.com/atom/atom/issues/5046. Currently, the `autoIndent` property of the `options` parameter is always overwritten by the `autoIndentOnPaste` config value. With this PR, the property is only assigned if it not present.

Also, it adds an menu entry for Paste without formatting.

### Benefits

As discussed in https://github.com/atom/atom/issues/5046.

### Applicable Issues

Implements https://github.com/atom/atom/issues/5046.