### PR TITLE
Fix resetting styles in NodePool

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -4034,7 +4034,6 @@ class NodePool {
   constructor () {
     this.elementsByType = {}
     this.textNodes = []
-    this.stylesByNode = new WeakMap()
   }
 
   getElement (type, className, style) {
@@ -4055,14 +4054,10 @@ class NodePool {
 
     if (element) {
       element.className = className
-      var existingStyle = this.stylesByNode.get(element)
-      if (existingStyle) {
-        for (var key in existingStyle) {
-          if (!style || !style[key]) element.style[key] = ''
-        }
-      }
+      element.styleMap.forEach((value, key) => {
+        if (!style || style[key] == null) element.style[key] = ''
+      })
       if (style) Object.assign(element.style, style)
-      this.stylesByNode.set(element, style)
 
       while (element.firstChild) element.firstChild.remove()
       return element
@@ -4070,7 +4065,6 @@ class NodePool {
       var newElement = document.createElement(type)
       if (className) newElement.className = className
       if (style) Object.assign(newElement.style, style)
-      this.stylesByNode.set(newElement, style)
       return newElement
     }
   }


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/14842.

Previously, we were mistakenly not clearing out some styling properties like `marginTop`, thus causing e.g. line numbers to be misaligned. This was caused by manual updates to an element's style object, without a consequent update to the `NodePool`.

With this pull-request we will now rely on `element.styleMap` (a DOM primitive) to detect which styles have been set on a element that is about to be recycled and, if the object being created doesn't use them, simply clear them out.