### PR TITLE
Set the panel flag as focused when activate() is called

### DIFF
--- a/src/pane.js
+++ b/src/pane.js
@@ -393,7 +393,6 @@ class Pane {
 
   // Called by the view layer to indicate that the pane has gained focus.
   focus () {
-    this.focused = true
     return this.activate()
   }
 
@@ -1011,6 +1010,8 @@ class Pane {
   // Public: Makes this pane the *active* pane, causing it to gain focus.
   activate () {
     if (this.isDestroyed()) throw new Error('Pane has been destroyed')
+    this.focused = true
+
     if (this.container) this.container.didActivatePane(this)
     this.emitter.emit('did-activate')
   }


### PR DESCRIPTION
### Identify the Bug

Programmatically calling `pane.activate()` does not currently update its `isFocused()` state.

This PR fixes https://github.com/atom/atom/issues/18913

### Description of the Change

This PR changes the logic to set the `focused` flag on the `activate()` method instead of the `focus()` method. Since `focus()` always calls `activate()` this should not affect that method.

### Alternate Designs

N/A

### Possible Drawbacks

🤷‍♂️

### Verification Process

Open Atom and execute the following from the developer console:

```js
const assert = require('assert')
const pane = atom.workspace.paneForURI('atom://config')
assert.ok(!pane.isFocused())
pane.activate()
assert.ok(pane.isFocused()) 
```

### Release Notes

Fixed `pane.activate()` to update the panel `isFocused()` state.