### PR TITLE
Fix ability to activate next/previous pane in a dock

### DIFF
--- a/spec/dock-spec.js
+++ b/spec/dock-spec.js
@@ -65,7 +65,6 @@ describe('Dock', () => {
   describe('activating the next pane', () => {
     describe('when the dock has more than one pane', () => {
       it('activates the next pane', () => {
-        jasmine.attachToDOM(atom.workspace.getElement())
         const dock = atom.workspace.getLeftDock()
         const pane1 = dock.getPanes()[0]
         const pane2 = pane1.splitRight()
@@ -84,7 +83,6 @@ describe('Dock', () => {
 
     describe('when the dock has only one pane', () => {
       it('leaves the current pane active', () => {
-        jasmine.attachToDOM(atom.workspace.getElement())
         const dock = atom.workspace.getLeftDock()
 
         expect(dock.getPanes().length).toBe(1)
@@ -99,7 +97,6 @@ describe('Dock', () => {
   describe('activating the previous pane', () => {
     describe('when the dock has more than one pane', () => {
       it('activates the previous pane', () => {
-        jasmine.attachToDOM(atom.workspace.getElement())
         const dock = atom.workspace.getLeftDock()
         const pane1 = dock.getPanes()[0]
         const pane2 = pane1.splitRight()
@@ -118,7 +115,6 @@ describe('Dock', () => {
 
     describe('when the dock has only one pane', () => {
       it('leaves the current pane active', () => {
-        jasmine.attachToDOM(atom.workspace.getElement())
         const dock = atom.workspace.getLeftDock()
 
         expect(dock.getPanes().length).toBe(1)

--- a/spec/dock-spec.js
+++ b/spec/dock-spec.js
@@ -62,6 +62,74 @@ describe('Dock', () => {
     })
   })
 
+  describe('activating the next pane', () => {
+    describe('when the dock has more than one pane', () => {
+      it('activates the next pane', () => {
+        jasmine.attachToDOM(atom.workspace.getElement())
+        const dock = atom.workspace.getLeftDock()
+        const pane1 = dock.getPanes()[0]
+        const pane2 = pane1.splitRight()
+        const pane3 = pane2.splitRight()
+        pane2.activate()
+        expect(pane1.isActive()).toBe(false)
+        expect(pane2.isActive()).toBe(true)
+        expect(pane3.isActive()).toBe(false)
+
+        dock.activateNextPane()
+        expect(pane1.isActive()).toBe(false)
+        expect(pane2.isActive()).toBe(false)
+        expect(pane3.isActive()).toBe(true)
+      })
+    })
+
+    describe('when the dock has only one pane', () => {
+      it('leaves the current pane active', () => {
+        jasmine.attachToDOM(atom.workspace.getElement())
+        const dock = atom.workspace.getLeftDock()
+
+        expect(dock.getPanes().length).toBe(1)
+        const pane = dock.getPanes()[0]
+        expect(pane.isActive()).toBe(true)
+        dock.activateNextPane()
+        expect(pane.isActive()).toBe(true)
+      })
+    })
+  })
+
+  describe('activating the previous pane', () => {
+    describe('when the dock has more than one pane', () => {
+      it('activates the previous pane', () => {
+        jasmine.attachToDOM(atom.workspace.getElement())
+        const dock = atom.workspace.getLeftDock()
+        const pane1 = dock.getPanes()[0]
+        const pane2 = pane1.splitRight()
+        const pane3 = pane2.splitRight()
+        pane2.activate()
+        expect(pane1.isActive()).toBe(false)
+        expect(pane2.isActive()).toBe(true)
+        expect(pane3.isActive()).toBe(false)
+
+        dock.activatePreviousPane()
+        expect(pane1.isActive()).toBe(true)
+        expect(pane2.isActive()).toBe(false)
+        expect(pane3.isActive()).toBe(false)
+      })
+    })
+
+    describe('when the dock has only one pane', () => {
+      it('leaves the current pane active', () => {
+        jasmine.attachToDOM(atom.workspace.getElement())
+        const dock = atom.workspace.getLeftDock()
+
+        expect(dock.getPanes().length).toBe(1)
+        const pane = dock.getPanes()[0]
+        expect(pane.isActive()).toBe(true)
+        dock.activatePreviousPane()
+        expect(pane.isActive()).toBe(true)
+      })
+    })
+  })
+
   describe('when the dock resize handle is double-clicked', () => {
     describe('when the dock is open', () => {
       it('resizes a vertically-oriented dock to the current item\'s preferred width', async () => {

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2528,6 +2528,62 @@ i = /test/; #FIXME\
     })
   })
 
+  describe('::activateNextPane', () => {
+    describe('when the active workspace pane is inside a dock', () => {
+      it('activates the next pane in the dock', () => {
+        const dock = atom.workspace.getLeftDock()
+        const dockPane1 = dock.getPanes()[0]
+        const dockPane2 = dockPane1.splitRight()
+
+        dockPane2.focus()
+        expect(atom.workspace.getActivePane()).toBe(dockPane2)
+        atom.workspace.activateNextPane()
+        expect(atom.workspace.getActivePane()).toBe(dockPane1)
+      })
+    })
+
+    describe('when the active workspace pane is inside the workspace center', () => {
+      it('activates the next pane in the workspace center', () => {
+        const center = atom.workspace.getCenter()
+        const centerPane1 = center.getPanes()[0]
+        const centerPane2 = centerPane1.splitRight()
+
+        centerPane2.focus()
+        expect(atom.workspace.getActivePane()).toBe(centerPane2)
+        atom.workspace.activateNextPane()
+        expect(atom.workspace.getActivePane()).toBe(centerPane1)
+      })
+    })
+  })
+
+  describe('::activatePreviousPane', () => {
+    describe('when the active workspace pane is inside a dock', () => {
+      it('activates the previous pane in the dock', () => {
+        const dock = atom.workspace.getLeftDock()
+        const dockPane1 = dock.getPanes()[0]
+        const dockPane2 = dockPane1.splitRight()
+
+        dockPane1.focus()
+        expect(atom.workspace.getActivePane()).toBe(dockPane1)
+        atom.workspace.activatePreviousPane()
+        expect(atom.workspace.getActivePane()).toBe(dockPane2)
+      })
+    })
+
+    describe('when the active workspace pane is inside the workspace center', () => {
+      it('activates the previous pane in the workspace center', () => {
+        const center = atom.workspace.getCenter()
+        const centerPane1 = center.getPanes()[0]
+        const centerPane2 = centerPane1.splitRight()
+
+        centerPane1.focus()
+        expect(atom.workspace.getActivePane()).toBe(centerPane1)
+        atom.workspace.activatePreviousPane()
+        expect(atom.workspace.getActivePane()).toBe(centerPane2)
+      })
+    })
+  })
+
   describe('when the core.allowPendingPaneItems option is falsey', () => {
     it('does not open item with `pending: true` option as pending', () => {
       let pane = null

--- a/src/dock.js
+++ b/src/dock.js
@@ -626,6 +626,16 @@ module.exports = class Dock {
     return this.paneContainer.getActivePane()
   }
 
+  // Extended: Make the next pane active.
+  activateNextPane () {
+    return this.paneContainer.activateNextPane()
+  }
+
+  // Extended: Make the previous pane active.
+  activatePreviousPane () {
+    return this.paneContainer.activatePreviousPane()
+  }
+
   paneForURI (uri) {
     return this.paneContainer.paneForURI(uri)
   }


### PR DESCRIPTION
Fixes #14442.

### Description of the Change

Prior to this change, when a dock had focus, triggering `window:focus-next-pane` or `window:focus-previous-pane` would throw an error:

```
At /Applications/Atom.app/Contents/Resources/app/src/workspace.js:1559

TypeError: this.getActivePaneContainer(...).activateNextPane is not a function
    at Workspace.activateNextPane (/Applications/Atom.app/Contents/Resources/app/src/workspace.js:1559:1)
    at atom-workspace.window:focus-next-pane (/Applications/Atom.app/Contents/Resources/app/src/register-default-commands.js:168:1)
    at CommandRegistry.module.exports.CommandRegistry.handleCommandEvent (/Applications/Atom.app/Contents/Resources/app/src/command-registry.js:265:1)
    at /Applications/Atom.app/Contents/Resources/app/src/command-registry.js:3:1
    at KeymapManager.module.exports.KeymapManager.dispatchCommandEvent (/Applications/Atom.app/Contents/Resources/app/node_modules/atom-keymap/lib/keymap-manager.js:610:1)
    at KeymapManager.module.exports.KeymapManager.handleKeyboardEvent (/Applications/Atom.app/Contents/Resources/app/node_modules/atom-keymap/lib/keymap-manager.js:401:1)
    at WindowEventHandler.module.exports.WindowEventHandler.handleDocumentKeyEvent (/Applications/Atom.app/Contents/Resources/app/src/window-event-handler.js:100:1)
    at HTMLDocument.<anonymous> (/Applications/Atom.app/Contents/Resources/app/src/window-event-handler.js:3:1)
```

[`Workspace.activateNextPane()` calls `this.getActivePaneContainer().activateNextPane()`](https://github.com/atom/atom/blob/ae9f24602d80cb15fe0edc15c1aae37d44ee786c/src/workspace.js#L1361). `this.getActivePaneContainer()` returns either a `WorkspaceCenter` (if the workspace center is the active pane container) or a `Dock` (if a dock is the active pane container). `WorkspaceCenter` has an [`activateNextPane`](https://github.com/atom/atom/blob/8ed16cea43cfd3f3b04b51ed5851892944ac7f19/src/workspace-center.js#L290-L298) function, but `Dock` does not. Therefore, calling `Workspace.activateNextPane()` results in an error when a `Dock` is the active pane container. (The same goes for `activatePreviousPane`.)

This change resolves this issue by [adding `activateNextPane` and `activatePreviousPane` functions to `Dock`](https://github.com/atom/atom/blob/ae9f24602d80cb15fe0edc15c1aae37d44ee786c/src/dock.js#L629-L637).

With this change in place, triggering `window:focus-next-pane` or `window:focus-previous-pane` in a dock will focus the dock's next or previous pane respectively. If the dock has only one pane, then that pane will remain focused. In other words, these two commands should provide the same behavior regardless of whether they're executed in a dock or in the workspace center.

### Alternate Designs

None.

### Why Should This Be In Core?

It's a fix for an existing bug in atom/atom: #14442

### Benefits

Fixes #14442.

### Possible Drawbacks

From a functionality perspective, I'm not aware of any drawbacks.

From a code perspective:
- It seems like there's an interface that we expect both `Dock` and `WorkspaceCenter` to implement, but I don't see that interface explicitly described or enforced anywhere. I _think_ that lack of explicit interface is a cause of the bug seen in #14442. There may be other bugs that are lurking due to code that implicitly expects a `WorkspaceCenter` and a `Dock` to provide a common interface.
- [`Dock`](https://github.com/atom/atom/blob/8ed16cea43cfd3f3b04b51ed5851892944ac7f19/src/dock.js) and [`WorkspaceCenter`](https://github.com/atom/atom/blob/8ed16cea43cfd3f3b04b51ed5851892944ac7f19/src/workspace-center.js) have quite a bit of duplicate code ([side-by-side screenshot](https://cloud.githubusercontent.com/assets/2988/26175132/a7d9c034-3b1f-11e7-9586-f738646b7440.png)), and this PR adds even more. Perhaps a future refactoring could reduce this duplication.

### Applicable Issues

#14442

### Demo

https://github.com/atom/command-palette/issues/79#issue-227125354 shows the behavior prior to this change. The gif below shows the behavior after this change:

![demo](https://cloud.githubusercontent.com/assets/2988/26176358/d8723fba-3b23-11e7-84a7-8588669ef786.gif)
