### PR TITLE
:arrow_up: :electron: electron@2.0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "2.0.14",
+  "electronVersion": "2.0.16",
   "dependencies": {
     "@atom/nsfw": "1.0.18",
     "@atom/source-map-support": "^0.3.4",


### PR DESCRIPTION
Updates Electron to [2.0.16](https://github.com/electron/electron/releases/tag/v2.0.16).