### PR TITLE
Fix autocomplete icon

### DIFF
--- a/packages/one-dark-ui/styles/lists.less
+++ b/packages/one-dark-ui/styles/lists.less
@@ -123,6 +123,12 @@
   .list-group li {
     padding-left: @popover-list-padding;
   }
+
+  // Un-reset icon in popover lists
+  .icon.icon {
+    display: inline-block;
+    height: inherit;
+  }
 }
 
 .ui-sortable {

--- a/packages/one-light-ui/styles/lists.less
+++ b/packages/one-light-ui/styles/lists.less
@@ -123,6 +123,12 @@
   .list-group li {
     padding-left: @popover-list-padding;
   }
+
+  // Un-reset icon in popover lists
+  .icon.icon {
+    display: inline-block;
+    height: inherit;
+  }
 }
 
 .ui-sortable {


### PR DESCRIPTION
### Description of the Change

This fixes the icons in the autocomplete popover.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/378023/45337539-863a0680-b5c3-11e8-83de-4a7a30a732b7.png) | ![image](https://user-images.githubusercontent.com/378023/45337524-77535400-b5c3-11e8-894b-655b5063aa65.png)

### Alternate Designs

The selector used to win in specificity is pretty ugly, but we can't really change the class names because other packages and themes use it too.

### Why Should This Be In Core?

It's a bundled package

### Benefits

Icon's background doesn't look broken anymore.

### Possible Drawbacks

Even harder to override

### Verification Process

1. Open a file
2. Start typing so that the autocomplete popover shows up
3. Verify that the icon's background looks ok

### Applicable Issues

None, pointed out in Slack by @maxbrunsfeld 
