### PR TITLE
More history manager fixes in specs

### DIFF
--- a/spec/history-manager-spec.js
+++ b/spec/history-manager-spec.js
@@ -183,6 +183,10 @@ describe("HistoryManager", () => {
   describe("saveState", () => {
     let savedHistory
     beforeEach(() => {
+      // historyManager.saveState is spied on globally to prevent specs from
+      // modifying the shared project history. Since these tests depend on
+      // saveState, we unspy it but in turn spy on the state store instead
+      // so that no data is actually stored to it.
       jasmine.unspy(historyManager, 'saveState')
 
       spyOn(historyManager.stateStore, 'save').andCallFake((name, history) => {

--- a/spec/history-manager-spec.js
+++ b/spec/history-manager-spec.js
@@ -181,12 +181,12 @@ describe("HistoryManager", () => {
   })
 
   describe("saveState", () => {
-    let savedProjects
+    let savedHistory
     beforeEach(() => {
       jasmine.unspy(historyManager, 'saveState')
 
-      spyOn(historyManager.stateStore, 'save').andCallFake((name, {projects}) => {
-        savedProjects = {projects}
+      spyOn(historyManager.stateStore, 'save').andCallFake((name, history) => {
+        savedHistory = history
         return Promise.resolve()
       })
     })
@@ -195,7 +195,7 @@ describe("HistoryManager", () => {
       await historyManager.addProject(["/save/state"])
       await historyManager.saveState()
       const historyManager2 = new HistoryManager({stateStore, project, commands: commandRegistry})
-      spyOn(historyManager2.stateStore, 'load').andCallFake(name => Promise.resolve(savedProjects))
+      spyOn(historyManager2.stateStore, 'load').andCallFake(name => Promise.resolve(savedHistory))
       await historyManager2.loadState()
       expect(historyManager2.getProjects()[0].paths).toEqual(['/save/state'])
     })

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -9,7 +9,6 @@ pathwatcher = require 'pathwatcher'
 FindParentDir = require 'find-parent-dir'
 {CompositeDisposable} = require 'event-kit'
 
-{HistoryManager} = require '../src/history-manager'
 TextEditor = require '../src/text-editor'
 TextEditorElement = require '../src/text-editor-element'
 TextMateLanguageMode = require '../src/text-mate-language-mode'
@@ -64,7 +63,7 @@ else
 
 beforeEach ->
   # Do not clobber recent project history
-  spyOn(HistoryManager::, 'saveState').andReturn(Promise.resolve())
+  spyOn(Object.getPrototypeOf(atom.history), 'saveState').andReturn(Promise.resolve())
 
   atom.project.setPaths([specProjectPath])
 

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -9,6 +9,7 @@ pathwatcher = require 'pathwatcher'
 FindParentDir = require 'find-parent-dir'
 {CompositeDisposable} = require 'event-kit'
 
+{HistoryManager} = require '../src/history-manager'
 TextEditor = require '../src/text-editor'
 TextEditorElement = require '../src/text-editor-element'
 TextMateLanguageMode = require '../src/text-mate-language-mode'
@@ -63,7 +64,7 @@ else
 
 beforeEach ->
   # Do not clobber recent project history
-  spyOn(atom.history, 'saveState').andReturn(Promise.resolve())
+  spyOn(HistoryManager::, 'saveState').andReturn(Promise.resolve())
 
   atom.project.setPaths([specProjectPath])
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

My previous attempt to prevent specs from modifying the recent project history (#16255) worked for the most part but had some edge cases that I'm attempting to fix in this PR.  Specifically, #16255 only spied on `atom.history.saveState`.  If a different HistoryManager was instantiated, it would be able to save history state and globally modify the recent project history.  I found this to occur in at least two specs: a Workspace spec that was creating a new AtomEnvironment (and hence associated HistoryManager) and HistoryManager specs that used its own HistoryManager instance.  To prevent _any_ HistoryManagers from modifying project history, spec-helper now spies on the HistoryManager _prototype_ rather than a specific instance.  That means all instances of HistoryManager will now have saveState spied on.  However, since some HistoryManager specs explicitly test saveState, for those tests I temporarily unspy saveState and instead spy on the underlying state store.  My previous "fix" for HistoryManager was to spy on `atom.applicationDelegate.didChangeHistoryManager`, which is responsible for broadcasting project history changes to other Atom windows.  This was a faulty implementation because while the project history would appear to be conserved, the state store would still be updated with the incorrect project history data.  Therefore as soon as you opened another window the recent projects menu would again be incorrect.

### Test Plan
* Run some specs in the dedicated spec window and then close it.  Ensure that other non-spec windows have their project history maintained, even after opening a new window.
* Run all Workspace specs.  Ensure that other non-spec windows have their project history maintained, even after opening a new window.
* Run all HistoryManager specs.  Ensure that other non-spec windows have their project history maintained, even after opening a new window.

### Alternate Designs

None.

### Why Should This Be In Core?

The legacy spec helper is in core.

### Benefits

No specs should be able to modify project history unless you explicitly unspy `saveState`.

### Possible Drawbacks

None.

### Applicable Issues

#16255