### PR TITLE
Remove trailing whitespace from text editor docs

### DIFF
--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -3604,7 +3604,7 @@ class TextEditor {
   // coordinates. Useful with {Config::get}.
   //
   // For example, if called with a position inside the parameter list of an
-  // anonymous CoffeeScript function, this method returns a {ScopeDescriptor} with 
+  // anonymous CoffeeScript function, this method returns a {ScopeDescriptor} with
   // the following scopes array:
   // `["source.coffee", "meta.function.inline.coffee", "meta.parameters.coffee", "variable.parameter.function.coffee"]`
   //


### PR DESCRIPTION
### Description of the Change

Remove trailing whitespace from text editor API docs so the linter is happy (and thus the tests pass 😄)