### PR TITLE
Teach Pane to always look for a pane item's onDidTerminatePendingState function

### DIFF
--- a/spec/pane-spec.js
+++ b/spec/pane-spec.js
@@ -219,6 +219,34 @@ describe('Pane', () => {
       runs(() => expect(eventOrder).toEqual(['add', 'remove']))
     })
 
+    it('subscribes to be notified when item terminates its pending state', () => {
+      const fakeDisposable = { dispose: () => {} }
+      const spy = jasmine.createSpy('onDidTerminatePendingState').andReturn((fakeDisposable))
+
+      const pane = new Pane(paneParams({items: []}))
+      const item = {
+        getTitle: () => '',
+        onDidTerminatePendingState: spy
+      }
+      pane.addItem(item)
+
+      expect(spy).toHaveBeenCalled()
+    })
+
+    it('subscribes to be notified when item is destroyed', () => {
+      const fakeDisposable = { dispose: () => {} }
+      const spy = jasmine.createSpy('onDidDestroy').andReturn((fakeDisposable))
+
+      const pane = new Pane(paneParams({items: []}))
+      const item = {
+        getTitle: () => '',
+        onDidDestroy: spy
+      }
+      pane.addItem(item)
+
+      expect(spy).toHaveBeenCalled()
+    })
+
     describe('when using the old API of ::addItem(item, index)', () => {
       beforeEach(() => spyOn(Grim, 'deprecate'))
 

--- a/src/pane.js
+++ b/src/pane.js
@@ -614,15 +614,15 @@ class Pane {
 
     if (this.items.includes(item)) return
 
+    const itemSubscriptions = new CompositeDisposable()
+    this.subscriptionsPerItem.set(item, itemSubscriptions)
     if (typeof item.onDidDestroy === 'function') {
-      const itemSubscriptions = new CompositeDisposable()
       itemSubscriptions.add(item.onDidDestroy(() => this.removeItem(item, false)))
-      if (typeof item.onDidTerminatePendingState === 'function') {
-        itemSubscriptions.add(item.onDidTerminatePendingState(() => {
-          if (this.getPendingItem() === item) this.clearPendingItem()
-        }))
-      }
-      this.subscriptionsPerItem.set(item, itemSubscriptions)
+    }
+    if (typeof item.onDidTerminatePendingState === 'function') {
+      itemSubscriptions.add(item.onDidTerminatePendingState(() => {
+        if (this.getPendingItem() === item) this.clearPendingItem()
+      }))
     }
 
     this.items.splice(index, 0, item)


### PR DESCRIPTION
Fixes #17535

### Description of the Change

Prior to this pull request, if a PaneItem implemented the `onDidDestroy` function _and_ the `onDidTerminatePendingState` function, then the Pane would make use of both functions. However, if PaneItem implemented an `onDidTerminatePendingState` function but did _not_ implement an `onDidDestroy` function, the Pane wrongly ignored the `onDidTerminatePendingState` function.

With the changes in this pull request, the `onDidTerminatePendingState` function and `onDidDestroy` functions are treated independently:

- If the item only implements `onDidTerminatePendingState`, that's fine: `Pane` will use it
- If the item only implements `onDidDestroy`, that's fine, too: `Pane` will use it
- If the item implements both functions, `Pane` will use both functions
- If the item implements neither function, that's fine as well

### Verification Process

- [x] Verify correct behavior for `PaneItem` that implements `onDidTerminatePendingState` but not `onDidDestroy` (i.e., perform the "Steps to Reproduce" identified in #17535)
    1. Implement a new `PaneItem` with an opener. Implement `onDidTerminatePendingState` but not `onDidDestroy`

        <details>
        <summary>Code</summary>

        ```js
        const {Emitter} = require('atom')

        class SomePaneItem {
          constructor () {
            this.emitter = new Emitter()
          }

          getElement () {
            return document.createElement('div')
          }

          terminatePendingState () {
            this.emitter.emit('did-terminate-pending-state')
          }

          onDidTerminatePendingState (callback) {
            return this.emitter.on('did-terminate-pending-state', callback)
          }

          getTitle () {
            return 'some-pane-item'
          }

          getURI () {
            return 'atom://some-pane-item'
          }
        }
        ```
        </details>

    2. Open it as a pending item with a call to `atom.workspace.open(item, {pending: true})`
    3. Double-click on the tab title
    4. Verify that the item terminates its pending state and becomes a non-pending item

- [x] Verify correct behavior for `PaneItem` that implements `onDidDestroy` but not `onDidTerminatePendingState`

    1. Implement a new `PaneItem` with an opener. Implement `onDidDestroy` but not `onDidTerminatePendingState`

        <details>
        <summary>Code</summary>

        ```js
        const {Emitter} = require('atom')

        class SomePaneItem {
          constructor () {
            this.emitter = new Emitter()
          }

          getElement () {
            return document.createElement('div')
          }

          destroy () {
            this.emitter.emit('did-destroy')
          }

          onDidDestroy (callback) {
            return this.emitter.on('did-destroy', callback)
          }

          getTitle () {
            return 'some-pane-item'
          }

          getURI () {
            return 'atom://some-pane-item'
          }
        }
        ```
        </details>

    2. Call `onDidDestroy` to register a callback

        <details>
        <summary>Code</summary>

        ```js
        item.onDidDestroy(() => console.log('Destroyed'))
        ```
        </details>

    3. Open the item with a call to `atom.workspace.open(item)`
    4. Destroy the item with a call to `item.destroy()`
    5. Verify that the callback is invoked and that the pane item is removed from the workspace
