### PR TITLE
Bump Azure Devops Mac images to version 10.14

### DIFF
--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -9,7 +9,7 @@ jobs:
       IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
       IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
     pool:
-      vmImage: macos-10.13
+      vmImage: macos-10.14
 
     steps:
       - task: NodeTool@0
@@ -95,7 +95,7 @@ jobs:
     dependsOn: macOS_build
     timeoutInMinutes: 180
     pool:
-      vmImage: macos-10.13
+      vmImage: macos-10.14
     strategy:
       maxParallel: 3
       matrix:


### PR DESCRIPTION
Upgrade macos version to 10.14 before Azure DevOps deprecates 10.13

> [On March 23, 2020, we'll be removing the following Azure Pipelines hosted images: macOS X High Sierra 10.13 (macOS-10.13)](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops)