### PR TITLE
Fixed issue #10374

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -675,7 +675,7 @@ class Cursor extends Model {
     const nonWordCharacters = _.escapeRegExp(this.getNonWordCharacters())
     let source = `^[\t ]*$|[^\\s${nonWordCharacters}]+`
     if (!options || options.includeNonWordCharacters !== false) {
-      source += `|${`[${nonWordCharacters}]+`}`
+      source += `|[${nonWordCharacters}]`
     }
     return new RegExp(source, 'g')
   }


### PR DESCRIPTION
### Identify the Bug
#10374

### Description of the Change
Just removed "+" character from regex so when you double click on things like `)));` it will only select single character

### Alternate Designs
Because this is how word selection works in any OS. Only in atom you can select `)));` by double clicking on it

### Possible Drawbacks
People who leave atom because of this can go back now

### Verification Process
It's just a word selection regex.

### Release Notes
"Not applicable"