### PR TITLE
Avoid sending async updates on config update

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -576,7 +576,7 @@ class AtomApplication extends EventEmitter {
 
     this.disposable.add(ipcHelpers.respondTo('set-user-settings', (window, settings, filePath) => {
       if (!this.quitting) {
-        ConfigFile.at(filePath || this.configFilePath).update(JSON.parse(settings))
+        return ConfigFile.at(filePath || this.configFilePath).update(JSON.parse(settings))
       }
     }))
 


### PR DESCRIPTION
In https://github.com/atom/atom/commit/7a5d727e224a7a5fa9c45a1979bb1758c12d8b20 the `'set-user-settings'` callback was changed so that it no longer returned the promise created by `ConfigFile.update()`. This meant that the logic in [`ApplicateDelegate.onDidChangeUserSetting()`](https://github.com/atom/atom/blob/5f0231b/src/application-delegate.js#L193-L206) which uses `.pendingSettingUpdateCount` to avoid triggering in response to calls to
`ApplicationDelegate.setUserSettings` was no longer effective.

I noticed this when updating settings via the setting view. If you type at just the right (wrong?) cadence, you'll notice that your input can get updated with stale values.

Something like this:

```
You type            "a"      "b"            "c"
config.set          "a"      "ab"           "ac"
config.observe                        "a"         "ab"    "ac"
Input value         "a"      "ab"     "a"   "ac"  "ab"    "ac"
```

It's possible that this is the same as https://github.com/atom/settings-view/issues/1062

After this change typing in a settings input seems to behave as expected.