### PR TITLE
Use the correct executable name on the code signing tool

### DIFF
--- a/script/build
+++ b/script/build
@@ -107,7 +107,7 @@ if (!argv.generateApiDocs) {
           }
 
           if (argv.codeSign) {
-            const executablesToSign = [ path.join(packagedAppPath, 'Atom.exe') ]
+            const executablesToSign = [ path.join(packagedAppPath, CONFIG.executableName) ]
             if (argv.createWindowsInstaller) {
               executablesToSign.push(path.join(__dirname, 'node_modules', '@atom', 'electron-winstaller', 'vendor', 'Squirrel.exe'))
             }

--- a/script/lib/kill-running-atom-instances.js
+++ b/script/lib/kill-running-atom-instances.js
@@ -5,9 +5,7 @@ const CONFIG = require('../config.js');
 module.exports = function() {
   if (process.platform === 'win32') {
     // Use START as a way to ignore error if Atom.exe isnt running
-    childProcess.execSync(
-      `START taskkill /F /IM ${CONFIG.appMetadata.productName}.exe`
-    );
+    childProcess.execSync(`START taskkill /F /IM ${CONFIG.executableName}`);
   } else {
     childProcess.execSync(`pkill -9 ${CONFIG.appMetadata.productName} || true`);
   }


### PR DESCRIPTION
https://github.com/atom/atom/pull/17813 has introduced an issue on the code signing step (which is only executed when running production builds) that [is causing CI failures](https://dev.azure.com/github/Atom/_build/results?buildId=45503).

The problem is that the signing logic had `Atom.exe` hardcoded, while now the executable name is dynamic and depends on the release channel (e.g `atom-beta.exe`, `atom-nightly.exe`, `atom.exe`). This PR fixes the issue by reusing the `CONFIG` param that calculates the executable name.

I've double checked that there are no more `atom.exe` hardcoded in the atom repo, but it's possible that more issues arise after fixing this 🤔.