### PR TITLE
➡️ Migrate core package 'atom-light-syntax' into ./packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -340,8 +340,7 @@
       }
     },
     "atom-light-syntax": {
-      "version": "https://www.atom.io/api/packages/atom-light-syntax/versions/0.29.1/tarball",
-      "integrity": "sha512-sRUWw4iJi8zuw4EBtcE2kGeSzGquQP6ZQqC0k7+UlbHdoL0a/l9mlBftcow6VRCnLb/lPCkH3Aywmq3PbmFOHg=="
+      "version": "file:packages/atom-light-syntax"
     },
     "atom-light-ui": {
       "version": "https://www.atom.io/api/packages/atom-light-ui/versions/0.46.3/tarball",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "atom-dark-syntax": "file:packages/atom-dark-syntax",
     "atom-dark-ui": "file:packages/atom-dark-ui",
     "atom-keymap": "8.2.11",
-    "atom-light-syntax": "https://www.atom.io/api/packages/atom-light-syntax/versions/0.29.1/tarball",
+    "atom-light-syntax": "file:packages/atom-light-syntax",
     "atom-light-ui": "https://www.atom.io/api/packages/atom-light-ui/versions/0.46.3/tarball",
     "atom-select-list": "^0.7.2",
     "atom-ui": "0.4.1",
@@ -172,7 +172,7 @@
   "packageDependencies": {
     "atom-dark-syntax": "file:./packages/atom-dark-syntax",
     "atom-dark-ui": "file:./packages/atom-dark-ui",
-    "atom-light-syntax": "0.29.1",
+    "atom-light-syntax": "file:./packages/atom-light-syntax",
     "atom-light-ui": "0.46.3",
     "base16-tomorrow-dark-theme": "1.6.0",
     "base16-tomorrow-light-theme": "1.6.0",

--- a/packages/README.md
+++ b/packages/README.md
@@ -11,7 +11,7 @@ See [RFC 003](https://github.com/atom/atom/blob/master/docs/rfcs/003-consolidate
 | **about** | [`./packages/about`](./about) | [#17832](https://github.com/atom/atom/issues/17832) |
 | **atom-dark-syntax** | [`./packages/atom-dark-syntax`][./atom-dark-syntax] | [#17849](https://github.com/atom/atom/issues/17849) |
 | **atom-dark-ui** | [`./packages/atom-dark-ui`][./atom-dark-ui] | [#17850](https://github.com/atom/atom/issues/17850) |
-| **atom-light-syntax** | [`atom/atom-light-syntax`][atom-light-syntax] | [#17851](https://github.com/atom/atom/issues/17851) |
+| **atom-light-syntax** | [`./packages/atom-light-syntax`][./atom-light-syntax] | [#17851](https://github.com/atom/atom/issues/17851) |
 | **atom-light-ui** | [`atom/atom-light-ui`][atom-light-ui] | [#17852](https://github.com/atom/atom/issues/17852) |
 | **autocomplete-atom-api** | [`atom/autocomplete-atom-api`][autocomplete-atom-api] |  |
 | **autocomplete-css** | [`atom/autocomplete-css`][autocomplete-css] |  |

--- a/packages/atom-light-syntax/LICENSE.md
+++ b/packages/atom-light-syntax/LICENSE.md
@@ -1,0 +1,20 @@
+Copyright (c) 2014 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/atom-light-syntax/README.md
+++ b/packages/atom-light-syntax/README.md
@@ -1,0 +1,9 @@
+# Atom Light Syntax theme
+
+A light syntax theme for Atom.
+
+This theme is installed by default with Atom and can be activated by going to
+the _Themes_ section in the Settings view (`cmd-,`) and selecting it from the
+_Syntax Themes_ dropdown menu.
+
+![](https://f.cloud.github.com/assets/671378/2264690/886ce496-9e75-11e3-971a-9a24f359c481.png)

--- a/packages/atom-light-syntax/index.less
+++ b/packages/atom-light-syntax/index.less
@@ -1,0 +1,7 @@
+
+// Atom Light Syntax theme
+
+@import "styles/syntax-variables.less";
+
+@import 'styles/editor.less';
+@import 'styles/syntax.less';

--- a/packages/atom-light-syntax/package.json
+++ b/packages/atom-light-syntax/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "atom-light-syntax",
+  "theme": "syntax",
+  "version": "0.29.1",
+  "description": "A light syntax theme",
+  "repository": "https://github.com/atom/atom",
+  "license": "MIT",
+  "engines": {
+    "atom": ">0.40.0"
+  }
+}

--- a/packages/atom-light-syntax/styles/editor.less
+++ b/packages/atom-light-syntax/styles/editor.less
@@ -1,0 +1,56 @@
+atom-text-editor {
+  background-color: @syntax-background-color;
+  color: @syntax-text-color;
+
+  .invisible-character {
+    color: @syntax-invisible-character-color;
+  }
+
+  .indent-guide {
+    color: @syntax-indent-guide-color;
+  }
+
+  .wrap-guide {
+    background-color: @syntax-wrap-guide-color;
+  }
+
+  .gutter {
+    color: @syntax-gutter-text-color;
+    background: @syntax-gutter-background-color;
+  }
+
+  .gutter .line-number.folded,
+  .gutter .line-number:after,
+  .fold-marker:after {
+    color: #e87b00;
+  }
+
+  .invisible {
+    color: #555;
+  }
+
+  .selection .region {
+    background-color: #e1e1e1;
+  }
+
+  .bracket-matcher .region {
+    background-color: #C9C9C9;
+    opacity: .7;
+    border-bottom: 0 none;
+  }
+
+  &.is-focused {
+    .cursor {
+      border-color: @syntax-cursor-color;
+    }
+
+    .selection .region {
+      background-color: @syntax-selection-color;
+    }
+
+    .line-number.cursor-line-no-selection,
+    .line.cursor-line {
+      background-color: @syntax-gutter-background-color-selected;
+    }
+  }
+}

--- a/packages/atom-light-syntax/styles/syntax-variables.less
+++ b/packages/atom-light-syntax/styles/syntax-variables.less
@@ -1,0 +1,44 @@
+// This defines all syntax variables that syntax themes must implement when they
+// include a syntax-variables.less file.
+
+// General colors
+@syntax-text-color: #555;
+@syntax-cursor-color: black;
+@syntax-selection-color: #afc4da;
+@syntax-selection-flash-color: #69c;
+@syntax-background-color: white;
+
+// Guide colors
+@syntax-wrap-guide-color: rgba(85, 85, 85, .2);
+@syntax-indent-guide-color: rgba(85, 85, 85, .2);
+@syntax-invisible-character-color: rgba(85, 85, 85, .2);
+
+// For find and replace markers
+@syntax-result-marker-color: #999;
+@syntax-result-marker-color-selected: black;
+
+// Gutter colors
+@syntax-gutter-text-color: @syntax-text-color;
+@syntax-gutter-text-color-selected: @syntax-gutter-text-color;
+@syntax-gutter-background-color: white;
+@syntax-gutter-background-color-selected: rgba(255, 255, 134, 0.34);
+
+// For git diff info. i.e. in the gutter
+@syntax-color-renamed: #96CBFE;
+@syntax-color-added: #718C00;
+@syntax-color-modified: #ff982d;
+@syntax-color-removed: #D14;
+
+// For language entity colors
+@syntax-color-variable: #008080;
+@syntax-color-constant: #099;
+@syntax-color-property: #333;
+@syntax-color-value: @syntax-color-constant;
+@syntax-color-function: #900;
+@syntax-color-method: @syntax-color-function;
+@syntax-color-class: #606aa1;
+@syntax-color-keyword: #222;
+@syntax-color-tag: #008080;
+@syntax-color-attribute: #458;
+@syntax-color-import: @syntax-color-keyword;
+@syntax-color-snippet: @syntax-color-constant;

--- a/packages/atom-light-syntax/styles/syntax.less
+++ b/packages/atom-light-syntax/styles/syntax.less
@@ -1,0 +1,194 @@
+.syntax--comment {
+  color: #999988;
+  font-style: italic;
+}
+
+.syntax--string {
+  color: #D14;
+}
+
+// String interpolation in Ruby, CoffeeScript, and others
+.syntax--string {
+  .syntax--source,
+  .syntax--meta.syntax--embedded.syntax--line {
+    color: #5A5A5A;
+  }
+
+  .syntax--punctuation.syntax--section.syntax--embedded {
+    color: #920B2D;
+
+    .syntax--source {
+      color: #920B2D;  // Required for the end of embedded strings in Ruby #716
+    }
+  }
+}
+
+.syntax--constant {
+  &.syntax--numeric {
+    color: #D14;
+  }
+
+  &.syntax--language {
+    color: #606aa1;
+  }
+
+  &.syntax--character,
+  &.syntax--other {
+    color: #606aa1;
+  }
+
+  &.syntax--symbol {
+    color: #990073;
+  }
+
+  &.syntax--numeric.syntax--line-number.syntax--find-in-files .syntax--match {
+    color: rgba(143, 190, 0, 0.63);
+  }
+}
+
+.syntax--variable {
+  color: #008080;
+
+  &.syntax--parameter {
+    color: #606aa1;
+  }
+}
+
+// Keywords
+.syntax--keyword {
+  color: #222;
+  font-weight: bold;
+
+  &.syntax--unit {
+    color: #445588;
+  }
+
+  &.syntax--special-method {
+    color: #0086B3;
+  }
+}
+
+.syntax--storage {
+  color: #222;
+
+  &.syntax--type {
+    color: #222;
+  }
+}
+
+.syntax--entity {
+  &.syntax--name.syntax--class {
+    text-decoration: underline;
+    color: #606aa1;
+  }
+
+  &.syntax--other.syntax--inherited-class {
+    text-decoration: underline;
+    color: #606aa1;
+  }
+
+  &.syntax--name.syntax--function {
+    color: #900;
+  }
+
+  &.syntax--name.syntax--tag {
+    color: #008080;
+  }
+
+  &.syntax--other.syntax--attribute-name {
+    color: #458;
+    font-weight: bold;
+  }
+
+  &.syntax--name.syntax--filename.syntax--find-in-files {
+    color: #E6DB74;
+  }
+}
+
+.syntax--support {
+  &.syntax--constant,
+  &.syntax--function,
+  &.syntax--type {
+    color: #458;
+  }
+
+  &.syntax--class {
+    color: #008080;
+  }
+}
+
+.syntax--invalid {
+  color: #F8F8F0;
+  background-color: #00A8C6;
+
+  &.syntax--deprecated {
+    color: #F8F8F0;
+    background-color: #8FBE00;
+  }
+}
+
+
+.syntax--meta {
+  &.syntax--structure.syntax--dictionary.syntax--json > .syntax--string.syntax--quoted.syntax--double.syntax--json,
+  &.syntax--structure.syntax--dictionary.syntax--json > .syntax--string.syntax--quoted.syntax--double.syntax--json .syntax--punctuation.syntax--string {
+    color: #000080;
+  }
+
+  &.syntax--structure.syntax--dictionary.syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--double.syntax--json {
+    color: #d14;
+  }
+
+  &.syntax--diff,
+  &.syntax--diff.syntax--header {
+    color: #75715E;
+  }
+}
+
+// CSS Styles
+.syntax--css {
+  &.syntax--support.syntax--property-name {
+    font-weight: bold;
+    color: #333;
+  }
+
+  &.syntax--constant {
+    color: #099;
+  }
+}
+
+// Markdown
+.syntax--source.syntax--gfm {
+  color: #444;
+}
+
+.syntax--gfm {
+  .syntax--markup.syntax--heading {
+    color: #111;
+  }
+
+  & .syntax--link {
+    color: #888;
+  }
+
+  .syntax--variable.syntax--list {
+    color: #888;
+  }
+}
+
+.syntax--markdown {
+  .syntax--paragraph {
+    color: #444;
+  }
+
+  .syntax--heading {
+    color: #111;
+  }
+
+  .syntax--link {
+    color: #888;
+
+    .syntax--string {
+      color: #888;
+    }
+  }
+}


### PR DESCRIPTION
### Description of the Change

This PR migrates the core [`atom-light-syntax`](https://github.com/atom/atom-light-syntax) package into `atom/atom`.  See issue #17851 for more information.