### PR TITLE
Switch to atomeditor/atom-linux-ci image for Linux builds

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,7 +1,7 @@
 resources:
   containers:
   - container: atom-linux-ci
-    image: daviwil/atom-linux-ci:latest
+    image: atomeditor/atom-linux-ci:latest
 
 jobs:
 

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -3,7 +3,7 @@ trigger: none  # No CI builds, only PR builds
 resources:
   containers:
   - container: atom-linux-ci
-    image: daviwil/atom-linux-ci:latest
+    image: atomeditor/atom-linux-ci:latest
 
 jobs:
 

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -6,7 +6,7 @@ trigger:
 resources:
   containers:
   - container: atom-linux-ci
-    image: daviwil/atom-linux-ci:latest
+    image: atomeditor/atom-linux-ci:latest
 
 jobs:
 


### PR DESCRIPTION
This change switches the Docker image we use for Linux CI builds on Azure Pipelines from [`daviwil/atom-linux-ci`](https://hub.docker.com/r/daviwil/atom-linux-ci/) to [`atomeditor/atom-linux-ci`](https://hub.docker.com/r/atomeditor/atom-linux-ci), the [new official fork](https://github.com/atom/atom-docker-ci).