### PR TITLE
Fix out of date doc block method name

### DIFF
--- a/src/decoration.js
+++ b/src/decoration.js
@@ -157,7 +157,7 @@ class Decoration {
   // ## Examples
   //
   // ```coffee
-  // decoration.update({type: 'line-number', class: 'my-new-class'})
+  // decoration.setProperties({type: 'line-number', class: 'my-new-class'})
   // ```
   //
   // * `newProperties` {Object} eg. `{type: 'line-number', class: 'my-new-class'}`

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -139,7 +139,7 @@ class AtomApplication extends EventEmitter {
   // for testing purposes without booting up the world. As you add tests, feel free to move instantiation
   // of these various sub-objects into the constructor, but you'll need to remove the side-effects they
   // perform during their construction, adding an initialize method that you call here.
-  initialize (options) {
+  async initialize (options) {
     global.atomApplication = this
 
     // DEPRECATED: This can be removed at some point (added in 1.13)
@@ -155,7 +155,9 @@ class AtomApplication extends EventEmitter {
     this.listenForArgumentsFromNewProcess()
     this.setupDockMenu()
 
-    return this.launch(options)
+    const result = await this.launch(options)
+    this.autoUpdateManager.initialize()
+    return result;
   }
 
   async destroy () {
@@ -171,7 +173,6 @@ class AtomApplication extends EventEmitter {
     if (!this.configFilePromise) {
       this.configFilePromise = this.configFile.watch()
       this.disposable.add(await this.configFilePromise)
-      this.autoUpdateManager.initialize()
       this.config.onDidChange('core.titleBar', this.promptForRestart.bind(this))
     }
 


### PR DESCRIPTION
Looks like this method name changed in https://github.com/atom/atom/pull/3456/files#diff-88c69a7ba7e0c0d0090f4501ca44472c but the comment did not get updated.