### PR TITLE
Fix measuring lines in presence of pending autoscroll requests

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -3399,6 +3399,15 @@ describe('TextEditorComponent', () => {
         expect(top).toBe(clientTopForLine(referenceComponent, 12) - referenceContentRect.top)
         expect(left).toBe(clientLeftForCharacter(referenceComponent, 12, 1) - referenceContentRect.left)
       }
+
+      // Measuring a currently rendered line while an autoscroll that causes
+      // that line to go off-screen is in progress.
+      {
+        editor.setCursorScreenPosition([10, 0])
+        const {top, left} = component.pixelPositionForScreenPosition({row: 3, column: 5})
+        expect(top).toBe(clientTopForLine(referenceComponent, 3) - referenceContentRect.top)
+        expect(left).toBe(clientLeftForCharacter(referenceComponent, 3, 5) - referenceContentRect.left)
+      }
     })
 
     it('does not get the component into an inconsistent state when the model has unflushed changes (regression)', async () => {
@@ -3444,6 +3453,16 @@ describe('TextEditorComponent', () => {
         pixelPosition.top += component.getLineHeight() / 3
         pixelPosition.left += component.getBaseCharacterWidth() / 3
         expect(component.screenPositionForPixelPosition(pixelPosition)).toEqual([12, 1])
+      }
+
+      // Measuring a currently rendered line while an autoscroll that causes
+      // that line to go off-screen is in progress.
+      {
+        const pixelPosition = referenceComponent.pixelPositionForScreenPosition({row: 3, column: 4})
+        pixelPosition.top += component.getLineHeight() / 3
+        pixelPosition.left += component.getBaseCharacterWidth() / 3
+        editor.setCursorBufferPosition([10, 0])
+        expect(component.screenPositionForPixelPosition(pixelPosition)).toEqual([3, 4])
       }
     })
   })


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15168.

Calling `pixelPositionForScreenPosition` was sometimes throwing an error indicating that the requested position was not rendered and that, as such, could not be measured.

This was caused by trying to measure a line that was visible at the moment of the call while also having a pending autoscroll request that would cause that line to go off-screen. Due to how the code was structured, we would mistakenly detect that line as visible, autoscroll to a different location, re-render a different region of the buffer and then try to measure the now invisible line.

This commit fixes this issue by restructuring and simplifying the logic for rendering invisible lines in order to measure them. Now, every line for which a measurement has been requested is stored in a `linesToMeasure` map. During the first phase of the update process (after honoring autoscroll requests), we detect which of these lines are currently visible and if some of them are not, we store them into the `extraRenderedScreenLines` map, which is then used to render lines that are invisible but need measurement.

@Ben3eeE @ungb: I am unable to reproduce the issue after this pull-request. Can you help me ensure this fixes all the reports we've got for this issue so far? They seem to be generated by slightly different reproduction steps, although I think they can all be traced back to the root cause described above.

/cc: @nathansobo for 👀 
