### PR TITLE
Stop dragging only when user interacts with keyboard

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -4422,7 +4422,7 @@ describe('TextEditorComponent', () => {
       expect(dragEvents).toEqual([])
     })
 
-    it('calls `didStopDragging` if the buffer changes while dragging', async () => {
+    it('calls `didStopDragging` if the user interacts with the keyboard while dragging', async () => {
       const {component, editor} = buildComponent()
 
       let dragging = false
@@ -4435,8 +4435,14 @@ describe('TextEditorComponent', () => {
       await getNextAnimationFramePromise()
       expect(dragging).toBe(true)
 
-      editor.delete()
+      // Buffer changes don't cause dragging to be stopped.
+      editor.insertText('X')
+      expect(dragging).toBe(true)
+
+      // Keyboard interaction prevents users from dragging further.
+      component.didKeydown({code: 'KeyX'})
       expect(dragging).toBe(false)
+
       window.dispatchEvent(new MouseEvent('mousemove'))
       await getNextAnimationFramePromise()
       expect(dragging).toBe(false)


### PR DESCRIPTION
Refs: https://github.com/atom/atom/pull/15407

Previously, we prevented users from dragging the selection further when the buffer was about to change. This was problematic because any change in the buffer, even one that was performed "automatically" by a package, would cancel the dragging action and result in a confusing experience for the user. On the other hand, we want to prevent users from accidentally selecting text when they perform an edit (see #15217, #15405).

This pull-request addresses both concerns by canceling the dragging as soon as the user interacts with the keyboard, instead of canceling the dragging when the buffer is about to change. One downside of this approach is that it changes the behavior of pressing a key that does not result in a buffer change, e.g. <kbd>Shift</kbd>, <kbd>Right-Arrow</kbd>, etc. In fact, pressing one of those keys will now prevent users from dragging the selection further. This seems like an acceptable tradeoff, but we are open to revisiting it in case it introduces pain in some other area of the system.

🍐'd with @jasonrudolph 

/cc: @nathansobo @Ben3eeE @ungb 