### PR TITLE
Perform all config file IO in the main process

### DIFF
--- a/spec/config-file-spec.js
+++ b/spec/config-file-spec.js
@@ -1,0 +1,109 @@
+const {it, fit, ffit, beforeEach, afterEach, conditionPromise} = require('./async-spec-helpers')
+const fs = require('fs-plus')
+const path = require('path')
+const temp = require('temp').track()
+const dedent = require('dedent')
+const ConfigFile = require('../src/config-file')
+
+describe('ConfigFile', () => {
+  let filePath, configFile, subscription
+
+  beforeEach(async () => {
+    jasmine.useRealClock()
+    const tempDir = fs.realpathSync(temp.mkdirSync())
+    filePath = path.join(tempDir, 'the-config.cson')
+  })
+
+  afterEach(() => {
+    subscription.dispose()
+  })
+
+  describe('when the file does not exist', () => {
+    it('returns an empty object from .get()', async () => {
+      configFile = new ConfigFile(filePath)
+      subscription = await configFile.watch()
+      expect(configFile.get()).toEqual({})
+    })
+  })
+
+  describe('when the file is empty', () => {
+    it('returns an empty object from .get()', async () => {
+      writeFileSync(filePath, '')
+      configFile = new ConfigFile(filePath)
+      subscription = await configFile.watch()
+      expect(configFile.get()).toEqual({})
+    })
+  })
+
+  describe('when the file is updated with valid CSON', () => {
+    it('notifies onDidChange observers with the data', async () => {
+      configFile = new ConfigFile(filePath)
+      subscription = await configFile.watch()
+
+      const event = new Promise(resolve => configFile.onDidChange(resolve))
+
+      writeFileSync(filePath, dedent `
+        '*':
+          foo: 'bar'
+
+        'javascript':
+          foo: 'baz'
+      `)
+
+      expect(await event).toEqual({
+        '*': {foo: 'bar'},
+        'javascript': {foo: 'baz'}
+      })
+
+      expect(configFile.get()).toEqual({
+        '*': {foo: 'bar'},
+        'javascript': {foo: 'baz'}
+      })
+    })
+  })
+
+  describe('when the file is  updated with invalid CSON', () => {
+    it('notifies onDidError observers', async () => {
+      configFile = new ConfigFile(filePath)
+      subscription = await configFile.watch()
+
+      const message = new Promise(resolve => configFile.onDidError(resolve))
+
+      writeFileSync(filePath, dedent `
+        um what?
+      `, 2)
+
+      expect(await message).toContain('Failed to load `the-config.cson`')
+
+      const event = new Promise(resolve => configFile.onDidChange(resolve))
+
+      writeFileSync(filePath, dedent `
+        '*':
+          foo: 'bar'
+
+        'javascript':
+          foo: 'baz'
+      `, 4)
+
+      expect(await event).toEqual({
+        '*': {foo: 'bar'},
+        'javascript': {foo: 'baz'}
+      })
+    })
+  })
+
+  describe('updating the config', () => {
+    it('persists the data to the file', async () => {
+      configFile = new ConfigFile(filePath)
+      subscription = await configFile.watch()
+      await configFile.update({foo: 'bar'})
+      expect(fs.readFileSync(filePath, 'utf8')).toBe('foo: "bar"\n')
+    })
+  })
+})
+
+function writeFileSync (filePath, content, seconds = 2) {
+  const utime = (Date.now() / 1000) + seconds
+  fs.writeFileSync(filePath, content)
+  fs.utimesSync(filePath, utime, utime)
+}

--- a/spec/config-file-spec.js
+++ b/spec/config-file-spec.js
@@ -91,15 +91,6 @@ describe('ConfigFile', () => {
       })
     })
   })
-
-  describe('updating the config', () => {
-    it('persists the data to the file', async () => {
-      configFile = new ConfigFile(filePath)
-      subscription = await configFile.watch()
-      await configFile.update({foo: 'bar'})
-      expect(fs.readFileSync(filePath, 'utf8')).toBe('foo: "bar"\n')
-    })
-  })
 })
 
 function writeFileSync (filePath, content, seconds = 2) {

--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -1,26 +1,18 @@
 const path = require('path')
 const temp = require('temp').track()
-let CSON = require('season')
 const fs = require('fs-plus')
 
 describe('Config', () => {
-  let dotAtomPath = null
+  let savedSettings
 
   beforeEach(() => {
-    spyOn(atom.config, 'load')
-    spyOn(atom.config, 'save')
     spyOn(console, 'warn')
-    dotAtomPath = temp.path('atom-spec-config')
-    atom.config.configDirPath = dotAtomPath
-    atom.config.enablePersistence = true
     atom.config.settingsLoaded = true
-    atom.config.pendingOperations = []
-    atom.config.configFilePath = path.join(atom.config.configDirPath, 'atom.config.cson')
-  })
 
-  afterEach(() => {
-    atom.config.enablePersistence = false
-    fs.removeSync(dotAtomPath)
+    savedSettings = []
+    atom.config.saveCallback = function (settings) {
+      savedSettings.push(settings)
+    }
   })
 
   describe('.get(keyPath, {scope, sources, excludeSources})', () => {
@@ -186,22 +178,24 @@ describe('Config', () => {
     it("saves the user's config to disk after it stops changing", () => {
       atom.config.set('foo.bar.baz', 42)
       advanceClock(50)
-      expect(atom.config.save).not.toHaveBeenCalled()
+      expect(savedSettings.length).toBe(0)
       atom.config.set('foo.bar.baz', 43)
       advanceClock(50)
-      expect(atom.config.save).not.toHaveBeenCalled()
+      expect(savedSettings.length).toBe(0)
       atom.config.set('foo.bar.baz', 44)
       advanceClock(150)
-      expect(atom.config.save).toHaveBeenCalled()
+      expect(savedSettings.length).toBe(1)
     })
 
     it("does not save when a non-default 'source' is given", () => {
       atom.config.set('foo.bar.baz', 42, {source: 'some-other-source', scopeSelector: '.a'})
       advanceClock(500)
-      expect(atom.config.save).not.toHaveBeenCalled()
+      expect(savedSettings.length).toBe(0)
     })
 
-    it("does not allow a 'source' option without a 'scopeSelector'", () => expect(() => atom.config.set('foo', 1, {source: ['.source.ruby']})).toThrow())
+    it("does not allow a 'source' option without a 'scopeSelector'", () => {
+      expect(() => atom.config.set('foo', 1, {source: ['.source.ruby']})).toThrow()
+    })
 
     describe('when the key-path is null', () =>
       it('sets the root object', () => {
@@ -322,11 +316,11 @@ describe('Config', () => {
     it('calls ::save()', () => {
       atom.config.setDefaults('a', {b: 3})
       atom.config.set('a.b', 4)
-      atom.config.save.reset()
+      savedSettings.length = 0
 
       atom.config.unset('a.c')
       advanceClock(500)
-      expect(atom.config.save.callCount).toBe(1)
+      expect(savedSettings.length).toBe(1)
     })
 
     describe("when no 'scopeSelector' is given", () => {
@@ -400,11 +394,11 @@ describe('Config', () => {
       it('calls ::save()', () => {
         atom.config.setDefaults('foo', {bar: {baz: 10}})
         atom.config.set('foo.bar.baz', 55, {scopeSelector: '.source.coffee'})
-        atom.config.save.reset()
+        savedSettings.length = 0
 
         atom.config.unset('foo.bar.baz', {scopeSelector: '.source.coffee'})
         advanceClock(150)
-        expect(atom.config.save.callCount).toBe(1)
+        expect(savedSettings.length).toBe(1)
       })
 
       it('allows removing settings for a specific source and scope selector', () => {
@@ -433,55 +427,50 @@ describe('Config', () => {
         atom.config.unset('foo.bar.baz', {scopeSelector: '.source.coffee'})
         expect(atom.config.get('foo.bar.baz', {scope: ['.source.coffee']})).toBe(10)
 
-        expect(atom.config.save).not.toHaveBeenCalled()
+        expect(savedSettings.length).toBe(0)
 
         const scopedProperties = atom.config.scopedSettingsStore.propertiesForSource('user-config')
         expect(scopedProperties['.coffee.source']).toBeUndefined()
       })
 
       it('removes the scoped value when it was the only set value on the object', () => {
-        spyOn(CSON, 'writeFileSync')
-        atom.config.save.andCallThrough()
-
         atom.config.setDefaults('foo', {bar: {baz: 10}})
         atom.config.set('foo.bar.baz', 55, {scopeSelector: '.source.coffee'})
         atom.config.set('foo.bar.ok', 20, {scopeSelector: '.source.coffee'})
         expect(atom.config.get('foo.bar.baz', {scope: ['.source.coffee']})).toBe(55)
 
         advanceClock(150)
-        CSON.writeFileSync.reset()
+        savedSettings.length = 0
 
         atom.config.unset('foo.bar.baz', {scopeSelector: '.source.coffee'})
         expect(atom.config.get('foo.bar.baz', {scope: ['.source.coffee']})).toBe(10)
         expect(atom.config.get('foo.bar.ok', {scope: ['.source.coffee']})).toBe(20)
 
         advanceClock(150)
-        expect(CSON.writeFileSync).toHaveBeenCalled()
-        let properties = CSON.writeFileSync.mostRecentCall.args[1]
-        expect(properties['.coffee.source']).toEqual({
+        expect(savedSettings[0]['.coffee.source']).toEqual({
           foo: {
             bar: {
               ok: 20
             }
           }
         })
-        CSON.writeFileSync.reset()
 
         atom.config.unset('foo.bar.ok', {scopeSelector: '.source.coffee'})
 
         advanceClock(150)
-        expect(CSON.writeFileSync).toHaveBeenCalled()
-        properties = CSON.writeFileSync.mostRecentCall.args[1]
-        expect(properties['.coffee.source']).toBeUndefined()
+        expect(savedSettings.length).toBe(2)
+        expect(savedSettings[1]['.coffee.source']).toBeUndefined()
       })
 
       it('does not call ::save when the value is already at the default', () => {
         atom.config.setDefaults('foo', {bar: {baz: 10}})
         atom.config.set('foo.bar.baz', 55)
-        atom.config.save.reset()
+        advanceClock(150)
+        savedSettings.length = 0
 
         atom.config.unset('foo.bar.ok', {scopeSelector: '.source.coffee'})
-        expect(atom.config.save).not.toHaveBeenCalled()
+        advanceClock(150)
+        expect(savedSettings.length).toBe(0)
         expect(atom.config.get('foo.bar.baz', {scope: ['.source.coffee']})).toBe(55)
       })
     })
@@ -600,7 +589,7 @@ describe('Config', () => {
       advanceClock(100) // complete pending save that was requested in ::set
 
       observeHandler.reset()
-      atom.config.loadUserConfig()
+      atom.config.resetUserSettings({foo: {}})
       expect(observeHandler).toHaveBeenCalledWith(undefined)
     })
 
@@ -781,7 +770,7 @@ describe('Config', () => {
     })
   })
 
-  describe('.getSources()', () =>
+  describe('.getSources()', () => {
     it("returns an array of all of the config's source names", () => {
       expect(atom.config.getSources()).toEqual([])
 
@@ -796,1387 +785,1032 @@ describe('Config', () => {
         'source-3'
       ])
     })
-  )
+  })
 
-  describe('Internal Methods', () => {
-    describe('.save()', () => {
-      CSON = require('season')
+  describe('.save()', () => {
+    it('calls the save callback with any non-default properties', () => {
+      atom.config.set('a.b.c', 1)
+      atom.config.set('a.b.d', 2)
+      atom.config.set('x.y.z', 3)
+      atom.config.setDefaults('a.b', {e: 4, f: 5})
 
-      beforeEach(() => {
-        spyOn(CSON, 'writeFileSync')
-        jasmine.unspy(atom.config, 'save')
-      })
-
-      describe('when ~/.atom/config.json exists', () => {
-        it('writes any non-default properties to ~/.atom/config.json', () => {
-          atom.config.set('a.b.c', 1)
-          atom.config.set('a.b.d', 2)
-          atom.config.set('x.y.z', 3)
-          atom.config.setDefaults('a.b', {e: 4, f: 5})
-
-          CSON.writeFileSync.reset()
-          atom.config.save()
-
-          expect(CSON.writeFileSync.argsForCall[0][0]).toBe(atom.config.configFilePath)
-          const writtenConfig = CSON.writeFileSync.argsForCall[0][1]
-          expect(writtenConfig).toEqual({'*': atom.config.settings})
-        })
-
-        it('writes properties in alphabetical order', () => {
-          let key
-          atom.config.set('foo', 1)
-          atom.config.set('bar', 2)
-          atom.config.set('baz.foo', 3)
-          atom.config.set('baz.bar', 4)
-
-          CSON.writeFileSync.reset()
-          atom.config.save()
-
-          expect(CSON.writeFileSync.argsForCall[0][0]).toBe(atom.config.configFilePath)
-          const writtenConfig = CSON.writeFileSync.argsForCall[0][1]
-          expect(writtenConfig).toEqual({'*': atom.config.settings})
-
-          let expectedKeys = ['bar', 'baz', 'foo']
-          let foundKeys = []
-          for (key in writtenConfig['*']) {
-            if ((expectedKeys).includes(key)) {
-              foundKeys.push(key)
-            }
-          }
-          expect(foundKeys).toEqual(expectedKeys)
-          expectedKeys = ['bar', 'foo']
-          foundKeys = []
-          for (key in writtenConfig['*']['baz']) {
-            if ((expectedKeys).includes(key)) {
-              foundKeys.push(key)
-            }
-          }
-          expect(foundKeys).toEqual(expectedKeys)
-        })
-      })
-
-      describe("when ~/.atom/config.json doesn't exist", () =>
-        it('writes any non-default properties to ~/.atom/config.cson', () => {
-          atom.config.set('a.b.c', 1)
-          atom.config.set('a.b.d', 2)
-          atom.config.set('x.y.z', 3)
-          atom.config.setDefaults('a.b', {e: 4, f: 5})
-
-          CSON.writeFileSync.reset()
-          atom.config.save()
-
-          expect(CSON.writeFileSync.argsForCall[0][0]).toBe(path.join(atom.config.configDirPath, 'atom.config.cson'))
-          const writtenConfig = CSON.writeFileSync.argsForCall[0][1]
-          expect(writtenConfig).toEqual({'*': atom.config.settings})
-        })
-      )
-
-      describe('when scoped settings are defined', () =>
-        it('writes out explicitly set config settings', () => {
-          atom.config.set('foo.bar', 'ruby', {scopeSelector: '.source.ruby'})
-          atom.config.set('foo.omg', 'wow', {scopeSelector: '.source.ruby'})
-          atom.config.set('foo.bar', 'coffee', {scopeSelector: '.source.coffee'})
-
-          CSON.writeFileSync.reset()
-          atom.config.save()
-
-          const writtenConfig = CSON.writeFileSync.argsForCall[0][1]
-          expect(writtenConfig).toEqualJson({
-            '*':
-              atom.config.settings,
-            '.ruby.source': {
-              foo: {
-                bar: 'ruby',
-                omg: 'wow'
-              }
-            },
-            '.coffee.source': {
-              foo: {
-                bar: 'coffee'
-              }
-            }
-          })
-        })
-      )
-
-      describe('when an error is thrown writing the file to disk', () => {
-        let addErrorHandler = null
-        beforeEach(() => atom.notifications.onDidAddNotification(addErrorHandler = jasmine.createSpy()))
-
-        it('creates a notification', () => {
-          jasmine.unspy(CSON, 'writeFileSync')
-          spyOn(CSON, 'writeFileSync').andCallFake(() => {
-            const error = new Error()
-            error.code = 'EPERM'
-            error.path = atom.config.getUserConfigPath()
-            throw error
-          })
-
-          const save = () => atom.config.save()
-          expect(save).not.toThrow()
-          expect(addErrorHandler.callCount).toBe(1)
-        })
-      })
+      atom.config.save()
+      expect(savedSettings).toEqual([{'*': atom.config.settings}])
     })
 
-    describe('.loadUserConfig()', () => {
-      beforeEach(() => {
-        expect(fs.existsSync(atom.config.configDirPath)).toBeFalsy()
-        atom.config.setSchema('foo', {
-          type: 'object',
-          properties: {
-            bar: {
-              type: 'string',
-              default: 'def'
-            },
-            int: {
-              type: 'integer',
-              default: 12
-            }
-          }
+    it('serializes properties in alphabetical order', () => {
+      atom.config.set('foo', 1)
+      atom.config.set('bar', 2)
+      atom.config.set('baz.foo', 3)
+      atom.config.set('baz.bar', 4)
+
+      savedSettings.length = 0
+      atom.config.save()
+
+      const writtenConfig = savedSettings[0]
+      expect(writtenConfig).toEqual({'*': atom.config.settings})
+
+      let expectedKeys = ['bar', 'baz', 'foo']
+      let foundKeys = []
+      for (const key in writtenConfig['*']) {
+        if ((expectedKeys).includes(key)) {
+          foundKeys.push(key)
         }
-        )
-      })
-
-      afterEach(() => fs.removeSync(dotAtomPath))
-
-      describe('when the config file contains scoped settings', () => {
-        beforeEach(() => {
-          fs.writeFileSync(atom.config.configFilePath,
-            `
-            '*':
-              foo:
-                bar: 'baz'
-
-            '.source.ruby':
-              foo:
-                bar: 'more-specific'\
-            `
-          )
-          atom.config.loadUserConfig()
-        })
-
-        it('updates the config data based on the file contents', () => {
-          expect(atom.config.get('foo.bar')).toBe('baz')
-          expect(atom.config.get('foo.bar', {scope: ['.source.ruby']})).toBe('more-specific')
-        })
-      })
-
-      describe('when the config file does not conform to the schema', () => {
-        beforeEach(() =>
-          fs.writeFileSync(atom.config.configFilePath,
-            `
-            '*':
-              foo:
-                bar: 'omg'
-                int: 'baz'
-            '.source.ruby':
-              foo:
-                bar: 'scoped'
-                int: 'nope'
-            `
-          )
-        )
-
-        it('validates and does not load the incorrect values', () => {
-          atom.config.loadUserConfig()
-          expect(atom.config.get('foo.int')).toBe(12)
-          expect(atom.config.get('foo.bar')).toBe('omg')
-          expect(atom.config.get('foo.int', {scope: ['.source.ruby']})).toBe(12)
-          expect(atom.config.get('foo.bar', {scope: ['.source.ruby']})).toBe('scoped')
-        })
-      })
-
-      describe('when the config file contains valid cson', () => {
-        beforeEach(() => fs.writeFileSync(atom.config.configFilePath, "foo: bar: 'baz'"))
-
-        it('updates the config data based on the file contents', () => {
-          atom.config.loadUserConfig()
-          expect(atom.config.get('foo.bar')).toBe('baz')
-        })
-
-        it('notifies observers for updated keypaths on load', () => {
-          const observeHandler = jasmine.createSpy('observeHandler')
-          atom.config.observe('foo.bar', observeHandler)
-
-          atom.config.loadUserConfig()
-
-          expect(observeHandler).toHaveBeenCalledWith('baz')
-        })
-      })
-
-      describe('when the config file contains invalid cson', () => {
-        let addErrorHandler = null
-        beforeEach(() => {
-          addErrorHandler = jasmine.createSpy()
-          atom.notifications.onDidAddNotification(addErrorHandler)
-          fs.writeFileSync(atom.config.configFilePath, '{{{{{')
-        })
-
-        it('logs an error to the console and does not overwrite the config file on a subsequent save', () => {
-          atom.config.loadUserConfig()
-          expect(addErrorHandler.callCount).toBe(1)
-          atom.config.set('hair', 'blonde') // trigger a save
-          expect(atom.config.save).not.toHaveBeenCalled()
-        })
-      })
-
-      describe('when the config file does not exist', () =>
-        it('creates it with an empty object', () => {
-          fs.makeTreeSync(atom.config.configDirPath)
-          atom.config.loadUserConfig()
-          expect(fs.existsSync(atom.config.configFilePath)).toBe(true)
-          expect(CSON.readFileSync(atom.config.configFilePath)).toEqual({})
-        })
-    )
-
-      describe('when the config file contains values that do not adhere to the schema', () => {
-        beforeEach(() => {
-          fs.writeFileSync(atom.config.configFilePath,
-            `
-              foo:
-                bar: 'baz'
-                int: 'bad value'
-            `
-          )
-          atom.config.loadUserConfig()
-        })
-
-        it('updates the only the settings that have values matching the schema', () => {
-          expect(atom.config.get('foo.bar')).toBe('baz')
-          expect(atom.config.get('foo.int')).toBe(12)
-
-          expect(console.warn).toHaveBeenCalled()
-          expect(console.warn.mostRecentCall.args[0]).toContain('foo.int')
-        })
-      })
-
-      describe('when there is a pending save', () =>
-        it('does not change the config settings', () => {
-          fs.writeFileSync(atom.config.configFilePath, "'*': foo: bar: 'baz'")
-
-          atom.config.set('foo.bar', 'quux')
-          atom.config.loadUserConfig()
-          expect(atom.config.get('foo.bar')).toBe('quux')
-
-          advanceClock(100)
-          expect(atom.config.save.callCount).toBe(1)
-
-          expect(atom.config.get('foo.bar')).toBe('quux')
-          atom.config.loadUserConfig()
-          expect(atom.config.get('foo.bar')).toBe('baz')
-        })
-      )
-
-      describe('when the config file fails to load', () => {
-        let addErrorHandler = null
-
-        beforeEach(() => {
-          addErrorHandler = jasmine.createSpy()
-          atom.notifications.onDidAddNotification(addErrorHandler)
-          return spyOn(fs, 'makeTreeSync').andCallFake(() => {
-            const error = new Error()
-            error.code = 'EPERM'
-            throw error
-          })
-        })
-
-        it('creates a notification and does not try to save later changes to disk', () => {
-          const load = () => atom.config.loadUserConfig()
-          expect(load).not.toThrow()
-          expect(addErrorHandler.callCount).toBe(1)
-
-          atom.config.set('foo.bar', 'baz')
-          advanceClock(100)
-          expect(atom.config.save).not.toHaveBeenCalled()
-          expect(atom.config.get('foo.bar')).toBe('baz')
-        })
-      })
-    })
-
-    describe('.observeUserConfig()', () => {
-      let updatedHandler = null
-
-      const writeConfigFile = (data, secondsInFuture) => {
-        if (secondsInFuture == null) { secondsInFuture = 0 }
-        fs.writeFileSync(atom.config.configFilePath, data)
-
-        const future = (Date.now() / 1000) + secondsInFuture
-        fs.utimesSync(atom.config.configFilePath, future, future)
       }
-
-      beforeEach(() => {
-        jasmine.useRealClock()
-
-        atom.config.setSchema('foo', {
-          type: 'object',
-          properties: {
-            bar: {
-              type: 'string',
-              default: 'def'
-            },
-            baz: {
-              type: 'string'
-            },
-            scoped: {
-              type: 'boolean'
-            },
-            int: {
-              type: 'integer',
-              default: 12
-            }
-          }
+      expect(foundKeys).toEqual(expectedKeys)
+      expectedKeys = ['bar', 'foo']
+      foundKeys = []
+      for (const key in writtenConfig['*']['baz']) {
+        if ((expectedKeys).includes(key)) {
+          foundKeys.push(key)
         }
-        )
-
-        expect(fs.existsSync(atom.config.configDirPath)).toBeFalsy()
-        writeConfigFile(
-          `
-            '*':
-              foo:
-                bar: 'baz'
-                scoped: false
-            '.source.ruby':
-              foo:
-                scoped: true
-          `
-        )
-        atom.config.loadUserConfig()
-
-        waitsForPromise(() => atom.config.observeUserConfig())
-
-        runs(() => {
-          updatedHandler = jasmine.createSpy('updatedHandler')
-          atom.config.onDidChange(updatedHandler)
-        })
-      })
-
-      afterEach(() => {
-        atom.config.unobserveUserConfig()
-        fs.removeSync(dotAtomPath)
-      })
-
-      describe('when the config file changes to contain valid cson', () => {
-        it('updates the config data', () => {
-          writeConfigFile("foo: { bar: 'quux', baz: 'bar'}", 2)
-
-          waitsFor('update event', () => updatedHandler.callCount > 0)
-
-          runs(() => {
-            expect(atom.config.get('foo.bar')).toBe('quux')
-            expect(atom.config.get('foo.baz')).toBe('bar')
-          })
-        })
-
-        it('does not fire a change event for paths that did not change', () => {
-          const noChangeSpy = jasmine.createSpy('unchanged')
-          atom.config.onDidChange('foo.bar', (noChangeSpy))
-
-          writeConfigFile("foo: { bar: 'baz', baz: 'ok'}", 2)
-          waitsFor('update event', () => updatedHandler.callCount > 0)
-
-          runs(() => {
-            expect(noChangeSpy).not.toHaveBeenCalled()
-            expect(atom.config.get('foo.bar')).toBe('baz')
-            expect(atom.config.get('foo.baz')).toBe('ok')
-          })
-        })
-
-        describe('when the default value is a complex value', () => {
-          beforeEach(() => {
-            atom.config.setSchema('foo.bar', {
-              type: 'array',
-              items: {
-                type: 'string'
-              }
-            }
-            )
-
-            updatedHandler.reset()
-            writeConfigFile("foo: { bar: ['baz', 'ok']}", 4)
-            waitsFor('update event', () => updatedHandler.callCount > 0)
-            runs(() => updatedHandler.reset())
-          })
-
-          it('does not fire a change event for paths that did not change', () => {
-            const noChangeSpy = jasmine.createSpy('unchanged')
-            atom.config.onDidChange('foo.bar', noChangeSpy)
-
-            writeConfigFile("foo: { bar: ['baz', 'ok'], baz: 'another'}", 2)
-            waitsFor('update event', () => updatedHandler.callCount > 0)
-
-            runs(() => {
-              expect(noChangeSpy).not.toHaveBeenCalled()
-              expect(atom.config.get('foo.bar')).toEqual(['baz', 'ok'])
-              expect(atom.config.get('foo.baz')).toBe('another')
-            })
-          })
-        })
-
-        describe('when scoped settings are used', () => {
-          it('fires a change event for scoped settings that are removed', () => {
-            const scopedSpy = jasmine.createSpy()
-            atom.config.onDidChange('foo.scoped', {scope: ['.source.ruby']}, scopedSpy)
-
-            writeConfigFile(
-              `
-                '*':
-                  foo:
-                    scoped: false
-              `, 2
-            )
-            waitsFor('update event', () => updatedHandler.callCount > 0)
-
-            runs(() => {
-              expect(scopedSpy).toHaveBeenCalled()
-              expect(atom.config.get('foo.scoped', {scope: ['.source.ruby']})).toBe(false)
-            })
-          })
-
-          it('does not fire a change event for paths that did not change', () => {
-            const noChangeSpy = jasmine.createSpy('no change')
-            atom.config.onDidChange('foo.scoped', {scope: ['.source.ruby']}, noChangeSpy)
-
-            writeConfigFile(
-              `
-                '*':
-                  foo:
-                    bar: 'baz'
-                '.source.ruby':
-                  foo:
-                    scoped: true
-              `, 2
-            )
-            waitsFor('update event', () => updatedHandler.callCount > 0)
-
-            runs(() => {
-              expect(noChangeSpy).not.toHaveBeenCalled()
-              expect(atom.config.get('foo.bar', {scope: ['.source.ruby']})).toBe('baz')
-              expect(atom.config.get('foo.scoped', {scope: ['.source.ruby']})).toBe(true)
-            })
-          })
-        })
-      })
-
-      describe('when the config file changes to omit a setting with a default', () =>
-        it('resets the setting back to the default', () => {
-          writeConfigFile("foo: { baz: 'new'}", 2)
-          waitsFor('update event', () => updatedHandler.callCount > 0)
-          runs(() => {
-            expect(atom.config.get('foo.bar')).toBe('def')
-            expect(atom.config.get('foo.baz')).toBe('new')
-          })
-        })
-      )
-
-      describe('when the config file changes to be empty', () => {
-        beforeEach(() => {
-          updatedHandler.reset()
-          writeConfigFile('', 4)
-          waitsFor('update event', () => updatedHandler.callCount > 0)
-        })
-
-        it('resets all settings back to the defaults', () => {
-          expect(updatedHandler.callCount).toBe(1)
-          expect(atom.config.get('foo.bar')).toBe('def')
-          atom.config.set('hair', 'blonde') // trigger a save
-          waitsFor('save', () => atom.config.save.callCount > 0)
-        })
-
-        describe('when the config file subsequently changes again to contain configuration', () => {
-          beforeEach(() => {
-            updatedHandler.reset()
-            writeConfigFile("foo: bar: 'newVal'", 2)
-            waitsFor('update event', () => updatedHandler.callCount > 0)
-          })
-
-          it('sets the setting to the value specified in the config file', () => expect(atom.config.get('foo.bar')).toBe('newVal'))
-        })
-      })
-
-      describe('when the config file changes to contain invalid cson', () => {
-        let addErrorHandler = null
-        beforeEach(() => {
-          addErrorHandler = jasmine.createSpy('error handler')
-          atom.notifications.onDidAddNotification(addErrorHandler)
-          writeConfigFile('}}}', 4)
-          waitsFor('error to be logged', () => addErrorHandler.callCount > 0)
-        })
-
-        it('logs a warning and does not update config data', () => {
-          expect(updatedHandler.callCount).toBe(0)
-          expect(atom.config.get('foo.bar')).toBe('baz')
-
-          atom.config.set('hair', 'blonde') // trigger a save
-          expect(atom.config.save).not.toHaveBeenCalled()
-        })
-
-        describe('when the config file subsequently changes again to contain valid cson', () => {
-          beforeEach(() => {
-            updatedHandler.reset()
-            writeConfigFile("foo: bar: 'newVal'", 6)
-            waitsFor('update event', () => updatedHandler.callCount > 0)
-          })
-
-          it('updates the config data and resumes saving', () => {
-            atom.config.set('hair', 'blonde')
-            waitsFor('save', () => atom.config.save.callCount > 0)
-          })
-        })
-      })
+      }
+      expect(foundKeys).toEqual(expectedKeys)
     })
 
-    describe('.initializeConfigDirectory()', () => {
-      beforeEach(() => {
-        if (fs.existsSync(dotAtomPath)) {
-          fs.removeSync(dotAtomPath)
-        }
+    describe('when scoped settings are defined', () => {
+      it('serializes any explicitly set config settings', () => {
+        atom.config.set('foo.bar', 'ruby', {scopeSelector: '.source.ruby'})
+        atom.config.set('foo.omg', 'wow', {scopeSelector: '.source.ruby'})
+        atom.config.set('foo.bar', 'coffee', {scopeSelector: '.source.coffee'})
 
-        atom.config.configDirPath = dotAtomPath
-      })
+        savedSettings.length = 0
+        atom.config.save()
 
-      afterEach(() => fs.removeSync(dotAtomPath))
-
-      describe("when the configDirPath doesn't exist", () =>
-        it('copies the contents of dot-atom to ~/.atom', () => {
-          if (process.platform === 'win32') { return } // Flakey test on Win32
-          let initializationDone = false
-          jasmine.unspy(window, 'setTimeout')
-          atom.config.initializeConfigDirectory(() => {
-            initializationDone = true
-          })
-
-          waitsFor(() => initializationDone)
-
-          runs(() => {
-            expect(fs.existsSync(atom.config.configDirPath)).toBeTruthy()
-            expect(fs.existsSync(path.join(atom.config.configDirPath, 'packages'))).toBeTruthy()
-            expect(fs.isFileSync(path.join(atom.config.configDirPath, 'snippets.cson'))).toBeTruthy()
-            expect(fs.isFileSync(path.join(atom.config.configDirPath, 'init.coffee'))).toBeTruthy()
-            expect(fs.isFileSync(path.join(atom.config.configDirPath, 'styles.less'))).toBeTruthy()
-          })
-        })
-      )
-    })
-
-    describe('.pushAtKeyPath(keyPath, value)', () =>
-      it('pushes the given value to the array at the key path and updates observers', () => {
-        atom.config.set('foo.bar.baz', ['a'])
-        const observeHandler = jasmine.createSpy('observeHandler')
-        atom.config.observe('foo.bar.baz', observeHandler)
-        observeHandler.reset()
-
-        expect(atom.config.pushAtKeyPath('foo.bar.baz', 'b')).toBe(2)
-        expect(atom.config.get('foo.bar.baz')).toEqual(['a', 'b'])
-        expect(observeHandler).toHaveBeenCalledWith(atom.config.get('foo.bar.baz'))
-      })
-    )
-
-    describe('.unshiftAtKeyPath(keyPath, value)', () =>
-      it('unshifts the given value to the array at the key path and updates observers', () => {
-        atom.config.set('foo.bar.baz', ['b'])
-        const observeHandler = jasmine.createSpy('observeHandler')
-        atom.config.observe('foo.bar.baz', observeHandler)
-        observeHandler.reset()
-
-        expect(atom.config.unshiftAtKeyPath('foo.bar.baz', 'a')).toBe(2)
-        expect(atom.config.get('foo.bar.baz')).toEqual(['a', 'b'])
-        expect(observeHandler).toHaveBeenCalledWith(atom.config.get('foo.bar.baz'))
-      })
-    )
-
-    describe('.removeAtKeyPath(keyPath, value)', () =>
-      it('removes the given value from the array at the key path and updates observers', () => {
-        atom.config.set('foo.bar.baz', ['a', 'b', 'c'])
-        const observeHandler = jasmine.createSpy('observeHandler')
-        atom.config.observe('foo.bar.baz', observeHandler)
-        observeHandler.reset()
-
-        expect(atom.config.removeAtKeyPath('foo.bar.baz', 'b')).toEqual(['a', 'c'])
-        expect(atom.config.get('foo.bar.baz')).toEqual(['a', 'c'])
-        expect(observeHandler).toHaveBeenCalledWith(atom.config.get('foo.bar.baz'))
-      })
-    )
-
-    describe('.setDefaults(keyPath, defaults)', () => {
-      it('assigns any previously-unassigned keys to the object at the key path', () => {
-        atom.config.set('foo.bar.baz', {a: 1})
-        atom.config.setDefaults('foo.bar.baz', {a: 2, b: 3, c: 4})
-        expect(atom.config.get('foo.bar.baz.a')).toBe(1)
-        expect(atom.config.get('foo.bar.baz.b')).toBe(3)
-        expect(atom.config.get('foo.bar.baz.c')).toBe(4)
-
-        atom.config.setDefaults('foo.quux', {x: 0, y: 1})
-        expect(atom.config.get('foo.quux.x')).toBe(0)
-        expect(atom.config.get('foo.quux.y')).toBe(1)
-      })
-
-      it('emits an updated event', () => {
-        const updatedCallback = jasmine.createSpy('updated')
-        atom.config.onDidChange('foo.bar.baz.a', updatedCallback)
-        expect(updatedCallback.callCount).toBe(0)
-        atom.config.setDefaults('foo.bar.baz', {a: 2})
-        expect(updatedCallback.callCount).toBe(1)
-      })
-    })
-
-    describe('.setSchema(keyPath, schema)', () => {
-      it('creates a properly nested schema', () => {
-        const schema = {
-          type: 'object',
-          properties: {
-            anInt: {
-              type: 'integer',
-              default: 12
+        const writtenConfig = savedSettings[0]
+        expect(writtenConfig).toEqualJson({
+          '*':
+            atom.config.settings,
+          '.ruby.source': {
+            foo: {
+              bar: 'ruby',
+              omg: 'wow'
+            }
+          },
+          '.coffee.source': {
+            foo: {
+              bar: 'coffee'
             }
           }
-        }
-
-        atom.config.setSchema('foo.bar', schema)
-
-        expect(atom.config.getSchema('foo')).toEqual({
-          type: 'object',
-          properties: {
-            bar: {
-              type: 'object',
-              properties: {
-                anInt: {
-                  type: 'integer',
-                  default: 12
-                }
-              }
-            }
-          }
-        })
-      })
-
-      it('sets defaults specified by the schema', () => {
-        const schema = {
-          type: 'object',
-          properties: {
-            anInt: {
-              type: 'integer',
-              default: 12
-            },
-            anObject: {
-              type: 'object',
-              properties: {
-                nestedInt: {
-                  type: 'integer',
-                  default: 24
-                },
-                nestedObject: {
-                  type: 'object',
-                  properties: {
-                    superNestedInt: {
-                      type: 'integer',
-                      default: 36
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        atom.config.setSchema('foo.bar', schema)
-        expect(atom.config.get('foo.bar.anInt')).toBe(12)
-        expect(atom.config.get('foo.bar.anObject')).toEqual({
-          nestedInt: 24,
-          nestedObject: {
-            superNestedInt: 36
-          }
-        })
-
-        expect(atom.config.get('foo')).toEqual({
-          bar: {
-            anInt: 12,
-            anObject: {
-              nestedInt: 24,
-              nestedObject: {
-                superNestedInt: 36
-              }
-            }
-          }
-        })
-        atom.config.set('foo.bar.anObject.nestedObject.superNestedInt', 37)
-        expect(atom.config.get('foo')).toEqual({
-          bar: {
-            anInt: 12,
-            anObject: {
-              nestedInt: 24,
-              nestedObject: {
-                superNestedInt: 37
-              }
-            }
-          }
-        })
-      })
-
-      it('can set a non-object schema', () => {
-        const schema = {
-          type: 'integer',
-          default: 12
-        }
-
-        atom.config.setSchema('foo.bar.anInt', schema)
-        expect(atom.config.get('foo.bar.anInt')).toBe(12)
-        expect(atom.config.getSchema('foo.bar.anInt')).toEqual({
-          type: 'integer',
-          default: 12
-        })
-      })
-
-      it('allows the schema to be retrieved via ::getSchema', () => {
-        const schema = {
-          type: 'object',
-          properties: {
-            anInt: {
-              type: 'integer',
-              default: 12
-            }
-          }
-        }
-
-        atom.config.setSchema('foo.bar', schema)
-
-        expect(atom.config.getSchema('foo.bar')).toEqual({
-          type: 'object',
-          properties: {
-            anInt: {
-              type: 'integer',
-              default: 12
-            }
-          }
-        })
-
-        expect(atom.config.getSchema('foo.bar.anInt')).toEqual({
-          type: 'integer',
-          default: 12
-        })
-
-        expect(atom.config.getSchema('foo.baz')).toEqual({type: 'any'})
-        expect(atom.config.getSchema('foo.bar.anInt.baz')).toBe(null)
-      })
-
-      it('respects the schema for scoped settings', () => {
-        const schema = {
-          type: 'string',
-          default: 'ok',
-          scopes: {
-            '.source.js': {
-              default: 'omg'
-            }
-          }
-        }
-        atom.config.setSchema('foo.bar.str', schema)
-
-        expect(atom.config.get('foo.bar.str')).toBe('ok')
-        expect(atom.config.get('foo.bar.str', {scope: ['.source.js']})).toBe('omg')
-        expect(atom.config.get('foo.bar.str', {scope: ['.source.coffee']})).toBe('ok')
-      })
-
-      describe('when a schema is added after config values have been set', () => {
-        let schema = null
-        beforeEach(() => {
-          schema = {
-            type: 'object',
-            properties: {
-              int: {
-                type: 'integer',
-                default: 2
-              },
-              str: {
-                type: 'string',
-                default: 'def'
-              }
-            }
-          }
-        })
-
-        it('respects the new schema when values are set', () => {
-          expect(atom.config.set('foo.bar.str', 'global')).toBe(true)
-          expect(atom.config.set('foo.bar.str', 'scoped', {scopeSelector: '.source.js'})).toBe(true)
-          expect(atom.config.get('foo.bar.str')).toBe('global')
-          expect(atom.config.get('foo.bar.str', {scope: ['.source.js']})).toBe('scoped')
-
-          expect(atom.config.set('foo.bar.noschema', 'nsGlobal')).toBe(true)
-          expect(atom.config.set('foo.bar.noschema', 'nsScoped', {scopeSelector: '.source.js'})).toBe(true)
-          expect(atom.config.get('foo.bar.noschema')).toBe('nsGlobal')
-          expect(atom.config.get('foo.bar.noschema', {scope: ['.source.js']})).toBe('nsScoped')
-
-          expect(atom.config.set('foo.bar.int', 'nope')).toBe(true)
-          expect(atom.config.set('foo.bar.int', 'notanint', {scopeSelector: '.source.js'})).toBe(true)
-          expect(atom.config.set('foo.bar.int', 23, {scopeSelector: '.source.coffee'})).toBe(true)
-          expect(atom.config.get('foo.bar.int')).toBe('nope')
-          expect(atom.config.get('foo.bar.int', {scope: ['.source.js']})).toBe('notanint')
-          expect(atom.config.get('foo.bar.int', {scope: ['.source.coffee']})).toBe(23)
-
-          atom.config.setSchema('foo.bar', schema)
-
-          expect(atom.config.get('foo.bar.str')).toBe('global')
-          expect(atom.config.get('foo.bar.str', {scope: ['.source.js']})).toBe('scoped')
-          expect(atom.config.get('foo.bar.noschema')).toBe('nsGlobal')
-          expect(atom.config.get('foo.bar.noschema', {scope: ['.source.js']})).toBe('nsScoped')
-
-          expect(atom.config.get('foo.bar.int')).toBe(2)
-          expect(atom.config.get('foo.bar.int', {scope: ['.source.js']})).toBe(2)
-          expect(atom.config.get('foo.bar.int', {scope: ['.source.coffee']})).toBe(23)
-        })
-
-        it('sets all values that adhere to the schema', () => {
-          expect(atom.config.set('foo.bar.int', 10)).toBe(true)
-          expect(atom.config.set('foo.bar.int', 15, {scopeSelector: '.source.js'})).toBe(true)
-          expect(atom.config.set('foo.bar.int', 23, {scopeSelector: '.source.coffee'})).toBe(true)
-          expect(atom.config.get('foo.bar.int')).toBe(10)
-          expect(atom.config.get('foo.bar.int', {scope: ['.source.js']})).toBe(15)
-          expect(atom.config.get('foo.bar.int', {scope: ['.source.coffee']})).toBe(23)
-
-          atom.config.setSchema('foo.bar', schema)
-
-          expect(atom.config.get('foo.bar.int')).toBe(10)
-          expect(atom.config.get('foo.bar.int', {scope: ['.source.js']})).toBe(15)
-          expect(atom.config.get('foo.bar.int', {scope: ['.source.coffee']})).toBe(23)
-        })
-      })
-
-      describe('when the value has an "integer" type', () => {
-        beforeEach(() => {
-          const schema = {
-            type: 'integer',
-            default: 12
-          }
-          atom.config.setSchema('foo.bar.anInt', schema)
-        })
-
-        it('coerces a string to an int', () => {
-          atom.config.set('foo.bar.anInt', '123')
-          expect(atom.config.get('foo.bar.anInt')).toBe(123)
-        })
-
-        it('does not allow infinity', () => {
-          atom.config.set('foo.bar.anInt', Infinity)
-          expect(atom.config.get('foo.bar.anInt')).toBe(12)
-        })
-
-        it('coerces a float to an int', () => {
-          atom.config.set('foo.bar.anInt', 12.3)
-          expect(atom.config.get('foo.bar.anInt')).toBe(12)
-        })
-
-        it('will not set non-integers', () => {
-          atom.config.set('foo.bar.anInt', null)
-          expect(atom.config.get('foo.bar.anInt')).toBe(12)
-
-          atom.config.set('foo.bar.anInt', 'nope')
-          expect(atom.config.get('foo.bar.anInt')).toBe(12)
-        })
-
-        describe('when the minimum and maximum keys are used', () => {
-          beforeEach(() => {
-            const schema = {
-              type: 'integer',
-              minimum: 10,
-              maximum: 20,
-              default: 12
-            }
-            atom.config.setSchema('foo.bar.anInt', schema)
-          })
-
-          it('keeps the specified value within the specified range', () => {
-            atom.config.set('foo.bar.anInt', '123')
-            expect(atom.config.get('foo.bar.anInt')).toBe(20)
-
-            atom.config.set('foo.bar.anInt', '1')
-            expect(atom.config.get('foo.bar.anInt')).toBe(10)
-          })
-        })
-      })
-
-      describe('when the value has an "integer" and "string" type', () => {
-        beforeEach(() => {
-          const schema = {
-            type: ['integer', 'string'],
-            default: 12
-          }
-          atom.config.setSchema('foo.bar.anInt', schema)
-        })
-
-        it('can coerce an int, and fallback to a string', () => {
-          atom.config.set('foo.bar.anInt', '123')
-          expect(atom.config.get('foo.bar.anInt')).toBe(123)
-
-          atom.config.set('foo.bar.anInt', 'cats')
-          expect(atom.config.get('foo.bar.anInt')).toBe('cats')
-        })
-      })
-
-      describe('when the value has an "string" and "boolean" type', () => {
-        beforeEach(() => {
-          const schema = {
-            type: ['string', 'boolean'],
-            default: 'def'
-          }
-          atom.config.setSchema('foo.bar', schema)
-        })
-
-        it('can set a string, a boolean, and revert back to the default', () => {
-          atom.config.set('foo.bar', 'ok')
-          expect(atom.config.get('foo.bar')).toBe('ok')
-
-          atom.config.set('foo.bar', false)
-          expect(atom.config.get('foo.bar')).toBe(false)
-
-          atom.config.set('foo.bar', undefined)
-          expect(atom.config.get('foo.bar')).toBe('def')
-        })
-      })
-
-      describe('when the value has a "number" type', () => {
-        beforeEach(() => {
-          const schema = {
-            type: 'number',
-            default: 12.1
-          }
-          atom.config.setSchema('foo.bar.aFloat', schema)
-        })
-
-        it('coerces a string to a float', () => {
-          atom.config.set('foo.bar.aFloat', '12.23')
-          expect(atom.config.get('foo.bar.aFloat')).toBe(12.23)
-        })
-
-        it('will not set non-numbers', () => {
-          atom.config.set('foo.bar.aFloat', null)
-          expect(atom.config.get('foo.bar.aFloat')).toBe(12.1)
-
-          atom.config.set('foo.bar.aFloat', 'nope')
-          expect(atom.config.get('foo.bar.aFloat')).toBe(12.1)
-        })
-
-        describe('when the minimum and maximum keys are used', () => {
-          beforeEach(() => {
-            const schema = {
-              type: 'number',
-              minimum: 11.2,
-              maximum: 25.4,
-              default: 12.1
-            }
-            atom.config.setSchema('foo.bar.aFloat', schema)
-          })
-
-          it('keeps the specified value within the specified range', () => {
-            atom.config.set('foo.bar.aFloat', '123.2')
-            expect(atom.config.get('foo.bar.aFloat')).toBe(25.4)
-
-            atom.config.set('foo.bar.aFloat', '1.0')
-            expect(atom.config.get('foo.bar.aFloat')).toBe(11.2)
-          })
-        })
-      })
-
-      describe('when the value has a "boolean" type', () => {
-        beforeEach(() => {
-          const schema = {
-            type: 'boolean',
-            default: true
-          }
-          atom.config.setSchema('foo.bar.aBool', schema)
-        })
-
-        it('coerces various types to a boolean', () => {
-          atom.config.set('foo.bar.aBool', 'true')
-          expect(atom.config.get('foo.bar.aBool')).toBe(true)
-          atom.config.set('foo.bar.aBool', 'false')
-          expect(atom.config.get('foo.bar.aBool')).toBe(false)
-          atom.config.set('foo.bar.aBool', 'TRUE')
-          expect(atom.config.get('foo.bar.aBool')).toBe(true)
-          atom.config.set('foo.bar.aBool', 'FALSE')
-          expect(atom.config.get('foo.bar.aBool')).toBe(false)
-          atom.config.set('foo.bar.aBool', 1)
-          expect(atom.config.get('foo.bar.aBool')).toBe(false)
-          atom.config.set('foo.bar.aBool', 0)
-          expect(atom.config.get('foo.bar.aBool')).toBe(false)
-          atom.config.set('foo.bar.aBool', {})
-          expect(atom.config.get('foo.bar.aBool')).toBe(false)
-          atom.config.set('foo.bar.aBool', null)
-          expect(atom.config.get('foo.bar.aBool')).toBe(false)
-        })
-
-        it('reverts back to the default value when undefined is passed to set', () => {
-          atom.config.set('foo.bar.aBool', 'false')
-          expect(atom.config.get('foo.bar.aBool')).toBe(false)
-
-          atom.config.set('foo.bar.aBool', undefined)
-          expect(atom.config.get('foo.bar.aBool')).toBe(true)
-        })
-      })
-
-      describe('when the value has an "string" type', () => {
-        beforeEach(() => {
-          const schema = {
-            type: 'string',
-            default: 'ok'
-          }
-          atom.config.setSchema('foo.bar.aString', schema)
-        })
-
-        it('allows strings', () => {
-          atom.config.set('foo.bar.aString', 'yep')
-          expect(atom.config.get('foo.bar.aString')).toBe('yep')
-        })
-
-        it('will only set strings', () => {
-          expect(atom.config.set('foo.bar.aString', 123)).toBe(false)
-          expect(atom.config.get('foo.bar.aString')).toBe('ok')
-
-          expect(atom.config.set('foo.bar.aString', true)).toBe(false)
-          expect(atom.config.get('foo.bar.aString')).toBe('ok')
-
-          expect(atom.config.set('foo.bar.aString', null)).toBe(false)
-          expect(atom.config.get('foo.bar.aString')).toBe('ok')
-
-          expect(atom.config.set('foo.bar.aString', [])).toBe(false)
-          expect(atom.config.get('foo.bar.aString')).toBe('ok')
-
-          expect(atom.config.set('foo.bar.aString', {nope: 'nope'})).toBe(false)
-          expect(atom.config.get('foo.bar.aString')).toBe('ok')
-        })
-
-        it('does not allow setting children of that key-path', () => {
-          expect(atom.config.set('foo.bar.aString.something', 123)).toBe(false)
-          expect(atom.config.get('foo.bar.aString')).toBe('ok')
-        })
-
-        describe('when the schema has a "maximumLength" key', () =>
-          it('trims the string to be no longer than the specified maximum', () => {
-            const schema = {
-              type: 'string',
-              default: 'ok',
-              maximumLength: 3
-            }
-            atom.config.setSchema('foo.bar.aString', schema)
-            atom.config.set('foo.bar.aString', 'abcdefg')
-            expect(atom.config.get('foo.bar.aString')).toBe('abc')
-          })
-        )
-      })
-
-      describe('when the value has an "object" type', () => {
-        beforeEach(() => {
-          const schema = {
-            type: 'object',
-            properties: {
-              anInt: {
-                type: 'integer',
-                default: 12
-              },
-              nestedObject: {
-                type: 'object',
-                properties: {
-                  nestedBool: {
-                    type: 'boolean',
-                    default: false
-                  }
-                }
-              }
-            }
-          }
-          atom.config.setSchema('foo.bar', schema)
-        })
-
-        it('converts and validates all the children', () => {
-          atom.config.set('foo.bar', {
-            anInt: '23',
-            nestedObject: {
-              nestedBool: 'true'
-            }
-          }
-          )
-          expect(atom.config.get('foo.bar')).toEqual({
-            anInt: 23,
-            nestedObject: {
-              nestedBool: true
-            }
-          })
-        })
-
-        it('will set only the values that adhere to the schema', () => {
-          expect(atom.config.set('foo.bar', {
-            anInt: 'nope',
-            nestedObject: {
-              nestedBool: true
-            }
-          }
-          )).toBe(true)
-          expect(atom.config.get('foo.bar.anInt')).toEqual(12)
-          expect(atom.config.get('foo.bar.nestedObject.nestedBool')).toEqual(true)
-        })
-
-        describe('when the value has additionalProperties set to false', () =>
-          it('does not allow other properties to be set on the object', () => {
-            atom.config.setSchema('foo.bar', {
-              type: 'object',
-              properties: {
-                anInt: {
-                  type: 'integer',
-                  default: 12
-                }
-              },
-              additionalProperties: false
-            }
-            )
-
-            expect(atom.config.set('foo.bar', {anInt: 5, somethingElse: 'ok'})).toBe(true)
-            expect(atom.config.get('foo.bar.anInt')).toBe(5)
-            expect(atom.config.get('foo.bar.somethingElse')).toBeUndefined()
-
-            expect(atom.config.set('foo.bar.somethingElse', {anInt: 5})).toBe(false)
-            expect(atom.config.get('foo.bar.somethingElse')).toBeUndefined()
-          })
-        )
-
-        describe('when the value has an additionalProperties schema', () =>
-          it('validates properties of the object against that schema', () => {
-            atom.config.setSchema('foo.bar', {
-              type: 'object',
-              properties: {
-                anInt: {
-                  type: 'integer',
-                  default: 12
-                }
-              },
-              additionalProperties: {
-                type: 'string'
-              }
-            }
-            )
-
-            expect(atom.config.set('foo.bar', {anInt: 5, somethingElse: 'ok'})).toBe(true)
-            expect(atom.config.get('foo.bar.anInt')).toBe(5)
-            expect(atom.config.get('foo.bar.somethingElse')).toBe('ok')
-
-            expect(atom.config.set('foo.bar.somethingElse', 7)).toBe(false)
-            expect(atom.config.get('foo.bar.somethingElse')).toBe('ok')
-
-            expect(atom.config.set('foo.bar', {anInt: 6, somethingElse: 7})).toBe(true)
-            expect(atom.config.get('foo.bar.anInt')).toBe(6)
-            expect(atom.config.get('foo.bar.somethingElse')).toBe(undefined)
-          })
-        )
-      })
-
-      describe('when the value has an "array" type', () => {
-        beforeEach(() => {
-          const schema = {
-            type: 'array',
-            default: [1, 2, 3],
-            items: {
-              type: 'integer'
-            }
-          }
-          atom.config.setSchema('foo.bar', schema)
-        })
-
-        it('converts an array of strings to an array of ints', () => {
-          atom.config.set('foo.bar', ['2', '3', '4'])
-          expect(atom.config.get('foo.bar')).toEqual([2, 3, 4])
-        })
-
-        it('does not allow setting children of that key-path', () => {
-          expect(atom.config.set('foo.bar.child', 123)).toBe(false)
-          expect(atom.config.set('foo.bar.child.grandchild', 123)).toBe(false)
-          expect(atom.config.get('foo.bar')).toEqual([1, 2, 3])
-        })
-      })
-
-      describe('when the value has a "color" type', () => {
-        beforeEach(() => {
-          const schema = {
-            type: 'color',
-            default: 'white'
-          }
-          atom.config.setSchema('foo.bar.aColor', schema)
-        })
-
-        it('returns a Color object', () => {
-          let color = atom.config.get('foo.bar.aColor')
-          expect(color.toHexString()).toBe('#ffffff')
-          expect(color.toRGBAString()).toBe('rgba(255, 255, 255, 1)')
-
-          color.red = 0
-          color.green = 0
-          color.blue = 0
-          color.alpha = 0
-          atom.config.set('foo.bar.aColor', color)
-
-          color = atom.config.get('foo.bar.aColor')
-          expect(color.toHexString()).toBe('#000000')
-          expect(color.toRGBAString()).toBe('rgba(0, 0, 0, 0)')
-
-          color.red = 300
-          color.green = -200
-          color.blue = -1
-          color.alpha = 'not see through'
-          atom.config.set('foo.bar.aColor', color)
-
-          color = atom.config.get('foo.bar.aColor')
-          expect(color.toHexString()).toBe('#ff0000')
-          expect(color.toRGBAString()).toBe('rgba(255, 0, 0, 1)')
-
-          color.red = 11
-          color.green = 11
-          color.blue = 124
-          color.alpha = 1
-          atom.config.set('foo.bar.aColor', color)
-
-          color = atom.config.get('foo.bar.aColor')
-          expect(color.toHexString()).toBe('#0b0b7c')
-          expect(color.toRGBAString()).toBe('rgba(11, 11, 124, 1)')
-        })
-
-        it('coerces various types to a color object', () => {
-          atom.config.set('foo.bar.aColor', 'red')
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 0, blue: 0, alpha: 1})
-          atom.config.set('foo.bar.aColor', '#020')
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 0, green: 34, blue: 0, alpha: 1})
-          atom.config.set('foo.bar.aColor', '#abcdef')
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 171, green: 205, blue: 239, alpha: 1})
-          atom.config.set('foo.bar.aColor', 'rgb(1,2,3)')
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 1, green: 2, blue: 3, alpha: 1})
-          atom.config.set('foo.bar.aColor', 'rgba(4,5,6,.7)')
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 4, green: 5, blue: 6, alpha: 0.7})
-          atom.config.set('foo.bar.aColor', 'hsl(120,100%,50%)')
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 0, green: 255, blue: 0, alpha: 1})
-          atom.config.set('foo.bar.aColor', 'hsla(120,100%,50%,0.3)')
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 0, green: 255, blue: 0, alpha: 0.3})
-          atom.config.set('foo.bar.aColor', {red: 100, green: 255, blue: 2, alpha: 0.5})
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 100, green: 255, blue: 2, alpha: 0.5})
-          atom.config.set('foo.bar.aColor', {red: 255})
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 0, blue: 0, alpha: 1})
-          atom.config.set('foo.bar.aColor', {red: 1000})
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 0, blue: 0, alpha: 1})
-          atom.config.set('foo.bar.aColor', {red: 'dark'})
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 0, green: 0, blue: 0, alpha: 1})
-        })
-
-        it('reverts back to the default value when undefined is passed to set', () => {
-          atom.config.set('foo.bar.aColor', undefined)
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 255, blue: 255, alpha: 1})
-        })
-
-        it('will not set non-colors', () => {
-          atom.config.set('foo.bar.aColor', null)
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 255, blue: 255, alpha: 1})
-
-          atom.config.set('foo.bar.aColor', 'nope')
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 255, blue: 255, alpha: 1})
-
-          atom.config.set('foo.bar.aColor', 30)
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 255, blue: 255, alpha: 1})
-
-          atom.config.set('foo.bar.aColor', false)
-          expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 255, blue: 255, alpha: 1})
-        })
-
-        it('returns a clone of the Color when returned in a parent object', () => {
-          const color1 = atom.config.get('foo.bar').aColor
-          const color2 = atom.config.get('foo.bar').aColor
-          expect(color1.toRGBAString()).toBe('rgba(255, 255, 255, 1)')
-          expect(color2.toRGBAString()).toBe('rgba(255, 255, 255, 1)')
-          expect(color1).not.toBe(color2)
-          expect(color1).toEqual(color2)
-        })
-      })
-
-      describe('when the `enum` key is used', () => {
-        beforeEach(() => {
-          const schema = {
-            type: 'object',
-            properties: {
-              str: {
-                type: 'string',
-                default: 'ok',
-                enum: ['ok', 'one', 'two']
-              },
-              int: {
-                type: 'integer',
-                default: 2,
-                enum: [2, 3, 5]
-              },
-              arr: {
-                type: 'array',
-                default: ['one', 'two'],
-                items: {
-                  type: 'string',
-                  enum: ['one', 'two', 'three']
-                }
-              },
-              str_options: {
-                type: 'string',
-                default: 'one',
-                enum: [
-                  {value: 'one', description: 'One'},
-                  'two',
-                  {value: 'three', description: 'Three'}
-                ]
-              }
-            }
-          }
-
-          atom.config.setSchema('foo.bar', schema)
-        })
-
-        it('will only set a string when the string is in the enum values', () => {
-          expect(atom.config.set('foo.bar.str', 'nope')).toBe(false)
-          expect(atom.config.get('foo.bar.str')).toBe('ok')
-
-          expect(atom.config.set('foo.bar.str', 'one')).toBe(true)
-          expect(atom.config.get('foo.bar.str')).toBe('one')
-        })
-
-        it('will only set an integer when the integer is in the enum values', () => {
-          expect(atom.config.set('foo.bar.int', '400')).toBe(false)
-          expect(atom.config.get('foo.bar.int')).toBe(2)
-
-          expect(atom.config.set('foo.bar.int', '3')).toBe(true)
-          expect(atom.config.get('foo.bar.int')).toBe(3)
-        })
-
-        it('will only set an array when the array values are in the enum values', () => {
-          expect(atom.config.set('foo.bar.arr', ['one', 'five'])).toBe(true)
-          expect(atom.config.get('foo.bar.arr')).toEqual(['one'])
-
-          expect(atom.config.set('foo.bar.arr', ['two', 'three'])).toBe(true)
-          expect(atom.config.get('foo.bar.arr')).toEqual(['two', 'three'])
-        })
-
-        it('will honor the enum when specified as an array', () => {
-          expect(atom.config.set('foo.bar.str_options', 'one')).toBe(true)
-          expect(atom.config.get('foo.bar.str_options')).toEqual('one')
-
-          expect(atom.config.set('foo.bar.str_options', 'two')).toBe(true)
-          expect(atom.config.get('foo.bar.str_options')).toEqual('two')
-
-          expect(atom.config.set('foo.bar.str_options', 'One')).toBe(false)
-          expect(atom.config.get('foo.bar.str_options')).toEqual('two')
         })
       })
     })
   })
 
-  describe('when .set/.unset is called prior to .loadUserConfig', () => {
+  describe('.resetUserSettings()', () => {
+    beforeEach(() => {
+      atom.config.setSchema('foo', {
+        type: 'object',
+        properties: {
+          bar: {
+            type: 'string',
+            default: 'def'
+          },
+          int: {
+            type: 'integer',
+            default: 12
+          }
+        }
+      })
+    })
+
+    describe('when the config file contains scoped settings', () => {
+      it('updates the config data based on the file contents', () => {
+        atom.config.resetUserSettings({
+          '*': {
+            foo: {
+              bar: 'baz'
+            }
+          },
+
+          '.source.ruby': {
+            foo: {
+              bar: 'more-specific'
+            }
+          }
+        })
+        expect(atom.config.get('foo.bar')).toBe('baz')
+        expect(atom.config.get('foo.bar', {scope: ['.source.ruby']})).toBe('more-specific')
+      })
+    })
+
+    describe('when the config file does not conform to the schema', () => {
+      it('validates and does not load the incorrect values', () => {
+        atom.config.resetUserSettings({
+          '*': {
+            foo: {
+              bar: 'omg',
+              int: 'baz'
+            }
+          },
+          '.source.ruby': {
+            foo: {
+              bar: 'scoped',
+              int: 'nope'
+            }
+          }
+        })
+        expect(atom.config.get('foo.int')).toBe(12)
+        expect(atom.config.get('foo.bar')).toBe('omg')
+        expect(atom.config.get('foo.int', {scope: ['.source.ruby']})).toBe(12)
+        expect(atom.config.get('foo.bar', {scope: ['.source.ruby']})).toBe('scoped')
+      })
+    })
+
+    it('updates the config data based on the file contents', () => {
+      atom.config.resetUserSettings({foo: {bar: 'baz'}})
+      expect(atom.config.get('foo.bar')).toBe('baz')
+    })
+
+    it('notifies observers for updated keypaths on load', () => {
+      const observeHandler = jasmine.createSpy('observeHandler')
+      atom.config.observe('foo.bar', observeHandler)
+      atom.config.resetUserSettings({foo: {bar: 'baz'}})
+      expect(observeHandler).toHaveBeenCalledWith('baz')
+    })
+
+    describe('when the config file contains values that do not adhere to the schema', () => {
+      it('updates the only the settings that have values matching the schema', () => {
+        atom.config.resetUserSettings({
+          foo: {
+            bar: 'baz',
+            int: 'bad value'
+          }
+        })
+        expect(atom.config.get('foo.bar')).toBe('baz')
+        expect(atom.config.get('foo.int')).toBe(12)
+        expect(console.warn).toHaveBeenCalled()
+        expect(console.warn.mostRecentCall.args[0]).toContain('foo.int')
+      })
+    })
+
+    it('does not fire a change event for paths that did not change', () => {
+      atom.config.resetUserSettings({
+        foo: {bar: 'baz', int: 3}
+      })
+
+      const noChangeSpy = jasmine.createSpy('unchanged')
+      atom.config.onDidChange('foo.bar', (noChangeSpy))
+
+      atom.config.resetUserSettings({
+        foo: {bar: 'baz', int: 4}
+      })
+
+      expect(noChangeSpy).not.toHaveBeenCalled()
+      expect(atom.config.get('foo.bar')).toBe('baz')
+      expect(atom.config.get('foo.int')).toBe(4)
+    })
+
+    it('does not fire a change event for paths whose non-primitive values did not change', () => {
+      atom.config.setSchema('foo.bar', {
+        type: 'array',
+        items: {
+          type: 'string'
+        }
+      })
+
+      atom.config.resetUserSettings({
+        foo: {bar: ['baz', 'quux'], int: 2}
+      })
+
+      const noChangeSpy = jasmine.createSpy('unchanged')
+      atom.config.onDidChange('foo.bar', (noChangeSpy))
+
+      atom.config.resetUserSettings({
+        foo: {bar: ['baz', 'quux'], int: 2}
+      })
+
+      expect(noChangeSpy).not.toHaveBeenCalled()
+      expect(atom.config.get('foo.bar')).toEqual(['baz', 'quux'])
+    })
+
+    describe('when a setting with a default is removed', () => {
+      it('resets the setting back to the default', () => {
+        atom.config.resetUserSettings({
+          foo: {bar: ['baz', 'quux'], int: 2}
+        })
+
+        const events = []
+        atom.config.onDidChange('foo.int', event => events.push(event))
+
+        atom.config.resetUserSettings({
+          foo: {bar: ['baz', 'quux']}
+        })
+
+        expect(events.length).toBe(1)
+        expect(events[0]).toEqual({oldValue: 2, newValue: 12})
+      })
+    })
+  })
+
+  describe('.pushAtKeyPath(keyPath, value)', () => {
+    it('pushes the given value to the array at the key path and updates observers', () => {
+      atom.config.set('foo.bar.baz', ['a'])
+      const observeHandler = jasmine.createSpy('observeHandler')
+      atom.config.observe('foo.bar.baz', observeHandler)
+      observeHandler.reset()
+
+      expect(atom.config.pushAtKeyPath('foo.bar.baz', 'b')).toBe(2)
+      expect(atom.config.get('foo.bar.baz')).toEqual(['a', 'b'])
+      expect(observeHandler).toHaveBeenCalledWith(atom.config.get('foo.bar.baz'))
+    })
+  })
+
+  describe('.unshiftAtKeyPath(keyPath, value)', () => {
+    it('unshifts the given value to the array at the key path and updates observers', () => {
+      atom.config.set('foo.bar.baz', ['b'])
+      const observeHandler = jasmine.createSpy('observeHandler')
+      atom.config.observe('foo.bar.baz', observeHandler)
+      observeHandler.reset()
+
+      expect(atom.config.unshiftAtKeyPath('foo.bar.baz', 'a')).toBe(2)
+      expect(atom.config.get('foo.bar.baz')).toEqual(['a', 'b'])
+      expect(observeHandler).toHaveBeenCalledWith(atom.config.get('foo.bar.baz'))
+    })
+  })
+
+  describe('.removeAtKeyPath(keyPath, value)', () => {
+    it('removes the given value from the array at the key path and updates observers', () => {
+      atom.config.set('foo.bar.baz', ['a', 'b', 'c'])
+      const observeHandler = jasmine.createSpy('observeHandler')
+      atom.config.observe('foo.bar.baz', observeHandler)
+      observeHandler.reset()
+
+      expect(atom.config.removeAtKeyPath('foo.bar.baz', 'b')).toEqual(['a', 'c'])
+      expect(atom.config.get('foo.bar.baz')).toEqual(['a', 'c'])
+      expect(observeHandler).toHaveBeenCalledWith(atom.config.get('foo.bar.baz'))
+    })
+  })
+
+  describe('.setDefaults(keyPath, defaults)', () => {
+    it('assigns any previously-unassigned keys to the object at the key path', () => {
+      atom.config.set('foo.bar.baz', {a: 1})
+      atom.config.setDefaults('foo.bar.baz', {a: 2, b: 3, c: 4})
+      expect(atom.config.get('foo.bar.baz.a')).toBe(1)
+      expect(atom.config.get('foo.bar.baz.b')).toBe(3)
+      expect(atom.config.get('foo.bar.baz.c')).toBe(4)
+
+      atom.config.setDefaults('foo.quux', {x: 0, y: 1})
+      expect(atom.config.get('foo.quux.x')).toBe(0)
+      expect(atom.config.get('foo.quux.y')).toBe(1)
+    })
+
+    it('emits an updated event', () => {
+      const updatedCallback = jasmine.createSpy('updated')
+      atom.config.onDidChange('foo.bar.baz.a', updatedCallback)
+      expect(updatedCallback.callCount).toBe(0)
+      atom.config.setDefaults('foo.bar.baz', {a: 2})
+      expect(updatedCallback.callCount).toBe(1)
+    })
+  })
+
+  describe('.setSchema(keyPath, schema)', () => {
+    it('creates a properly nested schema', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          anInt: {
+            type: 'integer',
+            default: 12
+          }
+        }
+      }
+
+      atom.config.setSchema('foo.bar', schema)
+
+      expect(atom.config.getSchema('foo')).toEqual({
+        type: 'object',
+        properties: {
+          bar: {
+            type: 'object',
+            properties: {
+              anInt: {
+                type: 'integer',
+                default: 12
+              }
+            }
+          }
+        }
+      })
+    })
+
+    it('sets defaults specified by the schema', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          anInt: {
+            type: 'integer',
+            default: 12
+          },
+          anObject: {
+            type: 'object',
+            properties: {
+              nestedInt: {
+                type: 'integer',
+                default: 24
+              },
+              nestedObject: {
+                type: 'object',
+                properties: {
+                  superNestedInt: {
+                    type: 'integer',
+                    default: 36
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      atom.config.setSchema('foo.bar', schema)
+      expect(atom.config.get('foo.bar.anInt')).toBe(12)
+      expect(atom.config.get('foo.bar.anObject')).toEqual({
+        nestedInt: 24,
+        nestedObject: {
+          superNestedInt: 36
+        }
+      })
+
+      expect(atom.config.get('foo')).toEqual({
+        bar: {
+          anInt: 12,
+          anObject: {
+            nestedInt: 24,
+            nestedObject: {
+              superNestedInt: 36
+            }
+          }
+        }
+      })
+      atom.config.set('foo.bar.anObject.nestedObject.superNestedInt', 37)
+      expect(atom.config.get('foo')).toEqual({
+        bar: {
+          anInt: 12,
+          anObject: {
+            nestedInt: 24,
+            nestedObject: {
+              superNestedInt: 37
+            }
+          }
+        }
+      })
+    })
+
+    it('can set a non-object schema', () => {
+      const schema = {
+        type: 'integer',
+        default: 12
+      }
+
+      atom.config.setSchema('foo.bar.anInt', schema)
+      expect(atom.config.get('foo.bar.anInt')).toBe(12)
+      expect(atom.config.getSchema('foo.bar.anInt')).toEqual({
+        type: 'integer',
+        default: 12
+      })
+    })
+
+    it('allows the schema to be retrieved via ::getSchema', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          anInt: {
+            type: 'integer',
+            default: 12
+          }
+        }
+      }
+
+      atom.config.setSchema('foo.bar', schema)
+
+      expect(atom.config.getSchema('foo.bar')).toEqual({
+        type: 'object',
+        properties: {
+          anInt: {
+            type: 'integer',
+            default: 12
+          }
+        }
+      })
+
+      expect(atom.config.getSchema('foo.bar.anInt')).toEqual({
+        type: 'integer',
+        default: 12
+      })
+
+      expect(atom.config.getSchema('foo.baz')).toEqual({type: 'any'})
+      expect(atom.config.getSchema('foo.bar.anInt.baz')).toBe(null)
+    })
+
+    it('respects the schema for scoped settings', () => {
+      const schema = {
+        type: 'string',
+        default: 'ok',
+        scopes: {
+          '.source.js': {
+            default: 'omg'
+          }
+        }
+      }
+      atom.config.setSchema('foo.bar.str', schema)
+
+      expect(atom.config.get('foo.bar.str')).toBe('ok')
+      expect(atom.config.get('foo.bar.str', {scope: ['.source.js']})).toBe('omg')
+      expect(atom.config.get('foo.bar.str', {scope: ['.source.coffee']})).toBe('ok')
+    })
+
+    describe('when a schema is added after config values have been set', () => {
+      let schema = null
+      beforeEach(() => {
+        schema = {
+          type: 'object',
+          properties: {
+            int: {
+              type: 'integer',
+              default: 2
+            },
+            str: {
+              type: 'string',
+              default: 'def'
+            }
+          }
+        }
+      })
+
+      it('respects the new schema when values are set', () => {
+        expect(atom.config.set('foo.bar.str', 'global')).toBe(true)
+        expect(atom.config.set('foo.bar.str', 'scoped', {scopeSelector: '.source.js'})).toBe(true)
+        expect(atom.config.get('foo.bar.str')).toBe('global')
+        expect(atom.config.get('foo.bar.str', {scope: ['.source.js']})).toBe('scoped')
+
+        expect(atom.config.set('foo.bar.noschema', 'nsGlobal')).toBe(true)
+        expect(atom.config.set('foo.bar.noschema', 'nsScoped', {scopeSelector: '.source.js'})).toBe(true)
+        expect(atom.config.get('foo.bar.noschema')).toBe('nsGlobal')
+        expect(atom.config.get('foo.bar.noschema', {scope: ['.source.js']})).toBe('nsScoped')
+
+        expect(atom.config.set('foo.bar.int', 'nope')).toBe(true)
+        expect(atom.config.set('foo.bar.int', 'notanint', {scopeSelector: '.source.js'})).toBe(true)
+        expect(atom.config.set('foo.bar.int', 23, {scopeSelector: '.source.coffee'})).toBe(true)
+        expect(atom.config.get('foo.bar.int')).toBe('nope')
+        expect(atom.config.get('foo.bar.int', {scope: ['.source.js']})).toBe('notanint')
+        expect(atom.config.get('foo.bar.int', {scope: ['.source.coffee']})).toBe(23)
+
+        atom.config.setSchema('foo.bar', schema)
+
+        expect(atom.config.get('foo.bar.str')).toBe('global')
+        expect(atom.config.get('foo.bar.str', {scope: ['.source.js']})).toBe('scoped')
+        expect(atom.config.get('foo.bar.noschema')).toBe('nsGlobal')
+        expect(atom.config.get('foo.bar.noschema', {scope: ['.source.js']})).toBe('nsScoped')
+
+        expect(atom.config.get('foo.bar.int')).toBe(2)
+        expect(atom.config.get('foo.bar.int', {scope: ['.source.js']})).toBe(2)
+        expect(atom.config.get('foo.bar.int', {scope: ['.source.coffee']})).toBe(23)
+      })
+
+      it('sets all values that adhere to the schema', () => {
+        expect(atom.config.set('foo.bar.int', 10)).toBe(true)
+        expect(atom.config.set('foo.bar.int', 15, {scopeSelector: '.source.js'})).toBe(true)
+        expect(atom.config.set('foo.bar.int', 23, {scopeSelector: '.source.coffee'})).toBe(true)
+        expect(atom.config.get('foo.bar.int')).toBe(10)
+        expect(atom.config.get('foo.bar.int', {scope: ['.source.js']})).toBe(15)
+        expect(atom.config.get('foo.bar.int', {scope: ['.source.coffee']})).toBe(23)
+
+        atom.config.setSchema('foo.bar', schema)
+
+        expect(atom.config.get('foo.bar.int')).toBe(10)
+        expect(atom.config.get('foo.bar.int', {scope: ['.source.js']})).toBe(15)
+        expect(atom.config.get('foo.bar.int', {scope: ['.source.coffee']})).toBe(23)
+      })
+    })
+
+    describe('when the value has an "integer" type', () => {
+      beforeEach(() => {
+        const schema = {
+          type: 'integer',
+          default: 12
+        }
+        atom.config.setSchema('foo.bar.anInt', schema)
+      })
+
+      it('coerces a string to an int', () => {
+        atom.config.set('foo.bar.anInt', '123')
+        expect(atom.config.get('foo.bar.anInt')).toBe(123)
+      })
+
+      it('does not allow infinity', () => {
+        atom.config.set('foo.bar.anInt', Infinity)
+        expect(atom.config.get('foo.bar.anInt')).toBe(12)
+      })
+
+      it('coerces a float to an int', () => {
+        atom.config.set('foo.bar.anInt', 12.3)
+        expect(atom.config.get('foo.bar.anInt')).toBe(12)
+      })
+
+      it('will not set non-integers', () => {
+        atom.config.set('foo.bar.anInt', null)
+        expect(atom.config.get('foo.bar.anInt')).toBe(12)
+
+        atom.config.set('foo.bar.anInt', 'nope')
+        expect(atom.config.get('foo.bar.anInt')).toBe(12)
+      })
+
+      describe('when the minimum and maximum keys are used', () => {
+        beforeEach(() => {
+          const schema = {
+            type: 'integer',
+            minimum: 10,
+            maximum: 20,
+            default: 12
+          }
+          atom.config.setSchema('foo.bar.anInt', schema)
+        })
+
+        it('keeps the specified value within the specified range', () => {
+          atom.config.set('foo.bar.anInt', '123')
+          expect(atom.config.get('foo.bar.anInt')).toBe(20)
+
+          atom.config.set('foo.bar.anInt', '1')
+          expect(atom.config.get('foo.bar.anInt')).toBe(10)
+        })
+      })
+    })
+
+    describe('when the value has an "integer" and "string" type', () => {
+      beforeEach(() => {
+        const schema = {
+          type: ['integer', 'string'],
+          default: 12
+        }
+        atom.config.setSchema('foo.bar.anInt', schema)
+      })
+
+      it('can coerce an int, and fallback to a string', () => {
+        atom.config.set('foo.bar.anInt', '123')
+        expect(atom.config.get('foo.bar.anInt')).toBe(123)
+
+        atom.config.set('foo.bar.anInt', 'cats')
+        expect(atom.config.get('foo.bar.anInt')).toBe('cats')
+      })
+    })
+
+    describe('when the value has an "string" and "boolean" type', () => {
+      beforeEach(() => {
+        const schema = {
+          type: ['string', 'boolean'],
+          default: 'def'
+        }
+        atom.config.setSchema('foo.bar', schema)
+      })
+
+      it('can set a string, a boolean, and revert back to the default', () => {
+        atom.config.set('foo.bar', 'ok')
+        expect(atom.config.get('foo.bar')).toBe('ok')
+
+        atom.config.set('foo.bar', false)
+        expect(atom.config.get('foo.bar')).toBe(false)
+
+        atom.config.set('foo.bar', undefined)
+        expect(atom.config.get('foo.bar')).toBe('def')
+      })
+    })
+
+    describe('when the value has a "number" type', () => {
+      beforeEach(() => {
+        const schema = {
+          type: 'number',
+          default: 12.1
+        }
+        atom.config.setSchema('foo.bar.aFloat', schema)
+      })
+
+      it('coerces a string to a float', () => {
+        atom.config.set('foo.bar.aFloat', '12.23')
+        expect(atom.config.get('foo.bar.aFloat')).toBe(12.23)
+      })
+
+      it('will not set non-numbers', () => {
+        atom.config.set('foo.bar.aFloat', null)
+        expect(atom.config.get('foo.bar.aFloat')).toBe(12.1)
+
+        atom.config.set('foo.bar.aFloat', 'nope')
+        expect(atom.config.get('foo.bar.aFloat')).toBe(12.1)
+      })
+
+      describe('when the minimum and maximum keys are used', () => {
+        beforeEach(() => {
+          const schema = {
+            type: 'number',
+            minimum: 11.2,
+            maximum: 25.4,
+            default: 12.1
+          }
+          atom.config.setSchema('foo.bar.aFloat', schema)
+        })
+
+        it('keeps the specified value within the specified range', () => {
+          atom.config.set('foo.bar.aFloat', '123.2')
+          expect(atom.config.get('foo.bar.aFloat')).toBe(25.4)
+
+          atom.config.set('foo.bar.aFloat', '1.0')
+          expect(atom.config.get('foo.bar.aFloat')).toBe(11.2)
+        })
+      })
+    })
+
+    describe('when the value has a "boolean" type', () => {
+      beforeEach(() => {
+        const schema = {
+          type: 'boolean',
+          default: true
+        }
+        atom.config.setSchema('foo.bar.aBool', schema)
+      })
+
+      it('coerces various types to a boolean', () => {
+        atom.config.set('foo.bar.aBool', 'true')
+        expect(atom.config.get('foo.bar.aBool')).toBe(true)
+        atom.config.set('foo.bar.aBool', 'false')
+        expect(atom.config.get('foo.bar.aBool')).toBe(false)
+        atom.config.set('foo.bar.aBool', 'TRUE')
+        expect(atom.config.get('foo.bar.aBool')).toBe(true)
+        atom.config.set('foo.bar.aBool', 'FALSE')
+        expect(atom.config.get('foo.bar.aBool')).toBe(false)
+        atom.config.set('foo.bar.aBool', 1)
+        expect(atom.config.get('foo.bar.aBool')).toBe(false)
+        atom.config.set('foo.bar.aBool', 0)
+        expect(atom.config.get('foo.bar.aBool')).toBe(false)
+        atom.config.set('foo.bar.aBool', {})
+        expect(atom.config.get('foo.bar.aBool')).toBe(false)
+        atom.config.set('foo.bar.aBool', null)
+        expect(atom.config.get('foo.bar.aBool')).toBe(false)
+      })
+
+      it('reverts back to the default value when undefined is passed to set', () => {
+        atom.config.set('foo.bar.aBool', 'false')
+        expect(atom.config.get('foo.bar.aBool')).toBe(false)
+
+        atom.config.set('foo.bar.aBool', undefined)
+        expect(atom.config.get('foo.bar.aBool')).toBe(true)
+      })
+    })
+
+    describe('when the value has an "string" type', () => {
+      beforeEach(() => {
+        const schema = {
+          type: 'string',
+          default: 'ok'
+        }
+        atom.config.setSchema('foo.bar.aString', schema)
+      })
+
+      it('allows strings', () => {
+        atom.config.set('foo.bar.aString', 'yep')
+        expect(atom.config.get('foo.bar.aString')).toBe('yep')
+      })
+
+      it('will only set strings', () => {
+        expect(atom.config.set('foo.bar.aString', 123)).toBe(false)
+        expect(atom.config.get('foo.bar.aString')).toBe('ok')
+
+        expect(atom.config.set('foo.bar.aString', true)).toBe(false)
+        expect(atom.config.get('foo.bar.aString')).toBe('ok')
+
+        expect(atom.config.set('foo.bar.aString', null)).toBe(false)
+        expect(atom.config.get('foo.bar.aString')).toBe('ok')
+
+        expect(atom.config.set('foo.bar.aString', [])).toBe(false)
+        expect(atom.config.get('foo.bar.aString')).toBe('ok')
+
+        expect(atom.config.set('foo.bar.aString', {nope: 'nope'})).toBe(false)
+        expect(atom.config.get('foo.bar.aString')).toBe('ok')
+      })
+
+      it('does not allow setting children of that key-path', () => {
+        expect(atom.config.set('foo.bar.aString.something', 123)).toBe(false)
+        expect(atom.config.get('foo.bar.aString')).toBe('ok')
+      })
+
+      describe('when the schema has a "maximumLength" key', () =>
+        it('trims the string to be no longer than the specified maximum', () => {
+          const schema = {
+            type: 'string',
+            default: 'ok',
+            maximumLength: 3
+          }
+          atom.config.setSchema('foo.bar.aString', schema)
+          atom.config.set('foo.bar.aString', 'abcdefg')
+          expect(atom.config.get('foo.bar.aString')).toBe('abc')
+        })
+      )
+    })
+
+    describe('when the value has an "object" type', () => {
+      beforeEach(() => {
+        const schema = {
+          type: 'object',
+          properties: {
+            anInt: {
+              type: 'integer',
+              default: 12
+            },
+            nestedObject: {
+              type: 'object',
+              properties: {
+                nestedBool: {
+                  type: 'boolean',
+                  default: false
+                }
+              }
+            }
+          }
+        }
+        atom.config.setSchema('foo.bar', schema)
+      })
+
+      it('converts and validates all the children', () => {
+        atom.config.set('foo.bar', {
+          anInt: '23',
+          nestedObject: {
+            nestedBool: 'true'
+          }
+        }
+        )
+        expect(atom.config.get('foo.bar')).toEqual({
+          anInt: 23,
+          nestedObject: {
+            nestedBool: true
+          }
+        })
+      })
+
+      it('will set only the values that adhere to the schema', () => {
+        expect(atom.config.set('foo.bar', {
+          anInt: 'nope',
+          nestedObject: {
+            nestedBool: true
+          }
+        }
+        )).toBe(true)
+        expect(atom.config.get('foo.bar.anInt')).toEqual(12)
+        expect(atom.config.get('foo.bar.nestedObject.nestedBool')).toEqual(true)
+      })
+
+      describe('when the value has additionalProperties set to false', () =>
+        it('does not allow other properties to be set on the object', () => {
+          atom.config.setSchema('foo.bar', {
+            type: 'object',
+            properties: {
+              anInt: {
+                type: 'integer',
+                default: 12
+              }
+            },
+            additionalProperties: false
+          }
+          )
+
+          expect(atom.config.set('foo.bar', {anInt: 5, somethingElse: 'ok'})).toBe(true)
+          expect(atom.config.get('foo.bar.anInt')).toBe(5)
+          expect(atom.config.get('foo.bar.somethingElse')).toBeUndefined()
+
+          expect(atom.config.set('foo.bar.somethingElse', {anInt: 5})).toBe(false)
+          expect(atom.config.get('foo.bar.somethingElse')).toBeUndefined()
+        })
+      )
+
+      describe('when the value has an additionalProperties schema', () =>
+        it('validates properties of the object against that schema', () => {
+          atom.config.setSchema('foo.bar', {
+            type: 'object',
+            properties: {
+              anInt: {
+                type: 'integer',
+                default: 12
+              }
+            },
+            additionalProperties: {
+              type: 'string'
+            }
+          }
+          )
+
+          expect(atom.config.set('foo.bar', {anInt: 5, somethingElse: 'ok'})).toBe(true)
+          expect(atom.config.get('foo.bar.anInt')).toBe(5)
+          expect(atom.config.get('foo.bar.somethingElse')).toBe('ok')
+
+          expect(atom.config.set('foo.bar.somethingElse', 7)).toBe(false)
+          expect(atom.config.get('foo.bar.somethingElse')).toBe('ok')
+
+          expect(atom.config.set('foo.bar', {anInt: 6, somethingElse: 7})).toBe(true)
+          expect(atom.config.get('foo.bar.anInt')).toBe(6)
+          expect(atom.config.get('foo.bar.somethingElse')).toBe(undefined)
+        })
+      )
+    })
+
+    describe('when the value has an "array" type', () => {
+      beforeEach(() => {
+        const schema = {
+          type: 'array',
+          default: [1, 2, 3],
+          items: {
+            type: 'integer'
+          }
+        }
+        atom.config.setSchema('foo.bar', schema)
+      })
+
+      it('converts an array of strings to an array of ints', () => {
+        atom.config.set('foo.bar', ['2', '3', '4'])
+        expect(atom.config.get('foo.bar')).toEqual([2, 3, 4])
+      })
+
+      it('does not allow setting children of that key-path', () => {
+        expect(atom.config.set('foo.bar.child', 123)).toBe(false)
+        expect(atom.config.set('foo.bar.child.grandchild', 123)).toBe(false)
+        expect(atom.config.get('foo.bar')).toEqual([1, 2, 3])
+      })
+    })
+
+    describe('when the value has a "color" type', () => {
+      beforeEach(() => {
+        const schema = {
+          type: 'color',
+          default: 'white'
+        }
+        atom.config.setSchema('foo.bar.aColor', schema)
+      })
+
+      it('returns a Color object', () => {
+        let color = atom.config.get('foo.bar.aColor')
+        expect(color.toHexString()).toBe('#ffffff')
+        expect(color.toRGBAString()).toBe('rgba(255, 255, 255, 1)')
+
+        color.red = 0
+        color.green = 0
+        color.blue = 0
+        color.alpha = 0
+        atom.config.set('foo.bar.aColor', color)
+
+        color = atom.config.get('foo.bar.aColor')
+        expect(color.toHexString()).toBe('#000000')
+        expect(color.toRGBAString()).toBe('rgba(0, 0, 0, 0)')
+
+        color.red = 300
+        color.green = -200
+        color.blue = -1
+        color.alpha = 'not see through'
+        atom.config.set('foo.bar.aColor', color)
+
+        color = atom.config.get('foo.bar.aColor')
+        expect(color.toHexString()).toBe('#ff0000')
+        expect(color.toRGBAString()).toBe('rgba(255, 0, 0, 1)')
+
+        color.red = 11
+        color.green = 11
+        color.blue = 124
+        color.alpha = 1
+        atom.config.set('foo.bar.aColor', color)
+
+        color = atom.config.get('foo.bar.aColor')
+        expect(color.toHexString()).toBe('#0b0b7c')
+        expect(color.toRGBAString()).toBe('rgba(11, 11, 124, 1)')
+      })
+
+      it('coerces various types to a color object', () => {
+        atom.config.set('foo.bar.aColor', 'red')
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 0, blue: 0, alpha: 1})
+        atom.config.set('foo.bar.aColor', '#020')
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 0, green: 34, blue: 0, alpha: 1})
+        atom.config.set('foo.bar.aColor', '#abcdef')
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 171, green: 205, blue: 239, alpha: 1})
+        atom.config.set('foo.bar.aColor', 'rgb(1,2,3)')
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 1, green: 2, blue: 3, alpha: 1})
+        atom.config.set('foo.bar.aColor', 'rgba(4,5,6,.7)')
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 4, green: 5, blue: 6, alpha: 0.7})
+        atom.config.set('foo.bar.aColor', 'hsl(120,100%,50%)')
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 0, green: 255, blue: 0, alpha: 1})
+        atom.config.set('foo.bar.aColor', 'hsla(120,100%,50%,0.3)')
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 0, green: 255, blue: 0, alpha: 0.3})
+        atom.config.set('foo.bar.aColor', {red: 100, green: 255, blue: 2, alpha: 0.5})
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 100, green: 255, blue: 2, alpha: 0.5})
+        atom.config.set('foo.bar.aColor', {red: 255})
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 0, blue: 0, alpha: 1})
+        atom.config.set('foo.bar.aColor', {red: 1000})
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 0, blue: 0, alpha: 1})
+        atom.config.set('foo.bar.aColor', {red: 'dark'})
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 0, green: 0, blue: 0, alpha: 1})
+      })
+
+      it('reverts back to the default value when undefined is passed to set', () => {
+        atom.config.set('foo.bar.aColor', undefined)
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 255, blue: 255, alpha: 1})
+      })
+
+      it('will not set non-colors', () => {
+        atom.config.set('foo.bar.aColor', null)
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 255, blue: 255, alpha: 1})
+
+        atom.config.set('foo.bar.aColor', 'nope')
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 255, blue: 255, alpha: 1})
+
+        atom.config.set('foo.bar.aColor', 30)
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 255, blue: 255, alpha: 1})
+
+        atom.config.set('foo.bar.aColor', false)
+        expect(atom.config.get('foo.bar.aColor')).toEqual({red: 255, green: 255, blue: 255, alpha: 1})
+      })
+
+      it('returns a clone of the Color when returned in a parent object', () => {
+        const color1 = atom.config.get('foo.bar').aColor
+        const color2 = atom.config.get('foo.bar').aColor
+        expect(color1.toRGBAString()).toBe('rgba(255, 255, 255, 1)')
+        expect(color2.toRGBAString()).toBe('rgba(255, 255, 255, 1)')
+        expect(color1).not.toBe(color2)
+        expect(color1).toEqual(color2)
+      })
+    })
+
+    describe('when the `enum` key is used', () => {
+      beforeEach(() => {
+        const schema = {
+          type: 'object',
+          properties: {
+            str: {
+              type: 'string',
+              default: 'ok',
+              enum: ['ok', 'one', 'two']
+            },
+            int: {
+              type: 'integer',
+              default: 2,
+              enum: [2, 3, 5]
+            },
+            arr: {
+              type: 'array',
+              default: ['one', 'two'],
+              items: {
+                type: 'string',
+                enum: ['one', 'two', 'three']
+              }
+            },
+            str_options: {
+              type: 'string',
+              default: 'one',
+              enum: [
+                {value: 'one', description: 'One'},
+                'two',
+                {value: 'three', description: 'Three'}
+              ]
+            }
+          }
+        }
+
+        atom.config.setSchema('foo.bar', schema)
+      })
+
+      it('will only set a string when the string is in the enum values', () => {
+        expect(atom.config.set('foo.bar.str', 'nope')).toBe(false)
+        expect(atom.config.get('foo.bar.str')).toBe('ok')
+
+        expect(atom.config.set('foo.bar.str', 'one')).toBe(true)
+        expect(atom.config.get('foo.bar.str')).toBe('one')
+      })
+
+      it('will only set an integer when the integer is in the enum values', () => {
+        expect(atom.config.set('foo.bar.int', '400')).toBe(false)
+        expect(atom.config.get('foo.bar.int')).toBe(2)
+
+        expect(atom.config.set('foo.bar.int', '3')).toBe(true)
+        expect(atom.config.get('foo.bar.int')).toBe(3)
+      })
+
+      it('will only set an array when the array values are in the enum values', () => {
+        expect(atom.config.set('foo.bar.arr', ['one', 'five'])).toBe(true)
+        expect(atom.config.get('foo.bar.arr')).toEqual(['one'])
+
+        expect(atom.config.set('foo.bar.arr', ['two', 'three'])).toBe(true)
+        expect(atom.config.get('foo.bar.arr')).toEqual(['two', 'three'])
+      })
+
+      it('will honor the enum when specified as an array', () => {
+        expect(atom.config.set('foo.bar.str_options', 'one')).toBe(true)
+        expect(atom.config.get('foo.bar.str_options')).toEqual('one')
+
+        expect(atom.config.set('foo.bar.str_options', 'two')).toBe(true)
+        expect(atom.config.get('foo.bar.str_options')).toEqual('two')
+
+        expect(atom.config.set('foo.bar.str_options', 'One')).toBe(false)
+        expect(atom.config.get('foo.bar.str_options')).toEqual('two')
+      })
+    })
+  })
+
+  describe('when .set/.unset is called prior to .resetUserSettings', () => {
     beforeEach(() => {
       atom.config.settingsLoaded = false
-      fs.writeFileSync(atom.config.configFilePath,
-         `
-          '*':
-            foo:
-              bar: 'baz'
-            do:
-              ray: 'me'
-        `
-      )
     })
 
     it('ensures that early set and unset calls are replayed after the config is loaded from disk', () => {
@@ -2188,18 +1822,24 @@ describe('Config', () => {
       expect(atom.config.get('do.ray')).toBeUndefined()
 
       advanceClock(100)
-      expect(atom.config.save).not.toHaveBeenCalled()
+      expect(savedSettings.length).toBe(0)
 
-      atom.config.loadUserConfig()
+      atom.config.resetUserSettings({
+        '*': {
+          foo: {
+            bar: 'baz'
+          },
+          do: {
+            ray: 'me'
+          }
+        }
+      })
 
       advanceClock(100)
-      waitsFor(() => atom.config.save.callCount > 0)
-
-      runs(() => {
-        expect(atom.config.get('foo.bar')).toBeUndefined()
-        expect(atom.config.get('foo.qux')).toBe('boo')
-        expect(atom.config.get('do.ray')).toBe('me')
-      })
+      expect(savedSettings.length).toBe(1)
+      expect(atom.config.get('foo.bar')).toBeUndefined()
+      expect(atom.config.get('foo.qux')).toBe('boo')
+      expect(atom.config.get('do.ray')).toBe('me')
     })
   })
 })

--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -177,13 +177,11 @@ describe('Config', () => {
 
     it("saves the user's config to disk after it stops changing", () => {
       atom.config.set('foo.bar.baz', 42)
-      advanceClock(50)
       expect(savedSettings.length).toBe(0)
       atom.config.set('foo.bar.baz', 43)
-      advanceClock(50)
       expect(savedSettings.length).toBe(0)
       atom.config.set('foo.bar.baz', 44)
-      advanceClock(150)
+      advanceClock(10)
       expect(savedSettings.length).toBe(1)
     })
 

--- a/src/application-delegate.js
+++ b/src/application-delegate.js
@@ -175,6 +175,26 @@ class ApplicationDelegate {
     return remote.systemPreferences.getUserDefault(key, type)
   }
 
+  setUserSettings (config) {
+    return ipcHelpers.call('set-user-settings', config)
+  }
+
+  onDidChangeUserSettings (callback) {
+    const outerCallback = (event, message, detail) => {
+      if (message === 'did-change-user-settings') callback(detail)
+    }
+    ipcRenderer.on('message', outerCallback)
+    return new Disposable(() => ipcRenderer.removeListener('message', outerCallback))
+  }
+
+  onDidFailToReadUserSettings (callback) {
+    const outerCallback = (event, message, detail) => {
+      if (message === 'did-fail-to-read-user-settings') callback(detail)
+    }
+    ipcRenderer.on('message', outerCallback)
+    return new Disposable(() => ipcRenderer.removeListener('message', outerCallback))
+  }
+
   confirm (options, callback) {
     if (typeof callback === 'function') {
       // Async version: pass options directly to Electron but set sane defaults

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -85,8 +85,11 @@ class AtomEnvironment {
 
     // Public: A {Config} instance
     this.config = new Config({
-      notificationManager: this.notifications,
-      enablePersistence: this.enablePersistence
+      saveCallback: settings => {
+        if (this.enablePersistence) {
+          this.applicationDelegate.setUserSettings(settings)
+        }
+      }
     })
     this.config.setSchema(null, {type: 'object', properties: _.clone(ConfigSchema)})
 
@@ -207,14 +210,19 @@ class AtomEnvironment {
     this.blobStore = params.blobStore
     this.configDirPath = params.configDirPath
 
-    const {devMode, safeMode, resourcePath} = this.getLoadSettings()
+    const {devMode, safeMode, resourcePath, userSettings} = this.getLoadSettings()
 
     ConfigSchema.projectHome = {
       type: 'string',
       default: path.join(fs.getHomeDirectory(), 'github'),
       description: 'The directory where projects are assumed to be located. Packages created using the Package Generator will be stored here by default.'
     }
-    this.config.initialize({configDirPath: this.configDirPath, resourcePath, projectHomeSchema: ConfigSchema.projectHome})
+
+    this.config.initialize({
+      mainSource: this.enablePersistence && path.join(this.configDirPath, 'config.cson'),
+      projectHomeSchema: ConfigSchema.projectHome
+    })
+    this.config.resetUserSettings(userSettings)
 
     this.menu.initialize({resourcePath})
     this.contextMenu.initialize({resourcePath, devMode})
@@ -235,8 +243,6 @@ class AtomEnvironment {
     this.commandInstaller.initialize(this.getVersion())
     this.uriHandlerRegistry.registerHostHandler('core', CoreURIHandlers.create(this))
     this.autoUpdater.initialize()
-
-    this.config.load()
 
     this.protocolHandlerInstaller.initialize(this.config, this.notifications)
 
@@ -368,7 +374,6 @@ class AtomEnvironment {
     this.project = null
     this.commands.clear()
     if (this.stylesElement) this.stylesElement.remove()
-    this.config.unobserveUserConfig()
     this.autoUpdater.destroy()
     this.uriHandlerRegistry.destroy()
 
@@ -777,6 +782,12 @@ class AtomEnvironment {
         if (error) console.warn(error.message)
       })
 
+      this.disposables.add(this.applicationDelegate.onDidChangeUserSettings(settings =>
+        this.config.resetUserSettings(settings)
+      ))
+      this.disposables.add(this.applicationDelegate.onDidFailToReadUserSettings(message =>
+        this.notifications.addError(message)
+      ))
       this.disposables.add(this.applicationDelegate.onDidOpenLocations(this.openLocations.bind(this)))
       this.disposables.add(this.applicationDelegate.onApplicationMenuCommand(this.dispatchApplicationMenuCommand.bind(this)))
       this.disposables.add(this.applicationDelegate.onContextMenuCommand(this.dispatchContextMenuCommand.bind(this)))

--- a/src/config-file.js
+++ b/src/config-file.js
@@ -1,0 +1,88 @@
+const _ = require('underscore-plus')
+const fs = require('fs-plus')
+const dedent = require('dedent')
+const {Emitter} = require('event-kit')
+const {watchPath} = require('./path-watcher')
+const CSON = require('season')
+const Path = require('path')
+
+const EVENT_TYPES = new Set([
+  'created',
+  'modified',
+  'renamed'
+])
+
+module.exports =
+class ConfigFile {
+  constructor (path) {
+    this.path = path
+    this.requestLoad = _.debounce(() => this.reload(), 100)
+    this.emitter = new Emitter()
+    this.value = {}
+  }
+
+  get () {
+    return this.value
+  }
+
+  update (value) {
+    return new Promise((resolve, reject) =>
+      CSON.writeFile(this.path, value, error => {
+        if (error) {
+          reject(error)
+        } else {
+          this.value = value
+          resolve()
+        }
+      })
+    )
+  }
+
+  async watch (callback) {
+    if (!fs.existsSync(this.path)) {
+      fs.makeTreeSync(Path.dirname(this.path))
+      CSON.writeFileSync(this.path, {}, {flag: 'wx'})
+    }
+
+    await this.reload()
+
+    try {
+      const watcher = await watchPath(this.path, {}, events => {
+        if (events.some(event => EVENT_TYPES.has(event.action))) this.requestLoad()
+      })
+      return watcher
+    } catch (error) {
+      this.emitter.emit('did-error', dedent `
+        Unable to watch path: \`${Path.basename(this.path)}\`.
+
+        Make sure you have permissions to \`${this.path}\`.
+        On linux there are currently problems with watch sizes.
+        See [this document][watches] for more info.
+
+        [watches]:https://github.com/atom/atom/blob/master/docs/build-instructions/linux.md#typeerror-unable-to-watch-path\
+      `)
+    }
+  }
+
+  onDidChange (callback) {
+    return this.emitter.on('did-change', callback)
+  }
+
+  onDidError (callback) {
+    return this.emitter.on('did-error', callback)
+  }
+
+  reload () {
+    return new Promise(resolve => {
+      CSON.readFile(this.path, (error, data) => {
+        if (error) {
+          this.emitter.emit('did-error', `Failed to load \`${Path.basename(this.path)}\` - ${error.message}`)
+        } else {
+          this.value = data || {}
+          this.emitter.emit('did-change', this.value)
+        }
+        resolve()
+      })
+    })
+  }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -430,7 +430,7 @@ class Config {
     this.transactDepth = 0
     this.pendingOperations = []
     this.legacyScopeAliases = {}
-    this.requestSave = _.debounce(() => this.save(), 100)
+    this.requestSave = _.debounce(() => this.save(), 1)
   }
 
   /*

--- a/src/config.js
+++ b/src/config.js
@@ -940,10 +940,10 @@ class Config {
     }
 
     Object.assign(rootSchema, schema)
-    return this.transact(() => {
+    this.transact(() => {
       this.setDefaults(keyPath, this.extractDefaultsFromSchema(schema))
       this.setScopedDefaultsFromSchema(keyPath, schema)
-      return this.resetSettingsForSchemaChange()
+      this.resetSettingsForSchemaChange()
     })
   }
 
@@ -1100,26 +1100,25 @@ sizes. See [this document][watches] for more info.
   }
 
   getRawValue (keyPath, options = {}) {
-    let defaultValue, value
-
-    const configIndex = (options.excludeSources || []).indexOf(this.getUserConfigPath())
-    if (configIndex < 0) {
+    let value
+    if (!options.excludeSources || !options.excludeSources.includes(this.getUserConfigPath())) {
       value = getValueAtKeyPath(this.settings, keyPath)
     }
 
-    const optionSources = (options.sources || []).length
-    if (optionSources <= 0) {
+    let defaultValue
+    if (!options.sources || options.sources.length === 0) {
       defaultValue = getValueAtKeyPath(this.defaultSettings, keyPath)
     }
 
     if (value != null) {
       value = this.deepClone(value)
-      if (isPlainObject(value) && isPlainObject(defaultValue)) { this.deepDefaults(value, defaultValue) }
+      if (isPlainObject(value) && isPlainObject(defaultValue)) {
+        this.deepDefaults(value, defaultValue)
+      }
+      return value
     } else {
-      value = this.deepClone(defaultValue)
+      return this.deepClone(defaultValue)
     }
-
-    return value
   }
 
   setRawValue (keyPath, value) {

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -55,6 +55,12 @@ class AtomWindow extends EventEmitter {
     if (this.shouldHideTitleBar()) options.frame = false
     this.browserWindow = new BrowserWindow(options)
 
+    Object.defineProperty(this.browserWindow, 'loadSettingsJSON', {
+      get: () => JSON.stringify(Object.assign({
+        userSettings: this.atomApplication.configFile.get()
+      }, this.loadSettings))
+    })
+
     this.handleEvents()
 
     this.loadSettings = Object.assign({}, settings)
@@ -95,8 +101,6 @@ class AtomWindow extends EventEmitter {
 
     this.representedDirectoryPaths = this.loadSettings.initialPaths
     if (!this.loadSettings.env) this.env = this.loadSettings.env
-
-    this.browserWindow.loadSettingsJSON = JSON.stringify(this.loadSettings)
 
     this.browserWindow.on('window:loaded', () => {
       this.disableZoom()
@@ -244,6 +248,14 @@ class AtomWindow extends EventEmitter {
   async openLocations (locationsToOpen) {
     await this.loadedPromise
     this.sendMessage('open-locations', locationsToOpen)
+  }
+
+  didChangeUserSettings (settings) {
+    this.sendMessage('did-change-user-settings', settings)
+  }
+
+  didFailToReadUserSettings (message) {
+    this.sendMessage('did-fail-to-read-user-settings', message)
   }
 
   replaceEnvironment (env) {
@@ -414,7 +426,6 @@ class AtomWindow extends EventEmitter {
     this.representedDirectoryPaths = representedDirectoryPaths
     this.representedDirectoryPaths.sort()
     this.loadSettings.initialPaths = this.representedDirectoryPaths
-    this.browserWindow.loadSettingsJSON = JSON.stringify(this.loadSettings)
     return this.atomApplication.saveCurrentWindowOptions()
   }
 

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -19,6 +19,16 @@ module.exports = function start (resourcePath, startTime) {
     }
   })
 
+  process.on('unhandledRejection', function (error = {}) {
+    if (error.message != null) {
+      console.log(error.message)
+    }
+
+    if (error.stack != null) {
+      console.log(error.stack)
+    }
+  })
+
   const previousConsoleLog = console.log
   console.log = nslog
 


### PR DESCRIPTION
### Motivation

When your config settings are updated from within Atom (e.g. when you change settings in the [settings view](https://github.com/atom/settings-view)), the new settings are written to your `config.cson`. Each window process does this independently, and also sets up its own independent file watcher to detect when `config.cson` changes.

When settings are updated simultaneously in *multiple* Atom windows, the `config.cson` file can be written to simultaneously by multiple window processes and become corrupted. This rarely happens since it is hard for a user to simultaneously interact with multiple Atom windows. The most common way that it occurs is when quitting (or restarting) the app. Certain packages update your settings during deactivation, which is problematic if multiple windows are being closed at once.

### Solution

This PR reorganizes our interaction with `config.cson` so that it is centralized in the main process. The main process sets up one *single* file watcher and notifies all of the window processes when `config.cson` changes. Similarly, when settings are updated in some window, that window sends the new settings to the main process, and *it* takes care of writing them to disk.

In the process, I've made all the IO relating to `config.cson` asynchronous.

### Drawbacks

If you run multiple instances of Atom (e.g. Atom Beta and Atom Stable) simultaneously, it is theoretically possible that the two *main* processes could still end up writing to `config.cson` simultaneously. It would be more difficult to cause this to happen though; you'd have to perform some action that affected not only multiple windows, but *multiple applications* simultaneously.

We could still later introduce some kind of lock file, but I'm not sure it's worth it anymore, since contention will now be so uncommon.

Fixes https://github.com/atom/atom/issues/14909