### PR TITLE
Remove delay on window focus (fixes #9544)

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -19,6 +19,12 @@ const configSchema = {
         title: 'Exclude VCS Ignored Paths',
         description: 'Files and directories ignored by the current project\'s VCS system will be ignored by some packages, such as the fuzzy finder and find and replace. For example, projects using Git have these paths defined in the .gitignore file. Individual packages might have additional config settings for ignoring VCS ignored files and folders.'
       },
+      gitRepositoryRefreshOnWindowFocus: {
+          type: 'boolean',
+          default: false,
+          title: 'Re-index Git Repositories on Window Focus',
+          description: 'If true, Atom will pause to re-index all Git repositories that are open in the tree view each time the focus returns to the Atom window. May cause a 3-10 second delay each time you switch to and from another window.'
+      },
       followSymlinks: {
         type: 'boolean',
         default: true,

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -20,10 +20,10 @@ const configSchema = {
         description: 'Files and directories ignored by the current project\'s VCS system will be ignored by some packages, such as the fuzzy finder and find and replace. For example, projects using Git have these paths defined in the .gitignore file. Individual packages might have additional config settings for ignoring VCS ignored files and folders.'
       },
       gitRepositoryRefreshOnWindowFocus: {
-          type: 'boolean',
-          default: false,
-          title: 'Re-index Git Repositories on Window Focus',
-          description: 'If true, Atom will pause to re-index all Git repositories that are open in the tree view each time the focus returns to the Atom window. May cause a 3-10 second delay each time you switch to and from another window.'
+        type: 'boolean',
+        default: false,
+        title: 'Re-index Git Repositories on Window Focus',
+        description: 'If true, Atom will pause to re-index all Git repositories that are open in the tree view each time the focus returns to the Atom window. May cause a 3-10 second delay each time you switch to and from another window.'
       },
       followSymlinks: {
         type: 'boolean',

--- a/src/git-repository.coffee
+++ b/src/git-repository.coffee
@@ -57,8 +57,9 @@ class GitRepository
   #
   # * `path` The {String} path to the Git repository to open.
   # * `options` An optional {Object} with the following keys:
-  #   * `refreshOnWindowFocus` A {Boolean}, `true` to refresh the index and
-  #     statuses when the window is focused.
+  #   * `project` An optional {Project} representing a project open in the editor,
+  #      will be wired up with event handlers to check status after changes
+  #   * `config` An {Object} that is not used
   #
   # Returns a {GitRepository} instance or `null` if the repository could not be opened.
   @open: (path, options) ->
@@ -81,16 +82,15 @@ class GitRepository
     for submodulePath, submoduleRepo of @repo.submodules
       submoduleRepo.upstream = {ahead: 0, behind: 0}
 
-    {@project, @config, refreshOnWindowFocus} = options
+    {@project, @config} = options
 
-    refreshOnWindowFocus ?= true
-    if refreshOnWindowFocus
-      onWindowFocus = =>
+    onWindowFocus = =>
+      if atom.config.get('core.gitRepositoryRefreshOnWindowFocus')
         @refreshIndex()
         @refreshStatus()
 
-      window.addEventListener 'focus', onWindowFocus
-      @subscriptions.add new Disposable(-> window.removeEventListener 'focus', onWindowFocus)
+    window.addEventListener 'focus', onWindowFocus
+    @subscriptions.add new Disposable(-> window.removeEventListener 'focus', onWindowFocus)
 
     if @project?
       @project.getBuffers().forEach (buffer) => @subscribeToBuffer(buffer)


### PR DESCRIPTION
- Wire up the focus handler unconditionally
- Add new `core.gitRepositoryRefreshOnWindowFocus` setting
- Check `core.gitRepositoryRefreshOnWindowFocus` in focus handler
- Remove `refreshOnWindowFocus` param since it was unused
- Document the `project` and `config` params

### Description of the Change

If the user has one or more projects in the tree view with Git repositories, Atom freezes for a few seconds each time the window gains focus. The editor spends this time re-indexing Git data for all of those projects in the foreground. This makes Atom feel sluggish and unresponsive, and disrupts work flow when the user is likely to be ready to blaze ahead with an active task.

See #9544 for full discussion of the issue.

After this change, the default behavior is to no longer do this re-indexing work on window focus. A new settings checkbox can be used to enable the old behavior:

![image](https://user-images.githubusercontent.com/1559108/29900065-d6f52a24-8db4-11e7-9b7b-398a5d375f8b.png)

### Alternate Designs

The old code had an unused Boolean parameter controlling whether the focus handler would be wired up. We could have passed the new setting as the value of that parameter. I decided that wasn't desirable because the changes could not take effect immediately when the user changed the setting. To respond to user setting changes on the fly, we need to wire up the event unconditionally and check the setting's current value when it fires. Since the old parameter would conflict with the new setting, it is removed.

### Why Should This Be In Core?

Fixes an issue with Core.

### Benefits

- Improved responsiveness when multitasking Atom with other applications
- Multiple users on #9544 reported quitting Atom or almost quitting due to this issue, so possible improvement in user outreach and retention
- Multiple users on #9544 resorted to risky workarounds (deleting or renaming a project's .git folder, deactivating core packages, avoiding the use of project folders), so possible improvement in general stability if those workarounds are no longer needed

### Possible Drawbacks

The old code does not document why this behavior existed, so we do not know the exact rationale for it or what might be lost by removing it. I speculate that it is to account for the possibility that the user might make changes affecting one of Atom's currently open Git repositories in an external application, which would then need to be reflected in Atom. However, this behavior imposes a serious usability penalty for all Git users, and users who do not need it have no recourse to eliminate this penalty. Furthermore, it is not a robust solution to that potential problem, as it is possible to modify a Git repo without switching focus away from Atom (for example, via a scheduled task or a remote login from another computer).

To mitigate the possibility of new issues, the problematic code is not simply removed. Rather, a setting is created so that users who need the old behavior and are willing to tolerate its drawbacks can enable it with a checkbox in the Core settings.

### Applicable Issues

- Fixes #9544 