### PR TITLE
Disable @atom/notify on master for now

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -331,7 +331,7 @@ const configSchema = {
       fileSystemWatcher: {
         description: 'Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes. Polling may be useful for network drives, but will be more costly in terms of CPU overhead.<br>This setting will require a relaunch of Atom to take effect.',
         type: 'string',
-        default: 'experimental',
+        default: 'native',
         enum: [
           {
             value: 'native',


### PR DESCRIPTION
We're seeing some bad behavior from the Rust notify crate that has me worried about the entire direction proposed in #19244.

1. I've personally seen at least one instance of the crate not picking up events from the file system.
2. @as-cii has witnessed rogue instances `notify-subprocess-darwin` pegging a core at 100%. When we sampled them, it looked like they were in a busy loop in the `unwatch` method of the Notify crate.

Both cases undermine my confidence in the Notify crate. My premise was that we'd take a reliable solution and wrap it in a subprocess, but it's seeming like that solution isn't as battle-tested and solid as I had hoped. For now, we can switch back to `@atom/nsfw` while we figure out how to proceed from here.

cc @as-cii @rafeca