### PR TITLE
Use Node 8.9.3 in Atom CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      env: NODE_VERSION=6.9.4 DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1
+      env: NODE_VERSION=8.9.3 DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1
 
 sudo: required
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
   global:
     ATOM_DEV_RESOURCE_PATH: c:\projects\atom
     TEST_JUNIT_XML_ROOT: c:\projects\junit-test-results
-    NODE_VERSION: 6.9.4
+    NODE_VERSION: 8.9.3
 
   matrix:
   - TASK: test
@@ -36,7 +36,6 @@ install:
   - IF NOT EXIST %TEST_JUNIT_XML_ROOT% MKDIR %TEST_JUNIT_XML_ROOT%
   - SET PATH=C:\Program Files\Atom\resources\cli;%PATH%
   - ps: Install-Product node $env:NODE_VERSION $env:PLATFORM
-  - npm install -g npm@5.3.0
 
 build_script:
   - CD %APPVEYOR_BUILD_FOLDER%

--- a/circle.yml
+++ b/circle.yml
@@ -17,9 +17,8 @@ general:
 dependencies:
   pre:
     - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash
-    - nvm install 6.9.4
-    - nvm use 6.9.4
-    - npm install -g npm@5.3.0
+    - nvm install 8.9.3
+    - nvm use 8.9.3
 
   override:
     - script/build --code-sign --compress-artifacts


### PR DESCRIPTION
### Description of the Change

Since we're now using Electron 2.0 which uses Node 8.9.3, it makes sense to use that same version in our CI build so that our build scripts have access to the same goodies as Atom itself.  This should also speed up our builds somewhat since there were some performance improvements

Specific installations of npm 5.3.0 have been removed since npm 5.5.0 comes with Node 8.9.3.

### Alternate Designs

Rewrite Atom build scripts in Python

### Why Should This Be In Core?

It's CI, dudes

### Benefits

Even Noder than before

### Possible Drawbacks

8 looks like eyes if you turn your head sideways

### Verification Process

Wait for CI to go green

### Applicable Issues

None
