### PR TITLE
Remove 'project' command line flag

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -204,7 +204,6 @@ class AtomApplication extends EventEmitter {
 
   openWithOptions (options) {
     const {
-      projectSpecification,
       initialPaths,
       pathsToOpen,
       executedFrom,
@@ -259,7 +258,6 @@ class AtomApplication extends EventEmitter {
         profileStartup,
         clearWindowState,
         addToLastWindow,
-        projectSpecification,
         env
       })
     } else if (urlsToOpen.length > 0) {
@@ -829,7 +827,6 @@ class AtomApplication extends EventEmitter {
     window,
     clearWindowState,
     addToLastWindow,
-    projectSpecification,
     env
   } = {}) {
     if (!pathsToOpen || pathsToOpen.length === 0) return
@@ -863,7 +860,7 @@ class AtomApplication extends EventEmitter {
     }
 
     let openedWindow
-    if (existingWindow && (projectSpecification == null || projectSpecification.config == null)) {
+    if (existingWindow) {
       openedWindow = existingWindow
       openedWindow.openLocations(locationsToOpen)
       if (openedWindow.isMinimized()) {
@@ -899,7 +896,6 @@ class AtomApplication extends EventEmitter {
         windowDimensions,
         profileStartup,
         clearWindowState,
-        projectSpecification,
         env
       })
       this.addWindow(openedWindow)

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -22,7 +22,6 @@ class AtomWindow extends EventEmitter {
     this.safeMode = settings.safeMode
     this.devMode = settings.devMode
     this.resourcePath = settings.resourcePath
-    this.projectSpecification = settings.projectSpecification
 
     let {pathToOpen, locationsToOpen} = settings
     if (!locationsToOpen && pathToOpen) locationsToOpen = [{pathToOpen}]
@@ -60,8 +59,7 @@ class AtomWindow extends EventEmitter {
       get: () => JSON.stringify(Object.assign({
         userSettings: !this.isSpec
           ? this.atomApplication.configFile.get()
-          : null,
-        projectSpecification: this.projectSpecification
+          : null
       }, this.loadSettings))
     })
 


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/17178

This (temporarily) removes the command line interface to the feature added in https://github.com/atom/atom/pull/16845. As far as I can tell, that interface never quite worked correctly. In my testing, the `paths` specified in the given project file were not opened. I think there are actually multiple causes of this:

1. Because the project specification was not integrated into the state serialization system, once the state was loaded from indexedDB, the paths would immediately [be replaced](https://github.com/atom/atom/blob/db36ca059080e6a4651b11176b1c4d69146bb48d/src/atom-environment.js#L1227) by different paths.
2. Project paths are also updated after the call to `project.replace` when the asynchronous [`open-paths` message](https://github.com/atom/atom/blob/db36ca059080e6a4651b11176b1c4d69146bb48d/src/atom-environment.js#L1351-L1406) is received.
2. As [someone reported](https://github.com/atom/atom/pull/16845#issuecomment-379592937) on the initial PR, some logic in the command line parsing caused the directory containing the project path itself to be opened.

The actual reason that I discovered this is while investigating #17178. macOS users are getting [this error](https://github.com/atom/atom/blob/db36ca059080e6a4651b11176b1c4d69146bb48d/src/main-process/parse-command-line.js#L212) when trying to open files in Atom by double clicking them. I added some code to log out the path when that error occurs, and I'm seeing that sometimes when double clicking a file, Atom is getting invoked with a `project` flag set to some weird non-existent path like `/sn_1_01235345`. I have no idea what causes that flag to get set.

/cc @matthewwithanm @philipfweiss It seemed like the command line `project` flag was not an important feature on your end; you mainly needed the `Project.replace` API. Is that right?

I think we can put back the `project` flag at some point, but for now I just need to get a hotfix out for #17178 and don't have time to fully backfill tests for this feature, think through how to integrate the `project` flag with the rest of the system, and avoid the bug described above.