### PR TITLE
Convert arguments to absolute paths

### DIFF
--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -3,7 +3,9 @@
 if command -v "cygpath" > /dev/null; then
   # We have cygpath to do the conversion
   ATOMCMD=$(cygpath "$(dirname "$0")/atom.cmd" -a -w)
+  ARGS=( $(cygpath -a -w "$@" | tr '\n' ' ') ) 
 else
+  ARGS=$@
   pushd "$(dirname "$0")" > /dev/null
   if [[ $(uname -r) == *-Microsoft ]]; then
     # We are in Windows Subsystem for Linux, map /mnt/drive
@@ -16,7 +18,7 @@ else
   popd > /dev/null
 fi
 if [ "$(uname -o)" == "Msys" ]; then
-  cmd.exe //C "$ATOMCMD" "$@" # Msys thinks /C is a Windows path...
+  cmd.exe //C "$ATOMCMD" "${ARGS[@]}" # Msys thinks /C is a Windows path...
 else
-  cmd.exe /C "$ATOMCMD" "$@" # Cygwin does not
+  cmd.exe /C "$ATOMCMD" "${ARGS[@]}" # Cygwin does not
 fi


### PR DESCRIPTION
This script launches cmd and has it launch atom with the passed arguments. The problem is that cmd will not (necessarily) start in the pwd. So, relative paths like `.` and `..` have a different meaning. So we should first convert them to absolute paths with cygpath. 

Try it yourself. Go to some directory in bash and run `atom .` Rather than opening your current bash pwd, you'll open $HOME because when cmd opens, that's where it will be. Now apply this change and try the same thing. 

By the way, I only see this problem affecting MSysGit and MSys2. I can't say whether it affects other environments.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

In environments where `cygpath` is available, use it to convert any paths passed to `atom.sh` to absolute paths. 

### Alternate Designs

None

### Why Should This Be In Core?

Because it makes atom work properly on the command line.

### Benefits

MSys users will be able to run `atom .` to open the current directory in atom.

### Possible Drawbacks

Probably none.

### Verification Process

Tested as:
`atom .`
`atom ..` 
`atom . ..`

As well as other combinations of relative and absolute paths. On both MSys2 and MSysGit

### Applicable Issues

None