### PR TITLE
Don't mention authors in issues created by the move bot

### DIFF
--- a/.github/move.yml
+++ b/.github/move.yml
@@ -1,0 +1,4 @@
+# Configuration for move-issues - https://github.com/dessant/move-issues
+
+# Mention issue, comment and command authors
+mentionAuthors: false


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

With https://github.com/dessant/move-issues/issues/1 being fixed in https://github.com/dessant/move-issues/commit/d561ee2614896b8c8f404d3696c98e8679a77380 we can now configure the move-issues bot to not mention authors.

There is also a `keepContentMentions` configuration option that will preserve mentions to teams/users in the issue content. This defaults to false.

### Alternate Designs

N/A

### Why Should This Be In Core?

It should be everywhere

### Benefits

* Less mentions to the maintainers that move issues
* Less mentions to every user involved in the issue

### Possible Drawbacks

This applies to all comments and the command comment. So the user that opened the issue will have to subscribe to the new issue if they want updates.

### Verification Process

N/A

### Applicable Issues

https://github.com/dessant/move-issues/issues/1
