### PR TITLE
Only update window title from center pane

### DIFF
--- a/src/workspace.js
+++ b/src/workspace.js
@@ -555,7 +555,7 @@ module.exports = class Workspace extends Model {
     const appName = 'Atom'
     const left = this.project.getPaths()
     const projectPaths = left != null ? left : []
-    const item = this.getActivePaneItem()
+    const item = this.getCenter().getActivePaneItem()
     if (item) {
       itemPath = typeof item.getPath === 'function' ? item.getPath() : undefined
       const longTitle = typeof item.getLongTitle === 'function' ? item.getLongTitle() : undefined


### PR DESCRIPTION
When multiple projects are opened simultaneously, users will see an incorrect title bar when they focus on side panes such as "Diagnostics". Users expect to see the correct project and file path in the title bar. Instead, the users only ever see the first project name when they focus on side panes. 

For example, user has project "alpha" and "beta" open simultaneously. In the diagnostics pane, user selects an error from file "beta/somefile.js". The center pane will display the file correctly but the title bar displays "Diagnostics -- ~/alpha"

Title bar should not care which side pane is focused, it should just display which file is currently active.
 
Released under CC0.

### Description of the Change

Only update window title from center pane

### Alternate Designs

In terms of Diagnostics, maybe when clicking on item from diagnostics table, manually update window title there.

### Why Should This Be In Core?

It needed to be in the workplace.js

### Benefits

Stops confusing user which project they are on. 

### Possible Drawbacks

For users are used to title showing side pane names, this is a surprise.

### Verification Process

Set focus on side panes such as file tree, diagnostics, debugger, window title does not update
Change active editor, window title updates to correct file name + project

### Applicable Issues

There is a bug reported to Nuclide team. 
