### PR TITLE
Highlight keyword.operator by default

### DIFF
--- a/packages/one-dark-syntax/styles/syntax/_base.less
+++ b/packages/one-dark-syntax/styles/syntax/_base.less
@@ -28,7 +28,7 @@
   }
 
   &.syntax--operator {
-    color: @mono-1;
+    color: @hue-3;
   }
 
   &.syntax--other.syntax--special-method {


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

Highlight keyword.operator by default

Fixes #19386 

### Description of the Change

Change operator color to @hue-3, which is also used in C, C++, Python, and Java

### Alternate Designs

@hue-1 is also possible (used by JavaScript and TypeScript), bug alas...

### Possible Drawbacks

People have to update screenshots?

### Verification Process

None

### Release Notes

Not applicable