### PR TITLE
Update apm to remove node-gyp logic

### DIFF
--- a/apm/package-lock.json
+++ b/apm/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "atom-package-manager": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/atom-package-manager/-/atom-package-manager-2.3.0.tgz",
-      "integrity": "sha512-WI2HaA19A4rKyaNnaoOE7vIlHBiwXQGq+/Kw1Z38LARvYOuWi7BK2GX0cZYqi4I5Yh5elpxrl01M2QmL09saNg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/atom-package-manager/-/atom-package-manager-2.3.1.tgz",
+      "integrity": "sha512-CAys5szBJbqhkizMm32o0+uOTpT9rgPh9TdFX0R//usjOAgDr8iJ7oGNfULPvJzaKnBhrokuniKNumAxVyuauA==",
       "requires": {
         "@atom/plist": "0.4.4",
         "asar-require": "0.3.0",

--- a/apm/package-lock.json
+++ b/apm/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "atom-package-manager": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/atom-package-manager/-/atom-package-manager-2.2.4.tgz",
-      "integrity": "sha512-Iyfs8FNPH+fDLm2DlzE+71TGGZt0fAO2fchJKUHbMLqxFPBPjOgigViQZxDhb2eBRYi2jLKkbalCa4m21Q8CRA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/atom-package-manager/-/atom-package-manager-2.3.0.tgz",
+      "integrity": "sha512-WI2HaA19A4rKyaNnaoOE7vIlHBiwXQGq+/Kw1Z38LARvYOuWi7BK2GX0cZYqi4I5Yh5elpxrl01M2QmL09saNg==",
       "requires": {
         "@atom/plist": "0.4.4",
         "asar-require": "0.3.0",
@@ -834,19 +834,12 @@
           }
         },
         "keytar": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/keytar/-/keytar-4.7.0.tgz",
-          "integrity": "sha512-0hLlRRkhdR0068fVQo21hnIndGvacsh9PtAHGAPMPzxFjJwP8idAkVAcbdb1P5B+gterCBa3+4hxL0NPMDlZtw==",
+          "version": "4.9.0",
+          "resolved": "https://registry.npmjs.org/keytar/-/keytar-4.9.0.tgz",
+          "integrity": "sha512-5aKEpnxRWUIhSlRXckqTxomqokV1/tOBe3EdbCDyMjDaoa5AkVHVa1yK+fa2CgJR5MadbJndFWmcDMCq812F4A==",
           "requires": {
-            "nan": "2.13.2",
+            "nan": "2.14.0",
             "prebuild-install": "5.3.0"
-          },
-          "dependencies": {
-            "nan": {
-              "version": "2.13.2",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-              "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
-            }
           }
         },
         "klaw": {
@@ -3876,9 +3869,9 @@
           }
         },
         "psl": {
-          "version": "1.1.31",
-          "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-          "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+          "version": "1.1.32",
+          "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+          "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
         },
         "pump": {
           "version": "2.0.1",

--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "2.3.0"
+    "atom-package-manager": "2.3.1"
   }
 }

--- a/apm/package.json
+++ b/apm/package.json
@@ -6,6 +6,6 @@
     "url": "https://github.com/atom/atom.git"
   },
   "dependencies": {
-    "atom-package-manager": "2.2.4"
+    "atom-package-manager": "2.3.0"
   }
 }


### PR DESCRIPTION
Template does not apply - this is a package version bump.

See atom/apm#845 for the majority of the details. We now delegate to npm to handle Electron header installation rather than trying to do it ourselves through node-gyp.

2.3.0 also contains a Node version bump to 10.2.1, in order to match Electron 3.