### PR TITLE
Correct grammatical error

### DIFF
--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -8,7 +8,7 @@
 # You can create a new keybinding in this file by typing "key" and then hitting
 # tab.
 #
-# Here's an example taken from Atom's built-in keymap:
+# Examples taken from Atom's built-in keymap:
 #
 # 'atom-text-editor':
 #   'enter': 'editor:newline'

--- a/src/atom-environment.coffee
+++ b/src/atom-environment.coffee
@@ -563,6 +563,7 @@ class AtomEnvironment extends Model
   isMaximized: ->
     @applicationDelegate.isWindowMaximized()
 
+  # Extended: Maximize the current window.
   maximize: ->
     @applicationDelegate.maximizeWindow()
 


### PR DESCRIPTION
### Requirements

It is just a correcting grammar...

### Description of the Change
In 'atom/dot-atom/keymap.cson', there are more than one example.
There are 'atom-text-editor' and 'atom-workspace'.
But in line 11, it said "Here's _an example_ taken from Atom's built in keymap:".
So I changed it to "_Examples_ taken from Atom's built in keymap:"

### Why Should This Be In Core?
To correct grammar.
<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

### Benefits

Just correct grammar.
<!-- What benefits will be realized by the code change? -->
