### PR TITLE
Fix errors when passing subword regex to native find methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "service-hub": "^0.7.4",
     "sinon": "1.17.4",
     "temp": "^0.8.3",
-    "text-buffer": "13.8.2",
+    "text-buffer": "13.8.3",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",
     "winreg": "^1.2.1",

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -1077,6 +1077,20 @@ describe('TextEditor', () => {
         expect(editor.getCursorBufferPosition()).toEqual([0, 1])
       })
 
+      it('stops at camelCase boundaries with non-ascii characters', () => {
+        editor.setText(' gétÁrevìôüsWord\n')
+        editor.setCursorBufferPosition([0, 16])
+
+        editor.moveToPreviousSubwordBoundary()
+        expect(editor.getCursorBufferPosition()).toEqual([0, 12])
+
+        editor.moveToPreviousSubwordBoundary()
+        expect(editor.getCursorBufferPosition()).toEqual([0, 4])
+
+        editor.moveToPreviousSubwordBoundary()
+        expect(editor.getCursorBufferPosition()).toEqual([0, 1])
+      })
+
       it('skips consecutive non-word characters', () => {
         editor.setText('e, => \n')
         editor.setCursorBufferPosition([0, 6])
@@ -1089,6 +1103,21 @@ describe('TextEditor', () => {
 
       it('skips consecutive uppercase characters', () => {
         editor.setText(' AAADF \n')
+        editor.setCursorBufferPosition([0, 7])
+        editor.moveToPreviousSubwordBoundary()
+        expect(editor.getCursorBufferPosition()).toEqual([0, 6])
+
+        editor.moveToPreviousSubwordBoundary()
+        expect(editor.getCursorBufferPosition()).toEqual([0, 1])
+
+        editor.setText('ALPhA\n')
+        editor.setCursorBufferPosition([0, 4])
+        editor.moveToPreviousSubwordBoundary()
+        expect(editor.getCursorBufferPosition()).toEqual([0, 2])
+      })
+
+      it('skips consecutive uppercase non-ascii letters', () => {
+        editor.setText(' ÀÁÅDF \n')
         editor.setCursorBufferPosition([0, 7])
         editor.moveToPreviousSubwordBoundary()
         expect(editor.getCursorBufferPosition()).toEqual([0, 6])

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -3321,13 +3321,13 @@ describe('TextEditor', () => {
           beforeEach(() => {
             editor.setSoftWrapped(true)
             editor.setEditorWidthInChars(80)
-            editor.setText(`\
-1
-2
-Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat.
-3
-4\
-`)
+            editor.setText(dedent `
+              1
+              2
+              Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi enim ad minim veniam, quis nostrud exerci tation ullamcorper suscipit lobortis nisl ut aliquip ex ea commodo consequat.
+              3
+              4
+            `)
           })
 
           it('moves the lines past the soft wrapped line', () => {
@@ -5881,21 +5881,20 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh 
 
       editor.duplicateLines()
 
-      expect(editor.getTextInBufferRange([[2, 0], [13, 5]])).toBe(`\
-\    if (items.length <= 1) return items;
-    if (items.length <= 1) return items;
-    var pivot = items.shift(), current, left = [], right = [];
-    while(items.length > 0) {
-      current = items.shift();
-      current < pivot ? left.push(current) : right.push(current);
-    }
-    var pivot = items.shift(), current, left = [], right = [];
-    while(items.length > 0) {
-      current = items.shift();
-      current < pivot ? left.push(current) : right.push(current);
-    }\
-`
-      )
+      expect(editor.getTextInBufferRange([[2, 0], [13, 5]])).toBe(dedent `
+        if (items.length <= 1) return items;
+        if (items.length <= 1) return items;
+        var pivot = items.shift(), current, left = [], right = [];
+        while(items.length > 0) {
+          current = items.shift();
+          current < pivot ? left.push(current) : right.push(current);
+        }
+        var pivot = items.shift(), current, left = [], right = [];
+        while(items.length > 0) {
+          current = items.shift();
+          current < pivot ? left.push(current) : right.push(current);
+        }\
+      `.split('\n').map(l => `    ${l}`).join('\n'))
       expect(editor.getSelectedBufferRanges()).toEqual([[[3, 5], [3, 5]], [[9, 0], [14, 0]]])
 
       // folds are also duplicated
@@ -5911,42 +5910,40 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh 
 
       editor.duplicateLines()
 
-      expect(editor.getTextInBufferRange([[2, 0], [11, 5]])).toBe(`\
-\    if (items.length <= 1) return items;
-    var pivot = items.shift(), current, left = [], right = [];
-    while(items.length > 0) {
-      current = items.shift();
-      current < pivot ? left.push(current) : right.push(current);
-    }
-    while(items.length > 0) {
-      current = items.shift();
-      current < pivot ? left.push(current) : right.push(current);
-    }\
-`
-      )
+      expect(editor.getTextInBufferRange([[2, 0], [11, 5]])).toBe(dedent`
+        if (items.length <= 1) return items;
+        var pivot = items.shift(), current, left = [], right = [];
+        while(items.length > 0) {
+          current = items.shift();
+          current < pivot ? left.push(current) : right.push(current);
+        }
+        while(items.length > 0) {
+          current = items.shift();
+          current < pivot ? left.push(current) : right.push(current);
+        }
+      `.split('\n').map(l => `    ${l}`).join('\n'))
       expect(editor.getSelectedBufferRange()).toEqual([[8, 0], [8, 0]])
     })
 
     it('can duplicate the last line of the buffer', () => {
       editor.setSelectedBufferRange([[11, 0], [12, 2]])
       editor.duplicateLines()
-      expect(editor.getTextInBufferRange([[11, 0], [14, 2]])).toBe(`\
-\  return sort(Array.apply(this, arguments));
-};
-  return sort(Array.apply(this, arguments));
-};\
-`
-      )
+      expect(editor.getTextInBufferRange([[11, 0], [14, 2]])).toBe('  ' + dedent `
+          return sort(Array.apply(this, arguments));
+        };
+          return sort(Array.apply(this, arguments));
+        };
+      `.trim())
       expect(editor.getSelectedBufferRange()).toEqual([[13, 0], [14, 2]])
     })
 
     it('only duplicates lines containing multiple selections once', () => {
-      editor.setText(`\
-aaaaaa
-bbbbbb
-cccccc
-dddddd\
-`)
+      editor.setText(dedent `
+        aaaaaa
+        bbbbbb
+        cccccc
+        dddddd
+      `)
       editor.setSelectedBufferRanges([
         [[0, 1], [0, 2]],
         [[0, 3], [0, 4]],
@@ -5955,15 +5952,15 @@ dddddd\
         [[3, 3], [3, 4]]
       ])
       editor.duplicateLines()
-      expect(editor.getText()).toBe(`\
-aaaaaa
-aaaaaa
-bbbbbb
-cccccc
-dddddd
-cccccc
-dddddd\
-`)
+      expect(editor.getText()).toBe(dedent `
+        aaaaaa
+        aaaaaa
+        bbbbbb
+        cccccc
+        dddddd
+        cccccc
+        dddddd
+      `)
       expect(editor.getSelectedBufferRanges()).toEqual([
         [[1, 1], [1, 2]],
         [[1, 3], [1, 4]],

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -454,23 +454,25 @@ class Cursor extends Model {
   getPreviousWordBoundaryBufferPosition (options = {}) {
     const currentBufferPosition = this.getBufferPosition()
     const previousNonBlankRow = this.editor.buffer.previousNonBlankRow(currentBufferPosition.row)
-    const scanRange = [[previousNonBlankRow || 0, 0], currentBufferPosition]
+    const scanRange = Range(Point(previousNonBlankRow || 0, 0), currentBufferPosition)
 
-    let beginningOfWordPosition
-    this.editor.backwardsScanInBufferRange(options.wordRegex || this.wordRegExp(), scanRange, ({range, stop}) => {
+    const ranges = this.editor.buffer.findAllInRangeSync(
+      options.wordRegex || this.wordRegExp(),
+      scanRange
+    )
+
+    const range = ranges[ranges.length - 1]
+    if (range) {
       if (range.start.row < currentBufferPosition.row && currentBufferPosition.column > 0) {
-        // force it to stop at the beginning of each line
-        beginningOfWordPosition = new Point(currentBufferPosition.row, 0)
-      } else if (range.end.isLessThan(currentBufferPosition)) {
-        beginningOfWordPosition = range.end
+        return Point(currentBufferPosition.row, 0)
+      } else if (currentBufferPosition.isGreaterThan(range.end)) {
+        return Point.fromObject(range.end)
       } else {
-        beginningOfWordPosition = range.start
+        return Point.fromObject(range.start)
       }
-
-      if (!beginningOfWordPosition.isEqual(currentBufferPosition)) stop()
-    })
-
-    return beginningOfWordPosition || currentBufferPosition
+    } else {
+      return currentBufferPosition
+    }
   }
 
   // Public: Returns buffer position of the next word boundary. It might be on
@@ -481,23 +483,24 @@ class Cursor extends Model {
   //      (default: {::wordRegExp})
   getNextWordBoundaryBufferPosition (options = {}) {
     const currentBufferPosition = this.getBufferPosition()
-    const scanRange = [currentBufferPosition, this.editor.getEofBufferPosition()]
+    const scanRange = Range(currentBufferPosition, this.editor.getEofBufferPosition())
 
-    let endOfWordPosition
-    this.editor.scanInBufferRange((options.wordRegex != null ? options.wordRegex : this.wordRegExp()), scanRange, function ({range, stop}) {
+    const range = this.editor.buffer.findInRangeSync(
+      options.wordRegex || this.wordRegExp(),
+      scanRange
+    )
+
+    if (range) {
       if (range.start.row > currentBufferPosition.row) {
-        // force it to stop at the beginning of each line
-        endOfWordPosition = new Point(range.start.row, 0)
-      } else if (range.start.isGreaterThan(currentBufferPosition)) {
-        endOfWordPosition = range.start
+        return Point(range.start.row, 0)
+      } else if (currentBufferPosition.isLessThan(range.start)) {
+        return Point.fromObject(range.start)
       } else {
-        endOfWordPosition = range.end
+        return Point.fromObject(range.end)
       }
-
-      if (!endOfWordPosition.isEqual(currentBufferPosition)) stop()
-    })
-
-    return endOfWordPosition || currentBufferPosition
+    } else {
+      return currentBufferPosition
+    }
   }
 
   // Public: Retrieves the buffer position of where the current word starts.


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/16126
Depends on https://github.com/atom/superstring/pull/43

I have also updated some subword movement methods on `TextEditor` to use `TextBuffer.findAllInRangeSync` instead of `scanInRange`, for consistency and so that the existing tests will now catch the errors you were seeing @t9md.