### PR TITLE
git-diff: Fix subfolder git detection

### DIFF
--- a/packages/git-diff/lib/helpers.js
+++ b/packages/git-diff/lib/helpers.js
@@ -1,10 +1,10 @@
 'use babel';
 
+const { Directory } = require('atom');
+
 export default async function(goalPath) {
-  for (const directory of atom.project.getDirectories()) {
-    if (goalPath === directory.getPath() || directory.contains(goalPath)) {
-      return atom.project.repositoryForDirectory(directory);
-    }
+  if (goalPath) {
+    return atom.project.repositoryForDirectory(new Directory(goalPath));
   }
   return null;
 }

--- a/packages/git-diff/lib/helpers.js
+++ b/packages/git-diff/lib/helpers.js
@@ -1,6 +1,5 @@
 'use babel';
-
-const { Directory } = require('atom');
+import { Directory } from 'atom';
 
 export default async function(goalPath) {
   if (goalPath) {

--- a/packages/git-diff/spec/git-diff-spec.js
+++ b/packages/git-diff/spec/git-diff-spec.js
@@ -54,7 +54,6 @@ describe('GitDiff package', () => {
       );
       editor.insertText('a');
       advanceClock(editor.getBuffer().stoppedChangingDelay);
-
       waitsFor(() => editor.getMarkers().length > 0);
       runs(() => {
         expect(

--- a/packages/git-diff/spec/git-diff-subfolder-spec.js
+++ b/packages/git-diff/spec/git-diff-subfolder-spec.js
@@ -1,0 +1,313 @@
+const path = require('path');
+const fs = require('fs-plus');
+const temp = require('temp').track();
+
+describe('GitDiff package', () => {
+  let editor, editorElement, projectPath, screenUpdates;
+
+  beforeEach(() => {
+    screenUpdates = 0;
+    spyOn(window, 'requestAnimationFrame').andCallFake(fn => {
+      fn();
+      screenUpdates++;
+    });
+    spyOn(window, 'cancelAnimationFrame').andCallFake(i => null);
+
+    projectPath = temp.mkdirSync('git-diff-spec-');
+    const otherPath = temp.mkdirSync('some-other-path-');
+
+    fs.copySync(path.join(__dirname, 'fixtures', 'working-dir'), projectPath);
+    fs.moveSync(
+      path.join(projectPath, 'git.git'),
+      path.join(projectPath, '.git')
+    );
+    atom.project.setPaths([otherPath, projectPath]);
+
+    jasmine.attachToDOM(atom.workspace.getElement());
+
+    waitsForPromise(async () => {
+      await atom.workspace.open(path.join(projectPath, 'sample.js'));
+      await atom.packages.activatePackage('git-diff');
+    });
+
+    runs(() => {
+      editor = atom.workspace.getActiveTextEditor();
+      editorElement = atom.views.getView(editor);
+    });
+  });
+
+  afterEach(() => {
+    temp.cleanup();
+  });
+
+  describe('when the editor has no changes', () => {
+    it("doesn't mark the editor", () => {
+      waitsFor(() => screenUpdates > 0);
+      runs(() => expect(editor.getMarkers().length).toBe(0));
+    });
+  });
+
+  describe('when the editor has modified lines', () => {
+    it('highlights the modified lines', () => {
+      expect(editorElement.querySelectorAll('.git-line-modified').length).toBe(
+        0
+      );
+      editor.insertText('a');
+      advanceClock(editor.getBuffer().stoppedChangingDelay);
+
+      waitsFor(() => editor.getMarkers().length > 0);
+      runs(() => {
+        expect(
+          editorElement.querySelectorAll('.git-line-modified').length
+        ).toBe(1);
+        expect(editorElement.querySelector('.git-line-modified')).toHaveData(
+          'buffer-row',
+          0
+        );
+      });
+    });
+  });
+
+  describe('when the editor has added lines', () => {
+    it('highlights the added lines', () => {
+      expect(editorElement.querySelectorAll('.git-line-added').length).toBe(0);
+      editor.moveToEndOfLine();
+      editor.insertNewline();
+      editor.insertText('a');
+      advanceClock(editor.getBuffer().stoppedChangingDelay);
+      waitsFor(() => editor.getMarkers().length > 0);
+      runs(() => {
+        expect(editorElement.querySelectorAll('.git-line-added').length).toBe(
+          1
+        );
+        expect(editorElement.querySelector('.git-line-added')).toHaveData(
+          'buffer-row',
+          1
+        );
+      });
+    });
+  });
+
+  describe('when the editor has removed lines', () => {
+    it('highlights the line preceeding the deleted lines', () => {
+      expect(editorElement.querySelectorAll('.git-line-added').length).toBe(0);
+      editor.setCursorBufferPosition([5]);
+      editor.deleteLine();
+      advanceClock(editor.getBuffer().stoppedChangingDelay);
+      waitsFor(() => editor.getMarkers().length > 0);
+      runs(() => {
+        expect(editorElement.querySelectorAll('.git-line-removed').length).toBe(
+          1
+        );
+        expect(editorElement.querySelector('.git-line-removed')).toHaveData(
+          'buffer-row',
+          4
+        );
+      });
+    });
+  });
+
+  describe('when the editor has removed the first line', () => {
+    it('highlights the line preceeding the deleted lines', () => {
+      expect(editorElement.querySelectorAll('.git-line-added').length).toBe(0);
+      editor.setCursorBufferPosition([0, 0]);
+      editor.deleteLine();
+      advanceClock(editor.getBuffer().stoppedChangingDelay);
+      waitsFor(() => editor.getMarkers().length > 0);
+      runs(() => {
+        expect(
+          editorElement.querySelectorAll('.git-previous-line-removed').length
+        ).toBe(1);
+        expect(
+          editorElement.querySelector('.git-previous-line-removed')
+        ).toHaveData('buffer-row', 0);
+      });
+    });
+  });
+
+  describe('when a modified line is restored to the HEAD version contents', () => {
+    it('removes the diff highlight', () => {
+      expect(editorElement.querySelectorAll('.git-line-modified').length).toBe(
+        0
+      );
+      editor.insertText('a');
+      advanceClock(editor.getBuffer().stoppedChangingDelay);
+      waitsFor(
+        () => editorElement.querySelectorAll('.git-line-modified').length > 0
+      );
+      runs(() => {
+        expect(
+          editorElement.querySelectorAll('.git-line-modified').length
+        ).toBe(1);
+        editor.backspace();
+        advanceClock(editor.getBuffer().stoppedChangingDelay);
+      });
+      waitsFor(
+        () => editorElement.querySelectorAll('.git-line-modified').length < 1
+      );
+      runs(() => {
+        expect(
+          editorElement.querySelectorAll('.git-line-modified').length
+        ).toBe(0);
+      });
+    });
+  });
+
+  describe('when a modified file is opened', () => {
+    it('highlights the changed lines', () => {
+      fs.writeFileSync(
+        path.join(projectPath, 'sample.txt'),
+        'Some different text.'
+      );
+
+      waitsForPromise(() =>
+        atom.workspace.open(path.join(projectPath, 'sample.txt'))
+      );
+
+      runs(() => {
+        editor = atom.workspace.getActiveTextEditor();
+        editorElement = editor.getElement();
+      });
+
+      waitsFor(() => editor.getMarkers().length > 0);
+
+      runs(() => {
+        expect(
+          editorElement.querySelectorAll('.git-line-modified').length
+        ).toBe(1);
+        expect(editorElement.querySelector('.git-line-modified')).toHaveData(
+          'buffer-row',
+          0
+        );
+      });
+    });
+  });
+
+  describe('when the project paths change', () => {
+    it("doesn't try to use the destroyed git repository", () => {
+      editor.deleteLine();
+      atom.project.setPaths([temp.mkdirSync('no-repository')]);
+      advanceClock(editor.getBuffer().stoppedChangingDelay);
+      waitsFor(() => editor.getMarkers().length === 0);
+      runs(() => {
+        expect(editor.getMarkers().length).toBe(0);
+      });
+    });
+  });
+
+  describe('move-to-next-diff/move-to-previous-diff events', () => {
+    it('moves the cursor to first character of the next/previous diff line', () => {
+      editor.insertText('a');
+      waitsFor(() => editor.getMarkers().length > 0);
+      runs(() => {
+        editor.setCursorBufferPosition([5]);
+        editor.deleteLine();
+        advanceClock(editor.getBuffer().stoppedChangingDelay);
+
+        editor.setCursorBufferPosition([0]);
+        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+        expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
+
+        atom.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
+        expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
+      });
+    });
+
+    it('wraps around to the first/last diff in the file', () => {
+      editor.insertText('a');
+      waitsFor(() => editor.getMarkers().length > 0);
+      runs(() => {
+        editor.setCursorBufferPosition([5]);
+        editor.deleteLine();
+        advanceClock(editor.getBuffer().stoppedChangingDelay);
+
+        editor.setCursorBufferPosition([0]);
+        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+        expect(editor.getCursorBufferPosition().toArray()).toEqual([4, 4]);
+
+        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+        expect(editor.getCursorBufferPosition().toArray()).toEqual([0, 0]);
+
+        atom.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
+        expect(editor.getCursorBufferPosition().toArray()).toEqual([4, 4]);
+      });
+    });
+
+    describe('when the wrapAroundOnMoveToDiff config option is false', () => {
+      beforeEach(() =>
+        atom.config.set('git-diff.wrapAroundOnMoveToDiff', false)
+      );
+
+      it('does not wraps around to the first/last diff in the file', () => {
+        editor.insertText('a');
+        editor.setCursorBufferPosition([5]);
+        editor.deleteLine();
+        advanceClock(editor.getBuffer().stoppedChangingDelay);
+        waitsFor(() => editor.getMarkers().length > 0);
+
+        runs(() => {
+          editor.setCursorBufferPosition([0]);
+          atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+          expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
+
+          atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
+          expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
+
+          atom.commands.dispatch(
+            editorElement,
+            'git-diff:move-to-previous-diff'
+          );
+          expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
+
+          atom.commands.dispatch(
+            editorElement,
+            'git-diff:move-to-previous-diff'
+          );
+          expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
+        });
+      });
+    });
+  });
+
+  describe('when the showIconsInEditorGutter config option is true', () => {
+    beforeEach(() => {
+      atom.config.set('git-diff.showIconsInEditorGutter', true);
+    });
+
+    it('the gutter has a git-diff-icon class', () => {
+      waitsFor(() => screenUpdates > 0);
+      runs(() => {
+        expect(editorElement.querySelector('.gutter')).toHaveClass(
+          'git-diff-icon'
+        );
+      });
+    });
+
+    it('keeps the git-diff-icon class when editor.showLineNumbers is toggled', () => {
+      waitsFor(() => screenUpdates > 0);
+
+      runs(() => {
+        atom.config.set('editor.showLineNumbers', false);
+        expect(editorElement.querySelector('.gutter')).not.toHaveClass(
+          'git-diff-icon'
+        );
+
+        atom.config.set('editor.showLineNumbers', true);
+        expect(editorElement.querySelector('.gutter')).toHaveClass(
+          'git-diff-icon'
+        );
+      });
+    });
+
+    it('removes the git-diff-icon class when the showIconsInEditorGutter config option set to false', () => {
+      waitsFor(() => screenUpdates > 0);
+
+      runs(() => {
+        atom.config.set('git-diff.showIconsInEditorGutter', false);
+        expect(editorElement.querySelector('.gutter')).not.toHaveClass(
+          'git-diff-icon'
+        );
+      });
+    });
+  });
+});

--- a/packages/git-diff/spec/git-diff-subfolder-spec.js
+++ b/packages/git-diff/spec/git-diff-subfolder-spec.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs-plus');
 const temp = require('temp').track();
 
-describe('GitDiff package', () => {
+describe('GitDiff when targeting nested repository', () => {
   let editor, editorElement, projectPath, screenUpdates;
 
   beforeEach(() => {
@@ -14,21 +14,32 @@ describe('GitDiff package', () => {
     spyOn(window, 'cancelAnimationFrame').andCallFake(i => null);
 
     projectPath = temp.mkdirSync('git-diff-spec-');
-    const otherPath = temp.mkdirSync('some-other-path-');
 
-    fs.copySync(path.join(__dirname, 'fixtures'), projectPath);
+    fs.copySync(path.join(__dirname, 'fixtures', 'working-dir'), projectPath);
     fs.moveSync(
-      path.join(projectPath, 'working-dir', 'git.git'),
-      path.join(projectPath, 'working-dir', '.git')
+      path.join(projectPath, 'git.git'),
+      path.join(projectPath, '.git')
     );
-    atom.project.setPaths([otherPath, projectPath]);
+
+    // The nested repo doesn't need to be managed by the temp module because
+    // it's a part of our test environment.
+    const nestedPath = path.join(projectPath, 'nested-repository');
+    // When instantiating a GitRepository, the repository will always point
+    // to the .git folder in it's path.
+    const targetRepositoryPath = path.join(nestedPath, '.git');
+    // Initialize the repository contents.
+    fs.copySync(path.join(__dirname, 'fixtures', 'working-dir'), nestedPath);
+    fs.moveSync(
+      path.join(nestedPath, 'git.git'),
+      path.join(nestedPath, '.git')
+    );
+
+    atom.project.setPaths([projectPath]);
 
     jasmine.attachToDOM(atom.workspace.getElement());
 
     waitsForPromise(async () => {
-      await atom.workspace.open(
-        path.join(projectPath, 'working-dir', 'sample.js')
-      );
+      await atom.workspace.open(path.join(nestedPath, 'sample.js'));
       await atom.packages.activatePackage('git-diff');
     });
 
@@ -41,275 +52,21 @@ describe('GitDiff package', () => {
   afterEach(() => {
     temp.cleanup();
   });
-
-  describe('when the editor has no changes', () => {
-    it("doesn't mark the editor", () => {
+  
+  describe('When git-diff targets a file in a nested git-repository', () => {
+    /***
+     * Non-hack regression prevention for nested repositories. If we know
+     * that our project path contains two repositories, we can ensure that
+     * git-diff is targeting the correct one by creating an artificial change
+     * in the ancestor repository, which doesn't effect the target repository.
+     * If our diff shows any kind of change to our target file, we're targeting
+     * the incorrect repository.
+     */
+    it("uses the innermost repository", () => {
+      //waitsForPromise(async () => await new Promise(resolve => setTimeout(resolve, 4000)));
+      //waitsFor(() => !! atom.packages.isPackageLoaded("git-diff"));
       waitsFor(() => screenUpdates > 0);
       runs(() => expect(editor.getMarkers().length).toBe(0));
-    });
-  });
-
-  describe('when the editor has modified lines', () => {
-    it('highlights the modified lines', () => {
-      expect(editorElement.querySelectorAll('.git-line-modified').length).toBe(
-        0
-      );
-      editor.insertText('a');
-      advanceClock(editor.getBuffer().stoppedChangingDelay);
-
-      waitsFor(() => editor.getMarkers().length > 0);
-      runs(() => {
-        expect(
-          editorElement.querySelectorAll('.git-line-modified').length
-        ).toBe(1);
-        expect(editorElement.querySelector('.git-line-modified')).toHaveData(
-          'buffer-row',
-          0
-        );
-      });
-    });
-  });
-
-  describe('when the editor has added lines', () => {
-    it('highlights the added lines', () => {
-      expect(editorElement.querySelectorAll('.git-line-added').length).toBe(0);
-      editor.moveToEndOfLine();
-      editor.insertNewline();
-      editor.insertText('a');
-      advanceClock(editor.getBuffer().stoppedChangingDelay);
-      waitsFor(() => editor.getMarkers().length > 0);
-      runs(() => {
-        expect(editorElement.querySelectorAll('.git-line-added').length).toBe(
-          1
-        );
-        expect(editorElement.querySelector('.git-line-added')).toHaveData(
-          'buffer-row',
-          1
-        );
-      });
-    });
-  });
-
-  describe('when the editor has removed lines', () => {
-    it('highlights the line preceeding the deleted lines', () => {
-      expect(editorElement.querySelectorAll('.git-line-added').length).toBe(0);
-      editor.setCursorBufferPosition([5]);
-      editor.deleteLine();
-      advanceClock(editor.getBuffer().stoppedChangingDelay);
-      waitsFor(() => editor.getMarkers().length > 0);
-      runs(() => {
-        expect(editorElement.querySelectorAll('.git-line-removed').length).toBe(
-          1
-        );
-        expect(editorElement.querySelector('.git-line-removed')).toHaveData(
-          'buffer-row',
-          4
-        );
-      });
-    });
-  });
-
-  describe('when the editor has removed the first line', () => {
-    it('highlights the line preceeding the deleted lines', () => {
-      expect(editorElement.querySelectorAll('.git-line-added').length).toBe(0);
-      editor.setCursorBufferPosition([0, 0]);
-      editor.deleteLine();
-      advanceClock(editor.getBuffer().stoppedChangingDelay);
-      waitsFor(() => editor.getMarkers().length > 0);
-      runs(() => {
-        expect(
-          editorElement.querySelectorAll('.git-previous-line-removed').length
-        ).toBe(1);
-        expect(
-          editorElement.querySelector('.git-previous-line-removed')
-        ).toHaveData('buffer-row', 0);
-      });
-    });
-  });
-
-  describe('when a modified line is restored to the HEAD version contents', () => {
-    it('removes the diff highlight', () => {
-      expect(editorElement.querySelectorAll('.git-line-modified').length).toBe(
-        0
-      );
-      editor.insertText('a');
-      advanceClock(editor.getBuffer().stoppedChangingDelay);
-      waitsFor(
-        () => editorElement.querySelectorAll('.git-line-modified').length > 0
-      );
-      runs(() => {
-        expect(
-          editorElement.querySelectorAll('.git-line-modified').length
-        ).toBe(1);
-        editor.backspace();
-        advanceClock(editor.getBuffer().stoppedChangingDelay);
-      });
-      waitsFor(
-        () => editorElement.querySelectorAll('.git-line-modified').length < 1
-      );
-      runs(() => {
-        expect(
-          editorElement.querySelectorAll('.git-line-modified').length
-        ).toBe(0);
-      });
-    });
-  });
-
-  describe('when a modified file is opened', () => {
-    it('highlights the changed lines', () => {
-      fs.writeFileSync(
-        path.join(projectPath, 'working-dir', 'sample.txt'),
-        'Some different text.'
-      );
-
-      waitsForPromise(() =>
-        atom.workspace.open(path.join(projectPath, 'working-dir', 'sample.txt'))
-      );
-
-      runs(() => {
-        editor = atom.workspace.getActiveTextEditor();
-        editorElement = editor.getElement();
-      });
-
-      waitsFor(() => editor.getMarkers().length > 0);
-
-      runs(() => {
-        expect(
-          editorElement.querySelectorAll('.git-line-modified').length
-        ).toBe(1);
-        expect(editorElement.querySelector('.git-line-modified')).toHaveData(
-          'buffer-row',
-          0
-        );
-      });
-    });
-  });
-
-  describe('when the project paths change', () => {
-    it("doesn't try to use the destroyed git repository", () => {
-      editor.deleteLine();
-      atom.project.setPaths([temp.mkdirSync('no-repository')]);
-      advanceClock(editor.getBuffer().stoppedChangingDelay);
-      waitsFor(() => editor.getMarkers().length === 0);
-      runs(() => {
-        expect(editor.getMarkers().length).toBe(0);
-      });
-    });
-  });
-
-  describe('move-to-next-diff/move-to-previous-diff events', () => {
-    it('moves the cursor to first character of the next/previous diff line', () => {
-      editor.insertText('a');
-      waitsFor(() => editor.getMarkers().length > 0);
-      runs(() => {
-        editor.setCursorBufferPosition([5]);
-        editor.deleteLine();
-        advanceClock(editor.getBuffer().stoppedChangingDelay);
-
-        editor.setCursorBufferPosition([0]);
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
-        expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
-
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
-        expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
-      });
-    });
-
-    it('wraps around to the first/last diff in the file', () => {
-      editor.insertText('a');
-      waitsFor(() => editor.getMarkers().length > 0);
-      runs(() => {
-        editor.setCursorBufferPosition([5]);
-        editor.deleteLine();
-        advanceClock(editor.getBuffer().stoppedChangingDelay);
-
-        editor.setCursorBufferPosition([0]);
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
-        expect(editor.getCursorBufferPosition().toArray()).toEqual([4, 4]);
-
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
-        expect(editor.getCursorBufferPosition().toArray()).toEqual([0, 0]);
-
-        atom.commands.dispatch(editorElement, 'git-diff:move-to-previous-diff');
-        expect(editor.getCursorBufferPosition().toArray()).toEqual([4, 4]);
-      });
-    });
-
-    describe('when the wrapAroundOnMoveToDiff config option is false', () => {
-      beforeEach(() =>
-        atom.config.set('git-diff.wrapAroundOnMoveToDiff', false)
-      );
-
-      it('does not wraps around to the first/last diff in the file', () => {
-        editor.insertText('a');
-        editor.setCursorBufferPosition([5]);
-        editor.deleteLine();
-        advanceClock(editor.getBuffer().stoppedChangingDelay);
-        waitsFor(() => editor.getMarkers().length > 0);
-
-        runs(() => {
-          editor.setCursorBufferPosition([0]);
-          atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
-          expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
-
-          atom.commands.dispatch(editorElement, 'git-diff:move-to-next-diff');
-          expect(editor.getCursorBufferPosition()).toEqual([4, 4]);
-
-          atom.commands.dispatch(
-            editorElement,
-            'git-diff:move-to-previous-diff'
-          );
-          expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
-
-          atom.commands.dispatch(
-            editorElement,
-            'git-diff:move-to-previous-diff'
-          );
-          expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
-        });
-      });
-    });
-  });
-
-  describe('when the showIconsInEditorGutter config option is true', () => {
-    beforeEach(() => {
-      atom.config.set('git-diff.showIconsInEditorGutter', true);
-    });
-
-    it('the gutter has a git-diff-icon class', () => {
-      waitsFor(() => screenUpdates > 0);
-      runs(() => {
-        expect(editorElement.querySelector('.gutter')).toHaveClass(
-          'git-diff-icon'
-        );
-      });
-    });
-
-    it('keeps the git-diff-icon class when editor.showLineNumbers is toggled', () => {
-      waitsFor(() => screenUpdates > 0);
-
-      runs(() => {
-        atom.config.set('editor.showLineNumbers', false);
-        expect(editorElement.querySelector('.gutter')).not.toHaveClass(
-          'git-diff-icon'
-        );
-
-        atom.config.set('editor.showLineNumbers', true);
-        expect(editorElement.querySelector('.gutter')).toHaveClass(
-          'git-diff-icon'
-        );
-      });
-    });
-
-    it('removes the git-diff-icon class when the showIconsInEditorGutter config option set to false', () => {
-      waitsFor(() => screenUpdates > 0);
-
-      runs(() => {
-        atom.config.set('git-diff.showIconsInEditorGutter', false);
-        expect(editorElement.querySelector('.gutter')).not.toHaveClass(
-          'git-diff-icon'
-        );
-      });
     });
   });
 });

--- a/packages/git-diff/spec/git-diff-subfolder-spec.js
+++ b/packages/git-diff/spec/git-diff-subfolder-spec.js
@@ -16,17 +16,19 @@ describe('GitDiff package', () => {
     projectPath = temp.mkdirSync('git-diff-spec-');
     const otherPath = temp.mkdirSync('some-other-path-');
 
-    fs.copySync(path.join(__dirname, 'fixtures', 'working-dir'), projectPath);
+    fs.copySync(path.join(__dirname, 'fixtures'), projectPath);
     fs.moveSync(
-      path.join(projectPath, 'git.git'),
-      path.join(projectPath, '.git')
+      path.join(projectPath, 'working-dir', 'git.git'),
+      path.join(projectPath, 'working-dir', '.git')
     );
     atom.project.setPaths([otherPath, projectPath]);
 
     jasmine.attachToDOM(atom.workspace.getElement());
 
     waitsForPromise(async () => {
-      await atom.workspace.open(path.join(projectPath, 'sample.js'));
+      await atom.workspace.open(
+        path.join(projectPath, 'working-dir', 'sample.js')
+      );
       await atom.packages.activatePackage('git-diff');
     });
 
@@ -156,12 +158,12 @@ describe('GitDiff package', () => {
   describe('when a modified file is opened', () => {
     it('highlights the changed lines', () => {
       fs.writeFileSync(
-        path.join(projectPath, 'sample.txt'),
+        path.join(projectPath, 'working-dir', 'sample.txt'),
         'Some different text.'
       );
 
       waitsForPromise(() =>
-        atom.workspace.open(path.join(projectPath, 'sample.txt'))
+        atom.workspace.open(path.join(projectPath, 'working-dir', 'sample.txt'))
       );
 
       runs(() => {

--- a/packages/git-diff/spec/git-diff-subfolder-spec.js
+++ b/packages/git-diff/spec/git-diff-subfolder-spec.js
@@ -3,7 +3,7 @@ const fs = require('fs-plus');
 const temp = require('temp').track();
 
 describe('GitDiff when targeting nested repository', () => {
-  let editor, editorElement, projectPath, screenUpdates;
+  let editor, projectPath, screenUpdates;
 
   beforeEach(() => {
     screenUpdates = 0;
@@ -24,9 +24,6 @@ describe('GitDiff when targeting nested repository', () => {
     // The nested repo doesn't need to be managed by the temp module because
     // it's a part of our test environment.
     const nestedPath = path.join(projectPath, 'nested-repository');
-    // When instantiating a GitRepository, the repository will always point
-    // to the .git folder in it's path.
-    const targetRepositoryPath = path.join(nestedPath, '.git');
     // Initialize the repository contents.
     fs.copySync(path.join(__dirname, 'fixtures', 'working-dir'), nestedPath);
     fs.moveSync(
@@ -45,14 +42,13 @@ describe('GitDiff when targeting nested repository', () => {
 
     runs(() => {
       editor = atom.workspace.getActiveTextEditor();
-      editorElement = atom.views.getView(editor);
     });
   });
 
   afterEach(() => {
     temp.cleanup();
   });
-  
+
   describe('When git-diff targets a file in a nested git-repository', () => {
     /***
      * Non-hack regression prevention for nested repositories. If we know
@@ -62,9 +58,9 @@ describe('GitDiff when targeting nested repository', () => {
      * If our diff shows any kind of change to our target file, we're targeting
      * the incorrect repository.
      */
-    it("uses the innermost repository", () => {
-      //waitsForPromise(async () => await new Promise(resolve => setTimeout(resolve, 4000)));
-      //waitsFor(() => !! atom.packages.isPackageLoaded("git-diff"));
+    it('uses the innermost repository', () => {
+      // waitsForPromise(async () => await new Promise(resolve => setTimeout(resolve, 4000)));
+      // waitsFor(() => !! atom.packages.isPackageLoaded("git-diff"));
       waitsFor(() => screenUpdates > 0);
       runs(() => expect(editor.getMarkers().length).toBe(0));
     });


### PR DESCRIPTION
# Identify the Bug

Fixes https://github.com/atom/atom/issues/21630.
Fixes https://github.com/atom/github/issues/1149.
Fixes https://github.com/atom/github/issues/1835.

Linked PRs:
tree-view: https://github.com/atom/tree-view/pull/1367
tabs: https://github.com/atom/tabs/pull/560
status-bar: https://github.com/aminya/status-bar/pull/4

minimap-git-diff: https://github.com/atom-minimap/minimap-git-diff/pull/31
file-icons: https://github.com/file-icons/atom-fs/pull/9
linter: https://github.com/steelbrain/linter/pull/1715

### Description of the Change

By using atom.project.repositoryForPath function instead of matching the path with added directories, subfolders will get identified.
Made necessary changes to referenced places to handle the async nature of the atom.project.repositoryForPath.

### Alternate Designs

None.

### Possible Drawbacks

Since atom.project.repositoryForPath is an async function, there maybe a little lag when loading file which already has changes.

### Verification Process

TODO

### Release Notes

- Fixed subfolders of project folders not getting detected as git repositories.