### PR TITLE
Stop scaling up small scroll wheel events

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1368,40 +1368,6 @@ describe('TextEditorComponent', () => {
       }
     })
 
-    it('always scrolls by a minimum of 1, even when the delta is small or the scroll sensitivity is low', () => {
-      const scrollSensitivity = 10
-      const {component, editor} = buildComponent({height: 50, width: 50, scrollSensitivity})
-
-      {
-        component.didMouseWheel({wheelDeltaX: 0, wheelDeltaY: -3})
-        expect(component.getScrollTop()).toBe(1)
-        expect(component.getScrollLeft()).toBe(0)
-        expect(component.refs.content.style.transform).toBe(`translate(0px, -1px)`)
-      }
-
-      {
-        component.didMouseWheel({wheelDeltaX: -4, wheelDeltaY: 0})
-        expect(component.getScrollTop()).toBe(1)
-        expect(component.getScrollLeft()).toBe(1)
-        expect(component.refs.content.style.transform).toBe(`translate(-1px, -1px)`)
-      }
-
-      editor.update({scrollSensitivity: 100})
-      {
-        component.didMouseWheel({wheelDeltaX: 0, wheelDeltaY: 0.3})
-        expect(component.getScrollTop()).toBe(0)
-        expect(component.getScrollLeft()).toBe(1)
-        expect(component.refs.content.style.transform).toBe(`translate(-1px, 0px)`)
-      }
-
-      {
-        component.didMouseWheel({wheelDeltaX: 0.1, wheelDeltaY: 0})
-        expect(component.getScrollTop()).toBe(0)
-        expect(component.getScrollLeft()).toBe(0)
-        expect(component.refs.content.style.transform).toBe(`translate(0px, 0px)`)
-      }
-    })
-
     it('inverts deltaX and deltaY when holding shift on Windows and Linux', async () => {
       const scrollSensitivity = 50
       const {component, editor} = buildComponent({height: 50, width: 50, scrollSensitivity})

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1520,15 +1520,11 @@ class TextEditorComponent {
     let {wheelDeltaX, wheelDeltaY} = event
 
     if (Math.abs(wheelDeltaX) > Math.abs(wheelDeltaY)) {
-      wheelDeltaX = (Math.sign(wheelDeltaX) === 1)
-        ? Math.max(1, wheelDeltaX * scrollSensitivity)
-        : Math.min(-1, wheelDeltaX * scrollSensitivity)
+      wheelDeltaX = wheelDeltaX * scrollSensitivity
       wheelDeltaY = 0
     } else {
       wheelDeltaX = 0
-      wheelDeltaY = (Math.sign(wheelDeltaY) === 1)
-        ? Math.max(1, wheelDeltaY * scrollSensitivity)
-        : Math.min(-1, wheelDeltaY * scrollSensitivity)
+      wheelDeltaY = wheelDeltaY * scrollSensitivity
     }
 
     if (this.getPlatform() !== 'darwin' && event.shiftKey) {


### PR DESCRIPTION
### Description of the Change

As discussed in #16743, this reverts #15487.

#15487 essentially compensated for the fact that `wheelDelta` was switched to `delta` in the 1.19 editor rewrite, reducing the scroll sensitivity by 1/3. Now that it's been switched back in 1.24, #15487 is no longer necessary, and in fact it stops the trackpad from distinguishing between different small velocities.

Per #16743, it would actually be best to move back to `delta` eventually, but only when the interaction with scroll sensitivity is properly figured out, such that #15487 isn't necessary either way.

cc @Ben3eeE @50Wliu @nathansobo

### Benefits

This makes scrolling at low velocities feel slightly more natural on a macOS trackpad.

### Possible Drawbacks

This should be safe because it only affects small scroll deltas which are only generated by trackpads.

### Verification Process

Opened an editor window, pasted a large block of text, then scrolled around slowly using a macOS trackpad at different scroll sensitivities.

### Applicable Issues

See #16743 and #15567.