### PR TITLE
enable multi-threading on Atom

### DIFF
--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -49,7 +49,10 @@ module.exports = class AtomWindow extends EventEmitter {
         // (Ref: https://github.com/atom/atom/pull/12696#issuecomment-290496960)
         disableBlinkFeatures: 'Auxclick',
         nodeIntegration: true,
-        webviewTag: true
+        webviewTag: true,
+
+        // node support in threads
+        nodeIntegrationInWorker: true
       },
       simpleFullscreen: this.getSimpleFullscreen()
     };


### PR DESCRIPTION
### Description of the Change

This enables the possibility of multithreading in Atom as stated in Electron documentation. It allows using Node features in WebWorkers.
https://www.electronjs.org/docs/tutorial/multithreading

This allows offloading the parts of the code that are blocking the main thread to another thread, which can result in a huge performance gain.

#### Alternate Designs

N/A

#### Possible Drawbacks

N/A

### Verification Process
- CI passes
- Using the built Atom

### Release Notes

- Now Atom allows using the multi-threading features of Nodejs