### PR TITLE
Fix some Tree-sitter bugs found when enabling by default

### DIFF
--- a/spec/tree-sitter-language-mode-spec.js
+++ b/spec/tree-sitter-language-mode-spec.js
@@ -1413,6 +1413,23 @@ describe('TreeSitterLanguageMode', () => {
         'property.name'
       ])
     })
+
+    it('includes the root scope name even when the given position is in trailing whitespace at EOF', () => {
+      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+        scopeName: 'source.js',
+        parser: 'tree-sitter-javascript',
+        scopes: {
+          program: 'source.js',
+          property_identifier: 'property.name'
+        }
+      })
+
+      buffer.setText('a; ')
+      buffer.setLanguageMode(new TreeSitterLanguageMode({buffer, grammar}))
+      expect(editor.scopeDescriptorForBufferPosition([0, 3]).getScopesArray()).toEqual([
+        'source.js'
+      ])
+    })
   })
 
   describe('.bufferRangeForScopeAtPosition(selector?, position)', () => {

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -429,6 +429,9 @@ class TreeSitterLanguageMode {
     for (const scope of iterator.getOpenScopeIds()) {
       scopes.push(this.grammar.scopeNameForScopeId(scope, false))
     }
+    if (scopes.length === 0 || scopes[0] !== this.grammar.scopeName) {
+      scopes.unshift(this.grammar.scopeName)
+    }
     return new ScopeDescriptor({scopes})
   }
 


### PR DESCRIPTION
This PR extracts two bug fixes that I found as part of https://github.com/atom/atom/pull/17879:

* Ensure that grammars' root scope descriptors are always included in scope descriptors, even for buffer positions for which there is no syntax node (i.e. leading or trailing whitespace in the file).
* Tweak the logic for updating parse trees synchronously for quick parses such that it works when there are synchronous edits and multiple quick parses in a row.

/cc @joefitzgerald - I believe this fixes the bug you reported today

Fixes https://github.com/atom/atom/issues/17942