### PR TITLE
Parallelize Tests in CI (+ Refactor and Improvements)

### DIFF
--- a/script/test
+++ b/script/test
@@ -87,9 +87,11 @@ function spawnTest(executablePath, testArguments, options, callback, testName, f
   const cp = childProcess.spawn(executablePath, testArguments, options)
 
   // collect outputs and errors
-  let stderrOutput = ''
-  cp.stderr.on('data', data => { stderrOutput += data })
-  cp.stdout.on('data', data => { stderrOutput += data })
+	let stderrOutput = ''
+	if (cp.stdout) {
+	  cp.stderr.on('data', data => { stderrOutput += data })
+	  cp.stdout.on('data', data => { stderrOutput += data })
+	}
 
   // on error
   cp.on('error', error => {

--- a/script/test
+++ b/script/test
@@ -194,34 +194,19 @@ function runBenchmarkTests (callback) {
   cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-benchmarks'}) })
 }
 
-let testSuitesToRun = requestedTestSuites() || testSuitesForPlatform(process.platform)
+let testSuitesToRun = requestedTestSuites(process.platform)
 
-function requestedTestSuites () {
-  const suites = []
-  if (argv.coreMain) {
-    suites.push(runCoreMainProcessTests)
-  }
-  if (argv.coreRenderer) {
-    suites.push(...coreRenderProcessTestSuites)
-  }
-  if (argv.coreBenchmark) {
-    suites.push(runBenchmarkTests)
-  }
-  if (argv.package) {
-    suites.push(...packageTestSuites)
-  }
-  return suites.length > 0 ? suites : null
-}
-
-function testSuitesForPlatform (platform) {
-  let suites = []
-  // Env variable options
-  let coreMain = process.env.ATOM_RUN_CORE_MAIN_TESTS === 'true'
+function requestedTestSuites (platform) {
+  // env variable or argv options
+  let coreAll = process.env.ATOM_RUN_CORE_TESTS === 'true'
+  let coreMain = process.env.ATOM_RUN_CORE_MAIN_TESTS === 'true' || argv.coreMain
+  let coreRenderer = argv.coreRenderer || process.env.ATOM_RUN_CORE_RENDER_TESTS == 'true'
   let coreRenderer1 = process.env.ATOM_RUN_CORE_RENDER_TESTS === '1'
   let coreRenderer2 = process.env.ATOM_RUN_CORE_RENDER_TESTS === '2'
-  let coreAll = process.env.ATOM_RUN_CORE_TESTS === 'true'
+  let packageAll = argv.package || process.env.ATOM_RUN_PACKAGE_TESTS == 'true'
   let packages1 = process.env.ATOM_RUN_PACKAGE_TESTS === '1'
   let packages2 = process.env.ATOM_RUN_PACKAGE_TESTS === '2'
+  let benchmark = argv.coreBenchmark
 
   // Operating system overrides:
   coreMain = coreMain || (platform === 'linux') || (platform === 'win32' && process.arch === 'x86')
@@ -229,26 +214,61 @@ function testSuitesForPlatform (platform) {
   // split package tests (used for macos in CI)
   const PACKAGES_TO_TEST_IN_PARALLEL = 23
   // split core render test (used for windows x64 in CI)
-  const CORE_RENDER_TO_TEST_IN_PARALLEL = 35
+  const CORE_RENDER_TO_TEST_IN_PARALLEL = 45
 
-  if (coreMain) {
-    suites = [runCoreMainProcessTests]
-  } else if (coreRenderer1) {
-    suites = coreRenderProcessTestSuites.slice(0, CORE_RENDER_TO_TEST_IN_PARALLEL)
-  } else if (coreRenderer2) {
-    suites = coreRenderProcessTestSuites.slice(CORE_RENDER_TO_TEST_IN_PARALLEL)
-  } else if (coreAll) {
-    suites = [runCoreMainProcessTests, ...coreRenderProcessTestSuites]
-  } else if (packages1) {
-    suites = packageTestSuites.slice(0, PACKAGES_TO_TEST_IN_PARALLEL)
-  } else if (packages2) {
-    suites = packageTestSuites.slice(PACKAGES_TO_TEST_IN_PARALLEL)
+  let suites = []
+  // Core tess
+  if (coreAll) {
+    suites.push(...[runCoreMainProcessTests, ...coreRenderProcessTestSuites])
   } else {
-    suites = [runCoreMainProcessTests, ...coreRenderProcessTestSuites, ...packageTestSuites] // all
+
+    // Core main tests
+    if (coreMain) {
+      suites.push(runCoreMainProcessTests)
+    }
+
+    // Core renderer tests
+    if (coreRenderer) {
+      suites.push(...coreRenderProcessTestSuites)
+    } else {
+      // split
+      if (coreRenderer1) {
+        suites.push(...coreRenderProcessTestSuites.slice(0, CORE_RENDER_TO_TEST_IN_PARALLEL))
+      }
+      if (coreRenderer2) {
+        suites.push(...coreRenderProcessTestSuites.slice(CORE_RENDER_TO_TEST_IN_PARALLEL))
+      }
+    }
+
+  }
+
+  // Package tests
+  if (packageAll) {
+    suites.push(...packageTestSuites)
+  } else {
+    // split
+    if (packages1) {
+      suites.push(...packageTestSuites.slice(0, PACKAGES_TO_TEST_IN_PARALLEL))
+    }
+    if (packages2) {
+      suites.push(...packageTestSuites.slice(PACKAGES_TO_TEST_IN_PARALLEL))
+    }
+  }
+
+  // Benchmark tests
+  if (benchmark) {
+    suites.push(runBenchmarkTests)
   }
 
   if (argv.skipMainProcessTests) {
     suites = suites.filter(suite => suite !== runCoreMainProcessTests)
+  }
+
+  // Remove duplicates
+  suites = Array.from(new Set(suites))
+
+  if (suites.length == 0) {
+    throw new Error("No tests was requested")
   }
 
   return suites

--- a/script/test
+++ b/script/test
@@ -210,28 +210,24 @@ function requestedTestSuites () {
 
 function testSuitesForPlatform (platform) {
   let suites = []
-  switch (platform) {
-    case 'darwin':
-      const PACKAGES_TO_TEST_IN_PARALLEL = 23
+  if ((platform === 'darwin') || (platform === 'win32' && process.arch === 'x64'))  {
+    const PACKAGES_TO_TEST_IN_PARALLEL = 23
 
-      if (process.env.ATOM_RUN_CORE_TESTS === 'true') {
-        suites = [runCoreMainProcessTests, runCoreRenderProcessTests]
-      } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '1') {
-        suites = packageTestSuites.slice(0, PACKAGES_TO_TEST_IN_PARALLEL)
-      } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '2') {
-        suites = packageTestSuites.slice(PACKAGES_TO_TEST_IN_PARALLEL)
-      } else {
-        suites = [runCoreMainProcessTests, runCoreRenderProcessTests].concat(packageTestSuites)
-      }
-      break
-    case 'win32':
-      suites = (process.arch === 'x64') ? [runCoreMainProcessTests, runCoreRenderProcessTests] : [runCoreMainProcessTests]
-      break
-    case 'linux':
-      suites = [runCoreMainProcessTests]
-      break
-    default:
-      console.log(`Unrecognized platform: ${platform}`)
+    if (process.env.ATOM_RUN_CORE_TESTS === 'true') {
+      suites = [runCoreMainProcessTests, runCoreRenderProcessTests]
+    } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '1') {
+      suites = packageTestSuites.slice(0, PACKAGES_TO_TEST_IN_PARALLEL)
+    } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '2') {
+      suites = packageTestSuites.slice(PACKAGES_TO_TEST_IN_PARALLEL)
+    } else {
+      suites = [runCoreMainProcessTests, runCoreRenderProcessTests].concat(packageTestSuites)
+    }
+  }
+  else if ((platform === 'linux') || (platform === 'win32' && process.arch === 'x86')) {
+    suites = [runCoreMainProcessTests]
+  }
+  else {
+    console.log(`Unrecognized platform: ${platform}`)
   }
 
   if (argv.skipMainProcessTests) {

--- a/script/test
+++ b/script/test
@@ -297,7 +297,7 @@ function requestedTestSuites (platform) {
   return suites
 }
 
-async.parallel(testSuitesToRun, function (err, results) {
+async.series(testSuitesToRun, function (err, results) {
   if (err) {
     console.error(err)
     process.exit(1)

--- a/script/test
+++ b/script/test
@@ -102,18 +102,23 @@ function runCoreMainProcessTests (callback) {
   cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-main-process'}) })
 }
 
-function runCoreRenderProcessTests (callback) {
-  const testPath = path.join(CONFIG.repositoryRootPath, 'spec')
-  const testArguments = [
-    '--resource-path', resourcePath,
-    '--test', testPath
-  ]
-  const testEnv = prepareEnv('core-render-process')
+// Build an array of functions, each running tests for a different rendering test
+const coreRenderProcessTestSuites = []
+const testPath = path.join(CONFIG.repositoryRootPath, 'spec')
+let testFiles = glob.sync(path.join(testPath, '*-spec.+(js|coffee|ts|jsx|tsx|mjs)'))
+for (let testFile of testFiles) {
+  coreRenderProcessTestSuites.push( function (callback) {
 
-  console.log('Executing core render process tests'.bold.green)
-  const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
-  cp.on('error', error => { callback(error) })
-  cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-render-process'}) })
+    const testEnv = prepareEnv('core-render-process')
+    console.log(`Executing core render process tests for ${testFile}`.bold.green)
+    const testArguments = [
+      '--resource-path', resourcePath,
+      '--test', testFile
+    ]
+    const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
+    cp.on('error', error => { callback(error) })
+    cp.on('close', exitCode => { callback(null, {exitCode, step: `core-render-process for ${testFile}`}) })
+  })
 }
 
 // Build an array of functions, each running tests for a different bundled package
@@ -197,7 +202,7 @@ function requestedTestSuites () {
     suites.push(runCoreMainProcessTests)
   }
   if (argv.coreRenderer) {
-    suites.push(runCoreRenderProcessTests)
+    suites.push(...coreRenderProcessTestSuites)
   }
   if (argv.coreBenchmark) {
     suites.push(runBenchmarkTests)
@@ -210,24 +215,36 @@ function requestedTestSuites () {
 
 function testSuitesForPlatform (platform) {
   let suites = []
-  if ((platform === 'darwin') || (platform === 'win32' && process.arch === 'x64'))  {
-    const PACKAGES_TO_TEST_IN_PARALLEL = 23
+  // Env variable options
+  let coreMain = process.env.ATOM_RUN_CORE_MAIN_TESTS === 'true'
+  let coreRenderer1 = process.env.ATOM_RUN_CORE_RENDER_TESTS === '1'
+  let coreRenderer2 = process.env.ATOM_RUN_CORE_RENDER_TESTS === '2'
+  let coreAll = process.env.ATOM_RUN_CORE_TESTS === 'true'
+  let packages1 = process.env.ATOM_RUN_PACKAGE_TESTS === '1'
+  let packages2 = process.env.ATOM_RUN_PACKAGE_TESTS === '2'
 
-    if (process.env.ATOM_RUN_CORE_TESTS === 'true') {
-      suites = [runCoreMainProcessTests, runCoreRenderProcessTests]
-    } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '1') {
-      suites = packageTestSuites.slice(0, PACKAGES_TO_TEST_IN_PARALLEL)
-    } else if (process.env.ATOM_RUN_PACKAGE_TESTS === '2') {
-      suites = packageTestSuites.slice(PACKAGES_TO_TEST_IN_PARALLEL)
-    } else {
-      suites = [runCoreMainProcessTests, runCoreRenderProcessTests].concat(packageTestSuites)
-    }
-  }
-  else if ((platform === 'linux') || (platform === 'win32' && process.arch === 'x86')) {
+  // Operating system overrides:
+  coreMain = coreMain || (platform === 'linux') || (platform === 'win32' && process.arch === 'x86')
+
+  // split package tests (used for macos in CI)
+  const PACKAGES_TO_TEST_IN_PARALLEL = 23
+  // split core render test (used for windows x64 in CI)
+  const CORE_RENDER_TO_TEST_IN_PARALLEL = 35
+
+  if (coreMain) {
     suites = [runCoreMainProcessTests]
-  }
-  else {
-    console.log(`Unrecognized platform: ${platform}`)
+  } else if (coreRenderer1) {
+    suites = coreRenderProcessTestSuites.slice(0, CORE_RENDER_TO_TEST_IN_PARALLEL)
+  } else if (coreRenderer2) {
+    suites = coreRenderProcessTestSuites.slice(CORE_RENDER_TO_TEST_IN_PARALLEL)
+  } else if (coreAll) {
+    suites = [runCoreMainProcessTests, ...coreRenderProcessTestSuites]
+  } else if (packages1) {
+    suites = packageTestSuites.slice(0, PACKAGES_TO_TEST_IN_PARALLEL)
+  } else if (packages2) {
+    suites = packageTestSuites.slice(PACKAGES_TO_TEST_IN_PARALLEL)
+  } else {
+    suites = [runCoreMainProcessTests, ...coreRenderProcessTestSuites, ...packageTestSuites] // all
   }
 
   if (argv.skipMainProcessTests) {

--- a/script/test
+++ b/script/test
@@ -126,6 +126,9 @@ for (let testFile of testFiles) {
 	return coreRenderProcessTestSuites
 }
 
+
+function getPackageTestSuites() {
+	
 // Build an array of functions, each running tests for a different bundled package
 const packageTestSuites = []
 for (let packageName in CONFIG.appMetadata.packageDependencies) {
@@ -188,6 +191,10 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
   })
 }
 
+	return packageTestSuites
+}
+
+
 function runBenchmarkTests (callback) {
   const benchmarksPath = path.join(CONFIG.repositoryRootPath, 'benchmarks')
   const testArguments = ['--benchmark-test', benchmarksPath]
@@ -248,15 +255,15 @@ function requestedTestSuites (platform) {
   }
 
   // Package tests
-  if (packageAll) {
-    suites.push(...packageTestSuites)
+	if (packageAll) {
+	  suites.push(...getPackageTestSuites())
   } else {
     // split
     if (packages1) {
-      suites.push(...packageTestSuites.slice(0, PACKAGES_TO_TEST_IN_PARALLEL))
+      suites.push(...getPackageTestSuites().slice(0, PACKAGES_TO_TEST_IN_PARALLEL))
     }
     if (packages2) {
-      suites.push(...packageTestSuites.slice(PACKAGES_TO_TEST_IN_PARALLEL))
+      suites.push(...getPackageTestSuites().slice(PACKAGES_TO_TEST_IN_PARALLEL))
     }
   }
 

--- a/script/test
+++ b/script/test
@@ -281,10 +281,14 @@ async.parallel(testSuitesToRun, function (err, results) {
   } else {
     const failedSteps = results.filter(({exitCode}) => exitCode !== 0)
 
-    for (const {step} of failedSteps) {
-      console.error(`Error! The '${step}' test step finished with a non-zero exit code`)
+    if (failedSteps.length > 0) {
+      console.warn("\n \n *** Reporting the errors that happened in all of the tests: *** \n \n")
+      for (const {step} of failedSteps) {
+        console.error(`Error! The '${step}' test step finished with a non-zero exit code`)
+      }
+      process.exit(1)
     }
 
-    process.exit(failedSteps.length === 0 ? 0 : 1)
+    process.exit(0)
   }
 })

--- a/script/test
+++ b/script/test
@@ -65,7 +65,7 @@ if (process.platform === 'darwin') {
   assertExecutablePaths(executablePaths)
   executablePath = executablePaths[0]
 } else {
-  throw new Error('Running tests on this platform is not supported.')
+  throw new Error('##[error] Running tests on this platform is not supported.')
 }
 
 function prepareEnv (suiteName) {
@@ -96,7 +96,7 @@ function runCoreMainProcessTests (callback) {
 
   const testEnv = Object.assign({}, prepareEnv('core-main-process'), {ATOM_GITHUB_INLINE_GIT_EXEC: 'true'})
 
-  console.log('Executing core main process tests'.bold.green)
+  console.log('##[command] Executing core main process tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })
   cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-main-process'}) })
@@ -110,7 +110,7 @@ for (let testFile of testFiles) {
   coreRenderProcessTestSuites.push( function (callback) {
 
     const testEnv = prepareEnv('core-render-process')
-    console.log(`Executing core render process tests for ${testFile}`.bold.green)
+    console.log(`##[command] Executing core render process tests for ${testFile}`.bold.green)
     const testArguments = [
       '--resource-path', resourcePath,
       '--test', testFile
@@ -150,7 +150,7 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
     const nodeModulesPath = path.join(repositoryPackagePath, 'node_modules')
     let finalize = () => null
     if (require(pkgJsonPath).atomTestRunner) {
-      console.log(`Installing test runner dependencies for ${packageName}`.bold.green)
+      console.log(`##[command] Installing test runner dependencies for ${packageName}`.bold.green)
       if (fs.existsSync(nodeModulesPath)) {
         const backup = backupNodeModules(repositoryPackagePath)
         finalize = backup.restore
@@ -158,9 +158,9 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
         finalize = () => fs.removeSync(nodeModulesPath)
       }
       runApmInstall(repositoryPackagePath)
-      console.log(`Executing ${packageName} tests`.green)
+      console.log(`##[command] Executing ${packageName} tests`.green)
     } else {
-      console.log(`Executing ${packageName} tests`.bold.green)
+      console.log(`##[command] Executing ${packageName} tests`.bold.green)
     }
     const cp = childProcess.spawn(executablePath, testArguments, {env: testEnv})
 
@@ -174,7 +174,7 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
     })
     cp.on('close', exitCode => {
       if (exitCode !== 0) {
-        console.log(`Package tests failed for ${packageName}:`.red)
+        console.log(`##[error] Package tests failed for ${packageName}:`.red)
         console.log(stderrOutput)
       }
       finalize()
@@ -188,7 +188,7 @@ function runBenchmarkTests (callback) {
   const testArguments = ['--benchmark-test', benchmarksPath]
   const testEnv = prepareEnv('benchmark')
 
-  console.log('Executing benchmark tests'.bold.green)
+  console.log('##[command] Executing benchmark tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })
   cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-benchmarks'}) })
@@ -282,9 +282,9 @@ async.parallel(testSuitesToRun, function (err, results) {
     const failedSteps = results.filter(({exitCode}) => exitCode !== 0)
 
     if (failedSteps.length > 0) {
-      console.warn("\n \n *** Reporting the errors that happened in all of the tests: *** \n \n")
+			console.warn("\n \n ##[error] *** Reporting the errors that happened in all of the tests: *** \n \n")
       for (const {step} of failedSteps) {
-        console.error(`Error! The '${step}' test step finished with a non-zero exit code`)
+        console.error(`##[error] The '${step}' test step finished with a non-zero exit code`)
       }
       process.exit(1)
     }

--- a/script/test
+++ b/script/test
@@ -274,7 +274,7 @@ function requestedTestSuites (platform) {
   return suites
 }
 
-async.series(testSuitesToRun, function (err, results) {
+async.parallel(testSuitesToRun, function (err, results) {
   if (err) {
     console.error(err)
     process.exit(1)

--- a/script/test
+++ b/script/test
@@ -102,6 +102,8 @@ function runCoreMainProcessTests (callback) {
   cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-main-process', testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`}) })
 }
 
+function getCoreRenderProcessTestSuites() {
+
 // Build an array of functions, each running tests for a different rendering test
 const coreRenderProcessTestSuites = []
 const testPath = path.join(CONFIG.repositoryRootPath, 'spec')
@@ -119,6 +121,9 @@ for (let testFile of testFiles) {
     cp.on('error', error => { callback(error) })
     cp.on('close', exitCode => { callback(null, {exitCode, step: `core-render-process for ${testFile}.`, testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`}) })
   })
+}
+
+	return coreRenderProcessTestSuites
 }
 
 // Build an array of functions, each running tests for a different bundled package
@@ -219,7 +224,7 @@ function requestedTestSuites (platform) {
   let suites = []
   // Core tess
   if (coreAll) {
-    suites.push(...[runCoreMainProcessTests, ...coreRenderProcessTestSuites])
+    suites.push(...[runCoreMainProcessTests, ...getCoreRenderProcessTestSuites()])
   } else {
 
     // Core main tests
@@ -229,14 +234,14 @@ function requestedTestSuites (platform) {
 
     // Core renderer tests
     if (coreRenderer) {
-      suites.push(...coreRenderProcessTestSuites)
+      suites.push(...getCoreRenderProcessTestSuites())
     } else {
       // split
       if (coreRenderer1) {
-        suites.push(...coreRenderProcessTestSuites.slice(0, CORE_RENDER_TO_TEST_IN_PARALLEL))
+        suites.push(...getCoreRenderProcessTestSuites().slice(0, CORE_RENDER_TO_TEST_IN_PARALLEL))
       }
       if (coreRenderer2) {
-        suites.push(...coreRenderProcessTestSuites.slice(CORE_RENDER_TO_TEST_IN_PARALLEL))
+        suites.push(...getCoreRenderProcessTestSuites().slice(CORE_RENDER_TO_TEST_IN_PARALLEL))
       }
     }
 

--- a/script/test
+++ b/script/test
@@ -140,14 +140,14 @@ const coreRenderProcessTestSuites = []
 const testPath = path.join(CONFIG.repositoryRootPath, 'spec')
 let testFiles = glob.sync(path.join(testPath, '*-spec.+(js|coffee|ts|jsx|tsx|mjs)'))
 for (let testFile of testFiles) {
+	const testArguments = [
+		'--resource-path', resourcePath,
+		'--test', testFile
+	]
+	// the function which runs by async:
   coreRenderProcessTestSuites.push( function (callback) {
-
     const testEnv = prepareEnv('core-render-process')
     console.log(`##[command] Executing core render process tests for ${testFile}`.bold.green)
-    const testArguments = [
-      '--resource-path', resourcePath,
-      '--test', testFile
-    ]
     spawnTest(executablePath, testArguments, {env: testEnv}, callback, `core-render-process in ${testFile}.`)
   })
 }
@@ -176,15 +176,17 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
 
   const testFolder = path.join(repositoryPackagePath, testSubdir)
 
-  packageTestSuites.push(function (callback) {
-    const testArguments = [
-      '--resource-path', resourcePath,
-      '--test', testFolder
-    ]
-    const testEnv = prepareEnv(`bundled-package-${packageName}`)
+	const testArguments = [
+		'--resource-path', resourcePath,
+		'--test', testFolder
+	]
 
-    const pkgJsonPath = path.join(repositoryPackagePath, 'package.json')
-    const nodeModulesPath = path.join(repositoryPackagePath, 'node_modules')
+	const pkgJsonPath = path.join(repositoryPackagePath, 'package.json')
+	const nodeModulesPath = path.join(repositoryPackagePath, 'node_modules')
+
+	// the function which runs by async:
+  packageTestSuites.push(function (callback) {
+    const testEnv = prepareEnv(`bundled-package-${packageName}`)
     let finalize = () => null
     if (require(pkgJsonPath).atomTestRunner) {
       console.log(`##[command] Installing test runner dependencies for ${packageName}`.bold.green)

--- a/script/test
+++ b/script/test
@@ -99,7 +99,7 @@ function runCoreMainProcessTests (callback) {
   console.log('##[command] Executing core main process tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })
-  cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-main-process'}) })
+  cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-main-process', testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`}) })
 }
 
 // Build an array of functions, each running tests for a different rendering test
@@ -117,7 +117,7 @@ for (let testFile of testFiles) {
     ]
     const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
     cp.on('error', error => { callback(error) })
-    cp.on('close', exitCode => { callback(null, {exitCode, step: `core-render-process for ${testFile}`}) })
+    cp.on('close', exitCode => { callback(null, {exitCode, step: `core-render-process for ${testFile}.`, testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`}) })
   })
 }
 
@@ -178,7 +178,7 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
         console.log(stderrOutput)
       }
       finalize()
-      callback(null, {exitCode, step: `package-${packageName}`})
+      callback(null, {exitCode, step: `package-${packageName}.`, testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`})
     })
   })
 }
@@ -191,7 +191,7 @@ function runBenchmarkTests (callback) {
   console.log('##[command] Executing benchmark tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
   cp.on('error', error => { callback(error) })
-  cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-benchmarks'}) })
+  cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-benchmarks', testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`}) })
 }
 
 let testSuitesToRun = requestedTestSuites(process.platform)
@@ -283,8 +283,8 @@ async.parallel(testSuitesToRun, function (err, results) {
 
     if (failedSteps.length > 0) {
 			console.warn("\n \n ##[error] *** Reporting the errors that happened in all of the tests: *** \n \n")
-      for (const {step} of failedSteps) {
-        console.error(`##[error] The '${step}' test step finished with a non-zero exit code`)
+      for (const {step, testCommand} of failedSteps) {
+        console.error(`##[error] The '${step}' test step finished with a non-zero exit code \n ${testCommand}`)
       }
       process.exit(1)
     }

--- a/script/test
+++ b/script/test
@@ -83,6 +83,37 @@ function prepareEnv (suiteName) {
   return env
 }
 
+function spawnTest(executablePath, testArguments, options, callback, testName, finalize = null) {
+  const cp = childProcess.spawn(executablePath, testArguments, options)
+
+  // collect outputs and errors
+  let stderrOutput = ''
+  cp.stderr.on('data', data => { stderrOutput += data })
+  cp.stdout.on('data', data => { stderrOutput += data })
+
+  // on error
+  cp.on('error', error => {
+    console.log(error, "error")
+    if (finalize) { finalize() } 		// if finalizer provided
+    callback(error)
+  })
+
+	// on close
+  cp.on('close', exitCode => {
+    if (exitCode !== 0) {
+      console.log(`##[error] Tests for ${testName} failed.`.red)
+      console.log(stderrOutput)
+    }
+    if (finalize) { finalize() } 		// if finalizer provided
+    callback(null, {
+      exitCode,
+      step: testName,
+      testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`,
+    })
+  })
+
+}
+
 function runCoreMainProcessTests (callback) {
   const testPath = path.join(CONFIG.repositoryRootPath, 'spec', 'main-process')
   const testArguments = [
@@ -97,9 +128,7 @@ function runCoreMainProcessTests (callback) {
   const testEnv = Object.assign({}, prepareEnv('core-main-process'), {ATOM_GITHUB_INLINE_GIT_EXEC: 'true'})
 
   console.log('##[command] Executing core main process tests'.bold.green)
-  const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
-  cp.on('error', error => { callback(error) })
-  cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-main-process', testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`}) })
+  spawnTest(executablePath, testArguments, {stdio: 'inherit', env: testEnv}, callback, 'core-main-process')
 }
 
 function getCoreRenderProcessTestSuites() {
@@ -117,9 +146,7 @@ for (let testFile of testFiles) {
       '--resource-path', resourcePath,
       '--test', testFile
     ]
-    const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
-    cp.on('error', error => { callback(error) })
-    cp.on('close', exitCode => { callback(null, {exitCode, step: `core-render-process for ${testFile}.`, testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`}) })
+    spawnTest(executablePath, testArguments, {env: testEnv}, callback, `core-render-process in ${testFile}.`)
   })
 }
 
@@ -128,7 +155,7 @@ for (let testFile of testFiles) {
 
 
 function getPackageTestSuites() {
-	
+
 // Build an array of functions, each running tests for a different bundled package
 const packageTestSuites = []
 for (let packageName in CONFIG.appMetadata.packageDependencies) {
@@ -170,24 +197,7 @@ for (let packageName in CONFIG.appMetadata.packageDependencies) {
     } else {
       console.log(`##[command] Executing ${packageName} tests`.bold.green)
     }
-    const cp = childProcess.spawn(executablePath, testArguments, {env: testEnv})
-
-    let stderrOutput = ''
-    cp.stderr.on('data', data => { stderrOutput += data })
-    cp.stdout.on('data', data => { stderrOutput += data })
-    cp.on('error', error => {
-      console.log(error, "error")
-      finalize()
-      callback(error)
-    })
-    cp.on('close', exitCode => {
-      if (exitCode !== 0) {
-        console.log(`##[error] Package tests failed for ${packageName}:`.red)
-        console.log(stderrOutput)
-      }
-      finalize()
-      callback(null, {exitCode, step: `package-${packageName}.`, testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`})
-    })
+    spawnTest(executablePath, testArguments, {env: testEnv}, callback, `${packageName} package`, finalize)
   })
 }
 
@@ -202,8 +212,7 @@ function runBenchmarkTests (callback) {
 
   console.log('##[command] Executing benchmark tests'.bold.green)
   const cp = childProcess.spawn(executablePath, testArguments, {stdio: 'inherit', env: testEnv})
-  cp.on('error', error => { callback(error) })
-  cp.on('close', exitCode => { callback(null, {exitCode, step: 'core-benchmarks', testCommand: `You can run the test again using: \n\t ${executablePath} ${testArguments.join(' ')}`}) })
+  spawnTest(executablePath, testArguments, {stdio: 'inherit', env: testEnv}, callback, `core-benchmarks`)
 }
 
 let testSuitesToRun = requestedTestSuites(process.platform)

--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -16,7 +16,7 @@ jobs:
 
     dependsOn:
       - GetReleaseVersion
-      - Windows
+      - Windows_test
       - Linux
       - macOS_tests
 

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -8,6 +8,7 @@ jobs:
       ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
       IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
       IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
+      RunCoreMainTests: true
     pool:
       vmImage: macos-10.14
 
@@ -24,6 +25,9 @@ jobs:
         displayName: Run linter
 
       - template: templates/build.yml
+
+      # core main tests
+      - template: templates/test.yml
 
       - script: |
           cp $(Build.SourcesDirectory)/out/*.zip $(Build.ArtifactStagingDirectory)
@@ -51,8 +55,8 @@ jobs:
     strategy:
       maxParallel: 3
       matrix:
-        core:
-          RunCoreTests: true
+        renderer:
+          RunCoreRendererTests: true
           RunPackageTests: false
         packages-1:
           RunCoreTests: false

--- a/script/vsts/platforms/templates/test.yml
+++ b/script/vsts/platforms/templates/test.yml
@@ -21,6 +21,7 @@ steps:
       ATOM_JASMINE_REPORTER: list
       TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
       ATOM_RUN_CORE_TESTS: $(RunCoreTests)
+      ATOM_RUN_CORE_MAIN_TESTS: $(RunCoreMainTests)
       ATOM_RUN_CORE_RENDER_TESTS: $(RunCoreRendererTests)
       ATOM_RUN_PACKAGE_TESTS: $(RunPackageTests)
     displayName: Run tests

--- a/script/vsts/platforms/templates/test.yml
+++ b/script/vsts/platforms/templates/test.yml
@@ -21,6 +21,7 @@ steps:
       ATOM_JASMINE_REPORTER: list
       TEST_JUNIT_XML_ROOT: $(Common.TestResultsDirectory)/junit
       ATOM_RUN_CORE_TESTS: $(RunCoreTests)
+      ATOM_RUN_CORE_RENDER_TESTS: $(RunCoreRendererTests)
       ATOM_RUN_PACKAGE_TESTS: $(RunPackageTests)
     displayName: Run tests
     condition: and(succeeded(), ne(variables['Atom.SkipTests'], 'true'))

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -1,5 +1,5 @@
 jobs:
-  - job: Windows
+  - job: Windows_Build
     dependsOn: GetReleaseVersion
     timeoutInMinutes: 180
     strategy:
@@ -68,3 +68,54 @@ jobs:
             - fileName: RELEASES$(FileID)
               fileDir: $(Build.SourcesDirectory)/out
               condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'))
+
+  - job: Windows_RendererTests
+    dependsOn: Windows_Build
+    timeoutInMinutes: 180
+    strategy:
+      maxParallel: 2
+      matrix:
+        x64_Renderer_Test1:
+          RunCoreMainTests: false
+          RunCoreRendererTests: 1
+          buildArch: x64
+        x64_Renderer_Test2:
+          RunCoreMainTests: false
+          RunCoreRendererTests: 2
+          buildArch: x64
+
+    pool:
+      vmImage: vs2017-win2016
+
+    variables:
+      AppName: $[ dependencies.GetReleaseVersion.outputs['Version.AppName'] ]
+      ReleaseVersion: $[ dependencies.GetReleaseVersion.outputs['Version.ReleaseVersion'] ]
+      IsReleaseBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsReleaseBranch'] ]
+      IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
+
+    steps:
+      - template: templates/preparation.yml
+
+      - template: templates/cache.yml
+        parameters:
+          OS: windows
+
+      # Downloading the build artifacts
+      - pwsh: |
+          if ($env:BUILD_ARCH -eq "x64") {
+            $env:FileID="-x64"
+          } else {
+            $env:FileID=""
+          }
+          echo "##vso[task.setvariable variable=FileID]$env:FileID" # Azure syntax
+        env:
+          BUILD_ARCH: $(BUILD_ARCH)
+        displayName: Set FileID based on the arch
+
+      - template: templates/download-unzip.yml
+        parameters:
+          artifacts:
+            -  atom$(FileID)-windows.zip
+
+      #  Core renderer tests
+      - template: templates/test.yml

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -1,5 +1,5 @@
 jobs:
-  - job: Windows_Build
+  - job: Windows
     dependsOn: GetReleaseVersion
     timeoutInMinutes: 180
     strategy:
@@ -72,7 +72,7 @@ jobs:
               condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'))
 
   - job: Windows_RendererTests
-    dependsOn: Windows_Build
+    dependsOn: Windows
     timeoutInMinutes: 180
     strategy:
       maxParallel: 2

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -81,13 +81,15 @@ jobs:
           RunCoreMainTests: false
           RunCoreRendererTests: 1
           BUILD_ARCH: x64
+          os: windows-2019
         x64_Renderer_Test2:
           RunCoreMainTests: false
           RunCoreRendererTests: 2
           BUILD_ARCH: x64
+          os: windows-2019
 
     pool:
-      vmImage: vs2017-win2016
+      vmImage: $(os)
 
     variables:
       AppName: $[ dependencies.GetReleaseVersion.outputs['Version.AppName'] ]

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -1,5 +1,5 @@
 jobs:
-  - job: Windows
+  - job: Windows_build
     dependsOn: GetReleaseVersion
     timeoutInMinutes: 180
     strategy:
@@ -71,8 +71,8 @@ jobs:
               fileDir: $(Build.SourcesDirectory)/out
               condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'))
 
-  - job: Windows_RendererTests
-    dependsOn: Windows
+  - job: Windows_tests
+    dependsOn: Windows_build
     timeoutInMinutes: 180
     strategy:
       maxParallel: 2

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -7,8 +7,10 @@ jobs:
       matrix:
         x64:
           BUILD_ARCH: x64
+          RunCoreMainTests: true
         x86:
           BUILD_ARCH: x86
+          RunCoreMainTests: true
 
     pool:
       vmImage: vs2017-win2016
@@ -78,11 +80,11 @@ jobs:
         x64_Renderer_Test1:
           RunCoreMainTests: false
           RunCoreRendererTests: 1
-          buildArch: x64
+          BUILD_ARCH: x64
         x64_Renderer_Test2:
           RunCoreMainTests: false
           RunCoreRendererTests: 2
-          buildArch: x64
+          BUILD_ARCH: x64
 
     pool:
       vmImage: vs2017-win2016

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -102,6 +102,8 @@ jobs:
         parameters:
           OS: windows
 
+      - template: templates/bootstrap.yml
+
       # Downloading the build artifacts
       - pwsh: |
           if ($env:BUILD_ARCH -eq "x64") {

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -56,7 +56,7 @@ jobs:
           artifacts:
             - fileName: atom$(FileID)-windows.zip
               fileDir: $(Build.SourcesDirectory)/out
-              condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+              condition: and( succeeded(), or( eq(variables['BUILD_ARCH'], 'x64'), ne(variables['Build.Reason'], 'PullRequest') ) )
             - fileName: AtomSetup$(FileID).exe
               fileDir: $(Build.SourcesDirectory)/out
               condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'))

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -19,7 +19,7 @@ jobs:
 
     dependsOn:
       - GetReleaseVersion
-      - Windows
+      - Windows_tests
       - Linux
       - macOS_tests
 

--- a/src/main-process/start.js
+++ b/src/main-process/start.js
@@ -1,7 +1,7 @@
 const { app } = require('electron');
 const nslog = require('nslog');
 const path = require('path');
-const temp = require('temp').track();
+const temp = require('temp');
 const parseCommandLine = require('./parse-command-line');
 const startCrashReporter = require('../crash-reporter-start');
 const getReleaseChannel = require('../get-release-channel');


### PR DESCRIPTION
### Description of the Change
This:
- On Windows, runs core renderer tests using two Azure agents. This in addition to double the overall test speed, will allow rerunning the failed ones in case some fail due to timeouts.
- allows requesting any tests on any operating system
- parallelizes core renderer tests by using separate child processes for each file. 
- allows rerunning only the failed tests rather than restarting the whole CI.
- reduces Windows timeouts by running the tests on windows-2019.


### Verification
The CI passes

### Release Notes
Same as the description

### Closes
This supersedes these old pull requests: 
#18270 