### PR TITLE
Add missing x64 build artifacts to appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,6 +77,12 @@ artifacts:
     name: atom-windows.zip
   - path: out\RELEASES
     name: RELEASES
+  - path: out\AtomSetup-x64.exe
+    name: AtomSetup-x64.exe
+  - path: out\atom-x64-windows.zip
+    name: atom-x64-windows.zip
+  - path: out\RELEASES-x64
+    name: RELEASES-x64
   - path: out\atom-*-delta.nupkg
     name: atom-delta.nupkg
   - path: out\atom-*-full.nupkg


### PR DESCRIPTION
This change fixes an issue introduced by PR #17538 which changed how we name build artifacts on Windows.  Previously, our build scripts named AtomSetup.exe, atom-windows.zip, and RELEASES the same for x64 and x86 builds.  The aforementioned PR changed the build scripts to [add `x64` into these filenames](https://github.com/atom/atom/pull/17538/files#diff-131cff56e21060c243d2fd3d0339d39f) on x64 builds to match what we deliver as release assets.

This change updates `appveyor.yml` to ensure that the x64 artifacts are uploaded on successful AppVeyor builds.

/cc @jasonrudolph 