### PR TITLE
Fix folding for lines that contain a comment

### DIFF
--- a/spec/fixtures/sample-with-comments.js
+++ b/spec/fixtures/sample-with-comments.js
@@ -3,7 +3,7 @@ var quicksort = function () {
     this is a multiline comment
     it is, I promise
   */
-  var sort = function(items) {
+  var sort = function(items) { // comment at the end of a foldable line
     // This is a collection of
     // single line comments.
     // Wowza

--- a/spec/language-mode-spec.coffee
+++ b/spec/language-mode-spec.coffee
@@ -461,6 +461,9 @@ describe "LanguageMode", ->
         expect(languageMode.isFoldableAtBufferRow(24)).toBe true
         expect(languageMode.isFoldableAtBufferRow(28)).toBe false
 
+      it "returns true for lines that end with a comment and are followed by an indented line", ->
+        expect(languageMode.isFoldableAtBufferRow(5)).toBe true
+
       it "does not return true for a line in the middle of a comment that's followed by an indented line", ->
         expect(languageMode.isFoldableAtBufferRow(7)).toBe false
         editor.buffer.insert([8, 0], '  ')

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -1,5 +1,5 @@
 Token = require './token'
-CommentScopeRegex  = /(\b|\.)comment/
+CommentScopeRegex = /(\b|\.)comment/
 
 idCounter = 1
 
@@ -54,7 +54,15 @@ class TokenizedLine
         @isCommentLine = true
         return @isCommentLine
 
+    startIndex = 0
     for tag in @tags
+      # If we haven't encountered any comment scope when reading the first
+      # non-whitespace chunk of text, then we consider this as not being a
+      # comment line.
+      if tag > 0
+        break unless isWhitespaceOnly(@text.substr(startIndex, tag))
+        startIndex += tag
+
       if @isCommentOpenTag(tag)
         @isCommentLine = true
         return @isCommentLine
@@ -75,3 +83,9 @@ class TokenizedLine
     count = 0
     count++ for tag in @tags when tag >= 0
     count
+
+isWhitespaceOnly = (text) ->
+  for char in text
+    if char isnt '\t' and char isnt ' '
+      return false
+  return true


### PR DESCRIPTION
Fixes #15308

In attempting to optimize the performance of `isFoldableAtBufferRow` in 3c87b74, we mistakenly introduced a bug that caused lines that contained a comment but didn't start with one to not be foldable anymore.

With this commit we are restoring the previous behavior, thus only disabling folding for lines that start with a comment (ignoring leading whitespaces).

/cc: @nathansobo @Ben3eeE @ungb 