### PR TITLE
Exclude @atom/notify binary from the ASAR bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -456,9 +456,9 @@
       }
     },
     "@atom/notify": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@atom/notify/-/notify-1.2.2.tgz",
-      "integrity": "sha512-6hVDX5Y1dov5Wk0e3deLUzPLiBaz7g180Uzh8ca5zu/iFHEGSeRNzV8DY7m9fmT00/gVkptyx+vjGewYctsUpA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@atom/notify/-/notify-1.3.0.tgz",
+      "integrity": "sha512-dFBaZ2a2BEfS/uiMq/dkYGl0mGaaf8u9L8wqwr/ODSt0rw2weQe/5owtYnTeb0YoqJxO9zLQzgE1PscThAxyMw=="
     },
     "@atom/nsfw": {
       "version": "1.0.22",

--- a/package-lock.json
+++ b/package-lock.json
@@ -456,9 +456,9 @@
       }
     },
     "@atom/notify": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@atom/notify/-/notify-1.3.0.tgz",
-      "integrity": "sha512-dFBaZ2a2BEfS/uiMq/dkYGl0mGaaf8u9L8wqwr/ODSt0rw2weQe/5owtYnTeb0YoqJxO9zLQzgE1PscThAxyMw=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@atom/notify/-/notify-1.3.2.tgz",
+      "integrity": "sha512-EGCDK33j4mstsdbpHXmSVOsi27uzFGWv+9CFctiMQy8rPD5DVOWuLLkES+74nsiFgzlkEbR1ahgQghpnjPzB1Q=="
     },
     "@atom/nsfw": {
       "version": "1.0.22",

--- a/package-lock.json
+++ b/package-lock.json
@@ -456,9 +456,9 @@
       }
     },
     "@atom/notify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@atom/notify/-/notify-1.2.1.tgz",
-      "integrity": "sha512-d1mZlBmPrYbk/SS1q0+gq/I9lG58a+PZ5y9vKBNuWzbgVaDPhpYBJyiO4glr80UbTxCQ/KW8AAD+rY517P8TfA=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@atom/notify/-/notify-1.2.2.tgz",
+      "integrity": "sha512-6hVDX5Y1dov5Wk0e3deLUzPLiBaz7g180Uzh8ca5zu/iFHEGSeRNzV8DY7m9fmT00/gVkptyx+vjGewYctsUpA=="
     },
     "@atom/nsfw": {
       "version": "1.0.22",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "electronVersion": "2.0.18",
   "dependencies": {
-    "@atom/notify": "1.2.1",
+    "@atom/notify": "1.2.2",
     "@atom/nsfw": "1.0.22",
     "@atom/source-map-support": "^0.3.4",
     "@atom/watcher": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "electronVersion": "2.0.18",
   "dependencies": {
-    "@atom/notify": "1.2.2",
+    "@atom/notify": "1.3.0",
     "@atom/nsfw": "1.0.22",
     "@atom/source-map-support": "^0.3.4",
     "@atom/watcher": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "electronVersion": "2.0.18",
   "dependencies": {
-    "@atom/notify": "1.3.0",
+    "@atom/notify": "1.3.2",
     "@atom/nsfw": "1.0.22",
     "@atom/source-map-support": "^0.3.4",
     "@atom/watcher": "1.3.1",

--- a/script/lib/package-application.js
+++ b/script/lib/package-application.js
@@ -108,6 +108,7 @@ function buildAsarUnpackGlobExpression () {
     path.join('**', 'node_modules', 'dugite', 'git', '**'),
     path.join('**', 'node_modules', 'github', 'bin', '**'),
     path.join('**', 'node_modules', 'vscode-ripgrep', 'bin', '**'),
+    path.join('**', 'node_modules', '@atom', 'notify', 'bin', '**'),
     path.join('**', 'resources', 'atom.png')
   ]
 

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -586,7 +586,8 @@ class PathWatcherManager {
     if (this.useExperimentalWatcher()) {
       if (!this.notifyWatcher) {
         const options = {
-          onError: (error) => {
+          transformBinPath: (binPath) => binPath.replace(/\bapp\.asar\b/, 'app.asar.unpacked'),
+          onError: error => {
             throw new Error(`Error watching file system: ${error}`)
           }
         }


### PR DESCRIPTION
🍐'd with @jasonrudolph 

Fixes #19311

In #19244, I included a dependency on `@atom/notify` to support watching the file system. It spawns an external binary, which worked fine in tests and in dev mode, but broke when the module was packaged in an ASAR archive. If you want to spawn a process from a node module that is inside an ASAR archive, that binary must be on the physical file system. Electron's file system hacks support `require` and other file system operations, but they don't support `spawn`.

This PR updates the `@atom/notify` dependency to support transforming the binary path to account for the module being packaged in a separate location (`atom.asar/@atom/notify`) than the binary it is trying to spawn `(atom.asar.unpacked/@atom/notify/bin`).