### PR TITLE
Change atom.sh not to spawn a sleep process every second on --wait

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -149,6 +149,7 @@ trap 'on_die' SIGQUIT SIGTERM
 # If the wait flag is set, don't exit this process until Atom tells it to.
 if [ $WAIT ]; then
   while true; do
+    read
     sleep 1
   done
 fi

--- a/atom.sh
+++ b/atom.sh
@@ -148,8 +148,16 @@ trap 'on_die' SIGQUIT SIGTERM
 
 # If the wait flag is set, don't exit this process until Atom tells it to.
 if [ $WAIT ]; then
+  WAIT_FIFO="$ATOM_HOME/.wait_fifo"
   while true; do
-    read
+    [ -f "$WAIT_FIFO" ] && rm "$WAIT_FIFO"
+    [ ! -p "$WAIT_FIFO" ] && mkfifo "$WAIT_FIFO"
+    read < "$WAIT_FIFO" || break
+    sleep 1 # prevent a tight loop
+  done
+  
+  # fall back to sleep
+  while true; do
     sleep 1
   done
 fi


### PR DESCRIPTION
### Description of the Change
As sleep(1) is not a bash builtin, every second a new process is spawed.
To  prevent this, the POSIX read can be used instead.
Since it is (required to be) a bash builtin, it is immediately killed along with bash unlike a longer running sleep would be.
In case stdin is e.g. /dev/null for whatever reason (this would break `EDITOR=nano`), sleep is still kept to prevent a tight loop.

### Alternate Designs
* a longer sleep interval: this would require job management as sleep would keep running even if bash is killed and thus cause huge delays

### Why Should This Be In Core?
not possible otherwise

### Benefits
Those sleep processes can be annoying in e.g. `execsnoop` or even `htop`

### Possible Drawbacks
e: does consume stdin, though I don't see how that is a problem

### Verification Process
* edited my distributions `/usr/bin/atom` accordingly (Archlinux, Atom 1.27) (this file hasn't changed since)
* opened a file using `/usr/bin/atom --wait file` and verified that it exited upon closing the tab

### Applicable Issues