### PR TITLE
Create file recovery directory if it doesn't already exist

### DIFF
--- a/src/main-process/file-recovery-service.js
+++ b/src/main-process/file-recovery-service.js
@@ -147,7 +147,7 @@ async function tryStatFile (path) {
 }
 
 async function copyFile (source, destination, mode) {
-  mkdirp.sync(Path.dirname(destination))
+  await mkdirp(Path.dirname(destination))
   return new Promise((resolve, reject) => {
     const readStream = fs.createReadStream(source)
     readStream

--- a/src/main-process/file-recovery-service.js
+++ b/src/main-process/file-recovery-service.js
@@ -2,6 +2,7 @@ const {dialog} = require('electron')
 const crypto = require('crypto')
 const Path = require('path')
 const fs = require('fs-plus')
+const mkdirp = require('mkdirp')
 
 module.exports =
 class FileRecoveryService {
@@ -146,6 +147,7 @@ async function tryStatFile (path) {
 }
 
 async function copyFile (source, destination, mode) {
+  mkdirp.sync(path.dirname(destination));
   return new Promise((resolve, reject) => {
     const readStream = fs.createReadStream(source)
     readStream

--- a/src/main-process/file-recovery-service.js
+++ b/src/main-process/file-recovery-service.js
@@ -147,17 +147,19 @@ async function tryStatFile (path) {
 }
 
 async function copyFile (source, destination, mode) {
-  await mkdirp(Path.dirname(destination))
   return new Promise((resolve, reject) => {
-    const readStream = fs.createReadStream(source)
-    readStream
-      .on('error', reject)
-      .once('open', () => {
-        const writeStream = fs.createWriteStream(destination, {mode})
-        writeStream
-          .on('error', reject)
-          .on('open', () => readStream.pipe(writeStream))
-          .once('close', () => resolve())
-      })
+    mkdirp(Path.dirname(destination), (error) => {
+      if (error) return reject(error)
+      const readStream = fs.createReadStream(source)
+      readStream
+        .on('error', reject)
+        .once('open', () => {
+          const writeStream = fs.createWriteStream(destination, {mode})
+          writeStream
+            .on('error', reject)
+            .on('open', () => readStream.pipe(writeStream))
+            .once('close', () => resolve())
+        })
+    })
   })
 }

--- a/src/main-process/file-recovery-service.js
+++ b/src/main-process/file-recovery-service.js
@@ -147,7 +147,7 @@ async function tryStatFile (path) {
 }
 
 async function copyFile (source, destination, mode) {
-  mkdirp.sync(path.dirname(destination));
+  mkdirp.sync(Path.dirname(destination))
   return new Promise((resolve, reject) => {
     const readStream = fs.createReadStream(source)
     readStream


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/17013 by creating the recovery directory

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

From v1.24.0 to v1.25.0-beta0 a regression issue was created by replacing fs-plus.copyFileSync() with a local function that does a stream copy. The problem is that the new function does not create the directory first, but fs-plus.copyFileSync() did.

I've added the same mkdirp.sync() call that fs-plus uses in copyFileSync().

### Alternate Designs

It's also possible to revert to using copyFileSync() from fs-plus, but I presume the change was for a good reason.

### Why Should This Be In Core?

The FileRecoveryService is core functionality.

### Benefits

Fixes very significant problems that folks have been experiencing with git

### Possible Drawbacks

None that I can see.

### Verification Process

I was not able to reproduce the issue with this change in place.

### Applicable Issues

https://github.com/atom/atom/issues/17013
https://github.com/atom/github/issues/1418
https://github.com/atom/atom/issues/17223
https://github.com/atom/atom/issues/17235
https://github.com/atom/github/issues/1283
https://github.com/atom/github/issues/1375
https://github.com/atom/atom/issues/11384
https://github.com/atom/atom/issues/16420
https://github.com/atom/atom/issues/17179
https://github.com/atom/atom/issues/17187
