### PR TITLE
Try an apm that depends on node-gyp explicitly

### DIFF
--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "1.18.2"
+    "atom-package-manager": "1.18.3-0"
   }
 }

--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "1.18.3-0"
+    "atom-package-manager": "1.18.3"
   }
 }


### PR DESCRIPTION
For some reason, `npm` isn't flattening all of `apm`'s indirect dependencies in its `node_modules` folder, violating an assumption we're making about the path of `node-gyp`, which is a dependency of the bundled `npm`. To work around this, we're adding an explicit dependency on `node-gyp` so we always know where it will be located.