### PR TITLE
Update .deb package dependencies

### DIFF
--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libcap2, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4
+Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4
 Recommends: lsb-release
 Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
 Section: devel

--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libcap2, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4
+Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libcap2, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4
 Recommends: lsb-release
 Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
 Section: devel

--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, gconf2, gconf-service, libgtk-3-0 (>= 3.9.10), libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libcap2, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4
+Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libcap2, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4
 Recommends: lsb-release
 Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
 Section: devel


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

First reported in https://github.com/atom/ci/issues/90, it seems that we aren't reporting the correct dependencies list in our `.deb` package files.

### Description of the Change

This PR:
* Replaces the `gconf2` and `gconf-service` dependencies with `libgconf-2-4 (>= 3.2.5) | libgconf2-4`
    * Originally added in https://github.com/atom/atom/commit/f431bb6396f9f5c5c5f98fa08040dc3410896d69 as a blanket list from the `webupd8` package of Atom at the time, these were likely mistaken attempts at the correct dependency.
    * `electron-installer-debian` lists [`libgconf-2-4 | libgconf2-4`](https://github.com/electron-userland/electron-installer-debian/blob/4ad7774f4e172bf11992efe81d9d12704df693d4/src/dependencies.js#L6), we are using the slightly more restrictive version range from Chrome 64.0.3282.167-1 documented [here](https://github.com/atom/atom/pull/16812#issuecomment-367502699).
* Removes the `libudev0 | libudev1` dependency
    * This was also added as part of https://github.com/atom/atom/commit/f431bb6396f9f5c5c5f98fa08040dc3410896d69. Our current binary doesn't link against this so if it was used in the past it is no longer required.
*  Removes the `libcap2` dependency
    * This was added in response to #7066, however no verification appears to have been done that this was actually necessary, and our current binary doesn't link against this library.

### Alternate Designs

The first point there is a mistake that definitely should be requested. The latter two removals of `libudev0 | libudev1` and `libcap2` could simply be left in though as it's possible some other part requires them.

### Possible Drawbacks

One of the removed dependencies may actually be required, leading to systems that don't have them installed from some other source having issues running Atom without manual installation of the dependencies first.

### Verification Process

I manually ran through the dependencies that would be generated by [electron-installer-debian](https://github.com/electron-userland/electron-installer-debian) for an Electron 2.x application and came up with the following list:
* `libgtk-3-0`
* `libnotify4`
* `libnss3`
* `libxss1`
* `libxtst6`
* `xdg-utils`
* `libgconf-2-4 | libgconf2-4`
  * This is _only_ required for Electron 2.x applications and should be removed once we migrate to Electron 3+
* The following are required for Electron's trash implementation, but none appear to currently be listed as Atom dependencies
  * `kde-cli-tools`
  * `kde-runtime`
  * `trash-cli`
  * `libglib2.0-bin`
  * `gvfs-bin`

Excluding the dependencies listed in that for a generic Electron application we are left with:
* `libcurl3 | libcurl4`
  * Needed for `dugite`, see #18201
* `git`
  * Needed for APM, see #4668
* `libxkbfile1`
  * Needed for `atom-keymap` / `keyboard-layout`, see https://github.com/atom/atom/pull/16812#issuecomment-367597643
* `libasound2 (>= 1.0.16)`
  * From Chrome .deb (recommended in Electron), see https://github.com/atom/atom/pull/16812#issuecomment-367502699
* `libx11-xcb1` # From Chrome .deb, see https://github.com/atom/atom/pull/16812#issuecomment-367502699
* `libgcrypt11 | libgcrypt20`
  * The need for this is unclear, but it is a dependency of the binary so it should remain listed
  * Originally added in https://github.com/atom/atom/commit/f431bb6396f9f5c5c5f98fa08040dc3410896d69 and expanded in https://github.com/atom/atom/commit/9b20239b9afa22425e283764bf9b13379a4fba7f
* `python`
  * This was Atom's first ever listed dependency... but with no reasoning attached. It's likely this is listed for APM.

After reviewing the list of dependencies and making the changes in this PR I ran through the build process manually in an `atom/atom-docker-ci` build instance and got a package with the following dependencies:
```
# dpkg -I out/atom-amd64.deb
 new Debian package, version 2.0.
 size 119913752 bytes: control archive=640 bytes.
     648 bytes,    12 lines      control
 Package: atom-dev
 Version: 1.39.0-dev-3945fd864
 Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4
 Recommends: lsb-release
 Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
 Section: devel
 Priority: optional
 Architecture: amd64
 Installed-Size: 595808
 Maintainer: GitHub <atom@github.com>
 Description: A hackable text editor for the 21st Century.
  Atom is a free and open source text editor that is modern, approachable, and hackable to the core.
```

This has _not_ been tested in a full Debian based linux distribution, only minimal ones within Docker!

### Release Notes

N/A