### PR TITLE
Fix overlay resizing infinite loop

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -4202,7 +4202,7 @@ class OverlayComponent {
       if (contentRect.width !== this.props.measuredDimensions.width || contentRect.height !== this.props.measuredDimensions.height) {
         this.resizeObserver.disconnect()
         this.props.didResize()
-        process.nextTick(() => { this.resizeObserver.observe(this.element) })
+        process.nextTick(() => { this.resizeObserver.observe(this.props.element) })
       }
     })
     this.didAttach()
@@ -4226,7 +4226,7 @@ class OverlayComponent {
   }
 
   didAttach () {
-    this.resizeObserver.observe(this.element)
+    this.resizeObserver.observe(this.props.element)
   }
 
   didDetach () {


### PR DESCRIPTION
When an overlay is present, we are comparing the dimensions of the overlay's child with the dimensions of `atom-overlay`. If they are different, we disconnect the resize observer, call the `.didResize` callback, and observe `atom-overlay` once more on the next tick. In autocomplete-plus (possibly others), the child of the overlay never matches the dimensions of the overlay, and the resize observer callback gets triggered on every tick as long as the suggestion list is present.

This bug is particularly noticeable when a large file like text-editor-component.js is opened and completely folded. Here are timelines before and after this fix when a suggestion list for the same prefix at the same editor position is opened:

before
![screen shot 2017-10-14 at 6 59 32 pm](https://user-images.githubusercontent.com/520209/31580701-edaf6df0-b114-11e7-8156-820a18593186.png)

after
![screen shot 2017-10-14 at 6 55 19 pm](https://user-images.githubusercontent.com/520209/31580706-10b0b80e-b115-11e7-9393-1a8b43f23796.png)

Here's a zoomed in shot of the timeline before the fix:
![screen shot 2017-10-14 at 7 00 09 pm](https://user-images.githubusercontent.com/520209/31580702-f153f426-b114-11e7-95a6-662aba98515e.png)


