### PR TITLE
AppVeyor node_module caches get corrupted, let's just disable them for now

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,10 +58,6 @@ artifacts:
     name: atom-full.nupkg
 
 cache:
-  - '%APPVEYOR_BUILD_FOLDER%\script\node_modules'
-  - '%APPVEYOR_BUILD_FOLDER%\apm\node_modules'
-  - '%APPVEYOR_BUILD_FOLDER%\node_modules'
   - '%APPVEYOR_BUILD_FOLDER%\electron'
   - '%USERPROFILE%\.atom\.apm'
   - '%USERPROFILE%\.atom\compile-cache'
-  - '%USERPROFILE%\.atom\snapshot-cache'


### PR DESCRIPTION
This PR removes the node_module caches so builds will complete, even if they're slower