### PR TITLE
Make notifications.clear public and emit event

### DIFF
--- a/spec/notification-manager-spec.js
+++ b/spec/notification-manager-spec.js
@@ -68,7 +68,7 @@ describe('NotificationManager', () => {
   })
 
   describe('clearing notifications', function () {
-    it('clears the notifications when ::clear has been called', function(){
+    it('clears the notifications when ::clear has been called', () => {
       manager.addSuccess('success')
       expect(manager.getNotifications().length).toBe(1)
       manager.clear()
@@ -76,16 +76,16 @@ describe('NotificationManager', () => {
     })
 
     describe('adding events', () => {
-      let addSpy
+      let clearSpy
 
       beforeEach(() => {
-        addSpy = jasmine.createSpy()
-        manager.onDidClearNotifications(addSpy)
+        clearSpy = jasmine.createSpy()
+        manager.onDidClearNotifications(clearSpy)
       })
 
       it('emits an event when the notifications have been cleared', () => {
         manager.clear()
-        expect(addSpy).toHaveBeenCalled()
+        expect(clearSpy).toHaveBeenCalled()
       })
     })
   })

--- a/spec/notification-manager-spec.js
+++ b/spec/notification-manager-spec.js
@@ -67,7 +67,7 @@ describe('NotificationManager', () => {
     })
   })
 
-  describe('clearing notifications', function () {
+  describe('clearing notifications', () => {
     it('clears the notifications when ::clear has been called', () => {
       manager.addSuccess('success')
       expect(manager.getNotifications().length).toBe(1)

--- a/spec/notification-manager-spec.js
+++ b/spec/notification-manager-spec.js
@@ -66,4 +66,27 @@ describe('NotificationManager', () => {
       expect(notification.getType()).toBe('success')
     })
   })
+
+  describe('clearing notifications', function () {
+    it('clears the notifications when ::clear has been called', function(){
+      manager.addSuccess('success')
+      expect(manager.getNotifications().length).toBe(1)
+      manager.clear()
+      expect(manager.getNotifications().length).toBe(0)
+    })
+
+    describe('adding events', () => {
+      let addSpy
+
+      beforeEach(() => {
+        addSpy = jasmine.createSpy()
+        manager.onDidClearNotifications(addSpy)
+      })
+
+      it('emits an event when the notifications have been cleared', () => {
+        manager.clear()
+        expect(addSpy).toHaveBeenCalled()
+      })
+    })
+  })
 })

--- a/src/notification-manager.js
+++ b/src/notification-manager.js
@@ -27,6 +27,15 @@ class NotificationManager {
     return this.emitter.on('did-add-notification', callback)
   }
 
+  // Public: Invoke the given callback after the notifications have been cleared.
+  //
+  // * `callback` {Function} to be called after the notifications are cleared.
+  //
+  // Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidClearNotifications (callback) {
+    return this.emitter.on('did-clear-notifications', callback)
+  }
+
   /*
   Section: Adding Notifications
   */

--- a/src/notification-manager.js
+++ b/src/notification-manager.js
@@ -199,8 +199,10 @@ class NotificationManager {
   /*
   Section: Managing Notifications
   */
-
+  
+  // Public: Clear all the notifications.
   clear () {
     this.notifications = []
+    this.emitter.emit('did-clear-notifications')
   }
 }

--- a/src/notification-manager.js
+++ b/src/notification-manager.js
@@ -208,7 +208,7 @@ class NotificationManager {
   /*
   Section: Managing Notifications
   */
-  
+
   // Public: Clear all the notifications.
   clear () {
     this.notifications = []


### PR DESCRIPTION
### Description of the Change

make `atom.notifications.clear()` public and emit a `did-clear-notifications` event

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

NotificationsManager would need to emit the event

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

### Benefits

Could let notifications packages know when to clear the notifications log

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

none

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

https://github.com/atom/notifications/pull/164#issuecomment-341341995

<!-- Enter any applicable Issues here -->
