### PR TITLE
Revert change to move mouse cursor on right-click

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -2992,7 +2992,7 @@ describe('TextEditorComponent', () => {
             [[1, 16], [1, 16]]
           ])
 
-          // ctrl-click does not add cursors on macOS, but it *does* move the cursor
+          // ctrl-click does not add cursors on macOS, nor does it move the cursor
           component.didMouseDownOnContent(
             Object.assign(clientPositionForCharacter(component, 1, 4), {
               detail: 1,
@@ -3001,7 +3001,7 @@ describe('TextEditorComponent', () => {
             })
           )
           expect(editor.getSelectedScreenRanges()).toEqual([
-            [[1, 4], [1, 4]]
+            [[1, 16], [1, 16]]
           ])
 
           // ctrl-click adds cursors on platforms *other* than macOS

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -2840,9 +2840,9 @@ describe('TextEditorComponent', () => {
 
   describe('mouse input', () => {
     describe('on the lines', () => {
-      describe('when there is only one cursor and no selection', () => {
-        it('positions the cursor on single-click or when middle/right-clicking', async () => {
-          for (const button of [0, 1, 2]) {
+      describe('when there is only one cursor', () => {
+        it('positions the cursor on single-click or when middle-clicking', async () => {
+          for (const button of [0, 1]) {
             const {component, element, editor} = buildComponent()
             const {lineHeight} = component.measurements
 
@@ -2918,70 +2918,6 @@ describe('TextEditorComponent', () => {
 
             expect(editor.testAutoscrollRequests).toEqual([])
           }
-        })
-      })
-
-      describe('when there is more than one cursor', () => {
-        it('does not move the cursor when right-clicking', async () => {
-          const {component, element, editor} = buildComponent()
-          const {lineHeight} = component.measurements
-
-          editor.setCursorScreenPosition([5, 17], {autoscroll: false})
-          editor.addCursorAtScreenPosition([2, 4])
-          component.didMouseDownOnContent({
-            detail: 1,
-            button: 2,
-            clientX: clientLeftForCharacter(component, 0, 0) - 1,
-            clientY: clientTopForLine(component, 0) - 1
-          })
-          expect(editor.getCursorScreenPositions()).toEqual([Point.fromObject([5, 17]), Point.fromObject([2, 4])])
-        })
-
-        it('does move the cursor when middle-clicking', async () => {
-          const {component, element, editor} = buildComponent()
-          const {lineHeight} = component.measurements
-
-          editor.setCursorScreenPosition([5, 17], {autoscroll: false})
-          editor.addCursorAtScreenPosition([2, 4])
-          component.didMouseDownOnContent({
-            detail: 1,
-            button: 1,
-            clientX: clientLeftForCharacter(component, 0, 0) - 1,
-            clientY: clientTopForLine(component, 0) - 1
-          })
-          expect(editor.getCursorScreenPositions()).toEqual([Point.fromObject([0, 0])])
-        })
-      })
-
-      describe('when there are non-empty selections', () => {
-        it('does not move the cursor when right-clicking', async () => {
-          const {component, element, editor} = buildComponent()
-          const {lineHeight} = component.measurements
-
-          editor.setCursorScreenPosition([5, 17], {autoscroll: false})
-          editor.selectRight(3)
-          component.didMouseDownOnContent({
-            detail: 1,
-            button: 2,
-            clientX: clientLeftForCharacter(component, 0, 0) - 1,
-            clientY: clientTopForLine(component, 0) - 1
-          })
-          expect(editor.getSelectedScreenRange()).toEqual([[5, 17], [5, 20]])
-        })
-
-        it('does move the cursor when middle-clicking', async () => {
-          const {component, element, editor} = buildComponent()
-          const {lineHeight} = component.measurements
-
-          editor.setCursorScreenPosition([5, 17], {autoscroll: false})
-          editor.selectRight(3)
-          component.didMouseDownOnContent({
-            detail: 1,
-            button: 1,
-            clientX: clientLeftForCharacter(component, 0, 0) - 1,
-            clientY: clientTopForLine(component, 0) - 1
-          })
-          expect(editor.getSelectedScreenRange()).toEqual([[0, 0], [0, 0]])
         })
       })
 

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1762,13 +1762,18 @@ class TextEditorComponent {
       return
     }
 
+    if (button !== 0) return
+
+    // Ctrl-click brings up the context menu on macOS
+    if (platform === 'darwin' && ctrlKey) return
+
     if (target && target.matches('.fold-marker')) {
       const bufferPosition = model.bufferPositionForScreenPosition(screenPosition)
       model.destroyFoldsContainingBufferPositions([bufferPosition], false)
       return
     }
 
-    const addOrRemoveSelection = metaKey || ctrlKey
+    const addOrRemoveSelection = metaKey || (ctrlKey && platform !== 'darwin')
 
     switch (detail) {
       case 1:

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1752,18 +1752,13 @@ class TextEditorComponent {
 
     const screenPosition = this.screenPositionForMouseEvent(event)
 
-    if (button !== 0 || (platform === 'darwin' && ctrlKey)) {
-      // Always set cursor position on middle-click
-      // Only set cursor position on right-click if there is one cursor with no selection
-      const ranges = model.getSelectedBufferRanges()
-      if (button === 1 || (ranges.length === 1 && ranges[0].isEmpty())) {
-        model.setCursorScreenPosition(screenPosition, {autoscroll: false})
-      }
+    if (button === 1) {
+      model.setCursorScreenPosition(screenPosition, {autoscroll: false})
 
       // On Linux, pasting happens on middle click. A textInput event with the
       // contents of the selection clipboard will be dispatched by the browser
       // automatically on mouseup.
-      if (platform === 'linux' && button === 1 && this.isInputEnabled()) model.insertText(clipboard.readText('selection'))
+      if (platform === 'linux' && this.isInputEnabled()) model.insertText(clipboard.readText('selection'))
       return
     }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Was too quick to implement this change.  Turns out most editors don't do this.

### Alternate Designs

An alternate design would be to implement this as a config setting.

### Why Should This Be In Core?

!

### Benefits

Consistency with other editors.

### Possible Drawbacks

Should be none as this was a recently-introduced change.

### Applicable Issues

https://github.com/atom/atom/pull/16328#issuecomment-350041675

/cc @Ingramz @ungb @Ben3eeE 