### PR TITLE
[WIP] Do not normalize C: to C:.

### DIFF
--- a/src/default-directory-provider.coffee
+++ b/src/default-directory-provider.coffee
@@ -55,4 +55,10 @@ class DefaultDirectoryProvider
         "#{matchData[1].toUpperCase()}#{uri.slice(1)}"
       else
         uri
-    path.normalize(pathWithNormalizedDiskDriveLetter)
+
+    # On Windows, a bare drive such as 'C:' gets normalized to 'C:.'
+    normalizedPath = path.normalize(pathWithNormalizedDiskDriveLetter)
+    if process.platform is 'win32' and /^[A-Z]:\.$/.test(normalizedPath)
+      return normalizedPath.slice(0, -1)
+    else
+      return normalizedPath


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

For unknown reasons, `path.normalize` will add a period to the end of a standalone drive letter when normalizing it.  This results in a path such as `C:.`, which, while accepted in Windows Explorer, is treated as `.` by other programs such as Powershell and `path.basename`.  This PR manually fixes the path normalization when the path is _only_ a drive letter on Windows.

### Alternate Designs

Ideally, this should be fixed upstream in Node.

### Why Should This Be In Core?

Because this is a part of the fundamental `atom.project.setPaths` API.

### Benefits

Tree View, with a few additional fixes, should function correctly when being set to a root drive path.

### Possible Drawbacks

None?

### Applicable Issues

Refs #903