### PR TITLE
Distinguish between anonymous * token and wildcard selector

### DIFF
--- a/spec/syntax-scope-map-spec.js
+++ b/spec/syntax-scope-map-spec.js
@@ -74,4 +74,14 @@ describe('SyntaxScopeMap', () => {
     expect(map.get(['a', 'c', 'b'], [0, 1, 1])).toBe('z')
     expect(map.get(['a', 'c', 'b'], [0, 2, 1])).toBe('w')
   })
+
+  it('distinguishes between an anonymous * token and the wildcard selector', () => {
+    const map = new SyntaxScopeMap({
+      '"*"': 'x',
+      'a > "b"': 'y'
+    })
+
+    expect(map.get(['b'], [0], false)).toBe(undefined)
+    expect(map.get(['*'], [0], false)).toBe('x')
+  })
 })

--- a/src/syntax-scope-map.js
+++ b/src/syntax-scope-map.js
@@ -8,8 +8,8 @@ class SyntaxScopeMap {
     for (let selector in resultsBySelector) {
       this.addSelector(selector, resultsBySelector[selector])
     }
-    setTableDefaults(this.namedScopeTable)
-    setTableDefaults(this.anonymousScopeTable)
+    setTableDefaults(this.namedScopeTable, true)
+    setTableDefaults(this.anonymousScopeTable, false)
   }
 
   addSelector (selector, result) {
@@ -126,8 +126,8 @@ class SyntaxScopeMap {
   }
 }
 
-function setTableDefaults (table) {
-  const defaultTypeTable = table['*']
+function setTableDefaults (table, allowWildcardSelector) {
+  const defaultTypeTable = allowWildcardSelector ? table['*'] : null
 
   for (let type in table) {
     let typeTable = table[type]
@@ -138,14 +138,14 @@ function setTableDefaults (table) {
     }
 
     if (typeTable.parents) {
-      setTableDefaults(typeTable.parents)
+      setTableDefaults(typeTable.parents, true)
     }
 
     for (let key in typeTable.indices) {
       const indexTable = typeTable.indices[key]
       mergeTable(indexTable, typeTable, false)
       if (indexTable.parents) {
-        setTableDefaults(indexTable.parents)
+        setTableDefaults(indexTable.parents, true)
       }
     }
   }


### PR DESCRIPTION
Paired with @maxbrunsfeld 

### Identify the Bug

An anonymous token `"*"` is not distinguished with the wildcard selector `*`. So if a tree-sitter grammar has a scope mapping like this:

```
'"*"': 'keyword.operator'
'relational_expression > ">"': 'keyword.operator'
```

It will scope any `>` as `keyword.operator`

### Description of the Change

This changes `setTableDefaults` to add a parameter for allowing wildcard selectors so we can disallow it when mapping the anonymous nodes.

### Verification Process

* This PR https://github.com/atom/language-c/pull/303 adds scope mappings for `relational_expression > ">"` and `"*"` to be `keyword.operator`. Without this change tree-sitter will still scope `>` and `<` in templates as `keyword.operator`
* Passing tests

### Release Notes