### PR TITLE
Don't boost tree-sitter grammars' score unless they match in some way

### DIFF
--- a/spec/grammar-registry-spec.js
+++ b/spec/grammar-registry-spec.js
@@ -415,6 +415,14 @@ describe('GrammarRegistry', () => {
         expect(grammar.id).toBe('javascript')
         expect(grammar instanceof TreeSitterGrammar).toBe(true)
       })
+
+      it('only favors a tree-sitter grammar if it actually matches in some way (regression)', () => {
+        atom.config.set('core.useTreeSitterParsers', true)
+        grammarRegistry.loadGrammarSync(require.resolve('language-javascript/grammars/tree-sitter-javascript.cson'))
+
+        const grammar = grammarRegistry.selectGrammar('test', '')
+        expect(grammar.name).toBe('Null Grammar')
+      })
     })
 
     describe('tree-sitter grammars with content regexes', () => {

--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -214,11 +214,7 @@ class GrammarRegistry {
     }
 
     if (grammar instanceof TreeSitterGrammar) {
-      if (this.config.get('core.useTreeSitterParsers')) {
-        score += 0.05
-      } else {
-        score = -Infinity
-      }
+      if (!this.config.get('core.useTreeSitterParsers')) return -Infinity
 
       if (grammar.contentRegExp) {
         if (grammar.contentRegExp.test(contents)) {
@@ -227,6 +223,8 @@ class GrammarRegistry {
           score -= 0.25
         }
       }
+
+      if (score > 0) score += 0.05
     } else if (this.grammarMatchesPrefix(grammar, contents)) {
       score += 0.25
     }


### PR DESCRIPTION
This fixes a regression I just introduced in #17468