### PR TITLE
Wait for config file to load before prompting to restart in config.onDidChange callback

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -271,17 +271,17 @@ class AtomApplication extends EventEmitter {
 
   async launch (options) {
     if (!this.configFilePromise) {
-      this.configFilePromise = this.configFile.watch()
+      this.configFilePromise = this.configFile.watch().then(disposable => {
+        this.disposable.add(disposable)
+        this.config.onDidChange('core.titleBar', () => this.promptForRestart())
+        this.config.onDidChange('core.colorProfile', () => this.promptForRestart())
+      })
 
       // TodoElectronIssue: In electron v2 awaiting the watcher causes some delay
       // in Windows machines, which affects directly the startup time.
-      if (process.platform === 'win32') {
-        this.configFilePromise.then(disposable => this.disposable.add(disposable))
-      } else {
-        this.disposable.add(await this.configFilePromise)
+      if (process.platform !== 'win32') {
+        await this.configFilePromise
       }
-      this.config.onDidChange('core.titleBar', () => this.promptForRestart())
-      this.config.onDidChange('core.colorProfile', () => this.promptForRestart())
     }
 
     let optionsForWindowsToOpen = []


### PR DESCRIPTION
Fixes #19323.

In #19246, we stopped awaiting the watching of the config file on Windows for performance reasons. However, directly after the `await` of the promise returned by `watch`, we call `this.config.onDidChange` with the assumption that it has already been loaded. This PR moves those observations into a `then` callback chained onto the original promise so that we only observe changes once the file is loaded, regardless of whether we call `await`. It also adds the returned disposable in the `then` callback on all platforms just to unify the logic as much as possible.

cc @Arcanemagus 