### PR TITLE
FIX "softWrapped" appear twice in field extraction

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -153,7 +153,7 @@ class TextEditor extends Model
 
     {
       @softTabs, @initialScrollTopRow, @initialScrollLeftColumn, initialLine, initialColumn, tabLength,
-      @softWrapped, @decorationManager, @selectionsMarkerLayer, @buffer, suppressCursorCreation,
+      @decorationManager, @selectionsMarkerLayer, @buffer, suppressCursorCreation,
       @mini, @placeholderText, lineNumberGutterVisible, @showLineNumbers, @largeFileMode,
       @assert, grammar, @showInvisibles, @autoHeight, @autoWidth, @scrollPastEnd, @scrollSensitivity, @editorWidthInChars,
       @tokenizedBuffer, @displayLayer, @invisibles, @showIndentGuide,


### PR DESCRIPTION
### Description of the Change

`@softWrapped` appears TWICE where it should be ONCE in object params field extraction.
See line 160 also have `@softWrapped`.


### Alternate Designs

NO

### Why Should This Be In Core?

Just bug

### Benefits

clean

### Possible Drawbacks

no

### Applicable Issues

no
