### PR TITLE
Don't allow vertical scrollbar to affect soft wrap column

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -26,6 +26,7 @@ document.registerElement('text-editor-component-test-element', {
 })
 
 const editors = []
+let verticalScrollbarWidth, horizontalScrollbarHeight
 
 describe('TextEditorComponent', () => {
   beforeEach(() => {
@@ -33,8 +34,15 @@ describe('TextEditorComponent', () => {
 
     // Force scrollbars to be visible regardless of local system configuration
     const scrollbarStyle = document.createElement('style')
-    scrollbarStyle.textContent = '::-webkit-scrollbar { -webkit-appearance: none }'
+    scrollbarStyle.textContent = 'atom-text-editor ::-webkit-scrollbar { -webkit-appearance: none }'
     jasmine.attachToDOM(scrollbarStyle)
+
+    if (verticalScrollbarWidth == null) {
+      const {component, element} = buildComponent({text: 'abcdefgh\n'.repeat(10), width: 30, height: 30})
+      verticalScrollbarWidth = getVerticalScrollbarWidth(component)
+      horizontalScrollbarHeight = getHorizontalScrollbarHeight(component)
+      element.remove()
+    }
   })
 
   afterEach(() => {
@@ -184,8 +192,8 @@ describe('TextEditorComponent', () => {
     })
 
     it('makes the content at least as tall as the scroll container client height', async () => {
-      const {component, element, editor} = buildComponent({text: 'a', height: 100})
-      expect(component.refs.content.offsetHeight).toBe(100)
+      const {component, element, editor} = buildComponent({text: 'a'.repeat(100), width: 50, height: 100})
+      expect(component.refs.content.offsetHeight).toBe(100 - getHorizontalScrollbarHeight(component))
 
       editor.setText('a\n'.repeat(30))
       await component.getNextUpdatePromise()
@@ -201,7 +209,7 @@ describe('TextEditorComponent', () => {
       await setEditorHeightInLines(component, 6)
 
       // scroll to end
-      await setScrollTop(component, scrollContainer.scrollHeight - scrollContainer.clientHeight)
+      await setScrollTop(component, Infinity)
       expect(component.getFirstVisibleRow()).toBe(editor.getScreenLineCount() - 3)
 
       editor.update({scrollPastEnd: false})
@@ -211,7 +219,7 @@ describe('TextEditorComponent', () => {
       // Always allows at least 3 lines worth of overscroll if the editor is short
       await setEditorHeightInLines(component, 2)
       await editor.update({scrollPastEnd: true})
-      await setScrollTop(component, scrollContainer.scrollHeight - scrollContainer.clientHeight)
+      await setScrollTop(component, Infinity)
       expect(component.getFirstVisibleRow()).toBe(editor.getScreenLineCount() + 1)
     })
 
@@ -296,31 +304,6 @@ describe('TextEditorComponent', () => {
       expect(lineNumberNodeForScreenRow(component, 0).querySelector('.foldable')).toBeNull()
     })
 
-    it('gracefully handles folds that change the soft-wrap boundary by causing the vertical scrollbar to disappear (regression)', async () => {
-      const text =  ('x'.repeat(100) + '\n') + 'y\n'.repeat(28) + '  z\n'.repeat(50)
-      const {component, element, editor} = buildComponent({text, height: 1000, width: 500})
-
-      element.addEventListener('scroll', (event) => {
-        event.stopPropagation()
-      }, true)
-
-      editor.setSoftWrapped(true)
-      jasmine.attachToDOM(element)
-      await component.getNextUpdatePromise()
-
-      const firstScreenLineLengthWithVerticalScrollbar = element.querySelector('.line').textContent.length
-
-      setScrollTop(component, 620)
-      await component.getNextUpdatePromise()
-
-      editor.foldBufferRow(28)
-      await component.getNextUpdatePromise()
-
-      const firstLineElement = element.querySelector('.line')
-      expect(firstLineElement.dataset.screenRow).toBe('0')
-      expect(firstLineElement.textContent.length).toBeGreaterThan(firstScreenLineLengthWithVerticalScrollbar)
-    })
-
     it('shows the foldable icon on the last screen row of a buffer row that can be folded', async () => {
       const {component, element, editor} = buildComponent({text: 'abc\n  de\nfghijklm\n  no', softWrapped: true})
       await setEditorWidthInCharacters(component, 5)
@@ -361,18 +344,14 @@ describe('TextEditorComponent', () => {
       expect(getVerticalScrollbarWidth(component)).toBeGreaterThan(0)
       expect(getHorizontalScrollbarHeight(component)).toBe(0)
       expect(verticalScrollbar.style.visibility).toBe('')
-      expect(verticalScrollbar.style.bottom).toBe('0px')
       expect(horizontalScrollbar.style.visibility).toBe('hidden')
-      expect(component.refs.scrollbarCorner).toBeUndefined()
 
       editor.setText('a'.repeat(100))
       await component.getNextUpdatePromise()
       expect(getVerticalScrollbarWidth(component)).toBe(0)
       expect(getHorizontalScrollbarHeight(component)).toBeGreaterThan(0)
       expect(verticalScrollbar.style.visibility).toBe('hidden')
-      expect(horizontalScrollbar.style.right).toBe('0px')
       expect(horizontalScrollbar.style.visibility).toBe('')
-      expect(component.refs.scrollbarCorner).toBeUndefined()
 
       editor.setText('')
       await component.getNextUpdatePromise()
@@ -380,37 +359,6 @@ describe('TextEditorComponent', () => {
       expect(getHorizontalScrollbarHeight(component)).toBe(0)
       expect(verticalScrollbar.style.visibility).toBe('hidden')
       expect(horizontalScrollbar.style.visibility).toBe('hidden')
-      expect(component.refs.scrollbarCorner).toBeUndefined()
-
-      editor.setText(SAMPLE_TEXT)
-      await component.getNextUpdatePromise()
-
-      // Does not show scrollbars if the content perfectly fits
-      element.style.width = component.getGutterContainerWidth() + component.getContentWidth() + 'px'
-      element.style.height = component.getContentHeight() + 'px'
-      await component.getNextUpdatePromise()
-      expect(getVerticalScrollbarWidth(component)).toBe(0)
-      expect(getHorizontalScrollbarHeight(component)).toBe(0)
-      expect(verticalScrollbar.style.visibility).toBe('hidden')
-      expect(horizontalScrollbar.style.visibility).toBe('hidden')
-
-      // Shows scrollbars if the only reason we overflow is the presence of the
-      // scrollbar for the opposite axis.
-      element.style.width = component.getGutterContainerWidth() + component.getContentWidth() - 1 + 'px'
-      element.style.height = component.getContentHeight() + component.getHorizontalScrollbarHeight() - 1 + 'px'
-      await component.getNextUpdatePromise()
-      expect(getVerticalScrollbarWidth(component)).toBeGreaterThan(0)
-      expect(getHorizontalScrollbarHeight(component)).toBeGreaterThan(0)
-      expect(verticalScrollbar.style.visibility).toBe('')
-      expect(horizontalScrollbar.style.visibility).toBe('')
-
-      element.style.width = component.getGutterContainerWidth() + component.getContentWidth() + component.getVerticalScrollbarWidth() - 1 + 'px'
-      element.style.height = component.getContentHeight() - 1 + 'px'
-      await component.getNextUpdatePromise()
-      expect(getVerticalScrollbarWidth(component)).toBeGreaterThan(0)
-      expect(getHorizontalScrollbarHeight(component)).toBeGreaterThan(0)
-      expect(verticalScrollbar.style.visibility).toBe('')
-      expect(horizontalScrollbar.style.visibility).toBe('')
     })
 
     describe('when scrollbar styles change or the editor element is detached and then reattached', () => {
@@ -683,17 +631,6 @@ describe('TextEditorComponent', () => {
       expect(scrollContainer.clientWidth).toBe(scrollContainer.scrollWidth)
     })
 
-    it('accounts for the width of the vertical scrollbar when soft-wrapping lines', async () => {
-      const {component, element, editor} = buildComponent({
-        height: 200,
-        text: 'a'.repeat(300),
-        softWrapped: true
-      })
-      await setEditorWidthInCharacters(component, 23)
-      expect(Math.floor(component.getScrollContainerClientWidth() / component.getBaseCharacterWidth())).toBe(20)
-      expect(editor.lineLengthForScreenRow(0)).toBe(20)
-    })
-
     it('correctly forces the display layer to index visible rows when resizing (regression)', async () => {
       const text = 'a'.repeat(30) + '\n' + 'b'.repeat(1000)
       const {component, element, editor} = buildComponent({height: 300, width: 800, attach: false, text})
@@ -718,7 +655,7 @@ describe('TextEditorComponent', () => {
       editor.setText('a')
       await component.getNextUpdatePromise()
 
-      expect(element.querySelector('.line').offsetWidth).toBe(scrollContainer.offsetWidth)
+      expect(element.querySelector('.line').offsetWidth).toBe(scrollContainer.offsetWidth - verticalScrollbarWidth)
     })
 
     it('resizes based on the content when the autoHeight and/or autoWidth options are true', async () => {
@@ -728,44 +665,39 @@ describe('TextEditorComponent', () => {
       const {gutterContainer, scrollContainer} = component.refs
       const initialWidth = element.offsetWidth
       const initialHeight = element.offsetHeight
-      expect(initialWidth).toBe(component.getGutterContainerWidth() + component.getContentWidth() + 2 * editorPadding)
-      expect(initialHeight).toBe(component.getContentHeight() + 2 * editorPadding)
+      expect(initialWidth).toBe(
+        component.getGutterContainerWidth() +
+        component.getContentWidth() +
+        verticalScrollbarWidth +
+        2 * editorPadding
+      )
+      expect(initialHeight).toBe(
+        component.getContentHeight() +
+        horizontalScrollbarHeight +
+        2 * editorPadding
+      )
 
       // When autoWidth is enabled, width adjusts to content
       editor.setCursorScreenPosition([6, Infinity])
       editor.insertText('x'.repeat(50))
       await component.getNextUpdatePromise()
-      expect(element.offsetWidth).toBe(component.getGutterContainerWidth() + component.getContentWidth() + 2 * editorPadding)
+      expect(element.offsetWidth).toBe(
+        component.getGutterContainerWidth() +
+        component.getContentWidth() +
+        verticalScrollbarWidth +
+        2 * editorPadding
+      )
       expect(element.offsetWidth).toBeGreaterThan(initialWidth)
 
       // When autoHeight is enabled, height adjusts to content
       editor.insertText('\n'.repeat(5))
       await component.getNextUpdatePromise()
-      expect(element.offsetHeight).toBe(component.getContentHeight() + 2 * editorPadding)
-      expect(element.offsetHeight).toBeGreaterThan(initialHeight)
-
-      // When a horizontal scrollbar is visible, autoHeight accounts for it
-      editor.update({autoWidth: false})
-      await component.getNextUpdatePromise()
-      element.style.width = component.getGutterContainerWidth() + component.getContentHeight() - 20 + 'px'
-      await component.getNextUpdatePromise()
-      expect(component.canScrollHorizontally()).toBe(true)
-      expect(component.canScrollVertically()).toBe(false)
-      expect(element.offsetHeight).toBe(component.getContentHeight() + component.getHorizontalScrollbarHeight() + 2 * editorPadding)
-
-      // When a vertical scrollbar is visible, autoWidth accounts for it
-      editor.update({autoWidth: true, autoHeight: false})
-      await component.getNextUpdatePromise()
-      element.style.height = component.getContentHeight() - 20
-      await component.getNextUpdatePromise()
-      expect(component.canScrollHorizontally()).toBe(false)
-      expect(component.canScrollVertically()).toBe(true)
-      expect(element.offsetWidth).toBe(
-        component.getGutterContainerWidth() +
-        component.getContentWidth() +
-        component.getVerticalScrollbarWidth() +
+      expect(element.offsetHeight).toBe(
+        component.getContentHeight() +
+        horizontalScrollbarHeight +
         2 * editorPadding
       )
+      expect(element.offsetHeight).toBeGreaterThan(initialHeight)
     })
 
     it('does not render the line number gutter at all if the isLineNumberGutterVisible parameter is false', () => {
@@ -1051,7 +983,6 @@ describe('TextEditorComponent', () => {
     it('does not render scrollbars', async () => {
       const {component, element, editor} = buildComponent({mini: true, autoHeight: false})
       await setEditorWidthInCharacters(component, 10)
-      await setEditorHeightInLines(component, 1)
 
       editor.setText('x'.repeat(20) + 'y'.repeat(20))
       await component.getNextUpdatePromise()
@@ -1136,7 +1067,7 @@ describe('TextEditorComponent', () => {
 
   describe('autoscroll', () => {
     it('automatically scrolls vertically when the requested range is within the vertical scroll margin of the top or bottom', async () => {
-      const {component, editor} = buildComponent({height: 120})
+      const {component, editor} = buildComponent({height: 120 + horizontalScrollbarHeight})
       expect(component.getLastVisibleRow()).toBe(7)
 
       editor.scrollToScreenRange([[4, 0], [6, 0]])
@@ -1158,7 +1089,7 @@ describe('TextEditorComponent', () => {
 
     it('does not vertically autoscroll by more than half of the visible lines if the editor is shorter than twice the scroll margin', async () => {
       const {component, element, editor} = buildComponent({autoHeight: false})
-      element.style.height = 5.5 * component.measurements.lineHeight + 'px'
+      element.style.height = 5.5 * component.measurements.lineHeight + horizontalScrollbarHeight + 'px'
       await component.getNextUpdatePromise()
       expect(component.getLastVisibleRow()).toBe(5)
       const scrollMarginInLines = 2
@@ -1222,7 +1153,7 @@ describe('TextEditorComponent', () => {
     it('does not horizontally autoscroll by more than half of the visible "base-width" characters if the editor is narrower than twice the scroll margin', async () => {
       const {component, editor} = buildComponent({autoHeight: false})
       await setEditorWidthInCharacters(component, 1.5 * editor.horizontalScrollMargin)
-      const editorWidthInChars = component.getScrollContainerWidth() / component.getBaseCharacterWidth()
+      const editorWidthInChars = component.getScrollContainerClientWidth() / component.getBaseCharacterWidth()
       expect(Math.round(editorWidthInChars)).toBe(9)
 
       editor.scrollToScreenRange([[6, 10], [6, 15]])
@@ -2121,7 +2052,8 @@ describe('TextEditorComponent', () => {
 
       // render an editor that already contains some block decorations
       const {component, element} = buildComponent({editor, rowsPerTile: 3})
-      await setEditorHeightInLines(component, 4)
+      element.style.height = 4 * component.getLineHeight() + horizontalScrollbarHeight + 'px'
+      await component.getNextUpdatePromise()
       expect(component.getRenderedStartRow()).toBe(0)
       expect(component.getRenderedEndRow()).toBe(9)
       expect(component.getScrollHeight()).toBe(
@@ -2336,7 +2268,7 @@ describe('TextEditorComponent', () => {
       component.element.style.width = (
         component.getGutterContainerWidth() +
         component.getScrollContainerClientWidth() * 2 +
-        component.getVerticalScrollbarWidth()
+        verticalScrollbarWidth
       ) + 'px'
       await component.getNextUpdatePromise()
       expect(component.getRenderedStartRow()).toBe(0)
@@ -3566,12 +3498,12 @@ describe('TextEditorComponent', () => {
     describe('on the scrollbars', () => {
       it('delegates the mousedown events to the parent component unless the mousedown was on the actual scrollbar', async () => {
         const {component, element, editor} = buildComponent({height: 100})
-        await setEditorWidthInCharacters(component, 8.5)
+        await setEditorWidthInCharacters(component, 6)
 
         const verticalScrollbar = component.refs.verticalScrollbar
         const horizontalScrollbar = component.refs.horizontalScrollbar
-        const leftEdgeOfVerticalScrollbar = verticalScrollbar.element.getBoundingClientRect().right - getVerticalScrollbarWidth(component)
-        const topEdgeOfHorizontalScrollbar = horizontalScrollbar.element.getBoundingClientRect().bottom - getHorizontalScrollbarHeight(component)
+        const leftEdgeOfVerticalScrollbar = verticalScrollbar.element.getBoundingClientRect().right - verticalScrollbarWidth
+        const topEdgeOfHorizontalScrollbar = horizontalScrollbar.element.getBoundingClientRect().bottom - horizontalScrollbarHeight
 
         verticalScrollbar.didMouseDown({
           button: 0,
@@ -4133,7 +4065,7 @@ describe('TextEditorComponent', () => {
 
     it('assigns scrollTop on the component when calling setFirstVisibleScreenRow', async () => {
       const {component, element, editor} = buildComponent({rowsPerTile: 3, autoHeight: false})
-      element.style.height = 4 * component.measurements.lineHeight + 'px'
+      element.style.height = 4 * component.measurements.lineHeight + horizontalScrollbarHeight + 'px'
       await component.getNextUpdatePromise()
 
       expect(component.getMaxScrollTop() / component.getLineHeight()).toBe(9)
@@ -4317,6 +4249,7 @@ async function setEditorWidthInCharacters (component, widthInCharacters) {
   component.element.style.width =
     component.getGutterContainerWidth() +
     widthInCharacters * component.measurements.baseCharacterWidth +
+    verticalScrollbarWidth +
     'px'
   await component.getNextUpdatePromise()
 }

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1188,8 +1188,8 @@ describe('TextEditorComponent', () => {
       await component.getNextUpdatePromise()
 
       const actualScrollCenter = (component.getScrollTop() + component.getScrollBottom()) / 2
-      const expectedScrollCenter = Math.round((4 + 7) / 2 * component.getLineHeight())
-      expect(actualScrollCenter).toBe(expectedScrollCenter)
+      const expectedScrollCenter = (4 + 7) / 2 * component.getLineHeight()
+      expect(actualScrollCenter).toBeCloseTo(expectedScrollCenter, 0)
     })
 
     it('automatically scrolls horizontally when the requested range is within the horizontal scroll margin of the right edge of the gutter or right edge of the scroll container', async () => {
@@ -1202,23 +1202,21 @@ describe('TextEditorComponent', () => {
 
       editor.scrollToScreenRange([[1, 12], [2, 28]])
       await component.getNextUpdatePromise()
-      let expectedScrollLeft = Math.round(
+      let expectedScrollLeft =
         clientLeftForCharacter(component, 1, 12) -
         lineNodeForScreenRow(component, 1).getBoundingClientRect().left -
         (editor.horizontalScrollMargin * component.measurements.baseCharacterWidth)
-      )
-      expect(component.getScrollLeft()).toBe(expectedScrollLeft)
+      expect(component.getScrollLeft()).toBeCloseTo(expectedScrollLeft, 0)
 
       editor.scrollToScreenRange([[1, 12], [2, 28]], {reversed: false})
       await component.getNextUpdatePromise()
-      expectedScrollLeft = Math.round(
+      expectedScrollLeft =
         component.getGutterContainerWidth() +
         clientLeftForCharacter(component, 2, 28) -
         lineNodeForScreenRow(component, 2).getBoundingClientRect().left +
         (editor.horizontalScrollMargin * component.measurements.baseCharacterWidth) -
         component.getScrollContainerClientWidth()
-      )
-      expect(component.getScrollLeft()).toBe(expectedScrollLeft)
+      expect(component.getScrollLeft()).toBeCloseTo(expectedScrollLeft, 0)
     })
 
     it('does not horizontally autoscroll by more than half of the visible "base-width" characters if the editor is narrower than twice the scroll margin', async () => {
@@ -1324,22 +1322,22 @@ describe('TextEditorComponent', () => {
 
       // Assigns the scrollTop based on the logical position when attached
       jasmine.attachToDOM(element)
-      expect(component.getScrollLeft()).toBe(Math.round(2 * component.getBaseCharacterWidth()))
+      expect(component.getScrollLeft()).toBeCloseTo(2 * component.getBaseCharacterWidth(), 0)
 
       // Allows the scrollTopRow to be updated while attached
       component.setScrollLeftColumn(4)
-      expect(component.getScrollLeft()).toBe(Math.round(4 * component.getBaseCharacterWidth()))
+      expect(component.getScrollLeft()).toBeCloseTo(4 * component.getBaseCharacterWidth(), 0)
 
       // Preserves the scrollTopRow when detached
       element.remove()
-      expect(component.getScrollLeft()).toBe(Math.round(4 * component.getBaseCharacterWidth()))
+      expect(component.getScrollLeft()).toBeCloseTo(4 * component.getBaseCharacterWidth(), 0)
 
       component.setScrollLeftColumn(6)
-      expect(component.getScrollLeft()).toBe(Math.round(6 * component.getBaseCharacterWidth()))
+      expect(component.getScrollLeft()).toBeCloseTo(6 * component.getBaseCharacterWidth(), 0)
 
       jasmine.attachToDOM(element)
       element.style.width = '60px'
-      expect(component.getScrollLeft()).toBe(Math.round(6 * component.getBaseCharacterWidth()))
+      expect(component.getScrollLeft()).toBeCloseTo(6 * component.getBaseCharacterWidth(), 0)
     })
   })
 
@@ -4162,17 +4160,17 @@ describe('TextEditorComponent', () => {
       element.style.width = 30 * component.getBaseCharacterWidth() + 'px'
       await component.getNextUpdatePromise()
       expect(editor.getFirstVisibleScreenColumn()).toBe(0)
-      expect(component.refs.horizontalScrollbar.element.scrollLeft).toBe(0 * component.getBaseCharacterWidth())
+      expect(component.refs.horizontalScrollbar.element.scrollLeft).toBe(0)
 
       setScrollLeft(component, 5.5 * component.getBaseCharacterWidth())
       expect(editor.getFirstVisibleScreenColumn()).toBe(5)
       await component.getNextUpdatePromise()
-      expect(component.refs.horizontalScrollbar.element.scrollLeft).toBe(Math.round(5.5 * component.getBaseCharacterWidth()))
+      expect(component.refs.horizontalScrollbar.element.scrollLeft).toBeCloseTo(5.5 * component.getBaseCharacterWidth(), -1)
 
       editor.setFirstVisibleScreenColumn(12)
-      expect(component.getScrollLeft()).toBe(Math.round(12 * component.getBaseCharacterWidth()))
+      expect(component.getScrollLeft()).toBeCloseTo(12 * component.getBaseCharacterWidth(), -1)
       await component.getNextUpdatePromise()
-      expect(component.refs.horizontalScrollbar.element.scrollLeft).toBe(Math.round(12 * component.getBaseCharacterWidth()))
+      expect(component.refs.horizontalScrollbar.element.scrollLeft).toBeCloseTo(12 * component.getBaseCharacterWidth(), -1)
     })
   })
 

--- a/spec/text-editor-element-spec.js
+++ b/spec/text-editor-element-spec.js
@@ -9,7 +9,7 @@ describe('TextEditorElement', () => {
     jasmineContent = document.body.querySelector('#jasmine-content')
     // Force scrollbars to be visible regardless of local system configuration
     const scrollbarStyle = document.createElement('style')
-    scrollbarStyle.textContent = '::-webkit-scrollbar { -webkit-appearance: none }'
+    scrollbarStyle.textContent = 'atom-text-editor ::-webkit-scrollbar { -webkit-appearance: none }'
     jasmine.attachToDOM(scrollbarStyle)
   })
 
@@ -338,18 +338,20 @@ describe('TextEditorElement', () => {
       element.style.width = '200px'
       jasmine.attachToDOM(element)
 
+      const horizontalScrollbarHeight = element.component.getHorizontalScrollbarHeight()
+
       expect(element.getMaxScrollTop()).toBe(0)
       await editor.update({autoHeight: false})
 
-      element.style.height = '100px'
+      element.style.height = 100 + horizontalScrollbarHeight + 'px'
       await element.getNextUpdatePromise()
       expect(element.getMaxScrollTop()).toBe(60)
 
-      element.style.height = '120px'
+      element.style.height = 120 + horizontalScrollbarHeight + 'px'
       await element.getNextUpdatePromise()
       expect(element.getMaxScrollTop()).toBe(40)
 
-      element.style.height = '200px'
+      element.style.height = 200 + horizontalScrollbarHeight + 'px'
       await element.getNextUpdatePromise()
       expect(element.getMaxScrollTop()).toBe(0)
     })
@@ -392,10 +394,13 @@ describe('TextEditorElement', () => {
     it('returns true if the given row range intersects the visible row range', async () => {
       const element = buildTextEditorElement()
       const editor = element.getModel()
+      const horizontalScrollbarHeight = element.component.getHorizontalScrollbarHeight()
+
       editor.update({autoHeight: false})
       element.getModel().setText('x\n'.repeat(20))
-      element.style.height = '120px'
+      element.style.height = 120 + horizontalScrollbarHeight + 'px'
       await element.getNextUpdatePromise()
+
       element.setScrollTop(80)
       await element.getNextUpdatePromise()
       expect(element.getVisibleRowRange()).toEqual([4, 11])
@@ -412,9 +417,11 @@ describe('TextEditorElement', () => {
     it('returns a {top/left/width/height} object describing the rectangle between two screen positions, even if they are not on screen', async () => {
       const element = buildTextEditorElement()
       const editor = element.getModel()
+      const horizontalScrollbarHeight = element.component.getHorizontalScrollbarHeight()
+
       editor.update({autoHeight: false})
       element.getModel().setText('xxxxxxxxxxxxxxxxxxxxxx\n'.repeat(20))
-      element.style.height = '120px'
+      element.style.height = 120 + horizontalScrollbarHeight + 'px'
       await element.getNextUpdatePromise()
       element.setScrollTop(80)
       await element.getNextUpdatePromise()

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -458,15 +458,18 @@ class TextEditorComponent {
     let clientContainerWidth = '100%'
     if (this.hasInitialMeasurements) {
       if (model.getAutoHeight()) {
-        clientContainerHeight = this.getContentHeight()
-        if (this.canScrollHorizontally()) clientContainerHeight += this.getHorizontalScrollbarHeight()
-        clientContainerHeight += 'px'
+        clientContainerHeight =
+          this.getContentHeight() +
+          this.getHorizontalScrollbarHeight() +
+          'px'
       }
       if (model.getAutoWidth()) {
         style.width = 'min-content'
-        clientContainerWidth = this.getGutterContainerWidth() + this.getContentWidth()
-        if (this.canScrollVertically()) clientContainerWidth += this.getVerticalScrollbarWidth()
-        clientContainerWidth += 'px'
+        clientContainerWidth =
+          this.getGutterContainerWidth() +
+          this.getContentWidth() +
+          this.getVerticalScrollbarWidth() +
+          'px'
       } else {
         style.width = this.element.style.width
       }
@@ -751,20 +754,14 @@ class TextEditorComponent {
         scrollLeft = this.getScrollLeft()
         canScrollHorizontally = this.canScrollHorizontally()
         canScrollVertically = this.canScrollVertically()
-        horizontalScrollbarHeight =
-          canScrollHorizontally
-          ? this.getHorizontalScrollbarHeight()
-          : 0
-        verticalScrollbarWidth =
-          canScrollVertically
-          ? this.getVerticalScrollbarWidth()
-          : 0
+        horizontalScrollbarHeight = this.getHorizontalScrollbarHeight()
+        verticalScrollbarWidth = this.getVerticalScrollbarWidth()
         forceScrollbarVisible = this.remeasureScrollbars
       } else {
         forceScrollbarVisible = true
       }
 
-      const dummyScrollbarVnodes = [
+      return [
         $(DummyScrollbarComponent, {
           ref: 'verticalScrollbar',
           orientation: 'vertical',
@@ -786,13 +783,10 @@ class TextEditorComponent {
           scrollLeft,
           verticalScrollbarWidth,
           forceScrollbarVisible
-        })
-      ]
+        }),
 
-      // If both scrollbars are visible, push a dummy element to force a "corner"
-      // to render where the two scrollbars meet at the lower right
-      if (verticalScrollbarWidth > 0 && horizontalScrollbarHeight > 0) {
-        dummyScrollbarVnodes.push($.div(
+        // Force a "corner" to render where the two scrollbars meet at the lower right
+        $.div(
           {
             ref: 'scrollbarCorner',
             className: 'scrollbar-corner',
@@ -805,10 +799,8 @@ class TextEditorComponent {
               overflow: 'scroll'
             }
           }
-        ))
-      }
-
-      return dummyScrollbarVnodes
+        )
+      ]
     } else {
       return null
     }
@@ -2626,37 +2618,25 @@ class TextEditorComponent {
 
   getScrollContainerHeight () {
     if (this.props.model.getAutoHeight()) {
-      return this.getScrollHeight()
+      return this.getScrollHeight() + this.getHorizontalScrollbarHeight()
     } else {
       return this.getClientContainerHeight()
     }
   }
 
   getScrollContainerClientWidth () {
-    if (this.canScrollVertically()) {
-      return this.getScrollContainerWidth() - this.getVerticalScrollbarWidth()
-    } else {
-      return this.getScrollContainerWidth()
-    }
+    return this.getScrollContainerWidth() - this.getVerticalScrollbarWidth()
   }
 
   getScrollContainerClientHeight () {
-    if (this.canScrollHorizontally()) {
-      return this.getScrollContainerHeight() - this.getHorizontalScrollbarHeight()
-    } else {
-      return this.getScrollContainerHeight()
-    }
+    return this.getScrollContainerHeight() - this.getHorizontalScrollbarHeight()
   }
 
   canScrollVertically () {
     const {model} = this.props
     if (model.isMini()) return false
     if (model.getAutoHeight()) return false
-    if (this.getContentHeight() > this.getScrollContainerHeight()) return true
-    return (
-      this.getContentWidth() > this.getScrollContainerWidth() &&
-      this.getContentHeight() > (this.getScrollContainerHeight() - this.getHorizontalScrollbarHeight())
-    )
+    return this.getContentHeight() > this.getScrollContainerClientHeight()
   }
 
   canScrollHorizontally () {
@@ -2664,11 +2644,7 @@ class TextEditorComponent {
     if (model.isMini()) return false
     if (model.getAutoWidth()) return false
     if (model.isSoftWrapped()) return false
-    if (this.getContentWidth() > this.getScrollContainerWidth()) return true
-    return (
-      this.getContentHeight() > this.getScrollContainerHeight() &&
-      this.getContentWidth() > (this.getScrollContainerWidth() - this.getVerticalScrollbarWidth())
-    )
+    return this.getContentWidth() > this.getScrollContainerClientWidth()
   }
 
   getScrollHeight () {


### PR DESCRIPTION
### Background

Previously, the decision of whether to show or hide scrollbars in a text editor was made by estimating whether or not a scrollbar was *needed* based on the editor's content. It involved a circular data flow:

```
vertical scrollbar visibility
      ↓
editor width
      ↓
horizontal scrollbar visibility
      ↓
editor height
      ↓
vertical scrollbar visibility
```

From what I can tell, there are some subtle issues with the timing of our measurements that currently cause this calculation to produce unstable results, resulting in the issues linked below.

Aside from these rendering bugs, this overall approach for showing and hiding scrollbars seems different from other applications that I'm familiar with. In other applications, there does not seem to be this circular feedback loop.

For example, in `TextEdit.app`, note how the soft wrap behavior is never affected by the vertical scrollbar. Rather, the scrollbars' visibility is controlled by the macOS `Show Scrollbars` setting. They behave as follows:

* When `Show Scrollbars > When Scrolling` (aka 'overlay' mode) is selected, the scrollbars appear and disappear based on the editor's content, but they do not affect the editor's soft wrapping.
* When `Show Scrollbars > Always` (aka 'legacy' mode) is selected, the scrollbars are always visible, so again the editor's soft wrapping does not change based on the height of its content.

![text-edit-scrollbar-2](https://user-images.githubusercontent.com/326587/41000967-850ba2ec-68c4-11e8-9e47-13cc4335b2ed.gif)

I did a similar test with Sublime Text 3, and I observed a similar behavior. I think that these apps' behavior seems simpler than Atom's from an implementation perspective, and probably better from a UX perspective as well. 

### Description of the Change

In this PR, I've changed Atom's logic for showing and hiding scrollbars in two ways:

1. The editor's soft wrap column always leaves room for the vertical scrollbar, even if it is hidden.
2. In auto-size mode, the editor always grows large enough to account for both scrollbars, even if they are hidden.

### Alternate Designs

We could also fix the bugs referenced below within the current paradigm. @Ben3eeE had [one idea](https://github.com/atom/atom/issues/17268#issuecomment-386596339) for fixing this bug at the cost of performing extra DOM measurements. From my testing, this fix does indeed work.

### Benefits

The reasons that I'm proposing this solution instead is:
1. From what I can tell, it makes the `TextEditor` behave more like other native widgets.
2. It does not require any extra DOM measurements; in fact it results in us doing less work overall in `TextEditorComponent`.

### Possible Drawbacks

This is a bigger change, and it definitely requires careful testing on all three platforms.

### Verification Process

On all three platforms (and with all possible scrollbar settings on mac):

1. Open a file with soft wrapping (e.g. a markdown or text file).
2. Add and remove content at the end of the file so that the vertical scrollbar enables and disables.
3. Check that the soft wrapping does not change.
4. Check that the scrollbars look and behave correctly overall.

Also,

1. Open a file with no soft wrapping and some long lines.
2. Check that the scrollbars look and behave correctly overall.

### Applicable Issues

Fixes #13769
Fixes #17268