### PR TITLE
Faster atom.packages.getAvailablePackages

### DIFF
--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -424,8 +424,7 @@ module.exports = class PackageManager {
           const packageName = path.basename(packagePath);
           if (
             !packageName.startsWith('.') &&
-            !packagesByName.has(packageName) &&
-            fs.isDirectorySync(packagePath)
+            !packagesByName.has(packageName)
           ) {
             packages.push({
               name: packageName,

--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -419,12 +419,12 @@ module.exports = class PackageManager {
 
     for (const packageDirPath of this.packageDirPaths) {
       if (fs.isDirectorySync(packageDirPath)) {
-        const packagePaths = fs
+        const packageNames = fs
           .readdirSync(packageDirPath, { withFileTypes: true })
           .filter(dirent => dirent.isDirectory())
           .map(dirent => dirent.name);
 
-        for (const packageName of packagePaths) {
+        for (const packageName of packageNames) {
           if (
             !packageName.startsWith('.') &&
             !packagesByName.has(packageName)

--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -419,10 +419,11 @@ module.exports = class PackageManager {
 
     for (const packageDirPath of this.packageDirPaths) {
       if (fs.isDirectorySync(packageDirPath)) {
-
-        const packagePaths = fs.readdirSync(packageDirPath, { withFileTypes: true })
-        .filter(dirent => dirent.isDirectory())
-        .map(dirent => dirent.name);
+          
+        const packagePaths = fs
+          .readdirSync(packageDirPath, { withFileTypes: true })
+          .filter((dirent) => dirent.isDirectory())
+          .map((dirent) => dirent.name);
 
         for (const packageName of packagePaths) {
           if (
@@ -433,7 +434,7 @@ module.exports = class PackageManager {
             packages.push({
               name: packageName,
               path: packagePath,
-              isBundled: false
+              isBundled: false,
             });
             packagesByName.add(packageName);
           }

--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -419,13 +419,17 @@ module.exports = class PackageManager {
 
     for (const packageDirPath of this.packageDirPaths) {
       if (fs.isDirectorySync(packageDirPath)) {
-        for (let packagePath of fs.readdirSync(packageDirPath)) {
-          packagePath = path.join(packageDirPath, packagePath);
-          const packageName = path.basename(packagePath);
+
+        const packagePaths = fs.readdirSync(packageDirPath, { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory())
+        .map(dirent => dirent.name);
+
+        for (const packageName of packagePaths) {
           if (
             !packageName.startsWith('.') &&
             !packagesByName.has(packageName)
           ) {
+            const packagePath = path.join(packageDirPath, packageName);
             packages.push({
               name: packageName,
               path: packagePath,

--- a/src/package-manager.js
+++ b/src/package-manager.js
@@ -419,11 +419,10 @@ module.exports = class PackageManager {
 
     for (const packageDirPath of this.packageDirPaths) {
       if (fs.isDirectorySync(packageDirPath)) {
-          
         const packagePaths = fs
           .readdirSync(packageDirPath, { withFileTypes: true })
-          .filter((dirent) => dirent.isDirectory())
-          .map((dirent) => dirent.name);
+          .filter(dirent => dirent.isDirectory())
+          .map(dirent => dirent.name);
 
         for (const packageName of packagePaths) {
           if (
@@ -434,7 +433,7 @@ module.exports = class PackageManager {
             packages.push({
               name: packageName,
               path: packagePath,
-              isBundled: false,
+              isBundled: false
             });
             packagesByName.add(packageName);
           }


### PR DESCRIPTION
### Description of the Change

- Removes the unnecessary directory existence check. This path is read from `fs.readdir`, and so we are sure that it exists!

- Increasing the performance of getting the list of all available atom packages

### Quantitative Performance Benefits

For my setup (having 209 packages), it speeds up the command by ~10ms.

### Possible Drawbacks
Nothing I can think of

### Verification Process

 I measured it using this method:
```js
const t1 = window.performance.now()
const packages = atom.packages.getAvailablePackages()
console.log(window.performance.now() - t1)

// to check the result
console.log(packages)
```

Also, by using this change, it decreased the loading time of my package [package-switch](https://github.com/aminya/package-switch) by using this custom command which implements the change: 
https://github.com/aminya/package-switch/blob/003894af9eb31bb279721bb102788194078da086/src/bundles.ts#L90

### Applicable Issues

### Release Notes

- Increasing the performance of getting the list of all available atom packages
