### PR TITLE
Fix error causing tree-sitter highlighting to get out-of-sync when editing rapidly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5529,9 +5529,9 @@
       "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg=="
     },
     "tree-sitter": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.13.15.tgz",
-      "integrity": "sha512-FuvU+csO7t/rQqLdL3+w4Jg+4Zl22Y4uCi4L9X/qJG57Zn71ZzP3oHtDSRgpiIms6g3Y7cEJvF7K/rCw11q92Q==",
+      "version": "0.13.16",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.13.16.tgz",
+      "integrity": "sha512-VWPg7cbqEk3vMM6ehAlGKRx44P2FQZgOjvObHTowM7uwI7Z2K+TF2GBI65JwYRTiRkOfbPEIRLDLA2oPQfvDMA==",
       "requires": {
         "nan": "^2.10.0",
         "prebuild-install": "^5.0.0"
@@ -5543,15 +5543,16 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "prebuild-install": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.1.0.tgz",
-          "integrity": "sha512-jGdh2Ws5OUCvBm+aQ/je7hgOBfLIFcgnF9DZ1PIEvht0JKfMwn3Gy0MPHL16JcAUI6tu7LX0D3VxmvMm1XZwAw==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.1.tgz",
+          "integrity": "sha512-9DAccsInWHB48TBQi2eJkLPE049JuAI6FjIH0oIrij4bpDVEbX6JvlWRAcAAlUqBHhjgq0jNqA3m3bBXWm9v6w==",
           "requires": {
             "detect-libc": "^1.0.3",
             "expand-template": "^1.0.2",
             "github-from-package": "0.0.0",
             "minimist": "^1.2.0",
             "mkdirp": "^0.5.1",
+            "napi-build-utils": "^1.0.1",
             "node-abi": "^2.2.0",
             "noop-logger": "^0.1.1",
             "npmlog": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "temp": "^0.8.3",
     "text-buffer": "13.14.10",
     "timecop": "https://www.atom.io/api/packages/timecop/versions/0.36.2/tarball",
-    "tree-sitter": "0.13.15",
+    "tree-sitter": "0.13.16",
     "tree-sitter-css": "^0.13.7",
     "tree-view": "https://www.atom.io/api/packages/tree-view/versions/0.224.2/tarball",
     "typescript-simple": "1.0.0",


### PR DESCRIPTION
### Identify the Bug

When using Tree-sitter, it was previously possible to get the buffer and the syntax tree into an inconsistent state by making many rapid changes to the buffer.

See also:
* https://twitter.com/jetzajac/status/1054895895760773120
* https://github.com/atom/language-python/issues/281#issuecomment-434021610

### Description of the Change

Whenever you make a change to a buffer that's using Tree-sitter, we start incrementally re-parsing the buffer. If that parse does *not* complete quickly, we allow it to finish parsing in the background. Then, if you make additional edits while that parse is still going, we need to store those edits so that we can apply them after-the-fact to the new syntax tree.

We store the edits in a `Patch` in order to group the changes efficiently. Unfortunately, the code that was mutating that patch was passing the wrong values to `Patch.splice`. I'm not sure how this huge logic error didn't cause more problems than it did!

### Verification Process

The easiest way I found to reproduce the original bug was to open a large JavaScript file, place the cursor somewhere near the top of the file, and hold down `command-x` (`Editor: Delete Line`). Previously, you would periodically get broken syntax highlighting.

Now, with this change, I'm not seeing this problem.

### Release Notes

* Fixed an issue where making many rapid edits could cause incorrect syntax highlighting to be rendered.