### PR TITLE
Wait until the editor is ready on application test

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -663,6 +663,7 @@ describe('AtomApplication', function () {
             parseCommandLine([path.join(makeTempDir('a'), 'file-a')])
           )
           await focusWindow(window)
+          await emitterEventPromise(window, 'window:locations-opened')
 
           // Choosing "Don't save"
           mockElectronShowMessageBox({ response: 2 })
@@ -679,6 +680,7 @@ describe('AtomApplication', function () {
             parseCommandLine([path.join(makeTempDir('a'), 'file-a')])
           )
           await focusWindow(window)
+          await emitterEventPromise(window, 'window:locations-opened')
 
           // Choosing "Don't save"
           mockElectronShowMessageBox({ response: 2 })


### PR DESCRIPTION
This should fix the root issue that made the test that was fixed on https://github.com/atom/atom/pull/19124 flaky.

The problem is that this specific test was not waiting until the editor was completely ready, so sometimes the confirmation dialog was shown and some other times it wasn't.

This PR add the needed wait to that test. If we find additiional flaky tests in that file we may want to add similar waits.