### PR TITLE
:arrow_up: electron-link

### DIFF
--- a/script/package.json
+++ b/script/package.json
@@ -8,7 +8,7 @@
     "colors": "1.1.2",
     "donna": "1.0.16",
     "electron-chromedriver": "~2.0",
-    "electron-link": "0.2.0",
+    "electron-link": "0.2.2",
     "electron-mksnapshot": "~2.0",
     "electron-packager": "7.3.0",
     "electron-winstaller": "2.6.4",


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This change bumps electron-link to v0.2.2, enabling Atom builds on Node.js 10.  See this issue for more details: https://github.com/atom/electron-link/issues/11

### Alternate Designs

No alternative designs needed.

### Why Should This Be In Core?

This is part of Atom's build script.

### Benefits

Users can now build Atom using Node.js 10.

### Possible Drawbacks

Newer version of leveldown in electron-link could cause issues, but it's a necessary change.

### Verification Process

Clean CI on electron-link, also checking for clean CI on Atom.

### Applicable Issues

https://github.com/atom/electron-link/issues/11