### PR TITLE
Improve spec stack traces

### DIFF
--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -23,19 +23,20 @@ formatStackTrace = (spec, message='', stackTrace) ->
   lines.shift() if message.trim() is errorMatch?[1]?.trim()
 
   lines = lines.map (line) ->
-    line = line.trim()
-    if line.startsWith('at ')
-      line = line
+    # Only format actual stacktrace lines
+    if /^\s*at\s/.test(line)
+      # Needs to occur before path relativization
+      if process.platform is 'win32' and /file:\/\/\//.test(line)
+        # file:///C:/some/file -> C:\some\file
+        line = line.replace('file:///', '').replace(///#{path.posix.sep}///g, path.win32.sep)
+
+      line = line.trim()
         # at jasmine.Spec.<anonymous> (path:1:2) -> at path:1:2
         .replace(/^at jasmine\.Spec\.<anonymous> \(([^)]+)\)/, 'at $1')
         # at it (path:1:2) -> at path:1:2
         .replace(/^at f*it \(([^)]+)\)/, 'at $1')
         # at spec/file-test.js -> at file-test.js
         .replace(spec.specDirectory + path.sep, '')
-
-      if process.platform is 'win32' and /file:\/\/\//.test(line)
-        # file:///C:/some/file -> C:\some\file
-        line = line.replace('file:///', '').replace(///#{path.posix.sep}///g, path.win32.sep)
 
     return line
 

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -23,21 +23,21 @@ formatStackTrace = (spec, message='', stackTrace) ->
   lines.shift() if message.trim() is errorMatch?[1]?.trim()
 
   lines = lines.map (line) ->
-    line = line
-      # at jasmine.Spec.<anonymous> (path:1:2) -> at path:1:2
-      .replace(/at jasmine\.Spec\.<anonymous> \(([^)]+)\)/, 'at $1')
-      # at it (path:1:2) -> at path:1:2
-      .replace(/at f*it \(([^)]+)\)/, 'at $1')
-      # at spec/file-test.js -> at file-test.js
-      .replace("at #{spec.specDirectory}#{path.sep}", 'at ')
-      # (spec/file-test.js:1:2) -> (file-test.js:1:2)
-      .replace("(#{spec.specDirectory}#{path.sep}", '(')
+    line = line.trim()
+    if line.startsWith('at ')
+      line = line
+        # at jasmine.Spec.<anonymous> (path:1:2) -> at path:1:2
+        .replace(/^at jasmine\.Spec\.<anonymous> \(([^)]+)\)/, 'at $1')
+        # at it (path:1:2) -> at path:1:2
+        .replace(/^at f*it \(([^)]+)\)/, 'at $1')
+        # at spec/file-test.js -> at file-test.js
+        .replace(spec.specDirectory + path.sep, '')
 
-    if process.platform is 'win32' and /file:\/\/\//.test(line)
-      # file:///C:/some/file -> C:\some\file
-      line = line.replace('file:///', '').replace(///#{path.posix.sep}///g, path.win32.sep)
+      if process.platform is 'win32' and /file:\/\/\//.test(line)
+        # file:///C:/some/file -> C:\some\file
+        line = line.replace('file:///', '').replace(///#{path.posix.sep}///g, path.win32.sep)
 
-    return line.trim()
+    return line
 
   lines.join('\n').trim()
 

--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -9,34 +9,40 @@ ipcHelpers = require '../src/ipc-helpers'
 formatStackTrace = (spec, message='', stackTrace) ->
   return stackTrace unless stackTrace
 
+  # at ... (.../jasmine.js:1:2)
   jasminePattern = /^\s*at\s+.*\(?.*[/\\]jasmine(-[^/\\]*)?\.js:\d+:\d+\)?\s*$/
-  firstJasmineLinePattern = /^\s*at [/\\].*[/\\]jasmine(-[^/\\]*)?\.js:\d+:\d+\)?\s*$/
+  # at jasmine.Something... (.../jasmine.js:1:2)
+  firstJasmineLinePattern = /^\s*at\s+jasmine\.[A-Z][^\s]*\s+\(?.*[/\\]jasmine(-[^/\\]*)?\.js:\d+:\d+\)?\s*$/
   lines = []
   for line in stackTrace.split('\n')
-    lines.push(line) unless jasminePattern.test(line)
     break if firstJasmineLinePattern.test(line)
+    lines.push(line) unless jasminePattern.test(line)
 
   # Remove first line of stack when it is the same as the error message
   errorMatch = lines[0]?.match(/^Error: (.*)/)
   lines.shift() if message.trim() is errorMatch?[1]?.trim()
 
-  for line, index in lines
-    # Remove prefix of lines matching: at jasmine.Spec.<anonymous> (path:1:2)
-    prefixMatch = line.match(/at jasmine\.Spec\.<anonymous> \(([^)]+)\)/)
-    line = "at #{prefixMatch[1]}" if prefixMatch
+  lines = lines.map (line) ->
+    line = line
+      # at jasmine.Spec.<anonymous> (path:1:2) -> at path:1:2
+      .replace(/at jasmine\.Spec\.<anonymous> \(([^)]+)\)/, 'at $1')
+      # at it (path:1:2) -> at path:1:2
+      .replace(/at f*it \(([^)]+)\)/, 'at $1')
+      # at spec/file-test.js -> at file-test.js
+      .replace("at #{spec.specDirectory}#{path.sep}", 'at ')
+      # (spec/file-test.js:1:2) -> (file-test.js:1:2)
+      .replace("(#{spec.specDirectory}#{path.sep}", '(')
 
-    # Relativize locations to spec directory
-    if process.platform is 'win32'
+    if process.platform is 'win32' and /file:\/\/\//.test(line)
+      # file:///C:/some/file -> C:\some\file
       line = line.replace('file:///', '').replace(///#{path.posix.sep}///g, path.win32.sep)
-    line = line.replace("at #{spec.specDirectory}#{path.sep}", 'at ')
-    lines[index] = line.replace("(#{spec.specDirectory}#{path.sep}", '(') # at step (path:1:2)
 
-  lines = lines.map (line) -> line.trim()
+    return line.trim()
+
   lines.join('\n').trim()
 
 module.exports =
 class AtomReporter
-
   constructor: ->
     @element = document.createElement('div')
     @element.classList.add('spec-reporter-container')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Two enhancements and one bugfix.
* Formats `at it (path.js:1:2)` to simply `at path.js:1:2`
* Speeds up line parsing by updating `firstJasmineLinePattern` to match when the line starts with `at jasmine.` and ends with a Jasmine filepath
* Only replaces forward slashes with backslashes on Windows when `file:///` is present on the same line

Also changed the `for...of` loop to `lines.map`.

### Alternate Designs

None.

### Why Should This Be In Core?

Unfortunately, this is in core and not a separate module :/.

### Benefits

Better stacktrace reporting :sparkles:

### Possible Drawbacks

If the stacktrace line starts with anything we're trying to replace it _will_ get replaced.  In addition, there is a possibility that stacktraces are reported differently on macOS and Linux.  I doubt that however.

### Applicable Issues

Fixes #14053, a regression caused by my previous stacktrace formatting PR.