### PR TITLE
Suppress composition events default prevented on previous keydown

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1570,6 +1570,10 @@ class TextEditorComponent {
   }
 
   didTextInput (event) {
+    // Workaround for Chromium not preventing composition events when
+    // preventDefault is called on the keydown event that precipitated them.
+    if (this.lastKeydown && this.lastKeydown.defaultPrevented) return
+
     if (!this.isInputEnabled()) return
 
     event.stopPropagation()
@@ -1626,7 +1630,6 @@ class TextEditorComponent {
 
   didKeypress (event) {
     this.lastKeydownBeforeKeypress = this.lastKeydown
-    this.lastKeydown = null
 
     // This cancels the accented character behavior if we type a key normally
     // with the menu open.
@@ -1636,7 +1639,6 @@ class TextEditorComponent {
   didKeyup (event) {
     if (this.lastKeydownBeforeKeypress && this.lastKeydownBeforeKeypress.code === event.code) {
       this.lastKeydownBeforeKeypress = null
-      this.lastKeydown = null
     }
   }
 
@@ -1662,6 +1664,10 @@ class TextEditorComponent {
   }
 
   didCompositionUpdate (event) {
+    // Workaround for Chromium not preventing composition events when
+    // preventDefault is called on the keydown event that precipitated them.
+    if (this.lastKeydown && this.lastKeydown.defaultPrevented) return
+
     if (this.getChromeVersion() === 56) {
       process.nextTick(() => {
         if (this.compositionCheckpoint) {


### PR DESCRIPTION
Fixes #15189

It seems like Chrome 56 has a regression that causes `compositionstart` and `compositionupdate` events to still be fired even if `preventDefault` is called on the original `keydown` event. This PR introduces a workaround that suppresses handling of these events if `defaultPrevented` is true on the most recent `keydown` event.

/cc @Ben3eeE @ungb 