### PR TITLE
Minify the startup snapshot script with terser

### DIFF
--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -9926,6 +9926,32 @@
         }
       }
     },
+    "terser": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.8.1.tgz",
+      "integrity": "sha512-FRin3gKQ0vm0xPPLuxw1FqpVgv1b2pBpYCaFb5qe6A7sD749Fnq1VbDiX3CEFM0BV0fqDzFtBfgmxhxCdzKQIg==",
+      "requires": {
+        "commander": "~2.16.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.6"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-support": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",

--- a/script/package.json
+++ b/script/package.json
@@ -37,6 +37,7 @@
     "stylelint-config-standard": "^18.1.0",
     "sync-request": "3.0.1",
     "tello": "1.0.7",
+    "terser": "^3.8.1",
     "webdriverio": "2.4.5",
     "yargs": "4.8.1"
   }


### PR DESCRIPTION
### Background

I was just looking at a heap snapshot in Atom and I noticed something striking - over a third of the memory allocated on V8's heap is due to a single `script` object: Atom's concatenated startup script.

In particular, the script retains a reference to its source code as a string, which consumes around 45MB of RAM:

<img width="1042" alt="screen shot 2018-08-24 at 5 08 19 pm" src="https://user-images.githubusercontent.com/326587/44612839-c70ede80-a7c0-11e8-987d-3989a4c5debb.png">

In addition, the script maintains an array of `line ends`, which I assume V8 uses for computing stack traces. This consumes almost 3MB.

<img width="1042" alt="screen shot 2018-08-24 at 5 08 37 pm" src="https://user-images.githubusercontent.com/326587/44612844-da21ae80-a7c0-11e8-92df-76c892783a7c.png">

### Proposed Change

In this PR, I minify the startup script that `electron-link` generates using [`terser`](https://github.com/fabiosantoscode/terser#mangle-properties-options) (a fork of uglify that works with es6).

### Results

When I compute a heap snapshot after minification, the startup script's `source` now consumes only 16MB on the heap, and its `line ends` no longer shows up in the snapshot (there are no line endings any more).

To get a sense of the overall impact, I rebuilt `Atom Dev` with this change and ran it simultaneously with the most recent `Atom Beta`. In each case, I opened one file in the `atom/atom` repo. When all is said and done, it looks like this reduces our memory consumption by **45 MB per window**, and the same amount in the main process!

<img width="267" alt="screen shot 2018-08-24 at 5 20 53 pm" src="https://user-images.githubusercontent.com/326587/44612965-228d9c00-a7c2-11e8-859a-c2594aa34aad.png">

### Drawbacks

The minification step does take some time. It adds 10 - 20 seconds to the build.