### PR TITLE
Avoid AppVeyor build failures due to problem uploading JUnit XML

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,6 @@ environment:
     ATOM_DEV_RESOURCE_PATH: c:\projects\atom
     ATOM_JASMINE_REPORTER: list
     CI: true
-    TEST_JUNIT_XML_ROOT: c:\projects\junit-test-results
     NODE_VERSION: 8.9.3
 
   matrix:
@@ -35,7 +34,6 @@ matrix:
       TASK: test
 
 install:
-  - IF NOT EXIST %TEST_JUNIT_XML_ROOT% MKDIR %TEST_JUNIT_XML_ROOT%
   - SET PATH=C:\Program Files\Atom\resources\cli;%PATH%
   - ps: Install-Product node $env:NODE_VERSION $env:PLATFORM
   - npm install --global npm@6.2.0
@@ -95,14 +93,3 @@ cache:
   - '%APPVEYOR_BUILD_FOLDER%\electron'
   - '%USERPROFILE%\.atom\.apm'
   - '%USERPROFILE%\.atom\compile-cache'
-
-on_finish:
-  - ps: |
-      $wc = New-Object 'System.Net.WebClient'
-      $endpoint = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
-      Write-Output "Searching for JUnit XML output beneath $($env:TEST_JUNIT_XML_ROOT)"
-      Get-ChildItem -Path $env:TEST_JUNIT_XML_ROOT -Recurse -File -Name -Include "*.xml" | ForEach-Object {
-        $full = "$($env:TEST_JUNIT_XML_ROOT)\$($_)"
-        Write-Output "Uploading JUnit XML file $($full)"
-        $wc.UploadFile($endpoint, $full)
-      }


### PR DESCRIPTION
Closes #18994

### Description of the Change
As seen in #18994, our AppVeyor builds periodically fail due to problems uploading the JUnit XML output. Since we already have JUnit XML output for all of our builds on Azure DevOps, and since we want to retire AppVeyor and move to Azure DevOps, it seems pragmatic to resolve this issue by removing the JUnit XML processing from the AppVeyor build. This pull request currently takes this approach to resolving #18994.

### Alternate Designs
We could enhance the [uploading logic](https://github.com/atom/atom/blob/27ff10409f467f6b95d322da12de514cab3c9db5/appveyor.yml#L101-L108) to gracefully ignore errors that occur during upload and/or retry the upload when it fails. However, since we're hoping to migrate off of AppVeyor, this doesn't feel like a particularly productive endeavor.

### Possible Drawbacks
When a test fails on AppVeyor, developers will need to look for the test failure in the build log ([screenshot](https://user-images.githubusercontent.com/2988/56991382-7f1d3400-6b65-11e9-8985-f6e40e2e8770.png)) instead of finding it on the "Tests" tab ([screenshot](https://user-images.githubusercontent.com/2988/56991383-7f1d3400-6b65-11e9-9c9f-bb15ff9d6e13.png)).

### Verification Process
- [x] Verify that Azure DevOps has offers the JUnit XML goodies for all platforms -- https://github.com/atom/atom/pull/19243#issuecomment-488107339
- [x] Ensure that the AppVeyor build still passes and that you can still see all the build output in the AppVeyor log
