### PR TITLE
Better auto-indent for TextMate grammars

### DIFF
--- a/benchmarks/text-editor-autoindent.bench.js
+++ b/benchmarks/text-editor-autoindent.bench.js
@@ -1,0 +1,48 @@
+const {TextEditor, TextBuffer} = require('atom')
+module.exports = async ({test}) => {
+  const data = []
+  const workspaceElement = atom.workspace.getElement()
+  document.body.appendChild(workspaceElement)
+  atom.packages.loadPackages()
+  await atom.packages.activate()
+  console.log(atom.getLoadSettings().resourcePath);
+  for (let pane of atom.workspace.getPanes()) {
+    pane.destroy()
+  }
+  const stepSize = 1000
+  const minLines = 10
+  const maxLines = 10 * stepSize + minLines
+  const commentBodyLine = "Lorem ipsum dolor sit amet\n"
+  const commentBody = commentBodyLine.repeat(maxLines)
+  const commentStart = "/*\n"
+  const commentEnd = "*/\n"
+  const startContext = "switch (x) { case 0: ".repeat(12) + "\n"
+  const endContext = "}\n" + "}".repeat(11)
+  for (let numLines = maxLines; numLines >= minLines; numLines -= stepSize) {
+    let testCommentBody = commentBody.slice(0, numLines * commentBodyLine.length)
+    let comment = commentStart + testCommentBody + commentEnd
+    let text = startContext + comment + endContext
+    const buffer = new TextBuffer({text})
+    const editor = new TextEditor({buffer, autoHeight: false, largeFileMode: true})
+    atom.grammars.assignLanguageMode(buffer, "source.js")
+    atom.workspace.getActivePane().activateItem(editor)
+    let indentRow = editor.getLineCount() - 2
+    editor.setSelectedBufferRange([[indentRow, 0], [indentRow, Infinity]])
+    let t0 = window.performance.now()
+    editor.autoIndentSelectedRows()
+    let t1 = window.performance.now()
+    data.push({
+      name: 'Auto indenting with a lot of commented lines above',
+      x: numLines,
+      duration: t1 - t0
+    })
+    editor.destroy()
+    buffer.destroy()
+    await timeout(2000)
+  }
+  workspaceElement.remove()
+  return data
+}
+function timeout (duration) {
+  return new Promise((resolve) => setTimeout(resolve, duration))
+}

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -4743,6 +4743,18 @@ describe('TextEditor', () => {
           )
         })
 
+        describe('when pasting in a file with only comments above', () => {
+          it('auto-indents to 0', () => {
+            editor.setText('/**\n *\n */\n')
+            atom.clipboard.write('function foo() {\n\n}')
+
+            editor.setCursorBufferPosition([3, 0])
+            editor.pasteText()
+            expect(editor.lineTextForBufferRow(3)).toBe('function foo() {')
+            expect(editor.lineTextForBufferRow(5)).toBe('}')
+          })
+        })
+
         describe('when `autoIndentOnPaste` is false', () => {
           beforeEach(() => editor.update({autoIndentOnPaste: false}))
 

--- a/src/text-mate-language-mode.js
+++ b/src/text-mate-language-mode.js
@@ -152,8 +152,6 @@ class TextMateLanguageMode {
     if (currentRow === 0) return null
 
     let activeRow = currentRow - 1
-
-    let seenNonBlankRow = false;
     let firstNonBlankRow = currentRow
 
     const lowerBound = Math.max(0, currentRow - 1000)

--- a/src/text-mate-language-mode.js
+++ b/src/text-mate-language-mode.js
@@ -171,6 +171,8 @@ class TextMateLanguageMode {
       }
     }
 
+    if (activeRow === -1) return 0
+
     return firstNonBlankRow === currentRow ? this.buffer.previousNonBlankRow(activeRow) : firstNonBlankRow
   }
 

--- a/src/text-mate-language-mode.js
+++ b/src/text-mate-language-mode.js
@@ -171,7 +171,7 @@ class TextMateLanguageMode {
       }
     }
 
-    if (activeRow === -1) return 0
+    if (activeRow === -1) return 0 
 
     return firstNonBlankRow === currentRow ? this.buffer.previousNonBlankRow(activeRow) : firstNonBlankRow
   }

--- a/src/text-mate-language-mode.js
+++ b/src/text-mate-language-mode.js
@@ -127,10 +127,10 @@ class TextMateLanguageMode {
 
     if (!decreaseIndentRegex.testSync(line)) return
 
-    const precedingRow = this.buffer.previousNonBlankRow(bufferRow)
+    let precedingRow = this.getPrecedingIndentRow(bufferRow)
     if (precedingRow == null) return
+    let precedingLine = this.buffer.lineForRow(precedingRow)
 
-    const precedingLine = this.buffer.lineForRow(precedingRow)
     let desiredIndentLevel = this.indentLevelForLine(precedingLine, tabLength)
 
     const increaseIndentRegex = this.increaseIndentRegexForScopeDescriptor(scopeDescriptor)
@@ -148,6 +148,17 @@ class TextMateLanguageMode {
     return desiredIndentLevel
   }
 
+  getPrecedingIndentRow (currentRow) {
+    let activeRow = currentRow
+    while (activeRow > 0) {
+      activeRow -= 1
+      if (!this.isRowCommented(activeRow) && !this.buffer.isRowBlank(activeRow)) {
+        return activeRow
+      }
+    }
+    return null
+  }
+
   _suggestedIndentForLineWithScopeAtBufferRow (bufferRow, line, scopeDescriptor, tabLength, options) {
     const increaseIndentRegex = this.increaseIndentRegexForScopeDescriptor(scopeDescriptor)
     const decreaseIndentRegex = this.decreaseIndentRegexForScopeDescriptor(scopeDescriptor)
@@ -155,7 +166,7 @@ class TextMateLanguageMode {
 
     let precedingRow
     if (!options || options.skipBlankLines !== false) {
-      precedingRow = this.buffer.previousNonBlankRow(bufferRow)
+      precedingRow = this.getPrecedingIndentRow(bufferRow)
       if (precedingRow == null) return 0
     } else {
       precedingRow = bufferRow - 1

--- a/src/text-mate-language-mode.js
+++ b/src/text-mate-language-mode.js
@@ -171,7 +171,7 @@ class TextMateLanguageMode {
       }
     }
 
-    if (activeRow === -1) return 0 
+    if (activeRow === -1) return 0
 
     return firstNonBlankRow === currentRow ? this.buffer.previousNonBlankRow(activeRow) : firstNonBlankRow
   }

--- a/src/text-mate-language-mode.js
+++ b/src/text-mate-language-mode.js
@@ -149,14 +149,31 @@ class TextMateLanguageMode {
   }
 
   getPrecedingIndentRow (currentRow) {
-    let activeRow = currentRow
-    while (activeRow > 0) {
-      activeRow -= 1
+    if (currentRow === 0) return null
+
+    let activeRow = currentRow - 1
+
+    let seenNonBlankRow = false;
+    let firstNonBlankRow = currentRow
+
+    const lowerBound = Math.max(0, currentRow - 1000)
+    for (; activeRow >= lowerBound; activeRow--) {
+      if (!this.buffer.isRowBlank(activeRow)) {
+        if (!this.isRowCommented(activeRow)) {
+          return activeRow
+        }
+        firstNonBlankRow = activeRow
+        break
+      }
+    }
+
+    for (; activeRow >= lowerBound; activeRow--) {
       if (!this.isRowCommented(activeRow) && !this.buffer.isRowBlank(activeRow)) {
         return activeRow
       }
     }
-    return null
+
+    return firstNonBlankRow === currentRow ? this.buffer.previousNonBlankRow(activeRow) : firstNonBlankRow
   }
 
   _suggestedIndentForLineWithScopeAtBufferRow (bufferRow, line, scopeDescriptor, tabLength, options) {

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -1219,7 +1219,8 @@ function hasMatchingFoldSpec (specs, node) {
   'decreaseIndentRegexForScopeDescriptor',
   'decreaseNextIndentRegexForScopeDescriptor',
   'regexForPattern',
-  'getNonWordCharacters'
+  'getNonWordCharacters',
+  'getPrecedingIndentRow'
 ].forEach(methodName => {
   TreeSitterLanguageMode.prototype[methodName] = TextMateLanguageMode.prototype[methodName]
 })


### PR DESCRIPTION
### Description of the Change

Makes auto-indent skip over lines that start with a comment, so they do not interfere.

### Alternate Designs

I considered going through the tags of each line manually, which would allow better handling of the following:
```
stuff
           /* comment */ if (true) {
}          }
|          ^ we technically want it here
^ it will actually go here
```
This happens because the line we wanted to align with starts with a comment, so we skip over it with the current implementation. However, checking tokens would be a lot more work, and we don't get the caching for free like we do with `isCommented()`. Plus, Tree-sitter can give us the corresponding line directly, so this is only needed while TextMate grammars are still widely used.

### Why Should This Be In Core?

Is core mechanic

### Benefits

Fixes bad auto-indenting with things like
```
class MyClass {
    public void myMethod() {
        if (true) {

        // A comment <- originally used as line to align with; now ignored
        } else if (/* type something here */) {

        }
    }
}
```

### Possible Drawbacks

The check is _slightly_ slower when many comments are present, but only for the very first run. Subsequent runs cache whether lines are commented, so performance is nearly identical to the original. (benchmarks to be added)

### Verification Process

Manually (tests to be added?) with above example code, and file with 10 000 consecutive comment lines above an auto-indenting line.

### Applicable Issues

Fixes #17364