### PR TITLE
Prefer package name from metadata

### DIFF
--- a/src/package.js
+++ b/src/package.js
@@ -43,8 +43,8 @@ class Package {
       ? params.bundledPackage
       : this.packageManager.isBundledPackagePath(this.path)
     this.name =
-      params.name ||
       (this.metadata && this.metadata.name) ||
+      params.name ||
       path.basename(this.path)
     this.reset()
   }


### PR DESCRIPTION
When loading a package prefer the name specified in the package metadata instead of the name of the folder that the package's files reside in.

Fixes #16703.