### PR TITLE
script/bootstrap: Make `apm --version` print the Atom version currently being bootstrapped

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -36,10 +36,13 @@ if (process.platform === 'win32') deleteMsbuildFromPath()
 
 installScriptDependencies(ci)
 installApm(ci)
+const apmVersionEnv = Object.assign({}, process.env);
+// Set resource path so that apm can load Atom's version.
+apmVersionEnv.ATOM_RESOURCE_PATH = CONFIG.repositoryRootPath;
 childProcess.execFileSync(
   CONFIG.getApmBinPath(),
   ['--version'],
-  {stdio: 'inherit'}
+  {stdio: 'inherit', env: apmVersionEnv}
 )
 runApmInstall(CONFIG.repositoryRootPath, ci)
 


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Issue or RFC Endorsed by Atom's Maintainers

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

None

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Tell `apm --version` where to find this repository's Atom metadata.

(During `script/bootstrap`: makes a separate copy of the `process.env` JS object, adds `ATOM_RESOURCE_PATH: CONFIG.repositoryRootPath` to that new object, and have `apm --version` run with this updated object as its `env` object.)

Now `apm --version` will print the Atom version being bootstrapped. (Previously, it printed whatever stable version of Atom you had on your system, which was irrelevant, or if you had no stable Atom installed, it would print "unknown").

ONLY affects the bootstrap process, and ONLY affects the one-off run of `apm --version`. This separate modified `env` object is never used again.

### Alternate Designs

Not a big deal, potential for very slightly less memory usage and (probably non-noticeably) very slightly faster execution:

Potentially re-use this `env` object in the immediate next step of bootstrapping, which is running `apm install` in the root of the repo. We do the same process there, [making a copy of `process.env` and adding `ATOM_RESOURCE_PATH: CONFIG.repositoryRootPath` to it](https://github.com/atom/atom/blob/8bc9b6cabcec927b7e85759b308cb03a8858a07e/script/lib/run-apm-install.js#L8-L10). These objects are redundant and identical. So re-using should be trivial, I just didn't look into implementing that.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Tiny bit more bootstrap complexity. Worth it for more useful and less-confusing human-readable script output.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Ran `script/bootstrap` with and without this change.

Before:

```console
Installing apm
[...]
atom 1.51.0
[...]
Installing modules ✓
```

After:

```console
Installing apm
[...]
atom 1.53.0-dev
[...]
Installing modules ✓
```

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A