### PR TITLE
Separate keyboard enablement from read-only editor state

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2965,7 +2965,7 @@ class TextEditorComponent {
   }
 
   setInputEnabled (inputEnabled) {
-    this.props.model.update({enableKeyboardInput: inputEnabled})
+    this.props.model.update({keyboardInputEnabled: inputEnabled})
   }
 
   isInputEnabled () {

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2965,11 +2965,11 @@ class TextEditorComponent {
   }
 
   setInputEnabled (inputEnabled) {
-    this.props.model.update({readOnly: !inputEnabled})
+    this.props.model.update({enableKeyboardInput: inputEnabled})
   }
 
-  isInputEnabled (inputEnabled) {
-    return !this.props.model.isReadOnly()
+  isInputEnabled () {
+    return !this.props.model.isReadOnly() && this.props.model.isKeyboardInputEnabled()
   }
 
   getHiddenInput () {

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -477,7 +477,7 @@ class TextEditorComponent {
       attributes.mini = ''
     }
 
-    if (!this.isInputEnabled()) {
+    if (!model.isReadOnly()) {
       attributes.readonly = ''
     }
 

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -477,7 +477,7 @@ class TextEditorComponent {
       attributes.mini = ''
     }
 
-    if (!model.isReadOnly()) {
+    if (model.isReadOnly()) {
       attributes.readonly = ''
     }
 

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -130,6 +130,7 @@ class TextEditor {
     this.decorationManager = params.decorationManager
     this.selectionsMarkerLayer = params.selectionsMarkerLayer
     this.mini = (params.mini != null) ? params.mini : false
+    this.enableKeyboardInput = (params.enableKeyboardInput != null) ? params.enableKeyboardInput : true
     this.readOnly = (params.readOnly != null) ? params.readOnly : false
     this.placeholderText = params.placeholderText
     this.showLineNumbers = params.showLineNumbers
@@ -416,6 +417,14 @@ class TextEditor {
           }
           break
 
+        case 'enableKeyboardInput':
+          if (value !== this.enableKeyboardInput) {
+            this.enableKeyboardInput = value
+            if (this.component != null) {
+              this.component.scheduleUpdate()
+            }
+          }
+
         case 'placeholderText':
           if (value !== this.placeholderText) {
             this.placeholderText = value
@@ -547,6 +556,7 @@ class TextEditor {
       preferredLineLength: this.preferredLineLength,
       mini: this.mini,
       readOnly: this.readOnly,
+      enableKeyboardInput: this.enableKeyboardInput,
       editorWidthInChars: this.editorWidthInChars,
       width: this.width,
       maxScreenLineLength: this.maxScreenLineLength,
@@ -987,6 +997,12 @@ class TextEditor {
   }
 
   isReadOnly () { return this.readOnly }
+
+  enableKeyboardInput (enabled) {
+    this.update({enableKeyboardInput: enabled})
+  }
+
+  isKeyboardInputEnabled () { return this.keyboardInputEnabled }
 
   onDidChangeMini (callback) {
     return this.emitter.on('did-change-mini', callback)

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -130,7 +130,7 @@ class TextEditor {
     this.decorationManager = params.decorationManager
     this.selectionsMarkerLayer = params.selectionsMarkerLayer
     this.mini = (params.mini != null) ? params.mini : false
-    this.enableKeyboardInput = (params.enableKeyboardInput != null) ? params.enableKeyboardInput : true
+    this.keyboardInputEnabled = (params.keyboardInputEnabled != null) ? params.keyboardInputEnabled : true
     this.readOnly = (params.readOnly != null) ? params.readOnly : false
     this.placeholderText = params.placeholderText
     this.showLineNumbers = params.showLineNumbers
@@ -417,9 +417,9 @@ class TextEditor {
           }
           break
 
-        case 'enableKeyboardInput':
-          if (value !== this.enableKeyboardInput) {
-            this.enableKeyboardInput = value
+        case 'keyboardInputEnabled':
+          if (value !== this.keyboardInputEnabled) {
+            this.keyboardInputEnabled = value
             if (this.component != null) {
               this.component.scheduleUpdate()
             }
@@ -556,7 +556,7 @@ class TextEditor {
       preferredLineLength: this.preferredLineLength,
       mini: this.mini,
       readOnly: this.readOnly,
-      enableKeyboardInput: this.enableKeyboardInput,
+      keyboardInputEnabled: this.keyboardInputEnabled,
       editorWidthInChars: this.editorWidthInChars,
       width: this.width,
       maxScreenLineLength: this.maxScreenLineLength,
@@ -999,10 +999,10 @@ class TextEditor {
   isReadOnly () { return this.readOnly }
 
   enableKeyboardInput (enabled) {
-    this.update({enableKeyboardInput: enabled})
+    this.update({keyboardInputEnabled: enabled})
   }
 
-  isKeyboardInputEnabled () { return this.enableKeyboardInput }
+  isKeyboardInputEnabled () { return this.keyboardInputEnabled }
 
   onDidChangeMini (callback) {
     return this.emitter.on('did-change-mini', callback)

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -107,6 +107,13 @@ class TextEditor {
     }
 
     state.assert = atomEnvironment.assert.bind(atomEnvironment)
+
+    // Semantics of the readOnly flag have changed since its introduction.
+    // Only respect readOnly2, which has been set with the current readOnly semantics.
+    delete state.readOnly
+    state.readOnly = state.readOnly2
+    delete state.readOnly2
+
     const editor = new TextEditor(state)
     if (state.registered) {
       const disposable = atomEnvironment.textEditors.add(editor)
@@ -555,7 +562,7 @@ class TextEditor {
       softWrapAtPreferredLineLength: this.softWrapAtPreferredLineLength,
       preferredLineLength: this.preferredLineLength,
       mini: this.mini,
-      readOnly: this.readOnly,
+      readOnly2: this.readOnly, // readOnly encompassed both readOnly and keyboardInputEnabled
       keyboardInputEnabled: this.keyboardInputEnabled,
       editorWidthInChars: this.editorWidthInChars,
       width: this.width,

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -431,6 +431,7 @@ class TextEditor {
               this.component.scheduleUpdate()
             }
           }
+          break
 
         case 'placeholderText':
           if (value !== this.placeholderText) {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -1002,7 +1002,7 @@ class TextEditor {
     this.update({enableKeyboardInput: enabled})
   }
 
-  isKeyboardInputEnabled () { return this.keyboardInputEnabled }
+  isKeyboardInputEnabled () { return this.enableKeyboardInput }
 
   onDidChangeMini (callback) {
     return this.emitter.on('did-change-mini', callback)


### PR DESCRIPTION
Add an `enableKeyboardInput()` configuration to `TextEditor` that allows a package to explicitly take control of the editor's input without making the editor read-only. I'm also changing `TextEditorComponent.setInputEnabled()` to modify the editor's keyboard enablement rather than read-onliness to restore the behavior of calling it directly.

Fixes #17121.