### PR TITLE
Fix dock button rendering issue

### DIFF
--- a/static/docks.less
+++ b/static/docks.less
@@ -115,6 +115,9 @@ atom-dock {
     align-items: center;
     cursor: pointer;
 
+    // Promote to own layer, fixes rendering issue atom/atom#14915
+    will-change: transform;
+
     &.right { left: 0; }
     &.bottom { top: 0; }
     &.left { right: 0; }


### PR DESCRIPTION
### Description of the Change

This promotes the `.atom-dock-toggle-button-inner` to a GPU layer.

### Alternate Designs

- There would be other ways like `transform: translateZ(0)` or `backface-visibility: hidden`, but `will-change` is more official.
- We could also promote the parent element `.atom-dock-toggle-button`, but since the "inner" element is the one that actually gets transformed, it seems more appropriate.

### Why Should This Be In Core?

It's where the dock styles live.

### Benefits

Fixes this rendering issue: #14915

### Possible Drawbacks

Forcing layers could have some side effects elsewhere. 

### Applicable Issues

Fixes #14915
