### PR TITLE
Allow comma-separated selectors as keys in Tree-sitter scope mappings

### DIFF
--- a/src/tree-sitter-grammar.js
+++ b/src/tree-sitter-grammar.js
@@ -22,7 +22,17 @@ class TreeSitterGrammar {
 
     const scopeSelectors = {}
     for (const key in params.scopes || {}) {
-      scopeSelectors[key] = toSyntaxClasses(params.scopes[key])
+      const classes = toSyntaxClasses(params.scopes[key])
+      const selectors = key.split(/,\s+/)
+      for (let selector of selectors) {
+        selector = selector.trim()
+        if (!selector) continue
+        if (scopeSelectors[selector]) {
+          scopeSelectors[selector] = [].concat(scopeSelectors[selector], classes)
+        } else {
+          scopeSelectors[selector] = classes
+        }
+      }
     }
 
     this.scopeMap = new SyntaxScopeMap(scopeSelectors)


### PR DESCRIPTION
Now that scope map values have a bit more structure (see https://github.com/atom/atom/pull/17738), it's nice to be able to avoid duplicating these values when they are used with multiple selectors. This PR allows the keys of a scope map to contain comma-separated selectors, similar to CSS.