### PR TITLE
Restore use of Ubuntu 14.04 for Linux CI builds

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,8 +1,3 @@
-resources:
-  containers:
-    - container: atom-linux-ci
-      image: atomeditor/atom-linux-ci:latest
-
 jobs:
   - job: GetReleaseVersion
     steps:

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -97,7 +97,7 @@ jobs:
           ArtifactName: atom.x86_64.rpm
           ArtifactType: Container
         displayName: Upload atom.x84_64.rpm
-        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+        # condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
       - task: PublishBuildArtifacts@1
         inputs:
@@ -105,7 +105,7 @@ jobs:
           ArtifactName: atom-amd64.deb
           ArtifactType: Container
         displayName: Upload atom-amd64.deb
-        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+        # condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
       - task: PublishBuildArtifacts@1
         inputs:
@@ -113,4 +113,4 @@ jobs:
           ArtifactName: atom-amd64.tar.gz
           ArtifactType: Container
         displayName: Upload atom-amd64.tar.gz
-        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+        # condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -97,7 +97,7 @@ jobs:
           ArtifactName: atom.x86_64.rpm
           ArtifactType: Container
         displayName: Upload atom.x84_64.rpm
-        # condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
       - task: PublishBuildArtifacts@1
         inputs:
@@ -105,7 +105,7 @@ jobs:
           ArtifactName: atom-amd64.deb
           ArtifactType: Container
         displayName: Upload atom-amd64.deb
-        # condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
       - task: PublishBuildArtifacts@1
         inputs:
@@ -113,4 +113,4 @@ jobs:
           ArtifactName: atom-amd64.tar.gz
           ArtifactType: Container
         displayName: Upload atom-amd64.tar.gz
-        # condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -2,16 +2,26 @@ jobs:
   - job: Linux
     dependsOn: GetReleaseVersion
     timeoutInMinutes: 180
-
     variables:
       ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
     pool:
       # This image is used to host the Docker container that runs the build
       vmImage: ubuntu-16.04
-
-    container: atom-linux-ci
+    container: ubuntu:trusty
 
     steps:
+      - script: |
+          sudo apt-get update
+          sudo apt-get install -y wget software-properties-common
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
+          sudo apt-get update
+          sudo apt-get install -y build-essential ca-certificates clang-5.0 xvfb fakeroot git libsecret-1-dev rpm libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgconf2-4 libgtk-3-0 libasound2
+        displayName: Install apt dependencies
+
+      - script: sudo /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
+        displayName: Start Xvfb
+
       - task: NodeTool@0
         inputs:
           versionSpec: 10.2.1
@@ -32,6 +42,9 @@ jobs:
         env:
           CI: true
           CI_PROVIDER: VSTS
+          CC: clang-5.0
+          CXX: clang++-5.0
+          npm_config_clang: 1
         condition: ne(variables['CacheRestored'], 'true')
 
       - task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
@@ -48,6 +61,9 @@ jobs:
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
           ATOM_RELEASE_VERSION: $(ReleaseVersion)
+          CC: clang-5.0
+          CXX: clang++-5.0
+          npm_config_clang: 1
         displayName: Build Atom
 
       - script: script/test
@@ -56,6 +72,7 @@ jobs:
           CI_PROVIDER: VSTS
           ATOM_JASMINE_REPORTER: list
           TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
+          DISPLAY: :99.0
         displayName: Run tests
         condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))
 

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -16,7 +16,7 @@ jobs:
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main"
           sudo apt-get update
-          sudo apt-get install -y build-essential ca-certificates clang-5.0 xvfb fakeroot git libsecret-1-dev rpm libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgconf2-4 libgtk-3-0 libasound2
+          sudo apt-get install -y build-essential ca-certificates clang-5.0 xvfb fakeroot git libsecret-1-dev rpm libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgconf2-4 libgtk-3-0 libasound2 libicu-dev
         displayName: Install apt dependencies
 
       - script: sudo /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -13,6 +13,6 @@ jobs:
         name: Version
 
   # Import OS-specific build definitions
-  # - template: platforms/windows.yml
-  # - template: platforms/macos.yml
+  - template: platforms/windows.yml
+  - template: platforms/macos.yml
   - template: platforms/linux.yml

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -1,10 +1,5 @@
 trigger: none # No CI builds, only PR builds
 
-resources:
-  containers:
-    - container: atom-linux-ci
-      image: atomeditor/atom-linux-ci:latest
-
 jobs:
   - job: GetReleaseVersion
     steps:
@@ -18,6 +13,6 @@ jobs:
         name: Version
 
   # Import OS-specific build definitions
-  - template: platforms/windows.yml
-  - template: platforms/macos.yml
+  # - template: platforms/windows.yml
+  # - template: platforms/macos.yml
   - template: platforms/linux.yml

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -3,11 +3,6 @@ trigger:
   - 1.* # VSTS only supports wildcards at the end
   - electron-*
 
-resources:
-  containers:
-    - container: atom-linux-ci
-      image: atomeditor/atom-linux-ci:latest
-
 jobs:
   - job: GetReleaseVersion
     steps:


### PR DESCRIPTION
As part of the transition from Travis CI to Azure Pipelines to build Atom on Linux in #19597, we started using Ubuntu 18.04 as opposed to Ubuntu 14.04. This caused unintended side effects, such as atom/atom#19692, atom/atom#19690 and atom/atom#19682.

Even though, as @mfonville [pointed out](https://github.com/atom/atom/pull/19617#issuecomment-507193834), standard support for Ubuntu 14.04 ended in April 2019, we still want to support users running Atom on Fedora and CentOS 7. It is possible that we would able to do so by using Ubuntu 16, but for now using an Ubuntu version that we know works seems like the most pragmatic solution.

🍐'd with @jasonrudolph 