### PR TITLE
Fix documentation for the Config class

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,8 @@ const Color = require('./color')
 const ScopedPropertyStore = require('scoped-property-store')
 const ScopeDescriptor = require('./scope-descriptor')
 
+const schemaEnforcers = {}
+
 // Essential: Used to access all of Atom's configuration details.
 //
 // An instance of this class is always available as the `atom.config` global.
@@ -359,8 +361,6 @@ const ScopeDescriptor = require('./scope-descriptor')
 //
 // * Don't depend on (or write to) configuration keys outside of your keypath.
 //
-const schemaEnforcers = {}
-
 class Config {
   static addSchemaEnforcer (typeName, enforcerFunction) {
     if (schemaEnforcers[typeName] == null) { schemaEnforcers[typeName] = [] }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The parser that generates the documentation requires the comment for the documentation to be immediately preceding the class definition. As part of the decaffeination process in #16593 a variable declaration was placed between the class definition and it's documentation, causing the parser to think there was none... and excluding it from the final result.

### Alternate Designs

Possibly make the parser to be more flexible about nodes it ignores when finding the documentation, however this will greatly increase the complexity for little benefit.

### Why Should This Be In Core?

This fixes a bug in Core.

### Benefits

The documentation for the `Config` class will now show up.

### Possible Drawbacks

None.

### Verification Process

I manually ran the documentation generation part of the build process from a "primed" state and verified that the information necessary for the documentation of the `Config` class was present.

### Applicable Issues

Fixes #16955.