### PR TITLE
Prepare Atom for the electron v3 upgrade

### DIFF
--- a/spec/fixtures/babel/invalid.js
+++ b/spec/fixtures/babel/invalid.js
@@ -1,3 +1,3 @@
 'use 6to6';
 
-module.exports = async function* hello() {}
+export default 42;

--- a/spec/style-manager-spec.js
+++ b/spec/style-manager-spec.js
@@ -57,7 +57,6 @@ describe('StyleManager', () => {
           atom-text-editor::shadow .class-1, atom-text-editor::shadow .class-2 { color: red }
           atom-text-editor::shadow > .class-3 { color: yellow }
           atom-text-editor .class-4 { color: blue }
-          another-element::shadow .class-5 { color: white }
           atom-text-editor[data-grammar*=\"js\"]::shadow .class-6 { color: green; }
           atom-text-editor[mini].is-focused::shadow .class-7 { color: green; }
         `)
@@ -69,7 +68,6 @@ describe('StyleManager', () => {
           'atom-text-editor.editor .class-1, atom-text-editor.editor .class-2',
           'atom-text-editor.editor > .class-3',
           'atom-text-editor .class-4',
-          'another-element::shadow .class-5',
           'atom-text-editor[data-grammar*="js"].editor .class-6',
           'atom-text-editor[mini].is-focused.editor .class-7'
         ])
@@ -134,13 +132,6 @@ describe('StyleManager', () => {
             r => r.selectorText
           )
         ).toEqual(['atom-text-editor .class-1, atom-text-editor .class-2'])
-      })
-
-      it('does not transform CSS rules with invalid syntax', () => {
-        styleManager.addStyleSheet("atom-text-editor::shadow .class-1 { font-family: inval'id }")
-        expect(Array.from(styleManager.getStyleElements()[0].sheet.cssRules).map((r) => r.selectorText)).toEqual([
-          'atom-text-editor::shadow .class-1'
-        ])
       })
 
       it('does not throw exceptions on rules with no selectors', () => {

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2511,7 +2511,7 @@ describe('Workspace', () => {
           })
 
           runs(() => {
-            fs.rename(
+            fs.renameSync(
               path.join(projectPath, 'git.git'),
               path.join(projectPath, '.git')
             )

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -177,7 +177,7 @@ exports.install = function (resourcesPath, nodeRequire) {
       var rawData = sourceMappingURL.slice(sourceMappingURL.indexOf(',') + 1)
 
       try {
-        var sourceMap = JSON.parse(new Buffer(rawData, 'base64'))
+        var sourceMap = JSON.parse(Buffer.from(rawData, 'base64'))
       } catch (error) {
         console.warn('Error parsing source map', error.stack)
         return null

--- a/src/file-system-blob-store.js
+++ b/src/file-system-blob-store.js
@@ -20,7 +20,7 @@ class FileSystemBlobStore {
 
   reset () {
     this.inMemoryBlobs = new Map()
-    this.storedBlob = new Buffer(0)
+    this.storedBlob = Buffer.alloc(0)
     this.storedBlobMap = {}
     this.usedKeys = new Set()
   }


### PR DESCRIPTION
This PR cherry picks a subset of the commits found in https://github.com/atom/atom/pull/18603 that can be easily added to `master` now before we do the actual migration to electron v3.
