### PR TITLE
Tweak package-lock to avoid loading `fs-extra` twice on main-process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,18 +35,6 @@
       "requires": {
         "fs-extra": "^7.0.0",
         "nan": "^2.10.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        }
       }
     },
     "@atom/source-map-support": {
@@ -68,16 +56,6 @@
         "prebuild-install": "5.2.4"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
         "nan": {
           "version": "2.12.1",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
@@ -2991,9 +2969,9 @@
       "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
     },
     "fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3245,6 +3223,16 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
         },
         "moment": {
           "version": "2.24.0",
@@ -6173,16 +6161,6 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
           }
         },
         "lodash": {


### PR DESCRIPTION
Following the instructions on https://github.com/atom/atom/issues/19269 I've identified that during the main process startup flow we're loading the `fs-extra` (and all its dependant modules) twice: once for `@atom/watcher` and another time for `@atom/nsfw` ([details](https://gist.github.com/rafeca/b4b44b5dcc8c764e4984221ede9d2ade#file-startup_modules-txt-L163-L338)).

Both of them have the same version (v7.0.1), but for some reason the npm lock file at some point in the past decided to put an older version (v4.0.3) which is used by the `github` package on the root folder, and this prevented these two duplicates of the same version to be hoisted up on the dependency tree.

In this PR I've modified manually the `package-lock` file to make `npm` recalculate the best hoisting for modules, so libraries don't get duplicated (the manual modifications consisted on deleting all the `fs-extra` instances on the `package-lock`).

With this, the number of modules loaded during the main process start gets reduced from [373](https://gist.github.com/rafeca/b4b44b5dcc8c764e4984221ede9d2ade) to [286](https://gist.github.com/rafeca/850576596cc544f2ab6eafb95ebd7309).

I've tried to check if this impacted startup time but I couldn't see noticeable changes (something around ~10-20ms only, and still hard to tell if it was just attributed to noise), but this could have more impact on other slower platforms.