### PR TITLE
Increase the timeout for the FileRecoveryService tests

### DIFF
--- a/spec/main-process/file-recovery-service.test.js
+++ b/spec/main-process/file-recovery-service.test.js
@@ -8,8 +8,10 @@ const sinon = require('sinon')
 const { escapeRegExp } = require('underscore-plus')
 const temp = require('temp').track()
 
-describe('FileRecoveryService', () => {
+describe('FileRecoveryService', function () {
   let recoveryService, recoveryDirectory, spies
+
+  this.timeout(10 * 1000)
 
   beforeEach(() => {
     recoveryDirectory = temp.mkdirSync('atom-spec-file-recovery')


### PR DESCRIPTION
This PR increases the timeout of the `FileRecovery` tests to 10s, so we don't get the weird timeouts that have started occurring on Linux recently.

This fixes https://github.com/atom/atom/issues/19235