### PR TITLE
Teach CI to use versions specified in package-lock.json

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ environment:
   global:
     ATOM_DEV_RESOURCE_PATH: c:\projects\atom
     ATOM_JASMINE_REPORTER: list
+    CI: true
     TEST_JUNIT_XML_ROOT: c:\projects\junit-test-results
     NODE_VERSION: 8.9.3
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -26,7 +26,7 @@ if (!ci && process.env.CI === 'true' && process.argv.indexOf('--no-ci') === -1) 
   ci = true
 }
 
-verifyMachineRequirements()
+verifyMachineRequirements(ci)
 
 if (dependenciesFingerprint.isOutdated()) {
   cleanDependencies()

--- a/script/config.js
+++ b/script/config.js
@@ -77,6 +77,8 @@ function getApmBinPath () {
 }
 
 function getNpmBinPath (external = false) {
+  if (process.env.NPM_BIN_PATH) return process.env.NPM_BIN_PATH
+
   const npmBinName = process.platform === 'win32' ? 'npm.cmd' : 'npm'
   const localNpmBinPath = path.resolve(repositoryRootPath, 'script', 'node_modules', '.bin', npmBinName)
   return !external && fs.existsSync(localNpmBinPath) ? localNpmBinPath : npmBinName

--- a/script/lib/verify-machine-requirements.js
+++ b/script/lib/verify-machine-requirements.js
@@ -6,9 +6,9 @@ const path = require('path')
 
 const CONFIG = require('../config')
 
-module.exports = function () {
+module.exports = function (ci) {
   verifyNode()
-  verifyNpm()
+  verifyNpm(ci)
   if (process.platform === 'win32') {
     verifyPython()
   }
@@ -27,14 +27,15 @@ function verifyNode () {
   }
 }
 
-function verifyNpm () {
-  const stdout = childProcess.execFileSync(CONFIG.getNpmBinPath(), ['--version'], {env: process.env})
+function verifyNpm (ci) {
+  const stdout = childProcess.execFileSync(CONFIG.getNpmBinPath(ci), ['--version'], {env: process.env})
   const fullVersion = stdout.toString().trim()
   const majorVersion = fullVersion.split('.')[0]
-  if (majorVersion >= 3) {
+  const oldestMajorVersionSupported = ci ? 6 : 3
+  if (majorVersion >= oldestMajorVersionSupported) {
     console.log(`Npm:\tv${fullVersion}`)
   } else {
-    throw new Error(`npm v3+ is required to build Atom. npm v${fullVersion} was detected.`)
+    throw new Error(`npm v${oldestMajorVersionSupported}+ is required to build Atom. npm v${fullVersion} was detected.`)
   }
 }
 

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -14,6 +14,9 @@ jobs:
   steps:
   - script: script/bootstrap
     displayName: Bootstrap build environment
+    env:
+      CI: true
+      CI_PROVIDER: VSTS
 
   - script: script/lint
     displayName: Run linter

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -19,7 +19,7 @@ jobs:
   - script: npm install --global npm@6.2.0
     displayName: Update npm
 
-  - script: script/bootstrap
+  - script: export PATH="/usr/local/bin:${PATH}" && script/bootstrap
     displayName: Bootstrap build environment
     env:
       CI: true

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -19,11 +19,12 @@ jobs:
   - script: npm install --global npm@6.2.0
     displayName: Update npm
 
-  - script: export PATH="/usr/local/bin:${PATH}" && script/bootstrap
+  - script: script/bootstrap
     displayName: Bootstrap build environment
     env:
       CI: true
       CI_PROVIDER: VSTS
+      NPM_BIN_PATH: /usr/local/bin/npm
 
   - script: script/lint
     displayName: Run linter

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -21,6 +21,9 @@ jobs:
 
   - script: script/bootstrap
     displayName: Bootstrap build environment
+    env:
+      CI: true
+      CI_PROVIDER: VSTS
 
   - script: script/lint
     displayName: Run linter

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -40,6 +40,8 @@ jobs:
       node script\vsts\windows-run.js script\bootstrap.cmd
     env:
       BUILD_ARCH: $(buildArch)
+      CI: true
+      CI_PROVIDER: VSTS
     displayName: Bootstrap build environment
 
   - script: node script\vsts\windows-run.js script\lint.cmd

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -27,6 +27,9 @@ jobs:
   - script: |
       ECHO Installing npm-windows-upgrade
       npm install --global --production npm-windows-upgrade
+    displayName: Install npm-windows-upgrade
+
+  - script: |
       ECHO Upgrading npm
       npm-windows-upgrade --no-spinner --no-prompt --npm-version 6.2.0
     displayName: Install npm 6.2.0
@@ -42,6 +45,7 @@ jobs:
       BUILD_ARCH: $(buildArch)
       CI: true
       CI_PROVIDER: VSTS
+      NPM_BIN_PATH: "D:\\a\\_tool\\node\\8.9.3\\x64\\npm.cmd"
     displayName: Bootstrap build environment
 
   - script: node script\vsts\windows-run.js script\lint.cmd


### PR DESCRIPTION
Closes #19148

This pull request does the following:

- Ensure that our CI builds use npm 6+ to install dependencies. There are two parts to this:
    - Make sure that npm 6+ is installed
    - When installing dependencies, make sure that npm 6+ is used (instead of using an older version of npm that might be installed)
- Ensure that `npm ci` is used to install dependencies (instead of `npm install`). Our pre-existing build scripts already run `npm ci` when the `CI` environment variable is set to `true`. So, this pull request ensures that our CI builds set this environment variable. 

### TODO

Verify that `npm ci` is being used in:

- [x] [AppVeyor builds](https://ci.appveyor.com/project/Atom/atom/builds/23924023/job/yv7aen31f9kwebdr#L28) 
- [x] [Azure DevOps Windows x86 builds](https://github.visualstudio.com/Atom/_build/results?buildId=38125&view=logs&jobId=97a617bf-bcbd-5dfa-bba2-cfba2747b693&taskId=ce76a027-d404-5bfb-7945-43613713e966&lineStart=15&lineEnd=18&colStart=1&colEnd=1)
- [x] [Azure DevOps Windows x64 builds](https://github.visualstudio.com/Atom/_build/results?buildId=38125&view=logs&jobId=4fbced83-508e-5fe0-c978-5c71ec0fc506&taskId=efea9dc6-8b7a-5cfd-995a-4727b0e8449d&lineStart=14&lineEnd=17&colStart=1&colEnd=1)
- [x] [Azure DevOps macOS builds](https://github.visualstudio.com/Atom/_build/results?buildId=38125&view=logs&jobId=a5e52b91-c83f-5429-4a68-c246fc63a4f7&taskId=5852bf5a-5a02-52f3-bee8-4fdc90cda9d0&lineStart=14&lineEnd=17&colStart=1&colEnd=1)
- [x] [Azure DevOps Linux builds](https://github.visualstudio.com/Atom/_build/results?buildId=37985&view=logs&jobId=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&taskId=73c4289c-110b-5085-4a98-4009fa5cc9c8&lineStart=14&lineEnd=17&colStart=1&colEnd=1)


