### PR TITLE
Switch to fork of nsfw to fix symlink loops on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "electronVersion": "1.6.15",
   "dependencies": {
-    "@atom/nsfw": "^1.0.17",
+    "@atom/nsfw": "^1.0.18",
     "@atom/source-map-support": "^0.3.4",
     "async": "0.2.6",
     "atom-keymap": "8.2.8",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "electronVersion": "1.6.15",
   "dependencies": {
+    "@atom/nsfw": "^1.0.17",
     "@atom/source-map-support": "^0.3.4",
     "async": "0.2.6",
     "atom-keymap": "8.2.8",
@@ -53,7 +54,6 @@
     "mocha-multi-reporters": "^1.1.4",
     "mock-spawn": "^0.2.6",
     "normalize-package-data": "^2.0.0",
-    "nsfw": "^1.0.15",
     "nslog": "^3",
     "oniguruma": "6.2.1",
     "pathwatcher": "8.0.1",


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/15966

This PR switches to a new fork of `nsfw` that incorporates the changes made in https://github.com/Axosoft/nsfw/pull/41 to avoid endless loops when constructing watch trees for directories containing recursive symbolic links on Linux. We can switch back to the main `nsfw` if that PR gets merged.

/cc @ungb @Ben3eeE in case you want to test this out on projects recursive symbolic links in Linux. A good way to test would be to just add a recursive link inside the `atom/atom` repo.