### PR TITLE
Added word "want" in sentence

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -43,7 +43,7 @@ const schemaEnforcers = {}
 // ### Value Coercion
 //
 // Config settings each have a type specified by way of a
-// [schema](json-schema.org). For example we might an integer setting that only
+// [schema](json-schema.org). For example we might want an integer setting that only
 // allows integers greater than `0`:
 //
 // ```coffee


### PR DESCRIPTION
### Description of the Chang

I simply added the word "want" to the documentation for config document page.  The sentence seemed off.  This isn't a code-related fix, so I think most of the template of the pull request may not apply.