### PR TITLE
Update soft wrap margins on gutter re-measurement

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -2085,6 +2085,22 @@ describe('TextEditorComponent', () => {
       const bLabels = Array.from(bNumbers, e => e.textContent)
       expect(bLabels).toEqual(['b - 0', 'b - 1', 'b - 2', 'b - 3', 'b - 4', 'b - 5'])
     })
+
+    it("updates the editor's soft wrap width when a custom gutter's measurement is available", () => {
+      const {component, element, editor} = buildComponent({
+        lineNumberGutterVisible: false,
+        width: 400,
+        softWrapped: true,
+        attach: false,
+      })
+      const gutter = editor.addGutter({name: 'a', priority: 10})
+      gutter.getElement().style.width = '100px'
+
+      jasmine.attachToDOM(element)
+
+      expect(component.getGutterContainerWidth()).toBe(100)
+      expect(editor.getSoftWrapColumn()).toBe(39);
+    })
   })
 
   describe('block decorations', () => {

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -2099,7 +2099,11 @@ describe('TextEditorComponent', () => {
       jasmine.attachToDOM(element)
 
       expect(component.getGutterContainerWidth()).toBe(100)
-      expect(editor.getSoftWrapColumn()).toBe(39);
+
+      // Component client width - gutter container width - vertical scrollbar width
+      const softWrapColumn = Math.floor(
+        (400 - 100 - component.getVerticalScrollbarWidth()) / component.getBaseCharacterWidth())
+      expect(editor.getSoftWrapColumn()).toBe(softWrapColumn)
     })
   })
 

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -387,8 +387,9 @@ class TextEditorComponent {
   }
 
   measureContentDuringUpdateSync () {
+    let gutterDimensionsChanged = false
     if (this.remeasureGutterDimensions) {
-      this.measureGutterDimensions()
+      gutterDimensionsChanged = this.measureGutterDimensions()
       this.remeasureGutterDimensions = false
     }
     const wasHorizontalScrollbarVisible = (
@@ -419,7 +420,7 @@ class TextEditorComponent {
     this.linesToMeasure.clear()
     this.measuredContent = true
 
-    return wasHorizontalScrollbarVisible !== isHorizontalScrollbarVisible
+    return gutterDimensionsChanged || wasHorizontalScrollbarVisible !== isHorizontalScrollbarVisible
   }
 
   updateSyncAfterMeasuringContent () {


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

This fixes #18086. I've verified that this corrects the editor jank I observed both in my super-contrived isolated repro case _and_ in the case where @Arcanemagus originally spotted it in atom/github#1512.

### Description of the Change

Return `true` from `TextEditorComponent::measureContentDuringUpdateSync()` if the horizontal scrollbar has toggled its visibility _or_ if gutter measurements have changed. This will cause `updateSync()` to restart the initial frame with the correct gutter measurements in place and calculate the correct soft-wrap column in time for the first render to complete.

### Alternate Designs

I _could_ have worked around this by manually triggering a TextEditorComponent update after the initial render has completed. That seems pretty hacky, though, and that PR already depends on features from 1.32, so I figured I might as well fix The Real Problem.

### Possible Drawbacks

This could cause a more expensive initial render. We're already paying this price when a horizontal scrollbar is needed, though.

### Verification Process

I've followed the repro steps from #18086 to make sure that the editor renders correctly on the first try. I've also used dev mode to verify that it fixes the way that this manifests in the GitHub package.