### PR TITLE
➡️ Migrate core package 'atom-dark-syntax' into ./packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -299,8 +299,7 @@
       }
     },
     "atom-dark-syntax": {
-      "version": "https://www.atom.io/api/packages/atom-dark-syntax/versions/0.29.1/tarball",
-      "integrity": "sha512-b5rCHzPR64JCc5WrLFsz1UawYKUB5v6QswTe/MYHs7tkmJJNzaFbQi2JmbroK58b+3ccwbYrRH8DxWyzGRS2kg=="
+      "version": "file:packages/atom-dark-syntax"
     },
     "atom-dark-ui": {
       "version": "https://www.atom.io/api/packages/atom-dark-ui/versions/0.53.3/tarball",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "about": "file:packages/about",
     "archive-view": "https://www.atom.io/api/packages/archive-view/versions/0.65.1/tarball",
     "async": "0.2.6",
-    "atom-dark-syntax": "https://www.atom.io/api/packages/atom-dark-syntax/versions/0.29.1/tarball",
+    "atom-dark-syntax": "file:packages/atom-dark-syntax",
     "atom-dark-ui": "https://www.atom.io/api/packages/atom-dark-ui/versions/0.53.3/tarball",
     "atom-keymap": "8.2.11",
     "atom-light-syntax": "https://www.atom.io/api/packages/atom-light-syntax/versions/0.29.1/tarball",
@@ -170,7 +170,7 @@
     "yargs": "^3.23.0"
   },
   "packageDependencies": {
-    "atom-dark-syntax": "0.29.1",
+    "atom-dark-syntax": "file:./packages/atom-dark-syntax",
     "atom-dark-ui": "0.53.3",
     "atom-light-syntax": "0.29.1",
     "atom-light-ui": "0.46.3",

--- a/packages/README.md
+++ b/packages/README.md
@@ -9,8 +9,8 @@ See [RFC 003](https://github.com/atom/atom/blob/master/docs/rfcs/003-consolidate
 | Package | Where to find it | Migration issue |
 |---------|------------------|-----------------|
 | **about** | [`./packages/about`](./about) | [#17832](https://github.com/atom/atom/issues/17832) |
-| **atom-dark-syntax** | [`atom/atom-dark-syntax`][atom-dark-syntax] | [#17849](https://github.com/atom/atom/issues/17849) |
 | **atom-dark-ui** | [`atom/atom-dark-ui`][atom-dark-ui] | [#17850](https://github.com/atom/atom/issues/17850) |
+| **atom-dark-syntax** | [`./packages/atom-dark-syntax`][./atom-dark-syntax] | [#17849](https://github.com/atom/atom/issues/17849) |
 | **atom-light-syntax** | [`atom/atom-light-syntax`][atom-light-syntax] | [#17851](https://github.com/atom/atom/issues/17851) |
 | **atom-light-ui** | [`atom/atom-light-ui`][atom-light-ui] | [#17852](https://github.com/atom/atom/issues/17852) |
 | **autocomplete-atom-api** | [`atom/autocomplete-atom-api`][autocomplete-atom-api] |  |

--- a/packages/atom-dark-syntax/LICENSE.md
+++ b/packages/atom-dark-syntax/LICENSE.md
@@ -1,0 +1,20 @@
+Copyright (c) 2014 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/atom-dark-syntax/README.md
+++ b/packages/atom-dark-syntax/README.md
@@ -1,0 +1,9 @@
+# Atom Dark Syntax theme
+
+A dark syntax theme for Atom.
+
+This theme is installed by default with Atom and can be activated by going to
+the _Themes_ section in the Settings view (`cmd-,`) and selecting it from the
+_Syntax Themes_ dropdown menu.
+
+![](https://f.cloud.github.com/assets/671378/2264549/f49e9bf2-9e73-11e3-9329-e2d59dd1b119.png)

--- a/packages/atom-dark-syntax/index.less
+++ b/packages/atom-dark-syntax/index.less
@@ -1,0 +1,7 @@
+
+// Atom Dark Syntax theme
+
+@import "styles/syntax-variables.less";
+
+@import "styles/editor.less";
+@import "styles/syntax.less";

--- a/packages/atom-dark-syntax/package.json
+++ b/packages/atom-dark-syntax/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "atom-dark-syntax",
+  "theme": "syntax",
+  "version": "0.29.1",
+  "description": "A dark theme for syntax",
+  "repository": "https://github.com/atom/atom",
+  "license": "MIT",
+  "engines": {
+    "atom": ">0.50.0"
+  }
+}

--- a/packages/atom-dark-syntax/styles/editor.less
+++ b/packages/atom-dark-syntax/styles/editor.less
@@ -1,0 +1,50 @@
+atom-text-editor {
+  background-color: @syntax-background-color;
+  color: @syntax-text-color;
+
+  .invisible-character {
+    color: @syntax-invisible-character-color;
+  }
+
+  .indent-guide {
+    color: @syntax-indent-guide-color;
+  }
+
+  .wrap-guide {
+    background-color: @syntax-wrap-guide-color;
+  }
+
+  .gutter {
+    background-color: @syntax-gutter-background-color;
+  }
+  .gutter .cursor-line {
+    background-color: @syntax-gutter-background-color-selected;
+  }
+  .line-number.cursor-line-no-selection {
+    background-color: @syntax-gutter-background-color-selected;
+  }
+
+  .gutter .line-number.folded,
+  .gutter .line-number:after,
+  .fold-marker:after {
+    color: #fba0e3;
+  }
+
+  .invisible {
+    color: @syntax-text-color;
+  }
+
+  .cursor {
+    border-color: @syntax-cursor-color;
+  }
+
+  .selection .region {
+    background-color: @syntax-selection-color;
+  }
+
+  .bracket-matcher .region {
+    border-bottom: 1px solid #f8de7e;
+    margin-top: -1px;
+    opacity: .7;
+  }
+}

--- a/packages/atom-dark-syntax/styles/syntax-variables.less
+++ b/packages/atom-dark-syntax/styles/syntax-variables.less
@@ -1,0 +1,44 @@
+// This defines all syntax variables that syntax themes must implement when they
+// include a syntax-variables.less file.
+
+// General colors
+@syntax-text-color: #c5c8c6;
+@syntax-cursor-color: white;
+@syntax-selection-color: #444;
+@syntax-selection-flash-color: #eee;
+@syntax-background-color: #1d1f21;
+
+// Guide colors
+@syntax-wrap-guide-color: rgba(197, 200, 198, .1);
+@syntax-indent-guide-color: rgba(197, 200, 198, .2);
+@syntax-invisible-character-color: rgba(197, 200, 198, .2);
+
+// For find and replace markers
+@syntax-result-marker-color: #888;
+@syntax-result-marker-color-selected: white;
+
+// Gutter colors
+@syntax-gutter-text-color: @syntax-text-color;
+@syntax-gutter-text-color-selected: @syntax-gutter-text-color;
+@syntax-gutter-background-color: lighten(@syntax-background-color, 5%);
+@syntax-gutter-background-color-selected: rgba(255, 255, 255, 0.14);
+
+// For git diff info. i.e. in the gutter
+@syntax-color-renamed: #96CBFE;
+@syntax-color-added: #A8FF60;
+@syntax-color-modified: #E9C062;
+@syntax-color-removed: #CC6666;
+
+// For language entity colors
+@syntax-color-variable: #C6C5FE;
+@syntax-color-constant: #99CC99;
+@syntax-color-property: #EDEDED;
+@syntax-color-value: #F9EE98;
+@syntax-color-function: #DAD085;
+@syntax-color-method: @syntax-color-function;
+@syntax-color-class: #62B1FE;
+@syntax-color-keyword: #96CBFE;
+@syntax-color-tag: #96CBFE;
+@syntax-color-attribute: #FF73FD;
+@syntax-color-import: @syntax-color-keyword;
+@syntax-color-snippet: @syntax-color-constant;

--- a/packages/atom-dark-syntax/styles/syntax.less
+++ b/packages/atom-dark-syntax/styles/syntax.less
@@ -1,0 +1,283 @@
+.syntax--comment {
+  color: #8a8a8a;
+}
+
+.syntax--entity {
+  color: #FFD2A7;
+
+  &.syntax--name.syntax--type {
+    text-decoration: underline;
+    color: #FFFFB6;
+  }
+
+  &.syntax--other.syntax--inherited-class {
+    color: #9B5C2E;
+  }
+}
+
+.syntax--keyword {
+  color: #96CBFE;
+
+  &.syntax--control {
+    color: #96CBFE;
+  }
+
+  &.syntax--operator {
+    color: #EDEDED;
+  }
+}
+
+.syntax--storage {
+  color: #CFCB90;
+
+  &.syntax--modifier {
+    color: #96CBFE;
+  }
+}
+
+.syntax--constant {
+  color: #99CC99;
+
+  &.syntax--numeric {
+    color: #FF73FD;
+  }
+}
+
+.syntax--variable {
+  color: #C6C5FE;
+}
+
+.syntax--invalid.syntax--deprecated {
+  text-decoration: underline;
+  color: #FD5FF1;
+}
+
+.syntax--invalid.syntax--illegal {
+  color: #FD5FF1;
+  background-color: rgba(86, 45, 86, 0.75);
+}
+
+// String interpolation in Ruby, CoffeeScript, and others
+.syntax--string {
+  .syntax--source,
+  .syntax--meta.syntax--embedded.syntax--line {
+    color: #EDEDED;
+  }
+
+  .syntax--punctuation.syntax--section.syntax--embedded {
+    color: #00A0A0;
+
+    .syntax--source {
+      color: #00A0A0;  // Required for the end of embedded strings in Ruby #716
+    }
+  }
+}
+
+.syntax--string {
+  color: #A8FF60;
+
+  .syntax--constant {
+    color: #00A0A0;
+  }
+
+  &.syntax--regexp {
+    color: #E9C062;
+
+    .syntax--constant.syntax--character.syntax--escape,
+    .syntax--source.syntax--ruby.syntax--embedded,
+    .syntax--string.syntax--regexp.syntax--arbitrary-repetition {
+      color: #FF8000;
+    }
+
+    &.syntax--group {
+      color: #C6A24F;
+      background-color: rgba(255, 255, 255, 0.06);
+    }
+
+    &.syntax--character-class {
+      color: #B18A3D;
+    }
+  }
+
+  .syntax--variable {
+    color: #8A9A95;
+  }
+}
+
+.syntax--support {
+  color: #FFFFB6;
+
+  &.syntax--function {
+    color: #DAD085;
+  }
+
+  &.syntax--constant {
+    color: #FFD2A7;
+  }
+
+  &.syntax--type.syntax--property-name.syntax--css {
+    color: #EDEDED;
+  }
+}
+
+.syntax--source .syntax--entity.syntax--name.syntax--tag,
+.syntax--source .syntax--punctuation.syntax--tag {
+  color: #96CBFE;
+}
+.syntax--source .syntax--entity.syntax--other.syntax--attribute-name {
+  color: #FF73FD;
+}
+
+.syntax--entity {
+  &.syntax--other.syntax--attribute-name {
+    color: #FF73FD;
+  }
+
+  &.syntax--name.syntax--tag.syntax--namespace,
+  &.syntax--other.syntax--attribute-name.syntax--namespace {
+    color: #E18964;
+  }
+}
+
+.syntax--meta {
+  &.syntax--preprocessor.syntax--c {
+    color: #8996A8;
+  }
+
+  &.syntax--preprocessor.syntax--c .syntax--keyword {
+    color: #AFC4DB;
+  }
+
+  &.syntax--cast {
+    color: #676767;
+  }
+
+  &.syntax--sgml.syntax--html .syntax--meta.syntax--doctype,
+  &.syntax--sgml.syntax--html .syntax--meta.syntax--doctype .syntax--entity,
+  &.syntax--sgml.syntax--html .syntax--meta.syntax--doctype .syntax--string,
+  &.syntax--xml-processing,
+  &.syntax--xml-processing .syntax--entity,
+  &.syntax--xml-processing .syntax--string {
+    color: #8a8a8a;
+  }
+
+  &.syntax--tag .syntax--entity,
+  &.syntax--tag > .syntax--punctuation,
+  &.syntax--tag.syntax--inline .syntax--entity {
+    color: #FF73FD;
+  }
+  &.syntax--tag .syntax--name,
+  &.syntax--tag.syntax--inline .syntax--name,
+  &.syntax--tag > .syntax--punctuation {
+    color: #96CBFE;
+  }
+
+  &.syntax--selector.syntax--css .syntax--entity.syntax--name.syntax--tag {
+    text-decoration: underline;
+    color: #96CBFE;
+  }
+
+  &.syntax--selector.syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--tag.syntax--pseudo-class {
+    color: #8F9D6A;
+  }
+
+  &.syntax--selector.syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--id {
+    color: #8B98AB;
+  }
+
+  &.syntax--selector.syntax--css .syntax--entity.syntax--other.syntax--attribute-name.syntax--class {
+    color: #62B1FE;
+  }
+
+  &.syntax--property-group .syntax--support.syntax--constant.syntax--property-value.syntax--css,
+  &.syntax--property-value .syntax--support.syntax--constant.syntax--property-value.syntax--css {
+    color: #F9EE98;
+  }
+
+  &.syntax--preprocessor.syntax--at-rule .syntax--keyword.syntax--control.syntax--at-rule {
+    color: #8693A5;
+  }
+
+  &.syntax--property-value .syntax--support.syntax--constant.syntax--named-color.syntax--css,
+  &.syntax--property-value .syntax--constant {
+    color: #87C38A;
+  }
+
+  &.syntax--constructor.syntax--argument.syntax--css {
+    color: #8F9D6A;
+  }
+
+  &.syntax--diff,
+  &.syntax--diff.syntax--header {
+    color: #F8F8F8;
+    background-color: #0E2231;
+  }
+
+  &.syntax--separator {
+    color: #60A633;
+    background-color: #242424;
+  }
+
+  &.syntax--line.syntax--entry.syntax--logfile,
+  &.syntax--line.syntax--exit.syntax--logfile {
+    background-color: rgba(238, 238, 238, 0.16);
+  }
+
+  &.syntax--line.syntax--error.syntax--logfile {
+    background-color: #751012;
+  }
+}
+
+// Markdown Styles
+.syntax--source.syntax--gfm {
+  color: #999;
+}
+
+.syntax--gfm {
+  .syntax--markup.syntax--heading {
+    color: #eee;
+  }
+
+  .syntax--link {
+    color: #555;
+  }
+
+  .syntax--variable.syntax--list,
+  .syntax--support.syntax--quote {
+    color: #555;
+  }
+
+  .syntax--link .syntax--entity {
+    color: #ddd;
+  }
+
+  .syntax--raw {
+    color: #aaa;
+  }
+}
+
+.syntax--markdown {
+  .syntax--paragraph {
+    color: #999;
+  }
+
+  .syntax--heading {
+    color: #eee;
+  }
+
+  .syntax--raw {
+    color: #aaa;
+  }
+
+  .syntax--link {
+    color: #555;
+
+    .syntax--string {
+      color: #555;
+
+      &.syntax--title {
+        color: #ddd;
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description of the Change

This PR migrates the core [`atom-dark-syntax`](https://github.com/atom/atom-dark-syntax) package into `atom/atom`.  See issue #17849 for more information.