### PR TITLE
Refactor install script for linux (install dev channel parallel, use icon themes)

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -9,11 +9,17 @@ else
   exit 1
 fi
 
-if [ "$(basename $0)" == 'atom-beta' ]; then
-  BETA_VERSION=true
-else
-  BETA_VERSION=
-fi
+case $(basename $0) in
+  atom-beta)
+    CHANNEL=beta
+    ;;
+  atom-dev)
+    CHANNEL=dev
+    ;;
+  *)
+    CHANNEL=stable
+    ;;
+esac
 
 export ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT=true
 
@@ -67,7 +73,7 @@ if [ $OS == 'Mac' ]; then
     ATOM_APP_NAME="$(basename "$ATOM_APP")"
   fi
 
-  if [ -n "$BETA_VERSION" ]; then
+  if [ "$CHANNEL" == 'beta' ]; then
     ATOM_EXECUTABLE_NAME="Atom Beta"
   else
     ATOM_EXECUTABLE_NAME="Atom"
@@ -101,11 +107,17 @@ elif [ $OS == 'Linux' ]; then
   SCRIPT=$(readlink -f "$0")
   USR_DIRECTORY=$(readlink -f $(dirname $SCRIPT)/..)
 
-  if [ -n "$BETA_VERSION" ]; then
-    ATOM_PATH="$USR_DIRECTORY/share/atom-beta/atom"
-  else
-    ATOM_PATH="$USR_DIRECTORY/share/atom/atom"
-  fi
+  case $CHANNEL in
+    beta)
+      ATOM_PATH="$USR_DIRECTORY/share/atom-beta/atom"
+      ;;
+    dev)
+      ATOM_PATH="$USR_DIRECTORY/share/atom-dev/atom"
+      ;;
+    *)
+      ATOM_PATH="$USR_DIRECTORY/share/atom/atom"
+      ;;
+  esac
 
   ATOM_HOME="${ATOM_HOME:-$HOME/.atom}"
   mkdir -p "$ATOM_HOME"

--- a/script/lib/install-application.js
+++ b/script/lib/install-application.js
@@ -4,6 +4,7 @@ const fs = require('fs-extra')
 const handleTilde = require('./handle-tilde')
 const path = require('path')
 const template = require('lodash.template')
+const startCase = require('lodash.startcase')
 
 const CONFIG = require('../config')
 
@@ -39,9 +40,9 @@ module.exports = function (packagedAppPath, installDir) {
       })
     }
   } else {
-    const atomExecutableName = CONFIG.channel === 'beta' ? 'atom-beta' : 'atom'
-    const apmExecutableName = CONFIG.channel === 'beta' ? 'apm-beta' : 'apm'
-    const appName = CONFIG.channel === 'beta' ? 'Atom Beta' : 'Atom'
+    const atomExecutableName = CONFIG.channel === 'stable' ? 'atom' : 'atom-' + CONFIG.channel
+    const apmExecutableName = CONFIG.channel === 'stable' ? 'apm' : 'apm-' + CONFIG.channel
+    const appName = CONFIG.channel === 'stable' ? 'Atom' : startCase('Atom ' + CONFIG.channel)
     const appDescription = CONFIG.appMetadata.description
     const prefixDirPath = installDir !== '' ? handleTilde(installDir) : path.join('/usr', 'local')
     const shareDirPath = path.join(prefixDirPath, 'share')

--- a/script/lib/install-application.js
+++ b/script/lib/install-application.js
@@ -5,6 +5,7 @@ const handleTilde = require('./handle-tilde')
 const path = require('path')
 const template = require('lodash.template')
 const startCase = require('lodash.startcase')
+const execSync = require('child_process').execSync
 
 const CONFIG = require('../config')
 
@@ -95,6 +96,11 @@ module.exports = function (packagedAppPath, installDir) {
           fs.copySync(iconPath, path.join(baseIconThemeDirPath, `${size}x${size}`, 'apps', fullIconName))
         }
       })
+
+      console.log(`Updating icon cache for "${baseIconThemeDirPath}"`)
+      try {
+        execSync(`gtk-update-icon-cache ${baseIconThemeDirPath} --force`)
+      } catch (e) {}
     }
 
     { // Install xdg desktop file

--- a/script/lib/install-application.js
+++ b/script/lib/install-application.js
@@ -7,27 +7,28 @@ const template = require('lodash.template')
 
 const CONFIG = require('../config')
 
+function install (installationDirPath, packagedAppFileName, packagedAppPath) {
+  if (fs.existsSync(installationDirPath)) {
+    console.log(`Removing previously installed "${packagedAppFileName}" at "${installationDirPath}"`)
+    fs.removeSync(installationDirPath)
+  }
+
+  console.log(`Installing "${packagedAppFileName}" at "${installationDirPath}"`)
+  fs.copySync(packagedAppPath, installationDirPath)
+}
+
+
 module.exports = function (packagedAppPath, installDir) {
   const packagedAppFileName = path.basename(packagedAppPath)
   if (process.platform === 'darwin') {
     const installPrefix = installDir !== '' ? handleTilde(installDir) : path.join(path.sep, 'Applications')
     const installationDirPath = path.join(installPrefix, packagedAppFileName)
-    if (fs.existsSync(installationDirPath)) {
-      console.log(`Removing previously installed "${packagedAppFileName}" at "${installationDirPath}"`)
-      fs.removeSync(installationDirPath)
-    }
-    console.log(`Installing "${packagedAppPath}" at "${installationDirPath}"`)
-    fs.copySync(packagedAppPath, installationDirPath)
+    install(installationDirPath, packagedAppFileName, packagedAppPath)
   } else if (process.platform === 'win32') {
     const installPrefix = installDir !== '' ? installDir : process.env.LOCALAPPDATA
     const installationDirPath = path.join(installPrefix, packagedAppFileName, 'app-dev')
     try {
-      if (fs.existsSync(installationDirPath)) {
-        console.log(`Removing previously installed "${packagedAppFileName}" at "${installationDirPath}"`)
-        fs.removeSync(installationDirPath)
-      }
-      console.log(`Installing "${packagedAppPath}" at "${installationDirPath}"`)
-      fs.copySync(packagedAppPath, installationDirPath)
+      install(installationDirPath, packagedAppFileName, packagedAppPath)
     } catch (e) {
       console.log(`Administrator elevation required to install into "${installationDirPath}"`)
       const fsAdmin = require('fs-admin')
@@ -54,12 +55,7 @@ module.exports = function (packagedAppPath, installDir) {
     fs.mkdirpSync(applicationsDirPath)
     fs.mkdirpSync(binDirPath)
 
-    if (fs.existsSync(installationDirPath)) {
-      console.log(`Removing previously installed "${packagedAppFileName}" at "${installationDirPath}"`)
-      fs.removeSync(installationDirPath)
-    }
-    console.log(`Installing "${packagedAppFileName}" at "${installationDirPath}"`)
-    fs.copySync(packagedAppPath, installationDirPath)
+    install(installationDirPath, packagedAppFileName, packagedAppPath)
 
     if (fs.existsSync(desktopEntryPath)) {
       console.log(`Removing existing desktop entry file at "${desktopEntryPath}"`)

--- a/script/lib/install-application.js
+++ b/script/lib/install-application.js
@@ -62,7 +62,7 @@ module.exports = function (packagedAppPath, installDir) {
       fs.removeSync(desktopEntryPath)
     }
     console.log(`Writing desktop entry file at "${desktopEntryPath}"`)
-    const iconPath = path.join(CONFIG.repositoryRootPath, 'resources', 'app-icons', CONFIG.channel, 'png', '1024.png')
+    const iconPath = path.join(installationDirPath, 'atom.png')
     const desktopEntryTemplate = fs.readFileSync(path.join(CONFIG.repositoryRootPath, 'resources', 'linux', 'atom.desktop.in'))
     const desktopEntryContents = template(desktopEntryTemplate)({
       appName,

--- a/script/package.json
+++ b/script/package.json
@@ -19,6 +19,7 @@
     "joanna": "0.0.9",
     "klaw-sync": "^1.1.2",
     "legal-eagle": "0.14.0",
+    "lodash.startcase": "4.4.0",
     "lodash.template": "4.4.0",
     "minidump": "0.9.0",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
### Description of the Change

* Some refactoring on the install script (mainly on the linux part) (1.-3. commit).
* Change the install script to create a separate installation for the dev channel (`atom-dev`) like it is already done for the beta channel (`atom-beta`) (4. commit).
* Change the way icons are handled in the xdg desktop file. This replaces the absolute path used previously with a icon name. The name will then be interpreted by the desktop environment, which in turn selects the icon from a icon theme. This is also how the desktop files in the dep and rpm packages already work. (5. commit).
* Change the install script to copy the application icons (in all resolutions) to the default icon theme. This is required to make to point above work when no alternative icon theme is used or the alternative icon theme does not provide an icon. (5. commit).

### Alternate Designs

None

### Why Should This Be In Core?

* Refactors core code.
* The beta channel is already installed in parallel so the dev channel should be too.
* The new way desktop files are handled is more "linuxy" and preferable as default.

### Benefits

* Cleaner code
* Allows all channels to be installed in parallel.
* Users are able to use alternative icon themes with atom; makes atom more hackable.
* The desktop environment gets to choose between different resolutions.
* Aligns the way the manually installed version behaves with the what is installed from a package.

### Possible Drawbacks

None known

### Applicable Issues

* Perhaps fix #12993 (icon scaling issue).
* Fixes icon behavior mentioned in #14480 (wrong icon path). This is fixed with the 2. commit and with the alternative design from the 5. commit.