### PR TITLE
Add "Release Notes" section to PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -39,3 +39,21 @@ We must be able to understand the design of your change from this description. I
 What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
 
 -->
+
+### Release Notes
+
+<!--
+
+Please describe the changes in a single line that explains this improvement in
+terms that a user can understand.  This text will be used in Atom's release notes.
+
+If this change is not user-facing or notable enough to be included in release notes
+you may use the strings "Not applicable" or "N/A" here.
+
+Examples:
+
+- The GitHub package now allows you to add co-authors to commits.
+- Fixed an issue where multiple cursors did not work in a file with a single line.
+- Increased the performance of searching and replacing across a whole project.
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -10,3 +10,21 @@
 We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.
 
 -->
+
+### Release Notes
+
+<!--
+
+Please describe the changes in a single line that explains this improvement in
+terms that a user can understand.  This text will be used in Atom's release notes.
+
+If this change is not user-facing or notable enough to be included in release notes
+you may use the strings "Not applicable" or "N/A" here.
+
+Examples:
+
+- The GitHub package now allows you to add co-authors to commits.
+- Fixed an issue where multiple cursors did not work in a file with a single line.
+- Increased the performance of searching and replacing across a whole project.
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/feature_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_change.md
@@ -50,3 +50,21 @@ What process did you follow to verify that your change has the desired effects?
 Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
 
 -->
+
+### Release Notes
+
+<!--
+
+Please describe the changes in a single line that explains this improvement in
+terms that a user can understand.  This text will be used in Atom's release notes.
+
+If this change is not user-facing or notable enough to be included in release notes
+you may use the strings "Not applicable" or "N/A" here.
+
+Examples:
+
+- The GitHub package now allows you to add co-authors to commits.
+- Fixed an issue where multiple cursors did not work in a file with a single line.
+- Increased the performance of searching and replacing across a whole project.
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/performance_improvement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/performance_improvement.md
@@ -35,3 +35,21 @@ What process did you follow to verify that the change has not introduced any reg
 ### Applicable Issues
 
 <!-- Enter any applicable Issues here -->
+
+### Release Notes
+
+<!--
+
+Please describe the changes in a single line that explains this improvement in
+terms that a user can understand.  This text will be used in Atom's release notes.
+
+If this change is not user-facing or notable enough to be included in release notes
+you may use the strings "Not applicable" or "N/A" here.
+
+Examples:
+
+- The GitHub package now allows you to add co-authors to commits.
+- Fixed an issue where multiple cursors did not work in a file with a single line.
+- Increased the performance of searching and replacing across a whole project.
+
+-->


### PR DESCRIPTION
### Description of the Change

This change adds a "Release Notes" section to our PR templates so that contributors can help our release process by adding appropriate release notes for the change they are contributing.

This section of the PR template may be targeted by automation in the future, both to prevent PRs without Release Notes from being merged and also to consume these notes for changelog generation.