### PR TITLE
Improved clarity of Editor not responding actions

### DIFF
--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -160,7 +160,7 @@ class AtomWindow
 
       chosen = dialog.showMessageBox @browserWindow,
         type: 'warning'
-        buttons: ['Close', 'Keep Waiting']
+        buttons: ['Force Close', 'Keep Waiting']
         message: 'Editor is not responding'
         detail: 'The editor is not responding. Would you like to force close it or just keep waiting?'
       @browserWindow.destroy() if chosen is 0


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Changed the label on the positive button of the "Editor is not responding" alert dialog from "Close" to "Force Close" because "Close" might imply closing the Alert/Dialog instead of the editor, whereas "Force Close" better describes the action that button will take.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Other strings may be "Force Quit" or "End Process" or "Close Editor"

### Why Should This Be In Core?

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

This change is a tweak to the core strings.

### Benefits

<!-- What benefits will be realized by the code change? -->

Makes a (minor) improvement to user experience and reduces decision fatigue for end users. 

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Slight (neglibile) increase in file size due to longer string.

### Applicable Issues

<!-- Enter any applicable Issues here -->

Translation/localization will need to be updated elsewhere.