### PR TITLE
⬆️ tree-sitter@0.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6532,18 +6532,18 @@
       "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q=="
     },
     "tree-sitter": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.15.0.tgz",
-      "integrity": "sha512-3CDZ7X4hSJgMXOo8WWhYIwS06hFDmI3x6/3rX+i+LP4ykL3UWVt5TgNKYjAkgBxbpFEHGkaSBe5LRQu5LHOQ3A==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.15.2.tgz",
+      "integrity": "sha512-wzUyNy/ela+G4uuZBBCswdVHYZhreKESwkEav0dx/aagTIB367XRnHYu+jUDPANxCHsG7yyP0ESP5zwNd6fyNA==",
       "requires": {
         "nan": "^2.13.2",
         "prebuild-install": "^5.0.0"
       },
       "dependencies": {
         "nan": {
-          "version": "2.13.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "temp": "^0.9.0",
     "text-buffer": "13.17.0",
     "timecop": "https://www.atom.io/api/packages/timecop/versions/0.36.2/tarball",
-    "tree-sitter": "0.15.0",
+    "tree-sitter": "0.15.2",
     "tree-sitter-css": "^0.13.7",
     "tree-view": "https://www.atom.io/api/packages/tree-view/versions/0.228.0/tarball",
     "typescript-simple": "1.0.0",


### PR DESCRIPTION
This includes [the PR](https://github.com/tree-sitter/tree-sitter/pull/361) that fixes the recent crashes on OSX < 10.12

Fixes https://github.com/atom/atom/issues/19497

---

- *List of changes between `tree-sitter@0.15.0` and `tree-sitter@0.15.2`: https://github.com/tree-sitter/node-tree-sitter/compare/v0.15.0...v0.15.2*
