### PR TITLE
Re-enable draft release automation for builds on release branches

### DIFF
--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -62,19 +62,17 @@ jobs:
       downloadType: 'specific'
     displayName: Download Release Artifacts
 
-  # NOTE: This has been disabled until one final issue has been resolved
-  #       around setting the SHA on GitHub releases.
-  # - script: |
-  #     node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)" --linux-repo-name "atom-staging"
-  #   env:
-  #     GITHUB_TOKEN: $(GITHUB_TOKEN)
-  #     ATOM_RELEASE_VERSION: $(ReleaseVersion)
-  #     ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
-  #     ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
-  #     ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
-  #     PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
-  #   displayName: Create Draft Release
-  #   condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'))
+  - script: |
+      node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)" --linux-repo-name "atom-staging"
+    env:
+      GITHUB_TOKEN: $(GITHUB_TOKEN)
+      ATOM_RELEASE_VERSION: $(ReleaseVersion)
+      ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
+      ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
+      ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
+      PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
+    displayName: Create Draft Release
+    condition: and(succeeded(), eq(variables['Atom.AutoDraftRelease'], 'true'), eq(variables['IsReleaseBranch'], 'true'))
 
   - script: |
       node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --assets-path "$(System.ArtifactsDirectory)" --s3-path "vsts-artifacts/$(Build.BuildId)/"

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -97,7 +97,7 @@ async function uploadArtifacts () {
     const releaseSha =
         !isNightlyRelease
             ? spawnSync('git', ['rev-parse', 'HEAD']).stdout.toString().trimEnd()
-            : undefined
+            : 'master' // Nightly tags are created in atom/atom-nightly-releases so the SHA is irrelevant
 
     console.log(`Creating GitHub release v${releaseVersion}`)
     const release =

--- a/script/vsts/upload-artifacts.js
+++ b/script/vsts/upload-artifacts.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const glob = require('glob')
+const spawnSync = require('../lib/spawn-sync')
 const publishRelease = require('publish-release')
 const releaseNotes = require('./lib/release-notes')
 const uploadToS3 = require('./lib/upload-to-s3')
@@ -93,6 +94,11 @@ async function uploadArtifacts () {
 
     console.log(`New release notes:\n\n${newReleaseNotes}`)
 
+    const releaseSha =
+        !isNightlyRelease
+            ? spawnSync('git', ['rev-parse', 'HEAD']).stdout.toString().trimEnd()
+            : undefined
+
     console.log(`Creating GitHub release v${releaseVersion}`)
     const release =
       await publishReleaseAsync({
@@ -101,6 +107,7 @@ async function uploadArtifacts () {
         repo: !isNightlyRelease ? 'atom' : 'atom-nightly-releases',
         name: CONFIG.computedAppVersion,
         notes: newReleaseNotes,
+        target_commitish: releaseSha,
         tag: `v${CONFIG.computedAppVersion}`,
         draft: !isNightlyRelease,
         prerelease: CONFIG.channel !== 'stable',


### PR DESCRIPTION
### Description of the Change

This change re-enables draft release automation for Atom release branches and fixes an issue that showed up after PR #17862.  After merging the aforementioned PR, I had to disable this automation due to a last minute issue I found with how GitHub releases were being created.  This change fixes that by explicitly mentioning the SHA of the commit for the release branch from which the release is created.

This change also adds a new Azure Pipelines variable called `Atom.AutoDraftRelease` which can be set to `true` or `false` at the build definition level depending on whether we want this behavior to be turned on at any given time.  I have configured it to be set to `false` until the team has decided that this automation will be used for Atom stable and beta releases.

### Alternate Designs

Nothing relevant to mention.

### Possible Drawbacks

No possible side effects since this behavior is not turned on by default

### Verification Process

- [x] Ensure that a draft GitHub release gets created from an emulated release build with the correct SHA for `HEAD` of that branch
- [x] Ensure that release artifacts are correctly uploaded to S3
- [x] Ensure that Linux packages are correctly uploaded to Packagecloud
- [x] Ensure that Atom's release verifier thinks that the draft release is shippable
- [x] Ensure that draft release automation is not attempted when `Atom.AutoDraftRelease` is set to `false`

### Post-merge Tasks

- [x] Cherry-pick changes to `1.37-releases`
- [x] Cherry-pick changes to `1.38-releases`
- [x] Ensure that `Atom.AutoDraftRelease` is set to `false` in the "Atom Production Branches" build definition

### Release Notes

N/A
