### PR TITLE
Add async into package.json and bump async in package-lock.json to 2.6.2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,10 @@
           "version": "0.2.0",
           "bundled": true
         },
+          "async": {
+          "version": "2.6.2",
+          "bundled": true
+        },
         "asynckit": {
           "version": "0.4.0",
           "bundled": true

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@atom/watcher": "1.3.1",
     "about": "file:packages/about",
     "archive-view": "https://www.atom.io/api/packages/archive-view/versions/0.65.1/tarball",
-    "async": "0.2.6",
+    "async": "2.6.2",
     "atom-dark-syntax": "file:packages/atom-dark-syntax",
     "atom-dark-ui": "file:packages/atom-dark-ui",
     "atom-keymap": "8.2.13",


### PR DESCRIPTION
### Description of the Change



Async is a utility module which provides straight-forward, powerful functions for working with asynchronous JavaScript. Although originally designed for use with Node.js and installable via npm install --save async, it can also be used directly in the browser.

This version of the package is optimized for the Node.js environment. If you use Async with webpack, install async-es instead.



### Quantitative Performance Benefits

Add powerful functions working with nodejs, with huge support backing it.

### Possible Drawbacks

Possible side-effects include more commands to deal with. Negative impacts include more possible failures.

### Verification Process
I ran all supported commands for async, with many passes and 1 failure.

### Applicable Issues

No applicable issues.

### Release Notes

You can now use lots of packages bundled in async + have more support for different real-life scenarios that involve async.
