### PR TITLE
Revert launch scenario changes

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -26,10 +26,20 @@ esac
 
 export ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT=true
 
-while getopts ":wtfvh-:" opt; do
+ATOM_ADD=false
+ATOM_NEW_WINDOW=false
+EXIT_CODE_OVERRIDE=
+
+while getopts ":anwtfvh-:" opt; do
   case "$opt" in
     -)
       case "${OPTARG}" in
+        add)
+          ATOM_ADD=true
+          ;;
+        new-window)
+          ATOM_NEW_WINDOW=true
+          ;;
         wait)
           WAIT=1
           ;;
@@ -45,6 +55,12 @@ while getopts ":wtfvh-:" opt; do
           ;;
       esac
       ;;
+    a)
+      ATOM_ADD=true
+      ;;
+    n)
+      ATOM_NEW_WINDOW=true
+      ;;
     w)
       WAIT=1
       ;;
@@ -57,6 +73,11 @@ while getopts ":wtfvh-:" opt; do
       ;;
   esac
 done
+
+if [ "${ATOM_ADD}" = "true" ] && [ "${ATOM_NEW_WINDOW}" = "true" ]; then
+  EXPECT_OUTPUT=1
+  EXIT_CODE_OVERRIDE=1
+fi
 
 if [ $REDIRECT_STDERR ]; then
   exec 2> /dev/null
@@ -115,7 +136,11 @@ if [ $OS == 'Mac' ]; then
 
   if [ $EXPECT_OUTPUT ]; then
     "$ATOM_PATH/$ATOM_APP_NAME/Contents/MacOS/$ATOM_EXECUTABLE_NAME" --executed-from="$(pwd)" --pid=$$ "$@"
-    exit $?
+    if [ $? -eq 0 ] && [ -n "${EXIT_CODE_OVERRIDE}" ]; then
+      exit "${EXIT_CODE_OVERRIDE}"
+    else
+      exit $?
+    fi
   else
     open -a "$ATOM_PATH/$ATOM_APP_NAME" -n --args --executed-from="$(pwd)" --pid=$$ --path-environment="$PATH" "$@"
   fi
@@ -144,7 +169,11 @@ elif [ $OS == 'Linux' ]; then
 
   if [ $EXPECT_OUTPUT ]; then
     "$ATOM_PATH" --executed-from="$(pwd)" --pid=$$ "$@"
-    exit $?
+    if [ $? -eq 0 ] && [ -n "${EXIT_CODE_OVERRIDE}" ]; then
+      exit "${EXIT_CODE_OVERRIDE}"
+    else
+      exit $?
+    fi
   else
     (
     nohup "$ATOM_PATH" --executed-from="$(pwd)" --pid=$$ "$@" > "$ATOM_HOME/nohup.out" 2>&1

--- a/resources/win/atom.cmd
+++ b/resources/win/atom.cmd
@@ -4,6 +4,8 @@ SET EXPECT_OUTPUT=
 SET WAIT=
 SET PSARGS=%*
 SET ELECTRON_ENABLE_LOGGING=
+SET ATOM_ADD=
+SET ATOM_NEW_WINDOW=
 
 FOR %%a IN (%*) DO (
   IF /I "%%a"=="-f"                         SET EXPECT_OUTPUT=YES
@@ -17,6 +19,10 @@ FOR %%a IN (%*) DO (
   IF /I "%%a"=="-v"                         SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="--version"                  SET EXPECT_OUTPUT=YES
   IF /I "%%a"=="--enable-electron-logging"  SET ELECTRON_ENABLE_LOGGING=YES
+  IF /I "%%a"=="-a"                         SET ATOM_ADD=YES
+  IF /I "%%a"=="--add"                      SET ATOM_ADD=YES
+  IF /I "%%a"=="-n"                         SET ATOM_NEW_WINDOW=YES
+  IF /I "%%a"=="--new-window"               SET ATOM_NEW_WINDOW=YES
   IF /I "%%a"=="-w"           (
     SET EXPECT_OUTPUT=YES
     SET WAIT=YES
@@ -24,6 +30,12 @@ FOR %%a IN (%*) DO (
   IF /I "%%a"=="--wait"       (
     SET EXPECT_OUTPUT=YES
     SET WAIT=YES
+  )
+)
+
+IF "%ATOM_ADD%"=="YES" (
+  IF "%ATOM_NEW_WINDOW%"=="YES" (
+    SET EXPECT_OUTPUT=YES
   )
 )
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -230,6 +230,7 @@ class AtomApplication extends EventEmitter {
       pidToKillWhenClosed,
       devMode,
       safeMode,
+      newWindow,
       logFile,
       profileStartup,
       timeout,
@@ -267,6 +268,7 @@ class AtomApplication extends EventEmitter {
         foldersToOpen,
         executedFrom,
         pidToKillWhenClosed,
+        newWindow,
         devMode,
         safeMode,
         profileStartup,
@@ -280,6 +282,7 @@ class AtomApplication extends EventEmitter {
       // Always open a editor window if this is the first instance of Atom.
       return this.openPath({
         pidToKillWhenClosed,
+        newWindow,
         devMode,
         safeMode,
         profileStartup,
@@ -791,6 +794,7 @@ class AtomApplication extends EventEmitter {
   // options -
   //   :pathToOpen - The file path to open
   //   :pidToKillWhenClosed - The integer of the pid to kill
+  //   :newWindow - Boolean of whether this should be opened in a new window.
   //   :devMode - Boolean to control the opened window's dev mode.
   //   :safeMode - Boolean to control the opened window's safe mode.
   //   :profileStartup - Boolean to control creating a profile of the startup time.
@@ -810,6 +814,7 @@ class AtomApplication extends EventEmitter {
     return this.openPaths({
       pathsToOpen: [pathToOpen],
       pidToKillWhenClosed,
+      newWindow,
       devMode,
       safeMode,
       profileStartup,
@@ -826,6 +831,7 @@ class AtomApplication extends EventEmitter {
   //   :pathsToOpen - The array of file paths to open
   //   :foldersToOpen - An array of additional paths to open that must be existing directories
   //   :pidToKillWhenClosed - The integer of the pid to kill
+  //   :newWindow - Boolean of whether this should be opened in a new window.
   //   :devMode - Boolean to control the opened window's dev mode.
   //   :safeMode - Boolean to control the opened window's safe mode.
   //   :windowDimensions - Object with height and width keys.
@@ -836,6 +842,7 @@ class AtomApplication extends EventEmitter {
     foldersToOpen,
     executedFrom,
     pidToKillWhenClosed,
+    newWindow,
     devMode,
     safeMode,
     windowDimensions,

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -803,6 +803,7 @@ class AtomApplication extends EventEmitter {
   openPath ({
     pathToOpen,
     pidToKillWhenClosed,
+    newWindow,
     devMode,
     safeMode,
     profileStartup,

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -878,13 +878,14 @@ class AtomApplication extends EventEmitter {
     const normalizedPathsToOpen = locationsToOpen.map(location => location.pathToOpen).filter(Boolean)
 
     let existingWindow
-    if (addToLastWindow && normalizedPathsToOpen.length > 0) {
+    if (!newWindow && normalizedPathsToOpen.length > 0) {
       existingWindow = this.windowForPaths(normalizedPathsToOpen, devMode)
-      if (!existingWindow) {
-        let lastWindow = window || this.getLastFocusedWindow()
-        if (lastWindow && lastWindow.devMode === devMode) {
-          existingWindow = lastWindow
-        }
+    }
+
+    if (addToLastWindow && !existingWindow) {
+      let lastWindow = window || this.getLastFocusedWindow()
+      if (lastWindow && lastWindow.devMode === devMode) {
+        existingWindow = lastWindow
       }
     }
 

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -105,6 +105,16 @@ module.exports = function parseCommandLine (processArgs) {
     executedFrom = process.cwd()
   }
 
+  if (newWindow && addToLastWindow) {
+    process.stderr.write(
+      `Only one of the --add and --new-window options may be specified at the same time.\n\n${options.help()}`,
+    )
+
+    // Exiting the main process with a nonzero exit code on MacOS causes the app open to fail with the mysterious
+    // message "LSOpenURLsWithRole() failed for the application /Applications/Atom Dev.app with error -10810."
+    process.exit(0)
+  }
+
   let pidToKillWhenClosed = null
   if (args['wait']) {
     pidToKillWhenClosed = args['pid']

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -15,16 +15,13 @@ module.exports = function parseCommandLine (processArgs) {
       atom [options] [path ...]
       atom file[:line[:column]]
 
-    If no arguments are given and no Atom windows are already open, restore all windows
-    from the previous editing session. Use "atom --new-window" to open a single empty
-    Atom window instead.
+    One or more paths to files or folders may be specified. If there is an
+    existing Atom window that contains all of the given folders, the paths
+    will be opened in that window. Otherwise, they will be opened in a new
+    window.
 
-    If no arguments are given and at least one Atom window is open, open a new, empty
-    Atom window.
-
-    One or more paths to files or folders may be specified. All paths will be opened
-    in a new Atom window. Each file may be opened at the desired line (and optionally
-    column) by appending the numbers after the file name, e.g. \`atom file:5:8\`.
+    A file may be opened at the desired line (and optionally column) by
+    appending the numbers right after the file name, e.g. \`atom file:5:8\`.
 
     Paths that start with \`atom://\` will be interpreted as URLs.
 
@@ -43,7 +40,7 @@ module.exports = function parseCommandLine (processArgs) {
   options.alias('f', 'foreground').boolean('f').describe('f', 'Keep the main process in the foreground.')
   options.alias('h', 'help').boolean('h').describe('h', 'Print this usage message.')
   options.alias('l', 'log-file').string('l').describe('l', 'Log all output to file.')
-  options.alias('n', 'new-window').boolean('n').describe('n', 'Launch an empty Atom window instead of restoring previous session.')
+  options.alias('n', 'new-window').boolean('n').describe('n', 'Open a new window.')
   options.boolean('profile-startup').describe('profile-startup', 'Create a profile of the startup execution time.')
   options.alias('r', 'resource-path').string('r').describe('r', 'Set the path to the Atom source directory and enable dev-mode.')
   options.boolean('safe').describe(


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Fixes #18967 by selectively reverting functionality introduced in #18608.

### Description of the Change

- [x] Modify AtomApplication to interpret the `newWindow` and `addToLastWindow` options as it did prior to #18608. Specifically:
  * If `newWindow` is true, always open the given paths in a new Atom window.
  * If `addToLastWindow` is true, open the given paths in an existing Atom window that "contains" all of the current paths. If none are found, open them in in the last-opened Atom window.
  * If both `newWindow` and `addToLastWindow` are false, open the given paths in an existing Atom window that "contains" all of the current paths. If none are found, open them in a new Atom window.
- [x] Re-propagate the `newWindow` option throughout `AtomApplication`.
- [x] Revert the changes to `--help` text.
- [x] Ensure that `--new-window` and `--add` are mutually exclusive - exit with an error when both are provided.
- [x] Close atom/flight-manual.atom.io#510 to keep our docs accurate.

### Alternate Designs

See https://github.com/atom/atom/issues/18967#issuecomment-472417823 for some discussions of alternatives.

### Possible Drawbacks

Messing with people's muscle memory again?

### Verification Process

Existing Atom windows are launched in the order of their numbering. Windows in the "outcome" column marked in **bold** are focused. Paths in parenthesis are the project root folders in each window.

| Precondition | Command | Outcome | Verified? |
| -- | -- | -- | -- |
| No Atom windows | `atom` | **Window 0 (empty)** | ✅ |
| No Atom windows | `atom ~/zero` | **Window 0 (`~/zero`)** | ✅ |
| No Atom windows | `atom --add ~/zero` | **Window 0 (`~/zero`)** | ✅|
| No Atom windows | `atom --new-window ~/zero` | **Window 0 (`~/zero`)** | ✅|
| Window 0 (`~/zero`) | `atom` | Window 0 (`~/zero`)<br>**Window 1 (empty)** | ✅|
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom ~/zero` | **Window 0 (`~/zero`)**<br>Window 1 (`~/one`) | ✅|
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom ~/zero/file` | **Window 0 (`~/zero`)**<br>Window 1 (`~/one`) | ✅|
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom --add ~/zero` | **Window 0 (`~/zero`)**<br>Window 1 (`~/one`) | ✅|
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom --new-window ~/zero` | Window 0 (`~/zero`)<br>Window 1 (`~/one`)<br>**Window 2 (`~/zero`)** | ✅|
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom ~/two` | Window 0 (`~/zero`)<br>Window 1 (`~/one`)<br>**Window 2 (`~/two`)** | ✅|
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom --add ~/two` | Window 0 (`~/zero`)<br>**Window 1 (`~/one`, `~/two`)** | ✅|
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom --new-window ~/two` | Window 0 (`~/zero`)<br>Window 1 (`~/one`)<br>**Window 2 (`~/two`)** | ✅|

#### Behavior on Atom 1.35.1

This is the behavior for the same scenarios with the current stable Atom release, before #18608 was merged.

| Precondition | Command | Outcome | Consistent? |
| -- | -- | -- | -- |
| No Atom windows | `atom` | **Window 0 (empty)** | ✅ |
| No Atom windows | `atom ~/zero` | **Window 0 (`~/zero`)** | ✅ |
| No Atom windows | `atom --add ~/zero` | **Window 0 (`~/zero`)** | ✅ |
| No Atom windows | `atom --new-window ~/zero` | **Window 0 (`~/zero`)** | ✅ |
| Window 0 (`~/zero`) | `atom` | Window 0 (`~/zero`)<br>**Window 1 (empty)** | ✅|
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom ~/zero` | **Window 0 (`~/zero`)**<br>Window 1 (`~/one`) | ✅ |
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom ~/zero/file` | **Window 0 (`~/zero`)**<br>Window 1 (`~/one`) | ✅ |
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom --add ~/zero` | **Window 0 (`~/zero`)**<br>Window 1 (`~/one`) | ✅ |
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom --new-window ~/zero` | Window 0 (`~/zero`)<br>Window 1 (`~/one`)<br>**Window 2 (`~/zero`)** | ✅|
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom ~/two` | Window 0 (`~/zero`)<br>Window 1 (`~/one`)<br>**Window 2 (`~/two`)** | ✅ |
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom --add ~/two` | Window 0 (`~/zero`)<br>**Window 1 (`~/one`, `~/two`)** | ✅|
| Window 0 (`~/zero`)<br>Window 1 (`~/one`) | `atom --new-window ~/two` | Window 0 (`~/zero`)<br>Window 1 (`~/one`)<br>**Window 2 (`~/two`)** | ✅|

### Release Notes

_N/A (kind of)_. Specifically, we should _remove_ this bullet point:

> When launching Atom from the command line, a new window is always opened with the provided paths. To open the requested locations in an existing window, --add must be specified.