### PR TITLE
"Reopen projects" in a new window

### DIFF
--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -306,7 +306,14 @@ class AtomEnvironment {
   }
 
   registerDefaultCommands () {
-    registerDefaultCommands({commandRegistry: this.commands, config: this.config, commandInstaller: this.commandInstaller, notificationManager: this.notifications, project: this.project, clipboard: this.clipboard})
+    registerDefaultCommands({
+      commandRegistry: this.commands,
+      config: this.config,
+      commandInstaller: this.commandInstaller,
+      notificationManager: this.notifications,
+      project: this.project,
+      clipboard: this.clipboard
+    })
   }
 
   registerDefaultOpeners () {

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -478,17 +478,17 @@ class AtomApplication extends EventEmitter {
 
   // Registers basic application commands, non-idempotent.
   handleEvents () {
-    const getLoadSettings = includeWindow => {
-      const window = this.focusedWindow()
+    const createOpenSettings = ({event, sameWindow}) => {
+      const targetWindow = event ? this.atomWindowForEvent(event) : this.focusedWindow()
       return {
-        devMode: window ? window.devMode : false,
-        safeMode: window ? window.safeMode : false,
-        window: includeWindow && window ? window : null
+        devMode: targetWindow ? targetWindow.devMode : false,
+        safeMode: targetWindow ? targetWindow.safeMode : false,
+        window: sameWindow && targetWindow ? targetWindow : null
       }
     }
 
     this.on('application:quit', () => app.quit())
-    this.on('application:new-window', () => this.openPath(getLoadSettings(false)))
+    this.on('application:new-window', () => this.openPath(createOpenSettings({})))
     this.on('application:new-file', () => (this.focusedWindow() || this).openPath())
     this.on('application:open-dev', () => this.promptForPathToOpen('all', {devMode: true}))
     this.on('application:open-safe', () => this.promptForPathToOpen('all', {safeMode: true}))
@@ -517,9 +517,16 @@ class AtomApplication extends EventEmitter {
         this.openPaths({ pathsToOpen: paths })
       })
 
-      this.on('application:open', () => this.promptForPathToOpen('all', getLoadSettings(true), getDefaultPath()))
-      this.on('application:open-file', () => this.promptForPathToOpen('file', getLoadSettings(true), getDefaultPath()))
-      this.on('application:open-folder', () => this.promptForPathToOpen('folder', getLoadSettings(true), getDefaultPath()))
+      this.on('application:open', () => {
+        this.promptForPathToOpen('all', createOpenSettings({sameWindow: true}), getDefaultPath())
+      })
+      this.on('application:open-file', () => {
+        this.promptForPathToOpen('file', createOpenSettings({sameWindow: true}), getDefaultPath())
+      })
+      this.on('application:open-folder', () => {
+        this.promptForPathToOpen('folder', createOpenSettings({sameWindow: true}), getDefaultPath())
+      })
+
       this.on('application:bring-all-windows-to-front', () => Menu.sendActionToFirstResponder('arrangeInFront:'))
       this.on('application:hide', () => Menu.sendActionToFirstResponder('hide:'))
       this.on('application:hide-other-applications', () => Menu.sendActionToFirstResponder('hideOtherApplications:'))
@@ -623,16 +630,15 @@ class AtomApplication extends EventEmitter {
       }
     }))
 
-    // A request from the associated render process to open a new render process.
-    this.disposable.add(ipcHelpers.on(ipcMain, 'open', (event, options) => {
-      const window = this.atomWindowForEvent(event)
+    // A request from the associated render process to open a set of paths using the standard window location logic.
+    // Used for application:reopen-project.
+    this.disposable.add(ipcHelpers.on(ipcMain, 'open', (_event, options) => {
       if (options) {
         if (typeof options.pathsToOpen === 'string') {
           options.pathsToOpen = [options.pathsToOpen]
         }
 
         if (options.pathsToOpen && options.pathsToOpen.length > 0) {
-          options.window = window
           this.openPaths(options)
         } else {
           this.addWindow(this.createWindow(options))
@@ -640,6 +646,18 @@ class AtomApplication extends EventEmitter {
       } else {
         this.promptForPathToOpen('all', {window})
       }
+    }))
+
+    // Prompt for a file, folder, or either, then open the chosen paths. Files will be opened in the originating
+    // window; folders will be opened in a new window unless an existing window exactly contains all of them.
+    this.disposable.add(ipcHelpers.on(ipcMain, 'open-chosen-any', (event, defaultPath) => {
+      this.promptForPathToOpen('all', createOpenSettings({event, sameWindow: true}), defaultPath)
+    }))
+    this.disposable.add(ipcHelpers.on(ipcMain, 'open-chosen-file', (event, defaultPath) => {
+      this.promptForPathToOpen('file', createOpenSettings({event, sameWindow: true}), defaultPath)
+    }))
+    this.disposable.add(ipcHelpers.on(ipcMain, 'open-chosen-folder', (event, defaultPath) => {
+      this.promptForPathToOpen('folder', createOpenSettings({event}), defaultPath)
     }))
 
     this.disposable.add(ipcHelpers.on(ipcMain, 'update-application-menu', (event, template, menu) => {
@@ -666,19 +684,6 @@ class AtomApplication extends EventEmitter {
 
     this.disposable.add(ipcHelpers.on(ipcMain, 'command', (event, command) => {
       this.emit(command)
-    }))
-
-    this.disposable.add(ipcHelpers.on(ipcMain, 'open-command', (event, command, defaultPath) => {
-      switch (command) {
-        case 'application:open':
-          return this.promptForPathToOpen('all', getLoadSettings(true), defaultPath)
-        case 'application:open-file':
-          return this.promptForPathToOpen('file', getLoadSettings(true), defaultPath)
-        case 'application:open-folder':
-          return this.promptForPathToOpen('folder', getLoadSettings(true), defaultPath)
-        default:
-          return console.log(`Invalid open-command received: ${command}`)
-      }
     }))
 
     this.disposable.add(ipcHelpers.on(ipcMain, 'window-command', (event, command, ...args) => {

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -599,7 +599,7 @@ class AtomApplication extends EventEmitter {
 
     // Triggered by the 'open-file' event from Electron:
     // https://electronjs.org/docs/api/app#event-open-file-macos
-    // For example, this is fired when a file is dragged and dropped onto the dock.
+    // For example, this is fired when a file is dragged and dropped onto the Atom application icon in the dock.
     this.disposable.add(ipcHelpers.on(app, 'open-file', (event, pathToOpen) => {
       event.preventDefault()
       this.openPath({pathToOpen})

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -597,6 +597,9 @@ class AtomApplication extends EventEmitter {
       this.deleteSocketSecretFile()
     }))
 
+    // Triggered by the 'open-file' event from Electron:
+    // https://electronjs.org/docs/api/app#event-open-file-macos
+    // For example, this is fired when a file is dragged and dropped onto the dock.
     this.disposable.add(ipcHelpers.on(app, 'open-file', (event, pathToOpen) => {
       event.preventDefault()
       this.openPath({pathToOpen})

--- a/src/register-default-commands.coffee
+++ b/src/register-default-commands.coffee
@@ -36,13 +36,13 @@ module.exports = ({commandRegistry, commandInstaller, config, notificationManage
       'application:new-file': -> ipcRenderer.send('command', 'application:new-file')
       'application:open': ->
         defaultPath = atom.workspace.getActiveTextEditor()?.getPath() ? atom.project.getPaths()?[0]
-        ipcRenderer.send('open-command', 'application:open', defaultPath)
+        ipcRenderer.send('open-chosen-any', defaultPath)
       'application:open-file': ->
         defaultPath = atom.workspace.getActiveTextEditor()?.getPath() ? atom.project.getPaths()?[0]
-        ipcRenderer.send('open-command', 'application:open-file', defaultPath)
+        ipcRenderer.send('open-chosen-file', defaultPath)
       'application:open-folder': ->
         defaultPath = atom.workspace.getActiveTextEditor()?.getPath() ? atom.project.getPaths()?[0]
-        ipcRenderer.send('open-command', 'application:open-folder', defaultPath)
+        ipcRenderer.send('open-chosen-folder', defaultPath)
       'application:open-dev': -> ipcRenderer.send('command', 'application:open-dev')
       'application:open-safe': -> ipcRenderer.send('command', 'application:open-safe')
       'application:add-project-folder': -> atom.addProjectFolder()


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Fixes #19149.

### Description of the Change

I'm reworking the IPC messages that `AtomEnvironment` and `AtomApplication` use to communicate messages related to file opening to clarify which are used for what, then making sure that the `application:reopen-projects`, `application:open`, `application:open-file`, and `application:open-folder` use them consistently. I'm also backfilling tests for IPC message handling.

### Alternate Designs

I could have opted for a more surgical fix within the confines of the existing IPC message structure. The way they were structured was fairly confusing though - we had listeners for `"open"`, `"open-command"` with a subcommand switch for `application:open`, `application:open-file`, or `application:open-folder`, and `"open-file"`, all of which behaved in slightly different ways.

I also considered making `application:reopen-projects` pass a `newWindow` parameter to _always_ open a new window for the reopened projects, but opted to preserve the old behavior as closely as I could.

### Possible Drawbacks

Because the `"open"` command handler used by `application:reopen-projects` uses the standard command-line rules for reusing existing windows, there is still a situation which may exhibit undesired behavior:

> Given `[a,b _]`, reopening the project `b` will only refocus the window because the existing window already contains the named path, but that window won't have the same state as the project with `b` alone.

### Verification Process

In addition to unit tests, here's my behavior verification matrix.

Given this directory tree:

```
a/
  1.md
b/
  2.md
```

* 1.36.0 outcome cells marked with :new: have changed from 1.35.1 to 1.36.0 (intentionally or otherwise).
* 1.36.1 outcome cells marked with :new: have intentionally changed from 1.35.1 to 1.36.1.
* 1.36.1 outcome cells marked with :bug: were unintentionally changed from 1.35.1 to 1.36.0 and reverted to their original behavior for 1.36.1.
* 1.36.1 outcome cells marked with :bug: :new: unintentionally changed from 1.35.1 to 1.36.0, but changed to _different_ behavior for 1.36.1.

#### No open windows

| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
| -- | -- | -- | -- |
| File -> Reopen Project -> a | _(nothing)_ | _(nothing)_ | `[a _]` :bug: :new: |
| File -> Open... -> `a/1.md` | `[a 1.md]` | `[_ 1.md]` :new: | `[_ 1.md]` :new: |

#### One empty window

> `[_ _]`

| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
| -- | -- | -- | -- |
| File -> Reopen Project -> b | `[b _]` |  `[_ _]` :new: |  `[b _]` :bug: |
| File -> Open... -> `a/1.md` | `[a 1.md]` | `[_ 1.md]` :new: | `[_ 1.md]` :new: |
| File -> Open... -> `a` |  `[a _]` |  `[_ _] [a _]` :new: | `[a _]` :bug: |
| `application:reopen-project`, choose `a` | `[a _]` | `[a _]` | `[a _]` |
| `application:open`, choose `a/1.md` | `[a 1.md]` | `[_ 1.md]` :new: | `[_ 1.md]` :new: |
| `application:open`, choose `b` | `[b _]` | `[_ _] [b _]` | `[b _]` :bug: |
| `application:open-file`, choose `a/1.md` | `[a 1.md]` | `[_ 1.md]` :new: | `[_ 1.md]` :bug: :new: |
| `application:open-folder`, choose `b` | `[b _]` | `[_ _] [b _]` :new: | `[b _]` :bug: :new: |

#### One window with a project root

> `[a _]`

| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
| -- | -- | -- | -- |
| File -> Reopen Project -> `b` | `[a _] [b _]` | `[a _]` :new: | `[a _] [b _]` :bug: |
| File -> Open... -> `a/1.md` | `[a 1.md]` | `[a 1.md]` | `[a 1.md]` |
| File -> Open... -> `b/2.md` | `[a 2.md]` | `[a 2.md]` | `[a 2.md]` |
| File -> Open... -> `b` | `[a _] [b _]` | `[a _] [b _]` | `[a _] [b _]` |
| `application:reopen-project`, choose `b` | `[a _] [b _]` | `[a,b _]` :new: | `[a _] [b _]` :bug: |
| `application:open`, choose `b/2.md` | `[a 2.md]` | `[a 2.md]` | `[a 2.md]` |
| `application:open`, choose `b` | `[a _] [b _]` | `[a _] [b _]` | `[a _] [b _]` |
| `application:open-file`, choose `a/1.md` | `[a 1.md]` | `[a 1.md]` | `[a 1.md]` |
| `application:open-file`, choose `b/2.md` | `[a 2.md]` | `[a 2.md]` | `[a 2.md]` |
| `application:open-folder`, choose `b` | `[a _] [b _]` | `[a _] [b _]` | `[a _] [b _]` |

#### That weird edge case

> `[a,b _]`<br/>
> `b` has project state of `2.md`

| Action | Outcome (<=1.35.1) | Outcome (1.36.0) | Outcome (1.36.1) |
| -- | -- | -- | -- |
| File -> Reopen Project -> `b` | `[a _] [b _]` | `[a _] [b _]` | `[a _] [b _]` |

### Release Notes

* "File -> Reopen Project" works correctly on macOS when no windows are open.
* "File -> Reopen Project" from the application menu opens the chosen project folders.
* Choosing `application:reopen-project` from the command palette opens chosen project folders in a new window when appropriate.

The other :new: and :bug: :new: rows correspond to changes introduced by #19169.