### PR TITLE
:arrow_up: spell-check@0.74.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "package-generator": "1.3.0",
     "settings-view": "0.255.0",
     "snippets": "1.3.3",
-    "spell-check": "0.73.5",
+    "spell-check": "0.74.0",
     "status-bar": "1.8.15",
     "styleguide": "0.49.11",
     "symbols-view": "0.118.2",


### PR DESCRIPTION
It seems that spell-check is having a problem being snapshotted on some platforms. This PR is intended to allow us to debug the builds easier.