### PR TITLE
Don't assign a default project path for package specs that don't have a fixtures directory

### DIFF
--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -58,7 +58,7 @@ if specPackagePath = FindParentDir.sync(testPaths[0], 'package.json')
 if specDirectory = FindParentDir.sync(testPaths[0], 'fixtures')
   specProjectPath = path.join(specDirectory, 'fixtures')
 else
-  specProjectPath = path.join(__dirname, 'fixtures')
+  specProjectPath = require('os').tmpdir()
 
 beforeEach ->
   atom.project.setPaths([specProjectPath])


### PR DESCRIPTION
References https://github.com/atom/spell-check/issues/223, but it won't fix it until this PR is hotfixed to stable.

This prevents package specs that don't have a fixtures directory from attempting to read files out of a non-existent directory inside the ASAR bundle, which causes ENOTDIR errors in superstring.

If the spec does not have a parent folder containing a fixtures directory, we now set the default project path to `os.tmpdir()`.