### PR TITLE
Adjust jasmine default timeout value

### DIFF
--- a/spec/jasmine-test-runner.coffee
+++ b/spec/jasmine-test-runner.coffee
@@ -8,6 +8,7 @@ temp.track()
 
 module.exports = ({logFile, headless, testPaths, buildAtomEnvironment}) ->
   window[key] = value for key, value of require '../vendor/jasmine'
+
   require 'jasmine-tagged'
 
   # Rewrite global jasmine functions to have support for async tests.

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -48,12 +48,12 @@ jasmine.getEnv().addEqualityTester (a, b) ->
   # Match jasmine.any's equality matching logic
   return a.jasmineMatches(b) if a?.jasmineMatches?
   return b.jasmineMatches(a) if b?.jasmineMatches?
-  
+
   # Use underscore's definition of equality for toEqual assertions
   _.isEqual(a, b)
 
 if process.env.CI
-  jasmine.getEnv().defaultTimeoutInterval = 60000
+  jasmine.getEnv().defaultTimeoutInterval = 120000
 else
   jasmine.getEnv().defaultTimeoutInterval = 5000
 


### PR DESCRIPTION
## Context
Some of the tests on window x86 are timing out due to timeout.
This is a temporary fix to increase the timeout interval.

We already have https://github.com/atom/atom/pull/21109/ which could help us improve our CI run times.

