### PR TITLE
Fix restart behavior for "Restart and Install Update" on macOS

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -91,6 +91,7 @@ class AtomApplication extends EventEmitter {
   constructor (options) {
     super()
     this.quitting = false
+    this.quittingForUpdate = false
     this.getAllWindows = this.getAllWindows.bind(this)
     this.getLastFocusedWindow = this.getLastFocusedWindow.bind(this)
     this.resourcePath = options.resourcePath
@@ -384,6 +385,7 @@ class AtomApplication extends EventEmitter {
 
     this.on('application:install-update', () => {
       this.quitting = true
+      this.quittingForUpdate = true
       this.autoUpdateManager.install()
     })
 

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -148,7 +148,7 @@ class AtomWindow extends EventEmitter {
 
   handleEvents () {
     this.browserWindow.on('close', async event => {
-      if (!this.atomApplication.quitting && !this.unloading) {
+      if ((!this.atomApplication.quitting || this.atomApplication.quittingForUpdate) && !this.unloading) {
         event.preventDefault()
         this.unloading = true
         this.atomApplication.saveCurrentWindowOptions(false)


### PR DESCRIPTION
### Identify the Bug

Fixes #17976

### Description of the Change

This change introduces an additional boolean property on `AtomApplication` called `quittingForUpdate` which indicates that Atom is quitting due to a pending update.  This property is then used in the `close` handler on `AtomWindow` so that Atom isn't prevented from shutting down when `this.quitting` is set to `true`.

### Alternate Designs

It's possible that a better design could be found through refactoring Atom's shutdown logic, but that approach is much more likely to introduce new regressions and unexpected behavior.

### Possible Drawbacks

This solution is simple enough that it shouldn't have any drawbacks other than the introduction of another boolean flag.  The upside, however, is that this boolean only needs to be checked in one place and the rest of Atom's shutdown logic can be totally oblivious to it.

### Verification Process

- [x] Ensure that Atom quits and restarts when "Restart and Install Update" is clicked in either the application menu or on the About page
- [x] Ensure that project state is restored correctly after Atom restarts for the update
- [x] Ensure that normal Atom shutdown (`Atom -> Quit`) is not impacted by this change

### Release Notes

On macOS, Atom now restarts correctly when installing new updates with "Restart and Install Update"