### PR TITLE
Blacklist `yauzl` from snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "solarized-dark-syntax": "1.1.5",
     "solarized-light-syntax": "1.1.5",
     "about": "1.9.1",
-    "archive-view": "0.64.6",
+    "archive-view": "0.65.0",
     "autocomplete-atom-api": "0.10.7",
     "autocomplete-css": "0.17.5",
     "autocomplete-html": "0.8.4",

--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -42,7 +42,6 @@ module.exports = function (packagedAppPath) {
         requiredModuleRelativePath === path.join('..', 'node_modules', 'atom-keymap', 'lib', 'command-event.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'babel-core', 'index.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'cached-run-in-this-context', 'lib', 'main.js') ||
-        requiredModuleRelativePath === path.join('..', 'node_modules', 'decompress-zip', 'lib', 'decompress-zip.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'debug', 'node.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'git-utils', 'src', 'git.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'glob', 'glob.js') ||

--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -63,6 +63,7 @@ module.exports = function (packagedAppPath) {
         requiredModuleRelativePath === path.join('..', 'node_modules', 'temp', 'lib', 'temp.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'tmp', 'lib', 'tmp.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'tree-sitter', 'index.js') ||
+        requiredModuleRelativePath === path.join('..', 'node_modules', 'yauzl', 'index.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'winreg', 'lib', 'registry.js')
       )
     }


### PR DESCRIPTION
### Description of the Change
This PR adds `yauzl` to the snapshot blacklist in order to leverage recent changes to `ls-archive` in which we switched from a dependency on `decompress-zip` to `yauzl`.

### Why Should This Be In Core?

Because snapshotting happens in core, and we bundle the `archive-view` package that pulls in the problematic `yauzl` npm package.

### Benefits

Allows us to keep modernizing `archive-view`, and also resolves the intermittent problem with the outdated `string_decoder` package used by `decompress-zip`'s dependency chain.

### Possible Drawbacks

None?

### Verification Process

Tested locally (on macOS 10.13.5) by running `script/build --install`.

### Applicable Issues

Fixes #17125 (for real this time).