### PR TITLE
Fix IME composition preview for new editors

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1670,7 +1670,7 @@ class TextEditorComponent {
 
     if (this.getChromeVersion() === 56) {
       process.nextTick(() => {
-        if (this.compositionCheckpoint) {
+        if (this.compositionCheckpoint != null) {
           const previewText = this.getHiddenInput().value
           this.props.model.insertText(previewText, {select: true})
         }


### PR DESCRIPTION
Composition checkpoints are actually *numbers*, and the first checkpoint starts at `0`, which was previously being detected as falsy. The fix is to null check the composition checkpoint explicitly.

/cc @Ben3eeE @as-cii 