### PR TITLE
Remove cached-run-in-this-context dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2195,14 +2195,6 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
-    "cached-run-in-this-context": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cached-run-in-this-context/-/cached-run-in-this-context-0.5.0.tgz",
-      "integrity": "sha512-FdtDP0u8WjetQ95nLz9vI06efJTFrmtmk5ZT6FECpyTKi9aakNLMHyMH21WRbGYyWlbmB/QlRoB/g1lcEpyjMw==",
-      "requires": {
-        "nan": "^2.10.0"
-      }
-    },
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "base16-tomorrow-light-theme": "file:packages/base16-tomorrow-light-theme",
     "bookmarks": "https://www.atom.io/api/packages/bookmarks/versions/0.46.0/tarball",
     "bracket-matcher": "https://www.atom.io/api/packages/bracket-matcher/versions/0.91.0/tarball",
-    "cached-run-in-this-context": "0.5.0",
     "chai": "3.5.0",
     "chart.js": "^2.3.0",
     "clear-cut": "^2.0.2",

--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -47,7 +47,6 @@ module.exports = function (packagedAppPath) {
         requiredModuleRelativePath === path.join('..', 'src', 'electron-shims.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'atom-keymap', 'lib', 'command-event.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'babel-core', 'index.js') ||
-        requiredModuleRelativePath === path.join('..', 'node_modules', 'cached-run-in-this-context', 'lib', 'main.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'debug', 'node.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'git-utils', 'src', 'git.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'glob', 'glob.js') ||

--- a/src/native-compile-cache.js
+++ b/src/native-compile-cache.js
@@ -35,8 +35,8 @@ class NativeCompileCache {
   }
 
   runInThisContext (code, filename) {
-    // produceCachedData is deprecated after Node 10.6, will need to update
-    // this for Electron 4.0 to use script.createCachedData()
+    // TodoElectronIssue:  produceCachedData is deprecated after Node 10.6, so we'll
+    // will need to update this for Electron v4 to use script.createCachedData().
     const script = new vm.Script(code, {filename, produceCachedData: true})
     return {
       result: script.runInThisContext(),

--- a/static/index.js
+++ b/static/index.js
@@ -1,8 +1,4 @@
 (function () {
-  // Eagerly require cached-run-in-this-context to prevent a circular require
-  // when using `NativeCompileCache` for the first time.
-  require('cached-run-in-this-context')
-
   // Define the window start time before the requires so we get a more accurate
   // window:start marker.
   const startWindowTime = Date.now()


### PR DESCRIPTION
This PR cherry-picks two of the commits from the electron v3 upgrade to be able to merge them into master before doing the actual upgrade (and lower the risk of the upgrade).

The two commits replace the `cached-run-in-this-context` by the raw `vm` APIs. I don't have much context about the reasons of this change, but it may have to do with the comments on https://github.com/atom/cached-run-in-this-context/pull/2 :

> We weren't able to conclusively tell that this module was speeding up compilation. When we upgrade Atom to use Electron 3, we should experiment with disabling the NativeCompileCache altogether to see whether this module is still helping us.

/cc @maxbrunsfeld , @daviwil for more context