### PR TITLE
⬆️ electron-osx-sign@0.4.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2831,9 +2831,9 @@
       }
     },
     "electron-osx-sign": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.16.tgz",
-      "integrity": "sha512-ziMWfc3NmQlwnWLW6EaZq8nH2BWVng/atX5GWsGwhexJYpdW6hsg//MkAfRTRx1kR3Veiqkeiog1ibkbA4x0rg==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.17.tgz",
+      "integrity": "sha512-wUJPmZJQCs1zgdlQgeIpRcvrf7M5/COQaOV68Va1J/SgmWx5KL2otgg+fAae7luw6qz9R8Gvu/Qpe9tAOu/3xQ==",
       "requires": {
         "bluebird": "^3.5.0",
         "compare-version": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "dev-live-reload": "file:packages/dev-live-reload",
     "devtron": "1.3.0",
     "electron-notarize": "0.3.0",
-    "electron-osx-sign": "0.4.16",
+    "electron-osx-sign": "0.4.17",
     "encoding-selector": "https://www.atom.io/api/packages/encoding-selector/versions/0.23.9/tarball",
     "etch": "^0.12.6",
     "event-kit": "^2.5.3",


### PR DESCRIPTION
Bumps electron-osx-sign from 0.4.15 to 0.4.17