### PR TITLE
Fix race condition between opening new files and restoring window state

### DIFF
--- a/spec/atom-environment-spec.js
+++ b/spec/atom-environment-spec.js
@@ -1,5 +1,6 @@
 const {it, fit, ffit, beforeEach, afterEach, conditionPromise} = require('./async-spec-helpers')
 const _ = require('underscore-plus')
+const fs = require('fs')
 const path = require('path')
 const temp = require('temp').track()
 const AtomEnvironment = require('../src/atom-environment')
@@ -471,15 +472,28 @@ describe('AtomEnvironment', () => {
         await atom.workspace.open()
       })
 
-      it('automatically restores the saved state into the current environment', () => {
-        const state = {}
-        spyOn(atom.workspace, 'open')
-        spyOn(atom, 'restoreStateIntoThisEnvironment')
+      it('automatically restores the saved state into the current environment', async () => {
+        const projectPath = temp.mkdirSync()
+        const filePath1 = path.join(projectPath, 'file-1')
+        const filePath2 = path.join(projectPath, 'file-2')
+        const filePath3 = path.join(projectPath, 'file-3')
+        fs.writeFileSync(filePath1, 'abc')
+        fs.writeFileSync(filePath2, 'def')
+        fs.writeFileSync(filePath3, 'ghi')
 
-        atom.attemptRestoreProjectStateForPaths(state, [__dirname], [__filename])
-        expect(atom.restoreStateIntoThisEnvironment).toHaveBeenCalledWith(state)
-        expect(atom.workspace.open.callCount).toBe(1)
-        expect(atom.workspace.open).toHaveBeenCalledWith(__filename)
+        const env1 = new AtomEnvironment({applicationDelegate: atom.applicationDelegate})
+        env1.project.setPaths([projectPath])
+        await env1.workspace.open(filePath1)
+        await env1.workspace.open(filePath2)
+        await env1.workspace.open(filePath3)
+        const env1State = env1.serialize()
+        env1.destroy()
+
+        const env2 = new AtomEnvironment({applicationDelegate: atom.applicationDelegate})
+        await env2.attemptRestoreProjectStateForPaths(env1State, [projectPath], [filePath2])
+        const restoredURIs = env2.workspace.getPaneItems().map(p => p.getURI())
+        expect(restoredURIs).toEqual([filePath1, filePath2, filePath3])
+        env2.destroy()
       })
 
       describe('when a dock has a non-text editor', () => {

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -1121,7 +1121,7 @@ class AtomEnvironment {
     }
 
     if (windowIsUnused()) {
-      this.restoreStateIntoThisEnvironment(state)
+      await this.restoreStateIntoThisEnvironment(state)
       return Promise.all(filesToOpen.map(file => this.workspace.open(file)))
     } else {
       let resolveDiscardStatePromise = null

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -373,7 +373,7 @@ class AtomEnvironment {
     if (this.project) this.project.destroy()
     this.project = null
     this.commands.clear()
-    this.stylesElement.remove()
+    if (this.stylesElement) this.stylesElement.remove()
     this.config.unobserveUserConfig()
     this.autoUpdater.destroy()
     this.uriHandlerRegistry.destroy()


### PR DESCRIPTION
### Description of the Change

This pull request fixes a race condition in the `attemptRestoreProjectStateForPaths` function that could cause a file to be opened more than once within the same workspace pane.

In particular, when opening some file into an empty window, Atom tries to recover the state for the project containing the file (if there is one). However, we were previously not waiting until the `AtomEnvironment`'s state had been fully deserialized before trying to load the requested file into the workspace. If the same file also existed in the serialized representation of the workspace, it could end up being opened twice.

With this pull request we will now wait until the environment has been fully deserialized before honoring the user's request of loading new files into an empty window.

### Alternate Designs

None.

### Benefits

Other than fixing https://github.com/atom/atom/issues/16364, these changes also improve tests, which now verify more thoroughly the behavior of `attemptRestoreProjectStateForPaths`.

### Possible Drawbacks

None.

### Verification Process

See reproduction steps in https://github.com/atom/atom/issues/16364.

### Applicable Issues

Fixes https://github.com/atom/atom/issues/16364