### PR TITLE
Update /docs/README.md to direct people to the new docs locations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,20 +2,20 @@
 
 ![Atom](https://cloud.githubusercontent.com/assets/72919/2874231/3af1db48-d3dd-11e3-98dc-6066f8bc766f.png)
 
-Most of the Atom user and developer documentation is contained in the [Atom Flight Manual](https://github.com/atom/flight-manual.atom.io) repository.
-
-In this directory you can only find very specific build and API level documentation. Some of this may eventually move to the Flight Manual as well.
+Most of the Atom user and developer documentation is contained in the [Atom Flight Manual](https://github.com/atom/flight-manual.atom.io).
 
 ## Build documentation
 
 Instructions for building Atom on various platforms from source.
 
-* [macOS](./build-instructions/macOS.md)
-* [Windows](./build-instructions/windows.md)
-* [Linux](./build-instructions/linux.md)
 * [FreeBSD](./build-instructions/freebsd.md)
+* Moved to [the Flight Manual](https://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/)
+    * Linux
+    * macOS
+    * Windows
 
-## Other documentation here
+## Other documentation
 
-* [apm REST API](./apm-rest-api.md)
-* [Tips for contributing to packages](./contributing-to-packages.md)
+[Native Profiling on macOS](./native-profiling.md)
+
+The other documentation that was listed here previously has been moved to [the Flight Manual](https://flight-manual.atom.io).


### PR DESCRIPTION
### Description of the Change

Update the README to point people to the new docs locations.

### Alternate Designs

None considered.

### Why Should This Be In Core?

The README is already in core.

### Benefits

People won't have to click a link to a doc that says "click here to go to the Flight Manual".

### Possible Drawbacks

Still can't get rid of the directory altogether because people may have bookmarks or something.

### Applicable Issues

N/A