### PR TITLE
Use the configuration from AtomApplication in the main process

### DIFF
--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -544,10 +544,26 @@ class PathWatcherManager {
   // Private: Access the currently active manager instance, creating one if necessary.
   static active () {
     if (!this.activeManager) {
-      this.activeManager = new PathWatcherManager(atom.config.get('core.fileSystemWatcher'))
-      this.sub = atom.config.onDidChange('core.fileSystemWatcher', ({newValue}) => { this.transitionTo(newValue) })
+      const config = this.findConfig()
+
+      this.activeManager = new PathWatcherManager(config.get('core.fileSystemWatcher'))
+      this.sub = config.onDidChange('core.fileSystemWatcher', ({newValue}) => {
+        this.transitionTo(newValue)
+      })
     }
     return this.activeManager
+  }
+
+  static findConfig() {
+    if (global.atomApplication) {
+      return global.atomApplication.config
+    }
+
+    if (global.atom) {
+      return global.atom.config
+    }
+
+    throw new Error('Unable to find Atom configuration')
   }
 
   // Private: Replace the active {PathWatcherManager} with a new one that creates [NativeWatchers]{NativeWatcher}


### PR DESCRIPTION
When initializing a PathWatcher to watch for config file changes in the main process, read the config from `AtomApplication` instead of `AtomEnvironment`.

Something small that I noticed trying to track down a root cause for https://github.com/atom/watcher/issues/124.