### PR TITLE
Remove unnecessary check to allow scrolling to center

### DIFF
--- a/packages/go-to-line/spec/go-to-line-spec.js
+++ b/packages/go-to-line/spec/go-to-line-spec.js
@@ -75,7 +75,7 @@ describe('GoToLine', () => {
       goToLine.miniEditor.insertText('45:4');
       atom.commands.dispatch(goToLine.miniEditor.element, 'core:confirm');
       const rowsPerPage = editor.getRowsPerPage();
-      const currentRow = editor.getCursorBufferPosition().row - 1;
+      const currentRow = editor.getCursorBufferPosition().row;
       expect(editor.getFirstVisibleScreenRow()).toBe(
         currentRow - Math.ceil(rowsPerPage / 2)
       );

--- a/src/text-editor-component.js
+++ b/src/text-editor-component.js
@@ -2320,15 +2320,10 @@ module.exports = class TextEditorComponent {
     let desiredScrollTop, desiredScrollBottom;
     if (options && options.center) {
       const desiredScrollCenter = (screenRangeTop + screenRangeBottom) / 2;
-      if (
-        desiredScrollCenter < this.getScrollTop() ||
-        desiredScrollCenter > this.getScrollBottom()
-      ) {
-        desiredScrollTop =
-          desiredScrollCenter - this.getScrollContainerClientHeight() / 2;
-        desiredScrollBottom =
-          desiredScrollCenter + this.getScrollContainerClientHeight() / 2;
-      }
+      desiredScrollTop =
+        desiredScrollCenter - this.getScrollContainerClientHeight() / 2;
+      desiredScrollBottom =
+        desiredScrollCenter + this.getScrollContainerClientHeight() / 2;
     } else {
       desiredScrollTop = screenRangeTop - verticalScrollMargin;
       desiredScrollBottom = screenRangeBottom + verticalScrollMargin;


### PR DESCRIPTION
Resolves #11429

The check is unnecessary. The values of `desiredScrollTop` and `desiredScrollBottom` is already catered for by adding or subtracting `desiredScrollCenter` value from `getScrollContainerClientHeight`.