### PR TITLE
Normalize access keys (shortcuts) on buttons in dialogs

### DIFF
--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -143,6 +143,7 @@ class ApplicationDelegate
       message: message
       detail: detailedMessage
       buttons: buttonLabels
+      normalizeAccessKeys: true
     })
 
     if _.isArray(buttons)


### PR DESCRIPTION
Merged the access keys in https://github.com/atom/atom/commit/7c681905bd81948a09b54fc6013a917852148f12 but forgot that accelerators in buttons were opt-in via the `normalizeAccessKeys` option in the intervening time.