### PR TITLE
Don't create a promise when preloading package settings in snapshot

### DIFF
--- a/src/package.js
+++ b/src/package.js
@@ -648,16 +648,15 @@ class Package {
       })
     }
 
-    return new Promise(resolve => {
-      if (this.preloadedPackage && this.packageManager.packagesCache[this.name]) {
-        for (let settingsPath in this.packageManager.packagesCache[this.name].settings) {
-          const properties = this.packageManager.packagesCache[this.name].settings[settingsPath]
-          const settingsFile = new SettingsFile(`core:${settingsPath}`, properties || {})
-          this.settings.push(settingsFile)
-          if (this.settingsActivated) settingsFile.activate(this.config)
-        }
-        return resolve()
-      } else {
+    if (this.preloadedPackage && this.packageManager.packagesCache[this.name]) {
+      for (let settingsPath in this.packageManager.packagesCache[this.name].settings) {
+        const properties = this.packageManager.packagesCache[this.name].settings[settingsPath]
+        const settingsFile = new SettingsFile(`core:${settingsPath}`, properties || {})
+        this.settings.push(settingsFile)
+        if (this.settingsActivated) settingsFile.activate(this.config)
+      }
+    } else {
+      return new Promise(resolve => {
         const settingsDirPath = path.join(this.path, 'settings')
         fs.exists(settingsDirPath, (settingsDirExists) => {
           if (!settingsDirExists) return resolve()
@@ -666,8 +665,8 @@ class Package {
             async.each(settingsPaths, loadSettingsFile, () => resolve())
           })
         })
-      }
-    })
+      })
+    }
   }
 
   serialize () {


### PR DESCRIPTION
Fixes #19374 

Promise creation is forbidden within `mksnapshot` starting from Electron 3 (see https://github.com/electron/libchromiumcontent/pull/363, https://github.com/nodejs/node/pull/13242 and https://github.com/electron/electron/issues/18420). Since preloading a package's settings is a synchronous action anyway, we just avoid instantiating a new Promise when calling `loadSettings`.

This fixes the crashes we were observing in #19373 when generating a new snapshot, and it is a prerequisite for shipping the Electron 3 upgrade after a hotfix with https://github.com/electron/electron/pull/18426 is released.