### PR TITLE
Don't select when typing while also holding the left mouse button

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1864,6 +1864,7 @@ class TextEditorComponent {
   handleMouseDragUntilMouseUp ({didDrag, didStopDragging}) {
     let dragging = false
     let lastMousemoveEvent
+    let bufferWillChangeDisposable
 
     const animationFrameLoop = () => {
       window.requestAnimationFrame(() => {
@@ -1885,6 +1886,7 @@ class TextEditorComponent {
     function didMouseUp () {
       window.removeEventListener('mousemove', didMouseMove)
       window.removeEventListener('mouseup', didMouseUp)
+      bufferWillChangeDisposable.dispose()
       if (dragging) {
         dragging = false
         didStopDragging()
@@ -1893,6 +1895,10 @@ class TextEditorComponent {
 
     window.addEventListener('mousemove', didMouseMove)
     window.addEventListener('mouseup', didMouseUp, {capture: true})
+    // Simulate a mouse-up event if the buffer is about to change. This prevents
+    // unwanted selections when users perform edits while holding the left mouse
+    // button at the same time.
+    bufferWillChangeDisposable = this.props.model.getBuffer().onWillChange(didMouseUp)
   }
 
   autoscrollOnMouseDrag ({clientX, clientY}, verticalOnly = false) {


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15217
Fixes https://github.com/atom/atom/issues/15405

This pull-request addresses a regression that was causing edits performed while users were holding the left mouse button to result in unwanted selections.

| Before                                                                                                        | After                                                                                                        |
|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
| ![before](https://user-images.githubusercontent.com/482957/29560759-615f5b22-8733-11e7-98e8-72a79b1e28dc.gif) | ![after](https://user-images.githubusercontent.com/482957/29560760-617e3628-8733-11e7-937e-5fe55a16b974.gif) |

Back in Atom 1.18, we used to handle this subtle behavior via an `onWillChange` event subscription on the buffer:

https://github.com/atom/atom/blob/783cda8642e42e842a7aac761f267e151f3db324/src/text-editor-component.coffee#L727

And this pull-request uses the same strategy to work around the problem.

/cc: @nathansobo @Ben3eeE @ungb 