### PR TITLE
Update Jasmine stacktrace formatting

### DIFF
--- a/spec/atom-reporter.coffee
+++ b/spec/atom-reporter.coffee
@@ -33,6 +33,8 @@ formatStackTrace = (spec, message='', stackTrace) ->
       line = line.trim()
         # at jasmine.Spec.<anonymous> (path:1:2) -> at path:1:2
         .replace(/^at jasmine\.Spec\.<anonymous> \(([^)]+)\)/, 'at $1')
+        # at jasmine.Spec.it (path:1:2) -> at path:1:2
+        .replace(/^at jasmine\.Spec\.f*it \(([^)]+)\)/, 'at $1')
         # at it (path:1:2) -> at path:1:2
         .replace(/^at f*it \(([^)]+)\)/, 'at $1')
         # at spec/file-test.js -> at file-test.js


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Updating Electron to 2.x changed how stacktraces are reported, so the logic needed to be updated.

### Alternate Designs

I'm not sure if the two other ones are needed anymore.

### Why Should This Be In Core?

Stacktrace formatting is handled by core.

### Benefits

Cleaner stacktraces when using the GUI test runner.

### Possible Drawbacks

None.

### Verification Process

Ran a failing test with and without this change and noted the reported stacktrace.

### Applicable Issues

None.