### PR TITLE
reinstall electron-mksnapshot and fix dhcp arch generation

### DIFF
--- a/script/lib/create-debian-package.js
+++ b/script/lib/create-debian-package.js
@@ -24,7 +24,7 @@ module.exports = function(packagedAppPath) {
   } else if (process.arch === 'ppc') {
     arch = 'powerpc';
   } else {
-    arch = process.arch;
+    arch = spawnSync('dpkg', ['--print-architecture']).stdout.toString().trim();
   }
 
   const outputDebianPackageFilePath = path.join(

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -2076,34 +2076,61 @@
       }
     },
     "electron-download": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-4.1.0.tgz",
-      "integrity": "sha1-v5MsdG8vh//MCdHdRy8v9rkYeEU=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-4.1.1.tgz",
+      "integrity": "sha512-FjEWG9Jb/ppK/2zToP+U5dds114fM1ZOJqMAR4aXXL5CvyPE9fiqBK/9YcwC9poIFQTEJk/EM/zyRwziziRZrg==",
       "requires": {
-        "debug": "^2.2.0",
+        "debug": "^3.0.0",
         "env-paths": "^1.0.0",
-        "fs-extra": "^2.0.0",
+        "fs-extra": "^4.0.1",
         "minimist": "^1.2.0",
-        "nugget": "^2.0.0",
+        "nugget": "^2.0.1",
         "path-exists": "^3.0.0",
-        "rc": "^1.1.2",
-        "semver": "^5.3.0",
-        "sumchecker": "^2.0.1"
+        "rc": "^1.2.1",
+        "semver": "^5.4.1",
+        "sumchecker": "^2.0.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "fs-extra": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "requires": {
             "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0"
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },


### PR DESCRIPTION
Hello, Atom Team. It is me again, from #19921 . Sorry for not following the contribution guide again. 

I have work out the armv7l porting of Atom at my repo: https://github.com/aguegu/atom/tree/master/arm32v7

It is executed within Docker, So I believe many Atom lovers could repeat and verify my process and get their Atom on ARM, especially raspbian. 

Even though you officially refuse to support Arm platforms, I have to say that our current state is just one step away from successful arm porting. As shown in this PR, all I ask are:

1. reinstall `electron-mksnapshot` in `script/`, yes, the version is still `4.2.0` as the `package.json` said, but its dependences would got upgraded. `electron-download` upgrading from `4.1.0` to `4.1.1` makes a big deal, because with the later version, it can download the right chromedriver with the right arm surfix, like armv7l. 

2. correct the `arch` generation in `script/lib/create-debian-package.js`, as #19921 . But this time, the function is more accurate and universal. I believe for the main stream platforms, this function should work too, as long as `dpkg` is involved. But for now, I only changed the `else` part.

With these 2 small patches, ARM users would just be much `luckier` when trying to build Atom for their target platforms. And I believe it would not affect a thing for your officially supported platforms.

I have written my own build instruction at https://github.com/aguegu/atom/tree/master/arm32v7 . But I will not introduce the folder to the main stream. with this patch, it process mainly just like the [doc](https://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/#platform-linux). The tricky things are how to setup the minimum building environment and the process always take a while. But I got them all figured out. If you do not follow the `docker` way, the native way should just work too. As I said, you would get `luckier`. :)

Again, even though official support for ARM is sadly refused. I have to say that modern editor users long for their favourite editors on ARM. Because basically all your peers look like fail to achieve it too.  VSCode bin does not work, Sublime text is even more far away. Java based editors are just unbearable slow. 

![Screenshot from 2019-09-18 05-45-57](https://user-images.githubusercontent.com/1559791/65082061-a02cd700-d9d7-11e9-91fc-ad9f8ce78bd4.png)

For the community and be the community. 