### PR TITLE
'cmd--': As default for 'window:decrease-font-size' on MacOs

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -79,8 +79,8 @@
   'ctrl-shift-tab ^ctrl': 'pane:move-active-item-to-top-of-stack'
   'cmd-=': 'window:increase-font-size'
   'cmd-+': 'window:increase-font-size'
-  'cmd--': 'window:decrease-font-size'
   'cmd-_': 'window:decrease-font-size'
+  'cmd--': 'window:decrease-font-size'
   'cmd-0': 'window:reset-font-size'
 
   'cmd-k up': 'pane:split-up-and-copy-active-item' # Atom Specific


### PR DESCRIPTION
### Description of the Change

The keybinding 'cmd--' appears  instead of  'cmd-_' on  'View' drop down 
<br>
<img width="514" alt="captura de ecra 2017-12-07 as 19 06 29" src="https://user-images.githubusercontent.com/23191168/33735235-a0683f58-db86-11e7-80a7-68d37f4a969f.png">


### Alternate Designs

none.

### Why Should This Be In Core?

Fix issue https://github.com/atom/atom/issues/16024

### Benefits

'cmd--' is more used and more pratical too.

### Possible Drawbacks

none

### Applicable Issues

https://github.com/atom/atom/issues/16024
