### PR TITLE
:arrow_up: electron@2.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "2.0.6",
+  "electronVersion": "2.0.7",
   "dependencies": {
     "@atom/nsfw": "^1.0.18",
     "@atom/source-map-support": "^0.3.4",


### PR DESCRIPTION
### Description of the Change

Release notes: https://github.com/electron/electron/releases/tag/v2.0.7

### Bug Fixes

* Fix handling SIGINT and SIGTERM in the Electron CLI helper. electron/electron#13888 
* Remove upstream code that used private Mac API. electron/electron#13919 
* Improve handling of `--enable-features` and `--disable-features`. electron/electron#13921 
* Fix some APIs modified for ASAR support couldn't be util.promisified. electron/electron#13960
* Prevent menu update while it's open. electron/electron#13966 
* Use unverified sync token in WebGL's DrawingBuffer. electron/electron#13919

### Verification Process

- [x] Green CI :green_apple: 
