### PR TITLE
⬆️ nsfw@1.0.26 & language-typescript@0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,12 +29,19 @@
       }
     },
     "@atom/nsfw": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/@atom/nsfw/-/nsfw-1.0.25.tgz",
-      "integrity": "sha512-V7g509EVRCCkzoQW/QA7lQsROrjsfYYEJRHzEuc6+PAH88Z4oAs7D3W8MOJrBPo+6e06gxEwfxZjIq7BQbpfwQ==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@atom/nsfw/-/nsfw-1.0.26.tgz",
+      "integrity": "sha512-VpYcOglpGRn1Gg2CbyTftDo1y3jcjUaWsXueUVGhwk57EYZbt4Wgu5GvQ7qK4pudiLA56gvhshAslhokJpDJ2g==",
       "requires": {
         "fs-extra": "^7.0.0",
-        "nan": "^2.10.0"
+        "nan": "^2.14.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        }
       }
     },
     "@atom/source-map-support": {
@@ -4110,8 +4117,8 @@
       "integrity": "sha512-6xFDqM6nZpynmxGKUS85iUWY0yeub7GYvLyzSOqDejMuOL5UXAITnSNcb7jhr+hQA8KTj5dCmRjphkAQER4Ucg=="
     },
     "language-typescript": {
-      "version": "https://www.atom.io/api/packages/language-typescript/versions/0.5.3/tarball",
-      "integrity": "sha512-L6lMJyk/Ze8YSyIbNsOnGxqgywVxJMcauo2UnHdOi7GZ2oKbPz+5kjEpeBRmz9PrHtslyZH7JiMLkEU/OLFdPw==",
+      "version": "https://www.atom.io/api/packages/language-typescript/versions/0.6.0/tarball",
+      "integrity": "sha512-MA9lYpUBiRt9oIkyUkiDnpZmrW36S6AnJl4oFqvFFAp5Js79dh347VDl5itlX00ZMuEi8oU0jCsTtT1pQiJ1xQ==",
       "requires": {
         "tree-sitter-typescript": "^0.15.1"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "electronVersion": "4.2.7",
   "dependencies": {
-    "@atom/nsfw": "1.0.25",
+    "@atom/nsfw": "1.0.26",
     "@atom/source-map-support": "^0.3.4",
     "@atom/watcher": "1.3.1",
     "about": "file:packages/about",
@@ -108,7 +108,7 @@
     "language-text": "https://www.atom.io/api/packages/language-text/versions/0.7.4/tarball",
     "language-todo": "https://www.atom.io/api/packages/language-todo/versions/0.29.4/tarball",
     "language-toml": "https://www.atom.io/api/packages/language-toml/versions/0.20.0/tarball",
-    "language-typescript": "https://www.atom.io/api/packages/language-typescript/versions/0.5.3/tarball",
+    "language-typescript": "https://www.atom.io/api/packages/language-typescript/versions/0.6.0/tarball",
     "language-xml": "https://www.atom.io/api/packages/language-xml/versions/0.35.3/tarball",
     "language-yaml": "https://www.atom.io/api/packages/language-yaml/versions/0.32.0/tarball",
     "less-cache": "1.1.0",
@@ -259,7 +259,7 @@
     "language-text": "0.7.4",
     "language-todo": "0.29.4",
     "language-toml": "0.20.0",
-    "language-typescript": "0.5.3",
+    "language-typescript": "0.6.0",
     "language-xml": "0.35.3",
     "language-yaml": "0.32.0"
   },


### PR DESCRIPTION
*List of changes between `language-typescript@0.5.3` and `language-typescript@0.6.0`: https://github.com/atom/language-typescript/compare/v0.5.3...v0.6.0*

*List of changes between `nsfw@1.0.25` and `nsfw@1.0.26`: https://github.com/atom/nsfw/compare/v1.0.25...v1.0.26*

Refs: 
* https://github.com/atom/language-typescript/pull/43 (Thanks for the contribution @sharedprophet :bow:)
* https://github.com/atom/nsfw/pull/11 (Thanks for the contribution @yvele :bow:)

### Release Notes
Update legacy TextMate grammars to match microsoft/vscode@e6abf47
