### PR TITLE
support ES6 default require for packages

### DIFF
--- a/src/module-utils.js
+++ b/src/module-utils.js
@@ -1,5 +1,5 @@
 // a require function with both ES5 and ES6 default export support
-function requireX(path) {
+function requireModule(path) {
   const modul = require(path);
   if (modul === null || modul === undefined) {
     // if null do not bother
@@ -18,4 +18,4 @@ function requireX(path) {
   }
 }
 
-exports.requireX = requireX;
+exports.requireModule = requireModule;

--- a/src/module-utils.js
+++ b/src/module-utils.js
@@ -5,7 +5,10 @@ function requireX(path) {
     // if null do not bother
     return modul;
   } else {
-    if (modul.__esModule === true && typeof modul.default === 'object') {
+    if (
+      modul.__esModule === true &&
+      (modul.default !== undefined || modul.default !== null)
+    ) {
       // __esModule flag is true and default is exported, which means that
       // an object containing the main functions (e.g. activate, etc) is default exported
       return modul.default;

--- a/src/module-utils.js
+++ b/src/module-utils.js
@@ -1,0 +1,18 @@
+// a require function with both ES5 and ES6 default export support
+function requireX(path) {
+  const modul = require(path);
+  if (modul === null || modul === undefined) {
+    // if null do not bother
+    return modul;
+  } else {
+    if (modul.__esModule === true && typeof modul.default === 'object') {
+      // __esModule flag is true and default is exported, which means that
+      // an object containing the main functions (e.g. activate, etc) is default exported
+      return modul.default;
+    } else {
+      return modul;
+    }
+  }
+}
+
+exports.requireX = requireX;

--- a/src/module-utils.js
+++ b/src/module-utils.js
@@ -7,7 +7,7 @@ function requireX(path) {
   } else {
     if (
       modul.__esModule === true &&
-      (modul.default !== undefined || modul.default !== null)
+      (modul.default !== undefined && modul.default !== null)
     ) {
       // __esModule flag is true and default is exported, which means that
       // an object containing the main functions (e.g. activate, etc) is default exported

--- a/src/package.js
+++ b/src/package.js
@@ -8,7 +8,7 @@ const dedent = require('dedent');
 const CompileCache = require('./compile-cache');
 const ModuleCache = require('./module-cache');
 const BufferedProcess = require('./buffered-process');
-const { requireX } = require('./module-utils');
+const { requireModule } = require('./module-utils');
 
 // Extended: Loads and activates a package's main module and resources such as
 // stylesheets, keymaps, grammar, editor properties, and menus.
@@ -882,7 +882,7 @@ module.exports = class Package {
   requireMainModule() {
     if (this.bundledPackage && this.packageManager.packagesCache[this.name]) {
       if (this.packageManager.packagesCache[this.name].main) {
-        this.mainModule = requireX(
+        this.mainModule = requireModule(
           this.packageManager.packagesCache[this.name].main
         );
         return this.mainModule;
@@ -906,7 +906,7 @@ module.exports = class Package {
 
         const previousViewProviderCount = this.viewRegistry.getViewProviderCount();
         const previousDeserializerCount = this.deserializerManager.getDeserializerCount();
-        this.mainModule = requireX(mainModulePath);
+        this.mainModule = requireModule(mainModulePath);
         if (
           this.viewRegistry.getViewProviderCount() ===
             previousViewProviderCount &&

--- a/src/package.js
+++ b/src/package.js
@@ -8,6 +8,7 @@ const dedent = require('dedent');
 const CompileCache = require('./compile-cache');
 const ModuleCache = require('./module-cache');
 const BufferedProcess = require('./buffered-process');
+const { requireX } = require('./module-utils');
 
 // Extended: Loads and activates a package's main module and resources such as
 // stylesheets, keymaps, grammar, editor properties, and menus.
@@ -881,7 +882,7 @@ module.exports = class Package {
   requireMainModule() {
     if (this.bundledPackage && this.packageManager.packagesCache[this.name]) {
       if (this.packageManager.packagesCache[this.name].main) {
-        this.mainModule = this._require(
+        this.mainModule = requireX(
           this.packageManager.packagesCache[this.name].main
         );
         return this.mainModule;
@@ -905,7 +906,7 @@ module.exports = class Package {
 
         const previousViewProviderCount = this.viewRegistry.getViewProviderCount();
         const previousDeserializerCount = this.deserializerManager.getDeserializerCount();
-        this.mainModule = this._require(mainModulePath);
+        this.mainModule = requireX(mainModulePath);
         if (
           this.viewRegistry.getViewProviderCount() ===
             previousViewProviderCount &&
@@ -918,26 +919,6 @@ module.exports = class Package {
           );
         }
         return this.mainModule;
-      }
-    }
-  }
-
-  // a require function with both ES5 and ES6 default export support
-  _require(path) {
-    const modul = require(path);
-    if (modul === null || modul === undefined) {
-      // if null do not bother
-      return modul;
-    } else {
-      if (
-        modul.__esModule === true &&
-        typeof modul.default === 'object'
-      ) {
-        // __esModule flag is true and default is exported, which means that
-        // an object containing the main functions (e.g. activate, etc) is default exported
-        return modul.default;
-      } else {
-        return modul;
       }
     }
   }

--- a/src/package.js
+++ b/src/package.js
@@ -931,10 +931,9 @@ module.exports = class Package {
     } else {
       if (
         modul.__esModule === true &&
-        typeof modul.default === 'object' &&
-        typeof modul.default.activate === 'function'
+        typeof modul.default === 'object'
       ) {
-        // __esModule flag is true and the activate function exists inside it, which means
+        // __esModule flag is true and default is exported, which means that
         // an object containing the main functions (e.g. activate, etc) is default exported
         return modul.default;
       } else {


### PR DESCRIPTION
### Description of the change

#### In short: 
This allows loading the packages that are Es module and export their function wrapped in a default object. This is the case for any package that uses Babel 6, Babel 7, or other modern compilers for transpiling their package.

This will also allow us to use babel 7 in Atom's babel transpiler as in https://github.com/atom/atom/pull/20965

#### Longer:
The behavior of ES6 is to use `exports.default = ....` for exporting something as default. 
This is equal to using `module.exports = ....` or `module.exports = {...}`.

In ES6 requiring the modules that exported like need explicitly calling `.default`
```js
const x = require(module).default // require(module) is wrong
```

`_require` function in this pull request checks if `default` property exists and returns what it is inside it instead of returning the useless module itself (which will not have the activate function for the package). 

`_require` function checks this phenomenon and adds support for it. Many compilers or bundlers use `_interopDefault` which serves the same purpose. 


### Drawbacks
This function is written pretty conservatively and has no drawbacks.

In Atom, all the packages can only export their functions either named or wrapped in an object. There is no real useful default export that can be called directly. So the mixed situation does not happen, and we can safely merge this PR. 

### Verification
The CI passes

### Release Notes
- Adding support for the packages that export their main functions under an object and are transpiled using modern transpilers (e.g babel 6 or later, etc).