### PR TITLE
Added feature: show the first line of the file contents in the file tab for unsaved file

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -507,6 +507,11 @@ const configSchema = {
         default: false,
         description: 'Allow the editor to be scrolled past the end of the last line.'
       },
+      showFileContentInsteadOfUntitled: {
+        type: 'boolean',
+        default: false,
+        description: 'Show the file first row as a file name instead of untitled if the file is not saved yet'
+      },
       undoGroupingInterval: {
         type: 'integer',
         default: 300,

--- a/src/text-editor-registry.js
+++ b/src/text-editor-registry.js
@@ -20,6 +20,7 @@ const EDITOR_PARAMS_BY_SETTING_KEY = [
   ['editor.autoIndent', 'autoIndent'],
   ['editor.autoIndentOnPaste', 'autoIndentOnPaste'],
   ['editor.scrollPastEnd', 'scrollPastEnd'],
+  ['editor.showFileContentInsteadOfUntitled', 'showFileContentInsteadOfUntitled'],
   ['editor.undoGroupingInterval', 'undoGroupingInterval'],
   ['editor.scrollSensitivity', 'scrollSensitivity']
 ]

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -609,9 +609,8 @@ class TextEditor {
       this.mergeIntersectingSelections()
       if (this.component) this.component.didChangeDisplayLayer(changes)
       this.emitter.emit('did-change', changes.map(change => new ChangeEvent(change)))
-      if(this.showFileContentInsteadOfUntitled){
-        this.emitter.emit('did-change-title', this.getTitle())
-      }
+      if (this.showFileContentInsteadOfUntitled)
+      this.emitter.emit('did-change-title', this.getTitle())
     }))
     this.disposables.add(this.displayLayer.onDidReset(() => {
       this.mergeIntersectingSelections()
@@ -1100,10 +1099,10 @@ class TextEditor {
   //
   // Returns a {String}.
   getTitle () {
-    if(this.showFileContentInsteadOfUntitled){
-      return this.getFileName() ||  this.buffer.getLines()[0].substr(0,40) || 'untitled'
-    }else{
-      return this.getFileName() || 'untitled'
+    if (this.showFileContentInsteadOfUntitled) {
+     return this.getFileName() ||  this.buffer.getLines()[0].substr(0, 40) || 'untitled'
+    } else {
+     return this.getFileName() || 'untitled'
     }
   }
 

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -609,8 +609,7 @@ class TextEditor {
       this.mergeIntersectingSelections()
       if (this.component) this.component.didChangeDisplayLayer(changes)
       this.emitter.emit('did-change', changes.map(change => new ChangeEvent(change)))
-      if (this.showFileContentInsteadOfUntitled)
-      this.emitter.emit('did-change-title', this.getTitle())
+      if (this.showFileContentInsteadOfUntitled) this.emitter.emit('did-change-title', this.getTitle())
     }))
     this.disposables.add(this.displayLayer.onDidReset(() => {
       this.mergeIntersectingSelections()
@@ -1100,9 +1099,9 @@ class TextEditor {
   // Returns a {String}.
   getTitle () {
     if (this.showFileContentInsteadOfUntitled) {
-     return this.getFileName() ||  this.buffer.getLines()[0].substr(0, 40) || 'untitled'
+      return this.getFileName() || this.buffer.getLines()[0].substr(0, 40) || 'untitled'
     } else {
-     return this.getFileName() || 'untitled'
+      return this.getFileName() || 'untitled'
     }
   }
 

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -1101,7 +1101,7 @@ class TextEditor {
   // Returns a {String}.
   getTitle () {
     if(this.showFileContentInsteadOfUntitled){
-      return this.getFileName() || this.buffer.getLines()[0] || 'untitled'
+      return this.getFileName() ||  this.buffer.getLines()[0].substr(0,40) || 'untitled'
     }else{
       return this.getFileName() || 'untitled'
     }

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -146,6 +146,7 @@ class TextEditor {
     this.autoHeight = params.autoHeight
     this.autoWidth = params.autoWidth
     this.scrollPastEnd = (params.scrollPastEnd != null) ? params.scrollPastEnd : false
+    this.showFileContentInsteadOfUntitled = (params.showFileContentInsteadOfUntitled != null) ? params.showFileContentInsteadOfUntitled : false
     this.scrollSensitivity = (params.scrollSensitivity != null) ? params.scrollSensitivity : 40
     this.editorWidthInChars = params.editorWidthInChars
     this.invisibles = params.invisibles
@@ -608,6 +609,9 @@ class TextEditor {
       this.mergeIntersectingSelections()
       if (this.component) this.component.didChangeDisplayLayer(changes)
       this.emitter.emit('did-change', changes.map(change => new ChangeEvent(change)))
+      if(this.showFileContentInsteadOfUntitled){
+        this.emitter.emit('did-change-title', this.getTitle())
+      }
     }))
     this.disposables.add(this.displayLayer.onDidReset(() => {
       this.mergeIntersectingSelections()
@@ -1090,11 +1094,17 @@ class TextEditor {
   // UI such as the tabs.
   //
   // If the editor's buffer is saved, its title is the file name. If it is
-  // unsaved, its title is "untitled".
+  // unsaved and empty, its title is "untitled". If it is unsaved, not
+  // empty and "showFileContentInsteadOfUntitled" property is enabled then its
+  // title is the first line of the file.
   //
   // Returns a {String}.
   getTitle () {
-    return this.getFileName() || 'untitled'
+    if(this.showFileContentInsteadOfUntitled){
+      return this.getFileName() || this.buffer.getLines()[0] || 'untitled'
+    }else{
+      return this.getFileName() || 'untitled'
+    }
   }
 
   // Essential: Get unique title for display in other parts of the UI, such as


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers
It's not (yet) endorsed by atom's maintainers but I thinks it's good idea to make it possible. (#18978)
### Description of the Change
If the user is doesn't want to see "Untitled" tab everywhere if the user opening unsaved files, then the user is now able to enable this option in the "Settings" under the "Editor" tab.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
\-
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks
Nothing.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
- How did you verify that all new functionality works as expected?

0, **Go to settings and check or uncheck "Show File Content Instead Of Untitled"**
1, **Opening new file.** 
The tab title should be 'untitled', because it's empty.

**_If the "Show File Content Instead Of Untitled" option is checked._**
2, **Write something in the first row.**
The tab title should change to the first row content.
3, **Delete everything from first row.**
The tab title should be 'untitled' again.
4, **Write something in the first row.**
The tab title should change to the first row content again.
5, **Save the file**
The tab title should be the file name

**_If the "Show File Content Instead Of Untitled" option is unchecked._**
2, **Write something in the first row.**
Nothing happens
3, **Delete everything from first row.**
Nothing happens
4, **Write something in the first row.**
Nothing happens
5, **Save the file**
The tab title should be the file name



<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes
Added option: Show the first line of the file contents in the file tab for unsaved file
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->