### PR TITLE
Support custom test runner environment variables

### DIFF
--- a/spec/workspace-element-spec.js
+++ b/spec/workspace-element-spec.js
@@ -895,27 +895,39 @@ describe('WorkspaceElement', () => {
 
       // No active item. Use first project directory.
       atom.commands.dispatch(workspaceElement, 'window:run-package-specs')
-      expect(ipcRenderer.send).toHaveBeenCalledWith('run-package-specs', path.join(projectPaths[0], 'spec'))
+      expect(ipcRenderer.send).toHaveBeenCalledWith('run-package-specs', path.join(projectPaths[0], 'spec'), {})
       ipcRenderer.send.reset()
 
       // Active item doesn't implement ::getPath(). Use first project directory.
       const item = document.createElement('div')
       atom.workspace.getActivePane().activateItem(item)
       atom.commands.dispatch(workspaceElement, 'window:run-package-specs')
-      expect(ipcRenderer.send).toHaveBeenCalledWith('run-package-specs', path.join(projectPaths[0], 'spec'))
+      expect(ipcRenderer.send).toHaveBeenCalledWith('run-package-specs', path.join(projectPaths[0], 'spec'), {})
       ipcRenderer.send.reset()
 
       // Active item has no path. Use first project directory.
       item.getPath = () => null
       atom.commands.dispatch(workspaceElement, 'window:run-package-specs')
-      expect(ipcRenderer.send).toHaveBeenCalledWith('run-package-specs', path.join(projectPaths[0], 'spec'))
+      expect(ipcRenderer.send).toHaveBeenCalledWith('run-package-specs', path.join(projectPaths[0], 'spec'), {})
       ipcRenderer.send.reset()
 
       // Active item has path. Use project path for item path.
       item.getPath = () => path.join(projectPaths[1], 'a-file.txt')
       atom.commands.dispatch(workspaceElement, 'window:run-package-specs')
-      expect(ipcRenderer.send).toHaveBeenCalledWith('run-package-specs', path.join(projectPaths[1], 'spec'))
+      expect(ipcRenderer.send).toHaveBeenCalledWith('run-package-specs', path.join(projectPaths[1], 'spec'), {})
       ipcRenderer.send.reset()
+    })
+
+    it("passes additional options to the spec window", () => {
+      const workspaceElement = atom.workspace.getElement()
+      spyOn(ipcRenderer, 'send')
+
+      const projectPath = temp.mkdirSync('dir1-')
+      atom.project.setPaths([projectPath])
+      workspaceElement.runPackageSpecs({env: {ATOM_GITHUB_BABEL_ENV: 'coverage'}})
+
+      expect(ipcRenderer.send).toHaveBeenCalledWith(
+        'run-package-specs', path.join(projectPath, 'spec'), {env: {ATOM_GITHUB_BABEL_ENV: 'coverage'}})
     })
   })
 })

--- a/src/initialize-test-window.coffee
+++ b/src/initialize-test-window.coffee
@@ -24,9 +24,13 @@ module.exports = ({blobStore}) ->
     ApplicationDelegate = require '../src/application-delegate'
     Clipboard = require '../src/clipboard'
     TextEditor = require '../src/text-editor'
+    {updateProcessEnv} = require('./update-process-env')
     require './electron-shims'
 
-    {testRunnerPath, legacyTestRunnerPath, headless, logFile, testPaths} = getWindowLoadSettings()
+    ipcRenderer.on 'environment', (event, env) ->
+      updateProcessEnv(env)
+
+    {testRunnerPath, legacyTestRunnerPath, headless, logFile, testPaths, env} = getWindowLoadSettings()
 
     unless headless
       # Show window synchronously so a focusout doesn't fire on input elements
@@ -58,6 +62,8 @@ module.exports = ({blobStore}) ->
     exportsPath = path.join(getWindowLoadSettings().resourcePath, 'exports')
     require('module').globalPaths.push(exportsPath)
     process.env.NODE_PATH = exportsPath # Set NODE_PATH env variable since tasks may need it.
+
+    updateProcessEnv(env)
 
     # Set up optional transpilation for packages under test if any
     FindParentDir = require 'find-parent-dir'

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -1168,6 +1168,7 @@ class AtomApplication extends EventEmitter {
       env
     })
     this.addWindow(window)
+    if (env) window.replaceEnvironment(env)
     return window
   }
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -511,11 +511,12 @@ class AtomApplication extends EventEmitter {
       if (this.applicationMenu) this.applicationMenu.update(window, template, menu)
     }))
 
-    this.disposable.add(ipcHelpers.on(ipcMain, 'run-package-specs', (event, packageSpecPath) => {
+    this.disposable.add(ipcHelpers.on(ipcMain, 'run-package-specs', (event, packageSpecPath, options = {}) => {
       this.runTests({
         resourcePath: this.devResourcePath,
         pathsToOpen: [packageSpecPath],
-        headless: false
+        headless: false,
+        ...options
       })
     }))
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -512,12 +512,11 @@ class AtomApplication extends EventEmitter {
     }))
 
     this.disposable.add(ipcHelpers.on(ipcMain, 'run-package-specs', (event, packageSpecPath, options = {}) => {
-      this.runTests({
+      this.runTests(Object.assign({
         resourcePath: this.devResourcePath,
         pathsToOpen: [packageSpecPath],
-        headless: false,
-        ...options
-      })
+        headless: false
+      }, options))
     }))
 
     this.disposable.add(ipcHelpers.on(ipcMain, 'run-benchmarks', (event, benchmarksPath) => {

--- a/src/workspace-element.js
+++ b/src/workspace-element.js
@@ -310,7 +310,7 @@ class WorkspaceElement extends HTMLElement {
     }
   }
 
-  runPackageSpecs () {
+  runPackageSpecs (options = {}) {
     const activePaneItem = this.model.getActivePaneItem()
     const activePath = activePaneItem && typeof activePaneItem.getPath === 'function' ? activePaneItem.getPath() : null
     let projectPath
@@ -326,7 +326,7 @@ class WorkspaceElement extends HTMLElement {
         specPath = testPath
       }
 
-      ipcRenderer.send('run-package-specs', specPath)
+      ipcRenderer.send('run-package-specs', specPath, options)
     }
   }
 


### PR DESCRIPTION
To generate Istanbul test coverage data for atom/github from the graphical test runner, we need to have `ATOM_GITHUB_BABEL_ENV` set to `"coverage". This activates a Babel environment that includes "babel-plugin-istanbul" that installs instrumentation into the transpiled source. But, we can't have it set when launching Atom, because the version of atom/github that's bundled with Atom (or, in my case, installed in `~/.atom/packages`) doesn't include the plugin, which is a devDependency.

We wouldn't want to activate it for the github package in the host Atom environment, anyway, because the instrumentation has a pretty significant performance cost.

I'm adding an optional parameter to `WorkspaceElement::runPackageSpecs()` that's eventually used to initialize the `AtomWindow`. I've also added some code within the test window to pick up and install the environment before running transpilers or anything from the package source.

Here's how I'm using this in my `init.js`:

```js
atom.commands.add('me:run-package-specs', () => {
  atom.workspace.getElement().runPackageSpecs({
    env: Object.assign({}, process.env, {ATOM_GITHUB_BABEL_ENV: 'coverage'})
  })
})
```

/cc @annthurium @kuychaco 