### PR TITLE
Correct Interactions with Scrollbars and Cursors when switching between split panes

### DIFF
--- a/spec/pane-element-spec.coffee
+++ b/spec/pane-element-spec.coffee
@@ -240,8 +240,8 @@ describe "PaneElement", ->
       itemChild.focus()
       expect(activationCount).toBe(0)
 
-  describe "when the pane element is focused but the activeItem does not change" ->
-    it "refocuses activeItem when pane element becomes focused"
+  describe "when the pane element is focused but the activeItem does not change", ->
+    it "refocuses activeItem when pane element becomes focused", ->
       item = document.createElement('div')
       item.tabIndex = -1
       pane.activateItem(item)

--- a/spec/pane-element-spec.coffee
+++ b/spec/pane-element-spec.coffee
@@ -240,6 +240,22 @@ describe "PaneElement", ->
       itemChild.focus()
       expect(activationCount).toBe(0)
 
+  describe "when the pane element is focused but the activeItem does not change" ->
+    it "refocuses activeItem when pane element becomes focused"
+      item = document.createElement('div')
+      item.tabIndex = -1
+      pane.activateItem(item)
+      jasmine.attachToDOM(paneElement)
+
+      expect(document.activeElement).toBe document.body
+      paneElement.focus()
+      expect(document.activeElement).toBe item
+      paneElement.blur()
+      expect(document.activeElement).toBe document.body
+      paneElement.focus()
+      expect(document.activeElement).toBe item
+
+
   describe "when the pane element is attached", ->
     it "focuses the pane element if isFocused() returns true on its model", ->
       pane.focus()

--- a/src/pane-element.coffee
+++ b/src/pane-element.coffee
@@ -131,8 +131,7 @@ class PaneElement extends HTMLElement
   flexScaleChanged: (flexScale) ->
     @style.flexGrow = flexScale
 
-  getActiveView: -> @views.getView(@model.getActiveItem())
-
+  getActiveView: -> @views.getView(@model.getActiveItem()).focus()
   hasFocus: ->
     this is document.activeElement or @contains(document.activeElement)
 

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -734,6 +734,8 @@ class TextEditorComponent {
       let canScrollHorizontally, canScrollVertically
 
       if (this.hasInitialMeasurements) {
+        if (this.refs.verticalScrollbar) this.refs.verticalScrollbar.flushScrollPosition()
+        if (this.refs.horizontalScrollbar) this.refs.horizontalScrollbar.flushScrollPosition()
         scrollHeight = this.getScrollHeight()
         scrollWidth = this.getScrollWidth()
         scrollTop = this.getScrollTop()
@@ -1415,9 +1417,6 @@ class TextEditorComponent {
 
       if (this.isVisible()) {
         this.didShow()
-
-        if (this.refs.verticalScrollbar) this.refs.verticalScrollbar.flushScrollPosition()
-        if (this.refs.horizontalScrollbar) this.refs.horizontalScrollbar.flushScrollPosition()
       } else {
         this.didHide()
       }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
There's two changes in this pull request:
1. Flushing scroll position to dummy scrollbar when rendering if initial measurements are present
2. Refocusing the active item of a pane when a pane focuses, but the active item does not change

### Alternate Designs
N/A

### Why Should This Be In Core?
These changes should be in core because they relate to the core functions of text-editors and panes

### Benefits
Corrects annoying effects of splitting panes and switching between editors

### Possible Drawbacks
N/A

### Verification Process
To verify scroll position: 

1. Open a file, and scroll down to bottom
2. Open a second file in the same pane
3. Right click on the second file and select split pane
4. Navigate back to first that was opened
5. Verify that scrollbar is in the same position that it was left in

To verify text editor becomes active

1. Open a file and click somewhere in the file
2. Open a second file in another pane
3. Click the tab of the first file
4. Verify that the cursor becomes active when the tab was clicked

### Applicable Issues
[#15585](https://github.com/atom/atom/issues/15585)
[#14985](https://github.com/atom/atom/issues/14985) kind of related... I found that manually clicking between the tabs also makes the cursor disappear because the active text editor is not re-focused
