### PR TITLE
deprecate minimap in favor of minimap-plus

### DIFF
--- a/script/deprecated-packages.json
+++ b/script/deprecated-packages.json
@@ -1035,9 +1035,9 @@
     "latestHasDeprecations": true
   },
   "minimap": {
-    "version": "<=3.5.6",
-    "hasDeprecations": true,
-    "latestHasDeprecations": false
+    "hasAlternative": true,
+    "message": "`minimap` has been replaced by `minimap-plus`. Please install `minimap-plus` instead",
+    "alternative": "minimap-plus"
   },
   "minimap-color-highlight": {
     "version": "<=4.1.3",


### PR DESCRIPTION
### Description of the change

This PR deprecates minimap in favor of minimap-plus. One of the maintainers of minimap requested me to deprecate minimap in favor of minimap-plus because the old package is not updated for more than two years, and they do not have time to do much with that project.
https://github.com/atom-minimap/minimap/issues/700#issuecomment-724403010

The new package is located at:
https://atom.io/packages/minimap-plus

### Release Notes
N/A