### PR TITLE
Catch exceptions for bad package.json when looking for Atom repo in pwd

### DIFF
--- a/src/main-process/main.js
+++ b/src/main-process/main.js
@@ -20,8 +20,12 @@ const args =
 function isAtomRepoPath (repoPath) {
   let packageJsonPath = path.join(repoPath, 'package.json')
   if (fs.statSyncNoException(packageJsonPath)) {
-    let packageJson = CSON.readFileSync(packageJsonPath)
-    return packageJson.name === 'atom'
+    try {
+      let packageJson = CSON.readFileSync(packageJsonPath)
+      return packageJson.name === 'atom'
+    } catch (e) {
+      return false
+    }
   }
 
   return false


### PR DESCRIPTION
### Description of the Change

Fixes an issue encountered by @Arcanemagus where opening Atom in a folder with a malformed `package.json` will cause Atom's main process to crash.

### Alternate Designs

None.

### Benefits

No more :boom:

### Possible Drawbacks

None.

### Verification Process

- [x] Opened Atom in a folder with the following `package.json` and verified that it does not crash

```
{ name: "atom": , }
```

### Applicable Issues

Fixes https://github.com/atom/atom/issues/18058.
