### PR TITLE
Update existing editors' language modes when toggling tree-sitter feature flag

### DIFF
--- a/spec/grammar-registry-spec.js
+++ b/spec/grammar-registry-spec.js
@@ -14,6 +14,7 @@ describe('GrammarRegistry', () => {
 
   beforeEach(() => {
     grammarRegistry = new GrammarRegistry({config: atom.config})
+    expect(subscriptionCount(grammarRegistry)).toBe(1)
   })
 
   describe('.assignLanguageMode(buffer, languageId)', () => {
@@ -207,16 +208,16 @@ describe('GrammarRegistry', () => {
 
       const disposable = grammarRegistry.maintainLanguageMode(buffer)
       expect(retainedBufferCount(grammarRegistry)).toBe(1)
-      expect(subscriptionCount(grammarRegistry)).toBe(2)
+      expect(subscriptionCount(grammarRegistry)).toBe(3)
 
       buffer.destroy()
       expect(retainedBufferCount(grammarRegistry)).toBe(0)
-      expect(subscriptionCount(grammarRegistry)).toBe(0)
+      expect(subscriptionCount(grammarRegistry)).toBe(1)
       expect(buffer.emitter.getTotalListenerCount()).toBe(0)
 
       disposable.dispose()
       expect(retainedBufferCount(grammarRegistry)).toBe(0)
-      expect(subscriptionCount(grammarRegistry)).toBe(0)
+      expect(subscriptionCount(grammarRegistry)).toBe(1)
     })
 
     it('does not retain the buffer when the grammar registry is destroyed', () => {
@@ -225,12 +226,12 @@ describe('GrammarRegistry', () => {
 
       const disposable = grammarRegistry.maintainLanguageMode(buffer)
       expect(retainedBufferCount(grammarRegistry)).toBe(1)
-      expect(subscriptionCount(grammarRegistry)).toBe(2)
+      expect(subscriptionCount(grammarRegistry)).toBe(3)
 
       grammarRegistry.clear()
 
       expect(retainedBufferCount(grammarRegistry)).toBe(0)
-      expect(subscriptionCount(grammarRegistry)).toBe(0)
+      expect(subscriptionCount(grammarRegistry)).toBe(1)
       expect(buffer.emitter.getTotalListenerCount()).toBe(0)
     })
   })

--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -38,6 +38,14 @@ class GrammarRegistry {
     const grammarAddedOrUpdated = this.grammarAddedOrUpdated.bind(this)
     this.textmateRegistry.onDidAddGrammar(grammarAddedOrUpdated)
     this.textmateRegistry.onDidUpdateGrammar(grammarAddedOrUpdated)
+
+    this.subscriptions.add(this.config.onDidChange('core.useTreeSitterParsers', () => {
+      this.grammarScoresByBuffer.forEach((score, buffer) => {
+        if (!this.languageOverridesByBufferId.has(buffer.id)) {
+          this.autoAssignLanguageMode(buffer)
+        }
+      })
+    }))
   }
 
   serialize () {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -4093,7 +4093,7 @@ class TextEditor {
   // Extended: Unfold all existing folds.
   unfoldAll () {
     const result = this.displayLayer.destroyAllFolds()
-    this.scrollToCursorPosition()
+    if (result.length > 0) this.scrollToCursorPosition()
     return result
   }
 


### PR DESCRIPTION
This makes it easier to compare the old and new syntax highlighting.