### PR TITLE
Upgrade text-buffer to v13.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "sinon": "1.17.4",
     "@atom/source-map-support": "^0.3.4",
     "temp": "^0.8.3",
-    "text-buffer": "13.0.5",
+    "text-buffer": "13.0.6-0",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",
     "winreg": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "sinon": "1.17.4",
     "@atom/source-map-support": "^0.3.4",
     "temp": "^0.8.3",
-    "text-buffer": "13.0.6-0",
+    "text-buffer": "13.0.6",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",
     "winreg": "^1.2.1",


### PR DESCRIPTION
This changes marker layer `onDidUpdate` events to occur after text-buffer `onDidChangeText` events. Also, those events will now be triggered at the end of the outermost transaction, analogously to `onDidChangeText`.