### PR TITLE
Show pending IME input instead of just the last typed character

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1628,7 +1628,7 @@ class TextEditorComponent {
   }
 
   didCompositionUpdate (event) {
-    this.props.model.insertText(event.data, {select: true})
+    this.props.model.insertText(event.data, {select: this.accentedCharacterMenuIsOpen})
   }
 
   didCompositionEnd (event) {


### PR DESCRIPTION
Fixes #14911.

Back in #13880 we revisited our approach to handling input events, greatly improving support for the [accented character menu](https://support.apple.com/en-us/HT201586) on macOS along the way. In that process, we also rewrote the logic for dealing with IME events, which caused in-progress IME input to be replaced with the last typed character while the IME panel was open:

![wrong-behavior](https://user-images.githubusercontent.com/14314532/27643959-0f04396e-5c55-11e7-838c-ac15ef580fbe.gif)

With this pull-request we will now show every character that has been pressed and, only at the end, replace the entire stream of character with the selected IME alternative:

![kapture 2017-07-03 at 11 28 24](https://user-images.githubusercontent.com/482957/27786774-d8cc11f0-5fe2-11e7-8b7e-3fcbe8323f62.gif)