### PR TITLE
Restore the fs.existsSync guard in Config

### DIFF
--- a/src/config.coffee
+++ b/src/config.coffee
@@ -867,8 +867,9 @@ class Config
     return if @savePending
 
     try
-      fs.makeTreeSync(path.dirname(@configFilePath))
-      CSON.writeFileSync(@configFilePath, {}, {flag: 'wx'}) # fails if file exists
+      unless fs.existsSync(@configFilePath)
+        fs.makeTreeSync(path.dirname(@configFilePath))
+        CSON.writeFileSync(@configFilePath, {}, {flag: 'wx'}) # fails if file exists
     catch error
       if error.code isnt 'EEXIST'
         @configFileHasErrors = true


### PR DESCRIPTION
season 6.0.0's `CSON.writeFileSync` method didn't have a third "options" argument, so if this code is executed with an old version of season, it will _always_ unconditionally wipe the config. This can happen if, for example, you open Atom in developer mode after doing a `git pull` in your Atom directory but before running a `script/build` to update the dependencies.

/cc @BinaryMuse @damieng @kuychaco 