### PR TITLE
⬆️  Update packages to populate status bar for pending editor pane items

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "github": "0.3.3",
     "git-diff": "1.3.6",
     "go-to-line": "0.32.1",
-    "grammar-selector": "0.49.4",
+    "grammar-selector": "0.49.5",
     "image-view": "0.61.2",
     "incompatible-packages": "0.27.3",
     "keybinding-resolver": "0.38.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "dalek": "0.2.1",
     "deprecation-cop": "0.56.7",
     "dev-live-reload": "0.47.1",
-    "encoding-selector": "0.23.3",
+    "encoding-selector": "0.23.4",
     "exception-reporting": "0.41.4",
     "find-and-replace": "0.208.3",
     "fuzzy-finder": "1.5.8",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "settings-view": "0.250.0",
     "snippets": "1.1.4",
     "spell-check": "0.71.4",
-    "status-bar": "1.8.10",
+    "status-bar": "1.8.11",
     "styleguide": "0.49.6",
     "symbols-view": "0.116.0",
     "tabs": "0.106.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "image-view": "0.61.2",
     "incompatible-packages": "0.27.3",
     "keybinding-resolver": "0.38.0",
-    "line-ending-selector": "0.6.3",
+    "line-ending-selector": "0.7.1",
     "link": "0.31.3",
     "markdown-preview": "0.159.12",
     "metrics": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "exception-reporting": "0.41.4",
     "find-and-replace": "0.208.3",
     "fuzzy-finder": "1.5.8",
-    "github": "0.3.2",
+    "github": "0.3.3",
     "git-diff": "1.3.6",
     "go-to-line": "0.32.1",
     "grammar-selector": "0.49.4",


### PR DESCRIPTION
This PR upgrades the packages associated with the issue described in https://github.com/atom/atom/issues/14648.

Now that https://github.com/atom/atom/pull/14695 is merged, and now that we have new releases of the [associated packages](https://github.com/atom/status-bar/issues/194#issuecomment-306206730), this PR updates Atom to use those new releases.

Associated PRs:

- https://github.com/atom/status-bar/pull/195
- https://github.com/atom/grammar-selector/pull/45
- https://github.com/atom/encoding-selector/pull/49
- https://github.com/atom/line-ending-selector/pull/46
- https://github.com/atom/github/pull/905
