### PR TITLE
Appendable scopes in Tree-sitter grammars

### DIFF
--- a/spec/syntax-scope-map-spec.js
+++ b/spec/syntax-scope-map-spec.js
@@ -8,11 +8,11 @@ describe('SyntaxScopeMap', () => {
       c: 'z'
     });
 
-    expect(map.get(['a', 'b', 'c'], [0, 0, 0])).toBe('x');
-    expect(map.get(['d', 'b', 'c'], [0, 0, 0])).toBe('y');
-    expect(map.get(['d', 'e', 'c'], [0, 0, 0])).toBe('z');
-    expect(map.get(['e', 'c'], [0, 0, 0])).toBe('z');
-    expect(map.get(['c'], [0, 0, 0])).toBe('z');
+    expect(map.get(['a', 'b', 'c'], [0, 0, 0])).toEqual(['z', 'y', 'x']);
+    expect(map.get(['d', 'b', 'c'], [0, 0, 0])).toEqual(['z', 'y']);
+    expect(map.get(['d', 'e', 'c'], [0, 0, 0])).toEqual(['z']);
+    expect(map.get(['e', 'c'], [0, 0, 0])).toEqual(['z']);
+    expect(map.get(['c'], [0, 0, 0])).toEqual(['z']);
     expect(map.get(['d'], [0, 0, 0])).toBe(undefined);
   });
 
@@ -24,12 +24,12 @@ describe('SyntaxScopeMap', () => {
       'b:nth-child(2)': 'z'
     });
 
-    expect(map.get(['a', 'b'], [0, 0])).toBe('w');
-    expect(map.get(['a', 'b'], [0, 1])).toBe('x');
-    expect(map.get(['a', 'b'], [0, 2])).toBe('w');
-    expect(map.get(['b'], [0])).toBe('y');
-    expect(map.get(['b'], [1])).toBe('y');
-    expect(map.get(['b'], [2])).toBe('z');
+    expect(map.get(['a', 'b'], [0, 0])).toEqual(['y', 'w']);
+    expect(map.get(['a', 'b'], [0, 1])).toEqual(['y', 'w', 'x']);
+    expect(map.get(['a', 'b'], [0, 2])).toEqual(['y', 'z', 'w']);
+    expect(map.get(['b'], [0])).toEqual(['y']);
+    expect(map.get(['b'], [1])).toEqual(['y']);
+    expect(map.get(['b'], [2])).toEqual(['y', 'z']);
   });
 
   it('can match :nth-child pseudo-selectors on interior nodes', () => {
@@ -40,9 +40,10 @@ describe('SyntaxScopeMap', () => {
     });
 
     expect(map.get(['b', 'c'], [0, 0])).toBe(undefined);
-    expect(map.get(['b', 'c'], [1, 0])).toBe('w');
-    expect(map.get(['a', 'b', 'c'], [1, 0, 0])).toBe('x');
-    expect(map.get(['a', 'b', 'c'], [1, 2, 0])).toBe('y');
+    expect(map.get(['b', 'c'], [1, 0])).toEqual(['w']);
+    expect(map.get(['a', 'b', 'c'], [1, 0, 0])).toEqual(['x']);
+    expect(map.get(['a', 'b', 'c'], [1, 1, 0])).toEqual(['w', 'x']);
+    expect(map.get(['a', 'b', 'c'], [1, 2, 0])).toEqual(['x', 'y']);
   });
 
   it('allows anonymous tokens to be referred to by their string value', () => {
@@ -54,10 +55,10 @@ describe('SyntaxScopeMap', () => {
     });
 
     expect(map.get(['b'], [0], true)).toBe(undefined);
-    expect(map.get(['b'], [0], false)).toBe('w');
-    expect(map.get(['a', 'b'], [0, 0], false)).toBe('x');
-    expect(map.get(['a', 'b'], [0, 1], false)).toBe('y');
-    expect(map.get(['a', '"'], [0, 1], false)).toBe('z');
+    expect(map.get(['b'], [0], false)).toEqual(['w']);
+    expect(map.get(['a', 'b'], [0, 0], false)).toEqual(['w', 'x']);
+    expect(map.get(['a', 'b'], [0, 1], false)).toEqual(['w', 'x', 'y']);
+    expect(map.get(['a', '"'], [0, 1], false)).toEqual(['z']);
   });
 
   it('supports the wildcard selector', () => {
@@ -68,22 +69,214 @@ describe('SyntaxScopeMap', () => {
       'a > *:nth-child(1) > b': 'z'
     });
 
-    expect(map.get(['b'], [0])).toBe('w');
-    expect(map.get(['c'], [0])).toBe('w');
-    expect(map.get(['a', 'b'], [0, 0])).toBe('x');
-    expect(map.get(['a', 'b'], [0, 1])).toBe('y');
-    expect(map.get(['a', 'c'], [0, 1])).toBe('y');
-    expect(map.get(['a', 'c', 'b'], [0, 1, 1])).toBe('z');
-    expect(map.get(['a', 'c', 'b'], [0, 2, 1])).toBe('w');
+    expect(map.get(['b'], [0])).toEqual(['w']);
+    expect(map.get(['c'], [0])).toEqual(['w']);
+    expect(map.get(['a', 'b'], [0, 0])).toEqual(['w', 'x']);
+    expect(map.get(['a', 'b'], [0, 1])).toEqual(['w', 'x', 'y']);
+    expect(map.get(['a', 'c'], [0, 1])).toEqual(['w', 'x', 'y']);
+    expect(map.get(['a', 'c', 'b'], [0, 2, 1])).toEqual(['w']);
+    expect(map.get(['a', 'c', 'b'], [0, 1, 1])).toEqual(['w', 'z']);
+    expect(map.get(['a', 'a', 'b'], [0, 2, 1])).toEqual(['w', 'x', 'y']);
+    expect(map.get(['a', 'a', 'b'], [0, 1, 1])).toEqual(['w', 'x', 'y', 'z']);
   });
 
-  it('distinguishes between an anonymous * token and the wildcard selector', () => {
+  it('distinguishes between an anonymous token and the wildcard selector', () => {
     const map = new SyntaxScopeMap({
-      '"*"': 'x',
-      'a > "b"': 'y'
+      '*': 's',
+      b: 't',
+      '"*"': 'u',
+      '"b"': 'v',
+      'a > *': 'w',
+      'a > b': 'x',
+      'a > "*"': 'y',
+      'a > "b"': 'z'
     });
 
-    expect(map.get(['b'], [0], false)).toBe(undefined);
-    expect(map.get(['*'], [0], false)).toBe('x');
+    expect(map.get(['*'], [0])).toEqual(['s']);
+    expect(map.get(['b'], [0])).toEqual(['s', 't']);
+    expect(map.get(['*'], [0], false)).toEqual(['s', 'u']);
+    expect(map.get(['b'], [0], false)).toEqual(['s', 'v']);
+    expect(map.get(['a', '*'], [0, 0])).toEqual(['s', 'w']);
+    expect(map.get(['a', 'b'], [0, 0])).toEqual(['s', 't', 'w', 'x']);
+    expect(map.get(['a', '*'], [0, 0], false)).toEqual(['s', 'u', 'w', 'y']);
+    expect(map.get(['a', 'b'], [0, 0], false)).toEqual(['s', 'v', 'w', 'z']);
+    expect(map.get(['a', 'b', '*'], [0, 0, 0])).toEqual(['s']);
+    expect(map.get(['a', 'b', 'b'], [0, 0, 0])).toEqual(['s', 't']);
+    expect(map.get(['a', 'b', '*'], [0, 0, 0], false)).toEqual(['s', 'u']);
+    expect(map.get(['a', 'b', 'b'], [0, 0, 0], false)).toEqual(['s', 'v']);
+  });
+
+  it('understands adjacent wildcards', () => {
+    const map = new SyntaxScopeMap({
+      '* > *': 'w',
+      '* > * > * > d': 'x',
+      'a > * > * > *': 'y',
+      'a > * > * > d': 'z'
+    });
+
+    expect(map.get(['a'], [0])).toBe(undefined);
+    expect(map.get(['d'], [0])).toBe(undefined);
+    expect(map.get(['a', 'd'], [0, 0])).toEqual(['w']);
+    expect(map.get(['a', 'b', 'd'], [0, 0])).toEqual(['w']);
+    expect(map.get(['a', 'b', 'c', 'c'], [0, 0])).toEqual(['w', 'y']);
+    expect(map.get(['b', 'b', 'c', 'd'], [0, 0])).toEqual(['w', 'x']);
+    expect(map.get(['a', 'b', 'c', 'd'], [0, 0])).toEqual(['w', 'x', 'y', 'z']);
+  });
+
+  it('sorts selectors by specificity', () => {
+    const map = new SyntaxScopeMap({
+      c: 'j',
+      '* > c': 'k',
+      '* > c:nth-child(1)': 'l',
+      'b > *': 'm',
+      'b > c': 'n',
+      'b > c:nth-child(1)': 'o',
+      'b:nth-child(1) > *': 'p',
+      'b:nth-child(1) > c': 'q',
+      'b:nth-child(1) > c:nth-child(1)': 'r',
+      '* > b > c': 's',
+      'a > * > *': 't',
+      'a > * > c:nth-child(1)': 'u',
+      'a > b > *': 'v',
+      'a > b > c': 'w',
+      'a > b > c:nth-child(1)': 'x',
+      'a:nth-child(1) > * > c': 'y',
+      'a:nth-child(1) > b:nth-child(1) > c': 'z'
+    });
+
+    expect(map.get(['a', 'b', 'c'], [0, 0, 0])).toEqual([
+      'j',
+      'k',
+      'm',
+      'n',
+      's',
+      't',
+      'v',
+      'w'
+    ]);
+    expect(map.get(['a', 'b', 'c'], [0, 0, 1])).toEqual([
+      'j',
+      'k',
+      'l',
+      'm',
+      'n',
+      'o',
+      's',
+      't',
+      'u',
+      'v',
+      'w',
+      'x'
+    ]);
+    expect(map.get(['a', 'b', 'c'], [0, 1, 0])).toEqual([
+      'j',
+      'k',
+      'm',
+      'n',
+      'p',
+      'q',
+      's',
+      't',
+      'v',
+      'w'
+    ]);
+    expect(map.get(['a', 'b', 'c'], [0, 1, 1])).toEqual([
+      'j',
+      'k',
+      'l',
+      'm',
+      'n',
+      'o',
+      'p',
+      'q',
+      'r',
+      's',
+      't',
+      'u',
+      'v',
+      'w',
+      'x'
+    ]);
+    expect(map.get(['a', 'b', 'c'], [1, 0, 0])).toEqual([
+      'j',
+      'k',
+      'm',
+      'n',
+      's',
+      't',
+      'v',
+      'w',
+      'y'
+    ]);
+    expect(map.get(['a', 'b', 'c'], [1, 0, 1])).toEqual([
+      'j',
+      'k',
+      'l',
+      'm',
+      'n',
+      'o',
+      's',
+      't',
+      'u',
+      'v',
+      'w',
+      'x',
+      'y'
+    ]);
+    expect(map.get(['a', 'b', 'c'], [1, 1, 0])).toEqual([
+      'j',
+      'k',
+      'm',
+      'n',
+      'p',
+      'q',
+      's',
+      't',
+      'v',
+      'w',
+      'y',
+      'z'
+    ]);
+    expect(map.get(['a', 'b', 'c'], [1, 1, 1])).toEqual([
+      'j',
+      'k',
+      'l',
+      'm',
+      'n',
+      'o',
+      'p',
+      'q',
+      'r',
+      's',
+      't',
+      'u',
+      'v',
+      'w',
+      'x',
+      'y',
+      'z'
+    ]);
+  });
+
+  it('throws an error for invalid selectors', () => {
+    const invalid = [
+      { 'a > b >': '' },
+      { 'a >:nth-child(1) b': '' },
+      { 'a > b:last-of-type': '' },
+      { 'a:nth-child(1):nth-child(2)': '' }
+    ];
+
+    expect(() => new SyntaxScopeMap(invalid[0])).toThrow(
+      "Unsupported selector 'a > b >'"
+    );
+    expect(() => new SyntaxScopeMap(invalid[1])).toThrow(
+      "Unsupported selector 'a >:nth-child(1) b'"
+    );
+    expect(() => new SyntaxScopeMap(invalid[2])).toThrow(
+      "Unsupported selector 'a > b:last-of-type'"
+    );
+    expect(() => new SyntaxScopeMap(invalid[3])).toThrow(
+      "Unsupported selector 'a:nth-child(1):nth-child(2)'"
+    );
   });
 });

--- a/src/syntax-scope-map.js
+++ b/src/syntax-scope-map.js
@@ -7,102 +7,69 @@ module.exports = class SyntaxScopeMap {
     for (let selector in resultsBySelector) {
       this.addSelector(selector, resultsBySelector[selector]);
     }
-    setTableDefaults(this.namedScopeTable, true);
-    setTableDefaults(this.anonymousScopeTable, false);
+    setTableDefaults(this.namedScopeTable);
+    setTableDefaults(this.anonymousScopeTable, this.namedScopeTable);
+    setTableResults(this.namedScopeTable);
+    setTableResults(this.anonymousScopeTable);
   }
 
   addSelector(selector, result) {
     parser(parseResult => {
       for (let selectorNode of parseResult.nodes) {
         let currentTable = null;
-        let currentIndexValue = null;
+        let currentIndex = null;
 
         for (let i = selectorNode.nodes.length - 1; i >= 0; i--) {
           const termNode = selectorNode.nodes[i];
 
-          switch (termNode.type) {
-            case 'tag':
-              if (!currentTable) currentTable = this.namedScopeTable;
-              if (!currentTable[termNode.value])
-                currentTable[termNode.value] = {};
-              currentTable = currentTable[termNode.value];
-              if (currentIndexValue != null) {
-                if (!currentTable.indices) currentTable.indices = {};
-                if (!currentTable.indices[currentIndexValue])
-                  currentTable.indices[currentIndexValue] = {};
-                currentTable = currentTable.indices[currentIndexValue];
-                currentIndexValue = null;
-              }
-              break;
-
-            case 'string':
-              if (!currentTable) currentTable = this.anonymousScopeTable;
-              const value = termNode.value.slice(1, -1).replace(/\\"/g, '"');
-              if (!currentTable[value]) currentTable[value] = {};
-              currentTable = currentTable[value];
-              if (currentIndexValue != null) {
-                if (!currentTable.indices) currentTable.indices = {};
-                if (!currentTable.indices[currentIndexValue])
-                  currentTable.indices[currentIndexValue] = {};
-                currentTable = currentTable.indices[currentIndexValue];
-                currentIndexValue = null;
-              }
-              break;
-
-            case 'universal':
-              if (currentTable) {
-                if (!currentTable['*']) currentTable['*'] = {};
-                currentTable = currentTable['*'];
-              } else {
-                if (!this.namedScopeTable['*']) {
-                  this.namedScopeTable['*'] = this.anonymousScopeTable[
-                    '*'
-                  ] = {};
-                }
-                currentTable = this.namedScopeTable['*'];
-              }
-              if (currentIndexValue != null) {
-                if (!currentTable.indices) currentTable.indices = {};
-                if (!currentTable.indices[currentIndexValue])
-                  currentTable.indices[currentIndexValue] = {};
-                currentTable = currentTable.indices[currentIndexValue];
-                currentIndexValue = null;
-              }
-              break;
-
-            case 'combinator':
-              if (currentIndexValue != null) {
-                rejectSelector(selector);
-              }
-
-              if (termNode.value === '>') {
-                if (!currentTable.parents) currentTable.parents = {};
-                currentTable = currentTable.parents;
-              } else {
-                rejectSelector(selector);
-              }
-              break;
-
-            case 'pseudo':
-              if (termNode.value === ':nth-child') {
-                currentIndexValue = termNode.nodes[0].nodes[0].value;
-              } else {
-                rejectSelector(selector);
-              }
-              break;
-
-            default:
-              rejectSelector(selector);
+          if (termNode.type === 'string') {
+            if (!currentTable) currentTable = this.anonymousScopeTable;
+            termNode.value = termNode.value.slice(1, -1).replace(/\\"/g, '"');
           }
+
+          if (
+            termNode.type === 'tag' ||
+            termNode.type === 'string' ||
+            termNode.type === 'universal'
+          ) {
+            if (!currentTable) currentTable = this.namedScopeTable;
+            if (!currentTable[termNode.value])
+              currentTable[termNode.value] = {};
+            currentTable = currentTable[termNode.value];
+            if (!currentTable.indices) currentTable.indices = {};
+            if (currentIndex == null) currentIndex = '*';
+            if (!currentTable.indices[currentIndex])
+              currentTable.indices[currentIndex] = {};
+            currentTable = currentTable.indices[currentIndex];
+            currentIndex = null;
+            continue;
+          }
+
+          if (termNode.type === 'combinator') {
+            if (!currentTable || currentIndex != null || termNode.value !== '>')
+              rejectSelector(selector);
+            if (!currentTable.parents) currentTable.parents = {};
+            currentTable = currentTable.parents;
+            continue;
+          }
+
+          if (termNode.type === 'pseudo') {
+            if (currentIndex != null || termNode.value !== ':nth-child')
+              rejectSelector(selector);
+            currentIndex = termNode.nodes[0].nodes[0].value;
+            continue;
+          }
+
+          rejectSelector(selector);
         }
 
-        currentTable.result = result;
+        currentTable.results = [result];
       }
     }).process(selector);
   }
 
   get(nodeTypes, childIndices, leafIsNamed = true) {
-    let result;
+    let results;
     let i = nodeTypes.length - 1;
     let currentTable = leafIsNamed
       ? this.namedScopeTable[nodeTypes[i]]
@@ -111,69 +78,68 @@ module.exports = class SyntaxScopeMap {
     if (!currentTable) currentTable = this.namedScopeTable['*'];
 
     while (currentTable) {
-      if (currentTable.indices && currentTable.indices[childIndices[i]]) {
-        currentTable = currentTable.indices[childIndices[i]];
+      if (currentTable.results != null) results = currentTable.results;
+
+      if (currentTable.indices) {
+        currentTable =
+          currentTable.indices[childIndices[i]] || currentTable.indices['*'];
+        continue;
       }
 
-      if (currentTable.result != null) {
-        result = currentTable.result;
-      }
+      if (i === 0 || !currentTable.parents) break;
 
-      if (i === 0) break;
-      i--;
       currentTable =
-        currentTable.parents &&
-        (currentTable.parents[nodeTypes[i]] || currentTable.parents['*']);
+        currentTable.parents[nodeTypes[--i]] || currentTable.parents['*'];
     }
 
-    return result;
+    return results;
   }
 };
 
-function setTableDefaults(table, allowWildcardSelector) {
-  const defaultTypeTable = allowWildcardSelector ? table['*'] : null;
+function setTableDefaults(table, defaultTable) {
+  defaultTable = defaultTable || table;
 
-  for (let type in table) {
-    let typeTable = table[type];
-    if (typeTable === defaultTypeTable) continue;
-
-    if (defaultTypeTable) {
-      mergeTable(typeTable, defaultTypeTable);
+  if (defaultTable['*']) {
+    for (let key in table) {
+      if (key === '*' && defaultTable === table) continue;
+      mergeTable(table[key], defaultTable['*']);
     }
+  }
 
-    if (typeTable.parents) {
-      setTableDefaults(typeTable.parents, true);
-    }
+  for (let key in table) {
+    if (table[key].indices) setTableDefaults(table[key].indices);
+    if (table[key].parents) setTableDefaults(table[key].parents);
+  }
+}
 
-    for (let key in typeTable.indices) {
-      const indexTable = typeTable.indices[key];
-      mergeTable(indexTable, typeTable, false);
-      if (indexTable.parents) {
-        setTableDefaults(indexTable.parents, true);
-      }
+function mergeTable(table, defaultTable) {
+  if (defaultTable.results)
+    table.results = [].concat(defaultTable.results, table.results || []);
+
+  if (
+    (defaultTable.indices &&
+      (defaultTable = defaultTable.indices) &&
+      (table.indices = table.indices || {}) &&
+      (table = table.indices)) ||
+    (defaultTable.parents &&
+      (defaultTable = defaultTable.parents) &&
+      (table.parents = table.parents || {}) &&
+      (table = table.parents))
+  ) {
+    for (let key in defaultTable) {
+      if (!table[key]) table[key] = {};
+      mergeTable(table[key], defaultTable[key]);
     }
   }
 }
 
-function mergeTable(table, defaultTable, mergeIndices = true) {
-  if (mergeIndices && defaultTable.indices) {
-    if (!table.indices) table.indices = {};
-    for (let key in defaultTable.indices) {
-      if (!table.indices[key]) table.indices[key] = {};
-      mergeTable(table.indices[key], defaultTable.indices[key]);
+function setTableResults(table, results) {
+  for (let key in table) {
+    for (let index in table[key].indices) {
+      const node = table[key].indices[index];
+      if (results) node.results = [].concat(results, node.results || []);
+      setTableResults(node.parents, node.results);
     }
-  }
-
-  if (defaultTable.parents) {
-    if (!table.parents) table.parents = {};
-    for (let key in defaultTable.parents) {
-      if (!table.parents[key]) table.parents[key] = {};
-      mergeTable(table.parents[key], defaultTable.parents[key]);
-    }
-  }
-
-  if (defaultTable.result != null && table.result == null) {
-    table.result = defaultTable.result;
   }
 }
 

--- a/src/tree-sitter-grammar.js
+++ b/src/tree-sitter-grammar.js
@@ -149,7 +149,10 @@ const preprocessScopes = value =>
     : typeof value.match === 'string'
     ? { match: new RegExp(value.match), scopes: preprocessScopes(value.scopes) }
     : typeof value.with === 'string'
-    ? { with: value.with.split('.'), scopes: preprocessScopes(value.scopes) }
+    ? {
+        with: value.with.split('.').filter(scope => scope !== ''),
+        scopes: preprocessScopes(value.scopes)
+      }
     : preprocessScopes(value.scopes);
 
 const NODE_NAME_REGEX = /[\w_]+/;

--- a/src/tree-sitter-grammar.js
+++ b/src/tree-sitter-grammar.js
@@ -31,14 +31,8 @@ module.exports = class TreeSitterGrammar {
       for (let selector of selectors) {
         selector = selector.trim();
         if (!selector) continue;
-        if (scopeSelectors[selector]) {
-          scopeSelectors[selector] = [].concat(
-            scopeSelectors[selector],
-            classes
-          );
-        } else {
-          scopeSelectors[selector] = classes;
-        }
+        if (!scopeSelectors[selector]) scopeSelectors[selector] = [];
+        scopeSelectors[selector].push(classes);
       }
     }
 
@@ -146,11 +140,17 @@ module.exports = class TreeSitterGrammar {
 const preprocessScopes = value =>
   typeof value === 'string'
     ? value
+    : value == null
+    ? '.'
     : Array.isArray(value)
     ? value.map(preprocessScopes)
-    : value.match
+    : typeof value.exact === 'string'
+    ? { exact: value.exact, scopes: preprocessScopes(value.scopes) }
+    : typeof value.match === 'string'
     ? { match: new RegExp(value.match), scopes: preprocessScopes(value.scopes) }
-    : Object.assign({}, value, { scopes: preprocessScopes(value.scopes) });
+    : typeof value.with === 'string'
+    ? { with: value.with.split('.'), scopes: preprocessScopes(value.scopes) }
+    : preprocessScopes(value.scopes);
 
 const NODE_NAME_REGEX = /[\w_]+/;
 

--- a/src/tree-sitter-language-mode.js
+++ b/src/tree-sitter-language-mode.js
@@ -1336,8 +1336,7 @@ const applyLeafRules = (rules, cursor, scopes = [], depth = 0) => {
     if (
       (rules.exact && rules.exact === cursor.nodeText) ||
       (rules.match && rules.match.test(cursor.nodeText)) ||
-      (rules.with &&
-        rules.with.every(scope => !scope || scopes.includes(scope)))
+      (rules.with && rules.with.every(scope => scopes.includes(scope)))
     )
       return applyLeafRules(rules.scopes, cursor, scopes, depth);
   }


### PR DESCRIPTION
## Issue

Fixes #20147

## Current state

In a Tree-sitter grammar file, the scopes of the most specific selector override other scopes. That leads to many repetitions of identical rules for different selectors. An example:

```cson
'identifier': [
  # Some rules
  {
    exact: 'String',
    scopes: 'entity.type.support' # String
  },
  {
    match: '^[0-9_]*[A-Z]',
    scopes: 'entity.type' # Type
  },
  'entity.variable' # variable
]

'call > identifier': [
  # The same rules
  {
    exact: 'String',
    scopes: 'entity.type.support.constructor.call' # String()
  },
  {
    match: '^[0-9_]*[A-Z]',
    scopes: 'entity.type.constructor.call' # Type()
  }
  'entity.function.call' # function()
]

'attribute > identifier:nth-child(2)': [
  # The same rules again
  {
    match: '^[0-9_]*[A-Z]',
    scopes: 'entity.type.member' # _.Type
  },
  'entity.variable.member' # _.member
]
```

Grammars quickly become convoluted. This PR introduces two features to alleviate this issue.

## New feature: appendable scopes

Appendable scopes start with a period and are simply appended to less specific scopes:

```cson
'identifier': [
  {
    exact: 'String',
    scopes: 'entity.type.support'
  },
  {
    match: '^[0-9_]*[A-Z]',
    scopes: 'entity.type'
  },
  'entity.variable'
]

'call > identifier': '.call' # Append '.call'

'attribute > identifier:nth-child(2)': '.member' # Append '.member'
```

## New feature: "with" rules

The "with" rule matches already applied scopes:

```cson
'identifier': [
  {
    exact: 'String',
    scopes: 'entity.type.support'
  },
  {
    match: '^[0-9_]*[A-Z]',
    scopes: 'entity.type'
  },
  'entity.variable'
]

'call > identifier': [
  {
    with: 'entity.type', # If the token has the scopes 'entity' and 'type'
    scopes: '.constructor.call' # Append '.constructor.call'
  },
  'entity.function.call' # Else, override all previously applied scopes with 'entity.function.call'
]

'attribute > identifier:nth-child(2)': [
  {
    with: 'entity.type.support', # If the token has the scopes 'entity' and 'type' and 'support'
    scopes: 'entity.type.member' # Override all previously applied scopes with 'entity.type.member'
  },
  '.member' # Else, append '.member'
]
```

## Scopes selection logic

Scopes for a token are applied with the following algorithm:
1. Go to the least specific selector.
2. Set `overridable = true`.
3. Go to the first ruleset of the selector.
4. Select the first matching rule, or go to step 7 if there are no matches.
5. If the rule's scopes are appendable, append them to previously applied scopes.
6. Else, if `overridable == true`, override all previously applied scopes, and set `overridable = false`.
7. If there is another ruleset for the selector, continue to that ruleset and go to step 4.
8. If there is a more specific selector, continue to that selector and go to step 2.

When there are no appendable scopes in the grammar, this algorithm outputs the same scopes as before.

### Examples

```cson
# selector: ruleset
'identifier': [
  {
    # rule
    exact: 'String',
    scopes: 'entity.type.support' # String
  },
  {
    # rule
    match: '^[0-9_]*[A-Z]',
    scopes: 'entity.type' # Type
  },
  # rule (default)
  'entity.variable' # variable
]

# selector: ruleset
'attribute > identifier:nth-child(2)': [
  {
    # rule
    with: 'entity.type.support',
    scopes: 'entity.type.member' # _.String
  },
  # rule (default)
  '.member' # _.member
]

# selector, selector: ruleset
'''
call > identifier,
call > attribute > identifier:nth-child(2)
''': [
  {
    # rule
    with: 'entity.type',
    scopes: '.constructor.call' # Type()
  },
  # rule (default)
  'entity.function.call' # function()
]

# selector: ruleset
'call > attribute > identifier:nth-child(2)': {
  # rule
  with: 'entity.function',
  scopes: '.method' # _.method()
}
```

`_.String()` will be scoped:  
`entity.type.support` -> `entity.type.member` -> `.constructor.call` = `entity.type.member.constructor.call`

`_.method()` will be scoped:  
`entity.variable` -> `.member` -> `entity.function.call` -> `.method` = `entity.function.call.method`

## Code changes

#### `src/tree-sitter-grammar.js`

- `scopeSelectors[selector]` is now always an array of rulesets.
- `preprocessScopes()` now translates null/undefined scopes to `'.'` (= append nothing).
- `preprocessScopes()` parses "with" rules.  
- `preprocessScopes()` requires strings for "match", "exact", and "with" rules.  


#### `src/syntax-scope-map.js`

- Changed the switch statement in `addSelector()` to a series of if conditions to avoid code repetition since the linter doesn't allow fallthroughs (cases without breaks).
- Tweaked the structure of `SyntaxScopeMap.namedScopeTable` and `SyntaxScopeMap.anonymousScopeTable`. They are now:
    ```
    table = {
        node: {
            indices: {
                (nth-child number or *): {
                    results: ...,
                    parents: {
                        node: {
                            ...
    ```
    So for example, the selector `a > *:nth-child(3) > b:nth-child(1)` will give this table:
    ```
    namedScopeTable = {
        b: {
            indices: {
                1: {
                    parents: {
                        *: {
                            indices: {
                                3: {
                                    parents: {
                                        a: {
                                            indices: {
                                                *: {
                                                    results: ...
    ```
- Changed `setTableDefaults()` so that results of wildcards are prepended to results of other selectors, and created `setTableResults()` so that results of less specific selectors are prepended to results of more specific selectors. Results are now deep arrays of selectors sorted by specificity and rulesets sorted by order of appearance:
    ```
                       selector                             selector
       |----------------------------------------|   |---------------------|
       |           ruleset           ruleset    |   |       ruleset       |
       |  |----------------------|  |--------|  |   |  |---------------|  |
    [  [  [  rule,  rule,  rule  ], [  rule  ]  ],  [  [  rule,  rule  ]  ]  ]
    ```
- `get()` now returns that deep array.

#### `src/tree-sitter-language-mode.js`

- `applyLeafRules()` now parses a deep array to return a string of scopes.

## Possible Drawbacks

No regressions. Scopes in existing Tree-sitter grammar files are applied like before.

## Verification Process

- Added extensive specs with complex test cases.
- Built atom from this branch and tested the changes in many languages.

## Release Notes

- Allow appendable scopes in Tree-sitter grammars.