### PR TITLE
Use native isArray, endsWith

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1062,7 +1062,7 @@ class Config {
   deepClone (object) {
     if (object instanceof Color) {
       return object.clone()
-    } else if (_.isArray(object)) {
+    } else if (Array.isArray(object)) {
       return object.map(value => this.deepClone(value))
     } else if (isPlainObject(object)) {
       return _.mapObject(object, (key, value) => [key, this.deepClone(value)])
@@ -1416,7 +1416,7 @@ Config.addSchemaEnforcers({
   }
 })
 
-let isPlainObject = value => _.isObject(value) && !_.isArray(value) && !_.isFunction(value) && !_.isString(value) && !(value instanceof Color)
+let isPlainObject = value => _.isObject(value) && !Array.isArray(value) && !_.isFunction(value) && !_.isString(value) && !(value instanceof Color)
 
 let sortObject = value => {
   if (!isPlainObject(value)) { return value }

--- a/src/decoration.js
+++ b/src/decoration.js
@@ -1,4 +1,3 @@
-const _ = require('underscore-plus')
 const {Emitter} = require('event-kit')
 
 let idCounter = 0
@@ -49,7 +48,7 @@ class Decoration {
   // 'line-number' is a 'gutter', but a 'gutter' is not a 'line-number'.
   static isType (decorationProperties, type) {
     // 'line-number' is a special case of 'gutter'.
-    if (_.isArray(decorationProperties.type)) {
+    if (Array.isArray(decorationProperties.type)) {
       if (decorationProperties.type.includes(type)) {
         return true
       }

--- a/src/notification.js
+++ b/src/notification.js
@@ -21,7 +21,7 @@ class Notification {
       throw new Error(`Notification must be created with string message: ${this.message}`)
     }
 
-    if (!_.isObject(this.options) || _.isArray(this.options)) {
+    if (!_.isObject(this.options) || Array.isArray(this.options)) {
       throw new Error(`Notification must be created with an options object: ${this.options}`)
     }
   }

--- a/src/theme-manager.js
+++ b/src/theme-manager.js
@@ -103,7 +103,7 @@ class ThemeManager {
 
   warnForNonExistentThemes () {
     let themeNames = this.config.get('core.themes') || []
-    if (!_.isArray(themeNames)) { themeNames = [themeNames] }
+    if (!Array.isArray(themeNames)) { themeNames = [themeNames] }
     for (let themeName of themeNames) {
       if (!themeName || (typeof themeName !== 'string') || !this.packageManager.resolvePackagePath(themeName)) {
         console.warn(`Enabled theme '${themeName}' is not installed.`)
@@ -116,7 +116,7 @@ class ThemeManager {
   // Returns an array of theme names in the order that they should be activated.
   getEnabledThemeNames () {
     let themeNames = this.config.get('core.themes') || []
-    if (!_.isArray(themeNames)) { themeNames = [themeNames] }
+    if (!Array.isArray(themeNames)) { themeNames = [themeNames] }
     themeNames = themeNames.filter((themeName) =>
       (typeof themeName === 'string') && this.packageManager.resolvePackagePath(themeName)
     )
@@ -138,7 +138,7 @@ class ThemeManager {
       if (themeNames.length === 0) {
         themeNames = ['one-dark-syntax', 'one-dark-ui']
       } else if (themeNames.length === 1) {
-        if (_.endsWith(themeNames[0], '-ui')) {
+        if (themeNames[0].endsWith('-ui')) {
           themeNames.unshift('one-dark-syntax')
         } else {
           themeNames.push('one-dark-ui')


### PR DESCRIPTION
### Description of the Change
- Used native `Array.isArray` instead of Underscore's isArray.
- Used native `endsWith` instead of Underscore's
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Benefits

Less external dependencies
<!-- What benefits will be realized by the code change? -->