### PR TITLE
Remeasure block decorations if content changes

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1941,8 +1941,6 @@ describe('TextEditorComponent', () => {
       item3.style.margin = '10px'
       item2.style.height = '33px'
       item2.style.margin = '0px'
-      component.invalidateBlockDecorationDimensions(decoration2)
-      component.invalidateBlockDecorationDimensions(decoration3)
       await component.getNextUpdatePromise()
       expect(component.getRenderedStartRow()).toBe(0)
       expect(component.getRenderedEndRow()).toBe(9)
@@ -1973,7 +1971,6 @@ describe('TextEditorComponent', () => {
       item3.style.wordWrap = 'break-word'
       const contentWidthInCharacters = Math.floor(component.getScrollContainerClientWidth() / component.getBaseCharacterWidth())
       item3.textContent = 'x'.repeat(contentWidthInCharacters * 2)
-      component.invalidateBlockDecorationDimensions(decoration3)
       await component.getNextUpdatePromise()
 
       // make the editor wider, so that the decoration doesn't wrap anymore.

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1,4 +1,4 @@
-/* global ResizeObserver, MutationObserver */
+/* global ResizeObserver */
 
 const etch = require('etch')
 const {Point, Range} = require('text-buffer')
@@ -2347,15 +2347,13 @@ class TextEditorComponent {
 
     this.blockDecorationsToMeasure.add(decoration)
 
-    let mutationObserver
+    let resizeObserver
     if (decoration.properties.item) {
-      mutationObserver = new MutationObserver(() => {
+      resizeObserver = new ResizeObserver(() => {
         this.invalidateBlockDecorationDimensions(decoration)
       })
 
-      mutationObserver.observe(decoration.properties.item, {
-        attributes: true, childList: true, characterData: true, subtree: true
-      })
+      resizeObserver.observe(decoration.properties.item)
     }
 
     const didUpdateDisposable = marker.bufferMarker.onDidChange((e) => {
@@ -2369,7 +2367,7 @@ class TextEditorComponent {
       this.lineTopIndex.removeBlock(decoration)
       didUpdateDisposable.dispose()
       didDestroyDisposable.dispose()
-      if (mutationObserver) mutationObserver.disconnect()
+      if (resizeObserver) resizeObserver.disconnect()
       this.scheduleUpdate()
     })
   }

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2349,8 +2349,11 @@ class TextEditorComponent {
 
     let resizeObserver
     if (decoration.properties.item) {
-      resizeObserver = new ResizeObserver(() => {
-        this.invalidateBlockDecorationDimensions(decoration)
+      resizeObserver = new ResizeObserver((entries) => {
+        // We only call observe a single time, therefore entries should only have one entry
+        const height = entries[0].contentRect.height
+        this.lineTopIndex.resizeBlock(decoration, height)
+        this.scheduleUpdate()
       })
 
       resizeObserver.observe(decoration.properties.item)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Since #13880 the height of a block decorations doesn't get recalculated anymore if the content changes. This brings back the behavior of Atom 1.18. For more information on how to reproduce and GIFs see #14836

### Alternate Designs

I considered adding mutation observers to `decoration-manager` but this way we have a finer control over which decoration to schedule for remeasurment.

### Why Should This Be In Core?

This fixes a :bug: 😄 

### Benefits

This makes block decoration rendering consistent with the way it was in Atom 1.18

### Possible Drawbacks

I don't know how performance critical multiple `MutationObserver`'s are.

### Applicable Issues

Fixes #14836

/cc: @nathansobo @as-cii
