### PR TITLE
Debounce the resize event handler

### DIFF
--- a/spec/window-event-handler-spec.js
+++ b/spec/window-event-handler-spec.js
@@ -1,5 +1,6 @@
 const KeymapManager = require('atom-keymap');
 const WindowEventHandler = require('../src/window-event-handler');
+const { conditionPromise } = require('./async-spec-helpers');
 
 describe('WindowEventHandler', () => {
   let windowEventHandler;
@@ -50,10 +51,13 @@ describe('WindowEventHandler', () => {
   });
 
   describe('resize event', () =>
-    it('calls storeWindowDimensions', () => {
+    it('calls storeWindowDimensions', async () => {
+      jasmine.useRealClock();
+
       spyOn(atom, 'storeWindowDimensions');
       window.dispatchEvent(new CustomEvent('resize'));
-      expect(atom.storeWindowDimensions).toHaveBeenCalled();
+
+      await conditionPromise(() => atom.storeWindowDimensions.callCount > 0);
     }));
 
   describe('window:close event', () =>

--- a/src/window-event-handler.js
+++ b/src/window-event-handler.js
@@ -1,5 +1,6 @@
 const { Disposable, CompositeDisposable } = require('event-kit');
 const listen = require('./delegated-listener');
+const { debounce } = require('underscore-plus');
 
 // Handles low-level events related to the `window`.
 module.exports = class WindowEventHandler {
@@ -65,7 +66,11 @@ module.exports = class WindowEventHandler {
     );
     this.addEventListener(this.window, 'focus', this.handleWindowFocus);
     this.addEventListener(this.window, 'blur', this.handleWindowBlur);
-    this.addEventListener(this.window, 'resize', this.handleWindowResize);
+    this.addEventListener(
+      this.window,
+      'resize',
+      debounce(this.handleWindowResize, 500)
+    );
 
     this.addEventListener(this.document, 'keyup', this.handleDocumentKeyEvent);
     this.addEventListener(


### PR DESCRIPTION
## Context

Atom is currently listening to window `resize` events to store the window width/height and position and be able to restore the window dimensions when it gets reopened.

In order to do so, the `resize` handler is doing the following:
* Get the current `BrowserWindow` object from the main process (synchronous IPC call).
* Get the `BrowserWindow` size from the main process (synchronous IPC call).
* Get the `BrowserWindow` position from the main process (synchronous IPC call).
* Validate that data is correct.
* Serialize the data into JSON and store it on `localStorage` (all synchronous).

All this processing usually takes 2-5ms on my high end machine, but under some circumstances (don't know what triggers it) it can take 40-50ms (or even up to 200-400ms, for example on Electron v4 because of https://github.com/electron/electron/issues/19027). These times are way above the frame budget and cause very noticeable lagging on the UI when resizing.

## Solution

The solution is a one-line change: just using a simple debouncer to only store the windows dimensions when the resizing has finished makes the UI lag-free.

[Here there's a comparison video](https://imgur.com/a/ySTlc17) between current master and this PR, to see the noticeable difference (I didn't upload a `gif` since it cannot be appreciated well with that format due to the framerate).