### PR TITLE
Use capture phase for mouseup handler

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1887,7 +1887,7 @@ class TextEditorComponent {
     }
 
     window.addEventListener('mousemove', didMouseMove)
-    window.addEventListener('mouseup', didMouseUp)
+    window.addEventListener('mouseup', didMouseUp, {capture: true})
   }
 
   autoscrollOnMouseDrag ({clientX, clientY}, verticalOnly = false) {


### PR DESCRIPTION
Fixes #15295

This ensures that we always handle the mouseup even if the mouse is outside of the editor when the button is released, and also fixes a weird interaction with the `atom-terminal-panel` package.