### PR TITLE
Add a command to log the syntax tree

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -198,11 +198,11 @@ class Cursor extends Model {
     return this.editor.scopeDescriptorForBufferPosition(this.getBufferPosition())
   }
 
-  // Public: Retrieves the syntax tree descriptor for the cursor's current position.
+  // Public: Retrieves the syntax tree scope descriptor for the cursor's current position.
   //
   // Returns a {ScopeDescriptor}
-  getSyntaxTree () {
-    return this.editor.syntaxTreeForBufferPosition(this.getBufferPosition())
+  getSyntaxTreeScopeDescriptor () {
+    return this.editor.syntaxTreeScopeDescriptorForBufferPosition(this.getBufferPosition())
   }
 
   // Public: Returns true if this cursor has no non-whitespace characters before

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -198,6 +198,13 @@ class Cursor extends Model {
     return this.editor.scopeDescriptorForBufferPosition(this.getBufferPosition())
   }
 
+  // Public: Retrieves the syntax tree descriptor for the cursor's current position.
+  //
+  // Returns a {ScopeDescriptor}
+  getSyntaxTree () {
+    return this.editor.syntaxTreeForBufferPosition(this.getBufferPosition())
+  }
+
   // Public: Returns true if this cursor has no non-whitespace characters before
   // its current position.
   hasPrecedingCharactersOnLine () {

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -273,7 +273,7 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
         @foldAllAtIndentLevel(8)
         @scrollToCursorPosition()
       'editor:log-cursor-scope': -> showCursorScope(@getCursorScope(), notificationManager)
-      'editor:log-cursor-syntax-tree': -> showSyntaxTree(@getSyntaxTree(), notificationManager)
+      'editor:log-cursor-syntax-tree-scope': -> showSyntaxTree(@getCursorSyntaxTreeScope(), notificationManager)
       'editor:copy-path': -> copyPathToClipboard(this, project, clipboard, false)
       'editor:copy-project-path': -> copyPathToClipboard(this, project, clipboard, true)
       'editor:toggle-indent-guide': -> config.set('editor.showIndentGuide', not config.get('editor.showIndentGuide'))

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -273,6 +273,7 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
         @foldAllAtIndentLevel(8)
         @scrollToCursorPosition()
       'editor:log-cursor-scope': -> showCursorScope(@getCursorScope(), notificationManager)
+      'editor:log-cursor-syntax-tree': -> showSyntaxTree(@getSyntaxTree(), notificationManager)
       'editor:copy-path': -> copyPathToClipboard(this, project, clipboard, false)
       'editor:copy-project-path': -> copyPathToClipboard(this, project, clipboard, true)
       'editor:toggle-indent-guide': -> config.set('editor.showIndentGuide', not config.get('editor.showIndentGuide'))
@@ -331,6 +332,13 @@ showCursorScope = (descriptor, notificationManager) ->
   list = descriptor.scopes.toString().split(',')
   list = list.map (item) -> "* #{item}"
   content = "Scopes at Cursor\n#{list.join('\n')}"
+
+  notificationManager.addInfo(content, dismissable: true)
+
+showSyntaxTree = (descriptor, notificationManager) ->
+  list = descriptor.scopes.toString().split(',')
+  list = list.map (item) -> "* #{item}"
+  content = "Syntax tree at Cursor\n#{list.join('\n')}"
 
   notificationManager.addInfo(content, dismissable: true)
 

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -3850,6 +3850,28 @@ class TextEditor {
       : new ScopeDescriptor({scopes: ['text']})
   }
 
+  // Essential: Get the syntactic tree {ScopeDescriptor} for the given position in buffer
+  // coordinates or the syntactic {ScopeDescriptor} for TextMate language mode
+  //
+  // For example, if called with a position inside the parameter list of a
+  // JavaScript class function, this method returns a {ScopeDescriptor} with
+  // the following syntax nodes array:
+  // `["source.js", "program", "expression_statement", "assignment_expression", "class", "class_body", "method_definition", "formal_parameters", "identifier"]`
+  // if tree-sitter is used
+  // and the following scopes array:
+  // `["source.js"]`
+  // if textmate is used
+  //
+  // * `bufferPosition` A {Point} or {Array} of `[row, column]`.
+  //
+  // Returns a {ScopeDescriptor}.
+  syntaxTreeForBufferPosition (bufferPosition) {
+    const languageMode = this.buffer.getLanguageMode()
+    return languageMode.syntaxTreeForPosition
+      ? languageMode.syntaxTreeForPosition(bufferPosition)
+      : this.scopeDescriptorForBufferPosition(bufferPosition)
+  }
+
   // Extended: Get the range in buffer coordinates of all tokens surrounding the
   // cursor that match the given scope selector.
   //
@@ -3879,6 +3901,11 @@ class TextEditor {
   // Get the scope descriptor at the cursor.
   getCursorScope () {
     return this.getLastCursor().getScopeDescriptor()
+  }
+
+  // Get the syntax nodes at the cursor.
+  getSyntaxTree () {
+    return this.getLastCursor().getSyntaxTree()
   }
 
   tokenForBufferPosition (bufferPosition) {

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -3865,10 +3865,10 @@ class TextEditor {
   // * `bufferPosition` A {Point} or {Array} of `[row, column]`.
   //
   // Returns a {ScopeDescriptor}.
-  syntaxTreeForBufferPosition (bufferPosition) {
+  syntaxTreeScopeDescriptorForBufferPosition (bufferPosition) {
     const languageMode = this.buffer.getLanguageMode()
-    return languageMode.syntaxTreeForPosition
-      ? languageMode.syntaxTreeForPosition(bufferPosition)
+    return languageMode.syntaxTreeScopeDescriptorForPosition
+      ? languageMode.syntaxTreeScopeDescriptorForPosition(bufferPosition)
       : this.scopeDescriptorForBufferPosition(bufferPosition)
   }
 
@@ -3904,8 +3904,8 @@ class TextEditor {
   }
 
   // Get the syntax nodes at the cursor.
-  getSyntaxTree () {
-    return this.getLastCursor().getSyntaxTree()
+  getCursorSyntaxTreeScope () {
+    return this.getLastCursor().getSyntaxTreeScopeDescriptor()
   }
 
   tokenForBufferPosition (bufferPosition) {

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -429,7 +429,7 @@ class TreeSitterLanguageMode {
     })
   }
 
-  syntaxTreeForPosition (point) {
+  syntaxTreeScopeDescriptorForPosition (point) {
     if (!this.tree) return this.rootScopeDescriptor
     point = Point.fromObject(point)
 

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -429,6 +429,45 @@ class TreeSitterLanguageMode {
     })
   }
 
+  syntaxTreeForPosition (point) {
+    if (!this.tree) return this.rootScopeDescriptor
+    point = Point.fromObject(point)
+
+    const iterators = []
+    this._forEachTreeWithRange(new Range(point, point), tree => {
+      const rootStartIndex = tree.rootNode.startIndex
+      let node = tree.rootNode.descendantForPosition(point)
+
+      // Don't include anonymous token types like '(' because they prevent scope chains
+      // from being parsed as CSS selectors by the `slick` parser. Other css selector
+      // parsers like `postcss-selector-parser` do allow arbitrary quoted strings in
+      // selectors.
+      if (!node.isNamed) node = node.parent
+      iterators.push({node, rootStartIndex})
+    })
+
+    iterators.sort(compareScopeDescriptorIterators)
+    const scopes = []
+
+    for (;;) {
+      const {length} = iterators
+      if (!length) break
+      const iterator = iterators[length - 1]
+      scopes.push(iterator.node.type)
+      iterator.node = iterator.node.parent
+      if (iterator.node) {
+        let i = length - 1
+        while (i > 0 && compareScopeDescriptorIterators(iterator, iterators[i - 1]) < 0) i--
+        if (i < length - 1) iterators.splice(i, 0, iterators.pop())
+      } else {
+        iterators.pop()
+      }
+    }
+
+    scopes.push(this.grammar.scopeName)
+    return new ScopeDescriptor({scopes: scopes.reverse()})
+  }
+
   scopeDescriptorForPosition (point) {
     const iterator = this.buildHighlightIterator()
     const scopes = []
@@ -1100,6 +1139,13 @@ function nodeIsSmaller (left, right) {
   if (!left) return false
   if (!right) return true
   return left.endIndex - left.startIndex < right.endIndex - right.startIndex
+}
+
+function compareScopeDescriptorIterators (a, b) {
+  return (
+    a.node.startIndex - b.node.startIndex ||
+    a.rootStartIndex - b.rootStartIndex
+  )
 }
 
 function last (array) {

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -430,42 +430,27 @@ class TreeSitterLanguageMode {
   }
 
   syntaxTreeScopeDescriptorForPosition (point) {
-    if (!this.tree) return this.rootScopeDescriptor
+    const nodes = []
     point = Point.fromObject(point)
-
-    const iterators = []
     this._forEachTreeWithRange(new Range(point, point), tree => {
-      const rootStartIndex = tree.rootNode.startIndex
       let node = tree.rootNode.descendantForPosition(point)
-
-      // Don't include anonymous token types like '(' because they prevent scope chains
-      // from being parsed as CSS selectors by the `slick` parser. Other css selector
-      // parsers like `postcss-selector-parser` do allow arbitrary quoted strings in
-      // selectors.
-      if (!node.isNamed) node = node.parent
-      iterators.push({node, rootStartIndex})
+      while (node) {
+        nodes.push(node)
+        node = node.parent
+      }
     })
 
-    iterators.sort(compareScopeDescriptorIterators)
-    const scopes = []
+    // The nodes are mostly already sorted from smallest to largest,
+    // but for files with multiple syntax trees (e.g. ERB), each tree's
+    // nodes are separate. Sort the nodes from largest to smallest.
+    nodes.reverse()
+    nodes.sort((a, b) =>
+      a.startIndex - b.startIndex || b.endIndex - a.endIndex
+    )
 
-    for (;;) {
-      const {length} = iterators
-      if (!length) break
-      const iterator = iterators[length - 1]
-      scopes.push(iterator.node.type)
-      iterator.node = iterator.node.parent
-      if (iterator.node) {
-        let i = length - 1
-        while (i > 0 && compareScopeDescriptorIterators(iterator, iterators[i - 1]) < 0) i--
-        if (i < length - 1) iterators.splice(i, 0, iterators.pop())
-      } else {
-        iterators.pop()
-      }
-    }
-
-    scopes.push(this.grammar.scopeName)
-    return new ScopeDescriptor({scopes: scopes.reverse()})
+    const nodeTypes = nodes.map(node => node.type)
+    nodeTypes.unshift(this.grammar.scopeName)
+    return new ScopeDescriptor({scopes: nodeTypes})
   }
 
   scopeDescriptorForPosition (point) {
@@ -1139,13 +1124,6 @@ function nodeIsSmaller (left, right) {
   if (!left) return false
   if (!right) return true
   return left.endIndex - left.startIndex < right.endIndex - right.startIndex
-}
-
-function compareScopeDescriptorIterators (a, b) {
-  return (
-    a.node.startIndex - b.node.startIndex ||
-    a.rootStartIndex - b.rootStartIndex
-  )
 }
 
 function last (array) {


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Description of the Change

This adds back the functionality that the `editor:log-cursor-scope` command used to provide when tree-sitter was used. The command will run default back to `editor:log-cursor-scope` if text mate is used for the current editor.

This is because the command is very useful when developing grammars 🙂 

@maxbrunsfeld Opening this as a PR to
* See if you are ok with adding back this functionality with a new command name
* Ask what we should do when it's run on editors with textmate language mode
* Ask if this implementation looks ok
* Ask if I'm naming things in a way that makes sense 😅 

If all is 👍 I can write some tests for this functionality and fill out the rest of the template to get this PR merged.

### Verification Process

- [x] Run the command `editor:log-cursor-syntax-tree-scope` in a JavaScript file with tree-sitter enabled
  - [x] Expected: Show a notification with the syntax tree scope descriptor
- [x] Run the command `editor:log-cursor-syntax-tree-scope` in a JavaScript file with tree-sitter disabled
  - [x] Expected: Show a notification with the scope descriptor
  - [x] Expected: Same ScopeDescriptor is in a notification when also running the `editor:log-cursor-scope` command
- [x] Run the command `editor:log-cursor-syntax-tree-scope` in a CoffeScript file with tree-sitter enabled
  - [x] Expected: Show a notification with the scope descriptor
  - [x] Expected: Same ScopeDescriptor is in a notification when also running the `editor:log-cursor-scope` command
- [x] Run the command `editor:log-cursor-syntax-tree-scope` in a CoffeScript file with tree-sitter disabled
  - [x] Expected: Show a notification with the scope descriptor
  - [x] Expected: Same ScopeDescriptor is in a notification when also running the `editor:log-cursor-scope` command
- [x] Bind the command in your keymap and check that it works when running it from a keybinding
- [x] Passing tests

CoffeScript is a language that currently does not have tree-sitter syntax highlighting

Keymap used for testing the command from a keymap:
```
'atom-text-editor:not([mini])':
  'ctrl-shift-g': 'editor:log-cursor-syntax-tree-scope'
```