### PR TITLE
Document the reversed option to Selection.setBufferRange

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -84,6 +84,8 @@ class Selection {
   //
   // * `bufferRange` The new {Range} to select.
   // * `options` (optional) {Object} with the keys:
+  //   * `reversed` {Boolean} indicating whether to set the selection in a
+  //     reversed orientation.
   //   * `preserveFolds` if `true`, the fold settings are preserved after the
   //     selection moves.
   //   * `autoscroll` {Boolean} indicating whether to autoscroll to the new


### PR DESCRIPTION
### Description of the Change

As it says on the tin. The option is useful when you need to create multiple selections, each with their own `reversed` flag. Since `TextEditor.setSelectedBufferRanges` doesn't take an array of reversed flags, the only way I can find is to set the flags separately using this option.

### Release Notes

Document the reversed option to Selection.setBufferRange.
