### PR TITLE
Pin @atom/nsfw to 1.0.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,15 @@
   "requires": true,
   "dependencies": {
     "@atom/nsfw": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@atom/nsfw/-/nsfw-1.0.20.tgz",
-      "integrity": "sha512-g/7g0xeqoqhnpb28GZr0I6h8q6sKzS83ic+e+40cD5GoEx8Gpo2MzlvrHvrkONGxckxnSmtcIGlon7YoT/UV3Q==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@atom/nsfw/-/nsfw-1.0.18.tgz",
+      "integrity": "sha512-YceKV9a3X62mh4Q78Nyi8aTRaoVGdpeJBHogL8gxU17iBhEpYvxGgMfTe02j1hH2taFT4barkZ5RdZkGKIsJ/w==",
       "requires": {
-        "fs-extra": "^7.0.0",
+        "fs-extra": "^0.26.5",
         "lodash.isinteger": "^4.0.4",
         "lodash.isundefined": "^3.0.1",
-        "nan": "^2.10.0",
-        "promisify-node": "^0.5.0"
+        "nan": "^2.0.0",
+        "promisify-node": "^0.3.0"
       }
     },
     "@atom/source-map-support": {
@@ -2308,13 +2308,25 @@
       "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
     },
     "fs-extra": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+      "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
       "requires": {
         "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
       }
     },
     "fs-minipass": {
@@ -3115,6 +3127,14 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
         "is-buffer": "^1.1.5"
+      }
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "requires": {
+        "graceful-fs": "^4.1.9"
       }
     },
     "language-c": {
@@ -4350,12 +4370,11 @@
       }
     },
     "promisify-node": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/promisify-node/-/promisify-node-0.5.0.tgz",
-      "integrity": "sha512-GR2E4qgCoKFTprhULqP2OP3bl8kHo16XtnqtkHH6be7tPW1yL6rXd15nl3oV2sLTFv1+j6tqoF69VVpFtJ/j+A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/promisify-node/-/promisify-node-0.3.0.tgz",
+      "integrity": "sha1-tLVaz5D6p9K4uQyjlomQhsAwYM8=",
       "requires": {
-        "nodegit-promise": "^4.0.0",
-        "object-assign": "^4.1.1"
+        "nodegit-promise": "~4.0.0"
       }
     },
     "prop-types": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "electronVersion": "2.0.9",
   "dependencies": {
-    "@atom/nsfw": "^1.0.19",
+    "@atom/nsfw": "1.0.18",
     "@atom/source-map-support": "^0.3.4",
     "@atom/watcher": "1.0.8",
     "about": "file:packages/about",


### PR DESCRIPTION
### Description of the Change

This change pins `@atom/nsfw` to version 1.0.18 to avoid a crash that appears in version 1.0.19+ of this module.  Once the [underlying issue](https://github.com/atom/nsfw/issues/1) has been resolved we'll bump the version back to latest.

### Alternate Designs

None, aside from taking the time to fix the underlying issue.

### Why Should This Be In Core?

Resolves a native code crash that caused recurring CI failures.

### Benefits

CI is more stable.

### Possible Drawbacks

None.

### Verification Process

- [x] Renderer process tests succeed without crashes locally on Windows after 10 runs
- [x] CI is green on VSTS and AppVeyor after a few successful runs.

### Applicable Issues

https://github.com/atom/nsfw/issues/1
