### PR TITLE
Add .toString() method for Color objects

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -88,7 +88,7 @@ export default class Color {
   toJSON () {
     return this.alpha === 1 ? this.toHexString() : this.toRGBAString()
   }
-  
+
   toString () {
     return this.toRGBAString()
   }

--- a/src/color.js
+++ b/src/color.js
@@ -88,6 +88,10 @@ export default class Color {
   toJSON () {
     return this.alpha === 1 ? this.toHexString() : this.toRGBAString()
   }
+  
+  toString () {
+    return this.toRGBAString()
+  }
 
   isEqual (color) {
     if (this === color) {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Color had a lot of helpful `to*` methods, but it was missing arguably the most important one: `toString()`.  This fixes the Settings Panel from displaying `[object Object]` as the default value for a color:
![color-object-object-default-value](https://user-images.githubusercontent.com/2766036/32694736-d1c3d268-c747-11e7-9912-21432cb4119a.png)

### Alternate Designs

I chose to use `this.toRGBAString()` because the Windows color picker does not have a hex picker.  Alternate designs include creating a more human-readable presentation such as `Red: 255, Green: 255, Blue: 255, Alpha: 1` or using `this.toJSON()`, but then the default will be fairly useless for Windows users.  However, it would appear that Linux's default color picker only has hex input: https://github.com/atom/settings-view/issues/520.  Perhaps both should be used, such as `rgba(255, 255, 255, 1) (#FFFFFF)`?

### Why Should This Be In Core?

Color is an essential class and it makes sense for it to support `.toString()`.

### Benefits

More helpful string representation for Settings View.

### Possible Drawbacks

None.

### Applicable Issues

None.