### PR TITLE
Align git-diff icons

### DIFF
--- a/packages/git-diff/styles/git-diff.less
+++ b/packages/git-diff/styles/git-diff.less
@@ -21,7 +21,7 @@ atom-text-editor {
       left: 0;
       height: 0;
       width: 0;
-      content: " ";
+      content: "";
       border: solid transparent;
       border-left-color: @syntax-color-removed;
       border-width: @size;
@@ -41,18 +41,15 @@ atom-text-editor {
     padding-left: 1.4em; // space for diff icon
 
     &:before {
-     .octicon-font();
+      .octicon-font();
+      content: "";
       display: inline-block;
       position: absolute;
-      top: -.05em;
+      top: .2em;
       left: .4em;
-
-      // make sure it doesnt affect the gutter line height.
-      height: 0px;
+      height: 0px; // make sure it doesnt affect the gutter line height.
       width: 1em;
-      content: " ";
-      padding-right: 0.4em;
-      font-size: .95em;
+      font-size: .75em;
     }
 
     &.git-line-modified:before {

--- a/packages/git-diff/styles/git-diff.less
+++ b/packages/git-diff/styles/git-diff.less
@@ -37,15 +37,15 @@ atom-text-editor {
   }
 
   .gutter.git-diff-icon .line-number {
-    width: 100%;
-    border-left: none;
-    padding-left: 0.4em;
+    border-left-width: 0;
+    padding-left: 1.4em; // space for diff icon
 
     &:before {
      .octicon-font();
       display: inline-block;
-      position: relative;
+      position: absolute;
       top: -.05em;
+      left: .4em;
 
       // make sure it doesnt affect the gutter line height.
       height: 0px;
@@ -70,13 +70,12 @@ atom-text-editor {
       border: none; // reset triangle
       content: @dash;
       color: @syntax-color-removed;
-      position: relative;
     }
     &.git-line-removed:before {
-      top: .6em;
+      top: 1em;
     }
     &.git-previous-line-removed:before {
-      top: -.6em;
+      top: 0;
     }
   }
 }


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Closes https://github.com/atom/atom/issues/18684

### Description of the Change

This aligns the git-diff icons when the line numbers increase in digits. The icons are also slightly smaller to make it feel less cramped.

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/378023/52766182-b6ea0480-3069-11e9-802d-f9e1d57a97d4.png) | ![after](https://user-images.githubusercontent.com/378023/52766181-b6516e00-3069-11e9-8e37-f8e0d5a6a88b.png)

### Alternate Designs

We could move the icons to the right of the line number, but there are issues, see  https://github.com/atom/atom/issues/18684. Also, it's nice having the fold icon close to the indent guides.

### Possible Drawbacks

None

### Verification Process

- [x] Test additions, modifications and deletions
- [x] Test deleting first line -> icon should be visible at the top
- [x] Test different font-size and line-heights
- [x] Test different themes
- [x] Test when icons are hidden -> colored stripe gets used instead


### Release Notes

N/A