### PR TITLE
Re-upgrade electron-link to v0.3.3

### DIFF
--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -684,7 +684,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-      "optional": true,
       "requires": {
         "hoek": "0.9.x"
       }
@@ -1734,9 +1733,9 @@
       }
     },
     "electron-link": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/electron-link/-/electron-link-0.3.2.tgz",
-      "integrity": "sha512-V7QmtujzWgvrW5BI2CKmIRF+q+pkrFO5Lecd8TpibbBz+FfW5WQ4kCN0sZjNaUOMtGGroCib721OqIDEynjwgA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/electron-link/-/electron-link-0.3.3.tgz",
+      "integrity": "sha512-dxFY3o3E9kBkOyfaY66PWabK1AL5Re8qmy2Abz2/VhVkp2KtvUn6BZODTm9XpC0REgWxlQfRyHlNTlXRBPrWCQ==",
       "requires": {
         "ast-util": "^0.6.0",
         "encoding-down": "~5.0.0",
@@ -2258,9 +2257,9 @@
       }
     },
     "expand-template": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
     "extend": {
       "version": "3.0.1",
@@ -3173,8 +3172,7 @@
     "hoek": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "optional": true
+      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
     },
     "home-or-tmp": {
       "version": "1.0.0",
@@ -3870,14 +3868,14 @@
       }
     },
     "level-codec": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.0.tgz",
-      "integrity": "sha512-OIpVvjCcZNP5SdhcNupnsI1zo5Y9Vpm+k/F1gfG5kXrtctlrwanisakweJtE0uA0OpLukRfOQae+Fg0M5Debhg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
+      "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q=="
     },
     "level-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.0.tgz",
-      "integrity": "sha512-AmY4HCp9h3OiU19uG+3YWkdELgy05OTP/r23aNHaQKWv8DO787yZgsEuGVkoph40uwN+YdUKnANlrxSsoOaaxg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
       "requires": {
         "errno": "~0.1.1"
       }
@@ -3922,15 +3920,22 @@
       }
     },
     "leveldown": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-4.0.1.tgz",
-      "integrity": "sha512-ZlBKVSsglPIPJnz4ggB8o2R0bxDxbsMzuQohbfgoFMVApyTE118DK5LNRG0cRju6rt3OkGxe0V6UYACGlq/byg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-4.0.2.tgz",
+      "integrity": "sha512-SUgSRTWFh3eeiTdIt2a4Fi9TZO5oWzE9uC/Iw8+fVr1sk8x1S2l151UWwSmrMFZB3GxJhZIf4bQ0n+051Cctpw==",
       "requires": {
         "abstract-leveldown": "~5.0.0",
         "bindings": "~1.3.0",
         "fast-future": "~1.0.2",
-        "nan": "~2.10.0",
-        "prebuild-install": "^4.0.0"
+        "nan": "~2.12.1",
+        "prebuild-install": "~5.2.4"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+          "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+        }
       }
     },
     "levelup": {
@@ -4555,6 +4560,11 @@
         }
       }
     },
+    "napi-build-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+      "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA=="
+    },
     "natives": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
@@ -4585,9 +4595,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
         }
       }
     },
@@ -8039,21 +8049,22 @@
       "integrity": "sha1-aJQxe7jUcVflneKkoAnbfm9j4w4="
     },
     "prebuild-install": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
-      "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.5.tgz",
+      "integrity": "sha512-6uZgMVg7yDfqlP5CPurVhtq3hUKBFNufiar4J5hZrlHTo59DDBEtyxw01xCdFss9j0Zb9+qzFVf/s4niayba3w==",
       "requires": {
         "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
+        "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
         "noop-logger": "^0.1.1",
         "npmlog": "^4.0.1",
         "os-homedir": "^1.0.1",
         "pump": "^2.0.1",
-        "rc": "^1.1.6",
+        "rc": "^1.2.7",
         "simple-get": "^2.7.0",
         "tar-fs": "^1.13.0",
         "tunnel-agent": "^0.6.0",

--- a/script/package.json
+++ b/script/package.json
@@ -10,7 +10,7 @@
     "colors": "1.1.2",
     "donna": "1.0.16",
     "electron-chromedriver": "~2.0",
-    "electron-link": "0.3.2",
+    "electron-link": "0.3.3",
     "electron-mksnapshot": "~2.0",
     "electron-packager": "7.3.0",
     "electron-winstaller": "2.6.4",


### PR DESCRIPTION
It looks like our `electron-link` dependency got caught in the downgrade from Electron 3 to Electron 2. `electron-link@3.3.0` includes a pretty important startup performance fix, atom/electron-link#16, so we should re-include it ASAP.

🎩 Hat tip to @rafeca who noticed the performance regression pretty much immediately after coming back from vacation 😄 