### PR TITLE
Set Electron version within the build process environment

### DIFF
--- a/script/build
+++ b/script/build
@@ -57,6 +57,8 @@ process.on('unhandledRejection', function (e) {
 })
 
 const CONFIG = require('./config')
+process.env.ELECTRON_VERSION = CONFIG.appMetadata.electronVersion
+
 let binariesPromise = Promise.resolve()
 
 if (!argv.existingBinaries) {


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Issue or RFC Endorsed by Atom's Maintainers

This is follow-on work from atom/github#1982.

### Description of the Change

Populate the `ELECTRON_VERSION` environment variable with the current Electron version for the `script/build` process and its child processes.

When we upgraded to Babel 7 in atom/github, we changed our Babel configuration to target the current Electron version as read from `process.versions.electron`. Unfortunately, the Atom build script runs bundled package transpilers in a _Node_ process instead, so this is `undefined` when we try to build Atom. Setting the environment variable gives us an alternative way to transpile correctly.

### Alternate Designs

Another option is to ensure than an Electron process is used to transpile bundled packages. That sounded like a lot more work, though.

### Possible Drawbacks

_N/A_

### Verification Process

We ran Atom's `script/build` with atom/github@0.27.1, which includes https://github.com/atom/github/commit/75f5c26d5c646edad70a810b3329182ea06e6098, and were able to transpile successfully.

### Release Notes

_N/A_

cc @vanessayuenn 