### PR TITLE
:arrow_up: git-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "fs-plus": "^3.0.1",
     "fstream": "0.1.24",
     "fuzzaldrin": "^2.1",
-    "git-utils": "5.2.1",
+    "git-utils": "5.3.1",
     "glob": "^7.1.1",
     "grim": "1.5.0",
     "jasmine-json": "~0.0",


### PR DESCRIPTION
### Description of the Change

Update git-utils dependency to 5.3.0 to make use of updated libgit2 0.26.0.  (https://github.com/atom/git-utils/pull/77)

Submitting this as a PR to make sure that we don't run into any CI issues with the change.
