### PR TITLE
⬆️ metrics@1.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "line-ending-selector": "0.7.7",
     "link": "0.31.4",
     "markdown-preview": "0.159.20",
-    "metrics": "1.2.6",
+    "metrics": "1.2.8",
     "notifications": "0.70.5",
     "open-on-github": "1.3.1",
     "package-generator": "1.3.0",


### PR DESCRIPTION
Incorporates the changes from https://github.com/atom/metrics/pull/88 and https://github.com/atom/metrics/pull/89. 

https://github.com/atom/metrics/pull/89 resolves the CI failures described in https://github.com/atom/atom/commit/e352b2f1077a4c9af21f4a812cbca136960e83bc.

/fyi @annthurium 