### PR TITLE
Hide off-screen lines when we render them for measurement

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -3765,6 +3765,22 @@ describe('TextEditorComponent', () => {
       component.screenPositionForPixelPosition({top: 800, left: 1})
       await updatePromise
     })
+
+    it('does not shift cursors downward or render off-screen content when measuring off-screen lines (regression)', async () => {
+      const {component, element, editor} = buildComponent({rowsPerTile: 2, autoHeight: false})
+      await setEditorHeightInLines(component, 3)
+      const {top, left} = component.pixelPositionForScreenPosition({row: 12, column: 1})
+
+      expect(element.querySelector('.cursor').getBoundingClientRect().top).toBe(component.refs.lineTiles.getBoundingClientRect().top)
+      expect(element.querySelector('.line[data-screen-row="12"]').style.visibility).toBe('hidden')
+
+      // Ensure previously measured off screen lines don't have any weird
+      // styling when they come on screen in the next frame
+      await setEditorHeightInLines(component, 13)
+      const previouslyMeasuredLineElement = element.querySelector('.line[data-screen-row="12"]')
+      expect(previouslyMeasuredLineElement.style.display).toBe('')
+      expect(previouslyMeasuredLineElement.style.visibility).toBe('')
+    })
   })
 
   describe('screenPositionForPixelPosition', () => {

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -618,6 +618,7 @@ class TextEditorComponent {
         if (screenRow < startRow || screenRow >= endRow) {
           children.push($(LineComponent, {
             key: 'extra-' + screenLine.id,
+            hidden: true,
             screenLine,
             screenRow,
             displayLayer: this.props.model.displayLayer,
@@ -3863,10 +3864,15 @@ class LineComponent {
   }
 
   appendContents () {
-    const {displayLayer, nodePool, screenLine, textDecorations, textNodesByScreenLineId} = this.props
+    const {displayLayer, nodePool, hidden, screenLine, textDecorations, textNodesByScreenLineId} = this.props
 
     const textNodes = []
     textNodesByScreenLineId.set(screenLine.id, textNodes)
+
+    if (hidden) {
+      this.element.style.position = 'absolute'
+      this.element.style.visibility = 'hidden'
+    }
 
     const {lineText, tags} = screenLine
     let openScopeNode = nodePool.getElement('SPAN', null, null)


### PR DESCRIPTION
Previously, we weren't hiding off-screen lines that we rendered for measurement. That could cause flickering artifacts like the one below when re-triggering measurements, as well as the cursors div being pushed down momentarily.

![](https://user-images.githubusercontent.com/1058982/29333256-63dfdf1e-8203-11e7-9587-bccb69c4377a.gif)

/cc @as-cii @Ben3eeE 