### PR TITLE
Add libcurl3 and libcurl4 as deps for .deb package

### DIFF
--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, gconf2, gconf-service, libgtk-3-0 (>= 3.9.10), libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libcap2, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1
+Depends: git, gconf2, gconf-service, libgtk-3-0 (>= 3.9.10), libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libcap2, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4
 Recommends: lsb-release
 Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
 Section: devel


### PR DESCRIPTION
### Identify the Bug

https://github.com/atom/github/issues/848

### Description of the Change

This change adds `libcurl3` and `libcurl4` as dependencies of the .deb package to ensure one of them is available for `dugite`.

### Alternate Designs

None.

### Possible Drawbacks

None.

### Verification Process

- [x] Green CI builds on VSTS (Ubuntu 18.04) and Travis CI (Ubuntu 14.04)
