### PR TITLE
Prevent the browser from auto-scrolling the scroll container on spacebar

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1616,11 +1616,23 @@ class TextEditorComponent {
     if (this.isInputEnabled()) {
       event.stopPropagation()
 
-      // WARNING: If we call preventDefault on the input of a space character,
-      // then the browser interprets the spacebar keypress as a page-down command,
-      // causing spaces to scroll elements containing editors. This is impossible
-      // to test.
-      if (event.data !== ' ') event.preventDefault()
+      // WARNING: If we call preventDefault on the input of a space
+      // character, then the browser interprets the spacebar keypress as a
+      // page-down command, causing spaces to scroll elements containing
+      // editors. This means typing space will actually change the contents
+      // of the hidden input, which will cause the browser to autoscroll the
+      // scroll container to reveal the input if it is off screen (See
+      // https://github.com/atom/atom/issues/16046). To correct for this
+      // situation, we automatically reset the scroll position to 0,0 after
+      // typing a space. None of this can really be tested.
+      if (event.data === ' ') {
+        window.setImmediate(() => {
+          this.refs.scrollContainer.scrollTop = 0
+          this.refs.scrollContainer.scrollLeft = 0
+        })
+      } else {
+        event.preventDefault()
+      }
 
       // If the input event is fired while the accented character menu is open it
       // means that the user has chosen one of the accented alternatives. Thus, we


### PR DESCRIPTION
Fixes #16046

When the user is typing in the editor, we prevent the insertion of all characters into the hidden input except spaces. If we prevent the default action of space insertion, then the spacebar is interpreted by the browser as a request by the user to page down, so we have to insert it. Unfortunately, if the input is off screen, inserting a space causes the browser to attempt to scroll it into view. Since we implement our own scrolling, this causes content to become hidden.

This PR forces the scrollTop and scrollLeft of the scroll container back to 0 after typing a space in the editor. Often this will do nothing, but sometimes it will correct for the browser's auto-scroll behavior which we didn't want in the first place.