### PR TITLE
[autoflow] Fix bug #18030

### DIFF
--- a/packages/autoflow/lib/autoflow.coffee
+++ b/packages/autoflow/lib/autoflow.coffee
@@ -132,7 +132,10 @@ module.exports =
             if linePrefix.search(/^\s*\/\*/) isnt -1 or linePrefix.search(/^\s*-(?!-)/) isnt -1
               linePrefix = wrappedLinePrefix
             if linePrefixNew and index <= 0 and !linePrefix
-              lines.push(linePrefixNew + currentLine.join(''))
+              if currentLine[0] == "%"
+                lines.push(linePrefix + currentLine.join(''))
+              else
+                lines.push(linePrefixNew + currentLine.join(''))
             else
               lines.push(linePrefix + currentLine.join(''))
           currentLine = []

--- a/packages/autoflow/lib/autoflow.coffee
+++ b/packages/autoflow/lib/autoflow.coffee
@@ -132,7 +132,7 @@ module.exports =
             if linePrefix.search(/^\s*\/\*/) isnt -1 or linePrefix.search(/^\s*-(?!-)/) isnt -1
               linePrefix = wrappedLinePrefix
             if linePrefixNew and index <= 0 and !linePrefix
-              if currentLine[0] == "%"
+              if currentLine.join('')[0] == '%'
                 lines.push(linePrefix + currentLine.join(''))
               else
                 lines.push(linePrefixNew + currentLine.join(''))
@@ -148,7 +148,10 @@ module.exports =
         currentLine.push(segment)
         currentLineLength += segment.length
       if linePrefixNew and index <= 0 and !linePrefix
-        lines.push(linePrefixNew + currentLine.join(''))
+        if currentLine.join('')[0] == '%'
+          lines.push(linePrefix + currentLine.join(''))
+        else
+          lines.push(linePrefixNew + currentLine.join(''))
       else
         lines.push(linePrefix + currentLine.join(''))
       wrappedLines = beginningLinesToIgnore.concat(lines.concat(endingLinesToIgnore))

--- a/packages/autoflow/spec/autoflow-spec.coffee
+++ b/packages/autoflow/spec/autoflow-spec.coffee
@@ -372,6 +372,26 @@ describe "Autoflow package", ->
 
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
 
+    it 'properly reflows inline comments ', ->
+      text =
+        '''
+        Beard pinterest actually brunch brooklyn jean shorts YOLO. % Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      res =
+        '''
+        Beard pinterest actually brunch brooklyn jean shorts YOLO. % Knausgaard sriracha
+        % banh mi, cold-pressed retro whatever ethical man braid asymmetrical
+        % fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa
+        % leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually
+        % aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial
+        % letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade,
+        % tacos pickled fanny pack literally meh pinterest slow-carb. Meditation
+        % microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
     it 'properly reflows - list items ', ->
       text =
         '''

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -684,7 +684,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-      "optional": true,
       "requires": {
         "hoek": "0.9.x"
       }
@@ -3173,8 +3172,7 @@
     "hoek": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "optional": true
+      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
     },
     "home-or-tmp": {
       "version": "1.0.0",


### PR DESCRIPTION
### Identify the Bug

The link for this bug: #18030

### Description of the Change

1. Find the first substring that matches `%`, considering the case that `\%` is not a comment symbol;
2. Record the index of `%` in the text (characters after this index are all comments);
3. Decide whether or not to add `%` at the beginning of a new line based on the index.

### Alternate Designs

Alternative: Check if `segment == '%'` for each segment instead of using index.

It is possible that there are many `%` in the text, which is hard to distinguish using the alternative. The index is the unique feature to locate the symbol in the text.

### Possible Drawbacks

I fixed the bug for comment symbol `%` as described in #18030 but didn't consider other comment symbols. Further enhancement can be made for other comment symbols, such as `#` in Python.

### Verification Process

I typed texts for the following 4 cases in a .tex file, and pressed Edit -> Reflow Selection (MacOS 10.14.1).
1. plain text without comment symbols;
2. text starting with comment symbols;
3. text with `%` in the middle;
4. text with `\%` (`\%` isn't treated as comment symbol).
5. text with `\\%` (`%` should still be treated as. comment symbol).

The first 2 cases are original features while the last two are new. I tested that the first two still work correctly after changing the codes. Here is the outcome for 3, 4 and 5.

Example 1:
```
Lorem ipsum dolor sit amet, % consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
```
After Reflow Selection,
```
Lorem ipsum dolor sit amet, % consectetur adipisicing elit, sed do eiusmod 
% tempor incididunt ut labore et dolore
```

Example 2:
```
Lorem ipsum dolor sit amet, \% consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
```
After Reflow Selection,
```
Lorem ipsum dolor sit amet, \% consectetur adipisicing elit, sed do eiusmod
tempor incididunt ut labore et dolore
```

Example 3:
```
Lorem ipsum dolor sit amet, \\% consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
```
After Reflow Selection,
```
Lorem ipsum dolor sit amet, \\% consectetur adipisicing elit, sed do eiusmod
% tempor incididunt ut labore et dolore
```

I also tested for longer text:
Example 4:
```
Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. % Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
```
After Reflow Selection,
```
Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
consequat. % Duis aute irure dolor in reprehenderit in voluptate velit esse
% cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
% proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
```

### Release Notes

N/A