### PR TITLE
Add 'it' in front of spec descriptions

### DIFF
--- a/spec/jasmine-list-reporter.js
+++ b/spec/jasmine-list-reporter.js
@@ -2,7 +2,7 @@ const { TerminalReporter } = require('jasmine-tagged')
 
 class JasmineListReporter extends TerminalReporter {
   fullDescription (spec) {
-    let fullDescription = spec.description
+    let fullDescription = 'it ' + spec.description
     let currentSuite = spec.suite
     while (currentSuite) {
       fullDescription = currentSuite.description + ' > ' + fullDescription


### PR DESCRIPTION
`Workspace > when an item is moved > clears the location if it's the default`
should be
`Workspace > when an item is moved > it clears the location if it's the default`