### PR TITLE
Undo integration of @atom/notify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -456,9 +456,9 @@
       }
     },
     "@atom/notify": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@atom/notify/-/notify-1.3.3.tgz",
-      "integrity": "sha512-AExln6/wUVEo4mpkMmJu1n37RxQ1qKlwvGKaMncL5UkIEXYzKtjs303OS5T9WZ0Ks/YDUOn7B9Np3t4BIYbiYg=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@atom/notify/-/notify-1.3.2.tgz",
+      "integrity": "sha512-EGCDK33j4mstsdbpHXmSVOsi27uzFGWv+9CFctiMQy8rPD5DVOWuLLkES+74nsiFgzlkEbR1ahgQghpnjPzB1Q=="
     },
     "@atom/nsfw": {
       "version": "1.0.22",

--- a/package-lock.json
+++ b/package-lock.json
@@ -456,9 +456,9 @@
       }
     },
     "@atom/notify": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@atom/notify/-/notify-1.3.2.tgz",
-      "integrity": "sha512-EGCDK33j4mstsdbpHXmSVOsi27uzFGWv+9CFctiMQy8rPD5DVOWuLLkES+74nsiFgzlkEbR1ahgQghpnjPzB1Q=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@atom/notify/-/notify-1.2.1.tgz",
+      "integrity": "sha512-d1mZlBmPrYbk/SS1q0+gq/I9lG58a+PZ5y9vKBNuWzbgVaDPhpYBJyiO4glr80UbTxCQ/KW8AAD+rY517P8TfA=="
     },
     "@atom/nsfw": {
       "version": "1.0.22",

--- a/package-lock.json
+++ b/package-lock.json
@@ -455,11 +455,6 @@
         }
       }
     },
-    "@atom/notify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@atom/notify/-/notify-1.2.1.tgz",
-      "integrity": "sha512-d1mZlBmPrYbk/SS1q0+gq/I9lG58a+PZ5y9vKBNuWzbgVaDPhpYBJyiO4glr80UbTxCQ/KW8AAD+rY517P8TfA=="
-    },
     "@atom/nsfw": {
       "version": "1.0.22",
       "resolved": "https://registry.npmjs.org/@atom/nsfw/-/nsfw-1.0.22.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "electronVersion": "2.0.18",
   "dependencies": {
-    "@atom/notify": "1.3.2",
+    "@atom/notify": "1.2.1",
     "@atom/nsfw": "1.0.22",
     "@atom/source-map-support": "^0.3.4",
     "@atom/watcher": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "electronVersion": "2.0.18",
   "dependencies": {
-    "@atom/notify": "1.3.3",
+    "@atom/notify": "1.3.2",
     "@atom/nsfw": "1.0.22",
     "@atom/source-map-support": "^0.3.4",
     "@atom/watcher": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "license": "MIT",
   "electronVersion": "2.0.18",
   "dependencies": {
-    "@atom/notify": "1.2.1",
     "@atom/nsfw": "1.0.22",
     "@atom/source-map-support": "^0.3.4",
     "@atom/watcher": "1.3.1",

--- a/script/lib/generate-startup-snapshot.js
+++ b/script/lib/generate-startup-snapshot.js
@@ -69,7 +69,6 @@ module.exports = function (packagedAppPath) {
         requiredModuleRelativePath === path.join('..', 'node_modules', 'yauzl', 'index.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', 'winreg', 'lib', 'registry.js') ||
         requiredModuleRelativePath === path.join('..', 'node_modules', '@atom', 'fuzzy-native', 'lib', 'main.js') ||
-        requiredModuleRelativePath === path.join('..', 'node_modules', '@atom', 'notify', 'lib', 'bin-path.js') ||
         // The startup-time script is used by both the renderer and the main process and having it in the
         // snapshot causes issues.
         requiredModuleRelativePath === path.join('..', 'src', 'startup-time.js')

--- a/script/lib/package-application.js
+++ b/script/lib/package-application.js
@@ -112,7 +112,6 @@ function buildAsarUnpackGlobExpression () {
     path.join('**', 'node_modules', 'dugite', 'git', '**'),
     path.join('**', 'node_modules', 'github', 'bin', '**'),
     path.join('**', 'node_modules', 'vscode-ripgrep', 'bin', '**'),
-    path.join('**', 'node_modules', '@atom', 'notify', 'bin', '**'),
     path.join('**', 'resources', 'atom.png')
   ]
 

--- a/script/test
+++ b/script/test
@@ -48,7 +48,6 @@ const resourcePath = CONFIG.repositoryRootPath
 let executablePath
 if (process.platform === 'darwin') {
   const executablePaths = glob.sync(path.join(CONFIG.buildOutputPath, '*.app'))
-  assert(executablePaths.length > 0, `No application found in ${CONFIG.buildOutputPath} to run tests against`)
   assert(executablePaths.length === 1, `More than one application to run tests against was found. ${executablePaths.join(',')}`)
   executablePath = path.join(executablePaths[0], 'Contents', 'MacOS', path.basename(executablePaths[0], '.app'))
 } else if (process.platform === 'linux') {

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -78,10 +78,7 @@ jobs:
       IS_SIGNED_ZIP_BRANCH: $(IsSignedZipBranch)
     displayName: Build Atom
 
-  - powershell: |
-      # Normalize %TEMP% as a long (non 8.3) path to avoid assertion failures comparing paths in temp folders
-      $env:TEMP = (Get-Item -LiteralPath $env:TEMP).FullName
-      node script\vsts\windows-run.js script\test.cmd
+  - script: node script\vsts\windows-run.js script\test.cmd
     env:
       CI: true
       CI_PROVIDER: VSTS

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -329,17 +329,17 @@ const configSchema = {
         default: 40
       },
       fileSystemWatcher: {
-        description: 'Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes. Polling may be useful for network drives, but will be more costly in terms of CPU overhead.<br>This setting will require a relaunch of Atom to take effect.',
+        description: 'Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes.',
         type: 'string',
-        default: 'experimental',
+        default: 'native',
         enum: [
           {
             value: 'native',
-            description: 'Native operating system APIs (@atom/nsfw)'
+            description: 'Native operating system APIs'
           },
           {
             value: 'experimental',
-            description: 'Experimental (@atom/notify)'
+            description: 'Experimental filesystem watching library'
           },
           {
             value: 'poll',
@@ -350,11 +350,6 @@ const configSchema = {
             description: 'Emulated with Atom events'
           }
         ]
-      },
-      fileSystemWatcherPollInterval: {
-        description: "If the 'Polling' option is selected for the file system watcher, this will be the interval between polls.",
-        type: 'number',
-        default: 1000
       },
       useTreeSitterParsers: {
         type: 'boolean',

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -331,7 +331,7 @@ const configSchema = {
       fileSystemWatcher: {
         description: 'Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes. Polling may be useful for network drives, but will be more costly in terms of CPU overhead.<br>This setting will require a relaunch of Atom to take effect.',
         type: 'string',
-        default: 'native',
+        default: 'experimental',
         enum: [
           {
             value: 'native',

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -282,7 +282,6 @@ class AtomApplication extends EventEmitter {
       }
       this.config.onDidChange('core.titleBar', () => this.promptForRestart())
       this.config.onDidChange('core.colorProfile', () => this.promptForRestart())
-      this.config.onDidChange('core.fileSystemWatcher', () => this.promptForRestart())
     }
 
     let optionsForWindowsToOpen = []

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -586,8 +586,7 @@ class PathWatcherManager {
     if (this.useExperimentalWatcher()) {
       if (!this.notifyWatcher) {
         const options = {
-          transformBinPath: (binPath) => binPath.replace(/\bapp\.asar\b/, 'app.asar.unpacked'),
-          onError: error => {
+          onError: (error) => {
             throw new Error(`Error watching file system: ${error}`)
           }
         }

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -2,9 +2,8 @@ const fs = require('fs')
 const path = require('path')
 
 const {Emitter, Disposable, CompositeDisposable} = require('event-kit')
-
-const NotifyWatcher = require('@atom/notify')
 const nsfw = require('@atom/nsfw')
+const watcher = require('@atom/watcher')
 const {NativeWatcherRegistry} = require('./native-watcher-registry')
 
 // Private: Associate native watcher action flags with descriptive String equivalents.
@@ -385,7 +384,12 @@ class PathWatcher {
     return this.normalizedPathPromise
   }
 
-  // Private: Return a {Promise} that will resolve when the underlying native watcher is ready to begin sending events.
+  // Private: Return a {Promise} that will resolve the first time that this watcher is attached to a native watcher.
+  getAttachedPromise () {
+    return this.attachedPromise
+  }
+
+  // Extended: Return a {Promise} that will resolve when the underlying native watcher is ready to begin sending events.
   // When testing filesystem watchers, it's important to await this promise before making filesystem changes that you
   // intend to assert about because there will be a delay between the instantiation of the watcher and the activation
   // of the underlying OS resources that feed its events.
@@ -540,18 +544,50 @@ class PathWatcherManager {
   // Private: Access the currently active manager instance, creating one if necessary.
   static active () {
     if (!this.activeManager) {
-      this.activeManager = new PathWatcherManager(
-        atom.config.get('core.fileSystemWatcher'),
-        atom.config.get('core.fileSystemWatcherPollInterval')
-      )
+      this.activeManager = new PathWatcherManager(atom.config.get('core.fileSystemWatcher'))
+      this.sub = atom.config.onDidChange('core.fileSystemWatcher', ({newValue}) => { this.transitionTo(newValue) })
     }
     return this.activeManager
   }
 
+  // Private: Replace the active {PathWatcherManager} with a new one that creates [NativeWatchers]{NativeWatcher}
+  // based on the value of `setting`.
+  static async transitionTo (setting) {
+    const current = this.active()
+
+    if (this.transitionPromise) {
+      await this.transitionPromise
+    }
+
+    if (current.setting === setting) {
+      return
+    }
+    current.isShuttingDown = true
+
+    let resolveTransitionPromise = () => {}
+    this.transitionPromise = new Promise(resolve => {
+      resolveTransitionPromise = resolve
+    })
+
+    const replacement = new PathWatcherManager(setting)
+    this.activeManager = replacement
+
+    await Promise.all(
+      Array.from(current.live, async ([root, native]) => {
+        const w = await replacement.createWatcher(root, {}, () => {})
+        native.reattachTo(w.native, root, w.native.options || {})
+      })
+    )
+
+    current.stopAllWatchers()
+
+    resolveTransitionPromise()
+    this.transitionPromise = null
+  }
+
   // Private: Initialize global {PathWatcher} state.
-  constructor (setting, pollInterval) {
+  constructor (setting) {
     this.setting = setting
-    this.pollInterval = pollInterval
     this.live = new Map()
 
     const initLocal = NativeConstructor => {
@@ -572,9 +608,15 @@ class PathWatcherManager {
 
     if (setting === 'atom') {
       initLocal(AtomNativeWatcher)
-    } else if (setting === 'native') {
+    } else if (setting === 'experimental') {
+      //
+    } else if (setting === 'poll') {
+      //
+    } else {
       initLocal(NSFWNativeWatcher)
     }
+
+    this.isShuttingDown = false
   }
 
   useExperimentalWatcher () {
@@ -582,53 +624,66 @@ class PathWatcherManager {
   }
 
   // Private: Create a {PathWatcher} tied to this global state. See {watchPath} for detailed arguments.
-  async watchPath (rootPath, options, eventCallback) {
+  async createWatcher (rootPath, options, eventCallback) {
+    if (this.isShuttingDown) {
+      await this.constructor.transitionPromise
+      return PathWatcherManager.active().createWatcher(rootPath, options, eventCallback)
+    }
+
     if (this.useExperimentalWatcher()) {
-      if (!this.notifyWatcher) {
-        const options = {
-          onError: (error) => {
-            throw new Error(`Error watching file system: ${error}`)
-          }
-        }
-        if (this.setting === 'poll') {
-          options.pollInterval = this.pollInterval
-        }
-        this.notifyWatcher = new NotifyWatcher(options)
+      if (this.setting === 'poll') {
+        options.poll = true
       }
 
-      const watch = await this.notifyWatcher.watchPath(rootPath, event => {
-        if (event.action === 'error') {
-          watch.emitter.emit('error', event.description)
-          throw new Error(`Error watching file system at "${event.path}": ${event.description}`)
-        } else {
-          eventCallback(event)
-        }
-      })
-      watch.emitter = new Emitter()
-      watch.onDidError = function (handler) {
-        return this.emitter.on('error', handler)
-      }
-      return watch
-    } else {
-      const w = new PathWatcher(this.nativeRegistry, rootPath, options)
-      w.onDidChange(eventCallback)
-      await w.getStartPromise()
+      const w = await watcher.watchPath(rootPath, options, eventCallback)
+      this.live.set(rootPath, w.native)
       return w
     }
+
+    const w = new PathWatcher(this.nativeRegistry, rootPath, options)
+    w.onDidChange(eventCallback)
+    await w.getStartPromise()
+    return w
+  }
+
+  // Private: Directly access the {NativeWatcherRegistry}.
+  getRegistry () {
+    if (this.useExperimentalWatcher()) {
+      return watcher.getRegistry()
+    }
+
+    return this.nativeRegistry
+  }
+
+  // Private: Sample watcher usage statistics. Only available for experimental watchers.
+  status () {
+    if (this.useExperimentalWatcher()) {
+      return watcher.status()
+    }
+
+    return {}
+  }
+
+  // Private: Return a {String} depicting the currently active native watchers.
+  print () {
+    if (this.useExperimentalWatcher()) {
+      return watcher.printWatchers()
+    }
+
+    return this.nativeRegistry.print()
   }
 
   // Private: Stop all living watchers.
   //
   // Returns a {Promise} that resolves when all native watcher resources are disposed.
-  async stopAllWatchers () {
+  stopAllWatchers () {
     if (this.useExperimentalWatcher()) {
-      await this.notifyWatcher.kill()
-      this.notifyWatcher = null
-    } else {
-      await Promise.all(
-        Array.from(this.live, ([, w]) => w.stop())
-      )
+      return watcher.stopAllWatchers()
     }
+
+    return Promise.all(
+      Array.from(this.live, ([, w]) => w.stop())
+    )
   }
 }
 
@@ -672,7 +727,7 @@ class PathWatcherManager {
 // ```
 //
 function watchPath (rootPath, options, eventCallback) {
-  return PathWatcherManager.active().watchPath(rootPath, options, eventCallback)
+  return PathWatcherManager.active().createWatcher(rootPath, options, eventCallback)
 }
 
 // Private: Return a Promise that resolves when all {NativeWatcher} instances associated with a FileSystemManager
@@ -681,4 +736,24 @@ function stopAllWatchers () {
   return PathWatcherManager.active().stopAllWatchers()
 }
 
-module.exports = {watchPath, stopAllWatchers, PathWatcherManager}
+// Private: Show the currently active native watchers in a formatted {String}.
+watchPath.printWatchers = function () {
+  return PathWatcherManager.active().print()
+}
+
+// Private: Access the active {NativeWatcherRegistry}.
+watchPath.getRegistry = function () {
+  return PathWatcherManager.active().getRegistry()
+}
+
+// Private: Sample usage statistics for the active watcher.
+watchPath.status = function () {
+  return PathWatcherManager.active().status()
+}
+
+// Private: Configure @atom/watcher ("experimental") directly.
+watchPath.configure = function (...args) {
+  return watcher.configure(...args)
+}
+
+module.exports = {watchPath, stopAllWatchers}


### PR DESCRIPTION
As I've noted [elsewhere](https://github.com/atom/atom/issues/18991#issuecomment-493199413), it turns out that switching our underlying notification system was a mistake. This PR reverts the original PR #19244 and a few follow-up PRs that fixed issues on with the ASAR bundle (#19325) and V8 snapshots (#19331). It also reverts the PR that switches the default back to `nsfw`, since reverting the other PRs rendered that unnecessary. Sorry for the churn everybody.