### PR TITLE
Add remember-folds to deprecated packages

### DIFF
--- a/script/deprecated-packages.json
+++ b/script/deprecated-packages.json
@@ -1275,6 +1275,11 @@
     "hasDeprecations": true,
     "latestHasDeprecations": true
   },
+  "remember-folds": {
+    "version": "<=1.32.0",
+    "hasAlternative": true,
+    "alternative": "core"
+  },
   "remember-session": {
     "hasAlternative": true,
     "alternative": "core"


### PR DESCRIPTION

### Description of the Change

This adds my "remember-folds" package to the deprecated list, as it appears that this functionality works in core as of v1.32.0 (as I could best guess from my analysis).

Following the process shown in ["how to mark a package as deprecated"](https://discuss.atom.io/t/how-to-mark-a-package-as-deprecated/34745), as indicated on the [issue on the `remember-folds` repo](https://github.com/forivall/atom-remember-folds/issues/31), this PR adds it to the deprecated list.

### Release Notes

- The `remember-folds` package is now marked deprecated.