### PR TITLE
Provide API for observing the active text editor

### DIFF
--- a/spec/dock-spec.js
+++ b/spec/dock-spec.js
@@ -1,5 +1,7 @@
 /** @babel */
 
+const Grim = require('grim')
+
 import {it, fit, ffit, fffit, beforeEach, afterEach} from './async-spec-helpers'
 
 describe('Dock', () => {
@@ -327,6 +329,15 @@ describe('Dock', () => {
       Object.defineProperty(dragEvent, 'target', {value: textNode})
 
       expect(() => atom.workspace.getElement().handleDragStart(dragEvent)).not.toThrow()
+    })
+  })
+
+  describe('::getActiveTextEditor()', () => {
+    it('is deprecated', () => {
+      spyOn(Grim, 'deprecate')
+
+      atom.workspace.getLeftDock().getActiveTextEditor()
+      expect(Grim.deprecate.callCount).toBe(1)
     })
   })
 })

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -1419,6 +1419,42 @@ describe('Workspace', () => {
     })
   })
 
+  describe('::getActiveTextEditor()', () => {
+    describe("when the workspace center's active pane item is a text editor", () => {
+      describe('when the workspace center has focus', function () {
+        it('returns the text editor', () => {
+          const workspaceCenter = workspace.getCenter()
+          const editor = new TextEditor()
+          workspaceCenter.getActivePane().activateItem(editor)
+          workspaceCenter.activate()
+
+          expect(workspace.getActiveTextEditor()).toBe(editor)
+        })
+      })
+
+      describe('when a dock has focus', function () {
+        it('returns the text editor', () => {
+          const workspaceCenter = workspace.getCenter()
+          const editor = new TextEditor()
+          workspaceCenter.getActivePane().activateItem(editor)
+          workspace.getLeftDock().activate()
+
+          expect(workspace.getActiveTextEditor()).toBe(editor)
+        })
+      })
+    })
+
+    describe("when the workspace center's active pane item is not a text editor", () => {
+      it('returns undefined', () => {
+        const workspaceCenter = workspace.getCenter()
+        const nonEditorItem = document.createElement('div')
+        workspaceCenter.getActivePane().activateItem(nonEditorItem)
+
+        expect(workspace.getActiveTextEditor()).toBeUndefined()
+      })
+    })
+  })
+
   describe('::observeTextEditors()', () => {
     it('invokes the observer with current and future text editors', () => {
       const observed = []

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -1471,6 +1471,90 @@ describe('Workspace', () => {
     })
   })
 
+  describe('::observeActiveTextEditor()', () => {
+    let center, pane, observed
+
+    beforeEach(() => {
+      center = workspace.getCenter()
+      pane = center.getActivePane()
+      observed = []
+    })
+
+    it('invokes the observer with current active text editor and each time a different text editor becomes active', () => {
+      const inactiveEditorBeforeRegisteringObserver = new TextEditor()
+      const activeEditorBeforeRegisteringObserver = new TextEditor()
+      pane.activateItem(inactiveEditorBeforeRegisteringObserver)
+      pane.activateItem(activeEditorBeforeRegisteringObserver)
+
+      workspace.observeActiveTextEditor(editor => observed.push(editor))
+
+      const editorAddedAfterRegisteringObserver = new TextEditor()
+      const nonEditorItemAddedAfterRegisteringObserver = document.createElement('div')
+      pane.activateItem(editorAddedAfterRegisteringObserver)
+
+      expect(observed).toEqual(
+        [activeEditorBeforeRegisteringObserver, editorAddedAfterRegisteringObserver]
+      )
+    })
+
+    it('does not invoke the observer when there is no current active text editor', () => {
+      const editor = new TextEditor()
+      const nonEditorItem = document.createElement('div')
+      pane.activateItem(editor)
+      pane.activateItem(nonEditorItem)
+
+      workspace.observeActiveTextEditor(editor => observed.push(editor))
+
+      expect(observed).toEqual([])
+    })
+
+    it("invokes the observer when a text editor becomes the workspace center's active pane item while a dock has focus", () => {
+      workspace.observeActiveTextEditor(editor => observed.push(editor))
+
+      const dock = workspace.getLeftDock()
+      dock.activate()
+      expect(atom.workspace.getActivePaneContainer()).toBe(dock)
+
+      const editor = new TextEditor()
+      center.getActivePane().activateItem(editor)
+      expect(atom.workspace.getActivePaneContainer()).toBe(dock)
+
+      expect(observed).toEqual([editor])
+    })
+
+    it('invokes the observer when the last text editor is closed', () => {
+      workspace.observeActiveTextEditor(editor => observed.push(editor))
+
+      const editor = new TextEditor()
+      pane.activateItem(editor)
+      pane.destroyItem(editor)
+
+      expect(observed).toEqual([editor, undefined])
+    })
+
+    it("invokes the observer when the workspace center's active pane item changes from an editor item to a non-editor item", () => {
+      workspace.observeActiveTextEditor(editor => observed.push(editor))
+
+      const editor = new TextEditor()
+      const nonEditorItem = document.createElement('div')
+      pane.activateItem(editor)
+      pane.activateItem(nonEditorItem)
+
+      expect(observed).toEqual([editor, undefined])
+    })
+
+    it("does not invoke the observer when the workspace center's active pane item changes from a non-editor item to another non-editor item", () => {
+      workspace.observeActiveTextEditor(editor => observed.push(editor))
+
+      const nonEditorItem1 = document.createElement('div')
+      const nonEditorItem2 = document.createElement('div')
+      pane.activateItem(nonEditorItem1)
+      pane.activateItem(nonEditorItem1)
+
+      expect(observed).toEqual([])
+    })
+  })
+
   describe('when an editor is destroyed', () => {
     it('removes the editor', () => {
       let editor = null

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -1423,15 +1423,10 @@ describe('Workspace', () => {
   })
 
   describe('::observeActiveTextEditor()', () => {
-    let center, pane, observed
-
-    beforeEach(() => {
-      center = workspace.getCenter()
-      pane = center.getActivePane()
-      observed = []
-    })
-
     it('invokes the observer with current active text editor and each time a different text editor becomes active', () => {
+      const pane = workspace.getCenter().getActivePane()
+      observed = []
+
       const inactiveEditorBeforeRegisteringObserver = new TextEditor()
       const activeEditorBeforeRegisteringObserver = new TextEditor()
       pane.activateItem(inactiveEditorBeforeRegisteringObserver)
@@ -1447,20 +1442,19 @@ describe('Workspace', () => {
         [activeEditorBeforeRegisteringObserver, editorAddedAfterRegisteringObserver]
       )
     })
+  })
 
-    it('does not invoke the observer when there is no current active text editor', () => {
-      const editor = new TextEditor()
-      const nonEditorItem = document.createElement('div')
-      pane.activateItem(editor)
-      pane.activateItem(nonEditorItem)
+  describe('::onDidChangeActiveTextEditor()', () => {
+    let center, pane, observed
 
-      workspace.observeActiveTextEditor(editor => observed.push(editor))
-
-      expect(observed).toEqual([])
+    beforeEach(() => {
+      center = workspace.getCenter()
+      pane = center.getActivePane()
+      observed = []
     })
 
     it("invokes the observer when a text editor becomes the workspace center's active pane item while a dock has focus", () => {
-      workspace.observeActiveTextEditor(editor => observed.push(editor))
+      workspace.onDidChangeActiveTextEditor(editor => observed.push(editor))
 
       const dock = workspace.getLeftDock()
       dock.activate()
@@ -1474,28 +1468,26 @@ describe('Workspace', () => {
     })
 
     it('invokes the observer when the last text editor is closed', () => {
-      workspace.observeActiveTextEditor(editor => observed.push(editor))
-
       const editor = new TextEditor()
       pane.activateItem(editor)
-      pane.destroyItem(editor)
 
-      expect(observed).toEqual([editor, undefined])
+      workspace.onDidChangeActiveTextEditor(editor => observed.push(editor))
+      pane.destroyItem(editor)
+      expect(observed).toEqual([undefined])
     })
 
     it("invokes the observer when the workspace center's active pane item changes from an editor item to a non-editor item", () => {
-      workspace.observeActiveTextEditor(editor => observed.push(editor))
-
       const editor = new TextEditor()
       const nonEditorItem = document.createElement('div')
       pane.activateItem(editor)
-      pane.activateItem(nonEditorItem)
 
-      expect(observed).toEqual([editor, undefined])
+      workspace.onDidChangeActiveTextEditor(editor => observed.push(editor))
+      pane.activateItem(nonEditorItem)
+      expect(observed).toEqual([undefined])
     })
 
     it("does not invoke the observer when the workspace center's active pane item changes from a non-editor item to another non-editor item", () => {
-      workspace.observeActiveTextEditor(editor => observed.push(editor))
+      workspace.onDidChangeActiveTextEditor(editor => observed.push(editor))
 
       const nonEditorItem1 = document.createElement('div')
       const nonEditorItem2 = document.createElement('div')
@@ -1510,10 +1502,9 @@ describe('Workspace', () => {
 
       simulateReload()
 
-      const editor = workspace.getActiveTextEditor()
-      workspace.observeActiveTextEditor(editor => observed.push(editor))
+      workspace.onDidChangeActiveTextEditor(editor => observed.push(editor))
       workspace.closeActivePaneItemOrEmptyPaneOrWindow()
-      expect(observed).toEqual([editor, undefined])
+      expect(observed).toEqual([undefined])
     })
   })
 

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -120,6 +120,20 @@ describe('Workspace', () => {
         expect(atom.workspace.getTextEditors().length).toBe(0)
       })
     })
+
+    it('remembers whether the workspace had an active text editor', async () => {
+      await atom.workspace.open('../sample.txt')
+      expect(atom.workspace.hasActiveTextEditor).toBe(true)
+
+      simulateReload()
+      expect(atom.workspace.hasActiveTextEditor).toBe(true)
+
+      atom.workspace.getActivePane().destroy()
+      expect(atom.workspace.hasActiveTextEditor).toBe(false)
+
+      simulateReload()
+      expect(atom.workspace.hasActiveTextEditor).toBe(false)
+    })
   })
 
   describe('::open(itemOrURI, options)', () => {

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -120,62 +120,6 @@ describe('Workspace', () => {
         expect(atom.workspace.getTextEditors().length).toBe(0)
       })
     })
-
-    describe('where a dock contains an editor', () => {
-      afterEach(() => {
-        atom.workspace.getRightDock().paneContainer.destroy()
-      })
-
-      it('constructs the view with the same panes', () => {
-        const pane1 = atom.workspace.getRightDock().getActivePane()
-        const pane2 = pane1.splitRight({copyActiveItem: true})
-        const pane3 = pane2.splitRight({copyActiveItem: true})
-        let pane4 = null
-
-        waitsForPromise(() =>
-          atom.workspace.open(null, {location: 'right'}).then(editor => editor.setText('An untitled editor.'))
-        )
-
-        waitsForPromise(() =>
-          atom.workspace.open('b', {location: 'right'}).then(editor => pane2.activateItem(editor.copy()))
-        )
-
-        waitsForPromise(() =>
-          atom.workspace.open('../sample.js', {location: 'right'}).then(editor => pane3.activateItem(editor))
-        )
-
-        runs(() => {
-          pane3.activeItem.setCursorScreenPosition([2, 4])
-          pane4 = pane2.splitDown()
-        })
-
-        waitsForPromise(() =>
-          atom.workspace.open('../sample.txt', {location: 'right'}).then(editor => pane4.activateItem(editor))
-        )
-
-        runs(() => {
-          pane4.getActiveItem().setCursorScreenPosition([0, 2])
-          pane2.activate()
-
-          simulateReload()
-
-          expect(atom.workspace.getTextEditors().length).toBe(5)
-          const [editor1, editor2, untitledEditor, editor3, editor4] = atom.workspace.getTextEditors()
-          const firstDirectory = atom.project.getDirectories()[0]
-          expect(firstDirectory).toBeDefined()
-          expect(editor1.getPath()).toBe(firstDirectory.resolve('b'))
-          expect(editor2.getPath()).toBe(firstDirectory.resolve('../sample.txt'))
-          expect(editor2.getCursorScreenPosition()).toEqual([0, 2])
-          expect(editor3.getPath()).toBe(firstDirectory.resolve('b'))
-          expect(editor4.getPath()).toBe(firstDirectory.resolve('../sample.js'))
-          expect(editor4.getCursorScreenPosition()).toEqual([2, 4])
-          expect(untitledEditor.getPath()).toBeUndefined()
-          expect(untitledEditor.getText()).toBe('An untitled editor.')
-
-          expect(atom.workspace.getRightDock().getActiveTextEditor().getPath()).toBe(editor3.getPath())
-        })
-      })
-    })
   })
 
   describe('::open(itemOrURI, options)', () => {
@@ -426,6 +370,13 @@ describe('Workspace', () => {
 
           runs(() => expect(workspace.getActivePaneItem()).toBe(editor))
         })
+      })
+    })
+
+    describe('when attempting to open an editor in a dock', () => {
+      it('opens the editor in the workspace center', async () => {
+        await atom.workspace.open('sample.txt', {location: 'right'})
+        expect(atom.workspace.getCenter().getActivePaneItem().getFileName()).toEqual('sample.txt')
       })
     })
 

--- a/src/dock.js
+++ b/src/dock.js
@@ -4,6 +4,7 @@ const _ = require('underscore-plus')
 const {CompositeDisposable} = require('event-kit')
 const PaneContainer = require('./pane-container')
 const TextEditor = require('./text-editor')
+const Grim = require('grim')
 
 const MINIMUM_SIZE = 100
 const DEFAULT_INITIAL_SIZE = 300
@@ -590,11 +591,13 @@ module.exports = class Dock {
     return this.paneContainer.getTextEditors()
   }
 
-  // Essential: Get the active item if it is a {TextEditor}.
+  // Deprecated: Get the active item if it is a {TextEditor}.
   //
   // Returns a {TextEditor} or `undefined` if the current active item is not a
   // {TextEditor}.
   getActiveTextEditor () {
+    Grim.deprecate('Text editors are not allowed in docks. Use atom.workspace.getActiveTextEditor() instead.')
+
     const activeItem = this.getActivePaneItem()
     if (activeItem instanceof TextEditor) { return activeItem }
   }

--- a/src/dock.js
+++ b/src/dock.js
@@ -590,9 +590,9 @@ module.exports = class Dock {
     return this.paneContainer.getTextEditors()
   }
 
-  // Essential: Get the active item if it is an {TextEditor}.
+  // Essential: Get the active item if it is a {TextEditor}.
   //
-  // Returns an {TextEditor} or `undefined` if the current active item is not an
+  // Returns a {TextEditor} or `undefined` if the current active item is not a
   // {TextEditor}.
   getActiveTextEditor () {
     const activeItem = this.getActivePaneItem()

--- a/src/dock.js
+++ b/src/dock.js
@@ -385,21 +385,6 @@ module.exports = class Dock {
   Section: Event Subscription
   */
 
-  // Essential: Invoke the given callback with all current and future text
-  // editors in the dock.
-  //
-  // * `callback` {Function} to be called with current and future text editors.
-  //   * `editor` An {TextEditor} that is present in {::getTextEditors} at the time
-  //     of subscription or that is added at some later time.
-  //
-  // Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
-  observeTextEditors (callback) {
-    for (const textEditor of this.getTextEditors()) {
-      callback(textEditor)
-    }
-    return this.onDidAddTextEditor(({textEditor}) => callback(textEditor))
-  }
-
   // Essential: Invoke the given callback with all current and future panes items
   // in the dock.
   //

--- a/src/dock.js
+++ b/src/dock.js
@@ -569,13 +569,6 @@ module.exports = class Dock {
     return this.paneContainer.getActivePaneItem()
   }
 
-  // Essential: Get all text editors in the dock.
-  //
-  // Returns an {Array} of {TextEditor}s.
-  getTextEditors () {
-    return this.paneContainer.getTextEditors()
-  }
-
   // Deprecated: Get the active item if it is a {TextEditor}.
   //
   // Returns a {TextEditor} or `undefined` if the current active item is not a

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -3627,6 +3627,9 @@ class TextEditor extends Model
       })
       @component.element
 
+  getAllowedLocations: ->
+    ['center']
+
   # Essential: Retrieves the greyed out placeholder of a mini editor.
   #
   # Returns a {String}.

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -345,8 +345,7 @@ module.exports = class Workspace extends Model {
         left: this.paneContainers.left.serialize(),
         right: this.paneContainers.right.serialize(),
         bottom: this.paneContainers.bottom.serialize()
-      },
-      hasActiveTextEditor: this.hasActiveTextEditor
+      }
     }
   }
 
@@ -373,9 +372,7 @@ module.exports = class Workspace extends Model {
       this.paneContainers.center.deserialize(state.paneContainer, deserializerManager)
     }
 
-    if (state.hasActiveTextEditor != null) {
-      this.hasActiveTextEditor = state.hasActiveTextEditor
-    }
+    this.hasActiveTextEditor = this.getActiveTextEditor() != null
 
     this.updateWindowTitle()
   }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -427,7 +427,7 @@ module.exports = class Workspace extends Model {
     if (paneContainer === this.getCenter()) {
       const itemIsTextEditor = item instanceof TextEditor
       const activeTextEditorChanged =
-        itemIsTextEditor || (this.activeTextEditor instanceof TextEditor)
+        itemIsTextEditor || (this.activeTextEditor != null)
 
       if (activeTextEditorChanged) {
         this.activeTextEditor = itemIsTextEditor ? item : null

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1282,12 +1282,12 @@ module.exports = class Workspace extends Model {
     return this.getPaneItems().filter(item => item instanceof TextEditor)
   }
 
-  // Essential: Get the active item if it is an {TextEditor}.
+  // Essential: Get the workspace center's active item if it is a {TextEditor}.
   //
-  // Returns an {TextEditor} or `undefined` if the current active item is not an
-  // {TextEditor}.
+  // Returns a {TextEditor} or `undefined` if the workspace center's current
+  // active item is not a {TextEditor}.
   getActiveTextEditor () {
-    const activeItem = this.getActivePaneItem()
+    const activeItem = this.getCenter().getActivePaneItem()
     if (activeItem instanceof TextEditor) { return activeItem }
   }
 

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -216,7 +216,7 @@ module.exports = class Workspace extends Model {
       bottom: this.createDock('bottom')
     }
     this.activePaneContainer = this.paneContainers.center
-    this.activeTextEditor = null
+    this.hasActiveTextEditor = false
 
     this.panelContainers = {
       top: new PanelContainer({viewRegistry: this.viewRegistry, location: 'top'}),
@@ -345,7 +345,8 @@ module.exports = class Workspace extends Model {
         left: this.paneContainers.left.serialize(),
         right: this.paneContainers.right.serialize(),
         bottom: this.paneContainers.bottom.serialize()
-      }
+      },
+      hasActiveTextEditor: this.hasActiveTextEditor
     }
   }
 
@@ -370,6 +371,10 @@ module.exports = class Workspace extends Model {
     } else if (state.paneContainer) {
       // TODO: Remove this fallback once a lot of time has passed since 1.17 was released
       this.paneContainers.center.deserialize(state.paneContainer, deserializerManager)
+    }
+
+    if (state.hasActiveTextEditor != null) {
+      this.hasActiveTextEditor = state.hasActiveTextEditor
     }
 
     this.updateWindowTitle()
@@ -425,12 +430,11 @@ module.exports = class Workspace extends Model {
     }
 
     if (paneContainer === this.getCenter()) {
-      const newActiveTextEditor = (item instanceof TextEditor) ? item : null
-      const oldActiveTextEditor = this.activeTextEditor
+      const hadActiveTextEditor = this.hasActiveTextEditor
+      this.hasActiveTextEditor = item instanceof TextEditor
 
-      if (newActiveTextEditor || oldActiveTextEditor) {
-        this.activeTextEditor = newActiveTextEditor
-        const itemValue = (this.activeTextEditor || undefined)
+      if (this.hasActiveTextEditor || hadActiveTextEditor) {
+        const itemValue = this.hasActiveTextEditor ? item : undefined
         this.emitter.emit('did-change-active-text-editor', itemValue)
       }
     }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -690,13 +690,12 @@ module.exports = class Workspace extends Model {
   // an active text editor.
   //
   // * `callback` {Function} to be called when the active text editor changes.
-  //   * `editor` The active {TextEditor} or undefined if there is no longer an
+  //   * `editor` The active {TextEditor} or undefined if there is not an
   //      active text editor.
   //
   // Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   observeActiveTextEditor (callback) {
-    const activeTextEditor = this.getActiveTextEditor()
-    if (activeTextEditor != null) { callback(activeTextEditor) }
+    callback(this.getActiveTextEditor())
 
     return this.onDidChangeActiveTextEditor(callback)
   }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -297,6 +297,7 @@ module.exports = class Workspace extends Model {
       bottom: this.createDock('bottom')
     }
     this.activePaneContainer = this.paneContainers.center
+    this.hasActiveTextEditor = false
 
     this.panelContainers = {
       top: new PanelContainer({viewRegistry: this.viewRegistry, location: 'top'}),

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -660,6 +660,14 @@ module.exports = class Workspace extends Model {
     return this.emitter.on('did-stop-changing-active-pane-item', callback)
   }
 
+  // Essential: Invoke the given callback when a text editor becomes the active
+  // text editor and when there is no longer an active text editor.
+  //
+  // * `callback` {Function} to be called when the active text editor changes.
+  //   * `editor` The active {TextEditor} or undefined if there is no longer an
+  //      active text editor.
+  //
+  // Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidChangeActiveTextEditor (callback) {
     return this.emitter.on('did-change-active-text-editor', callback)
   }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -684,6 +684,15 @@ module.exports = class Workspace extends Model {
     return this.onDidChangeActivePaneItem(callback)
   }
 
+  // Essential: Invoke the given callback with the current active text editor
+  // (if any), with all future active text editors, and when there is no longer
+  // an active text editor.
+  //
+  // * `callback` {Function} to be called when the active text editor changes.
+  //   * `editor` The active {TextEditor} or undefined if there is no longer an
+  //      active text editor.
+  //
+  // Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   observeActiveTextEditor (callback) {
     const activeTextEditor = this.getActiveTextEditor()
     if (activeTextEditor != null) { callback(activeTextEditor) }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -425,13 +425,12 @@ module.exports = class Workspace extends Model {
     }
 
     if (paneContainer === this.getCenter()) {
-      const itemIsTextEditor = item instanceof TextEditor
-      const activeTextEditorChanged =
-        itemIsTextEditor || (this.activeTextEditor != null)
+      const newActiveTextEditor = (item instanceof TextEditor) ? item : null
+      const oldActiveTextEditor = this.activeTextEditor
 
-      if (activeTextEditorChanged) {
-        this.activeTextEditor = itemIsTextEditor ? item : null
-        const itemValue = itemIsTextEditor ? item : undefined
+      if (newActiveTextEditor || oldActiveTextEditor) {
+        this.activeTextEditor = newActiveTextEditor
+        const itemValue = (this.activeTextEditor || undefined)
         this.emitter.emit('did-change-active-text-editor', itemValue)
       }
     }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -425,12 +425,13 @@ module.exports = class Workspace extends Model {
     }
 
     if (paneContainer === this.getCenter()) {
+      const itemIsTextEditor = item instanceof TextEditor
       const activeTextEditorChanged =
-        (item instanceof TextEditor) || (this.activeTextEditor instanceof TextEditor)
+        itemIsTextEditor || (this.activeTextEditor instanceof TextEditor)
 
       if (activeTextEditorChanged) {
-        this.activeTextEditor = (item instanceof TextEditor) ? item : null
-        const itemValue = (item instanceof TextEditor) ? item : undefined
+        this.activeTextEditor = itemIsTextEditor ? item : null
+        const itemValue = itemIsTextEditor ? item : undefined
         this.emitter.emit('did-change-active-text-editor', itemValue)
       }
     }


### PR DESCRIPTION
### Description of the Change

As the first step toward resolving #14648, this pull request implements the proposal outlined in https://github.com/atom/atom/issues/14648#issuecomment-305017095:

> - Disallow editors in docks. Only allow editors in the workspace center.
> - Change `atom.workspace.getActiveTextEditor()` to return the active text editor (if any) in the workspace center. (This is more consistent with the pre 1.17.0 behavior described in https://github.com/atom/atom/issues/14648#issuecomment-304381899.)
> - Introduce `atom.workspace.observeActiveTextEditor()` as a means of observing the active text editor. (Packages like encoding-selector and grammar-selector _want_ to observe the active text editor, but currently have to rely on observing the active pane item, which is problematic for the reasons described in https://github.com/atom/atom/issues/14648#issuecomment-304391943.)

Once this pull request is merged, I'll then be able to update each of the core packages that currently use `atom.workspace.observeActivePaneItem()` to instead use `atom.workspace.observeActiveTextEditor()` to receive notifications each time a different text editor becomes active. Once that's done, we'll be able to close #14648.

### Alternate Designs

- For packages that need to observe the active text editor (e.g., https://github.com/atom/status-bar/issues/194), we could require those packages to observe all pane containers and watch for a text editor to become active in that pane container. Because observing the active text editor is a common need, I'd rather provide a core API for this functionality and not require each package to implement and maintain this logic.
- Instead of disallowing editors in docks, we could teach `atom.workspace.getActiveTextEditor()` to first check for an active text editor in the active pane container and return it if it exists, and to otherwise return the active text editor (if any) in the workspace center. `atom.workspace.observeActiveTextEditor()` would need to use similar logic to notify observers each time the value of `atom.workspace.getActiveTextEditor()` changes. This approach would likely allow us to resolve https://github.com/atom/status-bar/issues/194, but it feels overly complicated, and it seems like something that is more likely to cause future confusion, surprise, and additional maintenance overhead.

### Why Should This Be In Core?

It's the first step toward resolving #14648.

### Benefits

- Developers will have a core API for getting notified when:
  - A text editor becomes the active text editor
  - There is no longer an active text editor
- The behavior of `atom.workspace.getActiveTextEditor()` will [more closely match its pre-1.17.0 behavior](https://github.com/atom/atom/issues/14648#issuecomment-304381899), which various [packages relied on](https://github.com/atom/find-and-replace/pull/904).
- We answer the question, "Does it make sense to have an editor in a dock?" Answer: No. Atom expects to find editors in the workspace center. Docks are intended to provide supporting tools like a tree view, a debugger, a console. xref: http://blog.atom.io/2017/05/23/docks-deep-dive.html
- It reduces (hopefully 🤞) the overall number of scenarios that need to be considered in Atom core and in packages that interact with editors (e.g., https://github.com/atom/find-and-replace/issues/901#issuecomment-304078622).

### Possible Drawbacks

- By disallowing editors in docks, we reduce Atom's overall flexibility. If someone comes up with a compelling reason for using an editor in a dock, they're out of luck.
- Implementing `getAllowedLocations()` on an item affects where the item opens when using `atom.workspace.open()` and when [dragging an item to a dock in the UI](https://github.com/atom/atom/blob/16e1ef917be66637a58bad5e09c7d546782ee6e8/src/dock.js#L228-L229). However, functions like [`Pane::addItem()`](https://atom.io/docs/api/v1.17.2/Pane#instance-addItem) currently allow you to add the item to any location, regardless of the locations returned by the item's `getAllowedLocations()` function. In other words, there will continue to be ways to programmatically add a text editor to a dock, even though we're discouraging it and considering it to be unsupported behavior.

### Applicable Issues

- #14648
- https://github.com/atom/status-bar/issues/194

### TODO

- [x] Add `TextEditor::getAllowedLocations()` to indicate that editors belong in the workspace center
- [x] Add `Workspace::observeActiveTextEditor()`
- [x] Add API docs for new functions in `Workspace`
- [x] Determine and implement reasonable behavior for existing text editor functions in `Dock`:
  - [x] [`observeTextEditors`](https://github.com/atom/atom/blob/16e1ef917be66637a58bad5e09c7d546782ee6e8/src/dock.js#L387-L400) -- 0b314ac1a98ca06c82fc369fffe4f13fc772abe5
  - [x] [`getTextEditors`](https://github.com/atom/atom/blob/16e1ef917be66637a58bad5e09c7d546782ee6e8/src/dock.js#L586-L591) -- 09495dfc35b1294df0f4785e00d4eb1f8c7e27fc
  - [x] [`getActiveTextEditor`](https://github.com/atom/atom/blob/16e1ef917be66637a58bad5e09c7d546782ee6e8/src/dock.js#L593-L600) -- f8ebd71200af4dcc5cf6fc2d85e68247833d9acc
