### PR TITLE
Doc: explain how to open a file at a certain line and column

### DIFF
--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -12,12 +12,17 @@ module.exports = function parseCommandLine (processArgs) {
   options.usage(
     dedent`Atom Editor v${version}
 
-    Usage: atom [options] [path ...]
+    Usage:
+      atom [options] [path ...]
+      atom file[:line[:column]]
 
     One or more paths to files or folders may be specified. If there is an
     existing Atom window that contains all of the given folders, the paths
     will be opened in that window. Otherwise, they will be opened in a new
     window.
+
+    A file may be opened at the desired line (and optionally column) by
+    appending the numbers right after the file name, e.g. \`atom file:5:8\`.
 
     Paths that start with \`atom://\` will be interpreted as URLs.
 


### PR DESCRIPTION
This is a follow-up to the discussion in issue #17515.

The first place where I'd have expected to find this information is in the `atom --help` output, so it's where I've put it.
I can't find any other place, as Atom doesn't have a man page and The Flight Manual seems dedicated entirely to the GUI of Atom.