### PR TITLE
Fix language-typescript version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,7 +260,7 @@
     "language-text": "0.7.4",
     "language-todo": "0.29.4",
     "language-toml": "0.20.0",
-    "language-typescript": "0.5.2",
+    "language-typescript": "0.5.3",
     "language-xml": "0.35.3",
     "language-yaml": "0.32.0"
   },


### PR DESCRIPTION
A series of recent pull requests (https://github.com/atom/atom/pull/19951, https://github.com/atom/atom/pull/19952, and https://github.com/atom/atom/pull/19953) attempted to complete a successful upgrade to language-typescript 0.5.3. As discussed in https://github.com/atom/atom/pull/20041#discussion_r337085075, after those changes, there was still one place in `package.json` that was referencing language-typescript 0.5.2. This pull request resolves that inconsistency. With these changes in place, Atom should be reliably using language-typescript 0.5.3. 😅
