### PR TITLE
Render highlights behind lines

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -3536,7 +3536,8 @@ class CursorsAndInputComponent {
         zIndex: 1,
         width: scrollWidth + 'px',
         height: scrollHeight + 'px',
-        pointerEvents: 'none'
+        pointerEvents: 'none',
+        userSelect: 'none'
       }
     }, children)
   }
@@ -4012,6 +4013,7 @@ class HighlightsComponent {
     this.element.style.contain = 'strict'
     this.element.style.position = 'absolute'
     this.element.style.overflow = 'hidden'
+    this.element.style.userSelect = 'none'
     this.highlightComponentsByKey = new Map()
     this.update(props)
   }

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -594,12 +594,14 @@ class TextEditorComponent {
   }
 
   renderLineTiles () {
-    const children = []
     const style = {
       position: 'absolute',
       contain: 'strict',
       overflow: 'hidden'
     }
+
+    const children = []
+    children.push(this.renderHighlightDecorations())
 
     if (this.hasInitialMeasurements) {
       const {lineComponentsByScreenLineId} = this
@@ -653,7 +655,6 @@ class TextEditorComponent {
     }
 
     children.push(this.renderPlaceholderText())
-    children.push(this.renderHighlightDecorations())
     children.push(this.renderCursorsAndInput())
 
     return $.div(


### PR DESCRIPTION
Refs: https://github.com/atom/atom/pull/16511

This fixes a bug that was causing text to be covered up by selections due to the highlights container being rendered above the editor tiles.

| Before                                                                                                        | After                                                                                                        |
|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
| ![before](https://user-images.githubusercontent.com/482957/34721486-3163a256-f543-11e7-97ce-7f1d15e010d1.gif) | ![after](https://user-images.githubusercontent.com/482957/34721487-3180121a-f543-11e7-8b0f-8ce59894c8e5.gif) |

I have tested that this pull-request doesn't re-introduce the issue fixed in https://github.com/atom/atom/pull/16511.

/cc: @nathansobo 