### PR TITLE
Fixed links in keymap.cson

### DIFF
--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -18,7 +18,7 @@
 #   'ctrl-p': 'core:move-down'
 #
 # You can find more information about keymaps in these guides:
-# * http://flight-manual.atom.io/using-atom/sections/basic-customization/#_customizing_keybindings
+# * http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings
 # * http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth/
 #
 # If you're having trouble with your keybindings not working, try the
@@ -29,4 +29,4 @@
 # This file uses CoffeeScript Object Notation (CSON).
 # If you are unfamiliar with CSON, you can read more about it in the
 # Atom Flight Manual:
-# http://flight-manual.atom.io/using-atom/sections/basic-customization/#_cson
+# http://flight-manual.atom.io/using-atom/sections/basic-customization/#configuring-with-cson


### PR DESCRIPTION
### Description of the Change

Fixed links in keymap.cson comments. Old links is not actual.

### Benefits

More cosy keymap docs.

### Possible Drawbacks

None

### Applicable Issues

#14779