### PR TITLE
Make soft-wrap break words before a slash or space and after a dash

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -560,7 +560,7 @@ describe('TextEditor', () => {
           it('wraps to the end of the previous line', () => {
             editor.setCursorScreenPosition([4, 4])
             editor.moveLeft()
-            expect(editor.getCursorScreenPosition()).toEqual([3, 46])
+            expect(editor.getCursorScreenPosition()).toEqual([3, 49])
           })
         })
 
@@ -790,7 +790,7 @@ describe('TextEditor', () => {
         editor.setCursorScreenPosition([0, 2])
         editor.moveToEndOfLine()
         const cursor = editor.getLastCursor()
-        expect(cursor.getScreenPosition()).toEqual([4, 4])
+        expect(cursor.getScreenPosition()).toEqual([3, 5])
       })
     })
 

--- a/src/text-utils.js
+++ b/src/text-utils.js
@@ -103,7 +103,8 @@ const isWordStart = (previousCharacter, character) =>
   ((character !== ' ') && (character !== '\t'))
 
 const isWrapBoundary = (previousCharacter, character) =>
-  isWordStart(previousCharacter, character) || isCJKCharacter(character)
+  isWordStart(previousCharacter, character) || isCJKCharacter(character) ||
+  previousCharacter === '-' || character === '/' || character === ' '
 
 // Does the given string contain at least surrogate pair, variation sequence,
 // or combined character?


### PR DESCRIPTION
### Description of the Change
Wrapping now includes wrap on dash and slash. Remake of #17141, which was in response to issue #16904, in which the user wanted more "aggressive" wrapping. To implement this change, the isWrapBoundary variable was given character checks for spaces, slashes, and dashes as wrap boundaries.

Compared to the previous iteration of this PR, it checks if the previousCharacter (not the current character) is a dash, to cut words after it, so that it is consistent with how word-wrapping works in most software.

Any help to fix tests is appreciated since I do not have experience with those.

### Alternate Designs
The proposed version was selected because it produced the simplest fix to this problem.

### Why Should This Be In Core?
This should be in the core because it has to do with editor functionality.

### Benefits
A much more intuitive soft-wrap functionality that doesn't breakup words in the middle if it doesn't have to.

### Possible Drawbacks
This is not a new behavior, but it will be more visible:

The cursor can’t be after the last character, because it’s the same position than the beginning of the following line, and so “Move to end of line” puts the cursor before the last character of the line visually.

### Verification Process
The new soft-wrap was tested with tests such as these:
<img alt="screen shot 2018-04-14 at 11 34 11 pm" width="419" src="https://user-images.githubusercontent.com/15944354/38774883-12151018-4040-11e8-821f-a264ba1577d3.png">