### PR TITLE
Write config file atomically

### DIFF
--- a/src/config-file.js
+++ b/src/config-file.js
@@ -6,6 +6,7 @@ const {watchPath} = require('./path-watcher')
 const CSON = require('season')
 const Path = require('path')
 const async = require('async')
+const temp = require('temp')
 
 const EVENT_TYPES = new Set([
   'created',
@@ -37,9 +38,11 @@ class ConfigFile {
     this.reloadCallbacks = []
 
     // Use a queue to prevent multiple concurrent write to the same file.
-    const writeQueue = async.queue((data, callback) =>
-      CSON.writeFile(this.path, data, error => {
-        if (error) {
+    const writeQueue = async.queue((data, callback) => {
+      (async () => {
+        try {
+          await writeCSONFileAtomically(this.path, data)
+        } catch (error) {
           this.emitter.emit('did-error', dedent `
             Failed to write \`${Path.basename(this.path)}\`.
 
@@ -47,8 +50,8 @@ class ConfigFile {
           `)
         }
         callback()
-      })
-    )
+      })()
+    })
 
     this.requestLoad = _.debounce(() => this.reload(), 200)
     this.requestSave = _.debounce((data) => writeQueue.push(data), 200)
@@ -115,4 +118,28 @@ class ConfigFile {
       })
     })
   }
+}
+
+function writeCSONFile (path, data) {
+  return new Promise((resolve, reject) => {
+    CSON.writeFile(path, data, error => {
+      if (error) reject(error)
+      else resolve()
+    })
+  })
+}
+
+async function writeCSONFileAtomically (path, data) {
+  const tempPath = temp.path()
+  await writeCSONFile(tempPath, data)
+  await rename(tempPath, path)
+}
+
+function rename (oldPath, newPath) {
+  return new Promise((resolve, reject) => {
+    fs.rename(oldPath, newPath, error => {
+      if (error) reject(error)
+      else resolve()
+    })
+  })
 }


### PR DESCRIPTION
### Description of the Change

We (the Nuclide team) continue to have reports of #17060 from Windows users, even after #17166. The cause isn't certain, however, we do know that [the `before-quit` event isn't reliable on Windows][1]. In any case, atomic writes (write + move) are less error-prone.

I rolled back the fix from #17060 to get back to a state where the issue could be reproduced somewhat reliably, then made the change an was unable to repro. This isn't a guaranteed fix (since the same could be said about #17060), but it seems more robust.

I was initially worried about the watcher not picking up the replace, but I tested that file updates were reflected in UI and that UI updates were mirrored to the file on both MacOS and Windows and we're good.

### Alternate Designs

None.

### Possible Drawbacks

* We're doing two operations (write and move) where we used to do one so this is going to be slower.
* There could be something subtle with the watcher I didn't pick up on when testing.
* I haven't verified on Linux.

### Verification Process

* For both MacOS and Windows:
    * Update `editor.fontSize` in my `config.cson` and see change in Atom.
    * Use `⌘+` to increase the font size and see change in `config.cson`.
* Install @Arcanemagus's settings-wiper from #17060 and repeat his instructions in that issue for wiping settings many (~50) times without settings loss.

### Applicable Issues

* #17166
* #17060
* #16786 
* #14909

cc @ebluestein

[1]: https://github.com/electron/electron/blob/master/docs/api/app.md#event-before-quit