### PR TITLE
⬆️ git-utils@5.6.0, scandal@3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3192,9 +3192,9 @@
       }
     },
     "git-utils": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.5.0.tgz",
-      "integrity": "sha512-4t3f2pU4HPgKOyTXyaEdMHTBwa24ubC4FykCXlqnsPgHlupSq66d0/aq0h92BgnyGwI3ogqx9D0a+Uw/jNckOg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.6.0.tgz",
+      "integrity": "sha512-eOBROJEQPQtkqzZe5V0m43YhKjhmzXTqULxlhoaCwORClnHtZIwkJQTS6THXRbvIqDq/cRHta85IqTbVzdvB5g==",
       "requires": {
         "fs-plus": "^3.0.0",
         "nan": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5667,18 +5667,27 @@
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
     },
     "scandal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/scandal/-/scandal-3.1.0.tgz",
-      "integrity": "sha1-m0AkuXxxm74lAIzAm6rHn7tdNQE=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/scandal/-/scandal-3.2.0.tgz",
+      "integrity": "sha512-kXICe3ygxwyyO3Ur+k49UzQlu8yrdQgzD03eMgV8sMWDom9q4qpEvZuQRUcbyAujC1TpISPRUPoirOIO1bRxcQ==",
       "requires": {
         "argparse": "^1.0.2",
-        "git-utils": "^5.0.0",
+        "git-utils": "^5.6.0",
         "isbinaryfile": "^2.0.4",
         "minimatch": "^2.0.9",
         "split": "^1.0.0",
         "temp": "^0.8.3"
       },
       "dependencies": {
+        "git-utils": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.6.0.tgz",
+          "integrity": "sha512-eOBROJEQPQtkqzZe5V0m43YhKjhmzXTqULxlhoaCwORClnHtZIwkJQTS6THXRbvIqDq/cRHta85IqTbVzdvB5g==",
+          "requires": {
+            "fs-plus": "^3.0.0",
+            "nan": "^2.0.0"
+          }
+        },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "property-accessors": "^1.1.3",
     "random-words": "0.0.1",
     "resolve": "^1.1.6",
-    "scandal": "^3.1.0",
+    "scandal": "^3.2.0",
     "scoped-property-store": "^0.17.0",
     "scrollbar-style": "^3.2",
     "season": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "fuzzaldrin": "^2.1",
     "fuzzy-finder": "https://www.atom.io/api/packages/fuzzy-finder/versions/1.13.7/tarball",
     "git-diff": "file:packages/git-diff",
-    "git-utils": "5.5.0",
+    "git-utils": "5.6.0",
     "github": "https://www.atom.io/api/packages/github/versions/0.29.0/tarball",
     "glob": "^7.1.1",
     "go-to-line": "file:packages/go-to-line",


### PR DESCRIPTION
These two new versions contain fixes for Electron v4.

----

- *List of changes between `git-utils@5.5.0` and `git-utils@5.6.0`: https://github.com/atom/git-utils/compare/v5.5.0...v5.6.0*
- *List of changes between `scandal@3.1.0` and `scandal@3.2.0`: https://github.com/atom/scandal/compare/v3.1.0...v3.2.0*
