### PR TITLE
Fix atom --dev with JSON config files

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -1096,14 +1096,14 @@ class AtomApplication extends EventEmitter {
       if (devMode) {
         try {
           windowInitializationScript = require.resolve(
-            path.join(this.devResourcePath, 'src', 'initialize-application-window')
+            path.join(this.devResourcePath, 'src', 'initialize-application-window.coffee')
           )
           resourcePath = this.devResourcePath
         } catch (error) {}
       }
 
       if (!windowInitializationScript) {
-        windowInitializationScript = require.resolve('../initialize-application-window')
+        windowInitializationScript = require.resolve('../initialize-application-window.coffee')
       }
       if (!resourcePath) resourcePath = this.resourcePath
       if (!windowDimensions) windowDimensions = this.getDimensionsForNewWindow()


### PR DESCRIPTION
When running `atom --dev` using a local resource path e.g `atom --dev --resource-path /foo` and having a `config.json` file instead of the default `config.cson`, an error used to appear in the command line, preventing Atom from launching:

```
Error: Cannot find module '../initialize-application-window'
    at Module._resolveFilename (module.js:543:15)
    at Function.Module._resolveFilename (/Users/rafeca/github/atom/atom/out/Atom Dev.app/Contents/Resources/electron.asar/common/reset-search-paths.js:35:12)
    at Function.resolve (internal/module.js:18:19)
    at AtomApplication.openPaths (/Users/rafeca/github/atom/atom/src/main-process/atom-application.js:1106:46)
    at <anonymous>
```

This seems to be caused by the require system not handling `coffee` file extensions.

This works when using a `cson` config file because in order to parse that format, the coffeescript compiler needs to be initialized, which probably hooks on the require system to add the `coffee` extension. This PR changes the `require.resolve` to make it non-dependant on the fact that the coffeescript compiler has been loaded.