### PR TITLE
Style operators in typescript and flow in one-dark/light-syntax

### DIFF
--- a/packages/one-dark-syntax/index.less
+++ b/packages/one-dark-syntax/index.less
@@ -16,6 +16,7 @@
 @import "styles/syntax/ini.less";
 @import "styles/syntax/java.less";
 @import "styles/syntax/javascript.less";
+@import "styles/syntax/typescript.less";
 @import "styles/syntax/json.less";
 @import "styles/syntax/ng.less";
 @import "styles/syntax/ruby.less";

--- a/packages/one-dark-syntax/styles/syntax/typescript.less
+++ b/packages/one-dark-syntax/styles/syntax/typescript.less
@@ -1,0 +1,11 @@
+.syntax--source.syntax--ts {
+  .syntax--keyword.syntax--operator {
+    color: @hue-1;
+  }
+}
+
+.syntax--source.syntax--flow {
+  .syntax--keyword.syntax--operator {
+    color: @hue-1;
+  }
+}

--- a/packages/one-light-syntax/index.less
+++ b/packages/one-light-syntax/index.less
@@ -16,6 +16,7 @@
 @import "styles/syntax/ini.less";
 @import "styles/syntax/java.less";
 @import "styles/syntax/javascript.less";
+@import "styles/syntax/typescript.less";
 @import "styles/syntax/json.less";
 @import "styles/syntax/ng.less";
 @import "styles/syntax/ruby.less";

--- a/packages/one-light-syntax/styles/syntax/typescript.less
+++ b/packages/one-light-syntax/styles/syntax/typescript.less
@@ -1,0 +1,11 @@
+.syntax--source.syntax--ts {
+  .syntax--keyword.syntax--operator {
+    color: @hue-1;
+  }
+}
+
+.syntax--source.syntax--flow {
+  .syntax--keyword.syntax--operator {
+    color: @hue-1;
+  }
+}


### PR DESCRIPTION
### Description of the Change

@simurai When testing https://github.com/atom/language-javascript/pull/612 I noticed that operators are not styled the same in typescript as they are in javascript.

This PR is an attempt to style them in one-dark and one-light syntax to look the same as javascript. I've never done anything in less so I probably messed something up 😅

Let me know what you think about this 🙇 

### Alternate Designs

They are given the same class (`keyword.operator.js`) so we might be able to style all of these in the same file instead having a separate `typescript.less` file.

### Possible Drawbacks

Someone likes that operators are not styled and doesn't want this change

### Verification Process

I checked that operators are styled when using the typescript language mode.