### PR TITLE
Atom from WSL respects windows drive mount location defined in /etc/wsl.conf

### DIFF
--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -7,6 +7,10 @@ else
   pushd "$(dirname "$0")" > /dev/null
   if [[ $(uname -r) == *-Microsoft ]]; then
     # We are in Windows Subsystem for Linux, map /mnt/drive
+    root="/mnt/"
+    # If different root mount point defined in /etc/wsl.conf, use that instead
+    eval $(grep "^root" /etc/wsl.conf | sed -e "s/ //g")
+    root="$(echo $root | sed 's|/|\\/|g')"
     ATOMCMD="$(echo $PWD | sed 's/\/mnt\/\([a-z]*\)\(.*\)/\1:\2/')/atom.cmd"
     ATOMCMD="${ATOMCMD////\\}"
   else


### PR DESCRIPTION
### Description of the Change

Allows the default atom shell script to use the WSL windows drive mount point defined in /etc/wsl.conf

### Why Should This Be In Core?

The current core supports WSL except for cases when the windows drive mount point is not default

### Benefits

Any wsl.conf configured windows drive mount point will work instead of just the default

### Possible Drawbacks

Potentially doesn't account for every edge case mount point?

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

1. Change WSL default windows drive mount points to anything other than /mnt/%drive_letter%.
This is done in the /etc/wsl.conf file, specified here
3. Navigate to a directory on the windows filesystem inside WSL. Eg /c/dev/
4. Run "atom ."

### Applicable Issues

#17794
