### PR TITLE
Update language-coffee-script to v0.49.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "language-gfm": "0.90.1",
     "language-git": "0.19.1",
     "language-go": "0.44.2",
-    "language-html": "0.47.5",
+    "language-html": "0.47.6",
     "language-hyperlink": "0.16.2",
     "language-java": "0.27.4",
     "language-javascript": "0.127.3",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "language-gfm": "0.90.1",
     "language-git": "0.19.1",
     "language-go": "0.44.2",
-    "language-html": "0.47.4",
+    "language-html": "0.47.5",
     "language-hyperlink": "0.16.2",
     "language-java": "0.27.4",
     "language-javascript": "0.127.3",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "wrap-guide": "0.40.2",
     "language-c": "0.58.1",
     "language-clojure": "0.22.4",
-    "language-coffee-script": "0.48.9",
+    "language-coffee-script": "0.49.0",
     "language-csharp": "0.14.2",
     "language-css": "0.42.5",
     "language-gfm": "0.90.1",


### PR DESCRIPTION
Introduces a very large overhaul of the language-coffee-script grammar, bringing it up-to-date with language-javascript.

language-html contains a temporary spec fix.