### PR TITLE
During quit, close unloaded windows

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -437,7 +437,14 @@ class AtomApplication extends EventEmitter {
       if (!this.quitting) {
         this.quitting = true
         event.preventDefault()
-        const windowUnloadPromises = this.getAllWindows().map(window => window.prepareToUnload())
+        const windowUnloadPromises = this.getAllWindows().map(async window => {
+          const unloaded = await window.prepareToUnload()
+          if (unloaded) {
+            window.close()
+            await window.closedPromise
+          }
+          return unloaded
+        })
         const windowUnloadedResults = await Promise.all(windowUnloadPromises)
         if (windowUnloadedResults.every(Boolean)) {
           app.quit()


### PR DESCRIPTION
### Description of the Change

When quitting the app (e.g. by Cmd-Q on macOS), in `before-quit` Atom asks each open window to unload. Any one of them can resolve the promise with `false` (e.g. because user realized they didn't want to quit and hit Cancel on unsaved changes dialog), which stops the app from quitting.

When some of the windows end up unloading successfully, but the quit is stopped this way, these windows stay open, left in a weird unloaded state (Atom expects them to ultimately get closed by a quit, which doesn't happen). This adds logic to immediately close windows after they are successfully unloaded during a quit.

### Alternate Designs

We could close the window in `prepareToUnload()`? We'd need to check that this makes sense for all callsites.

### Why Should This Be In Core?

It's a bugfix.

### Benefits

1. No unloaded windows after an interrupted quit.
2. Windows get closed as soon as they are unloaded - even during a successful quit, you could see the unloaded UI if one window's unload is significantly slower than others'.

### Possible Drawbacks

State restoration on other platforms? Everything worked fine in my testing on macOS.

### Verification Process

1. Added a test.
2. Had 2 windows, hit Cmd-Q. Window A returned `false` from `prepareToUnload()`. Window B still closed.

### Applicable Issues

Don't know.