### PR TITLE
Use wheelDelta instead of delta in the scroll handler

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -25,7 +25,7 @@ document.registerElement('text-editor-component-test-element', {
   })
 })
 
-fdescribe('TextEditorComponent', () => {
+describe('TextEditorComponent', () => {
   beforeEach(() => {
     jasmine.useRealClock()
 

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -25,7 +25,7 @@ document.registerElement('text-editor-component-test-element', {
   })
 })
 
-describe('TextEditorComponent', () => {
+fdescribe('TextEditorComponent', () => {
   beforeEach(() => {
     jasmine.useRealClock()
 
@@ -1325,7 +1325,7 @@ describe('TextEditorComponent', () => {
       {
         const expectedScrollTop = 20 * (scrollSensitivity / 100)
         const expectedScrollLeft = component.getScrollLeft()
-        component.didMouseWheel({deltaX: 5, deltaY: 20})
+        component.didMouseWheel({wheelDeltaX: -5, wheelDeltaY: -20})
         expect(component.getScrollTop()).toBe(expectedScrollTop)
         expect(component.getScrollLeft()).toBe(expectedScrollLeft)
         expect(component.refs.content.style.transform).toBe(`translate(${-expectedScrollLeft}px, ${-expectedScrollTop}px)`)
@@ -1334,7 +1334,7 @@ describe('TextEditorComponent', () => {
       {
         const expectedScrollTop = component.getScrollTop() - (10 * (scrollSensitivity / 100))
         const expectedScrollLeft = component.getScrollLeft()
-        component.didMouseWheel({deltaX: 5, deltaY: -10})
+        component.didMouseWheel({wheelDeltaX: -5, wheelDeltaY: 10})
         expect(component.getScrollTop()).toBe(expectedScrollTop)
         expect(component.getScrollLeft()).toBe(expectedScrollLeft)
         expect(component.refs.content.style.transform).toBe(`translate(${-expectedScrollLeft}px, ${-expectedScrollTop}px)`)
@@ -1343,7 +1343,7 @@ describe('TextEditorComponent', () => {
       {
         const expectedScrollTop = component.getScrollTop()
         const expectedScrollLeft = 20 * (scrollSensitivity / 100)
-        component.didMouseWheel({deltaX: 20, deltaY: -10})
+        component.didMouseWheel({wheelDeltaX: -20, wheelDeltaY: 10})
         expect(component.getScrollTop()).toBe(expectedScrollTop)
         expect(component.getScrollLeft()).toBe(expectedScrollLeft)
         expect(component.refs.content.style.transform).toBe(`translate(${-expectedScrollLeft}px, ${-expectedScrollTop}px)`)
@@ -1352,7 +1352,7 @@ describe('TextEditorComponent', () => {
       {
         const expectedScrollTop = component.getScrollTop()
         const expectedScrollLeft = component.getScrollLeft() - (10 * (scrollSensitivity / 100))
-        component.didMouseWheel({deltaX: -10, deltaY: 8})
+        component.didMouseWheel({wheelDeltaX: 10, wheelDeltaY: -8})
         expect(component.getScrollTop()).toBe(expectedScrollTop)
         expect(component.getScrollLeft()).toBe(expectedScrollLeft)
         expect(component.refs.content.style.transform).toBe(`translate(${-expectedScrollLeft}px, ${-expectedScrollTop}px)`)
@@ -1364,14 +1364,14 @@ describe('TextEditorComponent', () => {
       const {component, editor} = buildComponent({height: 50, width: 50, scrollSensitivity})
 
       {
-        component.didMouseWheel({deltaX: 0, deltaY: 3})
+        component.didMouseWheel({wheelDeltaX: 0, wheelDeltaY: -3})
         expect(component.getScrollTop()).toBe(1)
         expect(component.getScrollLeft()).toBe(0)
         expect(component.refs.content.style.transform).toBe(`translate(0px, -1px)`)
       }
 
       {
-        component.didMouseWheel({deltaX: 4, deltaY: 0})
+        component.didMouseWheel({wheelDeltaX: -4, wheelDeltaY: 0})
         expect(component.getScrollTop()).toBe(1)
         expect(component.getScrollLeft()).toBe(1)
         expect(component.refs.content.style.transform).toBe(`translate(-1px, -1px)`)
@@ -1379,14 +1379,14 @@ describe('TextEditorComponent', () => {
 
       editor.update({scrollSensitivity: 100})
       {
-        component.didMouseWheel({deltaX: 0, deltaY: -0.3})
+        component.didMouseWheel({wheelDeltaX: 0, wheelDeltaY: 0.3})
         expect(component.getScrollTop()).toBe(0)
         expect(component.getScrollLeft()).toBe(1)
         expect(component.refs.content.style.transform).toBe(`translate(-1px, 0px)`)
       }
 
       {
-        component.didMouseWheel({deltaX: -0.1, deltaY: 0})
+        component.didMouseWheel({wheelDeltaX: 0.1, wheelDeltaY: 0})
         expect(component.getScrollTop()).toBe(0)
         expect(component.getScrollLeft()).toBe(0)
         expect(component.refs.content.style.transform).toBe(`translate(0px, 0px)`)
@@ -1400,7 +1400,7 @@ describe('TextEditorComponent', () => {
       component.props.platform = 'linux'
       {
         const expectedScrollTop = 20 * (scrollSensitivity / 100)
-        component.didMouseWheel({deltaX: 0, deltaY: 20})
+        component.didMouseWheel({wheelDeltaX: 0, wheelDeltaY: -20})
         expect(component.getScrollTop()).toBe(expectedScrollTop)
         expect(component.refs.content.style.transform).toBe(`translate(0px, -${expectedScrollTop}px)`)
         await setScrollTop(component, 0)
@@ -1408,7 +1408,7 @@ describe('TextEditorComponent', () => {
 
       {
         const expectedScrollLeft = 20 * (scrollSensitivity / 100)
-        component.didMouseWheel({deltaX: 0, deltaY: 20, shiftKey: true})
+        component.didMouseWheel({wheelDeltaX: 0, wheelDeltaY: -20, shiftKey: true})
         expect(component.getScrollLeft()).toBe(expectedScrollLeft)
         expect(component.refs.content.style.transform).toBe(`translate(-${expectedScrollLeft}px, 0px)`)
         await setScrollLeft(component, 0)
@@ -1416,7 +1416,7 @@ describe('TextEditorComponent', () => {
 
       {
         const expectedScrollTop = 20 * (scrollSensitivity / 100)
-        component.didMouseWheel({deltaX: 20, deltaY: 0, shiftKey: true})
+        component.didMouseWheel({wheelDeltaX: -20, wheelDeltaY: 0, shiftKey: true})
         expect(component.getScrollTop()).toBe(expectedScrollTop)
         expect(component.refs.content.style.transform).toBe(`translate(0px, -${expectedScrollTop}px)`)
         await setScrollTop(component, 0)
@@ -1425,7 +1425,7 @@ describe('TextEditorComponent', () => {
       component.props.platform = 'win32'
       {
         const expectedScrollTop = 20 * (scrollSensitivity / 100)
-        component.didMouseWheel({deltaX: 0, deltaY: 20})
+        component.didMouseWheel({wheelDeltaX: 0, wheelDeltaY: -20})
         expect(component.getScrollTop()).toBe(expectedScrollTop)
         expect(component.refs.content.style.transform).toBe(`translate(0px, -${expectedScrollTop}px)`)
         await setScrollTop(component, 0)
@@ -1433,7 +1433,7 @@ describe('TextEditorComponent', () => {
 
       {
         const expectedScrollLeft = 20 * (scrollSensitivity / 100)
-        component.didMouseWheel({deltaX: 0, deltaY: 20, shiftKey: true})
+        component.didMouseWheel({wheelDeltaX: 0, wheelDeltaY: -20, shiftKey: true})
         expect(component.getScrollLeft()).toBe(expectedScrollLeft)
         expect(component.refs.content.style.transform).toBe(`translate(-${expectedScrollLeft}px, 0px)`)
         await setScrollLeft(component, 0)
@@ -1441,7 +1441,7 @@ describe('TextEditorComponent', () => {
 
       {
         const expectedScrollTop = 20 * (scrollSensitivity / 100)
-        component.didMouseWheel({deltaX: 20, deltaY: 0, shiftKey: true})
+        component.didMouseWheel({wheelDeltaX: -20, wheelDeltaY: 0, shiftKey: true})
         expect(component.getScrollTop()).toBe(expectedScrollTop)
         expect(component.refs.content.style.transform).toBe(`translate(0px, -${expectedScrollTop}px)`)
         await setScrollTop(component, 0)
@@ -1450,7 +1450,7 @@ describe('TextEditorComponent', () => {
       component.props.platform = 'darwin'
       {
         const expectedScrollTop = 20 * (scrollSensitivity / 100)
-        component.didMouseWheel({deltaX: 0, deltaY: 20})
+        component.didMouseWheel({wheelDeltaX: 0, wheelDeltaY: -20})
         expect(component.getScrollTop()).toBe(expectedScrollTop)
         expect(component.refs.content.style.transform).toBe(`translate(0px, -${expectedScrollTop}px)`)
         await setScrollTop(component, 0)
@@ -1458,7 +1458,7 @@ describe('TextEditorComponent', () => {
 
       {
         const expectedScrollTop = 20 * (scrollSensitivity / 100)
-        component.didMouseWheel({deltaX: 0, deltaY: 20, shiftKey: true})
+        component.didMouseWheel({wheelDeltaX: 0, wheelDeltaY: -20, shiftKey: true})
         expect(component.getScrollTop()).toBe(expectedScrollTop)
         expect(component.refs.content.style.transform).toBe(`translate(0px, -${expectedScrollTop}px)`)
         await setScrollTop(component, 0)
@@ -1466,7 +1466,7 @@ describe('TextEditorComponent', () => {
 
       {
         const expectedScrollLeft = 20 * (scrollSensitivity / 100)
-        component.didMouseWheel({deltaX: 20, deltaY: 0, shiftKey: true})
+        component.didMouseWheel({wheelDeltaX: -20, wheelDeltaY: 0, shiftKey: true})
         expect(component.getScrollLeft()).toBe(expectedScrollLeft)
         expect(component.refs.content.style.transform).toBe(`translate(-${expectedScrollLeft}px, 0px)`)
         await setScrollLeft(component, 0)

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1510,28 +1510,28 @@ class TextEditorComponent {
   didMouseWheel (event) {
     const scrollSensitivity = this.props.model.getScrollSensitivity() / 100
 
-    let {deltaX, deltaY} = event
+    let {wheelDeltaX, wheelDeltaY} = event
 
-    if (Math.abs(deltaX) > Math.abs(deltaY)) {
-      deltaX = (Math.sign(deltaX) === 1)
-        ? Math.max(1, deltaX * scrollSensitivity)
-        : Math.min(-1, deltaX * scrollSensitivity)
-      deltaY = 0
+    if (Math.abs(wheelDeltaX) > Math.abs(wheelDeltaY)) {
+      wheelDeltaX = (Math.sign(wheelDeltaX) === 1)
+        ? Math.max(1, wheelDeltaX * scrollSensitivity)
+        : Math.min(-1, wheelDeltaX * scrollSensitivity)
+      wheelDeltaY = 0
     } else {
-      deltaX = 0
-      deltaY = (Math.sign(deltaY) === 1)
-        ? Math.max(1, deltaY * scrollSensitivity)
-        : Math.min(-1, deltaY * scrollSensitivity)
+      wheelDeltaX = 0
+      wheelDeltaY = (Math.sign(wheelDeltaY) === 1)
+        ? Math.max(1, wheelDeltaY * scrollSensitivity)
+        : Math.min(-1, wheelDeltaY * scrollSensitivity)
     }
 
     if (this.getPlatform() !== 'darwin' && event.shiftKey) {
-      let temp = deltaX
-      deltaX = deltaY
-      deltaY = temp
+      let temp = wheelDeltaX
+      wheelDeltaX = wheelDeltaY
+      wheelDeltaY = temp
     }
 
-    const scrollLeftChanged = deltaX !== 0 && this.setScrollLeft(this.getScrollLeft() + deltaX)
-    const scrollTopChanged = deltaY !== 0 && this.setScrollTop(this.getScrollTop() + deltaY)
+    const scrollLeftChanged = wheelDeltaX !== 0 && this.setScrollLeft(this.getScrollLeft() - wheelDeltaX)
+    const scrollTopChanged = wheelDeltaY !== 0 && this.setScrollTop(this.getScrollTop() - wheelDeltaY)
 
     if (scrollLeftChanged || scrollTopChanged) this.updateSync()
   }


### PR DESCRIPTION
In Atom 1.19 we changed the scroll handler to use deltaX and deltaY instead of wheelDeltaX/wheelDeltaY. wheelDelta is larger so this caused the scrolling speed to slow down. This change in speed was especially noticeable on Linux.

Fixes https://github.com/atom/atom/issues/15567

# Test plan

* Scrolling on macOS with a mouse
  * [x]  Scroll in every direction
  * [x]  Scroll in every direction while holding shift
* Scrolling on macOS with a touchpad
  * [x]  Scroll in every direction
  * [x]  Scroll in every direction while holding shift
  * [x]  Slightly scroll down/up, ensuring that for small values of `wheelDeltaY * scrollSensitivity` we still honor the scrolling.
  * [x]  Slightly scroll left/right, ensuring that for small values of `wheelDeltaX * scrollSensitivity` we still honor the scrolling.
* Scrolling on Windows with a mouse
  * [x]  Scroll in every direction
  * [x]  Scroll in every direction while holding shift
* Scrolling on Windows with a touchpad
  * [ ]  Scroll in every direction
  * [ ]  Scroll in every direction while holding shift
  * [ ]  Slightly scroll down/up, ensuring that for small values of `wheelDeltaY * scrollSensitivity` we still honor the scrolling.
  * [ ]  Slightly scroll left/right, ensuring that for small values of `wheelDeltaX * scrollSensitivity` we still honor the scrolling.
* Scrolling on Linux with a mouse
  * [X] Scroll in every direction
  * [X]  Scroll in every direction while holding shift
* Scrolling on Linux with a touchpad
  * [x] Scroll in every direction
  * [x]  Scroll in every direction while holding shift
  * [x]  Slightly scroll down/up, ensuring that for small values of `wheelDeltaY * scrollSensitivity` we still honor the scrolling.
  * [x]  Slightly scroll left/right, ensuring that for small values of `wheelDeltaX * scrollSensitivity` we still honor the scrolling.


/cc: @nathansobo @as-cii 