### PR TITLE
Review/finalize Python approach for mid 2020

### DIFF
--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4, policykit-1
+Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4, policykit-1
 Recommends: lsb-release
 Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
 Section: devel

--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python | python2, gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4, policykit-1
+Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), python, gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4, policykit-1
 Recommends: lsb-release
 Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
 Section: devel


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

Addresses most of #20585

_(Some small additional things are left to do, in order to adjust the repo for Python 3. See: https://github.com/atom/atom/issues/20585#issuecomment-628180838 for details.)_

The following PR was rolled into this PR, so it should be automatically closed if this is merged:

Closes #20670

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

This was a multi-part fix. Some of it has already been merged. This PR exists to review/finalize the approach taken. The goal is to ensure the Atom project supports Python 3, and can keep operating entirely without needing Python 2. That said, the approach taken here does maintain full backward compatibility with Python 2.

- #20703 already pulled in `apm` with newer `node-gyp` that supports Python 2 AND Python 3.
  - `node-gyp` is the only reason end users would need Python in order to use Atom/apm. It builds Atom packages that include native c/c++ code. `gyp` is written in Python, so running `node-gyp` requires a Python interpreter on the system.
- #20711 already updated `npm` (and its dependency `node-gyp`) in the `script/` directory, to ensure Atom itself can be BUILT with either Python 2 or Python 3.
  - As mentioned before, this is fully backward-compatible; Atom can still be built using Python 2, no problem. The built Atom packages should be the same, regardless. This is about being able to build Atom after Python 2 becomes fully deprecated and developers update their machines to only having Python 3.
- Commit https://github.com/atom/atom/pull/20716/commits/9b9547344f80c96b61c6ea8036c24478e208bd61 drops the `python` dependency from the Debian/Ubuntu `.deb` package.
  - As discussed in the comments of #20670 
- Commit https://github.com/atom/atom/pull/20716/commits/e8b470cc79c2bda71d14816c5ccc0d8f0523ff47 reverts #20406, which as it turns out took a misinformed approach.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

The main, most-important thing that was accomplished with regard to Python and Atom, was updating to a newer version of `node-gyp` which supports both Python 3 and Python 2.

See: #20703 and https://github.com/atom/apm/pull/887 for the implementation.

As far as I am concerned, and as far as I can tell, that part is not a controversial change, as there is no obvious downside, and as such there is no proposed alternate design for that part.

---

Everything else is at least an order of magnitude less important, IMO.

The subjective parts left to decide on are:

- Have a python dependency in the `.deb` file?
  - This is different from the packaging for all other supported OSes, i.e. Fedora, macOS and Windows. It dates back to https://github.com/atom/atom/pull/3599.
  - If keeping a Python dependency in the `.deb` file, it should by Python 3 aware, i.e. `python3 | python2 | python`. (versionless `python` should be last, as the versionless `python` package is being deprecated in upstream Debian/Ubuntu.)
  - If keeping a Python dependency in the `.deb` file, should it be `Depends:` (hard requirement), `Recommends:` (optional but installed by defatult), or `Suggests:` (optional, not installed by default)?
  - Prior discussion is in the comments of #20670

### Possible Drawbacks

For the core change, updating `npm` and `node-gyp`, there are no drawbacks that I am aware of, whatsoever. This is a minor version bump of `npm`, and a well-tested major version bump of `node-gyp` that has been working well so far in `apm`. The new version of `node-gyp` is included in the latest upstream releases of `npm`, so is likely to see wide usage, testing and attention for any bugs.

`apm` 2.5.0 also bundles newer Node 10.20.1, a minor version bump over Node 10.2.1. Again, this is a minor version bump of highly-used/tested upstream Node.js. Bugs or issues in the latest v10 Long-Term-Service version of Node are not expected, and in fact could reasonably be expected to include fixes for miscellaneous bugs.

---

As for the subjective situation with the `.deb` packaging, every available approach is somewhat arbitrary.

Users don't strictly need Python in order to use Atom/apm, unless they install one of a handful of Atom packages that include native code. See: https://github.com/atom/atom/pull/20406#issuecomment-616162951 for an investigation into this.

Putting Python in the `.deb` package's dependencies would purport to make sure everyone is prepared to install that handful of packages. (Conversely, removing the python dependency might be considered a "breaking change" for users of that handful of packages. But only in the rare circumstances where a user has no Python installed, which as far as I know is not possible on Debian/Ubuntu under a graphical desktop environment; Various Debian/Ubuntu desktop components depend on one version or other of Python. It's only possible to not have Python installed on headless server/docker variants of Debian/Ubuntu, I think.)

Furthermore: Other than the `.deb` package, no other official Atom package has Python as an install-time dependency. Atom users on other OSes have apparently been okay all this time without an install-time dependency on Python.

`node-gyp` has additional requirements that currently are NOT specified as install-time dependencies in any platform's packaging, particularly `make`, `cc`/`gcc` and `c++`/`g++`. So users without those installed need to read the `node-gyp` error messages they encounter, and understand the message well enough to realize that they must install a C compiler and a  C++ compiler to their system.

As such, the Python dependency in the `.deb` file is not sufficient on its own to ensure Atom users can successfully build packages with `node-gyp`.

Admittedly, using the `python3 | python2 | python` dependency logic would work on all Debian/Ubuntu releases past and for the foreseeable future. But the question remains: Why go out of our way to ensure the user has Python when few users will need it, and the users who need it must also manually install certain dependencies like `gcc` and `g++`?

By the way, users of currently supported desktop-oriented builds of Debian/Ubuntu will have both Python 2 AND Python 3 installed, by default. Only minimal/headless server/Docker images of Debian/Ubuntu are at all likely to have neither Python 2 nor Python 3 installed.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Manually built `apm` and `atom` with every variation of these changes discussed. Checked whether the built atom `.deb` file could be installed on various distros. Checked whether the resulting `apm` command works, e.g. by running `apm install tree-view`. Saw that CI passes.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A

(Not user-facing? But this could work: "- Atom no longer requires Python in order to install on Debian/Ubuntu." "- Atom and apm now support Python 3.")