### PR TITLE
MacOS App Notarization

### DIFF
--- a/resources/mac/entitlements.plist
+++ b/resources/mac/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+  </dict>
+</plist>

--- a/script/lib/code-sign-on-mac.js
+++ b/script/lib/code-sign-on-mac.js
@@ -1,8 +1,14 @@
-const downloadFileFromGithub = require('./download-file-from-github');
 const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');
 const spawnSync = require('./spawn-sync');
+const CONFIG = require('../config');
+const macEntitlementsPath = path.join(
+  CONFIG.repositoryRootPath,
+  'resources',
+  'mac',
+  'atom-Info.plist'
+);
 
 module.exports = function(packagedAppPath) {
   if (
@@ -127,6 +133,10 @@ module.exports = function(packagedAppPath) {
         '--force',
         '--verbose',
         '--keychain',
+        '--entitlements',
+        macEntitlementsPath,
+        '--options',
+        'runtime',
         process.env.ATOM_MAC_CODE_SIGNING_KEYCHAIN,
         '--sign',
         'Developer ID Application: GitHub',

--- a/script/lib/code-sign-on-mac.js
+++ b/script/lib/code-sign-on-mac.js
@@ -1,3 +1,4 @@
+const downloadFileFromGithub = require('./download-file-from-github');
 const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -9,7 +9,7 @@ jobs:
       IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
       IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
     pool:
-      vmImage: macos-10.13
+      vmImage: macos-10.14
 
     steps:
       - task: NodeTool@0
@@ -95,7 +95,7 @@ jobs:
     dependsOn: macOS_build
     timeoutInMinutes: 180
     pool:
-      vmImage: macos-10.13
+      vmImage: macos-10.14
     strategy:
       maxParallel: 3
       matrix:


### PR DESCRIPTION
## TODO

- [ ] Migrate mac-signing from xcode cli tool to the electron-packager's electron-osx-sign.
- [ ] Add notarization to the mac signing task.
- [ ] Look into migrating the test-sign-on-mac to use electron-packager.
- [ ] Link and close any issues that might be resolved by the notarization.
- [ ] Merge into master after the new release https://github.com/atom/maintainers-log/issues/201
