### PR TITLE
Try a different approach for preventing autoscroll to off-screen input

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1410,24 +1410,8 @@ class TextEditorComponent {
       this.scheduleUpdate()
     }
 
-    // Transfer focus to the hidden input, but first ensure the input is in the
-    // visible part of the scrolled content to avoid the browser trying to
-    // auto-scroll to the form-field.
     const {hiddenInput} = this.refs.cursorsAndInput.refs
-    hiddenInput.style.top = this.getScrollTop() + 'px'
-    hiddenInput.style.left = this.getScrollLeft() + 'px'
-
     hiddenInput.focus()
-
-    // Restore the previous position of the field now that it is already focused
-    // and won't cause unwanted scrolling.
-    if (this.hiddenInputPosition) {
-      hiddenInput.style.top = this.hiddenInputPosition.pixelTop + 'px'
-      hiddenInput.style.left = this.hiddenInputPosition.pixelLeft + 'px'
-    } else {
-      hiddenInput.style.top = 0
-      hiddenInput.style.left = 0
-    }
   }
 
   // Called by TextEditorElement so that this function is always the first
@@ -1450,6 +1434,12 @@ class TextEditorComponent {
   }
 
   didFocusHiddenInput () {
+    // Focusing the hidden input when it is off-screen causes the browser to
+    // scroll it into view. Since we use synthetic scrolling this behavior
+    // causes all the lines to disappear so we counteract it by always setting
+    // the scroll position to 0.
+    this.refs.scrollContainer.scrollTop = 0
+    this.refs.scrollContainer.scrollLeft = 0
     if (!this.focused) {
       this.focused = true
       this.startCursorBlinking()


### PR DESCRIPTION
This fixes a bug that got introduced in #13880 which was causing lines to disappear due to the browser trying to scroll the hidden input into view after it was focused.

![image_1024](https://cloud.githubusercontent.com/assets/482957/26637604/2ccb612a-4620-11e7-8032-625b15c31911.png)

With this pull-request we unconditionally restore the scroll top and the scroll left properties of the scroll view to 0 every time the hidden input is focused.

/cc: @atom/maintainers 