### PR TITLE
"Open file" in existing window

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -968,11 +968,21 @@ class AtomApplication extends EventEmitter {
     const normalizedPathsToOpen = locationsToOpen.map(location => location.pathToOpen).filter(Boolean)
 
     let existingWindow
-    if (!newWindow && normalizedPathsToOpen.length > 0) {
+
+    // Explicitly provided AtomWindow has precedence unless a new window is forced.
+    if (!newWindow) {
+      existingWindow = window
+    }
+
+    // If no window is specified, a new window is not forced, and at least one path is provided, locate
+    // an existing window that contains all paths.
+    if (!existingWindow && !newWindow && normalizedPathsToOpen.length > 0) {
       existingWindow = this.windowForPaths(normalizedPathsToOpen, devMode)
     }
 
-    if (addToLastWindow && !existingWindow) {
+    // No window specified, new window not forced, no existing window found, and addition to the last window
+    // requested. Find the last focused window.
+    if (!existingWindow && !newWindow && addToLastWindow) {
       let lastWindow = window || this.getLastFocusedWindow()
       if (lastWindow && lastWindow.devMode === devMode) {
         existingWindow = lastWindow

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -639,13 +639,15 @@ class AtomApplication extends EventEmitter {
     }))
 
     this.disposable.add(ipcHelpers.on(ipcMain, 'open-command', (event, command, defaultPath) => {
+      const options = getLoadSettings()
+      options.window = this.atomWindowForEvent(event)
       switch (command) {
         case 'application:open':
-          return this.promptForPathToOpen('all', getLoadSettings(), defaultPath)
+          return this.promptForPathToOpen('all', options, defaultPath)
         case 'application:open-file':
-          return this.promptForPathToOpen('file', getLoadSettings(), defaultPath)
+          return this.promptForPathToOpen('file', options, defaultPath)
         case 'application:open-folder':
-          return this.promptForPathToOpen('folder', getLoadSettings(), defaultPath)
+          return this.promptForPathToOpen('folder', options, defaultPath)
         default:
           return console.log(`Invalid open-command received: ${command}`)
       }


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Fixes #19133.

### Description of the Change

In AtomApplication:

* Made the `getLoadSettings()` helper optionally include the last focused window in its output.
* Modified `openPaths()` to more strongly respect an explicitly provided `{window}` argument. (Previously, `{window}` would be used only if `{addToLastWindow}` was set to true.)
* Changed `promptForPathsToOpen()` to pass a `{window}` argument on to `openPaths()` if and only if all of the chosen paths are non-directories. (This is to be consistent with the behavior in 1.35.1; "open folder" opens a new window, "open file" opens in the existing window.)
* Used `getLoadSettings(true)` in all of the codepaths that an "open" or "open file" dialog can hit.

### Alternate Designs

We could refactor the opening logic completely I guess to be clearer and less error-prone. Now isn't the time to do that, though, and it went poorly the last time I tried it.

### Possible Drawbacks

`application:open-file` and `application:open-folder` have inconsistent and confusing behavior.

### Verification Process

I did a manual Atom build and verified that the File -> Open... menu item and the `cmd-O` keybinding opened files in the current window and folders in a new window.

### Release Notes

This is fixing a regression, so no release notes.