### PR TITLE
Always run tests where directed

### DIFF
--- a/src/main-process/atom-application.coffee
+++ b/src/main-process/atom-application.coffee
@@ -120,7 +120,9 @@ class AtomApplication
     Promise.all(windowsClosePromises).then(=> @disposable.dispose())
 
   launch: (options) ->
-    if options.pathsToOpen?.length > 0 or options.urlsToOpen?.length > 0 or options.test or options.benchmark or options.benchmarkTest
+    if options.test or options.benchmark or options.benchmarkTest
+      @openWithOptions(options)
+    else if options.pathsToOpen?.length > 0 or options.urlsToOpen?.length > 0
       if @config.get('core.restorePreviousWindowsOnStart') is 'always'
         @loadState(_.deepClone(options))
       @openWithOptions(options)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

#13947 introduced a regression with `atom --test` where if `core.restorePreviousWindowsOnStart` was set to `always`, `atom --test` would ignore the supplied directory and instead test specs in the first folder you opened.  Had a very fun time trying to figure out why `atom --test spec` was running `language-html` tests instead of `tree-view` ones...

### Alternate Designs

None!

### Why Should This Be In Core?

Because I would like to be able to tell Atom where I want the specs to be run!

### Benefits

Being able to test any directory from the command line regardless of where Atom was started!

### Possible Drawbacks

None?!

### Applicable Issues

None!