### PR TITLE
Use endsWith to match modules to exclude from the snapshot

### DIFF
--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -27,47 +27,37 @@ module.exports = function (packagedAppPath) {
         coreModules.has(modulePath) ||
         (relativePath.startsWith(path.join('..', 'src')) && relativePath.endsWith('-element.js')) ||
         relativePath.startsWith(path.join('..', 'node_modules', 'dugite')) ||
+        relativePath.endsWith(path.join('node_modules', 'coffee-script', 'lib', 'coffee-script', 'register.js')) ||
+        relativePath.endsWith(path.join('node_modules', 'fs-extra', 'lib', 'index.js')) ||
+        relativePath.endsWith(path.join('node_modules', 'graceful-fs', 'graceful-fs.js')) ||
+        relativePath.endsWith(path.join('node_modules', 'htmlparser2', 'lib', 'index.js')) ||
+        relativePath.endsWith(path.join('node_modules', 'minimatch', 'minimatch.js')) ||
         relativePath === path.join('..', 'exports', 'atom.js') ||
         relativePath === path.join('..', 'src', 'electron-shims.js') ||
         relativePath === path.join('..', 'src', 'safe-clipboard.js') ||
         relativePath === path.join('..', 'node_modules', 'atom-keymap', 'lib', 'command-event.js') ||
         relativePath === path.join('..', 'node_modules', 'babel-core', 'index.js') ||
         relativePath === path.join('..', 'node_modules', 'cached-run-in-this-context', 'lib', 'main.js') ||
-        relativePath === path.join('..', 'node_modules', 'coffee-script', 'lib', 'coffee-script', 'register.js') ||
-        relativePath === path.join('..', 'node_modules', 'cson-parser', 'node_modules', 'coffee-script', 'lib', 'coffee-script', 'register.js') ||
         relativePath === path.join('..', 'node_modules', 'decompress-zip', 'lib', 'decompress-zip.js') ||
         relativePath === path.join('..', 'node_modules', 'debug', 'node.js') ||
-        relativePath === path.join('..', 'node_modules', 'fs-extra', 'lib', 'index.js') ||
-        relativePath === path.join('..', 'node_modules', 'github', 'node_modules', 'fs-extra', 'lib', 'index.js') ||
         relativePath === path.join('..', 'node_modules', 'git-utils', 'src', 'git.js') ||
         relativePath === path.join('..', 'node_modules', 'glob', 'glob.js') ||
-        relativePath === path.join('..', 'node_modules', 'graceful-fs', 'graceful-fs.js') ||
-        relativePath === path.join('..', 'node_modules', 'htmlparser2', 'lib', 'index.js') ||
-        relativePath === path.join('..', 'node_modules', 'markdown-preview', 'node_modules', 'htmlparser2', 'lib', 'index.js') ||
-        relativePath === path.join('..', 'node_modules', 'roaster', 'node_modules', 'htmlparser2', 'lib', 'index.js') ||
-        relativePath === path.join('..', 'node_modules', 'task-lists', 'node_modules', 'htmlparser2', 'lib', 'index.js') ||
         relativePath === path.join('..', 'node_modules', 'iconv-lite', 'lib', 'index.js') ||
         relativePath === path.join('..', 'node_modules', 'less', 'index.js') ||
         relativePath === path.join('..', 'node_modules', 'less', 'lib', 'less', 'fs.js') ||
         relativePath === path.join('..', 'node_modules', 'less', 'lib', 'less-node', 'index.js') ||
-        relativePath === path.join('..', 'node_modules', 'less', 'node_modules', 'graceful-fs', 'graceful-fs.js') ||
-        relativePath === path.join('..', 'node_modules', 'minimatch', 'minimatch.js') ||
         relativePath === path.join('..', 'node_modules', 'node-fetch', 'lib', 'fetch-error.js') ||
-        relativePath === path.join('..', 'node_modules', 'nsfw', 'node_modules', 'fs-extra', 'lib', 'index.js') ||
         relativePath === path.join('..', 'node_modules', 'superstring', 'index.js') ||
         relativePath === path.join('..', 'node_modules', 'oniguruma', 'src', 'oniguruma.js') ||
         relativePath === path.join('..', 'node_modules', 'request', 'index.js') ||
         relativePath === path.join('..', 'node_modules', 'resolve', 'index.js') ||
         relativePath === path.join('..', 'node_modules', 'resolve', 'lib', 'core.js') ||
-        relativePath === path.join('..', 'node_modules', 'scandal', 'node_modules', 'minimatch', 'minimatch.js') ||
         relativePath === path.join('..', 'node_modules', 'settings-view', 'node_modules', 'glob', 'glob.js') ||
-        relativePath === path.join('..', 'node_modules', 'settings-view', 'node_modules', 'minimatch', 'minimatch.js') ||
         relativePath === path.join('..', 'node_modules', 'spellchecker', 'lib', 'spellchecker.js') ||
         relativePath === path.join('..', 'node_modules', 'spelling-manager', 'node_modules', 'natural', 'lib', 'natural', 'index.js') ||
         relativePath === path.join('..', 'node_modules', 'tar', 'tar.js') ||
         relativePath === path.join('..', 'node_modules', 'temp', 'lib', 'temp.js') ||
-        relativePath === path.join('..', 'node_modules', 'tmp', 'lib', 'tmp.js') ||
-        relativePath === path.join('..', 'node_modules', 'tree-view', 'node_modules', 'minimatch', 'minimatch.js')
+        relativePath === path.join('..', 'node_modules', 'tmp', 'lib', 'tmp.js')
       )
     }
   }).then((snapshotScript) => {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

There's a couple of common packages that need to be excluded from the snapshot.  Rather than listing each instance (since they may or may not be deduped), match using `endsWith`.

### Alternate Designs

None.

### Why Should This Be In Core?

Already is.

### Benefits

Less code maintenance if a package is un-deduped or a new dependency of that package is added in a different module.  Also fixes an intermittent build issue for me where an additional fs-extra shows up in github/node_modules/nsfw/node_modules/fs-extra.

### Possible Drawbacks

None.

### Applicable Issues

None.

/cc @as-cii just wanted to make sure this is safe to do.