### PR TITLE
⬆️ fuzzy-finder@1.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2484,8 +2484,8 @@
       "integrity": "sha1-gy9kifvodnaUWVmckUpnDsIpR+4="
     },
     "fuzzy-finder": {
-      "version": "https://www.atom.io/api/packages/fuzzy-finder/versions/1.9.1/tarball",
-      "integrity": "sha512-UHyWdvhaiosjg4Rf3OKIWHew7kAB3T6ZQkaTJKMfBoARAdV3t6TvifRKYFICUjERWCHsx2fB+AZ1QwtMYuDiHA==",
+      "version": "https://www.atom.io/api/packages/fuzzy-finder/versions/1.9.2/tarball",
+      "integrity": "sha512-gpr1DXfxCEwMO48uCudocIZomhHlMJk+l1lAXJXwamtprDRsuzSqVMFjlyM49/cn4P5ToMhVHHHFngg0wklpvw==",
       "requires": {
         "async": "0.2.6",
         "atom-select-list": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "fs-plus": "^3.0.1",
     "fstream": "0.1.24",
     "fuzzaldrin": "^2.1",
-    "fuzzy-finder": "https://www.atom.io/api/packages/fuzzy-finder/versions/1.9.1/tarball",
+    "fuzzy-finder": "https://www.atom.io/api/packages/fuzzy-finder/versions/1.9.2/tarball",
     "git-diff": "file:packages/git-diff",
     "git-utils": "5.2.1",
     "github": "https://www.atom.io/api/packages/github/versions/0.26.0/tarball",


### PR DESCRIPTION
Includes https://github.com/atom/fuzzy-finder/pull/366, which reduces the startup time of the fuzzy finder on large repositories.

---------

[*(list of changes between `fuzzy-finder@1.9.1` and `fuzzy-finder@1.9.2`)*](https://github.com/atom/fuzzy-finder/compare/v1.9.1...v1.9.2)