### PR TITLE
Deb packaging: Support Python 3, move "python" to "Recommends:"

### DIFF
--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,7 +1,7 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python | python2, gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4, policykit-1
-Recommends: lsb-release
+Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4, policykit-1
+Recommends: lsb-release, python
 Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
 Section: devel
 Priority: optional

--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,7 +1,7 @@
 Package: <%= appFileName %>
 Version: <%= version %>
 Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4, policykit-1
-Recommends: lsb-release, python
+Recommends: lsb-release, python3 (>= 3.5) | python2 (>= 2.7) | python
 Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
 Section: devel
 Priority: optional


### PR DESCRIPTION
### Brief Summary

Makes python an optional dependency (but still installed by default). Edit to add: Now depends on any of `python3 (>= 3.5) | python2 (>= 2.7) | python` to support both Python 2 and Python 3.

One can do `apt install atom --no-install-recommends` to skip installing `python`, if they want. If the `python`/`python2` packages aren't available (as is expected for the next upcoming Debian/Ubuntu releases), this PR will let the user install Atom.

### Identify the Bug

Follow-up to #20356 and #20406 after doing some more research. 

### Description of the Change

Move Python dependency from the `Depends:` field (meaning a hard dependency) to the `Recommends:` field (making it an optional dependency).

<details><summary>More about Recommends: in .deb packages (click to expand)</summary>

The default [behavior of `Recommends:` in a `.deb` package](https://www.debian.org/doc/debian-policy/ch-relationships.html#binary-dependencies-depends-recommends-suggests-enhances-pre-depends) is to install the Recommended packages along with any Required packages. However, when a Recommended package is **not available** in the package repositories, or the user specifies [**`--no-install-recommends`**](http://manpages.ubuntu.com/manpages/focal/en/man8/apt-get.8.html#options), `atom` will still be installed, and a little message shows that another package had been Recommended but isn't going to be installed. Example apt output:

```
$ sudo apt install atom --no-install-recommends
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Suggested packages:
  gir1.2-gnomekeyring-1.0
Recommended packages:
  python
The following NEW packages will be installed:
  atom
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
[...]
```
_[End of expanded info.]_

</details>

#### Thoughts on why this is a good approach

Making Python an optional dependency for Atom seems okay to me, because Atom actually works without any Python installed on the end-user's computer. We only need `python` in limited circumstances. (Specifically: The current release of [`apm`](https://github.com/atom/apm) needs Python 2 to compile/install certain Atom packages containing native C or C++ code. See: https://github.com/atom/atom/pull/20406#issuecomment-616162951. This is a small minority of Atom packages.)

Furthermore, the Fedora, Windows and macOS packaging of Atom do not include a Python requirement to install or run Atom. Loosening the python dependency would be in line with the packaging for those operating systems.

We won't be able to install Python 2 in upcoming Debian/Ubuntu releases. The tentative plan for Debian Bullseye and Ubuntu 20.10 is to not offer Python 2 in the package repos. (So having less than a hard dependency (if any) on Python 2 is desirable for continued installability in those upcoming distros.)

~~_This is intended to be a "best solution available" to keep Atom installable on newer Debian/Ubuntu distributions, at least until the better solution (compatibility with both Python 2 and 3) can be merged at `apm`: https://github.com/atom/apm/pull/875_~~

Edit: Python 3 support has been added! See #20703 and https://github.com/atom/apm/pull/887.

### Alternate Designs

Various degrees along the spectrum of requiring Python... from hard-requiring `python`, to dropping `python` entirely:

- Use `Requires: python`
  - (makes Python a hard dependency. Overkill IMO, based on how rarely Python is actually used by Atom. Also, brittle with respect to future Debian/Ubuntu Releases that don't plan to ship any form of Python 2.)
- _Use `Recommends: python`_
  - _(This is the proposal in the PR right now. Installs `python` by default, if available, but `python` is still entirely optional. Can be deliberately skipped with `apt install --no-install-recommends` if the user wants.)_
- Use `Suggests: python`
  - (This doesn't install `python` by default; It simply shows a message "Suggested packages: python". Users can install with `apt install atom --install-suggests`, if they want. I just found out about that flag today, so I reckon most don't know how to install the suggested packages like that. Unclear what value this would have for end-users IMO. Effectively almost the same as dropping Python altogether. Pro: Hints to the user they might want Python. Con: Most people probably don't read the message?)
- Don't specify a Python dependency at all.
  - (Seems like a missed opportunity to let the user know they might want Python. But would be in line with packaging for other OSes.)

### Possible Drawbacks

This is a fairly low-stakes topic. Atom rarely uses Python. Only when installing an Atom package with native code to be compiled with `node-gyp`. See: https://github.com/atom/atom/pull/20406#issuecomment-616162951. Any of the four approaches above would be acceptable, but I think this is the better choice among them.

_(The implementation in #20406 was somewhat flawed, because `apm` can't detect Python from the `python2` package without the symlink `/usr/bin/python` --> `/usr/bin/python2`, which can be had in the `python-is-python2` package in Ubuntu 20.04... which is the package that "Provides" the `python` package in Ubuntu 20.04. As it turned out, #20406 was unnecessary, and this PR is designed to be a better approach than was taken in that PR, having had the benefit of more research.)_

### Verification Process

I built Atom on this PR's branch, following the instructions here: https://flight-manual.atom.io/hacking-atom/sections/hacking-on-atom-core/ ... and tested installing with/without the `--no-install-recommends` flag.

#### More Verification Process

For initial investigation, I needed quicker iteration, so I repackaged the stable Atom 1.45.0 `.deb` package using the method described here: https://github.com/atom/atom/issues/20356#issuecomment-603762624

I added `python` and a fake package I knew wasn't in the repos ("`marcopolo`") to the `Recommends:` field of `debian/control.in` to observe `apt install`'s behavior. I can confirm that `--no-install-recommends` skips installing `python` and "`marcopolo`". And I can confirm that if I try to install Atom, the fake `marcopolo` package shows in a message like so:

```
Recommended packages:
  marcopolo
```

This is only an advisory message, and I can still install Atom despite the fact that the Recommended package `marcopolo` doesn't exist. This simulates the `python` package not being available in the package repos (`python` "not existing") in upcoming Debian and Ubuntu releases.

As such, this PR should be forward-compatible with the upcoming Debian/Ubuntu.

### Release Notes

Not applicable

(This whole saga turned out to not be a user-facing issue, yet, in stable releases of Atom on stable releases of Ubuntu/Debian.)