### PR TITLE
Don't snapshot the `iconv-lite` module

### DIFF
--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -46,7 +46,7 @@ module.exports = function (packagedAppPath) {
         relativePath == path.join('..', 'node_modules', 'markdown-preview', 'node_modules', 'htmlparser2', 'lib', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'roaster', 'node_modules', 'htmlparser2', 'lib', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'task-lists', 'node_modules', 'htmlparser2', 'lib', 'index.js') ||
-        relativePath == path.join('..', 'node_modules', 'iconv-lite', 'encodings', 'index.js') ||
+        relativePath == path.join('..', 'node_modules', 'iconv-lite', 'lib', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'less', 'index.js') ||
         relativePath == path.join('..', 'node_modules', 'less', 'lib', 'less', 'fs.js') ||
         relativePath == path.join('..', 'node_modules', 'less', 'lib', 'less-node', 'index.js') ||


### PR DESCRIPTION
Fixes https://github.com/atom/encoding-selector/issues/48.

When deciding which methods to export, `iconv-lite` verifies the availability of some Node features, which is clearly an unsupported behavior when executing it via `mksnapshot`.

In this case we were not getting any exception at compile-time, but we noticed some methods were missing from iconv-lite's API. With this commit we are excluding this module from the snapshot, thus making all of its methods available again.

/cc: @iolsen