### PR TITLE
⬆️ electron-link@0.4.0

### DIFF
--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -1733,29 +1733,30 @@
       }
     },
     "electron-link": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/electron-link/-/electron-link-0.3.3.tgz",
-      "integrity": "sha512-dxFY3o3E9kBkOyfaY66PWabK1AL5Re8qmy2Abz2/VhVkp2KtvUn6BZODTm9XpC0REgWxlQfRyHlNTlXRBPrWCQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/electron-link/-/electron-link-0.4.0.tgz",
+      "integrity": "sha512-zhc74EBUj5LnaGCCZY2McC/6EkZa/5+nnDucGQGyC+umIaCmxPAl/Ptyvg6YwJLMYj1VAdyqngIPC2x6nXXOEg==",
       "requires": {
+        "acorn": "^6.1.1",
         "ast-util": "^0.6.0",
         "encoding-down": "~5.0.0",
         "indent-string": "^3.2.0",
         "leveldown": "~4.0.0",
         "levelup": "~3.0.0",
-        "recast": "^0.12.6",
+        "recast": "^0.17.5",
         "resolve": "^1.5.0",
         "source-map": "^0.5.6"
       },
       "dependencies": {
-        "ast-types": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
-          "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
         },
-        "core-js": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+        "ast-types": {
+          "version": "0.12.3",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.3.tgz",
+          "integrity": "sha512-wJUcAfrdW+IgDoMGNz5MmcvahKgB7BwIbLupdKVVHxHNYt+HVR2k35swdYNv9aZpF8nvlkjbnkp2rrNwxGckZA=="
         },
         "esprima": {
           "version": "4.0.1",
@@ -1768,14 +1769,13 @@
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
         },
         "recast": {
-          "version": "0.12.9",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.9.tgz",
-          "integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
+          "version": "0.17.5",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.17.5.tgz",
+          "integrity": "sha512-K+DgfAMIyEjNKjaFSWgg9TTu7wFgU/4KTyw4E9vl6M5QPDuUYbyt49Yzb0EIDbZks+6lXk/UZ9eTuE4jlLyf2A==",
           "requires": {
-            "ast-types": "0.10.1",
-            "core-js": "^2.4.1",
+            "ast-types": "0.12.3",
             "esprima": "~4.0.0",
-            "private": "~0.1.5",
+            "private": "^0.1.8",
             "source-map": "~0.6.1"
           },
           "dependencies": {

--- a/script/package.json
+++ b/script/package.json
@@ -10,7 +10,7 @@
     "colors": "1.1.2",
     "donna": "1.0.16",
     "electron-chromedriver": "~2.0",
-    "electron-link": "0.3.3",
+    "electron-link": "0.4.0",
     "electron-mksnapshot": "~2.0",
     "electron-packager": "7.3.0",
     "electron-winstaller": "2.6.4",


### PR DESCRIPTION
This version adds support for ecmaScript 9th edition features (like rest destructuring).

This will unblock https://github.com/atom/atom/pull/19209

----

*List of changes between `electron-link@0.3.3` and `markdown-preview@0.4.0`: https://github.com/atom/electron-link/compare/v0.3.3...v0.4.0*