### PR TITLE
Enable default editor keymaps for editors located outside atom-workspace

### DIFF
--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -87,7 +87,7 @@
   'alt-8': 'pane:show-item-8'
   'alt-9': 'pane:show-item-9'
 
-'atom-workspace atom-text-editor':
+'atom-text-editor':
   # Platform Bindings
   'ctrl-left': 'editor:move-to-beginning-of-word'
   'ctrl-right': 'editor:move-to-end-of-word'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -92,7 +92,7 @@
   'alt-8': 'pane:show-item-8'
   'alt-9': 'pane:show-item-9'
 
-'atom-workspace atom-text-editor':
+'atom-text-editor':
   # Platform Bindings
   'ctrl-left': 'editor:move-to-beginning-of-word'
   'ctrl-right': 'editor:move-to-end-of-word'


### PR DESCRIPTION
Fixes https://github.com/atom/teletype/issues/208

This is similar to what we do for macOS keymaps: 

https://github.com/atom/atom/blob/6cbc9988ecf935ab3905700a68bf3ce4f854cb3b/keymaps/darwin.cson#L108-L163

And would fix an issue teletype users are noticing when using editor commands in the popover. Since the popover is located outside the workspace (i.e. because it is a tooltip), keyboard shortcuts are not working for Linux and Windows users. I assume this is an issue with every package that attempts to use an editor outside the `atom-workspace` element.

@atom/maintainers: what do you think?

/cc: @AlexWayfer, who originally reported the issue on atom/teletype.