### PR TITLE
Toggle comment cursor placement

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -770,7 +770,10 @@ class Selection {
   //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify text within a read-only editor. (default: false)
   toggleLineComments (options = {}) {
     if (!this.ensureWritable('toggleLineComments', options)) return
-    this.editor.toggleLineCommentsForBufferRows(...(this.getBufferRowRange() || []))
+    let bufferRowRange = this.getBufferRowRange() || []
+    let cursor = this.cursor
+    let setCursor = this.isEmpty() && this.cursor.isAtEndOfLine()
+    this.editor.toggleLineCommentsForBufferRows(...bufferRowRange, { setCursor, cursor })
   }
 
   // Public: Cuts the selection until the end of the screen line.

--- a/src/selection.js
+++ b/src/selection.js
@@ -771,9 +771,7 @@ class Selection {
   toggleLineComments (options = {}) {
     if (!this.ensureWritable('toggleLineComments', options)) return
     let bufferRowRange = this.getBufferRowRange() || [null, null]
-    let cursor = this.cursor
-    let setCursor = this.isEmpty() && this.cursor.isAtEndOfLine()
-    this.editor.toggleLineCommentsForBufferRows(...bufferRowRange, { setCursor, cursor })
+    this.editor.toggleLineCommentsForBufferRows(...bufferRowRange, {correctSelection: true, selection: this})
   }
 
   // Public: Cuts the selection until the end of the screen line.

--- a/src/selection.js
+++ b/src/selection.js
@@ -770,7 +770,7 @@ class Selection {
   //   * `bypassReadOnly` (optional) {Boolean} Must be `true` to modify text within a read-only editor. (default: false)
   toggleLineComments (options = {}) {
     if (!this.ensureWritable('toggleLineComments', options)) return
-    let bufferRowRange = this.getBufferRowRange() || []
+    let bufferRowRange = this.getBufferRowRange() || [null, null]
     let cursor = this.cursor
     let setCursor = this.isEmpty() && this.cursor.isAtEndOfLine()
     this.editor.toggleLineCommentsForBufferRows(...bufferRowRange, { setCursor, cursor })

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -4739,11 +4739,23 @@ class TextEditor {
           this.buffer.insert([start, indentLength], commentStartString + ' ')
           this.buffer.insert([end, this.buffer.lineLengthForRow(end)], ' ' + commentEndString)
           if (options.correctSelection && options.selection) {
-            let oldRange = options.selection.getBufferRange()
             let endLineLength = this.buffer.lineLengthForRow(end)
-            let startDelta = oldRange.start.column === 0 ? [0, commentStartString.length + 1] : [0, 0]
-            let endDelta = oldRange.end.column === endLineLength ? [0, - commentEndString.length - 1] : [0, 0]
-            options.selection.setBufferRange(oldRange.translate(startDelta, endDelta), { autoscroll: false })
+            let startDelta, endDelta
+            let oldRange = options.selection.getBufferRange()
+            if (oldRange.isEmpty()) {
+              if (oldRange.start.column === 0) {
+                startDelta = [0, commentStartString.length + 1]
+              } else if (oldRange.start.column === endLineLength) {
+                startDelta = [0, -commentEndString.length - 1]
+              } else {
+                startDelta = [0, 0]
+              }
+              options.selection.setBufferRange(oldRange.translate(startDelta), { autoscroll: false })
+            } else {
+              startDelta = oldRange.start.column === 0 ? [0, commentStartString.length + 1] : [0, 0]
+              endDelta = oldRange.end.column === endLineLength ? [0, -commentEndString.length - 1] : [0, 0]
+              options.selection.setBufferRange(oldRange.translate(startDelta, endDelta), { autoscroll: false })
+            }
           }
         })
       }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -4709,7 +4709,7 @@ class TextEditor {
 
   toggleLineCommentForBufferRow (row) { this.toggleLineCommentsForBufferRows(row, row) }
 
-  toggleLineCommentsForBufferRows (start, end, { setCursor=false, cursor }) {
+  toggleLineCommentsForBufferRows (start, end, options = {}) {
     const languageMode = this.buffer.getLanguageMode()
     let {commentStartString, commentEndString} =
       languageMode.commentStringsForPosition &&
@@ -4738,9 +4738,12 @@ class TextEditor {
           const indentLength = this.buffer.lineForRow(start).match(/^\s*/)[0].length
           this.buffer.insert([start, indentLength], commentStartString + ' ')
           this.buffer.insert([end, this.buffer.lineLengthForRow(end)], ' ' + commentEndString)
-          if (setCursor) {
-            let newPosition = [cursor.getBufferRow(), cursor.getBufferColumn() - commentEndString.length - 1]
-            cursor.setBufferPosition(newPosition, { autoscroll: false })
+          if (options.correctSelection && options.selection) {
+            let oldRange = options.selection.getBufferRange()
+            let endLineLength = this.buffer.lineLengthForRow(end)
+            let startDelta = oldRange.start.column === 0 ? [0, commentStartString.length + 1] : [0, 0]
+            let endDelta = oldRange.end.column === endLineLength ? [0, - commentEndString.length - 1] : [0, 0]
+            options.selection.setBufferRange(oldRange.translate(startDelta, endDelta), { autoscroll: false })
           }
         })
       }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -4709,14 +4709,13 @@ class TextEditor {
 
   toggleLineCommentForBufferRow (row) { this.toggleLineCommentsForBufferRows(row, row) }
 
-  toggleLineCommentsForBufferRows (start, end) {
+  toggleLineCommentsForBufferRows (start, end, { setCursor=false, cursor }) {
     const languageMode = this.buffer.getLanguageMode()
     let {commentStartString, commentEndString} =
       languageMode.commentStringsForPosition &&
       languageMode.commentStringsForPosition(Point(start, 0)) || {}
     if (!commentStartString) return
     commentStartString = commentStartString.trim()
-
     if (commentEndString) {
       commentEndString = commentEndString.trim()
       const startDelimiterColumnRange = columnRangeForStartDelimiter(
@@ -4739,6 +4738,10 @@ class TextEditor {
           const indentLength = this.buffer.lineForRow(start).match(/^\s*/)[0].length
           this.buffer.insert([start, indentLength], commentStartString + ' ')
           this.buffer.insert([end, this.buffer.lineLengthForRow(end)], ' ' + commentEndString)
+          if (setCursor) {
+            let newPosition = [cursor.getBufferRow(), cursor.getBufferColumn() - commentEndString.length - 1]
+            cursor.setBufferPosition(newPosition, { autoscroll: false })
+          }
         })
       }
     } else {


### PR DESCRIPTION
### Description of the Change

When `toggleLineComments` is triggered, it will now correct the selection range to be within the comment delimiters.

It will activate when 
  - `correctSelection` is true (it is hardcoded `true` right now when toggling comments), 
  - The end comment delim is truthy,
  - The line is being commented

If these conditions pass, it will then get the selection range and see if the head or tail needs to be moved. The range is adjusted, with `autoscroll` disabled to be consistent with exisiting behaviour (and it would be _really_ annoying otherwise).

  - Note: because the delim is added by modifying the entire line, there is no need to move the cursor if it is not at an end. The bug only happens because the cursor being at an end counts as outside the modification range, and so is pushed along when the change is applied.


### Alternate Designs

I originally had it only work for empty selections, but decided this way is better.

It does seem quite long compared to what it's supposed to do though. I don't know how much of a problem that is.

This is applied to every selection in the editor when line comments are toggled. It's possible people only want it when there is just one selection / cursor. An interesting bug(?) is that when there's an even number of cursors on a line, it gets toggled twice, resulting in no change (this bug isn't related to this PR though).

### Why Should This Be In Core?

It's a core mechanic

### Benefits

Consistent with other text editors, and makes sense.

### Possible Drawbacks

There's an interesting `...(this.getBufferRowRange() || [])` statement in the original version. I'm not sure when `getBufferRowRange` will return a falsey value, but that would shift the arguments of the function, moving the `options` parameter to `start`. 

Originally, if it does evaluate to `[]`, no error is thrown but the top line would be comment toggled. That seems like a bug, but isn't related to this PR. I've changed the empty array to `[null, null]` though, to ensure the argument positions are not changed.

### Verification Process

I tested manually, with the CSS grammar. I'll try to write proper tests after some feedback for changes, etc.

For now, this is what I'm expecting (where `|` is selection head/tail)

```
## Single cursor in line
ab|c
->
/* ab|c */

## Selection in line
a|b|c
->
/* a|b|c */

## Single cursor at end
abc|
->
/* abc| */

## Single cursor at beginning
|abc
->
/* |abc */

## Selection on whole line
|abc|
->
/* |abc| */

## Multi-whole line selection
|a
b|
 ->
/* |a
b| */

## Multi-partial line selection
a|bc
abc
abc|
->
/* a|bc
abc
abc| */

a|bc
abc
ab|c
->
/* a|bc
abc
ab|c */
```

### Applicable Issues

Fix #4784