### PR TITLE
Refactoring, remove reduanded else

### DIFF
--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -443,9 +443,8 @@ class AtomEnvironment {
     if (this.shellEnvironmentLoaded) {
       callback()
       return new Disposable()
-    } else {
-      return this.emitter.once('loaded-shell-environment', callback)
     }
+    return this.emitter.once('loaded-shell-environment', callback)
   }
 
   /*
@@ -1212,9 +1211,8 @@ or use Pane::saveItemAs for programmatic saving.`)
       if (!stateKey) stateKey = this.getStateKey(this.getLoadSettings().initialPaths)
       if (stateKey) {
         return this.stateStore.load(stateKey)
-      } else {
-        return this.applicationDelegate.getTemporaryWindowState()
       }
+      return this.applicationDelegate.getTemporaryWindowState()
     } else {
       return Promise.resolve(null)
     }

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -62,8 +62,7 @@ class Clipboard {
     const text = this.read()
     if (this.signatureForMetadata === this.md5(text)) {
       return {text, metadata: this.metadata}
-    } else {
-      return {text}
     }
+    return {text}
   }
 }

--- a/src/decoration.js
+++ b/src/decoration.js
@@ -58,13 +58,11 @@ class Decoration {
       }
 
       return false
-    } else {
-      if (type === 'gutter') {
-        return ['gutter', 'line-number'].includes(decorationProperties.type)
-      } else {
-        return type === decorationProperties.type
-      }
     }
+    if (type === 'gutter') {
+      return ['gutter', 'line-number'].includes(decorationProperties.type)
+    }
+    return type === decorationProperties.type
   }
 
   /*

--- a/src/main-process/squirrel-update.js
+++ b/src/main-process/squirrel-update.js
@@ -89,9 +89,8 @@ const removeCommandsFromPath = callback =>
 
     if (pathEnv !== newPathEnv) {
       return spawnSetx(['Path', newPathEnv], callback)
-    } else {
-      return callback()
     }
+    return callback()
   })
 
 // Create a desktop and start menu shortcut by using the command line API

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -124,7 +124,6 @@ function getConfig () {
 function normalizeDriveLetterName (filePath) {
   if (process.platform === 'win32' && filePath) {
     return filePath.replace(/^([a-z]):/, ([driveLetter]) => driveLetter.toUpperCase() + ':')
-  } else {
-    return filePath
   }
+  return filePath
 }

--- a/src/null-grammar.js
+++ b/src/null-grammar.js
@@ -6,23 +6,20 @@ module.exports = {
   scopeForId (id) {
     if (id === -1 || id === -2) {
       return this.scopeName
-    } else {
-      return null
     }
+    return null
   },
   startIdForScope (scopeName) {
     if (scopeName === this.scopeName) {
       return -1
-    } else {
-      return null
     }
+    return null
   },
   endIdForScope (scopeName) {
     if (scopeName === this.scopeName) {
       return -2
-    } else {
-      return null
     }
+    return null
   },
   tokenizeLine (text) {
     return {

--- a/src/pane-container.js
+++ b/src/pane-container.js
@@ -146,9 +146,8 @@ class PaneContainer {
   getPanes () {
     if (this.alive) {
       return this.getRoot().getPanes()
-    } else {
-      return []
     }
+    return []
   }
 
   getPaneItems () {
@@ -192,9 +191,8 @@ class PaneContainer {
       const nextIndex = (currentIndex + 1) % panes.length
       panes[nextIndex].activate()
       return true
-    } else {
-      return false
     }
+    return false
   }
 
   activatePreviousPane () {
@@ -205,9 +203,8 @@ class PaneContainer {
       if (previousIndex < 0) { previousIndex = panes.length - 1 }
       panes[previousIndex].activate()
       return true
-    } else {
-      return false
     }
+    return false
   }
 
   moveActiveItemToPane (destPane) {

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2202,9 +2202,8 @@ class TextEditorComponent {
     if (clientContainerHeight !== this.measurements.clientContainerHeight) {
       this.measurements.clientContainerHeight = clientContainerHeight
       return true
-    } else {
-      return false
     }
+    return false
   }
 
   measureClientContainerWidth () {
@@ -2212,9 +2211,8 @@ class TextEditorComponent {
     if (clientContainerWidth !== this.measurements.clientContainerWidth) {
       this.measurements.clientContainerWidth = clientContainerWidth
       return true
-    } else {
-      return false
     }
+    return false
   }
 
   measureScrollbarDimensions () {
@@ -2865,9 +2863,8 @@ class TextEditorComponent {
   getScrollTopRow () {
     if (this.hasInitialMeasurements) {
       return this.rowForPixelPosition(this.getScrollTop())
-    } else {
-      return this.pendingScrollTopRow || 0
     }
+    return this.pendingScrollTopRow || 0
   }
 
   setScrollLeftColumn (scrollLeftColumn, scheduleUpdate = true) {
@@ -2877,10 +2874,9 @@ class TextEditorComponent {
         this.scheduleUpdate()
       }
       return didScroll
-    } else {
-      this.pendingScrollLeftColumn = scrollLeftColumn
-      return false
     }
+    this.pendingScrollLeftColumn = scrollLeftColumn
+    return false
   }
 
   getScrollLeftColumn () {

--- a/src/text-mate-language-mode.js
+++ b/src/text-mate-language-mode.js
@@ -210,14 +210,12 @@ class TextMateLanguageMode {
       let prefixedScope = prefixedScopes.get(scope)
       if (prefixedScope) {
         return prefixedScope
-      } else {
-        prefixedScope = `syntax--${scope.replace(/\./g, ' syntax--')}`
-        prefixedScopes.set(scope, prefixedScope)
-        return prefixedScope
       }
-    } else {
-      return null
+      prefixedScope = `syntax--${scope.replace(/\./g, ' syntax--')}`
+      prefixedScopes.set(scope, prefixedScope)
+      return prefixedScope
     }
+    return null
   }
 
   getInvalidatedRanges () {
@@ -462,9 +460,8 @@ class TextMateLanguageMode {
     const precedingLine = this.tokenizedLines[bufferRow - 1]
     if (precedingLine) {
       return this.scopesFromTags(precedingLine.openScopes, precedingLine.tags)
-    } else {
-      return []
     }
+    return []
   }
 
   scopesFromTags (startingScopes, tags) {
@@ -651,9 +648,8 @@ class TextMateLanguageMode {
   endRowForFoldAtRow (row, tabLength, existenceOnly = false) {
     if (this.isRowCommented(row)) {
       return this.endRowForCommentFoldAtRow(row, existenceOnly)
-    } else {
-      return this.endRowForCodeFoldAtRow(row, tabLength, existenceOnly)
     }
+    return this.endRowForCodeFoldAtRow(row, tabLength, existenceOnly)
   }
 
   endRowForCommentFoldAtRow (row, existenceOnly) {

--- a/src/theme-manager.js
+++ b/src/theme-manager.js
@@ -233,17 +233,15 @@ On linux there are currently problems with watch sizes. See
   resolveStylesheet (stylesheetPath) {
     if (path.extname(stylesheetPath).length > 0) {
       return fs.resolveOnLoadPath(stylesheetPath)
-    } else {
-      return fs.resolveOnLoadPath(stylesheetPath, ['css', 'less'])
     }
+    return fs.resolveOnLoadPath(stylesheetPath, ['css', 'less'])
   }
 
   loadStylesheet (stylesheetPath, importFallbackVariables) {
     if (path.extname(stylesheetPath) === '.less') {
       return this.loadLessStylesheet(stylesheetPath, importFallbackVariables)
-    } else {
-      return fs.readFileSync(stylesheetPath, 'utf8')
     }
+    return fs.readFileSync(stylesheetPath, 'utf8')
   }
 
   loadLessStylesheet (lessStylesheetPath, importFallbackVariables = false) {


### PR DESCRIPTION
### Description of the Change

We can delete last `else` because this no necessary.

For example, if we have code like this:

```javascript
if (typeof child === 'number') {
  return child
} else {
  return this.nodes.indexOf(child)
}
```

And variable `child` has type `number` then the function always return `child` and never goes on the lines after if-statment. So we can delete `else`-branch:

```javascript
if (typeof child === 'number') {
  return child
}
return this.nodes.indexOf(child)
``` 

I think this part of code more readable then first one.

### Why Should This Be In Core?

It can do code more clear.

### Benefits

Another developer can easily understand the code. 

### Possible Drawbacks

Non

### Verification Process

Run the tests

### Applicable Issues

Non
