### PR TITLE
Decaffeinate src/initialize-application-window.js

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -598,7 +598,7 @@ describe('AtomApplication', function () {
           assert.notStrictEqual(uw, w0)
           assert.strictEqual(
             uw.loadSettings.windowInitializationScript,
-            path.resolve(__dirname, '../../src/initialize-application-window.coffee')
+            path.resolve(__dirname, '../../src/initialize-application-window.js')
           )
 
           uw.emit('window:loaded')

--- a/src/initialize-application-window.js
+++ b/src/initialize-application-window.js
@@ -1,14 +1,15 @@
-AtomEnvironment = require './atom-environment'
-ApplicationDelegate = require './application-delegate'
-Clipboard = require './clipboard'
-TextEditor = require './text-editor'
-TextEditorComponent = require './text-editor-component'
-FileSystemBlobStore = require './file-system-blob-store'
-NativeCompileCache = require './native-compile-cache'
-CompileCache = require './compile-cache'
-ModuleCache = require './module-cache'
+const AtomEnvironment = require('./atom-environment')
+const ApplicationDelegate = require('./application-delegate')
+const Clipboard = require('./clipboard')
+const TextEditor = require('./text-editor')
 
-if global.isGeneratingSnapshot
+require('./text-editor-component')
+require('./file-system-blob-store')
+require('./native-compile-cache')
+require('./compile-cache')
+require('./module-cache')
+
+if (global.isGeneratingSnapshot) {
   require('about')
   require('archive-view')
   require('autocomplete-atom-api')
@@ -61,50 +62,57 @@ if global.isGeneratingSnapshot
   require('welcome')
   require('whitespace')
   require('wrap-guide')
+}
 
-clipboard = new Clipboard
+const clipboard = new Clipboard()
 TextEditor.setClipboard(clipboard)
-TextEditor.viewForItem = (item) -> atom.views.getView(item)
+TextEditor.viewForItem = item => atom.views.getView(item)
 
 global.atom = new AtomEnvironment({
   clipboard,
-  applicationDelegate: new ApplicationDelegate,
+  applicationDelegate: new ApplicationDelegate(),
   enablePersistence: true
 })
 
 TextEditor.setScheduler(global.atom.views)
 global.atom.preloadPackages()
 
-# Like sands through the hourglass, so are the days of our lives.
-module.exports = ({blobStore}) ->
-  {updateProcessEnv} = require('./update-process-env')
-  path = require 'path'
-  require './window'
-  getWindowLoadSettings = require './get-window-load-settings'
-  {ipcRenderer} = require 'electron'
-  {resourcePath, devMode, env} = getWindowLoadSettings()
-  require './electron-shims'
+// Like sands through the hourglass, so are the days of our lives.
+module.exports = function ({ blobStore }) {
+  const { updateProcessEnv } = require('./update-process-env')
+  const path = require('path')
+  require('./window')
+  const getWindowLoadSettings = require('./get-window-load-settings')
+  const { ipcRenderer } = require('electron')
+  const { resourcePath, devMode } = getWindowLoadSettings()
+  require('./electron-shims')
 
-  # Add application-specific exports to module search path.
-  exportsPath = path.join(resourcePath, 'exports')
+  // Add application-specific exports to module search path.
+  const exportsPath = path.join(resourcePath, 'exports')
   require('module').globalPaths.push(exportsPath)
   process.env.NODE_PATH = exportsPath
 
-  # Make React faster
-  process.env.NODE_ENV ?= 'production' unless devMode
+  // Make React faster
+  if (!devMode && process.env.NODE_ENV == null) {
+    process.env.NODE_ENV = 'production'
+  }
 
   global.atom.initialize({
-    window, document, blobStore,
+    window,
+    document,
+    blobStore,
     configDirPath: process.env.ATOM_HOME,
     env: process.env
   })
 
-  global.atom.startEditorWindow().then ->
-    # Workaround for focus getting cleared upon window creation
-    windowFocused = ->
+  return global.atom.startEditorWindow().then(function () {
+    // Workaround for focus getting cleared upon window creation
+    const windowFocused = function () {
       window.removeEventListener('focus', windowFocused)
-      setTimeout (-> document.querySelector('atom-workspace').focus()), 0
+      setTimeout(() => document.querySelector('atom-workspace').focus(), 0)
+    }
     window.addEventListener('focus', windowFocused)
-    ipcRenderer.on('environment', (event, env) ->
-      updateProcessEnv(env)
-    )
+
+    ipcRenderer.on('environment', (event, env) => updateProcessEnv(env))
+  })
+}

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -1096,14 +1096,14 @@ class AtomApplication extends EventEmitter {
       if (devMode) {
         try {
           windowInitializationScript = require.resolve(
-            path.join(this.devResourcePath, 'src', 'initialize-application-window.coffee')
+            path.join(this.devResourcePath, 'src', 'initialize-application-window')
           )
           resourcePath = this.devResourcePath
         } catch (error) {}
       }
 
       if (!windowInitializationScript) {
-        windowInitializationScript = require.resolve('../initialize-application-window.coffee')
+        windowInitializationScript = require.resolve('../initialize-application-window')
       }
       if (!resourcePath) resourcePath = this.resourcePath
       if (!windowDimensions) windowDimensions = this.getDimensionsForNewWindow()


### PR DESCRIPTION
After merging https://github.com/atom/atom/pull/19270 we realized that it broke nightly builds because when using asar archives the coffeescript files get transpiled to js and renamed, so the resolution does not work anymore.

The easiest and cleanest way to fix this is by decaffeinating this file, so it always has the `js` extension (it's a short and relatively simple file to decaffeinate).