### PR TITLE
Enable "File -> Open" to work on macOS when no windows are open

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -638,6 +638,31 @@ describe('AtomApplication', function () {
     assert(atomApplication.getAllWindows().length === 0)
   })
 
+  if (process.platform === 'darwin') {
+    it('allows opening a new folder after all windows are closed', async () => {
+      const atomApplication = buildAtomApplication()
+      sinon.stub(atomApplication, 'promptForPathToOpen')
+
+      // Open a window and then close it, leaving the app running
+      const [window] = await atomApplication.launch(parseCommandLine([]))
+      await focusWindow(window)
+      window.close()
+      await window.closedPromise
+
+      atomApplication.emit('application:open')
+      await conditionPromise(() => atomApplication.promptForPathToOpen.calledWith('all'))
+      atomApplication.promptForPathToOpen.reset()
+
+      atomApplication.emit('application:open-file')
+      await conditionPromise(() => atomApplication.promptForPathToOpen.calledWith('file'))
+      atomApplication.promptForPathToOpen.reset()
+
+      atomApplication.emit('application:open-folder')
+      await conditionPromise(() => atomApplication.promptForPathToOpen.calledWith('file'))
+      atomApplication.promptForPathToOpen.reset()
+    })
+  }
+
   function buildAtomApplication (params = {}) {
     const atomApplication = new AtomApplication(Object.assign({
       resourcePath: ATOM_RESOURCE_PATH,

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -23,6 +23,20 @@ const ConfigSchema = require('../config-schema')
 
 const LocationSuffixRegExp = /(:\d+)(:\d+)?$/
 
+const getDefaultPath = () => {
+  const editor = atom.workspace.getActiveTextEditor()
+  if (!editor) {
+    return undefined
+  }
+  if (!editor.getPath()) {
+    return undefined
+  }
+  const paths = atom.project.getPaths()
+  if (paths) {
+    return paths[0]
+  }
+}
+
 // The application's singleton class.
 //
 // It's the entry point into the Atom application and maintains the global state
@@ -371,6 +385,9 @@ class AtomApplication extends EventEmitter {
     this.on('application:new-file', () => (this.focusedWindow() || this).openPath())
     this.on('application:open-dev', () => this.promptForPathToOpen('all', {devMode: true}))
     this.on('application:open-safe', () => this.promptForPathToOpen('all', {safeMode: true}))
+    this.on('application:open', () => this.promptForPathToOpen('all', getLoadSettings(), getDefaultPath()))
+    this.on('application:open-file', () => this.promptForPathToOpen('file', getLoadSettings(), getDefaultPath()))
+    this.on('application:open-folder', () => this.promptForPathToOpen('file', getLoadSettings(), getDefaultPath()))
     this.on('application:inspect', ({x, y, atomWindow}) => {
       if (!atomWindow) atomWindow = this.focusedWindow()
       if (atomWindow) atomWindow.browserWindow.inspectElement(x, y)

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -25,11 +25,8 @@ const LocationSuffixRegExp = /(:\d+)(:\d+)?$/
 
 const getDefaultPath = () => {
   const editor = atom.workspace.getActiveTextEditor()
-  if (!editor) {
-    return undefined
-  }
-  if (!editor.getPath()) {
-    return undefined
+  if (!editor || !editor.getPath()) {
+    return
   }
   const paths = atom.project.getPaths()
   if (paths) {


### PR DESCRIPTION
Currently, Atom only sets up "File -> Open" menu handler upon window creation. That means, that when there are no windows opened on macOS - File -> Open does nothing. I've added event handlers which don't depend on window creation to make it work all the time.