### PR TITLE
⬆️ find-and-replace@0.215.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "dev-live-reload": "0.48.1",
     "encoding-selector": "0.23.9",
     "exception-reporting": "0.43.1",
-    "find-and-replace": "0.215.11",
+    "find-and-replace": "0.215.12",
     "fuzzy-finder": "1.8.2",
     "github": "0.18.2",
     "git-diff": "1.3.9",


### PR DESCRIPTION
Upgrade find-and-replace package from v0.215.11 to v0.215.12.

Diff: https://github.com/atom/find-and-replace/compare/v0.215.11...v0.215.12

Changelog:

- atom/find-and-replace#1035 Don't show find-and-replace "Copy Path" item in tree-view context menu 

