### PR TITLE
update npm@6.14.8

### DIFF
--- a/apm/package-lock.json
+++ b/apm/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "atom-package-manager": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/atom-package-manager/-/atom-package-manager-2.5.0.tgz",
-      "integrity": "sha512-bCD2GAfKZDiTmVQOn63yVonUsouesyyn//5H4Y9BEcBKRSD3JmUxyYF2ivner1TQg9HGuHG86z2gr7BkFg+9Mg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/atom-package-manager/-/atom-package-manager-2.5.2.tgz",
+      "integrity": "sha512-2ILgdWZEi2H2mhotoRRPwrw38ZQOxILH/DoZln551sp/39+7ci/zxmwVa0MAfdI99P67yiEY+ZFqqaaTlpdPvQ==",
       "requires": {
         "@atom/plist": "0.4.4",
         "asar-require": "0.3.0",
@@ -16,7 +16,7 @@
         "fs-plus": "2.x",
         "git-utils": "^5.6.2",
         "hosted-git-info": "^2.1.4",
-        "keytar": "^4.0",
+        "keytar": "^4.13.0",
         "mv": "2.0.0",
         "ncp": "~0.5.1",
         "npm": "^6.14.4",
@@ -50,9 +50,9 @@
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "version": "6.12.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -165,9 +165,9 @@
           "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+          "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
         },
         "balanced-match": {
           "version": "1.0.0",
@@ -192,9 +192,9 @@
           }
         },
         "bl": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+          "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -565,9 +565,9 @@
           },
           "dependencies": {
             "type": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-              "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+              "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
             }
           }
         },
@@ -582,9 +582,9 @@
           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
@@ -775,11 +775,11 @@
           "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "requires": {
-            "ajv": "^6.5.5",
+            "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
           }
         },
@@ -1033,9 +1033,9 @@
           "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "node-abi": {
-          "version": "2.16.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.16.0.tgz",
-          "integrity": "sha512-+sa0XNlWDA6T+bDLmkCUYn6W5k5W6BPRL6mqzSCs6H/xUgtl4D5x2fORKDzopKiU6wsyn/+wXlRXwXeSp+mtoA==",
+          "version": "2.19.1",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
+          "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
           "requires": {
             "semver": "^5.4.1"
           }
@@ -1054,9 +1054,9 @@
           }
         },
         "npm": {
-          "version": "6.14.5",
-          "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.5.tgz",
-          "integrity": "sha512-CDwa3FJd0XJpKDbWCST484H+mCNjF26dPrU+xnREW+upR0UODjMEfXPl3bxWuAwZIX6c2ASg1plLO7jP8ehWeA==",
+          "version": "6.14.8",
+          "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.8.tgz",
+          "integrity": "sha512-HBZVBMYs5blsj94GTeQZel7s9odVuuSUHy1+AlZh7rPVux1os2ashvEGLy/STNK7vUjbrCg5Kq9/GXisJgdf6A==",
           "requires": {
             "JSONStream": "^1.3.5",
             "abbrev": "~1.1.1",
@@ -1064,7 +1064,7 @@
             "ansistyles": "~0.1.3",
             "aproba": "^2.0.0",
             "archy": "~1.0.0",
-            "bin-links": "^1.1.7",
+            "bin-links": "^1.1.8",
             "bluebird": "^3.5.5",
             "byte-size": "^5.0.1",
             "cacache": "^12.0.3",
@@ -1085,7 +1085,7 @@
             "find-npm-prefix": "^1.0.2",
             "fs-vacuum": "~1.2.10",
             "fs-write-stream-atomic": "~1.0.10",
-            "gentle-fs": "^2.3.0",
+            "gentle-fs": "^2.3.1",
             "glob": "^7.1.6",
             "graceful-fs": "^4.2.4",
             "has-unicode": "~2.0.1",
@@ -1100,14 +1100,14 @@
             "is-cidr": "^3.0.0",
             "json-parse-better-errors": "^1.0.2",
             "lazy-property": "~1.0.0",
-            "libcipm": "^4.0.7",
+            "libcipm": "^4.0.8",
             "libnpm": "^3.0.1",
             "libnpmaccess": "^3.0.2",
             "libnpmhook": "^5.0.3",
             "libnpmorg": "^1.0.1",
             "libnpmsearch": "^2.0.2",
             "libnpmteam": "^1.0.2",
-            "libnpx": "^10.2.2",
+            "libnpx": "^10.2.4",
             "lock-verify": "^2.1.0",
             "lockfile": "^1.0.4",
             "lodash._baseindexof": "*",
@@ -1122,22 +1122,22 @@
             "lodash.uniq": "~4.5.0",
             "lodash.without": "~4.4.0",
             "lru-cache": "^5.1.1",
-            "meant": "~1.0.1",
+            "meant": "^1.0.2",
             "mississippi": "^3.0.0",
             "mkdirp": "^0.5.5",
             "move-concurrently": "^1.0.1",
             "node-gyp": "^5.1.0",
             "nopt": "^4.0.3",
             "normalize-package-data": "^2.5.0",
-            "npm-audit-report": "^1.3.2",
+            "npm-audit-report": "^1.3.3",
             "npm-cache-filename": "~1.0.2",
             "npm-install-checks": "^3.0.2",
-            "npm-lifecycle": "^3.1.4",
+            "npm-lifecycle": "^3.1.5",
             "npm-package-arg": "^6.1.1",
             "npm-packlist": "^1.4.8",
             "npm-pick-manifest": "^3.0.2",
             "npm-profile": "^4.0.4",
-            "npm-registry-fetch": "^4.0.4",
+            "npm-registry-fetch": "^4.0.7",
             "npm-user-validate": "~1.0.0",
             "npmlog": "~4.1.2",
             "once": "~1.4.0",
@@ -1323,7 +1323,7 @@
               }
             },
             "bin-links": {
-              "version": "1.1.7",
+              "version": "1.1.8",
               "bundled": true,
               "requires": {
                 "bluebird": "^3.5.3",
@@ -1458,23 +1458,36 @@
               }
             },
             "cliui": {
-              "version": "4.1.0",
+              "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "^3.1.0",
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
               },
               "dependencies": {
                 "ansi-regex": {
-                  "version": "3.0.0",
+                  "version": "4.1.0",
                   "bundled": true
                 },
-                "strip-ansi": {
-                  "version": "4.0.0",
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "3.1.0",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "^3.0.0"
+                    "emoji-regex": "^7.0.1",
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^5.1.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "5.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^4.1.0"
                   }
                 }
               }
@@ -1575,10 +1588,10 @@
               }
             },
             "configstore": {
-              "version": "3.1.2",
+              "version": "3.1.5",
               "bundled": true,
               "requires": {
-                "dot-prop": "^4.1.0",
+                "dot-prop": "^4.2.1",
                 "graceful-fs": "^4.1.2",
                 "make-dir": "^1.0.0",
                 "unique-string": "^1.0.0",
@@ -1729,7 +1742,7 @@
               }
             },
             "dot-prop": {
-              "version": "4.2.0",
+              "version": "4.2.1",
               "bundled": true,
               "requires": {
                 "is-obj": "^1.0.0"
@@ -1786,6 +1799,10 @@
             },
             "editor": {
               "version": "1.0.0",
+              "bundled": true
+            },
+            "emoji-regex": {
+              "version": "7.0.3",
               "bundled": true
             },
             "encoding": {
@@ -1894,13 +1911,6 @@
             "find-npm-prefix": {
               "version": "1.0.2",
               "bundled": true
-            },
-            "find-up": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "locate-path": "^2.0.0"
-              }
             },
             "flush-write-stream": {
               "version": "1.0.3",
@@ -2079,7 +2089,7 @@
               "bundled": true
             },
             "gentle-fs": {
-              "version": "2.3.0",
+              "version": "2.3.1",
               "bundled": true,
               "requires": {
                 "aproba": "^1.1.2",
@@ -2106,7 +2116,7 @@
               }
             },
             "get-caller-file": {
-              "version": "1.0.3",
+              "version": "2.0.5",
               "bundled": true
             },
             "get-stream": {
@@ -2300,10 +2310,6 @@
                 "validate-npm-package-name": "^3.0.0"
               }
             },
-            "invert-kv": {
-              "version": "2.0.0",
-              "bundled": true
-            },
             "ip": {
               "version": "1.1.5",
               "bundled": true
@@ -2458,15 +2464,8 @@
               "version": "1.0.0",
               "bundled": true
             },
-            "lcid": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "invert-kv": "^2.0.0"
-              }
-            },
             "libcipm": {
-              "version": "4.0.7",
+              "version": "4.0.8",
               "bundled": true,
               "requires": {
                 "bin-links": "^1.1.2",
@@ -2475,7 +2474,7 @@
                 "find-npm-prefix": "^1.0.2",
                 "graceful-fs": "^4.1.11",
                 "ini": "^1.3.5",
-                "lock-verify": "^2.0.2",
+                "lock-verify": "^2.1.0",
                 "mkdirp": "^0.5.1",
                 "npm-lifecycle": "^3.0.0",
                 "npm-logical-tree": "^1.2.1",
@@ -2621,7 +2620,7 @@
               }
             },
             "libnpx": {
-              "version": "10.2.2",
+              "version": "10.2.4",
               "bundled": true,
               "requires": {
                 "dotenv": "^5.0.1",
@@ -2631,15 +2630,7 @@
                 "update-notifier": "^2.3.0",
                 "which": "^1.3.0",
                 "y18n": "^4.0.0",
-                "yargs": "^11.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
+                "yargs": "^14.2.3"
               }
             },
             "lock-verify": {
@@ -2751,31 +2742,9 @@
                 "ssri": "^6.0.0"
               }
             },
-            "map-age-cleaner": {
-              "version": "0.1.3",
-              "bundled": true,
-              "requires": {
-                "p-defer": "^1.0.0"
-              }
-            },
             "meant": {
-              "version": "1.0.1",
+              "version": "1.0.2",
               "bundled": true
-            },
-            "mem": {
-              "version": "4.3.0",
-              "bundled": true,
-              "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^2.0.0",
-                "p-is-promise": "^2.0.0"
-              },
-              "dependencies": {
-                "mimic-fn": {
-                  "version": "2.1.0",
-                  "bundled": true
-                }
-              }
             },
             "mime-db": {
               "version": "1.35.0",
@@ -2794,6 +2763,10 @@
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
+            },
+            "minimist": {
+              "version": "1.2.5",
+              "bundled": true
             },
             "minizlib": {
               "version": "1.3.3",
@@ -2867,10 +2840,6 @@
               "version": "0.0.7",
               "bundled": true
             },
-            "nice-try": {
-              "version": "1.0.5",
-              "bundled": true
-            },
             "node-fetch-npm": {
               "version": "2.0.2",
               "bundled": true,
@@ -2925,7 +2894,7 @@
               }
             },
             "npm-audit-report": {
-              "version": "1.3.2",
+              "version": "1.3.3",
               "bundled": true,
               "requires": {
                 "cli-table3": "^0.5.0",
@@ -2951,7 +2920,7 @@
               }
             },
             "npm-lifecycle": {
-              "version": "3.1.4",
+              "version": "3.1.5",
               "bundled": true,
               "requires": {
                 "byline": "^5.0.0",
@@ -3010,7 +2979,7 @@
               }
             },
             "npm-registry-fetch": {
-              "version": "4.0.4",
+              "version": "4.0.7",
               "bundled": true,
               "requires": {
                 "JSONStream": "^1.3.4",
@@ -3023,7 +2992,7 @@
               },
               "dependencies": {
                 "safe-buffer": {
-                  "version": "5.2.0",
+                  "version": "5.2.1",
                   "bundled": true
                 }
               }
@@ -3088,41 +3057,6 @@
               "version": "1.0.2",
               "bundled": true
             },
-            "os-locale": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "execa": "^1.0.0",
-                "lcid": "^2.0.0",
-                "mem": "^4.0.0"
-              },
-              "dependencies": {
-                "cross-spawn": {
-                  "version": "6.0.5",
-                  "bundled": true,
-                  "requires": {
-                    "nice-try": "^1.0.4",
-                    "path-key": "^2.0.1",
-                    "semver": "^5.5.0",
-                    "shebang-command": "^1.2.0",
-                    "which": "^1.2.9"
-                  }
-                },
-                "execa": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "cross-spawn": "^6.0.0",
-                    "get-stream": "^4.0.0",
-                    "is-stream": "^1.1.0",
-                    "npm-run-path": "^2.0.0",
-                    "p-finally": "^1.0.0",
-                    "signal-exit": "^3.0.0",
-                    "strip-eof": "^1.0.0"
-                  }
-                }
-              }
-            },
             "os-tmpdir": {
               "version": "1.0.2",
               "bundled": true
@@ -3135,33 +3069,7 @@
                 "os-tmpdir": "^1.0.0"
               }
             },
-            "p-defer": {
-              "version": "1.0.0",
-              "bundled": true
-            },
             "p-finally": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "p-is-promise": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "p-limit": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "p-try": "^1.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "p-limit": "^1.1.0"
-              }
-            },
-            "p-try": {
               "version": "1.0.0",
               "bundled": true
             },
@@ -3396,12 +3304,6 @@
                 "ini": "~1.3.0",
                 "minimist": "^1.2.0",
                 "strip-json-comments": "~2.0.1"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.5",
-                  "bundled": true
-                }
               }
             },
             "read": {
@@ -3516,7 +3418,7 @@
               "bundled": true
             },
             "require-main-filename": {
-              "version": "1.0.1",
+              "version": "2.0.0",
               "bundled": true
             },
             "resolve-from": {
@@ -3686,7 +3588,7 @@
               }
             },
             "spdx-license-ids": {
-              "version": "3.0.3",
+              "version": "3.0.5",
               "bundled": true
             },
             "split-on-first": {
@@ -4079,20 +3981,36 @@
               }
             },
             "wrap-ansi": {
-              "version": "2.1.0",
+              "version": "5.1.0",
               "bundled": true,
               "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
               },
               "dependencies": {
+                "ansi-regex": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
                 "string-width": {
-                  "version": "1.0.2",
+                  "version": "3.1.0",
                   "bundled": true,
                   "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
+                    "emoji-regex": "^7.0.1",
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^5.1.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "5.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^4.1.0"
                   }
                 }
               }
@@ -4127,34 +4045,93 @@
               "bundled": true
             },
             "yargs": {
-              "version": "11.1.1",
+              "version": "14.2.3",
               "bundled": true,
               "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^3.1.0",
+                "cliui": "^5.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
                 "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
+                "require-main-filename": "^2.0.0",
                 "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
+                "string-width": "^3.0.0",
                 "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
+                "y18n": "^4.0.0",
+                "yargs-parser": "^15.0.1"
               },
               "dependencies": {
-                "y18n": {
-                  "version": "3.2.1",
+                "ansi-regex": {
+                  "version": "4.1.0",
                   "bundled": true
+                },
+                "find-up": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "locate-path": "^3.0.0"
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "locate-path": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-locate": "^3.0.0",
+                    "path-exists": "^3.0.0"
+                  }
+                },
+                "p-limit": {
+                  "version": "2.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-try": "^2.0.0"
+                  }
+                },
+                "p-locate": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-limit": "^2.0.0"
+                  }
+                },
+                "p-try": {
+                  "version": "2.2.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "emoji-regex": "^7.0.1",
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^5.1.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "5.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^4.1.0"
+                  }
                 }
               }
             },
             "yargs-parser": {
-              "version": "9.0.2",
+              "version": "15.0.1",
               "bundled": true,
               "requires": {
-                "camelcase": "^4.1.0"
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "5.3.1",
+                  "bundled": true
+                }
               }
             }
           }
@@ -4381,9 +4358,9 @@
           }
         },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4434,9 +4411,9 @@
           "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
         },
         "simple-concat": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-          "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+          "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
         },
         "simple-get": {
           "version": "2.8.1",
@@ -4667,9 +4644,9 @@
           "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
         },
         "underscore": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-          "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
+          "integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw=="
         },
         "underscore-plus": {
           "version": "1.7.0",
@@ -4680,9 +4657,9 @@
           }
         },
         "uri-js": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-          "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+          "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
           "requires": {
             "punycode": "^2.1.0"
           }

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -6334,9 +6334,9 @@
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
     "npm": {
-      "version": "6.14.4",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.4.tgz",
-      "integrity": "sha512-B8UDDbWvdkW6RgXFn8/h2cHJP/u/FPa4HWeGzW23aNEBARN3QPrRaHqPIZW2NSN3fW649gtgUDNZpaRs0zTMPw==",
+      "version": "6.14.8",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.8.tgz",
+      "integrity": "sha512-HBZVBMYs5blsj94GTeQZel7s9odVuuSUHy1+AlZh7rPVux1os2ashvEGLy/STNK7vUjbrCg5Kq9/GXisJgdf6A==",
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -6344,7 +6344,7 @@
         "ansistyles": "~0.1.3",
         "aproba": "^2.0.0",
         "archy": "~1.0.0",
-        "bin-links": "^1.1.7",
+        "bin-links": "^1.1.8",
         "bluebird": "^3.5.5",
         "byte-size": "^5.0.1",
         "cacache": "^12.0.3",
@@ -6365,9 +6365,9 @@
         "find-npm-prefix": "^1.0.2",
         "fs-vacuum": "~1.2.10",
         "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.3.0",
+        "gentle-fs": "^2.3.1",
         "glob": "^7.1.6",
-        "graceful-fs": "^4.2.3",
+        "graceful-fs": "^4.2.4",
         "has-unicode": "~2.0.1",
         "hosted-git-info": "^2.8.8",
         "iferr": "^1.0.2",
@@ -6380,14 +6380,14 @@
         "is-cidr": "^3.0.0",
         "json-parse-better-errors": "^1.0.2",
         "lazy-property": "~1.0.0",
-        "libcipm": "^4.0.7",
+        "libcipm": "^4.0.8",
         "libnpm": "^3.0.1",
         "libnpmaccess": "^3.0.2",
         "libnpmhook": "^5.0.3",
         "libnpmorg": "^1.0.1",
         "libnpmsearch": "^2.0.2",
         "libnpmteam": "^1.0.2",
-        "libnpx": "^10.2.2",
+        "libnpx": "^10.2.4",
         "lock-verify": "^2.1.0",
         "lockfile": "^1.0.4",
         "lodash._baseindexof": "*",
@@ -6402,22 +6402,22 @@
         "lodash.uniq": "~4.5.0",
         "lodash.without": "~4.4.0",
         "lru-cache": "^5.1.1",
-        "meant": "~1.0.1",
+        "meant": "^1.0.2",
         "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.4",
+        "mkdirp": "^0.5.5",
         "move-concurrently": "^1.0.1",
         "node-gyp": "^5.1.0",
-        "nopt": "~4.0.1",
+        "nopt": "^4.0.3",
         "normalize-package-data": "^2.5.0",
-        "npm-audit-report": "^1.3.2",
+        "npm-audit-report": "^1.3.3",
         "npm-cache-filename": "~1.0.2",
         "npm-install-checks": "^3.0.2",
-        "npm-lifecycle": "^3.1.4",
+        "npm-lifecycle": "^3.1.5",
         "npm-package-arg": "^6.1.1",
         "npm-packlist": "^1.4.8",
         "npm-pick-manifest": "^3.0.2",
         "npm-profile": "^4.0.4",
-        "npm-registry-fetch": "^4.0.3",
+        "npm-registry-fetch": "^4.0.7",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
@@ -6603,7 +6603,7 @@
           }
         },
         "bin-links": {
-          "version": "1.1.7",
+          "version": "1.1.8",
           "bundled": true,
           "requires": {
             "bluebird": "^3.5.3",
@@ -6738,23 +6738,36 @@
           }
         },
         "cliui": {
-          "version": "4.1.0",
+          "version": "5.0.0",
           "bundled": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "3.0.0",
+              "version": "4.1.0",
               "bundled": true
             },
-            "strip-ansi": {
-              "version": "4.0.0",
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "3.1.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
               }
             }
           }
@@ -6855,10 +6868,10 @@
           }
         },
         "configstore": {
-          "version": "3.1.2",
+          "version": "3.1.5",
           "bundled": true,
           "requires": {
-            "dot-prop": "^4.1.0",
+            "dot-prop": "^4.2.1",
             "graceful-fs": "^4.1.2",
             "make-dir": "^1.0.0",
             "unique-string": "^1.0.0",
@@ -7009,7 +7022,7 @@
           }
         },
         "dot-prop": {
-          "version": "4.2.0",
+          "version": "4.2.1",
           "bundled": true,
           "requires": {
             "is-obj": "^1.0.0"
@@ -7066,6 +7079,10 @@
         },
         "editor": {
           "version": "1.0.0",
+          "bundled": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
           "bundled": true
         },
         "encoding": {
@@ -7174,13 +7191,6 @@
         "find-npm-prefix": {
           "version": "1.0.2",
           "bundled": true
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
         },
         "flush-write-stream": {
           "version": "1.0.3",
@@ -7359,7 +7369,7 @@
           "bundled": true
         },
         "gentle-fs": {
-          "version": "2.3.0",
+          "version": "2.3.1",
           "bundled": true,
           "requires": {
             "aproba": "^1.1.2",
@@ -7386,7 +7396,7 @@
           }
         },
         "get-caller-file": {
-          "version": "1.0.3",
+          "version": "2.0.5",
           "bundled": true
         },
         "get-stream": {
@@ -7446,7 +7456,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.3",
+          "version": "4.2.4",
           "bundled": true
         },
         "har-schema": {
@@ -7579,10 +7589,6 @@
             "validate-npm-package-license": "^3.0.1",
             "validate-npm-package-name": "^3.0.0"
           }
-        },
-        "invert-kv": {
-          "version": "2.0.0",
-          "bundled": true
         },
         "ip": {
           "version": "1.1.5",
@@ -7738,15 +7744,8 @@
           "version": "1.0.0",
           "bundled": true
         },
-        "lcid": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "invert-kv": "^2.0.0"
-          }
-        },
         "libcipm": {
-          "version": "4.0.7",
+          "version": "4.0.8",
           "bundled": true,
           "requires": {
             "bin-links": "^1.1.2",
@@ -7755,7 +7754,7 @@
             "find-npm-prefix": "^1.0.2",
             "graceful-fs": "^4.1.11",
             "ini": "^1.3.5",
-            "lock-verify": "^2.0.2",
+            "lock-verify": "^2.1.0",
             "mkdirp": "^0.5.1",
             "npm-lifecycle": "^3.0.0",
             "npm-logical-tree": "^1.2.1",
@@ -7901,7 +7900,7 @@
           }
         },
         "libnpx": {
-          "version": "10.2.2",
+          "version": "10.2.4",
           "bundled": true,
           "requires": {
             "dotenv": "^5.0.1",
@@ -7911,15 +7910,7 @@
             "update-notifier": "^2.3.0",
             "which": "^1.3.0",
             "y18n": "^4.0.0",
-            "yargs": "^11.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "yargs": "^14.2.3"
           }
         },
         "lock-verify": {
@@ -8031,31 +8022,9 @@
             "ssri": "^6.0.0"
           }
         },
-        "map-age-cleaner": {
-          "version": "0.1.3",
-          "bundled": true,
-          "requires": {
-            "p-defer": "^1.0.0"
-          }
-        },
         "meant": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "bundled": true
-        },
-        "mem": {
-          "version": "4.3.0",
-          "bundled": true,
-          "requires": {
-            "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^2.0.0",
-            "p-is-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "mimic-fn": {
-              "version": "2.1.0",
-              "bundled": true
-            }
-          }
         },
         "mime-db": {
           "version": "1.35.0",
@@ -8074,6 +8043,10 @@
           "requires": {
             "brace-expansion": "^1.1.7"
           }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "bundled": true
         },
         "minizlib": {
           "version": "1.3.3",
@@ -8109,7 +8082,7 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.4",
+          "version": "0.5.5",
           "bundled": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -8147,10 +8120,6 @@
           "version": "0.0.7",
           "bundled": true
         },
-        "nice-try": {
-          "version": "1.0.5",
-          "bundled": true
-        },
         "node-fetch-npm": {
           "version": "2.0.2",
           "bundled": true,
@@ -8178,7 +8147,7 @@
           }
         },
         "nopt": {
-          "version": "4.0.1",
+          "version": "4.0.3",
           "bundled": true,
           "requires": {
             "abbrev": "1",
@@ -8205,7 +8174,7 @@
           }
         },
         "npm-audit-report": {
-          "version": "1.3.2",
+          "version": "1.3.3",
           "bundled": true,
           "requires": {
             "cli-table3": "^0.5.0",
@@ -8231,7 +8200,7 @@
           }
         },
         "npm-lifecycle": {
-          "version": "3.1.4",
+          "version": "3.1.5",
           "bundled": true,
           "requires": {
             "byline": "^5.0.0",
@@ -8290,7 +8259,7 @@
           }
         },
         "npm-registry-fetch": {
-          "version": "4.0.3",
+          "version": "4.0.7",
           "bundled": true,
           "requires": {
             "JSONStream": "^1.3.4",
@@ -8303,7 +8272,7 @@
           },
           "dependencies": {
             "safe-buffer": {
-              "version": "5.2.0",
+              "version": "5.2.1",
               "bundled": true
             }
           }
@@ -8368,41 +8337,6 @@
           "version": "1.0.2",
           "bundled": true
         },
-        "os-locale": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "execa": "^1.0.0",
-            "lcid": "^2.0.0",
-            "mem": "^4.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "6.0.5",
-              "bundled": true,
-              "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            },
-            "execa": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^4.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
-              }
-            }
-          }
-        },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true
@@ -8415,33 +8349,7 @@
             "os-tmpdir": "^1.0.0"
           }
         },
-        "p-defer": {
-          "version": "1.0.0",
-          "bundled": true
-        },
         "p-finally": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "p-is-promise": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "p-limit": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
           "version": "1.0.0",
           "bundled": true
         },
@@ -8676,12 +8584,6 @@
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.5",
-              "bundled": true
-            }
           }
         },
         "read": {
@@ -8796,7 +8698,7 @@
           "bundled": true
         },
         "require-main-filename": {
-          "version": "1.0.1",
+          "version": "2.0.0",
           "bundled": true
         },
         "resolve-from": {
@@ -8966,7 +8868,7 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.3",
+          "version": "3.0.5",
           "bundled": true
         },
         "split-on-first": {
@@ -9359,20 +9261,36 @@
           }
         },
         "wrap-ansi": {
-          "version": "2.1.0",
+          "version": "5.1.0",
           "bundled": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
             "string-width": {
-              "version": "1.0.2",
+              "version": "3.1.0",
               "bundled": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
               }
             }
           }
@@ -9407,34 +9325,93 @@
           "bundled": true
         },
         "yargs": {
-          "version": "11.1.1",
+          "version": "14.2.3",
           "bundled": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.1.0",
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
+            "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
+            "string-width": "^3.0.0",
             "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
           },
           "dependencies": {
-            "y18n": {
-              "version": "3.2.1",
+            "ansi-regex": {
+              "version": "4.1.0",
               "bundled": true
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
             }
           }
         },
         "yargs-parser": {
-          "version": "9.0.2",
+          "version": "15.0.1",
           "bundled": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "5.3.1",
+              "bundled": true
+            }
           }
         }
       }

--- a/script/package.json
+++ b/script/package.json
@@ -37,7 +37,7 @@
     "nock": "^13.0.2",
     "node-fetch": "^2.6.1",
     "normalize-package-data": "2.3.5",
-    "npm": "6.14.4",
+    "npm": "6.14.8",
     "npm-check": "^5.9.2",
     "passwd-user": "2.1.0",
     "pegjs": "0.9.0",

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -25,7 +25,7 @@ steps:
       versionSpec: 12.16.3
     displayName: Install Node.js 12.16.3
 
-  - script: npm install --global npm@6.9.0
+  - script: npm install --global npm@6.14.8
     displayName: Update npm
 
   # Windows Specific


### PR DESCRIPTION
### Description of the change

This updates npm to 6.14.8.

Related: https://github.com/atom/apm/pull/900

### Verification
The CI passes. npm versions are [Node version agnostic](https://github.com/npm/cli/blob/bd2721dbc3de13a5ba889eba50644475d80f6948/package.json#L311), so it will work on Node version without changing the behavior.

### Drawbacks
none

### Release Notes
- Update npm to 6.14.8


Closes https://github.com/atom/atom/pull/21051