### PR TITLE
Use UI variables on container

### DIFF
--- a/packages/incompatible-packages/styles/incompatible-packages.less
+++ b/packages/incompatible-packages/styles/incompatible-packages.less
@@ -8,8 +8,8 @@
     padding: 15px;
     margin-bottom: 10px;
     border-radius: 6px;
-    border: 1px solid #d1d1d2;
-    background-color: #fafafa;
+    border: 1px solid @base-border-color;
+    background-color: lighten(@tool-panel-background-color, 8%);
     overflow: hidden;
 
     .badge {


### PR DESCRIPTION
### Identify the Bug

https://github.com/atom/atom/issues/20545

### Description of the Change

The `.incompatible-package` container looks quite awkward in dark themes, this PR adjusts its look to match that of the `settings-view` containers ([for reference](https://github.com/atom/settings-view/blob/b6b27e949d6b59ada88a7e7ae34d2b3c0b5feee4/styles/package-card.less#L15-L16)).

### Possible Drawbacks

I don't believe there are any drawbacks

### Verification Process

The changes only apply to the scope of the `incompatible-packages` view

### Release Notes

This PR streamlines the `incompatible-packages` view with the rest of the Atom UI