### PR TITLE
Fix flaky test re: flashing highlight decorations

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1443,27 +1443,6 @@ describe('TextEditorComponent', () => {
       expect(highlights[0].classList.contains('b')).toBe(false)
       expect(highlights[1].classList.contains('b')).toBe(false)
 
-      // Flash existing highlight
-      decoration.flash('c', 100)
-      await component.getNextUpdatePromise()
-      expect(highlights[0].classList.contains('c')).toBe(true)
-      expect(highlights[1].classList.contains('c')).toBe(true)
-
-      // Add second flash class
-      decoration.flash('d', 100)
-      await component.getNextUpdatePromise()
-      expect(highlights[0].classList.contains('c')).toBe(true)
-      expect(highlights[1].classList.contains('c')).toBe(true)
-      expect(highlights[0].classList.contains('d')).toBe(true)
-      expect(highlights[1].classList.contains('d')).toBe(true)
-
-      await conditionPromise(() =>
-        !highlights[0].classList.contains('c') &&
-        !highlights[1].classList.contains('c') &&
-        !highlights[0].classList.contains('d') &&
-        !highlights[1].classList.contains('d')
-      )
-
       // Flashing the same class again before the first flash completes
       // removes the flash class and adds it back on the next frame to ensure
       // CSS transitions apply to the second flash.
@@ -1486,6 +1465,27 @@ describe('TextEditorComponent', () => {
         !highlights[0].classList.contains('e') &&
         !highlights[1].classList.contains('e')
       )
+    })
+
+    it("flashing a highlight decoration doesn't unflash other highlight decorations", async () => {
+      const {component, element, editor} = buildComponent({rowsPerTile: 3, height: 200})
+      const marker = editor.markScreenRange([[2, 4], [3, 4]])
+      const decoration = editor.decorateMarker(marker, {type: 'highlight', class: 'a'})
+
+      // Flash one class
+      decoration.flash('c', 1000)
+      await component.getNextUpdatePromise()
+      const highlights = element.querySelectorAll('.highlight.a')
+      expect(highlights[0].classList.contains('c')).toBe(true)
+      expect(highlights[1].classList.contains('c')).toBe(true)
+
+      // Flash another class while the previously-flashed class is still highlighted
+      decoration.flash('d', 100)
+      await component.getNextUpdatePromise()
+      expect(highlights[0].classList.contains('c')).toBe(true)
+      expect(highlights[1].classList.contains('c')).toBe(true)
+      expect(highlights[0].classList.contains('d')).toBe(true)
+      expect(highlights[1].classList.contains('d')).toBe(true)
     })
 
     it('supports layer decorations', async () => {


### PR DESCRIPTION
Fixes #15158

---

As shown in #15158, [these assertions in `spec/text-editor-component-spec.js`](https://github.com/atom/atom/blob/29810c6cd1924e08126bd18d759b80abfd1c199c/spec/text-editor-component-spec.js#L1462-L1463) occasionally fail on AppVeyor:

```
TextEditorComponent
  highlight decorations
    it can flash highlight decorations
      Expected false to be true.
        at it (C:\projects\atom\spec\text-editor-component-spec.js:1462:53)
      Expected false to be true.
        at it (C:\projects\atom\spec\text-editor-component-spec.js:1463:53)
```

I haven't been able to reproduce the failure locally, but after discussion with @nathansobo, we have a hunch regarding the source of the intermittent failures. It seems that the flash for class 'c' sometimes ends before the flash for class 'd' happens:

```js
// Flash existing highlight
decoration.flash('c', 100)
await component.getNextUpdatePromise()
expect(highlights[0].classList.contains('c')).toBe(true)
expect(highlights[1].classList.contains('c')).toBe(true)

// Add second flash class
decoration.flash('d', 100)
await component.getNextUpdatePromise()
expect(highlights[0].classList.contains('c')).toBe(true) // <== occasionally fails
expect(highlights[1].classList.contains('c')).toBe(true) // <== occasionally fails
expect(highlights[0].classList.contains('d')).toBe(true)
expect(highlights[1].classList.contains('d')).toBe(true)
```


Prior to this PR, we only flashed class 'c' for 100ms, and perhaps that isn't always enough time. In this PR, we increase the flash duration from 100ms to 1000ms, greatly increasing the likelihood that we're allowing enough time for the flash on class 'd' to take place before the flash for class 'c' ends. (Even 1000ms doesn't _guarantee_ that we're allowing enough time, but we don't have a better solution available at the moment.)

This PR also extracts the involved assertions into their own test, so that 1) we can more clearly explain the scenario that these assertions are testing and 2) it will be easier to isolate any future intermittent test failures related to these assertions.
