### PR TITLE
Don't delete the package-lock.json in /script/vsts

### DIFF
--- a/script/lib/clean-package-lock.js
+++ b/script/lib/clean-package-lock.js
@@ -10,7 +10,7 @@ const path = require('path')
 
 module.exports = function () {
   console.log('Deleting problematic package-lock.json files')
-  let paths = glob.sync(path.join(CONFIG.repositoryRootPath, '**', 'package-lock.json'), {ignore: path.join('**', 'node_modules', '**')})
+  let paths = glob.sync(path.join(CONFIG.repositoryRootPath, '**', 'package-lock.json'), {ignore: [path.join('**', 'node_modules', '**'), path.join('**', 'vsts', '**')]})
 
   for (let path of paths) {
     fs.unlinkSync(path)


### PR DESCRIPTION
### Description of the Change

In https://github.com/atom/atom/pull/16493, I added a step to the build script to delete `package-lock.json` files from the tree because they were causing problems with building under certain versions of Node. I noticed that in the new [nightly releases](https://github.com/atom/atom/pull/17538) the `package-lock.json` is checked in and is apparently being used by the build. This change ignores that specific lockfile in order to keep everything tidy when building.

### Alternate Designs

Considered taking this out and dealing with having the lockfiles but I'm still not sure we're ready for that.

### Why Should This Be In Core?

This is a change to core.

### Benefits

You don't have to revert the deletion of the lockfile every time you build.

### Possible Drawbacks

🤷‍♂️

### Verification Process

Built using this change and `script/vsts/package-lock.json` was still there but the others weren't.

-----

/cc @daviwil to double-check that having `script/vsts/package-lock.json` checked in is intentional.