### PR TITLE
:bug: Fix Report Issue link to CONTRIBUTING.md

### DIFF
--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -237,7 +237,7 @@ class AtomApplication
     @on 'application:open-discussions', -> shell.openExternal('https://discuss.atom.io')
     @on 'application:open-faq', -> shell.openExternal('https://atom.io/faq')
     @on 'application:open-terms-of-use', -> shell.openExternal('https://atom.io/terms')
-    @on 'application:report-issue', -> shell.openExternal('https://github.com/atom/atom/blob/master/CONTRIBUTING.md#submitting-issues')
+    @on 'application:report-issue', -> shell.openExternal('https://github.com/atom/atom/blob/master/CONTRIBUTING.md#reporting-bugs')
     @on 'application:search-issues', -> shell.openExternal('https://github.com/search?q=+is%3Aissue+user%3Aatom')
 
     @on 'application:install-update', =>


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The "Report Issue" link in the Help menu currently directs users to https://github.com/atom/atom/blob/master/CONTRIBUTING.md#submitting-issues. #submitting-issues is no longer the name of the relevant section (it was actually renamed 2 years ago in commit https://github.com/atom/atom/commit/ee53bbf348e24a04fcfe67b6d7507c267dcc7678). This PR addresses this issue by updating the link to reflect the new name of that section.

### Alternate Designs

The "Reporting Bugs" header in `CONTRIBUTING.md` could've been renamed back to "Submitting Issues," but that disrupts the flow of the document.

### Why Should This Be In Core?

Because it doesn't make sense for a package to update a link from atom's Help menu to atom's `CONTRIBUTING.md` file. 😛 

### Benefits

Users will be taken directly to the relevant section when they're trying to report an issue with atom.

### Possible Drawbacks

The link might break again the next time the section gets renamed, in which case, we'll have to update this again. 😛 

### Applicable Issues

N/A
