### PR TITLE
Add 'await' keyword at async function call and remove unnecessary parameter

### DIFF
--- a/src/main-process/application-menu.js
+++ b/src/main-process/application-menu.js
@@ -201,7 +201,7 @@ class ApplicationMenu {
       if (item.command) {
         item.accelerator = this.acceleratorForCommand(item.command, keystrokesByCommand)
         item.click = () => global.atomApplication.sendCommand(item.command, item.commandDetail)
-        if (!/^application:/.test(item.command, item.commandDetail)) {
+        if (!/^application:/.test(item.command)) {
           item.metadata.windowSpecific = true
         }
       }

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -243,7 +243,7 @@ class AtomNativeWatcher extends NativeWatcher {
 
     this.subs.add(treeView.onEntryDeleted(async event => {
       const realPath = await getRealPath(event.path)
-      if (!realPath || isOpenInEditor(realPath)) return
+      if (!realPath || await isOpenInEditor(realPath)) return
 
       this.onEvents([{action: 'deleted', path: realPath}])
     }))
@@ -253,7 +253,7 @@ class AtomNativeWatcher extends NativeWatcher {
         getRealPath(event.newPath),
         getRealPath(event.initialPath)
       ])
-      if (!realNewPath || !realOldPath || isOpenInEditor(realNewPath) || isOpenInEditor(realOldPath)) return
+      if (!realNewPath || !realOldPath || await isOpenInEditor(realNewPath) || await isOpenInEditor(realOldPath)) return
 
       this.onEvents([{action: 'renamed', path: realNewPath, oldPath: realOldPath}])
     }))


### PR DESCRIPTION
### Description of the Change

* Add 'await' keyword at async function 'isOpenInEditor()' call
  - 'isOpenInEditor()' returns a Promise object, so 'await' keyword should be added to use the boolean value for condition check
* Remove unnecessary parameter of 'RegExp.prototype.test()'
  - Remove second parameter of 'RegExp.prototype.test()' because it only handles the first parameter. (See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test)

See [DeepScan results page](https://deepscan.io/dashboard/#view=project&pid=2005&bid=9394&subview=issues) for more details.

### Benefits

Fix bug and optimize code


### Applicable Issues
https://github.com/atom/atom/issues/16858