### PR TITLE
Move getBuffer out of Event Subscription section

### DIFF
--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -959,9 +959,6 @@ class TextEditor {
     return this.decorationManager.onDidUpdateDecorations(callback)
   }
 
-  // Essential: Retrieves the current {TextBuffer}.
-  getBuffer () { return this.buffer }
-
   // Retrieves the current buffer's URI.
   getURI () { return this.buffer.getUri() }
 
@@ -1074,6 +1071,15 @@ class TextEditor {
     } else {
       return this.editorWidthInChars
     }
+  }
+  
+  /*
+  Section: Buffer
+  */
+
+  // Essential: Retrieves the current {TextBuffer}.
+  getBuffer () {
+    return this.buffer
   }
 
   /*

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -1072,7 +1072,7 @@ class TextEditor {
       return this.editorWidthInChars
     }
   }
-  
+
   /*
   Section: Buffer
   */


### PR DESCRIPTION
### Requirements for Contributing Documentation

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.

### Description of the Change

Because it looks a little silly as-is...
![text-editor-event-subscription-get-buffer](https://user-images.githubusercontent.com/2766036/50531661-fff6f100-0adb-11e9-9f0d-deeb116564e9.png)

### Release Notes

N/A