### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/main-process/atom-protocol-handler.js
+++ b/src/main-process/atom-protocol-handler.js
@@ -1,5 +1,5 @@
 const {protocol} = require('electron')
-const fs = require('fs')
+const fs = require('fs-plus')
 const path = require('path')
 
 // Handles requests with 'atom' protocol.


### PR DESCRIPTION
This pull request fixes some deprecation warnings we were observing in [our test suite](https://dev.azure.com/github/Atom/_build/results?buildId=40878&view=logs&jobId=a5e52b91-c83f-5429-4a68-c246fc63a4f7&taskId=8b9bff53-2841-58c7-68fc-e30c30330fc3&lineStart=336&lineEnd=337&colStart=1&colEnd=1), as well as when opening packages that registered protocol handlers such as the `welcome` package.

The warnings were due to using the `fs.(l)statSyncNoException` API, which will be deprecated from Electron 4 onwards. We had already dealt with this by shipping https://github.com/atom/fs-plus/pull/46, which provided a shim on `fs-plus` to suppress the warning. However, `AtomProtocolHandler` was still using the standard `fs` module, which was causing the warning to be displayed whenever a package registered a URL opener.

With these changes, we will now require `fs-plus` instead of `fs` in `AtomProtocolHandler`, thus using the shimmed API that does not emit a deprecation warning.

/cc: @jasonrudolph @50Wliu @rafeca 