### PR TITLE
Don't break subpixel AA when cursor is at the end of longest line

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -104,7 +104,7 @@ describe('TextEditorComponent', () => {
 
       {
         expect(editor.getApproximateLongestScreenRow()).toBe(3)
-        const expectedWidth = Math.round(
+        const expectedWidth = Math.ceil(
           component.pixelPositionForScreenPosition(Point(3, Infinity)).left +
           component.getBaseCharacterWidth()
         )
@@ -121,7 +121,7 @@ describe('TextEditorComponent', () => {
         // Capture the width of the lines before requesting the width of
         // longest line, because making that request forces a DOM update
         const actualWidth = element.querySelector('.lines').style.width
-        const expectedWidth = Math.round(
+        const expectedWidth = Math.ceil(
           component.pixelPositionForScreenPosition(Point(6, Infinity)).left +
           component.getBaseCharacterWidth()
         )
@@ -3980,7 +3980,7 @@ describe('TextEditorComponent', () => {
       // Capture the width of the lines before requesting the width of
       // longest line, because making that request forces a DOM update
       const actualWidth = element.querySelector('.lines').style.width
-      const expectedWidth = Math.round(
+      const expectedWidth = Math.ceil(
         component.pixelPositionForScreenPosition(Point(3, Infinity)).left +
         component.getBaseCharacterWidth()
       )

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2694,7 +2694,7 @@ class TextEditorComponent {
   }
 
   getContentWidth () {
-    return Math.round(this.getLongestLineWidth() + this.getBaseCharacterWidth())
+    return Math.ceil(this.getLongestLineWidth() + this.getBaseCharacterWidth())
   }
 
   getScrollContainerClientWidthInBaseCharacters () {


### PR DESCRIPTION
### Description of the Change

With the Electron upgrade, something changed in the way characters are rendered/measured, and that was causing subpixel anti-aliasing to stop working when cursors were at the end of the longest line.

![before](https://user-images.githubusercontent.com/482957/35146473-685b8538-fd0b-11e7-9f90-dff9ed1c47ce.gif)

Every cursor has a width that is calculated in the following way:

* If there's a character after the cursor, the width corresponds to the width of such character.
* Otherwise, the width equals to the "base character width" measured on a dummy line.

In the latter case, even if we were setting the width of the content container to account for the width of such cursor, some rounding problem was causing the cursor to be able to escape the container and thus break subpixel anti-aliasing.

With this pull request, instead of rounding the value we assign to the container width, we will always ceil it. This ensures that cursors are always strictly contained within the parent element and resolves the subpixel anti-aliasing issue.

![after](https://user-images.githubusercontent.com/482957/35146493-7cbeb43c-fd0b-11e7-9acd-a6767a85bf03.gif)

### Alternate Designs

None.

### Benefits

Fixes a regression in the subpixel anti-aliasing rendering code path that was causing text to look blurry when cursor was at the end of the longest line.

### Possible Drawbacks

None.

### Verification Process

See previously attached GIFs.

### Applicable Issues

It doesn't seem like this problem has been reported anywhere. /cc: @Ben3eeE @ungb @rsese in case you are aware of any recent report about this. If so, feel free to edit the body of this pull request to automatically close any relevant issue once this pull request gets merged.

/cc: @nathansobo 