### PR TITLE
Separate tests and installer creation on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,8 +36,7 @@ install:
 
 build_script:
   - CD %APPVEYOR_BUILD_FOLDER%
-  - |
-    IF [%TASK%]==[installer] (
+  - IF [%TASK%]==[installer] (
       SET BUILD_ARG=--create-windows-installer
     ) ELSE (
       SET BUILD_ARG=
@@ -45,12 +44,11 @@ build_script:
   - script\build.cmd --code-sign --compress-artifacts %BUILD_ARG%
 
 test_script:
-  - |
-    IF [%TASK%]==[test] (
-      script\lint.cmd
+  - IF [%TASK%]==[test] (
+      script\lint.cmd &&
       script\test.cmd
     ) ELSE (
-      ECHO
+      ECHO Skipping tests
     )
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,13 @@ environment:
   global:
     ATOM_DEV_RESOURCE_PATH: c:\projects\atom
     TEST_JUNIT_XML_ROOT: c:\projects\junit-test-results
+    NODE_VERSION: 6.9.4
 
   matrix:
-  - NODE_VERSION: 6.9.4
+  - TASK: test
+    BUILD_ARG:
+  - TASK: installer
+    BUILD_ARG: --create-windows-installer
 
 matrix:
   fast_finish: true
@@ -34,14 +38,16 @@ install:
 
 build_script:
   - CD %APPVEYOR_BUILD_FOLDER%
-  - script\build.cmd --code-sign --compress-artifacts
+  - script\build.cmd --code-sign --compress-artifacts %BUILD_ARG%
 
 test_script:
-  - script\lint.cmd
-  - script\test.cmd
-
-after_test:
-  - IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] ( script\create-installer.cmd )
+  - |
+    IF [%TASK]==[test] (
+      script\lint.cmd
+      script\test.cmd
+    ) ELSE (
+      ECHO
+    )
 
 deploy: off
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ build_script:
 
 test_script:
   - |
-    IF [%TASK]==[test] (
+    IF [%TASK%]==[test] (
       script\lint.cmd
       script\test.cmd
     ) ELSE (

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ build_script:
       SET BUILD=yes &&
       ECHO "Skipping installer build on non-installer build matrix row"
     )
-  - IF [%BUILD]==[yes] (
+  - IF [%BUILD%]==[yes] (
       script\build.cmd --code-sign --compress-artifacts %BUILD_ARG%
     )
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,19 +38,13 @@ build_script:
   - CD %APPVEYOR_BUILD_FOLDER%
   - IF [%TASK%]==[installer] (
       IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] (
-        SET BUILD_ARG=--create-windows-installer &&
-        SET BUILD=yes
+        script\build.cmd --code-sign --compress-artifacts --create-windows-installer
       ) ELSE (
-        ECHO "Skipping installer and Atom build on non-release branch" &&
-        SET BUILD=no
+        ECHO Skipping installer and Atom build on non-release branch
       )
     ) ELSE (
-      SET BUILD_ARG= &&
-      SET BUILD=yes &&
-      ECHO "Skipping installer build on non-installer build matrix row"
-    )
-  - IF [%BUILD%]==[yes] (
-      script\build.cmd --code-sign --compress-artifacts %BUILD_ARG%
+      ECHO Skipping installer build on non-installer build matrix row &&
+      script\build.cmd --code-sign --compress-artifacts
     )
 
 test_script:
@@ -58,7 +52,7 @@ test_script:
       script\lint.cmd &&
       script\test.cmd
     ) ELSE (
-      ECHO Skipping tests
+      ECHO Skipping tests on installer build matrix row
     )
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,9 +37,14 @@ install:
 build_script:
   - CD %APPVEYOR_BUILD_FOLDER%
   - IF [%TASK%]==[installer] (
-      SET BUILD_ARG=--create-windows-installer
+      IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] (
+        SET BUILD_ARG=--create-windows-installer
+      ) ELSE (
+        ECHO "Skipping installer build on non-release branch"
+      )
     ) ELSE (
-      SET BUILD_ARG=
+      SET BUILD_ARG= &&
+      ECHO "Skipping installer build on non-installer build matrix row"
     )
   - script\build.cmd --code-sign --compress-artifacts %BUILD_ARG%
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,15 +38,20 @@ build_script:
   - CD %APPVEYOR_BUILD_FOLDER%
   - IF [%TASK%]==[installer] (
       IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] (
-        SET BUILD_ARG=--create-windows-installer
+        SET BUILD_ARG=--create-windows-installer &&
+        SET BUILD=yes
       ) ELSE (
-        ECHO "Skipping installer build on non-release branch"
+        ECHO "Skipping installer and Atom build on non-release branch" &&
+        SET BUILD=no
       )
     ) ELSE (
       SET BUILD_ARG= &&
+      SET BUILD=yes &&
       ECHO "Skipping installer build on non-installer build matrix row"
     )
-  - script\build.cmd --code-sign --compress-artifacts %BUILD_ARG%
+  - IF [%BUILD]==[yes] (
+      script\build.cmd --code-sign --compress-artifacts %BUILD_ARG%
+    )
 
 test_script:
   - IF [%TASK%]==[test] (

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,9 +23,7 @@ environment:
 
   matrix:
   - TASK: test
-    BUILD_ARG:
   - TASK: installer
-    BUILD_ARG: --create-windows-installer
 
 matrix:
   fast_finish: true
@@ -38,6 +36,12 @@ install:
 
 build_script:
   - CD %APPVEYOR_BUILD_FOLDER%
+  - |
+    IF [%TASK%]==[installer] (
+      SET BUILD_ARG=--create-windows-installer
+    ) ELSE (
+      SET BUILD_ARG=
+    )
   - script\build.cmd --code-sign --compress-artifacts %BUILD_ARG%
 
 test_script:


### PR DESCRIPTION
Let's try using a build matrix to split installer creation into a different job than the linting and tests. Hopefully this will help us sneak builds in under the AppVeyor time cutoff.