### PR TITLE
Correct Project.onDidChangeFiles documentation

### DIFF
--- a/src/project.js
+++ b/src/project.js
@@ -199,7 +199,7 @@ class Project extends Model {
   // const disposable = atom.project.onDidChangeFiles(events => {
   //   for (const event of events) {
   //     // "created", "modified", "deleted", or "renamed"
-  //     console.log(`Event action: ${event.type}`)
+  //     console.log(`Event action: ${event.action}`)
   //
   //     // absolute path to the filesystem entry that was touched
   //     console.log(`Event path: ${event.path}`)


### PR DESCRIPTION
Looks like I missed a block of example code when `.type` was renamed to `.action`.

Fixes #17150.