### PR TITLE
If Text Editor Component uses the scroll event, consume it / prevent bubbling

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1681,7 +1681,7 @@ describe('TextEditorComponent', () => {
         scrollSensitivity
       });
       // stub in place for Event.preventDefault()
-      const eventPreventDefaultStub = function () {}
+      const eventPreventDefaultStub = function() {};
 
       {
         const expectedScrollTop = 20 * (scrollSensitivity / 100);
@@ -1753,6 +1753,8 @@ describe('TextEditorComponent', () => {
         width: 50,
         scrollSensitivity
       });
+      // stub in place for Event.preventDefault()
+      const eventPreventDefaultStub = function() {};
 
       component.props.platform = 'linux';
       {

--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -1680,11 +1680,17 @@ describe('TextEditorComponent', () => {
         width: 50,
         scrollSensitivity
       });
+      // stub in place for Event.preventDefault()
+      const eventPreventDefaultStub = function () {}
 
       {
         const expectedScrollTop = 20 * (scrollSensitivity / 100);
         const expectedScrollLeft = component.getScrollLeft();
-        component.didMouseWheel({ wheelDeltaX: -5, wheelDeltaY: -20 });
+        component.didMouseWheel({
+          wheelDeltaX: -5,
+          wheelDeltaY: -20,
+          preventDefault: eventPreventDefaultStub
+        });
         expect(component.getScrollTop()).toBe(expectedScrollTop);
         expect(component.getScrollLeft()).toBe(expectedScrollLeft);
         expect(component.refs.content.style.transform).toBe(
@@ -1696,7 +1702,11 @@ describe('TextEditorComponent', () => {
         const expectedScrollTop =
           component.getScrollTop() - 10 * (scrollSensitivity / 100);
         const expectedScrollLeft = component.getScrollLeft();
-        component.didMouseWheel({ wheelDeltaX: -5, wheelDeltaY: 10 });
+        component.didMouseWheel({
+          wheelDeltaX: -5,
+          wheelDeltaY: 10,
+          preventDefault: eventPreventDefaultStub
+        });
         expect(component.getScrollTop()).toBe(expectedScrollTop);
         expect(component.getScrollLeft()).toBe(expectedScrollLeft);
         expect(component.refs.content.style.transform).toBe(
@@ -1707,7 +1717,11 @@ describe('TextEditorComponent', () => {
       {
         const expectedScrollTop = component.getScrollTop();
         const expectedScrollLeft = 20 * (scrollSensitivity / 100);
-        component.didMouseWheel({ wheelDeltaX: -20, wheelDeltaY: 10 });
+        component.didMouseWheel({
+          wheelDeltaX: -20,
+          wheelDeltaY: 10,
+          preventDefault: eventPreventDefaultStub
+        });
         expect(component.getScrollTop()).toBe(expectedScrollTop);
         expect(component.getScrollLeft()).toBe(expectedScrollLeft);
         expect(component.refs.content.style.transform).toBe(
@@ -1719,7 +1733,11 @@ describe('TextEditorComponent', () => {
         const expectedScrollTop = component.getScrollTop();
         const expectedScrollLeft =
           component.getScrollLeft() - 10 * (scrollSensitivity / 100);
-        component.didMouseWheel({ wheelDeltaX: 10, wheelDeltaY: -8 });
+        component.didMouseWheel({
+          wheelDeltaX: 10,
+          wheelDeltaY: -8,
+          preventDefault: eventPreventDefaultStub
+        });
         expect(component.getScrollTop()).toBe(expectedScrollTop);
         expect(component.getScrollLeft()).toBe(expectedScrollLeft);
         expect(component.refs.content.style.transform).toBe(
@@ -1739,7 +1757,11 @@ describe('TextEditorComponent', () => {
       component.props.platform = 'linux';
       {
         const expectedScrollTop = 20 * (scrollSensitivity / 100);
-        component.didMouseWheel({ wheelDeltaX: 0, wheelDeltaY: -20 });
+        component.didMouseWheel({
+          wheelDeltaX: 0,
+          wheelDeltaY: -20,
+          preventDefault: eventPreventDefaultStub
+        });
         expect(component.getScrollTop()).toBe(expectedScrollTop);
         expect(component.refs.content.style.transform).toBe(
           `translate(0px, -${expectedScrollTop}px)`
@@ -1752,7 +1774,8 @@ describe('TextEditorComponent', () => {
         component.didMouseWheel({
           wheelDeltaX: 0,
           wheelDeltaY: -20,
-          shiftKey: true
+          shiftKey: true,
+          preventDefault: eventPreventDefaultStub
         });
         expect(component.getScrollLeft()).toBe(expectedScrollLeft);
         expect(component.refs.content.style.transform).toBe(
@@ -1766,7 +1789,8 @@ describe('TextEditorComponent', () => {
         component.didMouseWheel({
           wheelDeltaX: -20,
           wheelDeltaY: 0,
-          shiftKey: true
+          shiftKey: true,
+          preventDefault: eventPreventDefaultStub
         });
         expect(component.getScrollTop()).toBe(expectedScrollTop);
         expect(component.refs.content.style.transform).toBe(
@@ -1778,7 +1802,11 @@ describe('TextEditorComponent', () => {
       component.props.platform = 'win32';
       {
         const expectedScrollTop = 20 * (scrollSensitivity / 100);
-        component.didMouseWheel({ wheelDeltaX: 0, wheelDeltaY: -20 });
+        component.didMouseWheel({
+          wheelDeltaX: 0,
+          wheelDeltaY: -20,
+          preventDefault: eventPreventDefaultStub
+        });
         expect(component.getScrollTop()).toBe(expectedScrollTop);
         expect(component.refs.content.style.transform).toBe(
           `translate(0px, -${expectedScrollTop}px)`
@@ -1791,7 +1819,8 @@ describe('TextEditorComponent', () => {
         component.didMouseWheel({
           wheelDeltaX: 0,
           wheelDeltaY: -20,
-          shiftKey: true
+          shiftKey: true,
+          preventDefault: eventPreventDefaultStub
         });
         expect(component.getScrollLeft()).toBe(expectedScrollLeft);
         expect(component.refs.content.style.transform).toBe(
@@ -1805,7 +1834,8 @@ describe('TextEditorComponent', () => {
         component.didMouseWheel({
           wheelDeltaX: -20,
           wheelDeltaY: 0,
-          shiftKey: true
+          shiftKey: true,
+          preventDefault: eventPreventDefaultStub
         });
         expect(component.getScrollTop()).toBe(expectedScrollTop);
         expect(component.refs.content.style.transform).toBe(
@@ -1817,7 +1847,11 @@ describe('TextEditorComponent', () => {
       component.props.platform = 'darwin';
       {
         const expectedScrollTop = 20 * (scrollSensitivity / 100);
-        component.didMouseWheel({ wheelDeltaX: 0, wheelDeltaY: -20 });
+        component.didMouseWheel({
+          wheelDeltaX: 0,
+          wheelDeltaY: -20,
+          preventDefault: eventPreventDefaultStub
+        });
         expect(component.getScrollTop()).toBe(expectedScrollTop);
         expect(component.refs.content.style.transform).toBe(
           `translate(0px, -${expectedScrollTop}px)`
@@ -1830,7 +1864,8 @@ describe('TextEditorComponent', () => {
         component.didMouseWheel({
           wheelDeltaX: 0,
           wheelDeltaY: -20,
-          shiftKey: true
+          shiftKey: true,
+          preventDefault: eventPreventDefaultStub
         });
         expect(component.getScrollTop()).toBe(expectedScrollTop);
         expect(component.refs.content.style.transform).toBe(
@@ -1844,7 +1879,8 @@ describe('TextEditorComponent', () => {
         component.didMouseWheel({
           wheelDeltaX: -20,
           wheelDeltaY: 0,
-          shiftKey: true
+          shiftKey: true,
+          preventDefault: eventPreventDefaultStub
         });
         expect(component.getScrollLeft()).toBe(expectedScrollLeft);
         expect(component.refs.content.style.transform).toBe(

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1736,7 +1736,10 @@ module.exports = class TextEditorComponent {
     const scrollTopChanged =
       wheelDeltaY !== 0 && this.setScrollTop(this.getScrollTop() - wheelDeltaY);
 
-    if (scrollLeftChanged || scrollTopChanged) this.updateSync();
+    if (scrollLeftChanged || scrollTopChanged) {
+      event.preventDefault();
+      this.updateSync();
+    }
   }
 
   didResize() {


### PR DESCRIPTION
### Identify the Bug

Scrolling a text editor component lets the mousewheel event bubble up and cause scrolling events even though the event has been acted upon / used.

In a normal browser the inner scrollable would scroll to the edge before then scrolling the parent. This change makes it consistent with expected HTML scroll behaviour.

Without it, the scroll event continues outside the editor to any other element containing it, even though the scroll event already was acted upon by the child (text editor component).

If a package wanted to also use the mouse wheel event when integrating into a text editor (or if the text editor itself is inside something scrollable) this change makes more sense as it prevents multiple responses to a single user input.

### Description of the Change

Prevent the default action of the event if it is consumed.

### Possible Drawbacks

There doesn't appear to be any side effects to this change. (Tested on linux: Pop_OS 19.10, 1.42.0)

I don't think a release note is needed, but "Text Editor consumes scroll wheel events when used" sounds accurate.