### PR TITLE
Fix regression where config file was loaded in specs

### DIFF
--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -57,7 +57,9 @@ class AtomWindow extends EventEmitter {
 
     Object.defineProperty(this.browserWindow, 'loadSettingsJSON', {
       get: () => JSON.stringify(Object.assign({
-        userSettings: this.atomApplication.configFile.get()
+        userSettings: !this.isSpec
+          ? this.atomApplication.configFile.get()
+          : null
       }, this.loadSettings)),
       configurable: true
     })


### PR DESCRIPTION
This regressed due to https://github.com/atom/atom/pull/16628.

Fixes https://github.com/atom/atom/issues/16910
Refs https://github.com/atom/spell-check/pull/240