### PR TITLE
⬆️ spellchecker@3.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6028,9 +6028,9 @@
       }
     },
     "spellchecker": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/spellchecker/-/spellchecker-3.6.0.tgz",
-      "integrity": "sha512-aGt8FEaFONTlo/IvDXbUvzN39NizCqkYS+MoQP8THy+Ocf1+OCfnG6QwrZwWxfrd8l06nxuc15icNiP8/ol/GA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/spellchecker/-/spellchecker-3.6.1.tgz",
+      "integrity": "sha512-i7qp5m/JpZqs+3LanJW6hhlXTX/m9+x8jvZvOuG/V3XlWHLsCsJQdOvGAXIU8ZHA1wuv1VRPJLpfVI8/e/ZBOg==",
       "requires": {
         "any-promise": "^1.3.0",
         "nan": "^2.14.0"


### PR DESCRIPTION
`spellchecker@3.6.0` contained a bunch of unneeded files that have been removed in `v3.6.1`: https://github.com/atom/node-spellchecker/issues/123