### PR TITLE
On Azure DevOps, upload Windows crash dumps to S3 on release branches

### DIFF
--- a/script/vsts/lib/upload-to-s3.js
+++ b/script/vsts/lib/upload-to-s3.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const path = require('path')
 const aws = require('aws-sdk')
 
-module.exports = function (s3Key, s3Secret, s3Bucket, directory, assets) {
+module.exports = function (s3Key, s3Secret, s3Bucket, directory, assets, acl = 'public-read') {
   const s3 = new aws.S3({
     accessKeyId: s3Key,
     secretAccessKey: s3Secret,
@@ -37,7 +37,7 @@ module.exports = function (s3Key, s3Secret, s3Bucket, directory, assets) {
       console.info(`Uploading ${assetPath}`)
       const params = {
         Key: `${directory}${path.basename(assetPath)}`,
-        ACL: 'public-read',
+        ACL: acl,
         Body: fs.createReadStream(assetPath)
       }
 

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -116,6 +116,17 @@ jobs:
     displayName: Publish crash reports on non-release branch
     condition: and(failed(), eq(variables['IsReleaseBranch'], 'false'))
 
+  - script: >
+      node $(Build.SourcesDirectory)\script\vsts\upload-crash-reports.js --crash-report-path "%ARTIFACT_STAGING_DIR%\crash-reports" --s3-path "vsts-artifacts/%BUILD_ID%/"
+    env:
+      ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
+      ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
+      ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
+      ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
+      BUILD_ID: $(Build.BuildId)
+    displayName: Upload crash reports to S3 on release branch
+    condition: and(failed(), ne(variables['ATOM_RELEASES_S3_KEY'], ''))
+
   - task: PublishBuildArtifacts@1
     inputs:
       PathtoPublish: $(Build.SourcesDirectory)/out/atom-x64-windows.zip

--- a/script/vsts/upload-crash-reports.js
+++ b/script/vsts/upload-crash-reports.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const glob = require('glob')
+const uploadToS3 = require('./lib/upload-to-s3')
+
+const yargs = require('yargs')
+const argv = yargs
+  .usage('Usage: $0 [options]')
+  .help('help')
+  .describe('crash-report-path', 'The local path of a directory containing crash reports to upload')
+  .describe('s3-path', 'Indicates the S3 path in which the crash reports should be uploaded')
+  .wrap(yargs.terminalWidth())
+  .argv
+
+async function uploadCrashReports () {
+  const crashesPath = argv.crashReportPath
+  const crashes = glob.sync('/*.dmp', { root: crashesPath })
+  const bucketPath = argv.s3Path
+
+  if (crashes && crashes.length > 0) {
+    console.log(`Uploading ${crashes.length} private crash reports to S3 under '${bucketPath}'`)
+
+    await uploadToS3(
+      process.env.ATOM_RELEASES_S3_KEY,
+      process.env.ATOM_RELEASES_S3_SECRET,
+      process.env.ATOM_RELEASES_S3_BUCKET,
+      bucketPath,
+      crashes,
+      'private'
+    )
+  }
+}
+
+// Wrap the call the async function and catch errors from its promise because
+// Node.js doesn't yet allow use of await at the script scope
+uploadCrashReports().catch(err => {
+  console.error('An error occurred while uploading crash reports:\n\n', err)
+  process.exit(1)
+})


### PR DESCRIPTION
In #19171, I changed the build pipeline to publish Windows crash reports as artifacts on pull requests. As I stated in that PR, because these crash reports contain environment variables, publishing them as artifacts on our release builds would leak secrets such as our S3 credentials.

In this follow-up PR, we upload Windows crash reports produced during *release* builds to S3 with a `private` ACL. This will allow anyone with full S3 credentials to retrieve the reports but prevent the public from obtaining them.

After a test run in which I intentionally crashed the render process, I confirmed that the report was uploaded to S3 with the appropriate permissions:

Here's me fetching the access control list for the uploaded crash report:

```
> aws s3api get-object-acl --bucket github-atom-io --key vsts-artifacts/38193/940dc76a-8f0e-4f53-a51e-953a2733c8a1.dmp
{
    "Owner": {
        "DisplayName": "github",
        "ID": "a925e1762249f9122ac610ec6917c1465d18f063a083ee989c825cbaa9483def"
    },
    "Grants": [
        {
            "Grantee": {
                "DisplayName": "github",
                "ID": "a925e1762249f9122ac610ec6917c1465d18f063a083ee989c825cbaa9483def",
                "Type": "CanonicalUser"
            },
            "Permission": "FULL_CONTROL"
        }
    ]
}
```

Contrast the above ACL to one that makes the object publicly-readable, such as for our ordinary build artifacts. Notice that ACL includes an entry for `AllUsers` granting them `READ` access, whereas the entry above does not. This satisfies me that I've handled the permissions correctly and we will avoid leaking release build secrets crash reports.

```
> aws s3api get-object-acl --bucket github-atom-io --key vsts-artifacts/9824/atom-mac.zip
{
    "Owner": {
        "DisplayName": "github",
        "ID": "a925e1762249f9122ac610ec6917c1465d18f063a083ee989c825cbaa9483def"
    },
    "Grants": [
        {
            "Grantee": {
                "DisplayName": "github",
                "ID": "a925e1762249f9122ac610ec6917c1465d18f063a083ee989c825cbaa9483def",
                "Type": "CanonicalUser"
            },
            "Permission": "FULL_CONTROL"
        },
        {
            "Grantee": {
                "Type": "Group",
                "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
            },
            "Permission": "READ"
        }
    ]
}
```

Tasks:
* [x] Confirm we upload Windows crash reports to S3 on release builds
* [x] Confirm that crash reports have the appropriate ACL on S3
* [x] Confirm we don't upload crash reports to S3 on PR builds
* [x] Confirm that uploading step doesn't interfere with green release builds
* [x] Confirm that uploading step doesn't interfere with green PR builds
