### PR TITLE
Don't render block decorations located outside the visible range

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1153,9 +1153,11 @@ class TextEditorComponent {
   }
 
   addBlockDecorationToRender (decoration, screenRange, reversed) {
-    const screenPosition = reversed ? screenRange.start : screenRange.end
-    const tileStartRow = this.tileStartRowForRow(screenPosition.row)
-    const screenLine = this.renderedScreenLines[screenPosition.row - this.getRenderedStartRow()]
+    const {row} = reversed ? screenRange.start : screenRange.end
+    if (row < this.getRenderedStartRow() || row >= this.getRenderedEndRow()) return
+
+    const tileStartRow = this.tileStartRowForRow(row)
+    const screenLine = this.renderedScreenLines[row - this.getRenderedStartRow()]
 
     let decorationsByScreenLine = this.decorationsToRender.blocks.get(tileStartRow)
     if (!decorationsByScreenLine) {


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15441

Previously, when trying to use block decorations on non-empty markers, Atom could sometimes throw an error if such markers ended or started at a position that was not currently rendered.

In fact, even if we already restricted the decoration query to markers that intersected the visible row range, markers that were only partially visible would still be considered for rendering. If, depending on the `reversed` property, we decided to render the tail or head of the marker in question and this was outside the viewport, Atom would throw the aforementioned exception.

This pull-request addresses the above issue by explicitly ignoring block decorations that are located on rows that are not yet rendered.

/cc: @nathansobo @Ben3eeE @rsese @ungb