### PR TITLE
Add overlay when resizing panels to prevent panes stealing focus

### DIFF
--- a/src/pane-resize-handle-element.coffee
+++ b/src/pane-resize-handle-element.coffee
@@ -26,11 +26,11 @@ class PaneResizeHandleElement extends HTMLElement
 
   resizeStarted: (e) ->
     e.stopPropagation()
-    if @over then @removeChild @over
-    @over = document.createElement('div')
-    @over.classList.add('atom-panels-cursor-overlay')
-    @over.classList.add(if @isHorizontal then 'horizontal' else 'vertical')
-    @appendChild @over
+    if not @over
+      @over = document.createElement('div')
+      @over.classList.add('atom-pane-cursor-overlay')
+      @over.classList.add(if @isHorizontal then 'horizontal' else 'vertical')
+      @appendChild @over
     document.addEventListener 'mousemove', @resizePane
     document.addEventListener 'mouseup', @resizeStopped
 

--- a/src/pane-resize-handle-element.coffee
+++ b/src/pane-resize-handle-element.coffee
@@ -26,6 +26,7 @@ class PaneResizeHandleElement extends HTMLElement
 
   resizeStarted: (e) ->
     e.stopPropagation()
+    if @over then @removeChild @over
     @over = document.createElement('div')
     @over.classList.add('atom-panels-cursor-overlay')
     @over.classList.add(if @isHorizontal then 'horizontal' else 'vertical')

--- a/src/pane-resize-handle-element.coffee
+++ b/src/pane-resize-handle-element.coffee
@@ -26,12 +26,19 @@ class PaneResizeHandleElement extends HTMLElement
 
   resizeStarted: (e) ->
     e.stopPropagation()
+    @over = document.createElement('div')
+    @over.classList.add('atom-panels-cursor-overlay')
+    @over.classList.add(if @isHorizontal then 'horizontal' else 'vertical')
+    @appendChild @over
     document.addEventListener 'mousemove', @resizePane
     document.addEventListener 'mouseup', @resizeStopped
 
   resizeStopped: ->
     document.removeEventListener 'mousemove', @resizePane
     document.removeEventListener 'mouseup', @resizeStopped
+    if @over
+      @removeChild @over
+      @over = undefined
 
   calcRatio: (ratio1, ratio2, total) ->
     allRatio = ratio1 + ratio2

--- a/src/pane-resize-handle-element.coffee
+++ b/src/pane-resize-handle-element.coffee
@@ -26,20 +26,20 @@ class PaneResizeHandleElement extends HTMLElement
 
   resizeStarted: (e) ->
     e.stopPropagation()
-    if not @over
-      @over = document.createElement('div')
-      @over.classList.add('atom-pane-cursor-overlay')
-      @over.classList.add(if @isHorizontal then 'horizontal' else 'vertical')
-      @appendChild @over
+    if not @overlay
+      @overlay = document.createElement('div')
+      @overlay.classList.add('atom-pane-cursor-overlay')
+      @overlay.classList.add(if @isHorizontal then 'horizontal' else 'vertical')
+      @appendChild @overlay
     document.addEventListener 'mousemove', @resizePane
     document.addEventListener 'mouseup', @resizeStopped
 
   resizeStopped: ->
     document.removeEventListener 'mousemove', @resizePane
     document.removeEventListener 'mouseup', @resizeStopped
-    if @over
-      @removeChild @over
-      @over = undefined
+    if @overlay
+      @removeChild @overlay
+      @overlay = undefined
 
   calcRatio: (ratio1, ratio2, total) ->
     allRatio = ratio1 + ratio2

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -344,6 +344,7 @@ module.exports = class TextEditor {
   get languageMode() {
     return this.buffer.getLanguageMode();
   }
+
   get tokenizedBuffer() {
     return this.buffer.getLanguageMode();
   }

--- a/static/core-ui/panels.less
+++ b/static/core-ui/panels.less
@@ -30,20 +30,3 @@ atom-panel-container > atom-panel.left > *,
 atom-panel-container > atom-panel.right > * {
   height: initial;
 }
-
-.atom-panels-cursor-overlay {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 4;
-
-  &.horizontal {
-    cursor: col-resize;
-  }
-
-  &.vertical {
-    cursor: row-resize;
-  }
-}

--- a/static/core-ui/panels.less
+++ b/static/core-ui/panels.less
@@ -30,3 +30,20 @@ atom-panel-container > atom-panel.left > *,
 atom-panel-container > atom-panel.right > * {
   height: initial;
 }
+
+.atom-panels-cursor-overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 4;
+
+  &.horizontal {
+    cursor: col-resize;
+  }
+
+  &.vertical {
+    cursor: row-resize;
+  }
+}

--- a/static/core-ui/panes.less
+++ b/static/core-ui/panes.less
@@ -112,7 +112,7 @@ atom-pane-container {
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 10;
+  z-index: 4;
 
   &.horizontal {
     cursor: col-resize;

--- a/static/core-ui/panes.less
+++ b/static/core-ui/panes.less
@@ -22,7 +22,7 @@ atom-pane-container {
       &:before {
         content: "";
         position: absolute;
-        z-index: 3;
+        z-index: 11;
       }
     }
   }
@@ -103,5 +103,22 @@ atom-pane-container {
         cursor: ew-resize;
       }
     }
+  }
+}
+
+.atom-pane-cursor-overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+
+  &.horizontal {
+    cursor: col-resize;
+  }
+
+  &.vertical {
+    cursor: row-resize;
   }
 }


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

#20216

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Adds a div across the whole window when resizing panels.

This div keeps the context on Atom, even when a panel might normally grab it (e.g., if it were an `iframe` or `webview`). This is relevant for packages that provide this kind of panel, such as ones using the default Mozilla PDF viewer. Adding an overlay is already done by the Dock class.

### Alternate Designs

I considered if it could be fixed by the package making the iframe in the first place. However, anything that could be done (if at all) would just be a hack, and wouldn't benefit any other packages that use iframes and face the same issue. This fixes the issue at its root. 

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
My biggest concern is somehow not cleaning up the div after resizing stops. The Dock class already makes a similar overlay, and I am not aware of any issues with it. The method here is somewhat different, but should work so long as `resizeStopped` is called when resizing has stopped.

### Verification Process

1. Have the following in your `init.js` file
```javascript
atom.workspace.addOpener(uri => {
  if (uri === "frame://example") {
    const frame = document.createElement("iframe");
    frame.setAttribute("style", "width:100%;height:100%");

    return {
      getTitle: () => "iframe",
      element: frame,
    };
  }
})

atom.workspace.addOpener(uri => {
  if (uri === "editor://example") {
    return atom.workspace.buildTextEditor();
  }
})

atom.workspace.open("frame://example");
atom.workspace.open("editor://example");
```
2. Move the TextEditor panel so that both are visible side by side
3. Resize the panels by dragging the resize element towards the TextEditor. Both with and without this PR should have no issue dragging towards the TextEditor.
4.  Resize the panels by dragging the resize element towards the iframe. Without this PR, it should only move if you drag slowly. If you drag quickly over the iframe, the resize will stop until you move off the iframe. With this PR, it works at all speeds.

Additionally:
1. When resizing, tab out to a different application
2. Move and release the mouse anywhere.
3. Look back at the Atom window. It should have moved the divider where you released the mouse (this is the same as with resizing a dock).

Notes: 
- Programmatic resize methods should not be affected. This div is only created when clicking down on the resize element. 
- Double clicking the resize element to centre the division was broken by the initial attempt. The div was being made over the resize element, so a double click event was not detected. I have given the resize element a `z-index` of 11, and the overlay a `z-index` of 4. This matches the values used for the dock resize & overlay.

The following demonstrate the difference. In the first one, the mouse was not released. In the second, the mouse was released and double clicked to cause the panels to balance.
Old behaviour:
![noverlay](https://user-images.githubusercontent.com/22167388/64074492-68dbdc00-ccef-11e9-8d86-4238211d57a8.gif)

New behaviour:
![overlay](https://user-images.githubusercontent.com/22167388/64074494-71ccad80-ccef-11e9-91bf-60bbed97534c.gif)


### Release Notes

- Add overlay when resizing panels to prevent panes stealing focus
