### PR TITLE
Update first-mate to 7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "etch": "^0.12.6",
     "event-kit": "^2.5.0",
     "find-parent-dir": "^0.3.0",
-    "first-mate": "7.1.0",
+    "first-mate": "7.1.1",
     "focus-trap": "^2.3.0",
     "fs-admin": "^0.1.6",
     "fs-plus": "^3.0.1",


### PR DESCRIPTION
Fixes a bug where injections would not be updated when a grammar the injections depend on was.  For example:

* `language-a` has injections that depend on `language-b`.
* `language-a` is loaded before `language-b`.
* Before: `language-a`'s injections don't use `language-b`'s patterns, even after `language-b` is loaded.
* After: `language-a`'s injections pick up on `language-b`'s patterns after it is loaded.

Necessary for atom/language-php#330