### PR TITLE
Remove unused methods to translate legacy menu items

### DIFF
--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -176,27 +176,6 @@ class ContextMenuManager
         .filter((submenuItem) -> submenuItem isnt null)
     return item
 
-  convertLegacyItemsBySelector: (legacyItemsBySelector, devMode) ->
-    itemsBySelector = {}
-
-    for selector, commandsByLabel of legacyItemsBySelector
-      itemsBySelector[selector] = @convertLegacyItems(commandsByLabel, devMode)
-
-    itemsBySelector
-
-  convertLegacyItems: (legacyItems, devMode) ->
-    items = []
-
-    for label, commandOrSubmenu of legacyItems
-      if typeof commandOrSubmenu is 'object'
-        items.push({label, submenu: @convertLegacyItems(commandOrSubmenu, devMode), devMode})
-      else if commandOrSubmenu is '-'
-        items.push({type: 'separator'})
-      else
-        items.push({label, command: commandOrSubmenu, devMode})
-
-    items
-
   showForEvent: (event) ->
     @activeElement = event.target
     menuTemplate = @templateForEvent(event)


### PR DESCRIPTION
Searching the code base and the GitHub repository shows no usage or
documentation for these two methods.

From what I can surmise, the call to `convertLegacyItemsBySelector` was removed
in https://github.com/atom/atom/commit/cc4ee926993edc479a1624b269d0c159608f1399
by @thomasjo but these methods just weren't cleaned up.