### PR TITLE
Replace pathwatcher w/ bundled watcher to catch created & rename events

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "scandal": "^3.1.0",
     "scoped-property-store": "^0.17.0",
     "scrollbar-style": "^3.2",
-    "season": "^6.0.0",
+    "season": "^6.0.1",
     "semver": "^4.3.3",
     "service-hub": "^0.7.4",
     "sinon": "1.17.4",

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1750,7 +1750,7 @@ describe "Config", ->
           expect(atom.config.set('foo.bar.str_options', 'One')).toBe false
           expect(atom.config.get('foo.bar.str_options')).toEqual 'two'
 
-  describe "when .set/.unset is called prior to .loadUserConfig", ->
+  fdescribe "when .set/.unset is called prior to .loadUserConfig", ->
     beforeEach ->
       atom.config.settingsLoaded = false
 

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -896,19 +896,15 @@ describe "Config", ->
     describe ".observeUserConfig()", ->
       updatedHandler = null
 
-      writeConfigFile = (data) ->
-        previousSetTimeoutCallCount = setTimeout.callCount
-        runs ->
-          fs.writeFileSync(atom.config.configFilePath, data)
-        # waitsFor "debounced config file load", ->
-        #   setTimeout.callCount > previousSetTimeoutCallCount
-        waitsFor "file written", ->
-          fs.readFileSync(atom.config.configFilePath, 'utf8') is data
-        runs ->
-          advanceClock(1000)
+      writeConfigFile = (data, secondsInFuture = 0) ->
+        fs.writeFileSync(atom.config.configFilePath, data)
+
+        future = (Date.now() / 1000) + secondsInFuture
+        fs.utimesSync(atom.config.configFilePath, future, future)
 
       beforeEach ->
-        console.log 'beforeEach'
+        jasmine.useRealClock()
+
         atom.config.setSchema 'foo',
           type: 'object'
           properties:
@@ -924,7 +920,7 @@ describe "Config", ->
               default: 12
 
         expect(fs.existsSync(atom.config.configDirPath)).toBeFalsy()
-        fs.writeFileSync atom.config.configFilePath, """
+        writeConfigFile """
           '*':
             foo:
               bar: 'baz'
@@ -955,9 +951,11 @@ describe "Config", ->
           atom.config.unobserveUserConfig()
           fs.removeSync(dotAtomPath)
 
-        fit "updates the config data", ->
-          writeConfigFile("foo: { bar: 'quux', baz: 'bar'}")
+        it "updates the config data", ->
+          writeConfigFile "foo: { bar: 'quux', baz: 'bar'}", 2
+
           waitsFor 'update event', -> updatedHandler.callCount > 0
+
           runs ->
             expect(atom.config.get('foo.bar')).toBe 'quux'
             expect(atom.config.get('foo.baz')).toBe 'bar'
@@ -965,7 +963,7 @@ describe "Config", ->
         it "does not fire a change event for paths that did not change", ->
           atom.config.onDidChange 'foo.bar', noChangeSpy = jasmine.createSpy()
 
-          writeConfigFile("foo: { bar: 'baz', baz: 'ok'}")
+          writeConfigFile "foo: { bar: 'baz', baz: 'ok'}", 2
           waitsFor 'update event', -> updatedHandler.callCount > 0
 
           runs ->
@@ -980,7 +978,8 @@ describe "Config", ->
               items:
                 type: 'string'
 
-            writeConfigFile("foo: { bar: ['baz', 'ok']}")
+            updatedHandler.reset()
+            writeConfigFile "foo: { bar: ['baz', 'ok']}", 4
             waitsFor 'update event', -> updatedHandler.callCount > 0
             runs -> updatedHandler.reset()
 
@@ -988,7 +987,7 @@ describe "Config", ->
             noChangeSpy = jasmine.createSpy()
             atom.config.onDidChange('foo.bar', noChangeSpy)
 
-            writeConfigFile("foo: { bar: ['baz', 'ok'], baz: 'another'}")
+            writeConfigFile "foo: { bar: ['baz', 'ok'], baz: 'another'}", 2
             waitsFor 'update event', -> updatedHandler.callCount > 0
 
             runs ->
@@ -1005,7 +1004,7 @@ describe "Config", ->
               '*':
                 foo:
                   scoped: false
-            """
+            """, 2
             waitsFor 'update event', -> updatedHandler.callCount > 0
 
             runs ->
@@ -1023,7 +1022,7 @@ describe "Config", ->
               '.source.ruby':
                 foo:
                   scoped: true
-            """
+            """, 2
             waitsFor 'update event', -> updatedHandler.callCount > 0
 
             runs ->
@@ -1033,7 +1032,7 @@ describe "Config", ->
 
       describe "when the config file changes to omit a setting with a default", ->
         it "resets the setting back to the default", ->
-          writeConfigFile("foo: { baz: 'new'}")
+          writeConfigFile "foo: { baz: 'new'}", 2
           waitsFor 'update event', -> updatedHandler.callCount > 0
           runs ->
             expect(atom.config.get('foo.bar')).toBe 'def'
@@ -1041,20 +1040,20 @@ describe "Config", ->
 
       describe "when the config file changes to be empty", ->
         beforeEach ->
-          writeConfigFile("")
+          updatedHandler.reset()
+          writeConfigFile "", 4
           waitsFor 'update event', -> updatedHandler.callCount > 0
 
         it "resets all settings back to the defaults", ->
           expect(updatedHandler.callCount).toBe 1
           expect(atom.config.get('foo.bar')).toBe 'def'
           atom.config.set("hair", "blonde") # trigger a save
-          advanceClock(500)
-          expect(atom.config.save).toHaveBeenCalled()
+          waitsFor 'save', -> atom.config.save.callCount > 0
 
         describe "when the config file subsequently changes again to contain configuration", ->
           beforeEach ->
             updatedHandler.reset()
-            writeConfigFile("foo: bar: 'newVal'")
+            writeConfigFile "foo: bar: 'newVal'", 2
             waitsFor 'update event', -> updatedHandler.callCount > 0
 
           it "sets the setting to the value specified in the config file", ->
@@ -1064,24 +1063,25 @@ describe "Config", ->
         addErrorHandler = null
         beforeEach ->
           atom.notifications.onDidAddNotification addErrorHandler = jasmine.createSpy()
-          writeConfigFile("}}}")
+          writeConfigFile "}}}", 4
           waitsFor "error to be logged", -> addErrorHandler.callCount > 0
 
         it "logs a warning and does not update config data", ->
           expect(updatedHandler.callCount).toBe 0
           expect(atom.config.get('foo.bar')).toBe 'baz'
+
           atom.config.set("hair", "blonde") # trigger a save
           expect(atom.config.save).not.toHaveBeenCalled()
 
         describe "when the config file subsequently changes again to contain valid cson", ->
           beforeEach ->
-            writeConfigFile("foo: bar: 'newVal'")
+            updatedHandler.reset()
+            writeConfigFile "foo: bar: 'newVal'", 6
             waitsFor 'update event', -> updatedHandler.callCount > 0
 
           it "updates the config data and resumes saving", ->
             atom.config.set("hair", "blonde")
-            advanceClock(500)
-            expect(atom.config.save).toHaveBeenCalled()
+            waitsFor 'save', -> atom.config.save.callCount > 0
 
     describe ".initializeConfigDirectory()", ->
       beforeEach ->
@@ -1757,6 +1757,7 @@ describe "Config", ->
 
           expect(atom.config.set('foo.bar.str_options', 'One')).toBe false
           expect(atom.config.get('foo.bar.str_options')).toEqual 'two'
+
   describe "when .set/.unset is called prior to .loadUserConfig", ->
     console.log 'this test'
     beforeEach ->

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -934,7 +934,7 @@ describe "Config", ->
         waitsForPromise -> atom.config.observeUserConfig()
 
         runs ->
-          updatedHandler = jasmine.createSpy("updatedHandler")
+          updatedHandler = jasmine.createSpy "updatedHandler"
           atom.config.onDidChange updatedHandler
 
       afterEach ->
@@ -953,7 +953,7 @@ describe "Config", ->
             expect(atom.config.get('foo.baz')).toBe 'bar'
 
         it "does not fire a change event for paths that did not change", ->
-          atom.config.onDidChange 'foo.bar', noChangeSpy = jasmine.createSpy()
+          atom.config.onDidChange 'foo.bar', noChangeSpy = jasmine.createSpy "unchanged"
 
           writeConfigFile "foo: { bar: 'baz', baz: 'ok'}", 2
           waitsFor 'update event', -> updatedHandler.callCount > 0
@@ -976,7 +976,7 @@ describe "Config", ->
             runs -> updatedHandler.reset()
 
           it "does not fire a change event for paths that did not change", ->
-            noChangeSpy = jasmine.createSpy()
+            noChangeSpy = jasmine.createSpy "unchanged"
             atom.config.onDidChange('foo.bar', noChangeSpy)
 
             writeConfigFile "foo: { bar: ['baz', 'ok'], baz: 'another'}", 2
@@ -1004,7 +1004,7 @@ describe "Config", ->
               expect(atom.config.get('foo.scoped', scope: ['.source.ruby'])).toBe false
 
           it "does not fire a change event for paths that did not change", ->
-            noChangeSpy = jasmine.createSpy()
+            noChangeSpy = jasmine.createSpy "no change"
             atom.config.onDidChange('foo.scoped', scope: ['.source.ruby'], noChangeSpy)
 
             writeConfigFile """
@@ -1054,7 +1054,7 @@ describe "Config", ->
       describe "when the config file changes to contain invalid cson", ->
         addErrorHandler = null
         beforeEach ->
-          atom.notifications.onDidAddNotification addErrorHandler = jasmine.createSpy()
+          atom.notifications.onDidAddNotification addErrorHandler = jasmine.createSpy "error handler"
           writeConfigFile "}}}", 4
           waitsFor "error to be logged", -> addErrorHandler.callCount > 0
 

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1752,7 +1752,9 @@ describe "Config", ->
 
   describe "when .set/.unset is called prior to .loadUserConfig", ->
     beforeEach ->
-      fs.writeFileSync config.configFilePath, """
+      atom.config.settingsLoaded = false
+
+      fs.writeFileSync atom.config.configFilePath, """
         '*':
           foo:
             bar: 'baz'
@@ -1761,22 +1763,19 @@ describe "Config", ->
       """
 
     it "ensures that all settings are loaded correctly", ->
-      console.log 'test start'
-      config.unset('foo.bar')
-      expect(config.save).not.toHaveBeenCalled()
-      config.set('foo.qux', 'boo')
-      expect(config.save).not.toHaveBeenCalled()
-      expect(config.get('foo.qux')).toBeUndefined()
-      expect(config.get('do.ray')).toBeUndefined()
+      atom.config.unset('foo.bar')
+      expect(atom.config.save).not.toHaveBeenCalled()
+      atom.config.set('foo.qux', 'boo')
+      expect(atom.config.save).not.toHaveBeenCalled()
+      expect(atom.config.get('foo.qux')).toBeUndefined()
+      expect(atom.config.get('do.ray')).toBeUndefined()
 
-      console.log 'loadUserConfig'
-      config.loadUserConfig()
+      atom.config.loadUserConfig()
+      advanceClock 100
 
-      waitsFor -> config.get('foo.bar') is undefined
+      waitsFor -> atom.config.save.callCount > 0
+
       runs ->
-        expect(config.save).toHaveBeenCalled()
-        expect(config.get('foo.bar')).toBeUndefined()
-        expect(config.get('foo.qux')).toBe('boo')
-        expect(config.get('do.ray')).toBe('me')
-
-      console.log 'end test'
+        expect(atom.config.get('foo.bar')).toBeUndefined()
+        expect(atom.config.get('foo.qux')).toBe('boo')
+        expect(atom.config.get('do.ray')).toBe('me')

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -878,7 +878,7 @@ describe "Config", ->
 
         beforeEach ->
           atom.notifications.onDidAddNotification addErrorHandler = jasmine.createSpy()
-          spyOn(fs, "existsSync").andCallFake ->
+          spyOn(fs, "makeTreeSync").andCallFake ->
             error = new Error()
             error.code = 'EPERM'
             throw error

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1756,3 +1756,34 @@ describe "Config", ->
 
           expect(atom.config.set('foo.bar.str_options', 'One')).toBe false
           expect(atom.config.get('foo.bar.str_options')).toEqual 'two'
+  describe "when .set/.unset is called prior to .loadUserConfig", ->
+    console.log 'this test'
+    beforeEach ->
+      fs.writeFileSync config.configFilePath, """
+        '*':
+          foo:
+            bar: 'baz'
+          do:
+            ray: 'me'
+      """
+
+    it "ensures that all settings are loaded correctly", ->
+      console.log 'test start'
+      config.unset('foo.bar')
+      expect(config.save).not.toHaveBeenCalled()
+      config.set('foo.qux', 'boo')
+      expect(config.save).not.toHaveBeenCalled()
+      expect(config.get('foo.qux')).toBeUndefined()
+      expect(config.get('do.ray')).toBeUndefined()
+
+      console.log 'loadUserConfig'
+      config.loadUserConfig()
+
+      waitsFor -> config.get('foo.bar') is undefined
+      runs ->
+        expect(config.save).toHaveBeenCalled()
+        expect(config.get('foo.bar')).toBeUndefined()
+        expect(config.get('foo.qux')).toBe('boo')
+        expect(config.get('do.ray')).toBe('me')
+
+      console.log 'end test'

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -931,7 +931,6 @@ describe "Config", ->
         """
         atom.config.loadUserConfig()
 
-        console.log 'observeUserConfig promise', atom.config.observeUserConfig()
         waitsForPromise -> atom.config.observeUserConfig()
 
         runs ->
@@ -939,17 +938,10 @@ describe "Config", ->
           atom.config.onDidChange updatedHandler
 
       afterEach ->
-        # WHY IS THIS NOT RUNNING?
-        console.log 'afterEach'
         atom.config.unobserveUserConfig()
         fs.removeSync(dotAtomPath)
 
       describe "when the config file changes to contain valid cson", ->
-        afterEach ->
-          # WHY IS THIS NOT RUNNING?
-          console.log 'afterEach'
-          atom.config.unobserveUserConfig()
-          fs.removeSync(dotAtomPath)
 
         it "updates the config data", ->
           writeConfigFile "foo: { bar: 'quux', baz: 'bar'}", 2
@@ -1759,7 +1751,6 @@ describe "Config", ->
           expect(atom.config.get('foo.bar.str_options')).toEqual 'two'
 
   describe "when .set/.unset is called prior to .loadUserConfig", ->
-    console.log 'this test'
     beforeEach ->
       fs.writeFileSync config.configFilePath, """
         '*':

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -1750,7 +1750,7 @@ describe "Config", ->
           expect(atom.config.set('foo.bar.str_options', 'One')).toBe false
           expect(atom.config.get('foo.bar.str_options')).toEqual 'two'
 
-  fdescribe "when .set/.unset is called prior to .loadUserConfig", ->
+  describe "when .set/.unset is called prior to .loadUserConfig", ->
     beforeEach ->
       atom.config.settingsLoaded = false
       fs.writeFileSync atom.config.configFilePath, """

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -14,6 +14,7 @@ describe "Config", ->
     atom.config.configDirPath = dotAtomPath
     atom.config.enablePersistence = true
     atom.config.settingsLoaded = true
+    atom.config.pendingOperations = []
     atom.config.configFilePath = path.join(atom.config.configDirPath, "atom.config.cson")
 
   afterEach ->

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -13,6 +13,7 @@ describe "Config", ->
     dotAtomPath = temp.path('atom-spec-config')
     atom.config.configDirPath = dotAtomPath
     atom.config.enablePersistence = true
+    atom.config.settingsLoaded = true
     atom.config.configFilePath = path.join(atom.config.configDirPath, "atom.config.cson")
 
   afterEach ->

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -429,6 +429,7 @@ class Config
     , 100
 
     debouncedSave = _.debounce =>
+      @savePending = false
       @save()
     , 100
     @requestSave = =>
@@ -922,7 +923,6 @@ class Config
     @notificationManager?.addError(errorMessage, {detail, dismissable: true})
 
   save: ->
-    @savePending = false
     return if @shouldNotAccessFileSystem()
 
     allSettings = {'*': @settings}

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -860,7 +860,6 @@ class Config
   loadUserConfig: ->
     return if @shouldNotAccessFileSystem()
 
-    console.log 'loadUserConfig'
     try
       fs.makeTreeSync(path.dirname(@configFilePath))
       CSON.writeFileSync(@configFilePath, {}, {flag: 'wx'}) # fails if file exists
@@ -891,13 +890,9 @@ class Config
     return if @shouldNotAccessFileSystem()
 
     try
-      console.trace 'create watch subscription', @watchSubscriptionPromise
       @watchSubscriptionPromise ?= watchPath @configFilePath, {}, (events) =>
-        console.log events
         for {action} in events
-          console.log action, @watchSubscriptionPromise?
           if action in ['created', 'modified', 'renamed'] and @watchSubscriptionPromise?
-            console.warn 'request load'
             @requestLoad()
     catch error
       @notifyFailure """
@@ -912,7 +907,6 @@ class Config
   unobserveUserConfig: ->
     @watchSubscriptionPromise?.then((watcher) => watcher?.dispose())
     @watchSubscriptionPromise = null
-    console.log 'unobserve'
 
   notifyFailure: (errorMessage, detail) ->
     @notificationManager?.addError(errorMessage, {detail, dismissable: true})

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -956,9 +956,7 @@ class Config
       @set(key, value, save: false) for key, value of newSettings
       if @pendingOperations.length
         op() for op in @pendingOperations
-        @requestSave()
         @pendingOperations = []
-      return
 
   getRawValue: (keyPath, options) ->
     unless options?.excludeSources?.indexOf(@getUserConfigPath()) >= 0

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -951,7 +951,7 @@ class Config
       @set(key, value, save: false) for key, value of newSettings
       if @pendingOperations.length
         op() for op in @pendingOperations
-        @debouncedSave()
+        @requestSave()
         @pendingOperations = []
       return
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -864,9 +864,10 @@ class Config
       fs.makeTreeSync(path.dirname(@configFilePath))
       CSON.writeFileSync(@configFilePath, {}, {flag: 'wx'}) # fails if file exists
     catch error
-      @configFileHasErrors = true
-      @notifyFailure("Failed to initialize `#{path.basename(@configFilePath)}`", error.stack)
-      return
+      if error.code isnt 'EEXIST'
+        @configFileHasErrors = true
+        @notifyFailure("Failed to initialize `#{path.basename(@configFilePath)}`", error.stack)
+        return
 
     try
       unless @savePending

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -702,7 +702,8 @@ class Config
           setValueAtKeyPath(settings, keyPath, undefined)
           settings = withoutEmptyObjects(settings)
           @set(null, settings, {scopeSelector, source, priority: @priorityForSource(source)}) if settings?
-          @requestSave() if source is @getUserConfigPath and not @configFileHasErrors and @settingsLoaded
+          if source is @getUserConfigPath() and not @configFileHasErrors and @settingsLoaded
+            @requestSave()
       else
         @scopedSettingsStore.removePropertiesForSourceAndSelector(source, scopeSelector)
         @emitChangeEvent()

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -648,11 +648,12 @@ class Config
   # * `true` if the value was set.
   # * `false` if the value was not able to be coerced to the type specified in the setting's schema.
   set: ->
+    [keyPath, value, options] = arguments
+
     unless @settingsLoaded
-      @pendingOperations.push(() => @set.apply(@, arguments))
+      @pendingOperations.push () => @set.call(this, keyPath, value, options)
       return
 
-    [keyPath, value, options] = arguments
     scopeSelector = options?.scopeSelector
     source = options?.source
     shouldSave = options?.save ? true
@@ -684,7 +685,7 @@ class Config
   #   * `source` (optional) {String}. See {::set}
   unset: (keyPath, options) ->
     unless @settingsLoaded
-      @pendingOperations.push(() => @unset.apply(@, arguments))
+      @pendingOperations.push () => @unset.call(this, keyPath, options)
       return
 
     {scopeSelector, source} = options ? {}

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -656,7 +656,7 @@ class Config
     [keyPath, value, options] = arguments
 
     unless @settingsLoaded
-      @pendingOperations.push () => @set.call(this, keyPath, value, options)
+      @pendingOperations.push => @set.call(this, keyPath, value, options)
 
     scopeSelector = options?.scopeSelector
     source = options?.source
@@ -690,7 +690,7 @@ class Config
   #   * `source` (optional) {String}. See {::set}
   unset: (keyPath, options) ->
     unless @settingsLoaded
-      @pendingOperations.push () => @unset.call(this, keyPath, options)
+      @pendingOperations.push => @unset.call(this, keyPath, options)
 
     {scopeSelector, source} = options ? {}
     source ?= @getUserConfigPath()
@@ -916,7 +916,7 @@ class Config
     @watchSubscriptionPromise
 
   unobserveUserConfig: ->
-    @watchSubscriptionPromise?.then((watcher) => watcher?.dispose())
+    @watchSubscriptionPromise?.then (watcher) -> watcher?.dispose()
     @watchSubscriptionPromise = null
 
   notifyFailure: (errorMessage, detail) ->

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -862,11 +862,8 @@ class Config
 
     console.log 'loadUserConfig'
     try
-      # fs.makeTreeSync(path.dirname(@configFilePath))
-      # CSON.writeFileSync(@configFilePath, {flag: 'x'}, {}) # fails if file exists
-      unless fs.existsSync(@configFilePath)
-        fs.makeTreeSync(path.dirname(@configFilePath))
-        CSON.writeFileSync(@configFilePath, {})
+      fs.makeTreeSync(path.dirname(@configFilePath))
+      CSON.writeFileSync(@configFilePath, {}, {flag: 'wx'}) # fails if file exists
     catch error
       @configFileHasErrors = true
       @notifyFailure("Failed to initialize `#{path.basename(@configFilePath)}`", error.stack)

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -851,6 +851,8 @@ class Config
 
     console.log 'loadUserConfig'
     try
+      # fs.makeTreeSync(path.dirname(@configFilePath))
+      # CSON.writeFileSync(@configFilePath, {flag: 'x'}, {}) # fails if file exists
       unless fs.existsSync(@configFilePath)
         fs.makeTreeSync(path.dirname(@configFilePath))
         CSON.writeFileSync(@configFilePath, {})

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -872,6 +872,11 @@ class Config
     try
       unless @savePending
         userConfig = CSON.readFileSync(@configFilePath)
+        userConfig = {} if userConfig is null
+
+        unless isPlainObject(userConfig)
+          throw new Error("`#{path.basename(@configFilePath)}` must contain valid JSON or CSON")
+
         @resetUserSettings(userConfig)
         @configFileHasErrors = false
     catch error
@@ -930,11 +935,6 @@ class Config
   ###
 
   resetUserSettings: (newSettings) ->
-    unless isPlainObject(newSettings)
-      @settings = {}
-      @emitChangeEvent()
-      return
-
     if newSettings.global?
       newSettings['*'] = newSettings.global
       delete newSettings.global

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -399,8 +399,6 @@ class Config
 
   # Created during initialization, available as `atom.config`
   constructor: ({@notificationManager, @enablePersistence}={}) ->
-    @settingsLoaded = false
-    @pendingOperations = []
     @clear()
 
   initialize: ({@configDirPath, @resourcePath, projectHomeSchema}) ->
@@ -420,9 +418,11 @@ class Config
     @settings = {}
     @scopedSettingsStore = new ScopedPropertyStore
 
+    @settingsLoaded = false
     @savePending = false
     @configFileHasErrors = false
     @transactDepth = 0
+    @pendingOperations = []
 
     @requestLoad = _.debounce =>
       @loadUserConfig()


### PR DESCRIPTION
Fixes #14909 

This PR addresses three issues related to config settings data loss.

### Issue 1
_config file stops being watched_

Repro steps (on MacOS):
1. `mv config.cson config.cson-bak`
2. open Atom and open `config.cson`. Note that it's empty except for some settings set by packages. Add `editor.fontSize` and set it to something unusual. Note that the font updates immediately after setting it.
3. `mv config.cson-bak config.cson`
4. note that the `config.cson` file updates, but settings are not loaded. That is, if you changed the `editor.fontSize` normally you observe it updating on the spot, but making changes to the file after moving it will do nothing
5. reload the editor and note that `config.cson` has reverted back to its bare state 

Turns out that after step 3 we stop watching the `config.cson` file. Pathwatcher gives us a `delete`, and subsequent file changes do not result in more `change` events so we don't reload the user's config and update the in-memory settings. Reloading Atom flushes the stale settings to disk and overwrites the changes that were made resulting in lost settings. 

The fix implemented in this PR involves using @smashwilson's new bundled file watching service. We reload the user's config on `created`, `modified`, and `renamed` events. 

The bug outlined above resulted in the config file reverting to a previous version of the file prior to being overwritten. It seems that most of the reports in #14909 indicate that the config file was reset completely, which points to a root cause other than what was outlined above. 

The rest of this PR aims to make the code around writing to the config file more airtight. There are only two places where we make calls to `writeFileSync`: 

### Issue 2
_race condition in `loadUserConfig` when a config file does not yet exist_

Previously, there was room for a race condition. An external process could have created a config file after we checked for its existence and before we wrote to the file, potentially resulting in overwriting the changes made by an external process. 
```
      unless fs.existsSync(@configFilePath)
        CSON.writeFileSync(@configFilePath, {})
``` 
Solution: Don't write file if it already exists (depends on https://github.com/atom/season/pull/22)
```
      CSON.writeFileSync(@configFilePath, {flag: 'x'}, {}) # fails if file exists
```

### Issue 3

_race condition in `save()` we write the blank in-memory settings to disk before the first `loadUserSettings()` call_

Previously, there was the possibility that this happened before the in-memory settings were updated to reflect the user's config on disk (`@settings` is initialized to `{}` and updated only after `loadUserConfig` is called). In this case, writing to the file would clobber all the user's settings. This is the most likely cause of the issues reported in #14909. 

Solution: Store of `set` and `unset` operations run prior to loading the user's config and run them once the in-memory settings are updated. 


TODO:
- [x] fix tests
- [x] update `season` to take options
- [x] store pending operations in config before loaded
- [ ] for hotfix https://github.com/Axosoft/nsfw/blob/ef23f197cff6641276d90cdd779b4c1824fe6d6c/js/src/index.js#L80-L123