### PR TITLE
Update info on persisting inotify settings on linux

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -99,7 +99,7 @@ and restart Atom.  If Atom now works fine, you can make this setting permanent:
  * On Arch Linux, instead run: 
 
   ```
-  echo "fs.inotify.max_user_watches=204800" |sudo tee -a /usr/lib/sysctl.d/90-override.conf
+  echo "fs.inotify.max_user_watches=204800" | sudo tee -a /usr/lib/sysctl.d/90-override.conf
   ```
 
 See also 

--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -90,11 +90,17 @@ this is the reason for this error you can issue
 
 and restart Atom.  If Atom now works fine, you can make this setting permanent:
 
-On most Linux distributions: 
-  ```echo -e "fs.inotify.max_user_watches=204800\n"  sudo tee -a /etc/sysctl.conf```
+ * On most Linux distributions:
 
-On Arch Linux, instead run: 
-  ```echo -e "fs.inotify.max_user_watches=204800\n"  sudo tee -a /usr/lib/sysctl.d/90-override.conf```
+  ```
+  echo "fs.inotify.max_user_watches=204800" | sudo tee -a /etc/sysctl.conf
+  ```
+
+ * On Arch Linux, instead run: 
+
+  ```
+  echo "fs.inotify.max_user_watches=204800" |sudo tee -a /usr/lib/sysctl.d/90-override.conf
+  ```
 
 See also 
  * [Arch forum post](https://bbs.archlinux.org/viewtopic.php?id=193020)

--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -90,11 +90,16 @@ this is the reason for this error you can issue
 
 and restart Atom.  If Atom now works fine, you can make this setting permanent:
 
-  ```sh
-  echo 32768 | sudo tee -a /proc/sys/fs/inotify/max_user_watches
-  ```
+On most Linux distributions: 
+  ```echo -e "fs.inotify.max_user_watches=204800\n"  sudo tee -a /etc/sysctl.conf```
 
-See also [#2082](https://github.com/atom/atom/issues/2082).
+On Arch Linux, instead run: 
+  ```echo -e "fs.inotify.max_user_watches=204800\n"  sudo tee -a /usr/lib/sysctl.d/90-override.conf```
+
+See also 
+ * [Arch forum post](https://bbs.archlinux.org/viewtopic.php?id=193020)
+ * [#2082](https://github.com/atom/atom/issues/2082).
+ * [Readme](https://github.com/syncthing/syncthing-inotify)
 
 ### /usr/bin/env: node: No such file or directory
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

improve the documentation on how to make Atom work on linux (mostly Arch I guess).

The previous version already read "if this works you can make the setting persistent", however the method described only persisted until next boot. This PR describes how to make it persistent after reboot also.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

Atom displays a link to this file when file watching doesnt work as expected

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
