### PR TITLE
:bug: Don't prefix resource path if package path is already absolute

### DIFF
--- a/src/package.coffee
+++ b/src/package.coffee
@@ -96,7 +96,7 @@ class Package
 
   finishLoading: ->
     @measure 'loadTime', =>
-      @path = path.join(@packageManager.resourcePath, @path)
+      @path = path.resolve(@packageManager.resourcePath, @path)
       ModuleCache.add(@path, @metadata)
 
       @loadStylesheets()


### PR DESCRIPTION
We're running into an issue in Nuclide where sometimes `finishLoading()` is called twice on the `tree-view` package. As a result, the path gets prepended twice.

This doesn't fix the underlying bug, but I think it's still best to use `resolve()` here so that, if `@path` is absolute, the resource path won't be prepended multiple times.