### PR TITLE
Fix incorrect variable name

### DIFF
--- a/src/application-delegate.js
+++ b/src/application-delegate.js
@@ -249,7 +249,7 @@ class ApplicationDelegate {
       this.getCurrentWindow().showSaveDialog(options, callback)
     } else {
       // Sync
-      if (typeof params === 'string') {
+      if (typeof options === 'string') {
         options = {defaultPath: options}
       }
       return this.getCurrentWindow().showSaveDialog(options)


### PR DESCRIPTION
Regression from #16245.  `params` was changed to `options` in the parameters list but the typeof check was not changed.

/cc @kachkaev