### PR TITLE
Serialize settings as JSON when sending them to the main process

### DIFF
--- a/src/application-delegate.js
+++ b/src/application-delegate.js
@@ -182,7 +182,7 @@ class ApplicationDelegate {
   async setUserSettings (config) {
     this.pendingSettingsUpdateCount++
     try {
-      await ipcHelpers.call('set-user-settings', config)
+      await ipcHelpers.call('set-user-settings', JSON.stringify(config))
     } finally {
       this.pendingSettingsUpdateCount--
     }

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -559,7 +559,7 @@ class AtomApplication extends EventEmitter {
     }))
 
     this.disposable.add(ipcHelpers.respondTo('set-user-settings', (window, settings) =>
-      this.configFile.update(settings)
+      this.configFile.update(JSON.parse(settings))
     ))
 
     this.disposable.add(ipcHelpers.respondTo('center-window', window => window.center()))


### PR DESCRIPTION
Fixes #16789

Config settings of type `Color` should be written to the config file as a string like `#af01cd`. To achieve this, the class [overrides `toJSON` ](https://github.com/atom/atom/blob/1d9d17bc3935246789fdb2d8fed40286431a2bb7/src/color.js#L87-L89).

When I refactored the config system to IPC settings to the main process for writing, this behavior was inadvertently broken because sending a value over electron's IPC does not serialize it as JSON; it uses its own serialization mechanism that does not preserve objects' `toJSON` methods.