### PR TITLE
Make Tree-sitter grammars' contentRegExp work as intended

### DIFF
--- a/spec/package-manager-spec.js
+++ b/spec/package-manager-spec.js
@@ -1032,6 +1032,7 @@ describe('PackageManager', () => {
       })
 
       it('loads any tree-sitter grammars defined in the package', async () => {
+        atom.config.set('core.useTreeSitterParsers', true)
         await atom.packages.activatePackage('package-with-tree-sitter-grammar')
         const grammar = atom.grammars.selectGrammar('test.somelang')
         expect(grammar.name).toBe('Some Language')


### PR DESCRIPTION
Previously, when the `Use Tree Sitter Parsers` setting was enabled, CoffeeScript files were accidentally highlighted as C++ because of [the C++ grammar's `contentRegExp`](https://github.com/atom/language-c/blob/master/grammars/tree-sitter-cpp.cson#L27).

In this PR, I have made the following adjustments to the way Tree-sitter grammar selection works:

1. Tree-sitter grammars are never used unless the Tree-sitter setting is enabled.
1. A grammar that matches more path components is always preferred over a grammar that matches fewer path components (or no path components). This way, `.coffee` files will always use CoffeeScript rather than C++.
1. If two grammars have comparable score otherwise, `contentRegExp` comes into play. If a grammar's `contentRegExp` does match, the grammar is preferred, and if it does *not* match, the grammar is *dispreferred*. This way, `.h` files that do *not* contain 'class', 'namespace', etc, then the `C` grammar is explicitly preferred over the `C++` grammar.
1. Finally, if two grammars are *still* tied (and the Tree-sitter setting is enabled), then Tree-sitter grammars are preferred.

/cc @thomasjo 