### PR TITLE
Scrollbar correct pos after splitting

### DIFF
--- a/spec/grammar-registry-spec.js
+++ b/spec/grammar-registry-spec.js
@@ -345,6 +345,13 @@ describe('GrammarRegistry', () => {
       expect(atom.grammars.selectGrammar('foo.js').name).not.toBe(grammar.name)
     })
   })
+  
+    describe('Expected grammar of .md is .txt grammar', () => {
+    it("Expected grammar of .md is .txt grammar", async () => {
+      const grammar = atom.grammars.selectGrammar('test.txt')
+      expect(atom.grammars.selectGrammar('test.md').name).toBe(grammar.name)
+    })
+  })
 
   describe('serialization', () => {
     it('persists editors\' grammar overrides', async () => {

--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -146,6 +146,8 @@ class GrammarRegistry {
   }
 
   languageModeForGrammarAndBuffer (grammar, buffer) {
+    if (grammar == atom.grammars.selectGrammar('test.md'))
+      grammar = atom.grammars.selectGrammar('test.txt')
     return new TextMateLanguageMode({grammar, buffer, config: this.config})
   }
 

--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -146,8 +146,9 @@ class GrammarRegistry {
   }
 
   languageModeForGrammarAndBuffer (grammar, buffer) {
-    if (grammar === atom.grammars.selectGrammar('test.md'))
+    if (grammar === atom.grammars.selectGrammar('test.md')) {
       grammar = atom.grammars.selectGrammar('test.txt')
+    }
     return new TextMateLanguageMode({grammar, buffer, config: this.config})
   }
 

--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -146,6 +146,7 @@ class GrammarRegistry {
   }
 
   languageModeForGrammarAndBuffer (grammar, buffer) {
+    
     if (grammar == atom.grammars.selectGrammar('test.md'))
       grammar = atom.grammars.selectGrammar('test.txt')
     return new TextMateLanguageMode({grammar, buffer, config: this.config})

--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -146,8 +146,7 @@ class GrammarRegistry {
   }
 
   languageModeForGrammarAndBuffer (grammar, buffer) {
-    
-    if (grammar == atom.grammars.selectGrammar('test.md'))
+    if (grammar === atom.grammars.selectGrammar('test.md'))
       grammar = atom.grammars.selectGrammar('test.txt')
     return new TextMateLanguageMode({grammar, buffer, config: this.config})
   }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.-->

Fix #15585. Our change consisted of changing the grammar reading of "Markdown" files. For this, we did an if that checks the file extension. If the extension is ".md" (type "Markdown"), we make the extension ".txt" (type "Plane Text").  The changes are in the file grammar-registry.js, in the function languageModeForGrammarAndBuffer(grammar, buffer).

<img width="500" alt="atomsreenshot2" src="https://user-images.githubusercontent.com/25772364/33604471-0692ca9e-d9ae-11e7-9bda-194bf43e04c1.PNG">


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None.

### Why Should This Be In Core?

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

This changes fixed bug #15585.  Scrollbar position is on the correct position already.

### Benefits

<!-- What benefits will be realized by the code change? -->

Scrollbar stays in correct position when splitting panes.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

The file is no longer of the "Markdown" type and always becomes a "Plain Text".

### Applicable Issues

<!-- Enter any applicable Issues here -->

Scrollbar moves to the top when splitting panes #15585.
