### PR TITLE
Fixed atom.confirm and internal use of dialog.showMessageBox

### DIFF
--- a/src/application-delegate.js
+++ b/src/application-delegate.js
@@ -228,11 +228,11 @@ module.exports = class ApplicationDelegate {
         { type: 'info', normalizeAccessKeys: true },
         options
       );
-      remote.dialog.showMessageBox(
-        remote.getCurrentWindow(),
-        options,
-        callback
-      );
+      remote.dialog
+        .showMessageBox(remote.getCurrentWindow(), options)
+        .then(result => {
+          callback(result.response);
+        });
     } else {
       // Legacy sync version: options can only have `message`,
       // `detailedMessage` (optional), and buttons array or object (optional)
@@ -246,13 +246,16 @@ module.exports = class ApplicationDelegate {
         buttonLabels = Object.keys(buttons);
       }
 
-      const chosen = remote.dialog.showMessageBox(remote.getCurrentWindow(), {
-        type: 'info',
-        message,
-        detail: detailedMessage,
-        buttons: buttonLabels,
-        normalizeAccessKeys: true
-      });
+      const chosen = remote.dialog.showMessageBoxSync(
+        remote.getCurrentWindow(),
+        {
+          type: 'info',
+          message,
+          detail: detailedMessage,
+          buttons: buttonLabels,
+          normalizeAccessKeys: true
+        }
+      );
 
       if (Array.isArray(buttons)) {
         return chosen;

--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -2025,8 +2025,8 @@ module.exports = class AtomApplication extends EventEmitter {
     dialog.showOpenDialog(parentWindow, openOptions, callback);
   }
 
-  promptForRestart() {
-    dialog.showMessageBox(
+  async promptForRestart() {
+    const result = await dialog.showMessageBox(
       BrowserWindow.getFocusedWindow(),
       {
         type: 'warning',
@@ -2034,11 +2034,9 @@ module.exports = class AtomApplication extends EventEmitter {
         message:
           'You will need to restart Atom for this change to take effect.',
         buttons: ['Restart Atom', 'Cancel']
-      },
-      response => {
-        if (response === 0) this.restart();
       }
     );
+    if (result.response === 0) this.restart();
   }
 
   restart() {

--- a/src/main-process/atom-window.js
+++ b/src/main-process/atom-window.js
@@ -211,22 +211,17 @@ module.exports = class AtomWindow extends EventEmitter {
       this.resolveClosedPromise();
     });
 
-    this.browserWindow.on('unresponsive', () => {
+    this.browserWindow.on('unresponsive', async () => {
       if (this.isSpec) return;
-      dialog.showMessageBox(
-        this.browserWindow,
-        {
-          type: 'warning',
-          buttons: ['Force Close', 'Keep Waiting'],
-          cancelId: 1, // Canceling should be the least destructive action
-          message: 'Editor is not responding',
-          detail:
-            'The editor is not responding. Would you like to force close it or just keep waiting?'
-        },
-        response => {
-          if (response === 0) this.browserWindow.destroy();
-        }
-      );
+      const result = await dialog.showMessageBox(this.browserWindow, {
+        type: 'warning',
+        buttons: ['Force Close', 'Keep Waiting'],
+        cancelId: 1, // Canceling should be the least destructive action
+        message: 'Editor is not responding',
+        detail:
+          'The editor is not responding. Would you like to force close it or just keep waiting?'
+      });
+      if (result.response === 0) this.browserWindow.destroy();
     });
 
     this.browserWindow.webContents.on('crashed', async () => {
@@ -237,24 +232,23 @@ module.exports = class AtomWindow extends EventEmitter {
       }
 
       await this.fileRecoveryService.didCrashWindow(this);
-      dialog.showMessageBox(
-        this.browserWindow,
-        {
-          type: 'warning',
-          buttons: ['Close Window', 'Reload', 'Keep It Open'],
-          cancelId: 2, // Canceling should be the least destructive action
-          message: 'The editor has crashed',
-          detail: 'Please report this issue to https://github.com/atom/atom'
-        },
-        response => {
-          switch (response) {
-            case 0:
-              return this.browserWindow.destroy();
-            case 1:
-              return this.browserWindow.reload();
-          }
-        }
-      );
+
+      const result = await dialog.showMessageBox(this.browserWindow, {
+        type: 'warning',
+        buttons: ['Close Window', 'Reload', 'Keep It Open'],
+        cancelId: 2, // Canceling should be the least destructive action
+        message: 'The editor has crashed',
+        detail: 'Please report this issue to https://github.com/atom/atom'
+      });
+
+      switch (result.response) {
+        case 0:
+          this.browserWindow.destroy();
+          break;
+        case 1:
+          this.browserWindow.reload();
+          break;
+      }
     });
 
     this.browserWindow.webContents.on('will-navigate', (event, url) => {

--- a/src/main-process/auto-update-manager.js
+++ b/src/main-process/auto-update-manager.js
@@ -168,17 +168,14 @@ module.exports = class AutoUpdateManager extends EventEmitter {
   onUpdateNotAvailable() {
     autoUpdater.removeListener('error', this.onUpdateError);
     const { dialog } = require('electron');
-    dialog.showMessageBox(
-      {
-        type: 'info',
-        buttons: ['OK'],
-        icon: this.iconPath,
-        message: 'No update available.',
-        title: 'No Update Available',
-        detail: `Version ${this.version} is the latest version.`
-      },
-      () => {}
-    ); // noop callback to get async behavior
+    dialog.showMessageBox({
+      type: 'info',
+      buttons: ['OK'],
+      icon: this.iconPath,
+      message: 'No update available.',
+      title: 'No Update Available',
+      detail: `Version ${this.version} is the latest version.`
+    });
   }
 
   onUpdateError(event, message) {
@@ -187,17 +184,14 @@ module.exports = class AutoUpdateManager extends EventEmitter {
       this.onUpdateNotAvailable
     );
     const { dialog } = require('electron');
-    dialog.showMessageBox(
-      {
-        type: 'warning',
-        buttons: ['OK'],
-        icon: this.iconPath,
-        message: 'There was an error checking for updates.',
-        title: 'Update Error',
-        detail: message
-      },
-      () => {}
-    ); // noop callback to get async behavior
+    dialog.showMessageBox({
+      type: 'warning',
+      buttons: ['OK'],
+      icon: this.iconPath,
+      message: 'There was an error checking for updates.',
+      title: 'Update Error',
+      detail: message
+    });
   }
 
   getWindows() {

--- a/src/main-process/file-recovery-service.js
+++ b/src/main-process/file-recovery-service.js
@@ -83,13 +83,12 @@ module.exports = class FileRecoveryService {
                 recoveryFile.recoveryPath
               }".`;
             console.log(detail);
-            dialog.showMessageBox(
-              window,
-              { type: 'info', buttons: ['OK'], message, detail },
-              () => {
-                /* noop callback to get async behavior */
-              }
-            );
+            dialog.showMessageBox(window, {
+              type: 'info',
+              buttons: ['OK'],
+              message,
+              detail
+            });
           })
           .then(() => {
             for (let window of this.windowsByRecoveryFile.get(recoveryFile)) {


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. ✔️ 
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>. ✔️ 
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>. ❌ _See Verification Process_
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>. ✔️ 

### Identify the Bug

Closes https://github.com/atom/atom/issues/21586

### Description of the Change

Electron's `showMessageBox` [was promisified](https://github.com/electron/electron/pull/17298) (a breaking change), it no longer takes a 3rd `callback` parameter that controls whether or not it is asynchronous. As such I've updated `atom.confirm` to call with `async`/`await` semantics when a `callback` is provided to `atom.confirm`, or to simply call (the new) `showMessageBoxSync` function when `atom.confirm` is called without a `callback`.

Additionally, I've updated all internal uses of `showMessageBox` to use the latest promisified API correctly.

### Alternate Designs

`atom.confirm` could in theory be updated to match Electron's `showMessageBox` semantics, however it'd be a breaking change in Atom's API; which is specifically what we're trying to fix/avoid with this PR.

### Possible Drawbacks

N/A - it's a pretty straight-forward change for a fairly critical bug.

### Verification Process

1. Built Atom locally.

2. Executed local (dev) Atom build with the [tabletop-simulator-lua](https://github.com/Berserk-Games/atom-tabletopsimulator-lua/) package installed (apm linked in this case)

_**EDIT**: The published Tabletop Simulator Lua package has since been updated to work around this issue. To recreate the failure you'll want to grab [the previous version](https://github.com/Berserk-Games/atom-tabletopsimulator-lua/commit/87f12ce5421c6c363a5ad167e410ed1f3ee6fef9)._

3. Launched the dev tools and placed a breakpoint at https://github.com/Berserk-Games/atom-tabletopsimulator-lua/blob/87f12ce5421c6c363a5ad167e410ed1f3ee6fef9/lib/tabletopsimulator-lua.coffee#L1223

4. Verified it was hit.

Additionally, changed Atom's Settings `Core` -> `Color Profile` which triggers Atom's `promptForRestart` method, displaying a dialog (now using async/await), and verified that pressing the `Restart Atom` button triggers an Atom restart.

**Specs**

I have _not_ written specs for this change, as I don't believe the existing spec infrastructure provides the necessary mechanisms to push a button in a native message box prompt. `showMessageDialog` is implemented natively so we can't really get at its internals.

### Release Notes

**User facing**

- Fixed an issue that may have caused third-party packages to fail to perform actions after prompting for confirmation.

**Technical**

- Fixed an issue that resulted in atom.confirm callbacks not being called.