### PR TITLE
Debug find-and-replace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3340,8 +3340,8 @@
       }
     },
     "find-and-replace": {
-      "version": "https://www.atom.io/api/packages/find-and-replace/versions/0.219.5/tarball",
-      "integrity": "sha512-FVi54caB9IFGRBxye9nqnshryjCGhumlqioU/fwJTE+N8kUmJ/zjTUKiy9FhDK5782PUc4ig0cHimbH7o8vxmA==",
+      "version": "github:sadick254/find-and-replace#a69b187498e66a8fcfcc109f995c4d2b81c0ff73",
+      "from": "github:sadick254/find-and-replace",
       "requires": {
         "binary-search": "^1.3.3",
         "etch": "0.9.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "etch": "0.14.1",
     "event-kit": "^2.5.3",
     "exception-reporting": "file:packages/exception-reporting",
-    "find-and-replace": "https://www.atom.io/api/packages/find-and-replace/versions/0.219.5/tarball",
+    "find-and-replace": "github:sadick254/find-and-replace",
     "find-parent-dir": "^0.3.0",
     "first-mate": "7.4.1",
     "focus-trap": "6.1.0",

--- a/script/vsts/pull-requests.yml
+++ b/script/vsts/pull-requests.yml
@@ -5,6 +5,6 @@ jobs:
   - template: platforms/templates/get-release-version.yml
 
   # Import OS-specific build definitions
-  - template: platforms/windows.yml
+  #- template: platforms/windows.yml
   - template: platforms/macos.yml
-  - template: platforms/linux.yml
+  #- template: platforms/linux.yml


### PR DESCRIPTION
We have been experiencing CI failures due to the find and replace package. I created a fork of the `find-and-replace` package and `atom` with the hopes to replicate the failure. I have done multiple runs but the failure doesn't show up.
```
ResultsView
  core:move-to-top and core:move-to-bottom
    it ResultsView core:move-to-top and core:move-to-bottom selects the first/last item when core:move-to-top/move-to-bottom is triggered
      Expected undefined to have class 'selected'.
        at jasmine.Spec.<anonymous> (/Users/runner/work/1/s/node_modules/find-and-replace/spec/results-view-spec.js:307:71)
        at Generator.next (<anonymous>)
        at step (/Users/runner/work/1/s/node_modules/find-and-replace/spec/results-view-spec.js:1:428)
    it ResultsView core:move-to-top and core:move-to-bottom selects the path when when core:move-to-bottom is triggered and last item is collapsed
      Expected '<li class="list-nested-item"><div class="list-item path-row" data-file-path="/Users/runner/work/1/s/node_modules/find-and-replace/spec/fixtures/project/sample.coffee"><span data-name="sample.coffee" class="icon-file-text icon"></span><span class="path-name bright">sample.coffee</span><span class="path-match-number">(5 matches)</span></div></li>' to have class 'selected'.
        at jasmine.Spec.<anonymous> (/Users/runner/work/1/s/node_modules/find-and-replace/spec/results-view-spec.js:320:101)
        at Generator.next (<anonymous>)
        at step (/Users/runner/work/1/s/node_modules/find-and-replace/spec/results-view-spec.js:1:428)
```
