### PR TITLE
Invalidate block decoration dimensions automatically when their size changes

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1941,8 +1941,6 @@ describe('TextEditorComponent', () => {
       item3.style.margin = '10px'
       item2.style.height = '33px'
       item2.style.margin = '0px'
-      component.invalidateBlockDecorationDimensions(decoration2)
-      component.invalidateBlockDecorationDimensions(decoration3)
       await component.getNextUpdatePromise()
       expect(component.getRenderedStartRow()).toBe(0)
       expect(component.getRenderedEndRow()).toBe(9)
@@ -1973,7 +1971,6 @@ describe('TextEditorComponent', () => {
       item3.style.wordWrap = 'break-word'
       const contentWidthInCharacters = Math.floor(component.getScrollContainerClientWidth() / component.getBaseCharacterWidth())
       item3.textContent = 'x'.repeat(contentWidthInCharacters * 2)
-      component.invalidateBlockDecorationDimensions(decoration3)
       await component.getNextUpdatePromise()
 
       // make the editor wider, so that the decoration doesn't wrap anymore.


### PR DESCRIPTION
Supersedes https://github.com/atom/atom/pull/14844.
Fixes https://github.com/atom/atom/issues/14836.

In the previous implementation of the editor rendering layer, we used to continuously re-measure block decorations that were on-screen. This was done to allow users to interact with the decorations, without requiring any extra work by package authors if the decorations size changed dynamically as a response to user input. During the rewrite in #13880 we lost this behavior and issues like the one linked above started arising. 

With this pull-request, we will now automatically schedule a new update when detecting that a block decoration got resized and call `invalidateBlockDecorationDimensions` on behalf of package authors. This is powered by a per-component `ResizeObserver` that listens for size changes on every added block decoration.