### PR TITLE
Revert inadvertent changes to package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1529,11 +1529,11 @@
       "dependencies": {
         "etch": {
           "version": "0.9.0",
-          "resolved": false
+          "bundled": true
         },
         "semver": {
           "version": "5.5.1",
-          "resolved": false
+          "bundled": true
         }
       }
     },
@@ -1819,11 +1819,11 @@
       "dependencies": {
         "underscore": {
           "version": "1.9.1",
-          "resolved": false
+          "bundled": true
         },
         "underscore-plus": {
           "version": "1.7.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "underscore": "^1.9.1"
           }
@@ -2115,7 +2115,6 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -2675,7 +2674,7 @@
       "dependencies": {
         "grim": {
           "version": "2.0.2",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "event-kit": "^2.0.0"
           }
@@ -2828,22 +2827,22 @@
       "dependencies": {
         "etch": {
           "version": "0.9.0",
-          "resolved": false
+          "bundled": true
         },
         "grim": {
           "version": "2.0.2",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "event-kit": "^2.0.0"
           }
         },
         "underscore": {
           "version": "1.9.1",
-          "resolved": false
+          "bundled": true
         },
         "underscore-plus": {
           "version": "1.7.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "underscore": "^1.9.1"
           }
@@ -3180,11 +3179,11 @@
       "dependencies": {
         "underscore": {
           "version": "1.9.1",
-          "resolved": false
+          "bundled": true
         },
         "underscore-plus": {
           "version": "1.7.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "underscore": "^1.9.1"
           }
@@ -3656,11 +3655,11 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": false
+          "bundled": true
         },
         "temp": {
           "version": "0.8.3",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "os-tmpdir": "^1.0.0",
             "rimraf": "~2.2.6"
@@ -3863,8 +3862,7 @@
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "optional": true
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "home-or-tmp": {
       "version": "1.0.0",
@@ -4133,7 +4131,7 @@
       "resolved": "https://registry.npmjs.org/jasmine-focused/-/jasmine-focused-1.0.7.tgz",
       "integrity": "sha1-uDx1fIAOaOHW78GjoaE/85/23NI=",
       "requires": {
-        "jasmine-node": "jasmine-node@git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
+        "jasmine-node": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
         "underscore-plus": "1.x",
         "walkdir": "0.0.7"
       }
@@ -4716,11 +4714,11 @@
       "dependencies": {
         "underscore": {
           "version": "1.9.1",
-          "resolved": false
+          "bundled": true
         },
         "underscore-plus": {
           "version": "1.7.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "underscore": "^1.9.1"
           }
@@ -4743,11 +4741,11 @@
       "dependencies": {
         "underscore": {
           "version": "1.9.1",
-          "resolved": false
+          "bundled": true
         },
         "underscore-plus": {
           "version": "1.7.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "underscore": "^1.9.1"
           }


### PR DESCRIPTION
🍐'd with @jasonrudolph 

The changes to `package-lock.json` we are reverting in this PR were introduced for unknown reasons in fd82a58f1d6e851000e73e434de21b967920b194. Perhaps I accidentally ran `npm install` inside the this repository with a newer version of `npm`, but that's just a theory.

For whatever reason, the changes caused the following failure when building from a clean state locally on `master`:

```
./script/build --install
Node:	v8.16.0
Npm:	v6.2.0
Cleaning /Users/joe/github/atom/apm/node_modules
Cleaning /Users/joe/github/atom/node_modules
Cleaning /Users/joe/github/atom/script/node_modules
Installing script dependencies
../src/main.cc:26:15: warning: 'Call' is deprecated [-Wdeprecated-declarations]
    callback->Call(1, argv);
              ^
../../nan/nan.h:1617:3: note: 'Call' has been explicitly marked deprecated here
  NAN_DEPRECATED inline v8::Local<v8::Value>
  ^
../../nan/nan.h:98:40: note: expanded from macro 'NAN_DEPRECATED'
# define NAN_DEPRECATED __attribute__((deprecated))
                                       ^
1 warning generated.
Installing apm
../src/onig-scanner-worker.cc:37:15: warning: 'Call' is deprecated [-Wdeprecated-declarations]
    callback->Call(2, argv);
              ^
../../nan/nan.h:1739:3: note: 'Call' has been explicitly marked deprecated here
  NAN_DEPRECATED inline v8::Local<v8::Value>
  ^
../../nan/nan.h:104:40: note: expanded from macro 'NAN_DEPRECATED'
# define NAN_DEPRECATED __attribute__((deprecated))
                                       ^
../src/onig-scanner-worker.cc:43:15: warning: 'Call' is deprecated [-Wdeprecated-declarations]
    callback->Call(2, argv);
              ^
../../nan/nan.h:1739:3: note: 'Call' has been explicitly marked deprecated here
  NAN_DEPRECATED inline v8::Local<v8::Value>
  ^
../../nan/nan.h:104:40: note: expanded from macro 'NAN_DEPRECATED'
# define NAN_DEPRECATED __attribute__((deprecated))
                                       ^
2 warnings generated.
../src/onig-string.cc:30:40: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
  hasMultiByteChars = (value->Length() != utf8_length_);
                       ~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~
1 warning generated.
../deps/libgit2/deps/zlib/inflate.c:1507:61: warning: shifting a negative signed value is undefined [-Wshift-negative-value]
    if (strm == Z_NULL || strm->state == Z_NULL) return -1L << 16;
                                                        ~~~ ^
1 warning generated.
../src/onig-scanner-worker.cc:37:15: warning: 'Call' is deprecated [-Wdeprecated-declarations]
    callback->Call(2, argv);
              ^
../../nan/nan.h:1739:3: note: 'Call' has been explicitly marked deprecated here
  NAN_DEPRECATED inline v8::Local<v8::Value>
  ^
../../nan/nan.h:104:40: note: expanded from macro 'NAN_DEPRECATED'
# define NAN_DEPRECATED __attribute__((deprecated))
                                       ^
../src/onig-scanner-worker.cc:43:15: warning: 'Call' is deprecated [-Wdeprecated-declarations]
    callback->Call(2, argv);
              ^
../../nan/nan.h:1739:3: note: 'Call' has been explicitly marked deprecated here
  NAN_DEPRECATED inline v8::Local<v8::Value>
  ^
../../nan/nan.h:104:40: note: expanded from macro 'NAN_DEPRECATED'
# define NAN_DEPRECATED __attribute__((deprecated))
                                       ^
2 warnings generated.
../src/onig-string.cc:30:40: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
  hasMultiByteChars = (value->Length() != utf8_length_);
                       ~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~
1 warning generated.
../deps/libgit2/deps/zlib/inflate.c:1507:61: warning: shifting a negative signed value is undefined [-Wshift-negative-value]
    if (strm == Z_NULL || strm->state == Z_NULL) return -1L << 16;
                                                        ~~~ ^
1 warning generated.
apm  2.2.4
npm  6.2.0
node 8.9.3 x64
atom 1.39.0-dev-4057388da
python 2.7.16
git 2.21.0
Installing modules ✗
> atom@1.39.0-dev preinstall /Users/joe/github/atom
> node -e 'process.exit(0)'


npm ERR! code ENOLOCAL
npm ERR! Could not install from "node_modules/jasmine-focused/jasmine-node@git+https:/github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef" as it does not contain a package.json file.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/joe/.atom/.apm/_logs/2019-05-24T16_00_13_487Z-debug.log
child_process.js:630
    throw err;
    ^

Error: Command failed: /Users/joe/github/atom/apm/node_modules/atom-package-manager/bin/apm install
    at checkExecSyncError (child_process.js:607:13)
    at Object.execFileSync (child_process.js:627:13)
    at module.exports (/Users/joe/github/atom/script/lib/run-apm-install.js:14:16)
    at Object.<anonymous> (/Users/joe/github/atom/script/bootstrap:44:1)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
```

cc @joefitzgerald and thanks again for the heads up! ❤️ 