### PR TITLE
Update CI scripts to lint early and fail fast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ install:
   - npm install --global npm@6.2.0
   - script/bootstrap
 
-script:
-  - script/lint
-  - script/build --no-bootstrap --create-debian-package --create-rpm-package --compress-artifacts
-  - script/test
+script: >
+  script/lint &&
+  script/build --no-bootstrap --create-debian-package --create-rpm-package --compress-artifacts &&
+  script/test
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,11 @@ install:
   - nvm install $NODE_VERSION
   - nvm use --delete-prefix $NODE_VERSION
   - npm install --global npm@6.2.0
-  - script/build --create-debian-package --create-rpm-package --compress-artifacts
+  - script/bootstrap
 
 script:
   - script/lint
+  - script/build --no-bootstrap --create-debian-package --create-rpm-package --compress-artifacts
   - script/test
 
 cache:

--- a/script/build
+++ b/script/build
@@ -2,9 +2,13 @@
 
 'use strict'
 
-// Run bootstrap first to ensure all the dependencies used later in this script
-// are installed.
-require('./bootstrap')
+if (process.argv.includes('--no-bootstrap')) {
+  console.log('Skipping bootstrap')
+} else {
+  // Bootstrap first to ensure all the dependencies used later in this script
+  // are installed.
+  require('./bootstrap')
+}
 
 // Needed so we can require src/module-cache.coffee during generateModuleCache
 require('coffee-script/register')

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -12,14 +12,17 @@ jobs:
   container: atom-linux-ci
 
   steps:
-  - script: script/build --create-debian-package --create-rpm-package --compress-artifacts
+  - script: script/bootstrap
+    displayName: Bootstrap build environment
+
+  - script: script/lint
+    displayName: Run linter
+
+  - script: script/build --no-bootstrap --create-debian-package --create-rpm-package --compress-artifacts
     env:
       GITHUB_TOKEN: $(GITHUB_TOKEN)
       ATOM_RELEASE_VERSION: $(ReleaseVersion)
     displayName: Build Atom
-
-  - script: script/lint
-    displayName: Run linter
 
   - script: script/test
     env:

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -19,11 +19,17 @@ jobs:
   - script: npm install --global npm@6.2.0
     displayName: Update npm
 
+  - script: script/bootstrap
+    displayName: Bootstrap build environment
+
+  - script: script/lint
+    displayName: Run linter
+
   - script: |
       if [ $IS_RELEASE_BRANCH == "true" ] || [ $IS_SIGNED_ZIP_BRANCH == "true" ]; then
-        script/build --code-sign --compress-artifacts
+        script/build --no-bootstrap --code-sign --compress-artifacts
       else
-        script/build --compress-artifacts
+        script/build --no-bootstrap --compress-artifacts
       fi
     displayName: Build Atom
     env:
@@ -35,9 +41,6 @@ jobs:
       ATOM_MAC_CODE_SIGNING_CERT_PASSWORD: $(ATOM_MAC_CODE_SIGNING_CERT_PASSWORD)
       ATOM_MAC_CODE_SIGNING_KEYCHAIN: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN)
       ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD)
-
-  - script: script/lint
-    displayName: Run linter
 
   - script: |
       osascript -e 'tell application "System Events" to keystroke "x"' # clear screen saver

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -37,18 +37,27 @@ jobs:
     displayName: Install Windows build dependencies
 
   - script: |
+      node script\vsts\windows-run.js script\bootstrap.cmd
+    displayName: Bootstrap build environment
+
+  - script: node script\vsts\windows-run.js script\lint.cmd
+    env:
+      BUILD_ARCH: $(buildArch)
+    displayName: Run linter
+
+  - script: |
       IF NOT EXIST C:\tmp MKDIR C:\tmp
       SET SQUIRREL_TEMP=C:\tmp
       IF [%IS_RELEASE_BRANCH%]==[true] (
         ECHO Creating production artifacts for release branch %BUILD_SOURCEBRANCHNAME%
-        node script\vsts\windows-run.js script\build.cmd --code-sign --compress-artifacts --create-windows-installer
+        node script\vsts\windows-run.js script\build.cmd --no-bootstrap --code-sign --compress-artifacts --create-windows-installer
       ) ELSE (
         IF [%IS_SIGNED_ZIP_BRANCH%]==[true] (
           ECHO Creating signed CI artifacts for branch %BUILD_SOURCEBRANCHNAME%
-          node script\vsts\windows-run.js script\build.cmd --code-sign --compress-artifacts
+          node script\vsts\windows-run.js script\build.cmd --no-bootstrap --code-sign --compress-artifacts
         ) ELSE (
           ECHO Pull request build, no code signing will be performed
-          node script\vsts\windows-run.js script\build.cmd --compress-artifacts
+          node script\vsts\windows-run.js script\build.cmd --no-bootstrap --compress-artifacts
         )
       )
     env:
@@ -60,11 +69,6 @@ jobs:
       IS_RELEASE_BRANCH: $(IsReleaseBranch)
       IS_SIGNED_ZIP_BRANCH: $(IsSignedZipBranch)
     displayName: Build Atom
-
-  - script: node script\vsts\windows-run.js script\lint.cmd
-    env:
-      BUILD_ARCH: $(buildArch)
-    displayName: Run linter
 
   - script: node script\vsts\windows-run.js script\test.cmd
     env:

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -50,14 +50,14 @@ jobs:
       SET SQUIRREL_TEMP=C:\tmp
       IF [%IS_RELEASE_BRANCH%]==[true] (
         ECHO Creating production artifacts for release branch %BUILD_SOURCEBRANCHNAME%
-        node script\vsts\windows-run.js script\build.cmd --no-bootstrap --code-sign --compress-artifacts --create-windows-installer
+        node script\vsts\windows-run.js script\build.cmd --code-sign --compress-artifacts --create-windows-installer
       ) ELSE (
         IF [%IS_SIGNED_ZIP_BRANCH%]==[true] (
           ECHO Creating signed CI artifacts for branch %BUILD_SOURCEBRANCHNAME%
-          node script\vsts\windows-run.js script\build.cmd --no-bootstrap --code-sign --compress-artifacts
+          node script\vsts\windows-run.js script\build.cmd --code-sign --compress-artifacts
         ) ELSE (
           ECHO Pull request build, no code signing will be performed
-          node script\vsts\windows-run.js script\build.cmd --no-bootstrap --compress-artifacts
+          node script\vsts\windows-run.js script\build.cmd --compress-artifacts
         )
       )
     env:

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -38,6 +38,8 @@ jobs:
 
   - script: |
       node script\vsts\windows-run.js script\bootstrap.cmd
+    env:
+      BUILD_ARCH: $(buildArch)
     displayName: Bootstrap build environment
 
   - script: node script\vsts\windows-run.js script\lint.cmd

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -1,4 +1,4 @@
-const AtomWindow = require('./atom-window');
+const AtomWindow = require('./atom-window')
 const ApplicationMenu = require('./application-menu')
 const AtomProtocolHandler = require('./atom-protocol-handler')
 const AutoUpdateManager = require('./auto-update-manager')

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -1,4 +1,4 @@
-const AtomWindow = require('./atom-window')
+const AtomWindow = require('./atom-window');
 const ApplicationMenu = require('./application-menu')
 const AtomProtocolHandler = require('./atom-protocol-handler')
 const AutoUpdateManager = require('./auto-update-manager')


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

This pull request closes #18940.

This pull request also helps us make progress toward #19006.

### Description of the Change

This pull request enhances the CI builds to "fail fast" when a linting violation is present, so that developers can enjoy a faster feedback loop.  (See #18940 for more discussion of the motivation.)

As @50Wliu mentions in https://github.com/atom/atom/issues/18940#issuecomment-475021141, `script/lint` depends on `script/bootstrap`. Prior to this pull request, `script/bootstrap` only ran as part of `script/build`. Because of that, we ran `script/lint` *after* `script/build` so that all of the dependencies for `script/lint` would be in place. However, `script/build` is one of the slowest parts of the CI build, so it would be nice if we didn't have to wait for `script/build` to complete in order to check for linting violations. 

With the changes in this pull request, we now run `script/bootstrap` on its own early in the CI set-up, and that enables us to run `script/lint` _before_ running `script/build`. 😅

### Alternate Designs

Since `script/bootstrap` now runs earlier in the CI process, this pull request adds an option that allows you to tell `script/build` to skip bootstrapping. This isn't essential, but I think it's nice to have. As an alternative, instead of adding an option to `script/build` to allow you to skip bootstrapping, we could have `script/build` always bootstrap (just as it did prior to this pull request). This approach would result in less logic to maintain, but the unnecessary bootstrapping adds about 15 seconds to the build (as measured on a 2018 MacBook Pro). Since we're running `script/lint` before `script/build`, and since `script/lint` depends on `script/bootstrap`, we don't _need_ to run `script/bootstrap` as part of `script/build`, so we can save some time by skipping it.

### Possible Drawbacks

It introduces a small bit of additional conditional logic to `script/build`.

### Verification Process

To verify these changes, I [intentionally inserted a linting violation](https://github.com/atom/atom/commit/2717815762823d2d9bc75d2a9e2712845739c587) and confirmed that the builds failed fast. I then [removed the linting violation](https://github.com/atom/atom/commit/b5748bcbdc07928b85735e10d46470e5c52cd17e) and confirmed that all the builds passed. For more details, please see below.

- [x] Travis CI
	- [x] [Fail fast on linting violation](https://travis-ci.org/atom/atom/builds/514681544#L736)
	- [x] [Complete successfully after removing linting violation](https://travis-ci.org/atom/atom/builds/514776458#L736)
- [x] Azure DevOps Production Branches Pipeline
	- [x] Linux
		- [x] [Fail fast on linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37020&view=logs&jobId=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&taskId=5b4cc83a-7bb0-5664-5bb1-588f7e4dc05b&lineStart=14&lineEnd=15&colStart=1&colEnd=1)
		- [x] [Complete successfully after removing linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37090)
	- [x] Windows 64
		- [x] [Fail fast on linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37020&view=logs&jobId=4fbced83-508e-5fe0-c978-5c71ec0fc506&taskId=efea9dc6-8b7a-5cfd-995a-4727b0e8449d&lineStart=14&lineEnd=15&colStart=1&colEnd=1)
		- [x] [Complete successfully after removing linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37090)
	- [x] Windows x86
		- [x] [Fail fast on linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37020&view=logs&jobId=a5e52b91-c83f-5429-4a68-c246fc63a4f7&taskId=2dac33d1-b0ca-5feb-3c36-18b56319df50&lineStart=14&lineEnd=15&colStart=1&colEnd=1)
		- [x] [Complete successfully after removing linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37090)
	- [x] macOS
		- [x] [Fail fast on linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37020&view=logs&jobId=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&taskId=5b4cc83a-7bb0-5664-5bb1-588f7e4dc05b&lineStart=14&lineEnd=15&colStart=1&colEnd=1)
		- [x] [Complete successfully after removing linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37090)
- [x] Azure DevOps Pull Requests Pipeline
	- [x] Linux
		- [x] [Fail fast on linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37011&view=logs&jobId=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&taskId=5b4cc83a-7bb0-5664-5bb1-588f7e4dc05b&lineStart=14&lineEnd=15&colStart=1&colEnd=1)
		- [x] [Complete successfully after removing linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37090)
	- [x] Windows 64
		- [x] [Fail fast on linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37011&view=logs&jobId=4fbced83-508e-5fe0-c978-5c71ec0fc506&taskId=efea9dc6-8b7a-5cfd-995a-4727b0e8449d&lineStart=14&lineEnd=15&colStart=1&colEnd=1)
		- [x] [Complete successfully after removing linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37090)
	- [x] Windows x86
		- [x] [Fail fast on linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37011&view=logs&jobId=97a617bf-bcbd-5dfa-bba2-cfba2747b693&taskId=ce76a027-d404-5bfb-7945-43613713e966&lineStart=15&lineEnd=16&colStart=1&colEnd=1)
		- [x] [Complete successfully after removing linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37090)
	- [x] macOS
		- [x] [Fail fast on linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37011&view=logs&jobId=a5e52b91-c83f-5429-4a68-c246fc63a4f7&taskId=2dac33d1-b0ca-5feb-3c36-18b56319df50&lineStart=14&lineEnd=15&colStart=1&colEnd=1)
		- [x] [Complete successfully after removing linting violation](https://github.visualstudio.com/Atom/_build/results?buildId=37090)

Note: This pull request doesn't change anything about the AppVeyor build.  In the AppVeyor build, `script/lint` and `script/test` both run as part of the `test_script` step [here](https://github.com/atom/atom/blob/44271255fc5e0ff6ab73c49a669f0c068837947a/appveyor.yml#L68).  To have `script/lint` run before `script/build`, I think we'd have to move `script/build` out of the [`build_script` step](https://github.com/atom/atom/blob/44271255fc5e0ff6ab73c49a669f0c068837947a/appveyor.yml#L42-L64) into the `test_script` step, and that just seems weird. Given that we're hoping to retire AppVeyor before too long, I think we should leave this as is. Linting will still fail fast on Travis CI and Azure DevOps, so that will give developers the faster feedback loop that we're looking for.

### Release Notes

N/A - This is not a user-facing change, so it probably shouldn't go into the release notes.

---

/fyi @Aerijo