### PR TITLE
Added Keyword `auto`, which might be used with `trait`, and `macro`.

### DIFF
--- a/packages/language-rust-bundled/grammars/tree-sitter-rust.cson
+++ b/packages/language-rust-bundled/grammars/tree-sitter-rust.cson
@@ -114,6 +114,7 @@ scopes:
   '"union"': 'storage.modifier'
   'mutable_specifier': 'storage.modifier'
   '"auto"': 'storage.modifier'
+  '"macro"': 'storage.modifier'
 
   '"unsafe"': 'keyword.control'
   '"use"': 'keyword.control'

--- a/packages/language-rust-bundled/grammars/tree-sitter-rust.cson
+++ b/packages/language-rust-bundled/grammars/tree-sitter-rust.cson
@@ -113,6 +113,7 @@ scopes:
   '"enum"': 'storage.modifier'
   '"union"': 'storage.modifier'
   'mutable_specifier': 'storage.modifier'
+  '"auto"': 'storage.modifier'
 
   '"unsafe"': 'keyword.control'
   '"use"': 'keyword.control'


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix.

### Identify the Bug

Fix for bug https://github.com/atom/atom/issues/21053

### Description of the Change

Added Keyword `auto`, which might be used with `trait`, in  packages/language-rust-bundled/grammars/tree-sitter-rust.cson

### Verification Process

I was unable to test it with my setup, seems NixoOS and node is a bit tricky…anyway, I am pretty sure, this should work, it is quite simple, but it is untested, sorry.

### Release Notes

Added Keyword `auto` for rust, which might be used with `trait`. 
