### PR TITLE
[Atom development] Move linter dependencies to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,11 @@
     "language-xml": "0.35.2",
     "language-yaml": "0.30.1"
   },
+  "devDependencies": {
+    "coffeelint": "1.15.7",
+    "csslint": "1.0.2",
+    "standard": "8.4.0"
+  },
   "private": true,
   "scripts": {
     "preinstall": "node -e 'process.exit(0)'",

--- a/script/package.json
+++ b/script/package.json
@@ -4,9 +4,7 @@
   "dependencies": {
     "async": "2.0.1",
     "babel-core": "5.8.38",
-    "coffeelint": "1.15.7",
     "colors": "1.1.2",
-    "csslint": "1.0.2",
     "donna": "1.0.16",
     "electron-chromedriver": "~1.6",
     "electron-link": "0.1.1",
@@ -28,7 +26,6 @@
     "runas": "3.1.1",
     "season": "5.3.0",
     "semver": "5.3.0",
-    "standard": "8.4.0",
     "sync-request": "3.0.1",
     "tello": "1.0.5",
     "webdriverio": "2.4.5",


### PR DESCRIPTION
Atom's linter configurations are stored in the root, but since they were only used in files under `scripts/`, their npm dependencies were stored `scripts/package.json`. This meant that tools like the `coffeelint` and `standard` integrations for Atom couldn't find those binaries from `src/`, `spec/`, etc and either fell back to bundled or global versions (as did Atom's `linter-coffeescript`) which mismatched the lcoal installation, or simply failed silently (as with `linter-js-standard` and `linter-js-standard-engine`).

This change makes the correct versions available to these tools, and they remain accessible from `scripts/` so long as the root as its dependencies installed.

Somewhat unrelated: would you be opposed to me documenting my experience getting Atom dev up and running in a section next to `Building` in the project README? Could also mention these packages and how to build Atom using Atom itself.

Open to alternative suggestions to get these tools to play properly while developing Atom with Atom :)

Released under CC0.