### PR TITLE
Update languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "language-clojure": "0.22.4",
     "language-coffee-script": "0.49.1",
     "language-csharp": "0.14.3",
-    "language-css": "0.42.6",
+    "language-css": "0.42.7",
     "language-gfm": "0.90.2",
     "language-git": "0.19.1",
     "language-go": "0.44.3",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "language-java": "0.27.5",
     "language-javascript": "0.127.6",
     "language-json": "0.19.1",
-    "language-less": "0.33.1",
+    "language-less": "0.34.0",
     "language-make": "0.22.3",
     "language-mustache": "0.14.4",
     "language-objective-c": "0.15.1",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "language-css": "0.42.6",
     "language-gfm": "0.90.2",
     "language-git": "0.19.1",
-    "language-go": "0.44.2",
+    "language-go": "0.44.3",
     "language-html": "0.48.1",
     "language-hyperlink": "0.16.3",
     "language-java": "0.27.4",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "language-toml": "0.18.1",
     "language-typescript": "0.2.2",
     "language-xml": "0.35.2",
-    "language-yaml": "0.31.0"
+    "language-yaml": "0.31.1"
   },
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "language-source": "0.9.0",
     "language-sql": "0.25.8",
     "language-text": "0.7.3",
-    "language-todo": "0.29.2",
+    "language-todo": "0.29.3",
     "language-toml": "0.18.1",
     "language-typescript": "0.2.2",
     "language-xml": "0.35.2",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "language-python": "0.45.4",
     "language-ruby": "0.71.4",
     "language-ruby-on-rails": "0.25.2",
-    "language-sass": "0.61.1",
+    "language-sass": "0.61.2",
     "language-shellscript": "0.25.3",
     "language-source": "0.9.0",
     "language-sql": "0.25.8",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "wrap-guide": "0.40.2",
     "language-c": "0.58.1",
     "language-clojure": "0.22.4",
-    "language-coffee-script": "0.49.1",
+    "language-coffee-script": "0.49.2",
     "language-csharp": "0.14.3",
     "language-css": "0.42.7",
     "language-gfm": "0.90.2",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "language-go": "0.44.3",
     "language-html": "0.48.1",
     "language-hyperlink": "0.16.3",
-    "language-java": "0.27.4",
+    "language-java": "0.27.5",
     "language-javascript": "0.127.6",
     "language-json": "0.19.1",
     "language-less": "0.33.1",

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "language-php": "0.42.1",
     "language-property-list": "0.9.1",
     "language-python": "0.45.4",
-    "language-ruby": "0.71.3",
+    "language-ruby": "0.71.4",
     "language-ruby-on-rails": "0.25.2",
     "language-sass": "0.61.1",
     "language-shellscript": "0.25.3",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "language-perl": "0.37.0",
     "language-php": "0.42.2",
     "language-property-list": "0.9.1",
-    "language-python": "0.45.4",
+    "language-python": "0.45.5",
     "language-ruby": "0.71.4",
     "language-ruby-on-rails": "0.25.2",
     "language-sass": "0.61.2",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "language-json": "0.19.1",
     "language-less": "0.33.1",
     "language-make": "0.22.3",
-    "language-mustache": "0.14.3",
+    "language-mustache": "0.14.4",
     "language-objective-c": "0.15.1",
     "language-perl": "0.37.0",
     "language-php": "0.42.2",

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "language-ruby": "0.71.4",
     "language-ruby-on-rails": "0.25.2",
     "language-sass": "0.61.2",
-    "language-shellscript": "0.25.3",
+    "language-shellscript": "0.25.4",
     "language-source": "0.9.0",
     "language-sql": "0.25.8",
     "language-text": "0.7.3",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "github": "0.7.0",
     "git-diff": "1.3.6",
     "go-to-line": "0.32.1",
-    "grammar-selector": "0.49.6",
+    "grammar-selector": "0.49.7",
     "image-view": "0.62.4",
     "incompatible-packages": "0.27.3",
     "keybinding-resolver": "0.38.0",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "language-mustache": "0.14.3",
     "language-objective-c": "0.15.1",
     "language-perl": "0.37.0",
-    "language-php": "0.42.1",
+    "language-php": "0.42.2",
     "language-property-list": "0.9.1",
     "language-python": "0.45.4",
     "language-ruby": "0.71.4",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "language-git": "0.19.1",
     "language-go": "0.44.2",
     "language-html": "0.48.1",
-    "language-hyperlink": "0.16.2",
+    "language-hyperlink": "0.16.3",
     "language-java": "0.27.4",
     "language-javascript": "0.127.5",
     "language-json": "0.19.1",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "language-gfm": "0.90.2",
     "language-git": "0.19.1",
     "language-go": "0.44.3",
-    "language-html": "0.48.1",
+    "language-html": "0.48.2",
     "language-hyperlink": "0.16.3",
     "language-java": "0.27.5",
     "language-javascript": "0.127.6",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "language-html": "0.48.1",
     "language-hyperlink": "0.16.3",
     "language-java": "0.27.4",
-    "language-javascript": "0.127.5",
+    "language-javascript": "0.127.6",
     "language-json": "0.19.1",
     "language-less": "0.33.1",
     "language-make": "0.22.3",

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -1585,15 +1585,15 @@ i = /test/; #FIXME\
       atom2.project.deserialize(atom.project.serialize())
       atom2.workspace.deserialize(atom.workspace.serialize(), atom2.deserializers)
 
-      expect(atom2.grammars.getGrammars().map(grammar => grammar.name).sort()).toEqual([
-        'CoffeeScript',
-        'CoffeeScript (Literate)',
-        'JSDoc',
-        'JavaScript',
-        'Null Grammar',
-        'Regular Expression Replacement (JavaScript)',
-        'Regular Expressions (JavaScript)',
-        'TODO'
+      expect(atom2.grammars.getGrammars().map(grammar => grammar.scopeName).sort()).toEqual([
+        'source.coffee',
+        'source.js',
+        'source.js.regexp',
+        'source.js.regexp.replacement',
+        'source.jsdoc',
+        'source.litcoffee',
+        'text.plain.null-grammar',
+        'text.todo'
       ])
 
       atom2.destroy()


### PR DESCRIPTION
Quite a lot of minor changes this time around.

* **Fix Coffeescript methods wrapped in parentheses**
* Add CSS font-display property
* Support deeply nested Go accessors and channels in variable declarations
* **Fix HTML snippets and XML tag**
* Remove Hyperlink as a selectable grammar
* Add punctuation tokens for `@` in decorations and fix generic Java arrays
* Make internal JS grammars unselectable, allow spreads to precede await, and allow `package` as a method name
* **Better Less mixin support**
* Add support for Handlebars multiline comments
* Add `.theme` as a PHP filetype, **tokenize namespaces preceding scope resolution operators, fix infinite injection loop, and add support for ternaries**
* **Revert Python indentation updates**, update snippets, add indentation patterns for async definitions, and support lowercase hex characters
* Fix Ruby variables ending in `do` and recognize multiline regexes
* **Fix SCSS tag names and property names getting mixed up** and fix Sass snippets
* Support unquoted Shell herestrings and Greek prompt symbols
* Remove TODO as a selectable grammar
* Add `.ksy` as a YAML filetype