### PR TITLE
Remove duplicate mocking

### DIFF
--- a/spec/pane-spec.js
+++ b/spec/pane-spec.js
@@ -1350,6 +1350,7 @@ describe('Pane', () => {
     let editor1, pane, eventCount
 
     beforeEach(async () => {
+      jasmine.useMockClock()
       editor1 = await atom.workspace.open('sample.txt', {pending: true})
       pane = atom.workspace.getActivePane()
       eventCount = 0

--- a/spec/pane-spec.js
+++ b/spec/pane-spec.js
@@ -1350,7 +1350,6 @@ describe('Pane', () => {
     let editor1, pane, eventCount
 
     beforeEach(async () => {
-      jasmine.useMockClock()
       editor1 = await atom.workspace.open('sample.txt', {pending: true})
       pane = atom.workspace.getActivePane()
       eventCount = 0

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -64,7 +64,6 @@ beforeEach ->
   atom.project.setPaths([specProjectPath])
 
   window.resetTimeouts()
-  spyOn(Date, 'now').andCallFake -> window.now
   spyOn(_._, "now").andCallFake -> window.now
   spyOn(window, "setTimeout").andCallFake window.fakeSetTimeout
   spyOn(window, "clearTimeout").andCallFake window.fakeClearTimeout
@@ -180,7 +179,6 @@ jasmine.useRealClock = ->
   jasmine.unspy(window, 'setTimeout')
   jasmine.unspy(window, 'clearTimeout')
   jasmine.unspy(_._, 'now')
-  jasmine.unspy(Date, 'now')
 
 # The clock is halfway mocked now in a sad and terrible way... only setTimeout
 # and clearTimeout are included. This method will also include setInterval. We

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -65,6 +65,7 @@ beforeEach ->
 
   window.resetTimeouts()
   spyOn(_._, "now").andCallFake -> window.now
+  spyOn(Date, 'now').andCallFake(-> window.now)
   spyOn(window, "setTimeout").andCallFake window.fakeSetTimeout
   spyOn(window, "clearTimeout").andCallFake window.fakeClearTimeout
 
@@ -179,6 +180,7 @@ jasmine.useRealClock = ->
   jasmine.unspy(window, 'setTimeout')
   jasmine.unspy(window, 'clearTimeout')
   jasmine.unspy(_._, 'now')
+  jasmine.unspy(Date, 'now')
 
 # The clock is halfway mocked now in a sad and terrible way... only setTimeout
 # and clearTimeout are included. This method will also include setInterval. We
@@ -186,8 +188,6 @@ jasmine.useRealClock = ->
 jasmine.useMockClock = ->
   spyOn(window, 'setInterval').andCallFake(fakeSetInterval)
   spyOn(window, 'clearInterval').andCallFake(fakeClearInterval)
-  spyOn(Date, 'now').andCallFake(-> window.now)
-
 
 addCustomMatchers = (spec) ->
   spec.addMatchers


### PR DESCRIPTION
Prior to this PR, we were mocking `Date.now` once in the spec helper, then blowing up with a redundant mock error when `jasmine.useMockClock` is called.

Since this was newly introduced, let's only set it up when clock mocking is specifically requested to minimize breakage. We really need to deprecate the global spec helper someday. It's bad news.

This needs to be hot-fixed to 1.19.

/cc @hansonw