### PR TITLE
:arrow_up: electron@1.6.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "1.6.9",
+  "electronVersion": "1.6.14",
   "dependencies": {
     "@atom/source-map-support": "^0.3.4",
     "async": "0.2.6",


### PR DESCRIPTION
Upgrading to the latest 1.6 patch to get the RCE fix: https://electron.atom.io/blog/2017/09/27/chromium-rce-vulnerability-fix

Fixes https://github.com/atom/atom/issues/13885