### PR TITLE
Empty editor scrollup after splitting

### DIFF
--- a/src/tokenized-buffer.js
+++ b/src/tokenized-buffer.js
@@ -224,18 +224,16 @@ class TokenizedBuffer {
   }
 
   setGrammar (grammar) {
-    if (!grammar || grammar === this.grammar) return
-
-    
+    if (!grammar || grammar === this.grammar) return   
     
     // when the new grammar equals to the grammar of md extension
     // the grammar is equal to the txt grammar
-    if(grammar != atom.grammars.selectGrammar('.md'))
+    if(grammar != atom.grammars.selectGrammar('.md')) {
         this.grammar = grammar
-
-    else
+    }
+    else {
         this.grammar = atom.grammars.selectGrammar('.txt')
-    
+    }
     this.rootScopeDescriptor = new ScopeDescriptor({scopes: [this.grammar.scopeName]})
 
     if (this.grammarUpdateDisposable) this.grammarUpdateDisposable.dispose()

--- a/src/tokenized-buffer.js
+++ b/src/tokenized-buffer.js
@@ -40,7 +40,7 @@ class TokenizedBuffer {
     this.assert = params.assert
     this.scopedSettingsDelegate = params.scopedSettingsDelegate
 
-    this.(params.grammar || NullGrammar)
+    this.setGrammar(params.grammar || NullGrammar)
     this.disposables.add(this.buffer.registerTextDecorationLayer(this))
   }
 

--- a/src/tokenized-buffer.js
+++ b/src/tokenized-buffer.js
@@ -226,7 +226,14 @@ class TokenizedBuffer {
   setGrammar (grammar) {
     if (!grammar || grammar === this.grammar) return
 
-    this.grammar = grammar
+    # when the new grammar equals to the grammar of md extension
+    # the grammar is equal to the txt grammar
+    if(grammar != atom.grammars.selectGrammar('.md'))
+        this.grammar = grammar
+
+    else
+        this.grammar = atom.grammars.selectGrammar('.txt')
+    
     this.rootScopeDescriptor = new ScopeDescriptor({scopes: [this.grammar.scopeName]})
 
     if (this.grammarUpdateDisposable) this.grammarUpdateDisposable.dispose()

--- a/src/tokenized-buffer.js
+++ b/src/tokenized-buffer.js
@@ -224,15 +224,14 @@ class TokenizedBuffer {
   }
 
   setGrammar (grammar) {
-    if (!grammar || grammar === this.grammar) return   
+    if (!grammar || grammar === this.grammar) return
     
     // when the new grammar equals to the grammar of md extension
     // the grammar is equal to the txt grammar
-    if(grammar != atom.grammars.selectGrammar('.md')) {
-        this.grammar = grammar
-    }
-    else {
-        this.grammar = atom.grammars.selectGrammar('.txt')
+    if (grammar !== atom.grammars.selectGrammar('.md')) {
+      this.grammar = grammar
+    } else {
+      this.grammar = atom.grammars.selectGrammar('.txt')
     }
     this.rootScopeDescriptor = new ScopeDescriptor({scopes: [this.grammar.scopeName]})
 

--- a/src/tokenized-buffer.js
+++ b/src/tokenized-buffer.js
@@ -228,8 +228,8 @@ class TokenizedBuffer {
 
     
     
-    # when the new grammar equals to the grammar of md extension
-    # the grammar is equal to the txt grammar
+    // when the new grammar equals to the grammar of md extension
+    // the grammar is equal to the txt grammar
     if(grammar != atom.grammars.selectGrammar('.md'))
         this.grammar = grammar
 

--- a/src/tokenized-buffer.js
+++ b/src/tokenized-buffer.js
@@ -40,7 +40,8 @@ class TokenizedBuffer {
     this.assert = params.assert
     this.scopedSettingsDelegate = params.scopedSettingsDelegate
 
-    this.setGrammar(params.grammar || NullGrammar)
+    this.
+(params.grammar || NullGrammar)
     this.disposables.add(this.buffer.registerTextDecorationLayer(this))
   }
 
@@ -226,6 +227,7 @@ class TokenizedBuffer {
   setGrammar (grammar) {
     if (!grammar || grammar === this.grammar) return
 
+    
     # when the new grammar equals to the grammar of md extension
     # the grammar is equal to the txt grammar
     if(grammar != atom.grammars.selectGrammar('.md'))

--- a/src/tokenized-buffer.js
+++ b/src/tokenized-buffer.js
@@ -40,8 +40,7 @@ class TokenizedBuffer {
     this.assert = params.assert
     this.scopedSettingsDelegate = params.scopedSettingsDelegate
 
-    this.
-(params.grammar || NullGrammar)
+    this.(params.grammar || NullGrammar)
     this.disposables.add(this.buffer.registerTextDecorationLayer(this))
   }
 

--- a/src/tokenized-buffer.js
+++ b/src/tokenized-buffer.js
@@ -228,6 +228,7 @@ class TokenizedBuffer {
     if (!grammar || grammar === this.grammar) return
 
     
+    
     # when the new grammar equals to the grammar of md extension
     # the grammar is equal to the txt grammar
     if(grammar != atom.grammars.selectGrammar('.md'))

--- a/src/tokenized-buffer.js
+++ b/src/tokenized-buffer.js
@@ -225,7 +225,7 @@ class TokenizedBuffer {
 
   setGrammar (grammar) {
     if (!grammar || grammar === this.grammar) return
-    
+
     // when the new grammar equals to the grammar of md extension
     // the grammar is equal to the txt grammar
     if (grammar !== atom.grammars.selectGrammar('.md')) {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Fix #15584. Our change consisted of the editor's resolution being empty when dividing a page and scrolling up. For this, we did an if that checks the file extension. If the extension is ".md" (type "Markdown"), we make the extension ".txt" (type "Plane Text").  The changes are in the file tokenized-buffer.js, in the function setGrammar(grammar).

<img width="481" alt="atomsreenshot" src="https://user-images.githubusercontent.com/25772364/33316540-2ceb4b26-d42c-11e7-8d50-a3094dae69c2.PNG">


![atomgif](https://user-images.githubusercontent.com/25772364/33316503-101a3b74-d42c-11e7-8984-130daf826550.gif)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
None.

### Why Should This Be In Core?

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->
This changes fixed bug #15584. Editor isn’t empty if you scroll up after splitting already.

### Benefits

<!-- What benefits will be realized by the code change? -->
Atom’s users can already scroll by dividing the page and the editor is not empty.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
The file is no longer of the "Markdown" type and always becomes a "Plain Text".

### Applicable Issues

<!-- Enter any applicable Issues here -->
Editor is empty if you scroll up after splitting #15584.
