### PR TITLE
Configure probot/no-response to allow 28 days when requesting more info on an issue

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-no-response - https://github.com/probot/no-response
 
 # Number of days of inactivity before an issue is closed for lack of response
-daysUntilClose: 180
+daysUntilClose: 28
 
 # Label requiring a response
 responseRequiredLabel: more-information-needed


### PR DESCRIPTION
### Description of the Change

Building on the [probot/no-response](https://github.com/apps/no-response) configuration implemented in #18077, this pull request adjusts the timeframe to allow 28 days for the issue author to reply to a request for more information.

Currently, when someone opens an issue and we need additional information, a maintainer will ask the issue author for more information and the maintainer will apply the [`more-information-needed` label](https://github.com/atom/atom/issues?page=2&q=is%3Aissue+is%3Aopen+label%3Amore-information-needed). Up to six months can go by without the issue author responding to the request for more information. In these cases, because we still lack the requested information, the issue is not actionable. To help Atom's maintainers focus our attention on actionable issues, the [No Response](https://github.com/apps/no-response) app will now close these non-actionable issues after 28 days, and it will post a comment explaining why the issue was closed:

> This issue has been automatically closed because there has been no response to our request for more information from the original author. With only the information that is currently in the issue, we don't have enough information to take action. Please reach out if you have or find the answers we need so that we can investigate further.

At that point, if the original author (or anyone else) replies with the requested information, we can re-open the issue.

### Alternate Designs

N/A

### Possible Drawbacks

When we merge this change, the app's first "sweep" will identify about 40 issues that are more than 28 days old and have the `more-information-needed` label. For anyone watching the atom/atom repository, or anyone subscribed to all of those issues, they'll receive a batch of notifications for all of those issues at once. 📨

### Verification Process

N/A
