### PR TITLE
Allow you to tab through modal text box

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -170,7 +170,7 @@ class TextEditorComponent {
     this.textDecorationBoundaries = []
     this.pendingScrollTopRow = this.props.initialScrollTopRow
     this.pendingScrollLeftColumn = this.props.initialScrollLeftColumn
-    this.tabIndex = this.props.element && this.props.element.tabIndex ? this.props.element.tabIndex : -1;
+    this.tabIndex = this.props.element && this.props.element.tabIndex ? this.props.element.tabIndex : -1
 
     this.measuredContent = false
     this.queryGuttersToRender()

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -170,6 +170,7 @@ class TextEditorComponent {
     this.textDecorationBoundaries = []
     this.pendingScrollTopRow = this.props.initialScrollTopRow
     this.pendingScrollLeftColumn = this.props.initialScrollLeftColumn
+    this.tabIndex = this.props.element && this.props.element.tabIndex ? this.props.element.tabIndex : -1;
 
     this.measuredContent = false
     this.queryGuttersToRender()
@@ -477,7 +478,7 @@ class TextEditorComponent {
         style,
         attributes,
         dataset,
-        tabIndex: -1,
+        tabIndex: this.tabIndex,
         on: {mousewheel: this.didMouseWheel}
       },
       $.div(
@@ -3586,7 +3587,7 @@ class CursorsAndInputComponent {
         compositionupdate: didCompositionUpdate,
         compositionend: didCompositionEnd
       },
-      tabIndex: -1,
+      tabIndex: this.tabIndex,
       style: {
         position: 'absolute',
         width: '1px',


### PR DESCRIPTION
### Description of the Change
We have a modal with elements (1) text box, (2) text box, (3) cancel button, and (4) clone button, respectively, from the top-left to the bottom-right.
<img width="608" alt="screen shot 2017-11-08 at 12 43 16 am" src="https://user-images.githubusercontent.com/6532060/32539885-c2282eba-c41f-11e7-841f-891925c8eb27.png">

For this modal element, the tabIndexes are -1, -1, 3, 4, respectively. This causes the tabbing order to be (1) > (3) > (4) or (2) > (3) > (4), and then looping forever between (3) and (4), because tabIndex=-1 signifies to skip tabbing for that element. It would appear the root cause is the tabIndex for those elements is hardcoded to be -1. We should probably change that.

Instead, allow a tabIndex to be inferred from the constructor. Now the modal has tabIndexes of 1, 2, 3, 4, as it was intended to be, from the atom github repo.

But now there is a new issue. We can only tab from (1) > (2), but never to (3) or (4). I have tried to understand why this is happening, but I can't come to a conclusion after playing around with the values, nor do I understand how to debug tabbing better than the trial and error approach I have now. Seems like something that's probably better for another ticket, because the tabIndexes are correct now.

### Alternate Designs
Maybe instead of inferring tabIndex from `this.props.element.tabIndex` in line 173, we should instead have some kind of explicit field to specify it, like `this.props.tabIndex`. I would not be opposed to that. Of course, then we need to do some more refactoring work to make tabIndex work for all objects that create this modal. It's a tradeoff between time investment and tech debt.

Also, I'm not sure if this would break other things. Seems like a pretty broad change.

### Why Should This Be In Core?
The core issue here is that the tabIndex is being overwritten in `text-editor-component.js` from a hardcoded value. Even if another package (in this case, the Github package) specifies a tabIndex, it will be squashed by what's hardcoded, and that seems wrong.

### Benefits
You can tab through your text boxes now.

### Possible Drawbacks
You can't tab through your buttons now. I think you also can't use the escape button to exit out of a modal, but you couldn't do that anyways unless the focus was on the "Cancel" button, so the problems are linked.

I think the tabbing thing is actually a separate issue, and this PR just solves the tabIndex being squashed by a hardcoded value.

### Applicable Issues
#16004 
