### PR TITLE
Update the macOS Azure CI image to macos-10.15

### DIFF
--- a/script/vsts/nightly-release.yml
+++ b/script/vsts/nightly-release.yml
@@ -56,7 +56,7 @@ jobs:
     timeoutInMinutes: 180
 
     pool:
-      vmImage: macos-10.14
+      vmImage: macos-10.15
 
     steps:
       - template: platforms/templates/preparation.yml

--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -10,7 +10,7 @@ jobs:
       IsSignedZipBranch: $[ dependencies.GetReleaseVersion.outputs['Version.IsSignedZipBranch'] ]
       RunCoreMainTests: true
     pool:
-      vmImage: macos-10.14
+      vmImage: macos-10.15
 
     steps:
       - template: templates/preparation.yml
@@ -48,7 +48,7 @@ jobs:
     dependsOn: macOS_build
     timeoutInMinutes: 180
     pool:
-      vmImage: macos-10.14
+      vmImage: macos-10.15
     strategy:
       maxParallel: 3
       matrix:


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Description of the Change

Updates the macOS Azure CI image from [macos-10.14](https://github.com/microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-10.14-Readme.md) to [macos-10.15](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md). This
- Makes sure we are testing on the latest possible macOS image
- Updates npm from 3.10.10 to 6.14.6, most likely removing the need to upgrade it separately (see #21317)

### Alternate Designs

NA

### Possible Drawbacks

Could fail to detect changes that are incompatible with 10.14. But then, by the same logic, the current setup doesn't detect incompatibilities with 10.15, which is more recent and therefore more important IMO.

### Verification Process

CI passes

### Release Notes

NA
