### PR TITLE
Use a custom Jasmine reporter to actually show spec names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      env: NODE_VERSION=8.9.3 DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1
+      env: NODE_VERSION=8.9.3 DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1 ATOM_JASMINE_REPORTER=list
 
 sudo: required
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ platform:
 environment:
   global:
     ATOM_DEV_RESOURCE_PATH: c:\projects\atom
+    ATOM_JASMINE_REPORTER: list
     TEST_JUNIT_XML_ROOT: c:\projects\junit-test-results
     NODE_VERSION: 8.9.3
 

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       CI: true
       CI_PROVIDER: VSTS
+      ATOM_JASMINE_REPORTER: list
     displayName: Run tests
     condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
 

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -44,6 +44,7 @@ jobs:
     env:
       CI: true
       CI_PROVIDER: VSTS
+      ATOM_JASMINE_REPORTER: list
     displayName: Run tests
     condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
 

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -69,6 +69,7 @@ jobs:
     env:
       CI: true
       CI_PROVIDER: VSTS
+      ATOM_JASMINE_REPORTER: list
       BUILD_ARCH: $(buildArch)
     displayName: Run tests
     condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))

--- a/spec/jasmine-list-reporter.js
+++ b/spec/jasmine-list-reporter.js
@@ -1,6 +1,6 @@
 const {TerminalReporter} = require('jasmine-tagged')
 
-class JasmineTerminalReporter extends TerminalReporter {
+class JasmineListReporter extends TerminalReporter {
   fullDescription (spec) {
     let fullDescription = spec.description
     let currentSuite = spec.suite
@@ -30,4 +30,4 @@ class JasmineTerminalReporter extends TerminalReporter {
   }
 }
 
-module.exports = { JasmineTerminalReporter }
+module.exports = { JasmineListReporter }

--- a/spec/jasmine-list-reporter.js
+++ b/spec/jasmine-list-reporter.js
@@ -17,10 +17,12 @@ class JasmineListReporter extends TerminalReporter {
 
   reportSpecResults (spec) {
     const result = spec.results()
-    let msg = ''
     if (result.skipped) {
-      msg = this.stringWithColor_(this.fullDescription(spec) + ' [skip]', this.color_.ignore())
-    } else if (result.passed()) {
+      return
+    }
+
+    let msg = ''
+    if (result.passed()) {
       msg = this.stringWithColor_('[pass]', this.color_.pass())
     } else {
       msg = this.stringWithColor_('[FAIL]', this.color_.fail())

--- a/spec/jasmine-terminal-reporter.js
+++ b/spec/jasmine-terminal-reporter.js
@@ -1,0 +1,33 @@
+const {TerminalReporter} = require('jasmine-tagged')
+
+class JasmineTerminalReporter extends TerminalReporter {
+  fullDescription (spec) {
+    let fullDescription = spec.description
+    let currentSuite = spec.suite
+    while (currentSuite) {
+      fullDescription = currentSuite.description + ' > ' + fullDescription
+      currentSuite = currentSuite.parentSuite
+    }
+    return fullDescription
+  }
+
+  reportSpecStarting (spec) {
+    this.print_(this.fullDescription(spec) + ' ')
+  }
+
+  reportSpecResults (spec) {
+    const result = spec.results()
+    let msg = ''
+    if (result.skipped) {
+      msg = this.stringWithColor_(this.fullDescription(spec) + ' [skip]', this.color_.ignore())
+    } else if (result.passed()) {
+      msg = this.stringWithColor_('[pass]', this.color_.pass())
+    } else {
+      msg = this.stringWithColor_('[FAIL]', this.color_.fail())
+      this.addFailureToFailures_(spec)
+    }
+    this.printLine_(msg)
+  }
+}
+
+module.exports = { JasmineTerminalReporter }

--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -94,8 +94,7 @@ buildTerminalReporter = (logFile, resolveWithExitCode) ->
     else
       ipcRenderer.send 'write-to-stderr', str
 
-  {JasmineTerminalReporter} = require './jasmine-terminal-reporter'
-  new JasmineTerminalReporter
+  options =
     print: (str) ->
       log(str)
     onComplete: (runner) ->
@@ -109,3 +108,10 @@ buildTerminalReporter = (logFile, resolveWithExitCode) ->
         resolveWithExitCode(1)
       else
         resolveWithExitCode(0)
+
+  if process.env.ATOM_JASMINE_REPORTER is 'list'
+    {JasmineListReporter} = require './jasmine-list-reporter'
+    new JasmineListReporter(options)
+  else
+    {TerminalReporter} = require 'jasmine-tagged'
+    new TerminalReporter(options)

--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -94,8 +94,8 @@ buildTerminalReporter = (logFile, resolveWithExitCode) ->
     else
       ipcRenderer.send 'write-to-stderr', str
 
-  {TerminalReporter} = require 'jasmine-tagged'
-  new TerminalReporter
+  {JasmineTerminalReporter} = require './jasmine-terminal-reporter'
+  new JasmineTerminalReporter
     print: (str) ->
       log(str)
     onComplete: (runner) ->


### PR DESCRIPTION
Our CI builds have been really flaky again recently, and it's difficult to see _why_ because a renderer crash prevents anything but a bunch of dots from showing up in test output. I'm replacing our Jasmine reporter with one that displays the full name of each spec before it begins so that we can diagnose these issues more rapidly.

#### Remaining work

- [x] Do the same for the main process Mocha tests
- [x] Make the new reporters opt-in