### PR TITLE
Async bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -35,7 +35,9 @@ async function bootstrap() {
 
   if (process.platform === 'win32') deleteMsbuildFromPath()
 
-  process.env.JOBS = "max";
+  if (proces.env.JOBS === undefined) {
+    process.env.JOBS = "max";
+  }
 
   await Promise.all([
     installScriptDependencies(ci),

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,45 +2,61 @@
 
 'use strict'
 
-const path = require('path')
-const CONFIG = require('./config')
-const childProcess = require('child_process')
-const cleanDependencies = require('./lib/clean-dependencies')
-const deleteMsbuildFromPath = require('./lib/delete-msbuild-from-path')
-const dependenciesFingerprint = require('./lib/dependencies-fingerprint')
-const installApm = require('./lib/install-apm')
-const runApmInstall = require('./lib/run-apm-install')
-const installScriptDependencies = require('./lib/install-script-dependencies')
-const verifyMachineRequirements = require('./lib/verify-machine-requirements')
+async function bootstrap() {
+  const path = require('path')
+  const CONFIG = require('./config')
+  const childProcess = require('child_process')
+  const cleanDependencies = require('./lib/clean-dependencies')
+  const deleteMsbuildFromPath = require('./lib/delete-msbuild-from-path')
+  const dependenciesFingerprint = require('./lib/dependencies-fingerprint')
+  const installApm = require('./lib/install-apm')
+  const runApmInstall = require('./lib/run-apm-install')
+  const installScriptDependencies = require('./lib/install-script-dependencies')
+  const verifyMachineRequirements = require('./lib/verify-machine-requirements')
 
-process.on('unhandledRejection', function (e) {
-  console.error(e.stack || e)
-  process.exit(1)
-})
+  process.on('unhandledRejection', function (e) {
+    console.error(e.stack || e)
+    process.exit(1)
+  })
 
-// We can't use yargs until installScriptDependencies() is executed, so...
-let ci = process.argv.indexOf('--ci') !== -1
+  // We can't use yargs until installScriptDependencies() is executed, so...
+  let ci = process.argv.indexOf('--ci') !== -1
 
-if (!ci && process.env.CI === 'true' && process.argv.indexOf('--no-ci') === -1) {
-  console.log('Automatically enabling --ci because CI is set in the environment')
-  ci = true
+  if (!ci && process.env.CI === 'true' && process.argv.indexOf('--no-ci') === -1) {
+    console.log('Automatically enabling --ci because CI is set in the environment')
+    ci = true
+  }
+
+  verifyMachineRequirements(ci)
+
+  if (dependenciesFingerprint.isOutdated()) {
+    cleanDependencies()
+  }
+
+  if (process.platform === 'win32') deleteMsbuildFromPath()
+
+  process.env.JOBS = "max";
+
+  await Promise.all([
+    installScriptDependencies(ci),
+    installApm(ci, true)
+      .then(() => {
+        childProcess.execFileSync(
+          CONFIG.getApmBinPath(),
+          ['--version'],
+          { stdio: 'inherit' }
+        );
+      })
+      .then(() => runApmInstall(CONFIG.repositoryRootPath, ci, undefined, true)),
+  ]);
+
+  dependenciesFingerprint.write()
 }
 
-verifyMachineRequirements(ci)
-
-if (dependenciesFingerprint.isOutdated()) {
-  cleanDependencies()
+if (require.main === module) {
+  bootstrap();
 }
 
-if (process.platform === 'win32') deleteMsbuildFromPath()
-
-installScriptDependencies(ci)
-installApm(ci)
-childProcess.execFileSync(
-  CONFIG.getApmBinPath(),
-  ['--version'],
-  {stdio: 'inherit'}
-)
-runApmInstall(CONFIG.repositoryRootPath, ci)
-
-dependenciesFingerprint.write()
+module.exports = {
+  bootstrap,
+};

--- a/script/build
+++ b/script/build
@@ -2,160 +2,166 @@
 
 'use strict'
 
-if (process.argv.includes('--no-bootstrap')) {
-  console.log('Skipping bootstrap')
-} else {
-  // Bootstrap first to ensure all the dependencies used later in this script
-  // are installed.
-  require('./bootstrap')
-}
+async function build() {
+  if (process.argv.includes('--no-bootstrap')) {
+    console.log('Skipping bootstrap')
+  } else {
+    // Bootstrap first to ensure all the dependencies used later in this script
+    // are installed.
+    await require('./bootstrap').bootstrap();
+  }
 
-// Required to load CS files in this build script, such as those in `donna`
-require('coffee-script/register')
-require('colors')
+  // Required to load CS files in this build script, such as those in `donna`
+  require('coffee-script/register')
+  require('colors')
 
-const path = require('path')
-const yargs = require('yargs')
-const argv = yargs
-  .usage('Usage: $0 [options]')
-  .help('help')
-  .describe('existing-binaries', 'Use existing Atom binaries (skip clean/transpile/cache)')
-  .describe('code-sign', 'Code-sign executables (macOS and Windows only)')
-  .describe('test-sign', 'Test-sign executables (macOS only)')
-  .describe('create-windows-installer', 'Create installer (Windows only)')
-  .describe('create-debian-package', 'Create .deb package (Linux only)')
-  .describe('create-rpm-package', 'Create .rpm package (Linux only)')
-  .describe('compress-artifacts', 'Compress Atom binaries (and symbols on macOS)')
-  .describe('generate-api-docs', 'Only build the API documentation')
-  .describe('install', 'Install Atom')
-  .string('install')
-  .describe('ci', 'Install dependencies quickly (package-lock.json files must be up to date)')
-  .wrap(yargs.terminalWidth())
-  .argv
+  const path = require('path')
+  const yargs = require('yargs')
+  const argv = yargs
+    .usage('Usage: $0 [options]')
+    .help('help')
+    .describe('existing-binaries', 'Use existing Atom binaries (skip clean/transpile/cache)')
+    .describe('code-sign', 'Code-sign executables (macOS and Windows only)')
+    .describe('test-sign', 'Test-sign executables (macOS only)')
+    .describe('create-windows-installer', 'Create installer (Windows only)')
+    .describe('create-debian-package', 'Create .deb package (Linux only)')
+    .describe('create-rpm-package', 'Create .rpm package (Linux only)')
+    .describe('compress-artifacts', 'Compress Atom binaries (and symbols on macOS)')
+    .describe('generate-api-docs', 'Only build the API documentation')
+    .describe('install', 'Install Atom')
+    .string('install')
+    .describe('ci', 'Install dependencies quickly (package-lock.json files must be up to date)')
+    .wrap(yargs.terminalWidth())
+    .argv
 
-const checkChromedriverVersion = require('./lib/check-chromedriver-version')
-const cleanOutputDirectory = require('./lib/clean-output-directory')
-const codeSignOnMac = require('./lib/code-sign-on-mac')
-const codeSignOnWindows = require('./lib/code-sign-on-windows')
-const compressArtifacts = require('./lib/compress-artifacts')
-const copyAssets = require('./lib/copy-assets')
-const createDebianPackage = require('./lib/create-debian-package')
-const createRpmPackage = require('./lib/create-rpm-package')
-const createWindowsInstaller = require('./lib/create-windows-installer')
-const dumpSymbols = require('./lib/dump-symbols')
-const generateAPIDocs = require('./lib/generate-api-docs')
-const generateMetadata = require('./lib/generate-metadata')
-const generateModuleCache = require('./lib/generate-module-cache')
-const generateStartupSnapshot = require('./lib/generate-startup-snapshot')
-const installApplication = require('./lib/install-application')
-const notarizeOnMac = require('./lib/notarize-on-mac')
-const packageApplication = require('./lib/package-application')
-const prebuildLessCache = require('./lib/prebuild-less-cache')
-const testSignOnMac = require('./lib/test-sign-on-mac')
-const transpileBabelPaths = require('./lib/transpile-babel-paths')
-const transpileCoffeeScriptPaths = require('./lib/transpile-coffee-script-paths')
-const transpileCsonPaths = require('./lib/transpile-cson-paths')
-const transpilePegJsPaths = require('./lib/transpile-peg-js-paths')
-const transpilePackagesWithCustomTranspilerPaths = require('./lib/transpile-packages-with-custom-transpiler-paths.js')
+  const checkChromedriverVersion = require('./lib/check-chromedriver-version')
+  const cleanOutputDirectory = require('./lib/clean-output-directory')
+  const codeSignOnMac = require('./lib/code-sign-on-mac')
+  const codeSignOnWindows = require('./lib/code-sign-on-windows')
+  const compressArtifacts = require('./lib/compress-artifacts')
+  const copyAssets = require('./lib/copy-assets')
+  const createDebianPackage = require('./lib/create-debian-package')
+  const createRpmPackage = require('./lib/create-rpm-package')
+  const createWindowsInstaller = require('./lib/create-windows-installer')
+  const dumpSymbols = require('./lib/dump-symbols')
+  const generateAPIDocs = require('./lib/generate-api-docs')
+  const generateMetadata = require('./lib/generate-metadata')
+  const generateModuleCache = require('./lib/generate-module-cache')
+  const generateStartupSnapshot = require('./lib/generate-startup-snapshot')
+  const installApplication = require('./lib/install-application')
+  const notarizeOnMac = require('./lib/notarize-on-mac')
+  const packageApplication = require('./lib/package-application')
+  const prebuildLessCache = require('./lib/prebuild-less-cache')
+  const testSignOnMac = require('./lib/test-sign-on-mac')
+  const transpileBabelPaths = require('./lib/transpile-babel-paths')
+  const transpileCoffeeScriptPaths = require('./lib/transpile-coffee-script-paths')
+  const transpileCsonPaths = require('./lib/transpile-cson-paths')
+  const transpilePegJsPaths = require('./lib/transpile-peg-js-paths')
+  const transpilePackagesWithCustomTranspilerPaths = require('./lib/transpile-packages-with-custom-transpiler-paths.js')
 
-process.on('unhandledRejection', function (e) {
-  console.error(e.stack || e)
-  process.exit(1)
-})
+  process.on('unhandledRejection', function (e) {
+    console.error(e.stack || e)
+    process.exit(1)
+  })
 
-const CONFIG = require('./config')
-process.env.ELECTRON_VERSION = CONFIG.appMetadata.electronVersion
+  const CONFIG = require('./config')
+  process.env.ELECTRON_VERSION = CONFIG.appMetadata.electronVersion
 
-let binariesPromise = Promise.resolve()
+  let binariesPromise = Promise.resolve()
 
-if (!argv.existingBinaries) {
-  checkChromedriverVersion()
-  cleanOutputDirectory()
-  copyAssets()
-  transpilePackagesWithCustomTranspilerPaths()
-  transpileBabelPaths()
-  transpileCoffeeScriptPaths()
-  transpileCsonPaths()
-  transpilePegJsPaths()
-  generateModuleCache()
-  prebuildLessCache()
-  generateMetadata()
-  generateAPIDocs()
+  if (!argv.existingBinaries) {
+    checkChromedriverVersion()
+    cleanOutputDirectory()
+    copyAssets()
+    transpilePackagesWithCustomTranspilerPaths()
+    transpileBabelPaths()
+    transpileCoffeeScriptPaths()
+    transpileCsonPaths()
+    transpilePegJsPaths()
+    generateModuleCache()
+    prebuildLessCache()
+    generateMetadata()
+    generateAPIDocs()
+    if (!argv.generateApiDocs) {
+      binariesPromise = dumpSymbols()
+    }
+  }
+
   if (!argv.generateApiDocs) {
-    binariesPromise = dumpSymbols()
+    binariesPromise
+      .then(packageApplication)
+      .then(packagedAppPath => generateStartupSnapshot(packagedAppPath).then(() => packagedAppPath))
+      .then(async packagedAppPath => {
+        switch (process.platform) {
+          case 'darwin': {
+            if (argv.codeSign) {
+              await codeSignOnMac(packagedAppPath)
+              await notarizeOnMac(packagedAppPath)
+            } else if (argv.testSign) {
+              testSignOnMac(packagedAppPath)
+            } else {
+              console.log('Skipping code-signing. Specify the --code-sign option to perform code-signing'.gray)
+            }
+            break
+          }
+          case 'win32': {
+            if (argv.testSign) {
+              console.log('Test signing is not supported on Windows, skipping.'.gray)
+            }
+
+            if (argv.codeSign) {
+              const executablesToSign = [path.join(packagedAppPath, CONFIG.executableName)]
+              if (argv.createWindowsInstaller) {
+                executablesToSign.push(path.join(__dirname, 'node_modules', '@atom', 'electron-winstaller', 'vendor', 'Squirrel.exe'))
+              }
+              codeSignOnWindows(executablesToSign)
+            } else {
+              console.log('Skipping code-signing. Specify the --code-sign option to perform code-signing'.gray)
+            }
+            if (argv.createWindowsInstaller) {
+              return createWindowsInstaller(packagedAppPath)
+                .then((installerPath) => {
+                  argv.codeSign && codeSignOnWindows([installerPath])
+                  return packagedAppPath
+                })
+            } else {
+              console.log('Skipping creating installer. Specify the --create-windows-installer option to create a Squirrel-based Windows installer.'.gray)
+            }
+            break
+          }
+          case 'linux': {
+            if (argv.createDebianPackage) {
+              createDebianPackage(packagedAppPath)
+            } else {
+              console.log('Skipping creating debian package. Specify the --create-debian-package option to create it.'.gray)
+            }
+
+            if (argv.createRpmPackage) {
+              createRpmPackage(packagedAppPath)
+            } else {
+              console.log('Skipping creating rpm package. Specify the --create-rpm-package option to create it.'.gray)
+            }
+            break
+          }
+        }
+
+        return Promise.resolve(packagedAppPath)
+      }).then(packagedAppPath => {
+        if (argv.compressArtifacts) {
+          compressArtifacts(packagedAppPath)
+        } else {
+          console.log('Skipping artifacts compression. Specify the --compress-artifacts option to compress Atom binaries (and symbols on macOS)'.gray)
+        }
+
+        if (argv.install != null) {
+          installApplication(packagedAppPath, argv.install)
+        } else {
+          console.log('Skipping installation. Specify the --install option to install Atom'.gray)
+        }
+      })
   }
 }
 
-if (!argv.generateApiDocs) {
-  binariesPromise
-    .then(packageApplication)
-    .then(packagedAppPath => generateStartupSnapshot(packagedAppPath).then(() => packagedAppPath))
-    .then(async packagedAppPath => {
-      switch (process.platform) {
-        case 'darwin': {
-          if (argv.codeSign) {
-            await codeSignOnMac(packagedAppPath)
-            await notarizeOnMac(packagedAppPath)
-          } else if (argv.testSign) {
-            testSignOnMac(packagedAppPath)
-          } else {
-            console.log('Skipping code-signing. Specify the --code-sign option to perform code-signing'.gray)
-          }
-          break
-        }
-        case 'win32': {
-          if (argv.testSign) {
-            console.log('Test signing is not supported on Windows, skipping.'.gray)
-          }
-
-          if (argv.codeSign) {
-            const executablesToSign = [ path.join(packagedAppPath, CONFIG.executableName) ]
-            if (argv.createWindowsInstaller) {
-              executablesToSign.push(path.join(__dirname, 'node_modules', '@atom', 'electron-winstaller', 'vendor', 'Squirrel.exe'))
-            }
-            codeSignOnWindows(executablesToSign)
-          } else {
-            console.log('Skipping code-signing. Specify the --code-sign option to perform code-signing'.gray)
-          }
-          if (argv.createWindowsInstaller) {
-            return createWindowsInstaller(packagedAppPath)
-              .then((installerPath) => {
-                argv.codeSign && codeSignOnWindows([installerPath])
-                return packagedAppPath
-              })
-          } else {
-            console.log('Skipping creating installer. Specify the --create-windows-installer option to create a Squirrel-based Windows installer.'.gray)
-          }
-          break
-        }
-        case 'linux': {
-          if (argv.createDebianPackage) {
-            createDebianPackage(packagedAppPath)
-          } else {
-            console.log('Skipping creating debian package. Specify the --create-debian-package option to create it.'.gray)
-          }
-
-          if (argv.createRpmPackage) {
-            createRpmPackage(packagedAppPath)
-          } else {
-            console.log('Skipping creating rpm package. Specify the --create-rpm-package option to create it.'.gray)
-          }
-          break
-        }
-      }
-
-      return Promise.resolve(packagedAppPath)
-    }).then(packagedAppPath => {
-      if (argv.compressArtifacts) {
-        compressArtifacts(packagedAppPath)
-      } else {
-        console.log('Skipping artifacts compression. Specify the --compress-artifacts option to compress Atom binaries (and symbols on macOS)'.gray)
-      }
-
-      if (argv.install != null) {
-        installApplication(packagedAppPath, argv.install)
-      } else {
-        console.log('Skipping installation. Specify the --install option to install Atom'.gray)
-      }
-    })
+if (require.main === module) {
+  build();
 }

--- a/script/lib/install-apm.js
+++ b/script/lib/install-apm.js
@@ -4,7 +4,7 @@ const childProcess = require('child_process');
 
 const CONFIG = require('../config');
 
-module.exports = function(ci, promise=false) {
+module.exports = function(ci, promise = false) {
   console.log('Installing apm');
   // npm ci leaves apm with a bunch of unmet dependencies
 
@@ -15,11 +15,11 @@ module.exports = function(ci, promise=false) {
         ['--global-style', '--loglevel=error', 'install'],
         { env: process.env, cwd: CONFIG.apmRootPath },
         () => {
-          console.log("Installed apm");
+          console.log('Installed apm');
           resolve();
         }
       );
-    })
+    });
   } else {
     childProcess.execFileSync(
       CONFIG.getNpmBinPath(),

--- a/script/lib/install-apm.js
+++ b/script/lib/install-apm.js
@@ -4,12 +4,27 @@ const childProcess = require('child_process');
 
 const CONFIG = require('../config');
 
-module.exports = function(ci) {
+module.exports = function(ci, promise=false) {
   console.log('Installing apm');
   // npm ci leaves apm with a bunch of unmet dependencies
-  childProcess.execFileSync(
-    CONFIG.getNpmBinPath(),
-    ['--global-style', '--loglevel=error', 'install'],
-    { env: process.env, cwd: CONFIG.apmRootPath }
-  );
+
+  if (promise) {
+    return new Promise(resolve => {
+      childProcess.execFile(
+        CONFIG.getNpmBinPath(),
+        ['--global-style', '--loglevel=error', 'install'],
+        { env: process.env, cwd: CONFIG.apmRootPath },
+        () => {
+          console.log("Installed apm");
+          resolve();
+        }
+      );
+    })
+  } else {
+    childProcess.execFileSync(
+      CONFIG.getNpmBinPath(),
+      ['--global-style', '--loglevel=error', 'install'],
+      { env: process.env, cwd: CONFIG.apmRootPath }
+    );
+  }
 };

--- a/script/lib/install-script-dependencies.js
+++ b/script/lib/install-script-dependencies.js
@@ -7,10 +7,16 @@ const CONFIG = require('../config');
 process.env.ELECTRON_CUSTOM_VERSION = CONFIG.appMetadata.electronVersion;
 
 module.exports = function(ci) {
-  console.log('Installing script dependencies');
-  childProcess.execFileSync(
-    CONFIG.getNpmBinPath(ci),
-    ['--loglevel=error', ci ? 'ci' : 'install'],
-    { env: process.env, cwd: CONFIG.scriptRootPath }
-  );
+  return new Promise(resolve => {
+    console.log('Installing script dependencies');
+    childProcess.execFile(
+      CONFIG.getNpmBinPath(ci),
+      ['--loglevel=error', ci ? 'ci' : 'install'],
+      { env: process.env, cwd: CONFIG.scriptRootPath },
+      () => {
+        console.log("Installed script dependencies");
+        resolve()
+      },
+    );
+  })
 };

--- a/script/lib/install-script-dependencies.js
+++ b/script/lib/install-script-dependencies.js
@@ -14,9 +14,9 @@ module.exports = function(ci) {
       ['--loglevel=error', ci ? 'ci' : 'install'],
       { env: process.env, cwd: CONFIG.scriptRootPath },
       () => {
-        console.log("Installed script dependencies");
-        resolve()
-      },
+        console.log('Installed script dependencies');
+        resolve();
+      }
     );
-  })
+  });
 };

--- a/script/lib/run-apm-install.js
+++ b/script/lib/run-apm-install.js
@@ -4,16 +4,27 @@ const childProcess = require('child_process');
 
 const CONFIG = require('../config');
 
-module.exports = function(packagePath, ci, stdioOptions) {
+module.exports = function(packagePath, ci, stdioOptions, promise=false) {
   const installEnv = Object.assign({}, process.env);
   // Set resource path so that apm can load metadata related to Atom.
   installEnv.ATOM_RESOURCE_PATH = CONFIG.repositoryRootPath;
   // Set our target (Electron) version so that node-pre-gyp can download the
   // proper binaries.
   installEnv.npm_config_target = CONFIG.appMetadata.electronVersion;
-  childProcess.execFileSync(CONFIG.getApmBinPath(), [ci ? 'ci' : 'install'], {
-    env: installEnv,
-    cwd: packagePath,
-    stdio: stdioOptions || 'inherit'
-  });
+
+  if (promise) {
+    return new Promise(resolve => {
+      childProcess.execFile(CONFIG.getApmBinPath(), [ci ? 'ci' : 'install'], {
+        env: installEnv,
+        cwd: packagePath,
+        stdio: stdioOptions || 'inherit'
+      }, () => resolve());
+    })
+  } else {
+    childProcess.execFileSync(CONFIG.getApmBinPath(), [ci ? 'ci' : 'install'], {
+      env: installEnv,
+      cwd: packagePath,
+      stdio: stdioOptions || 'inherit'
+    });
+  }
 };

--- a/script/lib/run-apm-install.js
+++ b/script/lib/run-apm-install.js
@@ -4,7 +4,7 @@ const childProcess = require('child_process');
 
 const CONFIG = require('../config');
 
-module.exports = function(packagePath, ci, stdioOptions, promise=false) {
+module.exports = function(packagePath, ci, stdioOptions, promise = false) {
   const installEnv = Object.assign({}, process.env);
   // Set resource path so that apm can load metadata related to Atom.
   installEnv.ATOM_RESOURCE_PATH = CONFIG.repositoryRootPath;
@@ -14,12 +14,17 @@ module.exports = function(packagePath, ci, stdioOptions, promise=false) {
 
   if (promise) {
     return new Promise(resolve => {
-      childProcess.execFile(CONFIG.getApmBinPath(), [ci ? 'ci' : 'install'], {
-        env: installEnv,
-        cwd: packagePath,
-        stdio: stdioOptions || 'inherit'
-      }, () => resolve());
-    })
+      childProcess.execFile(
+        CONFIG.getApmBinPath(),
+        [ci ? 'ci' : 'install'],
+        {
+          env: installEnv,
+          cwd: packagePath,
+          stdio: stdioOptions || 'inherit'
+        },
+        () => resolve()
+      );
+    });
   } else {
     childProcess.execFileSync(CONFIG.getApmBinPath(), [ci ? 'ci' : 'install'], {
       env: installEnv,


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Issue or RFC Endorsed by Atom's Maintainers

None yet. This PR should show if it's worth looking into.

### Description of the Change

Attempts to make key parts of the build script async. Many stages of the build do not depend on others, but a lot of synchronous file operations are used. This PR converts many of them to use promises, to allow multiple steps to run concurrently. This is expected to be an improvement because the build seems to be IO heavy.

This change is relatively conservative, as there are still parts that use synchronous calls. I also haven't worked out all the dependencies yet, so it's possible some steps may still be run concurrently.

### Alternate Designs

I noticed @aminya is trying out worker threads. It would be interesting to see if that approach offers any significant gains over Promises.

### Possible Drawbacks

It makes logging more difficult :(. It's not a problem though, the work in #21288 theoretically supports logging for async jobs (even across worker threads).

### Verification Process

CI passes and time for bootstrap ~~+ build~~ is decreased.

Edit: The initial approach had a lot of changes, and something broke. I've restricted it to just the bootstrap right now.

### Release Notes
NA