### PR TITLE
Tweak config APIs for dealing w/ legacy scope aliases

### DIFF
--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -115,7 +115,7 @@ describe('Config', () => {
 
       describe('when the first component of the scope descriptor matches a legacy scope alias', () =>
         it('falls back to properties defined for the legacy scope if no value is found for the original scope descriptor', () => {
-          atom.config.addLegacyScopeAlias('javascript', '.source.js')
+          atom.config.setLegacyScopeAliasForNewScope('javascript', '.source.js')
           atom.config.set('foo', 100, {scopeSelector: '.source.js'})
           atom.config.set('foo', 200, {scopeSelector: 'javascript for_statement'})
 
@@ -154,7 +154,7 @@ describe('Config', () => {
 
     describe('when the first component of the scope descriptor matches a legacy scope alias', () =>
       it('includes the values defined for the legacy scope', () => {
-        atom.config.addLegacyScopeAlias('javascript', '.source.js')
+        atom.config.setLegacyScopeAliasForNewScope('javascript', '.source.js')
 
         expect(atom.config.set('foo', 41)).toBe(true)
         expect(atom.config.set('foo', 42, {scopeSelector: 'javascript'})).toBe(true)

--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -399,7 +399,7 @@ class GrammarRegistry {
     if (grammar instanceof TreeSitterGrammar) {
       this.treeSitterGrammarsById[grammar.id] = grammar
       if (grammar.legacyScopeName) {
-        this.config.addLegacyScopeAlias(grammar.id, grammar.legacyScopeName)
+        this.config.setLegacyScopeAliasForNewScope(grammar.id, grammar.legacyScopeName)
         this.textMateScopeNamesByTreeSitterLanguageId.set(grammar.id, grammar.legacyScopeName)
         this.treeSitterLanguageIdsByTextMateScopeName.set(grammar.legacyScopeName, grammar.id)
       }
@@ -414,7 +414,7 @@ class GrammarRegistry {
     if (grammar instanceof TreeSitterGrammar) {
       delete this.treeSitterGrammarsById[grammar.id]
       if (grammar.legacyScopeName) {
-        this.config.removeLegacyScopeAlias(grammar.id)
+        this.config.removeLegacyScopeAliasForNewScope(grammar.id)
         this.textMateScopeNamesByTreeSitterLanguageId.delete(grammar.id)
         this.treeSitterLanguageIdsByTextMateScopeName.delete(grammar.legacyScopeName)
       }


### PR DESCRIPTION
This just renames some internal methods for dealing with legacy scope aliases (introduced in https://github.com/atom/atom/pull/16299). I want to use one of these methods in the `snippets` package.