### PR TITLE
Don't soft-wrap spaces and '/' to new lines

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -561,7 +561,7 @@ describe('TextEditor', () => {
           it('wraps to the end of the previous line', () => {
             editor.setCursorScreenPosition([4, 4])
             editor.moveLeft()
-            expect(editor.getCursorScreenPosition()).toEqual([3, 49])
+            expect(editor.getCursorScreenPosition()).toEqual([3, 46])
           })
         })
 
@@ -791,7 +791,7 @@ describe('TextEditor', () => {
         editor.setCursorScreenPosition([0, 2])
         editor.moveToEndOfLine()
         const cursor = editor.getLastCursor()
-        expect(cursor.getScreenPosition()).toEqual([3, 5])
+        expect(cursor.getScreenPosition()).toEqual([4, 4])
       })
     })
 

--- a/src/text-utils.js
+++ b/src/text-utils.js
@@ -99,12 +99,19 @@ const isCJKCharacter = (character) =>
   isKoreanCharacter(character)
 
 const isWordStart = (previousCharacter, character) =>
-  ((previousCharacter === ' ') || (previousCharacter === '\t')) &&
-  ((character !== ' ') && (character !== '\t'))
+  (
+    previousCharacter === ' ' ||
+    previousCharacter === '\t' ||
+    previousCharacter === '-' ||
+    previousCharacter === '/'
+  ) &&
+  (
+    character !== ' ' &&
+    character !== '\t'
+  )  
 
 const isWrapBoundary = (previousCharacter, character) =>
-  isWordStart(previousCharacter, character) || isCJKCharacter(character) ||
-  previousCharacter === '-' || character === '/' || character === ' '
+  isWordStart(previousCharacter, character) || isCJKCharacter(character)
 
 // Does the given string contain at least surrogate pair, variation sequence,
 // or combined character?

--- a/src/text-utils.js
+++ b/src/text-utils.js
@@ -108,7 +108,7 @@ const isWordStart = (previousCharacter, character) =>
   (
     character !== ' ' &&
     character !== '\t'
-  )  
+  )
 
 const isWrapBoundary = (previousCharacter, character) =>
   isWordStart(previousCharacter, character) || isCJKCharacter(character)


### PR DESCRIPTION
### Identify the Bug

Fixes #18195 

### Description of the Change

This change fixes an issue introduced by #17949 where new soft-wrapping behavior was causing spaces and forward slashes `/` to be wrapped to the next line:

![](https://user-images.githubusercontent.com/1789/46509661-4e5c6280-c801-11e8-87d3-62836d013255.png)

This change resolves the issue by changing `isWordStart` to consider `-` and `/` as non-word characters instead of the approach that was taken in #17949.

### Alternate Designs

The alternate design in #17949 caused unwanted regressions in text wrapping.

### Possible Drawbacks

Could cause unexpected wrapping behavior for some users since we haven't soft-wrapped on these characters before in the past.

### Verification Process

- [x] Soft-wrapping on `-`, `/`, and ` ` (space) operates similarly to other editors like TextEdit (see screenshot below)
- [x] CI specs pass

https://user-images.githubusercontent.com/1789/46509661-4e5c6280-c801-11e8-87d3-62836d013255.png