### PR TITLE
Only return overridden language ids in .getGrammarOverride

### DIFF
--- a/spec/grammar-registry-spec.js
+++ b/spec/grammar-registry-spec.js
@@ -24,6 +24,7 @@ describe('GrammarRegistry', () => {
       const buffer = new TextBuffer()
       expect(grammarRegistry.assignLanguageMode(buffer, 'source.js')).toBe(true)
       expect(buffer.getLanguageMode().getLanguageId()).toBe('source.js')
+      expect(grammarRegistry.getAssignedLanguageId(buffer)).toBe('source.js')
 
       // Returns true if we found the grammar, even if it didn't change
       expect(grammarRegistry.assignLanguageMode(buffer, 'source.js')).toBe(true)
@@ -47,6 +48,7 @@ describe('GrammarRegistry', () => {
 
         expect(grammarRegistry.assignLanguageMode(buffer, null)).toBe(true)
         expect(buffer.getLanguageMode().getLanguageId()).toBe('text.plain.null-grammar')
+        expect(grammarRegistry.getAssignedLanguageId(buffer)).toBe(null)
       })
     })
   })

--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -135,6 +135,14 @@ class GrammarRegistry {
     return true
   }
 
+  // Extended: Get the `languageId` that has been explicitly assigned to
+  // to the given buffer, if any.
+  //
+  // Returns a {String} id of the language
+  getAssignedLanguageId (buffer) {
+    return this.languageOverridesByBufferId.get(buffer.id)
+  }
+
   // Extended: Remove any language mode override that has been set for the
   // given {TextBuffer}. This will assign to the buffer the best language
   // mode available.
@@ -293,7 +301,7 @@ class GrammarRegistry {
   grammarOverrideForPath (filePath) {
     Grim.deprecate('Use buffer.getLanguageMode().getLanguageId() instead')
     const buffer = atom.project.findBufferForPath(filePath)
-    if (buffer) return this.languageOverridesByBufferId.get(buffer.id)
+    if (buffer) return this.getAssignedLanguageId(buffer)
   }
 
   // Deprecated: Set the grammar override for the given file path.

--- a/src/text-editor-registry.js
+++ b/src/text-editor-registry.js
@@ -205,7 +205,7 @@ class TextEditorRegistry {
   // Returns a {String} scope name, or `null` if no override has been set
   // for the given editor.
   getGrammarOverride (editor) {
-    return editor.getBuffer().getLanguageMode().grammar.scopeName
+    return atom.grammars.getAssignedLanguageId(editor.getBuffer())
   }
 
   // Deprecated: Remove any grammar override that has been set for the given {TextEditor}.


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/16747