### PR TITLE
Bump modules that were updated for Node 10 / Electron 3 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1159,11 +1159,11 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cached-run-in-this-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cached-run-in-this-context/-/cached-run-in-this-context-0.4.1.tgz",
-      "integrity": "sha1-CMFYHi2cP2aba92poQCtYdqlRfM=",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cached-run-in-this-context/-/cached-run-in-this-context-0.5.0.tgz",
+      "integrity": "sha512-FdtDP0u8WjetQ95nLz9vI06efJTFrmtmk5ZT6FECpyTKi9aakNLMHyMH21WRbGYyWlbmB/QlRoB/g1lcEpyjMw==",
       "requires": {
-        "nan": "^2.1.0"
+        "nan": "^2.10.0"
       }
     },
     "camelcase": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@atom/nsfw": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@atom/nsfw/-/nsfw-1.0.18.tgz",
-      "integrity": "sha512-YceKV9a3X62mh4Q78Nyi8aTRaoVGdpeJBHogL8gxU17iBhEpYvxGgMfTe02j1hH2taFT4barkZ5RdZkGKIsJ/w==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@atom/nsfw/-/nsfw-1.0.19.tgz",
+      "integrity": "sha512-TjPoWzDR7R/7xe+11H96S9p60B+m4ggVCwVRT8bSAwH9NlF0YAzF2Ho+j0T8dJE4dZTRzielSS9MCOsN5IVplQ==",
       "requires": {
         "fs-extra": "^0.26.5",
         "lodash.isinteger": "^4.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -316,16 +316,16 @@
       }
     },
     "atom-keymap": {
-      "version": "8.2.10",
-      "resolved": "https://registry.npmjs.org/atom-keymap/-/atom-keymap-8.2.10.tgz",
-      "integrity": "sha512-OGdBlLyxQxHNXD4/H0OyaN8/Sfq40MvXf9YcdzME/XycM8ZVCj3ZYEVN5OU1R9Kmz/vfBWjLM6E+/l2sYSWqhQ==",
+      "version": "8.2.11",
+      "resolved": "https://registry.npmjs.org/atom-keymap/-/atom-keymap-8.2.11.tgz",
+      "integrity": "sha512-dpTpDNENJMjT9tc+F5xUOzMKkf9rje+VZcy/Iz1+U2xvtfyhTDiHJgglXFfIqJ/0s1sCYBUfQESjJFmwBXRe1Q==",
       "requires": {
         "clear-cut": "^2",
         "emissary": "^1.1.0",
         "event-kit": "^1.0.0",
         "fs-plus": "^3.0.0",
         "grim": "^1.2.1",
-        "keyboard-layout": "2.0.13",
+        "keyboard-layout": "2.0.14",
         "pathwatcher": "^8.0.0",
         "property-accessors": "^1",
         "season": "^6.0.2"
@@ -3097,12 +3097,12 @@
       }
     },
     "keyboard-layout": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/keyboard-layout/-/keyboard-layout-2.0.13.tgz",
-      "integrity": "sha512-WxVc3bBITttHozSyEYPsyr5rN2KQuXtEaXMlQfQjEze1JrkLw30yH/bcNn1IGx48b+tdOdybpnq++JFLU2FaZg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/keyboard-layout/-/keyboard-layout-2.0.14.tgz",
+      "integrity": "sha512-QuCfpEC8oai6F8oaNQdxi5+1QIpaQu9HSVI9yzkC2HbIXeBnahzHFDRVGUtwwAWiNnzjNBjUI/djsrMGUTgK1w==",
       "requires": {
         "event-kit": "^2.0.0",
-        "nan": "^2.0.0"
+        "nan": "^2.10.0"
       }
     },
     "keytar": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2237,12 +2237,12 @@
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "fs-admin": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/fs-admin/-/fs-admin-0.1.6.tgz",
-      "integrity": "sha512-JHRSPVRBrYggAGM6kpvNvFdxuFmoDxamnBVQT/JApZtVji7bHKbhLOka1Y2pNSQ/OVChbmZFKcWdpwuZEpA65w==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/fs-admin/-/fs-admin-0.1.7.tgz",
+      "integrity": "sha512-EQNioqUHgtnX9ErMiPuvHCAx0M1VSa9u4oxGF+EGVYBL15Mg5BxEzGBrTAYHUQDDobqw1Yc+6YqZWwSIIe+EwQ==",
       "requires": {
         "mocha": "^3.5.0",
-        "nan": "^2.6.2"
+        "nan": "^2.10.0"
       },
       "dependencies": {
         "commander": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "electronVersion": "2.0.7",
   "dependencies": {
-    "@atom/nsfw": "^1.0.18",
+    "@atom/nsfw": "^1.0.19",
     "@atom/source-map-support": "^0.3.4",
     "@atom/watcher": "1.0.8",
     "about": "file:packages/about",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "base16-tomorrow-light-theme": "https://www.atom.io/api/packages/base16-tomorrow-light-theme/versions/1.6.0/tarball",
     "bookmarks": "https://www.atom.io/api/packages/bookmarks/versions/0.45.1/tarball",
     "bracket-matcher": "https://www.atom.io/api/packages/bracket-matcher/versions/0.89.3/tarball",
-    "cached-run-in-this-context": "0.4.1",
+    "cached-run-in-this-context": "0.5.0",
     "chai": "3.5.0",
     "chart.js": "^2.3.0",
     "clear-cut": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "async": "0.2.6",
     "atom-dark-syntax": "https://www.atom.io/api/packages/atom-dark-syntax/versions/0.29.1/tarball",
     "atom-dark-ui": "https://www.atom.io/api/packages/atom-dark-ui/versions/0.53.3/tarball",
-    "atom-keymap": "8.2.10",
+    "atom-keymap": "8.2.11",
     "atom-light-syntax": "https://www.atom.io/api/packages/atom-light-syntax/versions/0.29.1/tarball",
     "atom-light-ui": "https://www.atom.io/api/packages/atom-light-ui/versions/0.46.3/tarball",
     "atom-select-list": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "find-parent-dir": "^0.3.0",
     "first-mate": "7.1.1",
     "focus-trap": "2.4.5",
-    "fs-admin": "^0.1.6",
+    "fs-admin": "^0.1.7",
     "fs-plus": "^3.0.1",
     "fstream": "0.1.24",
     "fuzzaldrin": "^2.1",


### PR DESCRIPTION
### Description of the Change

This change bumps a few npm modules that needed to be updated for Node 10 / Electron 3 support.  Running a PR

### Alternate Designs

None.

### Why Should This Be In Core?

Updating core Atom dependencies.

### Benefits

Moving closer to Node 10 / Electron 3 support for Atom.

### Possible Drawbacks

Build breaks?

### Verification Process

- [x] Wait for green CI builds

### Applicable Issues

N/A
