### PR TITLE
Prompt to save when unloading if editor is in conflict

### DIFF
--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -5324,37 +5324,6 @@ describe "TextEditor", ->
         [[6, 3], [6, 4]],
       ])
 
-  describe ".shouldPromptToSave()", ->
-    it "returns true when buffer changed", ->
-      jasmine.unspy(editor, 'shouldPromptToSave')
-      expect(editor.shouldPromptToSave()).toBeFalsy()
-      buffer.setText('changed')
-      expect(editor.shouldPromptToSave()).toBeTruthy()
-
-    it "returns false when an edit session's buffer is in use by more than one session", ->
-      jasmine.unspy(editor, 'shouldPromptToSave')
-      buffer.setText('changed')
-
-      editor2 = null
-      waitsForPromise ->
-        atom.workspace.getActivePane().splitRight()
-        atom.workspace.open('sample.js', autoIndent: false).then (o) -> editor2 = o
-
-      runs ->
-        expect(editor.shouldPromptToSave()).toBeFalsy()
-        editor2.destroy()
-        expect(editor.shouldPromptToSave()).toBeTruthy()
-
-    it "returns false when close of a window requested and edit session opened inside project", ->
-      jasmine.unspy(editor, 'shouldPromptToSave')
-      buffer.setText('changed')
-      expect(editor.shouldPromptToSave(windowCloseRequested: true, projectHasPaths: true)).toBeFalsy()
-
-    it "returns true when close of a window requested and edit session opened without project", ->
-      jasmine.unspy(editor, 'shouldPromptToSave')
-      buffer.setText('changed')
-      expect(editor.shouldPromptToSave(windowCloseRequested: true, projectHasPaths: false)).toBeTruthy()
-
   describe "when the editor contains surrogate pair characters", ->
     it "correctly backspaces over them", ->
       editor.setText('\uD835\uDF97\uD835\uDF97\uD835\uDF97')

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -961,7 +961,7 @@ class TextEditor extends Model
   # this editor.
   shouldPromptToSave: ({windowCloseRequested, projectHasPaths}={}) ->
     if windowCloseRequested and projectHasPaths and atom.stateStore.isConnected()
-      false
+      @buffer.isInConflict()
     else
       @isModified() and not @buffer.hasMultipleEditors()
 


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/15791

Normally we don't prompt to save editors when reloading or closing a window. But if an editor's contents have changed on disk, then we would need to save the editor to avoid data loss.

I'm not positive that this is the best solution, but it seems reasonable to let you know that if you don't save, you'll lose your changes. Ultimately, we need a little more UI to surface the fact that the editor has changed on disk.