### PR TITLE
Update auxiliary click logic for moving cursors

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1759,9 +1759,10 @@ class TextEditorComponent {
     const screenPosition = this.screenPositionForMouseEvent(event)
 
     if (button !== 0 || (platform === 'darwin' && ctrlKey)) {
-      // Set cursor position only if there is one cursor with no selection
+      // Always set cursor position on middle-click
+      // Only set cursor position on right-click if there is one cursor with no selection
       const ranges = model.getSelectedBufferRanges()
-      if (ranges.length === 1 && ranges[0].isEmpty()) {
+      if (button === 1 || (ranges.length === 1 && ranges[0].isEmpty())) {
         model.setCursorScreenPosition(screenPosition, {autoscroll: false})
       }
 

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1758,11 +1758,12 @@ class TextEditorComponent {
 
     const screenPosition = this.screenPositionForMouseEvent(event)
 
-    // All clicks should set the cursor position, but only left-clicks should
-    // have additional logic.
-    // On macOS, ctrl-click brings up the context menu so also handle that case.
     if (button !== 0 || (platform === 'darwin' && ctrlKey)) {
-      model.setCursorScreenPosition(screenPosition, {autoscroll: false})
+      // Set cursor position only if there is one cursor with no selection
+      const ranges = model.getSelectedBufferRanges()
+      if (ranges.length === 1 && ranges[0].isEmpty()) {
+        model.setCursorScreenPosition(screenPosition, {autoscroll: false})
+      }
 
       // On Linux, pasting happens on middle click. A textInput event with the
       // contents of the selection clipboard will be dispatched by the browser


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* When right-clicking when more than one cursor is present or if there is a non-empty selection, the cursor should not be moved to retain proper context
* When middle-clicking, the cursor should always be moved (same behavior as on master)

### Alternate Designs

None.

### Why Should This Be In Core?

This is a regression fix for #16324.

### Benefits

More native right-click handling.

### Possible Drawbacks

Potentially more cases that I didn't think of.

### Applicable Issues

Fixes #16324

/cc @Ingramz