### PR TITLE
Fix exceptions when measuring pixel positions with pending content updates

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -3335,6 +3335,15 @@ describe('TextEditorComponent', () => {
         expect(left).toBe(clientLeftForCharacter(referenceComponent, 12, 1) - referenceContentRect.left)
       }
     })
+
+    it('does not get the component into an inconsistent state when the model has unflushed changes (regression)', async () => {
+      const {component, element, editor} = buildComponent({rowsPerTile: 2, autoHeight: false, text: ''})
+      await setEditorHeightInLines(component, 10)
+
+      const updatePromise = editor.getBuffer().append("hi\n")
+      component.screenPositionForPixelPosition({top: 800, left: 1})
+      await updatePromise
+    })
   })
 
   describe('screenPositionForPixelPosition', () => {

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -251,20 +251,17 @@ class TextEditorComponent {
 
     this.measureBlockDecorations()
 
-    this.measuredContent = false
     this.updateSyncBeforeMeasuringContent()
     if (useScheduler === true) {
       const scheduler = etch.getScheduler()
       scheduler.readDocument(() => {
         this.measureContentDuringUpdateSync()
-        this.measuredContent = true
         scheduler.updateDocument(() => {
           this.updateSyncAfterMeasuringContent()
         })
       })
     } else {
       this.measureContentDuringUpdateSync()
-      this.measuredContent = true
       this.updateSyncAfterMeasuringContent()
     }
   }
@@ -341,6 +338,7 @@ class TextEditorComponent {
   }
 
   updateSyncBeforeMeasuringContent () {
+    this.measuredContent = false
     this.derivedDimensionsCache = {}
     this.updateModelSoftWrapColumn()
     if (this.pendingAutoscroll) {
@@ -384,6 +382,8 @@ class TextEditorComponent {
       }
       this.pendingAutoscroll = null
     }
+
+    this.measuredContent = true
   }
 
   updateSyncAfterMeasuringContent () {


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15042
Fixes https://github.com/atom/atom/issues/15002
Fixes https://github.com/atom/atom/issues/15031
Fixes https://github.com/atom/atom/issues/14834
Fixes https://github.com/atom/atom/issues/14794
Fixes https://github.com/atom/atom/issues/14980

/cc @iolsen @ungb This needs to go out in a 1.19 hotfix asap.

🍐 'd with @nathansobo 