### PR TITLE
Update first-mate

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "language-gfm": "0.90.1",
     "language-git": "0.19.1",
     "language-go": "0.44.2",
-    "language-html": "0.48.0",
+    "language-html": "0.48.1",
     "language-hyperlink": "0.16.2",
     "language-java": "0.27.4",
     "language-javascript": "0.127.5",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "etch": "^0.12.6",
     "event-kit": "^2.4.0",
     "find-parent-dir": "^0.3.0",
-    "first-mate": "7.0.8",
+    "first-mate": "7.0.9",
     "focus-trap": "^2.3.0",
     "fs-admin": "^0.1.6",
     "fs-plus": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "etch": "^0.12.6",
     "event-kit": "^2.4.0",
     "find-parent-dir": "^0.3.0",
-    "first-mate": "7.0.7",
+    "first-mate": "7.0.8",
     "focus-trap": "^2.3.0",
     "fs-admin": "^0.1.6",
     "fs-plus": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "language-mustache": "0.14.3",
     "language-objective-c": "0.15.1",
     "language-perl": "0.37.0",
-    "language-php": "0.42.0",
+    "language-php": "0.42.1",
     "language-property-list": "0.9.1",
     "language-python": "0.45.4",
     "language-ruby": "0.71.3",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "language-c": "0.58.1",
     "language-clojure": "0.22.4",
     "language-coffee-script": "0.49.1",
-    "language-csharp": "0.14.2",
+    "language-csharp": "0.14.3",
     "language-css": "0.42.6",
     "language-gfm": "0.90.1",
     "language-git": "0.19.1",


### PR DESCRIPTION
first-mate is now more in line with the original TextMate implementation.

* [x] https://github.com/asciidoctor/atom-language-asciidoc/pull/185
* [x] https://github.com/nwhetsell/language-csound/pull/3
* [ ] https://github.com/paxromana96/language-frege/pull/1
* [x] https://github.com/aegypius/language-gentoo/pull/5
* [x] https://github.com/atom-haskell/language-haskell/pull/110
* [x] https://github.com/burodepeper/language-markdown/pull/193
* [x] https://github.com/tggreene/language-pixie/pull/1
* [x] https://github.com/hellerve/language-zepto/pull/1