### PR TITLE
Fix failing Windows nightly builds

### DIFF
--- a/script/lib/create-windows-installer.js
+++ b/script/lib/create-windows-installer.js
@@ -16,6 +16,7 @@ module.exports = (packagedAppPath) => {
     loadingGif: path.join(CONFIG.repositoryRootPath, 'resources', 'win', 'loading.gif'),
     outputDirectory: CONFIG.buildOutputPath,
     noMsi: true,
+    noDelta: CONFIG.channel === 'nightly', // Delta packages are broken for nightly versions past nightly9 due to Squirrel/NuGet limitations
     remoteReleases: `https://atom.io/api/updates${archSuffix}?version=${CONFIG.computedAppVersion}`,
     setupExe: `AtomSetup${process.arch === 'x64' ? '-x64' : ''}.exe`,
     setupIcon: path.join(CONFIG.repositoryRootPath, 'resources', 'app-icons', CONFIG.channel, 'atom.ico')

--- a/script/lib/create-windows-installer.js
+++ b/script/lib/create-windows-installer.js
@@ -29,7 +29,7 @@ module.exports = (packagedAppPath) => {
     }
 
     for (let nupkgPath of glob.sync(`${CONFIG.buildOutputPath}/atom-*.nupkg`)) {
-      if (!nupkgPath.includes(CONFIG.appMetadata.version)) {
+      if (!nupkgPath.includes(CONFIG.computedAppVersion)) {
         console.log(`Deleting downloaded nupkg for previous version at ${nupkgPath} to prevent it from being stored as an artifact`)
         fs.unlinkSync(nupkgPath)
       } else {


### PR DESCRIPTION
### Description of the Change

Windows builds for Atom Nightly releases started failing two days ago with this error:

```
2018-07-19T04:51:24.8313461Z Error: Failed with exit code: 4294967295
2018-07-19T04:51:24.8313925Z Output:
2018-07-19T04:51:24.8314245Z System.IO.FileNotFoundException: The base package release does not exist
2018-07-19T04:51:24.8314666Z File name: 'D:\a\1\s\out\atom-1.30.0-nightly1-full.nupkg'
2018-07-19T04:51:24.8315221Z    at Squirrel.DeltaPackageBuilder.CreateDeltaPackage(ReleasePackage basePackage, ReleasePackage newPackage, String outputFile)
2018-07-19T04:51:24.8315990Z    at Squirrel.Update.Program.Releasify(String package, String targetDir, String packagesDir, String bootstrapperExe, String backgroundGif, String signingOpts, String baseUrl, String setupIcon, Boolean generateMsi, String frameworkVersion, Boolean generateDeltas)
2018-07-19T04:51:24.8316677Z    at Squirrel.Update.Program.executeCommandLine(String[] args)
2018-07-19T04:51:24.8317066Z    at Squirrel.Update.Program.main(String[] args)
2018-07-19T04:51:24.8317420Z    at Squirrel.Update.Program.Main(String[] args)
2018-07-19T04:51:24.8317661Z 
2018-07-19T04:51:24.8317999Z   at ChildProcess.proc.on.code (D:\a\1\s\script\node_modules\electron-winstaller\lib\spawn-promise.js:62:16)
2018-07-19T04:51:24.8318923Z   at emitTwo (events.js:126:13)
2018-07-19T04:51:24.8319275Z   at ChildProcess.emit (events.js:214:7)
2018-07-19T04:51:24.8319668Z   at maybeClose (internal/child_process.js:925:16)
2018-07-19T04:51:24.8320356Z   at Process.ChildProcess._handle.onexit (internal/child_process.js:209:5)
```

The problem here is that when generating a delta package, Squirrel is looking for the previous version of `1.30.0-nightly10` in the `RELEASES` file and it's choosing `1.30.0-nightly1` instead of `1.30.0-nightly9`.  This happens due to a bug in the `SemanticVersion` class of Squirrel's fork of NuGet 2.0.

The solution for now is to turn off delta package builds only for Nightly releases until we can get the underlying issue fixed in Squirrel.Windows and Squirrel's fork of NuGet 2.0.

### Alternate Designs

The ideal fix is to change how version comparisons work in Squirrel's fork of NuGet 2.0.  The offending code is [here](https://github.com/paulcbetts/NuGet/blob/master/src/Core/SemanticVersion.cs#L243):

```
            return StringComparer.OrdinalIgnoreCase.Compare(SpecialVersion, other.SpecialVersion);
```

This comparison should be changed to use the [`StrCmpLogicalW`](http://msdn.microsoft.com/en-us/library/bb759947(VS.85).aspx) API which takes numeric sections of strings into account to produce orderings that look like what you'd get in a sorted file listing in Windows Explorer.

### Possible Drawbacks

We won't have delta packages for now, meaning that users will have to download the full nuget package for each Nightly release on Windows until this bug is fixed.  This isn't a huge concern since macOS users already have to do this as Squirrel.Mac doesn't support delta packages.

### Verification Process

- [x] Built Atom Nightly `1.30.0-nightly10` locally on a Windows machine and verified that the build fails in the same way as on VSTS **before** the fix
- [x] Built Atom Nightly `1.30.0-nightly10` locally and verified that the build completes successfully without generating a delta package **after** the fix.
