### PR TITLE
Bump version for `about` package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "one-light-syntax": "1.8.2",
     "solarized-dark-syntax": "1.1.4",
     "solarized-light-syntax": "1.1.4",
-    "about": "1.8.1",
+    "about": "1.8.2",
     "archive-view": "0.64.3",
     "autocomplete-atom-api": "0.10.7",
     "autocomplete-css": "0.17.5",


### PR DESCRIPTION
The `about` package needs to link to the application-specific terms of service, and now it does.