### PR TITLE
Line ending selector update

### DIFF
--- a/packages/line-ending-selector/lib/selector.js
+++ b/packages/line-ending-selector/lib/selector.js
@@ -8,6 +8,7 @@ import { setLineEnding } from './main';
 export class Selector {
   lineEndingListView;
   modalPanel;
+  previousActivePane;
 
   // Make a selector object (should be called once)
   constructor(selectorItems) {
@@ -34,12 +35,12 @@ export class Selector {
         if (editor instanceof TextEditor) {
         setLineEnding(editor, lineEnding.value);
         }
-        this.modalPanel.hide();
+        this.hide();
     },
 
     // called when the user presses Esc or the list loses focus. // use `=>` for `this`
     didCancelSelection: () => {
-        this.modalPanel.hide();
+        this.hide();
     }
     });
 
@@ -51,9 +52,20 @@ export class Selector {
 
   // Show a selector object
   show() {
+    this.previousActivePane = atom.workspace.getActivePane();
+
+    // Show selector
     this.lineEndingListView.reset();
     this.modalPanel.show();
     this.lineEndingListView.focus();
+  }
+
+  // Hide a selector
+  hide() {
+    // hide modal panel
+    this.modalPanel.hide();
+    // focus on the previous active pane
+    this.previousActivePane.activate();
   }
 
   // Dispose selector

--- a/packages/line-ending-selector/lib/selector.js
+++ b/packages/line-ending-selector/lib/selector.js
@@ -11,46 +11,42 @@ export class Selector {
 
   // Make a selector object (should be called once)
   constructor(selectorItems) {
-    if (!this.modalPanel) {
-      // Defining a SelectListView with methods - https://github.com/atom/atom-select-list
-      this.lineEndingListView = new SelectListView({
-        // an array containing the objects you want to show in the select list
-        items: selectorItems,
+    // Defining a SelectListView with methods - https://github.com/atom/atom-select-list
+    this.lineEndingListView = new SelectListView({
+    // an array containing the objects you want to show in the select list
+    items: selectorItems,
 
-        // called whenever an item needs to be displayed.
-        elementForItem: lineEnding => {
-          const element = document.createElement('li');
-          element.textContent = lineEnding.name;
-          return element;
-        },
+    // called whenever an item needs to be displayed.
+    elementForItem: lineEnding => {
+        const element = document.createElement('li');
+        element.textContent = lineEnding.name;
+        return element;
+    },
 
-        // called to retrieve a string property on each item and that will be used to filter them.
-        filterKeyForItem: lineEnding => {
-          return lineEnding.name;
-        },
+    // called to retrieve a string property on each item and that will be used to filter them.
+    filterKeyForItem: lineEnding => {
+        return lineEnding.name;
+    },
 
-        // called when the user clicks or presses Enter on an item. // use `=>` for `this`
-        didConfirmSelection: lineEnding => {
-          const editor = atom.workspace.getActiveTextEditor();
-          if (editor instanceof TextEditor) {
-            setLineEnding(editor, lineEnding.value);
-          }
-          this.modalPanel.hide();
-        },
-
-        // called when the user presses Esc or the list loses focus. // use `=>` for `this`
-        didCancelSelection: () => {
-          this.modalPanel.hide();
+    // called when the user clicks or presses Enter on an item. // use `=>` for `this`
+    didConfirmSelection: lineEnding => {
+        const editor = atom.workspace.getActiveTextEditor();
+        if (editor instanceof TextEditor) {
+        setLineEnding(editor, lineEnding.value);
         }
-      });
+        this.modalPanel.hide();
+    },
 
-      // Adding SelectListView to panel
-      this.modalPanel = atom.workspace.addModalPanel({
-        item: this.lineEndingListView
-      });
-    } else {
-      atom.notifications.addError('First dispose() the Selector object');
+    // called when the user presses Esc or the list loses focus. // use `=>` for `this`
+    didCancelSelection: () => {
+        this.modalPanel.hide();
     }
+    });
+
+    // Adding SelectListView to panel
+    this.modalPanel = atom.workspace.addModalPanel({
+    item: this.lineEndingListView
+    });
   }
 
   // Show a selector object

--- a/packages/line-ending-selector/lib/selector.js
+++ b/packages/line-ending-selector/lib/selector.js
@@ -1,0 +1,69 @@
+'use babel';
+
+import SelectListView from 'atom-select-list';
+
+import { TextEditor } from 'atom';
+import { setLineEnding } from './main';
+
+export class Selector {
+  lineEndingListView;
+  modalPanel;
+
+  // Make a selector object (should be called once)
+  constructor(selectorItems) {
+    if (!this.modalPanel) {
+      // Defining a SelectListView with methods - https://github.com/atom/atom-select-list
+      this.lineEndingListView = new SelectListView({
+        // an array containing the objects you want to show in the select list
+        items: selectorItems,
+
+        // called whenever an item needs to be displayed.
+        elementForItem: lineEnding => {
+          const element = document.createElement('li');
+          element.textContent = lineEnding.name;
+          return element;
+        },
+
+        // called to retrieve a string property on each item and that will be used to filter them.
+        filterKeyForItem: lineEnding => {
+          return lineEnding.name;
+        },
+
+        // called when the user clicks or presses Enter on an item. // use `=>` for `this`
+        didConfirmSelection: lineEnding => {
+          const editor = atom.workspace.getActiveTextEditor();
+          if (editor instanceof TextEditor) {
+            setLineEnding(editor, lineEnding.value);
+          }
+          this.modalPanel.hide();
+        },
+
+        // called when the user presses Esc or the list loses focus. // use `=>` for `this`
+        didCancelSelection: () => {
+          this.modalPanel.hide();
+        }
+      });
+
+      // Adding SelectListView to panel
+      this.modalPanel = atom.workspace.addModalPanel({
+        item: this.lineEndingListView
+      });
+    } else {
+      atom.notifications.addError('First dispose() the Selector object');
+    }
+  }
+
+  // Show a selector object
+  show() {
+    this.lineEndingListView.reset();
+    this.modalPanel.show();
+    this.lineEndingListView.focus();
+  }
+
+  // Dispose selector
+  dispose() {
+    this.lineEndingListView.destroy();
+    this.modalPanel.destroy();
+    this.modalPanel = null;
+  }
+}

--- a/packages/line-ending-selector/lib/selector.js
+++ b/packages/line-ending-selector/lib/selector.js
@@ -14,39 +14,39 @@ export class Selector {
   constructor(selectorItems) {
     // Defining a SelectListView with methods - https://github.com/atom/atom-select-list
     this.lineEndingListView = new SelectListView({
-    // an array containing the objects you want to show in the select list
-    items: selectorItems,
+      // an array containing the objects you want to show in the select list
+      items: selectorItems,
 
-    // called whenever an item needs to be displayed.
-    elementForItem: lineEnding => {
+      // called whenever an item needs to be displayed.
+      elementForItem: lineEnding => {
         const element = document.createElement('li');
         element.textContent = lineEnding.name;
         return element;
-    },
+      },
 
-    // called to retrieve a string property on each item and that will be used to filter them.
-    filterKeyForItem: lineEnding => {
+      // called to retrieve a string property on each item and that will be used to filter them.
+      filterKeyForItem: lineEnding => {
         return lineEnding.name;
-    },
+      },
 
-    // called when the user clicks or presses Enter on an item. // use `=>` for `this`
-    didConfirmSelection: lineEnding => {
+      // called when the user clicks or presses Enter on an item. // use `=>` for `this`
+      didConfirmSelection: lineEnding => {
         const editor = atom.workspace.getActiveTextEditor();
         if (editor instanceof TextEditor) {
-        setLineEnding(editor, lineEnding.value);
+          setLineEnding(editor, lineEnding.value);
         }
         this.hide();
-    },
+      },
 
-    // called when the user presses Esc or the list loses focus. // use `=>` for `this`
-    didCancelSelection: () => {
+      // called when the user presses Esc or the list loses focus. // use `=>` for `this`
+      didCancelSelection: () => {
         this.hide();
-    }
+      }
     });
 
     // Adding SelectListView to panel
     this.modalPanel = atom.workspace.addModalPanel({
-    item: this.lineEndingListView
+      item: this.lineEndingListView
     });
   }
 


### PR DESCRIPTION
## Description of the Change

- Defining a Selector class with `constructor`, `show`, and `dispose` method.
- `constructor`: this class is only initiated once inside the activate function (delayed until `line-ending-selector:show` is called), and so this improves the loading time of the package.
- `show`: A method `show` is defined for the class which is called every time `line-ending-selector:show` is called. 
- the run time of the package is improved by separating the initiation (`constructor`) part from runtime (`show`). In the previous design, the initiation and show parts were called every time.

### Possible Drawbacks

### Verification Process
- Tests pass without touching their code
- Exact code was tested inside another package [Atom-indent-detective](https://github.com/JunoLab/atom-indent-detective/pull/17)
- Quite similar code is now used inside [grammar-list-view](https://github.com/atom/atom/blob/master/packages/grammar-selector/lib/grammar-list-view.js)

### Applicable Issues

### Release Notes

- Improving line-ending-selector performance (loading time and run time)
- Making code modular by introducing Selector class
