### PR TITLE
Store/retrieve state from windows that have no opened project

### DIFF
--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -1499,7 +1499,18 @@ or use Pane::saveItemAs for programmatic saving.`);
   }
 
   getStateKey(paths) {
-    if (paths && paths.length > 0) {
+    if (!paths) {
+      return null;
+    }
+
+    if (paths.length === 0) {
+      // If the current window does not have any project opened, use the
+      // windowId to retrieve its state. Maybe we could do that for all
+      // the windows.
+      paths = [this.getLoadSettings().windowId];
+    }
+
+    if (paths.length > 0) {
       const sha1 = crypto
         .createHash('sha1')
         .update(

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -384,6 +384,7 @@ module.exports = class AtomApplication extends EventEmitter {
       clearWindowState,
       addToLastWindow,
       preserveFocus,
+      windowId,
       env
     } = options;
 
@@ -427,12 +428,13 @@ module.exports = class AtomApplication extends EventEmitter {
         profileStartup,
         clearWindowState,
         addToLastWindow,
+        windowId,
         env
       });
     } else if (urlsToOpen && urlsToOpen.length > 0) {
       return Promise.all(
         urlsToOpen.map(urlToOpen =>
-          this.openUrl({ urlToOpen, devMode, safeMode, env })
+          this.openUrl({ urlToOpen, devMode, safeMode, env, windowId })
         )
       );
     } else {
@@ -446,7 +448,8 @@ module.exports = class AtomApplication extends EventEmitter {
         profileStartup,
         clearWindowState,
         addToLastWindow,
-        env
+        env,
+        windowId
       });
     }
   }
@@ -1235,6 +1238,7 @@ module.exports = class AtomApplication extends EventEmitter {
   //   :profileStartup - Boolean to control creating a profile of the startup time.
   //   :window - {AtomWindow} to open file paths in.
   //   :addToLastWindow - Boolean of whether this should be opened in last focused window.
+  //   :windowId - Identifier used to retrieve the window state (if the window has no projects).
   openPath({
     pathToOpen,
     pidToKillWhenClosed,
@@ -1245,7 +1249,8 @@ module.exports = class AtomApplication extends EventEmitter {
     window,
     clearWindowState,
     addToLastWindow,
-    env
+    env,
+    windowId
   } = {}) {
     return this.openPaths({
       pathsToOpen: [pathToOpen],
@@ -1257,7 +1262,8 @@ module.exports = class AtomApplication extends EventEmitter {
       window,
       clearWindowState,
       addToLastWindow,
-      env
+      env,
+      windowId
     });
   }
 
@@ -1273,6 +1279,7 @@ module.exports = class AtomApplication extends EventEmitter {
   //   :windowDimensions - Object with height and width keys.
   //   :window - {AtomWindow} to open file paths in.
   //   :addToLastWindow - Boolean of whether this should be opened in last focused window.
+  //   :windowId - Identifier used to retrieve the window state (if the window has no projects).
   async openPaths({
     pathsToOpen,
     foldersToOpen,
@@ -1286,7 +1293,8 @@ module.exports = class AtomApplication extends EventEmitter {
     window,
     clearWindowState,
     addToLastWindow,
-    env
+    env,
+    windowId
   } = {}) {
     if (!env) env = process.env;
     if (!pathsToOpen) pathsToOpen = [];
@@ -1419,7 +1427,8 @@ module.exports = class AtomApplication extends EventEmitter {
         windowDimensions,
         profileStartup,
         clearWindowState,
-        env
+        env,
+        windowId
       });
       this.addWindow(openedWindow);
       openedWindow.focus();
@@ -1495,7 +1504,10 @@ module.exports = class AtomApplication extends EventEmitter {
       version: APPLICATION_STATE_VERSION,
       windows: this.getAllWindows()
         .filter(window => !window.isSpec)
-        .map(window => ({ projectRoots: window.projectRoots }))
+        .map(window => ({
+          projectRoots: window.projectRoots,
+          windowId: window.windowId
+        }))
     };
     state.windows.reverse();
 
@@ -1518,7 +1530,8 @@ module.exports = class AtomApplication extends EventEmitter {
         foldersToOpen: each.projectRoots,
         devMode: this.devMode,
         safeMode: this.safeMode,
-        newWindow: true
+        newWindow: true,
+        windowId: each.windowId
       }));
     } else if (state.version === undefined) {
       // Atom <= 1.36.0

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -1,4 +1,5 @@
 const { BrowserWindow, app, dialog, ipcMain } = require('electron');
+const crypto = require('crypto');
 const path = require('path');
 const url = require('url');
 const { EventEmitter } = require('events');
@@ -23,6 +24,7 @@ module.exports = class AtomWindow extends EventEmitter {
     this.safeMode = settings.safeMode;
     this.devMode = settings.devMode;
     this.resourcePath = settings.resourcePath;
+    this.windowId = settings.windowId || crypto.randomBytes(8).toString('hex');
 
     const locationsToOpen = settings.locationsToOpen || [];
 
@@ -80,6 +82,7 @@ module.exports = class AtomWindow extends EventEmitter {
 
     this.loadSettings = Object.assign({}, settings);
     this.loadSettings.appVersion = app.getVersion();
+    this.loadSettings.windowId = this.windowId;
     this.loadSettings.resourcePath = this.resourcePath;
     this.loadSettings.atomHome = process.env.ATOM_HOME;
     if (this.loadSettings.devMode == null) this.loadSettings.devMode = false;


### PR DESCRIPTION
This PR attempts to solve the root issue that causes the confusion around the "Restore previous window on start" config setting (reported in https://github.com/atom/settings-view/issues/1129).

## Problem

The root problem is that in order to store (or retrieve) an editor window state, Atom uses the list of folders that are currently opened as the key. This is a simple approach but has the limitation that cannot be used to store the state when opening a single file or a set of files (as feature which was introduced in https://github.com/atom/atom/pull/18608).

## Solution

In order to fix this, I've introduced the `windowId` param, which is a unique identifier for each `window` which is used for storing and retrieving the state of windows that do not have any opened project.

This allows to keep the full state of Atom windows (even if there are many windows without any opened project) when opening Atom without passing any arguments.

## Major drawback

There's a big drawback on this solution, which IMHO we need to fix before considering merging it: Since there's no cleaning mechanism on the [`StateStore`](https://github.com/atom/atom/blob/master/src/state-store.js) (the `IndexedDB` database which keeps the state of the Atom windows), adding this logic will make its size increase indefinitely, since window identifiers will get generated every time a new Atom window without a project gets created (so e.g every time a user runs `atom Readme.md`).

This problem is already happening on `master`, since every time that a user opens a folder on Atom, this folder state will permanently be stored on the `IndexedDB` database, but with this PR the issue is amplified considerably (specially for people that use Atom to edit single files).

## Next steps

As I mention, I don't think this PR is shippable in the current state, but I've sent it anyways to:

- Gather feedback about the approach and whether it makes sense to invest time on fixing the drawback.
- If we want to go forward with this solution, I'll let anyone who's willing to fix the drawback to do so. The easiest way to fix it is to make the `StateStore` a LRU cache.
- The last step would be to add some tests to this PR 😃 