### PR TITLE
:memo: Update README [ci skip]

### DIFF
--- a/packages/autoflow/README.md
+++ b/packages/autoflow/README.md
@@ -1,5 +1,7 @@
 # Autoflow package
 
-Format the current selection to have lines no longer than 80 characters using `cmd-alt-q` on macOS and `ctrl-shift-q` on Windows and Linux. If nothing is selected, the current paragraph will be reflowed.
+Format the current selection to have lines no longer than 80 characters using `cmd-alt-q` (or `cmd-opt-q`) on macOS and `ctrl-shift-q` on Windows and Linux. If nothing is selected, the current paragraph will be reflowed.
 
 This package uses the config value of `editor.preferredLineLength` when set to determine desired line length.
+
+A word of warning: using `shift-opt` instead of just `opt` is a macOS shortcut for force quitting all applications and logging the user out. Be careful of what you press.


### PR DESCRIPTION
### Description of the Change

This change adds a clarification of key mapping for Mac users as well as a warning for a system shortcut that may be unintentionally used.

### Release Notes

Updated documentation to include a warning to Mac users.


-----
[View rendered packages/autoflow/README.md](https://github.com/thomasstep/atom/blob/master/packages/autoflow/README.md)