### PR TITLE
Recognize .tsx source as Typescript

### DIFF
--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -17,6 +17,7 @@ var packageTranspilationRegistry = new PackageTranspilationRegistry()
 var COMPILERS = {
   '.js': packageTranspilationRegistry.wrapTranspiler(require('./babel')),
   '.ts': packageTranspilationRegistry.wrapTranspiler(require('./typescript')),
+  '.tsx': packageTranspilationRegistry.wrapTranspiler(require('./typescript')),
   '.coffee': packageTranspilationRegistry.wrapTranspiler(require('./coffee-script'))
 }
 


### PR DESCRIPTION
### Requirements

### Description of the Change

✨ Extra kudos to @kuychaco, who did the (rather painful) work of tracking this down yesterday. ✨ 

Ensure that `.tsx` is added to `require.extensions` by the CompilerCache.

Although the (ancient) version of Typescript that we bundle doesn't understand `.tsx` files itself, this will allow packages using [atom-ts-transpiler](https://www.npmjs.com/package/atom-ts-transpiler) to properly transpile `.tsx` source with newer Typescript releases.

### Alternate Designs

Alas, importing modules with a specified extension is explicitly disallowed by Typescript itself: see Microsoft/TypeScript#11901.

In general, it may be nice to allow custom transpilers to contribute recognized extensions to be added to `require.extensions` in addition to the built-in ones from `COMPILERS`. Personally, I'd wait until we had at least one more transpiler that needs this before adding that complexity, though.

### Why Should This Be In Core?

atom-ts-transpiler cannot import `.tsx` files until this change is in place.

### Benefits

TypeScript packages will be able to use `.tsx` source files and use React or Etch properly.

### Possible Drawbacks

If any existing packages are using the built-in TypeScript transpiler and contain `.tsx` source, they'll break because the old TypeScript version doesn't actually support them. But, `.tsx` source wouldn't have been working for them in the first place, and this would be a nudge to transition to a custom transpiler anyway.

### Verification Process

I built a [minimal TypeScript and React package](https://github.com/smashwilson/minimal-typescript-atom) and loaded it in dev mode with and without this change. Without it, the import statement for the `.tsx` file fails; with it, the package works correctly.

/cc @kuychaco @daviwil This should unblock our path to using TypeScript 🙌 
