### PR TITLE
Remove random-words dependancy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5916,11 +5916,6 @@
       "resolved": "https://registry.npmjs.org/random-seed/-/random-seed-0.2.0.tgz",
       "integrity": "sha1-TRiJtG3ITvUjFs63dysM4KVE844="
     },
-    "random-words": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/random-words/-/random-words-0.0.1.tgz",
-      "integrity": "sha1-QOMAkgM62Ptg1mrRW+NiDTwlxB8="
-    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "postcss-selector-parser": "2.2.1",
     "prebuild-install": "5.3.5",
     "property-accessors": "^1.1.3",
-    "random-words": "0.0.1",
     "resolve": "1.17.0",
     "scandal": "^3.2.0",
     "scoped-property-store": "^0.17.0",


### PR DESCRIPTION
This dependancy is not being utilized in the atom repo currently

It was used in https://github.com/atom/atom/blob/72b120cfe12d987407c9745ec0a4c55a6c83104c/spec/random-editor-spec.coffee
but that spec has long been deleted from the repo

Resolves #21040