### PR TITLE
Autoscroll to cursor position after folding or unfolding

### DIFF
--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -3750,13 +3750,19 @@ class TextEditor {
   foldCurrentRow () {
     const {row} = this.getCursorBufferPosition()
     const range = this.tokenizedBuffer.getFoldableRangeContainingPoint(Point(row, Infinity))
-    if (range) return this.displayLayer.foldBufferRange(range)
+    if (range) {
+      const result = this.displayLayer.foldBufferRange(range)
+      this.scrollToCursorPosition()
+      return result
+    }
   }
 
   // Essential: Unfold the most recent cursor's row by one level.
   unfoldCurrentRow () {
     const {row} = this.getCursorBufferPosition()
-    return this.displayLayer.destroyFoldsContainingBufferPositions([Point(row, Infinity)], false)
+    const result = this.displayLayer.destroyFoldsContainingBufferPositions([Point(row, Infinity)], false)
+    this.scrollToCursorPosition()
+    return result
   }
 
   // Essential: Fold the given row in buffer coordinates based on its indentation
@@ -3774,6 +3780,7 @@ class TextEditor {
         const existingFolds = this.displayLayer.foldsIntersectingBufferRange(Range(foldableRange.start, foldableRange.start))
         if (existingFolds.length === 0) {
           this.displayLayer.foldBufferRange(foldableRange)
+          this.scrollToCursorPosition()
         } else {
           const firstExistingFoldRange = this.displayLayer.bufferRangeForFold(existingFolds[0])
           if (firstExistingFoldRange.start.isLessThan(position)) {
@@ -3791,7 +3798,9 @@ class TextEditor {
   // * `bufferRow` A {Number}
   unfoldBufferRow (bufferRow) {
     const position = Point(bufferRow, Infinity)
-    return this.displayLayer.destroyFoldsContainingBufferPositions([position])
+    const result = this.displayLayer.destroyFoldsContainingBufferPositions([position])
+    this.scrollToCursorPosition()
+    return result
   }
 
   // Extended: For each selection, fold the rows it intersects.
@@ -3807,6 +3816,7 @@ class TextEditor {
     for (let range of this.tokenizedBuffer.getFoldableRanges(this.getTabLength())) {
       this.displayLayer.foldBufferRange(range)
     }
+    this.scrollToCursorPosition()
   }
 
   // Extended: Unfold all existing folds.
@@ -3824,6 +3834,7 @@ class TextEditor {
     for (let range of this.tokenizedBuffer.getFoldableRangesAtIndentLevel(level, this.getTabLength())) {
       this.displayLayer.foldBufferRange(range)
     }
+    this.scrollToCursorPosition()
   }
 
   // Extended: Determine whether the given row in buffer coordinates is foldable.
@@ -3851,11 +3862,14 @@ class TextEditor {
   // Extended: Fold the given buffer row if it isn't currently folded, and unfold
   // it otherwise.
   toggleFoldAtBufferRow (bufferRow) {
+    let result
     if (this.isFoldedAtBufferRow(bufferRow)) {
-      return this.unfoldBufferRow(bufferRow)
+      result = this.unfoldBufferRow(bufferRow)
     } else {
-      return this.foldBufferRow(bufferRow)
+      result = this.foldBufferRow(bufferRow)
     }
+    this.scrollToCursorPosition()
+    return result
   }
 
   // Extended: Determine whether the most recently added cursor's row is folded.
@@ -3894,7 +3908,9 @@ class TextEditor {
   //
   // Returns the new {Fold}.
   foldBufferRowRange (startRow, endRow) {
-    return this.foldBufferRange(Range(Point(startRow, Infinity), Point(endRow, Infinity)))
+    const result = this.foldBufferRange(Range(Point(startRow, Infinity), Point(endRow, Infinity)))
+    this.scrollToCursorPosition()
+    return result
   }
 
   foldBufferRange (range) {


### PR DESCRIPTION
When folding or unfolding large blocks, it is possible to move the cursor off screen. Whenever this happens it is annoying and confusing, so this PR changes all code paths that create or destroy folds to autoscroll to the cursor position afterwards.

There were several different fold/unfold code paths, so I decided to weave simple autoscroll assertions into the existing tests.