### PR TITLE
Delete 'packages/**/node_modules' in script/clean

### DIFF
--- a/script/lib/clean-dependencies.js
+++ b/script/lib/clean-dependencies.js
@@ -3,10 +3,12 @@ const path = require('path')
 const CONFIG = require('../config')
 
 module.exports = function () {
-  // We can't require fs-extra if `script/bootstrap` has never been run, because
-  // it's a third party module. This is okay because cleaning dependencies only
-  // makes sense if dependencies have been installed at least once.
+  // We can't require fs-extra or glob if `script/bootstrap` has never been run,
+  // because they are third party modules. This is okay because cleaning
+  // dependencies only makes sense if dependencies have been installed at least
+  // once.
   const fs = require('fs-extra')
+  const glob = require('glob')
 
   const apmDependenciesPath = path.join(CONFIG.apmRootPath, 'node_modules')
   console.log(`Cleaning ${apmDependenciesPath}`)
@@ -19,4 +21,9 @@ module.exports = function () {
   const scriptDependenciesPath = path.join(CONFIG.scriptRootPath, 'node_modules')
   console.log(`Cleaning ${scriptDependenciesPath}`)
   fs.removeSync(scriptDependenciesPath)
+
+  const bundledPackageDependenciesPaths = path.join(CONFIG.repositoryRootPath, 'packages', '**', 'node_modules')
+  for (const bundledPackageDependencyPath of glob.sync(bundledPackageDependenciesPaths)) {
+    fs.removeSync(bundledPackageDependencyPath)
+  }
 }


### PR DESCRIPTION
### Description of the Change

This change adds an additional step to `script/lib/clean-dependencies.js` which causes `script/clean` to delete `node_modules` folders for repo-local bundled packages under `packages/`.  This is needed because repo-local package folders are symlinked into Atom's `node_modules` folder so deleting that folder doesn't cause those packages' `node_modules` folders to also be deleted.

### Alternate Designs

None.

### Possible Drawbacks

None.

### Verification Process

- [x] Run `script/clean` after building Atom and verify that `node_modules` folders for packages in `packages/` are now deleted

### Release Notes

N/A