### PR TITLE
Update Debian dependencies, fixes Ubuntu Groovy

### DIFF
--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,8 +1,8 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, libgconf-2-4 (>= 3.2.5) | libgconf2-4, libgtk-3-0 (>= 3.9.10), libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libasound2 (>= 1.0.16), libxkbfile1, libcurl3 | libcurl4, policykit-1
-Recommends: lsb-release
-Suggests: libsecret-1-0, gir1.2-gnomekeyring-1.0
+Depends: git, libgconf-2-4 (>= 3.2.5), libgtk-3-0 (>= 3.9.10), libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), kde-cli-tools | kde-runtime | trash-cli | libglib2.0-bin | gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libcurl3 | libcurl4
+Recommends: libasound2 (>= 1.0.16), policykit-1
+Suggests: lsb-release
 Section: devel
 Priority: optional
 Architecture: <%= arch %>

--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, libgconf-2-4 (>= 3.2.5), libgtk-3-0 (>= 3.9.10), libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), kde-cli-tools | kde-runtime | trash-cli | libglib2.0-bin | gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libcurl3 | libcurl4
+Depends: git, libgconf-2-4 (>= 3.2.5), libgtk-3-0 (>= 3.9.10), libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), kde-cli-tools | kde-runtime | trash-cli | libglib2.0-bin | gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libxkbfile1, libcurl3 | libcurl4
 Recommends: libasound2 (>= 1.0.16), policykit-1, libsecret-1-0, gnome-keyring
 Suggests: lsb-release
 Section: devel

--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,8 +1,8 @@
 Package: <%= appFileName %>
 Version: <%= version %>
 Depends: git, libgconf-2-4 (>= 3.2.5), libgtk-3-0 (>= 3.9.10), libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), kde-cli-tools | kde-runtime | trash-cli | libglib2.0-bin | gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libcurl3 | libcurl4
-Recommends: libasound2 (>= 1.0.16), policykit-1
-Suggests: libsecret-1-0, lsb-release
+Recommends: libasound2 (>= 1.0.16), policykit-1, libsecret-1-0, gnome-keyring
+Suggests: lsb-release
 Section: devel
 Priority: optional
 Architecture: <%= arch %>

--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, libgconf-2-4 (>= 3.2.5), libgtk-3-0 (>= 3.9.10), libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), kde-cli-tools | kde-runtime | trash-cli | libglib2.0-bin | gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libxkbfile1, libcurl3 | libcurl4
+Depends: git, libgconf-2-4 (>= 3.2.5), libgtk-3-0 (>= 3.9.10), libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), libglib2.0-bin | kde-cli-tools | kde-runtime, xdg-utils, libx11-xcb1, libxss1, libxkbfile1, libcurl3 | libcurl4
 Recommends: libasound2 (>= 1.0.16), policykit-1, libsecret-1-0, gnome-keyring
 Suggests: lsb-release
 Section: devel

--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -2,7 +2,7 @@ Package: <%= appFileName %>
 Version: <%= version %>
 Depends: git, libgconf-2-4 (>= 3.2.5), libgtk-3-0 (>= 3.9.10), libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), kde-cli-tools | kde-runtime | trash-cli | libglib2.0-bin | gvfs-bin, xdg-utils, libx11-xcb1, libxss1, libcurl3 | libcurl4
 Recommends: libasound2 (>= 1.0.16), policykit-1
-Suggests: lsb-release
+Suggests: libsecret-1-0, lsb-release
 Section: devel
 Priority: optional
 Architecture: <%= arch %>


### PR DESCRIPTION
Atom is not install-able on Ubuntu Groovy because of outdated dependencies as described in #21422 
This fixes and updates Atom dependencies after investigation with @DeeDeeG 
Some dependencies are not required by Electron anymore, some packages are unavailable/outdated and need alternatives
Some dependencies are less strict and can be a suggestion or recommendation. For details see bugreport #21422
