### PR TITLE
Add markers for more granular logging of startup time

### DIFF
--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -69,7 +69,10 @@ module.exports = function (packagedAppPath) {
         requiredModuleRelativePath === path.join('..', 'node_modules', 'tree-sitter', 'index.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'yauzl', 'index.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'winreg', 'lib', 'registry.js') ||
-        requiredModuleRelativePath === path.join('..', 'node_modules', '@atom', 'fuzzy-native', 'lib', 'main.js')
+        requiredModuleRelativePath === path.join('..', 'node_modules', '@atom', 'fuzzy-native', 'lib', 'main.js') ||
+        // The startup-time script is used by both the renderer and the main process and having it in the
+        // snapshot causes issues.
+        requiredModuleRelativePath === path.join('..', 'src', 'startup-time.js')
       )
     }
   }).then(({snapshotScript}) => {

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -6,6 +6,7 @@ const StorageFolder = require('../storage-folder')
 const Config = require('../config')
 const ConfigFile = require('../config-file')
 const FileRecoveryService = require('./file-recovery-service')
+const StartupTime = require('../startup-time')
 const ipcHelpers = require('../ipc-helpers')
 const {BrowserWindow, Menu, app, clipboard, dialog, ipcMain, shell, screen} = require('electron')
 const {CompositeDisposable, Disposable} = require('event-kit')
@@ -135,6 +136,8 @@ module.exports =
 class AtomApplication extends EventEmitter {
   // Public: The entry point into the Atom application.
   static open (options) {
+    StartupTime.addMarker('main-process:atom-application:open')
+
     const socketSecret = getExistingSocketSecret(options.version)
     const socketPath = getSocketPath(socketSecret)
     const createApplication = options.createApplication || (async () => {
@@ -172,6 +175,8 @@ class AtomApplication extends EventEmitter {
   }
 
   constructor (options) {
+    StartupTime.addMarker('main-process:atom-application:constructor:start')
+
     super()
     this.quitting = false
     this.quittingForUpdate = false
@@ -214,6 +219,8 @@ class AtomApplication extends EventEmitter {
 
     this.disposable = new CompositeDisposable()
     this.handleEvents()
+
+    StartupTime.addMarker('main-process:atom-application:constructor:end')
   }
 
   // This stuff was previously done in the constructor, but we want to be able to construct this object
@@ -221,6 +228,8 @@ class AtomApplication extends EventEmitter {
   // of these various sub-objects into the constructor, but you'll need to remove the side-effects they
   // perform during their construction, adding an initialize method that you call here.
   async initialize (options) {
+    StartupTime.addMarker('main-process:atom-application:initialize:start')
+
     global.atomApplication = this
 
     // DEPRECATED: This can be removed at some point (added in 1.13)
@@ -245,6 +254,8 @@ class AtomApplication extends EventEmitter {
     const result = await this.launch(options)
     this.autoUpdateManager.initialize()
     await socketServerPromise
+
+    StartupTime.addMarker('main-process:atom-application:initialize:end')
 
     return result
   }
@@ -1084,6 +1095,7 @@ class AtomApplication extends EventEmitter {
     let openedWindow
     if (existingWindow) {
       openedWindow = existingWindow
+      StartupTime.addMarker('main-process:atom-application:open-in-existing')
       openedWindow.openLocations(locationsToOpen)
       if (openedWindow.isMinimized()) {
         openedWindow.restore()
@@ -1108,6 +1120,7 @@ class AtomApplication extends EventEmitter {
       if (!resourcePath) resourcePath = this.resourcePath
       if (!windowDimensions) windowDimensions = this.getDimensionsForNewWindow()
 
+      StartupTime.addMarker('main-process:atom-application:create-window')
       openedWindow = this.createWindow({
         locationsToOpen,
         windowInitializationScript,

--- a/src/main-process/main.js
+++ b/src/main-process/main.js
@@ -3,6 +3,8 @@ if (typeof snapshotResult !== 'undefined') {
 }
 
 const startTime = Date.now()
+const StartupTime = require('../startup-time')
+StartupTime.setStartTime()
 
 const path = require('path')
 const fs = require('fs-plus')

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -8,9 +8,13 @@ const atomPaths = require('../atom-paths')
 const fs = require('fs')
 const CSON = require('season')
 const Config = require('../config')
+const StartupTime = require('../startup-time')
+
+StartupTime.setStartTime()
 
 module.exports = function start (resourcePath, devResourcePath, startTime) {
   global.shellStartTime = startTime
+  StartupTime.addMarker('main-process:start')
 
   process.on('uncaughtException', function (error = {}) {
     if (error.message != null) {
@@ -85,7 +89,9 @@ module.exports = function start (resourcePath, devResourcePath, startTime) {
     app.setPath('userData', temp.mkdirSync('atom-test-data'))
   }
 
+  StartupTime.addMarker('main-process:electron-onready:start')
   app.on('ready', function () {
+    StartupTime.addMarker('main-process:electron-onready:end')
     app.removeListener('open-file', addPathToOpen)
     app.removeListener('open-url', addUrlToOpen)
     const AtomApplication = require(path.join(args.resourcePath, 'src', 'main-process', 'atom-application'))

--- a/src/startup-time.js
+++ b/src/startup-time.js
@@ -1,0 +1,33 @@
+let startTime
+let markers = []
+
+module.exports = {
+  setStartTime () {
+    if (!startTime) {
+      startTime = Date.now()
+    }
+  },
+  addMarker (label, dateTime) {
+    if (!startTime) {
+      return
+    }
+
+    dateTime = dateTime || Date.now()
+    markers.push({label, time: dateTime - startTime})
+  },
+  importData (data) {
+    startTime = data.startTime
+    markers = data.markers
+  },
+  exportData () {
+    if (!startTime) {
+      return undefined
+    }
+
+    return { startTime, markers }
+  },
+  deleteData () {
+    startTime = undefined
+    markers = []
+  }
+}


### PR DESCRIPTION
## Context

Currently we're only logging two measures to give us information about the startup performance of Atom: the shell load time and the core load time.

They have been useful to identify performance regressions so far, but they are not enough to debug potential bottlenecks in Atom startup in real-life conditions.

## Summary of changes

This PR aims to give us much more granular data about the startup performance of Atom by doing two things:
* Allowing us to create arbitrary markers at any point during the startup of Atom which will get logged via the `metrics` package.
* Unifying the startup time taken by the main process and the renderer process by allowing to create markers anywhere.

As an example, with this PR these are the markers created during the startup of Atom (the ones happening in the main process are prepended by `main-process:` and the ones happening in the renderer process start with `window:`):

```json
{
  "startTime":1557502272939,
  "markers":[
    {
      "label":"main-process:start",
      "time":0
    },
    {
      "label":"main-process:electron-onready:start",
      "time":51
    },
    {
      "label":"main-process:electron-onready:end",
      "time":252
    },
    {
      "label":"main-process:atom-application:open",
      "time":324
    },
    {
      "label":"main-process:atom-application:constructor:start",
      "time":324
    },
    {
      "label":"main-process:atom-application:constructor:end",
      "time":329
    },
    {
      "label":"main-process:atom-application:initialize:start",
      "time":329
    },
    {
      "label":"main-process:atom-application:create-window",
      "time":446
    },
    {
      "label":"main-process:atom-window:start",
      "time":447
    },
    {
      "label":"main-process:atom-window:end",
      "time":463
    },
    {
      "label":"main-process:atom-application:initialize:end",
      "time":480
    },
    {
      "label":"window:start",
      "time":687
    },
    {
      "label":"window:onload:start",
      "time":693
    },
    {
      "label":"window:setup-window:start",
      "time":729
    },
    {
      "label":"window:initialize:start",
      "time":1156
    },
    {
      "label":"window:environment:start-editor-window:start",
      "time":1197
    },
    {
      "label":"window:onload:end",
      "time":1198
    },
    {
      "label":"window:environment:start-editor-window:display-window",
      "time":1206
    },
    {
      "label":"window:environment:start-editor-window:load-packages",
      "time":1445
    },
    {
      "label":"window:environment:start-editor-window:deserialize-state",
      "time":1598
    },
    {
      "label":"window:environment:start-editor-window:activate-packages",
      "time":3222
    },
    {
      "label":"window:environment:start-editor-window:open-editor",
      "time":3862
    },
    {
      "label":"window:environment:start-editor-window:end",
      "time":3893
    },
    {
      "label":"window:initialize:end",
      "time":3894
    },
    {
      "label":"window:setup-window:end",
      "time":3894
    }
  ]
}
```

### Verification steps

- [ ] Check that the markers get correctly created when opening a new Atom window from scratch.
- [ ] Check that markers do not get created under the following conditions:
  - [ ] When refreshing the Atom window
  - [ ] When opening a new window via Open new WIndow"
  - [ ] When opening a new window via Re-open project"
  - [ ] When running `atom` CLI on a different path (which opens a new window).

### Next steps

- [ ] Create some automated tests.