### PR TITLE
Send OS version to the autoupdate endpoint

### DIFF
--- a/src/main-process/auto-update-manager.js
+++ b/src/main-process/auto-update-manager.js
@@ -1,4 +1,5 @@
 const { EventEmitter } = require('events');
+const os = require('os');
 const path = require('path');
 
 const IdleState = 'idle';
@@ -34,14 +35,16 @@ module.exports = class AutoUpdateManager extends EventEmitter {
   initialize() {
     if (process.platform === 'win32') {
       const archSuffix = process.arch === 'ia32' ? '' : `-${process.arch}`;
-      this.feedUrl = `${
-        this.updateUrlPrefix
-      }/api/updates${archSuffix}?version=${this.version}`;
+      this.feedUrl =
+        this.updateUrlPrefix +
+        `/api/updates${archSuffix}?version=${this.version}&os_version=${
+          os.release
+        }`;
       autoUpdater = require('./auto-updater-win32');
     } else {
-      this.feedUrl = `${this.updateUrlPrefix}/api/updates?version=${
-        this.version
-      }`;
+      this.feedUrl =
+        this.updateUrlPrefix +
+        `/api/updates?version=${this.version}&os_version=${os.release}`;
       ({ autoUpdater } = require('electron'));
     }
 


### PR DESCRIPTION
## Context

Atom is going to be upgraded to use Electron v4 (PR: #19373), and since that new version of Electron does not support OSX < 10.10, we need to make users of older OSX versions to stick to a version of Atom that uses Electron v3.

## Solution

We're going to add some custom logic on the autoupdate backend to force clients on older OSX versions to stick to the latest Atom stable/beta/nightly version that uses Electron v3.

In order to do so, we need to send the `os_version` parameter to the autoupdate backend, which is what this PR is doing 😃

More information [in this comment](https://github.com/atom/atom/pull/19373#issuecomment-505969940).