### PR TITLE
fix deb package generation on armhf platform (raspbian)

### DIFF
--- a/script/lib/create-debian-package.js
+++ b/script/lib/create-debian-package.js
@@ -23,6 +23,8 @@ module.exports = function(packagedAppPath) {
     arch = 'amd64';
   } else if (process.arch === 'ppc') {
     arch = 'powerpc';
+  } else if (process.arch === 'arm') {
+    arch = 'armhf';
   } else {
     arch = process.arch;
   }


### PR DESCRIPTION
Sorry for not following the bug template. 

It is a small tweak. There are many issues about `arm` port of Atom. Since now we got raspberry pi 4 with 4GB ram. Now we get a platform popular enough to give the porting another try.

I follow the `build from source` guideline, it almost works, if you got the right chromedriver. But when building the deb package, the deb architecture has to be set to 'armhf' to make the deb installable on raspbian.

