### PR TITLE
Atom launch scenario descriptions

### DIFF
--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -43,8 +43,8 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [] [/a 1.md] | [] [ 1.md] :new: | [ 1.md] :new:|
-| `atom /a`                   | [] [/a]      | [] [/a]          | [] [/a]      |
+| `atom /a/1.md`              | [/a 1.md] | [] [ 1.md] :new: | [ 1.md] :new:|
+| `atom /a`                   | [/a]      | [] [/a]          | [] [/a]      |
 | `atom --add /a/1.md`        | [/a 1.md]    | [ 1.md] :new:    | [ 1.md]      |
 | `atom --add /a`             | [/a]         | [/a]             | [/a]         |
 | `atom --new-window /a/1.md` | [] [/a 1.md] | [] [ 1.md] :new: | [] [ 1.md]   |
@@ -60,7 +60,7 @@ With the following starting state:
 | --- | --- | --- | --- |
 | `atom /a/1.md`              | [/a 1.md]      | [/a 1.md]          | [/a 1.md]    |
 | `atom /a`                   | [/a]           | [/a]               | [/a]         |
-| `atom /b/3.md`              | [/a] [/b 3.md] | [/a] [ 3.md] :new: | [/a] [ 3.md] |
+| `atom /b/3.md`              | [/a 3.md] | [/a] [ 3.md] :new: | [/a] [ 3.md] |
 | `atom /b`                   | [/a] [/b]      | [/a] [/b]          | [/a] [/b]    |
 | `atom --add /a/1.md`        | [/a 1.md]      | [/a 1.md]          | [/a 1.md]    |
 | `atom --add /a`             | [/a]           | [/a]               | [/a]         |
@@ -109,8 +109,8 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [] [/a 1.md] | [] [ 1.md] :new: | [ 1.md] :new: |
-| Click on `/a`      | [] [/a]      | [] [/a]          | [] [/a]       |
+| Click on `/a/1.md` | [/a 1.md] | [] [ 1.md] :new: | [ 1.md] :new: |
+| Click on `/a`      | [/a]      | [] [/a]          | [] [/a]       |
 
 ### Open window, project root
 
@@ -122,7 +122,7 @@ With the following starting state:
 | --- | --- | --- | --- |
 | Click on `/a/1.md` | [/a 1.md]      | [/a 1.md]          | [/a 1.md]    |
 | Click on `/a`      | [/a]           | [/a]               | [/a]         |
-| Click on `/b/3.md` | [/a] [/b 3.md] | [/a] [ 3.md] :new: | [/a] [ 3.md] |
+| Click on `/b/3.md` | [/a 3.md] | [/a] [ 3.md] :new: | [/a] [ 3.md] |
 | Click on `/b`      | [/a] [/b]      | [/a] [/b]          | [/a] [/b]    |
 
 ### Open windows, one with a project root and one without

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -117,8 +117,8 @@ When no Atom windows are open, file manager context operations have the followin
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [/a 1.md] | [ 1.md] :new: | [ 1.md] |
-| Click on `/a`      | [/a]      | [/a]          | [/a]    |
+| Click on `/a/1.md` | [/a 1.md] | [ 1.md] :warning: | [ 1.md] |
+| Click on `/a`      | [/a]      | [/a]              | [/a]    |
 
 ### Open window, no project roots
 
@@ -128,8 +128,8 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [/a 1.md] | [] [ 1.md] :new: | [ 1.md] :new: |
-| Click on `/a`      | [/a]      | [] [/a]          | [/a]       |
+| Click on `/a/1.md` | [/a 1.md] | [] [ 1.md] :warning: | [ 1.md] :new: |
+| Click on `/a`      | [/a]      | [] [/a] :warning:    | [/a]       |
 
 ### Open window, project root
 
@@ -139,10 +139,10 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [/a 1.md]      | [/a 1.md]          | [/a 1.md]    |
-| Click on `/a`      | [/a]           | [/a]               | [/a]         |
-| Click on `/b/3.md` | [/a 3.md]      | [/a] [ 3.md] :new: | [/a 3.md] |
-| Click on `/b`      | [/a] [/b]      | [/a] [/b]          | [/a] [/b]    |
+| Click on `/a/1.md` | [/a 1.md]      | [/a 1.md]              | [/a 1.md]    |
+| Click on `/a`      | [/a]           | [/a]                   | [/a]         |
+| Click on `/b/3.md` | [/a 3.md]      | [/a] [ 3.md] :warning: | [/a 3.md] |
+| Click on `/b`      | [/a] [/b]      | [/a] [/b]              | [/a] [/b]    |
 
 ### Open windows, one with a project root and one without
 
@@ -150,16 +150,16 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [/a 1.md] []      | [/a 1.md] []          | [/a 1.md] []       |
-| Click on `/a`      | [/a] []           | [/a] []               | [/a] []            |
-| Click on `/b/3.md` | [/a] [/b 3.md]    | [/a] [] [ 3.md] :new: | [/a] [ 3.md] :new: |
-| Click on `/b`      | [/a] [] [/b]      | [/a] [] [/b]          | [/a] [] [/b]       |
+| Click on `/a/1.md` | [/a 1.md] []      | [/a 1.md] []              | [/a 1.md] []       |
+| Click on `/a`      | [/a] []           | [/a] []                   | [/a] []            |
+| Click on `/b/3.md` | [/a] [/b 3.md]    | [/a] [] [ 3.md] :warning: | [/a] [ 3.md] :new: |
+| Click on `/b`      | [/a] [] [/b]      | [/a] [] [/b]              | [/a] [] [/b]       |
 
 > [] [/a]
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [] [/a 1.md] | | |
-| Click on `/a`      | [] [/a]      | | |
-| Click on `/b/3.md` | [] [/a 3.md] | | |
-| Click on `/b`      | [] [/a] [/b] | | |
+| Click on `/a/1.md` | [] [/a 1.md] | [] [/a 1.md]              | |
+| Click on `/a`      | [] [/a]      | [] [/a]                   | |
+| Click on `/b/3.md` | [] [/a 3.md] | [] [/a] [ 3.md] :warning: | |
+| Click on `/b`      | [] [/a] [/b] | [] [/a] [/b]              | |

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -46,7 +46,7 @@ With the following starting state:
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
 | `atom /a/1.md`              | [/a 1.md]    | [] [ 1.md] :warning: | [ 1.md]    |
-| `atom /a`                   | [/a]         | [] [/a] :warning:    | [] [/a]    |
+| `atom /a`                   | [/a]         | [] [/a] :warning:    | [/a]    |
 | `atom --add /a/1.md`        | [/a 1.md]    | [ 1.md] :warning:    | [ 1.md]    |
 | `atom --add /a`             | [/a]         | [/a]                 | [/a]       |
 | `atom --new-window /a/1.md` | [] [/a 1.md] | [] [ 1.md] :warning: | [] [ 1.md] |

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -79,18 +79,18 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [/a 1.md] []      | [/a 1.md] []          | [/a 1.md] []       |
-| `atom /a`                   | [/a] []           | [/a] []               | [/a] []            |
-| `atom /b/3.md`              | [/a] [/b 3.md]    | [/a] [] [ 3.md] :new: | [/a] [ 3.md] :new: |
-| `atom /b`                   | [/a] [/b]         | [/a] [] [/b]          | [/a] [] [/b]       |
-| `atom --add /a/1.md`        | [/a 1.md] []      | [/a 1.md] []          | [/a 1.md] []       |
-| `atom --add /a`             | [/a] []           | [/a] []               | [/a] []            |
-| `atom --add /b/3.md`        | [/a] [/b 3.md]    | [/a] [ 3.md] :new:    | [/a] [ 3.md]       |
-| `atom --add /b`             | [/a] [/b]         | [/a] [/b]             | [/a] [/b]          |
-| `atom --new-window /a/1.md` | [/a] [] [/a 1.md] | [/a] [] [ 1.md] :new: | [/a] [] [1.md]     |
-| `atom --new-window /a`      | [/a] [] [/a]      | [/a] [] [/a]          | [/a] [] [/a]       |
-| `atom --new-window /b/3.md` | [/a] [] [/b 3.md] | [/a] [] [ 3.md] :new: | [/a] [] [ 3.md]    |
-| `atom --new-window /b`      | [/a] [] [/b]      | [/a] [] [/b]          | [/a] [] [/b]       |
+| `atom /a/1.md`              | [/a 1.md] []      | [/a 1.md] []              | [/a 1.md] []       |
+| `atom /a`                   | [/a] []           | [/a] []                   | [/a] []            |
+| `atom /b/3.md`              | [/a] [/b 3.md]    | [/a] [] [ 3.md] :warning: | [/a] [ 3.md] :new: |
+| `atom /b`                   | [/a] [/b]         | [/a] [] [/b] :warning:    | [/a] [] [/b]       |
+| `atom --add /a/1.md`        | [/a 1.md] []      | [/a 1.md] []              | [/a 1.md] []       |
+| `atom --add /a`             | [/a] []           | [/a] []                   | [/a] []            |
+| `atom --add /b/3.md`        | [/a] [/b 3.md]    | [/a] [ 3.md] :warning:    | [/a] [ 3.md]       |
+| `atom --add /b`             | [/a] [/b]         | [/a] [/b]                 | [/a] [/b]          |
+| `atom --new-window /a/1.md` | [/a] [] [/a 1.md] | [/a] [] [ 1.md] :warning: | [/a] [] [1.md]     |
+| `atom --new-window /a`      | [/a] [] [/a]      | [/a] [] [/a]              | [/a] [] [/a]       |
+| `atom --new-window /b/3.md` | [/a] [] [/b 3.md] | [/a] [] [ 3.md] :warning: | [/a] [] [ 3.md]    |
+| `atom --new-window /b`      | [/a] [] [/b]      | [/a] [] [/b]              | [/a] [] [/b]       |
 
 > [] [/a]
 

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -18,6 +18,8 @@ For brevity, the scenarios below are described using the following notation:
 | [ 3.md] | single Atom window with no project roots and one open editor `/b/3.md` |
 | [/a 1.md] [/b 3.md] | two Atom windows:<br/>the first-opened has one project root (`/a`) and one open editor `/a/1.md`<br/>the second-opened has one project root (`/b`) and one open editor `/b/3.md`. |
 
+Changes in behavior from the immediately preceding version (the column to the immediate left) are marked with :new:
+
 ## CLI actions
 
 ### No open windows
@@ -26,12 +28,12 @@ When no Atom windows are open, CLI actions have the following outcomes:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [/a 1.md] | [ 1.md] | [ 1.md] |
-| `atom /a`                   | [/a]      | [/a]    | [/a]    |
-| `atom --add /a/1.md`        | [/a 1.md] | [ 1.md] | [ 1.md] |
-| `atom --add /a`             | [/a]      | [/a]    | [/a]    |
-| `atom --new-window /a/1.md` | [/a 1.md] | [ 1.md] | [ 1.md] |
-| `atom --new-window /a`      | [/a]      | [/a]    | [/a]    |
+| `atom /a/1.md`              | [/a 1.md] | [ 1.md] :new: | [ 1.md] |
+| `atom /a`                   | [/a]      | [/a]          | [/a]    |
+| `atom --add /a/1.md`        | [/a 1.md] | [ 1.md] :new: | [ 1.md] |
+| `atom --add /a`             | [/a]      | [/a]          | [/a]    |
+| `atom --new-window /a/1.md` | [/a 1.md] | [ 1.md] :new: | [ 1.md] |
+| `atom --new-window /a`      | [/a]      | [/a]          | [/a]    |
 
 ### Open window, no project roots
 
@@ -41,12 +43,12 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [] [/a 1.md] | [] [ 1.md] | [ 1.md]    |
-| `atom /a`                   | [] [/a]      | [] [/a]    | [] [/a]    |
-| `atom --add /a/1.md`        | [/a 1.md]    | [ 1.md]    | [ 1.md]    |
-| `atom --add /a`             | [/a]         | [/a]       | [/a]       |
-| `atom --new-window /a/1.md` | [] [/a 1.md] | [] [ 1.md] | [] [ 1.md] |
-| `atom --new-window /a`      | [] [/a]      | [] [/a]    | [] [/a]    |
+| `atom /a/1.md`              | [] [/a 1.md] | [] [ 1.md] :new: | [ 1.md] :new:|
+| `atom /a`                   | [] [/a]      | [] [/a]          | [] [/a]      |
+| `atom --add /a/1.md`        | [/a 1.md]    | [ 1.md] :new:    | [ 1.md]      |
+| `atom --add /a`             | [/a]         | [/a]             | [/a]         |
+| `atom --new-window /a/1.md` | [] [/a 1.md] | [] [ 1.md] :new: | [] [ 1.md]   |
+| `atom --new-window /a`      | [] [/a]      | [] [/a]          | [] [/a]      |
 
 ### Open window, project root
 
@@ -56,18 +58,18 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [/a 1.md]      | [/a 1.md]    | [/a 1.md]    |
-| `atom /a`                   | [/a]           | [/a]         | [/a]         |
-| `atom /b/3.md`              | [/a] [/b 3.md] | [/a] [ 3.md] | [/a] [ 3.md] |
-| `atom /b`                   | [/a] [/b]      | [/a] [/b]    | [/a] [/b]    |
-| `atom --add /a/1.md`        | [/a 1.md]      | [/a 1.md]    | [/a 1.md]    |
-| `atom --add /a`             | [/a]           | [/a]         | [/a]         |
-| `atom --add /b/3.md`        | [/a,/b 3.md]   | [/a 3.md]    | [/a 3.md]    |
-| `atom --add /b`             | [/a,/b]        | [/a,/b]      | [/a,/b]      |
-| `atom --new-window /a/1.md` | [/a] [/a 1.md] | [/a] [ 1.md] | [/a] [ 1.md] |
-| `atom --new-window /a`      | [/a] [/a]      | [/a] [/a]    | [/a] [/a]    |
-| `atom --new-window /b/3.md` | [/a] [/b 3.md] | [/a] [ 3.md] | [/a] [ 3.md] |
-| `atom --new-window /b`      | [/a] [/b]      | [/a] [/b]    | [/a] [/b]    |
+| `atom /a/1.md`              | [/a 1.md]      | [/a 1.md]          | [/a 1.md]    |
+| `atom /a`                   | [/a]           | [/a]               | [/a]         |
+| `atom /b/3.md`              | [/a] [/b 3.md] | [/a] [ 3.md] :new: | [/a] [ 3.md] |
+| `atom /b`                   | [/a] [/b]      | [/a] [/b]          | [/a] [/b]    |
+| `atom --add /a/1.md`        | [/a 1.md]      | [/a 1.md]          | [/a 1.md]    |
+| `atom --add /a`             | [/a]           | [/a]               | [/a]         |
+| `atom --add /b/3.md`        | [/a,/b 3.md]   | [/a 3.md] :new:    | [/a 3.md]    |
+| `atom --add /b`             | [/a,/b]        | [/a,/b]            | [/a,/b]      |
+| `atom --new-window /a/1.md` | [/a] [/a 1.md] | [/a] [ 1.md] :new: | [/a] [ 1.md] |
+| `atom --new-window /a`      | [/a] [/a]      | [/a] [/a]          | [/a] [/a]    |
+| `atom --new-window /b/3.md` | [/a] [/b 3.md] | [/a] [ 3.md] :new: | [/a] [ 3.md] |
+| `atom --new-window /b`      | [/a] [/b]      | [/a] [/b]          | [/a] [/b]    |
 
 ### Open windows, one with a project root and one without
 
@@ -75,18 +77,18 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [/a 1.md] []      | [/a 1.md] []    | [/a 1.md] []    |
-| `atom /a`                   | [/a] []           | [/a] []         | [/a] []         |
-| `atom /b/3.md`              | [/a] [] [/b 3.md] | [/a] [] [ 3.md] | [/a] [ 3.md]    |
-| `atom /b`                   | [/a] [] [/b]      | [/a] [] [/b]    | [/a] [] [/b]    |
-| `atom --add /a/1.md`        | [/a 1.md] []      | [/a 1.md] []    | [/a 1.md] []    |
-| `atom --add /a`             | [/a] []           | [/a] []         | [/a] []         |
-| `atom --add /b/3.md`        | [/a] [/b 3.md]    | [/a] [ 3.md]    | [/a] [ 3.md]    |
-| `atom --add /b`             | [/a] [/b]         | [/a] [/b]       | [/a] [/b]       |
-| `atom --new-window /a/1.md` | [/a] [] [/a 1.md] | [/a] [] [ 1.md] | [/a] [] [1.md]  |
-| `atom --new-window /a`      | [/a] [] [/a]      | [/a] [] [/a]    | [/a] [] [/a]    |
-| `atom --new-window /b/3.md` | [/a] [] [/b 3.md] | [/a] [] [ 3.md] | [/a] [] [ 3.md] |
-| `atom --new-window /b`      | [/a] [] [/b]      | [/a] [] [/b]    | [/a] [] [/b]    |
+| `atom /a/1.md`              | [/a 1.md] []      | [/a 1.md] []          | [/a 1.md] []       |
+| `atom /a`                   | [/a] []           | [/a] []               | [/a] []            |
+| `atom /b/3.md`              | [/a] [] [/b 3.md] | [/a] [] [ 3.md] :new: | [/a] [ 3.md] :new: |
+| `atom /b`                   | [/a] [] [/b]      | [/a] [] [/b]          | [/a] [] [/b]       |
+| `atom --add /a/1.md`        | [/a 1.md] []      | [/a 1.md] []          | [/a 1.md] []       |
+| `atom --add /a`             | [/a] []           | [/a] []               | [/a] []            |
+| `atom --add /b/3.md`        | [/a] [/b 3.md]    | [/a] [ 3.md] :new:    | [/a] [ 3.md]       |
+| `atom --add /b`             | [/a] [/b]         | [/a] [/b]             | [/a] [/b]          |
+| `atom --new-window /a/1.md` | [/a] [] [/a 1.md] | [/a] [] [ 1.md] :new: | [/a] [] [1.md]     |
+| `atom --new-window /a`      | [/a] [] [/a]      | [/a] [] [/a]          | [/a] [] [/a]       |
+| `atom --new-window /b/3.md` | [/a] [] [/b 3.md] | [/a] [] [ 3.md] :new: | [/a] [] [ 3.md]    |
+| `atom --new-window /b`      | [/a] [] [/b]      | [/a] [] [/b]          | [/a] [] [/b]       |
 
 ## File manager integration actions
 
@@ -96,8 +98,8 @@ When no Atom windows are open, file manager context operations have the followin
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [/a 1.md] | [ 1.md] | [ 1.md] |
-| Click on `/a`      | [/a]      | [/a]    | [/a]    |
+| Click on `/a/1.md` | [/a 1.md] | [ 1.md] :new: | [ 1.md] |
+| Click on `/a`      | [/a]      | [/a]          | [/a]    |
 
 ### Open window, no project roots
 
@@ -107,8 +109,8 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [] [/a 1.md] | [] [ 1.md] | [ 1.md] |
-| Click on `/a`      | [] [/a]      | [] [/a]    | [] [/a] |
+| Click on `/a/1.md` | [] [/a 1.md] | [] [ 1.md] :new: | [ 1.md] :new: |
+| Click on `/a`      | [] [/a]      | [] [/a]          | [] [/a]       |
 
 ### Open window, project root
 
@@ -118,10 +120,10 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [/a 1.md]      | [/a 1.md]    | [/a 1.md]    |
-| Click on `/a`      | [/a]           | [/a]         | [/a]         |
-| Click on `/b/3.md` | [/a] [/b 3.md] | [/a] [ 3.md] | [/a] [ 3.md] |
-| Click on `/b`      | [/a] [/b]      | [/a] [/b]    | [/a] [/b]    |
+| Click on `/a/1.md` | [/a 1.md]      | [/a 1.md]          | [/a 1.md]    |
+| Click on `/a`      | [/a]           | [/a]               | [/a]         |
+| Click on `/b/3.md` | [/a] [/b 3.md] | [/a] [ 3.md] :new: | [/a] [ 3.md] |
+| Click on `/b`      | [/a] [/b]      | [/a] [/b]          | [/a] [/b]    |
 
 ### Open windows, one with a project root and one without
 
@@ -129,7 +131,7 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [/a 1.md] []      | [/a 1.md] []    | [/a 1.md] [] |
-| Click on `/a`      | [/a] []           | [/a] []         | [/a] []      |
-| Click on `/b/3.md` | [/a] [] [/b 3.md] | [/a] [] [ 3.md] | [/a] [ 3.md] |
-| Click on `/b`      | [/a] [] [/b]      | [/a] [] [/b]    | [/a] [] [/b] |
+| Click on `/a/1.md` | [/a 1.md] []      | [/a 1.md] []          | [/a 1.md] []       |
+| Click on `/a`      | [/a] []           | [/a] []               | [/a] []            |
+| Click on `/b/3.md` | [/a] [] [/b 3.md] | [/a] [] [ 3.md] :new: | [/a] [ 3.md] :new: |
+| Click on `/b`      | [/a] [] [/b]      | [/a] [] [/b]          | [/a] [] [/b]       |

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -20,7 +20,7 @@ For brevity, the scenarios below are described using the following notation:
 
 The order of window expressions indicates the order in which the windows were last focused.
 
-Changes in behavior from the immediately preceding version (the column to the immediate left) are marked with :new:
+Changes in behavior from <=1.35.1 to 1.36.0 are marked with :warning: - some of these are intentional desirable and others are not. Changes in behavior from <=1.35.1 to 1.36.1 are marked with :new: and should be our intentional, agreed-upon changes. _Unintentional_ changes from <=1.35.1 to 1.36.0 that we intend to revert back in 1.36.1 are marked with :bug:. Changes marked with both :new: and :bug: are scenarios in which we should differ from _both_ <=1.35.1 and 1.36.0.
 
 ## CLI actions
 
@@ -30,12 +30,12 @@ When no Atom windows are open, CLI actions have the following outcomes:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [/a 1.md] | [ 1.md] :warning: | [ 1.md] |
-| `atom /a`                   | [/a]      | [/a]              | [/a]    |
-| `atom --add /a/1.md`        | [/a 1.md] | [ 1.md] :warning: | [ 1.md] |
-| `atom --add /a`             | [/a]      | [/a]              | [/a]    |
-| `atom --new-window /a/1.md` | [/a 1.md] | [ 1.md] :warning: | [ 1.md] |
-| `atom --new-window /a`      | [/a]      | [/a]              | [/a]    |
+| `atom /a/1.md`              | [/a 1.md] | [ 1.md] :warning: | [ 1.md] :new: |
+| `atom /a`                   | [/a]      | [/a]              | [/a]          |
+| `atom --add /a/1.md`        | [/a 1.md] | [ 1.md] :warning: | [ 1.md] :new: |
+| `atom --add /a`             | [/a]      | [/a]              | [/a]          |
+| `atom --new-window /a/1.md` | [/a 1.md] | [ 1.md] :warning: | [ 1.md] :new: |
+| `atom --new-window /a`      | [/a]      | [/a]              | [/a]          |
 
 ### Open window, no project roots
 
@@ -45,12 +45,12 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [/a 1.md]    | [] [ 1.md] :warning: | [ 1.md]    |
-| `atom /a`                   | [/a]         | [] [/a] :warning:    | [/a]    |
-| `atom --add /a/1.md`        | [/a 1.md]    | [ 1.md] :warning:    | [ 1.md]    |
-| `atom --add /a`             | [/a]         | [/a]                 | [/a]       |
-| `atom --new-window /a/1.md` | [] [/a 1.md] | [] [ 1.md] :warning: | [] [ 1.md] |
-| `atom --new-window /a`      | [] [/a]      | [] [/a]              | [] [/a]    |
+| `atom /a/1.md`              | [/a 1.md]    | [] [ 1.md] :warning: | [ 1.md] :bug: :new: |
+| `atom /a`                   | [/a]         | [] [/a] :warning:    | [/a] :bug:          |
+| `atom --add /a/1.md`        | [/a 1.md]    | [ 1.md] :warning:    | [ 1.md] :new:       |
+| `atom --add /a`             | [/a]         | [/a]                 | [/a]                |
+| `atom --new-window /a/1.md` | [] [/a 1.md] | [] [ 1.md] :warning: | [] [ 1.md] :new:    |
+| `atom --new-window /a`      | [] [/a]      | [] [/a]              | [] [/a]             |
 
 ### Open window, project root
 
@@ -60,18 +60,18 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [/a 1.md]      | [/a 1.md]              | [/a 1.md]    |
-| `atom /a`                   | [/a]           | [/a]                   | [/a]         |
-| `atom /b/3.md`              | [/a 3.md]      | [/a] [ 3.md] :warning: | [/a] [ 3.md] |
-| `atom /b`                   | [/a] [/b]      | [/a] [/b]              | [/a] [/b]    |
-| `atom --add /a/1.md`        | [/a 1.md]      | [/a 1.md]              | [/a 1.md]    |
-| `atom --add /a`             | [/a]           | [/a]                   | [/a]         |
-| `atom --add /b/3.md`        | [/a,/b 3.md]   | [/a 3.md] :warning:    | [/a 3.md]    |
-| `atom --add /b`             | [/a,/b]        | [/a,/b]                | [/a,/b]      |
-| `atom --new-window /a/1.md` | [/a] [/a 1.md] | [/a] [ 1.md] :warning: | [/a] [ 1.md] |
-| `atom --new-window /a`      | [/a] [/a]      | [/a] [/a]              | [/a] [/a]    |
-| `atom --new-window /b/3.md` | [/a] [/b 3.md] | [/a] [ 3.md] :warning: | [/a] [ 3.md] |
-| `atom --new-window /b`      | [/a] [/b]      | [/a] [/b]              | [/a] [/b]    |
+| `atom /a/1.md`              | [/a 1.md]      | [/a 1.md]              | [/a 1.md]          |
+| `atom /a`                   | [/a]           | [/a]                   | [/a]               |
+| `atom /b/3.md`              | [/a 3.md]      | [/a] [ 3.md] :warning: | [/a 3.md] :bug:    |
+| `atom /b`                   | [/a] [/b]      | [/a] [/b]              | [/a] [/b]          |
+| `atom --add /a/1.md`        | [/a 1.md]      | [/a 1.md]              | [/a 1.md]          |
+| `atom --add /a`             | [/a]           | [/a]                   | [/a]               |
+| `atom --add /b/3.md`        | [/a,/b 3.md]   | [/a 3.md] :warning:    | [/a 3.md] :new:    |
+| `atom --add /b`             | [/a,/b]        | [/a,/b]                | [/a,/b]            |
+| `atom --new-window /a/1.md` | [/a] [/a 1.md] | [/a] [ 1.md] :warning: | [/a] [ 1.md] :new: |
+| `atom --new-window /a`      | [/a] [/a]      | [/a] [/a]              | [/a] [/a]          |
+| `atom --new-window /b/3.md` | [/a] [/b 3.md] | [/a] [ 3.md] :warning: | [/a] [ 3.md] :new: |
+| `atom --new-window /b`      | [/a] [/b]      | [/a] [/b]              | [/a] [/b]          |
 
 ### Open windows, one with a project root and one without
 
@@ -79,35 +79,35 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [/a 1.md] []      | [/a 1.md] []              | [/a 1.md] []       |
-| `atom /a`                   | [/a] []           | [/a] []                   | [/a] []            |
-| `atom /b/3.md`              | [/a] [/b 3.md]    | [/a] [] [ 3.md] :warning: | [/a] [ 3.md] :new: |
-| `atom /b`                   | [/a] [/b]         | [/a] [] [/b] :warning:    | [/a] [] [/b]       |
-| `atom --add /a/1.md`        | [/a 1.md] []      | [/a 1.md] []              | [/a 1.md] []       |
-| `atom --add /a`             | [/a] []           | [/a] []                   | [/a] []            |
-| `atom --add /b/3.md`        | [/a] [/b 3.md]    | [/a] [ 3.md] :warning:    | [/a] [ 3.md]       |
-| `atom --add /b`             | [/a] [/b]         | [/a] [/b]                 | [/a] [/b]          |
-| `atom --new-window /a/1.md` | [/a] [] [/a 1.md] | [/a] [] [ 1.md] :warning: | [/a] [] [1.md]     |
-| `atom --new-window /a`      | [/a] [] [/a]      | [/a] [] [/a]              | [/a] [] [/a]       |
-| `atom --new-window /b/3.md` | [/a] [] [/b 3.md] | [/a] [] [ 3.md] :warning: | [/a] [] [ 3.md]    |
-| `atom --new-window /b`      | [/a] [] [/b]      | [/a] [] [/b]              | [/a] [] [/b]       |
+| `atom /a/1.md`              | [/a 1.md] []      | [/a 1.md] []              | [/a 1.md] []             |
+| `atom /a`                   | [/a] []           | [/a] []                   | [/a] []                  |
+| `atom /b/3.md`              | [/a] [/b 3.md]    | [/a] [] [ 3.md] :warning: | [/a] [ 3.md] :bug: :new: |
+| `atom /b`                   | [/a] [/b]         | [/a] [] [/b] :warning:    | [/a] [/b] :bug:          |
+| `atom --add /a/1.md`        | [/a 1.md] []      | [/a 1.md] []              | [/a 1.md] []             |
+| `atom --add /a`             | [/a] []           | [/a] []                   | [/a] []                  |
+| `atom --add /b/3.md`        | [/a] [/b 3.md]    | [/a] [ 3.md] :warning:    | [/a] [ 3.md] :new:       |
+| `atom --add /b`             | [/a] [/b]         | [/a] [/b]                 | [/a] [/b]                |
+| `atom --new-window /a/1.md` | [/a] [] [/a 1.md] | [/a] [] [ 1.md] :warning: | [/a] [] [ 1.md] :new:    |
+| `atom --new-window /a`      | [/a] [] [/a]      | [/a] [] [/a]              | [/a] [] [/a]             |
+| `atom --new-window /b/3.md` | [/a] [] [/b 3.md] | [/a] [] [ 3.md] :warning: | [/a] [] [ 3.md] :new:    |
+| `atom --new-window /b`      | [/a] [] [/b]      | [/a] [] [/b]              | [/a] [] [/b]             |
 
 > [] [/a]
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [] [/a 1.md]      | [] [/a 1.md] | |
-| `atom /a`                   | [] [/a]           | [] [/a] | |
-| `atom /b/3.md`              | [] [/a 3.md]      | [] [/a] [ 3.md] :warning: | |
-| `atom /b`                   | [] [/a] [/b]      | [] [/a] [/b] | |
-| `atom --add /a/1.md`        | [] [/a 1.md]      | [] [/a 1.md] | |
-| `atom --add /a`             | [] [/a]           | [] [/a] | |
-| `atom --add /b/3.md`        | [] [/a,/b 3.md]   | [] [/a 3.md] :warning: | |
-| `atom --add /b`             | [] [/a,/b]        | [] [/a,/b] | |
-| `atom --new-window /a/1.md` | [] [/a] [/a 1.md] | [] [/a] [ 1.md] :warning: | |
-| `atom --new-window /a`      | [] [/a] [/a]      | [] [/a] [/a] | |
-| `atom --new-window /b/3.md` | [] [/a] [/b 3.md] | [] [/a] [ 3.md] :warning: | |
-| `atom --new-window /b`      | [] [/a] [/b]      | [] [/a] [/b] | |
+| `atom /a/1.md`              | [] [/a 1.md]      | [] [/a 1.md]              | [] [/a 1.md]          |
+| `atom /a`                   | [] [/a]           | [] [/a]                   | [] [/a]               |
+| `atom /b/3.md`              | [] [/a 3.md]      | [] [/a] [ 3.md] :warning: | [] [/a 3.md] :bug:    |
+| `atom /b`                   | [] [/a] [/b]      | [] [/a] [/b]              | [/b] [/a] :bug: :new: |
+| `atom --add /a/1.md`        | [] [/a 1.md]      | [] [/a 1.md]              | [] [/a 1.md]          |
+| `atom --add /a`             | [] [/a]           | [] [/a]                   | [] [/a]               |
+| `atom --add /b/3.md`        | [] [/a,/b 3.md]   | [] [/a 3.md] :warning:    | [] [/a 3.md] :new:    |
+| `atom --add /b`             | [] [/a,/b]        | [] [/a,/b]                | [] [/a,/b]            |
+| `atom --new-window /a/1.md` | [] [/a] [/a 1.md] | [] [/a] [ 1.md] :warning: | [] [/a] [ 1.md] :new: |
+| `atom --new-window /a`      | [] [/a] [/a]      | [] [/a] [/a]              | [] [/a] [/a]          |
+| `atom --new-window /b/3.md` | [] [/a] [/b 3.md] | [] [/a] [ 3.md] :warning: | [] [/a] [ 3.md] :new: |
+| `atom --new-window /b`      | [] [/a] [/b]      | [] [/a] [/b]              | [] [/a] [/b]          |
 
 ## File manager integration actions
 
@@ -117,8 +117,8 @@ When no Atom windows are open, file manager context operations have the followin
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [/a 1.md] | [ 1.md] :warning: | [ 1.md] |
-| Click on `/a`      | [/a]      | [/a]              | [/a]    |
+| Click on `/a/1.md` | [/a 1.md] | [ 1.md] :warning: | [ 1.md] :new: |
+| Click on `/a`      | [/a]      | [/a]              | [/a]          |
 
 ### Open window, no project roots
 
@@ -128,8 +128,8 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [/a 1.md] | [] [ 1.md] :warning: | [ 1.md] :new: |
-| Click on `/a`      | [/a]      | [] [/a] :warning:    | [/a]       |
+| Click on `/a/1.md` | [/a 1.md] | [] [ 1.md] :warning: | [ 1.md] :bug: :new: |
+| Click on `/a`      | [/a]      | [] [/a] :warning:    | [/a] :bug: :new:    |
 
 ### Open window, project root
 
@@ -139,10 +139,10 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [/a 1.md]      | [/a 1.md]              | [/a 1.md]    |
-| Click on `/a`      | [/a]           | [/a]                   | [/a]         |
-| Click on `/b/3.md` | [/a 3.md]      | [/a] [ 3.md] :warning: | [/a 3.md] |
-| Click on `/b`      | [/a] [/b]      | [/a] [/b]              | [/a] [/b]    |
+| Click on `/a/1.md` | [/a 1.md]      | [/a 1.md]              | [/a 1.md]       |
+| Click on `/a`      | [/a]           | [/a]                   | [/a]            |
+| Click on `/b/3.md` | [/a 3.md]      | [/a] [ 3.md] :warning: | [/a 3.md] :bug: |
+| Click on `/b`      | [/a] [/b]      | [/a] [/b]              | [/a] [/b]       |
 
 ### Open windows, one with a project root and one without
 
@@ -150,16 +150,16 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [/a 1.md] []      | [/a 1.md] []              | [/a 1.md] []       |
-| Click on `/a`      | [/a] []           | [/a] []                   | [/a] []            |
-| Click on `/b/3.md` | [/a] [/b 3.md]    | [/a] [] [ 3.md] :warning: | [/a] [ 3.md] :new: |
-| Click on `/b`      | [/a] [] [/b]      | [/a] [] [/b]              | [/a] [] [/b]       |
+| Click on `/a/1.md` | [/a 1.md] []      | [/a 1.md] []              | [/a 1.md] []             |
+| Click on `/a`      | [/a] []           | [/a] []                   | [/a] []                  |
+| Click on `/b/3.md` | [/a] [/b 3.md]    | [/a] [] [ 3.md] :warning: | [/a] [ 3.md] :bug: :new: |
+| Click on `/b`      | [/a] [] [/b]      | [/a] [] [/b]              | [/a] [/b] :bug: :new:    |
 
 > [] [/a]
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| Click on `/a/1.md` | [] [/a 1.md] | [] [/a 1.md]              | |
-| Click on `/a`      | [] [/a]      | [] [/a]                   | |
-| Click on `/b/3.md` | [] [/a 3.md] | [] [/a] [ 3.md] :warning: | |
-| Click on `/b`      | [] [/a] [/b] | [] [/a] [/b]              | |
+| Click on `/a/1.md` | [] [/a 1.md] | [] [/a 1.md]              | [] [/a 1.md]             |
+| Click on `/a`      | [] [/a]      | [] [/a]                   | [] [/a]                  |
+| Click on `/b/3.md` | [] [/a 3.md] | [] [/a] [ 3.md] :warning: | [ 3.md] [/a] :bug: :new: |
+| Click on `/b`      | [] [/a] [/b] | [] [/a] [/b]              | [/b] [/a] :bug: :new:    |

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -92,10 +92,12 @@ With the following starting state:
 
 ### No open windows
 
-When no Atom windows are open, CLI actions have the following outcomes:
+When no Atom windows are open, file manager context operations have the following outcomes:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
+| Click on `/a/1.md` | [/a 1.md] | [ 1.md] | [ 1.md] |
+| Click on `/a`      | [/a]      | [/a]    | [/a]    |
 
 ### Open window, no project roots
 
@@ -105,6 +107,8 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
+| Click on `/a/1.md` | [] [/a 1.md] | [] [ 1.md] | [ 1.md] |
+| Click on `/a`      | [] [/a]      | [] [/a]    | [] [/a] |
 
 ### Open window, project root
 
@@ -114,6 +118,10 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
+| Click on `/a/1.md` | [/a 1.md]      | [/a 1.md]    | [/a 1.md]    |
+| Click on `/a`      | [/a]           | [/a]         | [/a]         |
+| Click on `/b/3.md` | [/a] [/b 3.md] | [/a] [ 3.md] | [/a] [ 3.md] |
+| Click on `/b`      | [/a] [/b]      | [/a] [/b]    | [/a] [/b]    |
 
 ### Open windows, one with a project root and one without
 
@@ -121,3 +129,7 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
+| Click on `/a/1.md` | [/a 1.md] []      | [/a 1.md] []    | [/a 1.md] [] |
+| Click on `/a`      | [/a] []           | [/a] []         | [/a] []      |
+| Click on `/b/3.md` | [/a] [] [/b 3.md] | [/a] [] [ 3.md] | [/a] [ 3.md] |
+| Click on `/b`      | [/a] [] [/b]      | [/a] [] [/b]    | [/a] [] [/b] |

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -96,18 +96,18 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [] [/a 1.md]      | | |
-| `atom /a`                   | [] [/a]           | | |
-| `atom /b/3.md`              | [] [/a 3.md]      | | |
-| `atom /b`                   | [] [/a] [/b]      | | |
-| `atom --add /a/1.md`        | [] [/a 1.md]      | | |
-| `atom --add /a`             | [] [/a]           | | |
-| `atom --add /b/3.md`        | [] [/a,/b 3.md]   | | |
-| `atom --add /b`             | [] [/a,/b]        | | |
-| `atom --new-window /a/1.md` | [] [/a] [/a 1.md] | | |
-| `atom --new-window /a`      | [] [/a] [/a]      | | |
-| `atom --new-window /b/3.md` | [] [/a] [/b 3.md] | | |
-| `atom --new-window /b`      | [] [/b] [/b]      | | |
+| `atom /a/1.md`              | [] [/a 1.md]      | [] [/a 1.md] | |
+| `atom /a`                   | [] [/a]           | [] [/a] | |
+| `atom /b/3.md`              | [] [/a 3.md]      | [] [/a] [ 3.md] :warning: | |
+| `atom /b`                   | [] [/a] [/b]      | [] [/a] [/b] | |
+| `atom --add /a/1.md`        | [] [/a 1.md]      | [] [/a 1.md] | |
+| `atom --add /a`             | [] [/a]           | [] [/a] | |
+| `atom --add /b/3.md`        | [] [/a,/b 3.md]   | [] [/a 3.md] :warning: | |
+| `atom --add /b`             | [] [/a,/b]        | [] [/a,/b] | |
+| `atom --new-window /a/1.md` | [] [/a] [/a 1.md] | [] [/a] [ 1.md] :warning: | |
+| `atom --new-window /a`      | [] [/a] [/a]      | [] [/a] [/a] | |
+| `atom --new-window /b/3.md` | [] [/a] [/b 3.md] | [] [/a] [ 3.md] :warning: | |
+| `atom --new-window /b`      | [] [/a] [/b]      | [] [/a] [/b] | |
 
 ## File manager integration actions
 

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -153,7 +153,7 @@ With the following starting state:
 | Click on `/a/1.md` | [/a 1.md] []      | [/a 1.md] []              | [/a 1.md] []             |
 | Click on `/a`      | [/a] []           | [/a] []                   | [/a] []                  |
 | Click on `/b/3.md` | [/a] [/b 3.md]    | [/a] [] [ 3.md] :warning: | [/a] [ 3.md] :bug: :new: |
-| Click on `/b`      | [/a] [] [/b]      | [/a] [] [/b]              | [/a] [/b] :bug: :new:    |
+| Click on `/b`      | [/a] [/b]         | [/a] [] [/b] :warning:    | [/a] [/b] :bug:          |
 
 > [] [/a]
 

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -30,12 +30,12 @@ When no Atom windows are open, CLI actions have the following outcomes:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [/a 1.md] | [ 1.md] :new: | [ 1.md] |
-| `atom /a`                   | [/a]      | [/a]          | [/a]    |
-| `atom --add /a/1.md`        | [/a 1.md] | [ 1.md] :new: | [ 1.md] |
-| `atom --add /a`             | [/a]      | [/a]          | [/a]    |
-| `atom --new-window /a/1.md` | [/a 1.md] | [ 1.md] :new: | [ 1.md] |
-| `atom --new-window /a`      | [/a]      | [/a]          | [/a]    |
+| `atom /a/1.md`              | [/a 1.md] | [ 1.md] :warning: | [ 1.md] |
+| `atom /a`                   | [/a]      | [/a]              | [/a]    |
+| `atom --add /a/1.md`        | [/a 1.md] | [ 1.md] :warning: | [ 1.md] |
+| `atom --add /a`             | [/a]      | [/a]              | [/a]    |
+| `atom --new-window /a/1.md` | [/a 1.md] | [ 1.md] :warning: | [ 1.md] |
+| `atom --new-window /a`      | [/a]      | [/a]              | [/a]    |
 
 ### Open window, no project roots
 
@@ -45,12 +45,12 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [/a 1.md] | [] [ 1.md] :new: | [ 1.md] :new:|
-| `atom /a`                   | [/a]      | [] [/a]          | [] [/a]      |
-| `atom --add /a/1.md`        | [/a 1.md]    | [ 1.md] :new:    | [ 1.md]      |
-| `atom --add /a`             | [/a]         | [/a]             | [/a]         |
-| `atom --new-window /a/1.md` | [] [/a 1.md] | [] [ 1.md] :new: | [] [ 1.md]   |
-| `atom --new-window /a`      | [] [/a]      | [] [/a]          | [] [/a]      |
+| `atom /a/1.md`              | [/a 1.md]    | [] [ 1.md] :warning: | [ 1.md]    |
+| `atom /a`                   | [/a]         | [] [/a] :warning:    | [] [/a]    |
+| `atom --add /a/1.md`        | [/a 1.md]    | [ 1.md] :warning:    | [ 1.md]    |
+| `atom --add /a`             | [/a]         | [/a]                 | [/a]       |
+| `atom --new-window /a/1.md` | [] [/a 1.md] | [] [ 1.md] :warning: | [] [ 1.md] |
+| `atom --new-window /a`      | [] [/a]      | [] [/a]              | [] [/a]    |
 
 ### Open window, project root
 

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -60,18 +60,18 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [/a 1.md]      | [/a 1.md]          | [/a 1.md]    |
-| `atom /a`                   | [/a]           | [/a]               | [/a]         |
-| `atom /b/3.md`              | [/a 3.md] | [/a] [ 3.md] :new: | [/a] [ 3.md] |
-| `atom /b`                   | [/a] [/b]      | [/a] [/b]          | [/a] [/b]    |
-| `atom --add /a/1.md`        | [/a 1.md]      | [/a 1.md]          | [/a 1.md]    |
-| `atom --add /a`             | [/a]           | [/a]               | [/a]         |
-| `atom --add /b/3.md`        | [/a,/b 3.md]   | [/a 3.md] :new:    | [/a 3.md]    |
-| `atom --add /b`             | [/a,/b]        | [/a,/b]            | [/a,/b]      |
-| `atom --new-window /a/1.md` | [/a] [/a 1.md] | [/a] [ 1.md] :new: | [/a] [ 1.md] |
-| `atom --new-window /a`      | [/a] [/a]      | [/a] [/a]          | [/a] [/a]    |
-| `atom --new-window /b/3.md` | [/a] [/b 3.md] | [/a] [ 3.md] :new: | [/a] [ 3.md] |
-| `atom --new-window /b`      | [/a] [/b]      | [/a] [/b]          | [/a] [/b]    |
+| `atom /a/1.md`              | [/a 1.md]      | [/a 1.md]              | [/a 1.md]    |
+| `atom /a`                   | [/a]           | [/a]                   | [/a]         |
+| `atom /b/3.md`              | [/a 3.md]      | [/a] [ 3.md] :warning: | [/a] [ 3.md] |
+| `atom /b`                   | [/a] [/b]      | [/a] [/b]              | [/a] [/b]    |
+| `atom --add /a/1.md`        | [/a 1.md]      | [/a 1.md]              | [/a 1.md]    |
+| `atom --add /a`             | [/a]           | [/a]                   | [/a]         |
+| `atom --add /b/3.md`        | [/a,/b 3.md]   | [/a 3.md] :warning:    | [/a 3.md]    |
+| `atom --add /b`             | [/a,/b]        | [/a,/b]                | [/a,/b]      |
+| `atom --new-window /a/1.md` | [/a] [/a 1.md] | [/a] [ 1.md] :warning: | [/a] [ 1.md] |
+| `atom --new-window /a`      | [/a] [/a]      | [/a] [/a]              | [/a] [/a]    |
+| `atom --new-window /b/3.md` | [/a] [/b 3.md] | [/a] [ 3.md] :warning: | [/a] [ 3.md] |
+| `atom --new-window /b`      | [/a] [/b]      | [/a] [/b]              | [/a] [/b]    |
 
 ### Open windows, one with a project root and one without
 

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -18,6 +18,8 @@ For brevity, the scenarios below are described using the following notation:
 | [ 3.md] | single Atom window with no project roots and one open editor `/b/3.md` |
 | [/a 1.md] [/b 3.md] | two Atom windows:<br/>the first-opened has one project root (`/a`) and one open editor `/a/1.md`<br/>the second-opened has one project root (`/b`) and one open editor `/b/3.md`. |
 
+The order of window expressions indicates the order in which the windows were last focused.
+
 Changes in behavior from the immediately preceding version (the column to the immediate left) are marked with :new:
 
 ## CLI actions
@@ -90,6 +92,23 @@ With the following starting state:
 | `atom --new-window /b/3.md` | [/a] [] [/b 3.md] | [/a] [] [ 3.md] :new: | [/a] [] [ 3.md]    |
 | `atom --new-window /b`      | [/a] [] [/b]      | [/a] [] [/b]          | [/a] [] [/b]       |
 
+> [] [/a]
+
+| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
+| --- | --- | --- | --- |
+| `atom /a/1.md`              | [] [/a 1.md]      | | |
+| `atom /a`                   | [] [/a]           | | |
+| `atom /b/3.md`              | [] [/a 3.md]      | | |
+| `atom /b`                   | [] [/a] [/b]      | | |
+| `atom --add /a/1.md`        | [] [/a 1.md]      | | |
+| `atom --add /a`             | [] [/a]           | | |
+| `atom --add /b/3.md`        | [] [/a,/b 3.md]   | | |
+| `atom --add /b`             | [] [/a,/b]        | | |
+| `atom --new-window /a/1.md` | [] [/a] [/a 1.md] | | |
+| `atom --new-window /a`      | [] [/a] [/a]      | | |
+| `atom --new-window /b/3.md` | [] [/a] [/b 3.md] | | |
+| `atom --new-window /b`      | [] [/b] [/b]      | | |
+
 ## File manager integration actions
 
 ### No open windows
@@ -135,3 +154,12 @@ With the following starting state:
 | Click on `/a`      | [/a] []           | [/a] []               | [/a] []            |
 | Click on `/b/3.md` | [/a] [/b 3.md]    | [/a] [] [ 3.md] :new: | [/a] [ 3.md] :new: |
 | Click on `/b`      | [/a] [] [/b]      | [/a] [] [/b]          | [/a] [] [/b]       |
+
+> [] [/a]
+
+| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
+| --- | --- | --- | --- |
+| Click on `/a/1.md` | [] [/a 1.md] | | |
+| Click on `/a`      | [] [/a]      | | |
+| Click on `/b/3.md` | [] [/a 3.md] | | |
+| Click on `/b`      | [] [/a] [/b] | | |

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -96,18 +96,18 @@ With the following starting state:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
-| `atom /a/1.md`              | [] [/a 1.md]      | [] [/a 1.md]              | [] [/a 1.md]          |
-| `atom /a`                   | [] [/a]           | [] [/a]                   | [] [/a]               |
-| `atom /b/3.md`              | [] [/a 3.md]      | [] [/a] [ 3.md] :warning: | [] [/a 3.md] :bug:    |
-| `atom /b`                   | [] [/a] [/b]      | [] [/a] [/b]              | [/b] [/a] :bug: :new: |
-| `atom --add /a/1.md`        | [] [/a 1.md]      | [] [/a 1.md]              | [] [/a 1.md]          |
-| `atom --add /a`             | [] [/a]           | [] [/a]                   | [] [/a]               |
-| `atom --add /b/3.md`        | [] [/a,/b 3.md]   | [] [/a 3.md] :warning:    | [] [/a 3.md] :new:    |
-| `atom --add /b`             | [] [/a,/b]        | [] [/a,/b]                | [] [/a,/b]            |
-| `atom --new-window /a/1.md` | [] [/a] [/a 1.md] | [] [/a] [ 1.md] :warning: | [] [/a] [ 1.md] :new: |
-| `atom --new-window /a`      | [] [/a] [/a]      | [] [/a] [/a]              | [] [/a] [/a]          |
-| `atom --new-window /b/3.md` | [] [/a] [/b 3.md] | [] [/a] [ 3.md] :warning: | [] [/a] [ 3.md] :new: |
-| `atom --new-window /b`      | [] [/a] [/b]      | [] [/a] [/b]              | [] [/a] [/b]          |
+| `atom /a/1.md`              | [] [/a 1.md]      | [] [/a 1.md]              | [] [/a 1.md]             |
+| `atom /a`                   | [] [/a]           | [] [/a]                   | [] [/a]                  |
+| `atom /b/3.md`              | [] [/a 3.md]      | [] [/a] [ 3.md] :warning: | [ 3.md] [/a] :bug: :new: |
+| `atom /b`                   | [] [/a] [/b]      | [] [/a] [/b]              | [/b] [/a] :bug: :new:    |
+| `atom --add /a/1.md`        | [] [/a 1.md]      | [] [/a 1.md]              | [] [/a 1.md]             |
+| `atom --add /a`             | [] [/a]           | [] [/a]                   | [] [/a]                  |
+| `atom --add /b/3.md`        | [] [/a,/b 3.md]   | [] [/a 3.md] :warning:    | [] [/a 3.md] :new:       |
+| `atom --add /b`             | [] [/a,/b]        | [] [/a,/b]                | [] [/a,/b]               |
+| `atom --new-window /a/1.md` | [] [/a] [/a 1.md] | [] [/a] [ 1.md] :warning: | [] [/a] [ 1.md] :new:    |
+| `atom --new-window /a`      | [] [/a] [/a]      | [] [/a] [/a]              | [] [/a] [/a]             |
+| `atom --new-window /b/3.md` | [] [/a] [/b 3.md] | [] [/a] [ 3.md] :warning: | [] [/a] [ 3.md] :new:    |
+| `atom --new-window /b`      | [] [/a] [/b]      | [] [/a] [/b]              | [] [/a] [/b]             |
 
 ## File manager integration actions
 

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -79,8 +79,8 @@ With the following starting state:
 | --- | --- | --- | --- |
 | `atom /a/1.md`              | [/a 1.md] []      | [/a 1.md] []          | [/a 1.md] []       |
 | `atom /a`                   | [/a] []           | [/a] []               | [/a] []            |
-| `atom /b/3.md`              | [/a] [] [/b 3.md] | [/a] [] [ 3.md] :new: | [/a] [ 3.md] :new: |
-| `atom /b`                   | [/a] [] [/b]      | [/a] [] [/b]          | [/a] [] [/b]       |
+| `atom /b/3.md`              | [/a] [/b 3.md]    | [/a] [] [ 3.md] :new: | [/a] [ 3.md] :new: |
+| `atom /b`                   | [/a] [/b]         | [/a] [] [/b]          | [/a] [] [/b]       |
 | `atom --add /a/1.md`        | [/a 1.md] []      | [/a 1.md] []          | [/a 1.md] []       |
 | `atom --add /a`             | [/a] []           | [/a] []               | [/a] []            |
 | `atom --add /b/3.md`        | [/a] [/b 3.md]    | [/a] [ 3.md] :new:    | [/a] [ 3.md]       |
@@ -122,7 +122,7 @@ With the following starting state:
 | --- | --- | --- | --- |
 | Click on `/a/1.md` | [/a 1.md]      | [/a 1.md]          | [/a 1.md]    |
 | Click on `/a`      | [/a]           | [/a]               | [/a]         |
-| Click on `/b/3.md` | [/a 3.md] | [/a] [ 3.md] :new: | [/a] [ 3.md] |
+| Click on `/b/3.md` | [/a 3.md]      | [/a] [ 3.md] :new: | [/a] [ 3.md] |
 | Click on `/b`      | [/a] [/b]      | [/a] [/b]          | [/a] [/b]    |
 
 ### Open windows, one with a project root and one without
@@ -133,5 +133,5 @@ With the following starting state:
 | --- | --- | --- | --- |
 | Click on `/a/1.md` | [/a 1.md] []      | [/a 1.md] []          | [/a 1.md] []       |
 | Click on `/a`      | [/a] []           | [/a] []               | [/a] []            |
-| Click on `/b/3.md` | [/a] [] [/b 3.md] | [/a] [] [ 3.md] :new: | [/a] [ 3.md] :new: |
+| Click on `/b/3.md` | [/a] [/b 3.md]    | [/a] [] [ 3.md] :new: | [/a] [ 3.md] :new: |
 | Click on `/b`      | [/a] [] [/b]      | [/a] [] [/b]          | [/a] [] [/b]       |

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -129,7 +129,7 @@ With the following starting state:
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
 | --- | --- | --- | --- |
 | Click on `/a/1.md` | [/a 1.md] | [] [ 1.md] :new: | [ 1.md] :new: |
-| Click on `/a`      | [/a]      | [] [/a]          | [] [/a]       |
+| Click on `/a`      | [/a]      | [] [/a]          | [/a]       |
 
 ### Open window, project root
 
@@ -141,7 +141,7 @@ With the following starting state:
 | --- | --- | --- | --- |
 | Click on `/a/1.md` | [/a 1.md]      | [/a 1.md]          | [/a 1.md]    |
 | Click on `/a`      | [/a]           | [/a]               | [/a]         |
-| Click on `/b/3.md` | [/a 3.md]      | [/a] [ 3.md] :new: | [/a] [ 3.md] |
+| Click on `/b/3.md` | [/a 3.md]      | [/a] [ 3.md] :new: | [/a 3.md] |
 | Click on `/b`      | [/a] [/b]      | [/a] [/b]          | [/a] [/b]    |
 
 ### Open windows, one with a project root and one without

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -1,0 +1,123 @@
+# Atom launch behavior
+
+All examples use the following directory structure:
+
+```
+/a/1.md
+/a/2.md
+/b/3.md
+```
+
+For brevity, the scenarios below are described using the following notation:
+
+| Notation | Meaning |
+| -- | -- |
+| [] | single Atom window with no project roots or open editors |
+| [/a,/b] | single Atom window with two project roots (`/a` and `/b`) and no open editors |
+| [/a 1.md,2.md] | single Atom window with one project root (`/a`) and two open editors `/a/1.md` and `/a/2.md` |
+| [ 3.md] | single Atom window with no project roots and one open editor `/b/3.md` |
+| [/a 1.md] [/b 3.md] | two Atom windows:<br/>the first-opened has one project root (`/a`) and one open editor `/a/1.md`<br/>the second-opened has one project root (`/b`) and one open editor `/b/3.md`. |
+
+## CLI actions
+
+### No open windows
+
+When no Atom windows are open, CLI actions have the following outcomes:
+
+| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
+| --- | --- | --- |
+| `atom /a/1.md`              | [/a 1.md] | [ 1.md] | [ 1.md] |
+| `atom /a`                   | [/a]      | [/a]    | [/a]    |
+| `atom --add /a/1.md`        | [/a 1.md] | [ 1.md] | [ 1.md] |
+| `atom --add /a`             | [/a]      | [/a]    | [/a]    |
+| `atom --new-window /a/1.md` | [/a 1.md] | [ 1.md] | [ 1.md] |
+| `atom --new-window /a`      | [/a]      | [/a]    | [/a]    |
+
+### Open window, no project roots
+
+With the following starting state:
+
+> []
+
+| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
+| --- | --- | --- |
+| `atom /a/1.md`              | [] [/a 1.md] | [] [ 1.md] | [ 1.md]    |
+| `atom /a`                   | [] [/a]      | [] [/a]    | [] [/a]    |
+| `atom --add /a/1.md`        | [/a 1.md]    | [ 1.md]    | [ 1.md]    |
+| `atom --add /a`             | [/a]         | [/a]       | [/a]       |
+| `atom --new-window /a/1.md` | [] [/a 1.md] | [] [ 1.md] | [] [ 1.md] |
+| `atom --new-window /a`      | [] [/a]      | [] [/a]    | [] [/a]    |
+
+### Open window, project root
+
+With the following starting state:
+
+> [/a]
+
+| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
+| --- | --- | --- |
+| `atom /a/1.md`              | [/a 1.md]      | [/a 1.md]    | [/a 1.md]    |
+| `atom /a`                   | [/a]           | [/a]         | [/a]         |
+| `atom /b/3.md`              | [/a] [/b 3.md] | [/a] [ 3.md] | [/a] [ 3.md] |
+| `atom /b`                   | [/a] [/b]      | [/a] [/b]    | [/a] [/b]    |
+| `atom --add /a/1.md`        | [/a 1.md]      | [/a 1.md]    | [/a 1.md]    |
+| `atom --add /a`             | [/a]           | [/a]         | [/a]         |
+| `atom --add /b/3.md`        | [/a,/b 3.md]   | [/a 3.md]    | [/a 3.md]    |
+| `atom --add /b`             | [/a,/b]        | [/a,/b]      | [/a,/b]      |
+| `atom --new-window /a/1.md` | [/a] [/a 1.md] | [/a] [ 1.md] | [/a] [ 1.md] |
+| `atom --new-window /a`      | [/a] [/a]      | [/a] [/a]    | [/a] [/a]    |
+| `atom --new-window /b/3.md` | [/a] [/b 3.md] | [/a] [ 3.md] | [/a] [ 3.md] |
+| `atom --new-window /b`      | [/a] [/b]      | [/a] [/b]    | [/a] [/b]    |
+
+### Open windows, one with a project root and one without
+
+> [/a] []
+
+| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
+| --- | --- | --- |
+| `atom /a/1.md`              | [/a 1.md] []      | [/a 1.md] []    | [/a 1.md] []    |
+| `atom /a`                   | [/a] []           | [/a] []         | [/a] []         |
+| `atom /b/3.md`              | [/a] [] [/b 3.md] | [/a] [] [ 3.md] | [/a] [ 3.md]    |
+| `atom /b`                   | [/a] [] [/b]      | [/a] [] [/b]    | [/a] [] [/b]    |
+| `atom --add /a/1.md`        | [/a 1.md] []      | [/a 1.md] []    | [/a 1.md] []    |
+| `atom --add /a`             | [/a] []           | [/a] []         | [/a] []         |
+| `atom --add /b/3.md`        | [/a] [/b 3.md]    | [/a] [ 3.md]    | [/a] [ 3.md]    |
+| `atom --add /b`             | [/a] [/b]         | [/a] [/b]       | [/a] [/b]       |
+| `atom --new-window /a/1.md` | [/a] [] [/a 1.md] | [/a] [] [ 1.md] | [/a] [] [1.md]  |
+| `atom --new-window /a`      | [/a] [] [/a]      | [/a] [] [/a]    | [/a] [] [/a]    |
+| `atom --new-window /b/3.md` | [/a] [] [/b 3.md] | [/a] [] [ 3.md] | [/a] [] [ 3.md] |
+| `atom --new-window /b`      | [/a] [] [/b]      | [/a] [] [/b]    | [/a] [] [/b]    |
+
+## File manager integration actions
+
+### No open windows
+
+When no Atom windows are open, CLI actions have the following outcomes:
+
+| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
+| --- | --- | --- |
+
+### Open window, no project roots
+
+With the following starting state:
+
+> []
+
+| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
+| --- | --- | --- |
+
+### Open window, project root
+
+With the following starting state:
+
+> [/a]
+
+| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
+| --- | --- | --- |
+
+### Open windows, one with a project root and one without
+
+> [/a] []
+
+| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
+| --- | --- | --- |

--- a/docs/launch-behavior.md
+++ b/docs/launch-behavior.md
@@ -25,7 +25,7 @@ For brevity, the scenarios below are described using the following notation:
 When no Atom windows are open, CLI actions have the following outcomes:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `atom /a/1.md`              | [/a 1.md] | [ 1.md] | [ 1.md] |
 | `atom /a`                   | [/a]      | [/a]    | [/a]    |
 | `atom --add /a/1.md`        | [/a 1.md] | [ 1.md] | [ 1.md] |
@@ -40,7 +40,7 @@ With the following starting state:
 > []
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `atom /a/1.md`              | [] [/a 1.md] | [] [ 1.md] | [ 1.md]    |
 | `atom /a`                   | [] [/a]      | [] [/a]    | [] [/a]    |
 | `atom --add /a/1.md`        | [/a 1.md]    | [ 1.md]    | [ 1.md]    |
@@ -55,7 +55,7 @@ With the following starting state:
 > [/a]
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `atom /a/1.md`              | [/a 1.md]      | [/a 1.md]    | [/a 1.md]    |
 | `atom /a`                   | [/a]           | [/a]         | [/a]         |
 | `atom /b/3.md`              | [/a] [/b 3.md] | [/a] [ 3.md] | [/a] [ 3.md] |
@@ -74,7 +74,7 @@ With the following starting state:
 > [/a] []
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | `atom /a/1.md`              | [/a 1.md] []      | [/a 1.md] []    | [/a 1.md] []    |
 | `atom /a`                   | [/a] []           | [/a] []         | [/a] []         |
 | `atom /b/3.md`              | [/a] [] [/b 3.md] | [/a] [] [ 3.md] | [/a] [ 3.md]    |
@@ -95,7 +95,7 @@ With the following starting state:
 When no Atom windows are open, CLI actions have the following outcomes:
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 
 ### Open window, no project roots
 
@@ -104,7 +104,7 @@ With the following starting state:
 > []
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 
 ### Open window, project root
 
@@ -113,11 +113,11 @@ With the following starting state:
 > [/a]
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 
 ### Open windows, one with a project root and one without
 
 > [/a] []
 
 | Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
-| --- | --- | --- |
+| --- | --- | --- | --- |


### PR DESCRIPTION
### Requirements for Contributing Documentation

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.

### Description of the Change

Exhaustively document Atom launch scenarios and behavior across versions 1.35.1, 1.36.0, and speculative behavior for a hypothetical 1.36.1.

See the discussion in #19147 for additional feedback and discussion.

### TODO

- [x] Describe common scenarios when launching from the command line or via file manager
- [x] Split `[/a] []` sections to cover order-dependent launch behavior
- [ ] Describe the zero-argument scenarios (i.e., launch from CLI as `atom` or by clicking on dock/start menu)
- [ ] Describe how the `core.restorePreviousWindowsOnStart` setting affects these scenarios

### Release Notes

_N/A_


-----
[View rendered docs/launch-behavior.md](https://github.com/atom/atom/blob/aw/document-launch-behaviors/docs/launch-behavior.md)