### PR TITLE
Stop using Babel in Atom Core (benchmarks, exports, src)

### DIFF
--- a/exports/atom.js
+++ b/exports/atom.js
@@ -1,13 +1,12 @@
-/** @babel */
-
-import TextBuffer, {Point, Range} from 'text-buffer'
-import {File, Directory} from 'pathwatcher'
-import {Emitter, Disposable, CompositeDisposable} from 'event-kit'
-import BufferedNodeProcess from '../src/buffered-node-process'
-import BufferedProcess from '../src/buffered-process'
-import GitRepository from '../src/git-repository'
-import Notification from '../src/notification'
-import {watchPath} from '../src/path-watcher'
+const TextBuffer = require('text-buffer')
+const {Point, Range} = TextBuffer
+const {File, Directory} = require('pathwatcher')
+const {Emitter, Disposable, CompositeDisposable} = require('event-kit')
+const BufferedNodeProcess = require('../src/buffered-node-process')
+const BufferedProcess = require('../src/buffered-process')
+const GitRepository = require('../src/git-repository')
+const Notification = require('../src/notification')
+const {watchPath} = require('../src/path-watcher')
 
 const atomExport = {
   BufferedNodeProcess,
@@ -42,4 +41,4 @@ if (process.type === 'renderer') {
   atomExport.TextEditor = require('../src/text-editor')
 }
 
-export default atomExport
+module.exports = atomExport

--- a/script/lib/transpile-babel-paths.js
+++ b/script/lib/transpile-babel-paths.js
@@ -16,9 +16,6 @@ module.exports = function () {
 
 function getPathsToTranspile () {
   let paths = []
-  paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'benchmarks', '**', '*.js'), {nodir: true}))
-  paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'exports', '**', '*.js'), {nodir: true}))
-  paths = paths.concat(glob.sync(path.join(CONFIG.intermediateAppPath, 'src', '**', '*.js'), {nodir: true}))
   for (let packageName of Object.keys(CONFIG.appMetadata.packageDependencies)) {
     paths = paths.concat(glob.sync(
       path.join(CONFIG.intermediateAppPath, 'node_modules', packageName, '**', '*.js'),

--- a/src/atom-paths.js
+++ b/src/atom-paths.js
@@ -1,5 +1,3 @@
-/** @babel */
-
 const fs = require('fs-plus')
 const path = require('path')
 

--- a/src/auto-update-manager.js
+++ b/src/auto-update-manager.js
@@ -1,8 +1,7 @@
-'use babel'
+const {Emitter, CompositeDisposable} = require('event-kit')
 
-import {Emitter, CompositeDisposable} from 'event-kit'
-
-export default class AutoUpdateManager {
+module.exports =
+class AutoUpdateManager {
   constructor ({applicationDelegate}) {
     this.applicationDelegate = applicationDelegate
     this.subscriptions = new CompositeDisposable()

--- a/src/buffered-node-process.js
+++ b/src/buffered-node-process.js
@@ -1,6 +1,4 @@
-/** @babel */
-
-import BufferedProcess from './buffered-process'
+const BufferedProcess = require('./buffered-process')
 
 // Extended: Like {BufferedProcess}, but accepts a Node script as the command
 // to run.
@@ -12,7 +10,8 @@ import BufferedProcess from './buffered-process'
 // ```js
 //   const {BufferedNodeProcess} = require('atom')
 // ```
-export default class BufferedNodeProcess extends BufferedProcess {
+module.exports =
+class BufferedNodeProcess extends BufferedProcess {
 
   // Public: Runs the given Node script by spawning a new child process.
   //

--- a/src/buffered-process.js
+++ b/src/buffered-process.js
@@ -1,9 +1,7 @@
-/** @babel */
-
-import _ from 'underscore-plus'
-import ChildProcess from 'child_process'
-import {Emitter} from 'event-kit'
-import path from 'path'
+const _ = require('underscore-plus')
+const ChildProcess = require('child_process')
+const {Emitter} = require('event-kit')
+const path = require('path')
 
 // Extended: A wrapper which provides standard error/output line buffering for
 // Node's ChildProcess.
@@ -19,7 +17,8 @@ import path from 'path'
 // const exit = (code) => console.log("ps -ef exited with #{code}")
 // const process = new BufferedProcess({command, args, stdout, exit})
 // ```
-export default class BufferedProcess {
+module.exports =
+class BufferedProcess {
   /*
   Section: Construction
   */

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -1,7 +1,5 @@
-/** @babel */
-
-import crypto from 'crypto'
-import clipboard from './safe-clipboard'
+const crypto = require('crypto')
+const clipboard = require('./safe-clipboard')
 
 // Extended: Represents the clipboard used for copying and pasting in Atom.
 //
@@ -14,7 +12,8 @@ import clipboard from './safe-clipboard'
 //
 // console.log(atom.clipboard.read()) # 'hello'
 // ```
-export default class Clipboard {
+module.exports =
+class Clipboard {
   constructor () {
     this.reset()
   }

--- a/src/color.js
+++ b/src/color.js
@@ -1,10 +1,9 @@
-/** @babel */
-
 let ParsedColor = null
 
 // Essential: A simple color class returned from {Config::get} when the value
 // at the key path is of type 'color'.
-export default class Color {
+module.exports =
+class Color {
   // Essential: Parse a {String} or {Object} into a {Color}.
   //
   // * `value` A {String} such as `'white'`, `#ff00ff`, or

--- a/src/deserializer-manager.js
+++ b/src/deserializer-manager.js
@@ -1,6 +1,4 @@
-/** @babel */
-
-import {Disposable} from 'event-kit'
+const {Disposable} = require('event-kit')
 
 // Extended: Manages the deserializers used for serialized state
 //
@@ -21,7 +19,8 @@ import {Disposable} from 'event-kit'
 //   serialize: ->
 //     @state
 // ```
-export default class DeserializerManager {
+module.exports =
+class DeserializerManager {
   constructor (atomEnvironment) {
     this.atomEnvironment = atomEnvironment
     this.deserializers = {}

--- a/src/history-manager.js
+++ b/src/history-manager.js
@@ -1,13 +1,11 @@
-/** @babel */
-
-import {Emitter, CompositeDisposable} from 'event-kit'
+const {Emitter, CompositeDisposable} = require('event-kit')
 
 // Extended: History manager for remembering which projects have been opened.
 //
 // An instance of this class is always available as the `atom.history` global.
 //
 // The project history is used to enable the 'Reopen Project' menu.
-export class HistoryManager {
+class HistoryManager {
   constructor ({project, commands, stateStore}) {
     this.stateStore = stateStore
     this.emitter = new Emitter()
@@ -116,7 +114,7 @@ function arrayEquivalent (a, b) {
   return true
 }
 
-export class HistoryProject {
+class HistoryProject {
   constructor (paths, lastOpened) {
     this.paths = paths
     this.lastOpened = lastOpened || new Date()
@@ -128,3 +126,5 @@ export class HistoryProject {
   set lastOpened (lastOpened) { this._lastOpened = lastOpened }
   get lastOpened () { return this._lastOpened }
 }
+
+module.exports = {HistoryManager, HistoryProject}

--- a/src/initialize-benchmark-window.js
+++ b/src/initialize-benchmark-window.js
@@ -1,11 +1,9 @@
-/** @babel */
+const {remote} = require('electron')
+const path = require('path')
+const ipcHelpers = require('./ipc-helpers')
+const util = require('util')
 
-import {remote} from 'electron'
-import path from 'path'
-import ipcHelpers from './ipc-helpers'
-import util from 'util'
-
-export default async function () {
+module.exports = async function () {
   const getWindowLoadSettings = require('./get-window-load-settings')
   const {test, headless, resourcePath, benchmarkPaths} = getWindowLoadSettings()
   try {

--- a/src/main-process/file-recovery-service.js
+++ b/src/main-process/file-recovery-service.js
@@ -1,11 +1,10 @@
-'use babel'
+const {dialog} = require('electron')
+const crypto = require('crypto')
+const Path = require('path')
+const fs = require('fs-plus')
 
-import {dialog} from 'electron'
-import crypto from 'crypto'
-import Path from 'path'
-import fs from 'fs-plus'
-
-export default class FileRecoveryService {
+module.exports =
+class FileRecoveryService {
   constructor (recoveryDirectory) {
     this.recoveryDirectory = recoveryDirectory
     this.recoveryFilesByFilePath = new Map()

--- a/src/main-process/win-shell.js
+++ b/src/main-process/win-shell.js
@@ -1,7 +1,5 @@
-'use babel'
-
-import Registry from 'winreg'
-import Path from 'path'
+const Registry = require('winreg')
+const Path = require('path')
 
 let exeName = Path.basename(process.execPath)
 let appPath = `\"${process.execPath}\"`

--- a/src/native-watcher-registry.js
+++ b/src/native-watcher-registry.js
@@ -1,5 +1,3 @@
-/** @babel */
-
 const path = require('path')
 
 // Private: re-join the segments split from an absolute path to form another absolute path.

--- a/src/null-grammar.js
+++ b/src/null-grammar.js
@@ -1,8 +1,6 @@
-/** @babel */
+const {Disposable} = require('event-kit')
 
-import {Disposable} from 'event-kit'
-
-export default {
+module.exports = {
   name: 'Null Grammar',
   scopeName: 'text.plain.null-grammar',
   scopeForId (id) {

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -1,5 +1,3 @@
-/** @babel */
-
 const fs = require('fs')
 const path = require('path')
 

--- a/src/reopen-project-list-view.js
+++ b/src/reopen-project-list-view.js
@@ -1,8 +1,7 @@
-/** @babel */
+const SelectListView = require('atom-select-list')
 
-import SelectListView from 'atom-select-list'
-
-export default class ReopenProjectListView {
+module.exports =
+class ReopenProjectListView {
   constructor (callback) {
     this.callback = callback
     this.selectListView = new SelectListView({

--- a/src/reopen-project-menu-manager.js
+++ b/src/reopen-project-menu-manager.js
@@ -1,9 +1,8 @@
-/** @babel */
+const {CompositeDisposable} = require('event-kit')
+const path = require('path')
 
-import {CompositeDisposable} from 'event-kit'
-import path from 'path'
-
-export default class ReopenProjectMenuManager {
+module.exports =
+class ReopenProjectMenuManager {
   constructor ({menu, commands, history, config, open}) {
     this.menuManager = menu
     this.historyManager = history

--- a/src/update-process-env.js
+++ b/src/update-process-env.js
@@ -1,7 +1,5 @@
-/** @babel */
-
-import fs from 'fs'
-import childProcess from 'child_process'
+const fs = require('fs')
+const childProcess = require('child_process')
 
 const ENVIRONMENT_VARIABLES_TO_PRESERVE = new Set([
   'NODE_ENV',
@@ -120,4 +118,4 @@ async function getEnvFromShell (env) {
   return result
 }
 
-export default { updateProcessEnv, shouldGetEnvFromShell }
+module.exports = {updateProcessEnv, shouldGetEnvFromShell}

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1,5 +1,3 @@
-'use babel'
-
 const _ = require('underscore-plus')
 const url = require('url')
 const path = require('path')


### PR DESCRIPTION
### Description of the Change

This pull request stops transpiling (via Babel) JavaScript files located in the following folders:

* `benchmarks`
* `exports`
* `src`

Please, note that we still transpile core packages. Eventually, it might be worth transitioning away from Babel for those as well.

### Alternate Designs

None.

### Why Should This Be In Core?

Core is where transpilation and packaging takes place.

### Benefits

* Reduced complexity of the build, which now only transpiles babel files found in core packages.
* Smaller footprint for JS files, thanks to removing source maps.
* Easier debugging, thanks to removing Babel async generators.

### Possible Drawbacks

Unclear, but theoretically none.

### Verification Process

* Run tests and see that they pass.
* Run Atom and see that no syntax error occurs.
* Snapshots are generated correctly.

/cc: @atom/maintainers 