### PR TITLE
Improve spec reporter

### DIFF
--- a/spec/menu-manager-spec.coffee
+++ b/spec/menu-manager-spec.coffee
@@ -6,6 +6,7 @@ describe "MenuManager", ->
 
   beforeEach ->
     menu = new MenuManager({keymapManager: atom.keymaps, packageManager: atom.packages})
+    spyOn(menu, 'sendToBrowserProcess') # Do not modify Atom's actual menus
     menu.initialize({resourcePath: atom.getLoadSettings().resourcePath})
 
   describe "::add(items)", ->
@@ -54,7 +55,6 @@ describe "MenuManager", ->
     afterEach -> Object.defineProperty process, 'platform', value: originalPlatform
 
     it "sends the current menu template and associated key bindings to the browser process", ->
-      spyOn(menu, 'sendToBrowserProcess')
       menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
       atom.keymaps.add 'test', 'atom-workspace': 'ctrl-b': 'b'
       menu.update()
@@ -66,7 +66,6 @@ describe "MenuManager", ->
     it "omits key bindings that are mapped to unset! in any context", ->
       # it would be nice to be smarter about omitting, but that would require a much
       # more dynamic interaction between the currently focused element and the menu
-      spyOn(menu, 'sendToBrowserProcess')
       menu.add [{label: "A", submenu: [{label: "B", command: "b"}]}]
       atom.keymaps.add 'test', 'atom-workspace': 'ctrl-b': 'b'
       atom.keymaps.add 'test', 'atom-text-editor': 'ctrl-b': 'unset!'
@@ -77,7 +76,6 @@ describe "MenuManager", ->
 
     it "omits key bindings that could conflict with AltGraph characters on macOS", ->
       Object.defineProperty process, 'platform', value: 'darwin'
-      spyOn(menu, 'sendToBrowserProcess')
       menu.add [{label: "A", submenu: [
         {label: "B", command: "b"},
         {label: "C", command: "c"}
@@ -98,7 +96,6 @@ describe "MenuManager", ->
 
     it "omits key bindings that could conflict with AltGraph characters on Windows", ->
       Object.defineProperty process, 'platform', value: 'win32'
-      spyOn(menu, 'sendToBrowserProcess')
       menu.add [{label: "A", submenu: [
         {label: "B", command: "b"},
         {label: "C", command: "c"}

--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -165,6 +165,7 @@ body {
     font-weight: bold;
     color: #d9534f;
     padding: 5px 0 5px 0;
+    white-space: pre-wrap;
   }
 
   .result-message.deprecation-message {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* Preserve whitespace in failure messages.  Prevents the following from happening:
![collapsed-whitespace](https://user-images.githubusercontent.com/2766036/32275841-05b651c4-bf0d-11e7-960d-9e7cb8effdbd.png)
* Do not modify menus.  Prevents Atom's menus from changing into just A -> B.

### Alternate Designs

I'm unsure whether to use `pre-wrap` or `pre`.  Since `pre-wrap` appears to be the more conservative option, I'm going to stick with that until there's a spec that is easier to read with `pre`.

### Why Should This Be In Core?

Take a wild guess.

### Benefits

Less frustration when running specs.

### Possible Drawbacks

N/A

### Applicable Issues

N/A