### PR TITLE
Add ripgrep pcre2 search support

### DIFF
--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2652,6 +2652,30 @@ describe('Workspace', () => {
               });
             });
           });
+          describe('pcre2 enabled', async () => {
+            it('supports lookbehind searches', async () => {
+              const results = [];
+
+              await scan(/(?<!a)aa\b/, { PCRE2: true }, result =>
+                results.push(result)
+              );
+
+              expect(results.length).toBe(1);
+              const { filePath, matches } = results[0];
+              expect(filePath).toBe(
+                atom.project.getDirectories()[0].resolve('a')
+              );
+              expect(matches).toHaveLength(1);
+              expect(matches[0]).toEqual({
+                matchText: 'aa',
+                lineText: 'cc aa cc',
+                lineTextOffset: 0,
+                range: [[1, 3], [1, 5]],
+                leadingContextLines: [],
+                trailingContextLines: []
+              });
+            });
+          });
         }
 
         it('returns results on lines with unicode strings', async () => {

--- a/src/ripgrep-directory-searcher.js
+++ b/src/ripgrep-directory-searcher.js
@@ -269,6 +269,10 @@ module.exports = class RipgrepDirectorySearcher {
       args.push('--no-ignore-vcs');
     }
 
+    if (options.PCRE2) {
+      args.push('--pcre2');
+    }
+
     args.push('.');
 
     const child = spawn(this.rgPath, args, {

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -2104,6 +2104,7 @@ module.exports = class Workspace extends Model {
         follow: this.config.get('core.followSymlinks'),
         leadingContextLineCount: options.leadingContextLineCount || 0,
         trailingContextLineCount: options.trailingContextLineCount || 0,
+        PCRE2: options.PCRE2,
         didMatch: result => {
           if (!this.project.isPathModified(result.filePath)) {
             return iterator(result);


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

Suggestion discussed [in this PR](https://github.com/atom/find-and-replace/pull/1086#issuecomment-502605862).

Fixes https://github.com/atom/find-and-replace/issues/571

### Description of the Change

Added option to enable `pcre2` ripgrep regex engine for search.

### Alternate Designs

None applicable.

### Possible Drawbacks

Enabling PCRE2 potentially incurs performance penalty, as explained on [ripgrep's wiki](https://github.com/BurntSushi/ripgrep/blob/7b3fe6b3251a18d2b8d3efe7ee6a85c9e9e4e565/FAQ.md#why-does-ripgrep-get-slower-when-i-enable-pcre2-regexes), thus this PR depends on a new `atom/find-and-replace` PCRE2 option, being added [in this PR](https://github.com/atom/find-and-replace/pull/1095).

### Verification Process

I haven't verified anything because I haven't managed to build Atom ATM. Considering the nature of the change, I'm relying on the CI. If this is not acceptable, feel free to close or keep the PR open until I manage to build Atom locally, but I give no promises as to when I'll get the time to do so.

### Release Notes

- Added support to enable `pcre2` for ripgrep search engine in find-and-replace package to enable advanced regex features such as lookbehind.