### PR TITLE
⬆️ chart.js@2.9.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2169,9 +2169,9 @@
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "chart.js": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.3.tgz",
-      "integrity": "sha512-+2jlOobSk52c1VU6fzkh3UwqHMdSlgH1xFv9FKMqHiNCpXsGPQa/+81AFa+i3jZ253Mq9aAycPwDjnn1XbRNNw==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
       "requires": {
         "chartjs-color": "^2.1.0",
         "moment": "^2.10.2"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bookmarks": "https://www.atom.io/api/packages/bookmarks/versions/0.46.0/tarball",
     "bracket-matcher": "https://www.atom.io/api/packages/bracket-matcher/versions/0.91.2/tarball",
     "chai": "4.2.0",
-    "chart.js": "^2.3.0",
+    "chart.js": "2.9.4",
     "clear-cut": "^2.0.2",
     "coffee-script": "1.12.7",
     "color": "3.1.3",


### PR DESCRIPTION
Bumps chart.js from 2.9.3 to 2.9.4