### PR TITLE
Always provide a devResourcePath in load settings

### DIFF
--- a/src/main-process/main.js
+++ b/src/main-process/main.js
@@ -14,6 +14,7 @@ const args =
   yargs(process.argv)
     .alias('d', 'dev')
     .alias('t', 'test')
+    .alias('r', 'resource-path')
     .argv
 
 function isAtomRepoPath (repoPath) {

--- a/src/main-process/main.js
+++ b/src/main-process/main.js
@@ -27,27 +27,31 @@ function isAtomRepoPath (repoPath) {
 }
 
 let resourcePath
+let devResourcePath
 
 if (args.resourcePath) {
   resourcePath = args.resourcePath
+  devResourcePath = resourcePath
 } else {
   const stableResourcePath = path.dirname(path.dirname(__dirname))
   const defaultRepositoryPath = path.join(electron.app.getPath('home'), 'github', 'atom')
 
+  if (process.env.ATOM_DEV_RESOURCE_PATH) {
+    devResourcePath = process.env.ATOM_DEV_RESOURCE_PATH
+  } else if (isAtomRepoPath(process.cwd())) {
+    devResourcePath = process.cwd()
+  } else if (fs.statSyncNoException(defaultRepositoryPath)) {
+    devResourcePath = defaultRepositoryPath
+  } else {
+    devResourcePath = stableResourcePath
+  }
+
   if (args.dev || args.test || args.benchmark || args.benchmarkTest) {
-    if (process.env.ATOM_DEV_RESOURCE_PATH) {
-      resourcePath = process.env.ATOM_DEV_RESOURCE_PATH
-    } else if (isAtomRepoPath(process.cwd())) {
-      resourcePath = process.cwd()
-    } else if (fs.statSyncNoException(defaultRepositoryPath)) {
-      resourcePath = defaultRepositoryPath
-    } else {
-      resourcePath = stableResourcePath
-    }
+    resourcePath = devResourcePath
   } else {
     resourcePath = stableResourcePath
   }
 }
 
 const start = require(path.join(resourcePath, 'src', 'main-process', 'start'))
-start(resourcePath, startTime)
+start(resourcePath, devResourcePath, startTime)

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -6,7 +6,7 @@ const {app} = require('electron')
 const path = require('path')
 const fs = require('fs-plus')
 
-module.exports = function parseCommandLine (processArgs, initialResourcePath) {
+module.exports = function parseCommandLine (processArgs, resourcePath, devResourcePath) {
   const options = yargs(processArgs).wrap(yargs.terminalWidth())
   const version = app.getVersion()
   options.usage(
@@ -119,8 +119,6 @@ module.exports = function parseCommandLine (processArgs, initialResourcePath) {
   let pathsToOpen = []
   let urlsToOpen = []
   let devMode = args['dev']
-  let devResourcePath = initialResourcePath
-  let resourcePath = null
 
   for (const path of args._) {
     if (path.startsWith('atom://')) {
@@ -130,21 +128,8 @@ module.exports = function parseCommandLine (processArgs, initialResourcePath) {
     }
   }
 
-  if (args['resource-path']) {
+  if (args['resource-path'] || test) {
     devMode = true
-    devResourcePath = args['resource-path']
-  }
-
-  if (test) {
-    devMode = true
-  }
-
-  if (devMode) {
-    resourcePath = devResourcePath
-  }
-
-  if (!fs.statSyncNoException(resourcePath)) {
-    resourcePath = path.dirname(path.dirname(__dirname))
   }
 
   if (args['path-environment']) {

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -3,10 +3,8 @@
 const dedent = require('dedent')
 const yargs = require('yargs')
 const {app} = require('electron')
-const path = require('path')
-const fs = require('fs-plus')
 
-module.exports = function parseCommandLine (processArgs, resourcePath, devResourcePath) {
+module.exports = function parseCommandLine (processArgs) {
   const options = yargs(processArgs).wrap(yargs.terminalWidth())
   const version = app.getVersion()
   options.usage(
@@ -128,7 +126,7 @@ module.exports = function parseCommandLine (processArgs, resourcePath, devResour
     }
   }
 
-  if (args['resource-path'] || test) {
+  if (args.resourcePath || test) {
     devMode = true
   }
 
@@ -138,12 +136,7 @@ module.exports = function parseCommandLine (processArgs, resourcePath, devResour
     process.env.PATH = args['path-environment']
   }
 
-  resourcePath = normalizeDriveLetterName(resourcePath)
-  devResourcePath = normalizeDriveLetterName(devResourcePath)
-
   return {
-    resourcePath,
-    devResourcePath,
     pathsToOpen,
     urlsToOpen,
     executedFrom,
@@ -164,13 +157,5 @@ module.exports = function parseCommandLine (processArgs, resourcePath, devResour
     benchmark,
     benchmarkTest,
     env: process.env
-  }
-}
-
-function normalizeDriveLetterName (filePath) {
-  if (process.platform === 'win32' && filePath) {
-    return filePath.replace(/^([a-z]):/, ([driveLetter]) => driveLetter.toUpperCase() + ':')
-  } else {
-    return filePath
   }
 }

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -9,7 +9,7 @@ const fs = require('fs')
 const CSON = require('season')
 const Config = require('../config')
 
-module.exports = function start (initialResourcePath, startTime) {
+module.exports = function start (resourcePath, devResourcePath, startTime) {
   global.shellStartTime = startTime
 
   process.on('uncaughtException', function (error = {}) {
@@ -37,7 +37,7 @@ module.exports = function start (initialResourcePath, startTime) {
 
   app.commandLine.appendSwitch('enable-experimental-web-platform-features')
 
-  const args = parseCommandLine(process.argv.slice(1), initialResourcePath)
+  const args = parseCommandLine(process.argv.slice(1), resourcePath, devResourcePath)
   atomPaths.setAtomHome(app.getPath('home'))
   atomPaths.setUserData(app)
   setupCompileCache()

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -37,7 +37,10 @@ module.exports = function start (resourcePath, devResourcePath, startTime) {
 
   app.commandLine.appendSwitch('enable-experimental-web-platform-features')
 
-  const args = parseCommandLine(process.argv.slice(1), resourcePath, devResourcePath)
+  const args = parseCommandLine(process.argv.slice(1))
+  args.resourcePath = normalizeDriveLetterName(resourcePath)
+  args.devResourcePath = normalizeDriveLetterName(devResourcePath)
+
   atomPaths.setAtomHome(app.getPath('home'))
   atomPaths.setUserData(app)
   setupCompileCache()
@@ -123,4 +126,12 @@ function getConfig () {
   }
 
   return config
+}
+
+function normalizeDriveLetterName (filePath) {
+  if (process.platform === 'win32' && filePath) {
+    return filePath.replace(/^([a-z]):/, ([driveLetter]) => driveLetter.toUpperCase() + ':')
+  } else {
+    return filePath
+  }
 }


### PR DESCRIPTION
### Description of the Change

This change fixes an issue introduced by PR #17892 which caused Atom's graphical spec runner to stop working. This was caused by a simplification of dev resource path detection logic which left a couple of code paths lacking a proper dev resource path. The solution in this PR is to always add a `devResourcePath` property to the load settings object that gets created when Atom starts up.

### Verification Process

Same verification steps as #17892:

- [x] `atom --dev .` uses `ATOM_DEV_RESOURCE_PATH` if one is set
- [x] `atom --dev .` in Atom repo path uses current directory as dev resource path when there is no `ATOM_DEV_RESOURCE_PATH` set and the current directory appears to be a clone of `atom/atom`
- [x] `atom --dev .` uses `~/github/atom` as the dev resource path if it exists and none of the path sources above are present
- [x] `atom --dev .` uses its bundled resource path when none of the path sources above are present
- [x] `atom -r path/to/atom` overrides all other possible resource path sources

Also validating the following two cases for each of the above items:

- [x] Package specs for settings-view run successfully
- [x] Opening Settings view and navigating to Packages tab does not throw an error about missing dependency module