### PR TITLE
Actually dump minidump contents to .sym files

### DIFF
--- a/script/lib/dump-symbols.js
+++ b/script/lib/dump-symbols.js
@@ -35,7 +35,7 @@ function dumpSymbol (binaryPath) {
           const symbolDirPath = path.join(CONFIG.symbolsPath, filename, moduleLine[1])
           const symbolFilePath = path.join(symbolDirPath, `${filename}.sym`)
           fs.mkdirpSync(symbolDirPath)
-          fs.writeFileSync(symbolFilePath)
+          fs.writeFileSync(symbolFilePath, content)
           resolve()
         }
       }


### PR DESCRIPTION
So... all of the `.node.sym` files included in `atom-mac-symbols.zip` artifacts in Atom releases include only the string "undefined." This corrects the build process to actually write the minidump symbol contents to those files.