### PR TITLE
Use a consistent app naming strategy across non-stable channels

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -83,6 +83,8 @@ if [ $OS == 'Mac' ]; then
     ATOM_EXECUTABLE_NAME="Atom Beta"
   elif [ "$CHANNEL" == 'nightly' ]; then
     ATOM_EXECUTABLE_NAME="Atom Nightly"
+  elif [ "$CHANNEL" == 'dev' ]; then
+    ATOM_EXECUTABLE_NAME="Atom Dev"
   else
     ATOM_EXECUTABLE_NAME="Atom"
   fi

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "exception-reporting": "0.43.1",
     "find-and-replace": "0.215.11",
     "fuzzy-finder": "1.8.2",
-    "github": "0.17.2",
+    "github": "0.17.3",
     "git-diff": "1.3.9",
     "go-to-line": "0.33.0",
     "grammar-selector": "0.50.1",

--- a/script/config.js
+++ b/script/config.js
@@ -56,7 +56,7 @@ function getChannel (version) {
   return 'stable'
 }
 
-function getAppName(channel) {
+function getAppName (channel) {
   return channel === 'stable'
     ? 'Atom'
     : `Atom ${process.env.ATOM_CHANNEL_DISPLAY_NAME || channel.charAt(0).toUpperCase() + channel.slice(1)}`

--- a/script/config.js
+++ b/script/config.js
@@ -22,13 +22,13 @@ const appMetadata = require(path.join(repositoryRootPath, 'package.json'))
 const apmMetadata = require(path.join(apmRootPath, 'package.json'))
 const computedAppVersion = computeAppVersion(process.env.ATOM_RELEASE_VERSION || appMetadata.version)
 const channel = getChannel(computedAppVersion)
-const channelDisplayName = getChannelDisplayName(channel)
+const appName = getAppName(channel)
 
 module.exports = {
   appMetadata,
   apmMetadata,
   channel,
-  channelDisplayName,
+  appName,
   computedAppVersion,
   repositoryRootPath,
   apmRootPath,
@@ -56,9 +56,10 @@ function getChannel (version) {
   return 'stable'
 }
 
-function getChannelDisplayName (channel) {
-  if (channel === 'stable' || channel === 'dev') return null
-  return process.env.ATOM_CHANNEL_DISPLAY_NAME || channel.charAt(0).toUpperCase() + channel.slice(1)
+function getAppName(channel) {
+  return channel === 'stable'
+    ? 'Atom'
+    : `Atom ${process.env.ATOM_CHANNEL_DISPLAY_NAME || channel.charAt(0).toUpperCase() + channel.slice(1)}`
 }
 
 function computeAppVersion (version) {

--- a/script/lib/create-debian-package.js
+++ b/script/lib/create-debian-package.js
@@ -12,7 +12,6 @@ module.exports = function (packagedAppPath) {
   console.log(`Creating Debian package for "${packagedAppPath}"`)
   const atomExecutableName = CONFIG.channel === 'stable' ? 'atom' : `atom-${CONFIG.channel}`
   const apmExecutableName = CONFIG.channel === 'stable' ? 'apm' : `apm-${CONFIG.channel}`
-  const appName = CONFIG.channel === 'stable' ? 'Atom' : `Atom ${CONFIG.channelDisplayName}`
   const appDescription = CONFIG.appMetadata.description
   const appVersion = CONFIG.appMetadata.version
   let arch
@@ -88,7 +87,7 @@ module.exports = function (packagedAppPath) {
   console.log(`Writing desktop entry file into "${debianPackageApplicationsDirPath}"`)
   const desktopEntryTemplate = fs.readFileSync(path.join(CONFIG.repositoryRootPath, 'resources', 'linux', 'atom.desktop.in'))
   const desktopEntryContents = template(desktopEntryTemplate)({
-    appName: appName,
+    appName: CONFIG.appName,
     appFileName: atomExecutableName,
     description: appDescription,
     installDir: '/usr',

--- a/script/lib/create-rpm-package.js
+++ b/script/lib/create-rpm-package.js
@@ -12,7 +12,7 @@ module.exports = function (packagedAppPath) {
   console.log(`Creating rpm package for "${packagedAppPath}"`)
   const atomExecutableName = CONFIG.channel === 'stable' ? 'atom' : `atom-${CONFIG.channel}`
   const apmExecutableName = CONFIG.channel === 'stable' ? 'apm' : `apm-${CONFIG.channel}`
-  const appName = CONFIG.channel === 'stable' ? 'Atom' : `Atom ${CONFIG.channelDisplayName}`
+  const appName = CONFIG.appName
   const appDescription = CONFIG.appMetadata.description
   // RPM versions can't have dashes or tildes in them.
   // (Ref.: https://twiki.cern.ch/twiki/bin/view/Main/RPMAndDebVersioning)

--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -74,7 +74,7 @@ module.exports = function (packagedAppPath) {
     const verifySnapshotScriptPath = path.join(CONFIG.repositoryRootPath, 'script', 'verify-snapshot-script')
     let nodeBundledInElectronPath
     if (process.platform === 'darwin') {
-      const executableName = CONFIG.channelDisplayName ? `Atom ${CONFIG.channelDisplayName}` : 'Atom'
+      const executableName = CONFIG.appName
       nodeBundledInElectronPath = path.join(packagedAppPath, 'Contents', 'MacOS', executableName)
     } else if (process.platform === 'win32') {
       nodeBundledInElectronPath = path.join(packagedAppPath, 'atom.exe')

--- a/script/lib/package-application.js
+++ b/script/lib/package-application.js
@@ -114,7 +114,7 @@ function buildAsarUnpackGlobExpression () {
 
 function getAppName () {
   if (process.platform === 'darwin') {
-    return CONFIG.channelDisplayName ? `Atom ${CONFIG.channelDisplayName}` : 'Atom'
+    return CONFIG.appName
   } else {
     return 'atom'
   }
@@ -169,8 +169,7 @@ function renamePackagedAppDir (packageOutputDirPath) {
     if (fs.existsSync(packagedAppPath)) fs.removeSync(packagedAppPath)
     fs.renameSync(packageOutputDirPath, packagedAppPath)
   } else {
-    const appName = CONFIG.channel !== 'stable' ? `Atom ${CONFIG.channelDisplayName}` : 'Atom'
-    packagedAppPath = path.join(CONFIG.buildOutputPath, appName)
+    packagedAppPath = path.join(CONFIG.buildOutputPath, CONFIG.appName)
     if (process.platform === 'win32' && process.arch !== 'ia32') {
       packagedAppPath += ` ${process.arch}`
     }


### PR DESCRIPTION
### Description of the Change

This change makes the naming of the Atom application consistent across all non-stable channels (Beta, Nightly, Dev) to simplify the logic of scripts which consume these channels (like `atom/ci`).  This builds on some changes I made in PR #17538 which generalize some of the app naming code we were using to take other non-stable channels into account (like Nightly).

The only real impact this change has is that the .app file that's created from a `master` build on macOS will now be called **Atom Dev.app**.  I'm bringing this to general awareness in case anyone has any personal scripts for regularly building and using Atom from `master`.

This issue originally came up when @smashwilson found that the `atom/ci` script didn't properly find the Atom Dev build it unpacks on Linux because the folder names have changed.  While trying to fix that script, I realized that the Windows ZIP contained a folder called "Atom null" because of a bug in the code.  This change fixes it for all cases.

### Alternate Designs

Special case the dev channel to be called "Atom" and not "Atom Dev".  I'm fine with doing this if folks think it's a better approach.

### Why Should This Be In Core?

It's part of the Atom build process.

### Benefits

Consistent naming for non-stable channel builds, easier to predict what the app name will be without special casing.

### Possible Drawbacks

Breaking some existing workflows, but not terribly likely and easy to fix if so.

### Verification Process

- [x] Let CI complete and verify artifacts that are generated to make sure "Atom Dev" is being used as the app name on all 3 platforms:
  - [x] Windows
  - [x] macOS
  - [x] Linux
