### PR TITLE
Fix typos across atom repo

### DIFF
--- a/docs/rfcs/001-updatable-bundled-packages.md
+++ b/docs/rfcs/001-updatable-bundled-packages.md
@@ -60,7 +60,7 @@ The primary drawback of this approach is that Updatable bundled packages might e
 
 ### Increased Atom startup time
 
-Another major drawback is that the snapshotted code for the bundled package will no longer be used since a newer version has been installed.  This updated version of the package cannot be easily added back into Atom's snapshot so it could cause a noticable drag on Atom's startup time.  Some quick measurements with Timecop show a 10x increase in GitHub package load time for bundled (snapshot) vs updated (non-snapshot) package code:
+Another major drawback is that the snapshotted code for the bundled package will no longer be used since a newer version has been installed.  This updated version of the package cannot be easily added back into Atom's snapshot so it could cause a noticeable drag on Atom's startup time.  Some quick measurements with Timecop show a 10x increase in GitHub package load time for bundled (snapshot) vs updated (non-snapshot) package code:
 
 | GitHub Package Code              | Load Time |
 |----------------------------------|-----------|

--- a/src/grammar-registry.js
+++ b/src/grammar-registry.js
@@ -154,7 +154,7 @@ module.exports = class GrammarRegistry {
   // * `buffer` The {TextBuffer} whose grammar will be set.
   // * `grammar` The desired {Grammar}.
   //
-  // Returns a {Boolean} that indicates whether the assignment was sucessful
+  // Returns a {Boolean} that indicates whether the assignment was successful
   assignGrammar(buffer, grammar) {
     if (!grammar) return false;
     if (buffer.getBuffer) buffer = buffer.getBuffer();
@@ -547,7 +547,7 @@ module.exports = class GrammarRegistry {
   // * `grammarPath` A {String} absolute file path to a grammar file.
   // * `callback` A {Function} to call when loaded with the following arguments:
   //   * `error` An {Error}, may be null.
-  //   * `grammar` A {Grammar} or null if an error occured.
+  //   * `grammar` A {Grammar} or null if an error occurred.
   loadGrammar(grammarPath, callback) {
     this.readGrammar(grammarPath, (error, grammar) => {
       if (error) return callback(error);
@@ -572,7 +572,7 @@ module.exports = class GrammarRegistry {
   // * `grammarPath` A {String} absolute file path to a grammar file.
   // * `callback` A {Function} to call when read with the following arguments:
   //   * `error` An {Error}, may be null.
-  //   * `grammar` A {Grammar} or null if an error occured.
+  //   * `grammar` A {Grammar} or null if an error occurred.
   //
   // Returns undefined.
   readGrammar(grammarPath, callback) {

--- a/src/ripgrep-directory-searcher.js
+++ b/src/ripgrep-directory-searcher.js
@@ -129,7 +129,7 @@ function processUnicodeMatch(match) {
 
 // This function processes a ripgrep submatch to create the correct
 // range. This is mostly needed for multi-line results, since the range
-// will have differnt start and end rows and we need to calculate these
+// will have different start and end rows and we need to calculate these
 // based on the lines that ripgrep returns.
 function processSubmatch(submatch, lineText, offsetRow) {
   const lineParts = lineText.split('\n');

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1865,7 +1865,7 @@ module.exports = class TextEditorComponent {
   // keydown(code: X), keypress, keydown(code: X)
   //
   // The code X must be the same in the keydown events that bracket the
-  // keypress, meaning we're *holding* the _same_ key we intially pressed.
+  // keypress, meaning we're *holding* the _same_ key we initially pressed.
   // Got that?
   didKeydown(event) {
     // Stop dragging when user interacts with the keyboard. This prevents

--- a/src/text-editor.js
+++ b/src/text-editor.js
@@ -2596,7 +2596,7 @@ module.exports = class TextEditor {
   // * __cursor__: Render a cursor at the head of the {DisplayMarker}. If multiple cursor decorations
   //     are created for the same marker, their class strings and style objects are combined
   //     into a single cursor. This decoration type may be used to style existing cursors
-  //     by passing in their markers or to render artificial cursors that don't actaully
+  //     by passing in their markers or to render artificial cursors that don't actually
   //     exist in the model by passing a marker that isn't associated with a real cursor.
   //
   // ## Arguments

--- a/src/uri-handler-registry.js
+++ b/src/uri-handler-registry.js
@@ -27,7 +27,7 @@ const { Emitter, Disposable } = require('event-kit');
 // is triggered. If you need your package to activate right away, you can add
 // `"deferActivation": false` to your "uriHandler" configuration object. When activation
 // is deferred, once Atom receives a request for a URI in your package's namespace, it will
-// activate your pacakge and then call `methodName` on it as before.
+// activate your package and then call `methodName` on it as before.
 //
 // If your package specifies a deprecated `urlMain` property, you cannot register URI handlers
 // via the `uriHandler` key.


### PR DESCRIPTION
**Fix Typos across atom Repo**

```
atom/docs/rfcs/001-updatable-bundled-packages.md:63:247: "noticable" is a misspelling of "noticeable"
atom/src/grammar-registry.js:157:67: "sucessful" is a misspelling of "successful"
atom/src/grammar-registry.js:550:51: "occured" is a misspelling of "occurred"
atom/src/grammar-registry.js:575:51: "occured" is a misspelling of "occurred"
atom/src/ripgrep-directory-searcher.js:132:13: "differnt" is a misspelling of "different"
atom/src/text-editor-component.js:1868:57: "intially" is a misspelling of "initially"
atom/src/text-editor.js:2599:80: "actaully" is a misspelling of "actually"
atom/src/uri-handler-registry.js:30:17: "pacakge" is a misspelling of "package"
```

-----
[View rendered docs/rfcs/001-updatable-bundled-packages.md](https://github.com/yohix/atom/blob/fix-typos/docs/rfcs/001-updatable-bundled-packages.md)