### PR TITLE
Add `StartupWMClass` to .desktop for easier window-app association

### DIFF
--- a/resources/linux/atom.desktop.in
+++ b/resources/linux/atom.desktop.in
@@ -8,3 +8,4 @@ Type=Application
 StartupNotify=true
 Categories=GNOME;GTK;Utility;TextEditor;Development;
 MimeType=text/plain;
+StartupWMClass=Atom


### PR DESCRIPTION
### Description of the Change

Just adds a `StartupWMClass` entry to `atom.desktop`. This helps window managers associating Atom's window with the .desktop file that started Atom. It should help with some issues relative atom in docks, such as missing or duplicated icons.

### References

  - [Startup notification spec](https://specifications.freedesktop.org/startup-notification-spec/startup-notification-0.1.txt)