### PR TITLE
Use npm 5.3.0 for building Atom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - source /tmp/.nvm/nvm.sh
   - nvm install $NODE_VERSION
   - nvm use --delete-prefix $NODE_VERSION
-  - npm install -g npm@5.1.0
+  - npm install -g npm@5.3.0
   - script/build --create-debian-package --create-rpm-package --compress-artifacts
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ matrix:
 install:
   - SET PATH=C:\Program Files\Atom\resources\cli;%PATH%
   - ps: Install-Product node $env:NODE_VERSION $env:PLATFORM
-  - npm install -g npm@5.1.0
+  - npm install -g npm@5.3.0
 
 build_script:
   - IF NOT EXIST C:\sqtemp MKDIR C:\sqtemp

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
     - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash
     - nvm install 6.9.4
     - nvm use 6.9.4
-    - npm install -g npm@5.1.0
+    - npm install -g npm@5.3.0
 
   override:
     - script/build --code-sign --compress-artifacts

--- a/script/package.json
+++ b/script/package.json
@@ -22,7 +22,7 @@
     "minidump": "0.9.0",
     "mkdirp": "0.5.1",
     "normalize-package-data": "2.3.5",
-    "npm": "5.1.0",
+    "npm": "5.3.0",
     "passwd-user": "2.1.0",
     "pegjs": "0.9.0",
     "runas": "3.1.1",


### PR DESCRIPTION
Fixes #15037.

---

To overcome issues with npm 5.2, https://github.com/atom/atom/pull/15004 and https://github.com/atom/atom/pull/15014 configured the build process to use npm 5.1. That change resolved the issues we were seeing with the AppVeyor build [A], but it unintentionally introduced a problem for anyone attempting to build Atom with Node 8.

While the [CI builds use Node 6.9.4](https://github.com/atom/atom/blob/3d02234cbdf701a851d9b1239d67dcdbc8808146/circle.yml#L19-L20), we aim to support [Node 6 or newer](https://github.com/atom/atom/blob/d61967bff479acbdc6216dc9618879ebe8d23910/docs/build-instructions/macOS.md#requirements). However, pinning npm to 5.1 causes problems when trying to build with Node 8 [B].

To resolve the original problems that we were addressing in https://github.com/atom/atom/pull/15004 and https://github.com/atom/atom/pull/15014, _and_ to restore support for building Atom with Node 8, this PR updates the build to use npm 5.3. The CI builds still use Node 6.9.4, but you should be able to build locally with Node 6 or newer once this PR is merged.

---

[A] Example AppVeyor build failure prior to pinning npm version: https://ci.appveyor.com/project/Atom/atom/build/7267/job/3narmqtij0sgb28f

[B] Example Circle CI build failure using npm 5.1 and Node 8.1.4: https://circleci.com/gh/atom/atom/4364

