### PR TITLE
Allow the use of console, stdout, and stderr in Jasmine tests

### DIFF
--- a/src/initialize-test-window.coffee
+++ b/src/initialize-test-window.coffee
@@ -32,7 +32,17 @@ module.exports = ({blobStore}) ->
 
     {testRunnerPath, legacyTestRunnerPath, headless, logFile, testPaths, env} = getWindowLoadSettings()
 
-    unless headless
+    if headless
+      # Install console functions that output to stdout and stderr.
+      util = require 'util'
+
+      Object.defineProperties process,
+        stdout: {value: remote.process.stdout}
+        stderr: {value: remote.process.stderr}
+
+      console.log = (args...) -> process.stdout.write "#{util.format(args...)}\n"
+      console.error = (args...) -> process.stderr.write "#{util.format(args...)}\n"
+    else
       # Show window synchronously so a focusout doesn't fire on input elements
       # that are focused in the very first spec run.
       remote.getCurrentWindow().show()


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Possibly related to #15868? I'll need to verify if this helps in that scenario. But this is an annoyance that I encountered trying to debug #18857, which is a failure we're seeing only in CI. Basically: when running specs that use the default Jasmine spec runner in a headless window, `console.log` and `console.error` do nothing.

### Description of the Change

When launching a headless spec runner, initialize `console.log`, `console.error`, `process.stdout`, and `process.stderr` to point to the standard out and err streams exposed through Electron's "remote" module.

All credit to @BinaryMuse for giving me the code to yank from our Mocha runner, which doesn't have this problem:

https://github.com/BinaryMuse/atom-mocha-test-runner/blob/e69077dec77e11d28a22b09e40b999f84cb5c495/lib/create-runner.js#L51-L59

### Alternate Designs

_N/A_

### Possible Drawbacks

Other console methods (`console.table`, `console.dirxml`...) still have their output eaten. They're a little less obvious to stub, though, and are less widespread for good old-fashioned printf-style debugging.

### Verification Process

I'm verifying that this works properly by focusing a spec and adding `console.log` and `console.error` statements to its beginning. Ideally, they should be visible:

- [x] locally
  - [x] when headless;
  - [x] when using the graphical spec runner;
 - [x] in CI;
   - [x] on Windows;
   - [x] on macOS;
   - [x] on Linux.

### Release Notes

* `console.log` and `console.error` output to standard out and error when invoked from the headless test runner..