### PR TITLE
Check for package.json parse errors in isAtomRepoPath

### DIFF
--- a/src/main-process/main.js
+++ b/src/main-process/main.js
@@ -18,10 +18,15 @@ const args =
     .argv
 
 function isAtomRepoPath (repoPath) {
-  let packageJsonPath = path.join(repoPath, 'package.json')
+  const packageJsonPath = path.join(repoPath, 'package.json')
   if (fs.statSyncNoException(packageJsonPath)) {
-    let packageJson = CSON.readFileSync(packageJsonPath)
-    return packageJson.name === 'atom'
+    try {
+      const packageJson = CSON.readFileSync(packageJsonPath)
+      return packageJson.name === 'atom'
+    } catch (e) {
+      // If any errors are encountered in parsing assume this isn't a valid path
+      return false
+    }
   }
 
   return false


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Wrap the call to the season parser in a `try`/`catch` block to prevent errors in parsing any package.json file in the current directory from crashing the entire Atom process.

### Alternate Designs

Switching to the built in `JSON.parse` _would_ remove the need to bring in the `season` parser, but it would still require a `try`/`catch` block around the parsing.

We _could_ try manually parsing the file to avoid any of the validity checks since all we care about is the name, but that's more effort than it is worth.

### Why Should This Be In Core?

It fixes a bug in core.

### Benefits

Atom will no longer crash when launched from a directory with an invalid `package.json`.

### Possible Drawbacks

The function now has a `try`/`catch` block, preventing some runtime optimizations from being possible on the function, however as it is only run once per window initialization the runtime will never optimize it in the first place.

### Verification Process

I created a build with these changes on top of e6507c59cb846cd02b84f4a3b10dd43b2572a939 and ran it in a directory that was crashing the previous version without issues.

### Applicable Issues

Fixes #18058.
