### PR TITLE
Report macOS renderer crashes in CI

### DIFF
--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -52,6 +52,12 @@ jobs:
       cp $(Build.SourcesDirectory)/out/*.zip $(Build.ArtifactStagingDirectory)
     displayName: Stage Artifacts
 
+  - script: |
+      mkdir -p $(Build.ArtifactStagingDirectory)/crash-reports
+      cp ${HOME}/Library/Logs/DiagnosticReports/*.crash $(Build.ArtifactStagingDirectory)/crash-reports
+    displayName: Stage Crash Reports
+    condition: failed()
+
   - task: PublishBuildArtifacts@1
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/atom-mac.zip
@@ -75,3 +81,10 @@ jobs:
       ArtifactType: Container
     displayName: Upload atom-api.json
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/crash-reports
+      ArtifactName: crash-reports.zip
+    displayName: Upload Crash Reports
+    condition: failed()

--- a/spec/goes-boom-spec.js
+++ b/spec/goes-boom-spec.js
@@ -1,5 +1,0 @@
-describe('crash handler', () => {
-  it('goes boom', () => {
-    process.crash()
-  })
-})

--- a/spec/goes-boom-spec.js
+++ b/spec/goes-boom-spec.js
@@ -1,0 +1,5 @@
+describe('crash handler', () => {
+  it('goes boom', () => {
+    process.crash()
+  })
+})


### PR DESCRIPTION
When we have a renderer process crash in CI, we aren't left with a lot of information to work with. #18788 lets us see at least the name of the crashing spec in the build output, but if the crash location is inconsistent, or if we can't repro locally, we're still out of luck.

If possible, I'd like to upload crash reports from each OS in our Azure DevOps builds so that we can investigate further.

Note that Windows will be the tricky one to handle here. Windows crash dumps include all of the crashed process' environment variables, which can include build secrets in release builds! To avoid leaking those, we'll need to find somewhere private to upload them instead.

##### Remaining work

- [x] macOS
  - [x] Upload crash reports from `~/Library/Logs/DiagnosticReports` as a build artifact