### PR TITLE
Change dot-atom keymap.cson

### DIFF
--- a/dot-atom/keymap.cson
+++ b/dot-atom/keymap.cson
@@ -14,8 +14,8 @@
 #   'enter': 'editor:newline'
 #
 # 'atom-workspace':
-#   'ctrl-shift-p': 'core:move-up'
-#   'ctrl-p': 'core:move-down'
+#   'ctrl-pageup': 'pane:show-previous-item'
+#   'ctrl-pagedown': 'pane:show-next-item'
 #
 # You can find more information about keymaps in these guides:
 # * http://flight-manual.atom.io/using-atom/sections/basic-customization/#customizing-keybindings


### PR DESCRIPTION
- ctrl-shift-p and ctrl-p exist only macOS keymap
- i think example is same all platforms

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->
dot-atom keymap.cson example is only exist macOS 
i think example should work all platforms.
### Benefits

<!-- What benefits will be realized by the code change? -->
if someone use example keymaps they work all platfroms
### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
