### PR TITLE
Don't add fully-contained selections above/below

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -2376,6 +2376,19 @@ describe('TextEditor', () => {
           ])
         })
       })
+
+      it('does not create a new selection if it would be fully contained within another selection', () => {
+        editor.setText('abc\ndef\nghi\njkl\nmno')
+        editor.setCursorBufferPosition([0, 1])
+
+        let addedSelectionCount = 0
+        editor.onDidAddSelection(() => { addedSelectionCount++ })
+
+        editor.addSelectionBelow()
+        editor.addSelectionBelow()
+        editor.addSelectionBelow()
+        expect(addedSelectionCount).toBe(3)
+      })
     })
 
     describe('.addSelectionAbove()', () => {
@@ -2497,6 +2510,19 @@ describe('TextEditor', () => {
             [[9, 0], [9, 0]]
           ])
         })
+      })
+
+      it('does not create a new selection if it would be fully contained within another selection', () => {
+        editor.setText('abc\ndef\nghi\njkl\nmno')
+        editor.setCursorBufferPosition([4, 1])
+
+        let addedSelectionCount = 0
+        editor.onDidAddSelection(() => { addedSelectionCount++ })
+
+        editor.addSelectionAbove()
+        editor.addSelectionAbove()
+        editor.addSelectionAbove()
+        expect(addedSelectionCount).toBe(3)
       })
     })
 

--- a/src/selection.js
+++ b/src/selection.js
@@ -832,8 +832,12 @@ class Selection {
         if (clippedRange.isEmpty()) continue
       }
 
-      const selection = this.editor.addSelectionForScreenRange(clippedRange)
-      selection.setGoalScreenRange(range)
+      const containingSelections = this.editor.selectionsMarkerLayer.findMarkers({containsScreenRange: clippedRange})
+      if (containingSelections.length === 0) {
+        const selection = this.editor.addSelectionForScreenRange(clippedRange)
+        selection.setGoalScreenRange(range)
+      }
+
       break
     }
   }
@@ -854,8 +858,12 @@ class Selection {
         if (clippedRange.isEmpty()) continue
       }
 
-      const selection = this.editor.addSelectionForScreenRange(clippedRange)
-      selection.setGoalScreenRange(range)
+      const containingSelections = this.editor.selectionsMarkerLayer.findMarkers({containsScreenRange: clippedRange})
+      if (containingSelections.length === 0) {
+        const selection = this.editor.addSelectionForScreenRange(clippedRange)
+        selection.setGoalScreenRange(range)
+      }
+
       break
     }
   }


### PR DESCRIPTION
🍐'd with @nathansobo 

### Description of the Change

This pull request updates the "add selection below/above" command to only create new selections if they will not be contained within an existing selection.

### Benefits

Other than improving the performance of the above commands, this fixes https://github.com/atom/atom/issues/14622 by preventing the need to merge redundant intersecting selections, which was causing selections to be reversed when adding selections above.

### Alternate Designs

* Change the behavior of `mergeIntersectingSelections` to be smarter about the directionality of the resulting merged selections. However, those selections never needed to exist in the first place so we decided to ignore this path.
* Change `TextEditor.addSelectionForBufferRange` to re-use selections when the supplied range is contained by an existing selection. We decided to not go with this approach because of the risk of breaking public APIs.

### Possible Drawbacks

Unclear.

### Verification Process

See the reproduction steps at https://github.com/atom/atom/issues/14622.

### Applicable Issues

Fixes https://github.com/atom/atom/issues/14622.