### PR TITLE
open file with conflict name test using chai

### DIFF
--- a/spec/test-file-spec.js
+++ b/spec/test-file-spec.js
@@ -1,0 +1,24 @@
+const chai = require('chai')
+const expect = chai.expect
+const fs = require('fs');
+const assert = require('assert');
+
+const file_name = 'test_file.txt'
+const path = `./${file_name}`;
+
+async function get_files(file_path) {
+	return fs.readFile(path, (err, data) => {
+		if (err) throw err;
+		return data;
+	})
+}
+
+describe("Open a file with name conflict with existing folder", () => {
+	it('read files', () => {
+		return get_files(path).then(res => {
+			assert.equal(res, file_name);
+		})
+	})
+});
+
+


### PR DESCRIPTION
- Description:
While opening a file with the name same as the existing directory's name, it will throw an EISDIR error, this PR is about a test suite that check the file is opened properly.

- Additional Notes: 
 **EISDIR** error, an error from '**fs**' package in node.js, specifically means 'try to open a file but the path give is a directory''
This PR is related to issue[#4885](https://github.com/atom/atom/issues/4885)

