### PR TITLE
Fire grammar activation hooks after emitting new editors

### DIFF
--- a/src/workspace.js
+++ b/src/workspace.js
@@ -497,14 +497,19 @@ module.exports = class Workspace extends Model {
       if (item instanceof TextEditor) {
         const subscriptions = new CompositeDisposable(
           this.textEditorRegistry.add(item),
-          this.textEditorRegistry.maintainConfig(item),
-          item.observeGrammar(this.handleGrammarUsed.bind(this))
+          this.textEditorRegistry.maintainConfig(item)
         )
         if (!this.project.findBufferForId(item.buffer.id)) {
           this.project.addBuffer(item.buffer)
         }
         item.onDidDestroy(() => { subscriptions.dispose() })
         this.emitter.emit('did-add-text-editor', {textEditor: item, pane, index})
+        // It's important to call handleGrammarUsed after emitting the did-add event:
+        // if we activate a package between adding the editor to the registry and emitting
+        // the package may receive the editor twice from `observeTextEditors`.
+        subscriptions.add(
+          item.observeGrammar(this.handleGrammarUsed.bind(this))
+        )
       }
     })
   }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -507,9 +507,12 @@ module.exports = class Workspace extends Model {
         // It's important to call handleGrammarUsed after emitting the did-add event:
         // if we activate a package between adding the editor to the registry and emitting
         // the package may receive the editor twice from `observeTextEditors`.
-        subscriptions.add(
-          item.observeGrammar(this.handleGrammarUsed.bind(this))
-        )
+        // (Note that the item can be destroyed by an `observeTextEditors` handler.)
+        if (!item.isDestroyed()) {
+          subscriptions.add(
+            item.observeGrammar(this.handleGrammarUsed.bind(this))
+          )
+        }
       }
     })
   }


### PR DESCRIPTION
This fixes a bug where packages with grammar activation hooks may receive duplicate editors from the `atom.workspace.observeTextEditors` API.

To see why this happens, we can see that in `atom.workspace.subscribeToAddedItems` a new editor `E` will be processed with the following sequence of events:

1) `E` is added to the `TextEditorRegistry`.
2) Activation hooks are fired for the editor's grammar (potentially activating a package, "A")
3) A "did-add-text-editor" event for `E` is fired (triggering `atom.workspace.observeTextEditors` callbacks).

However, this sequence can lead to text editors being received multiple times from a package A's perspective - if package A activates and immediately starts listening to `atom.workspace.observeTextEditors` in step 2 then it sees editor `E` twice - once in the initial list of editors and once again when the `did-add-text-editor` event fires.

As long as we invert steps 2) and 3) above everything should be OK (I think). I modified the `grammar-used` spec to check for this - hopefully that makes things clear if the description above didn't make sense.