### PR TITLE
Use the Node version bundled in Electron to verify snapshot script

### DIFF
--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -76,7 +76,20 @@ module.exports = function (packagedAppPath) {
     process.stdout.write('\n')
 
     console.log('Verifying if snapshot can be executed via `mksnapshot`')
-    vm.runInNewContext(snapshotScript, undefined, {filename: snapshotScriptPath, displayErrors: true})
+    const verifySnapshotScriptPath = path.join(CONFIG.repositoryRootPath, 'script', 'verify-snapshot-script')
+    let nodeBundledInElectronPath
+    if (process.platform === 'darwin') {
+      nodeBundledInElectronPath = path.join(packagedAppPath, 'Contents', 'MacOS', 'Atom')
+    } else if (process.platform === 'win32') {
+      nodeBundledInElectronPath = path.join(packagedAppPath, 'atom.exe')
+    } else {
+      nodeBundledInElectronPath = path.join(packagedAppPath, 'atom')
+    }
+    childProcess.execFileSync(
+      nodeBundledInElectronPath,
+      [verifySnapshotScriptPath, snapshotScriptPath],
+      {env: Object.assign(process.env, {ELECTRON_RUN_AS_NODE: 1})}
+    )
 
     const generatedStartupBlobPath = path.join(CONFIG.buildOutputPath, 'snapshot_blob.bin')
     console.log(`Generating startup blob at "${generatedStartupBlobPath}"`)

--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -3,7 +3,6 @@ const fs = require('fs')
 const path = require('path')
 const electronLink = require('electron-link')
 const CONFIG = require('../config')
-const vm = require('vm')
 
 module.exports = function (packagedAppPath) {
   const snapshotScriptPath = path.join(CONFIG.buildOutputPath, 'startup.js')

--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -88,7 +88,7 @@ module.exports = function (packagedAppPath) {
     childProcess.execFileSync(
       nodeBundledInElectronPath,
       [verifySnapshotScriptPath, snapshotScriptPath],
-      {env: Object.assign(process.env, {ELECTRON_RUN_AS_NODE: 1})}
+      {env: Object.assign({}, process.env, {ELECTRON_RUN_AS_NODE: 1})}
     )
 
     const generatedStartupBlobPath = path.join(CONFIG.buildOutputPath, 'snapshot_blob.bin')

--- a/script/verify-snapshot-script
+++ b/script/verify-snapshot-script
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const vm = require('vm')
+const snapshotScriptPath = process.argv[2]
+const snapshotScript = fs.readFileSync(snapshotScriptPath, 'utf8')
+vm.runInNewContext(snapshotScript, undefined, {filename: snapshotScriptPath, displayErrors: true})


### PR DESCRIPTION
Previously, we used to verify the snapshot script by running it in a new, empty context (similar to the one that `mksnapshot` creates when generating the startup blob).

However, this context was being created using the Node version that `script/build` was executed with. Such version may not match the Node version shipped with Electron, and could thus cause the build script to report "false negatives" when verifying the snapshot script. For instance, running `script/build` with Node 4 would cause it to throw an error when encountering keywords like `async`/`await`, even if they're 100% supported in Electron 1.6.9.

With this pull-request we are changing the snapshot verification code to use the Node version bundled in Electron in order to avoid the aforementioned mismatches.

@damieng @leroix: I believe this will fix the errors you were encountering on #15554.

/cc: @atom/maintainers