### PR TITLE
[wip] Improve ability to detect Python 2 during build

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,6 +3,8 @@
 'use strict'
 
 const childProcess = require('child_process')
+const path = require('path')
+const dowsingRod = require('@atom/dowsing-rod')
 const CONFIG = require('./config')
 const cleanDependencies = require('./lib/clean-dependencies')
 const deleteMsbuildFromPath = require('./lib/delete-msbuild-from-path')
@@ -16,6 +18,11 @@ process.on('unhandledRejection', function (e) {
   console.error(e.stack || e)
   process.exit(1)
 })
+
+dowsingRod.setPythonEnvSync({
+  npmBin: CONFIG.getNpmBinPath(),
+  pythonBinFile: path.join(CONFIG.atomHomeDirPath, 'python2bin'),
+}, process.env)
 
 verifyMachineRequirements()
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,7 +4,6 @@
 
 const childProcess = require('child_process')
 const path = require('path')
-const dowsingRod = require('@atom/dowsing-rod')
 const CONFIG = require('./config')
 const cleanDependencies = require('./lib/clean-dependencies')
 const deleteMsbuildFromPath = require('./lib/delete-msbuild-from-path')
@@ -19,11 +18,6 @@ process.on('unhandledRejection', function (e) {
   process.exit(1)
 })
 
-dowsingRod.setPythonEnvSync({
-  npmBin: CONFIG.getNpmBinPath(),
-  pythonBinFile: path.join(CONFIG.atomHomeDirPath, 'python2bin'),
-}, process.env)
-
 verifyMachineRequirements()
 
 if (dependenciesFingerprint.isOutdated()) {
@@ -33,6 +27,13 @@ if (dependenciesFingerprint.isOutdated()) {
 if (process.platform === 'win32') deleteMsbuildFromPath()
 
 installScriptDependencies()
+
+const dowsingRod = require('@atom/dowsing-rod')
+dowsingRod.setPythonEnvSync({
+  npmBin: CONFIG.getNpmBinPath(),
+  pythonBinFile: path.join(CONFIG.atomHomeDirPath, 'python2bin'),
+}, process.env)
+
 installApm()
 childProcess.execFileSync(
   CONFIG.getApmBinPath(),

--- a/script/package.json
+++ b/script/package.json
@@ -2,6 +2,7 @@
   "name": "atom-build-scripts",
   "description": "Atom build scripts",
   "dependencies": {
+    "@atom/dowsing-rod": "^1.0.1",
     "async": "2.0.1",
     "babel-core": "5.8.38",
     "coffeelint": "1.15.7",

--- a/script/package.json
+++ b/script/package.json
@@ -2,7 +2,7 @@
   "name": "atom-build-scripts",
   "description": "Atom build scripts",
   "dependencies": {
-    "@atom/dowsing-rod": "^1.0.1",
+    "@atom/dowsing-rod": "^1.1.0",
     "async": "2.0.1",
     "babel-core": "5.8.38",
     "coffeelint": "1.15.7",


### PR DESCRIPTION
### Description of the Change

Use [@atom/dowsing-rod](https://github.com/atom/dowsing-rod) to aggressively detect python 2 installations and pass it to node-gyp subprocesses. We won't be able to get away from requiring python 2 entirely, but we can at least accept a python 2 path from `npm config get python` or `${PYTHON}`.

Without this in place, even with `${PYTHON}` set to a python2 install, the build for git-utils fails with a python 2/3 compatibility problem. It turns out that the Makefile generated by node-gyp sometimes executes a file with a `#!/usr/bin/env python` shebang line, so unless the python2 binary is actually discoverable on the `${PATH}` as "python", the build fails.

### Alternate Designs

The clearest alternative is to actually fix node-gyp at the source, by porting gyp to Python 3 or JavaScript. That would require getting a patch accepted into gyp, then waiting for it to be included in a node-gyp release, then a node release, then upgrade our build to use that node version.

### Why Should This Be In Core?

It's where the build is.

I'm also going to create a parallel pull request for apm to improve our Python detection during apm builds (atom/apm#775).

### Benefits

Developers who:

* Use `homebrew` on MacOS and have the `python` formula installed.
* Use Arch Linux or other distributions that use Python 3 as their default `python` package.

...will be able to build Atom without having to break things on their system that rely on Python 3 being the default. We'll also have a nice message if Python 2 cannot be found.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

The ultimate test is to run `script/build` with Python 3 on the PATH.

### Applicable Issues

* atom/git-utils#48
* atom/git-utils#72
* atom/apm#698
* atom/apm#706
* atom/apm#703
