### PR TITLE
Improve RPM package dependencies

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -8,9 +8,11 @@ AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
 %ifarch i386 i486 i586 i686
-Requires: lsb-core-noarch, libXss.so.1 libsecret-1.so.0
+Requires: libXss.so.1 libsecret-1.so.0 lib
+Recommends: lsb-core-noarch
 %else
-Requires: lsb-core-noarch, libXss.so.1()(64bit) libsecret-1.so.0()(64bit)
+Requires: libXss.so.1()(64bit) libsecret-1.so.0()(64bit)
+Recommends: lsb-core-noarch
 %endif
 
 %description

--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -8,10 +8,10 @@ AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
 %ifarch i386 i486 i586 i686
-Requires: libXss.so.1 libsecret-1.so.0 lib
+Requires: libgconf-2.so.4 libXss.so.1 libsecret-1.so.0 lib
 Recommends: lsb-core-noarch
 %else
-Requires: libXss.so.1()(64bit) libsecret-1.so.0()(64bit)
+Requires: libgconf-2.so.4()(64bit) libXss.so.1()(64bit) libsecret-1.so.0()(64bit)
 Recommends: lsb-core-noarch
 %endif
 


### PR DESCRIPTION
### Description of the Change

This PR makes a couple small improvements to Atom's RPM package build:

- Makes Linux Standard Base "recommended" (optional) so that users of some Linux distros don't get a bunch of unwanted packages installed
- Adds GConf2 as a required dependency of the package (as we do in the .deb package)

### Alternate Designs

None.

### Why Should This Be In Core?

This improves our RPM package build for official Atom releases.

### Benefits

See above.

### Possible Drawbacks

Could be possible that removing LSB from required dependencies could cause an important dependency to be missed, but this is something we will be able to fix if and when it shows up.

### Verification Process

- [ ] Green CI build
- [ ] Build an RPM package and check its dependencies
- [ ] Build an RPM package and try to install it

### Applicable Issues

Fixes #16977.
Fixes #17241.
