### PR TITLE
Update marked to guard against regex DoS

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "key-path-helpers": "^0.4.0",
     "less-cache": "1.1.0",
     "line-top-index": "0.3.1",
-    "marked": "^0.3.6",
+    "marked": "^0.3.12",
     "minimatch": "^3.0.3",
     "mocha": "2.5.1",
     "mocha-junit-reporter": "^1.13.0",


### PR DESCRIPTION
### Description of the Change
This bumps the version of the `marked` package, since the current version contains a security flaw.

### Why Should This Be In Core?
This should be in core, because having security vulnerabilities in core is bad?

### Benefits
It fixes [this](https://nodesecurity.io/advisories/531).

### Possible Drawbacks
None, that I'm aware of.