### PR TITLE
Use correct executable name for Atom Dev.app in atom.sh on macOS

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -79,14 +79,20 @@ if [ $OS == 'Mac' ]; then
     ATOM_APP_NAME="$(basename "$ATOM_APP")"
   fi
 
-  if [ "$CHANNEL" == 'beta' ]; then
-    ATOM_EXECUTABLE_NAME="Atom Beta"
-  elif [ "$CHANNEL" == 'nightly' ]; then
-    ATOM_EXECUTABLE_NAME="Atom Nightly"
-  elif [ "$CHANNEL" == 'dev' ]; then
-    ATOM_EXECUTABLE_NAME="Atom Dev"
+  if [ ! -z "${ATOM_APP_NAME}" ]; then
+    # If ATOM_APP_NAME is known, use it as the executable name
+    ATOM_EXECUTABLE_NAME="${ATOM_APP_NAME%.*}"
   else
-    ATOM_EXECUTABLE_NAME="Atom"
+    # Else choose it from the inferred channel name
+    if [ "$CHANNEL" == 'beta' ]; then
+      ATOM_EXECUTABLE_NAME="Atom Beta"
+    elif [ "$CHANNEL" == 'nightly' ]; then
+      ATOM_EXECUTABLE_NAME="Atom Nightly"
+    elif [ "$CHANNEL" == 'dev' ]; then
+      ATOM_EXECUTABLE_NAME="Atom Dev"
+    else
+      ATOM_EXECUTABLE_NAME="Atom"
+    fi
   fi
 
   if [ -z "${ATOM_PATH}" ]; then


### PR DESCRIPTION
### Description of the Change

PR #17680 broke how `atom.sh` resolves the `.app` file for the version of Atom it intends to launch because we now name `dev` channel builds `Atom Dev.app`.  This PR fixes the script to use the name of the `.app` file that `atom.sh` is contained within when `/usr/local/bin/atom` is symbolically linked to it.

This only appears as an issue when calling `atom` with a parameter like `--version` which follows a different code path that invokes the executable file at `Atom Dev.app/Contents/MacOS/Atom Dev`

### Verification Process

- [x] Symlinking `/usr/local/bin/atom` to `atom.sh` inside `/Applications/Atom.app` and calling `atom --version` returns Atom Stable info
- [x] Symlinking `/usr/local/bin/atom` to `atom.sh` inside `/Applications/Atom Dev.app` and calling `atom --version` returns Atom Dev info
- [x] Symlinking `/usr/local/bin/atom` to `atom.sh` inside `/Applications/Atom Beta.app` and calling `atom --version` returns Atom Beta info
- [x] Symlinking `/usr/local/bin/atom` to `atom.sh` inside `/Applications/Atom Nightly.app` and calling `atom --version` returns Atom Nightly info