### PR TITLE
Upgrade text buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6551,9 +6551,9 @@
       }
     },
     "text-buffer": {
-      "version": "13.16.0",
-      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.16.0.tgz",
-      "integrity": "sha512-J00KcJDKvV87I/4o7F6LYu+2/fzmuEb7liBbZsIeCUM+T0kwqW7k0R7ddyk9EJR2Nqq7asng2/hVIBNYldIfEg==",
+      "version": "13.16.1-0",
+      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.16.1-0.tgz",
+      "integrity": "sha512-kMuN/Y7d3tkQpjksGBdgK3xsExqzWVBJPCRDfDWhDIY7WD9/ymwyZfisN3dw6l1lsd6fHZmJtXp+rnBHfKOnVA==",
       "requires": {
         "delegato": "^1.0.0",
         "diff": "^2.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6551,9 +6551,9 @@
       }
     },
     "text-buffer": {
-      "version": "13.16.1-0",
-      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.16.1-0.tgz",
-      "integrity": "sha512-kMuN/Y7d3tkQpjksGBdgK3xsExqzWVBJPCRDfDWhDIY7WD9/ymwyZfisN3dw6l1lsd6fHZmJtXp+rnBHfKOnVA==",
+      "version": "13.16.1",
+      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.16.1.tgz",
+      "integrity": "sha512-/P3D92KLtyrB+P+cc2W7i8jOEw6/1l72tblKobECCXOxkmJJuEqzyt7Kdw9RySJwQYIh9YRllksQ7IQJOp+XeA==",
       "requires": {
         "delegato": "^1.0.0",
         "diff": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "symbols-view": "https://www.atom.io/api/packages/symbols-view/versions/0.118.2/tarball",
     "tabs": "https://www.atom.io/api/packages/tabs/versions/0.110.0/tarball",
     "temp": "^0.9.0",
-    "text-buffer": "13.16.1-0",
+    "text-buffer": "13.16.1",
     "timecop": "https://www.atom.io/api/packages/timecop/versions/0.36.2/tarball",
     "tree-sitter": "0.15.0",
     "tree-sitter-css": "^0.13.7",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "symbols-view": "https://www.atom.io/api/packages/symbols-view/versions/0.118.2/tarball",
     "tabs": "https://www.atom.io/api/packages/tabs/versions/0.110.0/tarball",
     "temp": "^0.9.0",
-    "text-buffer": "13.16.0",
+    "text-buffer": "13.16.1-0",
     "timecop": "https://www.atom.io/api/packages/timecop/versions/0.36.2/tarball",
     "tree-sitter": "0.15.0",
     "tree-sitter-css": "^0.13.7",


### PR DESCRIPTION
I'm opening this PR to test the optimization from https://github.com/atom/text-buffer/pull/312 against Atom. I think it should be fine, but I want to see a green Atom build first before publishing an official `text-buffer` release.