### PR TITLE
:memo: Add missing parameter documentation

### DIFF
--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -447,6 +447,7 @@ class Pane
   # Public: Make the given item *active*, causing it to be displayed by
   # the pane's view.
   #
+  # * `item` The item to activate
   # * `options` (optional) {Object}
   #   * `pending` (optional) {Boolean} indicating that the item should be added
   #     in a pending state if it does not yet exist in the pane. Existing pending


### PR DESCRIPTION
### Description of the Change

Add missing documentation for a function parameter.

### Alternate Designs

N/A

### Why Should This Be In Core?

Documenting something that is already in core.

### Benefits

People will understand the documentation better.

### Possible Drawbacks

N/A

### Applicable Issues

None known.