### PR TITLE
Use class colors for inherited classes in One syntax themes

### DIFF
--- a/packages/one-dark-syntax/styles/syntax/_base.less
+++ b/packages/one-dark-syntax/styles/syntax/_base.less
@@ -16,7 +16,7 @@
   }
 
   &.syntax--other.syntax--inherited-class {
-    color: @hue-4;
+    color: @hue-6-2;
   }
 }
 

--- a/packages/one-light-syntax/styles/syntax/_base.less
+++ b/packages/one-light-syntax/styles/syntax/_base.less
@@ -16,7 +16,7 @@
   }
 
   &.syntax--other.syntax--inherited-class {
-    color: @hue-4;
+    color: @hue-6-2;
   }
 }
 


### PR DESCRIPTION
Closes #19588

This pull request introduces a more consistent syntax highlighting for inherited classes. In particular, we will start using `@hue-6-2` in One syntax themes to avoid making them look like strings. This is the same hue that is used for class declarations.

## One Light
| Before | After |
|--------|-------|
| <img width="237" alt="Screen Shot 2019-07-31 at 17 19 56" src="https://user-images.githubusercontent.com/482957/62225218-4d13ac00-b3b8-11e9-9fd2-3e68679b86b1.png"> | <img width="237" alt="Screen Shot 2019-07-31 at 17 19 35" src="https://user-images.githubusercontent.com/482957/62225220-4dac4280-b3b8-11e9-88a5-b995ddca4b5b.png"> |

## One Dark
| Before | After |
|--------|-------|
| <img width="237" alt="Screen Shot 2019-07-31 at 17 20 02" src="https://user-images.githubusercontent.com/482957/62225221-4dac4280-b3b8-11e9-9d2b-f6e487cb408a.png"> | <img width="237" alt="Screen Shot 2019-07-31 at 17 19 21" src="https://user-images.githubusercontent.com/482957/62225223-4e44d900-b3b8-11e9-8338-045aa4c2ceea.png"> |

/cc: @silentsokolov