### PR TITLE
Enable MAX_SCREEN_LINE_LENGTH to now be set via a config option

### DIFF
--- a/spec/text-editor-registry-spec.js
+++ b/spec/text-editor-registry-spec.js
@@ -544,6 +544,21 @@ describe('TextEditorRegistry', function () {
       expect(editor.getSoftWrapColumn()).toBe(80)
     })
 
+    it('allows for custom definition of maximum soft wrap based on config', async function () {
+      editor.update({
+        softWrapped: false,
+        maxScreenLineLength: 1500,
+      })
+
+      expect(editor.getSoftWrapColumn()).toBe(1500)
+
+      atom.config.set('editor.softWrap', false)
+      atom.config.set('editor.maxScreenLineLength', 500)
+      registry.maintainConfig(editor)
+      await initialPackageActivation
+      expect(editor.getSoftWrapColumn()).toBe(500)
+    })
+
     it('sets the preferred line length based on the config', async function () {
       editor.update({preferredLineLength: 80})
       expect(editor.getPreferredLineLength()).toBe(80)

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -74,6 +74,7 @@ describe "TextEditor", ->
           expect(editor2.getInvisibles()).toEqual(editor.getInvisibles())
           expect(editor2.getEditorWidthInChars()).toBe(editor.getEditorWidthInChars())
           expect(editor2.displayLayer.tabLength).toBe(editor2.getTabLength())
+          expect(editor2.displayLayer.softWrapColumn).toBe(editor2.getSoftWrapColumn())
 
   describe "when the editor is constructed with the largeFileMode option set to true", ->
     it "loads the editor but doesn't tokenize", ->
@@ -145,7 +146,7 @@ describe "TextEditor", ->
       returnedPromise = editor.update({
         tabLength: 6, softTabs: false, softWrapped: true, editorWidthInChars: 40,
         showInvisibles: false, mini: false, lineNumberGutterVisible: false, scrollPastEnd: true,
-        autoHeight: false
+        autoHeight: false, maxScreenLineLength: 1000
       })
 
       expect(returnedPromise).toBe(element.component.getNextUpdatePromise())
@@ -5918,3 +5919,11 @@ describe "TextEditor", ->
   describe "::getElement", ->
     it "returns an element", ->
       expect(editor.getElement() instanceof HTMLElement).toBe(true)
+
+  describe 'setMaxScreenLineLength', ->
+    it "sets the maximum line length in the editor before soft wrapping is forced", ->
+      expect(editor.getSoftWrapColumn()).toBe(500)
+      editor.update({
+        maxScreenLineLength: 1500
+      })
+      expect(editor.getSoftWrapColumn()).toBe(1500)

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -5918,12 +5918,3 @@ describe "TextEditor", ->
   describe "::getElement", ->
     it "returns an element", ->
       expect(editor.getElement() instanceof HTMLElement).toBe(true)
-
-  describe 'setMaxScreenLineLength', ->
-    it "sets the maximum line length in the editor before soft wrapping is forced", ->
-      expect(editor.maxScreenLineLength()).toBe 500
-      editor.update({
-        maxScreenLineLength: 1500
-      })
-      expect(editor.maxScreenLineLength()).toBe 1500
-

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -5918,3 +5918,12 @@ describe "TextEditor", ->
   describe "::getElement", ->
     it "returns an element", ->
       expect(editor.getElement() instanceof HTMLElement).toBe(true)
+
+  describe 'setMaxScreenLineLength', ->
+    it "sets the maximum line length in the editor before soft wrapping is forced", ->
+      expect(editor.maxScreenLineLength()).toBe 500
+      editor.update({
+        maxScreenLineLength: 1500
+      })
+      expect(editor.maxScreenLineLength()).toBe 1500
+

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -409,6 +409,12 @@ const configSchema = {
         minimum: 1,
         description: 'Identifies the length of a line which is used when wrapping text with the `Soft Wrap At Preferred Line Length` setting enabled, in number of characters.'
       },
+      maxScreenLineLength: {
+        type: 'integer',
+        default: 500,
+        minimum: 500,
+        description: 'Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters.'
+      },
       tabLength: {
         type: 'integer',
         default: 2,

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -409,12 +409,6 @@ const configSchema = {
         minimum: 1,
         description: 'Identifies the length of a line which is used when wrapping text with the `Soft Wrap At Preferred Line Length` setting enabled, in number of characters.'
       },
-      maxScreenLineLength: {
-        type: 'integer',
-        default: 500,
-        minimum: 500,
-        description: 'Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters.'
-      },
       tabLength: {
         type: 'integer',
         default: 2,

--- a/src/text-editor-registry.js
+++ b/src/text-editor-registry.js
@@ -18,6 +18,7 @@ const EDITOR_PARAMS_BY_SETTING_KEY = [
   ['editor.softWrapHangingIndent', 'softWrapHangingIndentLength'],
   ['editor.softWrapAtPreferredLineLength', 'softWrapAtPreferredLineLength'],
   ['editor.preferredLineLength', 'preferredLineLength'],
+  ['editor.maxScreenLineLength', 'maxScreenLineLength'],
   ['editor.autoIndent', 'autoIndent'],
   ['editor.autoIndentOnPaste', 'autoIndentOnPaste'],
   ['editor.scrollPastEnd', 'scrollPastEnd'],

--- a/src/text-editor-registry.js
+++ b/src/text-editor-registry.js
@@ -18,7 +18,6 @@ const EDITOR_PARAMS_BY_SETTING_KEY = [
   ['editor.softWrapHangingIndent', 'softWrapHangingIndentLength'],
   ['editor.softWrapAtPreferredLineLength', 'softWrapAtPreferredLineLength'],
   ['editor.preferredLineLength', 'preferredLineLength'],
-  ['editor.maxScreenLineLength', 'maxScreenLineLength'],
   ['editor.autoIndent', 'autoIndent'],
   ['editor.autoIndentOnPaste', 'autoIndentOnPaste'],
   ['editor.scrollPastEnd', 'scrollPastEnd'],

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -17,7 +17,6 @@ TextEditorElement = null
 {isDoubleWidthCharacter, isHalfWidthCharacter, isKoreanCharacter, isWrapBoundary} = require './text-utils'
 
 ZERO_WIDTH_NBSP = '\ufeff'
-MAX_SCREEN_LINE_LENGTH = 500
 
 # Essential: This class represents all essential editing state for a single
 # {TextBuffer}, including cursor and selection positions, folds, and soft wraps.
@@ -158,7 +157,7 @@ class TextEditor extends Model
       @assert, grammar, @showInvisibles, @autoHeight, @autoWidth, @scrollPastEnd, @scrollSensitivity, @editorWidthInChars,
       @tokenizedBuffer, @displayLayer, @invisibles, @showIndentGuide,
       @softWrapped, @softWrapAtPreferredLineLength, @preferredLineLength,
-      @showCursorOnSelection
+      @showCursorOnSelection, @maxScreenLineLength
     } = params
 
     @assert ?= (condition) -> condition
@@ -183,6 +182,7 @@ class TextEditor extends Model
     @softWrapped ?= false
     @softWrapAtPreferredLineLength ?= false
     @preferredLineLength ?= 80
+    @maxScreenLineLength ?= 500
     @showLineNumbers ?= true
 
     @buffer ?= new TextBuffer({
@@ -323,6 +323,11 @@ class TextEditor extends Model
             @preferredLineLength = value
             displayLayerParams.softWrapColumn = @getSoftWrapColumn()
 
+        when 'maxScreenLineLength'
+          if value isnt @maxScreenLineLength
+            @maxScreenLineLength = value
+            displayLayerParams.softWrapColumn = @getSoftWrapColumn()
+
         when 'mini'
           if value isnt @mini
             @mini = value
@@ -433,7 +438,7 @@ class TextEditor extends Model
       softWrapHangingIndentLength: @displayLayer.softWrapHangingIndent
 
       @id, @softTabs, @softWrapped, @softWrapAtPreferredLineLength,
-      @preferredLineLength, @mini, @editorWidthInChars, @width, @largeFileMode,
+      @preferredLineLength, @mini, @editorWidthInChars, @width, @largeFileMode, @maxScreenLineLength,
       @registered, @invisibles, @showInvisibles, @showIndentGuide, @autoHeight, @autoWidth
     }
 
@@ -3039,7 +3044,7 @@ class TextEditor extends Model
       else
         @getEditorWidthInChars()
     else
-      MAX_SCREEN_LINE_LENGTH
+      @maxScreenLineLength
 
   ###
   Section: Indentation


### PR DESCRIPTION
### Description of the Change

This change enables the maximum softWrapColumn in the display layer object to be set using a configuration parameter rather than using the MAX_SCREEN_LINE_LENGTH constant. This value is returned by the getSoftWrapColumn function.

The default and minimum is still set at 500 to satisfy the design decision to address performance issues for those opening minified files, however it can be adjusted upwards for those who require a more flexible option.

### Alternate Designs

As the getSoftWrapColumn function used a constant as the default return value, there are no alternate design options.

### Why Should This Be In Core?

This needs to be in core as it is affecting the editor display layer parameters directly 

### Benefits

Benefits are that the number of people who work with long line files that are not necessarily minified are able to customise their maximum width by the settings editor instead of using the constant value

### Possible Drawbacks

Possible drawbacks are that a user sets the width high enough to cause performance issues with minified files, however this can be mitigated by reverting the setting to defaults in the editor settings

### Applicable Issues

* https://discuss.atom.io/t/atom-editor-line-length-wraps-at-500-chars-on-1-15/40589/3
* https://discuss.atom.io/t/1-14-1-16-is-forcing-a-line-wrap-even-with-soft-wrap-toggled-off/41758/4
* https://discuss.atom.io/t/how-do-i-turn-off-soft-wrap/40417/11

Related to: https://github.com/atom/atom/pull/13820
