### PR TITLE
Fix window state not saving on close

### DIFF
--- a/spec/window-event-handler-spec.coffee
+++ b/spec/window-event-handler-spec.coffee
@@ -48,6 +48,11 @@ describe "WindowEventHandler", ->
       window.dispatchEvent(new CustomEvent('window:close'))
       expect(atom.close).toHaveBeenCalled()
 
+    it "saves the window state", ->
+      spyOn(atom, 'storeWindowDimensions')
+      window.dispatchEvent(new CustomEvent('window:close'))
+      expect(atom.storeWindowDimensions).toHaveBeenCalled()
+
   describe "when a link is clicked", ->
     it "opens the http/https links in an external application", ->
       {shell} = require 'electron'

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -158,6 +158,7 @@ class WindowEventHandler
     @atomEnvironment.toggleFullScreen()
 
   handleWindowClose: =>
+    @atomEnvironment.storeWindowDimensions()
     @atomEnvironment.close()
 
   handleWindowReload: =>


### PR DESCRIPTION
### Description of the Change

Fix #13909. It seems there have been fixes for saving window state previously however these only save on `blur`, and `beforeUnload`. None of these are triggered if you immediately close the window.

### Alternate Designs

None

### Why Should This Be In Core?

It's a bug fix.

### Benefits

The bug is fixed.

### Possible Drawbacks

None

### Applicable Issues

#13909