### PR TITLE
Atom.sh - identify and create atom home dir regardless of platform

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -59,6 +59,9 @@ if [ $REDIRECT_STDERR ]; then
   exec 2> /dev/null
 fi
 
+ATOM_HOME="${ATOM_HOME:-$HOME/.atom}"
+mkdir -p "$ATOM_HOME"
+
 if [ $OS == 'Mac' ]; then
   if [ -L "$0" ]; then
     SCRIPT="$(readlink "$0")"
@@ -119,9 +122,6 @@ elif [ $OS == 'Linux' ]; then
       ;;
   esac
 
-  ATOM_HOME="${ATOM_HOME:-$HOME/.atom}"
-  mkdir -p "$ATOM_HOME"
-
   : ${TMPDIR:=/tmp}
 
   [ -x "$ATOM_PATH" ] || ATOM_PATH="$TMPDIR/atom-build/Atom/atom"
@@ -155,7 +155,7 @@ if [ $WAIT ]; then
     read < "$WAIT_FIFO" || break
     sleep 1 # prevent a tight loop
   done
-  
+
   # fall back to sleep
   while true; do
     sleep 1


### PR DESCRIPTION
This fixes a bug introduced in #17403. We use the `ATOM_HOME` variable in the definition of `WAIT_FIFO`, but that variable was only defined when running on Linux, not on macOS. I've updated the script to define (and ensure the existence of) `ATOM_HOME` on both platforms, not just Linux.

/cc @lllusion3469