### PR TITLE
Link spec for finding icon dir in install script

### DIFF
--- a/script/lib/install-application.js
+++ b/script/lib/install-application.js
@@ -19,6 +19,13 @@ function install (installationDirPath, packagedAppFileName, packagedAppPath) {
   fs.copySync(packagedAppPath, installationDirPath)
 }
 
+/**
+ * Finds the path to the base directory of the icon default icon theme
+ * This follows the freedesktop Icon Theme Specification:
+ * https://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#install_icons
+ * and the XDG Base Directory Specification:
+ * https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables
+ */
 function findBaseIconThemeDirPath () {
   const defaultBaseIconThemeDir = '/usr/share/icons/hicolor'
   const dataDirsString = process.env.XDG_DATA_DIRS


### PR DESCRIPTION
This is a follow up of #15498

### Description of the Change

Adds a comment that links to the relevant specification for a function.

### Alternate Designs

None

### Why Should This Be In Core?

The documented function is in core

### Benefits

Future changes are more likely to be in line with the spec too

### Possible Drawbacks

None

### Verification Process

None

### Applicable Issues

None
