### PR TITLE
Upgrade npm on Azure Pipelines when running macOS tests

### DIFF
--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -115,6 +115,9 @@ jobs:
           versionSpec: 10.2.1
         displayName: Install Node.js 10.2.1
 
+      - script: npm install --global npm@6.2.0
+        displayName: Update npm
+
       - task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
         displayName: Restore node_modules cache
         inputs:


### PR DESCRIPTION
This fixes an error in macOS tests that would occur when creating a pull requests from a fork.

/cc: @Aerijo 