### PR TITLE
Simplify `didFocus` logic in `TextEditorComponent`

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1656,15 +1656,6 @@ module.exports = class TextEditorComponent {
   // Called by TextEditorElement so that focus events can be handled before
   // the element is attached to the DOM.
   didFocus() {
-    // This element can be focused from a parent custom element's
-    // attachedCallback before *its* attachedCallback is fired. This protects
-    // against that case.
-    if (!this.attached) this.didAttach();
-
-    // The element can be focused before the intersection observer detects that
-    // it has been shown for the first time. If this element is being focused,
-    // it is necessarily visible, so we call `didShow` to ensure the hidden
-    // input is rendered before we try to shift focus to it.
     if (!this.visible) this.didShow();
 
     if (!this.focused) {


### PR DESCRIPTION
Prior to #15302, we wanted to make sure the component had rendered the hidden input when receiving the focus event. To do so, we added some workarounds for scenarios where the focus event was triggered before the component had the chance to detect it was attached or visible.

After that pull-request, however, we always render the hidden input independently of which events the component has observed, thus making those workarounds not necessary anymore.

Please, note that we decided not to include this pull-request's changes in #15302 because we didn't feel comfortable hotfixing them to stable and beta, and want to let them bake for a full release cycle instead.

/cc: @nathansobo 