### PR TITLE
Fix typo in TreeSitterLanguageMode.onDidChangeHighlighting

### DIFF
--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -64,7 +64,7 @@ class TreeSitterLanguageMode {
   }
 
   onDidChangeHighlighting (callback) {
-    return this.emitter.on('did-change-hightlighting', callback)
+    return this.emitter.on('did-change-highlighting', callback)
   }
 
   classNameForScopeId (scopeId) {


### PR DESCRIPTION
😬  A typo in the event name was causing the `onDidChangeHighlighting` method to *never* call its callback. The `TreeSitterLanguageMode` tests weren't catching this because they would always invalidate the display layer's screen line cache in order to test another aspect of highlighting. This fixes the tests so that they properly test the invalidation.

/cc @nathansobo @Ben3eeE 