### PR TITLE
Cross-platform CI scripts

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,6 +1,8 @@
 jobs:
-  # Import "GetReleaseVersion" job definition
+  # Import "GetReleaseVersion" job definition, with the "NightlyFlag" parameter set
   - template: platforms/templates/get-release-version.yml
+    parameters:
+      NightlyFlag: --nightly
 
   # Import OS-specific build definitions
   - template: platforms/windows.yml

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -1,16 +1,6 @@
 jobs:
-  - job: GetReleaseVersion
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm install` completes.
-      - script: |
-          cd script/vsts
-          npm install
-        displayName: npm install
-      - script: node script/vsts/get-release-version.js --nightly
-        name: Version
+  # Import "GetReleaseVersion" job definition
+  - template: platforms/templates/get-release-version.yml
 
   # Import OS-specific build definitions
   - template: platforms/windows.yml

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -32,10 +32,7 @@ jobs:
       ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
 
     steps:
-      - task: NodeTool@0
-        inputs:
-          versionSpec: 12.4.0
-        displayName: Install Node.js 12.4.0
+      - template: platforms/templates/preparation.yml
 
        #This has to be done separately because VSTS inexplicably
        #exits the script block after `npm install` completes.
@@ -68,17 +65,9 @@ jobs:
       vmImage: macos-10.14
 
     steps:
-      - task: NodeTool@0
-        inputs:
-          versionSpec: 12.13.1
-        displayName: Install Node.js 12.13.1
+      - template: platforms/templates/preparation.yml
 
-      - script: npm install --global npm@6.12.1
-        displayName: Update npm
-
-      - script: |
-          script/bootstrap
-        displayName: Bootstrap
+      - template: platforms/templates/bootstrap.yml
 
       - script: |
           cd script/lib

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
       - template: platforms/templates/preparation.yml
 
-       #This has to be done separately because VSTS inexplicably
-       #exits the script block after `npm install` completes.
       - script: |
           cd script/vsts
           npm install

--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -5,7 +5,6 @@ jobs:
     variables:
       ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
     pool:
-      # This image is used to host the Docker container that runs the build
       vmImage: ubuntu-16.04
 
     steps:

--- a/script/vsts/platforms/templates/bootstrap.yml
+++ b/script/vsts/platforms/templates/bootstrap.yml
@@ -2,7 +2,7 @@ steps:
   - pwsh: |
       # OS specific env variables
       if ($env:AGENT_OS -eq "Windows_NT") {
-        $env:NPM_BIN_PATH="C:/hostedtoolcache/windows/node/12.16.3/x64/npm.cmd"
+        $env:NPM_BIN_PATH="C:/npm/prefix/npm.cmd"
         $env:npm_config_build_from_source=true
       }
       if ($env:AGENT_OS -eq "Darwin") {

--- a/script/vsts/platforms/templates/get-release-version.yml
+++ b/script/vsts/platforms/templates/get-release-version.yml
@@ -1,0 +1,17 @@
+jobs:
+
+- job: GetReleaseVersion
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+    # This has to be done separately because VSTS inexplicably
+    # exits the script block after `npm ci` completes.
+    - script: |
+        cd script/vsts
+        npm ci
+      displayName: npm ci
+    - script: node script/vsts/get-release-version.js
+      name: Version
+      env:
+        REPO_OWNER: $(REPO_OWNER)
+        NIGHTLY_RELEASE_REPO: $(NIGHTLY_RELEASE_REPO)

--- a/script/vsts/platforms/templates/get-release-version.yml
+++ b/script/vsts/platforms/templates/get-release-version.yml
@@ -14,6 +14,6 @@ jobs:
   steps:
     - script: |
         cd script/vsts
-        npm ci
+        npm install
         node get-release-version.js ${{ parameters.NightlyFlag }}
       name: Version

--- a/script/vsts/platforms/templates/get-release-version.yml
+++ b/script/vsts/platforms/templates/get-release-version.yml
@@ -1,3 +1,11 @@
+parameters:
+  - name: NightlyFlag
+    type: string
+    values:
+      - ' '
+      - --nightly
+    default: ' '
+
 jobs:
 
 - job: GetReleaseVersion
@@ -10,7 +18,7 @@ jobs:
         cd script/vsts
         npm ci
       displayName: npm ci
-    - script: node script/vsts/get-release-version.js
+    - script: node script/vsts/get-release-version.js ${{ parameters.NightlyFlag }}
       name: Version
       env:
         REPO_OWNER: $(REPO_OWNER)

--- a/script/vsts/platforms/templates/get-release-version.yml
+++ b/script/vsts/platforms/templates/get-release-version.yml
@@ -12,14 +12,8 @@ jobs:
   pool:
     vmImage: 'ubuntu-latest'
   steps:
-    # This has to be done separately because VSTS inexplicably
-    # exits the script block after `npm ci` completes.
     - script: |
         cd script/vsts
         npm ci
-      displayName: npm ci
-    - script: node script/vsts/get-release-version.js ${{ parameters.NightlyFlag }}
+        node get-release-version.js ${{ parameters.NightlyFlag }}
       name: Version
-      env:
-        REPO_OWNER: $(REPO_OWNER)
-        NIGHTLY_RELEASE_REPO: $(NIGHTLY_RELEASE_REPO)

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -28,14 +28,6 @@ steps:
   - script: npm install --global npm@6.9.0
     displayName: Update npm
 
-  # Use Azure Syntax to set env variables for all shells and steps
-  - pwsh: |
-      if ($env:AGENT_OS -eq "Windows_NT") {
-        $env:BUILD_ARCH=$env:buildArch
-        echo "##vso[task.setvariable variable=BUILD_ARCH]$env:BUILD_ARCH"
-      }
-    displayName: Setting globally used env variables
-
   # Windows Specific
   - task: UsePythonVersion@0
     inputs:

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -35,18 +35,6 @@ steps:
     condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - script: |
-      ECHO Installing npm-windows-upgrade
-      npm install --global --production npm-windows-upgrade
-    displayName: Install npm-windows-upgrade
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-
-  - script: |
-      ECHO Upgrading npm
-      npm-windows-upgrade --no-spinner --no-prompt --npm-version 6.9.0
-    displayName: Install npm 6.9.0
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-
-  - script: |
       npm install --global --production windows-build-tools@4.0
     displayName: Install windows build tools
     condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -6,9 +6,9 @@ jobs:
       maxParallel: 2
       matrix:
         x64:
-          buildArch: x64
+          BUILD_ARCH: x64
         x86:
-          buildArch: x86
+          BUILD_ARCH: x86
 
     pool:
       vmImage: vs2017-win2016
@@ -30,7 +30,7 @@ jobs:
 
       - script: node script\vsts\windows-run.js script\lint.cmd
         env:
-          BUILD_ARCH: $(buildArch)
+          BUILD_ARCH: $(BUILD_ARCH)
         displayName: Run linter
 
       - template: templates/build.yml
@@ -46,7 +46,7 @@ jobs:
           }
           echo "##vso[task.setvariable variable=FileID]$env:FileID" # Azure syntax
         env:
-          BUILD_ARCH: $(buildArch)
+          BUILD_ARCH: $(BUILD_ARCH)
         displayName: Set FileID based on the arch
 
       - template: templates/publish.yml

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -1,18 +1,8 @@
 trigger: none # No CI builds, only PR builds
 
 jobs:
-  - job: GetReleaseVersion
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm install` completes.
-      - script: |
-          cd script/vsts
-          npm install
-        displayName: npm install
-      - script: node script/vsts/get-release-version.js
-        name: Version
+  # Import "GetReleaseVersion" job definition
+  - template: platforms/templates/get-release-version.yml
 
   # Import OS-specific build definitions
   - template: platforms/windows.yml

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -39,10 +39,7 @@ jobs:
       IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
 
     steps:
-      - task: NodeTool@0
-        inputs:
-          versionSpec: 12.4.0
-        displayName: Install Node.js 12.4.0
+      - template: platforms/templates/preparation.yml
 
       # This has to be done separately because VSTS inexplicably
       # exits the script block after `npm install` completes.

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -31,8 +31,6 @@ jobs:
     steps:
       - template: platforms/templates/preparation.yml
 
-      # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm install` completes.
       - script: |
           cd script/vsts
           npm install

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -5,18 +5,8 @@ trigger:
 pr: none # no PR triggers
 
 jobs:
-  - job: GetReleaseVersion
-    pool:
-      vmImage: 'ubuntu-latest'
-    steps:
-      # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm install` completes.
-      - script: |
-          cd script/vsts
-          npm install
-        displayName: npm install
-      - script: node script/vsts/get-release-version.js
-        name: Version
+  # Import "GetReleaseVersion" job definition
+  - template: platforms/templates/get-release-version.yml
 
   # Import OS-specific build definitions.
   - template: platforms/windows.yml


### PR DESCRIPTION
### Description of the change
- This uses Powershell 7 as a cross-platform shell for CI scripts:
	- PowerShell 7 allows using the same syntax and code across all the operating systems.
	- This simplifies CI scripts. For example, previously CMD was used in Windows, which is an old shell with limited functionality.
	- The old linux_trusty container did not detect pwsh, so we use the Linux image provided by Microsoft, and we use Clang 9 that is provided in it.

- This refactors CI scripts into separate files (templates): 
	- It also allows using parallelization of the tests without copy-pasting the same code. For example: 
		- In macOS, the same templates are reused in the test phase. 
		- In Windows x86, the templates are used for parallelization of tests in [this PR](https://github.com/atom-ide-community/atom/pull/31)

	- This makes it easier to manage CI code. For example, we can quickly compare the publish step for all operating systems without going through big files and trying to find the relevant steps.

Previously, the CI scripts were written back in ~2017. At that time, Azure Templates had not been introduced yet, and because of that using PowerShell was not suitable yet. Now in 2020, we can benefit from these and improve the CI. This is also a requirement for the future Test Parallelization pull request.

### Verification
The CI passes. Tested in atom-ide-community

### Release Notes
N/A

~### Includes~
~This includes #21023.~
~This supersedes #21057.~

~### Thing you should do~
~Because this includes #21023, it requires you to set `SHOULD_SIGN=true` as an environment variable inside Azure.~

### Fork Pull request
https://github.com/atom-ide-community/atom/pull/46