### PR TITLE
Don't take destructive action on esc

### DIFF
--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -185,6 +185,7 @@ class AtomWindow extends EventEmitter {
       dialog.showMessageBox(this.browserWindow, {
         type: 'warning',
         buttons: ['Force Close', 'Keep Waiting'],
+        cancelId: 1, // Canceling should be the least destructive action
         message: 'Editor is not responding',
         detail:
           'The editor is not responding. Would you like to force close it or just keep waiting?'
@@ -202,6 +203,7 @@ class AtomWindow extends EventEmitter {
       dialog.showMessageBox(this.browserWindow, {
         type: 'warning',
         buttons: ['Close Window', 'Reload', 'Keep It Open'],
+        cancelId: 2, // Canceling should be the least destructive action
         message: 'The editor has crashed',
         detail: 'Please report this issue to https://github.com/atom/atom'
       }, response => {


### PR DESCRIPTION
### Description of the Change

People instinctively hit escape to ignore alerts, so we shouldn't have it do something destructive.

### Alternate Designs

We could also switch the button order but I kept it the same in most regards.

### Possible Drawbacks

Maybe somebody memorized that hitting escape did the destructive thing? Seems unlikely.

### Verification Process

Did the following in the console:

```js
require('electron').remote.getCurrentWindow().emit('unresponsive')
```

```js
require('electron').remote.getCurrentWindow().emit('crash')
```

Hit escape after each and the window wasn't destroyed. Repeated, clicking the destructive buttons and it was.