### PR TITLE
⬆️ mocha-junit-reporter@2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5168,9 +5168,9 @@
       }
     },
     "mocha-junit-reporter": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.23.1.tgz",
-      "integrity": "sha512-qeDvKlZyAH2YJE1vhryvjUQ06t2hcnwwu4k5Ddwn0GQINhgEYFhlGM0DwYCVUHq5cuo32qAW6HDsTHt7zz99Ng==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.0.0.tgz",
+      "integrity": "sha512-20HoWh2HEfhqmigfXOKUhZQyX23JImskc37ZOhIjBKoBEsb+4cAFRJpAVhFpnvsztLklW/gFVzsrobjLwmX4lA==",
       "requires": {
         "debug": "^2.2.0",
         "md5": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "metrics": "https://www.atom.io/api/packages/metrics/versions/1.8.1/tarball",
     "minimatch": "^3.0.3",
     "mocha": "2.5.1",
-    "mocha-junit-reporter": "^1.13.0",
+    "mocha-junit-reporter": "2.0.0",
     "mocha-multi-reporters": "^1.1.4",
     "mock-spawn": "^0.2.6",
     "normalize-package-data": "^2.0.0",


### PR DESCRIPTION
Bumps mocha-junit-reporter from 1.23.1 to 2.0.0