### PR TITLE
Fix bugs found when adding ruby tree-sitter grammar

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "language-gfm": "0.90.5",
     "language-git": "0.19.1",
     "language-go": "0.46.0",
-    "language-html": "0.51.0",
+    "language-html": "0.51.1",
     "language-hyperlink": "0.16.3",
     "language-java": "0.30.0",
     "language-javascript": "0.129.0",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "language-php": "0.44.0",
     "language-property-list": "0.9.1",
     "language-python": "0.51.0",
-    "language-ruby": "0.71.4",
+    "language-ruby": "0.72.0",
     "language-ruby-on-rails": "0.25.3",
     "language-sass": "0.62.0",
     "language-shellscript": "0.27.0",

--- a/src/tree-sitter-grammar.js
+++ b/src/tree-sitter-grammar.js
@@ -13,6 +13,7 @@ class TreeSitterGrammar {
     if (params.injectionRegExp) this.injectionRegExp = new RegExp(params.injectionRegExp)
 
     this.folds = params.folds || []
+    this.folds.forEach(normalizeFoldSpecification)
 
     this.commentStrings = {
       commentStartString: params.comments && params.comments.start,
@@ -71,4 +72,37 @@ class TreeSitterGrammar {
   deactivate () {
     if (this.registration) this.registration.dispose()
   }
+}
+
+const NODE_NAME_REGEX = /[\w_]+/
+
+function matcherForSpec (spec) {
+  if (typeof spec === 'string') {
+    if (spec[0] === '"' && spec[spec.length - 1] === '"') {
+      return {
+        type: spec.substr(1, spec.length - 2),
+        named: false
+      }
+    }
+
+    if (!NODE_NAME_REGEX.test(spec)) {
+      return {type: spec, named: false}
+    }
+
+    return {type: spec, named: true}
+  }
+  return spec
+}
+
+function normalizeFoldSpecification (spec) {
+  if (spec.type) {
+    if (Array.isArray(spec.type)) {
+      spec.matchers = spec.type.map(matcherForSpec)
+    } else {
+      spec.matchers = [matcherForSpec(spec.type)]
+    }
+  }
+
+  if (spec.start) normalizeFoldSpecification(spec.start)
+  if (spec.end) normalizeFoldSpecification(spec.end)
 }

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -41,15 +41,12 @@ class TreeSitterLanguageMode {
     this.emitRangeUpdate = this.emitRangeUpdate.bind(this)
 
     this.subscription = this.buffer.onDidChangeText(({changes}) => {
-      for (let i = changes.length - 1; i >= 0; i--) {
+      for (let i = 0, {length} = changes; i < length; i++) {
         const {oldRange, newRange} = changes[i]
-        const startRow = oldRange.start.row
-        const oldEndRow = oldRange.end.row
-        const newEndRow = newRange.end.row
         this.isFoldableCache.splice(
-          startRow,
-          oldEndRow - startRow,
-          ...new Array(newEndRow - startRow)
+          newRange.start.row,
+          oldRange.end.row - oldRange.start.row,
+          ...new Array(newRange.end.row - newRange.start.row)
         )
       }
 

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -713,8 +713,11 @@ class HighlightIterator {
 class LayerHighlightIterator {
   constructor (languageLayer, treeCursor) {
     this.languageLayer = languageLayer
-    this.treeCursor = treeCursor
+
+    // The iterator is always positioned at either the start or the end of some node
+    // in the syntax tree.
     this.atEnd = false
+    this.treeCursor = treeCursor
 
     // In order to determine which selectors match its current node, the iterator maintains
     // a list of the current node's ancestors. Because the selectors can use the `:nth-child`
@@ -757,7 +760,10 @@ class LayerHighlightIterator {
       const scopeId = this._currentScopeId()
       if (scopeId) {
         if (this.treeCursor.startIndex < targetIndex) {
-          insertContainingTag(scopeId, this.treeCursor.startIndex, containingTags, containingTagStartIndices)
+          insertContainingTag(
+            scopeId, this.treeCursor.startIndex,
+            containingTags, containingTagStartIndices
+          )
           containingTagEndIndices.push(this.treeCursor.endIndex)
         } else {
           this.atEnd = false
@@ -785,32 +791,25 @@ class LayerHighlightIterator {
   }
 
   moveToSuccessor () {
-    let didMove = false
     this.closeTags.length = 0
     this.openTags.length = 0
 
-    while (!(this.done || (didMove && (this.closeTags.length || this.openTags.length)))) {
+    while (!this.done && !this.closeTags.length && !this.openTags.length) {
       if (this.atEnd) {
         if (this._moveRight()) {
           const scopeId = this._currentScopeId()
           if (scopeId) this.openTags.push(scopeId)
-
-          didMove = true
           this.atEnd = false
           this._moveDown()
         } else if (this._moveUp(true)) {
-          didMove = true
           this.atEnd = true
         } else {
           this.done = true
         }
       } else if (this._moveDown()) {
-        didMove = true
       } else {
         const scopeId = this._currentScopeId()
         if (scopeId) this.closeTags.push(scopeId)
-
-        didMove = true
         this.atEnd = true
         this._moveUp(false)
       }


### PR DESCRIPTION
This PR upgrades `language-ruby` to include https://github.com/atom/language-ruby/pull/225, and upgrades `language-html` to include an ERB grammar. The ruby parser surfaced a couple of bugs in the way the `TreeSitterLanguageMode` uses the syntax trees. I've fixed them here.