### PR TITLE
Suppress default-prevented composition events on compositionstart instead of compositionupdate

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1671,17 +1671,6 @@ class TextEditorComponent {
   //   4. compositionend fired
   //   5. textInput fired; event.data == the completion string
   didCompositionStart () {
-    if (this.getChromeVersion() === 56) {
-      this.getHiddenInput().value = ''
-    }
-
-    this.compositionCheckpoint = this.props.model.createCheckpoint()
-    if (this.accentedCharacterMenuIsOpen) {
-      this.props.model.selectLeft()
-    }
-  }
-
-  didCompositionUpdate (event) {
     // Workaround for Chromium not preventing composition events when
     // preventDefault is called on the keydown event that precipitated them.
     if (this.lastKeydown && this.lastKeydown.defaultPrevented) {
@@ -1695,6 +1684,17 @@ class TextEditorComponent {
       return
     }
 
+    if (this.getChromeVersion() === 56) {
+      this.getHiddenInput().value = ''
+    }
+
+    this.compositionCheckpoint = this.props.model.createCheckpoint()
+    if (this.accentedCharacterMenuIsOpen) {
+      this.props.model.selectLeft()
+    }
+  }
+
+  didCompositionUpdate (event) {
     if (this.getChromeVersion() === 56) {
       process.nextTick(() => {
         if (this.compositionCheckpoint != null) {


### PR DESCRIPTION
Fixes #15344

In #15314, @as-cii found a workaround to composition events still firing after a default-prevented keydown event. Unfortunately, applying this workaround in the `compositionupdate` handler instead of the `compositionstart` handler meant we still created a composition checkpoint. Then, on the next input event, we detected the presence of this checkpoint and reverted to it, causing the cursor to move as in #15344.

This PR moves the same logic from #15314 to `compositionstart` and avoids creation of a composition checkpoint following a default-prevented keydown event.

/cc @as-cii @ungb @Ben3eeE 