### PR TITLE
Replace font stack with Chromium 56's "system-ui" generic font family

### DIFF
--- a/static/variables/ui-variables.less
+++ b/static/variables/ui-variables.less
@@ -81,5 +81,5 @@
 
 // Other
 
-@font-family: 'BlinkMacSystemFont', 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;
+@font-family: system-ui;
 @use-custom-controls: true; // false uses native controls


### PR DESCRIPTION
### Description of the Change

Atom currently [does not use the system font](https://github.com/atom/atom/issues/8656), but instead hardcodes a bunch of fonts in a "font stack" (priority list), hoping that the actual system font is present in that list and in the right position.

This doesn't always work and gives particularly poor results on Linux, where changing the system font is easy and Atom stands out as the one application that doesn't respect the change. The reason this long-standing issue is still open is that until recently this wasn't possible to fix from CSS (except on macOS with the `BlinkMacSystemFont` placeholder family) and would have required platform-specific code that resolves the correct family.

Enter Chromium 56, shipping with Atom 1.19! It introduces the [`system-ui` generic font family](https://www.chromestatus.com/feature/5640395337760768) that "allows authors to style contents so it fits within the system UI". It works on all platforms! 🎉 🎆 🍾 

Closes #8656. The same change should probably be made also in Atom's default UI themes.

### Alternate Designs

The alternatives are keeping the font stack, or resolving the system font family programmatically. Both are clearly worse.

### Why Should This Be In Core?

Because the font family is defined in core.

### Benefits

Atom looks a tiny bit more like a native application.

### Possible Drawbacks

Can't think of any.

### Applicable Issues

#8656
