### PR TITLE
Publish nightly releases to atom repo on packagecloud.io

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -53,7 +53,7 @@ jobs:
         displayName: Download Release Artifacts
 
       - script: |
-          node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)"
+          node $(Build.SourcesDirectory)\script\vsts\upload-artifacts.js --create-github-release --assets-path "$(System.ArtifactsDirectory)" --linux-repo-name "atom"
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
           ATOM_RELEASE_VERSION: $(ReleaseVersion)


### PR DESCRIPTION
This is one of the remaining tasks listed on https://github.com/atom/atom/issues/17884 in order to ship nightly releases.

Instead of uploading to `atom-staging` (as instructed in https://github.com/atom/atom/issues/17884), I've changed that to upload to `atom`, since that's the public repository where users can download from.

## Verification steps

- [x] Check that the CI on this PR passes correctly.
- [x] Merge it, trigger a Nightly build and check that the nightly finishes successfully.
- [x] Try running `sudo apt-get install atom-nightly` from an Ubuntu VM and check that it works correctly.
- [x] Trigger a new nightly build and check that `sudo apt-get update && sudo apt-get install atom-nightly` updates to the new nightly.