### PR TITLE
Generate delta nightly updaters for windows

### DIFF
--- a/script/lib/create-windows-installer.js
+++ b/script/lib/create-windows-installer.js
@@ -25,7 +25,6 @@ module.exports = packagedAppPath => {
     ),
     outputDirectory: CONFIG.buildOutputPath,
     noMsi: true,
-    noDelta: CONFIG.channel === 'nightly', // Delta packages are broken for nightly versions past nightly9 due to Squirrel/NuGet limitations
     remoteReleases: `${updateUrlPrefix}/api/updates${archSuffix}?version=${
       CONFIG.computedAppVersion
     }`,


### PR DESCRIPTION
Atom has recently been updated [to use `electron-winstaller@3.0.4`](https://github.com/atom/atom/pull/19539), which includes a new version of `Squirrel.Windows` with the following fix: anaisbetts/NuGet#1

Thanks to that fix we don't need anymore to disable delta nuget updaters, since their generation won't fail anymore past `nightly-9`.