### PR TITLE
Fix repository tests that fail when run in fork of atom/atom

### DIFF
--- a/spec/fixtures/git/master.git/config
+++ b/spec/fixtures/git/master.git/config
@@ -4,3 +4,6 @@
 	bare = false
 	logallrefupdates = true
 	ignorecase = true
+[remote "origin"]
+	url = https://github.com/example-user/example-repo.git
+	fetch = +refs/heads/*:refs/remotes/origin/*

--- a/spec/project-spec.js
+++ b/spec/project-spec.js
@@ -1000,10 +1000,13 @@ describe('Project', () => {
       const observed = []
       const disposable = atom.project.onDidAddRepository((repo) => observed.push(repo))
 
-      const repositoryPath = path.join(__dirname, '..')
-      atom.project.addPath(repositoryPath)
+      const projectRootPath = temp.mkdirSync()
+      const fixtureRepoPath = fs.absolute(path.join(__dirname, 'fixtures', 'git', 'master.git'))
+      fs.copySync(fixtureRepoPath, path.join(projectRootPath, '.git'))
+
+      atom.project.addPath(projectRootPath)
       expect(observed.length).toBe(1)
-      expect(observed[0].getOriginURL()).toContain('atom/atom')
+      expect(observed[0].getOriginURL()).toEqual('https://github.com/example-user/example-repo.git')
 
       disposable.dispose()
     })
@@ -1012,9 +1015,16 @@ describe('Project', () => {
       const observed = []
       const disposable = atom.project.onDidAddRepository((repo) => observed.push(repo))
 
-      atom.project.addPath(__dirname)
+      const projectRootPath = temp.mkdirSync()
+      const fixtureRepoPath = fs.absolute(path.join(__dirname, 'fixtures', 'git', 'master.git'))
+      fs.copySync(fixtureRepoPath, path.join(projectRootPath, '.git'))
+
+      const projectSubDirPath = path.join(projectRootPath, 'sub-dir')
+      fs.mkdirSync(projectSubDirPath)
+
+      atom.project.addPath(projectSubDirPath)
       expect(observed.length).toBe(1)
-      expect(observed[0].getOriginURL()).toContain('atom/atom')
+      expect(observed[0].getOriginURL()).toEqual('https://github.com/example-user/example-repo.git')
 
       disposable.dispose()
     })


### PR DESCRIPTION
Prior to this change, two of the repository-related tests assumed that they were running in a local checkout of https://github.com/atom/atom, and the tests unintentionally failed if the local repository was a fork of atom/atom.

We first noticed this failure in https://circleci.com/gh/marcomorain/atom-1/29:

```
Project
  .onDidAddRepository()
    it invokes callback when a path is added and the path is the root of a repository
      Expected 'git@github.com:marcomorain/atom-1.git' to contain 'atom/atom'.
        at jasmine.Spec.it (/Users/distiller/project/spec/project-spec.js:1006:42)
    it invokes callback when a path is added and the path is subdirectory of a repository
      Expected 'git@github.com:marcomorain/atom-1.git' to contain 'atom/atom'.
        at jasmine.Spec.it (/Users/distiller/project/spec/project-spec.js:1017:42)
```

Instead of depending on the local checkout of the atom repository for these tests, this pull request updates the tests to use one of the fixture repositories. 😅
