### PR TITLE
Support onlyHead, onlyEmpty, and omitEmptyLastRow for gutter decorations

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1112,8 +1112,26 @@ class TextEditorComponent {
       decorations = []
       this.decorationsToRender.customGutter.set(decoration.gutterName, decorations)
     }
-    const top = this.pixelPositionAfterBlocksForRow(screenRange.start.row)
-    const height = this.pixelPositionBeforeBlocksForRow(screenRange.end.row + 1) - top
+
+    let omitLastRow = false
+    if (screenRange.isEmpty()) {
+      if (decoration.onlyNonEmpty) return
+    } else {
+      if (decoration.onlyEmpty) return
+      if (decoration.omitEmptyLastRow !== false) {
+        omitLastRow = screenRange.end.column === 0
+      }
+    }
+
+    let rangeStartRow = screenRange.start.row
+    let rangeEndRow = screenRange.end.row
+
+    if (decoration.onlyHead) {
+      rangeStartRow = rangeEndRow
+    }
+
+    const top = this.pixelPositionAfterBlocksForRow(rangeStartRow)
+    const height = this.pixelPositionBeforeBlocksForRow(rangeEndRow + (omitLastRow ? 0 : 1)) - top
 
     decorations.push({
       className: 'decoration' + (decoration.class ? ' ' + decoration.class : ''),


### PR DESCRIPTION
### Description of the Change

Adds support for `onlyHead`, `onlyEmpty` and `omitEmptyLastRow` to custom gutter decorations. 

### Alternate Designs
None

### Why Should This Be In Core?
This is changing core TextEditorComponent behavior.

### Benefits
Currently scary hacks [like this](https://github.com/steelbrain/linter-ui-default/blob/3b87b59b1d506f195b9703d1a9d0b23ed412e128/lib/editor/index.js#L94) are needed if a package has a custom gutter and wants to have the cursor-line selection highlight extend over the custom gutter.

This allows a package to opt-in to a cursor-line on their gutter with (example taken from linter-ui-plus package):

```js
    this.textEditor.decorateMarkerLayer(this.textEditor.selectionsMarkerLayer, {
      gutterName: 'linter-ui-plus',
      type: 'gutter',
      class: 'line-number cursor-line-no-selection',
      onlyEmpty: true,
      onlyHead: true
    })

    this.textEditor.decorateMarkerLayer(this.textEditor.selectionsMarkerLayer, {
      gutterName: 'linter-ui-plus',
      type: 'gutter',
      class: 'line-number cursor-line'
    })
```

### Possible Drawbacks
None but I don't understand that much of the text editor code. @nathansobo ?

### Applicable Issues
None that I found
