### PR TITLE
Prevent node_modules/nan pattern from matching node_modules/nanoid

### DIFF
--- a/script/lib/include-path-in-packaged-app.js
+++ b/script/lib/include-path-in-packaged-app.js
@@ -40,7 +40,7 @@ const EXCLUDE_REGEXPS_SOURCES = [
     path.join('get-parameter-names', 'node_modules', '.bin', 'testla')
   ),
   escapeRegExp(path.join('jasmine-reporters', 'ext')),
-  escapeRegExp(path.join('node_modules', 'nan')),
+  escapeRegExp(path.join('node_modules', 'nan')) + '\\b',
   escapeRegExp(path.join('node_modules', 'native-mate')),
   escapeRegExp(path.join('build', 'binding.Makefile')),
   escapeRegExp(path.join('build', 'config.gypi')),


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

Likely fix for #21341. We won't really know for sure until CI builds start using a nightly build that includes this fix.

### Description of the Change

The function exported from `script/lib/include-path-in-packaged-app.js` is used to determine whether or not a specific file within the source tree or `node_modules` is included in the packaged app. It does this by compiling a pair of giant regexps and matching them against path strings. One of these patterns, `escapeRegExp(path.join('node_modules', 'nan'))`, recently began to unexpectedly match one of our transitive dependencies, `node_modules/nanoid`. (I expect an upgrade to a different package introduced it as a new dependency recently.) This caused the `nanoid` dependency to be omitted from the application bundle and snapshot, which caused Atom to fail on launch when the dependency was needed (dev and test mode).

### Alternate Designs

I'd love to revisit the structure of `script/lib/include-path-in-packaged-app.js` and find a less brittle mechanism than a giant regexp to include and exclude specific files. Maybe a list of fnmatch globs instead, or some kind of trie structure? Event a giant Set of exact paths might be better.

I also thought about appending a `\b` to _all_ of the path regexps to prevent the same kind of failures in the future, but ultimately decided to keep this diff short and low-risk.

### Possible Drawbacks

None.

### Verification Process

I've built Atom from source with `script/build --install` and verified that the generated artifacts launch correctly. I've also verified that using this Atom build can correctly run a package's test suite.

### Release Notes

_N/A_