### PR TITLE
Test .oldPath and .path on rename events

### DIFF
--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -505,9 +505,9 @@ class PathWatcher {
         if (srcWatched && destWatched) {
           filtered.push(modifyEvent(event))
         } else if (srcWatched && !destWatched) {
-          filtered.push({action: 'deleted', kind: event.kind, path: modifyPath(event.oldPath)})
+          filtered.push({action: 'deleted', kind: event.kind, path: event.oldPath})
         } else if (!srcWatched && destWatched) {
-          filtered.push({action: 'created', kind: event.kind, path: modifyPath(event.path)})
+          filtered.push({action: 'created', kind: event.kind, path: event.path})
         }
       } else {
         if (isWatched(event.path)) {

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -516,8 +516,6 @@ class PathWatcher {
       }
     }
 
-    const filtered = events.filter(event => event.path.startsWith(this.normalizedPath))
-
     if (filtered.length > 0) {
       callback(filtered)
     }

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -492,7 +492,7 @@ class PathWatcher {
   // events may include events for paths above this watcher's root path, so filter them to only include the relevant
   // ones, then re-broadcast them to our subscribers.
   onNativeEvents (events, callback) {
-    const isWatched = eventPath => eventPath.startsWith(this.normalizedPath)
+    const isWatchedPath = eventPath => eventPath.startsWith(this.normalizedPath)
 
     const filtered = []
     for (let i = 0; i < events.length; i++) {
@@ -503,14 +503,14 @@ class PathWatcher {
         const destWatched = isWatchedPath(event.path)
 
         if (srcWatched && destWatched) {
-          filtered.push(modifyEvent(event))
+          filtered.push(event)
         } else if (srcWatched && !destWatched) {
           filtered.push({action: 'deleted', kind: event.kind, path: event.oldPath})
         } else if (!srcWatched && destWatched) {
           filtered.push({action: 'created', kind: event.kind, path: event.path})
         }
       } else {
-        if (isWatched(event.path)) {
+        if (isWatchedPath(event.path)) {
           filtered.push(event)
         }
       }


### PR DESCRIPTION
Report rename events that move files out from the `PathWatcher`'s root as deletions and events that move files in as creations. This fixes a bug where rename events out of the watched root would be dropped (because `.path` was not within the normalized directory, even though `.oldPath` was) and ensures consistency across platforms with the way that "rename away" appears.

Fixes #16623.