### PR TITLE
Support multiple config file paths

### DIFF
--- a/spec/config-file-spec.js
+++ b/spec/config-file-spec.js
@@ -91,6 +91,27 @@ describe('ConfigFile', () => {
       })
     })
   })
+
+  describe('ConfigFile.at()', () => {
+    let path0, path1
+
+    beforeEach(() => {
+      path0 = filePath
+      path1 = path.join(fs.realpathSync(temp.mkdirSync()), 'the-config.cson')
+
+      configFile = ConfigFile.at(path0)
+    })
+
+    it('returns an existing ConfigFile', () => {
+      const cf = ConfigFile.at(path0)
+      expect(cf).toEqual(configFile)
+    })
+
+    it('creates a new ConfigFile for unrecognized paths', () => {
+      const cf = ConfigFile.at(path1)
+      expect(cf).not.toEqual(configFile)
+    })
+  })
 })
 
 function writeFileSync (filePath, content, seconds = 2) {

--- a/spec/config-file-spec.js
+++ b/spec/config-file-spec.js
@@ -62,7 +62,7 @@ describe('ConfigFile', () => {
     })
   })
 
-  describe('when the file is  updated with invalid CSON', () => {
+  describe('when the file is updated with invalid CSON', () => {
     it('notifies onDidError observers', async () => {
       configFile = new ConfigFile(filePath)
       subscription = await configFile.watch()

--- a/src/application-delegate.js
+++ b/src/application-delegate.js
@@ -179,10 +179,10 @@ class ApplicationDelegate {
     return remote.systemPreferences.getUserDefault(key, type)
   }
 
-  async setUserSettings (config) {
+  async setUserSettings (config, configFilePath) {
     this.pendingSettingsUpdateCount++
     try {
-      await ipcHelpers.call('set-user-settings', JSON.stringify(config))
+      await ipcHelpers.call('set-user-settings', JSON.stringify(config), configFilePath)
     } finally {
       this.pendingSettingsUpdateCount--
     }

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -86,7 +86,7 @@ class AtomEnvironment {
     this.config = new Config({
       saveCallback: settings => {
         if (this.enablePersistence) {
-          this.applicationDelegate.setUserSettings(settings)
+          this.applicationDelegate.setUserSettings(settings, this.config.getUserConfigPath())
         }
       }
     })

--- a/src/config-file.js
+++ b/src/config-file.js
@@ -15,6 +15,21 @@ const EVENT_TYPES = new Set([
 
 module.exports =
 class ConfigFile {
+  static at (path) {
+    if (!this._known) {
+      this._known = new Map()
+    }
+
+    const existing = this._known.get(path)
+    if (existing) {
+      return existing
+    }
+
+    const created = new ConfigFile(path)
+    this._known.set(path, created)
+    return created
+  }
+
   constructor (path) {
     this.path = path
     this.emitter = new Emitter()

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -113,10 +113,12 @@ class AtomApplication extends EventEmitter {
       ? path.join(process.env.ATOM_HOME, 'config.json')
       : path.join(process.env.ATOM_HOME, 'config.cson')
 
-    this.configFile = new ConfigFile(configFilePath)
+    this.configFile = ConfigFile.at(configFilePath)
     this.config = new Config({
       saveCallback: settings => {
-        if (!this.quitting) return this.configFile.update(settings)
+        if (!this.quitting) {
+          return this.configFile.update(settings)
+        }
       }
     })
     this.config.setSchema(null, {type: 'object', properties: _.clone(ConfigSchema)})
@@ -561,8 +563,8 @@ class AtomApplication extends EventEmitter {
       window.setPosition(x, y)
     }))
 
-    this.disposable.add(ipcHelpers.respondTo('set-user-settings', (window, settings) =>
-      this.configFile.update(JSON.parse(settings))
+    this.disposable.add(ipcHelpers.respondTo('set-user-settings', (window, settings, filePath) =>
+      ConfigFile.at(filePath || this.configFilePath).update(JSON.parse(settings))
     ))
 
     this.disposable.add(ipcHelpers.respondTo('center-window', window => window.center()))


### PR DESCRIPTION
When config file I/O was centralized to the main process, the Config object's `mainSource` is disregarded and all configs are serialized to the same file. This results in config file loss when using `atom-mocha-test-runner` because the AtomEnvironments built there enable persistence to a temporary directory:

```js
global.buildAtomEnvironment = function (params = {}) {
  let defaultParams = {
    applicationDelegate,
    window,
    document,
    enablePersistence: true,
    configDirPath: tmpDir
  }
  return buildAtomEnvironment(Object.assign(defaultParams, params))
}
```

This restores the ability to track multiple Config objects and Atom environments by passing the source as well as the config payload to the main process through IPC.

Partial fix for #14909, specifically the bit where atom/github's test suite was resetting configuration :wink: