### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Atom is only available for 64-bit Linux systems.
 
 Configure your distribution's package manager to install and update Atom by following the [Linux installation instructions](https://flight-manual.atom.io/getting-started/sections/installing-atom/#platform-linux) in the Flight Manual.  You will also find instructions on how to install Atom's official Linux packages without using a package repository, though you will not get automatic updates after installing Atom this way.
 
-### Archive extraction
+#### Archive extraction
 
 An archive is available for people who don't want to install `atom` as root.
 


### PR DESCRIPTION
### Description of the Change

Change sectioning of README.md. Macs can't run the binary file in `atom-amd64.tar.gz`, so I'm nesting this under the linux section, which is where I believe this was intended to be/

### Release Notes

N/A

Sorry for not adding `[ci skip]` to the commit, I had already committed the change and then read the `Contributing.md`

-----
[View rendered README.md](https://github.com/SConaway/atom/blob/patch-1/README.md)