### PR TITLE
Set visibility: hidden on dummy scrollbars if native ones are invisible

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -305,7 +305,9 @@ describe('TextEditorComponent', () => {
       expect(getVerticalScrollbarWidth(component)).toBeGreaterThan(0)
       expect(getHorizontalScrollbarHeight(component)).toBeGreaterThan(0)
       expect(verticalScrollbar.style.bottom).toBe(getVerticalScrollbarWidth(component) + 'px')
+      expect(verticalScrollbar.style.visibility).toBe('')
       expect(horizontalScrollbar.style.right).toBe(getHorizontalScrollbarHeight(component) + 'px')
+      expect(horizontalScrollbar.style.visibility).toBe('')
       expect(component.refs.scrollbarCorner).toBeDefined()
 
       setScrollTop(component, 100)
@@ -323,20 +325,26 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise()
       expect(getVerticalScrollbarWidth(component)).toBeGreaterThan(0)
       expect(getHorizontalScrollbarHeight(component)).toBe(0)
+      expect(verticalScrollbar.style.visibility).toBe('')
       expect(verticalScrollbar.style.bottom).toBe('0px')
+      expect(horizontalScrollbar.style.visibility).toBe('hidden')
       expect(component.refs.scrollbarCorner).toBeUndefined()
 
       editor.setText('a'.repeat(100))
       await component.getNextUpdatePromise()
       expect(getVerticalScrollbarWidth(component)).toBe(0)
       expect(getHorizontalScrollbarHeight(component)).toBeGreaterThan(0)
+      expect(verticalScrollbar.style.visibility).toBe('hidden')
       expect(horizontalScrollbar.style.right).toBe('0px')
+      expect(horizontalScrollbar.style.visibility).toBe('')
       expect(component.refs.scrollbarCorner).toBeUndefined()
 
       editor.setText('')
       await component.getNextUpdatePromise()
       expect(getVerticalScrollbarWidth(component)).toBe(0)
       expect(getHorizontalScrollbarHeight(component)).toBe(0)
+      expect(verticalScrollbar.style.visibility).toBe('hidden')
+      expect(horizontalScrollbar.style.visibility).toBe('hidden')
       expect(component.refs.scrollbarCorner).toBeUndefined()
 
       editor.setText(SAMPLE_TEXT)
@@ -348,6 +356,8 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise()
       expect(getVerticalScrollbarWidth(component)).toBe(0)
       expect(getHorizontalScrollbarHeight(component)).toBe(0)
+      expect(verticalScrollbar.style.visibility).toBe('hidden')
+      expect(horizontalScrollbar.style.visibility).toBe('hidden')
 
       // Shows scrollbars if the only reason we overflow is the presence of the
       // scrollbar for the opposite axis.
@@ -356,13 +366,16 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise()
       expect(getVerticalScrollbarWidth(component)).toBeGreaterThan(0)
       expect(getHorizontalScrollbarHeight(component)).toBeGreaterThan(0)
+      expect(verticalScrollbar.style.visibility).toBe('')
+      expect(horizontalScrollbar.style.visibility).toBe('')
 
       element.style.width = component.getGutterContainerWidth() + component.getContentWidth() + component.getVerticalScrollbarWidth() - 1 + 'px'
       element.style.height = component.getContentHeight() - 1 + 'px'
       await component.getNextUpdatePromise()
       expect(getVerticalScrollbarWidth(component)).toBeGreaterThan(0)
       expect(getHorizontalScrollbarHeight(component)).toBeGreaterThan(0)
-
+      expect(verticalScrollbar.style.visibility).toBe('')
+      expect(horizontalScrollbar.style.visibility).toBe('')
     })
 
     it('updates the bottom/right of dummy scrollbars and client height/width measurements without forgetting the previous scroll top/left when scrollbar styles change', async () => {
@@ -3174,7 +3187,7 @@ describe('TextEditorComponent', () => {
         const leftEdgeOfVerticalScrollbar = verticalScrollbar.element.getBoundingClientRect().right - getVerticalScrollbarWidth(component)
         const topEdgeOfHorizontalScrollbar = horizontalScrollbar.element.getBoundingClientRect().bottom - getHorizontalScrollbarHeight(component)
 
-        verticalScrollbar.didMousedown({
+        verticalScrollbar.didMouseDown({
           button: 0,
           detail: 1,
           clientY: clientTopForLine(component, 4),
@@ -3182,7 +3195,7 @@ describe('TextEditorComponent', () => {
         })
         expect(editor.getCursorScreenPosition()).toEqual([0, 0])
 
-        verticalScrollbar.didMousedown({
+        verticalScrollbar.didMouseDown({
           button: 0,
           detail: 1,
           clientY: clientTopForLine(component, 4),
@@ -3190,7 +3203,7 @@ describe('TextEditorComponent', () => {
         })
         expect(editor.getCursorScreenPosition()).toEqual([4, 6])
 
-        horizontalScrollbar.didMousedown({
+        horizontalScrollbar.didMouseDown({
           button: 0,
           detail: 1,
           clientY: topEdgeOfHorizontalScrollbar,
@@ -3198,7 +3211,7 @@ describe('TextEditorComponent', () => {
         })
         expect(editor.getCursorScreenPosition()).toEqual([4, 6])
 
-        horizontalScrollbar.didMousedown({
+        horizontalScrollbar.didMouseDown({
           button: 0,
           detail: 1,
           clientY: topEdgeOfHorizontalScrollbar - 1,

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -740,19 +740,21 @@ class TextEditorComponent {
           ref: 'verticalScrollbar',
           orientation: 'vertical',
           didScroll: this.didScrollDummyScrollbar,
-          didMousedown: this.didMouseDownOnContent,
+          didMouseDown: this.didMouseDownOnContent,
           scrollHeight,
           scrollTop,
           horizontalScrollbarHeight,
+          verticalScrollbarWidth,
           forceScrollbarVisible
         }),
         $(DummyScrollbarComponent, {
           ref: 'horizontalScrollbar',
           orientation: 'horizontal',
           didScroll: this.didScrollDummyScrollbar,
-          didMousedown: this.didMouseDownOnContent,
+          didMouseDown: this.didMouseDownOnContent,
           scrollWidth,
           scrollLeft,
+          horizontalScrollbarHeight,
           verticalScrollbarWidth,
           forceScrollbarVisible
         })
@@ -2912,55 +2914,67 @@ class DummyScrollbarComponent {
   }
 
   render () {
+    const {
+      orientation, scrollWidth, scrollHeight,
+      verticalScrollbarWidth, horizontalScrollbarHeight, forceScrollbarVisible,
+      didScroll, didMouseDown
+    } = this.props
+
     const outerStyle = {
       position: 'absolute',
       contain: 'strict',
       zIndex: 1
     }
     const innerStyle = {}
-    if (this.props.orientation === 'horizontal') {
-      let right = (this.props.verticalScrollbarWidth || 0)
+    if (orientation === 'horizontal') {
+      let right = (verticalScrollbarWidth || 0)
       outerStyle.bottom = 0
       outerStyle.left = 0
       outerStyle.right = right + 'px'
       outerStyle.height = '15px'
       outerStyle.overflowY = 'hidden'
-      outerStyle.overflowX = this.props.forceScrollbarVisible ? 'scroll' : 'auto'
+      outerStyle.overflowX = forceScrollbarVisible ? 'scroll' : 'auto'
       outerStyle.cursor = 'default'
+      if (horizontalScrollbarHeight === 0) {
+        outerStyle.visibility = 'hidden'
+      }
       innerStyle.height = '15px'
-      innerStyle.width = (this.props.scrollWidth || 0) + 'px'
+      innerStyle.width = (scrollWidth || 0) + 'px'
     } else {
-      let bottom = (this.props.horizontalScrollbarHeight || 0)
+      let bottom = (horizontalScrollbarHeight || 0)
       outerStyle.right = 0
       outerStyle.top = 0
       outerStyle.bottom = bottom + 'px'
       outerStyle.width = '15px'
       outerStyle.overflowX = 'hidden'
-      outerStyle.overflowY = this.props.forceScrollbarVisible ? 'scroll' : 'auto'
+      outerStyle.overflowY = forceScrollbarVisible ? 'scroll' : 'auto'
       outerStyle.cursor = 'default'
+      if (verticalScrollbarWidth === 0) {
+        outerStyle.visibility = 'hidden'
+      }
       innerStyle.width = '15px'
-      innerStyle.height = (this.props.scrollHeight || 0) + 'px'
+      innerStyle.height = (scrollHeight || 0) + 'px'
     }
 
     return $.div(
       {
-        className: `${this.props.orientation}-scrollbar`,
+        className: `${orientation}-scrollbar`,
         style: outerStyle,
         on: {
-          scroll: this.props.didScroll,
-          mousedown: this.didMousedown
+          scroll: didScroll,
+          mousedown: didMouseDown
         }
       },
       $.div({style: innerStyle})
     )
   }
 
-  didMousedown (event) {
+  didMouseDown (event) {
     let {bottom, right} = this.element.getBoundingClientRect()
     const clickedOnScrollbar = (this.props.orientation === 'horizontal')
       ? event.clientY >= (bottom - this.getRealScrollbarHeight())
       : event.clientX >= (right - this.getRealScrollbarWidth())
-    if (!clickedOnScrollbar) this.props.didMousedown(event)
+    if (!clickedOnScrollbar) this.props.didMouseDown(event)
   }
 
   getRealScrollbarWidth () {


### PR DESCRIPTION
Fixes #14661

This prevents the cursor from unexpectedly changing when approaching the bottom/right corner of the editor with the mouse, even when no scrollbar is being shown.

/cc: @nathansobo @ungb @50Wliu @Ben3eeE 