### PR TITLE
Fix error when launching graphical spec runner

### DIFF
--- a/src/main-process/get-dev-resource-path.js
+++ b/src/main-process/get-dev-resource-path.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const path = require('path')
+const fs = require('fs-plus')
+const CSON = require('season')
+const electron = require('electron')
+
+module.exports = function () {
+  const appResourcePath = path.dirname(path.dirname(__dirname))
+  const defaultRepositoryPath = path.join(electron.app.getPath('home'), 'github', 'atom')
+
+  if (process.env.ATOM_DEV_RESOURCE_PATH) {
+    return process.env.ATOM_DEV_RESOURCE_PATH
+  } else if (isAtomRepoPath(process.cwd())) {
+    return process.cwd()
+  } else if (fs.statSyncNoException(defaultRepositoryPath)) {
+    return defaultRepositoryPath
+  }
+
+  return appResourcePath
+}
+
+function isAtomRepoPath (repoPath) {
+  let packageJsonPath = path.join(repoPath, 'package.json')
+  if (fs.statSyncNoException(packageJsonPath)) {
+    let packageJson = CSON.readFileSync(packageJsonPath)
+    return packageJson.name === 'atom'
+  }
+
+  return false
+}

--- a/src/main-process/main.js
+++ b/src/main-process/main.js
@@ -5,10 +5,8 @@ if (typeof snapshotResult !== 'undefined') {
 const startTime = Date.now()
 
 const path = require('path')
-const fs = require('fs-plus')
-const CSON = require('season')
 const yargs = require('yargs')
-const electron = require('electron')
+const getDevResourcePath = require('./get-dev-resource-path')
 
 const args =
   yargs(process.argv)
@@ -16,34 +14,14 @@ const args =
     .alias('t', 'test')
     .argv
 
-function isAtomRepoPath (repoPath) {
-  let packageJsonPath = path.join(repoPath, 'package.json')
-  if (fs.statSyncNoException(packageJsonPath)) {
-    let packageJson = CSON.readFileSync(packageJsonPath)
-    return packageJson.name === 'atom'
-  }
-
-  return false
-}
-
 let resourcePath
 
 if (args.resourcePath) {
   resourcePath = args.resourcePath
 } else {
   const stableResourcePath = path.dirname(path.dirname(__dirname))
-  const defaultRepositoryPath = path.join(electron.app.getPath('home'), 'github', 'atom')
-
   if (args.dev || args.test || args.benchmark || args.benchmarkTest) {
-    if (process.env.ATOM_DEV_RESOURCE_PATH) {
-      resourcePath = process.env.ATOM_DEV_RESOURCE_PATH
-    } else if (isAtomRepoPath(process.cwd())) {
-      resourcePath = process.cwd()
-    } else if (fs.statSyncNoException(defaultRepositoryPath)) {
-      resourcePath = defaultRepositoryPath
-    } else {
-      resourcePath = stableResourcePath
-    }
+    resourcePath = getDevResourcePath() || stableResourcePath
   } else {
     resourcePath = stableResourcePath
   }

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -5,8 +5,9 @@ const yargs = require('yargs')
 const {app} = require('electron')
 const path = require('path')
 const fs = require('fs-plus')
+const getDevResourcePath = require('./get-dev-resource-path')
 
-module.exports = function parseCommandLine (processArgs, initialResourcePath) {
+module.exports = function parseCommandLine (processArgs) {
   const options = yargs(processArgs).wrap(yargs.terminalWidth())
   const version = app.getVersion()
   options.usage(
@@ -119,7 +120,7 @@ module.exports = function parseCommandLine (processArgs, initialResourcePath) {
   let pathsToOpen = []
   let urlsToOpen = []
   let devMode = args['dev']
-  let devResourcePath = initialResourcePath
+  let devResourcePath = getDevResourcePath()
   let resourcePath = null
 
   for (const path of args._) {

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -7,7 +7,7 @@ const path = require('path')
 const fs = require('fs-plus')
 const getDevResourcePath = require('./get-dev-resource-path')
 
-module.exports = function parseCommandLine (processArgs) {
+module.exports = function parseCommandLine (processArgs, initialResourcePath) {
   const options = yargs(processArgs).wrap(yargs.terminalWidth())
   const version = app.getVersion()
   options.usage(
@@ -120,7 +120,7 @@ module.exports = function parseCommandLine (processArgs) {
   let pathsToOpen = []
   let urlsToOpen = []
   let devMode = args['dev']
-  let devResourcePath = getDevResourcePath()
+  let devResourcePath = initialResourcePath || getDevResourcePath()
   let resourcePath = null
 
   for (const path of args._) {

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -9,7 +9,7 @@ const fs = require('fs')
 const CSON = require('season')
 const Config = require('../config')
 
-module.exports = function start (resourcePath, startTime) {
+module.exports = function start (initialResourcePath, startTime) {
   global.shellStartTime = startTime
 
   process.on('uncaughtException', function (error = {}) {
@@ -37,7 +37,7 @@ module.exports = function start (resourcePath, startTime) {
 
   app.commandLine.appendSwitch('enable-experimental-web-platform-features')
 
-  const args = parseCommandLine(process.argv.slice(1))
+  const args = parseCommandLine(process.argv.slice(1), initialResourcePath)
   atomPaths.setAtomHome(app.getPath('home'))
   atomPaths.setUserData(app)
   setupCompileCache()

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -9,7 +9,7 @@ const fs = require('fs')
 const CSON = require('season')
 const Config = require('../config')
 
-module.exports = function start (initialResourcePath, startTime) {
+module.exports = function start (resourcePath, startTime) {
   global.shellStartTime = startTime
 
   process.on('uncaughtException', function (error = {}) {
@@ -37,7 +37,7 @@ module.exports = function start (initialResourcePath, startTime) {
 
   app.commandLine.appendSwitch('enable-experimental-web-platform-features')
 
-  const args = parseCommandLine(process.argv.slice(1), initialResourcePath)
+  const args = parseCommandLine(process.argv.slice(1))
   atomPaths.setAtomHome(app.getPath('home'))
   atomPaths.setUserData(app)
   setupCompileCache()


### PR DESCRIPTION
### Description of the Change

This change fixes an issue introduced by PR #17892 which caused Atom's graphical spec runner to stop working.  This was caused by a simplification of dev resource path detection logic which left a couple of code paths lacking a proper resource path.  The solution in this PR is to roll back that change and introduce a simpler change which achieves the same benefits without the aforementioned issue.