### PR TITLE
WIP: Try fixing non-container Linux builds on Azure Pipelines

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,8 +1,3 @@
-resources:
-  containers:
-  - container: atom-linux-ci
-    image: daviwil/atom-linux-ci:latest
-
 jobs:
 
 - job: GetReleaseVersion
@@ -22,7 +17,7 @@ jobs:
 - template: platforms/linux.yml
 
 - job: Release
-  pool:
+  pool: 
     vmImage: vs2015-win2012r2 # needed for Python 2.7 and gyp
 
   dependsOn:

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -6,13 +6,24 @@ jobs:
   variables:
     ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
   pool:
-    # This image is used to host the Docker container that runs the build
     vmImage: ubuntu-16.04
 
-  container: atom-linux-ci
-
   steps:
-  - script: script/build --create-debian-package --create-rpm-package --compress-artifacts
+  - task: NodeTool@0
+    inputs:
+      versionSpec: 8.9.3
+    displayName: Install Node.js 8.9.3
+
+  - script: npm install --global npm@6.2.0
+    displayName: Update npm
+
+  - script: |
+      sudo apt-get update
+      sudo apt-get install -y --no-install-recommends build-essential xvfb clang-3.5 fakeroot git libsecret-1-dev rpm libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgconf2-4 libgtk-3-0
+    displayName: Install apt dependencies
+
+  - script: |
+      script/build --create-debian-package --create-rpm-package --compress-artifacts
     env:
       ATOM_RELEASE_VERSION: $(ReleaseVersion)
     displayName: Build Atom
@@ -20,7 +31,11 @@ jobs:
   - script: script/lint
     displayName: Run linter
 
-  - script: script/test
+  - script: |
+      sudo /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
+      export DISPLAY=':99.0'
+      Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+      script/test
     env:
       CI: true
       CI_PROVIDER: VSTS

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -23,7 +23,7 @@ jobs:
     displayName: Install apt dependencies
 
   - script: |
-      script/build --create-debian-package --create-rpm-package --compress-artifacts
+      CC=clang-3.5 CXX=clang++-3.5 npm_config_clang=1 script/build --create-debian-package --create-rpm-package --compress-artifacts
     env:
       ATOM_RELEASE_VERSION: $(ReleaseVersion)
     displayName: Build Atom

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -1,10 +1,5 @@
 trigger: none  # No CI builds, only PR builds
 
-resources:
-  containers:
-  - container: atom-linux-ci
-    image: daviwil/atom-linux-ci:latest
-
 jobs:
 
 - job: GetReleaseVersion

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -2,11 +2,6 @@ trigger:
 - master
 - 1.* # VSTS only supports wildcards at the end
 
-resources:
-  containers:
-  - container: atom-linux-ci
-    image: daviwil/atom-linux-ci:latest
-
 jobs:
 
 - job: GetReleaseVersion
@@ -26,7 +21,7 @@ jobs:
 - template: platforms/linux.yml
 
 - job: UploadArtifacts
-  pool:
+  pool: 
     vmImage: vs2015-win2012r2 # needed for python 2.7 and gyp
 
   dependsOn:
@@ -40,7 +35,7 @@ jobs:
     IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
     IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
 
-  steps:
+  steps:  
   - task: NodeTool@0
     inputs:
       versionSpec: 8.9.3


### PR DESCRIPTION
This change is a quick experiment to see if I can get non-container builds working on Azure Pipelines so that we can start running render process tests as part of CI again.