### PR TITLE
Convert line endings when copy and pasting

### DIFF
--- a/spec/clipboard-spec.js
+++ b/spec/clipboard-spec.js
@@ -1,32 +1,41 @@
 describe('Clipboard', () => {
   describe('write(text, metadata) and read()', () => {
     it('writes and reads text to/from the native clipboard', () => {
-      expect(atom.clipboard.read()).toBe('initial clipboard content')
-      atom.clipboard.write('next')
-      expect(atom.clipboard.read()).toBe('next')
-    })
+      expect(atom.clipboard.read()).toBe('initial clipboard content');
+      atom.clipboard.write('next');
+      expect(atom.clipboard.read()).toBe('next');
+    });
 
     it('returns metadata if the item on the native clipboard matches the last written item', () => {
-      atom.clipboard.write('next', {meta: 'data'})
-      expect(atom.clipboard.read()).toBe('next')
-      expect(atom.clipboard.readWithMetadata().text).toBe('next')
-      expect(atom.clipboard.readWithMetadata().metadata).toEqual({meta: 'data'})
-    })
-  })
+      atom.clipboard.write('next', { meta: 'data' });
+      expect(atom.clipboard.read()).toBe('next');
+      expect(atom.clipboard.readWithMetadata().text).toBe('next');
+      expect(atom.clipboard.readWithMetadata().metadata).toEqual({
+        meta: 'data'
+      });
+    });
+  });
 
   describe('line endings', () => {
-    let originalPlatform = process.platform
+    let originalPlatform = process.platform;
 
-    const eols = new Map([['win32', '\r\n'], ['darwin', '\n'], ['linux', '\n']])
+    const eols = new Map([
+      ['win32', '\r\n'],
+      ['darwin', '\n'],
+      ['linux', '\n']
+    ]);
     for (let [platform, eol] of eols) {
       it(`converts line endings to the OS's native line endings on ${platform}`, () => {
-        Object.defineProperty(process, 'platform', {value: platform})
+        Object.defineProperty(process, 'platform', { value: platform });
 
-        atom.clipboard.write('next\ndone\r\n\n', {meta: 'data'})
-        expect(atom.clipboard.readWithMetadata()).toEqual({text: `next${eol}done${eol}${eol}`, metadata: {meta: 'data'}})
+        atom.clipboard.write('next\ndone\r\n\n', { meta: 'data' });
+        expect(atom.clipboard.readWithMetadata()).toEqual({
+          text: `next${eol}done${eol}${eol}`,
+          metadata: { meta: 'data' }
+        });
 
-        Object.defineProperty(process, 'platform', {value: originalPlatform})
-      })
+        Object.defineProperty(process, 'platform', { value: originalPlatform });
+      });
     }
-  })
-})
+  });
+});

--- a/spec/clipboard-spec.js
+++ b/spec/clipboard-spec.js
@@ -1,17 +1,32 @@
-describe('Clipboard', () =>
-  describe('write(text, metadata) and read()', function() {
-    it('writes and reads text to/from the native clipboard', function() {
-      expect(atom.clipboard.read()).toBe('initial clipboard content');
-      atom.clipboard.write('next');
-      expect(atom.clipboard.read()).toBe('next');
-    });
+describe('Clipboard', () => {
+  describe('write(text, metadata) and read()', () => {
+    it('writes and reads text to/from the native clipboard', () => {
+      expect(atom.clipboard.read()).toBe('initial clipboard content')
+      atom.clipboard.write('next')
+      expect(atom.clipboard.read()).toBe('next')
+    })
 
-    return it('returns metadata if the item on the native clipboard matches the last written item', function() {
-      atom.clipboard.write('next', { meta: 'data' });
-      expect(atom.clipboard.read()).toBe('next');
-      expect(atom.clipboard.readWithMetadata().text).toBe('next');
-      expect(atom.clipboard.readWithMetadata().metadata).toEqual({
-        meta: 'data'
-      });
-    });
-  }));
+    it('returns metadata if the item on the native clipboard matches the last written item', () => {
+      atom.clipboard.write('next', {meta: 'data'})
+      expect(atom.clipboard.read()).toBe('next')
+      expect(atom.clipboard.readWithMetadata().text).toBe('next')
+      expect(atom.clipboard.readWithMetadata().metadata).toEqual({meta: 'data'})
+    })
+  })
+
+  describe('line endings', () => {
+    let originalPlatform = process.platform
+
+    const eols = new Map([['win32', '\r\n'], ['darwin', '\n'], ['linux', '\n']])
+    for (let [platform, eol] of eols) {
+      it(`converts line endings to the OS's native line endings on ${platform}`, () => {
+        Object.defineProperty(process, 'platform', {value: platform})
+
+        atom.clipboard.write('next\ndone\r\n\n', {meta: 'data'})
+        expect(atom.clipboard.readWithMetadata()).toEqual({text: `next${eol}done${eol}${eol}`, metadata: {meta: 'data'}})
+
+        Object.defineProperty(process, 'platform', {value: originalPlatform})
+      })
+    }
+  })
+})

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -3,6 +3,7 @@ const path = require('path');
 const temp = require('temp').track();
 const dedent = require('dedent');
 const { clipboard } = require('electron');
+const os = require('os');
 const TextEditor = require('../src/text-editor');
 const TextBuffer = require('text-buffer');
 const TextMateLanguageMode = require('../src/text-mate-language-mode');
@@ -5051,7 +5052,7 @@ describe('TextEditor', () => {
           editor.cutSelectedText();
           expect(buffer.lineForRow(0)).toBe('var  = function () {');
           expect(buffer.lineForRow(1)).toBe('  var  = function(items) {');
-          expect(clipboard.readText()).toBe('quicksort\nsort');
+          expect(clipboard.readText()).toBe(['quicksort', 'sort'].join(os.EOL));
         });
 
         describe('when no text is selected', () => {
@@ -5068,13 +5069,14 @@ describe('TextEditor', () => {
             expect(buffer.lineForRow(4)).toBe(
               '      current < pivot ? left.push(current) : right.push(current);'
             );
+
             expect(atom.clipboard.read()).toEqual(
               [
                 'var quicksort = function () {',
                 '',
                 '      current = items.shift();',
                 ''
-              ].join('\n')
+              ].join(os.EOL)
             );
           });
         });
@@ -5087,7 +5089,9 @@ describe('TextEditor', () => {
               [[1, 6], [1, 10]]
             ]);
             editor.cutSelectedText();
-            expect(atom.clipboard.read()).toEqual(`quicksort\nsort\nitems`);
+            expect(atom.clipboard.read()).toEqual(
+              ['quicksort', 'sort', 'items'].join(os.EOL)
+            );
           });
         });
       });
@@ -5115,7 +5119,9 @@ describe('TextEditor', () => {
               expect(buffer.lineForRow(2)).toBe('    if (items.length');
               expect(buffer.lineForRow(3)).toBe('    var pivot = item');
               expect(atom.clipboard.read()).toBe(
-                ' <= 1) return items;\ns.shift(), current, left = [], right = [];'
+                ` <= 1) return items;${
+                  os.EOL
+                }s.shift(), current, left = [], right = [];`
               );
             }));
 
@@ -5131,7 +5137,7 @@ describe('TextEditor', () => {
               );
               expect(buffer.lineForRow(3)).toBe('    var pivot = item');
               expect(atom.clipboard.read()).toBe(
-                ' <= 1) ret\ns.shift(), current, left = [], right = [];'
+                ` <= 1) ret${os.EOL}s.shift(), current, left = [], right = [];`
               );
             }));
         });
@@ -5151,7 +5157,9 @@ describe('TextEditor', () => {
             expect(buffer.lineForRow(2)).toBe('    if (items.length');
             expect(buffer.lineForRow(3)).toBe('    var pivot = item');
             expect(atom.clipboard.read()).toBe(
-              ' <= 1) return items;\ns.shift(), current, left = [], right = [];'
+              ` <= 1) return items;${
+                os.EOL
+              }s.shift(), current, left = [], right = [];`
             );
           });
         });
@@ -5166,7 +5174,7 @@ describe('TextEditor', () => {
             expect(buffer.lineForRow(2)).toBe('    if (items.lengthurn items;');
             expect(buffer.lineForRow(3)).toBe('    var pivot = item');
             expect(atom.clipboard.read()).toBe(
-              ' <= 1) ret\ns.shift(), current, left = [], right = [];'
+              ` <= 1) ret${os.EOL}s.shift(), current, left = [], right = [];`
             );
           });
         });
@@ -5186,8 +5194,12 @@ describe('TextEditor', () => {
           expect(buffer.lineForRow(2)).toBe(
             '    if (items.length <= 1) return items;'
           );
-          expect(clipboard.readText()).toBe('quicksort\nsort\nitems');
-          expect(atom.clipboard.read()).toEqual('quicksort\nsort\nitems');
+          expect(clipboard.readText()).toBe(
+            ['quicksort', 'sort', 'items'].join(os.EOL)
+          );
+          expect(atom.clipboard.read()).toEqual(
+            ['quicksort', 'sort', 'items'].join(os.EOL)
+          );
         });
 
         describe('when no text is selected', () => {
@@ -5202,9 +5214,9 @@ describe('TextEditor', () => {
             editor.copySelectedText();
             expect(atom.clipboard.read()).toEqual(
               [
-                '  var sort = function(items) {\n',
-                '      current = items.shift();\n'
-              ].join('\n')
+                `  var sort = function(items) {${os.EOL}`,
+                `      current = items.shift();${os.EOL}`
+              ].join(os.EOL)
             );
             expect(editor.getSelectedBufferRanges()).toEqual([
               [[1, 5], [1, 5]],
@@ -5221,7 +5233,9 @@ describe('TextEditor', () => {
               [[1, 6], [1, 10]]
             ]);
             editor.copySelectedText();
-            expect(atom.clipboard.read()).toEqual(`quicksort\nsort\nitems`);
+            expect(atom.clipboard.read()).toEqual(
+              ['quicksort', 'sort', 'items'].join(os.EOL)
+            );
           });
         });
       });
@@ -5241,8 +5255,12 @@ describe('TextEditor', () => {
             expect(buffer.lineForRow(2)).toBe(
               '    if (items.length <= 1) return items;'
             );
-            expect(clipboard.readText()).toBe('quicksort\nsort\nitems');
-            expect(atom.clipboard.read()).toEqual(`quicksort\nsort\nitems`);
+            expect(clipboard.readText()).toBe(
+              ['quicksort', 'sort', 'items'].join(os.EOL)
+            );
+            expect(atom.clipboard.read()).toEqual(
+              ['quicksort', 'sort', 'items'].join(os.EOL)
+            );
           });
         });
 
@@ -5540,7 +5558,7 @@ describe('TextEditor', () => {
 
           expect(editor.lineTextForBufferRow(5)).toBe('  a(x);');
           expect(editor.lineTextForBufferRow(6)).toBe('  b(x);');
-          expect(editor.buffer.lineEndingForRow(6)).toBe('\r\n');
+          expect(editor.buffer.lineEndingForRow(6)).toBe(os.EOL);
           expect(editor.lineTextForBufferRow(7)).toBe('c(x);');
           expect(editor.lineTextForBufferRow(8)).toBe(
             '      current = items.shift();'

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -42,6 +42,8 @@ module.exports = class Clipboard {
   // * `text` The {String} to store.
   // * `metadata` (optional) The additional info to associate with the text.
   write(text, metadata) {
+    text = text.replace(/\r?\n/g, process.platform === 'win32' ? '\r\n' : '\n');
+
     this.signatureForMetadata = this.md5(text);
     this.metadata = metadata;
     clipboard.writeText(text);


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Issue or RFC Endorsed by Atom's Maintainers

#8365, endorsed by @maxbrunsfeld [here](https://github.com/atom/atom/issues/8365#issuecomment-433170963).

### Description of the Change

Whenever text is copied to the clipboard, all line endings are converted to the underlying OS's default line endings (CRLF on Windows, LF otherwise). Fixes #8365.

### Alternate Designs

I could have done `const os = require('os')` and then used `os.EOL` instead of hardcoding the line endings in `clipboard.js`, but that didn't seem worth it.

This could also be implemented as a Windows-only feature, which I believe is how VSCode does it.

### Possible Drawbacks

Sometimes you may want to explicitly copy the text as-is without conversions, and this will prevent that.

### Verification Process

On Windows, I copied text with LF line endings and pasted them into http://www.unit-conversion.info/texttools/hexadecimal/, which confirmed that the pasted text had `0d 0a` (CRLF).

### Release Notes

Line endings are now converted when copy and pasting.