### PR TITLE
`[ci skip]` must be in the title for Appveyor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,7 @@ Atom Core and all packages can be developed locally. For instructions on how to 
 * Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
 * Limit the first line to 72 characters or less
 * Reference issues and pull requests liberally after the first line
-* When only changing documentation, include `[ci skip]` in the commit description
+* When only changing documentation, include `[ci skip]` in the commit title
 * Consider starting the commit message with an applicable emoji:
     * :art: `:art:` when improving the format/structure of the code
     * :racehorse: `:racehorse:` when improving performance


### PR DESCRIPTION
Unfortunately, Appveyor stands out from Travis and CircleCI in that it [requires](https://www.appveyor.com/docs/how-to/filtering-commits/#skip-directive-in-commit-message) the `[ci skip]` directive to be in the commit title, rather than anywhere in the commit message.