### PR TITLE
TextEditorComponent - when updated synchronously, update even when hidden

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -201,8 +201,11 @@ class TextEditorComponent {
   }
 
   scheduleUpdate (nextUpdateOnlyBlinksCursors = false) {
-    if (!this.visible) return
-    if (this.suppressUpdates) return
+    if (
+      this.suppressUpdates ||
+      !this.attached ||
+      (!this.visible && !this.updatedSynchronously)
+    ) return
 
     this.nextUpdateOnlyBlinksCursors =
       this.nextUpdateOnlyBlinksCursors !== false && nextUpdateOnlyBlinksCursors === true
@@ -219,14 +222,15 @@ class TextEditorComponent {
 
   updateSync (useScheduler = false) {
     // Don't proceed if we know we are not visible
-    if (!this.visible) {
+    if (!this.attached || !(this.updatedSynchronously || this.visible)) {
       this.updateScheduled = false
       return
     }
 
     // Don't proceed if we have to pay for a measurement anyway and detect
     // that we are no longer visible.
-    if ((this.remeasureCharacterDimensions || this.remeasureAllBlockDecorations) && !this.isVisible()) {
+    if ((this.remeasureCharacterDimensions || this.remeasureAllBlockDecorations) &&
+        !(this.updatedSynchronously || this.isVisible())) {
       if (this.resolveNextUpdatePromise) this.resolveNextUpdatePromise()
       this.updateScheduled = false
       return


### PR DESCRIPTION
Atom's `TextEditor` objects normally update their DOM element asynchronously for performance reasons. They also use an `IntersectionObserver` to avoid unnecessary updates while they are not visible.

There is currently a `setUpdatedSynchronously` method that you can use to force text editors to always update immediately. Previously, even when editors were configured to update synchronously, they would not update unless visible. This PR causes text editors which have been set to update synchronously to update their DOM immediately even when hidden. I think that this is the behavior most users would want from the `setUpdatedSynchronously` method; it's typically a method that you call on a text editor when you need to interact with its DOM element programmatically and you don't want to the normal optimizations that prevent updates.