### PR TITLE
Pane on did change path

### DIFF
--- a/spec/pane-element-spec.coffee
+++ b/spec/pane-element-spec.coffee
@@ -113,6 +113,49 @@ describe "PaneElement", ->
         expect(paneElement.dataset.activeItemPath).toBeUndefined()
         expect(paneElement.dataset.activeItemName).toBeUndefined()
 
+      describe "when the path of the item changes", ->
+        [item1, item2] = []
+
+        beforeEach ->
+          item1 = document.createElement('div')
+          item1.path = '/foo/bar.txt'
+          item1.changePathCallbacks = []
+          item1.setPath = (path) ->
+            this.path = path
+            callback() for callback in changePathCallbacks
+          item1.getPath = -> this.path
+          item1.onDidChangePath = (callback) -> this.changePathCallbacks.push(callback)
+
+          item2 = document.createElement('div')
+
+          pane.addItem(item1)
+          pane.addItem(item2)
+
+        it "changes the file path and file name data attributes on the pane if the active item path is changed", ->
+
+          expect(paneElement.dataset.activeItemPath).toBe '/foo/bar.txt'
+          expect(paneElement.dataset.activeItemName).toBe 'bar.txt'
+
+          item1.setPath "/foo/bar1.txt"
+
+          expect(paneElement.dataset.activeItemPath).toBe '/foo/bar1.txt'
+          expect(paneElement.dataset.activeItemName).toBe 'bar1.txt'
+
+          pane.activateItem(item2)
+
+          expect(paneElement.dataset.activeItemPath).toBeUndefined()
+          expect(paneElement.dataset.activeItemName).toBeUndefined()
+
+          item1.setPath "/foo/bar2.txt"
+
+          expect(paneElement.dataset.activeItemPath).toBeUndefined()
+          expect(paneElement.dataset.activeItemName).toBeUndefined()
+
+          pane.activateItem(item1)
+
+          expect(paneElement.dataset.activeItemPath).toBe '/foo/bar2.txt'
+          expect(paneElement.dataset.activeItemName).toBe 'bar2.txt'
+
   describe "when an item is removed from the pane", ->
     describe "when the destroyed item is an element", ->
       it "removes the item from the itemViews div", ->

--- a/spec/pane-element-spec.coffee
+++ b/spec/pane-element-spec.coffee
@@ -121,10 +121,14 @@ describe "PaneElement", ->
           item1.path = '/foo/bar.txt'
           item1.changePathCallbacks = []
           item1.setPath = (path) ->
-            this.path = path
+            @path = path
             callback() for callback in changePathCallbacks
-          item1.getPath = -> this.path
-          item1.onDidChangePath = (callback) -> this.changePathCallbacks.push(callback)
+            return
+          item1.getPath = -> @path
+          item1.onDidChangePath = (callback) ->
+            @changePathCallbacks.push(callback)
+            return dispose: =>
+              @changePathCallbacks = @changePathCallbacks.filter (f) -> f isnt callback
 
           item2 = document.createElement('div')
 

--- a/spec/pane-element-spec.coffee
+++ b/spec/pane-element-spec.coffee
@@ -122,11 +122,11 @@ describe "PaneElement", ->
           item1.changePathCallbacks = []
           item1.setPath = (path) ->
             @path = path
-            callback() for callback in changePathCallbacks
+            callback() for callback in @changePathCallbacks
             return
           item1.getPath = -> @path
           item1.onDidChangePath = (callback) ->
-            @changePathCallbacks.push(callback)
+            @changePathCallbacks.push callback
             return dispose: =>
               @changePathCallbacks = @changePathCallbacks.filter (f) -> f isnt callback
 

--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -79,7 +79,7 @@ class PaneElement extends HTMLElement
   activeItemChanged: (item) ->
     delete @dataset.activeItemName
     delete @dataset.activeItemPath
-    @changePathDisposable?.dispose?()
+    @changePathDisposable?.dispose()
 
     return unless item?
 
@@ -126,6 +126,7 @@ class PaneElement extends HTMLElement
 
   paneDestroyed: ->
     @subscriptions.dispose()
+    @changePathDisposable?.dispose()
 
   flexScaleChanged: (flexScale) ->
     @style.flexGrow = flexScale

--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -79,6 +79,7 @@ class PaneElement extends HTMLElement
   activeItemChanged: (item) ->
     delete @dataset.activeItemName
     delete @dataset.activeItemPath
+    @changePathDisposable?.dispose?()
 
     return unless item?
 
@@ -88,6 +89,12 @@ class PaneElement extends HTMLElement
     if itemPath = item.getPath?()
       @dataset.activeItemName = path.basename(itemPath)
       @dataset.activeItemPath = itemPath
+
+      if item.onDidChangePath?
+        @changePathDisposable = item.onDidChangePath =>
+          itemPath = item.getPath()
+          @dataset.activeItemName = path.basename(itemPath)
+          @dataset.activeItemPath = itemPath
 
     unless @itemViews.contains(itemView)
       @itemViews.appendChild(itemView)


### PR DESCRIPTION

### Description of the Change

Change a pane elements `.dataset.activeItemPath` and `.dataset.activeItemName` when the path changes.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs



<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

needs to change the core pane-element

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

### Benefits

```javascript
atom.workspace.getActivePane().element.dataset.activeItemPath
```
will be more reliable.


<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

none

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

#15691 

<!-- Enter any applicable Issues here -->
