### PR TITLE
Use a different polkit policy name for each Atom channel on Linux

### DIFF
--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -26,7 +26,7 @@ chmod 755 "%{buildroot}/<%= installDir %>/bin/<%= appFileName %>"
 mkdir -p "%{buildroot}/<%= installDir %>/share/applications/"
 cp "<%= appFileName %>.desktop" "%{buildroot}/<%= installDir %>/share/applications/"
 mkdir -p "%{buildroot}/<%= installDir %>/share/polkit-1/actions/"
-cp "atom.policy" "%{buildroot}/<%= installDir %>/share/polkit-1/actions/atom.policy"
+cp "<%= policyFileName %>" "%{buildroot}/<%= installDir %>/share/polkit-1/actions/<%= policyFileName %>"
 
 mkdir -p "%{buildroot}/<%= installDir %>/share/icons/hicolor/1024x1024/apps"
 cp "icons/1024.png" "%{buildroot}/<%= installDir %>/share/icons/hicolor/1024x1024/apps/<%= appFileName %>.png"

--- a/resources/linux/redhat/atom.spec.in
+++ b/resources/linux/redhat/atom.spec.in
@@ -52,5 +52,5 @@ cp "icons/16.png" "%{buildroot}/<%= installDir %>/share/icons/hicolor/16x16/apps
 <%= installDir %>/bin/<%= apmFileName %>
 <%= installDir %>/share/<%= appFileName %>/
 <%= installDir %>/share/applications/<%= appFileName %>.desktop
-<%= installDir %>/share/polkit-1/actions/atom.policy
+<%= installDir %>/share/polkit-1/actions/<%= policyFileName %>
 <%= installDir %>/share/icons/hicolor/

--- a/script/lib/create-debian-package.js
+++ b/script/lib/create-debian-package.js
@@ -209,7 +209,12 @@ module.exports = function(packagedAppPath) {
   );
   fs.copySync(
     path.join(CONFIG.repositoryRootPath, 'resources', 'linux', 'atom.policy'),
-    path.join(debianPackageShareDirPath, 'polkit-1', 'actions', 'atom.policy')
+    path.join(
+      debianPackageShareDirPath,
+      'polkit-1',
+      'actions',
+      `atom-${CONFIG.channel}.policy`
+    )
   );
 
   console.log(`Generating .deb file from ${debianPackageDirPath}`);

--- a/script/lib/create-rpm-package.js
+++ b/script/lib/create-rpm-package.js
@@ -19,6 +19,7 @@ module.exports = function(packagedAppPath) {
   // RPM versions can't have dashes or tildes in them.
   // (Ref.: https://twiki.cern.ch/twiki/bin/view/Main/RPMAndDebVersioning)
   const appVersion = CONFIG.appMetadata.version.replace(/-/g, '.');
+  const policyFileName = `atom-${CONFIG.channel}.policy`;
 
   const rpmPackageDirPath = path.join(CONFIG.homeDirPath, 'rpmbuild');
   const rpmPackageBuildDirPath = path.join(rpmPackageDirPath, 'BUILD');
@@ -114,7 +115,7 @@ module.exports = function(packagedAppPath) {
   console.log(`Copying atom.policy into "${rpmPackageBuildDirPath}"`);
   fs.copySync(
     path.join(CONFIG.repositoryRootPath, 'resources', 'linux', 'atom.policy'),
-    path.join(rpmPackageBuildDirPath, 'atom.policy')
+    path.join(rpmPackageBuildDirPath, policyFileName)
   );
 
   console.log(`Generating .rpm package from "${rpmPackageDirPath}"`);

--- a/script/lib/create-rpm-package.js
+++ b/script/lib/create-rpm-package.js
@@ -81,7 +81,8 @@ module.exports = function(packagedAppPath) {
     apmFileName: apmExecutableName,
     description: appDescription,
     installDir: '/usr',
-    version: appVersion
+    version: appVersion,
+    policyFileName
   });
   fs.writeFileSync(rpmPackageSpecFilePath, rpmPackageSpecsContents);
 


### PR DESCRIPTION
Refs: https://github.com/atom/atom/issues/17884#issuecomment-503992230

Using the same name would generate an exception when trying to install more than one version of Atom at the same time.