### PR TITLE
Upgrade to Electron Packager 11

### DIFF
--- a/script/lib/package-application.js
+++ b/script/lib/package-application.js
@@ -31,6 +31,8 @@ module.exports = function () {
     out: CONFIG.buildOutputPath,
     overwrite: true,
     platform: process.platform,
+    // Atom doesn't have devDependencies, but if prune is true, it will delete the non-standard packageDependencies.
+    prune: false,
     win32metadata: {
       CompanyName: 'GitHub, Inc.',
       FileDescription: 'Atom',

--- a/script/lib/package-application.js
+++ b/script/lib/package-application.js
@@ -123,8 +123,8 @@ function getAppName () {
 function runPackager (options) {
   return electronPackager(options)
     .then(packageOutputDirPaths => {
-        assert(packageOutputDirPaths.length === 1, 'Generated more than one electron application!')
-        return renamePackagedAppDir(packageOutputDirPaths[0])
+      assert(packageOutputDirPaths.length === 1, 'Generated more than one electron application!')
+      return renamePackagedAppDir(packageOutputDirPaths[0])
     })
 }
 

--- a/script/lib/package-application.js
+++ b/script/lib/package-application.js
@@ -26,7 +26,7 @@ module.exports = function () {
     electronVersion: CONFIG.appMetadata.electronVersion,
     extendInfo: path.join(CONFIG.repositoryRootPath, 'resources', 'mac', 'atom-Info.plist'),
     helperBundleId: 'com.github.atom.helper',
-    icon: getIcon(),
+    icon: path.join(CONFIG.repositoryRootPath, 'resources', 'app-icons', CONFIG.channel, 'atom'),
     name: appName,
     out: CONFIG.buildOutputPath,
     overwrite: true,
@@ -117,19 +117,6 @@ function getAppName () {
     return CONFIG.channel === 'beta' ? 'Atom Beta' : 'Atom'
   } else {
     return 'atom'
-  }
-}
-
-function getIcon () {
-  switch (process.platform) {
-    case 'darwin':
-      return path.join(CONFIG.repositoryRootPath, 'resources', 'app-icons', CONFIG.channel, 'atom.icns')
-    case 'linux':
-      // Don't pass an icon, as the dock/window list icon is set via the icon
-      // option in the BrowserWindow constructor in atom-window.coffee.
-      return null
-    default:
-      return path.join(CONFIG.repositoryRootPath, 'resources', 'app-icons', CONFIG.channel, 'atom.ico')
   }
 }
 

--- a/script/lib/package-application.js
+++ b/script/lib/package-application.js
@@ -4,12 +4,14 @@ const assert = require('assert')
 const childProcess = require('child_process')
 const electronPackager = require('electron-packager')
 const fs = require('fs-extra')
+const hostArch = require('electron-packager/targets').hostArch
 const includePathInPackagedApp = require('./include-path-in-packaged-app')
 const getLicenseText = require('./get-license-text')
 const path = require('path')
 const spawnSync = require('./spawn-sync')
 
 const CONFIG = require('../config')
+const HOST_ARCH = hostArch()
 
 module.exports = function () {
   const appName = getAppName()
@@ -18,7 +20,7 @@ module.exports = function () {
     appBundleId: 'com.github.atom',
     appCopyright: `Copyright © 2014-${(new Date()).getFullYear()} GitHub, Inc. All rights reserved.`,
     appVersion: CONFIG.appMetadata.version,
-    arch: process.platform === 'darwin' ? 'x64' : process.arch, // OS X is 64-bit only
+    arch: process.platform === 'darwin' ? 'x64' : HOST_ARCH, // OS X is 64-bit only
     asar: {unpack: buildAsarUnpackGlobExpression()},
     buildVersion: CONFIG.appMetadata.version,
     download: {cache: CONFIG.electronDownloadPath},
@@ -140,12 +142,12 @@ function renamePackagedAppDir (packageOutputDirPath) {
   } else if (process.platform === 'linux') {
     const appName = CONFIG.channel === 'beta' ? 'atom-beta' : 'atom'
     let architecture
-    if (process.arch === 'ia32') {
+    if (HOST_ARCH === 'ia32') {
       architecture = 'i386'
-    } else if (process.arch === 'x64') {
+    } else if (HOST_ARCH === 'x64') {
       architecture = 'amd64'
     } else {
-      architecture = process.arch
+      architecture = HOST_ARCH
     }
     packagedAppPath = path.join(CONFIG.buildOutputPath, `${appName}-${CONFIG.appMetadata.version}-${architecture}`)
     if (fs.existsSync(packagedAppPath)) fs.removeSync(packagedAppPath)
@@ -153,8 +155,8 @@ function renamePackagedAppDir (packageOutputDirPath) {
   } else {
     const appName = CONFIG.channel === 'beta' ? 'Atom Beta' : 'Atom'
     packagedAppPath = path.join(CONFIG.buildOutputPath, appName)
-    if (process.platform === 'win32' && process.arch !== 'ia32') {
-      packagedAppPath += ` ${process.arch}`
+    if (process.platform === 'win32' && HOST_ARCH !== 'ia32') {
+      packagedAppPath += ` ${HOST_ARCH}`
     }
     if (fs.existsSync(packagedAppPath)) fs.removeSync(packagedAppPath)
     fs.renameSync(packageOutputDirPath, packagedAppPath)

--- a/script/lib/package-application.js
+++ b/script/lib/package-application.js
@@ -15,26 +15,26 @@ module.exports = function () {
   const appName = getAppName()
   console.log(`Running electron-packager on ${CONFIG.intermediateAppPath} with app name "${appName}"`)
   return runPackager({
-    'app-bundle-id': 'com.github.atom',
-    'app-copyright': `Copyright © 2014-${(new Date()).getFullYear()} GitHub, Inc. All rights reserved.`,
-    'app-version': CONFIG.appMetadata.version,
-    'arch': process.platform === 'darwin' ? 'x64' : process.arch, // OS X is 64-bit only
-    'asar': {unpack: buildAsarUnpackGlobExpression()},
-    'build-version': CONFIG.appMetadata.version,
-    'download': {cache: CONFIG.electronDownloadPath},
-    'dir': CONFIG.intermediateAppPath,
-    'extend-info': path.join(CONFIG.repositoryRootPath, 'resources', 'mac', 'atom-Info.plist'),
-    'helper-bundle-id': 'com.github.atom.helper',
-    'icon': getIcon(),
-    'name': appName,
-    'out': CONFIG.buildOutputPath,
-    'overwrite': true,
-    'platform': process.platform,
-    'version': CONFIG.appMetadata.electronVersion,
-    'version-string': {
-      'CompanyName': 'GitHub, Inc.',
-      'FileDescription': 'Atom',
-      'ProductName': 'Atom'
+    appBundleId: 'com.github.atom',
+    appCopyright: `Copyright © 2014-${(new Date()).getFullYear()} GitHub, Inc. All rights reserved.`,
+    appVersion: CONFIG.appMetadata.version,
+    arch: process.platform === 'darwin' ? 'x64' : process.arch, // OS X is 64-bit only
+    asar: {unpack: buildAsarUnpackGlobExpression()},
+    buildVersion: CONFIG.appMetadata.version,
+    download: {cache: CONFIG.electronDownloadPath},
+    dir: CONFIG.intermediateAppPath,
+    electronVersion: CONFIG.appMetadata.electronVersion,
+    extendInfo: path.join(CONFIG.repositoryRootPath, 'resources', 'mac', 'atom-Info.plist'),
+    helperBundleId: 'com.github.atom.helper',
+    icon: getIcon(),
+    name: appName,
+    out: CONFIG.buildOutputPath,
+    overwrite: true,
+    platform: process.platform,
+    win32metadata: {
+      CompanyName: 'GitHub, Inc.',
+      FileDescription: 'Atom',
+      ProductName: 'Atom'
     }
   }).then((packagedAppPath) => {
     let bundledResourcesPath
@@ -134,18 +134,11 @@ function getIcon () {
 }
 
 function runPackager (options) {
-  return new Promise((resolve, reject) => {
-    electronPackager(options, (err, packageOutputDirPaths) => {
-      if (err) {
-        reject(err)
-        throw new Error(err)
-      } else {
+  return electronPackager(options)
+    .then(packageOutputDirPaths => {
         assert(packageOutputDirPaths.length === 1, 'Generated more than one electron application!')
-        const packagedAppPath = renamePackagedAppDir(packageOutputDirPaths[0])
-        resolve(packagedAppPath)
-      }
+        return renamePackagedAppDir(packageOutputDirPaths[0])
     })
-  })
 }
 
 function renamePackagedAppDir (packageOutputDirPath) {

--- a/script/package.json
+++ b/script/package.json
@@ -11,7 +11,7 @@
     "electron-chromedriver": "~1.7",
     "electron-link": "0.1.2",
     "electron-mksnapshot": "~1.7",
-    "electron-packager": "7.3.0",
+    "electron-packager": "9.0.0",
     "electron-winstaller": "2.6.4",
     "fs-admin": "^0.1.5",
     "fs-extra": "0.30.0",

--- a/script/package.json
+++ b/script/package.json
@@ -11,7 +11,7 @@
     "electron-chromedriver": "~1.7",
     "electron-link": "0.1.2",
     "electron-mksnapshot": "~1.7",
-    "electron-packager": "10.1.0",
+    "electron-packager": "11.0.0",
     "electron-winstaller": "2.6.4",
     "fs-admin": "^0.1.5",
     "fs-extra": "0.30.0",

--- a/script/package.json
+++ b/script/package.json
@@ -11,7 +11,7 @@
     "electron-chromedriver": "~1.7",
     "electron-link": "0.1.2",
     "electron-mksnapshot": "~1.7",
-    "electron-packager": "9.0.0",
+    "electron-packager": "10.1.0",
     "electron-winstaller": "2.6.4",
     "fs-admin": "^0.1.5",
     "fs-extra": "0.30.0",


### PR DESCRIPTION
### Description of the Change

Hi there, I'm the maintainer of Electron Packager. I just released [version 9.0.0](https://github.com/electron-userland/electron-packager/releases/tag/v9.0.0), and thought that I could help upgrade a bunch of the projects that depend on it.

### Alternate Designs

N/A

### Why Should This Be In Core?

This already packages Atom :smile:

### Benefits

There's so many more features in 11 than 7.3.0, but the most notable ones are that version 8 added armv7l support, 9 added arm64 support, and 11 added mips64el support, so whenever you're ready to start officially supporting those platforms, Packager's ready to help!

### Possible Drawbacks

As with any upgrade of a module, there might be some bugs that crept in, but hopefully this whole exercise will help find them.

### Applicable Issues

None that I'm aware of.