### PR TITLE
Modify TextEditorComponent updateClassList to always add managed classes to element

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -818,6 +818,18 @@ describe('TextEditorComponent', () => {
       expect(element.className).toBe('editor a b')
     })
 
+    it('does not blow away class names managed by the component when packages change the element class name', async () => {
+      assertDocumentFocused()
+      const {component, element, editor} = buildComponent({mini: true})
+      element.classList.add('a', 'b')
+      element.focus()
+      await component.getNextUpdatePromise()
+      expect(element.className).toBe('editor mini a b is-focused')
+      element.className = 'a c d';
+      await component.getNextUpdatePromise()
+      expect(element.className).toBe('a c d editor is-focused mini')
+    })
+
     it('ignores resize events when the editor is hidden', async () => {
       const {component, element, editor} = buildComponent({autoHeight: false})
       element.style.height = 5 * component.getLineHeight() + 'px'

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -848,10 +848,7 @@ class TextEditorComponent {
     }
 
     for (let i = 0; i < newClassList.length; i++) {
-      const className = newClassList[i]
-      if (!oldClassList || !oldClassList.includes(className)) {
-        this.element.classList.add(className)
-      }
+      this.element.classList.add(newClassList[i])
     }
 
     this.classList = newClassList


### PR DESCRIPTION
### Description of the Change

Currently, the `updateClassList` method on the `TextEditorComponent` does not re-add the managed classes (editor, mini, is-focused) whenever the `<atom-text-editor>` element is re-rendered with a changed class. This PR fixes the issue by always adding the `newClassList` classes to the element, relying on `element.classList.add` to determine if the classes already exist (and should be ignored).

### Alternate Designs

N/A

### Why Should This Be In Core?

This address an issue that exists in one of the main core classes, which is used within other atom/atom classes. Implementing the change in a separate package would add an unnecessary additional dependency

### Benefits

This change will allow external packages to dynamically set <atom-text-editor> element classes without having to worry about losing the managed classes (editor, mini, is-focused). This is especially useful in React components that reuse an <atom-text-editor> element when re-rendering

### Possible Drawbacks

This change will affect packages' styling of atom-text-editor elements which rely on the managed classes not being re-applied. In such cases, the packages can regain specificity by adding the appropriate managed class names to the selectors.

### Verification Process
 - Added new spec test and verified passing tests
 - Verified by modifying the `find-and-replace` package's `project-find-view` to set the findEditor's class based on the text (see video), and ensuring the managed classes remain on the element
 - Manually tested <atom-text-editor> elements with changes to verify correct functionality

### Screencasts:
#### Before:
![updateclasslist_before](https://user-images.githubusercontent.com/5060851/42791351-1180d0a0-8925-11e8-8e82-99d3f581c165.gif)

#### After:
![updateclasslist_after](https://user-images.githubusercontent.com/5060851/42791362-1b0022fc-8925-11e8-9f22-d047257b0132.gif)



