### PR TITLE
script executables should be LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,13 @@ spec/fixtures/sample.txt text eol=lf
 
 # Windows bash scripts are also Unix LF endings
 *.sh		eol=lf
+
+# The script executables should be LF so they can be edited on Windows
+script/bootstrap text eol=lf
+script/build text eol=lf
+script/cibuild text eol=lf
+script/clean text eol=lf
+script/lint text eol=lf
+script/postprocess-junit-results text eol=lf
+script/test text eol=lf
+script/verify-snapshot-script text eol=lf


### PR DESCRIPTION
### Description of the change + Benefits

This makes the script executables LF so they can be edited on Windows. 

### Issue
I had ended up editing these files on Windows and the line ending changes made them non-working inside WSL or my Linux CI.

I fixed the issue by running the following to make sure everything is back to its state:
```
 git update-index --chmod=+x script/bootstrap
 git update-index --chmod=+x script/build
 git update-index --chmod=+x script/cibuild
 git update-index --chmod=+x script/clean
 git update-index --chmod=+x script/lint
 git update-index --chmod=+x script/postprocess-junit-results
 git update-index --chmod=+x script/test
 git update-index --chmod=+x script/verify-snapshot-script
```

### Verification
The CI passes

### Drawbacks
N/A
### Release Notes
N/A