### PR TITLE
Extend the color profile PR (#17380)

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -174,6 +174,7 @@ class AtomApplication extends EventEmitter {
       this.configFilePromise = this.configFile.watch()
       this.disposable.add(await this.configFilePromise)
       this.config.onDidChange('core.titleBar', this.promptForRestart.bind(this))
+      this.config.onDidChange('core.colorProfile', this.promptForRestart.bind(this))
     }
 
     const optionsForWindowsToOpen = []

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -173,8 +173,8 @@ class AtomApplication extends EventEmitter {
     if (!this.configFilePromise) {
       this.configFilePromise = this.configFile.watch()
       this.disposable.add(await this.configFilePromise)
-      this.config.onDidChange('core.titleBar', this.promptForRestart.bind(this))
-      this.config.onDidChange('core.colorProfile', this.promptForRestart.bind(this))
+      this.config.onDidChange('core.titleBar', () => this.promptForRestart())
+      this.config.onDidChange('core.colorProfile', () => this.promptForRestart())
     }
 
     const optionsForWindowsToOpen = []


### PR DESCRIPTION
### Description of the Change

Extends #17380 by wiring up the dialog prompt for restarting Atom whenever the `core.colorProfile` setting is changed. Since this removes the need for the explicit description remark about restarting Atom, that sentence is also removed.

The third (and optional) change alters the bound functions used when wiring up the change event listeners to arrow functions. We can drop that commit if it's deemed risky, not necessary, or some such.

### Alternate Designs

A more elaborate opt-in mechanism for "prompt for relaunch" was considered, but rejected after taking into consideration the concept of [YAGNI™](https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it).

### Why Should This Be In Core?

For obvious reasons.

### Benefits

Users do not have to manually restart Atom. Some users will likely not read the description and realize they need to manually restart Atom, which would most likely lead to issues being submitted, etc.

### Possible Drawbacks

More code, and complexity?

### Verification Process

Manually tested on Ubuntu 16.04. Works as expected.
