### PR TITLE
🚱 Fix leak of LanguageMode objects in tests

### DIFF
--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -90,6 +90,7 @@ module.exports = class PackageManager {
     this.packagesCache = packageJSON._atomPackages != null ? packageJSON._atomPackages : {}
     this.packageDependencies = packageJSON.packageDependencies != null ? packageJSON.packageDependencies : {}
     this.triggeredActivationHooks.clear()
+    this.activatePromise = null
   }
 
   /*
@@ -112,6 +113,14 @@ module.exports = class PackageManager {
   // Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
   onDidActivateInitialPackages (callback) {
     return this.emitter.on('did-activate-initial-packages', callback)
+  }
+
+  getActivatePromise() {
+    if (this.activatePromise) {
+      return this.activatePromise
+    } else {
+      return Promise.resolve()
+    }
   }
 
   // Public: Invoke the given callback when a package is activated.
@@ -659,10 +668,11 @@ module.exports = class PackageManager {
       const packages = this.getLoadedPackagesForTypes(types)
       promises = promises.concat(activator.activatePackages(packages))
     }
-    return Promise.all(promises).then(() => {
+    this.activatePromise = Promise.all(promises).then(() => {
       this.triggerDeferredActivationHooks()
       this.initialPackagesActivated = true
       this.emitter.emit('did-activate-initial-packages')
+      this.activatePromise = null
     })
   }
 

--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -674,6 +674,7 @@ module.exports = class PackageManager {
       this.emitter.emit('did-activate-initial-packages')
       this.activatePromise = null
     })
+    return this.activatePromise
   }
 
   registerURIHandlerForPackage (packageName, handler) {

--- a/src/text-editor-registry.js
+++ b/src/text-editor-registry.js
@@ -38,19 +38,10 @@ const EDITOR_PARAMS_BY_SETTING_KEY = [
 module.exports =
 class TextEditorRegistry {
   constructor ({config, assert, packageManager}) {
-    this.assert = assert
     this.config = config
+    this.assert = assert
+    this.packageManager = packageManager
     this.clear()
-
-    this.initialPackageActivationPromise = new Promise((resolve) => {
-      // TODO: Remove this usage of a private property of PackageManager.
-      // Should PackageManager just expose a promise-based API like this?
-      if (packageManager.deferredActivationHooks) {
-        packageManager.onDidActivateInitialPackages(resolve)
-      } else {
-        resolve()
-      }
-    })
   }
 
   deserialize (state) {
@@ -216,7 +207,7 @@ class TextEditorRegistry {
   }
 
   async updateAndMonitorEditorSettings (editor, oldLanguageMode) {
-    await this.initialPackageActivationPromise
+    await this.packageManager.getActivatePromise()
     this.updateEditorSettingsForLanguageMode(editor, oldLanguageMode)
     this.subscribeToSettingsForEditorScope(editor)
   }


### PR DESCRIPTION
Fixes #18991

In #18991, we were experiencing render process crashes caused by the render process running out of memory. Upon investigating, we discovered that the memory used by the `Atom Helper` process rapidly increased during `text-editor-spec.js`, from a couple hundred megabytes to 3+ gigabytes by the end of those tests.

We were confused, because a heap snapshot of the process indicated a normal heap size of just a couple hundred megabytes. Upon further investigation, I discovered that we were leaking `TextMateLanguageMode` objects. These language modes reference TextMate grammars, which themselves reference a large number of Oniguruma regular expression objects, which are implemented in a native C++ and therefore not tracked as part of the JS heap. That explains the discrepancy between the process memory consumed and what was being reported in the Chrome dev tools.

The cause of the leak was subtle. In `TextEditorRegistry`, we were assigning a promise to an instance field named `initialPackageActivationPromise`. This would resolve when the `PackageManager` emitted an `onDidActivateInitialPackages` event. We then `await`ed this promise in `updateAndMonitorEditorSettings`, and this ended up implicitly capturing the `oldLanguageMode` variable that we interacted with after resuming from the `await`. Unfortunately, in many tests, we never emit the `onDidActivateInitialPackages` event at all, so this promise was hanging around unresolved. This was causing the `oldLanguageMode` to be kept in scope by the `initialPackageActivationPromise` we were `await`ing. Not sure how clear that was, but hopefully it helps explain the diff to a careful reader.

My solution is to expose a `getActivatePromise` method on the `PackageManager` itself. We store off the promise during activation and then null it out when we're done. Most importantly, we *also* null out this promise when we call `PackageManager.prototype.reset`, so that any objects that are implicitly captured by code `await`ing this promise get garbage collected.

As a result, we end `text-editor-spec.js` with 6 `TextMateLanguageMode` objects on the heap instead of 954, and the memory consumed by the process is kept more reasonable (though Jasmine still seems to be leakier than I'd prefer).

### Before:

<img width="1023" alt="Screen Shot 2019-05-17 at 4 32 37 PM" src="https://user-images.githubusercontent.com/1789/57960152-7e560300-78c4-11e9-9f5a-21352bd9e1c3.png">

### After:

<img width="1023" alt="Screen Shot 2019-05-17 at 4 39 15 PM" src="https://user-images.githubusercontent.com/1789/57960158-83b34d80-78c4-11e9-9767-1f22600ea86e.png">
