### PR TITLE
Normalize command line paths with windows drive letters

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -838,13 +838,12 @@ class AtomApplication extends EventEmitter {
     let existingWindow
     if (!newWindow) {
       existingWindow = this.windowForPaths(pathsToOpen, devMode)
-      const stats = pathsToOpen.map(pathToOpen => fs.statSyncNoException(pathToOpen))
       if (!existingWindow) {
         let lastWindow = window || this.getLastFocusedWindow()
         if (lastWindow && lastWindow.devMode === devMode) {
           if (addToLastWindow || (
-              stats.every(s => s.isFile && s.isFile()) ||
-              (stats.some(s => s.isDirectory && s.isDirectory()) && !lastWindow.hasProjectPath()))) {
+              locationsToOpen.every(({stat}) => stat && stat.isFile()) ||
+              (locationsToOpen.some(({stat}) => stat && stat.isDirectory()) && !lastWindow.hasProjectPath()))) {
             existingWindow = lastWindow
           }
         }
@@ -1267,11 +1266,11 @@ class AtomApplication extends EventEmitter {
       initialLine = initialColumn = null
     }
 
-    if (url.parse(pathToOpen).protocol == null) {
-      pathToOpen = path.resolve(executedFrom, fs.normalize(pathToOpen))
-    }
+    const normalizedPath = path.normalize(path.resolve(executedFrom, fs.normalize(pathToOpen)))
+    const stat = fs.statSyncNoException(normalizedPath)
+    if (stat) pathToOpen = normalizedPath
 
-    return {pathToOpen, initialLine, initialColumn}
+    return {pathToOpen, stat, initialLine, initialColumn}
   }
 
   // Opens a native dialog to prompt the user for a path.


### PR DESCRIPTION
Fixes #16740

In #16497, I generalized the behavior of `atom --wait` flag so that it will wait for a specific *file path* to close, rather than waiting for an entire *window* to close. Obviously, this new approach relies on file paths being represented consistently. In particular, if I open a file called `C:/my/repo/.git/COMMIT_EDITMSG` (forward slashes) the `--wait` session will not be terminated when I close a file called `C:\my\repo\.git\COMMIT_EDITMSG` (backslashes).

Previously, file paths passed as command line arguments were not normalized if they had the possibility of being URLs. This prevented windows paths with drive letters from being normalized. Now, we normalize any file path that exists on disk.