### PR TITLE
Add command to paste without reformatting

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -132,6 +132,7 @@
   'ctrl-shift-w': 'editor:select-word'
   'cmd-ctrl-left': 'editor:move-selection-left'
   'cmd-ctrl-right': 'editor:move-selection-right'
+  'cmd-shift-V': 'editor:paste-without-reformatting'
 
   # Emacs
   'alt-f': 'editor:move-to-end-of-word'

--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -105,6 +105,7 @@
   'alt-shift-right': 'editor:select-to-next-subword-boundary'
   'alt-backspace': 'editor:delete-to-beginning-of-subword'
   'alt-delete': 'editor:delete-to-end-of-subword'
+  'ctrl-shift-V': 'editor:paste-without-reformatting'
 
   # Sublime Parity
   'ctrl-a': 'core:select-all'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -110,6 +110,7 @@
   'alt-shift-right': 'editor:select-to-next-subword-boundary'
   'alt-backspace': 'editor:delete-to-beginning-of-subword'
   'alt-delete': 'editor:delete-to-end-of-subword'
+  'ctrl-shift-V': 'editor:paste-without-reformatting'
 
   # Sublime Parity
   'ctrl-a': 'core:select-all'

--- a/menus/darwin.cson
+++ b/menus/darwin.cson
@@ -65,6 +65,7 @@
       { label: 'Copy', command: 'core:copy' }
       { label: 'Copy Path', command: 'editor:copy-path' }
       { label: 'Paste', command: 'core:paste' }
+      { label: 'Paste Without Reformatting', command: 'editor:paste-without-reformatting' }
       { label: 'Select All', command: 'core:select-all' }
       { type: 'separator' }
       { label: 'Toggle Comments', command: 'editor:toggle-line-comments' }

--- a/menus/linux.cson
+++ b/menus/linux.cson
@@ -38,6 +38,7 @@
       { label: 'C&opy', command: 'core:copy' }
       { label: 'Copy Pat&h', command: 'editor:copy-path' }
       { label: '&Paste', command: 'core:paste' }
+      { label: 'Paste Without Reformatting', command: 'editor:paste-without-reformatting' }
       { label: 'Select &All', command: 'core:select-all' }
       { type: 'separator' }
       { label: '&Toggle Comments', command: 'editor:toggle-line-comments' }

--- a/menus/win32.cson
+++ b/menus/win32.cson
@@ -46,6 +46,7 @@
       { label: '&Copy', command: 'core:copy' }
       { label: 'Copy Pat&h', command: 'editor:copy-path' }
       { label: '&Paste', command: 'core:paste' }
+      { label: 'Paste Without Reformatting', command: 'editor:paste-without-reformatting' }
       { label: 'Select &All', command: 'core:select-all' }
       { type: 'separator' }
       { label: '&Toggle Comments', command: 'editor:toggle-line-comments' }

--- a/spec/selection-spec.coffee
+++ b/spec/selection-spec.coffee
@@ -103,6 +103,11 @@ describe "Selection", ->
       selection.insertText("\r\n", autoIndent: true)
       expect(buffer.lineForRow(2)).toBe "  "
 
+    it "does not adjust the indent of trailing lines if preserveTrailingLineIndentation is true", ->
+      selection.setBufferRange [[5, 0], [5, 0]]
+      selection.insertText('      foo\n    bar\n', preserveTrailingLineIndentation: true, indentBasis: 1)
+      expect(buffer.lineForRow(6)).toBe('    bar')
+
   describe ".fold()", ->
     it "folds the buffer range spanned by the selection", ->
       selection.setBufferRange([[0, 3], [1, 6]])

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -4222,6 +4222,19 @@ describe "TextEditor", ->
               expect(editor.lineTextForBufferRow(3)).toBe("    if (items.length <= 1) return items;")
               expect(editor.getCursorBufferPosition()).toEqual([3, 13])
 
+        it "respects options that preserve the formatting of the pasted text", ->
+          editor.update({autoIndentOnPaste: true})
+          atom.clipboard.write("a(x);\n  b(x);\r\nc(x);\n", indentBasis: 0)
+          editor.setCursorBufferPosition([5, 0])
+          editor.insertText('  ')
+          editor.pasteText({autoIndent: false, preserveTrailingLineIndentation: true, normalizeLineEndings: false})
+
+          expect(editor.lineTextForBufferRow(5)).toBe "  a(x);"
+          expect(editor.lineTextForBufferRow(6)).toBe "  b(x);"
+          expect(editor.buffer.lineEndingForRow(6)).toBe "\r\n"
+          expect(editor.lineTextForBufferRow(7)).toBe "c(x);"
+          expect(editor.lineTextForBufferRow(8)).toBe "      current = items.shift();"
+
     describe ".indentSelectedRows()", ->
       describe "when nothing is selected", ->
         describe "when softTabs is enabled", ->

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -174,6 +174,11 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
         'core:cut': -> @cutSelectedText()
         'core:copy': -> @copySelectedText()
         'core:paste': -> @pasteText()
+        'editor:paste-without-reformatting': -> @pasteText({
+          normalizeLineEndings: false,
+          autoIndent: false,
+          preserveTrailingLineIndentation: true
+        })
         'editor:delete-to-previous-word-boundary': -> @deleteToPreviousWordBoundary()
         'editor:delete-to-next-word-boundary': -> @deleteToNextWordBoundary()
         'editor:delete-to-beginning-of-word': -> @deleteToBeginningOfWord()

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -356,13 +356,19 @@ class Selection extends Model
   #
   # * `text` A {String} representing the text to add
   # * `options` (optional) {Object} with keys:
-  #   * `select` if `true`, selects the newly added text.
-  #   * `autoIndent` if `true`, indents all inserted text appropriately.
-  #   * `autoIndentNewline` if `true`, indent newline appropriately.
-  #   * `autoDecreaseIndent` if `true`, decreases indent level appropriately
+  #   * `select` If `true`, selects the newly added text.
+  #   * `autoIndent` If `true`, indents all inserted text appropriately.
+  #   * `autoIndentNewline` If `true`, indent newline appropriately.
+  #   * `autoDecreaseIndent` If `true`, decreases indent level appropriately
   #     (for example, when a closing bracket is inserted).
+  #   * `preserveTrailingLineIndentation` By default, when pasting multiple
+  #   lines, Atom attempts to preserve the relative indent level between the
+  #   first line and trailing lines, even if the indent level of the first
+  #   line has changed from the copied text. If this option is `true`, this
+  #   behavior is suppressed.
+  #     level between the first lines and the trailing lines.
   #   * `normalizeLineEndings` (optional) {Boolean} (default: true)
-  #   * `undo` if `skip`, skips the undo stack for this operation.
+  #   * `undo` If `skip`, skips the undo stack for this operation.
   insertText: (text, options={}) ->
     oldBufferRange = @getBufferRange()
     wasReversed = @isReversed()
@@ -373,7 +379,7 @@ class Selection extends Model
     remainingLines = text.split('\n')
     firstInsertedLine = remainingLines.shift()
 
-    if options.indentBasis?
+    if options.indentBasis? and not options.preserveTrailingLineIndentation
       indentAdjustment = @editor.indentLevelForLine(precedingText) - options.indentBasis
       @adjustIndent(remainingLines, indentAdjustment)
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -3247,12 +3247,13 @@ class TextEditor extends Model
   # corresponding clipboard selection text.
   #
   # * `options` (optional) See {Selection::insertText}.
-  pasteText: (options={}) ->
+  pasteText: (options) ->
+    options = Object.assign({}, options)
     {text: clipboardText, metadata} = @constructor.clipboard.readWithMetadata()
     return false unless @emitWillInsertTextEvent(clipboardText)
 
     metadata ?= {}
-    options.autoIndent = @shouldAutoIndentOnPaste()
+    options.autoIndent ?= @shouldAutoIndentOnPaste()
 
     @mutateSelectedText (selection, index) =>
       if metadata.selections?.length is @getSelections().length


### PR DESCRIPTION
This PR adds a command to paste without performing any reformatting, regardless of the source of the copied text or the settings for the current file. The following transformations are suppressed:

* **Line ending normalization**. All instances of `\r\n` and `\n` in the pasted text will be preserved regardless of the line endings in the file.
* **Auto-indent** There is a global "auto-indent on paste" setting that can also be assigned per-language, but this command is a way to momentarily bypass that setting.
* **Relative indent level adjustment** By default, we attempt to keep the relative indent level of all lines consistent with the copied text. Sometimes people don't want that.

![screen shot 2017-10-23 at 5 16 51 pm](https://user-images.githubusercontent.com/1789/31917683-03a691e4-b816-11e7-9ace-05e477e86f21.png)

Relevant to recent discussion in #1407