### PR TITLE
Use a custom Ubuntu 18.04 container for VSTS Linux builds

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,3 +1,8 @@
+resources:
+  containers:
+  - container: atom-linux-ci
+    image: daviwil/atom-linux-ci:latest
+
 jobs:
 
 - job: GetReleaseVersion
@@ -17,7 +22,7 @@ jobs:
 - template: platforms/linux.yml
 
 - job: Release
-  pool: 
+  pool:
     vmImage: vs2015-win2012r2 # needed for Python 2.7 and gyp
 
   dependsOn:

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -6,24 +6,13 @@ jobs:
   variables:
     ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
   pool:
+    # This image is used to host the Docker container that runs the build
     vmImage: ubuntu-16.04
 
+  container: atom-linux-ci
+
   steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: 8.9.3
-    displayName: Install Node.js 8.9.3
-
-  - script: npm install --global npm@6.2.0
-    displayName: Update npm
-
-  - script: |
-      sudo apt-get update
-      sudo apt-get install -y --no-install-recommends build-essential xvfb clang-3.5 fakeroot git libsecret-1-dev rpm libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgconf2-4 libgtk-3-0
-    displayName: Install apt dependencies
-
-  - script: |
-      script/build --create-debian-package --create-rpm-package --compress-artifacts
+  - script: script/build --create-debian-package --create-rpm-package --compress-artifacts
     env:
       ATOM_RELEASE_VERSION: $(ReleaseVersion)
     displayName: Build Atom
@@ -31,11 +20,7 @@ jobs:
   - script: script/lint
     displayName: Run linter
 
-  - script: |
-      sudo /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
-      export DISPLAY=':99.0'
-      Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-      script/test
+  - script: script/test
     env:
       CI: true
       CI_PROVIDER: VSTS

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -1,5 +1,10 @@
 trigger: none  # No CI builds, only PR builds
 
+resources:
+  containers:
+  - container: atom-linux-ci
+    image: daviwil/atom-linux-ci:latest
+
 jobs:
 
 - job: GetReleaseVersion

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -2,6 +2,11 @@ trigger:
 - master
 - 1.* # VSTS only supports wildcards at the end
 
+resources:
+  containers:
+  - container: atom-linux-ci
+    image: daviwil/atom-linux-ci:latest
+
 jobs:
 
 - job: GetReleaseVersion
@@ -21,7 +26,7 @@ jobs:
 - template: platforms/linux.yml
 
 - job: UploadArtifacts
-  pool: 
+  pool:
     vmImage: vs2015-win2012r2 # needed for python 2.7 and gyp
 
   dependsOn:
@@ -35,7 +40,7 @@ jobs:
     IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
     IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
 
-  steps:  
+  steps:
   - task: NodeTool@0
     inputs:
       versionSpec: 8.9.3


### PR DESCRIPTION
### Description of the Change

This change seeks to fix a recurring failure in our VSTS CI tests on Linux possibly caused by a build dependency on Ubuntu 16.04 that clashes with Electron 2.0.8+.  The fix is to use a [custom container image]() based on Ubuntu 18.04 so that we can build and test successfully with Electron 2.0.8+.

### Alternate Designs

Find the issue in Electron causing our tests to fail and get it fixed, but that will be much more time consuming.  I'll pursue this also but only after getting our builds green again.

### Why Should This Be In Core?

It fixes an issue preventing our Linux CI runs on VSTS from succeeding reliably.

### Benefits

It fixes an issue preventing our Linux CI runs on VSTS from succeeding reliably.

### Possible Drawbacks

Possibly slower builds due to the upgrade step.

### Verification Process

- [x] Ensure CI passes after using new container image
- [x] Try a build generated on Ubuntu 18.04 on an Ubuntu 16.04 VM and make sure it runs correctly and passes a basic sanity check

### Applicable Issues

None.
