### PR TITLE
⬆️ electron-winstaller

### DIFF
--- a/script/build
+++ b/script/build
@@ -109,7 +109,7 @@ if (!argv.generateApiDocs) {
           if (argv.codeSign) {
             const executablesToSign = [ path.join(packagedAppPath, 'Atom.exe') ]
             if (argv.createWindowsInstaller) {
-              executablesToSign.push(path.join(__dirname, 'node_modules', 'electron-winstaller', 'vendor', 'Squirrel.exe'))
+              executablesToSign.push(path.join(__dirname, 'node_modules', '@atom', 'electron-winstaller', 'vendor', 'Squirrel.exe'))
             }
             codeSignOnWindows(executablesToSign)
           } else {

--- a/script/lib/code-sign-on-windows.js
+++ b/script/lib/code-sign-on-windows.js
@@ -40,6 +40,7 @@ module.exports = function(filesToSign) {
       __dirname,
       '..',
       'node_modules',
+      '@atom',
       'electron-winstaller',
       'vendor',
       'signtool.exe'

--- a/script/lib/create-windows-installer.js
+++ b/script/lib/create-windows-installer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const electronInstaller = require('electron-winstaller');
+const electronInstaller = require('@atom/electron-winstaller');
 const fs = require('fs');
 const glob = require('glob');
 const path = require('path');

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -8,6 +8,66 @@
       "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-4.0.2.tgz",
       "integrity": "sha512-XtGk+IF57pr852UK1AhQJXqmm1WmSgS5uISL+LPs0z/iAxXouMvdlLJrHPeukP6gd7yR2rDTMSMkHNODgwIq7A=="
     },
+    "@atom/electron-winstaller": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@atom/electron-winstaller/-/electron-winstaller-0.0.1.tgz",
+      "integrity": "sha512-E8bGTBrhf4HsZZS5oPxQgx8XL2wCz04vi0gtYzQH+i9gpxdkuGuV+RHGAtQY+k+wbG5RVR89sB6ICMmhUYNi2Q==",
+      "requires": {
+        "@babel/runtime": "^7.3.4",
+        "asar": "^1.0.0",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "lodash.template": "^4.2.2",
+        "pify": "^4.0.1",
+        "temp": "^0.9.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        },
+        "temp": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.0.tgz",
+          "integrity": "sha512-YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==",
+          "requires": {
+            "rimraf": "~2.6.2"
+          }
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -2299,66 +2359,6 @@
       "version": "1.3.52",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz",
       "integrity": "sha1-0tnxJwuko7lnuDHEDvcftNmrXOA="
-    },
-    "electron-winstaller": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-3.0.4.tgz",
-      "integrity": "sha512-u3wTQUzBBBGWbExkKvgKt69EMoF0xC8uLQS5vTXtwr97BH8ffSW8CcHvVGWRyRDIhg2AA+togKOKWr41wgCeiA==",
-      "requires": {
-        "@babel/runtime": "^7.3.4",
-        "asar": "^1.0.0",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.1",
-        "lodash.template": "^4.2.2",
-        "pify": "^4.0.1",
-        "temp": "^0.9.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
-        },
-        "temp": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.0.tgz",
-          "integrity": "sha512-YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==",
-          "requires": {
-            "rimraf": "~2.6.2"
-          }
-        }
-      }
     },
     "emoji-regex": {
       "version": "7.0.3",

--- a/script/package.json
+++ b/script/package.json
@@ -14,7 +14,7 @@
     "electron-link": "0.4.0",
     "electron-mksnapshot": "^3.1.10",
     "electron-packager": "12.2.0",
-    "electron-winstaller": "^3.0.4",
+    "@atom/electron-winstaller": "0.0.1",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.2.0",
     "eslint-config-standard": "^12.0.0",


### PR DESCRIPTION
With this PR Atom uses a custom version of `electron-winstaller` that contains a custom version of `Squirrel.Windows` built from https://github.com/Squirrel/Squirrel.Windows/pull/1492 .

This should fix the issues when upgrading from e.g `nightly-9` to `nightly-10`.

## Verification plan

- [x] Check that this PR gets built correctly.
- [x] Enable production and signed builds on this branch and check that the PR gets built correctly.
- [x] Merge this PR and then Queue a new [Atom Nightly build](https://dev.azure.com/github/Atom/_build?definitionId=1&_a=summary) to check that nightly builds are still working.
- [x] Check that a Windows Atom Nightly installation gets upgraded to the created nightly build.
- [x] Create yet another Atom Nightly build and check that the previously upgraded Atom Nightly build can get upgraded again.
- [x] Create an Atom Nightly build with a prerelease number `>=10` and check that a Windows nightly with prerelease number `<10` can be upgraded successfully.
