### PR TITLE
Allow escaped quote literals in the SyntaxScopeMap

### DIFF
--- a/spec/syntax-scope-map-spec.js
+++ b/spec/syntax-scope-map-spec.js
@@ -49,13 +49,15 @@ describe('SyntaxScopeMap', () => {
     const map = new SyntaxScopeMap({
       '"b"': 'w',
       'a > "b"': 'x',
-      'a > "b":nth-child(1)': 'y'
+      'a > "b":nth-child(1)': 'y',
+      '"\\""': 'z'
     })
 
     expect(map.get(['b'], [0], true)).toBe(undefined)
     expect(map.get(['b'], [0], false)).toBe('w')
     expect(map.get(['a', 'b'], [0, 0], false)).toBe('x')
     expect(map.get(['a', 'b'], [0, 1], false)).toBe('y')
+    expect(map.get(['a', '"'], [0, 1], false)).toBe('z')
   })
 
   it('supports the wildcard selector', () => {

--- a/src/syntax-scope-map.js
+++ b/src/syntax-scope-map.js
@@ -36,7 +36,7 @@ class SyntaxScopeMap {
 
             case 'string':
               if (!currentTable) currentTable = this.anonymousScopeTable
-              const value = termNode.value.slice(1, -1)
+              const value = termNode.value.slice(1, -1).replace(/\\"/g, '"')
               if (!currentTable[value]) currentTable[value] = {}
               currentTable = currentTable[value]
               if (currentIndexValue != null) {


### PR DESCRIPTION
As raised by @Ben3eeE in https://github.com/atom/language-json/pull/68#issuecomment-492440942, we are currently unable to apply decorative syntax scopes to `"` literals for TreeSitter grammars, which is forcing us to break user expectations around how syntax themes apply to strings.

In this PR, I add some special handling for escaped `"` literals to the `SyntaxScopeMap`. Internally, the `SyntaxScopeMap` uses the `postcss-selector-parser` library to parse any scope it is provided. This library allows `"` literals inside of selectors, but they need to be *escaped* in the selector. So a valid post CSS selector looks like this:

```
string > "\""
```

Unfortunately, these selectors are themselves expressed as strings within CSON or JSON files in our grammars. That means the escaping gets a bit intense, and looks like this:

```CSON
'string > "\\""': 'puncuation.quote.double.whatever'
```

Notice that I include **2** backslashes when escaping the quote so that they end up getting passed through to the parser as a single `\`. If I only include one backslash it ends up looking like an escaped quote at the interpretation level of CSON rather than the level of the selector language. 😓

Anyway, once properly escaped, the quote literal is handled by the parser, but the value it spits out continues to include the escaping backslash. In order to match the text of the anonymous nodes returned by TreeSitter, we need to remove the escaping after trimming off the outer quotes.

@Ben3eeE hopefully this gives you what you need to style quotes properly in various grammars.

cc @50Wliu @maxbrunsfeld