### PR TITLE
⬆️  Update autocomplete-plus to v2.35.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "autocomplete-atom-api": "0.10.3",
     "autocomplete-css": "0.17.3",
     "autocomplete-html": "0.8.1",
-    "autocomplete-plus": "2.35.9",
+    "autocomplete-plus": "2.35.10",
     "autocomplete-snippets": "1.11.1",
     "autoflow": "0.29.0",
     "autosave": "0.24.3",


### PR DESCRIPTION
Upgrade to autocomplete-plus v2.35.10 to take advantage of https://github.com/atom/autocomplete-plus/pull/887.