### PR TITLE
Changed atom safe mode theme to One Dark.

### DIFF
--- a/spec/theme-manager-spec.js
+++ b/spec/theme-manager-spec.js
@@ -424,12 +424,12 @@ h2 {
       waitsForPromise(() => atom.themes.activateThemes())
     })
 
-    it('uses the default dark UI and syntax themes and logs a warning', function () {
+    it('uses the default one-dark UI and syntax themes and logs a warning', function () {
       const activeThemeNames = atom.themes.getActiveThemeNames()
       expect(console.warn.callCount).toBe(2)
       expect(activeThemeNames.length).toBe(2)
-      expect(activeThemeNames).toContain('atom-dark-ui')
-      expect(activeThemeNames).toContain('atom-dark-syntax')
+      expect(activeThemeNames).toContain('one-dark-ui')
+      expect(activeThemeNames).toContain('one-dark-syntax')
     })
   })
 
@@ -459,8 +459,8 @@ h2 {
       it('uses the default dark UI and syntax themes', function () {
         const activeThemeNames = atom.themes.getActiveThemeNames()
         expect(activeThemeNames.length).toBe(2)
-        expect(activeThemeNames).toContain('atom-dark-ui')
-        expect(activeThemeNames).toContain('atom-dark-syntax')
+        expect(activeThemeNames).toContain('one-dark-ui')
+        expect(activeThemeNames).toContain('one-dark-syntax')
       })
     })
 
@@ -471,10 +471,10 @@ h2 {
         waitsForPromise(() => atom.themes.activateThemes())
       })
 
-      it('uses the default dark UI theme', function () {
+      it('uses the default one-dark UI theme', function () {
         const activeThemeNames = atom.themes.getActiveThemeNames()
         expect(activeThemeNames.length).toBe(2)
-        expect(activeThemeNames).toContain('atom-dark-ui')
+        expect(activeThemeNames).toContain('one-dark-ui')
         expect(activeThemeNames).toContain('atom-light-syntax')
       })
     })
@@ -486,11 +486,11 @@ h2 {
         waitsForPromise(() => atom.themes.activateThemes())
       })
 
-      it('uses the default dark syntax theme', function () {
+      it('uses the default one-dark syntax theme', function () {
         const activeThemeNames = atom.themes.getActiveThemeNames()
         expect(activeThemeNames.length).toBe(2)
         expect(activeThemeNames).toContain('atom-light-ui')
-        expect(activeThemeNames).toContain('atom-dark-syntax')
+        expect(activeThemeNames).toContain('one-dark-syntax')
       })
     })
   })

--- a/src/theme-manager.js
+++ b/src/theme-manager.js
@@ -136,12 +136,12 @@ class ThemeManager {
       ]
       themeNames = _.intersection(themeNames, builtInThemeNames)
       if (themeNames.length === 0) {
-        themeNames = ['atom-dark-syntax', 'atom-dark-ui']
+        themeNames = ['one-dark-syntax', 'one-dark-ui']
       } else if (themeNames.length === 1) {
         if (_.endsWith(themeNames[0], '-ui')) {
-          themeNames.unshift('atom-dark-syntax')
+          themeNames.unshift('one-dark-syntax')
         } else {
-          themeNames.push('atom-dark-ui')
+          themeNames.push('one-dark-ui')
         }
       }
     }


### PR DESCRIPTION
### Description of the Change

Use default theme (One Dark) instead of first theme (Atom Dark) in safe mode, when a custom theme is used in regular mode. When loading the themes, the first theme in the stack would be Atom Dark, with this is change, the top theme will be One Dark.

### Alternate Designs

None.

### Why Should This Be In Core?

Fix Issue [#16196](https://github.com/atom/atom/issues/16196).

### Benefits

Atom's default theme is a much better theme, and has been recently updated (Aug 26 2017) unlike the Atom Dark that had no updates in years (Aug 28, 2014).

### Possible Drawbacks

None.

### Applicable Issues

Fixes #16196