### PR TITLE
maintainGrammar -> maintainLanguageMode

### DIFF
--- a/src/text-editor-registry.js
+++ b/src/text-editor-registry.js
@@ -185,7 +185,7 @@ class TextEditorRegistry {
   // Returns a {Disposable} that can be used to stop updating the editor's
   // grammar.
   maintainGrammar (editor) {
-    atom.grammars.maintainGrammar(editor.getBuffer())
+    atom.grammars.maintainLanguageMode(editor.getBuffer())
   }
 
   // Deprecated: Force a {TextEditor} to use a different grammar than the


### PR DESCRIPTION
Not sure if this will work. But it seems that `maintainGrammar` doesn't exist and was replaced with `maintainLanguageMode` and that this was never changed.

/cc: @maxbrunsfeld 