### PR TITLE
Auto-format yaml files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: python
 
 python:
-  - "2.7.13"
+  - '2.7.13'
 
 git:
   depth: 10
 
 branches:
   only:
-  - master
-  - /^[0-9.]+-releases$/
-  - /.*-test-travis$/
+    - master
+    - /^[0-9.]+-releases$/
+    - /.*-test-travis$/
 
 matrix:
   include:
@@ -19,7 +19,7 @@ matrix:
       env: NODE_VERSION=8.9.3 DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1 ATOM_JASMINE_REPORTER=list
 
 before_install:
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
+  - '/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16'
 
 install:
   - git clone https://github.com/creationix/nvm.git /tmp/.nvm
@@ -57,11 +57,11 @@ addons:
     target_paths: travis-artifacts/$TRAVIS_BUILD_ID
   apt:
     packages:
-    - build-essential
-    - clang-3.3
-    - fakeroot
-    - git
-    - libsecret-1-dev
-    - rpm
-    - libx11-dev
-    - libxkbfile-dev
+      - build-essential
+      - clang-3.3
+      - fakeroot
+      - git
+      - libsecret-1-dev
+      - rpm
+      - libx11-dev
+      - libxkbfile-dev

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image: Visual Studio 2015
 
-version: "{build}"
+version: '{build}'
 
 skip_tags: true
 clone_folder: c:\projects\atom
@@ -8,9 +8,9 @@ clone_depth: 10
 
 branches:
   only:
-  - master
-  - /^[0-9.]+-releases$/
-  - /^electron-[0-9.]+$/
+    - master
+    - /^[0-9.]+-releases$/
+    - /^electron-[0-9.]+$/
 
 platform:
   - x64
@@ -24,8 +24,8 @@ environment:
     NODE_VERSION: 8.9.3
 
   matrix:
-  - TASK: test
-  - TASK: installer
+    - TASK: test
+    - TASK: installer
 
 matrix:
   fast_finish: true
@@ -46,28 +46,28 @@ build_script:
   - IF [%APPVEYOR_REPO_BRANCH%]==[master] IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET IS_SIGNED_ZIP_BRANCH=true
   - IF [%APPVEYOR_REPO_BRANCH:~0,9%]==[electron-] IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET IS_SIGNED_ZIP_BRANCH=true
   - IF [%TASK%]==[installer] (
-      IF [%IS_RELEASE_BRANCH%]==[true] (
-        ECHO Building on release branch - Creating production artifacts &&
-        script\build.cmd --code-sign --compress-artifacts --create-windows-installer
-      ) ELSE (
-        IF [%IS_SIGNED_ZIP_BRANCH%]==[true] (
-          ECHO Building on %APPVEYOR_REPO_BRANCH% branch - Creating signed zips &&
-          script\build.cmd --code-sign --compress-artifacts
-        ) ELSE (
-          ECHO Skipping installer build for non-release/non-master branch
-        )
-      )
+    IF [%IS_RELEASE_BRANCH%]==[true] (
+    ECHO Building on release branch - Creating production artifacts &&
+    script\build.cmd --code-sign --compress-artifacts --create-windows-installer
     ) ELSE (
-      ECHO Test build only - Not creating artifacts &&
-      script\build.cmd
+    IF [%IS_SIGNED_ZIP_BRANCH%]==[true] (
+    ECHO Building on %APPVEYOR_REPO_BRANCH% branch - Creating signed zips &&
+    script\build.cmd --code-sign --compress-artifacts
+    ) ELSE (
+    ECHO Skipping installer build for non-release/non-master branch
+    )
+    )
+    ) ELSE (
+    ECHO Test build only - Not creating artifacts &&
+    script\build.cmd
     )
 
 test_script:
   - IF [%TASK%]==[test] (
-      script\lint.cmd &&
-      script\test.cmd
+    script\lint.cmd &&
+    script\test.cmd
     ) ELSE (
-      ECHO Skipping tests on installer build matrix row
+    ECHO Skipping tests on installer build matrix row
     )
 
 deploy: off

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,65 +1,64 @@
 resources:
   containers:
-  - container: atom-linux-ci
-    image: atomeditor/atom-linux-ci:latest
+    - container: atom-linux-ci
+      image: atomeditor/atom-linux-ci:latest
 
 jobs:
+  - job: GetReleaseVersion
+    steps:
+      # This has to be done separately because VSTS inexplicably
+      # exits the script block after `npm install` completes.
+      - script: |
+          cd script\vsts
+          npm install
+        displayName: npm install
+      - script: node script\vsts\get-release-version.js --nightly
+        name: Version
 
-- job: GetReleaseVersion
-  steps:
-  # This has to be done separately because VSTS inexplicably
-  # exits the script block after `npm install` completes.
-  - script: |
-      cd script\vsts
-      npm install
-    displayName: npm install
-  - script: node script\vsts\get-release-version.js --nightly
-    name: Version
+  # Import OS-specific build definitions
+  - template: platforms/windows.yml
+  - template: platforms/macos.yml
+  - template: platforms/linux.yml
 
-# Import OS-specific build definitions
-- template: platforms/windows.yml
-- template: platforms/macos.yml
-- template: platforms/linux.yml
+  - job: Release
+    pool:
+      vmImage: vs2015-win2012r2 # needed for Python 2.7 and gyp
 
-- job: Release
-  pool:
-    vmImage: vs2015-win2012r2 # needed for Python 2.7 and gyp
+    dependsOn:
+      - GetReleaseVersion
+      - Windows
+      - Linux
+      - macOS_tests
 
-  dependsOn:
-  - GetReleaseVersion
-  - Windows
-  - Linux
-  - macOS_tests
+    variables:
+      ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
 
-  variables:
-    ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: 8.9.3
+        displayName: Install Node.js 8.9.3
 
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: 8.9.3
-    displayName: Install Node.js 8.9.3
+      # This has to be done separately because VSTS inexplicably
+      # exits the script block after `npm install` completes.
+      - script: |
+          cd script\vsts
+          npm install
+        displayName: npm install
 
-  # This has to be done separately because VSTS inexplicably
-  # exits the script block after `npm install` completes.
-  - script: |
-      cd script\vsts
-      npm install
-    displayName: npm install
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          itemPattern: '**'
+          downloadType: 'specific'
+        displayName: Download Release Artifacts
 
-  - task: DownloadBuildArtifacts@0
-    inputs:
-      itemPattern: '**'
-      downloadType: 'specific'
-    displayName: Download Release Artifacts
-
-  - script: |
-      node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)"
-    env:
-      GITHUB_TOKEN: $(GITHUB_TOKEN)
-      ATOM_RELEASE_VERSION: $(ReleaseVersion)
-      ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
-      ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
-      ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
-      PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
-    displayName: Create Nightly Release
+      - script: |
+          node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)"
+        env:
+          GITHUB_TOKEN: $(GITHUB_TOKEN)
+          ATOM_RELEASE_VERSION: $(ReleaseVersion)
+          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
+          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
+          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
+          PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
+        displayName: Create Nightly Release

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -1,91 +1,91 @@
 jobs:
-- job: Linux
-  dependsOn: GetReleaseVersion
-  timeoutInMinutes: 180
+  - job: Linux
+    dependsOn: GetReleaseVersion
+    timeoutInMinutes: 180
 
-  variables:
-    ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
-  pool:
-    # This image is used to host the Docker container that runs the build
-    vmImage: ubuntu-16.04
+    variables:
+      ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
+    pool:
+      # This image is used to host the Docker container that runs the build
+      vmImage: ubuntu-16.04
 
-  container: atom-linux-ci
+    container: atom-linux-ci
 
-  steps:
-  - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
-    displayName: Restore node_modules cache
-    inputs:
-      keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
-      targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-      vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+    steps:
+      - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
+        displayName: Restore node_modules cache
+        inputs:
+          keyfile: 'package.json, script/vsts/platforms/windows.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
+          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
+          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
 
-  - script: script/bootstrap
-    displayName: Bootstrap build environment
-    env:
-      CI: true
-      CI_PROVIDER: VSTS
-    condition: ne(variables['CacheRestored'], 'true')
+      - script: script/bootstrap
+        displayName: Bootstrap build environment
+        env:
+          CI: true
+          CI_PROVIDER: VSTS
+        condition: ne(variables['CacheRestored'], 'true')
 
-  - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
-    displayName: Save node_modules cache
-    inputs:
-      keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
-      targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-      vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+      - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
+        displayName: Save node_modules cache
+        inputs:
+          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
+          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
+          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
 
-  - script: script/lint
-    displayName: Run linter
+      - script: script/lint
+        displayName: Run linter
 
-  - script: script/build --no-bootstrap --create-debian-package --create-rpm-package --compress-artifacts
-    env:
-      GITHUB_TOKEN: $(GITHUB_TOKEN)
-      ATOM_RELEASE_VERSION: $(ReleaseVersion)
-    displayName: Build Atom
+      - script: script/build --no-bootstrap --create-debian-package --create-rpm-package --compress-artifacts
+        env:
+          GITHUB_TOKEN: $(GITHUB_TOKEN)
+          ATOM_RELEASE_VERSION: $(ReleaseVersion)
+        displayName: Build Atom
 
-  - script: script/test
-    env:
-      CI: true
-      CI_PROVIDER: VSTS
-      ATOM_JASMINE_REPORTER: list
-      TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
-    displayName: Run tests
-    condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
+      - script: script/test
+        env:
+          CI: true
+          CI_PROVIDER: VSTS
+          ATOM_JASMINE_REPORTER: list
+          TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
+        displayName: Run tests
+        condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
 
-  - script: script/postprocess-junit-results --search-folder "${TEST_JUNIT_XML_ROOT}" --test-results-files "**/*.xml"
-    env:
-      TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
-    displayName: Post-process test results
-    condition: ne(variables['Atom.SkipTests'], 'true')
+      - script: script/postprocess-junit-results --search-folder "${TEST_JUNIT_XML_ROOT}" --test-results-files "**/*.xml"
+        env:
+          TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
+        displayName: Post-process test results
+        condition: ne(variables['Atom.SkipTests'], 'true')
 
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      searchFolder: $(Common.TestResultsDirectory)/junit
-      testResultsFiles: "**/*.xml"
-      mergeTestResults: true
-      testRunTitle: Linux
-    condition: ne(variables['Atom.SkipTests'], 'true')
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: JUnit
+          searchFolder: $(Common.TestResultsDirectory)/junit
+          testResultsFiles: '**/*.xml'
+          mergeTestResults: true
+          testRunTitle: Linux
+        condition: ne(variables['Atom.SkipTests'], 'true')
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/out/atom.x86_64.rpm
-      ArtifactName: atom.x86_64.rpm
-      ArtifactType: Container
-    displayName: Upload atom.x84_64.rpm
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/out/atom.x86_64.rpm
+          ArtifactName: atom.x86_64.rpm
+          ArtifactType: Container
+        displayName: Upload atom.x84_64.rpm
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/out/atom-amd64.deb
-      ArtifactName: atom-amd64.deb
-      ArtifactType: Container
-    displayName: Upload atom-amd64.deb
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/out/atom-amd64.deb
+          ArtifactName: atom-amd64.deb
+          ArtifactType: Container
+        displayName: Upload atom-amd64.deb
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/out/atom-amd64.tar.gz
-      ArtifactName: atom-amd64.tar.gz
-      ArtifactType: Container
-    displayName: Upload atom-amd64.tar.gz
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/out/atom-amd64.tar.gz
+          ArtifactName: atom-amd64.tar.gz
+          ArtifactType: Container
+        displayName: Upload atom-amd64.tar.gz
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -1,182 +1,182 @@
 jobs:
-- job: macOS_build
-  displayName: macOS build
-  dependsOn: GetReleaseVersion
-  timeoutInMinutes: 180
+  - job: macOS_build
+    displayName: macOS build
+    dependsOn: GetReleaseVersion
+    timeoutInMinutes: 180
 
-  variables:
-    ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
-    IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
-    IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
-  pool:
-    vmImage: macos-10.13
+    variables:
+      ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
+      IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
+      IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
+    pool:
+      vmImage: macos-10.13
 
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: 8.9.3
-    displayName: Install Node.js 8.9.3
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: 8.9.3
+        displayName: Install Node.js 8.9.3
 
-  - script: npm install --global npm@6.2.0
-    displayName: Update npm
+      - script: npm install --global npm@6.2.0
+        displayName: Update npm
 
-  - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
-    displayName: Restore node_modules cache
-    inputs:
-      keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
-      targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-      vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+      - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
+        displayName: Restore node_modules cache
+        inputs:
+          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
+          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
+          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
 
-  - script: script/bootstrap
-    displayName: Bootstrap build environment
-    env:
-      CI: true
-      CI_PROVIDER: VSTS
-      NPM_BIN_PATH: /usr/local/bin/npm
-    condition: ne(variables['CacheRestored'], 'true')
+      - script: script/bootstrap
+        displayName: Bootstrap build environment
+        env:
+          CI: true
+          CI_PROVIDER: VSTS
+          NPM_BIN_PATH: /usr/local/bin/npm
+        condition: ne(variables['CacheRestored'], 'true')
 
-  - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
-    displayName: Save node_modules cache
-    inputs:
-      keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
-      targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-      vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+      - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
+        displayName: Save node_modules cache
+        inputs:
+          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
+          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
+          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
 
-  - script: script/lint
-    displayName: Run linter
+      - script: script/lint
+        displayName: Run linter
 
-  - script: |
-      if [ $IS_RELEASE_BRANCH == "true" ] || [ $IS_SIGNED_ZIP_BRANCH == "true" ]; then
-        script/build --no-bootstrap --code-sign --compress-artifacts
-      else
-        script/build --no-bootstrap --compress-artifacts
-      fi
-    displayName: Build Atom
-    env:
-      GITHUB_TOKEN: $(GITHUB_TOKEN)
-      IS_RELEASE_BRANCH: $(IsReleaseBranch)
-      IS_SIGNED_ZIP_BRANCH: $(IsSignedZipBranch)
-      ATOM_RELEASE_VERSION: $(ReleaseVersion)
-      ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL: $(ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL)
-      ATOM_MAC_CODE_SIGNING_CERT_PASSWORD: $(ATOM_MAC_CODE_SIGNING_CERT_PASSWORD)
-      ATOM_MAC_CODE_SIGNING_KEYCHAIN: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN)
-      ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD)
+      - script: |
+          if [ $IS_RELEASE_BRANCH == "true" ] || [ $IS_SIGNED_ZIP_BRANCH == "true" ]; then
+            script/build --no-bootstrap --code-sign --compress-artifacts
+          else
+            script/build --no-bootstrap --compress-artifacts
+          fi
+        displayName: Build Atom
+        env:
+          GITHUB_TOKEN: $(GITHUB_TOKEN)
+          IS_RELEASE_BRANCH: $(IsReleaseBranch)
+          IS_SIGNED_ZIP_BRANCH: $(IsSignedZipBranch)
+          ATOM_RELEASE_VERSION: $(ReleaseVersion)
+          ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL: $(ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL)
+          ATOM_MAC_CODE_SIGNING_CERT_PASSWORD: $(ATOM_MAC_CODE_SIGNING_CERT_PASSWORD)
+          ATOM_MAC_CODE_SIGNING_KEYCHAIN: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN)
+          ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD)
 
-  - script: |
-      cp $(Build.SourcesDirectory)/out/*.zip $(Build.ArtifactStagingDirectory)
-    displayName: Stage Artifacts
+      - script: |
+          cp $(Build.SourcesDirectory)/out/*.zip $(Build.ArtifactStagingDirectory)
+        displayName: Stage Artifacts
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/atom-mac.zip
-      ArtifactName: atom-mac.zip
-      ArtifactType: Container
-    displayName: Upload atom-mac.zip
-    condition: succeeded()
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.ArtifactStagingDirectory)/atom-mac.zip
+          ArtifactName: atom-mac.zip
+          ArtifactType: Container
+        displayName: Upload atom-mac.zip
+        condition: succeeded()
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/atom-mac-symbols.zip
-      ArtifactName: atom-mac-symbols.zip
-      ArtifactType: Container
-    displayName: Upload atom-mac-symbols.zip
-    condition: succeeded()
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.ArtifactStagingDirectory)/atom-mac-symbols.zip
+          ArtifactName: atom-mac-symbols.zip
+          ArtifactType: Container
+        displayName: Upload atom-mac-symbols.zip
+        condition: succeeded()
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/docs/output/atom-api.json
-      ArtifactName: atom-api.json
-      ArtifactType: Container
-    displayName: Upload atom-api.json
-    condition: succeeded()
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/docs/output/atom-api.json
+          ArtifactName: atom-api.json
+          ArtifactType: Container
+        displayName: Upload atom-api.json
+        condition: succeeded()
 
-- job: macOS_tests
-  displayName: macOS test
-  dependsOn: macOS_build
-  timeoutInMinutes: 180
-  pool:
-    vmImage: macos-10.13
-  strategy:
-    maxParallel: 3
-    matrix:
-      core:
-        RunCoreTests: true
-        RunPackageTests: false
-      packages-1:
-        RunCoreTests: false
-        RunPackageTests: 1
-      packages-2:
-        RunCoreTests: false
-        RunPackageTests: 2
+  - job: macOS_tests
+    displayName: macOS test
+    dependsOn: macOS_build
+    timeoutInMinutes: 180
+    pool:
+      vmImage: macos-10.13
+    strategy:
+      maxParallel: 3
+      matrix:
+        core:
+          RunCoreTests: true
+          RunPackageTests: false
+        packages-1:
+          RunCoreTests: false
+          RunPackageTests: 1
+        packages-2:
+          RunCoreTests: false
+          RunPackageTests: 2
 
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: 8.9.3
-    displayName: Install Node.js 8.9.3
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: 8.9.3
+        displayName: Install Node.js 8.9.3
 
-  - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
-    displayName: Restore node_modules cache
-    inputs:
-      keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
-      targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-      vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+      - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
+        displayName: Restore node_modules cache
+        inputs:
+          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
+          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
+          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
 
-  - task: DownloadBuildArtifacts@0
-    displayName: Download atom-mac.zip
-    inputs:
-      artifactName: 'atom-mac.zip'
-      downloadPath: $(Build.SourcesDirectory)
+      - task: DownloadBuildArtifacts@0
+        displayName: Download atom-mac.zip
+        inputs:
+          artifactName: 'atom-mac.zip'
+          downloadPath: $(Build.SourcesDirectory)
 
-  - script: unzip atom-mac.zip/atom-mac.zip -d out
-    displayName: Unzip atom-mac.zip
+      - script: unzip atom-mac.zip/atom-mac.zip -d out
+        displayName: Unzip atom-mac.zip
 
-  - task: DownloadBuildArtifacts@0
-    displayName: Download atom-mac-symbols.zip
-    inputs:
-      artifactName: 'atom-mac-symbols.zip'
-      downloadPath: $(Build.SourcesDirectory)
+      - task: DownloadBuildArtifacts@0
+        displayName: Download atom-mac-symbols.zip
+        inputs:
+          artifactName: 'atom-mac-symbols.zip'
+          downloadPath: $(Build.SourcesDirectory)
 
-  - script: unzip atom-mac-symbols.zip/atom-mac-symbols.zip -d out
-    displayName: Unzip atom-mac-symbols.zip
+      - script: unzip atom-mac-symbols.zip/atom-mac-symbols.zip -d out
+        displayName: Unzip atom-mac-symbols.zip
 
-  - script: |
-      osascript -e 'tell application "System Events" to keystroke "x"' # clear screen saver
-      caffeinate -s script/test # Run with caffeinate to prevent screen saver
-    env:
-      CI: true
-      CI_PROVIDER: VSTS
-      ATOM_JASMINE_REPORTER: list
-      TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
-      ATOM_RUN_CORE_TESTS: $(RunCoreTests)
-      ATOM_RUN_PACKAGE_TESTS: $(RunPackageTests)
-    displayName: Run tests
-    condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
+      - script: |
+          osascript -e 'tell application "System Events" to keystroke "x"' # clear screen saver
+          caffeinate -s script/test # Run with caffeinate to prevent screen saver
+        env:
+          CI: true
+          CI_PROVIDER: VSTS
+          ATOM_JASMINE_REPORTER: list
+          TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
+          ATOM_RUN_CORE_TESTS: $(RunCoreTests)
+          ATOM_RUN_PACKAGE_TESTS: $(RunPackageTests)
+        displayName: Run tests
+        condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
 
-  - script: script/postprocess-junit-results --search-folder "${TEST_JUNIT_XML_ROOT}" --test-results-files "**/*.xml"
-    env:
-      TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
-    displayName: Post-process test results
-    condition: ne(variables['Atom.SkipTests'], 'true')
+      - script: script/postprocess-junit-results --search-folder "${TEST_JUNIT_XML_ROOT}" --test-results-files "**/*.xml"
+        env:
+          TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
+        displayName: Post-process test results
+        condition: ne(variables['Atom.SkipTests'], 'true')
 
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      searchFolder: $(Common.TestResultsDirectory)/junit
-      testResultsFiles: "**/*.xml"
-      mergeTestResults: true
-      testRunTitle: MacOS
-    condition: ne(variables['Atom.SkipTests'], 'true')
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: JUnit
+          searchFolder: $(Common.TestResultsDirectory)/junit
+          testResultsFiles: '**/*.xml'
+          mergeTestResults: true
+          testRunTitle: MacOS
+        condition: ne(variables['Atom.SkipTests'], 'true')
 
-  - script: |
-      mkdir -p $(Build.ArtifactStagingDirectory)/crash-reports
-      cp ${HOME}/Library/Logs/DiagnosticReports/*.crash $(Build.ArtifactStagingDirectory)/crash-reports
-    displayName: Stage Crash Reports
-    condition: failed()
+      - script: |
+          mkdir -p $(Build.ArtifactStagingDirectory)/crash-reports
+          cp ${HOME}/Library/Logs/DiagnosticReports/*.crash $(Build.ArtifactStagingDirectory)/crash-reports
+        displayName: Stage Crash Reports
+        condition: failed()
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/crash-reports
-      ArtifactName: crash-reports.zip
-    displayName: Upload Crash Reports
-    condition: failed()
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.ArtifactStagingDirectory)/crash-reports
+          ArtifactName: crash-reports.zip
+        displayName: Upload Crash Reports
+        condition: failed()

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -1,249 +1,249 @@
 jobs:
-- job: Windows
-  dependsOn: GetReleaseVersion
-  timeoutInMinutes: 180
-  strategy:
-    maxParallel: 2
-    matrix:
-      x64:
-        buildArch: x64
-      x86:
-        buildArch: x86
+  - job: Windows
+    dependsOn: GetReleaseVersion
+    timeoutInMinutes: 180
+    strategy:
+      maxParallel: 2
+      matrix:
+        x64:
+          buildArch: x64
+        x86:
+          buildArch: x86
 
-  pool:
-    vmImage: vs2015-win2012r2 # needed for python 2.7 and gyp
+    pool:
+      vmImage: vs2015-win2012r2 # needed for python 2.7 and gyp
 
-  variables:
-    ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
-    IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
-    IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
+    variables:
+      ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
+      IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
+      IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
 
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: 8.9.3
-    displayName: Install Node.js 8.9.3
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: 8.9.3
+        displayName: Install Node.js 8.9.3
 
-  - script: |
-      ECHO Installing npm-windows-upgrade
-      npm install --global --production npm-windows-upgrade
-    displayName: Install npm-windows-upgrade
+      - script: |
+          ECHO Installing npm-windows-upgrade
+          npm install --global --production npm-windows-upgrade
+        displayName: Install npm-windows-upgrade
 
-  - script: |
-      ECHO Upgrading npm
-      npm-windows-upgrade --no-spinner --no-prompt --npm-version 6.2.0
-    displayName: Install npm 6.2.0
+      - script: |
+          ECHO Upgrading npm
+          npm-windows-upgrade --no-spinner --no-prompt --npm-version 6.2.0
+        displayName: Install npm 6.2.0
 
-  - script: |
-      cd script\vsts
-      npm install
-    displayName: Install Windows build dependencies
+      - script: |
+          cd script\vsts
+          npm install
+        displayName: Install Windows build dependencies
 
-  - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
-    displayName: Restore node_modules cache (x64)
-    inputs:
-      keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x64-cache-key'
-      targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-      vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
-    condition: eq(variables['buildArch'], 'x64')
+      - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
+        displayName: Restore node_modules cache (x64)
+        inputs:
+          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x64-cache-key'
+          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
+          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+        condition: eq(variables['buildArch'], 'x64')
 
-  - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
-    displayName: Restore node_modules cache (x86)
-    inputs:
-      keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x86-cache-key'
-      targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-      vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
-    condition: eq(variables['buildArch'], 'x86')
+      - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
+        displayName: Restore node_modules cache (x86)
+        inputs:
+          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x86-cache-key'
+          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
+          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+        condition: eq(variables['buildArch'], 'x86')
 
-  - script: |
-      node script\vsts\windows-run.js script\bootstrap.cmd
-    env:
-      BUILD_ARCH: $(buildArch)
-      CI: true
-      CI_PROVIDER: VSTS
-      NPM_BIN_PATH: "D:\\a\\_tool\\node\\8.9.3\\x64\\npm.cmd"
-    displayName: Bootstrap build environment
-    condition: ne(variables['CacheRestored'], 'true')
+      - script: |
+          node script\vsts\windows-run.js script\bootstrap.cmd
+        env:
+          BUILD_ARCH: $(buildArch)
+          CI: true
+          CI_PROVIDER: VSTS
+          NPM_BIN_PATH: "D:\\a\\_tool\\node\\8.9.3\\x64\\npm.cmd"
+        displayName: Bootstrap build environment
+        condition: ne(variables['CacheRestored'], 'true')
 
-  - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
-    displayName: Save node_modules cache (x64)
-    inputs:
-      keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x64-cache-key'
-      targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-      vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
-    condition: eq(variables['buildArch'], 'x64')
+      - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
+        displayName: Save node_modules cache (x64)
+        inputs:
+          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x64-cache-key'
+          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
+          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+        condition: eq(variables['buildArch'], 'x64')
 
-  - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
-    displayName: Save node_modules cache (x86)
-    inputs:
-      keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x86-cache-key'
-      targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-      vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
-    condition: eq(variables['buildArch'], 'x86')
+      - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
+        displayName: Save node_modules cache (x86)
+        inputs:
+          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x86-cache-key'
+          targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
+          vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
+        condition: eq(variables['buildArch'], 'x86')
 
-  - script: node script\vsts\windows-run.js script\lint.cmd
-    env:
-      BUILD_ARCH: $(buildArch)
-    displayName: Run linter
+      - script: node script\vsts\windows-run.js script\lint.cmd
+        env:
+          BUILD_ARCH: $(buildArch)
+        displayName: Run linter
 
-  - script: |
-      IF NOT EXIST C:\tmp MKDIR C:\tmp
-      SET SQUIRREL_TEMP=C:\tmp
-      IF [%IS_RELEASE_BRANCH%]==[true] (
-        ECHO Creating production artifacts for release branch %BUILD_SOURCEBRANCHNAME%
-        node script\vsts\windows-run.js script\build.cmd --no-bootstrap --code-sign --compress-artifacts --create-windows-installer
-      ) ELSE (
-        IF [%IS_SIGNED_ZIP_BRANCH%]==[true] (
-          ECHO Creating signed CI artifacts for branch %BUILD_SOURCEBRANCHNAME%
-          node script\vsts\windows-run.js script\build.cmd --no-bootstrap --code-sign --compress-artifacts
-        ) ELSE (
-          ECHO Pull request build, no code signing will be performed
-          node script\vsts\windows-run.js script\build.cmd --no-bootstrap --compress-artifacts
-        )
-      )
-    env:
-      GITHUB_TOKEN: $(GITHUB_TOKEN)
-      BUILD_ARCH: $(buildArch)
-      ATOM_RELEASE_VERSION: $(ReleaseVersion)
-      ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL: $(ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL)
-      ATOM_WIN_CODE_SIGNING_CERT_PASSWORD: $(ATOM_WIN_CODE_SIGNING_CERT_PASSWORD)
-      IS_RELEASE_BRANCH: $(IsReleaseBranch)
-      IS_SIGNED_ZIP_BRANCH: $(IsSignedZipBranch)
-    displayName: Build Atom
+      - script: |
+          IF NOT EXIST C:\tmp MKDIR C:\tmp
+          SET SQUIRREL_TEMP=C:\tmp
+          IF [%IS_RELEASE_BRANCH%]==[true] (
+            ECHO Creating production artifacts for release branch %BUILD_SOURCEBRANCHNAME%
+            node script\vsts\windows-run.js script\build.cmd --no-bootstrap --code-sign --compress-artifacts --create-windows-installer
+          ) ELSE (
+            IF [%IS_SIGNED_ZIP_BRANCH%]==[true] (
+              ECHO Creating signed CI artifacts for branch %BUILD_SOURCEBRANCHNAME%
+              node script\vsts\windows-run.js script\build.cmd --no-bootstrap --code-sign --compress-artifacts
+            ) ELSE (
+              ECHO Pull request build, no code signing will be performed
+              node script\vsts\windows-run.js script\build.cmd --no-bootstrap --compress-artifacts
+            )
+          )
+        env:
+          GITHUB_TOKEN: $(GITHUB_TOKEN)
+          BUILD_ARCH: $(buildArch)
+          ATOM_RELEASE_VERSION: $(ReleaseVersion)
+          ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL: $(ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL)
+          ATOM_WIN_CODE_SIGNING_CERT_PASSWORD: $(ATOM_WIN_CODE_SIGNING_CERT_PASSWORD)
+          IS_RELEASE_BRANCH: $(IsReleaseBranch)
+          IS_SIGNED_ZIP_BRANCH: $(IsSignedZipBranch)
+        displayName: Build Atom
 
-  - script: node script\vsts\windows-run.js script\test.cmd
-    env:
-      CI: true
-      CI_PROVIDER: VSTS
-      ATOM_JASMINE_REPORTER: list
-      TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)\junit
-      BUILD_ARCH: $(buildArch)
-    displayName: Run tests
-    condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
+      - script: node script\vsts\windows-run.js script\test.cmd
+        env:
+          CI: true
+          CI_PROVIDER: VSTS
+          ATOM_JASMINE_REPORTER: list
+          TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)\junit
+          BUILD_ARCH: $(buildArch)
+        displayName: Run tests
+        condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
 
-  - script: >
-      node script\vsts\windows-run.js script\postprocess-junit-results.cmd
-      --search-folder %TEST_JUNIT_XML_ROOT% --test-results-files "**/*.xml"
-    env:
-      TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)\junit
-    displayName: Post-process test results
-    condition: ne(variables['Atom.SkipTests'], 'true')
+      - script: >
+          node script\vsts\windows-run.js script\postprocess-junit-results.cmd
+          --search-folder %TEST_JUNIT_XML_ROOT% --test-results-files "**/*.xml"
+        env:
+          TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)\junit
+        displayName: Post-process test results
+        condition: ne(variables['Atom.SkipTests'], 'true')
 
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: JUnit
-      searchFolder: $(Common.TestResultsDirectory)\junit
-      testResultsFiles: "**/*.xml"
-      mergeTestResults: true
-      testRunTitle: Windows $(buildArch)
-    condition: ne(variables['Atom.SkipTests'], 'true')
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: JUnit
+          searchFolder: $(Common.TestResultsDirectory)\junit
+          testResultsFiles: '**/*.xml'
+          mergeTestResults: true
+          testRunTitle: Windows $(buildArch)
+        condition: ne(variables['Atom.SkipTests'], 'true')
 
-  - script: |
-      IF NOT EXIST "%ARTIFACT_STAGING_DIR%\crash-reports" MKDIR "%ARTIFACT_STAGING_DIR%\crash-reports"
-      IF EXIST "%Temp%\Atom Crashes" (
-        FOR %%a in ("%Temp%\Atom Crashes\*.dmp") DO XCOPY "%%a" "%ARTIFACT_STAGING_DIR%\crash-reports" /I
-      )
-    displayName: Stage crash reports
-    condition: failed()
-    env:
-      ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
+      - script: |
+          IF NOT EXIST "%ARTIFACT_STAGING_DIR%\crash-reports" MKDIR "%ARTIFACT_STAGING_DIR%\crash-reports"
+          IF EXIST "%Temp%\Atom Crashes" (
+            FOR %%a in ("%Temp%\Atom Crashes\*.dmp") DO XCOPY "%%a" "%ARTIFACT_STAGING_DIR%\crash-reports" /I
+          )
+        displayName: Stage crash reports
+        condition: failed()
+        env:
+          ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/crash-reports
-      ArtifactName: crash-reports
-    displayName: Publish crash reports on non-release branch
-    condition: and(failed(), eq(variables['ATOM_RELEASES_S3_KEY'], ''))
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.ArtifactStagingDirectory)/crash-reports
+          ArtifactName: crash-reports
+        displayName: Publish crash reports on non-release branch
+        condition: and(failed(), eq(variables['ATOM_RELEASES_S3_KEY'], ''))
 
-  - script: >
-      node $(Build.SourcesDirectory)\script\vsts\upload-crash-reports.js --crash-report-path "%ARTIFACT_STAGING_DIR%\crash-reports" --s3-path "vsts-artifacts/%BUILD_ID%/"
-    env:
-      ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
-      ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
-      ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
-      ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
-      BUILD_ID: $(Build.BuildId)
-    displayName: Upload crash reports to S3 on release branch
-    condition: and(failed(), ne(variables['ATOM_RELEASES_S3_KEY'], ''))
+      - script: >
+          node $(Build.SourcesDirectory)\script\vsts\upload-crash-reports.js --crash-report-path "%ARTIFACT_STAGING_DIR%\crash-reports" --s3-path "vsts-artifacts/%BUILD_ID%/"
+        env:
+          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
+          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
+          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
+          ARTIFACT_STAGING_DIR: $(Build.ArtifactStagingDirectory)
+          BUILD_ID: $(Build.BuildId)
+        displayName: Upload crash reports to S3 on release branch
+        condition: and(failed(), ne(variables['ATOM_RELEASES_S3_KEY'], ''))
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/out/atom-x64-windows.zip
-      ArtifactName: atom-x64-windows.zip
-      ArtifactType: Container
-    displayName: Upload atom-x64-windows.zip
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['buildArch'], 'x64'))
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/out/atom-x64-windows.zip
+          ArtifactName: atom-x64-windows.zip
+          ArtifactType: Container
+        displayName: Upload atom-x64-windows.zip
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['buildArch'], 'x64'))
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/out/AtomSetup-x64.exe
-      ArtifactName: AtomSetup-x64.exe
-      ArtifactType: Container
-    displayName: Upload AtomSetup-x64.exe
-    condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x64'))
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/out/AtomSetup-x64.exe
+          ArtifactName: AtomSetup-x64.exe
+          ArtifactType: Container
+        displayName: Upload AtomSetup-x64.exe
+        condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x64'))
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/out/atom-x64-$(ReleaseVersion)-full.nupkg
-      ArtifactName: atom-x64-$(ReleaseVersion)-full.nupkg
-      ArtifactType: Container
-    displayName: Upload atom-x64-$(ReleaseVersion)-full.nupkg
-    condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x64'))
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/out/atom-x64-$(ReleaseVersion)-full.nupkg
+          ArtifactName: atom-x64-$(ReleaseVersion)-full.nupkg
+          ArtifactType: Container
+        displayName: Upload atom-x64-$(ReleaseVersion)-full.nupkg
+        condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x64'))
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/out/atom-x64-$(ReleaseVersion)-delta.nupkg
-      ArtifactName: atom-x64-$(ReleaseVersion)-delta.nupkg
-      ArtifactType: Container
-    displayName: Upload atom-x64-$(ReleaseVersion)-delta.nupkg
-    condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x64'))
-    continueOnError: true  # Nightly builds don't produce delta packages yet, so don't fail the build
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/out/atom-x64-$(ReleaseVersion)-delta.nupkg
+          ArtifactName: atom-x64-$(ReleaseVersion)-delta.nupkg
+          ArtifactType: Container
+        displayName: Upload atom-x64-$(ReleaseVersion)-delta.nupkg
+        condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x64'))
+        continueOnError: true # Nightly builds don't produce delta packages yet, so don't fail the build
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/out/RELEASES-x64
-      ArtifactName: RELEASES-x64
-      ArtifactType: Container
-    displayName: Upload RELEASES-x64
-    condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x64'))
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/out/RELEASES-x64
+          ArtifactName: RELEASES-x64
+          ArtifactType: Container
+        displayName: Upload RELEASES-x64
+        condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x64'))
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/out/atom-windows.zip
-      ArtifactName: atom-windows.zip
-      ArtifactType: Container
-    displayName: Upload atom-windows.zip
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['buildArch'], 'x86'))
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/out/atom-windows.zip
+          ArtifactName: atom-windows.zip
+          ArtifactType: Container
+        displayName: Upload atom-windows.zip
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['buildArch'], 'x86'))
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/out/AtomSetup.exe
-      ArtifactName: AtomSetup.exe
-      ArtifactType: Container
-    displayName: Upload AtomSetup.exe
-    condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x86'))
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/out/AtomSetup.exe
+          ArtifactName: AtomSetup.exe
+          ArtifactType: Container
+        displayName: Upload AtomSetup.exe
+        condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x86'))
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/out/atom-$(ReleaseVersion)-full.nupkg
-      ArtifactName: atom-$(ReleaseVersion)-full.nupkg
-      ArtifactType: Container
-    displayName: Upload atom-$(ReleaseVersion)-full.nupkg
-    condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x86'))
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/out/atom-$(ReleaseVersion)-full.nupkg
+          ArtifactName: atom-$(ReleaseVersion)-full.nupkg
+          ArtifactType: Container
+        displayName: Upload atom-$(ReleaseVersion)-full.nupkg
+        condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x86'))
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/out/atom-$(ReleaseVersion)-delta.nupkg
-      ArtifactName: atom-$(ReleaseVersion)-delta.nupkg
-      ArtifactType: Container
-    displayName: Upload atom-$(ReleaseVersion)-delta.nupkg
-    condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x86'))
-    continueOnError: true  # Nightly builds don't produce delta packages yet, so don't fail the build
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/out/atom-$(ReleaseVersion)-delta.nupkg
+          ArtifactName: atom-$(ReleaseVersion)-delta.nupkg
+          ArtifactType: Container
+        displayName: Upload atom-$(ReleaseVersion)-delta.nupkg
+        condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x86'))
+        continueOnError: true # Nightly builds don't produce delta packages yet, so don't fail the build
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      PathtoPublish: $(Build.SourcesDirectory)/out/RELEASES
-      ArtifactName: RELEASES
-      ArtifactType: Container
-    displayName: Upload RELEASES
-    condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x86'))
+      - task: PublishBuildArtifacts@1
+        inputs:
+          PathtoPublish: $(Build.SourcesDirectory)/out/RELEASES
+          ArtifactName: RELEASES
+          ArtifactType: Container
+        displayName: Upload RELEASES
+        condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x86'))

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -1,24 +1,23 @@
-trigger: none  # No CI builds, only PR builds
+trigger: none # No CI builds, only PR builds
 
 resources:
   containers:
-  - container: atom-linux-ci
-    image: atomeditor/atom-linux-ci:latest
+    - container: atom-linux-ci
+      image: atomeditor/atom-linux-ci:latest
 
 jobs:
+  - job: GetReleaseVersion
+    steps:
+      # This has to be done separately because VSTS inexplicably
+      # exits the script block after `npm install` completes.
+      - script: |
+          cd script\vsts
+          npm install
+        displayName: npm install
+      - script: node script\vsts\get-release-version.js
+        name: Version
 
-- job: GetReleaseVersion
-  steps:
-  # This has to be done separately because VSTS inexplicably
-  # exits the script block after `npm install` completes.
-  - script: |
-      cd script\vsts
-      npm install
-    displayName: npm install
-  - script: node script\vsts\get-release-version.js
-    name: Version
-
-# Import OS-specific build definitions
-- template: platforms/windows.yml
-- template: platforms/macos.yml
-- template: platforms/linux.yml
+  # Import OS-specific build definitions
+  - template: platforms/windows.yml
+  - template: platforms/macos.yml
+  - template: platforms/linux.yml

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -1,85 +1,84 @@
 trigger:
-- master
-- 1.* # VSTS only supports wildcards at the end
-- electron-*
+  - master
+  - 1.* # VSTS only supports wildcards at the end
+  - electron-*
 
 resources:
   containers:
-  - container: atom-linux-ci
-    image: atomeditor/atom-linux-ci:latest
+    - container: atom-linux-ci
+      image: atomeditor/atom-linux-ci:latest
 
 jobs:
+  - job: GetReleaseVersion
+    steps:
+      # This has to be done separately because VSTS inexplicably
+      # exits the script block after `npm install` completes.
+      - script: |
+          cd script\vsts
+          npm install
+        displayName: npm install
+      - script: node script\vsts\get-release-version.js
+        name: Version
 
-- job: GetReleaseVersion
-  steps:
-  # This has to be done separately because VSTS inexplicably
-  # exits the script block after `npm install` completes.
-  - script: |
-      cd script\vsts
-      npm install
-    displayName: npm install
-  - script: node script\vsts\get-release-version.js
-    name: Version
+  # Import OS-specific build definitions.
+  - template: platforms/windows.yml
+  - template: platforms/macos.yml
+  - template: platforms/linux.yml
 
-# Import OS-specific build definitions.
-- template: platforms/windows.yml
-- template: platforms/macos.yml
-- template: platforms/linux.yml
+  - job: UploadArtifacts
+    pool:
+      vmImage: vs2015-win2012r2 # needed for python 2.7 and gyp
 
-- job: UploadArtifacts
-  pool:
-    vmImage: vs2015-win2012r2 # needed for python 2.7 and gyp
+    dependsOn:
+      - GetReleaseVersion
+      - Windows
+      - Linux
+      - macOS_tests
 
-  dependsOn:
-  - GetReleaseVersion
-  - Windows
-  - Linux
-  - macOS_tests
+    variables:
+      ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
+      IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
+      IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
 
-  variables:
-    ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
-    IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
-    IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: 8.9.3
+        displayName: Install Node.js 8.9.3
 
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: 8.9.3
-    displayName: Install Node.js 8.9.3
+      # This has to be done separately because VSTS inexplicably
+      # exits the script block after `npm install` completes.
+      - script: |
+          cd script\vsts
+          npm install
+        env:
+          GITHUB_TOKEN: $(GITHUB_TOKEN)
+        displayName: npm install
 
-  # This has to be done separately because VSTS inexplicably
-  # exits the script block after `npm install` completes.
-  - script: |
-      cd script\vsts
-      npm install
-    env:
-      GITHUB_TOKEN: $(GITHUB_TOKEN)
-    displayName: npm install
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          itemPattern: '**'
+          downloadType: 'specific'
+        displayName: Download Release Artifacts
 
-  - task: DownloadBuildArtifacts@0
-    inputs:
-      itemPattern: '**'
-      downloadType: 'specific'
-    displayName: Download Release Artifacts
+      - script: |
+          node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)" --linux-repo-name "atom-staging"
+        env:
+          GITHUB_TOKEN: $(GITHUB_TOKEN)
+          ATOM_RELEASE_VERSION: $(ReleaseVersion)
+          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
+          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
+          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
+          PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
+        displayName: Create Draft Release
+        condition: and(succeeded(), eq(variables['Atom.AutoDraftRelease'], 'true'), eq(variables['IsReleaseBranch'], 'true'))
 
-  - script: |
-      node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)" --linux-repo-name "atom-staging"
-    env:
-      GITHUB_TOKEN: $(GITHUB_TOKEN)
-      ATOM_RELEASE_VERSION: $(ReleaseVersion)
-      ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
-      ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
-      ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
-      PACKAGE_CLOUD_API_KEY: $(PACKAGE_CLOUD_API_KEY)
-    displayName: Create Draft Release
-    condition: and(succeeded(), eq(variables['Atom.AutoDraftRelease'], 'true'), eq(variables['IsReleaseBranch'], 'true'))
-
-  - script: |
-      node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --assets-path "$(System.ArtifactsDirectory)" --s3-path "vsts-artifacts/$(Build.BuildId)/"
-    env:
-      ATOM_RELEASE_VERSION: $(ReleaseVersion)
-      ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
-      ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
-      ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
-    displayName: Upload CI Artifacts to S3
-    condition: and(succeeded(), eq(variables['IsSignedZipBranch'], 'true'))
+      - script: |
+          node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --assets-path "$(System.ArtifactsDirectory)" --s3-path "vsts-artifacts/$(Build.BuildId)/"
+        env:
+          ATOM_RELEASE_VERSION: $(ReleaseVersion)
+          ATOM_RELEASES_S3_KEY: $(ATOM_RELEASES_S3_KEY)
+          ATOM_RELEASES_S3_SECRET: $(ATOM_RELEASES_S3_SECRET)
+          ATOM_RELEASES_S3_BUCKET: $(ATOM_RELEASES_S3_BUCKET)
+        displayName: Upload CI Artifacts to S3
+        condition: and(succeeded(), eq(variables['IsSignedZipBranch'], 'true'))


### PR DESCRIPTION
This PR changes the indentation of the `yaml` files in the repo to be auto-formatted by `prettier`.

This is to allow smooth integration with the `prettier` package on Atom, which auto-formats yaml files when editing them.