### PR TITLE
Fix "Open Folder" menu item on Windows 

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -658,7 +658,7 @@ describe('AtomApplication', function () {
       atomApplication.promptForPathToOpen.reset()
 
       atomApplication.emit('application:open-folder')
-      await conditionPromise(() => atomApplication.promptForPathToOpen.calledWith('file'))
+      await conditionPromise(() => atomApplication.promptForPathToOpen.calledWith('folder'))
       atomApplication.promptForPathToOpen.reset()
     })
   }

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -382,9 +382,6 @@ class AtomApplication extends EventEmitter {
     this.on('application:new-file', () => (this.focusedWindow() || this).openPath())
     this.on('application:open-dev', () => this.promptForPathToOpen('all', {devMode: true}))
     this.on('application:open-safe', () => this.promptForPathToOpen('all', {safeMode: true}))
-    this.on('application:open', () => this.promptForPathToOpen('all', getLoadSettings(), getDefaultPath()))
-    this.on('application:open-file', () => this.promptForPathToOpen('file', getLoadSettings(), getDefaultPath()))
-    this.on('application:open-folder', () => this.promptForPathToOpen('file', getLoadSettings(), getDefaultPath()))
     this.on('application:inspect', ({x, y, atomWindow}) => {
       if (!atomWindow) atomWindow = this.focusedWindow()
       if (atomWindow) atomWindow.browserWindow.inspectElement(x, y)
@@ -406,6 +403,9 @@ class AtomApplication extends EventEmitter {
     this.on('application:check-for-update', () => this.autoUpdateManager.check())
 
     if (process.platform === 'darwin') {
+      this.on('application:open', () => this.promptForPathToOpen('all', getLoadSettings(), getDefaultPath()))
+      this.on('application:open-file', () => this.promptForPathToOpen('file', getLoadSettings(), getDefaultPath()))
+      this.on('application:open-folder', () => this.promptForPathToOpen('folder', getLoadSettings(), getDefaultPath()))
       this.on('application:bring-all-windows-to-front', () => Menu.sendActionToFirstResponder('arrangeInFront:'))
       this.on('application:hide', () => Menu.sendActionToFirstResponder('hide:'))
       this.on('application:hide-other-applications', () => Menu.sendActionToFirstResponder('hideOtherApplications:'))


### PR DESCRIPTION
### Identify the Bug

Fixes https://github.com/atom/atom/issues/18835

### Description of the Change

This change fixes an issue introduced by PR https://github.com/atom/atom/pull/17529 which caused the "File -> Open Folder" menu item to incorrectly launch the "Open File" dialog on Windows.  The fix is to send the correct parameter `folder` to `promptForPathToOpen` when the `application:open-folder` command is executed.  I've also moved the registration for these event handlers into a macOS-only code block so that they won't be activated on Windows (the original fix was only relevant to Atom instances on macOS where no windows were currently open).

### Alternate Designs

None.

### Possible Drawbacks

None.

### Verification Process

- [x] Manually verify that the "Open Folder" dialog opens on Windows when clicking "File -> Open Folder"
- [x] Manually verify that the "File -> Open" dialog still enables files and folders to be opened when no Atom windows are currently open

### Release Notes

N/A