### PR TITLE
Don't try to measure lines that don't exist

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -24,7 +24,7 @@ document.registerElement('text-editor-component-test-element', {
   })
 })
 
-describe('TextEditorComponent', () => {
+fdescribe('TextEditorComponent', () => {
   beforeEach(() => {
     jasmine.useRealClock()
 
@@ -959,6 +959,14 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise()
 
       expect(component.getScrollLeft()).toBe(component.getScrollWidth() - component.getScrollContainerClientWidth())
+    })
+
+    it('does not try to measure lines that do not exist when the animation frame is delivered', async () => {
+      const {component, editor} = buildComponent({autoHeight: false, height: 30, rowsPerTile: 2})
+      editor.scrollToBufferPosition([11, 5])
+      editor.getBuffer().deleteRows(11, 12)
+      await component.getNextUpdatePromise()
+      expect(component.getScrollBottom()).toBe((10 + 1) * component.measurements.lineHeight)
     })
 
     it('accounts for the presence of horizontal scrollbars that appear during the same frame as the autoscroll', async () => {

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -24,7 +24,7 @@ document.registerElement('text-editor-component-test-element', {
   })
 })
 
-fdescribe('TextEditorComponent', () => {
+describe('TextEditorComponent', () => {
   beforeEach(() => {
     jasmine.useRealClock()
 

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -332,7 +332,7 @@ class TextEditorComponent {
     this.derivedDimensionsCache = {}
     this.updateModelSoftWrapColumn()
     if (this.pendingAutoscroll) {
-      const {screenRange, options} = this.pendingAutoscroll
+      let {screenRange, options} = this.pendingAutoscroll
       this.autoscrollVertically(screenRange, options)
       this.requestHorizontalMeasurement(screenRange.start.row, screenRange.start.column)
       this.requestHorizontalMeasurement(screenRange.end.row, screenRange.end.column)
@@ -2097,7 +2097,12 @@ class TextEditorComponent {
     if (column === 0) return
 
     if (row < this.getRenderedStartRow() || row >= this.getRenderedEndRow()) {
-      this.requestExtraLineToMeasure(row, this.props.model.screenLineForScreenRow(row))
+      const screenLine = this.props.model.screenLineForScreenRow(row)
+      if (screenLine) {
+        this.requestExtraLineToMeasure(row, screenLine)
+      } else {
+        return
+      }
     }
 
     let columns = this.horizontalPositionsToMeasure.get(row)


### PR DESCRIPTION
By the time that the animation frame is delivered, the requested autoscroll position could not exist anymore. This could cause the editor component to measure a non-existent line and, as a result, throw an exception.

With this commit we will always ignore measurements for screen lines that do not exist.

/cc: @nathansobo 