### PR TITLE
Remove delays that we no longer need in watch-path tests

### DIFF
--- a/spec/path-watcher-spec.js
+++ b/spec/path-watcher-spec.js
@@ -7,7 +7,6 @@ import { promisify } from 'util';
 
 import { CompositeDisposable } from 'event-kit';
 import { watchPath, stopAllWatchers } from '../src/path-watcher';
-import { timeoutPromise } from './async-spec-helpers';
 
 temp.track();
 
@@ -22,7 +21,6 @@ describe('watchPath', function() {
   let subs;
 
   beforeEach(function() {
-    jasmine.useRealClock();
     subs = new CompositeDisposable();
   });
 
@@ -111,12 +109,6 @@ describe('watchPath', function() {
         waitForChanges(rootWatcher, subFile),
         waitForChanges(childWatcher, subFile)
       ]);
-
-      // In Windows64, in some situations nsfw (the currently default watcher)
-      // does not trigger the change events if they happen just after start watching,
-      // so we need to wait some time. More info: https://github.com/atom/atom/issues/19442
-      await timeoutPromise(300);
-
       await writeFile(subFile, 'subfile\n', { encoding: 'utf8' });
       await firstChanges;
 
@@ -163,11 +155,6 @@ describe('watchPath', function() {
 
       expect(subWatcher0.native).toBe(parentWatcher.native);
       expect(subWatcher1.native).toBe(parentWatcher.native);
-
-      // In Windows64, in some situations nsfw (the currently default watcher)
-      // does not trigger the change events if they happen just after start watching,
-      // so we need to wait some time. More info: https://github.com/atom/atom/issues/19442
-      await timeoutPromise(300);
 
       // Ensure events are filtered correctly
       await Promise.all([


### PR DESCRIPTION
This pull request reverts the changes introduced in https://github.com/atom/atom/pull/19459. With the upgrade to atom/nsfw v1.0.25 in #19525, we should no longer need the delays introduced in #19459. 😅

To gain confidence that we no longer need these delays, I pushed up a [temporary commit](https://github.com/atom/atom/commit/2e6cbd9c19781e1e11697ba289d257eb8e3820db#diff-a5307c09bb725b0581c516daa542522eR93) to [run these two tests 10,000 times on CI](https://github.visualstudio.com/Atom/_build/results?buildId=43309):
- The [first test](https://github.com/atom/atom/blob/2e6cbd9c19781e1e11697ba289d257eb8e3820db/spec/path-watcher-spec.js#L93-L120) ran successfully 10,000 times.
- The [second test](https://github.com/atom/atom/blob/2e6cbd9c19781e1e11697ba289d257eb8e3820db/spec/path-watcher-spec.js#L122-L177) ran successfully 7,406 times before the CI job timed out. (It turns out that Azure Pipelines didn't want to keep running a build that's already been running for 3 hours. 😇😅) Despite "only" running 7,406 times, I think we can safely assume that this test no longer needs the delays introduced in #19459.

---

Refs: https://github.com/atom/atom/issues/19442