### PR TITLE
Upload Electron crash reports to Bugsnag via Atom.io if user has consented to Telemetry

### DIFF
--- a/src/atom-environment.js
+++ b/src/atom-environment.js
@@ -45,6 +45,7 @@ const TextBuffer = require('text-buffer');
 const TextEditorRegistry = require('./text-editor-registry');
 const AutoUpdateManager = require('./auto-update-manager');
 const StartupTime = require('./startup-time');
+const getReleaseChannel = require('./get-release-channel');
 
 const stat = util.promisify(fs.stat);
 
@@ -565,18 +566,7 @@ class AtomEnvironment {
   // name like 'beta' or 'nightly' if one is found in the Atom version or 'stable'
   // otherwise.
   getReleaseChannel() {
-    // This matches stable, dev (with or without commit hash) and any other
-    // release channel following the pattern '1.00.0-channel0'
-    const match = this.getVersion().match(
-      /\d+\.\d+\.\d+(-([a-z]+)(\d+|-\w{4,})?)?$/
-    );
-    if (!match) {
-      return 'unrecognized';
-    } else if (match[2]) {
-      return match[2];
-    }
-
-    return 'stable';
+    return getReleaseChannel(this.getVersion());
   }
 
   // Public: Returns a {Boolean} that is `true` if the current version is an official release.

--- a/src/crash-reporter-start.js
+++ b/src/crash-reporter-start.js
@@ -3,13 +3,13 @@ module.exports = function(params) {
   const os = require('os');
   const platformRelease = os.release();
   const arch = os.arch();
-  const { uploadToServer } = params;
+  const { uploadToServer, releaseChannel } = params;
 
   crashReporter.start({
     productName: 'Atom',
     companyName: 'GitHub',
     submitURL: 'https://atom.io/crash_reports',
     uploadToServer,
-    extra: { platformRelease, arch }
+    extra: { platformRelease, arch, releaseChannel }
   });
 };

--- a/src/crash-reporter-start.js
+++ b/src/crash-reporter-start.js
@@ -1,11 +1,13 @@
 module.exports = function(params) {
   const { crashReporter } = require('electron');
+  const platformRelease = require('os').release();
   const { uploadToServer } = params;
 
   crashReporter.start({
     productName: 'Atom',
     companyName: 'GitHub',
     submitURL: 'https://atom.io/crash_reports',
-    uploadToServer
+    uploadToServer,
+    extra: { platformRelease }
   });
 };

--- a/src/crash-reporter-start.js
+++ b/src/crash-reporter-start.js
@@ -1,6 +1,8 @@
 module.exports = function(params) {
   const { crashReporter } = require('electron');
-  const platformRelease = require('os').release();
+  const os = require('os');
+  const platformRelease = os.release();
+  const arch = os.arch();
   const { uploadToServer } = params;
 
   crashReporter.start({
@@ -8,6 +10,6 @@ module.exports = function(params) {
     companyName: 'GitHub',
     submitURL: 'https://atom.io/crash_reports',
     uploadToServer,
-    extra: { platformRelease }
+    extra: { platformRelease, arch }
   });
 };

--- a/src/crash-reporter-start.js
+++ b/src/crash-reporter-start.js
@@ -1,14 +1,11 @@
 module.exports = function(params) {
   const { crashReporter } = require('electron');
-  const { uploadToServer, appVersion } = params;
+  const { uploadToServer } = params;
 
   crashReporter.start({
     productName: 'Atom',
     companyName: 'GitHub',
     submitURL: 'https://atom.io/crash_reports',
-    uploadToServer,
-    extra: {
-      appVersion
-    }
+    uploadToServer
   });
 };

--- a/src/crash-reporter-start.js
+++ b/src/crash-reporter-start.js
@@ -1,10 +1,14 @@
-module.exports = function(extra) {
+module.exports = function(params) {
   const { crashReporter } = require('electron');
+  const { uploadToServer, appVersion } = params;
+
   crashReporter.start({
     productName: 'Atom',
     companyName: 'GitHub',
-    submitURL: 'https://crashreporter.atom.io',
-    uploadToServer: false,
-    extra: extra
+    submitURL: 'https://atom.io/crash_reports',
+    uploadToServer,
+    extra: {
+      appVersion
+    }
   });
 };

--- a/src/get-release-channel.js
+++ b/src/get-release-channel.js
@@ -1,0 +1,14 @@
+module.exports = function(version) {
+  // This matches stable, dev (with or without commit hash) and any other
+  // release channel following the pattern '1.00.0-channel0'
+  const match = version.match(
+    /\d+\.\d+\.\d+(-([a-z]+)(\d+|-\w{4,})?)?$/
+  );
+  if (!match) {
+    return 'unrecognized';
+  } else if (match[2]) {
+    return match[2];
+  }
+
+  return 'stable';
+}

--- a/src/get-release-channel.js
+++ b/src/get-release-channel.js
@@ -1,9 +1,7 @@
 module.exports = function(version) {
   // This matches stable, dev (with or without commit hash) and any other
   // release channel following the pattern '1.00.0-channel0'
-  const match = version.match(
-    /\d+\.\d+\.\d+(-([a-z]+)(\d+|-\w{4,})?)?$/
-  );
+  const match = version.match(/\d+\.\d+\.\d+(-([a-z]+)(\d+|-\w{4,})?)?$/);
   if (!match) {
     return 'unrecognized';
   } else if (match[2]) {
@@ -11,4 +9,4 @@ module.exports = function(version) {
   }
 
   return 'stable';
-}
+};

--- a/src/initialize-test-window.coffee
+++ b/src/initialize-test-window.coffee
@@ -6,10 +6,7 @@ cloneObject = (object) ->
   clone
 
 module.exports = ({blobStore}) ->
-  startCrashReporter = require('./crash-reporter-start')
   {remote} = require 'electron'
-
-  startCrashReporter() # Before anything else
 
   exitWithStatusCode = (status) ->
     remote.app.emit('will-quit')

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -87,7 +87,10 @@ module.exports = function start(resourcePath, devResourcePath, startTime) {
 
   app.on('open-file', addPathToOpen);
   app.on('open-url', addUrlToOpen);
-  app.on('will-finish-launching', startCrashReporter);
+  app.on('will-finish-launching', () => startCrashReporter({
+    uploadToServer: config.get('core.telemetryConsent') === 'limited',
+    appVersion: app.getVersion()
+  }));
 
   if (args.userDataDir != null) {
     app.setPath('userData', args.userDataDir);

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -4,6 +4,7 @@ const path = require('path');
 const temp = require('temp').track();
 const parseCommandLine = require('./parse-command-line');
 const startCrashReporter = require('../crash-reporter-start');
+const getReleaseChannel = require('../get-release-channel');
 const atomPaths = require('../atom-paths');
 const fs = require('fs');
 const CSON = require('season');
@@ -87,9 +88,12 @@ module.exports = function start(resourcePath, devResourcePath, startTime) {
 
   app.on('open-file', addPathToOpen);
   app.on('open-url', addUrlToOpen);
-  app.on('will-finish-launching', () => startCrashReporter({
-    uploadToServer: config.get('core.telemetryConsent') === 'limited'
-  }));
+  app.on('will-finish-launching', () =>
+    startCrashReporter({
+      uploadToServer: config.get('core.telemetryConsent') === 'limited',
+      releaseChannel: getReleaseChannel(app.getVersion())
+    })
+  );
 
   if (args.userDataDir != null) {
     app.setPath('userData', args.userDataDir);

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -88,8 +88,7 @@ module.exports = function start(resourcePath, devResourcePath, startTime) {
   app.on('open-file', addPathToOpen);
   app.on('open-url', addUrlToOpen);
   app.on('will-finish-launching', () => startCrashReporter({
-    uploadToServer: config.get('core.telemetryConsent') === 'limited',
-    appVersion: app.getVersion()
+    uploadToServer: config.get('core.telemetryConsent') === 'limited'
   }));
 
   if (args.userDataDir != null) {

--- a/static/index.js
+++ b/static/index.js
@@ -7,6 +7,7 @@
   const path = require('path');
   const Module = require('module');
   const getWindowLoadSettings = require('../src/get-window-load-settings');
+  const getReleaseChannel = require('../src/get-release-channel');
   const StartupTime = require('../src/startup-time');
   const entryPointDirPath = __dirname;
   let blobStore = null;
@@ -144,16 +145,16 @@
       ? snapshotResult.customRequire('../src/crash-reporter-start.js')
       : require('../src/crash-reporter-start');
 
-    console.log(getWindowLoadSettings())
-    const { userSettings } = getWindowLoadSettings();
+    const { userSettings, appVersion } = getWindowLoadSettings();
     const uploadToServer =
       userSettings &&
       userSettings.core &&
       userSettings.core.telemetryConsent === 'limited';
+    const releaseChannel = getReleaseChannel(appVersion);
 
     startCrashReporter({
       uploadToServer,
-      process: 'renderer'
+      releaseChannel
     });
 
     const CSON = useSnapshot

--- a/static/index.js
+++ b/static/index.js
@@ -145,7 +145,7 @@
       : require('../src/crash-reporter-start');
 
     console.log(getWindowLoadSettings())
-    const { userSettings, appVersion } = getWindowLoadSettings();
+    const { userSettings } = getWindowLoadSettings();
     const uploadToServer =
       userSettings &&
       userSettings.core &&
@@ -153,7 +153,7 @@
 
     startCrashReporter({
       uploadToServer,
-      appVersion
+      process: 'renderer'
     });
 
     const CSON = useSnapshot

--- a/static/index.js
+++ b/static/index.js
@@ -143,7 +143,18 @@
     const startCrashReporter = useSnapshot
       ? snapshotResult.customRequire('../src/crash-reporter-start.js')
       : require('../src/crash-reporter-start');
-    startCrashReporter({ _version: getWindowLoadSettings().appVersion });
+
+    console.log(getWindowLoadSettings())
+    const { userSettings, appVersion } = getWindowLoadSettings();
+    const uploadToServer =
+      userSettings &&
+      userSettings.core &&
+      userSettings.core.telemetryConsent === 'limited';
+
+    startCrashReporter({
+      uploadToServer,
+      appVersion
+    });
 
     const CSON = useSnapshot
       ? snapshotResult.customRequire('../node_modules/season/lib/cson.js')


### PR DESCRIPTION
🍐'd with @jasonrudolph

Currently, we are not capturing crashes of the Electron render process or main process that occur in production. With this PR, we tell the Electron crash reporter that we want to upload crash reports to `https://atom.io/crash_reports` if the user has consented to telemetry. We include the value of `require('os').release()` and `require('os').arch()` as well as the `releaseChannel` as `extra` fields to be sent by the reporter.

I will open another PR on Atom.io that uses the reported information to report the crash to Bugsnag via Bugsnag's REST API.