### PR TITLE
forceHideTitleBar

### DIFF
--- a/src/main-process/atom-window.coffee
+++ b/src/main-process/atom-window.coffee
@@ -49,7 +49,7 @@ class AtomWindow
     if @shouldAddCustomInsetTitleBar()
       options.titleBarStyle = 'hidden-inset'
 
-    if @shouldHideTitleBar()
+    if @shouldHideTitleBar() or @forceHideTitleBar()
       options.frame = false
 
     @browserWindow = new BrowserWindow(options)
@@ -255,7 +255,11 @@ class AtomWindow
     not @isSpec and
     process.platform is 'darwin' and
     @atomApplication.config.get('core.titleBar') is 'hidden'
-
+  
+  forceHideTitleBar: ->
+    not @isSpec and
+    @atomApplication.config.get('core.titleBar') is 'forcehidden'
+   
   close: -> @browserWindow.close()
 
   focus: -> @browserWindow.focus()


### PR DESCRIPTION

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Way so we could please hide the title bar on Windows through a config value.

I created a custom titleBar package for atom: https://atom.io/packages/atom-windows-titlebar
To hide the titlebar it requires sort of a hack to change the frame: false in the atom-window.js

Now with asar we can not change the file inside at all because atom is locking the file

### Alternate Designs

A simple config value I think will let us do the trick. Possibly using a different config name would be appropriate.

### Why Should This Be In Core?

Other developers have created custom titlebar packages. I think it adds a bit more hackability to the editor

### Benefits

More options for developers of packages

### Possible Drawbacks

Someone accidentally setting this value or the package crashing and then the titlebar gets hidden. Possibly there is another way to hide the electron frame during runtime by opening new BrowserWindow