### PR TITLE
Update bracket-matcher to 0.91.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "autosave": "0.24.6",
     "background-tips": "0.28.0",
     "bookmarks": "0.46.0",
-    "bracket-matcher": "0.90.4",
+    "bracket-matcher": "0.91.0",
     "command-palette": "0.43.5",
     "dalek": "file:./packages/dalek",
     "deprecation-cop": "file:./packages/deprecation-cop",


### PR DESCRIPTION
* atom/bracket-matcher#381: Remove `findEnclosingTags` (fixes #18160)
* atom/bracket-matcher#382: Use package-lock.json for faster installation

[_All changes_](https://github.com/atom/bracket-matcher/compare/v0.90.5...v0.91.0)