### PR TITLE
Fix handling of jQuery objects in `TooltipManager.add` method

### DIFF
--- a/spec/tooltip-manager-spec.js
+++ b/spec/tooltip-manager-spec.js
@@ -108,8 +108,12 @@ describe('TooltipManager', () => {
       const element2 = document.createElement('div')
       jasmine.attachToDOM(element2)
 
-      const fakeJqueryWrapper = [element, element2]
-      fakeJqueryWrapper.jquery = 'any-version'
+      const fakeJqueryWrapper = {
+        0: element,
+        1: element2,
+        length: 2,
+        jquery: 'any-version'
+      }
       const disposable = manager.add(fakeJqueryWrapper, {title: 'Title'})
 
       hover(element, () => expect(document.body.querySelector('.tooltip')).toHaveText('Title'))

--- a/src/tooltip-manager.js
+++ b/src/tooltip-manager.js
@@ -114,7 +114,9 @@ class TooltipManager {
   add (target, options) {
     if (target.jquery) {
       const disposable = new CompositeDisposable()
-      for (const element of target) { disposable.add(this.add(element, options)) }
+      for (let i = 0; i < target.length; i++) {
+        disposable.add(this.add(target[i], options))
+      }
       return disposable
     }
 


### PR DESCRIPTION
### Background

In #15972, I converted the `TooltipManager` class from CoffeeScript to JavaScript using [`decaffeinate`](https://github.com/decaffeinate/decaffeinate):

As part of that conversion (7b76ee3f2593e48ab86fca7e1c602332b4bc8cf7), this line of CoffeeScript:

https://github.com/atom/atom/blob/db960763cfceaaac6a17aaa100a7ea849faabeb6/src/tooltip-manager.coffee#L111

Became this line of JavaScript:

https://github.com/atom/atom/blob/7b76ee3f2593e48ab86fca7e1c602332b4bc8cf7/src/tooltip-manager.js#L127

That change led to the regression described in https://github.com/atom/atom/issues/16135.

A [`for...of` loop](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of) requires that the given object implement the [iterable protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#The_iterable_protocol). As @UziTech points out in https://github.com/atom/atom/issues/16135#issuecomment-342928215, jQuery objects gained support for the iterable protocol in jQuery 2.2.0, but earlier versions didn't support it. Since many Atom packages use space-pen for their views, and since [space-pen uses jQuery 2.1.4](https://github.com/atom/atom/issues/16135#issuecomment-342928215), the change in #15972 introduced a regression impacting those packages.

### Proposed solution

To address the regression, this PR does two things:

1. fb74992454f9cfa1027523a3448036e07fc67f20 enhances the existing test that exercises the handling of jQuery objects in `TooltipManager.add`. By using a fake jQuery object that [more closely matches a real jQuery object](https://github.com/atom/atom/issues/16135#issuecomment-342923149), the test fails with the same error seen in #16135: https://circleci.com/gh/atom/atom/6007
2. 0e82b8bb42ed9ca4a6a12497ffd0622fff0d45e8 replaces the `for...of` loop with a traditional `for` loop, and that fixes the test failure and resolves the bug.

### Proposed test plan

In addition to ensuring that the test suite is passing, I used the following steps to manually verify that this change fixes the bug:

- [x] Install the platform-ide-terminal package and verify that I can reproduce the bug in Atom beta 1.23 (https://github.com/platformio/platformio-atom-ide-terminal/issues/403)
- [x] With this branch checked out locally, open Atom in dev mode and verify that:
    - [x] I don't get the error seen in https://github.com/platformio/platformio-atom-ide-terminal/issues/403
    - [x] I can see the tooltips for the icons that platform-ide-terminal adds to the status bar

If there's any additional verification that would be helpful here, please let me know.

