### PR TITLE
Don't try to write config file while quitting

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -116,7 +116,9 @@ class AtomApplication extends EventEmitter {
 
     this.configFile = new ConfigFile(configFilePath)
     this.config = new Config({
-      saveCallback: settings => this.configFile.update(settings)
+      saveCallback: settings => {
+        if (!this.quitting) return this.configFile.update(settings)
+      }
     })
     this.config.setSchema(null, {type: 'object', properties: _.clone(ConfigSchema)})
 


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/16786
Refs https://github.com/atom/atom/pull/16628#issuecomment-367172653

This is a bit speculative, but I think that this fixes a problem with the fix introduced in https://github.com/atom/atom/pull/16628. In that PR, I made all of the config file IO async. I'm concerned that what's happening is that some package is writing to `atom.config` on shutdown (which was the cause of the original bug) and the Atom main process is exiting *after* we start to write the config file but *before* the write completes.

To fix this case, I have added logic to prevent config file writes during shutdown.

/cc @rsese 