### PR TITLE
Move syntax-aware-selection key bindings to base keymap

### DIFF
--- a/keymaps/base.cson
+++ b/keymaps/base.cson
@@ -8,6 +8,8 @@
 'atom-text-editor:not([mini])':
   # Atom Specific
   'ctrl-shift-c': 'editor:copy-path'
+  'alt-up': 'editor:select-larger-syntax-node'
+  'alt-down': 'editor:select-smaller-syntax-node'
 
   # Sublime Parity
   'tab': 'editor:indent'

--- a/keymaps/darwin.cson
+++ b/keymaps/darwin.cson
@@ -133,8 +133,6 @@
   'cmd-ctrl-left': 'editor:move-selection-left'
   'cmd-ctrl-right': 'editor:move-selection-right'
   'cmd-shift-V': 'editor:paste-without-reformatting'
-  'alt-up': 'editor:select-larger-syntax-node'
-  'alt-down': 'editor:select-smaller-syntax-node'
 
   # Emacs
   'alt-f': 'editor:move-to-end-of-word'


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/18312