### PR TITLE
Enable packages to control order of context menu items

### DIFF
--- a/spec/context-menu-manager-spec.coffee
+++ b/spec/context-menu-manager-spec.coffee
@@ -333,3 +333,46 @@ describe "ContextMenuManager", ->
             }
           ]
         ])
+
+  describe "::templateForEvent(target) (sorting)", ->
+    it "applies simple sorting rules", ->
+      contextMenu.add('.parent': [{
+        label: 'My Command',
+        command: "test:my-command",
+        after: ["test:my-other-command"]
+      }, {
+        label: 'My Other Command',
+        command: "test:my-other-command",
+      }])
+      dispatchedEvent = {target: parent}
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([{
+        label: 'My Other Command',
+        command: 'test:my-other-command',
+      }, {
+        label: 'My Command',
+        command: 'test:my-command',
+        after: ["test:my-other-command"]
+      }])
+
+    it "applies sorting rules recursively to submenus", ->
+      contextMenu.add('.parent': [{
+        submenu: [{
+          label: 'My Command',
+          command: "test:my-command",
+          after: ["test:my-other-command"]
+        }, {
+          label: 'My Other Command',
+          command: "test:my-other-command",
+        }]
+      }])
+      dispatchedEvent = {target: parent}
+      expect(contextMenu.templateForEvent(dispatchedEvent)).toEqual([{
+        submenu: [{
+          label: 'My Other Command',
+          command: 'test:my-other-command',
+        }, {
+          label: 'My Command',
+          command: 'test:my-command',
+          after: ["test:my-other-command"]
+        }]
+      }])

--- a/spec/menu-sort-helpers-spec.js
+++ b/spec/menu-sort-helpers-spec.js
@@ -7,12 +7,14 @@ describe('contextMenu', () => {
       expect(sortMenuItems(items)).toEqual(items)
     })
   })
+
   describe('dedupes separators', () => {
     it('trims leading separators', () => {
       const items = [{ type: 'separator' }, { command: 'core:one' }]
       const expected = [{ command: 'core:one' }]
       expect(sortMenuItems(items)).toEqual(expected)
     })
+
     it('preserves separators at the begining of set two', () => {
       const items = [
         { command: 'core:one' },
@@ -25,11 +27,13 @@ describe('contextMenu', () => {
       ]
       expect(sortMenuItems(items)).toEqual(expected)
     })
+
     it('trims trailing separators', () => {
       const items = [{ command: 'core:one' }, { type: 'separator' }]
       const expected = [{ command: 'core:one' }]
       expect(sortMenuItems(items)).toEqual(expected)
     })
+
     it('removes duplicate separators across sets', () => {
       const items = [
         { command: 'core:one' }, { type: 'separator' },
@@ -43,6 +47,7 @@ describe('contextMenu', () => {
       expect(sortMenuItems(items)).toEqual(expected)
     })
   })
+
   describe('can move an item to a different group by merging groups', () => {
     it('can move a group of one item', () => {
       const items = [
@@ -61,6 +66,7 @@ describe('contextMenu', () => {
       ]
       expect(sortMenuItems(items)).toEqual(expected)
     })
+
     it("moves all items in the moving item's group", () => {
       const items = [
         { command: 'core:one' },
@@ -80,6 +86,7 @@ describe('contextMenu', () => {
       ]
       expect(sortMenuItems(items)).toEqual(expected)
     })
+
     it("ignores positions relative to commands that don't exist", () => {
       const items = [
         { command: 'core:one' },
@@ -99,6 +106,7 @@ describe('contextMenu', () => {
       ]
       expect(sortMenuItems(items)).toEqual(expected)
     })
+
     it('can handle recursive group merging', () => {
       const items = [
         { command: 'core:one', after: ['core:three'] },
@@ -112,6 +120,7 @@ describe('contextMenu', () => {
       ]
       expect(sortMenuItems(items)).toEqual(expected)
     })
+
     it('can merge multiple groups when given a list of before/after commands', () => {
       const items = [
         { command: 'core:one' },
@@ -127,6 +136,7 @@ describe('contextMenu', () => {
       ]
       expect(sortMenuItems(items)).toEqual(expected)
     })
+
     it('can merge multiple groups based on both before/after commands', () => {
       const items = [
         { command: 'core:one' },
@@ -143,6 +153,7 @@ describe('contextMenu', () => {
       expect(sortMenuItems(items)).toEqual(expected)
     })
   })
+
   describe('sorts items within their ultimate group', () => {
     it('does a simple sort', () => {
       const items = [
@@ -154,6 +165,7 @@ describe('contextMenu', () => {
         { command: 'core:two', after: ['core:one'] }
       ])
     })
+
     it('resolves cycles by ignoring things that conflict', () => {
       const items = [
         { command: 'core:two', after: ['core:one'] },
@@ -165,6 +177,7 @@ describe('contextMenu', () => {
       ])
     })
   })
+
   describe('sorts groups', () => {
     it('does a simple sort', () => {
       const items = [
@@ -178,6 +191,7 @@ describe('contextMenu', () => {
         { command: 'core:two', afterGroupContaining: ['core:one'] }
       ])
     })
+
     it('resolves cycles by ignoring things that conflict', () => {
       const items = [
         { command: 'core:two', afterGroupContaining: ['core:one'] },
@@ -190,6 +204,7 @@ describe('contextMenu', () => {
         { command: 'core:two', afterGroupContaining: ['core:one'] }
       ])
     })
+
     it('ignores references to commands that do not exist', () => {
       const items = [
         { command: 'core:one' },
@@ -205,6 +220,7 @@ describe('contextMenu', () => {
         { command: 'core:two', afterGroupContaining: ['core:does-not-exist'] }
       ])
     })
+
     it('only respects the first matching [before|after]GroupContaining rule in a given group', () => {
       const items = [
         { command: 'core:one' },

--- a/spec/menu-sort-helpers-spec.js
+++ b/spec/menu-sort-helpers-spec.js
@@ -1,0 +1,227 @@
+const {sortMenuItems} = require('../src/menu-sort-helpers')
+
+describe('contextMenu', () => {
+  describe('dedupes separators', () => {
+    it('preserves existing submenus', () => {
+      const items = [{ submenu: [] }]
+      expect(sortMenuItems(items)).toEqual(items)
+    })
+  })
+  describe('dedupes separators', () => {
+    it('trims leading separators', () => {
+      const items = [{ type: 'separator' }, { command: 'core:one' }]
+      const expected = [{ command: 'core:one' }]
+      expect(sortMenuItems(items)).toEqual(expected)
+    })
+    it('preserves separators at the begining of set two', () => {
+      const items = [
+        { command: 'core:one' },
+        { type: 'separator' }, { command: 'core:two' }
+      ]
+      const expected = [
+        { command: 'core:one' },
+        { type: 'separator' },
+        { command: 'core:two' }
+      ]
+      expect(sortMenuItems(items)).toEqual(expected)
+    })
+    it('trims trailing separators', () => {
+      const items = [{ command: 'core:one' }, { type: 'separator' }]
+      const expected = [{ command: 'core:one' }]
+      expect(sortMenuItems(items)).toEqual(expected)
+    })
+    it('removes duplicate separators across sets', () => {
+      const items = [
+        { command: 'core:one' }, { type: 'separator' },
+        { type: 'separator' }, { command: 'core:two' }
+      ]
+      const expected = [
+        { command: 'core:one' },
+        { type: 'separator' },
+        { command: 'core:two' }
+      ]
+      expect(sortMenuItems(items)).toEqual(expected)
+    })
+  })
+  describe('can move an item to a different group by merging groups', () => {
+    it('can move a group of one item', () => {
+      const items = [
+        { command: 'core:one' },
+        { type: 'separator' },
+        { command: 'core:two' },
+        { type: 'separator' },
+        { command: 'core:three', after: ['core:one'] },
+        { type: 'separator' }
+      ]
+      const expected = [
+        { command: 'core:one' },
+        { command: 'core:three', after: ['core:one'] },
+        { type: 'separator' },
+        { command: 'core:two' }
+      ]
+      expect(sortMenuItems(items)).toEqual(expected)
+    })
+    it("moves all items in the moving item's group", () => {
+      const items = [
+        { command: 'core:one' },
+        { type: 'separator' },
+        { command: 'core:two' },
+        { type: 'separator' },
+        { command: 'core:three', after: ['core:one'] },
+        { command: 'core:four' },
+        { type: 'separator' }
+      ]
+      const expected = [
+        { command: 'core:one' },
+        { command: 'core:three', after: ['core:one'] },
+        { command: 'core:four' },
+        { type: 'separator' },
+        { command: 'core:two' }
+      ]
+      expect(sortMenuItems(items)).toEqual(expected)
+    })
+    it("ignores positions relative to commands that don't exist", () => {
+      const items = [
+        { command: 'core:one' },
+        { type: 'separator' },
+        { command: 'core:two' },
+        { type: 'separator' },
+        { command: 'core:three', after: ['core:does-not-exist'] },
+        { command: 'core:four', after: ['core:one'] },
+        { type: 'separator' }
+      ]
+      const expected = [
+        { command: 'core:one' },
+        { command: 'core:three', after: ['core:does-not-exist'] },
+        { command: 'core:four', after: ['core:one'] },
+        { type: 'separator' },
+        { command: 'core:two' }
+      ]
+      expect(sortMenuItems(items)).toEqual(expected)
+    })
+    it('can handle recursive group merging', () => {
+      const items = [
+        { command: 'core:one', after: ['core:three'] },
+        { command: 'core:two', before: ['core:one'] },
+        { command: 'core:three' }
+      ]
+      const expected = [
+        { command: 'core:three' },
+        { command: 'core:two', before: ['core:one'] },
+        { command: 'core:one', after: ['core:three'] }
+      ]
+      expect(sortMenuItems(items)).toEqual(expected)
+    })
+    it('can merge multiple groups when given a list of before/after commands', () => {
+      const items = [
+        { command: 'core:one' },
+        { type: 'separator' },
+        { command: 'core:two' },
+        { type: 'separator' },
+        { command: 'core:three', after: ['core:one', 'core:two'] }
+      ]
+      const expected = [
+        { command: 'core:two' },
+        { command: 'core:one' },
+        { command: 'core:three', after: ['core:one', 'core:two'] }
+      ]
+      expect(sortMenuItems(items)).toEqual(expected)
+    })
+    it('can merge multiple groups based on both before/after commands', () => {
+      const items = [
+        { command: 'core:one' },
+        { type: 'separator' },
+        { command: 'core:two' },
+        { type: 'separator' },
+        { command: 'core:three', after: ['core:one'], before: ['core:two'] }
+      ]
+      const expected = [
+        { command: 'core:one' },
+        { command: 'core:three', after: ['core:one'], before: ['core:two'] },
+        { command: 'core:two' }
+      ]
+      expect(sortMenuItems(items)).toEqual(expected)
+    })
+  })
+  describe('sorts items within their ultimate group', () => {
+    it('does a simple sort', () => {
+      const items = [
+        { command: 'core:two', after: ['core:one'] },
+        { command: 'core:one' }
+      ]
+      expect(sortMenuItems(items)).toEqual([
+        { command: 'core:one' },
+        { command: 'core:two', after: ['core:one'] }
+      ])
+    })
+    it('resolves cycles by ignoring things that conflict', () => {
+      const items = [
+        { command: 'core:two', after: ['core:one'] },
+        { command: 'core:one', after: ['core:two'] }
+      ]
+      expect(sortMenuItems(items)).toEqual([
+        { command: 'core:one', after: ['core:two'] },
+        { command: 'core:two', after: ['core:one'] }
+      ])
+    })
+  })
+  describe('sorts groups', () => {
+    it('does a simple sort', () => {
+      const items = [
+        { command: 'core:two', afterGroupContaining: ['core:one'] },
+        { type: 'separator' },
+        { command: 'core:one' }
+      ]
+      expect(sortMenuItems(items)).toEqual([
+        { command: 'core:one' },
+        { type: 'separator' },
+        { command: 'core:two', afterGroupContaining: ['core:one'] }
+      ])
+    })
+    it('resolves cycles by ignoring things that conflict', () => {
+      const items = [
+        { command: 'core:two', afterGroupContaining: ['core:one'] },
+        { type: 'separator' },
+        { command: 'core:one', afterGroupContaining: ['core:two'] }
+      ]
+      expect(sortMenuItems(items)).toEqual([
+        { command: 'core:one', afterGroupContaining: ['core:two'] },
+        { type: 'separator' },
+        { command: 'core:two', afterGroupContaining: ['core:one'] }
+      ])
+    })
+    it('ignores references to commands that do not exist', () => {
+      const items = [
+        { command: 'core:one' },
+        { type: 'separator' },
+        {
+          command: 'core:two',
+          afterGroupContaining: ['core:does-not-exist']
+        }
+      ]
+      expect(sortMenuItems(items)).toEqual([
+        { command: 'core:one' },
+        { type: 'separator' },
+        { command: 'core:two', afterGroupContaining: ['core:does-not-exist'] }
+      ])
+    })
+    it('only respects the first matching [before|after]GroupContaining rule in a given group', () => {
+      const items = [
+        { command: 'core:one' },
+        { type: 'separator' },
+        { command: 'core:three', beforeGroupContaining: ['core:one'] },
+        { command: 'core:four', afterGroupContaining: ['core:two'] },
+        { type: 'separator' },
+        { command: 'core:two' }
+      ]
+      expect(sortMenuItems(items)).toEqual([
+        { command: 'core:three', beforeGroupContaining: ['core:one'] },
+        { command: 'core:four', afterGroupContaining: ['core:two'] },
+        { type: 'separator' },
+        { command: 'core:one' },
+        { type: 'separator' },
+        { command: 'core:two' }
+      ])
+    })
+  })
+})

--- a/src/context-menu-manager.coffee
+++ b/src/context-menu-manager.coffee
@@ -5,6 +5,7 @@ fs = require 'fs-plus'
 {Disposable} = require 'event-kit'
 {remote} = require 'electron'
 MenuHelpers = require './menu-helpers'
+{sortMenuItems} = require './menu-sort-helpers'
 
 platformContextMenu = require('../package.json')?._atomMenu?['context-menu']
 
@@ -149,7 +150,7 @@ class ContextMenuManager
     @pruneRedundantSeparators(template)
     @addAccelerators(template)
 
-    template
+    return @sortTemplate(template)
 
   # Adds an `accelerator` property to items that have key bindings. Electron
   # uses this property to surface the relevant keymaps in the context menu.
@@ -174,6 +175,13 @@ class ContextMenuManager
       else
         keepNextItemIfSeparator = true
         index++
+
+  sortTemplate: (template) ->
+    template = sortMenuItems(template)
+    for id, item of template
+      if Array.isArray(item.submenu)
+        item.submenu = @sortTemplate(item.submenu)
+    return template
 
   # Returns an object compatible with `::add()` or `null`.
   cloneItemForEvent: (item, event) ->

--- a/src/menu-helpers.js
+++ b/src/menu-helpers.js
@@ -83,7 +83,11 @@ function cloneMenuItem (item) {
     'submenu',
     'commandDetail',
     'role',
-    'accelerator'
+    'accelerator',
+    'before',
+    'after',
+    'beforeGroupContaining',
+    'afterGroupContaining'
   )
   if (item.submenu != null) {
     item.submenu = item.submenu.map(submenuItem => cloneMenuItem(submenuItem))

--- a/src/menu-sort-helpers.js
+++ b/src/menu-sort-helpers.js
@@ -64,13 +64,7 @@ function sortTopologically (originalOrder, edgesById) {
     sorted.push(id)
   }
 
-  while (true) {
-    const unmarkedId = originalOrder.find(id => !marked.has(id))
-    if (unmarkedId == null) {
-      break
-    }
-    visit(unmarkedId)
-  }
+  originalOrder.forEach(visit)
   return sorted
 }
 

--- a/src/menu-sort-helpers.js
+++ b/src/menu-sort-helpers.js
@@ -45,7 +45,7 @@ function indexOfGroupContainingCommand (groups, command, ignoreGroup) {
 }
 
 // Sort nodes topologically using a depth-first approach. Encountered cycles
-// and broken.
+// are broken.
 function sortTopologically (originalOrder, edgesById) {
   const sorted = []
   const marked = new Set()

--- a/src/menu-sort-helpers.js
+++ b/src/menu-sort-helpers.js
@@ -1,0 +1,192 @@
+// UTILS
+
+function splitArray (arr, predicate) {
+  let lastArr = []
+  const multiArr = [lastArr]
+  arr.forEach(item => {
+    if (predicate(item)) {
+      if (lastArr.length > 0) {
+        lastArr = []
+        multiArr.push(lastArr)
+      }
+    } else {
+      lastArr.push(item)
+    }
+  })
+  return multiArr
+}
+
+function joinArrays (arrays, joiner) {
+  const joinedArr = []
+  arrays.forEach((arr, i) => {
+    if (i > 0 && arr.length > 0) {
+      joinedArr.push(joiner)
+    }
+    joinedArr.push(...arr)
+  })
+  return joinedArr
+}
+
+const pushOntoMultiMap = (map, key, value) => {
+  if (!map.has(key)) {
+    map.set(key, [])
+  }
+  map.get(key).push(value)
+}
+
+function indexOfGroupContainingCommand (groups, command, ignoreGroup) {
+  return groups.findIndex(
+    candiateGroup =>
+      candiateGroup !== ignoreGroup &&
+      candiateGroup.some(
+        candidateItem => candidateItem.command === command
+      )
+  )
+}
+
+// Sort nodes topologically using a depth-first approach. Encountered cycles
+// and broken.
+function sortTopologically (originalOrder, edgesById) {
+  const sorted = []
+  const marked = new Set()
+
+  function visit (id) {
+    if (marked.has(id)) {
+      // Either this node has already been placed, or we have encountered a
+      // cycle and need to exit.
+      return
+    }
+    marked.add(id)
+    const edges = edgesById.get(id)
+    if (edges != null) {
+      edges.forEach(visit)
+    }
+    sorted.push(id)
+  }
+
+  while (true) {
+    const unmarkedId = originalOrder.find(id => !marked.has(id))
+    if (unmarkedId == null) {
+      break
+    }
+    visit(unmarkedId)
+  }
+  return sorted
+}
+
+function attemptToMergeAGroup (groups) {
+  for (let i = 0; i < groups.length; i++) {
+    const group = groups[i]
+    for (const item of group) {
+      const toCommands = [...(item.before || []), ...(item.after || [])]
+      for (const command of toCommands) {
+        const index = indexOfGroupContainingCommand(groups, command, group)
+        if (index === -1) {
+          // No valid edge for this command
+          continue
+        }
+        const mergeTarget = groups[index]
+        // Merge with group containing `command`
+        mergeTarget.push(...group)
+        groups.splice(i, 1)
+        return true
+      }
+    }
+  }
+  return false
+}
+
+// Merge groups based on before/after positions
+// Mutates both the array of groups, and the individual group arrays.
+function mergeGroups (groups) {
+  let mergedAGroup = true
+  while (mergedAGroup) {
+    mergedAGroup = attemptToMergeAGroup(groups)
+  }
+  return groups
+}
+
+function sortItemsInGroup (group) {
+  const originalOrder = group.map((node, i) => i)
+  const edges = new Map()
+  const commandToIndex = new Map(group.map((item, i) => [item.command, i]))
+
+  group.forEach((item, i) => {
+    if (item.before) {
+      item.before.forEach(toCommand => {
+        const to = commandToIndex.get(toCommand)
+        if (to != null) {
+          pushOntoMultiMap(edges, to, i)
+        }
+      })
+    }
+    if (item.after) {
+      item.after.forEach(toCommand => {
+        const to = commandToIndex.get(toCommand)
+        if (to != null) {
+          pushOntoMultiMap(edges, i, to)
+        }
+      })
+    }
+  })
+
+  const sortedNodes = sortTopologically(originalOrder, edges)
+
+  return sortedNodes.map(i => group[i])
+}
+
+function findEdgesInGroup (groups, i, edges) {
+  const group = groups[i]
+  for (const item of group) {
+    if (item.beforeGroupContaining) {
+      for (const command of item.beforeGroupContaining) {
+        const to = indexOfGroupContainingCommand(groups, command, group)
+        if (to !== -1) {
+          pushOntoMultiMap(edges, to, i)
+          return
+        }
+      }
+    }
+    if (item.afterGroupContaining) {
+      for (const command of item.afterGroupContaining) {
+        const to = indexOfGroupContainingCommand(groups, command, group)
+        if (to !== -1) {
+          pushOntoMultiMap(edges, i, to)
+          return
+        }
+      }
+    }
+  }
+}
+
+function sortGroups (groups) {
+  const originalOrder = groups.map((item, i) => i)
+  const edges = new Map()
+
+  for (let i = 0; i < groups.length; i++) {
+    findEdgesInGroup(groups, i, edges)
+  }
+
+  const sortedGroupIndexes = sortTopologically(originalOrder, edges)
+  return sortedGroupIndexes.map(i => groups[i])
+}
+
+function isSeparator (item) {
+  return item.type === 'separator'
+}
+
+function sortMenuItems (menuItems) {
+  // Split the items into their implicit groups based upon separators.
+  const groups = splitArray(menuItems, isSeparator)
+  // Merge groups that contain before/after references to eachother.
+  const mergedGroups = mergeGroups(groups)
+  // Sort each individual group internally.
+  const mergedGroupsWithSortedItems = mergedGroups.map(sortItemsInGroup)
+  // Sort the groups based upon their beforeGroupContaining/afterGroupContaining
+  // references.
+  const sortedGroups = sortGroups(mergedGroupsWithSortedItems)
+  // Join the groups back
+  return joinArrays(sortedGroups, { type: 'separator' })
+}
+
+module.exports = {sortMenuItems}


### PR DESCRIPTION
### Goals:

* Allow packages to share context menu “groups” (sets of context menu items delineated by separators). For example, a package should be able to provide a “Copy Full Path” context menu item which lives in the same group as the core “Copy” item.
* Allow packages to control the ordering of context menu items.
* Allow packages to control the order of context menu groups.

### Constraints:

* Packages should be able to position their items alongside other package's items without requiring the other package to make any changes.
* The current sorting behavior should be maintained for context menus which do not contain any items which use this new option.
* Packages may make ordering requests which are in contradictory. In this case, some ordering requests must be ignored in a deterministic way.

### Prior work:

* There has been at least [one prior proposal](https://github.com/atom/atom/issues/6270) to (discussion [here](https://discuss.atom.io/t/is-there-a-way-to-specify-menu-item-order-when-inserting-menu-items/14937)) support ordering in Atom context menus. It got as far as [merging support into Electron](https://github.com/electron/electron/pull/1373). Unfortunately, the Electron implementation has [some problems](https://github.com/electron/electron/issues/11668), and the Atom support was never implemented.
* The prior proposal seems to be based upon the the [API that Eclipse has](https://help.eclipse.org/luna/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fextension-points%2Forg_eclipse_ui_menus.html).

> ![screen shot 2018-01-25 at 2 28 25 pm](https://user-images.githubusercontent.com/162735/35655082-ee0ed606-06a4-11e8-97ff-9c4a9b47c424.png)

-- Extract from the Eclipse documentation.

### Proposed Solution:

* Add four new optional properties to the context menu items accepted by atom.contextMenu.add() each accepting as its value either an array of atom commands. The four properties are:
    * `before`
    * `after`
    * `beforeGroupContaining`
    * `afterGroupContaining`
* `before`/`after` Provide a means for a single context menu item to declare their placement relative to another context menu item. These also imply that menu item in question should be placed in the same “group” as the item 
* `beforeGroupContaining`/`afterGroupContaining` Provide a means for a single context menu to declare the placement of their containing group, relative to the containing group of the specified item. Ideally these could be declared on some entity representing the notion of a “group”, but no such entity exists at this time, and I don't believe it's worth introducing a new construct within this API.

Edge case handling:

* If no menu item with the given command exists, the relationship is ignored. This allows package authors to declare positioning relative to packages which the user may or may not have installed.
* When a menu item attempts to position itself relative to another item, the two groups are joined. Note that this can happen recursively.
* If two sets of menu items are provided by two consecutive plugins, and they don't delineate their items with separators, the items at the boundaries will be merged together into a group. If any item in that group specifies its position, it would cause all items in that new group to be relocated.

Possible challenges:

* This approach assumes that context menus do not contain multiple entries that dispatch the same command. I can't think of any rational case in which this would happen, but it could be that there is some case I have not thought of. Another option would be for menu items to declare their position relative to other items via the other item's label. This would have the advantage that Atom is already enforcing label uniqueness, but it does not seem as stable for me. Localization would be one reason to avoid using labels as an item's unique identifier.

