### PR TITLE
Upload CI test output to build results on Azure Pipelines

### DIFF
--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -12,13 +12,15 @@ jobs:
   container: atom-linux-ci
 
   steps:
-  - script:
+  - script: |
       if [ $IS_RELEASE_BRANCH == "true" ] || [ $IS_SIGNED_ZIP_BRANCH == "true" ]; then
         script/build --create-debian-package --create-rpm-package --compress-artifacts
       else
         script/build --compress-artifacts
       fi
     env:
+      IS_RELEASE_BRANCH: $(IsReleaseBranch)
+      IS_SIGNED_ZIP_BRANCH: $(IsSignedZipBranch)
       ATOM_RELEASE_VERSION: $(ReleaseVersion)
     displayName: Build Atom
 

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -37,8 +37,7 @@ jobs:
     inputs:
       testRunTitle: Linux
       testResultsFormat: 'JUnit'
-      testResultsFiles: '**/TEST-*.xml'
-      searchFolder: '$(Common.TestResultsDirectory)'
+      testResultsFiles: '$(Common.TestResultsDirectory)/**/TEST-*.xml'
     displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')
 

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -12,7 +12,12 @@ jobs:
   container: atom-linux-ci
 
   steps:
-  - script: script/build --create-debian-package --create-rpm-package --compress-artifacts
+  - script:
+      if [ $IS_RELEASE_BRANCH == "true" ] || [ $IS_SIGNED_ZIP_BRANCH == "true" ]; then
+        script/build --create-debian-package --create-rpm-package --compress-artifacts
+      else
+        script/build --compress-artifacts
+      fi
     env:
       ATOM_RELEASE_VERSION: $(ReleaseVersion)
     displayName: Build Atom

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -30,8 +30,11 @@ jobs:
 
   - task: PublishTestResults@2
     inputs:
+      testRunTitle: Linux
       testResultsFormat: 'JUnit'
       testResultsFiles: '$(Common.TestResultsDirectory)/**/*.xml'
+      mergeTestResults: true
+    displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')
 
   - task: PublishBuildArtifacts@1

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -29,6 +29,7 @@ jobs:
 
   - script: |
       script/test
+      ls -alR $(Common.TestResultsDirectory)
       ls -al $(Common.TestResultsDirectory)/**/TEST-*.xml
     env:
       CI: true

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -32,7 +32,8 @@ jobs:
     inputs:
       testRunTitle: Linux
       testResultsFormat: 'JUnit'
-      testResultsFiles: '$(Common.TestResultsDirectory)/**/*.xml'
+      testResultsFiles: '**/TEST-*.xml'
+      searchFolder: '$(Common.TestResultsDirectory)'
     displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')
 

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -38,6 +38,7 @@ jobs:
       testRunTitle: Linux
       testResultsFormat: 'JUnit'
       testResultsFiles: '$(Common.TestResultsDirectory)/**/TEST-*.xml'
+      mergeTestResults: true
     displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')
 

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -27,7 +27,9 @@ jobs:
   - script: script/lint
     displayName: Run linter
 
-  - script: script/test
+  - script: |
+      script/test
+      ls -al $(Common.TestResultsDirectory)/**/TEST-*.xml
     env:
       CI: true
       CI_PROVIDER: VSTS
@@ -38,8 +40,8 @@ jobs:
   - task: PublishTestResults@2
     inputs:
       testRunTitle: Linux
-      testResultsFormat: 'JUnit'
-      testResultsFiles: '$(Common.TestResultsDirectory)/**/TEST-*.xml'
+      testResultsFormat: JUnit
+      testResultsFiles: $(Common.TestResultsDirectory)/**/TEST-*.xml
       mergeTestResults: true
     displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -24,8 +24,15 @@ jobs:
     env:
       CI: true
       CI_PROVIDER: VSTS
+      TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)
     displayName: Run tests
     condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: '$(Common.TestResultsDirectory)/**/*.xml'
+    condition: ne(variables['Atom.SkipTests'], 'true')
 
   - task: PublishBuildArtifacts@1
     inputs:

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -33,7 +33,6 @@ jobs:
       testRunTitle: Linux
       testResultsFormat: 'JUnit'
       testResultsFiles: '$(Common.TestResultsDirectory)/**/*.xml'
-      mergeTestResults: true
     displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')
 

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -52,7 +52,8 @@ jobs:
     inputs:
       testRunTitle: macOS
       testResultsFormat: 'JUnit'
-      testResultsFiles: '$(Common.TestResultsDirectory)/**/*.xml'
+      testResultsFiles: '**/TEST-*.xml'
+      searchFolder: '$(Common.TestResultsDirectory)'
     displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')
 

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -44,8 +44,15 @@ jobs:
     env:
       CI: true
       CI_PROVIDER: VSTS
+      TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)
     displayName: Run tests
     condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: '$(Common.TestResultsDirectory)/**/*.xml'
+    condition: ne(variables['Atom.SkipTests'], 'true')
 
   - script: |
       cp $(Build.SourcesDirectory)/out/*.zip $(Build.ArtifactStagingDirectory)

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -53,7 +53,6 @@ jobs:
       testRunTitle: macOS
       testResultsFormat: 'JUnit'
       testResultsFiles: '$(Common.TestResultsDirectory)/**/*.xml'
-      mergeTestResults: true
     displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')
 

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -52,8 +52,7 @@ jobs:
     inputs:
       testRunTitle: macOS
       testResultsFormat: 'JUnit'
-      testResultsFiles: '**/TEST-*.xml'
-      searchFolder: '$(Common.TestResultsDirectory)'
+      testResultsFiles: '$(Common.TestResultsDirectory)/**/TEST-*.xml'
     displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')
 

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -53,6 +53,7 @@ jobs:
       testRunTitle: macOS
       testResultsFormat: 'JUnit'
       testResultsFiles: '$(Common.TestResultsDirectory)/**/TEST-*.xml'
+      mergeTestResults: true
     displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')
 

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -50,8 +50,11 @@ jobs:
 
   - task: PublishTestResults@2
     inputs:
+      testRunTitle: macOS
       testResultsFormat: 'JUnit'
       testResultsFiles: '$(Common.TestResultsDirectory)/**/*.xml'
+      mergeTestResults: true
+    displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')
 
   - script: |

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -70,8 +70,15 @@ jobs:
       CI: true
       CI_PROVIDER: VSTS
       BUILD_ARCH: $(buildArch)
+      TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)
     displayName: Run tests
     condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: '$(Common.TestResultsDirectory)/**/*.xml'
+    condition: ne(variables['Atom.SkipTests'], 'true')
 
   - task: PublishBuildArtifacts@1
     inputs:

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -76,8 +76,12 @@ jobs:
 
   - task: PublishTestResults@2
     inputs:
+      testRunTitle: Windows
       testResultsFormat: 'JUnit'
       testResultsFiles: '$(Common.TestResultsDirectory)/**/*.xml'
+      mergeTestResults: true
+      buildPlatform: $(buildArch)
+    displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')
 
   - task: PublishBuildArtifacts@1

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -78,7 +78,8 @@ jobs:
     inputs:
       testRunTitle: Windows $(buildArch)
       testResultsFormat: 'JUnit'
-      testResultsFiles: '$(Common.TestResultsDirectory)/**/*.xml'
+      testResultsFiles: '**/TEST-*.xml'
+      searchFolder: '$(Common.TestResultsDirectory)'
       buildPlatform: $(buildArch)
     displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -76,7 +76,7 @@ jobs:
 
   - task: PublishTestResults@2
     inputs:
-      testRunTitle: Windows
+      testRunTitle: Windows $(buildArch)
       testResultsFormat: 'JUnit'
       testResultsFiles: '$(Common.TestResultsDirectory)/**/*.xml'
       mergeTestResults: true

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -79,6 +79,7 @@ jobs:
       testRunTitle: Windows $(buildArch)
       testResultsFormat: 'JUnit'
       testResultsFiles: '$(Common.TestResultsDirectory)/**/TEST-*.xml'
+      mergeTestResults: true
       buildPlatform: $(buildArch)
     displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -79,7 +79,6 @@ jobs:
       testRunTitle: Windows $(buildArch)
       testResultsFormat: 'JUnit'
       testResultsFiles: '$(Common.TestResultsDirectory)/**/*.xml'
-      mergeTestResults: true
       buildPlatform: $(buildArch)
     displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -78,8 +78,7 @@ jobs:
     inputs:
       testRunTitle: Windows $(buildArch)
       testResultsFormat: 'JUnit'
-      testResultsFiles: '**/TEST-*.xml'
-      searchFolder: '$(Common.TestResultsDirectory)'
+      testResultsFiles: '$(Common.TestResultsDirectory)/**/TEST-*.xml'
       buildPlatform: $(buildArch)
     displayName: Publish test results
     condition: ne(variables['Atom.SkipTests'], 'true')

--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -9,7 +9,7 @@ module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
 
   if process.env.TEST_JUNIT_XML_PATH
     require 'jasmine-reporters'
-    jasmine.getEnv().addReporter new jasmine.JUnitXmlReporter(process.env.TEST_JUNIT_XML_PATH, true, true)
+    jasmine.getEnv().addReporter new jasmine.JUnitXmlReporter(process.env.TEST_JUNIT_XML_PATH, true, !headless)
 
   # Allow document.title to be assigned in specs without screwing up spec window title
   documentTitle = null

--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -9,7 +9,7 @@ module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
 
   if process.env.TEST_JUNIT_XML_PATH
     require 'jasmine-reporters'
-    jasmine.getEnv().addReporter new jasmine.JUnitXmlReporter(process.env.TEST_JUNIT_XML_PATH, true, !headless)
+    jasmine.getEnv().addReporter new jasmine.JUnitXmlReporter(process.env.TEST_JUNIT_XML_PATH, true, not headless)
 
   # Allow document.title to be assigned in specs without screwing up spec window title
   documentTitle = null


### PR DESCRIPTION
### Description of the Change

This change causes Atom's CI tests to be logged in JUnit format so that they can be uploaded to the test results view in Azure Pipelines for each build.  The benefit of doing this is that we can use Pipelines' test analysis tools to understand which tests have been failing consistently over time.  

More info here: https://docs.microsoft.com/en-us/azure/devops/pipelines/test/review-continuous-test-results-after-build?view=vsts

### Alternate Designs

None.

### Possible Drawbacks

None.

### Verification Process

- [ ] Verify that test results are uploaded to the test view and display appropriaely
- [x] Verify whether main process test results are included
