### PR TITLE
Remove hyphen from coffee-script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chai": "3.5.0",
     "chart.js": "^2.3.0",
     "clear-cut": "^2.0.2",
-    "coffee-script": "1.12.7",
+    "coffeescript": "1.12.7",
     "color": "^0.7.3",
     "dedent": "^0.7.0",
     "devtron": "1.3.0",

--- a/script/build
+++ b/script/build
@@ -7,7 +7,7 @@
 require('./bootstrap')
 
 // Needed so we can require src/module-cache.coffee during generateModuleCache
-require('coffee-script/register')
+require('coffeescript/register')
 require('colors')
 
 const path = require('path')

--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -27,7 +27,7 @@ module.exports = function (packagedAppPath) {
         coreModules.has(modulePath) ||
         (relativePath.startsWith(path.join('..', 'src')) && relativePath.endsWith('-element.js')) ||
         relativePath.startsWith(path.join('..', 'node_modules', 'dugite')) ||
-        relativePath.endsWith(path.join('node_modules', 'coffee-script', 'lib', 'coffee-script', 'register.js')) ||
+        relativePath.endsWith(path.join('node_modules', 'coffeescript', 'lib', 'coffeescript', 'register.js')) ||
         relativePath.endsWith(path.join('node_modules', 'fs-extra', 'lib', 'index.js')) ||
         relativePath.endsWith(path.join('node_modules', 'graceful-fs', 'graceful-fs.js')) ||
         relativePath.endsWith(path.join('node_modules', 'htmlparser2', 'lib', 'index.js')) ||

--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -27,7 +27,7 @@ module.exports = function (packagedAppPath) {
         coreModules.has(modulePath) ||
         (relativePath.startsWith(path.join('..', 'src')) && relativePath.endsWith('-element.js')) ||
         relativePath.startsWith(path.join('..', 'node_modules', 'dugite')) ||
-        relativePath.endsWith(path.join('node_modules', 'coffeescript', 'lib', 'coffeescript', 'register.js')) ||
+        relativePath.endsWith(path.join('node_modules', 'coffeescript', 'lib', 'coffee-script', 'register.js')) ||
         relativePath.endsWith(path.join('node_modules', 'fs-extra', 'lib', 'index.js')) ||
         relativePath.endsWith(path.join('node_modules', 'graceful-fs', 'graceful-fs.js')) ||
         relativePath.endsWith(path.join('node_modules', 'htmlparser2', 'lib', 'index.js')) ||

--- a/spec/compile-cache-spec.coffee
+++ b/spec/compile-cache-spec.coffee
@@ -1,7 +1,7 @@
 path = require 'path'
 temp = require('temp').track()
 Babel = require 'babel-core'
-CoffeeScript = require 'coffee-script'
+CoffeeScript = require 'coffeescript'
 {TypeScriptSimple} = require 'typescript-simple'
 CSON = require 'season'
 CompileCache = require '../src/compile-cache'
@@ -42,8 +42,8 @@ describe 'CompileCache', ->
         expect(CompileCache.getCacheStats()['.js']).toEqual {hits: 1, misses: 1}
         expect(Babel.transform.callCount).toBe 1
 
-    describe 'when the given file is coffee-script', ->
-      it 'compiles the file with coffee-script and caches it', ->
+    describe 'when the given file is coffeescript', ->
+      it 'compiles the file with coffeescript and caches it', ->
         CompileCache.addPathToCache(path.join(fixtures, 'coffee.coffee'), atomHome)
         expect(CompileCache.getCacheStats()['.coffee']).toEqual {hits: 0, misses: 1}
         expect(CoffeeScript.compile.callCount).toBe 1

--- a/spec/tokenized-buffer-spec.js
+++ b/spec/tokenized-buffer-spec.js
@@ -866,7 +866,7 @@ describe('TokenizedBuffer', () => {
       `)
     })
 
-    it('works for coffee-script', async () => {
+    it('works for coffeescript', async () => {
       const editor = await atom.workspace.open('coffee.coffee')
       await atom.packages.activatePackage('language-coffee-script')
       buffer = editor.buffer

--- a/src/coffeescript.js
+++ b/src/coffeescript.js
@@ -21,9 +21,9 @@ exports.getCachePath = function (sourceCode) {
 exports.compile = function (sourceCode, filePath) {
   if (!CoffeeScript) {
     var previousPrepareStackTrace = Error.prepareStackTrace
-    CoffeeScript = require('coffee-script')
+    CoffeeScript = require('coffeescript')
 
-    // When it loads, coffee-script reassigns Error.prepareStackTrace. We have
+    // When it loads, coffeescript reassigns Error.prepareStackTrace. We have
     // already reassigned it via the 'source-map-support' module, so we need
     // to set it back.
     Error.prepareStackTrace = previousPrepareStackTrace

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -17,7 +17,7 @@ var packageTranspilationRegistry = new PackageTranspilationRegistry()
 var COMPILERS = {
   '.js': packageTranspilationRegistry.wrapTranspiler(require('./babel')),
   '.ts': packageTranspilationRegistry.wrapTranspiler(require('./typescript')),
-  '.coffee': packageTranspilationRegistry.wrapTranspiler(require('./coffee-script'))
+  '.coffee': packageTranspilationRegistry.wrapTranspiler(require('./coffeescript'))
 }
 
 exports.addTranspilerConfigForPath = function (packagePath, packageName, packageMeta, config) {


### PR DESCRIPTION
CoffeeScript is switching from `coffee-script` to `coffeescript` as the primary module for various reasons.

Refs https://github.com/atom/atom/pull/13731#issuecomment-340002601

cc @nathansobo 
