### PR TITLE
Restore a missing "typeof"

### DIFF
--- a/src/package.coffee
+++ b/src/package.coffee
@@ -517,7 +517,7 @@ class Package
       console.error "Error deactivating package '#{@name}'", e.stack
 
     # We support then-able async promises as well as sync ones from deactivate
-    if deactivationResult?.then is 'function'
+    if typeof deactivationResult?.then is 'function'
       deactivationResult.then => @afterDeactivation()
     else
       @afterDeactivation()


### PR DESCRIPTION
The deactivationResult returned from a package's `deactivate()` method was having its `then` property compared to the string `"function"` rather than its _type_ being compared to `"function"`. As a result, async package deactivation functions were not returning the correct Promise from `PackageManager.deactivatePackage()`.

Quick fix :zap: