### PR TITLE
Increase timeout for atom-application.test.js on CI

### DIFF
--- a/spec/main-process/atom-application.test.js
+++ b/spec/main-process/atom-application.test.js
@@ -47,6 +47,10 @@ const {
 describe('AtomApplication', function() {
   let scenario, sinon;
 
+  if (process.env.CI) {
+    this.timeout(10 * 1000);
+  }
+
   beforeEach(async function() {
     sinon = sandbox.create();
     scenario = await LaunchScenario.create(sinon);


### PR DESCRIPTION
Fixes #19512 

On Azure and Travis, we recently started observing a few test failures in atom-application.test.js.

After staring at those tests for a bit, it doesn't seem like they are failing due to a race condition. Instead, it is possible that these tests are simply timing out due to CI containers sometimes being overloaded and, thus, slower.  I tested this hypothesis locally by running tests on a VM while stress-testing the host machine. Tests would eventually have passed, but they  timed out before having the chance to do so.

This commit increases the timeout on CI to 10 seconds for `AtomApplication` tests in  an attempt to fix the spurious failures we were observing. This is similar to what we've historically done for renderer process tests (see [spec/spec-helper.coffee](https://github.com/atom/atom/blob/7faea50190a8c6738b6ecee105645ee274a32b6e/spec/spec-helper.coffee#L50)).