### PR TITLE
Calculate env vars when launching Atom from the desktop

### DIFF
--- a/atom.sh
+++ b/atom.sh
@@ -24,7 +24,11 @@ case $(basename $0) in
     ;;
 esac
 
-export ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT=true
+# Only set the ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT env var if it hasn't been set.
+if [ -z "$ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT" ]
+then
+  export ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT=true
+fi
 
 ATOM_ADD=false
 ATOM_NEW_WINDOW=false

--- a/resources/linux/atom.desktop.in
+++ b/resources/linux/atom.desktop.in
@@ -2,7 +2,7 @@
 Name=<%= appName %>
 Comment=<%= description %>
 GenericName=Text Editor
-Exec=<%= installDir %>/bin/<%= appFileName %> %F
+Exec=env ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT=false <%= installDir %>/bin/<%= appFileName %> %F
 Icon=<%= iconPath %>
 Type=Application
 StartupNotify=true

--- a/src/update-process-env.js
+++ b/src/update-process-env.js
@@ -51,7 +51,9 @@ function shouldGetEnvFromShell (env) {
     return false
   }
 
-  if (env.ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT || process.env.ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT) {
+  const disableSellingOut = env.ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT || process.env.ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT
+
+  if (disableSellingOut === 'true') {
     return false
   }
 


### PR DESCRIPTION
### Identify the Bug

Atom [has some logic](https://github.com/atom/atom/blob/master/src/update-process-env.js#L61-L95) to get the correct env variables when calling directly the Atom binary (the one located in `/usr/share/atom/atom`).

This logic is bypassed when calling Atom via the bash CLI (the script located in `/usr/bin/atom`). This is done [by checking](https://github.com/atom/atom/blob/master/src/update-process-env.js#L54) the `ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT` env var which [is set](https://github.com/atom/atom/blob/master/atom.sh#L27) by the CLI (there's more info in [the PR](https://github.com/atom/atom/pull/12562) that introduced this).

This logic assumes that entry points that don't contain the correct env vars (like a desktop launcher) will call the binary directly, while a shell script or terminal (which contain the correct env vars) will call the CLI. After #17508, this is no longer true, and this is the root cause of the issue.

Applicable issue: https://github.com/atom/atom/issues/18318

### Description of the Change

This PR makes Atom keep using the previous logic to calculate env vars instead. To do so, it modifies the linux launcher to define the `ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT` env var and changes the bash script to not define it if it's already set.

### Alternate Designs

* Create a different bash script which is only used by desktop launchers. This will require more changes and it does not provide any major benefit.
* Change the bash script to use bash in interactive mode. This can cause unexpected behaviours in some configurations (depending on the users' `.bashrc` files).

### Possible Drawbacks

None that I can think of.

### Verification Process

- [x] Patched a working copy of Atom in a linux machine and checked that it works correctly.
- [x] Download an Atom build from this PR and verify it.

### Release Notes

Fixed issue inheriting environmental variables when opening Atom from the desktop on Linux.