### PR TITLE
Fix exception when multiple language layers are not yet highlighted

### DIFF
--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -1010,7 +1010,7 @@ class HighlightIterator {
       if (
         next.offset === first.offset &&
         next.atEnd === first.atEnd &&
-        next.languageLayer.depth > first.languageLayer.depth
+        next.depth > first.depth
       ) {
         this.currentScopeIsCovered = true;
         return;
@@ -1079,6 +1079,7 @@ class HighlightIterator {
 class LayerHighlightIterator {
   constructor(languageLayer, treeCursor) {
     this.languageLayer = languageLayer;
+    this.depth = this.languageLayer.depth;
 
     // The iterator is always positioned at either the start or the end of some node
     // in the syntax tree.


### PR DESCRIPTION
This fixes a regression introduced in #19556.

The code introduced in that PR ☝️ relied on the existence of a property `LayerHighlightIterator.languageLayer` which was not present on the `NullHighlightIterator`. This caused intermittent exceptions in the case where there were multiple injected language layers whose asynchronous parsing had not yet completed.