### PR TITLE
Replace new Buffer() with Buffer.from()

### DIFF
--- a/spec/file-system-blob-store-spec.coffee
+++ b/spec/file-system-blob-store-spec.coffee
@@ -18,88 +18,88 @@ describe "FileSystemBlobStore", ->
     expect(blobStore.get("bar")).toBeUndefined()
 
   it "allows to read and write buffers from/to memory without persisting them", ->
-    blobStore.set("foo", new Buffer("foo"))
-    blobStore.set("bar", new Buffer("bar"))
+    blobStore.set("foo", Buffer.from("foo"))
+    blobStore.set("bar", Buffer.from("bar"))
 
-    expect(blobStore.get("foo")).toEqual(new Buffer("foo"))
-    expect(blobStore.get("bar")).toEqual(new Buffer("bar"))
+    expect(blobStore.get("foo")).toEqual(Buffer.from("foo"))
+    expect(blobStore.get("bar")).toEqual(Buffer.from("bar"))
 
     expect(blobStore.get("baz")).toBeUndefined()
     expect(blobStore.get("qux")).toBeUndefined()
 
   it "persists buffers when saved and retrieves them on load, giving priority to in-memory ones", ->
-    blobStore.set("foo", new Buffer("foo"))
-    blobStore.set("bar", new Buffer("bar"))
+    blobStore.set("foo", Buffer.from("foo"))
+    blobStore.set("bar", Buffer.from("bar"))
     blobStore.save()
 
     blobStore = FileSystemBlobStore.load(storageDirectory)
 
-    expect(blobStore.get("foo")).toEqual(new Buffer("foo"))
-    expect(blobStore.get("bar")).toEqual(new Buffer("bar"))
+    expect(blobStore.get("foo")).toEqual(Buffer.from("foo"))
+    expect(blobStore.get("bar")).toEqual(Buffer.from("bar"))
     expect(blobStore.get("baz")).toBeUndefined()
     expect(blobStore.get("qux")).toBeUndefined()
 
-    blobStore.set("foo", new Buffer("changed"))
+    blobStore.set("foo", Buffer.from("changed"))
 
-    expect(blobStore.get("foo")).toEqual(new Buffer("changed"))
+    expect(blobStore.get("foo")).toEqual(Buffer.from("changed"))
 
   it "persists in-memory and previously stored buffers, and deletes unused keys when saved", ->
-    blobStore.set("foo", new Buffer("foo"))
-    blobStore.set("bar", new Buffer("bar"))
+    blobStore.set("foo", Buffer.from("foo"))
+    blobStore.set("bar", Buffer.from("bar"))
     blobStore.save()
 
     blobStore = FileSystemBlobStore.load(storageDirectory)
-    blobStore.set("bar", new Buffer("changed"))
-    blobStore.set("qux", new Buffer("qux"))
+    blobStore.set("bar", Buffer.from("changed"))
+    blobStore.set("qux", Buffer.from("qux"))
     blobStore.save()
 
     blobStore = FileSystemBlobStore.load(storageDirectory)
 
     expect(blobStore.get("foo")).toBeUndefined()
-    expect(blobStore.get("bar")).toEqual(new Buffer("changed"))
-    expect(blobStore.get("qux")).toEqual(new Buffer("qux"))
+    expect(blobStore.get("bar")).toEqual(Buffer.from("changed"))
+    expect(blobStore.get("qux")).toEqual(Buffer.from("qux"))
 
   it "allows to delete keys from both memory and stored buffers", ->
-    blobStore.set("a", new Buffer("a"))
-    blobStore.set("b", new Buffer("b"))
+    blobStore.set("a", Buffer.from("a"))
+    blobStore.set("b", Buffer.from("b"))
     blobStore.save()
 
     blobStore = FileSystemBlobStore.load(storageDirectory)
 
     blobStore.get("a") # prevent the key from being deleted on save
-    blobStore.set("b", new Buffer("b"))
-    blobStore.set("c", new Buffer("c"))
+    blobStore.set("b", Buffer.from("b"))
+    blobStore.set("c", Buffer.from("c"))
     blobStore.delete("b")
     blobStore.delete("c")
     blobStore.save()
 
     blobStore = FileSystemBlobStore.load(storageDirectory)
 
-    expect(blobStore.get("a")).toEqual(new Buffer("a"))
+    expect(blobStore.get("a")).toEqual(Buffer.from("a"))
     expect(blobStore.get("b")).toBeUndefined()
     expect(blobStore.get("b")).toBeUndefined()
     expect(blobStore.get("c")).toBeUndefined()
 
   it "ignores errors when loading an invalid blob store", ->
-    blobStore.set("a", new Buffer("a"))
-    blobStore.set("b", new Buffer("b"))
+    blobStore.set("a", Buffer.from("a"))
+    blobStore.set("b", Buffer.from("b"))
     blobStore.save()
 
     # Simulate corruption
-    fs.writeFileSync(path.join(storageDirectory, "MAP"), new Buffer([0]))
-    fs.writeFileSync(path.join(storageDirectory, "INVKEYS"), new Buffer([0]))
-    fs.writeFileSync(path.join(storageDirectory, "BLOB"), new Buffer([0]))
+    fs.writeFileSync(path.join(storageDirectory, "MAP"), Buffer.from([0]))
+    fs.writeFileSync(path.join(storageDirectory, "INVKEYS"), Buffer.from([0]))
+    fs.writeFileSync(path.join(storageDirectory, "BLOB"), Buffer.from([0]))
 
     blobStore = FileSystemBlobStore.load(storageDirectory)
 
     expect(blobStore.get("a")).toBeUndefined()
     expect(blobStore.get("b")).toBeUndefined()
 
-    blobStore.set("a", new Buffer("x"))
-    blobStore.set("b", new Buffer("y"))
+    blobStore.set("a", Buffer.from("x"))
+    blobStore.set("b", Buffer.from("y"))
     blobStore.save()
 
     blobStore = FileSystemBlobStore.load(storageDirectory)
 
-    expect(blobStore.get("a")).toEqual(new Buffer("x"))
-    expect(blobStore.get("b")).toEqual(new Buffer("y"))
+    expect(blobStore.get("a")).toEqual(Buffer.from("x"))
+    expect(blobStore.get("b")).toEqual(Buffer.from("y"))

--- a/spec/native-compile-cache-spec.coffee
+++ b/spec/native-compile-cache-spec.coffee
@@ -89,7 +89,7 @@ describe "NativeCompileCache", ->
 
   it "deletes previously cached code when the cache is an invalid file", ->
     fakeCacheStore.has.andReturn(true)
-    fakeCacheStore.get.andCallFake -> new Buffer("an invalid cache")
+    fakeCacheStore.get.andCallFake -> Buffer.from("an invalid cache")
 
     fn3 = require('./fixtures/native-cache/file-3')
 


### PR DESCRIPTION
The `Buffer` constructor [got deprecated in Node v10](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/), so in order to get rid of deprecation warnings in the `electron-3` branch we need to replace these by `Buffer.from()` calls.

🍐'd with @as-cii 