### PR TITLE
Include more metadata when missing a line node in horizontal measurement

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2231,7 +2231,8 @@ class TextEditorComponent {
       if (!lineNode) {
         const error = new Error('Requested measurement of a line that is not currently rendered')
         error.metadata = {
-          row, columnsToMeasure,
+          row,
+          columnsToMeasure,
           renderedScreenLineIds: this.renderedScreenLines.map((line) => line.id),
           extraRenderedScreenLineIds: Array.from(this.extraRenderedScreenLines.keys()),
           lineNodeScreenLineIds: Array.from(this.lineNodesByScreenLineId.keys())

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2230,7 +2230,12 @@ class TextEditorComponent {
 
       if (!lineNode) {
         const error = new Error('Requested measurement of a line that is not currently rendered')
-        error.metadata = {row, columnsToMeasure}
+        error.metadata = {
+          row, columnsToMeasure,
+          renderedScreenLineIds: this.renderedScreenLines.map((line) => line.id),
+          extraRenderedScreenLineIds: Array.from(this.extraRenderedScreenLines.keys()),
+          lineNodeScreenLineIds: Array.from(this.lineNodesByScreenLineId.keys())
+        }
         throw error
       }
 


### PR DESCRIPTION
This PR adds more metadata to the exception throw in https://github.com/atom/atom/issues/15263, with hopes we can understand the cause. We have yet to see one of these exceptions in BugSnag, which makes me think that it's either extremely rare and those experiencing it have metrics disabled, or that there's something wrong with our exception reporting.

/cc @as-cii 