### PR TITLE
Backport config improvements to 1.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom",
   "productName": "Atom",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "A hackable text editor for the 21st Century.",
   "main": "./src/main-process/main.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "scandal": "^3.1.0",
     "scoped-property-store": "^0.17.0",
     "scrollbar-style": "^3.2",
-    "season": "^6.0.0",
+    "season": "^6.0.1",
     "semver": "^4.3.3",
     "service-hub": "^0.7.4",
     "sinon": "1.17.4",

--- a/src/backport-watch-path.js
+++ b/src/backport-watch-path.js
@@ -3,7 +3,7 @@
 const fs = require('fs-plus')
 const {Disposable} = require('event-kit')
 
-function stat(filePath) {
+function stat (filePath) {
   return new Promise((resolve, reject) => {
     fs.stat(filePath, (err, stat) => {
       if (err) {

--- a/src/backport-watch-path.js
+++ b/src/backport-watch-path.js
@@ -1,0 +1,50 @@
+// Backport single-file, stat-polling file watching from nsfw
+
+const fs = require('fs-plus')
+const {Disposable} = require('event-kit')
+
+function stat(filePath) {
+  return new Promise((resolve, reject) => {
+    fs.stat(filePath, (err, stat) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(stat)
+      }
+    })
+  })
+}
+
+const INTERVAL = 100
+
+exports.watchPath = async function (filePath, options, eventCallback) {
+  let fileStat = null
+  let pollInterval = null
+
+  const getStatus = async () => {
+    try {
+      const nextStat = await stat(filePath)
+      if (fileStat === null) {
+        fileStat = nextStat
+        eventCallback([{action: 'created', path: filePath}])
+      } else if (nextStat.mtime - fileStat.mtime !== 0 || nextStat.ctime - fileStat.ctime !== 0) {
+        fileStat = nextStat
+        eventCallback([{action: 'modified', path: filePath}])
+      }
+    } catch (e) {
+      console.log('error', e)
+      if (fileStat !== null) {
+        fileStat = null
+        eventCallback([{action: 'deleted', path: filePath}])
+      }
+    }
+  }
+
+  fileStat = await stat(filePath).catch(null)
+  pollInterval = setInterval(getStatus, INTERVAL)
+
+  return new Disposable(() => {
+    clearInterval(pollInterval)
+    return Promise.resolve()
+  })
+}

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -4,7 +4,7 @@ fs = require 'fs-plus'
 CSON = require 'season'
 path = require 'path'
 async = require 'async'
-{watchPath} = require './path-watcher'
+{watchPath} = require './backport-watch-path'
 {
   getValueAtKeyPath, setValueAtKeyPath, deleteValueAtKeyPath,
   pushKeyPath, splitKeyPath,


### PR DESCRIPTION
Backport the Config changes from #15440 to stable to deal with the race conditions #14909.

This will require some additional work because the `watchPath` API wasn't introduced until 1.21, so I'll need to backport the stat-polling logic from nsfw.

/cc @kuychaco who did most of the original PR
/cc @ungb @rsese @iolsen for visibility into progress on this