### PR TITLE
[packages/autoflow] Handles wrapping text around LaTeX tags

### DIFF
--- a/packages/autoflow/spec/autoflow-spec.coffee
+++ b/packages/autoflow/spec/autoflow-spec.coffee
@@ -560,3 +560,71 @@ describe "Autoflow package", ->
         '''
 
       expect(autoflow.reflow(test, wrapColumn: 80)).toEqual res
+
+    it 'properly reflows text around LaTeX tags', ->
+      text =
+        '''
+        \\begin{verbatim}
+            Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at blandit, vel vestibulum libero dolor, semper lobortis ligula praesent. Eget condimentum integer, porta sagittis nam, fusce vitae a vitae augue. Nec semper quis sed ut, est porttitor praesent. Nisl velit quam dolore velit quam, elementum neque pellentesque pulvinar et vestibulum.
+        \\end{verbatim}
+        '''
+
+      res =
+        '''
+        \\begin{verbatim}
+            Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at
+            blandit, vel vestibulum libero dolor, semper lobortis ligula praesent. Eget
+            condimentum integer, porta sagittis nam, fusce vitae a vitae augue. Nec
+            semper quis sed ut, est porttitor praesent. Nisl velit quam dolore velit
+            quam, elementum neque pellentesque pulvinar et vestibulum.
+        \\end{verbatim}
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'properly reflows text inside LaTeX tags', ->
+      text =
+        '''
+        \\item{
+            Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at blandit, vel vestibulum libero dolor, semper lobortis ligula praesent. Eget condimentum integer, porta sagittis nam, fusce vitae a vitae augue. Nec semper quis sed ut, est porttitor praesent. Nisl velit quam dolore velit quam, elementum neque pellentesque pulvinar et vestibulum.
+        }
+        '''
+
+      res =
+        '''
+        \\item{
+            Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at
+            blandit, vel vestibulum libero dolor, semper lobortis ligula praesent. Eget
+            condimentum integer, porta sagittis nam, fusce vitae a vitae augue. Nec
+            semper quis sed ut, est porttitor praesent. Nisl velit quam dolore velit
+            quam, elementum neque pellentesque pulvinar et vestibulum.
+        }
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'properly reflows text inside nested LaTeX tags', ->
+      text =
+        '''
+        \\begin{enumerate}[label=(\\alph*)]
+            \\item{
+                Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at blandit, vel vestibulum libero dolor, semper lobortis ligula praesent. Eget condimentum integer, porta sagittis nam, fusce vitae a vitae augue. Nec semper quis sed ut, est porttitor praesent. Nisl velit quam dolore velit quam, elementum neque pellentesque pulvinar et vestibulum.
+            }
+        \\end{enumerate}
+        '''
+
+      res =
+        '''
+        \\begin{enumerate}[label=(\\alph*)]
+            \\item{
+                Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at
+                blandit, vel vestibulum libero dolor, semper lobortis ligula praesent.
+                Eget condimentum integer, porta sagittis nam, fusce vitae a vitae augue.
+                Nec semper quis sed ut, est porttitor praesent. Nisl velit quam dolore
+                velit quam, elementum neque pellentesque pulvinar et vestibulum.
+            }
+        \\end{enumerate}
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+


### PR DESCRIPTION
(This PR is a resubmission of atom/autoflow#68 now that `autoflow` is merged into the main `atom` repo.)

### Issue or RFC Endorsed by Atom's Maintainers

atom/autoflow#68

### Description of the Change

Currently, LaTeX tags that are placed next to the text would be wrapped together with the text. For example, the following text:

```
\begin{enumerate}[label=(\alph*)]
    \item{
        Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at blandit, vel vestibulum libero dolor, semper lobortis ligula praesent. Eget condimentum integer, porta sagittis nam, fusce vitae a vitae augue. Nec semper quis sed ut, est porttitor praesent. Nisl velit quam dolore velit quam, elementum neque pellentesque pulvinar et vestibulum.
    }
\end{enumerate}
```

would be wrapped to

```
\begin{enumerate}[label=(\alph*)] \item{ Lorem ipsum dolor sit amet, nisl odio
amet, et tempor netus neque at at blandit, vel vestibulum libero dolor, semper
lobortis ligula praesent. Eget condimentum integer, porta sagittis nam, fusce
vitae a vitae augue. Nec semper quis sed ut, est porttitor praesent. Nisl velit
quam dolore velit quam, elementum neque pellentesque pulvinar et vestibulum. }
\end{enumerate}
```

whereas the expected result is

```
\begin{enumerate}[label=(\alph*)]
    \item{
        Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at
        blandit, vel vestibulum libero dolor, semper lobortis ligula praesent.
        Eget condimentum integer, porta sagittis nam, fusce vitae a vitae augue.
        Nec semper quis sed ut, est porttitor praesent. Nisl velit quam dolore
        velit quam, elementum neque pellentesque pulvinar et vestibulum.
    }
\end{enumerate}
```

This PR changes the wrapping algorithm such that lines at the beginning and end of each paragraph that resemble LaTeX tags would be ignored for the purpose of wrapping. At the end of the wrapping process, they would be reproduced verbatim. This results in the expected result shown above.

This PR adds 3 test cases in `spec/autoflow-spec.coffee` that demonstrate and test the expected behavior.

### Alternate Designs

N/A

### Possible Drawbacks

The main drawback is the potential of non-LaTeX-tags being mis-detected as LaTeX tags, and therefore ignored from the wrapping process. To minimize this risk, the matching regular expressions are written to match the whole line using `/^...$/g` instead of any part of the line.

### Verification Process

- Added unit tests.
- Ran the entire `autoflow` test suite.
- Quick manual test on a LaTeX file and verified the expected behavior.