### PR TITLE
Set multiline flags for out-of-Atom regex replacements

### DIFF
--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2395,13 +2395,13 @@ i = /test/; #FIXME\
         })
       })
 
-      it('uses the multiline flag when searching', () => {
+      it('does not discard the multiline flag', () => {
         const filePath = path.join(projectDir, 'sample.js')
         fs.copyFileSync(path.join(fixturesDir, 'sample.js'), filePath)
 
         const results = []
         waitsForPromise(() =>
-          atom.workspace.replace(/;$/gi, 'items', [filePath], result => results.push(result))
+          atom.workspace.replace(/;$/gmi, 'items', [filePath], result => results.push(result))
         )
 
         runs(() => {

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2394,6 +2394,22 @@ i = /test/; #FIXME\
           expect(results[0].replacements).toBe(6)
         })
       })
+
+      it('uses the multiline flag when searching', () => {
+        const filePath = path.join(projectDir, 'sample.js')
+        fs.copyFileSync(path.join(fixturesDir, 'sample.js'), filePath)
+
+        const results = []
+        waitsForPromise(() =>
+          atom.workspace.replace(/;$/gi, 'items', [filePath], result => results.push(result))
+        )
+
+        runs(() => {
+          expect(results).toHaveLength(1)
+          expect(results[0].filePath).toBe(filePath)
+          expect(results[0].replacements).toBe(8)
+        })
+      })
     })
 
     describe('when a buffer is already open', () => {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1949,7 +1949,8 @@ module.exports = class Workspace extends Model {
       }
 
       if (!outOfProcessFinished.length) {
-        let flags = 'gm' // set multiline flag so ^ and $ match start/end of line, not file
+        let flags = 'g'
+        if (regex.multiline) { flags += 'm' }
         if (regex.ignoreCase) { flags += 'i' }
 
         const task = Task.once(

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1949,7 +1949,7 @@ module.exports = class Workspace extends Model {
       }
 
       if (!outOfProcessFinished.length) {
-        let flags = 'g'
+        let flags = 'gm' // set multiline flag so ^ and $ match start/end of line, not file
         if (regex.ignoreCase) { flags += 'i' }
 
         const task = Task.once(


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

A very simple one-liner.  The `m` flag wasn't being added when doing a regex replacement on files not opened in Atom.  For those who aren't aware, `m` changes the meaning of `^` and `$` to mean "begin/end of line", rather than "begin/end of string" (which can be generalized to "begin/end of file" in Atom's case).  The behavior that `m` introduces is consistent with what most developers view `^` and `$` as, and is also what find-and-replace visually shows in the results view.  Therefore, this change fixes the discrepancy between the visual, expected result and the actual result when the regex contains a `^` or `$` and the matched string is not the first/last line in the file.

text-buffer already adds the `m` flag when replacing files inside of Atom.
https://github.com/atom/text-buffer/blob/bb9134fc93713273dcccafd9e917e00f1f2f58cc/src/text-buffer.coffee#L1326

### Alternate Designs

None.

### Why Should This Be In Core?

`atom.workspace.replace()` is a public API.

### Benefits

When searching with a regex that contains a `^` or `$`, replacements should now work as expected.

### Possible Drawbacks

There is one drawback: there is no way to return to the non-multiline behavior of `^` and `$` once the flag is set.  JavaScript does not yet support `\A` and `\Z`.

### Applicable Issues

Refs atom/find-and-replace#622