### PR TITLE
Fix js colors in Solarized Dark Package

### DIFF
--- a/packages/solarized-dark-syntax/styles/syntax/javascript.less
+++ b/packages/solarized-dark-syntax/styles/syntax/javascript.less
@@ -6,23 +6,19 @@
   .syntax--support.syntax--class {
     color: @green;
   }
-  
+
   .syntax--entity {
     &.syntax--name.syntax--type {
       color: @yellow;
     }
     &.syntax--name {
       color: @syntax-text-color;
-      
-      &.syntax--function {
-        color: @blue;
-      }
     }
-    
+
     &.syntax--name.syntax--tag {
       color: @blue;
     }
-    
+
     &.syntax--other.syntax--attribute-name {
       color: @yellow;
     }
@@ -40,7 +36,7 @@
     color: @green;
   }
   .syntax--keyword.syntax--control {
-    color: @orange;
+    color: @green;
   }
   .syntax--keyword.syntax--control.syntax--regexp {
     color: @cyan;
@@ -75,7 +71,13 @@
   .syntax--support.syntax--constant {
     color: @syntax-text-color;
   }
-  
+  .syntax--constant.syntax--numeric {
+    color: @syntax-text-color;
+  }
+
+  .syntax--storage {
+    color: @blue;
+  }
   .syntax--storage.syntax--modifier {
     color: @yellow;
   }
@@ -93,7 +95,7 @@
   .syntax--meta.syntax--brace.syntax--curly {
     color: @blue;
   }
-  
+
   .syntax--string.syntax--quoted.syntax--template {
     .syntax--embedded.syntax--source {
       color: @syntax-text-color;
@@ -102,14 +104,14 @@
       }
     }
   }
-  
+
   &.syntax--embedded .syntax--entity.syntax--name.syntax--tag {
     color: @blue;
   }
 
   .syntax--import {
     .syntax--control {
-      color: @orange;
+      color: @yellow;
     }
   }
 }


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->
Issue #19990 

### Description of the Change

<!--
-->

Solarized dark colors in js files looks off comparing to the [original solarized dark js reference](https://raw.githubusercontent.com/altercation/solarized/master/img/screen-javascript-dark.png)

Before:

![Screen Shot 2019-10-02 at 1 32 38 PM](https://user-images.githubusercontent.com/1993929/66072495-c051af80-e51a-11e9-891e-831708448a70.png)

After (changes highlighted)
![Screen Shot 2019-10-02 at 1 32 45 PM](https://user-images.githubusercontent.com/1993929/66072819-6998a580-e51b-11e9-83c5-0ec4ada2167c.png)


### Alternate Designs

<!-- -->
Matching solarized dark spec

### Possible Drawbacks

<!-- -->
Might affect users that are used to the current (wrong) colors in js files 

### Verification Process

<!--

-->

Checked through many of my js files and jsx files, they look the same except for the color variations changed in this PR

### Release Notes

<!--


-->
- Match JS colors more closely the original solarized spec.
