### PR TITLE
Only set VSTS build number in non-PR builds to avoid auth errors

### DIFF
--- a/script/vsts/get-release-version.js
+++ b/script/vsts/get-release-version.js
@@ -39,7 +39,11 @@ async function getReleaseVersion () {
   // include the version.  Writing these strings to stdout causes VSTS to set
   // the associated variables.
   console.log(`##vso[task.setvariable variable=ReleaseVersion;isOutput=true]${releaseVersion}`)
-  console.log(`##vso[build.updatebuildnumber]${releaseVersion}+${process.env.BUILD_BUILDNUMBER}`)
+  if (!process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER) {
+    // Only set the build number on non-PR builds as it causes build errors when
+    // non-admins send PRs to the repo
+    console.log(`##vso[build.updatebuildnumber]${releaseVersion}+${process.env.BUILD_BUILDNUMBER}`)
+  }
 
   // Write out some variables that indicate whether artifacts should be uploaded
   const buildBranch = process.env.BUILD_SOURCEBRANCHNAME


### PR DESCRIPTION
### Description of the Change

This change fixes VSTS PR build errors we see when a non-maintainer sends a PR to this repo:

```
TF400813: The user '37997752-33c2-4c03-970c-cdc086fbc5e2' is not authorized to access this resource.
```

This error occurs due to a bug in VSTS which should be resolved in an upcoming release but for now this change will get us moving.

### Alternate Designs

None.

### Why Should This Be In Core?

It's for da build.

### Benefits

Outside contributors get PR build runs.

### Possible Drawbacks

None.

### Verification Process

- [x] The VSTS build for this PR passes and doesn't have a custom build number

### Applicable Issues

None.
