### PR TITLE
Use spec reporters in CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ platform:
 environment:
   global:
     ATOM_DEV_RESOURCE_PATH: c:\projects\atom
-    TEST_JUNIT_XML_PATH: c:\projects\atom\junit-results.xml
+    TEST_JUNIT_XML_ROOT: c:\projects\junit-test-results
 
   matrix:
   - NODE_VERSION: 6.9.4
@@ -27,6 +27,7 @@ matrix:
   fast_finish: true
 
 install:
+  - IF NOT EXIST %TEST_JUNIT_XML_ROOT% MKDIR %TEST_JUNIT_XML_ROOT%
   - SET PATH=C:\Program Files\Atom\resources\cli;%PATH%
   - ps: Install-Product node $env:NODE_VERSION $env:PLATFORM
   - npm install -g npm@5.3.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,8 @@ after_test:
   - ps: |
       $wc = New-Object 'System.Net.WebClient'
       $endpoint = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
-      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT\* -Recurse -File -Name -Include *.xml | ForEach-Object {
+      Write-Output "Searching for JUnit XML output beneath $($env:TEST_JUNIT_XML_ROOT)"
+      Get-ChildItem -Path "$($env:TEST_JUNIT_XML_ROOT)\*" -Recurse -File -Name -Include "*.xml" | ForEach-Object {
         Write-Output "Uploading JUnit XML $($_)"
         $wc.UploadFile($endpoint, $_)
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ test_script:
 after_test:
   - ps: |
       $wc = New-Object 'System.Net.WebClient'
-      $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", $env:TEST_JUNIT_XML_PATH)
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $env:TEST_JUNIT_XML_PATH)
   - IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] (
       IF NOT EXIST C:\sqtemp MKDIR C:\sqtemp
       SET SQUIRREL_TEMP=C:\sqtemp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,8 +45,8 @@ after_test:
       $wc = New-Object 'System.Net.WebClient'
       $endpoint = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
       Write-Output "Searching for JUnit XML output beneath $($env:TEST_JUNIT_XML_ROOT)"
-      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT) -Recurse -File -Name
-      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT) -Recurse -File -Name -Include "*.xml" | ForEach-Object {
+      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT -Recurse -File -Name
+      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT -Recurse -File -Name -Include "*.xml" | ForEach-Object {
         Write-Output "Uploading JUnit XML $($_)"
         $wc.UploadFile($endpoint, $_)
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,7 @@ after_test:
       $wc = New-Object 'System.Net.WebClient'
       $endpoint = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
       Write-Output "Searching for JUnit XML output beneath $($env:TEST_JUNIT_XML_ROOT)"
+      Get-ChildItem -Path "$($env:TEST_JUNIT_XML_ROOT)\*" -Recurse -File -Name
       Get-ChildItem -Path "$($env:TEST_JUNIT_XML_ROOT)\*" -Recurse -File -Name -Include "*.xml" | ForEach-Object {
         Write-Output "Uploading JUnit XML $($_)"
         $wc.UploadFile($endpoint, $_)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,8 +45,8 @@ after_test:
       $wc = New-Object 'System.Net.WebClient'
       $endpoint = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
       Write-Output "Searching for JUnit XML output beneath $($env:TEST_JUNIT_XML_ROOT)"
-      Get-ChildItem -Path "$($env:TEST_JUNIT_XML_ROOT)\*" -Recurse -File -Name
-      Get-ChildItem -Path "$($env:TEST_JUNIT_XML_ROOT)\*" -Recurse -File -Name -Include "*.xml" | ForEach-Object {
+      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT) -Recurse -File -Name
+      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT) -Recurse -File -Name -Include "*.xml" | ForEach-Object {
         Write-Output "Uploading JUnit XML $($_)"
         $wc.UploadFile($endpoint, $_)
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,11 @@ test_script:
 after_test:
   - ps: |
       $wc = New-Object 'System.Net.WebClient'
-      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $env:TEST_JUNIT_XML_PATH)
+      $endpoint = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
+      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT -Recurse -Include *.xml | ForEach-Object {
+        Write-Output "Uploading JUnit XML $($_)"
+        $wc.UploadFile($endpoint, $_)
+      }
   - IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] (
       IF NOT EXIST C:\sqtemp MKDIR C:\sqtemp
       SET SQUIRREL_TEMP=C:\sqtemp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ after_test:
   - ps: |
       $wc = New-Object 'System.Net.WebClient'
       $endpoint = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
-      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT -Recurse -Include *.xml | ForEach-Object {
+      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT\* -Recurse -File -Name -Include *.xml | ForEach-Object {
         Write-Output "Uploading JUnit XML $($_)"
         $wc.UploadFile($endpoint, $_)
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ platform:
 environment:
   global:
     ATOM_DEV_RESOURCE_PATH: c:\projects\atom
+    TEST_JUNIT_XML_PATH: c:\projects\atom\junit-results.xml
 
   matrix:
   - NODE_VERSION: 6.9.4
@@ -39,6 +40,9 @@ test_script:
   - script\test.cmd
 
 after_test:
+  - ps: |
+      $wc = New-Object 'System.Net.WebClient'
+      $wc.UploadFile("https://ci.appveyor.com/api/testresults/xunit/$($env:APPVEYOR_JOB_ID)", $env:TEST_JUNIT_XML_PATH)
   - IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] (
       IF NOT EXIST C:\sqtemp MKDIR C:\sqtemp
       SET SQUIRREL_TEMP=C:\sqtemp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,15 +41,6 @@ test_script:
   - script\test.cmd
 
 after_test:
-  - ps: |
-      $wc = New-Object 'System.Net.WebClient'
-      $endpoint = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
-      Write-Output "Searching for JUnit XML output beneath $($env:TEST_JUNIT_XML_ROOT)"
-      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT -Recurse -File -Name
-      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT -Recurse -File -Name -Include "*.xml" | ForEach-Object {
-        Write-Output "Uploading JUnit XML $($_)"
-        $wc.UploadFile($endpoint, $_)
-      }
   - IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] (
       IF NOT EXIST C:\sqtemp MKDIR C:\sqtemp
       SET SQUIRREL_TEMP=C:\sqtemp
@@ -73,3 +64,13 @@ cache:
   - '%APPVEYOR_BUILD_FOLDER%\electron'
   - '%USERPROFILE%\.atom\.apm'
   - '%USERPROFILE%\.atom\compile-cache'
+
+on_finish:
+  - ps: |
+      $wc = New-Object 'System.Net.WebClient'
+      $endpoint = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
+      Write-Output "Searching for JUnit XML output beneath $($env:TEST_JUNIT_XML_ROOT)"
+      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT -Recurse -File -Name -Include "*.xml" | ForEach-Object {
+        Write-Output "Uploading JUnit XML $($_)"
+        $wc.UploadFile($endpoint, $_)
+      }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,6 +71,7 @@ on_finish:
       $endpoint = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
       Write-Output "Searching for JUnit XML output beneath $($env:TEST_JUNIT_XML_ROOT)"
       Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT -Recurse -File -Name -Include "*.xml" | ForEach-Object {
-        Write-Output "Uploading JUnit XML $($_)"
-        $wc.UploadFile($endpoint, $_)
+        $full = "$($env:TEST_JUNIT_XML_ROOT)\$($_)"
+        Write-Output "Uploading JUnit XML file $($full)"
+        $wc.UploadFile($endpoint, $full)
       }

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,7 @@ machine:
     XCODE_SCHEME: test
     XCODE_WORKSPACE: test
     XCODE_PROJECT: test
+    TEST_JUNIT_XML_ROOT: ${CIRCLE_TEST_REPORTS}
 
   xcode:
     version: 7.3

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "electronVersion": "1.6.9",
   "dependencies": {
+    "@atom/source-map-support": "^0.3.4",
     "async": "0.2.6",
     "atom-keymap": "8.2.2",
     "atom-select-list": "^0.1.0",
@@ -38,6 +39,7 @@
     "glob": "^7.1.1",
     "grim": "1.5.0",
     "jasmine-json": "~0.0",
+    "jasmine-reporters": "^2.2.1",
     "jasmine-tagged": "^1.1.4",
     "key-path-helpers": "^0.4.0",
     "less-cache": "1.1.0",
@@ -45,6 +47,8 @@
     "marked": "^0.3.6",
     "minimatch": "^3.0.3",
     "mocha": "2.5.1",
+    "mocha-junit-reporter": "^1.13.0",
+    "mocha-multi-reporters": "^1.1.4",
     "mock-spawn": "^0.2.6",
     "normalize-package-data": "^2.0.0",
     "nslog": "^3",
@@ -63,7 +67,6 @@
     "semver": "^4.3.3",
     "service-hub": "^0.7.4",
     "sinon": "1.17.4",
-    "@atom/source-map-support": "^0.3.4",
     "temp": "^0.8.3",
     "text-buffer": "13.0.7",
     "typescript-simple": "1.0.0",
@@ -193,8 +196,5 @@
       "HTMLElement",
       "snapshotResult"
     ]
-  },
-  "devDependencies": {
-    "jasmine-reporters": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -193,5 +193,8 @@
       "HTMLElement",
       "snapshotResult"
     ]
+  },
+  "devDependencies": {
+    "jasmine-reporters": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "glob": "^7.1.1",
     "grim": "1.5.0",
     "jasmine-json": "~0.0",
-    "jasmine-reporters": "^2.2.1",
+    "jasmine-reporters": "1.1.0",
     "jasmine-tagged": "^1.1.4",
     "key-path-helpers": "^0.4.0",
     "less-cache": "1.1.0",

--- a/script/test
+++ b/script/test
@@ -33,7 +33,7 @@ if (process.platform === 'darwin') {
 }
 
 function prepareEnv (suiteName) {
-  const env = {}
+  const env = Object.assign({}, process.env)
 
   if (process.env.TEST_JUNIT_XML_ROOT) {
     // Tell Jasmine to output this suite's results as a JUnit XML file to a subdirectory of the root, so that a

--- a/script/test
+++ b/script/test
@@ -35,10 +35,10 @@ if (process.platform === 'darwin') {
 function prepareEnv (suiteName) {
   const env = {}
 
-  if (process.env.CIRCLE_TEST_REPORTS) {
-    // CircleCI
-    // Tell Jasmine to output this suite's results to the directory that Circle expects to find JUnit XML files in.
-    const outputPath = path.join(process.env.CIRCLE_TEST_REPORTS, suiteName, 'test-results.xml')
+  if (process.env.TEST_JUNIT_XML_ROOT) {
+    // Tell Jasmine to output this suite's results as a JUnit XML file to a subdirectory of the root, so that a
+    // CI system can interpret it.
+    const outputPath = path.join(process.env.TEST_JUNIT_XML_ROOT, suiteName, 'test-results.xml')
     env.TEST_JUNIT_XML_PATH = outputPath
   }
 

--- a/script/test
+++ b/script/test
@@ -32,18 +32,29 @@ if (process.platform === 'darwin') {
   throw new Error('Running tests on this platform is not supported.')
 }
 
+function prepareEnv (suiteName) {
+  const env = {}
+
+  if (process.env.CIRCLE_TEST_REPORTS) {
+    // CircleCI
+    // Tell Jasmine to output this suite's results to the directory that Circle expects to find JUnit XML files in.
+    const outputPath = path.join(process.env.CIRCLE_TEST_REPORTS, suiteName, 'test-results.xml')
+    env.TEST_JUNIT_XML_PATH = outputPath
+  }
+
+  return env
+}
+
 function runCoreMainProcessTests (callback) {
   const testPath = path.join(CONFIG.repositoryRootPath, 'spec', 'main-process')
   const testArguments = [
     '--resource-path', resourcePath,
     '--test', '--main-process', testPath
   ]
+  const testEnv = Object.assign({}, prepareEnv('core-main-process'), process.env, {ATOM_GITHUB_INLINE_GIT_EXEC: 'true'})
 
   console.log('Executing core main process tests'.bold.green)
-  const cp = childProcess.spawn(executablePath, testArguments, {
-    stdio: 'inherit',
-    env: Object.assign({}, process.env, {ATOM_GITHUB_INLINE_GIT_EXEC: 'true'})
-  })
+  const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })
   cp.on('close', exitCode => { callback(null, exitCode) })
 }
@@ -54,9 +65,10 @@ function runCoreRenderProcessTests (callback) {
     '--resource-path', resourcePath,
     '--test', testPath
   ]
+  const testEnv = prepareEnv('core-render-process')
 
   console.log('Executing core render process tests'.bold.green)
-  const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit'})
+  const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })
   cp.on('close', exitCode => { callback(null, exitCode) })
 }
@@ -87,6 +99,7 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
       '--resource-path', resourcePath,
       '--test', testFolder
     ]
+    const testEnv = prepareEnv(`bundled-package-${packageName}`)
 
     const pkgJsonPath = path.join(repositoryPackagePath, 'package.json')
     const nodeModulesPath = path.join(repositoryPackagePath, 'node_modules')
@@ -105,7 +118,7 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
     } else {
       console.log(`Executing ${packageName} tests`.bold.green)
     }
-    const cp = childProcess.spawn(executablePath, testArguments)
+    const cp = childProcess.spawn(executablePath, testArguments, {env: testEnv})
     let stderrOutput = ''
     cp.stderr.on('data', data => { stderrOutput += data })
     cp.stdout.on('data', data => { stderrOutput += data })
@@ -127,9 +140,10 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
 function runBenchmarkTests (callback) {
   const benchmarksPath = path.join(CONFIG.repositoryRootPath, 'benchmarks')
   const testArguments = ['--benchmark-test', benchmarksPath]
+  const testEnv = prepareEnv('benchmark')
 
   console.log('Executing benchmark tests'.bold.green)
-  const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit'})
+  const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })
   cp.on('close', exitCode => { callback(null, exitCode) })
 }

--- a/script/test
+++ b/script/test
@@ -51,7 +51,9 @@ function runCoreMainProcessTests (callback) {
     '--resource-path', resourcePath,
     '--test', '--main-process', testPath
   ]
-  const testEnv = Object.assign({}, prepareEnv('core-main-process'), process.env, {ATOM_GITHUB_INLINE_GIT_EXEC: 'true'})
+  const testEnv = Object.assign({}, prepareEnv('core-main-process'), {ATOM_GITHUB_INLINE_GIT_EXEC: 'true'})
+
+  console.log(`test environment: ${require('util').inspect(testEnv)}`)
 
   console.log('Executing core main process tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})

--- a/script/test
+++ b/script/test
@@ -105,7 +105,6 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
 
     const pkgJsonPath = path.join(repositoryPackagePath, 'package.json')
     const nodeModulesPath = path.join(repositoryPackagePath, 'node_modules')
-    const nodeModulesBackupPath = path.join(repositoryPackagePath, 'node_modules.bak')
     let finalize = () => null
     if (require(pkgJsonPath).atomTestRunner) {
       console.log(`Installing test runner dependencies for ${packageName}`.bold.green)
@@ -152,12 +151,17 @@ function runBenchmarkTests (callback) {
 
 let testSuitesToRun = testSuitesForPlatform(process.platform)
 
-function testSuitesForPlatform(platform) {
-  switch(platform) {
-    case 'darwin':  return [runCoreMainProcessTests, runCoreRenderProcessTests, runBenchmarkTests].concat(packageTestSuites)
-    case 'win32':   return (process.arch === 'x64') ? [runCoreMainProcessTests, runCoreRenderProcessTests] : [runCoreMainProcessTests]
-    case 'linux':   return [runCoreMainProcessTests]
-    default:        return []
+function testSuitesForPlatform (platform) {
+  switch (platform) {
+    case 'darwin':
+      return [runCoreMainProcessTests, runCoreRenderProcessTests, runBenchmarkTests].concat(packageTestSuites)
+    case 'win32':
+      return (process.arch === 'x64') ? [runCoreMainProcessTests, runCoreRenderProcessTests] : [runCoreMainProcessTests]
+    case 'linux':
+      return [runCoreMainProcessTests]
+    default:
+      console.log(`Unrecognized platform: ${platform}`)
+      return []
   }
 }
 

--- a/script/test
+++ b/script/test
@@ -53,8 +53,6 @@ function runCoreMainProcessTests (callback) {
   ]
   const testEnv = Object.assign({}, prepareEnv('core-main-process'), {ATOM_GITHUB_INLINE_GIT_EXEC: 'true'})
 
-  console.log(`test environment: ${require('util').inspect(testEnv)}`)
-
   console.log('Executing core main process tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })

--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -7,6 +7,10 @@ module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
   window[key] = value for key, value of require '../vendor/jasmine'
   require 'jasmine-tagged'
 
+  if process.env.TEST_JUNIT_XML_PATH
+    require 'jasmine-reporters'
+    jasmine.getEnv().addReporter new jasmine.JUnitXmlReporter(process.env.TEST_JUNIT_XML_PATH, true, true)
+
   # Allow document.title to be assigned in specs without screwing up spec window title
   documentTitle = null
   Object.defineProperty document, 'title',

--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -9,11 +9,7 @@ module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
 
   if process.env.TEST_JUNIT_XML_PATH
     require 'jasmine-reporters'
-    console.log "Producing JUnit XML output at #{process.env.TEST_JUNIT_XML_PATH}."
     jasmine.getEnv().addReporter new jasmine.JUnitXmlReporter(process.env.TEST_JUNIT_XML_PATH, true, true)
-  else
-    console.log "TEST_JUNIT_XML_PATH was falsy"
-    console.log require('util').inspect process.env
 
   # Allow document.title to be assigned in specs without screwing up spec window title
   documentTitle = null

--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -9,6 +9,7 @@ module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
 
   if process.env.TEST_JUNIT_XML_PATH
     require 'jasmine-reporters'
+    console.log "Producing JUnit XML output at #{process.env.TEST_JUNIT_XML_PATH}."
     jasmine.getEnv().addReporter new jasmine.JUnitXmlReporter(process.env.TEST_JUNIT_XML_PATH, true, true)
 
   # Allow document.title to be assigned in specs without screwing up spec window title

--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -11,6 +11,9 @@ module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
     require 'jasmine-reporters'
     console.log "Producing JUnit XML output at #{process.env.TEST_JUNIT_XML_PATH}."
     jasmine.getEnv().addReporter new jasmine.JUnitXmlReporter(process.env.TEST_JUNIT_XML_PATH, true, true)
+  else
+    console.log "TEST_JUNIT_XML_PATH was falsy"
+    console.log require('util').inspect process.env
 
   # Allow document.title to be assigned in specs without screwing up spec window title
   documentTitle = null

--- a/spec/main-process/mocha-test-runner.js
+++ b/spec/main-process/mocha-test-runner.js
@@ -12,7 +12,6 @@ export default function (testPaths) {
   }
 
   if (process.env.TEST_JUNIT_XML_PATH) {
-    console.log(`Mocha: Producing JUnit XML output at ${process.env.TEST_JUNIT_XML_PATH}.`)
     reporterOptions = {
       reporterEnabled: 'list, mocha-junit-reporter',
       mochaJunitReporterReporterOptions: {

--- a/spec/main-process/mocha-test-runner.js
+++ b/spec/main-process/mocha-test-runner.js
@@ -7,7 +7,24 @@ import {assert} from 'chai'
 export default function (testPaths) {
   global.assert = assert
 
-  const mocha = new Mocha({reporter: 'spec'})
+  let reporterOptions = {
+    reporterEnabled: 'list'
+  }
+
+  if (process.env.TEST_JUNIT_XML_PATH) {
+    console.log(`Mocha: Producing JUnit XML output at ${process.env.TEST_JUNIT_XML_PATH}.`)
+    reporterOptions = {
+      reporterEnabled: 'list, mocha-junit-reporter',
+      mochaJunitReporterReporterOptions: {
+        mochaFile: process.env.TEST_JUNIT_XML_PATH
+      }
+    }
+  }
+
+  const mocha = new Mocha({
+    reporter: 'mocha-multi-reporters',
+    reporterOptions
+  })
   for (let testPath of testPaths) {
     if (fs.isDirectorySync(testPath)) {
       for (let testFilePath of fs.listTreeSync(testPath)) {


### PR DESCRIPTION
Use the JUnit XML reporter from [jasmine-reporters](https://www.npmjs.com/package/jasmine-reporters) to produce test reports on CI builds on CircleCI and AppVeyor. This should expose test metadata that we can use to:

* More quickly diagnose failures
* Produce metadata that we can consume to identify flakes over time