### PR TITLE
Drop use of GPU tiles for lines and line numbers

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -3167,15 +3167,12 @@ class LineNumberGutterComponent {
         children[i] = $.div({
           key: rootComponent.idsByTileStartRow.get(tileStartRow),
           style: {
-            contain: 'strict',
-            overflow: 'hidden',
+            contain: 'layout style',
             position: 'absolute',
             top: 0,
-            height: ceilToPhysicalPixelBoundary(tileHeight) + 'px',
-            width: ceilToPhysicalPixelBoundary(width) + 'px',
-            willChange: 'transform',
-            transform: `translateY(${roundToPhysicalPixelBoundary(tileTop)}px)`,
-            backgroundColor: 'inherit'
+            height: tileHeight + 'px',
+            width: width + 'px',
+            transform: `translateY(${tileTop}px)`
           }
         }, ...tileChildren)
       }
@@ -3546,13 +3543,11 @@ class LinesTileComponent {
     return $.div(
       {
         style: {
-          contain: 'strict',
+          contain: 'layout style',
           position: 'absolute',
-          height: ceilToPhysicalPixelBoundary(height) + 'px',
-          width: ceilToPhysicalPixelBoundary(width) + 'px',
-          willChange: 'transform',
-          transform: `translateY(${roundToPhysicalPixelBoundary(top)}px)`,
-          backgroundColor: 'inherit'
+          height: height + 'px',
+          width: width + 'px',
+          transform: `translateY(${top}px)`
         }
       },
       $.div({

--- a/static/text-editor.less
+++ b/static/text-editor.less
@@ -86,7 +86,6 @@ atom-text-editor {
 
   .line {
     white-space: pre;
-    overflow: hidden;
     contain: layout;
 
     &.cursor-line .fold-marker::after {


### PR DESCRIPTION
Fixes #15171

At the cost of a very minimal reduction in layout performance, we gain reliable rendering at all line heights and don't have to worry about characters that extend above/below the footprint of a line.

@ungb @Ben3eeE @50Wliu: this should fix all the reported bugs of cropped text when using certain fonts or line heights. We have tested it on both Linux and macOS, but it would be nice if you could give this a spin too. Please, feel free to add more issues to the "Fixes" list in case you can think of other related bug reports. Thanks! ✨ 