### PR TITLE
add `configurable: true` to browserwindow.loadSettingsJSON

### DIFF
--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -57,8 +57,9 @@ class AtomWindow extends EventEmitter {
 
     Object.defineProperty(this.browserWindow, 'loadSettingsJSON', {
       get: () => JSON.stringify(Object.assign({
-        userSettings: this.atomApplication.configFile.get()
-      }, this.loadSettings))
+        userSettings: this.atomApplication.configFile.get(),
+      }, this.loadSettings)),
+      configurable: true
     })
 
     this.handleEvents()

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -57,7 +57,7 @@ class AtomWindow extends EventEmitter {
 
     Object.defineProperty(this.browserWindow, 'loadSettingsJSON', {
       get: () => JSON.stringify(Object.assign({
-        userSettings: this.atomApplication.configFile.get(),
+        userSettings: this.atomApplication.configFile.get()
       }, this.loadSettings)),
       configurable: true
     })


### PR DESCRIPTION
### Description of the Change

Some packages, including Facebook's Nuclide, rely on monkey-patching browserWindow.loadSettingsJSON. Recent changes to the master branch of atom (the addition of the ConfigFile class / related code) changed the behavior of this property, adding a getter using Object.defineProperty. 

With Object.defineProperty, `configurable` defaults to false, and it is impossible for packages to monkeypatch loadSettingsJSON. At the moment, this is a breaking change in Nuclide. Adding the `configurable: true` flag fixes this regression and allows us to redefine the getter.

### Alternate Designs

Ideally we would like to fix the regression with only changes to Nuclide, but we could not find another way to monkeypatch browserWindow.loadSettingsJSON, without adding `configurable: true` to Object.defineProperty. If someone knows of an approach we would love to hear! 

### Why Should This Be In Core?

To fix a regression caused by a recent update to core. 