### PR TITLE
Removed buggy auto indent behavior from move line up and down

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -2706,6 +2706,7 @@ describe('TextEditor', () => {
 
         describe('when the selection spans multiple lines', () => {
           it('moves the lines spanned by the selection to the preceding row', () => {
+            editor.update({autoIndent: false})
             expect(editor.lineTextForBufferRow(2)).toBe('    if (items.length <= 1) return items;')
             expect(editor.lineTextForBufferRow(3)).toBe('    var pivot = items.shift(), current, left = [], right = [];')
             expect(editor.lineTextForBufferRow(4)).toBe('    while(items.length > 0) {')
@@ -2717,6 +2718,8 @@ describe('TextEditor', () => {
             expect(editor.lineTextForBufferRow(2)).toBe('    var pivot = items.shift(), current, left = [], right = [];')
             expect(editor.lineTextForBufferRow(3)).toBe('    while(items.length > 0) {')
             expect(editor.lineTextForBufferRow(4)).toBe('    if (items.length <= 1) return items;')
+            editor.update({autoIndent: true})
+
           })
 
           describe("when the selection's end intersects a fold", () =>

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -2705,7 +2705,6 @@ describe('TextEditor', () => {
         })
 
         describe('when the selection spans multiple lines', () => {
-          editor.update({autoIndent: false})
           it('moves the lines spanned by the selection to the preceding row', () => {
             expect(editor.lineTextForBufferRow(2)).toBe('    if (items.length <= 1) return items;')
             expect(editor.lineTextForBufferRow(3)).toBe('    var pivot = items.shift(), current, left = [], right = [];')
@@ -2779,7 +2778,6 @@ describe('TextEditor', () => {
               expect(editor.isFoldedAtBufferRow(8)).toBeFalsy()
             })
           )
-          editor.update({autoIndent: true})
         })
 
         describe('when the selection spans multiple lines, but ends at column 0', () => {
@@ -3071,7 +3069,6 @@ describe('TextEditor', () => {
         })
 
         describe('when the selection spans multiple lines', () => {
-          editor.update({autoIndent: false})
           it('moves the lines spanned by the selection to the following row', () => {
             expect(editor.lineTextForBufferRow(2)).toBe('    if (items.length <= 1) return items;')
             expect(editor.lineTextForBufferRow(3)).toBe('    var pivot = items.shift(), current, left = [], right = [];')
@@ -3085,7 +3082,6 @@ describe('TextEditor', () => {
             expect(editor.lineTextForBufferRow(3)).toBe('    if (items.length <= 1) return items;')
             expect(editor.lineTextForBufferRow(4)).toBe('    var pivot = items.shift(), current, left = [], right = [];')
           })
-          editor.update({autoIndent: true})
         })
 
         describe('when the selection spans multiple lines, but ends at column 0', () => {
@@ -3644,7 +3640,6 @@ describe('TextEditor', () => {
       })
 
       it("inserts a newline below the cursor's current line, autoindents it, and moves the cursor to the end of the line", () => {
-        editor.update({autoIndent: true})
         editor.insertNewlineBelow()
         expect(buffer.lineForRow(0)).toBe('var quicksort = function () {')
         expect(buffer.lineForRow(1)).toBe('  ')

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -2705,8 +2705,8 @@ describe('TextEditor', () => {
         })
 
         describe('when the selection spans multiple lines', () => {
+          editor.update({autoIndent: false})
           it('moves the lines spanned by the selection to the preceding row', () => {
-            editor.update({autoIndent: false})
             expect(editor.lineTextForBufferRow(2)).toBe('    if (items.length <= 1) return items;')
             expect(editor.lineTextForBufferRow(3)).toBe('    var pivot = items.shift(), current, left = [], right = [];')
             expect(editor.lineTextForBufferRow(4)).toBe('    while(items.length > 0) {')
@@ -2718,8 +2718,6 @@ describe('TextEditor', () => {
             expect(editor.lineTextForBufferRow(2)).toBe('    var pivot = items.shift(), current, left = [], right = [];')
             expect(editor.lineTextForBufferRow(3)).toBe('    while(items.length > 0) {')
             expect(editor.lineTextForBufferRow(4)).toBe('    if (items.length <= 1) return items;')
-            editor.update({autoIndent: true})
-
           })
 
           describe("when the selection's end intersects a fold", () =>
@@ -2781,6 +2779,7 @@ describe('TextEditor', () => {
               expect(editor.isFoldedAtBufferRow(8)).toBeFalsy()
             })
           )
+          editor.update({autoIndent: true})
         })
 
         describe('when the selection spans multiple lines, but ends at column 0', () => {
@@ -3072,6 +3071,7 @@ describe('TextEditor', () => {
         })
 
         describe('when the selection spans multiple lines', () => {
+          editor.update({autoIndent: false})
           it('moves the lines spanned by the selection to the following row', () => {
             expect(editor.lineTextForBufferRow(2)).toBe('    if (items.length <= 1) return items;')
             expect(editor.lineTextForBufferRow(3)).toBe('    var pivot = items.shift(), current, left = [], right = [];')
@@ -3085,6 +3085,7 @@ describe('TextEditor', () => {
             expect(editor.lineTextForBufferRow(3)).toBe('    if (items.length <= 1) return items;')
             expect(editor.lineTextForBufferRow(4)).toBe('    var pivot = items.shift(), current, left = [], right = [];')
           })
+          editor.update({autoIndent: true})
         })
 
         describe('when the selection spans multiple lines, but ends at column 0', () => {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -1471,7 +1471,7 @@ class TextEditor {
       }
 
       this.setSelectedBufferRanges(newSelectionRanges, {autoscroll: false, preserveFolds: true})
-      //if (this.shouldAutoIndent()) this.autoIndentSelectedRows()
+      // if (this.shouldAutoIndent()) this.autoIndentSelectedRows()
       this.scrollToBufferPosition([newSelectionRanges[0].start.row, 0])
     })
   }
@@ -1549,7 +1549,7 @@ class TextEditor {
       }
 
       this.setSelectedBufferRanges(newSelectionRanges, {autoscroll: false, preserveFolds: true})
-      //if (this.shouldAutoIndent()) this.autoIndentSelectedRows()
+      // if (this.shouldAutoIndent()) this.autoIndentSelectedRows()
       this.scrollToBufferPosition([newSelectionRanges[0].start.row - 1, 0])
     })
   }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -1471,7 +1471,7 @@ class TextEditor {
       }
 
       this.setSelectedBufferRanges(newSelectionRanges, {autoscroll: false, preserveFolds: true})
-      if (this.shouldAutoIndent()) this.autoIndentSelectedRows()
+      //if (this.shouldAutoIndent()) this.autoIndentSelectedRows()
       this.scrollToBufferPosition([newSelectionRanges[0].start.row, 0])
     })
   }
@@ -1549,7 +1549,7 @@ class TextEditor {
       }
 
       this.setSelectedBufferRanges(newSelectionRanges, {autoscroll: false, preserveFolds: true})
-      if (this.shouldAutoIndent()) this.autoIndentSelectedRows()
+      //if (this.shouldAutoIndent()) this.autoIndentSelectedRows()
       this.scrollToBufferPosition([newSelectionRanges[0].start.row - 1, 0])
     })
   }


### PR DESCRIPTION
change auto indent to be off for moving multiple lines of code at once - many people suggested that this was causing bugs in their editing process.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

This is mainly in reference to #16571. I have been experiencing a good amount of bugs dealing with moving multiple lines of code because auto ident has issues correctly indenting after the move. Rather than try to indent and potentially create bugs, I just turned auto indent off so that normal behavior can be expected. I attempted to fix the auto indent issue but it ended up being too in depth, I may try again at a later date.

-->

### Alternate Designs

<!-- I considered turning off auto indent for all of line moving, but it seemed to be working very well with single line moves and working around folds, so I decided it was only necessary for multiple lines of indented code. I also attempted to fix the auto indent itself but was stuck figuring out exactly how it works - I will keep working on this-->

### Why Should This Be In Core?

<!-- Auto indent is a key feature, and right now it is buggy with regards to moving multiple lines at once. In order to ensure that core is less buggy, this should be fixed-->

### Benefits

<!-- Less buggy auto indent behavior, regardless of how nicely it auto indents, users prefer standard indentation that is not buggy-->

### Possible Drawbacks

<!-- This could cause an issue with someone who has expected a certain way of indenting, but really should not cause too many issues -->

### Verification Process

<!--
I ran atom in dev mode and was able to fix the buggy behavior that I had experienced in a similar way as #16571. I then ran all the tests and did not break anything, and since the code change is only in regard to MoveLineUp and MoveLineUp, I can be relatively certain that nothing else has been broken.

This change would technically be a regression, because sometimes auto indent did work on multiple lines, but I believe that stopping buggy behavior is more important. 

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
Ran the exact same process as #16571 and it worked as intended.

-->

### Applicable Issues

#16571
