### PR TITLE
Allow existing windows to be used when running atom --wait

### DIFF
--- a/src/application-delegate.js
+++ b/src/application-delegate.js
@@ -139,6 +139,10 @@ class ApplicationDelegate {
     return ipcRenderer.send('execute-javascript-in-dev-tools', code)
   }
 
+  didCloseInitialPath (path) {
+    return ipcHelpers.call('window-method', 'didCloseInitialPath', path)
+  }
+
   setWindowDocumentEdited (edited) {
     return ipcHelpers.call('window-method', 'setDocumentEdited', edited)
   }

--- a/src/application-delegate.js
+++ b/src/application-delegate.js
@@ -139,8 +139,8 @@ class ApplicationDelegate {
     return ipcRenderer.send('execute-javascript-in-dev-tools', code)
   }
 
-  didCloseInitialPath (path) {
-    return ipcHelpers.call('window-method', 'didCloseInitialPath', path)
+  didClosePathWithWaitSession (path) {
+    return ipcHelpers.call('window-method', 'didClosePathWithWaitSession', path)
   }
 
   setWindowDocumentEdited (edited) {

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -824,8 +824,15 @@ class AtomEnvironment {
       this.document.body.appendChild(this.workspace.getElement())
       if (this.backgroundStylesheet) this.backgroundStylesheet.remove()
 
-      this.disposables.add(this.project.onDidChangePaths(() => {
-        this.applicationDelegate.setRepresentedDirectoryPaths(this.project.getPaths())
+      let previousProjectPaths = this.project.getPaths()
+      this.disposables.add(this.project.onDidChangePaths(newPaths => {
+        for (let path of previousProjectPaths) {
+          if (this.pathsToNotifyWhenClosed.has(path) && !newPaths.includes(path)) {
+            this.applicationDelegate.didCloseInitialPath(path)
+          }
+        }
+        previousProjectPaths = newPaths
+        this.applicationDelegate.setRepresentedDirectoryPaths(newPaths)
       }))
       this.disposables.add(this.workspace.onDidDestroyPaneItem(({item}) => {
         const path = item.getPath && item.getPath()

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -70,6 +70,7 @@ class AtomEnvironment {
     this.loadTime = null
     this.emitter = new Emitter()
     this.disposables = new CompositeDisposable()
+    this.pathsToNotifyWhenClosed = new Set()
 
     // Public: A {DeserializerManager} instance
     this.deserializers = new DeserializerManager(this)
@@ -359,6 +360,7 @@ class AtomEnvironment {
     this.grammars.clear()
     this.textEditors.clear()
     this.views.clear()
+    this.pathsToNotifyWhenClosed.clear()
   }
 
   destroy () {
@@ -822,7 +824,15 @@ class AtomEnvironment {
       this.document.body.appendChild(this.workspace.getElement())
       if (this.backgroundStylesheet) this.backgroundStylesheet.remove()
 
-      this.watchProjectPaths()
+      this.disposables.add(this.project.onDidChangePaths(() => {
+        this.applicationDelegate.setRepresentedDirectoryPaths(this.project.getPaths())
+      }))
+      this.disposables.add(this.workspace.onDidDestroyPaneItem(({item}) => {
+        const path = item.getPath && item.getPath()
+        if (this.pathsToNotifyWhenClosed.has(path)) {
+          this.applicationDelegate.didCloseInitialPath(path)
+        }
+      }))
 
       this.packages.activate()
       this.keymaps.loadUserKeymap()
@@ -1023,13 +1033,6 @@ class AtomEnvironment {
 
   loadThemes () {
     return this.themes.load()
-  }
-
-  // Notify the browser project of the window's current project path
-  watchProjectPaths () {
-    this.disposables.add(this.project.onDidChangePaths(() => {
-      this.applicationDelegate.setRepresentedDirectoryPaths(this.project.getPaths())
-    }))
   }
 
   setDocumentEdited (edited) {
@@ -1300,8 +1303,9 @@ class AtomEnvironment {
       }
     }
 
-    for (var {pathToOpen, initialLine, initialColumn, forceAddToWindow} of locations) {
-      if (pathToOpen && (needsProjectPaths || forceAddToWindow)) {
+    for (const location of locations) {
+      const {pathToOpen} = location
+      if (pathToOpen && (needsProjectPaths || location.forceAddToWindow)) {
         if (fs.existsSync(pathToOpen)) {
           pushFolderToOpen(this.project.getDirectoryForProjectPath(pathToOpen).getPath())
         } else if (fs.existsSync(path.dirname(pathToOpen))) {
@@ -1312,8 +1316,10 @@ class AtomEnvironment {
       }
 
       if (!fs.isDirectorySync(pathToOpen)) {
-        fileLocationsToOpen.push({pathToOpen, initialLine, initialColumn})
+        fileLocationsToOpen.push(location)
       }
+
+      if (location.notifyWhenClosed) this.pathsToNotifyWhenClosed.add(pathToOpen)
     }
 
     let restoredState = false
@@ -1334,7 +1340,7 @@ class AtomEnvironment {
 
     if (!restoredState) {
       const fileOpenPromises = []
-      for ({pathToOpen, initialLine, initialColumn} of fileLocationsToOpen) {
+      for (const {pathToOpen, initialLine, initialColumn} of fileLocationsToOpen) {
         fileOpenPromises.push(this.workspace && this.workspace.open(pathToOpen, {initialLine, initialColumn}))
       }
       await Promise.all(fileOpenPromises)

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -70,7 +70,7 @@ class AtomEnvironment {
     this.loadTime = null
     this.emitter = new Emitter()
     this.disposables = new CompositeDisposable()
-    this.pathsToNotifyWhenClosed = new Set()
+    this.pathsWithWaitSessions = new Set()
 
     // Public: A {DeserializerManager} instance
     this.deserializers = new DeserializerManager(this)
@@ -360,7 +360,7 @@ class AtomEnvironment {
     this.grammars.clear()
     this.textEditors.clear()
     this.views.clear()
-    this.pathsToNotifyWhenClosed.clear()
+    this.pathsWithWaitSessions.clear()
   }
 
   destroy () {
@@ -827,8 +827,8 @@ class AtomEnvironment {
       let previousProjectPaths = this.project.getPaths()
       this.disposables.add(this.project.onDidChangePaths(newPaths => {
         for (let path of previousProjectPaths) {
-          if (this.pathsToNotifyWhenClosed.has(path) && !newPaths.includes(path)) {
-            this.applicationDelegate.didCloseInitialPath(path)
+          if (this.pathsWithWaitSessions.has(path) && !newPaths.includes(path)) {
+            this.applicationDelegate.didClosePathWithWaitSession(path)
           }
         }
         previousProjectPaths = newPaths
@@ -836,8 +836,8 @@ class AtomEnvironment {
       }))
       this.disposables.add(this.workspace.onDidDestroyPaneItem(({item}) => {
         const path = item.getPath && item.getPath()
-        if (this.pathsToNotifyWhenClosed.has(path)) {
-          this.applicationDelegate.didCloseInitialPath(path)
+        if (this.pathsWithWaitSessions.has(path)) {
+          this.applicationDelegate.didClosePathWithWaitSession(path)
         }
       }))
 
@@ -1326,7 +1326,7 @@ class AtomEnvironment {
         fileLocationsToOpen.push(location)
       }
 
-      if (location.notifyWhenClosed) this.pathsToNotifyWhenClosed.add(pathToOpen)
+      if (location.hasWaitSession) this.pathsWithWaitSessions.add(pathToOpen)
     }
 
     let restoredState = false

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -793,7 +793,7 @@ class AtomApplication extends EventEmitter {
     for (let i = 0; i < pathsToOpen.length; i++) {
       const location = this.parsePathToOpen(pathsToOpen[i], executedFrom, addToLastWindow)
       location.forceAddToWindow = addToLastWindow
-      location.notifyWhenClosed = pidToKillWhenClosed != null
+      location.hasWaitSession = pidToKillWhenClosed != null
       locationsToOpen.push(location)
       pathsToOpen[i] = location.pathToOpen
     }
@@ -886,7 +886,7 @@ class AtomApplication extends EventEmitter {
     this.waitSessionsByWindow.delete(window)
   }
 
-  windowDidCloseInitialPath (window, initialPath) {
+  windowDidClosePathWithWaitSession (window, initialPath) {
     const waitSessions = this.waitSessionsByWindow.get(window)
     if (!waitSessions) return
     for (let i = waitSessions.length - 1; i >= 0; i--) {

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -101,6 +101,7 @@ class AtomApplication extends EventEmitter {
     this.socketPath = options.socketPath
     this.logFile = options.logFile
     this.userDataDir = options.userDataDir
+    this._killProcess = options.killProcess || process.kill.bind(process)
     if (options.test || options.benchmark || options.benchmarkTest) this.socketPath = null
 
     this.pidsToOpenWindows = {}
@@ -880,7 +881,7 @@ class AtomApplication extends EventEmitter {
   killProcess (pid) {
     try {
       const parsedPid = parseInt(pid)
-      if (isFinite(parsedPid)) process.kill(parsedPid)
+      if (isFinite(parsedPid)) this._killProcess(parsedPid)
     } catch (error) {
       if (error.code !== 'ESRCH') {
         console.log(`Killing process ${pid} failed: ${error.code != null ? error.code : error.message}`)

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -888,6 +888,7 @@ class AtomApplication extends EventEmitter {
 
   windowDidCloseInitialPath (window, initialPath) {
     const waitSessions = this.waitSessionsByWindow.get(window)
+    if (!waitSessions) return
     for (let i = waitSessions.length - 1; i >= 0; i--) {
       const session = waitSessions[i]
       session.remainingPaths.delete(initialPath)

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -104,7 +104,7 @@ class AtomApplication extends EventEmitter {
     this._killProcess = options.killProcess || process.kill.bind(process)
     if (options.test || options.benchmark || options.benchmarkTest) this.socketPath = null
 
-    this.pidsToOpenWindows = {}
+    this.waitSessionsByWindow = new Map()
     this.windowStack = new WindowStack()
 
     this.config = new Config({enablePersistence: true})
@@ -789,13 +789,17 @@ class AtomApplication extends EventEmitter {
     safeMode = Boolean(safeMode)
     clearWindowState = Boolean(clearWindowState)
 
-    const locationsToOpen = pathsToOpen.map(pathToOpen =>
-      this.locationForPathToOpen(pathToOpen, executedFrom, addToLastWindow)
-    )
-    pathsToOpen = locationsToOpen.map(locationToOpen => locationToOpen.pathToOpen)
+    const locationsToOpen = []
+    for (let i = 0; i < pathsToOpen.length; i++) {
+      const location = this.parsePathToOpen(pathsToOpen[i], executedFrom, addToLastWindow)
+      location.forceAddToWindow = addToLastWindow
+      location.notifyWhenClosed = pidToKillWhenClosed != null
+      locationsToOpen.push(location)
+      pathsToOpen[i] = location.pathToOpen
+    }
 
     let existingWindow
-    if (!pidToKillWhenClosed && !newWindow) {
+    if (!newWindow) {
       existingWindow = this.windowForPaths(pathsToOpen, devMode)
       const stats = pathsToOpen.map(pathToOpen => fs.statSyncNoException(pathToOpen))
       if (!existingWindow) {
@@ -853,26 +857,43 @@ class AtomApplication extends EventEmitter {
     }
 
     if (pidToKillWhenClosed != null) {
-      this.pidsToOpenWindows[pidToKillWhenClosed] = openedWindow
+      if (!this.waitSessionsByWindow.has(openedWindow)) {
+        this.waitSessionsByWindow.set(openedWindow, [])
+      }
+      this.waitSessionsByWindow.get(openedWindow).push({
+        pid: pidToKillWhenClosed,
+        remainingPaths: new Set(pathsToOpen)
+      })
     }
 
-    openedWindow.browserWindow.once('closed', () => this.killProcessForWindow(openedWindow))
+    openedWindow.browserWindow.once('closed', () => this.killProcessesForWindow(openedWindow))
     return openedWindow
   }
 
   // Kill all processes associated with opened windows.
   killAllProcesses () {
-    for (let pid in this.pidsToOpenWindows) {
-      this.killProcess(pid)
+    for (let window of this.waitSessionsByWindow.keys()) {
+      this.killProcessesForWindow(window)
     }
   }
 
-  // Kill process associated with the given opened window.
-  killProcessForWindow (openedWindow) {
-    for (let pid in this.pidsToOpenWindows) {
-      const trackedWindow = this.pidsToOpenWindows[pid]
-      if (trackedWindow === openedWindow) {
-        this.killProcess(pid)
+  killProcessesForWindow (window) {
+    const sessions = this.waitSessionsByWindow.get(window)
+    if (!sessions) return
+    for (const session of sessions) {
+      this.killProcess(session.pid)
+    }
+    this.waitSessionsByWindow.delete(window)
+  }
+
+  windowDidCloseInitialPath (window, initialPath) {
+    const waitSessions = this.waitSessionsByWindow.get(window)
+    for (let i = waitSessions.length - 1; i >= 0; i--) {
+      const session = waitSessions[i]
+      session.remainingPaths.delete(initialPath)
+      if (session.remainingPaths.size === 0) {
+        this.killProcess(session.pid)
+        waitSessions.splice(i, 1)
       }
     }
   }
@@ -887,7 +908,6 @@ class AtomApplication extends EventEmitter {
         console.log(`Killing process ${pid} failed: ${error.code != null ? error.code : error.message}`)
       }
     }
-    delete this.pidsToOpenWindows[pid]
   }
 
   saveState (allowEmpty = false) {
@@ -1193,7 +1213,7 @@ class AtomApplication extends EventEmitter {
     }
   }
 
-  locationForPathToOpen (pathToOpen, executedFrom = '', forceAddToWindow) {
+  parsePathToOpen (pathToOpen, executedFrom = '') {
     let initialColumn, initialLine
     if (!pathToOpen) {
       return {pathToOpen}
@@ -1218,7 +1238,7 @@ class AtomApplication extends EventEmitter {
       pathToOpen = path.resolve(executedFrom, fs.normalize(pathToOpen))
     }
 
-    return {pathToOpen, initialLine, initialColumn, forceAddToWindow}
+    return {pathToOpen, initialLine, initialColumn}
   }
 
   // Opens a native dialog to prompt the user for a path.

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -411,6 +411,10 @@ class AtomWindow extends EventEmitter {
     return this.atomApplication.saveState()
   }
 
+  didCloseInitialPath (path) {
+    this.atomApplication.windowDidCloseInitialPath(this, path)
+  }
+
   copy () {
     return this.browserWindow.copy()
   }

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -411,8 +411,8 @@ class AtomWindow extends EventEmitter {
     return this.atomApplication.saveState()
   }
 
-  didCloseInitialPath (path) {
-    this.atomApplication.windowDidCloseInitialPath(this, path)
+  didClosePathWithWaitSession (path) {
+    this.atomApplication.windowDidClosePathWithWaitSession(this, path)
   }
 
   copy () {


### PR DESCRIPTION
### Motivation

The `--wait` flag allows Atom to block until you are finished editing a file. Unfortunately, the way it is currently implemented, it simply opens a new Atom window and blocks until that entire *window* is closed. This means that opening a file with `atom --wait` is currently much slower than with `atom`, because the latter command can reuse an existing Atom window.

### Solution

This PR changes the behavior of `atom --wait` so that it doesn't necessarily open a new window. It now uses the same criteria for selecting a window that the `atom` command normally uses, and can be freely combined with any other flag. Examples:

* `--wait --new-window` - reproduce the *old* behavior of `--wait`
* `--wait file1 file2` add multiple files to the current window and block until they are all closed
* `--wait --add some-folder` - add a project folder to the current window and block until this project folder is removed
* `--wait some-file some-folder`

No matter how it is combined with other flags and arguments, `atom --wait` will block until all of the specified paths have been closed.

### Result

Once this change ships, you might consider putting this line to your `~/.bash_profile`:

```sh
export GIT_EDITOR='atom --wait'
```

![rebase](https://user-images.githubusercontent.com/326587/34635311-9123ee8e-f242-11e7-9ebc-b8f3b75388d1.gif)


Fixes https://github.com/atom/atom/issues/1433
Depends on https://github.com/atom/atom/pull/16500
  
  