### PR TITLE
Enable installing apm using the ci command

### DIFF
--- a/script/lib/install-apm.js
+++ b/script/lib/install-apm.js
@@ -8,7 +8,7 @@ module.exports = function (ci) {
   console.log('Installing apm')
   childProcess.execFileSync(
     CONFIG.getNpmBinPath(ci),
-    ['--loglevel=error', ci ? 'ci' : 'install'],
+    ['--global-style', '--loglevel=error', ci ? 'ci' : 'install'],
     {env: process.env, cwd: CONFIG.apmRootPath}
   )
 }

--- a/script/lib/install-apm.js
+++ b/script/lib/install-apm.js
@@ -6,10 +6,9 @@ const CONFIG = require('../config')
 
 module.exports = function (ci) {
   console.log('Installing apm')
-  // npm ci leaves apm with a bunch of unmet dependencies
   childProcess.execFileSync(
-    CONFIG.getNpmBinPath(),
-    ['--global-style', '--loglevel=error', 'install'],
+    CONFIG.getNpmBinPath(ci),
+    ['--loglevel=error', ci ? 'ci' : 'install'],
     {env: process.env, cwd: CONFIG.apmRootPath}
   )
 }


### PR DESCRIPTION
There's been a few dependency changes (notably: the dropping of node-gyp), so let's give this another try. Seems to work on my machine™.