### PR TITLE
Initialize ProtocolHandlerInstaller after initializing Config

### DIFF
--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -206,11 +206,12 @@ class AtomEnvironment {
     this.themes.initialize({configDirPath: this.configDirPath, resourcePath, safeMode, devMode})
 
     this.commandInstaller.initialize(this.getVersion())
-    this.protocolHandlerInstaller.initialize(this.config, this.notifications)
     this.uriHandlerRegistry.registerHostHandler('core', CoreURIHandlers.create(this))
     this.autoUpdater.initialize()
 
     this.config.load()
+
+    this.protocolHandlerInstaller.initialize(this.config, this.notifications)
 
     this.themes.loadBaseStylesheets()
     this.initialStyleElements = this.styles.getSnapshot()


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Initialize `ProtocolHandlerInstaller` after initializing Config. Config is initialized synchronously, so it should be OK to simply reorder them. Without this `ProtocolHandlerInstaller` fails to read the config value on `initialize` which causes the notification to be shown each time on Atom startup even if you select 'never'.

This allows it to correctly read `core.uriHandlerRegistration` and avoids popping the notification even if set to 'never'.

### Alternate Designs

N/A

### Why Should This Be In Core?

Fixes a bug.

### Benefits

Fixes a bug.

### Possible Drawbacks

Code formatting?

### Applicable Issues

Fixes #16201

cc @damieng @BinaryMuse 