### PR TITLE
Fix Tree-sitter folding bug affecting HTML

### DIFF
--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -304,6 +304,7 @@ class TreeSitterLanguageMode {
           foldEnd = new Point(foldEndNode.startPosition.row - 1, Infinity)
         } else {
           foldEnd = foldEndNode.startPosition
+          if (!pointIsGreater(foldEnd, foldStart)) continue
         }
       } else {
         const {endPosition} = node
@@ -559,6 +560,10 @@ class TreeSitterHighlightIterator {
     const scopeName = this.currentScopeName()
     if (scopeName) this.openTags.push(this.languageMode.grammar.idForScope(scopeName))
   }
+}
+
+function pointIsGreater (left, right) {
+  return left.row > right.row || left.row === right.row && left.column > right.column
 }
 
 function last (array) {


### PR DESCRIPTION
This fixes a bug where void tags (e.g. `meta`) fold weirdly when Tree-sitter is enabled.

/cc @queerviolet - this addresses that folding wonkiness where `meta` tags would disappear completely when folding them. Now those one-line void tags just won't fold.