### PR TITLE
Fix #16218

### DIFF
--- a/src/menu-helpers.coffee
+++ b/src/menu-helpers.coffee
@@ -46,7 +46,7 @@ normalizeLabel = (label) ->
     label.replace(/\&/g, '')
 
 cloneMenuItem = (item) ->
-  item = _.pick(item, 'type', 'label', 'enabled', 'visible', 'command', 'submenu', 'commandDetail', 'role', 'accelerator')
+  item = _.pick(item, 'type', 'label', 'enabled', 'visible', 'command', 'submenu', 'commandDetail', 'role', 'accelerator', 'icon')
   if item.submenu?
     item.submenu = item.submenu.map (submenuItem) -> cloneMenuItem(submenuItem)
   item


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This one-liner allows you to actually specify an `icon` property for menu items

### Alternate Designs

A possible alternate design would be to find a way to use `for(in)` loop to assign every property. I went with the design I did because it required the least amount of changes and I'm less likely to screw it up

### Why Should This Be In Core?

The alternative is to put this little code snippet in your package that will make you cringe really hard.
```
(function() {
	var _ = window.require('underscore-plus');
	var oldpick = _.pick;
	// please forgive me
	_.pick = function(...args) {
		if(args[1] == 'type' && args[2] == 'label' && args[3] == 'enabled') {
			args.push('icon');
		}
		return oldpick.call(this, ...args);
	};
})();
```

### Benefits

You can now use icons in menu items

### Possible Drawbacks

In order to use this you have to use `atom.contextMenu.add`

### Applicable Issues

#16218
