### PR TITLE
Handle empty username

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -33,7 +33,7 @@ class AtomApplication extends EventEmitter {
   // Public: The entry point into the Atom application.
   static open (options) {
     if (!options.socketPath) {
-      const username = process.platform === 'win32' ? process.env.USERNAME : process.env.USER
+      const {username} = os.userInfo()
 
       // Lowercasing the ATOM_HOME to make sure that we don't get multiple sockets
       // on case-insensitive filesystems due to arbitrary case differences in paths.
@@ -44,7 +44,7 @@ class AtomApplication extends EventEmitter {
         .update('|')
         .update(process.arch)
         .update('|')
-        .update(username)
+        .update(username || '')
         .update('|')
         .update(atomHomeUnique)
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Changes Atom to use `os.userInfo().username` to determine the user name, defaulting to an empty string if it still can't be determined.

### Alternate Designs

If the username isn't necessarily _required_ for the uniqueness of the hash, a simpler and probably slightly faster method would be to keep the current method of determining it and simply default to the empty string.

### Why Should This Be In Core?

This is fixing a bug in core.

### Benefits

Atom doesn't crash when `USERNAME`/`USER` isn't defined.

### Possible Drawbacks

This is likely to be slightly slower than the previous method of just checking environment variables.

### Verification Process

I verified this was an issue using the steps outlined in #16821. To verify that this fixes the issue I set up an environment that the current version (v1.25.0-beta2) fails in, built a version based on this PR, and verified that the new build works properly in that environment.

### Applicable Issues

Fixes #16821.
