### PR TITLE
Attempt to fix watchPath flaky tests on Windows

### DIFF
--- a/spec/path-watcher-spec.js
+++ b/spec/path-watcher-spec.js
@@ -21,6 +21,7 @@ describe('watchPath', function() {
   let subs;
 
   beforeEach(function() {
+    jasmine.useRealClock();
     subs = new CompositeDisposable();
   });
 
@@ -44,8 +45,11 @@ describe('watchPath', function() {
 
         if (!fired && waiting.size === 0) {
           fired = true;
-          resolve(relevantEvents);
-          sub.dispose();
+
+          sub.then(s => {
+            s.dispose();
+            resolve(relevantEvents);
+          });
         }
       });
     });

--- a/src/path-watcher.js
+++ b/src/path-watcher.js
@@ -444,7 +444,7 @@ class PathWatcher {
   // * `callback` {Function} to be called with each batch of filesystem events.
   //
   // Returns a {Disposable} that will stop the underlying watcher when all callbacks mapped to it have been disposed.
-  onDidChange(callback) {
+  async onDidChange(callback) {
     if (this.native) {
       const sub = this.native.onDidChange(events =>
         this.onNativeEvents(events, callback)
@@ -454,9 +454,8 @@ class PathWatcher {
       this.native.start();
     } else {
       // Attach to a new native listener and retry
-      this.nativeWatcherRegistry.attach(this).then(() => {
-        this.onDidChange(callback);
-      });
+      await this.nativeWatcherRegistry.attach(this);
+      await this.onDidChange(callback, this.watchedPath);
     }
 
     return new Disposable(() => {
@@ -696,7 +695,7 @@ class PathWatcherManager {
     }
 
     const w = new PathWatcher(this.nativeRegistry, rootPath, options);
-    w.onDidChange(eventCallback);
+    await w.onDidChange(eventCallback);
     await w.getStartPromise();
     return w;
   }


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/atom/atom/issues/19442.

## Context

After doing a ton of debugging, it seems that in some situations the change event that should be triggered by [changing the root file](https://github.com/atom/atom/blob/master/spec/path-watcher-spec.js#L161) is never captured by [`onDidChange()`](https://github.com/atom/atom/blob/master/spec/path-watcher-spec.js#L38) callback.

My hypothesis is that since the `onDidChange()` method [has some asynchronous code](https://github.com/atom/atom/blob/master/src/path-watcher.js#L457-L459), the actual subscription to change events happens asynchronously (but there is no logic to wait until the actual subscription is done).

In most situations this is fine, since by [awaiting the `startPromise`](https://github.com/atom/atom/blob/master/src/path-watcher.js#L700) is enough because it usually gets resolved after the subscriptions of `onDidChange()` are done (thanks to the [`native.start()` method](https://github.com/atom/atom/blob/master/src/path-watcher.js#L454)).

In some rare cases, though (specially when calling the `onDidChange()` method multiple times), it can happen that the `startPromise` gets resolved before one of the `onDidChange` calls has successfully done the needed subscriptions, which then can cause the watcher to not start listening to events just after calling the `onDidChange()` method.

## Solution

I've decided to change the `onDidChange()` method to return a `Promise`, since this is the most explicit and correct way to mark a method that does async work.

This may be strange, since afaik `onDidXXX` methods don't usually return promises on Atom (but also they are usually not async). I've decided to go through this path because:
1. The alternative solutions that I could find had worse tradeoffs.
2. This `onDidChange()` method is private (at least based on the code comment), so making it return a Promise should have a really small effect.

## Alternative solutions

I could see two alternative solutions:

1. Add some kind of delay to the `path-watcher` tests, between when the subscription happens and when we start writing on files. This would not fix the underlying issue of the wathing code and could still lead to flakiness.
2. Add yet another `Promise` to the `watcher` code that needs to be awaited and keep the `onDidChange` method returning the `Disposable`. Taking into account that this class already has [3 Promises](https://github.com/atom/atom/blob/master/src/path-watcher.js#L378-L387) that are awaited in different parts, I think that adding yet another one would only lead to more potential race conditions in the future when code gets changed/updated.
