### PR TITLE
Always revert to composition checkpoint, even if input is disabled

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1595,30 +1595,30 @@ class TextEditorComponent {
   }
 
   didTextInput (event) {
-    if (!this.isInputEnabled()) return
-
-    event.stopPropagation()
-
-    // WARNING: If we call preventDefault on the input of a space character,
-    // then the browser interprets the spacebar keypress as a page-down command,
-    // causing spaces to scroll elements containing editors. This is impossible
-    // to test.
-    if (event.data !== ' ') event.preventDefault()
-
     if (this.compositionCheckpoint) {
       this.props.model.revertToCheckpoint(this.compositionCheckpoint)
       this.compositionCheckpoint = null
     }
 
-    // If the input event is fired while the accented character menu is open it
-    // means that the user has chosen one of the accented alternatives. Thus, we
-    // will replace the original non accented character with the selected
-    // alternative.
-    if (this.accentedCharacterMenuIsOpen) {
-      this.props.model.selectLeft()
-    }
+    if (this.isInputEnabled()) {
+      event.stopPropagation()
 
-    this.props.model.insertText(event.data, {groupUndo: true})
+      // WARNING: If we call preventDefault on the input of a space character,
+      // then the browser interprets the spacebar keypress as a page-down command,
+      // causing spaces to scroll elements containing editors. This is impossible
+      // to test.
+      if (event.data !== ' ') event.preventDefault()
+
+      // If the input event is fired while the accented character menu is open it
+      // means that the user has chosen one of the accented alternatives. Thus, we
+      // will replace the original non accented character with the selected
+      // alternative.
+      if (this.accentedCharacterMenuIsOpen) {
+        this.props.model.selectLeft()
+      }
+
+      this.props.model.insertText(event.data, {groupUndo: true})
+    }
   }
 
   // We need to get clever to detect when the accented character menu is


### PR DESCRIPTION
Fixes #15783 

Previously, if the user opened the IME menu while input was disabled, we would create a composition checkpoint without reverting to it after the composition ended. When enabling input again, the first keystroke would cause any buffer change that occurred between the IME composition and the keystroke to be reverted.

With this commit we will always revert and delete the composition checkpoint as soon as the composition ends, regardless of whether the input is enabled or not.

@t9md @ungb @Ben3eeE: since we're touching the IME code path, could you help me test this doesn't introduce any weird regression? Thanks! 🙇 

/cc: @nathansobo 