### PR TITLE
⬆️ coffeestack@1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2375,47 +2375,21 @@
       "integrity": "sha1-wF2uDLeVkdBbMHCoQzqYyaiczFM="
     },
     "coffeestack": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/coffeestack/-/coffeestack-1.1.2.tgz",
-      "integrity": "sha1-NSePO+uc5vXQraH7bgh4UrZXzpg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/coffeestack/-/coffeestack-1.2.0.tgz",
+      "integrity": "sha512-vXT7ZxSZ4lXHh/0A2cODyFqrVIl4Vb0Er5wcS2SrFN4jW8g1qIAmcMsRlRdUKvnvfmKixvENYspAyF/ihWbpyw==",
       "requires": {
         "coffee-script": "~1.8.0",
-        "fs-plus": "^2.5.0",
+        "fs-plus": "^3.1.1",
         "source-map": "~0.1.43"
       },
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
         "coffee-script": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
           "integrity": "sha1-nJ8dK0pSoADe0Vtll5FwNkgmPB0=",
           "requires": {
             "mkdirp": "~0.3.5"
-          }
-        },
-        "fs-plus": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-2.10.1.tgz",
-          "integrity": "sha1-MgR4HXhAYR5jZOe2+wWMljJ8WqU=",
-          "requires": {
-            "async": "^1.5.2",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.2",
-            "underscore-plus": "1.x"
-          },
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            }
           }
         },
         "mkdirp": {


### PR DESCRIPTION
The new version of coffeestack contains [a new version of `fs-plus`](https://github.com/kevinsawicki/coffeestack/pull/3), which at the same time [fixes](https://github.com/atom/fs-plus/pull/46) the following deprecation warnings on Node v10 (electron v3):

```
The 'lstatSyncNoException' function has been deprecated and marked for removal.
```
---

*List of changes between `coffeestack@1.1.2` and `coffeestack@1.2.0`: https://github.com/kevinsawicki/coffeestack/compare/v1.1.2...v1.2.0*