### PR TITLE
Shim tokens in TokenizedLines returned from TreeSitterLanguageMode

### DIFF
--- a/spec/tree-sitter-language-mode-spec.js
+++ b/spec/tree-sitter-language-mode-spec.js
@@ -2210,6 +2210,47 @@ describe('TreeSitterLanguageMode', () => {
       expect(editor.getSelectedText()).toBe('html ` <b>c${def()}e${f}g</b> `');
     });
   });
+
+  describe('.tokenizedLineForRow(row)', () => {
+    it('returns a shimmed TokenizedLine with tokens', () => {
+      const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
+        parser: 'tree-sitter-javascript',
+        scopes: {
+          program: 'source',
+          'call_expression > identifier': 'function',
+          property_identifier: 'property',
+          'call_expression > member_expression > property_identifier': 'method',
+          identifier: 'variable'
+        }
+      });
+
+      buffer.setText('aa.bbb = cc(d.eee());\n\n    \n  b');
+
+      const languageMode = new TreeSitterLanguageMode({ buffer, grammar });
+      buffer.setLanguageMode(languageMode);
+
+      expect(languageMode.tokenizedLineForRow(0).tokens).toEqual([
+        { value: 'aa', scopes: ['source', 'variable'] },
+        { value: '.', scopes: ['source'] },
+        { value: 'bbb', scopes: ['source', 'property'] },
+        { value: ' = ', scopes: ['source'] },
+        { value: 'cc', scopes: ['source', 'function'] },
+        { value: '(', scopes: ['source'] },
+        { value: 'd', scopes: ['source', 'variable'] },
+        { value: '.', scopes: ['source'] },
+        { value: 'eee', scopes: ['source', 'method'] },
+        { value: '());', scopes: ['source'] }
+      ]);
+      expect(languageMode.tokenizedLineForRow(1).tokens).toEqual([]);
+      expect(languageMode.tokenizedLineForRow(2).tokens).toEqual([
+        { value: '    ', scopes: ['source'] }
+      ]);
+      expect(languageMode.tokenizedLineForRow(3).tokens).toEqual([
+        { value: '  ', scopes: ['source'] },
+        { value: 'b', scopes: ['source', 'variable'] }
+      ]);
+    });
+  });
 });
 
 function nextHighlightingUpdate(languageMode) {

--- a/src/tokenized-line.coffee
+++ b/src/tokenized-line.coffee
@@ -10,21 +10,25 @@ class TokenizedLine
 
     return unless properties?
 
-    {@openScopes, @text, @tags, @ruleStack, @tokenIterator, @grammar} = properties
+    {@openScopes, @text, @tags, @ruleStack, @tokenIterator, @grammar, tokens} = properties
+    @cachedTokens = tokens
 
   getTokenIterator: -> @tokenIterator.reset(this)
 
   Object.defineProperty @prototype, 'tokens', get: ->
-    iterator = @getTokenIterator()
-    tokens = []
+    if @cachedTokens
+      @cachedTokens
+    else
+      iterator = @getTokenIterator()
+      tokens = []
 
-    while iterator.next()
-      tokens.push(new Token({
-        value: iterator.getText()
-        scopes: iterator.getScopes().slice()
-      }))
+      while iterator.next()
+        tokens.push(new Token({
+          value: iterator.getText()
+          scopes: iterator.getScopes().slice()
+        }))
 
-    tokens
+      tokens
 
   tokenAtBufferColumn: (bufferColumn) ->
     @tokens[@tokenIndexAtBufferColumn(bufferColumn)]

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -511,7 +511,8 @@ class TreeSitterLanguageMode {
       }
 
       if (end.column < lineText.length) {
-        for (const _ of iterator.getCloseScopeIds()) {
+        const closeScopeCount = iterator.getCloseScopeIds().length;
+        for (let i = 0; i < closeScopeCount; i++) {
           scopes.pop();
         }
         scopes.push(...iterator.getOpenScopeIds());

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -488,9 +488,44 @@ class TreeSitterLanguageMode {
   */
 
   tokenizedLineForRow(row) {
+    const lineText = this.buffer.lineForRow(row);
+    const tokens = [];
+
+    const iterator = this.buildHighlightIterator();
+    let start = { row, column: 0 };
+    const scopes = iterator.seek(start, row);
+    while (true) {
+      const end = iterator.getPosition();
+      if (end.row > row) {
+        end.row = row;
+        end.column = lineText.length;
+      }
+
+      if (end.column > start.column) {
+        tokens.push(
+          new Token({
+            value: lineText.substring(start.column, end.column),
+            scopes: scopes.map(s => this.grammar.scopeNameForScopeId(s))
+          })
+        );
+      }
+
+      if (end.column < lineText.length) {
+        for (const _ of iterator.getCloseScopeIds()) {
+          scopes.pop();
+        }
+        scopes.push(...iterator.getOpenScopeIds());
+        start = end;
+        iterator.moveToSuccessor();
+      } else {
+        break;
+      }
+    }
+
     return new TokenizedLine({
       openScopes: [],
-      text: this.buffer.lineForRow(row),
+      text: lineText,
+      tokens,
       tags: [],
       ruleStack: [],
       lineEnding: this.buffer.lineEndingForRow(row),


### PR DESCRIPTION
Fixes #18973

🍐'd with @as-cii

Package authors are using the private `tokenizedLineForRow` method on language modes to get syntactic information about lines. Even though this method is private, @maxbrunsfeld provided a shim implementation in `TreeSitterLanguageMode` that enabled usage of some basic properties on returned `TokenizedLine` object, but this did not include the ability to read the `tokens` field. This is causing exceptions for at least one popular package, `atom-aligner`.

In this PR, @as-cii and I have enhanced the `TokenizedLine`s returned by `TreeSitterLanguageMode.prototype.tokenizedLineForRow` to include a valid `tokens` array. We construct these tokens eagerly via the highlight iterator, which could impose a cost for those that call this method and don't use `tokens`, but making the method lazy would have been extremely complex due to the potential for the state of the buffer and the syntax tree to change after the `TokenizedLine` is returned.