### PR TITLE
Make atom.commands.dispatch return a promise that resolves after listeners complete

### DIFF
--- a/spec/command-registry-spec.js
+++ b/spec/command-registry-spec.js
@@ -208,10 +208,10 @@ describe("CommandRegistry", () => {
       expect(sequence[1][0]).toBe('listener');
       expect(sequence[2][0]).toBe('onDidDispatch');
 
-      waitsFor(() => sequence.length === 4), "onDidFinish never called");
+      waitsFor(() => sequence.length === 4, "onDidFinish never called");
 
       runs(() => {
-        expect(sequence[3][0]).toBe 'onDidFinish'
+        expect(sequence[3][0]).toBe('onDidFinish');
 
         expect(sequence[0][1] === sequence[1][1] && sequence[1][1] === sequence[2][1] && sequence[2][1] === sequence[3][1]).toBe(true);
         expect(sequence[0][1].constructor).toBe(CustomEvent);

--- a/spec/command-registry-spec.js
+++ b/spec/command-registry-spec.js
@@ -370,7 +370,7 @@ describe("CommandRegistry", () => {
       registry.add('.grandchild', 'command', () => 1);
       registry.add('.grandchild', 'command', () => Promise.resolve(2));
       registry.add('.grandchild', 'command', () => new Promise((resolve) => {
-        setTimeout(() => { resolve(3); }, 100);
+        global.setTimeout(() => { resolve(3); }, 100);
       }));
 
       const values = await registry.dispatch(grandchild, 'command');
@@ -381,7 +381,7 @@ describe("CommandRegistry", () => {
       registry.add('.grandchild', 'command', () => 1);
       registry.add('.grandchild', 'command', () => Promise.resolve(2));
       registry.add('.grandchild', 'command', () => new Promise((resolve, reject) => {
-        setTimeout(() => { reject(3); }, 100);
+        global.setTimeout(() => { reject(3); }, 100);
       }));
 
       let value;

--- a/spec/command-registry-spec.js
+++ b/spec/command-registry-spec.js
@@ -210,20 +210,6 @@ describe("CommandRegistry", () => {
       expect(sequence[0][1].constructor).toBe(CustomEvent);
       expect(sequence[0][1].target).toBe(grandchild);
     });
-
-    it("returns a promise", () => {
-      const calls = [];
-      registry.add('.grandchild', 'command', () => 'grandchild');
-      registry.add(child, 'command', () => 'child-inline');
-      registry.add('.child', 'command', () => 'child');
-      registry.add('.parent', 'command', () => 'parent');
-
-      waitsForPromise(() => grandchild.dispatchEvent(new CustomEvent('command', {bubbles: true})).then(args => { calls = args; }));
-
-      runs(() => {
-        expect(calls).toEqual(['grandchild', 'child-inline', 'child', 'parent']);
-      });
-    });
   });
 
   describe("::add(selector, commandName, callback)", () => {
@@ -371,12 +357,12 @@ describe("CommandRegistry", () => {
       expect(called).toBe(true);
     });
 
-    it("returns a boolean indicating whether any listeners matched the command", () => {
+    it("returns a promise if any listeners matched the command", () => {
       registry.add('.grandchild', 'command', () => {});
 
-      expect(registry.dispatch(grandchild, 'command')).toBe(true);
-      expect(registry.dispatch(grandchild, 'bogus')).toBe(false);
-      expect(registry.dispatch(parent, 'command')).toBe(false);
+      expect(registry.dispatch(grandchild, 'command').constructor.name).toBe("Promise");
+      expect(registry.dispatch(grandchild, 'bogus')).toBe(null);
+      expect(registry.dispatch(parent, 'command')).toBe(null);
     });
   });
 

--- a/spec/command-registry-spec.js
+++ b/spec/command-registry-spec.js
@@ -367,10 +367,11 @@ describe("CommandRegistry", () => {
     });
 
     it("returns a promise that resolves when the listeners resolve", async () => {
+      jasmine.useRealClock();
       registry.add('.grandchild', 'command', () => 1);
       registry.add('.grandchild', 'command', () => Promise.resolve(2));
       registry.add('.grandchild', 'command', () => new Promise((resolve) => {
-        global.setTimeout(() => { resolve(3); }, 100);
+        setTimeout(() => { resolve(3); }, 1);
       }));
 
       const values = await registry.dispatch(grandchild, 'command');
@@ -378,10 +379,11 @@ describe("CommandRegistry", () => {
     });
 
     it("returns a promise that rejects when a listener is rejected", async () => {
+      jasmine.useRealClock();
       registry.add('.grandchild', 'command', () => 1);
       registry.add('.grandchild', 'command', () => Promise.resolve(2));
       registry.add('.grandchild', 'command', () => new Promise((resolve, reject) => {
-        global.setTimeout(() => { reject(3); }, 100);
+        setTimeout(() => { reject(3); }, 1);
       }));
 
       let value;

--- a/spec/command-registry-spec.js
+++ b/spec/command-registry-spec.js
@@ -375,7 +375,7 @@ describe("CommandRegistry", () => {
       }));
 
       const values = await registry.dispatch(grandchild, 'command');
-      expect(values).toEqual([1, 2, 3]);
+      expect(values).toEqual([3, 2, 1]);
     });
 
     it("returns a promise that rejects when a listener is rejected", async () => {

--- a/src/command-registry.js
+++ b/src/command-registry.js
@@ -289,14 +289,6 @@ module.exports = class CommandRegistry {
     return this.emitter.on('did-dispatch', callback)
   }
 
-  // Public: Invoke the given callback after finishing a command event.
-  //
-  // * `callback` {Function} to be called after finishing each command
-  //   * `event` The Event that was dispatched
-  onDidFinish (callback) {
-    return this.emitter.on('did-finish', callback)
-  }
-
   getSnapshot () {
     const snapshot = {}
     for (const commandName in this.selectorBasedListenersByCommandName) {
@@ -403,12 +395,7 @@ module.exports = class CommandRegistry {
 
     this.emitter.emit('did-dispatch', dispatchedEvent)
 
-    Promise.all(matched).then(
-      _ => this.emitter.emit('did-finish', dispatchedEvent),
-      _ => this.emitter.emit('did-finish', dispatchedEvent)
-    )
-
-    return matched.length > 0
+    return (matched.length > 0 ? Promise.all(matched) : null)
   }
 
   commandRegistered (commandName) {


### PR DESCRIPTION
### Description of the Change

adds an `atom.commands.onDidFinish` function that is called after commands actually finish.

This will require commands that are asynchronous to return a promise so onDidFinish can know when a command is still working asynchronously.

### Alternate Designs

This comes from trying to return a commands value in #14720 

I decided to go with a `did-finish` event to keep backwards compatibility and use the event emitter already attached to `atom.commands`

This event is emitted once `Promise.all` on the return values of the command listeners finishes. Therefore it will be emitted when all listeners are resolved or one listener is rejected. And only the dispatched event is provided. A couple things could be changed here:

- We could wait until all listeners are resolved or rejected.
- We could emit a different event if rejected.
- We could include the returned values of the commands.

### Why Should This Be In Core?

It requires changes to the command registry and package creators to return a promise if the command is async.

### Benefits

- Ability to tell when an async command actually finishes.
- Ability to dispatch commands in series.

### Possible Drawbacks

Package creators will need to come on board for this to be very usefull

### Applicable Issues

#13195
