### PR TITLE
Skip dev mode windows when choosing an existing window for an open action

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -675,6 +675,18 @@ describe('AtomApplication', function () {
       assert.isNull(w._locations[0].initialLine)
       assert.isNull(w._locations[0].initialColumn)
     })
+
+    it('disregards test and benchmark windows', async function () {
+      await scenario.launch(parseCommandLine(['--test', 'b']))
+      await scenario.open(parseCommandLine(['--new-window']))
+      await scenario.open(parseCommandLine(['--test', 'c']))
+      await scenario.open(parseCommandLine(['--benchmark', 'b']))
+
+      await scenario.open(parseCommandLine(['a/1.md']))
+
+      // Test and benchmark StubWindows are visible as empty editor windows here
+      await scenario.assert('[_ _] [_ 1.md] [_ _] [_ _]')
+    })
   })
 
   if (process.platform === 'darwin' || process.platform === 'win32') {

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -866,6 +866,7 @@ class AtomApplication extends EventEmitter {
   // Returns the {AtomWindow} for the given locations.
   windowForLocations (locationsToOpen, devMode, safeMode) {
     return this.getLastFocusedWindow(window =>
+      !window.isSpec &&
       window.devMode === devMode &&
       window.safeMode === safeMode &&
       window.containsLocations(locationsToOpen)
@@ -1021,13 +1022,13 @@ class AtomApplication extends EventEmitter {
       // focused window that matches the requested dev and safe modes.
       if (!existingWindow && addToLastWindow) {
         existingWindow = this.getLastFocusedWindow(win => {
-          return win.devMode === devMode && win.safeMode === safeMode
+          return !win.isSpec && win.devMode === devMode && win.safeMode === safeMode
         })
       }
 
       // Fall back to the last focused window that has no project roots.
       if (!existingWindow) {
-        existingWindow = this.getLastFocusedWindow(win => !win.hasProjectPaths())
+        existingWindow = this.getLastFocusedWindow(win => !win.isSpec && !win.hasProjectPaths())
       }
 
       // One last case: if *no* paths are directories, add to the last focused window.
@@ -1035,7 +1036,7 @@ class AtomApplication extends EventEmitter {
         const noDirectories = locationsToOpen.every(location => !location.isDirectory)
         if (noDirectories) {
           existingWindow = this.getLastFocusedWindow(win => {
-            return win.devMode === devMode && win.safeMode === safeMode
+            return !win.isSpec && win.devMode === devMode && win.safeMode === safeMode
           })
         }
       }


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Fixes #19223, and an adjacent fault related to the same thing happening with benchmark windows.

### Description of the Change

Check `isSpec` on candidate windows when locating an existing window to open paths in.

### Alternate Designs

Rather than filtering out spec windows, I thought about flagging editor windows and adding a positive check instead. That way we'd be insulated against the addition of other new window types that shouldn't receive paths. This felt less invasive, though, and adding new window types is very rare.

### Possible Drawbacks

_N/A_

### Verification Process

- [x] Add a unit test and get it to pass.
- [x] Open an editor window and the spec runner in a dev build of Atom. Focus the spec runner, then run an `atom a/1.md` command on the command line. The non-spec window should be focused and the path added to it.

### Release Notes

* Test and benchmark runner windows are no longer considered for opening paths.