### PR TITLE
:arrow_up: metrics to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "line-ending-selector": "0.7.7",
     "link": "0.31.4",
     "markdown-preview": "0.159.20",
-    "metrics": "1.3.1",
+    "metrics": "1.4.1",
     "notifications": "0.70.5",
     "open-on-github": "1.3.1",
     "package-generator": "1.3.0",


### PR DESCRIPTION
Include new `telemetry` upgrades to the metrics package in Atom core, woohoo.

Only opening a pull request on this to take advantage of running all the tests in the CI builds.