### PR TITLE
Don't reinstall npm in CI

### DIFF
--- a/script/vsts/platforms/templates/bootstrap.yml
+++ b/script/vsts/platforms/templates/bootstrap.yml
@@ -2,15 +2,12 @@ steps:
   - pwsh: |
       # OS specific env variables
       if ($env:AGENT_OS -eq "Windows_NT") {
-        $env:NPM_BIN_PATH="C:/npm/prefix/npm.cmd"
         $env:npm_config_build_from_source=true
       }
       if ($env:AGENT_OS -eq "Darwin") {
-        $env:NPM_BIN_PATH="/usr/local/bin/npm"
         $env:npm_config_build_from_source=true
       }
       if ($env:AGENT_OS -eq "Linux") {
-        $env:NPM_BIN_PATH="/usr/local/bin/npm"
         $env:CC=clang
         $env:CXX=clang++
         $env:npm_config_clang=1

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -25,9 +25,6 @@ steps:
       versionSpec: 12.16.3
     displayName: Install Node.js 12.16.3
 
-  - script: npm install --global npm@6.14.8
-    displayName: Update npm
-
   # Windows Specific
   - task: UsePythonVersion@0
     inputs:


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Description of the Change

Removes the `Update npm` CI build step.

This step was added to the Azure CI builds 2 years ago in #17803 to get the new `--ci` flag. There have been a couple of bumps over the years, and I believe it was introduced in 17ec08067bcc189c83ba1ab3f961abc2e8525c39 initially (it at least didn't exist in `.travis.yml` before then).

From what I can tell, this upgrading / setting of the npm version was done to take advantage of newer features or bug fixes. I do not think it should be necessary any more.

On Linux and macOS the step takes < 10 seconds to complete. On Windows it takes 30-60 seconds (4% of build time up to boostrap finish). This isn't a lot with respect to the other steps, but it happens before linting and is a cost that doesn't seem necessary. If it builds without setting it now, then we get the same effect from the stability of CI environments themselves. Issues would be isolated to upgrading the CI environment.

Regarding the use of npm, it _should not_ affect anything to do with the built Atom. All Atom packages should be installed with `apm install`, which controls it's own npm version as well as several environment variables to ensure native packages build for the correct Electron version. If npm is being used for this purpose that would be a problem. So it should only be relevant to installing the dependencies in `scripts` (interestingly, `npm` is listed as a dependency in `scripts/package.json`. It should be possible to remove it from there too).

And finally, for some reason Linux already doesn't use the fixed npm version anyway. This can be seen in any of the Bootstrap job logs: e.g., https://github.visualstudio.com/Atom/_build/results?buildId=81413&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=09bcc455-e770-5f06-0452-f817068d38b7
```
Node:	v12.16.3
Npm:	v6.14.8
Python:	v2.7.12
```
(expected is npm@6.9.0)

### Alternate Designs

Leave as is. It's not a significant gain by itself. But it may be possible to find several more changes, and the cumulative effect could be significant.

### Possible Drawbacks

Maybe no one thinks to check npm version if something breaks after it is updated in the CI environment? But then the Linux job would break anyway because it doesn't seem to use the installed npm.

### Verification Process

CI passes

### Release Notes

NA
