### PR TITLE
Fix bug caused by dragging file from desktop through dock handle

### DIFF
--- a/src/dock.js
+++ b/src/dock.js
@@ -233,7 +233,7 @@ module.exports = class Dock {
         ),
         $(DockToggleButton, {
           ref: 'toggleButton',
-          onDragEnter: this.handleToggleButtonDragEnter,
+          onDragEnter: this.state.draggingItem ? this.handleToggleButtonDragEnter : null,
           location: this.location,
           toggle: this.toggle,
           dockIsVisible: shouldBeVisible,
@@ -779,7 +779,10 @@ class DockToggleButton {
         {
           ref: 'innerElement',
           className: `atom-dock-toggle-button-inner ${this.props.location}`,
-          on: {click: this.handleClick, dragenter: this.handleDragEnter}
+          on: {
+            click: this.handleClick,
+            dragenter: this.props.onDragEnter
+          }
         },
         $.span({
           ref: 'iconElement',
@@ -807,10 +810,6 @@ class DockToggleButton {
 
   handleClick () {
     this.props.toggle()
-  }
-
-  handleDragEnter () {
-    this.props.onDragEnter()
   }
 }
 


### PR DESCRIPTION
This is a fix for #16933. To avoid rebase issues I based it on #16864.

The problem is that, while the workspace element only cares about drags originating from the current document, the same isn't true of the "dragenter" event that that dock uses. Rather than trying to handle this class of events specially in the dock, we simply limit our listening to when something is being dragged. Since we have a single source of truth for this information, this should be resilient to future changes in logic.