### PR TITLE
Don't enable electron logging by default

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -31,6 +31,9 @@ while getopts ":wtfvh-:" opt; do
         foreground|benchmark|benchmark-test|test)
           EXPECT_OUTPUT=1
           ;;
+        enable-electron-logging)
+          export ELECTRON_ENABLE_LOGGING=1
+          ;;
       esac
       ;;
     w)
@@ -48,10 +51,6 @@ done
 
 if [ $REDIRECT_STDERR ]; then
   exec 2> /dev/null
-fi
-
-if [ $EXPECT_OUTPUT ]; then
-  export ELECTRON_ENABLE_LOGGING=1
 fi
 
 if [ $OS == 'Mac' ]; then

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -5,16 +5,17 @@ SET WAIT=
 SET PSARGS=%*
 
 FOR %%a IN (%*) DO (
-  IF /I "%%a"=="-f"               SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="--foreground"     SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="-h"               SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="--help"           SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="-t"               SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="--test"           SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="--benchmark"      SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="--benchmark-test" SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="-v"               SET EXPECT_OUTPUT=YES
-  IF /I "%%a"=="--version"        SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="-f"                         SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--foreground"               SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="-h"                         SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--help"                     SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="-t"                         SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--test"                     SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--benchmark"                SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--benchmark-test"           SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="-v"                         SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--version"                  SET EXPECT_OUTPUT=YES
+  IF /I "%%a"=="--enable-electron-logging"  SET ELECTRON_ENABLE_LOGGING=YES
   IF /I "%%a"=="-w"           (
     SET EXPECT_OUTPUT=YES
     SET WAIT=YES
@@ -26,7 +27,6 @@ FOR %%a IN (%*) DO (
 )
 
 IF "%EXPECT_OUTPUT%"=="YES" (
-  SET ELECTRON_ENABLE_LOGGING=YES
   IF "%WAIT%"=="YES" (
     powershell -noexit "Start-Process -FilePath \"%~dp0\..\..\atom.exe\" -ArgumentList \"--pid=$pid $env:PSARGS\" ; wait-event"
     exit 0

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -3,6 +3,7 @@
 SET EXPECT_OUTPUT=
 SET WAIT=
 SET PSARGS=%*
+SET ELECTRON_ENABLE_LOGGING=
 
 FOR %%a IN (%*) DO (
   IF /I "%%a"=="-f"                         SET EXPECT_OUTPUT=YES

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -55,6 +55,7 @@ module.exports = function parseCommandLine (processArgs) {
   options.string('socket-path')
   options.string('user-data-dir')
   options.boolean('clear-window-state').describe('clear-window-state', 'Delete all Atom environment state.')
+  options.boolean('enable-electron-logging').describe('enable-electron-logging', 'Enable low-level logging messages from Electron.')
 
   const args = options.argv
 


### PR DESCRIPTION
@as-cii @jasonrudolph This cleans up the test noise we were seeing on our package.

In #9268, @thomasjo set the `ELECTRON_ENABLE_LOGGING` environment variable to true. He states in that PR that this was necessary to enable `console.log` to go to `stdout`, and I didn't take the time to go back and test that ancient version of Electron to confirm this to be true, but I'll take him at his word.

Now, however, `console.log` seems to work irrespective of this environment variable. Furthermore setting this environment variable has the unfortunate side effect of causing lots of fairly low level warning messages from within Chromium's internals to spam the console when Atom is run headless. In this PR, I remove the lines from `atom.sh` and `atom.cmd` that set this variable. It's still possible to automatically assign the variable via the `--enable-electron-logging` flag.

@damieng would you mind checking my changes in `cmd.sh` and maybe @ungb could you test it out? I just want to make sure I didn't break the script.