### PR TITLE
Fix uncaught TypeError at createObjectStore

### DIFF
--- a/src/state-store.js
+++ b/src/state-store.js
@@ -14,6 +14,9 @@ class StateStore {
         const dbOpenRequest = indexedDB.open(this.databaseName, this.version)
         dbOpenRequest.onupgradeneeded = (event) => {
           let db = event.target.result
+          db.onerror = (event) => {
+            console.error('Error loading database', event)
+          }
           db.createObjectStore('states')
         }
         dbOpenRequest.onsuccess = () => {


### PR DESCRIPTION
Fixes #15172
---
As shown here:

Uncaught TypeError: Cannot read property 'createObjectStore' of undefined
```
At C:\Users\Midhu\AppData\Local\atom\app-1.18.0\resources\app\src\state-store.js:17

TypeError: Cannot read property 'createObjectStore' of undefined
    at IDBOpenDBRequest.dbOpenRequest.onupgradeneeded (~/AppData/Local/atom/app-1.18.0/resources/app/src/state-store.js:17:19)
```
---
I haven't been able to reproduce the error locally but I suspect this might be the cause.
