### PR TITLE
Define indent/outdent behavior for single-line selected text

### DIFF
--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -5032,7 +5032,9 @@ describe('TextEditor', () => {
         it('inserts a tab in place of the selection', () => {
           editor.setSelectedBufferRange([[0, 4], [0, 13]]);
           editor.indent();
-          expect(buffer.lineForRow(0)).toEqual(`var ${editor.getTabText()} = function () {`);
+          expect(buffer.lineForRow(0)).toEqual(
+            `var ${editor.getTabText()} = function () {`
+          );
         });
       });
 
@@ -5755,8 +5757,8 @@ describe('TextEditor', () => {
           expect(buffer.lineForRow(1)).toBe('var sort = function(items) {');
           expect(editor.getSelectedBufferRange()).toEqual([
             [1, 0],
-            [1, 30 - editor.getTabLength()]]
-          );
+            [1, 30 - editor.getTabLength()]
+          ]);
         });
       });
 

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -5018,7 +5018,7 @@ describe('TextEditor', () => {
         });
       });
 
-      describe('when a single line has been selected from start to end'), () => {
+      describe('when a single line has been selected from start to end', () => {
         it('indents the selected line', () => {
           editor.setSelectedBufferRange([[0, 0], [0, 29]]);
           const selection = editor.getLastSelection();

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -5019,7 +5019,7 @@ describe('TextEditor', () => {
       });
 
       describe('when a single line has been selected from start to end'), () => {
-        it('indents the selected line'), () => {
+        it('indents the selected line', () => {
           editor.setSelectedBufferRange([[0, 0], [0, 29]]);
           const selection = editor.getLastSelection();
           spyOn(selection, 'indentSelectedRows');

--- a/spec/text-editor-spec.js
+++ b/spec/text-editor-spec.js
@@ -5008,13 +5008,31 @@ describe('TextEditor', () => {
         });
       });
 
-      describe('when the selection is not empty', () => {
+      describe('when selection spans across multiple lines', () => {
         it('indents the selected lines', () => {
           editor.setSelectedBufferRange([[0, 0], [10, 0]]);
           const selection = editor.getLastSelection();
           spyOn(selection, 'indentSelectedRows');
           editor.indent();
           expect(selection.indentSelectedRows).toHaveBeenCalled();
+        });
+      });
+
+      describe('when a single line has been selected from start to end'), () => {
+        it('indents the selected line'), () => {
+          editor.setSelectedBufferRange([[0, 0], [0, 29]]);
+          const selection = editor.getLastSelection();
+          spyOn(selection, 'indentSelectedRows');
+          editor.indent();
+          expect(selection.indentSelectedRows).toHaveBeenCalled();
+        });
+      });
+
+      describe('when selection is made within a single line', () => {
+        it('inserts a tab in place of the selection', () => {
+          editor.setSelectedBufferRange([[0, 4], [0, 13]]);
+          editor.indent();
+          expect(buffer.lineForRow(0)).toEqual(`var ${editor.getTabText()} = function () {`);
         });
       });
 
@@ -5718,7 +5736,7 @@ describe('TextEditor', () => {
         });
       });
 
-      describe('when one line is selected', () => {
+      describe('when part of one line is selected', () => {
         it('outdents line and retains editor', () => {
           editor.setSelectedBufferRange([[1, 4], [1, 14]]);
           editor.outdentSelectedRows();
@@ -5727,6 +5745,18 @@ describe('TextEditor', () => {
             [1, 4 - editor.getTabLength()],
             [1, 14 - editor.getTabLength()]
           ]);
+        });
+      });
+
+      describe('when one line is selected from start to end', () => {
+        it('outdents line and retains editor', () => {
+          editor.setSelectedBufferRange([[1, 0], [1, 30]]);
+          editor.outdentSelectedRows();
+          expect(buffer.lineForRow(1)).toBe('var sort = function(items) {');
+          expect(editor.getSelectedBufferRange()).toEqual([
+            [1, 0],
+            [1, 30 - editor.getTabLength()]]
+          );
         });
       });
 

--- a/src/selection.js
+++ b/src/selection.js
@@ -1002,7 +1002,12 @@ module.exports = class Selection {
           { bypassReadOnly }
         );
       }
-    } else if (bufferRange.isSingleLine() && !bufferRange.isEqual(this.editor.bufferRangeForBufferRow(bufferRange.start.row))) {
+    } else if (
+      bufferRange.isSingleLine() &&
+      !bufferRange.isEqual(
+        this.editor.bufferRangeForBufferRow(bufferRange.start.row)
+      )
+    ) {
       this.insertText(this.editor.getTabText(), { bypassReadOnly });
     } else {
       this.indentSelectedRows({ bypassReadOnly });


### PR DESCRIPTION
### Description of the Change

Text borrowed from #15096, which I had to close due to a force-push.

While working on atom/snippets#239, I realized that there isn't a properly defined behavior for selecting a segment of text on single line and indenting/outdenting it:

![indent_undefined_behavior](https://user-images.githubusercontent.com/1017132/28606639-b0d2367e-71e0-11e7-90cb-35bc9ce09c3c.gif)

Here is why I don't think this has been defined yet:
1. There is no spec for single-line selected text being indented via `indent()`: https://github.com/atom/atom/blob/a7736b81e3f6628f2a9e685f28f4c1df9a5e4615/spec/text-editor-spec.coffee#L3673-L3789

2. `indentSelectedRows` (which is used in `indent()`) is poorly documented:
https://github.com/atom/atom/blob/a7736b81e3f6628f2a9e685f28f4c1df9a5e4615/src/selection.coffee#L671-L679
    > If the selection spans multiple rows, indent all of them.

    It's possible to interpret this in a way that if the selection does not span across multiple rows, then nothing gets indented. [_Insert your favorite programmer-goes-to-grocery-store-joke here._](https://www.reddit.com/r/Jokes/comments/1nmkfq/a_programmer_is_going_to_the_grocery_store/)

3. The current behavior is not intuitive and unexpected for anyone coming from a different editor. With the exception of Brackets, other text editors tend to agree that selecting text and pressing tab within a single line should not indent the whole line, but insert/overwrite with a tab.

Outdent is done through `outdentSelectedRows`, which [has a spec for single line selected text](https://github.com/atom/atom/blob/2420d12e44f33f0178c8c0ef41e3a2c22cf4fb8e/spec/text-editor-spec.coffee#L4265-L4270). However it seems to be slightly mislabeled, there is actually less than one line selected. That is not a big deal and can be easily fixed, but it's possible that something is missing from here too.

At minimum I am looking to define behavior for following cases:
1. Selecting whole line and issuing `indent()`.
2. Selecting substring within line with length greater than 0 and issuing `indent()`.
3. Selecting whole line and issuing `outdentSelectedRows()`.
4. Selecting substring within line with length greater than 0 and issuing `outdentSelectedRows()`.

There might be additional cases that might need be considered, but I don't want this to be come overly ambitious, so starting with a more managable goal might be better.

The motivation for all of this comes from behavior related to text selections that come from traversing tab stops within snippets, where indenting/outdenting may lead to unexpected results:

![indent_snippet1](https://user-images.githubusercontent.com/1017132/28608860-e7ee5908-71ea-11e7-8bc2-19aadfcc2a3b.gif)
![indent_snippet2](https://user-images.githubusercontent.com/1017132/28608859-e7edd960-71ea-11e7-90d3-7b1bfb94e899.gif)

Personally I think that outdent behavior can be kept as-is and it is sufficient to simply improve the spec and cover cases 3 and 4. Outdenting does not break out of snippet's tab stops whereas indenting does, so indicating change with a slightly more destructive (but predictable) operation should be obvious enough that it's impossible to return to snippet's tab stops.

Visual Studio Code's behavior is a suitable candidate, which indents if the whole line is selected, but inserts a tab when only part of line is selected. Outdent is handled in the same way as Atom does it now. If there aren't any objections or better ideas, I might just implement that and propose this as the final solution.

Code at the time of writing in pull request is just to get the ball rolling and does not represent the final proposed solution in any way. But it does replace everything with a tab if at most only one line has been selected.

Currently the code implements Visual Studio Code behavior where fully selected single line indents and otherwise inserts a tab. Outdent remains the same as it is now.

### Alternate Designs

Sublime text's behavior was considered, which replaces the line with a tab if the start and end cursor is on the same line. This however can be at times more inconvenient than the Visual Studio Code behavior of indenting the line instead.

### Possible Drawbacks

Change in behavior that might upset users who are already used to the less flexible behavior in place right now.

### Verification Process

Both hand-testing and automated testing of use cases that were not previously covered (selecting right amount of text and pressing <kbd>Tab</kbd>.

### Release Notes

Not finalized.