### PR TITLE
⬆️ nslog@3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5011,11 +5011,18 @@
       }
     },
     "nslog": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/nslog/-/nslog-3.0.0.tgz",
-      "integrity": "sha1-nvfjpGveHnVyRFQcyhP/K2dvexk=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nslog/-/nslog-3.2.0.tgz",
+      "integrity": "sha512-3J5XPvodzhRpy0S7DIuxzQ16e70XZ8gS7MTvA70PiEFG9iZBv8XFABsyZDphO/62b/kEPkgPpoAbQvZprqLhOQ==",
       "requires": {
-        "nan": "^2.0.0"
+        "nan": "^2.14.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        }
       }
     },
     "nth-check": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "mock-spawn": "^0.2.6",
     "normalize-package-data": "^2.0.0",
     "notifications": "https://www.atom.io/api/packages/notifications/versions/0.70.6/tarball",
-    "nslog": "^3",
+    "nslog": "^3.0.0",
     "one-dark-syntax": "file:packages/one-dark-syntax",
     "one-dark-ui": "file:packages/one-dark-ui",
     "one-light-syntax": "file:packages/one-light-syntax",


### PR DESCRIPTION
This updates `nslog` to add support for Node v12 (which will be useful when upgrading to Electron v5).

----

*List of changes between `nslog@3.0.0` and `nslog@3.2.0`: https://github.com/atom/node-nslog/compare/v3.0.0...v3.2.0*