### PR TITLE
Enable dark mode title bar theme in macOS Mojave

### DIFF
--- a/resources/mac/atom-Info.plist
+++ b/resources/mac/atom-Info.plist
@@ -34,6 +34,8 @@
 	<string>AtomApplication</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<string>NO</string>
 	<key>SUScheduledCheckInterval</key>
 	<string>3600</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
### Identify the Bug

Fixes #18111

### Description of the Change

This change makes a small tweak to Atom's `Info.plist` file to enable the display of a dark title bar in macOS Mojave's dark mode.

### Alternate Designs

No alternate designs.

### Possible Drawbacks

None.

### Verification Process

- [x] Build Atom with this change and verify that dark title bar is used in Mojave dark mode:

**Before**

![image](https://user-images.githubusercontent.com/79405/51943298-02e04c80-23ce-11e9-82ef-19ddf7b9b6fc.png)

**After**

![image](https://user-images.githubusercontent.com/79405/51943310-096ec400-23ce-11e9-8411-772f7bdc128e.png)

### Release Notes

When using macOS Mojave's dark mode, Atom now shows a dark title bar