### PR TITLE
Elevate installation step for Linux during 'script/build --install'

### DIFF
--- a/script/build
+++ b/script/build
@@ -129,7 +129,13 @@ binariesPromise
     }
 
     if (argv.install != null) {
-      installApplication(packagedAppPath, argv.install)
+      if (process.platform === 'linux') {
+        // Execute the Linux install step with sudo
+        console.log('Installing Atom using sudo, please enter your password!'.yellow)
+        require('child_process').execSync("sudo node -e \"require('./script/lib/install-application')('" + packagedAppPath + "', '" + argv.install + "')\"", { stdio:[0,1,2] });
+      } else {
+        installApplication(packagedAppPath, argv.install)
+      }
     } else {
       console.log('Skipping installation. Specify the --install option to install Atom'.gray)
     }


### PR DESCRIPTION
### Description of the Change

This change fixes #14848 which reports that running 'script/build --install' on Linux
fails with permissions errors.  This happens because the user is advised to run the
build script as a normal user (without sudo) because the script does not work when
run as sudo.

The solution is to use ChildProcess.execSync to invoke Node.js to call into our
installation code with sudo permissions just at the point where installation is
needed.  Windows and macOS paths do not receive similar elevation since it isn't
needed on those platforms.

This change also fixes #7134.

### Alternate Designs

This was the most expedient choice that does not break the current installation experience and documentation for Linux users.

One possible alternative I considered is to introduce a `scripts/install` script which can be run by the user with `sudo scripts/install` to take care of the installation step.  This is a perfectly viable option but would require some code reuse between the build and install scripts so that relevant information (like the build output path for the platform) can be reused.  If people think this is a better option I am happy to create a PR with that approach instead.

### Why Should This Be In Core?

It's part of our standard build script.

### Benefits

Enables Linux users to install developer builds of Atom without having to use hacky extra steps.

### Possible Drawbacks

The means with which I run the installation step as `sudo` may carry security implications.  Would definitely appreciate feedback on this aspect.

### Verification Process

I tested these changes on my Fedora Linux 27 machine, they work as expected.  The user is prompted for their credentials, and once entered, the Atom artifacts get installed in `/usr/local/share/atom` as intended.

### Applicable Issues

#14848
#7134
