### PR TITLE
Always return a Disposable from the watch() method

### DIFF
--- a/src/config-file.js
+++ b/src/config-file.js
@@ -1,7 +1,7 @@
 const _ = require('underscore-plus')
 const fs = require('fs-plus')
 const dedent = require('dedent')
-const {Emitter} = require('event-kit')
+const {Disposable, Emitter} = require('event-kit')
 const {watchPath} = require('./path-watcher')
 const CSON = require('season')
 const Path = require('path')
@@ -74,10 +74,9 @@ class ConfigFile {
     await this.reload()
 
     try {
-      const watcher = await watchPath(this.path, {}, events => {
+      return await watchPath(this.path, {}, events => {
         if (events.some(event => EVENT_TYPES.has(event.action))) this.requestLoad()
       })
-      return watcher
     } catch (error) {
       this.emitter.emit('did-error', dedent `
         Unable to watch path: \`${Path.basename(this.path)}\`.
@@ -88,6 +87,7 @@ class ConfigFile {
 
         [watches]:https://github.com/atom/atom/blob/master/docs/build-instructions/linux.md#typeerror-unable-to-watch-path\
       `)
+      return new Disposable()
     }
   }
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -608,7 +608,11 @@ class AtomApplication extends EventEmitter {
 
     this.configFile.onDidError(message => {
       const window = this.focusedWindow() || this.getLastFocusedWindow()
-      if (window) window.didFailToReadUserSettings(message)
+      if (window) {
+        window.didFailToReadUserSettings(message)
+      } else {
+        console.error(message)
+      }
     })
 
     this.disposable.add(ipcHelpers.on(app, 'before-quit', async event => {


### PR DESCRIPTION
When there's an error watching the config file (as it happened [here](https://github.com/atom/atom/issues/19320)), we're currently swallowing the actual error and returning `undefined` from the `watch` method. This basically produces a different error in `atom-application` since that return value is not a disposable.

In order to fix that while maintaining what I think is the original goal of the code, this PR adds a `return` statement to return an empty disposable. This way the error gets propagated correctly to `atom-application` and it actually does not prevent Atom to get opened.

Note that this does not fix the original error reported in https://github.com/atom/atom/issues/19320: it just makes it easier to debug.

## Alternate designs

Instead of returning an empty `Disposable`, we can just remove the `catch` block and completely fail if there's an error watching the config file. I haven't decided to do so to maintain as much as possible the intention of the original code (which was to not fail under that circumstance), but I can change that if somebody has strong opinions on it.