### PR TITLE
Update atom-select-list to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "package-generator": "1.3.0",
     "settings-view": "0.253.1",
     "snippets": "1.1.10",
-    "spell-check": "0.72.3",
+    "spell-check": "0.72.4",
     "status-bar": "1.8.15",
     "styleguide": "0.49.10",
     "symbols-view": "0.118.2",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "spell-check": "0.72.3",
     "status-bar": "1.8.15",
     "styleguide": "0.49.9",
-    "symbols-view": "0.118.1",
+    "symbols-view": "0.118.2",
     "tabs": "0.109.1",
     "timecop": "0.36.2",
     "tree-view": "0.221.3",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "github": "0.9.0",
     "git-diff": "1.3.7",
     "go-to-line": "0.32.1",
-    "grammar-selector": "0.49.8",
+    "grammar-selector": "0.49.9",
     "image-view": "0.62.4",
     "incompatible-packages": "0.27.3",
     "keybinding-resolver": "0.38.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "autoflow": "0.29.0",
     "autosave": "0.24.6",
     "background-tips": "0.27.1",
-    "bookmarks": "0.45.0",
+    "bookmarks": "0.45.1",
     "bracket-matcher": "0.88.2",
     "command-palette": "0.43.0",
     "dalek": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "encoding-selector": "0.23.8",
     "exception-reporting": "0.42.0",
     "find-and-replace": "0.215.0",
-    "fuzzy-finder": "1.7.3",
+    "fuzzy-finder": "1.7.4",
     "github": "0.9.0",
     "git-diff": "1.3.7",
     "go-to-line": "0.32.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@atom/source-map-support": "^0.3.4",
     "async": "0.2.6",
     "atom-keymap": "8.2.8",
-    "atom-select-list": "^0.1.0",
+    "atom-select-list": "^0.7.0",
     "atom-ui": "0.4.1",
     "babel-core": "5.8.38",
     "cached-run-in-this-context": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "open-on-github": "1.3.1",
     "package-generator": "1.3.0",
     "settings-view": "0.253.1",
-    "snippets": "1.1.9",
+    "snippets": "1.1.10",
     "spell-check": "0.72.3",
     "status-bar": "1.8.15",
     "styleguide": "0.49.9",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "image-view": "0.62.4",
     "incompatible-packages": "0.27.3",
     "keybinding-resolver": "0.38.1",
-    "line-ending-selector": "0.7.4",
+    "line-ending-selector": "0.7.5",
     "link": "0.31.4",
     "markdown-preview": "0.159.18",
     "metrics": "1.2.6",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "snippets": "1.1.10",
     "spell-check": "0.72.3",
     "status-bar": "1.8.15",
-    "styleguide": "0.49.9",
+    "styleguide": "0.49.10",
     "symbols-view": "0.118.2",
     "tabs": "0.109.1",
     "timecop": "0.36.2",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "find-and-replace": "0.215.0",
     "fuzzy-finder": "1.7.3",
     "github": "0.9.0",
-    "git-diff": "1.3.6",
+    "git-diff": "1.3.7",
     "go-to-line": "0.32.1",
     "grammar-selector": "0.49.8",
     "image-view": "0.62.4",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "dalek": "0.2.1",
     "deprecation-cop": "0.56.9",
     "dev-live-reload": "0.48.1",
-    "encoding-selector": "0.23.7",
+    "encoding-selector": "0.23.8",
     "exception-reporting": "0.42.0",
     "find-and-replace": "0.215.0",
     "fuzzy-finder": "1.7.3",


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This unifies all atom-select-list dependencies to 0.7.0, which includes performance improvements and UX enhancements (over 0.1.0).  This will also allow us to start deduping atom-select-list again.

### Alternate Designs

None.

### Why Should This Be In Core?

Because these are all core packages.

### Benefits

Less space needed for install due to deduping as well as performance improvements.

### Possible Drawbacks

None.

### Applicable Issues

None.