### PR TITLE
☝🏾language-javascript to 0.129.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "language-html": "https://www.atom.io/api/packages/language-html/versions/0.51.1/tarball",
     "language-hyperlink": "https://www.atom.io/api/packages/language-hyperlink/versions/0.16.3/tarball",
     "language-java": "https://www.atom.io/api/packages/language-java/versions/0.30.0/tarball",
-    "language-javascript": "https://www.atom.io/api/packages/language-javascript/versions/0.129.4/tarball",
+    "language-javascript": "https://www.atom.io/api/packages/language-javascript/versions/0.129.5/tarball",
     "language-json": "https://www.atom.io/api/packages/language-json/versions/0.19.2/tarball",
     "language-less": "https://www.atom.io/api/packages/language-less/versions/0.34.2/tarball",
     "language-make": "https://www.atom.io/api/packages/language-make/versions/0.22.3/tarball",

--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
     "language-html": "0.51.1",
     "language-hyperlink": "0.16.3",
     "language-java": "0.30.0",
-    "language-javascript": "0.129.4",
+    "language-javascript": "0.129.5",
     "language-json": "0.19.2",
     "language-less": "0.34.2",
     "language-make": "0.22.3",


### PR DESCRIPTION
For regex syntax highlighting.

Fixes #17805 
See also https://github.com/atom/language-javascript/pull/589