### PR TITLE
Fix flaky test for `Project.onDidChangeFiles()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,9 +29,9 @@
       }
     },
     "@atom/nsfw": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@atom/nsfw/-/nsfw-1.0.24.tgz",
-      "integrity": "sha512-/pv/m+HRX/E8qvN+lUijsLWCcx24503l4J4Wf2mfVqaXxexYIKVMGZS1ZikX0Vf507sUbtD7600JiBK/RBaRhg==",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@atom/nsfw/-/nsfw-1.0.25.tgz",
+      "integrity": "sha512-V7g509EVRCCkzoQW/QA7lQsROrjsfYYEJRHzEuc6+PAH88Z4oAs7D3W8MOJrBPo+6e06gxEwfxZjIq7BQbpfwQ==",
       "requires": {
         "fs-extra": "^7.0.0",
         "nan": "^2.10.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "electronVersion": "3.1.10",
   "dependencies": {
-    "@atom/nsfw": "1.0.24",
+    "@atom/nsfw": "1.0.25",
     "@atom/source-map-support": "^0.3.4",
     "@atom/watcher": "1.3.1",
     "about": "file:packages/about",

--- a/spec/project-spec.js
+++ b/spec/project-spec.js
@@ -1084,8 +1084,6 @@ describe('Project', () => {
     };
 
     it('reports filesystem changes within project paths', async () => {
-      if (process.platform === 'win32') return; // Flaky results on Windows: https://github.com/atom/atom/issues/19507
-
       jasmine.useRealClock();
       const dirOne = temp.mkdirSync('atom-spec-project-one');
       const fileOne = path.join(dirOne, 'file-one.txt');

--- a/spec/project-spec.js
+++ b/spec/project-spec.js
@@ -1084,6 +1084,8 @@ describe('Project', () => {
     };
 
     it('reports filesystem changes within project paths', async () => {
+      if (process.platform === 'win32') return; // Flaky results on Windows: https://github.com/atom/atom/issues/19507
+
       jasmine.useRealClock();
       const dirOne = temp.mkdirSync('atom-spec-project-one');
       const fileOne = path.join(dirOne, 'file-one.txt');

--- a/spec/project-spec.js
+++ b/spec/project-spec.js
@@ -1059,11 +1059,13 @@ describe('Project', () => {
     const waitForEvents = paths => {
       const remaining = new Set(paths.map(p => fs.realpathSync(p)));
       return new Promise((resolve, reject) => {
+        let expireTimeoutId;
         checkCallback = () => {
           for (let event of events) {
             remaining.delete(event.path);
           }
           if (remaining.size === 0) {
+            clearTimeout(expireTimeoutId)
             resolve();
           }
         };
@@ -1076,8 +1078,8 @@ describe('Project', () => {
           );
         };
 
+        expireTimeoutId = setTimeout(expire, 2000);
         checkCallback();
-        setTimeout(expire, 2000);
       });
     };
 

--- a/spec/project-spec.js
+++ b/spec/project-spec.js
@@ -1081,6 +1081,7 @@ describe('Project', () => {
     };
 
     it('reports filesystem changes within project paths', () => {
+      jasmine.useRealClock();
       const dirOne = temp.mkdirSync('atom-spec-project-one');
       const fileOne = path.join(dirOne, 'file-one.txt');
       const fileTwo = path.join(dirOne, 'file-two.txt');

--- a/spec/project-spec.js
+++ b/spec/project-spec.js
@@ -1042,11 +1042,12 @@ describe('Project', () => {
   });
 
   describe('.onDidChangeFiles()', () => {
-    let sub = [];
-    const events = [];
+    let sub;
+    let events;
     let checkCallback = () => {};
 
     beforeEach(() => {
+      events = []
       sub = atom.project.onDidChangeFiles(incoming => {
         events.push(...incoming);
         checkCallback();

--- a/spec/project-spec.js
+++ b/spec/project-spec.js
@@ -1083,7 +1083,7 @@ describe('Project', () => {
       });
     };
 
-    it('reports filesystem changes within project paths', () => {
+    it('reports filesystem changes within project paths', async () => {
       jasmine.useRealClock();
       const dirOne = temp.mkdirSync('atom-spec-project-one');
       const fileOne = path.join(dirOne, 'file-one.txt');
@@ -1092,24 +1092,17 @@ describe('Project', () => {
       const fileThree = path.join(dirTwo, 'file-three.txt');
 
       // Ensure that all preexisting watchers are stopped
-      waitsForPromise(() => stopAllWatchers());
+      await stopAllWatchers();
 
-      runs(() => atom.project.setPaths([dirOne]));
-      waitsForPromise(() => atom.project.getWatcherPromise(dirOne));
+      atom.project.setPaths([dirOne]);
+      await atom.project.getWatcherPromise(dirOne);
 
-      runs(() => {
-        expect(atom.project.watcherPromisesByPath[dirTwo]).toEqual(undefined);
-
-        fs.writeFileSync(fileThree, 'three\n');
-        fs.writeFileSync(fileTwo, 'two\n');
-        fs.writeFileSync(fileOne, 'one\n');
-      });
-
-      waitsForPromise(() => waitForEvents([fileOne, fileTwo]));
-
-      runs(() =>
-        expect(events.some(event => event.path === fileThree)).toBeFalsy()
-      );
+      expect(atom.project.watcherPromisesByPath[dirTwo]).toEqual(undefined);
+      fs.writeFileSync(fileThree, 'three\n');
+      fs.writeFileSync(fileTwo, 'two\n');
+      fs.writeFileSync(fileOne, 'one\n');
+      await waitForEvents([fileOne, fileTwo]);
+      expect(events.some(event => event.path === fileThree)).toBeFalsy()
     });
   });
 

--- a/spec/project-spec.js
+++ b/spec/project-spec.js
@@ -1047,7 +1047,7 @@ describe('Project', () => {
     let checkCallback = () => {};
 
     beforeEach(() => {
-      events = []
+      events = [];
       sub = atom.project.onDidChangeFiles(incoming => {
         events.push(...incoming);
         checkCallback();
@@ -1065,7 +1065,7 @@ describe('Project', () => {
             remaining.delete(event.path);
           }
           if (remaining.size === 0) {
-            clearTimeout(expireTimeoutId)
+            clearTimeout(expireTimeoutId);
             resolve();
           }
         };
@@ -1102,7 +1102,7 @@ describe('Project', () => {
       fs.writeFileSync(fileTwo, 'two\n');
       fs.writeFileSync(fileOne, 'one\n');
       await waitForEvents([fileOne, fileTwo]);
-      expect(events.some(event => event.path === fileThree)).toBeFalsy()
+      expect(events.some(event => event.path === fileThree)).toBeFalsy();
     });
   });
 


### PR DESCRIPTION
Fixes #19507 by upgrading to atom/nsfw@1.0.25, which incorporates the fix introduced in https://github.com/atom/nsfw/pull/9.

---

Note: In addition to fixing the underlying flakiness, this pull request also introduces a handful of improvements to the spec itself. Each commit in this pull request makes an isolated improvement described in the commit message.