### PR TITLE
Update languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "wrap-guide": "0.40.2",
     "language-c": "0.58.1",
     "language-clojure": "0.22.4",
-    "language-coffee-script": "0.48.7",
+    "language-coffee-script": "0.48.8",
     "language-csharp": "0.14.2",
     "language-css": "0.42.3",
     "language-gfm": "0.89.1",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "language-text": "0.7.3",
     "language-todo": "0.29.1",
     "language-toml": "0.18.1",
-    "language-xml": "0.35.1",
+    "language-xml": "0.35.2",
     "language-yaml": "0.30.1"
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "language-mustache": "0.14.1",
     "language-objective-c": "0.15.1",
     "language-perl": "0.37.0",
-    "language-php": "0.39.0",
+    "language-php": "0.40.0",
     "language-property-list": "0.9.1",
     "language-python": "0.45.3",
     "language-ruby": "0.71.1",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "language-ruby": "0.71.2",
     "language-ruby-on-rails": "0.25.2",
     "language-sass": "0.60.0",
-    "language-shellscript": "0.25.1",
+    "language-shellscript": "0.25.2",
     "language-source": "0.9.0",
     "language-sql": "0.25.7",
     "language-text": "0.7.3",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "language-php": "0.40.0",
     "language-property-list": "0.9.1",
     "language-python": "0.45.3",
-    "language-ruby": "0.71.1",
+    "language-ruby": "0.71.2",
     "language-ruby-on-rails": "0.25.2",
     "language-sass": "0.60.0",
     "language-shellscript": "0.25.1",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "language-html": "0.47.3",
     "language-hyperlink": "0.16.2",
     "language-java": "0.27.2",
-    "language-javascript": "0.127.0",
+    "language-javascript": "0.127.1",
     "language-json": "0.19.1",
     "language-less": "0.33.0",
     "language-make": "0.22.3",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "whitespace": "0.37.2",
     "wrap-guide": "0.40.2",
     "language-c": "0.58.1",
-    "language-clojure": "0.22.3",
+    "language-clojure": "0.22.4",
     "language-coffee-script": "0.48.7",
     "language-csharp": "0.14.2",
     "language-css": "0.42.3",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "language-perl": "0.37.0",
     "language-php": "0.40.0",
     "language-property-list": "0.9.1",
-    "language-python": "0.45.3",
+    "language-python": "0.45.4",
     "language-ruby": "0.71.2",
     "language-ruby-on-rails": "0.25.2",
     "language-sass": "0.60.0",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "language-git": "0.19.1",
     "language-go": "0.44.1",
     "language-html": "0.47.3",
-    "language-hyperlink": "0.16.1",
+    "language-hyperlink": "0.16.2",
     "language-java": "0.27.2",
     "language-javascript": "0.127.0",
     "language-json": "0.19.1",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "language-todo": "0.29.1",
     "language-toml": "0.18.1",
     "language-xml": "0.35.1",
-    "language-yaml": "0.30.0"
+    "language-yaml": "0.30.1"
   },
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "language-html": "0.47.3",
     "language-hyperlink": "0.16.1",
     "language-java": "0.27.2",
-    "language-javascript": "0.126.1",
+    "language-javascript": "0.127.0",
     "language-json": "0.19.1",
     "language-less": "0.32.0",
     "language-make": "0.22.3",

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "language-sass": "0.60.0",
     "language-shellscript": "0.25.1",
     "language-source": "0.9.0",
-    "language-sql": "0.25.6",
+    "language-sql": "0.25.7",
     "language-text": "0.7.3",
     "language-todo": "0.29.1",
     "language-toml": "0.18.1",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "language-clojure": "0.22.3",
     "language-coffee-script": "0.48.7",
     "language-csharp": "0.14.2",
-    "language-css": "0.42.2",
+    "language-css": "0.42.3",
     "language-gfm": "0.89.1",
     "language-git": "0.19.1",
     "language-go": "0.44.1",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "language-coffee-script": "0.48.8",
     "language-csharp": "0.14.2",
     "language-css": "0.42.3",
-    "language-gfm": "0.89.1",
+    "language-gfm": "0.90.0",
     "language-git": "0.19.1",
     "language-go": "0.44.1",
     "language-html": "0.47.3",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "language-java": "0.27.2",
     "language-javascript": "0.127.0",
     "language-json": "0.19.1",
-    "language-less": "0.32.0",
+    "language-less": "0.33.0",
     "language-make": "0.22.3",
     "language-mustache": "0.14.1",
     "language-objective-c": "0.15.1",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "language-python": "0.45.3",
     "language-ruby": "0.71.1",
     "language-ruby-on-rails": "0.25.2",
-    "language-sass": "0.59.0",
+    "language-sass": "0.60.0",
     "language-shellscript": "0.25.1",
     "language-source": "0.9.0",
     "language-sql": "0.25.6",

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -1582,6 +1582,7 @@ i = /test/; #FIXME\
       expect(atom2.grammars.getGrammars().map(grammar => grammar.name).sort()).toEqual([
         'CoffeeScript',
         'CoffeeScript (Literate)',
+        'JSDoc',
         'JavaScript',
         'Null Grammar',
         'Regular Expression Replacement (JavaScript)',


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* language-javascript
  * JSDoc overhaul
  * Add a return snippet
  * Recognize `stringify` as `support.function.js`
  * Resolve incompatibilities with Linguist
* language-css
  * Add `fr` unit
  * Add semicolon to `import` snippet
* language-sass
  * Inherit number matching from language-css
  * Adjust variable and map scopes
  * Tokenize placeholders in at-rules
* language-less
  * Inherit number matching from language-css
  * Add punctuation scopes to variables
  * Stop matching URLs at first closing parenthesis
  * Resolve incompatibilities with Linguist
* language-clojure
  * Don't tokenize trailing whitespace as invalid
  * Don't tokenize escaped semicolons as comments
  * Add support for `.joke` and `.joker` files
* language-coffee-script
  * Resolve incompatibilities with Linguist
  * Add support for escaped JavaScript
* language-yaml
  * Resolve incompatibilities with Linguist
* language-xml
  * Allow space after attribute name
* language-php
  * Clean up grammar file
  * Tokenize `$this` as `variable.language.this.php`
  * Scope cleanup
  * Add `AND` as a valid SQL keyword
  * Tokenize parentheses
  * Fix inline include not stopping at the closing PHP tag
  * Tokenize multiple exceptions in a catch clause
  * Tokenize typehinted function arguments with default values
  * Tokenize function return values
  * Support `use` in traits
  * Tokenize the special `class` keyword when used in scope resolution
  * Remove erroneous function pass-by-reference regex
  * Support namespaced typehints
  * Add basic support for commas
  * Add structure to switch statements
  * Tokenize PHPDoc param types
* language-sql
  * Clean up comment regexes
  * Tokenize bare `float` type
* language-ruby
  * Tokenize embedded XML in heredocs
  * Fix end-of-heredoc tokenization
* language-hyperlink
  * Fix `mailto` scope
  * Do not inject inside regexp strings, even in text grammars
* language-gfm
  * Tokenize codeblocks containing unrecognized languages
* language-shellscript
  * Resolve incompatibilities with Linguist
* language-python
  * Update auto-indent regexes

### Possible Drawbacks

language-php regressions as I changed probably more than half the regexes.
JSDoc overhaul in language-javascript.
The fact that this language update is absolutely massive because I think I missed the last update I wanted to do and then went on vacation before getting this one out.