### PR TITLE
Restore selectionsMarkerLayer of different editor

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -5193,6 +5193,111 @@ describe('TextEditor', () => {
       })
     })
 
+    describe('undo/redo restore selections of editor which initiated original change', () => {
+      let editor1, editor2
+
+      beforeEach(async () => {
+        editor1 = editor
+        editor2 = new TextEditor({buffer: editor1.buffer})
+
+        editor1.setText(dedent `
+          aaaaaa
+          bbbbbb
+          cccccc
+          dddddd
+          eeeeee
+        `)
+      })
+
+      it('[editor.transact] restore selection of change-initiated-editor', async () => {
+        editor1.setCursorBufferPosition([0, 0]); editor1.transact(() => editor1.insertText('1'))
+        editor2.setCursorBufferPosition([1, 0]); editor2.transact(() => editor2.insertText('2'))
+        editor1.setCursorBufferPosition([2, 0]); editor1.transact(() => editor1.insertText('3'))
+        editor2.setCursorBufferPosition([3, 0]); editor2.transact(() => editor2.insertText('4'))
+
+        expect(editor1.getText()).toBe(dedent `
+          1aaaaaa
+          2bbbbbb
+          3cccccc
+          4dddddd
+          eeeeee
+        `)
+
+        editor2.setCursorBufferPosition([4, 0])
+        editor1.undo(); expect(editor1.getCursorBufferPosition()).toEqual([3, 0])
+        editor1.undo(); expect(editor1.getCursorBufferPosition()).toEqual([2, 0])
+        editor1.undo(); expect(editor1.getCursorBufferPosition()).toEqual([1, 0])
+        editor1.undo(); expect(editor1.getCursorBufferPosition()).toEqual([0, 0])
+        expect(editor2.getCursorBufferPosition()).toEqual([4, 0]) // remain unchanged
+
+        editor1.redo(); expect(editor1.getCursorBufferPosition()).toEqual([0, 1])
+        editor1.redo(); expect(editor1.getCursorBufferPosition()).toEqual([1, 1])
+        editor1.redo(); expect(editor1.getCursorBufferPosition()).toEqual([2, 1])
+        editor1.redo(); expect(editor1.getCursorBufferPosition()).toEqual([3, 1])
+        expect(editor2.getCursorBufferPosition()).toEqual([4, 0]) // remain unchanged
+
+        editor1.setCursorBufferPosition([4, 0])
+        editor2.undo(); expect(editor2.getCursorBufferPosition()).toEqual([3, 0])
+        editor2.undo(); expect(editor2.getCursorBufferPosition()).toEqual([2, 0])
+        editor2.undo(); expect(editor2.getCursorBufferPosition()).toEqual([1, 0])
+        editor2.undo(); expect(editor2.getCursorBufferPosition()).toEqual([0, 0])
+        expect(editor1.getCursorBufferPosition()).toEqual([4, 0]) // remain unchanged
+
+        editor2.redo(); expect(editor2.getCursorBufferPosition()).toEqual([0, 1])
+        editor2.redo(); expect(editor2.getCursorBufferPosition()).toEqual([1, 1])
+        editor2.redo(); expect(editor2.getCursorBufferPosition()).toEqual([2, 1])
+        editor2.redo(); expect(editor2.getCursorBufferPosition()).toEqual([3, 1])
+        expect(editor1.getCursorBufferPosition()).toEqual([4, 0]) // remain unchanged
+      })
+
+      it('[manually group checkpoint] restore selection of change-initiated-editor', async () => {
+        const transact = (editor, fn) => {
+          const checkpoint = editor.createCheckpoint()
+          fn()
+          editor.groupChangesSinceCheckpoint(checkpoint)
+        }
+
+        editor1.setCursorBufferPosition([0, 0]); transact(editor1, () => editor1.insertText('1'))
+        editor2.setCursorBufferPosition([1, 0]); transact(editor2, () => editor2.insertText('2'))
+        editor1.setCursorBufferPosition([2, 0]); transact(editor1, () => editor1.insertText('3'))
+        editor2.setCursorBufferPosition([3, 0]); transact(editor2, () => editor2.insertText('4'))
+
+        expect(editor1.getText()).toBe(dedent `
+          1aaaaaa
+          2bbbbbb
+          3cccccc
+          4dddddd
+          eeeeee
+        `)
+
+        editor2.setCursorBufferPosition([4, 0])
+        editor1.undo(); expect(editor1.getCursorBufferPosition()).toEqual([3, 0])
+        editor1.undo(); expect(editor1.getCursorBufferPosition()).toEqual([2, 0])
+        editor1.undo(); expect(editor1.getCursorBufferPosition()).toEqual([1, 0])
+        editor1.undo(); expect(editor1.getCursorBufferPosition()).toEqual([0, 0])
+        expect(editor2.getCursorBufferPosition()).toEqual([4, 0]) // remain unchanged
+
+        editor1.redo(); expect(editor1.getCursorBufferPosition()).toEqual([0, 1])
+        editor1.redo(); expect(editor1.getCursorBufferPosition()).toEqual([1, 1])
+        editor1.redo(); expect(editor1.getCursorBufferPosition()).toEqual([2, 1])
+        editor1.redo(); expect(editor1.getCursorBufferPosition()).toEqual([3, 1])
+        expect(editor2.getCursorBufferPosition()).toEqual([4, 0]) // remain unchanged
+
+        editor1.setCursorBufferPosition([4, 0])
+        editor2.undo(); expect(editor2.getCursorBufferPosition()).toEqual([3, 0])
+        editor2.undo(); expect(editor2.getCursorBufferPosition()).toEqual([2, 0])
+        editor2.undo(); expect(editor2.getCursorBufferPosition()).toEqual([1, 0])
+        editor2.undo(); expect(editor2.getCursorBufferPosition()).toEqual([0, 0])
+        expect(editor1.getCursorBufferPosition()).toEqual([4, 0]) // remain unchanged
+
+        editor2.redo(); expect(editor2.getCursorBufferPosition()).toEqual([0, 1])
+        editor2.redo(); expect(editor2.getCursorBufferPosition()).toEqual([1, 1])
+        editor2.redo(); expect(editor2.getCursorBufferPosition()).toEqual([2, 1])
+        editor2.redo(); expect(editor2.getCursorBufferPosition()).toEqual([3, 1])
+        expect(editor1.getCursorBufferPosition()).toEqual([4, 0]) // remain unchanged
+      })
+    })
+
     describe('when the buffer is changed (via its direct api, rather than via than edit session)', () => {
       it('moves the cursor so it is in the same relative position of the buffer', () => {
         expect(editor.getCursorScreenPosition()).toEqual([0, 0])

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -5209,7 +5209,7 @@ describe('TextEditor', () => {
         `)
       })
 
-      it('[editor.transact] restore selection of change-initiated-editor', async () => {
+      it('[editor.transact] restore selection of change-initiated-editor', () => {
         editor1.setCursorBufferPosition([0, 0]); editor1.transact(() => editor1.insertText('1'))
         editor2.setCursorBufferPosition([1, 0]); editor2.transact(() => editor2.insertText('2'))
         editor1.setCursorBufferPosition([2, 0]); editor1.transact(() => editor1.insertText('3'))
@@ -5250,7 +5250,7 @@ describe('TextEditor', () => {
         expect(editor1.getCursorBufferPosition()).toEqual([4, 0]) // remain unchanged
       })
 
-      it('[manually group checkpoint] restore selection of change-initiated-editor', async () => {
+      it('[manually group checkpoint] restore selection of change-initiated-editor', () => {
         const transact = (editor, fn) => {
           const checkpoint = editor.createCheckpoint()
           fn()


### PR DESCRIPTION
### Description of the Change

Aiming  to fix: atom/atom#16176
Depends https://github.com/atom/text-buffer/pull/287

- Register `this.selectionsMarkerLayerId` to `buffer` on instantiation
- Pass `selectionsMarkerLayerId` on transact/undo/redo/createCheckpoint/groupChangesSinceCheckpoint


## Scenario this PR intends

- When same buffer is opened in two editor(editor1 and editor2).
- And make multiple changes sometimes on editor1 and sometimes on editor2.
- Then undo/redo.

#### Before This PR

Undo/redo restore selection(= cursor) snapshotted on that editor.

![before2](https://user-images.githubusercontent.com/155205/37705114-47c34ba4-2d3e-11e8-9064-2b20e4c9c97d.gif)

#### After this PR

Undo/redo restore selection(= cursor) snapshotted on change initiated editor.

![after2](https://user-images.githubusercontent.com/155205/37705117-4c348072-2d3e-11e8-8df9-7d89856a9882.gif)

### Alternate Designs

I don't know

### Why Should This Be In Core?

Since we cannot fix this on user side(init script/packages).

### Benefits

User can see textual change when undo/redo where multiple editors which shares same buffer instance were opened.

### Possible Drawbacks

Add some complexity, adding text-editor specific code onto text-buffer's core.

### Verification Process

#### Scenario Which I want to fix(or improve)

Open multiple text-editors which shares same buffer

##### Condition

- Open `editor1`, make **change-1**
- Open `editor2` by copying `editor1`, make **change-2**
- Open `editor3` by copying `editor2`, make **change-3**
- Now `editor1`, `editor2`, `editor3` shares same buffer instance and have distinct selectionsMarkerLayer which is used to keep distinct cursors

##### Current behavior

- Undo on `editor1`, `editor1`'s cursor is not restored to **point-of-before-change-3**.
- Undo on `editor2`, `editor2`'s cursor is restored to **point-of-before-change-2**, since `editor2` is same editor where **change-2** was made.
- Undo on `editor3`, `editor3`'s cursor is not restored to **point-of-before-change-1**.
- Open `editor4` by copying `editor3` and then destroy `editor1`, `editor2`, `editor3`
- Undoing/Redoing on `editor4` only undo/redo textual changes, but cursor is not restored, and not scrolled to textual changes, because `selectionsMarkerLayer` is not shared across editors.

##### New behavior

NOTE: Require changes' in atom's text-editor to use new machanism

- Undo on `editor1`, `editor1`'s cursor is restored to **point-of-before-change-3** by restoring marker snapshot taken on `editor3`'s selectionsMarkerLayer to `editor1`.
- Undo on `editor2`, `editor2`'s cursor is restored to **point-of-before-change-2**.
- Undo on `editor3`, `editor3`'s cursor is restored to **point-of-before-change-1**.
- Open `editor4` by copying `editor3` and then destroy `editor1`, `editor2`, `editor3`
- Undoing/Redoing on `editor4` does undo/redo textual changes, and cursor is restored to each snapshot-ed point when change was made, because when undo/redo `selectionsMarkerLayer` is restored from different `selectionsMarkerLayer` which shares same buffer.

### Applicable Issues

https://github.com/atom/atom/issues/16176
