### PR TITLE
await uriHandler

### DIFF
--- a/spec/uri-handler-registry-spec.js
+++ b/spec/uri-handler-registry-spec.js
@@ -89,7 +89,7 @@ describe('URIHandlerRegistry', () => {
     for (const uri of invalidUris) {
       try {
         await registry.handleURI(uri)
-        expect(uri).toBe("throwing an error");
+        expect(uri).toBe('throwing an error')
       } catch (ex) {
         numErrors++
       }

--- a/spec/uri-handler-registry-spec.js
+++ b/spec/uri-handler-registry-spec.js
@@ -89,6 +89,7 @@ describe('URIHandlerRegistry', () => {
     for (const uri of invalidUris) {
       try {
         await registry.handleURI(uri)
+        expect(uri).toBe("throwing an error");
       } catch (ex) {
         numErrors++
       }

--- a/spec/uri-handler-registry-spec.js
+++ b/spec/uri-handler-registry-spec.js
@@ -11,31 +11,31 @@ describe('URIHandlerRegistry', () => {
     registry = new URIHandlerRegistry(5)
   })
 
-  it('handles URIs on a per-host basis', () => {
+  it('handles URIs on a per-host basis', async () => {
     const testPackageSpy = jasmine.createSpy()
     const otherPackageSpy = jasmine.createSpy()
     registry.registerHostHandler('test-package', testPackageSpy)
     registry.registerHostHandler('other-package', otherPackageSpy)
 
-    registry.handleURI('atom://yet-another-package/path')
+    await registry.handleURI('atom://yet-another-package/path')
     expect(testPackageSpy).not.toHaveBeenCalled()
     expect(otherPackageSpy).not.toHaveBeenCalled()
 
-    registry.handleURI('atom://test-package/path')
+    await registry.handleURI('atom://test-package/path')
     expect(testPackageSpy).toHaveBeenCalledWith(
       url.parse('atom://test-package/path', true),
       'atom://test-package/path'
     )
     expect(otherPackageSpy).not.toHaveBeenCalled()
 
-    registry.handleURI('atom://other-package/path')
+    await registry.handleURI('atom://other-package/path')
     expect(otherPackageSpy).toHaveBeenCalledWith(
       url.parse('atom://other-package/path', true),
       'atom://other-package/path'
     )
   })
 
-  it('keeps track of the most recent URIs', () => {
+  it('keeps track of the most recent URIs', async () => {
     const spy1 = jasmine.createSpy()
     const spy2 = jasmine.createSpy()
     const changeSpy = jasmine.createSpy()
@@ -51,7 +51,9 @@ describe('URIHandlerRegistry', () => {
       'atom://two/more/stuff'
     ]
 
-    uris.forEach(u => registry.handleURI(u))
+    for (const u of uris) {
+      await registry.handleURI(u)
+    }
 
     expect(changeSpy.callCount).toBe(5)
     expect(registry.getRecentlyHandledURIs()).toEqual(
@@ -67,7 +69,7 @@ describe('URIHandlerRegistry', () => {
         .reverse()
     )
 
-    registry.handleURI('atom://another/url')
+    await registry.handleURI('atom://another/url')
     expect(changeSpy.callCount).toBe(6)
     const history = registry.getRecentlyHandledURIs()
     expect(history.length).toBe(5)
@@ -75,14 +77,23 @@ describe('URIHandlerRegistry', () => {
     expect(history[4].uri).toBe(uris[1])
   })
 
-  it('refuses to handle bad URLs', () => {
-    ;[
+  it('refuses to handle bad URLs', async () => {
+    const invalidUris = [
       'atom:package/path',
       'atom:8080://package/path',
       'user:pass@atom://package/path',
       'smth://package/path'
-    ].forEach(uri => {
-      expect(() => registry.handleURI(uri)).toThrow()
-    })
+    ]
+
+    let numErrors = 0
+    for (const uri of invalidUris) {
+      try {
+        await registry.handleURI(uri)
+      } catch (ex) {
+        numErrors++
+      }
+    }
+
+    expect(numErrors).toBe(invalidUris.length)
   })
 })

--- a/src/uri-handler-registry.js
+++ b/src/uri-handler-registry.js
@@ -89,7 +89,7 @@ class URIHandlerRegistry {
     })
   }
 
-  handleURI (uri) {
+  async handleURI (uri) {
     const parsed = url.parse(uri, true)
     const {protocol, slashes, auth, port, host} = parsed
     if (protocol !== 'atom:' || slashes !== true || auth || port) {
@@ -101,7 +101,7 @@ class URIHandlerRegistry {
     try {
       if (registration) {
         historyEntry.handled = true
-        registration(parsed, uri)
+        await registration(parsed, uri)
       }
     } finally {
       this.history.unshift(historyEntry)


### PR DESCRIPTION
### Identify the Bug

uriHandler functions are not awaited when called so an async function could fail without changing the history.

This also helps with testing uri handlers.

fixes #19174

### Description of the Change

Make URIHandlerRegistry.handleURI async and await every uriHandler function.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

none, it didn't return anything before.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

ran tests

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

N/A

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->