### PR TITLE
Shim rowsPerPage property on Editor instances

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -3527,6 +3527,10 @@ class TextEditor extends Model
     else
       1
 
+  Object.defineProperty(@prototype, 'rowsPerPage', {
+    get: -> @getRowsPerPage()
+  })
+
   ###
   Section: Config
   ###


### PR DESCRIPTION
Several packages were relying on a raw property rather than the getter method. This isn't really officially supported, but may as well keep them working.

Fixes https://github.com/callum-ramage/ctrl-dir-scroll/issues/28