### PR TITLE
📝 Provide separate pull request templates based on the type of change being contributed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,41 @@
+### Requirements for Contributing a Bug Fix
+
+* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
+* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.
+
+### Identify the Bug
+
+<!--
+
+Link to the issue describing the bug that you're fixing.
+
+If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
+Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.
+
+-->
+
+### Description of the Change
+
+<!--
+
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+
+-->
+
+### Alternate Designs
+
+<!-- Explain what other alternates were considered and why the proposed version was selected -->
+
+### Possible Drawbacks
+
+<!-- What are the possible side-effects or negative impacts of the code change? -->
+
+### Verification Process
+
+<!--
+
+What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,0 +1,12 @@
+### Requirements for Contributing Documentation
+
+* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
+
+### Description of the Change
+
+<!--
+
+We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/feature_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_change.md
@@ -1,0 +1,52 @@
+### Requirements for Adding, Changing, or Removing a Feature
+
+* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
+* The pull request must update the test suite to exercise the updated functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.
+
+### Issue or RFC Endorsed by Atom's Maintainers
+
+<!--
+
+Link to the issue or RFC that your change relates to. This must be one of the following:
+
+* An open issue with the `help-wanted` label
+* An open issue with the `triaged` label
+* An RFC with "accepted" status
+
+To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/atom/blob/master/CONTRIBUTING.md#suggesting-enhancements
+
+To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
+
+-->
+
+### Description of the Change
+
+<!--
+
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+
+-->
+
+### Alternate Designs
+
+<!-- Explain what other alternates were considered and why the proposed version was selected -->
+
+### Possible Drawbacks
+
+<!-- What are the possible side-effects or negative impacts of the code change? -->
+
+### Verification Process
+
+<!--
+
+What process did you follow to verify that your change has the desired effects?
+
+- How did you verify that all new functionality works as expected?
+- How did you verify that all changed functionality works as expected?
+- How did you verify that the change has not introduced any regressions?
+
+Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/performance_improvement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/performance_improvement.md
@@ -1,0 +1,37 @@
+### Requirements for Contributing a Performance Improvement
+
+* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+* The pull request must only affect performance of existing functionality. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
+* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.
+
+### Description of the Change
+
+<!--
+
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+
+-->
+
+### Quantitative Performance Benefits
+
+<!--
+
+Describe the exact performance improvement observed (for example, reduced time to complete an operation, reduced memory use, etc.). Describe how you measured this change. Bonus points for including graphs that demonstrate the improvement or attached dumps from the built-in profiling tools.
+
+-->
+
+### Possible Drawbacks
+
+<!-- What are the possible side-effects or negative impacts of the code change? -->
+
+### Verification Process
+
+<!--
+
+What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
+
+-->
+
+### Applicable Issues
+
+<!-- Enter any applicable Issues here -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,21 +206,20 @@ Atom Core and all packages can be developed locally. For instructions on how to 
 
 ### Pull Requests
 
-* Fill in [the required template](PULL_REQUEST_TEMPLATE.md)
-* Do not include issue numbers in the PR title
-* Include screenshots and animated GIFs in your pull request whenever possible.
-* Follow the [JavaScript](#javascript-styleguide) and [CoffeeScript](#coffeescript-styleguide) styleguides.
-* Include thoughtfully-worded, well-structured [Jasmine](https://jasmine.github.io/) specs in the `./spec` folder. Run them using `atom --test spec`. See the [Specs Styleguide](#specs-styleguide) below.
-* Document new code based on the [Documentation Styleguide](#documentation-styleguide)
-* End all files with a newline
-* [Avoid platform-dependent code](https://flight-manual.atom.io/hacking-atom/sections/cross-platform-compatibility/)
-* Place requires in the following order:
-    * Built in Node Modules (such as `path`)
-    * Built in Atom and Electron Modules (such as `atom`, `remote`)
-    * Local Modules (using relative paths)
-* Place class properties in the following order:
-    * Class methods and properties (methods starting with a `@` in CoffeeScript or `static` in JavaScript)
-    * Instance methods and properties
+The process described here has several goals:
+
+- Maintain Atom's quality
+- Fix problems that are important to users
+- Engage the community in working toward the best possible Atom
+- Enable a sustainable system for Atom's maintainers to review contributions
+
+Please follow these steps to have your contribution considered by the maintainers:
+
+1. Follow all instructions in [the template](PULL_REQUEST_TEMPLATE.md)
+2. Follow the [styleguides](#styleguides)
+3. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
+
+While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
 
 ## Styleguides
 
@@ -266,6 +265,14 @@ All JavaScript must adhere to [JavaScript Standard Style](https://standardjs.com
   }
   export default ClassName
   ```
+* Place requires in the following order:
+    * Built in Node Modules (such as `path`)
+    * Built in Atom and Electron Modules (such as `atom`, `remote`)
+    * Local Modules (using relative paths)
+* Place class properties in the following order:
+    * Class methods and properties (methods starting with `static`)
+    * Instance methods and properties
+* [Avoid platform-dependent code](https://flight-manual.atom.io/hacking-atom/sections/cross-platform-compatibility/)
 
 ### CoffeeScript Styleguide
 
@@ -289,6 +296,14 @@ All JavaScript must adhere to [JavaScript Standard Style](https://standardjs.com
   you don't want it to return a collected array.
 * Use `this` instead of a standalone `@`
   * `return this` instead of `return @`
+* Place requires in the following order:
+    * Built in Node Modules (such as `path`)
+    * Built in Atom and Electron Modules (such as `atom`, `remote`)
+    * Local Modules (using relative paths)
+* Place class properties in the following order:
+    * Class methods and properties (methods starting with a `@`)
+    * Instance methods and properties
+* [Avoid platform-dependent code](https://flight-manual.atom.io/hacking-atom/sections/cross-platform-compatibility/)
 
 ### Specs Styleguide
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,46 +1,10 @@
-### Requirements
+⚛👋 Hello there! Welcome. Please follow the steps below to tell us about your contribution.
 
-* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
-* All new code requires tests to ensure against regressions
-
-### Description of the Change
-
-<!--
-
-We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
-
--->
-
-### Alternate Designs
-
-<!-- Explain what other alternates were considered and why the proposed version was selected -->
-
-### Why Should This Be In Core?
-
-<!-- Explain why this functionality should be in atom/atom as opposed to a package -->
-
-### Benefits
-
-<!-- What benefits will be realized by the code change? -->
-
-### Possible Drawbacks
-
-<!-- What are the possible side-effects or negative impacts of the code change? -->
-
-### Verification Process
-
-<!--
-
-What process did you follow to verify that your change has the desired effects?
-
-- How did you verify that all new functionality works as expected?
-- How did you verify that all changed functionality works as expected?
-- How did you verify that the change has not introduced any regressions?
-
-Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
-
--->
-
-### Applicable Issues
-
-<!-- Enter any applicable Issues here -->
+1. Copy the correct template for your contribution
+  - 🐛 Are you fixing a bug? Copy the template from https://bit.ly/atom-bugfix
+  - 📈 Are you improving performance? Copy the template from https://bit.ly/atom-perf
+  - 📝 Are you updating documentation? Copy the template from https://bit.ly/atom-docs
+  - 💻 Are you changing functionality? Copy the template from https://bit.ly/atom-behavior
+2. Replace this text with the contents of the template
+3. Fill in all sections of the template
+4. Click "Create pull request"


### PR DESCRIPTION
### Requirements for Contributing Documentation

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/contextualize-pull-request-templates/.github/PULL_REQUEST_TEMPLATE.

### Description of the Change

#### Pull request templates 

Currently, Atom has a [one-size-fits-all pull request template](https://raw.githubusercontent.com/atom/atom/699db3092063c5ae56966007694d782b6f8b1a42/PULL_REQUEST_TEMPLATE.md). Whether you're fixing a typo in a markdown file, adding a new feature, fixing a bug, or improving performance, we ask the contributor to [explain why the change should be part of atom/atom](https://github.com/atom/atom/blame/699db3092063c5ae56966007694d782b6f8b1a42/PULL_REQUEST_TEMPLATE.md#L18-L20), describe [alternate designs](https://github.com/atom/atom/blame/699db3092063c5ae56966007694d782b6f8b1a42/PULL_REQUEST_TEMPLATE.md#L14-L16), etc. Because some of those questions aren't applicable to some types of changes, we frequently see either A) the contributor having to answer questions that aren't applicable to their change, or B) the contributor deleting parts of the template.

In order to better respect the contributor's time, and to increase the utility of the template in helping the contributor explain their change, and to increase the utility of the template in helping maintainers and community members understand and review the change, this pull request provides separate templates based on the type of change being contributed. 👩‍💻:atom:👨‍💻

#### `CONTRIBUTING.md`

Because [`CONTRIBUTING.md` currently references the one-size-fits-all pull request template](https://github.com/atom/atom/blob/699db3092063c5ae56966007694d782b6f8b1a42/CONTRIBUTING.md#pull-requests), this pull request also updates the relevant section of `CONTRIBUTING.md`. The updated section attempts to provide context for the *goals* of our pull request requirements, and it distills the actual pull request requirements into three bullets. 1️⃣2️⃣3️⃣😅 

#### Contributor experience

For repositories with multiple _issue_ templates, github.com [presents a handy UI for helping the contributor choose the appropriate template](https://help.github.com/articles/about-issue-and-pull-request-templates/#issue-templates). Presently, there is no equivalent UI for repositories with multiple _pull request_ templates. Therefore, we need to help the user find the right pull request template for their change. The top-level `PULL_REQUEST_TEMPLATE.md` will serve this purpose:

<img width="999" alt="top-level-pull-request-template-screenshot" src="https://user-images.githubusercontent.com/2988/45493713-675f7f80-b73d-11e8-9e06-7bb783b522a7.png">

I dislike that this requires the contributor to go fetch the template on their own and paste it in. But, I love that everything is visible without scrolling; that's an improvement over the current template. 😇 
