### PR TITLE
Add a new keybinding for window:reload Fixes #1794

### DIFF
--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -27,6 +27,7 @@
   'left': 'core:move-left'
   'right': 'core:move-right'
   'ctrl-alt-cmd-l': 'window:reload'
+  'ctrl-alt-cmd-k': 'window:reload'
   'alt-cmd-i': 'window:toggle-dev-tools'
   'cmd-alt-ctrl-p': 'window:run-package-specs'
   'ctrl-shift-left': 'pane:move-item-left'


### PR DESCRIPTION
### Description of the Change

This commit adds a new (and default) keybinding for "View/Developer/Reload Window" that isn't in conflict with 1Password's keybindings.

### Alternate Designs

N/A?

### Why Should This Be In Core?

It's not unreasonable to presume that there's a large percentage of 1Password users among Atom developer community, so it would be beneficial fix this binding clash.

### Benefits

See above.

### Possible Drawbacks

I've left previous binding in, so users unaffected by this problem won't have to adjust.
It could conflict with other applications or Atom packages, but I've not experienced any issues.

### Verification Process

I've been using both keybindings in my own keymap for a while now.

### Applicable Issues

Issue #1794 (while closed, the it is still relevant).
