### PR TITLE
⬆️ underscore-plus@1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1305,7 +1305,7 @@
     "autoflow": {
       "version": "file:packages/autoflow",
       "requires": {
-        "underscore-plus": "^1.6.6"
+        "underscore-plus": "^1.7.0"
       }
     },
     "autosave": {
@@ -2264,7 +2264,7 @@
         "fs-plus": "^3.0.0",
         "grim": "^2.0.1",
         "marked": "^0.3.6",
-        "underscore-plus": "^1.0.0"
+        "underscore-plus": "^1.7.0"
       },
       "dependencies": {
         "etch": {
@@ -2605,7 +2605,7 @@
         "fs-plus": "^3.0.0",
         "node-uuid": "~1.4.7",
         "stack-trace": "0.0.9",
-        "underscore-plus": "1.x"
+        "underscore-plus": "^1.7.0"
       }
     },
     "expand-template": {
@@ -4076,7 +4076,7 @@
       "version": "file:packages/line-ending-selector",
       "requires": {
         "atom-select-list": "^0.7.0",
-        "underscore-plus": "^1.6.6"
+        "underscore-plus": "^1.7.0"
       }
     },
     "line-top-index": {
@@ -4090,7 +4090,7 @@
     "link": {
       "version": "file:packages/link",
       "requires": {
-        "underscore-plus": "1.x"
+        "underscore-plus": "^1.7.0"
       }
     },
     "lodash": {

--- a/package.json
+++ b/package.json
@@ -162,7 +162,6 @@
     "tree-sitter-css": "^0.13.7",
     "tree-view": "https://www.atom.io/api/packages/tree-view/versions/0.225.0/tarball",
     "typescript-simple": "1.0.0",
-    "underscore-plus": "^1.6.8",
     "update-package-dependencies": "https://www.atom.io/api/packages/update-package-dependencies/versions/0.13.1/tarball",
     "welcome": "https://www.atom.io/api/packages/welcome/versions/0.36.9/tarball",
     "whitespace": "https://www.atom.io/api/packages/whitespace/versions/0.37.7/tarball",

--- a/packages/autoflow/package.json
+++ b/packages/autoflow/package.json
@@ -14,7 +14,7 @@
     "atom": "*"
   },
   "dependencies": {
-    "underscore-plus": "^1.6.6"
+    "underscore-plus": "^1.7.0"
   },
   "devDependencies": {
     "coffeelint": "^1.9.7"

--- a/packages/deprecation-cop/package.json
+++ b/packages/deprecation-cop/package.json
@@ -13,7 +13,7 @@
     "fs-plus": "^3.0.0",
     "grim": "^2.0.1",
     "marked": "^0.3.6",
-    "underscore-plus": "^1.0.0"
+    "underscore-plus": "^1.7.0"
   },
   "consumedServices": {
     "status-bar": {

--- a/packages/exception-reporting/package.json
+++ b/packages/exception-reporting/package.json
@@ -12,7 +12,7 @@
     "fs-plus": "^3.0.0",
     "node-uuid": "~1.4.7",
     "stack-trace": "0.0.9",
-    "underscore-plus": "1.x"
+    "underscore-plus": "^1.7.0"
   },
   "devDependencies": {
     "semver": "^5.3.0"

--- a/packages/line-ending-selector/package.json
+++ b/packages/line-ending-selector/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "atom-select-list": "^0.7.0",
-    "underscore-plus": "^1.6.6"
+    "underscore-plus": "^1.7.0"
   },
   "consumedServices": {
     "status-bar": {

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -14,7 +14,7 @@
     ]
   },
   "dependencies": {
-    "underscore-plus": "1.x"
+    "underscore-plus": "^1.7.0"
   },
   "devDependencies": {
     "standard": "^10.0.3"

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -684,7 +684,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-      "optional": true,
       "requires": {
         "hoek": "0.9.x"
       }
@@ -3173,8 +3172,7 @@
     "hoek": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "optional": true
+      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
     },
     "home-or-tmp": {
       "version": "1.0.0",


### PR DESCRIPTION
`underscore-plus@1.7.0` has `underscore@1.9.1`, which contains many changes, bugfixes and performance improvements ([changelog](https://underscorejs.org/#changelog)).