### PR TITLE
Ensure TextEditorComponent was resized before asserting on its contents

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -3297,9 +3297,12 @@ describe('TextEditorComponent', () => {
       // make the editor taller and wider and the same time, ensuring the number
       // of rendered lines is correct.
       setEditorHeightInLines(component, 13);
-      await setEditorWidthInCharacters(component, 50);
-      expect(component.getRenderedStartRow()).toBe(0);
-      expect(component.getRenderedEndRow()).toBe(13);
+      setEditorWidthInCharacters(component, 50);
+      await conditionPromise(
+        () =>
+          component.getRenderedStartRow() === 0 &&
+          component.getRenderedEndRow() === 13
+      );
       expect(component.getScrollHeight()).toBe(
         editor.getScreenLineCount() * component.getLineHeight() +
           getElementHeight(item2) +


### PR DESCRIPTION
Fixes #19443 

Previously, we would wait for the next update promise after resizing the editor as an indicator of when the resize occurred. Unfortunately, resize events are unreliable and may not be emitted right away. This could cause the test code to wait for an update promise that was unrelated to the resize event (e.g., cursor blinking).

This pull request uses a condition-based promise that ensures the rendered rows have changed as a result of the resize. This seems to fix the issue locally when introducing artificial timeouts in the resize event.