### PR TITLE
Install apm using ci

### DIFF
--- a/script/lib/install-apm.js
+++ b/script/lib/install-apm.js
@@ -6,10 +6,9 @@ const CONFIG = require('../config');
 
 module.exports = function(ci) {
   console.log('Installing apm');
-  // npm ci leaves apm with a bunch of unmet dependencies
   childProcess.execFileSync(
     CONFIG.getNpmBinPath(),
-    ['--global-style', '--loglevel=error', 'install'],
+    ['--global-style', '--loglevel=error', ci ? 'ci' : 'install'],
     { env: process.env, cwd: CONFIG.apmRootPath }
   );
 };

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -33,8 +33,8 @@ jobs:
           CI: true
           CI_PROVIDER: VSTS
           NPM_BIN_PATH: /usr/local/bin/npm
-        condition: ne(variables['CacheRestored'], 'true')
 
+        # condition: ne(variables['CacheRestored'], 'true')
       - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
         displayName: Save node_modules cache
         inputs:


### PR DESCRIPTION
This previously didn't work because of implicit node-gyp dependencies. Now that apm is node-gypless, let's try this again. It should provide a significant performance boost to build times when the cache is unable to be restored.