### PR TITLE
Fix highlight end pixel position calculation

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1697,6 +1697,22 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise()
       expect(Array.from(marker1Region.parentElement.children).indexOf(marker1Region)).toBe(0)
     })
+
+    it('correctly positions highlights that end on rows preceding block decorations', async () => {
+      const {editor, element, component} = buildComponent()
+
+      const item = document.createElement('div')
+      item.style.height = '30px'
+      editor.decorateMarker(editor.markBufferPosition([4, 0]), {
+        type: 'block',  position: 'after', item
+      })
+      editor.setSelectedBufferRange([[3, 0], [4, Infinity]])
+      await component.getNextUpdatePromise()
+
+      const regions = element.querySelectorAll('.selection .region')
+      expect(regions[0].offsetTop).toBe(3 * component.getLineHeight())
+      expect(regions[1].offsetTop).toBe(4 * component.getLineHeight())
+    })
   })
 
   describe('overlay decorations', () => {

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1982,7 +1982,6 @@ describe('TextEditorComponent', () => {
   })
 
   describe('block decorations', () => {
-    it('renders visible block decorations between the appropriate lines, refreshing and measuring them as needed', async () => {
       const editor = buildEditor({autoHeight: false})
       const {item: item1, decoration: decoration1} = createBlockDecorationAtScreenRow(editor, 0, {height: 11, position: 'before'})
       const {item: item2, decoration: decoration2} = createBlockDecorationAtScreenRow(editor, 2, {height: 22, margin: 10, position: 'before'})
@@ -2010,8 +2009,8 @@ describe('TextEditorComponent', () => {
       // add block decorations
       const {item: item3, decoration: decoration3} = createBlockDecorationAtScreenRow(editor, 4, {height: 33, position: 'before'})
       const {item: item4, decoration: decoration4} = createBlockDecorationAtScreenRow(editor, 7, {height: 44, position: 'before'})
-      const {item: item5, decoration: decoration5} = createBlockDecorationAtScreenRow(editor, 7, {height: 55, position: 'after'})
-      const {item: item6, decoration: decoration6} = createBlockDecorationAtScreenRow(editor, 12, {height: 66, position: 'after'})
+      const {item: item5, decoration: decoration5} = createBlockDecorationAtScreenRow(editor, 7, {height: 50, marginBottom: 5, position: 'after'})
+      const {item: item6, decoration: decoration6} = createBlockDecorationAtScreenRow(editor, 12, {height: 60, marginTop: 6, position: 'after'})
       await component.getNextUpdatePromise()
       expect(component.getRenderedStartRow()).toBe(0)
       expect(component.getRenderedEndRow()).toBe(9)
@@ -2343,11 +2342,13 @@ describe('TextEditorComponent', () => {
       expect(editor.getCursorScreenPosition()).toEqual([0, 0])
     })
 
-    function createBlockDecorationAtScreenRow(editor, screenRow, {height, margin, position}) {
+    function createBlockDecorationAtScreenRow(editor, screenRow, {height, margin, marginTop, marginBottom, position}) {
       const marker = editor.markScreenPosition([screenRow, 0], {invalidate: 'never'})
       const item = document.createElement('div')
       item.style.height = height + 'px'
       if (margin != null) item.style.margin = margin + 'px'
+      if (marginTop != null) item.style.marginTop = marginTop + 'px'
+      if (marginBottom != null) item.style.marginBottom = marginBottom + 'px'
       item.style.width = 30 + 'px'
       const decoration = editor.decorateMarker(marker, {type: 'block', item, position})
       return {item, decoration}

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1698,20 +1698,30 @@ describe('TextEditorComponent', () => {
       expect(Array.from(marker1Region.parentElement.children).indexOf(marker1Region)).toBe(0)
     })
 
-    it('correctly positions highlights that end on rows preceding block decorations', async () => {
+    it('correctly positions highlights that end on rows preceding or following block decorations', async () => {
       const {editor, element, component} = buildComponent()
 
-      const item = document.createElement('div')
-      item.style.height = '30px'
+      const item1 = document.createElement('div')
+      item1.style.height = '30px'
+      item1.style.backgroundColor = 'blue'
       editor.decorateMarker(editor.markBufferPosition([4, 0]), {
-        type: 'block',  position: 'after', item
+        type: 'block',  position: 'after', item: item1
       })
-      editor.setSelectedBufferRange([[3, 0], [4, Infinity]])
-      await component.getNextUpdatePromise()
+      const item2 = document.createElement('div')
+      item2.style.height = '30px'
+      item2.style.backgroundColor = 'yellow'
+      editor.decorateMarker(editor.markBufferPosition([4, 0]), {
+        type: 'block',  position: 'before', item: item2
+      })
+      editor.decorateMarker(editor.markBufferRange([[3, 0], [4, Infinity]]), {
+        type: 'highlight', class: 'highlight'
+      })
 
-      const regions = element.querySelectorAll('.selection .region')
+      await component.getNextUpdatePromise()
+      const regions = element.querySelectorAll('.highlight .region')
       expect(regions[0].offsetTop).toBe(3 * component.getLineHeight())
-      expect(regions[1].offsetTop).toBe(4 * component.getLineHeight())
+      expect(regions[0].offsetHeight).toBe(component.getLineHeight())
+      expect(regions[1].offsetTop).toBe(4 * component.getLineHeight() + 30)
     })
   })
 

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1982,6 +1982,7 @@ describe('TextEditorComponent', () => {
   })
 
   describe('block decorations', () => {
+    it('renders visible block decorations between the appropriate lines, refreshing and measuring them as needed', async () => {
       const editor = buildEditor({autoHeight: false})
       const {item: item1, decoration: decoration1} = createBlockDecorationAtScreenRow(editor, 0, {height: 11, position: 'before'})
       const {item: item2, decoration: decoration2} = createBlockDecorationAtScreenRow(editor, 2, {height: 22, margin: 10, position: 'before'})

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1316,7 +1316,7 @@ class TextEditorComponent {
         const {start, end} = highlight.screenRange
         highlight.startPixelTop = this.pixelPositionAfterBlocksForRow(start.row)
         highlight.startPixelLeft = this.pixelLeftForRowAndColumn(start.row, start.column)
-        highlight.endPixelTop = this.pixelPositionBeforeBlocksForRow(end.row + 1)
+        highlight.endPixelTop = this.pixelPositionBeforeBlocksForRow(end.row) + this.getLineHeight()
         highlight.endPixelLeft = this.pixelLeftForRowAndColumn(end.row, end.column)
       }
       this.decorationsToRender.highlights.set(tileRow, highlights)

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -120,6 +120,8 @@ class TextEditorComponent {
     this.horizontalPixelPositionsByScreenLineId = new Map() // Values are maps from column to horiontal pixel positions
     this.blockDecorationsToMeasure = new Set()
     this.blockDecorationsByElement = new WeakMap()
+    this.blockDecorationSentinel = document.createElement('div')
+    this.blockDecorationSentinel.style.height = '1px'
     this.heightsByBlockDecoration = new WeakMap()
     this.blockDecorationResizeObserver = new ResizeObserver(this.didResizeBlockDecorations.bind(this))
     this.lineNodesByScreenLineId = new Map()
@@ -309,21 +311,22 @@ class TextEditorComponent {
           const parentElement = decorationElement.parentElement
 
           if (!decorationElement.previousSibling) {
-            const sentinelElement = document.createElement('div')
+            const sentinelElement = this.blockDecorationSentinel.cloneNode()
             parentElement.insertBefore(sentinelElement, decorationElement)
             sentinelElements.add(sentinelElement)
           }
 
           if (!decorationElement.nextSibling) {
-            const sentinelElement = document.createElement('div')
+            const sentinelElement = this.blockDecorationSentinel.cloneNode()
             parentElement.appendChild(sentinelElement)
             sentinelElements.add(sentinelElement)
           }
 
           this.didMeasureVisibleBlockDecoration = true
         } else {
+          blockDecorationMeasurementArea.appendChild(this.blockDecorationSentinel.cloneNode())
           blockDecorationMeasurementArea.appendChild(decorationElement)
-          blockDecorationMeasurementArea.appendChild(document.createElement('div'))
+          blockDecorationMeasurementArea.appendChild(this.blockDecorationSentinel.cloneNode())
         }
       })
 

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1316,7 +1316,7 @@ class TextEditorComponent {
         const {start, end} = highlight.screenRange
         highlight.startPixelTop = this.pixelPositionAfterBlocksForRow(start.row)
         highlight.startPixelLeft = this.pixelLeftForRowAndColumn(start.row, start.column)
-        highlight.endPixelTop = this.pixelPositionBeforeBlocksForRow(end.row) + this.getLineHeight()
+        highlight.endPixelTop = this.pixelPositionAfterBlocksForRow(end.row) + this.getLineHeight()
         highlight.endPixelLeft = this.pixelLeftForRowAndColumn(end.row, end.column)
       }
       this.decorationsToRender.highlights.set(tileRow, highlights)


### PR DESCRIPTION
Previously, we were calculating the position preceding block decorations for the row following the end of the highlighted range, but that's actually wrong. We just want the position following block decorations of the end of the highlighted range, plus one line height. This prevents us from incorrectly rendering the end of highlight after block decorations that immediately follow the end of the highlighted range.

Before:

<img width="316" alt="screen shot 2017-08-18 at 8 56 51 pm" src="https://user-images.githubusercontent.com/1789/29482915-ded1c2cc-8457-11e7-8351-e954d1429aa2.png">

After:

<img width="362" alt="screen shot 2017-08-18 at 8 56 44 pm" src="https://user-images.githubusercontent.com/1789/29482921-f6ad596a-8457-11e7-9e4e-07ae2aba52ad.png">

/cc @ungb @as-cii 