### PR TITLE
Always round GPU layer dimensions to physical pixel boundaries

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -551,10 +551,10 @@ class TextEditorComponent {
       backgroundColor: 'inherit'
     }
     if (this.hasInitialMeasurements) {
-      style.width = this.getScrollWidth() + 'px'
-      style.height = this.getScrollHeight() + 'px'
+      style.width = ceilToPhysicalPixelBoundary(this.getScrollWidth()) + 'px'
+      style.height = ceilToPhysicalPixelBoundary(this.getScrollHeight()) + 'px'
       style.willChange = 'transform'
-      style.transform = `translate(${-this.getScrollLeft()}px, ${-this.getScrollTop()}px)`
+      style.transform = `translate(${-roundToPhysicalPixelBoundary(this.getScrollLeft())}px, ${-roundToPhysicalPixelBoundary(this.getScrollTop())}px)`
       children = [
         this.renderLineTiles(),
         this.renderBlockDecorationMeasurementArea(),
@@ -3015,7 +3015,7 @@ class GutterContainerComponent {
     }
 
     if (hasInitialMeasurements) {
-      innerStyle.transform = `translateY(${-scrollTop}px)`
+      innerStyle.transform = `translateY(${-roundToPhysicalPixelBoundary(scrollTop)}px)`
     }
 
     return $.div(
@@ -3171,10 +3171,10 @@ class LineNumberGutterComponent {
             overflow: 'hidden',
             position: 'absolute',
             top: 0,
-            height: tileHeight + 'px',
-            width: width + 'px',
+            height: ceilToPhysicalPixelBoundary(tileHeight) + 'px',
+            width: ceilToPhysicalPixelBoundary(width) + 'px',
             willChange: 'transform',
-            transform: `translateY(${tileTop}px)`,
+            transform: `translateY(${roundToPhysicalPixelBoundary(tileTop)}px)`,
             backgroundColor: 'inherit'
           }
         }, ...tileChildren)
@@ -3185,7 +3185,7 @@ class LineNumberGutterComponent {
       {
         className: 'gutter line-numbers',
         attributes: {'gutter-name': 'line-number'},
-        style: {position: 'relative', height: height + 'px'},
+        style: {position: 'relative', height: ceilToPhysicalPixelBoundary(height) + 'px'},
         on: {
           mousedown: this.didMouseDown
         }
@@ -3548,10 +3548,10 @@ class LinesTileComponent {
         style: {
           contain: 'strict',
           position: 'absolute',
-          height: height + 'px',
-          width: width + 'px',
+          height: ceilToPhysicalPixelBoundary(height) + 'px',
+          width: ceilToPhysicalPixelBoundary(width) + 'px',
           willChange: 'transform',
-          transform: `translateY(${top}px)`,
+          transform: `translateY(${roundToPhysicalPixelBoundary(top)}px)`,
           backgroundColor: 'inherit'
         }
       },
@@ -4302,4 +4302,14 @@ class NodePool {
       }
     }
   }
+}
+
+function roundToPhysicalPixelBoundary (virtualPixelPosition) {
+  const virtualPixelsPerPhysicalPixel = (1 / window.devicePixelRatio)
+  return Math.round(virtualPixelPosition / virtualPixelsPerPhysicalPixel) * virtualPixelsPerPhysicalPixel
+}
+
+function ceilToPhysicalPixelBoundary (virtualPixelPosition) {
+  const virtualPixelsPerPhysicalPixel = (1 / window.devicePixelRatio)
+  return Math.ceil(virtualPixelPosition / virtualPixelsPerPhysicalPixel) * virtualPixelsPerPhysicalPixel
 }


### PR DESCRIPTION
Fixes #13361
Fixes #15180
Fixes #15257
Fixes #14237
Fixes #14898
Fixes #12652
Fixes #13627

This ensure subpixel anti-aliasing works when `window.devicePixelRatio` is not an integer. Since subpixel anti-aliasing relies on the physical characteristics of the display, Chromium only enables it when rasterizing content that it knows will be aligned to a physical pixel boundary.

@50Wliu @ungb @Ben3eeE: can you give this a spin on Windows, please? We have tested it works correctly with 125% on Windows and by manually calling `setZoomLevel` on macOS in the console, but we'd like to make sure this is a holistic solution to the blurriness problem. Also, if you think this fixes more issues than the ones we have linked above, feel free to add them.

/cc: @atom/maintainers 

🍐'd with @nathansobo.