### PR TITLE
Allow you to tab through modal text box

### DIFF
--- a/spec/text-editor-element-spec.js
+++ b/spec/text-editor-element-spec.js
@@ -89,6 +89,22 @@ describe('TextEditorElement', () => {
     expect(element.getModel().getText()).toBe('testing')
   })
 
+  describe('tabIndex', () => {
+    it('uses a default value of -1', () => {
+      jasmineContent.innerHTML = '<atom-text-editor />'
+      const element = jasmineContent.firstChild
+      expect(element.tabIndex).toBe(-1)
+      expect(element.querySelector('input').tabIndex).toBe(-1)
+    })
+
+    it('uses the custom value when given', () => {
+      jasmineContent.innerHTML = '<atom-text-editor tabIndex="42" />'
+      const element = jasmineContent.firstChild
+      expect(element.tabIndex).toBe(-1)
+      expect(element.querySelector('input').tabIndex).toBe(42)
+    })
+  })
+
   describe('when the model is assigned', () =>
     it("adds the 'mini' attribute if .isMini() returns true on the model", async () => {
       const element = buildTextEditorElement()

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -170,7 +170,7 @@ class TextEditorComponent {
     this.textDecorationBoundaries = []
     this.pendingScrollTopRow = this.props.initialScrollTopRow
     this.pendingScrollLeftColumn = this.props.initialScrollLeftColumn
-    this.tabIndex = this.props.element && this.props.element.tabIndex ? this.props.element.tabIndex : -1;
+    this.tabIndex = this.props.element && this.props.element.tabIndex ? this.props.element.tabIndex : -1
 
     this.measuredContent = false
     this.queryGuttersToRender()

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -482,7 +482,7 @@ class TextEditorComponent {
         style,
         attributes,
         dataset,
-        tabIndex: this.tabIndex,
+        tabIndex: -1,
         on: {mousewheel: this.didMouseWheel}
       },
       $.div(
@@ -682,7 +682,8 @@ class TextEditorComponent {
       scrollWidth: this.getScrollWidth(),
       decorationsToRender: this.decorationsToRender,
       cursorsBlinkedOff: this.cursorsBlinkedOff,
-      hiddenInputPosition: this.hiddenInputPosition
+      hiddenInputPosition: this.hiddenInputPosition,
+      tabIndex: this.tabIndex
     })
   }
 
@@ -3547,7 +3548,7 @@ class CursorsAndInputComponent {
     const {
       lineHeight, hiddenInputPosition, didBlurHiddenInput, didFocusHiddenInput,
       didPaste, didTextInput, didKeydown, didKeyup, didKeypress,
-      didCompositionStart, didCompositionUpdate, didCompositionEnd
+      didCompositionStart, didCompositionUpdate, didCompositionEnd, tabIndex
     } = this.props
 
     let top, left
@@ -3575,7 +3576,7 @@ class CursorsAndInputComponent {
         compositionupdate: didCompositionUpdate,
         compositionend: didCompositionEnd
       },
-      tabIndex: this.tabIndex,
+      tabIndex: tabIndex,
       style: {
         position: 'absolute',
         width: '1px',

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -170,6 +170,7 @@ class TextEditorComponent {
     this.textDecorationBoundaries = []
     this.pendingScrollTopRow = this.props.initialScrollTopRow
     this.pendingScrollLeftColumn = this.props.initialScrollLeftColumn
+    this.tabIndex = this.props.element && this.props.element.tabIndex ? this.props.element.tabIndex : -1;
 
     this.measuredContent = false
     this.queryGuttersToRender()
@@ -481,7 +482,7 @@ class TextEditorComponent {
         style,
         attributes,
         dataset,
-        tabIndex: -1,
+        tabIndex: this.tabIndex,
         on: {mousewheel: this.didMouseWheel}
       },
       $.div(
@@ -3574,7 +3575,7 @@ class CursorsAndInputComponent {
         compositionupdate: didCompositionUpdate,
         compositionend: didCompositionEnd
       },
-      tabIndex: -1,
+      tabIndex: this.tabIndex,
       style: {
         position: 'absolute',
         width: '1px',

--- a/src/text-editor-element.js
+++ b/src/text-editor-element.js
@@ -32,7 +32,7 @@ class TextEditorElement extends HTMLElement {
   createdCallback () {
     this.emitter = new Emitter()
     this.initialText = this.textContent
-    this.tabIndex = -1
+    if (this.tabIndex == null) this.tabIndex = -1
     this.addEventListener('focus', (event) => this.getComponent().didFocus(event))
     this.addEventListener('blur', (event) => this.getComponent().didBlur(event))
   }


### PR DESCRIPTION
Fixes #16004

Supersedes #16127

---

This pull request builds on @itsmichaelwang's changes in #16127 and attempts to resolve the [possible drawbacks noted in that pull request](https://github.com/atom/atom/pull/16127#issue-151324878). (Please see #16127 for background on the overall approach.)

@itsmichaelwang: Thank you for getting this started! :bow:

### Demo

The demo below illustrates:

- <kbd>tab</kbd> to focus next element
- <kbd>shift</kbd>+<kbd>tab</kbd> to focus previous element
- <kbd>escape</kbd> to dismiss modal

![demo](https://user-images.githubusercontent.com/2988/34582512-12b2b7fa-f162-11e7-933f-3fda6ed282d6.gif)

### TODO

- [x] Allow tab navigation from one `atom-text-editor` element to another ordered by tabIndex
- [x] Allow tab navigation from an `atom-text-editor` element to another element ordered by tabIndex
- [x] Get sanity check from maintainers regarding unintended side effects this change might have
- [x] Add a test for specifying a custom tab index on an `atom-text-editor` element
- [x] Document and execute [verification process](https://github.com/atom/atom/pull/16484)

### Verification Process

- [x] Verify that you can tab through text fields and buttons in `github:clone` dialog. (See demo gif.)
- [x] Verify that you can still tab through fields in the find-and-replace dialog.
- [x] Verify that <kbd>tab</kbd> still inserts a tab (or spaces, depending on your preferences) when editing a buffer
- [x] When a line is selected in a buffer, verify that <kbd>tab</kbd> still indents the line and that <kbd>shift</kbd>+<kbd>tab</kbd> still outdents the line.
