### PR TITLE
:arrow_up: autocomplete-plus

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "autocomplete-atom-api": "0.10.2",
     "autocomplete-css": "0.17.2",
     "autocomplete-html": "0.8.0",
-    "autocomplete-plus": "2.35.7",
+    "autocomplete-plus": "2.35.8",
     "autocomplete-snippets": "1.11.0",
     "autoflow": "0.29.0",
     "autosave": "0.24.3",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "autocomplete-css": "0.17.2",
     "autocomplete-html": "0.8.0",
     "autocomplete-plus": "2.35.8",
-    "autocomplete-snippets": "1.11.0",
+    "autocomplete-snippets": "1.11.1",
     "autoflow": "0.29.0",
     "autosave": "0.24.3",
     "background-tips": "0.27.1",


### PR DESCRIPTION
Update autocomplete-plus package on atom/atom.  Seems like test failure were occurring on master.  Creating PR to address test failures before merging.


see:
https://circleci.com/gh/atom/atom/4747?utm_campaign=chatroom-integration&utm_medium=referral&utm_source=slack

Changes that went in for `autocomplete-plus` between 2.35.7 -> 2.35.8:
(https://github.com/atom/autocomplete-plus/compare/58beee8bdfa4281e5900578d0f4f2dc1053cb00f...master)


- [x] Fix test failures

/cc @simurai 