### PR TITLE
Support activation hooks by grammar scope

### DIFF
--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1268,6 +1268,7 @@ module.exports = class Workspace extends Model {
 
   handleGrammarUsed (grammar) {
     if (grammar == null) { return }
+    this.packageManager.triggerActivationHook(`${grammar.scopeName}:root-scope-used`)
     return this.packageManager.triggerActivationHook(`${grammar.packageName}:grammar-used`)
   }
 

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1269,7 +1269,7 @@ module.exports = class Workspace extends Model {
   handleGrammarUsed (grammar) {
     if (grammar == null) { return }
     this.packageManager.triggerActivationHook(`${grammar.scopeName}:root-scope-used`)
-    return this.packageManager.triggerActivationHook(`${grammar.packageName}:grammar-used`)
+    this.packageManager.triggerActivationHook(`${grammar.packageName}:grammar-used`)
   }
 
   // Public: Returns a {Boolean} that is `true` if `object` is a `TextEditor`.


### PR DESCRIPTION
### Description of the Change

Adds activation hook for grammar scope name.

### Alternate Designs

None

### Why Should This Be In Core?

Is core mechanic

### Benefits

Makes activation package agnostic, much like the services API.

### Possible Drawbacks

None

### Verification Process

Tested manually. ~Will add tests.~

Test added.

### Applicable Issues

Fixes #14148 