### PR TITLE
Support sync condition in spec

### DIFF
--- a/spec/async-spec-helpers.js
+++ b/spec/async-spec-helpers.js
@@ -7,7 +7,12 @@ async function conditionPromise(
   while (true) {
     await timeoutPromise(100);
 
-    if (await condition()) {
+    // if condition is sync
+    if (condition.constructor.name !== 'AsyncFunction' && condition()) {
+      return;
+    }
+    // if condition is async
+    else if (await condition()) {
       return;
     }
 

--- a/spec/pane-spec.js
+++ b/spec/pane-spec.js
@@ -399,9 +399,8 @@ describe('Pane', () => {
       const pendingSpy = jasmine.createSpy('onItemDidTerminatePendingState');
       const destroySpy = jasmine.createSpy('onWillDestroyItem');
 
-      await atom.workspace.open('sample.txt', { pending: true }).then(() => {
-        pane = atom.workspace.getActivePane();
-      });
+      await atom.workspace.open('sample.txt', { pending: true });
+      pane = atom.workspace.getActivePane();
 
       pane.onItemDidTerminatePendingState(pendingSpy);
       pane.onWillDestroyItem(destroySpy);


### PR DESCRIPTION
### Description of the change

1) Some conditions may be sync functions that we don't need to await! This removes the needs for awaiting these functions.

One of such conditions: https://github.com/atom/atom/blob/55abad9861aa96101423aa4751c0243d37dd9096/spec/pane-spec.js#L673

2) It also removes then on an awaited function!
