### PR TITLE
Update tree-sitter to v0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6194,42 +6194,12 @@
       "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q=="
     },
     "tree-sitter": {
-      "version": "0.13.23",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.13.23.tgz",
-      "integrity": "sha512-75AiPbMEstv+YK8h4FkAHnmAJ6nNIUj/NFzRvKCHovmwSEKMi8Wc/E/crB4lJnHBOfV/f/DMQjN+e1Y36kagug==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.14.0.tgz",
+      "integrity": "sha512-aBdFQrQWodjA4MEC7JwPw3M0vhcL3BD4Ivj5jmL6Y8aThGdFxjO0YJzo+//yK8O5RHvfA6rgJa5CYZ2z4qzQrw==",
       "requires": {
         "nan": "^2.10.0",
         "prebuild-install": "^5.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "prebuild-install": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.1.tgz",
-          "integrity": "sha512-9DAccsInWHB48TBQi2eJkLPE049JuAI6FjIH0oIrij4bpDVEbX6JvlWRAcAAlUqBHhjgq0jNqA3m3bBXWm9v6w==",
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
-            "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "napi-build-utils": "^1.0.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.2.7",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
-          }
-        }
       }
     },
     "tree-sitter-bash": {

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "temp": "^0.8.3",
     "text-buffer": "13.15.1",
     "timecop": "https://www.atom.io/api/packages/timecop/versions/0.36.2/tarball",
-    "tree-sitter": "0.13.23",
+    "tree-sitter": "0.14.0",
     "tree-sitter-css": "^0.13.7",
     "tree-view": "https://www.atom.io/api/packages/tree-view/versions/0.225.0/tarball",
     "typescript-simple": "1.0.0",

--- a/spec/tree-sitter-language-mode-spec.js
+++ b/spec/tree-sitter-language-mode-spec.js
@@ -414,7 +414,7 @@ describe('TreeSitterLanguageMode', () => {
         const languageMode = new TreeSitterLanguageMode({
           buffer,
           grammar,
-          syncOperationLimit: 0
+          syncTimeoutMicros: 0
         })
         buffer.setLanguageMode(languageMode)
         await nextHighlightingUpdate(languageMode)
@@ -797,7 +797,7 @@ describe('TreeSitterLanguageMode', () => {
           buffer,
           grammar: htmlGrammar,
           grammars: atom.grammars,
-          syncOperationLimit: 0
+          syncTimeoutMicros: 0
         })
         buffer.setLanguageMode(languageMode)
 
@@ -827,7 +827,7 @@ describe('TreeSitterLanguageMode', () => {
       )
       atom.grammars.loadGrammarSync(jsGrammarPath)
       atom.grammars.assignLanguageMode(buffer, 'source.js')
-      buffer.getLanguageMode().syncOperationLimit = 0
+      buffer.getLanguageMode().syncTimeoutMicros = 0
 
       const initialSeed = Date.now()
       for (let i = 0, trialCount = 10; i < trialCount; i++) {

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -24,7 +24,7 @@ class TreeSitterLanguageMode {
     }
   }
 
-  constructor ({buffer, grammar, config, grammars, syncOperationLimit}) {
+  constructor ({buffer, grammar, config, grammars, syncTimeoutMicros}) {
     TreeSitterLanguageMode._patchSyntaxNode()
     this.id = nextId++
     this.buffer = buffer
@@ -35,8 +35,8 @@ class TreeSitterLanguageMode {
     this.rootLanguageLayer = new LanguageLayer(this, grammar)
     this.injectionsMarkerLayer = buffer.addMarkerLayer()
 
-    if (syncOperationLimit != null) {
-      this.syncOperationLimit = syncOperationLimit
+    if (syncTimeoutMicros != null) {
+      this.syncTimeoutMicros = syncTimeoutMicros
     }
 
     this.rootScopeDescriptor = new ScopeDescriptor({scopes: [this.grammar.scopeName]})
@@ -111,7 +111,7 @@ class TreeSitterLanguageMode {
     const parser = PARSER_POOL.pop() || new Parser()
     parser.setLanguage(language)
     const result = parser.parseTextBuffer(this.buffer.buffer, oldTree, {
-      syncOperationLimit: this.syncOperationLimit,
+      syncTimeoutMicros: this.syncTimeoutMicros,
       includedRanges: ranges
     })
 
@@ -1225,6 +1225,6 @@ function hasMatchingFoldSpec (specs, node) {
 })
 
 TreeSitterLanguageMode.LanguageLayer = LanguageLayer
-TreeSitterLanguageMode.prototype.syncOperationLimit = 1000
+TreeSitterLanguageMode.prototype.syncTimeoutMicros = 1000
 
 module.exports = TreeSitterLanguageMode


### PR DESCRIPTION
This PR bumps the `tree-sitter` node module to the latest version. The only Tree-sitter changes that affect this module are:

* a fix for [one rare bug](https://github.com/tree-sitter/tree-sitter/commit/213ccfd3a47b4e0ce0f52d2db3b1875b4ef37998) caught by the randomized tests
* PRs https://github.com/tree-sitter/tree-sitter/pull/301 and https://github.com/tree-sitter/tree-sitter/pull/308, which make the parsing timeout API more straightforward to use. These changes affected the module's public API slightly, and I've adjusted the Tree-sitter calls to use the new API.

For context, the initial reason behind this ☝️ timeout API is described [here](https://github.com/atom/atom/pull/17339#issuecomment-391527608); I wanted a way to parse synchronously (within a certain "cutoff") when possible, to prevent unnecessary DOM updates. Previously, the cutoff was specified in fairly arbitrary units, whereas now it's specified as a real time duration, in microseconds. I've set the synchronous parsing cutoff at one millisecond for now, which is the amount of time I was trying to approximate before.

### Testing

There haven't been any large code changes, so this should be low risk. But in order to test exhaustively that Tree-sitter is working well in Atom, I plan to do this:

* [x] Make sure the `TreeSitterLanguageMode` unit tests pass
* [x] Get a list of all the grammars that Atom currently bundles

```js
Object.keys(atom.grammars.treeSitterGrammarsById)
```

* [x] View and edit some code in each of these languages:

  * [x] `source.c`
  * [x] `source.cpp`
  * [x] `text.html.basic`
  * [x] `text.html.ejs`
  * [x] `text.html.erb`
  * [x] `source.js`
  * [x] `source.flow`
  * [x] `source.ts`
  * [x] `source.ruby`
  * [x] `source.css`
  * [x] `source.go`
  * [x] `source.jsdoc`
  * [x] `source.js.regexp`
  * [x] `source.python`
  * [x] `source.rust`
  * [x] `source.shell`