### PR TITLE
Calculate correctly the nupkg filenames when uploading artifacts

### DIFF
--- a/script/vsts/get-release-version.js
+++ b/script/vsts/get-release-version.js
@@ -11,6 +11,17 @@ const argv = yargs
   .describe('nightly', 'Indicates that a nightly version should be produced')
   .wrap(yargs.terminalWidth()).argv;
 
+function getAppName(version) {
+  const match = version.match(/\d+\.\d+\.\d+(-([a-z]+)(\d+|-\w{4,})?)?$/);
+  if (!match) {
+    throw new Error(`Found incorrectly formatted Atom version ${version}`);
+  } else if (match[2]) {
+    return `atom-${match[2]}`;
+  }
+
+  return 'atom';
+}
+
 async function getReleaseVersion() {
   let releaseVersion = process.env.ATOM_RELEASE_VERSION || appMetadata.version;
   if (argv.nightly) {
@@ -67,6 +78,12 @@ async function getReleaseVersion() {
       buildBranch.startsWith('electron-') ||
       (buildBranch === 'master' &&
         !process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER));
+
+  console.log(
+    `##vso[task.setvariable variable=AppName;isOutput=true]${getAppName(
+      releaseVersion
+    )}`
+  );
   console.log(
     `##vso[task.setvariable variable=IsReleaseBranch;isOutput=true]${isReleaseBranch}`
   );

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -14,6 +14,7 @@ jobs:
       vmImage: vs2015-win2012r2 # needed for python 2.7 and gyp
 
     variables:
+      AppName: $[ dependencies.GetReleaseVersion.outputs['Version.AppName'] ]
       ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
       IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
       IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
@@ -184,18 +185,18 @@ jobs:
 
       - task: PublishBuildArtifacts@1
         inputs:
-          PathtoPublish: $(Build.SourcesDirectory)/out/atom-x64-$(ReleaseVersion)-full.nupkg
-          ArtifactName: atom-x64-$(ReleaseVersion)-full.nupkg
+          PathtoPublish: $(Build.SourcesDirectory)/out/$(AppName)-x64-$(ReleaseVersion)-full.nupkg
+          ArtifactName: $(AppName)-x64-$(ReleaseVersion)-full.nupkg
           ArtifactType: Container
-        displayName: Upload atom-x64-$(ReleaseVersion)-full.nupkg
+        displayName: Upload $(AppName)-x64-$(ReleaseVersion)-full.nupkg
         condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x64'))
 
       - task: PublishBuildArtifacts@1
         inputs:
-          PathtoPublish: $(Build.SourcesDirectory)/out/atom-x64-$(ReleaseVersion)-delta.nupkg
-          ArtifactName: atom-x64-$(ReleaseVersion)-delta.nupkg
+          PathtoPublish: $(Build.SourcesDirectory)/out/$(AppName)-x64-$(ReleaseVersion)-delta.nupkg
+          ArtifactName: $(AppName)-x64-$(ReleaseVersion)-delta.nupkg
           ArtifactType: Container
-        displayName: Upload atom-x64-$(ReleaseVersion)-delta.nupkg
+        displayName: Upload $(AppName)-x64-$(ReleaseVersion)-delta.nupkg
         condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x64'))
         continueOnError: true # Nightly builds don't produce delta packages yet, so don't fail the build
 
@@ -225,18 +226,18 @@ jobs:
 
       - task: PublishBuildArtifacts@1
         inputs:
-          PathtoPublish: $(Build.SourcesDirectory)/out/atom-$(ReleaseVersion)-full.nupkg
-          ArtifactName: atom-$(ReleaseVersion)-full.nupkg
+          PathtoPublish: $(Build.SourcesDirectory)/out/$(AppName)-$(ReleaseVersion)-full.nupkg
+          ArtifactName: $(AppName)-$(ReleaseVersion)-full.nupkg
           ArtifactType: Container
-        displayName: Upload atom-$(ReleaseVersion)-full.nupkg
+        displayName: Upload $(AppName)-$(ReleaseVersion)-full.nupkg
         condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x86'))
 
       - task: PublishBuildArtifacts@1
         inputs:
-          PathtoPublish: $(Build.SourcesDirectory)/out/atom-$(ReleaseVersion)-delta.nupkg
-          ArtifactName: atom-$(ReleaseVersion)-delta.nupkg
+          PathtoPublish: $(Build.SourcesDirectory)/out/$(AppName)-$(ReleaseVersion)-delta.nupkg
+          ArtifactName: $(AppName)-$(ReleaseVersion)-delta.nupkg
           ArtifactType: Container
-        displayName: Upload atom-$(ReleaseVersion)-delta.nupkg
+        displayName: Upload $(AppName)-$(ReleaseVersion)-delta.nupkg
         condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'), eq(variables['buildArch'], 'x86'))
         continueOnError: true # Nightly builds don't produce delta packages yet, so don't fail the build
 


### PR DESCRIPTION
As part of https://github.com/atom/atom/pull/17813, the filenames of the `nupkg` files have changed and this is causing more issues than expected.

This PR fixes the latest issue found, which prevents the Azure pipelines from uploading the artifacts correctly. This was caused by having the filenames hardcoded, so the easiest solution is to calculate the correct application name in JS and pass it back to Azure as a build variable (like we're doing for other data like the app version).

An easier solution would have been to just use globs or wildcards on the `PathToPublish` param for the upload artifacts step, but unfortunately [Azure Pipelines does not support them](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/publish-build-artifacts?view=azure-devops).