### PR TITLE
Clarify the context under which log-file is used

### DIFF
--- a/src/main-process/parse-command-line.js
+++ b/src/main-process/parse-command-line.js
@@ -59,7 +59,7 @@ module.exports = function parseCommandLine(processArgs) {
   options
     .alias('l', 'log-file')
     .string('l')
-    .describe('l', 'Log all output to file.');
+    .describe('l', 'Log all output to file when running tests.');
   options
     .alias('n', 'new-window')
     .boolean('n')


### PR DESCRIPTION
Resolves #15144

`--log-file` option seem only to used in the context of running tests. It makes sense to have this as part of the description to avoid confusion.

https://github.com/atom/atom/blob/e3fa3172e0ae58fa023abf1fcb11ec51e81371ee/spec/jasmine-test-runner.coffee#L142
