### PR TITLE
Improve grammar scoring

### DIFF
--- a/spec/grammars-spec.coffee
+++ b/spec/grammars-spec.coffee
@@ -55,33 +55,16 @@ describe "the `grammars` global", ->
         expect(atom.grammars.selectGrammar('something\\.git\\config').scopeName).toBe 'source.git-config'
 
     it "can use the filePath to load the correct grammar based on the grammar's filetype", ->
-      waitsForPromise ->
-        atom.packages.activatePackage('language-git')
-
-      runs ->
-        expect(atom.grammars.selectGrammar("file.js").name).toBe "JavaScript" # based on extension (.js)
-        expect(atom.grammars.selectGrammar(path.join(temp.dir, '.git', 'config')).name).toBe "Git Config" # based on end of the path (.git/config)
-        expect(atom.grammars.selectGrammar("Rakefile").name).toBe "Ruby" # based on the file's basename (Rakefile)
-        expect(atom.grammars.selectGrammar("curb").name).toBe "Null Grammar"
-        expect(atom.grammars.selectGrammar("/hu.git/config").name).toBe "Null Grammar"
+      expect(atom.grammars.selectGrammar("file.js").name).toBe "JavaScript" # based on extension (.js)
+      expect(atom.grammars.selectGrammar(path.join(temp.dir, '.git', 'config')).name).toBe "Git Config" # based on end of the path (.git/config)
+      expect(atom.grammars.selectGrammar("Rakefile").name).toBe "Ruby" # based on the file's basename (Rakefile)
+      expect(atom.grammars.selectGrammar("curb").name).toBe "Null Grammar"
+      expect(atom.grammars.selectGrammar("/hu.git/config").name).toBe "Null Grammar"
+      expect(atom.grammars.selectGrammar("/.git.config").name).toBe "Null Grammar" # differentiates between a '.' and '/' as file type path delimiters
 
     it "uses the filePath's shebang line if the grammar cannot be determined by the extension or basename", ->
       filePath = require.resolve("./fixtures/shebang")
       expect(atom.grammars.selectGrammar(filePath).name).toBe "Ruby"
-
-    it "uses the number of newlines in the first line regex to determine the number of lines to test against", ->
-      waitsForPromise ->
-        atom.packages.activatePackage('language-property-list')
-
-      runs ->
-        fileContent = "first-line\n<html>"
-        expect(atom.grammars.selectGrammar("dummy.coffee", fileContent).name).toBe "CoffeeScript"
-
-        fileContent = '<?xml version="1.0" encoding="UTF-8"?>'
-        expect(atom.grammars.selectGrammar("grammar.tmLanguage", fileContent).name).toBe "Null Grammar"
-
-        fileContent += '\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
-        expect(atom.grammars.selectGrammar("grammar.tmLanguage", fileContent).name).toBe "Property List (XML)"
 
     it "doesn't read the file when the file contents are specified", ->
       filePath = require.resolve("./fixtures/shebang")
@@ -143,13 +126,13 @@ describe "the `grammars` global", ->
         expect(atom.grammars.selectGrammar('Rakefile', '').scopeName).toBe 'source.coffee'
         expect(atom.grammars.selectGrammar('Cakefile', '').scopeName).toBe 'source.ruby'
 
-      it "favors user-defined file types over grammars with matching first-line-regexps", ->
+      it "favors user-defined file types over grammars with matching first-line-match patterns", ->
         atom.config.set('core.customFileTypes', 'source.ruby': ['bootstrap'])
         expect(atom.grammars.selectGrammar('bootstrap', '#!/usr/bin/env node').scopeName).toBe 'source.ruby'
 
-  describe "when there is a grammar with a first line pattern, the file type of the file is known, but from a different grammar", ->
-    it "favors file type over the matching pattern", ->
-      expect(atom.grammars.selectGrammar('foo.rb', '#!/usr/bin/env node').scopeName).toBe 'source.ruby'
+    describe "when there is a grammar with a first line pattern, the file type of the file is known, but from a different grammar", ->
+      it "favors file type over the matching pattern", ->
+        expect(atom.grammars.selectGrammar('foo.rb', '#!/usr/bin/env node').scopeName).toBe 'source.ruby'
 
   describe ".removeGrammar(grammar)", ->
     it "removes the grammar, so it won't be returned by selectGrammar", ->


### PR DESCRIPTION
⚠️ WIP ⚠️ Code should be final. No tests for new functionality or fixed bugs yet.

### Description of the Change

This mostly fixes bugs or logic errors, but also introduces a way to score a grammar based on how well did the first line pattern match a given document.

Highlights for the impatient:
* Removed underscore requirement from the file 🎉 
* Minimum score a grammar can now obtain is 0, meaning it did not match at all.
* Instead of using the somewhat clever way of storing the score information in integer part and fractional part of the score, all info is now all packed to inside a 53 bit integer `[0, Number.MAX_SAFE_INTEGER]` due to the requirement to predictably store two varying-length scoring criteria compared to just one.
![bit_layout_for_grammar_scoring](https://user-images.githubusercontent.com/1017132/31943457-86a7f838-b8d1-11e7-98f8-1ec9feda6977.png)
If either criteria exceeds their given bit range, they'll gain the largest possible value (all 1-s in its range).
* Fixed a bug caused in #13597 where non-bundled package criteria was considered only if path matched. The non-bundled package criteria should have been also applied if only first line does match.
* Fixed path scoring ignoring the contents of the delimiters when matching. This allowed the `fileType` `a/b/c` to be matched in a path such as `/some/path/some-filename.a.b.c`
* Changed path scoring to take into account the preceding period in path if the pattern did not start with either a period or slash in order to give an advantage to (most, if not all) file types that don't specify a period in front of them. If the intention is to match just dotfiles or filenames, this can now be done accurately by specifying `/.dotfile` or `/somefile` as file type. This was inspired by the [TextMate implementation](https://github.com/textmate/textmate/blob/0a597f15050ab35fa12d31076e95e7692558b05d/Frameworks/io/src/path.cc#L204-L218).
* Allow explicitly to match file types which specify a suffix using underscore. This is useful for Cucumber/Gherkin steps files, which end with `_steps.rb`.
* Fixed an edge case in path matching where for each user defined file type that matched, the score was incremented even if the match was not the longest. 
* Removed `grammarMatchesContents` in favor of newly created `getContentScore`. It felt safe to do so, because it's considered a private method and I couldn't find any other uses on Github. Essentially the same thing, but instead of returning true/false it returns a length count of the matched text. Zero-length match is distinguished from no match.
* Removed newline count "optimization" from the first line matching due to it counting across the whole pattern for just newlines, which gives the worst case maximum possible literal newlines that needs to match (overshooting in cases such as `a\n|b\nc`), but does not consider other characters that might contain newline (`\s`; `.` metacharacter if `s` modifier was set, if `\n` count is increased using a modifier `\n+` or `(\n)*`, etc...). It's an artifact from TextMate. We'll assume the input given is already limited by the caller in order to allow more flexible matching:
https://github.com/atom/atom/blob/0511c0ae4a5f18b81b3c64ad31f15dbfd8ba3a38/src/text-editor-registry.js#L30

### Alternate Designs

A version where the score was more detailed object with separate criteria was briefly considered. For compatibility reasons and simply due to not making much sense, the packing into single integer was preferred instead.

### Why Should This Be In Core?

It mostly already is.

### Benefits

More granular grammar evaluation, less likely users are greeted by an incorrectly highlighted file. Grammar developers can leverage extra flexibility.

### Possible Drawbacks

Code is slightly harder to grok because bitwise operations are done using regular multiplication and addition (JavaScript's bitwise operations are limited to 32 bits, however `Number` integer range is 53 bits). I've done my best to make it as easy to understand as possible.

### Applicable Issues

https://github.com/atom/language-php/pull/292
https://github.com/atom/first-mate/issues/17