### PR TITLE
allow the use of double slash flow comments

### DIFF
--- a/spec/babel-spec.coffee
+++ b/spec/babel-spec.coffee
@@ -42,6 +42,11 @@ describe "Babel transpiler support", ->
       transpiled = require('./fixtures/babel/flow-comment.js')
       expect(transpiled(3)).toBe 4
 
+  describe 'when a .js file starts with // @flow', ->
+    it "transpiles it using babel", ->
+      transpiled = require('./fixtures/babel/flow-slash-comment.js')
+      expect(transpiled(3)).toBe 4
+
   describe "when a .js file does not start with 'use babel';", ->
     it "does not transpile it using babel", ->
       spyOn(console, 'error')

--- a/spec/fixtures/babel/flow-slash-comment.js
+++ b/spec/fixtures/babel/flow-slash-comment.js
@@ -1,0 +1,4 @@
+// @flow
+
+const f: Function = v => v + 1
+module.exports = f

--- a/src/babel.js
+++ b/src/babel.js
@@ -11,7 +11,8 @@ var PREFIXES = [
   '/** @babel */',
   '"use babel"',
   '\'use babel\'',
-  '/* @flow */'
+  '/* @flow */',
+  '// @flow'
 ]
 
 var PREFIX_LENGTH = Math.max.apply(Math, PREFIXES.map(function (prefix) {


### PR DESCRIPTION
### Description of the Change
Currently, a Flow comment needs to be used with the following syntax: `/* @flow */`. This PR allows the usage of `// @flow` as well.

### Why Should This Be In Core?
To allow flexibility the same way that both `'use babel'` and `"use babel"` are supported.

### Benefits
It's a convenience.

### Possible Drawbacks
It is kind of a trivial addition.

### Verification Process
I wrote a test case for this, but I was having trouble getting `npm test` or `script/test` to work for me. I got an error like so:

```
AssertionError [ERR_ASSERTION]: More than one application to run tests against was found. 
```

I'm not sure how I'm supposed to develop on Atom if I already have Atom installed on my computer which I imagine is causing this error.

### Applicable Issues

N/A
