### PR TITLE
Improve issue, bug, pr  and feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -5,7 +5,6 @@ about: Suggest an idea for this project
 ---
 
 <!--
-
 Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/atom/blob/master/CODE_OF_CONDUCT.md
 
 Do you want to ask a question? Are you looking for support? The Atom message board is the best place for getting support: https://discuss.atom.io
@@ -21,21 +20,20 @@ Keep in mind that Atom is highly customizable in a number of ways and we strongl
 If you're convinced that none of these options are appropriate for the feature you want, please explain why that's the case by completely filling out the issue template below.
 
 Also note that the Atom team has finite resources so it's unlikely that we'll work on feature requests. If we're interested in a particular feature however, we'll follow up and ask you to submit an RFC to talk about it in more detail.
-
 -->
 
 ## Summary
+<!-- Add one paragraph explanation of the feature. -->
 
-One paragraph explanation of the feature.
 
 ## Motivation
+<!-- Why are you/we doing this? What use cases does it support? What is the expected outcome? -->
 
-Why are we doing this? What use cases does it support? What is the expected outcome?
 
 ## Describe alternatives you've considered
+<!-- Add a clear and concise description of the alternative solutions you've considered. Be sure to explain why Atom's existing customizability isn't suitable for this feature. -->
 
-A clear and concise description of the alternative solutions you've considered. Be sure to explain why Atom's existing customizability isn't suitable for this feature.
 
 ## Additional context
+<!-- Add any other context or screenshots about the feature request here. -->
 
-Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,42 +5,48 @@ about: Create a report to help us improve
 ---
 
 <!--
-
 Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/atom/blob/master/CODE_OF_CONDUCT.md
 
 Do you want to ask a question? Are you looking for support? The Atom message board is the best place for getting support: https://discuss.atom.io
-
 -->
 
 ### Prerequisites
+<details>
+  <summary> Click to view prerequisites list.
 
-* [ ] Put an X between the brackets on this line if you have done all of the following:
-    * Reproduced the problem in Safe Mode: https://flight-manual.atom.io/hacking-atom/sections/debugging/#using-safe-mode
-    * Followed all applicable steps in the debugging guide: https://flight-manual.atom.io/hacking-atom/sections/debugging/
-    * Checked the FAQs on the message board for common solutions: https://discuss.atom.io/c/faq
-    * Checked that your issue isn't already filed: https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Aatom
-    * Checked that there is not already an Atom package that provides the described functionality: https://atom.io/packages
+- [ ] Put an X between the brackets on this line if you have done all of the following:
+  </summary>
+
+  * Reproduced the problem in Safe Mode: https://flight-manual.atom.io/hacking-atom/sections/debugging/#using-safe-mode
+  * Followed all applicable steps in the debugging guide: https://flight-manual.atom.io/hacking-atom/sections/debugging/
+  * Checked the FAQs on the message board for common solutions: https://discuss.atom.io/c/faq
+  * Checked that your issue isn't already filed: https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Aatom
+</details>
 
 ### Description
+<!-- Add a description of the issue you are facing. -->
 
-[Description of the issue]
 
 ### Steps to Reproduce
+<!-- Fill in the numbered steps below with the information required until issue you are reporting became apparent.
+You can add more steps as needed.  -->
+1.
+2.
+3.
 
-1. [First Step]
-2. [Second Step]
-3. [and so on...]
+**Expected behavior:** <!-- What did you expect to have happened -->
 
-**Expected behavior:** [What you expect to happen]
 
-**Actual behavior:** [What actually happens]
+**Actual behavior:** <!-- What actually happens -->
 
-**Reproduces how often:** [What percentage of the time does it reproduce?]
+
+**Reproduces how often:** <!-- What percentage of the time does it reproduce? -->
+
 
 ### Versions
+<!-- You can get this information from the copy and pasting of the output of `atom --version` and `apm --version` from the command line. Also, please include the OS and what version of the OS you're running. -->
 
-You can get this information from copy and pasting the output of `atom --version` and `apm --version` from the command line. Also, please include the OS and what version of the OS you're running.
 
 ### Additional Information
+<!-- Add any additional information, configuration or data that might be necessary to reproduce the issue. -->
 
-Any additional information, configuration or data that might be necessary to reproduce the issue.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,40 +1,46 @@
 <!--
-
 Have you read Atom's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/atom/atom/blob/master/CODE_OF_CONDUCT.md
 
 Do you want to ask a question? Are you looking for support? The Atom message board is the best place for getting support: https://discuss.atom.io
-
 -->
 
 ### Prerequisites
+<details>
+  <summary> Click to view prerequisites list.
 
 * [ ] Put an X between the brackets on this line if you have done all of the following:
-    * Reproduced the problem in Safe Mode: https://flight-manual.atom.io/hacking-atom/sections/debugging/#using-safe-mode
-    * Followed all applicable steps in the debugging guide: https://flight-manual.atom.io/hacking-atom/sections/debugging/
-    * Checked the FAQs on the message board for common solutions: https://discuss.atom.io/c/faq
-    * Checked that your issue isn't already filed: https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Aatom
-    * Checked that there is not already an Atom package that provides the described functionality: https://atom.io/packages
+  </summary>
+
+  * Reproduced the problem in Safe Mode: https://flight-manual.atom.io/hacking-atom/sections/debugging/#using-safe-mode
+  * Followed all applicable steps in the debugging guide: https://flight-manual.atom.io/hacking-atom/sections/debugging/
+  * Checked the FAQs on the message board for common solutions: https://discuss.atom.io/c/faq
+  * Checked that your issue isn't already filed: https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Aatom
+</details>
 
 ### Description
+<!-- Add a description of the issue you are facing. -->
 
-[Description of the issue]
 
 ### Steps to Reproduce
+<!-- Fill in the numbered steps below with the information required until issue you are reporting became apparent.
+You can add more steps as needed.  -->
+1.
+2.
+3.
 
-1. [First Step]
-2. [Second Step]
-3. [and so on...]
+**Expected behavior:** <!-- What did you expect to have happened -->
 
-**Expected behavior:** [What you expect to happen]
 
-**Actual behavior:** [What actually happens]
+**Actual behavior:** <!-- What actually happens -->
 
-**Reproduces how often:** [What percentage of the time does it reproduce?]
+
+**Reproduces how often:** <!-- What percentage of the time does it reproduce? -->
+
 
 ### Versions
+<!-- You can get this information from the copy and pasting of the output of `atom --version` and `apm --version` from the command line. Also, please include the OS and what version of the OS you're running. -->
 
-You can get this information from copy and pasting the output of `atom --version` and `apm --version` from the command line. Also, please include the OS and what version of the OS you're running.
 
 ### Additional Information
+<!-- Add any additional information, configuration or data that might be necessary to reproduce the issue. -->
 
-Any additional information, configuration or data that might be necessary to reproduce the issue.


### PR DESCRIPTION
<!--
Feature requests without these improvements show text like https://github.com/atom/atom/issues/17869

Bug reports look like this https://github.com/atom/atom/issues/17870
-->
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-->

It improves the section information explanations on what is expected from user to enter in each section and hides these explanations from the final post.
This prevents user from having to manually delete these areas or comment them out before hitting the create pull request or submit new issue buttons

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

Considered not having an expanded version in bug report file, but for the sake of clarity and actually making relevant information on the final post be as concise as possible opted by the version you see.

I considered further improving wording here but am waiting for some feedback which may may end up leading to that at a later time post review.

### Why Should This Be In Core?
<!-- Explain why this functionality should be in atom/atom as opposed to a package -->
An improvement to documentation should be part of repo.

### Benefits
<!-- What benefits will be realized by the code change? -->
issue and feature request templates currently show extraneous instructions iin open bug reports/feature request if a user does not delete them or comment them out as I did for this PR.
The benefits are three fold.

* user doesn't have to waste time removing or commenting out any extra information. 
* Improved conciseness of the final feature request or bug report  
* readers dont have to waste time skimming or reading irrelevant information and in case of bug reports any unfolded information is available at a click.


### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the code change? -->
None

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
-->

### Applicable Issues
<!-- Enter any applicable Issues here -->

* TL;DR shows relevant user submitted information only in all sections.

The benefits outlined above explain and help understand the current issues. 
However as someone who has done both feature requests and bug reports in atom project, I found the process overly convoluted of trying to follow the templates instructions and after posting I found there can be further improvements since these instructions were visible after posting.
I had to delete or comment out these instructions so the resulting report was as concise as should be.

So here is to helping others not having to worry about that and also help feature request and bug report reviewers dont have to read these extraneous portions.  