### PR TITLE
Don't autoscroll when using the mouse to add, delete or move selections

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -2706,6 +2706,8 @@ describe('TextEditorComponent', () => {
           clientY: clientTopForLine(component, 3) + lineHeight / 2
         })
         expect(editor.getCursorScreenPosition()).toEqual([3, 16])
+
+        expect(editor.testAutoscrollRequests).toEqual([])
       })
 
       it('selects words on double-click', () => {
@@ -2714,6 +2716,7 @@ describe('TextEditorComponent', () => {
         component.didMouseDownOnContent({detail: 1, button: 0, clientX, clientY})
         component.didMouseDownOnContent({detail: 2, button: 0, clientX, clientY})
         expect(editor.getSelectedScreenRange()).toEqual([[1, 13], [1, 21]])
+        expect(editor.testAutoscrollRequests).toEqual([])
       })
 
       it('selects lines on triple-click', () => {
@@ -2723,6 +2726,7 @@ describe('TextEditorComponent', () => {
         component.didMouseDownOnContent({detail: 2, button: 0, clientX, clientY})
         component.didMouseDownOnContent({detail: 3, button: 0, clientX, clientY})
         expect(editor.getSelectedScreenRange()).toEqual([[1, 0], [2, 0]])
+        expect(editor.testAutoscrollRequests).toEqual([])
       })
 
       it('adds or removes cursors when holding cmd or ctrl when single-clicking', () => {
@@ -2760,7 +2764,7 @@ describe('TextEditorComponent', () => {
         expect(editor.getCursorScreenPositions()).toEqual([[1, 16]])
 
         // cmd-clicking within a selection destroys it
-        editor.addSelectionForScreenRange([[2, 10], [2, 15]])
+        editor.addSelectionForScreenRange([[2, 10], [2, 15]], {autoscroll: false})
         expect(editor.getSelectedScreenRanges()).toEqual([
           [[1, 16], [1, 16]],
           [[2, 10], [2, 15]]
@@ -2790,7 +2794,7 @@ describe('TextEditorComponent', () => {
 
         // ctrl-click adds cursors on platforms *other* than macOS
         component.props.platform = 'win32'
-        editor.setCursorScreenPosition([1, 4])
+        editor.setCursorScreenPosition([1, 4], {autoscroll: false})
         component.didMouseDownOnContent(
           Object.assign(clientPositionForCharacter(component, 1, 16), {
             detail: 1,
@@ -2799,11 +2803,13 @@ describe('TextEditorComponent', () => {
           })
         )
         expect(editor.getCursorScreenPositions()).toEqual([[1, 4], [1, 16]])
+
+        expect(editor.testAutoscrollRequests).toEqual([])
       })
 
       it('adds word selections when holding cmd or ctrl when double-clicking', () => {
         const {component, editor} = buildComponent()
-        editor.addCursorAtScreenPosition([1, 16])
+        editor.addCursorAtScreenPosition([1, 16], {autoscroll: false})
         expect(editor.getCursorScreenPositions()).toEqual([[0, 0], [1, 16]])
 
         component.didMouseDownOnContent(
@@ -2824,11 +2830,12 @@ describe('TextEditorComponent', () => {
           [[0, 0], [0, 0]],
           [[1, 13], [1, 21]]
         ])
+        expect(editor.testAutoscrollRequests).toEqual([])
       })
 
       it('adds line selections when holding cmd or ctrl when triple-clicking', () => {
         const {component, editor} = buildComponent()
-        editor.addCursorAtScreenPosition([1, 16])
+        editor.addCursorAtScreenPosition([1, 16], {autoscroll: false})
         expect(editor.getCursorScreenPositions()).toEqual([[0, 0], [1, 16]])
 
         const {clientX, clientY} = clientPositionForCharacter(component, 1, 16)
@@ -2840,12 +2847,13 @@ describe('TextEditorComponent', () => {
           [[0, 0], [0, 0]],
           [[1, 0], [2, 0]]
         ])
+        expect(editor.testAutoscrollRequests).toEqual([])
       })
 
       it('expands the last selection on shift-click', () => {
         const {component, element, editor} = buildComponent()
 
-        editor.setCursorScreenPosition([2, 18])
+        editor.setCursorScreenPosition([2, 18], {autoscroll: false})
         component.didMouseDownOnContent(Object.assign({
           detail: 1,
           button: 0,
@@ -2862,8 +2870,8 @@ describe('TextEditorComponent', () => {
 
         // reorients word-wise selections to keep the word selected regardless of
         // where the subsequent shift-click occurs
-        editor.setCursorScreenPosition([2, 18])
-        editor.getLastSelection().selectWord()
+        editor.setCursorScreenPosition([2, 18], {autoscroll: false})
+        editor.getLastSelection().selectWord({autoscroll: false})
         component.didMouseDownOnContent(Object.assign({
           detail: 1,
           button: 0,
@@ -2880,8 +2888,8 @@ describe('TextEditorComponent', () => {
 
         // reorients line-wise selections to keep the word selected regardless of
         // where the subsequent shift-click occurs
-        editor.setCursorScreenPosition([2, 18])
-        editor.getLastSelection().selectLine()
+        editor.setCursorScreenPosition([2, 18], {autoscroll: false})
+        editor.getLastSelection().selectLine(null, {autoscroll: false})
         component.didMouseDownOnContent(Object.assign({
           detail: 1,
           button: 0,
@@ -2895,6 +2903,8 @@ describe('TextEditorComponent', () => {
           shiftKey: true
         }, clientPositionForCharacter(component, 3, 11)))
         expect(editor.getSelectedScreenRange()).toEqual([[2, 0], [4, 0]])
+
+        expect(editor.testAutoscrollRequests).toEqual([])
       })
 
       it('expands the last selection on drag', () => {
@@ -4250,7 +4260,10 @@ function buildEditor (params = {}) {
   for (const paramName of ['mini', 'autoHeight', 'autoWidth', 'lineNumberGutterVisible', 'showLineNumbers', 'placeholderText', 'softWrapped', 'scrollSensitivity']) {
     if (params[paramName] != null) editorParams[paramName] = params[paramName]
   }
-  return new TextEditor(editorParams)
+  const editor = new TextEditor(editorParams)
+  editor.testAutoscrollRequests = []
+  editor.onDidRequestAutoscroll((request) => { editor.testAutoscrollRequests.push(request) })
+  return editor
 }
 
 function buildComponent (params = {}) {

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1761,22 +1761,22 @@ class TextEditorComponent {
           if (existingSelection) {
             if (model.hasMultipleCursors()) existingSelection.destroy()
           } else {
-            model.addCursorAtScreenPosition(screenPosition)
+            model.addCursorAtScreenPosition(screenPosition, {autoscroll: false})
           }
         } else {
           if (shiftKey) {
-            model.selectToScreenPosition(screenPosition)
+            model.selectToScreenPosition(screenPosition, {autoscroll: false})
           } else {
-            model.setCursorScreenPosition(screenPosition)
+            model.setCursorScreenPosition(screenPosition, {autoscroll: false})
           }
         }
         break
       case 2:
-        if (addOrRemoveSelection) model.addCursorAtScreenPosition(screenPosition)
+        if (addOrRemoveSelection) model.addCursorAtScreenPosition(screenPosition, {autoscroll: false})
         model.getLastSelection().selectWord({autoscroll: false})
         break
       case 3:
-        if (addOrRemoveSelection) model.addCursorAtScreenPosition(screenPosition)
+        if (addOrRemoveSelection) model.addCursorAtScreenPosition(screenPosition, {autoscroll: false})
         model.getLastSelection().selectLine(null, {autoscroll: false})
         break
     }


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15489

Previously, we used to scroll the editor on behalf of the user when clicking near the edges. This behavior was being perceived as jarring, because it would move up/down the line the user was trying to click:

![kapture 2017-09-05 at 15 23 22](https://user-images.githubusercontent.com/482957/30063198-2c6790b2-924e-11e7-9720-0d3cf676a932.gif)

With this pull-request we are restoring the behavior Atom 1.18 exhibited, which prevents the editor from auto-scrolling when using the mouse to add, delete or move selections:

![kapture 2017-09-05 at 15 25 24](https://user-images.githubusercontent.com/482957/30063285-766c9a9a-924e-11e7-8f0b-075e6ab0b35e.gif)

/cc: @nathansobo @ungb @Ben3eeE @50Wliu 