### PR TITLE
Clarify deprecation of `undo: skip` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "service-hub": "^0.7.4",
     "sinon": "1.17.4",
     "temp": "^0.8.3",
-    "text-buffer": "13.13.0",
+    "text-buffer": "13.14.0",
     "tree-sitter": "^0.11.0",
     "typescript-simple": "1.0.0",
     "underscore-plus": "^1.6.6",

--- a/src/selection.js
+++ b/src/selection.js
@@ -446,7 +446,7 @@ class Selection {
   //   behavior is suppressed.
   //     level between the first lines and the trailing lines.
   //   * `normalizeLineEndings` (optional) {Boolean} (default: true)
-  //   * `undo` If `skip`, skips the undo stack for this operation.
+  //   * `undo` *Deprecated* If `skip`, skips the undo stack for this operation. This property is deprecated. Call groupLastChanges() on the {TextBuffer} afterward instead.
   //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify a read-only editor. (default: false)
   insertText (text, options = {}) {
     if (!this.ensureWritable('insertText', options)) return

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -1320,7 +1320,7 @@ class TextEditor {
   // * `text` A {String}
   // * `options` (optional) {Object}
   //   * `normalizeLineEndings` (optional) {Boolean} (default: true)
-  //   * `undo` (optional) {String} 'skip' will skip the undo system
+  //   * `undo` (optional) *Deprecated* {String} 'skip' will skip the undo system. This property is deprecated. Call groupLastChanges() on the {TextBuffer} afterward instead.
   //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify a read-only editor. (default: false)
   //
   // Returns the {Range} of the newly-inserted text.


### PR DESCRIPTION
Closes #16956

### TODO

- [x] Update docs for methods that use the deprecated `undo` option
- [x] Update to a new version of text-buffer that includes the changes from https://github.com/atom/text-buffer/pull/295