### PR TITLE
Add a new injection point setting to support parsing Rust macros via language injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4010,7 +4010,7 @@
     "language-rust-bundled": {
       "version": "file:packages/language-rust-bundled",
       "requires": {
-        "tree-sitter-rust": "^0.13.7"
+        "tree-sitter-rust": "^0.15.1"
       }
     },
     "language-sass": {
@@ -6675,9 +6675,9 @@
       }
     },
     "tree-sitter-rust": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.13.7.tgz",
-      "integrity": "sha512-OX7VlqNhw67yIB69ZhgtJb6sXhwLVwGx991EjLf4PP2bY4dWBgmZ+KxwxN7HBwk9RdUsNLf0KbTwzVRadKhPGw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-rust/-/tree-sitter-rust-0.15.1.tgz",
+      "integrity": "sha512-nkuVgr/1QS/IkC1IE9DhjMKbGUUNymrMnRlV6HcOOOsW8s4ubCaL9Yu0M+eyVwSGjiD92xWEZMtt1I5ekUILYg==",
       "requires": {
         "nan": "^2.8.0"
       }

--- a/packages/language-rust-bundled/grammars/tree-sitter-rust.cson
+++ b/packages/language-rust-bundled/grammars/tree-sitter-rust.cson
@@ -2,6 +2,7 @@ name: 'Rust'
 scopeName: 'source.rust'
 type: 'tree-sitter'
 parser: 'tree-sitter-rust'
+injectionRegex: 'rust'
 
 fileTypes: [
   'rs'

--- a/packages/language-rust-bundled/lib/main.js
+++ b/packages/language-rust-bundled/lib/main.js
@@ -1,0 +1,9 @@
+exports.activate = function() {
+  for (const nodeType of ['macro_invocation', 'macro_rule']) {
+    atom.grammars.addInjectionPoint('source.rust', {
+      type: nodeType,
+      language() { return 'rust'; },
+      content(node) { return node.lastChild; },
+    });
+  }
+};

--- a/packages/language-rust-bundled/lib/main.js
+++ b/packages/language-rust-bundled/lib/main.js
@@ -2,8 +2,13 @@ exports.activate = function() {
   for (const nodeType of ['macro_invocation', 'macro_rule']) {
     atom.grammars.addInjectionPoint('source.rust', {
       type: nodeType,
-      language() { return 'rust'; },
-      content(node) { return node.lastChild; },
+      language() {
+        return 'rust';
+      },
+      content(node) {
+        return node.lastChild;
+      },
+      includeChildren: true
     });
   }
 };

--- a/packages/language-rust-bundled/package.json
+++ b/packages/language-rust-bundled/package.json
@@ -7,6 +7,7 @@
     "grammar",
     "rust"
   ],
+  "main": "lib/main.js",
   "repository": "https://github.com/atom/atom",
   "license": "MIT",
   "dependencies": {

--- a/packages/language-rust-bundled/package.json
+++ b/packages/language-rust-bundled/package.json
@@ -10,7 +10,7 @@
   "repository": "https://github.com/atom/atom",
   "license": "MIT",
   "dependencies": {
-    "tree-sitter-rust": "^0.13.7"
+    "tree-sitter-rust": "^0.15.1"
   },
   "engines": {
     "atom": ">=1.0.0 <2.0.0"

--- a/src/initialize-application-window.js
+++ b/src/initialize-application-window.js
@@ -41,6 +41,7 @@ if (global.isGeneratingSnapshot) {
   require('language-html');
   require('language-javascript');
   require('language-ruby');
+  require('language-rust-bundled');
   require('language-typescript');
   require('line-ending-selector');
   require('link');

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -1315,6 +1315,9 @@ class NullHighlightIterator {
   seek() {
     return [];
   }
+  compare() {
+    return 1;
+  }
   moveToSuccessor() {}
   getOffset() {
     return Infinity;

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -32,7 +32,7 @@ class TreeSitterLanguageMode {
     this.config = config;
     this.grammarRegistry = grammars;
     this.parser = new Parser();
-    this.rootLanguageLayer = new LanguageLayer(this, grammar);
+    this.rootLanguageLayer = new LanguageLayer(this, grammar, 0, true);
     this.injectionsMarkerLayer = buffer.addMarkerLayer();
 
     if (syncTimeoutMicros != null) {
@@ -637,13 +637,14 @@ class TreeSitterLanguageMode {
 }
 
 class LanguageLayer {
-  constructor(languageMode, grammar, contentChildTypes) {
+  constructor(languageMode, grammar, depth, isOpaque) {
     this.languageMode = languageMode;
     this.grammar = grammar;
     this.tree = null;
     this.currentParsePromise = null;
     this.patchSinceCurrentParseStarted = null;
-    this.contentChildTypes = contentChildTypes;
+    this.depth = depth;
+    this.isOpaque = isOpaque;
   }
 
   buildHighlightIterator() {
@@ -885,7 +886,8 @@ class LanguageLayer {
           marker.languageLayer = new LanguageLayer(
             this.languageMode,
             grammar,
-            injectionPoint.contentChildTypes
+            this.depth + 1,
+            injectionPoint.includeChildren
           );
           marker.parentLanguageLayer = this;
         }
@@ -895,7 +897,8 @@ class LanguageLayer {
           new NodeRangeSet(
             nodeRangeSet,
             injectionNodes,
-            injectionPoint.newlinesBetween
+            injectionPoint.newlinesBetween,
+            injectionPoint.includeChildren
           )
         );
       }
@@ -910,7 +913,6 @@ class LanguageLayer {
     }
 
     if (markersToUpdate.size > 0) {
-      this.lastUpdateWasAsync = true;
       const promises = [];
       for (const [marker, nodeRangeSet] of markersToUpdate) {
         promises.push(marker.languageLayer.update(nodeRangeSet));
@@ -938,6 +940,7 @@ class HighlightIterator {
   constructor(languageMode) {
     this.languageMode = languageMode;
     this.iterators = null;
+    this.opaqueLayerDepth = 0;
   }
 
   seek(targetPosition, endRow) {
@@ -947,55 +950,97 @@ class HighlightIterator {
       }
     );
 
-    this.iterators = [
-      this.languageMode.rootLanguageLayer.buildHighlightIterator()
-    ];
-    for (const marker of injectionMarkers) {
-      this.iterators.push(marker.languageLayer.buildHighlightIterator());
-    }
-    this.iterators.sort((a, b) => b.getIndex() - a.getIndex());
-
     const containingTags = [];
     const containingTagStartIndices = [];
     const targetIndex = this.languageMode.buffer.characterIndexForPosition(
       targetPosition
     );
-    for (let i = this.iterators.length - 1; i >= 0; i--) {
-      this.iterators[i].seek(
-        targetIndex,
-        containingTags,
-        containingTagStartIndices
-      );
+
+    this.iterators = [];
+    const iterator = this.languageMode.rootLanguageLayer.buildHighlightIterator();
+    if (iterator.seek(targetIndex, containingTags, containingTagStartIndices)) {
+      this.iterators.push(iterator);
     }
-    this.iterators.sort((a, b) => b.getIndex() - a.getIndex());
+    for (const marker of injectionMarkers) {
+      const iterator = marker.languageLayer.buildHighlightIterator();
+      if (
+        iterator.seek(targetIndex, containingTags, containingTagStartIndices)
+      ) {
+        this.iterators.push(iterator);
+      }
+    }
+    this.iterators.sort((a, b) => b.compare(a));
     return containingTags;
   }
 
   moveToSuccessor() {
-    const lastIndex = this.iterators.length - 1;
-    const leader = this.iterators[lastIndex];
-    leader.moveToSuccessor();
-    const leaderCharIndex = leader.getIndex();
-    let i = lastIndex;
-    while (i > 0 && this.iterators[i - 1].getIndex() < leaderCharIndex) i--;
-    if (i < lastIndex) this.iterators.splice(i, 0, this.iterators.pop());
+    let leader = last(this.iterators);
+    if (leader.moveToSuccessor()) {
+      const leaderIndex = this.iterators.length - 1;
+      let i = leaderIndex;
+      while (i > 0 && this.iterators[i - 1].compare(leader) < 0) i--;
+      if (i < leaderIndex) {
+        this.iterators.splice(i, 0, this.iterators.pop());
+        this.trackLayerDepth();
+      }
+    } else {
+      this.iterators.pop();
+      this.trackLayerDepth();
+    }
+  }
+
+  trackLayerDepth() {
+    let i = this.iterators.length - 1;
+    let iterator = this.iterators[i];
+    if (!iterator) return;
+    const offset = iterator.getOffset();
+    if (iterator.languageLayer.isOpaque) {
+      this.opaqueLayerDepth = iterator.languageLayer.depth;
+    }
+
+    while (i > 0) {
+      i--;
+      iterator = this.iterators[i];
+      if (iterator.startOffset > offset) break;
+      if (iterator.languageLayer.isOpaque) {
+        const { depth } = iterator.languageLayer;
+        if (depth > this.opaqueLayerDepth) {
+          this.opaqueLayerDepth = depth;
+        }
+      }
+    }
   }
 
   getPosition() {
-    return last(this.iterators).getPosition();
+    const iterator = last(this.iterators);
+    if (iterator) {
+      return iterator.getPosition();
+    } else {
+      return Point.INFINITY;
+    }
   }
 
   getCloseScopeIds() {
-    return last(this.iterators).getCloseScopeIds();
+    const iterator = last(this.iterators);
+    if (iterator && iterator.languageLayer.depth >= this.opaqueLayerDepth) {
+      return iterator.getCloseScopeIds();
+    } else {
+      return [];
+    }
   }
 
   getOpenScopeIds() {
-    return last(this.iterators).getOpenScopeIds();
+    const iterator = last(this.iterators);
+    if (iterator && iterator.languageLayer.depth >= this.opaqueLayerDepth) {
+      return iterator.getOpenScopeIds();
+    } else {
+      return [];
+    }
   }
 
   logState() {
     const iterator = last(this.iterators);
-    if (iterator.treeCursor) {
+    if (iterator && iterator.treeCursor) {
       console.log(
         iterator.getPosition(),
         iterator.treeCursor.nodeType,
@@ -1029,6 +1074,8 @@ class LayerHighlightIterator {
     this.atEnd = false;
     this.treeCursor = treeCursor;
 
+    this.startOffset = this.treeCursor.startIndex;
+
     // In order to determine which selectors match its current node, the iterator maintains
     // a list of the current node's ancestors. Because the selectors can use the `:nth-child`
     // pseudo-class, each node's child index is also stored.
@@ -1046,7 +1093,6 @@ class LayerHighlightIterator {
   seek(targetIndex, containingTags, containingTagStartIndices) {
     while (this.treeCursor.gotoParent()) {}
 
-    this.done = false;
     this.atEnd = true;
     this.closeTags.length = 0;
     this.openTags.length = 0;
@@ -1057,8 +1103,7 @@ class LayerHighlightIterator {
     const containingTagEndIndices = [];
 
     if (targetIndex >= this.treeCursor.endIndex) {
-      this.done = true;
-      return;
+      return false;
     }
 
     let childIndex = -1;
@@ -1099,14 +1144,14 @@ class LayerHighlightIterator {
       }
     }
 
-    return containingTags;
+    return true;
   }
 
   moveToSuccessor() {
     this.closeTags.length = 0;
     this.openTags.length = 0;
 
-    while (!this.done && !this.closeTags.length && !this.openTags.length) {
+    while (!this.closeTags.length && !this.openTags.length) {
       if (this.atEnd) {
         if (this._moveRight()) {
           const scopeId = this._currentScopeId();
@@ -1116,7 +1161,7 @@ class LayerHighlightIterator {
         } else if (this._moveUp(true)) {
           this.atEnd = true;
         } else {
-          this.done = true;
+          return false;
         }
       } else if (!this._moveDown()) {
         const scopeId = this._currentScopeId();
@@ -1125,26 +1170,32 @@ class LayerHighlightIterator {
         this._moveUp(false);
       }
     }
+
+    return true;
   }
 
   getPosition() {
-    if (this.done) {
-      return Point.INFINITY;
-    } else if (this.atEnd) {
+    if (this.atEnd) {
       return this.treeCursor.endPosition;
     } else {
       return this.treeCursor.startPosition;
     }
   }
 
-  getIndex() {
-    if (this.done) {
-      return Infinity;
-    } else if (this.atEnd) {
+  getOffset() {
+    if (this.atEnd) {
       return this.treeCursor.endIndex;
     } else {
       return this.treeCursor.startIndex;
     }
+  }
+
+  compare(other) {
+    let result = this.getOffset() - other.getOffset();
+    if (result !== 0) return result;
+    if (this.atEnd && !other.atEnd) return -1;
+    if (other.atEnd && !this.atEnd) return 1;
+    return this.depth - other.depth;
   }
 
   getCloseScopeIds() {
@@ -1156,6 +1207,7 @@ class LayerHighlightIterator {
   }
 
   // Private methods
+
   _moveUp(atLastChild) {
     let result = false;
     const { endIndex } = this.treeCursor;
@@ -1264,7 +1316,7 @@ class NullHighlightIterator {
     return [];
   }
   moveToSuccessor() {}
-  getIndex() {
+  getOffset() {
     return Infinity;
   }
   getPosition() {
@@ -1279,10 +1331,11 @@ class NullHighlightIterator {
 }
 
 class NodeRangeSet {
-  constructor(previous, nodes, newlinesBetween) {
+  constructor(previous, nodes, newlinesBetween, includeChildren) {
     this.previous = previous;
     this.nodes = nodes;
     this.newlinesBetween = newlinesBetween;
+    this.includeChildren = includeChildren;
   }
 
   getRanges(buffer) {
@@ -1293,18 +1346,20 @@ class NodeRangeSet {
       let position = node.startPosition;
       let index = node.startIndex;
 
-      for (const child of node.children) {
-        const nextIndex = child.startIndex;
-        if (nextIndex > index) {
-          this._pushRange(buffer, previousRanges, result, {
-            startIndex: index,
-            endIndex: nextIndex,
-            startPosition: position,
-            endPosition: child.startPosition
-          });
+      if (!this.includeChildren) {
+        for (const child of node.children) {
+          const nextIndex = child.startIndex;
+          if (nextIndex > index) {
+            this._pushRange(buffer, previousRanges, result, {
+              startIndex: index,
+              endIndex: nextIndex,
+              startPosition: position,
+              endPosition: child.startPosition
+            });
+          }
+          position = child.endPosition;
+          index = child.endIndex;
         }
-        position = child.endPosition;
-        index = child.endIndex;
       }
 
       if (node.endIndex > index) {


### PR DESCRIPTION
Fixes #19435

### Summary

This PR upgrades [`tree-sitter-rust`](https://github.com/tree-sitter/tree-sitter-rust) to the latest version. Because of some changes that I've made to that parser, we need to change the way that we highlight *macro definitions* and *macro invocations* in Rust code. This change required adding a new option to the existing injection point API. It should improve the experience of editing Rust code that contains macros.

### Background - Rust Macros

Macros come up a lot in Rust, especially macro *invocations*, like this:

```rust
assert_eq!(a.b(), C::D { e: f });
```

The Rust parser does not actually *parse* the arguments to macros (everything after the `!` in the example above) as written using normal Rust syntax. Instead, it parses them into simple [*token trees*](https://rust-lang.github.io/rustc-guide/macro-expansion.html) - loose sequences of tokens with bracket-matching as the only structure. The contents of the Token trees get parsed later, after macro expansion.

### Background - Syntax Highlighting Macros

Even though macro arguments are technically just token trees, in practice, they usually contain valid Rust syntax. So it's desirable to highlight macro arguments as if they were Rust expressions.

In the old version of `tree-sitter-rust` (0.13.7 and below), the parser itself would [*try* to parse token trees as Rust code](https://github.com/tree-sitter/tree-sitter-rust/blob/v0.13.7/grammar.js#L224-L249), and fall back to treating them as token trees if this parsing failed. It did this using Tree-sitter's GLR system for handling ambiguity. So in most cases, macro calls would appear in the syntax tree with their arguments fully parsed.

### Changing How Macros are Highlighted

There were a couple of problems with this :point_up: approach:

First of all, if there was *anything* invalid inside of a macro call, the entire macro call would switch back to being parsed as a simple token tree. During the course of typing, this sometimes caused unexpectedly large changes to the highlighting. Also, the ambiguity of parsing token trees as Rust code caused the parser to have a larger binary size than it would otherwise need to.

I've since realized that Rust macros should be highlighted using [**language injection**](https://flight-manual.atom.io/hacking-atom/sections/creating-a-grammar/#language-injection), similarly to what we do for [Ruby code within ERB](https://github.com/atom/language-html/blob/153f176a006e1276888c9ff3309ab76ffebf0701/lib/main.js#L34-L39), and [C code within C macro definitions](https://github.com/atom/language-c/blob/3cd4db63bc916447b08b0201e55e79a464a26deb/lib/main.js#L5-L9). This way, we won't totally give up on parsing the macros due to small parse errors, and we don't need to complicate the Rust parser itself to handle the behavior.

### The `includeChildren` API

Unfortunately, the [current language injection API](https://flight-manual.atom.io/hacking-atom/sections/creating-a-grammar/#language-injection) isn't quite suitable for parsing Rust token trees as Rust code.

Currently, when you add an *injection point* for a given node `N`, we assume that if `N` has internal structure, we should preserve that internal structure. Specifically:

* We continue to render highlighting for the tokens *within* `N`
* When computing which ranges of text we should pass to the injected language parser, we *subtract* those tokens' ranges from `N's` range, so that we can pass only `N's` *own* text, not its children's text.

This is not the behavior we want for handling Rust macros. All of the *tokens* within a token tree are already parsed out as separate tokens by the outer Rust parser. We *do want* to reinterpret them via a second pass of the Rust parser.

I've added a new boolean option to the `GrammarRegistry.addInjectionPoint` method called `includeChildren` that implements this new behavior. If you call `addInjectionPoint` with `includeChildren` set to `true`, then the matching nodes' entire text will be passed to the injected parser, including the nodes' children's text.

### QA Process

In addition to writing one unit test for this new behavior, I've been testing this manually by opening large Rust source files containing lots of macro invocations and macro definitions, like [this one from `serde`](https://github.com/serde-rs/serde/blob/master/serde/src/de/impls.rs), editing, and verifying that syntax highlighting looks good.