### PR TITLE
Don't attempt to move undefined items when splitting panes

### DIFF
--- a/spec/pane-spec.js
+++ b/spec/pane-spec.js
@@ -1152,6 +1152,32 @@ describe('Pane', () => {
       })
     })
 
+    describe('when the pane is empty', () => {
+      describe('when `moveActiveItem: true` is passed in the params', () => {
+        it('gracefully ignores the moveActiveItem parameter', () => {
+          pane1.destroyItem(item1)
+          expect(pane1.getActiveItem()).toBe(undefined)
+
+          const pane2 = pane1.split('horizontal', 'before', {moveActiveItem: true})
+          expect(container.root.children).toEqual([pane2, pane1])
+
+          expect(pane2.getActiveItem()).toBe(undefined)
+        })
+      })
+
+      describe('when `copyActiveItem: true` is passed in the params', () => {
+        it('gracefully ignores the copyActiveItem parameter', () => {
+          pane1.destroyItem(item1)
+          expect(pane1.getActiveItem()).toBe(undefined)
+
+          const pane2 = pane1.split('horizontal', 'before', {copyActiveItem: true})
+          expect(container.root.children).toEqual([pane2, pane1])
+
+          expect(pane2.getActiveItem()).toBe(undefined)
+        })
+      })
+    })
+
     it('activates the new pane', () => {
       expect(pane1.isActive()).toBe(true)
       const pane2 = pane1.splitRight()

--- a/src/pane.coffee
+++ b/src/pane.coffee
@@ -888,7 +888,7 @@ class Pane
       when 'before' then @parent.insertChildBefore(this, newPane)
       when 'after' then @parent.insertChildAfter(this, newPane)
 
-    @moveItemToPane(@activeItem, newPane) if params?.moveActiveItem
+    @moveItemToPane(@activeItem, newPane) if params?.moveActiveItem and @activeItem
 
     newPane.activate()
     newPane


### PR DESCRIPTION
### Description of the Change

Before this PR running `pane:split-[direction]-and-move-active-item` on an empty pane creates a new empty pane and throws an exception because `undefined` can not be moved. This PR adds a condition to not try and move if `@activeItem` is `undefined`.

With this change the behavior is the same in that we create an empty pane in the direction when doing this but without throwing an exception.

I also added a test for copying empty panes. `pane:split-[direction]-and-copy-active-item` already worked on empty panes before this PR.

### Alternate Designs

We could do nothing if `@activeItem` is `undefined`. But I did not go with this because it changes the behavior and the split functions should return the created pane.

### Why Should This Be In Core?

The code is already in core.

### Benefits

* Fixes an exception

### Possible Drawbacks

Did not consider any drawbacks.

### Applicable Issues

Fixes https://github.com/atom/atom/issues/11189
