### PR TITLE
⬆️ snippets@1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5114,8 +5114,8 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "snippets": {
-      "version": "https://www.atom.io/api/packages/snippets/versions/1.4.0/tarball",
-      "integrity": "sha512-pfw/YOwYeU4xJBEe/qztZx8Lq0ODLtSy7seoaMRu4w1lGlzl0HsqBeqTwLxR6bak3nS5WLj+k3hSJO+yNJWH2w==",
+      "version": "https://www.atom.io/api/packages/snippets/versions/1.4.1/tarball",
+      "integrity": "sha512-bLQmuMmyC+Sfjm/jdPbY3j/Vml3E4ApKhMFRb4AJLTde5m7TEhdTmsQBtkf+vFqGfr76tZ144F9NWH12ryS5rw==",
       "requires": {
         "async": "~0.2.6",
         "atom-select-list": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "service-hub": "^0.7.4",
     "settings-view": "https://www.atom.io/api/packages/settings-view/versions/0.259.0/tarball",
     "sinon": "1.17.4",
-    "snippets": "https://www.atom.io/api/packages/snippets/versions/1.4.0/tarball",
+    "snippets": "https://www.atom.io/api/packages/snippets/versions/1.4.1/tarball",
     "solarized-dark-syntax": "file:packages/solarized-dark-syntax",
     "solarized-light-syntax": "file:packages/solarized-light-syntax",
     "spell-check": "https://www.atom.io/api/packages/spell-check/versions/0.74.2/tarball",


### PR DESCRIPTION
Includes https://github.com/atom/snippets/pull/290, which will prevent a spec from failing once https://github.com/atom/atom/pull/18917 gets merged.

---------

[*(list of changes between `snippets@1.4.0` and `snippets@1.4.1`)*](https://github.com/atom/snippets/compare/v1.4.0...v1.4.1)