### PR TITLE
Register for `core.titleBar` changes after the initial load of config

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -146,8 +146,6 @@ class AtomApplication extends EventEmitter {
       this.config.set('core.titleBar', 'custom')
     }
 
-    this.config.onDidChange('core.titleBar', this.promptForRestart.bind(this))
-
     process.nextTick(() => this.autoUpdateManager.initialize())
     this.applicationMenu = new ApplicationMenu(this.version, this.autoUpdateManager)
     this.atomProtocolHandler = new AtomProtocolHandler(this.resourcePath, this.safeMode)
@@ -171,6 +169,7 @@ class AtomApplication extends EventEmitter {
     if (!this.configFilePromise) {
       this.configFilePromise = this.configFile.watch()
       this.disposable.add(await this.configFilePromise)
+      this.config.onDidChange('core.titleBar', this.promptForRestart.bind(this))
     }
 
     const optionsForWindowsToOpen = []


### PR DESCRIPTION
This pull request prevents the change handler for `core.titleBar` from being triggered every time a new instance of the main process is created. This fixes a regression that was causing users to be prompted for a restart every time they opened Atom.

🍐'd with @maxbrunsfeld and @nathansobo 