### PR TITLE
Modernize built-in TypeScript transpiler to support JSX (React) files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "sinon": "1.17.4",
     "temp": "^0.8.3",
     "text-buffer": "13.8.6",
-    "typescript-simple": "1.0.0",
+    "typescript-simple": "^8.0.5",
     "underscore-plus": "^1.6.6",
     "winreg": "^1.2.1",
     "yargs": "^3.23.0"

--- a/spec/fixtures/typescript/foo.tsx
+++ b/spec/fixtures/typescript/foo.tsx
@@ -1,0 +1,3 @@
+export default function Foo (props) {
+  return <div>foo</div>
+}

--- a/spec/typescript-spec.coffee
+++ b/spec/typescript-spec.coffee
@@ -1,4 +1,4 @@
-fdescribe "TypeScript transpiler support", ->
+describe "TypeScript transpiler support", ->
   describe "when there is a .ts file", ->
     it "transpiles it using typescript", ->
       transpiled = require('./fixtures/typescript/valid.ts')

--- a/spec/typescript-spec.coffee
+++ b/spec/typescript-spec.coffee
@@ -1,4 +1,4 @@
-describe "TypeScript transpiler support", ->
+fdescribe "TypeScript transpiler support", ->
   describe "when there is a .ts file", ->
     it "transpiles it using typescript", ->
       transpiled = require('./fixtures/typescript/valid.ts')
@@ -7,3 +7,8 @@ describe "TypeScript transpiler support", ->
   describe "when the .ts file is invalid", ->
     it "does not transpile", ->
       expect(-> require('./fixtures/typescript/invalid.ts')).toThrow()
+
+  describe "when there is a .tsx file", ->
+    it "transpiles it using typescript and react", ->
+      transpiled = require('./fixtures/typescript/foo.tsx').default
+      expect(transpiled.toString()).toContain('React.createElement')

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -17,6 +17,7 @@ var packageTranspilationRegistry = new PackageTranspilationRegistry()
 var COMPILERS = {
   '.js': packageTranspilationRegistry.wrapTranspiler(require('./babel')),
   '.ts': packageTranspilationRegistry.wrapTranspiler(require('./typescript')),
+  '.tsx': packageTranspilationRegistry.wrapTranspiler(require('./typescript')),
   '.coffee': packageTranspilationRegistry.wrapTranspiler(require('./coffee-script'))
 }
 

--- a/src/typescript.js
+++ b/src/typescript.js
@@ -5,9 +5,10 @@ var crypto = require('crypto')
 var path = require('path')
 
 var defaultOptions = {
-  target: 1,
+  target: 1, // ES3 = 0, ES5 = 1, ES2015 = 2, ES2016 = 3, ES2017 = 4, ...
   module: 'commonjs',
-  sourceMap: true
+  sourceMap: true,
+  jsx: 2 // None = 0, Preserve = 1, React = 2, ReactNative = 3
 }
 
 var TypeScriptSimple = null


### PR DESCRIPTION
### Description of the Change
This PR upgrades `typescript-simple` to the latest version to make it possible for package developers to use TypeScript + JSX (React) transpilation.

JSX support was added in TypeScript 1.6, but our version of `typescript-simple` bundles TypeScript 1.4. The proposed change will give us TypeScript 2.6, which is the latest and greatest.

### Alternate Designs
As I see it right now, there are two alternatives approaches;
1. Update `typescript-simple` to a version that bundles TypeScript 1.6, to minimize the risk of breaking changes affecting packages, etc.
2. Find another, more scalable solution for allowing packages with custom transpilers, or Atom Core, to add additional extensions to `require.extensions`.

Note that we could technically speaking also just add the `.tsx` mapping using the current version of TypeScript, but it will never work unless the package actually uses a custom transpiler with a more modern TypeScript. I think this is a bad idea since it would mean shipping something that doesn't work.

### Why Should This Be In Core?

Even though we now have custom transpiler support on package-level, this functionality is still heavily reliant upon us monkey patching `require.extensions` in [`compile-cache.js`](https://github.com/atom/atom/blob/6cbc9988ecf935ab3905700a68bf3ce4f854cb3b/src/compile-cache.js#L226-L237). Therefore, if a package developer wants to use JSX in TypeScript, it will not currently work since we are not mapping the `.tsx` extension to any transpiler. It is technically possible to work around this limitation by explicitly specifying the `.tsx` when requiring JSX components from a TypeScript module, but this causes TypeScript to spit out warnings/errors, since it is terrible idea that will not work in general scenarios because `.tsx` files will be transpiled to `.js` or `.jsx` files depending upon the compiler options. This just happens to magically work in Atom due to the compile cache, and what not.

### Benefits

Allows package developers to use TypeScript's JSX support. Another, almost accidental, benefit is that we'll provide modern TypeScript transpilation support out of the box.

### Possible Drawbacks

This might break packages that are currently using the antiquated, built-in TypeScript support due to the remarkable number of [breaking changes](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes) introduced in TypeScript since v1.4.

### Applicable Issues

Quick search did not reveal any obviously applicable issues.

### Additional tasks
- [ ] Find all community packages that use our built-in TypeScript support.
  - [ ] Check if any of these packages are affected by breaking changes.
  - [ ] Submit PRs to affected packages.
- [ ] Celebrate.
