### PR TITLE
Update CSP to allow using eval from JavaScript

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src * atom://*; img-src blob: data: * atom://*; script-src 'self'; style-src 'self' 'unsafe-inline'; media-src blob: data: mediastream: * atom://*;">
+  <meta http-equiv="Content-Security-Policy" content="default-src * atom://*; img-src blob: data: * atom://*; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src blob: data: mediastream: * atom://*;">
   <script src="index.js"></script>
 </head>
 <body tabindex="-1">


### PR DESCRIPTION
### Description of the Change

While attempting to interact with an Express.js server within some Atom tests, we ran into the following error related to Atom's current Content Security Policy:

```
EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self'".

  at Function.wrapfunction [as function] (node_modules/depd/index.js:409:43)
  at populateConstructorExports (node_modules/http-errors/index.js:247:45)
  at Object.<anonymous> (node_modules/http-errors/index.js:29:1)
  at Object.<anonymous> (node_modules/http-errors/index.js:262:3)
```

This PR updates the policy to resolve this error ☝️, allowing Atom to run [this code](https://user-images.githubusercontent.com/2988/27043798-58b9ed04-4f69-11e7-80e8-3db5f8336cd5.png).

### Alternate Designs

We could have changed Express.js's dependencies to stop using eval, but we are not aware of any advantages of making such a change upstream.

### Why Should This Be In Core?

N/A

### Benefits

Allow package authors to use libraries that rely on eval.

### Possible Drawbacks

We're not aware of any negative consequences that this change would introduce, but it _is_ a change to the CSP, so we definitely want to hear from others. :pray:

@atom/maintainers: Do you know of any negative consequences that would result from this change?

### Applicable Issues

N/A
