### PR TITLE
Fix atom.desktop for some Linux systems

### DIFF
--- a/resources/linux/atom.desktop.in
+++ b/resources/linux/atom.desktop.in
@@ -8,4 +8,4 @@ Type=Application
 StartupNotify=true
 Categories=GNOME;GTK;Utility;TextEditor;Development;
 MimeType=text/plain;
-StartupWMClass=Atom
+StartupWMClass=atom


### PR DESCRIPTION
For some linux systems the window manager does not associate atom.desktop with Atom processes unless the class name is in lowercase. See #16791