### PR TITLE
Don't mutate Pane serialized state during deserialization

### DIFF
--- a/src/pane.js
+++ b/src/pane.js
@@ -41,13 +41,13 @@ class Pane {
       )
     }
 
-    return new Pane(Object.assign(state, {
+    return new Pane(Object.assign({
       deserializerManager: deserializers,
       notificationManager: notifications,
       viewRegistry: views,
       config,
       applicationDelegate
-    }))
+    }, state))
   }
 
   constructor (params = {}) {


### PR DESCRIPTION
### Identify the Bug

#18221

### Description of the Change

Don't `Object.assign` into the serialized state object.

### Alternate Designs

none

### Possible Drawbacks

None I can imagine unless this strange behavior was relied upon for some reason.

### Verification Process

`atom --test spec` resulted in the following output

```
Project
  .replace
    it clears a project through replace with no params
      Expected 'buzz' to be undefined.
        at jasmine.Spec.it (/Users/tjfryan/atom/spec/project-spec.js:304:38)
      Expected [ '/var/folders/8h/s7w820y96yj0k72y8dbjlzgx234zj0/T/project-path1118910-8465-1x2mi1x.8u3l', '/var/folders/8h/s7w820y96yj0k72y8dbjlzgx234zj0/T/project-path2118910-8465-1l4r37f.hzpl' ] to equal [  ].
        at jasmine.Spec.it (/Users/tjfryan/atom/spec/project-spec.js:305:39)
    it responds to change of project specification
      Expected false to be true.
        at jasmine.Spec.it (/Users/tjfryan/atom/spec/project-spec.js:318:25)


Finished in 447.432 seconds
2088 tests, 10986 assertions, 3 failures, 2 skipped
```
None of the failures appear to be related
