### PR TITLE
Fix typo in atom.confirm documentation

### DIFF
--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -1010,6 +1010,7 @@ class AtomEnvironment {
   //     window.alert('bummer')
   //   }
   // })
+  // ```
   //
   // ```js
   // // Legacy sync version


### PR DESCRIPTION
There was a missing ```.