### PR TITLE
Fix flaky test re: blinking cursor

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -424,15 +424,8 @@ describe('TextEditorComponent', () => {
       editor.moveRight()
       await component.getNextUpdatePromise()
 
-      await conditionPromise(() =>
-        getComputedStyle(cursor1).opacity === '0' && getComputedStyle(cursor2).opacity === '0'
-      )
-      await conditionPromise(() =>
-        getComputedStyle(cursor1).opacity === '1' && getComputedStyle(cursor2).opacity === '1'
-      )
-      await conditionPromise(() =>
-        getComputedStyle(cursor1).opacity === '0' && getComputedStyle(cursor2).opacity === '0'
-      )
+      expect(getComputedStyle(cursor1).opacity).toBe('1')
+      expect(getComputedStyle(cursor2).opacity).toBe('1')
     })
 
     it('gives cursors at the end of lines the width of an "x" character', async () => {

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -411,26 +411,28 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise()
       const [cursor1, cursor2] = element.querySelectorAll('.cursor')
 
-      expect(getComputedStyle(cursor1).opacity).toBe('1')
-      expect(getComputedStyle(cursor2).opacity).toBe('1')
-
-      await conditionPromise(() =>
-        getComputedStyle(cursor1).opacity === '0' && getComputedStyle(cursor2).opacity === '0'
-      )
-
       await conditionPromise(() =>
         getComputedStyle(cursor1).opacity === '1' && getComputedStyle(cursor2).opacity === '1'
       )
-
       await conditionPromise(() =>
         getComputedStyle(cursor1).opacity === '0' && getComputedStyle(cursor2).opacity === '0'
+      )
+      await conditionPromise(() =>
+        getComputedStyle(cursor1).opacity === '1' && getComputedStyle(cursor2).opacity === '1'
       )
 
       editor.moveRight()
       await component.getNextUpdatePromise()
 
-      expect(getComputedStyle(cursor1).opacity).toBe('1')
-      expect(getComputedStyle(cursor2).opacity).toBe('1')
+      await conditionPromise(() =>
+        getComputedStyle(cursor1).opacity === '0' && getComputedStyle(cursor2).opacity === '0'
+      )
+      await conditionPromise(() =>
+        getComputedStyle(cursor1).opacity === '1' && getComputedStyle(cursor2).opacity === '1'
+      )
+      await conditionPromise(() =>
+        getComputedStyle(cursor1).opacity === '0' && getComputedStyle(cursor2).opacity === '0'
+      )
     })
 
     it('gives cursors at the end of lines the width of an "x" character', async () => {


### PR DESCRIPTION
Fixes #15122

---

As shown in #15122, [these assertions in `spec/text-editor-component-spec.js`](https://github.com/atom/atom/blob/7d6bd2a6b19be004254865d163d74bd5e849be2f/spec/text-editor-component-spec.js#L414-L415) occasionally fail on AppVeyor:

```
TextEditorComponent
  rendering
    it blinks cursors when the editor is focused and the cursors are not moving
      Expected '0' to be '1'.
        at it (C:\projects\atom\spec\text-editor-component-spec.js:414:49)
      Expected '0' to be '1'.
        at it (C:\projects\atom\spec\text-editor-component-spec.js:415:49)
```

I haven't been able to reproduce the failure locally, but I have a hunch regarding the source of the intermittent failures. I think it might be a case of "overspecification" in the test's assertions. The test expects the blinking cursor to *start* in the visible state, and then transition to the invisible state. When we see the failure above, I suspect that the cursor has already transitioned from the visible state to the invisible state by the time the assertions run.

Since the test aims to verify that the cursor blinks [1], it seems like we should focus on the blinking, and not worry about the *initial* state of the cursor. This PR removes the assertions that verify the initial state of the cursor, and instead asserts that the cursor toggles between the visible and the invisible state.

@nathansobo: Given your familiarly with this test, would you mind reviewing this change? I *think* this change has a good chance of resolving the intermittent failures while still maintaining the spirit of the test. What do you think?

---

[1] eb22b58756add00ae8f2a00d123e52e8ae2f6c69 introduced this test as a smoke test for cursor blinking
