### PR TITLE
Add indentation to force YAML to leave certain lines the way they are

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,18 +14,18 @@ staleLabel: stale
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
   Thanks for your contribution!
-
+   
   This issue has been automatically marked as stale because it has not had
   recent activity. Because the Atom team treats their issues
   [as their backlog](https://en.wikipedia.org/wiki/Scrum_(software_development)#Product_backlog), stale issues
   are closed. If you would like this issue to remain open:
-
-  1. Verify that you can still reproduce the issue in the latest version of Atom
-  1. Comment that the issue is still reproducible and include:
-    * What version of Atom you reproduced the issue on
-    * What OS and version you reproduced the issue on
-    * What steps you followed to reproduce the issue
-
+   
+   1. Verify that you can still reproduce the issue in the latest version of Atom
+   1. Comment that the issue is still reproducible and include:
+      * What version of Atom you reproduced the issue on
+      * What OS and version you reproduced the issue on
+      * What steps you followed to reproduce the issue
+   
   Issues that are labeled as triaged will not be automatically marked as stale.
 # Comment to post when removing the stale label. Set to `false` to disable
 unmarkComment: false


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Stale bot was posting comments that looked wonky:

<img width="886" alt="screen shot 2017-10-07 at 1 01 15 pm" src="https://user-images.githubusercontent.com/1038121/31311356-af7f1c34-ab5f-11e7-9087-9e988741e602.png">

This should fix it so that they look the way they were intended to look.

### Alternate Designs

Another possibility is to use the literal scalar syntax `|` in the place of `>`:

```
markComment: |
  Thanks for your contribution!
   
  This issue has been automatically marked as stale because it has not had recent activity. Because the Atom team treats their issues [as their backlog](https://en.wikipedia.org/wiki/Scrum_(software_development)#Product_backlog), stale issues are closed. 

  If you would like this issue to remain open:
   
  1. Verify that you can still reproduce the issue in the latest version of Atom
  1. Comment that the issue is still reproducible and include:
      * What version of Atom you reproduced the issue on
      * What OS and version you reproduced the issue on
      * What steps you followed to reproduce the issue
   
  Issues that are labeled as triaged will not be automatically marked as stale.
```

but that means the second paragraph would have to be one long line and that makes the file less readable, I think.

### Why Should This Be In Core?

It already is.

### Benefits

No more wonky looking Stale bot comments.

### Possible Drawbacks

None that I can think of.

### Applicable Issues

N/A
