### PR TITLE
Null guard auto-prefixing of `.` to scopes for backward compatibility

### DIFF
--- a/src/scope-descriptor.coffee
+++ b/src/scope-descriptor.coffee
@@ -41,7 +41,7 @@ class ScopeDescriptor
   getScopeChain: ->
     # For backward compatibility, prefix TextMate-style scope names with
     # leading dots (e.g. 'source.js' -> '.source.js').
-    if @scopes[0].includes('.')
+    if @scopes[0]?.includes('.')
       result = ''
       for scope, i in @scopes
         result += ' ' if i > 0


### PR DESCRIPTION
Previously, each scope name in a scope descriptor was automatically prefixed with a leading `.` in order to normalize TextMate-style scope names such as `sourc.js` that come out of TextMate grammars to Atom-style scope names `.source.js`. This wasn't the right place to perform this normalization, but details ended up leaking into public APIs, and normalizing it sooner would have caused breakage.

In https://github.com/atom/atom/pull/16299, we added some code to avoid prefixing elements of scope selectors with a leading `.` unless they already contain a `.` in the first element of the descriptor. This was to allow TreeSitter scopes to be individual tokens that don't contain any dots for simplicity.

Unfortunately, in some cases, packages such as atom-beautify pass [empty scope descriptors](https://github.com/Glavin001/atom-beautify/blob/d9b71cfe94195c88db134fe9589ebfefd635cf0e/src/options.json#L1957) to `atom.config.get`. #16299 assumes descriptors always have a first element, causing breakage. This PR adds a simple guard against that situation.

Fixes #16540.