### PR TITLE
Update deprecation-cop.less

### DIFF
--- a/packages/deprecation-cop/styles/deprecation-cop.less
+++ b/packages/deprecation-cop/styles/deprecation-cop.less
@@ -13,7 +13,7 @@
 .deprecation-cop {
   overflow: auto;
   -webkit-flex: 1;
-  background-color: @app-background-color !important;
+  background-color: @app-background-color;
 
   .deprecation-overview {    
     &:after {

--- a/packages/deprecation-cop/styles/deprecation-cop.less
+++ b/packages/deprecation-cop/styles/deprecation-cop.less
@@ -28,7 +28,7 @@
   }
 
   .deprecation-info:hover {
-    background-color: @background-color-selected !important;
+    background-color: @background-color-selected;
   }
 
   .deprecation-detail.list-item {


### PR DESCRIPTION
### Requirements for Contributing a Performance Improvement

### Description of the Change

Removing '!important argument from background-color of deprecation-cop'

### Quantitative Performance Benefits

According to #18174 , removing !important makes changing background color changes easier

### Possible Drawbacks

May mess with current background color settings

### Verification Process

Did not verify

### Applicable Issues

N/A