### PR TITLE
Add ability to retry flaky Jasmine tests

### DIFF
--- a/spec/native-watcher-registry-spec.js
+++ b/spec/native-watcher-registry-spec.js
@@ -100,6 +100,8 @@ describe('NativeWatcherRegistry', function () {
   })
 
   it('reuses an existing NativeWatcher on the same directory', async function () {
+    this.RETRY_FLAKY_TEST_AND_SLOW_DOWN_THE_BUILD()
+
     const EXISTING = new MockNative('existing')
     const existingPath = absolute('existing', 'path')
     let firstTime = true


### PR DESCRIPTION
Our builds are currently plagued by a handful of timing-dependent tests that fail intermittently. The ideal solution would be to find and fix the source of indeterminacy in these tests, as I did in https://github.com/atom/settings-view/pull/1123, but that can be time consuming. An even *better* solution would be to restructure these code paths and tests to not depend on timing in a critical way, but that would be even *more* difficult. Another alternative is just to delete the offending tests, but I'm reluctant to lose the coverage on functionality that they are trying to document.

So in the interests of reducing spurious build failures *quickly* without resorting to deleting tests, I'm introducing the ability to retry flaky tests as an experiment. Teammates have expressed concerns about the long-term impact of doing this and I myself am not totally sure it's a good idea, but I think it's worth trying. This feature essentially transforms flaky tests that cause massive delays in our build process into technical debt. We still to prioritize cleaning them up, but we can mitigate their impact on our build process in the short term. If we're still seeing a test be unreliable after retrying it, at that point I think we 
should either delete it or make fixing it a top priority in that sprint.

So if you encounter a flaky test and you've spent some time trying to figure it out and just can't, you now have a new option. You can add the following to the top of the test body:

```js
 it('fails 5% of the time on Windows x86 for unknown reasons and ruins our lives', async function () {
    this.RETRY_FLAKY_TEST_AND_SLOW_DOWN_THE_BUILD()

    // ... insert remainder of poorly-designed test case here ;-)
})
```

I've deliberately made using this option ugly and screamingly obvious to discourage its use. Sorry in advance if this ends up being a bad idea.