### PR TITLE
Change SubWord selection to avoid selecting both sides of a dot "."

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -1048,6 +1048,24 @@ describe('TextEditor', () => {
         expect(editor.getCursorBufferPosition()).toEqual([0, 1])
       })
 
+      it('stops at word and dot boundaries', () => {
+        editor.setText('sub.word \n')
+        editor.setCursorBufferPosition([0, 9])
+        editor.moveToPreviousSubwordBoundary()
+        expect(editor.getCursorBufferPosition()).toEqual([0, 8])
+
+        editor.moveToPreviousSubwordBoundary()
+        expect(editor.getCursorBufferPosition()).toEqual([0, 4])
+
+        editor.moveToPreviousSubwordBoundary()
+        expect(editor.getCursorBufferPosition()).toEqual([0, 0])
+
+        editor.setText(' word\n')
+        editor.setCursorBufferPosition([0, 3])
+        editor.moveToPreviousSubwordBoundary()
+        expect(editor.getCursorBufferPosition()).toEqual([0, 1])
+      })
+
       it('stops at camelCase boundaries', () => {
         editor.setText(' getPreviousWord\n')
         editor.setCursorBufferPosition([0, 16])

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -664,7 +664,7 @@ class Cursor extends Model {
   // Returns a {RegExp}.
   wordRegExp (options) {
     const nonWordCharacters = _.escapeRegExp(this.getNonWordCharacters())
-    let source = `^[\t\r ]*$|[^\\s${nonWordCharacters}]+`
+    let source = `^[\t\r ]*$|[^\\s${nonWordCharacters}]+\\.?`
     if (!options || options.includeNonWordCharacters !== false) {
       source += `|${`[${nonWordCharacters}]+`}`
     }
@@ -699,7 +699,6 @@ class Cursor extends Model {
       segments.push(`\\s*[${_.escapeRegExp(nonWordCharacters)}]+`)
     }
     segments.push('_+')
-    const testRegExp = new RegExp(segments.join('|'), 'g')
     return new RegExp(segments.join('|'), 'g')
   }
 

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -690,8 +690,7 @@ class Cursor extends Model {
       '\\d+'
     ]
     if (options.backwards) {
-      segments.push(`${snakeCamelSegment}\\.?`)
-      segments.push(`${snakeCamelSegment}_*`)
+      segments.push(`${snakeCamelSegment}[\\._]*`)
       segments.push(`[${_.escapeRegExp(nonWordCharacters)}]+\\s*`)
     } else {
       segments.push(`_*${snakeCamelSegment}`)

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -690,13 +690,16 @@ class Cursor extends Model {
       '\\d+'
     ]
     if (options.backwards) {
+      segments.push(`${snakeCamelSegment}\\.?`)
       segments.push(`${snakeCamelSegment}_*`)
       segments.push(`[${_.escapeRegExp(nonWordCharacters)}]+\\s*`)
     } else {
       segments.push(`_*${snakeCamelSegment}`)
+      segments.push(`\\.?${snakeCamelSegment}`)
       segments.push(`\\s*[${_.escapeRegExp(nonWordCharacters)}]+`)
     }
     segments.push('_+')
+    const testRegExp = new RegExp(segments.join('|'), 'g')
     return new RegExp(segments.join('|'), 'g')
   }
 

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -664,7 +664,7 @@ class Cursor extends Model {
   // Returns a {RegExp}.
   wordRegExp (options) {
     const nonWordCharacters = _.escapeRegExp(this.getNonWordCharacters())
-    let source = `^[\t\r ]*$|[^\\s${nonWordCharacters}]+\\.?`
+    let source = `^[\t\r ]*$|[^\\s${nonWordCharacters}]+`
     if (!options || options.includeNonWordCharacters !== false) {
       source += `|${`[${nonWordCharacters}]+`}`
     }


### PR DESCRIPTION
### Requirements

Atom    : 1.23.1
Electron: 1.6.15
Chrome  : 56.0.2924.87
Node    : 7.4.0

### Description of the Change

Atom's Subword (ctrl-left/right arrow) right now move to both sides of a dot. Here are examples of the current behavior. 

Current Atom's subWord selection moving forward (the "|" represents the cursor):
`|this.aMethod`
`this|.aMethod`
`this.|aMethod`
`this.a|Method`
`this.aMethod|`
Current Atom's SubWord selection moving backwards (the "|" represents the cursor):
`this.aMethod|`
`this.a|Method`
`this.|aMethod`
`this|.aMethod`
`|this.aMethod`

Now the same example with the proposed behavior:

Proposed Atom's subWord selection moving forward (the "|" represents the cursor):
`|this.aMethod`
`this|.aMethod`
`this.a|Method`
`this.aMethod|`
Porpoised Atom's SubWord selection moving backwards (the "|" represents the cursor):
`this.aMethod|`
`this.a|Method`
`this.|aMethod`
`|this.aMethod`

As it can be seen, the proposed behavior only changes the dot "." selection, everything else remains the same.

### Alternate Designs

### Why Should This Be In Core?

The current behavior creates an unnecessary need for an extra input to move across  subwords.
The current behavior also repeats functionality since the same behavior can be obtained by using just left/right arrow. Example (the "|" represents the cursor):
If the cursor is at the left of a dot and we are moving forward, like shown:
`this|.method`
Then the input alt-right arrow would produce the same output as simply right arrow:
`this.|method`

This also happens when selecting text by using shit-alt-arrow.

### Benefits

This changes makes moving trough subwords faster, but it also is a more natural way of doing it.

### Possible Drawbacks

Some user may struggle to accommodate to this change at  first.

### Applicable Issues

This issues asked for a change in behavior, however, this change does not supply every change requested in them.

https://github.com/atom/atom/issues/13651
https://github.com/atom/atom/issues/13953