### PR TITLE
Actually require @atom/nsfw dependency in path-watcher.js

### DIFF
--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const path = require('path')
 
 const {Emitter, Disposable, CompositeDisposable} = require('event-kit')
-const nsfw = require('nsfw')
+const nsfw = require('@atom/nsfw')
 const {NativeWatcherRegistry} = require('./native-watcher-registry')
 
 // Private: Associate native watcher action flags with descriptive String equivalents.


### PR DESCRIPTION
Fixes #15966

In #16017, I upgraded the `nsfw` dependency to `@atom/nsfw` (a temporary fork), but unfortunately I forgot to change the `require` call to `@atom/nsfw` in `path-watcher.js` 🤦‍♂️ . This means the fix didn't actually go out and we must have been requiring some other version of `nsfw` somehow. Not sure which one 😬 .