### PR TITLE
performance: add more CSS containment to text-editor

### DIFF
--- a/static/core-ui/text-editor.less
+++ b/static/core-ui/text-editor.less
@@ -9,7 +9,7 @@
 }
 
 atom-text-editor {
-  contain: @contain_but_size;
+  contain: @contain_except_size;
   display: flex;
   cursor: text;
   font-family: var(--editor-font-family);
@@ -17,14 +17,14 @@ atom-text-editor {
   line-height: var(--editor-line-height);
 
   .gutter-container {
-    contain: @contain_but_size;
+    contain: @contain_except_size;
     width: min-content;
     background-color: inherit;
     cursor: default;
   }
 
   .gutter {
-    contain: @contain_but_size;
+    contain: @contain_except_size;
     overflow: hidden;
     z-index: 0;
     text-align: right;
@@ -36,7 +36,7 @@ atom-text-editor {
 
   .gutter:hover {
     .line-number.foldable .icon-right {
-      contain: @contain_but_layout_size;
+      contain: @contain_except_layout_size;
       visibility: visible;
 
       &:hover {
@@ -47,7 +47,7 @@ atom-text-editor {
 
   .gutter, .gutter:hover {
     .line-number.folded .icon-right {
-      contain: @contain_but_layout_size;
+      contain: @contain_except_layout_size;
       .octicon(chevron-right, 0.8em);
 
       visibility: visible;
@@ -60,20 +60,20 @@ atom-text-editor {
   }
 
   .line-numbers {
-    contain: @contain_but_size;
+    contain: @contain_except_size;
     width: max-content;
     background-color: inherit;
   }
 
   .line-number {
-    contain: @contain_but_size;
+    contain: @contain_except_size;
     padding-left: .5em;
     white-space: nowrap;
     opacity: 0.6;
     position: relative;
 
     .icon-right {
-      contain: @contain_but_layout_size;
+      contain: @contain_except_layout_size;
       .octicon(chevron-down, 0.8em);
       display: inline-block;
       visibility: hidden;
@@ -87,20 +87,20 @@ atom-text-editor {
   }
 
   .highlight {
-    contain: @contain_but_paint;
+    contain: @contain_except_paint;
     background: none;
     padding: 0;
   }
 
   .highlight .region {
-    contain: @contain_but_paint;
+    contain: @contain_except_paint;
     pointer-events: none;
     z-index: -1;
   }
 
   .line {
     white-space: pre;
-    contain: @contain_but_size;
+    contain: @contain_except_size;
 
     &.cursor-line .fold-marker::after {
       opacity: 1;
@@ -120,7 +120,7 @@ atom-text-editor {
   }
 
   .placeholder-text {
-    contain: @contain_but_size;
+    contain: @contain_except_size;
     position: absolute;
     color: @text-color-subtle;
   }
@@ -132,7 +132,7 @@ atom-text-editor {
   }
 
   .indent-guide {
-    contain: @contain_but_layout_size;
+    contain: @contain_except_layout_size;
     display: inline-block;
     box-shadow: inset 1px 0;
   }
@@ -161,7 +161,7 @@ atom-text-editor {
 }
 
 atom-text-editor[mini] {
-  contain: @contain_but_size;
+  contain: @contain_except_size;
   font-size: @input-font-size;
   line-height: @component-line-height;
   max-height: @component-line-height + 2; // +2 for borders
@@ -169,7 +169,7 @@ atom-text-editor[mini] {
 }
 
 atom-overlay {
-  contain: @contain_but_size_paint;
+  contain: @contain_except_size_paint;
   position: fixed;
   display: block;
   z-index: 4;

--- a/static/core-ui/text-editor.less
+++ b/static/core-ui/text-editor.less
@@ -120,7 +120,7 @@ atom-text-editor {
   }
 
   .placeholder-text {
-    contain: @contain_all;
+    contain: @contain_but_size;
     position: absolute;
     color: @text-color-subtle;
   }

--- a/static/core-ui/text-editor.less
+++ b/static/core-ui/text-editor.less
@@ -1,19 +1,12 @@
 @import "ui-variables";
 @import "octicon-utf-codes";
 @import "octicon-mixins";
+@import "utils.less";
 
 :root {
   // Fixes specs
   --editor-font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
 }
-
-// CSS containment variables.
-// The words after `but` show the excluded/incompatible values.
-@contain_all: layout size paint style;
-@contain_but_size: layout paint style;
-@contain_but_layout: size paint style;
-@contain_but_paint: layout size style;
-@contain_but_layout_size: paint style;
 
 atom-text-editor {
   contain: @contain_but_size;

--- a/static/core-ui/text-editor.less
+++ b/static/core-ui/text-editor.less
@@ -169,7 +169,7 @@ atom-text-editor[mini] {
 }
 
 atom-overlay {
-  contain: @containt_but_size_paint;
+  contain: @contain_but_size_paint;
   position: fixed;
   display: block;
   z-index: 4;

--- a/static/core-ui/text-editor.less
+++ b/static/core-ui/text-editor.less
@@ -7,10 +7,13 @@
   --editor-font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
 }
 
+// CSS containment variables.
+// The words after `but` show the excluded/incompatible values.
 @contain_all: layout size paint style;
 @contain_but_size: layout paint style;
 @contain_but_layout: size paint style;
 @contain_but_paint: layout size style;
+@contain_but_layout_size: paint style;
 
 atom-text-editor {
   contain: @contain_but_size;
@@ -40,7 +43,7 @@ atom-text-editor {
 
   .gutter:hover {
     .line-number.foldable .icon-right {
-      contain: paint style;
+      contain: @contain_but_layout_size;
       visibility: visible;
 
       &:hover {
@@ -51,7 +54,7 @@ atom-text-editor {
 
   .gutter, .gutter:hover {
     .line-number.folded .icon-right {
-      contain: paint style;
+      contain: @contain_but_layout_size;
       .octicon(chevron-right, 0.8em);
 
       visibility: visible;
@@ -77,7 +80,7 @@ atom-text-editor {
     position: relative;
 
     .icon-right {
-      contain: paint style;
+      contain: @contain_but_layout_size;
       .octicon(chevron-down, 0.8em);
       display: inline-block;
       visibility: hidden;
@@ -136,7 +139,7 @@ atom-text-editor {
   }
 
   .indent-guide {
-    contain: paint style;
+    contain: @contain_but_layout_size;
     display: inline-block;
     box-shadow: inset 1px 0;
   }

--- a/static/core-ui/text-editor.less
+++ b/static/core-ui/text-editor.less
@@ -176,7 +176,7 @@ atom-text-editor[mini] {
 }
 
 atom-overlay {
-  contain: layout style;
+  contain: @containt_but_size_paint;
   position: fixed;
   display: block;
   z-index: 4;

--- a/static/core-ui/text-editor.less
+++ b/static/core-ui/text-editor.less
@@ -7,7 +7,13 @@
   --editor-font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
 }
 
+@contain_all: layout size paint style;
+@contain_but_size: layout paint style;
+@contain_but_layout: size paint style;
+@contain_but_paint: layout size style;
+
 atom-text-editor {
+  contain: @contain_but_size;
   display: flex;
   cursor: text;
   font-family: var(--editor-font-family);
@@ -15,12 +21,14 @@ atom-text-editor {
   line-height: var(--editor-line-height);
 
   .gutter-container {
+    contain: @contain_but_size;
     width: min-content;
     background-color: inherit;
     cursor: default;
   }
 
   .gutter {
+    contain: @contain_but_size;
     overflow: hidden;
     z-index: 0;
     text-align: right;
@@ -32,6 +40,7 @@ atom-text-editor {
 
   .gutter:hover {
     .line-number.foldable .icon-right {
+      contain: paint style;
       visibility: visible;
 
       &:hover {
@@ -42,6 +51,7 @@ atom-text-editor {
 
   .gutter, .gutter:hover {
     .line-number.folded .icon-right {
+      contain: paint style;
       .octicon(chevron-right, 0.8em);
 
       visibility: visible;
@@ -54,17 +64,20 @@ atom-text-editor {
   }
 
   .line-numbers {
+    contain: @contain_but_size;
     width: max-content;
     background-color: inherit;
   }
 
   .line-number {
+    contain: @contain_but_size;
     padding-left: .5em;
     white-space: nowrap;
     opacity: 0.6;
     position: relative;
 
     .icon-right {
+      contain: paint style;
       .octicon(chevron-down, 0.8em);
       display: inline-block;
       visibility: hidden;
@@ -78,18 +91,20 @@ atom-text-editor {
   }
 
   .highlight {
+    contain: @contain_but_paint;
     background: none;
     padding: 0;
   }
 
   .highlight .region {
+    contain: @contain_but_paint;
     pointer-events: none;
     z-index: -1;
   }
 
   .line {
     white-space: pre;
-    contain: layout;
+    contain: @contain_but_size;
 
     &.cursor-line .fold-marker::after {
       opacity: 1;
@@ -97,6 +112,7 @@ atom-text-editor {
   }
 
   .fold-marker {
+    contain: @contain_all;
     cursor: default;
 
     &::after {
@@ -108,21 +124,25 @@ atom-text-editor {
   }
 
   .placeholder-text {
+    contain: @contain_all;
     position: absolute;
     color: @text-color-subtle;
   }
 
   .invisible-character {
+    contain: @contain_all;
     font-weight: normal !important;
     font-style: normal !important;
   }
 
   .indent-guide {
+    contain: paint style;
     display: inline-block;
     box-shadow: inset 1px 0;
   }
 
   .cursor {
+    contain: @contain_all;
     z-index: 4;
     pointer-events: none;
     box-sizing: border-box;
@@ -145,6 +165,7 @@ atom-text-editor {
 }
 
 atom-text-editor[mini] {
+  contain: @contain_but_size;
   font-size: @input-font-size;
   line-height: @component-line-height;
   max-height: @component-line-height + 2; // +2 for borders
@@ -152,6 +173,7 @@ atom-text-editor[mini] {
 }
 
 atom-overlay {
+  contain: layout style;
   position: fixed;
   display: block;
   z-index: 4;

--- a/static/core-ui/utils.less
+++ b/static/core-ui/utils.less
@@ -7,4 +7,4 @@
 @contain_but_paint: layout size style;
 @contain_but_layout_size: paint style;
 @contain_but_layout_paint: size style;
-@containt_but_size_paint: layout style;
+@contain_but_size_paint: layout style;

--- a/static/core-ui/utils.less
+++ b/static/core-ui/utils.less
@@ -1,0 +1,10 @@
+
+// CSS containment variables.
+// The words after `but` explicitly show the excluded/incompatible values.
+@contain_all: layout size paint style;
+@contain_but_layout: size paint style;
+@contain_but_size: layout paint style;
+@contain_but_paint: layout size style;
+@contain_but_layout_size: paint style;
+@contain_but_layout_paint: size style;
+@containt_but_size_paint: layout style;

--- a/static/core-ui/utils.less
+++ b/static/core-ui/utils.less
@@ -2,9 +2,9 @@
 // CSS containment variables.
 // The words after `but` explicitly show the excluded/incompatible values.
 @contain_all: layout size paint style;
-@contain_but_layout: size paint style;
-@contain_but_size: layout paint style;
-@contain_but_paint: layout size style;
-@contain_but_layout_size: paint style;
-@contain_but_layout_paint: size style;
-@contain_but_size_paint: layout style;
+@contain_except_layout: size paint style;
+@contain_except_size: layout paint style;
+@contain_except_paint: layout size style;
+@contain_except_layout_size: paint style;
+@contain_except_layout_paint: size style;
+@contain_except_size_paint: layout style;


### PR DESCRIPTION
### Description of the Change

This adds more [CSS containment](https://drafts.csswg.org/css-contain/#contain-property) to tree-view CSS classes. This results in performance improvements by giving the hint to the browser that the size/paint/layout of these elements does not affect other elements around them.

I have added the CSS containment for each class selectively by testing all the functionalities. As you see, these do not change the functionality. 

I have explicitly specified the excluded/incompatible values, so no confusion happens in the future that why some of the `contain` values are missing.

### Benefits
Improves the performance and responsiveness of the text editor. It has improved scrolling performance. The datatips and decorations are rendered faster than before. 

The reason is that the browser will not need to recalculate the styles on clicks, scrolling, drag-drop, during the loading, etc.

Quoting [CSS specifications](https://drafts.csswg.org/css-contain/#contain-property)
> The contain property allows an author to indicate that an element and its contents are, as much as possible, independent of the rest of the document tree. This allows user agents to utilize much stronger optimizations when rendering a page using contain properly and allows authors to be confident that their page won’t accidentally fall into a slow code path due to an innocuous change.

<details>
<summary>Some benchmarks</summary>

The benefits are more apparent during interactions.

Here I opened the src/text-editor.js and I waited for 15s (linter/linter-ui-default and atom-ide-javascript were enabled)
After this PR
![image](https://user-images.githubusercontent.com/16418197/96802584-c76e8880-13cf-11eb-969d-05189a4989f8.png)
![image](https://user-images.githubusercontent.com/16418197/96802594-ca697900-13cf-11eb-9bdf-7681bd287ed7.png)

Before this PR
![image](https://user-images.githubusercontent.com/16418197/96802610-d2291d80-13cf-11eb-8a0f-fb8ed4fba40f.png)
![image](https://user-images.githubusercontent.com/16418197/96802618-d35a4a80-13cf-11eb-917f-b02526f58f00.png)



</details>

### Future improvements
- I have some PRs on hold which adds CSS containment to other classes. such as this one: https://github.com/atom-ide-community/atom/pull/238

- We can provide an optional API for using a more contained class. For example, we can have an `overlay-contained` which allows creating a fully contained datatip. As I tested this, this class works with atom-ide-datatips.

### Verifications 

I have tested all the functionalities including:
- Writing text
- Removing text
- Selecting text
- Highlighting text
- Folding and unfolding 
- Hovering on the gutter
- Line numbers preserved
- Text entries in settings view, fuzzy finder, etc work without issues
- Datatips and Linter overlays work as expected
- Linter decorations work as expected
- Autocomplete works as expected
- Pigments colors work as expected
- Scrolling works as expected
- Themes can be changed
- Text editors can be resized or moved

This is in addition to all of the tests passing.

### Release Notes
- Improving the performance of text editor by adding more CSS containment
