### PR TITLE
Increase scrollbar contrast in dark themes

### DIFF
--- a/static/text-editor.less
+++ b/static/text-editor.less
@@ -145,3 +145,17 @@ atom-overlay {
   display: block;
   z-index: 4;
 }
+
+// This adds the background color to scrollbars for only a very short time.
+// So that the native macOS "When scrolling" scrollbars adjust for dark themes.
+.platform-darwin .scrollbars-visible-when-scrolling {
+  atom-text-editor {
+    .vertical-scrollbar,
+    .horizontal-scrollbar {
+      @keyframes scrollbars-visible-when-scrolling-fix {
+        0% { background-color: @syntax-background-color; }
+      }
+      animation: scrollbars-visible-when-scrolling-fix 0.01s;
+    }
+  }
+}


### PR DESCRIPTION
### Description of the Change

In #15401 @haidran noticed that the native "only when scrolling" scrollbars of the tree-view have a light handle with dark themes, but not in buffers. Turns out that Chromium/macOS switches between a light and dark handle based on the `background-color` of the element that has `overflow` scrolling enabled. Unfortunately we can't just add a background color to the scrollbars of `atom-text-editor` because it would cover the code underneath.

As a potential solution, this PR adds the syntax background color to scrollbars initially only for a very short time through a keyframe animation and then removes the background color again. This will have the effect that the scrollbars still pick up the right syntax background color and adjust the handle accordingly for dark themes.

Before | After
--- | ---
![screen shot 2017-09-09 at 12 47 01 pm](https://user-images.githubusercontent.com/378023/30237351-0f84751c-956b-11e7-9e26-2c80e072a3be.png) | ![screen shot 2017-09-09 at 12 46 02 pm](https://user-images.githubusercontent.com/378023/30237353-1158c226-956b-11e7-8445-4a63ac286798.png)


### Alternate Designs

Instead of an animation (adding and removing the background color) we could also keep an almost transparent background color, like `background-color: fade(@syntax-background-color, 0.01%);`. It won't be visible by eye. But using an animation feels still slightly better since it's more temporarily. 

Another alternative would be to implement our own custom scrollbars, but that's much bigger in scope.

### Why Should This Be In Core?

Since all dark themes are affected.

### Benefits

Better buffer scrollbar handle contrast for dark themes.

### Possible Drawbacks

A keyframe animation might have negative side effects on the buffer, like causing repaint or so. /cc @nathansobo @as-cii 

### Applicable Issues

Fixes #15401