### PR TITLE
Don't throw when destroying block decorations inside marker change event

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -2541,6 +2541,24 @@ describe('TextEditorComponent', () => {
       ])
     })
 
+    it('does not throw exceptions when destroying a block decoration inside a marker change event (regression)', async () => {
+      const {editor, component} = buildComponent({rowsPerTile: 3})
+
+      const marker = editor.markScreenPosition([2, 0])
+      marker.onDidChange(() => { marker.destroy() })
+      const item = document.createElement('div')
+      editor.decorateMarker(marker, {type: 'block', item})
+
+      await component.getNextUpdatePromise()
+      expect(item.nextSibling).toBe(lineNodeForScreenRow(component, 2))
+
+      marker.setBufferRange([[0, 0], [0, 0]])
+      expect(marker.isDestroyed()).toBe(true)
+
+      await component.getNextUpdatePromise()
+      expect(item.parentElement).toBeNull()
+    })
+
     it('does not attempt to render block decorations located outside the visible range', async () => {
       const {editor, component} = buildComponent({autoHeight: false, rowsPerTile: 2})
       await setEditorHeightInLines(component, 2)

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2523,6 +2523,7 @@ class TextEditorComponent {
         didDestroyDisposable.dispose()
 
         if (wasValid) {
+          wasValid = false
           this.blockDecorationsToMeasure.delete(decoration)
           this.heightsByBlockDecoration.delete(decoration)
           this.blockDecorationsByElement.delete(element)


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15756

Previously, when markers were destroyed inside of a `marker.onDidChange` handler that was registered *before* decorating the marker, we would attempt to remove block decorations from the `LineTopIndex` twice: once when destroying the marker, and once when receiving the marker change event.

This was a little counterintuitive at first, because we were already disposing the change event handler associated with the marker upon its destruction. However, we would still receive a marker change event because the marker was getting destroyed *while* notifying its change event subscribers.

With this pull-request we will gracefully handle that situation by remembering that the marker became invalid during its destruction, so that when the change event is finally triggered, it will simply be ignored because the marker validity will not change.

/cc: @nathansobo @Ben3eeE 