### PR TITLE
Improve confirm documentation

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -821,6 +821,9 @@ class AtomEnvironment extends Model
     @emitter.emit 'did-beep'
 
   # Essential: A flexible way to open a dialog akin to an alert dialog.
+  # 
+  # If the dialog is closed (via `Esc` key or `X` in the top corner) without selecting a button
+  # the first button will be clicked unless a "Cancel" or "No" button is provided.
   #
   # ## Examples
   #
@@ -839,7 +842,7 @@ class AtomEnvironment extends Model
   #   * `buttons` (optional) Either an array of strings or an object where keys are
   #     button names and the values are callbacks to invoke when clicked.
   #
-  # Returns the chosen button index {Number} if the buttons option was an array.
+  # Returns the chosen button index {Number} if the buttons option is an array or the return value of the callback if the buttons option is an object.
   confirm: (params={}) ->
     @applicationDelegate.confirm(params)
 

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -821,7 +821,7 @@ class AtomEnvironment extends Model
     @emitter.emit 'did-beep'
 
   # Essential: A flexible way to open a dialog akin to an alert dialog.
-  # 
+  #
   # If the dialog is closed (via `Esc` key or `X` in the top corner) without selecting a button
   # the first button will be clicked unless a "Cancel" or "No" button is provided.
   #


### PR DESCRIPTION
### Description of the Change

Updated atom.confirm documentation to include what happens if dialog is closed without selecting an option

### Possible Drawbacks

I'm not 100% sure this is correct on all OSes 

I had to do quite a bit of experimentation on Windows to figure out all the edge cases.

Most of the information I got from the [dialog.showMessageBox](https://github.com/electron/electron/blob/master/docs/api/dialog.md#dialogshowmessageboxbrowserwindow-options-callback) documentation but there seems to be quite a few differences between Oses

<!-- What are the possible side-effects or negative impacts of the code change? -->
