### PR TITLE
Use native Array.isArray in application-delegate

### DIFF
--- a/src/application-delegate.coffee
+++ b/src/application-delegate.coffee
@@ -1,4 +1,3 @@
-_ = require 'underscore-plus'
 {ipcRenderer, remote, shell} = require 'electron'
 ipcHelpers = require './ipc-helpers'
 {Disposable} = require 'event-kit'
@@ -133,7 +132,7 @@ class ApplicationDelegate
 
   confirm: ({message, detailedMessage, buttons}) ->
     buttons ?= {}
-    if _.isArray(buttons)
+    if Array.isArray(buttons)
       buttonLabels = buttons
     else
       buttonLabels = Object.keys(buttons)
@@ -146,7 +145,7 @@ class ApplicationDelegate
       normalizeAccessKeys: true
     })
 
-    if _.isArray(buttons)
+    if Array.isArray(buttons)
       chosen
     else
       callback = buttons[buttonLabels[chosen]]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Uses the native `Array.isArray` function in application-delegate, because that's what underscore-plus does anyway.

### Alternate Designs

None.

### Why Should This Be In Core?

Code cleanup.

### Benefits

:art:

### Possible Drawbacks

None.

### Applicable Issues

None.