### PR TITLE
Reset goal column on all cursor changes

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -861,6 +861,15 @@ describe('TextEditor', () => {
           })
         })
       })
+
+      it("clears the goal column", () => {
+        editor.setText('first\n\nthird')
+        editor.setCursorScreenPosition([0, 3])
+        editor.moveDown()
+        editor.moveToFirstCharacterOfLine()
+        editor.moveDown()
+        expect(editor.getCursorBufferPosition()).toEqual([2, 0])
+      })
     })
 
     describe('.moveToBeginningOfWord()', () => {

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -326,7 +326,9 @@ class Cursor extends Model {
 
   // Public: Moves the cursor to the bottom of the buffer.
   moveToBottom () {
+    const column = this.goalColumn
     this.setBufferPosition(this.editor.getEofBufferPosition())
+    this.goalColumn = column
   }
 
   // Public: Moves the cursor to the beginning of the line.
@@ -711,6 +713,7 @@ class Cursor extends Model {
   changePosition (options, fn) {
     this.clearSelection({autoscroll: false})
     fn()
+    this.goalColumn = null
     const autoscroll = (options && options.autoscroll != null)
       ? options.autoscroll
       : this.isLastCursor()


### PR DESCRIPTION
Previously, pressing the home key (move-to-first-character-of-line)
while on an empty line wouldn't clear the goal column. This is because
it was only cleared on cursor *change* and that didn't result in a
change. With this commit, it's *always* cleared. Operations that want
to preserve the goal column can reset it afterwards.