### PR TITLE
Fix reopen project when there are no open windows

### DIFF
--- a/spec/reopen-project-menu-manager-spec.js
+++ b/spec/reopen-project-menu-manager-spec.js
@@ -137,12 +137,12 @@ describe('ReopenProjectMenuManager', () => {
       const first = projectsMenu.submenu[0]
       expect(first.label).toBe('/a')
       expect(first.command).toBe('application:reopen-project')
-      expect(first.commandDetail).toEqual({ index: 0 })
+      expect(first.commandDetail).toEqual({ index: 0, paths: ['/a'] })
 
       const second = projectsMenu.submenu[1]
       expect(second.label).toBe('b, c:\\')
       expect(second.command).toBe('application:reopen-project')
-      expect(second.commandDetail).toEqual({ index: 1 })
+      expect(second.commandDetail).toEqual({ index: 1, paths: ['/b', 'c:\\'] })
     })
 
     it("adds only the number of menu items specified in the 'core.reopenProjectMenuCount' config", () => {
@@ -199,12 +199,12 @@ describe('ReopenProjectMenuManager', () => {
       const first = projectsMenu.submenu[0]
       expect(first.label).toBe('/a')
       expect(first.command).toBe('application:reopen-project')
-      expect(first.commandDetail).toEqual({ index: 0 })
+      expect(first.commandDetail).toEqual({ index: 0, paths: ['/a'] })
 
       const second = projectsMenu.submenu[1]
       expect(second.label).toBe('b, c:\\')
       expect(second.command).toBe('application:reopen-project')
-      expect(second.commandDetail).toEqual({ index: 1 })
+      expect(second.commandDetail).toEqual({ index: 1, paths: ['/b', 'c:\\'] })
     })
   })
 
@@ -226,12 +226,15 @@ describe('ReopenProjectMenuManager', () => {
       const first = recentMenu.submenu[0]
       expect(first.label).toBe('/users/neila')
       expect(first.command).toBe('application:reopen-project')
-      expect(first.commandDetail).toEqual({ index: 0 })
+      expect(first.commandDetail).toEqual({ index: 0, paths: ['/users/neila'] })
 
       const second = recentMenu.submenu[1]
       expect(second.label).toBe('buzza, michaelc')
       expect(second.command).toBe('application:reopen-project')
-      expect(second.commandDetail).toEqual({ index: 1 })
+      expect(second.commandDetail).toEqual({
+        index: 1,
+        paths: ['/users/buzza', 'users/michaelc']
+      })
     })
   })
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -403,6 +403,10 @@ class AtomApplication extends EventEmitter {
     this.on('application:check-for-update', () => this.autoUpdateManager.check())
 
     if (process.platform === 'darwin') {
+      this.on('application:reopen-project', ({ paths }) => {
+        this.openPaths({ pathsToOpen: paths })
+      })
+
       this.on('application:open', () => this.promptForPathToOpen('all', getLoadSettings(), getDefaultPath()))
       this.on('application:open-file', () => this.promptForPathToOpen('file', getLoadSettings(), getDefaultPath()))
       this.on('application:open-folder', () => this.promptForPathToOpen('folder', getLoadSettings(), getDefaultPath()))

--- a/src/reopen-project-menu-manager.js
+++ b/src/reopen-project-menu-manager.js
@@ -125,7 +125,7 @@ class ReopenProjectMenuManager {
           submenu: projects.map((project, index) => ({
             label: this.createLabel(project),
             command: 'application:reopen-project',
-            commandDetail: {index: index}
+            commandDetail: { index: index, paths: project.paths }
           }))
         }
       ]


### PR DESCRIPTION
### Identify the Bug

Fixes https://github.com/atom/atom/issues/17530

### Description of the Change

This PR adds some logic in the atom application process to handle the reopen commands, so when one of these commands gets triggered without an atom environment it still works.

### Alternate Designs

I cannot think about an alternative way of implementing this...

### Possible Drawbacks

Cannot identify any.

### Verification Process

1. Close all Atom windows from OSX
2. Go to `File -> Recent Project` and open one of the projects listed there.
3. Open two folders in a single Atom window and close that window.
4. Go to `File -> Recent Project` and open the recent project containing the two folders.

### Release Notes

Fixed an issue in OSX that prevented File->Reopen Project  to work when there were no open windows