### PR TITLE
Use standard (eslint's) 'env' field over globals

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,27 +174,14 @@
     "test": "node script/test"
   },
   "standard": {
+    "env": {
+      "atomtest": true,
+      "browser": true,
+      "jasmine": true,
+      "node": true
+    },
     "globals": [
       "atom",
-      "afterEach",
-      "beforeEach",
-      "describe",
-      "fdescribe",
-      "xdescribe",
-      "expect",
-      "it",
-      "fit",
-      "xit",
-      "jasmine",
-      "runs",
-      "spyOn",
-      "waitsFor",
-      "waitsForPromise",
-      "indexedDB",
-      "IntersectionObserver",
-      "FocusEvent",
-      "requestAnimationFrame",
-      "HTMLElement",
       "snapshotResult"
     ]
   }

--- a/spec/panel-container-element-spec.js
+++ b/spec/panel-container-element-spec.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* global HTMLElement */
-
 const Panel = require('../src/panel')
 const PanelContainer = require('../src/panel-container')
 

--- a/spec/text-editor-element-spec.js
+++ b/spec/text-editor-element-spec.js
@@ -1,5 +1,3 @@
-/* global HTMLDivElement */
-
 const {it, fit, ffit, fffit, beforeEach, afterEach, conditionPromise, timeoutPromise} = require('./async-spec-helpers')
 const TextEditor = require('../src/text-editor')
 const TextEditorElement = require('../src/text-editor-element')

--- a/spec/workspace-element-spec.js
+++ b/spec/workspace-element-spec.js
@@ -1,7 +1,5 @@
 /** @babel */
 
-/* global getComputedStyle, WheelEvent */
-
 const {ipcRenderer} = require('electron')
 const path = require('path')
 const temp = require('temp').track()

--- a/src/panel-container-element.js
+++ b/src/panel-container-element.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* global HTMLElement */
-
 const {CompositeDisposable} = require('event-kit')
 
 class PanelContainerElement extends HTMLElement {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -1,5 +1,3 @@
-/* global MutationObserver */
-
 'use strict'
 
 const EventKit = require('event-kit')

--- a/src/workspace-element.js
+++ b/src/workspace-element.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* global HTMLElement */
-
 const {ipcRenderer} = require('electron')
 const path = require('path')
 const fs = require('fs-plus')


### PR DESCRIPTION
Test Plan: ensure every removed global is a part of an added `env` from https://github.com/sindresorhus/globals/blob/master/globals.json

run `./script/lint`

Released under CC0