### PR TITLE
Improvements to ripgrep scanner

### DIFF
--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2701,7 +2701,7 @@ describe('Workspace', () => {
           let projectPath;
           let ignoredPath;
 
-          beforeEach(() => {
+          beforeEach(async () => {
             const sourceProjectPath = path.join(
               __dirname,
               'fixtures',
@@ -2713,22 +2713,17 @@ describe('Workspace', () => {
             const writerStream = fstream.Writer(projectPath);
             fstream.Reader(sourceProjectPath).pipe(writerStream);
 
-            waitsFor(done => {
-              writerStream.on('close', done);
-              writerStream.on('error', done);
+            await new Promise(resolve => {
+              writerStream.on('close', resolve);
+              writerStream.on('error', resolve);
             });
 
-            runs(() => {
-              fs.renameSync(
-                path.join(projectPath, 'git.git'),
-                path.join(projectPath, '.git')
-              );
-              ignoredPath = path.join(projectPath, 'ignored.txt');
-              fs.writeFileSync(
-                ignoredPath,
-                'this match should not be included'
-              );
-            });
+            fs.renameSync(
+              path.join(projectPath, 'git.git'),
+              path.join(projectPath, '.git')
+            );
+            ignoredPath = path.join(projectPath, 'ignored.txt');
+            fs.writeFileSync(ignoredPath, 'this match should not be included');
           });
 
           afterEach(() => {

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2771,33 +2771,6 @@ describe('Workspace', () => {
 
             expect(resultHandler).toHaveBeenCalledWith(ignoredPath);
           });
-
-          // This is a current limitation of the ripgrep scanner: whenever it finds a folder
-          // ignored by the vcs, it stops there and it does not try to traverse their subfolders.
-          if (!ripgrep) {
-            it('does not exclude files when searching on an ignored subfolder even when core.excludeVcsIgnoredPaths is true', async () => {
-              fs.mkdirSync(path.join(projectPath, 'poop'));
-              fs.mkdirSync(path.join(projectPath, 'poop', 'subfolder'));
-              ignoredPath = path.join(
-                path.join(projectPath, 'poop', 'subfolder', 'whatever.txt')
-              );
-              fs.writeFileSync(ignoredPath, 'this match should be included');
-
-              atom.project.setPaths([projectPath]);
-              atom.config.set('core.excludeVcsIgnoredPaths', true);
-              const resultHandler = jasmine.createSpy('result found');
-
-              await scan(
-                /match/,
-                {
-                  paths: ['poop/subfolder']
-                },
-                ({ filePath }) => resultHandler(filePath)
-              );
-
-              expect(resultHandler).toHaveBeenCalledWith(ignoredPath);
-            });
-          }
         });
 
         describe('when the core.followSymlinks config is used', () => {

--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2697,7 +2697,7 @@ describe('Workspace', () => {
           });
         });
 
-        describe('when the core.excludeVcsIgnoredPaths config is truthy', () => {
+        describe('when the core.excludeVcsIgnoredPaths config is used', () => {
           let projectPath;
           let ignoredPath;
 
@@ -2737,14 +2737,26 @@ describe('Workspace', () => {
             }
           });
 
-          it('excludes ignored files', async () => {
+          it('excludes ignored files when core.excludeVcsIgnoredPaths is true', async () => {
             atom.project.setPaths([projectPath]);
             atom.config.set('core.excludeVcsIgnoredPaths', true);
             const resultHandler = jasmine.createSpy('result found');
 
-            await scan(/match/, {}, () => resultHandler());
+            await scan(/match/, {}, ({ filePath }) => resultHandler(filePath));
 
             expect(resultHandler).not.toHaveBeenCalled();
+          });
+
+          it('does not excludes ignored files when core.excludeVcsIgnoredPaths is false', async () => {
+            atom.project.setPaths([projectPath]);
+            atom.config.set('core.excludeVcsIgnoredPaths', false);
+            const resultHandler = jasmine.createSpy('result found');
+
+            await scan(/match/, {}, ({ filePath }) => resultHandler(filePath));
+
+            expect(resultHandler).toHaveBeenCalledWith(
+              path.join(projectPath, 'ignored.txt')
+            );
           });
         });
 

--- a/src/default-directory-searcher.js
+++ b/src/default-directory-searcher.js
@@ -82,7 +82,7 @@ module.exports = class DefaultDirectorySearcher {
   //   Each item in the array is a file/directory pattern, e.g., `src` to search in the "src"
   //   directory or `*.js` to search all JavaScript files. In practice, this often comes from the
   //   comma-delimited list of patterns in the bottom text input of the ProjectFindView dialog.
-  //   * `ignoreHidden` {boolean} whether to ignore hidden files.
+  //   * `includeHidden` {boolean} whether to ignore hidden files.
   //   * `excludeVcsIgnores` {boolean} whether to exclude VCS ignored paths.
   //   * `exclusions` {Array} similar to inclusions
   //   * `follow` {boolean} whether symlinks should be followed.

--- a/src/ripgrep-directory-searcher.js
+++ b/src/ripgrep-directory-searcher.js
@@ -257,6 +257,10 @@ module.exports = class RipgrepDirectorySearcher {
       args.push('--multiline');
     }
 
+    if (!options.excludeVcsIgnores) {
+      args.push('--no-ignore-vcs');
+    }
+
     args.push(directoryPath);
 
     const child = spawn(this.rgPath, args, {

--- a/src/ripgrep-directory-searcher.js
+++ b/src/ripgrep-directory-searcher.js
@@ -269,10 +269,8 @@ module.exports = class RipgrepDirectorySearcher {
       args.push('--no-ignore-vcs');
     }
 
-    args.push(directoryPath);
-
     const child = spawn(this.rgPath, args, {
-      cwd: directory.getPath(),
+      cwd: directoryPath,
       stdio: ['pipe', 'pipe', 'pipe']
     });
 
@@ -313,7 +311,7 @@ module.exports = class RipgrepDirectorySearcher {
 
           if (message.type === 'begin') {
             pendingEvent = {
-              filePath: getText(message.data.path),
+              filePath: path.join(directoryPath, getText(message.data.path)),
               matches: []
             };
             pendingLeadingContext = [];
@@ -390,8 +388,6 @@ module.exports = class RipgrepDirectorySearcher {
       if (pattern.endsWith('/')) {
         pattern = pattern.slice(0, -1);
       }
-
-      pattern = pattern.startsWith('**/') ? pattern : `**/${pattern}`;
 
       output.push(pattern);
       output.push(pattern.endsWith('/**') ? pattern : `${pattern}/**`);

--- a/src/ripgrep-directory-searcher.js
+++ b/src/ripgrep-directory-searcher.js
@@ -269,6 +269,8 @@ module.exports = class RipgrepDirectorySearcher {
       args.push('--no-ignore-vcs');
     }
 
+    args.push('.');
+
     const child = spawn(this.rgPath, args, {
       cwd: directoryPath,
       stdio: ['pipe', 'pipe', 'pipe']

--- a/src/ripgrep-directory-searcher.js
+++ b/src/ripgrep-directory-searcher.js
@@ -257,6 +257,10 @@ module.exports = class RipgrepDirectorySearcher {
       args.push('--multiline');
     }
 
+    if (options.follow) {
+      args.push('--follow');
+    }
+
     if (!options.excludeVcsIgnores) {
       args.push('--no-ignore-vcs');
     }

--- a/src/ripgrep-directory-searcher.js
+++ b/src/ripgrep-directory-searcher.js
@@ -193,7 +193,7 @@ module.exports = class RipgrepDirectorySearcher {
   //   Each item in the array is a file/directory pattern, e.g., `src` to search in the "src"
   //   directory or `*.js` to search all JavaScript files. In practice, this often comes from the
   //   comma-delimited list of patterns in the bottom text input of the ProjectFindView dialog.
-  //   * `ignoreHidden` {boolean} whether to ignore hidden files.
+  //   * `includeHidden` {boolean} whether to ignore hidden files.
   //   * `excludeVcsIgnores` {boolean} whether to exclude VCS ignored paths.
   //   * `exclusions` {Array} similar to inclusions
   //   * `follow` {boolean} whether symlinks should be followed.
@@ -230,7 +230,7 @@ module.exports = class RipgrepDirectorySearcher {
     const directoryPath = directory.getPath();
     const regexpStr = this.prepareRegexp(regexp.source);
 
-    const args = ['--hidden', '--json', '--regexp', regexpStr];
+    const args = ['--json', '--regexp', regexpStr];
     if (options.leadingContextLineCount) {
       args.push('--before-context', options.leadingContextLineCount);
     }
@@ -255,6 +255,10 @@ module.exports = class RipgrepDirectorySearcher {
 
     if (this.isMultilineRegexp(regexpStr)) {
       args.push('--multiline');
+    }
+
+    if (options.includeHidden) {
+      args.push('--hidden');
     }
 
     if (options.follow) {


### PR DESCRIPTION
This PR includes support for a few options that were ignored on the initial PR that added support for using `ripgrep` as the `scan()` backend.

List of options:

* `excludeVcsIgnores`: Whether or not to ignore files/folders that are ignored by `git`.
* `follow`: Whether or not to follow symlinks.
* `includeHidden`: Whether or not to search on hidden files (`workspace.scan()` hardcodes this to `true` though).

We did not catch this because there was no test checking them, so I've added tests for each of them to ensure that we don't add regressions in the future.

## Missing thing

I've noticed that the `scandal` scanner is able to search on a subfolder of a vcs ignored folder even when `excludeVcsIgnores` is enabled, so if we have (with `node_modules` being ignored by `git`):

```
node_modules/
  left-pad/
    index.js
```

1. If the user performs a normal search, neither `scandal` or `ripgrep` will search on the `node_modules/left-pad/index.js` file.
2. If the user performs a search on the `node_modules` folder, `scandal` and `ripgrep` will search on the `node_modules/left-pad/index.js` file.
3. If the user performs a search on the `node_modules/left-pad` folder, `scandal` will search on the `node_modules/left-pad/index.js` file but `ripgrep` won't.

I'll check how can we fix the scenario 3 (it may require bigger changes) and send a follow-up PR.