### PR TITLE
Comment out broken part of code for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Atom](https://cloud.githubusercontent.com/assets/72919/2874231/3af1db48-d3dd-11e3-98dc-6066f8bc766f.png)
 
 [![macOS Build Status](https://circleci.com/gh/atom/atom/tree/master.svg?style=shield)](https://circleci.com/gh/atom/atom) [![Linux Build Status](https://travis-ci.org/atom/atom.svg?branch=master)](https://travis-ci.org/atom/atom) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/1tkktwh654w07eim?svg=true)](https://ci.appveyor.com/project/Atom/atom)
-[![Dependency Status](https://david-dm.org/atom/atom.svg)](https://david-dm.org/atom/atom)
+<!--[![Dependency Status](https://david-dm.org/atom/atom.svg)](https://david-dm.org/atom/atom)-->
 [![Join the Atom Community on Slack](http://atom-slack.herokuapp.com/badge.svg)](http://atom-slack.herokuapp.com/)
 
 Atom is a hackable text editor for the 21st century, built on [Electron](https://github.com/atom/electron), and based on everything we love about our favorite editors. We designed it to be deeply customizable, but still approachable using the default configuration.


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

I commented out the "Dependancy Status" in the README.md, because in current time, the dependency status hosted on https://david-dm.org/atom/atom, is giving a 502 Bad Gateway error. I chose to comment out, and not delete because the website could be fixed in the near future.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
No other alternatives were considered, as a search in "Issues" of "Error 502" takes nothing up. An alternative to this choice would be to delete the code, but that would stop the potential for a fix when the website does get fixed.

### Why Should This Be In Core?

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->
This functionality is not affecting ATOM directly (to my knowledge) and only affects the GitHub repository for ATOM, so this question does not apply.

### Benefits

<!-- What benefits will be realized by the code change? -->
Will fix a temporary error, causing less confusion, and more polish, for visitors looking at the repository.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
If the code was changed into a comment, and the website was fixed, the fix would not be realized and would have to be manually checked.

### Applicable Issues

<!-- Enter any applicable Issues here -->
