### PR TITLE
Remove electron configuration

### DIFF
--- a/script/build
+++ b/script/build
@@ -64,6 +64,8 @@ process.on('unhandledRejection', function (e) {
 })
 
 const CONFIG = require('./config')
+
+// Used by the 'github' package for Babel configuration
 process.env.ELECTRON_VERSION = CONFIG.appMetadata.electronVersion
 
 let binariesPromise = Promise.resolve()

--- a/script/lib/install-script-dependencies.js
+++ b/script/lib/install-script-dependencies.js
@@ -4,7 +4,7 @@ const childProcess = require('child_process');
 
 const CONFIG = require('../config');
 
-// For the 'electron-mksnapshot' dependency
+// For the 'electron-mksnapshot' and 'electron-chromedriver' dependency
 process.env.ELECTRON_CUSTOM_VERSION = CONFIG.appMetadata.electronVersion;
 
 module.exports = function(ci) {

--- a/script/lib/install-script-dependencies.js
+++ b/script/lib/install-script-dependencies.js
@@ -4,7 +4,7 @@ const childProcess = require('child_process');
 
 const CONFIG = require('../config');
 
-// For the 'electron-mksnapshot' and 'electron-chromedriver' dependency
+// Recognised by '@electron/get', used by the 'electron-mksnapshot' and 'electron-chromedriver' dependencies
 process.env.ELECTRON_CUSTOM_VERSION = CONFIG.appMetadata.electronVersion;
 
 module.exports = function(ci) {

--- a/script/lib/install-script-dependencies.js
+++ b/script/lib/install-script-dependencies.js
@@ -4,6 +4,7 @@ const childProcess = require('child_process');
 
 const CONFIG = require('../config');
 
+// For the 'electron-mksnapshot' dependency
 process.env.ELECTRON_CUSTOM_VERSION = CONFIG.appMetadata.electronVersion;
 
 module.exports = function(ci) {

--- a/script/lib/run-apm-install.js
+++ b/script/lib/run-apm-install.js
@@ -8,9 +8,7 @@ module.exports = function(packagePath, ci, stdioOptions) {
   const installEnv = Object.assign({}, process.env);
   // Set resource path so that apm can load metadata related to Atom.
   installEnv.ATOM_RESOURCE_PATH = CONFIG.repositoryRootPath;
-  // Set our target (Electron) version so that node-pre-gyp can download the
-  // proper binaries.
-  installEnv.npm_config_target = CONFIG.appMetadata.electronVersion;
+
   childProcess.execFileSync(CONFIG.getApmBinPath(), [ci ? 'ci' : 'install'], {
     env: installEnv,
     cwd: packagePath,


### PR DESCRIPTION
### Description of the Change

Removes the environment configuration concerning the electron version. Managing the environment is apm's job, and it [already sets this variable anyway](https://github.com/atom/apm/blob/ff9170e2efaf11949dd9e194b0f6f3e09d37569c/src/command.coffee#L110).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None. Only apm should be managing electron compatibility logic.

### Possible Drawbacks

None. It has no effect now anyway because apm overwrites it.

### Verification Process

CI passes

### Release Notes

NA
