### PR TITLE
Don't move the cursor when clicking on a scrollbar 

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2963,7 +2963,7 @@ class DummyScrollbarComponent {
     const {
       orientation, scrollWidth, scrollHeight,
       verticalScrollbarWidth, horizontalScrollbarHeight,
-      canScroll, forceScrollbarVisible, didScroll, didMouseDown
+      canScroll, forceScrollbarVisible, didScroll
     } = this.props
 
     const outerStyle = {
@@ -3005,7 +3005,7 @@ class DummyScrollbarComponent {
         style: outerStyle,
         on: {
           scroll: didScroll,
-          mousedown: didMouseDown
+          mousedown: this.didMouseDown
         }
       },
       $.div({style: innerStyle})


### PR DESCRIPTION
Fixes #15488 
Fixes #15489

This pull-request fixes a regression introduced in https://github.com/atom/atom/pull/15367 while refactoring `DummyScrollbarComponent`. Instead of calling the `didMouseDown` method on the component itself, we were invoking the `didMouseDown` function that was passed by the parent component.

/cc: @nathansobo @ungb @Ben3eeE @rsese 