### PR TITLE
Increase dock hover affordance

### DIFF
--- a/static/docks.less
+++ b/static/docks.less
@@ -16,9 +16,10 @@ atom-dock {
 .atom-dock-inner {
   display: flex;
 
-  // Keep the area at least a pixel wide so that you have something to hover
+  // Keep the area at least 2 pixels wide so that you have something to hover
   // over to trigger the toggle button affordance even when fullscreen.
-  &.left, &.right { min-width: 1px; }
+  // Needs to be 2 pixels to work on Windows when scaled to 150%. See atom/atom #15728
+  &.left, &.right { min-width: 2px; }
   &.bottom { min-height: 1px; }
 
   &.bottom { width: 100%; }


### PR DESCRIPTION
### Description of the Change

This PR increase the `1px` wide hover affordance to open docks to `2px`.

### Why Should This Be In Core?

Docks are part of core

### Benefits

It allows opening the right dock on Windows when maximized and scaled to 150%. See https://github.com/atom/atom/issues/15728

### Possible Drawbacks

Themes might have to adjust docks toggle button's position for the extra pixel.

![screen shot 2017-12-20 at 7 52 19 pm](https://user-images.githubusercontent.com/378023/34204122-e9ca516a-e5c0-11e7-9ad6-a97cf5127fd3.png)

### Applicable Issues

Fixes https://github.com/atom/atom/issues/15728
