### PR TITLE
Fix regression re: closing tabs via middle mouse click on Linux

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -3016,6 +3016,17 @@ describe('TextEditorComponent', () => {
     })
   })
 
+  describe('paste event', () => {
+    it("prevents the browser's default processing for the event on Linux", () => {
+      const {component} = buildComponent({platform: 'linux'})
+      const event = { preventDefault: () => {} }
+      spyOn(event, 'preventDefault')
+
+      component.didPaste(event)
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+  })
+
   describe('keyboard input', () => {
     it('handles inserted accented characters via the press-and-hold menu on macOS correctly', () => {
       const {editor, component, element} = buildComponent({text: ''})

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -2687,18 +2687,42 @@ describe('TextEditorComponent', () => {
         expect(component.getScrollLeft()).toBe(maxScrollLeft)
       })
 
-      it('positions the cursor on clicking the middle mouse button on Linux', async () => {
-        // The browser synthesizes the paste as a textInput event on mouseup
-        // so it is not possible to test it here.
+      it('pastes the previously selected text when clicking the middle mouse button on Linux', async () => {
+        spyOn(electron.ipcRenderer, 'send').andCallFake(function (eventName, selectedText) {
+          if (eventName === 'write-text-to-selection-clipboard') {
+            clipboard.writeText(selectedText, 'selection')
+          }
+        })
+
         const {component, editor} = buildComponent({platform: 'linux'})
 
+        // Middle mouse pasting.
         editor.setSelectedBufferRange([[1, 6], [1, 10]])
+        await conditionPromise(() => TextEditor.clipboard.read() === 'sort')
         component.didMouseDownOnContent({
           button: 1,
           clientX: clientLeftForCharacter(component, 10, 0),
           clientY: clientTopForLine(component, 10)
         })
-        expect(editor.getSelectedBufferRange()).toEqual([[10, 0], [10, 0]])
+        expect(TextEditor.clipboard.read()).toBe('sort')
+        expect(editor.lineTextForBufferRow(10)).toBe('sort')
+        editor.undo()
+
+        // Ensure left clicks don't interfere.
+        editor.setSelectedBufferRange([[1, 2], [1, 5]])
+        await conditionPromise(() => TextEditor.clipboard.read() === 'var')
+        component.didMouseDownOnContent({
+          button: 0,
+          detail: 1,
+          clientX: clientLeftForCharacter(component, 10, 0),
+          clientY: clientTopForLine(component, 10)
+        })
+        component.didMouseDownOnContent({
+          button: 1,
+          clientX: clientLeftForCharacter(component, 10, 0),
+          clientY: clientTopForLine(component, 10)
+        })
+        expect(editor.lineTextForBufferRow(10)).toBe('var')
       })
     })
 

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1553,7 +1553,12 @@ class TextEditorComponent {
   }
 
   didPaste (event) {
-    // TODO Explain the motivation for this logic
+    // On Linux, Chromium translates a middle-button mouse click into a
+    // mousedown event *and* a paste event. Since Atom supports the middle mouse
+    // click as a way of closing a tab, we only want the mousedown event, not
+    // the paste event. And since we don't use the `paste` event for any
+    // behavior in Atom, we can no-op the event to eliminate this issue.
+    // See https://github.com/atom/atom/pull/15183#issue-248432413.
     if (this.getPlatform() === 'linux') event.preventDefault()
   }
 

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -70,6 +70,7 @@ class TextEditorComponent {
     this.updateSync = this.updateSync.bind(this)
     this.didBlurHiddenInput = this.didBlurHiddenInput.bind(this)
     this.didFocusHiddenInput = this.didFocusHiddenInput.bind(this)
+    this.didPaste = this.didPaste.bind(this)
     this.didTextInput = this.didTextInput.bind(this)
     this.didKeydown = this.didKeydown.bind(this)
     this.didKeyup = this.didKeyup.bind(this)
@@ -1553,7 +1554,7 @@ class TextEditorComponent {
 
   didPaste (event) {
     // TODO Explain the motivation for this logic
-    if ((this.props.platform || process.platform) === 'linux') event.preventDefault()
+    if (this.getPlatform() === 'linux') event.preventDefault()
   }
 
   didTextInput (event) {


### PR DESCRIPTION
Fixes atom/tabs#461
Fixes atom/tabs#52

---

On Linux, when the user performs a middle-button mouse click, Chromium fires both a `mousedown` event *and* a `paste` event. This PR teaches the `TextEditorComponent` to ignore the `paste` event.

When the user performs a middle-mouse click on a tab, we first get the `mousedown` event. In response to that event, we [close the tab and attempt to prevent Chromium's default processing for the event](https://github.com/atom/tabs/blob/ce1d92e0abb669155caa178bb71166b9f16f329a/lib/tab-bar-view.coffee#L416-L418). This prevents Chromium's default processing for the *`mousedown`* event, but then Chromium also fires a *`paste`* event, and that event pastes the clipboard's current content into the newly-focused text editor. 🤦

#14987 removed some of the middle-button mouse click handling related to pasting on Linux. This PR restores that logic and the related tests. (See `TextEditorComponent::didMouseDownOnContent(event)`.) With that change in place, since Atom already has its own logic for handling pasting, we shouldn't need to handle browser `paste` events. By ignoring the browser `paste` events on Linux, this PR fixes atom/tabs#461.

### TODO

- [x] Fix atom/tabs#461
- [x] Add test for `TextEditorComponent::didPaste(event)`
- [x] Address TODO in `TextEditorComponent::didPaste(event)` (https://github.com/atom/atom/pull/15183#discussion_r131672090)

### Test plan

- [x] Test on Ubuntu:
  - [x] Verify fix for https://github.com/atom/tabs/issues/461
  - [x] Verify the previous fix for https://github.com/atom/atom/issues/8648 is still intact
- [x] Test on macOS: Verify that the ctrl-click behavior fixed in https://github.com/atom/atom/pull/14987 is still intact
