### PR TITLE
Fix issue when ripgrep returns matches that are empty

### DIFF
--- a/spec/workspace-spec.js
+++ b/spec/workspace-spec.js
@@ -2512,6 +2512,34 @@ describe('Workspace', () => {
         });
 
         if (ripgrep) {
+          it('returns empty text matches', async () => {
+            const results = [];
+            await scan(
+              /^\s{0}/,
+              {
+                paths: [`oh-git`]
+              },
+              result => results.push(result)
+            );
+
+            expect(results.length).toBe(1);
+            const { filePath, matches } = results[0];
+            expect(filePath).toBe(
+              atom.project
+                .getDirectories()[0]
+                .resolve(path.join('a-dir', 'oh-git'))
+            );
+            expect(matches).toHaveLength(1);
+            expect(matches[0]).toEqual({
+              matchText: '',
+              lineText: 'bbb aaaa',
+              lineTextOffset: 0,
+              range: [[0, 0], [0, 0]],
+              leadingContextLines: [],
+              trailingContextLines: []
+            });
+          });
+
           describe('newlines on regexps', async () => {
             it('returns multiline results from regexps', async () => {
               const results = [];

--- a/src/ripgrep-directory-searcher.js
+++ b/src/ripgrep-directory-searcher.js
@@ -157,7 +157,7 @@ function processSubmatch(submatch, lineText, offsetRow) {
 }
 
 function getText(input) {
-  return input.text
+  return 'text' in input
     ? input.text
     : Buffer.from(input.bytes, 'base64').toString();
 }


### PR DESCRIPTION
There can be searches where `ripgrep` returns an empty string as a result, like the added spec where the user searches for lines with no indentation (interestingly, this seems to not work using the standard searcher). The `ripgrep` scanner was not handling well this situation since the check for existance of the `text` key was not restrictive enough.

This PR fixes it