### PR TITLE
Kill all the child processes first on killing a buffered process

### DIFF
--- a/src/buffered-process.js
+++ b/src/buffered-process.js
@@ -205,6 +205,33 @@ export default class BufferedProcess {
     })
   }
 
+  // Kill all child processes of the spawned process on Nix platforms.
+  //
+  killOnNix () {
+    if (!this.process) return
+
+    const parentPid = this.process.pid
+    const cmd = 'pkill'
+    const args = [
+      '-P',
+      `${parentPid}`
+    ]
+
+    let pkillProcess
+
+    try {
+      pkillProcess = ChildProcess.spawn(cmd, args)
+    } catch (spawnError) {
+      this.killProcess()
+      return
+    }
+
+    pkillProcess.on('error', () => { })
+    pkillProcess.stdout.on('close', () => {
+      this.killProcess()
+    })
+  }
+
   killProcess () {
     if (this.process) this.process.kill()
     this.process = null
@@ -238,7 +265,7 @@ export default class BufferedProcess {
     if (process.platform === 'win32') {
       this.killOnWindows()
     } else {
-      this.killProcess()
+      this.killOnNix()
     }
   }
 


### PR DESCRIPTION
### Description of the Change

On killing a buffered process, this patch ensures that all of its child processes are killed first.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

It might be possible to do the same thing at the client side of BufferedProcess, but BufferedProcess is already doing it on Windows platform as you can see in BufferedProcess.killOnWindows(). That's the reason why I added killOnNix() to BufferedProcess.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

BufferedProcess is already doing the same thing on Windows platform, therefore it'll be better to have the same functionality on *nix platforms
<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

### Benefits

We don't have to use Terminal or Task Manager to check if a grand-child process is still running or not.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Whenever Atom calls BufferedProcess.kill(), it'll spawn 'pkill' to kill all possible child processes.  But, anyway, Atom already do the same thing by running 'wmic' on Windows :)
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

It fixes #7252 : Problem with killing children processes 

<!-- Enter any applicable Issues here -->
