### PR TITLE
Add support doc

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,11 @@
+# Atom Support
+
+If you're looking for support for Atom there are a lot of options, check out:
+
+* User Documentation &mdash; [The Atom Flight Manual](http://flight-manual.atom.io)
+* Developer Documentation &mdash; [Atom API Documentation](https://atom.io/docs/api/latest)
+* FAQ &mdash; [The Atom FAQ on Discuss](https://discuss.atom.io/c/faq)
+* Message Board &mdash; [Discuss, the official Atom and Electron message board](https://discuss.atom.io)
+* Chat &mdash; [Join the Atom Slack team](http://atom-slack.herokuapp.com/)
+
+On Discuss and in the Atom Slack team, there are a bunch of helpful community members that should be willing to point you in the right direction.


### PR DESCRIPTION
Add document to point people to our various support resources.

[SUPPORT doc documentation](https://help.github.com/articles/adding-support-resources-to-your-project/)