### PR TITLE
Update fuzzaldrin-plus to 0.6.0 in all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "encoding-selector": "0.23.8",
     "exception-reporting": "0.43.1",
     "find-and-replace": "0.215.5",
-    "fuzzy-finder": "1.7.5",
+    "fuzzy-finder": "1.7.6",
     "github": "0.10.1",
     "git-diff": "1.3.9",
     "go-to-line": "0.33.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "autocomplete-atom-api": "0.10.7",
     "autocomplete-css": "0.17.5",
     "autocomplete-html": "0.8.4",
-    "autocomplete-plus": "2.40.2",
+    "autocomplete-plus": "2.40.3",
     "autocomplete-snippets": "1.12.0",
     "autoflow": "0.29.3",
     "autosave": "0.24.6",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "background-tips": "0.28.0",
     "bookmarks": "0.45.1",
     "bracket-matcher": "0.89.1",
-    "command-palette": "0.43.3",
+    "command-palette": "0.43.4",
     "dalek": "0.2.1",
     "deprecation-cop": "0.56.9",
     "dev-live-reload": "0.48.1",


### PR DESCRIPTION
The fuzzaldrin-plus dependency has been updated from 0.4.1 to 0.6.0 in autocomplete-plus, command-palette, and fuzzy-finder for better fuzzying.