### PR TITLE
Clip cursor width when soft-wrap is on and cursor is at the end of a line

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -564,9 +564,20 @@ describe('TextEditorComponent', () => {
 
     it('gives cursors at the end of lines the width of an "x" character', async () => {
       const {component, element, editor} = buildComponent()
+      editor.setText('abcde')
+      await setEditorWidthInCharacters(component, 5.5)
+
       editor.setCursorScreenPosition([0, Infinity])
       await component.getNextUpdatePromise()
       expect(element.querySelector('.cursor').offsetWidth).toBe(Math.round(component.getBaseCharacterWidth()))
+
+      // Clip cursor width when soft-wrap is on and the cursor is at the end of
+      // the line. This prevents the parent tile from disabling sub-pixel
+      // anti-aliasing. For some reason, adding overflow: hidden to the cursor
+      // container doesn't solve this issue so we're adding this workaround instead.
+      editor.setSoftWrapped(true)
+      await component.getNextUpdatePromise()
+      expect(element.querySelector('.cursor').offsetWidth).toBeLessThan(Math.round(component.getBaseCharacterWidth()))
     })
 
     it('positions and sizes cursors correctly when they are located next to a fold marker', async () => {

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -3522,7 +3522,7 @@ class CursorsAndInputComponent {
 
       const cursorStyle = {
         height: cursorHeight,
-        width: pixelWidth + 'px',
+        width: Math.min(pixelWidth, scrollWidth - pixelLeft) + 'px',
         transform: `translate(${pixelLeft}px, ${pixelTop}px)`
       }
       if (extraCursorStyle) Object.assign(cursorStyle, extraCursorStyle)


### PR DESCRIPTION
### Description of the Change

This pull request prevents the parent tile from disabling sub-pixel anti-aliasing by clipping the cursor width to be fully contained within the editor when soft-wrap is on and the cursor is at the end of a line. For some reason, adding `overflow: hidden` to the cursor container element doesn't solve the issue, so we're adding this workaround instead.

### Alternate Designs

Unclear.

### Verification Process

* Enable soft-wrap
* Keep writing until reaching the end of the line (without wrapping to the next line)
* Notice how sub pixel anti-aliasing doesn't break anymore

| Before                                                                                                        | After                                                                                                        |
|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
| ![before](https://user-images.githubusercontent.com/482957/37338414-aafe390a-26b7-11e8-8bf9-0b1a46730bad.gif) | ![after](https://user-images.githubusercontent.com/482957/37338415-ab1dc8ba-26b7-11e8-82da-a1d8c3edf354.gif) |

### Applicable Issues

Fixes #16889

/cc: @Ben3eeE @50Wliu can you confirm this pull request fixes it? Thanks! 🙇 