### PR TITLE
Clean up unhelpful 'No README data' warnings in Atom build

### DIFF
--- a/script/lib/generate-metadata.js
+++ b/script/lib/generate-metadata.js
@@ -27,7 +27,9 @@ function buildBundledPackagesMetadata () {
     const packageMetadataPath = path.join(packagePath, 'package.json')
     const packageMetadata = JSON.parse(fs.readFileSync(packageMetadataPath, 'utf8'))
     normalizePackageData(packageMetadata, (msg) => {
-      console.warn(`Invalid package metadata. ${packageMetadata.name}: ${msg}`)
+      if (!msg.match(/No README data$/)) {
+        console.warn(`Invalid package metadata. ${packageMetadata.name}: ${msg}`)
+      }
     }, true)
     if (packageMetadata.repository && packageMetadata.repository.url && packageMetadata.repository.type === 'git') {
       packageMetadata.repository.url = packageMetadata.repository.url.replace(/^git\+/, '')


### PR DESCRIPTION
### Description of the Change

This change ignores any validation errors about 'No README data' from [`normalize-package-data`](https://www.npmjs.com/package/normalize-package-data) when generating metadata for Atom builds.  This has been introducing unhelpful noise into our build output.

### Alternate Designs

None... ?

### Possible Drawbacks

None

### Verification Process

- [x] Verify that the CI build doesn't have a bunch of 'No README data' messages like this:

```
2018-10-03T03:24:46.0947519Z Invalid package metadata. metrics: No README data
2018-10-03T03:24:46.0958643Z Invalid package metadata. notifications: No README data
2018-10-03T03:24:46.0972798Z Invalid package metadata. open-on-github: No README data
2018-10-03T03:24:46.0986356Z Invalid package metadata. package-generator: No README data
2018-10-03T03:24:46.1132237Z Invalid package metadata. settings-view: No README data
2018-10-03T03:24:46.1206693Z Invalid package metadata. snippets: No README data
2018-10-03T03:24:46.1207744Z Invalid package metadata. spell-check: No README data
2018-10-03T03:24:46.1211624Z Invalid package metadata. status-bar: No README data
2018-10-03T03:24:46.1211906Z Invalid package metadata. styleguide: No README data
2018-10-03T03:24:46.1225622Z Invalid package metadata. symbols-view: No README data
2018-10-03T03:24:46.1241693Z Invalid package metadata. tabs: No README data
2018-10-03T03:24:46.1255567Z Invalid package metadata. timecop: No README data
2018-10-03T03:24:46.1296818Z Invalid package metadata. welcome: No README data
2018-10-03T03:24:46.1309714Z Invalid package metadata. whitespace: No README data
2018-10-03T03:24:46.1322098Z Invalid package metadata. wrap-guide: No README data
2018-10-03T03:24:46.1334211Z Invalid package metadata. language-c: No README data
2018-10-03T03:24:46.1359817Z Invalid package metadata. language-clojure: No README data
2018-10-03T03:24:46.1372526Z Invalid package metadata. language-coffee-script: No README data
2018-10-03T03:24:46.1394982Z Invalid package metadata. language-css: No README data
2018-10-03T03:24:46.1406818Z Invalid package metadata. language-gfm: No README data
2018-10-03T03:24:46.1417700Z Invalid package metadata. language-git: No README data
2018-10-03T03:24:46.1429078Z Invalid package metadata. language-go: No README data
2018-10-03T03:24:46.1440891Z Invalid package metadata. language-html: No README data
2018-10-03T03:24:46.1455502Z Invalid package metadata. language-hyperlink: No README data
2018-10-03T03:24:46.1464772Z Invalid package metadata. language-java: No README data
2018-10-03T03:24:46.1476851Z Invalid package metadata. language-javascript: No README data
2018-10-03T03:24:46.1616558Z Invalid package metadata. language-json: No README data
2018-10-03T03:24:46.1616892Z Invalid package metadata. language-less: No README data
2018-10-03T03:24:46.1617032Z Invalid package metadata. language-make: No README data
2018-10-03T03:24:46.1617213Z Invalid package metadata. language-mustache: No README data
2018-10-03T03:24:46.1617348Z Invalid package metadata. language-objective-c: No README data
2018-10-03T03:24:46.1617493Z Invalid package metadata. language-perl: No README data
2018-10-03T03:24:46.1617755Z Invalid package metadata. language-php: No README data
2018-10-03T03:24:46.1617907Z Invalid package metadata. language-property-list: No README data
2018-10-03T03:24:46.1618027Z Invalid package metadata. language-python: No README data
2018-10-03T03:24:46.1631436Z Invalid package metadata. language-ruby: No README data
2018-10-03T03:24:46.1645904Z Invalid package metadata. language-ruby-on-rails: No README data
2018-10-03T03:24:46.1655213Z Invalid package metadata. language-sass: No README data
2018-10-03T03:24:46.1726309Z Invalid package metadata. language-shellscript: No README data
2018-10-03T03:24:46.1739478Z Invalid package metadata. language-source: No README data
2018-10-03T03:24:46.1752087Z Invalid package metadata. language-sql: No README data
2018-10-03T03:24:46.1762629Z Invalid package metadata. language-text: No README data
2018-10-03T03:24:46.1771623Z Invalid package metadata. language-todo: No README data
2018-10-03T03:24:46.1779955Z Invalid package metadata. language-toml: No README data
2018-10-03T03:24:46.1790791Z Invalid package metadata. language-typescript: No README data
2018-10-03T03:24:46.1802871Z Invalid package metadata. language-xml: No README data
2018-10-03T03:24:46.1814182Z Invalid package metadata. language-yaml: No README data
```
