### PR TITLE
Do not store null buffers on the cacheStore

### DIFF
--- a/src/native-compile-cache.js
+++ b/src/native-compile-cache.js
@@ -43,7 +43,7 @@ class NativeCompileCache {
     const script = new vm.Script(code, { filename, produceCachedData: true });
     return {
       result: script.runInThisContext(),
-      cacheBuffer: script.cachedData
+      cacheBuffer: script.cachedDataProduced ? script.cachedData : null
     };
   }
 
@@ -102,7 +102,7 @@ class NativeCompileCache {
           console.error(`Error running script ${filename}`);
           throw err;
         }
-        if (compilationResult.cacheBuffer !== null) {
+        if (compilationResult.cacheBuffer) {
           self.cacheStore.set(cacheKey, compilationResult.cacheBuffer);
         }
         compiledWrapper = compilationResult.result;


### PR DESCRIPTION
It looks like the `cachedData` property of `vm.Script()` ([more info](https://nodejs.org/docs/latest-v8.x/api/vm.html#vm_new_vm_script_code_options)) in Node v10 is assigned to `undefined` instead of `null` whenever it can't be computed.

This is causing issues when trying to store the data between reloads and produces a `TypeError` (more info in [the reporting issue](https://github.com/atom/atom/issues/19430)). I'm not sure if this can be causing performance regressions due to not being able to cache some compiled files output...

This fixes https://github.com/atom/atom/issues/19430