### PR TITLE
Upgrade to Electron 1.7.15 in Atom 1.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "1.7.11",
+  "electronVersion": "1.7.15",
   "dependencies": {
     "@atom/nsfw": "^1.0.18",
     "@atom/watcher": "1.0.3",


### PR DESCRIPTION
Relevant release notes:

- https://electronjs.org/releases#1.7.12
- https://electronjs.org/releases#1.7.13
- https://electronjs.org/releases#1.7.14
- https://electronjs.org/releases#1.7.15