### PR TITLE
Merge global and scoped non word characters

### DIFF
--- a/spec/text-mate-language-mode-spec.js
+++ b/spec/text-mate-language-mode-spec.js
@@ -1477,6 +1477,29 @@ describe('TextMateLanguageMode', () => {
       ]);
     }));
 
+  describe('.getNonWordCharacters', () => {
+    it('merges the language mode non word characters with the globally set non word characters', () => {
+      config.set('editor.nonWordCharacters', '»');
+
+      const buffer = atom.project.bufferForPathSync('sample.js');
+      const languageMode = new TextMateLanguageMode({
+        buffer,
+        config,
+        grammar: atom.grammars.grammarForScopeName('source.js')
+      });
+
+      const scopedNonWords = config.getRawScopedValue(
+        ['source.js'],
+        'editor.nonWordCharacters'
+      );
+      const globalNonWords = config.get('editor.nonWordCharacters');
+
+      expect(languageMode.getNonWordCharacters([0, 0])).toEqual(
+        `${scopedNonWords}${globalNonWords}`
+      );
+    });
+  });
+
   function simulateFold(ranges) {
     buffer.transact(() => {
       for (const range of ranges.reverse()) {

--- a/src/text-mate-language-mode.js
+++ b/src/text-mate-language-mode.js
@@ -70,7 +70,9 @@ class TextMateLanguageMode {
 
   getNonWordCharacters(position) {
     const scope = this.scopeDescriptorForPosition(position);
-    return this.config.get('editor.nonWordCharacters', { scope });
+    const rawValue = this.config.getRawValue('editor.nonWordCharacters');
+    const scopedValue = this.config.get('editor.nonWordCharacters', { scope });
+    return `${scopedValue}${rawValue}`;
   }
 
   /*


### PR DESCRIPTION
Resolves #11986

**Current behaviour**
If a package (mostly language packages) has a `nonWordCharacter` key set in their config. The global `nonWordCharacters` setting is ignored.
This means if you add a non-word character in the atom config file, that character won't be picked up by atom.