### PR TITLE
Fix WSL uname test

### DIFF
--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -5,7 +5,7 @@ if command -v "cygpath" > /dev/null; then
   ATOMCMD=$(cygpath "$(dirname "$0")/atom.cmd" -a -w)
 else
   pushd "$(dirname "$0")" > /dev/null
-  if [[ $(uname -r) =~ "(M|m)icrosoft" ]]; then
+  if [[ $(uname -r) =~ (M|m)icrosoft ]]; then
     # We are in Windows Subsystem for Linux, map /mnt/drive
     root="/mnt/"
     # If different root mount point defined in /etc/wsl.conf, use that instead

--- a/resources/win/atom.sh
+++ b/resources/win/atom.sh
@@ -5,7 +5,7 @@ if command -v "cygpath" > /dev/null; then
   ATOMCMD=$(cygpath "$(dirname "$0")/atom.cmd" -a -w)
 else
   pushd "$(dirname "$0")" > /dev/null
-  if [[ $(uname -r) == *-Microsoft ]]; then
+  if [[ $(uname -r) =~ "(M|m)icrosoft" ]]; then
     # We are in Windows Subsystem for Linux, map /mnt/drive
     root="/mnt/"
     # If different root mount point defined in /etc/wsl.conf, use that instead


### PR DESCRIPTION
On WSL2, Ubuntu 20.04.1, `uname -r` == `4.19.128-microsoft-standard`, so it won't match `/Microsoft$/` because both wrong case and non-final.

I've changed it to use a simple regex.