### PR TITLE
Clear electron-link's snapshot cache in script/clean

### DIFF
--- a/script/lib/clean-caches.js
+++ b/script/lib/clean-caches.js
@@ -14,6 +14,7 @@ module.exports = function () {
     path.join(CONFIG.atomHomeDirPath, '.apm'),
     path.join(CONFIG.atomHomeDirPath, '.npm'),
     path.join(CONFIG.atomHomeDirPath, 'compile-cache'),
+    path.join(CONFIG.atomHomeDirPath, 'snapshot-cache'),
     path.join(CONFIG.atomHomeDirPath, 'atom-shell'),
     path.join(CONFIG.atomHomeDirPath, 'electron'),
     path.join(os.tmpdir(), 'atom-build'),


### PR DESCRIPTION
### Background

When rebuilding master after https://github.com/atom/atom/commit/c57c4b96a1e98dce995ca3518f665cebb6330a00 (which removed one of several instances of `string_decoder` in our dependencies) landed, I started getting this error at runtime:

```
Uncaught (in promise) Error: Cannot find module '../node_modules/string_decoder/index.js'
    at Module._resolveFilename (module.js:543:15)
    at Module._resolveFilename (/Applications/Atom.app/Contents/Resources/electron.asar/common/reset-search-paths.js:35:12)
    at Function.get_Module._resolveFilename (/Applications/Atom.app/Contents/Resources/app/src/module-cache.js:354:58)
    at Module.require (file:///Applications/Atom.app/Contents/Resources/app.asar/static/index.js:40:43)
    at require (internal/module.js:11:18)
    at customRequire (/Applications/Atom.app/Contents/Resources/app/static/<embedded>:96:26)
    at get_Decoder (/Applications/Atom.app/Contents/Resources/app/node_modules/split/index.js:12:37)
```

The transformed source code of the `split` module was invalid, referencing a path in `node_modules` that was no longer present.

### Description of the Change

This PR adds `~/.atom/snapshot-cache` to the list of directories that should be cleared when running `script/clean`.

### Benefits

Electron link caches the result of transforming each source file with a key based on the source file's contents. But the output depends on more than just the source file's content - `require` paths are -pre-resolved based on the state of the file system. So when the content of the application's `node_modules` folder changes, previously cached transformations for *unrelated* source files can be rendered invalid.

This is a pretty rare occurrence, but when it does occur, running `script/clean` should ensure that we get a correct build again.

### Possible Drawbacks

Maybe there's a way that we could make the caching logic more bulletproof, such that it would never give back stale data. This seems complex though, and the current situation works most of the time.
