### PR TITLE
Notify when deserializing project state for missing directories

### DIFF
--- a/spec/atom-environment-spec.coffee
+++ b/spec/atom-environment-spec.coffee
@@ -325,7 +325,7 @@ describe "AtomEnvironment", ->
     describe "deserialization failures", ->
 
       it "propagates project state restoration failures", ->
-        spyOn(atom.project, 'deserialize').andCallFake =>
+        spyOn(atom.project, 'deserialize').andCallFake ->
           err = new Error('deserialization failure')
           err.missingProjectPaths = ['/foo']
           Promise.reject(err)
@@ -337,7 +337,7 @@ describe "AtomEnvironment", ->
             {description: 'Project directory `/foo` is no longer on disk.'}
 
       it "accumulates and reports two errors with one notification", ->
-        spyOn(atom.project, 'deserialize').andCallFake =>
+        spyOn(atom.project, 'deserialize').andCallFake ->
           err = new Error('deserialization failure')
           err.missingProjectPaths = ['/foo', '/wat']
           Promise.reject(err)
@@ -349,7 +349,7 @@ describe "AtomEnvironment", ->
             {description: 'Project directories `/foo` and `/wat` are no longer on disk.'}
 
       it "accumulates and reports three+ errors with one notification", ->
-        spyOn(atom.project, 'deserialize').andCallFake =>
+        spyOn(atom.project, 'deserialize').andCallFake ->
           err = new Error('deserialization failure')
           err.missingProjectPaths = ['/foo', '/wat', '/stuff', '/things']
           Promise.reject(err)

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -143,6 +143,26 @@ describe "Project", ->
       runs ->
         expect(deserializedProject.getBuffers().length).toBe 0
 
+    it "deserializes buffers that have never been saved before", ->
+      pathToOpen = path.join(temp.mkdirSync('atom-spec-project'), 'file.txt')
+
+      waitsForPromise ->
+        atom.workspace.open(pathToOpen)
+
+      runs ->
+        atom.workspace.getActiveTextEditor().setText('unsaved\n')
+        expect(atom.project.getBuffers().length).toBe 1
+
+        deserializedProject = new Project({notificationManager: atom.notifications, packageManager: atom.packages, confirm: atom.confirm})
+
+      waitsForPromise ->
+        deserializedProject.deserialize(atom.project.serialize({isUnloading: false}))
+
+      runs ->
+        expect(deserializedProject.getBuffers().length).toBe 1
+        expect(deserializedProject.getBuffers()[0].getPath()).toBe pathToOpen
+        expect(deserializedProject.getBuffers()[0].getText()).toBe 'unsaved\n'
+
     it "serializes marker layers and history only if Atom is quitting", ->
       waitsForPromise -> atom.workspace.open('a')
 

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -411,7 +411,7 @@ describe "Project", ->
       runs ->
         expect(repository.isDestroyed()).toBe(false)
 
-  describe ".setPaths(paths)", ->
+  describe ".setPaths(paths, options)", ->
     describe "when path is a file", ->
       it "sets its path to the files parent directory and updates the root directory", ->
         filePath = require.resolve('./fixtures/dir/a')
@@ -448,6 +448,17 @@ describe "Project", ->
         expect(onDidChangePathsSpy.callCount).toBe 1
         expect(onDidChangePathsSpy.mostRecentCall.args[0]).toEqual(paths)
 
+      it "optionally throws an error with any paths that did not exist", ->
+        paths = [temp.mkdirSync("exists0"), "/doesnt-exists/0", temp.mkdirSync("exists1"), "/doesnt-exists/1"]
+
+        try
+          atom.project.setPaths paths, mustExist: true
+          expect('no exception thrown').toBeUndefined()
+        catch e
+          expect(e.missingProjectPaths).toEqual [paths[1], paths[3]]
+
+        expect(atom.project.getPaths()).toEqual [paths[0], paths[2]]
+
     describe "when no paths are given", ->
       it "clears its path", ->
         atom.project.setPaths([])
@@ -459,7 +470,7 @@ describe "Project", ->
       expect(atom.project.getPaths()[0]).toEqual path.dirname(require.resolve('./fixtures/dir/a'))
       expect(atom.project.getDirectories()[0].path).toEqual path.dirname(require.resolve('./fixtures/dir/a'))
 
-  describe ".addPath(path)", ->
+  describe ".addPath(path, options)", ->
     it "calls callbacks registered with ::onDidChangePaths", ->
       onDidChangePathsSpy = jasmine.createSpy('onDidChangePaths spy')
       atom.project.onDidChangePaths(onDidChangePathsSpy)

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -75,7 +75,11 @@ describe "Project", ->
         expect(atom.project.getBuffers().length).toBe 1
         fs.mkdirSync(pathToOpen)
         deserializedProject = new Project({notificationManager: atom.notifications, packageManager: atom.packages, confirm: atom.confirm})
+
+      waitsForPromise ->
         deserializedProject.deserialize(atom.project.serialize({isUnloading: false}))
+
+      runs ->
         expect(deserializedProject.getBuffers().length).toBe 0
 
     it "does not deserialize buffers when their path is inaccessible", ->
@@ -90,7 +94,11 @@ describe "Project", ->
         expect(atom.project.getBuffers().length).toBe 1
         fs.chmodSync(pathToOpen, '000')
         deserializedProject = new Project({notificationManager: atom.notifications, packageManager: atom.packages, confirm: atom.confirm})
+
+      waitsForPromise ->
         deserializedProject.deserialize(atom.project.serialize({isUnloading: false}))
+
+      runs ->
         expect(deserializedProject.getBuffers().length).toBe 0
 
     it "serializes marker layers and history only if Atom is quitting", ->
@@ -100,6 +108,7 @@ describe "Project", ->
       bufferA = null
       layerA = null
       markerA = null
+      notQuittingProject = null
 
       runs ->
         bufferA = atom.project.getBuffers()[0]
@@ -109,9 +118,11 @@ describe "Project", ->
 
       waitsForPromise ->
         notQuittingProject = new Project({notificationManager: atom.notifications, packageManager: atom.packages, confirm: atom.confirm})
-        notQuittingProject.deserialize(atom.project.serialize({isUnloading: false})).then ->
-          expect(notQuittingProject.getBuffers()[0].getMarkerLayer(layerA.id)?.getMarker(markerA.id)).toBeUndefined()
-          expect(notQuittingProject.getBuffers()[0].undo()).toBe(false)
+        notQuittingProject.deserialize(atom.project.serialize({isUnloading: false}))
+
+      runs ->
+        expect(notQuittingProject.getBuffers()[0].getMarkerLayer(layerA.id)?.getMarker(markerA.id)).toBeUndefined()
+        expect(notQuittingProject.getBuffers()[0].undo()).toBe(false)
 
       waitsForPromise ->
         quittingProject = new Project({notificationManager: atom.notifications, packageManager: atom.packages, confirm: atom.confirm})

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -498,6 +498,11 @@ describe "Project", ->
       atom.project.addPath('/this-definitely/does-not-exist')
       expect(atom.project.getPaths()).toEqual(previousPaths)
 
+    it "optionally throws on non-existent directories", ->
+      expect ->
+        atom.project.addPath '/this-definitely/does-not-exist', mustExist: true
+      .toThrow()
+
   describe ".removePath(path)", ->
     onDidChangePathsSpy = null
 

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -25,11 +25,14 @@ describe "Project", ->
       state = atom.project.serialize()
       state.paths.push('/directory/that/does/not/exist')
 
+      err = null
       waitsForPromise ->
         deserializedProject.deserialize(state, atom.deserializers)
+          .catch (e) -> err = e
 
       runs ->
         expect(deserializedProject.getPaths()).toEqual(atom.project.getPaths())
+        expect(err.missingProjectPaths).toEqual ['/directory/that/does/not/exist']
 
     it "does not include unretained buffers in the serialized state", ->
       waitsForPromise ->

--- a/spec/project-spec.coffee
+++ b/spec/project-spec.coffee
@@ -47,7 +47,7 @@ describe "Project", ->
       state = atom.project.serialize()
 
       fs.rmdirSync(childPath)
-      fs.writeFileSync(childPath, 'suprise!\n')
+      fs.writeFileSync(childPath, 'surprise!\n')
 
       err = null
       waitsForPromise ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -76,6 +76,15 @@ describe "TextEditor", ->
           expect(editor2.displayLayer.tabLength).toBe(editor2.getTabLength())
           expect(editor2.displayLayer.softWrapColumn).toBe(editor2.getSoftWrapColumn())
 
+    it "ignores buffers with retired IDs", ->
+      editor2 = TextEditor.deserialize(editor.serialize(), {
+        assert: atom.assert,
+        textEditors: atom.textEditors,
+        project: {bufferForIdSync: -> null}
+      })
+
+      expect(editor2).toBeNull()
+
   describe "when the editor is constructed with the largeFileMode option set to true", ->
     it "loads the editor but doesn't tokenize", ->
       editor = null

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -1022,7 +1022,7 @@ class AtomEnvironment extends Model
       @workspace.deserialize(state.workspace, @deserializers) if state.workspace?
       @deserializeTimings.workspace = Date.now() - startTime
 
-      if missingProjectPaths.length
+      if missingProjectPaths.length > 0
         count = if missingProjectPaths.length is 1 then '' else missingProjectPaths.length + ' '
         noun = if missingProjectPaths.length is 1 then 'directory' else 'directories'
         toBe = if missingProjectPaths.length is 1 then 'is' else 'are'

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -1005,7 +1005,7 @@ class AtomEnvironment extends Model
     startTime = Date.now()
     if state.project?
       projectPromise = @project.deserialize(state.project, @deserializers)
-        .catch (err) ->
+        .catch (err) =>
           if err.missingProjectPaths?
             missingProjectPaths.push(err.missingProjectPaths...)
           else

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -1009,7 +1009,7 @@ class AtomEnvironment extends Model
           if err.missingProjectPaths?
             missingProjectPaths.push(err.missingProjectPaths...)
           else
-            @notifications.addError "Unable to deserialize project", stack: err.stack
+            @notifications.addError "Unable to deserialize project", description: err.message, stack: err.stack
     else
       projectPromise = Promise.resolve()
 

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -72,7 +72,7 @@ class Project extends Model
       bufferPromises.push(TextBuffer.deserialize(bufferState))
     Promise.all(bufferPromises).then (@buffers) =>
       @subscribeToBuffer(buffer) for buffer in @buffers
-      @setPaths(state.paths)
+      @setPaths(state.paths, mustExist: true)
 
   serialize: (options={}) ->
     deserializer: 'Project'
@@ -234,7 +234,7 @@ class Project extends Model
     if added
       @emitter.emit 'did-change-paths', projectPaths
 
-    if options.mustExist is true and missingProjectPaths
+    if options.mustExist is true and missingProjectPaths.length > 0
       err = new Error "One or more project directories do not exist"
       err.missingProjectPaths = missingProjectPaths
       throw err

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -65,7 +65,11 @@ class Project extends Model
 
     handleBufferState = (bufferState) =>
       bufferState.shouldDestroyOnFileDelete ?= -> atom.config.get('core.closeDeletedFileTabs')
-      bufferState.mustExist = true
+
+      # Use a little guilty knowledge of the way TextBuffers are serialized.
+      # This allows TextBuffers that have never been saved (but have filePaths) to be deserialized, but prevents
+      # TextBuffers backed by files that have been deleted from being saved.
+      bufferState.mustExist = bufferState.digestWhenLastPersisted isnt false
 
       TextBuffer.deserialize(bufferState).catch (err) =>
         @retiredBufferIDs.add(bufferState.id)

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -83,7 +83,7 @@ class Project extends Model
     Promise.all(bufferPromises).then (buffers) =>
       @buffers = buffers.filter(Boolean)
       @subscribeToBuffer(buffer) for buffer in @buffers
-      @setPaths(state.paths or [], mustExist: true)
+      @setPaths(state.paths or [], mustExist: true, exact: true)
 
   serialize: (options={}) ->
     deserializer: 'Project'
@@ -239,7 +239,7 @@ class Project extends Model
     missingProjectPaths = []
     for projectPath in projectPaths
       try
-        @addPath projectPath, emitEvent: false, mustExist: true, exact: true
+        @addPath projectPath, emitEvent: false, mustExist: true, exact: options.exact is true
         added = true
       catch e
         if e.missingProjectPaths?

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -235,20 +235,17 @@ class Project extends Model
     watcher.then((w) -> w.dispose()) for _, watcher in @watcherPromisesByPath
     @watcherPromisesByPath = {}
 
-    added = false
     missingProjectPaths = []
     for projectPath in projectPaths
       try
         @addPath projectPath, emitEvent: false, mustExist: true, exact: options.exact is true
-        added = true
       catch e
         if e.missingProjectPaths?
           missingProjectPaths.push e.missingProjectPaths...
         else
           throw e
 
-    if added
-      @emitter.emit 'did-change-paths', projectPaths
+    @emitter.emit 'did-change-paths', projectPaths
 
     if options.mustExist is true and missingProjectPaths.length > 0
       err = new Error "One or more project directories do not exist"

--- a/src/project.coffee
+++ b/src/project.coffee
@@ -49,6 +49,8 @@ class Project extends Model
     @buffers = []
     @setPaths([])
     @loadPromisesByPath = {}
+    @retiredBufferIDs = new Set()
+    @retiredBufferPaths = new Set()
     @consumeServices(packageManager)
 
   destroyUnretainedBuffers: ->

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -128,7 +128,10 @@ class TextEditor extends Model
       state.tokenizedBuffer = state.displayBuffer.tokenizedBuffer
 
     try
-      state.tokenizedBuffer = TokenizedBuffer.deserialize(state.tokenizedBuffer, atomEnvironment)
+      tokenizedBuffer = TokenizedBuffer.deserialize(state.tokenizedBuffer, atomEnvironment)
+      return null unless tokenizedBuffer?
+
+      state.tokenizedBuffer = tokenizedBuffer
       state.tabLength = state.tokenizedBuffer.getTabLength()
     catch error
       if error.syscall is 'read'

--- a/src/tokenized-buffer.coffee
+++ b/src/tokenized-buffer.coffee
@@ -23,11 +23,15 @@ class TokenizedBuffer extends Model
   changeCount: 0
 
   @deserialize: (state, atomEnvironment) ->
+    buffer = null
     if state.bufferId
-      state.buffer = atomEnvironment.project.bufferForIdSync(state.bufferId)
+      buffer = atomEnvironment.project.bufferForIdSync(state.bufferId)
     else
       # TODO: remove this fallback after everyone transitions to the latest version.
-      state.buffer = atomEnvironment.project.bufferForPathSync(state.bufferPath)
+      buffer = atomEnvironment.project.bufferForPathSync(state.bufferPath)
+    return null unless buffer?
+
+    state.buffer = buffer
     state.assert = atomEnvironment.assert
     new this(state)
 


### PR DESCRIPTION
When deserializing a serialized `Project` state that references one or more root directories that no longer exist, show an error notification.

When deserializing an _unmodified_ buffer that is no longer accessible for any reason, silently skip that buffer.

When deserializing a _modified_ buffer that is no longer accessible, deserialize the buffer. Eventually we might want to decorate the editor with a banner warning that the underlying file no longer exists.

Fixes #13325.