### PR TITLE
Do not delete global scope setting when resetting user settings

### DIFF
--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -1239,6 +1239,29 @@ describe('Config', () => {
         expect(events[0]).toEqual({ oldValue: 2, newValue: 12 })
       })
     })
+
+    it('keeps all the global scope settings after overriding one', () => {
+      atom.config.resetUserSettings({
+        '*': {
+          foo: {
+            bar: 'baz',
+            int: 99
+          }
+        }
+      })
+
+      atom.config.set('foo.int', 50, { scopeSelector: '*' })
+
+      advanceClock(100)
+
+      expect(savedSettings[0]['*'].foo).toEqual({
+        bar: 'baz',
+        int: 50
+      })
+      expect(atom.config.get('foo.int', { scope: ['*'] })).toEqual(50)
+      expect(atom.config.get('foo.bar', { scope: ['*'] })).toEqual('baz')
+      expect(atom.config.get('foo.int')).toEqual(50)
+    })
   })
 
   describe('.pushAtKeyPath(keyPath, value)', () => {

--- a/src/config.js
+++ b/src/config.js
@@ -691,7 +691,9 @@ class Config {
       this.pendingOperations.push(() => this.set(keyPath, value, options))
     }
 
-    const scopeSelector = options.scopeSelector
+    // We should never use the scoped store to set global settings, since they are kept directly
+    // in the config object.
+    const scopeSelector = options.scopeSelector !== '*' ? options.scopeSelector : undefined
     let source = options.source
     const shouldSave = options.save != null ? options.save : true
 


### PR DESCRIPTION
### Identify the Bug

This PR fixes https://github.com/atom/atom/issues/18372

### Description of the Change

**Edit**: This PR changes the `atom.config.set()` method to never use the scoped store when setting global config params (even when using the `scopeSelector`). This is to prevent incorrect values to be stored in the user config file, which happens when the scoped store receives a call to set a global property (since it does not hold any global properties).

~~This PR changes the logic of the `atom.config.resetUserSettings()` method to not delete the globally scoped settings (the ones under the scope `*`) before storing them on the [`scoped-settings-store`](https://github.com/atom/scoped-property-store).~~

~~Before, since the loaded globally scoped settings were not stored in the `scoped-settings-store`, the store did erase them if a user executed `atom.store.set(something, anything, {scopeSelector: '*'})` because it did not have the previous fields.~~

~~This seems to have been introduced by https://github.com/atom/atom/pull/4606 (4 years ago, lol), and my hypothesis is that it may had been just a small mistake when modifying the old logic, but I may be missing something and maybe this was intentional (cc/ @nathansobo if you remember it 😅).~~

### Alternate Designs

🤷‍♂️

### Possible Drawbacks

I'm not aware of any potential drawback apart from the risk of breaking some other logic that was depending on the previous behaviour

### Verification Process

* Manual verification
  1. Open Atom
  2. Execute `atom.config.set("foo.bar", "baz", {scopeSelector: '*'});`
  3. Open `~/.atom/config.cson` and check that my previous config is not gone 😄 
* Added an automated test that fails without this PR change.

### Release Notes

`atom.config.set` does not  erase settings when scopeSelector is `"*"` anymore.