### PR TITLE
Convert Dock class to Etch

### DIFF
--- a/spec/dock-spec.js
+++ b/spec/dock-spec.js
@@ -3,6 +3,9 @@
 const Grim = require('grim')
 
 import {it, fit, ffit, fffit, beforeEach, afterEach} from './async-spec-helpers'
+import etch from 'etch'
+
+const getNextUpdatePromise = () => etch.getScheduler().nextUpdatePromise
 
 describe('Dock', () => {
   describe('when a dock is activated', () => {
@@ -157,8 +160,10 @@ describe('Dock', () => {
         const dockElement = dock.getElement()
 
         dock.setState({size: 300})
+        await getNextUpdatePromise()
         expect(dockElement.offsetWidth).toBe(300)
         dockElement.querySelector('.atom-dock-resize-handle').dispatchEvent(new MouseEvent('mousedown', {detail: 2}))
+        await getNextUpdatePromise()
 
         expect(dockElement.offsetWidth).toBe(item.getPreferredWidth())
       })
@@ -178,8 +183,10 @@ describe('Dock', () => {
         const dockElement = dock.getElement()
 
         dock.setState({size: 300})
+        await getNextUpdatePromise()
         expect(dockElement.offsetHeight).toBe(300)
         dockElement.querySelector('.atom-dock-resize-handle').dispatchEvent(new MouseEvent('mousedown', {detail: 2}))
+        await getNextUpdatePromise()
 
         expect(dockElement.offsetHeight).toBe(item.getPreferredHeight())
       })
@@ -310,7 +317,7 @@ describe('Dock', () => {
   })
 
   describe('drag handling', () => {
-    it('expands docks to match the preferred size of the dragged item', () => {
+    it('expands docks to match the preferred size of the dragged item', async () => {
       jasmine.attachToDOM(atom.workspace.getElement())
 
       const element = document.createElement('div')
@@ -325,7 +332,8 @@ describe('Dock', () => {
       Object.defineProperty(dragEvent, 'target', {value: element})
 
       atom.workspace.getElement().handleDragStart(dragEvent)
-      expect(atom.workspace.getLeftDock().wrapperElement.offsetWidth).toBe(144)
+      await getNextUpdatePromise()
+      expect(atom.workspace.getLeftDock().refs.wrapperElement.offsetWidth).toBe(144)
     })
 
     it('does nothing when text nodes are dragged', () => {

--- a/spec/workspace-element-spec.js
+++ b/spec/workspace-element-spec.js
@@ -1,10 +1,13 @@
 /** @babel */
 
 const {ipcRenderer} = require('electron')
+const etch = require('etch')
 const path = require('path')
 const temp = require('temp').track()
 const {Disposable} = require('event-kit')
 const {it, fit, ffit, fffit, beforeEach, afterEach} = require('./async-spec-helpers')
+
+const getNextUpdatePromise = () => etch.getScheduler().nextUpdatePromise
 
 describe('WorkspaceElement', () => {
   afterEach(() => {
@@ -565,35 +568,42 @@ describe('WorkspaceElement', () => {
 
       // Mouse over where the toggle button would be if the dock were hovered
       moveMouse({clientX: 440, clientY: 150})
+      await getNextUpdatePromise()
       expectToggleButtonHidden(leftDock)
       expectToggleButtonHidden(rightDock)
       expectToggleButtonHidden(bottomDock)
 
       // Mouse over the dock
       moveMouse({clientX: 460, clientY: 150})
+      await getNextUpdatePromise()
       expectToggleButtonHidden(leftDock)
       expectToggleButtonVisible(rightDock, 'icon-chevron-right')
       expectToggleButtonHidden(bottomDock)
 
       // Mouse over the toggle button
       moveMouse({clientX: 440, clientY: 150})
+      await getNextUpdatePromise()
       expectToggleButtonHidden(leftDock)
       expectToggleButtonVisible(rightDock, 'icon-chevron-right')
       expectToggleButtonHidden(bottomDock)
 
       // Click the toggle button
-      rightDock.toggleButton.innerElement.click()
+      rightDock.refs.toggleButton.refs.innerElement.click()
+      await getNextUpdatePromise()
       expect(rightDock.isVisible()).toBe(false)
       expectToggleButtonHidden(rightDock)
 
       // Mouse to edge of the window
       moveMouse({clientX: 575, clientY: 150})
+      await getNextUpdatePromise()
       expectToggleButtonHidden(rightDock)
       moveMouse({clientX: 598, clientY: 150})
+      await getNextUpdatePromise()
       expectToggleButtonVisible(rightDock, 'icon-chevron-left')
 
       // Click the toggle button again
-      rightDock.toggleButton.innerElement.click()
+      rightDock.refs.toggleButton.refs.innerElement.click()
+      await getNextUpdatePromise()
       expect(rightDock.isVisible()).toBe(true)
       expectToggleButtonVisible(rightDock, 'icon-chevron-right')
 
@@ -601,35 +611,42 @@ describe('WorkspaceElement', () => {
 
       // Mouse over where the toggle button would be if the dock were hovered
       moveMouse({clientX: 160, clientY: 150})
+      await getNextUpdatePromise()
       expectToggleButtonHidden(leftDock)
       expectToggleButtonHidden(rightDock)
       expectToggleButtonHidden(bottomDock)
 
       // Mouse over the dock
       moveMouse({clientX: 140, clientY: 150})
+      await getNextUpdatePromise()
       expectToggleButtonVisible(leftDock, 'icon-chevron-left')
       expectToggleButtonHidden(rightDock)
       expectToggleButtonHidden(bottomDock)
 
       // Mouse over the toggle button
       moveMouse({clientX: 160, clientY: 150})
+      await getNextUpdatePromise()
       expectToggleButtonVisible(leftDock, 'icon-chevron-left')
       expectToggleButtonHidden(rightDock)
       expectToggleButtonHidden(bottomDock)
 
       // Click the toggle button
-      leftDock.toggleButton.innerElement.click()
+      leftDock.refs.toggleButton.refs.innerElement.click()
+      await getNextUpdatePromise()
       expect(leftDock.isVisible()).toBe(false)
       expectToggleButtonHidden(leftDock)
 
       // Mouse to edge of the window
       moveMouse({clientX: 25, clientY: 150})
+      await getNextUpdatePromise()
       expectToggleButtonHidden(leftDock)
       moveMouse({clientX: 2, clientY: 150})
+      await getNextUpdatePromise()
       expectToggleButtonVisible(leftDock, 'icon-chevron-right')
 
       // Click the toggle button again
-      leftDock.toggleButton.innerElement.click()
+      leftDock.refs.toggleButton.refs.innerElement.click()
+      await getNextUpdatePromise()
       expect(leftDock.isVisible()).toBe(true)
       expectToggleButtonVisible(leftDock, 'icon-chevron-left')
 
@@ -637,51 +654,58 @@ describe('WorkspaceElement', () => {
 
       // Mouse over where the toggle button would be if the dock were hovered
       moveMouse({clientX: 300, clientY: 190})
+      await getNextUpdatePromise()
       expectToggleButtonHidden(leftDock)
       expectToggleButtonHidden(rightDock)
       expectToggleButtonHidden(bottomDock)
 
       // Mouse over the dock
       moveMouse({clientX: 300, clientY: 210})
+      await getNextUpdatePromise()
       expectToggleButtonHidden(leftDock)
       expectToggleButtonHidden(rightDock)
       expectToggleButtonVisible(bottomDock, 'icon-chevron-down')
 
       // Mouse over the toggle button
       moveMouse({clientX: 300, clientY: 195})
+      await getNextUpdatePromise()
       expectToggleButtonHidden(leftDock)
       expectToggleButtonHidden(rightDock)
       expectToggleButtonVisible(bottomDock, 'icon-chevron-down')
 
       // Click the toggle button
-      bottomDock.toggleButton.innerElement.click()
+      bottomDock.refs.toggleButton.refs.innerElement.click()
+      await getNextUpdatePromise()
       expect(bottomDock.isVisible()).toBe(false)
       expectToggleButtonHidden(bottomDock)
 
       // Mouse to edge of the window
       moveMouse({clientX: 300, clientY: 290})
+      await getNextUpdatePromise()
       expectToggleButtonHidden(leftDock)
       moveMouse({clientX: 300, clientY: 299})
+      await getNextUpdatePromise()
       expectToggleButtonVisible(bottomDock, 'icon-chevron-up')
 
       // Click the toggle button again
-      bottomDock.toggleButton.innerElement.click()
+      bottomDock.refs.toggleButton.refs.innerElement.click()
+      await getNextUpdatePromise()
       expect(bottomDock.isVisible()).toBe(true)
       expectToggleButtonVisible(bottomDock, 'icon-chevron-down')
     })
 
-    function moveMouse(coordinates) {
+    function moveMouse (coordinates) {
       window.dispatchEvent(new MouseEvent('mousemove', coordinates))
       advanceClock(100)
     }
 
     function expectToggleButtonHidden(dock) {
-      expect(dock.toggleButton.element).not.toHaveClass('atom-dock-toggle-button-visible')
+      expect(dock.refs.toggleButton.element).not.toHaveClass('atom-dock-toggle-button-visible')
     }
 
     function expectToggleButtonVisible(dock, iconClass) {
-      expect(dock.toggleButton.element).toHaveClass('atom-dock-toggle-button-visible')
-      expect(dock.toggleButton.iconElement).toHaveClass(iconClass)
+      expect(dock.refs.toggleButton.element).toHaveClass('atom-dock-toggle-button-visible')
+      expect(dock.refs.toggleButton.refs.iconElement).toHaveClass(iconClass)
     }
   })
 

--- a/src/dock.js
+++ b/src/dock.js
@@ -1,5 +1,7 @@
-'use strict'
+/** @babel */
+/** @jsx etch.dom */
 
+const etch = require('etch')
 const _ = require('underscore-plus')
 const {CompositeDisposable, Emitter} = require('event-kit')
 const PaneContainer = require('./pane-container')
@@ -26,6 +28,8 @@ module.exports = class Dock {
     this.handleMouseUp = this.handleMouseUp.bind(this)
     this.handleDrag = _.throttle(this.handleDrag.bind(this), 30)
     this.handleDragEnd = this.handleDragEnd.bind(this)
+    this.handleToggleButtonDragEnter = this.handleToggleButtonDragEnter.bind(this)
+    this.toggle = this.toggle.bind(this)
 
     this.location = params.location
     this.widthOrHeight = getWidthOrHeight(this.location)
@@ -67,16 +71,17 @@ module.exports = class Dock {
       this.paneContainer.onDidChangeActivePaneItem((item) => params.didChangeActivePaneItem(this, item)),
       this.paneContainer.onDidDestroyPaneItem((item) => params.didDestroyPaneItem(item))
     )
+
+    etch.initialize(this)
   }
 
   // This method is called explicitly by the object which adds the Dock to the document.
   elementAttached () {
     // Re-render when the dock is attached to make sure we remeasure sizes defined in CSS.
-    this.render(this.state)
+    etch.update(this)
   }
 
   getElement () {
-    if (!this.element) this.render(this.state)
     return this.element
   }
 
@@ -151,9 +156,14 @@ module.exports = class Dock {
     }
 
     this.state = nextState
-    this.render(this.state)
 
     const {hovered, visible} = this.state
+
+    // Render immediately if the dock becomes visible or the size changes in case people are
+    // measuring after opening, for example.
+    if ((visible && !prevState.visible) || (this.state.size !== prevState.size)) etch.updateSync(this)
+    else etch.update(this)
+
     if (hovered !== prevState.hovered) {
       this.emitter.emit('did-change-hovered', hovered)
     }
@@ -162,80 +172,74 @@ module.exports = class Dock {
     }
   }
 
-  render (state) {
-    if (this.element == null) {
-      this.element = document.createElement('atom-dock')
-      this.element.classList.add(this.location)
-      this.innerElement = document.createElement('div')
-      this.innerElement.classList.add('atom-dock-inner', this.location)
-      this.maskElement = document.createElement('div')
-      this.maskElement.classList.add('atom-dock-mask')
-      this.wrapperElement = document.createElement('div')
-      this.wrapperElement.classList.add('atom-dock-content-wrapper', this.location)
-      this.resizeHandle = new DockResizeHandle({
-        location: this.location,
-        onResizeStart: this.handleResizeHandleDragStart,
-        onResizeToFit: this.handleResizeToFit
-      })
-      this.toggleButton = new DockToggleButton({
-        onDragEnter: this.handleToggleButtonDragEnter.bind(this),
-        location: this.location,
-        toggle: this.toggle.bind(this)
-      })
-      this.cursorOverlayElement = document.createElement('div')
-      this.cursorOverlayElement.classList.add('atom-dock-cursor-overlay', this.location)
+  render () {
+    const innerElementClassList = ['atom-dock-inner', this.location]
+    if (this.state.visible) innerElementClassList.push(VISIBLE_CLASS)
 
-      // Add the children to the DOM tree
-      this.element.appendChild(this.innerElement)
-      this.innerElement.appendChild(this.maskElement)
-      this.maskElement.appendChild(this.wrapperElement)
-      this.wrapperElement.appendChild(this.resizeHandle.getElement())
-      this.wrapperElement.appendChild(this.paneContainer.getElement())
-      this.wrapperElement.appendChild(this.cursorOverlayElement)
-      // The toggle button must be rendered outside the mask because (1) it shouldn't be masked and
-      // (2) if we made the mask larger to avoid masking it, the mask would block mouse events.
-      this.innerElement.appendChild(this.toggleButton.getElement())
-    }
+    const maskElementClassList = ['atom-dock-mask']
+    if (this.state.shouldAnimate) maskElementClassList.push(SHOULD_ANIMATE_CLASS)
 
-    if (state.visible) {
-      this.innerElement.classList.add(VISIBLE_CLASS)
-    } else {
-      this.innerElement.classList.remove(VISIBLE_CLASS)
-    }
+    const cursorOverlayElementClassList = ['atom-dock-cursor-overlay', this.location]
+    if (this.state.resizing) cursorOverlayElementClassList.push(CURSOR_OVERLAY_VISIBLE_CLASS)
 
-    if (state.shouldAnimate) {
-      this.maskElement.classList.add(SHOULD_ANIMATE_CLASS)
-    } else {
-      this.maskElement.classList.remove(SHOULD_ANIMATE_CLASS)
-    }
-
-    if (state.resizing) {
-      this.cursorOverlayElement.classList.add(CURSOR_OVERLAY_VISIBLE_CLASS)
-    } else {
-      this.cursorOverlayElement.classList.remove(CURSOR_OVERLAY_VISIBLE_CLASS)
-    }
-
-    const shouldBeVisible = state.visible || state.showDropTarget
+    const shouldBeVisible = this.state.visible || this.state.showDropTarget
     const size = Math.max(MINIMUM_SIZE,
-      state.size ||
-      (state.draggingItem && getPreferredSize(state.draggingItem, this.location)) ||
+      this.state.size ||
+      (this.state.draggingItem && getPreferredSize(this.state.draggingItem, this.location)) ||
       DEFAULT_INITIAL_SIZE
     )
 
     // We need to change the size of the mask...
-    this.maskElement.style[this.widthOrHeight] = `${shouldBeVisible ? size : 0}px`
+    const maskStyle = {[this.widthOrHeight]: `${shouldBeVisible ? size : 0}px`}
     // ...but the content needs to maintain a constant size.
-    this.wrapperElement.style[this.widthOrHeight] = `${size}px`
+    const wrapperStyle = {[this.widthOrHeight]: `${size}px`}
 
-    this.resizeHandle.update({dockIsVisible: this.state.visible})
-    this.toggleButton.update({
-      dockIsVisible: shouldBeVisible,
-      visible:
-        // Don't show the toggle button if the dock is closed and empty...
-        (state.hovered && (this.state.visible || this.getPaneItems().length > 0)) ||
-        // ...or if the item can't be dropped in that dock.
-        (!shouldBeVisible && state.draggingItem && isItemAllowed(state.draggingItem, this.location))
-    })
+    return (
+      <atom-dock className={this.location}>
+        <div ref='innerElement' className={innerElementClassList.join(' ')}>
+          <div
+            className={maskElementClassList.join(' ')}
+            style={maskStyle}>
+            <div
+              ref='wrapperElement'
+              className={`atom-dock-content-wrapper ${this.location}`}
+              style={wrapperStyle}>
+              <DockResizeHandle
+                location={this.location}
+                onResizeStart={this.handleResizeHandleDragStart}
+                onResizeToFit={this.handleResizeToFit}
+                dockIsVisible={this.state.visible}
+              />
+              <ElementComponent element={this.paneContainer.getElement()} />
+              <div className={cursorOverlayElementClassList.join(' ')} />
+            </div>
+          </div>
+          {/*
+            The toggle button must be rendered outside the mask because (1) it shouldn't be masked
+            and (2) if we made the mask larger to avoid masking it, the mask would block mouse
+            events.
+          */}
+          <DockToggleButton
+            ref='toggleButton'
+            onDragEnter={this.handleToggleButtonDragEnter}
+            location={this.location}
+            toggle={this.toggle}
+            dockIsVisible={shouldBeVisible}
+            visible={
+              // Don't show the toggle button if the dock is closed and empty...
+              (this.state.hovered && (this.state.visible || this.getPaneItems().length > 0)) ||
+              // ...or if the item can't be dropped in that dock.
+              (!shouldBeVisible && this.state.draggingItem && isItemAllowed(this.state.draggingItem, this.location))
+            }
+          />
+        </div>
+      </atom-dock>
+    )
+  }
+
+  update (props) {
+    // Since we're interopping with non-etch stuff, this method's actually never called.
+    return etch.update(this)
   }
 
   handleDidAddPaneItem () {
@@ -321,7 +325,7 @@ module.exports = class Dock {
   // area considered when detecting exit MUST fully encompass the area considered when detecting
   // entry.
   pointWithinHoverArea (point, detectingExit) {
-    const dockBounds = this.innerElement.getBoundingClientRect()
+    const dockBounds = this.refs.innerElement.getBoundingClientRect()
 
     // Copy the bounds object since we can't mutate it.
     const bounds = {
@@ -370,7 +374,7 @@ module.exports = class Dock {
     // remove it as an argument and determine whether we're inside the toggle button using
     // mouseenter/leave events on it. This class would still need to keep track of the mouse
     // position (via a mousemove listener) for the other measurements, though.
-    const toggleButtonBounds = this.toggleButton.getBounds()
+    const toggleButtonBounds = this.refs.toggleButton.getBounds()
     if (rectContainsPoint(toggleButtonBounds, point)) return true
 
     // The area used when detecting exit is actually larger than when detecting entrances. Expand
@@ -707,13 +711,20 @@ module.exports = class Dock {
 
 class DockResizeHandle {
   constructor (props) {
-    this.handleMouseDown = this.handleMouseDown.bind(this)
-
-    this.element = document.createElement('div')
-    this.element.classList.add('atom-dock-resize-handle', props.location)
-    this.element.addEventListener('mousedown', this.handleMouseDown)
     this.props = props
-    this.update(props)
+    etch.initialize(this)
+  }
+
+  render () {
+    const classList = ['atom-dock-resize-handle', this.props.location]
+    if (this.props.dockIsVisible) classList.push(RESIZE_HANDLE_RESIZABLE_CLASS)
+
+    return (
+      <div
+        className={classList.join(' ')}
+        on={{mousedown: this.handleMouseDown}}
+      />
+    )
   }
 
   getElement () {
@@ -729,12 +740,7 @@ class DockResizeHandle {
 
   update (newProps) {
     this.props = Object.assign({}, this.props, newProps)
-
-    if (this.props.dockIsVisible) {
-      this.element.classList.add(RESIZE_HANDLE_RESIZABLE_CLASS)
-    } else {
-      this.element.classList.remove(RESIZE_HANDLE_RESIZABLE_CLASS)
-    }
+    return etch.update(this)
   }
 
   handleMouseDown (event) {
@@ -748,22 +754,26 @@ class DockResizeHandle {
 
 class DockToggleButton {
   constructor (props) {
-    this.handleClick = this.handleClick.bind(this)
-    this.handleDragEnter = this.handleDragEnter.bind(this)
-
-    this.element = document.createElement('div')
-    this.element.classList.add('atom-dock-toggle-button', props.location)
-    this.element.classList.add(props.location)
-    this.innerElement = document.createElement('div')
-    this.innerElement.classList.add('atom-dock-toggle-button-inner', props.location)
-    this.innerElement.addEventListener('click', this.handleClick)
-    this.innerElement.addEventListener('dragenter', this.handleDragEnter)
-    this.iconElement = document.createElement('span')
-    this.innerElement.appendChild(this.iconElement)
-    this.element.appendChild(this.innerElement)
-
     this.props = props
-    this.update(props)
+    etch.initialize(this)
+  }
+
+  render () {
+    const classList = ['atom-dock-toggle-button', this.props.location]
+    if (this.props.visible) classList.push(TOGGLE_BUTTON_VISIBLE_CLASS)
+
+    return (
+      <div className={classList.join(' ')}>
+        <div
+          ref='innerElement'
+          className={`atom-dock-toggle-button-inner ${this.props.location}`}
+          on={{click: this.handleClick, dragenter: this.handleDragEnter}}>
+          <span
+            ref='iconElement'
+            className={`icon ${getIconName(this.props.location, this.props.dockIsVisible)}`} />
+        </div>
+      </div>
+    )
   }
 
   getElement () {
@@ -771,19 +781,12 @@ class DockToggleButton {
   }
 
   getBounds () {
-    return this.innerElement.getBoundingClientRect()
+    return this.refs.innerElement.getBoundingClientRect()
   }
 
   update (newProps) {
     this.props = Object.assign({}, this.props, newProps)
-
-    if (this.props.visible) {
-      this.element.classList.add(TOGGLE_BUTTON_VISIBLE_CLASS)
-    } else {
-      this.element.classList.remove(TOGGLE_BUTTON_VISIBLE_CLASS)
-    }
-
-    this.iconElement.className = 'icon ' + getIconName(this.props.location, this.props.dockIsVisible)
+    return etch.update(this)
   }
 
   handleClick () {
@@ -792,6 +795,18 @@ class DockToggleButton {
 
   handleDragEnter () {
     this.props.onDragEnter()
+  }
+}
+
+// An etch component that doesn't use etch, this component provides a gateway from JSX back into
+// the mutable DOM world.
+class ElementComponent {
+  constructor (props) {
+    this.element = props.element
+  }
+
+  update (props) {
+    this.element = props.element
   }
 }
 

--- a/src/dock.js
+++ b/src/dock.js
@@ -1,6 +1,3 @@
-/** @babel */
-/** @jsx etch.dom */
-
 const etch = require('etch')
 const _ = require('underscore-plus')
 const {CompositeDisposable, Emitter} = require('event-kit')
@@ -8,6 +5,7 @@ const PaneContainer = require('./pane-container')
 const TextEditor = require('./text-editor')
 const Grim = require('grim')
 
+const $ = etch.dom
 const MINIMUM_SIZE = 100
 const DEFAULT_INITIAL_SIZE = 300
 const SHOULD_ANIMATE_CLASS = 'atom-dock-should-animate'
@@ -194,46 +192,48 @@ module.exports = class Dock {
     // ...but the content needs to maintain a constant size.
     const wrapperStyle = {[this.widthOrHeight]: `${size}px`}
 
-    return (
-      <atom-dock className={this.location}>
-        <div ref='innerElement' className={innerElementClassList.join(' ')}>
-          <div
-            className={maskElementClassList.join(' ')}
-            style={maskStyle}>
-            <div
-              ref='wrapperElement'
-              className={`atom-dock-content-wrapper ${this.location}`}
-              style={wrapperStyle}>
-              <DockResizeHandle
-                location={this.location}
-                onResizeStart={this.handleResizeHandleDragStart}
-                onResizeToFit={this.handleResizeToFit}
-                dockIsVisible={this.state.visible}
-              />
-              <ElementComponent element={this.paneContainer.getElement()} />
-              <div className={cursorOverlayElementClassList.join(' ')} />
-            </div>
-          </div>
-          {/*
-            The toggle button must be rendered outside the mask because (1) it shouldn't be masked
-            and (2) if we made the mask larger to avoid masking it, the mask would block mouse
-            events.
-          */}
-          <DockToggleButton
-            ref='toggleButton'
-            onDragEnter={this.handleToggleButtonDragEnter}
-            location={this.location}
-            toggle={this.toggle}
-            dockIsVisible={shouldBeVisible}
-            visible={
-              // Don't show the toggle button if the dock is closed and empty...
-              (this.state.hovered && (this.state.visible || this.getPaneItems().length > 0)) ||
-              // ...or if the item can't be dropped in that dock.
-              (!shouldBeVisible && this.state.draggingItem && isItemAllowed(this.state.draggingItem, this.location))
-            }
-          />
-        </div>
-      </atom-dock>
+    return $(
+      'atom-dock',
+      {className: this.location},
+      $.div(
+        {ref: 'innerElement', className: innerElementClassList.join(' ')},
+        $.div(
+          {
+            className: maskElementClassList.join(' '),
+            style: maskStyle
+          },
+          $.div(
+            {
+              ref: 'wrapperElement',
+              className: `atom-dock-content-wrapper ${this.location}`,
+              style: wrapperStyle
+            },
+            $(DockResizeHandle, {
+              location: this.location,
+              onResizeStart: this.handleResizeHandleDragStart,
+              onResizeToFit: this.handleResizeToFit,
+              dockIsVisible: this.state.visible
+            }),
+            $(ElementComponent, {element: this.paneContainer.getElement()}),
+            $.div({className: cursorOverlayElementClassList.join(' ')})
+          )
+        ),
+        $(DockToggleButton, {
+          ref: 'toggleButton',
+          onDragEnter: this.handleToggleButtonDragEnter,
+          location: this.location,
+          toggle: this.toggle,
+          dockIsVisible: shouldBeVisible,
+          visible:
+            // Don't show the toggle button if the dock is closed and empty...
+            (this.state.hovered &&
+              (this.state.visible || this.getPaneItems().length > 0)) ||
+            // ...or if the item can't be dropped in that dock.
+            (!shouldBeVisible &&
+              this.state.draggingItem &&
+              isItemAllowed(this.state.draggingItem, this.location))
+        })
+      )
     )
   }
 
@@ -719,12 +719,10 @@ class DockResizeHandle {
     const classList = ['atom-dock-resize-handle', this.props.location]
     if (this.props.dockIsVisible) classList.push(RESIZE_HANDLE_RESIZABLE_CLASS)
 
-    return (
-      <div
-        className={classList.join(' ')}
-        on={{mousedown: this.handleMouseDown}}
-      />
-    )
+    return $.div({
+      className: classList.join(' '),
+      on: {mousedown: this.handleMouseDown}
+    })
   }
 
   getElement () {
@@ -762,17 +760,22 @@ class DockToggleButton {
     const classList = ['atom-dock-toggle-button', this.props.location]
     if (this.props.visible) classList.push(TOGGLE_BUTTON_VISIBLE_CLASS)
 
-    return (
-      <div className={classList.join(' ')}>
-        <div
-          ref='innerElement'
-          className={`atom-dock-toggle-button-inner ${this.props.location}`}
-          on={{click: this.handleClick, dragenter: this.handleDragEnter}}>
-          <span
-            ref='iconElement'
-            className={`icon ${getIconName(this.props.location, this.props.dockIsVisible)}`} />
-        </div>
-      </div>
+    return $.div(
+      {className: classList.join(' ')},
+      $.div(
+        {
+          ref: 'innerElement',
+          className: `atom-dock-toggle-button-inner ${this.props.location}`,
+          on: {click: this.handleClick, dragenter: this.handleDragEnter}
+        },
+        $.span({
+          ref: 'iconElement',
+          className: `icon ${getIconName(
+            this.props.location,
+            this.props.dockIsVisible
+          )}`
+        })
+      )
     )
   }
 

--- a/src/dock.js
+++ b/src/dock.js
@@ -50,6 +50,7 @@ module.exports = class Dock {
     })
 
     this.state = {
+      ready: false,
       size: null,
       visible: false,
       shouldAnimate: false
@@ -76,10 +77,16 @@ module.exports = class Dock {
   // This method is called explicitly by the object which adds the Dock to the document.
   elementAttached () {
     // Re-render when the dock is attached to make sure we remeasure sizes defined in CSS.
-    etch.update(this)
+    etch.updateSync(this)
   }
 
   getElement () {
+    if (!this.state.ready) {
+      // Render the element with its contents for the first time. This needs to be deferred so it's
+      // not done when snapshotting.
+      this.setState({ready: true})
+      etch.updateSync(this)
+    }
     return this.element
   }
 
@@ -171,6 +178,14 @@ module.exports = class Dock {
   }
 
   render () {
+    const atomDock = children => $('atom-dock', {className: this.location}, children)
+
+    // Because this code is included in the snapshot, we have to make sure we don't load
+    // DOM-touching classes (like PaneContainerElement) during initialization. The way we do this
+    // is by avoiding rendering the full contents until the element is attached, at which point we
+    // toggle the `ready` state and render the full dock contents.
+    if (!this.state.ready) return atomDock([])
+
     const innerElementClassList = ['atom-dock-inner', this.location]
     if (this.state.visible) innerElementClassList.push(VISIBLE_CLASS)
 
@@ -192,9 +207,7 @@ module.exports = class Dock {
     // ...but the content needs to maintain a constant size.
     const wrapperStyle = {[this.widthOrHeight]: `${size}px`}
 
-    return $(
-      'atom-dock',
-      {className: this.location},
+    return atomDock(
       $.div(
         {ref: 'innerElement', className: innerElementClassList.join(' ')},
         $.div(


### PR DESCRIPTION
Since #16116 is going to require big changes to how docks are layed out (for which I'll be using etch), I wanted to convert Dock itself. Then I'll update `Dock::render()` to replace the PaneContainer with a `DockGroupContainer` (which itself will render `DockGroups`).

Dock was already written in a super Reacty way so there isn't much being changed here. Basically, `render()` just returns vdom instead of being a side-effect cesspool.

While working on this, I (re)discovered #16769. In order to be able to verify that I didn't make a mess of things with this PR, I fixed that issue in #16863 and rebased on that. I opened this as a PR against that branch for review purposes, but after that's merged I'll rebase it onto master and switch the base. Please let me know if there was a better way to do it!