### PR TITLE
Add --generate-api-docs to build script

### DIFF
--- a/script/build
+++ b/script/build
@@ -6,7 +6,11 @@
 // are installed.
 require('./bootstrap')
 
+// Needed so we can require src/module-cache.coffee during generateModuleCache
+require('coffee-script/register')
 require('colors')
+
+const path = require('path')
 const yargs = require('yargs')
 const argv = yargs
   .usage('Usage: $0 [options]')
@@ -22,10 +26,6 @@ const argv = yargs
   .string('install')
   .wrap(yargs.terminalWidth())
   .argv
-
-// Needed so we can require src/module-cache.coffee during generateModuleCache
-require('coffee-script/register')
-const path = require('path')
 
 const checkChromedriverVersion = require('./lib/check-chromedriver-version')
 const cleanOutputDirectory = require('./lib/clean-output-directory')

--- a/script/build
+++ b/script/build
@@ -78,69 +78,67 @@ if (!argv.existingBinaries) {
   }
 }
 
-if (argv.generateApiDocs) {
-  process.exit()
-}
-
-binariesPromise
-  .then(packageApplication)
-  .then(packagedAppPath => generateStartupSnapshot(packagedAppPath).then(() => packagedAppPath))
-  .then(packagedAppPath => {
-    switch (process.platform) {
-      case 'darwin': {
-        if (argv.codeSign) {
-          codeSignOnMac(packagedAppPath)
-        } else {
-          console.log('Skipping code-signing. Specify the --code-sign option to perform code-signing'.gray)
-        }
-        break
-      }
-      case 'win32': {
-        if (argv.codeSign) {
-          const executablesToSign = [ path.join(packagedAppPath, 'Atom.exe') ]
-          if (argv.createWindowsInstaller) {
-            executablesToSign.push(path.join(__dirname, 'node_modules', 'electron-winstaller', 'vendor', 'Update.exe'))
+if (!argv.generateApiDocs) {
+  binariesPromise
+    .then(packageApplication)
+    .then(packagedAppPath => generateStartupSnapshot(packagedAppPath).then(() => packagedAppPath))
+    .then(packagedAppPath => {
+      switch (process.platform) {
+        case 'darwin': {
+          if (argv.codeSign) {
+            codeSignOnMac(packagedAppPath)
+          } else {
+            console.log('Skipping code-signing. Specify the --code-sign option to perform code-signing'.gray)
           }
-          codeSignOnWindows(executablesToSign)
-        } else {
-          console.log('Skipping code-signing. Specify the --code-sign option to perform code-signing'.gray)
+          break
         }
-        if (argv.createWindowsInstaller) {
-          return createWindowsInstaller(packagedAppPath)
-            .then(() => argv.codeSign && codeSignOnWindows([ path.join(CONFIG.buildOutputPath, 'AtomSetup.exe') ]))
-            .then(() => packagedAppPath)
-        } else {
-          console.log('Skipping creating installer. Specify the --create-windows-installer option to create a Squirrel-based Windows installer.'.gray)
+        case 'win32': {
+          if (argv.codeSign) {
+            const executablesToSign = [ path.join(packagedAppPath, 'Atom.exe') ]
+            if (argv.createWindowsInstaller) {
+              executablesToSign.push(path.join(__dirname, 'node_modules', 'electron-winstaller', 'vendor', 'Update.exe'))
+            }
+            codeSignOnWindows(executablesToSign)
+          } else {
+            console.log('Skipping code-signing. Specify the --code-sign option to perform code-signing'.gray)
+          }
+          if (argv.createWindowsInstaller) {
+            return createWindowsInstaller(packagedAppPath)
+              .then(() => argv.codeSign && codeSignOnWindows([ path.join(CONFIG.buildOutputPath, 'AtomSetup.exe') ]))
+              .then(() => packagedAppPath)
+          } else {
+            console.log('Skipping creating installer. Specify the --create-windows-installer option to create a Squirrel-based Windows installer.'.gray)
+          }
+          break
         }
-        break
+        case 'linux': {
+          if (argv.createDebianPackage) {
+            createDebianPackage(packagedAppPath)
+          } else {
+            console.log('Skipping creating debian package. Specify the --create-debian-package option to create it.'.gray)
+          }
+
+          if (argv.createRpmPackage) {
+            createRpmPackage(packagedAppPath)
+          } else {
+            console.log('Skipping creating rpm package. Specify the --create-rpm-package option to create it.'.gray)
+          }
+          break
+        }
       }
-      case 'linux': {
-        if (argv.createDebianPackage) {
-          createDebianPackage(packagedAppPath)
-        } else {
-          console.log('Skipping creating debian package. Specify the --create-debian-package option to create it.'.gray)
-        }
 
-        if (argv.createRpmPackage) {
-          createRpmPackage(packagedAppPath)
-        } else {
-          console.log('Skipping creating rpm package. Specify the --create-rpm-package option to create it.'.gray)
-        }
-        break
+      return Promise.resolve(packagedAppPath)
+    }).then(packagedAppPath => {
+      if (argv.compressArtifacts) {
+        compressArtifacts(packagedAppPath)
+      } else {
+        console.log('Skipping artifacts compression. Specify the --compress-artifacts option to compress Atom binaries (and symbols on macOS)'.gray)
       }
-    }
 
-    return Promise.resolve(packagedAppPath)
-  }).then(packagedAppPath => {
-    if (argv.compressArtifacts) {
-      compressArtifacts(packagedAppPath)
-    } else {
-      console.log('Skipping artifacts compression. Specify the --compress-artifacts option to compress Atom binaries (and symbols on macOS)'.gray)
-    }
-
-    if (argv.install != null) {
-      installApplication(packagedAppPath, argv.install)
-    } else {
-      console.log('Skipping installation. Specify the --install option to install Atom'.gray)
-    }
-  })
+      if (argv.install != null) {
+        installApplication(packagedAppPath, argv.install)
+      } else {
+        console.log('Skipping installation. Specify the --install option to install Atom'.gray)
+      }
+    })
+}

--- a/script/build
+++ b/script/build
@@ -6,11 +6,7 @@
 // are installed.
 require('./bootstrap')
 
-// Needed so we can require src/module-cache.coffee during generateModuleCache
-require('coffee-script/register')
 require('colors')
-
-const path = require('path')
 const yargs = require('yargs')
 const argv = yargs
   .usage('Usage: $0 [options]')
@@ -21,10 +17,15 @@ const argv = yargs
   .describe('create-debian-package', 'Create .deb package (Linux only)')
   .describe('create-rpm-package', 'Create .rpm package (Linux only)')
   .describe('compress-artifacts', 'Compress Atom binaries (and symbols on macOS)')
+  .describe('generate-api-docs', 'Only build the API documentation')
   .describe('install', 'Install Atom')
   .string('install')
   .wrap(yargs.terminalWidth())
   .argv
+
+// Needed so we can require src/module-cache.coffee during generateModuleCache
+require('coffee-script/register')
+const path = require('path')
 
 const checkChromedriverVersion = require('./lib/check-chromedriver-version')
 const cleanOutputDirectory = require('./lib/clean-output-directory')
@@ -72,7 +73,13 @@ if (!argv.existingBinaries) {
   prebuildLessCache()
   generateMetadata()
   generateAPIDocs()
-  binariesPromise = dumpSymbols()
+  if (!argv.generateApiDocs) {
+    binariesPromise = dumpSymbols()
+  }
+}
+
+if (argv.generateApiDocs) {
+  process.exit()
 }
 
 binariesPromise
@@ -86,6 +93,7 @@ binariesPromise
         } else {
           console.log('Skipping code-signing. Specify the --code-sign option to perform code-signing'.gray)
         }
+        break
       }
       case 'win32': {
         if (argv.codeSign) {
@@ -104,6 +112,7 @@ binariesPromise
         } else {
           console.log('Skipping creating installer. Specify the --create-windows-installer option to create a Squirrel-based Windows installer.'.gray)
         }
+        break
       }
       case 'linux': {
         if (argv.createDebianPackage) {
@@ -117,6 +126,7 @@ binariesPromise
         } else {
           console.log('Skipping creating rpm package. Specify the --create-rpm-package option to create it.'.gray)
         }
+        break
       }
     }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Add a new option `--generate-api-docs` that changes the build script to only do what is required to build the API documentation, skipping the process of building the full Atom binaries.

### Alternate Designs

Continuing to hack the build scripts manually to follow this behavior whenever a documentation only change is needed.

### Why Should This Be In Core?

It is an enhancement for the build script already in core.

### Benefits

Adds the ability to _only_ build the documentation when testing changes that only affect that and don't need the full binary to be built.

### Possible Drawbacks

Slightly higher complexity to the build script.

### Verification Process

Tested that this only does the necessary steps to build the documentation.

### Applicable Issues

None.
