### PR TITLE
Makes code-sign optional

### DIFF
--- a/script/vsts/get-release-version.js
+++ b/script/vsts/get-release-version.js
@@ -78,6 +78,7 @@ async function getReleaseVersion() {
       buildBranch.startsWith('electron-') ||
       (buildBranch === 'master' &&
         !process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER));
+  const SHOULD_SIGN = process.env.SHOULD_SIGN;
 
   console.log(
     `##vso[task.setvariable variable=AppName;isOutput=true]${getAppName(
@@ -89,6 +90,9 @@ async function getReleaseVersion() {
   );
   console.log(
     `##vso[task.setvariable variable=IsSignedZipBranch;isOutput=true]${isSignedZipBranch}`
+  );
+  console.log(
+    `##vso[task.setvariable variable=SHOULD_SIGN;isOutput=true]${SHOULD_SIGN}`
   );
 }
 

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -47,7 +47,7 @@ jobs:
         displayName: Run linter
 
       - script: |
-          if [ $IS_RELEASE_BRANCH == "true" ] || [ $IS_SIGNED_ZIP_BRANCH == "true" ]; then
+          if [ $SHOULD_SIGN == "true" ] && ([ $IS_RELEASE_BRANCH == "true" ] || [ $IS_SIGNED_ZIP_BRANCH == "true" ]); then
             script/build --no-bootstrap --code-sign --compress-artifacts
           else
             script/build --no-bootstrap --compress-artifacts

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -101,11 +101,19 @@ jobs:
           SET SQUIRREL_TEMP=C:\tmp
           IF [%IS_RELEASE_BRANCH%]==[true] (
             ECHO Creating production artifacts for release branch %BUILD_SOURCEBRANCHNAME%
-            node script\vsts\windows-run.js script\build.cmd --no-bootstrap --code-sign --compress-artifacts --create-windows-installer
+            IF [%SHOULD_SIGN%]==[true] (
+             node script\vsts\windows-run.js script\build.cmd --no-bootstrap --code-sign --compress-artifacts --create-windows-installer
+            ) ELSE (
+             node script\vsts\windows-run.js script\build.cmd --no-bootstrap --compress-artifacts --create-windows-installer
+            )
           ) ELSE (
             IF [%IS_SIGNED_ZIP_BRANCH%]==[true] (
               ECHO Creating signed CI artifacts for branch %BUILD_SOURCEBRANCHNAME%
+             IF [%SHOULD_SIGN%]==[true] (
               node script\vsts\windows-run.js script\build.cmd --no-bootstrap --code-sign --compress-artifacts
+             ) ELSE (
+              node script\vsts\windows-run.js script\build.cmd --no-bootstrap --compress-artifacts
+             )
             ) ELSE (
               ECHO Pull request build, no code signing will be performed
               node script\vsts\windows-run.js script\build.cmd --no-bootstrap --compress-artifacts


### PR DESCRIPTION
### Identify the Bug
Fixes https://github.com/atom-ide-community/atom/issues/8

### Description of the Change

Adds a `SHOULD_SIGN` env variable which allows skipping code signing when you are on the release branch. This allows building Atom without purchasing a code signing certificate. It is meant to facilitate the process of testing atom in the forks (particularly atom-community/atom)

### Alternate Designs

## Possible Drawbacks
Requires setting `SHOULD_SIGN=true` as an environment variable inside Azure.

## Verification Process

## Release Notes
N/A; this is a developer-facing change, not an end-user facing change.

