### PR TITLE
Add instructions for local development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,19 @@ Both issue lists are sorted by total number of comments. While not perfect, numb
 
 If you want to read about using Atom or developing packages in Atom, the [Atom Flight Manual](http://flight-manual.atom.io) is free and available online. You can find the source to the manual in [atom/flight-manual.atom.io](https://github.com/atom/flight-manual.atom.io).
 
+#### Local development
+
+All packages can be developed locally, by checking out the corresponding repository and registering the package to Atom with `apm`:
+
+```
+$ git clone url-to-git-repository
+$ cd path-to-package/
+$ apm link -d
+$ atom -d .
+```
+
+By running Atom with the `-d` flag, you signal it to run with development packages installed. `apm link` makes sure that your local repository is loaded by Atom.
+
 ### Pull Requests
 
 * Fill in [the required template](PULL_REQUEST_TEMPLATE.md)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Finding out how to contribute to my first Atom package was problematic
and took me quite some time to figure out how to locally run the packages.
There were some spread out answers in the Atom discussion forum,
but I think it is easier for new developers to read the CONTRIBUTING guide
instead of using Google to find out how to contribute.

### Alternate Designs

Right now it is only on the Atom discussion forum, not in the contributing guide.

### Why Should This Be In Core?

All Atom packages link to this contributing guide.

### Benefits

Developers who have not contributed just yet are now more easily able to find out how to develop local changes and contribute them :)

### Possible Drawbacks

None that I am aware of, more sentences? :open_mouth: 

### Applicable Issues

N/A
