### PR TITLE
Show appropriate error when running test without building

### DIFF
--- a/script/test
+++ b/script/test
@@ -45,19 +45,24 @@ const CONFIG = require('./config')
 const backupNodeModules = require('./lib/backup-node-modules')
 const runApmInstall = require('./lib/run-apm-install')
 
+function assertExecutablePaths(executablePaths) {
+	assert(executablePaths.length !== 0, `No atom build found. Please run "script/build" and try again.`)
+	assert(executablePaths.length === 1, `More than one application to run tests against was found. ${executablePaths.join(',')}`)
+}
+
 const resourcePath = CONFIG.repositoryRootPath
 let executablePath
 if (process.platform === 'darwin') {
   const executablePaths = glob.sync(path.join(CONFIG.buildOutputPath, '*.app'))
-  assert(executablePaths.length === 1, `More than one application to run tests against was found. ${executablePaths.join(',')}`)
+  assertExecutablePaths(executablePaths)
   executablePath = path.join(executablePaths[0], 'Contents', 'MacOS', path.basename(executablePaths[0], '.app'))
 } else if (process.platform === 'linux') {
   const executablePaths = glob.sync(path.join(CONFIG.buildOutputPath, 'atom-*', 'atom'))
-  assert(executablePaths.length === 1, `More than one application to run tests against was found. ${executablePaths.join(',')}`)
+  assertExecutablePaths(executablePaths)
   executablePath = executablePaths[0]
 } else if (process.platform === 'win32') {
   const executablePaths = glob.sync(path.join(CONFIG.buildOutputPath, '**', 'atom*.exe'))
-  assert(executablePaths.length === 1, `More than one application to run tests against was found. ${executablePaths.join(',')}`)
+  assertExecutablePaths(executablePaths)
   executablePath = executablePaths[0]
 } else {
   throw new Error('Running tests on this platform is not supported.')


### PR DESCRIPTION
When you run `script/test` without first building, you get the following error which is not very helpful
![Screenshot 2020-07-30 at 13 11 32](https://user-images.githubusercontent.com/5238135/88911235-3bccdc00-d266-11ea-9ae6-829e6dfffdb9.png)

This adds an assertion to provide a helpful error message in the event someone runs `script/test` without building
