### PR TITLE
Provide a default scope descriptor if language mode doesn't provide them

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -6747,6 +6747,14 @@ describe('TextEditor', () => {
     editor.destroy()
   })
 
+  describe('.scopeDescriptorForBufferPosition(position)', () => {
+    it('returns a default scope descriptor when no language mode is assigned', () => {
+      editor = new TextEditor({buffer: new TextBuffer()})
+      const scopeDescriptor = editor.scopeDescriptorForBufferPosition([0, 0])
+      expect(scopeDescriptor.getScopesArray()).toEqual(['text'])
+    })
+  })
+
   describe('.shouldPromptToSave()', () => {
     beforeEach(async () => {
       editor = await atom.workspace.open('sample.js')

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -11,6 +11,7 @@ const Cursor = require('./cursor')
 const Selection = require('./selection')
 const NullGrammar = require('./null-grammar')
 const TextMateLanguageMode = require('./text-mate-language-mode')
+const ScopeDescriptor = require('./scope-descriptor')
 
 const TextMateScopeSelector = require('first-mate').ScopeSelector
 const GutterContainer = require('./gutter-container')
@@ -3655,7 +3656,10 @@ class TextEditor {
   //
   // Returns a {ScopeDescriptor}.
   scopeDescriptorForBufferPosition (bufferPosition) {
-    return this.buffer.getLanguageMode().scopeDescriptorForPosition(bufferPosition)
+    const languageMode = this.buffer.getLanguageMode()
+    return languageMode.scopeDescriptorForPosition
+      ? languageMode.scopeDescriptorForPosition(bufferPosition)
+      : new ScopeDescriptor({scopes: ['text']})
   }
 
   // Extended: Get the range in buffer coordinates of all tokens surrounding the


### PR DESCRIPTION
Fixes https://github.com/atom/text-buffer/issues/290

/cc @pelmers I decided to fix the problem in the `TextEditor` class rather than adding the method in the `NullLanguageMode` because currently, the *LanguageMode* interface already has a lot of optional methods that are only used in the `TextEditor` layer (and non in `text-buffer` itself).