### PR TITLE
📝 CONTRIBUTING.md: JavaScript code is linted with Prettier now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,7 +249,7 @@ While the prerequisites above must be satisfied prior to having your pull reques
 
 ### JavaScript Styleguide
 
-All JavaScript must adhere to [JavaScript Standard Style](https://standardjs.com/).
+All JavaScript code is linted with [Prettier](https://prettier.io/).
 
 * Prefer the object spread operator (`{...anotherObj}`) to `Object.assign()`
 * Inline `export`s with expressions whenever possible


### PR DESCRIPTION
### Requirements for Contributing Documentation

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.

### Description of the Change

<!--

We must be able to understand the purpose of your change from this description. If we can't get a good idea of the benefits of the change from the description here, the pull request may be closed at the maintainers' discretion.

-->

The code has been linted with [Prettier](https://prettier.io) as of May 2019 (https://github.com/atom/atom/pull/19391). This obviously means that code conforming to Standard JS style would be flagged as needing changes by our current linter!

Update `CONTRIBUTING.md` to reflect this. (Closes https://github.com/atom/atom/issues/21132).

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.  This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Docs: JS is linted with Prettier now, not Standard

-----
[View rendered CONTRIBUTING.md](https://github.com/DeeDeeG/atom/blob/docs-js-is-linted-with-prettier-now/CONTRIBUTING.md)