### PR TITLE
Preserve Atom's exit code in atom.sh

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -136,10 +136,11 @@ if [ $OS == 'Mac' ]; then
 
   if [ $EXPECT_OUTPUT ]; then
     "$ATOM_PATH/$ATOM_APP_NAME/Contents/MacOS/$ATOM_EXECUTABLE_NAME" --executed-from="$(pwd)" --pid=$$ "$@"
-    if [ $? -eq 0 ] && [ -n "${EXIT_CODE_OVERRIDE}" ]; then
+    ATOM_EXIT=$?
+    if [ ${ATOM_EXIT} -eq 0 ] && [ -n "${EXIT_CODE_OVERRIDE}" ]; then
       exit "${EXIT_CODE_OVERRIDE}"
     else
-      exit $?
+      exit ${ATOM_EXIT}
     fi
   else
     open -a "$ATOM_PATH/$ATOM_APP_NAME" -n --args --executed-from="$(pwd)" --pid=$$ --path-environment="$PATH" "$@"
@@ -169,10 +170,11 @@ elif [ $OS == 'Linux' ]; then
 
   if [ $EXPECT_OUTPUT ]; then
     "$ATOM_PATH" --executed-from="$(pwd)" --pid=$$ "$@"
-    if [ $? -eq 0 ] && [ -n "${EXIT_CODE_OVERRIDE}" ]; then
+    ATOM_EXIT=$?
+    if [ ${ATOM_EXIT} -eq 0 ] && [ -n "${EXIT_CODE_OVERRIDE}" ]; then
       exit "${EXIT_CODE_OVERRIDE}"
     else
-      exit $?
+      exit ${ATOM_EXIT}
     fi
   else
     (


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

When running `atom --test` from the command line, a zero exit code is overwritten to be 1 by a conditional. This causes successful test runs to always exit as a failure. This is a regression caused by #19028.

### Description of the Change

The root cause of the problem is that bash's `$?` variable is overwritten by the test command used to check for an exit code override. By capturing `$?` immediately after the `atom` command returns, we can report it correctly.

### Alternate Designs

_N/A_

### Possible Drawbacks

There's some duplication between the MacOS and Linux branches in `atom.sh`. Not sure if it's worth addressing now though.

### Verification Process

I copied the `atom.sh` script over `/usr/local/bin/atom-nightly`, ran `atom-nightly --test test/` in the GitHub package source, and verified that it exited with a 0 status instead of a 1.

### Release Notes

_N/A_