### PR TITLE
Upgrade atom-keymap to fix caps lock issues on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@atom/source-map-support": "^0.3.4",
     "async": "0.2.6",
-    "atom-keymap": "8.2.2",
+    "atom-keymap": "8.2.3",
     "atom-select-list": "^0.1.0",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",


### PR DESCRIPTION
Includes the changes in https://github.com/atom/atom-keymap/pull/217