### PR TITLE
Add authentication/encryption when using pipes for IPC

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -967,12 +967,18 @@ describe('AtomApplication', function () {
       () => originalApplication.getAllWindows().length === 2
     )
 
-    // Check that the original application now has two opened windows.
-    assert.deepEqual(
-      originalApplication.getAllWindows().map(
-        window => window.loadSettings.initialPaths
+    // Check that the original application now has the two opened windows.
+    assert.notEqual(
+      originalApplication.getAllWindows().find(
+        window => window.loadSettings.initialPaths[0] === tempDirPath1
       ),
-      [[tempDirPath2], [tempDirPath1]]
+      undefined
+    )
+    assert.notEqual(
+      originalApplication.getAllWindows().find(
+        window => window.loadSettings.initialPaths[0] === tempDirPath2
+      ),
+      undefined
     )
   })
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -119,14 +119,16 @@ class AtomApplication extends EventEmitter {
   // Public: The entry point into the Atom application.
   static open (options) {
     const socketSecret = getExistingSocketSecret(options.version)
-    const socketPath = options.socketPath || getSocketPath(socketSecret)
+    const socketPath = getSocketPath(socketSecret)
 
     // FIXME: Sometimes when socketPath doesn't exist, net.connect would strangely
     // take a few seconds to trigger 'error' event, it could be a bug of node
     // or electron, before it's fixed we check the existence of socketPath to
     // speedup startup.
-    if ((process.platform !== 'win32' && !fs.existsSync(socketPath)) ||
-        options.test || options.benchmark || options.benchmarkTest || !socketPath) {
+    if (
+      !socketPath || options.test || options.benchmark || options.benchmarkTest ||
+      (process.platform !== 'win32' && !fs.existsSync(socketPath))
+    ) {
       new AtomApplication(options).initialize(options)
       return
     }
@@ -425,6 +427,10 @@ class AtomApplication extends EventEmitter {
   }
 
   deleteSocketSecretFile () {
+    if (!this.socketSecret) {
+      return
+    }
+
     const socketSecretPath = getSocketSecretPath(this.version)
 
     if (fs.existsSync(socketSecretPath)) {


### PR DESCRIPTION
This fixes a potential Atom security issue caused by the fact that in Windows machines there are no ACL mechanisms for named pipes

## Context

Atom has some logic to share the same [main process](https://electronjs.org/docs/tutorial/application-architecture#main-and-renderer-processes) when opening different instances (or windows) of the editor.

Currently, this is done in Windows by creating a named pipe the first time that Atom is launched, so subsequent launches can check if the pipe exists and if so they pass the needed information to launch the new Window through the pipe to the main process.

The created pipe name contains some additional information (the Atom version, local username who's launching Atom, cpu architecture), this way multiple users can have different instances of Atom opened without affecting each other.

## Security issue

In Windows, named pipes are global and available system wide: any user can create a named pipe, list all the named pipes that exist on the system, connect to any named pipe or sniff messages that travel through any named pipe.

## Solution

This solution provides 3 different takes:

1. The named pipe created by the server is not constant between executions but varies randomly, so a malicious user cannot guess what's going to be the name of the pipe and impersonate the server.
2. The payload sent from the client to the server is now encrypted, so a potential attacker cannot find out the env variables of another user by sniffing the named pipe information.
3. Clients authenticate themselves to the server when sending the options, so the server can ignore messages from untrusted clients.

In order to implement this whole flow, the server and the clients share a single secret which gets stored in the `ATOM_HOME` folder on a file only accessible to the current user. This secret gets randomly regenerated every time the server is started.

The secret file name contains the username and the Atom version (e.g `~/.atom/.atom-socket-secret-rafeca-1.35.1`, so if either multiple users share the same `ATOM_HOME` folder or a user launches multiple versions of Atom the different instances are kept isolated and secure.

## Implementation details

* The secret has a length of 32 bytes and is represented in hexadecimal on the secret file.
* The pipe name is generated from the secret, by using the HMAC authentication with a `sha256` hash function and a message fixed to `socketName` and stripped to 12 chars (to ensure that pipe names are not too long). This avoids leaking the secret through the pipe name.
* The authentication and encryption of messages from clients to the server is done using [`GCM` encryption](https://en.wikipedia.org/wiki/Galois/Counter_Mode) with AES-256. The initialization vector is generated randomly for each message and passed in clear text as part of the message.