### PR TITLE
Drop libgconf dependency for electron7+

### DIFF
--- a/resources/linux/debian/control.in
+++ b/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= appFileName %>
 Version: <%= version %>
-Depends: git, libgconf-2-4 (>= 3.2.5), libgtk-3-0 (>= 3.9.10), libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), libglib2.0-bin | kde-cli-tools | kde-runtime, xdg-utils, libx11-xcb1, libxss1, libxkbfile1, libcurl3 | libcurl4
+Depends: git, libgtk-3-0 (>= 3.9.10), libgcrypt20, libnotify4, libxtst6, libnss3 (>= 2:3.22), libglib2.0-bin | kde-cli-tools | kde-runtime, xdg-utils, libx11-xcb1, libxss1, libxkbfile1, libcurl3 | libcurl4
 Recommends: libasound2 (>= 1.0.16), policykit-1, libsecret-1-0, gnome-keyring
 Suggests: lsb-release
 Section: devel

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -4,7 +4,7 @@ steps:
   - script: |
       sudo apt-get update
       sudo apt-get install -y wget software-properties-common
-      sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev rpm libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgconf2-4 libgtk-3-0 libasound2 libicu-dev
+      sudo apt-get install -y build-essential ca-certificates xvfb fakeroot git libsecret-1-dev rpm libx11-dev libxkbfile-dev xz-utils xorriso zsync libxss1 libgtk-3-0 libasound2 libicu-dev
       # clang 9 is included in the image
       sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 10
       sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 10


### PR DESCRIPTION
Drop the libgconf debian packaging dependency. Not necessary for Electron 7 and higher. See for more information https://github.com/atom/atom/issues/21422#issuecomment-702402584
