### PR TITLE
Use npm install

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -4,11 +4,11 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm ci` completes.
+      # exits the script block after `npm install` completes.
       - script: |
           cd script/vsts
-          npm ci
-        displayName: npm ci
+          npm install
+        displayName: npm install
       - script: node script/vsts/get-release-version.js --nightly
         name: Version
 
@@ -38,11 +38,11 @@ jobs:
         displayName: Install Node.js 12.4.0
 
        #This has to be done separately because VSTS inexplicably
-       #exits the script block after `npm ci` completes.
+       #exits the script block after `npm install` completes.
       - script: |
           cd script/vsts
-          npm ci
-        displayName: npm ci
+          npm install
+        displayName: npm install
 
       - task: DownloadBuildArtifacts@0
         inputs:
@@ -76,14 +76,14 @@ jobs:
       - script: npm install --global npm@6.12.1
         displayName: Update npm
 
-      - script: | 
+      - script: |
           script/bootstrap
         displayName: Bootstrap
-      
-      - script: | 
+
+      - script: |
           cd script/lib
-          npm ci
-        displayName: npm ci
+          npm install
+        displayName: npm install
       - script: |
           cd script/lib/update-dependency
           node index.js

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -6,11 +6,11 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm ci` completes.
+      # exits the script block after `npm install` completes.
       - script: |
           cd script/vsts
-          npm ci
-        displayName: npm ci
+          npm install
+        displayName: npm install
       - script: node script/vsts/get-release-version.js
         name: Version
 

--- a/script/vsts/release-branch-build.yml
+++ b/script/vsts/release-branch-build.yml
@@ -10,11 +10,11 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm ci` completes.
+      # exits the script block after `npm install` completes.
       - script: |
           cd script/vsts
-          npm ci
-        displayName: npm ci
+          npm install
+        displayName: npm install
       - script: node script/vsts/get-release-version.js
         name: Version
 
@@ -45,13 +45,13 @@ jobs:
         displayName: Install Node.js 12.4.0
 
       # This has to be done separately because VSTS inexplicably
-      # exits the script block after `npm ci` completes.
+      # exits the script block after `npm install` completes.
       - script: |
           cd script/vsts
-          npm ci
+          npm install
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
-        displayName: npm ci
+        displayName: npm install
 
       - task: DownloadBuildArtifacts@0
         inputs:


### PR DESCRIPTION
After https://github.com/atom/atom/commit/c087fcfb490df22c858e98ade218ffaad5a94e71 we have been experiencing failures on our CI. The build atom step on linux fails with one of the two error messages.
- `FATAL ERROR: v8::HandleScope::CreateHandle() Cannot create a handle without a HandleScope`
- `/__w/_temp/20b36c6b-be24-40d6-a331-ce9e30f86b57.sh: line 1: 23246 Segmentation fault      (core dumped) script/build --no-bootstrap --create-debian-package --create-rpm-package --compress-artifacts`

With `npm install` the linux build step seem to pass successfully. I have run the CI with this change more than 10 times and all of builds passed this stage.
