### PR TITLE
Fix Docks docs

### DIFF
--- a/src/dock.js
+++ b/src/dock.js
@@ -16,8 +16,8 @@ const CURSOR_OVERLAY_VISIBLE_CLASS = 'atom-dock-cursor-overlay-visible'
 
 // Extended: A container at the edges of the editor window capable of holding items.
 // You should not create a Dock directly. Instead, access one of the three docks of the workspace
-// via {::getLeftDock}, {::getRightDock}, and {::getBottomDock} or add an item to a dock via
-// {Workspace::open}.
+// via {Workspace::getLeftDock}, {Workspace::getRightDock}, and {Workspace::getBottomDock}
+// or add an item to a dock via {Workspace::open}.
 module.exports = class Dock {
   constructor (params) {
     this.handleResizeHandleDragStart = this.handleResizeHandleDragStart.bind(this)

--- a/src/workspace-center.js
+++ b/src/workspace-center.js
@@ -3,6 +3,7 @@
 const TextEditor = require('./text-editor')
 const PaneContainer = require('./pane-container')
 
+// Essential: Represents the workspace at the center of the entire window.
 module.exports = class WorkspaceCenter {
   constructor (params) {
     params.location = 'center'

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1548,22 +1548,27 @@ module.exports = class Workspace extends Model {
   Section: Pane Locations
   */
 
+  // Essential: Get the {WorkspaceCenter} at the center of the editor window.
   getCenter () {
     return this.paneContainers.center
   }
 
+  // Essential: Get the {Dock} to the left of the editor window.
   getLeftDock () {
     return this.paneContainers.left
   }
 
+  // Essential: Get the {Dock} to the right of the editor window.
   getRightDock () {
     return this.paneContainers.right
   }
 
+  // Essential: Get the {Dock} below the editor window.
   getBottomDock () {
     return this.paneContainers.bottom
   }
 
+  // Essential: Get an {Array} of the current {WorkspaceCenter} and {Dock}s.
   getPaneContainers () {
     return [
       this.paneContainers.center,

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1568,7 +1568,6 @@ module.exports = class Workspace extends Model {
     return this.paneContainers.bottom
   }
 
-  // Essential: Get an {Array} of the current {WorkspaceCenter} and {Dock}s.
   getPaneContainers () {
     return [
       this.paneContainers.center,


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Fixes some issues with the new Docks documentation.  In particular, the documentation to `get{Left|Right|Bottom}Dock` was pointing to the wrong class and the methods themselves weren't public.

Please note: While adding documentation to the dock methods, I noticed that while `WorkspaceCenter` had docs for its individual methods, it did not have documentation for the class itself and therefore was not showing up as part of the API.  Therefore I've added a short blurb to the class.

The documentation I added was based off my best judgement and the comments for similar classes/methods; please feel free to improve them.

### Alternate Designs

N/A

### Why Should This Be In Core?

Because the documentation is in core.

### Benefits

Better documentation.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #14728

I have no clue how to test this.