### PR TITLE
Add feature request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,41 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+<!--
+
+Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/atom/blob/master/CODE_OF_CONDUCT.md
+
+Do you want to ask a question? Are you looking for support? The Atom message board is the best place for getting support: https://discuss.atom.io
+
+---
+
+Keep in mind that Atom is highly customizable in a number of ways and we strongly prefer that you consider these options before filing this issue:
+
+* https://flight-manual.atom.io/using-atom/sections/basic-customization/: tweak Atom's configuration, styles, and keybindings.
+* https://flight-manual.atom.io/using-atom/sections/atom-packages/: install a community package.
+* https://flight-manual.atom.io/hacking-atom/: use the Atom API in your init script, to create a package, or to enhance an existing package.
+
+If you're convinced that none of these options are appropriate for the feature you want, please explain why that's the case by completely filling out the issue template below.
+
+Also note that the Atom team has finite resources so it's unlikely that we'll work on feature requests. If we're interested in a particular feature however, we'll follow up and ask you to submit an RFC to talk about it in more detail.
+
+-->
+
+## Summary
+
+One paragraph explanation of the feature.
+
+## Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+## Describe alternatives you've considered
+
+A clear and concise description of the alternative solutions you've considered. Be sure to explain why Atom's existing customizability isn't suitable for this feature.
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+<!--
+
+Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/atom/blob/master/CODE_OF_CONDUCT.md
+
+Do you want to ask a question? Are you looking for support? The Atom message board is the best place for getting support: https://discuss.atom.io
+
+-->
+
+### Prerequisites
+
+* [ ] Put an X between the brackets on this line if you have done all of the following:
+    * Reproduced the problem in Safe Mode: https://flight-manual.atom.io/hacking-atom/sections/debugging/#using-safe-mode
+    * Followed all applicable steps in the debugging guide: https://flight-manual.atom.io/hacking-atom/sections/debugging/
+    * Checked the FAQs on the message board for common solutions: https://discuss.atom.io/c/faq
+    * Checked that your issue isn't already filed: https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Aatom
+    * Checked that there is not already an Atom package that provides the described functionality: https://atom.io/packages
+
+### Description
+
+[Description of the issue]
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expect to happen]
+
+**Actual behavior:** [What actually happens]
+
+**Reproduces how often:** [What percentage of the time does it reproduce?]
+
+### Versions
+
+You can get this information from copy and pasting the output of `atom --version` and `apm --version` from the command line. Also, please include the OS and what version of the OS you're running.
+
+### Additional Information
+
+Any additional information, configuration or data that might be necessary to reproduce the issue.


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Adds a new feature request issue template and uses the current issue template as the bug report issue template to take advantage of the new issue template chooser:

https://blog.github.com/2018-05-02-issue-template-improvements/

### Alternate Designs

Could leave things as is but we did find the current issue template is more bug report focused which caused some folks to delete it and leave a 1 or 2 sentence feature request.  Also, a separate feature request specific template should hopefully encourage more detailed feature requests.

### Why Should This Be In Core?

Needs to be so it shows up in the issue template chooser.

### Benefits

As mentioned above, a more feature request focused issue template will hopefully encourage people to describe why they want something in addition to encouraging them to look at Atom's customizability in case the feature can be satisfied without changes to Atom.

### Possible Drawbacks

It's possible that the extra friction for feature requests might discourage someone from making a feature request, but it's helpful for us to have more information about the what/why/alternatives considered.

### Verification Process

After merging:

1. [Create a new issue](https://github.com/atom/atom/issues/new) and make sure the template chooser shows.  
2. Check that the bug report issue template is the current default issue template.
3. Check that the feature request issue template is the one being added here.

### Applicable Issues

n/a