### PR TITLE
:arrow_up: apm@2.1.3

### DIFF
--- a/apm/package-lock.json
+++ b/apm/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "atom-package-manager": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atom-package-manager/-/atom-package-manager-2.1.2.tgz",
-      "integrity": "sha512-+TcekCI90GjWLX30AfO3rC0hyYxRReAoZ3EHGB+A9gOTTMYjDvDL5/RLMrC8eqXp6WRRNbfOZpV14lQWVWaUUQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/atom-package-manager/-/atom-package-manager-2.1.3.tgz",
+      "integrity": "sha512-DBkHKhcjNGaqr/pQxebU4+O0NPLJ0/ARVNxIU+OhvcQjH+VQg6o/Wt6IGMXxGeXCIZnH8MZa6+D7GQ1cukViQg==",
       "requires": {
         "asar-require": "0.3.0",
         "async": "~0.2.8",
@@ -78,7 +78,7 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -130,7 +130,7 @@
         },
         "asar": {
           "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/asar/-/asar-0.12.1.tgz",
+          "resolved": "http://registry.npmjs.org/asar/-/asar-0.12.1.tgz",
           "integrity": "sha1-35Q+jrXNdPvKBmPi10uPK3J7UI8=",
           "requires": {
             "chromium-pickle-js": "^0.1.0",
@@ -166,7 +166,7 @@
         },
         "async": {
           "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "asynckit": {
@@ -209,7 +209,7 @@
         },
         "bl": {
           "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+          "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "requires": {
             "readable-stream": "^2.3.5",
@@ -223,7 +223,7 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -305,9 +305,9 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
         },
         "chromium-pickle-js": {
           "version": "0.1.0",
@@ -345,9 +345,9 @@
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
         },
         "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+          "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -563,7 +563,7 @@
         },
         "event-kit": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/event-kit/-/event-kit-1.5.0.tgz",
           "integrity": "sha1-Ek72qtgyjcsmtxxHWQtbjmPrxIc=",
           "requires": {
             "grim": "^1.2.1"
@@ -596,7 +596,7 @@
         },
         "first-mate": {
           "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/first-mate/-/first-mate-6.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/first-mate/-/first-mate-6.2.0.tgz",
           "integrity": "sha1-lSnK5evqVkC03DxD7ViMWzUoVa8=",
           "requires": {
             "emissary": "^1",
@@ -633,6 +633,16 @@
             "asynckit": "^0.4.0",
             "combined-stream": "1.0.6",
             "mime-types": "^2.1.12"
+          },
+          "dependencies": {
+            "combined-stream": {
+              "version": "1.0.6",
+              "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+              "requires": {
+                "delayed-stream": "~1.0.0"
+              }
+            }
           }
         },
         "fs-constants": {
@@ -665,7 +675,7 @@
           "dependencies": {
             "async": {
               "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
               "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
             }
           }
@@ -862,7 +872,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "requires": {
             "graceful-fs": "^4.1.6"
@@ -880,12 +890,12 @@
           }
         },
         "keytar": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/keytar/-/keytar-4.2.1.tgz",
-          "integrity": "sha1-igamV3/fY3PgqmsRInfmPex3/RI=",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/keytar/-/keytar-4.3.0.tgz",
+          "integrity": "sha512-pd++/v+fS0LQKmzWlW6R1lziTXFqhfGeS6sYLfuTIqEy2pDzAbjutbSW8f9tnJdEEMn/9XhAQlT34VAtl9h4MQ==",
           "requires": {
             "nan": "2.8.0",
-            "prebuild-install": "^2.4.1"
+            "prebuild-install": "^5.0.0"
           },
           "dependencies": {
             "nan": {
@@ -939,7 +949,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mixto": {
@@ -997,7 +1007,7 @@
             },
             "ncp": {
               "version": "0.4.2",
-              "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+              "resolved": "http://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
               "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ="
             },
             "rimraf": {
@@ -1008,13 +1018,18 @@
           }
         },
         "nan": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-          "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+        },
+        "napi-build-utils": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+          "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA=="
         },
         "ncp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz",
           "integrity": "sha1-dDmFMW49tFkoG1hxaehFc1oFQ58="
         },
         "next-tick": {
@@ -1023,9 +1038,9 @@
           "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "node-abi": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
-          "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.5.tgz",
+          "integrity": "sha512-aa/UC6Nr3+tqhHGRsAuw/edz7/q9nnetBrKWxj6rpTtm+0X9T1qU7lIEHMS3yN9JwAbRiKUbRRFy1PLz/y3aaA==",
           "requires": {
             "semver": "^5.4.1"
           }
@@ -3919,7 +3934,7 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
             "lcid": "^1.0.0"
@@ -3966,21 +3981,22 @@
           }
         },
         "prebuild-install": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-          "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.0.tgz",
+          "integrity": "sha512-cpuyMS8y30Df0bnN+I8pdmpwtZbm8fj9cQADOhSH/qnS1exb80elZ707FTMohFBJax4NyWjJVSg0chRQXzHSvg==",
           "requires": {
             "detect-libc": "^1.0.3",
             "expand-template": "^1.0.2",
             "github-from-package": "0.0.0",
             "minimist": "^1.2.0",
             "mkdirp": "^0.5.1",
+            "napi-build-utils": "^1.0.1",
             "node-abi": "^2.2.0",
             "noop-logger": "^0.1.1",
             "npmlog": "^4.0.1",
             "os-homedir": "^1.0.1",
             "pump": "^2.0.1",
-            "rc": "^1.1.6",
+            "rc": "^1.2.7",
             "simple-get": "^2.7.0",
             "tar-fs": "^1.13.0",
             "tunnel-agent": "^0.6.0",
@@ -3989,7 +4005,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
             }
           }
@@ -4050,7 +4066,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
             }
           }
@@ -4065,7 +4081,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -4146,7 +4162,7 @@
           "dependencies": {
             "async": {
               "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
               "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
             },
             "coffee-script": {
@@ -4238,7 +4254,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -4282,16 +4298,16 @@
           }
         },
         "tar-stream": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
-          "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+          "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
           "requires": {
             "bl": "^1.0.0",
-            "buffer-alloc": "^1.1.0",
+            "buffer-alloc": "^1.2.0",
             "end-of-stream": "^1.0.0",
             "fs-constants": "^1.0.0",
             "readable-stream": "^2.3.0",
-            "to-buffer": "^1.1.0",
+            "to-buffer": "^1.1.1",
             "xtend": "^4.0.0"
           },
           "dependencies": {
@@ -4302,7 +4318,7 @@
             },
             "readable-stream": {
               "version": "2.3.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
               "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -4465,7 +4481,7 @@
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "requires": {
             "string-width": "^1.0.1",
@@ -4504,7 +4520,7 @@
         },
         "yargs": {
           "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "requires": {
             "camelcase": "^2.0.1",

--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "2.1.2"
+    "atom-package-manager": "2.1.3"
   }
 }


### PR DESCRIPTION
### Description of the Change

This change updates `apm` to make use of the fix for duplicated repo-local package installs: https://github.com/atom/apm/pull/821.  This should fix an issue where build times were gradually increasing as we consolidate more bundled packages back into the `./packages` folder.

### Alternate Designs

None.

### Possible Drawbacks

None.

### Verification Process

- [x] CI build does not show individual `apm install`s for bundled packages that have already been consolidated
- [x] CI tests are green for consolidated bundled packages
- [x] Local build contains all consolidated packages that are represented both in `packageDependencies` and `dependencies`