### PR TITLE
Fix Windows auto-update support detection

### DIFF
--- a/src/main-process/auto-updater-win32.js
+++ b/src/main-process/auto-updater-win32.js
@@ -39,7 +39,7 @@ class AutoUpdater extends EventEmitter {
   }
 
   supportsUpdates () {
-    SquirrelUpdate.existsSync()
+    return SquirrelUpdate.existsSync()
   }
 
   checkForUpdates () {


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Fixes #18559.

### Description of the Change

The Windows-specific AutoUpdater class had a method that was not returning the result of a delegated call, which was causing it to erroneously enter the "unsupported" state when `core.automaticallyUpdate` was set to "false".

### Alternate Designs

_N/A_

### Possible Drawbacks

_N/A_

### Verification Process

Set `core.automaticallyUpdate` to "false". Launch Atom on Windows and open the About window. The "Check now" button and "Automatically download updates" checkbox should be visible.

### Release Notes

* Fixed a regression that caused Atom to believe it couldn't automatically update on Windows while `core.automaticallyUpdate` was set to "false".