### PR TITLE
Fix select-word command between word and non-word chararacters

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -2007,13 +2007,17 @@ describe('TextEditor', () => {
 
       describe('when the cursor is between two words', () => {
         it('selects the word the cursor is on', () => {
-          editor.setCursorScreenPosition([0, 4])
+          editor.setCursorBufferPosition([0, 4])
           editor.selectWordsContainingCursors()
           expect(editor.getSelectedText()).toBe('quicksort')
 
-          editor.setCursorScreenPosition([0, 3])
+          editor.setCursorBufferPosition([0, 3])
           editor.selectWordsContainingCursors()
           expect(editor.getSelectedText()).toBe('var')
+
+          editor.setCursorBufferPosition([1, 22])
+          editor.selectWordsContainingCursors()
+          expect(editor.getSelectedText()).toBe('items')
         })
       })
 

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -594,7 +594,7 @@ class Cursor extends Model {
   getCurrentWordBufferRange (options = {}) {
     const position = this.getBufferPosition()
     const ranges = this.editor.buffer.findAllInRangeSync(
-      options.wordRegex || this.wordRegExp(),
+      options.wordRegex || this.wordRegExp(options),
       new Range(new Point(position.row, 0), new Point(position.row, Infinity))
     )
     const range = ranges.find(range =>


### PR DESCRIPTION
In #15776, we accidentally stopped passing an option to the `Cursor.wordRegExp` method that caused us to prefer word characters when selecting words at a boundary between word and non-word characters.

This is only on master so glad we caught it before the next release.

/cc @maxbrunsfeld 
