### PR TITLE
Adjust cursor scope when at end of line

### DIFF
--- a/spec/tree-sitter-language-mode-spec.js
+++ b/spec/tree-sitter-language-mode-spec.js
@@ -1441,6 +1441,13 @@ describe('TreeSitterLanguageMode', () => {
         'property.name'
       ])
 
+      // Drive-by test for .tokenForPosition()
+      const token = editor.tokenForBufferPosition([0, 'foo({b'.length])
+      expect(token.value).toBe('bar')
+      expect(token.scopes).toEqual([
+        'source.js',
+        'property.name'
+      ])
 
       buffer.setText('// baz\n')
 
@@ -1449,14 +1456,6 @@ describe('TreeSitterLanguageMode', () => {
       expect(editor.scopeDescriptorForBufferPosition([0, '// baz'.length]).getScopesArray()).toEqual([
         'source.js',
         'comment.block'
-      ])
-
-      // Drive-by test for .tokenForPosition()
-      const token = editor.tokenForBufferPosition([0, 'foo({b'.length])
-      expect(token.value).toBe('bar')
-      expect(token.scopes).toEqual([
-        'source.js',
-        'property.name'
       ])
     })
 

--- a/spec/tree-sitter-language-mode-spec.js
+++ b/spec/tree-sitter-language-mode-spec.js
@@ -1424,7 +1424,8 @@ describe('TreeSitterLanguageMode', () => {
         parser: 'tree-sitter-javascript',
         scopes: {
           program: 'source.js',
-          property_identifier: 'property.name'
+          property_identifier: 'property.name',
+          comment: 'comment.block'
         }
       })
 
@@ -1438,6 +1439,16 @@ describe('TreeSitterLanguageMode', () => {
       expect(editor.scopeDescriptorForBufferPosition([0, 'foo({'.length]).getScopesArray()).toEqual([
         'source.js',
         'property.name'
+      ])
+
+
+      buffer.setText('// baz\n')
+
+      // Adjust position when at end of line
+      buffer.setLanguageMode(new TreeSitterLanguageMode({buffer, grammar}))
+      expect(editor.scopeDescriptorForBufferPosition([0, '// baz'.length]).getScopesArray()).toEqual([
+        'source.js',
+        'comment.block'
       ])
 
       // Drive-by test for .tokenForPosition()
@@ -1559,6 +1570,15 @@ describe('TreeSitterLanguageMode', () => {
         'object',
         'pair',
         'property_identifier'
+      ])
+
+      buffer.setText('//bar\n')
+
+      buffer.setLanguageMode(new TreeSitterLanguageMode({buffer, grammar}))
+      expect(editor.syntaxTreeScopeDescriptorForBufferPosition([0, 5]).getScopesArray()).toEqual([
+        'source.js',
+        'program',
+        'comment'
       ])
     })
 

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -3865,11 +3865,11 @@ class TextEditor {
   // * `bufferPosition` A {Point} or {Array} of `[row, column]`.
   //
   // Returns a {ScopeDescriptor}.
-  syntaxTreeScopeDescriptorForBufferPosition (bufferPosition, options) {
+  syntaxTreeScopeDescriptorForBufferPosition (bufferPosition) {
     const languageMode = this.buffer.getLanguageMode()
     return languageMode.syntaxTreeScopeDescriptorForPosition
-      ? languageMode.syntaxTreeScopeDescriptorForPosition(bufferPosition, options)
-      : this.scopeDescriptorForBufferPosition(bufferPosition, options)
+      ? languageMode.syntaxTreeScopeDescriptorForPosition(bufferPosition)
+      : this.scopeDescriptorForBufferPosition(bufferPosition)
   }
 
   // Extended: Get the range in buffer coordinates of all tokens surrounding the

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -3843,10 +3843,10 @@ class TextEditor {
   // * `bufferPosition` A {Point} or {Array} of `[row, column]`.
   //
   // Returns a {ScopeDescriptor}.
-  scopeDescriptorForBufferPosition (bufferPosition) {
+  scopeDescriptorForBufferPosition (bufferPosition, options) {
     const languageMode = this.buffer.getLanguageMode()
     return languageMode.scopeDescriptorForPosition
-      ? languageMode.scopeDescriptorForPosition(bufferPosition)
+      ? languageMode.scopeDescriptorForPosition(bufferPosition, options)
       : new ScopeDescriptor({scopes: ['text']})
   }
 
@@ -3865,11 +3865,11 @@ class TextEditor {
   // * `bufferPosition` A {Point} or {Array} of `[row, column]`.
   //
   // Returns a {ScopeDescriptor}.
-  syntaxTreeScopeDescriptorForBufferPosition (bufferPosition) {
+  syntaxTreeScopeDescriptorForBufferPosition (bufferPosition, options) {
     const languageMode = this.buffer.getLanguageMode()
     return languageMode.syntaxTreeScopeDescriptorForPosition
-      ? languageMode.syntaxTreeScopeDescriptorForPosition(bufferPosition)
-      : this.scopeDescriptorForBufferPosition(bufferPosition)
+      ? languageMode.syntaxTreeScopeDescriptorForPosition(bufferPosition, options)
+      : this.scopeDescriptorForBufferPosition(bufferPosition, options)
   }
 
   // Extended: Get the range in buffer coordinates of all tokens surrounding the

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -3843,10 +3843,10 @@ class TextEditor {
   // * `bufferPosition` A {Point} or {Array} of `[row, column]`.
   //
   // Returns a {ScopeDescriptor}.
-  scopeDescriptorForBufferPosition (bufferPosition, options) {
+  scopeDescriptorForBufferPosition (bufferPosition) {
     const languageMode = this.buffer.getLanguageMode()
     return languageMode.scopeDescriptorForPosition
-      ? languageMode.scopeDescriptorForPosition(bufferPosition, options)
+      ? languageMode.scopeDescriptorForPosition(bufferPosition)
       : new ScopeDescriptor({scopes: ['text']})
   }
 

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -479,6 +479,10 @@ class TreeSitterLanguageMode {
 
   scopeDescriptorForPosition (point) {
     point = Point.fromObject(point)
+
+    if (point.column > 0)
+      point.column = Math.min(point.column, this.buffer.lineLengthForRow(point.row) - 1)
+
     const iterator = this.buildHighlightIterator()
     const scopes = []
     for (const scope of iterator.seek(point, point.row + 1)) {

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -457,7 +457,7 @@ class TreeSitterLanguageMode {
     const nodes = []
     point = Point.fromObject(point)
 
-    if (point.column > 0 && point.column == this.buffer.lineLengthForRow(point.row)) {
+    if (point.column > 0 && point.column === this.buffer.lineLengthForRow(point.row)) {
       point.column--
     }
 
@@ -485,7 +485,7 @@ class TreeSitterLanguageMode {
   scopeDescriptorForPosition (point) {
     point = Point.fromObject(point)
 
-    if (point.column > 0 && point.column == this.buffer.lineLengthForRow(point.row)) {
+    if (point.column > 0 && point.column === this.buffer.lineLengthForRow(point.row)) {
       point.column--
     }
 

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -453,9 +453,13 @@ class TreeSitterLanguageMode {
     })
   }
 
-  syntaxTreeScopeDescriptorForPosition (point) {
+  syntaxTreeScopeDescriptorForPosition (point, {includeNewline=false}) {
     const nodes = []
     point = Point.fromObject(point)
+
+    if (!includeNewline && point.column > 0)
+      point.column = Math.min(point.column, this.buffer.lineLengthForRow(point.row) - 1)
+
     this._forEachTreeWithRange(new Range(point, point), tree => {
       let node = tree.rootNode.descendantForPosition(point)
       while (node) {
@@ -477,10 +481,10 @@ class TreeSitterLanguageMode {
     return new ScopeDescriptor({scopes: nodeTypes})
   }
 
-  scopeDescriptorForPosition (point) {
+  scopeDescriptorForPosition (point, {includeNewline=false}) {
     point = Point.fromObject(point)
 
-    if (point.column > 0)
+    if (!includeNewline && point.column > 0)
       point.column = Math.min(point.column, this.buffer.lineLengthForRow(point.row) - 1)
 
     const iterator = this.buildHighlightIterator()

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -455,8 +455,9 @@ class TreeSitterLanguageMode {
 
   syntaxTreeScopeDescriptorForPosition (point) {
     const nodes = []
-    point = Point.fromObject(point)
+    point = this.buffer.clipPosition(Point.fromObject(point, true))
 
+    // If the position is the end of a line, get scope of left character instead of newline
     if (point.column > 0 && point.column === this.buffer.lineLengthForRow(point.row)) {
       point.column--
     }
@@ -483,8 +484,9 @@ class TreeSitterLanguageMode {
   }
 
   scopeDescriptorForPosition (point) {
-    point = Point.fromObject(point)
+    point = this.buffer.clipPosition(Point.fromObject(point, true))
 
+    // If the position is the end of a line, get scope of left character instead of newline
     if (point.column > 0 && point.column === this.buffer.lineLengthForRow(point.row)) {
       point.column--
     }

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -457,8 +457,8 @@ class TreeSitterLanguageMode {
     const nodes = []
     point = Point.fromObject(point)
 
-    if (point.column > 0) {
-      point.column = Math.min(point.column, this.buffer.lineLengthForRow(point.row) - 1)
+    if (point.column > 0 && point.column == this.buffer.lineLengthForRow(point.row)) {
+      point.column--
     }
 
     this._forEachTreeWithRange(new Range(point, point), tree => {
@@ -485,8 +485,8 @@ class TreeSitterLanguageMode {
   scopeDescriptorForPosition (point) {
     point = Point.fromObject(point)
 
-    if (point.column > 0) {
-      point.column = Math.min(point.column, this.buffer.lineLengthForRow(point.row) - 1)
+    if (point.column > 0 && point.column == this.buffer.lineLengthForRow(point.row)) {
+      point.column--
     }
 
     const iterator = this.buildHighlightIterator()

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -453,11 +453,11 @@ class TreeSitterLanguageMode {
     })
   }
 
-  syntaxTreeScopeDescriptorForPosition (point, {includeNewline=false}) {
+  syntaxTreeScopeDescriptorForPosition (point) {
     const nodes = []
     point = Point.fromObject(point)
 
-    if (!includeNewline && point.column > 0)
+    if (point.column > 0)
       point.column = Math.min(point.column, this.buffer.lineLengthForRow(point.row) - 1)
 
     this._forEachTreeWithRange(new Range(point, point), tree => {
@@ -481,10 +481,10 @@ class TreeSitterLanguageMode {
     return new ScopeDescriptor({scopes: nodeTypes})
   }
 
-  scopeDescriptorForPosition (point, {includeNewline=false}) {
+  scopeDescriptorForPosition (point) {
     point = Point.fromObject(point)
 
-    if (!includeNewline && point.column > 0)
+    if (point.column > 0)
       point.column = Math.min(point.column, this.buffer.lineLengthForRow(point.row) - 1)
 
     const iterator = this.buildHighlightIterator()

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -457,8 +457,9 @@ class TreeSitterLanguageMode {
     const nodes = []
     point = Point.fromObject(point)
 
-    if (point.column > 0)
+    if (point.column > 0) {
       point.column = Math.min(point.column, this.buffer.lineLengthForRow(point.row) - 1)
+    }
 
     this._forEachTreeWithRange(new Range(point, point), tree => {
       let node = tree.rootNode.descendantForPosition(point)
@@ -484,8 +485,9 @@ class TreeSitterLanguageMode {
   scopeDescriptorForPosition (point) {
     point = Point.fromObject(point)
 
-    if (point.column > 0)
+    if (point.column > 0) {
       point.column = Math.min(point.column, this.buffer.lineLengthForRow(point.row) - 1)
+    }
 
     const iterator = this.buildHighlightIterator()
     const scopes = []

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -455,10 +455,12 @@ class TreeSitterLanguageMode {
 
   syntaxTreeScopeDescriptorForPosition (point) {
     const nodes = []
-    point = this.buffer.clipPosition(Point.fromObject(point, true))
+    point = this.buffer.clipPosition(Point.fromObject(point))
 
-    // If the position is the end of a line, get scope of left character instead of newline
+    // If the position is the end of a line, get node of left character instead of newline
+    // This is to match TextMate behaviour, see https://github.com/atom/atom/issues/18463
     if (point.column > 0 && point.column === this.buffer.lineLengthForRow(point.row)) {
+      point = point.copy()
       point.column--
     }
 
@@ -484,10 +486,12 @@ class TreeSitterLanguageMode {
   }
 
   scopeDescriptorForPosition (point) {
-    point = this.buffer.clipPosition(Point.fromObject(point, true))
+    point = this.buffer.clipPosition(Point.fromObject(point))
 
     // If the position is the end of a line, get scope of left character instead of newline
+    // This is to match TextMate behaviour, see https://github.com/atom/atom/issues/18463
     if (point.column > 0 && point.column === this.buffer.lineLengthForRow(point.row)) {
+      point = point.copy()
       point.column--
     }
 


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Closes https://github.com/atom/atom/issues/18463
Fixes https://github.com/atom/autocomplete-plus/issues/1006

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

When the cursor is at the end of a non-empty line, it's effective position will be shifted back one column for Tree-sitter grammars (for both scope and node queries).

This is to match the existing TextMate behaviour, which extended the scopes of the last character to the newline character (whether this was intentional IDK).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I considered adding an options object that lets you specify if the newline should be used or not. I decided not to make it for this though, because passing it around started getting more complicated than I wanted.

I also considered implementing it in the text editor API, so the "raw" behaviour could still be accessed using the language mode API, but the position is not necessarily a Point yet at that stage. 

### Possible Drawbacks

If a user really wants to inspect the scope of a newline for a TS grammar, they will be unable to. This has always been true for TextMate grammars, but may be desirable for adoptors of Tree-sitter grammars? I don't know any convincing usecase, and we can add in that options object if someone raises an issue about it.

Behaviour when the row length is 0 and the column number is > 0 will make the column -1, which is sort of bad, but I figured behaviour there is undefined anyway.

### Verification Process

Manually tested, and automatic tests.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

- Adjust cursor scope to left character when at end of line