### PR TITLE
Parallelize macOS tests

### DIFF
--- a/script/test
+++ b/script/test
@@ -203,8 +203,10 @@ function testSuitesForPlatform (platform) {
     case 'darwin':
       if (process.env.ATOM_RUN_CORE_TESTS === 'true') {
         suites = [runCoreMainProcessTests, runCoreRenderProcessTests]
-      } else if (process.env.ATOM_RUN_PACKAGE_TESTS === 'true') {
-        suites = packageTestSuites
+      } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '1') {
+        suites = packageTestSuites.slice(0, Math.floor(packageTestSuites.length / 2))
+      } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '2') {
+        suites = packageTestSuites.slice(Math.floor(packageTestSuites.length / 2))
       } else {
         suites = [runCoreMainProcessTests, runCoreRenderProcessTests].concat(packageTestSuites)
       }

--- a/script/test
+++ b/script/test
@@ -201,7 +201,13 @@ function testSuitesForPlatform (platform) {
   let suites = []
   switch (platform) {
     case 'darwin':
-      suites = [runCoreMainProcessTests, runCoreRenderProcessTests, runBenchmarkTests].concat(packageTestSuites)
+      if (process.env.ATOM_RUN_CORE_TESTS === 'true') {
+        suites = [runCoreMainProcessTests, runCoreRenderProcessTests, runBenchmarkTests]
+      } else if (process.env.ATOM_RUN_PACKAGE_TESTS === 'true') {
+        suites = packageTestSuites
+      } else {
+        suites = [runCoreMainProcessTests, runCoreRenderProcessTests, runBenchmarkTests].concat(packageTestSuites)
+      }
       break
     case 'win32':
       suites = (process.arch === 'x64') ? [runCoreMainProcessTests, runCoreRenderProcessTests] : [runCoreMainProcessTests]

--- a/script/test
+++ b/script/test
@@ -200,8 +200,10 @@ function testSuitesForPlatform (platform) {
     case 'darwin':
       const PACKAGES_TO_TEST_IN_PARALLEL = 23
 
-      if (process.env.ATOM_RUN_CORE_TESTS === 'true') {
-        suites = [runCoreMainProcessTests, runCoreRenderProcessTests]
+      if (process.env.ATOM_RUN_CORE_MAIN_TESTS === 'true') {
+        suites = [runCoreMainProcessTests]
+      } else if (process.env.ATOM_RUN_CORE_RENDERER_TESTS === 'true') {
+        suites = [runCoreRenderProcessTests]
       } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '1') {
         suites = packageTestSuites.slice(0, PACKAGES_TO_TEST_IN_PARALLEL)
       } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '2') {

--- a/script/test
+++ b/script/test
@@ -116,10 +116,7 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
   const testSubdir = ['spec', 'test'].find(subdir => fs.existsSync(path.join(repositoryPackagePath, subdir)))
 
   if (!testSubdir) {
-    packageTestSuites.push(function (callback) {
-      console.log(`Skipping tests for ${packageName} because no test folder was found`.bold.yellow)
-      callback(null, {exitCode: 0, step: `package-${packageName}`})
-    })
+    console.log(`No test folder found for package: ${packageName}`.yellow)
     continue
   }
 
@@ -201,12 +198,14 @@ function testSuitesForPlatform (platform) {
   let suites = []
   switch (platform) {
     case 'darwin':
+      const PACKAGES_TO_TEST_IN_PARALLEL = 23
+
       if (process.env.ATOM_RUN_CORE_TESTS === 'true') {
         suites = [runCoreMainProcessTests, runCoreRenderProcessTests]
       } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '1') {
-        suites = packageTestSuites.slice(0, Math.floor(packageTestSuites.length / 2))
+        suites = packageTestSuites.slice(0, PACKAGES_TO_TEST_IN_PARALLEL)
       } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '2') {
-        suites = packageTestSuites.slice(Math.floor(packageTestSuites.length / 2))
+        suites = packageTestSuites.slice(PACKAGES_TO_TEST_IN_PARALLEL)
       } else {
         suites = [runCoreMainProcessTests, runCoreRenderProcessTests].concat(packageTestSuites)
       }

--- a/script/test
+++ b/script/test
@@ -202,11 +202,11 @@ function testSuitesForPlatform (platform) {
   switch (platform) {
     case 'darwin':
       if (process.env.ATOM_RUN_CORE_TESTS === 'true') {
-        suites = [runCoreMainProcessTests, runCoreRenderProcessTests, runBenchmarkTests]
+        suites = [runCoreMainProcessTests, runCoreRenderProcessTests]
       } else if (process.env.ATOM_RUN_PACKAGE_TESTS === 'true') {
         suites = packageTestSuites
       } else {
-        suites = [runCoreMainProcessTests, runCoreRenderProcessTests, runBenchmarkTests].concat(packageTestSuites)
+        suites = [runCoreMainProcessTests, runCoreRenderProcessTests].concat(packageTestSuites)
       }
       break
     case 'win32':

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -29,7 +29,7 @@ jobs:
   - GetReleaseVersion
   - Windows
   - Linux
-  - macOS
+  - macOS_tests
 
   variables:
     ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -63,6 +63,46 @@ jobs:
       ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD)
 
   - script: |
+      osascript -e 'tell application "System Events" to keystroke "x"' # clear screen saver
+      caffeinate -s script/test # Run with caffeinate to prevent screen saver
+    env:
+      CI: true
+      CI_PROVIDER: VSTS
+      ATOM_JASMINE_REPORTER: list
+      TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
+      ATOM_RUN_CORE_MAIN_TESTS: true
+    displayName: Run main process tests
+    condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
+
+  - script: script/postprocess-junit-results --search-folder "${TEST_JUNIT_XML_ROOT}" --test-results-files "**/*.xml"
+    env:
+      TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
+    displayName: Post-process test results
+    condition: ne(variables['Atom.SkipTests'], 'true')
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: JUnit
+      searchFolder: $(Common.TestResultsDirectory)/junit
+      testResultsFiles: "**/*.xml"
+      mergeTestResults: true
+      testRunTitle: MacOS
+    condition: ne(variables['Atom.SkipTests'], 'true')
+
+  - script: |
+      mkdir -p $(Build.ArtifactStagingDirectory)/crash-reports
+      cp ${HOME}/Library/Logs/DiagnosticReports/*.crash $(Build.ArtifactStagingDirectory)/crash-reports
+    displayName: Stage Crash Reports
+    condition: failed()
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/crash-reports
+      ArtifactName: crash-reports.zip
+    displayName: Upload Crash Reports
+    condition: failed()
+
+  - script: |
       cp $(Build.SourcesDirectory)/out/*.zip $(Build.ArtifactStagingDirectory)
     displayName: Stage Artifacts
 
@@ -100,13 +140,13 @@ jobs:
     maxParallel: 3
     matrix:
       core:
-        RunCoreTests: true
+        RunCoreRendererTests: true
         RunPackageTests: false
       packages-1:
-        RunCoreTests: false
+        RunCoreRendererTests: false
         RunPackageTests: 1
       packages-2:
-        RunCoreTests: false
+        RunCoreRendererTests: false
         RunPackageTests: 2
 
   steps:
@@ -148,7 +188,7 @@ jobs:
       CI_PROVIDER: VSTS
       ATOM_JASMINE_REPORTER: list
       TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
-      ATOM_RUN_CORE_TESTS: $(RunCoreTests)
+      ATOM_RUN_CORE_RENDERER_TESTS: $(RunCoreRendererTests)
       ATOM_RUN_PACKAGE_TESTS: $(RunPackageTests)
     displayName: Run tests
     condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -97,14 +97,17 @@ jobs:
   pool:
     vmImage: macos-10.13
   strategy:
-    maxParallel: 2
+    maxParallel: 3
     matrix:
       core:
         RunCoreTests: true
         RunPackageTests: false
-      packages:
+      packages-1:
         RunCoreTests: false
-        RunPackageTests: true
+        RunPackageTests: 1
+      packages-2:
+        RunCoreTests: false
+        RunPackageTests: 2
 
   steps:
   - task: NodeTool@0

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -1,5 +1,6 @@
 jobs:
-- job: macOS
+- job: macOS_build
+  displayName: macOS build
   dependsOn: GetReleaseVersion
   timeoutInMinutes: 180
 
@@ -62,6 +63,81 @@ jobs:
       ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD)
 
   - script: |
+      cp $(Build.SourcesDirectory)/out/*.zip $(Build.ArtifactStagingDirectory)
+    displayName: Stage Artifacts
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/atom-mac.zip
+      ArtifactName: atom-mac.zip
+      ArtifactType: Container
+    displayName: Upload atom-mac.zip
+    condition: succeeded()
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/atom-mac-symbols.zip
+      ArtifactName: atom-mac-symbols.zip
+      ArtifactType: Container
+    displayName: Upload atom-mac-symbols.zip
+    condition: succeeded()
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: $(Build.SourcesDirectory)/docs/output/atom-api.json
+      ArtifactName: atom-api.json
+      ArtifactType: Container
+    displayName: Upload atom-api.json
+    condition: succeeded()
+
+- job: macOS_tests
+  displayName: macOS test
+  dependsOn: macOS_build
+  timeoutInMinutes: 180
+  pool:
+    vmImage: macos-10.13
+  strategy:
+    maxParallel: 2
+    matrix:
+      core:
+        RunCoreTests: true
+        RunPackageTests: false
+      packages:
+        RunCoreTests: false
+        RunPackageTests: true
+
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: 8.9.3
+    displayName: Install Node.js 8.9.3
+
+  - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
+    displayName: Restore node_modules cache
+    inputs:
+      keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
+      targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
+      vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+
+  - task: DownloadBuildArtifacts@0
+    displayName: Download atom-mac.zip
+    inputs:
+      artifactName: 'atom-mac.zip'
+      downloadPath: $(Build.SourcesDirectory)
+
+  - script: unzip atom-mac.zip/atom-mac.zip -d out
+    displayName: Unzip atom-mac.zip
+
+  - task: DownloadBuildArtifacts@0
+    displayName: Download atom-mac-symbols.zip
+    inputs:
+      artifactName: 'atom-mac-symbols.zip'
+      downloadPath: $(Build.SourcesDirectory)
+
+  - script: unzip atom-mac-symbols.zip/atom-mac-symbols.zip -d out
+    displayName: Unzip atom-mac-symbols.zip
+
+  - script: |
       osascript -e 'tell application "System Events" to keystroke "x"' # clear screen saver
       caffeinate -s script/test # Run with caffeinate to prevent screen saver
     env:
@@ -69,6 +145,8 @@ jobs:
       CI_PROVIDER: VSTS
       ATOM_JASMINE_REPORTER: list
       TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
+      ATOM_RUN_CORE_TESTS: $(RunCoreTests)
+      ATOM_RUN_PACKAGE_TESTS: $(RunPackageTests)
     displayName: Run tests
     condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
 
@@ -88,38 +166,10 @@ jobs:
     condition: ne(variables['Atom.SkipTests'], 'true')
 
   - script: |
-      cp $(Build.SourcesDirectory)/out/*.zip $(Build.ArtifactStagingDirectory)
-    displayName: Stage Artifacts
-
-  - script: |
       mkdir -p $(Build.ArtifactStagingDirectory)/crash-reports
       cp ${HOME}/Library/Logs/DiagnosticReports/*.crash $(Build.ArtifactStagingDirectory)/crash-reports
     displayName: Stage Crash Reports
     condition: failed()
-
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/atom-mac.zip
-      ArtifactName: atom-mac.zip
-      ArtifactType: Container
-    displayName: Upload atom-mac.zip
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/atom-mac-symbols.zip
-      ArtifactName: atom-mac-symbols.zip
-      ArtifactType: Container
-    displayName: Upload atom-mac-symbols.zip
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/docs/output/atom-api.json
-      ArtifactName: atom-api.json
-      ArtifactType: Container
-    displayName: Upload atom-api.json
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
   - task: PublishBuildArtifacts@1
     inputs:

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -34,7 +34,7 @@ jobs:
   - GetReleaseVersion
   - Windows
   - Linux
-  - macOS
+  - macOS_tests
 
   variables:
     ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]


### PR DESCRIPTION
Refs: #19366 

This pull request changes our CI configuration to run tests in parallel on macOS. Specifically, it splits the macOS step into a **build phase** and a **test phase**. 

## Build Phase

During this phase, Azure Pipelines takes care of bootstrapping and building Atom. It then uploads the produced artifacts so that they can be used by the test phase described below.

Note that, perhaps counterintuitively, we will still execute main process tests as part of this phase. This is unfortunate, but there seems to be an issue when trying to execute main process tests on a container different from the one Atom was built on. These tests usually take less than 10 seconds anyways, so they should have a negligible cost on parallelism.

## Test Phase

During this phase, Azure Pipelines takes care of downloading the artifacts published by the build phase and use them to run tests. In particular, this phase is further split into 3 jobs that are executed in parallel:

- `macOS test core`, which runs core renderer tests.
- `macOS test packages-1`, which runs tests for the first 22 packages
- `macOS test packages-2`, which runs tests for the remaining packages

Splitting tests evenly across containers is non-trivial, especially since we don't know how long each test suite takes to execute. We could probably download that information from previous builds and schedule tests accordingly, but in this pull request I decided to go for a more low-tech approach. Empirically, I observed that the splitting strategy illustrated above achieves a good level of parallelism without introducing a ton of complexity.

## Conclusion

With these changes, build times when the `node_modules` cache is warm drop from ~1hr to ~40 minutes. In other words, after this pull request lands, we should be able to observe a consistent ~33% improvement in our build times. 🐎 

Please, note that there is still room for improvement, but it seems like additional enhancements to CI would come at a higher cost and we may want to work on them in a separate moment.