### PR TITLE
Only use AppVeyor on release branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,7 @@ clone_depth: 10
 
 branches:
   only:
-    - master
     - /^[0-9.]+-releases$/
-    - /^electron-[0-9.]+$/
 
 platform:
   - x64


### PR DESCRIPTION
https://github.com/atom/atom/pull/19508 will completely remove AppVeyor, but it will be a little while until we can merge that pull request. As noted in that pull request, our internal release publisher currently depends on AppVeyor for Windows build artifacts. That dependency affects Atom's release branches (e.g., `1.38-releases`), but it doesn't affect other branches.

So while we still need AppVeyor for Atom's release branches, we no longer need it for any other branches. With the changes in this pull request, AppVeyor will still run on release branches, but it won't run on any other branches. This change will lessen the impact of the issues described in https://github.com/atom/atom/issues/19253.