### PR TITLE
Don't terminate selection dragging when a modifier key is pressed

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -4428,11 +4428,14 @@ describe('TextEditorComponent', () => {
       const {component, editor} = buildComponent()
 
       let dragging = false
-      component.handleMouseDragUntilMouseUp({
-        didDrag: (event) => { dragging = true },
-        didStopDragging: () => { dragging = false }
-      })
+      function startDragging () {
+        component.handleMouseDragUntilMouseUp({
+          didDrag: (event) => { dragging = true },
+          didStopDragging: () => { dragging = false }
+        })
+      }
 
+      startDragging()
       window.dispatchEvent(new MouseEvent('mousemove'))
       await getNextAnimationFramePromise()
       expect(dragging).toBe(true)
@@ -4448,6 +4451,16 @@ describe('TextEditorComponent', () => {
       window.dispatchEvent(new MouseEvent('mousemove'))
       await getNextAnimationFramePromise()
       expect(dragging).toBe(false)
+
+      // Pressing a modifier key does not terminate dragging, (to ensure we can add new selections with the mouse)
+      startDragging()
+      window.dispatchEvent(new MouseEvent('mousemove'))
+      await getNextAnimationFramePromise()
+      expect(dragging).toBe(true)
+      component.didKeydown({key: 'Control'})
+      component.didKeydown({key: 'Alt'})
+      component.didKeydown({key: 'Meta'})
+      expect(dragging).toBe(true)
     })
 
     function getNextAnimationFramePromise () {

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1666,7 +1666,7 @@ class TextEditorComponent {
     // Stop dragging when user interacts with the keyboard. This prevents
     // unwanted selections in the case edits are performed while selecting text
     // at the same time.
-    if (this.stopDragging) this.stopDragging()
+    if (this.stopDragging && event.key !== 'Control' && event.key !== 'Alt' && event.key !== 'Meta') this.stopDragging()
 
     if (this.lastKeydownBeforeKeypress != null) {
       if (this.lastKeydownBeforeKeypress.code === event.code) {


### PR DESCRIPTION
Fixes #16059

This preserves the ability to add selections via ctrl- or cmd-click.

/cc @as-cii @Ben3eeE