### PR TITLE
Return a non-zero error code when windows-run.js CI script fails on VSTS

### DIFF
--- a/script/vsts/windows-run.js
+++ b/script/vsts/windows-run.js
@@ -39,5 +39,8 @@ async function runScriptForBuildArch () {
 }
 
 runScriptForBuildArch().catch(
-  err => console.error(`\nScript failed due to error: ${err.message}`)
+  err => {
+    console.error(`\nScript failed due to error: ${err.message}`)
+    process.exit(1)
+  }
 )


### PR DESCRIPTION
### Description of the Change

In PR #18048 I introduced a new CI script called [`windows-run.js`](https://github.com/atom/atom/blob/master/script/vsts/windows-run.js) which handles launching Atom build tasks using a 32-bit or 64-bit Node.js so that we can generate 32-bit builds of Atom on VSTS.  This script was missing proper error propagation, meaning that failed builds or test runs were being reported as successful because the script didn't report the failure properly (see the 64-bit Windows test run [in this VSTS job](https://github.visualstudio.com/Atom/_build/results?buildId=7619&view=logs)).  This PR resolves that issue.

### Alternate Designs

None.

### Why Should This Be In Core?

It's a CI script for Atom.

### Benefits

Errors will be reported correctly in Windows CI builds.

### Possible Drawbacks

None.

### Verification Process

- [x] Recurring Windows test failure actually shows up as red on VSTS

### Applicable Issues

None.
