### PR TITLE
Optimize populating Tree-sitter syntax tree injections

### DIFF
--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -421,7 +421,11 @@ class GrammarRegistry {
   addInjectionPoint (grammarId, injectionPoint) {
     const grammar = this.treeSitterGrammarsById[grammarId]
     if (grammar) {
-      grammar.injectionPoints.push(injectionPoint)
+      if (grammar.addInjectionPoint) {
+        grammar.addInjectionPoint(injectionPoint)
+      } else {
+        grammar.injectionPoints.push(injectionPoint)
+      }
     } else {
       this.treeSitterGrammarsById[grammarId] = {
         injectionPoints: [injectionPoint]
@@ -429,8 +433,7 @@ class GrammarRegistry {
     }
     return new Disposable(() => {
       const grammar = this.treeSitterGrammarsById[grammarId]
-      const index = grammar.injectionPoints.indexOf(injectionPoint)
-      if (index !== -1) grammar.injectionPoints.splice(index, 1)
+      grammar.removeInjectionPoint(injectionPoint)
     })
   }
 
@@ -454,7 +457,11 @@ class GrammarRegistry {
     if (grammar instanceof TreeSitterGrammar) {
       const existingParams = this.treeSitterGrammarsById[grammar.scopeName] || {}
       if (grammar.scopeName) this.treeSitterGrammarsById[grammar.scopeName] = grammar
-      if (existingParams.injectionPoints) grammar.injectionPoints.push(...existingParams.injectionPoints)
+      if (existingParams.injectionPoints) {
+        for (const injectionPoint of existingParams.injectionPoints) {
+          grammar.addInjectionPoint(injectionPoint)
+        }
+      }
       this.grammarAddedOrUpdated(grammar)
       return new Disposable(() => this.removeGrammar(grammar))
     } else {

--- a/src/tree-sitter-grammar.js
+++ b/src/tree-sitter-grammar.js
@@ -40,7 +40,11 @@ class TreeSitterGrammar {
 
     this.scopeMap = new SyntaxScopeMap(scopeSelectors)
     this.fileTypes = params.fileTypes || []
-    this.injectionPoints = params.injectionPoints || []
+    this.injectionPointsByType = {}
+
+    for (const injectionPoint of params.injectionPoints || []) {
+      this.addInjectionPoint(injectionPoint)
+    }
 
     // TODO - When we upgrade to a new enough version of node, use `require.resolve`
     // with the new `paths` option instead of this private API.
@@ -88,6 +92,25 @@ class TreeSitterGrammar {
 
   deactivate () {
     if (this.registration) this.registration.dispose()
+  }
+
+  addInjectionPoint (injectionPoint) {
+    let injectionPoints = this.injectionPointsByType[injectionPoint.type]
+    if (!injectionPoints) {
+      injectionPoints = this.injectionPointsByType[injectionPoint.type] = []
+    }
+    injectionPoints.push(injectionPoint)
+  }
+
+  removeInjectionPoint (injectionPoint) {
+    const injectionPoints = this.injectionPointsByType[injectionPoint.type]
+    if (injectionPoints) {
+      const index = injectionPoints.indexOf(injectionPoint)
+      if (index !== -1) injectionPoints.splice(index, 1)
+      if (injectionPoints.length === 0) {
+        delete this.injectionPointsByType[injectionPoint.type]
+      }
+    }
   }
 }
 

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -584,12 +584,12 @@ class LanguageLayer {
 
   async update (nodeRangeSet) {
     if (!this.currentParsePromise) {
-      do {
+      while (!this.destroyed && (!this.tree || this.tree.rootNode.hasChanges())) {
         const params = {async: false}
         this.currentParsePromise = this._performUpdate(nodeRangeSet, params)
         if (!params.async) break
         await this.currentParsePromise
-      } while (this.tree && this.tree.rootNode.hasChanges())
+      }
       this.currentParsePromise = null
     }
   }
@@ -610,6 +610,7 @@ class LanguageLayer {
       includedRanges = nodeRangeSet.getRanges()
       if (includedRanges.length === 0) {
         this.tree = null
+        this.destroyed = true
         return
       }
     }
@@ -694,14 +695,15 @@ class LanguageLayer {
     }
 
     const markersToUpdate = new Map()
-    for (const injectionPoint of this.grammar.injectionPoints) {
-      const nodes = this.tree.rootNode.descendantsOfType(
-        injectionPoint.type,
-        range.start,
-        range.end
-      )
+    const nodes = this.tree.rootNode.descendantsOfType(
+      Object.keys(this.grammar.injectionPointsByType),
+      range.start,
+      range.end
+    )
 
-      for (const node of nodes) {
+    let existingInjectionMarkerIndex = 0
+    for (const node of nodes) {
+      for (const injectionPoint of this.grammar.injectionPointsByType[node.type]) {
         const languageName = injectionPoint.language(node)
         if (!languageName) continue
 
@@ -715,10 +717,25 @@ class LanguageLayer {
         if (!injectionNodes.length) continue
 
         const injectionRange = rangeForNode(node)
-        let marker = existingInjectionMarkers.find(m =>
-          m.getRange().isEqual(injectionRange) &&
-          m.languageLayer.grammar === grammar
-        )
+
+        let marker
+        for (let i = existingInjectionMarkerIndex, n = existingInjectionMarkers.length; i < n; i++) {
+          const existingMarker = existingInjectionMarkers[i]
+          const comparison = existingMarker.getRange().compare(injectionRange)
+          if (comparison > 0) {
+            break
+          } else if (comparison === 0) {
+            existingInjectionMarkerIndex = i
+            if (existingMarker.languageLayer.grammar === grammar) {
+              marker = existingMarker
+              marker.id === node.id
+              break
+            }
+          } else {
+            existingInjectionMarkerIndex = i
+          }
+        }
+
         if (!marker) {
           marker = this.languageMode.injectionsMarkerLayer.markRange(injectionRange)
           marker.languageLayer = new LanguageLayer(this.languageMode, grammar, injectionPoint.contentChildTypes)


### PR DESCRIPTION
This is a quick follow-up to https://github.com/atom/atom/pull/18435. It fixes another problem that I discovered when addressing https://github.com/atom/language-javascript/issues/600.

In a very large file, when you make an edit that changes the syntax of a large part of the file (e.g. by introducing an error), there is currently a lot of time spent re-querying injection nodes and populating injections.

In this PR, I restructure that computation so that it does a single [`descendantsOfType`](https://github.com/tree-sitter/node-tree-sitter/blob/81d5f45c07ad55d6de3495cb1cc89273e0bb20be/tree-sitter.d.ts#L81) query with an array of all of the necessary node types. Then it can iterate through these nodes in a single loop, looking up the appropriate injection point(s) for each node.