### PR TITLE
Avoid covering up scopes at boundaries of injection layers

### DIFF
--- a/spec/tree-sitter-language-mode-spec.js
+++ b/spec/tree-sitter-language-mode-spec.js
@@ -866,6 +866,23 @@ describe('TreeSitterLanguageMode', () => {
         ]);
       });
 
+      it('reports scopes from shallower layers when they are at the start or end of an injection', async () => {
+        await atom.packages.activatePackage('language-javascript')
+
+        editor.setGrammar(atom.grammars.grammarForScopeName('source.js'))
+        editor.setText('/** @babel */\n{\n}')
+        expectTokensToEqual(editor, [
+          [
+            { text: '/** ', scopes: ['source js', 'comment block'] },
+            { text: '@babel', scopes: ['source js', 'comment block', 'keyword control'] },
+            { text: ' *', scopes: ['source js', 'comment block'] },
+            { text: '/', scopes: ['source js', 'comment block', 'meta delimiter slash'] }
+          ],
+          [{ text: '{', scopes: ['source js', 'punctuation definition function body begin bracket curly'] }],
+          [{ text: '}', scopes: ['source js', 'punctuation definition function body end bracket curly'] }]
+        ]);
+      })
+
       it('respects the `includeChildren` property of injection points', async () => {
         const rustGrammar = new TreeSitterGrammar(
           atom.grammars,

--- a/spec/tree-sitter-language-mode-spec.js
+++ b/spec/tree-sitter-language-mode-spec.js
@@ -867,21 +867,43 @@ describe('TreeSitterLanguageMode', () => {
       });
 
       it('reports scopes from shallower layers when they are at the start or end of an injection', async () => {
-        await atom.packages.activatePackage('language-javascript')
+        await atom.packages.activatePackage('language-javascript');
 
-        editor.setGrammar(atom.grammars.grammarForScopeName('source.js'))
-        editor.setText('/** @babel */\n{\n}')
+        editor.setGrammar(atom.grammars.grammarForScopeName('source.js'));
+        editor.setText('/** @babel */\n{\n}');
         expectTokensToEqual(editor, [
           [
             { text: '/** ', scopes: ['source js', 'comment block'] },
-            { text: '@babel', scopes: ['source js', 'comment block', 'keyword control'] },
+            {
+              text: '@babel',
+              scopes: ['source js', 'comment block', 'keyword control']
+            },
             { text: ' *', scopes: ['source js', 'comment block'] },
-            { text: '/', scopes: ['source js', 'comment block', 'meta delimiter slash'] }
+            {
+              text: '/',
+              scopes: ['source js', 'comment block', 'meta delimiter slash']
+            }
           ],
-          [{ text: '{', scopes: ['source js', 'punctuation definition function body begin bracket curly'] }],
-          [{ text: '}', scopes: ['source js', 'punctuation definition function body end bracket curly'] }]
+          [
+            {
+              text: '{',
+              scopes: [
+                'source js',
+                'punctuation definition function body begin bracket curly'
+              ]
+            }
+          ],
+          [
+            {
+              text: '}',
+              scopes: [
+                'source js',
+                'punctuation definition function body end bracket curly'
+              ]
+            }
+          ]
         ]);
-      })
+      });
 
       it('respects the `includeChildren` property of injection points', async () => {
         const rustGrammar = new TreeSitterGrammar(

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -32,7 +32,7 @@ class TreeSitterLanguageMode {
     this.config = config;
     this.grammarRegistry = grammars;
     this.parser = new Parser();
-    this.rootLanguageLayer = new LanguageLayer(this, grammar, 0, buffer.getRange());
+    this.rootLanguageLayer = new LanguageLayer(this, grammar, 0);
     this.injectionsMarkerLayer = buffer.addMarkerLayer();
 
     if (syncTimeoutMicros != null) {
@@ -637,14 +637,13 @@ class TreeSitterLanguageMode {
 }
 
 class LanguageLayer {
-  constructor(languageMode, grammar, depth, range) {
+  constructor(languageMode, grammar, depth) {
     this.languageMode = languageMode;
     this.grammar = grammar;
     this.tree = null;
     this.currentParsePromise = null;
     this.patchSinceCurrentParseStarted = null;
     this.depth = depth;
-    this.range = range
   }
 
   buildHighlightIterator() {
@@ -886,8 +885,7 @@ class LanguageLayer {
           marker.languageLayer = new LanguageLayer(
             this.languageMode,
             grammar,
-            this.depth + 1,
-            injectionRange
+            this.depth + 1
           );
           marker.parentLanguageLayer = this;
         }
@@ -1013,7 +1011,7 @@ class HighlightIterator {
         next.offset === first.offset &&
         next.atEnd === first.atEnd &&
         next.depth > first.depth &&
-        next.languageLayer.range.containsPoint(first.getPosition(), true)
+        !next.isAtInjectionBoundary()
       ) {
         this.currentScopeIsCovered = true;
         return;
@@ -1218,6 +1216,10 @@ class LayerHighlightIterator {
 
   getOpenScopeIds() {
     return this.openTags.slice();
+  }
+
+  isAtInjectionBoundary() {
+    return this.containingNodeTypes.length === 1;
   }
 
   // Private methods


### PR DESCRIPTION
This is a possible fix to https://github.com/atom/atom/issues/19582#issuecomment-517091238, mostly solved by @as-cii.

@as-cii I tweaked the implementation to use the syntax Tree instead of the buffer range to detect whether an iterator is at the start of end of its injection.

My concern about using the range is that the layers' ranges can change over time as the document is edited, so if we store a `range` property, it can become stale. I think that we can achieve a similar result by checking if we're parked at the start or end of the root node of the syntax tree.

I think there are still there are theoretically cases where we might erroneously cover scope boundaries with this logic, and we should probably be even more restrictive about when we cover scope boundaries, but I can't think of a concrete case where they would occur, so I think this idea is a good way to fix the problem we're currently seeing.