### PR TITLE
Tooltip should fade on keybaord event 17431

### DIFF
--- a/spec/tooltip-manager-spec.js
+++ b/spec/tooltip-manager-spec.js
@@ -213,6 +213,18 @@ describe('TooltipManager', () => {
       })
     )
 
+    describe('when a user types', () =>
+      it('hides the tooltips', () => {
+        const disposable = manager.add(element, { title: 'Title' })
+        hover(element, function () {
+          expect(document.body.querySelector('.tooltip')).not.toBeNull()
+          window.dispatchEvent(new CustomEvent('keydown'))
+          expect(document.body.querySelector('.tooltip')).toBeNull()
+          disposable.dispose()
+        })
+      })
+    )
+
     describe('findTooltips', () => {
       it('adds and remove tooltips correctly', () => {
         expect(manager.findTooltips(element).length).toBe(0)

--- a/spec/tooltip-manager-spec.js
+++ b/spec/tooltip-manager-spec.js
@@ -212,7 +212,7 @@ describe('TooltipManager', () => {
         })
       })
     )
-
+    
     describe('when a user types', () =>
       it('hides the tooltips', () => {
         const disposable = manager.add(element, { title: 'Title' })

--- a/src/tooltip-manager.js
+++ b/src/tooltip-manager.js
@@ -153,9 +153,11 @@ class TooltipManager {
     }
 
     window.addEventListener('resize', hideTooltip)
+    window.addEventListener('keydown', hideTooltip)
 
     const disposable = new Disposable(() => {
       window.removeEventListener('resize', hideTooltip)
+      window.removeEventListener('keydown', hideTooltip)
       hideTooltip()
       tooltip.destroy()
 

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -63,7 +63,7 @@ Tooltip.prototype.init = function (element, options) {
 
   var triggers = this.options.trigger.split(' ')
 
-  this.hideOrClickOutsideOfTooltip = (event) => {
+  this.hideOnClickOrTypeOutsideOfTooltip = (event) => {
     if (trigger === 'hover' || trigger === 'click' && event != undefined) {
       const tooltipElement = this.getTooltipElement();
       if (tooltipElement === event.target) return;
@@ -219,9 +219,9 @@ Tooltip.prototype.leave = function (event) {
 
 Tooltip.prototype.show = function () {
   if (this.hasContent() && this.enabled) {
-    if (this.hideOrClickOutsideOfTooltip) {
-      window.addEventListener('click', this.hideOrClickOutsideOfTooltip, true)
-      window.addEventListener('keydown', this.hideOrClickOutsideOfTooltip, true)
+    if (this.hideOnClickOrTypeOutsideOfTooltip) {
+      window.addEventListener('click', this.hideOnClickOrTypeOutsideOfTooltip, true)
+      window.addEventListener('keydown', this.hideOnClickOrTypeOutsideOfTooltip, true)
     }
 
     var tip = this.getTooltipElement()
@@ -358,9 +358,9 @@ Tooltip.prototype.setContent = function () {
 
 Tooltip.prototype.hide = function (callback) {
   this.inState = {}
-  if (this.hideOrClickOutsideOfTooltip) {
-    window.removeEventListener('click', this.hideOrClickOutsideOfTooltip, true)
-    window.removeEventListener('keydown', this.hideOrClickOutsideOfTooltip, true)
+  if (this.hideOnClickOrTypeOutsideOfTooltip) {
+    window.removeEventListener('click', this.hideOnClickOrTypeOutsideOfTooltip, true)
+    window.removeEventListener('keydown', this.hideOnClickOrTypeOutsideOfTooltip, true)
   }
 
   this.tip && this.tip.classList.remove('in')

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -64,7 +64,7 @@ Tooltip.prototype.init = function (element, options) {
   var triggers = this.options.trigger.split(' ')
 
   this.hideOnClickOrTypeOutsideOfTooltip = (event) => {
-    if (trigger === 'hover' || trigger === 'click' && event != undefined) {
+    if (trigger === 'hover' || trigger === 'click' && event) {
       const tooltipElement = this.getTooltipElement();
       if (tooltipElement === event.target) return;
       if (tooltipElement.contains(event.target)) return;

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -65,14 +65,14 @@ Tooltip.prototype.init = function (element, options) {
 
   this.hideOnClickOrTypeOutsideOfTooltip = (event) => {
     if (trigger === 'hover' || trigger === 'click' && event) {
-      const tooltipElement = this.getTooltipElement();
-      if (tooltipElement === event.target) return;
-      if (tooltipElement.contains(event.target)) return;
-      if (this.element === event.target) return;
-      if (this.element.contains(event.target)) return;
+      const tooltipElement = this.getTooltipElement()
+      if (tooltipElement === event.target) return
+      if (tooltipElement.contains(event.target)) return
+      if (this.element === event.target) return
+      if (this.element.contains(event.target)) return
       this.hide()
     } else {
-      return;
+      return
     }
   }
   for (var i = triggers.length; i--;) {
@@ -184,7 +184,6 @@ Tooltip.prototype.enter = function (event) {
     if (this.hoverState === 'in') this.show()
   }.bind(this), this.options.delay.show)
 }
-
 
 Tooltip.prototype.isInStateTrue = function () {
   for (var key in this.inState) {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -63,19 +63,22 @@ Tooltip.prototype.init = function (element, options) {
 
   var triggers = this.options.trigger.split(' ')
 
+  this.hideOrClickOutsideOfTooltip = (event) => {
+    if (trigger === 'hover' || trigger === 'click' && event != undefined) {
+      const tooltipElement = this.getTooltipElement();
+      if (tooltipElement === event.target) return;
+      if (tooltipElement.contains(event.target)) return;
+      if (this.element === event.target) return;
+      if (this.element.contains(event.target)) return;
+      this.hide()
+    } else {
+      return;
+    }
+  }
   for (var i = triggers.length; i--;) {
     var trigger = triggers[i]
-
     if (trigger === 'click') {
       this.disposables.add(listen(this.element, 'click', this.options.selector, this.toggle.bind(this)))
-      this.hideOnClickOutsideOfTooltip = (event) => {
-        const tooltipElement = this.getTooltipElement()
-        if (tooltipElement === event.target) return
-        if (tooltipElement.contains(event.target)) return
-        if (this.element === event.target) return
-        if (this.element.contains(event.target)) return
-        this.hide()
-      }
     } else if (trigger === 'manual') {
       this.show()
     } else {
@@ -93,7 +96,6 @@ Tooltip.prototype.init = function (element, options) {
         eventIn = 'focusin'
         eventOut = 'focusout'
       }
-
       this.disposables.add(listen(this.element, eventIn, this.options.selector, this.enter.bind(this)))
       this.disposables.add(listen(this.element, eventOut, this.options.selector, this.leave.bind(this)))
     }
@@ -183,6 +185,7 @@ Tooltip.prototype.enter = function (event) {
   }.bind(this), this.options.delay.show)
 }
 
+
 Tooltip.prototype.isInStateTrue = function () {
   for (var key in this.inState) {
     if (this.inState[key]) return true
@@ -216,8 +219,9 @@ Tooltip.prototype.leave = function (event) {
 
 Tooltip.prototype.show = function () {
   if (this.hasContent() && this.enabled) {
-    if (this.hideOnClickOutsideOfTooltip) {
-      window.addEventListener('click', this.hideOnClickOutsideOfTooltip, true)
+    if (this.hideOrClickOutsideOfTooltip) {
+      window.addEventListener('click', this.hideOrClickOutsideOfTooltip, true)
+      window.addEventListener('keydown', this.hideOrClickOutsideOfTooltip, true)
     }
 
     var tip = this.getTooltipElement()
@@ -354,9 +358,9 @@ Tooltip.prototype.setContent = function () {
 
 Tooltip.prototype.hide = function (callback) {
   this.inState = {}
-
-  if (this.hideOnClickOutsideOfTooltip) {
-    window.removeEventListener('click', this.hideOnClickOutsideOfTooltip, true)
+  if (this.hideOrClickOutsideOfTooltip) {
+    window.removeEventListener('click', this.hideOrClickOutsideOfTooltip, true)
+    window.removeEventListener('keydown', this.hideOrClickOutsideOfTooltip, true)
   }
 
   this.tip && this.tip.classList.remove('in')

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -63,22 +63,19 @@ Tooltip.prototype.init = function (element, options) {
 
   var triggers = this.options.trigger.split(' ')
 
-  this.hideOnClickOrTypeOutsideOfTooltip = (event) => {
-    if (trigger === 'hover' || trigger === 'click' && event) {
-      const tooltipElement = this.getTooltipElement()
-      if (tooltipElement === event.target) return
-      if (tooltipElement.contains(event.target)) return
-      if (this.element === event.target) return
-      if (this.element.contains(event.target)) return
-      this.hide()
-    } else {
-      return
-    }
-  }
   for (var i = triggers.length; i--;) {
     var trigger = triggers[i]
+
     if (trigger === 'click') {
       this.disposables.add(listen(this.element, 'click', this.options.selector, this.toggle.bind(this)))
+      this.hideOnClickOutsideOfTooltip = (event) => {
+        const tooltipElement = this.getTooltipElement()
+        if (tooltipElement === event.target) return
+        if (tooltipElement.contains(event.target)) return
+        if (this.element === event.target) return
+        if (this.element.contains(event.target)) return
+        this.hide()
+      }
     } else if (trigger === 'manual') {
       this.show()
     } else {
@@ -96,6 +93,7 @@ Tooltip.prototype.init = function (element, options) {
         eventIn = 'focusin'
         eventOut = 'focusout'
       }
+
       this.disposables.add(listen(this.element, eventIn, this.options.selector, this.enter.bind(this)))
       this.disposables.add(listen(this.element, eventOut, this.options.selector, this.leave.bind(this)))
     }
@@ -218,9 +216,8 @@ Tooltip.prototype.leave = function (event) {
 
 Tooltip.prototype.show = function () {
   if (this.hasContent() && this.enabled) {
-    if (this.hideOnClickOrTypeOutsideOfTooltip) {
-      window.addEventListener('click', this.hideOnClickOrTypeOutsideOfTooltip, true)
-      window.addEventListener('keydown', this.hideOnClickOrTypeOutsideOfTooltip, true)
+    if (this.hideOnClickOutsideOfTooltip) {
+      window.addEventListener('click', this.hideOnClickOutsideOfTooltip, true)
     }
 
     var tip = this.getTooltipElement()
@@ -357,9 +354,9 @@ Tooltip.prototype.setContent = function () {
 
 Tooltip.prototype.hide = function (callback) {
   this.inState = {}
-  if (this.hideOnClickOrTypeOutsideOfTooltip) {
-    window.removeEventListener('click', this.hideOnClickOrTypeOutsideOfTooltip, true)
-    window.removeEventListener('keydown', this.hideOnClickOrTypeOutsideOfTooltip, true)
+
+  if (this.hideOnClickOutsideOfTooltip) {
+    window.removeEventListener('click', this.hideOnClickOutsideOfTooltip, true)
   }
 
   this.tip && this.tip.classList.remove('in')


### PR DESCRIPTION
### Description of the Change

Fix #17431 by adding an event listener that listens for keydown events and hides a tooltip when a user types.

### Alternate Designs

1. Initially I had attached the event listener in the tooltip file instead of the tooltip manager, but I placed in the latter because that's where the hiding tooltips on resized lived as well. 



### Why Should This Be In Core?

Because it fixes a problem in core and most default editors have this feature. 

### Benefits

It fixes an issue where users may want to see the workspace they're typing in, but a tooltip is hiding it. 


### Possible Drawbacks

It adds an additional event listener for each tooltip.

### Verification Process

I modified the existing tooltip-manager spec to include a new test for this feature, ran the test suite, and also manually tested it by reproducing the steps listed in #17431.

### Applicable Issues

#17431
