### PR TITLE
Ensure that new editors get unique ids

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -20,14 +20,15 @@ describe('TextEditor', () => {
     await atom.packages.activatePackage('language-javascript')
   })
 
-  it('generates unique ids for each editor', () => {
-    // Deserialized editors are initialized with an id:
-    new TextEditor({id: 0})
-    new TextEditor({id: 1})
-    new TextEditor({id: 2})
-    // Initializing an editor without an id causes a new id to be generated:
-    const generatedId = new TextEditor().id
-    expect(generatedId).toBe(3)
+  it('generates unique ids for each editor', async () => {
+    // Deserialized editors are initialized with the serialized id. We can
+    // initialize an editor with what we expect to be the next id:
+    const deserialized = new TextEditor({id: editor.id+1})
+    expect(deserialized.id).toEqual(editor.id+1)
+
+    // The id generator should skip the id used up by the deserialized one:
+    const fresh = new TextEditor()
+    expect(fresh.id).toNotEqual(deserialized.id)
   })
 
   describe('when the editor is deserialized', () => {

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -20,6 +20,16 @@ describe('TextEditor', () => {
     await atom.packages.activatePackage('language-javascript')
   })
 
+  it('generates unique ids for each editor', () => {
+    // Deserialized editors are initialized with an id:
+    new TextEditor({id: 0})
+    new TextEditor({id: 1})
+    new TextEditor({id: 2})
+    // Initializing an editor without an id causes a new id to be generated:
+    const generatedId = new TextEditor().id
+    expect(generatedId).toBe(3)
+  })
+
   describe('when the editor is deserialized', () => {
     it('restores selections and folds based on markers in the buffer', async () => {
       editor.setSelectedBufferRange([[1, 2], [3, 4]])

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -121,7 +121,7 @@ class TextEditor {
     this.id = params.id != null ? params.id : nextId++
     if (this.id >= nextId) {
       // Ensure that new editors get unique ids:
-      nextId = this.id + 1;
+      nextId = this.id + 1
     }
     this.initialScrollTopRow = params.initialScrollTopRow
     this.initialScrollLeftColumn = params.initialScrollLeftColumn

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -119,6 +119,10 @@ class TextEditor {
     }
 
     this.id = params.id != null ? params.id : nextId++
+    if (this.id >= nextId) {
+      // Ensure that new editors get unique ids:
+      nextId = this.id + 1;
+    }
     this.initialScrollTopRow = params.initialScrollTopRow
     this.initialScrollLeftColumn = params.initialScrollLeftColumn
     this.decorationManager = params.decorationManager


### PR DESCRIPTION
This restores the behavior from when `TextEditor` was written in Coffeescript and extended the `Model` class.

### Description of the Change

With this change, editors opened after restoring the window state will get assigned IDs starting from `max(editor IDs) + 1`.

### Alternate Designs

An alternative could be to select the lowest available unique ID. This would require a more complicated ID generator, but is certainly possible if a more dense ID space is desirable. 

### Why Should This Be In Core?

Assuming that editor IDs are supposed to be unique, this is a bug in core.

### Benefits

Packages that look up editor instances by ID will be able to resolve to the correct editor.

### Possible Drawbacks

I'm not aware of any drawbacks.

### Applicable Issues

Fixes #16454.