### PR TITLE
Upgrade atom-keymap to incorporate changes to keyboard-layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1709,16 +1709,16 @@
       }
     },
     "atom-keymap": {
-      "version": "8.2.13-0",
-      "resolved": "https://registry.npmjs.org/atom-keymap/-/atom-keymap-8.2.13-0.tgz",
-      "integrity": "sha512-VnMMDwaKTk3IPIb6bJUJDbM5wHsgL/IXbE/Qmrc4sMgdMf45jU6ZDPimHB8Ll6tmSQibh9LPv4zZ/hYgUuzSCQ==",
+      "version": "8.2.14",
+      "resolved": "https://registry.npmjs.org/atom-keymap/-/atom-keymap-8.2.14.tgz",
+      "integrity": "sha512-9ofjA8IG/RNJcqvMvYglc0l7DljavIUQvGs5xdEtd5dEYX4rCQo9coeBfGaC0YM7FB0SBHPZy39QYFROkOzTOw==",
       "requires": {
         "clear-cut": "^2",
         "emissary": "^1.1.0",
         "event-kit": "^1.0.0",
         "fs-plus": "^3.0.0",
         "grim": "^1.2.1",
-        "keyboard-layout": "2.0.15-0",
+        "keyboard-layout": "2.0.16",
         "pathwatcher": "^8.0.0",
         "property-accessors": "^1",
         "season": "^6.0.2"
@@ -4332,9 +4332,9 @@
       }
     },
     "keyboard-layout": {
-      "version": "2.0.15-0",
-      "resolved": "https://registry.npmjs.org/keyboard-layout/-/keyboard-layout-2.0.15-0.tgz",
-      "integrity": "sha512-FmNwOaqs0nxkLgSFEAzIczV3gpBedFJ4xl/djzpsxbT36v/cafixtvs2e0g9PNMUxyHTyC48qXMMTftuTT78tg==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/keyboard-layout/-/keyboard-layout-2.0.16.tgz",
+      "integrity": "sha512-eGrxmlV6jbm/mbPEOpYGuH53XEC7wIUj9ZxKcT2z9QHJ/RwrT9iVkvxka9zRxqHZHwQzcffgsa5OxoVAKnhK9w==",
       "requires": {
         "event-kit": "^2.0.0",
         "nan": "^2.13.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1709,16 +1709,16 @@
       }
     },
     "atom-keymap": {
-      "version": "8.2.13",
-      "resolved": "https://registry.npmjs.org/atom-keymap/-/atom-keymap-8.2.13.tgz",
-      "integrity": "sha512-RNf+5KbAiXpNV2KZT0+XYpTRFE8rhq7NrBryghJAOlwayY3g3z6Kp9tMfaPJ05BkPo9mChcaFO6SKUL8LTQcBg==",
+      "version": "8.2.13-0",
+      "resolved": "https://registry.npmjs.org/atom-keymap/-/atom-keymap-8.2.13-0.tgz",
+      "integrity": "sha512-VnMMDwaKTk3IPIb6bJUJDbM5wHsgL/IXbE/Qmrc4sMgdMf45jU6ZDPimHB8Ll6tmSQibh9LPv4zZ/hYgUuzSCQ==",
       "requires": {
         "clear-cut": "^2",
         "emissary": "^1.1.0",
         "event-kit": "^1.0.0",
         "fs-plus": "^3.0.0",
         "grim": "^1.2.1",
-        "keyboard-layout": "2.0.14",
+        "keyboard-layout": "2.0.15-0",
         "pathwatcher": "^8.0.0",
         "property-accessors": "^1",
         "season": "^6.0.2"
@@ -4332,12 +4332,19 @@
       }
     },
     "keyboard-layout": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/keyboard-layout/-/keyboard-layout-2.0.14.tgz",
-      "integrity": "sha512-QuCfpEC8oai6F8oaNQdxi5+1QIpaQu9HSVI9yzkC2HbIXeBnahzHFDRVGUtwwAWiNnzjNBjUI/djsrMGUTgK1w==",
+      "version": "2.0.15-0",
+      "resolved": "https://registry.npmjs.org/keyboard-layout/-/keyboard-layout-2.0.15-0.tgz",
+      "integrity": "sha512-FmNwOaqs0nxkLgSFEAzIczV3gpBedFJ4xl/djzpsxbT36v/cafixtvs2e0g9PNMUxyHTyC48qXMMTftuTT78tg==",
       "requires": {
         "event-kit": "^2.0.0",
-        "nan": "^2.10.0"
+        "nan": "^2.13.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        }
       }
     },
     "keytar": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "async": "0.2.6",
     "atom-dark-syntax": "file:packages/atom-dark-syntax",
     "atom-dark-ui": "file:packages/atom-dark-ui",
-    "atom-keymap": "8.2.13",
+    "atom-keymap": "8.2.13-0",
     "atom-light-syntax": "file:packages/atom-light-syntax",
     "atom-light-ui": "file:packages/atom-light-ui",
     "atom-select-list": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "async": "0.2.6",
     "atom-dark-syntax": "file:packages/atom-dark-syntax",
     "atom-dark-ui": "file:packages/atom-dark-ui",
-    "atom-keymap": "8.2.13-0",
+    "atom-keymap": "8.2.14",
     "atom-light-syntax": "file:packages/atom-light-syntax",
     "atom-light-ui": "file:packages/atom-light-ui",
     "atom-select-list": "^0.7.2",


### PR DESCRIPTION
In https://github.com/atom/keyboard-layout/pull/51, @MarshallOfSound made some behavior-preserving changes to make the `keyboard-layout` module context-aware. I wanted to get that PR merged for him, and I also want to keep Atom up-to-date. This PR is to ensure we build green against the updated dependency. Once we get a green build I will publish non prerelease versions of `atom-keymap` and `keyboard-layout`.