### PR TITLE
Update Tree-sitter to 0.15.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6510,9 +6510,9 @@
       "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q=="
     },
     "tree-sitter": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.15.5.tgz",
-      "integrity": "sha512-3rrww3lc9NNbbVPT1uGkvbom5Ivr/lZqpzru/x+S0Jnh/jHKACNz7ED1JiAPKfR89eLRJxBGh+ZV5g+QqQrQaw==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.15.6.tgz",
+      "integrity": "sha512-OYe9n9Td3iSoGpV39kOZymnjQfkzBaOOzaPEBsAZuBhoVsr+FjLl8IqqyQg8iNNJOEBI5Qc1LbDH1acVXVHIpA==",
       "requires": {
         "nan": "^2.13.2",
         "prebuild-install": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "temp": "^0.9.0",
     "text-buffer": "13.17.0",
     "timecop": "https://www.atom.io/api/packages/timecop/versions/0.36.2/tarball",
-    "tree-sitter": "0.15.5",
+    "tree-sitter": "0.15.6",
     "tree-sitter-css": "^0.13.7",
     "tree-view": "https://www.atom.io/api/packages/tree-view/versions/0.228.0/tarball",
     "typescript-simple": "1.0.0",


### PR DESCRIPTION
This brings in a small bugfix for a randomized test failure that occurred on Tree-sitter's CI.