### PR TITLE
Fix deprecated hidden-inset title bar style

### DIFF
--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -51,7 +51,7 @@ class AtomWindow extends EventEmitter {
     // taskbar's icon. See https://github.com/atom/atom/issues/4811 for more.
     if (process.platform === 'linux') options.icon = ICON_PATH
     if (this.shouldAddCustomTitleBar()) options.titleBarStyle = 'hidden'
-    if (this.shouldAddCustomInsetTitleBar()) options.titleBarStyle = 'hidden-inset'
+    if (this.shouldAddCustomInsetTitleBar()) options.titleBarStyle = 'hiddenInset'
     if (this.shouldHideTitleBar()) options.frame = false
     this.browserWindow = new BrowserWindow(options)
 


### PR DESCRIPTION
As of https://github.com/electron/electron/pull/11975 the hidden-inset
titleBarStyle has been removed so the custom-inset title bar option
renders a normal title bar which is not desired.