### PR TITLE
Add apm version info to build

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,6 +2,7 @@
 
 'use strict'
 
+const childProcess = require('child_process')
 const CONFIG = require('./config')
 const cleanDependencies = require('./lib/clean-dependencies')
 const deleteMsbuildFromPath = require('./lib/delete-msbuild-from-path')
@@ -26,6 +27,11 @@ if (process.platform === 'win32') deleteMsbuildFromPath()
 
 installScriptDependencies()
 installApm()
+childProcess.execFileSync(
+  CONFIG.getApmBinPath(),
+  ['--version'],
+  {stdio: 'inherit'}
+)
 runApmInstall(CONFIG.repositoryRootPath)
 
 dependenciesFingerprint.write()


### PR DESCRIPTION
e.g.

```
Installing script dependencies         
Installing apm                         
apm  1.18.2                            
npm  3.10.10                           
node 6.9.5 x64                         
python 2.7.12                          
git 2.10.2.windows.1                   
visual studio 2015                     
Installing modules done                
Installing one-dark-syntax@1.7.1 done  
```