### PR TITLE
Fix handling of "empty" language injections with Tree-sitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3781,6 +3781,11 @@
         "rimraf": "2"
       }
     },
+    "fswin": {
+      "version": "3.19.908",
+      "resolved": "https://registry.npmjs.org/fswin/-/fswin-3.19.908.tgz",
+      "integrity": "sha512-xwq6wBg+KNuSjzQ3gZUOXt/FUhN9Wd+qQxz3yGM1xyTWu00ty82X+9Tc09z9XtMONYAhA8cCE3nolWoU7Rlz6g=="
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -7700,141 +7705,52 @@
       }
     },
     "text-buffer": {
-      "version": "13.17.3",
-      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.17.3.tgz",
-      "integrity": "sha512-2BMyWTolSD497rC8F0QNo6GJo6awkSrMFqtlVKtRB7lCGH3N6U4pmZJrO9qTZP43k6URdWBc++UPxSL7aXAd7g==",
+      "version": "13.18.5",
+      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.18.5.tgz",
+      "integrity": "sha512-EqtgNRq99Ow+BCV7TKzDGFdQA/MvRrghMHm4VuUMdisO8BSSFktpSaTBd18hizopM6ftU/qUEmM+YPdHAPyBvw==",
       "requires": {
         "delegato": "^1.0.0",
         "diff": "^2.2.1",
         "emissary": "^1.0.0",
         "event-kit": "^2.4.0",
-        "fs-admin": "^0.12.0",
+        "fs-admin": "^0.16.0",
         "fs-plus": "^3.0.0",
         "grim": "^2.0.2",
         "mkdirp": "^0.5.1",
         "pathwatcher": "^8.1.0",
         "serializable": "^1.0.3",
-        "superstring": "^2.4.2",
-        "underscore-plus": "^1.0.0"
+        "superstring": "^2.4.4",
+        "underscore-plus": "^1.0.0",
+        "winattr": "^3.0.0"
       },
       "dependencies": {
-        "bl": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-          "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          }
-        },
-        "decompress-response": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-          "requires": {
-            "mimic-response": "^2.0.0"
-          }
-        },
         "diff": {
           "version": "2.2.3",
           "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
           "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
         },
         "fs-admin": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/fs-admin/-/fs-admin-0.12.0.tgz",
-          "integrity": "sha512-rxGx07gnPqniQDLVIw7P8Rme5eK1WpTx8WhFN2zgqVJsK1cY4BRUXqE09u8uI6SHqkqkwKCl/G/7XD6ZNb/MrA==",
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/fs-admin/-/fs-admin-0.16.0.tgz",
+          "integrity": "sha512-ojkZQ4kmpdEViUNiqBbQ8YZuH+UjgJj621V9zeyfvviVgy7buf5K4vrVCCxf96QsWWLAtNiiplNMmxFO5zGoHg==",
           "requires": {
             "nan": "^2.13.2",
-            "prebuild-install": "5.3.3"
+            "prebuild-install": "^6.0.0"
           }
         },
-        "grim": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/grim/-/grim-2.0.2.tgz",
-          "integrity": "sha512-Qj7hTJRfd87E/gUgfvM0YIH/g2UA2SV6niv6BYXk1o6w4mhgv+QyYM1EjOJQljvzgEj4SqSsRWldXIeKHz3e3Q==",
+        "superstring": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/superstring/-/superstring-2.4.4.tgz",
+          "integrity": "sha512-41LWIGzy6tkUM6jUwbXTeGOLui3gGBxgV6m8gIWRzv1WdW0HV6oANHdGanRrM04mwFXXExII9OQ/XxaqU+Ft9w==",
           "requires": {
-            "event-kit": "^2.0.0"
-          }
-        },
-        "mimic-response": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
-        },
-        "prebuild-install": {
-          "version": "5.3.3",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
-          "integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^2.0.3",
-            "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "napi-build-utils": "^1.0.1",
-            "node-abi": "^2.7.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "pump": "^3.0.0",
-            "rc": "^1.2.7",
-            "simple-get": "^3.0.3",
-            "tar-fs": "^2.0.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
-          }
-        },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "simple-get": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-          "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-          "requires": {
-            "decompress-response": "^4.2.0",
-            "once": "^1.3.1",
-            "simple-concat": "^1.0.0"
-          }
-        },
-        "tar-fs": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
-          "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
-          "requires": {
-            "chownr": "^1.1.1",
-            "mkdirp-classic": "^0.5.2",
-            "pump": "^3.0.0",
-            "tar-stream": "^2.0.0"
-          }
-        },
-        "tar-stream": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-          "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
-          "requires": {
-            "bl": "^4.0.1",
-            "end-of-stream": "^1.4.1",
-            "fs-constants": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1"
+            "nan": "^2.14.2"
+          },
+          "dependencies": {
+            "nan": {
+              "version": "2.14.2",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+              "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+            }
           }
         }
       }
@@ -8606,6 +8522,14 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "winattr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/winattr/-/winattr-3.0.0.tgz",
+      "integrity": "sha512-dt33rYsTYcGbB+I1ubB6ZLODibRSCW//TgY/SuajLllR9kHnHnbUMqnXIe0osYsXUdRLGs770zb3t9z/ScGUpw==",
+      "requires": {
+        "fswin": "^3.18.918"
       }
     },
     "window-size": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3781,11 +3781,6 @@
         "rimraf": "2"
       }
     },
-    "fswin": {
-      "version": "3.19.908",
-      "resolved": "https://registry.npmjs.org/fswin/-/fswin-3.19.908.tgz",
-      "integrity": "sha512-xwq6wBg+KNuSjzQ3gZUOXt/FUhN9Wd+qQxz3yGM1xyTWu00ty82X+9Tc09z9XtMONYAhA8cCE3nolWoU7Rlz6g=="
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -7705,52 +7700,124 @@
       }
     },
     "text-buffer": {
-      "version": "13.18.5",
-      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.18.5.tgz",
-      "integrity": "sha512-EqtgNRq99Ow+BCV7TKzDGFdQA/MvRrghMHm4VuUMdisO8BSSFktpSaTBd18hizopM6ftU/qUEmM+YPdHAPyBvw==",
+      "version": "13.17.4",
+      "resolved": "https://registry.npmjs.org/text-buffer/-/text-buffer-13.17.4.tgz",
+      "integrity": "sha512-uDySuTJdjx+8ZEflmy3DLpMddtGJEP8oBeUcDrXcFapCpOyjAA4I9DQVXj6jkPm2S/Nkm5gPF+I4qpI50Vhtcg==",
       "requires": {
         "delegato": "^1.0.0",
         "diff": "^2.2.1",
         "emissary": "^1.0.0",
         "event-kit": "^2.4.0",
-        "fs-admin": "^0.16.0",
+        "fs-admin": "^0.12.0",
         "fs-plus": "^3.0.0",
         "grim": "^2.0.2",
         "mkdirp": "^0.5.1",
         "pathwatcher": "^8.1.0",
         "serializable": "^1.0.3",
-        "superstring": "^2.4.4",
-        "underscore-plus": "^1.0.0",
-        "winattr": "^3.0.0"
+        "superstring": "^2.4.2",
+        "underscore-plus": "^1.0.0"
       },
       "dependencies": {
+        "bl": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+          "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
         "diff": {
           "version": "2.2.3",
           "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
           "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k="
         },
         "fs-admin": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/fs-admin/-/fs-admin-0.16.0.tgz",
-          "integrity": "sha512-ojkZQ4kmpdEViUNiqBbQ8YZuH+UjgJj621V9zeyfvviVgy7buf5K4vrVCCxf96QsWWLAtNiiplNMmxFO5zGoHg==",
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/fs-admin/-/fs-admin-0.12.0.tgz",
+          "integrity": "sha512-rxGx07gnPqniQDLVIw7P8Rme5eK1WpTx8WhFN2zgqVJsK1cY4BRUXqE09u8uI6SHqkqkwKCl/G/7XD6ZNb/MrA==",
           "requires": {
             "nan": "^2.13.2",
-            "prebuild-install": "^6.0.0"
+            "prebuild-install": "5.3.3"
           }
         },
-        "superstring": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/superstring/-/superstring-2.4.4.tgz",
-          "integrity": "sha512-41LWIGzy6tkUM6jUwbXTeGOLui3gGBxgV6m8gIWRzv1WdW0HV6oANHdGanRrM04mwFXXExII9OQ/XxaqU+Ft9w==",
+        "mimic-response": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+        },
+        "prebuild-install": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
+          "integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
           "requires": {
-            "nan": "^2.14.2"
-          },
-          "dependencies": {
-            "nan": {
-              "version": "2.14.2",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-              "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
-            }
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.7.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^3.0.3",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "simple-get": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+          "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+          "requires": {
+            "decompress-response": "^4.2.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
+          }
+        },
+        "tar-fs": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+          "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+          "requires": {
+            "chownr": "^1.1.1",
+            "mkdirp-classic": "^0.5.2",
+            "pump": "^3.0.0",
+            "tar-stream": "^2.1.4"
+          }
+        },
+        "tar-stream": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+          "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+          "requires": {
+            "bl": "^4.0.3",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
           }
         }
       }
@@ -8522,14 +8589,6 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
         "string-width": "^1.0.2 || 2"
-      }
-    },
-    "winattr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/winattr/-/winattr-3.0.0.tgz",
-      "integrity": "sha512-dt33rYsTYcGbB+I1ubB6ZLODibRSCW//TgY/SuajLllR9kHnHnbUMqnXIe0osYsXUdRLGs770zb3t9z/ScGUpw==",
-      "requires": {
-        "fswin": "^3.18.918"
       }
     },
     "window-size": {

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "symbols-view": "https://www.atom.io/api/packages/symbols-view/versions/0.118.4/tarball",
     "tabs": "https://www.atom.io/api/packages/tabs/versions/0.110.0/tarball",
     "temp": "0.9.2",
-    "text-buffer": "13.17.3",
+    "text-buffer": "13.18.5",
     "timecop": "https://www.atom.io/api/packages/timecop/versions/0.36.2/tarball",
     "tree-sitter": "0.17.1",
     "tree-view": "https://www.atom.io/api/packages/tree-view/versions/0.228.2/tarball",

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "symbols-view": "https://www.atom.io/api/packages/symbols-view/versions/0.118.4/tarball",
     "tabs": "https://www.atom.io/api/packages/tabs/versions/0.110.0/tarball",
     "temp": "0.9.2",
-    "text-buffer": "13.18.5",
+    "text-buffer": "13.17.4",
     "timecop": "https://www.atom.io/api/packages/timecop/versions/0.36.2/tarball",
     "tree-sitter": "0.17.1",
     "tree-view": "https://www.atom.io/api/packages/tree-view/versions/0.228.2/tarball",


### PR DESCRIPTION
### Identify the Bug

Fixes #21093
Fixes #20884
Fixes #20897
Fixes https://github.com/atom/language-javascript/issues/676

1. The Rust grammar had a bug that caused poor error recovery.

2. There was a bug would occur in documents with language injections, where the injected document is empty. Examples include:
    * An empty string assigned to a node's `innerHTML` property in JavaScript. Usually, we highlight the contents of these strings as HTML.
      ```js
      node.innerHTML = "";
      ```
    * An empty script tag in an HTML document. Usually, we would parse the tag's contents this script tag as JavaScript:
      ```html
      <div>
        <script></script>
      </div>
      ```
    * In Ruby or JavaScript, a regular expression literal whose entire contents consist of escape sequences. Usually we highlight the contents of the regular expression using regex syntax:
      ```ruby
      s.search /\n/
      ```

The bug would cause us to accidentally *skip* highlighting large sections of the document.

### Description of the Change

These *injected* syntax trees are each associated with a *Marker* in the LanguageMode's `injectionsMarkerLayer`. This PR ensures that, when a language injection is empty, its marker is destroyed.

I also upgraded to the latest version of `tree-sitter-rust` in order to fix the last two issues mentioned in #21093, which were. unrelated, but easy to address.

### Verification Process

Create files containing all of the code examples in #21093. See that the syntax highlighting is all correct. Edit this files in a variety of ways and see that syntax highlighting stays correct.

### Release Notes

> Fixed a syntax highlighting bug that caused inconsistent and missing highlighting in several languages.