### PR TITLE
Fix Atom version in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "atom",
-  "version": "1.34.0-dev",
+  "version": "1.35.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
dadc11963b93cc020995b1c6ceebcdcd2db85f92 updated the Atom version from 1.34.0-dev to 1.35.0-dev in `package.json`, but it didn't make the corresponding change in `package-lock.json`. This pull request updates `package-lock.json` to resolve that discrepancy.

