### PR TITLE
Update github to 0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "exception-reporting": "0.41.4",
     "find-and-replace": "0.209.5",
     "fuzzy-finder": "1.5.8",
-    "github": "0.4.1",
+    "github": "0.4.2",
     "git-diff": "1.3.6",
     "go-to-line": "0.32.1",
     "grammar-selector": "0.49.5",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "exception-reporting": "0.41.4",
     "find-and-replace": "0.209.5",
     "fuzzy-finder": "1.5.8",
-    "github": "0.4.0",
+    "github": "0.4.1",
     "git-diff": "1.3.6",
     "go-to-line": "0.32.1",
     "grammar-selector": "0.49.5",

--- a/script/package.json
+++ b/script/package.json
@@ -9,7 +9,7 @@
     "csslint": "1.0.2",
     "donna": "1.0.16",
     "electron-chromedriver": "~1.6",
-    "electron-link": "0.1.0",
+    "electron-link": "0.1.1",
     "electron-mksnapshot": "~1.6",
     "electron-packager": "7.3.0",
     "electron-winstaller": "2.6.2",


### PR DESCRIPTION
Doing this in a PR because it broke snapshotting, likely because 0.4.1 changes the way that dependencies are de-duped.