### PR TITLE
Use async randomBytes API to speedup Windows startup

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -751,7 +751,7 @@ describe('AtomApplication', function () {
         options.version = version
 
         const app = scenario.addApplication(options)
-        await app.listenForArgumentsFromNewProcess()
+        await app.listenForArgumentsFromNewProcess(options)
         await app.launch(options)
         return app
       }
@@ -759,7 +759,7 @@ describe('AtomApplication', function () {
 
     it('creates a new application when no socket is present', async function () {
       const app0 = await AtomApplication.open({createApplication, version})
-      app0.deleteSocketSecretFile()
+      await app0.deleteSocketSecretFile()
 
       const app1 = await AtomApplication.open({createApplication, version})
       assert.isNotNull(app1)


### PR DESCRIPTION
This PR changes a bit the logic of `atom-application` to make the authentication through sockets async, which fixes https://github.com/atom/atom/issues/19239.

In order to make the code async and keep it as robust as possible a few changes needed to be done (basically to delay the execution of some logic while avoiding as much as possible potential race conditions).