### PR TITLE
Update to Tree-sitter 0.15.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6532,9 +6532,9 @@
       "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q=="
     },
     "tree-sitter": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.15.4.tgz",
-      "integrity": "sha512-EgZr6zJevERT/gl7dh2Z2sO0WKHSf8rLTJS38sLe0cTxqxTQ785VxemVCGBHzp8zZ4406sh+ORlB1z5HyORbYw==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.15.5.tgz",
+      "integrity": "sha512-3rrww3lc9NNbbVPT1uGkvbom5Ivr/lZqpzru/x+S0Jnh/jHKACNz7ED1JiAPKfR89eLRJxBGh+ZV5g+QqQrQaw==",
       "requires": {
         "nan": "^2.13.2",
         "prebuild-install": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "temp": "^0.9.0",
     "text-buffer": "13.17.0",
     "timecop": "https://www.atom.io/api/packages/timecop/versions/0.36.2/tarball",
-    "tree-sitter": "0.15.4",
+    "tree-sitter": "0.15.5",
     "tree-sitter-css": "^0.13.7",
     "tree-view": "https://www.atom.io/api/packages/tree-view/versions/0.228.0/tarball",
     "typescript-simple": "1.0.0",

--- a/spec/tree-sitter-language-mode-spec.js
+++ b/spec/tree-sitter-language-mode-spec.js
@@ -1811,7 +1811,7 @@ describe('TreeSitterLanguageMode', () => {
           [0, 5],
           [0, 8]
         ]);
-        expect(editor.bufferRangeForScopeAtPosition(null, [0, 9])).toEqual([
+        expect(editor.bufferRangeForScopeAtPosition(null, [0, 8])).toEqual([
           [0, 8],
           [0, 9]
         ]);


### PR DESCRIPTION
This PR bumps the `tree-sitter` to 0.15.5, which contains the very latest version of the core Tree-sitter library.

We were already using *almost* the latest version, after yesterday's upgrade due to https://github.com/atom/atom/issues/19497, but this brings us up to master.

### Small Behavior Change

There was a small fix to the behavior of the `ts_node_descendant_for_position` method in Tree-sitter, which slightly changes the behavior of some methods in Atom:

In particular, it fixes what I consider to be a bug in the behavior of the `editor:select-larger-syntax-node` where if you had your cursor between two adjacent tokens it would select the token *before* the cursor instead of the token immediately afterward.

It also fixes what I think was a bug in the `bufferRangeForScopeAtPosition` method. I've updated a test to reflect that change.

### Prebuilt Binaries

Today I merged https://github.com/tree-sitter/node-tree-sitter/pull/50, which I think *may* make it so that the prebuilt linux binaries of `tree-sitter` will work for Atom, so that we don't have to manually delete those binaries to avoid weird hangs on Travis. 🤞 