### PR TITLE
Fix: Added capturing to keydown events when hiding tooltips

### DIFF
--- a/spec/tooltip-manager-spec.js
+++ b/spec/tooltip-manager-spec.js
@@ -218,7 +218,9 @@ describe('TooltipManager', () => {
         const disposable = manager.add(element, { title: 'Title' })
         hover(element, function () {
           expect(document.body.querySelector('.tooltip')).not.toBeNull()
-          window.dispatchEvent(new CustomEvent('keydown'))
+          window.dispatchEvent(new CustomEvent('keydown', {
+            bubbles: true
+          }))
           expect(document.body.querySelector('.tooltip')).toBeNull()
           disposable.dispose()
         })

--- a/src/tooltip-manager.js
+++ b/src/tooltip-manager.js
@@ -153,11 +153,11 @@ class TooltipManager {
     }
 
     window.addEventListener('resize', hideTooltip)
-    window.addEventListener('keydown', hideTooltip)
+    window.addEventListener('keydown', hideTooltip, { capture: true })
 
     const disposable = new Disposable(() => {
       window.removeEventListener('resize', hideTooltip)
-      window.removeEventListener('keydown', hideTooltip)
+      window.removeEventListener('keydown', hideTooltip, { capture: true })
       hideTooltip()
       tooltip.destroy()
 


### PR DESCRIPTION
Description of the Change
Fix #17957 by ensuring capturing occurs and the event is bubbled up to the window. 

Alternate Designs
None.

Benefits
It fixes an issue where users may want to see the workspace they're typing in, but a tooltip is hiding it.

Possible Drawbacks
It adds an additional event listener for each tooltip.

Verification Process
I modified the existing tooltip-manager spec to include a new test for this feature, ran the test suite, and also manually tested it by reproducing the steps listed in #17957. 

Before fix
![tooltip-without-fix](https://user-images.githubusercontent.com/6132051/44883371-b0a6ce00-ac6b-11e8-8fc7-4e44c79b8ea5.gif)

After fix
![tooltip-with-fix](https://user-images.githubusercontent.com/6132051/44883382-bc929000-ac6b-11e8-9af2-acedbcbd5fb6.gif)



Applicable Issues
#17957