### PR TITLE
Spawn updated Atom immediately instead of waiting for `will-quit` event

### DIFF
--- a/spec/squirrel-update-spec.coffee
+++ b/spec/squirrel-update-spec.coffee
@@ -122,16 +122,3 @@ describe "Windows Squirrel Update", ->
 
         it "still has desktop shortcut", ->
           expect(fs.existsSync(desktopShortcutPath)).toBe true
-
-  describe ".restartAtom", ->
-    it "quits the app and spawns a new one", ->
-      app = new EventEmitter()
-      app.quit = jasmine.createSpy('quit')
-
-      SquirrelUpdate.restartAtom(app)
-      expect(app.quit.callCount).toBe 1
-
-      expect(Spawner.spawn.callCount).toBe 0
-      app.emit('will-quit')
-      expect(Spawner.spawn.callCount).toBe 1
-      expect(path.basename(Spawner.spawn.argsForCall[0][0])).toBe 'atom.cmd'

--- a/src/main-process/squirrel-update.js
+++ b/src/main-process/squirrel-update.js
@@ -165,9 +165,7 @@ exports.restartAtom = app => {
     const { projectPath } = global.atomApplication.lastFocusedWindow;
     if (projectPath) args = [projectPath];
   }
-  app.once('will-quit', () =>
-    Spawner.spawn(path.join(binFolder, 'atom.cmd'), args)
-  );
+  Spawner.spawn(path.join(binFolder, 'atom.cmd'), args);
   app.quit();
 };
 


### PR DESCRIPTION
Fixes #19493 

Spawning the new version of Atom within a `will-quit` handler would cause Electron to quit before having a chance to actually run the executable.

There may still be a possibility of raciness between closing the old version of Atom and opening the new one, causing resource contention between the two processes (e.g., IndexedDb) or failing to spawn the new process before the previous one quits. Addressing such raciness perfectly would require a much more complex solution and this approach is working for us consistently in our tests.

🍐'd with @nathansobo 