### PR TITLE
Optimize process kill by pid

### DIFF
--- a/src/buffered-process.js
+++ b/src/buffered-process.js
@@ -189,12 +189,12 @@ class BufferedProcess {
       output += data
     })
     wmicProcess.stdout.on('close', () => {
-      const pidsToKill = output.split(/\s+/)
-        .filter((pid) => /^\d+$/.test(pid))
-        .map((pid) => parseInt(pid))
-        .filter((pid) => pid !== parentPid && pid > 0 && pid < Infinity)
+      for (let pid of output.split(/\s+/)) {
+        if (!/^\d{1,10}$/.test(pid)) continue
+        pid = parseInt(pid, 10)
 
-      for (let pid of pidsToKill) {
+        if (!pid || pid === parentPid) continue
+
         try {
           process.kill(pid)
         } catch (error) {}


### PR DESCRIPTION
### Description of the Change
Minor refactoring code for killing process.
Used **1** `for loop` instead of **4** `for loops`

### Benefits

Improve performance
<!-- What benefits will be realized by the code change? -->

