### PR TITLE
Only expect a single 'did-destroy' event

### DIFF
--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -49,7 +49,7 @@ class Cursor extends Model
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidDestroy: (callback) ->
-    @emitter.on 'did-destroy', callback
+    @emitter.once 'did-destroy', callback
 
   ###
   Section: Managing Cursor Position

--- a/src/decoration.coffee
+++ b/src/decoration.coffee
@@ -105,7 +105,7 @@ class Decoration
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidDestroy: (callback) ->
-    @emitter.on 'did-destroy', callback
+    @emitter.once 'did-destroy', callback
 
   ###
   Section: Decoration Details

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -129,7 +129,7 @@ class GitRepository
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidDestroy: (callback) ->
-    @emitter.on 'did-destroy', callback
+    @emitter.once 'did-destroy', callback
 
   ###
   Section: Event Subscription

--- a/src/gutter.coffee
+++ b/src/gutter.coffee
@@ -48,7 +48,7 @@ class Gutter
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidDestroy: (callback) ->
-    @emitter.on 'did-destroy', callback
+    @emitter.once 'did-destroy', callback
 
   ###
   Section: Visibility

--- a/src/pane-axis.coffee
+++ b/src/pane-axis.coffee
@@ -69,7 +69,7 @@ class PaneAxis extends Model
     @emitter.on 'did-replace-child', fn
 
   onDidDestroy: (fn) ->
-    @emitter.on 'did-destroy', fn
+    @emitter.once 'did-destroy', fn
 
   onDidChangeFlexScale: (fn) ->
     @emitter.on 'did-change-flex-scale', fn

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -170,7 +170,7 @@ class Pane
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidDestroy: (callback) ->
-    @emitter.on 'did-destroy', callback
+    @emitter.once 'did-destroy', callback
 
   # Public: Invoke the given callback when the value of the {::isActive}
   # property changes.

--- a/src/panel-container.js
+++ b/src/panel-container.js
@@ -40,7 +40,7 @@ module.exports = class PanelContainer {
   }
 
   onDidDestroy (callback) {
-    return this.emitter.on('did-destroy', callback)
+    return this.emitter.once('did-destroy', callback)
   }
 
   /*

--- a/src/panel.js
+++ b/src/panel.js
@@ -66,7 +66,7 @@ class Panel {
   //
   // Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidDestroy (callback) {
-    return this.emitter.on('did-destroy', callback)
+    return this.emitter.once('did-destroy', callback)
   }
 
   /*

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -54,7 +54,7 @@ class Selection extends Model
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidDestroy: (callback) ->
-    @emitter.on 'did-destroy', callback
+    @emitter.once 'did-destroy', callback
 
   ###
   Section: Managing the selection range

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -647,7 +647,7 @@ class TextEditor extends Model
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidDestroy: (callback) ->
-    @emitter.on 'did-destroy', callback
+    @emitter.once 'did-destroy', callback
 
   # Extended: Calls your `callback` when a {Cursor} is added to the editor.
   # Immediately calls your callback for each existing cursor.


### PR DESCRIPTION
These events will only be fired a single time at most, so we should clean up the listeners after that.

This should help minimize accidental memory leaks.

cc @hansonw