### PR TITLE
⬆️ Upgrade image-view to 0.62.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "git-diff": "1.3.6",
     "go-to-line": "0.32.1",
     "grammar-selector": "0.49.5",
-    "image-view": "0.62.0",
+    "image-view": "0.62.1",
     "incompatible-packages": "0.27.3",
     "keybinding-resolver": "0.38.0",
     "line-ending-selector": "0.7.3",


### PR DESCRIPTION
This PR upgrades image-view to incorporate the changes in https://github.com/atom/image-view/pull/136, which fix the issue described in https://github.com/atom/image-view/issues/132. With this change, we restore the ability to see dimensions and file size for images shown in a pending pane item (e.g., pending pane items opened when browsing images via the tree view).