### PR TITLE
Make the atom.getReleaseChannel function public

### DIFF
--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -445,7 +445,9 @@ class AtomEnvironment extends Model
   getVersion: ->
     @appVersion ?= @getLoadSettings().appVersion
 
-  # Returns the release channel as a {String}. Will return one of `'dev', 'beta', 'stable'`
+  # Public: Gets the release channel of the Atom application.
+  #
+  # Returns the release channel as a {String}. Will return one of `dev`, `beta`, or `stable`.
   getReleaseChannel: ->
     version = @getVersion()
     if version.indexOf('beta') > -1


### PR DESCRIPTION
### Description of the Change

Make the `atom.getReleaseChannel` function public.

### Alternate Designs

The related functions such as `atom.getVersion` and `atom.isReleasedVersion` are already public, so I didn't believe that this should be any different.

### Why Should This Be In Core?

It already is.

### Benefits

People won't roll their own.

### Possible Drawbacks

Package authors may be more encouraged to make conditional code based on the release channel.

### Applicable Issues

N/A
