### PR TITLE
Try adding python 2.x back - newer Travis images dropped it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ addons:
     - fakeroot
     - git
     - libsecret-1-dev
+    - python
     - rpm
     - libx11-dev
     - libxkbfile-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+language: python
+
+python:
+  - "2.7.13"
+
 git:
   depth: 10
 
@@ -57,7 +62,6 @@ addons:
     - fakeroot
     - git
     - libsecret-1-dev
-    - python
     - rpm
     - libx11-dev
     - libxkbfile-dev


### PR DESCRIPTION
Newer travis Linux build images have dropped Python 2.x 

node-gyp requires this to build Atom so builds are now failing.