### PR TITLE
Add async and await keywords to Rust highlighter

### DIFF
--- a/packages/language-rust-bundled/grammars/tree-sitter-rust.cson
+++ b/packages/language-rust-bundled/grammars/tree-sitter-rust.cson
@@ -131,6 +131,8 @@ scopes:
   '"where"': 'keyword.control'
   '"ref"': 'keyword.control'
   '"macro_rules!"': 'keyword.control'
+  '"async"': 'keyword.control'
+  '"await"': 'keyword.control'
 
   '"as"': 'keyword.operator'
 


### PR DESCRIPTION
### Identify the Bug

See issue #20905 for more information.

### Description of the Change

This PR adds support for Rust's `async` and `await` keywords to `language-rust-bundled`. These keywords were added to the grammar, marked as `keyword.control`.

### Alternate Designs

Alternatively, one could choose not to highlight these keywords. The main argument that could be made is whether `async` and `await` are actually control flow keywords or function as something else.

### Possible Drawbacks

None that I can think of; if there are any, feel free to comment.

### Verification Process

This is a very simple change. I rebuilt the parser and everything was functional, including the new keywords.

### Release Notes

Rust's async and await keywords are now highlighted.
