### PR TITLE
Render line number gutter without numbers when showLineNumbers is false

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -596,9 +596,30 @@ describe('TextEditorComponent', () => {
       )
     })
 
-    it('supports the isLineNumberGutterVisible parameter', () => {
+    it('does not render the line number gutter at all if the isLineNumberGutterVisible parameter is false', () => {
       const {component, element, editor} = buildComponent({lineNumberGutterVisible: false})
       expect(element.querySelector('.line-number')).toBe(null)
+    })
+
+    it('does not render the line numbers but still renders the line number gutter if showLineNumbers is false', async () => {
+      function checkScrollContainerLeft (component) {
+        const {scrollContainer, gutterContainer} = component.refs
+        expect(scrollContainer.getBoundingClientRect().left).toBe(Math.round(gutterContainer.element.getBoundingClientRect().right))
+      }
+
+      const {component, element, editor} = buildComponent({showLineNumbers: false})
+      expect(Array.from(element.querySelectorAll('.line-number')).every((e) => e.textContent === '')).toBe(true)
+      checkScrollContainerLeft(component)
+
+      await editor.update({showLineNumbers: true})
+      expect(Array.from(element.querySelectorAll('.line-number')).map((e) => e.textContent)).toEqual([
+        '00', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13'
+      ])
+      checkScrollContainerLeft(component)
+
+      await editor.update({showLineNumbers: false})
+      expect(Array.from(element.querySelectorAll('.line-number')).every((e) => e.textContent === '')).toBe(true)
+      checkScrollContainerLeft(component)
     })
 
     it('supports the placeholderText parameter', () => {
@@ -3401,7 +3422,7 @@ function buildEditor (params = {}) {
   const buffer = new TextBuffer({text})
   const editorParams = {buffer}
   if (params.height != null) params.autoHeight = false
-  for (const paramName of ['mini', 'autoHeight', 'autoWidth', 'lineNumberGutterVisible', 'placeholderText', 'softWrapped']) {
+  for (const paramName of ['mini', 'autoHeight', 'autoWidth', 'lineNumberGutterVisible', 'showLineNumbers', 'placeholderText', 'softWrapped']) {
     if (params[paramName] != null) editorParams[paramName] = params[paramName]
   }
   return new TextEditor(editorParams)

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -98,7 +98,6 @@ class TextEditor extends Model
   registered: false
   atomicSoftTabs: true
   invisibles: null
-  showLineNumbers: true
   scrollSensitivity: 40
 
   Object.defineProperty @prototype, "element",
@@ -156,7 +155,7 @@ class TextEditor extends Model
     {
       @softTabs, @initialScrollTopRow, @initialScrollLeftColumn, initialLine, initialColumn, tabLength,
       @softWrapped, @decorationManager, @selectionsMarkerLayer, @buffer, suppressCursorCreation,
-      @mini, @placeholderText, lineNumberGutterVisible, @largeFileMode,
+      @mini, @placeholderText, lineNumberGutterVisible, @showLineNumbers, @largeFileMode,
       @assert, grammar, @showInvisibles, @autoHeight, @autoWidth, @scrollPastEnd, @editorWidthInChars,
       @tokenizedBuffer, @displayLayer, @invisibles, @showIndentGuide,
       @softWrapped, @softWrapAtPreferredLineLength, @preferredLineLength,
@@ -184,6 +183,7 @@ class TextEditor extends Model
     @softWrapped ?= false
     @softWrapAtPreferredLineLength ?= false
     @preferredLineLength ?= 80
+    @showLineNumbers ?= true
 
     @buffer ?= new TextBuffer({shouldDestroyOnFileDelete: ->
       atom.config.get('core.closeDeletedFileTabs')})
@@ -357,6 +357,7 @@ class TextEditor extends Model
         when 'showLineNumbers'
           if value isnt @showLineNumbers
             @showLineNumbers = value
+            @component?.scheduleUpdate()
 
         when 'showInvisibles'
           if value isnt @showInvisibles


### PR DESCRIPTION
In #13880 we honored the `lineNumberGutterVisible` parameter but neglected to honor the `showLineNumbers` parameter, which is what is used by the text editor registry to interact with the settings. In the previous editor implementation, both of these options simply hid the line number completely. In this version, we've elected to handle `showLineNumbers` differently from `lineNumberGutterVisible`. We continue to render the line number gutter (which contains diff decorations, fold indicators, etc), but we just don't render the line numbers in it. This provides more features and a better visual experience when the line numbers are disabled.

🍐ed with @as-cii