### PR TITLE
Move highlights container within lines container for theme compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "keybinding-resolver": "0.38.1",
     "line-ending-selector": "0.7.5",
     "link": "0.31.4",
-    "markdown-preview": "0.159.19",
+    "markdown-preview": "0.159.20",
     "metrics": "1.2.6",
     "notifications": "0.70.2",
     "open-on-github": "1.3.1",

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -263,13 +263,13 @@ describe('TextEditorComponent', () => {
     it('keeps the number of tiles stable when the visible line count changes during vertical scrolling', async () => {
       const {component, element, editor} = buildComponent({rowsPerTile: 3, autoHeight: false})
       await setEditorHeightInLines(component, 5.5)
-      expect(component.refs.lineTiles.children.length).toBe(3 + 1) // account for cursors container
+      expect(component.refs.lineTiles.children.length).toBe(3 + 2) // account for cursors and highlights containers
 
       await setScrollTop(component, 0.5 * component.getLineHeight())
-      expect(component.refs.lineTiles.children.length).toBe(3 + 1) // account for cursors container
+      expect(component.refs.lineTiles.children.length).toBe(3 + 2) // account for cursors and highlights containers
 
       await setScrollTop(component, 1 * component.getLineHeight())
-      expect(component.refs.lineTiles.children.length).toBe(3 + 1) // account for cursors container
+      expect(component.refs.lineTiles.children.length).toBe(3 + 2) // account for cursors and highlights containers
     })
 
     it('recycles tiles on resize', async () => {

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -577,7 +577,6 @@ class TextEditorComponent {
         on: {mousedown: this.didMouseDownOnContent},
         style
       },
-      this.renderHighlightDecorations(),
       this.renderLineTiles(),
       this.renderBlockDecorationMeasurementArea(),
       this.renderCharacterMeasurementLine()
@@ -654,6 +653,7 @@ class TextEditorComponent {
     }
 
     children.push(this.renderPlaceholderText())
+    children.push(this.renderHighlightDecorations())
     children.push(this.renderCursorsAndInput())
 
     return $.div(


### PR DESCRIPTION
### Description of the Change

This PR moves the highlights container inside of the lines for compatibility with themes that add padding or margin to the lines container. This was partially dealt with in #15317 by moving the cursors container, but the highlights container needs to move as well.

### Alternate Designs

We could fix all the themes to also style the highlights container, but that's a tall order.

### Benefits

Things should line up correctly.

### Possible Drawbacks

I originally rendered these outside of the lines container in the rendering rewrite because they are of a completely different type than the lines tiles, and it felt strange to have lines be a heterogenous collection. But it's not worth breaking themes.

### Verification Process

Load the no-caffeine-syntax theme and verify that the misalignment of highlights (such as selections) described in #15829 is no longer present.

### Applicable Issues

Fixes #15829

/cc @as-cii 