### PR TITLE
Escalate privileges when writing into a restricted location on Linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4442,8 +4442,14 @@
     "language-json": {
       "version": "https://www.atom.io/api/packages/language-json/versions/1.0.2/tarball",
       "integrity": "sha512-2OvmYoTjO5IXnnRMVMfPb7iOMEnqD36otbpOpQUELG4eJJqgrms6Hs7HnevFs5ZB4yLc1ZU2u9h9TAp/WXUmdA==",
-      "requires": {
-        "tree-sitter-json": "git://github.com/tree-sitter/tree-sitter-json.git#337f55be9b9b1ccb0baa7763bfe014a94acea7ea"
+      "dependencies": {
+        "tree-sitter-json": {
+          "version": "git://github.com/tree-sitter/tree-sitter-json.git#337f55be9b9b1ccb0baa7763bfe014a94acea7ea",
+          "from": "git://github.com/tree-sitter/tree-sitter-json.git#337f55be9b9b1ccb0baa7763bfe014a94acea7ea",
+          "requires": {
+            "nan": "^2.0.0"
+          }
+        }
       }
     },
     "language-less": {
@@ -6959,15 +6965,15 @@
       }
     },
     "text-buffer": {
-      "version": "13.15.3",
-      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.15.3.tgz",
-      "integrity": "sha512-H2fz/N15g0fBP7R33FUFLnIyND+Lji/xmuvHg9rKgmfCh7NAVxiFIvnZTabuBhL9InqPrtV5t4hkUy+r3dNXMg==",
+      "version": "13.15.4-0",
+      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.15.4-0.tgz",
+      "integrity": "sha512-7Cji8djB+Ncpru2TSadFvdThumwLn7sto8Omizh+W3twAZ1kWwOrbTN+UUmtnG/MrckRbOQqVutz97bIFq+CpA==",
       "requires": {
         "delegato": "^1.0.0",
         "diff": "^2.2.1",
         "emissary": "^1.0.0",
         "event-kit": "^2.4.0",
-        "fs-admin": "^0.1.7",
+        "fs-admin": "^0.5.0",
         "fs-plus": "^3.0.0",
         "grim": "^2.0.2",
         "mkdirp": "^0.5.1",
@@ -6982,6 +6988,14 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
           "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
         },
+        "fs-admin": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/fs-admin/-/fs-admin-0.5.0.tgz",
+          "integrity": "sha512-jU0x86bI6wmhdGGcpaO1rI7EpNx/44cEXPsHqFIRgs9SVsk3HSWn9Zd5fd7bdDw3LcmdnazOcJFK9PZsoNecAA==",
+          "requires": {
+            "nan": "^2.13.2"
+          }
+        },
         "grim": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/grim/-/grim-2.0.2.tgz",
@@ -6989,6 +7003,11 @@
           "requires": {
             "event-kit": "^2.0.0"
           }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
         }
       }
     },
@@ -7141,13 +7160,6 @@
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
           "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
         }
-      }
-    },
-    "tree-sitter-json": {
-      "version": "git://github.com/tree-sitter/tree-sitter-json.git#337f55be9b9b1ccb0baa7763bfe014a94acea7ea",
-      "from": "git://github.com/tree-sitter/tree-sitter-json.git#v0.14.0",
-      "requires": {
-        "nan": "^2.0.0"
       }
     },
     "tree-sitter-python": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4442,14 +4442,8 @@
     "language-json": {
       "version": "https://www.atom.io/api/packages/language-json/versions/1.0.2/tarball",
       "integrity": "sha512-2OvmYoTjO5IXnnRMVMfPb7iOMEnqD36otbpOpQUELG4eJJqgrms6Hs7HnevFs5ZB4yLc1ZU2u9h9TAp/WXUmdA==",
-      "dependencies": {
-        "tree-sitter-json": {
-          "version": "git://github.com/tree-sitter/tree-sitter-json.git#337f55be9b9b1ccb0baa7763bfe014a94acea7ea",
-          "from": "git://github.com/tree-sitter/tree-sitter-json.git#337f55be9b9b1ccb0baa7763bfe014a94acea7ea",
-          "requires": {
-            "nan": "^2.0.0"
-          }
-        }
+      "requires": {
+        "tree-sitter-json": "git://github.com/tree-sitter/tree-sitter-json.git#337f55be9b9b1ccb0baa7763bfe014a94acea7ea"
       }
     },
     "language-less": {
@@ -6965,9 +6959,9 @@
       }
     },
     "text-buffer": {
-      "version": "13.15.4-0",
-      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.15.4-0.tgz",
-      "integrity": "sha512-7Cji8djB+Ncpru2TSadFvdThumwLn7sto8Omizh+W3twAZ1kWwOrbTN+UUmtnG/MrckRbOQqVutz97bIFq+CpA==",
+      "version": "13.16.0",
+      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.16.0.tgz",
+      "integrity": "sha512-J00KcJDKvV87I/4o7F6LYu+2/fzmuEb7liBbZsIeCUM+T0kwqW7k0R7ddyk9EJR2Nqq7asng2/hVIBNYldIfEg==",
       "requires": {
         "delegato": "^1.0.0",
         "diff": "^2.2.1",
@@ -7160,6 +7154,13 @@
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
           "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
         }
+      }
+    },
+    "tree-sitter-json": {
+      "version": "git://github.com/tree-sitter/tree-sitter-json.git#337f55be9b9b1ccb0baa7763bfe014a94acea7ea",
+      "from": "git://github.com/tree-sitter/tree-sitter-json.git#v0.14.0",
+      "requires": {
+        "nan": "^2.0.0"
       }
     },
     "tree-sitter-python": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "symbols-view": "https://www.atom.io/api/packages/symbols-view/versions/0.118.2/tarball",
     "tabs": "https://www.atom.io/api/packages/tabs/versions/0.110.0/tarball",
     "temp": "^0.9.0",
-    "text-buffer": "13.15.3",
+    "text-buffer": "13.15.4-0",
     "timecop": "https://www.atom.io/api/packages/timecop/versions/0.36.2/tarball",
     "tree-sitter": "0.15.0",
     "tree-sitter-css": "^0.13.7",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "symbols-view": "https://www.atom.io/api/packages/symbols-view/versions/0.118.2/tarball",
     "tabs": "https://www.atom.io/api/packages/tabs/versions/0.110.0/tarball",
     "temp": "^0.9.0",
-    "text-buffer": "13.15.4-0",
+    "text-buffer": "13.16.0",
     "timecop": "https://www.atom.io/api/packages/timecop/versions/0.36.2/tarball",
     "tree-sitter": "0.15.0",
     "tree-sitter-css": "^0.13.7",

--- a/resources/linux/atom.policy
+++ b/resources/linux/atom.policy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+  <vendor>Atom</vendor>
+  <action id="atom.pkexec.dd">
+    <description gettext-domain="atom">Admin privileges required</description>
+    <message gettext-domain="atom">Please enter your password to save this file</message>
+    <annotate key="org.freedesktop.policykit.exec.path">/bin/dd</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+    <defaults>
+      <allow_any>auth_admin_keep</allow_any>
+      <allow_inactive>auth_admin_keep</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+</policyconfig>

--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4
+Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4, policykit-1
 Recommends: lsb-release
 Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
 Section: devel

--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -8,9 +8,9 @@ AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 Prefix:         <%= installDir %>
 
 %ifarch i386 i486 i586 i686
-Requires: lsb-core-noarch, libXss.so.1 libsecret-1.so.0
+Requires: lsb-core-noarch, libXss.so.1 libsecret-1.so.0, polkit
 %else
-Requires: lsb-core-noarch, libXss.so.1()(64bit) libsecret-1.so.0()(64bit)
+Requires: lsb-core-noarch, libXss.so.1()(64bit) libsecret-1.so.0()(64bit), polkit
 %endif
 
 %description

--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -25,6 +25,7 @@ cp atom.sh "%{buildroot}/<%= installDir %>/bin/<%= appFileName %>"
 chmod 755 "%{buildroot}/<%= installDir %>/bin/<%= appFileName %>"
 mkdir -p "%{buildroot}/<%= installDir %>/share/applications/"
 cp "<%= appFileName %>.desktop" "%{buildroot}/<%= installDir %>/share/applications/"
+cp "atom.policy" "%{buildroot}/<%= installDir %>/share/polkit-1/actions/atom.policy"
 
 mkdir -p "%{buildroot}/<%= installDir %>/share/icons/hicolor/1024x1024/apps"
 cp "icons/1024.png" "%{buildroot}/<%= installDir %>/share/icons/hicolor/1024x1024/apps/<%= appFileName %>.png"
@@ -50,4 +51,5 @@ cp "icons/16.png" "%{buildroot}/<%= installDir %>/share/icons/hicolor/16x16/apps
 <%= installDir %>/bin/<%= apmFileName %>
 <%= installDir %>/share/<%= appFileName %>/
 <%= installDir %>/share/applications/<%= appFileName %>.desktop
+<%= installDir %>/share/polkit-1/actions/atom.policy
 <%= installDir %>/share/icons/hicolor/

--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -25,6 +25,7 @@ cp atom.sh "%{buildroot}/<%= installDir %>/bin/<%= appFileName %>"
 chmod 755 "%{buildroot}/<%= installDir %>/bin/<%= appFileName %>"
 mkdir -p "%{buildroot}/<%= installDir %>/share/applications/"
 cp "<%= appFileName %>.desktop" "%{buildroot}/<%= installDir %>/share/applications/"
+mkdir -p "%{buildroot}/<%= installDir %>/share/polkit-1/actions/"
 cp "atom.policy" "%{buildroot}/<%= installDir %>/share/polkit-1/actions/atom.policy"
 
 mkdir -p "%{buildroot}/<%= installDir %>/share/icons/hicolor/1024x1024/apps"

--- a/script/lib/create-debian-package.js
+++ b/script/lib/create-debian-package.js
@@ -113,6 +113,12 @@ module.exports = function (packagedAppPath) {
     path.join(debianPackageLintianOverridesDirPath, atomExecutableName)
   )
 
+  console.log(`Copying polkit configuration into "${debianPackageShareDirPath}"`)
+  fs.copySync(
+    path.join(CONFIG.repositoryRootPath, 'resources', 'linux', 'atom.policy'),
+    path.join(debianPackageShareDirPath, 'polkit-1', 'actions', 'atom.policy')
+  )
+
   console.log(`Generating .deb file from ${debianPackageDirPath}`)
   spawnSync('fakeroot', ['dpkg-deb', '-b', debianPackageDirPath], {stdio: 'inherit'})
 

--- a/script/lib/create-rpm-package.js
+++ b/script/lib/create-rpm-package.js
@@ -76,6 +76,12 @@ module.exports = function (packagedAppPath) {
     path.join(rpmPackageBuildDirPath, 'atom.sh')
   )
 
+  console.log(`Copying atom.policy into "${rpmPackageBuildDirPath}"`)
+  fs.copySync(
+    path.join(CONFIG.repositoryRootPath, 'resources', 'linux', 'atom.policy'),
+    path.join(rpmPackageBuildDirPath, 'atom.policy')
+  )
+
   console.log(`Generating .rpm package from "${rpmPackageDirPath}"`)
   spawnSync('rpmbuild', ['-ba', '--clean', rpmPackageSpecFilePath])
   for (let generatedArch of fs.readdirSync(rpmPackageRpmsDirPath)) {

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -901,7 +901,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-      "optional": true,
       "requires": {
         "hoek": "0.9.x"
       }
@@ -3991,8 +3990,7 @@
     "hoek": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "optional": true
+      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
     },
     "home-or-tmp": {
       "version": "1.0.0",


### PR DESCRIPTION
- [x] Depends on https://github.com/atom/text-buffer/pull/311

Fixes https://github.com/atom/atom/issues/4115

This pull request upgrades text-buffer to prompt the user for privilege escalation when attempting to write to an unauthorized location on Linux. It takes advantage of [Polkit](https://wiki.archlinux.org/index.php/Polkit), which has now become a required dependency in the Debian and RPM distributions (1e87055 and 949e53e). Note that distros such as Ubuntu Desktop ship with a version of Polkit already.

The packages distributed from this version onward will also install a `.policy` file (50f73a5 and 3b5eb5d) that takes care of customizing the privilege escalation prompt, as well as retaining admin access to `dd` (the command line utility that we use for flushing in-memory text into a file) for a short period of time.

🍐'd with @rafeca 