### PR TITLE
Fix #16538: Middle-click pastes into read only editor on Linux

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1763,7 +1763,7 @@ class TextEditorComponent {
       // On Linux, pasting happens on middle click. A textInput event with the
       // contents of the selection clipboard will be dispatched by the browser
       // automatically on mouseup.
-      if (platform === 'linux' && button === 1) model.insertText(clipboard.readText('selection'))
+      if (platform === 'linux' && button === 1 && this.isInputEnabled()) model.insertText(clipboard.readText('selection'))
       return
     }
 


### PR DESCRIPTION
This change fixes an issue where users on Linux are able to paste into
read only TextEditors by clicking the middle mouse button.  The fix is
to check for whether the TextEditorComponent's isInputEnabled method
returns true before pasting with middle click on Linux.

### Verification Process

On Linux:

1. Copy text from an open buffer in Atom
2. Create a new editor with Ctrl+N
3. Drop into DevTools console and execute `atom.workspace.getActiveTextEditor().setReadOnly(true)`
3. Click the middle mouse button in the editor, verify that no text was pasted
4. Back in the DevTools console, execute `atom.workspace.getActiveTextEditor().setReadOnly(false)`
5. Click the middle mouse button in the editor, verify that the expected text was pasted
