### PR TITLE
Update apm on master

### DIFF
--- a/apm/package-lock.json
+++ b/apm/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "atom-package-manager": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/atom-package-manager/-/atom-package-manager-2.1.1.tgz",
-      "integrity": "sha512-pHRL1p1XQVNY/qpKgnlG0+nYfU9rAr2GC1BWg1M/s0cuN1IVvF5+vbyXY2Us/hdgJV9cwfWJLvHbB0ogzhmEHA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atom-package-manager/-/atom-package-manager-2.1.2.tgz",
+      "integrity": "sha512-+TcekCI90GjWLX30AfO3rC0hyYxRReAoZ3EHGB+A9gOTTMYjDvDL5/RLMrC8eqXp6WRRNbfOZpV14lQWVWaUUQ==",
       "requires": {
         "asar-require": "0.3.0",
         "async": "~0.2.8",
@@ -353,9 +353,9 @@
           }
         },
         "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+          "version": "2.18.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
+          "integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ=="
         },
         "concat-map": {
           "version": "0.0.1",

--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "2.1.1"
+    "atom-package-manager": "2.1.2"
   }
 }


### PR DESCRIPTION
Update apm to 2.1.2 with (hopefully) a fix for the Windows native module regression in apm 2.1.1.