### PR TITLE
⬆️ git-utils@5.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3040,9 +3040,9 @@
       }
     },
     "git-utils": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.2.1.tgz",
-      "integrity": "sha512-PrXaX4qb6ti9yU4p15RWeWklHdyEXCEIcdjbm3X5mAWL1VCFpl1hPdxk7T2qcFRNhF7TVXq3giotnJVne+1htA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.5.0.tgz",
+      "integrity": "sha512-4t3f2pU4HPgKOyTXyaEdMHTBwa24ubC4FykCXlqnsPgHlupSq66d0/aq0h92BgnyGwI3ogqx9D0a+Uw/jNckOg==",
       "requires": {
         "fs-plus": "^3.0.0",
         "nan": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "fuzzaldrin": "^2.1",
     "fuzzy-finder": "https://www.atom.io/api/packages/fuzzy-finder/versions/1.10.1/tarball",
     "git-diff": "file:packages/git-diff",
-    "git-utils": "5.2.1",
+    "git-utils": "5.5.0",
     "github": "https://www.atom.io/api/packages/github/versions/0.27.0/tarball",
     "glob": "^7.1.1",
     "go-to-line": "file:packages/go-to-line",


### PR DESCRIPTION
This new version contains libgit2/libgit2@9084712 and we're hoping to get some of the crashes and flaky tests solved ([more info](https://github.com/atom/atom/issues/19007)).
