### PR TITLE
⬆️ electron@1.7.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "1.7.11",
+  "electronVersion": "1.7.14",
   "dependencies": {
     "@atom/nsfw": "^1.0.18",
     "@atom/watcher": "1.0.3",


### PR DESCRIPTION
Upgrade from Electron 1.7.11 to 1.7.14 (i.e., the latest version in the Electron 1.7.x series).

Release notes:

- https://electronjs.org/releases#1.7.12
- https://electronjs.org/releases#1.7.13
- https://electronjs.org/releases#1.7.14