### PR TITLE
[Commands] Add support for rich listener objects with first-class metadata

### DIFF
--- a/spec/command-registry-spec.js
+++ b/spec/command-registry-spec.js
@@ -240,15 +240,15 @@ describe("CommandRegistry", () => {
       }).toThrow(new Error('Cannot register a command with a null listener.'));
     });
 
-    it("throws an error when called with an object listener without a handleEvent method", () => {
+    it("throws an error when called with an object listener without a onDidDispatch method", () => {
       const badListener = {
-        title: 'a listener without a handleEvent callback',
+        title: 'a listener without a onDidDispatch callback',
         description: 'this should throw an error'
       };
 
       expect(() => {
         registry.add(document.body, 'foo:bar', badListener);
-      }).toThrow(new Error('Listener must be a callback function or an object with a handleEvent method.'));
+      }).toThrow(new Error('Listener must be a callback function or an object with a onDidDispatch method.'));
     });
   });
 
@@ -281,7 +281,7 @@ describe("CommandRegistry", () => {
           some: 'other',
           object: 'data'
         },
-        handleEvent() {}
+        onDidDispatch() {}
       });
       registry.add('.grandchild', 'namespace:command-3', {
         name: 'some:other:incorrect:commandname',
@@ -290,7 +290,7 @@ describe("CommandRegistry", () => {
           some: 'other',
           object: 'data'
         },
-        handleEvent() {}
+        onDidDispatch() {}
       });
 
       const commands = registry.findCommands({target: grandchild});

--- a/spec/command-registry-spec.js
+++ b/spec/command-registry-spec.js
@@ -273,7 +273,7 @@ describe("CommandRegistry", () => {
       ]);
     });
 
-    it("returns commands with manual displayNames if set in the listener", () => {
+    it("returns commands with arbitrary metadata if set in a listener object", () => {
       registry.add('.grandchild', 'namespace:command-1', () => {});
       registry.add('.grandchild', 'namespace:command-2', {
         displayName: 'Custom Command 2',
@@ -283,7 +283,15 @@ describe("CommandRegistry", () => {
         },
         handleEvent() {}
       });
-      registry.add('.grandchild', 'namespace:command-3', () => {});
+      registry.add('.grandchild', 'namespace:command-3', {
+        name: 'some:other:incorrect:commandname',
+        displayName: 'Custom Command 3',
+        metadata: {
+          some: 'other',
+          object: 'data'
+        },
+        handleEvent() {}
+      });
 
       const commands = registry.findCommands({target: grandchild});
       expect(commands).toEqual([
@@ -300,30 +308,32 @@ describe("CommandRegistry", () => {
           name: 'namespace:command-2'
         },
         {
-          displayName: 'Namespace: Command 3',
+          displayName: 'Custom Command 3',
+          metadata: {
+            some : 'other',
+            object : 'data'
+          },
           name: 'namespace:command-3'
         }
       ]);
     });
 
-    it("ignores a `name` property if passed in registration object", () => {
-      registry.add('.grandchild', 'namespace:command-2', {
-        name: 'some:other:commandname',
-        displayName: 'Custom Command 2',
-        metadata: {
-          some: 'other',
-          object: 'data'
-        },
-        handleEvent() {}
-      });
+    it("returns commands with arbitrary metadata if set on a listener function", () => {
+      function listener () {}
+      listener.displayName = 'Custom Command 2'
+      listener.metadata = {
+        some: 'other',
+        object: 'data'
+      };
 
+      registry.add('.grandchild', 'namespace:command-2', listener);
       const commands = registry.findCommands({target: grandchild});
       expect(commands).toEqual([
         {
-          displayName: 'Custom Command 2',
+          displayName : 'Custom Command 2',
           metadata: {
-            some : 'other',
-            object : 'data'
+            some: 'other',
+            object: 'data'
           },
           name: 'namespace:command-2'
         }

--- a/spec/command-registry-spec.js
+++ b/spec/command-registry-spec.js
@@ -232,7 +232,7 @@ describe("CommandRegistry", () => {
       }).toThrow(new Error('Cannot register a command with a null listener.'));
     });
 
-    it("throws an error when called with an null callback and object target", () => {
+    it("throws an error when called with a null callback and object target", () => {
       const badCallback = null;
 
       expect(() => {
@@ -240,20 +240,20 @@ describe("CommandRegistry", () => {
       }).toThrow(new Error('Cannot register a command with a null listener.'));
     });
 
-    it("throws an error when called with an object listener without a onDidDispatch method", () => {
+    it("throws an error when called with an object listener without a didDispatch method", () => {
       const badListener = {
-        title: 'a listener without a onDidDispatch callback',
+        title: 'a listener without a didDispatch callback',
         description: 'this should throw an error'
       };
 
       expect(() => {
         registry.add(document.body, 'foo:bar', badListener);
-      }).toThrow(new Error('Listener must be a callback function or an object with a onDidDispatch method.'));
+      }).toThrow(new Error('Listener must be a callback function or an object with a didDispatch method.'));
     });
   });
 
   describe("::findCommands({target})", () => {
-    it("returns commands that can be invoked on the target or its ancestors", () => {
+    it("returns command descriptors that can be invoked on the target or its ancestors", () => {
       registry.add('.parent', 'namespace:command-1', () => {});
       registry.add('.child', 'namespace:command-2', () => {});
       registry.add('.grandchild', 'namespace:command-3', () => {});
@@ -273,7 +273,7 @@ describe("CommandRegistry", () => {
       ]);
     });
 
-    it("returns commands with arbitrary metadata if set in a listener object", () => {
+    it("returns command descriptors with arbitrary metadata if set in a listener object", () => {
       registry.add('.grandchild', 'namespace:command-1', () => {});
       registry.add('.grandchild', 'namespace:command-2', {
         displayName: 'Custom Command 2',
@@ -281,7 +281,7 @@ describe("CommandRegistry", () => {
           some: 'other',
           object: 'data'
         },
-        onDidDispatch() {}
+        didDispatch() {}
       });
       registry.add('.grandchild', 'namespace:command-3', {
         name: 'some:other:incorrect:commandname',
@@ -290,7 +290,7 @@ describe("CommandRegistry", () => {
           some: 'other',
           object: 'data'
         },
-        onDidDispatch() {}
+        didDispatch() {}
       });
 
       const commands = registry.findCommands({target: grandchild});
@@ -318,7 +318,7 @@ describe("CommandRegistry", () => {
       ]);
     });
 
-    it("returns commands with arbitrary metadata if set on a listener function", () => {
+    it("returns command descriptors with arbitrary metadata if set on a listener function", () => {
       function listener () {}
       listener.displayName = 'Custom Command 2'
       listener.metadata = {

--- a/src/command-registry.js
+++ b/src/command-registry.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* global Event, CustomEvent */
-
 const { Emitter, Disposable, CompositeDisposable } = require('event-kit')
 const { calculateSpecificity, validateSelector } = require('clear-cut')
 const _ = require('underscore-plus')
@@ -124,7 +122,7 @@ module.exports = class CommandRegistry {
     if (typeof commandName === 'object') {
       const commands = commandName
       throwOnInvalidSelector = listener
-      const disposable = new CompositeDisposable
+      const disposable = new CompositeDisposable()
       for (commandName in commands) {
         listener = commands[commandName]
         disposable.add(this.add(target, commandName, listener, throwOnInvalidSelector))
@@ -132,15 +130,15 @@ module.exports = class CommandRegistry {
       return disposable
     }
 
-    // type Listener = ?(e: CustomEvent) => void | ?{
-    //   displayName?: string,
-    //   description?: string,
-    //   handleEvent(e: CustomEvent): void,
-    // }
     if (listener == null) {
       throw new Error('Cannot register a command with a null listener.')
     }
 
+    // type Listener = ((e: CustomEvent) => void) | {
+    //   displayName?: string,
+    //   description?: string,
+    //   handleEvent(e: CustomEvent): void,
+    // }
     if ((typeof listener !== 'function') && (typeof listener.handleEvent !== 'function')) {
       throw new Error('Listener must be a callback function or an object with a handleEvent method.')
     }
@@ -175,7 +173,7 @@ module.exports = class CommandRegistry {
 
   addInlineListener (element, commandName, listener) {
     if (this.inlineListenersByCommandName[commandName] == null) {
-      this.inlineListenersByCommandName[commandName] = new WeakMap
+      this.inlineListenersByCommandName[commandName] = new WeakMap()
     }
 
     const listenersForCommand = this.inlineListenersByCommandName[commandName]
@@ -206,6 +204,13 @@ module.exports = class CommandRegistry {
   //  * `name` The name of the command. For example, `user:insert-date`.
   //  * `displayName` The display name of the command. For example,
   //    `User: Insert Date`.
+  // Additional metadata may also be present in the returned descriptor:
+  //  * `description` a {String} describing the function of the command in more
+  //    detail than the title
+  //  * `tags` an {Array} of {String}s that describe keywords related to the
+  //    command
+  //  Any additional nonstandard metadata provided when the command was `add`ed
+  //  may also be present in the returned descriptor.
   findCommands ({ target }) {
     const commandNames = new Set()
     const commands = []
@@ -216,10 +221,10 @@ module.exports = class CommandRegistry {
         listeners = this.inlineListenersByCommandName[name]
         if (listeners.has(currentTarget) && !commandNames.has(name)) {
           commandNames.add(name)
-          const targetListeners = listeners.get(currentTarget);
+          const targetListeners = listeners.get(currentTarget)
           commands.push(
             ...targetListeners.map(listener => listener.descriptor)
-          );
+          )
         }
       }
 
@@ -423,7 +428,7 @@ class SelectorBasedListener {
 
 class InlineListener {
   constructor (commandName, listener) {
-    this.callback = extractCallback(listener);
+    this.callback = extractCallback(listener)
     this.descriptor = extractDescriptor(commandName, listener)
   }
 }
@@ -437,11 +442,11 @@ function extractDescriptor (name, listener) {
     _.omit(listener, 'handleEvent'),
     {
       name,
-      displayName: listener.displayName ? listener.displayName : _.humanizeEventName(name),
+      displayName: listener.displayName ? listener.displayName : _.humanizeEventName(name)
     }
   )
 }
 
 function extractCallback (listener) {
-  return typeof listener === 'function' ? listener : listener.handleEvent;
+  return typeof listener === 'function' ? listener : listener.handleEvent
 }

--- a/src/command-registry.js
+++ b/src/command-registry.js
@@ -91,7 +91,7 @@ module.exports = class CommandRegistry {
   //   handle such as `user:insert-date`.
   // * `listener` A listener which handles the event.  Either A {Function} to
   //   call when the given command is invoked on an element matching the
-  //   selector, or an {Object} with a `handleEvent` property which is such a
+  //   selector, or an {Object} with a `onDidDispatch` property which is such a
   //   function.
   //
   //   It will be called with `this` referencing the matching DOM node.
@@ -137,10 +137,10 @@ module.exports = class CommandRegistry {
     // type Listener = ((e: CustomEvent) => void) | {
     //   displayName?: string,
     //   description?: string,
-    //   handleEvent(e: CustomEvent): void,
+    //   onDidDispatch(e: CustomEvent): void,
     // }
-    if ((typeof listener !== 'function') && (typeof listener.handleEvent !== 'function')) {
-      throw new Error('Listener must be a callback function or an object with a handleEvent method.')
+    if ((typeof listener !== 'function') && (typeof listener.onDidDispatch !== 'function')) {
+      throw new Error('Listener must be a callback function or an object with a onDidDispatch method.')
     }
 
     if (typeof target === 'string') {
@@ -376,7 +376,7 @@ module.exports = class CommandRegistry {
         if (immediatePropagationStopped) {
           break
         }
-        listener.callback.call(currentTarget, dispatchedEvent)
+        listener.onDidDispatch.call(currentTarget, dispatchedEvent)
       }
 
       if (currentTarget === window) {
@@ -403,12 +403,12 @@ module.exports = class CommandRegistry {
 
 // type Listener = {
 //   descriptor: CommandDescriptor,
-//   callback: (e: CustomEvent) => void,
+//   extractOnDidDispatch: (e: CustomEvent) => void,
 // };
 class SelectorBasedListener {
   constructor (selector, commandName, listener) {
     this.selector = selector
-    this.callback = extractCallback(listener)
+    this.onDidDispatch = extractOnDidDispatch(listener)
     this.descriptor = extractDescriptor(commandName, listener)
     this.specificity = calculateSpecificity(this.selector)
     this.sequenceNumber = SequenceCount++
@@ -428,7 +428,7 @@ class SelectorBasedListener {
 
 class InlineListener {
   constructor (commandName, listener) {
-    this.callback = extractCallback(listener)
+    this.onDidDispatch = extractOnDidDispatch(listener)
     this.descriptor = extractDescriptor(commandName, listener)
   }
 }
@@ -439,7 +439,7 @@ class InlineListener {
 // };
 function extractDescriptor (name, listener) {
   return Object.assign(
-    _.omit(listener, 'handleEvent'),
+    _.omit(listener, 'onDidDispatch'),
     {
       name,
       displayName: listener.displayName ? listener.displayName : _.humanizeEventName(name)
@@ -447,6 +447,6 @@ function extractDescriptor (name, listener) {
   )
 }
 
-function extractCallback (listener) {
-  return typeof listener === 'function' ? listener : listener.handleEvent
+function extractOnDidDispatch (listener) {
+  return typeof listener === 'function' ? listener : listener.onDidDispatch
 }


### PR DESCRIPTION
Fixes #15143 

This adds support for listener objects which, in addition to the existing callback listeners, can optionally provide a `displayName` ahead of time to avoid a potentially awkward humanized displayName.

Every object-based listener must implement `handleEvent()`, which plays the role of the callback fired when the command is dispatched.

We can support other first-class metadata, for example I'm preparing a pull request to the command palette to support displaying a command's `description` field as a second line below the `displayName` in search results. I even have an example of adding "tags" to a command to help capture keywords a user might use when searching for a command, kind of like how macOS shows "System Preferences" as a result for settings:

![image](https://user-images.githubusercontent.com/755844/29479570-c53d9712-8427-11e7-8ac0-00693cecc4f0.png)

Here's an example of an object command listener:

```js
atom.commands.add('foo:command', document.body, {
  displayName: 'My awesome foo command',
  description: 'Here\'s some detail about my foo command. Try it out!',
  handleEvent() {
    alert('foo!');
  },
```

It should also be technically possible to attach these properties to a function callback. If we'd like to officially support this I'll add some tests to check:

```js
function myListener() {
  alert('foo!');
}

myListener.displayName = 'My Awesome Listener';
myListener.description = 'Does awesome stuff!';
```

I'll cross-link my command palette pull request which demonstrates the use of this API.

Released under CC0.

cc @matthewwithanm @nathansobo  @hansonw @jinface