### PR TITLE
Parallel Bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -8,9 +8,7 @@ const childProcess = require('child_process')
 const cleanDependencies = require('./lib/clean-dependencies')
 const deleteMsbuildFromPath = require('./lib/delete-msbuild-from-path')
 const dependenciesFingerprint = require('./lib/dependencies-fingerprint')
-const installApm = require('./lib/install-apm')
-const runApmInstall = require('./lib/run-apm-install')
-const installScriptDependencies = require('./lib/install-script-dependencies')
+const installScriptRunnerDependencies = require('./lib/install-script-runner-dependencies')
 const verifyMachineRequirements = require('./lib/verify-machine-requirements')
 
 process.on('unhandledRejection', function (e) {
@@ -34,16 +32,26 @@ if (dependenciesFingerprint.isOutdated()) {
 
 if (process.platform === 'win32') deleteMsbuildFromPath()
 
-installScriptDependencies(ci)
-installApm(ci)
-const apmVersionEnv = Object.assign({}, process.env);
-// Set resource path so that apm can load Atom's version.
-apmVersionEnv.ATOM_RESOURCE_PATH = CONFIG.repositoryRootPath;
-childProcess.execFileSync(
-  CONFIG.getApmBinPath(),
-  ['--version'],
-  {stdio: 'inherit', env: apmVersionEnv}
-)
-runApmInstall(CONFIG.repositoryRootPath, ci)
+async function bootstrap() {
 
-dependenciesFingerprint.write()
+  installScriptRunnerDependencies()
+
+  const { spawn, Thread, Worker } = require(`${CONFIG.scriptRunnerModulesPath}/threads`)
+
+  const installScriptDependencies = await spawn(new Worker('./lib/install-script-dependencies'))
+  const installScriptDependenciesPromise = installScriptDependencies(ci)
+
+  const installApm = await spawn(new Worker('./lib/install-apm'))
+  await installApm(ci);
+  await Thread.terminate(installApm)
+
+  const runApmInstall = require('./lib/run-apm-install')
+  runApmInstall(CONFIG.repositoryRootPath, ci)
+
+  await installScriptDependenciesPromise;
+  await Thread.terminate(installScriptDependencies)
+
+  dependenciesFingerprint.write()
+}
+
+bootstrap().then(() => {process.exit(0)}).catch((e) =>  {throw e;})

--- a/script/build
+++ b/script/build
@@ -2,12 +2,16 @@
 
 'use strict'
 
+const CONFIG = require('./config')
+
 if (process.argv.includes('--no-bootstrap')) {
   console.log('Skipping bootstrap')
 } else {
   // Bootstrap first to ensure all the dependencies used later in this script
   // are installed.
-  require('./bootstrap')
+  const path = require('path')
+  const childProcess = require('child_process')
+  childProcess.execFileSync(process.execPath, [path.join(CONFIG.scriptRootPath, 'bootstrap')], { env: process.env, cwd: CONFIG.repositoryRootPath, stdio: 'inherit' });
 }
 
 // Required to load CS files in this build script, such as those in `donna`

--- a/script/build
+++ b/script/build
@@ -67,8 +67,6 @@ process.on('unhandledRejection', function (e) {
   process.exit(1)
 })
 
-const CONFIG = require('./config')
-
 // Used by the 'github' package for Babel configuration
 process.env.ELECTRON_VERSION = CONFIG.appMetadata.electronVersion
 

--- a/script/config.js
+++ b/script/config.js
@@ -10,6 +10,8 @@ const spawnSync = require('./lib/spawn-sync');
 const repositoryRootPath = path.resolve(__dirname, '..');
 const apmRootPath = path.join(repositoryRootPath, 'apm');
 const scriptRootPath = path.join(repositoryRootPath, 'script');
+const scriptRunnerRootPath = path.join(scriptRootPath, 'script-runner');
+const scriptRunnerModulesPath = path.join(scriptRunnerRootPath, 'node_modules');
 const buildOutputPath = path.join(repositoryRootPath, 'out');
 const docsOutputPath = path.join(repositoryRootPath, 'docs', 'output');
 const intermediateAppPath = path.join(buildOutputPath, 'app');
@@ -46,6 +48,8 @@ module.exports = {
   repositoryRootPath,
   apmRootPath,
   scriptRootPath,
+  scriptRunnerRootPath,
+  scriptRunnerModulesPath,
   buildOutputPath,
   docsOutputPath,
   intermediateAppPath,

--- a/script/config.js
+++ b/script/config.js
@@ -131,8 +131,3 @@ function getNpmBinPath(external = false) {
     ? localNpmBinPath
     : npmBinName;
 }
-
-// parallel build in node-gyp
-if (!process.env.JOBS) {
-  process.env.JOBS = 'max';
-}

--- a/script/config.js
+++ b/script/config.js
@@ -131,3 +131,8 @@ function getNpmBinPath(external = false) {
     ? localNpmBinPath
     : npmBinName;
 }
+
+// parallel build in node-gyp
+if (!process.env.JOBS) {
+  process.env.JOBS = 'max';
+}

--- a/script/lib/install-apm.js
+++ b/script/lib/install-apm.js
@@ -4,7 +4,7 @@ const childProcess = require('child_process');
 
 const CONFIG = require('../config');
 
-module.exports = function(ci) {
+function installApm(ci) {
   console.log('Installing apm');
   // npm ci leaves apm with a bunch of unmet dependencies
   childProcess.execFileSync(
@@ -12,4 +12,11 @@ module.exports = function(ci) {
     ['--global-style', '--loglevel=error', 'install'],
     { env: process.env, cwd: CONFIG.apmRootPath }
   );
-};
+  childProcess.execFileSync(CONFIG.getApmBinPath(), ['--version'], {
+    stdio: 'inherit'
+  });
+}
+
+const { expose } = require(`${CONFIG.scriptRunnerModulesPath}/threads/worker`);
+expose(installApm);
+module.exports = installApm;

--- a/script/lib/install-apm.js
+++ b/script/lib/install-apm.js
@@ -4,7 +4,7 @@ const childProcess = require('child_process');
 
 const CONFIG = require('../config');
 
-function installApm(ci) {
+function installApm(ci = false, showVersion = true) {
   console.log('Installing apm');
   // npm ci leaves apm with a bunch of unmet dependencies
   childProcess.execFileSync(
@@ -12,9 +12,11 @@ function installApm(ci) {
     ['--global-style', '--loglevel=error', 'install'],
     { env: process.env, cwd: CONFIG.apmRootPath }
   );
-  childProcess.execFileSync(CONFIG.getApmBinPath(), ['--version'], {
-    stdio: 'inherit'
-  });
+  if (showVersion) {
+    childProcess.execFileSync(CONFIG.getApmBinPath(), ['--version'], {
+      stdio: 'inherit'
+    });
+  }
 }
 
 const { expose } = require(`${CONFIG.scriptRunnerModulesPath}/threads/worker`);

--- a/script/lib/install-apm.js
+++ b/script/lib/install-apm.js
@@ -13,8 +13,13 @@ function installApm(ci = false, showVersion = true) {
     { env: process.env, cwd: CONFIG.apmRootPath }
   );
   if (showVersion) {
+    const apmVersionEnv = {
+      ...process.env,
+      ATOM_RESOURCE_PATH: CONFIG.repositoryRootPath
+    };
     childProcess.execFileSync(CONFIG.getApmBinPath(), ['--version'], {
-      stdio: 'inherit'
+      stdio: 'inherit',
+      env: apmVersionEnv
     });
   }
 }

--- a/script/lib/install-script-dependencies.js
+++ b/script/lib/install-script-dependencies.js
@@ -7,11 +7,15 @@ const CONFIG = require('../config');
 // Recognised by '@electron/get', used by the 'electron-mksnapshot' and 'electron-chromedriver' dependencies
 process.env.ELECTRON_CUSTOM_VERSION = CONFIG.appMetadata.electronVersion;
 
-module.exports = function(ci) {
+function installScriptDependencies(ci) {
   console.log('Installing script dependencies');
   childProcess.execFileSync(
     CONFIG.getNpmBinPath(ci),
     ['--loglevel=error', ci ? 'ci' : 'install'],
     { env: process.env, cwd: CONFIG.scriptRootPath }
   );
-};
+}
+
+const { expose } = require(`${CONFIG.scriptRunnerModulesPath}/threads/worker`);
+expose(installScriptDependencies);
+module.exports = installScriptDependencies;

--- a/script/lib/install-script-runner-dependencies.js
+++ b/script/lib/install-script-runner-dependencies.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const childProcess = require('child_process');
+
+const CONFIG = require('../config');
+
+process.env.ELECTRON_CUSTOM_VERSION = CONFIG.appMetadata.electronVersion;
+
+function installScriptRunnerDependencies(ci) {
+  console.log('Installing script runner dependencies');
+  childProcess.execFileSync(
+    CONFIG.getNpmBinPath(ci),
+    ['--loglevel=error', ci ? 'ci' : 'install'],
+    { env: process.env, cwd: CONFIG.scriptRunnerRootPath }
+  );
+}
+
+module.exports = installScriptRunnerDependencies;

--- a/script/lib/install-script-runner-dependencies.js
+++ b/script/lib/install-script-runner-dependencies.js
@@ -4,8 +4,6 @@ const childProcess = require('child_process');
 
 const CONFIG = require('../config');
 
-process.env.ELECTRON_CUSTOM_VERSION = CONFIG.appMetadata.electronVersion;
-
 function installScriptRunnerDependencies(ci) {
   console.log('Installing script runner dependencies');
   childProcess.execFileSync(

--- a/script/script-runner/package-lock.json
+++ b/script/script-runner/package-lock.json
@@ -1,0 +1,70 @@
+{
+  "name": "atom-build-scripts-runner",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "optional": true
+    },
+    "is-observable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "requires": {
+        "symbol-observable": "^1.1.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "observable-fns": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.5.1.tgz",
+      "integrity": "sha512-wf7g4Jpo1Wt2KIqZKLGeiuLOEMqpaOZ5gJn7DmSdqXgTdxRwSdBhWegQQpPteQ2gZvzCKqNNpwb853wcpA0j7A=="
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
+    "threads": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.3.tgz",
+      "integrity": "sha512-tKwFIWRgfAT85KGkrpDt2jWPO8IVH0sLNfB/pXad/VW9eUIY2Zlz+QyeizypXhPHv9IHfqRzvk2t3mPw+imhWw==",
+      "requires": {
+        "callsites": "^3.1.0",
+        "debug": "^4.1.1",
+        "is-observable": "^1.1.0",
+        "observable-fns": "^0.5.1",
+        "tiny-worker": ">= 2"
+      }
+    },
+    "tiny-worker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+      "optional": true,
+      "requires": {
+        "esm": "^3.2.25"
+      }
+    }
+  }
+}

--- a/script/script-runner/package.json
+++ b/script/script-runner/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "atom-build-scripts-runner",
+  "description": "Atom build scripts runner",
+  "dependencies": {
+    "threads": "^1.6.3"
+  }
+}

--- a/script/vsts/platforms/templates/bootstrap.yml
+++ b/script/vsts/platforms/templates/bootstrap.yml
@@ -23,4 +23,4 @@ steps:
       GITHUB_TOKEN: $(GITHUB_TOKEN)
       CI: true
       CI_PROVIDER: VSTS
-    condition: or(ne(variables['MainNodeModulesRestored'], 'true'), ne(variables['ScriptNodeModulesRestored'], 'true'), ne(variables['ApmNodeModulesRestored'], 'true'), ne(variables['LocalPackagesRestored'], 'true'))
+    condition: or(ne(variables['MainNodeModulesRestored'], 'true'), ne(variables['ScriptRunnerNodeModulesRestored'], true), ne(variables['ScriptNodeModulesRestored'], 'true'), ne(variables['ApmNodeModulesRestored'], 'true'), ne(variables['LocalPackagesRestored'], 'true'))

--- a/script/vsts/platforms/templates/cache.yml
+++ b/script/vsts/platforms/templates/cache.yml
@@ -16,6 +16,13 @@ steps:
       cacheHitVar: MainNodeModulesRestored
 
   - task: Cache@2
+    displayName: Cache script/script-runner/node_modules
+    inputs:
+      key: 'npm_script_runner | "$(Agent.OS)" | "$(BUILD_ARCH)" | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/script-runner/package.json, script/script-runner/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
+      path: 'script/script-runner/node_modules'
+      cacheHitVar: ScriptRunnerNodeModulesRestored
+
+  - task: Cache@2
     displayName: Cache script/node_modules
     inputs:
       key: 'npm_script | "$(Agent.OS)" | "$(BUILD_ARCH)" | packages/**, !packages/**/node_modules/** | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/script-runner/package.json, script/script-runner/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'

--- a/script/vsts/platforms/templates/cache.yml
+++ b/script/vsts/platforms/templates/cache.yml
@@ -11,21 +11,21 @@ steps:
   - task: Cache@2
     displayName: Cache node_modules
     inputs:
-      key: 'npm_main | "$(Agent.OS)" | "$(BUILD_ARCH)" | packages/**, !packages/**/node_modules/** | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
+      key: 'npm_main | "$(Agent.OS)" | "$(BUILD_ARCH)" | packages/**, !packages/**/node_modules/** | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/script-runner/package.json, script/script-runner/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
       path: 'node_modules'
       cacheHitVar: MainNodeModulesRestored
 
   - task: Cache@2
     displayName: Cache script/node_modules
     inputs:
-      key: 'npm_script | "$(Agent.OS)" | "$(BUILD_ARCH)" | packages/**, !packages/**/node_modules/** | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
+      key: 'npm_script | "$(Agent.OS)" | "$(BUILD_ARCH)" | packages/**, !packages/**/node_modules/** | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/script-runner/package.json, script/script-runner/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
       path: 'script/node_modules'
       cacheHitVar: ScriptNodeModulesRestored
 
   - task: Cache@2
     displayName: Cache apm/node_modules
     inputs:
-      key: 'npm_apm | "$(Agent.OS)" | "$(BUILD_ARCH)" | packages/**, !packages/**/node_modules/** | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
+      key: 'npm_apm | "$(Agent.OS)" | "$(BUILD_ARCH)" | packages/**, !packages/**/node_modules/** | package.json, package-lock.json, apm/package.json, script/package.json, script/package-lock.json, script/script-runner/package.json, script/script-runner/package-lock.json, script/vsts/platforms/${{ parameters.OS }}.yml, script/vsts/platforms/templates/preparation.yml'
       path: 'apm/node_modules'
       cacheHitVar: ApmNodeModulesRestored
 


### PR DESCRIPTION
### Description of the change

Run the bootstrap script on different threads in parallel:
	- apm installation runs in parallel to installing script/ dependencies
	- using JOBS env variable node-gyp is parallelized

### Benefits

Running this on a computer with multiple cores gives a good speedup.

Even in the CI with a processor with only [2 cores](https://docs.microsoft.com/en-us/azure/virtual-machines/dv2-dsv2-series#dsv2-series).

For example, on Linux, the bootstrap time is reduced from [7:30](https://dev.azure.com/atomcommunity/atomcommunity/_build/results?buildId=761&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=524bc222-c500-5ef6-2104-858d8102dde5) to [3:41](https://dev.azure.com/atomcommunity/atomcommunity/_build/results?buildId=818&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=524bc222-c500-5ef6-2104-858d8102dde5), which is 203% faster (2X).

### Verification

The CI passes. This is tested locally as well.


### Release Notes
- Faster bootstrapping by using parallelization

Closes https://github.com/atom/atom/pull/21315