### PR TITLE
Run each test suite with a pristine ATOM_HOME directory

### DIFF
--- a/script/test
+++ b/script/test
@@ -39,6 +39,7 @@ const childProcess = require('child_process')
 const fs = require('fs-extra')
 const glob = require('glob')
 const path = require('path')
+const temp = require('temp').track()
 
 const CONFIG = require('./config')
 const backupNodeModules = require('./lib/backup-node-modules')
@@ -63,7 +64,8 @@ if (process.platform === 'darwin') {
 }
 
 function prepareEnv (suiteName) {
-  const env = Object.assign({}, process.env)
+  const atomHomeDirPath = temp.mkdirSync(suiteName)
+  const env = Object.assign({}, process.env, {ATOM_HOME: atomHomeDirPath})
 
   if (process.env.TEST_JUNIT_XML_ROOT) {
     // Tell Jasmine to output this suite's results as a JUnit XML file to a subdirectory of the root, so that a

--- a/script/test
+++ b/script/test
@@ -200,10 +200,8 @@ function testSuitesForPlatform (platform) {
     case 'darwin':
       const PACKAGES_TO_TEST_IN_PARALLEL = 23
 
-      if (process.env.ATOM_RUN_CORE_MAIN_TESTS === 'true') {
-        suites = [runCoreMainProcessTests]
-      } else if (process.env.ATOM_RUN_CORE_RENDERER_TESTS === 'true') {
-        suites = [runCoreRenderProcessTests]
+      if (process.env.ATOM_RUN_CORE_TESTS === 'true') {
+        suites = [runCoreMainProcessTests, runCoreRenderProcessTests]
       } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '1') {
         suites = packageTestSuites.slice(0, PACKAGES_TO_TEST_IN_PARALLEL)
       } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '2') {

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -63,46 +63,6 @@ jobs:
       ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD)
 
   - script: |
-      osascript -e 'tell application "System Events" to keystroke "x"' # clear screen saver
-      caffeinate -s script/test # Run with caffeinate to prevent screen saver
-    env:
-      CI: true
-      CI_PROVIDER: VSTS
-      ATOM_JASMINE_REPORTER: list
-      TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
-      ATOM_RUN_CORE_MAIN_TESTS: true
-    displayName: Run main process tests
-    condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
-
-  - script: script/postprocess-junit-results --search-folder "${TEST_JUNIT_XML_ROOT}" --test-results-files "**/*.xml"
-    env:
-      TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
-    displayName: Post-process test results
-    condition: ne(variables['Atom.SkipTests'], 'true')
-
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      searchFolder: $(Common.TestResultsDirectory)/junit
-      testResultsFiles: "**/*.xml"
-      mergeTestResults: true
-      testRunTitle: MacOS
-    condition: ne(variables['Atom.SkipTests'], 'true')
-
-  - script: |
-      mkdir -p $(Build.ArtifactStagingDirectory)/crash-reports
-      cp ${HOME}/Library/Logs/DiagnosticReports/*.crash $(Build.ArtifactStagingDirectory)/crash-reports
-    displayName: Stage Crash Reports
-    condition: failed()
-
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/crash-reports
-      ArtifactName: crash-reports.zip
-    displayName: Upload Crash Reports
-    condition: failed()
-
-  - script: |
       cp $(Build.SourcesDirectory)/out/*.zip $(Build.ArtifactStagingDirectory)
     displayName: Stage Artifacts
 
@@ -140,13 +100,13 @@ jobs:
     maxParallel: 3
     matrix:
       core:
-        RunCoreRendererTests: true
+        RunCoreTests: true
         RunPackageTests: false
       packages-1:
-        RunCoreRendererTests: false
+        RunCoreTests: false
         RunPackageTests: 1
       packages-2:
-        RunCoreRendererTests: false
+        RunCoreTests: false
         RunPackageTests: 2
 
   steps:
@@ -188,7 +148,7 @@ jobs:
       CI_PROVIDER: VSTS
       ATOM_JASMINE_REPORTER: list
       TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
-      ATOM_RUN_CORE_RENDERER_TESTS: $(RunCoreRendererTests)
+      ATOM_RUN_CORE_TESTS: $(RunCoreTests)
       ATOM_RUN_PACKAGE_TESTS: $(RunPackageTests)
     displayName: Run tests
     condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))

--- a/spec/main-process/atom-window.test.js
+++ b/spec/main-process/atom-window.test.js
@@ -77,21 +77,6 @@ describe('AtomWindow', function() {
         );
       });
 
-      await new Promise((resolve, reject) => {
-        fs.symlink(
-          path.join(original.ATOM_HOME, 'compile-cache'),
-          path.join(atomHome, 'compile-cache'),
-          'junction',
-          err => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve();
-            }
-          }
-        );
-      });
-
       process.env.ATOM_HOME = atomHome;
       process.env.ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT = 'true';
     });


### PR DESCRIPTION
I had originally opened this pull request to address flakiness in autocomplete-plus tests, but in investigating that issue I discovered a couple of problems:

1. `compile-cache` was being symlinked in `AtomWindow` tests. This was causing some issues when the `ATOM_HOME` folder did not exist, but it has been fixed as part of 6a88fa4. Furthermore, it allowed us to move main process tests out of the `macOS Build` step, which resulted in removing quite a bit of duplication between `macOS_build` and `macOS_test`.
2. When running `script/test`, there was the potential for previous tests to affect the behavior of subsequent ones, because `ATOM_HOME` would be reused across test suites. I addressed this in ee0ddaa, which will now create a new temporary directory for each suite.

I've run tests multiple times with the two improvements illustrated above, and those seem to mitigate some of the flakiness we were observing for `autocomplete-plus`. I am still not entirely sure of what the root cause of the flakiness was (I couldn't reproduce the problem locally, and debugging tests on CI has an extremely bad feedback loop), but these seem to be good enhancements to our test suite nonetheless.