### PR TITLE
Open the save dialog in the project root for new items

### DIFF
--- a/spec/pane-spec.js
+++ b/spec/pane-spec.js
@@ -755,6 +755,17 @@ describe('Pane', () => {
         })
       })
 
+      describe('when the current item has a saveAs method and a project is open', () => {
+        it('opens a save dialog with the project directory', async () => {
+          pane.getActiveItem().saveAs = jasmine.createSpy('saveAs')
+          atom.project.setPaths([__dirname])
+          await pane.saveActiveItem()
+          expect(showSaveDialog).toHaveBeenCalledWith({
+            defaultPath: __dirname
+          })
+        })
+      })
+
       it('does nothing if the user cancels choosing a path', async () => {
         pane.getActiveItem().saveAs = jasmine.createSpy('saveAs')
         showSaveDialog.andReturn(undefined)

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -739,7 +739,7 @@ class Pane
     return unless item?.saveAs?
 
     saveOptions = item.getSaveDialogOptions?() ? {}
-    saveOptions.defaultPath ?= item.getPath()
+    saveOptions.defaultPath ?= item.getPath() ? atom.project.getPaths()[0]
     newItemPath = @applicationDelegate.showSaveDialog(saveOptions)
     if newItemPath
       promisify -> item.saveAs(newItemPath)


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

When you try to save a new file (Save an item without a uri), the save as dialog will open in a default OS dependent directory. For example, on Windows it opens in the working directory. But if you have a project open, it makes more sense to open it in the project root folder.

### Benefits

When you save a new file, the save as dialog will start in the project folder.

### Possible Drawbacks

I think that if you pass a `defaultPath` to `dialog.showSaveDialog` than it takes precedence over the OS remembering the last directory used in the dialog.

### Applicable Issues

Fixes #14732
