### PR TITLE
Use a simpler condition to determine whether to publish crash reports

### DIFF
--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -114,7 +114,7 @@ jobs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/crash-reports
       ArtifactName: crash-reports
     displayName: Publish crash reports on non-release branch
-    condition: and(failed(), eq(variables['IsReleaseBranch'], 'false'))
+    condition: and(failed(), eq(variables['ATOM_RELEASES_S3_KEY'], ''))
 
   - task: PublishBuildArtifacts@1
     inputs:


### PR DESCRIPTION
Immediately after merging #19171, I had second thoughts about the condition I was using to decide whether or not to upload crash reports. I was using the `isReleaseBranch` variable being false as my indicator, but then I started wondering if that might be false in situations where we are still exposing secrets via environment variables.

This PR changes the condition to test for the presence of secrets directly.

Tasks:
* [x] Ensure crash reports upload based on the new condition.
* [x] Ensure crash reports *don't* upload on builds that expose our secrets, even if there are crashes.