### PR TITLE
Async watchPath method

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "exception-reporting": "0.41.4",
     "find-and-replace": "0.209.5",
     "fuzzy-finder": "1.5.8",
-    "github": "0.4.2",
+    "github": "0.5.0",
     "git-diff": "1.3.6",
     "go-to-line": "0.32.1",
     "grammar-selector": "0.49.5",

--- a/spec/path-watcher-spec.js
+++ b/spec/path-watcher-spec.js
@@ -52,7 +52,7 @@ describe('watchPath', function () {
       const rootDir = await temp.mkdir('atom-fsmanager-test-')
 
       const watcher = await watchPath(rootDir, {}, () => {})
-      expect(watcher).to.be.a('PathWatcher')
+      expect(watcher.constructor.name).toBe('PathWatcher')
     })
 
     it('reuses an existing native watcher and resolves getStartPromise immediately if attached to a running watcher', async function () {

--- a/spec/path-watcher-spec.js
+++ b/spec/path-watcher-spec.js
@@ -48,21 +48,18 @@ describe('watchPath', function () {
   }
 
   describe('watchPath()', function () {
-    it('resolves getStartPromise() when the watcher begins listening', async function () {
+    it('resolves the returned promise when the watcher begins listening', async function () {
       const rootDir = await temp.mkdir('atom-fsmanager-test-')
 
-      const watcher = watchPath(rootDir, {}, () => {})
-      await watcher.getStartPromise()
+      const watcher = await watchPath(rootDir, {}, () => {})
+      expect(watcher).to.be.a('PathWatcher')
     })
 
     it('reuses an existing native watcher and resolves getStartPromise immediately if attached to a running watcher', async function () {
       const rootDir = await temp.mkdir('atom-fsmanager-test-')
 
-      const watcher0 = watchPath(rootDir, {}, () => {})
-      await watcher0.getStartPromise()
-
-      const watcher1 = watchPath(rootDir, {}, () => {})
-      await watcher1.getStartPromise()
+      const watcher0 = await watchPath(rootDir, {}, () => {})
+      const watcher1 = await watchPath(rootDir, {}, () => {})
 
       expect(watcher0.native).toBe(watcher1.native)
     })
@@ -70,28 +67,21 @@ describe('watchPath', function () {
     it("reuses existing native watchers even while they're still starting", async function () {
       const rootDir = await temp.mkdir('atom-fsmanager-test-')
 
-      const watcher0 = watchPath(rootDir, {}, () => {})
-      await watcher0.getAttachedPromise()
-      expect(watcher0.native.isRunning()).toBe(false)
-
-      const watcher1 = watchPath(rootDir, {}, () => {})
-      await watcher1.getAttachedPromise()
-
+      const [watcher0, watcher1] = await Promise.all([
+        watchPath(rootDir, {}, () => {}),
+        watchPath(rootDir, {}, () => {})
+      ])
       expect(watcher0.native).toBe(watcher1.native)
-
-      await Promise.all([watcher0.getStartPromise(), watcher1.getStartPromise()])
     })
 
     it("doesn't attach new watchers to a native watcher that's stopping", async function () {
       const rootDir = await temp.mkdir('atom-fsmanager-test-')
 
-      const watcher0 = watchPath(rootDir, {}, () => {})
-      await watcher0.getStartPromise()
+      const watcher0 = await watchPath(rootDir, {}, () => {})
       const native0 = watcher0.native
 
       watcher0.dispose()
-
-      const watcher1 = watchPath(rootDir, {}, () => {})
+      const watcher1 = await watchPath(rootDir, {}, () => {})
 
       expect(watcher1.native).not.toBe(native0)
     })
@@ -105,13 +95,8 @@ describe('watchPath', function () {
       await fs.mkdir(subDir)
 
       // Keep the watchers alive with an undisposed subscription
-      const rootWatcher = watchPath(rootDir, {}, () => {})
-      const childWatcher = watchPath(subDir, {}, () => {})
-
-      await Promise.all([
-        rootWatcher.getStartPromise(),
-        childWatcher.getStartPromise()
-      ])
+      const rootWatcher = await watchPath(rootDir, {}, () => {})
+      const childWatcher = await watchPath(subDir, {}, () => {})
 
       expect(rootWatcher.native).toBe(childWatcher.native)
       expect(rootWatcher.native.isRunning()).toBe(true)
@@ -120,13 +105,11 @@ describe('watchPath', function () {
         waitForChanges(rootWatcher, subFile),
         waitForChanges(childWatcher, subFile)
       ])
-
       await fs.writeFile(subFile, 'subfile\n', {encoding: 'utf8'})
       await firstChanges
 
       const nextRootEvent = waitForChanges(rootWatcher, rootFile)
       await fs.writeFile(rootFile, 'rootfile\n', {encoding: 'utf8'})
-
       await nextRootEvent
     })
 
@@ -149,22 +132,17 @@ describe('watchPath', function () {
       ])
 
       // Begin the child watchers and keep them alive
-      const subWatcher0 = watchPath(subDir0, {}, () => {})
+      const subWatcher0 = await watchPath(subDir0, {}, () => {})
       const subWatcherChanges0 = waitForChanges(subWatcher0, subFile0)
 
-      const subWatcher1 = watchPath(subDir1, {}, () => {})
+      const subWatcher1 = await watchPath(subDir1, {}, () => {})
       const subWatcherChanges1 = waitForChanges(subWatcher1, subFile1)
 
-      await Promise.all(
-        [subWatcher0, subWatcher1].map(watcher => watcher.getStartPromise())
-      )
       expect(subWatcher0.native).not.toBe(subWatcher1.native)
 
       // Create the parent watcher
-      const parentWatcher = watchPath(parentDir, {}, () => {})
+      const parentWatcher = await watchPath(parentDir, {}, () => {})
       const parentWatcherChanges = waitForChanges(parentWatcher, rootFile, subFile0, subFile1)
-
-      await parentWatcher.getStartPromise()
 
       expect(subWatcher0.native).toBe(parentWatcher.native)
       expect(subWatcher1.native).toBe(parentWatcher.native)

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -585,10 +585,10 @@ describe "Project", ->
       waitsForPromise -> stopAllWatchers()
 
       runs -> atom.project.setPaths([dirOne])
-      waitsForPromise -> atom.project.watchersByPath[dirOne].getStartPromise()
+      waitsForPromise -> atom.project.getWatcherPromise dirOne
 
       runs ->
-        expect(atom.project.watchersByPath[dirTwo]).toEqual undefined
+        expect(atom.project.watcherPromisesByPath[dirTwo]).toEqual undefined
 
         fs.writeFileSync fileThree, "three\n"
         fs.writeFileSync fileTwo, "two\n"

--- a/src/native-watcher-registry.js
+++ b/src/native-watcher-registry.js
@@ -431,6 +431,14 @@ class NativeWatcherRegistry {
       watcher.attachToNative(native, nativePath)
     })
   }
+
+  // Private: Generate a visual representation of the currently active watchers managed by this
+  // registry.
+  //
+  // Returns a {String} showing the tree structure.
+  print() {
+    return this.tree.print()
+  }
 }
 
 module.exports = {NativeWatcherRegistry}

--- a/src/native-watcher-registry.js
+++ b/src/native-watcher-registry.js
@@ -436,7 +436,7 @@ class NativeWatcherRegistry {
   // registry.
   //
   // Returns a {String} showing the tree structure.
-  print() {
+  print () {
     return this.tree.print()
   }
 }

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -581,6 +581,11 @@ class PathWatcherManager {
     return watcher
   }
 
+  // Private: Return a {String} depicting the currently active native watchers.
+  print () {
+    return this.nativeRegistry.print()
+  }
+
   // Private: Stop all living watchers.
   //
   // Returns a {Promise} that resolves when all native watcher resources are disposed.
@@ -641,4 +646,9 @@ function stopAllWatchers () {
   return PathWatcherManager.instance().stopAllWatchers()
 }
 
-module.exports = {watchPath, stopAllWatchers}
+// Private: Show the currently active native watchers.
+function printWatchers () {
+  return PathWatcherManager.instance().print()
+}
+
+module.exports = {watchPath, stopAllWatchers, printWatchers}

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -505,14 +505,16 @@ class PathWatcher {
     }))
 
     this.subs.add(native.onShouldDetach(({replacement, watchedPath}) => {
-      if (replacement !== native && this.normalizedPath.startsWith(watchedPath)) {
+      if (this.native === native && replacement !== native && this.normalizedPath.startsWith(watchedPath)) {
         this.attachToNative(replacement)
       }
     }))
 
     this.subs.add(native.onWillStop(() => {
-      this.subs.dispose()
-      this.native = null
+      if (this.native === native) {
+        this.subs.dispose()
+        this.native = null
+      }
     }))
 
     this.resolveAttachedPromise()

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -606,8 +606,8 @@ class PathWatcherManager {
 //      * `path` {String} containing the absolute path to the filesystem entry that was acted upon.
 //      * `oldPath` For rename events, {String} containing the filesystem entry's former absolute path.
 //
-// Returns a {PathWatcher}. Note that every {PathWatcher} is a {Disposable}, so they can be managed by
-// [CompositeDisposables]{CompositeDisposable} if desired.
+// Returns a {Promise} that will resolve to a {PathWatcher} once it has started. Note that every {PathWatcher}
+// is a {Disposable}, so they can be managed by a {CompositeDisposable} if desired.
 //
 // ```js
 // const {watchPath} = require('atom')
@@ -631,7 +631,8 @@ class PathWatcherManager {
 // ```
 //
 function watchPath (rootPath, options, eventCallback) {
-  return PathWatcherManager.instance().createWatcher(rootPath, options, eventCallback)
+  const watcher = PathWatcherManager.instance().createWatcher(rootPath, options, eventCallback)
+  return watcher.getStartPromise().then(() => watcher)
 }
 
 // Private: Return a Promise that resolves when all {NativeWatcher} instances associated with a FileSystemManager

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -339,7 +339,7 @@ class NativeWatcher {
 // ```js
 // const {watchPath} = require('atom')
 //
-// const disposable = watchPath('/var/log', {}, events => {
+// const disposable = await watchPath('/var/log', {}, events => {
 //   console.log(`Received batch of ${events.length} events.`)
 //   for (const event of events) {
 //     // "created", "modified", "deleted", "renamed"
@@ -423,6 +423,8 @@ class PathWatcher {
   // When testing filesystem watchers, it's important to await this promise before making filesystem changes that you
   // intend to assert about because there will be a delay between the instantiation of the watcher and the activation
   // of the underlying OS resources that feed it events.
+  //
+  // PathWatchers acquired through `watchPath` are already started.
   //
   // ```js
   // const {watchPath} = require('atom')
@@ -617,7 +619,7 @@ class PathWatcherManager {
 // ```js
 // const {watchPath} = require('atom')
 //
-// const disposable = watchPath('/var/log', {}, events => {
+// const disposable = await watchPath('/var/log', {}, events => {
 //   console.log(`Received batch of ${events.length} events.`)
 //   for (const event of events) {
 //     // "created", "modified", "deleted", "renamed"

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -140,6 +140,10 @@ class Project extends Model
   #
   # To watch paths outside of open projects, use the `watchPaths` function instead; see {PathWatcher}.
   #
+  # When writing tests against functionality that uses this method, be sure to wait for the
+  # {Promise} returned by {getWatcherPromise()} before manipulating the filesystem to ensure that
+  # the watcher is receiving events.
+  #
   # * `callback` {Function} to be called with batches of filesystem events reported by
   #   the operating system.
   #    * `events` An {Array} of objects that describe a batch of filesystem events.


### PR DESCRIPTION
Rather than synchronously returning a `PathWatcher` from the `watchPath` method and requiring users to await the `getStartPromise()` manually in test cases to avoid flaky tests, return a `Promise` that resolves to the `PathWatcher` after it's started.

I originally did it the other way for efficiency, but it's much harder to reason about, and accessing the start Promise in tests is often challenging. As evidence of this, it's the root cause of the flaky GitHub package test we're seeing in the atom/atom build right now... which _I_ wrote, against my own API 😇 

Along the way, I also fixed a subtle timing bug related to the event timing during the NativeWatcher re-attachment sequence when watchers are split or joined, and introduced a private `printWatchers()` method that's useful as a sanity check on the watchers that are alive at any given moment.

/cc @damieng as the only other current consumer of this API. If you're writing any tests that exercise `atom.project.onDidChangeFiles`, you'll need to await `atom.project.getWatcherPromise(projectPath)` before manipulating the filesystem and expecting the watcher to pick it up. I'd be happy to send PRs to fix any specs up myself if you point me to a repo that needs it.

/cc @nathansobo because this _should_ fix that GitHub package test flake you noticed yesterday.

/cc @maxbrunsfeld because this was his original suggestion and I should have listened to him to begin with :wink:

Remaining work: update the GitHub package to await the result of `watchPath`.