### PR TITLE
Update @atom/watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "electronVersion": "1.7.11",
   "dependencies": {
     "@atom/nsfw": "^1.0.18",
-    "@atom/watcher": "1.0.1",
+    "@atom/watcher": "1.0.2",
     "@atom/source-map-support": "^0.3.4",
     "async": "0.2.6",
     "atom-keymap": "8.2.9",


### PR DESCRIPTION
Pull in the latest changes to @atom/watcher.

Notably, bring in atom/watcher#123, which introduces an alternative, environment variable-based mechanism to establish logging for the main thread, worker thread, or polling thread. This should be useful when we need to collect data about crashes that occur early in the module's lifecycle, before the threads and message queues are established.

| Thread | Environment variable |
|--------|--------|
| Main (event loop) thread | `WATCHER_LOG_MAIN` |
| Worker thread | `WATCHER_LOG_WORKER` |
| Polling thread | `WATCHER_LOG_POLLING` |

All of these are interpreted the same way:

| Value | Meaning |
| ------ | ---------- |
| `stdout` | Log to standard out |
| `stderr` | Log to standard error |
| anything else | Log to a file at the given path |

> 📓  Note that if you want to log to stdout or stderr, you'll likely want to launch :atom: in such a way that it actually outputs to your console. I generally make sure there's no other Atom process running, then use:

```bash
$ WATCHER_LOG_MAIN=stdout atom --foreground --wait ${OTHER_ARGS}
```

@as-cii @maxbrunsfeld: Once this is in, I'd be very interested to know what you see in the main thread logs when atom/watcher#120 or a lock-up happens. We should be able to see what kind of message it's trying to send to the worker thread that's causing your crash.