### PR TITLE
Fix dock dragging and dropping

### DIFF
--- a/src/dock.js
+++ b/src/dock.js
@@ -153,7 +153,10 @@ module.exports = class Dock {
     this.state = nextState
     this.render(this.state)
 
-    const {visible} = this.state
+    const {hovered, visible} = this.state
+    if (hovered !== prevState.hovered) {
+      this.emitter.emit('did-change-hovered', hovered)
+    }
     if (visible !== prevState.visible) {
       this.emitter.emit('did-change-visible', visible)
     }
@@ -607,6 +610,16 @@ module.exports = class Dock {
   // Returns a {Disposable} on which `.dispose` can be called to unsubscribe.
   onDidDestroyPaneItem (callback) {
     return this.paneContainer.onDidDestroyPaneItem(callback)
+  }
+
+  // Extended: Invoke the given callback when the hovered state of the dock changes.
+  //
+  // * `callback` {Function} to be called when the hovered state changes.
+  //   * `hovered` {Boolean} Is the dock now hovered?
+  //
+  // Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidChangeHovered (callback) {
+    return this.emitter.on('did-change-hovered', callback)
   }
 
   /*

--- a/src/workspace-element.js
+++ b/src/workspace-element.js
@@ -186,18 +186,13 @@ class WorkspaceElement extends HTMLElement {
   }
 
   updateHoveredDock (mousePosition) {
-    this.hoveredDock = null
-    for (let location in this.model.paneContainers) {
-      if (location !== 'center') {
-        const dock = this.model.paneContainers[location]
-        if (!this.hoveredDock && dock.pointWithinHoverArea(mousePosition)) {
-          this.hoveredDock = dock
-          dock.setHovered(true)
-        } else {
-          dock.setHovered(false)
-        }
-      }
-    }
+    // If we haven't left the currently hovered dock, don't change anything.
+    if (this.hoveredDock && this.hoveredDock.pointWithinHoverArea(mousePosition, true)) return
+
+    const docks = [this.model.getLeftDock(), this.model.getRightDock(), this.model.getBottomDock()]
+    this.hoveredDock =
+      docks.find(dock => dock !== this.hoveredDock && dock.pointWithinHoverArea(mousePosition))
+    docks.forEach(dock => { dock.setHovered(dock === this.hoveredDock) })
     this.checkCleanupDockHoverEvents()
   }
 

--- a/src/workspace-element.js
+++ b/src/workspace-element.js
@@ -92,7 +92,13 @@ class WorkspaceElement extends HTMLElement {
         window.removeEventListener('dragstart', this.handleDragStart)
         window.removeEventListener('dragend', this.handleDragEnd, true)
         window.removeEventListener('drop', this.handleDrop, true)
-      })
+      }),
+      ...[this.model.getLeftDock(), this.model.getRightDock(), this.model.getBottomDock()]
+        .map(dock => dock.onDidChangeHovered(hovered => {
+          if (hovered) this.hoveredDock = dock
+          else if (dock === this.hoveredDock) this.hoveredDock = null
+          this.checkCleanupDockHoverEvents()
+        }))
     )
     this.initializeContent()
     this.observeScrollbarStyle()
@@ -190,10 +196,9 @@ class WorkspaceElement extends HTMLElement {
     if (this.hoveredDock && this.hoveredDock.pointWithinHoverArea(mousePosition, true)) return
 
     const docks = [this.model.getLeftDock(), this.model.getRightDock(), this.model.getBottomDock()]
-    this.hoveredDock =
+    const nextHoveredDock =
       docks.find(dock => dock !== this.hoveredDock && dock.pointWithinHoverArea(mousePosition))
-    docks.forEach(dock => { dock.setHovered(dock === this.hoveredDock) })
-    this.checkCleanupDockHoverEvents()
+    docks.forEach(dock => { dock.setHovered(dock === nextHoveredDock) })
   }
 
   checkCleanupDockHoverEvents () {


### PR DESCRIPTION
This fixes #16769, which described an issue whereby trying to drop into
a closed dock would cause the dock to repeatedly open and close.

I tried to describe in comments why this was happening and how we can
make sure to avoid it.

The solution adds another DOM measurement which I'm not too thrilled
about but I profiled and it didn't seem to be an issue.