### PR TITLE
Only cover scope boundaries in the parent layer if there is a scope boundary in the injected layer

### DIFF
--- a/spec/tree-sitter-language-mode-spec.js
+++ b/spec/tree-sitter-language-mode-spec.js
@@ -521,7 +521,10 @@ describe('TreeSitterLanguageMode', () => {
             'template_substitution > "}"': 'interpolation'
           },
           injectionRegExp: 'javascript',
-          injectionPoints: [HTML_TEMPLATE_LITERAL_INJECTION_POINT, JSDOC_INJECTION_POINT]
+          injectionPoints: [
+            HTML_TEMPLATE_LITERAL_INJECTION_POINT,
+            JSDOC_INJECTION_POINT
+          ]
         });
 
         htmlGrammar = new TreeSitterGrammar(atom.grammars, htmlGrammarPath, {
@@ -848,12 +851,10 @@ describe('TreeSitterLanguageMode', () => {
             injectionRegExp: 'jsdoc',
             injectionPoints: []
           }
-        )
-
+        );
         atom.grammars.addGrammar(jsGrammar);
         atom.grammars.addGrammar(jsdocGrammar);
 
-        // await atom.packages.activatePackage('language-javascript');
         editor.setGrammar(jsGrammar);
         editor.setText('/**\n*/\n{\n}');
 
@@ -2451,10 +2452,10 @@ const SCRIPT_TAG_INJECTION_POINT = {
 
 const JSDOC_INJECTION_POINT = {
   type: 'comment',
-  language (comment) {
-    if (comment.text.startsWith('/**')) return 'jsdoc'
+  language(comment) {
+    if (comment.text.startsWith('/**')) return 'jsdoc';
   },
-  content (comment) {
-    return comment
+  content(comment) {
+    return comment;
   }
-}
+};

--- a/spec/tree-sitter-language-mode-spec.js
+++ b/spec/tree-sitter-language-mode-spec.js
@@ -401,6 +401,35 @@ describe('TreeSitterLanguageMode', () => {
       ]);
     });
 
+    it('correctly closes the scopes of nodes that contain injected grammars', async () => {
+      await atom.packages.activatePackage('language-javascript');
+      editor.setGrammar(atom.grammars.grammarForScopeName('source.js'));
+      editor.setText('/**\n*/\n{\n}');
+
+      expectTokensToEqual(editor, [
+        [{ text: '/**', scopes: ['source js', 'comment block'] }],
+        [{ text: '*/', scopes: ['source js', 'comment block'] }],
+        [
+          {
+            text: '{',
+            scopes: [
+              'source js',
+              'punctuation definition function body begin bracket curly'
+            ]
+          }
+        ],
+        [
+          {
+            text: '}',
+            scopes: [
+              'source js',
+              'punctuation definition function body end bracket curly'
+            ]
+          }
+        ]
+      ]);
+    });
+
     describe('when the buffer changes during a parse', () => {
       it('immediately parses again when the current parse completes', async () => {
         const grammar = new TreeSitterGrammar(atom.grammars, jsGrammarPath, {
@@ -2375,6 +2404,7 @@ function expectTokensToEqual(editor, expectedTokenLines) {
     }
 
     for (let row = startRow; row <= lastRow; row++) {
+      console.log('Row', row);
       const tokenLine = tokenLines[row];
       const expectedTokenLine = expectedTokenLines[row];
 

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -1010,7 +1010,8 @@ class HighlightIterator {
       if (
         next.offset === first.offset &&
         next.atEnd === first.atEnd &&
-        next.depth > first.depth
+        next.depth > first.depth &&
+        next.openTags.length + next.closeTags.length > 0
       ) {
         this.currentScopeIsCovered = true;
         return;


### PR DESCRIPTION
Fixes #19582

#19556 introduced new behavior for scopes from injected grammars, causing them to "cover" or "shadow" scope boundaries in the parent grammar. This was added to prevent duplicated and conflicted scope boundaries from being rendered in cases where the syntax tree of a parent grammar contains nodes that overlap with the syntax tree of the child grammar. See the body of #19556 for more details.

In #19582, we discovered an edge case in the injection of the JSDoc grammar into JavaScript block comments. In some cases, the `HighlightIterator` associated with the nested JSDoc grammar ends up getting parked at the end of the comment but *not* getting associated with any `openTags` or `closeTags`. In that scenario, the `HighlightIterator` continues to shadow the scopes from the parent grammar even though it is not expressing a scope boundary itself. This causes the close tag for the comment to be hidden, incorrectly extending the `comment` scope beyond the bounds of the actual comment block.

The solution in this PR is to *only* hide scopes from the parent grammar in situations where the child grammar's `HighlightIterator` has at least one close tag or open tag. This prevents the close of the comment scope from being obscured and solves #19582.

In the process of exploring this issue, it occurred to @maxbrunsfeld and I that there might be more diabolical cases where a node in the child grammar shadows only a close tag in the parent grammar. However, this actually seems unlikely. If we shadow a scope *close* at a given position, there's a high probability that we *also* shadow the scope *open* due to the structure of the syntax tree, thus preventing an unbalanced scope open from occurring. In the event we encounter an actual case of an unbalanced tag caused by shadowing, we will have more information on which to base a solution. In the meantime, the hypothetical possibility doesn't justify the complexity of a full solution.