### PR TITLE
Add debug traces to failing test steps

### DIFF
--- a/script/test
+++ b/script/test
@@ -87,7 +87,7 @@ function runCoreMainProcessTests (callback) {
   console.log('Executing core main process tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })
-  cp.on('close', exitCode => { callback(null, exitCode) })
+  cp.on('close', exitCode => { callback(null, {exitCode}) })
 }
 
 function runCoreRenderProcessTests (callback) {
@@ -101,7 +101,7 @@ function runCoreRenderProcessTests (callback) {
   console.log('Executing core render process tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })
-  cp.on('close', exitCode => { callback(null, exitCode) })
+  cp.on('close', exitCode => { callback(null, {exitCode}) })
 }
 
 // Build an array of functions, each running tests for a different bundled package
@@ -118,7 +118,7 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
   if (!testSubdir) {
     packageTestSuites.push(function (callback) {
       console.log(`Skipping tests for ${packageName} because no test folder was found`.bold.yellow)
-      callback(null, 0)
+      callback(null, {exitCode: 0})
     })
     continue
   }
@@ -162,7 +162,7 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
         console.log(stderrOutput)
       }
       finalize()
-      callback(null, exitCode)
+      callback(null, {exitCode})
     })
   })
 }
@@ -175,7 +175,7 @@ function runBenchmarkTests (callback) {
   console.log('Executing benchmark tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })
-  cp.on('close', exitCode => { callback(null, exitCode) })
+  cp.on('close', exitCode => { callback(null, {exitCode}) })
 }
 
 let testSuitesToRun = requestedTestSuites() || testSuitesForPlatform(process.platform)
@@ -220,12 +220,12 @@ function testSuitesForPlatform (platform) {
   return suites
 }
 
-async.series(testSuitesToRun, function (err, exitCodes) {
+async.series(testSuitesToRun, function (err, results) {
   if (err) {
     console.error(err)
     process.exit(1)
   } else {
-    const testsPassed = exitCodes.every(exitCode => exitCode === 0)
+    const testsPassed = results.every(({exitCode}) => exitCode === 0)
     process.exit(testsPassed ? 0 : 1)
   }
 })

--- a/script/test
+++ b/script/test
@@ -87,7 +87,7 @@ function runCoreMainProcessTests (callback) {
   console.log('Executing core main process tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })
-  cp.on('close', exitCode => { callback(null, {exitCode}) })
+  cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-main-process'}) })
 }
 
 function runCoreRenderProcessTests (callback) {
@@ -101,7 +101,7 @@ function runCoreRenderProcessTests (callback) {
   console.log('Executing core render process tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })
-  cp.on('close', exitCode => { callback(null, {exitCode}) })
+  cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-render-process'}) })
 }
 
 // Build an array of functions, each running tests for a different bundled package
@@ -118,7 +118,7 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
   if (!testSubdir) {
     packageTestSuites.push(function (callback) {
       console.log(`Skipping tests for ${packageName} because no test folder was found`.bold.yellow)
-      callback(null, {exitCode: 0})
+      callback(null, {exitCode: 0, step: `package-${packageName}`})
     })
     continue
   }
@@ -162,7 +162,7 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
         console.log(stderrOutput)
       }
       finalize()
-      callback(null, {exitCode})
+      callback(null, {exitCode, step: `package-${packageName}`})
     })
   })
 }
@@ -175,7 +175,7 @@ function runBenchmarkTests (callback) {
   console.log('Executing benchmark tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })
-  cp.on('close', exitCode => { callback(null, {exitCode}) })
+  cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-benchmarks'}) })
 }
 
 let testSuitesToRun = requestedTestSuites() || testSuitesForPlatform(process.platform)
@@ -225,7 +225,12 @@ async.series(testSuitesToRun, function (err, results) {
     console.error(err)
     process.exit(1)
   } else {
-    const testsPassed = results.every(({exitCode}) => exitCode === 0)
-    process.exit(testsPassed ? 0 : 1)
+    const failedSteps = results.filter(({exitCode}) => exitCode !== 0)
+
+    for (const {step} of failedSteps) {
+      console.error(`Error! The '${step}' test step finished with a non-zero exit code`)
+    }
+
+    process.exit(failedSteps.length === 0 ? 0 : 1)
   }
 })


### PR DESCRIPTION
Currently, if one of the steps executed during the tests returns a non-zero exit code, we fail with the following message:

```
##[error]Cmd.exe exited with code '1'.
##[section]Finishing: Run tests
```

Normally, since the failing step prints an error, it's easy to identify which step failed, but in other situations (like [this test build](https://github.visualstudio.com/Atom/_build/results?buildId=36846&view=logs&jobId=4fbced83-508e-5fe0-c978-5c71ec0fc506&taskId=469abba8-e098-5409-562f-26dedf3df794&lineStart=2167&lineEnd=2168&colStart=1&colEnd=32)) it's hard to identify which step is failing.

For now this only prints the step that caused the failure (which is the only thing we can get at the moment), but we can use this to print additional information in the future.

This may give us some information to identify the root cause of https://github.com/atom/atom/issues/19089