### PR TITLE
Update Node.js version used in CI systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      env: NODE_VERSION=8.9.3 DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1 ATOM_JASMINE_REPORTER=list
+      env: NODE_VERSION=10.2.1 DISPLAY=:99.0 CC=clang CXX=clang++ npm_config_clang=1 ATOM_JASMINE_REPORTER=list
 
 before_install:
   - '/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
     ATOM_DEV_RESOURCE_PATH: c:\projects\atom
     ATOM_JASMINE_REPORTER: list
     CI: true
-    NODE_VERSION: 8.9.3
+    NODE_VERSION: 10.2.1
 
   matrix:
     - TASK: test

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -36,8 +36,8 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: 8.9.3
-        displayName: Install Node.js 8.9.3
+          versionSpec: 10.2.1
+        displayName: Install Node.js 10.2.1
 
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -12,6 +12,14 @@ jobs:
     container: atom-linux-ci
 
     steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: 10.2.1
+        displayName: Install Node.js 10.2.1
+
+      - script: npm install --global npm@6.2.0
+        displayName: Update npm
+
       - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
         displayName: Restore node_modules cache
         inputs:

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -23,7 +23,7 @@ jobs:
       - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
         displayName: Restore node_modules cache
         inputs:
-          keyfile: 'package.json, script/vsts/platforms/windows.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
+          keyfile: 'package.json, script/vsts/platforms/linux.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
           targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
           vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
 
@@ -37,7 +37,7 @@ jobs:
       - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
         displayName: Save node_modules cache
         inputs:
-          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
+          keyfile: 'package.json, script/vsts/platforms/linux.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
           targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
           vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
 

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -23,7 +23,7 @@ jobs:
       - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
         displayName: Restore node_modules cache
         inputs:
-          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
+          keyfile: 'package.json, script/vsts/platforms/macos.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
           targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
           vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
 
@@ -38,7 +38,7 @@ jobs:
       - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
         displayName: Save node_modules cache
         inputs:
-          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
+          keyfile: 'package.json, script/vsts/platforms/macos.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
           targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
           vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
 
@@ -118,7 +118,7 @@ jobs:
       - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
         displayName: Restore node_modules cache
         inputs:
-          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
+          keyfile: 'package.json, script/vsts/platforms/macos.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json'
           targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
           vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
 

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: 8.9.3
-        displayName: Install Node.js 8.9.3
+          versionSpec: 10.2.1
+        displayName: Install Node.js 10.2.1
 
       - script: npm install --global npm@6.2.0
         displayName: Update npm
@@ -112,8 +112,8 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: 8.9.3
-        displayName: Install Node.js 8.9.3
+          versionSpec: 10.2.1
+        displayName: Install Node.js 10.2.1
 
       - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
         displayName: Restore node_modules cache

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -42,7 +42,7 @@ jobs:
       - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
         displayName: Restore node_modules cache (x64)
         inputs:
-          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x64-cache-key'
+          keyfile: 'package.json, script/vsts/platforms/windows.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x64-cache-key'
           targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
           vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
         condition: eq(variables['buildArch'], 'x64')
@@ -50,7 +50,7 @@ jobs:
       - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
         displayName: Restore node_modules cache (x86)
         inputs:
-          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x86-cache-key'
+          keyfile: 'package.json, script/vsts/platforms/windows.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x86-cache-key'
           targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
           vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
         condition: eq(variables['buildArch'], 'x86')
@@ -68,7 +68,7 @@ jobs:
       - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
         displayName: Save node_modules cache (x64)
         inputs:
-          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x64-cache-key'
+          keyfile: 'package.json, script/vsts/platforms/windows.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x64-cache-key'
           targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
           vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
         condition: eq(variables['buildArch'], 'x64')
@@ -76,7 +76,7 @@ jobs:
       - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
         displayName: Save node_modules cache (x86)
         inputs:
-          keyfile: 'package.json, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x86-cache-key'
+          keyfile: 'package.json, script/vsts/platforms/windows.yml, **/package-lock.json, !**/node_modules/**/package-lock.json, !**/.*/**/package-lock.json, script/vsts/x86-cache-key'
           targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
           vstsFeed: 'bae1bc26-220d-43c7-a955-4de039370de2'
         condition: eq(variables['buildArch'], 'x86')

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -21,8 +21,8 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: 8.9.3
-        displayName: Install Node.js 8.9.3
+          versionSpec: 10.2.1
+        displayName: Install Node.js 10.2.1
 
       - script: |
           ECHO Installing npm-windows-upgrade
@@ -61,7 +61,7 @@ jobs:
           BUILD_ARCH: $(buildArch)
           CI: true
           CI_PROVIDER: VSTS
-          NPM_BIN_PATH: "D:\\a\\_tool\\node\\8.9.3\\x64\\npm.cmd"
+          NPM_BIN_PATH: "D:\\a\\_tool\\node\\10.2.1\\x64\\npm.cmd"
         displayName: Bootstrap build environment
         condition: ne(variables['CacheRestored'], 'true')
 

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -43,8 +43,8 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: 8.9.3
-        displayName: Install Node.js 8.9.3
+          versionSpec: 10.2.1
+        displayName: Install Node.js 10.2.1
 
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.

--- a/script/vsts/windows-run.js
+++ b/script/vsts/windows-run.js
@@ -5,7 +5,7 @@ const path = require('path');
 const download = require('download');
 const childProcess = require('child_process');
 
-const nodeVersion = '8.9.3';
+const nodeVersion = '10.2.1';
 const nodeFileName = `node-v${nodeVersion}-win-x86`;
 const extractedNodePath = `c:\\tmp\\${nodeFileName}`;
 


### PR DESCRIPTION
After the upgrade to Electron v3 Atom's codebase runs on Node v10.2.0, so upgrading the CI systems to also use the same Node.js version brings consistency (in terms of language features) and can also impact on build speed improvements (although these may be minor).

This PR updates the Node.js version to v10.2.1 (we cannot update to v10.2.0 since there are build failures caused by https://github.com/nodejs/node/issues/20921).