### PR TITLE
Add Probot lock configuration

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -14,4 +14,4 @@ lockComment: >
 exemptLabels:
   - help-wanted
 # Limit to only `issues` or `pulls`
-# only: issues
+only: issues

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,13 @@
+# Configuration for lock-threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 180
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  Locking this issue since it is closed and has had enough time for people
+  to give further feedback on. If you believe that you are encountering
+  the same problem described here, please open a new issue and fill out
+  [the entire template](https://github.com/atom/atom/blob/master/ISSUE_TEMPLATE.md)
+  to ensure that we have enough information to get this fixed. Thanks!
+# Limit to only `issues` or `pulls`
+# only: issues

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -6,7 +6,7 @@ daysUntilLock: 180
 lockComment: >
   This issue has been automatically locked since there has not been
   any recent activity after it was closed. If you can still reproduce this issue in
-  [safe mode](https://flight-manual.atom.io/hacking-atom/sections/debugging/#using-safe-mode)
+  [Safe Mode](https://flight-manual.atom.io/hacking-atom/sections/debugging/#using-safe-mode)
   then please open a new issue and fill out
   [the entire issue template](https://github.com/atom/atom/blob/master/ISSUE_TEMPLATE.md)
   to ensure that we have enough information to address your issue. Thanks!

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -10,5 +10,8 @@ lockComment: >
   then please open a new issue and fill out
   [the entire issue template](https://github.com/atom/atom/blob/master/ISSUE_TEMPLATE.md)
   to ensure that we have enough information to address your issue. Thanks!
+# Issues or pull requests with these labels will not be locked
+exemptLabels:
+  - help-wanted
 # Limit to only `issues` or `pulls`
 # only: issues

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -4,10 +4,10 @@
 daysUntilLock: 180
 # Comment to post before locking. Set to `false` to disable
 lockComment: >
-  Locking this issue since it is closed and has had enough time for people
-  to give further feedback on. If you believe that you are encountering
-  the same problem described here, please open a new issue and fill out
-  [the entire template](https://github.com/atom/atom/blob/master/ISSUE_TEMPLATE.md)
-  to ensure that we have enough information to get this fixed. Thanks!
+  This issue is now locked since it had enough time for everyone to give
+  further feedback on after it was closed. If you can still reproduce this
+  issue in safe mode `atom --safe` then please open a new issue and fill out
+  [the entire issue template](https://github.com/atom/atom/blob/master/ISSUE_TEMPLATE.md)
+  to ensure that we have enough information to address your issue. Thanks!
 # Limit to only `issues` or `pulls`
 # only: issues

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -4,10 +4,11 @@
 daysUntilLock: 180
 # Comment to post before locking. Set to `false` to disable
 lockComment: >
-  This issue is now locked since it had enough time for everyone to give further
-  feedback on after it was closed. If you can still reproduce this issue in
+  This issue has been automatically locked since there has not been
+  any recent activity after it was closed. If you can still reproduce this issue in
   [safe mode](https://flight-manual.atom.io/hacking-atom/sections/debugging/#using-safe-mode)
-  then please open a new issue and fill out [the entire issue template](https://github.com/atom/atom/blob/master/ISSUE_TEMPLATE.md)
+  then please open a new issue and fill out
+  [the entire issue template](https://github.com/atom/atom/blob/master/ISSUE_TEMPLATE.md)
   to ensure that we have enough information to address your issue. Thanks!
 # Limit to only `issues` or `pulls`
 # only: issues

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -4,10 +4,10 @@
 daysUntilLock: 180
 # Comment to post before locking. Set to `false` to disable
 lockComment: >
-  This issue is now locked since it had enough time for everyone to give
-  further feedback on after it was closed. If you can still reproduce this
-  issue in safe mode `atom --safe` then please open a new issue and fill out
-  [the entire issue template](https://github.com/atom/atom/blob/master/ISSUE_TEMPLATE.md)
+  This issue is now locked since it had enough time for everyone to give further
+  feedback on after it was closed. If you can still reproduce this issue in
+  [safe mode](https://flight-manual.atom.io/hacking-atom/sections/debugging/#using-safe-mode)
+  then please open a new issue and fill out [the entire issue template](https://github.com/atom/atom/blob/master/ISSUE_TEMPLATE.md)
   to ensure that we have enough information to address your issue. Thanks!
 # Limit to only `issues` or `pulls`
 # only: issues


### PR DESCRIPTION
### Description of the Change

Add lock configuration in preparation for adding [Lock Threads](https://probot.github.io/apps/lock/) to the Atom organization.

### Alternate Designs

N/A

### Why Should This Be In Core?

It needs to be everywhere.

### Benefits

The triage team will have to deal less with people saying "me too" on closed issues that, while they may appear related, often aren't.

### Possible Drawbacks

People may get upset that we're preventing them from commenting on old issues. Of course, they'll have to open new issues to let us know about it, which is the whole point.

### Applicable Issues

Too many to list.

/cc @Ben3eeE @50Wliu because you mentioned that you have a canned response for these kinds of things and maybe that would be better than what I've tossed together for the lock comment here.