### PR TITLE
Use a temporary directory for ATOM_HOME in tests

### DIFF
--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -1,7 +1,10 @@
 Grim = require 'grim'
 fs = require 'fs-plus'
+temp = require 'temp'
 path = require 'path'
 {ipcRenderer} = require 'electron'
+
+temp.track()
 
 module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
   window[key] = value for key, value of require '../vendor/jasmine'
@@ -17,13 +20,15 @@ module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
     get: -> documentTitle
     set: (title) -> documentTitle = title
 
+  atomHome = temp.mkdirSync prefix: 'atom-test-home-'
+
   ApplicationDelegate = require '../src/application-delegate'
   applicationDelegate = new ApplicationDelegate()
   applicationDelegate.setRepresentedFilename = ->
   applicationDelegate.setWindowDocumentEdited = ->
   window.atom = buildAtomEnvironment({
     applicationDelegate, window, document,
-    configDirPath: process.env.ATOM_HOME
+    configDirPath: atomHome
     enablePersistence: false
   })
 


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

_N/A_

### Description of the Change

Use a temporary directory for `configDirPath` instead of inheriting the local `ATOM_HOME`.

### Alternate Designs

_N/A_

### Possible Drawbacks

_N/A_

### Verification Process

Ran the renderer tests:

```
script/test --core-renderer
```

### Release Notes

* The default Jasmine test runner uses an isolated `ATOM_HOME` to avoid loading user packages.