### PR TITLE
Allow directory providers to implement a custom onDidChangeFiles

### DIFF
--- a/src/project.js
+++ b/src/project.js
@@ -338,13 +338,21 @@ class Project extends Model {
     }
 
     this.rootDirectories.push(directory)
-    this.watcherPromisesByPath[directory.getPath()] = watchPath(directory.getPath(), {}, events => {
+
+    const didChangeCallback = events => {
       // Stop event delivery immediately on removal of a rootDirectory, even if its watcher
       // promise has yet to resolve at the time of removal
       if (this.rootDirectories.includes(directory)) {
         this.emitter.emit('did-change-files', events)
       }
-    })
+    }
+    // We'll use the directory's custom onDidChangeFiles callback, if available.
+    // CustomDirectory::onDidChangeFiles should match the signature of
+    // Project::onDidChangeFiles below (although it may resolve asynchronously)
+    this.watcherPromisesByPath[directory.getPath()] =
+      directory.onDidChangeFiles != null
+        ? Promise.resolve(directory.onDidChangeFiles(didChangeCallback))
+        : watchPath(directory.getPath(), {}, didChangeCallback)
 
     for (let watchedPath in this.watcherPromisesByPath) {
       if (!this.rootDirectories.find(dir => dir.getPath() === watchedPath)) {


### PR DESCRIPTION
### Description of the Change

Atom has supported custom directory providers for quite a long time - the main use case being remote directories, e.g. in Nuclide (https://github.com/facebook/nuclide). The recent addition of file watchers causes several uncaught rejections when a remote directory is added, as it attempts to resolve remote URIs to create a file watcher.

To piggyback on the existing custom directory provider setup, we'll additionally allow custom directories to provide a `onDidChangeFiles` listener (with the same signature as `Project::onDidChangeFiles`) to override the default file watcher.

### Alternate Designs

Another possibility is to suppress file watching for non-local URIs, but this approach allows for greater extensibility as well as real remote file watching if we wanted it. This also opens the interesting option of having the default `Directory` class in `pathwatcher` implement `onDidChangeFiles`, allowing the file watching code to move out of this repo.

### Why Should This Be In Core?

There's no other way for a user-land package to override the file watching APIs.

### Benefits

Improved compatibility with custom directory providers (in particular remote directories).

### Possible Drawbacks

It's unclear how to better document this functionality. It seems that custom directory providers are generally underdocumented though?
