### PR TITLE
Fix gutter decoration regression in v1.19 beta

### DIFF
--- a/static/text-editor.less
+++ b/static/text-editor.less
@@ -20,6 +20,7 @@ atom-text-editor {
     min-width: 1em;
     box-sizing: border-box;
     background-color: inherit;
+    position: relative;
   }
 
   .gutter:hover {


### PR DESCRIPTION
Fixes #15062

## Demo

### With linter-ui gutter highlights to right of line numbers (default)

#### 1.18

![1 18-right](https://user-images.githubusercontent.com/2988/28797560-c0e23860-760f-11e7-9ced-0bd1f75b8828.png)

#### 1.19 before this PR

![1 19-before-right](https://user-images.githubusercontent.com/2988/28797561-c0e455e6-760f-11e7-8cb6-7ff053f95a77.png)

#### 1.19 after this PR

![1 19-after-right](https://user-images.githubusercontent.com/2988/28797558-c0dfa74e-760f-11e7-88f0-7d31b812a931.png)

### With linter-ui gutter highlights to left of line numbers

#### 1.18

![1 18](https://user-images.githubusercontent.com/2988/28797559-c0e19770-760f-11e7-8a06-056cb6afdc09.png)

#### 1.19 before this PR

![1 19-before](https://user-images.githubusercontent.com/2988/28797562-c0e48264-760f-11e7-95ad-b0754bbc42b8.png)

#### 1.19 after this PR

![1 19-after](https://user-images.githubusercontent.com/2988/28797563-c0e46784-760f-11e7-9215-c7227dc200f5.png)

---

xref #13880, which we believe to be the source of the regression that we're fixing in this PR