### PR TITLE
Update language-html to 0.48.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "language-json": "0.19.1",
     "language-less": "0.33.0",
     "language-make": "0.22.3",
-    "language-mustache": "0.14.1",
+    "language-mustache": "0.14.2",
     "language-objective-c": "0.15.1",
     "language-perl": "0.37.0",
     "language-php": "0.42.0",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "language-gfm": "0.90.1",
     "language-git": "0.19.1",
     "language-go": "0.44.2",
-    "language-html": "0.47.7",
+    "language-html": "0.48.0",
     "language-hyperlink": "0.16.2",
     "language-java": "0.27.4",
     "language-javascript": "0.127.3",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "language-html": "0.48.0",
     "language-hyperlink": "0.16.2",
     "language-java": "0.27.4",
-    "language-javascript": "0.127.3",
+    "language-javascript": "0.127.4",
     "language-json": "0.19.1",
     "language-less": "0.33.0",
     "language-make": "0.22.3",

--- a/spec/tokenized-buffer-spec.coffee
+++ b/spec/tokenized-buffer-spec.coffee
@@ -345,7 +345,7 @@ describe "TokenizedBuffer", ->
       runs ->
         fullyTokenize(tokenizedBuffer)
         {tokens} = tokenizedBuffer.tokenizedLines[0]
-        expect(tokens[0]).toEqual value: '<', scopes: ["text.html.ruby", "meta.tag.block.any.html", "punctuation.definition.tag.begin.html"]
+        expect(tokens[0]).toEqual value: '<', scopes: ["text.html.ruby", "meta.tag.block.div.html", "punctuation.definition.tag.begin.html"]
 
   describe ".tokenForPosition(position)", ->
     afterEach ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* Fix improper tokenization of script and style tags (where the tags themselves would have embedded scopes)
* Recognize XML namespaces
* Improve attribute tokenization
* Improve entity tokenization
* Add `text/ractive` to list of types that will be tokenized as HTML when in a script tag
* Remove useless `meta.tag.any.html`
* Add unique scopes for the `class` attribute

Other commits are mostly working around the `meta.tag.any.html` removal.