### PR TITLE
Add TreeSitterLanguageMode::getSyntaxNodeContainingRange and TreeSitterLanguageMode::getSyntaxNodeAtPosition

### DIFF
--- a/spec/tree-sitter-language-mode-spec.js
+++ b/spec/tree-sitter-language-mode-spec.js
@@ -1313,7 +1313,7 @@ describe('TreeSitterLanguageMode', () => {
   })
 
   describe('.getSyntaxNodeAtPosition(position, where?)', () => {
-    fit('returns the range of the smallest matching node at position', async () => {
+    it('returns the range of the smallest matching node at position', async () => {
       const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
         id: 'javascript',
         parser: 'tree-sitter-javascript'

--- a/spec/tree-sitter-language-mode-spec.js
+++ b/spec/tree-sitter-language-mode-spec.js
@@ -1134,6 +1134,206 @@ describe('TreeSitterLanguageMode', () => {
     })
   })
 
+  describe('.bufferRangeForScopeAtPosition(selector?, position)', () => {
+    describe('when selector = null', () => {
+      it('returns the range of the smallest node at position', async () => {
+        const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+          id: 'javascript',
+          parser: 'tree-sitter-javascript'
+        })
+
+        buffer.setText('foo({bar: baz});')
+
+        buffer.setLanguageMode(new TreeSitterLanguageMode({buffer, grammar}))
+        await nextHighlightingUpdate(buffer.getLanguageMode())
+        expect(editor.bufferRangeForScopeAtPosition(null, [0, 6])).toEqual(
+          [[0, 5], [0, 8]]
+        )
+        expect(editor.bufferRangeForScopeAtPosition(null, [0, 9])).toEqual(
+          [[0, 8], [0, 9]]
+        )
+      })
+
+      it('includes nodes in injected syntax trees', async () => {
+        const jsGrammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+          id: 'javascript',
+          parser: 'tree-sitter-javascript',
+          scopes: {},
+          injectionRegExp: 'javascript',
+          injectionPoints: [HTML_TEMPLATE_LITERAL_INJECTION_POINT]
+        })
+
+        const htmlGrammar = new TreeSitterGrammar(atom.grammars, htmlGrammarPath, {
+          id: 'html',
+          parser: 'tree-sitter-html',
+          scopes: {},
+          injectionRegExp: 'html',
+          injectionPoints: [SCRIPT_TAG_INJECTION_POINT]
+        })
+
+        atom.grammars.addGrammar(jsGrammar)
+        atom.grammars.addGrammar(htmlGrammar)
+
+        buffer.setText(`
+          <div>
+            <script>
+              html \`
+                <span>\${person.name}</span>
+              \`
+            </script>
+          </div>
+        `)
+
+        const languageMode = new TreeSitterLanguageMode({buffer, grammar: htmlGrammar, grammars: atom.grammars})
+        buffer.setLanguageMode(languageMode)
+        await nextHighlightingUpdate(languageMode)
+        await nextHighlightingUpdate(languageMode)
+        await nextHighlightingUpdate(languageMode)
+
+        const nameProperty = buffer.findSync('name')
+        const {start} = nameProperty
+        const position = Object.assign({}, start, {column: start.column + 2})
+        expect(languageMode.bufferRangeForScopeAtPosition(null, position))
+          .toEqual(nameProperty)
+      })
+    })
+
+    describe('with a selector', () => {
+      it('returns the range of the smallest matching node at position', async () => {
+        const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+          id: 'javascript',
+          parser: 'tree-sitter-javascript'
+        })
+
+        buffer.setText('foo({bar: baz});')
+
+        buffer.setLanguageMode(new TreeSitterLanguageMode({buffer, grammar}))
+        await nextHighlightingUpdate(buffer.getLanguageMode())
+        expect(editor.bufferRangeForScopeAtPosition('.property_identifier', [0, 6])).toEqual(
+          buffer.findSync('bar')
+        )
+        expect(editor.bufferRangeForScopeAtPosition('.call_expression', [0, 6])).toEqual(
+          [[0, 0], [0, buffer.getText().length - 1]]
+        )
+        expect(editor.bufferRangeForScopeAtPosition('.object', [0, 9])).toEqual(
+          buffer.findSync('{bar: baz}')
+        )
+      })
+
+      it('includes nodes in injected syntax trees', async () => {
+        const jsGrammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+          id: 'javascript',
+          parser: 'tree-sitter-javascript',
+          scopes: {},
+          injectionRegExp: 'javascript',
+          injectionPoints: [HTML_TEMPLATE_LITERAL_INJECTION_POINT]
+        })
+
+        const htmlGrammar = new TreeSitterGrammar(atom.grammars, htmlGrammarPath, {
+          id: 'html',
+          parser: 'tree-sitter-html',
+          scopes: {},
+          injectionRegExp: 'html',
+          injectionPoints: [SCRIPT_TAG_INJECTION_POINT]
+        })
+
+        atom.grammars.addGrammar(jsGrammar)
+        atom.grammars.addGrammar(htmlGrammar)
+
+        buffer.setText(`
+          <div>
+            <script>
+              html \`
+                <span>\${person.name}</span>
+              \`
+            </script>
+          </div>
+        `)
+
+        const languageMode = new TreeSitterLanguageMode({buffer, grammar: htmlGrammar, grammars: atom.grammars})
+        buffer.setLanguageMode(languageMode)
+        await nextHighlightingUpdate(languageMode)
+        await nextHighlightingUpdate(languageMode)
+        await nextHighlightingUpdate(languageMode)
+
+        const nameProperty = buffer.findSync('name')
+        const {start} = nameProperty
+        const position = Object.assign({}, start, {column: start.column + 2})
+        expect(languageMode.bufferRangeForScopeAtPosition('.property_identifier', position))
+          .toEqual(nameProperty)
+        expect(languageMode.bufferRangeForScopeAtPosition('.element', position))
+          .toEqual(buffer.findSync('<span>\\${person\\.name}</span>'))
+      })
+
+      it('accepts node-matching functions as selectors', async () => {
+        const jsGrammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+          id: 'javascript',
+          parser: 'tree-sitter-javascript',
+          scopes: {},
+          injectionRegExp: 'javascript',
+          injectionPoints: [HTML_TEMPLATE_LITERAL_INJECTION_POINT]
+        })
+
+        const htmlGrammar = new TreeSitterGrammar(atom.grammars, htmlGrammarPath, {
+          id: 'html',
+          parser: 'tree-sitter-html',
+          scopes: {},
+          injectionRegExp: 'html',
+          injectionPoints: [SCRIPT_TAG_INJECTION_POINT]
+        })
+
+        atom.grammars.addGrammar(jsGrammar)
+        atom.grammars.addGrammar(htmlGrammar)
+
+        buffer.setText(`
+          <div>
+            <script>
+              html \`
+                <span>\${person.name}</span>
+              \`
+            </script>
+          </div>
+        `)
+
+        const languageMode = new TreeSitterLanguageMode({buffer, grammar: htmlGrammar, grammars: atom.grammars})
+        buffer.setLanguageMode(languageMode)
+        await nextHighlightingUpdate(languageMode)
+        await nextHighlightingUpdate(languageMode)
+        await nextHighlightingUpdate(languageMode)
+
+        const nameProperty = buffer.findSync('name')
+        const {start} = nameProperty
+        const position = Object.assign({}, start, {column: start.column + 2})
+        const templateStringInCallExpression = node =>
+          node.type === 'template_string' && node.parent.type === 'call_expression'
+        expect(languageMode.bufferRangeForScopeAtPosition(templateStringInCallExpression, position))
+          .toEqual([[3, 19], [5, 15]])
+      })
+    })
+  })
+
+  describe('.getSyntaxNodeAtPosition(position, where?)', () => {
+    fit('returns the range of the smallest matching node at position', async () => {
+      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+        id: 'javascript',
+        parser: 'tree-sitter-javascript'
+      })
+
+      buffer.setText('foo(bar({x: 2}));')
+      const languageMode = new TreeSitterLanguageMode({buffer, grammar})
+      buffer.setLanguageMode(languageMode)
+      await nextHighlightingUpdate(languageMode)
+      expect(languageMode.getSyntaxNodeAtPosition([0, 6]).range).toEqual(
+        buffer.findSync('bar')
+      )
+      const findFoo = node =>
+        node.type === 'call_expression' && node.firstChild.text === 'foo'
+      expect(languageMode.getSyntaxNodeAtPosition([0, 6], findFoo).range).toEqual(
+        [[0, 0], [0, buffer.getText().length - 1]]
+      )
+    })
+  })
+
   describe('TextEditor.selectLargerSyntaxNode and .selectSmallerSyntaxNode', () => {
     it('expands and contracts the selection based on the syntax tree', async () => {
       const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -4,7 +4,7 @@ const {isSubset} = require('underscore-plus')
 
 // Private: Parse a selector into parts.
 //          If already parsed, returns the selector unmodified.
-// 
+//
 // * `selector` a {String|Array<String>} specifying what to match
 // Returns selector parts, an {Array<String>}.
 function parse (selector) {

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,0 +1,42 @@
+module.exports = {selectorMatchesAnyScope, matcherForSelector}
+
+const _ = require('underscore-plus')
+
+/**
+ * Parse a selector into parts. If already parsed, returns the selector
+ * unmodified.
+ * 
+ * @param {String|Array<String>} selector
+ * @returns {Array<String>} selector parts
+ */
+function parse (selector) {
+  return typeof selector === 'string'
+    ? selector.replace(/^\./, '').split('.')
+    : selector
+}
+
+const always = scope => true
+
+/**
+ * Return a matcher function for a selector.
+ * 
+ * @param {String} selector
+ * @returns {(scope: String) -> Boolean} a matcher function
+ */
+function matcherForSelector (selector) {
+  const parts = parse(selector)
+  return selector
+    ? scope => _.isSubset(parts, parse(scope))
+    : always
+}
+
+/**
+ * Return true iff the selector matches any provided scope.
+ * 
+ * @param {String} selector
+ * @param {Array<String>} scopes
+ * @returns {Boolean} true if any scope matches the selector
+ */
+function selectorMatchesAnyScope (selector, scopes) {
+  return !selector || scopes.some(matcherForSelector(selector))
+}

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,14 +1,12 @@
 module.exports = {selectorMatchesAnyScope, matcherForSelector}
 
-const _ = require('underscore-plus')
+const {isSubset} = require('underscore-plus')
 
-/**
- * Parse a selector into parts. If already parsed, returns the selector
- * unmodified.
- * 
- * @param {String|Array<String>} selector
- * @returns {Array<String>} selector parts
- */
+// Private: Parse a selector into parts.
+//          If already parsed, returns the selector unmodified.
+// 
+// * `selector` a {String|Array<String>} specifying what to match
+// Returns selector parts, an {Array<String>}.
 function parse (selector) {
   return typeof selector === 'string'
     ? selector.replace(/^\./, '').split('.')
@@ -17,26 +15,23 @@ function parse (selector) {
 
 const always = scope => true
 
-/**
- * Return a matcher function for a selector.
- * 
- * @param {String} selector
- * @returns {(scope: String) -> Boolean} a matcher function
- */
+// Essential: Return a matcher function for a selector.
+//
+// * selector, a {String} selector
+// Returns {(scope: String) -> Boolean}, a matcher function returning
+// true iff the scope matches the selector.
 function matcherForSelector (selector) {
   const parts = parse(selector)
   return selector
-    ? scope => _.isSubset(parts, parse(scope))
+    ? scope => isSubset(parts, parse(scope))
     : always
 }
 
-/**
- * Return true iff the selector matches any provided scope.
- * 
- * @param {String} selector
- * @param {Array<String>} scopes
- * @returns {Boolean} true if any scope matches the selector
- */
+// Essential: Return true iff the selector matches any provided scope.
+//
+// * {String} selector
+// * {Array<String>} scopes
+// Returns {Boolean} true if any scope matches the selector.
 function selectorMatchesAnyScope (selector, scopes) {
   return !selector || scopes.some(matcherForSelector(selector))
 }

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -22,6 +22,7 @@ const always = scope => true
 // true iff the scope matches the selector.
 function matcherForSelector (selector) {
   const parts = parse(selector)
+  if (typeof parts === 'function') return parts
   return selector
     ? scope => isSubset(parts, parse(scope))
     : always

--- a/src/text-mate-language-mode.js
+++ b/src/text-mate-language-mode.js
@@ -7,6 +7,7 @@ const ScopeDescriptor = require('./scope-descriptor')
 const NullGrammar = require('./null-grammar')
 const {OnigRegExp} = require('oniguruma')
 const {toFirstMateScopeId, fromFirstMateScopeId} = require('./first-mate-helpers')
+const {selectorMatchesAnyScope} = require('./selectors')
 
 const NON_WHITESPACE_REGEX = /\S/
 
@@ -725,14 +726,6 @@ class TextMateLanguageMode {
 }
 
 TextMateLanguageMode.prototype.chunkSize = 50
-
-function selectorMatchesAnyScope (selector, scopes) {
-  const targetClasses = selector.replace(/^\./, '').split('.')
-  return scopes.some((scope) => {
-    const scopeClasses = scope.split('.')
-    return _.isSubset(targetClasses, scopeClasses)
-  })
-}
 
 class TextMateHighlightIterator {
   constructor (languageMode) {

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -355,15 +355,17 @@ class TreeSitterLanguageMode {
     const searchEndIndex = Math.max(0, endIndex - 1)
 
     const matches = matcherForSelector(selector)
-
+    
     let smallestNode
     this._forEachTreeWithRange(range, tree => {
       let node = tree.rootNode.descendantForIndex(startIndex, searchEndIndex)
-      while (node && !nodeContainsIndices(node, startIndex, endIndex)) {
-        node = node.parent
-        console.log(node)
+      while (node) {
+        if (nodeContainsIndices(node, startIndex, endIndex) && matches(node.type)) {
+          if (nodeIsSmaller(node, smallestNode)) smallestNode = node
+          break
+        }
+        node = node.parent        
       }
-      if (matches(node.type) && nodeIsSmaller(node, smallestNode)) smallestNode = node
     })
 
     if (smallestNode) return rangeForNode(smallestNode)

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -355,7 +355,7 @@ class TreeSitterLanguageMode {
     const searchEndIndex = Math.max(0, endIndex - 1)
 
     const matches = matcherForSelector(selector)
-    
+
     let smallestNode
     this._forEachTreeWithRange(range, tree => {
       let node = tree.rootNode.descendantForIndex(startIndex, searchEndIndex)

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -349,18 +349,18 @@ class TreeSitterLanguageMode {
   Section - Syntax Tree APIs
   */
 
-  getRangeForSyntaxNodeContainingRange (range, selector) {
+  getRangeForSyntaxNodeContainingRange (range, where = _ => true) {
     const startIndex = this.buffer.characterIndexForPosition(range.start)
     const endIndex = this.buffer.characterIndexForPosition(range.end)
     const searchEndIndex = Math.max(0, endIndex - 1)
 
-    const matches = matcherForSelector(selector)
 
     let smallestNode
     this._forEachTreeWithRange(range, tree => {
+      if (typeof selector === 'function') debugger
       let node = tree.rootNode.descendantForIndex(startIndex, searchEndIndex)
       while (node) {
-        if (nodeContainsIndices(node, startIndex, endIndex) && matches(node.type)) {
+        if (nodeContainsIndices(node, startIndex, endIndex) && where(node)) {
           if (nodeIsSmaller(node, smallestNode)) smallestNode = node
           break
         }
@@ -372,6 +372,11 @@ class TreeSitterLanguageMode {
   }
 
   bufferRangeForScopeAtPosition (selector, position) {
+    if (typeof selector === 'string') {
+      const match = matcherForSelector(selector)
+      selector = ({type}) => match(type)
+    }
+    if (selector === null) selector = undefined
     return this.getRangeForSyntaxNodeContainingRange(new Range(position, position), selector)
   }
 

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -376,6 +376,11 @@ class TreeSitterLanguageMode {
     return smallestNode
   }
 
+  getRangeForSyntaxNodeContainingRange (range, where = _ => true) {
+    const node = this.getSyntaxNodeContainingRange(range, where)
+    return node && node.range
+  }
+
   getSyntaxNodeAtPosition (position, where) {
     return this.getSyntaxNodeContainingRange(new Range(position, position), where)
   }

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -363,14 +363,13 @@ class TreeSitterLanguageMode {
 
     let smallestNode
     this._forEachTreeWithRange(range, tree => {
-      if (typeof selector === 'function') debugger
       let node = tree.rootNode.descendantForIndex(startIndex, searchEndIndex)
       while (node) {
         if (nodeContainsIndices(node, startIndex, endIndex) && where(node)) {
           if (nodeIsSmaller(node, smallestNode)) smallestNode = node
           break
         }
-        node = node.parent        
+        node = node.parent
       }
     })
 

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -376,7 +376,7 @@ class TreeSitterLanguageMode {
     return smallestNode
   }
 
-  getRangeForSyntaxNodeContainingRange (range, where = _ => true) {
+  getRangeForSyntaxNodeContainingRange (range, where) {
     const node = this.getSyntaxNodeContainingRange(range, where)
     return node && node.range
   }


### PR DESCRIPTION
Adds:
  * `TreeSitterLanguageMode::getSyntaxNodeContainingRange(range: Range, where?: SyntaxNode -> Boolean)`
  * `TreeSitterLanguageMode::getSyntaxNodeAtPosition(range: Range, where?: SyntaxNode -> Boolean)`

These methods let you find a `SyntaxNode` at a location, optionally specifying a predicate function.

Changes:
  * `bufferRangeForScopeAtPosition(position)` to `bufferRangeForScopeAtPosition(selector, position)`.
  * `getRageForSyntaxNodeAtPosition(position)` to `getRangeForSyntaxNodeAtPosition(selector, where)`.

This brings it in line with the `TextMateLanguageMode` interface. The selector may be a string selector, or a predicate function of type `SyntaxNode -> Boolean`.

Needed for https://github.com/atom/toggle-quotes/issues/57.