### PR TITLE
Add x-scheme-handler/atom as MimeType in atom.desktop.in

### DIFF
--- a/resources/linux/atom.desktop.in
+++ b/resources/linux/atom.desktop.in
@@ -8,3 +8,10 @@ Type=Application
 StartupNotify=true
 Categories=GNOME;GTK;Utility;TextEditor;Development;
 MimeType=text/plain;
+
+[Desktop Action URIHandler]
+Name=<%= appName %> URI Handler
+Type=Application
+NoDisplay=true
+Exec=<%= installDir %>/share/<%= appFileName %>/atom --uri-handler %u
+MimeType=x-scheme-handler/atom;


### PR DESCRIPTION
This is an attempt to register Atom as a default protocol client for `atom://` URIs on at least *some* Linux systems. I'm not very familiar with this and am not quite sure if this is even the right path; thoughts from @atom/maintainers (maybe @smashwilson?) welcome!