### PR TITLE
Compatibility with linter-js-standard-engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,6 +270,7 @@
     "preinstall": "node -e 'process.exit(0)'",
     "test": "node script/test"
   },
+  "standard-engine": "./script/node_modules/standard",
   "standard": {
     "env": {
       "atomtest": true,


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Issue or RFC Endorsed by Atom's Maintainers

Nah. It's a one-line change to the `package.json`.

### Description of the Change

I use the [linter-js-standard-engine](https://atom.io/packages/linter-js-standard-engine) package as a linting service provider for atom-ide-ui. It's great, because it uses the actual version of `standard` (or `eslint`, or whatever) from your `package.json`, and it avoids a host of issues that can arise from linter version drift.

In the Atom repository, though, standard is only a dependency within the `script/` directory, so linter-js-standard-engine won't pick it up. I'm adding a bit of metadata to the `package.json` to override its default linter location logic and find the correct one.

### Alternate Designs

Using a different linter package? Dealing with having a dirty `package.json` all the time? Get used to running `script/lint` and doing it by hand instead?

### Possible Drawbacks

Increases clone and download size by 54 bytes.

### Verification Process

1. Run `apm install linter-js-standard-engine atom-ide-ui`.
2. Clone and open atom/atom. Open an editor on JavaScript source.
3. Ensure that there's no "unable to load linter" error in the diagnostics panel.
4. Add a semicolon and save the file. Ensure that the diagnostic appears.

### Release Notes

_N/A_