### PR TITLE
Flush scroll position to dummy scrollbar components on re-attach

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1403,6 +1403,9 @@ class TextEditorComponent {
 
       if (this.isVisible()) {
         this.didShow()
+
+        if (this.refs.verticalScrollbar) this.refs.verticalScrollbar.flushScrollPosition()
+        if (this.refs.horizontalScrollbar) this.refs.horizontalScrollbar.flushScrollPosition()
       } else {
         this.didHide()
       }


### PR DESCRIPTION
Fixes #15552

This prevents the dummy scrollbars from resetting their position to `0` when the editor element is moved elsewhere in the DOM (e.g. when splitting a pane item).

/cc: @nathansobo @50Wliu @Ben3eeE @rsese @ungb