### PR TITLE
If protocol handler set to never, unregister it on Windows

### DIFF
--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -59,7 +59,8 @@ module.exports = function (packagedAppPath) {
         relativePath === path.join('..', 'node_modules', 'tar', 'tar.js') ||
         relativePath === path.join('..', 'node_modules', 'temp', 'lib', 'temp.js') ||
         relativePath === path.join('..', 'node_modules', 'tmp', 'lib', 'tmp.js') ||
-        relativePath === path.join('..', 'node_modules', 'tree-sitter', 'index.js')
+        relativePath === path.join('..', 'node_modules', 'tree-sitter', 'index.js') ||
+        relativePath === path.join('..', 'node_modules', 'winreg', 'lib', 'registry.js')
       )
     }
   }).then((snapshotScript) => {

--- a/src/protocol-handler-installer.js
+++ b/src/protocol-handler-installer.js
@@ -11,10 +11,6 @@ class ProtocolHandlerInstaller {
     return ['win32', 'darwin'].includes(process.platform)
   }
 
-  isOldDefaultProtocolClient () {
-    return remote.app.isDefaultProtocolClient('atom', process.execPath, ['--uri-handler'])
-  }
-
   isDefaultProtocolClient () {
     return remote.app.isDefaultProtocolClient('atom', process.execPath, ['--uri-handler', '--'])
   }
@@ -25,32 +21,32 @@ class ProtocolHandlerInstaller {
     return this.isSupported() && remote.app.setAsDefaultProtocolClient('atom', process.execPath, ['--uri-handler', '--'])
   }
 
-  shouldUpgradeProtocolClient () {
-    // macOS and Linux ignore the last argument to `app.isDefaultProtocolClient`
-    // so we only need to upgrade the handler on Windows.
-    return process.platform === 'win32' && this.isOldDefaultProtocolClient()
-  }
-
   initialize (config, notifications) {
     if (!this.isSupported()) {
       return
     }
 
-    if (this.shouldUpgradeProtocolClient()) {
-      this.setAsDefaultProtocolClient()
-    } else if (!this.isDefaultProtocolClient()) {
-      const behaviorWhenNotProtocolClient = config.get(SETTING)
-      switch (behaviorWhenNotProtocolClient) {
-        case PROMPT:
+    const behaviorWhenNotProtocolClient = config.get(SETTING)
+    switch (behaviorWhenNotProtocolClient) {
+      case PROMPT:
+        if (!this.isDefaultProtocolClient()) {
           this.promptToBecomeProtocolClient(config, notifications)
-          break
-        case ALWAYS:
+        }
+        break
+      case ALWAYS:
+        if (!this.isDefaultProtocolClient()) {
           this.setAsDefaultProtocolClient()
-          break
-        case NEVER:
-        default:
-          // Do nothing
-      }
+        }
+        break
+      case NEVER:
+        if (process.platform === 'win32') {
+          // Only win32 supports deregistration
+          const Registry = require('winreg')
+          const commandKey = new Registry({hive: 'HKCR', key: `\\atom`})
+          commandKey.destroy((err, val) => { })
+        }
+      default:
+        // Do nothing
     }
   }
 

--- a/src/protocol-handler-installer.js
+++ b/src/protocol-handler-installer.js
@@ -43,8 +43,9 @@ class ProtocolHandlerInstaller {
           // Only win32 supports deregistration
           const Registry = require('winreg')
           const commandKey = new Registry({hive: 'HKCR', key: `\\atom`})
-          commandKey.destroy((err, val) => { })
+          commandKey.destroy((_err, _val) => { /* no op */ })
         }
+        break
       default:
         // Do nothing
     }


### PR DESCRIPTION
We should remove the protocol handler if never is set however the electron unregister does not appear to work so blow away the registry key instead.  This is only possible on Windows.