### PR TITLE
Work around doc comment parsing

### DIFF
--- a/src/workspace.js
+++ b/src/workspace.js
@@ -38,7 +38,7 @@ const ALL_LOCATIONS = ['center', 'left', 'right', 'bottom'];
 //
 // #### `getTitle()`
 //
-// Returns a {String} containing the title of the item to display on its
+// Will return a {String} containing the title of the item to display on its
 // associated tab.
 //
 // ### Optional Methods
@@ -69,11 +69,11 @@ const ALL_LOCATIONS = ['center', 'left', 'right', 'bottom'];
 //
 // #### `getURI()`
 //
-// Returns the URI associated with the item.
+// Will return the URI associated with the item.
 //
 // #### `getLongTitle()`
 //
-// Returns a {String} containing a longer version of the title to display in
+// Will return a {String} containing a longer version of the title to display in
 // places like the window title or on tabs their short titles are ambiguous.
 //
 // #### `onDidChangeTitle`
@@ -83,7 +83,7 @@ const ALL_LOCATIONS = ['center', 'left', 'right', 'bottom'];
 //
 // #### `getIconName()`
 //
-// Return a {String} with the name of an icon. If this method is defined and
+// Will return a {String} with the name of an icon. If this method is defined and
 // returns a string, the item's tab element will be rendered with the `icon` and
 // `icon-${iconName}` CSS classes.
 //
@@ -98,13 +98,13 @@ const ALL_LOCATIONS = ['center', 'left', 'right', 'bottom'];
 // override. Items can appear in the center or in a dock on the left, right, or
 // bottom of the workspace.
 //
-// Returns a {String} with one of the following values: `'center'`, `'left'`,
+// Will return a {String} with one of the following values: `'center'`, `'left'`,
 // `'right'`, `'bottom'`. If this method is not defined, `'center'` is the
 // default.
 //
 // #### `getAllowedLocations()`
 //
-// Tells the workspace where this item can be moved. Returns an {Array} of one
+// Tells the workspace where this item can be moved. Will return an {Array} of one
 // or more of the following values: `'center'`, `'left'`, `'right'`, or
 // `'bottom'`.
 //
@@ -129,12 +129,12 @@ const ALL_LOCATIONS = ['center', 'left', 'right', 'bottom'];
 //
 // #### `getPath()`
 //
-// Returns the local path associated with this item. This is only used to set
+// Will return the local path associated with this item. This is only used to set
 // the initial location of the "save as" dialog.
 //
 // #### `isModified()`
 //
-// Returns whether or not the item is modified to reflect modification in the
+// Will return whether or not the item is modified to reflect modification in the
 // UI.
 //
 // #### `onDidChangeModified()`
@@ -153,7 +153,7 @@ const ALL_LOCATIONS = ['center', 'left', 'right', 'bottom'];
 // initially displaying the dock to set its height. Once the dock has been
 // resized by the user, their height will override this value.
 //
-// Returns a {Number}.
+// Will return a {Number}.
 //
 // #### `getPreferredWidth()`
 //
@@ -161,7 +161,7 @@ const ALL_LOCATIONS = ['center', 'left', 'right', 'bottom'];
 // workspace when initially displaying the dock to set its width. Once the dock
 // has been resized by the user, their width will override this value.
 //
-// Returns a {Number}.
+// Will return a {Number}.
 //
 // #### `onDidTerminatePendingState(callback)`
 //
@@ -172,7 +172,7 @@ const ALL_LOCATIONS = ['center', 'left', 'right', 'bottom'];
 // #### `shouldPromptToSave()`
 //
 // This method indicates whether Atom should prompt the user to save this item
-// when the user closes or reloads the window. Returns a boolean.
+// when the user closes or reloads the window. Will return a boolean.
 module.exports = class Workspace extends Model {
   constructor(params) {
     super(...arguments);


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/atom/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see https://flight-manual.atom.io/hacking-atom/sections/writing-specs/.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/atom/atom/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Closes #17746
Closes #16106

### Description of the Change

Replaces all `Returns` in the initial doc comment with `Will return`. While the original sounds better, it caused issues where the parser sees `Returns`, assumes it is the last sentence, and stops parsing. The change will not be detected as a return statement, so the docs are fully parsed.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

The parser could be changed to handle it, but I don't know enough about how it works to change it. This change will at least let the docs not be broken until a proper solution is provided.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
na

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

The `docs/output/atom-api.json` output of `./script/build --generate-api-docs --no-bootstrap` looks right. I haven't seen how it looks on the website, so that should probably be done by someone.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->