### PR TITLE
Add verticalScrollMargin to configurable settings.

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -427,6 +427,12 @@ const configSchema = {
         minimum: 0,
         description: 'When soft wrap is enabled, defines length of additional indentation applied to wrapped lines, in number of characters.'
       },
+      verticalScrollMargin: {
+        type: 'integer',
+        default: 2,
+        minimum: 0,
+        description: 'Margin to leave at top and bottom of window when moving the cursor vertically.'
+      },
       scrollSensitivity: {
         type: 'integer',
         default: 40,

--- a/src/text-editor-registry.js
+++ b/src/text-editor-registry.js
@@ -10,6 +10,7 @@ const EDITOR_PARAMS_BY_SETTING_KEY = [
   ['editor.atomicSoftTabs', 'atomicSoftTabs'],
   ['editor.showInvisibles', 'showInvisibles'],
   ['editor.tabLength', 'tabLength'],
+  ['editor.verticalScrollMargin', 'verticalScrollMargin'],
   ['editor.invisibles', 'invisibles'],
   ['editor.showCursorOnSelection', 'showCursorOnSelection'],
   ['editor.showIndentGuide', 'showIndentGuide'],

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -159,7 +159,7 @@ class TextEditor extends Model
       @assert, grammar, @showInvisibles, @autoHeight, @autoWidth, @scrollPastEnd, @editorWidthInChars,
       @tokenizedBuffer, @displayLayer, @invisibles, @showIndentGuide,
       @softWrapped, @softWrapAtPreferredLineLength, @preferredLineLength,
-      @showCursorOnSelection
+      @showCursorOnSelection, @verticalScrollMargin
     } = params
 
     @assert ?= (condition) -> condition
@@ -184,6 +184,7 @@ class TextEditor extends Model
     @softWrapAtPreferredLineLength ?= false
     @preferredLineLength ?= 80
     @showLineNumbers ?= true
+    @verticalScrollMargin ?= 2
 
     @buffer ?= new TextBuffer({shouldDestroyOnFileDelete: ->
       atom.config.get('core.closeDeletedFileTabs')})
@@ -396,6 +397,10 @@ class TextEditor extends Model
           if value isnt @showCursorOnSelection
             @showCursorOnSelection = value
             @component?.scheduleUpdate()
+
+        when 'verticalScrollMargin'
+          if value isnt @verticalScrollMargin
+            @verticalScrollMargin = value
 
         else
           if param isnt 'ref' and param isnt 'key'
@@ -788,7 +793,8 @@ class TextEditor extends Model
       initialScrollTopRow: @getScrollTopRow(),
       initialScrollLeftColumn: @getScrollLeftColumn(),
       @assert, displayLayer, grammar: @getGrammar(),
-      @autoWidth, @autoHeight, @showCursorOnSelection
+      @autoWidth, @autoHeight, @showCursorOnSelection,
+      @verticalScrollMargin
     })
 
   # Controls visibility based on the given {Boolean}.
@@ -3651,8 +3657,12 @@ class TextEditor extends Model
     @getElement().pixelPositionForScreenPosition(screenPosition)
 
   getVerticalScrollMargin: ->
-    maxScrollMargin = Math.floor(((@height / @getLineHeightInPixels()) - 1) / 2)
-    Math.min(@verticalScrollMargin, maxScrollMargin)
+    # these can be uninitialized (e.g. in spec tests)
+    if !@height or !@getLineHeightInPixels()
+      @verticalScrollMargin
+    else
+      maxScrollMargin = Math.floor(((@height / @getLineHeightInPixels()) - 1) / 2)
+      Math.min(@verticalScrollMargin, maxScrollMargin)
 
   setVerticalScrollMargin: (@verticalScrollMargin) -> @verticalScrollMargin
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -3658,11 +3658,11 @@ class TextEditor extends Model
 
   getVerticalScrollMargin: ->
     # these can be uninitialized (e.g. in spec tests)
-    if !@height or !@getLineHeightInPixels()
-      @verticalScrollMargin
-    else
+    if @height and @getLineHeightInPixels()
       maxScrollMargin = Math.floor(((@height / @getLineHeightInPixels()) - 1) / 2)
       Math.min(@verticalScrollMargin, maxScrollMargin)
+    else
+      @verticalScrollMargin
 
   setVerticalScrollMargin: (@verticalScrollMargin) -> @verticalScrollMargin
 


### PR DESCRIPTION
### Description of the Change
Vertical scroll margin was already a feature, but it was hard coded to 2. This PR adds it as a configurable setting.
Primary changes that had to be made:
src/text-editor.coffee: Added verticalScrollMargin to constructor/copy/update.
src/config-schema.js: Added verticalScrollMargin as an editor property with default of 2 and a description of the feature.
src/text-editor-registry.js: Added verticalScrollMargin editor param.
spec/text-editor-spec.coffee: Added tests for the feature.

### Alternate Designs

There is a workaround mentioned in issue [#11799](https://github.com/atom/atom/issues/11799), but this PR simply adds it as a configurable setting.

### Why Should This Be In Core?

It's an existing feature in core, but its value is hard coded. In other editors this is usually either a configurable feature or non-existent (i.e. 0 margin).

### Benefits

People who are used to the lack of a vertical scroll margin in other editors, or who wish to customize it, can now easily modify the vertical scroll margin size in the settings.

### Possible Drawbacks

None that I'm aware of.

### Applicable Issues

[#11799](https://github.com/atom/atom/issues/11799)

