### PR TITLE
Fix backslash issue in paths in CI

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,5 +1,7 @@
 jobs:
   - job: GetReleaseVersion
+    pool:
+      vmImage: 'windows-latest'
     steps:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -2,6 +2,8 @@ trigger: none # No CI builds, only PR builds
 
 jobs:
   - job: GetReleaseVersion
+    pool:
+      vmImage: 'windows-latest'
     steps:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -5,6 +5,8 @@ trigger:
 
 jobs:
   - job: GetReleaseVersion
+    pool:
+      vmImage: 'windows-latest'
     steps:
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.


### PR DESCRIPTION
<details><summary>Requirements for Contributing a Bug Fix</summary>

### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

#21020; https://github.com/atom-ide-community/atom/pull/3#issuecomment-653653278

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

Sets the early stage of CI to explicitly run in Windows. This prevents failures due to backslashes "\\" in paths being seen as escape characters in Unix Oses.

Treating backslashes as escape characters turns the path "`script\vsts`" into "`scriptvsts`", an error which is enough to break the CI under Ubuntu/Linux or macOS.

An example of the error this fixes: [`sh: line 1: cd: scriptvsts: No such file or directory`](https://dev.azure.com/DeeDeeG/b/_build/results?buildId=40&view=logs&j=0d2f351d-5899-57e2-0cb5-b37eb91cc930&t=4bcffbf6-507a-564a-0cc4-d6754c0b024f&l=12)

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Replace backslashes with forward-slashes. See an example implementation here: https://github.com/DeeDeeG/atom/commit/fbc37428a847ea0977c9d0050688194720e49453

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

This PR sets the earliest stage of CI to run in "Windows latest", currently Windows Server 2019. (I believe this repo's CI settings have it set manually to Windows Server 2016.) No behavior changes or issues are expected, just wanted to point that out. We can set it to Windows Server 2016 instead if you want.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

This PR made our CI get further than it did before, over at our fork `atom-ide-community:atom`. Specifically, the "GetReleaseVersion" stage was [failing](https://dev.azure.com/atomcommunity/atomcommunity/_build/results?buildId=5&view=logs&j=0d2f351d-5899-57e2-0cb5-b37eb91cc930&t=4bcffbf6-507a-564a-0cc4-d6754c0b024f) before, but now it's [passing](https://dev.azure.com/atomcommunity/atomcommunity/_build/results?buildId=21&view=logs&jobId=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&j=0d2f351d-5899-57e2-0cb5-b37eb91cc930).

If the "GetReleaseVersion" stage of CI passes here for this PR, that would indicate the fix can be integrated to this repo well. Upstreaming this change from our fork makes forking Atom and setting up CI easier for others, with no apparent downsides for this repo.

We want to help Atom remain "the hackable text editor" by upstreaming as many changes as we can that keep Atom going.

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A; this is a developer-facing change, not an end-user facing change.