### PR TITLE
Fix white I-beam cursor

### DIFF
--- a/static/cursors.less
+++ b/static/cursors.less
@@ -8,7 +8,7 @@
 @ibeam-2x: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAQAAADZc7J/AAAAz0lEQVRIx2NgYGBY/R8I/vx5eelX3n82IJ9FxGf6tksvf/8FiTMQAcAGQMDvSwu09abffY8QYSAScNk45G198eX//yev73/4///701eh//kZSARckrNBRvz//+8+6ZohwCzjGNjdgQxkAg7B9WADeBjIBqtJCbhRA0YNoIkBSNmaPEMoNmA0FkYNoFKhapJ6FGyAH3nauaSmPfwI0v/3OukVi0CIZ+F25KrtYcx/CTIy0e+rC7R1Z4KMICVTQQ14feVXIbR695u14+Ir4gwAAD49E54wc1kWAAAAAElFTkSuQmCC');
 
 .cursor-white() {
-  cursor: -webkit-image-set(@ibeam-1x 1dppx, @ibeam-2x 2dppx) 5 8, text;
+  cursor: -webkit-image-set(@ibeam-1x 1x, @ibeam-2x 2x) 5 8, text;
 }
 
 // Editors

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -19,5 +19,6 @@ module.exports = {
     "rule-empty-line-before": null, // TODO: enable?
     "at-rule-empty-line-before": null, // TODO: enable?
     "font-family-no-duplicate-names": null, // TODO: enable?
+    "unit-no-unknown": [true, {"ignoreUnits": [ "x" ]}], // Needed for -webkit-image-set 1x/2x units
   }
 }


### PR DESCRIPTION
### Description of the Change

Fixes the white I-beam cursor in dark themes on macOS.

### Why Should This Be In Core?

It's part of the `/static` styles.

### Benefits

The white I-beam cursor is easier to see on a dark background.

### Possible Drawbacks

None

### Verification Process

1. Open Atom on macOS.
2. Switch to a dark theme.
3. Open a file.
4. Confirm that the I-beam cursor is **white** when over an editor.

### Applicable Issues

Fixes #17174