### PR TITLE
Change HTTP Links to HTTPS in /docs/build-instructions/

### DIFF
--- a/docs/build-instructions/linux.md
+++ b/docs/build-instructions/linux.md
@@ -1,1 +1,1 @@
-See the [Hacking on Atom Core](http://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/#platform-linux) section in the [Atom Flight Manual](http://flight-manual.atom.io).
+See the [Hacking on Atom Core](https://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/#platform-linux) section in the [Atom Flight Manual](https://flight-manual.atom.io).

--- a/docs/build-instructions/macOS.md
+++ b/docs/build-instructions/macOS.md
@@ -1,1 +1,1 @@
-See the [Hacking on Atom Core](http://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/#platform-mac) section in the [Atom Flight Manual](http://flight-manual.atom.io).
+See the [Hacking on Atom Core](https://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/#platform-mac) section in the [Atom Flight Manual](https://flight-manual.atom.io).

--- a/docs/build-instructions/windows.md
+++ b/docs/build-instructions/windows.md
@@ -1,1 +1,1 @@
-See the [Hacking on Atom Core](http://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/#platform-windows) section in the [Atom Flight Manual](http://flight-manual.atom.io).
+See the [Hacking on Atom Core](https://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/#platform-windows) section in the [Atom Flight Manual](https://flight-manual.atom.io).


### PR DESCRIPTION
### Description of the Change
Change HTTP links to HTTPS in /docs/build-instructions/ since the linked-to sites support SSL/TLS
### Alternate Designs
The alternative would be leaving the links as HTTP ones. This leaves users less secure while having only marginal userexperience benefits.
### Why Should This Be In Core?
The documentation changed is in Core.
### Benefits
Makes user interaction more secure by default.
### Possible Drawbacks
Marginal potential for devices not supporting SSL/TLS and marginal performance hits when accessing the links.
### Applicable Issues
Similar to issue #16167 and PR #16173