### PR TITLE
Preserve folds that are fully contained by the selection when changing selection ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "service-hub": "^0.7.4",
     "sinon": "1.17.4",
     "temp": "^0.8.3",
-    "text-buffer": "13.6.0-0",
+    "text-buffer": "13.6.0-2",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",
     "winreg": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "service-hub": "^0.7.4",
     "sinon": "1.17.4",
     "temp": "^0.8.3",
-    "text-buffer": "13.5.8",
+    "text-buffer": "13.6.0-0",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",
     "winreg": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "service-hub": "^0.7.4",
     "sinon": "1.17.4",
     "temp": "^0.8.3",
-    "text-buffer": "13.6.0-2",
+    "text-buffer": "13.6.0",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",
     "winreg": "^1.2.1",

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -1871,7 +1871,7 @@ describe "TextEditor", ->
         expect(selection1.getBufferRange()).toEqual [[2, 2], [3, 3]]
 
       describe "when the 'preserveFolds' option is false (the default)", ->
-        it "removes folds that contain the selections", ->
+        it "removes folds that contain one or both of the selection's end points", ->
           editor.setSelectedBufferRange([[0, 0], [0, 0]])
           editor.foldBufferRowRange(1, 4)
           editor.foldBufferRowRange(2, 3)
@@ -1882,6 +1882,9 @@ describe "TextEditor", ->
           expect(editor.isFoldedAtScreenRow(1)).toBeFalsy()
           expect(editor.isFoldedAtScreenRow(2)).toBeFalsy()
           expect(editor.isFoldedAtScreenRow(6)).toBeFalsy()
+          expect(editor.isFoldedAtScreenRow(10)).toBeTruthy()
+
+          editor.setSelectedBufferRange([[10, 0], [12, 0]])
           expect(editor.isFoldedAtScreenRow(10)).toBeTruthy()
 
       describe "when the 'preserveFolds' option is true", ->

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -87,7 +87,7 @@ class Selection extends Model
   setBufferRange: (bufferRange, options={}) ->
     bufferRange = Range.fromObject(bufferRange)
     options.reversed ?= @isReversed()
-    @editor.destroyFoldsContainingBufferPositions([bufferRange.start, bufferRange.end]) unless options.preserveFolds
+    @editor.destroyFoldsContainingBufferPositions([bufferRange.start, bufferRange.end], true) unless options.preserveFolds
     @modifySelection =>
       needsFlash = options.flash
       delete options.flash if options.flash?

--- a/src/selection.coffee
+++ b/src/selection.coffee
@@ -87,7 +87,7 @@ class Selection extends Model
   setBufferRange: (bufferRange, options={}) ->
     bufferRange = Range.fromObject(bufferRange)
     options.reversed ?= @isReversed()
-    @editor.destroyFoldsIntersectingBufferRange(bufferRange) unless options.preserveFolds
+    @editor.destroyFoldsContainingBufferPositions([bufferRange.start, bufferRange.end]) unless options.preserveFolds
     @modifySelection =>
       needsFlash = options.flash
       delete options.flash if options.flash?

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1771,7 +1771,7 @@ class TextEditorComponent {
 
     if (target && target.matches('.fold-marker')) {
       const bufferPosition = model.bufferPositionForScreenPosition(screenPosition)
-      model.destroyFoldsIntersectingBufferRange(Range(bufferPosition, bufferPosition))
+      model.destroyFoldsContainingBufferPositions([bufferPosition], false)
       return
     }
 

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2495,8 +2495,9 @@ class TextEditor extends Model
   #
   # Returns the added {Selection}.
   addSelectionForBufferRange: (bufferRange, options={}) ->
+    bufferRange = Range.fromObject(bufferRange)
     unless options.preserveFolds
-      @destroyFoldsIntersectingBufferRange(bufferRange)
+      @displayLayer.destroyFoldsContainingBufferPositions([bufferRange.start, bufferRange.end])
     @selectionsMarkerLayer.markBufferRange(bufferRange, {invalidate: 'never', reversed: options.reversed ? false})
     @getLastSelection().autoscroll() unless options.autoscroll is false
     @getLastSelection()
@@ -3445,6 +3446,10 @@ class TextEditor extends Model
   # Remove any {Fold}s found that intersect the given buffer range.
   destroyFoldsIntersectingBufferRange: (bufferRange) ->
     @displayLayer.destroyFoldsIntersectingBufferRange(bufferRange)
+
+  # Remove any {Fold}s found that intersect the given array of buffer positions.
+  destroyFoldsContainingBufferPositions: (bufferPositions) ->
+    @displayLayer.destroyFoldsContainingBufferPositions(bufferPositions)
 
   ###
   Section: Gutters

--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2497,7 +2497,7 @@ class TextEditor extends Model
   addSelectionForBufferRange: (bufferRange, options={}) ->
     bufferRange = Range.fromObject(bufferRange)
     unless options.preserveFolds
-      @displayLayer.destroyFoldsContainingBufferPositions([bufferRange.start, bufferRange.end])
+      @displayLayer.destroyFoldsContainingBufferPositions([bufferRange.start, bufferRange.end], true)
     @selectionsMarkerLayer.markBufferRange(bufferRange, {invalidate: 'never', reversed: options.reversed ? false})
     @getLastSelection().autoscroll() unless options.autoscroll is false
     @getLastSelection()
@@ -3318,8 +3318,7 @@ class TextEditor extends Model
   # Essential: Unfold the most recent cursor's row by one level.
   unfoldCurrentRow: ->
     {row} = @getCursorBufferPosition()
-    position = Point(row, Infinity)
-    @displayLayer.destroyFoldsIntersectingBufferRange(Range(position, position))
+    @displayLayer.destroyFoldsContainingBufferPositions([Point(row, Infinity)], false)
 
   # Essential: Fold the given row in buffer coordinates based on its indentation
   # level.
@@ -3348,7 +3347,7 @@ class TextEditor extends Model
   # * `bufferRow` A {Number}
   unfoldBufferRow: (bufferRow) ->
     position = Point(bufferRow, Infinity)
-    @displayLayer.destroyFoldsIntersectingBufferRange(Range(position, position))
+    @displayLayer.destroyFoldsContainingBufferPositions([position])
 
   # Extended: For each selection, fold the rows it intersects.
   foldSelectedLines: ->
@@ -3447,9 +3446,9 @@ class TextEditor extends Model
   destroyFoldsIntersectingBufferRange: (bufferRange) ->
     @displayLayer.destroyFoldsIntersectingBufferRange(bufferRange)
 
-  # Remove any {Fold}s found that intersect the given array of buffer positions.
-  destroyFoldsContainingBufferPositions: (bufferPositions) ->
-    @displayLayer.destroyFoldsContainingBufferPositions(bufferPositions)
+  # Remove any {Fold}s found that contain the given array of buffer positions.
+  destroyFoldsContainingBufferPositions: (bufferPositions, excludeEndpoints) ->
+    @displayLayer.destroyFoldsContainingBufferPositions(bufferPositions, excludeEndpoints)
 
   ###
   Section: Gutters


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15565
Depends on https://github.com/atom/text-buffer/pull/272

Previously, whenever we changed the range of a selection, we destroyed all *intersecting* folds. This caused us to destroy even folds that the selection completely contained, which was a counter-intuitive behavior.

This PR upgrades to a new version of `text-buffer` containing a new `destroyFoldsContainingBufferPositions` method that takes an array of positions and destroys any folds containing one of these positions (exclusive of its endpoints). I also use the new method on some other code paths that only need to destroy folds intersecting individual points rather than ranges.