### PR TITLE
Fix regressions handling mousedown on Linux and macOS

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1667,6 +1667,9 @@ class TextEditorComponent {
       return
     }
 
+    // Ctrl-click brings up the context menu on macOS
+    if (platform === 'darwin' && ctrlKey) return
+
     const addOrRemoveSelection = metaKey || (ctrlKey && platform !== 'darwin')
 
     switch (detail) {

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1645,10 +1645,11 @@ class TextEditorComponent {
   didMouseDownOnContent (event) {
     const {model} = this.props
     const {target, button, detail, ctrlKey, shiftKey, metaKey} = event
+    const platform = this.getPlatform()
 
     // Only handle mousedown events for left mouse button (or the middle mouse
     // button on Linux where it pastes the selection clipboard).
-    if (!(button === 0 || (this.getPlatform() === 'linux' && button === 1))) return
+    if (!(button === 0 || (platform === 'linux' && button === 1))) return
 
     const screenPosition = this.screenPositionForMouseEvent(event)
 
@@ -1659,14 +1660,14 @@ class TextEditorComponent {
     }
 
     // Handle middle mouse button only on Linux (paste clipboard)
-    if (this.getPlatform() === 'linux' && button === 1) {
+    if (platform === 'linux' && button === 1) {
       const selection = clipboard.readText('selection')
       model.setCursorScreenPosition(screenPosition, {autoscroll: false})
       model.insertText(selection)
       return
     }
 
-    const addOrRemoveSelection = metaKey || (ctrlKey && this.getPlatform() !== 'darwin')
+    const addOrRemoveSelection = metaKey || (ctrlKey && platform !== 'darwin')
 
     switch (detail) {
       case 1:

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -5,7 +5,6 @@ const {Point, Range} = require('text-buffer')
 const LineTopIndex = require('line-top-index')
 const TextEditor = require('./text-editor')
 const {isPairedCharacter} = require('./text-utils')
-const clipboard = require('./safe-clipboard')
 const electron = require('electron')
 const $ = etch.dom
 


### PR DESCRIPTION
Fixes #8648

This PR fixes two regressions related to mouse handling introduced in the latest editor rewrite (#13880) and the upgrade to Electron 1.6.x (#12696).

* On Linux, the middle mouse button pasting text twice (#8648). This regressed because Chrome now seems to synthesize textInput events on mouseup when clicking with the middle button. We had custom logic to emulate this behavior that was rendered redundant by this change.

* On Mac, ctrl-clicking is interpreted by the OS as a right click that brings up the context menu. We weren't bailing out in this case, which caused the cursor to move after the context menu had closed.

We should hot-fix this to 1.19-releases once it is merged.

/cc @ungb 