### PR TITLE
Remove duplicate command bindings for undo and redo

### DIFF
--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -122,8 +122,6 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
   commandRegistry.add(
     'atom-text-editor',
     stopEventPropagation({
-      'core:undo': -> @undo()
-      'core:redo': -> @redo()
       'core:move-left': -> @moveLeft()
       'core:move-right': -> @moveRight()
       'core:select-left': -> @selectLeft()


### PR DESCRIPTION
This fixes a regression introduced in #16999. The `core:undo` and `core:redo` commands were registered twice: once for non-read-only editors and once for *all* editors. This caused the `undo` and `redo` methods to get called twice when typing `command-z` and `command-shift-z` (or when dispatching `core:undo`/`core:redo` from the command palette).