### PR TITLE
Consistent CI job names

### DIFF
--- a/script/vsts/platforms/macos.yml
+++ b/script/vsts/platforms/macos.yml
@@ -1,6 +1,6 @@
 jobs:
   - job: macOS_build
-    displayName: macOS build
+    displayName: macOS Build
     dependsOn: GetReleaseVersion
     timeoutInMinutes: 180
 
@@ -47,7 +47,7 @@ jobs:
               condition: succeeded()
 
   - job: macOS_tests
-    displayName: macOS test
+    displayName: macOS Tests
     dependsOn: macOS_build
     timeoutInMinutes: 180
     pool:

--- a/script/vsts/platforms/templates/get-release-version.yml
+++ b/script/vsts/platforms/templates/get-release-version.yml
@@ -9,6 +9,7 @@ parameters:
 jobs:
 
 - job: GetReleaseVersion
+  displayName: Get Release Version
   pool:
     vmImage: 'ubuntu-latest'
   steps:

--- a/script/vsts/platforms/windows.yml
+++ b/script/vsts/platforms/windows.yml
@@ -1,5 +1,6 @@
 jobs:
   - job: Windows_build
+    displayName: Windows Build
     dependsOn: GetReleaseVersion
     timeoutInMinutes: 180
     strategy:
@@ -72,6 +73,7 @@ jobs:
               condition: and(succeeded(), eq(variables['IsReleaseBranch'], 'true'))
 
   - job: Windows_tests
+    displayName: Windows Tests
     dependsOn: Windows_build
     timeoutInMinutes: 180
     strategy:


### PR DESCRIPTION
This tweaks the obvious CI job display names to be more consistent with each other. The goal is to be Title Case.

`Linux` is left alone because it is both build and tests. I didn't look at the step names within each job.