### PR TITLE
Add notarization to macOS app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "atom",
-  "version": "1.44.0-dev",
+  "version": "1.45.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2588,6 +2588,45 @@
       "optional": true,
       "requires": {
         "jsbn": "~0.1.0"
+      }
+    },
+    "electron-notarize": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-0.2.1.tgz",
+      "integrity": "sha512-oZ6/NhKeXmEKNROiFmRNfytqu3cxqC95sjooG7kBXQVEUSQkZnbiAhxVh5jXngL881G197pbwpeVPJyM7Ikmxw==",
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^8.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "deprecation-cop": "file:packages/deprecation-cop",
     "dev-live-reload": "file:packages/dev-live-reload",
     "devtron": "1.3.0",
+    "electron-notarize": "^0.2.1",
     "encoding-selector": "https://www.atom.io/api/packages/encoding-selector/versions/0.23.9/tarball",
     "etch": "^0.12.6",
     "event-kit": "^2.5.3",

--- a/resources/mac/entitlements.plist
+++ b/resources/mac/entitlements.plist
@@ -2,7 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
-        <key>com.apple.security.cs.allow-jit</key>
         <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
         <true/>
     </dict>

--- a/resources/mac/entitlements.plist
+++ b/resources/mac/entitlements.plist
@@ -1,8 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-        <true/>
-    </dict>
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
 </plist>

--- a/resources/mac/entitlements.plist
+++ b/resources/mac/entitlements.plist
@@ -4,17 +4,5 @@
   <dict>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <key>com.apple.security.files.user-selected.read-write</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
-    <key>com.apple.security.cs.allow-jit</key>
-    <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
-    <key>com.apple.security.network.client</key>
-    <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
   </dict>
 </plist>

--- a/resources/mac/entitlements.plist
+++ b/resources/mac/entitlements.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-jit</key>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+    </dict>
+</plist>

--- a/script/build
+++ b/script/build
@@ -36,6 +36,7 @@ const argv = yargs
 const checkChromedriverVersion = require('./lib/check-chromedriver-version')
 const cleanOutputDirectory = require('./lib/clean-output-directory')
 const codeSignOnMac = require('./lib/code-sign-on-mac')
+const notarizeOnMac = require('./lib/notarize-on-mac')
 const codeSignOnWindows = require('./lib/code-sign-on-windows')
 const compressArtifacts = require('./lib/compress-artifacts')
 const copyAssets = require('./lib/copy-assets')
@@ -89,11 +90,12 @@ if (!argv.generateApiDocs) {
   binariesPromise
     .then(packageApplication)
     .then(packagedAppPath => generateStartupSnapshot(packagedAppPath).then(() => packagedAppPath))
-    .then(packagedAppPath => {
+    .then(async packagedAppPath => {
       switch (process.platform) {
         case 'darwin': {
           if (argv.codeSign) {
             codeSignOnMac(packagedAppPath)
+            await notarizeOnMac(packagedAppPath)
           } else if (argv.testSign) {
             testSignOnMac(packagedAppPath)
           } else {

--- a/script/lib/code-sign-on-mac.js
+++ b/script/lib/code-sign-on-mac.js
@@ -1,8 +1,15 @@
 const downloadFileFromGithub = require('./download-file-from-github');
+const CONFIG = require('../config');
 const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');
 const spawnSync = require('./spawn-sync');
+const macEntitlementsPath = path.join(
+  CONFIG.repositoryRootPath,
+  'resources',
+  'mac',
+  'atom-Info.plist'
+);
 
 module.exports = function(packagedAppPath) {
   if (
@@ -126,6 +133,10 @@ module.exports = function(packagedAppPath) {
         '--deep',
         '--force',
         '--verbose',
+        '--entitlements',
+        macEntitlementsPath,
+        '--options',
+        'runtime',
         '--keychain',
         process.env.ATOM_MAC_CODE_SIGNING_KEYCHAIN,
         '--sign',

--- a/script/lib/code-sign-on-mac.js
+++ b/script/lib/code-sign-on-mac.js
@@ -8,7 +8,7 @@ const macEntitlementsPath = path.join(
   CONFIG.repositoryRootPath,
   'resources',
   'mac',
-  'atom-Info.plist'
+  'entitlements.plist'
 );
 
 module.exports = function(packagedAppPath) {

--- a/script/lib/notarize-on-mac.js
+++ b/script/lib/notarize-on-mac.js
@@ -1,0 +1,20 @@
+const notarize = require('electron-notarize').notarize;
+
+module.exports = async function(packagedAppPath) {
+  const appBundleId = 'com.github.atom';
+  const appleId = process.env.AC_USER;
+  const appleIdPassword = process.env.AC_PASSWORD;
+
+  console.log(`Notarizing application at ${packagedAppPath}`);
+
+  try {
+    await notarize({
+      appBundleId: appBundleId,
+      appPath: packagedAppPath,
+      appleId: appleId,
+      appleIdPassword: appleIdPassword
+    });
+  } catch (e) {
+    throw new Error(e);
+  }
+};

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -61,6 +61,8 @@ jobs:
           ATOM_MAC_CODE_SIGNING_CERT_PASSWORD: $(ATOM_MAC_CODE_SIGNING_CERT_PASSWORD)
           ATOM_MAC_CODE_SIGNING_KEYCHAIN: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN)
           ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD)
+          AC_USER: $(AC_USER)
+          AC_PASSWORD: $(AC_PASSWORD)
 
       - script: |
           cp $(Build.SourcesDirectory)/out/*.zip $(Build.ArtifactStagingDirectory)

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -9,7 +9,7 @@ jobs:
       IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
       IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
     pool:
-      vmImage: macos-10.14
+      vmImage: macos-10.13
 
     steps:
       - task: NodeTool@0
@@ -97,7 +97,7 @@ jobs:
     dependsOn: macOS_build
     timeoutInMinutes: 180
     pool:
-      vmImage: macos-10.14
+      vmImage: macos-10.13
     strategy:
       maxParallel: 3
       matrix:

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -9,7 +9,7 @@ jobs:
       IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
       IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
     pool:
-      vmImage: macos-10.13
+      vmImage: macos-10.14
 
     steps:
       - task: NodeTool@0
@@ -95,7 +95,7 @@ jobs:
     dependsOn: macOS_build
     timeoutInMinutes: 180
     pool:
-      vmImage: macos-10.13
+      vmImage: macos-10.14
     strategy:
       maxParallel: 3
       matrix:


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Issue or RFC Endorsed by Atom's Maintainers
- https://github.com/atom/atom/issues/20071
- Also Notarization is going to be a hard requirements this year.

### Description of the Change

Enabling codesign in `Hardened Runtime` and adding notarization as part of Atom's build process.

### Alternate Designs

- We could migrate our code signing from cli to electron packager (oxs-sign) and implement the notarization using CLI, if you will call that an alternate design, since it's all doing the exact same thing.


### Possible Drawbacks

NA

### Verification Process

- The notarization didn't throw in the build process (in other words it succeeded).
- All CI tests are green.
- I downloaded the artifact (atom-mac.zip) and checked the codesign and notarization using CLI.
- I didn't get the "can't be open because apple can't check it for malicious software" (check the screenshots for before and after) and I was able to launch the app normally without having to go to the Download location and right-click to open the app.
- I did a smoke test by running the application to make sure basic IO functions work (Open a file, save a file, re-open a file).

Before:
<img width="419" alt="Screen Shot 2020-01-24 at 4 17 26 AM" src="https://user-images.githubusercontent.com/15927737/73073020-689dd200-3e84-11ea-9929-03c31a55639f.png">

After:
<img width="478" alt="Screen Shot 2020-01-24 at 4 30 37 AM" src="https://user-images.githubusercontent.com/15927737/73073028-6cc9ef80-3e84-11ea-9117-9e67240316b0.png">


### Release Notes

NA