### PR TITLE
Change HTTP Link to HTTPS in contributing-to-packages.md

### DIFF
--- a/docs/contributing-to-packages.md
+++ b/docs/contributing-to-packages.md
@@ -1,1 +1,1 @@
-See http://flight-manual.atom.io/hacking-atom/sections/contributing-to-official-atom-packages/
+See https://flight-manual.atom.io/hacking-atom/sections/contributing-to-official-atom-packages/


### PR DESCRIPTION
### Description of the Change
Change HTTP link to HTTPS in docs/contributing-to-packages.md since the linked-to site supports SSL/TLS
### Alternate Designs
The alternative would be leaving the link as HTTP. This leaves users less secure while having only marginal user experience benefits.
### Why Should This Be In Core?
The documentation changed is in Core.
### Benefits
Makes user interaction more secure by default.
### Possible Drawbacks
Marginal potential for devices not supporting SSL/TLS and marginal performance hits when accessing the link.
### Applicable Issues
Similar to issue #16167 and PR #16173