### PR TITLE
CI build template including patches

### DIFF
--- a/script/vsts/platforms/linux.yml
+++ b/script/vsts/platforms/linux.yml
@@ -20,19 +20,7 @@ jobs:
       - script: script/lint
         displayName: Run linter
 
-      - script: script/build --no-bootstrap --create-debian-package --create-rpm-package --compress-artifacts
-        env:
-          GITHUB_TOKEN: $(GITHUB_TOKEN)
-          ATOM_RELEASE_VERSION: $(ReleaseVersion)
-          CC: clang
-          CXX: clang++
-          npm_config_clang: 1
-        displayName: Build Atom
-
-      - script: |
-          sudo chown root ./out/atom*-amd64/chrome-sandbox
-          sudo chmod 4755 ./out/atom*-amd64/chrome-sandbox
-        displayName: Tweaking chrome-sandbox binary
+      - template: templates/build.yml
 
       - script: script/test
         env:

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -23,24 +23,7 @@ jobs:
       - script: script/lint
         displayName: Run linter
 
-      - script: |
-          if [ $SHOULD_SIGN == "true" ] && ([ $IS_RELEASE_BRANCH == "true" ] || [ $IS_SIGNED_ZIP_BRANCH == "true" ]); then
-            script/build --no-bootstrap --code-sign --compress-artifacts
-          else
-            script/build --no-bootstrap --compress-artifacts
-          fi
-        displayName: Build Atom
-        env:
-          GITHUB_TOKEN: $(GITHUB_TOKEN)
-          IS_RELEASE_BRANCH: $(IsReleaseBranch)
-          IS_SIGNED_ZIP_BRANCH: $(IsSignedZipBranch)
-          ATOM_RELEASE_VERSION: $(ReleaseVersion)
-          ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL: $(ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL)
-          ATOM_MAC_CODE_SIGNING_CERT_PASSWORD: $(ATOM_MAC_CODE_SIGNING_CERT_PASSWORD)
-          ATOM_MAC_CODE_SIGNING_KEYCHAIN: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN)
-          ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD)
-          AC_USER: $(AC_USER)
-          AC_PASSWORD: $(AC_PASSWORD)
+      - template: templates/build.yml
 
       - script: |
           cp $(Build.SourcesDirectory)/out/*.zip $(Build.ArtifactStagingDirectory)

--- a/script/vsts/platforms/templates/build.yml
+++ b/script/vsts/platforms/templates/build.yml
@@ -1,0 +1,58 @@
+steps:
+  - pwsh: |
+      # OS specific env variables
+      if ($env:AGENT_OS -eq "Windows_NT") {
+        $env:SQUIRREL_TEMP="C:/tmp"
+        $env:npm_config_build_from_source=true
+      }
+      elseif ($env:AGENT_OS -eq "Darwin") {
+        $AC_USER=$env:AC_USER
+        $AC_PASSWORD=$env:AC_PASSWORD
+      }
+      elseif ($env:AGENT_OS -eq "Linux") {
+        $env:CC=clang
+        $env:CXX=clang++
+        $env:npm_config_clang=1
+        $env:LinuxArgs="--create-debian-package --create-rpm-package"
+        $env:SHOULD_SIGN="false"
+      }
+
+      # Build Arguments
+      ## Creation of Windows Installaer
+      if ($env:AGENT_OS -eq "Windows_NT") {
+        mkdir -f -p $env:SQUIRREL_TEMP
+        if ($env:IS_RELEASE_BRANCH -eq "true") {
+          $CreateWindowsInstallaer="--create-windows-installer"
+        }
+      }
+
+      ## Code Sign
+      if ( ($env:SHOULD_SIGN -eq "true") -and (($env:IS_RELEASE_BRANCH -eq "true")  -or ($env:IS_SIGNED_ZIP_BRANCH -eq "true")) ) {
+        $CodeSign="--code-sign"
+      }
+
+      # Build
+      $esc = '--%'
+      if (($env:AGENT_OS  -eq "Windows_NT") -and ($env:BUILD_ARCH -eq "x86")) {
+        node 'script\vsts\windows-run.js' 'script\build.cmd' --no-bootstrap --compress-artifacts $esc $CodeSign $CreateWindowsInstallaer
+      } else {
+        script/build --no-bootstrap --compress-artifacts $esc $env:LinuxArgs $CodeSign $CreateWindowsInstallaer
+      }
+    displayName: Build Atom
+    env:
+      GITHUB_TOKEN: $(GITHUB_TOKEN)
+      IS_RELEASE_BRANCH: $(IsReleaseBranch)
+      IS_SIGNED_ZIP_BRANCH: $(IsSignedZipBranch)
+      ATOM_RELEASE_VERSION: $(ReleaseVersion)
+      ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL: $(ATOM_MAC_CODE_SIGNING_CERT_DOWNLOAD_URL)
+      ATOM_MAC_CODE_SIGNING_CERT_PASSWORD: $(ATOM_MAC_CODE_SIGNING_CERT_PASSWORD)
+      ATOM_MAC_CODE_SIGNING_KEYCHAIN: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN)
+      ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD)
+      ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL: $(ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL)
+      ATOM_WIN_CODE_SIGNING_CERT_PASSWORD: $(ATOM_WIN_CODE_SIGNING_CERT_PASSWORD)
+
+  - script: |
+      sudo chown root ./out/atom*-amd64/chrome-sandbox
+      sudo chmod 4755 ./out/atom*-amd64/chrome-sandbox
+    displayName: Tweaking chrome-sandbox binary
+    condition: eq(variables['Agent.OS'], 'Linux')

--- a/script/vsts/platforms/templates/build.yml
+++ b/script/vsts/platforms/templates/build.yml
@@ -5,10 +5,6 @@ steps:
         $env:SQUIRREL_TEMP="C:/tmp"
         $env:npm_config_build_from_source=true
       }
-      elseif ($env:AGENT_OS -eq "Darwin") {
-        $AC_USER=$env:AC_USER
-        $AC_PASSWORD=$env:AC_PASSWORD
-      }
       elseif ($env:AGENT_OS -eq "Linux") {
         $env:CC=clang
         $env:CXX=clang++
@@ -48,6 +44,8 @@ steps:
       ATOM_MAC_CODE_SIGNING_CERT_PASSWORD: $(ATOM_MAC_CODE_SIGNING_CERT_PASSWORD)
       ATOM_MAC_CODE_SIGNING_KEYCHAIN: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN)
       ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD: $(ATOM_MAC_CODE_SIGNING_KEYCHAIN_PASSWORD)
+      AC_USER: $(AC_USER)
+      AC_PASSWORD: $(AC_PASSWORD)
       ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL: $(ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL)
       ATOM_WIN_CODE_SIGNING_CERT_PASSWORD: $(ATOM_WIN_CODE_SIGNING_CERT_PASSWORD)
 

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -33,39 +33,7 @@ jobs:
           BUILD_ARCH: $(buildArch)
         displayName: Run linter
 
-      - script: |
-          IF NOT EXIST C:\tmp MKDIR C:\tmp
-          SET SQUIRREL_TEMP=C:\tmp
-          IF [%IS_RELEASE_BRANCH%]==[true] (
-            ECHO Creating production artifacts for release branch %BUILD_SOURCEBRANCHNAME%
-            IF [%SHOULD_SIGN%]==[true] (
-             node script\vsts\windows-run.js script\build.cmd --no-bootstrap --code-sign --compress-artifacts --create-windows-installer
-            ) ELSE (
-             node script\vsts\windows-run.js script\build.cmd --no-bootstrap --compress-artifacts --create-windows-installer
-            )
-          ) ELSE (
-            IF [%IS_SIGNED_ZIP_BRANCH%]==[true] (
-              ECHO Creating signed CI artifacts for branch %BUILD_SOURCEBRANCHNAME%
-             IF [%SHOULD_SIGN%]==[true] (
-              node script\vsts\windows-run.js script\build.cmd --no-bootstrap --code-sign --compress-artifacts
-             ) ELSE (
-              node script\vsts\windows-run.js script\build.cmd --no-bootstrap --compress-artifacts
-             )
-            ) ELSE (
-              ECHO Pull request build, no code signing will be performed
-              node script\vsts\windows-run.js script\build.cmd --no-bootstrap --compress-artifacts
-            )
-          )
-        env:
-          GITHUB_TOKEN: $(GITHUB_TOKEN)
-          BUILD_ARCH: $(buildArch)
-          ATOM_RELEASE_VERSION: $(ReleaseVersion)
-          ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL: $(ATOM_WIN_CODE_SIGNING_CERT_DOWNLOAD_URL)
-          ATOM_WIN_CODE_SIGNING_CERT_PASSWORD: $(ATOM_WIN_CODE_SIGNING_CERT_PASSWORD)
-          IS_RELEASE_BRANCH: $(IsReleaseBranch)
-          IS_SIGNED_ZIP_BRANCH: $(IsSignedZipBranch)
-          npm_config_build_from_source: true
-        displayName: Build Atom
+      - template: templates/build.yml
 
       - script: node script\vsts\windows-run.js script\test.cmd
         env:


### PR DESCRIPTION
#21230 including patches

This moves the secret variable to the env map. The problems of the old PR was because I did not know which variables are saved as secret in the Azure UI, and so I assumed they are available as environment variables in the shells.

Didn't notice that AC user and password are secrets variables too.