### PR TITLE
Change keybind for Fold-All, fix problem of incompatibility with US keyboard

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -186,8 +186,8 @@
 
   'cmd-alt-[': 'editor:fold-current-row'
   'cmd-alt-]': 'editor:unfold-current-row'
-  'cmd-alt-{': 'editor:fold-all' # Atom Specific
-  'cmd-alt-}': 'editor:unfold-all' # Atom Specific
+  'cmd-alt-f': 'editor:fold-all' # Atom Specific
+  'cmd-alt-u': 'editor:unfold-all' # Atom Specific
   'cmd-k cmd-0': 'editor:unfold-all'
   'cmd-k cmd-1': 'editor:fold-at-indent-level-1'
   'cmd-k cmd-2': 'editor:fold-at-indent-level-2'

--- a/keymaps/linux.cson
+++ b/keymaps/linux.cson
@@ -133,8 +133,8 @@
 
   'ctrl-alt-[': 'editor:fold-current-row'
   'ctrl-alt-]': 'editor:unfold-current-row'
-  'ctrl-alt-{': 'editor:fold-all' # Atom Specific
-  'ctrl-alt-}': 'editor:unfold-all' # Atom Specific
+  'ctrl-alt-f': 'editor:fold-all' # Atom Specific
+  'ctrl-alt-u': 'editor:unfold-all' # Atom Specific
   'ctrl-k ctrl-0': 'editor:unfold-all'
   'ctrl-k ctrl-1': 'editor:fold-at-indent-level-1'
   'ctrl-k ctrl-2': 'editor:fold-at-indent-level-2'

--- a/keymaps/win32.cson
+++ b/keymaps/win32.cson
@@ -136,8 +136,8 @@
 
   'ctrl-alt-[': 'editor:fold-current-row'
   'ctrl-alt-]': 'editor:unfold-current-row'
-  'ctrl-alt-{': 'editor:fold-all' # Atom Specific
-  'ctrl-alt-}': 'editor:unfold-all' # Atom Specific
+  'ctrl-alt-f': 'editor:fold-all' # Atom Specific
+  'ctrl-alt-u': 'editor:unfold-all' # Atom Specific
   'ctrl-k ctrl-0': 'editor:unfold-all'
   'ctrl-k ctrl-1': 'editor:fold-at-indent-level-1'
   'ctrl-k ctrl-2': 'editor:fold-at-indent-level-2'


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Our main objective with this change was to solve the issue presented in #14023 ([Folding keybindings duplicated](https://github.com/atom/atom/issues/14023)). 

The default keybindings (keyboard shortcuts) for Fold All ctrl-alt-{ and Fold Selection ctrl-alt-shift-[ on a US keyboard are the same . On top of that, the Fold All keybinding in the Command Palette is not the same as the one in the Settings, being instead the same as the Fold Selection keybinding.

The following files contain the source of this issue:

[atom/keymaps/darwin.cson](https://github.com/atom/atom/blob/master/keymaps/darwin.cson) (lines 189 and 190)
[atom/keymaps/win32.cson](https://github.com/atom/atom/blob/master/keymaps/win32.cson) (lines 139 and 140)
[atom/keymaps/linux.cson](https://github.com/atom/atom/blob/master/keymaps/linux.cson) (lines 136 and 137)

As explained above the keybinding for Fold All conflicted with the keybinding for Fold Selection. Because of that, we decided to change the following lines:

```
'ctrl-alt-{': 'editor:fold-all' # Atom Specific
'ctrl-alt-}': 'editor:unfold-all' # Atom Specific
```

to

```
'ctrl-alt-f': 'editor:fold-all' # Atom Specific
'ctrl-alt-u': 'editor:unfold-all' # Atom Specific
```

With this change we resolved the keybinding duplication, as well as the keybinding overlap. Although the keybinding for Unfold All had no issues, we decided to change it as well to keep the keybindings cohesive.


### Why Should This Be In Core?

Because the new keybindings introduced are intuitive, easy to use and they solve the issue described above.

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

### Benefits

The new keybindings are easy to replicate in all keyboard layouts.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Some developers might prefer the old keybindings.

<!-- What are the possible side-effects or negative impacts of the code change? -->

Aside from some developers preferences, it shouldn't change any of atom's functionalities, therefore, this change has no major negative impacts. 

### Applicable Issues

[#14023 - Folding keybindings duplicated](https://github.com/atom/atom/issues/14023)

<!-- Enter any applicable Issues here -->
