### PR TITLE
Round return values of getMaxScrollTop, getScrollHeight

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -205,6 +205,23 @@ describe('TextEditorComponent', () => {
       expect(component.getFirstVisibleRow()).toBe(editor.getScreenLineCount() + 1)
     })
 
+    it('does not fire onDidChangeScrollTop listeners when assigning the same maximal value and the content height has fractional pixels (regression)', async () => {
+      const {component, element, editor} = buildComponent({autoHeight: false, autoWidth: false})
+      await setEditorHeightInLines(component, 3)
+
+      // Force a fractional content height with a block decoration
+      const item = document.createElement("div")
+      item.style.height = '10.6px'
+      editor.decorateMarker(editor.markBufferPosition([0, 0]), {type: "block", item})
+      await component.getNextUpdatePromise()
+
+      component.setScrollTop(Infinity)
+      element.onDidChangeScrollTop((newScrollTop) => {
+        throw new Error('Scroll top should not have changed')
+      })
+      component.setScrollTop(component.getScrollTop())
+    })
+
     it('gives the line number tiles an explicit width and height so their layout can be strictly contained', async () => {
       const {component, element, editor} = buildComponent({rowsPerTile: 3})
 

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2728,7 +2728,7 @@ class TextEditorComponent {
   }
 
   getMaxScrollTop () {
-    return Math.max(0, this.getScrollHeight() - this.getScrollContainerClientHeight())
+    return Math.round(Math.max(0, this.getScrollHeight() - this.getScrollContainerClientHeight()))
   }
 
   getScrollBottom () {
@@ -2756,7 +2756,7 @@ class TextEditorComponent {
   }
 
   getMaxScrollLeft () {
-    return Math.max(0, this.getScrollWidth() - this.getScrollContainerClientWidth())
+    return Math.round(Math.max(0, this.getScrollWidth() - this.getScrollContainerClientWidth()))
   }
 
   getScrollRight () {


### PR DESCRIPTION
Fixes #15343

If the current `scrollTop`/`scrollLeft` value exceeds the `maxScrollTop` / `maxScrollLeft`, we reassign the values to the max on read. This allows us to behave correctly when the editor has changed in dimensions or the content has changed since the scroll position was previously assigned.

Prior to this PR, we were applying `Math.round` to the scroll positions when assigning them but **not** rounding the values when reassigning them to the max.

In situations where the content height contains fractional pixels, this can lead to a fractional-pixel scroll position when scrolled all the way down/right which causes blurry text. This can also cause unexpected firing of `onDidChangeScrollTop` when the value isn't actually changing due to a decision to notify listeners based on a rounded-up value not matching a fractional clipped value, as was the case in #15343.

/cc @t9md @Ben3eeE 