### PR TITLE
Add Probot no-response configuration

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,15 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an issue is closed for lack of response
+daysUntilClose: 180
+
+# Label requiring a response
+responseRequiredLabel: more-information-needed
+
+# Comment to post when closing an issue for lack of response. Set to `false` to disable.
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further.


### PR DESCRIPTION
### Description of the Change

Add configuration in preparation for installing the [No Response](https://github.com/apps/no-response) app on the atom/atom repository.

Currently, when someone opens an issue and we need additional information, a maintainer will ask the issue author for more information and the maintainer will apply the [`more-information-needed` label](https://github.com/atom/atom/issues?page=2&q=is%3Aissue+is%3Aopen+label%3Amore-information-needed). In many cases, months (even years) can go by without the issue author responding to the request for more information. In these cases, because we still lack the requested information, the issue is not actionable. Today, a maintainer would need to manually search for issues with the `more-information-needed` label, identify ones that have been open for too long without a reply from the issue author, and then manually close those issues.

To make more effective use of maintainers' time, and to help us more quickly distinguish actionable issues from non-actionable issues, we can use the [No Response](https://github.com/apps/no-response) app to automate the manual process described above. :robot::sparkles:

This pull request proposes that we start out with a fairly conservative configuration: If we've been waiting for a reply from the issue author for more than 180 days, and the issue author hasn't replied, the [No Response](https://github.com/apps/no-response) app will close the issue and post [a comment](https://github.com/atom/atom/blob/2a4a273a2ff47a44f138de00b7393246e2b0dfc5/.github/no-response.yml#L11-L15) explaining why it's closing the issue.

Once we verify that this is working smoothly, I'd like to decrease the time window to something smaller than 180 days, perhaps 28 days. That change would take place in a follow-up pull request.

### Alternate Designs

N/A

### Possible Drawbacks

- People may get upset that we're closing an issue. They may wrongly interpret it to mean that we don't care about the issue or that we refuse to address it. Hopefully the [comment](https://github.com/atom/atom/blob/2a4a273a2ff47a44f138de00b7393246e2b0dfc5/.github/no-response.yml#L11-L15) that the [No Response](https://github.com/apps/no-response) app posts will help them understand that we do indeed want to help, but that we need more information in order to provide that help. 🤞
- When we first install the app, its first "sweep" will identify about 20 issues that are more than 180 days old and have the `more-information-needed` label. For anyone watching the atom/atom repository, or anyone subscribed to all of those issues, they'll receive a batch of notifications for all of those issues at once. 📨

### Verification Process

N/A
