### PR TITLE
Make sure that Atom does not get autoupdated when running main process tests

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -992,6 +992,10 @@ describe('AtomApplication', function () {
         params
       )
     )
+
+    // Make sure that the app does not get updated automatically.
+    atomApplication.config.set('core.automaticallyUpdate', false)
+
     atomApplicationsToDestroy.push(atomApplication)
     return atomApplication
   }


### PR DESCRIPTION
## Context

Somehow, after adding a main process test in https://github.com/atom/atom/pull/19109/commits/df54e900d5ef25c7dd52b07d6141c91069ae5208, the Azure builds have started failing on master ([example](https://dev.azure.com/github/Atom/_build/results?buildId=37389)).

By looking at the logs, this seems to be caused by the autoupdate logic being triggered when that test is executed. Then, when Atom gets autoupdated during the CI build, another [unrelated test](https://github.com/atom/atom/blob/master/spec/buffered-process-spec.coffee#L71) starts failing with the following error:

```
{ Error: spawn /Users/vsts/agent/2.149.2/work/1/s/out/Atom Dev.app/Contents/MacOS/Atom Dev ENOENT
    at _errnoException (util.js:1024:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:190:19)
    at onErrorNT (internal/child_process.js:372:16)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
  code: 'ENOENT',
  errno: 'ENOENT',
  syscall: 'spawn /Users/vsts/agent/2.149.2/work/1/s/out/Atom Dev.app/Contents/MacOS/Atom Dev',
  path: '/Users/vsts/agent/2.149.2/work/1/s/out/Atom Dev.app/Contents/MacOS/Atom Dev',
  spawnargs: 
   [ '--benchmark-test',
     '/Users/vsts/agent/2.149.2/work/1/s/benchmarks' ] }
```

This issue only appears on `master` or on release branches (not on PRs), since the autoupdate logic  only works correctly when executed against a signed build of Atom, and we don't sign Atom on PRs.

## Solution

This PR is basically a workaround to avoid autoupdating Atom when running the tests, but the root issue here is that builds generated from CI can get autoupdated, somehow the autoupdate logic should prevent this...