### PR TITLE
Ignore scroll requests to NaN, null or undefined positions

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1296,6 +1296,38 @@ describe('TextEditorComponent', () => {
     })
   })
 
+  describe('scrolling via the API', () => {
+    it('ignores scroll requests to NaN, null or undefined positions', async () => {
+      const {component, element, editor} = buildComponent({rowsPerTile: 2, autoHeight: false})
+      await setEditorHeightInLines(component, 3)
+      await setEditorWidthInCharacters(component, 10)
+
+      const initialScrollTop = Math.round(2 * component.getLineHeight())
+      const initialScrollLeft = Math.round(5 * component.getBaseCharacterWidth())
+      setScrollTop(component, initialScrollTop)
+      setScrollLeft(component, initialScrollLeft)
+      await component.getNextUpdatePromise()
+
+      setScrollTop(component, NaN)
+      setScrollLeft(component, NaN)
+      await component.getNextUpdatePromise()
+      expect(component.getScrollTop()).toBe(initialScrollTop)
+      expect(component.getScrollLeft()).toBe(initialScrollLeft)
+
+      setScrollTop(component, null)
+      setScrollLeft(component, null)
+      await component.getNextUpdatePromise()
+      expect(component.getScrollTop()).toBe(initialScrollTop)
+      expect(component.getScrollLeft()).toBe(initialScrollLeft)
+
+      setScrollTop(component, undefined)
+      setScrollLeft(component, undefined)
+      await component.getNextUpdatePromise()
+      expect(component.getScrollTop()).toBe(initialScrollTop)
+      expect(component.getScrollLeft()).toBe(initialScrollLeft)
+    })
+  })
+
   describe('line and line number decorations', () => {
     it('adds decoration classes on screen lines spanned by decorated markers', async () => {
       const {component, element, editor} = buildComponent({softWrapped: true})

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2715,6 +2715,8 @@ class TextEditorComponent {
   }
 
   setScrollTop (scrollTop) {
+    if (Number.isNaN(scrollTop) || scrollTop == null) return false
+
     scrollTop = Math.round(Math.max(0, Math.min(this.getMaxScrollTop(), scrollTop)))
     if (scrollTop !== this.scrollTop) {
       this.derivedDimensionsCache = {}
@@ -2744,6 +2746,8 @@ class TextEditorComponent {
   }
 
   setScrollLeft (scrollLeft) {
+    if (Number.isNaN(scrollLeft) || scrollLeft == null) return false
+
     scrollLeft = Math.round(Math.max(0, Math.min(this.getMaxScrollLeft(), scrollLeft)))
     if (scrollLeft !== this.scrollLeft) {
       this.scrollLeftPending = true


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15247

This was a guard we used to have in `TextEditorPresenter`, prior to the editor rendering layer rewrite:

https://github.com/atom/atom/blob/b580ff8642d4401892c730f6bd2e1b38bd00b3e5/src/text-editor-presenter.coffee#L723-L732

With this pull-request we are adding those guard clauses back, preventing `NaN`, `null` or `undefined` values that were mistakenly passed to the `setScrollTop` or `setScrollLeft` APIs from putting the editor into an inconsistent state.

/cc: @nathansobo @Ben3eeE @ungb 