### PR TITLE
Await configuration loading on Windows

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -319,6 +319,7 @@ module.exports = class AtomApplication extends EventEmitter {
           this.promptForRestart()
         );
       });
+      
       await this.configFilePromise;
     }
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -319,7 +319,6 @@ module.exports = class AtomApplication extends EventEmitter {
           this.promptForRestart()
         );
       });
-      
       await this.configFilePromise;
     }
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -319,7 +319,6 @@ module.exports = class AtomApplication extends EventEmitter {
           this.promptForRestart()
         );
       });
-
       await this.configFilePromise;
     }
 

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -320,11 +320,7 @@ module.exports = class AtomApplication extends EventEmitter {
         );
       });
 
-      // TodoElectronIssue: In electron v2 awaiting the watcher causes some delay
-      // in Windows machines, which affects directly the startup time.
-      if (process.platform !== 'win32') {
-        await this.configFilePromise;
-      }
+      await this.configFilePromise;
     }
 
     let optionsForWindowsToOpen = [];


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

Hopefully fixes:
- https://github.com/atom/atom/issues/20268
- https://github.com/atom/atom/issues/20449
- https://github.com/atom/atom/issues/19716

### Description of the Change

Atom awaits for the configuration file to load before determining startup operations and then launching the electron window(s). This behavior was default for all OSs except for Windows, due to a slowdown that an old Electron version had when awaiting the config file promise to resolve, which directly impacted the window load time. I could not reproduce said slowdown after removing the OS check and always awaiting for the config file promise to resolve.

### Alternate Designs

\-

### Possible Drawbacks

In all of my tests there wasn't any additional delay in startup time after applying this patch. Nonetheless, more users should test to verify this fix does not introduce issues during startup.

### Verification Process

I followed the performance profiling procedure as described [here](https://flight-manual.atom.io/hacking-atom/sections/debugging/#profiling-startup-performance). Additionally, I examined outputs of the Timecop package before and after applying this fix. There was no additional delay.
I also manually performed several different tests to validate the fix is working, including but not limited to:
- Opening Atom by using a shortcut and no project folder supplied, or launching `atom-dev` from command line:
  - Atom consistently opened a completely empty window if "Restore Previous Windows On Start" was set to *no* and "Open Empty Editor On Start" was *disabled*.
  - Atom consistently opened an empty editor if "Restore Previous Windows On Start" was set to *no* and "Open Empty Editor On Start" was *enabled*.
- Launching atom from an explorer folder's context menu:
  - Atom consistently opened the selected folder as a project, with no untitled editor.

In essence, Atom behaved *exactly* as described in this pull request: 
 https://github.com/atom/atom/pull/19169#issue-271036417

The tests already defined on the [specs folder](https://github.com/atom/atom/blob/0b34be796312a94331acbc4602944cfe3666c76a/spec/main-process/atom-application.test.js) should cover the launching behavior.

### Release Notes

Fix an issue where a new editor window would not consistently follow the startup configuration on Windows.