### PR TITLE
Shrink probot-stale window to one year and close in two weeks

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,9 +2,9 @@
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
 # Starting at two years of no activity
-daysUntilStale: 730
+daysUntilStale: 365
 # Number of days of inactivity before a stale Issue or Pull Request is closed
-daysUntilClose: 30
+daysUntilClose: 14
 # Issues or Pull Requests with these labels will never be considered stale
 exemptLabels:
   - regression


### PR DESCRIPTION
[probot-stale](https://github.com/probot/stale) has been helping us clean up old issues. We originally implemented it with a very liberal two year stale window to ensure that it worked reliably. Now that probot-stale has [over five thousand issues across all of GitHub under its belt](https://github.com/search?q=commenter%3Aapp%2Fstale&ref=opensearch), we're confident that we can trust it with a more realistic window.

We're shrinking the window where something will be marked stale to one year and if there is no further activity after that, it will be closed in an additional two weeks. All other settings will remain the same.