### PR TITLE
Fix typo in protocol handler installer popup

### DIFF
--- a/src/protocol-handler-installer.js
+++ b/src/protocol-handler-installer.js
@@ -63,7 +63,7 @@ class ProtocolHandlerInstaller {
     notification = notifications.addInfo('Register as default atom:// URI handler?', {
       dismissable: true,
       icon: 'link',
-      description: 'Atom is not currently set as the defaut handler for atom:// URIs. Would you like Atom to handle ' +
+      description: 'Atom is not currently set as the default handler for atom:// URIs. Would you like Atom to handle ' +
         'atom:// URIs?',
       buttons: [
         {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Correct the typo "defaut" to the correct "default" in the atom:// URI protocol handler popup

### Alternate Designs

None

### Why Should This Be In Core?

A prominent typo should not be one of the first things a new Atom user sees

### Benefits

Not having a typo in a prominent popup

### Possible Drawbacks

None

### Applicable Issues

None