### PR TITLE
Ensure style updates take effect after the editor is re-attached

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -442,6 +442,18 @@ describe('TextEditorComponent', () => {
         expect(component.getScrollContainerClientHeight()).toBe(100 - 10)
         expect(component.getScrollContainerClientWidth()).toBe(100 - component.getGutterContainerWidth() - 10)
 
+        // Ensure style updates take effect after the editor is re-attached.
+        element.remove()
+        style.textContent = '::-webkit-scrollbar { height: 20px; width: 20px; }'
+        TextEditor.didUpdateScrollbarStyles()
+        jasmine.attachToDOM(element)
+        expect(component.refs.horizontalScrollbar.element.style.right).toBe('20px')
+        expect(component.refs.verticalScrollbar.element.style.bottom).toBe('20px')
+        expect(component.refs.horizontalScrollbar.element.scrollLeft).toBe(10)
+        expect(component.refs.verticalScrollbar.element.scrollTop).toBe(20)
+        expect(component.getScrollContainerClientHeight()).toBe(100 - 20)
+        expect(component.getScrollContainerClientWidth()).toBe(100 - component.getGutterContainerWidth() - 20)
+
         // Ensure we don't throw an error trying to remeasure non-existent scrollbars for mini editors.
         await editor.update({mini: true})
         TextEditor.didUpdateScrollbarStyles()
@@ -4059,6 +4071,18 @@ describe('TextEditorComponent', () => {
       expect(editor.getHalfWidthCharWidth()).toBeGreaterThan(initialHalfCharacterWidth)
       expect(editor.getKoreanCharWidth()).toBeGreaterThan(initialKoreanCharacterWidth)
       expect(queryOnScreenLineElements(element).length).toBeLessThan(initialRenderedLineCount)
+      verifyCursorPosition(component, cursorNode, 1, 29)
+
+      // Ensure style updates take effect after the editor is re-attached.
+      element.remove()
+      element.style.fontSize = initialFontSize - 5 + 'px'
+      TextEditor.didUpdateStyles()
+      jasmine.attachToDOM(element)
+      expect(editor.getDefaultCharWidth()).toBeLessThan(initialBaseCharacterWidth)
+      expect(editor.getDoubleWidthCharWidth()).toBeLessThan(initialDoubleCharacterWidth)
+      expect(editor.getHalfWidthCharWidth()).toBeLessThan(initialHalfCharacterWidth)
+      expect(editor.getKoreanCharWidth()).toBeLessThan(initialKoreanCharacterWidth)
+      expect(queryOnScreenLineElements(element).length).toBeGreaterThan(initialRenderedLineCount)
       verifyCursorPosition(component, cursorNode, 1, 29)
     })
 

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -37,6 +37,9 @@ class TextEditorComponent {
   }
 
   static didUpdateStyles () {
+    if (this.stylesUpdateCount == null) this.stylesUpdateCount = 0
+    this.stylesUpdateCount++
+
     if (this.attachedComponents) {
       this.attachedComponents.forEach((component) => {
         component.didUpdateStyles()
@@ -45,6 +48,9 @@ class TextEditorComponent {
   }
 
   static didUpdateScrollbarStyles () {
+    if (this.scrollbarStylesUpdateCount == null) this.scrollbarStylesUpdateCount = 0
+    this.scrollbarStylesUpdateCount++
+
     if (this.attachedComponents) {
       this.attachedComponents.forEach((component) => {
         component.didUpdateScrollbarStyles()
@@ -70,6 +76,8 @@ class TextEditorComponent {
     this.virtualNode = $('atom-text-editor')
     this.virtualNode.domNode = this.element
     this.refs = {}
+    this.stylesUpdateCount = this.constructor.stylesUpdateCount || 0
+    this.scrollbarStylesUpdateCount = this.constructor.scrollbarStylesUpdateCount || 0
 
     this.updateSync = this.updateSync.bind(this)
     this.didBlurHiddenInput = this.didBlurHiddenInput.bind(this)
@@ -1406,6 +1414,13 @@ class TextEditorComponent {
 
       this.overlayComponents.forEach((component) => component.didAttach())
 
+      if (this.stylesUpdateCount < this.constructor.stylesUpdateCount) {
+        this.didUpdateStyles()
+      }
+      if (this.scrollbarStylesUpdateCount < this.constructor.scrollbarStylesUpdateCount) {
+        this.didUpdateScrollbarStyles()
+      }
+
       if (this.isVisible()) {
         this.didShow()
 
@@ -1577,12 +1592,14 @@ class TextEditorComponent {
   }
 
   didUpdateStyles () {
+    this.stylesUpdateCount = this.constructor.stylesUpdateCount
     this.remeasureCharacterDimensions = true
     this.horizontalPixelPositionsByScreenLineId.clear()
     this.scheduleUpdate()
   }
 
   didUpdateScrollbarStyles () {
+    this.scrollbarStylesUpdateCount = this.constructor.scrollbarStylesUpdateCount
     if (!this.props.model.isMini()) {
       this.remeasureScrollbars = true
       this.scheduleUpdate()


### PR DESCRIPTION
Refs: https://github.com/atom/teletype/issues/174
Refs: https://github.com/atom/teletype/pull/185

Previously, performing a style change while an editor was detached would cause the editor component to not observe the change. Thus, if the editor was later re-attached, it would use potentially incorrect measurements to position lines, cursors, etc.

With this pull-request we will now keep track of a global counter of how many times the styles have changed. Also, each editor component will have its own local counter tracking how many style changes it has observed. If on re-attach the global counter is different from the local counter, it means that the editor component is using stale measurements and, as such, needs to clear them out and re-measure.

/cc: @nathansobo 