### PR TITLE
Fix reset-font-size

### DIFF
--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1543,9 +1543,9 @@ module.exports = class Workspace extends Model {
   }
 
   subscribeToFontSize () {
-    return this.config.onDidChange('editor.fontSize', ({oldValue}) => {
+    return this.config.onDidChange('editor.fontSize', () => {
       if (this.originalFontSize == null) {
-        this.originalFontSize = oldValue
+        this.originalFontSize = this.config.get('editor.fontSize')
       }
     })
   }


### PR DESCRIPTION
### Identify the Bug

#9873

### Description of the Change

If the user config is yet to be loaded `oldValue` equals the default font size `14px`. This breaks the reset font size functionality. Fetching the font-size from the config object instead of using `oldValue` seems to fix the issue. I'm running:

**macOS:** 10.14.3
**Node:** v11.14.0
**npm:** 6.9.0

### Alternate Designs

Not sure if this fix is needed at all TBH. [It has been pointed out that it works fine on Windows](https://github.com/atom/atom/issues/9873#issuecomment-457648226) and I know this has worked in previous versions of Atom on macOS as well. It could be an issue where the configuration hasn't yet been loaded for some reason.

### Possible Drawbacks

N/A

### Verification Process

- Set the configured font size to e.g. 10
- Increase or decrease the editor font size multiple times
- Reset the font size `window:reset-font-size`
- The font size should equal 10

### Release Notes

- Fix reset font size behaviour