### PR TITLE
pane.js: Additional destroy arguments of `force`

### DIFF
--- a/src/pane.js
+++ b/src/pane.js
@@ -736,9 +736,11 @@ class Pane {
 
   // Public: Destroy the active item and activate the next item.
   //
+  // * `force` (optional) {Boolean} Same behavior as destroyItem(item, force)
+  //
   // Returns a {Promise} that resolves when the item is destroyed.
-  destroyActiveItem () {
-    return this.destroyItem(this.activeItem)
+  destroyActiveItem (force) {
+    return this.destroyItem(this.activeItem, force)
   }
 
   // Public: Destroy the given item.
@@ -781,18 +783,22 @@ class Pane {
   }
 
   // Public: Destroy all items.
-  destroyItems () {
+  //
+  // * `force` (optional) {Boolean} Same behavior as destroyItem(item, force)
+  destroyItems (force) {
     return Promise.all(
-      this.getItems().map(item => this.destroyItem(item))
+      this.getItems().map(item => this.destroyItem(item, force))
     )
   }
 
   // Public: Destroy all items except for the active item.
-  destroyInactiveItems () {
+  //
+  // * `force` (optional) {Boolean} Same behavior as destroyItem(item, force)
+  destroyInactiveItems (force) {
     return Promise.all(
       this.getItems()
         .filter(item => item !== this.activeItem)
-        .map(item => this.destroyItem(item))
+        .map(item => this.destroyItem(item, force))
     )
   }
 


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

Such a small change I haven't created an issue yet.

### Description of the Change

Adds the option `force` to the other Pane Item destruction functions.

### Alternate Designs

Originally I had to either extend `Pane` and override `destroyItems`/`destroyInactiveItems`/etc or create a custom function to force-destroy items in Panes.

### Possible Drawbacks

Hopefully none, this should purely add options for other plugin developers.

### Verification Process

Ran Atom locally and tested each function with and without `force` option supplied, all seemed to work.

### Release Notes

Change is not user-facing: `N/A`.