### PR TITLE
Dedupe git-utils dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5679,15 +5679,6 @@
         "temp": "^0.8.3"
       },
       "dependencies": {
-        "git-utils": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.6.0.tgz",
-          "integrity": "sha512-eOBROJEQPQtkqzZe5V0m43YhKjhmzXTqULxlhoaCwORClnHtZIwkJQTS6THXRbvIqDq/cRHta85IqTbVzdvB5g==",
-          "requires": {
-            "fs-plus": "^3.0.0",
-            "nan": "^2.0.0"
-          }
-        },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",


### PR DESCRIPTION
As @50Wliu pointed in https://github.com/atom/atom/pull/19552/files#r294509104, the `git-utils` dependency got duplicated on #19552.

This PR dedupes it from `package-lock.json`