### PR TITLE
no PR triggers on release builds

### DIFF
--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -2,6 +2,7 @@ trigger:
   - master
   - 1.* # VSTS only supports wildcards at the end
   - electron-*
+pr: none # no PR triggers
 
 jobs:
   - job: GetReleaseVersion


### PR DESCRIPTION
### Identify the Bug
Release branch builds are triggered by making pull requests

### Description of the change
This prevents the release builds to be triggered by a pull request.

### Alternate Designs
Setting the option in Azure UI, but that reduces the reproducibility of the jobs for the forks. Atom should avoid setting the pipeline options in the Azure UI as much as possible because that is hidden from others who do not have access.


### Possible Drawbacks

### Verification Process

### Release Notes
N/A;

Fork PR: https://github.com/atom-ide-community/atom/pull/32