### PR TITLE
Remove --socket-path CLI argument

### DIFF
--- a/spec/integration/helpers/start-atom.coffee
+++ b/spec/integration/helpers/start-atom.coffee
@@ -11,7 +11,6 @@ webdriverio = require '../../../script/node_modules/webdriverio'
 AtomPath = remote.process.argv[0]
 AtomLauncherPath = path.join(__dirname, "..", "helpers", "atom-launcher.sh")
 ChromedriverPath = path.resolve(__dirname, '..', '..', '..', 'script', 'node_modules', 'electron-chromedriver', 'bin', 'chromedriver')
-SocketPath = path.join(os.tmpdir(), "atom-integration-test-#{Date.now()}.sock")
 ChromedriverPort = 9515
 ChromedriverURLBase = "/wd/hub"
 ChromedriverStatusURL = "http://localhost:#{ChromedriverPort}#{ChromedriverURLBase}/status"
@@ -53,7 +52,6 @@ buildAtomClient = (args, env) ->
           "dev"
           "safe"
           "user-data-dir=#{userDataDir}"
-          "socket-path=#{SocketPath}"
         ])
 
   isRunning = false
@@ -111,16 +109,6 @@ buildAtomClient = (args, env) ->
             return done() unless newWindowHandle
             @window(newWindowHandle)
               .waitForExist('atom-workspace', 10000, done)
-
-    .addCommand "startAnotherAtom", (args, env, done) ->
-      @call ->
-        if isRunning
-          spawnSync(AtomPath, args.concat([
-            "--dev"
-            "--safe"
-            "--socket-path=#{SocketPath}"
-          ]), env: extend({}, process.env, env))
-        done()
 
     .addCommand "dispatchCommand", (command, done) ->
       @execute "atom.commands.dispatch(document.activeElement, '#{command}')"

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -1390,7 +1390,6 @@ class AtomApplication extends EventEmitter {
     const args = []
     if (this.safeMode) args.push('--safe')
     if (this.logFile != null) args.push(`--log-file=${this.logFile}`)
-    if (this.socketPath != null) args.push(`--socket-path=${this.socketPath}`)
     if (this.userDataDir != null) args.push(`--user-data-dir=${this.userDataDir}`)
     if (this.devMode) {
       args.push('--dev')

--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -58,7 +58,6 @@ module.exports = function parseCommandLine (processArgs) {
   options.alias('v', 'version').boolean('v').describe('v', 'Print the version information.')
   options.alias('w', 'wait').boolean('w').describe('w', 'Wait for window to be closed before returning.')
   options.alias('a', 'add').boolean('a').describe('add', 'Open path as a new project in last used window.')
-  options.string('socket-path')
   options.string('user-data-dir')
   options.boolean('clear-window-state').describe('clear-window-state', 'Delete all Atom environment state.')
   options.boolean('enable-electron-logging').describe('enable-electron-logging', 'Enable low-level logging messages from Electron.')
@@ -121,7 +120,6 @@ module.exports = function parseCommandLine (processArgs) {
   }
 
   const logFile = args['log-file']
-  const socketPath = args['socket-path']
   const userDataDir = args['user-data-dir']
   const profileStartup = args['profile-startup']
   const clearWindowState = args['clear-window-state']
@@ -158,7 +156,6 @@ module.exports = function parseCommandLine (processArgs) {
     safeMode,
     newWindow,
     logFile,
-    socketPath,
     userDataDir,
     profileStartup,
     timeout,


### PR DESCRIPTION
This PR removes the `--socket-path` CLI argument, since it seems to not be used anymore.

The `--socket-path` argument was added in https://github.com/atom/atom/pull/5404/commits/ab43b08739da2159e241460c5f0e2dfa2414775c to enable the following integration test: https://github.com/atom/atom/pull/5404/commits/ab43b08739da2159e241460c5f0e2dfa2414775c which does not exist anymore.