### PR TITLE
Update to Electron 2.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "2.0.7",
+  "electronVersion": "2.0.9",
   "dependencies": {
     "@atom/nsfw": "^1.0.19",
     "@atom/source-map-support": "^0.3.4",


### PR DESCRIPTION
Updated Electron fixes segfault on glibc 2.28 (see https://github.com/electron/electron/issues/13972 )