### PR TITLE
Only deref top-level symlinks in node_modules when copying assets

### DIFF
--- a/script/lib/copy-assets.js
+++ b/script/lib/copy-assets.js
@@ -28,7 +28,7 @@ module.exports = function () {
 
   // Run a second copy pass for symlinked directories under node_modules.
   // We do this to ensure that symlinked repo-local bundled packages get
-  // copied to the output folder correctly.  We also copy only the top-level
+  // copied to the output folder correctly.  We dereference only the top-level
   // symlinks and not nested symlinks to avoid issues where symlinked binaries
   // are duplicated in Atom's installation packages (see atom/atom#18490).
   const nodeModulesPath = path.join(CONFIG.repositoryRootPath, 'node_modules')
@@ -36,9 +36,8 @@ module.exports = function () {
     .map(p => path.join(nodeModulesPath, p))
     .filter(p => fs.lstatSync(p).isSymbolicLink())
     .forEach(modulePath => {
+      // Replace the symlink that was copied already
       const destPath = path.join(CONFIG.intermediateAppPath, 'node_modules', path.basename(modulePath))
-
-      // Remove the symlink that was copied already
       fs.unlinkSync(destPath)
       fs.copySync(modulePath, destPath, { filter: includePathInPackagedApp, clobber: true })
     })

--- a/script/lib/copy-assets.js
+++ b/script/lib/copy-assets.js
@@ -32,7 +32,7 @@ module.exports = function () {
   // are duplicated in Atom's installation packages (see atom/atom#18490).
   const nodeModulesPath = path.join(CONFIG.repositoryRootPath, 'node_modules')
   glob.sync(path.join(nodeModulesPath, '*'))
-      .map(p => fs.lstatSync(p).isSymbolicLink() ? fs.readlinkSync(p) : p)
+      .map(p => fs.lstatSync(p).isSymbolicLink() ? path.resolve(nodeModulesPath, fs.readlinkSync(p)) : p)
       .forEach(modulePath => {
         const destPath = path.join(CONFIG.intermediateAppPath, 'node_modules', path.basename(modulePath))
         fs.copySync(modulePath, destPath, { filter: includePathInPackagedApp })

--- a/script/lib/copy-assets.js
+++ b/script/lib/copy-assets.js
@@ -23,8 +23,25 @@ module.exports = function () {
   ]
   srcPaths = srcPaths.concat(glob.sync(path.join(CONFIG.repositoryRootPath, 'spec', '*.*'), {ignore: path.join('**', '*-spec.*')}))
   for (let srcPath of srcPaths) {
-    fs.copySync(srcPath, computeDestinationPath(srcPath), {filter: includePathInPackagedApp, dereference: true})
+    fs.copySync(srcPath, computeDestinationPath(srcPath), {filter: includePathInPackagedApp})
   }
+
+  // Run a second copy pass for symlinked directories under node_modules.
+  // We do this to ensure that symlinked repo-local bundled packages get
+  // copied to the output folder correctly.  We also copy only the top-level
+  // symlinks and not nested symlinks to avoid issues where symlinked binaries
+  // are duplicated in Atom's installation packages (see atom/atom#18490).
+  const nodeModulesPath = path.join(CONFIG.repositoryRootPath, 'node_modules')
+  fs.readdirSync(nodeModulesPath)
+    .map(p => path.join(nodeModulesPath, p))
+    .filter(p => fs.lstatSync(p).isSymbolicLink())
+    .forEach(modulePath => {
+      const destPath = path.join(CONFIG.intermediateAppPath, 'node_modules', path.basename(modulePath))
+
+      // Remove the symlink that was copied already
+      fs.unlinkSync(destPath)
+      fs.copySync(modulePath, destPath, { filter: includePathInPackagedApp, clobber: true })
+    })
 
   fs.copySync(
     path.join(CONFIG.repositoryRootPath, 'resources', 'app-icons', CONFIG.channel, 'png', '1024.png'),

--- a/script/lib/package-application.js
+++ b/script/lib/package-application.js
@@ -29,6 +29,7 @@ module.exports = function () {
     'name': appName,
     'out': CONFIG.buildOutputPath,
     'overwrite': true,
+    'deref-symlinks': false,
     'platform': process.platform,
     'version': CONFIG.appMetadata.electronVersion,
     'version-string': {


### PR DESCRIPTION
### Identify the Bug

Fixes #18490

### Description of the Change

This change fixes an issue that caused some of Atom's installation packages (like the .rpm package) to gain around 2x in size (135 MB to 270 MB) between Atom 1.30 and 1.31.

The core issue came from a [small change](https://github.com/atom/atom/commit/09b45911bc9a2f1195450c1760e00b704ab9623c#diff-b56263f1f1a47bfce6e83ca748aae979) in our packaging logic that caused all symlinks under `node_modules` to be dereferenced.  This was a big problem for `dugite` which includes a full Git binary distribution where many Git commands are symlinked back to the core `git` binary.  Since we dereferenced symlinks, that caused all of these command symlinks to turn into full-sized `git` binaries, bloating our distribution size greatly.

### Alternate Designs

Instead of dereferencing all top-level symlinks under Atom's `node_modules` folder , we could scan the folders under `/packages` and copy those directly into the output folder.  I ultimately thought this was less flexible and forward-looking than scanning symlinks in `node_modules`, but I'm happy to go with the other approach if people think it's necessary.

### Possible Drawbacks

With this logic, other non-package symlinked folders under `node_modules` will also be copied into the output folder if they exist, but this should only be a problem (or benefit?) when producing local Atom builds.

### Verification Process

- [x] Produce full build of Atom and ensure that `git-*` commands are still symlinked inside of:
  - [x] `out/app/node_modules/dugite/git/libexec/gitcore`
  - [x] `out/atom-*/resources/app.asar.unpacked/node_modules/dugite/git/libexec/git-core`
- [x] Produce Atom .rpm package and ensure that it's once again in the neighborhood of 150MB
- [x] Produce release packages on all OSes to ensure that Git functionality works in the GitHub package
  - [x] Windows
  - [x] Linux
  - [x] macOS

### Release Notes

Fixed an issue causing some Atom release packages to double in size