### PR TITLE
Improve positioning when opening file at line

### DIFF
--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -888,28 +888,18 @@ describe('Workspace', () => {
         )
       })
 
-      it('unfolds the fold containing the line', () => {
+      it('unfolds the fold containing the line', async () => {
         let editor
 
-        waitsForPromise(() =>
-          workspace.open('../sample-with-many-folds.js')
-        )
+        await workspace.open('../sample-with-many-folds.js')
+        editor = workspace.getActiveTextEditor()
+        editor.foldBufferRow(2)
+        expect(editor.isFoldedAtBufferRow(2)).toBe(true)
+        expect(editor.isFoldedAtBufferRow(3)).toBe(true)
 
-        runs(() => {
-          editor = workspace.getActiveTextEditor()
-          editor.foldBufferRow(2)
-          expect(editor.isFoldedAtBufferRow(2)).toBe(true)
-          expect(editor.isFoldedAtBufferRow(3)).toBe(true)
-        })
-
-        waitsForPromise(() =>
-          workspace.open('../sample-with-many-folds.js', { initialLine: 2 })
-        )
-
-        runs(() => {
-          expect(editor.isFoldedAtBufferRow(2)).toBe(false)
-          expect(editor.isFoldedAtBufferRow(3)).toBe(false)
-        })
+        await workspace.open('../sample-with-many-folds.js', { initialLine: 2 })
+        expect(editor.isFoldedAtBufferRow(2)).toBe(false)
+        expect(editor.isFoldedAtBufferRow(3)).toBe(false)
       })
     })
 

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -887,6 +887,30 @@ describe('Workspace', () => {
           ).toEqual([2, 11])
         )
       })
+
+      it('unfolds the fold containing the line', () => {
+        let editor
+
+        waitsForPromise(() =>
+          workspace.open('../sample-with-many-folds.js')
+        )
+
+        runs(() => {
+          editor = workspace.getActiveTextEditor()
+          editor.foldBufferRow(2)
+          expect(editor.isFoldedAtBufferRow(2)).toBe(true)
+          expect(editor.isFoldedAtBufferRow(3)).toBe(true)
+        })
+
+        waitsForPromise(() =>
+          workspace.open('../sample-with-many-folds.js', { initialLine: 2 })
+        )
+
+        runs(() => {
+          expect(editor.isFoldedAtBufferRow(2)).toBe(false)
+          expect(editor.isFoldedAtBufferRow(3)).toBe(false)
+        })
+      })
     })
 
     describe('when the file size is over the limit defined in `core.warnOnLargeFileLimit`', () => {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1065,6 +1065,9 @@ module.exports = class Workspace extends Model {
         if (typeof item.setCursorBufferPosition === 'function') {
           item.setCursorBufferPosition([initialLine, initialColumn])
         }
+        if (typeof item.unfoldBufferRow === 'function') {
+          item.unfoldBufferRow(initialLine)
+        }
       }
 
       const index = pane.getActiveItemIndex()

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1068,6 +1068,9 @@ module.exports = class Workspace extends Model {
         if (typeof item.unfoldBufferRow === 'function') {
           item.unfoldBufferRow(initialLine)
         }
+        if (typeof item.scrollToBufferPosition === 'function') {
+          item.scrollToBufferPosition([initialLine, initialColumn], { center: true })
+        }
       }
 
       const index = pane.getActiveItemIndex()


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

https://github.com/atom/atom/issues/12253

### Description of the Change

Prior to this change, when you opened a file at a specific line, Atom would scroll to the given line number, but only enough so that the line is visible at the bottom of the editor. #12253 describes the problem with this behavior as follows:

> plugins like JSHint that are displayed at the bottom will cover the desired line number. Therefore, the user still has to scroll the content to view the line number, defeating the entire purpose of this feature.

With the changes in this pull request, when opening a file at a specific line, Atom will:
- Attempt to scroll the editor as needed so that the specified line is **centered vertically**
- If the file is already open and the requested line is hidden by a fold, unfold so that the line is visible

### Alternate Designs
In response to the problem that "plugins like JSHint that are displayed at the bottom will cover the desired line number," #12253 suggests scrolling the requested line to the top of the editor.

We could scroll the line to the top of the editor. However, centering the line vertically also resolves the stated problem. In addition to that, it has a couple advantages over scrolling the line to the top of the editor:

- It's often useful to see a few lines of context above the current line. (For decades, diff tools have made us accustomed to seeing a few lines of context above and below a given line. 😇👴) If we scroll the line to the top of the editor, we lose the context of the preceding lines.
- Centering the line restores Atom's originally-intended behavior, as it existed prior to the regression described in https://github.com/atom/atom/issues/12253#issuecomment-237252806.

### Possible Drawbacks

None that I'm aware of.

### Verification Process

The following steps use a file named [`package.json`](https://github.com/atom/atom/blob/0c51771244ae07ab383a089591788ba2ea9726f3/package.json#L286) as the test file. At the time of this writing, `package.json` contains 285 lines.

- [x] Open the file at a specific line and verify that Atom scrolls to that line
	- [x] `atom package.json:100` - Places cursor on line 100 and centers line 100 vertically in the editor
	- [x] `atom package.json:285`
		- [x] Places cursor on line 285 and centers line 285 vertically in the editor when `editor.scrollPastEnd` is set to `true`
		- [x] Places cursor on line 285 and renders line 285 at bottom of the editor when `editor.scrollPastEnd` is set to `false`
	- [x] `atom package.json:10000`
		- [x] Places cursor on line 285 and centers line 285 vertically in the editor when `editor.scrollPastEnd` is set to `true`
		- [x] Places cursor on line 285 and renders line 285 at bottom of the editor when `editor.scrollPastEnd` is set to `false`
	- [x] `atom package.json:1` - Places cursor on line 1 and renders line 1 at top of editor
- [x] When `package.json` is already open in Atom with the cursor on line 1 and the viewport scrolled so that you can only see lines 250-285, running `atom package.json:100` places cursor on line 100 and centers line 100 vertically in the editor
- [x] When `package.json` is already open in Atom and line 100 is hidden by a fold, running `atom package.json:100` places cursor on line 100, unfolds the fold, and centers line 100 vertically in the editor
- [x] Open file at specific line via URI handler, and verify that Atom scrolls to that line and centers it vertically in the editor (`atom://core/open/file?filename=%2FUsers%2Fme%2Fgithub%2Fatom%2Fpackage.json&line=100`)

### Release Notes

> When opening a file at a specific line number, if Atom needs to scroll down in order to show the requested line, Atom will attempt to center the line vertically in the editor so that you can quickly find the line and see its surrounding context.

### Before and After

#### Before

![before](https://user-images.githubusercontent.com/2988/57260042-f2281e00-702f-11e9-9b6c-7c20bae8b638.gif)

#### After

![after](https://user-images.githubusercontent.com/2988/57260043-f2281e00-702f-11e9-82cb-a02bcff3240d.gif)

