### PR TITLE
Fix mouseup listener cleanup when dragging in text editor

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1883,7 +1883,7 @@ class TextEditorComponent {
 
     function didMouseUp () {
       window.removeEventListener('mousemove', didMouseMove)
-      window.removeEventListener('mouseup', didMouseUp)
+      window.removeEventListener('mouseup', didMouseUp, {capture: true})
       bufferWillChangeDisposable.dispose()
       if (dragging) {
         dragging = false


### PR DESCRIPTION
This listener is added with `{capture: true}`, which means it'll only be removed if `removeEventListener()` is passed `{capture: true}` too. Without that (as it is currently), the listener is never removed and each mouseup event ends up triggering the handler one more time than the last. Eventually, this leads to slowdown. 😞