### PR TITLE
Refactor text-editor-registry .build test from async to sync

### DIFF
--- a/spec/text-editor-registry-spec.js
+++ b/spec/text-editor-registry-spec.js
@@ -3,6 +3,7 @@ const TextEditor = require('../src/text-editor');
 const TextBuffer = require('text-buffer');
 const { Point, Range } = TextBuffer;
 const dedent = require('dedent');
+const NullGrammar = require('../src/null-grammar');
 
 describe('TextEditorRegistry', function() {
   let registry, editor, initialPackageActivation;
@@ -69,16 +70,24 @@ describe('TextEditorRegistry', function() {
   });
 
   describe('.build', function() {
-    it('constructs a TextEditor with the right parameters based on its path and text', async function() {
-      await atom.packages.activatePackage('language-javascript');
-      await atom.packages.activatePackage('language-c');
-
+    it('constructs a TextEditor with the right parameters based on its path and text', function() {
       atom.config.set('editor.tabLength', 8, { scope: '.source.js' });
 
+      const languageMode = {
+        grammar: NullGrammar,
+        onDidChangeHighlighting: jasmine.createSpy()
+      };
+
+      const buffer = new TextBuffer({ filePath: 'test.js' });
+      buffer.setLanguageMode(languageMode);
+
       const editor = registry.build({
-        buffer: new TextBuffer({ filePath: 'test.js' })
+        buffer
       });
+
       expect(editor.getTabLength()).toBe(8);
+      expect(editor.getGrammar()).toEqual(NullGrammar);
+      expect(languageMode.onDidChangeHighlighting.calls.length).toBe(1);
     });
   });
 


### PR DESCRIPTION
### Reason for change
This test has been flaky on our CI due to its async nature. It is the most frequent failing test on our CI. 
The failures are due to timeouts on the CI. The timeouts could be as a result of slow infrastructure (slow vm's) which we have no control over.

This aims to resolve the timeout failures by making the async test sync.

### Expectation
The expectation is for `.build` to construct `TextEditor` with the right params.
We don't have to load the correct language package for this test. We can load a stub `languageMode` and assert that the correct grammar is set on `TextEditor`