### PR TITLE
Fix includeNonWordCharacters regression in Cursor

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -524,7 +524,7 @@ class Cursor extends Model {
       : new Range(new Point(position.row, 0), position)
 
     const ranges = this.editor.buffer.findAllInRangeSync(
-      options.wordRegex || this.wordRegExp(),
+      options.wordRegex || this.wordRegExp(options),
       scanRange
     )
 
@@ -556,7 +556,7 @@ class Cursor extends Model {
       : new Range(position, new Point(position.row, Infinity))
 
     const ranges = this.editor.buffer.findAllInRangeSync(
-      options.wordRegex || this.wordRegExp(),
+      options.wordRegex || this.wordRegExp(options),
       scanRange
     )
 


### PR DESCRIPTION
### Description of the Change

https://github.com/atom/atom/commit/43aa3c788fd10fe9879f1cf27d37d94df855d276 (https://github.com/atom/atom/pull/15776) broke `includeNonWordCharacters` functionality of `Cursor#getBeginningOfCurrentWordBufferPosition` and `Cursor#getEndOfCurrentWordBufferPosition`. I fixed that regression.

NOTE: There are no tests here. There are no tests of `Cursor` that I can see. I would be happy to add some tests to cover the `includeNonWordCharacters` functionality, but I could use some guidance (or an example?) on how to use/clean up after using `atom.workspace`, etc.

### Alternate Designs

Alternate designs would require needless refactoring. I just made the call to `#wordRegExp` look like it did before (i.e., it should be passed `options`).

### Why Should This Be In Core?

It was broken in core.

### Benefits

The regression of `includeNonWordCharacters` functionality will be resolved.

### Possible Drawbacks

I don't see any possible drawbacks of the change.

### Verification Process

I used [sublime-word-navigation](https://github.com/rosston/sublime-word-navigation-atom) to verify that the bug was fixed. That package uses `includeNonWordCharacters` for both [beginning](https://github.com/rosston/sublime-word-navigation-atom/blob/3ac1b9fba655494b9357ca372de7cbfbb057e6c2/lib/sublime-word-navigation.coffee#L33) and [end](https://github.com/rosston/sublime-word-navigation-atom/blob/3ac1b9fba655494b9357ca372de7cbfbb057e6c2/lib/sublime-word-navigation.coffee#L45) of word movement. With that package installed, I:
* typed `foo-bar-baz-qux` into a buffer
* set the cursor at the end of the buffer: `foo-bar-baz-qux|`
* _twice_ hit alt+left arrow (on macOS, adjust your word-by-word navigation shortcut by platform)

Without this fix in place, the cursor is after baz: `foo-bar-baz|-qux`
With this fix in place (and in Atom < 1.23.0), the cursor is in front of baz: `foo-bar-|baz-qux`

I did not verify that this change doesn't introduce any regressions. I am reverting a call back to what it was previously (passing in `options`), so I'm not very worried about regressions.

### Applicable Issues

None
