### PR TITLE
Exclude Shift from keydown events that terminate selection drags

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -4459,6 +4459,7 @@ describe('TextEditorComponent', () => {
       expect(dragging).toBe(true)
       component.didKeydown({key: 'Control'})
       component.didKeydown({key: 'Alt'})
+      component.didKeydown({key: 'Shift'})
       component.didKeydown({key: 'Meta'})
       expect(dragging).toBe(true)
     })

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1665,8 +1665,11 @@ class TextEditorComponent {
   didKeydown (event) {
     // Stop dragging when user interacts with the keyboard. This prevents
     // unwanted selections in the case edits are performed while selecting text
-    // at the same time.
-    if (this.stopDragging && event.key !== 'Control' && event.key !== 'Alt' && event.key !== 'Meta') this.stopDragging()
+    // at the same time. Modifier keys are exempt to preserve the ability to
+    // add selections, shift-scroll horizontally while selecting.
+    if (this.stopDragging && event.key !== 'Control' && event.key !== 'Alt' && event.key !== 'Meta' && event.key !== 'Shift') {
+      this.stopDragging()
+    }
 
     if (this.lastKeydownBeforeKeypress != null) {
       if (this.lastKeydownBeforeKeypress.code === event.code) {


### PR DESCRIPTION
Fixes #16063

Follows up on #16060 by including `Shift` in the modifiers that are exempt from terminating a drag operation.

/cc @50Wliu @as-cii 