### PR TITLE
Optimize tree-sitter HighlightIterator when there are many injections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -157,7 +157,7 @@
     "apparatus": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/apparatus/-/apparatus-0.0.10.tgz",
-      "integrity": "sha1-gep1Z3Ktp3hj21TO7oICwQm9yj4=",
+      "integrity": "sha512-KLy/ugo33KZA7nugtQ7O0E1c8kQ52N3IvD/XgIh4w/Nr28ypfkwDfA67F1ev4N1m5D+BOk1+b2dEJDfpj/VvZg==",
       "requires": {
         "sylvester": ">= 0.0.8"
       }
@@ -348,7 +348,7 @@
     "atom-pathspec": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/atom-pathspec/-/atom-pathspec-0.0.0.tgz",
-      "integrity": "sha1-Z6q6+VAZsK/Y4xWLLNexjXN2Q/E="
+      "integrity": "sha512-7UMEHdTtBV5sJONT0uMeQ6M8JFdfMQy/14rxuP6OuoFfSiDjxyZHuorIbv8gqhRB3FQMMLPzqONoFJE2cpHiCg=="
     },
     "atom-select-list": {
       "version": "0.7.2",
@@ -5132,7 +5132,7 @@
     "spelling-manager": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/spelling-manager/-/spelling-manager-1.1.0.tgz",
-      "integrity": "sha1-UZmGdZUpHgVjlExuL70ao02X3TQ=",
+      "integrity": "sha512-PpTP6XUZflCWO9YZO3wBSGAmqrUP6BFwSdmVFS6WBT9rFYg3ysmrIfyD1KnaVcnW6wuIKf+FDwefvU8PsD8Smg==",
       "requires": {
         "natural": "0.5.0",
         "xregexp": "^3.2.0"
@@ -5224,7 +5224,7 @@
     "streamroller": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
-      "integrity": "sha1-odG3z4PTmvsNYwSaWsv5NJO99ks=",
+      "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
       "requires": {
         "date-format": "^1.2.0",
         "debug": "^3.1.0",
@@ -5447,9 +5447,9 @@
       }
     },
     "text-buffer": {
-      "version": "13.14.10",
-      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.14.10.tgz",
-      "integrity": "sha512-W8ID3TnYdvuvqZCKP+zq3O/A4UwgZCGbp+V/ZifTQ+3JDlSRq6WFIIO9osLqtXnx7wMyhOAgSUGXBDSA5HUtrw==",
+      "version": "13.14.11",
+      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.14.11.tgz",
+      "integrity": "sha512-Cn4dsuHM0MAtejnMAVpYL9FKEuOX2aa9tXorATofW3NEEU57SXkkFudfySzgRPWtx8ysRsZQjFLlCmCRJ6WFig==",
       "requires": {
         "delegato": "^1.0.0",
         "diff": "^2.2.1",
@@ -5696,7 +5696,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "symbols-view": "https://www.atom.io/api/packages/symbols-view/versions/0.118.2/tarball",
     "tabs": "https://www.atom.io/api/packages/tabs/versions/0.109.2/tarball",
     "temp": "^0.8.3",
-    "text-buffer": "13.14.10",
+    "text-buffer": "13.14.11",
     "timecop": "https://www.atom.io/api/packages/timecop/versions/0.36.2/tarball",
     "tree-sitter": "0.13.19",
     "tree-sitter-css": "^0.13.7",


### PR DESCRIPTION
In the course of addressing https://github.com/atom/language-javascript/issues/600, I noticed that when there are a large number of language injections in a large file, highlighting operations and scope descriptor queries become very slow. Specifically, [this line of code](https://github.com/atom/atom/blob/ec72220ad667f55f259264ebe38b02597f73da5c/src/tree-sitter-language-mode.js#L770).

In https://github.com/atom/text-buffer/pull/305, I made it possible to avoid examining every single injection when seeking a highlight iterator. This PR takes advantage of that capability.