### PR TITLE
Fix missing READMEs on core package detail pages

### DIFF
--- a/script/lib/include-path-in-packaged-app.js
+++ b/script/lib/include-path-in-packaged-app.js
@@ -68,7 +68,6 @@ const EXCLUDE_REGEXPS_SOURCES = [
   // Ignore node_module files we won't need at runtime
   'node_modules' + escapeRegExp(path.sep) + '.*' + escapeRegExp(path.sep) + '_*te?sts?_*' + escapeRegExp(path.sep),
   'node_modules' + escapeRegExp(path.sep) + '.*' + escapeRegExp(path.sep) + 'examples?' + escapeRegExp(path.sep),
-  'node_modules' + escapeRegExp(path.sep) + '.*' + '\\.md$',
   'node_modules' + escapeRegExp(path.sep) + '.*' + '\\.d\\.ts$',
   'node_modules' + escapeRegExp(path.sep) + '.*' + '\\.js\\.map$',
   '.*' + escapeRegExp(path.sep) + 'test.*\\.html$'


### PR DESCRIPTION
### Description of the Change

This change fixes atom/settings-view#1069 which reports that README file information is no longer displayed on core package detail pages in the Settings view, like that of the About package.  It turns out that this issue was introduced in Atom 1.21.0 by the reintroduction of ASAR packaging (https://github.com/atom/atom/pull/14682).  When we package Atom's `node_modules` folder into the ASAR file, we exclude files with certain file extensions:

https://github.com/atom/atom/blob/f922b7bd9103f0598c0059b0ddc856757e0fd4a0/script/lib/include-path-in-packaged-app.js#L71

This change removes the exclusion of `.md` files from the ASAR files so that README.md and LICENSE.md files are now available for the package details page to display.

### Alternate Designs

README information is read from README.md files contained within package folders so this is the only solution.

### Why Should This Be In Core?

It affects how core package details are displayed in 

### Benefits

READMEs for for core Atom packages are now displayed in the Settings view.

### Possible Drawbacks

Marginally increased ASAR size by including core package `.md` files.

### Verification Process

- [x] Verify that README for core packages are now visible after this change
- [x] Verify that license details for core package are displayed after this change

Screenshot of `about` package README displayed in Atom after this change:

![image](https://user-images.githubusercontent.com/79405/44179277-f62f9c80-a0aa-11e8-8ac0-4dbb2ed7aa00.png)

### Applicable Issues

https://github.com/atom/settings-view/issues/1069
