### PR TITLE
Upload Windows crash reports on Azure build pipelines for pull requests only

### DIFF
--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -99,6 +99,23 @@ jobs:
       testRunTitle: Windows $(buildArch)
     condition: ne(variables['Atom.SkipTests'], 'true')
 
+  - script: |
+      IF NOT EXIST "%ARTIFACT_STAGING_DIR%\crash-reports" MKDIR "%ARTIFACT_STAGING_DIR%\crash-reports"
+      IF EXIST "%Temp%\Atom Crashes" (
+        FOR %%a in ("%Temp%\Atom Crashes\*.dmp") DO XCOPY "%%a" "%ARTIFACT_STAGING_DIR%\crash-reports" /I
+      )
+    displayName: Stage crash reports
+    condition: failed()
+    env:
+      ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/crash-reports
+      ArtifactName: crash-reports
+    displayName: Publish crash reports on non-release branch
+    condition: and(failed(), eq(variables['IsReleaseBranch'], 'false'))
+
   - task: PublishBuildArtifacts@1
     inputs:
       PathtoPublish: $(Build.SourcesDirectory)/out/atom-x64-windows.zip


### PR DESCRIPTION
To combat hard crashes like https://github.com/atom/atom/issues/18991, we need access to crash the dumps produced by Electron for a given build on Windows. Crash reports leak environment variables, so we can't upload them as public artifacts on release branches. This PR will enable uploading on non-release branches, and I will follow up with a second PR to upload them to a private location for release branches.

Tasks:
* [x] Initial implementation for Azure build pipelines
* [x] Ensure passing PR builds still succeed when there are no crash reports to publish
* [x] Ensure failing PR builds with no crashes don't produce errors for build steps associated with crash report upload.
* [x] Ensure PR builds can publish crash dumps
