### PR TITLE
Provide more context when test fails due to timeout in `waitsFor`

### DIFF
--- a/vendor/jasmine.js
+++ b/vendor/jasmine.js
@@ -2317,6 +2317,14 @@ jasmine.Spec.prototype.waitsFor = function(latchFunction, optional_timeoutMessag
     }
   }
 
+  if (optional_timeoutMessage_ == null) {
+    const objectToCaptureStack = {}
+    Error.captureStackTrace(objectToCaptureStack, waitsFor)
+    const stack = objectToCaptureStack.stack
+    const line = stack.split('\n')[1]
+    optional_timeoutMessage_ = `condition ${line}`
+  }
+
   var waitsForFunc = new jasmine.WaitsForBlock(this.env, optional_timeout_, latchFunction_, optional_timeoutMessage_, this);
   this.addToQueue(waitsForFunc);
   return this;


### PR DESCRIPTION
Prior to this change, if a test timed out using `waitsFor`, you ended up with a fairly vague error message:

> timeout: timed out after 5000 msec waiting for something to happen

If a test has multiple `waitsFor` calls, that error message leaves you wondering which one failed. :sob:

We ran into this problem when investigating #17325, in which the failing test included multiple places where the timeout could have occurred:

```js
beforeEach(() => {
  socketServer = net.createServer(() => {})
  socketPath = path.join(rootDir1, 'some.sock')
  waitsFor(done => socketServer.listen(socketPath, done))   // DID IT TIME OUT HERE?
})

afterEach(() => waitsFor(done => socketServer.close(done))) // OR HERE?  🤷🤷🤷🤷🤷
```

One option is to pass a custom error message to each `waitsFor` call. While that's still possible, we'd like the default error message to give you a better chance of diagnosing the problem. With the changes in this pull request, if you don't pass a custom error message, `waitsFor` will show you the filename and line number where the timeout occurred.

### Example

#### Before

> socket files on #darwin or #linux
> it ignores them
> **timeout: timed out after 5000 msec waiting for something to happen**

#### After

> socket files on #darwin or #linux
> it ignores them
> **timeout: timed out after 5000 msec waiting for condition at afterEach (~/github/fuzzy-finder/spec/fuzzy-finder-spec.js:263:27)**

