### PR TITLE
Fix @atom/notify subprocess path resolution when V8 startup snapshot is in effect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -456,9 +456,9 @@
       }
     },
     "@atom/notify": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@atom/notify/-/notify-1.3.2.tgz",
-      "integrity": "sha512-EGCDK33j4mstsdbpHXmSVOsi27uzFGWv+9CFctiMQy8rPD5DVOWuLLkES+74nsiFgzlkEbR1ahgQghpnjPzB1Q=="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@atom/notify/-/notify-1.3.3.tgz",
+      "integrity": "sha512-AExln6/wUVEo4mpkMmJu1n37RxQ1qKlwvGKaMncL5UkIEXYzKtjs303OS5T9WZ0Ks/YDUOn7B9Np3t4BIYbiYg=="
     },
     "@atom/nsfw": {
       "version": "1.0.22",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "electronVersion": "2.0.18",
   "dependencies": {
-    "@atom/notify": "1.3.2",
+    "@atom/notify": "1.3.3",
     "@atom/nsfw": "1.0.22",
     "@atom/source-map-support": "^0.3.4",
     "@atom/watcher": "1.3.1",

--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -69,6 +69,7 @@ module.exports = function (packagedAppPath) {
         requiredModuleRelativePath === path.join('..', 'node_modules', 'yauzl', 'index.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'winreg', 'lib', 'registry.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', '@atom', 'fuzzy-native', 'lib', 'main.js') ||
+        requiredModuleRelativePath === path.join('..', 'node_modules', '@atom', 'notify', 'lib', 'bin-path.js') ||
         // The startup-time script is used by both the renderer and the main process and having it in the
         // snapshot causes issues.
         requiredModuleRelativePath === path.join('..', 'src', 'startup-time.js')


### PR DESCRIPTION
Fixes #19311 (for real this time)

In #19325, I excluded `@atom/notify`'s subprocess binary from the ASAR bundle, but didn't realize there was *another* problem prohibiting spawning, which was the fact that `__dirname` is invalid inside of the V8 startup snapshot.

In this PR, we move resolution of the subprocess binary path to a separate file and exclude it from the snapshot to prevent this issue.

🍐'd with @as-cii 