### PR TITLE
Fix atom-application tests

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -663,6 +663,10 @@ describe('AtomApplication', function () {
             parseCommandLine([path.join(makeTempDir('a'), 'file-a')])
           )
           await focusWindow(window)
+
+          // Choosing "Don't save"
+          mockElectronShowMessageBox({ response: 2 })
+
           window.close()
           await window.closedPromise
           await atomApplication.lastBeforeQuitPromise
@@ -675,6 +679,10 @@ describe('AtomApplication', function () {
             parseCommandLine([path.join(makeTempDir('a'), 'file-a')])
           )
           await focusWindow(window)
+
+          // Choosing "Don't save"
+          mockElectronShowMessageBox({ response: 2 })
+
           window.close()
           await window.closedPromise
           await timeoutPromise(1000)


### PR DESCRIPTION
When closing a window with a file that does not exist, Atom opens a dialog asking the users if they want to save the changes. This dialog prevents the tests from finishing correctly (as seen in the [CI builds](https://github.visualstudio.com/Atom/_build/results?buildId=37183&view=logs&jobId=a5e52b91-c83f-5429-4a68-c246fc63a4f7&taskId=8b9bff53-2841-58c7-68fc-e30c30330fc3&lineStart=197&lineEnd=204&colStart=1&colEnd=3)).

I still don't know why this test can ever pass (currently it always fails on my OSX machine).

This should fix https://github.com/atom/atom/issues/18993