### PR TITLE
Autoscroll after folding from keyboard, take 2

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -115,12 +115,12 @@ describe('TextEditor', () => {
       editor.update({showCursorOnSelection: false})
       editor.setSelectedBufferRange([[1, 2], [3, 4]])
       editor.addSelectionForBufferRange([[5, 6], [7, 8]], {reversed: true})
-      editor.foldBufferRow(4)
-      expect(editor.isFoldedAtBufferRow(4)).toBeTruthy()
       editor.setScrollTopRow(3)
       expect(editor.getScrollTopRow()).toBe(3)
       editor.setScrollLeftColumn(4)
       expect(editor.getScrollLeftColumn()).toBe(4)
+      editor.foldBufferRow(4)
+      expect(editor.isFoldedAtBufferRow(4)).toBeTruthy()
 
       const editor2 = editor.copy()
       const element2 = editor2.getElement()
@@ -7028,19 +7028,15 @@ describe('TextEditor', () => {
     })
 
     describe('.unfoldAll()', () => {
-      it('unfolds every folded line and autoscrolls', async () => {
+      it('unfolds every folded line', async () => {
         editor = await atom.workspace.open('sample.js', {autoIndent: false})
-        const autoscrollEvents = []
-        editor.onDidRequestAutoscroll(event => autoscrollEvents.push(event))
 
         const initialScreenLineCount = editor.getScreenLineCount()
         editor.foldBufferRow(0)
         editor.foldBufferRow(1)
         expect(editor.getScreenLineCount()).toBeLessThan(initialScreenLineCount)
-        expect(autoscrollEvents.length).toBe(1)
         editor.unfoldAll()
         expect(editor.getScreenLineCount()).toBe(initialScreenLineCount)
-        expect(autoscrollEvents.length).toBe(2)
       })
 
       it('unfolds every folded line with comments', async () => {
@@ -7058,11 +7054,8 @@ describe('TextEditor', () => {
     describe('.foldAll()', () => {
       it('folds every foldable line', async () => {
         editor = await atom.workspace.open('sample.js', {autoIndent: false})
-        const autoscrollEvents = []
-        editor.onDidRequestAutoscroll(event => autoscrollEvents.push(event))
 
         editor.foldAll()
-        expect(autoscrollEvents.length).toBe(1)
         const [fold1, fold2, fold3] = editor.unfoldAll()
         expect([fold1.start.row, fold1.end.row]).toEqual([0, 12])
         expect([fold2.start.row, fold2.end.row]).toEqual([1, 9])
@@ -7093,11 +7086,7 @@ describe('TextEditor', () => {
 
       describe('when bufferRow can be folded', () => {
         it('creates a fold based on the syntactic region starting at the given row', () => {
-          const autoscrollEvents = []
-          editor.onDidRequestAutoscroll(event => autoscrollEvents.push(event))
-
           editor.foldBufferRow(1)
-          expect(autoscrollEvents.length).toBe(1)
           const [fold] = editor.unfoldAll()
           expect([fold.start.row, fold.end.row]).toEqual([1, 9])
         })
@@ -7144,14 +7133,10 @@ describe('TextEditor', () => {
     describe('.foldCurrentRow()', () => {
       it('creates a fold at the location of the last cursor', async () => {
         editor = await atom.workspace.open()
-
         editor.setText('\nif (x) {\n  y()\n}')
         editor.setCursorBufferPosition([1, 0])
         expect(editor.getScreenLineCount()).toBe(4)
-        const autoscrollEvents = []
-        editor.onDidRequestAutoscroll(event => autoscrollEvents.push(event))
         editor.foldCurrentRow()
-        expect(autoscrollEvents.length).toBe(1)
         expect(editor.getScreenLineCount()).toBe(3)
       })
 
@@ -7168,26 +7153,21 @@ describe('TextEditor', () => {
     describe('.foldAllAtIndentLevel(indentLevel)', () => {
       it('folds blocks of text at the given indentation level', async () => {
         editor = await atom.workspace.open('sample.js', {autoIndent: false})
-        const autoscrollEvents = []
-        editor.onDidRequestAutoscroll(event => autoscrollEvents.push(event))
 
         editor.foldAllAtIndentLevel(0)
         expect(editor.lineTextForScreenRow(0)).toBe(`var quicksort = function () {${editor.displayLayer.foldCharacter}`)
         expect(editor.getLastScreenRow()).toBe(0)
-        expect(autoscrollEvents.length).toBe(1)
 
         editor.foldAllAtIndentLevel(1)
         expect(editor.lineTextForScreenRow(0)).toBe('var quicksort = function () {')
         expect(editor.lineTextForScreenRow(1)).toBe(`  var sort = function(items) {${editor.displayLayer.foldCharacter}`)
         expect(editor.getLastScreenRow()).toBe(4)
-        expect(autoscrollEvents.length).toBe(2)
 
         editor.foldAllAtIndentLevel(2)
         expect(editor.lineTextForScreenRow(0)).toBe('var quicksort = function () {')
         expect(editor.lineTextForScreenRow(1)).toBe('  var sort = function(items) {')
         expect(editor.lineTextForScreenRow(2)).toBe('    if (items.length <= 1) return items;')
         expect(editor.getLastScreenRow()).toBe(9)
-        expect(autoscrollEvents.length).toBe(3)
       })
 
       it('folds every foldable range at a given indentLevel', async () => {

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -219,18 +219,40 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
       'editor:toggle-soft-wrap': -> @toggleSoftWrapped()
       'editor:fold-all': -> @foldAll()
       'editor:unfold-all': -> @unfoldAll()
-      'editor:fold-current-row': -> @foldCurrentRow()
-      'editor:unfold-current-row': -> @unfoldCurrentRow()
+      'editor:fold-current-row': ->
+        @foldCurrentRow()
+        @scrollToCursorPosition()
+      'editor:unfold-current-row': ->
+        @unfoldCurrentRow()
+        @scrollToCursorPosition()
       'editor:fold-selection': -> @foldSelectedLines()
-      'editor:fold-at-indent-level-1': -> @foldAllAtIndentLevel(0)
-      'editor:fold-at-indent-level-2': -> @foldAllAtIndentLevel(1)
-      'editor:fold-at-indent-level-3': -> @foldAllAtIndentLevel(2)
-      'editor:fold-at-indent-level-4': -> @foldAllAtIndentLevel(3)
-      'editor:fold-at-indent-level-5': -> @foldAllAtIndentLevel(4)
-      'editor:fold-at-indent-level-6': -> @foldAllAtIndentLevel(5)
-      'editor:fold-at-indent-level-7': -> @foldAllAtIndentLevel(6)
-      'editor:fold-at-indent-level-8': -> @foldAllAtIndentLevel(7)
-      'editor:fold-at-indent-level-9': -> @foldAllAtIndentLevel(8)
+      'editor:fold-at-indent-level-1': ->
+        @foldAllAtIndentLevel(0)
+        @scrollToCursorPosition()
+      'editor:fold-at-indent-level-2': ->
+        @foldAllAtIndentLevel(1)
+        @scrollToCursorPosition()
+      'editor:fold-at-indent-level-3': ->
+        @foldAllAtIndentLevel(2)
+        @scrollToCursorPosition()
+      'editor:fold-at-indent-level-4': ->
+        @foldAllAtIndentLevel(3)
+        @scrollToCursorPosition()
+      'editor:fold-at-indent-level-5': ->
+        @foldAllAtIndentLevel(4)
+        @scrollToCursorPosition()
+      'editor:fold-at-indent-level-6': ->
+        @foldAllAtIndentLevel(5)
+        @scrollToCursorPosition()
+      'editor:fold-at-indent-level-7': ->
+        @foldAllAtIndentLevel(6)
+        @scrollToCursorPosition()
+      'editor:fold-at-indent-level-8': ->
+        @foldAllAtIndentLevel(7)
+        @scrollToCursorPosition()
+      'editor:fold-at-indent-level-9': ->
+        @foldAllAtIndentLevel(8)
+        @scrollToCursorPosition()
       'editor:log-cursor-scope': -> showCursorScope(@getCursorScope(), notificationManager)
       'editor:copy-path': -> copyPathToClipboard(this, project, clipboard, false)
       'editor:copy-project-path': -> copyPathToClipboard(this, project, clipboard, true)

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -3750,19 +3750,13 @@ class TextEditor {
   foldCurrentRow () {
     const {row} = this.getCursorBufferPosition()
     const range = this.tokenizedBuffer.getFoldableRangeContainingPoint(Point(row, Infinity))
-    if (range) {
-      const result = this.displayLayer.foldBufferRange(range)
-      this.scrollToCursorPosition()
-      return result
-    }
+    if (range) return this.displayLayer.foldBufferRange(range)
   }
 
   // Essential: Unfold the most recent cursor's row by one level.
   unfoldCurrentRow () {
     const {row} = this.getCursorBufferPosition()
-    const result = this.displayLayer.destroyFoldsContainingBufferPositions([Point(row, Infinity)], false)
-    this.scrollToCursorPosition()
-    return result
+    return this.displayLayer.destroyFoldsContainingBufferPositions([Point(row, Infinity)], false)
   }
 
   // Essential: Fold the given row in buffer coordinates based on its indentation
@@ -3780,7 +3774,6 @@ class TextEditor {
         const existingFolds = this.displayLayer.foldsIntersectingBufferRange(Range(foldableRange.start, foldableRange.start))
         if (existingFolds.length === 0) {
           this.displayLayer.foldBufferRange(foldableRange)
-          this.scrollToCursorPosition()
         } else {
           const firstExistingFoldRange = this.displayLayer.bufferRangeForFold(existingFolds[0])
           if (firstExistingFoldRange.start.isLessThan(position)) {
@@ -3798,9 +3791,7 @@ class TextEditor {
   // * `bufferRow` A {Number}
   unfoldBufferRow (bufferRow) {
     const position = Point(bufferRow, Infinity)
-    const result = this.displayLayer.destroyFoldsContainingBufferPositions([position])
-    this.scrollToCursorPosition()
-    return result
+    return this.displayLayer.destroyFoldsContainingBufferPositions([position])
   }
 
   // Extended: For each selection, fold the rows it intersects.
@@ -3816,7 +3807,6 @@ class TextEditor {
     for (let range of this.tokenizedBuffer.getFoldableRanges(this.getTabLength())) {
       this.displayLayer.foldBufferRange(range)
     }
-    this.scrollToCursorPosition()
   }
 
   // Extended: Unfold all existing folds.
@@ -3834,7 +3824,6 @@ class TextEditor {
     for (let range of this.tokenizedBuffer.getFoldableRangesAtIndentLevel(level, this.getTabLength())) {
       this.displayLayer.foldBufferRange(range)
     }
-    this.scrollToCursorPosition()
   }
 
   // Extended: Determine whether the given row in buffer coordinates is foldable.
@@ -3862,14 +3851,11 @@ class TextEditor {
   // Extended: Fold the given buffer row if it isn't currently folded, and unfold
   // it otherwise.
   toggleFoldAtBufferRow (bufferRow) {
-    let result
     if (this.isFoldedAtBufferRow(bufferRow)) {
-      result = this.unfoldBufferRow(bufferRow)
+      return this.unfoldBufferRow(bufferRow)
     } else {
-      result = this.foldBufferRow(bufferRow)
+      return this.foldBufferRow(bufferRow)
     }
-    this.scrollToCursorPosition()
-    return result
   }
 
   // Extended: Determine whether the most recently added cursor's row is folded.
@@ -3908,9 +3894,7 @@ class TextEditor {
   //
   // Returns the new {Fold}.
   foldBufferRowRange (startRow, endRow) {
-    const result = this.foldBufferRange(Range(Point(startRow, Infinity), Point(endRow, Infinity)))
-    this.scrollToCursorPosition()
-    return result
+    return this.foldBufferRange(Range(Point(startRow, Infinity), Point(endRow, Infinity)))
   }
 
   foldBufferRange (range) {


### PR DESCRIPTION
This PR reverts a previous attempt in #16092 which was a bit too aggressive. It auto-scrolled at the model level after various folds. This PR tries a more conservative approach that simply auto-scrolls after fold *commands*. Auto-scrolling seems most intuitive when executed from the keyboard via a command.

Thanks @maxbrunsfeld for the early feedback. 💯 