### PR TITLE
Only clear linesToMeasure when we have actually measured

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -117,6 +117,22 @@ describe('TextEditorComponent', () => {
         )
         expect(actualWidth).toBe(expectedWidth + 'px')
       }
+
+      {
+        // Make sure we do not throw an error if a synchronous update is
+        // triggered before measuring the longest line from a
+        // previously-scheduled update.
+        editor.getBuffer().insert(Point(12, Infinity), 'x'.repeat(100))
+        expect(editor.getLongestScreenRow()).toBe(12)
+
+        TextEditorComponent.getScheduler().readDocument(() => {
+          // This will happen before the measurement phase of the update
+          // triggered above.
+          component.pixelPositionForScreenPosition(Point(11, Infinity))
+        })
+
+        await component.getNextUpdatePromise()
+      }
     })
 
     it('re-renders lines when their height changes', async () => {

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -32,6 +32,10 @@ class TextEditorComponent {
     etch.setScheduler(scheduler)
   }
 
+  static getScheduler () {
+    return etch.getScheduler()
+  }
+
   static didUpdateStyles () {
     if (this.attachedComponents) {
       this.attachedComponents.forEach((component) => {
@@ -389,6 +393,7 @@ class TextEditorComponent {
       this.pendingAutoscroll = null
     }
 
+    this.linesToMeasure.clear()
     this.measuredContent = true
   }
 
@@ -848,7 +853,6 @@ class TextEditorComponent {
         this.extraRenderedScreenLines.set(row, screenLine)
       }
     })
-    this.linesToMeasure.clear()
   }
 
   queryLineNumbersToRender () {


### PR DESCRIPTION
Fixes #15335

Previously, as soon as we decided to render linesToMeasure, we would clear them out. However, if a second update interleaved with the update that initially requested measurement, it could cause the requested lines to not be present when the measurement phase from the first update occurred. Now, any additional updates will only add to the set of lines that need to be measured until the measurement phase actually happens.

/cc @Ben3eeE @50Wliu @ungb 