### PR TITLE
Fix tree-sitter highlighting regression affecting python

### DIFF
--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -849,15 +849,10 @@ class LayerHighlightIterator {
     let result = false
     const {endIndex} = this.treeCursor
     let depth = this.containingNodeEndIndices.length
-    while (depth > 1) {
-      // Once the iterator has found a scope boundary, it needs to stay at the same
-      // position, so it should not move up if the parent node ends later than the
-      // current node.
-      if ((!atLastChild || this.openTags.length || this.closeTags.length) &&
-          this.containingNodeEndIndices[depth - 2] > endIndex) {
-        break
-      }
 
+    // The iterator should not move up until it has visited all of the children of this node.
+    while (depth > 1 && (atLastChild || this.containingNodeEndIndices[depth - 2] === endIndex)) {
+      atLastChild = false
       result = true
       this.treeCursor.gotoParent()
       this.containingNodeTypes.pop()
@@ -873,10 +868,11 @@ class LayerHighlightIterator {
   _moveDown () {
     let result = false
     const {startIndex} = this.treeCursor
+
+    // Once the iterator has found a scope boundary, it needs to stay at the same
+    // position, so it should not move down if the first child node starts later than the
+    // current node.
     while (this.treeCursor.gotoFirstChild()) {
-      // Once the iterator has found a scope boundary, it needs to stay at the same
-      // position, so it should not move down if the first child node starts later than the
-      // current node.
       if ((this.closeTags.length || this.openTags.length) &&
           this.treeCursor.startIndex > startIndex) {
         this.treeCursor.gotoParent()


### PR DESCRIPTION
Previously, there were certain circumstances where the highlighting iterator would *ascend* to a parent node even if hadn't yet visited all of that parent node's children. This caused big gaps in syntax highlighting for python.

/cc @queerviolet 