### PR TITLE
Add additional dependencies for linux

### DIFF
--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, python, gvfs-bin, xdg-utils, libcap2, libx11-xcb1, libxss1, libasound2, libxkbfile1
+Depends: git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libcap2, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1
 Recommends: lsb-release
 Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
 Section: devel

--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, python, gvfs-bin, xdg-utils, libcap2
+Depends: git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, python, gvfs-bin, xdg-utils, libcap2, libx11-xcb1, libxss1, libasound2, libxkbfile1
 Recommends: lsb-release
 Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
 Section: devel


### PR DESCRIPTION
From @Arcanemagus:

> I can confirm from building a minimal install for CI purposes that libxss1 and libasound2 are required. The base image that I am using there has libx11-xcb1 and libxkbfile1 installed automatically already, still checking that those aren't included transitively from another dependency.

Note that this fixes:
#4114 (Supposedly fixed in f431bb6, but at minimum libasound2 was reported there but missed)
#13591 (Unstated, but supposedly an Ubuntu 16.04 install of some sort)
#16659 (Some minimal Ubuntu base image)



/cc @Arcanemagus 