### PR TITLE
Do not clobber recent project history when running specs

### DIFF
--- a/spec/history-manager-spec.js
+++ b/spec/history-manager-spec.js
@@ -11,6 +11,9 @@ describe("HistoryManager", () => {
   let commandDisposable, projectDisposable
 
   beforeEach(async () => {
+    // Do not clobber recent project history
+    spyOn(atom.applicationDelegate, 'didChangeHistoryManager')
+
     commandDisposable = jasmine.createSpyObj('Disposable', ['dispose'])
     commandRegistry = jasmine.createSpyObj('CommandRegistry', ['add'])
     commandRegistry.add.andReturn(commandDisposable)

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -61,6 +61,9 @@ else
   specProjectPath = require('os').tmpdir()
 
 beforeEach ->
+  # Do not clobber recent project history
+  spyOn(atom.history, 'saveState').andReturn(Promise.resolve())
+
   atom.project.setPaths([specProjectPath])
 
   window.resetTimeouts()

--- a/src/history-manager.js
+++ b/src/history-manager.js
@@ -50,8 +50,8 @@ export class HistoryManager {
     return this.emitter.on('did-change-projects', callback)
   }
 
-  didChangeProjects (args) {
-    this.emitter.emit('did-change-projects', args || { reloaded: false })
+  didChangeProjects (args = {reloaded: false}) {
+    this.emitter.emit('did-change-projects', args)
   }
 
   async addProject (paths, lastOpened) {
@@ -93,7 +93,7 @@ export class HistoryManager {
   }
 
   async loadState () {
-    let history = await this.stateStore.load('history-manager')
+    const history = await this.stateStore.load('history-manager')
     if (history && history.projects) {
       this.projects = history.projects.filter(p => Array.isArray(p.paths) && p.paths.length > 0).map(p => new HistoryProject(p.paths, new Date(p.lastOpened)))
       this.didChangeProjects({reloaded: true})


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Previously, whenever running specs your recent project history would get :fire:d and completely replaced with whatever paths the tests you're running decided to open.  So most of the time my recent projects history would end up with only one entry, `C:\Users\user\Documents\GitHub\last-package-that-I-tested\spec\fixtures`.  Not very useful.  This change basically nulls out the relevant history-saving methods when running specs to avoid that.

### Alternate Designs

Change HistoryManager itself to prevent state storage when specs are running.  This seriously impedes the ability to test it, however.

### Why Should This Be In Core?

Changed the core spec helper file.

### Benefits

A more useful history menu for those who run specs frequently.

### Possible Drawbacks

None?

### Applicable Issues

None.