### PR TITLE
Only store directories in serialized application state

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -164,12 +164,12 @@ describe('AtomApplication', function () {
 
           it('restores windows when launched with a project path to open', async function () {
             await scenario.launch({app, pathsToOpen: ['a']})
-            await scenario.assert('[a _] [b _] [c _]')
+            await scenario.assert('[b _] [c _] [a _]')
           })
 
           it('restores windows when launched with a file path to open', async function () {
             await scenario.launch({app, pathsToOpen: ['a/1.md']})
-            await scenario.assert('[b 1.md] [c _]')
+            await scenario.assert('[b _] [c 1.md]')
           })
 
           it('collapses new paths into restored windows when appropriate', async function () {

--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -100,10 +100,13 @@ describe('AtomApplication', function () {
 
         beforeEach(function () {
           app = scenario.addApplication({
-            applicationJson: [
-              { initialPaths: ['b'] },
-              { initialPaths: ['c'] }
-            ]
+            applicationJson: {
+              version: '1',
+              windows: [
+                { projectRoots: [scenario.convertRootPath('b')] },
+                { projectRoots: [scenario.convertRootPath('c')] }
+              ]
+            }
           })
         })
 
@@ -184,6 +187,33 @@ describe('AtomApplication', function () {
             await scenario.open(parseCommandLine(['b']))
             await scenario.assert('[a _] [b _]')
           })
+        })
+      })
+
+      describe('with unversioned application state', function () {
+        it('reads "initialPaths" as project roots', async function () {
+          const app = scenario.addApplication({
+            applicationJson: [
+              {initialPaths: [scenario.convertRootPath('a')]},
+              {initialPaths: [scenario.convertRootPath('b'), scenario.convertRootPath('c')]}
+            ]
+          })
+          app.config.set('core.restorePreviousWindowsOnStart', 'always')
+
+          await scenario.launch({app})
+          await scenario.assert('[a _] [b,c _]')
+        })
+
+        it('filters file paths from project root lists', async function () {
+          const app = scenario.addApplication({
+            applicationJson: [
+              {initialPaths: [scenario.convertRootPath('b'), scenario.convertEditorPath('a/1.md')]}
+            ]
+          })
+          app.config.set('core.restorePreviousWindowsOnStart', 'always')
+
+          await scenario.launch({app})
+          await scenario.assert('[b _]')
         })
       })
     })
@@ -855,10 +885,13 @@ describe('AtomApplication', function () {
 
       assert.isTrue(scenario.getApplication(0).storageFolder.store.calledWith(
         'application.json',
-        [
-          {initialPaths: [scenario.convertRootPath('a')]},
-          {initialPaths: [scenario.convertRootPath('b'), scenario.convertRootPath('c')]}
-        ]
+        {
+          version: '1',
+          windows: [
+            {projectRoots: [scenario.convertRootPath('a')]},
+            {projectRoots: [scenario.convertRootPath('b'), scenario.convertRootPath('c')]}
+          ]
+        }
       ))
     })
 
@@ -872,9 +905,12 @@ describe('AtomApplication', function () {
 
       assert.isTrue(scenario.getApplication(0).storageFolder.store.calledWith(
         'application.json',
-        [
-          {initialPaths: [scenario.convertRootPath('a')]}
-        ]
+        {
+          version: '1',
+          windows: [
+            {projectRoots: [scenario.convertRootPath('a')]}
+          ]
+        }
       ))
     })
 
@@ -1338,9 +1374,7 @@ class LaunchScenario {
       return newWindow
     })
     this.sinon.stub(app.storageFolder, 'load', () => Promise.resolve(
-      (options.applicationJson || []).map(each => ({
-        initialPaths: this.convertPaths(each.initialPaths)
-      }))
+      options.applicationJson || {version: '1', windows: []}
     ))
     this.sinon.stub(app.storageFolder, 'store', () => Promise.resolve())
     this.applications.add(app)

--- a/spec/main-process/atom-window.test.js
+++ b/spec/main-process/atom-window.test.js
@@ -190,6 +190,7 @@ describe('AtomWindow', function () {
       ]
 
       const w = new AtomWindow(app, service, { browserWindowConstructor: StubBrowserWindow, locationsToOpen })
+      assert.deepEqual(w.projectRoots, ['/directory'])
 
       const loadPromise = emitterEventPromise(w, 'window:loaded')
       w.browserWindow.emit('window:loaded')
@@ -256,6 +257,24 @@ describe('AtomWindow', function () {
       assert.isTrue(w.loadSettings.hasOpenFiles)
       assert.deepEqual(w.loadSettings.initialProjectRoots, ['directory0', 'directory1'])
       assert.isTrue(w.hasProjectPaths())
+    })
+
+    it('is updated synchronously by openLocations', async function () {
+      const locationsToOpen = [
+        { pathToOpen: 'file.txt', isFile: true },
+        { pathToOpen: 'directory1', isDirectory: true },
+        { pathToOpen: 'directory0', isDirectory: true },
+        { pathToOpen: 'directory0', isDirectory: true },
+        { pathToOpen: 'new-file.txt' }
+      ]
+
+      const w = new AtomWindow(app, service, { browserWindowConstructor: StubBrowserWindow })
+      assert.deepEqual(w.projectRoots, [])
+
+      const promise = w.openLocations(locationsToOpen)
+      assert.deepEqual(w.projectRoots, ['directory0', 'directory1'])
+      w.resolveLoadedPromise()
+      await promise
     })
 
     it('is updated by setProjectRoots', function () {

--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -1247,9 +1247,8 @@ or use Pane::saveItemAs for programmatic saving.`)
       try {
         await this.project.deserialize(state.project, this.deserializers)
       } catch (error) {
-        if (error.missingProjectPaths) {
-          missingProjectPaths.push(...error.missingProjectPaths)
-        } else {
+        // We handle the missingProjectPaths case in openLocations().
+        if (!error.missingProjectPaths) {
           this.notifications.addError('Unable to deserialize project', {
             description: error.message,
             stack: error.stack
@@ -1268,7 +1267,7 @@ or use Pane::saveItemAs for programmatic saving.`)
 
     if (missingProjectPaths.length > 0) {
       const count = missingProjectPaths.length === 1 ? '' : missingProjectPaths.length + ' '
-      const noun = missingProjectPaths.length === 1 ? 'directory' : 'directories'
+      const noun = missingProjectPaths.length === 1 ? 'folder' : 'folders'
       const toBe = missingProjectPaths.length === 1 ? 'is' : 'are'
       const escaped = missingProjectPaths.map(projectPath => `\`${projectPath}\``)
       let group

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -1170,7 +1170,8 @@ class AtomApplication extends EventEmitter {
       return state.windows.map(each => ({
         foldersToOpen: each.projectRoots,
         devMode: this.devMode,
-        safeMode: this.safeMode
+        safeMode: this.safeMode,
+        newWindow: true
       }))
     } else if (state.version === undefined) {
       // Atom <= 1.36.0
@@ -1188,7 +1189,8 @@ class AtomApplication extends EventEmitter {
           return {
             foldersToOpen: classifiedPaths.filter(({isDir}) => isDir).map(({initialPath}) => initialPath),
             devMode: this.devMode,
-            safeMode: this.safeMode
+            safeMode: this.safeMode,
+            newWindow: true
           }
         })
       )

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -252,8 +252,7 @@ class AtomApplication extends EventEmitter {
       this.config.onDidChange('core.colorProfile', () => this.promptForRestart())
     }
 
-    const optionsForWindowsToOpen = []
-
+    let optionsForWindowsToOpen = []
     let shouldReopenPreviousWindows = false
 
     if (options.test || options.benchmark || options.benchmarkTest) {
@@ -269,9 +268,7 @@ class AtomApplication extends EventEmitter {
     }
 
     if (shouldReopenPreviousWindows) {
-      for (const previousOptions of await this.loadPreviousWindowOptions()) {
-        optionsForWindowsToOpen.push(previousOptions)
-      }
+      optionsForWindowsToOpen = [...await this.loadPreviousWindowOptions(), ...optionsForWindowsToOpen]
     }
 
     if (optionsForWindowsToOpen.length === 0) {

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -23,6 +23,11 @@ const ConfigSchema = require('../config-schema')
 
 const LocationSuffixRegExp = /(:\d+)(:\d+)?$/
 
+// Increment this when changing the serialization format of `${ATOM_HOME}/storage/application.json` used by
+// AtomApplication::saveCurrentWindowOptions() and AtomApplication::loadPreviousWindowOptions() in a backward-
+// incompatible way.
+const APPLICATION_STATE_VERSION = '1'
+
 const getDefaultPath = () => {
   const editor = atom.workspace.getActiveTextEditor()
   if (!editor || !editor.getPath()) {
@@ -1139,27 +1144,56 @@ class AtomApplication extends EventEmitter {
   async saveCurrentWindowOptions (allowEmpty = false) {
     if (this.quitting) return
 
-    const states = []
-    for (let window of this.getAllWindows()) {
-      if (!window.isSpec) states.push({initialPaths: window.projectRoots})
+    const state = {
+      version: APPLICATION_STATE_VERSION,
+      windows: this.getAllWindows()
+        .filter(window => !window.isSpec)
+        .map(window => ({projectRoots: window.projectRoots}))
     }
-    states.reverse()
+    state.windows.reverse()
 
-    if (states.length > 0 || allowEmpty) {
-      await this.storageFolder.store('application.json', states)
+    if (state.windows.length > 0 || allowEmpty) {
+      await this.storageFolder.store('application.json', state)
       this.emit('application:did-save-state')
     }
   }
 
   async loadPreviousWindowOptions () {
-    const states = await this.storageFolder.load('application.json')
-    if (states) {
-      return states.map(state => ({
-        foldersToOpen: state.initialPaths,
+    const state = await this.storageFolder.load('application.json')
+    if (!state) {
+      return []
+    }
+
+    if (state.version === APPLICATION_STATE_VERSION) {
+      // Atom >=1.36.1
+      // Schema: {version: '1', windows: [{projectRoots: ['<root-dir>', ...]}, ...]}
+      return state.windows.map(each => ({
+        foldersToOpen: each.projectRoots,
         devMode: this.devMode,
         safeMode: this.safeMode
       }))
+    } else if (state.version === undefined) {
+      // Atom <= 1.36.0
+      // Schema: [{initialPaths: ['<root-dir>', ...]}, ...]
+      return await Promise.all(
+        state.map(async windowState => {
+          // Classify each window's initialPaths as directories or non-directories
+          const classifiedPaths = await Promise.all(
+            windowState.initialPaths.map(initialPath => new Promise(resolve => {
+              fs.isDirectory(initialPath, isDir => resolve({initialPath, isDir}))
+            }))
+          )
+
+          // Only accept initialPaths that are existing directories
+          return {
+            foldersToOpen: classifiedPaths.filter(({isDir}) => isDir).map(({initialPath}) => initialPath),
+            devMode: this.devMode,
+            safeMode: this.safeMode
+          }
+        })
+      )
     } else {
+      // Unrecognized version (from a newer Atom?)
       return []
     }
   }

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -72,10 +72,7 @@ class AtomWindow extends EventEmitter {
     if (this.loadSettings.safeMode == null) this.loadSettings.safeMode = false
     if (this.loadSettings.clearWindowState == null) this.loadSettings.clearWindowState = false
 
-    this.projectRoots = locationsToOpen
-      .filter(location => location.pathToOpen && location.exists && location.isDirectory)
-      .map(location => location.pathToOpen)
-    this.projectRoots.sort()
+    this.addLocationsToOpen(locationsToOpen)
 
     this.loadSettings.hasOpenFiles = locationsToOpen
       .some(location => location.pathToOpen && !location.isDirectory)
@@ -240,6 +237,7 @@ class AtomWindow extends EventEmitter {
   }
 
   async openLocations (locationsToOpen) {
+    this.addLocationsToOpen(locationsToOpen)
     await this.loadedPromise
     this.sendMessage('open-locations', locationsToOpen)
   }
@@ -250,6 +248,18 @@ class AtomWindow extends EventEmitter {
 
   didFailToReadUserSettings (message) {
     this.sendMessage('did-fail-to-read-user-settings', message)
+  }
+
+  addLocationsToOpen (locationsToOpen) {
+    const roots = new Set(this.projectRoots || [])
+    for (const {pathToOpen, isDirectory} of locationsToOpen) {
+      if (isDirectory) {
+        roots.add(pathToOpen)
+      }
+    }
+
+    this.projectRoots = Array.from(roots)
+    this.projectRoots.sort()
   }
 
   replaceEnvironment (env) {


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Fixes #19146 without regressing #16645.

Atom's serialized application state has been erroneously written with _file paths_ given on the command line as well as project root directories. This is triggering the behavior introduced in #18742 to fix #16645, which is intended to detect the situation when a project root directory has been deleted from disk (and possibly replaced by a file) and rescue any window session state that was keyed by that directory.

### Description of the Change

I've modified the schema used to write `${ATOM_HOME}/storage/application.json` to be version-tagged and only include project root directories, with some renaming for clarity:

```json
{
  "version": "1",
  "windows": [
    {"projectRoots": ["<root-dir>", "<root-dir>"]},
    {"projectRoots": ["<root-dir>"]}
  ]
}
```

Application state may be loaded from either this schema or the previous, untagged one. When loading serialized state from the previous schema, non-directory paths are filtered out from each `initialPaths` array.

### Alternate Designs

One solution to the immediate problem would be to leave the schema unchanged and always filter non-directories from `initialPaths` on load. The problem with this is that we use the set of project root directories to key a window's serialized session state. By removing paths that used to be legitimate project root directories, we would be changing the session key, and possibly orphaning the session. For example:

```sh
# Assume core.restorePreviousWindowsOnStart !== "no"
$ atom a/ b/
# Open a file within b/, make changes, and do not save them
# Quit the application
$ rm -r a/
$ atom
# Atom launches one window containing b/; unsaved file changes are lost!
```

### Possible Drawbacks

There is a small chance that a path in `initialPaths` within unversioned application state used to be a legitimate project root, and therefore should be used to derive the window's state key. Unfortunately, we have no way to tell the difference between this case and the much more common case of `initialPaths` containing a file path.

### Verification Process

For all cases, set the `core.restorePreviousWindowsOnStart` configuration setting to `"always"`.

Assume the following directory structure:

```
temp/
  a/
    1.md
  b/
    2.md
  c/
```

#### Reading unversioned application state

Populate `~/.atom/storage/application.json` with the following:

```json
[
  {"initialPaths": ["/temp/a", "/temp/b/2.md"]},
  {"initialPaths": ["/temp/b"]},
]
```

Open Atom with no arguments.

- [x] No error notifications should appear.
- [x] Two windows should open: one containing only the project root `/temp/a`, and one containing only the project root `/temp/b`.

#### Writing and reading version 1 application state

Open Atom and create two windows. Adjust project root directories such that:

* One window contains `/temp/a`.
* One window contains `/temp/b` and `/temp/c`. Focus this window (so that it's the most recently focused).

Quit Atom.

Verify that `~/.atom/storage/application.json` contains the following (formatted less nicely):

```json
{
  "version": "1",
  "windows": [
    {"projectRoots": ["/temp/a"]},
    {"projectRoots": ["/temp/b", "/temp/c"]}
  ]
}
```

Re-open Atom with no arguments. Verify that:

- [x] The original windows are restored, and
- [x] Focus is on the window containing `/temp/b` and `/temp/c`.

Make changes to the file `/temp/b/2.md` and don't save them. Quit Atom.

Delete the `/temp/c` directory:

```sh
rm -r /temp/c
```

Open Atom with no arguments. Verify:

- [x] One window is opened containing `/temp/a`.
- [x] Another window is opened containing `/temp/b`.
- [x] A notification appears in the window containing `/temp/b` indicating that `/temp/c` no longer exists.
- [x] A buffer is open in the window containing `/temp/b` on the file `/temp/b/2.md` and it includes your unsaved changes.

### Release Notes

* After opening Atom with a file path and quitting, re-opening Atom no longer displays an incorrect error stating that the file could not be found.