### PR TITLE
Only scroll one axis at a time, whichever has the greater delta

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1133,41 +1133,45 @@ describe('TextEditorComponent', () => {
   })
 
   describe('scrolling via the mouse wheel', () => {
-    it('scrolls vertically when deltaY is not 0', () => {
+    it('scrolls vertically or horizontally depending on whether deltaX or deltaY is larger', () => {
       const scrollSensitivity = 30
-      const {component, editor} = buildComponent({height: 50, scrollSensitivity})
+      const {component, editor} = buildComponent({height: 50, width: 50, scrollSensitivity})
 
       {
         const expectedScrollTop = 20 * (scrollSensitivity / 100)
-        component.didMouseWheel({deltaX: 0, deltaY: 20})
+        const expectedScrollLeft = component.getScrollLeft()
+        component.didMouseWheel({deltaX: 5, deltaY: 20})
         expect(component.getScrollTop()).toBe(expectedScrollTop)
-        expect(component.refs.content.style.transform).toBe(`translate(0px, -${expectedScrollTop}px)`)
+        expect(component.getScrollLeft()).toBe(expectedScrollLeft)
+        expect(component.refs.content.style.transform).toBe(`translate(${-expectedScrollLeft}px, ${-expectedScrollTop}px)`)
       }
 
       {
         const expectedScrollTop = component.getScrollTop() - (10 * (scrollSensitivity / 100))
-        component.didMouseWheel({deltaX: 0, deltaY: -10})
+        const expectedScrollLeft = component.getScrollLeft()
+        component.didMouseWheel({deltaX: 5, deltaY: -10})
         expect(component.getScrollTop()).toBe(expectedScrollTop)
-        expect(component.refs.content.style.transform).toBe(`translate(0px, -${expectedScrollTop}px)`)
+        expect(component.getScrollLeft()).toBe(expectedScrollLeft)
+        expect(component.refs.content.style.transform).toBe(`translate(${-expectedScrollLeft}px, ${-expectedScrollTop}px)`)
       }
-    })
-
-    it('scrolls horizontally when deltaX is not 0', () => {
-      const scrollSensitivity = 60
-      const {component, editor} = buildComponent({width: 50, scrollSensitivity})
 
       {
+        global.debug = true
+        const expectedScrollTop = component.getScrollTop()
         const expectedScrollLeft = 20 * (scrollSensitivity / 100)
-        component.didMouseWheel({deltaX: 20, deltaY: 0})
+        component.didMouseWheel({deltaX: 20, deltaY: -10})
+        expect(component.getScrollTop()).toBe(expectedScrollTop)
         expect(component.getScrollLeft()).toBe(expectedScrollLeft)
-        expect(component.refs.content.style.transform).toBe(`translate(-${expectedScrollLeft}px, 0px)`)
+        expect(component.refs.content.style.transform).toBe(`translate(${-expectedScrollLeft}px, ${-expectedScrollTop}px)`)
       }
 
       {
+        const expectedScrollTop = component.getScrollTop()
         const expectedScrollLeft = component.getScrollLeft() - (10 * (scrollSensitivity / 100))
-        component.didMouseWheel({deltaX: -10, deltaY: 0})
+        component.didMouseWheel({deltaX: -10, deltaY: 8})
+        expect(component.getScrollTop()).toBe(expectedScrollTop)
         expect(component.getScrollLeft()).toBe(expectedScrollLeft)
-        expect(component.refs.content.style.transform).toBe(`translate(-${expectedScrollLeft}px, 0px)`)
+        expect(component.refs.content.style.transform).toBe(`translate(${-expectedScrollLeft}px, ${-expectedScrollTop}px)`)
       }
     })
 

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1496,8 +1496,14 @@ class TextEditorComponent {
     const scrollSensitivity = this.props.model.getScrollSensitivity() / 100
 
     let {deltaX, deltaY} = event
-    deltaX = deltaX * scrollSensitivity
-    deltaY = deltaY * scrollSensitivity
+
+    if (Math.abs(deltaX) > Math.abs(deltaY)) {
+      deltaX = deltaX * scrollSensitivity
+      deltaY = 0
+    } else {
+      deltaX = 0
+      deltaY = deltaY * scrollSensitivity
+    }
 
     if (this.getPlatform() !== 'darwin' && event.shiftKey) {
       let temp = deltaX
@@ -1505,11 +1511,10 @@ class TextEditorComponent {
       deltaY = temp
     }
 
-    const scrollPositionChanged =
-      this.setScrollLeft(this.getScrollLeft() + deltaX) ||
-      this.setScrollTop(this.getScrollTop() + deltaY)
+    const scrollLeftChanged = deltaX !== 0 && this.setScrollLeft(this.getScrollLeft() + deltaX)
+    const scrollTopChanged = deltaY !== 0 && this.setScrollTop(this.getScrollTop() + deltaY)
 
-    if (scrollPositionChanged) this.updateSync()
+    if (scrollLeftChanged || scrollTopChanged) this.updateSync()
   }
 
   didResize () {


### PR DESCRIPTION
Fixes #15239

This PR fixes a logic error in the following line of code:

```js
const scrollPositionChanged =
  this.setScrollLeft(this.getScrollLeft() + deltaX) ||
  this.setScrollTop(this.getScrollTop() + deltaY)
```

I didn't account for the "short-circuit" behavior of the or statement. With this code, we first attempt to scroll horizontally by `deltaX`, and if we scroll even a little, then we never attempt to scroll vertically. When I tested this originally, I thought we were getting the "one axis at a time" behavior automatically somehow, but really I was just seeing this bug. 🙈 

This PR restores the behavior prior to 1.19 of scrolling only on one axis at a time, whichever has the greater delta.