### PR TITLE
Use HTML native preventScroll for textEditorComponent focus

### DIFF
--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1698,12 +1698,6 @@ module.exports = class TextEditorComponent {
   }
 
   didFocusHiddenInput() {
-    // Focusing the hidden input when it is off-screen causes the browser to
-    // scroll it into view. Since we use synthetic scrolling this behavior
-    // causes all the lines to disappear so we counteract it by always setting
-    // the scroll position to 0.
-    this.refs.scrollContainer.scrollTop = 0;
-    this.refs.scrollContainer.scrollLeft = 0;
     if (!this.focused) {
       this.focused = true;
       this.startCursorBlinking();

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -1673,7 +1673,7 @@ module.exports = class TextEditorComponent {
       this.scheduleUpdate();
     }
 
-    this.getHiddenInput().focus();
+    this.getHiddenInput().focus({preventScroll:true});
   }
 
   // Called by TextEditorElement so that this function is always the first
@@ -1932,7 +1932,7 @@ module.exports = class TextEditorComponent {
         // Disabling the hidden input makes it lose focus as well, so we have to
         // re-enable and re-focus it.
         this.getHiddenInput().disabled = false;
-        this.getHiddenInput().focus();
+        this.getHiddenInput().focus({preventScroll:true});
       });
       return;
     }


### PR DESCRIPTION
With newer HTML event changes we no longer have to use a workaround to correct the scrolling caused by focusing the hidden input.

## Previous behaviour

Before this change if the text editor was inside a scrollable container with non-zero scrollLeft and the user had scrolled the text editor to the right, clicking on a blank line (where the cursor is outside the Electron viewport) would cause the outer scrollable container to move while the actual cursor in the text editor remains hidden (outside the textEditorComponent viewport).

## New behaviour

I believe Using `preventScroll` aligns with the original intention of the code and doesn't need the workaround to reset the scroll position. It also resolves the undesirable behaviour of scrolling a non-visible hiddenInput into view even if it's outside the element viewport.

## Notes

There might be other cases where using `preventScroll` in a `focus()` call is desirable, but this is the only one that I found had a direct negative effect in my use case.
