### PR TITLE
Should not use bind for map's callback in pane.coffee.

### DIFF
--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -637,7 +637,7 @@ class Pane
   # Public: Destroy all items.
   destroyItems: ->
     Promise.all(
-      @getItems().map(@destroyItem.bind(this))
+      @getItems().map((item) => @destroyItem(item))
     )
 
   # Public: Destroy all items except for the active item.
@@ -645,7 +645,7 @@ class Pane
     Promise.all(
       @getItems()
         .filter((item) => item isnt @activeItem)
-        .map(@destroyItem.bind(this))
+        .map((item) => @destroyItem(item))
     )
 
   promptToSaveItem: (item, options={}) ->
@@ -950,7 +950,7 @@ class Pane
   # Returns a {Promise} that resolves once the pane is either closed, or the
   # closing has been cancelled.
   close: ->
-    Promise.all(@getItems().map(@promptToSaveItem.bind(this))).then (results) =>
+    Promise.all(@getItems().map((item) => @promptToSaveItem(item))).then (results) =>
       @destroy() unless results.includes(false)
 
   handleSaveError: (error, item) ->


### PR DESCRIPTION
`Array.prototype.map` call callback with `callback(item, index, this)`.
So using `bind` is not appropriate for the function which take 2nd arg.

cc @maxbrunsfeld 

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I found this via code-reading. Not sure there is already reported issue.
Calling `pane.destroyItems()` don't `@promptToSaveItem` for items with index greater than 0.
Since map pass index, index goes to `force` arg of `destroyItems`. `force` become true unless index `0`.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

No

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

Bug
<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

### Benefits

Bug free.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

No.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
