### PR TITLE
Use default cursor on dummy scrollbars and make them 15px wide/tall

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2851,20 +2851,22 @@ class DummyScrollbarComponent {
       outerStyle.bottom = 0
       outerStyle.left = 0
       outerStyle.right = right + 'px'
-      outerStyle.height = '20px'
+      outerStyle.height = '15px'
       outerStyle.overflowY = 'hidden'
       outerStyle.overflowX = this.props.forceScrollbarVisible ? 'scroll' : 'auto'
-      innerStyle.height = '20px'
+      outerStyle.cursor = 'default'
+      innerStyle.height = '15px'
       innerStyle.width = (this.props.scrollWidth || 0) + 'px'
     } else {
       let bottom = (this.props.horizontalScrollbarHeight || 0)
       outerStyle.right = 0
       outerStyle.top = 0
       outerStyle.bottom = bottom + 'px'
-      outerStyle.width = '20px'
+      outerStyle.width = '15px'
       outerStyle.overflowX = 'hidden'
       outerStyle.overflowY = this.props.forceScrollbarVisible ? 'scroll' : 'auto'
-      innerStyle.width = '20px'
+      outerStyle.cursor = 'default'
+      innerStyle.width = '15px'
       innerStyle.height = (this.props.scrollHeight || 0) + 'px'
     }
 


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15166.

This restores scrollbars to adopt the styling they had prior to #13880, as you can see in the below CSS excerpt from Atom 1.18.0.

https://github.com/atom/atom/blob/783cda8642e42e842a7aac761f267e151f3db324/static/text-editor-light.less#L170-L198

@nathansobo: do you recall the reason why changed the styling to `20px`? I couldn't find an explanation on the commit that introduced them, so I went ahead and created this pull-request.

Also, /cc: @ungb and @Ben3eeE for help on testing this and making sure it restores the original behavior.