### PR TITLE
Update TextEditor styles when changing language mode

### DIFF
--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -4447,6 +4447,9 @@ class TextEditor {
       this.emitter.emit('did-tokenize')
     })
     if (this.languageModeSubscription) this.disposables.add(this.languageModeSubscription)
+
+    if (this.component) this.component.didUpdateStyles()
+
     this.emitter.emit('did-change-grammar', languageMode.grammar)
   }
 


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Whenever the `languageMode` of a `TextEditor` is changed, we currently do not update the styles of the editor, delaying that calculation to happen in the future, which can cause issues.

This can cause unexpected issues when the `TextEditor` gets hidden just after its `languageMode` gets changed, as seen in https://github.com/atom/find-and-replace/pull/1072.

There's a way to reproduce this issue with any text editor:

1. Create a `TextEditor` with some random text in its `TextBuffer`.
2. Update that `TextEditor` and wait until the [`onDidStopChanging()` callback](https://github.com/atom/atom/blob/master/src/text-editor.js#L685) gets triggered.
4. Set the either editor grammar or the text buffer language mode (it can be re-setted to its previous value).
5. Hide the `TextEditor` element (or deattach it from the DOM).
6. Cause a recalculation of dimensions on the `TextEditor`. This can be done by blurring the editor (if it had been focused before).
7. Display the editor again on the screen. Now the selection calculated position is wrong. This can be seen by focusing the editor and selecting all text.

Unfortunately I haven't been able to create an automated test that verifies that the previous behaviour is correct.

This is approximately what I've tried to execute:

```js
it('should recalculate editor styles when changing language mode', async () => {
  const buffer = new TextBuffer({text: 'hello'})
  editor = new TextEditor({buffer, mini: true})

  const container = document.createElement('div')
  container.appendChild(editor.element)

  jasmine.attachToDOM(container)

  editor.element.focus()
  editor.setText('hello, world')
  editor.selectAll()

  return new Promise(res => {
    editor.onDidStopChanging(() => {
      buffer.setLanguageMode(
        atom.grammars.languageModeForGrammarAndBuffer(atom.grammars.nullGrammar, buffer)
      )

      // Hide the container and remove focus from the editor.
      container.style.display = 'none'
      editor.element.blur()

      // Show and re-focus the container.
      container.style.display = 'block'
      editor.element.focus()
      editor.selectAll()

      const selectionElement = editor.element.querySelector('.highlight.selection .selection')
      expect(selectionElement.getBoundingClientRect().width).toBeGreaterThan(0)

      resolve();
    })

    advanceClock(editor.getBuffer().stoppedChangingDelay)
  })
})
```

Unfortunately, the previous test case passes both before this PR and afterwards. My hypothesis is that somehow the [timing mocks defined in the spec helpers file](https://github.com/atom/atom/blob/master/spec/spec-helper.coffee#L286-L289) are preventing the issue from happening in this test, but I haven't been able to demonstrate that.

Any help will be welcome here 😃 

### Description of the Change

This change calls the `didUpdateStyles()` method on the `TextComponent`. I've chosen this method over `updateSync()` to prevent calling it when the text editor is not visible, but I'm not super familiar with the different methods on the text editor so there may be a better one to call.

### Alternate Designs

N/A

### Possible Drawbacks

Not that I know of.

### Verification Process

Revert https://github.com/atom/find-and-replace/pull/1072 and check that this change also fixes the issue stated in https://github.com/atom/find-and-replace/issues/1067.

### Release Notes

- Fixed an issue where the text editor may not get correctly updated after changing its language mode.

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->