### PR TITLE
Scroll to center even if line is already visible

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1130,8 +1130,15 @@ describe('TextEditorComponent', () => {
       editor.scrollToScreenRange([[4, 0], [6, 0]], {center: true})
       await component.getNextUpdatePromise()
 
-      const actualScrollCenter = (component.getScrollTop() + component.getScrollBottom()) / 2
-      const expectedScrollCenter = (4 + 7) / 2 * component.getLineHeight()
+      let actualScrollCenter = (component.getScrollTop() + component.getScrollBottom()) / 2
+      let expectedScrollCenter = (4 + 7) / 2 * component.getLineHeight()
+      expect(actualScrollCenter).toBeCloseTo(expectedScrollCenter, 0)
+
+      editor.scrollToScreenRange([[6, 0], [6, 0]], {center: true})
+      await component.getNextUpdatePromise()
+
+      actualScrollCenter = (component.getScrollTop() + component.getScrollBottom()) / 2
+      expectedScrollCenter = (5 + 8) / 2 * component.getLineHeight()
       expect(actualScrollCenter).toBeCloseTo(expectedScrollCenter, 0)
     })
 

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2039,10 +2039,8 @@ class TextEditorComponent {
     let desiredScrollTop, desiredScrollBottom
     if (options && options.center) {
       const desiredScrollCenter = (screenRangeTop + screenRangeBottom) / 2
-      if (desiredScrollCenter < this.getScrollTop() || desiredScrollCenter > this.getScrollBottom()) {
-        desiredScrollTop = desiredScrollCenter - this.getScrollContainerClientHeight() / 2
-        desiredScrollBottom = desiredScrollCenter + this.getScrollContainerClientHeight() / 2
-      }
+      desiredScrollTop = desiredScrollCenter - this.getScrollContainerClientHeight() / 2
+      desiredScrollBottom = desiredScrollCenter + this.getScrollContainerClientHeight() / 2
     } else {
       desiredScrollTop = screenRangeTop - verticalScrollMargin
       desiredScrollBottom = screenRangeBottom + verticalScrollMargin


### PR DESCRIPTION
### Description of the Change

By removing the check that the `desiredScrollCenter` is not yet between the current `scrollTop` and `scrollBottom`, the scroll is always executed if possible. This is the expected behaviour according to the [docs](https://atom.io/docs/api/v1.19.4/TextEditor#instance-scrollToBufferPosition).

### Alternate Designs

The alternative is not changing it. I don't know why the check was ever added, but I can't think of any possible benefits.

### Why Should This Be In Core?

It's already there.

### Benefits

The behaviour will be as documented. This means that it's possible to center a certain position/range, regardless of the current scroll position.

### Possible Drawbacks

Nothing I can think of.

### Applicable Issues

#11429
