### PR TITLE
Focused pane marker

### DIFF
--- a/packages/one-dark-ui/styles/tabs.less
+++ b/packages/one-dark-ui/styles/tabs.less
@@ -213,7 +213,7 @@
 }
 
 
-// Active pane marker --------------
+// Active/focused pane marker --------------
 
 atom-pane-axis > atom-pane.active,
 atom-pane-container > atom-pane.pane {
@@ -226,6 +226,11 @@ atom-pane-container > atom-pane.pane {
     left: -1px; // cover left border
     bottom: 0;
     width: 2px;
+    background: mix(@text-color, @tab-background-color-editor, 33%);
+  }
+}
+.pane:focus-within {
+  .tab.active:before {
     background: @accent-color;
   }
 }

--- a/packages/one-light-ui/styles/tabs.less
+++ b/packages/one-light-ui/styles/tabs.less
@@ -213,7 +213,7 @@
 }
 
 
-// Active pane marker --------------
+// Active/focused pane marker --------------
 
 atom-pane-axis > atom-pane.active,
 atom-pane-container > atom-pane.pane {
@@ -226,6 +226,11 @@ atom-pane-container > atom-pane.pane {
     left: -1px; // cover left border
     bottom: 0;
     width: 2px;
+    background: mix(@text-color, @tab-background-color-editor, 33%);
+  }
+}
+.pane:focus-within {
+  .tab.active:before {
     background: @accent-color;
   }
 }


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Issue or RFC Endorsed by Atom's Maintainers

Closes https://github.com/atom/atom/issues/14283

### Description of the Change

This makes the "pane markers" of the One themes have 2 different states:

State | Screenshot
--- | ---
An "active" state -> grey marker | ![1](https://user-images.githubusercontent.com/378023/47843406-db93d680-de02-11e8-80cd-e05d6913ac7a.png)
A "active + focused" state -> blue bar | ![2](https://user-images.githubusercontent.com/378023/47843407-db93d680-de02-11e8-9967-d2310d8aa3cc.png)

This follows a similar pattern used in the tree-view, where the active file is grey, but turns blue when also focused.

![active](https://user-images.githubusercontent.com/378023/47843578-67a5fe00-de03-11e8-80d4-14b9ca8f405b.gif)


### Alternate Designs

Only show the marker when a pane has focus, but it might be nice to see, which of the panes is the active one. For example when opening a new file, you know where it will be opened.

### Possible Drawbacks

Some users might prefer to keep the marker blue all the time.

### Verification Process

1. Open a file
2. Open another file in split mode
3. Click between tree-view and the files and observe the marker switching between grey and blue

### Release Notes

N/A
