### PR TITLE
Preserve function names when minifying startup snapshot

### DIFF
--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -72,6 +72,7 @@ module.exports = function (packagedAppPath) {
 
     process.stdout.write('Minifying startup script')
     const minification = terser.minify(snapshotScript, {
+      keep_fnames: true,
       keep_classnames: true,
       compress: {keep_fargs: true, keep_infinity: true}
     })


### PR DESCRIPTION
This fixes a regression from https://github.com/atom/atom/pull/17926.

The `cson-parser` module relies on `Function.prototype.name` because it uses classes that are written in CoffeeScript.

/cc @50Wliu 