### PR TITLE
Avoid writing to config file while quitting

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -439,7 +439,11 @@ class AtomApplication extends EventEmitter {
         event.preventDefault()
         const windowUnloadPromises = this.getAllWindows().map(window => window.prepareToUnload())
         const windowUnloadedResults = await Promise.all(windowUnloadPromises)
-        if (windowUnloadedResults.every(Boolean)) app.quit()
+        if (windowUnloadedResults.every(Boolean)) {
+          app.quit()
+        } else {
+          this.quitting = false
+        }
       }
 
       resolveBeforeQuitPromise()
@@ -563,9 +567,11 @@ class AtomApplication extends EventEmitter {
       window.setPosition(x, y)
     }))
 
-    this.disposable.add(ipcHelpers.respondTo('set-user-settings', (window, settings, filePath) =>
-      ConfigFile.at(filePath || this.configFilePath).update(JSON.parse(settings))
-    ))
+    this.disposable.add(ipcHelpers.respondTo('set-user-settings', (window, settings, filePath) => {
+      if (!this.quitting) {
+        ConfigFile.at(filePath || this.configFilePath).update(JSON.parse(settings))
+      }
+    }))
 
     this.disposable.add(ipcHelpers.respondTo('center-window', window => window.center()))
     this.disposable.add(ipcHelpers.respondTo('focus-window', window => window.focus()))


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/17060

/cc @Arcanemagus - I was never able to reproduce the config loss using your steps. It seems like it might be more unlikely on macOs, or depending on the speed of your disk. I'm going to go ahead speculatively merge this PR that I *think* might fix the problem. When you get a chance, would you mind trying to reproduce the bug with a new build?