### PR TITLE
[WSL] Remove $root from $PWD when setting $ATOMCMD

### DIFF
--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -3,6 +3,9 @@
 if command -v "cygpath" > /dev/null; then
   # We have cygpath to do the conversion
   ATOMCMD=$(cygpath "$(dirname "$0")/atom.cmd" -a -w)
+elif command -v "wslpath" > /dev/null; then
+  # We have wslpath to do the conversion
+  ATOMCMD=$(wslpath -aw "$(dirname "$0")/atom.cmd")
 else
   pushd "$(dirname "$0")" > /dev/null
   if [[ $(uname -r) == *-Microsoft ]]; then

--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -10,8 +10,7 @@ else
     root="/mnt/"
     # If different root mount point defined in /etc/wsl.conf, use that instead
     eval $(grep "^root" /etc/wsl.conf | sed -e "s/ //g")
-    root="$(echo $root | sed 's|/|\\/|g')"
-    ATOMCMD="$(echo $PWD | sed 's/\/mnt\/\([a-z]*\)\(.*\)/\1:\2/')/atom.cmd"
+    ATOMCMD="$(echo ${PWD#$root} | sed 's/\([a-z]*\)\(.*\)/\1:\2/')/atom.cmd"
     ATOMCMD="${ATOMCMD////\\}"
   else
     # We don't have cygpath or WSL so try pwd -W


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

This PR fixes https://github.com/atom/atom/issues/19317.

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/atom/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

### Description of the Change

To launch Atom from Linux command line on WSL, we'll need to tell cmd.exe the path to the launcher script. We calculate that path as $ATOMCMD. Here's where we check for custom WSL root, and then set $ATOMCMD:

https://github.com/atom/atom/blob/c5ebfbddd096a24bb99b832432a5dfcd67da4714/resources/win/atom.sh#L8-L15

Comparing the current and proposed methods of setting $ATOMCMD, on Ubuntu 18.04.2 on WSL...

```
$ # Using a non-default root, / instead of /mnt/.
$ eval $(grep "^root" /etc/wsl.conf | sed -e "s/ //g")
$ echo $root
/

$ # Current method does not translate non-default root.
$ echo $PWD | sed 's/\/mnt\/\([a-z]*\)\(.*\)/\1:\2/'
/c/Users/Solvaholic/AppData/Local/atom/app-1.36.1/resources/cli

$ # Proposed method removes $root from translation.
$ echo ${PWD#$root} | sed 's/\([a-z]*\)\(.*\)/\1:\2/'
c:/Users/Solvaholic/AppData/Local/atom/app-1.36.1/resources/cli
```

https://github.com/atom/atom/issues/18702 / https://github.com/atom/atom/pull/18703 and https://github.com/atom/atom/issues/18126 address related issues.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

I've tried using aliases to hack around this, but I had trouble keeping up with them on fresh installs or when things changed.

Users who keep the default WSL root `/mnt/` will not experience the problem this change solves. I moved my WSL root to `/` because it's intuitive to me and fits my preferred usage of `/mnt` as an ephemeral mountpoint.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

Different WSL environments and user configurations may use and handle paths in such a way this proposed solution will lead to other issues.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

I replaced my installation's `resources/cli/atom.sh` with a copy of the proposed `resources/win/atom.sh`, and ran `atom` from my Ubuntu app.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

Fixed launching Atom from Linux / WSL command line in Windows 10.

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
