### PR TITLE
Don't remeasure invalid block decorations

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -2371,6 +2371,23 @@ describe('TextEditorComponent', () => {
       ])
     })
 
+    it('does not try to remeasure block decorations whose markers are invalid (regression)', async () => {
+      const editor = buildEditor({rowsPerTile: 3, autoHeight: false})
+      const {component, element} = buildComponent({editor, rowsPerTile: 3})
+      const {decoration, marker} = createBlockDecorationAtScreenRow(editor, 2, {height: '12px', invalidate: 'touch'})
+      editor.getBuffer().deleteRows(0, 3)
+      await component.getNextUpdatePromise()
+
+      // Trigger a re-measurement of all block decorations.
+      await setEditorWidthInCharacters(component, 20)
+      assertLinesAreAlignedWithLineNumbers(component)
+      assertTilesAreSizedAndPositionedCorrectly(component, [
+        {tileStartRow: 0, height: 3 * component.getLineHeight()},
+        {tileStartRow: 3, height: 3 * component.getLineHeight()},
+        {tileStartRow: 6, height: 3 * component.getLineHeight()}
+      ])
+    })
+
     it('measures block decorations correctly when they are added before the component width has been updated', async () => {
       {
         const {editor, component, element} = buildComponent({autoHeight: false, width: 500, attach: false})

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -286,7 +286,8 @@ class TextEditorComponent {
       const decorations = this.props.model.getDecorations()
       for (var i = 0; i < decorations.length; i++) {
         const decoration = decorations[i]
-        if (decoration.getProperties().type === 'block') {
+        const marker = decoration.getMarker()
+        if (marker.isValid() && decoration.getProperties().type === 'block') {
           this.blockDecorationsToMeasure.add(decoration)
         }
       }


### PR DESCRIPTION
This fixes an uncaught exception that was being thrown after invalidating a marker and resizing the editor. I don't think this issue was reported, but it could be reproduced by:

1. Opening a file with merge conflicts in a git repository.
2. Delete the entire region containing conflict markers.
3. Try to resize the editor.
4. 💥

/cc: @nathansobo @Ben3eeE 