### PR TITLE
Update to require libgtk-3-0

### DIFF
--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libcap2, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1
+Depends: git, gconf2, gconf-service, libgtk-3-0 (>= 3.9.10), libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libcap2, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1
 Recommends: lsb-release
 Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
 Section: devel


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The new version of Chromium included with Electron 2.0 requires a newer version of `libgtk` to be installed on the system to run. This updates the version to match the one pulled from Chrome 64.0.3282.167-1, listed [here](https://github.com/atom/atom/pull/16812#issuecomment-367502699).

### Alternate Designs

None.

### Why Should This Be In Core?

It fixes an issue with the current list of dependencies.

### Benefits

Minimal installations of Debian based Linux will have a better list of dependencies.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

I verified that before installing `libgtk-3-0` on a minimal installation running `atom-beta --version` exits with code `127`. After removing `libgtk2.0` with `sudo apt remove libgtk2.0 --assume-yes` and installing `libgtk-3-0` with `sudo apt install --assume-yes --quiet --no-install-suggests --no-install-recommends libgtk-3-0` the [tar release](https://github.com/atom/atom/releases/download/v1.28.0-beta0/atom-amd64.tar.gz) of Atom v1.28.0-beta0 is able to run `atom --version`.

### Applicable Issues

None.
