### PR TITLE
Allow nightly releases to auto-update

### DIFF
--- a/src/main-process/auto-update-manager.coffee
+++ b/src/main-process/auto-update-manager.coffee
@@ -94,7 +94,7 @@ class AutoUpdateManager
   scheduleUpdateCheck: ->
     # Only schedule update check periodically if running in release version and
     # and there is no existing scheduled update check.
-    unless /\w{7}/.test(@version) or @checkForUpdatesIntervalID
+    unless /-dev/.test(@version) or @checkForUpdatesIntervalID
       checkForUpdates = => @check(hidePopups: true)
       fourHours = 1000 * 60 * 60 * 4
       @checkForUpdatesIntervalID = setInterval(checkForUpdates, fourHours)


### PR DESCRIPTION
### Description of the Change

This change removes a bad version check which prevented nightly releases to be considered for auto-update checks.  The fix is to only skip auto-updates when using a build with a version containing `-dev`.

### Alternate Designs

Could have used a more elaborate version check but this simple check accomplishes all of that just by turning off auto-updates for `-dev-*` versions.

### Why Should This Be In Core?

This is a fix for auto-update behavior in Atom Nightly releases.

### Benefits

Nightly releases will now automatically check for updates.

### Possible Drawbacks

None that I know of.

### Verification Process

- [x] Ensure that an Atom Dev build does not check for updates automatically (it should report that updates are not possible in the About page)
- [x] Build a fake Nightly build and test it on macOS to see if it checks for updates automatically when Atom starts up

### Applicable Issues

Fixes #17885
