### PR TITLE
:memo: Fix cursor name letter casing

### DIFF
--- a/src/cursor.coffee
+++ b/src/cursor.coffee
@@ -37,7 +37,7 @@ class Cursor extends Model
   #     * `newBufferPosition` {Point}
   #     * `newScreenPosition` {Point}
   #     * `textChanged` {Boolean}
-  #     * `Cursor` {Cursor} that triggered the event
+  #     * `cursor` {Cursor} that triggered the event
   #
   # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidChangePosition: (callback) ->


### PR DESCRIPTION
### Description of the Change

The docs currently say `Cursor` instead of `cursor`, just a quick fix there.

As discussed with @50Wliu on slack