### PR TITLE
Don't listen for arguments from new processes in test or benchmarks

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -283,7 +283,12 @@ module.exports = class AtomApplication extends EventEmitter {
     // We need to do this because `listenForArgumentsFromNewProcess()` calls `crypto.randomBytes`,
     // which is really slow on Windows machines.
     // (TodoElectronIssue: This got fixed in electron v3: https://github.com/electron/electron/issues/2073).
-    const socketServerPromise = this.listenForArgumentsFromNewProcess(options);
+    let socketServerPromise
+    if (options.test || options.benchmark || options.benchmarkTest) {
+      socketServerPromise = Promise.resolve()
+    } else {
+      socketServerPromise = this.listenForArgumentsFromNewProcess()
+    }
 
     this.setupDockMenu();
 
@@ -505,12 +510,10 @@ module.exports = class AtomApplication extends EventEmitter {
   // You can run the atom command multiple times, but after the first launch
   // the other launches will just pass their information to this server and then
   // close immediately.
-  async listenForArgumentsFromNewProcess(options) {
-    if (!options.test && !options.benchmark && !options.benchmarkTest) {
-      this.socketSecretPromise = createSocketSecret(this.version);
-      this.socketSecret = await this.socketSecretPromise;
-      this.socketPath = getSocketPath(this.socketSecret);
-    }
+  async listenForArgumentsFromNewProcess() {
+    this.socketSecretPromise = createSocketSecret(this.version);
+    this.socketSecret = await this.socketSecretPromise;
+    this.socketPath = getSocketPath(this.socketSecret);
 
     await this.deleteSocketFile();
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -283,11 +283,11 @@ module.exports = class AtomApplication extends EventEmitter {
     // We need to do this because `listenForArgumentsFromNewProcess()` calls `crypto.randomBytes`,
     // which is really slow on Windows machines.
     // (TodoElectronIssue: This got fixed in electron v3: https://github.com/electron/electron/issues/2073).
-    let socketServerPromise
+    let socketServerPromise;
     if (options.test || options.benchmark || options.benchmarkTest) {
-      socketServerPromise = Promise.resolve()
+      socketServerPromise = Promise.resolve();
     } else {
-      socketServerPromise = this.listenForArgumentsFromNewProcess()
+      socketServerPromise = this.listenForArgumentsFromNewProcess();
     }
 
     this.setupDockMenu();


### PR DESCRIPTION
This pull request prevents the following macOS firewall prompt from showing up when running tests:
<p align=center>
<img width="488" alt="Screen Shot 2019-06-06 at 10 24 59" src="https://user-images.githubusercontent.com/482957/59018086-5ca5c700-8845-11e9-8976-1408808a5255.png"></p>

The prompt was being shown because we had some code within `listenForArgumentsFromNewProcess` that would conditionally create a domain socket file when `AtomApplication` wasn't being instantiated in test or benchmark environments. For test/benchmark environments, this meant that `this.socketPath` would be undefined.

Unfortunately, the conditional didn't extend all the way down until listening for incoming connections, which had the unfortunate side effect of calling `server.listen` with an undefined argument (`this.socketPath`). In turn, this would instruct Node to listen for any TCP connection on a random port, which would then kick off the firewall given that the machine could potentially accept connections coming from the Internet or LAN.

With this pull request, we are changing that behavior by moving the conditional up, and only call `listenForArgumentsFromNewProcess` when instantiating a real `AtomApplication`.