### PR TITLE
Remove unused package-lock.json files before building

### DIFF
--- a/script/build
+++ b/script/build
@@ -58,6 +58,7 @@ const CONFIG = require('./config')
 let binariesPromise = Promise.resolve()
 
 if (!argv.existingBinaries) {
+  cleanPackageLock()
   checkChromedriverVersion()
   cleanOutputDirectory()
   copyAssets()

--- a/script/build
+++ b/script/build
@@ -28,6 +28,7 @@ const argv = yargs
 
 const checkChromedriverVersion = require('./lib/check-chromedriver-version')
 const cleanOutputDirectory = require('./lib/clean-output-directory')
+const cleanPackageLock = require('./lib/clean-package-lock')
 const codeSignOnMac = require('./lib/code-sign-on-mac')
 const codeSignOnWindows = require('./lib/code-sign-on-windows')
 const compressArtifacts = require('./lib/compress-artifacts')

--- a/script/lib/clean-package-lock.js
+++ b/script/lib/clean-package-lock.js
@@ -1,0 +1,18 @@
+// This module exports a function that deletes all `package-lock.json` files that do
+// not exist under a `node_modules` directory.
+
+'use strict'
+
+const CONFIG = require('../config')
+const fs = require('fs-extra')
+const glob = require('glob')
+const path = require('path')
+
+module.exports = function () {
+  console.log('Deleting problematic package-lock.json files')
+  let paths = glob.sync(path.join(CONFIG.repositoryRootPath, '**', 'package-lock.json'), {ignore: path.join('**', 'node_modules', '**')})
+
+  for (let path of paths) {
+    fs.unlinkSync(path)
+  }
+}


### PR DESCRIPTION
### Description of the Change

`package-lock.json` files are generated by the build on certain configurations. When they are, they can sometimes create strange, hard-to-diagnose errors that prevent successive builds. This change deletes the `package-lock.json` files (that we don't use for Atom) before building so that people who aren't consistently building Atom don't get confused.

### Alternate Designs

Considered actually using the `package-lock.json` files but we're not ready to do that yet.

### Why Should This Be In Core?

Because that's where builds happen.

### Benefits

Easier build experience for everyone :tada:

### Possible Drawbacks

We'll have to rip this out if/when we decide to use `package-lock.json` files.

### Applicable Issues

None known?
