### PR TITLE
Move placeholder text inside lines div

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -486,8 +486,8 @@ describe('TextEditorComponent', () => {
       verifyCursorPosition(component, element.querySelector('.cursor'), 0, 4)
     })
 
-    it('positions cursors correctly when the lines container has a margin and/or is padded', async () => {
-      const {component, element, editor} = buildComponent()
+    it('positions cursors and placeholder text correctly when the lines container has a margin and/or is padded', async () => {
+      const {component, element, editor} = buildComponent({placeholderText: 'testing'})
 
       component.refs.lineTiles.style.marginLeft = '10px'
       TextEditor.didUpdateStyles()
@@ -510,6 +510,13 @@ describe('TextEditorComponent', () => {
       TextEditor.didUpdateStyles()
       await component.getNextUpdatePromise()
       verifyCursorPosition(component, element.querySelector('.cursor'), 2, 2)
+
+      editor.setText('')
+      await component.getNextUpdatePromise()
+
+      const placeholderTextLeft = element.querySelector('.placeholder-text').getBoundingClientRect().left
+      const linesLeft = component.refs.lineTiles.getBoundingClientRect().left
+      expect(placeholderTextLeft).toBe(linesLeft)
     })
 
     it('places the hidden input element at the location of the last cursor if it is visible', async () => {

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -551,8 +551,7 @@ class TextEditorComponent {
       children = [
         this.renderLineTiles(),
         this.renderBlockDecorationMeasurementArea(),
-        this.renderCharacterMeasurementLine(),
-        this.renderPlaceholderText()
+        this.renderCharacterMeasurementLine()
       ]
     } else {
       children = [
@@ -633,6 +632,7 @@ class TextEditorComponent {
       style.height = this.getScrollHeight() + 'px'
     }
 
+    children.push(this.renderPlaceholderText())
     children.push(this.renderCursorsAndInput())
 
     return $.div(


### PR DESCRIPTION
Following up on #15317, we need to move the placeholder text inside the lines div so that it aligns with the cursor in the event that themes apply padding or margin to the lines div.

/cc @as-cii @Ben3eeE 