### PR TITLE
Fix shaking editor when typing

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2811,7 +2811,7 @@ class TextEditorComponent {
   setScrollTop (scrollTop) {
     if (Number.isNaN(scrollTop) || scrollTop == null) return false
 
-    scrollTop = Math.round(Math.max(0, Math.min(this.getMaxScrollTop(), scrollTop)))
+    scrollTop = roundToPhysicalPixelBoundary(Math.max(0, Math.min(this.getMaxScrollTop(), scrollTop)))
     if (scrollTop !== this.scrollTop) {
       this.derivedDimensionsCache = {}
       this.scrollTopPending = true
@@ -2842,7 +2842,7 @@ class TextEditorComponent {
   setScrollLeft (scrollLeft) {
     if (Number.isNaN(scrollLeft) || scrollLeft == null) return false
 
-    scrollLeft = Math.round(Math.max(0, Math.min(this.getMaxScrollLeft(), scrollLeft)))
+    scrollLeft = roundToPhysicalPixelBoundary(Math.max(0, Math.min(this.getMaxScrollLeft(), scrollLeft)))
     if (scrollLeft !== this.scrollLeft) {
       this.scrollLeftPending = true
       this.scrollLeft = scrollLeft


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

When using DPI scaling the scroll position could be set to a position that was not possible causing a scroll event to scroll back. This was causing the editor to shake when editing. This PR fixes this by rounding scrollTop and scrollLeft to a physical pixel instead of rounding using Math.round

### Alternate Designs

N/A

### Why Should This Be In Core?

It is already in Core

### Benefits

* Fixes a bug causing the editor to shake when typing

### Verification Process

**Before:**
![before](https://user-images.githubusercontent.com/1058982/36989067-e79dd5e0-20a0-11e8-94bc-5de7a4a08b08.gif)

**After:**
![after](https://user-images.githubusercontent.com/1058982/36989078-eeed05fa-20a0-11e8-9d3c-bc032225c5a2.gif)


### Applicable Issues

Fixes https://github.com/atom/atom/issues/15786

/cc: @nathansobo 
