### PR TITLE
Do not depend on CONFIG.executableName on the windows tests

### DIFF
--- a/script/test
+++ b/script/test
@@ -56,7 +56,7 @@ if (process.platform === 'darwin') {
   assert(executablePaths.length === 1, `More than one application to run tests against was found. ${executablePaths.join(',')}`)
   executablePath = executablePaths[0]
 } else if (process.platform === 'win32') {
-  const executablePaths = glob.sync(path.join(CONFIG.buildOutputPath, '**', CONFIG.executableName))
+  const executablePaths = glob.sync(path.join(CONFIG.buildOutputPath, '**', 'atom*.exe'))
   assert(executablePaths.length === 1, `More than one application to run tests against was found. ${executablePaths.join(',')}`)
   executablePath = executablePaths[0]
 } else {


### PR DESCRIPTION
`CONFIG.executableName` depends on the `ATOM_RELEASE_VERSION` env variable to work correctly on nightly releases.

Since this env variable is not being set for the testing steps, the nightly release builds contain a wrong executableName on the testing step, which causes a failure when trying to find the Atom executable.

This commit fixes that by stop using the executableName from the test step, like it's done on other platforms, and should fix [the current failures that are happening on nightly](https://dev.azure.com/github/Atom/_build/results?buildId=45608).