### PR TITLE
Recognize Windows cmd or powershell environment in updateProcessEnv

### DIFF
--- a/spec/update-process-env-spec.js
+++ b/spec/update-process-env-spec.js
@@ -36,7 +36,7 @@ describe('updateProcessEnv(launchEnv)', function () {
   })
 
   describe('when the launch environment appears to come from a shell', function () {
-    it('updates process.env to match the launch environment', async function () {
+    it('updates process.env to match the launch environment because PWD is set', async function () {
       process.env = {
         WILL_BE_DELETED: 'hi',
         NODE_ENV: 'the-node-env',
@@ -51,6 +51,65 @@ describe('updateProcessEnv(launchEnv)', function () {
         ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true',
         PWD: '/the/dir',
         TERM: 'xterm-something',
+        KEY1: 'value1',
+        KEY2: 'value2',
+        NODE_ENV: 'the-node-env',
+        NODE_PATH: '/the/node/path',
+        ATOM_HOME: '/the/atom/home'
+      })
+
+      // See #11302. On Windows, `process.env` is a magic object that offers
+      // case-insensitive environment variable matching, so we cannot replace it
+      // with another object.
+      expect(process.env).toBe(initialProcessEnv)
+    })
+
+    it('updates process.env to match the launch environment because PROMPT is set', async function () {
+      process.env = {
+        WILL_BE_DELETED: 'hi',
+        NODE_ENV: 'the-node-env',
+        NODE_PATH: '/the/node/path',
+        ATOM_HOME: '/the/atom/home'
+      }
+
+      const initialProcessEnv = process.env
+
+      await updateProcessEnv({ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true', PROMPT: '$P$G', KEY1: 'value1', KEY2: 'value2'})
+      expect(process.env).toEqual({
+        ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true',
+        PROMPT: '$P$G',
+        KEY1: 'value1',
+        KEY2: 'value2',
+        NODE_ENV: 'the-node-env',
+        NODE_PATH: '/the/node/path',
+        ATOM_HOME: '/the/atom/home'
+      })
+
+      // See #11302. On Windows, `process.env` is a magic object that offers
+      // case-insensitive environment variable matching, so we cannot replace it
+      // with another object.
+      expect(process.env).toBe(initialProcessEnv)
+    })
+
+    it('updates process.env to match the launch environment because PSModulePath is set', async function () {
+      process.env = {
+        WILL_BE_DELETED: 'hi',
+        NODE_ENV: 'the-node-env',
+        NODE_PATH: '/the/node/path',
+        ATOM_HOME: '/the/atom/home'
+      }
+
+      const initialProcessEnv = process.env
+
+      await updateProcessEnv({
+        ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true',
+        PSModulePath: 'C:\\Program Files\\WindowsPowerShell\\Modules;C:\\WINDOWS\\system32\\WindowsPowerShell\\v1.0\\Modules\\',
+        KEY1: 'value1',
+        KEY2: 'value2'
+      })
+      expect(process.env).toEqual({
+        ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT: 'true',
+        PSModulePath: 'C:\\Program Files\\WindowsPowerShell\\Modules;C:\\WINDOWS\\system32\\WindowsPowerShell\\v1.0\\Modules\\',
         KEY1: 'value1',
         KEY2: 'value2',
         NODE_ENV: 'the-node-env',

--- a/src/update-process-env.js
+++ b/src/update-process-env.js
@@ -18,7 +18,7 @@ async function updateProcessEnv (launchEnv) {
   if (launchEnv) {
     if (shouldGetEnvFromShell(launchEnv)) {
       envToAssign = await getEnvFromShell(launchEnv)
-    } else if (launchEnv.PWD) {
+    } else if (launchEnv.PWD || launchEnv.PROMPT || launchEnv.PSModulePath) {
       envToAssign = launchEnv
     }
   }


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Windows doesn't have `PWD` in the environment passed to processes from the shell. cmd has `PROMPT` and PowerShell has `PSModulePath`, so also check for those to determine if we were launched from proper shell environment. At least that's what I think this condition is meant to check for.

### Alternate Designs

Maybe a different check is more appropriate.

### Why Should This Be In Core?

It's a bug in the core functionality of updating the environment from the shell on Windows.

### Benefits

The environment will be updated when using the `atom` command from the shell like it does on other operating systems.

### Possible Drawbacks

If this starts updating the environment on cases that it shouldn't.

### Applicable Issues

Fixes #14986
