### PR TITLE
Pin npm to 5.1 so we can build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ matrix:
 install:
   - SET PATH=C:\Program Files\Atom\resources\cli;%PATH%
   - ps: Install-Product node $env:NODE_VERSION $env:PLATFORM
-  - npm install -g npm
+  - npm install -g npm@5.1
 
 build_script:
   - IF NOT EXIST C:\sqtemp MKDIR C:\sqtemp


### PR DESCRIPTION
5.2 causes errors with eslinter-plugin-react
