### PR TITLE
Clear the dimensions cache after updating the soft wrap column

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2118,6 +2118,7 @@ class TextEditorComponent {
       // rendered start row accurately. 😥
       this.populateVisibleRowRange(renderedStartRow)
       this.props.model.setEditorWidthInChars(this.getScrollContainerClientWidthInBaseCharacters())
+      this.derivedDimensionsCache = {}
 
       this.suppressUpdates = false
     }


### PR DESCRIPTION
Updating the soft wrap column could cause us to compute different values for derived dimensions, so any dimensions that were cached *in the process* of updating the soft wrap column need to be cleared.

This fixes a randomized test failure found be @Ben3eeE.

/cc @Ben3eeE @as-cii