### PR TITLE
Enable eslint rules that got disabled

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,6 @@
   "rules": {
     "standard/no-callback-literal": ["off"],
     "node/no-deprecated-api": ["off"],
-    "no-use-before-define": ["off"],
     "prettier/prettier": ["off"] // disable prettier rules for now.
   },
   "overrides": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,6 @@
   "rules": {
     "standard/no-callback-literal": ["off"],
     "node/no-deprecated-api": ["off"],
-    "no-unused-expressions": ["off"],
     "symbol-description": ["off"],
     "no-use-before-define": ["off"],
     "prettier/prettier": ["off"] // disable prettier rules for now.

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,8 +24,6 @@
   },
   "rules": {
     "standard/no-callback-literal": ["off"],
-    "no-mixed-operators": ["off"],
-    "no-useless-escape": ["off"],
     "no-return-await": ["off"],
     "node/no-deprecated-api": ["off"],
     "prefer-promise-reject-errors": ["off"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,6 @@
   },
   "rules": {
     "standard/no-callback-literal": ["off"],
-    "no-return-await": ["off"],
     "node/no-deprecated-api": ["off"],
     "prefer-promise-reject-errors": ["off"],
     "no-unused-expressions": ["off"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,6 @@
   "rules": {
     "standard/no-callback-literal": ["off"],
     "node/no-deprecated-api": ["off"],
-    "symbol-description": ["off"],
     "no-use-before-define": ["off"],
     "prettier/prettier": ["off"] // disable prettier rules for now.
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,6 @@
   "rules": {
     "standard/no-callback-literal": ["off"],
     "node/no-deprecated-api": ["off"],
-    "prefer-promise-reject-errors": ["off"],
     "no-unused-expressions": ["off"],
     "symbol-description": ["off"],
     "no-use-before-define": ["off"],

--- a/script/lib/test-sign-on-mac.js
+++ b/script/lib/test-sign-on-mac.js
@@ -6,7 +6,7 @@ module.exports = function (packagedAppPath) {
       'find-certificate', '-c', 'Mac Developer'
     ])
 
-  const certMatch = (result.stdout || '').toString().match(/\"(Mac Developer.*\))\"/)
+  const certMatch = (result.stdout || '').toString().match(/"(Mac Developer.*\))"/)
   if (!certMatch || !certMatch[1]) {
     console.error('A "Mac Developer" certificate must be configured to perform test signing')
   } else {

--- a/spec/atom-environment-spec.js
+++ b/spec/atom-environment-spec.js
@@ -66,7 +66,7 @@ describe('AtomEnvironment', () => {
 
     it('will open the dev tools when an error is triggered', async () => {
       try {
-        a + 1 // eslint-disable-line no-undef
+        a + 1 // eslint-disable-line no-undef, no-unused-expressions
       } catch (e) {
         window.onerror(e.toString(), 'abc', 2, 3, e)
       }
@@ -87,7 +87,7 @@ describe('AtomEnvironment', () => {
         let error = null
         atom.onWillThrowError(willThrowSpy)
         try {
-          a + 1 // eslint-disable-line no-undef
+          a + 1 // eslint-disable-line no-undef, no-unused-expressions
         } catch (e) {
           error = e
           window.onerror(e.toString(), 'abc', 2, 3, e)
@@ -108,7 +108,7 @@ describe('AtomEnvironment', () => {
         atom.onWillThrowError(willThrowSpy)
 
         try {
-          a + 1 // eslint-disable-line no-undef
+          a + 1 // eslint-disable-line no-undef, no-unused-expressions
         } catch (e) {
           window.onerror(e.toString(), 'abc', 2, 3, e)
         }
@@ -127,7 +127,7 @@ describe('AtomEnvironment', () => {
         let error = null
         atom.onDidThrowError(didThrowSpy)
         try {
-          a + 1 // eslint-disable-line no-undef
+          a + 1 // eslint-disable-line no-undef, no-unused-expressions
         } catch (e) {
           error = e
           window.onerror(e.toString(), 'abc', 2, 3, e)

--- a/spec/atom-environment-spec.js
+++ b/spec/atom-environment-spec.js
@@ -545,7 +545,7 @@ describe('AtomEnvironment', () => {
           spyOn(atom, 'confirm').andReturn(1)
           spyOn(atom.project, 'addPath')
           spyOn(atom.workspace, 'open')
-          const state = Symbol()
+          const state = Symbol('state')
           atom.attemptRestoreProjectStateForPaths(
             state,
             [__dirname],
@@ -560,7 +560,7 @@ describe('AtomEnvironment', () => {
         spyOn(atom, 'confirm').andCallFake((options, callback) => callback(1))
         spyOn(atom.project, 'addPath')
         spyOn(atom.workspace, 'open')
-        const state = Symbol()
+        const state = Symbol('state')
 
         atom.attemptRestoreProjectStateForPaths(
           state,
@@ -579,7 +579,7 @@ describe('AtomEnvironment', () => {
         jasmine.useRealClock()
         spyOn(atom, 'confirm').andCallFake((options, callback) => callback(0))
         spyOn(atom, 'open')
-        const state = Symbol()
+        const state = Symbol('state')
 
         atom.attemptRestoreProjectStateForPaths(
           state,

--- a/spec/command-registry-spec.js
+++ b/spec/command-registry-spec.js
@@ -414,7 +414,7 @@ describe('CommandRegistry', () => {
         () =>
           new Promise((resolve, reject) => {
             setTimeout(() => {
-              reject(3)
+              reject(3) // eslint-disable-line prefer-promise-reject-errors
             }, 1)
           })
       )

--- a/spec/style-manager-spec.js
+++ b/spec/style-manager-spec.js
@@ -57,7 +57,7 @@ describe('StyleManager', () => {
           atom-text-editor::shadow .class-1, atom-text-editor::shadow .class-2 { color: red }
           atom-text-editor::shadow > .class-3 { color: yellow }
           atom-text-editor .class-4 { color: blue }
-          atom-text-editor[data-grammar*=\"js\"]::shadow .class-6 { color: green; }
+          atom-text-editor[data-grammar*="js"]::shadow .class-6 { color: green; }
           atom-text-editor[mini].is-focused::shadow .class-7 { color: green; }
         `)
         expect(

--- a/src/buffered-process.js
+++ b/src/buffered-process.js
@@ -88,18 +88,18 @@ class BufferedProcess {
             return arg
           } else {
             // Escape double quotes by putting a backslash in front of them
-            return `\"${arg.toString().replace(/"/g, '\\"')}\"`
+            return `"${arg.toString().replace(/"/g, '\\"')}"`
           }
         })
     }
 
     // The command itself is quoted if it contains spaces, &, ^, | or # chars
-    cmdArgs.unshift(/\s|&|\^|\(|\)|\||#/.test(command) ? `\"${command}\"` : command)
+    cmdArgs.unshift(/\s|&|\^|\(|\)|\||#/.test(command) ? `"${command}"` : command)
 
     const cmdOptions = _.clone(options)
     cmdOptions.windowsVerbatimArguments = true
 
-    this.spawn(this.getCmdPath(), ['/s', '/d', '/c', `\"${cmdArgs.join(' ')}\"`], cmdOptions)
+    this.spawn(this.getCmdPath(), ['/s', '/d', '/c', `"${cmdArgs.join(' ')}"`], cmdOptions)
   }
 
   /*

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -221,7 +221,7 @@ exports.install = function (resourcesPath, nodeRequire) {
   Error.prototype.getRawStack = function () {
     // Access this.stack to ensure prepareStackTrace has been run on this error
     // because it assigns this.rawStack as a side-effect
-    this.stack
+    this.stack // eslint-disable-line no-unused-expressions
     return this.rawStack
   }
 

--- a/src/default-directory-searcher.js
+++ b/src/default-directory-searcher.js
@@ -98,7 +98,7 @@ module.exports = class DefaultDirectorySearcher {
         if (isCancelled) {
           resolve()
         } else {
-          reject()
+          reject() // eslint-disable-line prefer-promise-reject-errors
         }
       })
     })

--- a/src/git-repository-provider.js
+++ b/src/git-repository-provider.js
@@ -87,7 +87,7 @@ async function findGitDirectory (directory) {
   } else if (directory.isRoot()) {
     return null
   } else {
-    return await findGitDirectory(directory.getParent())
+    return findGitDirectory(directory.getParent())
   }
 }
 
@@ -117,7 +117,7 @@ async function isValidGitDirectory (directory) {
   return (
     (await directory.getSubdirectory('objects').exists()) &&
     (await directory.getFile('HEAD').exists()) &&
-    (await directory.getSubdirectory('refs').exists())
+    directory.getSubdirectory('refs').exists()
   )
 }
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -1230,7 +1230,7 @@ class AtomApplication extends EventEmitter {
     } else if (state.version === undefined) {
       // Atom <= 1.36.0
       // Schema: [{initialPaths: ['<root-dir>', ...]}, ...]
-      return await Promise.all(
+      return Promise.all(
         state.map(async windowState => {
           // Classify each window's initialPaths as directories or non-directories
           const classifiedPaths = await Promise.all(

--- a/src/main-process/squirrel-update.js
+++ b/src/main-process/squirrel-update.js
@@ -34,19 +34,19 @@ const addCommandsToPath = callback => {
   const installCommands = callback => {
     const atomCommandPath = path.join(binFolder, 'atom.cmd')
     const relativeAtomPath = path.relative(binFolder, path.join(appFolder, 'resources', 'cli', 'atom.cmd'))
-    const atomCommand = `@echo off\r\n\"%~dp0\\${relativeAtomPath}\" %*`
+    const atomCommand = `@echo off\r\n"%~dp0\\${relativeAtomPath}" %*`
 
     const atomShCommandPath = path.join(binFolder, 'atom')
     const relativeAtomShPath = path.relative(binFolder, path.join(appFolder, 'resources', 'cli', 'atom.sh'))
-    const atomShCommand = `#!/bin/sh\r\n\"$(dirname \"$0\")/${relativeAtomShPath.replace(/\\/g, '/')}\" \"$@\"\r\necho`
+    const atomShCommand = `#!/bin/sh\r\n"$(dirname "$0")/${relativeAtomShPath.replace(/\\/g, '/')}" "$@"\r\necho`
 
     const apmCommandPath = path.join(binFolder, 'apm.cmd')
     const relativeApmPath = path.relative(binFolder, path.join(process.resourcesPath, 'app', 'apm', 'bin', 'apm.cmd'))
-    const apmCommand = `@echo off\r\n\"%~dp0\\${relativeApmPath}\" %*`
+    const apmCommand = `@echo off\r\n"%~dp0\\${relativeApmPath}" %*`
 
     const apmShCommandPath = path.join(binFolder, 'apm')
     const relativeApmShPath = path.relative(binFolder, path.join(appFolder, 'resources', 'cli', 'apm.sh'))
-    const apmShCommand = `#!/bin/sh\r\n\"$(dirname \"$0\")/${relativeApmShPath.replace(/\\/g, '/')}\" \"$@\"`
+    const apmShCommand = `#!/bin/sh\r\n"$(dirname "$0")/${relativeApmShPath.replace(/\\/g, '/')}" "$@"`
 
     fs.writeFile(atomCommandPath, atomCommand, () =>
       fs.writeFile(atomShCommandPath, atomShCommand, () =>

--- a/src/main-process/win-shell.js
+++ b/src/main-process/win-shell.js
@@ -2,8 +2,8 @@ const Registry = require('winreg')
 const Path = require('path')
 
 let exeName = Path.basename(process.execPath)
-let appPath = `\"${process.execPath}\"`
-let fileIconPath = `\"${Path.join(process.execPath, '..', 'resources', 'cli', 'file.ico')}\"`
+let appPath = `"${process.execPath}"`
+let fileIconPath = `"${Path.join(process.execPath, '..', 'resources', 'cli', 'file.ico')}"`
 let isBeta = appPath.includes(' Beta')
 let appName = exeName.replace('atom', isBeta ? 'Atom Beta' : 'Atom').replace('.exe', '')
 
@@ -56,14 +56,14 @@ exports.appName = appName
 
 exports.fileHandler = new ShellOption(`\\Software\\Classes\\Applications\\${exeName}`,
   [
-    {key: 'shell\\open\\command', name: '', value: `${appPath} \"%1\"`},
+    {key: 'shell\\open\\command', name: '', value: `${appPath} "%1"`},
     {key: 'shell\\open', name: 'FriendlyAppName', value: `${appName}`},
     {key: 'DefaultIcon', name: '', value: `${fileIconPath}`}
   ]
 )
 
 let contextParts = [
-    {key: 'command', name: '', value: `${appPath} \"%1\"`},
+    {key: 'command', name: '', value: `${appPath} "%1"`},
     {name: '', value: `Open with ${appName}`},
     {name: 'Icon', value: `${appPath}`}
 ]

--- a/src/pane.js
+++ b/src/pane.js
@@ -949,7 +949,7 @@ class Pane {
       }
     })
 
-    return await saveDialogPromise
+    return saveDialogPromise
   }
 
   // Public: Save all items.

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -55,7 +55,7 @@ class NativeWatcher {
   }
 
   doStart () {
-    return Promise.reject('doStart() not overridden')
+    return Promise.reject(new Error('doStart() not overridden'))
   }
 
   // Private: Return true if the underlying watcher is actively listening for filesystem events.

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -197,7 +197,7 @@ class TreeSitterLanguageMode {
     )
   }
 
-  indentLevelForLine (line, tabLength = tabLength) {
+  indentLevelForLine (line, tabLength) {
     let indentLength = 0
     for (let i = 0, {length} = line; i < length; i++) {
       const char = line[i]


### PR DESCRIPTION
On https://github.com/atom/atom/pull/19302, a few `eslint` rules were disabled to keep that PR small and manageable, now it's the time to enable a few of them.

There are two rules that I haven't enabled:

* `standard/no-callback-literal`: We have quite a few Atom public APIs that expect a callback with the result on the first argument, so to enable this rule we would have to either add a bunch of `ignore` comments or to create a quite big breaking change.
* `node/no-deprecated-api`: This is a quite useful rule, but I haven't been able to enable it because it complains about using `url.parse()`. Changing this to the new `URL()` constructor would be a breaking change, since we're passing `url` objects to packages.

We can follow-up what to do for these two rules in separate PRs, to keep the discussion focused.