### PR TITLE
Always use target window for drag-and-drop

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -803,22 +803,23 @@ describe('AtomApplication', function () {
     // This is the IPC message used to handle:
     // * application:reopen-project
     // * choosing "open in new window" when adding a folder that has previously saved state
+    // * drag and drop
     // * deprecated call links in deprecation-cop
     // * other direct callers of `atom.open()`
     it('"open" opens a fixed path by the standard opening rules', async function () {
       sinon.stub(app, 'atomWindowForEvent', () => w1)
 
-      electron.ipcMain.emit('open', {}, {pathsToOpen: scenario.convertEditorPath('a/1.md')})
+      electron.ipcMain.emit('open', {}, {pathsToOpen: [scenario.convertEditorPath('a/1.md')]})
       await app.openPaths.lastCall.returnValue
       await scenario.assert('[a 1.md] [_ _] [b _]')
 
-      electron.ipcMain.emit('open', {}, {pathsToOpen: scenario.convertRootPath('c')})
+      electron.ipcMain.emit('open', {}, {pathsToOpen: [scenario.convertRootPath('c')]})
       await app.openPaths.lastCall.returnValue
       await scenario.assert('[a 1.md] [c _] [b _]')
 
-      electron.ipcMain.emit('open', {}, {pathsToOpen: scenario.convertRootPath('d')})
+      electron.ipcMain.emit('open', {}, {pathsToOpen: [scenario.convertRootPath('d')], here: true})
       await app.openPaths.lastCall.returnValue
-      await scenario.assert('[a 1.md] [c _] [b _] [d _]')
+      await scenario.assert('[a 1.md] [c,d _] [b _]')
     })
 
     it('"open-chosen-any" opens a file in the sending window', async function () {

--- a/spec/pane-element-spec.coffee
+++ b/spec/pane-element-spec.coffee
@@ -263,7 +263,7 @@ describe "PaneElement", ->
         event = buildDragEvent("drop", [{path: "/fake1"}, {path: "/fake2"}])
         paneElement.dispatchEvent(event)
         expect(atom.applicationDelegate.open.callCount).toBe 1
-        expect(atom.applicationDelegate.open.argsForCall[0][0]).toEqual pathsToOpen: ['/fake1', '/fake2']
+        expect(atom.applicationDelegate.open.argsForCall[0][0]).toEqual pathsToOpen: ['/fake1', '/fake2'], here: true
 
     describe "when a non-file is dragged to the pane", ->
       it "does nothing", ->

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -637,10 +637,14 @@ class AtomApplication extends EventEmitter {
 
     // A request from the associated render process to open a set of paths using the standard window location logic.
     // Used for application:reopen-project.
-    this.disposable.add(ipcHelpers.on(ipcMain, 'open', (_event, options) => {
+    this.disposable.add(ipcHelpers.on(ipcMain, 'open', (event, options) => {
       if (options) {
         if (typeof options.pathsToOpen === 'string') {
           options.pathsToOpen = [options.pathsToOpen]
+        }
+
+        if (options.here) {
+          options.window = this.atomWindowForEvent(event)
         }
 
         if (options.pathsToOpen && options.pathsToOpen.length > 0) {

--- a/src/pane-element.js
+++ b/src/pane-element.js
@@ -62,7 +62,7 @@ class PaneElement extends HTMLElement {
       this.getModel().activate()
       const pathsToOpen = [...event.dataTransfer.files].map(file => file.path)
       if (pathsToOpen.length > 0) {
-        this.applicationDelegate.open({pathsToOpen})
+        this.applicationDelegate.open({pathsToOpen, here: true})
       }
     }
     this.addEventListener('focus', handleFocus, true)


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Fixes #19240.

### Description of the Change

Enhance the "open" IPC message understood by `AtomApplication` to understand a boolean `here` option. If set to a truthy value, the originating window of the IPC message will be used as a destination for opened paths. Set `{here: true}` in the "open" message sent from PaneElement in response to a drag-and-drop event. This will cause _all_ files you drag-and-drop to be opened in the window you dragged them onto.

### Alternate Designs

I could have added a new IPC message and handler for the "always open in sending window" case, like "open-here". I opted to modify the existing "open" handler instead because it will still do an open action with the dropped paths even if the originating window can't be found for whatever reason - if you drag-and-drop onto a window that's closing or something.

### Possible Drawbacks

It introduces additional complexity to the "open" handler.

### Verification Process

Open an Atom window in dev mode:

```
atom -d -f .
```

Drag and drop any file onto the window. Before this change, the dragged file is opened in a new window; after this change, it's opened in the existing window.

### Release Notes

* Dragging and dropping files onto a dev- or safe-mode window will open the dropped files in that window instead of opening a new one.