### PR TITLE
Always render hidden input

### DIFF
--- a/spec/text-editor-element-spec.js
+++ b/spec/text-editor-element-spec.js
@@ -203,6 +203,22 @@ describe('TextEditorElement', () => {
         expect(document.activeElement).toBe(element.querySelector('input'))
       })
     })
+
+    describe('if focused when invisible due to a zero height and width', () => {
+      it('focuses the hidden input and does not throw an exception', () => {
+        const parentElement = document.createElement('div')
+        parentElement.style.position = 'absolute'
+        parentElement.style.width = '0px'
+        parentElement.style.height = '0px'
+
+        const element = buildTextEditorElement({attach: false})
+        parentElement.appendChild(element)
+        jasmineContent.appendChild(parentElement)
+
+        element.focus()
+        expect(document.activeElement).toBe(element.component.getHiddenInput())
+      })
+    })
   })
 
   describe('::setModel', () => {

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -552,6 +552,7 @@ class TextEditorComponent {
       ]
     } else {
       children = [
+        this.renderCursorsAndInput(),
         this.renderBlockDecorationMeasurementArea(),
         this.renderCharacterMeasurementLine()
       ]
@@ -1449,16 +1450,14 @@ class TextEditorComponent {
       this.scheduleUpdate()
     }
 
-    const {hiddenInput} = this.refs.cursorsAndInput.refs
-    hiddenInput.focus()
+    this.getHiddenInput().focus()
   }
 
   // Called by TextEditorElement so that this function is always the first
   // listener to be fired, even if other listeners are bound before creating
   // the component.
   didBlur (event) {
-    const {cursorsAndInput} = this.refs
-    if (cursorsAndInput && event.relatedTarget === cursorsAndInput.refs.hiddenInput) {
+    if (event.relatedTarget === this.getHiddenInput()) {
       event.stopImmediatePropagation()
     }
   }


### PR DESCRIPTION
Fixes https://github.com/atom/notifications/issues/167
Fixes https://github.com/atom/atom/issues/15227

This avoids mysterious timing issues in which the editor gets a `focus` event in a state where `isVisible` returns false. If we always render the hidden input, we can always focus it. We still don't quite understand why things get into this state, but with this change we don't really need to.
