### PR TITLE
Fix search issues menu link

### DIFF
--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -238,7 +238,7 @@ class AtomApplication
     @on 'application:open-faq', -> shell.openExternal('https://atom.io/faq')
     @on 'application:open-terms-of-use', -> shell.openExternal('https://atom.io/terms')
     @on 'application:report-issue', -> shell.openExternal('https://github.com/atom/atom/blob/master/CONTRIBUTING.md#submitting-issues')
-    @on 'application:search-issues', -> shell.openExternal('https://github.com/issues?q=+is%3Aissue+user%3Aatom')
+    @on 'application:search-issues', -> shell.openExternal('https://github.com/search?q=+is%3Aissue+user%3Aatom')
 
     @on 'application:install-update', =>
       @quitting = true


### PR DESCRIPTION
### Description of the Change

The previous link would give a 404 when the user was not logged in to GitHub. This link works whether logged in or not.

### Alternate Designs

N/A

### Why Should This Be In Core?

Functionality is already in core.

### Benefits

Search Issues menu item now works whether one is logged in to GitHub or not.

### Possible Drawbacks

None known.

### Applicable Issues

Fixes #7758
