### PR TITLE
Override global jasmine spec functions

### DIFF
--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -10,6 +10,16 @@ module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
   window[key] = value for key, value of require '../vendor/jasmine'
   require 'jasmine-tagged'
 
+  # Rewrite global jasmine functions to have support for async tests.
+  # This way packages can create async specs without having to import these from the
+  # async-spec-helpers file.
+  global.it = asyncifyJasmineFn global.it, 1
+  global.fit = asyncifyJasmineFn global.fit, 1
+  global.ffit = asyncifyJasmineFn global.ffit, 1
+  global.fffit = asyncifyJasmineFn global.fffit, 1
+  global.beforeEach = asyncifyJasmineFn global.beforeEach, 0
+  global.afterEach = asyncifyJasmineFn global.afterEach, 0
+
   # Allow document.title to be assigned in specs without screwing up spec window title
   documentTitle = null
   Object.defineProperty document, 'title',
@@ -58,6 +68,28 @@ module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
 
   jasmineEnv.execute()
   promise
+
+asyncifyJasmineFn = (fn, callbackPosition) ->
+  (args...) ->
+    if typeof args[callbackPosition] is 'function'
+      callback = args[callbackPosition]
+
+      args[callbackPosition] = (args...) ->
+        result = callback.apply this, args
+        if result instanceof Promise
+          waitsForPromise(-> result)
+
+    fn.apply this, args
+
+waitsForPromise = (fn) ->
+  promise = fn()
+
+  global.waitsFor('spec promise to resolve', (done) ->
+    promise.then(done, (error) ->
+      jasmine.getEnv().currentSpec.fail error
+      done()
+    )
+  )
 
 disableFocusMethods = ->
   ['fdescribe', 'ffdescribe', 'fffdescribe', 'fit', 'ffit', 'fffit'].forEach (methodName) ->


### PR DESCRIPTION
## Issue or RFC Endorsed by Atom's Maintainers

[Comment on previous PR](https://github.com/atom/atom/pull/18896#discussion_r260396102).

## Description of the Change

Currently, if a spec uses the standard `it` function on an async test (the one that's stored in the global object), that test will always pass. This happens because the jasmine version checked into Atom does not natively support tests that return promises, so the failure happens asynchronously and the test runner cannot detect it.

To overcome this limitation, and because of the many repos that Atom use, a bunch of `async-spec-helpers.js` files have emerged (right now there are [31 of them](https://github.com/search?p=1&q=org%3Aatom+filename%3Aasync-spec-helpers.js&type=Code)) which implement custom `it`, `fit`, `beforeEach`, `afterEach`,... methods with support for async tests.

This can be confusing since some tests are currently using the builtin jasmine methods (mostly old tests that don't use async functions yet) and some other tests use the overriden versions located across the different `async-spec-helpers.js` files.

This PR modifies the builtin `jasmine` functions on the global test runner, so any Atom test will be able to use async functions, making the behaviour uniform across all tests and addressing the [valid concern](https://github.com/atom/atom/pull/18896#discussion_r260396102) stated by @Arcanemagus in #18896 .

As a nice side-effect, this PR will allow us to remove many of the `async-spec-helpers.js` files that we have hanging around 😃 

## Alternate Designs

Ideally we should upgrade the version of Jasmine that Atom tests are using: since v2.7 Jasmine [supports async tests](https://jasmine.github.io/tutorials/async#async-keyword).

Doing the upgrade may be very tricky, since Atom uses its own checked in version of Jasmine which has local modifications and [hasn't been updated since 6 years ago](https://github.com/atom/atom/commits/master/vendor/jasmine.js).

In the case that we want to do an upgrade of the test runner, it would be worth to explore how feasible would be to switch to a more advanced test runner like [Jest](https://jestjs.io/) which will probably provide many benefits like reduced test times or better developer experience (though it would be tricky to integrate since Atom tests are run in the Atom runtime, while Jest currently only runs on Node.js).

## Possible Drawbacks

Overriding globals is ugly and I should feel bad about it 🤡

## Verification Process

Check that all tests in CI keep passing.

## Release Notes

N/A.
