### PR TITLE
CI: Restore caches in sync

### DIFF
--- a/script/vsts/platforms/templates/cache.yml
+++ b/script/vsts/platforms/templates/cache.yml
@@ -11,20 +11,20 @@ steps:
   - task: Cache@2
     displayName: Cache node_modules
     inputs:
-      key: 'npm | "$(Agent.OS)" | "$(buildArch)" | package.json, package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      key: 'npm_main | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
       path: 'node_modules'
       cacheHitVar: MainNodeModulesRestored
 
   - task: Cache@2
     displayName: Cache script/node_modules
     inputs:
-      key: 'npm | "$(Agent.OS)" | "$(buildArch)" | script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      key: 'npm_script | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
       path: 'script/node_modules'
       cacheHitVar: ScriptNodeModulesRestored
 
   - task: Cache@2
     displayName: Cache apm/node_modules
     inputs:
-      key: 'npm | "$(Agent.OS)" | "$(buildArch)" | apm/package.json, apm/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml'
+      key: 'npm_apm | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
       path: 'apm/node_modules'
       cacheHitVar: ApmNodeModulesRestored


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

Discussed here: https://github.com/atom/atom/pull/21057#issuecomment-680170267

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

To simplify how CI handles caches, restore all three `node_modules` folders in sync with one-another.

- Track the same files for restoring all three caches. Either they all get restored, or none of them do.
- Stop tracking `apm/package-lock.json`, as it hasn't been stable lately.
- Start tracking `script/vsts/platforms/templates/preparation.yml`, because that's where Node and npm bumps and so on will live if/when the CI config gets fully "template-ized". (See: https://github.com/atom/atom/pull/21081) (This file will be automatically ignored until such a time as it is added to the repository).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Independent cache restores (which we're doing as of before this PR), or maybe more-optimistically restoring `apm` since it gets native code rebuilt during install anyhow.

- Independent cache restores make it hard to track where restored files came from. Also, all the `node_modules` folders other than `apm/node_modules` are deleted by `npm ci`, so restoring them is just wasted time.
  - Verdict: not as good as this PR.
- Optimistically restoring `apm/node_modules` might be interesting, since it is installed with `npm install`, not `npm ci`; It's not deleted during bootstrap. But that's one more thing to test if it works well, so I'm considering it out of scope for this PR.
  - Verdict: maybe later?

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Reduces the scenarios in which the `apm/node_modules` cache will be restored. Could add a few minutes to bootstrapping.

(See alternate designs above; More-optimistically restoring `apm/node_modules` could be explored in a follow-up PR.)

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Tested in my personal fork's CI and the `atom-ide-community` fork's CI. Should work here as well.

(To verify: watch that the macOS and Windows test jobs restore all three caches, skip bootstrapping, and successfully proceed on to run their tests.)

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A
