### PR TITLE
Improve behavior when restoring session that references a missing project folder

### DIFF
--- a/spec/atom-environment-spec.js
+++ b/spec/atom-environment-spec.js
@@ -742,6 +742,27 @@ describe('AtomEnvironment', () => {
           expect(atom.project.getPaths()).toEqual([])
         })
 
+        it('includes missing mandatory project folders in computation of initial state key', async () => {
+          const existingDir = path.join(__dirname, 'fixtures')
+          const missingDir = path.join(__dirname, 'no')
+
+          atom.loadState.andCallFake(function (key) {
+            if (key === `${existingDir}:${missingDir}`) {
+              return Promise.resolve(state)
+            } else {
+              return Promise.resolve(null)
+            }
+          })
+
+          await atom.openLocations([
+            {pathToOpen: existingDir},
+            {pathToOpen: missingDir, mustBeDirectory: true}
+          ])
+
+          expect(atom.attemptRestoreProjectStateForPaths).toHaveBeenCalledWith(state, [existingDir], [])
+          expect(atom.project.getPaths(), [existingDir])
+        })
+
         it('opens the specified files', async () => {
           await atom.openLocations([{pathToOpen: __dirname}, {pathToOpen: __filename}])
           expect(atom.attemptRestoreProjectStateForPaths).toHaveBeenCalledWith(state, [__dirname], [__filename])

--- a/spec/atom-environment-spec.js
+++ b/spec/atom-environment-spec.js
@@ -669,6 +669,21 @@ describe('AtomEnvironment', () => {
           expect(atom.workspace.getTextEditors().map(e => e.getPath())).toEqual([pathToOpen])
           expect(atom.project.getPaths()).toEqual([])
         })
+
+        it('may be required to be an existing directory', async () => {
+          const nonExistent = path.join(__dirname, 'no')
+          const existingFile = __filename
+          const existingDir = path.join(__dirname, 'fixtures')
+
+          await atom.openLocations([
+            {pathToOpen: nonExistent, mustBeDirectory: true},
+            {pathToOpen: existingFile, mustBeDirectory: true},
+            {pathToOpen: existingDir, mustBeDirectory: true}
+          ])
+
+          expect(atom.workspace.getTextEditors()).toEqual([])
+          expect(atom.project.getPaths()).toEqual([existingDir])
+        })
       })
 
       describe('when the opened path is handled by a registered directory provider', () => {

--- a/spec/atom-environment-spec.js
+++ b/spec/atom-environment-spec.js
@@ -671,6 +671,8 @@ describe('AtomEnvironment', () => {
         })
 
         it('may be required to be an existing directory', async () => {
+          spyOn(atom.notifications, 'addWarning')
+
           const nonExistent = path.join(__dirname, 'no')
           const existingFile = __filename
           const existingDir = path.join(__dirname, 'fixtures')
@@ -683,6 +685,11 @@ describe('AtomEnvironment', () => {
 
           expect(atom.workspace.getTextEditors()).toEqual([])
           expect(atom.project.getPaths()).toEqual([existingDir])
+
+          expect(atom.notifications.addWarning).toHaveBeenCalledWith(
+            'Unable to open project folders',
+            {description: `The directories \`${nonExistent}\` and \`${existingFile}\` do not exist.`}
+          )
         })
       })
 

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -1404,7 +1404,7 @@ or use Pane::saveItemAs for programmatic saving.`)
           // Found: add as a project folder
           foldersToAddToProject.add(directory.getPath())
         } else if (location.mustBeDirectory) {
-          // Not found and must be a directory: add to missing list
+          // Not found and must be a directory: add to missing list and use to derive state key
           missingFolders.push(location)
         } else {
           // Not found: open as a new file
@@ -1416,8 +1416,12 @@ or use Pane::saveItemAs for programmatic saving.`)
     }
 
     let restoredState = false
-    if (foldersToAddToProject.size > 0) {
-      const state = await this.loadState(this.getStateKey(Array.from(foldersToAddToProject)))
+    if (foldersToAddToProject.size > 0 || missingFolders.length > 0) {
+      // Include missing folders in the state key so that sessions restored with no-longer-present project root folders
+      // don't lose data.
+      const foldersForStateKey = Array.from(foldersToAddToProject)
+        .concat(missingFolders.map(location => location.pathToOpen))
+      const state = await this.loadState(this.getStateKey(Array.from(foldersForStateKey)))
 
       // only restore state if this is the first path added to the project
       if (state && needsProjectPaths) {

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -1386,7 +1386,7 @@ or use Pane::saveItemAs for programmatic saving.`)
         if (stats.isDirectory()) {
           // Directory: add as a project folder
           foldersToAddToProject.add(this.project.getDirectoryForProjectPath(pathToOpen).getPath())
-        } else if (stats.isFile()) {
+        } else if (stats.isFile() && !location.mustBeDirectory) {
           // File: add as a file location
           fileLocationsToOpen.push(location)
         }
@@ -1397,7 +1397,7 @@ or use Pane::saveItemAs for programmatic saving.`)
         if (directory) {
           // Found: add as a project folder
           foldersToAddToProject.add(directory.getPath())
-        } else {
+        } else if (!location.mustBeDirectory) {
           // Not found: open as a new file
           fileLocationsToOpen.push(location)
         }

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -1364,6 +1364,7 @@ or use Pane::saveItemAs for programmatic saving.`)
     const needsProjectPaths = this.project && this.project.getPaths().length === 0
     const foldersToAddToProject = new Set()
     const fileLocationsToOpen = []
+    const missingFolders = []
 
     // Asynchronously fetch stat information about each requested path to open.
     const locationStats = await Promise.all(
@@ -1386,9 +1387,13 @@ or use Pane::saveItemAs for programmatic saving.`)
         if (stats.isDirectory()) {
           // Directory: add as a project folder
           foldersToAddToProject.add(this.project.getDirectoryForProjectPath(pathToOpen).getPath())
-        } else if (stats.isFile() && !location.mustBeDirectory) {
-          // File: add as a file location
-          fileLocationsToOpen.push(location)
+        } else if (stats.isFile()) {
+          if (!location.mustBeDirectory) {
+            // File: add as a file location
+            fileLocationsToOpen.push(location)
+          } else {
+            missingFolders.push(location)
+          }
         }
       } else {
         // Path does not exist
@@ -1397,7 +1402,10 @@ or use Pane::saveItemAs for programmatic saving.`)
         if (directory) {
           // Found: add as a project folder
           foldersToAddToProject.add(directory.getPath())
-        } else if (!location.mustBeDirectory) {
+        } else if (location.mustBeDirectory) {
+          // Not found and must be a directory: add to missing list
+          missingFolders.push(location)
+        } else {
           // Not found: open as a new file
           fileLocationsToOpen.push(location)
         }
@@ -1428,6 +1436,33 @@ or use Pane::saveItemAs for programmatic saving.`)
         fileOpenPromises.push(this.workspace && this.workspace.open(pathToOpen, {initialLine, initialColumn}))
       }
       await Promise.all(fileOpenPromises)
+    }
+
+    if (missingFolders.length > 0) {
+      let message = 'Unable to open project folder'
+      if (missingFolders.length > 1) {
+        message += 's'
+      }
+
+      let description = 'The '
+      if (missingFolders.length === 1) {
+        description += 'directory `'
+        description += missingFolders[0].pathToOpen
+        description += '` does not exist.'
+      } else if (missingFolders.length === 2) {
+        description += `directories \`${missingFolders[0].pathToOpen}\` `
+        description += `and \`${missingFolders[1].pathToOpen}\` do not exist.`
+      } else {
+        description += 'directories '
+        description += (missingFolders
+          .slice(0, -1)
+          .map(location => location.pathToOpen)
+          .map(pathToOpen => '`' + pathToOpen + '`, ')
+          .join(''))
+        description += 'and `' + missingFolders[missingFolders.length - 1].pathToOpen + '` do not exist.'
+      }
+
+      this.notifications.addWarning(message, {description})
     }
 
     ipcRenderer.send('window-command', 'window:locations-opened')

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -1388,11 +1388,12 @@ or use Pane::saveItemAs for programmatic saving.`)
           // Directory: add as a project folder
           foldersToAddToProject.add(this.project.getDirectoryForProjectPath(pathToOpen).getPath())
         } else if (stats.isFile()) {
-          if (!location.mustBeDirectory) {
+          if (location.mustBeDirectory) {
+            // File: no longer a directory
+            missingFolders.push(location)
+          } else {
             // File: add as a file location
             fileLocationsToOpen.push(location)
-          } else {
-            missingFolders.push(location)
           }
         }
       } else {

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -249,7 +249,7 @@ class AtomApplication extends EventEmitter {
         timeout,
         env
       })
-    } else if (pathsToOpen.length > 0 || foldersToOpen.length > 0) {
+    } else if ((pathsToOpen && pathsToOpen.length > 0) || (foldersToOpen && foldersToOpen.length > 0)) {
       return this.openPaths({
         pathsToOpen,
         foldersToOpen,


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Fixes #16645.

### Description of the Change

When Atom is launched from the dock or start menu, or from the command-line with no path arguments, it (by default) attempts to restore the previous open windows and session state by reading a file at `~/.atom/storage/application.json`. I've modified the logic to handle root directories listed there that are no longer present by:

* Omitting them from the deserialized window state;
* Displaying a one-time warning listing the directories that were unable to load; and
* Continuing to use now-missing root directories to derive the state key used to identify persisted project state that should be loaded.

I've done this by:

1. Introducing a `foldersToOpen` parameter to `AtomApplication::openLocations()`. These are paths that _must_ be existing directories, in contrast to `pathsToOpen`, which may be files or directories that exist or not.
2. Translating this to `locationsToOpen` with a new key, `mustBeDirectory: true`.
3. Understanding `mustBeDirectory` in `AtomEnvironment::openLocations()` where we actually do the stat() calls. Locations with `mustBeDirectory: true` that are either missing or now files are added to an Array.
4. Concatenating `foldersToOpen` and `missingFolders` to derive the initial state key.
5. Display a (grammatically correct :sparkles:) warning about the folders that are now gone.

### Alternate Designs

I thought about introducing some new syntax for pathsToOpen to indicate that a specific path is required to be a directory, like `+some/path/`. It would have saved me adding another argument to our already-busy open methods, but I didn't want to have _more_ magic in our command-line story.

### Possible Drawbacks

If a user has different stored session state for the set of project folders that are still present, it'll be clobbered by this session.

Because of the way session state is tracked, we can only save one in this case. I chose to go with the session state that the user explicitly requested (assuming they understand that project folder set = session state key, of course).

### Verification Process

1. Open Atom with two project folders, `folder-0` and `folder-1`.
2. Open a buffer within `folder-0` and make unsaved changes.
2. Completely close Atom.
3. Delete `folder-1`.
4. Open Atom with no arguments (`atom`).

Atom should open with `folder-0` as an open project folder, an open buffer with the unsaved changes, and a warning notification saying that `folder-1` is no longer present.

### Release Notes

* When restoring state, project folders that no longer exist will cause a one-time notification and be removed.