### PR TITLE
Define indent/outdent behavior for single-line selected text

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -3766,13 +3766,27 @@ describe "TextEditor", ->
                 expect(buffer.lineForRow(7)).toMatch /^\t\t\t\t$/
                 expect(editor.getCursorBufferPosition()).toEqual [7, 4]
 
-      describe "when the selection is not empty", ->
+      describe "when selection spans across multiple lines", ->
         it "indents the selected lines", ->
           editor.setSelectedBufferRange([[0, 0], [10, 0]])
           selection = editor.getLastSelection()
           spyOn(selection, "indentSelectedRows")
           editor.indent()
           expect(selection.indentSelectedRows).toHaveBeenCalled()
+
+      describe "when a single line has been selected from start to end", ->
+        it "indents the selected line", ->
+          editor.setSelectedBufferRange([[0, 0], [0, 29]])
+          selection = editor.getLastSelection()
+          spyOn(selection, "indentSelectedRows")
+          editor.indent()
+          expect(selection.indentSelectedRows).toHaveBeenCalled()
+
+      describe "when selection is made within a single line", ->
+        it "inserts a tab in place of the selection", ->
+          editor.setSelectedBufferRange([[0, 4], [0, 13]])
+          editor.indent()
+          expect(buffer.lineForRow(0)).toEqual "var #{editor.getTabText()} = function () {"
 
       describe "if editor.softTabs is false", ->
         it "inserts a tab character into the buffer", ->
@@ -4262,12 +4276,19 @@ describe "TextEditor", ->
           editor.outdentSelectedRows()
           expect(buffer.lineForRow(0)).toBe "foo\t var quicksort = function () {"
 
-      describe "when one line is selected", ->
+      describe "when part of one line is selected", ->
         it "outdents line and retains editor", ->
           editor.setSelectedBufferRange([[1, 4], [1, 14]])
           editor.outdentSelectedRows()
           expect(buffer.lineForRow(1)).toBe "var sort = function(items) {"
           expect(editor.getSelectedBufferRange()).toEqual [[1, 4 - editor.getTabLength()], [1, 14 - editor.getTabLength()]]
+
+      describe "when one line is selected from start to end", ->
+        it "outdents line and retains editor", ->
+          editor.setSelectedBufferRange([[1, 0], [1, 30]])
+          editor.outdentSelectedRows()
+          expect(buffer.lineForRow(1)).toBe "var sort = function(items) {"
+          expect(editor.getSelectedBufferRange()).toEqual [[1, 0], [1, 30 - editor.getTabLength()]]
 
       describe "when multiple lines are selected", ->
         it "outdents selected lines and retains editor", ->

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -660,7 +660,7 @@ class Selection extends Model
   indent: ({autoIndent}={}) ->
     bufferRange = @getBufferRange()
 
-    if @isEmpty()
+    if bufferRange.isEmpty()
       {row} = @cursor.getBufferPosition()
       @cursor.skipLeadingWhitespace()
       desiredIndent = @editor.suggestedIndentForBufferRow(row)
@@ -671,7 +671,7 @@ class Selection extends Model
         @insertText(@editor.buildIndentString(delta))
       else
         @insertText(@editor.buildIndentString(1, @cursor.getBufferColumn()))
-    else if bufferRange.isSingleLine() and not bufferRange.containsRange(@editor.bufferRangeForBufferRow(bufferRange.start.row))
+    else if bufferRange.isSingleLine() and not bufferRange.isEqual(@editor.bufferRangeForBufferRow(bufferRange.start.row))
       @insertText(@editor.getTabText())
     else
       @indentSelectedRows()

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -656,10 +656,9 @@ class Selection extends Model
   #   * `autoIndent` If `true`, the line is indented to an automatically-inferred
   #     level. Otherwise, {TextEditor::getTabText} is inserted.
   indent: ({autoIndent}={}) ->
-    [start, end] = @getBufferRowRange()
+    {row} = @cursor.getBufferPosition()
 
-    if @isEmpty() or start is end
-      {row} = @cursor.getBufferPosition()
+    if @isEmpty()
       @cursor.skipLeadingWhitespace()
       desiredIndent = @editor.suggestedIndentForBufferRow(row)
       delta = desiredIndent - @cursor.getIndentLevel()

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -656,9 +656,10 @@ class Selection extends Model
   #   * `autoIndent` If `true`, the line is indented to an automatically-inferred
   #     level. Otherwise, {TextEditor::getTabText} is inserted.
   indent: ({autoIndent}={}) ->
-    {row} = @cursor.getBufferPosition()
+    [start, end] = @getBufferRowRange()
 
-    if @isEmpty()
+    if @isEmpty() or start is end
+      {row} = @cursor.getBufferPosition()
       @cursor.skipLeadingWhitespace()
       desiredIndent = @editor.suggestedIndentForBufferRow(row)
       delta = desiredIndent - @cursor.getIndentLevel()


### PR DESCRIPTION
Coming from atom/snippets#239, I have now realized that there isn't a properly defined behavior for selecting text on single line and indenting/outdenting it:

![indent_undefined_behavior](https://user-images.githubusercontent.com/1017132/28606639-b0d2367e-71e0-11e7-90cb-35bc9ce09c3c.gif)

Here is why I don't think this has been defined yet:
1. There is no spec for single-line selected text being indented via `indent()`: https://github.com/atom/atom/blob/a7736b81e3f6628f2a9e685f28f4c1df9a5e4615/spec/text-editor-spec.coffee#L3673-L3789

2. `indentSelectedRows` (which is used in `indent()`) is poorly documented:
https://github.com/atom/atom/blob/a7736b81e3f6628f2a9e685f28f4c1df9a5e4615/src/selection.coffee#L671-L679
    > If the selection spans multiple rows, indent all of them.

    It's possible to interpret this in a way that if the selection does not span across multiple rows, then nothing gets indented. [_Insert your favorite programmer-goes-to-grocery-store-joke here._](https://www.reddit.com/r/Jokes/comments/1nmkfq/a_programmer_is_going_to_the_grocery_store/)

3. The current behavior is not intuitive and unexpected for anyone coming from a different editor. With the exception of Brackets, other text editors tend to agree that selecting text and pressing tab within a single line should not indent the whole line, but insert/overwrite with a tab.

Outdent is done through `outdentSelectedRows`, which [has a spec for single line selected text](https://github.com/atom/atom/blob/2420d12e44f33f0178c8c0ef41e3a2c22cf4fb8e/spec/text-editor-spec.coffee#L4265-L4270). However it seems to be slightly mislabeled, there is actually less than one line selected. That is not a big deal and can be easily fixed, but it's possible that something is missing from here too.

At minimum I am looking to define behavior for following cases:
1. Selecting whole line and issuing `indent()`.
2. Selecting substring within line with length greater than 0 and issuing `indent()`.
3. Selecting whole line and issuing `outdentSelectedRows()`.
4. Selecting substring within line with length greater than 0 and issuing `outdentSelectedRows()`.

There might be additional cases that might need be considered, but I don't want this to be come overly ambitious, so starting with a more managable goal might be better.

The motivation for all of this comes from behavior related to text selections that come from traversing tab stops within snippets, where indenting/outdenting may lead to unexpected results:

![indent_snippet1](https://user-images.githubusercontent.com/1017132/28608860-e7ee5908-71ea-11e7-8bc2-19aadfcc2a3b.gif)
![indent_snippet2](https://user-images.githubusercontent.com/1017132/28608859-e7edd960-71ea-11e7-90d3-7b1bfb94e899.gif)

Personally I think that outdent behavior can be kept as-is and it is sufficient to simply improve the spec and cover cases 3 and 4. Outdenting does not break out of snippet's tab stops whereas indenting does, so indicating change with a slightly more destructive (but predictable) operation should be obvious enough that it's impossible to return to snippet's tab stops.

Visual Studio Code's behavior is a suitable candidate, which indents if the whole line is selected, but inserts a tab when only part of line is selected. Outdent is handled in the same way as Atom does it now. If there aren't any objections or better ideas, I might just implement that and propose this as the final solution.

Code at the time of writing in pull request is just to get the ball rolling and does not represent the final proposed solution in any way. But it does replace everything with a tab if at most only one line has been selected.