### PR TITLE
Assign originalFontSize when the Workspace is initialized

### DIFF
--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -313,6 +313,8 @@ class AtomEnvironment {
     this.attachSaveStateListeners();
     this.windowEventHandler.initialize(this.window, this.document);
 
+    this.workspace.initialize();
+
     const didChangeStyles = this.didChangeStyles.bind(this);
     this.disposables.add(this.styles.onDidAddStyleElement(didChangeStyles));
     this.disposables.add(this.styles.onDidUpdateStyleElement(didChangeStyles));
@@ -429,7 +431,7 @@ class AtomEnvironment {
     this.workspace.reset(this.packages);
     this.registerDefaultOpeners();
     this.project.reset(this.packages);
-    this.workspace.subscribeToEvents();
+    this.workspace.initialize();
     this.grammars.clear();
     this.textEditors.clear();
     this.views.clear();

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -256,8 +256,6 @@ module.exports = class Workspace extends Model {
     };
 
     this.incoming = new Map();
-
-    this.subscribeToEvents();
   }
 
   get paneContainer() {
@@ -375,9 +373,9 @@ module.exports = class Workspace extends Model {
     this.consumeServices(this.packageManager);
   }
 
-  subscribeToEvents() {
+  initialize() {
+    this.originalFontSize = this.config.get('editor.fontSize');
     this.project.onDidChangePaths(this.updateWindowTitle);
-    this.subscribeToFontSize();
     this.subscribeToAddedItems();
     this.subscribeToMovedItems();
     this.subscribeToDockToggling();
@@ -1751,14 +1749,6 @@ module.exports = class Workspace extends Model {
     if (this.originalFontSize) {
       this.config.set('editor.fontSize', this.originalFontSize);
     }
-  }
-
-  subscribeToFontSize() {
-    return this.config.onDidChange('editor.fontSize', () => {
-      if (this.originalFontSize == null) {
-        this.originalFontSize = this.config.get('editor.fontSize');
-      }
-    });
   }
 
   // Removes the item's uri from the list of potential items to reopen.


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/19521

When the `Workspace` is created, we capture the `originalFontSize` so that we can restore to it via the `window:reset-font-size` command.

If we tried to capture this font size in the `Workspace`'s constructor, it would always be assigned to the default because the workspace is constructed before the user's settings are loaded. Previously, we attempted to address this by storing the value when the setting `editor.fontSize` *changed*, which would happen when the user settings were loaded. Unfortunately, if the user had their font size assigned to the *default* size, the setting *wouldn't* change when their settings were loaded, and we'd never end up capturing the `originalFontSize`.

In this PR, I go with a different approach. Rather than waiting for the font size to change, I break out an `initialize` method on `Workspace` that only gets called after the settings have been loaded. This is a pattern we use with other major objects in the application, so I think it blends in reasonably well.