### PR TITLE
Use spawnSync instead of execSync in script/vsts/windows-run.js 

### DIFF
--- a/script/vsts/windows-run.js
+++ b/script/vsts/windows-run.js
@@ -16,6 +16,12 @@ async function downloadX86Node () {
 }
 
 async function runScriptForBuildArch () {
+  if (process.argv.length <= 2) {
+    console.error('A target script must be specified')
+    process.exit(1)
+  }
+
+  let exitCode = 0
   if (process.env.BUILD_ARCH === 'x86') {
     await downloadX86Node()
 
@@ -24,23 +30,22 @@ async function runScriptForBuildArch () {
     const runScript = `@echo off\r\nCALL ${extractedNodePath}\\nodevars.bat\r\nCALL ${path.resolve(process.argv[2])} ${process.argv.splice(3).join(' ')}`
     const runScriptPath = 'c:\\tmp\\run.cmd'
     fs.writeFileSync(runScriptPath, runScript)
-    childProcess.execSync(
-      `C:\\Windows\\SysWOW64\\cmd.exe /c "${runScriptPath}"`,
-      { env: process.env, stdio: 'inherit' }
-    )
-  } else {
-    if (process.argv.length > 2) {
-      childProcess.execSync(
-        process.argv.splice(2).join(' '),
+    exitCode =
+      childProcess.spawnSync(
+        'C:\\Windows\\SysWOW64\\cmd.exe',
+        ['/C', runScriptPath],
         { env: process.env, stdio: 'inherit' }
-      )
-    }
+      ).status
+  } else {
+    exitCode =
+      childProcess.spawnSync(
+        process.argv[2],
+        process.argv.splice(3),
+        { env: process.env, stdio: 'inherit' }
+      ).status
   }
+
+  process.exit(exitCode)
 }
 
-runScriptForBuildArch().catch(
-  err => {
-    console.error(`\nScript failed due to error: ${err.message}`)
-    process.exit(1)
-  }
-)
+runScriptForBuildArch()


### PR DESCRIPTION
### Description of the Change

This change replaces the use of `child_process.execSync` with `child_process.spawnSync` in [`script/vsts/windows-run.js`](https://github.com/atom/atom/blob/92731638894b338c52dcbe3c2bf3b1b3d2ed5965/script/vsts/windows-run.js#L27-L36) to improve output streaming and error reporting when running the build and CI tests on Azure Pipelines (VSTS).

### Alternate Designs

None.

### Possible Drawbacks

`spawnSync` might have some slight differences in behavior than `execSync` but that shouldn't matter much for a build script.

### Verification Process

- [x] Run a CI build with a test failure introduced and ensure its error gets written out correctly in the Windows test run
- [x] Run a CI build that should succeed and make sure Windows build/test output is streamed as it is written
