### PR TITLE
Add option to customize dock `DEFAULT_INITIAL_SIZE`

### DIFF
--- a/spec/dock-spec.js
+++ b/spec/dock-spec.js
@@ -26,6 +26,46 @@ describe('Dock', () => {
       expect(document.activeElement).toBe(dock.getActivePane().getElement())
       expect(didChangeVisibleSpy).toHaveBeenCalledWith(true)
     })
+
+    it('opens the vertically-oriented dock with the size of editor.dockSize config value', async () => {
+      atom.config.set('editor.dockSize', 400)
+
+      jasmine.attachToDOM(atom.workspace.getElement())
+
+      const item = {
+        element: document.createElement('div'),
+        getDefaultLocation () {
+          return 'left'
+        }
+      }
+
+      await atom.workspace.open(item)
+      const dock = atom.workspace.getLeftDock()
+      const dockElement = dock.getElement()
+
+      await getNextUpdatePromise()
+      expect(dockElement.offsetWidth).toBe(400)
+    })
+
+    it('opens the horizontally-oriented dock with the size of editor.dockSize config value', async () => {
+      atom.config.set('editor.dockSize', 400)
+
+      jasmine.attachToDOM(atom.workspace.getElement())
+
+      const item = {
+        element: document.createElement('div'),
+        getDefaultLocation () {
+          return 'bottom'
+        }
+      }
+
+      await atom.workspace.open(item)
+      const dock = atom.workspace.getBottomDock()
+      const dockElement = dock.getElement()
+
+      await getNextUpdatePromise()
+      expect(dockElement.offsetHeight).toBe(400)
+    })
   })
 
   describe('when a dock is hidden', () => {

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -553,6 +553,12 @@ const configSchema = {
         type: 'boolean',
         default: process.platform !== 'darwin',
         description: 'Change the editor font size when pressing the Ctrl key and scrolling the mouse up/down.'
+      },
+      dockSize: {
+        type: 'integer',
+        default: 300,
+        minimum: 100,
+        description: 'Defines the default dock size when opening new window.'
       }
     }
   }

--- a/src/dock.js
+++ b/src/dock.js
@@ -7,7 +7,6 @@ const Grim = require('grim')
 
 const $ = etch.dom
 const MINIMUM_SIZE = 100
-const DEFAULT_INITIAL_SIZE = 300
 const SHOULD_ANIMATE_CLASS = 'atom-dock-should-animate'
 const VISIBLE_CLASS = 'atom-dock-open'
 const RESIZE_HANDLE_RESIZABLE_CLASS = 'atom-dock-resize-handle-resizable'
@@ -190,7 +189,7 @@ module.exports = class Dock {
     const size = Math.max(MINIMUM_SIZE,
       this.state.size ||
       (this.state.draggingItem && getPreferredSize(this.state.draggingItem, this.location)) ||
-      DEFAULT_INITIAL_SIZE
+      this.config.get('editor.dockSize')
     )
 
     // We need to change the size of the mask...
@@ -409,7 +408,7 @@ module.exports = class Dock {
     const activePaneItem = this.paneContainer.getActivePaneItem() || this.paneContainer.getPaneItems()[0]
     // If there are items, we should have an explicit width; if not, we shouldn't.
     return activePaneItem
-      ? getPreferredSize(activePaneItem, this.location) || DEFAULT_INITIAL_SIZE
+      ? getPreferredSize(activePaneItem, this.location) || this.config.get('editor.dockSize')
       : null
   }
 


### PR DESCRIPTION
https://github.com/atom/atom/issues/19127
https://github.com/atom/tree-view/issues/250
https://github.com/atom/tree-view/issues/520

### Description of the Change

Add option to customize dock `DEFAULT_INITIAL_SIZE` using Editor Settings to keep dock size when opening new window

### Verification Process
* Enable tree-view
* Execute atom.config.set('editor.dockSize', 400);
* Open new Atom window
* Check changed tree-view dock initial size

### Release Notes

Added option allowing to customize initial dock size.