### PR TITLE
Bump minidump @aminya/minidump@0.19.0-8

### DIFF
--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -6101,9 +6101,9 @@
       "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
     },
     "minidump": {
-      "version": "npm:@aminya/minidump@0.19.0-5",
-      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-5.tgz",
-      "integrity": "sha512-r+QzIeiMCHNYpm6V9wE/9fjB7NdhIajIbafGFVXaBIWA0C/WxN3pZXgCQToXX3PdMHcOmj/xN8UKwMacN2yw3A=="
+      "version": "npm:@aminya/minidump@0.19.0-6",
+      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-6.tgz",
+      "integrity": "sha512-rZfOfa6s4+d++WSzMFHLahj6GATQxVbf2m4ng0vhqZYlwj9XVvmD4a4XtVeiB8ACXFE/x2KDnpQrVFb3L5Mw+g=="
     },
     "minimatch": {
       "version": "2.0.10",

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -6101,9 +6101,9 @@
       "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
     },
     "minidump": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/minidump/-/minidump-0.9.0.tgz",
-      "integrity": "sha1-Ei6d8kTzCPNEnvunpOLDIfQmwfk="
+      "version": "npm:@aminya/minidump@0.19.0-1",
+      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-1.tgz",
+      "integrity": "sha512-M3t1uYewVodpU/E8ysWThl0H8hFhw8f3UvSa1rVVgKzctS9QoHsEtC7YOQshhDFeQ4fFoyzeYB/IDQpnjzv+ew=="
     },
     "minimatch": {
       "version": "2.0.10",

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -6101,9 +6101,9 @@
       "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
     },
     "minidump": {
-      "version": "npm:@aminya/minidump@0.19.0-7",
-      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-7.tgz",
-      "integrity": "sha512-0il1fy+yxrbLCfq9IpOcVBKSEwB23WxXupqPEFEvmA4oaLhH8YQY0PPRPc0NSM4fz7aQOB9dI8v8h7zlM6yRrw=="
+      "version": "npm:@aminya/minidump@0.19.0-8",
+      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-8.tgz",
+      "integrity": "sha512-DGHiexVHOeRFoWVczrfU+kNJTtjUCKu7Nv6DDVI/pdJO4w0d2y0BH8DS6JZIrAxnfxXjJcyQ4ilZfIYtZZR70w=="
     },
     "minimatch": {
       "version": "2.0.10",

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -6101,9 +6101,9 @@
       "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
     },
     "minidump": {
-      "version": "npm:@aminya/minidump@0.19.0-1",
-      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-1.tgz",
-      "integrity": "sha512-M3t1uYewVodpU/E8ysWThl0H8hFhw8f3UvSa1rVVgKzctS9QoHsEtC7YOQshhDFeQ4fFoyzeYB/IDQpnjzv+ew=="
+      "version": "npm:@aminya/minidump@0.19.0-3",
+      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-3.tgz",
+      "integrity": "sha512-eL+7s7sOIil29SIv5Kwoa62GJjP5zxbHlhBH8n0kFgc+S3TOL/66Ri5GLbUNWRumYoI9c1S/EQrjqDItmF/RFg=="
     },
     "minimatch": {
       "version": "2.0.10",

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -6101,9 +6101,9 @@
       "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
     },
     "minidump": {
-      "version": "npm:@aminya/minidump@0.19.0-3",
-      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-3.tgz",
-      "integrity": "sha512-eL+7s7sOIil29SIv5Kwoa62GJjP5zxbHlhBH8n0kFgc+S3TOL/66Ri5GLbUNWRumYoI9c1S/EQrjqDItmF/RFg=="
+      "version": "npm:@aminya/minidump@0.19.0-4",
+      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-4.tgz",
+      "integrity": "sha512-EKEgyn97Wy5LrUaIHEXmQJ1umDxkess+IomhyoTTxBz3hrLGG3og9P40Fhwzyr75GY+sfR08vZW5lQS4F3woyA=="
     },
     "minimatch": {
       "version": "2.0.10",

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -6101,9 +6101,9 @@
       "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
     },
     "minidump": {
-      "version": "npm:@aminya/minidump@0.19.0-6",
-      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-6.tgz",
-      "integrity": "sha512-rZfOfa6s4+d++WSzMFHLahj6GATQxVbf2m4ng0vhqZYlwj9XVvmD4a4XtVeiB8ACXFE/x2KDnpQrVFb3L5Mw+g=="
+      "version": "npm:@aminya/minidump@0.19.0-7",
+      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-7.tgz",
+      "integrity": "sha512-0il1fy+yxrbLCfq9IpOcVBKSEwB23WxXupqPEFEvmA4oaLhH8YQY0PPRPc0NSM4fz7aQOB9dI8v8h7zlM6yRrw=="
     },
     "minimatch": {
       "version": "2.0.10",

--- a/script/package-lock.json
+++ b/script/package-lock.json
@@ -6101,9 +6101,9 @@
       "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
     },
     "minidump": {
-      "version": "npm:@aminya/minidump@0.19.0-4",
-      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-4.tgz",
-      "integrity": "sha512-EKEgyn97Wy5LrUaIHEXmQJ1umDxkess+IomhyoTTxBz3hrLGG3og9P40Fhwzyr75GY+sfR08vZW5lQS4F3woyA=="
+      "version": "npm:@aminya/minidump@0.19.0-5",
+      "resolved": "https://registry.npmjs.org/@aminya/minidump/-/minidump-0.19.0-5.tgz",
+      "integrity": "sha512-r+QzIeiMCHNYpm6V9wE/9fjB7NdhIajIbafGFVXaBIWA0C/WxN3pZXgCQToXX3PdMHcOmj/xN8UKwMacN2yw3A=="
     },
     "minimatch": {
       "version": "2.0.10",

--- a/script/package.json
+++ b/script/package.json
@@ -32,7 +32,7 @@
     "legal-eagle": "0.14.0",
     "lodash.startcase": "4.4.0",
     "lodash.template": "4.5.0",
-    "minidump": "npm:@aminya/minidump@0.19.0-6",
+    "minidump": "npm:@aminya/minidump@0.19.0-7",
     "mkdirp": "0.5.1",
     "nock": "^13.0.2",
     "node-fetch": "^2.6.1",

--- a/script/package.json
+++ b/script/package.json
@@ -32,7 +32,7 @@
     "legal-eagle": "0.14.0",
     "lodash.startcase": "4.4.0",
     "lodash.template": "4.5.0",
-    "minidump": "npm:@aminya/minidump@0.19.0-7",
+    "minidump": "npm:@aminya/minidump@0.19.0-8",
     "mkdirp": "0.5.1",
     "nock": "^13.0.2",
     "node-fetch": "^2.6.1",

--- a/script/package.json
+++ b/script/package.json
@@ -32,7 +32,7 @@
     "legal-eagle": "0.14.0",
     "lodash.startcase": "4.4.0",
     "lodash.template": "4.5.0",
-    "minidump": "0.9.0",
+    "minidump": "npm:@aminya/minidump@0.19.0-1",
     "mkdirp": "0.5.1",
     "nock": "^13.0.2",
     "node-fetch": "^2.6.1",

--- a/script/package.json
+++ b/script/package.json
@@ -32,7 +32,7 @@
     "legal-eagle": "0.14.0",
     "lodash.startcase": "4.4.0",
     "lodash.template": "4.5.0",
-    "minidump": "npm:@aminya/minidump@0.19.0-3",
+    "minidump": "npm:@aminya/minidump@0.19.0-4",
     "mkdirp": "0.5.1",
     "nock": "^13.0.2",
     "node-fetch": "^2.6.1",

--- a/script/package.json
+++ b/script/package.json
@@ -32,7 +32,7 @@
     "legal-eagle": "0.14.0",
     "lodash.startcase": "4.4.0",
     "lodash.template": "4.5.0",
-    "minidump": "npm:@aminya/minidump@0.19.0-5",
+    "minidump": "npm:@aminya/minidump@0.19.0-6",
     "mkdirp": "0.5.1",
     "nock": "^13.0.2",
     "node-fetch": "^2.6.1",

--- a/script/package.json
+++ b/script/package.json
@@ -32,7 +32,7 @@
     "legal-eagle": "0.14.0",
     "lodash.startcase": "4.4.0",
     "lodash.template": "4.5.0",
-    "minidump": "npm:@aminya/minidump@0.19.0-4",
+    "minidump": "npm:@aminya/minidump@0.19.0-5",
     "mkdirp": "0.5.1",
     "nock": "^13.0.2",
     "node-fetch": "^2.6.1",

--- a/script/package.json
+++ b/script/package.json
@@ -32,7 +32,7 @@
     "legal-eagle": "0.14.0",
     "lodash.startcase": "4.4.0",
     "lodash.template": "4.5.0",
-    "minidump": "npm:@aminya/minidump@0.19.0-1",
+    "minidump": "npm:@aminya/minidump@0.19.0-3",
     "mkdirp": "0.5.1",
     "nock": "^13.0.2",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
### Description of the change

Resolves the mindump issues on MacOS and Linux for Electron 9 in https://github.com/atom/atom/pull/21777

### Verification

I fixed minidump's building for MacOS and Linux in my fork:
- The submodules were not being instantiated and built correctly.
- MacOS files were not included in the build script

My fork: https://github.com/aminya/node-minidump

I have made a PR to the original package, but it may take some time until they merge it, so I have registered it with my name temporarily. 

https://github.com/electron/node-minidump/pull/40

### Release Notes
N/A