### PR TITLE
fix optimizer bailing on performDocumentUpdate

### DIFF
--- a/src/view-registry.js
+++ b/src/view-registry.js
@@ -233,16 +233,26 @@ class ViewRegistry {
     this.nextUpdatePromise = null
     this.resolveNextUpdatePromise = null
 
-    let writer
-    while ((writer = this.documentWriters.shift())) { writer() }
+    var writer = this.documentWriters.shift()
+    while (writer) {
+      writer()
+      writer = this.documentWriters.shift()
+    }
 
-    let reader
+    var reader = this.documentReaders.shift()
     this.documentReadInProgress = true
-    while ((reader = this.documentReaders.shift())) { reader() }
+    while (reader) {
+      reader()
+      reader = this.documentReaders.shift()
+    }
     this.documentReadInProgress = false
 
     // process updates requested as a result of reads
-    while ((writer = this.documentWriters.shift())) { writer() }
+    writer = this.documentWriters.shift()
+    while (writer) {
+      writer()
+      writer = this.documentWriters.shift()
+    }
 
     if (resolveNextUpdatePromise) { resolveNextUpdatePromise() }
   }


### PR DESCRIPTION
I've been noticing these warnings:
![screen shot 2017-10-26 at 3 25 53 pm](https://user-images.githubusercontent.com/520209/32078083-de98e812-ba62-11e7-9077-ebf7bb0510dd.png)

This function gets called a whole heck of a lot, so I'm worried about the optimizer bailing here. 