### PR TITLE
⬆️ electron-osx-sign@0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2963,9 +2963,9 @@
       }
     },
     "electron-osx-sign": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.17.tgz",
-      "integrity": "sha512-wUJPmZJQCs1zgdlQgeIpRcvrf7M5/COQaOV68Va1J/SgmWx5KL2otgg+fAae7luw6qz9R8Gvu/Qpe9tAOu/3xQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz",
+      "integrity": "sha512-icoRLHzFz/qxzDh/N4Pi2z4yVHurlsCAYQvsCSG7fCedJ4UJXBS6PoQyGH71IfcqKupcKeK7HX/NkyfG+v6vlQ==",
       "requires": {
         "bluebird": "^3.5.0",
         "compare-version": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "dev-live-reload": "file:packages/dev-live-reload",
     "devtron": "1.4.0",
     "electron-notarize": "1.0.0",
-    "electron-osx-sign": "0.4.17",
+    "electron-osx-sign": "0.5.0",
     "encoding-selector": "https://www.atom.io/api/packages/encoding-selector/versions/0.23.9/tarball",
     "etch": "0.14.1",
     "event-kit": "^2.5.3",


### PR DESCRIPTION
Bumps electron-osx-sign from 0.4.17 to 0.5.0