### PR TITLE
Fix out of date doc block method name

### DIFF
--- a/src/decoration.js
+++ b/src/decoration.js
@@ -157,7 +157,7 @@ class Decoration {
   // ## Examples
   //
   // ```coffee
-  // decoration.update({type: 'line-number', class: 'my-new-class'})
+  // decoration.setProperties({type: 'line-number', class: 'my-new-class'})
   // ```
   //
   // * `newProperties` {Object} eg. `{type: 'line-number', class: 'my-new-class'}`


### PR DESCRIPTION
Looks like this method name changed in https://github.com/atom/atom/pull/3456/files#diff-88c69a7ba7e0c0d0090f4501ca44472c but the comment did not get updated.

Replaces #17256