### PR TITLE
⬆️ electron@2.0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/atom/atom/issues"
   },
   "license": "MIT",
-  "electronVersion": "2.0.16",
+  "electronVersion": "2.0.18",
   "dependencies": {
     "@atom/nsfw": "1.0.18",
     "@atom/source-map-support": "^0.3.4",


### PR DESCRIPTION
Upgrade Electron from 2.0.16 to 2.0.18  :electron:

Release notes: 
- https://electronjs.org/releases/stable?version=2#2.0.17
- https://electronjs.org/releases/stable?version=2#2.0.18
