### PR TITLE
Allow atom:// urls to be opened from the command line

### DIFF
--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -19,6 +19,8 @@ module.exports = function parseCommandLine (processArgs) {
     will be opened in that window. Otherwise, they will be opened in a new
     window.
 
+    Paths that start with \`atom://\` will be interpreted as URLs.
+
     Environment Variables:
 
       ATOM_DEV_RESOURCE_PATH  The path from which Atom loads source code in dev mode.
@@ -76,7 +78,6 @@ module.exports = function parseCommandLine (processArgs) {
 
   const addToLastWindow = args['add']
   const safeMode = args['safe']
-  const pathsToOpen = args._
   const benchmark = args['benchmark']
   const benchmarkTest = args['benchmark-test']
   const test = args['test']
@@ -100,10 +101,19 @@ module.exports = function parseCommandLine (processArgs) {
   const userDataDir = args['user-data-dir']
   const profileStartup = args['profile-startup']
   const clearWindowState = args['clear-window-state']
+  const pathsToOpen = []
   const urlsToOpen = []
   let devMode = args['dev']
   let devResourcePath = process.env.ATOM_DEV_RESOURCE_PATH || path.join(app.getPath('home'), 'github', 'atom')
   let resourcePath = null
+
+  for (const path of args._) {
+    if (path.startsWith('atom://')) {
+      urlsToOpen.push(path)
+    } else {
+      pathsToOpen.push(path)
+    }
+  }
 
   if (args['resource-path']) {
     devMode = true


### PR DESCRIPTION
### Requirements

* All new code requires tests to ensure against regressions

I would love some guidance on how to write an automated test for this.

### Description of the Change

Some Atom extensions (like Nuclide) have functionality that can only be
triggered by open-url events, which only work on Mac OS.  With this
change, `atom://` URLs can be passed on the command-line, and they will
opened with the normal openUrl method on all platforms.

This change doesn't set Atom up as the default handler for atom:// urls.
That will require some platform-specific changes.


### Alternate Designs

I considered making a separate option for passing urls (--open-url), but this seems more convenient.

### Why Should This Be In Core?

Very simple change.  Brings the "open-url" interface to all platforms.

### Benefits

Windows and Linux users can easily simulate "open-url" events.

### Possible Drawbacks

Can't use the atom command line to open a file whose name starts with `atom://`, though you can still use `./atom://foo` or just `atom:/foo`.