### PR TITLE
Debug missing snapshot auxiliary data

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,6 +57,8 @@ artifacts:
     name: atom-delta.nupkg
   - path: out\atom-*-full.nupkg
     name: atom-full.nupkg
+  - path: out\startup.js
+    name: startup.js
 
 cache:
   - '%APPVEYOR_BUILD_FOLDER%\electron'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,11 +37,13 @@ build_script:
   - script\build.cmd --code-sign --compress-artifacts
 
 test_script:
-- script\lint.cmd
-- script\test.cmd
+# - script\lint.cmd
+# - script\test.cmd
+ - ECHO lol nope
 
 after_test:
-  - IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] ( script\create-installer.cmd )
+  # - IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] ( script\create-installer.cmd )
+  # - script\create-installer.cmd
 
 deploy: off
 artifacts:

--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -11,6 +11,8 @@ module.exports = function (packagedAppPath) {
   const baseDirPath = path.join(CONFIG.intermediateAppPath, 'static')
   let processedFiles = 0
 
+  console.log(`Creating snapshot with auxiliary data containing: ${Object.keys(CONFIG.snapshotAuxiliaryData)}`)
+
   return electronLink({
     baseDirPath,
     mainPath: path.resolve(baseDirPath, '..', 'src', 'initialize-application-window.js'),

--- a/script/lib/prebuild-less-cache.js
+++ b/script/lib/prebuild-less-cache.js
@@ -67,7 +67,7 @@ module.exports = function () {
         const relativeImportPath = path.relative(CONFIG.intermediateAppPath, absoluteImportPath)
         if (!CONFIG.snapshotAuxiliaryData.importedFilePathsByRelativeImportPath.hasOwnProperty(relativeImportPath)) {
           CONFIG.snapshotAuxiliaryData.importedFilePathsByRelativeImportPath[relativeImportPath] = []
-          console.log(`Adding ${relativeFilePath} to snapshot auxiliary data importedFilePathsByRelativeImportPath`)
+          console.log(`Adding ${relativeImportPath} to snapshot auxiliary data importedFilePathsByRelativeImportPath`)
           for (const importedFile of klawSync(absoluteImportPath, {nodir: true})) {
             CONFIG.snapshotAuxiliaryData.importedFilePathsByRelativeImportPath[relativeImportPath].push(
               path.relative(CONFIG.intermediateAppPath, importedFile.path)

--- a/script/lib/prebuild-less-cache.js
+++ b/script/lib/prebuild-less-cache.js
@@ -29,10 +29,12 @@ module.exports = function () {
     }
   }
 
+  console.log('Initializing lessSourcesByRelativeFilePath')
   CONFIG.snapshotAuxiliaryData.lessSourcesByRelativeFilePath = {}
   function saveIntoSnapshotAuxiliaryData (absoluteFilePath, content) {
     const relativeFilePath = path.relative(CONFIG.intermediateAppPath, absoluteFilePath)
     if (!CONFIG.snapshotAuxiliaryData.lessSourcesByRelativeFilePath.hasOwnProperty(relativeFilePath)) {
+      console.log(`Adding ${relativeFilePath} to snapshot auxiliary data lessSourcesByRelativeFilePath`)
       CONFIG.snapshotAuxiliaryData.lessSourcesByRelativeFilePath[relativeFilePath] = {
         content: content,
         digest: LessCache.digestForContent(content)
@@ -40,6 +42,7 @@ module.exports = function () {
     }
   }
 
+  console.log('Initializing importedFilePathsByRelativeImportPath')
   CONFIG.snapshotAuxiliaryData.importedFilePathsByRelativeImportPath = {}
   // Warm cache for every combination of the default UI and syntax themes,
   // because themes assign variables which may be used in any style sheet.
@@ -64,6 +67,7 @@ module.exports = function () {
         const relativeImportPath = path.relative(CONFIG.intermediateAppPath, absoluteImportPath)
         if (!CONFIG.snapshotAuxiliaryData.importedFilePathsByRelativeImportPath.hasOwnProperty(relativeImportPath)) {
           CONFIG.snapshotAuxiliaryData.importedFilePathsByRelativeImportPath[relativeImportPath] = []
+          console.log(`Adding ${relativeFilePath} to snapshot auxiliary data importedFilePathsByRelativeImportPath`)
           for (const importedFile of klawSync(absoluteImportPath, {nodir: true})) {
             CONFIG.snapshotAuxiliaryData.importedFilePathsByRelativeImportPath[relativeImportPath].push(
               path.relative(CONFIG.intermediateAppPath, importedFile.path)
@@ -104,7 +108,9 @@ module.exports = function () {
     }
   }
 
+  console.log('about to scan for less files')
   for (let lessFilePath of glob.sync(path.join(CONFIG.intermediateAppPath, 'node_modules', 'atom-ui', '**', '*.less'))) {
+    console.log(`saving ${lessFilePath}`)
     saveIntoSnapshotAuxiliaryData(lessFilePath, fs.readFileSync(lessFilePath, 'utf8'))
   }
 


### PR DESCRIPTION
Let's do some in-CI debugging to see where our snapshot auxiliary data (notable, the Less compile cache) is getting dropped.