### PR TITLE
fixed doc comment js syntax in project::onDidChangeFiles

### DIFF
--- a/src/project.js
+++ b/src/project.js
@@ -208,7 +208,7 @@ class Project extends Model {
   //       console.log(`.. renamed from: ${event.oldPath}`)
   //     }
   //   }
-  // }
+  // })
   //
   // disposable.dispose()
   // ```


### PR DESCRIPTION
### Requirements for Contributing Documentation

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.

### Description of the Change

In https://github.com/atom/atom/blob/44b7c1dd97f4b51de149c92993251af28084eb73/src/project.js#L199-L211 there currently is a closing parenthesis missing.
This PR fixed the syntax error.

Since (I assume) the [API docs page](https://atom.io/docs/api/v1.32.1/Project#instance-onDidChangeFiles) is generated from the docstring the syntax should be correct, since people likely copy the source code.

### Release Notes

- Fixed the JavaScript syntax in the example of `Project::onDidChangeFiles`