### PR TITLE
Preserve indentation when toggling comments on whitespace-only lines

### DIFF
--- a/spec/tokenized-buffer-spec.js
+++ b/spec/tokenized-buffer-spec.js
@@ -807,7 +807,7 @@ describe('TokenizedBuffer', () => {
 
         buffer.setText('  ')
         tokenizedBuffer.toggleLineCommentsForBufferRows(0, 0)
-        expect(buffer.lineForRow(0)).toBe('// ')
+        expect(buffer.lineForRow(0)).toBe('  // ')
 
         buffer.setText('    a\n  \n    b')
         tokenizedBuffer.toggleLineCommentsForBufferRows(0, 2)

--- a/src/tokenized-buffer.js
+++ b/src/tokenized-buffer.js
@@ -222,13 +222,18 @@ class TokenizedBuffer {
         }
       } else {
         let minIndentLevel = null
+        let minBlankIndentLevel
         for (let row = start; row <= end; row++) {
           const line = this.buffer.lineForRow(row)
           if (NON_WHITESPACE_REGEX.test(line)) {
             const indentLevel = this.indentLevelForLine(line)
             if (minIndentLevel == null || indentLevel < minIndentLevel) minIndentLevel = indentLevel
+          } else if (minIndentLevel == null) {
+            const indentLevel = this.indentLevelForLine(line)
+            if (minBlankIndentLevel == null || indentLevel < minBlankIndentLevel) minBlankIndentLevel = indentLevel
           }
         }
+        if (minIndentLevel == null) minIndentLevel = minBlankIndentLevel
         if (minIndentLevel == null) minIndentLevel = 0
 
         const tabLength = this.getTabLength()


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/atom/atom/pull/15713.

When toggling comments on whitespace-only lines, we need to preserve the indentation level.

/cc @jasonrudolph 