### PR TITLE
Add non-native macOS fullscreen mode config

### DIFF
--- a/src/config-schema.js
+++ b/src/config-schema.js
@@ -637,6 +637,13 @@ if (process.platform === 'darwin') {
     description:
       'Experimental: A `custom` title bar adapts to theme colors. Choosing `custom-inset` adds a bit more padding. The title bar can also be completely `hidden`.<br>Note: Switching to a custom or hidden title bar will compromise some functionality.<br>This setting will require a relaunch of Atom to take effect.'
   };
+
+  configSchema.core.properties.simpleFullScreenWindows = {
+    type: 'boolean',
+    default: false,
+    description:
+      'Use pre-Lion fullscreen on macOS. This does not create a new desktop space for the atom on fullscreen mode.'
+  };
 }
 
 module.exports = configSchema;

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -50,7 +50,8 @@ module.exports = class AtomWindow extends EventEmitter {
         disableBlinkFeatures: 'Auxclick',
         nodeIntegration: true,
         webviewTag: true
-      }
+      },
+      simpleFullscreen: this.getSimpleFullscreen()
     };
 
     // Don't set icon on Windows so the exe's ico will be used as window and
@@ -362,6 +363,10 @@ module.exports = class AtomWindow extends EventEmitter {
     const [x, y] = Array.from(this.browserWindow.getPosition());
     const [width, height] = Array.from(this.browserWindow.getSize());
     return { x, y, width, height };
+  }
+
+  getSimpleFullscreen() {
+    return this.atomApplication.config.get('core.simpleFullScreenWindows');
   }
 
   shouldAddCustomTitleBar() {


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Issue or RFC Endorsed by Atom's Maintainers
Resolves https://github.com/atom/atom/issues/967

### Description of the Change
Adds a config `Simple Full Screen Windows` which allows non-native macOS fullscreen windows.

![Screenshot 2020-08-24 at 10 45 41](https://user-images.githubusercontent.com/5238135/91017491-fdbda080-e5f6-11ea-9a12-82fb9acb69d2.png)

### Alternate Designs

N/A

### Possible Drawbacks

No possible drawbacks

### Verification Process
Tested on dev mode atom. The setting works.

### Release Notes
- Add non-native macOS fullscreen mode.