### PR TITLE
Keep recovery files around for an hour

### DIFF
--- a/src/main-process/file-recovery-service.js
+++ b/src/main-process/file-recovery-service.js
@@ -6,11 +6,11 @@ const mkdirp = require('mkdirp')
 const {promisify} = require('util')
 const unlink = promisify(fs.unlink)
 
-const DAY_MS = 24 * 60 * 60 * 1000
+const HOUR_MS = 60 * 60 * 1000
 
 module.exports =
 class FileRecoveryService {
-  constructor (recoveryDirectory, gcInterval=DAY_MS / 2) {
+  constructor (recoveryDirectory, gcInterval=HOUR_MS) {
     this.recoveryDirectory = recoveryDirectory
     this.recoveryFilesByFilePath = new Map()
     this.recoveryFilesByWindow = new WeakMap()
@@ -95,7 +95,7 @@ class FileRecoveryService {
     this.recoveryFilesByWindow.delete(window)
   }
 
-  async sweep(maxAge=DAY_MS, {ls=ls, unlink=unlink}={}) {
+  async sweep(maxAge=HOUR_MS, {ls=ls, unlink=unlink}={}) {
     const minMTime = Date.now() - maxAge
     const pathStats = await ls(this.recoveryPath, name => name.endsWith('~'))
     const garbage = pathStats.filter(({stat: {mtimeMs}}) => mtimeMs < minMTime)


### PR DESCRIPTION
### Identify the Bug

#11406 

### Description of the Change

Keep recovery files around longer. Instead of removing recovery files as soon as they've been saved, keep them around for about an hour. This provides an inconvenient but better than nothing safeguard against data loss.

Remediates, but doesn't fix, #11406.

When they would previously have been unlinked, recovery files are now renamed to `$filename~` (yes, ala Emacs). Once an hour, we garbage collect any recovery files that are more than one hour old.

### Alternate Designs

I mean, we should actually fix the bug, I just haven't been able to reliably repro it, and I don't really know what's going on. (More common in my experience was corrupting the state file, but that just resulted in a lost session).

I thought maybe this would be temporary, but I've talked myself into believing that recovery files should work this way generally, precisely to protect against data loss in unforeseen circumstances. It may also help our forensics on the root bug, since we'll basically have a log of save actions

### Possible Drawbacks

#### Disk space impact
|Save rate / min|Size of `~/.atom/recovery`|
|---|---|
|1k|3.6mb|
|10k|30.6mb|
|100k|300.6mb|

It gets a bit big if you're saving 100k file once per minute, but that's a... really big Atom buffer to be editing with such wild abandon. I think it's okay, but welcome thoughts.

Technically, this introduces a bug if a file save operation takes more than a hour. I think we'll live.

### Verification Process

Running some specs. Making sure files still save. The usual.