### PR TITLE
Fix generation of release notes for nightly builds

### DIFF
--- a/script/vsts/lib/release-notes.js
+++ b/script/vsts/lib/release-notes.js
@@ -150,7 +150,7 @@ module.exports.generateForNightly = async function(
     );
   }
 
-  return output;
+  return output.join('\n');
 };
 
 function extractWrittenReleaseNotes(oldReleaseNotes) {


### PR DESCRIPTION
In https://github.com/atom/atom/pull/19553 I attempted to improve the release notes generation logic, and turns out that I broke it even more, since I forgot to convert the array to a string before returning it 😅

This PR fixes that 😇 