### PR TITLE
Uninstall blacklisted packages automatically

### DIFF
--- a/benchmarks/text-editor-large-file-construction.bench.js
+++ b/benchmarks/text-editor-large-file-construction.bench.js
@@ -11,7 +11,7 @@ module.exports = async ({test}) => {
 
   document.body.appendChild(atom.workspace.getElement())
 
-  atom.packages.loadPackages()
+  await atom.packages.loadPackages()
   await atom.packages.activate()
 
   for (let pane of atom.workspace.getPanes()) {

--- a/benchmarks/text-editor-long-lines.bench.js
+++ b/benchmarks/text-editor-long-lines.bench.js
@@ -16,7 +16,7 @@ module.exports = async ({test}) => {
   const workspaceElement = atom.workspace.getElement()
   document.body.appendChild(workspaceElement)
 
-  atom.packages.loadPackages()
+  await atom.packages.loadPackages()
   await atom.packages.activate()
 
   console.log(atom.getLoadSettings().resourcePath);

--- a/spec/theme-manager-spec.js
+++ b/spec/theme-manager-spec.js
@@ -6,6 +6,7 @@ describe('atom.themes', function () {
   beforeEach(function () {
     spyOn(atom, 'inSpecMode').andReturn(false)
     spyOn(console, 'warn')
+    spyOn(atom.packages, 'fetchBlacklist').andCallFake(async () => new Set())
   })
 
   afterEach(function () {
@@ -20,7 +21,7 @@ describe('atom.themes', function () {
   describe('theme getters and setters', function () {
     beforeEach(function () {
       jasmine.snapshotDeprecations()
-      atom.packages.loadPackages()
+      waitsForPromise(() => atom.packages.loadPackages())
     })
 
     afterEach(() => jasmine.restoreDeprecationsSnapshot())

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -816,7 +816,7 @@ class AtomEnvironment {
 
       this.registerDefaultTargetForKeymaps()
 
-      this.packages.loadPackages()
+      await this.packages.loadPackages()
 
       const startTime = Date.now()
       await this.deserialize(state)

--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -931,6 +931,10 @@ module.exports = class PackageManager {
           It is strongly recommended that you delete the above folders manually.
         `
       })
+    } else {
+      this.notificationManager.addSuccess('Successfully uninstalled malicious packages', {
+        dismissable: true
+      })
     }
   }
 }

--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -18,7 +18,7 @@ const dedent = require('dedent')
 // blacklisted yet) from permanently modifying the env when they are installed.
 // This adds some friction to the development process but guarantees that Atom
 // will always hit the right endpoint.
-const BLACKLIST_API_URL = 'https://atom.io/api/blacklist'
+const BLACKLIST_API_URL = 'https://atom.io/api/packages/blacklisted'
 
 // Extended: Package manager for coordinating the lifecycle of Atom packages.
 //

--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -11,6 +11,14 @@ const Package = require('./package')
 const ThemePackage = require('./theme-package')
 const {isDeprecatedPackage, getDeprecatedPackageMetadata} = require('./deprecated-packages')
 const packageJSON = require('../package.json')
+const dedent = require('dedent')
+
+// Note that we are hardcoding the URL into the source code as opposed to using
+// an environment variable here to prevent malicious packages (that haven't been
+// blacklisted yet) from permanently modifying the env when they are installed.
+// This adds some friction to the development process but guarantees that Atom
+// will always hit the right endpoint.
+const BLACKLIST_API_URL = 'https://atom.io/api/blacklist'
 
 // Extended: Package manager for coordinating the lifecycle of Atom packages.
 //
@@ -515,19 +523,29 @@ module.exports = class PackageManager {
     return pack
   }
 
-  loadPackages () {
+  async loadPackages () {
     // Ensure atom exports is already in the require cache so the load time
     // of the first package isn't skewed by being the first to require atom
     require('../exports/atom')
 
+    const blacklistedPackageNames = await this.fetchBlacklist()
     const disabledPackageNames = new Set(this.config.get('core.disabledPackages'))
+    const installedBlacklistedPackages = []
+
     this.config.transact(() => {
       for (const pack of this.getAvailablePackages()) {
-        this.loadAvailablePackage(pack, disabledPackageNames)
+        if (blacklistedPackageNames.has(pack.name)) {
+          installedBlacklistedPackages.push(pack)
+        } else {
+          this.loadAvailablePackage(pack, disabledPackageNames)
+        }
       }
     })
     this.initialPackagesLoaded = true
     this.emitter.emit('did-load-initial-packages')
+    if (installedBlacklistedPackages.length > 0) {
+      this.uninstallBlacklistedPackages(installedBlacklistedPackages)
+    }
   }
 
   loadPackage (nameOrPath) {
@@ -867,6 +885,52 @@ module.exports = class PackageManager {
     if (metadata != null) {
       normalizePackageData = normalizePackageData || require('normalize-package-data')
       normalizePackageData(metadata)
+    }
+  }
+
+  async fetchBlacklist () {
+    try {
+      const response = await window.fetch(BLACKLIST_API_URL)
+      const blacklist = await response.json()
+      return new Set(blacklist)
+    } catch (e) {
+      return new Set()
+    }
+  }
+
+  uninstallBlacklistedPackages (packages) {
+    this.notificationManager.addWarning('Malicious packages detected', {
+      dismissable: true,
+      description: dedent`
+        Atom has detected the following malicious package on your system:
+
+        ${packages.map(p => '* ' + p.name).join('\n')}
+
+        For your own safety these packages will be deleted from your system.
+      `
+    })
+
+    const packagesToUninstallManually = []
+    for (let i = 0; i < packages.length; i++) {
+      const pack = packages[i]
+      try {
+        fs.removeSync(pack.path)
+      } catch (error) {
+        packagesToUninstallManually.push(pack)
+      }
+    }
+
+    if (packagesToUninstallManually.length > 0) {
+      this.notificationManager.addError('Unable to uninstall malicious packages', {
+        dismissable: true,
+        description: dedent`
+          The following malicious packages could not be uninstalled automatically:
+
+          ${packagesToUninstallManually.map(p => `* ${p.name}: \`${p.path}\``).join('\n')}
+
+          It is strongly recommended that you delete the above folders manually.
+        `
+      })
     }
   }
 }


### PR DESCRIPTION
In the scenario where a bad actor has published a malicious package (e.g., harvesting computer resources for use in cryptocurrency mining without user consent, transmitting sensitive data without user consent, etc.) and users have installed it, we would like a way to helpfully remove that package from affected user systems. 

As such, with this pull request we are introducing a new mechanism that fetches a list of blacklisted packages from atom.io before any 3rd-party package gets loaded. If any of the blacklisted packages happen to be installed on the user system, Atom will attempt to uninstall automatically:

![successful](https://user-images.githubusercontent.com/482957/37411729-c65b1f00-27a3-11e8-81bf-063a06cf3646.png)

If that fails for some reason (e.g., path permission issues), the package will still **not** be loaded but users will be informed that they need to uninstall the malicious package(s) manually:

![permission denied](https://user-images.githubusercontent.com/482957/37411747-cdc34d12-27a3-11e8-9a6d-a92f755fc4d4.png)

A few notes about how this was implemented:

* Checking whether a package is malicious or not happens **before** loading any third party code. This is to prevent an already `require`d package from monkey-patching and bypassing our safety measures. Please, note that there is no way (at least with plain Node APIs) of stopping a package's code from running once it has been loaded into the V8 isolate.
* The atom.io API URL is hardcoded and is not read from `process.env`. This adds some friction to local development, but it prevents malicious packages from permanently modifying a user's environment (which would always bypass the security feature herein proposed).
* `PackageManager::loadPackages` has now become asynchronous due to `window.fetch`ing the list of malicious packages from atom.io. What this means is that startup time _may_ become slightly worse, but we think we can mitigate this by using `Cache-Control` headers in the server response.
* The atom.io API returns a list of all blacklisted packages. While this list is potentially unbounded, we didn't want to send the installed user packages over the wire to respect user privacy concerns.
* There is a chance that a user had `apm link`ed a locally developed package whose name gets blacklisted at some point. Uninstalling the package is the wrong thing to do in that case, but we still think it is okay because it is a non-destructive action. Atom will not try to delete the actual folder but will just remove the symlink instead.

### TODO

* [x] Deploy blacklist endpoint to staging
* [x] Test that this code works correctly using staging
* [ ] Deploy blacklist endpoint to atom.io

@lee-dohm @jasonrudolph @haacked: I would :heart: your input on the messaging I have used in the notifications above. Please, feel free to edit this branch to make any modification you think might make that UX more user-friendly.

/cc: @atom/core