### PR TITLE
rpm: Use /usr/bin/atom with desktop file

### DIFF
--- a/resources/linux/atom.desktop.in
+++ b/resources/linux/atom.desktop.in
@@ -2,7 +2,7 @@
 Name=<%= appName %>
 Comment=<%= description %>
 GenericName=Text Editor
-Exec=<%= installDir %>/share/<%= appFileName %>/atom %F
+Exec=<%= installDir %>/<%= appFileName %> %F
 Icon=<%= iconPath %>
 Type=Application
 StartupNotify=true


### PR DESCRIPTION
### Requirements

### Description of the Change

Multiple people over multiple releases have had issues starting atom
noting scl errors. The fix was noted to be running /usr/bin/atom and has
been verified by multiple users. This change updates the desktop file to
use /usr/bin/atom instead of /usr/share/atom/atom.

### Alternate Designs

The current alternate designs are:

- Tell rpm users to not use the desktop file and instead run atom from the terminal.
- Have all terminal based packages work around the issue

### Why Should This Be In Core?

So people who install via rpm can click the desktop icon and use atom without errors 😄 

### Benefits

Same as "Why should this be in core?"


### Possible Drawbacks

I don't think there are any but I created this quickly based on the issue.

### Applicable Issues

See: https://github.com/atom/atom/issues/13451