### PR TITLE
Skip shell functions when parsing env

### DIFF
--- a/src/update-process-env.js
+++ b/src/update-process-env.js
@@ -121,12 +121,21 @@ async function getEnvFromShell(env) {
   }
 
   let result = {};
+  let skip = false;
   for (let line of stdout.split('\n')) {
-    if (line.includes('=')) {
+    // start of shell function definition: skip full definition
+    if (line.includes('=() {')) {
+      skip = true;
+    }
+    if (!skip && line.includes('=')) {
       let components = line.split('=');
       let key = components.shift();
       let value = components.join('=');
       result[key] = value;
+    }
+    // end of shell function definition
+    if (line === '}') {
+      skip = false;
     }
   }
   return result;


### PR DESCRIPTION
### Identify the Bug

Fixes #20389
Fixes #17369
Fixes #13451
Fixes blueimp/atom-open-terminal-here#27
Fixes blueimp/atom-open-terminal-here#18
Fixes bus-stop/Termination#101
Fixes bus-stop/terminus#24
Fixes platformio/platformio-atom-ide-terminal#120
Fixes platformio/platformio-atom-ide-terminal#293
Fixes AtomLinter/linter-pylint#243
Fixes AtomLinter/linter-flake8#643
Fixes AtomLinter/linter-flake8#165
Fixes AtomLinter/linter-flake8#422
Fixes AtomLinter/linter-puppet-lint#68
Fixes autocomplete-python/autocomplete-python#347

### Description of the Change

With this change `getEnvFromShell` now skips shell function definition to guarantee only environment variables are recorded and a sane `result` array is returned.

### Alternate Designs

Selected design fixes the issue with minimal change. But one may also question the need for `getEnvFromShell` function to execute in an external shell process the `env` command to get defined environment variables.

With this fix, the need for `ATOM_DISABLE_SHELLING_OUT_FOR_ENVIRONMENT` may also be questioned. Also `atom` binary could again be used directly by application link instead of `atom.sh` script.

### Possible Drawbacks

No drawback foreseen.

### Verification Process

Compile change in atom-dev, start terminus extensions: environment is found correctly defined and error messages disappeared.

### Release Notes

Skip shell functions when parsing env
