### PR TITLE
Use Tree-sitter for JSON

### DIFF
--- a/packages/atom-dark-syntax/index.less
+++ b/packages/atom-dark-syntax/index.less
@@ -5,3 +5,4 @@
 
 @import "styles/editor.less";
 @import "styles/syntax.less";
+@import "styles/languages.less";

--- a/packages/atom-dark-syntax/styles/languages.less
+++ b/packages/atom-dark-syntax/styles/languages.less
@@ -1,0 +1,7 @@
+// JSON
+
+.syntax--source.syntax--json {
+  .syntax--link {
+    color: #A8FF60;
+  }
+}

--- a/packages/atom-light-syntax/index.less
+++ b/packages/atom-light-syntax/index.less
@@ -5,3 +5,4 @@
 
 @import 'styles/editor.less';
 @import 'styles/syntax.less';
+@import "styles/languages.less";

--- a/packages/atom-light-syntax/styles/languages.less
+++ b/packages/atom-light-syntax/styles/languages.less
@@ -1,0 +1,22 @@
+// JSON ---------------------
+
+.syntax--source.syntax--json {
+  .syntax--key {
+    color: #000080;
+  }
+  .syntax--link {
+    color: #d14;
+  }
+}
+
+// TextMate (deprecated)
+.syntax--source.syntax--json {
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json > .syntax--string.syntax--quoted.syntax--double.syntax--json,
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json > .syntax--string.syntax--quoted.syntax--double.syntax--json .syntax--punctuation.syntax--string {
+    color: #000080;
+  }
+
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--double.syntax--json {
+    color: #d14;
+  }
+}

--- a/packages/atom-light-syntax/styles/syntax.less
+++ b/packages/atom-light-syntax/styles/syntax.less
@@ -129,15 +129,6 @@
 
 
 .syntax--meta {
-  &.syntax--structure.syntax--dictionary.syntax--json > .syntax--string.syntax--quoted.syntax--double.syntax--json,
-  &.syntax--structure.syntax--dictionary.syntax--json > .syntax--string.syntax--quoted.syntax--double.syntax--json .syntax--punctuation.syntax--string {
-    color: #000080;
-  }
-
-  &.syntax--structure.syntax--dictionary.syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--double.syntax--json {
-    color: #d14;
-  }
-
   &.syntax--diff,
   &.syntax--diff.syntax--header {
     color: #75715E;

--- a/packages/base16-tomorrow-dark-theme/styles/syntax/json.less
+++ b/packages/base16-tomorrow-dark-theme/styles/syntax/json.less
@@ -1,4 +1,13 @@
 .syntax--source.syntax--json {
+  .syntax--key {
+    color: @red;
+  }
+}
+
+
+// TextMate (deprecated) ---------------------
+
+.syntax--source.syntax--json {
   .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
     & > .syntax--string.syntax--quoted.syntax--json {
       & > .syntax--punctuation.syntax--string {

--- a/packages/base16-tomorrow-light-theme/styles/syntax/json.less
+++ b/packages/base16-tomorrow-light-theme/styles/syntax/json.less
@@ -1,4 +1,13 @@
 .syntax--source.syntax--json {
+  .syntax--key {
+    color: @red;
+  }
+}
+
+
+// TextMate (deprecated) ---------------------
+
+.syntax--source.syntax--json {
   .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
     & > .syntax--string.syntax--quoted.syntax--json {
       & > .syntax--punctuation.syntax--string {

--- a/packages/one-dark-syntax/styles/syntax/json.less
+++ b/packages/one-dark-syntax/styles/syntax/json.less
@@ -3,3 +3,28 @@
     color: @hue-5;
   }
 }
+
+
+// TextMate (deprecated) ---------------------
+
+.syntax--source.syntax--json {
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
+    & > .syntax--string.syntax--quoted.syntax--json {
+      & > .syntax--punctuation.syntax--string {
+        color: @hue-5;
+      }
+      color: @hue-5;
+    }
+  }
+
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json, .syntax--meta.syntax--structure.syntax--array.syntax--json {
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json,
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json > .syntax--punctuation {
+      color: @hue-4;
+    }
+
+    & > .syntax--constant.syntax--language.syntax--json {
+      color: @hue-1;
+    }
+  }
+}

--- a/packages/one-dark-syntax/styles/syntax/json.less
+++ b/packages/one-dark-syntax/styles/syntax/json.less
@@ -1,21 +1,5 @@
 .syntax--source.syntax--json {
-  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
-    & > .syntax--string.syntax--quoted.syntax--json {
-      & > .syntax--punctuation.syntax--string {
-        color: @hue-5;
-      }
-      color: @hue-5;
-    }
-  }
-
-  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json, .syntax--meta.syntax--structure.syntax--array.syntax--json {
-    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json,
-    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json > .syntax--punctuation {
-      color: @hue-4;
-    }
-
-    & > .syntax--constant.syntax--language.syntax--json {
-      color: @hue-1;
-    }
+  .syntax--key {
+    color: @hue-5;
   }
 }

--- a/packages/one-light-syntax/styles/syntax/json.less
+++ b/packages/one-light-syntax/styles/syntax/json.less
@@ -1,22 +1,5 @@
 .syntax--source.syntax--json {
-  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
-    & > .syntax--string.syntax--quoted.syntax--json {
-      & > .syntax--punctuation.syntax--string {
-        color: @hue-5;
-      }
-      color: @hue-5;
-    }
-  }
-
-  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json,
-  .syntax--meta.syntax--structure.syntax--array.syntax--json {
-    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json,
-    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json > .syntax--punctuation {
-      color: @hue-4;
-    }
-
-    & > .syntax--constant.syntax--language.syntax--json {
-      color: @hue-1;
-    }
+  .syntax--key {
+    color: @hue-5;
   }
 }

--- a/packages/one-light-syntax/styles/syntax/json.less
+++ b/packages/one-light-syntax/styles/syntax/json.less
@@ -3,3 +3,28 @@
     color: @hue-5;
   }
 }
+
+
+// TextMate (deprecated) ---------------------
+
+.syntax--source.syntax--json {
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json {
+    & > .syntax--string.syntax--quoted.syntax--json {
+      & > .syntax--punctuation.syntax--string {
+        color: @hue-5;
+      }
+      color: @hue-5;
+    }
+  }
+
+  .syntax--meta.syntax--structure.syntax--dictionary.syntax--json, .syntax--meta.syntax--structure.syntax--array.syntax--json {
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json,
+    & > .syntax--value.syntax--json > .syntax--string.syntax--quoted.syntax--json > .syntax--punctuation {
+      color: @hue-4;
+    }
+
+    & > .syntax--constant.syntax--language.syntax--json {
+      color: @hue-1;
+    }
+  }
+}


### PR DESCRIPTION
⚠️ Depends on https://github.com/atom/language-json/pull/68

### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

https://github.com/atom/language-json/pull/68

### Description of the Change

This updates the bundled themes to use the Tree-sitter grammar for JSON. Visually nothing should change and syntax highlighting should keep looking like the TextMate grammar. Well, almost. Links seem to include the quotes.

- [x] One
- [x] Atom
- [x] Base16
- [x] Solarized (no changes needed)

TextMate (One Dark) | Tree-sitter  (One Dark)
--- | ---
![TextMate](https://user-images.githubusercontent.com/378023/49275164-bfe12600-f4bd-11e8-8062-6778f312b133.png) | ![Tree-sitter](https://user-images.githubusercontent.com/378023/49275165-bfe12600-f4bd-11e8-8fc9-7ee9d2839249.png)


### Alternate Designs

N/A

### Possible Drawbacks

None


### Verification Process

1. Open a json file e.g. `package.json`
2. Verify that key (red) and value (green) are colored differently

### Release Notes

- JSON now uses Tree-sitter grammars