### PR TITLE
Default re-used element class name to empty string

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -4309,7 +4309,7 @@ class NodePool {
     }
 
     if (element) {
-      element.className = className
+      element.className = className || ''
       element.styleMap.forEach((value, key) => {
         if (!style || style[key] == null) element.style[key] = ''
       })


### PR DESCRIPTION
![span_before](https://user-images.githubusercontent.com/1017132/30161542-b192eb74-93d9-11e7-8848-dcd87247d3da.png)

At first I believed that [these span elements were redundant](https://github.com/atom/atom/blob/master/src/text-editor-component.js#L3883-L3884), however after discussion with @as-cii it came out that it is being used for [measuring the total length of the line](https://github.com/atom/atom/blob/a53958e00742b24aa0ebf47e264c46094c5c6c9b/src/text-editor-component.js#L2195), so they cannot be removed after all. Strangely, setting `this.element` as the `openScopeNode` did not introduce any regressions, which might need to be looked into, but it works for now, so I doubt there will be any progress made in that regard.

Still the main reason why I even started investigating this was due to the class name of these elements being suspicious (`"null"`), which happens because null value is converted to string. Defaulting to empty string fixes this and brings it in line with rest of the surrounding code.