### PR TITLE
Fix application:new-file command

### DIFF
--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -1376,6 +1376,8 @@ or use Pane::saveItemAs for programmatic saving.`)
     for (const {location, stats} of locationStats) {
       const {pathToOpen} = location
       if (!pathToOpen) {
+        // Untitled buffer
+        fileLocationsToOpen.push(location)
         continue
       }
 


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Invoking the `application:new-file` command has no effect.

### Description of the Change

In #18608, I reworked a bunch of the logic used by `AtomApplication::openLocations()` to interpret its `locationsToOpen` argument. This method is responsible for dividing them up into files to open in TextEditors and directories to add as project folders. In the process, I caused a regression in that any `locationsToOpen` elements with a null or undefined `pathToOpen` member would be ignored - but this is how the `application:new-file` command's handlers trigger the opening of an untitled TextEditor. I've restored the previous behavior by passing `locationsToOpen` elements with falsy `pathToOpen` members as "file" locations.

### Alternate Designs

I thought about making the "empty TextEditor" case more explicit, but that's riskier and would take longer.

### Possible Drawbacks

_N/A_

### Verification Process

Open Atom in dev mode and press <kbd>Cmd-N</kbd>.

### Release Notes

_N/A_