### PR TITLE
Update URL used for jasmine-node in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3628,7 +3628,7 @@
       "resolved": "https://registry.npmjs.org/jasmine-focused/-/jasmine-focused-1.0.7.tgz",
       "integrity": "sha1-uDx1fIAOaOHW78GjoaE/85/23NI=",
       "requires": {
-        "jasmine-node": "jasmine-node@git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
+        "jasmine-node": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
         "underscore-plus": "1.x",
         "walkdir": "0.0.7"
       }
@@ -3640,7 +3640,7 @@
     },
     "jasmine-node": {
       "version": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
-      "from": "jasmine-node@git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
+      "from": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
       "requires": {
         "coffee-script": ">=1.0.1",
         "coffeestack": ">=1 <2",


### PR DESCRIPTION
Fixes #20024 

---

Prior to this change, building atom/atom from source would fail with the following error:

```
$ ./script/build
Node:	v10.16.3
Npm:	v6.9.0
Installing script dependencies
Installing apm
...
apm  2.4.3
npm  6.2.0
node 10.2.1 x64
atom unknown
python 2.7.16
git 2.21.0
Installing modules ✗
> atom@1.42.0-dev preinstall /Users/j/src/atom
> node -e 'process.exit(0)'

npm ERR! code ENOLOCAL
npm ERR! Could not install from "node_modules/jasmine-focused/jasmine-node@git+https:/github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef" as it does not contain a package.json file.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/j/.atom/.apm/_logs/2019-10-17T14_54_36_051Z-debug.log
child_process.js:650
    throw err;
    ^

Error: Command failed: /Users/j/src/atom/apm/node_modules/atom-package-manager/bin/apm install
    at checkExecSyncError (child_process.js:629:11)
    at Object.execFileSync (child_process.js:647:13)
    at module.exports (/Users/j/src/atom/script/lib/run-apm-install.js:14:16)
    at Object.<anonymous> (/Users/j/src/atom/script/bootstrap:44:1)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
```

The changes in this pull request resolve that error, and `./script/build` is once again able to successfully build atom/atom.