### PR TITLE
[one-{dark,light}-ui] Apply focus styles to checkbox inputs

### DIFF
--- a/packages/one-dark-ui/styles/inputs.less
+++ b/packages/one-dark-ui/styles/inputs.less
@@ -66,6 +66,7 @@
 
 // States -------------------------
 
+.input-checkbox,
 .input-text,
 .input-search,
 .input-number,

--- a/packages/one-light-ui/styles/inputs.less
+++ b/packages/one-light-ui/styles/inputs.less
@@ -66,6 +66,7 @@
 
 // States -------------------------
 
+.input-checkbox,
 .input-text,
 .input-search,
 .input-number,


### PR DESCRIPTION
## Description of the Change
Previously, there was no way of visually identifying whether a checkbox was focused or not.

This adds input-checkbox to the selector in each theme's `inputs.less` to apply the
same border/box-shadow style to indicate focus to checkbox inputs when they are focused.

## Alternate Designs
Could create a visual indication through some other means (not re-using `.focus()`) but this seems to make the sense

## Why Should This Be In Core?
Checkboxes are implemented in core

## Benefits
Makes checkboxes more accessible to sighted users who use keyboards to traverse inputs

## Possible Drawbacks
N/A

## Verification Process
Tab through settings-view and verify screenshots:

Before ("Automatically updated" focused):
<img width="456" src="https://user-images.githubusercontent.com/755844/45648777-55077d80-ba7e-11e8-8b0c-4ff894ef290e.png">

After:
<img width="463" src="https://user-images.githubusercontent.com/755844/45648793-65b7f380-ba7e-11e8-9e86-32590a125eac.png">

<img width="500" src="https://user-images.githubusercontent.com/755844/45648802-694b7a80-ba7e-11e8-8d7b-1b1e9338718d.png">

## Applicable Issues
N/A