### PR TITLE
use `performance` instead of `Date` for measuring package load time

### DIFF
--- a/src/package.js
+++ b/src/package.js
@@ -4,6 +4,7 @@ const CSON = require('season');
 const fs = require('fs-plus');
 const { Emitter, CompositeDisposable } = require('event-kit');
 const dedent = require('dedent');
+const { performance } = require('perf_hooks');
 
 const CompileCache = require('./compile-cache');
 const ModuleCache = require('./module-cache');
@@ -77,9 +78,9 @@ module.exports = class Package {
   }
 
   measure(key, fn) {
-    const startTime = window.performance.now();
+    const startTime = performance.now();
     const value = fn();
-    this[key] = window.performance.now() - startTime;
+    this[key] = performance.now() - startTime;
     return value;
   }
 

--- a/src/package.js
+++ b/src/package.js
@@ -79,7 +79,7 @@ module.exports = class Package {
   measure(key, fn) {
     const startTime = window.performance.now();
     const value = fn();
-    this[key] = window.performance.now() - startTime;
+    this[key] = Math.round(window.performance.now() - startTime);
     return value;
   }
 

--- a/src/package.js
+++ b/src/package.js
@@ -4,7 +4,6 @@ const CSON = require('season');
 const fs = require('fs-plus');
 const { Emitter, CompositeDisposable } = require('event-kit');
 const dedent = require('dedent');
-const { performance } = require('perf_hooks');
 
 const CompileCache = require('./compile-cache');
 const ModuleCache = require('./module-cache');
@@ -78,9 +77,9 @@ module.exports = class Package {
   }
 
   measure(key, fn) {
-    const startTime = performance.now();
+    const startTime = window.performance.now();
     const value = fn();
-    this[key] = performance.now() - startTime;
+    this[key] = window.performance.now() - startTime;
     return value;
   }
 

--- a/src/package.js
+++ b/src/package.js
@@ -77,9 +77,9 @@ module.exports = class Package {
   }
 
   measure(key, fn) {
-    const startTime = Date.now();
+    const startTime = window.performance.now();
     const value = fn();
-    this[key] = Date.now() - startTime;
+    this[key] = window.performance.now() - startTime;
     return value;
   }
 


### PR DESCRIPTION
### Description of the change

This uses Node's `performance` instead of `Date` for measuring package load time, which is more accurate than `Date.now`.

Reference: 
https://nodejs.org/api/perf_hooks.html#perf_hooks_performance_now
https://developer.mozilla.org/en-US/docs/Web/API/Performance/now

### Verification
The CI passes

### Drawbacks
N/A

### Release Notes
- More accurate measure time in the TimeCope