### PR TITLE
Fix atom.open() when it has no arguments

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -822,6 +822,13 @@ describe('AtomApplication', function () {
       await scenario.assert('[a 1.md] [c,d _] [b _]')
     })
 
+    it('"open" without any option open the prompt for selecting a path', async function () {
+      sinon.stub(app, 'atomWindowForEvent', () => w1)
+
+      electron.ipcMain.emit('open', {})
+      assert.strictEqual(app.promptForPath.lastCall.args[0], 'all')
+    })
+
     it('"open-chosen-any" opens a file in the sending window', async function () {
       sinon.stub(app, 'atomWindowForEvent', () => w2)
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -688,7 +688,7 @@ class AtomApplication extends EventEmitter {
           this.addWindow(this.createWindow(options))
         }
       } else {
-        this.promptForPathToOpen('all', {window})
+        this.promptForPathToOpen('all', {})
       }
     }))
 


### PR DESCRIPTION
This fixes https://github.com/atom/atom/issues/19265. The root cause was an undefined variable (`window`).

Not passing any `window` object to `promptForPathToOpen()` seems to work correctly (at least on OSX).