### PR TITLE
Add .atom-socket-secret-* to .atom's .gitignore

### DIFF
--- a/dot-atom/.gitignore
+++ b/dot-atom/.gitignore
@@ -5,3 +5,4 @@ storage
 .apm
 .node-gyp
 .npm
+.atom-socket-secret-*


### PR DESCRIPTION
Fixes #19334, but only for clean installs (no existing `~/.atom` folder).