### PR TITLE
Double waitsFor timeout value

### DIFF
--- a/spec/integration/helpers/start-atom.js
+++ b/spec/integration/helpers/start-atom.js
@@ -199,7 +199,7 @@ Logs:\n${chromedriverLogs.join('\n')}`);
       }
       finish();
     },
-    30000
+    60000
   );
 
   waitsFor('webdriver to stop', chromeDriverDown, 15000);


### PR DESCRIPTION
The following test regularly fails on our CI pipeline due to timeouts.
 - it Smoke Test can open a file in Atom and perform basic operations on it
    `timeout: timed out after 30000 msec waiting for tests to run`

This PR increases the timeout value to allow longer wait period for the tests.