### PR TITLE
Teach AppVeyor to run installer task for master branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ build_script:
         ECHO Building on release branch - Creating production artifacts &&
         script\build.cmd --code-sign --compress-artifacts --create-windows-installer
       ) ELSE (
-        IF [%APPVEYOR_REPO_BRANCH%]==[master] (
+        IF [%APPVEYOR_REPO_BRANCH%]==[master] IF NOT DEFINED [%APPVEYOR_PULL_REQUEST_NUMBER%] (
           ECHO Building on master branch - Creating signed zips &&
           script\build.cmd --code-sign --compress-artifacts
         ) ELSE (

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,8 @@ build_script:
   - CD %APPVEYOR_BUILD_FOLDER%
   - IF NOT EXIST C:\tmp MKDIR C:\tmp
   - SET SQUIRREL_TEMP=C:\tmp
+  - ECHO APPVEYOR_REPO_BRANCH is '%APPVEYOR_REPO_BRANCH'
+  - ECHO APPVEYOR_PULL_REQUEST_NUMBER is '%APPVEYOR_PULL_REQUEST_NUMBER%'
   - IF [%TASK%]==[installer] (
       IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] (
         ECHO Building on release branch - Creating production artifacts &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,8 +50,7 @@ build_script:
           ECHO Building on master branch - Creating signed zips &&
           script\build.cmd --code-sign --compress-artifacts
         ) ELSE (
-          ECHO Building on non-master branch - Creating unsigned zips &&
-          script\build.cmd --compress-artifacts
+          ECHO Skipping installer build for non-release/non-master branch
         )
       )
     ) ELSE (

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,11 @@ build_script:
       IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] (
         script\build.cmd --code-sign --compress-artifacts --create-windows-installer
       ) ELSE (
-        ECHO Skipping installer and Atom build on non-release branch
+        IF [%APPVEYOR_REPO_BRANCH%]==[master] (
+          script\build.cmd --code-sign --compress-artifacts --create-windows-installer
+        ) ELSE (
+          ECHO Skipping installer and Atom build on non-release branch
+        )
       )
     ) ELSE (
       ECHO Skipping installer build on non-installer build matrix row &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,17 +43,20 @@ build_script:
   - SET SQUIRREL_TEMP=C:\tmp
   - IF [%TASK%]==[installer] (
       IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] (
+        ECHO Building on release branch - Creating production artifacts
         script\build.cmd --code-sign --compress-artifacts --create-windows-installer
       ) ELSE (
         IF [%APPVEYOR_REPO_BRANCH%]==[master] (
-          script\build.cmd --code-sign --compress-artifacts --create-windows-installer
+          ECHO Building on master branch - Creating signed zips
+          script\build.cmd --code-sign --compress-artifacts
         ) ELSE (
-          ECHO Skipping installer and Atom build on non-release branch
+          ECHO Building on non-master branch - Creating unsigned zips
+          script\build.cmd --compress-artifacts
         )
       )
     ) ELSE (
-      ECHO Skipping installer build on non-installer build matrix row &&
-      script\build.cmd --code-sign --compress-artifacts
+      ECHO Test build only - Not creating artifacts
+      script\build.cmd
     )
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,19 +43,19 @@ build_script:
   - SET SQUIRREL_TEMP=C:\tmp
   - IF [%TASK%]==[installer] (
       IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] (
-        ECHO Building on release branch - Creating production artifacts
+        ECHO Building on release branch - Creating production artifacts &&
         script\build.cmd --code-sign --compress-artifacts --create-windows-installer
       ) ELSE (
         IF [%APPVEYOR_REPO_BRANCH%]==[master] (
-          ECHO Building on master branch - Creating signed zips
+          ECHO Building on master branch - Creating signed zips &&
           script\build.cmd --code-sign --compress-artifacts
         ) ELSE (
-          ECHO Building on non-master branch - Creating unsigned zips
+          ECHO Building on non-master branch - Creating unsigned zips &&
           script\build.cmd --compress-artifacts
         )
       )
     ) ELSE (
-      ECHO Test build only - Not creating artifacts
+      ECHO Test build only - Not creating artifacts &&
       script\build.cmd
     )
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,8 @@ matrix:
       TASK: test
 
 install:
+  - ECHO APPVEYOR_REPO_BRANCH is '%APPVEYOR_REPO_BRANCH%'
+  - ECHO APPVEYOR_PULL_REQUEST_NUMBER is '%APPVEYOR_PULL_REQUEST_NUMBER%'
   - IF NOT EXIST %TEST_JUNIT_XML_ROOT% MKDIR %TEST_JUNIT_XML_ROOT%
   - SET PATH=C:\Program Files\Atom\resources\cli;%PATH%
   - ps: Install-Product node $env:NODE_VERSION $env:PLATFORM
@@ -41,8 +43,6 @@ build_script:
   - CD %APPVEYOR_BUILD_FOLDER%
   - IF NOT EXIST C:\tmp MKDIR C:\tmp
   - SET SQUIRREL_TEMP=C:\tmp
-  - ECHO APPVEYOR_REPO_BRANCH is '%APPVEYOR_REPO_BRANCH'
-  - ECHO APPVEYOR_PULL_REQUEST_NUMBER is '%APPVEYOR_PULL_REQUEST_NUMBER%'
   - IF [%TASK%]==[installer] (
       IF [%APPVEYOR_REPO_BRANCH:~-9%]==[-releases] (
         ECHO Building on release branch - Creating production artifacts &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ build_script:
         ECHO Building on release branch - Creating production artifacts &&
         script\build.cmd --code-sign --compress-artifacts --create-windows-installer
       ) ELSE (
-        IF [%APPVEYOR_REPO_BRANCH%]==[master] IF NOT DEFINED [%APPVEYOR_PULL_REQUEST_NUMBER%] (
+        IF [%APPVEYOR_REPO_BRANCH%]==[master] IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER (
           ECHO Building on master branch - Creating signed zips &&
           script\build.cmd --code-sign --compress-artifacts
         ) ELSE (

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,8 +32,6 @@ matrix:
       TASK: test
 
 install:
-  - ECHO APPVEYOR_REPO_BRANCH is '%APPVEYOR_REPO_BRANCH%'
-  - ECHO APPVEYOR_PULL_REQUEST_NUMBER is '%APPVEYOR_PULL_REQUEST_NUMBER%'
   - IF NOT EXIST %TEST_JUNIT_XML_ROOT% MKDIR %TEST_JUNIT_XML_ROOT%
   - SET PATH=C:\Program Files\Atom\resources\cli;%PATH%
   - ps: Install-Product node $env:NODE_VERSION $env:PLATFORM


### PR DESCRIPTION
### Motivation

We'd like to add support for a "dev" release channel (in addition to the beta and stable release channels). The dev channel would represent the latest successful build on the master branch.

The primary goal is to make it easy to run a package's CI suite against the current Atom master branch to detect potential issues early, as opposed to only discovering issues after master branch is promoted to the next beta release. For example, if teletype's CI suite periodically ran teletype's tests against an Atom dev channel, it would have automatically exposed the issue in https://github.com/atom/teletype/issues/300, instead of us having to manually discover that issue. 😅 

### Making it happen

For macOS on Circle CI, and rpm and debian on Travis CI, we're already producing the necessary build artifacts to support a dev channel.

For Windows on AppVeyor, the installer task produces the build artifacts that we need ([x64 example](https://ci.appveyor.com/project/Atom/atom/build/9355/job/g0vwhhtj59nv283q/artifacts), [x86 example](https://ci.appveyor.com/project/Atom/atom/build/9355/job/wypnj96kr308iioo/artifacts)). As of https://github.com/atom/atom/pull/15208, we only run the installer task on release branches (e.g., `1.23-releases`). We skip the installer task on all other branches, including master. As a result, our builds on the master branch don't provide the necessary artifacts for a dev channel (e.g., [x64 example](https://ci.appveyor.com/project/Atom/atom/build/9371/job/egys9532ba9c59x3/artifacts), [x86 example](https://ci.appveyor.com/project/Atom/atom/build/9371/job/egys9532ba9c59x3/artifacts)).

In addition to running the installer task on release branches, **this pull request aims to update the AppVeyor build to also run the installer task on the master branch.**
