### PR TITLE
Add custom properties to atom-workspace to track editor properties

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -380,7 +380,7 @@ const configSchema = {
       // These can be used as globals or scoped, thus defaults.
       fontFamily: {
         type: 'string',
-        default: '',
+        default: 'Menlo, Consolas, DejaVu Sans Mono, monospace',
         description: 'The name of the font family used for editor text.'
       },
       fontSize: {

--- a/src/workspace-element.js
+++ b/src/workspace-element.js
@@ -58,7 +58,7 @@ class WorkspaceElement extends HTMLElement {
   updateGlobalTextEditorStyleSheet () {
     const styleSheetSource = `atom-workspace {
   --editor-font-size: ${this.config.get('editor.fontSize')}px;
-  --editor-font-family: ${this.config.get('editor.fontFamily')}, monospace;
+  --editor-font-family: ${this.config.get('editor.fontFamily')};
   --editor-line-height: ${this.config.get('editor.lineHeight')};
 }`
     this.styleManager.addStyleSheet(styleSheetSource, {sourcePath: 'global-text-editor-styles', priority: -1})

--- a/src/workspace-element.js
+++ b/src/workspace-element.js
@@ -56,10 +56,16 @@ class WorkspaceElement extends HTMLElement {
   }
 
   updateGlobalTextEditorStyleSheet () {
-    const styleSheetSource = `atom-text-editor {
-  font-size: ${this.config.get('editor.fontSize')}px;
-  font-family: ${this.config.get('editor.fontFamily')};
-  line-height: ${this.config.get('editor.lineHeight')};
+    const styleSheetSource = `atom-workspace {
+  --editor-font-size: ${this.config.get('editor.fontSize')}px;
+  --editor-font-family: ${this.config.get('editor.fontFamily')};
+  --editor-line-height: ${this.config.get('editor.lineHeight')};
+}
+
+atom-text-editor {
+  font-family: var(--editor-font-family);
+  font-size: var(--editor-font-size);
+  line-height: var(--editor-line-height);
 }`
     this.styleManager.addStyleSheet(styleSheetSource, {sourcePath: 'global-text-editor-styles', priority: -1})
   }

--- a/src/workspace-element.js
+++ b/src/workspace-element.js
@@ -58,14 +58,8 @@ class WorkspaceElement extends HTMLElement {
   updateGlobalTextEditorStyleSheet () {
     const styleSheetSource = `atom-workspace {
   --editor-font-size: ${this.config.get('editor.fontSize')}px;
-  --editor-font-family: ${this.config.get('editor.fontFamily')};
+  --editor-font-family: ${this.config.get('editor.fontFamily')}, monospace;
   --editor-line-height: ${this.config.get('editor.lineHeight')};
-}
-
-atom-text-editor {
-  font-family: var(--editor-font-family);
-  font-size: var(--editor-font-size);
-  line-height: var(--editor-line-height);
 }`
     this.styleManager.addStyleSheet(styleSheetSource, {sourcePath: 'global-text-editor-styles', priority: -1})
   }

--- a/static/text-editor.less
+++ b/static/text-editor.less
@@ -4,8 +4,10 @@
 
 atom-text-editor {
   display: flex;
-  font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
   cursor: text;
+  font-family: var(--editor-font-family);
+  font-size: var(--editor-font-size);
+  line-height: var(--editor-line-height);
 
   .gutter-container {
     width: min-content;

--- a/static/text-editor.less
+++ b/static/text-editor.less
@@ -2,6 +2,11 @@
 @import "octicon-utf-codes";
 @import "octicon-mixins";
 
+:root {
+  // Fixes specs
+  --editor-font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+}
+
 atom-text-editor {
   display: flex;
   cursor: text;


### PR DESCRIPTION
### Description of the Change

Rather than directly setting rules on `atom-text-editor`, declare several CSS custom properties on the `atom-workspace` and then reference them in equivalent styling for `atom-text-editor`. These track the editor's current font size, font family, and line height.


### Alternate Designs

Declaring a set of static rules at the same time as the dynamically injected ones feels weird. On the other hand, I attempted to define these statically in `text-editor.less` and this resulted in inconsistent application when reloading the editor.

### Why Should This Be In Core?

Many packages can rely on this without bundling similar functionality for monitoring these changes. Additionally, in core we can use generic names like `--editor-font-size` without the need for something like a prefix.

### Benefits

Many packages are manually monitoring these changes and updating styles directly. This avoids situations like:

* [atom/github tracking styles](https://github.com/atom/github/blob/cab6f0d37c0deda6bb218bb64a37ed97254cd530/lib/github-package.js#L158-L172)
* [Atom IDE Outline tracking styles](https://github.com/facebook-atom/atom-ide-ui/blob/master/modules/atom-ide-ui/pkg/atom-ide-outline-view/lib/OutlineView.js#L75-L85)

### Possible Drawbacks

We may move to custom properties in the long run for theming, and this might commit us to an API we may want to change later. Other than that, none I can think of. 


### Verification Process

Reload Atom and verify the three text editor properties. Change each at runtime through settings and verify each is reflected.

### Applicable Issues