### PR TITLE
Fix two tree-sitter performance problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "sinon": "1.17.4",
     "temp": "^0.8.3",
     "text-buffer": "13.11.0",
-    "tree-sitter": "^0.8.4",
+    "tree-sitter": "^0.8.6",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",
     "winreg": "^1.2.1",

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -361,9 +361,8 @@ class TreeSitterHighlightIterator {
 
     var node = this.layer.document.rootNode
     var childIndex = -1
-    var done = false
     var nodeContainsTarget = true
-    do {
+    for (;;) {
       this.currentNode = node
       this.currentChildIndex = childIndex
       if (!nodeContainsTarget) break
@@ -380,18 +379,14 @@ class TreeSitterHighlightIterator {
         }
       }
 
-      done = true
-      for (var i = 0, {children} = node, childCount = children.length; i < childCount; i++) {
-        const child = children[i]
-        if (child.endIndex > this.currentIndex) {
-          node = child
-          childIndex = i
-          done = false
-          if (child.startIndex > this.currentIndex) nodeContainsTarget = false
-          break
-        }
+      node = node.firstChildForIndex(this.currentIndex)
+      if (node) {
+        if (node.startIndex > this.currentIndex) nodeContainsTarget = false
+        childIndex = node.childIndex
+      } else {
+        break
       }
-    } while (!done)
+    }
 
     return containingTags
   }


### PR DESCRIPTION
Fixes #16517

This PR fixes two performance problems we've observed when [the new `core.useTreeSitterParsers` feature flag](https://github.com/atom/atom/pull/16299) is enabled.

1. https://github.com/atom/atom/issues/16517. For certain types of syntax errors, the parser would accidentally try thousands of different error recoveries due to a gap in Tree-sitter's logic for limiting the effort spent on error recovery. I've addressed that gap in https://github.com/tree-sitter/tree-sitter/commit/dafa897021b12a23bb55042c6ef3748f5e807b37.

2. When editing large files, the `TreeSitterHighlightIterator.seek` method spent a lot of time iterating through long lists of syntax nodes looking for the node that contains a given character index in the document. In https://github.com/tree-sitter/tree-sitter/pull/123, I've added a new native API for quickly finding that node: `ASTNode.firstChildForIndex`.

There are still bugs and performance issues when using the new parsing system which I plan to address next month, but these two were particularly egregious.
  