### PR TITLE
Ensure app windows launch in the order we assert they do

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -352,11 +352,9 @@ describe('AtomApplication', function () {
 
       const atomApplication1 = buildAtomApplication()
       const app1Window1 = atomApplication1.launch(parseCommandLine([tempDirPath1]))
+      await emitterEventPromise(app1Window1, 'window:locations-opened')
       const app1Window2 = atomApplication1.launch(parseCommandLine([tempDirPath2]))
-      await Promise.all([
-        emitterEventPromise(app1Window1, 'window:locations-opened'),
-        emitterEventPromise(app1Window2, 'window:locations-opened')
-      ])
+      await emitterEventPromise(app1Window2, 'window:locations-opened')
 
       await Promise.all([
         app1Window1.prepareToUnload(),


### PR DESCRIPTION
If `app1Window2` finishes loading before `app1Window1`, the temporary directories will be serialized in the opposite order than the test is asserting. Await them one at a time, instead, to ensure that they launch in the correct order.

Fixes #16118.