### PR TITLE
feat: add setting to disable multi cursor on click

### DIFF
--- a/spec/text-editor-component-spec.js
+++ b/spec/text-editor-component-spec.js
@@ -4183,6 +4183,7 @@ describe('TextEditorComponent', () => {
         });
 
         it('adds or removes cursors when holding cmd or ctrl when single-clicking', () => {
+          atom.config.set('core.editor.multiCursorOnClick', true);
           const { component, editor } = buildComponent({ platform: 'darwin' });
           expect(editor.getCursorScreenPositions()).toEqual([[0, 0]]);
 
@@ -4263,6 +4264,7 @@ describe('TextEditorComponent', () => {
         });
 
         it('adds word selections when holding cmd or ctrl when double-clicking', () => {
+          atom.config.set('core.editor.multiCursorOnClick', true);
           const { component, editor } = buildComponent();
           editor.addCursorAtScreenPosition([1, 16], { autoscroll: false });
           expect(editor.getCursorScreenPositions()).toEqual([[0, 0], [1, 16]]);
@@ -4289,6 +4291,7 @@ describe('TextEditorComponent', () => {
         });
 
         it('adds line selections when holding cmd or ctrl when triple-clicking', () => {
+          atom.config.set('core.editor.multiCursorOnClick', true);
           const { component, editor } = buildComponent();
           editor.addCursorAtScreenPosition([1, 16], { autoscroll: false });
           expect(editor.getCursorScreenPositions()).toEqual([[0, 0], [1, 16]]);
@@ -4324,6 +4327,107 @@ describe('TextEditorComponent', () => {
             [[0, 0], [0, 0]],
             [[1, 0], [2, 0]]
           ]);
+          expect(editor.testAutoscrollRequests).toEqual([]);
+        });
+
+        it('does not add cursors when holding cmd or ctrl when single-clicking', () => {
+          atom.config.set('core.editor.multiCursorOnClick', false);
+          const { component, editor } = buildComponent({ platform: 'darwin' });
+          expect(editor.getCursorScreenPositions()).toEqual([[0, 0]]);
+
+          // moves cursor to 1, 16
+          component.didMouseDownOnContent(
+            Object.assign(clientPositionForCharacter(component, 1, 16), {
+              detail: 1,
+              button: 0,
+              metaKey: true
+            })
+          );
+          expect(editor.getCursorScreenPositions()).toEqual([[1, 16]]);
+
+          // ctrl-click does not add cursors on macOS, nor does it move the cursor
+          component.didMouseDownOnContent(
+            Object.assign(clientPositionForCharacter(component, 1, 4), {
+              detail: 1,
+              button: 0,
+              ctrlKey: true
+            })
+          );
+          expect(editor.getSelectedScreenRanges()).toEqual([
+            [[1, 16], [1, 16]]
+          ]);
+
+          // ctrl-click does not add cursors on platforms *other* than macOS
+          component.props.platform = 'win32';
+          editor.setCursorScreenPosition([1, 4], { autoscroll: false });
+          component.didMouseDownOnContent(
+            Object.assign(clientPositionForCharacter(component, 1, 16), {
+              detail: 1,
+              button: 0,
+              ctrlKey: true
+            })
+          );
+          expect(editor.getCursorScreenPositions()).toEqual([[1, 16]]);
+
+          expect(editor.testAutoscrollRequests).toEqual([]);
+        });
+
+        it('does not add word selections when holding cmd or ctrl when double-clicking', () => {
+          atom.config.set('core.editor.multiCursorOnClick', false);
+          const { component, editor } = buildComponent();
+
+          component.didMouseDownOnContent(
+            Object.assign(clientPositionForCharacter(component, 1, 16), {
+              detail: 1,
+              button: 0,
+              metaKey: true
+            })
+          );
+          component.didMouseDownOnContent(
+            Object.assign(clientPositionForCharacter(component, 1, 16), {
+              detail: 2,
+              button: 0,
+              metaKey: true
+            })
+          );
+          expect(editor.getSelectedScreenRanges()).toEqual([
+            [[1, 13], [1, 21]]
+          ]);
+          expect(editor.testAutoscrollRequests).toEqual([]);
+        });
+
+        it('does not add line selections when holding cmd or ctrl when triple-clicking', () => {
+          atom.config.set('core.editor.multiCursorOnClick', false);
+          const { component, editor } = buildComponent();
+
+          const { clientX, clientY } = clientPositionForCharacter(
+            component,
+            1,
+            16
+          );
+          component.didMouseDownOnContent({
+            detail: 1,
+            button: 0,
+            metaKey: true,
+            clientX,
+            clientY
+          });
+          component.didMouseDownOnContent({
+            detail: 2,
+            button: 0,
+            metaKey: true,
+            clientX,
+            clientY
+          });
+          component.didMouseDownOnContent({
+            detail: 3,
+            button: 0,
+            metaKey: true,
+            clientX,
+            clientY
+          });
+
+          expect(editor.getSelectedScreenRanges()).toEqual([[[1, 0], [2, 0]]]);
           expect(editor.testAutoscrollRequests).toEqual([]);
         });
 
@@ -4415,6 +4519,7 @@ describe('TextEditorComponent', () => {
         });
 
         it('expands the last selection on drag', () => {
+          atom.config.set('core.editor.multiCursorOnClick', true);
           const { component, editor } = buildComponent();
           spyOn(component, 'handleMouseDragUntilMouseUp');
 

--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -609,6 +609,12 @@ const configSchema = {
         default: process.platform !== 'darwin',
         description:
           'Change the editor font size when pressing the Ctrl key and scrolling the mouse up/down.'
+      },
+      multiCursorOnClick: {
+        type: 'boolean',
+        default: true,
+        description:
+          'Add multiple cursors when pressing the Ctrl key (Command key on MacOS) and clicking the editor.'
       }
     }
   }

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1991,7 +1991,9 @@ module.exports = class TextEditorComponent {
       return;
     }
 
-    const addOrRemoveSelection = metaKey || (ctrlKey && platform !== 'darwin');
+    const allowMultiCursor = atom.config.get('core.editor.multiCursorOnClick');
+    const addOrRemoveSelection =
+      allowMultiCursor && (metaKey || (ctrlKey && platform !== 'darwin'));
 
     switch (detail) {
       case 1:


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

fixes #7595

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

### Description of the Change

Add editor setting to disable multiple cursors on <kbd>Ctrl</kbd> + click

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks
none
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
tests
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes
Add editor setting to disable multiple cursors on Ctrl + click (Cmd + click on MacOS)
<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->